### PR TITLE
fix: bundle skill agent tier references

### DIFF
--- a/plugins/oh-my-codex/skills/ultrawork/SKILL.md
+++ b/plugins/oh-my-codex/skills/ultrawork/SKILL.md
@@ -35,7 +35,7 @@ Sequential task execution wastes time when tasks are independent. Ultrawork keep
 - When useful, run a direct-tool lane and one or more background evidence lanes at the same time. Evidence lanes can cover docs, tests, regression mapping, or bounded repo analysis.
 - Fire independent agent calls simultaneously -- never serialize independent work.
 - Always pass the `model` parameter explicitly when delegating.
-- Read `docs/shared/agent-tiers.md` before first delegation for agent selection guidance.
+- Read `references/agent-tiers.md` before first delegation for agent selection guidance.
 - Auto-delegate `researcher` when official docs, version-aware framework guidance, best practices, or external dependency behavior materially affect task correctness; treat it as an evidence lane, not a replacement primary workflow.
 - Use `run_in_background: true` for operations over ~30 seconds (installs, builds, tests).
 - Run quick commands (git status, file reads, simple checks) in the foreground.
@@ -44,7 +44,7 @@ Sequential task execution wastes time when tasks are independent. Ultrawork keep
 </Execution_Policy>
 
 <Steps>
-1. **Read agent reference**: Load `docs/shared/agent-tiers.md` for tier selection.
+1. **Read agent reference**: Load `references/agent-tiers.md` for tier selection.
 2. **Context + certainty check**:
    - State the task intent in one sentence.
    - List the constraints and unknowns that could invalidate a quick fix.

--- a/plugins/oh-my-codex/skills/ultrawork/references/agent-tiers.md
+++ b/plugins/oh-my-codex/skills/ultrawork/references/agent-tiers.md
@@ -1,0 +1,61 @@
+# Agent Tiers
+
+This file defines practical tier guidance for OMX agent routing.
+
+## Mental Model
+
+OMX now separates three concepts:
+
+- `role`: what the agent is responsible for (`executor`, `planner`, `architect`)
+- `tier`: how much reasoning/cost to spend (`LOW`, `STANDARD`, `THOROUGH`)
+- `posture`: how the role behaves (`frontier-orchestrator`, `deep-worker`, `fast-lane`)
+- `exactModel`: optional role pin that bypasses tier defaults when a role needs a
+  specific model contract.
+
+Use role to choose responsibility, tier to choose depth, and posture to choose operating style.
+
+## Tiers
+
+- `LOW`:
+  Fast lookups and narrow checks.
+  Use for simple exploration, style checks, and lightweight doc edits.
+  Typical roles: `explore`, `style-reviewer`, `writer`.
+
+- `STANDARD`:
+  Default tier for implementation, debugging, and normal verification.
+  Typical roles: `executor`, `debugger`, `test-engineer`, `quality-reviewer`.
+
+- `THOROUGH`:
+  Use for architectural, security-sensitive, or high-impact multi-file work.
+  Typical roles: `architect`, `critic`, `security-reviewer`, `executor`.
+  Note: `deep-executor` is deprecated; route implementation to `executor`.
+
+## Selection Rules
+
+1. Start at `STANDARD` for most code changes.
+2. Use `LOW` only when the task is bounded and non-invasive.
+3. Escalate to `THOROUGH` for:
+   - security/auth/trust-boundary changes
+   - architectural decisions with system-wide impact
+   - large refactors across many files
+4. For Ralph completion checks, use at least `STANDARD` architect verification.
+
+## Posture Guidance
+
+- `frontier-orchestrator`:
+  - Best for steerable frontier models and leader-style roles.
+  - Prioritizes intent classification, delegation, verification, and architectural judgment.
+  - Typical roles: `planner`, `analyst`, `architect`, `critic`, `code-reviewer`.
+  - Ralplan keeps `planner` and `architect` in this posture but pins them to
+    exact `gpt-5.4-mini` with high reasoning; the `critic` consensus gate stays
+    on the frontier lane.
+
+- `deep-worker`:
+  - Best for implementation-heavy roles that should carry work to completion.
+  - Prioritizes direct execution, minimal diffs, and strict verification.
+  - Typical roles: `executor`, `debugger`, `test-engineer`, `build-fixer`.
+
+- `fast-lane`:
+  - Best for cheap/fast models used for triage, search, and narrow synthesis.
+  - Prioritizes quick routing, concise search, and escalation over deep autonomous work.
+  - Typical roles: `explore`, `writer`, and lightweight research/search specialists.

--- a/skills/ecomode/SKILL.md
+++ b/skills/ecomode/SKILL.md
@@ -47,7 +47,7 @@ Ecomode is a modifier that combines with execution modes:
 
 **FIRST ACTION:** Before delegating any work, read the agent reference file:
 ```
-Read file: docs/shared/agent-tiers.md
+Read file: references/agent-tiers.md
 ```
 This provides the complete agent tier matrix, MCP tool assignments, and selection guidance.
 

--- a/skills/ecomode/references/agent-tiers.md
+++ b/skills/ecomode/references/agent-tiers.md
@@ -1,0 +1,61 @@
+# Agent Tiers
+
+This file defines practical tier guidance for OMX agent routing.
+
+## Mental Model
+
+OMX now separates three concepts:
+
+- `role`: what the agent is responsible for (`executor`, `planner`, `architect`)
+- `tier`: how much reasoning/cost to spend (`LOW`, `STANDARD`, `THOROUGH`)
+- `posture`: how the role behaves (`frontier-orchestrator`, `deep-worker`, `fast-lane`)
+- `exactModel`: optional role pin that bypasses tier defaults when a role needs a
+  specific model contract.
+
+Use role to choose responsibility, tier to choose depth, and posture to choose operating style.
+
+## Tiers
+
+- `LOW`:
+  Fast lookups and narrow checks.
+  Use for simple exploration, style checks, and lightweight doc edits.
+  Typical roles: `explore`, `style-reviewer`, `writer`.
+
+- `STANDARD`:
+  Default tier for implementation, debugging, and normal verification.
+  Typical roles: `executor`, `debugger`, `test-engineer`, `quality-reviewer`.
+
+- `THOROUGH`:
+  Use for architectural, security-sensitive, or high-impact multi-file work.
+  Typical roles: `architect`, `critic`, `security-reviewer`, `executor`.
+  Note: `deep-executor` is deprecated; route implementation to `executor`.
+
+## Selection Rules
+
+1. Start at `STANDARD` for most code changes.
+2. Use `LOW` only when the task is bounded and non-invasive.
+3. Escalate to `THOROUGH` for:
+   - security/auth/trust-boundary changes
+   - architectural decisions with system-wide impact
+   - large refactors across many files
+4. For Ralph completion checks, use at least `STANDARD` architect verification.
+
+## Posture Guidance
+
+- `frontier-orchestrator`:
+  - Best for steerable frontier models and leader-style roles.
+  - Prioritizes intent classification, delegation, verification, and architectural judgment.
+  - Typical roles: `planner`, `analyst`, `architect`, `critic`, `code-reviewer`.
+  - Ralplan keeps `planner` and `architect` in this posture but pins them to
+    exact `gpt-5.4-mini` with high reasoning; the `critic` consensus gate stays
+    on the frontier lane.
+
+- `deep-worker`:
+  - Best for implementation-heavy roles that should carry work to completion.
+  - Prioritizes direct execution, minimal diffs, and strict verification.
+  - Typical roles: `executor`, `debugger`, `test-engineer`, `build-fixer`.
+
+- `fast-lane`:
+  - Best for cheap/fast models used for triage, search, and narrow synthesis.
+  - Prioritizes quick routing, concise search, and escalation over deep autonomous work.
+  - Typical roles: `explore`, `writer`, and lightweight research/search specialists.

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -35,7 +35,7 @@ Sequential task execution wastes time when tasks are independent. Ultrawork keep
 - When useful, run a direct-tool lane and one or more background evidence lanes at the same time. Evidence lanes can cover docs, tests, regression mapping, or bounded repo analysis.
 - Fire independent agent calls simultaneously -- never serialize independent work.
 - Always pass the `model` parameter explicitly when delegating.
-- Read `docs/shared/agent-tiers.md` before first delegation for agent selection guidance.
+- Read `references/agent-tiers.md` before first delegation for agent selection guidance.
 - Auto-delegate `researcher` when official docs, version-aware framework guidance, best practices, or external dependency behavior materially affect task correctness; treat it as an evidence lane, not a replacement primary workflow.
 - Use `run_in_background: true` for operations over ~30 seconds (installs, builds, tests).
 - Run quick commands (git status, file reads, simple checks) in the foreground.
@@ -44,7 +44,7 @@ Sequential task execution wastes time when tasks are independent. Ultrawork keep
 </Execution_Policy>
 
 <Steps>
-1. **Read agent reference**: Load `docs/shared/agent-tiers.md` for tier selection.
+1. **Read agent reference**: Load `references/agent-tiers.md` for tier selection.
 2. **Context + certainty check**:
    - State the task intent in one sentence.
    - List the constraints and unknowns that could invalidate a quick fix.

--- a/skills/ultrawork/references/agent-tiers.md
+++ b/skills/ultrawork/references/agent-tiers.md
@@ -1,0 +1,61 @@
+# Agent Tiers
+
+This file defines practical tier guidance for OMX agent routing.
+
+## Mental Model
+
+OMX now separates three concepts:
+
+- `role`: what the agent is responsible for (`executor`, `planner`, `architect`)
+- `tier`: how much reasoning/cost to spend (`LOW`, `STANDARD`, `THOROUGH`)
+- `posture`: how the role behaves (`frontier-orchestrator`, `deep-worker`, `fast-lane`)
+- `exactModel`: optional role pin that bypasses tier defaults when a role needs a
+  specific model contract.
+
+Use role to choose responsibility, tier to choose depth, and posture to choose operating style.
+
+## Tiers
+
+- `LOW`:
+  Fast lookups and narrow checks.
+  Use for simple exploration, style checks, and lightweight doc edits.
+  Typical roles: `explore`, `style-reviewer`, `writer`.
+
+- `STANDARD`:
+  Default tier for implementation, debugging, and normal verification.
+  Typical roles: `executor`, `debugger`, `test-engineer`, `quality-reviewer`.
+
+- `THOROUGH`:
+  Use for architectural, security-sensitive, or high-impact multi-file work.
+  Typical roles: `architect`, `critic`, `security-reviewer`, `executor`.
+  Note: `deep-executor` is deprecated; route implementation to `executor`.
+
+## Selection Rules
+
+1. Start at `STANDARD` for most code changes.
+2. Use `LOW` only when the task is bounded and non-invasive.
+3. Escalate to `THOROUGH` for:
+   - security/auth/trust-boundary changes
+   - architectural decisions with system-wide impact
+   - large refactors across many files
+4. For Ralph completion checks, use at least `STANDARD` architect verification.
+
+## Posture Guidance
+
+- `frontier-orchestrator`:
+  - Best for steerable frontier models and leader-style roles.
+  - Prioritizes intent classification, delegation, verification, and architectural judgment.
+  - Typical roles: `planner`, `analyst`, `architect`, `critic`, `code-reviewer`.
+  - Ralplan keeps `planner` and `architect` in this posture but pins them to
+    exact `gpt-5.4-mini` with high reasoning; the `critic` consensus gate stays
+    on the frontier lane.
+
+- `deep-worker`:
+  - Best for implementation-heavy roles that should carry work to completion.
+  - Prioritizes direct execution, minimal diffs, and strict verification.
+  - Typical roles: `executor`, `debugger`, `test-engineer`, `build-fixer`.
+
+- `fast-lane`:
+  - Best for cheap/fast models used for triage, search, and narrow synthesis.
+  - Prioritizes quick routing, concise search, and escalation over deep autonomous work.
+  - Typical roles: `explore`, `writer`, and lightweight research/search specialists.

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -214,6 +214,15 @@ describe('package bin contract', () => {
     const traceServerEntry = results[0]?.files?.find((file) => file.path === 'dist/mcp/trace-server.js');
     const wikiServerEntry = results[0]?.files?.find((file) => file.path === 'dist/mcp/wiki-server.js');
     const rootRalphSkillEntry = results[0]?.files?.find((file) => file.path === 'skills/ralph/SKILL.md');
+    const rootUltraworkAgentTiersEntry = results[0]?.files?.find(
+      (file) => file.path === 'skills/ultrawork/references/agent-tiers.md',
+    );
+    const rootEcomodeAgentTiersEntry = results[0]?.files?.find(
+      (file) => file.path === 'skills/ecomode/references/agent-tiers.md',
+    );
+    const pluginUltraworkAgentTiersEntry = results[0]?.files?.find(
+      (file) => file.path === 'plugins/oh-my-codex/skills/ultrawork/references/agent-tiers.md',
+    );
     const promptEntry = results[0]?.files?.find((file) => file.path === 'prompts/executor.md');
     const templateEntry = results[0]?.files?.find((file) => file.path === 'templates/AGENTS.md');
     const rootNativeAgentEntry = results[0]?.files?.find((file) => file.path === 'agents' || file.path.startsWith('agents/'));
@@ -260,6 +269,9 @@ describe('package bin contract', () => {
       );
     }
     assert.ok(rootRalphSkillEntry, 'expected npm pack output to keep canonical root skills');
+    assert.ok(rootUltraworkAgentTiersEntry, 'expected npm pack output to include bundled ultrawork agent-tier reference');
+    assert.ok(rootEcomodeAgentTiersEntry, 'expected npm pack output to include bundled ecomode agent-tier reference');
+    assert.ok(pluginUltraworkAgentTiersEntry, 'expected npm pack output to include bundled plugin ultrawork agent-tier reference');
     assert.ok(promptEntry, 'expected npm pack output to keep prompts');
     assert.ok(templateEntry, 'expected npm pack output to keep templates');
     assert.equal(rootNativeAgentEntry, undefined, 'did not expect generated root native agent TOMLs in package output');


### PR DESCRIPTION
## Summary

Installed OMX skills can be read outside the source checkout, so root-relative guidance like `docs/shared/agent-tiers.md` is not reliable after npm/plugin installation. `ultrawork` and the deprecated compatibility `ecomode` skill both pointed at that root docs path, which caused installed agents to report that the delegation tier document was unavailable.

This change bundles the agent-tier reference next to the skills that require it and updates the installable guidance to use skill-local `references/agent-tiers.md` paths.

## Changes

- Add bundled `references/agent-tiers.md` copies for root `ultrawork` and `ecomode` skills.
- Add the same bundled reference to the plugin mirror for `ultrawork` via `npm run sync:plugin`.
- Update skill guidance to read the local reference path instead of `docs/shared/agent-tiers.md`.
- Extend the npm pack contract test so future packages must include the bundled references.

## Validation

- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run verify:plugin-bundle`
- [x] `node dist/scripts/run-test-files.js dist/cli/__tests__/package-bin-contract.test.js dist/catalog/__tests__/plugin-bundle-ssot.test.js`
- [x] Manual npm pack file presence check for the bundled root/plugin agent-tier references
- [ ] `omx doctor` (not run; no setup/config behavior changed)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #2908
