### PR TITLE
Fix autopilot ralplan consensus freshness

### DIFF
--- a/src/autopilot/__tests__/ralplan-gate.test.ts
+++ b/src/autopilot/__tests__/ralplan-gate.test.ts
@@ -281,6 +281,105 @@ describe('autopilot ralplan gate', () => {
     });
   }
 
+
+  it('accepts fresh next-state consensus over stale invalid current-state consensus', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-fresh-next-valid-'));
+    const sessionId = 'sess-autopilot-fresh-next-valid';
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-06-12T10:03:00.000Z',
+            threads: {
+              'thread-leader': { thread_id: 'thread-leader', kind: 'leader', first_seen_at: '2026-06-12T09:59:00.000Z', last_seen_at: '2026-06-12T09:59:00.000Z', turn_count: 1 },
+              'thread-architect-fresh': { thread_id: 'thread-architect-fresh', kind: 'subagent', first_seen_at: '2026-06-12T10:02:00.000Z', last_seen_at: '2026-06-12T10:02:00.000Z', completed_at: '2026-06-12T10:02:00.000Z', turn_count: 1 },
+              'thread-critic-fresh': { thread_id: 'thread-critic-fresh', kind: 'subagent', first_seen_at: '2026-06-12T10:03:00.000Z', last_seen_at: '2026-06-12T10:03:00.000Z', completed_at: '2026-06-12T10:03:00.000Z', turn_count: 1 },
+            },
+          },
+        },
+      }, null, 2));
+
+      const nextState = {
+        current_phase: 'ralplan',
+        review_cycle: 2,
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              review_cycle: 2,
+              session_id: sessionId,
+              thread_id: 'thread-architect-fresh',
+              artifact_path: '.omx/artifacts/architect-fresh.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-06-12T10:02:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              review_cycle: 2,
+              session_id: sessionId,
+              thread_id: 'thread-critic-fresh',
+              artifact_path: '.omx/artifacts/critic-fresh.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-06-12T10:03:00.000Z',
+            },
+          },
+        },
+      };
+      const currentState = {
+        current_phase: 'ralplan',
+        return_to_ralplan_reason: 'Code review requested a plan update.',
+        review_cycle: 1,
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'block',
+              review_cycle: 1,
+              session_id: sessionId,
+              thread_id: 'thread-architect-stale',
+              artifact_path: '.omx/artifacts/architect-stale.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-06-12T10:00:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              review_cycle: 1,
+              session_id: sessionId,
+              thread_id: 'thread-critic-stale',
+              artifact_path: '.omx/artifacts/critic-stale.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-06-12T10:01:00.000Z',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, sessionId, nextState, currentState });
+
+      assert.equal(decision.allowed, true);
+      assert.equal(decision.evidence?.source, 'next-autopilot-state');
+      assert.equal(decision.evidence?.blockedReason, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('rejects native review evidence from the session leader even when malformed tracking marks it as subagent', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-leader-spoof-'));
     const sessionId = 'sess-autopilot-leader-spoof';

--- a/src/autopilot/ralplan-gate.ts
+++ b/src/autopilot/ralplan-gate.ts
@@ -38,40 +38,50 @@ function ralplanHandoff(state: JsonObject | null | undefined): JsonObject | null
   return safeObject(handoffArtifacts(state)?.ralplan);
 }
 
-function gateSources(input: AutopilotRalplanUltragoalGateInput) {
-  const sources: Array<{ source: string; value: unknown }> = [];
-  for (const [label, state] of [
-    ['next-autopilot-state', input.nextState],
-    ['current-autopilot-state', input.currentState],
-  ] as const) {
-    if (!state) continue;
-    sources.push({ source: label, value: state });
-    const handoffs = handoffArtifacts(state);
-    if (handoffs) {
-      sources.push({
-        source: `${label}:handoff_artifacts`,
-        value: withParentReturnToRalplanContext(handoffs, state),
-      });
-    }
-    const ralplan = ralplanHandoff(state);
-    if (ralplan) {
-      sources.push({
-        source: `${label}:handoff_artifacts.ralplan`,
-        value: withParentReturnToRalplanContext(ralplan, state),
-      });
-    }
+function sourcesForState(label: string, state: JsonObject | null | undefined): Array<{ source: string; value: unknown }> {
+  if (!state) return [];
+  const sources: Array<{ source: string; value: unknown }> = [{ source: label, value: state }];
+  const handoffs = handoffArtifacts(state);
+  if (handoffs) {
+    sources.push({
+      source: `${label}:handoff_artifacts`,
+      value: withParentReturnToRalplanContext(handoffs, state),
+    });
+  }
+  const ralplan = ralplanHandoff(state);
+  if (ralplan) {
+    sources.push({
+      source: `${label}:handoff_artifacts.ralplan`,
+      value: withParentReturnToRalplanContext(ralplan, state),
+    });
   }
   return sources;
+}
+
+function gateSources(input: AutopilotRalplanUltragoalGateInput) {
+  return [
+    ...sourcesForState('next-autopilot-state', input.nextState),
+    ...sourcesForState('current-autopilot-state', input.currentState),
+  ];
 }
 
 export function canAdvanceAutopilotRalplanToUltragoal(
   input: AutopilotRalplanUltragoalGateInput,
 ): AutopilotRalplanUltragoalGateDecision {
-  const evidence = buildRalplanConsensusGateFromSources(gateSources(input), {
+  const options = {
     cwd: input.cwd,
     sessionId: input.sessionId,
     requireNativeSubagents: true,
-  });
+  };
+  const nextStateEvidence = buildRalplanConsensusGateFromSources(
+    sourcesForState('next-autopilot-state', input.nextState),
+    options,
+  );
+  const evidence = nextStateEvidence.complete
+    || nextStateEvidence.blockedReason === RALPLAN_CONSENSUS_BLOCKED_REASONS.nonApprovingReview
+    || nextStateEvidence.blockedReason === RALPLAN_CONSENSUS_BLOCKED_REASONS.nativeSubagentEvidenceMissing
+    ? nextStateEvidence
+    : buildRalplanConsensusGateFromSources(gateSources(input), options);
   if (evidence.complete) {
     return {
       allowed: true,

--- a/src/pipeline/__tests__/orchestrator.test.ts
+++ b/src/pipeline/__tests__/orchestrator.test.ts
@@ -4,6 +4,7 @@ import { mkdir, mkdtemp, rm, readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { existsSync } from 'fs';
+import { readModeState } from '../../modes/base.js';
 import {
   runPipeline,
   canResumePipeline,
@@ -394,6 +395,70 @@ describe('Pipeline Orchestrator', () => {
       assert.equal(result.status, 'failed');
       assert.equal(result.failedStage, 'code-review');
       assert.match(result.error ?? '', /Autopilot quality gates were not clean after 2 cycle/);
+    });
+
+
+    it('final completion write replaces stale BLOCK verdict state with clean artifacts', async () => {
+      let reviewRuns = 0;
+      const stages: PipelineStage[] = [
+        makeStage('ralplan', { artifacts: { plan: 'approved' } }),
+        makeStage('ultragoal', { artifacts: { implemented: true } }),
+        {
+          name: 'code-review',
+          async run(): Promise<StageResult> {
+            reviewRuns += 1;
+            const clean = reviewRuns > 1;
+            return {
+              status: 'completed',
+              artifacts: {
+                review_verdict: {
+                  stage: 'code-review',
+                  recommendation: clean ? 'APPROVE' : 'REQUEST CHANGES',
+                  architectural_status: clean ? 'CLEAR' : 'BLOCK',
+                  clean,
+                  artifact_path: clean ? '.omx/reviews/final-clean.json' : '.omx/reviews/stale-block.json',
+                },
+                return_to_ralplan_reason: clean ? null : 'Stale BLOCK must be replaced after clean review.',
+              },
+              duration_ms: 0,
+            };
+          },
+        },
+        makeStage('ultraqa', {
+          artifacts: {
+            qa_verdict: {
+              stage: 'ultraqa',
+              clean: true,
+              skipped: false,
+              url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/42',
+            },
+            return_to_ralplan_reason: null,
+          },
+        }),
+      ];
+
+      const result = await runPipeline({
+        name: 'stale-block-finalization',
+        task: 'finalization replaces stale blockers',
+        stages,
+        cwd: tempDir,
+      });
+
+      assert.equal(result.status, 'completed');
+      assert.equal(reviewRuns, 2);
+      const ext = await readPipelineState(tempDir);
+      const modeState = await readModeState('autopilot', tempDir);
+      assert.equal(modeState?.active, false);
+      assert.equal(modeState?.current_phase, 'complete');
+      assert.equal((ext?.review_verdict as { recommendation?: string } | undefined)?.recommendation, 'APPROVE');
+      assert.equal((ext?.review_verdict as { architectural_status?: string } | undefined)?.architectural_status, 'CLEAR');
+      assert.equal((ext?.review_verdict as { clean?: boolean } | undefined)?.clean, true);
+      assert.equal((ext?.qa_verdict as { clean?: boolean } | undefined)?.clean, true);
+      assert.equal(ext?.return_to_ralplan_reason, null);
+      assert.ok(ext?.handoff_artifacts?.code_review, 'clean code-review artifact should be preserved in terminal state');
+      assert.ok(ext?.handoff_artifacts?.ultraqa, 'clean ultraqa artifact should be preserved in terminal state');
+      assert.equal((ext?.pipeline_stage_results as Record<string, unknown> | undefined)?.['code-review'] !== undefined, true);
+      assert.equal((ext?.pipeline_stage_results as Record<string, unknown> | undefined)?.ultraqa !== undefined, true);
     });
 
     it('passes artifacts between stages', async () => {

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -279,7 +279,12 @@ export async function runPipeline(config: PipelineConfig): Promise<PipelineResul
     active: false,
     current_phase: 'complete',
     completed_at: new Date().toISOString(),
-  }, cwd, undefined, { trustedPipelineProgress: true });
+    review_verdict: artifacts.review_verdict ?? null,
+    qa_verdict: artifacts.qa_verdict ?? null,
+    return_to_ralplan_reason: null,
+    handoff_artifacts: normalizeHandoffArtifactKeys(handoffArtifactsByStage),
+    pipeline_stage_results: { ...stageResults },
+  } as Partial<PipelineModeStateExtension>, cwd, undefined, { trustedPipelineProgress: true });
 
   return {
     status: 'completed',


### PR DESCRIPTION
## Engineering rationale

Fixes PR1 ralplan consensus/state correctness for `omx-git` and `omx-x01` with a small dev-based change set.

The contract is explicit: **fresh consensus evidence wins over stale invalid/BLOCK evidence; completion/finalization must not preserve stale BLOCK review verdicts**.

Implementation keeps generic ralplan consensus reduction conservative (complete invalid/malformed consensus still blocks), while the Autopilot ralplan→ultragoal gate treats decisive `nextState` evidence as authoritative so stale `currentState` cannot override a fresh transition. Pipeline terminalization now writes the clean review/QA verdicts, clears `return_to_ralplan_reason`, and persists final handoff/stage artifacts so shallow merge state cannot retain stale BLOCK verdicts.

`omx-l3r` was quick-triaged via the ralplan consensus/runtime state-root coverage and was not included because those state-root regressions pass after #2807/#2816.

## Acceptance checklist

- [x] Fresh consensus evidence wins over stale invalid/BLOCK evidence.
- [x] Completion/finalization must not preserve stale BLOCK review verdicts.
- [x] Fresh/current invalid ralplan consensus remains blocking.
- [x] Final terminal state persists clean code-review and UltraQA artifacts and clears stale return-to-ralplan state.
- [x] `omx-l3r` state-root path remains covered by existing passing ralplan consensus/runtime tests; no current repro included.

## Verification

- `npm run build`
- `node dist/scripts/run-test-files.js dist/ralplan/__tests__/consensus-gate.test.js dist/ralplan/__tests__/runtime.test.js dist/autopilot/__tests__/ralplan-gate.test.js dist/pipeline/__tests__/orchestrator.test.js dist/state/__tests__/operations.test.js dist/hooks/__tests__/keyword-detector.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
- UltraQA targeted suite: `node dist/scripts/run-test-files.js dist/ralplan/__tests__/consensus-gate.test.js dist/autopilot/__tests__/ralplan-gate.test.js dist/pipeline/__tests__/orchestrator.test.js dist/state/__tests__/operations.test.js`

## Review evidence

- Ralplan gate: Architect APPROVE (`019ebca1-5282-7672-aa30-eef4aaa8d9f4`) → Critic APPROVE (`019ebca4-cfa5-7991-8c10-76d2fc99349d`).
- Scholastic ralplan advisory: ITERATE addressed (`019ebc99-05f3-7ab0-af34-3c6e1b10fd0f`).
- Code-review cycle 1: REQUEST CHANGES/BLOCK + Scholastic BLOCK; fixed by moving stale-current handling to Autopilot boundary.
- Code-review cycle 2: code-reviewer APPROVE (`019ebcb8-40db-7552-b9b4-1ac7193a5596`), architect CLEAR (`019ebcb8-455d-7e12-8bea-32f5a7d73536`), Scholastic PASS (`019ebcb8-4a0c-75b0-a2ea-520cf7b8d5d9`).
