### PR TITLE
Fix Ralplan consensus gate approval and freshness checks

### DIFF
--- a/src/autopilot/__tests__/ralplan-gate.test.ts
+++ b/src/autopilot/__tests__/ralplan-gate.test.ts
@@ -8,8 +8,129 @@ import {
   buildAutopilotRalplanUltragoalGateError,
   canAdvanceAutopilotRalplanToUltragoal,
 } from '../ralplan-gate.js';
+import { buildRalplanConsensusGateFromSources } from '../../ralplan/consensus-gate.js';
 
 describe('autopilot ralplan gate', () => {
+  it('rejects direct consensus when architect review is not approving', () => {
+    const evidence = buildRalplanConsensusGateFromSources([{
+      source: 'direct-architect-comment',
+      value: {
+        ralplan_consensus_gate: {
+          complete: true,
+          sequence: ['architect-review', 'critic-review'],
+          ralplan_architect_review: {
+            agent_role: 'architect',
+            verdict: 'comment',
+          },
+          ralplan_critic_review: {
+            agent_role: 'critic',
+            verdict: 'approve',
+          },
+        },
+      },
+    }]);
+
+    assert.equal(evidence.complete, false);
+    assert.equal(evidence.blockedReason, 'non_approving_ralplan_consensus_review');
+    assert.match(evidence.blockedDetails?.join('\n') ?? '', /architect review verdict=comment is not approve/);
+  });
+
+  it('rejects direct consensus when critic review is not approving', () => {
+    const evidence = buildRalplanConsensusGateFromSources([{
+      source: 'direct-critic-reject',
+      value: {
+        ralplan_consensus_gate: {
+          complete: true,
+          sequence: ['architect-review', 'critic-review'],
+          ralplan_architect_review: {
+            agent_role: 'architect',
+            verdict: 'approve',
+          },
+          ralplan_critic_review: {
+            agent_role: 'critic',
+            verdict: 'reject',
+          },
+        },
+      },
+    }]);
+
+    assert.equal(evidence.complete, false);
+    assert.equal(evidence.blockedReason, 'non_approving_ralplan_consensus_review');
+    assert.match(evidence.blockedDetails?.join('\n') ?? '', /critic review verdict=reject is not approve/);
+  });
+
+  it('accepts direct consensus when architect and critic reviews approve in order', () => {
+    const evidence = buildRalplanConsensusGateFromSources([{
+      source: 'direct-approval',
+      value: {
+        ralplan_consensus_gate: {
+          complete: true,
+          sequence: ['architect-review', 'critic-review'],
+          ralplan_architect_review: {
+            agent_role: 'architect',
+            verdict: 'approve',
+            completed_at: '2026-06-12T10:02:00.000Z',
+          },
+          ralplan_critic_review: {
+            agent_role: 'critic',
+            verdict: 'approve',
+            completed_at: '2026-06-12T10:03:00.000Z',
+          },
+        },
+      },
+    }]);
+
+    assert.equal(evidence.complete, true);
+    assert.equal(evidence.blockedReason, null);
+    assert.equal(evidence.source, 'direct-approval');
+  });
+
+  it('accepts fresh valid consensus before stale invalid consensus', () => {
+    const evidence = buildRalplanConsensusGateFromSources([
+      {
+        source: 'fresh-valid',
+        value: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              verdict: 'approve',
+              completed_at: '2026-06-12T10:02:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              verdict: 'approve',
+              completed_at: '2026-06-12T10:03:00.000Z',
+            },
+          },
+        },
+      },
+      {
+        source: 'stale-invalid',
+        value: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              verdict: 'iterate',
+              completed_at: '2026-06-12T09:58:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              verdict: 'approve',
+              completed_at: '2026-06-12T09:59:00.000Z',
+            },
+          },
+        },
+      },
+    ]);
+
+    assert.equal(evidence.complete, true);
+    assert.equal(evidence.blockedReason, null);
+    assert.equal(evidence.source, 'fresh-valid');
+  });
   it('rejects invalid next-state complete consensus before falling back to older valid current state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-next-invalid-terminal-'));
     const sessionId = 'sess-autopilot-next-invalid-terminal';

--- a/src/autopilot/__tests__/ralplan-gate.test.ts
+++ b/src/autopilot/__tests__/ralplan-gate.test.ts
@@ -224,6 +224,97 @@ describe('autopilot ralplan gate', () => {
     }
   });
 
+  it('rejects ordered invalid next-state direct consensus before older valid current state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-next-invalid-direct-'));
+    const sessionId = 'sess-autopilot-next-invalid-direct';
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-06-12T10:05:00.000Z',
+            threads: {
+              'thread-leader': { thread_id: 'thread-leader', kind: 'leader', first_seen_at: '2026-06-12T09:59:00.000Z', last_seen_at: '2026-06-12T09:59:00.000Z', turn_count: 1 },
+              'thread-architect-old': { thread_id: 'thread-architect-old', kind: 'subagent', first_seen_at: '2026-06-12T09:59:30.000Z', last_seen_at: '2026-06-12T09:59:30.000Z', completed_at: '2026-06-12T09:59:30.000Z', turn_count: 1 },
+              'thread-critic-old': { thread_id: 'thread-critic-old', kind: 'subagent', first_seen_at: '2026-06-12T10:00:00.000Z', last_seen_at: '2026-06-12T10:00:00.000Z', completed_at: '2026-06-12T10:00:00.000Z', turn_count: 1 },
+            },
+          },
+        },
+      }, null, 2));
+
+      const nextState = {
+        current_phase: 'ralplan',
+        return_to_ralplan_reason: 'Code review requested a plan update.',
+        ralplan_consensus_gate: {
+          complete: true,
+          sequence: ['architect-review', 'critic-review'],
+          ralplan_architect_review: {
+            agent_role: 'architect',
+            provenance_kind: 'native_subagent',
+            verdict: 'iterate',
+            session_id: sessionId,
+            thread_id: 'thread-architect-new',
+            artifact_path: '.omx/artifacts/architect-new.md',
+            tracker_path: '.omx/state/subagent-tracking.json',
+            completed_at: '2026-06-12T10:04:00.000Z',
+          },
+          ralplan_critic_review: {
+            agent_role: 'critic',
+            provenance_kind: 'native_subagent',
+            verdict: 'approve',
+            session_id: sessionId,
+            thread_id: 'thread-critic-new',
+            artifact_path: '.omx/artifacts/critic-new.md',
+            tracker_path: '.omx/state/subagent-tracking.json',
+            completed_at: '2026-06-12T10:05:00.000Z',
+          },
+        },
+      };
+      const currentState = {
+        current_phase: 'ralplan',
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-architect-old',
+              artifact_path: '.omx/artifacts/architect-old.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-06-12T09:59:30.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-critic-old',
+              artifact_path: '.omx/artifacts/critic-old.md',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-06-12T10:00:00.000Z',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, sessionId, nextState, currentState });
+
+      assert.equal(decision.allowed, false);
+      assert.equal(decision.evidence?.source, 'next-autopilot-state');
+      assert.equal(decision.evidence?.blockedReason, 'non_approving_ralplan_consensus_review');
+      assert.match(buildAutopilotRalplanUltragoalGateError(decision), /architect.*verdict=iterate/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('rejects stale nested ralplan handoff consensus when parent state returned to ralplan', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-stale-nested-'));
     const sessionId = 'sess-autopilot-stale-nested';

--- a/src/ralplan/__tests__/consensus-gate.test.ts
+++ b/src/ralplan/__tests__/consensus-gate.test.ts
@@ -100,6 +100,51 @@ describe('ralplan consensus gate state roots', () => {
     assert.match(gate.blockedDetails?.join(' ') ?? '', /sequence is not architect-review then critic-review/i);
   });
 
+  it('lets fresh ordered direct consensus displace stale no-order invalid direct consensus', () => {
+    const gate = buildRalplanConsensusGateFromSources([
+      {
+        source: 'stale-invalid-no-order',
+        value: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              verdict: 'iterate',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              verdict: 'approve',
+            },
+          },
+        },
+      },
+      {
+        source: 'fresh-valid-with-order',
+        value: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              verdict: 'approve',
+              completed_at: '2026-06-12T10:00:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              verdict: 'approve',
+              completed_at: '2026-06-12T10:05:00.000Z',
+            },
+          },
+        },
+      },
+    ]);
+
+    assert.equal(gate.complete, true);
+    assert.equal(gate.source, 'fresh-valid-with-order');
+    assert.equal(gate.blockedReason, null);
+  });
+
   it('ignores ambient root consensus unless the ambient session is bound to this cwd', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-local-'));
     const ambientRoot = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-ambient-'));
@@ -440,6 +485,39 @@ describe('ralplan consensus gate state roots', () => {
       assert.equal(gate.complete, false);
       assert.equal(gate.blockedReason, 'missing_sequential_architect_then_critic_approval');
       assert.equal(gate.source, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves ordered invalid direct consensus in a return-to-ralplan cycle without review_cycle', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-ordered-invalid-return-'));
+    try {
+      const gate = buildRalplanConsensusGateForCwd(cwd, {
+        artifacts: {
+          current_phase: 'ralplan',
+          return_to_ralplan_reason: 'Code review requested changes.',
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              verdict: 'iterate',
+              completed_at: '2026-06-12T10:00:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              verdict: 'approve',
+              completed_at: '2026-06-12T10:05:00.000Z',
+            },
+          },
+        },
+      });
+
+      assert.equal(gate.complete, false);
+      assert.equal(gate.source, 'stage-context-artifacts');
+      assert.equal(gate.blockedReason, 'non_approving_ralplan_consensus_review');
+      assert.match(gate.blockedDetails?.join(' ') ?? '', /architect.*verdict=iterate/i);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/ralplan/__tests__/consensus-gate.test.ts
+++ b/src/ralplan/__tests__/consensus-gate.test.ts
@@ -406,6 +406,45 @@ describe('ralplan consensus gate state roots', () => {
     }
   });
 
+  it('ignores stale invalid local ralplan state consensus during a return-to-ralplan cycle', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-stale-invalid-local-state-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify({
+        current_phase: 'complete',
+        ralplan_consensus_gate: {
+          complete: true,
+          sequence: ['architect-review', 'critic-review'],
+          ralplan_architect_review: {
+            agent_role: 'architect',
+            verdict: 'iterate',
+            completed_at: '2026-06-11T16:00:00.000Z',
+          },
+          ralplan_critic_review: {
+            agent_role: 'critic',
+            verdict: 'approve',
+            completed_at: '2026-06-11T16:05:00.000Z',
+          },
+        },
+      }, null, 2));
+
+      const gate = buildRalplanConsensusGateForCwd(cwd, {
+        artifacts: {
+          current_phase: 'ralplan',
+          return_to_ralplan_reason: 'Code review requested changes.',
+          review_cycle: 1,
+        },
+      });
+
+      assert.equal(gate.complete, false);
+      assert.equal(gate.blockedReason, 'missing_sequential_architect_then_critic_approval');
+      assert.equal(gate.source, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('rejects local nested handoff consensus when only the local container review_cycle advances', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-local-container-only-'));
     try {

--- a/src/ralplan/consensus-gate.ts
+++ b/src/ralplan/consensus-gate.ts
@@ -55,17 +55,7 @@ export function buildRalplanConsensusGateFromSources(
     source: string;
     options: RalplanNativeSubagentConsensusOptions;
   } | null = null;
-  let validEvidence: {
-    ralplan_architect_review: Record<string, unknown>;
-    ralplan_critic_review: Record<string, unknown>;
-    source: string;
-  } | null = null;
-  let invalidCompleteEvidence: {
-    ralplan_architect_review: Record<string, unknown> | null;
-    ralplan_critic_review: Record<string, unknown> | null;
-    source: string;
-    blockedDetails: string[];
-  } | null = null;
+  let firstCompleteEvidence: (ConsensusResolution & { source: string }) | null = null;
 
   for (const candidate of sources) {
     const evidence = resolveConsensusEvidence(candidate.value);
@@ -73,8 +63,11 @@ export function buildRalplanConsensusGateFromSources(
       ...options,
       sessionId: options.sessionId ?? candidate.sessionId,
     };
+
     if (evidence?.kind === 'invalid') {
-      invalidCompleteEvidence ??= { ...evidence, source: candidate.source };
+      if (isConsensusEvidenceNewerThanSelected(evidence, firstCompleteEvidence)) {
+        firstCompleteEvidence = { ...evidence, source: candidate.source };
+      }
       continue;
     }
 
@@ -86,29 +79,31 @@ export function buildRalplanConsensusGateFromSources(
         nativeBlockedEvidence ??= { ...evidence, source: candidate.source, options: candidateOptions };
         continue;
       }
-      validEvidence ??= { ...evidence, source: candidate.source };
+      if (isConsensusEvidenceNewerThanSelected(evidence, firstCompleteEvidence)) {
+        firstCompleteEvidence = { ...evidence, source: candidate.source };
+      }
     }
   }
 
-  if (invalidCompleteEvidence) {
+  if (firstCompleteEvidence?.kind === 'invalid') {
     return {
       complete: false,
       sequence: ['architect-review', 'critic-review'],
-      ralplan_architect_review: invalidCompleteEvidence.ralplan_architect_review,
-      ralplan_critic_review: invalidCompleteEvidence.ralplan_critic_review,
-      source: invalidCompleteEvidence.source,
+      ralplan_architect_review: firstCompleteEvidence.ralplan_architect_review,
+      ralplan_critic_review: firstCompleteEvidence.ralplan_critic_review,
+      source: firstCompleteEvidence.source,
       blockedReason: RALPLAN_CONSENSUS_BLOCKED_REASONS.nonApprovingReview,
-      blockedDetails: invalidCompleteEvidence.blockedDetails,
+      blockedDetails: firstCompleteEvidence.blockedDetails,
     };
   }
 
-  if (validEvidence) {
+  if (firstCompleteEvidence?.kind === 'valid') {
     return {
       complete: true,
       sequence: ['architect-review', 'critic-review'],
-      ralplan_architect_review: validEvidence.ralplan_architect_review,
-      ralplan_critic_review: validEvidence.ralplan_critic_review,
-      source: validEvidence.source,
+      ralplan_architect_review: firstCompleteEvidence.ralplan_architect_review,
+      ralplan_critic_review: firstCompleteEvidence.ralplan_critic_review,
+      source: firstCompleteEvidence.source,
       blockedReason: null,
     };
   }
@@ -212,7 +207,6 @@ function resolveConsensusEvidence(value: unknown): ConsensusResolution | null {
   const advancedReviewCycle = explicitFreshnessReviewCycle(record);
   const staleReturnToRalplanCycle = returnToRalplanCycle && advancedReviewCycle === null;
   const directGate = resolveDirectGate(record);
-  if (directGate?.kind === 'invalid') return directGate;
   if (
     directGate
     && (
@@ -399,12 +393,49 @@ function explicitFreshnessReviewCycle(record: Record<string, unknown>): number |
 }
 
 function reviewsCarryFreshnessCycle(evidence: ConsensusResolution, reviewCycle: number): boolean {
-  return evidence.kind === 'valid'
-    && reviewPairCarriesFreshnessCycle(
-      evidence.ralplan_architect_review,
-      evidence.ralplan_critic_review,
-      reviewCycle,
-    );
+  return reviewPairCarriesFreshnessCycle(
+    evidence.ralplan_architect_review,
+    evidence.ralplan_critic_review,
+    reviewCycle,
+  );
+}
+
+function isConsensusEvidenceNewerThanSelected(
+  evidence: ConsensusResolution,
+  selected: (ConsensusResolution & { source: string }) | null,
+): boolean {
+  if (!selected) return true;
+  const evidenceCycle = consensusEvidenceReviewCycle(evidence);
+  const selectedCycle = consensusEvidenceReviewCycle(selected);
+  if (evidenceCycle !== null && selectedCycle !== null && evidenceCycle !== selectedCycle) {
+    return evidenceCycle > selectedCycle;
+  }
+  const evidenceOrder = consensusEvidenceOrder(evidence);
+  const selectedOrder = consensusEvidenceOrder(selected);
+  if (evidenceOrder !== null && selectedOrder !== null && evidenceOrder !== selectedOrder) {
+    return evidenceOrder > selectedOrder;
+  }
+  return false;
+}
+
+function consensusEvidenceReviewCycle(evidence: ConsensusResolution): number | null {
+  return maxKnownNumber(
+    numericValue(evidence.ralplan_architect_review?.review_cycle ?? evidence.ralplan_architect_review?.reviewCycle),
+    numericValue(evidence.ralplan_critic_review?.review_cycle ?? evidence.ralplan_critic_review?.reviewCycle),
+  );
+}
+
+function consensusEvidenceOrder(evidence: ConsensusResolution): number | null {
+  return maxKnownNumber(
+    reviewOrderValue(evidence.ralplan_architect_review ?? {}),
+    reviewOrderValue(evidence.ralplan_critic_review ?? {}),
+  );
+}
+
+function maxKnownNumber(left: number | null, right: number | null): number | null {
+  if (left === null) return right;
+  if (right === null) return left;
+  return Math.max(left, right);
 }
 
 function reviewPairCarriesFreshnessCycle(

--- a/src/ralplan/consensus-gate.ts
+++ b/src/ralplan/consensus-gate.ts
@@ -207,13 +207,15 @@ function resolveConsensusEvidence(value: unknown): ConsensusResolution | null {
   const advancedReviewCycle = explicitFreshnessReviewCycle(record);
   const staleReturnToRalplanCycle = returnToRalplanCycle && advancedReviewCycle === null;
   const directGate = resolveDirectGate(record);
-  if (
-    directGate
-    && (
-      !returnToRalplanCycle
-      || (advancedReviewCycle !== null && reviewsCarryFreshnessCycle(directGate, advancedReviewCycle))
-    )
-  ) return directGate;
+  let deferredOrderedDirectGate: ConsensusResolution | null = null;
+  if (directGate) {
+    if (!returnToRalplanCycle) return directGate;
+    if (advancedReviewCycle !== null) {
+      if (reviewsCarryFreshnessCycle(directGate, advancedReviewCycle)) return directGate;
+    } else if (!hasExplicitReturnToRalplanReviewCycle(record) && consensusEvidenceOrder(directGate) !== null) {
+      deferredOrderedDirectGate = directGate;
+    }
+  }
 
   const handoffArtifactsAreStale = staleReturnToRalplanCycle;
   const topLevelHandoffArtifacts = handoffArtifactsAreStale ? null : asRecord(record.handoff_artifacts);
@@ -232,6 +234,8 @@ function resolveConsensusEvidence(value: unknown): ConsensusResolution | null {
     const evidence = resolveConsensusEvidence(withParentReturnToRalplanContext(stateHandoffArtifacts, stateContext));
     if (evidence) return evidence;
   }
+
+  if (deferredOrderedDirectGate) return deferredOrderedDirectGate;
 
   if (returnToRalplanCycle && advancedReviewCycle === null) return null;
 
@@ -407,14 +411,20 @@ function isConsensusEvidenceNewerThanSelected(
   if (!selected) return true;
   const evidenceCycle = consensusEvidenceReviewCycle(evidence);
   const selectedCycle = consensusEvidenceReviewCycle(selected);
-  if (evidenceCycle !== null && selectedCycle !== null && evidenceCycle !== selectedCycle) {
-    return evidenceCycle > selectedCycle;
+  if (evidenceCycle !== null || selectedCycle !== null) {
+    if (selectedCycle === null) return true;
+    if (evidenceCycle === null) return false;
+    if (evidenceCycle !== selectedCycle) return evidenceCycle > selectedCycle;
   }
+
   const evidenceOrder = consensusEvidenceOrder(evidence);
   const selectedOrder = consensusEvidenceOrder(selected);
-  if (evidenceOrder !== null && selectedOrder !== null && evidenceOrder !== selectedOrder) {
-    return evidenceOrder > selectedOrder;
+  if (evidenceOrder !== null || selectedOrder !== null) {
+    if (selectedOrder === null) return true;
+    if (evidenceOrder === null) return false;
+    if (evidenceOrder !== selectedOrder) return evidenceOrder > selectedOrder;
   }
+
   return false;
 }
 
@@ -438,6 +448,10 @@ function maxKnownNumber(left: number | null, right: number | null): number | nul
   return Math.max(left, right);
 }
 
+function hasExplicitReturnToRalplanReviewCycle(record: Record<string, unknown>): boolean {
+  return numericValue(record.review_cycle ?? record.reviewCycle) !== null
+    || numericValue(record.return_to_ralplan_parent_review_cycle ?? record.returnToRalplanParentReviewCycle) !== null;
+}
 function reviewPairCarriesFreshnessCycle(
   architectReview: Record<string, unknown> | null,
   criticReview: Record<string, unknown> | null,


### PR DESCRIPTION
## Summary
- validate persisted `complete:true` Ralplan consensus gates against architect and critic approval signals before accepting them
- keep fresh non-approving evidence terminal while allowing newer fresh valid evidence to supersede stale invalid return-to-ralplan evidence
- add regressions for architect/critic non-approval and stale invalid vs fresh valid consensus ordering

Resolves #2862

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/ralplan/__tests__/consensus-gate.test.js dist/autopilot/__tests__/ralplan-gate.test.js dist/state/__tests__/operations.test.js`
- `npm test -- src/ralplan/__tests__/consensus-gate.test.ts src/autopilot/__tests__/ralplan-gate.test.ts src/state/__tests__/operations.test.ts` timed out after 120s because this repo script runs the full test suite; build, native-agent verification, plugin-bundle verification, and the already-reached tests had no failures before timeout.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*