### PR TITLE
Make completed Codex goal cleanup explicit

### DIFF
--- a/plugins/oh-my-codex/skills/autoresearch-goal/SKILL.md
+++ b/plugins/oh-my-codex/skills/autoresearch-goal/SKILL.md
@@ -31,6 +31,9 @@ Use this workflow when a research mission should be bound to Codex goal-mode foc
 5. Completion is blocked until professor-critic validation records `verdict=pass`. After the mission audit passes, call `update_goal({status: "complete"})`, call `get_goal` again, then run:
    `omx autoresearch-goal complete --slug <slug> --codex-goal-json <get_goal-json-or-path>`
 6. Treat the completion command as read-only reconciliation plus durable OMX state update; hooks and shell commands must not mutate Codex goal state.
+7. After the completion command succeeds, run `/goal clear` in the Codex UI before starting another goal in this same thread/session. OMX prints this terminal cleanup step but does not invoke hidden clear routes.
 
 ## Completion gate
 A passing professor-critic artifact and a matching complete Codex `get_goal` snapshot are required. Assistant prose, partial tests, or a failed/blocked verdict are not sufficient.
+
+Lifecycle: `create_goal` starts the Codex thread goal, `update_goal({status: "complete"})` marks terminal success after the professor-critic and audit pass, and `/goal clear` removes the completed thread goal when another same-thread goal is needed. OMX shell commands and hooks reconcile snapshots and print the cleanup instruction; they must not mutate hidden Codex goal state.

--- a/plugins/oh-my-codex/skills/performance-goal/SKILL.md
+++ b/plugins/oh-my-codex/skills/performance-goal/SKILL.md
@@ -55,6 +55,7 @@ omx performance-goal complete --slug startup-latency --evidence "final evaluator
    - call `create_goal` only when no active goal exists and the objective is explicit;
    - work only against the evaluator contract;
    - after evaluator pass and completion audit, call `update_goal({status: "complete"})`, call `get_goal` again, and pass that snapshot to `omx performance-goal complete --codex-goal-json`;
+   - after `omx performance-goal complete` succeeds, run `/goal clear` in the Codex UI before starting another goal in this same thread/session; OMX prints this terminal cleanup step but does not invoke hidden clear routes;
 3. Optimize in small reversible patches.
 4. Run the evaluator and related regression tests.
 5. Record each pass/fail/blocker with `checkpoint`.
@@ -63,3 +64,5 @@ omx performance-goal complete --slug startup-latency --evidence "final evaluator
 ## Completion Gate
 
 A performance goal is incomplete unless `.omx/goals/performance/<slug>/state.json` contains a `lastValidation.status` of `pass` and `omx performance-goal complete` receives a matching complete Codex `get_goal` snapshot via `--codex-goal-json`. Passing ordinary tests alone is not sufficient unless they are the declared evaluator contract.
+
+Lifecycle: `create_goal` starts the Codex thread goal, `update_goal({status: "complete"})` marks terminal success after the evaluator and audit pass, and `/goal clear` removes the completed thread goal when another same-thread goal is needed. OMX shell commands and hooks reconcile snapshots and print the cleanup instruction; they must not mutate hidden Codex goal state.

--- a/plugins/oh-my-codex/skills/ultragoal/SKILL.md
+++ b/plugins/oh-my-codex/skills/ultragoal/SKILL.md
@@ -149,7 +149,7 @@ The final ultragoal story is not complete until the active agent has run the fin
 
 - The shell command cannot directly invoke Codex interactive `/goal`; it emits a model-facing handoff for the active Codex agent.
 - Ultragoal intentionally does not invoke `/goal clear` or hidden `thread/goal/clear`; the model-facing tool surface only provides `get_goal`, `create_goal`, and `update_goal`.
-- After a completed aggregate ultragoal run, clear the Codex goal manually with `/goal clear` before starting another ultragoal run in the same session/thread.
+- After a completed aggregate ultragoal run, `/goal clear` is the explicit terminal cleanup step before starting another goal in the same Codex thread/session: `create_goal` starts, `update_goal({status: "complete"})` marks terminal success, and `/goal clear` removes the completed thread goal for the next same-thread goal. OMX prints this next step but does not invoke hidden clear routes.
 - Never call `create_goal` when `get_goal` reports a different active goal.
 - Never call `update_goal` unless the aggregate run or legacy per-story goal is actually complete.
 - In aggregate mode, intermediate story checkpoints require a matching `active` Codex snapshot; final story completion requires a matching `complete` snapshot after `update_goal`.

--- a/skills/autoresearch-goal/SKILL.md
+++ b/skills/autoresearch-goal/SKILL.md
@@ -31,6 +31,9 @@ Use this workflow when a research mission should be bound to Codex goal-mode foc
 5. Completion is blocked until professor-critic validation records `verdict=pass`. After the mission audit passes, call `update_goal({status: "complete"})`, call `get_goal` again, then run:
    `omx autoresearch-goal complete --slug <slug> --codex-goal-json <get_goal-json-or-path>`
 6. Treat the completion command as read-only reconciliation plus durable OMX state update; hooks and shell commands must not mutate Codex goal state.
+7. After the completion command succeeds, run `/goal clear` in the Codex UI before starting another goal in this same thread/session. OMX prints this terminal cleanup step but does not invoke hidden clear routes.
 
 ## Completion gate
 A passing professor-critic artifact and a matching complete Codex `get_goal` snapshot are required. Assistant prose, partial tests, or a failed/blocked verdict are not sufficient.
+
+Lifecycle: `create_goal` starts the Codex thread goal, `update_goal({status: "complete"})` marks terminal success after the professor-critic and audit pass, and `/goal clear` removes the completed thread goal when another same-thread goal is needed. OMX shell commands and hooks reconcile snapshots and print the cleanup instruction; they must not mutate hidden Codex goal state.

--- a/skills/performance-goal/SKILL.md
+++ b/skills/performance-goal/SKILL.md
@@ -55,6 +55,7 @@ omx performance-goal complete --slug startup-latency --evidence "final evaluator
    - call `create_goal` only when no active goal exists and the objective is explicit;
    - work only against the evaluator contract;
    - after evaluator pass and completion audit, call `update_goal({status: "complete"})`, call `get_goal` again, and pass that snapshot to `omx performance-goal complete --codex-goal-json`;
+   - after `omx performance-goal complete` succeeds, run `/goal clear` in the Codex UI before starting another goal in this same thread/session; OMX prints this terminal cleanup step but does not invoke hidden clear routes;
 3. Optimize in small reversible patches.
 4. Run the evaluator and related regression tests.
 5. Record each pass/fail/blocker with `checkpoint`.
@@ -63,3 +64,5 @@ omx performance-goal complete --slug startup-latency --evidence "final evaluator
 ## Completion Gate
 
 A performance goal is incomplete unless `.omx/goals/performance/<slug>/state.json` contains a `lastValidation.status` of `pass` and `omx performance-goal complete` receives a matching complete Codex `get_goal` snapshot via `--codex-goal-json`. Passing ordinary tests alone is not sufficient unless they are the declared evaluator contract.
+
+Lifecycle: `create_goal` starts the Codex thread goal, `update_goal({status: "complete"})` marks terminal success after the evaluator and audit pass, and `/goal clear` removes the completed thread goal when another same-thread goal is needed. OMX shell commands and hooks reconcile snapshots and print the cleanup instruction; they must not mutate hidden Codex goal state.

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -149,7 +149,7 @@ The final ultragoal story is not complete until the active agent has run the fin
 
 - The shell command cannot directly invoke Codex interactive `/goal`; it emits a model-facing handoff for the active Codex agent.
 - Ultragoal intentionally does not invoke `/goal clear` or hidden `thread/goal/clear`; the model-facing tool surface only provides `get_goal`, `create_goal`, and `update_goal`.
-- After a completed aggregate ultragoal run, clear the Codex goal manually with `/goal clear` before starting another ultragoal run in the same session/thread.
+- After a completed aggregate ultragoal run, `/goal clear` is the explicit terminal cleanup step before starting another goal in the same Codex thread/session: `create_goal` starts, `update_goal({status: "complete"})` marks terminal success, and `/goal clear` removes the completed thread goal for the next same-thread goal. OMX prints this next step but does not invoke hidden clear routes.
 - Never call `create_goal` when `get_goal` reports a different active goal.
 - Never call `update_goal` unless the aggregate run or legacy per-story goal is actually complete.
 - In aggregate mode, intermediate story checkpoints require a matching `active` Codex snapshot; final story completion requires a matching `complete` snapshot after `update_goal`.

--- a/src/autoresearch/goal.ts
+++ b/src/autoresearch/goal.ts
@@ -4,6 +4,8 @@ import { join, relative } from 'node:path';
 import { slugifyMissionName } from './contracts.js';
 import {
   formatCodexGoalReconciliation,
+  buildCompletedCodexGoalRemediation,
+  buildCodexGoalTerminalCleanupNotice,
   parseCodexGoalSnapshot,
   reconcileCodexGoalSnapshot,
   type CodexGoalSnapshot,
@@ -325,11 +327,20 @@ export async function buildAutoresearchGoalHandoff(cwd: string, slug: string, no
     'Codex goal integration constraints:',
     '- This shell command does not mutate hidden Codex /goal state; it writes durable OMX artifacts and prints this handoff only.',
     '- First call get_goal. If no active goal exists, call create_goal with the payload below.',
+    `- If get_goal reports status complete before create_goal, do not call create_goal over it. ${buildCompletedCodexGoalRemediation('Autoresearch-goal preflight')}`,
     '- If a different active Codex goal exists, finish/checkpoint that goal before starting this autoresearch goal.',
     '- Iterate research until the professor-critic evaluator records a concrete pass/fail/blocker artifact.',
     '- Do not call update_goal({status: "complete"}) until the professor-critic verdict is pass and the objective audit proves the mission complete; then call get_goal again and run omx autoresearch-goal complete --codex-goal-json with the fresh snapshot.',
+    '- After omx autoresearch-goal complete succeeds, treat `/goal clear` as the explicit terminal cleanup step before another same-thread goal.',
     '- If validation fails or blocks, keep iterating or report the blocker with the recorded evidence; do not revive deprecated omx autoresearch.',
     '',
+    ...(mission.status === 'complete'
+      ? [
+        '',
+        'Terminal Codex goal cleanup:',
+        buildCodexGoalTerminalCleanupNotice('Autoresearch-goal completion'),
+      ]
+      : []),
     'create_goal payload:',
     JSON.stringify(createPayload, null, 2),
     '',

--- a/src/cli/__tests__/autoresearch-goal.test.ts
+++ b/src/cli/__tests__/autoresearch-goal.test.ts
@@ -183,6 +183,42 @@ describe('cli/autoresearch-goal', () => {
     });
   });
 
+  it('prints explicit terminal cleanup after successful completion without claiming hidden clear', async () => {
+    await withCwd(async () => {
+      await capture(() => autoresearchGoalCommand([
+          'create',
+          '--topic', 'Cleanup guidance',
+          '--rubric', 'Professor critic requires a pass.',
+        ]));
+        await capture(() => autoresearchGoalCommand([
+          'verdict',
+          '--slug', 'cleanup-guidance',
+          '--verdict', 'pass',
+          '--evidence', 'critic approved',
+        ]));
+
+        const objective = [
+          'Autoresearch goal: Cleanup guidance',
+          '',
+          'Research methodology / professor-critic rubric:',
+          'Professor critic requires a pass.',
+          '',
+          'Completion gate: record a passing professor-critic verdict with omx autoresearch-goal verdict --slug cleanup-guidance --verdict pass --evidence "<critic artifact/evidence>". After the objective audit passes, call update_goal({status: "complete"}), call get_goal again, then run omx autoresearch-goal complete --slug cleanup-guidance --codex-goal-json "<fresh get_goal JSON or path>".',
+        ].join('\n');
+        const completed = await capture(() => autoresearchGoalCommand([
+          'complete',
+          '--slug', 'cleanup-guidance',
+          '--codex-goal-json', JSON.stringify({ goal: { objective, status: 'complete' } }),
+        ]));
+
+        const output = completed.stdout.join('\n');
+        assert.equal(completed.exitCode, undefined);
+        assert.match(output, /Terminal next step for another goal in this same Codex thread\/session: run \/goal clear/);
+        assert.match(output, /OMX shell commands and hooks do not call \/goal clear or hidden thread\/goal\/clear routes/);
+        assert.doesNotMatch(output, /cleared Codex goal state/i);
+    });
+  });
+
   it('requires matching complete Codex goal proof for completion', async () => {
     await withCwd(async (cwd) => {
       await capture(() => autoresearchGoalCommand([

--- a/src/cli/__tests__/performance-goal.test.ts
+++ b/src/cli/__tests__/performance-goal.test.ts
@@ -124,6 +124,31 @@ describe('cli/performance-goal', () => {
     });
   });
 
+  it('prints explicit terminal cleanup after successful completion without claiming hidden clear', async () => {
+    await withCwd(async () => {
+      await capture(() => performanceGoalCommand([
+        'create',
+        '--objective', 'Reduce tail latency',
+        '--evaluator-command', 'node bench.js',
+        '--evaluator-contract', 'PASS when p99 latency improves.',
+        '--slug', 'tail-latency',
+      ]));
+      await capture(() => performanceGoalCommand(['checkpoint', '--slug', 'tail-latency', '--status', 'pass', '--evidence', 'bench pass']));
+
+      const completed = await capture(() => performanceGoalCommand([
+        'complete',
+        '--slug', 'tail-latency',
+        '--codex-goal-json', '{"goal":{"objective":"Reduce tail latency","status":"complete"}}',
+      ]));
+
+      const output = completed.stdout.join('\n');
+      assert.equal(completed.exitCode, undefined);
+      assert.match(output, /Terminal next step for another goal in this same Codex thread\/session: run \/goal clear/);
+      assert.match(output, /OMX shell commands and hooks do not call \/goal clear or hidden thread\/goal\/clear routes/);
+      assert.doesNotMatch(output, /cleared Codex goal state/i);
+    });
+  });
+
   it('requires matching complete Codex goal proof for completion', async () => {
     await withCwd(async () => {
       await capture(() => performanceGoalCommand([

--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -186,6 +186,42 @@ describe('cli/ultragoal', () => {
     });
   });
 
+  it('prints explicit terminal cleanup after final checkpoint without claiming hidden clear', async () => {
+    await withCwd(async (cwd) => {
+      await capture(() => ultragoalCommand(['create-goals', '--brief', '- Final milestone']));
+      await capture(() => ultragoalCommand(['complete-goals']));
+      const goals = JSON.parse(await readFile(join(cwd, '.omx/ultragoal/goals.json'), 'utf-8')) as { codexObjective: string };
+
+      const checkpoint = await capture(() => ultragoalCommand([
+        'checkpoint',
+        '--goal-id', 'G001-final-milestone',
+        '--status', 'complete',
+        '--evidence', 'tests and final review passed',
+        '--codex-goal-json', JSON.stringify({ goal: { objective: goals.codexObjective, status: 'complete' } }),
+        '--quality-gate-json', cleanQualityGate(),
+      ]));
+
+      const output = checkpoint.stdout.join('\n');
+      assert.equal(checkpoint.exitCode, undefined);
+      assert.match(output, /Terminal next step for another goal in this same Codex thread\/session: run \/goal clear/);
+      assert.match(output, /OMX shell commands and hooks do not call \/goal clear or hidden thread\/goal\/clear routes/);
+      assert.doesNotMatch(output, /cleared Codex goal state/i);
+    });
+  });
+
+  it('places completed-goal preflight remediation before create_goal guidance', async () => {
+    await withCwd(async () => {
+      await capture(() => ultragoalCommand(['create-goals', '--brief', '- First milestone']));
+      const next = await capture(() => ultragoalCommand(['complete-goals']));
+      const output = next.stdout.join('\n');
+
+      assert.match(output, /get_goal reports status complete before create_goal/);
+      assert.match(output, /Run \/goal clear in the Codex UI before starting another goal/);
+      assert.ok(output.indexOf('get_goal reports status complete before create_goal') < output.indexOf('create_goal payload'));
+      assert.match(output, /OMX did not and cannot clear hidden Codex goal state/);
+    });
+  });
+
   it('reports artifact-backed completion when Codex goal DB schema is unavailable', async () => {
     await withCwd(async (cwd) => {
       await capture(() => ultragoalCommand(['create-goals', '--brief', '- First milestone']));

--- a/src/cli/autoresearch-goal.ts
+++ b/src/cli/autoresearch-goal.ts
@@ -13,6 +13,7 @@ import {
 import {
   CodexGoalSnapshotError,
   formatCodexGoalReconciliation,
+  buildCodexGoalTerminalCleanupNotice,
   readCodexGoalSnapshotInput,
 } from '../goal-workflows/codex-goal-snapshot.js';
 
@@ -145,6 +146,7 @@ export async function autoresearchGoalCommand(args: string[]): Promise<void> {
       else {
         console.log(`autoresearch-goal complete: ${result.mission.slug}`);
         console.log('Codex goal reconciliation: matched a fresh complete get_goal snapshot; OMX mission completion is now durable.');
+        console.log(buildCodexGoalTerminalCleanupNotice('Autoresearch-goal completion'));
       }
       return;
     }

--- a/src/cli/performance-goal.ts
+++ b/src/cli/performance-goal.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 import {
   CodexGoalSnapshotError,
   formatCodexGoalReconciliation,
+  buildCodexGoalTerminalCleanupNotice,
   readCodexGoalSnapshotInput,
   reconcileCodexGoalSnapshot,
 } from '../goal-workflows/codex-goal-snapshot.js';
@@ -159,7 +160,10 @@ export async function performanceGoalCommand(args: string[]): Promise<void> {
         codexGoal: await readCodexGoalSnapshotInput(readValue(rest, '--codex-goal-json'), cwd),
       });
       if (json) printJson({ ok: true, state, instruction: buildPerformanceGoalInstruction(state) });
-      else printStatus(state);
+      else {
+        printStatus(state);
+        console.log(buildCodexGoalTerminalCleanupNotice('Performance-goal completion'));
+      }
       return;
     }
 

--- a/src/cli/ultragoal.ts
+++ b/src/cli/ultragoal.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 import {
   CodexGoalSnapshotError,
   formatCodexGoalReconciliation,
+  buildCodexGoalTerminalCleanupNotice,
   readCodexGoalSnapshotInput,
   reconcileCodexGoalSnapshot,
 } from '../goal-workflows/codex-goal-snapshot.js';
@@ -486,6 +487,10 @@ export async function ultragoalCommand(args: string[]): Promise<void> {
         const goal = plan.goals.find((candidate: UltragoalItem) => candidate.id === goalId);
         console.log(`ultragoal checkpoint: ${goalId} -> ${goal?.status ?? status}`);
         printStatus(plan);
+        const summary = summarizeUltragoalPlan(plan);
+        if (status === 'complete' && (summary.aggregateComplete || summary.artifactComplete)) {
+          console.log(buildCodexGoalTerminalCleanupNotice('Ultragoal completion'));
+        }
       }
       return;
     }

--- a/src/goal-workflows/codex-goal-snapshot.ts
+++ b/src/goal-workflows/codex-goal-snapshot.ts
@@ -198,3 +198,15 @@ export function formatCodexGoalReconciliation(reconciliation: CodexGoalReconcili
   const parts = [...reconciliation.errors, ...reconciliation.warnings];
   return parts.join(' ');
 }
+
+export function buildCodexGoalTerminalCleanupNotice(workflowLabel: string): string {
+  return [
+    `${workflowLabel}: Codex goal is complete and OMX durable workflow artifacts are complete.`,
+    'Terminal next step for another goal in this same Codex thread/session: run /goal clear in the Codex UI before calling create_goal for the next OMX goal.',
+    'OMX shell commands and hooks do not call /goal clear or hidden thread/goal/clear routes; if a future Codex tool surface exposes explicit clear/reset, use that tool instead.',
+  ].join('\n');
+}
+
+export function buildCompletedCodexGoalRemediation(workflowLabel: string): string {
+  return `${workflowLabel}: get_goal reports a completed Codex goal still attached to this thread. Run /goal clear in the Codex UI before starting another goal in this same thread/session; OMX did not and cannot clear hidden Codex goal state from shell/hooks.`;
+}

--- a/src/performance-goal/artifacts.ts
+++ b/src/performance-goal/artifacts.ts
@@ -3,6 +3,8 @@ import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import {
   formatCodexGoalReconciliation,
+  buildCompletedCodexGoalRemediation,
+  buildCodexGoalTerminalCleanupNotice,
   parseCodexGoalSnapshot,
   reconcileCodexGoalSnapshot,
 } from '../goal-workflows/codex-goal-snapshot.js';
@@ -292,14 +294,23 @@ export function buildPerformanceGoalInstruction(state: PerformanceGoalState): st
     '',
     'Codex goal integration constraints:',
     '- First call get_goal. If no active goal exists, call create_goal with the payload below.',
+    `- If get_goal reports status complete before create_goal, do not call create_goal over it. ${buildCompletedCodexGoalRemediation('Performance-goal preflight')}`,
     '- If a different active Codex goal exists, finish or checkpoint that goal before starting this performance goal.',
     '- Do not treat this shell command as hidden Codex goal mutation; it only wrote OMX artifacts and this handoff.',
     '- Optimize only against the evaluator command/contract below; do not begin optimization without that evaluator.',
     '- Completion is blocked until evaluator evidence passes and is recorded with `omx performance-goal checkpoint --status pass ...`.',
     '- After evaluator pass and a completion audit prove the objective is complete, call update_goal({status: "complete"}) in the Codex thread, then call get_goal again for a fresh completion snapshot.',
     `- Finish by running: omx performance-goal complete --slug ${state.slug} --evidence "<passing evaluator/tests/files evidence>" --codex-goal-json "<fresh get_goal JSON or path>"`,
+    '- After the complete command succeeds, treat `/goal clear` as the explicit terminal cleanup step before another same-thread goal.',
     '- If the evaluator fails or blocks, checkpoint with --status fail or --status blocked and continue iterating.',
     '',
+    ...(state.status === 'complete'
+      ? [
+        '',
+        'Terminal Codex goal cleanup:',
+        buildCodexGoalTerminalCleanupNotice('Performance-goal completion'),
+      ]
+      : []),
     'create_goal payload:',
     JSON.stringify(createPayload, null, 2),
     '',

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3172,6 +3172,64 @@ standardMaxRounds = 15
     }
   });
 
+  it("nudges next-goal prompts when a completed Codex goal cleanup step remains", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-completed-goal-prompt-"));
+    try {
+      await writeJson(join(cwd, ".omx", "goals", "performance", "latency", "state.json"), {
+        version: 1,
+        workflow: "performance-goal",
+        slug: "latency",
+        objective: "Reduce latency",
+        status: "complete",
+        completedAt: "2026-05-20T00:00:00.000Z",
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "UserPromptSubmit",
+        cwd,
+        session_id: "sess-completed-goal-prompt",
+        thread_id: "thread-completed-goal-prompt",
+        prompt: "Start the next performance goal now",
+      }, { cwd });
+
+      const output = JSON.stringify(result.outputJson);
+      assert.match(output, /run \/goal clear/);
+      assert.match(output, /before calling create_goal/);
+      assert.match(output, /hooks only nudge and must not mutate Codex goal state/);
+      assert.doesNotMatch(output, /cleared Codex goal state/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks Stop when a final answer starts another goal over completed state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-completed-goal-stop-"));
+    try {
+      await writeJson(join(cwd, ".omx", "ultragoal", "goals.json"), {
+        version: 1,
+        aggregateCompletion: { status: "complete", completedAt: "2026-05-20T00:00:00.000Z" },
+        goals: [{ id: "G001-done", status: "complete", objective: "Done" }],
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-completed-goal-stop",
+        thread_id: "thread-completed-goal-stop",
+        last_assistant_message: "Starting another ultragoal now; create_goal payload follows.",
+      }, { cwd });
+
+      const output = JSON.stringify(result.outputJson);
+      assert.equal(result.outputJson?.decision, "block");
+      assert.equal(result.outputJson?.stopReason, "completed_codex_goal_cleanup_required");
+      assert.match(output, /run \/goal clear/);
+      assert.match(output, /before calling create_goal/);
+      assert.match(output, /hooks only nudge and must not mutate Codex goal state/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("blocks ultragoal Stop for concise generic goal completion claims", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ultragoal-generic-complete-stop-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -88,6 +88,9 @@ import { readAutoresearchCompletionStatus, readAutoresearchModeStateForActiveDec
 import { normalizeAutopilotPhase } from "../autopilot/fsm.js";
 import { readRunState } from "../runtime/run-state.js";
 import { evaluateRalphCompletionAuditEvidence, isRalphCompletePhase } from "../ralph/completion-audit.js";
+import {
+  buildCodexGoalTerminalCleanupNotice,
+} from "../goal-workflows/codex-goal-snapshot.js";
 import { getRunContinuationSnapshot, shouldContinueRun } from "../runtime/run-loop.js";
 import {
   parseUltragoalSteeringDirective,
@@ -2395,6 +2398,63 @@ function reportsBlockedUltragoalCompletedAggregateMicrogoalLoop(goal: Record<str
     && /\b(?:unreconcilable|mismatch|loop|already complete|already completed|blocks?)\b/i.test(evidence);
 }
 
+function looksLikeNewGoalPrompt(text: string): boolean {
+  return /(?:\b(?:start|create|begin|new|another)\b.{0,80}\b(?:goal|ultragoal|performance[-\s]goal|autoresearch[-\s]goal)\b|\b(?:goal|ultragoal|performance[-\s]goal|autoresearch[-\s]goal)\b.{0,80}\b(?:start|create|begin|new|another)\b)/i.test(text);
+}
+
+async function findCompletedGoalWorkflowCleanupNotice(cwd: string): Promise<string | null> {
+  const ultragoal = await readJsonIfExists(join(cwd, ".omx", "ultragoal", "goals.json"));
+  const aggregateCompletion = safeObject(ultragoal?.aggregateCompletion);
+  const ultragoals = Array.isArray(ultragoal?.goals) ? ultragoal.goals.map(safeObject) : [];
+  if (safeString(aggregateCompletion.status) === "complete" || (ultragoals.length > 0 && ultragoals.every((goal) => safeString(goal.status) === "complete"))) {
+    return buildCodexGoalTerminalCleanupNotice("Ultragoal completion");
+  }
+
+  const performanceRoot = join(cwd, ".omx", "goals", "performance");
+  for (const entry of await readdir(performanceRoot, { withFileTypes: true }).catch(() => [])) {
+    if (!entry.isDirectory()) continue;
+    const state = await readJsonIfExists(join(performanceRoot, entry.name, "state.json"));
+    if (state?.workflow === "performance-goal" && safeString(state.status) === "complete") {
+      return buildCodexGoalTerminalCleanupNotice("Performance-goal completion");
+    }
+  }
+
+  const autoresearchRoot = join(cwd, ".omx", "goals", "autoresearch");
+  for (const entry of await readdir(autoresearchRoot, { withFileTypes: true }).catch(() => [])) {
+    if (!entry.isDirectory()) continue;
+    const mission = await readJsonIfExists(join(autoresearchRoot, entry.name, "mission.json"));
+    if (mission?.workflow === "autoresearch-goal" && safeString(mission.status) === "complete") {
+      return buildCodexGoalTerminalCleanupNotice("Autoresearch-goal completion");
+    }
+  }
+
+  return null;
+}
+
+async function buildCompletedGoalCleanupPromptWarning(cwd: string, prompt: string): Promise<string | null> {
+  if (!looksLikeNewGoalPrompt(prompt)) return null;
+  const notice = await findCompletedGoalWorkflowCleanupNotice(cwd);
+  if (!notice) return null;
+  return `${notice} Do not continue into create_goal until cleanup is explicit; hooks only nudge and must not mutate Codex goal state.`;
+}
+
+async function buildCompletedGoalCleanupStopOutput(payload: CodexHookPayload, cwd: string): Promise<Record<string, unknown> | null> {
+  const text = [
+    safeString(payload.last_user_message ?? payload.lastUserMessage),
+    safeString(payload.last_assistant_message ?? payload.lastAssistantMessage),
+  ].join("\n");
+  if (!looksLikeNewGoalPrompt(text)) return null;
+  const notice = await findCompletedGoalWorkflowCleanupNotice(cwd);
+  if (!notice) return null;
+  const systemMessage = `${notice} Do not continue into create_goal until cleanup is explicit; hooks only nudge and must not mutate Codex goal state.`;
+  return {
+    decision: "block",
+    reason: systemMessage,
+    stopReason: "completed_codex_goal_cleanup_required",
+    systemMessage,
+  };
+}
+
 async function findActiveGoalWorkflowReconciliationRequirement(cwd: string): Promise<{ workflow: string; command: string; remediation?: string } | null> {
   const ultragoal = await readJsonIfExists(join(cwd, ".omx", "ultragoal", "goals.json"));
   const aggregateCompletion = safeObject(ultragoal?.aggregateCompletion);
@@ -4651,7 +4711,8 @@ export async function dispatchCodexNativeHook(
 
   if (hookEventName === "UserPromptSubmit") {
     const prompt = readPromptText(payload);
-    goalWorkflowAdditionalContext = await buildGoalWorkflowReconciliationPromptWarning(cwd, prompt).catch(() => null);
+    goalWorkflowAdditionalContext = await buildCompletedGoalCleanupPromptWarning(cwd, prompt).catch(() => null)
+      ?? await buildGoalWorkflowReconciliationPromptWarning(cwd, prompt).catch(() => null);
     ultragoalSteeringAdditionalContext = prompt && !isSubagentPromptSubmit
       ? await applyUserPromptUltragoalSteering(cwd, prompt).catch((error) => `OMX native UserPromptSubmit rejected bounded .omx/ultragoal steering for G002-cli-and-prompt-submit-bridge: ${error instanceof Error ? error.message : String(error)}`)
       : null;
@@ -4834,7 +4895,7 @@ export async function dispatchCodexNativeHook(
   } else if (hookEventName === "Stop") {
     outputJson = await buildStopHookOutput(payload, cwd, stateDir, {
       skipRalphStopBlock: isSubagentStop,
-    });
+    }) ?? await buildCompletedGoalCleanupStopOutput(payload, cwd);
   }
 
   return {

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -4,7 +4,6 @@ import { join, relative } from 'node:path';
 import {
   formatCodexGoalReconciliation,
   buildCompletedCodexGoalRemediation,
-  buildCodexGoalTerminalCleanupNotice,
   parseCodexGoalSnapshot,
   reconcileCodexGoalSnapshot,
 } from '../goal-workflows/codex-goal-snapshot.js';

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -3,6 +3,8 @@ import { appendFile, mkdir, open, readFile, rename, rm, writeFile } from 'node:f
 import { join, relative } from 'node:path';
 import {
   formatCodexGoalReconciliation,
+  buildCompletedCodexGoalRemediation,
+  buildCodexGoalTerminalCleanupNotice,
   parseCodexGoalSnapshot,
   reconcileCodexGoalSnapshot,
 } from '../goal-workflows/codex-goal-snapshot.js';
@@ -1710,6 +1712,7 @@ function buildPerStoryCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalP
     '',
     'Codex goal integration constraints:',
     '- First call get_goal. If no active goal exists, call create_goal with the payload below.',
+    `- If get_goal reports status complete before create_goal, do not call create_goal over it. ${buildCompletedCodexGoalRemediation('Ultragoal preflight')}`,
     '- If a different active Codex goal exists, finish/checkpoint that goal before starting this ultragoal.',
     '- Ultragoal cannot call /goal clear from the model/shell tool surface. For another per-story goal in the same session/thread after a completed Codex goal, manually run /goal clear in the Codex UI before creating the next goal.',
     '- If get_goal returns a different completed legacy/thread goal and create_goal rejects because this thread already has a completed goal, continue only from a Codex goal context with no active/completed conflicting goal in the same repo/worktree and create the payload there.',
@@ -1736,6 +1739,9 @@ function buildPerStoryCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalP
     finalStory
       ? `  omx ultragoal checkpoint --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>" --codex-goal-json "<fresh complete get_goal JSON or path>" --quality-gate-json "<quality gate JSON or path>"`
       : null,
+    finalStory
+      ? '- After the final checkpoint command succeeds, treat `/goal clear` as the explicit terminal cleanup step before another same-thread goal.'
+      : null,
     '- If blocked or failed, checkpoint with --status failed and the failure evidence; rerun complete-goals --retry-failed to resume.',
     '',
     'create_goal payload:',
@@ -1761,6 +1767,7 @@ function buildAggregateCodexGoalInstruction(goal: UltragoalItem, plan: Ultragoal
     '- Codex goal = the whole ultragoal run; OMX G001/G002/etc. = ledger stories.',
     '- First call get_goal. If no active goal exists, call create_goal with the aggregate payload below.',
     '- If get_goal reports the same aggregate objective as active, continue this OMX story without creating a new Codex goal.',
+    `- If get_goal reports status complete before create_goal, do not call create_goal over it. ${buildCompletedCodexGoalRemediation('Ultragoal preflight')}`,
     '- If a different active or incomplete Codex goal exists, finish/checkpoint that goal before starting this ultragoal; do not replace hidden Codex state from the shell.',
     '- Ultragoal does not call /goal clear. After a completed aggregate run, manually run /goal clear in the Codex UI before starting another ultragoal run in the same session/thread.',
     finalStory
@@ -1777,6 +1784,9 @@ function buildAggregateCodexGoalInstruction(goal: UltragoalItem, plan: Ultragoal
       : null,
     finalStory
       ? '- If final $code-review is clean (APPROVE + CLEAR + independent code-reviewer and architect subagent evidence), call update_goal({status: "complete"}), call get_goal again for a fresh complete snapshot, then checkpoint with --quality-gate-json.'
+      : null,
+    finalStory
+      ? '- After the final checkpoint command succeeds, treat `/goal clear` as the explicit terminal cleanup step before another same-thread goal.'
       : null,
     `- Checkpoint this OMX story with a fresh get_goal snapshot whose objective matches the aggregate payload and whose status is ${checkpointStatus}:`,
     finalStory


### PR DESCRIPTION
Resolves #2890.

## Summary
- Adds explicit terminal `/goal clear` cleanup guidance after Ultragoal, performance-goal, and autoresearch-goal successful completion.
- Adds completed-goal preflight remediation before create_goal guidance without claiming OMX clears hidden Codex state.
- Adds UserPromptSubmit/Stop hook nudges for starting another goal while completed OMX goal artifacts indicate cleanup is needed.
- Documents the lifecycle: create_goal starts, update_goal({status: "complete"}) marks success, /goal clear removes the completed same-thread goal.

## Verification
- npm run build
- node dist/scripts/run-test-files.js dist/cli/__tests__/ultragoal.test.js dist/cli/__tests__/performance-goal.test.js dist/cli/__tests__/autoresearch-goal.test.js dist/scripts/__tests__/codex-native-hook.test.js

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*