### PR TITLE
Fix madmax run history discovery for resume/search

### DIFF
--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -328,6 +328,114 @@ printf '{"type":"session_meta","payload":{"id":"new-project-resume"}}\n' > "$COD
     }
   });
 
+  it('includes associated madmax boxed run-root sessions for plain resume', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-madmax-runtime-'));
+    try {
+      const home = join(wd, 'home');
+      const runsRoot = join(wd, 'runs');
+      const projectCodexHome = join(wd, '.codex');
+      const madmaxCodexHome = join(runsRoot, 'run-associated', '.omx', 'runtime', 'codex-home', 'omx-madmax-runtime');
+      const unrelatedCodexHome = join(runsRoot, 'run-unrelated', '.omx', 'runtime', 'codex-home', 'omx-unrelated-runtime');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const associatedRolloutPath = join(madmaxCodexHome, 'sessions', '2026', '06', '17', 'rollout-madmax-session.jsonl');
+      const unrelatedRolloutPath = join(unrelatedCodexHome, 'sessions', '2026', '06', '17', 'rollout-unrelated-session.jsonl');
+      const unrelatedSource = join(wd, 'unrelated-source');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await mkdir(projectCodexHome, { recursive: true });
+      await mkdir(join(wd, '.omx'), { recursive: true });
+      await mkdir(dirname(associatedRolloutPath), { recursive: true });
+      await mkdir(dirname(unrelatedRolloutPath), { recursive: true });
+      await mkdir(unrelatedSource, { recursive: true });
+      await writeFile(associatedRolloutPath, '{"type":"session_meta","payload":{"id":"madmax-session"}}\n');
+      await writeFile(unrelatedRolloutPath, '{"type":"session_meta","payload":{"id":"unrelated-session"}}\n');
+      await writeFile(join(runsRoot, 'registry.jsonl'), `${JSON.stringify({ source_cwd: wd, run_dir: join(runsRoot, 'run-associated') })}\n${JSON.stringify({ source_cwd: unrelatedSource, run_dir: join(runsRoot, 'run-unrelated') })}\n`);
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+      await writeFile(fakeCodexPath, `#!/bin/sh
+printf 'fake-codex:%s\n' "$*"
+if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-madmax-session.jsonl" ]; then echo madmax-rollout-present=yes; else echo madmax-rollout-present=no; fi
+if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-unrelated-session.jsonl" ]; then echo unrelated-rollout-present=yes; else echo unrelated-rollout-present=no; fi
+`);
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+
+      const result = runOmx(wd, ['resume'], {
+        HOME: home,
+        OMX_RUNS_DIR: runsRoot,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      });
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, /fake-codex:resume\b/);
+      assert.match(result.stdout, /madmax-rollout-present=yes/);
+      assert.match(result.stdout, /unrelated-rollout-present=no/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps madmax runtime history deduped across repeated resume cleanup', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-madmax-dedupe-'));
+    try {
+      const home = join(wd, 'home');
+      const runsRoot = join(wd, 'runs');
+      const projectCodexHome = join(wd, '.codex');
+      const madmaxCodexHome = join(runsRoot, 'run-associated', '.omx', 'runtime', 'codex-home', 'omx-madmax-runtime');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const associatedRolloutPath = join(madmaxCodexHome, 'sessions', '2026', '06', '17', 'rollout-madmax-session.jsonl');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await mkdir(projectCodexHome, { recursive: true });
+      await mkdir(join(wd, '.omx'), { recursive: true });
+      await mkdir(dirname(associatedRolloutPath), { recursive: true });
+      await writeFile(join(projectCodexHome, 'history.jsonl'), '{"session_id":"project-session"}\n');
+      await writeFile(join(projectCodexHome, 'session_index.jsonl'), '{"id":"project-session"}\n');
+      await writeFile(associatedRolloutPath, '{"type":"session_meta","payload":{"id":"madmax-session"}}\n');
+      await writeFile(join(madmaxCodexHome, 'history.jsonl'), '{"session_id":"madmax-session"}\n');
+      await writeFile(join(madmaxCodexHome, 'session_index.jsonl'), '{"id":"madmax-session"}\n');
+      await writeFile(join(runsRoot, 'registry.jsonl'), `${JSON.stringify({ source_cwd: wd, run_dir: join(runsRoot, 'run-associated') })}\n`);
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+      await writeFile(fakeCodexPath, '#!/bin/sh\nprintf \'fake-codex:%s\\n\' "$*"\n');
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+      const env = {
+        HOME: home,
+        OMX_RUNS_DIR: runsRoot,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      };
+
+      const first = runOmx(wd, ['resume'], env);
+      assert.equal(first.status, 0, first.error || first.stderr || first.stdout);
+      const second = runOmx(wd, ['resume'], env);
+      assert.equal(second.status, 0, second.error || second.stderr || second.stdout);
+
+      assert.equal(
+        await readFile(join(projectCodexHome, 'history.jsonl'), 'utf-8'),
+        '{"session_id":"project-session"}\n{"session_id":"madmax-session"}\n',
+      );
+      assert.equal(
+        await readFile(join(projectCodexHome, 'session_index.jsonl'), 'utf-8'),
+        '{"id":"project-session"}\n{"id":"madmax-session"}\n',
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('forwards --last to codex resume through the normal launch wrapper', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-resume-cli-'));
     try {

--- a/src/cli/__tests__/session-search.test.ts
+++ b/src/cli/__tests__/session-search.test.ts
@@ -130,6 +130,47 @@ describe('omx session search', () => {
     }
   });
 
+  it('searches associated madmax boxed run roots without leaking raw run paths', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-search-madmax-'));
+    const home = join(cwd, 'home');
+    const runsRoot = join(cwd, 'runs');
+    const associatedCodexHome = join(runsRoot, 'run-associated', '.omx', 'runtime', 'codex-home', 'omx-madmax-a');
+    const unrelatedCodexHome = join(runsRoot, 'run-unrelated', '.omx', 'runtime', 'codex-home', 'omx-madmax-b');
+    const unrelatedSource = join(cwd, 'unrelated-source');
+    try {
+      await mkdir(unrelatedSource, { recursive: true });
+      await writeRollout(associatedCodexHome, '2026-03-11T12:00:00.000Z', 'rollout-associated.jsonl', [
+        { type: 'session_meta', payload: { id: 'madmax-session', timestamp: '2026-03-11T12:00:00.000Z', cwd } },
+        { type: 'event_msg', payload: { type: 'user_message', message: 'associated madmax boxed search target' } },
+      ]);
+      await writeRollout(unrelatedCodexHome, '2026-03-11T12:00:00.000Z', 'rollout-unrelated.jsonl', [
+        { type: 'session_meta', payload: { id: 'unrelated-session', timestamp: '2026-03-11T12:00:00.000Z', cwd: unrelatedSource } },
+        { type: 'event_msg', payload: { type: 'user_message', message: 'associated madmax boxed search target unrelated' } },
+      ]);
+      await writeFile(join(runsRoot, 'registry.jsonl'), `${JSON.stringify({ source_cwd: cwd, run_dir: join(runsRoot, 'run-associated') })}\n${JSON.stringify({ source_cwd: unrelatedSource, run_dir: join(runsRoot, 'run-unrelated') })}\n`);
+
+      const result = runOmx(cwd, ['session', 'search', 'associated madmax boxed search target', '--json'], {
+        HOME: home,
+        CODEX_HOME: '',
+        OMX_RUNS_DIR: runsRoot,
+        OMX_ROOT: '',
+        OMX_STATE_ROOT: '',
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const parsed = JSON.parse(result.stdout) as {
+        results: Array<{ session_id: string; transcript_path: string }>;
+        sources: Array<{ codex_home: string }>;
+      };
+      assert.deepEqual(parsed.results.map((result) => result.session_id), ['madmax-session']);
+      assert.ok(parsed.sources.some((source) => source.codex_home === 'madmax:omx-madmax-a'));
+      assert.equal(parsed.sources.some((source) => source.codex_home.includes(runsRoot)), false);
+      assert.equal(parsed.results.some((result) => result.transcript_path.includes(runsRoot)), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('searches only the explicit --codex-home path', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-search-cli-codex-home-'));
     const home = join(cwd, 'home');

--- a/src/cli/project-runtime-codex-homes.ts
+++ b/src/cli/project-runtime-codex-homes.ts
@@ -1,14 +1,32 @@
-import { existsSync } from 'node:fs';
-import { readdir } from 'node:fs/promises';
-import { join } from 'node:path';
+import { existsSync, realpathSync } from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { omxRoot } from '../utils/paths.js';
 
 export interface ProjectRuntimeCodexHome {
   path: string;
   sessionCountHint: number;
+  source: 'project' | 'madmax-run';
+  publicLabel?: string;
+}
+
+interface MadmaxRunMetadata {
+  source_cwd?: unknown;
+  run_dir?: unknown;
+  cwd?: unknown;
 }
 
 export async function discoverProjectRuntimeCodexHomes(cwd: string): Promise<ProjectRuntimeCodexHome[]> {
+  const localHomes = await discoverLocalProjectRuntimeCodexHomes(cwd);
+  const madmaxHomes = await discoverAssociatedMadmaxRuntimeCodexHomes(cwd);
+  return [...localHomes, ...madmaxHomes].sort((a, b) => {
+    if (a.source !== b.source) return a.source === 'project' ? -1 : 1;
+    return b.path.localeCompare(a.path);
+  });
+}
+
+async function discoverLocalProjectRuntimeCodexHomes(cwd: string): Promise<ProjectRuntimeCodexHome[]> {
   const root = join(omxRoot(cwd), 'runtime', 'codex-home');
   if (!existsSync(root)) return [];
 
@@ -21,10 +39,107 @@ export async function discoverProjectRuntimeCodexHomes(cwd: string): Promise<Pro
     const sessions = join(home, 'sessions');
     if (!existsSync(sessions)) continue;
     const sessionCountHint = await countImmediateSessionEntries(sessions);
-    homes.push({ path: home, sessionCountHint });
+    homes.push({ path: home, sessionCountHint, source: 'project' });
   }
 
-  return homes.sort((a, b) => b.path.localeCompare(a.path));
+  return homes;
+}
+
+async function discoverAssociatedMadmaxRuntimeCodexHomes(
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ProjectRuntimeCodexHome[]> {
+  const runsRoot = resolveMadmaxRunsRoot(env);
+  if (!existsSync(runsRoot)) return [];
+
+  const associatedRunDirs = await discoverAssociatedMadmaxRunDirs(cwd, runsRoot);
+  const homes: ProjectRuntimeCodexHome[] = [];
+  for (const runDir of associatedRunDirs) {
+    const codexHomeRoot = join(runDir, '.omx', 'runtime', 'codex-home');
+    const entries = await readdir(codexHomeRoot, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      if (!entry.isDirectory() || !entry.name.startsWith('omx-')) continue;
+      const home = join(codexHomeRoot, entry.name);
+      const sessions = join(home, 'sessions');
+      if (!existsSync(sessions)) continue;
+      homes.push({
+        path: home,
+        sessionCountHint: await countImmediateSessionEntries(sessions),
+        source: 'madmax-run',
+        publicLabel: `madmax:${entry.name}`,
+      });
+    }
+  }
+  return homes;
+}
+
+async function discoverAssociatedMadmaxRunDirs(cwd: string, runsRoot: string): Promise<string[]> {
+  const canonicalCwd = canonicalizeComparableProjectPath(cwd);
+  const canonicalRunsRoot = resolve(runsRoot);
+  const seen = new Set<string>();
+  const runDirs: string[] = [];
+
+  const addMetadata = (raw: unknown): void => {
+    const metadata = parseMadmaxRunMetadata(raw);
+    if (!metadata) return;
+    if (canonicalizeComparableProjectPath(metadata.sourceCwd) !== canonicalCwd) return;
+    const runDir = resolve(metadata.runDir);
+    if (!isPathWithin(runDir, canonicalRunsRoot)) return;
+    if (!existsSync(runDir) || seen.has(runDir)) return;
+    seen.add(runDir);
+    runDirs.push(runDir);
+  };
+
+  const registryPath = join(runsRoot, 'registry.jsonl');
+  const rawRegistry = await readFile(registryPath, 'utf-8').catch(() => '');
+  for (const line of rawRegistry.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      addMetadata(JSON.parse(trimmed));
+    } catch {}
+  }
+
+  const entries = await readdir(runsRoot, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith('run-')) continue;
+    const metadataPath = join(runsRoot, entry.name, '.omxbox-run.json');
+    try {
+      addMetadata(JSON.parse(await readFile(metadataPath, 'utf-8')));
+    } catch {}
+  }
+
+  return runDirs.sort((a, b) => b.localeCompare(a));
+}
+
+function resolveMadmaxRunsRoot(env: NodeJS.ProcessEnv): string {
+  return resolve(env.OMX_RUNS_DIR || join(homedir(), '.omx-runs'));
+}
+
+function parseMadmaxRunMetadata(raw: unknown): { sourceCwd: string; runDir: string } | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const record = raw as MadmaxRunMetadata;
+  const sourceCwd = typeof record.source_cwd === 'string' ? record.source_cwd.trim() : '';
+  const runDir = typeof record.run_dir === 'string'
+    ? record.run_dir.trim()
+    : typeof record.cwd === 'string'
+      ? record.cwd.trim()
+      : '';
+  if (!sourceCwd || !runDir) return null;
+  return { sourceCwd, runDir };
+}
+
+function canonicalizeComparableProjectPath(rawPath: string): string {
+  const resolved = resolve(rawPath);
+  try {
+    return realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function isPathWithin(candidatePath: string, rootPath: string): boolean {
+  return candidatePath === rootPath || candidatePath.startsWith(`${rootPath}/`);
 }
 
 async function countImmediateSessionEntries(sessionsDir: string): Promise<number> {

--- a/src/session-history/search.ts
+++ b/src/session-history/search.ts
@@ -59,29 +59,38 @@ export interface SessionSearchSourceReport {
   codex_home: string;
   searched_files: number;
 }
+interface ResolvedSessionSearchCodexHome {
+  dir: string;
+  publicLabel: string;
+}
+
 
 function clampInteger(value: number, fallback: number, max: number): number {
   if (!Number.isInteger(value) || value < 0) return fallback;
   return Math.min(value, max);
 }
 
-async function normalizeExistingCodexHomeDirs(candidates: string[]): Promise<string[]> {
+async function normalizeExistingCodexHomeDirs(candidates: Array<string | ResolvedSessionSearchCodexHome>): Promise<ResolvedSessionSearchCodexHome[]> {
   const seen = new Set<string>();
-  const dirs: string[] = [];
+  const dirs: ResolvedSessionSearchCodexHome[] = [];
   for (const candidate of candidates) {
-    const trimmed = candidate.trim();
+    const rawDir = typeof candidate === 'string' ? candidate : candidate.dir;
+    const trimmed = rawDir.trim();
     if (trimmed === '') continue;
     const absolute = resolve(trimmed);
     if (!existsSync(absolute)) continue;
     const key = await realpath(absolute).catch(() => absolute);
     if (seen.has(key)) continue;
     seen.add(key);
-    dirs.push(absolute);
+    dirs.push({
+      dir: absolute,
+      publicLabel: typeof candidate === 'string' ? absolute : candidate.publicLabel,
+    });
   }
   return dirs;
 }
 
-export async function resolveSessionSearchCodexHomeDirs(options: Pick<SessionSearchOptions, 'cwd' | 'codexHomeDir' | 'codexHomeDirs'> = {}): Promise<string[]> {
+async function resolveSessionSearchCodexHomeSources(options: Pick<SessionSearchOptions, 'cwd' | 'codexHomeDir' | 'codexHomeDirs'> = {}): Promise<ResolvedSessionSearchCodexHome[]> {
   const cwd = options.cwd ?? process.cwd();
   if (options.codexHomeDirs && options.codexHomeDirs.length > 0) {
     return normalizeExistingCodexHomeDirs(options.codexHomeDirs);
@@ -90,7 +99,17 @@ export async function resolveSessionSearchCodexHomeDirs(options: Pick<SessionSea
     return normalizeExistingCodexHomeDirs([options.codexHomeDir]);
   }
   const projectHomes = await discoverProjectRuntimeCodexHomes(cwd);
-  return normalizeExistingCodexHomeDirs([codexHome(), ...projectHomes.map((home) => home.path)]);
+  return normalizeExistingCodexHomeDirs([
+    codexHome(),
+    ...projectHomes.map((home) => ({
+      dir: home.path,
+      publicLabel: home.source === 'madmax-run' ? home.publicLabel ?? 'madmax:runtime-codex-home' : home.path,
+    })),
+  ]);
+}
+
+export async function resolveSessionSearchCodexHomeDirs(options: Pick<SessionSearchOptions, 'cwd' | 'codexHomeDir' | 'codexHomeDirs'> = {}): Promise<string[]> {
+  return (await resolveSessionSearchCodexHomeSources(options)).map((source) => source.dir);
 }
 function normalizeProjectFilter(project: string | undefined, cwd: string): string | undefined {
   if (!project) return undefined;
@@ -302,6 +321,7 @@ async function searchRolloutFile(
     projectFilter?: string;
     cwd: string;
     codexHomeDir: string;
+    codexHomeDisplay: string;
   },
 ): Promise<{ meta: SessionMeta | null; results: SessionSearchResult[] }> {
   const stream = createReadStream(filePath, 'utf-8');
@@ -343,7 +363,7 @@ async function searchRolloutFile(
           session_id: meta.sessionId,
           timestamp: meta.timestamp,
           cwd: meta.cwd,
-          transcript_path: filePath,
+          transcript_path: join(options.codexHomeDisplay, relative(options.codexHomeDir, filePath)),
           transcript_path_relative: relative(options.codexHomeDir, filePath),
           record_type: candidate.recordType,
           line_number: lineNumber,
@@ -370,6 +390,7 @@ async function searchCodexHomeDir(
     sinceCutoff: number | null;
     projectFilter?: string;
     cwd: string;
+    codexHomeDisplay: string;
   },
 ): Promise<{ searchedFiles: number; matchedSessions: Set<string>; results: SessionSearchResult[] }> {
   const rolloutRoot = join(codexHomeDir, 'sessions');
@@ -398,6 +419,7 @@ async function searchCodexHomeDir(
       projectFilter: options.projectFilter,
       cwd: options.cwd,
       codexHomeDir,
+      codexHomeDisplay: options.codexHomeDisplay,
     });
 
     for (const result of fileSearch.results) {
@@ -416,7 +438,7 @@ export async function searchSessionHistory(options: SessionSearchOptions): Promi
   }
 
   const cwd = options.cwd ?? process.cwd();
-  const codexHomeDirs = await resolveSessionSearchCodexHomeDirs(options);
+  const codexHomeSources = await resolveSessionSearchCodexHomeSources(options);
   const limit = clampInteger(options.limit ?? DEFAULT_LIMIT, DEFAULT_LIMIT, MAX_LIMIT) || DEFAULT_LIMIT;
   const context = clampInteger(options.context ?? DEFAULT_CONTEXT, DEFAULT_CONTEXT, MAX_CONTEXT) || DEFAULT_CONTEXT;
   const caseSensitive = options.caseSensitive === true;
@@ -428,8 +450,8 @@ export async function searchSessionHistory(options: SessionSearchOptions): Promi
   const matchedSessions = new Set<string>();
   const sources: SessionSearchSourceReport[] = [];
 
-  for (const codexHomeDir of codexHomeDirs) {
-    const sourceSearch = await searchCodexHomeDir(codexHomeDir, {
+  for (const codexHomeSource of codexHomeSources) {
+    const sourceSearch = await searchCodexHomeDir(codexHomeSource.dir, {
       query,
       context,
       caseSensitive,
@@ -438,9 +460,10 @@ export async function searchSessionHistory(options: SessionSearchOptions): Promi
       sinceCutoff,
       projectFilter,
       cwd,
+      codexHomeDisplay: codexHomeSource.publicLabel,
     });
     searchedFiles += sourceSearch.searchedFiles;
-    sources.push({ codex_home: codexHomeDir, searched_files: sourceSearch.searchedFiles });
+    sources.push({ codex_home: codexHomeSource.publicLabel, searched_files: sourceSearch.searchedFiles });
     for (const sessionId of sourceSearch.matchedSessions) matchedSessions.add(sessionId);
     for (const result of sourceSearch.results) {
       results.push(result);


### PR DESCRIPTION
## Summary
- discover madmax boxed run-root Codex homes associated with the current source repo via public-safe run metadata
- include associated madmax histories in resume/project resume and session search while ignoring unrelated run roots
- redact madmax raw run paths from session-search public JSON/text source paths and preserve history/index de-dupe behavior

## Verification
- npm run build
- env -u OMX_ROOT -u OMX_STATE_ROOT -u OMX_SESSION_ID -u CODEX_SESSION_ID -u SESSION_ID node --test dist/cli/__tests__/resume.test.js dist/cli/__tests__/session-search.test.js
- npm run check:no-unused
- npm run lint

Closes #2851