### PR TITLE
Keep mixed Codex identities resumable without unsafe merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,25 @@ OMX also checks for npm updates at launch on a throttled cadence and prompts bef
 
 **Codex plugin install note:** this repo also ships an official Codex plugin layout at `plugins/oh-my-codex` with marketplace metadata in `.agents/plugins/marketplace.json`. That plugin bundles the mirrored skill surface plus plugin-scoped companion metadata for official Codex lifecycle hooks, optional MCP compatibility servers, and apps. It is still **not** a replacement for `npm install -g oh-my-codex` plus `omx setup`: plugin-scoped hooks launch the installed `omx` CLI, legacy setup mode installs native agents and prompts, and plugin setup mode relies on plugin discovery for bundled skills while archiving/removing legacy OMX-managed prompts/native-agent TOMLs so stale role files cannot shadow plugin behavior. Plugin mode still needs a persistent scope `AGENTS.md` (`~/.codex/AGENTS.md` for user setup or `./AGENTS.md` for project setup) as the durable orchestration guidance layer; session-scoped AGENTS files only compose that durable guidance with runtime overlays and are not a replacement.
 
+### Identity and Unified Sessions
+
+OMX keeps Codex account/API-key mixing explicit instead of pretending that local API-key runs and ChatGPT App/cloud tasks share one backend session. The default policy is `primary=chatgpt-main`, `api=allowed-mixed`, and `bridge=open-original`.
+
+Useful commands:
+
+```bash
+omx identity doctor
+omx identity list
+omx identity use chatgpt-main
+omx identity policy
+omx session list --unified
+omx session search "project or title" --unified
+omx session search "transcript phrase" --unified --deep
+omx resume --unified <session-id-or-fragment>
+```
+
+`omx identity doctor` explains the active `CODEX_HOME`, auth mode, matched auth slot, and likely causes of App/API session mismatch. Unified session indexing writes only local metadata and summaries to `~/.omx/state/session-ledger.jsonl`; `--deep` performs a temporary deeper local read for search and does not persist full transcripts. App task caches under `~/Library/Application Support/com.openai.chat` are read-only discovery sources, and `omx resume --unified` opens/resumes each entry in its original source rather than injecting transcripts across identities.
+
 Then work normally inside Codex:
 
 ```text

--- a/src/auth/__tests__/identity.test.ts
+++ b/src/auth/__tests__/identity.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectAuthFileKind, detectAuthKindFromJson, readIdentityStatus } from "../identity.js";
+
+describe("identity detection", () => {
+  it("detects API key and ChatGPT auth shapes without exposing credentials", () => {
+    assert.deepEqual(detectAuthKindFromJson({ auth_mode: "apikey", OPENAI_API_KEY: "sk-secret" }), {
+      kind: "api",
+      authMode: "apikey",
+    });
+    assert.deepEqual(detectAuthKindFromJson({ access_token: "secret-token" }), {
+      kind: "chatgpt",
+      authMode: undefined,
+    });
+    assert.equal(detectAuthKindFromJson({}).kind, "unknown");
+  });
+
+  it("reports active CODEX_HOME identity status", async () => {
+    const home = await mkdtemp(join(tmpdir(), "omx-identity-"));
+    try {
+      const codexHome = join(home, ".codex");
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(codexHome, "auth.json"), '{"auth_mode":"apikey","OPENAI_API_KEY":"sk-secret"}\n');
+      assert.equal((await detectAuthFileKind(join(codexHome, "auth.json"))).kind, "api");
+      const status = await readIdentityStatus(process.cwd(), { CODEX_HOME: codexHome }, home);
+      assert.equal(status.kind, "api");
+      assert.equal(status.codexHome, codexHome);
+      assert.match(status.warnings.join("\n"), /API key/);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("matches the live auth file to the actual slot contents", async () => {
+    const home = await mkdtemp(join(tmpdir(), "omx-identity-match-"));
+    try {
+      const codexHome = join(home, ".codex");
+      const authDir = join(home, ".omx", "auth");
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(authDir, { recursive: true });
+      await writeFile(join(codexHome, "auth.json"), '{"access_token":"api-live"}\n');
+      await writeFile(join(authDir, "main.json"), '{"access_token":"main"}\n');
+      await writeFile(join(authDir, "api.json"), '{"access_token":"api-live"}\n');
+      await writeFile(join(authDir, "slots.json"), JSON.stringify({ version: 1, currentSlot: "main", slots: [
+        { slot: "main", createdAt: "now", updatedAt: "now", kind: "chatgpt" },
+        { slot: "api", createdAt: "now", updatedAt: "now", kind: "api" },
+      ] }));
+
+      const status = await readIdentityStatus(process.cwd(), { CODEX_HOME: codexHome }, home);
+      assert.equal(status.currentSlot, "main");
+      assert.equal(status.matchedSlot, "api");
+      assert.match(status.warnings.join("\n"), /matches slot "api"/);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/auth/__tests__/storage.test.ts
+++ b/src/auth/__tests__/storage.test.ts
@@ -35,6 +35,75 @@ describe("auth slot storage", () => {
     }
   });
 
+  it("stores non-sensitive identity metadata for slots", async () => {
+    const home = await tempHome();
+    try {
+      const live = join(home, ".codex", "auth.json");
+      await mkdir(join(home, ".codex"), { recursive: true });
+      await writeFile(live, '{"auth_mode":"apikey","OPENAI_API_KEY":"secret"}\n');
+      await addSlotFromAuthFile("api-work", live, home, new Date("2026-05-24T00:00:00.000Z"), {
+        displayName: "API Work",
+        kind: "api",
+        isPrimary: false,
+        workspaceHint: "platform",
+        createdFromCodexHome: join(home, ".codex"),
+      });
+      const metadata = await readAuthMetadata(home);
+      assert.equal(metadata.slots[0]?.displayName, "API Work");
+      assert.equal(metadata.slots[0]?.kind, "api");
+      assert.equal(metadata.slots[0]?.workspaceHint, "platform");
+      assert.doesNotMatch(JSON.stringify(metadata), /secret/);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("can mark an added auth slot as current", async () => {
+    const home = await tempHome();
+    try {
+      const live = join(home, ".codex", "auth.json");
+      await mkdir(join(home, ".codex"), { recursive: true });
+      await writeFile(live, '{"auth_mode":"apikey","OPENAI_API_KEY":"secret"}\n');
+
+      await addSlotFromAuthFile(
+        "api-work",
+        live,
+        home,
+        new Date("2026-05-24T00:00:00.000Z"),
+        { kind: "api" },
+        { setCurrent: true },
+      );
+
+      const metadata = await readAuthMetadata(home);
+      assert.equal(metadata.currentSlot, "api-work");
+      assert.equal(metadata.slots[0]?.kind, "api");
+      assert.doesNotMatch(JSON.stringify(metadata), /secret/);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("drops unknown fields when reading slot metadata", async () => {
+    const home = await tempHome();
+    try {
+      const authDir = resolveOmxAuthDir(home);
+      await mkdir(authDir, { recursive: true });
+      await writeFile(resolveSlotPath("work", home), "{}\n");
+      await writeFile(join(authDir, "slots.json"), JSON.stringify({
+        version: 1,
+        currentSlot: "work",
+        slots: [
+          { slot: "work", createdAt: "now", updatedAt: "now", kind: "chatgpt", token: "secret-token" },
+        ],
+      }));
+      const metadata = await readAuthMetadata(home);
+      assert.equal(metadata.slots[0]?.slot, "work");
+      assert.doesNotMatch(JSON.stringify(metadata), /secret-token/);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
   it("uses owner-only modes for auth directory and files", async () => {
     if (process.platform === "win32") return;
     const home = await tempHome();

--- a/src/auth/identity.ts
+++ b/src/auth/identity.ts
@@ -1,0 +1,129 @@
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import { dirname } from "path";
+import { homedir } from "os";
+import { resolveLiveAuthPath, resolveSlotPath } from "./paths.js";
+import { listSlots, readAuthMetadata, useSlot, type AuthSlotRecord } from "./storage.js";
+
+export type IdentityKind = "chatgpt" | "api" | "unknown" | "missing" | "invalid";
+
+export interface IdentityStatus {
+  authPath: string;
+  codexHome: string;
+  kind: IdentityKind;
+  authMode?: string;
+  currentSlot?: string;
+  matchedSlot?: string;
+  slots: AuthSlotRecord[];
+  warnings: string[];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+export function detectAuthKindFromJson(parsed: unknown): { kind: IdentityKind; authMode?: string } {
+  const record = asRecord(parsed);
+  if (!record) return { kind: "invalid" };
+  const authMode = typeof record.auth_mode === "string" ? record.auth_mode : undefined;
+  if (authMode === "apikey" || typeof record.OPENAI_API_KEY === "string") {
+    return { kind: "api", authMode };
+  }
+  if (
+    authMode === "chatgpt" ||
+    typeof record.access_token === "string" ||
+    typeof record.refresh_token === "string" ||
+    asRecord(record.tokens) ||
+    asRecord(record.chatgpt)
+  ) {
+    return { kind: "chatgpt", authMode };
+  }
+  return { kind: "unknown", authMode };
+}
+
+export async function detectAuthFileKind(authPath: string): Promise<{ kind: IdentityKind; authMode?: string }> {
+  if (!existsSync(authPath)) return { kind: "missing" };
+  try {
+    return detectAuthKindFromJson(JSON.parse(await readFile(authPath, "utf-8")));
+  } catch {
+    return { kind: "invalid" };
+  }
+}
+
+async function matchLiveAuthSlot(authPath: string, slots: AuthSlotRecord[], home: string): Promise<string | undefined> {
+  let live: Buffer;
+  try {
+    live = await readFile(authPath);
+  } catch {
+    return undefined;
+  }
+  for (const slot of slots) {
+    try {
+      const candidate = await readFile(resolveSlotPath(slot.slot, home));
+      if (Buffer.compare(live, candidate) === 0) return slot.slot;
+    } catch {
+      // Missing or unreadable slots should not break doctor output.
+    }
+  }
+  return undefined;
+}
+
+export async function readIdentityStatus(
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+  home = homedir(),
+): Promise<IdentityStatus> {
+  const authPath = resolveLiveAuthPath(cwd, env, home);
+  const codexHome = dirname(authPath);
+  const detected = await detectAuthFileKind(authPath);
+  const metadata = await readAuthMetadata(home);
+  const slots = await listSlots(home);
+  const matchedSlot = await matchLiveAuthSlot(authPath, slots, home);
+  const warnings: string[] = [];
+  if (detected.kind === "api") {
+    warnings.push("Current CLI/OMX credentials use an API key; ChatGPT workspace/cloud features may not share this session.");
+  }
+  if (detected.kind === "missing") {
+    warnings.push("No active Codex auth cache was found for this CODEX_HOME.");
+  }
+  if (slots.some((slot) => slot.kind === "api") && slots.some((slot) => slot.kind === "chatgpt")) {
+    warnings.push("Both ChatGPT and API auth slots are configured; unified session commands will preserve source identity.");
+  }
+  if (metadata.currentSlot && matchedSlot && metadata.currentSlot !== matchedSlot) {
+    warnings.push(`Live auth.json matches slot "${matchedSlot}", but slots.json currentSlot is "${metadata.currentSlot}".`);
+  }
+  if (metadata.currentSlot && !matchedSlot && slots.length > 0 && detected.kind !== "missing") {
+    warnings.push("Live auth.json does not match any registered slot; run `omx auth add <slot>` or `omx identity use <slot>` to make routing explicit.");
+  }
+  const primaryCount = slots.filter((slot) => slot.isPrimary).length;
+  if (primaryCount > 1) warnings.push("Multiple auth slots are marked primary; prefer a single ChatGPT main slot.");
+  return {
+    authPath,
+    codexHome,
+    kind: detected.kind,
+    authMode: detected.authMode,
+    currentSlot: metadata.currentSlot,
+    matchedSlot,
+    slots,
+    warnings,
+  };
+}
+
+export async function switchIdentitySlot(
+  slot: string,
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+  home = homedir(),
+): Promise<AuthSlotRecord> {
+  return await switchIdentitySlotToAuthPath(slot, resolveLiveAuthPath(cwd, env, home), home);
+}
+
+export async function switchIdentitySlotToAuthPath(
+  slot: string,
+  liveAuthPath: string,
+  home = homedir(),
+): Promise<AuthSlotRecord> {
+  return await useSlot(slot, liveAuthPath, home);
+}

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,4 +1,5 @@
 export * from "./config.js";
+export * from "./identity.js";
 export * from "./paths.js";
 export * from "./quota-detector.js";
 export * from "./redact.js";

--- a/src/auth/storage.ts
+++ b/src/auth/storage.ts
@@ -20,6 +20,11 @@ export interface AuthSlotRecord {
   lastUsedAt?: string;
   lastQuotaAt?: string;
   exhaustedAt?: string;
+  displayName?: string;
+  kind?: "chatgpt" | "api" | "unknown";
+  isPrimary?: boolean;
+  workspaceHint?: string;
+  createdFromCodexHome?: string;
 }
 
 export interface AuthMetadata {
@@ -31,6 +36,18 @@ export interface AuthMetadata {
 export interface AtomicWriteOptions {
   mode?: number;
   beforeRename?: (tempPath: string) => void | Promise<void>;
+}
+
+export interface AuthSlotMetadataInput {
+  displayName?: string;
+  kind?: AuthSlotRecord["kind"];
+  isPrimary?: boolean;
+  workspaceHint?: string;
+  createdFromCodexHome?: string;
+}
+
+export interface AddSlotFromAuthFileOptions {
+  setCurrent?: boolean;
 }
 
 export async function atomicWriteFile(
@@ -68,7 +85,19 @@ export async function readAuthMetadata(home?: string): Promise<AuthMetadata> {
     slots: Array.isArray(parsed.slots)
       ? parsed.slots
           .filter((slot): slot is AuthSlotRecord => Boolean(slot && typeof slot.slot === "string"))
-          .map((slot) => ({ ...slot, slot: validateSlotName(slot.slot) }))
+          .map((slot) => ({
+            slot: validateSlotName(slot.slot),
+            createdAt: typeof slot.createdAt === "string" ? slot.createdAt : "",
+            updatedAt: typeof slot.updatedAt === "string" ? slot.updatedAt : "",
+            lastUsedAt: typeof slot.lastUsedAt === "string" ? slot.lastUsedAt : undefined,
+            lastQuotaAt: typeof slot.lastQuotaAt === "string" ? slot.lastQuotaAt : undefined,
+            exhaustedAt: typeof slot.exhaustedAt === "string" ? slot.exhaustedAt : undefined,
+            kind: slot.kind === "chatgpt" || slot.kind === "api" || slot.kind === "unknown" ? slot.kind : undefined,
+            displayName: typeof slot.displayName === "string" ? slot.displayName : undefined,
+            isPrimary: typeof slot.isPrimary === "boolean" ? slot.isPrimary : undefined,
+            workspaceHint: typeof slot.workspaceHint === "string" ? slot.workspaceHint : undefined,
+            createdFromCodexHome: typeof slot.createdFromCodexHome === "string" ? slot.createdFromCodexHome : undefined,
+          }))
       : [],
   };
 }
@@ -81,14 +110,25 @@ export async function writeAuthMetadata(metadata: AuthMetadata, home?: string): 
   });
 }
 
-function upsertSlotRecord(metadata: AuthMetadata, slot: string, nowIso: string): AuthSlotRecord {
+function applySlotMetadata(record: AuthSlotRecord, metadata?: AuthSlotMetadataInput): void {
+  if (!metadata) return;
+  if (metadata.displayName !== undefined) record.displayName = metadata.displayName;
+  if (metadata.kind !== undefined) record.kind = metadata.kind;
+  if (metadata.isPrimary !== undefined) record.isPrimary = metadata.isPrimary;
+  if (metadata.workspaceHint !== undefined) record.workspaceHint = metadata.workspaceHint;
+  if (metadata.createdFromCodexHome !== undefined) record.createdFromCodexHome = metadata.createdFromCodexHome;
+}
+
+function upsertSlotRecord(metadata: AuthMetadata, slot: string, nowIso: string, slotMetadata?: AuthSlotMetadataInput): AuthSlotRecord {
   const safeSlot = validateSlotName(slot);
   const existing = metadata.slots.find((record) => record.slot === safeSlot);
   if (existing) {
     existing.updatedAt = nowIso;
+    applySlotMetadata(existing, slotMetadata);
     return existing;
   }
   const record: AuthSlotRecord = { slot: safeSlot, createdAt: nowIso, updatedAt: nowIso };
+  applySlotMetadata(record, slotMetadata);
   metadata.slots.push(record);
   metadata.slots.sort((a, b) => a.slot.localeCompare(b.slot));
   return record;
@@ -99,6 +139,8 @@ export async function addSlotFromAuthFile(
   liveAuthPath: string,
   home?: string,
   now = new Date(),
+  slotMetadata?: AuthSlotMetadataInput,
+  options: AddSlotFromAuthFileOptions = {},
 ): Promise<AuthSlotRecord> {
   const safeSlot = validateSlotName(slot);
   await assertReadableFile(liveAuthPath, "live Codex auth.json");
@@ -107,7 +149,8 @@ export async function addSlotFromAuthFile(
   const target = resolveSlotPath(safeSlot, home);
   await atomicWriteFile(target, data, { mode: AUTH_FILE_MODE });
   const metadata = await readAuthMetadata(home);
-  const record = upsertSlotRecord(metadata, safeSlot, now.toISOString());
+  const record = upsertSlotRecord(metadata, safeSlot, now.toISOString(), slotMetadata);
+  if (options.setCurrent) metadata.currentSlot = safeSlot;
   await writeAuthMetadata(metadata, home);
   return record;
 }

--- a/src/cli/__tests__/auth.test.ts
+++ b/src/cli/__tests__/auth.test.ts
@@ -57,13 +57,25 @@ describe("omx auth CLI", () => {
     try {
       const home = join(wd, "home");
       const codexHome = join(home, ".codex");
+      const authDir = join(home, ".omx", "auth");
       const bin = join(wd, "bin");
       await mkdir(codexHome, { recursive: true });
+      await mkdir(authDir, { recursive: true });
+      await writeFile(join(authDir, "previous.json"), '{"access_token":"previous-secret"}\n');
+      await writeFile(join(authDir, "slots.json"), JSON.stringify({
+        version: 1,
+        currentSlot: "previous",
+        slots: [{ slot: "previous", createdAt: "now", updatedAt: "now", kind: "chatgpt" }],
+      }));
       await writeFakeCodex(bin, `#!/bin/sh\nif [ "$1" = "login" ]; then mkdir -p "$CODEX_HOME"; printf '{"access_token":"sentinel-secret"}\\n' > "$CODEX_HOME/auth.json"; exit 0; fi\necho unexpected "$@" >&2\nexit 2\n`);
       const env = { HOME: home, CODEX_HOME: codexHome, PATH: `${bin}:/usr/bin:/bin` };
       const add = runOmx(wd, ["auth", "add", "work"], env);
       assert.equal(add.status, 0, add.stderr);
       assert.doesNotMatch(add.stdout + add.stderr, /sentinel-secret/);
+      const metadata = JSON.parse(
+        await readFile(join(authDir, "slots.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(metadata.currentSlot, "work");
       const list = runOmx(wd, ["auth", "list", "--json"], env);
       assert.equal(list.status, 0, list.stderr);
       assert.match(list.stdout, /"slot": "work"/);
@@ -72,6 +84,35 @@ describe("omx auth CLI", () => {
       assert.equal(use.status, 0, use.stderr);
       assert.doesNotMatch(use.stdout + use.stderr, /sentinel-secret/);
       assert.equal(await readFile(join(codexHome, "auth.json"), "utf-8"), '{"access_token":"sentinel-secret"}\n');
+      const identityList = runOmx(wd, ["identity", "list"], env);
+      assert.equal(identityList.status, 0, identityList.stderr);
+      assert.match(identityList.stdout, /work/);
+      const doctor = runOmx(wd, ["identity", "doctor", "--json"], env);
+      assert.equal(doctor.status, 0, doctor.stderr);
+      assert.match(doctor.stdout, /"kind": "chatgpt"/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("switches identity slots through the compiled CLI", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-identity-use-"));
+    try {
+      const home = join(wd, "home");
+      const codexHome = join(home, ".codex");
+      const authDir = join(home, ".omx", "auth");
+      await mkdir(authDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(authDir, "main.json"), '{"access_token":"main-secret"}\n');
+      await writeFile(join(authDir, "api.json"), '{"auth_mode":"apikey","OPENAI_API_KEY":"api-secret"}\n');
+      await writeFile(join(authDir, "slots.json"), JSON.stringify({ version: 1, currentSlot: "main", slots: [
+        { slot: "main", createdAt: "now", updatedAt: "now", kind: "chatgpt", isPrimary: true },
+        { slot: "api", createdAt: "now", updatedAt: "now", kind: "api" }
+      ] }, null, 2));
+      const result = runOmx(wd, ["identity", "use", "api"], { HOME: home, CODEX_HOME: codexHome });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(await readFile(join(codexHome, "auth.json"), "utf-8"), '{"auth_mode":"apikey","OPENAI_API_KEY":"api-secret"}\n');
+      assert.doesNotMatch(result.stdout + result.stderr, /api-secret|main-secret/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -68,6 +68,8 @@ import {
   cleanupLaunchOrphanedMcpProcesses,
   reapPostLaunchOrphanedMcpProcesses,
   cleanupPostLaunchModeStateFiles,
+  recordLaunchIdentityMetadata,
+  reconcileLaunchIdentityMetadata,
   resolveBackgroundHelperLaunchMode,
   shouldDetachBackgroundHelper,
   resolveNotifyFallbackWatcherScript,
@@ -91,6 +93,8 @@ import {
   isExistingTmuxWindowTooCrampedForLaunchHud,
 } from "../index.js";
 import { mergeConfig, repairConfigIfNeeded } from "../../config/generator.js";
+import { writeAuthMetadata } from "../../auth/storage.js";
+import { resolveUnifiedSessionIdentityPath, writeUnifiedSessionIdentity } from "../../session-ledger/index.js";
 import { ensureReusableNodeModules } from "../../utils/repo-deps.js";
 import { readAllState } from "../../hud/state.js";
 import { generateOverlay } from "../../hooks/agents-overlay.js";
@@ -1336,6 +1340,75 @@ describe("cleanupPostLaunchModeStateFiles", () => {
   });
 });
 
+describe("recordLaunchIdentityMetadata", () => {
+  it("writes the active auth slot into the launch Codex home sidecar", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-identity-"));
+    const home = join(wd, "home");
+    const codexHome = join(wd, "runtime-codex-home");
+    const previousHome = process.env.HOME;
+
+    try {
+      process.env.HOME = home;
+      await writeAuthMetadata({
+        version: 1,
+        currentSlot: "main",
+        slots: [{
+          slot: "main",
+          createdAt: "2026-06-18T01:00:00.000Z",
+          updatedAt: "2026-06-18T01:00:00.000Z",
+          kind: "chatgpt",
+        }],
+      }, home);
+
+      await recordLaunchIdentityMetadata(wd, "sess-launch-identity", codexHome);
+
+      const sidecar = JSON.parse(
+        await readFile(resolveUnifiedSessionIdentityPath(codexHome, "sess-launch-identity"), "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(sidecar.version, 1);
+      assert.equal(sidecar.sessionId, "sess-launch-identity");
+      assert.equal(sidecar.identitySlot, "main");
+      assert.equal(sidecar.authMode, "chatgpt");
+    } finally {
+      if (typeof previousHome === "string") process.env.HOME = previousHome;
+      else delete process.env.HOME;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("copies the launch sidecar to the native Codex session id when available", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-identity-native-"));
+    const codexHome = join(wd, "runtime-codex-home");
+
+    try {
+      await writeUnifiedSessionIdentity(codexHome, {
+        version: 1,
+        sessionId: "omx-wrapper-session",
+        identitySlot: "main",
+        authMode: "chatgpt",
+        createdAt: "2026-06-18T01:00:00.000Z",
+      });
+
+      await reconcileLaunchIdentityMetadata(
+        wd,
+        "omx-wrapper-session",
+        codexHome,
+        "native-codex-session",
+      );
+
+      const sidecar = JSON.parse(
+        await readFile(resolveUnifiedSessionIdentityPath(codexHome, "native-codex-session"), "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(sidecar.version, 1);
+      assert.equal(sidecar.sessionId, "native-codex-session");
+      assert.equal(sidecar.identitySlot, "main");
+      assert.equal(sidecar.authMode, "chatgpt");
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("watcher script path resolution", () => {
   it("resolves packaged watcher entrypoints from dist/scripts", () => {
     assert.equal(
@@ -2272,6 +2345,13 @@ describe("project launch scope helpers", () => {
       await writeFile(join(runtimeCodexHome, "history.jsonl"), '{"session_id":"session-2835"}\n');
       await writeFile(join(runtimeCodexHome, "session_index.jsonl"), '{"id":"session-2835"}\n');
       await writeFile(join(runtimeCodexHome, "auth.json"), '{"token":"opaque"}\n');
+      await writeUnifiedSessionIdentity(runtimeCodexHome, {
+        version: 1,
+        sessionId: "session-2835",
+        identitySlot: "main",
+        authMode: "chatgpt",
+        createdAt: "2026-06-16T00:00:00.000Z",
+      });
 
       await cleanupRuntimeCodexHome(
         prepared.runtimeCodexHomeForCleanup,
@@ -2285,6 +2365,11 @@ describe("project launch scope helpers", () => {
       assert.equal(await readFile(join(projectCodexHome, "history.jsonl"), "utf-8"), '{"session_id":"session-2835"}\n');
       assert.equal(await readFile(join(projectCodexHome, "session_index.jsonl"), "utf-8"), '{"id":"session-2835"}\n');
       assert.equal(await readFile(join(projectCodexHome, "auth.json"), "utf-8"), '{"token":"opaque"}\n');
+      const sidecar = JSON.parse(
+        await readFile(resolveUnifiedSessionIdentityPath(projectCodexHome, "session-2835"), "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(sidecar.identitySlot, "main");
+      assert.equal(sidecar.authMode, "chatgpt");
       assert.equal(existsSync(runtimeCodexHome), false);
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -19,6 +19,7 @@ function runOmx(
     encoding: 'utf-8',
     env: {
       ...process.env,
+      CODEX_SQLITE_HOME: '',
       ...envOverrides,
     },
   });
@@ -492,6 +493,168 @@ if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-unrelated-session.jsonl" ]; the
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       assert.match(result.stdout, /fake-codex:resume --help\b/);
       assert.doesNotMatch(result.stdout, /Unknown command: resume/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('resumes unified CLI entries through codex resume in the recorded original identity', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-unified-cli-'));
+    try {
+      const home = join(wd, 'home');
+      const codexHome = join(home, '.codex');
+      const authDir = join(home, '.omx', 'auth');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const rolloutPath = join(codexHome, 'sessions', '2026', '06', '13', 'rollout-session-unified.jsonl');
+      await mkdir(dirname(rolloutPath), { recursive: true });
+      await mkdir(authDir, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(join(codexHome, 'auth.json'), '{"access_token":"old"}\n');
+      await writeFile(join(authDir, 'main.json'), '{"access_token":"main-secret"}\n');
+      await writeFile(join(authDir, 'slots.json'), JSON.stringify({ version: 1, currentSlot: 'main', slots: [
+        { slot: 'main', createdAt: 'now', updatedAt: 'now', kind: 'chatgpt' }
+      ] }));
+      await writeFile(rolloutPath, '{"type":"session_meta","payload":{"id":"session-unified","cwd":"/repo","timestamp":"2026-06-13T00:00:00.000Z","omx_auth_slot":"main"}}\n');
+      await writeFile(fakeCodexPath, '#!/bin/sh\nprintf \'fake-codex:%s\\n\' "$*"\nprintf \'auth:%s\\n\' "$(cat "$CODEX_HOME/auth.json")"\n');
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+
+      const result = runOmx(wd, ['resume', '--unified', 'session-unified'], {
+        HOME: home,
+        CODEX_HOME: codexHome,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /fake-codex:resume session-unified/);
+      assert.match(result.stdout, /main-secret/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('resumes unified runtime Codex home entries from their recorded home', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-unified-runtime-'));
+    try {
+      const home = join(wd, 'home');
+      const authDir = join(home, '.omx', 'auth');
+      const runtimeCodexHome = join(wd, '.omx', 'runtime', 'codex-home', 'omx-runtime-a');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const rolloutPath = join(runtimeCodexHome, 'sessions', '2026', '06', '13', 'rollout-runtime-unified.jsonl');
+      await mkdir(dirname(rolloutPath), { recursive: true });
+      await mkdir(authDir, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(join(runtimeCodexHome, 'auth.json'), '{"access_token":"old-runtime"}\n');
+      await writeFile(join(authDir, 'main.json'), '{"access_token":"main-secret"}\n');
+      await writeFile(join(authDir, 'slots.json'), JSON.stringify({ version: 1, currentSlot: 'main', slots: [
+        { slot: 'main', createdAt: 'now', updatedAt: 'now', kind: 'chatgpt' }
+      ] }));
+      await writeFile(rolloutPath, '{"type":"session_meta","payload":{"id":"runtime-unified","cwd":"/repo","timestamp":"2026-06-13T00:00:00.000Z","omx_auth_slot":"main"}}\n');
+      await writeFile(fakeCodexPath, `#!/bin/sh
+printf 'fake-codex:%s\n' "$*"
+printf 'codex-home:%s\n' "$CODEX_HOME"
+printf 'auth:%s\n' "$(cat "$CODEX_HOME/auth.json")"
+if [ -f "$CODEX_HOME/sessions/2026/06/13/rollout-runtime-unified.jsonl" ]; then echo runtime-rollout-present=yes; else echo runtime-rollout-present=no; fi
+`);
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+
+      const result = runOmx(wd, ['resume', '--unified', 'runtime-unified'], {
+        HOME: home,
+        CODEX_HOME: '',
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const expectedRuntimeCodexHome = await realpath(runtimeCodexHome);
+      assert.match(result.stdout, /fake-codex:resume runtime-unified/);
+      assert.match(result.stdout, new RegExp(`codex-home:${expectedRuntimeCodexHome.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      assert.match(result.stdout, /main-secret/);
+      assert.match(result.stdout, /runtime-rollout-present=yes/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('resumes unified madmax entries from their real boxed Codex home', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-unified-madmax-'));
+    try {
+      const home = join(wd, 'home');
+      const runsRoot = join(wd, 'runs');
+      const runDir = join(runsRoot, 'run-associated');
+      const madmaxCodexHome = join(runDir, '.omx', 'runtime', 'codex-home', 'omx-madmax-a');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const rolloutPath = join(madmaxCodexHome, 'sessions', '2026', '06', '13', 'rollout-madmax-unified.jsonl');
+      await mkdir(runDir, { recursive: true });
+      await mkdir(dirname(rolloutPath), { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(join(runDir, '.omxbox-run.json'), JSON.stringify({
+        source_cwd: wd,
+        run_dir: runDir,
+      }));
+      await writeFile(rolloutPath, '{"type":"session_meta","payload":{"id":"madmax-unified","cwd":"/repo","timestamp":"2026-06-13T00:00:00.000Z"}}\n');
+      await writeFile(fakeCodexPath, `#!/bin/sh
+printf 'fake-codex:%s\n' "$*"
+printf 'codex-home:%s\n' "$CODEX_HOME"
+if [ -f "$CODEX_HOME/sessions/2026/06/13/rollout-madmax-unified.jsonl" ]; then echo madmax-rollout-present=yes; else echo madmax-rollout-present=no; fi
+`);
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+
+      const result = runOmx(wd, ['resume', '--unified', 'madmax-unified'], {
+        HOME: home,
+        CODEX_HOME: '',
+        OMX_RUNS_DIR: runsRoot,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const expectedMadmaxCodexHome = await realpath(madmaxCodexHome);
+      assert.match(result.stdout, /fake-codex:resume madmax-unified/);
+      assert.equal(
+        result.stdout.includes(`codex-home:${madmaxCodexHome}`) ||
+          result.stdout.includes(`codex-home:${expectedMadmaxCodexHome}`),
+        true,
+      );
+      assert.match(result.stdout, /madmax-rollout-present=yes/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('opens unified App entries at their original read-only cache target', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-unified-app-'));
+    try {
+      const home = join(wd, 'home');
+      const appDir = join(home, 'Library', 'Application Support', 'com.openai.chat', 'codex-taskItems-v2-default-user');
+      await mkdir(appDir, { recursive: true });
+      const result = runOmx(wd, ['resume', '--unified', 'taskItems'], {
+        HOME: home,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /Open original Codex App session source/);
+      assert.match(result.stdout, /codex-taskItems-v2-default-user/);
+      assert.match(result.stdout, /read-only metadata/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/session-search-help.test.ts
+++ b/src/cli/__tests__/session-search-help.test.ts
@@ -23,7 +23,7 @@ describe('omx session help', () => {
     try {
       const mainHelp = runOmx(cwd, ['--help']);
       assert.equal(mainHelp.status, 0, mainHelp.stderr || mainHelp.stdout);
-      assert.match(mainHelp.stdout, /omx resume\s+Resume Codex sessions \(supports --project and --codex-home <path>\)/i);
+      assert.match(mainHelp.stdout, /omx resume\s+Resume Codex sessions \(supports --project and --codex-home <path>; --unified <id>\)/i);
       assert.match(mainHelp.stdout, /omx autoresearch\s+\[DEPRECATED\] Use \$autoresearch; direct CLI launch removed/i);
       assert.match(mainHelp.stdout, /omx session\s+Search prior local session transcripts \(--codex-home <path> escape hatch\)/i);
 

--- a/src/cli/__tests__/session-search.test.ts
+++ b/src/cli/__tests__/session-search.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, realpath, rm, utimes, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
@@ -12,11 +12,13 @@ async function writeRollout(
   isoDate: string,
   fileName: string,
   lines: Array<Record<string, unknown>>,
-): Promise<void> {
+): Promise<string> {
   const [year, month, day] = isoDate.slice(0, 10).split('-');
   const dir = join(codexHomeDir, 'sessions', year, month, day);
+  const filePath = join(dir, fileName);
   await mkdir(dir, { recursive: true });
-  await writeFile(join(dir, fileName), `${lines.map((line) => JSON.stringify(line)).join('\n')}\n`, 'utf-8');
+  await writeFile(filePath, `${lines.map((line) => JSON.stringify(line)).join('\n')}\n`, 'utf-8');
+  return filePath;
 }
 
 function runOmx(cwd: string, argv: string[], envOverrides: Record<string, string> = {}) {
@@ -88,6 +90,74 @@ describe('omx session search', () => {
     }
   });
 
+  it('lists and searches unified CLI and App metadata without mutating App cache', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-unified-cli-'));
+    const home = join(cwd, 'home');
+    const codexHomeDir = join(home, '.codex');
+    const appSupport = join(home, 'Library', 'Application Support', 'com.openai.chat');
+    try {
+      await mkdir(codexHomeDir, { recursive: true });
+      await writeFile(join(codexHomeDir, 'auth.json'), '{"auth_mode":"apikey","OPENAI_API_KEY":"secret"}\n');
+      await writeRollout(codexHomeDir, '2026-03-10T12:00:00.000Z', 'rollout-session-unified.jsonl', [
+        { type: 'session_meta', payload: { id: 'session-unified', timestamp: '2026-03-10T12:00:00.000Z', cwd } },
+        { type: 'event_msg', payload: { type: 'user_message', message: 'hidden deep transcript marker sk-supersecret999' } },
+      ]);
+      await writeRollout(codexHomeDir, '2026-03-11T12:00:00.000Z', 'rollout-session-late.jsonl', [
+        { type: 'session_meta', payload: { id: 'session-late', timestamp: '2026-03-11T12:00:00.000Z', cwd } },
+        ...Array.from({ length: 90 }, (_value, index) => ({
+          type: 'event_msg',
+          payload: { type: 'user_message', message: `deep filler line ${index}` },
+        })),
+        { type: 'event_msg', payload: { type: 'user_message', message: 'late unified deep transcript marker' } },
+      ]);
+      const appDir = join(appSupport, 'codex-taskDetails-v1-user');
+      await mkdir(appDir, { recursive: true });
+
+      const list = runOmx(cwd, ['session', 'list', '--unified', '--json'], {
+        HOME: home,
+        CODEX_HOME: codexHomeDir,
+      });
+      assert.equal(list.status, 0, list.stderr || list.stdout);
+      const parsed = JSON.parse(list.stdout) as { entries: Array<{ sessionId: string; source: string; authMode?: string }> };
+      assert.equal(parsed.entries.some((entry) => entry.sessionId === 'session-unified' && entry.source === 'cli' && entry.authMode === undefined), true);
+      assert.equal(parsed.entries.some((entry) => entry.sessionId === 'codex-taskDetails-v1-user' && entry.source === 'app'), true);
+      const ledger = await readFile(join(home, '.omx', 'state', 'session-ledger.jsonl'), 'utf-8');
+      assert.match(ledger, /session-unified/);
+      assert.doesNotMatch(ledger, /secret/);
+
+      const search = runOmx(cwd, ['session', 'search', 'taskDetails', '--unified', '--json'], {
+        HOME: home,
+        CODEX_HOME: codexHomeDir,
+      });
+      assert.equal(search.status, 0, search.stderr || search.stdout);
+      assert.match(search.stdout, /codex-taskDetails-v1-user/);
+
+      const shallowSearch = runOmx(cwd, ['session', 'search', 'hidden deep transcript', '--unified', '--json'], {
+        HOME: home,
+        CODEX_HOME: codexHomeDir,
+      });
+      assert.equal(shallowSearch.status, 0, shallowSearch.stderr || shallowSearch.stdout);
+      assert.equal((JSON.parse(shallowSearch.stdout) as { entries: unknown[] }).entries.length, 0);
+
+      const deepSearch = runOmx(cwd, ['session', 'search', 'hidden deep transcript', '--unified', '--deep', '--json'], {
+        HOME: home,
+        CODEX_HOME: codexHomeDir,
+      });
+      assert.equal(deepSearch.status, 0, deepSearch.stderr || deepSearch.stdout);
+      assert.match(deepSearch.stdout, /session-unified/);
+      assert.doesNotMatch(deepSearch.stdout, /sk-supersecret999/);
+
+      const lateDeepSearch = runOmx(cwd, ['session', 'search', 'late unified deep transcript marker', '--unified', '--deep', '--json'], {
+        HOME: home,
+        CODEX_HOME: codexHomeDir,
+      });
+      assert.equal(lateDeepSearch.status, 0, lateDeepSearch.stderr || lateDeepSearch.stdout);
+      assert.match(lateDeepSearch.stdout, /session-late/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('searches generated project runtime Codex homes in a project repo', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-search-cli-project-'));
     const home = join(cwd, 'home');
@@ -125,6 +195,43 @@ describe('omx session search', () => {
       assert.deepEqual(parsed.results.map((result) => result.session_id).sort(), ['default-session', 'runtime-session']);
       assert.ok(parsed.sources.some((source) => source.codex_home === defaultCodexHome));
       assert.ok(parsed.sources.some((source) => source.codex_home === runtimeCodexHome || source.codex_home === expectedRuntimeCodexHome));
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('searches generated project runtime Codex homes in unified mode', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-search-unified-runtime-'));
+    const home = join(cwd, 'home');
+    const defaultCodexHome = join(home, '.codex');
+    const runtimeCodexHome = join(cwd, '.omx', 'runtime', 'codex-home', 'omx-runtime-a');
+    try {
+      await writeRollout(defaultCodexHome, '2026-03-10T12:00:00.000Z', 'rollout-default.jsonl', [
+        {
+          type: 'session_meta',
+          payload: { id: 'default-unified-session', timestamp: '2026-03-10T12:00:00.000Z', cwd },
+        },
+      ]);
+      await writeRollout(runtimeCodexHome, '2026-03-11T12:00:00.000Z', 'rollout-runtime.jsonl', [
+        {
+          type: 'session_meta',
+          payload: { id: 'runtime-unified-session', timestamp: '2026-03-11T12:00:00.000Z', cwd },
+        },
+      ]);
+
+      const result = runOmx(cwd, ['session', 'search', 'unified-session', '--unified', '--json'], {
+        HOME: home,
+        CODEX_HOME: '',
+        OMX_ROOT: '',
+        OMX_STATE_ROOT: '',
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const expectedRuntimeCodexHome = await realpath(runtimeCodexHome);
+      const parsed = JSON.parse(result.stdout) as { entries: Array<{ sessionId: string; codexHome?: string }> };
+      assert.deepEqual(parsed.entries.map((entry) => entry.sessionId).sort(), ['default-unified-session', 'runtime-unified-session']);
+      assert.ok(parsed.entries.some((entry) => entry.codexHome === defaultCodexHome));
+      assert.ok(parsed.entries.some((entry) => entry.codexHome === runtimeCodexHome || entry.codexHome === expectedRuntimeCodexHome));
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -192,6 +299,78 @@ describe('omx session search', () => {
       assert.equal(result.status, 0, result.stderr || result.stdout);
       const parsed = JSON.parse(result.stdout) as { results: Array<{ session_id: string }> };
       assert.deepEqual(parsed.results.map((entry) => entry.session_id), ['explicit-session']);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('applies parsed filters to unified searches', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-search-unified-filters-'));
+    const home = join(cwd, 'home');
+    const defaultCodexHome = join(home, '.codex');
+    const explicitCodexHome = join(cwd, 'explicit-codex-home');
+    const chosenProject = join(cwd, 'chosen-project');
+    const otherProject = join(cwd, 'other-project');
+    try {
+      await writeRollout(defaultCodexHome, '2026-03-12T12:00:00.000Z', 'rollout-target-default.jsonl', [
+        { type: 'session_meta', payload: { id: 'target-default', timestamp: '2026-03-12T12:00:00.000Z', cwd: chosenProject } },
+      ]);
+      const oldPath = await writeRollout(explicitCodexHome, '2026-03-09T12:00:00.000Z', 'rollout-target-explicit-old.jsonl', [
+        { type: 'session_meta', payload: { id: 'target-explicit-old', timestamp: '2026-03-09T12:00:00.000Z', cwd: chosenProject } },
+      ]);
+      await utimes(oldPath, new Date('2026-03-09T12:00:00.000Z'), new Date('2026-03-09T12:00:00.000Z'));
+      await writeRollout(explicitCodexHome, '2026-03-12T12:00:00.000Z', 'rollout-target-explicit-other-project.jsonl', [
+        { type: 'session_meta', payload: { id: 'target-explicit-other-project', timestamp: '2026-03-12T12:00:00.000Z', cwd: otherProject } },
+      ]);
+      await writeRollout(explicitCodexHome, '2026-03-12T12:00:00.000Z', 'rollout-target-explicit-new.jsonl', [
+        { type: 'session_meta', payload: { id: 'target-explicit-new', timestamp: '2026-03-12T12:00:00.000Z', cwd: chosenProject } },
+      ]);
+
+      const result = runOmx(cwd, [
+        'session',
+        'search',
+        'target',
+        '--unified',
+        '--codex-home',
+        explicitCodexHome,
+        '--session',
+        'explicit',
+        '--project',
+        'chosen-project',
+        '--since',
+        '2026-03-10',
+        '--json',
+      ], {
+        HOME: home,
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const parsed = JSON.parse(result.stdout) as { entries: Array<{ sessionId: string; codexHome?: string }> };
+      assert.deepEqual(parsed.entries.map((entry) => entry.sessionId), ['target-explicit-new']);
+      assert.equal(parsed.entries[0]?.codexHome, explicitCodexHome);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('uses updated times for unified recency filters', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-search-unified-updated-'));
+    const home = join(cwd, 'home');
+    const codexHome = join(home, '.codex');
+    try {
+      const resumedPath = await writeRollout(codexHome, '2026-03-09T12:00:00.000Z', 'rollout-target-resumed.jsonl', [
+        { type: 'session_meta', payload: { id: 'target-resumed', timestamp: '2026-03-09T12:00:00.000Z', cwd } },
+      ]);
+      await utimes(resumedPath, new Date('2026-03-12T12:00:00.000Z'), new Date('2026-03-12T12:00:00.000Z'));
+
+      const result = runOmx(cwd, ['session', 'search', 'target', '--unified', '--since', '2026-03-10', '--json'], {
+        HOME: home,
+        CODEX_HOME: '',
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const parsed = JSON.parse(result.stdout) as { entries: Array<{ sessionId: string }> };
+      assert.deepEqual(parsed.entries.map((entry) => entry.sessionId), ['target-resumed']);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -2,6 +2,7 @@ import { dirname, join } from "path";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { spawnPlatformCommandSync, classifySpawnError } from "../utils/platform-command.js";
 import { readAuthConfig } from "../auth/config.js";
+import { detectAuthFileKind } from "../auth/identity.js";
 import { resolveLiveAuthPath } from "../auth/paths.js";
 import { redactAuthSecrets } from "../auth/redact.js";
 import { addSlotFromAuthFile, listSlots, useSlot } from "../auth/storage.js";
@@ -79,7 +80,13 @@ export async function authCommand(args: string[], env: NodeJS.ProcessEnv = proce
     if (!slot) throw new Error("Usage: omx auth add <slot>");
     const liveAuthPath = resolveLiveAuthPath(cwd, env, home);
     runCodexLogin(cwd, { ...env, CODEX_HOME: dirname(liveAuthPath) });
-    const record = await addSlotFromAuthFile(slot, liveAuthPath, home);
+    const detected = await detectAuthFileKind(liveAuthPath);
+    const record = await addSlotFromAuthFile(slot, liveAuthPath, home, new Date(), {
+      kind: detected.kind === "chatgpt" || detected.kind === "api" ? detected.kind : "unknown",
+      createdFromCodexHome: dirname(liveAuthPath),
+    }, {
+      setCurrent: true,
+    });
     await ensureSubscriptionCodexDefaults(dirname(liveAuthPath));
     console.log(`Added auth slot ${record.slot}`);
     return;

--- a/src/cli/identity.ts
+++ b/src/cli/identity.ts
@@ -1,0 +1,88 @@
+import { readIdentityStatus, switchIdentitySlot } from "../auth/identity.js";
+
+const HELP = `omx identity - Inspect and switch Codex identity slots
+
+Usage:
+  omx identity doctor [--json]
+  omx identity list [--json]
+  omx identity use <slot>
+  omx identity policy [--json]
+`;
+
+const POLICY = {
+  primary: "chatgpt-main",
+  api: "allowed-mixed",
+  bridge: "open-original",
+};
+
+function wantsJson(args: string[]): boolean {
+  return args.includes("--json");
+}
+
+export async function identityCommand(args: string[]): Promise<void> {
+  const command = args[0];
+  if (!command || command === "--help" || command === "-h" || command === "help") {
+    console.log(HELP.trim());
+    return;
+  }
+
+  if (command === "policy") {
+    if (wantsJson(args)) {
+      console.log(JSON.stringify(POLICY, null, 2));
+      return;
+    }
+    console.log(`primary=${POLICY.primary}`);
+    console.log(`api=${POLICY.api}`);
+    console.log(`bridge=${POLICY.bridge}`);
+    return;
+  }
+
+  if (command === "doctor") {
+    const status = await readIdentityStatus();
+    if (wantsJson(args)) {
+      console.log(JSON.stringify({ ...status, policy: POLICY }, null, 2));
+      return;
+    }
+    console.log(`codexHome: ${status.codexHome}`);
+    console.log(`authPath: ${status.authPath}`);
+    console.log(`activeKind: ${status.kind}`);
+    console.log(`authMode: ${status.authMode ?? "unknown"}`);
+    console.log(`currentSlot: ${status.currentSlot ?? "none"}`);
+    console.log(`slots: ${status.slots.length}`);
+    console.log(`policy: primary=${POLICY.primary} api=${POLICY.api} bridge=${POLICY.bridge}`);
+    for (const warning of status.warnings) console.log(`warning: ${warning}`);
+    if (status.warnings.length === 0) console.log("warning: none");
+    return;
+  }
+
+  if (command === "list") {
+    const status = await readIdentityStatus();
+    if (wantsJson(args)) {
+      console.log(JSON.stringify({ slots: status.slots, currentSlot: status.currentSlot }, null, 2));
+      return;
+    }
+    if (status.slots.length === 0) {
+      console.log("No identity slots configured. Run `omx auth add <slot>` first.");
+      return;
+    }
+    for (const slot of status.slots) {
+      const markers = [
+        slot.slot === status.currentSlot ? "current" : "",
+        slot.isPrimary ? "primary" : "",
+        slot.kind ? `kind=${slot.kind}` : "kind=unknown",
+      ].filter(Boolean).join(" ");
+      console.log(`${slot.slot}${slot.displayName ? ` (${slot.displayName})` : ""}${markers ? ` [${markers}]` : ""}`);
+    }
+    return;
+  }
+
+  if (command === "use") {
+    const slot = args[1];
+    if (!slot) throw new Error("Usage: omx identity use <slot>");
+    const record = await switchIdentitySlot(slot);
+    console.log(`Using identity slot ${record.slot}`);
+    return;
+  }
+
+  throw new Error(`Unknown identity command: ${command}\n${HELP.trim()}`);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -52,7 +52,12 @@ import { mcpServeCommand } from "./mcp-serve.js";
 import { adaptCommand } from "./adapt.js";
 import { listCommand } from "./list.js";
 import { authCommand } from "./auth.js";
+import { identityCommand } from "./identity.js";
 import { runAuthHotswap } from "../auth/hotswap.js";
+import { switchIdentitySlot, switchIdentitySlotToAuthPath } from "../auth/identity.js";
+import { resolveDefaultCodexHome } from "../auth/paths.js";
+import { readAuthMetadata } from "../auth/storage.js";
+import { copyUnifiedSessionIdentity, findUnifiedEntry, getUnifiedEntryCodexHomePath, refreshUnifiedLedger, writeUnifiedSessionIdentity } from "../session-ledger/index.js";
 import {
   MADMAX_FLAG,
   CODEX_BYPASS_FLAG,
@@ -222,9 +227,12 @@ Usage:
   omx doctor --team  Check team/swarm runtime health diagnostics
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
   omx auth      Manage Codex OAuth auth slots (add|list|use)
+  omx identity  Inspect/switch Codex identity slots and mixed API/account policy
   omx question  OMX-owned blocking question UI entrypoint for agent-invoked user questions
   omx adapt     Scaffold OMX-owned adapter foundations for persistent external targets
-  omx resume    Resume Codex sessions (supports --project and --codex-home <path>)
+  omx resume    Resume Codex sessions (supports --project and --codex-home <path>; --unified <id>)
+  omx resume --unified <id>
+                Resume/open a unified CLI/API/App session entry in its original identity/source
   omx explore   DEPRECATED compatibility command; use normal repo inspection or omx sparkshell
   omx api       Run native omx-api localhost gateway commands (serve|status|stop|generate)
   omx session   Search prior local session transcripts (--codex-home <path> escape hatch)
@@ -380,6 +388,7 @@ type CliCommand =
   | "doctor"
   | "cleanup"
   | "auth"
+  | "identity"
   | "ask"
   | "question"
   | "adapt"
@@ -409,6 +418,7 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "question",
   "cleanup",
   "auth",
+  "identity",
   "adapt",
   "explore",
   "autoresearch",
@@ -865,6 +875,21 @@ async function persistProjectLaunchRuntimeJsonlArtifact(source: string, destinat
   await writeFile(destination, lines.length > 0 ? `${lines.join("\n")}\n` : "", "utf-8");
 }
 
+async function persistProjectLaunchRuntimeSessionIdentities(
+  runtimeCodexHome: string,
+  projectCodexHome: string,
+): Promise<void> {
+  const source = join(runtimeCodexHome, ".omx", "session-identity");
+  if (!existsSync(source)) return;
+  const sourceStat = await lstat(source);
+  if (!sourceStat.isDirectory() || sourceStat.isSymbolicLink()) return;
+  await cp(source, join(projectCodexHome, ".omx", "session-identity"), {
+    recursive: true,
+    force: true,
+    verbatimSymlinks: true,
+  });
+}
+
 async function persistProjectLaunchRuntimeHistoryArtifacts(
   runtimeCodexHome: string | undefined,
   projectCodexHome: string | undefined,
@@ -891,6 +916,7 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
       await copyFile(source, destination);
     }
   }
+  await persistProjectLaunchRuntimeSessionIdentities(runtimeCodexHome, projectCodexHome);
 }
 
 async function ensureProjectLaunchRuntimeHistoryLinks(
@@ -2351,6 +2377,7 @@ export async function main(args: string[]): Promise<void> {
     "doctor",
     "cleanup",
     "auth",
+    "identity",
     "ask",
     "question",
     "autoresearch",
@@ -2405,7 +2432,11 @@ export async function main(args: string[]): Promise<void> {
         }
         break;
       case "resume":
-        await launchWithHud(["resume", ...launchArgs]);
+        if (launchArgs[0] === "--unified") {
+          await resumeUnifiedCommand(launchArgs.slice(1));
+        } else {
+          await launchWithHud(["resume", ...launchArgs]);
+        }
         break;
       case "setup":
         await setup({
@@ -2462,6 +2493,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "auth":
         await authCommand(args.slice(1));
+        break;
+      case "identity":
+        await identityCommand(args.slice(1));
         break;
       case "autoresearch":
         await autoresearchCommand(args.slice(1));
@@ -2635,6 +2669,32 @@ async function showStatus(): Promise<void> {
     logCliOperationFailure(err);
     console.log("No active modes.");
   }
+}
+
+async function resumeUnifiedCommand(args: string[]): Promise<void> {
+  const id = args[0];
+  if (!id || id === "--help" || id === "-h") {
+    console.log("Usage: omx resume --unified <session-id-or-fragment>");
+    return;
+  }
+  const entry = findUnifiedEntry(await refreshUnifiedLedger(), id);
+  if (!entry) {
+    throw new Error(`Unified session entry not found: ${id}. Run \`omx session list --unified\` first.`);
+  }
+  if (entry.source === "cli" || entry.source === "api" || entry.source === "omx") {
+    const codexHomePath = getUnifiedEntryCodexHomePath(entry);
+    if (entry.identitySlot) {
+      if (codexHomePath) await switchIdentitySlotToAuthPath(entry.identitySlot, join(codexHomePath, "auth.json"));
+      else await switchIdentitySlot(entry.identitySlot);
+    }
+    const resumeArgs = codexHomePath
+      ? ["resume", "--codex-home", codexHomePath, entry.sessionId]
+      : ["resume", entry.sessionId];
+    await launchWithHud(resumeArgs);
+    return;
+  }
+  console.log(`Open original Codex App session source: ${entry.openTarget ?? entry.sessionId}`);
+  console.log("This App/cloud entry is read-only metadata; OMX will not rewrite it into an API-key session.");
 }
 
 async function reasoningCommand(args: string[]): Promise<void> {
@@ -4595,6 +4655,50 @@ export async function reapPostLaunchOrphanedMcpProcesses(
   }
 }
 
+function resolveLaunchIdentityCodexHome(
+  cwd: string,
+  codexHomeOverride?: string,
+  home = process.env.HOME?.trim() || homedir(),
+): string {
+  return codexHomeOverride?.trim()
+    || resolveCodexHomeForLaunch(cwd, process.env)
+    || resolveDefaultCodexHome(home);
+}
+
+export async function recordLaunchIdentityMetadata(
+  cwd: string,
+  sessionId: string,
+  codexHomeOverride?: string,
+): Promise<void> {
+  const home = process.env.HOME?.trim() || homedir();
+  const metadata = await readAuthMetadata(home);
+  const currentSlot = metadata.currentSlot?.trim();
+  if (!currentSlot) return;
+  const slot = metadata.slots.find((candidate) => candidate.slot === currentSlot);
+  if (!slot) return;
+  const codexHomeDir = resolveLaunchIdentityCodexHome(cwd, codexHomeOverride, home);
+  await writeUnifiedSessionIdentity(codexHomeDir, {
+    version: 1,
+    sessionId,
+    identitySlot: slot.slot,
+    ...(slot.kind ? { authMode: slot.kind } : {}),
+    createdAt: new Date().toISOString(),
+  });
+}
+
+export async function reconcileLaunchIdentityMetadata(
+  cwd: string,
+  sessionId: string,
+  codexHomeOverride?: string,
+  nativeSessionId?: string,
+): Promise<void> {
+  const targetSessionId = nativeSessionId?.trim();
+  if (!targetSessionId || targetSessionId === sessionId) return;
+  const home = process.env.HOME?.trim() || homedir();
+  const codexHomeDir = resolveLaunchIdentityCodexHome(cwd, codexHomeOverride, home);
+  await copyUnifiedSessionIdentity(codexHomeDir, sessionId, targetSessionId);
+}
+
 /**
  * preLaunch: Prepare environment before Codex starts.
  * 1. Best-effort launch-safe orphan cleanup for detached OMX MCP processes
@@ -4652,6 +4756,12 @@ ${launchAppendix}${dirtyWorktreeGuidance}`
   // 3. Write session state
   await resetSessionMetrics(cwd, sessionId);
   await writeSessionStart(cwd, sessionId);
+  try {
+    await recordLaunchIdentityMetadata(cwd, sessionId, codexHomeOverride);
+  } catch (err) {
+    logCliOperationFailure(err);
+    // Non-fatal: launch identity sidecars only improve unified resume accuracy.
+  }
   tagCurrentTmuxSessionWithInstance(sessionId);
 
   // 4. Start notify fallback watcher (best effort)
@@ -5366,9 +5476,11 @@ export async function postLaunch(
 ): Promise<void> {
   // Capture session start time before cleanup (writeSessionEnd deletes session.json)
   let sessionStartedAt: string | undefined;
+  let nativeSessionId: string | undefined;
   try {
     const sessionState = await readSessionState(cwd);
     sessionStartedAt = sessionState?.started_at;
+    nativeSessionId = sessionState?.native_session_id?.trim();
   } catch (err) {
     logCliOperationFailure(err);
     // Non-fatal
@@ -5429,6 +5541,14 @@ export async function postLaunch(
     console.error(
       `[omx] postLaunch: model instructions cleanup failed: ${err instanceof Error ? err.message : err}`,
     );
+  }
+
+  // 1.5. Re-key launch identity metadata to the real Codex session id when hooks recorded it.
+  try {
+    await reconcileLaunchIdentityMetadata(cwd, sessionId, codexHomeOverride, nativeSessionId);
+  } catch (err) {
+    logCliOperationFailure(err);
+    // Non-fatal: unified resume can still fall back to rollout metadata.
   }
 
   // 2. Archive session (write history, delete session.json)

--- a/src/cli/session-search.ts
+++ b/src/cli/session-search.ts
@@ -1,11 +1,15 @@
-import { searchSessionHistory, type SessionSearchReport, type SessionSearchOptions } from '../session-history/search.js';
+import { parseSinceSpec, searchSessionHistory, type SessionSearchReport, type SessionSearchOptions } from '../session-history/search.js';
+import { refreshUnifiedLedger, searchUnifiedEntries, type UnifiedSessionEntry } from '../session-ledger/index.js';
 
 const HELP = `omx session - Search prior local session history
 
 Usage:
+  omx session list --unified [--json]
   omx session search <query> [options]
 
 Options:
+  --unified           Include CLI/API/App metadata in one local view
+  --deep              Reserved for explicit deeper local reads; v1 does not persist full-text indexes
   --limit <n>          Maximum results to return (default: 10)
   --session <id>       Restrict to a specific session id or id fragment
   --since <spec>       Restrict by recency (examples: 7d, 24h, 2026-03-10)
@@ -27,6 +31,8 @@ const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 export interface ParsedSessionSearchArgs {
   options: SessionSearchOptions;
   json: boolean;
+  unified: boolean;
+  deep: boolean;
 }
 
 function parsePositiveInteger(value: string, flag: string): number {
@@ -48,6 +54,12 @@ export function parseSessionSearchArgs(args: string[]): ParsedSessionSearchArgs 
     const token = args[index];
     if (token === '--json') {
       json = true;
+      continue;
+    }
+    if (token === '--unified') {
+      continue;
+    }
+    if (token === '--deep') {
       continue;
     }
     if (token === '--case-sensitive') {
@@ -103,7 +115,49 @@ export function parseSessionSearchArgs(args: string[]): ParsedSessionSearchArgs 
     throw new Error(`Missing search query.\n${HELP}`);
   }
 
-  return { options, json };
+  return { options, json, unified: args.includes('--unified'), deep: args.includes('--deep') };
+}
+
+function parseUnifiedListArgs(args: string[]): { json: boolean; deep: boolean } {
+  const allowed = new Set(['--json', '--unified', '--deep']);
+  for (const arg of args) {
+    if (!allowed.has(arg)) throw new Error(`Unknown option: ${arg}`);
+  }
+  return { json: args.includes('--json'), deep: args.includes('--deep') };
+}
+
+function formatUnifiedEntries(entries: UnifiedSessionEntry[]): string {
+  if (entries.length === 0) return 'No unified session entries found.';
+  return entries.map((entry) => [
+    `${entry.sessionId} [${entry.source}${entry.identitySlot ? `/${entry.identitySlot}` : ''}]`,
+    `  time: ${entry.updatedAt ?? entry.createdAt ?? 'unknown'}`,
+    `  cwd: ${entry.cwd ?? 'unknown'}`,
+    `  title: ${entry.title ?? 'unknown'}`,
+    `  open: ${entry.openTarget ?? entry.resumeCommand ?? 'unknown'}`,
+  ].join('\n')).join('\n\n');
+}
+
+function normalizeUnifiedProjectFilter(project: string | undefined, cwd: string): string | undefined {
+  const trimmed = project?.trim();
+  if (!trimmed || trimmed === 'all') return undefined;
+  if (trimmed === 'current') return cwd;
+  return trimmed;
+}
+
+function unifiedEntryTime(entry: UnifiedSessionEntry): number {
+  const parsed = Date.parse(entry.updatedAt ?? entry.createdAt ?? '');
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function filterUnifiedEntries(entries: UnifiedSessionEntry[], options: SessionSearchOptions): UnifiedSessionEntry[] {
+  const projectFilter = normalizeUnifiedProjectFilter(options.project, options.cwd ?? process.cwd());
+  const since = parseSinceSpec(options.since, options.now);
+  return entries.filter((entry) => {
+    if (options.session && !entry.sessionId.includes(options.session)) return false;
+    if (projectFilter && !(entry.cwd ?? '').includes(projectFilter)) return false;
+    if (since !== null && unifiedEntryTime(entry) < since) return false;
+    return true;
+  });
 }
 
 function formatReport(report: SessionSearchReport): string {
@@ -134,6 +188,20 @@ export async function sessionCommand(args: string[]): Promise<void> {
     return;
   }
 
+  if (subcommand === 'list') {
+    const parsed = parseUnifiedListArgs(args.slice(1));
+    if (!args.includes('--unified')) {
+      throw new Error(`omx session list currently requires --unified.\n${HELP}`);
+    }
+    const entries = await refreshUnifiedLedger({ deep: parsed.deep });
+    if (parsed.json) {
+      console.log(JSON.stringify({ entries }, null, 2));
+      return;
+    }
+    console.log(formatUnifiedEntries(entries));
+    return;
+  }
+
   if (subcommand !== 'search') {
     throw new Error(`Unknown session subcommand: ${subcommand}\n${HELP}`);
   }
@@ -144,6 +212,24 @@ export async function sessionCommand(args: string[]): Promise<void> {
   }
 
   const parsed = parseSessionSearchArgs(args.slice(1));
+  if (parsed.unified) {
+    const ledgerOptions = {
+      deep: parsed.deep,
+      ...(parsed.options.codexHomeDir ? { codexHomeDir: parsed.options.codexHomeDir } : {}),
+    };
+    const entries = searchUnifiedEntries(
+      filterUnifiedEntries(await refreshUnifiedLedger(ledgerOptions), parsed.options),
+      parsed.options.query,
+      { caseSensitive: parsed.options.caseSensitive },
+    )
+      .slice(0, parsed.options.limit ?? 10);
+    if (parsed.json) {
+      console.log(JSON.stringify({ query: parsed.options.query, entries }, null, 2));
+      return;
+    }
+    console.log(formatUnifiedEntries(entries));
+    return;
+  }
   const report = await searchSessionHistory(parsed.options);
   if (parsed.json) {
     console.log(JSON.stringify(report, null, 2));

--- a/src/session-ledger/__tests__/index.test.ts
+++ b/src/session-ledger/__tests__/index.test.ts
@@ -1,0 +1,368 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  buildUnifiedLedger,
+  copyUnifiedSessionIdentity,
+  refreshUnifiedLedger,
+  resolveSessionLedgerPath,
+  resolveUnifiedSessionIdentityPath,
+  searchUnifiedEntries,
+  writeUnifiedSessionIdentity,
+} from "../index.js";
+
+async function writeRollout(codexHome: string, isoDate: string, fileName: string, payload: Record<string, unknown>): Promise<void> {
+  const [year, month, day] = isoDate.slice(0, 10).split("-");
+  const rollout = join(codexHome, "sessions", year, month, day, fileName);
+  await mkdir(dirname(rollout), { recursive: true });
+  await writeFile(rollout, `${JSON.stringify({
+    type: "session_meta",
+    payload,
+  })}\n`);
+}
+
+describe("unified session ledger", () => {
+  it("collects CLI/API rollout metadata and App cache metadata read-only", async () => {
+    const home = await mkdtemp(join(tmpdir(), "omx-ledger-"));
+    const codexHome = join(home, ".codex");
+    const appSupport = join(home, "app-support");
+    try {
+      const rollout = join(codexHome, "sessions", "2026", "06", "13", "rollout-session-a.jsonl");
+      await mkdir(dirname(rollout), { recursive: true });
+      await writeFile(join(codexHome, "auth.json"), '{"auth_mode":"apikey","OPENAI_API_KEY":"sk-secret"}\n');
+      await writeFile(rollout, JSON.stringify({
+        type: "session_meta",
+        payload: { id: "session-a", timestamp: "2026-06-13T01:00:00.000Z", cwd: "/repo", auth_mode: "apikey" },
+      }) + "\n" + JSON.stringify({
+        type: "event_msg",
+        payload: { type: "user_message", message: "deep-only transcript phrase with sk-secret999" },
+      }) + "\n" + JSON.stringify({
+        type: "response_item",
+        payload: { item: { type: "function_call", name: "shell", arguments: '{"cmd":"rg function-argument-only-marker src"}' } },
+      }) + "\n");
+      const appDir = join(appSupport, "codex-taskItems-v2-default-user");
+      await mkdir(appDir, { recursive: true });
+      await writeFile(join(appDir, "cache.json"), JSON.stringify({
+        title: "App task with sk-appsecret999",
+        summary: "Cached summary with access_token:app-token-secret",
+      }));
+
+      const entries = await buildUnifiedLedger({ home, codexHomeDir: codexHome, appSupportDir: appSupport });
+      assert.equal(entries.some((entry) => entry.sessionId === "session-a" && entry.source === "api"), true);
+      assert.equal(entries.some((entry) => entry.sessionId === "codex-taskItems-v2-default-user" && entry.source === "app"), true);
+      assert.doesNotMatch(JSON.stringify(entries), /sk-appsecret999|app-token-secret/);
+      assert.equal(searchUnifiedEntries(entries, "repo").some((entry) => entry.sessionId === "session-a"), true);
+
+      await refreshUnifiedLedger({ home, codexHomeDir: codexHome, appSupportDir: appSupport });
+      const ledger = await readFile(join(home, ".omx", "state", "session-ledger.jsonl"), "utf-8");
+      assert.match(ledger, /session-a/);
+      assert.doesNotMatch(ledger, /sk-secret/);
+      assert.doesNotMatch(ledger, /deep-only transcript phrase/);
+
+      const deepEntries = await refreshUnifiedLedger({ home, codexHomeDir: codexHome, appSupportDir: appSupport, deep: true });
+      assert.equal(searchUnifiedEntries(deepEntries, "deep-only transcript phrase").some((entry) => entry.sessionId === "session-a"), true);
+      assert.equal(searchUnifiedEntries(deepEntries, "function-argument-only-marker").some((entry) => entry.sessionId === "session-a"), true);
+      const shallowLedger = await readFile(join(home, ".omx", "state", "session-ledger.jsonl"), "utf-8");
+      assert.doesNotMatch(shallowLedger, /deep-only transcript phrase/);
+      assert.doesNotMatch(shallowLedger, /function-argument-only-marker/);
+      assert.doesNotMatch(JSON.stringify(deepEntries), /sk-secret999/);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("does not stamp historical CLI sessions with the current auth slot", async () => {
+    const home = await mkdtemp(join(tmpdir(), "omx-ledger-slot-"));
+    const codexHome = join(home, ".codex");
+    const appSupport = join(home, "app-support");
+    try {
+      const implicitRollout = join(codexHome, "sessions", "2026", "06", "13", "rollout-implicit.jsonl");
+      const explicitRollout = join(codexHome, "sessions", "2026", "06", "14", "rollout-explicit.jsonl");
+      await mkdir(dirname(implicitRollout), { recursive: true });
+      await mkdir(dirname(explicitRollout), { recursive: true });
+      await mkdir(join(home, ".omx", "auth"), { recursive: true });
+      await writeFile(join(home, ".omx", "auth", "slots.json"), JSON.stringify({
+        version: 1,
+        currentSlot: "current-api",
+        slots: [{ slot: "current-api", createdAt: "", updatedAt: "", kind: "api" }],
+      }));
+      await writeFile(join(codexHome, "auth.json"), '{"auth_mode":"apikey","OPENAI_API_KEY":"sk-secret"}\n');
+      await writeFile(implicitRollout, `${JSON.stringify({
+        type: "session_meta",
+        payload: { id: "implicit-session", timestamp: "2026-06-13T01:00:00.000Z", cwd: "/repo" },
+      })}\n`);
+      await writeFile(explicitRollout, `${JSON.stringify({
+        type: "session_meta",
+        payload: {
+          id: "explicit-session",
+          timestamp: "2026-06-14T01:00:00.000Z",
+          cwd: "/repo",
+          omx_auth_slot: "created-chatgpt",
+        },
+      })}\n`);
+
+      const entries = await buildUnifiedLedger({ home, codexHomeDir: codexHome, appSupportDir: appSupport });
+      assert.equal(entries.find((entry) => entry.sessionId === "implicit-session")?.identitySlot, undefined);
+      assert.equal(entries.find((entry) => entry.sessionId === "implicit-session")?.source, "cli");
+      assert.equal(entries.find((entry) => entry.sessionId === "implicit-session")?.authMode, undefined);
+      assert.equal(entries.find((entry) => entry.sessionId === "explicit-session")?.identitySlot, "created-chatgpt");
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("uses launch identity sidecars only when rollout metadata omits the slot", async () => {
+    const home = await mkdtemp(join(tmpdir(), "omx-ledger-sidecar-"));
+    const codexHome = join(home, ".codex");
+    const appSupport = join(home, "app-support");
+    try {
+      await writeRollout(codexHome, "2026-06-13T01:00:00.000Z", "rollout-sidecar.jsonl", {
+        id: "sidecar-session",
+        timestamp: "2026-06-13T01:00:00.000Z",
+        cwd: "/repo",
+      });
+      await writeRollout(codexHome, "2026-06-14T01:00:00.000Z", "rollout-explicit-sidecar.jsonl", {
+        id: "explicit-sidecar-session",
+        timestamp: "2026-06-14T01:00:00.000Z",
+        cwd: "/repo",
+        omx_auth_slot: "rollout-slot",
+        omx_auth_mode: "chatgpt",
+      });
+      await writeUnifiedSessionIdentity(codexHome, {
+        version: 1,
+        sessionId: "sidecar-session",
+        identitySlot: "sidecar-slot",
+        authMode: "api",
+        createdAt: "2026-06-13T00:59:00.000Z",
+      });
+      await writeUnifiedSessionIdentity(codexHome, {
+        version: 1,
+        sessionId: "explicit-sidecar-session",
+        identitySlot: "sidecar-should-not-win",
+        authMode: "api",
+        createdAt: "2026-06-14T00:59:00.000Z",
+      });
+
+      const entries = await buildUnifiedLedger({ home, codexHomeDir: codexHome, appSupportDir: appSupport });
+      const sidecarEntry = entries.find((entry) => entry.sessionId === "sidecar-session");
+      assert.equal(sidecarEntry?.identitySlot, "sidecar-slot");
+      assert.equal(sidecarEntry?.authMode, "api");
+      assert.equal(sidecarEntry?.source, "api");
+      const explicitEntry = entries.find((entry) => entry.sessionId === "explicit-sidecar-session");
+      assert.equal(explicitEntry?.identitySlot, "rollout-slot");
+      assert.equal(explicitEntry?.authMode, "chatgpt");
+      assert.equal(explicitEntry?.source, "cli");
+
+      if (process.platform !== "win32") {
+        const sidecarPath = resolveUnifiedSessionIdentityPath(codexHome, "sidecar-session");
+        assert.equal((await stat(dirname(sidecarPath))).mode & 0o777, 0o700);
+        assert.equal((await stat(sidecarPath)).mode & 0o777, 0o600);
+      }
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("can copy a launch wrapper identity sidecar to the native Codex session id", async () => {
+    const home = await mkdtemp(join(tmpdir(), "omx-ledger-sidecar-native-"));
+    const codexHome = join(home, ".codex");
+    const appSupport = join(home, "app-support");
+    try {
+      await writeRollout(codexHome, "2026-06-13T01:00:00.000Z", "rollout-native-sidecar.jsonl", {
+        id: "native-codex-session",
+        timestamp: "2026-06-13T01:00:00.000Z",
+        cwd: "/repo",
+      });
+      await writeUnifiedSessionIdentity(codexHome, {
+        version: 1,
+        sessionId: "omx-wrapper-session",
+        identitySlot: "wrapper-slot",
+        authMode: "chatgpt",
+        createdAt: "2026-06-13T00:59:00.000Z",
+      });
+
+      assert.equal(
+        await copyUnifiedSessionIdentity(codexHome, "omx-wrapper-session", "native-codex-session"),
+        true,
+      );
+      assert.equal(
+        await copyUnifiedSessionIdentity(codexHome, "missing-wrapper-session", "unused-native-session"),
+        false,
+      );
+
+      const entries = await buildUnifiedLedger({ home, codexHomeDir: codexHome, appSupportDir: appSupport });
+      const nativeEntry = entries.find((entry) => entry.sessionId === "native-codex-session");
+      assert.equal(nativeEntry?.identitySlot, "wrapper-slot");
+      assert.equal(nativeEntry?.authMode, "chatgpt");
+      assert.equal(nativeEntry?.source, "cli");
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("does not overwrite an existing native Codex session identity sidecar", async () => {
+    const home = await mkdtemp(join(tmpdir(), "omx-ledger-sidecar-existing-native-"));
+    const codexHome = join(home, ".codex");
+    const appSupport = join(home, "app-support");
+    try {
+      await writeRollout(codexHome, "2026-06-13T01:00:00.000Z", "rollout-native-existing-sidecar.jsonl", {
+        id: "native-codex-session",
+        timestamp: "2026-06-13T01:00:00.000Z",
+        cwd: "/repo",
+      });
+      await writeUnifiedSessionIdentity(codexHome, {
+        version: 1,
+        sessionId: "omx-wrapper-session",
+        identitySlot: "current-wrapper-slot",
+        authMode: "api",
+        createdAt: "2026-06-13T01:01:00.000Z",
+      });
+      await writeUnifiedSessionIdentity(codexHome, {
+        version: 1,
+        sessionId: "native-codex-session",
+        identitySlot: "original-native-slot",
+        authMode: "chatgpt",
+        createdAt: "2026-06-13T00:59:00.000Z",
+      });
+
+      assert.equal(
+        await copyUnifiedSessionIdentity(codexHome, "omx-wrapper-session", "native-codex-session"),
+        false,
+      );
+
+      const entries = await buildUnifiedLedger({ home, codexHomeDir: codexHome, appSupportDir: appSupport });
+      const nativeEntry = entries.find((entry) => entry.sessionId === "native-codex-session");
+      assert.equal(nativeEntry?.identitySlot, "original-native-slot");
+      assert.equal(nativeEntry?.authMode, "chatgpt");
+      assert.equal(nativeEntry?.source, "cli");
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("includes generated project runtime Codex homes when no explicit Codex home is supplied", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-ledger-runtime-"));
+    const home = join(cwd, "home");
+    const defaultCodexHome = join(home, ".codex");
+    const runtimeCodexHome = join(cwd, ".omx", "runtime", "codex-home", "omx-runtime-a");
+    const previousCodexHome = process.env.CODEX_HOME;
+    try {
+      await writeRollout(defaultCodexHome, "2026-06-13T01:00:00.000Z", "rollout-default.jsonl", {
+        id: "default-session",
+        timestamp: "2026-06-13T01:00:00.000Z",
+        cwd,
+      });
+      await writeRollout(runtimeCodexHome, "2026-06-14T01:00:00.000Z", "rollout-runtime.jsonl", {
+        id: "runtime-session",
+        timestamp: "2026-06-14T01:00:00.000Z",
+        cwd,
+      });
+      process.env.CODEX_HOME = "";
+
+      const entries = await buildUnifiedLedger({ home, cwd, appSupportDir: join(home, "app-support") });
+
+      assert.equal(entries.some((entry) => entry.sessionId === "default-session" && entry.codexHome === defaultCodexHome), true);
+      assert.equal(entries.some((entry) => entry.sessionId === "runtime-session" && entry.codexHome === runtimeCodexHome), true);
+    } finally {
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("includes the persisted project Codex home for project-scope unified scans", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-ledger-project-home-"));
+    const home = join(cwd, "home");
+    const projectCodexHome = join(cwd, ".codex");
+    const previousCodexHome = process.env.CODEX_HOME;
+    try {
+      await mkdir(join(cwd, ".omx"), { recursive: true });
+      await writeFile(join(cwd, ".omx", "setup-scope.json"), JSON.stringify({ scope: "project" }));
+      await writeRollout(projectCodexHome, "2026-06-15T01:00:00.000Z", "rollout-project.jsonl", {
+        id: "project-session",
+        timestamp: "2026-06-15T01:00:00.000Z",
+        cwd,
+      });
+      process.env.CODEX_HOME = "";
+
+      const entries = await buildUnifiedLedger({ home, cwd, appSupportDir: join(home, "app-support") });
+
+      assert.equal(entries.some((entry) => entry.sessionId === "project-session" && entry.codexHome === projectCodexHome), true);
+    } finally {
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("uses madmax public labels for unified ledger entries without persisting run-root paths", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-ledger-madmax-"));
+    const home = join(cwd, "home");
+    const runsRoot = join(cwd, "runs");
+    const runDir = join(runsRoot, "run-associated");
+    const associatedCodexHome = join(runDir, ".omx", "runtime", "codex-home", "omx-madmax-a");
+    const previousCodexHome = process.env.CODEX_HOME;
+    const previousRunsDir = process.env.OMX_RUNS_DIR;
+    try {
+      await mkdir(runDir, { recursive: true });
+      await writeFile(join(runDir, ".omxbox-run.json"), JSON.stringify({
+        source_cwd: cwd,
+        run_dir: runDir,
+      }));
+      await writeRollout(associatedCodexHome, "2026-06-14T01:00:00.000Z", "rollout-madmax.jsonl", {
+        id: "madmax-session",
+        timestamp: "2026-06-14T01:00:00.000Z",
+        cwd,
+      });
+      process.env.CODEX_HOME = "";
+      process.env.OMX_RUNS_DIR = runsRoot;
+
+      const entries = await refreshUnifiedLedger({ home, cwd, appSupportDir: join(home, "app-support") });
+      const entry = entries.find((candidate) => candidate.sessionId === "madmax-session");
+      assert.equal(entry?.codexHome, "madmax:omx-madmax-a");
+      assert.equal(entry?.openTarget, join("madmax:omx-madmax-a", "sessions", "2026", "06", "14", "rollout-madmax.jsonl"));
+
+      const serializedEntries = JSON.stringify(entries);
+      const ledger = await readFile(resolveSessionLedgerPath(home), "utf-8");
+      assert.equal(serializedEntries.includes(associatedCodexHome), false);
+      assert.equal(serializedEntries.includes(runDir), false);
+      assert.equal(ledger.includes(associatedCodexHome), false);
+      assert.equal(ledger.includes(runDir), false);
+      assert.match(ledger, /madmax:omx-madmax-a/);
+    } finally {
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
+      if (previousRunsDir === undefined) delete process.env.OMX_RUNS_DIR;
+      else process.env.OMX_RUNS_DIR = previousRunsDir;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("writes refreshed ledger state with owner-only permissions", async () => {
+    if (process.platform === "win32") return;
+    const cwd = await mkdtemp(join(tmpdir(), "omx-ledger-mode-"));
+    const home = join(cwd, "home");
+    const codexHome = join(home, ".codex");
+    const previousCodexHome = process.env.CODEX_HOME;
+    try {
+      await writeRollout(codexHome, "2026-06-13T01:00:00.000Z", "rollout-default.jsonl", {
+        id: "private-ledger-session",
+        timestamp: "2026-06-13T01:00:00.000Z",
+        cwd,
+      });
+      process.env.CODEX_HOME = "";
+
+      await refreshUnifiedLedger({ home, cwd, appSupportDir: join(home, "app-support") });
+
+      const ledgerPath = resolveSessionLedgerPath(home);
+      assert.equal((await stat(dirname(ledgerPath))).mode & 0o777, 0o700);
+      assert.equal((await stat(ledgerPath)).mode & 0o777, 0o600);
+    } finally {
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/session-ledger/index.ts
+++ b/src/session-ledger/index.ts
@@ -1,0 +1,451 @@
+import { createReadStream, existsSync } from "fs";
+import { readdir, readFile, realpath, stat } from "fs/promises";
+import { createInterface } from "readline";
+import { homedir } from "os";
+import { basename, join, relative, resolve } from "path";
+import { resolveDefaultCodexHome } from "../auth/paths.js";
+import { redactAuthSecrets } from "../auth/redact.js";
+import { atomicWriteFile } from "../auth/storage.js";
+import { resolveCodexHomeForLaunch } from "../cli/codex-home.js";
+import { discoverProjectRuntimeCodexHomes } from "../cli/project-runtime-codex-homes.js";
+
+export type UnifiedSessionSource = "cli" | "app" | "omx" | "api";
+
+export interface UnifiedSessionEntry {
+  sessionId: string;
+  source: UnifiedSessionSource;
+  identitySlot?: string;
+  authMode?: string;
+  cwd?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  title?: string;
+  summary?: string;
+  openTarget?: string;
+  resumeCommand?: string;
+  codexHome?: string;
+}
+
+export interface UnifiedSessionIdentityMetadata {
+  version: 1;
+  sessionId: string;
+  identitySlot?: string;
+  authMode?: string;
+  createdAt: string;
+}
+
+const unifiedEntryCodexHomePath = Symbol("unifiedEntryCodexHomePath");
+const unifiedEntrySearchText = Symbol("unifiedEntrySearchText");
+
+type UnifiedSessionEntryWithCodexHomePath = UnifiedSessionEntry & {
+  [unifiedEntryCodexHomePath]?: string;
+  [unifiedEntrySearchText]?: string;
+};
+
+interface ResolvedUnifiedLedgerCodexHome {
+  dir: string;
+  publicLabel: string;
+}
+
+export interface BuildUnifiedLedgerOptions {
+  home?: string;
+  codexHomeDir?: string;
+  codexHomeDirs?: string[];
+  appSupportDir?: string;
+  cwd?: string;
+  deep?: boolean;
+  now?: Date;
+}
+
+export function resolveSessionLedgerPath(home = homedir()): string {
+  return join(home, ".omx", "state", "session-ledger.jsonl");
+}
+
+function safeSessionIdentityFileName(sessionId: string): string {
+  const safe = sessionId.trim().replace(/[^A-Za-z0-9._-]/g, "_");
+  return safe || "unknown";
+}
+
+export function resolveUnifiedSessionIdentityPath(codexHomeDir: string, sessionId: string): string {
+  return join(resolve(codexHomeDir), ".omx", "session-identity", `${safeSessionIdentityFileName(sessionId)}.json`);
+}
+
+export async function writeUnifiedSessionIdentity(
+  codexHomeDir: string,
+  metadata: UnifiedSessionIdentityMetadata,
+): Promise<void> {
+  const payload: UnifiedSessionIdentityMetadata = {
+    version: 1,
+    sessionId: metadata.sessionId,
+    ...(metadata.identitySlot ? { identitySlot: metadata.identitySlot } : {}),
+    ...(metadata.authMode ? { authMode: metadata.authMode } : {}),
+    createdAt: metadata.createdAt,
+  };
+  await atomicWriteFile(resolveUnifiedSessionIdentityPath(codexHomeDir, metadata.sessionId), `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+async function readUnifiedSessionIdentity(codexHomeDir: string, sessionId: string): Promise<UnifiedSessionIdentityMetadata | null> {
+  try {
+    const parsed = asRecord(JSON.parse(await readFile(resolveUnifiedSessionIdentityPath(codexHomeDir, sessionId), "utf-8")));
+    if (!parsed || parsed.version !== 1) return null;
+    const parsedSessionId = asString(parsed.sessionId);
+    if (parsedSessionId && parsedSessionId !== sessionId) return null;
+    return {
+      version: 1,
+      sessionId,
+      identitySlot: asString(parsed.identitySlot),
+      authMode: asString(parsed.authMode),
+      createdAt: asString(parsed.createdAt) ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function copyUnifiedSessionIdentity(
+  codexHomeDir: string,
+  sourceSessionId: string,
+  targetSessionId: string,
+): Promise<boolean> {
+  const sourceId = sourceSessionId.trim();
+  const targetId = targetSessionId.trim();
+  if (!sourceId || !targetId || sourceId === targetId) return false;
+  const metadata = await readUnifiedSessionIdentity(codexHomeDir, sourceId);
+  if (!metadata) return false;
+  if (await readUnifiedSessionIdentity(codexHomeDir, targetId)) return false;
+  await writeUnifiedSessionIdentity(codexHomeDir, {
+    ...metadata,
+    sessionId: targetId,
+  });
+  return true;
+}
+
+function redactOptionalText(value: string | undefined): string | undefined {
+  return value ? redactAuthSecrets(value) : undefined;
+}
+
+function sourceFromRolloutAuthMode(authMode: string | undefined): UnifiedSessionSource {
+  const normalized = authMode?.toLowerCase();
+  return normalized === "api" || normalized === "apikey" ? "api" : "cli";
+}
+
+function attachUnifiedEntryCodexHomePath(entry: UnifiedSessionEntry, codexHomePath: string): UnifiedSessionEntry {
+  Object.defineProperty(entry, unifiedEntryCodexHomePath, {
+    value: codexHomePath,
+    enumerable: false,
+    configurable: false,
+  });
+  return entry;
+}
+
+function attachUnifiedEntrySearchText(entry: UnifiedSessionEntry, searchText: string | undefined): UnifiedSessionEntry {
+  if (!searchText) return entry;
+  Object.defineProperty(entry, unifiedEntrySearchText, {
+    value: searchText,
+    enumerable: false,
+    configurable: false,
+  });
+  return entry;
+}
+
+export function getUnifiedEntryCodexHomePath(entry: UnifiedSessionEntry): string | undefined {
+  const codexHomePath = (entry as UnifiedSessionEntryWithCodexHomePath)[unifiedEntryCodexHomePath] ?? entry.codexHome;
+  return codexHomePath?.startsWith("madmax:") ? undefined : codexHomePath;
+}
+
+function getUnifiedEntrySearchText(entry: UnifiedSessionEntry): string | undefined {
+  return (entry as UnifiedSessionEntryWithCodexHomePath)[unifiedEntrySearchText];
+}
+
+async function listRolloutFiles(root: string): Promise<string[]> {
+  if (!existsSync(root)) return [];
+  const files: string[] = [];
+  const queue = [root];
+  while (queue.length > 0) {
+    const dir = queue.pop();
+    if (!dir) continue;
+    for (const entry of await readdir(dir, { withFileTypes: true }).catch(() => [])) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) queue.push(path);
+      if (entry.isFile() && entry.name.startsWith("rollout-") && entry.name.endsWith(".jsonl")) files.push(path);
+    }
+  }
+  return files;
+}
+
+async function readFirstJsonLine(filePath: string): Promise<Record<string, unknown> | null> {
+  const stream = createReadStream(filePath, "utf-8");
+  const reader = createInterface({ input: stream, crlfDelay: Infinity });
+  try {
+    for await (const line of reader) {
+      try {
+        const parsed = JSON.parse(line) as unknown;
+        return asRecord(parsed);
+      } catch {
+        return null;
+      }
+    }
+  } finally {
+    reader.close();
+    stream.destroy();
+  }
+  return null;
+}
+
+function extractText(value: unknown, texts: string[]): void {
+  if (typeof value === "string") {
+    const text = value.trim();
+    if (text) texts.push(text);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) extractText(item, texts);
+    return;
+  }
+  const record = asRecord(value);
+  if (!record) return;
+  for (const key of ["text", "message", "summary", "content", "output", "item", "items"]) {
+    if (key in record) extractText(record[key], texts);
+  }
+  if ("arguments" in record) {
+    const value = record.arguments;
+    if (typeof value === "string") {
+      const text = value.trim();
+      if (text) texts.push(text);
+    } else if (value && typeof value === "object") {
+      texts.push(JSON.stringify(value));
+    }
+  }
+}
+
+async function readDeepRolloutText(filePath: string): Promise<string | undefined> {
+  const stream = createReadStream(filePath, "utf-8");
+  const reader = createInterface({ input: stream, crlfDelay: Infinity });
+  const texts: string[] = [];
+  try {
+    for await (const line of reader) {
+      try {
+        const parsed = asRecord(JSON.parse(line) as unknown);
+        const payload = asRecord(parsed?.payload);
+        if (!payload) continue;
+        extractText(payload, texts);
+      } catch {
+        // Deep reads are best-effort only.
+      }
+    }
+  } finally {
+    reader.close();
+    stream.destroy();
+  }
+  const text = redactAuthSecrets(texts.join(" ").replace(/\s+/g, " ").trim());
+  return text || undefined;
+}
+
+async function collectCliEntries(codexHomeSource: ResolvedUnifiedLedgerCodexHome, deep = false): Promise<UnifiedSessionEntry[]> {
+  const codexHomeDir = codexHomeSource.dir;
+  const files = await listRolloutFiles(join(codexHomeDir, "sessions"));
+  const entries: UnifiedSessionEntry[] = [];
+  for (const file of files) {
+    const first = await readFirstJsonLine(file);
+    const payload = asRecord(first?.payload);
+    const fileInfo = await stat(file).catch(() => null);
+    const sessionId =
+      asString(payload?.id) ??
+      basename(file, ".jsonl").replace(/^rollout-/, "");
+    const cwd = asString(payload?.cwd);
+    const timestamp = asString(payload?.timestamp);
+    const sidecarIdentity = await readUnifiedSessionIdentity(codexHomeDir, sessionId);
+    const identitySlot =
+      asString(payload?.identitySlot) ??
+      asString(payload?.identity_slot) ??
+      asString(payload?.authSlot) ??
+      asString(payload?.auth_slot) ??
+      asString(payload?.omxAuthSlot) ??
+      asString(payload?.omx_auth_slot) ??
+      sidecarIdentity?.identitySlot;
+    const authMode =
+      asString(payload?.authMode) ??
+      asString(payload?.auth_mode) ??
+      asString(payload?.omxAuthMode) ??
+      asString(payload?.omx_auth_mode) ??
+      sidecarIdentity?.authMode;
+    const source = sourceFromRolloutAuthMode(authMode);
+    const deepText = deep ? await readDeepRolloutText(file) : undefined;
+    const entry: UnifiedSessionEntry = {
+      sessionId,
+      source,
+      identitySlot,
+      authMode,
+      cwd,
+      createdAt: timestamp,
+      updatedAt: fileInfo?.mtime.toISOString(),
+      title: cwd ? basename(cwd) : sessionId,
+      summary: deepText ? deepText.slice(0, 600) : `Codex ${source} session${cwd ? ` in ${cwd}` : ""}`,
+      openTarget: join(codexHomeSource.publicLabel, relative(codexHomeDir, file)),
+      resumeCommand: `codex resume ${sessionId}`,
+      codexHome: codexHomeSource.publicLabel,
+    };
+    attachUnifiedEntrySearchText(entry, deepText);
+    entries.push(attachUnifiedEntryCodexHomePath(entry, codexHomeDir));
+  }
+  return entries;
+}
+
+async function readOptionalJsonSummary(dir: string): Promise<{ title?: string; summary?: string }> {
+  const files = await readdir(dir, { withFileTypes: true }).catch(() => []);
+  for (const entry of files) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    try {
+      const parsed = asRecord(JSON.parse(await readFile(join(dir, entry.name), "utf-8")));
+      const title = redactOptionalText(asString(parsed?.title) ?? asString(parsed?.name));
+      const summary = redactOptionalText(asString(parsed?.summary) ?? asString(parsed?.description));
+      if (title || summary) return { title, summary };
+    } catch {
+      // App cache files are best-effort only.
+    }
+  }
+  return {};
+}
+
+async function collectAppEntries(appSupportDir: string): Promise<UnifiedSessionEntry[]> {
+  if (!existsSync(appSupportDir)) return [];
+  const entries: UnifiedSessionEntry[] = [];
+  const dirs = await readdir(appSupportDir, { withFileTypes: true }).catch(() => []);
+  for (const entry of dirs) {
+    if (!entry.isDirectory()) continue;
+    if (!/^codex-(?:taskItems|taskDetails|environments)-/.test(entry.name)) continue;
+    const path = join(appSupportDir, entry.name);
+    const info = await stat(path).catch(() => null);
+    const summary = await readOptionalJsonSummary(path);
+    entries.push({
+      sessionId: entry.name,
+      source: "app",
+      authMode: "chatgpt",
+      createdAt: info?.birthtime.toISOString(),
+      updatedAt: info?.mtime.toISOString(),
+      title: summary.title ?? entry.name,
+      summary: summary.summary ?? "Codex App/ChatGPT cached task metadata (read-only)",
+      openTarget: path,
+    });
+  }
+  return entries;
+}
+
+function dedupeEntries(entries: UnifiedSessionEntry[]): UnifiedSessionEntry[] {
+  const byKey = new Map<string, UnifiedSessionEntry>();
+  for (const entry of entries) {
+    const key = `${entry.source}:${getUnifiedEntryCodexHomePath(entry) ?? ""}:${entry.sessionId}`;
+    const current = byKey.get(key);
+    if (!current || String(entry.updatedAt ?? "") > String(current.updatedAt ?? "")) byKey.set(key, entry);
+  }
+  return [...byKey.values()].sort((a, b) => String(b.updatedAt ?? b.createdAt ?? "").localeCompare(String(a.updatedAt ?? a.createdAt ?? "")));
+}
+
+async function normalizeExistingCodexHomeDirs(candidates: Array<string | ResolvedUnifiedLedgerCodexHome>): Promise<ResolvedUnifiedLedgerCodexHome[]> {
+  const seen = new Set<string>();
+  const dirs: ResolvedUnifiedLedgerCodexHome[] = [];
+  for (const candidate of candidates) {
+    const rawDir = typeof candidate === "string" ? candidate : candidate.dir;
+    const trimmed = rawDir.trim();
+    if (!trimmed) continue;
+    const absolute = resolve(trimmed);
+    if (!existsSync(absolute)) continue;
+    const key = await realpath(absolute).catch(() => absolute);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    dirs.push({
+      dir: absolute,
+      publicLabel: typeof candidate === "string" ? absolute : candidate.publicLabel,
+    });
+  }
+  return dirs;
+}
+
+async function resolveUnifiedLedgerCodexHomeDirs(options: BuildUnifiedLedgerOptions, home: string): Promise<ResolvedUnifiedLedgerCodexHome[]> {
+  if (options.codexHomeDirs && options.codexHomeDirs.length > 0) {
+    return normalizeExistingCodexHomeDirs(options.codexHomeDirs);
+  }
+  if (options.codexHomeDir) {
+    return normalizeExistingCodexHomeDirs([options.codexHomeDir]);
+  }
+  const envCodexHome = process.env.CODEX_HOME?.trim();
+  const cwd = options.cwd ?? process.cwd();
+  const primaryCodexHome = envCodexHome || resolveCodexHomeForLaunch(cwd, process.env) || resolveDefaultCodexHome(home);
+  const runtimeHomes = await discoverProjectRuntimeCodexHomes(cwd);
+  return normalizeExistingCodexHomeDirs([
+    primaryCodexHome,
+    ...runtimeHomes.map((runtimeHome) => ({
+      dir: runtimeHome.path,
+      publicLabel: runtimeHome.source === "madmax-run"
+        ? runtimeHome.publicLabel ?? "madmax:runtime-codex-home"
+        : runtimeHome.path,
+    })),
+  ]);
+}
+
+export async function buildUnifiedLedger(options: BuildUnifiedLedgerOptions = {}): Promise<UnifiedSessionEntry[]> {
+  const home = options.home ?? homedir();
+  const codexHomeDirs = await resolveUnifiedLedgerCodexHomeDirs(options, home);
+  const appSupportDir = options.appSupportDir ?? join(home, "Library", "Application Support", "com.openai.chat");
+  const cliEntries: UnifiedSessionEntry[] = [];
+  for (const codexHomeDir of codexHomeDirs) {
+    cliEntries.push(...await collectCliEntries(codexHomeDir, options.deep === true));
+  }
+  return dedupeEntries([
+    ...cliEntries,
+    ...await collectAppEntries(appSupportDir),
+  ]);
+}
+
+export async function refreshUnifiedLedger(options: BuildUnifiedLedgerOptions = {}): Promise<UnifiedSessionEntry[]> {
+  const home = options.home ?? homedir();
+  const shallowEntries = await buildUnifiedLedger({ ...options, deep: false });
+  const ledgerPath = resolveSessionLedgerPath(home);
+  await atomicWriteFile(ledgerPath, `${shallowEntries.map((entry) => JSON.stringify(entry)).join("\n")}${shallowEntries.length ? "\n" : ""}`);
+  if (options.deep === true) return await buildUnifiedLedger({ ...options, deep: true });
+  return shallowEntries;
+}
+
+export function searchUnifiedEntries(
+  entries: UnifiedSessionEntry[],
+  query: string,
+  options: { caseSensitive?: boolean } = {},
+): UnifiedSessionEntry[] {
+  const needle = options.caseSensitive ? query.trim() : query.trim().toLowerCase();
+  if (!needle) return entries;
+  return entries.filter((entry) => [
+    entry.sessionId,
+    entry.source,
+    entry.identitySlot,
+    entry.authMode,
+    entry.cwd,
+    entry.title,
+    entry.summary,
+    getUnifiedEntrySearchText(entry),
+    entry.openTarget,
+    entry.resumeCommand,
+    entry.codexHome,
+  ].some((value) => {
+    if (typeof value !== "string") return false;
+    return options.caseSensitive ? value.includes(needle) : value.toLowerCase().includes(needle);
+  }));
+}
+
+export function findUnifiedEntry(entries: UnifiedSessionEntry[], id: string): UnifiedSessionEntry | null {
+  const needle = id.trim();
+  if (!needle) return null;
+  return entries.find((entry) => entry.sessionId === needle) ??
+    entries.find((entry) => entry.sessionId.includes(needle)) ??
+    entries.find((entry) => relative("/", entry.openTarget ?? "").includes(needle)) ??
+    null;
+}


### PR DESCRIPTION
## Summary

- Add non-sensitive identity status and unified local session ledger metadata across CLI/API/App sources.
- Preserve source boundaries for `omx resume --unified` instead of merging App/cloud metadata into API-key sessions.
- Keep App task caches read-only and persist only shallow, redacted metadata by default.

## Review follow-up

- Fresh replacement for #2880 against `dev`; the prior PR was closed only because it targeted `main`.
- Do not stamp historical CLI sessions with the scan-time `currentSlot`; automatic identity switching now requires a slot recorded on the session metadata itself.
- Honor parsed unified search filters including `--codex-home`, `--session`, `--project`, `--since`, and case sensitivity.
- Redact App cache title/summary strings before entries are returned or persisted to the unified ledger.

## Tests

- `npm run build`
- `node dist/scripts/run-test-files.js dist/session-ledger/__tests__/index.test.js dist/cli/__tests__/session-search.test.js dist/auth/__tests__/identity.test.js dist/auth/__tests__/storage.test.js dist/cli/__tests__/auth.test.js dist/cli/__tests__/resume.test.js`
- `npm run lint`
- `npm run check:no-unused`