### PR TITLE
fix: preserve project Codex transcripts across cleanup

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -52,6 +52,7 @@ import {
   prepareCodexHomeForLaunch,
   persistProjectLaunchRuntimeAuthState,
   persistProjectLaunchRuntimeProjectTrustState,
+  cleanupRuntimeCodexHome,
   runtimeCodexHomePath,
   buildDetachedSessionBootstrapSteps,
   buildDetachedTmuxSessionName,
@@ -2201,6 +2202,90 @@ describe("project launch scope helpers", () => {
         existsSync(join(runtimeCodexHome, "sessions", "2026", "06", "03", "rollout-session-2712.jsonl")),
         true,
       );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("creates durable project Codex transcript links for project launches", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-links-"));
+    try {
+      const projectCodexHome = join(wd, ".codex");
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+
+      const prepared = await prepareCodexHomeForLaunch(wd, "session-history-links", {});
+      const runtimeCodexHome = runtimeCodexHomePath(wd, "session-history-links");
+
+      assert.equal(prepared.codexHomeOverride, runtimeCodexHome);
+      assert.equal((await lstat(join(runtimeCodexHome, "sessions"))).isSymbolicLink(), true);
+      assert.equal((await lstat(join(runtimeCodexHome, "history.jsonl"))).isSymbolicLink(), true);
+      assert.equal((await lstat(join(runtimeCodexHome, "session_index.jsonl"))).isSymbolicLink(), true);
+      await writeFile(
+        join(runtimeCodexHome, "sessions", "linked-rollout.jsonl"),
+        '{"type":"session_meta"}\n',
+      );
+      await writeFile(join(runtimeCodexHome, "history.jsonl"), '{"session_id":"linked"}\n');
+      await writeFile(join(runtimeCodexHome, "session_index.jsonl"), '{"id":"linked"}\n');
+
+      await cleanupRuntimeCodexHome(
+        prepared.runtimeCodexHomeForCleanup,
+        prepared.projectLocalCodexHomeForCleanup,
+      );
+
+      assert.equal(
+        await readFile(join(projectCodexHome, "sessions", "linked-rollout.jsonl"), "utf-8"),
+        '{"type":"session_meta"}\n',
+      );
+      assert.equal(await readFile(join(projectCodexHome, "history.jsonl"), "utf-8"), '{"session_id":"linked"}\n');
+      assert.equal(await readFile(join(projectCodexHome, "session_index.jsonl"), "utf-8"), '{"id":"linked"}\n');
+      assert.equal(existsSync(runtimeCodexHome), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("copies non-symlink runtime Codex transcript artifacts before cleanup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-copyback-"));
+    try {
+      const projectCodexHome = join(wd, ".codex");
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await mkdir(projectCodexHome, { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+
+      const prepared = await prepareCodexHomeForLaunch(wd, "session-history-copyback", {});
+      const runtimeCodexHome = runtimeCodexHomePath(wd, "session-history-copyback");
+      await rm(join(runtimeCodexHome, "sessions"), { recursive: true, force: true });
+      await rm(join(runtimeCodexHome, "history.jsonl"), { force: true });
+      await rm(join(runtimeCodexHome, "session_index.jsonl"), { force: true });
+      await mkdir(join(runtimeCodexHome, "sessions", "2026", "06", "16"), { recursive: true });
+      await writeFile(
+        join(runtimeCodexHome, "sessions", "2026", "06", "16", "rollout-session-2835.jsonl"),
+        '{"type":"session_meta","payload":{"id":"session-2835"}}\n',
+      );
+      await writeFile(join(runtimeCodexHome, "history.jsonl"), '{"session_id":"session-2835"}\n');
+      await writeFile(join(runtimeCodexHome, "session_index.jsonl"), '{"id":"session-2835"}\n');
+      await writeFile(join(runtimeCodexHome, "auth.json"), '{"token":"opaque"}\n');
+
+      await cleanupRuntimeCodexHome(
+        prepared.runtimeCodexHomeForCleanup,
+        prepared.projectLocalCodexHomeForCleanup,
+      );
+
+      assert.equal(
+        await readFile(join(projectCodexHome, "sessions", "2026", "06", "16", "rollout-session-2835.jsonl"), "utf-8"),
+        '{"type":"session_meta","payload":{"id":"session-2835"}}\n',
+      );
+      assert.equal(await readFile(join(projectCodexHome, "history.jsonl"), "utf-8"), '{"session_id":"session-2835"}\n');
+      assert.equal(await readFile(join(projectCodexHome, "session_index.jsonl"), "utf-8"), '{"id":"session-2835"}\n');
+      assert.equal(await readFile(join(projectCodexHome, "auth.json"), "utf-8"), '{"token":"opaque"}\n');
+      assert.equal(existsSync(runtimeCodexHome), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { chmod, mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -79,6 +79,54 @@ if [ -f "$CODEX_HOME/sessions/2026/06/03/rollout-session-2712.jsonl" ]; then ech
       assert.match(result.stdout, /state-present=yes/);
       assert.match(result.stdout, /wal-present=yes/);
       assert.match(result.stdout, /rollout-present=yes/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('persists project-scope runtime Codex transcripts after cleanup', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-project-history-cleanup-'));
+    try {
+      const home = join(wd, 'home');
+      const projectCodexHome = join(wd, '.codex');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await mkdir(join(wd, '.omx'), { recursive: true });
+      await mkdir(projectCodexHome, { recursive: true });
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+      await writeFile(join(projectCodexHome, 'config.toml'), 'model = "gpt-5.5"\n');
+
+      await writeFile(fakeCodexPath, `#!/bin/sh
+mkdir -p "$CODEX_HOME/sessions/2026/06/16"
+printf '{"type":"session_meta","payload":{"id":"session-2835"}}\n' > "$CODEX_HOME/sessions/2026/06/16/rollout-session-2835.jsonl"
+printf '{"session_id":"session-2835"}\n' > "$CODEX_HOME/history.jsonl"
+printf '{"id":"session-2835"}\n' > "$CODEX_HOME/session_index.jsonl"
+printf 'fake-codex:%s\n' "$*"
+`);
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+
+      const result = runOmx(wd, ['resume'], {
+        HOME: home,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      });
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, /fake-codex:resume\b/);
+      assert.equal(
+        await readFile(join(projectCodexHome, 'sessions', '2026', '06', '16', 'rollout-session-2835.jsonl'), 'utf-8'),
+        '{"type":"session_meta","payload":{"id":"session-2835"}}\n',
+      );
+      assert.equal(await readFile(join(projectCodexHome, 'history.jsonl'), 'utf-8'), '{"session_id":"session-2835"}\n');
+      assert.equal(await readFile(join(projectCodexHome, 'session_index.jsonl'), 'utf-8'), '{"id":"session-2835"}\n');
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -823,14 +823,68 @@ const PROJECT_LAUNCH_PERSISTED_RUNTIME_ENTRY_NAMES = new Set([
   "auth.json",
 ]);
 
+const PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES = new Set([
+  "sessions",
+  "history.jsonl",
+  "session_index.jsonl",
+]);
+
 // Mirroring these files into the runtime CODEX_HOME would cause Codex to load
 // them as user-scope config alongside the canonical project-scope copies under
 // <cwd>/.codex, duplicating every native hook and asking the user to re-trust
 // hooks on every launch. See GH issue #2470.
 const PROJECT_LAUNCH_RUNTIME_SKIPPED_ENTRY_NAMES = new Set(["hooks.json"]);
 
+function shouldMirrorProjectLaunchRuntimeEntry(entryName: string, includeHistoryArtifacts: boolean): boolean {
+  if (PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES.has(entryName)) return true;
+  if (isCodexSqliteArtifact(entryName)) return includeHistoryArtifacts;
+  return true;
+}
+
 function shouldPersistProjectLaunchRuntimeEntry(entryName: string): boolean {
   return PROJECT_LAUNCH_PERSISTED_RUNTIME_ENTRY_NAMES.has(entryName);
+}
+
+async function persistProjectLaunchRuntimeHistoryArtifacts(
+  runtimeCodexHome: string | undefined,
+  projectCodexHome: string | undefined,
+): Promise<void> {
+  if (!runtimeCodexHome || !projectCodexHome) return;
+  if (!existsSync(runtimeCodexHome)) return;
+  await mkdir(projectCodexHome, { recursive: true });
+
+  for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
+    const source = join(runtimeCodexHome, entryName);
+    if (!existsSync(source)) continue;
+    const sourceStat = await lstat(source);
+    if (sourceStat.isSymbolicLink()) continue;
+    const destination = join(projectCodexHome, entryName);
+    if (sourceStat.isDirectory()) {
+      await cp(source, destination, { recursive: true, force: true, verbatimSymlinks: true });
+      continue;
+    }
+    if (sourceStat.isFile()) {
+      await copyFile(source, destination);
+    }
+  }
+}
+
+async function ensureProjectLaunchRuntimeHistoryLinks(
+  runtimeCodexHome: string,
+  projectCodexHome: string,
+): Promise<void> {
+  await mkdir(projectCodexHome, { recursive: true });
+  for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
+    const runtimeEntry = join(runtimeCodexHome, entryName);
+    if (existsSync(runtimeEntry)) continue;
+    const projectEntry = join(projectCodexHome, entryName);
+    if (entryName === "sessions") {
+      await mkdir(projectEntry, { recursive: true });
+    } else if (!existsSync(projectEntry)) {
+      await writeFile(projectEntry, "");
+    }
+    await linkOrCopyCodexHomeEntry(projectEntry, runtimeEntry);
+  }
 }
 
 export async function persistProjectLaunchRuntimeAuthState(
@@ -867,10 +921,13 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
   await rm(runtimeCodexHome, { recursive: true, force: true });
   await mkdir(runtimeCodexHome, { recursive: true });
 
-  if (!existsSync(projectCodexHome)) return runtimeCodexHome;
+  if (!existsSync(projectCodexHome)) {
+    await ensureProjectLaunchRuntimeHistoryLinks(runtimeCodexHome, projectCodexHome);
+    return runtimeCodexHome;
+  }
 
   for (const entry of await readdir(projectCodexHome, { withFileTypes: true })) {
-    if (isCodexSqliteArtifact(entry.name) && !options.includeHistoryArtifacts) continue;
+    if (!shouldMirrorProjectLaunchRuntimeEntry(entry.name, options.includeHistoryArtifacts === true)) continue;
     if (PROJECT_LAUNCH_RUNTIME_SKIPPED_ENTRY_NAMES.has(entry.name)) continue;
     const source = join(projectCodexHome, entry.name);
     const destination = join(runtimeCodexHome, entry.name);
@@ -889,6 +946,8 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
     }
     await linkOrCopyCodexHomeEntry(source, destination);
   }
+  await ensureProjectLaunchRuntimeHistoryLinks(runtimeCodexHome, projectCodexHome);
+
 
   return runtimeCodexHome;
 }
@@ -964,6 +1023,10 @@ export async function cleanupRuntimeCodexHome(
 ): Promise<void> {
   if (!runtimeCodexHomeForCleanup) return;
   await persistProjectLaunchRuntimeAuthState(
+    runtimeCodexHomeForCleanup,
+    projectCodexHomeForPersistence,
+  );
+  await persistProjectLaunchRuntimeHistoryArtifacts(
     runtimeCodexHomeForCleanup,
     projectCodexHomeForPersistence,
   );


### PR DESCRIPTION
Fixes #2835.

## Summary
- Keeps project-scope Codex transcript/history artifacts durable when launching through a per-session runtime CODEX_HOME.
- Creates runtime links/fallback copies for sessions/, history.jsonl, and session_index.jsonl so writes land in <repo>/.codex during normal project launches.
- Copies non-symlink runtime transcript/history artifacts back to project .codex before cleanup, while preserving existing auth/trust persistence behavior and avoiding symlink copy-over-self.

## Verification
- npm run build
- node dist/scripts/run-test-files.js dist/cli/__tests__/index.test.js dist/cli/__tests__/resume.test.js
- npm run lint
- npm run check:no-unused

## Review notes
- Architect review subagent exceeded bounded wait and was cancelled as a non-blocking review timeout; I performed a focused diff review against the acceptance criteria before commit.
- QA subagent output was unavailable due a schema/EOF error, so QA evidence is the focused regression tests and manual acceptance review above.

## Residual risk
- Low: durability now covers the reported project-scope runtime CODEX_HOME paths, but behavior still depends on filesystem symlink support falling back to copy when symlinks are unavailable.