### PR TITLE
fix(setup): preserve plugin AGENTS policy blocks

### DIFF
--- a/src/cli/__tests__/setup-agents-overwrite.test.ts
+++ b/src/cli/__tests__/setup-agents-overwrite.test.ts
@@ -9,6 +9,8 @@ import {
   addGeneratedAgentsMarker,
   OMX_MANAGED_AGENTS_END_MARKER,
   OMX_MANAGED_AGENTS_START_MARKER,
+  OMX_USER_POLICY_END_MARKER,
+  OMX_USER_POLICY_START_MARKER,
 } from '../../utils/agents-md.js';
 import { resolveAgentsModelTableContext, upsertAgentsModelTable } from '../../utils/agents-model-table.js';
 
@@ -563,6 +565,42 @@ describe('omx setup AGENTS refresh behavior', () => {
       assert.equal(await readlink(codexAgentsPath), missingAgentsPath);
       assert.equal(existsSync(missingAgentsPath), false);
       assert.match(output, /agents_md: updated=0, unchanged=0, backed_up=0, skipped=1, removed=0/);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves user-owned OMX policy blocks during forced plugin defaults refresh', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-plugin-agents-policy-'));
+    const restoreTty = setMockTty(false);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const codexAgentsPath = join(home, '.codex', 'AGENTS.md');
+    const policyBlock = [
+      OMX_USER_POLICY_START_MARKER,
+      'Durable local operator rule: never drop this.',
+      OMX_USER_POLICY_END_MARKER,
+    ].join('\n');
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await mkdir(join(home, '.codex'), { recursive: true });
+      await writeFile(codexAgentsPath, `# Local Instructions\n\n${policyBlock}\n`);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'user',
+        installMode: 'plugin',
+        force: true,
+        pluginDeveloperInstructionsPrompt: async () => false,
+      });
+
+      const agents = await readFile(codexAgentsPath, 'utf-8');
+      assert.match(output, /Generated plugin-mode AGENTS\.md defaults/);
+      assert.match(agents, /# oh-my-codex - Intelligent Multi-Agent Orchestration/);
+      assert.match(agents, /Durable local operator rule: never drop this\./);
+      assert.equal(countOccurrences(agents, OMX_USER_POLICY_START_MARKER), 1);
+      assert.equal(countOccurrences(agents, OMX_USER_POLICY_END_MARKER), 1);
     } finally {
       restoreHome();
       restoreTty();

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -93,6 +93,7 @@ import {
 	hasOmxAgentsContract,
 	hasOmxManagedAgentsSections,
 	isOmxGeneratedAgentsMd,
+	preserveUserOmxPolicyBlocks,
 	upsertManagedAgentsBlock,
 } from "../utils/agents-md.js";
 import { DEFAULT_HUD_CONFIG, type HudPreset } from "../hud/types.js";
@@ -2801,8 +2802,14 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 					}
 				}
 			} else if (usePluginAgentsMdDefault) {
+				const existingPluginAgentsMd = pluginAgentsMdExists
+					? await readFile(pluginAgentsMdDst, "utf-8")
+					: "";
+				const pluginAgentsMdContent = pluginAgentsMdExists
+					? preserveUserOmxPolicyBlocks(existingPluginAgentsMd, rewritten)
+					: rewritten;
 				const defaultWouldChange = pluginAgentsMdExists
-					? (await readFile(pluginAgentsMdDst, "utf-8")) !== rewritten
+					? existingPluginAgentsMd !== pluginAgentsMdContent
 					: true;
 				if (
 					resolvedScope.scope === "project" &&
@@ -2821,7 +2828,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 					console.log("  Stop the active session first, then re-run setup.");
 				} else {
 					const result = await syncManagedAgentsContent(
-						rewritten,
+						pluginAgentsMdContent,
 						pluginAgentsMdDst,
 						summary.agentsMd,
 						backupContext,

--- a/src/utils/__tests__/agents-md.test.ts
+++ b/src/utils/__tests__/agents-md.test.ts
@@ -6,8 +6,12 @@ import {
   hasOmxManagedAgentsSections,
   isOmxGeneratedAgentsMd,
   OMX_GENERATED_AGENTS_MARKER,
+  extractUserOmxPolicyBlocks,
   OMX_MANAGED_AGENTS_END_MARKER,
   OMX_MANAGED_AGENTS_START_MARKER,
+  OMX_USER_POLICY_END_MARKER,
+  OMX_USER_POLICY_START_MARKER,
+  preserveUserOmxPolicyBlocks,
 } from '../agents-md.js';
 
 describe('agents-md helpers', () => {
@@ -120,5 +124,50 @@ describe('agents-md helpers', () => {
     ].join('\n');
 
     assert.equal(hasOmxAgentsContract(content), false);
+  });
+
+  it('extracts complete user-owned OMX policy blocks', () => {
+    const content = [
+      '# Local policy',
+      OMX_USER_POLICY_START_MARKER,
+      'Keep durable operator guidance.',
+      OMX_USER_POLICY_END_MARKER,
+      'after',
+    ].join('\n');
+
+    assert.deepEqual(extractUserOmxPolicyBlocks(content), [
+      [
+        OMX_USER_POLICY_START_MARKER,
+        'Keep durable operator guidance.',
+        OMX_USER_POLICY_END_MARKER,
+      ].join('\n'),
+    ]);
+  });
+
+  it('appends missing user-owned OMX policy blocks to regenerated content', () => {
+    const existing = [
+      '# Local policy',
+      OMX_USER_POLICY_START_MARKER,
+      'Keep durable operator guidance.',
+      OMX_USER_POLICY_END_MARKER,
+      '',
+    ].join('\n');
+    const regenerated = `${OMX_GENERATED_AGENTS_MARKER}\n# New defaults\n`;
+
+    const result = preserveUserOmxPolicyBlocks(existing, regenerated);
+
+    assert.match(result, /# New defaults\n\n<!-- USER:OMX:POLICY:START -->\nKeep durable operator guidance\.\n<!-- USER:OMX:POLICY:END -->\n$/);
+  });
+
+  it('does not duplicate a user-owned OMX policy block already present', () => {
+    const policyBlock = [
+      OMX_USER_POLICY_START_MARKER,
+      'Keep durable operator guidance.',
+      OMX_USER_POLICY_END_MARKER,
+    ].join('\n');
+    const existing = `# Local policy\n${policyBlock}\n`;
+    const regenerated = `${OMX_GENERATED_AGENTS_MARKER}\n${policyBlock}\n`;
+
+    assert.equal(preserveUserOmxPolicyBlocks(existing, regenerated), regenerated);
   });
 });

--- a/src/utils/agents-md.ts
+++ b/src/utils/agents-md.ts
@@ -6,6 +6,9 @@ import {
 export const OMX_GENERATED_AGENTS_MARKER = '<!-- omx:generated:agents-md -->'
 export const OMX_MANAGED_AGENTS_START_MARKER = '<!-- OMX:AGENTS:START -->'
 export const OMX_MANAGED_AGENTS_END_MARKER = '<!-- OMX:AGENTS:END -->'
+export const OMX_USER_POLICY_START_MARKER = '<!-- USER:OMX:POLICY:START -->'
+export const OMX_USER_POLICY_END_MARKER = '<!-- USER:OMX:POLICY:END -->'
+
 export const OMX_AGENTS_CONTRACT_HEADING =
   '# oh-my-codex - Intelligent Multi-Agent Orchestration'
 const OMX_AGENTS_CONTRACT_REQUIRED_TEXT = [
@@ -49,6 +52,37 @@ function candidateHasOmxAgentsContract(content: string): boolean {
   )
 }
 
+export function extractUserOmxPolicyBlocks(content: string): string[] {
+  const blocks: string[] = []
+  let searchFrom = 0
+
+  while (searchFrom < content.length) {
+    const startIndex = content.indexOf(OMX_USER_POLICY_START_MARKER, searchFrom)
+    if (startIndex === -1) break
+
+    const endIndex = content.indexOf(OMX_USER_POLICY_END_MARKER, startIndex)
+    if (endIndex === -1) break
+
+    const blockEnd = endIndex + OMX_USER_POLICY_END_MARKER.length
+    blocks.push(content.slice(startIndex, blockEnd))
+    searchFrom = blockEnd
+  }
+
+  return blocks
+}
+
+export function preserveUserOmxPolicyBlocks(
+  existingContent: string,
+  nextContent: string,
+): string {
+  const missingBlocks = extractUserOmxPolicyBlocks(existingContent).filter(
+    (block) => !nextContent.includes(block),
+  )
+  if (missingBlocks.length === 0) return nextContent
+
+  const normalizedNext = nextContent.endsWith('\n') ? nextContent : `${nextContent}\n`
+  return `${normalizedNext.trimEnd()}\n\n${missingBlocks.join('\n\n')}\n`
+}
 export function upsertManagedAgentsBlock(
   existingContent: string,
   managedContent: string,


### PR DESCRIPTION
## Summary
- preserve `<!-- USER:OMX:POLICY:START -->` / `<!-- USER:OMX:POLICY:END -->` blocks when plugin-mode forced AGENTS.md defaults are regenerated
- add AGENTS.md helper coverage for policy block extraction/preservation
- add setup regression coverage for `omx setup --plugin --force` preserving user-owned policy blocks

Fixes #2867

## Verification
- npm run build
- node dist/scripts/run-test-files.js dist/utils/__tests__/agents-md.test.js dist/cli/__tests__/setup-agents-overwrite.test.js dist/cli/__tests__/setup-install-mode.test.js
- npm run lint
- npx tsc --noEmit
- npm run check:no-unused
- npm run verify:native-agents
- npm run verify:plugin-bundle
- node dist/scripts/generate-catalog-docs.js --check
