### PR TITLE
feat(config): add per-agent native model overrides

### DIFF
--- a/docs/reference/omx-config-schema-routing.md
+++ b/docs/reference/omx-config-schema-routing.md
@@ -25,6 +25,7 @@ Current code recognizes these top-level `.omx-config.json` keys:
 
 | Top-level key | Supported shape | Primary use |
 | --- | --- | --- |
+| `agentModels` | Object mapping agent names to non-empty model strings | Optional per-agent model overrides for generated native agent TOML, AGENTS.md model tables, and role-based worker/Ralph fallback routing. |
 | `agentReasoning` | Object mapping agent names to `low`, `medium`, `high`, or `xhigh` | Optional per-agent reasoning overrides for generated native agent TOML and role-based worker/Ralph staffing guidance. |
 | `env` | Object of non-empty string values | Fallback environment values for model routing and helper launch paths. Model-related supported keys are listed below. |
 | `models` | Object of non-empty string values | Mode defaults and low-complexity model aliases. Supported model-routing keys are listed below. |
@@ -51,10 +52,16 @@ Use [`docs/discord-integration.md`](../discord-integration.md) for Discord webho
 
 ## Supported model/env keys
 
-The model-routing reader supports `env`, `models`, and the role-reasoning override map `agentReasoning`.
+The model-routing reader supports `env`, `models`, and the per-role override maps `agentModels` and `agentReasoning`.
 
 ```json
 {
+  "agentModels": {
+    "planner": "gpt-5.5",
+    "architect": "gpt-5.5",
+    "researcher": "gpt-5.5",
+    "explore": "gpt-5.5"
+  },
   "agentReasoning": {
     "architect": "xhigh",
     "critic": "xhigh"
@@ -114,6 +121,32 @@ Supported model-routing keys:
 
 Do not invent per-role maps such as `models.executor`, `models.architect`, or `models.roles` unless your installed version documents that exact key. Current role routing is based on agent definitions and model class, not arbitrary per-role JSON maps.
 
+### `agentModels`
+
+`agentModels` is the supported per-agent model override map. Keys are normalized OMX agent names using the same normalization as `agentReasoning`: case-insensitive agent names containing letters, numbers, underscores, and hyphens. Values must be non-empty strings. Malformed agent names, empty values, and non-string values are ignored rather than fatal.
+
+```json
+{
+  "agentModels": {
+    "architect": "gpt-5.5",
+    "planner": "gpt-5.5",
+    "researcher": "gpt-5.5",
+    "explore": "gpt-5.5"
+  }
+}
+```
+
+These overrides do not change built-in defaults in source. They are user/project configuration that applies when OMX resolves generated native agent TOML, generated developer metadata/instructions, AGENTS.md model capability tables, and role-based team/Ralph fallback model selection. Rerun `omx setup --force` after changing this map so setup-managed native agent TOML and AGENTS.md managed sections are regenerated.
+
+For a named role, effective model precedence is:
+
+1. `.omx-config.json` `agentModels[role]`
+2. Built-in `exactModel` pins, such as planner/architect/researcher `gpt-5.4-mini`
+3. Special role logic, such as `executor` using the main/frontier lane
+4. `modelClass` routing: `fast` uses spark/low-complexity, `frontier` uses main/frontier, and `standard` uses the standard lane
+
+`agentModels` is the durable per-role surface. Do not put per-role models under `models.executor`, `models.architect`, or `models.roles`.
+
 ### `agentReasoning`
 
 `agentReasoning` is the supported per-agent reasoning override map. Keys are agent names and values must be one of `low`, `medium`, `high`, or `xhigh`.
@@ -130,6 +163,8 @@ Do not invent per-role maps such as `models.executor`, `models.architect`, or `m
 These overrides do not change built-in defaults in source. They are user/project configuration that applies when OMX resolves role reasoning for generated native agent TOML and role-based team/Ralph staffing/worker guidance. Rerun `omx setup` after changing this map so setup-managed native agent TOML files are regenerated. Malformed agent names, empty values, and unsupported effort values are ignored.
 
 ## Effective model precedence
+
+For generated native agents and role-based worker/Ralph fallback routing, `agentModels[role]` is checked before built-in exact pins and model-class routing. The sections below describe the lane defaults used when no per-agent override exists.
 
 ### Main/frontier default
 
@@ -175,13 +210,13 @@ For team low-complexity helpers, the exact order depends on the call path: `getS
 
 ## Role/category routing examples
 
-Native agent TOML generation and team model-contract logic use agent definitions with `modelClass`, optional `exactModel`, and `reasoningEffort` metadata. Exact-model pins win before class-based routing. Native-agent generation has one important frontier-lane precedence detail: for frontier roles and the `executor` special case, it reads the active Codex `config.toml` root `model` first, then falls back to `getMainDefaultModel()` if that root model is absent. Because `getMainDefaultModel()` is only the fallback in this path, `.omx-config.json` `env.OMX_DEFAULT_FRONTIER_MODEL` does not override an explicit `config.toml` root `model` for generated native-agent TOML.
+Native agent TOML generation and team model-contract logic use agent definitions with `modelClass`, optional `exactModel`, and `reasoningEffort` metadata. Per-agent `agentModels[role]` overrides win first. Exact-model pins win before class-based routing only when no per-agent model override exists. Native-agent generation has one important frontier-lane precedence detail: for frontier roles and the `executor` special case, it reads the active Codex `config.toml` root `model` first, then falls back to `getMainDefaultModel()` if that root model is absent. Because `getMainDefaultModel()` is only the fallback in this path, `.omx-config.json` `env.OMX_DEFAULT_FRONTIER_MODEL` does not override an explicit `config.toml` root `model` for generated native-agent TOML.
 
 Examples:
 
 | Role/category | Examples | Model class behavior |
 | --- | --- | --- |
-| Exact mini planning/research | `planner`, `architect`, `researcher` | Uses the exact `gpt-5.4-mini` pin before model-class routing; planner/architect keep `frontier-orchestrator` posture and high reasoning, while ralplan's `critic` remains frontier-routed for the consensus gate. |
+| Exact mini planning/research | `planner`, `architect`, `researcher` | Uses the exact `gpt-5.4-mini` pin before model-class routing unless `agentModels[role]` is set; planner/architect keep `frontier-orchestrator` posture and high reasoning, while ralplan's `critic` remains frontier-routed for the consensus gate. |
 | Frontier orchestration | `critic`, `code-reviewer`, `security-reviewer`, `team-executor`, `vision` | Native-agent generation uses active `config.toml` root `model` first, then the main/frontier default fallback. |
 | Standard worker/review | `debugger`, `quality-reviewer`, `api-reviewer`, `performance-reviewer`, `dependency-expert`, `writer` | Uses the standard-lane default, which inherits main/frontier unless `OMX_DEFAULT_STANDARD_MODEL` is set. |
 | Fast/low-complexity | `explore`, `style-reviewer` | Uses the spark/low-complexity default. |
@@ -241,12 +276,21 @@ This keeps orchestration on the frontier default, routes standard workers to a c
 
 ### Max-quality starter
 
-This keeps standard agents inheriting the frontier model by omitting `OMX_DEFAULT_STANDARD_MODEL`, while still preserving a fast spark lane for explicit low-complexity routing.
+This keeps standard agents inheriting the frontier model by omitting `OMX_DEFAULT_STANDARD_MODEL`, keeps a fast spark lane for default low-complexity routing, and explicitly promotes selected exact-pinned/generated roles to a max-quality model with matching reasoning overrides.
 
 ```json
 {
+  "agentModels": {
+    "planner": "gpt-5.5",
+    "architect": "gpt-5.5",
+    "researcher": "gpt-5.5",
+    "explore": "gpt-5.5"
+  },
   "agentReasoning": {
+    "planner": "high",
     "architect": "xhigh",
+    "researcher": "high",
+    "explore": "medium",
     "critic": "xhigh"
   },
   "env": {

--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -133,6 +133,33 @@ describe("agents/native-config", () => {
     }
   });
 
+  it("lets agentModels override exact pins without stale exact-mini guidance", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "omx-native-config-agent-models-"));
+    try {
+      await writeFile(join(codexHome, ".omx-config.json"), JSON.stringify({
+        agentModels: {
+          architect: "gpt-5.5",
+        },
+        agentReasoning: {
+          architect: "xhigh",
+        },
+      }));
+
+      const toml = generateAgentToml(AGENT_DEFINITIONS.architect, "Architect prompt", {
+        codexHomeOverride: codexHome,
+      });
+
+      assert.match(toml, /model = "gpt-5\.5"/);
+      assert.match(toml, /model_reasoning_effort = "xhigh"/);
+      assert.match(toml, /resolved_model: gpt-5\.5/);
+      assert.doesNotMatch(toml, /model = "gpt-5\.4-mini"/);
+      assert.doesNotMatch(toml, /exact gpt-5\.4-mini model/);
+      assert.doesNotMatch(toml, /resolved_model: gpt-5\.4-mini/);
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
 
   it("pins ralplan thesis/antithesis and researcher to exact gpt-5.4-mini without downgrading judgment roles", () => {
     process.env.OMX_DEFAULT_FRONTIER_MODEL = "gpt-5.5";

--- a/src/agents/native-config.ts
+++ b/src/agents/native-config.ts
@@ -14,6 +14,7 @@ import {
   getCodexConfigRootModelProvider,
   getEnvConfiguredStandardDefaultModel,
   getAgentReasoningOverride,
+  getAgentModelOverride,
   getMainDefaultModel,
   getSparkDefaultModel,
   getStandardDefaultModel,
@@ -174,6 +175,10 @@ function resolveAgentModel(
   agent: AgentDefinition,
   options: AgentModelResolutionOptions = {},
 ): string {
+  const modelOverride = getAgentModelOverride(agent.name, options.codexHomeOverride);
+  if (modelOverride) {
+    return modelOverride;
+  }
   if (agent.exactModel) {
     return agent.exactModel;
   }

--- a/src/cli/__tests__/doctor-spark-routing.test.ts
+++ b/src/cli/__tests__/doctor-spark-routing.test.ts
@@ -81,6 +81,22 @@ describe('checkSparkRouting', () => {
     assert.match(result.message, /stale install/);
   });
 
+  it('passes and reports intentional explore model override instead of stale spark guidance', () => {
+    writeFileSync(join(workDir, '.omx-config.json'), JSON.stringify({
+      agentModels: {
+        explore: 'gpt-5.5-explore',
+      },
+    }));
+    writeExploreToml('name = "explore"\nmodel = "gpt-5.5-explore"\n');
+
+    const result = checkSparkRouting(makePaths(workDir));
+
+    assert.equal(result.status, 'pass');
+    assert.match(result.message, /agentModels override/);
+    assert.match(result.message, /gpt-5\.5-explore/);
+    assert.doesNotMatch(result.message, /stale install/);
+  });
+
   it('warns when the Spark-lane agent routes through a non-default provider', () => {
     writeExploreToml(
       `name = "explore"\nmodel = "${SPARK_DEFAULT}"\nmodel_provider = "my-proxy"\n`,

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -73,6 +73,7 @@ import { hasOmxAgentsContract } from "../utils/agents-md.js";
 import {
 	OMX_DEFAULT_SPARK_MODEL_ENV,
 	OMX_SPARK_MODEL_ENV,
+	getAgentModelOverride,
 	getCodexConfigRootModelProvider,
 	getEnvConfiguredSparkDefaultModel,
 	getMainDefaultModel,
@@ -2056,6 +2057,11 @@ export function checkSparkRouting(paths: DoctorPaths): Check {
 	const standardModel = getStandardDefaultModel(codexHomeOverride);
 	const sparkSource = resolveSparkModelSource(codexHomeOverride);
 	const rootProvider = getCodexConfigRootModelProvider(codexHomeOverride);
+	const explicitSparkAgentOverrides = new Map(
+		getInstallableSparkLaneAgentNames()
+			.map((agentName) => [agentName, getAgentModelOverride(agentName, codexHomeOverride)] as const)
+			.filter((entry): entry is readonly [string, string] => typeof entry[1] === "string"),
+	);
 
 	const laneSummary =
 		`lanes: frontier=\`${frontierModel}\`, standard=\`${standardModel}\`, ` +
@@ -2087,6 +2093,21 @@ export function checkSparkRouting(paths: DoctorPaths): Check {
 		if (!info.model) {
 			problems.push(
 				`${agentName}.toml has no model field (stale install; run \`omx setup --force\`)`,
+			);
+			continue;
+		}
+		const explicitOverride = explicitSparkAgentOverrides.get(agentName);
+		if (explicitOverride) {
+			if (info.model !== explicitOverride) {
+				problems.push(
+					`${agentName}.toml model is \`${info.model}\` but agentModels.${agentName} explicitly resolves to \`${explicitOverride}\` (stale install; run \`omx setup --force\`)`,
+				);
+				continue;
+			}
+			wired.push(
+				`${agentName} -> \`${info.model}\` (agentModels override)${
+					info.modelProvider ? ` (provider: ${info.modelProvider})` : ""
+				}`,
 			);
 			continue;
 		}

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -2750,6 +2750,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				),
 				modelTableContext,
 				modelTableDefinitions,
+				{ codexHomeOverride: scopeDirs.codexHomeDir },
 			);
 			if (options.mergeAgents && pluginAgentsMdExists) {
 				if (pluginAgentsMdIsSymlink) {
@@ -2886,6 +2887,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				),
 				modelTableContext,
 				modelTableDefinitions,
+				{ codexHomeOverride: scopeDirs.codexHomeDir },
 			);
 			let changed = true;
 			let canApplyManagedModelRefresh = false;
@@ -2914,10 +2916,11 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 						const existingIsGeneratedAgentsMd = isOmxGeneratedAgentsMd(existing);
 						managedRefreshContent = teamModeEnabled(resolvedTeamMode)
 							? upsertAgentsModelTable(
-									existing,
-									modelTableContext,
-									modelTableDefinitions,
-								)
+								existing,
+								modelTableContext,
+								modelTableDefinitions,
+								{ codexHomeOverride: scopeDirs.codexHomeDir },
+							)
 							: existingIsGeneratedAgentsMd
 								? rewritten
 								: upsertManagedAgentsBlock(existing, rewritten);

--- a/src/config/__tests__/models.test.ts
+++ b/src/config/__tests__/models.test.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_SPARK_MODEL,
   DEFAULT_TEAM_CHILD_MODEL,
   getAgentReasoningOverride,
+  getAgentModelOverride,
   getEnvConfiguredStandardDefaultModel,
   getMainDefaultModel,
   getModelForMode,
@@ -16,6 +17,7 @@ import {
   getTeamChildModel,
   getTeamLowComplexityModel,
   readAgentReasoningOverrides,
+  readAgentModelOverrides,
   readConfiguredEnvOverrides,
 } from '../models.js';
 
@@ -264,6 +266,26 @@ describe('getModelForMode', () => {
     });
     assert.equal(getAgentReasoningOverride('ARCHITECT'), 'xhigh');
     assert.equal(getAgentReasoningOverride('executor'), undefined);
+  });
+
+  it('reads normalized per-agent model overrides from .omx-config.json', async () => {
+    await writeConfig({
+      agentModels: {
+        Architect: ' gpt-5.5 ',
+        critic: 'gpt-5.4',
+        executor: '',
+        researcher: 42,
+        'bad role': 'gpt-5',
+      },
+    });
+
+    assert.deepEqual(readAgentModelOverrides(), {
+      architect: 'gpt-5.5',
+      critic: 'gpt-5.4',
+    });
+    assert.equal(getAgentModelOverride('ARCHITECT'), 'gpt-5.5');
+    assert.equal(getAgentModelOverride('executor'), undefined);
+    assert.equal(getAgentModelOverride('bad role'), undefined);
   });
 
   it('keeps explicit low-complexity config ahead of OMX_DEFAULT_SPARK_MODEL', async () => {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -16,6 +16,9 @@
  *   },
  *   "agentReasoning": {
  *     "architect": "xhigh"
+ *   },
+ *   "agentModels": {
+ *     "architect": "gpt-5.5"
  *   }
  * }
  *
@@ -39,6 +42,7 @@ export type ConfiguredAgentReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh'
 
 interface OmxConfigFile {
   agentReasoning?: Record<string, unknown>;
+  agentModels?: Record<string, unknown>;
   env?: OmxConfigEnv;
   models?: ModelsConfig;
 }
@@ -174,6 +178,31 @@ export function getAgentReasoningOverride(
   const normalized = normalizeAgentName(agentName);
   if (!normalized) return undefined;
   return readAgentReasoningOverrides(codexHomeOverride)[normalized];
+}
+
+export function readAgentModelOverrides(
+  codexHomeOverride?: string,
+): Record<string, string> {
+  const config = readOmxConfigFile(codexHomeOverride);
+  const raw = config?.agentModels;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+
+  const resolved: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    const role = normalizeAgentName(key);
+    const model = normalizeConfiguredValue(value);
+    if (role && model) resolved[role] = model;
+  }
+  return resolved;
+}
+
+export function getAgentModelOverride(
+  agentName: string | undefined,
+  codexHomeOverride?: string,
+): string | undefined {
+  const normalized = normalizeAgentName(agentName);
+  if (!normalized) return undefined;
+  return readAgentModelOverrides(codexHomeOverride)[normalized];
 }
 
 export function readActiveProviderEnvOverrides(

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -192,6 +192,23 @@ describe('team model contract', () => {
     });
   });
 
+  it('honors per-agent model overrides before class and spark fallback routing', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-model-contract-agent-models-'));
+    try {
+      await writeFile(join(codexHome, '.omx-config.json'), JSON.stringify({
+        agentModels: {
+          architect: 'gpt-5.5-architect',
+          explore: 'gpt-5.5-explore',
+        },
+      }));
+
+      assert.equal(resolveAgentDefaultModel('architect', codexHome), 'gpt-5.5-architect');
+      assert.equal(resolveAgentDefaultModel('explore', codexHome), 'gpt-5.5-explore');
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
   it('keeps assigned worker roles as their own runtime identity', () => {
     withIsolatedDefaultModelEnv(() => {
       assert.equal(resolveAgentDefaultModel('explore'), expectedLowComplexityModel());

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -1,6 +1,7 @@
 import { getAgent } from '../agents/definitions.js';
 import {
   DEFAULT_SPARK_MODEL,
+  getAgentModelOverride,
   getAgentReasoningOverride,
   getMainDefaultModel,
   getSparkDefaultModel,
@@ -221,6 +222,8 @@ export function resolveAgentDefaultModel(
   if (typeof agentType !== 'string' || agentType.trim() === '') return undefined;
   const normalized = agentType.trim().toLowerCase();
   if (normalized === '') return undefined;
+  const modelOverride = getAgentModelOverride(normalized, codexHomeOverride);
+  if (modelOverride) return modelOverride;
   if (normalized.endsWith('-low')) return resolveTeamLowComplexityDefaultModel(codexHomeOverride);
   if (normalized === 'executor') return getMainDefaultModel(codexHomeOverride);
 

--- a/src/utils/__tests__/agents-model-table.test.ts
+++ b/src/utils/__tests__/agents-model-table.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   buildAgentsModelTable,
   OMX_MODELS_END_MARKER,
@@ -87,6 +90,33 @@ describe('agents model table', () => {
     assert.match(table, /\| `critic` \| `gpt-frontier` \| high \| Plan\/design critical challenge and review \(frontier-orchestrator, frontier\) \|/);
     assert.match(table, /\| `writer` \| `gpt-standard` \| high \| Documentation, migration notes, user guidance \(fast-lane, standard\) \|/);
     assert.match(table, /\| `executor` \| `gpt-frontier` \| medium \| Code implementation, refactoring, feature work \(deep-worker, standard\) \|/);
+  });
+
+  it('reflects per-agent model and reasoning overrides', async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-agents-model-table-'));
+    try {
+      await writeFile(join(codexHome, '.omx-config.json'), JSON.stringify({
+        agentModels: {
+          architect: 'gpt-5.5-architect',
+          explore: 'gpt-5.5-explore',
+        },
+        agentReasoning: {
+          architect: 'xhigh',
+          explore: 'medium',
+        },
+      }));
+
+      const table = buildAgentsModelTable({
+        frontierModel: 'gpt-frontier',
+        sparkModel: 'gpt-spark',
+        subagentDefaultModel: 'gpt-standard',
+      }, undefined, { codexHomeOverride: codexHome });
+
+      assert.match(table, /\| `architect` \| `gpt-5\.5-architect` \| xhigh \|/);
+      assert.match(table, /\| `explore` \| `gpt-5\.5-explore` \| medium \|/);
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
   });
 
   it('replaces existing marker-bounded content and inserts the block after team_model_resolution when missing', () => {

--- a/src/utils/agents-model-table.ts
+++ b/src/utils/agents-model-table.ts
@@ -5,6 +5,8 @@ import { getRootModelName } from '../config/generator.js';
 import {
   DEFAULT_FRONTIER_MODEL,
   DEFAULT_SPARK_MODEL,
+  getAgentModelOverride,
+  getAgentReasoningOverride,
   getEnvConfiguredSparkDefaultModel,
   getEnvConfiguredMainDefaultModel,
   getEnvConfiguredStandardDefaultModel,
@@ -22,6 +24,10 @@ export interface AgentsModelTableContext {
   subagentDefaultModel: string;
 }
 
+interface AgentsModelTableOptions {
+  codexHomeOverride?: string;
+}
+
 function escapeTableCell(value: string): string {
   return value.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
 }
@@ -33,7 +39,12 @@ function formatRoleLabel(role: string): string {
 function getAgentRecommendedModel(
   agent: AgentDefinition,
   context: AgentsModelTableContext,
+  options: AgentsModelTableOptions = {},
 ): string {
+  const modelOverride = getAgentModelOverride(agent.name, options.codexHomeOverride);
+  if (modelOverride) {
+    return modelOverride;
+  }
   if (agent.exactModel) {
     return agent.exactModel;
   }
@@ -51,6 +62,14 @@ function getAgentRecommendedModel(
     default:
       return context.subagentDefaultModel;
   }
+}
+
+function getAgentReasoningEffort(
+  agent: AgentDefinition,
+  options: AgentsModelTableOptions = {},
+): string {
+  return getAgentReasoningOverride(agent.name, options.codexHomeOverride)
+    ?? agent.reasoningEffort;
 }
 
 function getAgentUseCase(agent: AgentDefinition): string {
@@ -113,6 +132,7 @@ export function resolveAgentsModelTableContext(
 export function buildAgentsModelTable(
   context: AgentsModelTableContext,
   definitions: Record<string, AgentDefinition> = AGENT_DEFINITIONS,
+  options: AgentsModelTableOptions = {},
 ): string {
   const rows = [
     buildTableRow(
@@ -136,8 +156,8 @@ export function buildAgentsModelTable(
     ...getModelTableAgents(definitions).map((agent) =>
       buildTableRow(
         agent.name,
-        getAgentRecommendedModel(agent, context),
-        agent.reasoningEffort,
+        getAgentRecommendedModel(agent, context, options),
+        getAgentReasoningEffort(agent, options),
         getAgentUseCase(agent),
       ),
     ),
@@ -157,10 +177,11 @@ export function buildAgentsModelTable(
 export function renderAgentsModelTableBlock(
   context: AgentsModelTableContext,
   definitions: Record<string, AgentDefinition> = AGENT_DEFINITIONS,
+  options: AgentsModelTableOptions = {},
 ): string {
   return [
     OMX_MODELS_START_MARKER,
-    buildAgentsModelTable(context, definitions),
+    buildAgentsModelTable(context, definitions, options),
     OMX_MODELS_END_MARKER,
   ].join('\n');
 }
@@ -169,8 +190,9 @@ export function upsertAgentsModelTable(
   content: string,
   context: AgentsModelTableContext,
   definitions: Record<string, AgentDefinition> = AGENT_DEFINITIONS,
+  options: AgentsModelTableOptions = {},
 ): string {
-  const block = renderAgentsModelTableBlock(context, definitions);
+  const block = renderAgentsModelTableBlock(context, definitions, options);
   const startIndex = content.indexOf(OMX_MODELS_START_MARKER);
   const endIndex = content.indexOf(OMX_MODELS_END_MARKER);
 


### PR DESCRIPTION
## Summary
- Add top-level `.omx-config.json` `agentModels` parsing with normalized agent keys and lenient non-empty string values.
- Apply per-agent model overrides before exact pins/model-class routing across native agent TOML generation, team/Ralph fallback resolution, AGENTS.md model tables, and Spark doctor diagnostics.
- Document schema, precedence, regeneration flow, and max-quality starter config.

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/config/__tests__/models.test.js dist/agents/__tests__/native-config.test.js dist/team/__tests__/model-contract.test.js dist/utils/__tests__/agents-model-table.test.js dist/cli/__tests__/doctor-spark-routing.test.js`

Closes #2849.

Final merge remains owner-confirmation gated because this adds a user-facing config contract.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*