### PR TITLE
ci: move workflows to GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   changes:
     name: Detect CI lanes
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
       full_suite: ${{ steps.classify.outputs.full_suite }}
@@ -214,7 +214,7 @@ jobs:
 
   docs-check:
     name: Docs Check
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [changes]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.docs_changed == 'true' }}
@@ -225,7 +225,7 @@ jobs:
 
   rustfmt:
     name: Rust Format
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [changes]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.native_changed == 'true' }}
@@ -241,13 +241,13 @@ jobs:
 
   clippy:
     name: Rust Clippy
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [changes]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.native_changed == 'true' }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install self-hosted Rust build prerequisites
+      - name: Install Rust build prerequisites
         run: .github/scripts/install-prereqs.sh build-essential -- cc
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@v1
@@ -261,13 +261,13 @@ jobs:
 
   rust-tests:
     name: Rust Tests + Coverage Signal
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: [changes]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.native_changed == 'true' }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install self-hosted Rust build prerequisites
+      - name: Install Rust build prerequisites
         run: .github/scripts/install-prereqs.sh build-essential -- cc
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@v1
@@ -304,7 +304,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [changes]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
@@ -319,7 +319,7 @@ jobs:
 
   typecheck:
     name: Typecheck
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     needs: [changes]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
@@ -335,7 +335,7 @@ jobs:
 
   build-dist:
     name: Build dist artifact
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     needs: [changes]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.native_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
@@ -408,7 +408,7 @@ jobs:
             catalog-check: false
     steps:
       - uses: actions/checkout@v4
-      - name: Install self-hosted test prerequisites
+      - name: Install test prerequisites
         run: .github/scripts/install-prereqs.sh build-essential tmux -- cc tmux
       - name: Setup Rust for harness-backed Node tests
         uses: dtolnay/rust-toolchain@v1
@@ -461,7 +461,7 @@ jobs:
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install self-hosted test prerequisites
+      - name: Install test prerequisites
         run: .github/scripts/install-prereqs.sh tmux -- tmux
       - uses: actions/setup-node@v6
         with:
@@ -501,7 +501,7 @@ jobs:
 
   ralph-persistence-gate:
     name: Ralph Persistence Gate
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [changes, build-dist]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
@@ -522,13 +522,13 @@ jobs:
 
   build:
     name: Build (Full Source Build)
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: [changes, build-dist]
     if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.native_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install self-hosted Rust build prerequisites
+      - name: Install Rust build prerequisites
         run: .github/scripts/install-prereqs.sh build-essential -- cc
       - uses: actions/setup-node@v6
         with:
@@ -553,7 +553,7 @@ jobs:
   ci-status:
     name: CI Status
     if: always()
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'gajae-layofflabs-2' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [changes, docs-check, rustfmt, clippy, rust-tests, lint, typecheck, build-dist, test, coverage-team-critical, ralph-persistence-gate, build]
     steps:

--- a/.github/workflows/dev-merge-issue-close.yml
+++ b/.github/workflows/dev-merge-issue-close.yml
@@ -12,7 +12,7 @@ jobs:
   close-linked-issues:
     name: Close explicitly linked issues after dev merge
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'dev'
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,7 +8,7 @@ jobs:
   size-label:
     name: PR Size Label
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
@@ -53,7 +53,7 @@ jobs:
   draft-check:
     name: Draft Check
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v9
         with:
@@ -65,7 +65,7 @@ jobs:
   base-branch-guidance:
     name: PR Base Guidance
     if: github.event.pull_request.base.ref == 'main'
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     permissions: {}
     steps:
       - name: Remind contributors to target dev for normal contributions

--- a/.github/workflows/publish-npm-manual.yml
+++ b/.github/workflows/publish-npm-manual.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   publish:
     name: Publish npm package
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
   verify-version-sync:
     name: Verify Version Sync
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -152,7 +152,7 @@ jobs:
   publish-native-assets:
     name: Publish Native Assets
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     needs: [build-native]
     steps:
       - uses: actions/checkout@v4
@@ -217,7 +217,7 @@ jobs:
   smoke-verify-native:
     name: Smoke Verify Native Assets
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     needs: [publish-native-assets]
     steps:
       - uses: actions/checkout@v4
@@ -237,7 +237,7 @@ jobs:
   smoke-packed-install:
     name: Smoke Test Packed Global Install
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     needs: [smoke-verify-native]
     steps:
       - uses: actions/checkout@v4
@@ -253,7 +253,7 @@ jobs:
   publish-npm:
     name: Publish npm Package
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     needs: [smoke-packed-install]
     steps:
       - uses: actions/checkout@v4

--- a/src/verification/__tests__/ci-rust-gates.test.ts
+++ b/src/verification/__tests__/ci-rust-gates.test.ts
@@ -69,11 +69,13 @@ describe('CI Rust gates', () => {
   it('runs fork pull-request CI on GitHub-hosted runners instead of skipping lane detection', () => {
     const workflow = readCiWorkflow();
     const changesJob = jobBlock(workflow, 'changes');
+    const ciStatusJob = jobBlock(workflow, 'ci-status');
 
     assert.doesNotMatch(changesJob, /head\.repo\.full_name == github\.repository/);
     assert.doesNotMatch(changesJob, /^\s+if:\s*github\.event_name != 'pull_request'/m);
-    assert.match(workflow, /head\.repo\.full_name != github\.repository && 'ubuntu-latest' \|\| 'gajae-layofflabs-2'/);
-    assert.match(jobBlock(workflow, 'ci-status'), /head\.repo\.full_name != github\.repository && 'ubuntu-latest' \|\| 'gajae-layofflabs-2'/);
+    assert.match(changesJob, /^\s+runs-on:\s*ubuntu-latest$/m);
+    assert.match(ciStatusJob, /^\s+runs-on:\s*ubuntu-latest$/m);
+    assert.doesNotMatch(workflow, /runs-on:.*(?:self-hosted|gajae-layofflabs|gajae-code-heavy)/);
   });
 
   it('detects changed-file lanes once and exposes fail-closed outputs for targeted CI', () => {


### PR DESCRIPTION
## Summary
- Move workflows off self-hosted runner labels and onto GitHub-hosted `ubuntu-latest`.
- Remove the PR-vs-internal split that routed trusted events to `gajae-layofflabs-2` / self-hosted labels.
- Update self-hosted prerequisite wording where touched so CI logs no longer point maintainers back to broken private runners.

## Context
Owner requested retiring the broken self-hosted runner path and moving required CI to GitHub Actions hosted runners across the managed repos.

## Verification
- Grepped changed workflow files for blocking `runs-on` self-hosted/custom runner labels after migration.
- YAML-only CI routing change; full GitHub Actions verification will run on this PR.