### PR TITLE
fix: align sidecar team state root with Team runtime (#2824)

### DIFF
--- a/src/sidecar/__tests__/collector.test.ts
+++ b/src/sidecar/__tests__/collector.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join, relative } from 'node:path';
 import { describe, it } from 'node:test';
 import { collectSidecarSnapshot, readTailText } from '../collector.js';
+import { resolveCanonicalTeamStateRoot } from '../../team/state-root.js';
 
 async function writeJson(path: string, value: unknown): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
@@ -169,5 +170,69 @@ describe('collectSidecarSnapshot', () => {
       assert.ok(snapshot);
       assert.deepEqual(snapshot.events.map((event) => event.event_id), ['e28', 'e29', 'e30']);
     });
+  });
+});
+
+describe('collectSidecarSnapshot canonical Team state root parity', () => {
+  async function withBoxedTeam(
+    envKey: 'OMX_ROOT' | 'OMX_STATE_ROOT',
+    test: (params: { cwd: string; env: NodeJS.ProcessEnv; boxedRoot: string }) => Promise<void>,
+  ): Promise<void> {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-sidecar-boxed-'));
+    try {
+      const boxedRoot = join(cwd, 'box');
+      const env = { [envKey]: boxedRoot } as NodeJS.ProcessEnv;
+      const teamRoot = join(resolveCanonicalTeamStateRoot(cwd, env), 'team', 'demo');
+      await mkdir(teamRoot, { recursive: true });
+      await writeJson(join(teamRoot, 'config.json'), {
+        name: 'demo',
+        task: 'ship sidecar',
+        tmux_session: 'omx-demo',
+        workers: [{ name: 'worker-1', index: 1, role: 'executor' }],
+      });
+      await test({ cwd, env, boxedRoot });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  }
+
+  it('resolves sidecar team state under OMX_ROOT like the Team runtime', async () => {
+    await withBoxedTeam('OMX_ROOT', async ({ cwd, env, boxedRoot }) => {
+      assert.equal(resolveCanonicalTeamStateRoot(cwd, env), join(boxedRoot, '.omx', 'state'));
+      const snapshot = await collectSidecarSnapshot('demo', { cwd, env, now: new Date('2026-04-27T02:01:00.000Z') });
+      assert.ok(snapshot, 'sidecar must read team state from the canonical OMX_ROOT location');
+      assert.equal(snapshot.team_name, 'demo');
+    });
+  });
+
+  it('resolves sidecar team state under OMX_STATE_ROOT like the Team runtime', async () => {
+    await withBoxedTeam('OMX_STATE_ROOT', async ({ cwd, env, boxedRoot }) => {
+      assert.equal(resolveCanonicalTeamStateRoot(cwd, env), join(boxedRoot, '.omx', 'state'));
+      const snapshot = await collectSidecarSnapshot('demo', { cwd, env, now: new Date('2026-04-27T02:01:00.000Z') });
+      assert.ok(snapshot, 'sidecar must read team state from the canonical OMX_STATE_ROOT location');
+      assert.equal(snapshot.team_name, 'demo');
+    });
+  });
+
+  it('still honors OMX_TEAM_STATE_ROOT precedence over OMX_ROOT', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-sidecar-precedence-'));
+    try {
+      const teamStateRoot = join(cwd, 'explicit-team-state');
+      const env = { OMX_TEAM_STATE_ROOT: teamStateRoot, OMX_ROOT: join(cwd, 'box') } as NodeJS.ProcessEnv;
+      const teamRoot = join(teamStateRoot, 'team', 'demo');
+      await mkdir(teamRoot, { recursive: true });
+      await writeJson(join(teamRoot, 'config.json'), {
+        name: 'demo',
+        task: 'ship sidecar',
+        tmux_session: 'omx-demo',
+        workers: [{ name: 'worker-1', index: 1, role: 'executor' }],
+      });
+      assert.equal(resolveCanonicalTeamStateRoot(cwd, env), teamStateRoot);
+      const snapshot = await collectSidecarSnapshot('demo', { cwd, env, now: new Date('2026-04-27T02:01:00.000Z') });
+      assert.ok(snapshot, 'OMX_TEAM_STATE_ROOT must win over OMX_ROOT for sidecar lookup');
+      assert.equal(snapshot.team_name, 'demo');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/src/sidecar/collector.ts
+++ b/src/sidecar/collector.ts
@@ -1,6 +1,7 @@
 import { open, readFile, readdir } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { join } from 'node:path';
 import { TEAM_NAME_SAFE_PATTERN, TEAM_TASK_STATUSES, WORKER_NAME_SAFE_PATTERN } from '../team/contracts.js';
+import { resolveCanonicalTeamStateRoot } from '../team/state-root.js';
 import type {
   CollectSidecarSnapshotOptions,
   SidecarEvent,
@@ -46,13 +47,8 @@ function asTaskStatus(value: unknown): SidecarTask['status'] {
   return typeof value === 'string' && (TEAM_TASK_STATUSES as readonly string[]).includes(value) ? value as SidecarTask['status'] : 'pending';
 }
 
-function stateRoot(cwd: string, env: NodeJS.ProcessEnv): string {
-  const explicit = safeString(env.OMX_TEAM_STATE_ROOT);
-  return explicit ? resolve(cwd, explicit) : join(cwd, '.omx', 'state');
-}
-
 function teamRoot(teamName: string, cwd: string, env: NodeJS.ProcessEnv): string {
-  return join(stateRoot(cwd, env), 'team', teamName);
+  return join(resolveCanonicalTeamStateRoot(cwd, env), 'team', teamName);
 }
 
 async function readJson<T>(path: string): Promise<T | null> {


### PR DESCRIPTION
## Summary

Fixes #2824 — the sidecar state path differed from the Team runtime state path.

The sidecar collector resolved team state via a local `stateRoot()` helper that only honored `OMX_TEAM_STATE_ROOT` (falling back to `.omx/state`). The Team runtime resolves state through `resolveCanonicalTeamStateRoot`, which additionally honors `OMX_ROOT` and `OMX_STATE_ROOT` boxed roots. As a result, when a team ran under `OMX_ROOT`/`OMX_STATE_ROOT`, the sidecar looked in the wrong location and could not read team state.

## Changes

- `src/sidecar/collector.ts`: delegate `teamRoot()` to `resolveCanonicalTeamStateRoot` and drop the divergent local `stateRoot()` helper (and now-unused `resolve` import), so sidecar and Team runtime use identical state-root precedence.
- `src/sidecar/__tests__/collector.test.ts`: add regression coverage proving the sidecar resolves team state under `OMX_ROOT` and `OMX_STATE_ROOT` like the Team runtime, and that `OMX_TEAM_STATE_ROOT` still takes precedence over `OMX_ROOT`.

## State-root precedence (now shared)

1. `OMX_TEAM_STATE_ROOT`
2. `OMX_ROOT` / `OMX_STATE_ROOT` -> `<root>/.omx/state`
3. default `.omx/state`

## Verification

- `npm run build` (tsc typecheck) — clean
- `npm run check:no-unused` — clean
- `npx biome lint src/sidecar/collector.ts src/sidecar/__tests__/collector.test.ts` — OK
- Focused: `node dist/scripts/run-test-files.js dist/sidecar/__tests__/collector.test.js` — 7/7 pass (3 new)

Closes #2824

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
