### PR TITLE
[codex] Warn about external Codex MCP process guards

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -20,6 +20,7 @@ import {
 } from "./packaged-explore-harness-lock.js";
 import {
 	checkExploreHarness,
+	checkExternalCodexProcessGuards,
 	checkNativeHookDistSmoke,
 	classifyPostCompactHookStdout,
 } from "../doctor.js";
@@ -155,6 +156,69 @@ function buildHooksJsonWithPostCompactCommand(
 }
 
 describe("omx doctor onboarding warning copy", () => {
+	it("warns about external LaunchAgents that kill Codex app-server MCP children", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-external-guard-"));
+		try {
+			const home = join(wd, "home");
+			const launchAgentsDir = join(home, "Library", "LaunchAgents");
+			const scriptsDir = join(home, ".omx", "scripts");
+			const scriptPath = join(scriptsDir, "codex_mcp_child_guard.sh");
+			await mkdir(launchAgentsDir, { recursive: true });
+			await mkdir(scriptsDir, { recursive: true });
+			await writeFile(
+				scriptPath,
+				[
+					"#!/usr/bin/env bash",
+					"CODEX_MCP_GUARD_DEDUPE_APP_CHILDREN=1",
+					"app_pid=123",
+					"pgrep -P \"$app_pid\"",
+					"kill 456",
+					"",
+				].join("\n"),
+			);
+			await writeFile(
+				join(launchAgentsDir, "com.example.codex-mcp-child-guard.plist"),
+				[
+					'<?xml version="1.0" encoding="UTF-8"?>',
+					'<plist version="1.0">',
+					"<dict>",
+					"<key>Label</key>",
+					"<string>com.example.codex-mcp-child-guard</string>",
+					"<key>ProgramArguments</key>",
+					"<array>",
+					`<string>${scriptPath}</string>`,
+					"<string>cleanup</string>",
+					"</array>",
+					"</dict>",
+					"</plist>",
+					"",
+				].join("\n"),
+			);
+
+			const check = await checkExternalCodexProcessGuards({
+				platform: "darwin",
+				homeDir: home,
+			});
+
+			assert.ok(check);
+			assert.equal(check.name, "External process guards");
+			assert.equal(check.status, "warn");
+			assert.match(check.message, /com\.example\.codex-mcp-child-guard/);
+			assert.match(check.message, /Codex app-server MCP child dedupe/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("skips external process guard checks outside macOS", async () => {
+		const check = await checkExternalCodexProcessGuards({
+			platform: "linux",
+			homeDir: "/tmp/unused",
+		});
+
+		assert.equal(check, null);
+	});
+
 	it("warns that the built-in explore harness is not ready on Windows", () => {
 		const check = checkExploreHarness("win32", {} as NodeJS.ProcessEnv);
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -297,6 +297,10 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 	// Check 4.6: Lore commit guard default
 	checks.push(await checkLoreCommitGuard(paths.configPath));
 
+	// Check 4.7: External process guards
+	const externalProcessGuardCheck = await checkExternalCodexProcessGuards();
+	if (externalProcessGuardCheck) checks.push(externalProcessGuardCheck);
+
 	// Check 5: Prompts installed
 	checks.push(
 		await checkPrompts(paths.promptsDir, scopeResolution.installMode),
@@ -1153,6 +1157,120 @@ function isExplicitLoreCommitGuardOptOut(value: string): boolean {
 	return LORE_COMMIT_GUARD_EXPLICIT_OPT_OUT_VALUES.has(
 		value.trim().toLowerCase(),
 	);
+}
+
+interface ExternalCodexProcessGuardOptions {
+	platform?: NodeJS.Platform;
+	homeDir?: string;
+}
+
+function extractPlistStrings(content: string): string[] {
+	return [...content.matchAll(/<string>([^<]+)<\/string>/g)].map((match) =>
+		match[1]?.trim() ?? "",
+	);
+}
+
+function extractPlistLabel(content: string, fallback: string): string {
+	const labelMatch = content.match(
+		/<key>Label<\/key>\s*<string>([^<]+)<\/string>/,
+	);
+	return labelMatch?.[1]?.trim() || fallback;
+}
+
+async function readExistingTextFile(path: string): Promise<string> {
+	try {
+		return await readFile(path, "utf-8");
+	} catch {
+		return "";
+	}
+}
+
+function classifyExternalCodexProcessGuard(
+	plistContent: string,
+	combinedContent: string,
+): string | null {
+	const lowerPlist = plistContent.toLowerCase();
+	const lower = combinedContent.toLowerCase();
+	if (
+		lower.includes("codex-mcp-child-guard") ||
+		lower.includes("codex_mcp_child_guard") ||
+		combinedContent.includes("CODEX_MCP_GUARD_DEDUPE_APP_CHILDREN") ||
+		(lower.includes("codex app-server") &&
+			lower.includes("pgrep -p") &&
+			lower.includes("kill"))
+	) {
+		return "Codex app-server MCP child dedupe";
+	}
+	if (
+		(lowerPlist.includes("codex-xcode-mcp-guard") ||
+			lowerPlist.includes("codex_xcode_mcp_guard")) &&
+		lower.includes("xcodebuildmcp") &&
+		lower.includes("kill")
+	) {
+		return "XcodeBuildMCP cleanup";
+	}
+	return null;
+}
+
+export async function checkExternalCodexProcessGuards(
+	options: ExternalCodexProcessGuardOptions = {},
+): Promise<Check | null> {
+	const platform = options.platform ?? process.platform;
+	if (platform !== "darwin") return null;
+
+	const homeDir = options.homeDir ?? process.env.HOME;
+	if (!homeDir) return null;
+
+	const launchAgentsDir = join(homeDir, "Library", "LaunchAgents");
+	if (!existsSync(launchAgentsDir)) return null;
+
+	let entries: string[];
+	try {
+		entries = await readdir(launchAgentsDir);
+	} catch {
+		return null;
+	}
+
+	const findings: string[] = [];
+	for (const entry of entries) {
+		if (!entry.endsWith(".plist")) continue;
+		const plistPath = join(launchAgentsDir, entry);
+		const plistContent = await readExistingTextFile(plistPath);
+		if (plistContent.trim() === "") continue;
+
+		const loweredPlist = plistContent.toLowerCase();
+		if (
+			!loweredPlist.includes("codex") &&
+			!loweredPlist.includes("mcp") &&
+			!loweredPlist.includes("omx")
+		) {
+			continue;
+		}
+
+		let combinedContent = plistContent;
+		for (const value of extractPlistStrings(plistContent)) {
+			if (!value.startsWith("/")) continue;
+			if (!existsSync(value)) continue;
+			combinedContent += `\n${await readExistingTextFile(value)}`;
+		}
+
+		const reason = classifyExternalCodexProcessGuard(
+			plistContent,
+			combinedContent,
+		);
+		if (!reason) continue;
+
+		const label = extractPlistLabel(plistContent, entry);
+		findings.push(`${label} (${reason})`);
+	}
+
+	if (findings.length === 0) return null;
+
+	return {
+		name: "External process guards",
+		status: "warn",
+		message: `external LaunchAgent(s) may terminate Codex/MCP helper processes outside OMX setup ownership: ${findings.join(", ")}; unload/remove them before attributing SIGTERM or transport resets to standard OMX MCP configuration`,
+	};
 }
 
 interface NativeHookCheckContext {


### PR DESCRIPTION
## Summary

- Adds an `omx doctor` warning for macOS LaunchAgents that can terminate Codex/MCP helper processes outside OMX setup ownership.
- Detects the observed Codex app-server MCP child dedupe guard pattern and explicit XcodeBuildMCP cleanup guards.
- Adds regression coverage using an isolated temporary HOME and fake LaunchAgent/script fixtures.

## Root Cause

A local external LaunchAgent can kill Codex app-server MCP child processes while standard OMX MCP configuration still looks healthy. Before this change, `omx doctor` could report a healthy OMX install while SIGTERM or transport resets were actually caused by out-of-band process cleanup.

## Validation

- `npm run build`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/doctor-warning-copy.test.js`
- `npm run lint`
- `node dist/cli/omx.js doctor`
