### PR TITLE
Fix Codex 0.140 hooks.json state compatibility

### DIFF
--- a/src/cli/__tests__/doctor-invalid-config.test.ts
+++ b/src/cli/__tests__/doctor-invalid-config.test.ts
@@ -63,4 +63,50 @@ theme = "base16-ocean-light"
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('fails when hooks.json contains Codex 0.140-incompatible top-level state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-hooks-json-state-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(
+        join(codexDir, 'config.toml'),
+        'omx_enabled = true\nhooks = true\n',
+      );
+      await writeFile(
+        join(codexDir, 'hooks.json'),
+        JSON.stringify({
+          state: {
+            '/tmp/hooks.json:stop:0:0': { trusted_hash: 'sha256:legacy' },
+          },
+          hooks: {
+            SessionStart: [{ hooks: [{ type: 'command', command: 'node /repo/dist/scripts/codex-native-hook.js' }] }],
+            PreToolUse: [{ hooks: [{ type: 'command', command: 'node /repo/dist/scripts/codex-native-hook.js' }] }],
+            PostToolUse: [{ hooks: [{ type: 'command', command: 'node /repo/dist/scripts/codex-native-hook.js' }] }],
+            UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'node /repo/dist/scripts/codex-native-hook.js' }] }],
+            PreCompact: [{ hooks: [{ type: 'command', command: 'node /repo/dist/scripts/codex-native-hook.js' }] }],
+            PostCompact: [{ hooks: [{ type: 'command', command: 'node /repo/dist/scripts/codex-native-hook.js' }] }],
+            Stop: [{ hooks: [{ type: 'command', command: 'node /repo/dist/scripts/codex-native-hook.js' }] }],
+          },
+        }),
+      );
+
+      const res = runOmx(wd, ['doctor'], {
+        HOME: home,
+        CODEX_HOME: codexDir,
+      });
+
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(
+        res.stdout,
+        /\[XX\] Native hooks: top-level state in hooks\.json is incompatible with Codex 0\.140/,
+      );
+      assert.match(res.stdout, /unknown field state, expected hooks/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -355,6 +355,68 @@ describe("omx setup scope behavior", () => {
     }
   });
 
+  it("migrates legacy hooks.json state to config.toml and removes Codex-incompatible top-level state", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-hooks-state-migration-"));
+    try {
+      const home = join(wd, "home");
+      const codexDir = join(wd, ".codex");
+      await mkdir(home, { recursive: true });
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(
+        join(codexDir, "hooks.json"),
+        JSON.stringify(
+          {
+            state: {
+              "custom:/hooks.json:stop:0:0": {
+                trusted_hash: "sha256:user",
+                enabled: false,
+              },
+            },
+            hooks: {
+              Stop: [
+                {
+                  hooks: [
+                    {
+                      type: "command",
+                      command: 'node "/old/dist/scripts/codex-native-hook.js"',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        ) + "\n",
+      );
+      await writeFile(join(codexDir, "config.toml"), "omx_enabled = true\n");
+
+      const res = runOmx(wd, ["setup", "--scope", "project"], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+
+      const hooksJson = JSON.parse(
+        await readFile(join(codexDir, "hooks.json"), "utf-8"),
+      ) as {
+        state?: unknown;
+        hooks?: Record<string, unknown>;
+      };
+      assert.equal(Object.hasOwn(hooksJson, "state"), false);
+      assert.equal(Object.hasOwn(hooksJson.hooks ?? {}, "state"), false);
+      assert.ok(hooksJson.hooks?.Stop, "managed setup should preserve Stop coverage");
+
+      const configToml = await readFile(join(codexDir, "config.toml"), "utf-8");
+      assert.match(
+        configToml,
+        /^\[hooks\.state\."custom:\/hooks\.json:stop:0:0"\]$/m,
+      );
+      assert.match(configToml, /^trusted_hash = "sha256:user"$/m);
+      assert.match(configToml, /^enabled = false$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("defaults to user scope in non-interactive runs when no scope is persisted", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-scope-"));
     try {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -39,6 +39,7 @@ import {
 	discoverCodexHookConfigPaths,
 	getManagedCodexHookCommandsForEvent,
 	getMissingManagedCodexHookEvents,
+	hasCodexHooksJsonTopLevelState,
 } from "../config/codex-hooks.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { getDefaultBridge, isBridgeEnabled } from "../runtime/bridge.js";
@@ -1409,6 +1410,15 @@ async function checkNativeHooks(
 				status: "fail",
 				message:
 					'invalid hooks.json; Codex may skip OMX hook coverage until "omx setup --force" repairs it',
+			};
+		}
+		const hasTopLevelState = hasCodexHooksJsonTopLevelState(content);
+		if (hasTopLevelState === true) {
+			return {
+				name: "Native hooks",
+				status: "fail",
+				message:
+					'top-level state in hooks.json is incompatible with Codex 0.140 (unknown field state, expected hooks); run "omx setup --force" to migrate trust state to config.toml and repair hooks.json',
 			};
 		}
 

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -61,6 +61,7 @@ import {
 	buildManagedCodexNativeHookWindowsShimContent,
 	buildManagedCodexNativeHookWindowsShimPath,
 	mergeManagedCodexHooksConfig,
+	extractCodexHooksJsonTrustState,
 	removeManagedCodexHooks,
 } from "../config/codex-hooks.js";
 import {
@@ -423,6 +424,86 @@ function getBackupContext(
 		backupRoot: join(homedir(), ".omx", "backups", "setup", timestamp),
 		baseRoot: homedir(),
 	};
+}
+
+function escapeTomlBasicString(value: string): string {
+	return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function renderHooksJsonTrustStateToml(content: string | null | undefined): string {
+	const trustState = extractCodexHooksJsonTrustState(content);
+	return Object.entries(trustState)
+		.sort(([left], [right]) => left.localeCompare(right))
+		.flatMap(([key, state]) => [
+			`[hooks.state."${escapeTomlBasicString(key)}"]`,
+			`trusted_hash = "${escapeTomlBasicString(state.trusted_hash)}"`,
+			...(typeof state.enabled === "boolean" ? [`enabled = ${state.enabled}`] : []),
+			"",
+		])
+		.join("\n")
+		.trimEnd();
+}
+
+function existingHooksStateKeys(config: string): Set<string> {
+	try {
+		const parsed = TOML.parse(config) as {
+			hooks?: { state?: Record<string, unknown> };
+		};
+		return new Set(Object.keys(parsed.hooks?.state ?? {}));
+	} catch {
+		return new Set();
+	}
+}
+function appendHooksJsonTrustStateToConfig(
+	config: string,
+	hooksContent: string | null | undefined,
+): string {
+	const existingKeys = existingHooksStateKeys(config);
+	const trustState = extractCodexHooksJsonTrustState(hooksContent);
+	const migratableContent = JSON.stringify({
+		state: Object.fromEntries(
+			Object.entries(trustState).filter(([key]) => !existingKeys.has(key)),
+		),
+	});
+	const trustToml = renderHooksJsonTrustStateToml(migratableContent);
+	if (!trustToml) return config;
+	const base = config.trimEnd();
+	return [
+		base,
+		base ? "" : null,
+		"# Migrated from legacy hooks.json state; kept in Codex config.toml because Codex 0.140 rejects top-level hooks.json state.",
+		trustToml,
+		"",
+	].filter((line): line is string => line !== null).join("\n");
+}
+
+async function migrateLegacyHooksJsonTrustStateToConfig(
+	configPath: string,
+	hooksContent: string | null | undefined,
+	backupContext: SetupBackupContext,
+	summary: SetupCategorySummary,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
+): Promise<void> {
+	const existingConfig = existsSync(configPath)
+		? await readFile(configPath, "utf-8")
+		: "";
+	const nextConfig = appendHooksJsonTrustStateToConfig(existingConfig, hooksContent);
+	if (nextConfig === existingConfig) return;
+	if (
+		await ensureBackup(configPath, existsSync(configPath), backupContext, options)
+	) {
+		summary.backedUp += 1;
+	}
+	if (!options.dryRun) {
+		await mkdir(dirname(configPath), { recursive: true });
+		await writeFile(configPath, nextConfig);
+	}
+	summary.updated += 1;
+	if (options.verbose) {
+		console.log(
+			`  ${options.dryRun ? "would migrate" : "migrated"} legacy hooks.json trust state to ${configPath}`,
+		);
+	}
 }
 
 async function ensureBackup(
@@ -1797,6 +1878,13 @@ async function applyPluginModeHooksConfig(
 	const existingHooksContent = existsSync(hooksPath)
 		? await readFile(hooksPath, "utf-8")
 		: null;
+	await migrateLegacyHooksJsonTrustStateToConfig(
+		configPath,
+		existingHooksContent,
+		backupContext,
+		summary,
+		options,
+	);
 	if (options.pluginScopedHooks) {
 		await cleanupPluginModeManagedHooksJson(
 			existingHooksContent,
@@ -2582,6 +2670,13 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		const existingHooksContent = existsSync(scopeDirs.codexHooksFile)
 			? await readFile(scopeDirs.codexHooksFile, "utf-8")
 			: null;
+		await migrateLegacyHooksJsonTrustStateToConfig(
+			scopeDirs.codexConfigFile,
+			existingHooksContent,
+			backupContext,
+			summary.config,
+			{ dryRun, verbose },
+		);
 		const hooksConfig = mergeManagedCodexHooksConfig(
 			existingHooksContent,
 			pkgRoot,

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -11,6 +11,8 @@ import {
   buildManagedCodexHookTrustState,
   buildManagedCodexHookTrustToml,
   buildManagedCodexHooksConfig,
+  extractCodexHooksJsonTrustState,
+  hasCodexHooksJsonTopLevelState,
   discoverCodexHookConfigPaths,
   dedupeCodexHookConfigPaths,
   getMissingManagedCodexHookEvents,
@@ -366,7 +368,7 @@ describe("codex hooks helpers", () => {
     assert.doesNotMatch(toml, /echo keep-me/);
   });
 
-  it("keeps hooks.json trust state outside the hook event map", () => {
+  it("keeps hooks.json trust state out of Codex-facing output", () => {
     const merged = JSON.parse(
       mergeManagedCodexHooksConfig(
         JSON.stringify({
@@ -394,31 +396,53 @@ describe("codex hooks helpers", () => {
         "/hooks.json",
       ),
     ) as {
-      state: Record<string, { trusted_hash?: string; enabled?: boolean }>;
+      state?: Record<string, { trusted_hash?: string; enabled?: boolean }>;
       hooks: Record<string, Array<{ hooks?: Array<{ command?: string }> }>>;
     };
 
+    assert.equal(Object.hasOwn(merged, "state"), false);
     assert.equal(Object.hasOwn(merged.hooks, "state"), false);
     assert.ok(
       Object.values(merged.hooks).every(Array.isArray),
-      "Codex Rust hook discovery expects hooks.hooks values to be event arrays",
-    );
-    assert.deepEqual(merged.state["custom:/hooks.json:stop:0:0"], {
-      trusted_hash: "sha256:user",
-      enabled: false,
-    });
-    assert.deepEqual(merged.state["custom:/hooks.json:prompt:0:0"], {
-      trusted_hash: "sha256:top-level-user",
-      enabled: true,
-    });
-    assert.match(
-      merged.state["/hooks.json:stop:0:0"]?.trusted_hash ?? "",
-      /^sha256:[a-f0-9]{64}$/,
+      "Codex Rust hook discovery expects all hooks values to be event arrays",
     );
     assert.match(JSON.stringify(merged.hooks.Stop), /echo user-stop/);
   });
 
-  it("preserves top-level managed hook state metadata while updating trusted_hash", () => {
+  it("extracts legacy hooks.json trust state for migration before merge", () => {
+    const content = JSON.stringify({
+      state: {
+        "custom:/hooks.json:prompt:0:0": {
+          trusted_hash: "sha256:top-level-user",
+          enabled: true,
+        },
+      },
+      hooks: {
+        state: {
+          "custom:/hooks.json:stop:0:0": {
+            trusted_hash: "sha256:user",
+            enabled: false,
+          },
+          malformed: { enabled: true },
+        },
+      },
+    });
+
+    assert.equal(hasCodexHooksJsonTopLevelState(content), true);
+    assert.deepEqual(extractCodexHooksJsonTrustState(content), {
+      "custom:/hooks.json:stop:0:0": {
+        trusted_hash: "sha256:user",
+        enabled: false,
+      },
+      "custom:/hooks.json:prompt:0:0": {
+        trusted_hash: "sha256:top-level-user",
+        enabled: true,
+      },
+    });
+  });
+
+
+  it("drops top-level managed hook state metadata from hooks.json", () => {
     const managedState = buildManagedCodexHookTrustState("/hooks.json", "/repo");
     const managedKey = Object.keys(managedState).find((key) =>
       key.includes(":stop:"),
@@ -439,18 +463,16 @@ describe("codex hooks helpers", () => {
         "/hooks.json",
       ),
     ) as {
-      state: Record<string, { trusted_hash?: string; enabled?: boolean }>;
+      state?: Record<string, { trusted_hash?: string; enabled?: boolean }>;
       hooks: Record<string, unknown>;
     };
 
+    assert.equal(Object.hasOwn(merged, "state"), false);
     assert.equal(Object.hasOwn(merged.hooks, "state"), false);
-    assert.deepEqual(merged.state[managedKey], {
-      trusted_hash: managedState[managedKey]?.trusted_hash,
-      enabled: false,
-    });
   });
 
-  it("migrates misplaced managed hook state metadata while updating trusted_hash", () => {
+
+  it("drops misplaced managed hook state metadata from hooks.json", () => {
     const managedState = buildManagedCodexHookTrustState("/hooks.json", "/repo");
     const managedKey = Object.keys(managedState).find((key) =>
       key.includes(":stop:"),
@@ -473,16 +495,14 @@ describe("codex hooks helpers", () => {
         "/hooks.json",
       ),
     ) as {
-      state: Record<string, { trusted_hash?: string; enabled?: boolean }>;
+      state?: Record<string, { trusted_hash?: string; enabled?: boolean }>;
       hooks: Record<string, unknown>;
     };
 
+    assert.equal(Object.hasOwn(merged, "state"), false);
     assert.equal(Object.hasOwn(merged.hooks, "state"), false);
-    assert.deepEqual(merged.state[managedKey], {
-      trusted_hash: managedState[managedKey]?.trusted_hash,
-      enabled: false,
-    });
   });
+
 
   it("keeps managed hook merge idempotent", () => {
     const first = mergeManagedCodexHooksConfig(null, "/repo", "/hooks.json");
@@ -587,10 +607,8 @@ describe("codex hooks helpers", () => {
       state?: Record<string, { trusted_hash?: string }>;
       hooks?: Record<string, unknown>;
     };
+    assert.equal(Object.hasOwn(cleaned, "state"), false);
     assert.equal(Object.hasOwn(cleaned.hooks ?? {}, "state"), false);
-    assert.deepEqual(cleaned.state?.["custom:/hooks.json:session_start:0:0"], {
-      trusted_hash: "sha256:user",
-    });
   });
 
   it("detects user hooks that remain after managed wrapper removal", () => {

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -44,6 +44,11 @@ export interface ManagedCodexHookTrustState {
   trusted_hash: string;
 }
 
+export interface CodexHooksJsonTrustStateEntry {
+  trusted_hash: string;
+  enabled?: boolean;
+}
+
 export interface DedupedCodexHookConfigPath {
   path: string;
   reason: "unique";
@@ -619,6 +624,42 @@ export async function discoverCodexHookConfigPaths(
   return dedupeCodexHookConfigPaths(candidates, root);
 }
 
+function collectTrustStateEntries(
+  value: unknown,
+): Record<string, CodexHooksJsonTrustStateEntry> {
+  if (!isPlainObject(value)) return {};
+
+  const entries: Record<string, CodexHooksJsonTrustStateEntry> = {};
+  for (const [key, rawEntry] of Object.entries(value)) {
+    if (!isPlainObject(rawEntry) || typeof rawEntry.trusted_hash !== "string") {
+      continue;
+    }
+    entries[key] = {
+      trusted_hash: rawEntry.trusted_hash,
+      ...(typeof rawEntry.enabled === "boolean" ? { enabled: rawEntry.enabled } : {}),
+    };
+  }
+  return entries;
+}
+
+export function extractCodexHooksJsonTrustState(
+  content: string | null | undefined,
+): Record<string, CodexHooksJsonTrustStateEntry> {
+  if (typeof content !== "string") return {};
+  const parsed = parseCodexHooksConfig(content);
+  if (!parsed) return {};
+  return {
+    ...collectTrustStateEntries(parsed.hooks.state),
+    ...collectTrustStateEntries(parsed.root.state),
+  };
+}
+
+export function hasCodexHooksJsonTopLevelState(content: string): boolean | null {
+  const parsed = parseCodexHooksConfig(content);
+  if (!parsed) return null;
+  return Object.hasOwn(parsed.root, "state");
+}
+
 export function mergeManagedCodexHooksConfig(
   existingContent: string | null | undefined,
   pkgRoot: string,
@@ -643,9 +684,7 @@ export function mergeManagedCodexHooksConfig(
 
   const nextRoot = parsed ? cloneJson(parsed.root) : {};
   const nextHooks = parsed ? cloneJson(parsed.hooks) : {};
-  const misplacedHookState = isPlainObject(nextHooks.state)
-    ? cloneJson(nextHooks.state)
-    : {};
+  delete nextRoot.state;
   delete nextHooks.state;
 
   for (const eventName of MANAGED_HOOK_EVENTS) {
@@ -667,31 +706,6 @@ export function mergeManagedCodexHooksConfig(
     ];
   }
 
-  const existingRootState = isPlainObject(nextRoot.state)
-    ? cloneJson(nextRoot.state)
-    : {};
-  const nextState = {
-    ...misplacedHookState,
-    ...existingRootState,
-  };
-
-  const managedTrustState = hooksPath
-    ? buildManagedCodexHookTrustState(hooksPath, pkgRoot, resolvedOptions)
-    : {};
-  for (const [key, hookState] of Object.entries(managedTrustState)) {
-    const existingHookState = isPlainObject(nextState[key])
-      ? nextState[key]
-      : {};
-    nextState[key] = {
-      ...existingHookState,
-      trusted_hash: hookState.trusted_hash,
-    };
-  }
-  if (Object.keys(nextState).length > 0) {
-    nextRoot.state = nextState;
-  } else if (isPlainObject(nextRoot.state)) {
-    delete nextRoot.state;
-  }
 
   if (Object.keys(nextHooks).length > 0) {
     nextRoot.hooks = nextHooks;
@@ -712,9 +726,7 @@ export function removeManagedCodexHooks(
 
   const nextRoot = cloneJson(parsed.root);
   const nextHooks = cloneJson(parsed.hooks);
-  const misplacedHookState = isPlainObject(nextHooks.state)
-    ? cloneJson(nextHooks.state)
-    : {};
+  delete nextRoot.state;
   delete nextHooks.state;
   let removedCount = 0;
 
@@ -742,23 +754,6 @@ export function removeManagedCodexHooks(
   }
 
   const hasRemainingHookEntries = Object.keys(nextHooks).length > 0;
-  if (hasRemainingHookEntries) {
-    const existingRootState = isPlainObject(nextRoot.state)
-      ? cloneJson(nextRoot.state)
-      : {};
-    const nextState = {
-      ...misplacedHookState,
-      ...existingRootState,
-    };
-    if (Object.keys(nextState).length > 0) {
-      nextRoot.state = nextState;
-    } else if (isPlainObject(nextRoot.state)) {
-      delete nextRoot.state;
-    }
-  } else {
-    delete nextRoot.state;
-  }
-
   if (hasRemainingHookEntries) {
     nextRoot.hooks = nextHooks;
   } else {


### PR DESCRIPTION
## Summary
- remove top-level `state` and misplaced `hooks.state` from Codex-facing `hooks.json` merge/uninstall output
- migrate legacy `hooks.json` trust/hash state into `[hooks.state.*]` tables in `config.toml` during setup so trust metadata is not silently lost
- make `omx doctor` fail with explicit Codex 0.140 guidance when `hooks.json` still contains top-level `state`

## Changed files
- `src/config/codex-hooks.ts`
- `src/cli/setup.ts`
- `src/cli/doctor.ts`
- `src/config/__tests__/codex-hooks.test.ts`
- `src/cli/__tests__/setup-scope.test.ts`
- `src/cli/__tests__/doctor-invalid-config.test.ts`

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/config/__tests__/codex-hooks.test.js dist/cli/__tests__/doctor-invalid-config.test.js dist/cli/__tests__/setup-scope.test.js` (42 tests passed)
- `git diff --check -- src/cli/__tests__/doctor-invalid-config.test.ts src/cli/__tests__/setup-scope.test.ts src/cli/doctor.ts src/cli/setup.ts src/config/__tests__/codex-hooks.test.ts src/config/codex-hooks.ts`

## QA result
- Executor QA/red-team passed: contract coverage for no Codex-facing root state, setup migration preserving trust metadata, and doctor schema-mismatch detection all passed against the focused compiled tests.

## Review note
- Architect review subagents were given bounded waits but did not return a concrete blocker; recorded as a non-blocking bounded review timeout risk. I completed a focused diff review against the changed files and acceptance contract.

## Residual risks
- Did not run a live Codex 0.140 binary; coverage is via generated schema shape, doctor regression, and the reported runtime error path.

Fixes #2841

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*