### PR TITLE
Explain ralplan transition validator diagnostics

### DIFF
--- a/docs/contracts/ralplan-consensus-gate.md
+++ b/docs/contracts/ralplan-consensus-gate.md
@@ -1,0 +1,47 @@
+# Ralplan Consensus Gate Contract
+
+The `ralplan -> ultragoal` transition requires durable Architect and Critic approval evidence from native subagent lanes. Advisory lanes such as Scholastic do not replace this gate.
+
+## Required review artifact fields
+
+Each review artifact used by the gate must include:
+
+- `agent_role`: `architect` or `critic`
+- `provenance_kind`: `native_subagent`
+- `session_id`: the current transition session id, unless supplied by the transition context
+- `thread_id`: the native subagent thread id for that review lane
+- `tracker_path`: `.omx/state/subagent-tracking.json`
+
+The Architect and Critic reviews must approve in order and must refer to distinct native subagent threads.
+
+## Required tracker schema
+
+`.omx/state/subagent-tracking.json` must contain the session and both review threads:
+
+```text
+sessions["<current_session_id>"].threads["<architect_thread_id>"].kind = "subagent"
+sessions["<current_session_id>"].threads["<critic_thread_id>"].kind = "subagent"
+both threads have completed_at
+architect and critic thread IDs are distinct
+```
+
+The transition session is the explicit transition `sessionId` when available; otherwise it is resolved from the review artifact `session_id` fields.
+
+## Failure diagnostics
+
+Rejected transitions include a structured diagnostic object on `RalplanConsensusGateEvidence.diagnostic` and a rendered error with:
+
+- expected tracker schema,
+- current session id used for lookup,
+- Architect/Critic thread ids,
+- whether the tracker session exists,
+- whether each thread exists,
+- each thread `kind`,
+- whether each thread has `completed_at`,
+- whether thread ids are distinct,
+- remediation steps,
+- this docs path.
+
+## Remediation
+
+Re-run native ralplan Architect/Critic reviews, or repair the review artifacts so `agent_role`, `provenance_kind`, `session_id`, `thread_id`, and `tracker_path` point to completed native subagent threads in the current tracker.

--- a/src/autopilot/__tests__/ralplan-gate.test.ts
+++ b/src/autopilot/__tests__/ralplan-gate.test.ts
@@ -914,6 +914,123 @@ describe('autopilot ralplan gate', () => {
     }
   });
 
+  it('explains tracker-backed native review schema and observed missing session values', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-diagnostic-missing-session-'));
+    const sessionId = 'sess-autopilot-diagnostic-missing-session';
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {},
+      }, null, 2));
+
+      const state = {
+        current_phase: 'ralplan',
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-architect',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-06-12T10:02:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-critic',
+              tracker_path: '.omx/state/subagent-tracking.json',
+              completed_at: '2026-06-12T10:03:00.000Z',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, sessionId, currentState: state });
+      assert.equal(decision.allowed, false);
+      assert.equal(decision.evidence?.diagnostic?.current_session_id, sessionId);
+      assert.equal(decision.evidence?.diagnostic?.architect.session_found, false);
+      assert.equal(decision.evidence?.diagnostic?.architect.thread_found, false);
+      assert.equal(decision.evidence?.diagnostic?.distinct_thread_ids, true);
+      const error = buildAutopilotRalplanUltragoalGateError(decision);
+      assert.match(error, /Expected:/);
+      assert.match(error, /sessions\["<current_session_id>"\]\.threads\["<architect_thread_id>"\]\.kind = "subagent"/);
+      assert.match(error, /current_session_id: sess-autopilot-diagnostic-missing-session/);
+      assert.match(error, /architect thread_id: thread-architect found: no kind=missing completed=no/);
+      assert.match(error, /session_id: sess-autopilot-diagnostic-missing-session session_found=no/);
+      assert.match(error, /Re-run native ralplan Architect\/Critic reviews/);
+      assert.match(error, /docs\/contracts\/ralplan-consensus-gate\.md/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('explains observed tracker thread kind and completion checks', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-diagnostic-thread-values-'));
+    const sessionId = 'sess-autopilot-diagnostic-thread-values';
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            threads: {
+              'thread-architect': { thread_id: 'thread-architect', kind: 'leader', turn_count: 1 },
+              'thread-critic': { thread_id: 'thread-critic', kind: 'subagent', completed_at: '2026-06-12T10:03:00.000Z', turn_count: 1 },
+            },
+          },
+        },
+      }, null, 2));
+
+      const state = {
+        current_phase: 'ralplan',
+        handoff_artifacts: {
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-architect',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              session_id: sessionId,
+              thread_id: 'thread-critic',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, sessionId, currentState: state });
+      assert.equal(decision.allowed, false);
+      assert.equal(decision.evidence?.diagnostic?.architect.session_found, true);
+      assert.equal(decision.evidence?.diagnostic?.architect.thread_found, true);
+      assert.equal(decision.evidence?.diagnostic?.architect.kind, 'leader');
+      assert.equal(decision.evidence?.diagnostic?.architect.completed, false);
+      const error = buildAutopilotRalplanUltragoalGateError(decision);
+      assert.match(error, /architect thread_id: thread-architect found: yes kind=leader completed=no/);
+      assert.match(error, /critic thread_id: thread-critic found: yes kind=subagent completed=yes/);
+      assert.match(error, /distinct_thread_ids: yes/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('rejects native review evidence from the session leader even when malformed tracking marks it as subagent', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-leader-spoof-'));
     const sessionId = 'sess-autopilot-leader-spoof';

--- a/src/autopilot/ralplan-gate.ts
+++ b/src/autopilot/ralplan-gate.ts
@@ -109,6 +109,36 @@ function ralplanConsensusBlockedReason(evidence: RalplanConsensusGateEvidence): 
 export function buildAutopilotRalplanUltragoalGateError(
   decision: AutopilotRalplanUltragoalGateDecision,
 ): string {
+  const diagnostic = decision.evidence?.diagnostic;
+  if (diagnostic) {
+    const architect = diagnostic.architect;
+    const critic = diagnostic.critic;
+    const renderReview = (label: string, review: typeof architect) => [
+      `  ${label} thread_id: ${review.thread_id ?? 'missing'} found: ${review.thread_found ? 'yes' : 'no'} kind=${review.kind ?? 'missing'} completed=${review.completed ? 'yes' : 'no'}`,
+      `    session_id: ${review.session_id ?? 'missing'} session_found=${review.session_found ? 'yes' : 'no'}`,
+      review.problem ? `    problem: ${review.problem}` : null,
+    ].filter((line): line is string => Boolean(line)).join('\n');
+    return [
+      `Cannot transition ralplan -> ultragoal: ${decision.reason}.`,
+      '',
+      'Expected:',
+      ...diagnostic.expected_schema.map((line) => `  ${line}`),
+      '',
+      'Observed:',
+      `  current_session_id: ${diagnostic.current_session_id ?? 'missing'}`,
+      `  tracker_path: ${diagnostic.tracker_path}`,
+      renderReview('architect', architect),
+      renderReview('critic', critic),
+      `  distinct_thread_ids: ${diagnostic.distinct_thread_ids === null ? 'unknown' : diagnostic.distinct_thread_ids ? 'yes' : 'no'}`,
+      diagnostic.pair_problem ? `  pair_problem: ${diagnostic.pair_problem}` : null,
+      '',
+      'Fix:',
+      ...diagnostic.remediation.map((line) => `  ${line}`),
+      '',
+      'Docs:',
+      `  ${diagnostic.docs}`,
+    ].join('\n');
+  }
   const details = decision.evidence?.blockedDetails?.length
     ? ` Details: ${decision.evidence.blockedDetails.join('; ')}.`
     : '';

--- a/src/ralplan/consensus-gate.ts
+++ b/src/ralplan/consensus-gate.ts
@@ -12,6 +12,30 @@ export const RALPLAN_CONSENSUS_BLOCKED_REASONS = {
 export type RalplanConsensusBlockedReason =
   typeof RALPLAN_CONSENSUS_BLOCKED_REASONS[keyof typeof RALPLAN_CONSENSUS_BLOCKED_REASONS];
 
+export interface RalplanNativeReviewDiagnostic {
+  role: 'architect' | 'critic';
+  session_id: string | null;
+  thread_id: string | null;
+  tracker_path: string;
+  session_found: boolean;
+  thread_found: boolean;
+  kind: string | null;
+  completed: boolean;
+  problem: string | null;
+}
+
+export interface RalplanConsensusGateDiagnostic {
+  expected_schema: string[];
+  current_session_id: string | null;
+  tracker_path: string;
+  architect: RalplanNativeReviewDiagnostic;
+  critic: RalplanNativeReviewDiagnostic;
+  distinct_thread_ids: boolean | null;
+  pair_problem: string | null;
+  remediation: string[];
+  docs: string;
+}
+
 export interface RalplanConsensusGateEvidence {
   complete: boolean;
   sequence: ['architect-review', 'critic-review'];
@@ -20,6 +44,7 @@ export interface RalplanConsensusGateEvidence {
   source: string | null;
   blockedReason: RalplanConsensusBlockedReason | null;
   blockedDetails?: string[];
+  diagnostic?: RalplanConsensusGateDiagnostic;
 }
 
 export interface RalplanNativeSubagentConsensusOptions {
@@ -121,6 +146,7 @@ export function buildRalplanConsensusGateFromSources(
         trackerBackedNativeReviewProblem(nativeBlockedEvidence.ralplan_architect_review, 'architect', nativeBlockedEvidence.options),
         trackerBackedNativeReviewProblem(nativeBlockedEvidence.ralplan_critic_review, 'critic', nativeBlockedEvidence.options),
       ].filter((detail): detail is string => Boolean(detail)),
+      diagnostic: buildTrackerBackedNativeConsensusDiagnostic(nativeBlockedEvidence, nativeBlockedEvidence.options),
     };
   }
 
@@ -568,6 +594,83 @@ function nativeReviewThreadId(review: Record<string, unknown> | null): string {
   return typeof review?.thread_id === 'string' ? review.thread_id.trim() : '';
 }
 
+function currentTransitionSessionId(
+  evidence: {
+    ralplan_architect_review: Record<string, unknown> | null;
+    ralplan_critic_review: Record<string, unknown> | null;
+  },
+  options: RalplanNativeSubagentConsensusOptions,
+): string {
+  const transitionSessionId = typeof options.sessionId === 'string' ? options.sessionId.trim() : '';
+  return transitionSessionId
+    || nativeReviewSessionId(evidence.ralplan_architect_review)
+    || nativeReviewSessionId(evidence.ralplan_critic_review);
+}
+
+function buildTrackerBackedNativeConsensusDiagnostic(
+  evidence: {
+    ralplan_architect_review: Record<string, unknown> | null;
+    ralplan_critic_review: Record<string, unknown> | null;
+  },
+  options: RalplanNativeSubagentConsensusOptions,
+): RalplanConsensusGateDiagnostic {
+  const cwd = typeof options.cwd === 'string' ? options.cwd.trim() : '';
+  const trackerPath = cwd ? subagentTrackingPath(cwd) : '.omx/state/subagent-tracking.json';
+  const currentSessionId = currentTransitionSessionId(evidence, options);
+  const architectThreadId = nativeReviewThreadId(evidence.ralplan_architect_review);
+  const criticThreadId = nativeReviewThreadId(evidence.ralplan_critic_review);
+  return {
+    expected_schema: [
+      '.omx/state/subagent-tracking.json contains:',
+      'sessions["<current_session_id>"].threads["<architect_thread_id>"].kind = "subagent"',
+      'sessions["<current_session_id>"].threads["<critic_thread_id>"].kind = "subagent"',
+      'both threads have completed_at',
+      'architect and critic thread IDs are distinct',
+    ],
+    current_session_id: currentSessionId || null,
+    tracker_path: trackerPath,
+    architect: buildNativeReviewDiagnostic(evidence.ralplan_architect_review, 'architect', options),
+    critic: buildNativeReviewDiagnostic(evidence.ralplan_critic_review, 'critic', options),
+    distinct_thread_ids: architectThreadId && criticThreadId ? architectThreadId !== criticThreadId : null,
+    pair_problem: trackerBackedNativeReviewPairProblem(evidence, options),
+    remediation: [
+      'Re-run native ralplan Architect/Critic reviews.',
+      'Or repair the review artifact so agent_role, provenance_kind, session_id, thread_id, and tracker_path point to completed native subagent threads in the current tracker.',
+    ],
+    docs: 'docs/contracts/ralplan-consensus-gate.md',
+  };
+}
+
+function buildNativeReviewDiagnostic(
+  review: Record<string, unknown> | null,
+  agentRole: 'architect' | 'critic',
+  options: RalplanNativeSubagentConsensusOptions,
+): RalplanNativeReviewDiagnostic {
+  const cwd = typeof options.cwd === 'string' ? options.cwd.trim() : '';
+  const trackerPath = cwd ? subagentTrackingPath(cwd) : '.omx/state/subagent-tracking.json';
+  const problem = trackerBackedNativeReviewProblem(review, agentRole, options);
+  const sessionId = review
+    ? (typeof options.sessionId === 'string' && options.sessionId.trim()
+        ? options.sessionId.trim()
+        : nativeReviewSessionId(review))
+    : '';
+  const threadId = nativeReviewThreadId(review);
+  const tracking = cwd && sessionId ? readJsonState(trackerPath) : null;
+  const session = asRecord(asRecord(tracking?.sessions)?.[sessionId]);
+  const thread = asRecord(asRecord(session?.threads)?.[threadId]);
+  const completedAt = typeof thread?.completed_at === 'string' ? thread.completed_at.trim() : '';
+  return {
+    role: agentRole,
+    session_id: sessionId || null,
+    thread_id: threadId || null,
+    tracker_path: trackerPath,
+    session_found: Boolean(session),
+    thread_found: Boolean(thread),
+    kind: typeof thread?.kind === 'string' ? thread.kind : null,
+    completed: Boolean(completedAt),
+    problem,
+  };
+}
 function trackerBackedNativeReviewPairProblem(
   evidence: {
     ralplan_architect_review: Record<string, unknown> | null;


### PR DESCRIPTION
Resolves #2865

## Summary
- add structured ralplan native-subagent diagnostic details to consensus gate evidence
- render ralplan -> ultragoal failures with expected tracker schema, observed session/thread checks, remediation, and docs reference
- document the ralplan consensus gate contract and add regression coverage for missing-session and invalid-thread diagnostics

## Verification
- npm run build
- node dist/scripts/run-test-files.js dist/autopilot/__tests__/ralplan-gate.test.js dist/ralplan/__tests__/consensus-gate.test.js

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*