### PR TITLE
fix: accept tracker-backed ralplan native reviews

### DIFF
--- a/src/autopilot/__tests__/ralplan-gate.test.ts
+++ b/src/autopilot/__tests__/ralplan-gate.test.ts
@@ -281,7 +281,6 @@ describe('autopilot ralplan gate', () => {
     });
   }
 
-
   it('accepts fresh next-state consensus over stale invalid current-state consensus', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-fresh-next-valid-'));
     const sessionId = 'sess-autopilot-fresh-next-valid';
@@ -375,6 +374,329 @@ describe('autopilot ralplan gate', () => {
       assert.equal(decision.allowed, true);
       assert.equal(decision.evidence?.source, 'next-autopilot-state');
       assert.equal(decision.evidence?.blockedReason, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts tracker-backed native reviews without duplicated session, tracker, or artifact fields', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-tracker-resolved-'));
+    const sessionId = 'sess-autopilot-tracker-resolved';
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-06-12T10:03:00.000Z',
+            threads: {
+              'thread-leader': { thread_id: 'thread-leader', kind: 'leader', first_seen_at: '2026-06-12T09:59:00.000Z', last_seen_at: '2026-06-12T09:59:00.000Z', turn_count: 1 },
+              'thread-architect': { thread_id: 'thread-architect', kind: 'subagent', first_seen_at: '2026-06-12T10:02:00.000Z', last_seen_at: '2026-06-12T10:02:00.000Z', completed_at: '2026-06-12T10:02:00.000Z', turn_count: 1 },
+              'thread-critic': { thread_id: 'thread-critic', kind: 'subagent', first_seen_at: '2026-06-12T10:03:00.000Z', last_seen_at: '2026-06-12T10:03:00.000Z', completed_at: '2026-06-12T10:03:00.000Z', turn_count: 1 },
+            },
+          },
+        },
+      }, null, 2));
+
+      const state = {
+        current_phase: 'ralplan',
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              thread_id: 'thread-architect',
+              completed_at: '2026-06-12T10:02:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              thread_id: 'thread-critic',
+              completed_at: '2026-06-12T10:03:00.000Z',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, sessionId, currentState: state });
+      assert.equal(decision.allowed, true);
+      assert.equal(decision.evidence?.blockedReason, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects omitted review session ids when no transition session context exists', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-no-session-context-'));
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {},
+      }, null, 2));
+
+      const state = {
+        current_phase: 'ralplan',
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              thread_id: 'thread-architect',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              thread_id: 'thread-critic',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, currentState: state });
+      assert.equal(decision.allowed, false);
+      assert.match(buildAutopilotRalplanUltragoalGateError(decision), /cannot resolve session_id/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects architect and critic reviews that reuse the same native tracker thread', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-duplicate-thread-'));
+    const sessionId = 'sess-autopilot-duplicate-thread';
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-06-12T10:03:00.000Z',
+            threads: {
+              'thread-leader': { thread_id: 'thread-leader', kind: 'leader', first_seen_at: '2026-06-12T09:59:00.000Z', last_seen_at: '2026-06-12T09:59:00.000Z', turn_count: 1 },
+              'thread-reviewer': { thread_id: 'thread-reviewer', kind: 'subagent', first_seen_at: '2026-06-12T10:02:00.000Z', last_seen_at: '2026-06-12T10:03:00.000Z', completed_at: '2026-06-12T10:03:00.000Z', turn_count: 1 },
+            },
+          },
+        },
+      }, null, 2));
+
+      const state = {
+        current_phase: 'ralplan',
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-reviewer',
+              completed_at: '2026-06-12T10:02:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-reviewer',
+              completed_at: '2026-06-12T10:03:00.000Z',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, sessionId, currentState: state });
+      assert.equal(decision.allowed, false);
+      assert.match(buildAutopilotRalplanUltragoalGateError(decision), /distinct native subagent tracker threads/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects tracker-backed native reviews composed from different sessions', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-cross-session-'));
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          'sess-architect': {
+            session_id: 'sess-architect',
+            leader_thread_id: 'thread-leader-a',
+            updated_at: '2026-06-12T10:02:00.000Z',
+            threads: {
+              'thread-leader-a': { thread_id: 'thread-leader-a', kind: 'leader', first_seen_at: '2026-06-12T09:59:00.000Z', last_seen_at: '2026-06-12T09:59:00.000Z', turn_count: 1 },
+              'thread-architect': { thread_id: 'thread-architect', kind: 'subagent', first_seen_at: '2026-06-12T10:02:00.000Z', last_seen_at: '2026-06-12T10:02:00.000Z', completed_at: '2026-06-12T10:02:00.000Z', turn_count: 1 },
+            },
+          },
+          'sess-critic': {
+            session_id: 'sess-critic',
+            leader_thread_id: 'thread-leader-c',
+            updated_at: '2026-06-12T10:03:00.000Z',
+            threads: {
+              'thread-leader-c': { thread_id: 'thread-leader-c', kind: 'leader', first_seen_at: '2026-06-12T09:59:00.000Z', last_seen_at: '2026-06-12T09:59:00.000Z', turn_count: 1 },
+              'thread-critic': { thread_id: 'thread-critic', kind: 'subagent', first_seen_at: '2026-06-12T10:03:00.000Z', last_seen_at: '2026-06-12T10:03:00.000Z', completed_at: '2026-06-12T10:03:00.000Z', turn_count: 1 },
+            },
+          },
+        },
+      }, null, 2));
+
+      const state = {
+        current_phase: 'ralplan',
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: 'sess-architect',
+              thread_id: 'thread-architect',
+              completed_at: '2026-06-12T10:02:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: 'sess-critic',
+              thread_id: 'thread-critic',
+              completed_at: '2026-06-12T10:03:00.000Z',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, currentState: state });
+      assert.equal(decision.allowed, false);
+      assert.match(buildAutopilotRalplanUltragoalGateError(decision), /same native subagent tracker session/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects stale review session ids even when transition session context exists', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-live-session-mismatch-'));
+    const sessionId = 'sess-autopilot-live-session';
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-06-12T10:03:00.000Z',
+            threads: {
+              'thread-leader': { thread_id: 'thread-leader', kind: 'leader', first_seen_at: '2026-06-12T09:59:00.000Z', last_seen_at: '2026-06-12T09:59:00.000Z', turn_count: 1 },
+              'thread-architect': { thread_id: 'thread-architect', kind: 'subagent', first_seen_at: '2026-06-12T10:02:00.000Z', last_seen_at: '2026-06-12T10:02:00.000Z', completed_at: '2026-06-12T10:02:00.000Z', turn_count: 1 },
+              'thread-critic': { thread_id: 'thread-critic', kind: 'subagent', first_seen_at: '2026-06-12T10:03:00.000Z', last_seen_at: '2026-06-12T10:03:00.000Z', completed_at: '2026-06-12T10:03:00.000Z', turn_count: 1 },
+            },
+          },
+        },
+      }, null, 2));
+
+      const state = {
+        current_phase: 'ralplan',
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              thread_id: 'thread-architect',
+              completed_at: '2026-06-12T10:02:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: 'sess-stale-critic',
+              thread_id: 'thread-critic',
+              completed_at: '2026-06-12T10:03:00.000Z',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, sessionId, currentState: state });
+      assert.equal(decision.allowed, false);
+      assert.match(buildAutopilotRalplanUltragoalGateError(decision), /critic review session_id=sess-stale-critic does not match/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects tracker-backed native reviews whose subagent threads are not completed', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-incomplete-thread-'));
+    const sessionId = 'sess-autopilot-incomplete-thread';
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-06-12T10:03:00.000Z',
+            threads: {
+              'thread-leader': { thread_id: 'thread-leader', kind: 'leader', first_seen_at: '2026-06-12T09:59:00.000Z', last_seen_at: '2026-06-12T09:59:00.000Z', turn_count: 1 },
+              'thread-architect': { thread_id: 'thread-architect', kind: 'subagent', first_seen_at: '2026-06-12T10:02:00.000Z', last_seen_at: '2026-06-12T10:02:00.000Z', turn_count: 1 },
+              'thread-critic': { thread_id: 'thread-critic', kind: 'subagent', first_seen_at: '2026-06-12T10:03:00.000Z', last_seen_at: '2026-06-12T10:03:00.000Z', completed_at: '2026-06-12T10:03:00.000Z', turn_count: 1 },
+            },
+          },
+        },
+      }, null, 2));
+
+      const state = {
+        current_phase: 'ralplan',
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-architect',
+              completed_at: '2026-06-12T10:02:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-critic',
+              completed_at: '2026-06-12T10:03:00.000Z',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, sessionId, currentState: state });
+      assert.equal(decision.allowed, false);
+      assert.match(buildAutopilotRalplanUltragoalGateError(decision), /architect tracker thread thread-architect is not completed/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -474,6 +796,7 @@ describe('autopilot ralplan gate', () => {
                 kind: 'subagent',
                 first_seen_at: '2026-05-28T18:34:51.000Z',
                 last_seen_at: '2026-05-28T18:34:51.000Z',
+                completed_at: '2026-05-28T18:34:51.000Z',
                 turn_count: 1,
                 mode: 'architect',
               },
@@ -482,6 +805,7 @@ describe('autopilot ralplan gate', () => {
                 kind: 'subagent',
                 first_seen_at: '2026-05-28T18:35:10.000Z',
                 last_seen_at: '2026-05-28T18:35:10.000Z',
+                completed_at: '2026-05-28T18:35:10.000Z',
                 turn_count: 1,
                 mode: 'critic',
               },

--- a/src/ralplan/__tests__/consensus-gate.test.ts
+++ b/src/ralplan/__tests__/consensus-gate.test.ts
@@ -241,6 +241,100 @@ describe('ralplan consensus gate state roots', () => {
     }
   });
 
+  it('accepts session-scoped tracker-backed reviews without an explicit sessionId option', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-discovered-session-'));
+    const boxedRoot = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-discovered-root-'));
+    const previousOmxRoot = process.env.OMX_ROOT;
+    const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const previousOmxTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const sessionId = 'sess-discovered-consensus';
+    try {
+      delete process.env.OMX_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+      process.env.OMX_STATE_ROOT = boxedRoot;
+      const baseStateDir = getBaseStateDir(cwd);
+      const sessionDir = join(baseStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(baseStateDir, 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        native_session_id: 'thread-leader',
+        cwd,
+      }, null, 2));
+      await writeFile(subagentTrackingPath(cwd), JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-06-12T10:03:00.000Z',
+            threads: {
+              'thread-leader': {
+                thread_id: 'thread-leader',
+                kind: 'leader',
+                first_seen_at: '2026-06-12T09:59:00.000Z',
+                last_seen_at: '2026-06-12T09:59:00.000Z',
+                turn_count: 1,
+              },
+              'thread-architect': {
+                thread_id: 'thread-architect',
+                kind: 'subagent',
+                first_seen_at: '2026-06-12T10:02:00.000Z',
+                last_seen_at: '2026-06-12T10:02:00.000Z',
+                completed_at: '2026-06-12T10:02:00.000Z',
+                turn_count: 1,
+              },
+              'thread-critic': {
+                thread_id: 'thread-critic',
+                kind: 'subagent',
+                first_seen_at: '2026-06-12T10:03:00.000Z',
+                last_seen_at: '2026-06-12T10:03:00.000Z',
+                completed_at: '2026-06-12T10:03:00.000Z',
+                turn_count: 1,
+              },
+            },
+          },
+        },
+      }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        ralplan_consensus_gate: {
+          complete: true,
+          sequence: ['architect-review', 'critic-review'],
+          ralplan_architect_review: {
+            agent_role: 'architect',
+            provenance_kind: 'native_subagent',
+            verdict: 'approve',
+            thread_id: 'thread-architect',
+            completed_at: '2026-06-12T10:02:00.000Z',
+          },
+          ralplan_critic_review: {
+            agent_role: 'critic',
+            provenance_kind: 'native_subagent',
+            verdict: 'approve',
+            thread_id: 'thread-critic',
+            completed_at: '2026-06-12T10:03:00.000Z',
+          },
+        },
+      }, null, 2));
+
+      const gate = buildRalplanConsensusGateForCwd(cwd, {
+        requireNativeSubagents: true,
+      });
+
+      assert.equal(gate.complete, true);
+      assert.equal(gate.blockedReason, null);
+      assert.match(String(gate.source), new RegExp(`${sessionId}/ralplan-state\\.json$`));
+    } finally {
+      if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof previousOmxTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousOmxTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(boxedRoot, { recursive: true, force: true });
+    }
+  });
+
   it('rejects stale top-level handoff consensus during a return-to-ralplan cycle', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-stale-'));
     try {

--- a/src/ralplan/consensus-gate.ts
+++ b/src/ralplan/consensus-gate.ts
@@ -31,6 +31,7 @@ export interface RalplanNativeSubagentConsensusOptions {
 export interface RalplanConsensusSource {
   source: string;
   value: unknown;
+  sessionId?: string;
 }
 
 type ConsensusResolution = {
@@ -52,6 +53,7 @@ export function buildRalplanConsensusGateFromSources(
     ralplan_architect_review: Record<string, unknown>;
     ralplan_critic_review: Record<string, unknown>;
     source: string;
+    options: RalplanNativeSubagentConsensusOptions;
   } | null = null;
   let validEvidence: {
     ralplan_architect_review: Record<string, unknown>;
@@ -67,6 +69,10 @@ export function buildRalplanConsensusGateFromSources(
 
   for (const candidate of sources) {
     const evidence = resolveConsensusEvidence(candidate.value);
+    const candidateOptions = {
+      ...options,
+      sessionId: options.sessionId ?? candidate.sessionId,
+    };
     if (evidence?.kind === 'invalid') {
       invalidCompleteEvidence ??= { ...evidence, source: candidate.source };
       continue;
@@ -75,9 +81,9 @@ export function buildRalplanConsensusGateFromSources(
     if (evidence?.kind === 'valid') {
       if (
         options.requireNativeSubagents
-        && !hasTrackerBackedNativeRalplanLanes(evidence, options)
+        && !hasTrackerBackedNativeRalplanLanes(evidence, candidateOptions)
       ) {
-        nativeBlockedEvidence ??= { ...evidence, source: candidate.source };
+        nativeBlockedEvidence ??= { ...evidence, source: candidate.source, options: candidateOptions };
         continue;
       }
       validEvidence ??= { ...evidence, source: candidate.source };
@@ -116,8 +122,9 @@ export function buildRalplanConsensusGateFromSources(
       source: nativeBlockedEvidence.source,
       blockedReason: RALPLAN_CONSENSUS_BLOCKED_REASONS.nativeSubagentEvidenceMissing,
       blockedDetails: [
-        trackerBackedNativeReviewProblem(nativeBlockedEvidence.ralplan_architect_review, 'architect', options),
-        trackerBackedNativeReviewProblem(nativeBlockedEvidence.ralplan_critic_review, 'critic', options),
+        trackerBackedNativeReviewPairProblem(nativeBlockedEvidence, nativeBlockedEvidence.options),
+        trackerBackedNativeReviewProblem(nativeBlockedEvidence.ralplan_architect_review, 'architect', nativeBlockedEvidence.options),
+        trackerBackedNativeReviewProblem(nativeBlockedEvidence.ralplan_critic_review, 'critic', nativeBlockedEvidence.options),
       ].filter((detail): detail is string => Boolean(detail)),
     };
   }
@@ -175,22 +182,25 @@ export function readLocalRalplanConsensusStateCandidates(
   const scopedStateDir = getBaseStateDir(cwd);
   const localStateDir = localBaseStateDir(cwd);
   if (explicitSession && sessionIdList.length === 0) return [];
-  const stateRoots = sessionIdList.length > 0
+  const stateRoots: Array<{ dir: string; sessionId?: string }> = sessionIdList.length > 0
     ? uniquePaths(sessionIdList.flatMap((id) => [
       join(scopedStateDir, 'sessions', id),
       join(localStateDir, 'sessions', id),
-    ]))
-    : [localStateDir];
+    ])).map((dir) => ({
+      dir,
+      sessionId: sessionIdFromStateRoot(dir),
+    }))
+    : [{ dir: localStateDir }];
 
-  const paths = stateRoots.flatMap((dir) => [
-    join(dir, 'ralplan-state.json'),
-    join(dir, 'autopilot-state.json'),
+  const paths = stateRoots.flatMap(({ dir, sessionId }) => [
+    { path: join(dir, 'ralplan-state.json'), sessionId },
+    { path: join(dir, 'autopilot-state.json'), sessionId },
   ]);
 
-  return paths.flatMap((path) => {
+  return paths.flatMap(({ path, sessionId }) => {
     const state = readJsonState(path);
     if (!state) return [];
-    return [{ source: path, value: state }];
+    return [{ source: path, value: state, sessionId }];
   });
 }
 
@@ -504,9 +514,7 @@ function hasTrackerBackedNativeRalplanLanes(
   },
   options: RalplanNativeSubagentConsensusOptions,
 ): boolean {
-  const architectThreadId = nativeReviewThreadId(evidence.ralplan_architect_review);
-  const criticThreadId = nativeReviewThreadId(evidence.ralplan_critic_review);
-  if (!architectThreadId || !criticThreadId || architectThreadId === criticThreadId) return false;
+  if (trackerBackedNativeReviewPairProblem(evidence, options)) return false;
   return isTrackerBackedNativeReview(evidence.ralplan_architect_review, 'architect', options)
     && isTrackerBackedNativeReview(evidence.ralplan_critic_review, 'critic', options);
 }
@@ -515,12 +523,38 @@ function nativeReviewThreadId(review: Record<string, unknown> | null): string {
   return typeof review?.thread_id === 'string' ? review.thread_id.trim() : '';
 }
 
+function trackerBackedNativeReviewPairProblem(
+  evidence: {
+    ralplan_architect_review: Record<string, unknown> | null;
+    ralplan_critic_review: Record<string, unknown> | null;
+  },
+  options: RalplanNativeSubagentConsensusOptions,
+): string | null {
+  const architectThreadId = nativeReviewThreadId(evidence.ralplan_architect_review);
+  const criticThreadId = nativeReviewThreadId(evidence.ralplan_critic_review);
+  if (architectThreadId && criticThreadId && architectThreadId === criticThreadId) {
+    return 'architect and critic reviews must reference distinct native subagent tracker threads';
+  }
+
+  const transitionSessionId = typeof options.sessionId === 'string' ? options.sessionId.trim() : '';
+  const architectSessionId = transitionSessionId || nativeReviewSessionId(evidence.ralplan_architect_review);
+  const criticSessionId = transitionSessionId || nativeReviewSessionId(evidence.ralplan_critic_review);
+  if (!architectSessionId || !criticSessionId) return null;
+  return architectSessionId === criticSessionId
+    ? null
+    : `architect and critic reviews must resolve to the same native subagent tracker session; architect session_id=${architectSessionId}, critic session_id=${criticSessionId}`;
+}
+
 function isTrackerBackedNativeReview(
   review: Record<string, unknown> | null,
   agentRole: 'architect' | 'critic',
   options: RalplanNativeSubagentConsensusOptions,
 ): boolean {
   return trackerBackedNativeReviewProblem(review, agentRole, options) === null;
+}
+
+function nativeReviewSessionId(review: Record<string, unknown> | null): string {
+  return typeof review?.session_id === 'string' ? review.session_id.trim() : '';
 }
 
 function trackerBackedNativeReviewProblem(
@@ -540,13 +574,11 @@ function trackerBackedNativeReviewProblem(
       : '';
   const reviewSessionId = typeof review.session_id === 'string' ? review.session_id.trim() : '';
   const threadId = typeof review.thread_id === 'string' ? review.thread_id.trim() : '';
-  const artifactPath = typeof review.artifact_path === 'string' ? review.artifact_path.trim() : '';
   const trackerPath = typeof review.tracker_path === 'string' ? review.tracker_path.trim() : '';
   if (!sessionId) issues.push(`${agentRole} review cannot resolve session_id`);
-  if (!reviewSessionId || reviewSessionId !== sessionId) issues.push(`${agentRole} review session_id=${reviewSessionId || 'missing'} does not match ${sessionId || 'missing'}`);
+  if (reviewSessionId && reviewSessionId !== sessionId) issues.push(`${agentRole} review session_id=${reviewSessionId} does not match ${sessionId || 'missing'}`);
   if (!threadId) issues.push(`${agentRole} review missing thread_id`);
-  if (!artifactPath) issues.push(`${agentRole} review missing artifact_path`);
-  if (!trackerPath || !trackerPath.endsWith('subagent-tracking.json')) issues.push(`${agentRole} review missing subagent-tracking.json tracker_path`);
+  if (trackerPath && !trackerPath.endsWith('subagent-tracking.json')) issues.push(`${agentRole} review tracker_path=${trackerPath} is not subagent-tracking.json`);
   const cwd = typeof options.cwd === 'string' ? options.cwd.trim() : '';
   if (!cwd) issues.push(`${agentRole} review cannot resolve cwd for tracker lookup`);
 
@@ -565,6 +597,8 @@ function trackerBackedNativeReviewProblem(
     || (leaderThreadId && leaderThreadId === threadId && thread.kind !== 'subagent')
   ) return `${agentRole} tracker thread ${threadId} is the session leader`;
   if (thread.kind !== 'subagent') return `${agentRole} tracker thread ${threadId} has kind=${String(thread.kind || 'missing')}`;
+  const completedAt = typeof thread.completed_at === 'string' ? thread.completed_at.trim() : '';
+  if (!completedAt) return `${agentRole} tracker thread ${threadId} is not completed`;
   return null;
 }
 
@@ -615,6 +649,13 @@ function readLocalCurrentSessionIds(cwd: string): string[] {
 
 function localBaseStateDir(cwd: string): string {
   return join(resolveWorkingDirectoryForState(cwd), '.omx', 'state');
+}
+
+function sessionIdFromStateRoot(path: string): string | undefined {
+  const normalized = path.replace(/\\/g, '/');
+  const match = /\/sessions\/([^/]+)$/.exec(normalized);
+  const sessionId = match?.[1];
+  return sessionId && validateLocalSessionId(sessionId).length > 0 ? sessionId : undefined;
 }
 
 function uniquePaths(paths: string[]): string[] {


### PR DESCRIPTION
## Engineering rationale

Fixes bead `omx-i39.2` by moving Autopilot ralplan consensus proof away from duplicated artifact/path fields and onto the canonical native subagent tracker authority.

The contract: **Autopilot ralplan transition must accept completed native Architect/Critic reviews when tracker-backed evidence exists, without manual artifact fabrication or stale tracker false negatives.**

This PR:
- accepts native Architect/Critic approval records that omit duplicated `session_id`, `tracker_path`, and `artifact_path` when the session/thread can be resolved through canonical tracker state;
- propagates discovered session ids from session-scoped ralplan/autopilot state candidates so no-explicit-session callers (for example keyword gating) do not false-negative;
- rejects unsafe composites: duplicate Architect/Critic thread, cross-session evidence, stale explicit review session ids, leader/non-subagent threads, incomplete tracker threads, and non-approve evidence;
- keeps `artifact_path` as optional audit metadata, not the proof of native approval.

## Acceptance checklist

- [x] Autopilot ralplan transition accepts completed native Architect/Critic reviews when tracker-backed evidence exists.
- [x] No manual artifact fabrication is required for `artifact_path` / `tracker_path` fields.
- [x] Stale tracker false negatives are avoided for session-scoped state discovered without an explicit `sessionId` option.
- [x] Cross-session composite consensus is rejected.
- [x] Incomplete native subagent tracker threads are rejected unless `completed_at` is present.
- [x] Same-thread Architect/Critic reuse is rejected.
- [x] Stale explicit review `session_id` values are rejected even when transition session context exists.
- [x] PR is self-contained on `dev`: `origin/dev..HEAD` contains only `bef4c4b3`.

## Verification

- [x] `npm run build`
- [x] `node dist/scripts/run-test-files.js dist/ralplan/__tests__/consensus-gate.test.js dist/autopilot/__tests__/ralplan-gate.test.js` — 27/27 passed
- [x] `npx biome lint src/ralplan/consensus-gate.ts src/ralplan/__tests__/consensus-gate.test.ts src/autopilot/__tests__/ralplan-gate.test.ts`
- [x] `npm run check:no-unused -- --pretty false`
- [x] `git diff --check -- scoped files`
- [x] Autopilot code-review gate: code-reviewer APPROVE, architect CLEAR
- [x] Scholastic advisory: PASS / scoped wording observed (do not claim artifact/transcript authenticity; claim tracker-resolved native subagent lane identity plus approving review record)

## Validation note

A broad `npm test` run progressed through the changed suites but hit an unrelated existing version-stamp mismatch in `dist/cli/__tests__/version.test.js`: expected `oh-my-codex v0.18.12`, actual `oh-my-codex v0.18.12-dev-3742121e2557`. Scoped build/tests/lint/typecheck for this PR pass.
