### PR TITLE
Keep mixed Codex identities resumable without unsafe merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,25 @@ OMX also checks for npm updates at launch on a throttled cadence and prompts bef
 
 **Codex plugin install note:** this repo also ships an official Codex plugin layout at `plugins/oh-my-codex` with marketplace metadata in `.agents/plugins/marketplace.json`. That plugin bundles the mirrored skill surface plus plugin-scoped companion metadata for official Codex lifecycle hooks, optional MCP compatibility servers, and apps. It is still **not** a replacement for `npm install -g oh-my-codex` plus `omx setup`: plugin-scoped hooks launch the installed `omx` CLI, legacy setup mode installs native agents and prompts, and plugin setup mode relies on plugin discovery for bundled skills while archiving/removing legacy OMX-managed prompts/native-agent TOMLs so stale role files cannot shadow plugin behavior. Plugin mode still needs a persistent scope `AGENTS.md` (`~/.codex/AGENTS.md` for user setup or `./AGENTS.md` for project setup) as the durable orchestration guidance layer; session-scoped AGENTS files only compose that durable guidance with runtime overlays and are not a replacement.
 
+### Identity and Unified Sessions
+
+OMX keeps Codex account/API-key mixing explicit instead of pretending that local API-key runs and ChatGPT App/cloud tasks share one backend session. The default policy is `primary=chatgpt-main`, `api=allowed-mixed`, and `bridge=open-original`.
+
+Useful commands:
+
+```bash
+omx identity doctor
+omx identity list
+omx identity use chatgpt-main
+omx identity policy
+omx session list --unified
+omx session search "project or title" --unified
+omx session search "transcript phrase" --unified --deep
+omx resume --unified <session-id-or-fragment>
+```
+
+`omx identity doctor` explains the active `CODEX_HOME`, auth mode, matched auth slot, and likely causes of App/API session mismatch. Unified session indexing writes only local metadata and summaries to `~/.omx/state/session-ledger.jsonl`; `--deep` performs a temporary deeper local read for search and does not persist full transcripts. App task caches under `~/Library/Application Support/com.openai.chat` are read-only discovery sources, and `omx resume --unified` opens/resumes each entry in its original source rather than injecting transcripts across identities.
+
 Then work normally inside Codex:
 
 ```text

--- a/src/auth/__tests__/identity.test.ts
+++ b/src/auth/__tests__/identity.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectAuthFileKind, detectAuthKindFromJson, readIdentityStatus } from "../identity.js";
+
+describe("identity detection", () => {
+  it("detects API key and ChatGPT auth shapes without exposing credentials", () => {
+    assert.deepEqual(detectAuthKindFromJson({ auth_mode: "apikey", OPENAI_API_KEY: "sk-secret" }), {
+      kind: "api",
+      authMode: "apikey",
+    });
+    assert.deepEqual(detectAuthKindFromJson({ access_token: "secret-token" }), {
+      kind: "chatgpt",
+      authMode: undefined,
+    });
+    assert.equal(detectAuthKindFromJson({}).kind, "unknown");
+  });
+
+  it("reports active CODEX_HOME identity status", async () => {
+    const home = await mkdtemp(join(tmpdir(), "omx-identity-"));
+    try {
+      const codexHome = join(home, ".codex");
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(codexHome, "auth.json"), '{"auth_mode":"apikey","OPENAI_API_KEY":"sk-secret"}\n');
+      assert.equal((await detectAuthFileKind(join(codexHome, "auth.json"))).kind, "api");
+      const status = await readIdentityStatus(process.cwd(), { CODEX_HOME: codexHome }, home);
+      assert.equal(status.kind, "api");
+      assert.equal(status.codexHome, codexHome);
+      assert.match(status.warnings.join("\n"), /API key/);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("matches the live auth file to the actual slot contents", async () => {
+    const home = await mkdtemp(join(tmpdir(), "omx-identity-match-"));
+    try {
+      const codexHome = join(home, ".codex");
+      const authDir = join(home, ".omx", "auth");
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(authDir, { recursive: true });
+      await writeFile(join(codexHome, "auth.json"), '{"access_token":"api-live"}\n');
+      await writeFile(join(authDir, "main.json"), '{"access_token":"main"}\n');
+      await writeFile(join(authDir, "api.json"), '{"access_token":"api-live"}\n');
+      await writeFile(join(authDir, "slots.json"), JSON.stringify({ version: 1, currentSlot: "main", slots: [
+        { slot: "main", createdAt: "now", updatedAt: "now", kind: "chatgpt" },
+        { slot: "api", createdAt: "now", updatedAt: "now", kind: "api" },
+      ] }));
+
+      const status = await readIdentityStatus(process.cwd(), { CODEX_HOME: codexHome }, home);
+      assert.equal(status.currentSlot, "main");
+      assert.equal(status.matchedSlot, "api");
+      assert.match(status.warnings.join("\n"), /matches slot "api"/);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/auth/__tests__/storage.test.ts
+++ b/src/auth/__tests__/storage.test.ts
@@ -35,6 +35,50 @@ describe("auth slot storage", () => {
     }
   });
 
+  it("stores non-sensitive identity metadata for slots", async () => {
+    const home = await tempHome();
+    try {
+      const live = join(home, ".codex", "auth.json");
+      await mkdir(join(home, ".codex"), { recursive: true });
+      await writeFile(live, '{"auth_mode":"apikey","OPENAI_API_KEY":"secret"}\n');
+      await addSlotFromAuthFile("api-work", live, home, new Date("2026-05-24T00:00:00.000Z"), {
+        displayName: "API Work",
+        kind: "api",
+        isPrimary: false,
+        workspaceHint: "platform",
+        createdFromCodexHome: join(home, ".codex"),
+      });
+      const metadata = await readAuthMetadata(home);
+      assert.equal(metadata.slots[0]?.displayName, "API Work");
+      assert.equal(metadata.slots[0]?.kind, "api");
+      assert.equal(metadata.slots[0]?.workspaceHint, "platform");
+      assert.doesNotMatch(JSON.stringify(metadata), /secret/);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("drops unknown fields when reading slot metadata", async () => {
+    const home = await tempHome();
+    try {
+      const authDir = resolveOmxAuthDir(home);
+      await mkdir(authDir, { recursive: true });
+      await writeFile(resolveSlotPath("work", home), "{}\n");
+      await writeFile(join(authDir, "slots.json"), JSON.stringify({
+        version: 1,
+        currentSlot: "work",
+        slots: [
+          { slot: "work", createdAt: "now", updatedAt: "now", kind: "chatgpt", token: "secret-token" },
+        ],
+      }));
+      const metadata = await readAuthMetadata(home);
+      assert.equal(metadata.slots[0]?.slot, "work");
+      assert.doesNotMatch(JSON.stringify(metadata), /secret-token/);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
   it("uses owner-only modes for auth directory and files", async () => {
     if (process.platform === "win32") return;
     const home = await tempHome();

--- a/src/auth/identity.ts
+++ b/src/auth/identity.ts
@@ -1,0 +1,121 @@
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import { dirname } from "path";
+import { homedir } from "os";
+import { resolveLiveAuthPath, resolveSlotPath } from "./paths.js";
+import { listSlots, readAuthMetadata, useSlot, type AuthSlotRecord } from "./storage.js";
+
+export type IdentityKind = "chatgpt" | "api" | "unknown" | "missing" | "invalid";
+
+export interface IdentityStatus {
+  authPath: string;
+  codexHome: string;
+  kind: IdentityKind;
+  authMode?: string;
+  currentSlot?: string;
+  matchedSlot?: string;
+  slots: AuthSlotRecord[];
+  warnings: string[];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+export function detectAuthKindFromJson(parsed: unknown): { kind: IdentityKind; authMode?: string } {
+  const record = asRecord(parsed);
+  if (!record) return { kind: "invalid" };
+  const authMode = typeof record.auth_mode === "string" ? record.auth_mode : undefined;
+  if (authMode === "apikey" || typeof record.OPENAI_API_KEY === "string") {
+    return { kind: "api", authMode };
+  }
+  if (
+    authMode === "chatgpt" ||
+    typeof record.access_token === "string" ||
+    typeof record.refresh_token === "string" ||
+    asRecord(record.tokens) ||
+    asRecord(record.chatgpt)
+  ) {
+    return { kind: "chatgpt", authMode };
+  }
+  return { kind: "unknown", authMode };
+}
+
+export async function detectAuthFileKind(authPath: string): Promise<{ kind: IdentityKind; authMode?: string }> {
+  if (!existsSync(authPath)) return { kind: "missing" };
+  try {
+    return detectAuthKindFromJson(JSON.parse(await readFile(authPath, "utf-8")));
+  } catch {
+    return { kind: "invalid" };
+  }
+}
+
+async function matchLiveAuthSlot(authPath: string, slots: AuthSlotRecord[], home: string): Promise<string | undefined> {
+  let live: Buffer;
+  try {
+    live = await readFile(authPath);
+  } catch {
+    return undefined;
+  }
+  for (const slot of slots) {
+    try {
+      const candidate = await readFile(resolveSlotPath(slot.slot, home));
+      if (Buffer.compare(live, candidate) === 0) return slot.slot;
+    } catch {
+      // Missing or unreadable slots should not break doctor output.
+    }
+  }
+  return undefined;
+}
+
+export async function readIdentityStatus(
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+  home = homedir(),
+): Promise<IdentityStatus> {
+  const authPath = resolveLiveAuthPath(cwd, env, home);
+  const codexHome = dirname(authPath);
+  const detected = await detectAuthFileKind(authPath);
+  const metadata = await readAuthMetadata(home);
+  const slots = await listSlots(home);
+  const matchedSlot = await matchLiveAuthSlot(authPath, slots, home);
+  const warnings: string[] = [];
+  if (detected.kind === "api") {
+    warnings.push("Current CLI/OMX credentials use an API key; ChatGPT workspace/cloud features may not share this session.");
+  }
+  if (detected.kind === "missing") {
+    warnings.push("No active Codex auth cache was found for this CODEX_HOME.");
+  }
+  if (slots.some((slot) => slot.kind === "api") && slots.some((slot) => slot.kind === "chatgpt")) {
+    warnings.push("Both ChatGPT and API auth slots are configured; unified session commands will preserve source identity.");
+  }
+  if (metadata.currentSlot && matchedSlot && metadata.currentSlot !== matchedSlot) {
+    warnings.push(`Live auth.json matches slot "${matchedSlot}", but slots.json currentSlot is "${metadata.currentSlot}".`);
+  }
+  if (metadata.currentSlot && !matchedSlot && slots.length > 0 && detected.kind !== "missing") {
+    warnings.push("Live auth.json does not match any registered slot; run `omx auth add <slot>` or `omx identity use <slot>` to make routing explicit.");
+  }
+  const primaryCount = slots.filter((slot) => slot.isPrimary).length;
+  if (primaryCount > 1) warnings.push("Multiple auth slots are marked primary; prefer a single ChatGPT main slot.");
+  return {
+    authPath,
+    codexHome,
+    kind: detected.kind,
+    authMode: detected.authMode,
+    currentSlot: metadata.currentSlot,
+    matchedSlot,
+    slots,
+    warnings,
+  };
+}
+
+export async function switchIdentitySlot(
+  slot: string,
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+  home = homedir(),
+): Promise<AuthSlotRecord> {
+  return await useSlot(slot, resolveLiveAuthPath(cwd, env, home), home);
+}

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,4 +1,5 @@
 export * from "./config.js";
+export * from "./identity.js";
 export * from "./paths.js";
 export * from "./quota-detector.js";
 export * from "./redact.js";

--- a/src/auth/storage.ts
+++ b/src/auth/storage.ts
@@ -20,6 +20,11 @@ export interface AuthSlotRecord {
   lastUsedAt?: string;
   lastQuotaAt?: string;
   exhaustedAt?: string;
+  displayName?: string;
+  kind?: "chatgpt" | "api" | "unknown";
+  isPrimary?: boolean;
+  workspaceHint?: string;
+  createdFromCodexHome?: string;
 }
 
 export interface AuthMetadata {
@@ -31,6 +36,14 @@ export interface AuthMetadata {
 export interface AtomicWriteOptions {
   mode?: number;
   beforeRename?: (tempPath: string) => void | Promise<void>;
+}
+
+export interface AuthSlotMetadataInput {
+  displayName?: string;
+  kind?: AuthSlotRecord["kind"];
+  isPrimary?: boolean;
+  workspaceHint?: string;
+  createdFromCodexHome?: string;
 }
 
 export async function atomicWriteFile(
@@ -68,7 +81,19 @@ export async function readAuthMetadata(home?: string): Promise<AuthMetadata> {
     slots: Array.isArray(parsed.slots)
       ? parsed.slots
           .filter((slot): slot is AuthSlotRecord => Boolean(slot && typeof slot.slot === "string"))
-          .map((slot) => ({ ...slot, slot: validateSlotName(slot.slot) }))
+          .map((slot) => ({
+            slot: validateSlotName(slot.slot),
+            createdAt: typeof slot.createdAt === "string" ? slot.createdAt : "",
+            updatedAt: typeof slot.updatedAt === "string" ? slot.updatedAt : "",
+            lastUsedAt: typeof slot.lastUsedAt === "string" ? slot.lastUsedAt : undefined,
+            lastQuotaAt: typeof slot.lastQuotaAt === "string" ? slot.lastQuotaAt : undefined,
+            exhaustedAt: typeof slot.exhaustedAt === "string" ? slot.exhaustedAt : undefined,
+            kind: slot.kind === "chatgpt" || slot.kind === "api" || slot.kind === "unknown" ? slot.kind : undefined,
+            displayName: typeof slot.displayName === "string" ? slot.displayName : undefined,
+            isPrimary: typeof slot.isPrimary === "boolean" ? slot.isPrimary : undefined,
+            workspaceHint: typeof slot.workspaceHint === "string" ? slot.workspaceHint : undefined,
+            createdFromCodexHome: typeof slot.createdFromCodexHome === "string" ? slot.createdFromCodexHome : undefined,
+          }))
       : [],
   };
 }
@@ -81,14 +106,25 @@ export async function writeAuthMetadata(metadata: AuthMetadata, home?: string): 
   });
 }
 
-function upsertSlotRecord(metadata: AuthMetadata, slot: string, nowIso: string): AuthSlotRecord {
+function applySlotMetadata(record: AuthSlotRecord, metadata?: AuthSlotMetadataInput): void {
+  if (!metadata) return;
+  if (metadata.displayName !== undefined) record.displayName = metadata.displayName;
+  if (metadata.kind !== undefined) record.kind = metadata.kind;
+  if (metadata.isPrimary !== undefined) record.isPrimary = metadata.isPrimary;
+  if (metadata.workspaceHint !== undefined) record.workspaceHint = metadata.workspaceHint;
+  if (metadata.createdFromCodexHome !== undefined) record.createdFromCodexHome = metadata.createdFromCodexHome;
+}
+
+function upsertSlotRecord(metadata: AuthMetadata, slot: string, nowIso: string, slotMetadata?: AuthSlotMetadataInput): AuthSlotRecord {
   const safeSlot = validateSlotName(slot);
   const existing = metadata.slots.find((record) => record.slot === safeSlot);
   if (existing) {
     existing.updatedAt = nowIso;
+    applySlotMetadata(existing, slotMetadata);
     return existing;
   }
   const record: AuthSlotRecord = { slot: safeSlot, createdAt: nowIso, updatedAt: nowIso };
+  applySlotMetadata(record, slotMetadata);
   metadata.slots.push(record);
   metadata.slots.sort((a, b) => a.slot.localeCompare(b.slot));
   return record;
@@ -99,6 +135,7 @@ export async function addSlotFromAuthFile(
   liveAuthPath: string,
   home?: string,
   now = new Date(),
+  slotMetadata?: AuthSlotMetadataInput,
 ): Promise<AuthSlotRecord> {
   const safeSlot = validateSlotName(slot);
   await assertReadableFile(liveAuthPath, "live Codex auth.json");
@@ -107,7 +144,7 @@ export async function addSlotFromAuthFile(
   const target = resolveSlotPath(safeSlot, home);
   await atomicWriteFile(target, data, { mode: AUTH_FILE_MODE });
   const metadata = await readAuthMetadata(home);
-  const record = upsertSlotRecord(metadata, safeSlot, now.toISOString());
+  const record = upsertSlotRecord(metadata, safeSlot, now.toISOString(), slotMetadata);
   await writeAuthMetadata(metadata, home);
   return record;
 }

--- a/src/cli/__tests__/auth.test.ts
+++ b/src/cli/__tests__/auth.test.ts
@@ -72,6 +72,35 @@ describe("omx auth CLI", () => {
       assert.equal(use.status, 0, use.stderr);
       assert.doesNotMatch(use.stdout + use.stderr, /sentinel-secret/);
       assert.equal(await readFile(join(codexHome, "auth.json"), "utf-8"), '{"access_token":"sentinel-secret"}\n');
+      const identityList = runOmx(wd, ["identity", "list"], env);
+      assert.equal(identityList.status, 0, identityList.stderr);
+      assert.match(identityList.stdout, /work/);
+      const doctor = runOmx(wd, ["identity", "doctor", "--json"], env);
+      assert.equal(doctor.status, 0, doctor.stderr);
+      assert.match(doctor.stdout, /"kind": "chatgpt"/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("switches identity slots through the compiled CLI", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-identity-use-"));
+    try {
+      const home = join(wd, "home");
+      const codexHome = join(home, ".codex");
+      const authDir = join(home, ".omx", "auth");
+      await mkdir(authDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(authDir, "main.json"), '{"access_token":"main-secret"}\n');
+      await writeFile(join(authDir, "api.json"), '{"auth_mode":"apikey","OPENAI_API_KEY":"api-secret"}\n');
+      await writeFile(join(authDir, "slots.json"), JSON.stringify({ version: 1, currentSlot: "main", slots: [
+        { slot: "main", createdAt: "now", updatedAt: "now", kind: "chatgpt", isPrimary: true },
+        { slot: "api", createdAt: "now", updatedAt: "now", kind: "api" }
+      ] }, null, 2));
+      const result = runOmx(wd, ["identity", "use", "api"], { HOME: home, CODEX_HOME: codexHome });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(await readFile(join(codexHome, "auth.json"), "utf-8"), '{"auth_mode":"apikey","OPENAI_API_KEY":"api-secret"}\n');
+      assert.doesNotMatch(result.stdout + result.stderr, /api-secret|main-secret/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -19,6 +19,7 @@ function runOmx(
     encoding: 'utf-8',
     env: {
       ...process.env,
+      CODEX_SQLITE_HOME: '',
       ...envOverrides,
     },
   });
@@ -492,6 +493,67 @@ if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-unrelated-session.jsonl" ]; the
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       assert.match(result.stdout, /fake-codex:resume --help\b/);
       assert.doesNotMatch(result.stdout, /Unknown command: resume/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('resumes unified CLI entries through codex resume in the original identity', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-unified-cli-'));
+    try {
+      const home = join(wd, 'home');
+      const codexHome = join(home, '.codex');
+      const authDir = join(home, '.omx', 'auth');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const rolloutPath = join(codexHome, 'sessions', '2026', '06', '13', 'rollout-session-unified.jsonl');
+      await mkdir(dirname(rolloutPath), { recursive: true });
+      await mkdir(authDir, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(join(codexHome, 'auth.json'), '{"access_token":"old"}\n');
+      await writeFile(join(authDir, 'main.json'), '{"access_token":"main-secret"}\n');
+      await writeFile(join(authDir, 'slots.json'), JSON.stringify({ version: 1, currentSlot: 'main', slots: [
+        { slot: 'main', createdAt: 'now', updatedAt: 'now', kind: 'chatgpt' }
+      ] }));
+      await writeFile(rolloutPath, '{"type":"session_meta","payload":{"id":"session-unified","cwd":"/repo","timestamp":"2026-06-13T00:00:00.000Z"}}\n');
+      await writeFile(fakeCodexPath, '#!/bin/sh\nprintf \'fake-codex:%s\\n\' "$*"\nprintf \'auth:%s\\n\' "$(cat "$CODEX_HOME/auth.json")"\n');
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+
+      const result = runOmx(wd, ['resume', '--unified', 'session-unified'], {
+        HOME: home,
+        CODEX_HOME: codexHome,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /fake-codex:resume session-unified/);
+      assert.match(result.stdout, /main-secret/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('opens unified App entries at their original read-only cache target', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-unified-app-'));
+    try {
+      const home = join(wd, 'home');
+      const appDir = join(home, 'Library', 'Application Support', 'com.openai.chat', 'codex-taskItems-v2-default-user');
+      await mkdir(appDir, { recursive: true });
+      const result = runOmx(wd, ['resume', '--unified', 'taskItems'], {
+        HOME: home,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /Open original Codex App session source/);
+      assert.match(result.stdout, /codex-taskItems-v2-default-user/);
+      assert.match(result.stdout, /read-only metadata/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/session-search.test.ts
+++ b/src/cli/__tests__/session-search.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
@@ -83,6 +83,59 @@ describe('omx session search', () => {
       assert.equal(parsed.results[0].session_id, 'session-a');
       assert.equal(parsed.results[0].cwd, cwd);
       assert.match(parsed.results[0].snippet, /team api/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('lists and searches unified CLI and App metadata without mutating App cache', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-unified-cli-'));
+    const home = join(cwd, 'home');
+    const codexHomeDir = join(home, '.codex');
+    const appSupport = join(home, 'Library', 'Application Support', 'com.openai.chat');
+    try {
+      await mkdir(codexHomeDir, { recursive: true });
+      await writeFile(join(codexHomeDir, 'auth.json'), '{"auth_mode":"apikey","OPENAI_API_KEY":"secret"}\n');
+      await writeRollout(codexHomeDir, '2026-03-10T12:00:00.000Z', 'rollout-session-unified.jsonl', [
+        { type: 'session_meta', payload: { id: 'session-unified', timestamp: '2026-03-10T12:00:00.000Z', cwd } },
+        { type: 'event_msg', payload: { type: 'user_message', message: 'hidden deep transcript marker sk-supersecret999' } },
+      ]);
+      const appDir = join(appSupport, 'codex-taskDetails-v1-user');
+      await mkdir(appDir, { recursive: true });
+
+      const list = runOmx(cwd, ['session', 'list', '--unified', '--json'], {
+        HOME: home,
+        CODEX_HOME: codexHomeDir,
+      });
+      assert.equal(list.status, 0, list.stderr || list.stdout);
+      const parsed = JSON.parse(list.stdout) as { entries: Array<{ sessionId: string; source: string }> };
+      assert.equal(parsed.entries.some((entry) => entry.sessionId === 'session-unified' && entry.source === 'api'), true);
+      assert.equal(parsed.entries.some((entry) => entry.sessionId === 'codex-taskDetails-v1-user' && entry.source === 'app'), true);
+      const ledger = await readFile(join(home, '.omx', 'state', 'session-ledger.jsonl'), 'utf-8');
+      assert.match(ledger, /session-unified/);
+      assert.doesNotMatch(ledger, /secret/);
+
+      const search = runOmx(cwd, ['session', 'search', 'taskDetails', '--unified', '--json'], {
+        HOME: home,
+        CODEX_HOME: codexHomeDir,
+      });
+      assert.equal(search.status, 0, search.stderr || search.stdout);
+      assert.match(search.stdout, /codex-taskDetails-v1-user/);
+
+      const shallowSearch = runOmx(cwd, ['session', 'search', 'hidden deep transcript', '--unified', '--json'], {
+        HOME: home,
+        CODEX_HOME: codexHomeDir,
+      });
+      assert.equal(shallowSearch.status, 0, shallowSearch.stderr || shallowSearch.stdout);
+      assert.equal((JSON.parse(shallowSearch.stdout) as { entries: unknown[] }).entries.length, 0);
+
+      const deepSearch = runOmx(cwd, ['session', 'search', 'hidden deep transcript', '--unified', '--deep', '--json'], {
+        HOME: home,
+        CODEX_HOME: codexHomeDir,
+      });
+      assert.equal(deepSearch.status, 0, deepSearch.stderr || deepSearch.stdout);
+      assert.match(deepSearch.stdout, /session-unified/);
+      assert.doesNotMatch(deepSearch.stdout, /sk-supersecret999/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -2,6 +2,7 @@ import { dirname, join } from "path";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { spawnPlatformCommandSync, classifySpawnError } from "../utils/platform-command.js";
 import { readAuthConfig } from "../auth/config.js";
+import { detectAuthFileKind } from "../auth/identity.js";
 import { resolveLiveAuthPath } from "../auth/paths.js";
 import { redactAuthSecrets } from "../auth/redact.js";
 import { addSlotFromAuthFile, listSlots, useSlot } from "../auth/storage.js";
@@ -79,7 +80,11 @@ export async function authCommand(args: string[], env: NodeJS.ProcessEnv = proce
     if (!slot) throw new Error("Usage: omx auth add <slot>");
     const liveAuthPath = resolveLiveAuthPath(cwd, env, home);
     runCodexLogin(cwd, { ...env, CODEX_HOME: dirname(liveAuthPath) });
-    const record = await addSlotFromAuthFile(slot, liveAuthPath, home);
+    const detected = await detectAuthFileKind(liveAuthPath);
+    const record = await addSlotFromAuthFile(slot, liveAuthPath, home, new Date(), {
+      kind: detected.kind === "chatgpt" || detected.kind === "api" ? detected.kind : "unknown",
+      createdFromCodexHome: dirname(liveAuthPath),
+    });
     await ensureSubscriptionCodexDefaults(dirname(liveAuthPath));
     console.log(`Added auth slot ${record.slot}`);
     return;

--- a/src/cli/identity.ts
+++ b/src/cli/identity.ts
@@ -1,0 +1,88 @@
+import { readIdentityStatus, switchIdentitySlot } from "../auth/identity.js";
+
+const HELP = `omx identity - Inspect and switch Codex identity slots
+
+Usage:
+  omx identity doctor [--json]
+  omx identity list [--json]
+  omx identity use <slot>
+  omx identity policy [--json]
+`;
+
+const POLICY = {
+  primary: "chatgpt-main",
+  api: "allowed-mixed",
+  bridge: "open-original",
+};
+
+function wantsJson(args: string[]): boolean {
+  return args.includes("--json");
+}
+
+export async function identityCommand(args: string[]): Promise<void> {
+  const command = args[0];
+  if (!command || command === "--help" || command === "-h" || command === "help") {
+    console.log(HELP.trim());
+    return;
+  }
+
+  if (command === "policy") {
+    if (wantsJson(args)) {
+      console.log(JSON.stringify(POLICY, null, 2));
+      return;
+    }
+    console.log(`primary=${POLICY.primary}`);
+    console.log(`api=${POLICY.api}`);
+    console.log(`bridge=${POLICY.bridge}`);
+    return;
+  }
+
+  if (command === "doctor") {
+    const status = await readIdentityStatus();
+    if (wantsJson(args)) {
+      console.log(JSON.stringify({ ...status, policy: POLICY }, null, 2));
+      return;
+    }
+    console.log(`codexHome: ${status.codexHome}`);
+    console.log(`authPath: ${status.authPath}`);
+    console.log(`activeKind: ${status.kind}`);
+    console.log(`authMode: ${status.authMode ?? "unknown"}`);
+    console.log(`currentSlot: ${status.currentSlot ?? "none"}`);
+    console.log(`slots: ${status.slots.length}`);
+    console.log(`policy: primary=${POLICY.primary} api=${POLICY.api} bridge=${POLICY.bridge}`);
+    for (const warning of status.warnings) console.log(`warning: ${warning}`);
+    if (status.warnings.length === 0) console.log("warning: none");
+    return;
+  }
+
+  if (command === "list") {
+    const status = await readIdentityStatus();
+    if (wantsJson(args)) {
+      console.log(JSON.stringify({ slots: status.slots, currentSlot: status.currentSlot }, null, 2));
+      return;
+    }
+    if (status.slots.length === 0) {
+      console.log("No identity slots configured. Run `omx auth add <slot>` first.");
+      return;
+    }
+    for (const slot of status.slots) {
+      const markers = [
+        slot.slot === status.currentSlot ? "current" : "",
+        slot.isPrimary ? "primary" : "",
+        slot.kind ? `kind=${slot.kind}` : "kind=unknown",
+      ].filter(Boolean).join(" ");
+      console.log(`${slot.slot}${slot.displayName ? ` (${slot.displayName})` : ""}${markers ? ` [${markers}]` : ""}`);
+    }
+    return;
+  }
+
+  if (command === "use") {
+    const slot = args[1];
+    if (!slot) throw new Error("Usage: omx identity use <slot>");
+    const record = await switchIdentitySlot(slot);
+    console.log(`Using identity slot ${record.slot}`);
+    return;
+  }
+
+  throw new Error(`Unknown identity command: ${command}\n${HELP.trim()}`);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -52,7 +52,10 @@ import { mcpServeCommand } from "./mcp-serve.js";
 import { adaptCommand } from "./adapt.js";
 import { listCommand } from "./list.js";
 import { authCommand } from "./auth.js";
+import { identityCommand } from "./identity.js";
 import { runAuthHotswap } from "../auth/hotswap.js";
+import { switchIdentitySlot } from "../auth/identity.js";
+import { findUnifiedEntry, refreshUnifiedLedger } from "../session-ledger/index.js";
 import {
   MADMAX_FLAG,
   CODEX_BYPASS_FLAG,
@@ -222,9 +225,12 @@ Usage:
   omx doctor --team  Check team/swarm runtime health diagnostics
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
   omx auth      Manage Codex OAuth auth slots (add|list|use)
+  omx identity  Inspect/switch Codex identity slots and mixed API/account policy
   omx question  OMX-owned blocking question UI entrypoint for agent-invoked user questions
   omx adapt     Scaffold OMX-owned adapter foundations for persistent external targets
-  omx resume    Resume Codex sessions (supports --project and --codex-home <path>)
+  omx resume    Resume Codex sessions (supports --project, --codex-home <path>, and --unified <id>)
+  omx resume --unified <id>
+                Resume/open a unified CLI/API/App session entry in its original identity/source
   omx explore   DEPRECATED compatibility command; use normal repo inspection or omx sparkshell
   omx api       Run native omx-api localhost gateway commands (serve|status|stop|generate)
   omx session   Search prior local session transcripts (--codex-home <path> escape hatch)
@@ -380,6 +386,7 @@ type CliCommand =
   | "doctor"
   | "cleanup"
   | "auth"
+  | "identity"
   | "ask"
   | "question"
   | "adapt"
@@ -409,6 +416,7 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "question",
   "cleanup",
   "auth",
+  "identity",
   "adapt",
   "explore",
   "autoresearch",
@@ -2351,6 +2359,7 @@ export async function main(args: string[]): Promise<void> {
     "doctor",
     "cleanup",
     "auth",
+    "identity",
     "ask",
     "question",
     "autoresearch",
@@ -2405,7 +2414,11 @@ export async function main(args: string[]): Promise<void> {
         }
         break;
       case "resume":
-        await launchWithHud(["resume", ...launchArgs]);
+        if (launchArgs[0] === "--unified") {
+          await resumeUnifiedCommand(launchArgs.slice(1));
+        } else {
+          await launchWithHud(["resume", ...launchArgs]);
+        }
         break;
       case "setup":
         await setup({
@@ -2462,6 +2475,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "auth":
         await authCommand(args.slice(1));
+        break;
+      case "identity":
+        await identityCommand(args.slice(1));
         break;
       case "autoresearch":
         await autoresearchCommand(args.slice(1));
@@ -2677,6 +2693,25 @@ async function showStatus(): Promise<void> {
     logCliOperationFailure(err);
     console.log("No active modes.");
   }
+}
+
+async function resumeUnifiedCommand(args: string[]): Promise<void> {
+  const id = args[0];
+  if (!id || id === "--help" || id === "-h") {
+    console.log("Usage: omx resume --unified <session-id-or-fragment>");
+    return;
+  }
+  const entry = findUnifiedEntry(await refreshUnifiedLedger(), id);
+  if (!entry) {
+    throw new Error(`Unified session entry not found: ${id}. Run \`omx session list --unified\` first.`);
+  }
+  if (entry.source === "cli" || entry.source === "api" || entry.source === "omx") {
+    if (entry.identitySlot) await switchIdentitySlot(entry.identitySlot);
+    await launchWithHud(["resume", entry.sessionId]);
+    return;
+  }
+  console.log(`Open original Codex App session source: ${entry.openTarget ?? entry.sessionId}`);
+  console.log("This App/cloud entry is read-only metadata; OMX will not rewrite it into an API-key session.");
 }
 
 async function reasoningCommand(args: string[]): Promise<void> {

--- a/src/cli/session-search.ts
+++ b/src/cli/session-search.ts
@@ -1,11 +1,15 @@
 import { searchSessionHistory, type SessionSearchReport, type SessionSearchOptions } from '../session-history/search.js';
+import { refreshUnifiedLedger, searchUnifiedEntries, type UnifiedSessionEntry } from '../session-ledger/index.js';
 
 const HELP = `omx session - Search prior local session history
 
 Usage:
+  omx session list --unified [--json]
   omx session search <query> [options]
 
 Options:
+  --unified           Include CLI/API/App metadata in one local view
+  --deep              Reserved for explicit deeper local reads; v1 does not persist full-text indexes
   --limit <n>          Maximum results to return (default: 10)
   --session <id>       Restrict to a specific session id or id fragment
   --since <spec>       Restrict by recency (examples: 7d, 24h, 2026-03-10)
@@ -27,6 +31,8 @@ const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 export interface ParsedSessionSearchArgs {
   options: SessionSearchOptions;
   json: boolean;
+  unified: boolean;
+  deep: boolean;
 }
 
 function parsePositiveInteger(value: string, flag: string): number {
@@ -48,6 +54,12 @@ export function parseSessionSearchArgs(args: string[]): ParsedSessionSearchArgs 
     const token = args[index];
     if (token === '--json') {
       json = true;
+      continue;
+    }
+    if (token === '--unified') {
+      continue;
+    }
+    if (token === '--deep') {
       continue;
     }
     if (token === '--case-sensitive') {
@@ -103,7 +115,26 @@ export function parseSessionSearchArgs(args: string[]): ParsedSessionSearchArgs 
     throw new Error(`Missing search query.\n${HELP}`);
   }
 
-  return { options, json };
+  return { options, json, unified: args.includes('--unified'), deep: args.includes('--deep') };
+}
+
+function parseUnifiedListArgs(args: string[]): { json: boolean; deep: boolean } {
+  const allowed = new Set(['--json', '--unified', '--deep']);
+  for (const arg of args) {
+    if (!allowed.has(arg)) throw new Error(`Unknown option: ${arg}`);
+  }
+  return { json: args.includes('--json'), deep: args.includes('--deep') };
+}
+
+function formatUnifiedEntries(entries: UnifiedSessionEntry[]): string {
+  if (entries.length === 0) return 'No unified session entries found.';
+  return entries.map((entry) => [
+    `${entry.sessionId} [${entry.source}${entry.identitySlot ? `/${entry.identitySlot}` : ''}]`,
+    `  time: ${entry.updatedAt ?? entry.createdAt ?? 'unknown'}`,
+    `  cwd: ${entry.cwd ?? 'unknown'}`,
+    `  title: ${entry.title ?? 'unknown'}`,
+    `  open: ${entry.openTarget ?? entry.resumeCommand ?? 'unknown'}`,
+  ].join('\n')).join('\n\n');
 }
 
 function formatReport(report: SessionSearchReport): string {
@@ -134,6 +165,20 @@ export async function sessionCommand(args: string[]): Promise<void> {
     return;
   }
 
+  if (subcommand === 'list') {
+    const parsed = parseUnifiedListArgs(args.slice(1));
+    if (!args.includes('--unified')) {
+      throw new Error(`omx session list currently requires --unified.\n${HELP}`);
+    }
+    const entries = await refreshUnifiedLedger({ deep: parsed.deep });
+    if (parsed.json) {
+      console.log(JSON.stringify({ entries }, null, 2));
+      return;
+    }
+    console.log(formatUnifiedEntries(entries));
+    return;
+  }
+
   if (subcommand !== 'search') {
     throw new Error(`Unknown session subcommand: ${subcommand}\n${HELP}`);
   }
@@ -144,6 +189,16 @@ export async function sessionCommand(args: string[]): Promise<void> {
   }
 
   const parsed = parseSessionSearchArgs(args.slice(1));
+  if (parsed.unified) {
+    const entries = searchUnifiedEntries(await refreshUnifiedLedger({ deep: parsed.deep }), parsed.options.query)
+      .slice(0, parsed.options.limit ?? 10);
+    if (parsed.json) {
+      console.log(JSON.stringify({ query: parsed.options.query, entries }, null, 2));
+      return;
+    }
+    console.log(formatUnifiedEntries(entries));
+    return;
+  }
   const report = await searchSessionHistory(parsed.options);
   if (parsed.json) {
     console.log(JSON.stringify(report, null, 2));

--- a/src/session-ledger/__tests__/index.test.ts
+++ b/src/session-ledger/__tests__/index.test.ts
@@ -1,0 +1,47 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { buildUnifiedLedger, refreshUnifiedLedger, searchUnifiedEntries } from "../index.js";
+
+describe("unified session ledger", () => {
+  it("collects CLI/API rollout metadata and App cache metadata read-only", async () => {
+    const home = await mkdtemp(join(tmpdir(), "omx-ledger-"));
+    const codexHome = join(home, ".codex");
+    const appSupport = join(home, "app-support");
+    try {
+      const rollout = join(codexHome, "sessions", "2026", "06", "13", "rollout-session-a.jsonl");
+      await mkdir(dirname(rollout), { recursive: true });
+      await writeFile(join(codexHome, "auth.json"), '{"auth_mode":"apikey","OPENAI_API_KEY":"sk-secret"}\n');
+      await writeFile(rollout, JSON.stringify({
+        type: "session_meta",
+        payload: { id: "session-a", timestamp: "2026-06-13T01:00:00.000Z", cwd: "/repo" },
+      }) + "\n" + JSON.stringify({
+        type: "event_msg",
+        payload: { type: "user_message", message: "deep-only transcript phrase with sk-secret999" },
+      }) + "\n");
+      const appDir = join(appSupport, "codex-taskItems-v2-default-user");
+      await mkdir(appDir, { recursive: true });
+
+      const entries = await buildUnifiedLedger({ home, codexHomeDir: codexHome, appSupportDir: appSupport });
+      assert.equal(entries.some((entry) => entry.sessionId === "session-a" && entry.source === "api"), true);
+      assert.equal(entries.some((entry) => entry.sessionId === "codex-taskItems-v2-default-user" && entry.source === "app"), true);
+      assert.equal(searchUnifiedEntries(entries, "repo").some((entry) => entry.sessionId === "session-a"), true);
+
+      await refreshUnifiedLedger({ home, codexHomeDir: codexHome, appSupportDir: appSupport });
+      const ledger = await readFile(join(home, ".omx", "state", "session-ledger.jsonl"), "utf-8");
+      assert.match(ledger, /session-a/);
+      assert.doesNotMatch(ledger, /sk-secret/);
+      assert.doesNotMatch(ledger, /deep-only transcript phrase/);
+
+      const deepEntries = await refreshUnifiedLedger({ home, codexHomeDir: codexHome, appSupportDir: appSupport, deep: true });
+      assert.equal(searchUnifiedEntries(deepEntries, "deep-only transcript phrase").some((entry) => entry.sessionId === "session-a"), true);
+      const shallowLedger = await readFile(join(home, ".omx", "state", "session-ledger.jsonl"), "utf-8");
+      assert.doesNotMatch(shallowLedger, /deep-only transcript phrase/);
+      assert.doesNotMatch(JSON.stringify(deepEntries), /sk-secret999/);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/session-ledger/index.ts
+++ b/src/session-ledger/index.ts
@@ -1,0 +1,259 @@
+import { createReadStream, existsSync } from "fs";
+import { mkdir, readdir, readFile, stat, writeFile } from "fs/promises";
+import { createInterface } from "readline";
+import { homedir } from "os";
+import { basename, dirname, join, relative } from "path";
+import { resolveDefaultCodexHome } from "../auth/paths.js";
+import { readAuthMetadata } from "../auth/storage.js";
+import { detectAuthFileKind } from "../auth/identity.js";
+import { redactAuthSecrets } from "../auth/redact.js";
+
+export type UnifiedSessionSource = "cli" | "app" | "omx" | "api";
+
+export interface UnifiedSessionEntry {
+  sessionId: string;
+  source: UnifiedSessionSource;
+  identitySlot?: string;
+  authMode?: string;
+  cwd?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  title?: string;
+  summary?: string;
+  openTarget?: string;
+  resumeCommand?: string;
+  codexHome?: string;
+}
+
+export interface BuildUnifiedLedgerOptions {
+  home?: string;
+  codexHomeDir?: string;
+  appSupportDir?: string;
+  deep?: boolean;
+  now?: Date;
+}
+
+export function resolveSessionLedgerPath(home = homedir()): string {
+  return join(home, ".omx", "state", "session-ledger.jsonl");
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+async function listRolloutFiles(root: string): Promise<string[]> {
+  if (!existsSync(root)) return [];
+  const files: string[] = [];
+  const queue = [root];
+  while (queue.length > 0) {
+    const dir = queue.pop();
+    if (!dir) continue;
+    for (const entry of await readdir(dir, { withFileTypes: true }).catch(() => [])) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) queue.push(path);
+      if (entry.isFile() && entry.name.startsWith("rollout-") && entry.name.endsWith(".jsonl")) files.push(path);
+    }
+  }
+  return files;
+}
+
+async function readFirstJsonLine(filePath: string): Promise<Record<string, unknown> | null> {
+  const stream = createReadStream(filePath, "utf-8");
+  const reader = createInterface({ input: stream, crlfDelay: Infinity });
+  try {
+    for await (const line of reader) {
+      try {
+        const parsed = JSON.parse(line) as unknown;
+        return asRecord(parsed);
+      } catch {
+        return null;
+      }
+    }
+  } finally {
+    reader.close();
+    stream.destroy();
+  }
+  return null;
+}
+
+function extractText(value: unknown, texts: string[]): void {
+  if (texts.length >= 8) return;
+  if (typeof value === "string") {
+    const text = value.trim();
+    if (text) texts.push(text);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) extractText(item, texts);
+    return;
+  }
+  const record = asRecord(value);
+  if (!record) return;
+  for (const key of ["text", "message", "summary", "content", "output"]) {
+    if (key in record) extractText(record[key], texts);
+  }
+}
+
+async function readDeepRolloutSummary(filePath: string): Promise<string | undefined> {
+  const stream = createReadStream(filePath, "utf-8");
+  const reader = createInterface({ input: stream, crlfDelay: Infinity });
+  const texts: string[] = [];
+  let lines = 0;
+  try {
+    for await (const line of reader) {
+      lines += 1;
+      if (lines > 80 || texts.join(" ").length > 2000) break;
+      try {
+        const parsed = asRecord(JSON.parse(line) as unknown);
+        const payload = asRecord(parsed?.payload);
+        if (!payload) continue;
+        extractText(payload, texts);
+      } catch {
+        // Deep reads are best-effort only.
+      }
+    }
+  } finally {
+    reader.close();
+    stream.destroy();
+  }
+  const text = redactAuthSecrets(texts.join(" ").replace(/\s+/g, " ").trim());
+  return text ? text.slice(0, 600) : undefined;
+}
+
+async function collectCliEntries(home: string, codexHomeDir: string, deep = false): Promise<UnifiedSessionEntry[]> {
+  const auth = await detectAuthFileKind(join(codexHomeDir, "auth.json"));
+  const metadata = await readAuthMetadata(home);
+  const currentSlot = metadata.currentSlot;
+  const files = await listRolloutFiles(join(codexHomeDir, "sessions"));
+  const entries: UnifiedSessionEntry[] = [];
+  for (const file of files) {
+    const first = await readFirstJsonLine(file);
+    const payload = asRecord(first?.payload);
+    const fileInfo = await stat(file).catch(() => null);
+    const sessionId =
+      asString(payload?.id) ??
+      basename(file, ".jsonl").replace(/^rollout-/, "");
+    const cwd = asString(payload?.cwd);
+    const timestamp = asString(payload?.timestamp);
+    const source: UnifiedSessionSource = auth.kind === "api" ? "api" : "cli";
+    const deepSummary = deep ? await readDeepRolloutSummary(file) : undefined;
+    entries.push({
+      sessionId,
+      source,
+      identitySlot: currentSlot,
+      authMode: auth.kind,
+      cwd,
+      createdAt: timestamp,
+      updatedAt: fileInfo?.mtime.toISOString(),
+      title: cwd ? basename(cwd) : sessionId,
+      summary: deepSummary ?? `Codex ${source} session${cwd ? ` in ${cwd}` : ""}`,
+      openTarget: file,
+      resumeCommand: `codex resume ${sessionId}`,
+      codexHome: codexHomeDir,
+    });
+  }
+  return entries;
+}
+
+async function readOptionalJsonSummary(dir: string): Promise<{ title?: string; summary?: string }> {
+  const files = await readdir(dir, { withFileTypes: true }).catch(() => []);
+  for (const entry of files) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    try {
+      const parsed = asRecord(JSON.parse(await readFile(join(dir, entry.name), "utf-8")));
+      const title = asString(parsed?.title) ?? asString(parsed?.name);
+      const summary = asString(parsed?.summary) ?? asString(parsed?.description);
+      if (title || summary) return { title, summary };
+    } catch {
+      // App cache files are best-effort only.
+    }
+  }
+  return {};
+}
+
+async function collectAppEntries(appSupportDir: string): Promise<UnifiedSessionEntry[]> {
+  if (!existsSync(appSupportDir)) return [];
+  const entries: UnifiedSessionEntry[] = [];
+  const dirs = await readdir(appSupportDir, { withFileTypes: true }).catch(() => []);
+  for (const entry of dirs) {
+    if (!entry.isDirectory()) continue;
+    if (!/^codex-(?:taskItems|taskDetails|environments)-/.test(entry.name)) continue;
+    const path = join(appSupportDir, entry.name);
+    const info = await stat(path).catch(() => null);
+    const summary = await readOptionalJsonSummary(path);
+    entries.push({
+      sessionId: entry.name,
+      source: "app",
+      authMode: "chatgpt",
+      createdAt: info?.birthtime.toISOString(),
+      updatedAt: info?.mtime.toISOString(),
+      title: summary.title ?? entry.name,
+      summary: summary.summary ?? "Codex App/ChatGPT cached task metadata (read-only)",
+      openTarget: path,
+    });
+  }
+  return entries;
+}
+
+function dedupeEntries(entries: UnifiedSessionEntry[]): UnifiedSessionEntry[] {
+  const byKey = new Map<string, UnifiedSessionEntry>();
+  for (const entry of entries) {
+    const key = `${entry.source}:${entry.sessionId}`;
+    const current = byKey.get(key);
+    if (!current || String(entry.updatedAt ?? "") > String(current.updatedAt ?? "")) byKey.set(key, entry);
+  }
+  return [...byKey.values()].sort((a, b) => String(b.updatedAt ?? b.createdAt ?? "").localeCompare(String(a.updatedAt ?? a.createdAt ?? "")));
+}
+
+export async function buildUnifiedLedger(options: BuildUnifiedLedgerOptions = {}): Promise<UnifiedSessionEntry[]> {
+  const home = options.home ?? homedir();
+  const envCodexHome = process.env.CODEX_HOME?.trim();
+  const codexHomeDir = options.codexHomeDir ?? (envCodexHome || resolveDefaultCodexHome(home));
+  const appSupportDir = options.appSupportDir ?? join(home, "Library", "Application Support", "com.openai.chat");
+  return dedupeEntries([
+    ...await collectCliEntries(home, codexHomeDir, options.deep === true),
+    ...await collectAppEntries(appSupportDir),
+  ]);
+}
+
+export async function refreshUnifiedLedger(options: BuildUnifiedLedgerOptions = {}): Promise<UnifiedSessionEntry[]> {
+  const home = options.home ?? homedir();
+  const shallowEntries = await buildUnifiedLedger({ ...options, deep: false });
+  const ledgerPath = resolveSessionLedgerPath(home);
+  await mkdir(dirname(ledgerPath), { recursive: true });
+  await writeFile(ledgerPath, `${shallowEntries.map((entry) => JSON.stringify(entry)).join("\n")}${shallowEntries.length ? "\n" : ""}`);
+  if (options.deep === true) return await buildUnifiedLedger({ ...options, deep: true });
+  return shallowEntries;
+}
+
+export function searchUnifiedEntries(entries: UnifiedSessionEntry[], query: string): UnifiedSessionEntry[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return entries;
+  return entries.filter((entry) => [
+    entry.sessionId,
+    entry.source,
+    entry.identitySlot,
+    entry.authMode,
+    entry.cwd,
+    entry.title,
+    entry.summary,
+    entry.openTarget,
+    entry.resumeCommand,
+    entry.codexHome,
+  ].some((value) => typeof value === "string" && value.toLowerCase().includes(needle)));
+}
+
+export function findUnifiedEntry(entries: UnifiedSessionEntry[], id: string): UnifiedSessionEntry | null {
+  const needle = id.trim();
+  if (!needle) return null;
+  return entries.find((entry) => entry.sessionId === needle) ??
+    entries.find((entry) => entry.sessionId.includes(needle)) ??
+    entries.find((entry) => relative("/", entry.openTarget ?? "").includes(needle)) ??
+    null;
+}


### PR DESCRIPTION
## Summary

- Add non-sensitive Codex identity detection for API-key, ChatGPT login, and Codex App metadata sources.
- Add a unified session ledger that records source/path metadata without persisting full transcript content.
- Route `omx resume --unified` and unified session search back through the original session source instead of merging sessions across identity domains.

## Privacy / safety

- The Codex App cache is read-only for this feature.
- The ledger stores metadata needed for navigation, not raw transcript contents or auth secrets.
- Local diff scan found no real local paths, personal email, GitHub tokens, bearer tokens, or OpenAI key-shaped secrets.

## Tests

- `npm run build`
- `node dist/scripts/run-test-files.js dist/auth/__tests__/identity.test.js dist/auth/__tests__/storage.test.js dist/cli/__tests__/auth.test.js dist/cli/__tests__/resume.test.js dist/cli/__tests__/session-search.test.js dist/session-ledger/__tests__/index.test.js`

## Prior PR

- Replaces #2880, which was closed because contributor PRs must target `dev` instead of `main`.
