### PR TITLE
Fix stale Autopilot Stop hook state

### DIFF
--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, rm, writeFile, readFile } from 'fs/promises';
+import { existsSync } from 'fs';
 import { dirname, join } from 'path';
 import { tmpdir } from 'os';
 import { spawnSync } from 'child_process';
@@ -273,4 +274,62 @@ describe('CLI session-scoped state parity', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+  it('clears current-session autopilot and skill mirrors even when canonical root is inactive', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-clear-stale-autopilot-mirror-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-stale-autopilot-mirror';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(join(stateDir, 'autopilot-state.json'), JSON.stringify({
+        active: false,
+        mode: 'autopilot',
+        current_phase: 'cancelled',
+      }, null, 2));
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: false,
+        skill: '',
+        phase: 'cancelled',
+        active_skills: [],
+      }, null, 2));
+      await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'ultragoal',
+      }, null, 2));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'autopilot',
+        phase: 'ultragoal',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', phase: 'ultragoal', active: true, session_id: sessionId }],
+      }, null, 2));
+      await writeFile(join(sessionDir, 'native-stop-state.json'), JSON.stringify({
+        sessions: { [sessionId]: { last_signature: 'autopilot-stop|stale' } },
+      }, null, 2));
+
+      const clearAutopilot = runOmx(wd, 'state', 'clear', '--input', `{"mode":"autopilot","session_id":"${sessionId}"}`, '--json');
+      assert.equal(clearAutopilot.status, 0, clearAutopilot.stderr || clearAutopilot.stdout);
+      const clearSkill = runOmx(wd, 'state', 'clear', '--input', `{"mode":"skill-active","session_id":"${sessionId}"}`, '--json');
+      assert.equal(clearSkill.status, 0, clearSkill.stderr || clearSkill.stdout);
+      const cancelForce = runOmx(wd, 'cancel', '--force');
+      assert.equal(cancelForce.status, 0, cancelForce.stderr || cancelForce.stdout);
+
+      const autopilot = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8'));
+      assert.equal(autopilot.active, false);
+      assert.equal(autopilot.current_phase, 'cleared');
+      assert.equal(existsSync(join(sessionDir, 'skill-active-state.json')), false);
+      const nativeStop = JSON.parse(await readFile(join(sessionDir, 'native-stop-state.json'), 'utf-8'));
+      assert.deepEqual(nativeStop.sessions, {});
+      const listResult = runOmx(wd, 'state', 'list-active', '--json');
+      assert.equal(listResult.status, 0, listResult.stderr || listResult.stdout);
+      assert.deepEqual(JSON.parse(listResult.stdout), { active_modes: [] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2543,7 +2543,7 @@ export async function main(args: string[]): Promise<void> {
         await showStatus();
         break;
       case "cancel":
-        await cancelModes();
+        await cancelModes(args.slice(1));
         break;
       case "reasoning":
         await reasoningCommand(args.slice(1));
@@ -6190,10 +6190,11 @@ async function listHookVisibleRunDirStateRefs(cwd: string): Promise<ModeStateFil
   return refs.sort((a, b) => a.mode.localeCompare(b.mode));
 }
 
-async function cancelModes(): Promise<void> {
+async function cancelModes(args: string[] = []): Promise<void> {
   const { writeFile, readFile } = await import("fs/promises");
   const cwd = process.cwd();
   const nowIso = new Date().toISOString();
+  const force = args.includes("--force");
   try {
     const loadStates = async (refs: ModeStateFileRef[]) => {
       const loaded = new Map<
@@ -6233,6 +6234,8 @@ async function cancelModes(): Promise<void> {
       if (hasActiveWorkflowMode(runDirStates)) states = runDirStates;
     }
 
+    const currentSession = await readSessionState(cwd).catch(() => null);
+    const currentSessionId = typeof currentSession?.session_id === "string" ? currentSession.session_id.trim() : "";
     const changed = new Set<string>();
     const reported = new Set<string>();
 
@@ -6289,6 +6292,19 @@ async function cancelModes(): Promise<void> {
     for (const [mode, entry] of states.entries()) {
       if (!changed.has(mode)) continue;
       await writeFile(entry.path, JSON.stringify(entry.state, null, 2));
+    }
+    if (force && currentSessionId) {
+      const stopStateEntries = [...states.entries()].filter(([mode]) => mode === "native-stop");
+      for (const [, entry] of stopStateEntries) {
+        const sessions = entry.state.sessions && typeof entry.state.sessions === "object" && !Array.isArray(entry.state.sessions)
+          ? { ...(entry.state.sessions as Record<string, unknown>) }
+          : null;
+        if (!sessions || !Object.prototype.hasOwnProperty.call(sessions, currentSessionId)) continue;
+        delete sessions[currentSessionId];
+        entry.state.sessions = sessions;
+        await writeFile(entry.path, JSON.stringify(entry.state, null, 2));
+        changed.add("native-stop");
+      }
     }
 
     for (const mode of reported) {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -812,6 +812,83 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("does not block Stop on stale session autopilot mirror when canonical skill state is inactive", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stale-autopilot-mirror-"));
+    try {
+      const sessionId = "sess-stale-autopilot-mirror";
+      await writeJson(join(cwd, ".omx", "state", "session.json"), { session_id: sessionId, cwd });
+      await writeJson(join(cwd, ".omx", "state", "skill-active-state.json"), {
+        version: 1,
+        active: false,
+        skill: "",
+        phase: "cancelled",
+        active_skills: [],
+      });
+      await writeJson(join(cwd, ".omx", "state", "sessions", sessionId, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "ultragoal",
+        session_id: sessionId,
+      });
+      await writeJson(join(cwd, ".omx", "state", "sessions", sessionId, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "autopilot",
+        phase: "ultragoal",
+        session_id: sessionId,
+        active_skills: [{ skill: "autopilot", phase: "ultragoal", active: true, session_id: sessionId }],
+      });
+
+      const stdout = runNativeHookCli({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        thread_id: "thread-stale-autopilot-mirror",
+      }, { cwd });
+
+      assert.deepEqual(parseSingleJsonStdout(stdout), {});
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("includes blocking state source and canonical agreement in Stop diagnostics", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autopilot-diagnostic-"));
+    try {
+      const sessionId = "sess-autopilot-diagnostic";
+      await writeJson(join(cwd, ".omx", "state", "session.json"), { session_id: sessionId, cwd });
+      await writeJson(join(cwd, ".omx", "state", "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "autopilot",
+        phase: "ultragoal",
+        session_id: sessionId,
+        active_skills: [{ skill: "autopilot", phase: "ultragoal", active: true, session_id: sessionId }],
+      });
+      await writeJson(join(cwd, ".omx", "state", "sessions", sessionId, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "ultragoal",
+        session_id: sessionId,
+      });
+
+      const output = parseSingleJsonStdout(runNativeHookCli({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        thread_id: "thread-autopilot-diagnostic",
+      }, { cwd })) as { decision?: string; reason?: string; statePath?: string; canonicalDisagreement?: string };
+
+      assert.equal(output.decision, "block");
+      assert.match(String(output.reason ?? ""), /state: \.omx\/state\/sessions\/sess-autopilot-diagnostic\/autopilot-state\.json/);
+      assert.match(String(output.reason ?? ""), /canonical: canonical_agrees/);
+      assert.equal(output.statePath, ".omx/state/sessions/sess-autopilot-diagnostic/autopilot-state.json");
+      assert.equal(output.canonicalDisagreement, "canonical_agrees");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("emits exactly one parseable JSON object for active Stop CLI continuation", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-stop-json-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -13,6 +13,7 @@ import {
   readSkillActiveState,
   readVisibleSkillActiveStateForStateDir,
   type SkillActiveStateLike,
+  type SkillActiveEntry,
 } from "../state/skill-active.js";
 import {
   isTrustedSubagentThread,
@@ -40,7 +41,7 @@ import {
 } from "../team/state.js";
 import { omxNotepadPath, resolveProjectMemoryPath } from "../utils/paths.js";
 import { findGitLayout } from "../utils/git-layout.js";
-import { getBaseStateDir, getStateFilePath, getStatePath } from "../mcp/state-paths.js";
+import { getBaseStateDir, getStateFilePath, getStatePath, getAuthoritativeActiveStatePaths } from "../mcp/state-paths.js";
 import {
   detectKeywords,
   detectPrimaryKeyword,
@@ -2227,6 +2228,76 @@ function isStopExempt(payload: CodexHookPayload): boolean {
   );
 }
 
+async function readModeStateWithStopSource(
+  mode: "autopilot" | "ultrawork" | "ultraqa",
+  cwd: string,
+  sessionId?: string,
+): Promise<{ state: Record<string, unknown>; path: string } | null> {
+  const paths = await getAuthoritativeActiveStatePaths(mode, cwd, sessionId?.trim() || undefined).catch(() => [] as string[]);
+  const path = paths[0];
+  if (!path) return null;
+  const state = await readJsonIfExists(path);
+  return state ? { state, path } : null;
+}
+async function readRawSkillActiveState(path: string): Promise<SkillActiveStateLike | null> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf-8"));
+    return parsed && typeof parsed === "object" ? parsed as SkillActiveStateLike : null;
+  } catch {
+    return null;
+  }
+}
+
+
+function canonicalStopDisagreement(modeState: Record<string, unknown>, canonicalState: SkillActiveStateLike | null, mode: string, sessionId?: string): string {
+  if (!canonicalState) return "canonical_state_missing";
+  const normalizedSessionId = safeString(sessionId).trim();
+  const activeEntry = listRawActiveSkillEntries(canonicalState).find((entry) => {
+    if (entry.skill !== mode) return false;
+    const entrySessionId = safeString(entry.session_id ?? canonicalState.session_id).trim();
+    return normalizedSessionId ? entrySessionId === normalizedSessionId || entrySessionId === "" : true;
+  });
+  if (!activeEntry) return "canonical_inactive";
+  if (mode === "autopilot") {
+    const phase = safeString(modeState.current_phase ?? modeState.currentPhase).trim();
+    const canonicalPhase = safeString(activeEntry.phase ?? canonicalState.phase).trim();
+    if (phase && canonicalPhase && normalizeAutopilotPhase(phase) !== normalizeAutopilotPhase(canonicalPhase)) {
+      return `canonical_phase:${canonicalPhase}`;
+    }
+  }
+  return "canonical_agrees";
+}
+
+function listRawActiveSkillEntries(state: SkillActiveStateLike | null): SkillActiveEntry[] {
+  if (!state) return [];
+  const entries: SkillActiveEntry[] = [];
+  if (Array.isArray(state.active_skills)) {
+    for (const candidate of state.active_skills) {
+      if (!candidate || typeof candidate !== "object") continue;
+      const raw = candidate as unknown as Record<string, unknown>;
+      const skill = safeString(raw.skill).trim();
+      if (!skill || raw.active === false) continue;
+      entries.push({
+        ...raw,
+        skill,
+        phase: safeString(raw.phase).trim() || undefined,
+        session_id: safeString(raw.session_id).trim() || undefined,
+        thread_id: safeString(raw.thread_id).trim() || undefined,
+      });
+    }
+  }
+  const topLevelSkill = safeString(state.skill).trim();
+  if (state.active === true && topLevelSkill) {
+    entries.push({
+      skill: topLevelSkill,
+      phase: safeString(state.phase).trim() || undefined,
+      session_id: safeString(state.session_id).trim() || undefined,
+      thread_id: safeString(state.thread_id).trim() || undefined,
+    });
+  }
+  return entries;
+}
+
 async function buildModeBasedStopOutput(
   mode: "autopilot" | "ultrawork" | "ultraqa",
   cwd: string,
@@ -2238,17 +2309,38 @@ async function buildModeBasedStopOutput(
   if (mode === "autopilot" && await readAutopilotDeepInterviewQuestionWaitState(cwd, sessionId)) {
     return null;
   }
-  const state = await readModeStateForActiveDecision(mode, sessionId?.trim() || undefined, cwd);
+  const sourcedState = await readModeStateWithStopSource(mode, cwd, sessionId);
+  const state = sourcedState?.state ?? null;
   if (!state || !shouldContinueRun(state)) return null;
+  const rootCanonicalState = await readRawSkillActiveState(getSkillActiveStatePathsForStateDir(getBaseStateDir(cwd)).rootPath);
+  const canonicalDisagreement = rootCanonicalState
+    ? canonicalStopDisagreement(state, rootCanonicalState, mode, sessionId)
+    : "canonical_state_missing";
+  if (canonicalDisagreement === "canonical_inactive") return null;
   const phase = formatPhase(state.current_phase);
+  if (!rootCanonicalState || mode !== "autopilot") {
+    const systemMessage = mode === "autopilot" && phase.toLowerCase().replace(/_/g, "-") === "code-review"
+      ? "OMX autopilot is still active (phase: code-review). Run the required $code-review step before completing or clearing Autopilot state."
+      : `OMX ${mode} is still active (phase: ${phase}).`;
+    return {
+      decision: "block",
+      reason: `OMX ${mode} is still active (phase: ${phase}); continue the task and gather fresh verification evidence before stopping.`,
+      stopReason: `${mode}_${phase}`,
+      systemMessage,
+    };
+  }
+  const statePath = sourcedState ? formatStopStatePath(cwd, sourcedState.path) : "unknown";
+  const diagnostic = `state: ${statePath}; canonical: ${canonicalDisagreement}`;
   const systemMessage = mode === "autopilot" && phase.toLowerCase().replace(/_/g, "-") === "code-review"
-    ? "OMX autopilot is still active (phase: code-review). Run the required $code-review step before completing or clearing Autopilot state."
-    : `OMX ${mode} is still active (phase: ${phase}).`;
+    ? `OMX autopilot is still active (phase: code-review; ${diagnostic}). Run the required $code-review step before completing or clearing Autopilot state.`
+    : `OMX ${mode} is still active (phase: ${phase}; ${diagnostic}).`;
   return {
     decision: "block",
-    reason: `OMX ${mode} is still active (phase: ${phase}); continue the task and gather fresh verification evidence before stopping.`,
+    reason: `OMX ${mode} is still active (phase: ${phase}; ${diagnostic}); continue the task and gather fresh verification evidence before stopping.`,
     stopReason: `${mode}_${phase}`,
     systemMessage,
+    statePath,
+    canonicalDisagreement,
   };
 }
 

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -159,6 +159,32 @@ async function writeClearedSessionScopedModeState(
   await writeAtomicFile(path, JSON.stringify(clearedState, null, 2));
 }
 
+async function clearSessionNativeStopState(baseStateDir: string, sessionId: string): Promise<string[]> {
+  const paths = [
+    join(baseStateDir, 'native-stop-state.json'),
+    join(baseStateDir, 'sessions', sessionId, 'native-stop-state.json'),
+  ];
+  const changed: string[] = [];
+  for (const path of paths) {
+    if (!existsSync(path)) continue;
+    let state: Record<string, unknown>;
+    try {
+      state = JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    const sessions = state.sessions && typeof state.sessions === 'object' && !Array.isArray(state.sessions)
+      ? { ...(state.sessions as Record<string, unknown>) }
+      : null;
+    if (!sessions || !Object.prototype.hasOwnProperty.call(sessions, sessionId)) continue;
+    delete sessions[sessionId];
+    state.sessions = sessions;
+    await writeAtomicFile(path, JSON.stringify(state, null, 2));
+    changed.push(path);
+  }
+  return changed;
+}
+
 function readModeSupportsStrictValidation(mode: string): mode is SupportedStateReadMode {
   return SUPPORTED_STATE_READ_MODES.includes(mode as SupportedStateReadMode);
 }
@@ -628,6 +654,9 @@ export async function executeStateOperation(
           } else if (existsSync(path)) {
             await unlink(path);
           }
+          const nativeStopCleared = effectiveSessionId
+            ? await clearSessionNativeStopState(baseStateDir, effectiveSessionId)
+            : [];
           if (mode !== SKILL_ACTIVE_STATE_MODE) {
             await syncCanonicalSkillStateForMode({
               cwd,
@@ -638,7 +667,7 @@ export async function executeStateOperation(
               source: 'state-operations',
             });
           }
-          return { payload: { cleared: true, mode, path } };
+          return { payload: { cleared: true, mode, path, ...(nativeStopCleared.length > 0 ? { native_stop_cleared: nativeStopCleared } : {}) } };
         }
 
         const removedPaths: string[] = [];


### PR DESCRIPTION
## Summary
- Reconcile Stop hook Autopilot blocking with canonical skill-active state so stale session mirrors no longer block exit
- Add Stop diagnostics for Autopilot blockers showing source state file and canonical agreement/disagreement
- Clear native Stop replay mirrors during state clear and cancel --force for the current session

Fixes #2876

## Verification
- npm run build
- node --test dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/session-scoped-runtime.test.js
- npm run lint