### PR TITLE
Add Ultragoal architecture invariant gate

### DIFF
--- a/docs/ultragoal.md
+++ b/docs/ultragoal.md
@@ -56,7 +56,8 @@ For intermediate stories, do **not** call `update_goal`; checkpoint the OMX stor
 omx ultragoal checkpoint --goal-id G001-example --status complete --evidence "npm test passed; docs updated" --codex-goal-json ./get-goal.json
 ```
 
-For the final story, run the whole-run audit plus the mandatory final `ai-slop-cleaner`, post-cleaner verification, and independent `$code-review` gate. If review is clean (`APPROVE` + `CLEAR` with distinct `code-reviewer` and `architect` subagent evidence), call `update_goal({status: "complete"})`, call `get_goal` again, and checkpoint with the fresh complete aggregate snapshot plus `--quality-gate-json`. If review is non-clean or independent delegation is unavailable, do not call `update_goal`; use `omx ultragoal record-review-blockers` to append a durable blocker-resolution story and continue.
+For the final story, run the whole-run audit plus the mandatory final `ai-slop-cleaner`, post-cleaner verification, architecture-invariant audit, and independent `$code-review` gate. If review is clean (`APPROVE` + `CLEAR` with distinct `code-reviewer` and `architect` subagent evidence) and every required architecture/domain invariant from the brief/spec/planning artifacts is proved with implementation, test, and review evidence, call `update_goal({status: "complete"})`, call `get_goal` again, and checkpoint with the fresh complete aggregate snapshot plus `--quality-gate-json`. If review is non-clean or any invariant is unproved, do not call `update_goal`; use `omx ultragoal record-review-blockers` to append a durable blocker-resolution story and continue.
+
 
 Failure handling:
 
@@ -132,8 +133,10 @@ The final ultragoal story is not complete until the active agent has run the fin
 1. Run targeted verification for the story.
 2. Run `ai-slop-cleaner` on changed files only; if there are no relevant edits, the cleaner still runs and records a passed/no-op report.
 3. Rerun verification after the cleaner pass.
-4. Run `$code-review` through the independent review path. Clean means `codeReview.recommendation: "APPROVE"`, `codeReview.architectStatus: "CLEAR"`, and `codeReview.independentReview` contains distinct completed `code-reviewer` and `architect` subagent evidence. `COMMENT`, `WATCH`, `REQUEST CHANGES`, `BLOCK`, missing subagent evidence, unavailable delegation, and same-lane/self-review are non-clean. If the approved plan already used Scholastic for ontology-heavy review, carry that advisory evidence into the quality gate; non-clean Scholastic findings should be treated as blocker evidence rather than a completion claim.
-5. If review is non-clean, do **not** call `update_goal`. Record durable blocker work instead:
+4. Run the architecture-invariant audit: derive non-negotiable architecture/domain invariants from the brief/spec/interview/accepted steering/goal artifacts, list the source artifacts, and prove each required invariant with implementation, test, and independent review evidence.
+5. Run `$code-review` through the independent review path. Clean means `codeReview.recommendation: "APPROVE"`, `codeReview.architectStatus: "CLEAR"`, `codeReview.independentReview` contains distinct completed `code-reviewer` and `architect` subagent evidence, and `architectureInvariantGate.status: "passed"` proves every required invariant. `COMMENT`, `WATCH`, `REQUEST CHANGES`, `BLOCK`, missing subagent evidence, unavailable delegation, same-lane/self-review, and unproved architecture invariants are non-clean. If the approved plan already used Scholastic for ontology-heavy review, carry that advisory evidence into the quality gate; non-clean Scholastic findings should be treated as blocker evidence rather than a completion claim.
+6. If review or invariant proof is non-clean, do **not** call `update_goal`. Record durable blocker work instead:
+
 
    ```sh
    omx ultragoal record-review-blockers --goal-id <id> --title "Resolve final code-review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --codex-goal-json <active-get-goal-json-or-path>
@@ -141,7 +144,8 @@ The final ultragoal story is not complete until the active agent has run the fin
 
    This marks the current story `review_blocked`, appends a pending blocker-resolution story, keeps the Codex goal active, and lets `omx ultragoal complete-goals` start the blocker next. In legacy per-story mode, the blocker may need an available Codex goal context because the old per-story Codex goal remains active/incomplete.
 
-6. If review is clean, call `update_goal({status: "complete"})`, call `get_goal`, and checkpoint with a structured final gate:
+7. If review and invariant proof are clean, call `update_goal({status: "complete"})`, call `get_goal`, and checkpoint with a structured final gate:
+
 
    ```sh
    omx ultragoal checkpoint --goal-id <id> --status complete --evidence "<tests/files/review evidence>" --codex-goal-json <fresh-complete-get-goal-json-or-path> --quality-gate-json <quality-gate-json-or-path>
@@ -161,6 +165,22 @@ The final ultragoal story is not complete until the active agent has run the fin
       "codeReviewer": { "agentRole": "code-reviewer", "evidence": "code-reviewer subagent APPROVE evidence" },
       "architect": { "agentRole": "architect", "evidence": "architect subagent CLEAR evidence" }
     }
+  },
+
+  "architectureInvariantGate": {
+    "status": "passed",
+    "sourceArtifacts": [".omx/ultragoal/brief.md", ".omx/ultragoal/goals.json"],
+    "evidence": "final invariant audit proved all required architecture/domain invariants",
+    "invariants": [
+      {
+        "invariant": "Preserve the existing parser boundary.",
+        "source": ".omx/ultragoal/brief.md#architecture-invariants",
+        "status": "proved",
+        "implementationEvidence": "changed files preserve the parser boundary",
+        "testEvidence": "parser-boundary regression passed",
+        "reviewEvidence": "architect review confirmed the boundary is intact"
+      }
+    ]
   }
 }
 ```

--- a/plugins/oh-my-codex/skills/ultragoal/SKILL.md
+++ b/plugins/oh-my-codex/skills/ultragoal/SKILL.md
@@ -94,8 +94,10 @@ The final ultragoal story is not complete until the active agent has run the fin
 1. Run targeted verification for the story.
 2. Run `ai-slop-cleaner` on changed files only; if there are no relevant edits, the cleaner still runs and records a passed/no-op report.
 3. Rerun verification after the cleaner pass.
-4. Run `$code-review` through the independent review path. Clean means `codeReview.recommendation: "APPROVE"`, `codeReview.architectStatus: "CLEAR"`, and `codeReview.independentReview` contains distinct completed `code-reviewer` and `architect` subagent evidence. `COMMENT`, `WATCH`, `REQUEST CHANGES`, `BLOCK`, missing subagent evidence, unavailable delegation, and same-lane/self-review are non-clean.
-5. If review is non-clean, do **not** call `update_goal`. Record durable blocker work instead:
+4. Run the architecture-invariant audit: derive non-negotiable architecture/domain invariants from the brief/spec/interview/accepted steering/goal artifacts, list the source artifacts, and prove each required invariant with implementation, test, and independent review evidence.
+5. Run `$code-review` through the independent review path. Clean means `codeReview.recommendation: "APPROVE"`, `codeReview.architectStatus: "CLEAR"`, `codeReview.independentReview` contains distinct completed `code-reviewer` and `architect` subagent evidence, and `architectureInvariantGate.status: "passed"` proves every required invariant. `COMMENT`, `WATCH`, `REQUEST CHANGES`, `BLOCK`, missing subagent evidence, unavailable delegation, same-lane/self-review, and unproved architecture invariants are non-clean.
+6. If review or invariant proof is non-clean, do **not** call `update_goal`. Record durable blocker work instead:
+
 
    ```sh
    omx ultragoal record-review-blockers --goal-id <id> --title "Resolve final code-review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --codex-goal-json <active-get-goal-json-or-path>
@@ -103,7 +105,8 @@ The final ultragoal story is not complete until the active agent has run the fin
 
    This marks the current story `review_blocked`, appends a pending blocker-resolution story, keeps the Codex goal active, and lets `omx ultragoal complete-goals` start the blocker next. In legacy per-story mode, the blocker may need an available Codex goal context because the old per-story Codex goal remains active/incomplete.
 
-6. If review is clean, call `update_goal({status: "complete"})`, call `get_goal`, and checkpoint with a structured final gate:
+7. If review and invariant proof are clean, call `update_goal({status: "complete"})`, call `get_goal`, and checkpoint with a structured final gate:
+
 
    ```sh
    omx ultragoal checkpoint --goal-id <id> --status complete --evidence "<tests/files/review evidence>" --codex-goal-json <fresh-complete-get-goal-json-or-path> --quality-gate-json <quality-gate-json-or-path>
@@ -123,6 +126,21 @@ The final ultragoal story is not complete until the active agent has run the fin
       "codeReviewer": { "agentRole": "code-reviewer", "evidence": "code-reviewer subagent APPROVE evidence" },
       "architect": { "agentRole": "architect", "evidence": "architect subagent CLEAR evidence" }
     }
+  },
+  "architectureInvariantGate": {
+    "status": "passed",
+    "sourceArtifacts": [".omx/ultragoal/brief.md", ".omx/ultragoal/goals.json"],
+    "evidence": "final invariant audit proved all required architecture/domain invariants",
+    "invariants": [
+      {
+        "invariant": "Preserve the existing parser boundary.",
+        "source": ".omx/ultragoal/brief.md#architecture-invariants",
+        "status": "proved",
+        "implementationEvidence": "changed files preserve the parser boundary",
+        "testEvidence": "parser-boundary regression passed",
+        "reviewEvidence": "architect review confirmed the boundary is intact"
+      }
+    ]
   }
 }
 ```

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -94,8 +94,10 @@ The final ultragoal story is not complete until the active agent has run the fin
 1. Run targeted verification for the story.
 2. Run `ai-slop-cleaner` on changed files only; if there are no relevant edits, the cleaner still runs and records a passed/no-op report.
 3. Rerun verification after the cleaner pass.
-4. Run `$code-review` through the independent review path. Clean means `codeReview.recommendation: "APPROVE"`, `codeReview.architectStatus: "CLEAR"`, and `codeReview.independentReview` contains distinct completed `code-reviewer` and `architect` subagent evidence. `COMMENT`, `WATCH`, `REQUEST CHANGES`, `BLOCK`, missing subagent evidence, unavailable delegation, and same-lane/self-review are non-clean.
-5. If review is non-clean, do **not** call `update_goal`. Record durable blocker work instead:
+4. Run the architecture-invariant audit: derive non-negotiable architecture/domain invariants from the brief/spec/interview/accepted steering/goal artifacts, list the source artifacts, and prove each required invariant with implementation, test, and independent review evidence.
+5. Run `$code-review` through the independent review path. Clean means `codeReview.recommendation: "APPROVE"`, `codeReview.architectStatus: "CLEAR"`, `codeReview.independentReview` contains distinct completed `code-reviewer` and `architect` subagent evidence, and `architectureInvariantGate.status: "passed"` proves every required invariant. `COMMENT`, `WATCH`, `REQUEST CHANGES`, `BLOCK`, missing subagent evidence, unavailable delegation, same-lane/self-review, and unproved architecture invariants are non-clean.
+6. If review or invariant proof is non-clean, do **not** call `update_goal`. Record durable blocker work instead:
+
 
    ```sh
    omx ultragoal record-review-blockers --goal-id <id> --title "Resolve final code-review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --codex-goal-json <active-get-goal-json-or-path>
@@ -103,7 +105,8 @@ The final ultragoal story is not complete until the active agent has run the fin
 
    This marks the current story `review_blocked`, appends a pending blocker-resolution story, keeps the Codex goal active, and lets `omx ultragoal complete-goals` start the blocker next. In legacy per-story mode, the blocker may need an available Codex goal context because the old per-story Codex goal remains active/incomplete.
 
-6. If review is clean, call `update_goal({status: "complete"})`, call `get_goal`, and checkpoint with a structured final gate:
+7. If review and invariant proof are clean, call `update_goal({status: "complete"})`, call `get_goal`, and checkpoint with a structured final gate:
+
 
    ```sh
    omx ultragoal checkpoint --goal-id <id> --status complete --evidence "<tests/files/review evidence>" --codex-goal-json <fresh-complete-get-goal-json-or-path> --quality-gate-json <quality-gate-json-or-path>
@@ -123,6 +126,21 @@ The final ultragoal story is not complete until the active agent has run the fin
       "codeReviewer": { "agentRole": "code-reviewer", "evidence": "code-reviewer subagent APPROVE evidence" },
       "architect": { "agentRole": "architect", "evidence": "architect subagent CLEAR evidence" }
     }
+  },
+  "architectureInvariantGate": {
+    "status": "passed",
+    "sourceArtifacts": [".omx/ultragoal/brief.md", ".omx/ultragoal/goals.json"],
+    "evidence": "final invariant audit proved all required architecture/domain invariants",
+    "invariants": [
+      {
+        "invariant": "Preserve the existing parser boundary.",
+        "source": ".omx/ultragoal/brief.md#architecture-invariants",
+        "status": "proved",
+        "implementationEvidence": "changed files preserve the parser boundary",
+        "testEvidence": "parser-boundary regression passed",
+        "reviewEvidence": "architect review confirmed the boundary is intact"
+      }
+    ]
   }
 }
 ```

--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -31,6 +31,12 @@ function cleanQualityGate(): string {
         architect: { agentRole: 'architect', evidence: 'architect subagent returned CLEAR' },
       },
     },
+    architectureInvariantGate: {
+      status: 'passed',
+      sourceArtifacts: ['.omx/ultragoal/brief.md', '.omx/ultragoal/goals.json'],
+      invariants: [],
+      evidence: 'architect verified no additional architecture invariants were declared in the brief',
+    },
   });
 }
 

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -44,6 +44,13 @@ function cleanQualityGate(): object {
         architect: { agentRole: 'architect', evidence: 'architect subagent returned CLEAR' },
       },
     },
+    architectureInvariantGate: {
+      status: 'passed',
+      sourceArtifacts: ['.omx/ultragoal/brief.md', '.omx/ultragoal/goals.json'],
+      invariants: [],
+      evidence: 'architect verified no additional architecture invariants were declared in the brief',
+    },
+
   };
 }
 
@@ -882,6 +889,120 @@ describe('ultragoal artifacts', () => {
       assert.match(ledger, /"qualityGate"/);
       assert.match(ledger, /"aiSlopCleaner"/);
       assert.match(ledger, /"codeReview"/);
+    });
+  });
+
+  it('requires final architecture invariant proof from the brief before clean completion', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: [
+          'Ship the integration safely.',
+          '',
+          '## Architecture Invariants',
+          '- Preserve the existing parser boundary.',
+          '- Do not introduce a second scheduler.',
+        ].join('\n'),
+        goals: [{ title: 'Final', objective: 'Complete final milestone.' }],
+      });
+      const started = await startNextUltragoal(cwd);
+      const objective = started.plan.codexObjective!;
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: started.goal!.id,
+          status: 'complete',
+          evidence: 'tests passed',
+          codexGoal: { goal: { objective, status: 'complete' } },
+          qualityGate: cleanQualityGate(),
+        }),
+        /missing proof for required invariant from brief: Preserve the existing parser boundary/i,
+      );
+
+      await checkpointUltragoal(cwd, {
+        goalId: started.goal!.id,
+        status: 'complete',
+        evidence: 'final gates passed',
+        codexGoal: { goal: { objective, status: 'complete' } },
+        qualityGate: {
+          ...cleanQualityGate(),
+          architectureInvariantGate: {
+            status: 'passed',
+            sourceArtifacts: ['.omx/ultragoal/brief.md', '.omx/ultragoal/goals.json'],
+            evidence: 'all declared invariants have implementation, test, and review proof',
+            invariants: [
+              {
+                invariant: 'Preserve the existing parser boundary.',
+                source: '.omx/ultragoal/brief.md#architecture-invariants',
+                status: 'proved',
+                implementationEvidence: 'parser changes stayed inside src/parser without scheduler coupling',
+                testEvidence: 'parser boundary regression test passed',
+                reviewEvidence: 'architect review confirmed parser boundary remained intact',
+              },
+              {
+                invariant: 'Do not introduce a second scheduler.',
+                source: '.omx/ultragoal/brief.md#architecture-invariants',
+                status: 'proved',
+                implementationEvidence: 'implementation reused the existing scheduler entrypoint',
+                testEvidence: 'scheduler singleton regression passed',
+                reviewEvidence: 'architect review confirmed no duplicate scheduler path',
+              },
+            ],
+          },
+        },
+      });
+
+      const plan = await readUltragoalPlan(cwd);
+      assert.equal(isUltragoalDone(plan), true);
+    });
+  });
+
+  it('blocks final completion when architecture invariants are unproved or carry blockers', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: '## Domain Invariants\n- Ledger entries remain append-only.',
+        goals: [{ title: 'Final', objective: 'Complete final milestone.' }],
+      });
+      const started = await startNextUltragoal(cwd);
+      const objective = started.plan.codexObjective!;
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: started.goal!.id,
+          status: 'complete',
+          evidence: 'tests passed',
+          codexGoal: { goal: { objective, status: 'complete' } },
+          qualityGate: {
+            ...cleanQualityGate(),
+            architectureInvariantGate: {
+              status: 'passed',
+              sourceArtifacts: ['.omx/ultragoal/brief.md'],
+              evidence: 'invariant audit found unresolved blocker',
+              invariants: [
+                {
+                  invariant: 'Ledger entries remain append-only.',
+                  source: '.omx/ultragoal/brief.md#domain-invariants',
+                  status: 'blocked',
+                  implementationEvidence: 'mutation path still rewrites prior entries',
+                  testEvidence: 'append-only regression not written',
+                  reviewEvidence: 'architect BLOCK',
+                  blockers: ['existing migration rewrites ledger history'],
+                },
+              ],
+            },
+          },
+        }),
+        /not proved|blocker-resolution work/i,
+      );
+
+      const result = await recordFinalReviewBlockers(cwd, {
+        goalId: started.goal!.id,
+        title: 'Resolve final architecture invariant blockers',
+        objective: 'Prove ledger append-only behavior and rerun final quality gates.',
+        evidence: 'architectureInvariantGate found unproved invariant: Ledger entries remain append-only.',
+        codexGoal: { goal: { objective, status: 'active' } },
+      });
+      assert.equal(result.blockedGoal.status, 'review_blocked');
+      assert.match(result.addedGoal.objective, /ledger append-only/i);
     });
   });
 

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -915,7 +915,7 @@ describe('ultragoal artifacts', () => {
           codexGoal: { goal: { objective, status: 'complete' } },
           qualityGate: cleanQualityGate(),
         }),
-        /missing proof for required invariant from brief: Preserve the existing parser boundary/i,
+        /missing proof for required invariant from \.omx\/ultragoal\/brief\.md: Preserve the existing parser boundary/i,
       );
 
       await checkpointUltragoal(cwd, {
@@ -953,6 +953,153 @@ describe('ultragoal artifacts', () => {
 
       const plan = await readUltragoalPlan(cwd);
       assert.equal(isUltragoalDone(plan), true);
+    });
+  });
+
+  it('requires final architecture invariant proof from accepted steering annotations', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'Ship the integration safely without a brief invariant section.',
+        goals: [
+          { title: 'Audit steering invariant', objective: 'Accept steering invariant annotation.' },
+          { title: 'Final', objective: 'Complete final milestone.' },
+        ],
+      });
+      const first = await startNextUltragoal(cwd);
+      await steerUltragoal(cwd, {
+        kind: 'annotate_ledger',
+        source: 'finding',
+        evidence: 'Reviewer finding. Architecture invariant: Ledger entries remain append-only',
+        rationale: 'Non-negotiable architecture invariant: Ledger entries remain append-only',
+      });
+      await checkpointUltragoal(cwd, {
+        goalId: first.goal!.id,
+        status: 'complete',
+        evidence: 'steering invariant accepted for final gate coverage',
+        codexGoal: { goal: { objective: first.plan.codexObjective!, status: 'active' } },
+        allowActiveFinalCodexGoal: true,
+      });
+      const final = await startNextUltragoal(cwd);
+      const objective = final.plan.codexObjective!;
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: final.goal!.id,
+          status: 'complete',
+          evidence: 'tests passed',
+          codexGoal: { goal: { objective, status: 'complete' } },
+          qualityGate: {
+            ...cleanQualityGate(),
+            architectureInvariantGate: {
+              status: 'passed',
+              sourceArtifacts: ['.omx/ultragoal/ledger.jsonl'],
+              invariants: [],
+              evidence: 'architect verified no additional architecture invariants were declared in the brief',
+            },
+          },
+        }),
+        /missing proof for required invariant from \.omx\/ultragoal\/ledger\.jsonl: Ledger entries remain append-only/i,
+      );
+
+      await checkpointUltragoal(cwd, {
+        goalId: final.goal!.id,
+        status: 'complete',
+        evidence: 'final gates passed',
+        codexGoal: { goal: { objective, status: 'complete' } },
+        qualityGate: {
+          ...cleanQualityGate(),
+          architectureInvariantGate: {
+            status: 'passed',
+            sourceArtifacts: ['.omx/ultragoal/ledger.jsonl'],
+            evidence: 'accepted steering invariant has implementation, test, and review proof',
+            invariants: [
+              {
+                invariant: 'Ledger entries remain append-only',
+                source: '.omx/ultragoal/ledger.jsonl#steering-3-inline-architecture-invariant',
+                status: 'proved',
+                implementationEvidence: 'appendLedger only appends JSONL records',
+                testEvidence: 'ledger append-only regression passed',
+                reviewEvidence: 'architect review confirmed ledger mutation remains append-only',
+              },
+            ],
+          },
+        },
+      });
+
+      const plan = await readUltragoalPlan(cwd);
+      assert.equal(isUltragoalDone(plan), true);
+    });
+  });
+
+  it('rejects decorative architecture invariant provenance labels that omit source artifacts', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: [
+          'Ship the integration safely.',
+          '',
+          '## Architecture Invariants',
+          '- Preserve the existing parser boundary.',
+        ].join('\n'),
+        goals: [{ title: 'Final', objective: 'Complete final milestone.' }],
+      });
+      const started = await startNextUltragoal(cwd);
+      const objective = started.plan.codexObjective!;
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: started.goal!.id,
+          status: 'complete',
+          evidence: 'tests passed',
+          codexGoal: { goal: { objective, status: 'complete' } },
+          qualityGate: {
+            ...cleanQualityGate(),
+            architectureInvariantGate: {
+              status: 'passed',
+              sourceArtifacts: ['review-note: claims brief coverage'],
+              evidence: 'decorative label claims the invariant came from the brief',
+              invariants: [
+                {
+                  invariant: 'Preserve the existing parser boundary.',
+                  source: 'review-note: brief architecture invariant',
+                  status: 'proved',
+                  implementationEvidence: 'parser boundary preserved',
+                  testEvidence: 'parser boundary test passed',
+                  reviewEvidence: 'architect review confirmed parser boundary',
+                },
+              ],
+            },
+          },
+        }),
+        /sourceArtifacts must include required invariant source artifact: \.omx\/ultragoal\/brief\.md/i,
+      );
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: started.goal!.id,
+          status: 'complete',
+          evidence: 'tests passed',
+          codexGoal: { goal: { objective, status: 'complete' } },
+          qualityGate: {
+            ...cleanQualityGate(),
+            architectureInvariantGate: {
+              status: 'passed',
+              sourceArtifacts: ['.omx/ultragoal/brief.md'],
+              evidence: 'source artifact is listed but record source is decorative',
+              invariants: [
+                {
+                  invariant: 'Preserve the existing parser boundary.',
+                  source: 'review-note: brief architecture invariant',
+                  status: 'proved',
+                  implementationEvidence: 'parser boundary preserved',
+                  testEvidence: 'parser boundary test passed',
+                  reviewEvidence: 'architect review confirmed parser boundary',
+                },
+              ],
+            },
+          },
+        }),
+        /source must reference one of architectureInvariantGate\.sourceArtifacts|decorative provenance labels/i,
+      );
     });
   });
 

--- a/src/ultragoal/__tests__/docs-contract.test.ts
+++ b/src/ultragoal/__tests__/docs-contract.test.ts
@@ -68,6 +68,9 @@ describe('ultragoal docs contract', () => {
       assert.match(doc, /\$code-review/);
       assert.match(doc, /independent review path/i);
       assert.match(doc, /codeReview\.independentReview/);
+      assert.match(doc, /architectureInvariantGate/);
+      assert.match(doc, /architecture-invariant audit/i);
+      assert.match(doc, /implementation, test, and (?:independent )?review evidence/i);
       assert.match(doc, /code-reviewer/);
       assert.match(doc, /architect/);
       assert.match(doc, /same-lane\/self-review/i);

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -142,6 +142,17 @@ export interface UltragoalAggregateCompletion {
   codexGoal?: unknown;
 }
 
+export interface UltragoalArchitectureInvariantEvidence {
+  invariant: string;
+  source: string;
+  status: 'proved';
+  implementationEvidence: string;
+  testEvidence: string;
+  reviewEvidence: string;
+  blockers?: never;
+}
+
+
 export interface UltragoalPlan {
   version: 1;
   createdAt: string;
@@ -251,6 +262,13 @@ export interface UltragoalQualityGate {
       };
     };
   };
+  architectureInvariantGate: {
+    status: 'passed';
+    sourceArtifacts: string[];
+    invariants: UltragoalArchitectureInvariantEvidence[];
+    evidence: string;
+  };
+
 }
 
 export class UltragoalError extends Error {}
@@ -1174,9 +1192,68 @@ export async function steerUltragoal(cwd: string, proposal: UltragoalSteeringPro
   });
 }
 
-function validateQualityGate(value: unknown): UltragoalQualityGate {
+function normalizeInvariantText(value: string): string {
+  return value.replace(/[`*_~]/g, '').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function extractArchitectureInvariantsFromBrief(brief: string): string[] {
+  const lines = brief.split(/\r?\n/);
+  const invariants: string[] = [];
+  let inInvariantSection = false;
+  for (const line of lines) {
+    const heading = line.match(/^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$/);
+    if (heading) {
+      const label = heading[1]?.toLowerCase() ?? '';
+      inInvariantSection = /\b(?:architecture|architectural|domain|non-negotiable)\b/.test(label) && /\binvariants?\b|\bconstraints?\b|\bnon-negotiables?\b/.test(label);
+      continue;
+    }
+    if (!inInvariantSection) continue;
+    const item = cleanLine(line);
+    if (!item || item === line.trim()) continue;
+    invariants.push(item);
+  }
+  return Array.from(new Set(invariants.map((item) => item.trim()).filter(Boolean)));
+}
+
+function validateArchitectureInvariantGate(gate: Partial<UltragoalQualityGate>, requiredInvariants: readonly string[]): void {
+  const invariantGate = gate.architectureInvariantGate;
+  if (!invariantGate || typeof invariantGate !== 'object') {
+    throw new UltragoalError('Final quality gate is missing architectureInvariantGate evidence; include derived architecture/domain invariants, source artifacts, implementation/test/review evidence, or record final blockers for unproved invariants.');
+  }
+  if (invariantGate.status !== 'passed') {
+    throw new UltragoalError('Final architecture-invariant gate requires architectureInvariantGate.status="passed"; record blocker-resolution work for unproved invariants.');
+  }
+  if (!Array.isArray(invariantGate.sourceArtifacts)) {
+    throw new UltragoalError('Final architecture-invariant gate requires architectureInvariantGate.sourceArtifacts.');
+  }
+  for (const source of invariantGate.sourceArtifacts) assertNonEmpty(source, 'architectureInvariantGate.sourceArtifacts[]');
+  assertNonEmpty(invariantGate.evidence, 'architectureInvariantGate.evidence');
+  if (!Array.isArray(invariantGate.invariants)) {
+    throw new UltragoalError('Final architecture-invariant gate requires architectureInvariantGate.invariants.');
+  }
+  const provided = new Map<string, UltragoalArchitectureInvariantEvidence>();
+  for (const invariant of invariantGate.invariants) {
+    if (!invariant || typeof invariant !== 'object') throw new UltragoalError('Final architecture-invariant gate invariants must be objects.');
+    const record = invariant as Partial<UltragoalArchitectureInvariantEvidence> & { blockers?: unknown };
+    const text = assertNonEmpty(record.invariant, 'architectureInvariantGate.invariants[].invariant');
+    assertNonEmpty(record.source, 'architectureInvariantGate.invariants[].source');
+    if (record.status !== 'proved') throw new UltragoalError(`Final architecture invariant "${text}" is not proved; record blocker-resolution work before final completion.`);
+    if (record.blockers !== undefined) throw new UltragoalError(`Final architecture invariant "${text}" has blockers; record blocker-resolution work before final completion.`);
+    assertNonEmpty(record.implementationEvidence, 'architectureInvariantGate.invariants[].implementationEvidence');
+    assertNonEmpty(record.testEvidence, 'architectureInvariantGate.invariants[].testEvidence');
+    assertNonEmpty(record.reviewEvidence, 'architectureInvariantGate.invariants[].reviewEvidence');
+    provided.set(normalizeInvariantText(text), record as UltragoalArchitectureInvariantEvidence);
+  }
+  for (const required of requiredInvariants) {
+    if (!provided.has(normalizeInvariantText(required))) {
+      throw new UltragoalError(`Final architecture-invariant gate is missing proof for required invariant from brief: ${required}`);
+    }
+  }
+}
+
+function validateQualityGate(value: unknown, requiredInvariants: readonly string[] = []): UltragoalQualityGate {
   if (!value || typeof value !== 'object') {
-    throw new UltragoalError('Final ultragoal completion requires --quality-gate-json with ai-slop-cleaner, verification, and code-review evidence.');
+    throw new UltragoalError('Final ultragoal completion requires --quality-gate-json with ai-slop-cleaner, verification, code-review, and architecture-invariant evidence.');
   }
   const gate = value as Partial<UltragoalQualityGate>;
   const cleaner = gate.aiSlopCleaner;
@@ -1221,6 +1298,7 @@ function validateQualityGate(value: unknown): UltragoalQualityGate {
     throw new UltragoalError('Final code-review must use an independent architect subagent; self-review or default/authoring-lane review cannot approve the ultragoal gate.');
   }
   assertNonEmpty(architect.evidence, 'codeReview.independentReview.architect.evidence');
+  validateArchitectureInvariantGate(gate, requiredInvariants);
   return gate as UltragoalQualityGate;
 }
 
@@ -1366,8 +1444,11 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
     }
     if (finalRunCheckpoint && !options.allowActiveFinalCodexGoal) goal.evidence = options.evidence;
   }
+  const requiredArchitectureInvariants = options.status === 'complete' && (aggregateCompletion !== undefined || (isFinalRunCompletionCandidate(plan, goal) && !options.allowActiveFinalCodexGoal))
+    ? extractArchitectureInvariantsFromBrief(await readFile(ultragoalBriefPath(cwd), 'utf-8'))
+    : [];
   const qualityGate = options.status === 'complete' && (aggregateCompletion !== undefined || (isFinalRunCompletionCandidate(plan, goal) && !options.allowActiveFinalCodexGoal))
-    ? validateQualityGate(options.qualityGate)
+    ? validateQualityGate(options.qualityGate, requiredArchitectureInvariants)
     : undefined;
   if (aggregateCompletion) {
     plan.aggregateCompletion = aggregateCompletion;

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -1195,27 +1195,115 @@ export async function steerUltragoal(cwd: string, proposal: UltragoalSteeringPro
 function normalizeInvariantText(value: string): string {
   return value.replace(/[`*_~]/g, '').replace(/\s+/g, ' ').trim().toLowerCase();
 }
+interface RequiredArchitectureInvariant {
+  invariant: string;
+  sourceArtifact: string;
+  source: string;
+}
 
-function extractArchitectureInvariantsFromBrief(brief: string): string[] {
-  const lines = brief.split(/\r?\n/);
-  const invariants: string[] = [];
+function requiredInvariantSourceKey(invariant: RequiredArchitectureInvariant): string {
+  return `${normalizeInvariantText(invariant.invariant)}\u0000${invariant.sourceArtifact}`;
+}
+
+function uniqueRequiredArchitectureInvariants(invariants: readonly RequiredArchitectureInvariant[]): RequiredArchitectureInvariant[] {
+  const seen = new Set<string>();
+  const unique: RequiredArchitectureInvariant[] = [];
+  for (const invariant of invariants) {
+    const key = requiredInvariantSourceKey(invariant);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(invariant);
+  }
+  return unique;
+}
+
+function architectureInvariantSectionSlug(label: string): string {
+  return label
+    .replace(/[`*_~]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '') || 'architecture-invariants';
+}
+
+function normalizeSourceArtifact(value: string): string {
+  return value.trim().split('#', 1)[0]?.replace(/\\/g, '/') ?? '';
+}
+
+function sourceReferencesArtifact(source: string, artifact: string): boolean {
+  return normalizeSourceArtifact(source) === normalizeSourceArtifact(artifact);
+}
+
+function sourceReferencesAnyArtifact(source: string, artifacts: readonly string[]): boolean {
+  return artifacts.some((artifact) => sourceReferencesArtifact(source, artifact));
+}
+
+function invariantFromInlineDeclaration(line: string): string | undefined {
+  const trimmed = cleanLine(line).replace(/^['"]|['"]$/g, '').trim();
+  const match = /\b(?:(?:non-negotiable|required)\s+)?(?:architecture|architectural|domain)\s+(?:invariants?|constraints?|non-negotiables?)\s*:\s*(.+)$/i.exec(trimmed)
+    ?? /\bnon-negotiables?\s+(?:architecture|architectural|domain)\s+(?:invariants?|constraints?)\s*:\s*(.+)$/i.exec(trimmed);
+  const invariant = match?.[1]?.trim().replace(/[.;]\s*$/, '').trim();
+  return invariant || undefined;
+}
+
+function extractArchitectureInvariantsFromArtifact(text: string, sourceArtifact: string, sourcePrefix?: string): RequiredArchitectureInvariant[] {
+  const lines = text.split(/\r?\n/);
+  const invariants: RequiredArchitectureInvariant[] = [];
   let inInvariantSection = false;
+  let sectionSlug = 'architecture-invariants';
   for (const line of lines) {
     const heading = line.match(/^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$/);
     if (heading) {
-      const label = heading[1]?.toLowerCase() ?? '';
-      inInvariantSection = /\b(?:architecture|architectural|domain|non-negotiable)\b/.test(label) && /\binvariants?\b|\bconstraints?\b|\bnon-negotiables?\b/.test(label);
+      const label = heading[1] ?? '';
+      const normalizedLabel = label.toLowerCase();
+      inInvariantSection = /\b(?:architecture|architectural|domain|non-negotiable)\b/.test(normalizedLabel) && /\binvariants?\b|\bconstraints?\b|\bnon-negotiables?\b/.test(normalizedLabel);
+      if (inInvariantSection) sectionSlug = architectureInvariantSectionSlug(label);
+      continue;
+    }
+    const inline = invariantFromInlineDeclaration(line);
+    if (inline) {
+      invariants.push({ invariant: inline, sourceArtifact, source: `${sourceArtifact}#${sourcePrefix ?? 'inline-architecture-invariant'}` });
       continue;
     }
     if (!inInvariantSection) continue;
     const item = cleanLine(line);
     if (!item || item === line.trim()) continue;
-    invariants.push(item);
+    invariants.push({ invariant: item, sourceArtifact, source: `${sourceArtifact}#${sourcePrefix ? `${sourcePrefix}-${sectionSlug}` : sectionSlug}` });
   }
-  return Array.from(new Set(invariants.map((item) => item.trim()).filter(Boolean)));
+  return uniqueRequiredArchitectureInvariants(invariants.map((item) => ({ ...item, invariant: item.invariant.trim() })).filter((item) => item.invariant));
 }
 
-function validateArchitectureInvariantGate(gate: Partial<UltragoalQualityGate>, requiredInvariants: readonly string[]): void {
+function extractArchitectureInvariantsFromBrief(brief: string): RequiredArchitectureInvariant[] {
+  return extractArchitectureInvariantsFromArtifact(brief, `${ULTRAGOAL_DIR}/${ULTRAGOAL_BRIEF}`);
+}
+
+function extractArchitectureInvariantsFromAcceptedSteering(entries: readonly UltragoalLedgerEntry[]): RequiredArchitectureInvariant[] {
+  const invariants: RequiredArchitectureInvariant[] = [];
+  for (const [index, entry] of entries.entries()) {
+    if (entry.event !== 'steering_accepted' || !entry.steering?.invariant.accepted) continue;
+    const sourcePrefix = `steering-${index + 1}`;
+    const steering = entry.steering;
+    const texts = [
+      entry.evidence,
+      entry.message,
+      steering.evidence,
+      steering.rationale,
+      steering.directiveText,
+    ].filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
+    for (const text of texts) {
+      invariants.push(...extractArchitectureInvariantsFromArtifact(text, `${ULTRAGOAL_DIR}/${ULTRAGOAL_LEDGER}`, sourcePrefix));
+    }
+  }
+  return uniqueRequiredArchitectureInvariants(invariants);
+}
+
+async function collectRequiredArchitectureInvariants(cwd: string): Promise<RequiredArchitectureInvariant[]> {
+  const briefInvariants = extractArchitectureInvariantsFromBrief(await readFile(ultragoalBriefPath(cwd), 'utf-8'));
+  const steeringInvariants = extractArchitectureInvariantsFromAcceptedSteering(await readSteeringLedgerEntries(cwd));
+  return uniqueRequiredArchitectureInvariants([...briefInvariants, ...steeringInvariants]);
+}
+
+
+function validateArchitectureInvariantGate(gate: Partial<UltragoalQualityGate>, requiredInvariants: readonly RequiredArchitectureInvariant[]): void {
   const invariantGate = gate.architectureInvariantGate;
   if (!invariantGate || typeof invariantGate !== 'object') {
     throw new UltragoalError('Final quality gate is missing architectureInvariantGate evidence; include derived architecture/domain invariants, source artifacts, implementation/test/review evidence, or record final blockers for unproved invariants.');
@@ -1226,32 +1314,47 @@ function validateArchitectureInvariantGate(gate: Partial<UltragoalQualityGate>, 
   if (!Array.isArray(invariantGate.sourceArtifacts)) {
     throw new UltragoalError('Final architecture-invariant gate requires architectureInvariantGate.sourceArtifacts.');
   }
-  for (const source of invariantGate.sourceArtifacts) assertNonEmpty(source, 'architectureInvariantGate.sourceArtifacts[]');
+  const sourceArtifacts = invariantGate.sourceArtifacts.map((source) => assertNonEmpty(source, 'architectureInvariantGate.sourceArtifacts[]'));
+  for (const required of requiredInvariants) {
+    if (!sourceArtifacts.some((source) => sourceReferencesArtifact(source, required.sourceArtifact))) {
+      throw new UltragoalError(`Final architecture-invariant gate sourceArtifacts must include required invariant source artifact: ${required.sourceArtifact}`);
+    }
+  }
   assertNonEmpty(invariantGate.evidence, 'architectureInvariantGate.evidence');
   if (!Array.isArray(invariantGate.invariants)) {
     throw new UltragoalError('Final architecture-invariant gate requires architectureInvariantGate.invariants.');
   }
-  const provided = new Map<string, UltragoalArchitectureInvariantEvidence>();
+  const provided = new Map<string, UltragoalArchitectureInvariantEvidence[]>();
   for (const invariant of invariantGate.invariants) {
     if (!invariant || typeof invariant !== 'object') throw new UltragoalError('Final architecture-invariant gate invariants must be objects.');
     const record = invariant as Partial<UltragoalArchitectureInvariantEvidence> & { blockers?: unknown };
     const text = assertNonEmpty(record.invariant, 'architectureInvariantGate.invariants[].invariant');
-    assertNonEmpty(record.source, 'architectureInvariantGate.invariants[].source');
+    const source = assertNonEmpty(record.source, 'architectureInvariantGate.invariants[].source');
+    if (!sourceReferencesAnyArtifact(source, sourceArtifacts)) {
+      throw new UltragoalError(`Final architecture invariant "${text}" source must reference one of architectureInvariantGate.sourceArtifacts; decorative provenance labels are not sufficient.`);
+    }
     if (record.status !== 'proved') throw new UltragoalError(`Final architecture invariant "${text}" is not proved; record blocker-resolution work before final completion.`);
     if (record.blockers !== undefined) throw new UltragoalError(`Final architecture invariant "${text}" has blockers; record blocker-resolution work before final completion.`);
     assertNonEmpty(record.implementationEvidence, 'architectureInvariantGate.invariants[].implementationEvidence');
     assertNonEmpty(record.testEvidence, 'architectureInvariantGate.invariants[].testEvidence');
     assertNonEmpty(record.reviewEvidence, 'architectureInvariantGate.invariants[].reviewEvidence');
-    provided.set(normalizeInvariantText(text), record as UltragoalArchitectureInvariantEvidence);
+    const key = normalizeInvariantText(text);
+    const records = provided.get(key) ?? [];
+    records.push(record as UltragoalArchitectureInvariantEvidence);
+    provided.set(key, records);
   }
   for (const required of requiredInvariants) {
-    if (!provided.has(normalizeInvariantText(required))) {
-      throw new UltragoalError(`Final architecture-invariant gate is missing proof for required invariant from brief: ${required}`);
+    const matches = provided.get(normalizeInvariantText(required.invariant)) ?? [];
+    if (matches.length === 0) {
+      throw new UltragoalError(`Final architecture-invariant gate is missing proof for required invariant from ${required.sourceArtifact}: ${required.invariant}`);
+    }
+    if (!matches.some((record) => sourceReferencesArtifact(record.source, required.sourceArtifact))) {
+      throw new UltragoalError(`Final architecture-invariant gate proof for required invariant must reference ${required.sourceArtifact}: ${required.invariant}`);
     }
   }
 }
 
-function validateQualityGate(value: unknown, requiredInvariants: readonly string[] = []): UltragoalQualityGate {
+function validateQualityGate(value: unknown, requiredInvariants: readonly RequiredArchitectureInvariant[] = []): UltragoalQualityGate {
   if (!value || typeof value !== 'object') {
     throw new UltragoalError('Final ultragoal completion requires --quality-gate-json with ai-slop-cleaner, verification, code-review, and architecture-invariant evidence.');
   }
@@ -1445,7 +1548,7 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
     if (finalRunCheckpoint && !options.allowActiveFinalCodexGoal) goal.evidence = options.evidence;
   }
   const requiredArchitectureInvariants = options.status === 'complete' && (aggregateCompletion !== undefined || (isFinalRunCompletionCandidate(plan, goal) && !options.allowActiveFinalCodexGoal))
-    ? extractArchitectureInvariantsFromBrief(await readFile(ultragoalBriefPath(cwd), 'utf-8'))
+    ? await collectRequiredArchitectureInvariants(cwd)
     : [];
   const qualityGate = options.status === 'complete' && (aggregateCompletion !== undefined || (isFinalRunCompletionCandidate(plan, goal) && !options.allowActiveFinalCodexGoal))
     ? validateQualityGate(options.qualityGate, requiredArchitectureInvariants)


### PR DESCRIPTION
## Summary
- Adds a required `architectureInvariantGate` section to the final Ultragoal quality gate.
- Derives required architecture/domain invariants from brief sections and requires implementation, test, and review proof for each one.
- Blocks final completion when required invariants are missing, unproved, or carry blockers; existing `record-review-blockers` flow appends blocker-resolution work.
- Updates Ultragoal docs, mirrored skill guidance, CLI fixtures, artifact tests, and docs contract tests.

Closes #2847

## Verification
- `npm install`
- `npm run build`
- `node dist/scripts/run-test-files.js dist/ultragoal/__tests__/artifacts.test.js dist/ultragoal/__tests__/docs-contract.test.js dist/cli/__tests__/ultragoal.test.js`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*