### PR TITLE
fix(team): preserve HUD pane ownership on shutdown

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1628,6 +1628,20 @@ case "$1" in
     printf '%%44\\n'
     exit 0
     ;;
+  show-option)
+    case "$*" in
+      *"-p -t %11 @omx_team_pane_owner_id"*)
+        echo "team:shared-shutdown-cli"
+        ;;
+      *"-p -t %12 @omx_team_pane_owner_id"*)
+        echo "team:shared-shutdown-cli"
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    exit 0
+    ;;
   kill-pane)
     # Shared-session runtime coverage should validate pane-targeted teardown
     # only. Detached leader-wrapper signal behavior is covered separately in

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1612,7 +1612,7 @@ case "$1" in
         exit 1
         ;;
       *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
-        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tcodex\\n%%14\\tcodex\\tcodex\\n"
+        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=shared-shutdown-cli/worker-1 codex\\n%%14\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=shared-shutdown-cli/worker-2 codex\\n"
         exit 0
         ;;
       *"-t leader:0 -F #{pane_id}"*)
@@ -2423,7 +2423,7 @@ describe('teamCommand status', () => {
       assert.match(output, /inspect_hud: tmux capture-pane -p -t %11 -S -400/);
       assert.match(output, /inspect_worker-1: tmux capture-pane -p -t %21 -S -400/);
       assert.match(output, /inspect_worker-2: tmux capture-pane -p -t %22 -S -400/);
-      assert.match(output, /inspect_summary: [\s\S]*command=tmux capture-pane -p -t %22 -S -400/);
+      assert.match(output, /inspect_summary: [\s\S]*command=tmux capture-pane -p -t %21 -S -400/);
       assert.doesNotMatch(output
         .split('\n')
         .filter((line) => !line.includes('--model-inspect'))
@@ -2432,7 +2432,7 @@ describe('teamCommand status', () => {
       logs.length = 0;
       await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'pane-team', '--model-inspect']));
       const modelInspectOutput = logs.join('\n');
-      assert.match(modelInspectOutput, /inspect_summary: [\s\S]*command=omx sparkshell --tmux-pane %22 --tail-lines 400/);
+      assert.match(modelInspectOutput, /inspect_summary: [\s\S]*command=omx sparkshell --tmux-pane %21 --tail-lines 400/);
     } finally {
       console.log = originalLog;
       process.chdir(previousCwd);

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -592,6 +592,28 @@ describe('HUD pane ownership helpers', () => {
 });
 
 describe('dead HUD pane reaper', () => {
+  it('ignores team ACK commands that mention HUD preserve repro text', () => {
+    const panes = parseTmuxPaneSnapshot(
+      [
+        '%1\tcodex\tcodex',
+        [
+          '%2',
+          'node',
+          "node /repo/dist/cli/omx.js team api send-message --input '{\"body\":\"ACK: hud preserve repro just ack\"}' --json",
+        ].join('\t'),
+      ].join('\n'),
+    );
+
+    const result = reapDeadHudPanes(panes, {
+      killPane: () => {
+        throw new Error('team ACK command should not be classified as a HUD watch pane');
+      },
+    });
+
+    assert.deepEqual(findHudWatchPaneIds(panes), []);
+    assert.deepEqual(result, { reaped: [], preserved: [] });
+  });
+
   it('kills HUD panes whose leader pane is not present in the snapshot', () => {
     const panes = parseTmuxPaneSnapshot(
       [

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -6460,6 +6460,90 @@ esac
     }
   });
 
+  it('shutdownTeam preserves worker-looking panes when the team owner tag cannot be read', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-worker-owner-read-error-'));
+    const teamName = 'team-worker-owner-read-error';
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-shutdown-worker-owner-read-error-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-F #{pane_dead} #{pane_pid}"*)
+        exit 1
+        ;;
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-worker-owner-read-error/worker-1 codex\\n%%14\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-worker-owner-read-error/worker-2 codex\\n"
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  split-window)
+    printf '%%44\\n'
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *"-p -t %11 @omx_team_pane_owner_id"*)
+        echo "team:team-worker-owner-read-error"
+        ;;
+      *"-p -t %12 @omx_team_pane_owner_id"*)
+        echo "team:team-worker-owner-read-error"
+        ;;
+      *"-p -t %14 @omx_team_pane_owner_id"*)
+        exit 2
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    exit 0
+    ;;
+  kill-pane|resize-pane|select-pane|run-shell)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState(teamName, 'shutdown worker owner read error test', 'executor', 2, cwd);
+          const config = await readTeamConfig(teamName, cwd);
+          assert.ok(config);
+          if (!config) return;
+          config.tmux_session = 'leader:0';
+          config.leader_pane_id = '%11';
+          config.hud_pane_id = '%12';
+          config.workers[0]!.pane_id = '%13';
+          config.workers[1]!.pane_id = '%14';
+          await saveTeamConfig(config, cwd);
+
+          await shutdownTeam(teamName, cwd, { force: true });
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %14/);
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('shutdownTeam does not use a detected worker as fallback leader when the shared-session leader is stale', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-stale-leader-worker-'));
     const teamName = 'team-stale-leader-worker';
@@ -6988,6 +7072,189 @@ esac
     } finally {
       await rm(cwd, { recursive: true, force: true });
       await rm(leaderPaneCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shutdownTeam reclaims a legacy leader-owned HUD pane without a team owner tag', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-legacy-hud-owner-'));
+    const teamName = 'team-legacy-hud-owner';
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-shutdown-legacy-hud-owner-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{pane_current_path}"*)
+        echo "${cwd}"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-F #{pane_dead} #{pane_pid}"*)
+        exit 1
+        ;;
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\texec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%%11' node /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-legacy-hud-owner/worker-1 codex\\n"
+        exit 0
+        ;;
+      *"-t %11 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tzsh\\n"
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  split-window)
+    printf '%%44\\n'
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *"-p -t %11 @omx_team_pane_owner_id"*)
+        echo "team:team-legacy-hud-owner"
+        ;;
+      *"-p -t %12 @omx_team_pane_owner_id"*)
+        exit 1
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    exit 0
+    ;;
+  kill-pane|resize-pane|select-pane|run-shell)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState(teamName, 'shutdown legacy hud owner test', 'executor', 1, cwd);
+          const config = await readTeamConfig(teamName, cwd);
+          assert.ok(config);
+          if (!config) return;
+          config.tmux_session = 'leader:0';
+          config.leader_pane_id = '%11';
+          config.hud_pane_id = '%12';
+          config.workers[0]!.pane_id = '%13';
+          await saveTeamConfig(config, cwd);
+
+          await shutdownTeam(teamName, cwd, { force: true });
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
+          assert.match(tmuxLog, /select-pane -t %11/);
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shutdownTeam preserves a persisted HUD pane when the team owner tag cannot be read', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-hud-owner-read-error-'));
+    const teamName = 'team-hud-owner-read-error';
+    const originalWarn = console.warn;
+    const warnings: string[] = [];
+    try {
+      console.warn = (message?: unknown, ...optionalParams: unknown[]): void => {
+        warnings.push([message, ...optionalParams].map(String).join(' '));
+      };
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-shutdown-hud-owner-read-error-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-F #{pane_dead} #{pane_pid}"*)
+        exit 1
+        ;;
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\texec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%%11' node /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-hud-owner-read-error/worker-1 codex\\n"
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  split-window)
+    printf '%%44\\n'
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *"-p -t %11 @omx_team_pane_owner_id"*)
+        echo "team:team-hud-owner-read-error"
+        ;;
+      *"-p -t %12 @omx_team_pane_owner_id"*)
+        exit 2
+        ;;
+      *"-p -t %13 @omx_team_pane_owner_id"*)
+        echo "team:team-hud-owner-read-error"
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    exit 0
+    ;;
+  kill-pane|resize-pane|select-pane|run-shell)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState(teamName, 'shutdown hud owner read error test', 'executor', 1, cwd);
+          const config = await readTeamConfig(teamName, cwd);
+          assert.ok(config);
+          if (!config) return;
+          config.tmux_session = 'leader:0';
+          config.leader_pane_id = '%11';
+          config.hud_pane_id = '%12';
+          config.workers[0]!.pane_id = '%13';
+          await saveTeamConfig(config, cwd);
+
+          await shutdownTeam(teamName, cwd, { force: true });
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
+          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
+          assert.match(warnings.join('\n'), /skipped shared-session HUD pane %12 because team owner tag could not be read: tmux show-option exited 2/);
+        },
+      );
+    } finally {
+      console.warn = originalWarn;
+      await rm(cwd, { recursive: true, force: true });
     }
   });
 

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -6133,6 +6133,9 @@ case "$1" in
       *"-p -t %12 @omx_team_pane_owner_id"*)
         echo "team:team-shutdown-pane-reconcile"
         ;;
+      *"-p -t %13 @omx_team_pane_owner_id"|*"-p -t %14 @omx_team_pane_owner_id"|*"-p -t %16 @omx_team_pane_owner_id"|*"-p -t %17 @omx_team_pane_owner_id"|*"-p -t %18 @omx_team_pane_owner_id"|*"-p -t %19 @omx_team_pane_owner_id"*)
+        echo "team:team-shutdown-pane-reconcile"
+        ;;
       *)
         exit 1
         ;;
@@ -6656,6 +6659,9 @@ case "$1" in
         ;;
       *"-p -t %12 @omx_team_pane_owner_id"*)
         echo "team:other-team"
+        ;;
+      *"-p -t %13 @omx_team_pane_owner_id"*)
+        echo "team:team-reused-leader-pane"
         ;;
       *)
         exit 1

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1558,6 +1558,141 @@ process.on('SIGTERM', () => process.exit(0));`,
     assert.equal(shouldPrekillInteractiveShutdownProcessTrees('omx-team-alpha'), true);
   });
 
+  it('startTeam tags interactive panes with the derived tmux-pane leader identity when session id is unavailable', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-pane-derived-owner-'));
+    const prevTmux = process.env.TMUX;
+    const prevTmuxPane = process.env.TMUX_PANE;
+    const prevSessionId = process.env.OMX_SESSION_ID;
+    const prevCodexSessionId = process.env.CODEX_SESSION_ID;
+    const prevGenericSessionId = process.env.SESSION_ID;
+    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const prevSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
+    let runtime: TeamRuntime | null = null;
+
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-pane-derived-owner-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "\${1:-}" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*)
+        echo "120"
+        ;;
+      *)
+        echo "leader:0 %1"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-t %2 -F #{pane_pid}"*)
+        echo "2000002222"
+        ;;
+      *"pane_current_command"*)
+        printf "%%1\\tnode\\t'codex'\\n"
+        ;;
+      *)
+        printf "%%1\\n"
+        ;;
+    esac
+    exit 0
+    ;;
+  split-window)
+    case "$*" in
+      *" -h "*)
+        echo "%2"
+        ;;
+      *)
+        echo "%3"
+        ;;
+    esac
+    exit 0
+    ;;
+  set-option|resize-pane|select-layout|set-window-option|select-pane|set-hook|run-shell|send-keys|kill-pane|kill-session)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+          binaries: [{
+            name: 'gemini',
+            content: '#!/bin/sh\nexit 0\n',
+          }],
+          env: {
+            OMX_SESSION_ID: undefined,
+            CODEX_SESSION_ID: undefined,
+            SESSION_ID: undefined,
+          },
+        },
+        async ({ tmuxLogPath }) => {
+          process.env.TMUX = 'leader-session,stub,0';
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
+          process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+          process.env.OMX_TEAM_SKIP_READY_WAIT = '1';
+
+          runtime = await withoutTeamWorkerEnv(() =>
+            startTeam(
+              'pane-derived-owner',
+              'derived pane owner',
+              'executor',
+              1,
+              [{ subject: 's', description: 'd', owner: 'worker-1' }],
+              cwd,
+            ));
+
+          const manifest = JSON.parse(
+            await readFile(join(cwd, '.omx', 'state', 'team', runtime.teamName, 'manifest.v2.json'), 'utf-8'),
+          ) as { leader?: { session_id?: string } };
+          assert.equal(manifest.leader?.session_id, '%1');
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.match(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id %1/);
+          assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id %1/);
+          assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id %1/);
+          assert.match(tmuxLog, /exec env OMX_SESSION_ID='%1' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%1' .*hud --watch/);
+
+          await shutdownTeam(runtime.teamName, cwd, { force: true });
+          runtime = null;
+        },
+      );
+    } finally {
+      const runtimeToShutdown = runtime as TeamRuntime | null;
+      if (runtimeToShutdown) {
+        await shutdownTeam(runtimeToShutdown.teamName, cwd, { force: true }).catch(() => {});
+      }
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevTmuxPane === 'string') process.env.TMUX_PANE = prevTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof prevSessionId === 'string') process.env.OMX_SESSION_ID = prevSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      if (typeof prevCodexSessionId === 'string') process.env.CODEX_SESSION_ID = prevCodexSessionId;
+      else delete process.env.CODEX_SESSION_ID;
+      if (typeof prevGenericSessionId === 'string') process.env.SESSION_ID = prevGenericSessionId;
+      else delete process.env.SESSION_ID;
+      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof prevSkipReadyWait === 'string') process.env.OMX_TEAM_SKIP_READY_WAIT = prevSkipReadyWait;
+      else delete process.env.OMX_TEAM_SKIP_READY_WAIT;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('startTeam accepts native Windows tmux clients even when TMUX env vars are absent', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-win32-no-env-'));
     const prevTmux = process.env.TMUX;

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -7168,6 +7168,109 @@ esac
     }
   });
 
+  it('shutdownTeam restores standalone HUD for legacy leaders with only an instance tag', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-legacy-leader-instance-'));
+    const teamName = 'team-legacy-leader-instance';
+    const legacySessionId = 'legacy-leader-session';
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-shutdown-legacy-leader-instance-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{pane_current_path}"*)
+        echo "${cwd}"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-F #{pane_dead} #{pane_pid}"*)
+        exit 1
+        ;;
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\texec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%%11' node /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-legacy-leader-instance/worker-1 codex\\n"
+        exit 0
+        ;;
+      *"-t %11 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tzsh\\n"
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  split-window)
+    printf '%%44\\n'
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *"-p -t %11 @omx_team_pane_owner_id"*)
+        exit 1
+        ;;
+      *"-p -t %12 @omx_team_pane_owner_id"*)
+        exit 1
+        ;;
+      *"-p -t %13 @omx_team_pane_owner_id"*)
+        echo "team:team-legacy-leader-instance"
+        ;;
+      *"-p -t %11 @omx_pane_instance_id"*)
+        echo "${legacySessionId}"
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    exit 0
+    ;;
+  kill-pane|resize-pane|select-pane|run-shell)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+          env: { OMX_SESSION_ID: legacySessionId },
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState(teamName, 'shutdown legacy leader instance test', 'executor', 1, cwd);
+          const config = await readTeamConfig(teamName, cwd);
+          assert.ok(config);
+          if (!config) return;
+          config.tmux_session = 'leader:0';
+          config.leader_pane_id = '%11';
+          config.hud_pane_id = '%12';
+          config.workers[0]!.pane_id = '%13';
+          await saveTeamConfig(config, cwd);
+
+          await shutdownTeam(teamName, cwd, { force: true });
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.match(tmuxLog, /show-option -qv -p -t %11 @omx_team_pane_owner_id/);
+          assert.match(tmuxLog, /show-option -qv -p -t %11 @omx_pane_instance_id/);
+          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
+          assert.match(tmuxLog, /select-pane -t %11/);
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('shutdownTeam preserves a persisted HUD pane when the team owner tag cannot be read', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-hud-owner-read-error-'));
     const teamName = 'team-hud-owner-read-error';

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -3769,6 +3769,10 @@ process.on('SIGTERM', () => process.exit(0));
           tmuxScript: (tmuxLogPath) => `#!/bin/sh
 set -eu
 printf '%s\\n' "$*" >> "${tmuxLogPath}"
+hud_state="${tmuxLogPath}.hud-state"
+if [ ! -f "$hud_state" ]; then
+  printf 'absent' > "$hud_state"
+fi
 case "\${1:-}" in
   -V)
     echo "tmux 3.4"
@@ -3788,7 +3792,10 @@ case "\${1:-}" in
   list-panes)
     case "$*" in
       *"pane_current_command"* )
-        printf "%%1\\tnode\\t'codex'\\n"
+        printf "%%1\\tnode\\t'codex'\\n%%2\\tgemini\\tgemini\\n"
+        if [ "$(cat "$hud_state")" != "absent" ]; then
+          printf "%%3\\tnode\\texec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%%1' node /tmp/bin/omx.js hud --watch\\n"
+        fi
         ;;
       *"#{pane_dead} #{pane_pid}"*)
         echo "1 2000999999"
@@ -3807,13 +3814,35 @@ case "\${1:-}" in
       *" -h "*)
         echo "%2"
         ;;
+      *" -f "*)
+        printf 'team' > "$hud_state"
+        echo "%3"
+        ;;
       *)
+        printf 'standalone' > "$hud_state"
         echo "%3"
         ;;
     esac
     exit 0
     ;;
-  set-hook|run-shell|select-layout|set-window-option|select-pane|send-keys|kill-pane|kill-session)
+  show-option)
+    case "$*" in
+      *"-p -t %1 @omx_pane_instance_id"*)
+        echo "team-rerun-hud-session"
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    exit 0
+    ;;
+  kill-pane)
+    case "$*" in
+      *"%3"*) printf 'absent' > "$hud_state" ;;
+    esac
+    exit 0
+    ;;
+  set-hook|run-shell|select-layout|set-window-option|select-pane|send-keys|kill-session)
     exit 0
     ;;
   *)
@@ -3827,6 +3856,7 @@ esac
 exit 0
 `,
           }],
+          env: { OMX_SESSION_ID: 'team-rerun-hud-session' },
         },
         async ({ tmuxLogPath }) => {
           process.env.TMUX = 'leader-session,stub,0';
@@ -3845,6 +3875,8 @@ exit 0
             ));
           assert.equal(runtime.config.hud_pane_id, '%3');
           assert.ok(runtime.config.resize_hook_name);
+          const configBeforeShutdown = await readTeamConfig(runtime.teamName, cwd);
+          assert.equal(configBeforeShutdown?.hud_pane_id, '%3');
 
           await shutdownTeam(runtime.teamName, cwd, { force: true });
           runtime = null;
@@ -3871,7 +3903,7 @@ exit 0
           assert.equal(tmuxLog.match(/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 3);
           assert.equal(tmuxLog.match(/run-shell tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 3);
           assert.ok((tmuxLog.match(/select-layout -t leader:0 main-vertical/g)?.length ?? 0) >= 2);
-          assert.match(tmuxLog, /kill-pane -t %3/);
+          assert.equal(tmuxLog.match(/kill-pane -t %3/g)?.length ?? 0, 2);
         },
       );
     } finally {
@@ -5764,6 +5796,10 @@ esac
 
   it('shutdownTeam reconciles persisted worker panes with live tmux panes before teardown', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-pane-reconcile-'));
+    const powershellWorkerCommand = Buffer.from(
+      "$env:OMX_TEAM_INTERNAL_WORKER = 'team-shutdown-pane-reconcile/worker-6'; & '/opt/node.exe' '/tmp/node_modules/@openai/codex/bin/codex.js'",
+      'utf16le',
+    ).toString('base64');
     try {
       await withMockTmuxFixture(
         {
@@ -5791,7 +5827,7 @@ case "$1" in
         exit 0
         ;;
       *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
-        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tcodex\\n%%14\\tcodex\\tcodex\\n"
+        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\texec /bin/sh '/tmp/.omx/state/team/team-shutdown-pane-reconcile/runtime/worker-1-startup.sh'\\n%%14\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-shutdown-pane-reconcile/worker-2 codex\\n%%15\\tcodex\\tcodex unrelated-not-worker\\n%%16\\tcodex\\tenv OMX_TEAM_WORKER=team-shutdown-pane-reconcile/worker-3 codex\\n%%17\\tcodex\\tworker-wrapper OMX_TEAM_INTERNAL_WORKER='team-shutdown-pane-reconcile/worker-4' codex\\n%%18\\tcodex\\tenv 'OMX_TEAM_INTERNAL_WORKER=team-shutdown-pane-reconcile/worker-5' codex\\n%%19\\tpowershell.exe\\tpowershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${powershellWorkerCommand}\\n%%20\\tzsh\\techo 'OMX_TEAM_INTERNAL_WORKER=team-shutdown-pane-reconcile/worker-7'\\n%%21\\tzsh\\tprintf 'OMX_TEAM_INTERNAL_WORKER=team-shutdown-pane-reconcile/worker-8 codex'\\n%%22\\tzsh\\tenv OMX_TEAM_INTERNAL_WORKER=team-shutdown-pane-reconcile/worker-9 bash -lc 'echo codex'\\n"
         if [ -f "$restored_marker" ]; then
           printf "%%44\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n"
         fi
@@ -5805,6 +5841,17 @@ case "$1" in
   split-window)
     : > "$restored_marker"
     printf '%%44\\n'
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *"-p -t %11 @omx_pane_instance_id"*)
+        echo "\${OMX_SESSION_ID:-}"
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
     exit 0
     ;;
   kill-pane)
@@ -5822,6 +5869,7 @@ case "$1" in
     ;;
 esac
 `,
+          env: { OMX_SESSION_ID: 'team-shutdown-pane-reconcile-session' },
         },
         async ({ tmuxLogPath }) => {
           await initTeamState('team-shutdown-pane-reconcile', 'shutdown pane reconcile test', 'executor', 2, cwd);
@@ -5841,9 +5889,335 @@ esac
           assert.match(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
           assert.match(tmuxLog, /kill-pane -t %14/);
-          assert.match(tmuxLog, /kill-pane -t %999/);
+          assert.match(tmuxLog, /kill-pane -t %16/);
+          assert.match(tmuxLog, /kill-pane -t %17/);
+          assert.match(tmuxLog, /kill-pane -t %18/);
+          assert.match(tmuxLog, /kill-pane -t %19/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %999/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %15/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %20/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %21/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %22/);
           assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\{pane_id\}`));
           assert.doesNotMatch(tmuxLog, /kill-pane -t %44/);
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shutdownTeam preserves unrelated non-worker panes during shared-session shutdown', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-unrelated-pane-'));
+    const teamName = 'team-shutdown-unrelated-pane';
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-shutdown-unrelated-pane-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+restored_marker="${tmuxLogPath}.restored"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-F #{pane_dead} #{pane_pid}"*)
+        exit 1
+        ;;
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%10\\tzsh\\tzsh\\n%%11\\tnode\\tnode existing-user-work\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-shutdown-unrelated-pane/worker-1 codex\\n%%14\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-shutdown-unrelated-pane/worker-2 codex\\n%%15\\tnode\\tnode /tmp/bin/omx.js sidecar --watch\\n"
+        if [ -f "$restored_marker" ]; then
+          printf "%%44\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n"
+        fi
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  split-window)
+    : > "$restored_marker"
+    printf '%%44\\n'
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *"-p -t %10 @omx_pane_instance_id"*)
+        echo "\${OMX_SESSION_ID:-}"
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    exit 0
+    ;;
+  kill-pane|resize-pane|select-pane|run-shell)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+          env: { OMX_SESSION_ID: 'team-shutdown-unrelated-pane-session' },
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState(teamName, 'shutdown unrelated pane test', 'executor', 2, cwd);
+          const config = await readTeamConfig(teamName, cwd);
+          assert.ok(config);
+          if (!config) return;
+          config.tmux_session = 'leader:0';
+          config.leader_pane_id = '%10';
+          config.hud_pane_id = '%12';
+          config.workers[0]!.pane_id = '%13';
+          config.workers[1]!.pane_id = '%14';
+          await saveTeamConfig(config, cwd);
+
+          await shutdownTeam(teamName, cwd, { force: true });
+
+          const teamRoot = join(cwd, '.omx', 'state', 'team', teamName);
+          assert.equal(existsSync(teamRoot), false);
+          assert.equal(await readMonitorSnapshot(teamName, cwd), null);
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %10/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %15/);
+          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.match(tmuxLog, /kill-pane -t %14/);
+          assert.doesNotMatch(tmuxLog, /kill-session -t leader:0/);
+          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %10 -d -P -F #\\{pane_id\\}`));
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %44/);
+          assert.match(tmuxLog, /select-pane -t %10/);
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shutdownTeam ignores stale persisted worker pane ids when a shared-session pane lacks worker evidence', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-stale-worker-pane-id-'));
+    const teamName = 'team-stale-worker-pane-id';
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-shutdown-stale-worker-pane-id-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-F #{pane_dead} #{pane_pid}"*)
+        exit 1
+        ;;
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%10\\tzsh\\tzsh\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-stale-worker-pane-id/worker-1 codex\\n%%15\\tcodex\\tcodex unrelated-user-pane\\n"
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  split-window)
+    printf '%%44\\n'
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *"-p -t %10 @omx_pane_instance_id"*)
+        echo "\${OMX_SESSION_ID:-}"
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    exit 0
+    ;;
+  kill-pane|resize-pane|select-pane|run-shell)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+          env: { OMX_SESSION_ID: 'team-stale-worker-pane-id-session' },
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState(teamName, 'shutdown stale persisted worker pane id test', 'executor', 2, cwd);
+          const config = await readTeamConfig(teamName, cwd);
+          assert.ok(config);
+          if (!config) return;
+          config.tmux_session = 'leader:0';
+          config.leader_pane_id = '%10';
+          config.hud_pane_id = '%12';
+          config.workers[0]!.pane_id = '%13';
+          config.workers[1]!.pane_id = '%15';
+          await saveTeamConfig(config, cwd);
+
+          await shutdownTeam(teamName, cwd, { force: true });
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %10/);
+          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %15/);
+          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %10 -d -P -F #\\{pane_id\\}`));
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shutdownTeam does not use a detected worker as fallback leader when the shared-session leader is stale', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-stale-leader-worker-'));
+    const teamName = 'team-stale-leader-worker';
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-shutdown-stale-leader-worker-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-F #{pane_dead} #{pane_pid}"*)
+        exit 1
+        ;;
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tvim notes.md\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tenv 'OMX_TEAM_INTERNAL_WORKER=team-stale-leader-worker/worker-1' codex\\n"
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  kill-pane|select-pane|run-shell)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState(teamName, 'shutdown stale leader worker test', 'executor', 1, cwd);
+          const config = await readTeamConfig(teamName, cwd);
+          assert.ok(config);
+          if (!config) return;
+          config.tmux_session = 'leader:0';
+          config.leader_pane_id = '%10';
+          config.hud_pane_id = '%12';
+          config.workers[0]!.pane_id = '';
+          await saveTeamConfig(config, cwd);
+
+          await shutdownTeam(teamName, cwd, { force: true });
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %10/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
+          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /split-window/);
+          assert.doesNotMatch(tmuxLog, /select-pane -t %11/);
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shutdownTeam does not restore HUD onto a live leader pane without matching ownership tag', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-reused-leader-pane-'));
+    const teamName = 'team-reused-leader-pane';
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-shutdown-reused-leader-pane-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-F #{pane_dead} #{pane_pid}"*)
+        exit 1
+        ;;
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tvim unrelated-notes.md\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tenv 'OMX_TEAM_INTERNAL_WORKER=team-reused-leader-pane/worker-1' codex\\n"
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  show-option)
+    case "$*" in
+      *"-p -t %11 @omx_pane_instance_id"*)
+        echo "other-session"
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    exit 0
+    ;;
+  kill-pane|select-pane|run-shell)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+          env: { OMX_SESSION_ID: 'expected-team-session' },
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState(teamName, 'shutdown reused leader pane test', 'executor', 1, cwd);
+          const config = await readTeamConfig(teamName, cwd);
+          assert.ok(config);
+          if (!config) return;
+          config.tmux_session = 'leader:0';
+          config.leader_pane_id = '%11';
+          config.hud_pane_id = '%12';
+          config.workers[0]!.pane_id = '';
+          await saveTeamConfig(config, cwd);
+
+          await shutdownTeam(teamName, cwd, { force: true });
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.match(tmuxLog, /show-option -qv -p -t %11 @omx_pane_instance_id/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
+          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /split-window/);
+          assert.doesNotMatch(tmuxLog, /select-pane -t %11/);
         },
       );
     } finally {
@@ -5872,7 +6246,7 @@ case "$1" in
         exit 1
         ;;
       *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
-        printf "%%11\\tpwsh\\tpwsh\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tcodex\\n%%14\\tcodex\\tcodex\\n"
+        printf "%%11\\tpwsh\\tpwsh\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-shutdown-win32-split/worker-1 codex\\n%%14\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-shutdown-win32-split/worker-2 codex\\n"
         exit 0
         ;;
       *)
@@ -5884,6 +6258,17 @@ case "$1" in
     printf '%%44\\n'
     exit 0
     ;;
+  show-option)
+    case "$*" in
+      *"-p -t %11 @omx_pane_instance_id"*)
+        echo "\${OMX_SESSION_ID:-}"
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    exit 0
+    ;;
   kill-pane|resize-pane|select-pane)
     exit 0
     ;;
@@ -5892,6 +6277,7 @@ case "$1" in
     ;;
 esac
 `,
+            env: { OMX_SESSION_ID: 'team-shutdown-win32-split-session' },
           },
           async ({ tmuxLogPath }) => {
             await initTeamState('team-shutdown-win32-split', 'shutdown win32 split test', 'executor', 2, cwd);
@@ -5930,7 +6316,7 @@ esac
     }
   });
 
-  it('shutdownTeam reconciles stale leader and hud pane ids before native Windows split-pane teardown', async () => {
+  it('shutdownTeam preserves an unrelated HUD when the leader is live but persisted shared-session HUD is stale', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-win32-stale-topology-'));
     const teamName = 'team-win32-stale-topo';
     try {
@@ -5952,7 +6338,7 @@ case "$1" in
         exit 1
         ;;
       *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
-        printf "%%21\\tpwsh\\tpwsh\\n%%22\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%23\\tcodex\\tcodex\\n%%24\\tcodex\\tcodex\\n"
+        printf "%%11\\tpwsh\\tpwsh\\n%%22\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%23\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-win32-stale-topo/worker-1 codex\\n%%24\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-win32-stale-topo/worker-2 codex\\n"
         exit 0
         ;;
       *)
@@ -5962,6 +6348,17 @@ case "$1" in
     ;;
   split-window)
     printf '%%44\\n'
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *"-p -t %11 @omx_pane_instance_id"*)
+        echo "\${OMX_SESSION_ID:-}"
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
     exit 0
     ;;
   kill-pane|resize-pane|select-pane)
@@ -5992,13 +6389,13 @@ esac
             assert.equal(await readMonitorSnapshot(teamName, cwd), null);
 
             const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-            assert.doesNotMatch(tmuxLog, /list-panes -t %21 -F #\{pane_pid\}/);
-            assert.doesNotMatch(tmuxLog, /kill-pane -t %21/);
-            assert.match(tmuxLog, /kill-pane -t %22/);
+            assert.doesNotMatch(tmuxLog, /list-panes -t %11 -F #\{pane_pid\}/);
+            assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
+            assert.doesNotMatch(tmuxLog, /kill-pane -t %22/);
             assert.match(tmuxLog, /kill-pane -t %23/);
             assert.match(tmuxLog, /kill-pane -t %24/);
-            assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %21 -d -P -F #\\{pane_id\\}`));
-            assert.match(tmuxLog, /select-pane -t %21/);
+            assert.doesNotMatch(tmuxLog, /split-window/);
+            assert.doesNotMatch(tmuxLog, /select-pane -t %11/);
           },
         );
       });
@@ -6027,7 +6424,7 @@ case "$1" in
         exit 1
         ;;
       *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
-        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tcodex\\n%%14\\tcodex\\tcodex\\n"
+        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-shutdown-shared-session/worker-1 codex\\n%%14\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-shutdown-shared-session/worker-2 codex\\n"
         exit 0
         ;;
       *)
@@ -6039,6 +6436,17 @@ case "$1" in
     printf '%%44\\n'
     exit 0
     ;;
+  show-option)
+    case "$*" in
+      *"-p -t %11 @omx_pane_instance_id"*)
+        echo "\${OMX_SESSION_ID:-}"
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    exit 0
+    ;;
   kill-pane|resize-pane|select-pane)
     exit 0
     ;;
@@ -6047,6 +6455,7 @@ case "$1" in
     ;;
 esac
 `,
+          env: { OMX_SESSION_ID: 'team-shutdown-shared-session-owner' },
         },
         async ({ tmuxLogPath }) => {
           await initTeamState('team-shutdown-shared-session', 'shutdown shared session test', 'executor', 2, cwd);
@@ -6099,10 +6508,29 @@ case "$1" in
     exit 0
     ;;
   list-panes)
-    exit 1
+    case "$*" in
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\texec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%%11' node /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-shutdown-restore-hud/worker-2 codex\\n"
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
     ;;
   split-window)
     printf '%%44\n'
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *"-p -t %11 @omx_pane_instance_id"*)
+        echo "\${OMX_SESSION_ID:-}"
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
     exit 0
     ;;
   kill-pane|kill-session|select-pane)
@@ -6113,6 +6541,7 @@ case "$1" in
     ;;
 esac
 `,
+          env: { OMX_SESSION_ID: 'team-shutdown-restore-hud-session' },
         },
         async ({ tmuxLogPath }) => {
           await initTeamState('team-shutdown-restore-hud', 'shutdown restore hud test', 'executor', 2, cwd);
@@ -6128,14 +6557,18 @@ esac
 
           await shutdownTeam('team-shutdown-restore-hud', cwd, { force: true });
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          const count = (pattern: RegExp): number => [...tmuxLog.matchAll(pattern)].length;
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
           assert.match(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
           assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\{pane_id\}`));
+          assert.equal(count(/kill-pane -t %12/g), 1);
+          assert.equal(count(new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`, 'g')), 1);
           assert.match(tmuxLog, /run-shell -b sleep \d+; tmux resize-pane -t %44 -y \d+ >/);
           assert.match(tmuxLog, /run-shell tmux resize-pane -t %44 -y \d+ >/);
           assert.match(tmuxLog, /hud --watch/);
           assert.match(tmuxLog, /OMX_TMUX_HUD_LEADER_PANE='%11'/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %44/);
           assert.match(tmuxLog, /select-pane -t %11/);
         },
       );

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -6610,7 +6610,7 @@ esac
           assert.doesNotMatch(tmuxLog, /kill-pane -t %10/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
           assert.match(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, /split-window/);
           assert.doesNotMatch(tmuxLog, /select-pane -t %11/);
         },
@@ -7072,6 +7072,197 @@ esac
     } finally {
       await rm(cwd, { recursive: true, force: true });
       await rm(leaderPaneCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shutdownTeam preserves unpersisted legacy worker-looking panes without owner tags', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-unpersisted-legacy-worker-'));
+    const teamName = 'team-unpersisted-legacy-worker';
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-shutdown-unpersisted-legacy-worker-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{pane_current_path}"*)
+        echo "${cwd}"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-F #{pane_dead} #{pane_pid}"*)
+        exit 1
+        ;;
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\texec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%%11' node /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-unpersisted-legacy-worker/worker-1 codex\\n%%14\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-unpersisted-legacy-worker/worker-2 codex\\n"
+        exit 0
+        ;;
+      *"-t %11 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tzsh\\n"
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  split-window)
+    printf '%%44\\n'
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *"-p -t %11 @omx_team_pane_owner_id"*)
+        echo "team:team-unpersisted-legacy-worker"
+        ;;
+      *"-p -t %12 @omx_team_pane_owner_id"*)
+        echo "team:team-unpersisted-legacy-worker"
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    exit 0
+    ;;
+  kill-pane|resize-pane|select-pane|run-shell)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState(teamName, 'shutdown unpersisted legacy worker test', 'executor', 2, cwd);
+          const config = await readTeamConfig(teamName, cwd);
+          assert.ok(config);
+          if (!config) return;
+          config.tmux_session = 'leader:0';
+          config.leader_pane_id = '%11';
+          config.hud_pane_id = '%12';
+          config.workers[0]!.pane_id = '%13';
+          config.workers[1]!.pane_id = '%99';
+          await saveTeamConfig(config, cwd);
+
+          await shutdownTeam(teamName, cwd, { force: true });
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %14/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %99/);
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shutdownTeam reclaims a matching-owner live HUD when the persisted HUD id is stale', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-stale-hud-live-owner-'));
+    const teamName = 'team-stale-hud-live-owner';
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-shutdown-stale-hud-live-owner-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{pane_current_path}"*)
+        echo "${cwd}"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-F #{pane_dead} #{pane_pid}"*)
+        exit 1
+        ;;
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\texec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%%11' node /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-stale-hud-live-owner/worker-1 codex\\n"
+        exit 0
+        ;;
+      *"-t %11 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tzsh\\n"
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  split-window)
+    printf '%%44\\n'
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *"-p -t %11 @omx_team_pane_owner_id"*)
+        echo "team:team-stale-hud-live-owner"
+        ;;
+      *"-p -t %12 @omx_team_pane_owner_id"*)
+        echo "team:team-stale-hud-live-owner"
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    exit 0
+    ;;
+  kill-pane|resize-pane|select-pane|run-shell)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState(teamName, 'shutdown stale hud live owner test', 'executor', 1, cwd);
+          const config = await readTeamConfig(teamName, cwd);
+          assert.ok(config);
+          if (!config) return;
+          config.tmux_session = 'leader:0';
+          config.leader_pane_id = '%11';
+          config.hud_pane_id = '%99';
+          config.workers[0]!.pane_id = '%13';
+          await saveTeamConfig(config, cwd);
+
+          await shutdownTeam(teamName, cwd, { force: true });
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          const count = (pattern: RegExp): number => [...tmuxLog.matchAll(pattern)].length;
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
+          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %99/);
+          assert.equal(count(/kill-pane -t %12/g), 1);
+          assert.equal(count(new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`, 'g')), 1);
+          assert.match(tmuxLog, /select-pane -t %11/);
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
     }
   });
 

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -55,6 +55,10 @@ const skipSlowLifecycleUnderCoverage = coverageRun
   ? 'covered by the team-state-runtime lane; skipped under c8 to keep the coverage gate bounded around slow process-lifecycle waits'
   : false;
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 async function initRepo(): Promise<string> {
   const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-worktree-repo-'));
   execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
@@ -1693,6 +1697,144 @@ esac
     }
   });
 
+  it('startTeam keeps logical session id out of team shutdown ownership tags', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-pane-owner-env-isolated-'));
+    const prevTmux = process.env.TMUX;
+    const prevTmuxPane = process.env.TMUX_PANE;
+    const prevSessionId = process.env.OMX_SESSION_ID;
+    const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const prevSkipReadyWait = process.env.OMX_TEAM_SKIP_READY_WAIT;
+    let runtime: TeamRuntime | null = null;
+
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-pane-owner-env-isolated-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "\${1:-}" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*)
+        echo "120"
+        ;;
+      *)
+        echo "leader:0 %1"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-t %2 -F #{pane_pid}"*)
+        echo "2000002222"
+        ;;
+      *"pane_current_command"*)
+        printf "%%1\\tnode\\t'codex'\\n"
+        ;;
+      *)
+        printf "%%1\\n"
+        ;;
+    esac
+    exit 0
+    ;;
+  split-window)
+    case "$*" in
+      *" -h "*)
+        echo "%2"
+        ;;
+      *)
+        echo "%3"
+        ;;
+    esac
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *)
+        exit 1
+        ;;
+    esac
+    exit 0
+    ;;
+  set-option|resize-pane|select-layout|set-window-option|select-pane|set-hook|run-shell|send-keys|kill-pane|kill-session)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+          binaries: [{
+            name: 'gemini',
+            content: '#!/bin/sh\nexit 0\n',
+          }],
+        },
+        async ({ tmuxLogPath }) => {
+          process.env.TMUX = 'leader-session,stub,0';
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_SESSION_ID = 'logical-session-from-env';
+          process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
+          process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+          process.env.OMX_TEAM_SKIP_READY_WAIT = '1';
+
+          runtime = await withoutTeamWorkerEnv(() =>
+            startTeam(
+              'pane-owner-env-isolated',
+              'env session must not be pane owner',
+              'executor',
+              1,
+              [{ subject: 's', description: 'd', owner: 'worker-1' }],
+              cwd,
+            ));
+
+          const manifest = JSON.parse(
+            await readFile(join(cwd, '.omx', 'state', 'team', runtime.teamName, 'manifest.v2.json'), 'utf-8'),
+          ) as { leader?: { session_id?: string } };
+          assert.equal(manifest.leader?.session_id, 'logical-session-from-env');
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.match(tmuxLog, /set-option -t leader @omx_instance_id logical-session-from-env/);
+          assert.match(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id logical-session-from-env/);
+          assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id logical-session-from-env/);
+          assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id logical-session-from-env/);
+          assert.match(tmuxLog, /set-option -p -t %1 @omx_team_pane_owner_id team:pane-owner-env-isolat-[a-f0-9]{8}/);
+          assert.match(tmuxLog, /set-option -p -t %2 @omx_team_pane_owner_id team:pane-owner-env-isolat-[a-f0-9]{8}/);
+          assert.match(tmuxLog, /set-option -p -t %3 @omx_team_pane_owner_id team:pane-owner-env-isolat-[a-f0-9]{8}/);
+          assert.doesNotMatch(tmuxLog, /set-option -p -t %1 @omx_team_pane_owner_id logical-session-from-env/);
+          assert.match(tmuxLog, /exec env OMX_SESSION_ID='logical-session-from-env' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%1' .*hud --watch/);
+
+          await shutdownTeam(runtime.teamName, cwd, { force: true });
+          runtime = null;
+        },
+      );
+    } finally {
+      const runtimeToShutdown = runtime as TeamRuntime | null;
+      if (runtimeToShutdown) {
+        await shutdownTeam(runtimeToShutdown.teamName, cwd, { force: true }).catch(() => {});
+      }
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevTmuxPane === 'string') process.env.TMUX_PANE = prevTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof prevSessionId === 'string') process.env.OMX_SESSION_ID = prevSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      if (typeof prevLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = prevLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof prevSkipReadyWait === 'string') process.env.OMX_TEAM_SKIP_READY_WAIT = prevSkipReadyWait;
+      else delete process.env.OMX_TEAM_SKIP_READY_WAIT;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('startTeam accepts native Windows tmux clients even when TMUX env vars are absent', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-win32-no-env-'));
     const prevTmux = process.env.TMUX;
@@ -1842,11 +1984,13 @@ esac
         hudPaneId: '%4',
         resizeHookName: 'resize-hook',
         resizeHookTarget: 'leader:0',
+        teamPaneOwnerId: 'team:team-pane-persist-race',
       }, workerPaneIds);
 
       assert.equal(config.tmux_session, 'leader:0');
       assert.equal(config.leader_pane_id, '%1');
       assert.equal(config.hud_pane_id, '%4');
+      assert.equal(config.tmux_pane_owner_id, 'team:team-pane-persist-race');
       assert.deepEqual(workerPaneIds, ['%2', '%3']);
       assert.equal(config.workers[0]?.pane_id, '%2');
       assert.equal(config.workers[1]?.pane_id, '%3');
@@ -3962,8 +4106,11 @@ case "\${1:-}" in
     ;;
   show-option)
     case "$*" in
-      *"-p -t %1 @omx_pane_instance_id"*)
-        echo "team-rerun-hud-session"
+      *"-p -t %1 @omx_team_pane_owner_id"*)
+        echo "team:team-rerun-hud-6aa4d480"
+        ;;
+      *"-p -t %3 @omx_team_pane_owner_id"*)
+        echo "team:team-rerun-hud-6aa4d480"
         ;;
       *)
         exit 1
@@ -5980,8 +6127,11 @@ case "$1" in
     ;;
   show-option)
     case "$*" in
-      *"-p -t %11 @omx_pane_instance_id"*)
-        echo "\${OMX_SESSION_ID:-}"
+      *"-p -t %11 @omx_team_pane_owner_id"*)
+        echo "team:team-shutdown-pane-reconcile"
+        ;;
+      *"-p -t %12 @omx_team_pane_owner_id"*)
+        echo "team:team-shutdown-pane-reconcile"
         ;;
       *)
         exit 1
@@ -6082,8 +6232,11 @@ case "$1" in
     ;;
   show-option)
     case "$*" in
-      *"-p -t %10 @omx_pane_instance_id"*)
-        echo "\${OMX_SESSION_ID:-}"
+      *"-p -t %10 @omx_team_pane_owner_id"*)
+        echo "team:team-shutdown-unrelated-pane"
+        ;;
+      *"-p -t %12 @omx_team_pane_owner_id"*)
+        echo "team:team-shutdown-unrelated-pane"
         ;;
       *)
         exit 1
@@ -6172,8 +6325,11 @@ case "$1" in
     ;;
   show-option)
     case "$*" in
-      *"-p -t %10 @omx_pane_instance_id"*)
-        echo "\${OMX_SESSION_ID:-}"
+      *"-p -t %10 @omx_team_pane_owner_id"*)
+        echo "team:team-stale-worker-pane-id"
+        ;;
+      *"-p -t %12 @omx_team_pane_owner_id"*)
+        echo "team:team-stale-worker-pane-id"
         ;;
       *)
         exit 1
@@ -6218,6 +6374,92 @@ esac
     }
   });
 
+  it('shutdownTeam preserves worker-looking panes with a mismatched team owner tag', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-worker-owner-mismatch-'));
+    const teamName = 'team-worker-owner-mismatch';
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-shutdown-worker-owner-mismatch-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-F #{pane_dead} #{pane_pid}"*)
+        exit 1
+        ;;
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-worker-owner-mismatch/worker-1 codex\\n%%14\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-worker-owner-mismatch/worker-2 codex\\n"
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  split-window)
+    printf '%%44\\n'
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *"-p -t %11 @omx_team_pane_owner_id"*)
+        echo "team:team-worker-owner-mismatch"
+        ;;
+      *"-p -t %12 @omx_team_pane_owner_id"*)
+        echo "team:team-worker-owner-mismatch"
+        ;;
+      *"-p -t %14 @omx_team_pane_owner_id"*)
+        echo "team:other-team"
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    exit 0
+    ;;
+  kill-pane|resize-pane|select-pane|run-shell)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState(teamName, 'shutdown worker owner mismatch test', 'executor', 2, cwd);
+          const config = await readTeamConfig(teamName, cwd);
+          assert.ok(config);
+          if (!config) return;
+          config.tmux_session = 'leader:0';
+          config.leader_pane_id = '%11';
+          config.hud_pane_id = '%12';
+          config.workers[0]!.pane_id = '%13';
+          config.workers[1]!.pane_id = '%14';
+          await saveTeamConfig(config, cwd);
+
+          await shutdownTeam(teamName, cwd, { force: true });
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
+          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %14/);
+          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('shutdownTeam does not use a detected worker as fallback leader when the shared-session leader is stale', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-stale-leader-worker-'));
     const teamName = 'team-stale-leader-worker';
@@ -6246,6 +6488,17 @@ case "$1" in
         exit 1
         ;;
     esac
+    ;;
+  show-option)
+    case "$*" in
+      *"-p -t %12 @omx_team_pane_owner_id"*)
+        echo "team:team-stale-leader-worker"
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    exit 0
     ;;
   kill-pane|select-pane|run-shell)
     exit 0
@@ -6314,8 +6567,11 @@ case "$1" in
     ;;
   show-option)
     case "$*" in
-      *"-p -t %11 @omx_pane_instance_id"*)
-        echo "other-session"
+      *"-p -t %11 @omx_team_pane_owner_id"*)
+        echo "team:other-team"
+        ;;
+      *"-p -t %12 @omx_team_pane_owner_id"*)
+        echo "team:other-team"
         ;;
       *)
         exit 1
@@ -6347,9 +6603,10 @@ esac
           await shutdownTeam(teamName, cwd, { force: true });
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /show-option -qv -p -t %11 @omx_pane_instance_id/);
+          assert.match(tmuxLog, /show-option -qv -p -t %11 @omx_team_pane_owner_id/);
+          assert.match(tmuxLog, /show-option -qv -p -t %12 @omx_team_pane_owner_id/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
-          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, /split-window/);
           assert.doesNotMatch(tmuxLog, /select-pane -t %11/);
@@ -6395,8 +6652,11 @@ case "$1" in
     ;;
   show-option)
     case "$*" in
-      *"-p -t %11 @omx_pane_instance_id"*)
-        echo "\${OMX_SESSION_ID:-}"
+      *"-p -t %11 @omx_team_pane_owner_id"*)
+        echo "team:team-shutdown-win32-split"
+        ;;
+      *"-p -t %12 @omx_team_pane_owner_id"*)
+        echo "team:team-shutdown-win32-split"
         ;;
       *)
         exit 1
@@ -6487,8 +6747,8 @@ case "$1" in
     ;;
   show-option)
     case "$*" in
-      *"-p -t %11 @omx_pane_instance_id"*)
-        echo "\${OMX_SESSION_ID:-}"
+      *"-p -t %11 @omx_team_pane_owner_id"*)
+        echo "team:team-win32-stale-topo"
         ;;
       *)
         exit 1
@@ -6573,8 +6833,11 @@ case "$1" in
     ;;
   show-option)
     case "$*" in
-      *"-p -t %11 @omx_pane_instance_id"*)
-        echo "\${OMX_SESSION_ID:-}"
+      *"-p -t %11 @omx_team_pane_owner_id"*)
+        echo "team:team-shutdown-shared-session"
+        ;;
+      *"-p -t %12 @omx_team_pane_owner_id"*)
+        echo "team:team-shutdown-shared-session"
         ;;
       *)
         exit 1
@@ -6630,6 +6893,7 @@ esac
 
   it('shutdownTeam restores a standalone HUD pane after tearing down the team HUD', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-restore-hud-'));
+    const leaderPaneCwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-restore-hud-leader-cwd-'));
     try {
       await withMockTmuxFixture(
         {
@@ -6640,6 +6904,14 @@ printf '%s\n' "$*" >> "${tmuxLogPath}"
 case "$1" in
   -V)
     echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{pane_current_path}"*)
+        echo "${leaderPaneCwd}"
+        ;;
+    esac
     exit 0
     ;;
   list-panes)
@@ -6659,8 +6931,11 @@ case "$1" in
     ;;
   show-option)
     case "$*" in
-      *"-p -t %11 @omx_pane_instance_id"*)
-        echo "\${OMX_SESSION_ID:-}"
+      *"-p -t %11 @omx_team_pane_owner_id"*)
+        echo "team:team-shutdown-restore-hud"
+        ;;
+      *"-p -t %12 @omx_team_pane_owner_id"*)
+        echo "team:team-shutdown-restore-hud"
         ;;
       *)
         exit 1
@@ -6703,12 +6978,16 @@ esac
           assert.match(tmuxLog, /run-shell tmux resize-pane -t %44 -y \d+ >/);
           assert.match(tmuxLog, /hud --watch/);
           assert.match(tmuxLog, /OMX_TMUX_HUD_LEADER_PANE='%11'/);
+          assert.match(tmuxLog, /OMX_SESSION_ID='team-shutdown-restore-hud-session'/);
+          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\} -c ${escapeRegExp(leaderPaneCwd)} `));
+          assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\} -c ${escapeRegExp(cwd)} `));
           assert.doesNotMatch(tmuxLog, /kill-pane -t %44/);
           assert.match(tmuxLog, /select-pane -t %11/);
         },
       );
     } finally {
       await rm(cwd, { recursive: true, force: true });
+      await rm(leaderPaneCwd, { recursive: true, force: true });
     }
   });
 

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -725,6 +725,86 @@ describe('scaleUp', () => {
       const inbox = await readFile(join(cwd, '.omx', 'state', 'team', 'scale-up-role', 'workers', 'worker-2', 'inbox.md'), 'utf-8');
       assert.match(inbox, /Task 2/);
       assert.match(inbox, /Role: writer/);
+
+      const tmuxCommands = await readScaleUpTmuxLogCommands(tmuxLogPath);
+      assert.ok(tmuxCommands.some((command) => (
+        command === 'set-option -p -t %31 @omx_team_pane_owner_id team:scale-up-role'
+      )));
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(fakeBinDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rolls back a scaled worker pane when team owner tagging fails', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-scale-up-owner-tag-rollback-'));
+    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-scale-up-owner-tag-rollback-bin-'));
+    const tmuxLogPath = join(fakeBinDir, 'tmux.log');
+    const tmuxStubPath = join(fakeBinDir, 'tmux');
+    const previousPath = process.env.PATH;
+
+    try {
+      await writeFile(
+        tmuxStubPath,
+        [
+          '#!/bin/sh',
+          'set -eu',
+          `printf '%s\n' "$*" >> "${tmuxLogPath}"`,
+          'case "${1:-}" in',
+          '  -V)',
+          '    echo "tmux 3.2a"',
+          '    ;;',
+          '  split-window)',
+          '    echo "%31"',
+          '    ;;',
+          '  set-option)',
+          '    case "$*" in',
+          '      *"@omx_team_pane_owner_id"*)',
+          '        echo "owner tag failed" >&2',
+          '        exit 1',
+          '        ;;',
+          '    esac',
+          '    ;;',
+          '  list-panes)',
+          '    echo "42424"',
+          '    ;;',
+          '  kill-pane|send-keys|capture-pane)',
+          '    ;;',
+          'esac',
+          'exit 0',
+          '',
+        ].join('\n'),
+      );
+      await chmod(tmuxStubPath, 0o755);
+      await writeFile(tmuxLogPath, '');
+      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+
+      await initTeamState('scale-up-owner-tag-rollback', 'task', 'executor', 1, cwd);
+      await configureScaleUpTeamForDirectDispatch('scale-up-owner-tag-rollback', cwd);
+
+      const result = await scaleUp(
+        'scale-up-owner-tag-rollback',
+        1,
+        'executor',
+        [{ subject: 'new work', description: 'new work', owner: 'worker-2' }],
+        cwd,
+        { OMX_TEAM_SCALING_ENABLED: '1', OMX_TEAM_SKIP_READY_WAIT: '1' },
+      );
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.match(result.error, /Failed to tag tmux pane for worker-2/);
+
+      const config = await readTeamConfig('scale-up-owner-tag-rollback', cwd);
+      assert.equal(config?.workers.length, 1);
+      assert.equal(await readTask('scale-up-owner-tag-rollback', '1', cwd), null);
+
+      const tmuxCommands = await readScaleUpTmuxLogCommands(tmuxLogPath);
+      assert.ok(tmuxCommands.some((command) => (
+        command === 'set-option -p -t %31 @omx_team_pane_owner_id team:scale-up-owner-tag-rollback'
+      )));
+      assert.ok(tmuxCommands.some((command) => command === 'kill-pane -t %31'));
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -44,6 +44,7 @@ import {
   readDispatchRequest,
   readMonitorSnapshot,
   resolveDispatchLockTimeoutMs,
+  writeTeamManifestV2,
 } from '../state.js';
 import { normalizeDispatchRequest } from '../state/dispatch.js';
 
@@ -300,6 +301,32 @@ describe('team state', () => {
 
       const m2 = await migrateV1ToV2('team-mig', cwd);
       assert.deepEqual(m2, onDisk1);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('backfills missing or blank tmux pane owner ids in legacy manifests', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-pane-owner-backfill-'));
+    try {
+      await initTeamState('team-pane-owner-backfill', 't', 'executor', 1, cwd);
+      const manifestPath = join(cwd, '.omx', 'state', 'team', 'team-pane-owner-backfill', 'manifest.v2.json');
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as Record<string, unknown>;
+      delete manifest.tmux_pane_owner_id;
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+      const loadedManifest = await readTeamManifestV2('team-pane-owner-backfill', cwd);
+      const loadedConfig = await readTeamConfig('team-pane-owner-backfill', cwd);
+      assert.equal(loadedManifest?.tmux_pane_owner_id, 'team:team-pane-owner-backfill');
+      assert.equal(loadedConfig?.tmux_pane_owner_id, 'team:team-pane-owner-backfill');
+
+      await writeTeamManifestV2({
+        ...loadedManifest!,
+        tmux_pane_owner_id: '   ',
+      }, cwd);
+
+      const blankNormalized = await readTeamManifestV2('team-pane-owner-backfill', cwd);
+      assert.equal(blankNormalized?.tmux_pane_owner_id, 'team:team-pane-owner-backfill');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -3504,6 +3504,9 @@ esac
           assert.match(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id omx-pane-scope/);
           assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id omx-pane-scope/);
           assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id omx-pane-scope/);
+          assert.match(tmuxLog, /set-option -p -t %1 @omx_team_pane_owner_id team:pane-tags/);
+          assert.match(tmuxLog, /set-option -p -t %2 @omx_team_pane_owner_id team:pane-tags/);
+          assert.match(tmuxLog, /set-option -p -t %3 @omx_team_pane_owner_id team:pane-tags/);
           assert.match(tmuxLog, /exec env OMX_SESSION_ID='omx-pane-scope' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%1' .*hud --watch/);
         },
       );
@@ -4268,6 +4271,59 @@ esac
       );
     } finally {
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('restores standalone HUD panes from the live leader pane cwd with explicit session ownership', async () => {
+    const teamLaunchCwd = await mkdtemp(join(tmpdir(), 'omx-standalone-team-launch-cwd-'));
+    const leaderPaneCwd = await mkdtemp(join(tmpdir(), 'omx-standalone-leader-pane-cwd-'));
+
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-leader-cwd-standalone-hud-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  display-message)
+    case "$*" in
+      *"#{pane_current_path}"*)
+        echo "${leaderPaneCwd}"
+        ;;
+    esac
+    exit 0
+    ;;
+  split-window)
+    echo "%44"
+    exit 0
+    ;;
+  run-shell|select-pane|resize-pane|set-hook)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        async ({ logPath }) => {
+          const paneId = restoreStandaloneHudPane('%11', teamLaunchCwd, {
+            sessionId: 'current-session-for-hud',
+          });
+          assert.equal(paneId, '%44');
+
+          const tmuxLog = await readFile(logPath, 'utf-8');
+          assert.match(tmuxLog, /display-message -p -t %11 #\{pane_current_path\}/);
+          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\} -c ${escapeRegExp(leaderPaneCwd)} `));
+          assert.doesNotMatch(tmuxLog, new RegExp(`split-window .* -c ${escapeRegExp(teamLaunchCwd)} `));
+          assert.match(
+            tmuxLog,
+            /exec env OMX_SESSION_ID='current-session-for-hud' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%11' .*hud --watch/,
+          );
+        },
+      );
+    } finally {
+      await rm(teamLaunchCwd, { recursive: true, force: true });
+      await rm(leaderPaneCwd, { recursive: true, force: true });
     }
   });
 

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -3535,6 +3535,105 @@ esac
     }
   });
 
+  it('does not reuse the Team pane owner token as the HUD logical session id', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-hud-session-boundary-'));
+    const prevTmux = process.env.TMUX;
+    const prevTmuxPane = process.env.TMUX_PANE;
+    const prevSessionId = process.env.OMX_SESSION_ID;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-hud-session-boundary-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*)
+        echo "120"
+        ;;
+      *)
+        echo "shared:0 %1"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"-t %2 -F #{pane_pid}"*)
+        echo "2000002222"
+        ;;
+      *"pane_current_command"*)
+        printf "%%1\\tnode\\t'codex'\\n"
+        ;;
+      *)
+        printf "%%1\\n"
+        ;;
+    esac
+    exit 0
+    ;;
+  split-window)
+    case "$*" in
+      *" -h "*)
+        echo "%2"
+        ;;
+      *)
+        echo "%3"
+        ;;
+    esac
+    exit 0
+    ;;
+  set-option|resize-pane|select-layout|set-window-option|select-pane|set-hook|run-shell)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+        `,
+        async ({ logPath }) => {
+          const fakeBinDir = join(logPath, '..');
+          const geminiPath = join(fakeBinDir, 'gemini');
+          await writeFile(geminiPath, '#!/bin/sh\nexit 0\n');
+          await chmod(geminiPath, 0o755);
+
+          process.env.TMUX = '1';
+          process.env.TMUX_PANE = '%1';
+          delete process.env.OMX_SESSION_ID;
+          process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+
+          const session = createTeamSession('HUD Session Boundary', 1, cwd, [], undefined, {
+            teamPaneOwnerId: 'team:explicit-owner-boundary',
+          });
+          assert.equal(session.hudPaneId, '%3');
+          assert.equal(session.teamPaneOwnerId, 'team:explicit-owner-boundary');
+
+          const tmuxLog = await readFile(logPath, 'utf-8');
+          assert.match(tmuxLog, /set-option -p -t %1 @omx_team_pane_owner_id team:explicit-owner-boundary/);
+          assert.match(tmuxLog, /set-option -p -t %2 @omx_team_pane_owner_id team:explicit-owner-boundary/);
+          assert.match(tmuxLog, /set-option -p -t %3 @omx_team_pane_owner_id team:explicit-owner-boundary/);
+          assert.match(tmuxLog, /exec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%1' .*hud --watch/);
+          assert.doesNotMatch(tmuxLog, /OMX_SESSION_ID='team:explicit-owner-boundary'/);
+        },
+      );
+    } finally {
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevTmuxPane === 'string') process.env.TMUX_PANE = prevTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof prevSessionId === 'string') process.env.OMX_SESSION_ID = prevSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('removes only HUD panes owned by the current leader during team startup', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-owned-hud-startup-'));
     const prevTmux = process.env.TMUX;

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -85,6 +85,18 @@ function withMockedExistsSync<T>(mock: typeof fs.existsSync, fn: () => T): T {
   }
 }
 
+function withMockedStatSync<T>(mock: typeof fs.statSync, fn: () => T): T {
+  const original = fs.statSync;
+  fs.statSync = mock;
+  syncBuiltinESMExports();
+  try {
+    return fn();
+  } finally {
+    fs.statSync = original;
+    syncBuiltinESMExports();
+  }
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -4324,6 +4336,265 @@ esac
     } finally {
       await rm(teamLaunchCwd, { recursive: true, force: true });
       await rm(leaderPaneCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to the team launch cwd when the live leader pane cwd is unusable', async () => {
+    const teamLaunchCwd = await mkdtemp(join(tmpdir(), 'omx-standalone-team-launch-cwd-fallback-'));
+    const deletedLeaderPaneCwd = await mkdtemp(join(tmpdir(), 'omx-standalone-deleted-leader-pane-cwd-'));
+    await rm(deletedLeaderPaneCwd, { recursive: true, force: true });
+
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-deleted-leader-cwd-standalone-hud-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  display-message)
+    case "$*" in
+      *"#{pane_current_path}"*)
+        echo "${deletedLeaderPaneCwd}"
+        ;;
+    esac
+    exit 0
+    ;;
+  split-window)
+    case "$*" in
+      *"-c ${teamLaunchCwd} "*)
+        echo "%44"
+        exit 0
+        ;;
+      *"-c ${deletedLeaderPaneCwd} "*)
+        echo "deleted cwd should not be used" >&2
+        exit 1
+        ;;
+      *)
+        echo "unexpected cwd: $*" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  run-shell|select-pane|resize-pane|set-hook)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        async ({ logPath }) => {
+          const paneId = restoreStandaloneHudPane('%11', teamLaunchCwd, {
+            sessionId: 'current-session-for-hud',
+          });
+          assert.equal(paneId, '%44');
+
+          const tmuxLog = await readFile(logPath, 'utf-8');
+          assert.match(tmuxLog, /display-message -p -t %11 #\{pane_current_path\}/);
+          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\} -c ${escapeRegExp(teamLaunchCwd)} `));
+          assert.doesNotMatch(tmuxLog, new RegExp(`split-window .* -c ${escapeRegExp(deletedLeaderPaneCwd)} `));
+          assert.match(tmuxLog, /select-pane -t %11/);
+        },
+      );
+    } finally {
+      await rm(teamLaunchCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps MSYS drive-style live leader cwd candidates without raw stat prefiltering', async () => {
+    const liveLeaderCwd = '/c/live';
+    const fallbackCwd = 'C:\\fallback';
+    const fakeCygpathDir = await mkdtemp(join(tmpdir(), 'omx-msys-live-cygpath-'));
+    const previousPath = process.env.PATH;
+    const previousMsystem = process.env.MSYSTEM;
+    const previousOstype = process.env.OSTYPE;
+    const previousWsl = process.env.WSL_DISTRO_NAME;
+    const previousWslInterop = process.env.WSL_INTEROP;
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    const statCalls: string[] = [];
+
+    try {
+      const cygpathPath = join(fakeCygpathDir, 'cygpath');
+      await writeFile(cygpathPath, '#!/bin/sh\nprintf "%s\\n" "$2"\n');
+      await chmod(cygpathPath, 0o755);
+      process.env.PATH = `${fakeCygpathDir}:${previousPath ?? ''}`;
+      process.env.MSYSTEM = 'MINGW64';
+      process.env.OSTYPE = 'msys';
+      delete process.env.WSL_DISTRO_NAME;
+      delete process.env.WSL_INTEROP;
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+      await withMockTmuxFixture(
+        'omx-tmux-msys-live-cwd-standalone-hud-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  display-message)
+    case "$*" in
+      *"#{pane_current_path}"*)
+        echo "${liveLeaderCwd}"
+        ;;
+    esac
+    exit 0
+    ;;
+  split-window)
+    case "$*" in
+      *"-c ${liveLeaderCwd} "*)
+        echo "%44"
+        exit 0
+        ;;
+      *"-c ${fallbackCwd} "*)
+        echo "fallback cwd should not be used when MSYS live cwd succeeds" >&2
+        exit 1
+        ;;
+      *)
+        echo "unexpected cwd: $*" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  run-shell|select-pane|resize-pane|set-hook)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        async ({ logPath }) => {
+          const paneId = withMockedStatSync(
+            ((pathLike: fs.PathLike) => {
+              const value = String(pathLike);
+              statCalls.push(value);
+              if (value === fallbackCwd) return { isDirectory: () => true } as fs.Stats;
+              return { isDirectory: () => false } as fs.Stats;
+            }) as typeof fs.statSync,
+            () => restoreStandaloneHudPane('%11', fallbackCwd, { sessionId: 'current-session-for-hud' }),
+          );
+          assert.equal(paneId, '%44');
+          assert.equal(statCalls.includes(liveLeaderCwd), false);
+          assert.equal(statCalls.includes(fallbackCwd), true);
+
+          const tmuxLog = await readFile(logPath, 'utf-8');
+          assert.match(tmuxLog, /display-message -p -t %11 #\{pane_current_path\}/);
+          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\} -c ${escapeRegExp(liveLeaderCwd)} `));
+          assert.doesNotMatch(tmuxLog, new RegExp(`split-window .* -c ${escapeRegExp(fallbackCwd)} `));
+          assert.match(tmuxLog, /select-pane -t %11/);
+        },
+      );
+    } finally {
+      if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousMsystem === 'string') process.env.MSYSTEM = previousMsystem;
+      else delete process.env.MSYSTEM;
+      if (typeof previousOstype === 'string') process.env.OSTYPE = previousOstype;
+      else delete process.env.OSTYPE;
+      if (typeof previousWsl === 'string') process.env.WSL_DISTRO_NAME = previousWsl;
+      else delete process.env.WSL_DISTRO_NAME;
+      if (typeof previousWslInterop === 'string') process.env.WSL_INTEROP = previousWslInterop;
+      else delete process.env.WSL_INTEROP;
+      await rm(fakeCygpathDir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back after an unusable MSYS drive-style live leader cwd split attempt fails', async () => {
+    const liveLeaderCwd = '/c/deleted-live';
+    const fallbackCwd = 'C:\\fallback';
+    const fakeCygpathDir = await mkdtemp(join(tmpdir(), 'omx-msys-deleted-live-cygpath-'));
+    const previousPath = process.env.PATH;
+    const previousMsystem = process.env.MSYSTEM;
+    const previousOstype = process.env.OSTYPE;
+    const previousWsl = process.env.WSL_DISTRO_NAME;
+    const previousWslInterop = process.env.WSL_INTEROP;
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    const statCalls: string[] = [];
+
+    try {
+      const cygpathPath = join(fakeCygpathDir, 'cygpath');
+      await writeFile(cygpathPath, '#!/bin/sh\nprintf "%s\\n" "$2"\n');
+      await chmod(cygpathPath, 0o755);
+      process.env.PATH = `${fakeCygpathDir}:${previousPath ?? ''}`;
+      process.env.MSYSTEM = 'MINGW64';
+      process.env.OSTYPE = 'msys';
+      delete process.env.WSL_DISTRO_NAME;
+      delete process.env.WSL_INTEROP;
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+      await withMockTmuxFixture(
+        'omx-tmux-msys-deleted-live-cwd-standalone-hud-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  display-message)
+    case "$*" in
+      *"#{pane_current_path}"*)
+        echo "${liveLeaderCwd}"
+        ;;
+    esac
+    exit 0
+    ;;
+  split-window)
+    case "$*" in
+      *"-c ${liveLeaderCwd} "*)
+        echo "deleted live cwd cannot be used" >&2
+        exit 1
+        ;;
+      *"-c ${fallbackCwd} "*)
+        echo "%44"
+        exit 0
+        ;;
+      *)
+        echo "unexpected cwd: $*" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  run-shell|select-pane|resize-pane|set-hook)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        async ({ logPath }) => {
+          const paneId = withMockedStatSync(
+            ((pathLike: fs.PathLike) => {
+              const value = String(pathLike);
+              statCalls.push(value);
+              if (value === fallbackCwd) return { isDirectory: () => true } as fs.Stats;
+              return { isDirectory: () => false } as fs.Stats;
+            }) as typeof fs.statSync,
+            () => restoreStandaloneHudPane('%11', fallbackCwd, { sessionId: 'current-session-for-hud' }),
+          );
+          assert.equal(paneId, '%44');
+          assert.equal(statCalls.includes(liveLeaderCwd), false);
+          assert.equal(statCalls.includes(fallbackCwd), true);
+
+          const tmuxLog = await readFile(logPath, 'utf-8');
+          const liveAttemptIndex = tmuxLog.indexOf(`-c ${liveLeaderCwd} `);
+          const fallbackAttemptIndex = tmuxLog.indexOf(`-c ${fallbackCwd} `);
+          assert.ok(liveAttemptIndex >= 0, 'deleted MSYS live cwd should still be attempted');
+          assert.ok(fallbackAttemptIndex > liveAttemptIndex, 'fallback should be attempted after live split failure');
+          assert.match(tmuxLog, /select-pane -t %11/);
+        },
+      );
+    } finally {
+      if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousMsystem === 'string') process.env.MSYSTEM = previousMsystem;
+      else delete process.env.MSYSTEM;
+      if (typeof previousOstype === 'string') process.env.OSTYPE = previousOstype;
+      else delete process.env.OSTYPE;
+      if (typeof previousWsl === 'string') process.env.WSL_DISTRO_NAME = previousWsl;
+      else delete process.env.WSL_DISTRO_NAME;
+      if (typeof previousWslInterop === 'string') process.env.WSL_INTEROP = previousWslInterop;
+      else delete process.env.WSL_INTEROP;
+      await rm(fakeCygpathDir, { recursive: true, force: true });
     }
   });
 

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -3520,6 +3520,101 @@ esac
     }
   });
 
+  it('removes only HUD panes owned by the current leader during team startup', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-owned-hud-startup-'));
+    const prevTmux = process.env.TMUX;
+    const prevTmuxPane = process.env.TMUX_PANE;
+    const prevSessionId = process.env.OMX_SESSION_ID;
+    const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-owned-hud-startup-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  -V)
+    echo "tmux 3.4"
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *"#{window_width}"*)
+        echo "120"
+        ;;
+      *)
+        echo "shared:0 %1"
+        ;;
+    esac
+    exit 0
+    ;;
+  list-panes)
+    case "$*" in
+      *"pane_current_command"*)
+        printf "%%1\\tnode\\t'codex'\\n"
+        printf "%%7\\tnode\\t'codex neighbor'\\n"
+        printf "%%2\\tnode\\texec env OMX_SESSION_ID='leader-session-a' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%%1' node /tmp/bin/omx.js hud --watch\\n"
+        printf "%%8\\tnode\\texec env OMX_SESSION_ID='neighbor-session' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%%7' node /tmp/bin/omx.js hud --watch\\n"
+        ;;
+      *)
+        printf "%%1\\n%%7\\n%%2\\n%%8\\n"
+        ;;
+    esac
+    exit 0
+    ;;
+  split-window)
+    case "$*" in
+      *" -h "*)
+        echo "%3"
+        ;;
+      *)
+        echo "%4"
+        ;;
+    esac
+    exit 0
+    ;;
+  set-option|resize-pane|select-layout|set-window-option|select-pane|set-hook|run-shell|send-keys|kill-pane)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+        `,
+        async ({ logPath }) => {
+          const fakeBinDir = join(logPath, '..');
+          const geminiPath = join(fakeBinDir, 'gemini');
+          await writeFile(geminiPath, '#!/bin/sh\nexit 0\n');
+          await chmod(geminiPath, 0o755);
+
+          process.env.TMUX = 'shared-session,stub,0';
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_SESSION_ID = 'leader-session-a';
+          process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+
+          const session = createTeamSession('Owned HUD Startup', 1, cwd);
+          assert.equal(session.leaderPaneId, '%1');
+          assert.equal(session.hudPaneId, '%4');
+
+          const tmuxLog = await readFile(logPath, 'utf-8');
+          assert.match(tmuxLog, /kill-pane -t %2/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %8/);
+          assert.match(tmuxLog, /split-window -v -f -l 3 -t shared:0 -d -P -F #\{pane_id\}/);
+        },
+      );
+    } finally {
+      if (typeof prevTmux === 'string') process.env.TMUX = prevTmux;
+      else delete process.env.TMUX;
+      if (typeof prevTmuxPane === 'string') process.env.TMUX_PANE = prevTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof prevSessionId === 'string') process.env.OMX_SESSION_ID = prevSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('uses tmux 3.2a-compatible client-resized hook registration for team HUD resize', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-resize-hook-fallback-'));
     const prevTmux = process.env.TMUX;

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -2849,7 +2849,14 @@ export async function startTeam(
     const startupTiming = createStartupTimingRecorder(sanitized, leaderCwd);
 
     if (workerLaunchMode === 'interactive') {
-      const createdSession = createTeamSession(sanitized, workerCount, leaderCwd, sharedWorkerLaunchArgs, workerStartups);
+      const createdSession = createTeamSession(
+        sanitized,
+        workerCount,
+        leaderCwd,
+        sharedWorkerLaunchArgs,
+        workerStartups,
+        { ownerSessionId: leaderSessionId },
+      );
       sessionName = createdSession.name;
       sessionCreated = true;
       createdWorkerPaneIds.push(...createdSession.workerPaneIds);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -26,6 +26,7 @@ import {
   isWorkerPaneOpen,
   getWorkerPanePid,
   killWorkerByPaneIdAsync,
+  paneHasOmxInstanceTag,
   restoreStandaloneHudPane,
   teardownWorkerPanes,
   unregisterResizeHook,
@@ -372,14 +373,16 @@ export function applyCreatedInteractiveSessionToConfig(
 
 function collectShutdownPaneIds(params: {
   config: TeamConfig;
-  livePaneIds?: string[];
+  candidatePaneIds?: string[];
+  includePersistedWorkerPaneIds?: boolean;
   restoredStandaloneHudPaneId?: string | null;
   leaderPaneId?: string | null;
   hudPaneId?: string | null;
 }): string[] {
   const {
     config,
-    livePaneIds = [],
+    candidatePaneIds = [],
+    includePersistedWorkerPaneIds = true,
     restoredStandaloneHudPaneId = null,
     leaderPaneId = config.leader_pane_id,
     hudPaneId = config.hud_pane_id,
@@ -394,8 +397,8 @@ function collectShutdownPaneIds(params: {
 
   const paneIds = new Set<string>();
   for (const paneId of [
-    ...config.workers.map((worker) => worker.pane_id),
-    ...livePaneIds,
+    ...(includePersistedWorkerPaneIds ? config.workers.map((worker) => worker.pane_id) : []),
+    ...candidatePaneIds,
   ]) {
     if (typeof paneId !== 'string') continue;
     const normalized = paneId.trim();
@@ -3774,16 +3777,20 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   const hudPaneId = config.hud_pane_id;
   if (config.worker_launch_mode === 'interactive') {
     const sharedSessionTopology = sessionName.includes(':')
-      ? resolveSharedSessionShutdownTopology(sessionName, leaderPaneId)
+      ? resolveSharedSessionShutdownTopology(sessionName, leaderPaneId, sanitized)
       : null;
-    const effectiveLeaderPaneId = sharedSessionTopology?.leaderPaneId ?? leaderPaneId;
-    const effectiveHudPaneId = sharedSessionTopology?.hudPaneIds.find((paneId) => paneId === hudPaneId)
-      ?? sharedSessionTopology?.hudPaneIds[0]
-      ?? hudPaneId;
-    const livePaneIds = sharedSessionTopology?.livePaneIds ?? listPaneIds(sessionName);
+    const effectiveLeaderPaneId = sharedSessionTopology ? sharedSessionTopology.leaderPaneId : leaderPaneId;
+    const trustedHudRestoreLeaderPaneId = sharedSessionTopology
+      ? (paneHasOmxInstanceTag(effectiveLeaderPaneId, leaderSessionId) ? effectiveLeaderPaneId : null)
+      : effectiveLeaderPaneId;
+    const effectiveHudPaneId = sharedSessionTopology
+      ? (sharedSessionTopology.hudPaneIds.find((paneId) => paneId === hudPaneId) ?? null)
+      : hudPaneId;
+    const shutdownCandidatePaneIds = sharedSessionTopology?.teamWorkerPaneIds ?? listPaneIds(sessionName);
     let shutdownPaneIds = collectShutdownPaneIds({
       config,
-      livePaneIds,
+      candidatePaneIds: shutdownCandidatePaneIds,
+      includePersistedWorkerPaneIds: !sharedSessionTopology,
       leaderPaneId: effectiveLeaderPaneId,
       hudPaneId: effectiveHudPaneId,
     });
@@ -3818,15 +3825,21 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     if (effectiveHudPaneId) {
       await killWorkerByPaneIdAsync(effectiveHudPaneId, effectiveLeaderPaneId ?? undefined);
       if (sessionName.includes(':')) {
-        restoredHudPaneId = restoreStandaloneHudPane(effectiveLeaderPaneId, cwd);
+        restoredHudPaneId = restoreStandaloneHudPane(trustedHudRestoreLeaderPaneId, cwd);
         if (!restoredHudPaneId) {
-          console.warn(`[team shutdown] ${sanitized}: failed to restore standalone HUD pane`);
+          const reason = trustedHudRestoreLeaderPaneId
+            ? 'failed to restore standalone HUD pane'
+            : 'skipped standalone HUD restore because leader pane ownership could not be verified';
+          console.warn(`[team shutdown] ${sanitized}: ${reason}`);
         }
       }
     }
     shutdownPaneIds = collectShutdownPaneIds({
       config,
-      livePaneIds: listPaneIds(sessionName),
+      candidatePaneIds: sessionName.includes(':')
+        ? resolveSharedSessionShutdownTopology(sessionName, effectiveLeaderPaneId, sanitized).teamWorkerPaneIds
+        : listPaneIds(sessionName),
+      includePersistedWorkerPaneIds: !sessionName.includes(':'),
       restoredStandaloneHudPaneId: restoredHudPaneId,
       leaderPaneId: effectiveLeaderPaneId,
       hudPaneId: effectiveHudPaneId,

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -415,6 +415,7 @@ function collectShutdownPaneIds(params: {
 function filterSharedSessionShutdownWorkerPaneIdsByOwner(
   paneIds: string[],
   teamPaneOwnerId: string,
+  legacyPersistedWorkerPaneIds: ReadonlySet<string> = new Set<string>(),
   onOwnerReadError?: (paneId: string, error: string) => void,
 ): string[] {
   const expectedOwnerId = teamPaneOwnerId.trim();
@@ -422,7 +423,14 @@ function filterSharedSessionShutdownWorkerPaneIdsByOwner(
   return paneIds.filter((paneId) => {
     const actualOwnerId = readPaneTeamOwnerTagResult(paneId);
     if (actualOwnerId.status === 'value') return actualOwnerId.value === expectedOwnerId;
-    if (actualOwnerId.status === 'missing') return true;
+    if (actualOwnerId.status === 'missing') {
+      // Legacy, already-running Team panes may not have @omx_team_pane_owner_id.
+      // Keep that compatibility path explicitly bounded to panes that are both
+      // live worker-command candidates and persisted in this team's state. This
+      // preserves old Team cleanup without letting arbitrary worker-looking
+      // panes become kill candidates merely because the owner tag is absent.
+      return legacyPersistedWorkerPaneIds.has(paneId);
+    }
     onOwnerReadError?.(paneId, actualOwnerId.error);
     return false;
   });
@@ -436,11 +444,11 @@ function isSharedSessionHudPaneReclaimable(params: {
   onOwnerReadError?: (paneId: string, error: string) => void;
 }): boolean {
   const { paneId, persistedHudPaneId, leaderOwnedHudPaneIds, teamPaneOwnerId, onOwnerReadError } = params;
-  if (paneId !== persistedHudPaneId) return false;
   const expectedOwnerId = teamPaneOwnerId.trim();
   if (!expectedOwnerId) return false;
   const owner = readPaneTeamOwnerTagResult(paneId);
   if (owner.status === 'value') return owner.value === expectedOwnerId;
+  if (paneId !== persistedHudPaneId) return false;
   if (owner.status === 'missing') return leaderOwnedHudPaneIds.includes(paneId);
   onOwnerReadError?.(paneId, owner.error);
   return false;
@@ -3840,6 +3848,11 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       : null;
     const effectiveLeaderPaneId = sharedSessionTopology ? sharedSessionTopology.leaderPaneId : leaderPaneId;
     const tmuxPaneOwnerId = typeof config.tmux_pane_owner_id === 'string' ? config.tmux_pane_owner_id.trim() : '';
+    const legacyPersistedWorkerPaneIds = new Set(
+      config.workers
+        .map((worker) => (typeof worker.pane_id === 'string' ? worker.pane_id.trim() : ''))
+        .filter((paneId) => paneId.startsWith('%')),
+    );
     const ownerReadWarnings = new Set<string>();
     const warnOwnerReadError = (kind: string, paneId: string, error: string): void => {
       const key = `${kind}:${paneId}:${error}`;
@@ -3867,6 +3880,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       ? filterSharedSessionShutdownWorkerPaneIdsByOwner(
         sharedSessionTopology.teamWorkerPaneIds,
         tmuxPaneOwnerId,
+        legacyPersistedWorkerPaneIds,
         (paneId, error) => warnOwnerReadError('worker pane', paneId, error),
       )
       : listPaneIds(sessionName);
@@ -3925,6 +3939,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         ? filterSharedSessionShutdownWorkerPaneIdsByOwner(
           resolveSharedSessionShutdownTopology(sessionName, effectiveLeaderPaneId, sanitized).teamWorkerPaneIds,
           tmuxPaneOwnerId,
+          legacyPersistedWorkerPaneIds,
           (paneId, error) => warnOwnerReadError('worker pane', paneId, error),
         )
         : listPaneIds(sessionName),

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -27,7 +27,7 @@ import {
   getWorkerPanePid,
   killWorkerByPaneIdAsync,
   paneHasOmxTeamOwnerTag,
-  readPaneTeamOwnerTag,
+  readPaneTeamOwnerTagResult,
   restoreStandaloneHudPane,
   teardownWorkerPanes,
   unregisterResizeHook,
@@ -415,13 +415,35 @@ function collectShutdownPaneIds(params: {
 function filterSharedSessionShutdownWorkerPaneIdsByOwner(
   paneIds: string[],
   teamPaneOwnerId: string,
+  onOwnerReadError?: (paneId: string, error: string) => void,
 ): string[] {
   const expectedOwnerId = teamPaneOwnerId.trim();
-  if (!expectedOwnerId) return paneIds;
+  if (!expectedOwnerId) return [];
   return paneIds.filter((paneId) => {
-    const actualOwnerId = readPaneTeamOwnerTag(paneId);
-    return actualOwnerId === null || actualOwnerId === expectedOwnerId;
+    const actualOwnerId = readPaneTeamOwnerTagResult(paneId);
+    if (actualOwnerId.status === 'value') return actualOwnerId.value === expectedOwnerId;
+    if (actualOwnerId.status === 'missing') return true;
+    onOwnerReadError?.(paneId, actualOwnerId.error);
+    return false;
   });
+}
+
+function isSharedSessionHudPaneReclaimable(params: {
+  paneId: string;
+  persistedHudPaneId: string | null;
+  leaderOwnedHudPaneIds: string[];
+  teamPaneOwnerId: string;
+  onOwnerReadError?: (paneId: string, error: string) => void;
+}): boolean {
+  const { paneId, persistedHudPaneId, leaderOwnedHudPaneIds, teamPaneOwnerId, onOwnerReadError } = params;
+  if (paneId !== persistedHudPaneId) return false;
+  const expectedOwnerId = teamPaneOwnerId.trim();
+  if (!expectedOwnerId) return false;
+  const owner = readPaneTeamOwnerTagResult(paneId);
+  if (owner.status === 'value') return owner.value === expectedOwnerId;
+  if (owner.status === 'missing') return leaderOwnedHudPaneIds.includes(paneId);
+  onOwnerReadError?.(paneId, owner.error);
+  return false;
 }
 
 export function shouldPrekillInteractiveShutdownProcessTrees(sessionName: string): boolean {
@@ -3802,16 +3824,31 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       : null;
     const effectiveLeaderPaneId = sharedSessionTopology ? sharedSessionTopology.leaderPaneId : leaderPaneId;
     const tmuxPaneOwnerId = typeof config.tmux_pane_owner_id === 'string' ? config.tmux_pane_owner_id.trim() : '';
+    const ownerReadWarnings = new Set<string>();
+    const warnOwnerReadError = (kind: string, paneId: string, error: string): void => {
+      const key = `${kind}:${paneId}:${error}`;
+      if (ownerReadWarnings.has(key)) return;
+      ownerReadWarnings.add(key);
+      console.warn(`[team shutdown] ${sanitized}: skipped shared-session ${kind} ${paneId} because team owner tag could not be read: ${error}`);
+    };
     const trustedHudRestoreLeaderPaneId = sharedSessionTopology
       ? (paneHasOmxTeamOwnerTag(effectiveLeaderPaneId, tmuxPaneOwnerId) ? effectiveLeaderPaneId : null)
       : effectiveLeaderPaneId;
     const effectiveHudPaneId = sharedSessionTopology
-      ? (sharedSessionTopology.hudPaneIds.find((paneId) => (
-        paneId === hudPaneId && paneHasOmxTeamOwnerTag(paneId, tmuxPaneOwnerId)
-      )) ?? null)
+      ? (sharedSessionTopology.hudPaneIds.find((paneId) => isSharedSessionHudPaneReclaimable({
+        paneId,
+        persistedHudPaneId: hudPaneId,
+        leaderOwnedHudPaneIds: sharedSessionTopology.leaderOwnedHudPaneIds,
+        teamPaneOwnerId: tmuxPaneOwnerId,
+        onOwnerReadError: (hudPaneId, error) => warnOwnerReadError('HUD pane', hudPaneId, error),
+      })) ?? null)
       : hudPaneId;
     const shutdownCandidatePaneIds = sharedSessionTopology
-      ? filterSharedSessionShutdownWorkerPaneIdsByOwner(sharedSessionTopology.teamWorkerPaneIds, tmuxPaneOwnerId)
+      ? filterSharedSessionShutdownWorkerPaneIdsByOwner(
+        sharedSessionTopology.teamWorkerPaneIds,
+        tmuxPaneOwnerId,
+        (paneId, error) => warnOwnerReadError('worker pane', paneId, error),
+      )
       : listPaneIds(sessionName);
     let shutdownPaneIds = collectShutdownPaneIds({
       config,
@@ -3868,6 +3905,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         ? filterSharedSessionShutdownWorkerPaneIdsByOwner(
           resolveSharedSessionShutdownTopology(sessionName, effectiveLeaderPaneId, sanitized).teamWorkerPaneIds,
           tmuxPaneOwnerId,
+          (paneId, error) => warnOwnerReadError('worker pane', paneId, error),
         )
         : listPaneIds(sessionName),
       includePersistedWorkerPaneIds: !sessionName.includes(':'),

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -26,7 +26,8 @@ import {
   isWorkerPaneOpen,
   getWorkerPanePid,
   killWorkerByPaneIdAsync,
-  paneHasOmxInstanceTag,
+  paneHasOmxTeamOwnerTag,
+  readPaneTeamOwnerTag,
   restoreStandaloneHudPane,
   teardownWorkerPanes,
   unregisterResizeHook,
@@ -360,6 +361,7 @@ export function applyCreatedInteractiveSessionToConfig(
   config.tmux_session = createdSession.name;
   config.leader_pane_id = createdSession.leaderPaneId;
   config.hud_pane_id = createdSession.hudPaneId;
+  config.tmux_pane_owner_id = createdSession.teamPaneOwnerId;
   config.resize_hook_name = createdSession.resizeHookName;
   config.resize_hook_target = createdSession.resizeHookTarget;
   for (let i = 0; i < createdSession.workerPaneIds.length; i++) {
@@ -408,6 +410,18 @@ function collectShutdownPaneIds(params: {
   }
 
   return [...paneIds];
+}
+
+function filterSharedSessionShutdownWorkerPaneIdsByOwner(
+  paneIds: string[],
+  teamPaneOwnerId: string,
+): string[] {
+  const expectedOwnerId = teamPaneOwnerId.trim();
+  if (!expectedOwnerId) return paneIds;
+  return paneIds.filter((paneId) => {
+    const actualOwnerId = readPaneTeamOwnerTag(paneId);
+    return actualOwnerId === null || actualOwnerId === expectedOwnerId;
+  });
 }
 
 export function shouldPrekillInteractiveShutdownProcessTrees(sessionName: string): boolean {
@@ -2855,7 +2869,7 @@ export async function startTeam(
         leaderCwd,
         sharedWorkerLaunchArgs,
         workerStartups,
-        { ownerSessionId: leaderSessionId },
+        { ownerSessionId: leaderSessionId, teamPaneOwnerId: config.tmux_pane_owner_id },
       );
       sessionName = createdSession.name;
       sessionCreated = true;
@@ -3787,13 +3801,18 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       ? resolveSharedSessionShutdownTopology(sessionName, leaderPaneId, sanitized)
       : null;
     const effectiveLeaderPaneId = sharedSessionTopology ? sharedSessionTopology.leaderPaneId : leaderPaneId;
+    const tmuxPaneOwnerId = typeof config.tmux_pane_owner_id === 'string' ? config.tmux_pane_owner_id.trim() : '';
     const trustedHudRestoreLeaderPaneId = sharedSessionTopology
-      ? (paneHasOmxInstanceTag(effectiveLeaderPaneId, leaderSessionId) ? effectiveLeaderPaneId : null)
+      ? (paneHasOmxTeamOwnerTag(effectiveLeaderPaneId, tmuxPaneOwnerId) ? effectiveLeaderPaneId : null)
       : effectiveLeaderPaneId;
     const effectiveHudPaneId = sharedSessionTopology
-      ? (sharedSessionTopology.hudPaneIds.find((paneId) => paneId === hudPaneId) ?? null)
+      ? (sharedSessionTopology.hudPaneIds.find((paneId) => (
+        paneId === hudPaneId && paneHasOmxTeamOwnerTag(paneId, tmuxPaneOwnerId)
+      )) ?? null)
       : hudPaneId;
-    const shutdownCandidatePaneIds = sharedSessionTopology?.teamWorkerPaneIds ?? listPaneIds(sessionName);
+    const shutdownCandidatePaneIds = sharedSessionTopology
+      ? filterSharedSessionShutdownWorkerPaneIdsByOwner(sharedSessionTopology.teamWorkerPaneIds, tmuxPaneOwnerId)
+      : listPaneIds(sessionName);
     let shutdownPaneIds = collectShutdownPaneIds({
       config,
       candidatePaneIds: shutdownCandidatePaneIds,
@@ -3832,7 +3851,9 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     if (effectiveHudPaneId) {
       await killWorkerByPaneIdAsync(effectiveHudPaneId, effectiveLeaderPaneId ?? undefined);
       if (sessionName.includes(':')) {
-        restoredHudPaneId = restoreStandaloneHudPane(trustedHudRestoreLeaderPaneId, cwd);
+        restoredHudPaneId = restoreStandaloneHudPane(trustedHudRestoreLeaderPaneId, cwd, {
+          sessionId: leaderSessionId,
+        });
         if (!restoredHudPaneId) {
           const reason = trustedHudRestoreLeaderPaneId
             ? 'failed to restore standalone HUD pane'
@@ -3844,7 +3865,10 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     shutdownPaneIds = collectShutdownPaneIds({
       config,
       candidatePaneIds: sessionName.includes(':')
-        ? resolveSharedSessionShutdownTopology(sessionName, effectiveLeaderPaneId, sanitized).teamWorkerPaneIds
+        ? filterSharedSessionShutdownWorkerPaneIdsByOwner(
+          resolveSharedSessionShutdownTopology(sessionName, effectiveLeaderPaneId, sanitized).teamWorkerPaneIds,
+          tmuxPaneOwnerId,
+        )
         : listPaneIds(sessionName),
       includePersistedWorkerPaneIds: !sessionName.includes(':'),
       restoredStandaloneHudPaneId: restoredHudPaneId,

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -26,7 +26,7 @@ import {
   isWorkerPaneOpen,
   getWorkerPanePid,
   killWorkerByPaneIdAsync,
-  paneHasOmxTeamOwnerTag,
+  paneHasOmxInstanceTag,
   readPaneTeamOwnerTagResult,
   restoreStandaloneHudPane,
   teardownWorkerPanes,
@@ -444,6 +444,22 @@ function isSharedSessionHudPaneReclaimable(params: {
   if (owner.status === 'missing') return leaderOwnedHudPaneIds.includes(paneId);
   onOwnerReadError?.(paneId, owner.error);
   return false;
+}
+
+function isTrustedSharedSessionLeaderPaneForHudRestore(params: {
+  paneId: string | null;
+  teamPaneOwnerId: string;
+  legacyInstanceId: string;
+}): boolean {
+  const { paneId, teamPaneOwnerId, legacyInstanceId } = params;
+  if (!paneId) return false;
+  const expectedOwnerId = teamPaneOwnerId.trim();
+  if (expectedOwnerId) {
+    const owner = readPaneTeamOwnerTagResult(paneId);
+    if (owner.status === 'value') return owner.value === expectedOwnerId;
+    if (owner.status === 'error') return false;
+  }
+  return paneHasOmxInstanceTag(paneId, legacyInstanceId);
 }
 
 export function shouldPrekillInteractiveShutdownProcessTrees(sessionName: string): boolean {
@@ -3832,7 +3848,11 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       console.warn(`[team shutdown] ${sanitized}: skipped shared-session ${kind} ${paneId} because team owner tag could not be read: ${error}`);
     };
     const trustedHudRestoreLeaderPaneId = sharedSessionTopology
-      ? (paneHasOmxTeamOwnerTag(effectiveLeaderPaneId, tmuxPaneOwnerId) ? effectiveLeaderPaneId : null)
+      ? (isTrustedSharedSessionLeaderPaneForHudRestore({
+        paneId: effectiveLeaderPaneId,
+        teamPaneOwnerId: tmuxPaneOwnerId,
+        legacyInstanceId: leaderSessionId,
+      }) ? effectiveLeaderPaneId : null)
       : effectiveLeaderPaneId;
     const effectiveHudPaneId = sharedSessionTopology
       ? (sharedSessionTopology.hudPaneIds.find((paneId) => isSharedSessionHudPaneReclaimable({

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -25,6 +25,7 @@ import {
   trustWorkerMiseConfigIfAvailable,
   writeWorkerStartupScriptCommand,
   resolveTeamWorkerCliPlan,
+  tagPaneTeamOwner,
 } from './tmux-session.js';
 import { execFileSync, spawnSync } from 'child_process';
 import {
@@ -516,6 +517,16 @@ export async function scaleUp(
           workerName,
           worktreePath: workerWorkspace?.worktreePath,
         });
+      }
+      if (config.tmux_pane_owner_id) {
+        try {
+          tagPaneTeamOwner(paneId, config.tmux_pane_owner_id);
+        } catch (error) {
+          return await rollbackScaleUp(
+            `Failed to tag tmux pane for ${workerName}: ${error instanceof Error ? error.message : String(error)}`,
+            { paneId, workerName, worktreePath: workerWorkspace?.worktreePath },
+          );
+        }
       }
 
       // Intentionally avoid forcing `select-layout tiled` here.

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -91,6 +91,8 @@ export interface TeamConfig {
   leader_pane_id: string | null;
   /** HUD pane spawned below the leader column — excluded from worker pane cleanup. */
   hud_pane_id: string | null;
+  /** Team-scoped tmux pane owner token used by shutdown safety checks. */
+  tmux_pane_owner_id?: string;
   /** Registered HUD resize hook name used for window-size reconciliation. */
   resize_hook_name: string | null;
   /** Registered HUD resize hook target in "<session>:<window>" form. */
@@ -308,6 +310,7 @@ export interface TeamManifestV2 {
   worktree_mode?: WorktreeMode;
   leader_pane_id: string | null;
   hud_pane_id: string | null;
+  tmux_pane_owner_id?: string;
   resize_hook_name: string | null;
   resize_hook_target: string | null;
   /** Monotonic counter for worker index assignment during scaling. */
@@ -471,6 +474,10 @@ function defaultLeader(): TeamLeader {
     worker_id: 'leader-fixed',
     role: 'coordinator',
   };
+}
+
+function defaultTmuxPaneOwnerId(teamName: string): string {
+  return `team:${teamName}`;
 }
 
 function defaultPolicy(
@@ -823,6 +830,7 @@ export async function initTeamState(
   const displayMode = resolveDisplayModeFromEnv(env);
   const permissionsSnapshot = resolvePermissionsSnapshot(env);
   const workerLaunchMode = resolveWorkerLaunchModeFromEnv(env);
+  const tmuxPaneOwnerId = defaultTmuxPaneOwnerId(teamName);
 
   const config: TeamConfig = {
     name: teamName,
@@ -842,6 +850,7 @@ export async function initTeamState(
     worktree_mode: workspace.worktree_mode,
     leader_pane_id: null,
     hud_pane_id: null,
+    tmux_pane_owner_id: tmuxPaneOwnerId,
     resize_hook_name: null,
     resize_hook_target: null,
     next_worker_index: workerCount + 1,
@@ -887,6 +896,7 @@ export async function initTeamState(
       worktree_mode: workspace.worktree_mode,
       leader_pane_id: null,
       hud_pane_id: null,
+      tmux_pane_owner_id: tmuxPaneOwnerId,
       resize_hook_name: null,
       resize_hook_target: null,
       next_worker_index: workerCount + 1,
@@ -921,6 +931,7 @@ async function writeConfig(cfg: TeamConfig, cwd: string): Promise<void> {
       worktree_mode: normalized.worktree_mode,
       leader_pane_id: normalized.leader_pane_id,
       hud_pane_id: normalized.hud_pane_id,
+      tmux_pane_owner_id: normalized.tmux_pane_owner_id,
       resize_hook_name: normalized.resize_hook_name,
       resize_hook_target: normalized.resize_hook_target,
       next_worker_index: normalized.next_worker_index ?? existing.next_worker_index,
@@ -956,6 +967,7 @@ function teamConfigFromManifest(manifest: TeamManifestV2): TeamConfig {
     worktree_mode: manifest.worktree_mode,
     leader_pane_id: manifest.leader_pane_id,
     hud_pane_id: manifest.hud_pane_id,
+    tmux_pane_owner_id: manifest.tmux_pane_owner_id ?? defaultTmuxPaneOwnerId(manifest.name),
     resize_hook_name: manifest.resize_hook_name,
     resize_hook_target: manifest.resize_hook_target,
     next_worker_index: manifest.next_worker_index,
@@ -972,6 +984,9 @@ function normalizeTeamConfig(config: TeamConfig): TeamConfig {
     lifecycle_profile: 'default',
     leader_pane_id: config.leader_pane_id ?? null,
     hud_pane_id: config.hud_pane_id ?? null,
+    tmux_pane_owner_id: typeof config.tmux_pane_owner_id === 'string' && config.tmux_pane_owner_id.trim() !== ''
+      ? config.tmux_pane_owner_id.trim()
+      : defaultTmuxPaneOwnerId(config.name),
     resize_hook_name: config.resize_hook_name ?? null,
     resize_hook_target: config.resize_hook_target ?? null,
     worker_launch_mode: workerLaunchMode,
@@ -1009,6 +1024,7 @@ function teamManifestFromConfig(config: TeamConfig): TeamManifestV2 {
     worktree_mode: normalized.worktree_mode,
     leader_pane_id: normalized.leader_pane_id,
     hud_pane_id: normalized.hud_pane_id,
+    tmux_pane_owner_id: normalized.tmux_pane_owner_id,
     resize_hook_name: normalized.resize_hook_name,
     resize_hook_target: normalized.resize_hook_target,
     next_worker_index: normalized.next_worker_index,
@@ -1027,12 +1043,16 @@ export async function writeTeamManifestV2(manifest: TeamManifestV2, cwd: string)
     manifest.governance,
     manifest.policy as Partial<TeamGovernance>,
   );
+  const tmuxPaneOwnerId = typeof manifest.tmux_pane_owner_id === 'string' && manifest.tmux_pane_owner_id.trim() !== ''
+    ? manifest.tmux_pane_owner_id.trim()
+    : defaultTmuxPaneOwnerId(manifest.name);
   const p = teamManifestV2Path(manifest.name, cwd);
   await writeAtomic(
     p,
     JSON.stringify(
       {
         ...manifest,
+        tmux_pane_owner_id: tmuxPaneOwnerId,
         policy: normalizedPolicy,
         governance: normalizedGovernance,
         lifecycle_profile: 'default',
@@ -1058,8 +1078,12 @@ export async function readTeamManifestV2(teamName: string, cwd: string): Promise
       team_decomposition?: unknown;
     }) | undefined;
     const legacyTeamDecomposition = legacyPolicy?.team_decomposition;
+    const tmuxPaneOwnerId = typeof parsedManifest.tmux_pane_owner_id === 'string' && parsedManifest.tmux_pane_owner_id.trim() !== ''
+      ? parsedManifest.tmux_pane_owner_id.trim()
+      : defaultTmuxPaneOwnerId(parsedManifest.name);
     return {
       ...parsedManifest,
+      tmux_pane_owner_id: tmuxPaneOwnerId,
       policy: normalizeTeamPolicy(parsedManifest.policy, {
         display_mode: parsedManifest.policy?.display_mode === 'split_pane' ? 'split_pane' : 'auto',
         worker_launch_mode: parsedManifest.policy?.worker_launch_mode === 'prompt' ? 'prompt' : 'interactive',

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -21,6 +21,7 @@ export interface TeamConfig {
   worktree_mode?: WorktreeMode;
   leader_pane_id: string | null;
   hud_pane_id: string | null;
+  tmux_pane_owner_id?: string;
   resize_hook_name: string | null;
   resize_hook_target: string | null;
   next_worker_index?: number;
@@ -232,6 +233,7 @@ export interface TeamManifestV2 {
   worktree_mode?: WorktreeMode;
   leader_pane_id: string | null;
   hud_pane_id: string | null;
+  tmux_pane_owner_id?: string;
   resize_hook_name: string | null;
   resize_hook_target: string | null;
   next_worker_index?: number;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -2329,6 +2329,15 @@ export function killWorkerByPaneId(workerPaneId: string, leaderPaneId?: string):
   runTmux(['kill-pane', '-t', workerPaneId]);
 }
 
+export function paneHasOmxInstanceTag(paneId: string | null | undefined, instanceId: string | null | undefined): boolean {
+  const normalizedPaneId = normalizePaneTarget(paneId);
+  const expectedInstanceId = typeof instanceId === 'string' ? instanceId.trim() : '';
+  if (!normalizedPaneId || !expectedInstanceId) return false;
+  const result = runTmux(['show-option', '-qv', '-p', '-t', normalizedPaneId, OMX_PANE_INSTANCE_OPTION]);
+  if (!result.ok) return false;
+  return result.stdout.trim() === expectedInstanceId;
+}
+
 export async function killWorkerByPaneIdAsync(workerPaneId: string, leaderPaneId?: string): Promise<void> {
   if (!workerPaneId.startsWith('%')) return;
   // Guard: never kill the leader's own pane.
@@ -2358,6 +2367,7 @@ export interface PaneTeardownOptions {
 
 export interface SharedSessionShutdownTopology {
   livePaneIds: string[];
+  teamWorkerPaneIds: string[];
   leaderPaneId: string | null;
   hudPaneIds: string[];
 }
@@ -2404,6 +2414,7 @@ function normalizePaneTargets(
 export function resolveSharedSessionShutdownTopology(
   sessionName: string,
   preferredLeaderPaneId?: string | null,
+  teamName?: string | null,
 ): SharedSessionShutdownTopology {
   const panes = listPanes(sessionName);
   const livePaneIds = panes
@@ -2413,14 +2424,26 @@ export function resolveSharedSessionShutdownTopology(
   if (panes.length === 0) {
     return {
       livePaneIds,
+      teamWorkerPaneIds: [],
       leaderPaneId: fallbackLeaderPaneId,
       hudPaneIds: [],
     };
   }
 
-  const resolvedLeaderPaneId = normalizePaneTarget(
-    chooseTeamLeaderPaneId(panes, fallbackLeaderPaneId ?? ''),
-  ) ?? fallbackLeaderPaneId;
+  const normalizedTeamName = typeof teamName === 'string' ? teamName.trim() : '';
+  const normalizedTeamWorkerPaneIds = normalizedTeamName
+    ? panes
+      .filter((pane) => !isHudWatchPane(pane))
+      .filter((pane) => paneLooksLikeTeamWorkerPane(pane, normalizedTeamName))
+      .map((pane) => pane.paneId)
+      .filter((paneId) => paneId.startsWith('%'))
+    : [];
+  const workerPaneIdSet = new Set(normalizedTeamWorkerPaneIds);
+  const resolvedLeaderPaneId = chooseSharedSessionShutdownLeaderPaneId(
+    panes,
+    fallbackLeaderPaneId,
+    workerPaneIdSet,
+  );
   const hudPaneIds = panes
     .filter((pane) => pane.paneId !== resolvedLeaderPaneId)
     .filter((pane) => isHudWatchPane(pane))
@@ -2429,9 +2452,143 @@ export function resolveSharedSessionShutdownTopology(
 
   return {
     livePaneIds,
+    teamWorkerPaneIds: normalizedTeamWorkerPaneIds,
     leaderPaneId: resolvedLeaderPaneId,
     hudPaneIds,
   };
+}
+
+function chooseSharedSessionShutdownLeaderPaneId(
+  panes: TmuxPaneInfo[],
+  preferredLeaderPaneId: string | null,
+  teamWorkerPaneIds: ReadonlySet<string>,
+): string | null {
+  const preferred = panes.find((pane) => pane.paneId === preferredLeaderPaneId);
+  if (preferred && !isHudWatchPane(preferred) && !teamWorkerPaneIds.has(preferred.paneId)) {
+    return preferred.paneId;
+  }
+  return null;
+}
+
+function paneLooksLikeTeamWorkerPane(pane: TmuxPaneInfo, teamName: string): boolean {
+  const command = `${pane.startCommand || ''} ${pane.currentCommand || ''}`.replace(/\\/g, '/');
+  if (!command.trim() || !teamName) return false;
+  if (command.includes(`/team/${teamName}/runtime/worker-`) && command.includes('-startup.sh')) {
+    return true;
+  }
+  const commandVariants = [command, ...decodePowerShellEncodedCommands(command)];
+  return commandVariants.some((candidate) => (
+    commandHasTeamWorkerEnvMarker(candidate, 'OMX_TEAM_INTERNAL_WORKER', teamName)
+    || commandHasTeamWorkerEnvMarker(candidate, 'OMX_TEAM_WORKER', teamName)
+  ));
+}
+
+function commandHasTeamWorkerEnvMarker(command: string, envName: string, teamName: string): boolean {
+  const normalized = command.replace(/\\/g, '/');
+  const key = escapeRegExp(envName);
+  const workerValue = `${escapeRegExp(teamName)}/worker-[A-Za-z0-9_-]+`;
+  const shellAssignment = new RegExp(
+    `(?:^|[\\s;])(?:export\\s+)?(?:["']${key}=${workerValue}|${key}=(?:["']?${workerValue}))`,
+    'g',
+  );
+  const powerShellAssignment = new RegExp(`(?:^|;)\\s*\\$env:${key}\\s*=\\s*["']?${workerValue}`, 'gi');
+  return hasWorkerCliAfterEnvAssignment(
+    normalized,
+    shellAssignment,
+    hasSafeShellEnvAssignmentContext,
+    shellTailInvokesWorkerCli,
+  )
+    || hasWorkerCliAfterEnvAssignment(
+      normalized,
+      powerShellAssignment,
+      () => true,
+      powerShellTailInvokesWorkerCli,
+    );
+}
+
+function hasWorkerCliAfterEnvAssignment(
+  command: string,
+  assignmentPattern: RegExp,
+  contextIsSafe: (command: string, matchIndex: number) => boolean = () => true,
+  tailInvokesWorkerCli: (tail: string) => boolean = shellTailInvokesWorkerCli,
+): boolean {
+  assignmentPattern.lastIndex = 0;
+  for (const match of command.matchAll(assignmentPattern)) {
+    const matchIndex = match.index ?? 0;
+    if (!contextIsSafe(command, matchIndex)) continue;
+    const afterAssignment = command.slice(matchIndex + match[0].length);
+    if (tailInvokesWorkerCli(afterAssignment)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const WORKER_CLI_TOKEN_PATTERN = String.raw`(?:"[^"]*(?:^|[\/\\])?(?:codex|claude|gemini)(?:\.(?:js|mjs|cjs|cmd|exe|bat|ps1))?"|'[^']*(?:^|[\/\\])?(?:codex|claude|gemini)(?:\.(?:js|mjs|cjs|cmd|exe|bat|ps1))?'|(?:\S*[\/\\])?(?:codex|claude|gemini)(?:\.(?:js|mjs|cjs|cmd|exe|bat|ps1))?)`;
+
+function shellTailInvokesWorkerCli(tail: string): boolean {
+  const directTail = stripShellAssignmentTailPrefix(tail);
+  const directCliPattern = new RegExp(`^(?:exec\\s+)?${WORKER_CLI_TOKEN_PATTERN}(?:[\\s;"'\`]|$)`, 'i');
+  if (directCliPattern.test(directTail)) return true;
+
+  const shellCommandPattern = /(?:^|\s)-(?:c|lc)\s+(?:"([^"]*)"|'([^']*)'|(\S+))/gi;
+  for (const match of directTail.matchAll(shellCommandPattern)) {
+    const commandText = match[1] ?? match[2] ?? match[3] ?? '';
+    const execCliPattern = new RegExp(`(?:^|[\\s;&|])exec\\s+${WORKER_CLI_TOKEN_PATTERN}(?:[\\s;"'\`]|$)`, 'i');
+    if (execCliPattern.test(commandText)) return true;
+  }
+  return false;
+}
+
+function stripShellAssignmentTailPrefix(tail: string): string {
+  let value = tail.trimStart();
+  while (value.startsWith("'") || value.startsWith('"')) {
+    value = value.slice(1).trimStart();
+  }
+  const envAssignmentPattern = /^[A-Za-z_][A-Za-z0-9_]*=(?:'[^']*'|"[^"]*"|\S+)\s+/;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    const match = value.match(envAssignmentPattern);
+    if (match) {
+      value = value.slice(match[0].length).trimStart();
+      changed = true;
+    }
+  }
+  return value;
+}
+
+function powerShellTailInvokesWorkerCli(tail: string): boolean {
+  return /(?:^|[\s;&|"'`\/\\])(?:codex|claude|gemini)(?:\.(?:js|mjs|cjs|cmd|exe|bat|ps1))?(?:[\s;"'`]|$)/i.test(tail);
+}
+
+function hasSafeShellEnvAssignmentContext(command: string, matchIndex: number): boolean {
+  const prefix = command.slice(0, matchIndex).trimEnd();
+  if (!prefix) return true;
+  const segment = prefix.split(/&&|\|\||[;|]/).pop()?.trimEnd() ?? '';
+  if (!segment) return true;
+  return /(?:^|\s)(?:env|export)(?:\s+(?:'[^']*'|"[^"]*"|\S+))*$/.test(segment)
+    || /(?:^|\s)worker[-_]wrapper(?:\s+(?:'[^']*'|"[^"]*"|\S+))*$/.test(segment);
+}
+
+function decodePowerShellEncodedCommands(command: string): string[] {
+  const decoded: string[] = [];
+  const encodedCommandPattern = /(?:^|\s)-(?:EncodedCommand|enc|e)(?:\s+|:)([A-Za-z0-9+/=]+)/gi;
+  for (const match of command.matchAll(encodedCommandPattern)) {
+    const encoded = match[1];
+    if (!encoded) continue;
+    try {
+      const text = Buffer.from(encoded, 'base64').toString('utf16le').trim();
+      if (text) decoded.push(text.replace(/\\/g, '/'));
+    } catch {
+      // Ignore malformed pane command fragments; they are not team ownership evidence.
+    }
+  }
+  return decoded;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1,6 +1,6 @@
 import { spawnSync, execFile } from 'child_process';
 import { promisify } from 'util';
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { dirname, isAbsolute, join, resolve } from 'path';
 import {
@@ -358,6 +358,60 @@ function readPaneCurrentPath(paneId: string): string | null {
   if (!result.ok) return null;
   const path = result.stdout.split('\n')[0]?.trim() ?? '';
   return path === '' ? null : path;
+}
+
+function pathIsUsableDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+type RestoreCwdCandidateSource = 'explicit' | 'live' | 'fallback';
+
+type RestoreCwdCandidate = {
+  source: RestoreCwdCandidateSource;
+  rawPath: string;
+};
+
+function isMsysDriveSlashPath(path: string): boolean {
+  return /^\/[A-Za-z](?:\/|$)/.test(path);
+}
+
+function uniqueRestoreCwdCandidates(
+  candidates: Array<{source: RestoreCwdCandidateSource; rawPath: string | null | undefined}>,
+): RestoreCwdCandidate[] {
+  const seen = new Set<string>();
+  const result: RestoreCwdCandidate[] = [];
+  for (const candidate of candidates) {
+    const normalized = typeof candidate.rawPath === 'string' ? candidate.rawPath.trim() : '';
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push({ source: candidate.source, rawPath: normalized });
+  }
+  return result;
+}
+
+function shouldAttemptRestoreCwdCandidate(candidate: RestoreCwdCandidate): boolean {
+  if (candidate.source === 'live' && isMsysOrGitBash() && isMsysDriveSlashPath(candidate.rawPath)) {
+    return true;
+  }
+
+  return pathIsUsableDirectory(candidate.rawPath);
+}
+
+function resolveStandaloneHudRestoreCwdCandidates(
+  leaderPaneId: string,
+  fallbackCwd: string,
+  explicitCwd?: string | null,
+): RestoreCwdCandidate[] {
+  const liveLeaderCwd = readPaneCurrentPath(leaderPaneId);
+  return uniqueRestoreCwdCandidates([
+    { source: 'explicit', rawPath: explicitCwd },
+    { source: 'live', rawPath: liveLeaderCwd },
+    { source: 'fallback', rawPath: fallbackCwd },
+  ]).filter(shouldAttemptRestoreCwdCandidate);
 }
 
 const MAX_FRACTIONAL_SLEEP_MS = 60_000;
@@ -1646,25 +1700,34 @@ export function restoreStandaloneHudPane(
     return existingHudPaneId;
   }
 
-  const restoreCwd = options.cwd?.trim() || readPaneCurrentPath(normalizedLeaderPaneId) || cwd;
   const hudCmd = `exec env ${formatHudEnvAssignments(process.env, { sessionId: options.sessionId, leaderPaneId: normalizedLeaderPaneId })} ${shellQuoteSingle(translatePathForMsys(resolveLeaderNodePath()))} ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
-  const hudCwd = translatePathForMsys(restoreCwd);
-  const hudResult = runTmux([
-    'split-window',
-    '-v',
-    '-l',
-    String(HUD_TMUX_TEAM_HEIGHT_LINES),
-    '-t',
+  let hudResult: ReturnType<typeof runTmux> | null = null;
+  for (const restoreCwd of resolveStandaloneHudRestoreCwdCandidates(
     normalizedLeaderPaneId,
-    '-d',
-    '-P',
-    '-F',
-    '#{pane_id}',
-    '-c',
-    hudCwd,
-    hudCmd,
-  ]);
-  if (!hudResult.ok) return null;
+    cwd,
+    options.cwd,
+  )) {
+    const candidateResult = runTmux([
+      'split-window',
+      '-v',
+      '-l',
+      String(HUD_TMUX_TEAM_HEIGHT_LINES),
+      '-t',
+      normalizedLeaderPaneId,
+      '-d',
+      '-P',
+      '-F',
+      '#{pane_id}',
+      '-c',
+      translatePathForMsys(restoreCwd.rawPath),
+      hudCmd,
+    ]);
+    if (candidateResult.ok) {
+      hudResult = candidateResult;
+      break;
+    }
+  }
+  if (!hudResult?.ok) return null;
 
   const paneId = hudResult.stdout.split('\n')[0]?.trim() ?? '';
   if (!paneId.startsWith('%')) return null;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -39,6 +39,7 @@ import { findHudWatchPaneIds, OMX_TMUX_HUD_LEADER_PANE_ENV } from '../hud/tmux.j
 
 const OMX_INSTANCE_OPTION = '@omx_instance_id';
 const OMX_PANE_INSTANCE_OPTION = '@omx_pane_instance_id';
+const OMX_TEAM_PANE_OWNER_OPTION = '@omx_team_pane_owner_id';
 
 export interface TeamSession {
   name: string; // tmux target in "session:window" form
@@ -53,15 +54,27 @@ export interface TeamSession {
   resizeHookName: string | null;
   /** Registered tmux resize hook target in "<session>:<window>" form, or null. */
   resizeHookTarget: string | null;
+  /** Team-scoped tmux pane ownership token used by shutdown safety checks. */
+  teamPaneOwnerId: string;
 }
 
 export interface CreateTeamSessionOptions {
   /**
-   * Stable leader ownership id persisted to tmux pane options. This must match
-   * the manifest leader.session_id so shutdown can restore the leader HUD only
-   * when the pane still belongs to the same OMX/team runtime.
+   * Stable logical leader id forwarded to HUD/hook runtime and the generic
+   * tmux pane instance tag. Team shutdown must not rely on this value because
+   * environment session ids can be stale when a user starts OMX from another
+   * tmux pane in the same shell/session.
    */
   ownerSessionId?: string | null;
+  /** Team-scoped pane owner token used only for Team shutdown/teardown. */
+  teamPaneOwnerId?: string | null;
+}
+
+export interface RestoreStandaloneHudPaneOptions {
+  /** Session id that prompt-submit HUD reconciliation should use to dedupe the restored HUD. */
+  sessionId?: string | null;
+  /** Explicit HUD cwd override. When omitted, the live leader pane cwd is preferred over team launch cwd. */
+  cwd?: string | null;
 }
 
 const INJECTION_MARKER = '[OMX_TMUX_INJECT]';
@@ -186,6 +199,16 @@ function tagPaneInstance(paneTarget: string, instanceId: string): void {
   const sanitized = instanceId.trim();
   if (!target || !sanitized) return;
   const result = runTmux(['set-option', '-p', '-t', target, OMX_PANE_INSTANCE_OPTION, sanitized]);
+  if (!result.ok) {
+    throw new Error(`failed to tag tmux pane ${target}: ${result.stderr}`);
+  }
+}
+
+export function tagPaneTeamOwner(paneTarget: string, teamOwnerId: string): void {
+  const target = paneTarget.trim();
+  const sanitized = teamOwnerId.trim();
+  if (!target || !sanitized) return;
+  const result = runTmux(['set-option', '-p', '-t', target, OMX_TEAM_PANE_OWNER_OPTION, sanitized]);
   if (!result.ok) {
     throw new Error(`failed to tag tmux pane ${target}: ${result.stderr}`);
   }
@@ -327,6 +350,14 @@ function findHudPaneIds(target: string, leaderPaneId: string): string[] {
 
 function findOwnedHudPaneIds(target: string, leaderPaneId: string): string[] {
   return findHudWatchPaneIds(listPanes(target), leaderPaneId, { leaderPaneId });
+}
+
+function readPaneCurrentPath(paneId: string): string | null {
+  if (!paneId.startsWith('%')) return null;
+  const result = runTmux(['display-message', '-p', '-t', paneId, '#{pane_current_path}']);
+  if (!result.ok) return null;
+  const path = result.stdout.split('\n')[0]?.trim() ?? '';
+  return path === '' ? null : path;
 }
 
 const MAX_FRACTIONAL_SLEEP_MS = 60_000;
@@ -1363,16 +1394,18 @@ export function createTeamSession(
       throw new Error(`failed to parse current tmux target: ${context.stdout}`);
     }
     const teamTarget = `${sessionName}:${windowIndex}`;
-    const instanceId = (options.ownerSessionId ?? process.env.OMX_SESSION_ID ?? '').trim();
-    if (instanceId) {
-      const tagResult = runTmux(['set-option', '-t', sessionName, OMX_INSTANCE_OPTION, instanceId]);
+    const ownerSessionId = (options.ownerSessionId ?? process.env.OMX_SESSION_ID ?? '').trim();
+    const teamPaneOwnerId = (options.teamPaneOwnerId ?? `team:${safeTeamName}`).trim();
+    if (ownerSessionId) {
+      const tagResult = runTmux(['set-option', '-t', sessionName, OMX_INSTANCE_OPTION, ownerSessionId]);
       if (!tagResult.ok) {
         throw new Error(`failed to tag tmux session ${sessionName}: ${tagResult.stderr}`);
       }
     }
     const panes = listPanes(teamTarget);
     const leaderPaneId = chooseTeamLeaderPaneId(panes, detectedLeaderPaneId);
-    tagPaneInstance(leaderPaneId, instanceId);
+    tagPaneInstance(leaderPaneId, ownerSessionId);
+    tagPaneTeamOwner(leaderPaneId, teamPaneOwnerId);
     const initialHudPaneIds = findHudPaneIds(teamTarget, leaderPaneId);
     const omxEntry = resolveOmxCliEntryPath();
     const canRecreateTeamHud = Boolean(omxEntry && omxEntry.trim() !== '');
@@ -1440,7 +1473,8 @@ export function createTeamSession(
       if (isNativeWindows() && !waitForPaneToRemainPresent(teamTarget, paneId)) {
         throw new Error(`worker pane ${i} did not remain present after tmux split-window returned ${paneId}`);
       }
-      tagPaneInstance(paneId, instanceId);
+      tagPaneInstance(paneId, ownerSessionId);
+      tagPaneTeamOwner(paneId, teamPaneOwnerId);
       workerPaneIds.push(paneId);
       if (i === 1) rightStackRootPaneId = paneId;
     }
@@ -1467,7 +1501,7 @@ export function createTeamSession(
     let resizeHookName: string | null = null;
     let resizeHookTarget: string | null = null;
     if (canRecreateTeamHud && omxEntry) {
-      const hudCmd = `exec env ${formatHudEnvAssignments(process.env, { sessionId: instanceId, leaderPaneId })} node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
+      const hudCmd = `exec env ${formatHudEnvAssignments(process.env, { sessionId: ownerSessionId || teamPaneOwnerId, leaderPaneId })} node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
       const hudCwd = translatePathForMsys(cwd);
       const hudResult = runTmux([
         'split-window', '-v', '-f', '-l', String(HUD_TMUX_TEAM_HEIGHT_LINES), '-t', teamTarget, '-d', '-P', '-F', '#{pane_id}', '-c', hudCwd, hudCmd,
@@ -1479,7 +1513,8 @@ export function createTeamSession(
           if (isNativeWindows() && !waitForPaneToRemainPresent(teamTarget, id)) {
             throw new Error(`HUD pane did not remain present after tmux split-window returned ${id}`);
           }
-          tagPaneInstance(id, instanceId);
+          tagPaneInstance(id, ownerSessionId);
+          tagPaneTeamOwner(id, teamPaneOwnerId);
           hudPaneId = id;
 
           if (isNativeWindows()) {
@@ -1561,6 +1596,7 @@ export function createTeamSession(
       hudPaneId,
       resizeHookName,
       resizeHookTarget,
+      teamPaneOwnerId,
     };
   } catch (error) {
     if (registeredClientAttachedHook) {
@@ -1584,6 +1620,7 @@ export function createTeamSession(
 export function restoreStandaloneHudPane(
   leaderPaneId: string | null | undefined,
   cwd: string,
+  options: RestoreStandaloneHudPaneOptions = {},
 ): string | null {
   const normalizedLeaderPaneId = normalizePaneTarget(leaderPaneId);
   if (!normalizedLeaderPaneId) return null;
@@ -1609,8 +1646,9 @@ export function restoreStandaloneHudPane(
     return existingHudPaneId;
   }
 
-  const hudCmd = `exec env ${formatHudEnvAssignments(process.env, { leaderPaneId: normalizedLeaderPaneId })} ${shellQuoteSingle(translatePathForMsys(resolveLeaderNodePath()))} ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
-  const hudCwd = translatePathForMsys(cwd);
+  const restoreCwd = options.cwd?.trim() || readPaneCurrentPath(normalizedLeaderPaneId) || cwd;
+  const hudCmd = `exec env ${formatHudEnvAssignments(process.env, { sessionId: options.sessionId, leaderPaneId: normalizedLeaderPaneId })} ${shellQuoteSingle(translatePathForMsys(resolveLeaderNodePath()))} ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
+  const hudCwd = translatePathForMsys(restoreCwd);
   const hudResult = runTmux([
     'split-window',
     '-v',
@@ -2342,6 +2380,21 @@ export function paneHasOmxInstanceTag(paneId: string | null | undefined, instanc
   const result = runTmux(['show-option', '-qv', '-p', '-t', normalizedPaneId, OMX_PANE_INSTANCE_OPTION]);
   if (!result.ok) return false;
   return result.stdout.trim() === expectedInstanceId;
+}
+
+export function paneHasOmxTeamOwnerTag(paneId: string | null | undefined, teamOwnerId: string | null | undefined): boolean {
+  const expectedTeamOwnerId = typeof teamOwnerId === 'string' ? teamOwnerId.trim() : '';
+  if (!expectedTeamOwnerId) return false;
+  return readPaneTeamOwnerTag(paneId) === expectedTeamOwnerId;
+}
+
+export function readPaneTeamOwnerTag(paneId: string | null | undefined): string | null {
+  const normalizedPaneId = normalizePaneTarget(paneId);
+  if (!normalizedPaneId) return null;
+  const result = runTmux(['show-option', '-qv', '-p', '-t', normalizedPaneId, OMX_TEAM_PANE_OWNER_OPTION]);
+  if (!result.ok) return null;
+  const value = result.stdout.trim();
+  return value === '' ? null : value;
 }
 
 export async function killWorkerByPaneIdAsync(workerPaneId: string, leaderPaneId?: string): Promise<void> {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -35,7 +35,7 @@ import { resolveOmxCliEntryPath } from '../utils/paths.js';
 const execFileAsync = promisify(execFile);
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../hud/constants.js';
 import { OMX_TMUX_HUD_OWNER_ENV } from '../hud/reconcile.js';
-import { findHudWatchPaneIds, OMX_TMUX_HUD_LEADER_PANE_ENV } from '../hud/tmux.js';
+import { findHudWatchPaneIds, hudPaneMatchesOwner, OMX_TMUX_HUD_LEADER_PANE_ENV } from '../hud/tmux.js';
 
 const OMX_INSTANCE_OPTION = '@omx_instance_id';
 const OMX_PANE_INSTANCE_OPTION = '@omx_pane_instance_id';
@@ -2385,16 +2385,45 @@ export function paneHasOmxInstanceTag(paneId: string | null | undefined, instanc
 export function paneHasOmxTeamOwnerTag(paneId: string | null | undefined, teamOwnerId: string | null | undefined): boolean {
   const expectedTeamOwnerId = typeof teamOwnerId === 'string' ? teamOwnerId.trim() : '';
   if (!expectedTeamOwnerId) return false;
-  return readPaneTeamOwnerTag(paneId) === expectedTeamOwnerId;
+  const result = readPaneTeamOwnerTagResult(paneId);
+  return result.status === 'value' && result.value === expectedTeamOwnerId;
 }
 
 export function readPaneTeamOwnerTag(paneId: string | null | undefined): string | null {
+  const result = readPaneTeamOwnerTagResult(paneId);
+  return result.status === 'value' ? result.value : null;
+}
+
+export type PaneTeamOwnerTagReadResult =
+  | { status: 'value'; value: string }
+  | { status: 'missing' }
+  | { status: 'error'; error: string };
+
+export function readPaneTeamOwnerTagResult(paneId: string | null | undefined): PaneTeamOwnerTagReadResult {
   const normalizedPaneId = normalizePaneTarget(paneId);
-  if (!normalizedPaneId) return null;
-  const result = runTmux(['show-option', '-qv', '-p', '-t', normalizedPaneId, OMX_TEAM_PANE_OWNER_OPTION]);
-  if (!result.ok) return null;
-  const value = result.stdout.trim();
-  return value === '' ? null : value;
+  if (!normalizedPaneId) return { status: 'error', error: 'invalid pane target' };
+  const { result } = spawnPlatformCommandSync('tmux', [
+    'show-option',
+    '-qv',
+    '-p',
+    '-t',
+    normalizedPaneId,
+    OMX_TEAM_PANE_OWNER_OPTION,
+  ], { encoding: 'utf-8' });
+  if (result.error) {
+    return { status: 'error', error: result.error.message };
+  }
+  const stdout = typeof result.stdout === 'string' ? result.stdout.trim() : '';
+  if (result.status === 0) {
+    return stdout === '' ? { status: 'missing' } : { status: 'value', value: stdout };
+  }
+  const stderr = typeof result.stderr === 'string' ? result.stderr.trim() : '';
+  // tmux reports an unset user option as status 1 with no diagnostic on
+  // supported versions. Treat other failures, including signal/null exits,
+  // as real read errors so shared-pane shutdown fails closed instead of
+  // killing a pane whose owner could not be read.
+  if (result.status === 1 && stderr === '') return { status: 'missing' };
+  return { status: 'error', error: stderr || `tmux show-option exited ${result.status ?? 'unknown'}` };
 }
 
 export async function killWorkerByPaneIdAsync(workerPaneId: string, leaderPaneId?: string): Promise<void> {
@@ -2429,6 +2458,7 @@ export interface SharedSessionShutdownTopology {
   teamWorkerPaneIds: string[];
   leaderPaneId: string | null;
   hudPaneIds: string[];
+  leaderOwnedHudPaneIds: string[];
 }
 
 function normalizePaneTarget(value: string | null | undefined): string | null {
@@ -2486,6 +2516,7 @@ export function resolveSharedSessionShutdownTopology(
       teamWorkerPaneIds: [],
       leaderPaneId: fallbackLeaderPaneId,
       hudPaneIds: [],
+      leaderOwnedHudPaneIds: [],
     };
   }
 
@@ -2508,12 +2539,20 @@ export function resolveSharedSessionShutdownTopology(
     .filter((pane) => isHudWatchPane(pane))
     .map((pane) => pane.paneId)
     .filter((paneId) => paneId.startsWith('%'));
+  const leaderOwnedHudPaneIds = resolvedLeaderPaneId
+    ? panes
+      .filter((pane) => pane.paneId !== resolvedLeaderPaneId)
+      .filter((pane) => hudPaneMatchesOwner(pane, { leaderPaneId: resolvedLeaderPaneId }))
+      .map((pane) => pane.paneId)
+      .filter((paneId) => paneId.startsWith('%'))
+    : [];
 
   return {
     livePaneIds,
     teamWorkerPaneIds: normalizedTeamWorkerPaneIds,
     leaderPaneId: resolvedLeaderPaneId,
     hudPaneIds,
+    leaderOwnedHudPaneIds,
   };
 }
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -55,6 +55,15 @@ export interface TeamSession {
   resizeHookTarget: string | null;
 }
 
+export interface CreateTeamSessionOptions {
+  /**
+   * Stable leader ownership id persisted to tmux pane options. This must match
+   * the manifest leader.session_id so shutdown can restore the leader HUD only
+   * when the pane still belongs to the same OMX/team runtime.
+   */
+  ownerSessionId?: string | null;
+}
+
 const INJECTION_MARKER = '[OMX_TMUX_INJECT]';
 const MODEL_INSTRUCTIONS_FILE_KEY = 'model_instructions_file';
 const OMX_BYPASS_DEFAULT_SYSTEM_PROMPT_ENV = 'OMX_BYPASS_DEFAULT_SYSTEM_PROMPT';
@@ -313,11 +322,7 @@ export function chooseTeamLeaderPaneId(panes: TmuxPaneInfo[], preferredPaneId: s
 }
 
 function findHudPaneIds(target: string, leaderPaneId: string): string[] {
-  const panes = listPanes(target);
-  return panes
-    .filter((pane) => pane.paneId !== leaderPaneId)
-    .filter((pane) => isHudWatchPane(pane))
-    .map((pane) => pane.paneId);
+  return findHudWatchPaneIds(listPanes(target), leaderPaneId, { leaderPaneId });
 }
 
 function findOwnedHudPaneIds(target: string, leaderPaneId: string): string[] {
@@ -1318,6 +1323,7 @@ export function createTeamSession(
     workerCli?: TeamWorkerCli;
     workerRole?: string;
   }> = [],
+  options: CreateTeamSessionOptions = {},
 ): TeamSession {
   if (!isTmuxAvailable()) {
     throw new Error('tmux is not available');
@@ -1357,7 +1363,7 @@ export function createTeamSession(
       throw new Error(`failed to parse current tmux target: ${context.stdout}`);
     }
     const teamTarget = `${sessionName}:${windowIndex}`;
-    const instanceId = (process.env.OMX_SESSION_ID || '').trim();
+    const instanceId = (options.ownerSessionId ?? process.env.OMX_SESSION_ID ?? '').trim();
     if (instanceId) {
       const tagResult = runTmux(['set-option', '-t', sessionName, OMX_INSTANCE_OPTION, instanceId]);
       if (!tagResult.ok) {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1555,7 +1555,7 @@ export function createTeamSession(
     let resizeHookName: string | null = null;
     let resizeHookTarget: string | null = null;
     if (canRecreateTeamHud && omxEntry) {
-      const hudCmd = `exec env ${formatHudEnvAssignments(process.env, { sessionId: ownerSessionId || teamPaneOwnerId, leaderPaneId })} node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
+      const hudCmd = `exec env ${formatHudEnvAssignments(process.env, { sessionId: ownerSessionId, leaderPaneId })} node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
       const hudCwd = translatePathForMsys(cwd);
       const hudResult = runTmux([
         'split-window', '-v', '-f', '-l', String(HUD_TMUX_TEAM_HEIGHT_LINES), '-t', teamTarget, '-d', '-P', '-F', '#{pane_id}', '-c', hudCwd, hudCmd,


### PR DESCRIPTION
## Summary

Fixes Team shared-session shutdown/HUD regressions where Team cleanup could target unrelated panes, leave stale/duplicate HUD panes, restore the standalone HUD in the wrong cwd/session, or drop MSYS/Git Bash live pane cwd candidates before tmux can use them.

Target base branch: `dev`.

## Changes

- Add a Team-scoped tmux pane owner tag (`@omx_team_pane_owner_id`) separate from logical `OMX_SESSION_ID`.
- Persist/backfill `tmux_pane_owner_id` in Team config/manifest, and tag leader/worker/HUD panes during startup and scale-up.
- Filter shared-session teardown candidates by Team owner tag so unrelated panes and panes from other Team runs are preserved.
- Fail closed when Team owner-tag reads fail, preserving panes and logging shutdown warnings.
- Further bound untagged shared-session worker cleanup to panes that have both live worker-command evidence and persisted worker pane ids for the same Team.
- Preserve legacy leader instance tags as fallback evidence when restoring HUDs for already-running pre-owner-tag teams.
- Restore standalone HUD panes from the live leader pane cwd when usable, then fall back to the Team launch cwd if the live cwd is stale/unusable.
- Pass the current logical session id into standalone HUD restore so HUD reconciliation dedupes correctly.
- Do not reuse Team pane owner tokens as HUD `OMX_SESSION_ID` fallbacks.
- Reclaim matching-owner live HUD panes even when persisted `hud_pane_id` is stale, then restore one standalone HUD for the verified leader.
- Keep MSYS/Git Bash live `/c/...` cwd candidates without raw `statSync('/c/...')` prefiltering; validate them by the `tmux split-window -c translatePathForMsys(rawPath)` attempt and fall back if that split fails.
- Align shutdown test fixtures with the new owner-tag boundary so tests that expect cleanup use explicit matching Team owner tags instead of relying on broad untagged live-worker cleanup.
- Add/strengthen regression coverage for unrelated pane preservation, owner-tag read errors, legacy HUD reclaim/restore, live-cwd restore, session id propagation, stale/deleted cwd fallback, stale persisted HUD ids, and MSYS live cwd handling.

## Validation

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `git diff --check upstream/dev...HEAD && git diff --check`
- [x] Targeted G012/runtime/tmux regressions — 7/7 pass
- [x] `node dist/scripts/run-test-files.js dist/team/__tests__/runtime.test.js dist/team/__tests__/tmux-session.test.js` — runtime 145/145 and tmux-session 208/208 pass outside sandbox; process-tree tests require `ps`/`kill` access and fail under the local sandbox with EPERM
- [x] GitHub Actions CI for pushed HEAD `dfb1c377bc6533b9199312dcca48f967e88949de` — run #4630 success
- [x] Earlier broad Team/HUD verification recorded in Ultragoal evidence: runtime/tmux-session suites, scaling/state/CLI/HUD suites, `verify:native-agents`, `verify:plugin-bundle`, no-unused, and UltraQA adversarial Team/HUD shutdown matrix
- [x] Final independent review gate: code-reviewer APPROVE and architect CLEAR for HEAD `dfb1c377bc6533b9199312dcca48f967e88949de`

## Current branch state

- Local/fork branch: `fix/team-shutdown-preserve-panes`
- Pushed fork HEAD: `dfb1c377bc6533b9199312dcca48f967e88949de`
- Upstream base checked by `git ls-remote upstream refs/heads/dev`: `831d818e0da6ae223afe59eb45bf56853a620e07`

## Checklist

- [x] Focused on Team shutdown/HUD pane ownership and restore safety
- [x] Regression tests added for reported shutdown/HUD failure modes
- [x] Backward compatibility considered for legacy untagged Team panes and already-running Team leaders
- [x] No new runtime dependencies

## Related

Closes #2857