### PR TITLE
feat(vscode): add direct session API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,3 +17,12 @@ export { mergeConfig } from './config/generator.js';
 export { AGENT_DEFINITIONS, type AgentDefinition } from './agents/definitions.js';
 export { generateAgentToml, installNativeAgentConfigs } from './agents/native-config.js';
 export { hudCommand } from './hud/index.js';
+export {
+  buildDirectSessionArgs,
+  findDangerousLaunchArgs,
+  launchDirectSession,
+  launchRequiresDangerousApproval,
+  redactOmxLogLine,
+  resolveVscodeLaunchEnv,
+  runOmxCatalogCommand,
+} from './vscode/index.js';

--- a/src/vscode/__tests__/index.test.ts
+++ b/src/vscode/__tests__/index.test.ts
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict';
+import type { ChildProcess, SpawnOptions } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import { describe, it } from 'node:test';
+import {
+  buildDirectSessionArgs,
+  findDangerousLaunchArgs,
+  launchDirectSession,
+  launchRequiresDangerousApproval,
+  resolveVscodeLaunchEnv,
+  runOmxCatalogCommand,
+} from '../index.js';
+
+function fakeChildProcess(): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  child.stdout = new PassThrough() as ChildProcess['stdout'];
+  child.stderr = new PassThrough() as ChildProcess['stderr'];
+  Object.defineProperty(child, 'pid', { value: 12345 });
+  child.kill = (() => true) as ChildProcess['kill'];
+  return child;
+}
+
+async function withTempDir(test: (cwd: string) => Promise<void>): Promise<void> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-vscode-direct-'));
+  try {
+    await test(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+async function readFileEventually(path: string): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      return await readFile(path, 'utf8');
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  throw lastError;
+}
+
+describe('VSCode direct session API', () => {
+  it('builds direct launch args without preserving conflicting tmux policy flags', () => {
+    assert.deepEqual(
+      buildDirectSessionArgs({ codexArgs: ['--tmux', '--model', 'gpt-5', '--direct'] }),
+      ['launch', '--direct', '--model', 'gpt-5'],
+    );
+    assert.deepEqual(
+      buildDirectSessionArgs({ mode: 'resume', codexArgs: ['--tmux', '--last'] }),
+      ['resume', '--direct', '--last'],
+    );
+  });
+
+  it('requires explicit approval for dangerous launch flags', () => {
+    const args = buildDirectSessionArgs({ codexArgs: ['--madmax', '--yolo'] });
+    assert.equal(launchRequiresDangerousApproval(args), true);
+    assert.deepEqual(findDangerousLaunchArgs(args), ['--madmax', '--yolo']);
+    assert.throws(
+      () => launchDirectSession({
+        cwd: process.cwd(),
+        codexArgs: ['--dangerously-bypass-approvals-and-sandbox'],
+        sessionId: 'test-danger',
+      }),
+      /dangerous_launch_requires_approval/,
+    );
+  });
+
+  it('spawns omx in direct mode with VSCode session environment and log path', async () => {
+    await withTempDir(async (cwd) => {
+      let capturedCommand = '';
+      let capturedArgs: string[] = [];
+      let capturedOptions: SpawnOptions | undefined;
+      const child = fakeChildProcess();
+      const spawn = (command: string, args: string[], options: SpawnOptions): ChildProcess => {
+        capturedCommand = command;
+        capturedArgs = [...args];
+        capturedOptions = options;
+        return child;
+      };
+
+      const handle = launchDirectSession({
+        cwd,
+        omxCommand: 'custom-omx',
+        prompt: 'ship the extension',
+        sessionId: 'vscode-test-session',
+        env: { PATH: '/bin' },
+      }, {
+        spawn,
+        now: () => new Date('2026-06-13T00:00:00.000Z'),
+      });
+
+      assert.equal(capturedCommand, 'custom-omx');
+      assert.deepEqual(capturedArgs, ['launch', '--direct', 'ship the extension']);
+      assert.equal(capturedOptions?.cwd, cwd);
+      assert.equal((capturedOptions?.env as NodeJS.ProcessEnv).OMX_LAUNCH_POLICY, 'direct');
+      assert.equal((capturedOptions?.env as NodeJS.ProcessEnv).OMX_VSCODE_SESSION_ID, 'vscode-test-session');
+      assert.equal((capturedOptions?.env as NodeJS.ProcessEnv).OMX_VSCODE_LOG_PATH, handle.log_path);
+      assert.equal(handle.pid, 12345);
+      assert.equal(handle.stop(), true);
+
+      child.emit('exit', 0, null);
+      await new Promise((resolve) => setImmediate(resolve));
+    });
+  });
+
+  it('redacts child process output before writing VSCode session logs', async () => {
+    await withTempDir(async (cwd) => {
+      const child = fakeChildProcess();
+      const logPath = join(cwd, 'vscode-session.log');
+
+      launchDirectSession({
+        cwd,
+        omxCommand: 'custom-omx',
+        sessionId: 'vscode-redaction-session',
+        logPath,
+      }, {
+        spawn: () => child,
+        now: () => new Date('2026-06-13T00:00:00.000Z'),
+      });
+
+      child.stdout?.emit('data', 'Authorization: Bearer sk-live-token\n');
+      child.stderr?.emit('data', 'access_token=plain-secret\n');
+      child.emit('exit', 0, null);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const log = await readFileEventually(logPath);
+      assert.doesNotMatch(log, /sk-live-token/);
+      assert.doesNotMatch(log, /plain-secret/);
+      assert.match(log, /\[REDACTED]/);
+    });
+  });
+
+  it('builds VSCode launch env through the shared platform command resolver', async () => {
+    await withTempDir(async (cwd) => {
+      const binDir = join(cwd, 'bin');
+      await mkdir(binDir, { recursive: true });
+      const codexPath = join(binDir, 'codex');
+      await writeFile(codexPath, '#!/bin/sh\n');
+      await chmod(codexPath, 0o755);
+
+      const resolution = resolveVscodeLaunchEnv({
+        cwd,
+        omxCommand: join(cwd, 'dist', 'cli', 'omx.js'),
+        baseEnv: { PATH: '' },
+        extraPath: [binDir, binDir],
+        platform: 'linux',
+      });
+
+      assert.equal(resolution.codexPath, codexPath);
+      assert.equal(resolution.env.PATH?.split(delimiter)[0], binDir);
+      assert.equal(resolution.pathEntries.filter((entry) => entry === binDir).length, 1);
+      assert.ok(resolution.pathEntries.includes(join(cwd, 'dist', 'cli')));
+      assert.ok(resolution.pathEntries.includes(join(cwd, 'node_modules', '.bin')));
+    });
+  });
+
+  it('runs catalog commands with VSCode direct-session environment', async () => {
+    await withTempDir(async (cwd) => {
+      const scriptPath = join(cwd, 'catalog-env.cjs');
+      await writeFile(scriptPath, [
+        'process.stdout.write(JSON.stringify({',
+        '  policy: process.env.OMX_LAUNCH_POLICY,',
+        '  runner: process.env.OMX_VSCODE_RUNNER,',
+        '  argv: process.argv.slice(2),',
+        '}));',
+        '',
+      ].join('\n'));
+
+      const result = runOmxCatalogCommand({
+        cwd,
+        omxCommand: process.execPath,
+        args: [scriptPath, 'doctor', '--json'],
+      });
+
+      assert.equal(result.code, 0);
+      const payload = JSON.parse(result.stdout) as { policy?: string; runner?: string; argv?: string[] };
+      assert.equal(payload.policy, 'direct');
+      assert.equal(payload.runner, '1');
+      assert.deepEqual(payload.argv, ['doctor', '--json']);
+    });
+  });
+
+});

--- a/src/vscode/index.ts
+++ b/src/vscode/index.ts
@@ -1,0 +1,296 @@
+import { spawn as nodeSpawn, spawnSync as nodeSpawnSync } from 'node:child_process';
+import type { ChildProcess, SpawnOptions } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { createWriteStream, mkdirSync } from 'node:fs';
+import type { WriteStream } from 'node:fs';
+import { homedir } from 'node:os';
+import { delimiter, dirname, isAbsolute, join, resolve } from 'node:path';
+import { redactAuthSecrets } from '../auth/redact.js';
+import { CODEX_BYPASS_FLAG, MADMAX_FLAG, MADMAX_SPARK_FLAG } from '../cli/constants.js';
+import { resolveCommandPathForPlatform } from '../utils/platform-command.js';
+
+export const DIRECT_SESSION_SCHEMA_VERSION = 'omx.vscode/direct-session/v1';
+
+const DEFAULT_OMX_COMMAND = 'omx';
+const LAUNCH_POLICY_ENV = 'OMX_LAUNCH_POLICY';
+const VSCODE_RUNNER_ENV = 'OMX_VSCODE_RUNNER';
+const VSCODE_SESSION_ENV = 'OMX_VSCODE_SESSION_ID';
+const VSCODE_LOG_ENV = 'OMX_VSCODE_LOG_PATH';
+const DIRECT_POLICY_FLAGS = new Set(['--direct', '--tmux']);
+const DANGEROUS_FLAGS = new Set([
+  MADMAX_FLAG,
+  MADMAX_SPARK_FLAG,
+  CODEX_BYPASS_FLAG,
+  '--yolo',
+]);
+
+export type DirectSessionMode = 'launch' | 'resume';
+
+export interface BuildDirectSessionArgsOptions {
+  mode?: DirectSessionMode;
+  codexArgs?: string[];
+}
+
+export interface LaunchDirectSessionOptions extends BuildDirectSessionArgsOptions {
+  cwd: string;
+  prompt?: string;
+  omxCommand?: string;
+  env?: NodeJS.ProcessEnv;
+  dangerousApproved?: boolean;
+  logPath?: string;
+  sessionId?: string;
+}
+
+export interface ResolveVscodeLaunchEnvOptions {
+  cwd: string;
+  omxCommand?: string;
+  baseEnv?: NodeJS.ProcessEnv;
+  extraPath?: string[];
+  platform?: NodeJS.Platform;
+}
+
+export interface VscodeLaunchEnvResolution {
+  env: NodeJS.ProcessEnv;
+  pathKey: string;
+  pathEntries: string[];
+  codexPath: string | null;
+}
+
+export interface OmxDirectSessionHandle {
+  schema_version: typeof DIRECT_SESSION_SCHEMA_VERSION;
+  session_id: string;
+  cwd: string;
+  command: string;
+  args: string[];
+  pid?: number;
+  log_path: string;
+  started_at: string;
+  child: ChildProcess;
+  stop: (signal?: NodeJS.Signals | number) => boolean;
+}
+
+export interface RunOmxCatalogCommandOptions {
+  cwd: string;
+  omxCommand?: string;
+  args: string[];
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}
+
+export interface RunOmxCatalogCommandResult {
+  command: string;
+  args: string[];
+  stdout: string;
+  stderr: string;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
+
+interface LaunchDirectSessionDeps {
+  spawn?: (command: string, args: string[], options: SpawnOptions) => ChildProcess;
+  now?: () => Date;
+  randomId?: () => string;
+}
+
+function normalizeCwd(cwd: string): string {
+  const normalized = cwd.trim();
+  if (!normalized) throw new Error('cwd is required');
+  return resolve(normalized);
+}
+
+function stripPolicyFlags(args: readonly string[]): string[] {
+  return args.filter((arg) => !DIRECT_POLICY_FLAGS.has(arg));
+}
+
+function dedupePathEntries(entries: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const entry of entries) {
+    const trimmed = entry.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+function resolvePathKey(env: NodeJS.ProcessEnv): string {
+  return Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
+}
+
+function defaultVscodePathEntries(
+  cwd: string,
+  omxCommand: string | undefined,
+  platform: NodeJS.Platform,
+): string[] {
+  const entries = [
+    isAbsolute(omxCommand ?? '') ? dirname(omxCommand as string) : '',
+    join(cwd, 'node_modules', '.bin'),
+    join(homedir(), '.local', 'bin'),
+    join(homedir(), '.npm-global', 'bin'),
+  ];
+
+  if (platform === 'darwin') {
+    entries.push('/Applications/Codex.app/Contents/Resources');
+  }
+  if (platform !== 'win32') {
+    entries.push('/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin');
+  }
+
+  return entries;
+}
+
+export function resolveVscodeLaunchEnv(options: ResolveVscodeLaunchEnvOptions): VscodeLaunchEnvResolution {
+  const cwd = normalizeCwd(options.cwd);
+  const platform = options.platform ?? process.platform;
+  const baseEnv = options.baseEnv ?? process.env;
+  const pathKey = resolvePathKey(baseEnv);
+  const currentPathEntries = String(baseEnv[pathKey] ?? baseEnv.PATH ?? baseEnv.Path ?? '')
+    .split(delimiter)
+    .filter(Boolean);
+  const pathEntries = dedupePathEntries([
+    ...(options.extraPath ?? []),
+    ...defaultVscodePathEntries(cwd, options.omxCommand, platform),
+    ...currentPathEntries,
+  ]);
+  const mergedPath = pathEntries.join(delimiter);
+  const env = {
+    ...baseEnv,
+    [pathKey]: mergedPath,
+    PATH: mergedPath,
+  };
+
+  return {
+    env,
+    pathKey,
+    pathEntries,
+    codexPath: resolveCommandPathForPlatform('codex', platform, env),
+  };
+}
+
+export function buildDirectSessionArgs(options: BuildDirectSessionArgsOptions = {}): string[] {
+  const mode = options.mode ?? 'launch';
+  const codexArgs = stripPolicyFlags(options.codexArgs ?? []);
+  return mode === 'resume'
+    ? ['resume', '--direct', ...codexArgs]
+    : ['launch', '--direct', ...codexArgs];
+}
+
+export function findDangerousLaunchArgs(args: readonly string[]): string[] {
+  return args.filter((arg) => DANGEROUS_FLAGS.has(arg));
+}
+
+export function launchRequiresDangerousApproval(args: readonly string[]): boolean {
+  return findDangerousLaunchArgs(args).length > 0;
+}
+
+export function redactOmxLogLine(value: unknown): string {
+  return redactAuthSecrets(value);
+}
+
+function defaultSessionId(now: Date = new Date()): string {
+  const suffix = randomBytes(4).toString('hex');
+  return `vscode-${now.getTime()}-${suffix}`;
+}
+
+function defaultLogPath(cwd: string, sessionId: string): string {
+  return join(cwd, '.omx', 'logs', 'vscode', `${sessionId}.log`);
+}
+
+function ensureLogStream(path: string): WriteStream {
+  mkdirSync(dirname(path), { recursive: true });
+  return createWriteStream(path, { flags: 'a' });
+}
+
+function writeLog(stream: WriteStream, text: string): void {
+  stream.write(redactOmxLogLine(text));
+}
+
+function resolveLaunchEnv(
+  baseEnv: NodeJS.ProcessEnv,
+  sessionId: string,
+  logPath: string,
+): NodeJS.ProcessEnv {
+  return {
+    ...baseEnv,
+    [LAUNCH_POLICY_ENV]: 'direct',
+    [VSCODE_RUNNER_ENV]: '1',
+    [VSCODE_SESSION_ENV]: sessionId,
+    [VSCODE_LOG_ENV]: logPath,
+  };
+}
+
+export function launchDirectSession(
+  options: LaunchDirectSessionOptions,
+  deps: LaunchDirectSessionDeps = {},
+): OmxDirectSessionHandle {
+  const cwd = normalizeCwd(options.cwd);
+  const now = deps.now?.() ?? new Date();
+  const sessionId = options.sessionId ?? deps.randomId?.() ?? defaultSessionId(now);
+  const command = options.omxCommand?.trim() || DEFAULT_OMX_COMMAND;
+  const promptArg = typeof options.prompt === 'string' && options.prompt.trim() !== ''
+    ? [options.prompt]
+    : [];
+  const args = buildDirectSessionArgs({
+    mode: options.mode,
+    codexArgs: [...(options.codexArgs ?? []), ...promptArg],
+  });
+  const dangerousArgs = findDangerousLaunchArgs(args);
+  if (dangerousArgs.length > 0 && options.dangerousApproved !== true) {
+    throw new Error(`dangerous_launch_requires_approval:${dangerousArgs.join(',')}`);
+  }
+
+  const logPath = options.logPath ? resolve(options.logPath) : defaultLogPath(cwd, sessionId);
+  const logStream = ensureLogStream(logPath);
+  const env = resolveLaunchEnv(options.env ?? process.env, sessionId, logPath);
+  const spawnOptions: SpawnOptions = {
+    cwd,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  };
+  const child = (deps.spawn ?? nodeSpawn)(command, args, spawnOptions);
+  const startedAt = now.toISOString();
+  writeLog(logStream, `[${startedAt}] $ ${command} ${args.join(' ')}\n`);
+
+  child.stdout?.on('data', (chunk: Buffer | string) => writeLog(logStream, String(chunk)));
+  child.stderr?.on('data', (chunk: Buffer | string) => writeLog(logStream, String(chunk)));
+  child.on('error', (error) => {
+    writeLog(logStream, `\n[${new Date().toISOString()}] launch error: ${redactOmxLogLine(error)}\n`);
+  });
+  child.on('exit', (code, signal) => {
+    writeLog(logStream, `\n[${new Date().toISOString()}] exited code=${code ?? 'null'} signal=${signal ?? 'null'}\n`);
+    logStream.end();
+  });
+
+  return {
+    schema_version: DIRECT_SESSION_SCHEMA_VERSION,
+    session_id: sessionId,
+    cwd,
+    command,
+    args,
+    pid: child.pid,
+    log_path: logPath,
+    started_at: startedAt,
+    child,
+    stop: (signal: NodeJS.Signals | number = 'SIGTERM') => child.kill(signal),
+  };
+}
+
+export function runOmxCatalogCommand(options: RunOmxCatalogCommandOptions): RunOmxCatalogCommandResult {
+  const cwd = normalizeCwd(options.cwd);
+  const command = options.omxCommand?.trim() || DEFAULT_OMX_COMMAND;
+  const result = nodeSpawnSync(command, options.args, {
+    cwd,
+    env: { ...(options.env ?? process.env), [LAUNCH_POLICY_ENV]: 'direct', [VSCODE_RUNNER_ENV]: '1' },
+    encoding: 'utf8',
+    timeout: options.timeoutMs ?? 120_000,
+  });
+  return {
+    command,
+    args: [...options.args],
+    stdout: String(result.stdout ?? ''),
+    stderr: result.error ? result.error.message : String(result.stderr ?? ''),
+    code: typeof result.status === 'number' ? result.status : null,
+    signal: result.signal as NodeJS.Signals | null,
+  };
+}


### PR DESCRIPTION
## Why this PR

This is the first small slice of a larger VS Code extension effort. The earlier all-in-one proposal (#2853) bundled the extension package, Chat, Control Center, Log Explorer, and core APIs in one PR, which made it size/XL and hard to review.

This PR intentionally stops at the smallest reusable foundation: a UI-facing direct-session API that a future VS Code extension can call without duplicating launch, PATH, approval, or log-redaction behavior.

## What is included

- build direct `omx launch/resume --direct` arguments while stripping conflicting tmux policy flags
- detect dangerous launch flags and require explicit approval before process launch
- resolve the VS Code launch environment, including Codex PATH lookup through the shared platform command resolver
- launch OMX direct sessions with VS Code session/log env vars
- redact child stdout/stderr before writing VS Code session logs
- run catalog commands with the same direct-session environment

## What is intentionally not included

- no VS Code extension package yet
- no webviews yet
- no workspace snapshot/log explorer APIs yet
- no Chat/Control Center UI yet

Those are follow-up PRs once this base API is accepted.

## Planned follow-up stack

1. direct-session API (this PR)
2. workspace snapshot and log search APIs
3. VS Code extension package skeleton
4. Chat webview with persisted conversation store
5. Control Center and Log Explorer webviews

## Tests

- `npm run build`
- `node --test dist/vscode/__tests__/index.test.js`

Supersedes part of #2853 and replaces the still-too-large #2854.