### PR TITLE
docs: clarify ultragoal default flow

### DIFF
--- a/docs/agents.html
+++ b/docs/agents.html
@@ -21,7 +21,7 @@
     <main class="container">
       <h1>Agent Catalog</h1>
       <p class="muted">Specialist agent reference for advanced use inside the standard workflow.</p>
-      <p>Start with <code>$deep-interview</code>, then <code>$ralplan</code>, then execute with <code>$team</code> or <code>$ralph</code>. Use the catalog below when you already know you need a specialist lane.</p>
+      <p>Start with <code>$deep-interview</code>, then <code>$ralplan</code>, then execute with <code>$ultragoal</code>. Use <code>$team</code> only when a specific Ultragoal story needs coordinated parallel work, or <code>$ralph</code> when you intentionally want a single-owner fallback loop. Use the catalog below when you already know you need a specialist lane.</p>
 
       <h2>Build & Analysis</h2>
       <table>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -63,7 +63,7 @@ omx                                              # standard launch</code></pre>
         <li>Start Codex CLI with <code>omx</code>.</li>
         <li>Use <code>$deep-interview "clarify the auth change"</code> when intent or boundaries are still unclear.</li>
         <li>Use <code>$ralplan "approve the auth plan and review tradeoffs"</code> to lock the implementation plan; hand off only after Architect review evidence and then Critic review evidence are recorded.</li>
-        <li>Choose <code>$ralph "carry the approved plan to completion"</code> or <code>$team 3:executor "execute the approved plan in parallel"</code> based on execution style.</li>
+        <li>Use <code>$ultragoal "carry the approved plan to durable goals"</code> as the default execution wrapper; use <code>$team</code> only inside that path when coordinated parallel work materially helps, or <code>$ralph</code> as an intentional single-owner fallback.</li>
       </ol>
 
       <h2>Prompt Instruction Source</h2>


### PR DESCRIPTION
## Summary
- update public getting-started docs to make Ultragoal the default execution wrapper after ralplan
- update agent catalog docs to present team and ralph as optional/specific execution paths, not the default handoff

## Verification
- npm run build
- node --test dist/hooks/__tests__/autopilot-skill-contract.test.js dist/scripts/__tests__/docs-site-contract.test.js dist/cli/__tests__/install-docs-contract.test.js