### PR TITLE
fix(hud): stabilize standalone two-pane HUD ownership

### DIFF
--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -674,6 +674,94 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(Object.hasOwn(created[1]?.options ?? {}, 'fullWidth'), false);
   });
 
+  it('keeps pane-scoped standalone HUDs stable when two leaders share a window bottom', async () => {
+    const killed: string[] = [];
+    const created: Array<{ options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
+    const resized: Array<{ paneId: string; heightLines: number }> = [];
+
+    const codexPane = (paneId: string, paneLeft: number, paneWidth: number) => ({
+      paneId,
+      currentCommand: 'codex',
+      startCommand: 'codex',
+      paneLeft,
+      paneWidth,
+      paneBottom: 36,
+      windowWidth: 160,
+      windowHeight: 40,
+    });
+    const hudPane = (paneId: string, sessionId: string, leaderPaneId: string, paneLeft: number, paneWidth: number) => ({
+      paneId,
+      currentCommand: 'node',
+      startCommand: `exec env OMX_SESSION_ID='${sessionId}' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='${leaderPaneId}' node omx hud --watch --preset=focused`,
+      paneLeft,
+      paneWidth,
+      paneHeight: HUD_TMUX_HEIGHT_LINES,
+      paneBottom: 39,
+      windowWidth: 160,
+      windowHeight: 40,
+    });
+
+    const leftRepeatResult = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%left', OMX_SESSION_ID: 'sess-left', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        codexPane('%left', 0, 80),
+        codexPane('%right', 80, 80),
+        hudPane('%hud-left', 'sess-left', '%left', 0, 80),
+        hudPane('%hud-right', 'sess-right', '%right', 80, 80),
+      ],
+      createHudWatchPane: (_cwd, _cmd, options) => {
+        created.push({ options });
+        return '%hud-left-repeat';
+      },
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      resizeTmuxPane: (paneId, heightLines) => {
+        resized.push({ paneId, heightLines });
+        return true;
+      },
+      registerHudResizeHook: noOpRegisterHudResizeHook,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    const rightCreateResult = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%right', OMX_SESSION_ID: 'sess-right', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        codexPane('%left', 0, 80),
+        codexPane('%right', 80, 80),
+        hudPane('%hud-left', 'sess-left', '%left', 0, 80),
+        // This is the launch-time standalone split for pane B. It is pane-scoped,
+        // not full-window width, so prompt-submit/layout reconcile must keep it
+        // instead of killing it and recreating a full-width HUD that competes with
+        // pane A's HUD.
+        hudPane('%hud-right', 'sess-right', '%right', 80, 80),
+      ],
+      createHudWatchPane: (_cwd, _cmd, options) => {
+        created.push({ options });
+        return '%hud-right-repeat';
+      },
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      resizeTmuxPane: (paneId, heightLines) => {
+        resized.push({ paneId, heightLines });
+        return true;
+      },
+      registerHudResizeHook: noOpRegisterHudResizeHook,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(leftRepeatResult.status, 'unchanged');
+    assert.equal(leftRepeatResult.paneId, '%hud-left');
+    assert.equal(rightCreateResult.status, 'unchanged');
+    assert.equal(rightCreateResult.paneId, '%hud-right');
+    assert.deepEqual(killed, []);
+    assert.deepEqual(created, []);
+    assert.deepEqual(resized, []);
+  });
+
   it('collapses same-owner HUD panes that appear during the create race window', async () => {
     const killed: string[] = [];
     const resized: Array<{ paneId: string; heightLines: number }> = [];
@@ -1412,7 +1500,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(unregistered, ['%1']);
     assert.deepEqual(killed, ['%2']);
     assert.equal(created.length, 1);
-    assert.equal(created[0]?.options?.fullWidth, true);
+    assert.equal(Object.hasOwn(created[0]?.options ?? {}, 'fullWidth'), false);
     assert.equal(created[0]?.options?.targetPaneId, '%1');
     assert.equal(created[0]?.options?.heightLines, HUD_TMUX_HEIGHT_LINES);
     assert.deepEqual(resized, [{ paneId: '%9', heightLines: HUD_TMUX_HEIGHT_LINES }]);
@@ -1573,7 +1661,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(unregistered, ['%1']);
     assert.deepEqual(killed, ['%bad-a', '%bad-b']);
     assert.equal(created.length, 1);
-    assert.equal(created[0]?.options?.fullWidth, true);
+    assert.equal(Object.hasOwn(created[0]?.options ?? {}, 'fullWidth'), false);
     assert.equal(created[0]?.options?.targetPaneId, '%1');
   });
 

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -178,11 +178,24 @@ function hasCompleteGeometry(pane: TmuxPaneSnapshot): boolean {
   );
 }
 
-function needsHudTopologyRecreate(pane: TmuxPaneSnapshot): boolean {
+function needsHudTopologyRecreate(pane: TmuxPaneSnapshot, leaderPane?: TmuxPaneSnapshot): boolean {
   if (!hasCompleteGeometry(pane)) return false;
-  const spansWindowWidth = pane.paneLeft === 0 && pane.paneWidth === pane.windowWidth;
+  const expectedLeft = typeof leaderPane?.paneLeft === 'number' ? leaderPane.paneLeft : 0;
+  const expectedWidth = typeof leaderPane?.paneWidth === 'number' ? leaderPane.paneWidth : pane.windowWidth;
+  const spansExpectedWidth = pane.paneLeft === expectedLeft && pane.paneWidth === expectedWidth;
   const touchesWindowBottom = pane.paneBottom === (pane.windowHeight ?? 0) - 1;
-  return !spansWindowWidth || !touchesWindowBottom;
+  return !spansExpectedWidth || !touchesWindowBottom;
+}
+
+function shouldCreateFullWidthHud(leaderPane?: TmuxPaneSnapshot): boolean {
+  return Boolean(
+    leaderPane
+    && typeof leaderPane.paneLeft === 'number'
+    && typeof leaderPane.paneWidth === 'number'
+    && typeof leaderPane.windowWidth === 'number'
+    && leaderPane.paneLeft === 0
+    && leaderPane.paneWidth === leaderPane.windowWidth,
+  );
 }
 
 function needsHudHeightResize(pane: TmuxPaneSnapshot, desiredHeight: number): boolean {
@@ -310,11 +323,14 @@ export async function reconcileHudForPromptSubmit(
     omxTeamStateRoot: env.OMX_TEAM_STATE_ROOT,
     rootSource: env.OMX_TEAM_STATE_ROOT ? 'team-env' : env.OMX_ROOT ? 'omx-root-env' : env.OMX_STATE_ROOT ? 'omx-state-root-env' : 'cwd-default',
   });
+  const leaderPane = currentPaneId
+    ? panes.find((pane) => pane.paneId === currentPaneId && !isHudWatchPane(pane))
+    : undefined;
 
   const singleHudPane = hudPaneIds.length === 1
     ? panes.find((pane) => pane.paneId === hudPaneIds[0])
     : undefined;
-  if (singleHudPane && !needsHudTopologyRecreate(singleHudPane)) {
+  if (singleHudPane && !needsHudTopologyRecreate(singleHudPane, leaderPane)) {
     const shouldResize = needsHudHeightResize(singleHudPane, desiredHeight);
     const resized = shouldResize ? resizePane(singleHudPane.paneId, desiredHeight) : true;
     if (resized) ensureHudResizeHook(singleHudPane.paneId, currentPaneId, desiredHeight, cwd, deps);
@@ -330,7 +346,7 @@ export async function reconcileHudForPromptSubmit(
     const hudPanes = hudPaneIds
       .map((paneId) => panes.find((pane) => pane.paneId === paneId))
       .filter((pane): pane is TmuxPaneSnapshot => Boolean(pane));
-    const keeperPane = hudPanes.find((pane) => !needsHudTopologyRecreate(pane));
+    const keeperPane = hudPanes.find((pane) => !needsHudTopologyRecreate(pane, leaderPane));
 
     if (keeperPane) {
       for (const paneId of hudPaneIds.filter((paneId) => paneId !== keeperPane.paneId)) {
@@ -348,7 +364,8 @@ export async function reconcileHudForPromptSubmit(
   }
   const createFullWidth = hudPaneIds
     .map((paneId) => panes.find((pane) => pane.paneId === paneId))
-    .some((pane) => Boolean(pane && needsHudTopologyRecreate(pane)));
+    .some((pane) => Boolean(pane && needsHudTopologyRecreate(pane, leaderPane)))
+    && (!leaderPane || shouldCreateFullWidthHud(leaderPane));
 
   if (!resolvedSessionId) {
     return {


### PR DESCRIPTION
## Summary

Closes #2860.

- Treat standalone HUD topology as scoped to the owning leader pane geometry, not always full-window width.
- Preserve the prior full-width recreate behavior for full-width leaders and detached/unknown leader geometry.
- Add a regression for two live standalone leaders in one tmux window keeping independent pane-scoped HUDs stable without cross-owner kill/recreate churn.

## Verification

- `npm run build`
- `PATH=/tmp/omx-issue2860-fakebin:$PATH env -u TMUX -u TMUX_PANE node --test dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/tmux.test.js dist/hud/__tests__/hud-tmux-injection.test.js` — 122/122 pass. The fake tmux shim only supplies roomy `display-message` geometry so tests are not polluted by this agent's own cramped tmux pane.
- Live bounded tmux smoke with manual two-pane session: created two leader panes and two pane-scoped HUD panes, ran `omx hud --reconcile-tmux` for both leaders, and confirmed the original HUD panes stayed alive (`%7`, `%8`) with two HUD panes total.

## Notes

- Checked for open PRs mentioning #2860/standalone HUD flicker before opening; none were present.
- #2828 is Team shutdown/HUD ownership and #2859 is Windows hook shell wrapping; neither already fixes this standalone same-window pane-scoped reconcile path.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
