### PR TITLE
Fix autopilot review rework state

### DIFF
--- a/plugins/oh-my-codex/skills/autopilot/SKILL.md
+++ b/plugins/oh-my-codex/skills/autopilot/SKILL.md
@@ -53,7 +53,7 @@ Autopilot must not run a separate broad expansion/planning/execution/QA/validati
    - Run `$code-review` on the diff/artifacts produced by `$ultragoal`.
    - A clean review means final recommendation `APPROVE` with architectural status `CLEAR`.
    - `COMMENT`, `REQUEST CHANGES`, any architectural `WATCH`/`BLOCK`, or any unresolved finding is not clean.
-   - If not clean, increment the review cycle, persist `review_verdict`, set `return_to_ralplan_reason`, and transition back to Phase `ralplan`.
+   - If not clean because the implementation must be repaired, increment the review cycle, persist `review_verdict`, set `current_phase:"rework"`, and carry the findings as the sanctioned execution-fix input. Return to Phase `ralplan` only when the review shows the plan/requirements are wrong or incomplete.
 
 5. **Phase `ultraqa`** — adversarial QA gate
    - Run `$ultraqa` after a clean code review when user-facing behavior, workflows, CLI/runtime behavior, integration surfaces, or regression risk warrant adversarial QA.
@@ -84,7 +84,7 @@ Before Phase `deep-interview` or `ralplan` starts or resumes:
 - Always execute the recommended phases in order: `deep-interview`, then `ralplan`, then `ultragoal`, then `code-review`, then `ultraqa`.
 - `$team` is conditional and explicit: use it only within an Ultragoal story when parallel execution materially improves throughput, quality, or safety.
 - Never skip directly from vague/freeform expansion to implementation; unclear input must be clarified and planned through `$deep-interview` and `$ralplan`.
-- A non-clean `$code-review` or failed `$ultraqa` always returns to `$ralplan`; do not patch findings ad hoc outside the loop.
+- A non-clean `$code-review` that requires implementation repair enters Phase `rework`; a non-clean review that changes the plan/requirements, or failed `$ultraqa`, returns to `$ralplan`.
 - Each phase must write/update Autopilot state before handing off.
 - Use existing hooks, `.omx/state`, `$deep-interview`, `$ralplan`, `$ultragoal`, optional `$team`, `$code-review`, `$ultraqa`, and pipeline primitives; do not invent a separate execution framework.
 - Preserve legacy compatibility: if a user explicitly requests the old Ralph execution lane, use `$ralph` as an intentional alternate execution phase, but do not present it as Autopilot's default recommended loop.
@@ -140,8 +140,9 @@ Required fields:
 - **On missing ralplan consensus evidence**: keep `current_phase:"ralplan"`, persist `ralplan_consensus_gate.complete:false` with `blocked_reason`, and report an explicit blocker or max-iteration outcome instead of handing off to execution.
 - **On ultragoal -> code-review**: set `current_phase:"code-review"`, persist implementation/test/ledger evidence under `handoff_artifacts.ultragoal`.
 - **On code-review -> ultraqa**: set `current_phase:"ultraqa"` only after a real `$code-review` stage/subagent has produced durable evidence; persist the clean review under `handoff_artifacts.code_review` with its source thread/tool/stage reference. Do not author `review_verdict:{clean:true}` from the leader's own summary.
+- **On non-clean code-review requiring implementation repair**: increment `review_cycle`, set `current_phase:"rework"`, persist `review_verdict`, persist the phase handoff under `handoff_artifacts.code_review`, and keep the fix scoped to the review findings before returning to `code-review`.
 - **On clean review + passed/skipped QA**: set `active:false`, `current_phase:"complete"`, persist `review_verdict:{recommendation:"APPROVE", architectural_status:"CLEAR", clean:true}`, `qa_verdict:{clean:true, skipped:<boolean>, reason:<string|null>}`, and `completed_at` only when both gates have durable source evidence. Required evidence is either (a) actual `$code-review`/`$ultraqa` stage or native-subagent/thread/tool records, or (b) for QA only, an explicit persisted skip reason for a documented docs-only/trivially non-runtime condition. If that evidence is missing, keep the active phase at `code-review` or `ultraqa` and record a blocker instead of self-attesting a clean gate.
-- **On non-clean review or failed QA**: increment `iteration` and `review_cycle`, set `current_phase:"ralplan"`, persist `review_verdict` or `qa_verdict`, persist the phase handoff, and set `return_to_ralplan_reason` to a concise findings-driven reason.
+- **On non-clean review requiring plan changes or failed QA**: increment `iteration` and `review_cycle`, set `current_phase:"ralplan"`, persist `review_verdict` or `qa_verdict`, persist the phase handoff, and set `return_to_ralplan_reason` to a concise findings-driven reason.
 - **Legacy Ralph state**: if a user explicitly selected the legacy Ralph execution lane, phase names and handoff keys may include `ralph`; preserve and resume them rather than rewriting history to Ultragoal.
 - **On cancellation**: run `$cancel`; preserve progress for resume rather than deleting handoff artifacts.
 </State_Management>
@@ -151,6 +152,7 @@ When the user says `continue`, `resume`, or `keep going` while Autopilot is acti
 - `deep-interview`: clarify requirements and record the handoff artifact.
 - `ralplan`: run/update consensus planning from current handoffs and any `return_to_ralplan_reason`.
 - `ultragoal`: execute the approved plan durably and record verification/ledger evidence.
+- `rework`: perform only the implementation fixes required by the current code-review findings, record fresh implementation/verification evidence, and return to `code-review`.
 - `team`: continue explicit team work only when it is nested under the active Ultragoal story and report evidence back to the leader.
 - `code-review`: review the current diff and decide clean vs return-to-ralplan.
 - `ultraqa`: run or explicitly skip adversarial QA based on the documented condition, then finish if clean or transition to `ralplan` with findings if not clean.
@@ -167,7 +169,7 @@ Autopilot may be represented by the configurable pipeline orchestrator (`src/pip
 deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa
 ```
 
-Pipeline state should use `current_phase` values that match the same phase names (`deep-interview`, `ralplan`, `ultragoal`, `code-review`, `ultraqa`, `complete`, `failed`) and should carry `iteration`, `review_cycle`, `handoff_artifacts`, `review_verdict`, `qa_verdict`, and `return_to_ralplan_reason` alongside stage results. `$team` is not a default pipeline stage; it is an explicit conditional execution engine inside an Ultragoal story.
+Pipeline state should use `current_phase` values that match the same phase names (`deep-interview`, `ralplan`, `ultragoal`, `rework`, `code-review`, `ultraqa`, `complete`, `failed`) and should carry `iteration`, `review_cycle`, `handoff_artifacts`, `review_verdict`, `qa_verdict`, and `return_to_ralplan_reason` alongside stage results. `$team` is not a default pipeline stage; it is an explicit conditional execution engine inside an Ultragoal story.
 </Pipeline_Orchestrator>
 
 <Escalation_And_Stop_Conditions>
@@ -181,6 +183,7 @@ Pipeline state should use `current_phase` values that match the same phase names
 - [ ] Phase `deep-interview` produced/updated clarified requirements or a concise spec
 - [ ] Phase `ralplan` produced/updated approved planning artifacts and durable sequential evidence from a subsequent `Architect` approval followed by a subsequent `Critic` approval
 - [ ] Phase `ultragoal` implemented and verified the plan with fresh evidence and durable ledger/checkpoint references
+- [ ] Phase `rework` was used for implementation-only review fixes when applicable, with findings scoped to a fresh code-review cycle
 - [ ] `$team` was used only if the active Ultragoal story needed coordinated parallel work, or explicitly recorded as not needed
 - [ ] Phase `code-review` returned a clean verdict (`APPROVE` + `CLEAR`)
 - [ ] Phase `ultraqa` passed, or was explicitly skipped because the change was docs-only/trivially non-runtime with evidence

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -53,7 +53,7 @@ Autopilot must not run a separate broad expansion/planning/execution/QA/validati
    - Run `$code-review` on the diff/artifacts produced by `$ultragoal`.
    - A clean review means final recommendation `APPROVE` with architectural status `CLEAR`.
    - `COMMENT`, `REQUEST CHANGES`, any architectural `WATCH`/`BLOCK`, or any unresolved finding is not clean.
-   - If not clean, increment the review cycle, persist `review_verdict`, set `return_to_ralplan_reason`, and transition back to Phase `ralplan`.
+   - If not clean because the implementation must be repaired, increment the review cycle, persist `review_verdict`, set `current_phase:"rework"`, and carry the findings as the sanctioned execution-fix input. Return to Phase `ralplan` only when the review shows the plan/requirements are wrong or incomplete.
 
 5. **Phase `ultraqa`** — adversarial QA gate
    - Run `$ultraqa` after a clean code review when user-facing behavior, workflows, CLI/runtime behavior, integration surfaces, or regression risk warrant adversarial QA.
@@ -84,7 +84,7 @@ Before Phase `deep-interview` or `ralplan` starts or resumes:
 - Always execute the recommended phases in order: `deep-interview`, then `ralplan`, then `ultragoal`, then `code-review`, then `ultraqa`.
 - `$team` is conditional and explicit: use it only within an Ultragoal story when parallel execution materially improves throughput, quality, or safety.
 - Never skip directly from vague/freeform expansion to implementation; unclear input must be clarified and planned through `$deep-interview` and `$ralplan`.
-- A non-clean `$code-review` or failed `$ultraqa` always returns to `$ralplan`; do not patch findings ad hoc outside the loop.
+- A non-clean `$code-review` that requires implementation repair enters Phase `rework`; a non-clean review that changes the plan/requirements, or failed `$ultraqa`, returns to `$ralplan`.
 - Each phase must write/update Autopilot state before handing off.
 - Use existing hooks, `.omx/state`, `$deep-interview`, `$ralplan`, `$ultragoal`, optional `$team`, `$code-review`, `$ultraqa`, and pipeline primitives; do not invent a separate execution framework.
 - Preserve legacy compatibility: if a user explicitly requests the old Ralph execution lane, use `$ralph` as an intentional alternate execution phase, but do not present it as Autopilot's default recommended loop.
@@ -140,8 +140,9 @@ Required fields:
 - **On missing ralplan consensus evidence**: keep `current_phase:"ralplan"`, persist `ralplan_consensus_gate.complete:false` with `blocked_reason`, and report an explicit blocker or max-iteration outcome instead of handing off to execution.
 - **On ultragoal -> code-review**: set `current_phase:"code-review"`, persist implementation/test/ledger evidence under `handoff_artifacts.ultragoal`.
 - **On code-review -> ultraqa**: set `current_phase:"ultraqa"` only after a real `$code-review` stage/subagent has produced durable evidence; persist the clean review under `handoff_artifacts.code_review` with its source thread/tool/stage reference. Do not author `review_verdict:{clean:true}` from the leader's own summary.
+- **On non-clean code-review requiring implementation repair**: increment `review_cycle`, set `current_phase:"rework"`, persist `review_verdict`, persist the phase handoff under `handoff_artifacts.code_review`, and keep the fix scoped to the review findings before returning to `code-review`.
 - **On clean review + passed/skipped QA**: set `active:false`, `current_phase:"complete"`, persist `review_verdict:{recommendation:"APPROVE", architectural_status:"CLEAR", clean:true}`, `qa_verdict:{clean:true, skipped:<boolean>, reason:<string|null>}`, and `completed_at` only when both gates have durable source evidence. Required evidence is either (a) actual `$code-review`/`$ultraqa` stage or native-subagent/thread/tool records, or (b) for QA only, an explicit persisted skip reason for a documented docs-only/trivially non-runtime condition. If that evidence is missing, keep the active phase at `code-review` or `ultraqa` and record a blocker instead of self-attesting a clean gate.
-- **On non-clean review or failed QA**: increment `iteration` and `review_cycle`, set `current_phase:"ralplan"`, persist `review_verdict` or `qa_verdict`, persist the phase handoff, and set `return_to_ralplan_reason` to a concise findings-driven reason.
+- **On non-clean review requiring plan changes or failed QA**: increment `iteration` and `review_cycle`, set `current_phase:"ralplan"`, persist `review_verdict` or `qa_verdict`, persist the phase handoff, and set `return_to_ralplan_reason` to a concise findings-driven reason.
 - **Legacy Ralph state**: if a user explicitly selected the legacy Ralph execution lane, phase names and handoff keys may include `ralph`; preserve and resume them rather than rewriting history to Ultragoal.
 - **On cancellation**: run `$cancel`; preserve progress for resume rather than deleting handoff artifacts.
 </State_Management>
@@ -151,6 +152,7 @@ When the user says `continue`, `resume`, or `keep going` while Autopilot is acti
 - `deep-interview`: clarify requirements and record the handoff artifact.
 - `ralplan`: run/update consensus planning from current handoffs and any `return_to_ralplan_reason`.
 - `ultragoal`: execute the approved plan durably and record verification/ledger evidence.
+- `rework`: perform only the implementation fixes required by the current code-review findings, record fresh implementation/verification evidence, and return to `code-review`.
 - `team`: continue explicit team work only when it is nested under the active Ultragoal story and report evidence back to the leader.
 - `code-review`: review the current diff and decide clean vs return-to-ralplan.
 - `ultraqa`: run or explicitly skip adversarial QA based on the documented condition, then finish if clean or transition to `ralplan` with findings if not clean.
@@ -167,7 +169,7 @@ Autopilot may be represented by the configurable pipeline orchestrator (`src/pip
 deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa
 ```
 
-Pipeline state should use `current_phase` values that match the same phase names (`deep-interview`, `ralplan`, `ultragoal`, `code-review`, `ultraqa`, `complete`, `failed`) and should carry `iteration`, `review_cycle`, `handoff_artifacts`, `review_verdict`, `qa_verdict`, and `return_to_ralplan_reason` alongside stage results. `$team` is not a default pipeline stage; it is an explicit conditional execution engine inside an Ultragoal story.
+Pipeline state should use `current_phase` values that match the same phase names (`deep-interview`, `ralplan`, `ultragoal`, `rework`, `code-review`, `ultraqa`, `complete`, `failed`) and should carry `iteration`, `review_cycle`, `handoff_artifacts`, `review_verdict`, `qa_verdict`, and `return_to_ralplan_reason` alongside stage results. `$team` is not a default pipeline stage; it is an explicit conditional execution engine inside an Ultragoal story.
 </Pipeline_Orchestrator>
 
 <Escalation_And_Stop_Conditions>
@@ -181,6 +183,7 @@ Pipeline state should use `current_phase` values that match the same phase names
 - [ ] Phase `deep-interview` produced/updated clarified requirements or a concise spec
 - [ ] Phase `ralplan` produced/updated approved planning artifacts and durable sequential evidence from a subsequent `Architect` approval followed by a subsequent `Critic` approval
 - [ ] Phase `ultragoal` implemented and verified the plan with fresh evidence and durable ledger/checkpoint references
+- [ ] Phase `rework` was used for implementation-only review fixes when applicable, with findings scoped to a fresh code-review cycle
 - [ ] `$team` was used only if the active Ultragoal story needed coordinated parallel work, or explicitly recorded as not needed
 - [ ] Phase `code-review` returned a clean verdict (`APPROVE` + `CLEAR`)
 - [ ] Phase `ultraqa` passed, or was explicitly skipped because the change was docs-only/trivially non-runtime with evidence

--- a/src/autopilot/__tests__/fsm.test.ts
+++ b/src/autopilot/__tests__/fsm.test.ts
@@ -13,6 +13,8 @@ describe('autopilot supervisor FSM helpers', () => {
     assert.equal(normalizeAutopilotPhase('deep_interview'), 'deep-interview');
     assert.equal(normalizeAutopilotPhase('waiting_for_user'), 'waiting-for-user');
     assert.equal(normalizeAutopilotPhase('team'), 'team');
+    assert.equal(normalizeAutopilotPhase('review_fix'), 'rework');
+    assert.equal(normalizeAutopilotPhase('implementation-fix'), 'rework');
     assert.equal(normalizeAutopilotPhase('ralph'), 'ralph');
     assert.equal(normalizeAutopilotPhase('completed'), 'complete');
     assert.equal(normalizeAutopilotPhase('planning'), 'ralplan');
@@ -68,6 +70,11 @@ describe('autopilot supervisor FSM helpers', () => {
       active: true,
       current_phase: 'planning',
     }), 'autopilot:ralplan');
+    assert.equal(deriveAutopilotStageLabel({
+      mode: 'autopilot',
+      active: true,
+      current_phase: 'review-fix',
+    }), 'autopilot:rework');
   });
 
   it('does not derive standalone workflow states as Autopilot stage labels', () => {

--- a/src/autopilot/completion-gate.ts
+++ b/src/autopilot/completion-gate.ts
@@ -25,7 +25,7 @@ function stringField(value: JsonObject, key: string): string {
 }
 
 function isImplementationPhase(phase: AutopilotChildPhase | null): boolean {
-  return phase === 'ultragoal' || phase === 'team' || phase === 'ralph';
+  return phase === 'ultragoal' || phase === 'rework' || phase === 'team' || phase === 'ralph';
 }
 
 function isActiveAutopilotState(state: JsonObject): boolean {

--- a/src/autopilot/fsm.ts
+++ b/src/autopilot/fsm.ts
@@ -2,6 +2,7 @@ const AUTOPILOT_CHILD_PHASES = [
   'deep-interview',
   'ralplan',
   'ultragoal',
+  'rework',
   'team',
   'ralph',
   'code-review',
@@ -31,6 +32,7 @@ function normalizePhaseText(value: unknown): string {
   const normalized = safeString(value).toLowerCase().replace(/_/g, '-').replace(/^autopilot:/, '');
   if (normalized === 'completed') return 'complete';
   if (normalized === 'planning' || normalized === 'replan') return 'ralplan';
+  if (normalized === 'fix' || normalized === 'review-fix' || normalized === 'implementation-fix') return 'rework';
   return normalized;
 }
 

--- a/src/modes/__tests__/base-autopilot-gates.test.ts
+++ b/src/modes/__tests__/base-autopilot-gates.test.ts
@@ -60,6 +60,19 @@ describe('modes/base Autopilot gate integration', () => {
     }
   });
 
+  it('updateModeState rejects direct ralplan to rework skips', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-ralplan-rework-skip-'));
+    try {
+      await writeAutopilotState(wd, { current_phase: 'ralplan' });
+      await assert.rejects(
+        () => updateModeState('autopilot', { current_phase: 'rework' }, wd),
+        /Cannot skip Autopilot ultragoal gate/i,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('updateModeState rejects ralplan to code-review skips even with user-supplied pipeline fields', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-ralplan-skip-pipeline-fields-'));
     try {

--- a/src/modes/__tests__/base-autopilot-gates.test.ts
+++ b/src/modes/__tests__/base-autopilot-gates.test.ts
@@ -73,6 +73,45 @@ describe('modes/base Autopilot gate integration', () => {
     }
   });
 
+  it('updateModeState allows code-review REQUEST_CHANGES to enter rework', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-review-rework-'));
+    try {
+      await writeAutopilotState(wd, { current_phase: 'code-review', review_cycle: 1 });
+      await updateModeState('autopilot', {
+        current_phase: 'rework',
+        review_cycle: 2,
+        state: {
+          handoff_artifacts: {
+            code_review: {
+              stage: 'code-review',
+              recommendation: 'REQUEST_CHANGES',
+              architectural_status: 'CLEAR',
+              clean: false,
+              artifact_path: '.omx/reviews/code-review-cycle-1.json',
+              findings: ['Fix src/implementation.ts'],
+            },
+          },
+          review_verdict: {
+            stage: 'code-review',
+            recommendation: 'REQUEST_CHANGES',
+            architectural_status: 'CLEAR',
+            clean: false,
+            artifact_path: '.omx/reviews/code-review-cycle-1.json',
+            findings: ['Fix src/implementation.ts'],
+          },
+          return_to_ralplan_reason: null,
+        },
+      }, wd);
+
+      const raw = JSON.parse(await readFile(join(wd, '.omx', 'state', 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(raw.active, true);
+      assert.equal(raw.current_phase, 'rework');
+      assert.equal(raw.review_cycle, 2);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('updateModeState rejects ralplan to code-review skips even with user-supplied pipeline fields', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-mode-autopilot-ralplan-skip-pipeline-fields-'));
     try {

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -63,6 +63,7 @@ const AUTOPILOT_CHILD_PHASE_ORDER: AutopilotChildPhase[] = [
   'deep-interview',
   'ralplan',
   'ultragoal',
+  'rework',
   'team',
   'ralph',
   'code-review',

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -6958,6 +6958,58 @@ exit 0
     }
   });
 
+  it("allows Autopilot rework implementation writes while ralplan remains guarded", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-autopilot-rework-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionDir = join(stateDir, "sessions", "sess-autopilot-rework");
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-autopilot-rework", cwd });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "autopilot",
+        phase: "rework",
+        session_id: "sess-autopilot-rework",
+        thread_id: "thread-autopilot-rework",
+        active_skills: [
+          {
+            skill: "autopilot",
+            phase: "rework",
+            active: true,
+            session_id: "sess-autopilot-rework",
+            thread_id: "thread-autopilot-rework",
+          },
+        ],
+      });
+      await writeJson(join(sessionDir, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "rework",
+        review_cycle: 2,
+        review_verdict: { clean: false, recommendation: "REQUEST_CHANGES", findings: ["src/implementation.ts"] },
+        session_id: "sess-autopilot-rework",
+        thread_id: "thread-autopilot-rework",
+      });
+
+      const allowedImplementationEdit = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-autopilot-rework",
+          thread_id: "thread-autopilot-rework",
+          tool_name: "Edit",
+          tool_use_id: "tool-autopilot-rework-src-edit",
+          tool_input: { file_path: "src/implementation.ts", old_string: "a", new_string: "b" },
+        },
+        { cwd },
+      );
+      assert.equal(allowedImplementationEdit.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("allows null-device fd redirects while deep-interview blocks real Bash writes", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-deep-interview-null-redirect-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2746,6 +2746,10 @@ function canAutopilotSkillMirrorSupplyRalplanPhase(phase: string): boolean {
   return phase === "" || normalizeAutopilotPhase(phase) === "ralplan";
 }
 
+function isAutopilotReviewReworkPhase(phase: string): boolean {
+  return normalizeAutopilotPhase(phase) === "rework";
+}
+
 function hasExplicitExecutionHandoffSkill(
   state: SkillActiveStateLike | null,
   sessionId: string,
@@ -3151,6 +3155,7 @@ async function readActiveRalplanStateForPreToolUse(
   ));
   if (!hasActiveAutopilotSkill) return null;
   const autopilotStatePhase = safeString(autopilotState.current_phase ?? autopilotState.currentPhase).trim().toLowerCase();
+  if (isAutopilotReviewReworkPhase(autopilotStatePhase)) return null;
   if (!canAutopilotSkillMirrorSupplyRalplanPhase(autopilotStatePhase)) return null;
   const hasRalplanScopedAutopilotSkill = listActiveSkills(canonicalState).some((entry) => (
     entry.skill === "autopilot"

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -2441,7 +2441,7 @@ describe('state operations directory initialization', () => {
   });
 
   it('denies Autopilot implementation-phase completion before the code-review gate', async () => {
-    for (const phase of ['ultragoal', 'team', 'ralph']) {
+    for (const phase of ['ultragoal', 'rework', 'team', 'ralph']) {
       const wd = await mkdtemp(join(tmpdir(), `omx-state-ops-autopilot-${phase}-complete-deny-`));
       try {
         await withOmxRootEnv(wd, async () => {
@@ -2483,7 +2483,7 @@ describe('state operations directory initialization', () => {
   });
 
   it('denies Autopilot implementation-phase skip directly to ultraqa', async () => {
-    for (const phase of ['ultragoal', 'team', 'ralph']) {
+    for (const phase of ['ultragoal', 'rework', 'team', 'ralph']) {
       const wd = await mkdtemp(join(tmpdir(), `omx-state-ops-autopilot-${phase}-ultraqa-skip-deny-`));
       try {
         await withOmxRootEnv(wd, async () => {
@@ -2563,6 +2563,120 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('allows Autopilot code-review REQUEST_CHANGES to enter implementation rework', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-review-rework-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-review-rework';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({ active: true, mode: 'autopilot', current_phase: 'code-review', review_cycle: 1 }, null, 2),
+        );
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: true,
+          current_phase: 'rework',
+          review_cycle: 2,
+          state: {
+            handoff_artifacts: {
+              code_review: {
+                stage: 'code-review',
+                recommendation: 'REQUEST_CHANGES',
+                architectural_status: 'CLEAR',
+                clean: false,
+                artifact_path: '.omx/reviews/code-review-cycle-1.json',
+                findings: ['Fix src/implementation.ts'],
+              },
+            },
+            review_verdict: {
+              stage: 'code-review',
+              recommendation: 'REQUEST_CHANGES',
+              architectural_status: 'CLEAR',
+              clean: false,
+              artifact_path: '.omx/reviews/code-review-cycle-1.json',
+              findings: ['Fix src/implementation.ts'],
+            },
+            return_to_ralplan_reason: null,
+          },
+        });
+
+        assert.equal(response.isError, undefined);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, true);
+        assert.equal(state.current_phase, 'rework');
+        assert.equal(state.review_cycle, 2);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('replaces stale blocking review state when Autopilot completes with clean latest evidence', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-clean-clears-stale-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-clean-clears-stale';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(
+          join(sessionDir, 'autopilot-state.json'),
+          JSON.stringify({
+            active: true,
+            mode: 'autopilot',
+            current_phase: 'ultraqa',
+            return_to_ralplan_reason: 'Earlier code-review BLOCK required fixes.',
+            handoff_artifacts: {
+              code_review: { stage: 'code-review', recommendation: 'REQUEST_CHANGES', architectural_status: 'BLOCK', clean: false, artifact_path: '.omx/reviews/stale-block.json' },
+              ultraqa: null,
+            },
+            state: {
+              review_verdict: { stage: 'code-review', recommendation: 'REQUEST_CHANGES', architectural_status: 'BLOCK', clean: false, artifact_path: '.omx/reviews/stale-block.json' },
+              qa_verdict: null,
+              return_to_ralplan_reason: 'Earlier code-review BLOCK required fixes.',
+            },
+          }, null, 2),
+        );
+
+        const cleanReview = { stage: 'code-review', recommendation: 'APPROVE', architectural_status: 'CLEAR', clean: true, artifact_path: '.omx/reviews/code-review-cycle-2.json' };
+        const cleanQa = { stage: 'ultraqa', clean: true, skipped: false, url: 'https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/2864' };
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'complete',
+          completed_at: '2026-06-18T05:00:00.000Z',
+          state: {
+            review_verdict: cleanReview,
+            qa_verdict: cleanQa,
+          },
+        });
+
+        assert.equal(response.isError, undefined);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        const nestedState = state.state as Record<string, unknown>;
+        const handoffArtifacts = nestedState.handoff_artifacts as Record<string, unknown>;
+        assert.equal(state.active, false);
+        assert.equal(state.current_phase, 'complete');
+        assert.deepEqual(state.review_verdict, cleanReview);
+        assert.deepEqual(state.qa_verdict, cleanQa);
+        assert.equal(state.return_to_ralplan_reason, null);
+        assert.deepEqual(nestedState.review_verdict, cleanReview);
+        assert.deepEqual(nestedState.qa_verdict, cleanQa);
+        assert.equal(nestedState.return_to_ralplan_reason, null);
+        assert.deepEqual(handoffArtifacts.code_review, cleanReview);
+        assert.deepEqual(handoffArtifacts.ultraqa, cleanQa);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('denies Autopilot ultraqa completion without clean review and QA evidence', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ultraqa-complete-evidence-deny-'));
     try {
@@ -2606,7 +2720,7 @@ describe('state operations directory initialization', () => {
   });
 
   it('denies Autopilot implementation and code-review terminalization via inactive ultraqa phase', async () => {
-    for (const phase of ['ultragoal', 'team', 'ralph', 'code-review']) {
+    for (const phase of ['ultragoal', 'rework', 'team', 'ralph', 'code-review']) {
       const wd = await mkdtemp(join(tmpdir(), `omx-state-ops-autopilot-${phase}-inactive-ultraqa-deny-`));
       try {
         await withOmxRootEnv(wd, async () => {

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -21,7 +21,11 @@ import { evaluateRalphCompletionAuditEvidence } from '../ralph/completion-audit.
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
 import { RALPH_PHASES, validateAndNormalizeRalphState } from '../ralph/contract.js';
 import { applyRunOutcomeContract } from '../runtime/run-outcome.js';
-import { isAutopilotSuccessfulTerminalState, validateAutopilotCompletionTransition } from '../autopilot/completion-gate.js';
+import {
+  hasCleanAutopilotReviewAndQaEvidence,
+  isAutopilotSuccessfulTerminalState,
+  validateAutopilotCompletionTransition,
+} from '../autopilot/completion-gate.js';
 import { readUltragoalState } from '../hud/state.js';
 import {
   SKILL_ACTIVE_STATE_MODE,
@@ -56,6 +60,7 @@ const AUTOPILOT_CHILD_PHASE_ORDER: AutopilotChildPhase[] = [
   'deep-interview',
   'ralplan',
   'ultragoal',
+  'rework',
   'team',
   'ralph',
   'code-review',
@@ -216,6 +221,29 @@ function hasExplicitStateField(
       customState != null
       && Object.prototype.hasOwnProperty.call(customState as Record<string, unknown>, key)
     );
+}
+
+function objectRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function normalizeCleanAutopilotCompletionEvidence(state: Record<string, unknown>): void {
+  if (!isAutopilotSuccessfulTerminalState(state) || !hasCleanAutopilotReviewAndQaEvidence(state)) return;
+
+  const reviewVerdict = state.review_verdict;
+  const qaVerdict = state.qa_verdict;
+  const nestedState = { ...objectRecord(state.state) };
+  const handoffArtifacts = { ...objectRecord(nestedState.handoff_artifacts ?? state.handoff_artifacts) };
+
+  handoffArtifacts.code_review = reviewVerdict;
+  handoffArtifacts.ultraqa = qaVerdict;
+  state.handoff_artifacts = handoffArtifacts;
+  state.return_to_ralplan_reason = null;
+  nestedState.handoff_artifacts = handoffArtifacts;
+  nestedState.review_verdict = reviewVerdict;
+  nestedState.qa_verdict = qaVerdict;
+  nestedState.return_to_ralplan_reason = null;
+  state.state = nestedState;
 }
 
 export async function listStateStatuses(
@@ -470,6 +498,10 @@ export async function executeStateOperation(
               return;
             }
             Object.assign(mergedRaw, runOutcomeValidation.state);
+          }
+
+          if (mode === 'autopilot') {
+            normalizeCleanAutopilotCompletionEvidence(mergedRaw);
           }
 
           const currentAutopilotChildPhase = mode === 'autopilot'


### PR DESCRIPTION
Resolves #2864

## Summary
- add explicit Autopilot `rework` phase for implementation-only code-review REQUEST_CHANGES cycles
- allow implementation writes in supervised rework while keeping ralplan planning guarded
- normalize terminal completion evidence so clean latest code-review and ultraqa verdicts replace stale blocking artifacts

## Verification
- npm run build
- node dist/scripts/run-test-files.js dist/autopilot/__tests__/fsm.test.js dist/state/__tests__/operations.test.js dist/scripts/__tests__/codex-native-hook.test.js

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*