### PR TITLE
fix(ci): make dev-merge issue-close PR follow-up comment best-effort (#2826)

### DIFF
--- a/.github/scripts/dev-merge-issue-close.cjs
+++ b/.github/scripts/dev-merge-issue-close.cjs
@@ -108,8 +108,42 @@ function buildMaintainerPrComment({ issueNumbers }) {
   ].join('\n');
 }
 
+function isResourceNotAccessibleError(error) {
+  if (!error) return false;
+  if (error.status === 403 || error.status === '403') return true;
+  return /resource not accessible by integration/i.test(error.message || '');
+}
+
+async function postMergedPrFollowUpComment({ github, core, owner, repo, prNumber, issueNumbers }) {
+  const body = buildMaintainerPrComment({ issueNumbers });
+
+  try {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: prNumber,
+      body,
+    });
+    return { posted: true };
+  } catch (error) {
+    const detail = error && error.message ? error.message : String(error);
+    if (isResourceNotAccessibleError(error)) {
+      core.warning(
+        `Skipped best-effort PR follow-up comment on #${prNumber}: GitHub returned 403 Resource not accessible by integration. Linked issue closure already succeeded, so the workflow is not failing.`,
+      );
+    } else {
+      core.warning(
+        `Skipped best-effort PR follow-up comment on #${prNumber}: ${detail}. Linked issue closure already succeeded, so the workflow is not failing.`,
+      );
+    }
+    return { posted: false, error };
+  }
+}
+
 module.exports = {
   buildMaintainerCloseComment,
   buildMaintainerPrComment,
   collectLinkedLocalIssueNumbers,
+  isResourceNotAccessibleError,
+  postMergedPrFollowUpComment,
 };

--- a/.github/workflows/dev-merge-issue-close.yml
+++ b/.github/workflows/dev-merge-issue-close.yml
@@ -23,8 +23,8 @@ jobs:
           script: |
             const {
               buildMaintainerCloseComment,
-              buildMaintainerPrComment,
               collectLinkedLocalIssueNumbers,
+              postMergedPrFollowUpComment,
             } = require('./.github/scripts/dev-merge-issue-close.cjs');
 
             const pullRequest = context.payload.pull_request;
@@ -86,11 +86,13 @@ jobs:
               return;
             }
 
-            await github.rest.issues.createComment({
+            await postMergedPrFollowUpComment({
+              github,
+              core,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: pullRequest.number,
-              body: buildMaintainerPrComment({ issueNumbers: closedIssueNumbers }),
+              prNumber: pullRequest.number,
+              issueNumbers: closedIssueNumbers,
             });
 
             core.notice(`Closed linked issues after merge to dev: ${closedIssueNumbers.map((issueNumber) => `#${issueNumber}`).join(', ')}`);

--- a/src/verification/__tests__/dev-merge-issue-close-workflow.test.ts
+++ b/src/verification/__tests__/dev-merge-issue-close-workflow.test.ts
@@ -9,6 +9,8 @@ const {
   buildMaintainerCloseComment,
   buildMaintainerPrComment,
   collectLinkedLocalIssueNumbers,
+  isResourceNotAccessibleError,
+  postMergedPrFollowUpComment,
 } = require(join(process.cwd(), '.github', 'scripts', 'dev-merge-issue-close.cjs')) as {
   buildMaintainerCloseComment: ({ prNumber }: { prNumber: number }) => string;
   buildMaintainerPrComment: ({ issueNumbers }: { issueNumbers: number[] }) => string;
@@ -18,6 +20,17 @@ const {
     owner: string;
     repo: string;
   }) => number[];
+  isResourceNotAccessibleError: (error: unknown) => boolean;
+  postMergedPrFollowUpComment: (input: {
+    github: {
+      rest: { issues: { createComment: (args: Record<string, unknown>) => Promise<unknown> } };
+    };
+    core: { warning: (message: string) => void };
+    owner: string;
+    repo: string;
+    prNumber: number;
+    issueNumbers: number[];
+  }) => Promise<{ posted: boolean; error?: unknown }>;
 };
 
 describe('dev merge issue close workflow', () => {
@@ -34,9 +47,16 @@ describe('dev merge issue close workflow', () => {
     assert.match(workflow, /require\('\.\/\.github\/scripts\/dev-merge-issue-close\.cjs'\)/);
     assert.match(workflow, /title:\s*pullRequest\.title/);
     assert.match(workflow, /body:\s*pullRequest\.body/);
-    assert.match(workflow, /buildMaintainerPrComment/);
-    assert.match(workflow, /issue_number:\s*pullRequest\.number/);
+    assert.match(workflow, /postMergedPrFollowUpComment\(\{/);
+    assert.match(workflow, /prNumber:\s*pullRequest\.number/);
     assert.match(workflow, /issueNumbers:\s*closedIssueNumbers/);
+    // Linked issue closure stays enforced: the workflow still closes issues directly.
+    assert.match(workflow, /github\.rest\.issues\.update\(\{[\s\S]*state:\s*'closed'/);
+    // The best-effort PR comment must run only after issues are closed.
+    assert.match(
+      workflow,
+      /closedIssueNumbers\.length === 0[\s\S]*postMergedPrFollowUpComment\(\{/,
+    );
     assert.doesNotMatch(workflow, /commit/i);
     assert.doesNotMatch(workflow, /discussion/i);
   });
@@ -99,4 +119,75 @@ describe('dev merge issue close workflow', () => {
     assert.match(comment, /Issue creators can try it with `omx update --dev`/);
     assert.match(comment, /let us know whether it resolves the issue/);
   });
+  it('posts the PR follow-up comment on the success path', async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const warnings: string[] = [];
+    const github = {
+      rest: {
+        issues: {
+          createComment: async (args: Record<string, unknown>) => {
+            calls.push(args);
+            return { data: { id: 1 } };
+          },
+        },
+      },
+    };
+    const core = { warning: (message: string) => warnings.push(message) };
+
+    const result = await postMergedPrFollowUpComment({
+      github,
+      core,
+      owner: 'Yeachan-Heo',
+      repo: 'oh-my-codex',
+      prNumber: 2825,
+      issueNumbers: [2824],
+    });
+
+    assert.deepEqual(result, { posted: true });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].owner, 'Yeachan-Heo');
+    assert.equal(calls[0].repo, 'oh-my-codex');
+    assert.equal(calls[0].issue_number, 2825);
+    assert.match(String(calls[0].body), /Closed explicitly linked issue after this PR was merged into `dev`: #2824\./);
+    assert.deepEqual(warnings, []);
+  });
+
+  it('treats a 403 PR comment as best-effort and does not fail the workflow', async () => {
+    const warnings: string[] = [];
+    const error = Object.assign(new Error('Resource not accessible by integration'), { status: 403 });
+    const github = {
+      rest: {
+        issues: {
+          createComment: async () => {
+            throw error;
+          },
+        },
+      },
+    };
+    const core = { warning: (message: string) => warnings.push(message) };
+
+    const result = await postMergedPrFollowUpComment({
+      github,
+      core,
+      owner: 'Yeachan-Heo',
+      repo: 'oh-my-codex',
+      prNumber: 2825,
+      issueNumbers: [2824],
+    });
+
+    assert.equal(result.posted, false);
+    assert.equal(result.error, error);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /Skipped best-effort PR follow-up comment on #2825/);
+    assert.match(warnings[0], /403 Resource not accessible by integration/);
+    assert.match(warnings[0], /Linked issue closure already succeeded/);
+  });
+
+  it('detects the 403 resource-not-accessible error by status and message', () => {
+    assert.equal(isResourceNotAccessibleError({ status: 403 }), true);
+    assert.equal(isResourceNotAccessibleError({ message: 'Resource not accessible by integration' }), true);
+    assert.equal(isResourceNotAccessibleError({ status: 404, message: 'Not Found' }), false);
+    assert.equal(isResourceNotAccessibleError(undefined), false);
+  });
+
 });


### PR DESCRIPTION
## Summary

Fixes #2826. The `Dev Merge Issue Close` workflow could report a **failed run even after it successfully closed the linked issue**: once issue closure succeeded it posted a follow-up comment on the merged PR, and GitHub can return `403 Resource not accessible by integration`, failing the whole job (observed on run `27527186540` after PR #2825 / issue #2824).

This makes the **post-close PR follow-up comment best-effort** while keeping the **linked issue closure path enforced and unchanged**.

## Changes

- **`.github/scripts/dev-merge-issue-close.cjs`**
  - Add `postMergedPrFollowUpComment({ github, core, owner, repo, prNumber, issueNumbers })`: posts the PR summary comment; on failure (403 or any error) it reports via `core.warning(...)` and returns `{ posted: false, error }` **without throwing**, so a successful close is never turned into a failed run.
  - Add `isResourceNotAccessibleError(error)` (matches `status === 403` or the `Resource not accessible by integration` message) for a clearer 403-specific warning.
- **`.github/workflows/dev-merge-issue-close.yml`**
  - Call `postMergedPrFollowUpComment(...)` instead of the inline `github.rest.issues.createComment(...)` for the PR comment.
  - **Issue closure is untouched**: `github.rest.issues.update({ state: 'closed' })` still runs in the per-issue loop *before* the best-effort comment.
- **`src/verification/__tests__/dev-merge-issue-close-workflow.test.ts`**
  - Focused tests for the **success path**, the **403 best-effort path** (no throw, warning emitted, closure-already-succeeded note), and the error detector.
  - Workflow assertions updated to verify the best-effort wiring and that closure (`issues.update -> state: 'closed'`) stays enforced and runs before the PR comment.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Issue closed + PR comment OK | pass | pass |
| Issue closed + PR comment `403` | **job fails** | job passes; `core.warning` reports the skipped comment |
| Issue close fails | per-issue `core.warning` (unchanged) | per-issue `core.warning` (unchanged) |

## Verification

```
$ npx tsc            # clean, exit 0
$ node --test dist/verification/__tests__/dev-merge-issue-close-workflow.test.js
✔ scopes automation to merged pull_request_target closures into dev with issue write permissions
✔ extracts only explicitly linked local issues from PR title/body close keywords
✔ ignores unrelated references without close keywords or from other repositories
✔ dedupes repeated references and provides a standard maintainer close comment
✔ provides a matching PR summary comment after linked issues close
✔ posts the PR follow-up comment on the success path
✔ treats a 403 PR comment as best-effort and does not fail the workflow
✔ detects the 403 resource-not-accessible error by status and message
ℹ tests 8  ℹ pass 8  ℹ fail 0
```

`npx biome lint` on the changed test file: clean.

## Scope

Narrow to the dev-merge issue-close workflow/script/tests only. No change to release/publish issue #2822.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
