### PR TITLE
Preserve customized native agent TOMLs

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -2697,7 +2697,7 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
-	it("archives stale legacy prompts and refreshes generated native agents when plugin mode refreshes", async () => {
+	it("archives stale legacy prompts and preserves modified native agents when plugin mode refreshes", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {
 			await withIsolatedUserHome(wd, async (codexHomeDir) => {
@@ -2710,16 +2710,14 @@ describe("omx setup install mode behavior", () => {
 						promptPath,
 						"---\ndescription: stale legacy executor prompt\n---\n\nold executor body\n",
 					);
-					await writeFile(
-						agentPath,
-						[
-							"# oh-my-codex agent: planner",
-							'name = "planner"',
-							'description = "stale legacy generated planner"',
-							'developer_instructions = """old planner body"""',
-							"",
-						].join("\n"),
-					);
+					const staleAgentToml = [
+						"# oh-my-codex agent: planner",
+						'name = "planner"',
+						'description = "stale legacy generated planner"',
+						'developer_instructions = """old planner body"""',
+						"",
+					].join("\n");
+					await writeFile(agentPath, staleAgentToml);
 
 					const output = await captureConsoleOutput(async () => {
 						await setup({ scope: "user", installMode: "plugin" });
@@ -2727,10 +2725,7 @@ describe("omx setup install mode behavior", () => {
 
 					assert.equal(existsSync(promptPath), false);
 					assert.equal(existsSync(agentPath), true);
-					assert.match(
-						await readFile(agentPath, "utf-8"),
-						/^name = "planner"$/m,
-					);
+					assert.equal(await readFile(agentPath, "utf-8"), staleAgentToml);
 					assert.match(
 						output,
 						/Archived and removed .* legacy OMX-managed prompt file/,
@@ -2757,7 +2752,7 @@ describe("omx setup install mode behavior", () => {
 								join(backupRoot, entry, ".codex", "agents", "planner.toml"),
 							),
 						),
-						true,
+						false,
 					);
 				});
 			});

--- a/src/cli/__tests__/setup-prompts-overwrite.test.ts
+++ b/src/cli/__tests__/setup-prompts-overwrite.test.ts
@@ -88,6 +88,90 @@ describe('omx setup prompt/native-agent overwrite behavior', () => {
     }
   });
 
+  it('preserves user-customized installable native agent TOMLs during normal setup refresh', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-prompts-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const executorPath = join(wd, '.codex', 'agents', 'executor.toml');
+      const installed = await readFile(executorPath, 'utf-8');
+      const customized = installed
+        .replace(/^model = ".*"$/m, 'model = "gpt-5.4"')
+        .replace(/^model_reasoning_effort = ".*"$/m, 'model_reasoning_effort = "low"');
+      assert.notEqual(customized, installed);
+      await writeFile(executorPath, customized);
+
+      await setup({ scope: 'project' });
+
+      assert.equal(await readFile(executorPath, 'utf-8'), customized);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('overwrites customized native agent TOMLs only when setup force is explicit', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-prompts-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const executorPath = join(wd, '.codex', 'agents', 'executor.toml');
+      const installed = await readFile(executorPath, 'utf-8');
+      const customized = installed
+        .replace(/^model = ".*"$/m, 'model = "gpt-5.4"')
+        .replace(/^model_reasoning_effort = ".*"$/m, 'model_reasoning_effort = "low"');
+      await writeFile(executorPath, customized);
+
+      await setup({ scope: 'project', force: true });
+
+      const refreshed = await readFile(executorPath, 'utf-8');
+      assert.notEqual(refreshed, customized);
+      assert.match(refreshed, /^# oh-my-codex agent: executor$/m);
+      assert.doesNotMatch(refreshed, /^model = "gpt-5\.4"$/m);
+      assert.doesNotMatch(refreshed, /^model_reasoning_effort = "low"$/m);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('skips native agent TOMLs entirely during background update-check setup refreshes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-prompts-'));
+    const previousCwd = process.cwd();
+    const previousSkipNativeAgentRefresh = process.env.OMX_SKIP_NATIVE_AGENT_REFRESH;
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const executorPath = join(wd, '.codex', 'agents', 'executor.toml');
+      const installed = await readFile(executorPath, 'utf-8');
+      const customized = installed
+        .replace(/^model = ".*"$/m, 'model = "gpt-5.4"')
+        .replace(/^model_reasoning_effort = ".*"$/m, 'model_reasoning_effort = "low"');
+      await writeFile(executorPath, customized);
+
+      process.env.OMX_SKIP_NATIVE_AGENT_REFRESH = '1';
+      await setup({ scope: 'project', force: true });
+
+      assert.equal(await readFile(executorPath, 'utf-8'), customized);
+    } finally {
+      if (typeof previousSkipNativeAgentRefresh === 'string') process.env.OMX_SKIP_NATIVE_AGENT_REFRESH = previousSkipNativeAgentRefresh;
+      else delete process.env.OMX_SKIP_NATIVE_AGENT_REFRESH;
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('preserves setup-owned prompt assets and removes unknown prompts on --force', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-setup-prompts-'));
     const previousCwd = process.cwd();

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1176,6 +1176,7 @@ describe('runDeferredGlobalUpdate', () => {
       assert.equal(calls[0].options.cwd, cwd);
       assert.equal((calls[0].options.env as NodeJS.ProcessEnv | undefined)?.OMX_DEFERRED_UPDATE_PARENT_PID, '12345');
       assert.equal((calls[0].options.env as NodeJS.ProcessEnv | undefined)?.OMX_DEFERRED_UPDATE_LOG, result.logPath);
+      assert.equal((calls[0].options.env as NodeJS.ProcessEnv | undefined)?.OMX_SKIP_NATIVE_AGENT_REFRESH, '1');
       assert.match(calls[0].args[4], /Get-Process -Id \$parentPid/);
       assert.match(calls[0].args[4], /npm install -g oh-my-codex@latest/);
       assert.match(calls[0].args[4], /& 'omx' 'setup'/);
@@ -1186,7 +1187,7 @@ describe('runDeferredGlobalUpdate', () => {
 
   it('preserves plugin setup delivery mode for deferred post-update refreshes', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-deferred-update-plugin-'));
-    const calls: Array<{ command: string; args: string[] }> = [];
+    const calls: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = [];
 
     try {
       await mkdir(join(cwd, '.omx'), { recursive: true });
@@ -1197,8 +1198,8 @@ describe('runDeferredGlobalUpdate', () => {
 
       const result = runDeferredGlobalUpdate(
         cwd,
-        ((command, args) => {
-          calls.push({ command, args: args as string[] });
+        ((command, args, options) => {
+          calls.push({ command, args: args as string[], options: (options ?? {}) as Record<string, unknown> });
           return {
             once() {
               return this;
@@ -1213,6 +1214,7 @@ describe('runDeferredGlobalUpdate', () => {
       assert.equal(result.ok, true);
       assert.equal(calls.length, 1);
       assert.match(calls[0].args[1], /'omx' 'setup' '--scope' 'user' '--plugin' '--mcp' 'none' '--disable-team'/);
+      assert.equal((calls[0].options as { env?: NodeJS.ProcessEnv } | undefined)?.env?.OMX_SKIP_NATIVE_AGENT_REFRESH, '1');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -1357,6 +1359,7 @@ describe('post-update setup refresh handoff', () => {
       );
 
       assert.equal(result.ok, true);
+      assert.equal(received[0]?.command, process.execPath);
       assert.deepEqual(received[0]?.args, [
         '/tmp/omx.js',
         'setup',

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -21,6 +21,7 @@ import { spawnSync } from "child_process";
 import { createInterface } from "readline/promises";
 import { homedir } from "os";
 import TOML from "@iarna/toml";
+import { createHash } from "crypto";
 import {
 	codexHome,
 	codexConfigPath,
@@ -165,6 +166,7 @@ interface SetupOptions {
 	scope?: SetupScope;
 	verbose?: boolean;
 	agentsOverwritePrompt?: (destinationPath: string) => Promise<boolean>;
+	skipNativeAgentRefresh?: boolean;
 	setupScopePrompt?: (defaultScope: SetupScope) => Promise<SetupScope>;
 	persistedSetupReviewPrompt?: (
 		preferences: Partial<PersistedSetupScope>,
@@ -251,6 +253,7 @@ const PROJECT_GITIGNORE_ENTRIES = [
 const LEGACY_PROJECT_GITIGNORE_ENTRIES = [".codex/"] as const;
 const SETUP_ONLY_INSTALLABLE_SKILLS = new Set(["wiki"]);
 const DEFAULT_SETUP_MCP_MODE: SetupMcpMode = "none";
+const SKIP_NATIVE_AGENT_REFRESH_ENV = "OMX_SKIP_NATIVE_AGENT_REFRESH";
 const HARD_DEPRECATED_SKILL_NAMES = new Set(["web-clone"]);
 const TEAM_MODE_SKILL_NAMES = new Set(["team", "worker"]);
 const TEAM_MODE_PROMPT_NAMES = new Set(["team-executor"]);
@@ -1955,6 +1958,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		teamMode: requestedTeamMode,
 		scope: requestedScope,
 		verbose = false,
+		skipNativeAgentRefresh: requestedSkipNativeAgentRefresh = false,
 		setupScopePrompt,
 		persistedSetupReviewPrompt,
 		installModePrompt,
@@ -2033,6 +2037,9 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		)
 		?? "enabled";
 	const isTeamModeEnabled = teamModeEnabled(resolvedTeamMode);
+	const skipNativeAgentRefresh =
+		requestedSkipNativeAgentRefresh ||
+		process.env[SKIP_NATIVE_AGENT_REFRESH_ENV] === "1";
 	const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot);
 	const existingConfigForMcpMigration = existsSync(scopeDirs.codexConfigFile)
 		? await readFile(scopeDirs.codexConfigFile, "utf-8")
@@ -2307,7 +2314,12 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 
 	// Step 4: Install native agent configs
 	console.log("[4/8] Installing native agent configs...");
-	if (isPluginInstallMode) {
+	if (skipNativeAgentRefresh) {
+		summary.nativeAgents = createEmptyCategorySummary();
+		console.log(
+			"  Native agent refresh skipped for background update-check setup refresh.\n",
+		);
+	} else if (isPluginInstallMode) {
 		summary.nativeAgents = await refreshNativeAgentConfigs(
 			pkgRoot,
 			scopeDirs.nativeAgentsDir,
@@ -3135,6 +3147,144 @@ async function syncManagedContent(
 	}
 }
 
+interface NativeAgentInstallManifestEntry {
+	sha256: string;
+}
+
+interface NativeAgentInstallManifest {
+	version: 1;
+	files: Record<string, NativeAgentInstallManifestEntry>;
+}
+
+function hashContent(content: string): string {
+	return createHash("sha256").update(content).digest("hex");
+}
+
+function nativeAgentInstallManifestPath(agentsDir: string): string {
+	return join(agentsDir, "..", ".omx", "native-agents.json");
+}
+
+async function readNativeAgentInstallManifest(
+	agentsDir: string,
+): Promise<NativeAgentInstallManifest> {
+	const manifestPath = nativeAgentInstallManifestPath(agentsDir);
+	if (!existsSync(manifestPath)) return { version: 1, files: {} };
+
+	try {
+		const parsed = JSON.parse(await readFile(manifestPath, "utf-8")) as {
+			version?: unknown;
+			files?: unknown;
+		};
+		if (
+			parsed.version !== 1 ||
+			!parsed.files ||
+			typeof parsed.files !== "object"
+		) {
+			return { version: 1, files: {} };
+		}
+
+		const files: Record<string, NativeAgentInstallManifestEntry> = {};
+		for (const [fileName, entry] of Object.entries(
+			parsed.files as Record<string, unknown>,
+		)) {
+			if (!fileName.endsWith(".toml")) continue;
+			if (!entry || typeof entry !== "object") continue;
+			const sha256 = (entry as { sha256?: unknown }).sha256;
+			if (typeof sha256 === "string" && /^[0-9a-f]{64}$/i.test(sha256)) {
+				files[fileName] = { sha256: sha256.toLowerCase() };
+			}
+		}
+		return { version: 1, files };
+	} catch {
+		return { version: 1, files: {} };
+	}
+}
+
+async function writeNativeAgentInstallManifest(
+	agentsDir: string,
+	manifest: NativeAgentInstallManifest,
+): Promise<void> {
+	const manifestPath = nativeAgentInstallManifestPath(agentsDir);
+	await mkdir(dirname(manifestPath), { recursive: true });
+	const sortedFiles = Object.fromEntries(
+		Object.entries(manifest.files).sort(([left], [right]) =>
+			left.localeCompare(right),
+		),
+	);
+	await writeFile(
+		manifestPath,
+		JSON.stringify({ version: 1, files: sortedFiles }, null, 2) + "\n",
+	);
+}
+
+async function syncNativeAgentToml(
+	content: string,
+	dstPath: string,
+	summary: SetupCategorySummary,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose" | "force">,
+	verboseLabel: string,
+	manifest: NativeAgentInstallManifest,
+): Promise<void> {
+	const fileName = basename(dstPath);
+	const nextHash = hashContent(content);
+	const destinationExists = existsSync(dstPath);
+
+	if (!destinationExists) {
+		if (!options.dryRun) {
+			await mkdir(dirname(dstPath), { recursive: true });
+			await writeFile(dstPath, content);
+			manifest.files[fileName] = { sha256: nextHash };
+		}
+		summary.updated += 1;
+		if (options.verbose) {
+			console.log(
+				`  ${options.dryRun ? "would update" : "updated"} ${verboseLabel}`,
+			);
+		}
+		return;
+	}
+
+	const existing = await readFile(dstPath, "utf-8");
+	const existingHash = hashContent(existing);
+	if (existing === content) {
+		if (!options.dryRun) {
+			manifest.files[fileName] = { sha256: nextHash };
+		}
+		summary.unchanged += 1;
+		return;
+	}
+
+	const priorHash = manifest.files[fileName]?.sha256;
+	const safeToOverwrite = options.force || priorHash === existingHash;
+	if (!safeToOverwrite) {
+		summary.skipped += 1;
+		if (options.verbose) {
+			console.log(
+				`  skipped ${verboseLabel} (local modifications preserved; use --force to overwrite)`,
+			);
+		}
+		return;
+	}
+
+	if (await ensureBackup(dstPath, true, backupContext, options)) {
+		summary.backedUp += 1;
+	}
+
+	if (!options.dryRun) {
+		await mkdir(dirname(dstPath), { recursive: true });
+		await writeFile(dstPath, content);
+		manifest.files[fileName] = { sha256: nextHash };
+	}
+
+	summary.updated += 1;
+	if (options.verbose) {
+		console.log(
+			`  ${options.dryRun ? "would update" : "updated"} ${verboseLabel}`,
+		);
+	}
+}
+
 async function syncManagedWindowsNativeHookShim(
 	codexHomeDir: string,
 	pkgRoot: string,
@@ -3399,6 +3549,7 @@ async function refreshNativeAgentConfigs(
 		await mkdir(agentsDir, { recursive: true });
 	}
 
+	const nativeAgentManifest = await readNativeAgentInstallManifest(agentsDir);
 	const manifest = tryReadCatalogManifest();
 	const agentStatusByName = manifest
 		? getCatalogAgentStatusByName(manifest)
@@ -3439,13 +3590,14 @@ async function refreshNativeAgentConfigs(
 			codexHomeOverride: join(agentsDir, ".."),
 		});
 		const dst = join(agentsDir, `${name}.toml`);
-		await syncManagedContent(
+		await syncNativeAgentToml(
 			toml,
 			dst,
 			summary,
 			backupContext,
 			options,
 			`native agent ${name}.toml`,
+			nativeAgentManifest,
 		);
 	}
 
@@ -3489,6 +3641,7 @@ async function refreshNativeAgentConfigs(
 			}
 			if (!options.dryRun) {
 				await rm(staleAgentPath, { force: true });
+				delete nativeAgentManifest.files[file];
 			}
 			summary.removed += 1;
 			if (options.verbose) {
@@ -3500,6 +3653,10 @@ async function refreshNativeAgentConfigs(
 				console.log(`  ${prefix} ${file} (status: ${label}${reason})`);
 			}
 		}
+	}
+
+	if (!options.dryRun) {
+		await writeNativeAgentInstallManifest(agentsDir, nativeAgentManifest);
 	}
 
 	return summary;

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -68,6 +68,7 @@ const DEV_INSTALL_SOURCE = 'github:Yeachan-Heo/oh-my-codex#dev';
 const DEV_REPOSITORY_URL = 'https://github.com/Yeachan-Heo/oh-my-codex.git';
 const DEV_REPOSITORY_BRANCH = 'dev';
 const DEV_UPDATE_TIMEOUT_MS = 300000;
+const SKIP_NATIVE_AGENT_REFRESH_ENV = 'OMX_SKIP_NATIVE_AGENT_REFRESH';
 
 export function resolveUpdateChannelConfig(channel: UpdateChannel = 'stable'): UpdateChannelConfig {
   if (channel === 'dev') {
@@ -445,6 +446,7 @@ export function runDeferredGlobalUpdate(
       ...process.env,
       OMX_DEFERRED_UPDATE_LOG: logPath,
       OMX_DEFERRED_UPDATE_PARENT_PID: String(parentPid),
+      [SKIP_NATIVE_AGENT_REFRESH_ENV]: '1',
     };
 
     const command = platform === 'win32' ? 'powershell.exe' : 'sh';


### PR DESCRIPTION
Fixes #2819.

## Summary
- skip native-agent TOML refreshes for deferred/background update-check setup handoffs
- add a setup-owned native-agent hash manifest so normal setup refresh preserves user-modified TOMLs
- keep explicit setup --force as the only overwrite path for customized native-agent TOMLs
- add regressions for setup refresh, forced setup, and deferred update-check behavior

## Verification
- npm run build
- node dist/scripts/run-test-files.js dist/cli/__tests__/setup-prompts-overwrite.test.js dist/cli/__tests__/update.test.js dist/agents/__tests__/native-config.test.js
- npm run lint
- npm run check:no-unused