### PR TITLE
fix: make deep-interview/RALPLAN Bash write detector target-aware (#2829)

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -5951,6 +5951,22 @@ exit 0
       );
       assert.equal(allowedSubshellGrep.outputJson, null);
 
+      // Double-quoted spans that merely mention the literal token, expand a
+      // parameter, or run a substitution that is not `apply_patch` stay allowed
+      // — the quoted-substitution fix must not over-block read-only diagnostics.
+      const allowedQuotedMention = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-grep",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-grep-quoted-mention",
+          tool_input: { command: 'echo "${apply_patch} $(echo apply_patch)"' },
+        },
+        { cwd },
+      );
+      assert.equal(allowedQuotedMention.outputJson, null);
+
       const blockedApplyPatch = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",
@@ -6006,6 +6022,11 @@ exit 0
         { id: "tool-di-apply-patch-subshell-env", command: `(env apply_patch <<'EOF'${heredocBody}\n)` },
         { id: "tool-di-apply-patch-command-substitution", command: `x=$(apply_patch <<'EOF'${heredocBody}\n)` },
         { id: "tool-di-apply-patch-brace-group", command: `{ apply_patch <<'EOF'${heredocBody}\n}` },
+        // Command substitution runs even inside double quotes, so quoting the
+        // already-blocked `$(…)` / `` `…` `` form must not bypass the guard.
+        { id: "tool-di-apply-patch-quoted-command-substitution", command: `echo "$(apply_patch <<'EOF'${heredocBody}\n)"` },
+        { id: "tool-di-apply-patch-quoted-backtick", command: `echo "\`apply_patch <<'EOF'${heredocBody}\`"` },
+        { id: "tool-di-apply-patch-quoted-command-substitution-prefixed", command: `echo "patched: $(apply_patch <<'EOF'${heredocBody}\n) done"` },
       ];
       for (const form of blockedRealApplyPatchForms) {
         const blockedForm = await dispatchCodexNativeHook(

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -5976,6 +5976,35 @@ exit 0
         { cwd },
       );
       assert.equal((blockedEnvWrapperApplyPatch.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const heredocBody = "\n*** Begin Patch\n*** Add File: src/leak.ts\n+export const x = 1;\n*** End Patch\nEOF";
+      const blockedRealApplyPatchForms: Array<{ id: string; command: string }> = [
+        { id: "tool-di-apply-patch-env-i", command: `env -i apply_patch <<'EOF'${heredocBody}` },
+        { id: "tool-di-apply-patch-env-unset", command: `env -u FOO apply_patch <<'EOF'${heredocBody}` },
+        { id: "tool-di-apply-patch-env-i-assignment", command: `env -i FOO=bar apply_patch <<'EOF'${heredocBody}` },
+        { id: "tool-di-apply-patch-assignment-env", command: `FOO=bar env apply_patch <<'EOF'${heredocBody}` },
+        { id: "tool-di-apply-patch-exec-env-assignment", command: `exec env FOO=bar apply_patch <<'EOF'${heredocBody}` },
+        { id: "tool-di-apply-patch-absolute-path", command: `/usr/bin/apply_patch <<'EOF'${heredocBody}` },
+        { id: "tool-di-apply-patch-relative-path", command: `./apply_patch <<'EOF'${heredocBody}` },
+      ];
+      for (const form of blockedRealApplyPatchForms) {
+        const blockedForm = await dispatchCodexNativeHook(
+          {
+            hook_event_name: "PreToolUse",
+            cwd,
+            session_id: "sess-di-grep",
+            tool_name: "Bash",
+            tool_use_id: form.id,
+            tool_input: { command: form.command },
+          },
+          { cwd },
+        );
+        assert.equal(
+          (blockedForm.outputJson as { decision?: string } | null)?.decision,
+          "block",
+          `expected deep-interview to block real apply_patch form: ${form.command}`,
+        );
+      }
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -5950,6 +5950,32 @@ exit 0
         { cwd },
       );
       assert.equal((blockedApplyPatch.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedEnvAssignmentApplyPatch = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-grep",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-apply-patch-env-assignment",
+          tool_input: { command: "FOO=bar apply_patch <<'EOF'\n*** Begin Patch\n*** Add File: src/leak.ts\n+export const x = 1;\n*** End Patch\nEOF" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedEnvAssignmentApplyPatch.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedEnvWrapperApplyPatch = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-grep",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-apply-patch-env-wrapper",
+          tool_input: { command: "env FOO=bar apply_patch <<'EOF'\n*** Begin Patch\n*** Add File: src/leak.ts\n+export const x = 1;\n*** End Patch\nEOF" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedEnvWrapperApplyPatch.outputJson as { decision?: string } | null)?.decision, "block");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -5903,6 +5903,123 @@ exit 0
     }
   });
 
+  it("allows read-only diagnostics mentioning apply_patch while deep-interview blocks real apply_patch invocations", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-deep-interview-grep-apply-patch-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionDir = join(stateDir, "sessions", "sess-di-grep");
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-di-grep", cwd });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "deep-interview",
+        phase: "planning",
+        session_id: "sess-di-grep",
+        active_skills: [{ skill: "deep-interview", phase: "planning", active: true, session_id: "sess-di-grep" }],
+      });
+      await writeJson(join(sessionDir, "deep-interview-state.json"), {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+        session_id: "sess-di-grep",
+      });
+
+      const allowedGrep = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-grep",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-grep",
+          tool_input: { command: 'grep -n "apply_patch" dist/scripts/codex-native-hook.js' },
+        },
+        { cwd },
+      );
+      assert.equal(allowedGrep.outputJson, null);
+
+      const blockedApplyPatch = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-grep",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-apply-patch-invoke",
+          tool_input: { command: "apply_patch <<'EOF'\n*** Begin Patch\n*** Add File: src/leak.ts\n+export const x = 1;\n*** End Patch\nEOF" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedApplyPatch.outputJson as { decision?: string } | null)?.decision, "block");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows deep-interview same-command literal variable redirects to artifacts while blocking variable redirects outside them", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-deep-interview-var-redirect-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionDir = join(stateDir, "sessions", "sess-di-var-redirect");
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-di-var-redirect", cwd });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "deep-interview",
+        phase: "planning",
+        session_id: "sess-di-var-redirect",
+        active_skills: [{ skill: "deep-interview", phase: "planning", active: true, session_id: "sess-di-var-redirect" }],
+      });
+      await writeJson(join(sessionDir, "deep-interview-state.json"), {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+        session_id: "sess-di-var-redirect",
+      });
+
+      const allowedVarRedirect = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-var-redirect",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-var-redirect-allow",
+          tool_input: { command: 'SNAP=".omx/context/example.md"\ncat > "$SNAP" <<\'EOF\'\ncontent\nEOF' },
+        },
+        { cwd },
+      );
+      assert.equal(allowedVarRedirect.outputJson, null);
+
+      const blockedVarRedirect = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-var-redirect",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-var-redirect-block",
+          tool_input: { command: 'SNAP="src/leak.ts"\ncat > "$SNAP" <<\'EOF\'\ncontent\nEOF' },
+        },
+        { cwd },
+      );
+      assert.equal((blockedVarRedirect.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedUnresolvedVarRedirect = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-var-redirect",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-var-redirect-unresolved",
+          tool_input: { command: 'cat > "$SNAP" <<\'EOF\'\ncontent\nEOF' },
+        },
+        { cwd },
+      );
+      assert.equal((blockedUnresolvedVarRedirect.outputJson as { decision?: string } | null)?.decision, "block");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("allows deep-interview apply_patch artifact writes from freeform patch text while blocking outside paths", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-deep-interview-apply-patch-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -5938,6 +5938,19 @@ exit 0
       );
       assert.equal(allowedGrep.outputJson, null);
 
+      const allowedSubshellGrep = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-grep",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-grep-subshell",
+          tool_input: { command: '(grep -n "apply_patch" dist/scripts/codex-native-hook.js)' },
+        },
+        { cwd },
+      );
+      assert.equal(allowedSubshellGrep.outputJson, null);
+
       const blockedApplyPatch = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",
@@ -5986,6 +5999,13 @@ exit 0
         { id: "tool-di-apply-patch-exec-env-assignment", command: `exec env FOO=bar apply_patch <<'EOF'${heredocBody}` },
         { id: "tool-di-apply-patch-absolute-path", command: `/usr/bin/apply_patch <<'EOF'${heredocBody}` },
         { id: "tool-di-apply-patch-relative-path", command: `./apply_patch <<'EOF'${heredocBody}` },
+        { id: "tool-di-apply-patch-subshell", command: `(apply_patch <<'EOF'${heredocBody}\n)` },
+        { id: "tool-di-apply-patch-subshell-spaced", command: `( apply_patch <<'EOF'${heredocBody}\n)` },
+        { id: "tool-di-apply-patch-double-subshell", command: `((apply_patch <<'EOF'${heredocBody}\n))` },
+        { id: "tool-di-apply-patch-pipe-subshell", command: `true | (apply_patch <<'EOF'${heredocBody}\n)` },
+        { id: "tool-di-apply-patch-subshell-env", command: `(env apply_patch <<'EOF'${heredocBody}\n)` },
+        { id: "tool-di-apply-patch-command-substitution", command: `x=$(apply_patch <<'EOF'${heredocBody}\n)` },
+        { id: "tool-di-apply-patch-brace-group", command: `{ apply_patch <<'EOF'${heredocBody}\n}` },
       ];
       for (const form of blockedRealApplyPatchForms) {
         const blockedForm = await dispatchCodexNativeHook(

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2752,11 +2752,15 @@ function isNullDeviceRedirectTarget(target: string): boolean {
 }
 
 // Matches `apply_patch` only at a shell command position (statement start, or
-// after a pipe/`;`/`&`/`(` boundary, optionally via `sudo`/`command`/`exec`),
-// so read-only diagnostics that merely mention the literal token (e.g.
-// `grep -n "apply_patch" file`) are not misread as write intent.
+// after a pipe/`;`/`&`/`(` boundary, optionally via an `env` prefix and/or
+// zero-or-more leading `NAME=VALUE` assignments and a `sudo`/`command`/`exec`
+// wrapper), so read-only diagnostics that merely mention the literal token
+// (e.g. `grep -n "apply_patch" file`) are not misread as write intent, while
+// real env-prefixed invocations (`FOO=bar apply_patch`, `env FOO=bar
+// apply_patch`) stay blocked — mirroring the git commit guard's handling of
+// leading env assignments / `env` wrapper prefixes.
 function commandInvokesApplyPatch(command: string): boolean {
-  return /(?:^|[\n;&|(]|&&|\|\|)\s*(?:sudo\s+|command\s+|exec\s+)?apply_patch\b/.test(command);
+  return /(?:^|[\n;&|(]|&&|\|\|)\s*(?:env\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s'"]+)\s+)*(?:sudo\s+|command\s+|exec\s+)?apply_patch\b/.test(command);
 }
 
 // Collects same-command literal variable assignments (`NAME="value"`), skipping

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2751,6 +2751,39 @@ function isNullDeviceRedirectTarget(target: string): boolean {
   return normalized === "/dev/null" || normalized === "nul";
 }
 
+// Matches `apply_patch` only at a shell command position (statement start, or
+// after a pipe/`;`/`&`/`(` boundary, optionally via `sudo`/`command`/`exec`),
+// so read-only diagnostics that merely mention the literal token (e.g.
+// `grep -n "apply_patch" file`) are not misread as write intent.
+function commandInvokesApplyPatch(command: string): boolean {
+  return /(?:^|[\n;&|(]|&&|\|\|)\s*(?:sudo\s+|command\s+|exec\s+)?apply_patch\b/.test(command);
+}
+
+// Collects same-command literal variable assignments (`NAME="value"`), skipping
+// any value that involves expansion (`$`, backticks) so unresolved/dynamic
+// targets stay conservatively blocked.
+function extractCommandLiteralAssignments(command: string): Map<string, string> {
+  const assignments = new Map<string, string>();
+  const pattern = /(?:^|[\n;&|(]|&&|\|\|)\s*([A-Za-z_][A-Za-z0-9_]*)=(?:"([^"$`]*)"|'([^']*)'|([^\s"'$`;&|<>]+))/g;
+  for (const match of command.matchAll(pattern)) {
+    const name = safeString(match[1]).trim();
+    if (!name) continue;
+    const value = match[2] ?? match[3] ?? match[4] ?? "";
+    assignments.set(name, value);
+  }
+  return assignments;
+}
+
+// Resolves a redirect/tee target of the form `$NAME`/`${NAME}` against
+// same-command literal assignments; non-variable or unresolved targets are
+// returned unchanged so they remain subject to the allowed-path check.
+function resolveCommandRedirectTarget(target: string, assignments: Map<string, string>): string {
+  const variableMatch = target.match(/^\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?$/);
+  if (!variableMatch) return target;
+  const resolved = assignments.get(safeString(variableMatch[1]));
+  return resolved !== undefined ? resolved : target;
+}
+
 function extractDeepInterviewCommandRedirectTargets(command: string): string[] {
   const targets: string[] = [];
   for (const match of command.matchAll(/(?:^|[^>])>{1,2}\s*(["']?)([^\s&|;<>]+)\1/g)) {
@@ -2761,7 +2794,7 @@ function extractDeepInterviewCommandRedirectTargets(command: string): string[] {
 }
 
 function commandHasDeepInterviewWriteIntent(command: string): boolean {
-  return /\bapply_patch\b/.test(command)
+  return commandInvokesApplyPatch(command)
     || extractDeepInterviewCommandRedirectTargets(command).length > 0
     || /\btee\s+(?:-a\s+)?[^\s&|;]+/.test(command)
     || /\bsed\s+(?:[^\n;&|]*\s)?-i(?:\b|['"])/.test(command)
@@ -2770,10 +2803,12 @@ function commandHasDeepInterviewWriteIntent(command: string): boolean {
 }
 
 function extractDeepInterviewCommandWriteTargets(command: string): string[] {
-  const targets = extractDeepInterviewCommandRedirectTargets(command);
+  const assignments = extractCommandLiteralAssignments(command);
+  const targets = extractDeepInterviewCommandRedirectTargets(command)
+    .map((target) => resolveCommandRedirectTarget(target, assignments));
   for (const match of command.matchAll(/\btee\s+(?:-a\s+)?(["']?)([^\s&|;<>]+)\1/g)) {
     const candidate = safeString(match[2]).trim();
-    if (candidate) targets.push(candidate);
+    if (candidate) targets.push(resolveCommandRedirectTarget(candidate, assignments));
   }
   return targets;
 }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -61,6 +61,7 @@ import {
   SLOPPY_FALLBACK_PHRASE_PATTERNS,
   buildNativePostToolUseOutput,
   buildNativePreToolUseOutput,
+  commandInvokesApplyPatch,
   detectMcpTransportFailure,
   hasAnyPattern,
 } from "./codex-native-pre-post.js";
@@ -2749,18 +2750,6 @@ function collectImplementationToolPathCandidates(
 function isNullDeviceRedirectTarget(target: string): boolean {
   const normalized = target.trim().replace(/^['"]|['"]$/g, "").toLowerCase();
   return normalized === "/dev/null" || normalized === "nul";
-}
-
-// Matches `apply_patch` only at a shell command position (statement start, or
-// after a pipe/`;`/`&`/`(` boundary, optionally via an `env` prefix and/or
-// zero-or-more leading `NAME=VALUE` assignments and a `sudo`/`command`/`exec`
-// wrapper), so read-only diagnostics that merely mention the literal token
-// (e.g. `grep -n "apply_patch" file`) are not misread as write intent, while
-// real env-prefixed invocations (`FOO=bar apply_patch`, `env FOO=bar
-// apply_patch`) stay blocked — mirroring the git commit guard's handling of
-// leading env assignments / `env` wrapper prefixes.
-function commandInvokesApplyPatch(command: string): boolean {
-  return /(?:^|[\n;&|(]|&&|\|\|)\s*(?:env\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s'"]+)\s+)*(?:sudo\s+|command\s+|exec\s+)?apply_patch\b/.test(command);
 }
 
 // Collects same-command literal variable assignments (`NAME="value"`), skipping

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -368,6 +368,28 @@ function tokenizeShellCommandWithBoundaries(commandText: string): ShellToken[] |
       continue;
     }
 
+    // Grouping / command-substitution openers act as command-position
+    // boundaries so the command-head walk resumes after them, mirroring the
+    // legacy `[\n;&|(]` boundary set. This catches a real command immediately
+    // after `(`, `((`, `$(` (command substitution), or a backtick — e.g.
+    // `(apply_patch …)`, `true | (apply_patch …)`, `x=$(apply_patch …)`. We
+    // are outside quotes here, so a literal like `grep "(apply_patch"` is left
+    // intact and not split.
+    if (char === "(" || char === ")" || char === "`") {
+      pushCurrent();
+      nextTokenStartsCommand = true;
+      continue;
+    }
+
+    // `{` is a group opener only as its own word (`{ apply_patch …; }`):
+    // require an empty pending token (preceded by start/whitespace/boundary)
+    // and a following whitespace/newline so brace expansion (`{a,b}`) and
+    // parameter expansion (`${VAR}`) are left intact.
+    if (char === "{" && current === "" && /\s/.test(trimmed[index + 1] ?? " ")) {
+      nextTokenStartsCommand = true;
+      continue;
+    }
+
     if (/\s/.test(char)) {
       pushCurrent();
       continue;

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -325,6 +325,11 @@ function tokenizeShellCommandWithBoundaries(commandText: string): ShellToken[] |
   let quote: "'" | "\"" | null = null;
   let escaping = false;
   let nextTokenStartsCommand = false;
+  // Command substitution executes even inside double quotes, so we track an
+  // active `"$(…)"` (paren depth) or `` "`…`" `` (backtick) substitution to
+  // restore double-quote mode once it closes.
+  let dquoteSubstParenDepth = 0;
+  let backtickFromDquote = false;
 
   const pushCurrent = () => {
     if (!current) return;
@@ -357,6 +362,25 @@ function tokenizeShellCommandWithBoundaries(commandText: string): ShellToken[] |
         if (isDoubleQuotedShellEscapeTarget(trimmed[index + 1])) escaping = true;
         else current += char;
       }
+      // Command substitution runs inside double quotes, so `"$(cmd …)"` and
+      // `` "`cmd …`" `` are real invocations, not literal mentions. Treat the
+      // opener as a command-position boundary and parse the substitution body
+      // unquoted so the command-head walk resumes, then restore double-quote
+      // mode when it closes. Parameter expansion (`${VAR}`), `$HOME`, and an
+      // escaped `\$(` stay literal text (no false positive on `grep "(x"`).
+      else if (char === "$" && trimmed[index + 1] === "(") {
+        pushCurrent();
+        nextTokenStartsCommand = true;
+        index += 1;
+        dquoteSubstParenDepth = 1;
+        quote = null;
+      }
+      else if (char === "`") {
+        pushCurrent();
+        nextTokenStartsCommand = true;
+        backtickFromDquote = true;
+        quote = null;
+      }
       else current += char;
       continue;
     }
@@ -375,9 +399,29 @@ function tokenizeShellCommandWithBoundaries(commandText: string): ShellToken[] |
     // `(apply_patch …)`, `true | (apply_patch …)`, `x=$(apply_patch …)`. We
     // are outside quotes here, so a literal like `grep "(apply_patch"` is left
     // intact and not split.
+    // Closing backtick of a command substitution opened inside double quotes
+    // ends the substitution and restores the surrounding double-quoted literal.
+    if (char === "`" && backtickFromDquote) {
+      pushCurrent();
+      backtickFromDquote = false;
+      quote = "\"";
+      continue;
+    }
+
     if (char === "(" || char === ")" || char === "`") {
       pushCurrent();
       nextTokenStartsCommand = true;
+      // Track paren depth of a `"$(…)"` substitution opened inside double
+      // quotes so the matching `)` restores double-quote mode (nested `$(`
+      // and `(` inside it are balanced before we return to the literal).
+      if (dquoteSubstParenDepth > 0) {
+        if (char === "(") {
+          dquoteSubstParenDepth += 1;
+        } else if (char === ")") {
+          dquoteSubstParenDepth -= 1;
+          if (dquoteSubstParenDepth === 0) quote = "\"";
+        }
+      }
       continue;
     }
 

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -488,6 +488,77 @@ function findGitCommandTokenIndex(tokens: ShellToken[]): number {
   return -1;
 }
 
+const APPLY_PATCH_COMMAND_WRAPPER_TOKENS = new Set(["sudo", "command", "exec"]);
+
+// Detects a real `apply_patch` invocation at a shell command position using the
+// same tokenized command-head walk the git commit guard uses
+// (`findGitCommandTokenIndex`): after every statement boundary skip leading
+// inline `NAME=VALUE` assignments, the `env` executable with its full option
+// grammar (`-i`/`--ignore-environment`, `-u`/`--unset`/`--unset=`, `-C`/`-S`,
+// `--`, interleaved assignments), and `sudo`/`command`/`exec` wrappers — in any
+// order — then match when the resolved command token's basename is
+// `apply_patch`. This blocks path-qualified (`/usr/bin/apply_patch`,
+// `./apply_patch`), env-flag (`env -i apply_patch`, `env -u FOO apply_patch`),
+// and reordered (`FOO=bar env apply_patch`, `exec env FOO=bar apply_patch`)
+// forms, while read-only diagnostics that merely mention the literal token
+// (e.g. `grep -n "apply_patch" file`) are not misread as write intent. Heredoc
+// bodies are stripped first so patch payloads cannot break tokenization.
+export function commandInvokesApplyPatch(command: string): boolean {
+  const tokens = tokenizeShellCommandWithBoundaries(removeHereDocBodies(command));
+  if (!tokens) return false;
+
+  for (let commandStart = 0; commandStart < tokens.length; commandStart = nextCommandStart(tokens, commandStart)) {
+    let index = commandStart;
+    const commandEnd = nextCommandStart(tokens, commandStart);
+
+    let advanced = true;
+    while (advanced && index < commandEnd) {
+      advanced = false;
+
+      while (index < commandEnd && isInlineShellEnvAssignment(tokens[index]?.value ?? "")) {
+        index += 1;
+        advanced = true;
+      }
+
+      while (index < commandEnd && isEnvExecutableToken(tokens[index]?.value ?? "")) {
+        index += 1;
+        advanced = true;
+        while (index < commandEnd) {
+          const token = tokens[index]?.value ?? "";
+          if (token === "--") {
+            index += 1;
+            break;
+          }
+          if (isInlineShellEnvAssignment(token)) {
+            index += 1;
+            continue;
+          }
+          if (token === "-i" || token === "--ignore-environment" || token.startsWith("--unset=")) {
+            index += 1;
+            continue;
+          }
+          if (token.startsWith("-")) {
+            index += envOptionConsumesNextValue(token) ? 2 : 1;
+            continue;
+          }
+          break;
+        }
+      }
+
+      while (index < commandEnd && APPLY_PATCH_COMMAND_WRAPPER_TOKENS.has((tokens[index]?.value ?? "").toLowerCase())) {
+        index += 1;
+        advanced = true;
+      }
+    }
+
+    if (index < commandEnd && shellCommandBasename(tokens[index]?.value ?? "") === "apply_patch") return true;
+    if (commandEnd <= commandStart) break;
+    commandStart = commandEnd - 1;
+  }
+
+  return false;
+}
+
 function tokenValues(tokens: ShellToken[]): string[] {
   return tokens.map((token) => token.value);
 }


### PR DESCRIPTION
## Summary

Fixes two false positives in the deep-interview/RALPLAN PreToolUse Bash write-intent detector reported in #2829. The detector is now target-aware: read-only diagnostics and allowed artifact writes pass, while the planning write boundary stays intact.

### Case A — read-only diagnostics mentioning `apply_patch`
Previously `commandHasDeepInterviewWriteIntent` matched `\bapply_patch\b` anywhere in the command, so a read-only search like `grep -n "apply_patch" dist/scripts/codex-native-hook.js` was misclassified as write intent.

New `commandInvokesApplyPatch` only treats `apply_patch` as write intent when it is the command being invoked at a command position (statement start, or after a `|`/`;`/`&`/`(` boundary, optionally via `sudo`/`command`/`exec`). Real `apply_patch` invocations remain blocked.

### Case B — allowed artifact writes via same-command literal variable redirect
`SNAP=".omx/context/x.md"; cat > "$SNAP"` was blocked because the redirect-target extractor returned the literal `$SNAP`.

New `extractCommandLiteralAssignments` + `resolveCommandRedirectTarget` resolve redirect/tee targets against simple same-command literal assignments before the allowed-prefix check. Values involving expansion (`$`, backticks) are skipped, so unresolved/dynamic targets and redirects to disallowed paths stay conservatively blocked.

## Scope / safety
- Does **not** relax the planning-mode write boundary.
- Real `apply_patch` invocations and redirects to non-artifact paths remain blocked.
- Shared between deep-interview and RALPLAN guards (same helpers), so both modes get the fix.

## Tests
- Added focused tests in `src/scripts/__tests__/codex-native-hook.test.ts`:
  - allows read-only grep mentioning `apply_patch`; blocks a real `apply_patch` Bash invocation.
  - allows variable redirect resolving to `.omx/context/`; blocks variable redirects to disallowed and unresolved targets.
- Full `codex-native-hook.test.ts` suite passes (425/425).
- `biome lint`, `tsc`, `tsc -p tsconfig.no-unused.json`, and `verify:plugin-bundle` all pass.

Closes #2829

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*