### PR TITLE
Detect root-owned repo artifacts in doctor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
 
           function isTs(path) {
             return /^src\/.*\.(ts|tsx|mts|cts)$/.test(path)
+              || /^src\/compat\/fixtures\//.test(path)
               || /^playground\/.*\.(ts|tsx|js|mjs|cjs|json)$/.test(path);
           }
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -55,6 +55,18 @@ openai_base_url = "http://localhost:8317/v1"
 
 Use your actual proxy URL. If the profile-local `~/.codex/config.toml` is missing `openai_base_url`, Codex may send the proxy-issued key to the default endpoint. That can make setup and doctor look fine while real execution fails with 401-style auth errors.
 
+## Root-owned or non-writable repo artifacts
+
+OMX runtime and planning artifacts under repo-local `.omx/` and `.beads/` should be writable by the same operating-system user that runs `omx`. Files created through `sudo`, containers, or service users can become `root:root` or otherwise non-writable, which later blocks normal agents from appending plans, state, logs, or context artifacts.
+
+`omx doctor` scans `.omx/` and `.beads/` when they exist and reports exact root-owned, owner-mismatched, or non-writable paths. The safe manual repair is:
+
+```bash
+sudo chown -R $(id -u):$(id -g) <repo>
+```
+
+Use the repository root for `<repo>`. `omx doctor --force` attempts automatic ownership repair only when the repo root is owned by the invoking user; otherwise it leaves files unchanged and prints manual remediation guidance.
+
 ## Stale `doctor --team` or dead tmux session state
 
 `omx doctor --team`, `omx team resume`, or startup diagnostics can fail when a previous team state references a tmux session that no longer exists. The state may mention `resume_blocker`, or the dead session may be recorded under `.omx/state/team/<team-name>/config.json` or `manifest.v2.json`.

--- a/src/cli/__tests__/doctor-artifact-ownership.test.ts
+++ b/src/cli/__tests__/doctor-artifact-ownership.test.ts
@@ -48,11 +48,22 @@ describe("repo artifact ownership doctor check", () => {
 			const artifact = join(wd, ".beads", "state.json");
 			await mkdir(join(wd, ".beads"), { recursive: true });
 			await writeFile(artifact, "{}\n");
-
+			const currentUid = 1000;
+			const currentGid = 1000;
 			const check = await checkRepoArtifactOwnership(wd, {
-				currentUid: 1000,
+				currentUid,
 				accessPath: async (path) => {
 					if (path === artifact) throw new Error("not writable");
+				},
+				statPath: async (path) => {
+					const info = await lstat(path);
+					return new Proxy(info, {
+						get(target, property, receiver) {
+							if (property === "uid") return currentUid;
+							if (property === "gid") return currentGid;
+							return Reflect.get(target, property, receiver);
+						},
+					});
 				},
 			});
 

--- a/src/cli/__tests__/doctor-artifact-ownership.test.ts
+++ b/src/cli/__tests__/doctor-artifact-ownership.test.ts
@@ -1,0 +1,146 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, lstat, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+	checkRepoArtifactOwnership,
+	repairRepoArtifactOwnership,
+} from "../doctor.js";
+
+describe("repo artifact ownership doctor check", () => {
+	it("reports root-owned files under .omx/plans with exact remediation guidance", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-artifacts-"));
+		try {
+			const artifact = join(wd, ".omx", "plans", "root-owned.md");
+			await mkdir(join(wd, ".omx", "plans"), { recursive: true });
+			await writeFile(artifact, "# plan\n");
+
+			const check = await checkRepoArtifactOwnership(wd, {
+				currentUid: 1000,
+				statPath: async (path) => {
+					const info = await lstat(path);
+					if (path === artifact) {
+						return new Proxy(info, {
+							get(target, property, receiver) {
+								if (property === "uid") return 0;
+								if (property === "gid") return 0;
+								return Reflect.get(target, property, receiver);
+							},
+						});
+					}
+					return info;
+				},
+			});
+
+			assert.equal(check.status, "warn");
+			assert.match(check.message, /\.omx[\\/]plans[\\/]root-owned\.md \(root-owned uid=0 gid=0\)/);
+			assert.match(check.message, /sudo chown -R \$\(id -u\):\$\(id -g\)/);
+			assert.match(check.message, /omx doctor --force/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("reports non-writable files under repo-local artifact directories", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-artifacts-"));
+		try {
+			const artifact = join(wd, ".beads", "state.json");
+			await mkdir(join(wd, ".beads"), { recursive: true });
+			await writeFile(artifact, "{}\n");
+
+			const check = await checkRepoArtifactOwnership(wd, {
+				currentUid: 1000,
+				accessPath: async (path) => {
+					if (path === artifact) throw new Error("not writable");
+				},
+			});
+
+			assert.equal(check.status, "warn");
+			assert.match(check.message, /\.beads[\\/]state\.json \(not-writable uid=\d+ gid=\d+\)/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("repairs only when the repo root is owned by the current user", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-artifacts-"));
+		try {
+			const artifact = join(wd, ".omx", "plans", "root-owned.md");
+			await mkdir(join(wd, ".omx", "plans"), { recursive: true });
+			await writeFile(artifact, "# plan\n");
+			const calls: string[] = [];
+			const ownerUid = 1000;
+			const ownerGid = 1000;
+
+			const repaired = await repairRepoArtifactOwnership(wd, {
+				currentUid: ownerUid,
+				currentGid: ownerGid,
+				statPath: async (path) => {
+					const info = await lstat(path);
+					return new Proxy(info, {
+						get(target, property, receiver) {
+							if (property === "uid") return path === artifact ? 0 : ownerUid;
+							if (property === "gid") return path === artifact ? 0 : ownerGid;
+							return Reflect.get(target, property, receiver);
+						},
+					});
+				},
+				chownPath: async (path, uid, gid) => {
+					calls.push(`${path}:${uid}:${gid}`);
+				},
+			});
+
+			assert.equal(repaired.repaired, 1);
+			assert.deepEqual(repaired.skipped, []);
+			assert.deepEqual(calls, [`${artifact}:${ownerUid}:${ownerGid}`]);
+
+			const nonWritable = await repairRepoArtifactOwnership(wd, {
+				currentUid: ownerUid,
+				currentGid: ownerGid,
+				statPath: async (path) => {
+					const info = await lstat(path);
+					return new Proxy(info, {
+						get(target, property, receiver) {
+							if (property === "uid") return ownerUid;
+							if (property === "gid") return ownerGid;
+							return Reflect.get(target, property, receiver);
+						},
+					});
+				},
+				accessPath: async (path) => {
+					if (path === artifact) throw new Error("not writable");
+				},
+				chownPath: async () => {
+					assert.fail("writability-only repair should not call chown");
+				},
+			});
+
+			assert.equal(nonWritable.repaired, 0);
+			assert.deepEqual(nonWritable.skipped, [".omx/plans/root-owned.md: not writable by current user"]);
+
+			const blocked = await repairRepoArtifactOwnership(wd, {
+				currentUid: ownerUid,
+				currentGid: ownerGid,
+				statPath: async (path) => {
+					const info = await lstat(path);
+					return new Proxy(info, {
+						get(target, property, receiver) {
+							if (property === "uid") return ownerUid + 1;
+							if (property === "gid") return ownerGid;
+							return Reflect.get(target, property, receiver);
+						},
+					});
+				},
+				chownPath: async () => {
+					assert.fail("unsafe repair should not call chown");
+				},
+			});
+
+			assert.equal(blocked.repaired, 0);
+			assert.deepEqual(blocked.skipped, ["repo root is not owned by the current user"]);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2,10 +2,10 @@
  * omx doctor - Validate oh-my-codex installation
  */
 
-import { existsSync, readFileSync } from "fs";
-import { mkdtemp, readdir, readFile, rm } from "fs/promises";
+import { constants, existsSync, readFileSync } from "fs";
+import { access, chown, lstat, mkdtemp, readdir, readFile, rm } from "fs/promises";
 import { spawnSync } from "child_process";
-import { basename, join } from "path";
+import { basename, join, relative } from "path";
 import { tmpdir } from "os";
 import {
 	codexHome,
@@ -96,6 +96,37 @@ interface Check {
 	status: "pass" | "warn" | "fail";
 	message: string;
 }
+
+interface RepoArtifactIssue {
+	path: string;
+	type: "ownership" | "writability";
+	reason: "root-owned" | "owner-mismatch" | "not-writable";
+	uid?: number;
+	gid?: number;
+}
+
+interface RepoArtifactStats {
+	uid?: number;
+	gid?: number;
+	isSymbolicLink(): boolean;
+	isDirectory(): boolean;
+}
+
+interface RepoArtifactScanOptions {
+	currentUid?: number;
+	currentGid?: number;
+	maxExamples?: number;
+	statPath?: (path: string) => Promise<RepoArtifactStats>;
+	readDir?: (path: string) => Promise<string[]>;
+	accessPath?: (path: string, mode: number) => Promise<void>;
+}
+
+interface RepoArtifactRepairOptions extends RepoArtifactScanOptions {
+	chownPath?: (path: string, uid: number, gid: number) => Promise<void>;
+}
+
+const REPO_ARTIFACT_DIRS = [".omx", ".beads"] as const;
+
 
 interface NativeHookDistSmokeOptions {
 	packageRoot?: string;
@@ -233,6 +264,27 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 			: scopeResolution.source === "config"
 				? " (inferred from Codex plugin config)"
 			: "";
+	if (options.force) {
+		if (options.dryRun) {
+			const check = await checkRepoArtifactOwnership(cwd);
+			if (check.status !== "pass") {
+				console.log(`Dry run: ${check.message}`);
+				console.log();
+			}
+		} else {
+			const repair = await repairRepoArtifactOwnership(cwd);
+			if (repair.repaired > 0 || repair.skipped.length > 0) {
+				console.log(
+					`Repo artifact ownership repair: ${repair.repaired} path(s) repaired${
+						repair.skipped.length > 0
+							? `, ${repair.skipped.length} skipped (${repair.skipped.join("; ")})`
+							: ""
+					}`,
+				);
+				console.log();
+			}
+		}
+	}
 
 	console.log("oh-my-codex doctor");
 	console.log("==================\n");
@@ -336,6 +388,7 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
 	// Check 8: State directory
 	checks.push(checkDirectory("State dir", paths.stateDir));
+	checks.push(await checkRepoArtifactOwnership(cwd));
 
 	// Check 9: MCP servers configured
 	checks.push(
@@ -865,6 +918,178 @@ function checkDirectory(name: string, path: string): Check {
 		return { name, status: "pass", message: path };
 	}
 	return { name, status: "warn", message: `${path} (not created yet)` };
+}
+
+function currentProcessUid(): number | undefined {
+	return typeof process.getuid === "function" ? process.getuid() : undefined;
+}
+
+function currentProcessGid(): number | undefined {
+	return typeof process.getgid === "function" ? process.getgid() : undefined;
+}
+
+function remediationCommand(repoRoot: string): string {
+	return `sudo chown -R $(id -u):$(id -g) ${JSON.stringify(repoRoot)}`;
+}
+
+function formatArtifactPath(repoRoot: string, path: string): string {
+	const rel = relative(repoRoot, path);
+	return rel === "" ? "." : rel;
+}
+
+function formatArtifactIssue(repoRoot: string, issue: RepoArtifactIssue): string {
+	const owner =
+		typeof issue.uid === "number" && typeof issue.gid === "number"
+			? ` uid=${issue.uid} gid=${issue.gid}`
+			: "";
+	return `${formatArtifactPath(repoRoot, issue.path)} (${issue.reason}${owner})`;
+}
+
+function shouldReportOwnerMismatch(
+	uid: number | undefined,
+	currentUid: number | undefined,
+): boolean {
+	if (typeof uid !== "number") return false;
+	if (uid === 0) return true;
+	return typeof currentUid === "number" && uid !== currentUid;
+}
+
+function isOwnershipIssue(issue: RepoArtifactIssue): boolean {
+	return issue.type === "ownership";
+}
+
+async function collectRepoArtifactOwnershipIssues(
+	repoRoot: string,
+	options: RepoArtifactScanOptions = {},
+): Promise<RepoArtifactIssue[]> {
+	if (process.platform === "win32") return [];
+	const currentUid = options.currentUid ?? currentProcessUid();
+	const maxExamples = options.maxExamples ?? 20;
+	const statPath = options.statPath ?? lstat;
+	const readDir = options.readDir ?? readdir;
+	const accessPath = options.accessPath ?? access;
+	const issues: RepoArtifactIssue[] = [];
+	const visited = new Set<string>();
+
+	async function visit(path: string): Promise<void> {
+		if (issues.length >= maxExamples) return;
+		let info: RepoArtifactStats;
+		try {
+			info = await statPath(path);
+		} catch {
+			return;
+		}
+		if (info.isSymbolicLink()) return;
+
+		const uid = typeof info.uid === "number" ? info.uid : undefined;
+		const gid = typeof info.gid === "number" ? info.gid : undefined;
+		let reason: RepoArtifactIssue["reason"] | null = null;
+		if (uid === 0) reason = "root-owned";
+		else if (shouldReportOwnerMismatch(uid, currentUid)) reason = "owner-mismatch";
+		else {
+			try {
+				await accessPath(path, constants.W_OK);
+			} catch {
+				reason = "not-writable";
+			}
+		}
+		if (reason) {
+			issues.push({
+				path,
+				reason,
+				type: reason === "not-writable" ? "writability" : "ownership",
+				uid,
+				gid,
+			});
+		}
+		if (issues.length >= maxExamples || !info.isDirectory()) return;
+		if (visited.has(path)) return;
+		visited.add(path);
+
+		let entries: string[];
+		try {
+			entries = await readDir(path);
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			await visit(join(path, entry));
+			if (issues.length >= maxExamples) return;
+		}
+	}
+
+	for (const dir of REPO_ARTIFACT_DIRS) {
+		const root = join(repoRoot, dir);
+		if (existsSync(root)) await visit(root);
+	}
+	return issues;
+}
+
+export async function checkRepoArtifactOwnership(
+	repoRoot: string,
+	options: RepoArtifactScanOptions = {},
+): Promise<Check> {
+	const issues = await collectRepoArtifactOwnershipIssues(repoRoot, options);
+	if (issues.length === 0) {
+		return {
+			name: "Repo artifact ownership",
+			status: "pass",
+			message: "repo-local .omx/.beads artifacts are writable by the current user",
+		};
+	}
+
+	const examples = issues
+		.slice(0, options.maxExamples ?? 5)
+		.map((issue) => formatArtifactIssue(repoRoot, issue))
+		.join("; ");
+	const repair = remediationCommand(repoRoot);
+	return {
+		name: "Repo artifact ownership",
+		status: "warn",
+		message: `${issues.length} root-owned, owner-mismatched, or non-writable repo artifact(s): ${examples}. Safe remediation: ${repair}. Automatic repair is only run by \"omx doctor --force\" when the repo root is owned by the current user.`,
+	};
+}
+
+export async function repairRepoArtifactOwnership(
+	repoRoot: string,
+	options: RepoArtifactRepairOptions = {},
+): Promise<{ repaired: number; skipped: string[] }> {
+	if (process.platform === "win32") return { repaired: 0, skipped: [] };
+	const currentUid = options.currentUid ?? currentProcessUid();
+	const currentGid = options.currentGid ?? currentProcessGid();
+	if (typeof currentUid !== "number" || typeof currentGid !== "number") {
+		return { repaired: 0, skipped: ["current uid/gid unavailable"] };
+	}
+	const statPath = options.statPath ?? lstat;
+	const repoInfo = await statPath(repoRoot);
+	if (repoInfo.uid !== currentUid) {
+		return { repaired: 0, skipped: ["repo root is not owned by the current user"] };
+	}
+	const issues = await collectRepoArtifactOwnershipIssues(repoRoot, {
+		...options,
+		currentUid,
+		currentGid,
+		maxExamples: Number.MAX_SAFE_INTEGER,
+		statPath,
+	});
+	const ownershipIssues = issues.filter(isOwnershipIssue);
+	const writabilityIssues = issues.filter((issue) => !isOwnershipIssue(issue));
+	const chownPath = options.chownPath ?? chown;
+	let repaired = 0;
+	const skipped: string[] = [];
+	for (const issue of writabilityIssues) {
+		skipped.push(`${formatArtifactPath(repoRoot, issue.path)}: not writable by current user`);
+	}
+	for (const issue of ownershipIssues) {
+		try {
+			await chownPath(issue.path, currentUid, currentGid);
+			repaired++;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			skipped.push(`${formatArtifactPath(repoRoot, issue.path)}: ${message}`);
+		}
+	}
+	return { repaired, skipped };
 }
 
 function validateToml(content: string): string | null {

--- a/src/compat/fixtures/doctor/install-onboarding.stdout.txt
+++ b/src/compat/fixtures/doctor/install-onboarding.stdout.txt
@@ -18,6 +18,7 @@ Resolved setup scope: user
   [OK] Legacy skill roots: no ~/.agents/skills overlap detected
   [!!] AGENTS.md: not found in <CODEX_HOME>/AGENTS.md (run omx setup --scope user)
   [!!] State dir: <REPO_STATE_DIR> (not created yet)
+  [OK] Repo artifact ownership: repo-local .omx/.beads artifacts are writable by the current user
   [OK] MCP Servers: 1 user-managed MCP server(s) preserved; first-party OMX MCP omitted by default
   [OK] Prompt triage: config: enabled (default)
 

--- a/src/verification/__tests__/ci-rust-gates.test.ts
+++ b/src/verification/__tests__/ci-rust-gates.test.ts
@@ -168,6 +168,11 @@ describe('CI Rust gates', () => {
     assert.equal(sourceChange.full_suite, 'false');
     assert.equal(sourceChange.ts_changed, 'true');
 
+    const compatFixtureChange = classifyChangedPaths(['src/compat/fixtures/doctor/install-onboarding.stdout.txt']);
+    assert.equal(compatFixtureChange.full_suite, 'false');
+    assert.equal(compatFixtureChange.ts_changed, 'true');
+    assert.equal(compatFixtureChange.reason, 'targeted');
+
     const workflowChange = classifyChangedPaths(['.github/workflows/ci.yml']);
     assert.equal(workflowChange.full_suite, 'true');
     assert.equal(workflowChange.shared_config_changed, 'true');


### PR DESCRIPTION
Resolves #2869.

## Summary
- add `omx doctor` scanning for root-owned, owner-mismatched, or non-writable repo-local `.omx/` and `.beads/` artifacts
- add guarded `omx doctor --force` ownership repair that only chowns detected ownership issues when the repo root is owned by the invoking user
- document safe manual remediation for root-owned repo artifacts
- add focused doctor tests for root-owned, non-writable, and unsafe-repair behavior

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/doctor-artifact-ownership.test.js`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*