### PR TITLE
Resolve #2870: add model routing launch diagnostics

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1552,6 +1552,7 @@ describe("resolveWorkerSparkModel", () => {
   });
 
   it("reads low-complexity team model from config when codexHomeOverride is provided", async () => {
+    // Intentional legacy model fixture: verifies an explicit user override is routed to workers unchanged.
     const codexHome = await mkdtemp(join(tmpdir(), "omx-codex-home-"));
     try {
       await writeFile(

--- a/src/config/__tests__/models.test.ts
+++ b/src/config/__tests__/models.test.ts
@@ -204,6 +204,7 @@ describe('getModelForMode', () => {
   });
 
   it('returns low-complexity team model when configured', async () => {
+    // Intentional legacy model fixture: verifies explicit user config is preserved, not used as a runtime default.
     await writeConfig({ models: { team_low_complexity: 'gpt-4.1-mini' } });
     assert.equal(getTeamLowComplexityModel(), 'gpt-4.1-mini');
   });
@@ -289,6 +290,7 @@ describe('getModelForMode', () => {
   });
 
   it('keeps explicit low-complexity config ahead of OMX_DEFAULT_SPARK_MODEL', async () => {
+    // Intentional legacy model fixture: explicit user config must outrank current spark defaults.
     process.env.OMX_DEFAULT_SPARK_MODEL = 'gpt-5.3-codex-spark-fast';
     await writeConfig({ models: { team_low_complexity: 'gpt-4.1-mini' } });
     assert.equal(getTeamLowComplexityModel(), 'gpt-4.1-mini');

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -9,6 +9,7 @@ import {
   resolveAgentDefaultModel,
   resolveAgentReasoningEffort,
   resolveTeamWorkerLaunchArgs,
+  resolveTeamWorkerLaunchDiagnostics,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
   resolveTeamLowComplexityDefaultModel,
 } from '../model-contract.js';
@@ -215,6 +216,52 @@ describe('team model contract', () => {
       assert.equal(resolveAgentReasoningEffort('explore'), 'low');
       assert.equal(resolveAgentDefaultModel('style-reviewer'), expectedLowComplexityModel());
       assert.equal(resolveAgentReasoningEffort('style-reviewer'), 'low');
+    });
+  });
+
+  it('reports requested versus actual worker launch resolution for role defaults', () => {
+    withIsolatedDefaultModelEnv(() => {
+      assert.deepEqual(
+        resolveTeamWorkerLaunchDiagnostics({
+          requestedAgentType: 'architect',
+          fallbackModel: resolveAgentDefaultModel('architect'),
+          preferredReasoning: resolveAgentReasoningEffort('architect'),
+        }),
+        {
+          requestedAgentType: 'architect',
+          requestedDefaultModel: 'gpt-5.5',
+          requestedDefaultReasoning: 'high',
+          actualModel: 'gpt-5.5',
+          actualReasoning: 'high',
+          modelSource: 'fallback',
+          reasoningSource: 'role-default',
+          inheritedParentModel: false,
+          actualLaunchArgs: ['-c', 'model_reasoning_effort="high"', '--model', 'gpt-5.5'],
+        },
+      );
+    });
+  });
+
+  it('reports inherited parent model separately from role default reasoning', () => {
+    withIsolatedDefaultModelEnv(() => {
+      const diagnostics = resolveTeamWorkerLaunchDiagnostics({
+        requestedAgentType: 'explore',
+        inheritedArgs: ['--model', 'parent-session-model'],
+        fallbackModel: resolveAgentDefaultModel('explore'),
+        preferredReasoning: resolveAgentReasoningEffort('explore'),
+      });
+
+      assert.equal(diagnostics.requestedDefaultModel, expectedLowComplexityModel());
+      assert.equal(diagnostics.actualModel, 'parent-session-model');
+      assert.equal(diagnostics.modelSource, 'inherited');
+      assert.equal(diagnostics.reasoningSource, 'role-default');
+      assert.equal(diagnostics.inheritedParentModel, true);
+      assert.deepEqual(diagnostics.actualLaunchArgs, [
+        '-c',
+        'model_reasoning_effort="low"',
+        '--model',
+        'parent-session-model',
+      ]);
     });
   });
 });

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -562,6 +562,7 @@ describe('runtime', () => {
   });
 
   it('resolveWorkerLaunchArgsFromEnv reads low-complexity model from config when present', async () => {
+    // Intentional legacy model fixture: verifies explicit low-complexity config survives worker launch resolution.
     await withIsolatedDefaultModelEnvAsync(async () => {
       const previousCodexHome = process.env.CODEX_HOME;
       const tempCodexHome = await mkdtemp(join(tmpdir(), 'omx-codex-home-'));

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -33,6 +33,21 @@ export interface ParsedTeamWorkerLaunchArgs {
   modelOverride: string | null;
 }
 
+export type TeamWorkerLaunchModelSource = 'env' | 'inherited' | 'fallback' | 'none';
+export type TeamWorkerLaunchReasoningSource = 'explicit' | 'role-default' | 'none';
+
+export interface ResolvedTeamWorkerLaunchDiagnostics {
+  requestedAgentType?: string;
+  requestedDefaultModel?: string;
+  requestedDefaultReasoning?: TeamReasoningEffort;
+  actualModel?: string;
+  actualReasoning?: TeamReasoningEffort;
+  modelSource: TeamWorkerLaunchModelSource;
+  reasoningSource: TeamWorkerLaunchReasoningSource;
+  inheritedParentModel: boolean;
+  actualLaunchArgs: string[];
+}
+
 export interface ResolveTeamWorkerLaunchArgsOptions {
   existingRaw?: string;
   inheritedArgs?: string[];
@@ -80,6 +95,42 @@ function normalizeOptionalReasoning(reasoning?: TeamReasoningEffort | string | n
     return normalized;
   }
   return undefined;
+}
+
+function extractReasoningEffort(value: string | null): TeamReasoningEffort | undefined {
+  return normalizeOptionalReasoning(
+    value ? extractConfigStringValue(value, REASONING_KEY) : null,
+  );
+}
+
+function resolveTeamWorkerLaunchDiagnosticsFromParts(params: {
+  envParsed: ParsedTeamWorkerLaunchArgs;
+  inheritedParsed: ParsedTeamWorkerLaunchArgs;
+  fallbackModel?: string;
+  preferredReasoning?: TeamReasoningEffort;
+  actualLaunchArgs: string[];
+  requestedAgentType?: string;
+}): ResolvedTeamWorkerLaunchDiagnostics {
+  const envModel = normalizeOptionalModel(params.envParsed.modelOverride);
+  const inheritedModel = normalizeOptionalModel(params.inheritedParsed.modelOverride);
+  const fallbackModel = normalizeOptionalModel(params.fallbackModel);
+  const actualParsed = parseTeamWorkerLaunchArgs(params.actualLaunchArgs);
+  const requestedDefaultReasoning = normalizeOptionalReasoning(params.preferredReasoning);
+  const explicitReasoning = extractReasoningEffort(
+    params.envParsed.reasoningOverride ?? params.inheritedParsed.reasoningOverride,
+  );
+
+  return {
+    requestedAgentType: params.requestedAgentType,
+    requestedDefaultModel: fallbackModel,
+    requestedDefaultReasoning,
+    actualModel: normalizeOptionalModel(actualParsed.modelOverride),
+    actualReasoning: extractReasoningEffort(actualParsed.reasoningOverride),
+    modelSource: envModel ? 'env' : inheritedModel ? 'inherited' : fallbackModel ? 'fallback' : 'none',
+    reasoningSource: explicitReasoning ? 'explicit' : requestedDefaultReasoning ? 'role-default' : 'none',
+    inheritedParentModel: !envModel && Boolean(inheritedModel),
+    actualLaunchArgs: [...params.actualLaunchArgs],
+  };
 }
 
 export function splitWorkerLaunchArgs(raw: string | undefined): string[] {
@@ -204,6 +255,25 @@ export function resolveTeamWorkerLaunchArgs(options: ResolveTeamWorkerLaunchArgs
   const selectedModel = envModel ?? inheritedModel ?? fallbackModel;
   const selectedModelProvider = envParsed.modelProviderOverride ?? inheritedParsed.modelProviderOverride ?? undefined;
   return normalizeTeamWorkerLaunchArgs(allArgs, selectedModel, options.preferredReasoning, selectedModelProvider);
+}
+
+export function resolveTeamWorkerLaunchDiagnostics(
+  options: ResolveTeamWorkerLaunchArgsOptions & { requestedAgentType?: string },
+): ResolvedTeamWorkerLaunchDiagnostics {
+  const envArgs = splitWorkerLaunchArgs(options.existingRaw);
+  const inheritedArgs = options.inheritedArgs ?? [];
+  const envParsed = parseTeamWorkerLaunchArgs(envArgs);
+  const inheritedParsed = parseTeamWorkerLaunchArgs(inheritedArgs);
+  const actualLaunchArgs = resolveTeamWorkerLaunchArgs(options);
+
+  return resolveTeamWorkerLaunchDiagnosticsFromParts({
+    envParsed,
+    inheritedParsed,
+    fallbackModel: options.fallbackModel,
+    preferredReasoning: options.preferredReasoning,
+    actualLaunchArgs,
+    requestedAgentType: options.requestedAgentType,
+  });
 }
 
 export function resolveAgentReasoningEffort(

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -124,7 +124,6 @@ import {
   resolveTeamWorkerLaunchDiagnostics,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
   parseTeamWorkerLaunchArgs,
-  splitWorkerLaunchArgs,
   resolveAgentDefaultModel,
   resolveAgentReasoningEffort,
   type TeamReasoningEffort,

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -121,6 +121,7 @@ import { codexPromptsDir } from '../utils/paths.js';
 import { isTerminalPhase, type TeamPhase, type TerminalPhase } from './orchestrator.js';
 import {
   resolveTeamWorkerLaunchArgs,
+  resolveTeamWorkerLaunchDiagnostics,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
   parseTeamWorkerLaunchArgs,
   splitWorkerLaunchArgs,
@@ -2332,34 +2333,32 @@ export function resolveWorkerLaunchArgsFromEnv(
     ? ['--model', inheritedLeaderModel.trim()]
     : [];
   const fallbackModel = resolveAgentDefaultModel(agentType, env.CODEX_HOME);
-
-  // Detect if an explicit reasoning override exists before resolving (for log source labelling)
-  const preEnvArgs = splitWorkerLaunchArgs(env.OMX_TEAM_WORKER_LAUNCH_ARGS);
-  const preAllArgs = [...preEnvArgs, ...inheritedArgs];
-  const hasExplicitReasoning = parseTeamWorkerLaunchArgs(preAllArgs).reasoningOverride !== null;
-
-  const resolved = resolveTeamWorkerLaunchArgs({
+  const diagnostics = resolveTeamWorkerLaunchDiagnostics({
     existingRaw: env.OMX_TEAM_WORKER_LAUNCH_ARGS,
     inheritedArgs,
     fallbackModel,
     preferredReasoning,
+    requestedAgentType: agentType,
   });
 
-  // Extract resolved model and thinking level from result args for startup log
-  const resolvedParsed = parseTeamWorkerLaunchArgs(resolved);
-  const resolvedModel = resolvedParsed.modelOverride ?? fallbackModel ?? 'default';
-  const reasoningMatch = resolvedParsed.reasoningOverride?.match(/model_reasoning_effort\s*=\s*"?(\w+)"?/);
-  const thinkingLevel = reasoningMatch?.[1] ?? 'none';
-  const source = hasExplicitReasoning
-    ? 'explicit'
-    : (preferredReasoning ? 'role-default' : 'none/default-none');
+  const resolved = diagnostics.actualLaunchArgs;
+  const resolvedModel = diagnostics.actualModel ?? diagnostics.requestedDefaultModel ?? 'default';
+  const thinkingLevel = diagnostics.actualReasoning ?? 'none';
+  const source = diagnostics.reasoningSource === 'none'
+    ? 'none/default-none'
+    : diagnostics.reasoningSource;
+  const modelSource = diagnostics.modelSource;
+  const inheritedParentModel = diagnostics.inheritedParentModel ? 'yes' : 'no';
+  const requestedRole = diagnostics.requestedAgentType ?? 'unknown';
+  const requestedDefaultModel = diagnostics.requestedDefaultModel ?? 'none';
+  const requestedDefaultReasoning = diagnostics.requestedDefaultReasoning ?? 'none';
   const effectiveWorkerCli = workerCliOverride ?? resolveEffectiveWorkerCliForStartupLog(resolved, env);
   if (effectiveWorkerCli === 'claude') {
     console.log('[omx:team] worker startup resolution: model=claude source=local-settings');
   } else if (effectiveWorkerCli === 'gemini') {
     console.log('[omx:team] worker startup resolution: model=gemini source=local-settings');
   } else {
-    console.log(`[omx:team] worker startup resolution: model=${resolvedModel} thinking_level=${thinkingLevel} source=${source}`);
+    console.log(`[omx:team] worker startup resolution: requested_role=${requestedRole} requested_default_model=${requestedDefaultModel} requested_default_reasoning=${requestedDefaultReasoning} actual_model=${resolvedModel} thinking_level=${thinkingLevel} model_source=${modelSource} reasoning_source=${source} inherited_parent_model=${inheritedParentModel}`);
   }
 
   return resolved;


### PR DESCRIPTION
## Summary
- add a structured team worker launch diagnostics resolver that records requested role/default model/reasoning versus actual worker launch args
- expand worker startup logs with model source, reasoning source, and parent-model inheritance visibility
- classify all remaining `gpt-4.1-mini` references as intentional explicit-config fixtures and cover frontier/spark/standard-ish role paths via focused tests

## Audit summary
- `src/cli/__tests__/index.test.ts`: intentional legacy fixture for explicit user low-complexity config routed by `--spark`
- `src/config/__tests__/models.test.ts`: intentional legacy fixtures for explicit config precedence over current defaults
- `src/team/__tests__/runtime.test.ts`: intentional legacy fixture proving explicit low-complexity config survives worker launch resolution
- no production `gpt-4.1-mini` runtime default remains in the audited paths

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/team/__tests__/model-contract.test.js dist/team/__tests__/runtime.test.js dist/agents/__tests__/native-config.test.js dist/config/__tests__/models.test.js dist/cli/__tests__/index.test.js`

Resolves #2870

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*