### PR TITLE
fix: keep native hooks successful on null output

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -598,6 +598,32 @@ describe("codex native hook dispatch", () => {
     );
   });
 
+  it("emits no-op JSON stdout for PreToolUse non-Bash tools with null output", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-pretool-nonbash-noop-"));
+    try {
+      const result = spawnSync(process.execPath, [nativeHookScriptPath()], {
+        cwd,
+        input: JSON.stringify({
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-cli-pretool-nonbash-noop",
+          thread_id: "thread-cli-pretool-nonbash-noop",
+          turn_id: "turn-cli-pretool-nonbash-noop",
+          tool_name: "Read",
+          tool_input: { file_path: "package.json" },
+        }),
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.equal(result.stderr, "");
+      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("emits parseable no-op JSON stdout for inactive Stop CLI runs", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-stop-noop-json-"));
     try {
@@ -611,6 +637,32 @@ describe("codex native hook dispatch", () => {
       const output = parseSingleJsonStdout(stdout);
 
       assert.deepEqual(output, {});
+      assert.equal(existsSync(join(cwd, ".omx", "state")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("emits no-op JSON stdout for Stop payloads with no runtime output", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-stop-null-output-"));
+    try {
+      const result = spawnSync(process.execPath, [nativeHookScriptPath()], {
+        cwd,
+        input: JSON.stringify({
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-cli-stop-null-output",
+          thread_id: "thread-cli-stop-null-output",
+          turn_id: "turn-cli-stop-null-output",
+          stop_hook_active: true,
+        }),
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.equal(result.stderr, "");
+      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
       assert.equal(existsSync(join(cwd, ".omx", "state")), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -4818,7 +4818,7 @@ export async function runCodexNativeHookCli(): Promise<void> {
     const result = await dispatchCodexNativeHook(payload);
     if (result.outputJson) {
       writeNativeHookJsonStdout(result.outputJson);
-    } else if (result.hookEventName === "Stop") {
+    } else if (result.hookEventName !== "PreCompact" && result.hookEventName !== "PostCompact") {
       writeNativeHookJsonStdout({});
     }
   } catch (error) {


### PR DESCRIPTION
## Summary

Fixes #2872 by making successful native hook CLI dispatches that produce no `outputJson` write a safe no-op `{}` response instead of exiting with no stdout. This covers Windows Codex hook paths such as `PreToolUse` for non-Bash tools and no-op `Stop` payloads.

## Changes

- Write `{}` for successful null-output native hook CLI dispatches.
- Preserve existing stdout silence for `PreCompact` / `PostCompact`, which Codex rejects as hook JSON.
- Preserve fail-closed behavior for real non-Stop dispatch exceptions.
- Add CLI regression tests for:
  - `PreToolUse` non-Bash/null output (`Read` tool) exits 0 and emits `{}`.
  - `Stop` no-runtime-output payload exits 0 and emits `{}`.
  - Existing compact silence and dispatch-failure tests remain passing.

## Validation

- [x] `npm run build`
- [x] `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js` (429 tests)
- [ ] `npm test` (not run; targeted hook regression plus build for this focused native-hook fix)
- [ ] `omx doctor` (not setup/config behavior)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed (not needed; behavior is internal native-hook CLI fallback)
- [x] Backward-compatibility impact considered (compact hooks remain stdout-silent; dispatch exceptions remain fail-closed)

## Related

Closes #2872

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
