### PR TITLE
Fix HUD stale autopilot reporting

### DIFF
--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -199,6 +199,116 @@ describe('CLI session-scoped state parity', () => {
     }
   });
 
+  it('reports stale current-autopilot in status when no authoritative active modes exist', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-status-stale-current-autopilot-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: 'sess-stale-autopilot' }, null, 2));
+      const currentAutopilotPath = join(stateDir, 'current-autopilot.json');
+      const currentAutopilot = {
+        active: true,
+        current_phase: 'complete',
+        session_id: 'sess-stale-autopilot',
+        tmux_pane_id: '%42',
+      };
+      await writeFile(currentAutopilotPath, JSON.stringify(currentAutopilot, null, 2));
+
+      const statusResult = runOmx(wd, 'status');
+      assert.equal(statusResult.status, 0, statusResult.stderr || statusResult.stdout);
+      assert.match(statusResult.stdout, /autopilot: STALE \(phase: complete\)/);
+      assert.doesNotMatch(statusResult.stdout, /No active modes\./);
+
+      const listResult = runOmx(wd, 'state', 'list-active', '--json');
+      assert.equal(listResult.status, 0, listResult.stderr || listResult.stdout);
+      assert.deepEqual(JSON.parse(listResult.stdout), { active_modes: [] });
+      assert.deepEqual(JSON.parse(await readFile(currentAutopilotPath, 'utf-8')), currentAutopilot);
+      assert.equal(statusResult.stdout.trim(), 'autopilot: STALE (phase: complete)');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('reports stale current-autopilot alongside inactive authoritative modes only', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-status-stale-current-autopilot-with-inactive-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-stale-autopilot-inactive';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      const currentAutopilotPath = join(stateDir, 'current-autopilot.json');
+      const currentAutopilot = {
+        active: true,
+        current_phase: 'complete',
+        session_id: sessionId,
+        tmux_pane_id: '%43',
+      };
+      await writeFile(currentAutopilotPath, JSON.stringify(currentAutopilot, null, 2));
+      await writeFile(join(sessionDir, 'deep-interview-state.json'), JSON.stringify({
+        active: false,
+        mode: 'deep-interview',
+        current_phase: 'cleared',
+      }, null, 2));
+
+      const statusResult = runOmx(wd, 'status');
+      assert.equal(statusResult.status, 0, statusResult.stderr || statusResult.stdout);
+      assert.match(statusResult.stdout, /deep-interview: inactive \(phase: cleared\)/);
+      assert.match(statusResult.stdout, /autopilot: STALE \(phase: complete\)/);
+      assert.doesNotMatch(statusResult.stdout, /No active modes\./);
+      assert.deepEqual(JSON.parse(await readFile(currentAutopilotPath, 'utf-8')), currentAutopilot);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers authoritative active autopilot over stale current-autopilot in status', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-status-active-autopilot-precedence-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-active-autopilot';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(join(stateDir, 'current-autopilot.json'), JSON.stringify({
+        active: true,
+        current_phase: 'complete',
+        session_id: 'stale-session',
+        tmux_pane_id: '%99',
+      }, null, 2));
+      await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'ralplan',
+      }, null, 2));
+
+      const statusResult = runOmx(wd, 'status');
+      assert.equal(statusResult.status, 0, statusResult.stderr || statusResult.stdout);
+      assert.match(statusResult.stdout, /autopilot: ACTIVE \(phase: ralplan\)/);
+      assert.doesNotMatch(statusResult.stdout, /STALE/);
+      assert.doesNotMatch(statusResult.stdout, /phase: complete/);
+      assert.doesNotMatch(statusResult.stdout, /No active modes\./);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores unreportable current-autopilot in status', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-status-unreportable-current-autopilot-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'current-autopilot.json'), JSON.stringify({ active: true }, null, 2));
+
+      const statusResult = runOmx(wd, 'status');
+      assert.equal(statusResult.status, 0, statusResult.stderr || statusResult.stdout);
+      assert.match(statusResult.stdout, /No active modes\./);
+      assert.doesNotMatch(statusResult.stdout, /STALE/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('cancels linked ultrawork when Ralph is active', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-ralph-link-'));
     try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2577,6 +2577,33 @@ export async function main(args: string[]): Promise<void> {
   }
 }
 
+type StaleCurrentAutopilotStatus = {
+  phase: string;
+};
+
+function sanitizedStatusString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+async function readStaleCurrentAutopilotStatus(cwd: string): Promise<StaleCurrentAutopilotStatus | null> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(join(getBaseStateDir(cwd), "current-autopilot.json"), "utf-8"));
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const state = parsed as Record<string, unknown>;
+  if (state.active !== true) return null;
+  const phase = sanitizedStatusString(state.current_phase) ?? sanitizedStatusString(state.currentPhase);
+  const sessionId = sanitizedStatusString(state.session_id) ?? sanitizedStatusString(state.sessionId);
+  const tmuxPaneId = sanitizedStatusString(state.tmux_pane_id) ?? sanitizedStatusString(state.tmuxPaneId);
+  if (!phase && !sessionId && !tmuxPaneId) return null;
+  return { phase: phase ?? "active" };
+}
+
 async function showStatus(): Promise<void> {
   const { readFile } = await import("fs/promises");
   const cwd = process.cwd();
@@ -2598,15 +2625,24 @@ async function showStatus(): Promise<void> {
       }
       return false;
     };
-    if (!(await hasActiveWorkflowMode(refs))) {
+    let hasAuthoritativeActiveMode = await hasActiveWorkflowMode(refs);
+    if (!hasAuthoritativeActiveMode) {
       const runDirRefs = await listHookVisibleRunDirStateRefs(cwd);
-      if (await hasActiveWorkflowMode(runDirRefs)) refs = runDirRefs;
+      if (await hasActiveWorkflowMode(runDirRefs)) {
+        refs = runDirRefs;
+        hasAuthoritativeActiveMode = true;
+      }
     }
     const states = refs.map((ref) => ref.path);
     const ultragoalState = await readUltragoalState(cwd).catch(() => null);
     if (states.length === 0) {
       if (ultragoalState?.active) {
         console.log(`ultragoal: ACTIVE (phase: ${ultragoalState.status})`);
+        return;
+      }
+      const staleAutopilot = await readStaleCurrentAutopilotStatus(cwd);
+      if (staleAutopilot) {
+        console.log(`autopilot: STALE (phase: ${staleAutopilot.phase})`);
         return;
       }
       console.log("No active modes.");
@@ -2630,6 +2666,12 @@ async function showStatus(): Promise<void> {
     }
     if (ultragoalState?.active) {
       console.log(`ultragoal: ACTIVE (phase: ${ultragoalState.status})`);
+    }
+    if (!hasAuthoritativeActiveMode && !ultragoalState?.active) {
+      const staleAutopilot = await readStaleCurrentAutopilotStatus(cwd);
+      if (staleAutopilot) {
+        console.log(`autopilot: STALE (phase: ${staleAutopilot.phase})`);
+      }
     }
   } catch (err) {
     logCliOperationFailure(err);

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -1030,6 +1030,71 @@ describe('readAllState canonical skill precedence', () => {
     });
   });
 
+  it('reports stale current-autopilot when authoritative HUD state is inactive', async () => {
+    await withTempRepo('omx-hud-current-autopilot-stale-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-current-autopilot-stale';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd }));
+      await writeFile(join(rootStateDir, 'current-autopilot.json'), JSON.stringify({
+        active: true,
+        current_phase: 'complete',
+        session_id: sessionId,
+        tmux_pane_id: '%10',
+      }));
+
+      const state = await readAllState(cwd);
+      const rendered = stripSgr(renderHud(state, 'focused'));
+
+      assert.equal(state.autopilot, null);
+      assert.equal(state.staleAutopilot?.active, true);
+      assert.equal(state.staleAutopilot?.source, 'current-autopilot-stale');
+      assert.equal(state.staleAutopilot?.current_phase, 'complete');
+      assert.equal(state.staleAutopilot?.session_id, sessionId);
+      assert.equal(state.staleAutopilot?.tmux_pane_id, '%10');
+      assert.match(rendered, /autopilot:stale:complete/);
+      assert.doesNotMatch(rendered, /No active modes/);
+    });
+  });
+
+  it('prefers authoritative active autopilot over stale current-autopilot mirror', async () => {
+    await withTempRepo('omx-hud-current-autopilot-authoritative-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-current-autopilot-authoritative';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'autopilot',
+        phase: 'ralplan',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', phase: 'ralplan', active: true, session_id: sessionId }],
+      }));
+      await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'ralplan',
+        session_id: sessionId,
+      }));
+      await writeFile(join(rootStateDir, 'current-autopilot.json'), JSON.stringify({
+        active: true,
+        current_phase: 'complete',
+        session_id: sessionId,
+        tmux_pane_id: '%10',
+      }));
+
+      const state = await readAllState(cwd);
+      const rendered = stripSgr(renderHud(state, 'focused'));
+
+      assert.equal(state.staleAutopilot, null);
+      assert.equal(state.autopilot?.current_phase, 'ralplan');
+      assert.match(rendered, /autopilot:ralplan/);
+      assert.doesNotMatch(rendered, /autopilot:stale/);
+    });
+  });
+
   it('does not surface root canonical workflow entries without current-session ownership', async () => {
     await withTempRepo('omx-hud-root-stale-owner-', async (cwd) => {
       const rootStateDir = join(cwd, '.omx', 'state');

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -105,6 +105,12 @@ function renderAutopilot(ctx: HudRenderContext): string | null {
   return yellow(`autopilot:${phase}`);
 }
 
+function renderStaleAutopilot(ctx: HudRenderContext): string | null {
+  if (!ctx.staleAutopilot) return null;
+  const phase = sanitizeDynamicText(ctx.staleAutopilot.current_phase || 'active') || 'active';
+  return yellow(`autopilot:stale:${phase}`);
+}
+
 function renderRalplan(ctx: HudRenderContext): string | null {
   if (!ctx.ralplan) return null;
   const iteration = ctx.ralplan.iteration;
@@ -298,6 +304,7 @@ const MINIMAL_ELEMENTS: ElementRenderer[] = [
   renderCodeReview,
   renderUltraqa,
   renderExecutionSummary,
+  renderStaleAutopilot,
   renderTurns,
 ];
 
@@ -312,6 +319,7 @@ const FOCUSED_ELEMENTS: ElementRenderer[] = [
   renderCodeReview,
   renderUltraqa,
   renderExecutionSummary,
+  renderStaleAutopilot,
   renderTurns,
   renderTokens,
   renderQuota,
@@ -330,6 +338,7 @@ const FULL_ELEMENTS: ElementRenderer[] = [
   renderCodeReview,
   renderUltraqa,
   renderExecutionSummary,
+  renderStaleAutopilot,
   renderTurns,
   renderTokens,
   renderQuota,

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -51,6 +51,10 @@ async function readAuthoritativeModeState<T>(cwd: string, mode: string): Promise
   return readJsonFile<T>(getStateFilePath(`${mode}-state.json`, cwd, sessionId));
 }
 
+async function readCurrentAutopilotState(cwd: string): Promise<AutopilotStateForHud | null> {
+  return readJsonFile<AutopilotStateForHud>(join(getBaseStateDir(cwd), 'current-autopilot.json'));
+}
+
 function isValidPreset(value: unknown): value is ResolvedHudConfig['preset'] {
   return value === 'minimal' || value === 'focused' || value === 'full';
 }
@@ -497,6 +501,26 @@ function activeAutopilotPhase(autopilot: AutopilotStateForHud | null): string | 
   return sanitizeOptionalString(autopilot.current_phase)?.toLowerCase().replace(/_/g, '-');
 }
 
+function isReportableCurrentAutopilotState(autopilot: AutopilotStateForHud | null): boolean {
+  if (autopilot?.active !== true) return false;
+  return sanitizeOptionalString(autopilot.current_phase) !== undefined
+    || sanitizeOptionalString(autopilot.session_id) !== undefined
+    || sanitizeOptionalString(autopilot.tmux_pane_id) !== undefined;
+}
+
+function buildStaleCurrentAutopilotState(autopilot: AutopilotStateForHud | null): AutopilotStateForHud | null {
+  if (!isReportableCurrentAutopilotState(autopilot)) return null;
+  const reportable = autopilot as AutopilotStateForHud;
+  return {
+    ...reportable,
+    active: true,
+    mode: reportable.mode ?? 'autopilot',
+    source: 'current-autopilot-stale',
+    stale_reason: 'current-autopilot-not-authoritative',
+  };
+}
+
+
 function withLateGateSource<T extends { source?: LateGateHudSource }>(
   state: T | null,
   source: LateGateHudSource,
@@ -540,6 +564,7 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
     autoresearchDetail,
     ultraqaDetail,
     teamDetail,
+    currentAutopilotDetail,
   ] = await Promise.all([
     readAuthoritativeModeState<RalphStateForHud>(cwd, 'ralph'),
     readUltragoalState(cwd),
@@ -550,6 +575,7 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
     readAuthoritativeModeState<AutoresearchStateForHud>(cwd, 'autoresearch'),
     readAuthoritativeModeState<UltraqaStateForHud>(cwd, 'ultraqa'),
     readAuthoritativeModeState<TeamStateForHud>(cwd, 'team'),
+    readCurrentAutopilotState(cwd),
   ]);
 
   const ralph = shouldSurfaceCanonicalSkill(canonicalSkills, 'ralph', ralphDetail)
@@ -561,6 +587,7 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
   const autopilot = shouldSurfaceCanonicalSkill(canonicalSkills, 'autopilot', autopilotDetail)
     ? mergePhase(autopilotDetail?.active === true ? autopilotDetail : null, canonicalPhaseForSkill(canonicalSkills, 'autopilot'))
     : null;
+  const staleAutopilot = autopilot ? null : buildStaleCurrentAutopilotState(currentAutopilotDetail);
   const ralplan = shouldSurfaceCanonicalSkill(canonicalSkills, 'ralplan', ralplanDetail)
     ? mergePhase(ralplanDetail?.active === true ? ralplanDetail : null, canonicalPhaseForSkill(canonicalSkills, 'ralplan'))
     : null;
@@ -629,5 +656,6 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
     hudNotify,
     session,
     runtimeSnapshot,
+    staleAutopilot,
   };
 }

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -44,6 +44,11 @@ export interface UltraworkStateForHud {
 export interface AutopilotStateForHud {
   active: boolean;
   current_phase?: string;
+  mode?: string;
+  session_id?: string;
+  tmux_pane_id?: string;
+  source?: 'authoritative' | 'current-autopilot-stale';
+  stale_reason?: string;
 }
 
 /** Ralplan state for HUD display */
@@ -135,6 +140,7 @@ export interface HudRenderContext {
   metrics: HudMetrics | null;
   hudNotify: HudNotifyState | null;
   session: SessionStateForHud | null;
+  staleAutopilot?: AutopilotStateForHud | null;
   /** Rust-authored runtime snapshot (present when bridge is enabled and snapshot.json exists). */
   runtimeSnapshot?: import('../runtime/bridge.js').RuntimeSnapshot | null;
 }


### PR DESCRIPTION
Resolves #2903.

## Summary
- Read .omx/state/current-autopilot.json in HUD observer paths as a non-authoritative stale-state signal when canonical/autopilot session state is inactive or absent.
- Surface stale autopilot state in omx hud JSON and rendered HUD as autopilot:stale:<phase> instead of silently reporting no active modes.
- Preserve authoritative session/autopilot state precedence when it is present.

## Verification
- npm run build
- node dist/scripts/run-test-files.js dist/hud/__tests__/state.test.js
- npm run test:node

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*