### PR TITLE
Fix ralplan guard and HUD phase authority

### DIFF
--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -703,6 +703,58 @@ describe('readAllState canonical skill precedence', () => {
     });
   });
 
+  it('keeps session-scoped ralplan phase authoritative over stale canonical autopilot phase', async () => {
+    await withTempRepo('omx-hud-ralplan-session-authority-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-ralplan-advanced';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'autopilot',
+        phase: 'ralplan',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', phase: 'ralplan', active: true, session_id: sessionId }],
+      }));
+      await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'code-review',
+        session_id: sessionId,
+      }));
+
+      const state = await readAllState(cwd);
+      assert.deepEqual(state.autopilot, { active: true, mode: 'autopilot', current_phase: 'code-review', session_id: sessionId });
+      assert.equal(stripSgr(renderHud(state, 'focused')).includes('autopilot:code-review'), true);
+    });
+  });
+
+  it('uses canonical phase only when active mode detail has no phase', async () => {
+    await withTempRepo('omx-hud-canonical-fill-missing-phase-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-missing-phase';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'ralplan',
+        phase: 'critic_review',
+        session_id: sessionId,
+        active_skills: [{ skill: 'ralplan', phase: 'critic_review', active: true, session_id: sessionId }],
+      }));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        active: true,
+        iteration: 2,
+        session_id: sessionId,
+      }));
+
+      const state = await readAllState(cwd);
+      assert.deepEqual(state.ralplan, { active: true, iteration: 2, session_id: sessionId, current_phase: 'critic-review' });
+    });
+  });
+
   it('surfaces code-review from canonical skill-active without detail state', async () => {
     await withTempRepo('omx-hud-canonical-code-review-', async (cwd) => {
       const rootStateDir = join(cwd, '.omx', 'state');

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -423,6 +423,16 @@ export function buildGitBranchLabel(
 }
 
 const TERMINAL_OR_INACTIVE_PHASES = new Set(['complete', 'completed', 'cancelled', 'canceled', 'failed', 'inactive', 'cleared']);
+function normalizeCanonicalHudPhase(phase: string | undefined): string | undefined {
+  const raw = sanitizeOptionalString(phase);
+  if (!raw) return undefined;
+  const namespaced = raw.includes(':') ? raw.slice(raw.lastIndexOf(':') + 1) : raw;
+  const normalized = sanitizeOptionalString(namespaced)?.toLowerCase().replace(/_/g, '-');
+  if (!normalized || TERMINAL_OR_INACTIVE_PHASES.has(normalized)) return undefined;
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(normalized)) return undefined;
+  return normalized;
+}
+
 
 function isMissingTerminalOrInactiveDetail(detail: { active?: boolean; current_phase?: string } | null): boolean {
   if (!detail) return true;
@@ -453,12 +463,13 @@ function mergePhase<T extends { active?: boolean; current_phase?: string }>(
   detail: T | null,
   canonicalPhase?: string,
 ): T | null {
+  const normalizedCanonicalPhase = normalizeCanonicalHudPhase(canonicalPhase);
   if (detail?.active === true) {
-    if (!canonicalPhase || detail.current_phase) return detail;
-    return { ...detail, current_phase: canonicalPhase };
+    if (detail.current_phase || !normalizedCanonicalPhase) return detail;
+    return { ...detail, current_phase: normalizedCanonicalPhase };
   }
-  if (!canonicalPhase) return null;
-  return { active: true, current_phase: canonicalPhase } as T;
+  if (!normalizedCanonicalPhase) return null;
+  return { active: true, current_phase: normalizedCanonicalPhase } as T;
 }
 
 async function readCanonicalTeamPhase(cwd: string, teamDetail: TeamStateForHud | null): Promise<string | undefined> {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -6535,6 +6535,144 @@ exit 0
     }
   });
 
+  it("allows Ralplan read-only inspection and planning artifact writes while blocking implementation targets", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-ralplan-guard-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-ralplan-guard";
+      const sessionDir = join(stateDir, "sessions", sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, cwd });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "ralplan",
+        phase: "planning",
+        session_id: sessionId,
+        active_skills: [{ skill: "ralplan", phase: "planning", active: true, session_id: sessionId }],
+      });
+      await writeJson(join(sessionDir, "ralplan-state.json"), {
+        active: true,
+        mode: "ralplan",
+        current_phase: "planning",
+        session_id: sessionId,
+      });
+
+      const preToolUse = async (tool_name: string, tool_use_id: string, tool_input: Record<string, unknown>) => dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          tool_name,
+          tool_use_id,
+          tool_input,
+        },
+        { cwd },
+      );
+
+      const readOnlyCommands = [
+        "git status --short",
+        "ls -1 .omx/plans",
+        "find .omx/plans -type f -name '*.md'",
+        "grep -RIn \"Scholastic\" doc tests .omx/plans .omx/context",
+        "rg \"Scholastic\" doc tests .omx/plans .omx/context",
+        "sed -n '1,80p' .omx/plans/demo.md",
+        "cat .omx/plans/demo.md",
+        "git status --short; ls -1 .omx/plans; grep -RIn \"Scholastic\" doc tests .omx/plans .omx/context",
+      ];
+      for (const [index, command] of readOnlyCommands.entries()) {
+        const result = await preToolUse("Bash", `tool-ralplan-read-${index}`, { command });
+        assert.equal(result.outputJson, null, `read-only command should be allowed: ${command}`);
+      }
+
+      for (const path of [
+        ".omx/context/findings.md",
+        ".omx/plans/issue-2863.md",
+        ".omx/specs/issue-2863.md",
+        ".omx/state/required-planning-state.json",
+      ]) {
+        const writeResult = await preToolUse("Write", `tool-ralplan-write-${path}`, { file_path: path, content: "ok" });
+        assert.equal(writeResult.outputJson, null, `Write should be allowed for ${path}`);
+      }
+
+      const allowedPatchAdd = await preToolUse("apply_patch", "tool-ralplan-patch-add", {
+        input: "*** Begin Patch\n*** Add File: .omx/plans/issue-2863.md\n+# Plan\n*** End Patch\n",
+      });
+      assert.equal(allowedPatchAdd.outputJson, null);
+
+      const allowedPatchUpdate = await preToolUse("ApplyPatch", "tool-ralplan-patch-update", {
+        input: "*** Begin Patch\n*** Update File: .omx/plans/issue-2863.md\n@@\n-old\n+new\n*** End Patch\n",
+      });
+      assert.equal(allowedPatchUpdate.outputJson, null);
+
+      const allowedRedirect = await preToolUse("Bash", "tool-ralplan-redirect-allow", {
+        command: "printf '\\nmore\\n' >> .omx/plans/issue-2863.md",
+      });
+      assert.equal(allowedRedirect.outputJson, null);
+
+      const allowedTee = await preToolUse("Bash", "tool-ralplan-tee-allow", {
+        command: "printf '\\nmore\\n' | tee -a .omx/specs/issue-2863.md",
+      });
+      assert.equal(allowedTee.outputJson, null);
+
+      const blockedRedirect = await preToolUse("Bash", "tool-ralplan-redirect-block", {
+        command: "printf 'bad' > src/implementation.ts",
+      });
+      assert.equal((blockedRedirect.outputJson as { decision?: string } | null)?.decision, "block");
+      const redirectReason = String((blockedRedirect.outputJson as { reason?: string } | null)?.reason ?? "");
+      assert.match(redirectReason, /Bash redirect write/);
+      assert.match(redirectReason, /src\/implementation\.ts/);
+
+      const blockedEdit = await preToolUse("Edit", "tool-ralplan-edit-block", {
+        file_path: "src/implementation.ts",
+        old_string: "a",
+        new_string: "b",
+      });
+      assert.equal((blockedEdit.outputJson as { decision?: string } | null)?.decision, "block");
+      const editReason = String((blockedEdit.outputJson as { reason?: string } | null)?.reason ?? "");
+      assert.match(editReason, /Edit path/);
+      assert.match(editReason, /src\/implementation\.ts/);
+
+      const blockedMixedPatch = await preToolUse("apply_patch", "tool-ralplan-patch-mixed", {
+        input: "*** Begin Patch\n*** Add File: .omx/plans/ok.md\n+ok\n*** Add File: src/leak.ts\n+leak\n*** End Patch\n",
+      });
+      assert.equal((blockedMixedPatch.outputJson as { decision?: string } | null)?.decision, "block");
+      const mixedReason = String((blockedMixedPatch.outputJson as { reason?: string } | null)?.reason ?? "");
+      assert.match(mixedReason, /apply_patch target/);
+      assert.match(mixedReason, /src\/leak\.ts/);
+
+      const blockedUnparseablePatch = await preToolUse("apply_patch", "tool-ralplan-patch-unparseable", {
+        input: "not a recognizable patch",
+      });
+      assert.equal((blockedUnparseablePatch.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(String((blockedUnparseablePatch.outputJson as { reason?: string } | null)?.reason ?? ""), /apply_patch target extraction failed/);
+
+      const blockedUnresolvedRedirect = await preToolUse("Bash", "tool-ralplan-redirect-unresolved", {
+        command: "cat > \"$PLAN_PATH\" <<'EOF'\ncontent\nEOF",
+      });
+      assert.equal((blockedUnresolvedRedirect.outputJson as { decision?: string } | null)?.decision, "block");
+      const unresolvedReason = String((blockedUnresolvedRedirect.outputJson as { reason?: string } | null)?.reason ?? "");
+      assert.match(unresolvedReason, /unresolved Bash write target/);
+      assert.match(unresolvedReason, /\$PLAN_PATH/);
+
+      const blockedTraversal = await preToolUse("Write", "tool-ralplan-traversal-block", {
+        file_path: ".omx/plans/../../src/leak.ts",
+        content: "bad",
+      });
+      assert.equal((blockedTraversal.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(String((blockedTraversal.outputJson as { reason?: string } | null)?.reason ?? ""), /\.omx\/plans\/\.\.\/\.\.\/src\/leak\.ts/);
+
+      const blockedAbsolute = await preToolUse("Write", "tool-ralplan-absolute-block", {
+        file_path: "/tmp/leak.ts",
+        content: "bad",
+      });
+      assert.equal((blockedAbsolute.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(String((blockedAbsolute.outputJson as { reason?: string } | null)?.reason ?? ""), /\/tmp\/leak\.ts/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("allows Autopilot ralplan planning artifacts while blocking implementation writes", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-autopilot-ralplan-artifact-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3030,6 +3030,33 @@ function extractDeepInterviewCommandWriteTargets(command: string): string[] {
   }
   return targets;
 }
+function formatPlanningWriteBlockDetail(
+  operationClass: string,
+  target: string | undefined,
+  allowedPrefixes: readonly string[],
+): string {
+  const targetDetail = target ? `target ${target}` : "target <unresolved>";
+  return `${operationClass} ${targetDetail} is not under allowed planning artifact paths (${allowedPrefixes.join(", ")})`;
+}
+
+function isUnresolvedVariableTarget(target: string): boolean {
+  const normalized = target.trim().replace(/^['"]|['"]$/g, "");
+  return /^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$/.test(normalized);
+}
+
+
+function describeImplementationToolBlock(
+  toolName: string,
+  blockedPath: string | undefined,
+  pathCount: number,
+): string {
+  if (pathCount === 0) {
+    const operationClass = isApplyPatchToolName(toolName) ? "apply_patch target extraction failed" : `${toolName} path`;
+    return `${operationClass} target <unresolved>; only planning artifact paths are allowed (${RALPLAN_ALLOWED_WRITE_PREFIXES.join(", ")})`;
+  }
+  const operationClass = isApplyPatchToolName(toolName) ? "apply_patch target" : `${toolName} path`;
+  return formatPlanningWriteBlockDetail(operationClass, blockedPath, RALPLAN_ALLOWED_WRITE_PREFIXES);
+}
 
 function isAllowedDeepInterviewBashWrite(cwd: string, command: string): boolean {
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
@@ -3151,8 +3178,12 @@ function isAllowedRalplanBashWrite(cwd: string, command: string): boolean {
 function buildRalplanBashBlockedDetail(cwd: string, command: string): string {
   const targets = extractDeepInterviewCommandWriteTargets(command);
   const blockedTarget = targets.find((target) => !isAllowedRalplanArtifactPath(cwd, target));
+  if (blockedTarget && isUnresolvedVariableTarget(blockedTarget)) {
+    return `unresolved Bash write target ${blockedTarget} is not under allowed planning artifact paths or metadata paths (${RALPLAN_ALLOWED_WRITE_PREFIXES.join(", ")})`;
+  }
   if (blockedTarget) {
-    return `write target ${blockedTarget} is not under allowed planning artifact paths or metadata paths (${RALPLAN_ALLOWED_WRITE_PREFIXES.join(", ")})`;
+    const operationClass = /\btee\s+(?:-a\s+)?/.test(command) ? "Bash tee write" : "Bash redirect write";
+    return `${operationClass} target ${blockedTarget} is not under allowed planning artifact paths or metadata paths (${RALPLAN_ALLOWED_WRITE_PREFIXES.join(", ")})`;
   }
   const beadsCommand = classifyRalplanBeadsMetadataCommand(cwd, command);
   if (beadsCommand.present && !beadsCommand.allowed) {
@@ -3187,15 +3218,15 @@ async function buildRalplanPreToolUseBoundaryOutput(
       blockedDetail = buildRalplanBashBlockedDetail(cwd, command);
     }
   } else if (PLANNING_MODE_IMPLEMENTATION_TOOL_NAMES.has(toolName)) {
-    const candidates = collectImplementationToolPathCandidates(payload, toolName, pathCandidates);
-    if (candidates.length === 0) {
+    const toolPathCandidates = collectImplementationToolPathCandidates(payload, toolName, pathCandidates);
+    if (toolPathCandidates.length === 0) {
       blocked = true;
-      blockedDetail = `${toolName} did not include a file path; only planning artifact paths or metadata paths are allowed`;
+      blockedDetail = describeImplementationToolBlock(toolName, undefined, toolPathCandidates.length);
     } else {
-      const blockedPath = candidates.find((candidate) => !isAllowedRalplanArtifactPath(cwd, candidate));
+      const blockedPath = toolPathCandidates.find((candidate) => !isAllowedRalplanArtifactPath(cwd, candidate));
       blocked = blockedPath !== undefined;
       if (blockedPath !== undefined) {
-        blockedDetail = `path ${blockedPath} is not under allowed planning artifact paths or metadata paths (${RALPLAN_ALLOWED_WRITE_PREFIXES.join(", ")})`;
+        blockedDetail = describeImplementationToolBlock(toolName, blockedPath, toolPathCandidates.length);
       }
     }
   }


### PR DESCRIPTION
Fixes #2863

## Summary
- allow read-only Ralplan/Autopilot planning inspections while still blocking implementation writes
- allow planning artifact writes under .omx context/plans/specs/state and report the blocked operation class/target
- keep HUD Autopilot phase sourced from active session detail instead of stale canonical phase mirrors

## Validation
- npm run build
- node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js dist/hud/__tests__/state.test.js