### PR TITLE
Fix HUD cramped guard and tmux safe-paste cleanup

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-tmux-guard.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-tmux-guard.test.ts
@@ -272,6 +272,121 @@ exit 0
     }
   });
 
+  it('deletes the named buffer when verification fails after setup', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-tmux-guard-'));
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const tmuxLogPath = join(cwd, 'tmux.log');
+
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(
+        join(fakeBinDir, 'tmux'),
+        `#!/usr/bin/env bash
+set -eu
+printf '[%s]' "$@" >> "${tmuxLogPath}"
+printf '\n' >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "set-buffer" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == "show-buffer" ]]; then
+  echo "cannot read buffer" >&2
+  exit 1
+fi
+exit 0
+`,
+      );
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const moduleUrl = new URL('../../../dist/scripts/notify-hook/team-tmux-guard.js', import.meta.url).href;
+      const result = runSendPaneInputInChild({
+        fakeBinDir,
+        moduleUrl,
+        paneTarget: '%42',
+        prompt: 'supervisor handoff after setup',
+        submitKeyPresses: 1,
+        typePrompt: true,
+      });
+
+      assert.equal(result.status, 0, result.stderr);
+      const parsed = JSON.parse(result.stdout);
+      assert.equal(parsed.ok, false);
+      assert.equal(parsed.reason, 'buffer_show_failed');
+
+      const lines = (await readFile(tmuxLogPath, 'utf-8')).trim().split('\n').filter(Boolean);
+      assert.match(lines[0] ?? '', /\[set-buffer\]\[-b\]\[omx-pane-input-/);
+      assert.match(lines[1] ?? '', /\[show-buffer\]\[-b\]\[omx-pane-input-/);
+      assert.match(lines[2] ?? '', /\[delete-buffer\]\[-b\]\[omx-pane-input-/);
+      assert.equal(lines.length, 3);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('deletes the named buffer when paste fails after verification', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-tmux-guard-'));
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const tmuxLogPath = join(cwd, 'tmux.log');
+    const bufferPath = `${tmuxLogPath}.buffer`;
+
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(
+        join(fakeBinDir, 'tmux'),
+        `#!/usr/bin/env bash
+set -eu
+printf '[%s]' "$@" >> "${tmuxLogPath}"
+printf '\n' >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "set-buffer" ]]; then
+  printf '%s' "\${@: -1}" > "${bufferPath}"
+  exit 0
+fi
+if [[ "$cmd" == "show-buffer" ]]; then
+  cat "${bufferPath}"
+  exit 0
+fi
+if [[ "$cmd" == "paste-buffer" ]]; then
+  echo "paste failed" >&2
+  exit 1
+fi
+if [[ "$cmd" == "delete-buffer" ]]; then
+  rm -f "${bufferPath}"
+fi
+exit 0
+`,
+      );
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+
+      const moduleUrl = new URL('../../../dist/scripts/notify-hook/team-tmux-guard.js', import.meta.url).href;
+      const result = runSendPaneInputInChild({
+        fakeBinDir,
+        moduleUrl,
+        paneTarget: '%42',
+        prompt: 'supervisor handoff after verify',
+        submitKeyPresses: 1,
+        typePrompt: true,
+      });
+
+      assert.equal(result.status, 0, result.stderr);
+      const parsed = JSON.parse(result.stdout);
+      assert.equal(parsed.ok, false);
+      assert.equal(parsed.reason, 'buffer_paste_failed');
+
+      const lines = (await readFile(tmuxLogPath, 'utf-8')).trim().split('\n').filter(Boolean);
+      assert.match(lines[0] ?? '', /\[set-buffer\]\[-b\]\[omx-pane-input-/);
+      assert.match(lines[1] ?? '', /\[show-buffer\]\[-b\]\[omx-pane-input-/);
+      assert.match(lines[2] ?? '', /\[send-keys\]\[-t\]\[%42\]\[C-u\]/);
+      assert.match(lines[3] ?? '', /\[paste-buffer\]\[-t\]\[%42\]\[-b\]\[omx-pane-input-.*\]\[-p\]\[-d\]/);
+      assert.match(lines[4] ?? '', /\[delete-buffer\]\[-b\]\[omx-pane-input-/);
+      assert.equal(lines.length, 5);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('reports pane_not_ready with capture context when the pane is not input-ready', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-tmux-guard-'));
     const fakeBinDir = join(cwd, 'fake-bin');

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -1,5 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { OMX_TMUX_HUD_OWNER_ENV, reconcileHudForPromptSubmit } from '../reconcile.js';
 import { HUD_TMUX_HEIGHT_LINES, HUD_TMUX_ULTRAGOAL_HEIGHT_LINES, HUD_TMUX_MIN_LAUNCH_WINDOW_HEIGHT_LINES } from '../constants.js';
 import { OMX_TMUX_HUD_LEADER_PANE_ENV } from '../tmux.js';
@@ -1767,6 +1770,61 @@ describe('reconcileHudForPromptSubmit cramped-window guard (#2754)', () => {
     assert.equal(result.status, 'skipped_window_too_cramped');
     assert.equal(result.paneId, null);
     assert.deepEqual(created, []);
+  });
+
+  it('uses the default tmux window-size reader when production deps omit an injected reader', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-cramped-'));
+    const fakeBinDir = join(cwd, 'fake-bin');
+    const tmuxLogPath = join(cwd, 'tmux.log');
+    const tmuxBin = join(fakeBinDir, 'tmux');
+    const originalPath = process.env.PATH;
+
+    try {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(
+        tmuxBin,
+        `#!/usr/bin/env bash
+set -eu
+printf '[%s]' "$@" >> "${tmuxLogPath}"
+printf '\n' >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  printf '160\t${crampedHeight}'
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  printf '%%1\\037codex\\0370\\0370\\037160\\03724\\03723\\037160\\037${crampedHeight}\\037codex\\037/repo'
+fi
+`,
+      );
+      await chmod(tmuxBin, 0o755);
+      process.env.PATH = `${fakeBinDir}:${originalPath ?? ''}`;
+
+      const created: string[] = [];
+      const result = await reconcileHudForPromptSubmit('/repo', {
+        env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+        sessionId: 'sess-a',
+        sessionIds: ['sess-a'],
+        createHudWatchPane: (_cwd, cmd) => {
+          created.push(cmd);
+          return '%9';
+        },
+        resizeTmuxPane: () => true,
+        unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+        registerHudResizeHook: noOpRegisterHudResizeHook,
+        resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+      });
+
+      assert.equal(result.status, 'skipped_window_too_cramped');
+      assert.equal(result.paneId, null);
+      assert.deepEqual(created, []);
+      const log = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(log, /\[list-panes\]\[-t\]\[%1\]/);
+      assert.match(log, /\[display-message\]\[-p\]\[-t\]\[%1\]\[#\{window_width\}\t#\{window_height\}\]/);
+    } finally {
+      process.env.PATH = originalPath;
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it('creates the HUD on prompt submit when the existing window has room', async () => {

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -382,7 +382,7 @@ export async function reconcileHudForPromptSubmit(
   // recreate the cramped, unreadable 2-line HUD the launch path already
   // declined to add. Default behavior is preserved for normal/unknown heights.
   // (closes #2754)
-  if (hudPaneIds.length === 0 && deps.readCurrentWindowSize) {
+  if (hudPaneIds.length === 0 && (deps.readCurrentWindowSize || !deps.listCurrentWindowPanes)) {
     const readWindowSize = deps.readCurrentWindowSize ?? ((paneId) => readCurrentWindowSize(undefined, paneId));
     const windowHeight = readWindowSize(currentPaneId).height;
     if (isTmuxWindowTooCrampedForHudSplit(windowHeight)) {

--- a/src/scripts/notify-hook/team-tmux-guard.ts
+++ b/src/scripts/notify-hook/team-tmux-guard.ts
@@ -190,10 +190,12 @@ export async function sendPaneInput({
     deleteBufferArgv: pasteArgv.deleteBufferArgv,
   };
 
+  let bufferSet = false;
   try {
     if (typePrompt) {
       try {
         await runProcess('tmux', pasteArgv.setBufferArgv, 3000);
+        bufferSet = true;
       } catch (error) {
         return {
           ok: false,
@@ -254,9 +256,6 @@ export async function sendPaneInput({
       }
       await runProcess('tmux', submit, 3000);
     }
-    if (typePrompt) {
-      await runProcess('tmux', pasteArgv.deleteBufferArgv, 3000).catch(() => {});
-    }
     return { ok: true, sent: true, reason: 'sent', paneTarget: target, argv };
   } catch (error) {
     return {
@@ -267,6 +266,10 @@ export async function sendPaneInput({
       argv,
       error: error instanceof Error ? error.message : safeString(error),
     };
+  } finally {
+    if (bufferSet) {
+      await runProcess('tmux', pasteArgv.deleteBufferArgv, 3000).catch(() => {});
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- make prompt-submit HUD cramped-window protection use the default tmux window-size reader on production-style wiring
- clean tmux safe-paste named buffers in a finally block after successful set-buffer, including show/verify/paste/send failures
- add focused coverage for production-style HUD guard wiring and tmux cleanup failure paths while preserving successful send+Enter behavior

Resolves #2891

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/hud/__tests__/reconcile.test.js dist/hooks/__tests__/notify-hook-team-tmux-guard.test.js`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
