### PR TITLE
fix: make skill routing guidance self-contained

### DIFF
--- a/plugins/oh-my-codex/skills/ultrawork/SKILL.md
+++ b/plugins/oh-my-codex/skills/ultrawork/SKILL.md
@@ -34,8 +34,8 @@ Sequential task execution wastes time when tasks are independent. Ultrawork keep
 - Prefer direct tool work when the task is small, coupled, or blocked on immediate local context. Delegate only when the work is independent enough to benefit from parallel execution.
 - When useful, run a direct-tool lane and one or more background evidence lanes at the same time. Evidence lanes can cover docs, tests, regression mapping, or bounded repo analysis.
 - Fire independent agent calls simultaneously -- never serialize independent work.
-- Always pass the `model` parameter explicitly when delegating.
-- Read `docs/shared/agent-tiers.md` before first delegation for agent selection guidance.
+- When delegating through Codex native subagents, set an explicit installed `agent_type` and use `reasoning_effort` for intensity.
+- Pass `model` only when the user, repo config, or task requires a concrete override.
 - Auto-delegate `researcher` when official docs, version-aware framework guidance, best practices, or external dependency behavior materially affect task correctness; treat it as an evidence lane, not a replacement primary workflow.
 - Use `run_in_background: true` for operations over ~30 seconds (installs, builds, tests).
 - Run quick commands (git status, file reads, simple checks) in the foreground.
@@ -44,7 +44,7 @@ Sequential task execution wastes time when tasks are independent. Ultrawork keep
 </Execution_Policy>
 
 <Steps>
-1. **Read agent reference**: Load `docs/shared/agent-tiers.md` for tier selection.
+1. **Select delegation lane**: Choose the subagent role by responsibility and choose the reasoning intensity from the self-contained routing rules below.
 2. **Context + certainty check**:
    - State the task intent in one sentence.
    - List the constraints and unknowns that could invalidate a quick fix.
@@ -71,9 +71,9 @@ Sequential task execution wastes time when tasks are independent. Ultrawork keep
 </Steps>
 
 <Tool_Usage>
-- Use LOW-tier delegation for simple lookups and bounded evidence gathering.
-- Use STANDARD-tier delegation for standard implementation and regression work.
-- Use THOROUGH-tier delegation for complex analysis, architectural review, or risky multi-file changes.
+- LOW intensity: use `agent_type="explore"` for repo lookup, `writer` for lightweight docs, or a tightly scoped `executor` lane with `reasoning_effort="low"` for narrow, non-invasive work.
+- STANDARD intensity: use `agent_type="executor"`, `debugger`, or `test-engineer` with `reasoning_effort="medium"` for normal implementation, debugging, and regression work.
+- THOROUGH intensity: use `agent_type="architect"`, `critic`, `code-reviewer`, or a high-impact `executor` lane with `reasoning_effort="xhigh"` for architectural, security-sensitive, or broad multi-file changes.
 - Prefer a direct-tool lane when the immediate next step is blocked on local context.
 - Prefer background evidence lanes when you can learn something useful in parallel with implementation.
 - Use `run_in_background: true` for package installs, builds, and test suites.

--- a/skills/ecomode/SKILL.md
+++ b/skills/ecomode/SKILL.md
@@ -45,11 +45,11 @@ Ecomode is a modifier that combines with execution modes:
 
 ## Agent Selection in Ecomode
 
-**FIRST ACTION:** Before delegating any work, read the agent reference file:
-```
-Read file: docs/shared/agent-tiers.md
-```
-This provides the complete agent tier matrix, MCP tool assignments, and selection guidance.
+Ecomode is deprecated, so do not add a repository-doc read prerequisite before delegation. If legacy ecomode routing needs to be interpreted, use this self-contained mapping:
+
+- LOW intensity: prefer `agent_type="explore"` for search, `writer` for documentation, or a tightly scoped `executor` lane with `reasoning_effort="low"`.
+- STANDARD intensity: use `agent_type="executor"`, `debugger`, or `test-engineer` with `reasoning_effort="medium"` when LOW is insufficient.
+- THOROUGH intensity: use `agent_type="architect"`, `critic`, or high-impact `executor` with `reasoning_effort="xhigh"` only when essential.
 
 **Ecomode preference order:**
 

--- a/skills/ultrawork/SKILL.md
+++ b/skills/ultrawork/SKILL.md
@@ -34,8 +34,8 @@ Sequential task execution wastes time when tasks are independent. Ultrawork keep
 - Prefer direct tool work when the task is small, coupled, or blocked on immediate local context. Delegate only when the work is independent enough to benefit from parallel execution.
 - When useful, run a direct-tool lane and one or more background evidence lanes at the same time. Evidence lanes can cover docs, tests, regression mapping, or bounded repo analysis.
 - Fire independent agent calls simultaneously -- never serialize independent work.
-- Always pass the `model` parameter explicitly when delegating.
-- Read `docs/shared/agent-tiers.md` before first delegation for agent selection guidance.
+- When delegating through Codex native subagents, set an explicit installed `agent_type` and use `reasoning_effort` for intensity.
+- Pass `model` only when the user, repo config, or task requires a concrete override.
 - Auto-delegate `researcher` when official docs, version-aware framework guidance, best practices, or external dependency behavior materially affect task correctness; treat it as an evidence lane, not a replacement primary workflow.
 - Use `run_in_background: true` for operations over ~30 seconds (installs, builds, tests).
 - Run quick commands (git status, file reads, simple checks) in the foreground.
@@ -44,7 +44,7 @@ Sequential task execution wastes time when tasks are independent. Ultrawork keep
 </Execution_Policy>
 
 <Steps>
-1. **Read agent reference**: Load `docs/shared/agent-tiers.md` for tier selection.
+1. **Select delegation lane**: Choose the subagent role by responsibility and choose the reasoning intensity from the self-contained routing rules below.
 2. **Context + certainty check**:
    - State the task intent in one sentence.
    - List the constraints and unknowns that could invalidate a quick fix.
@@ -71,9 +71,9 @@ Sequential task execution wastes time when tasks are independent. Ultrawork keep
 </Steps>
 
 <Tool_Usage>
-- Use LOW-tier delegation for simple lookups and bounded evidence gathering.
-- Use STANDARD-tier delegation for standard implementation and regression work.
-- Use THOROUGH-tier delegation for complex analysis, architectural review, or risky multi-file changes.
+- LOW intensity: use `agent_type="explore"` for repo lookup, `writer` for lightweight docs, or a tightly scoped `executor` lane with `reasoning_effort="low"` for narrow, non-invasive work.
+- STANDARD intensity: use `agent_type="executor"`, `debugger`, or `test-engineer` with `reasoning_effort="medium"` for normal implementation, debugging, and regression work.
+- THOROUGH intensity: use `agent_type="architect"`, `critic`, `code-reviewer`, or a high-impact `executor` lane with `reasoning_effort="xhigh"` for architectural, security-sensitive, or broad multi-file changes.
 - Prefer a direct-tool lane when the immediate next step is blocked on local context.
 - Prefer background evidence lanes when you can learn something useful in parallel with implementation.
 - Use `run_in_background: true` for package installs, builds, and test suites.

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -25,6 +25,28 @@ type NpmPackDryRunResult = {
 };
 
 describe('package bin contract', () => {
+  it('keeps packaged skill guidance independent from repo-local agent tier docs', () => {
+    const skillGuidancePaths = [
+      'skills/ultrawork/SKILL.md',
+      'skills/ecomode/SKILL.md',
+      'plugins/oh-my-codex/skills/ultrawork/SKILL.md',
+    ];
+
+    for (const relativePath of skillGuidancePaths) {
+      const content = readFileSync(join(process.cwd(), relativePath), 'utf-8');
+      assert.doesNotMatch(
+        content,
+        /docs\/shared\/agent-tiers\.md/,
+        `${relativePath} should not require repository-local agent tier docs after installation`,
+      );
+      assert.doesNotMatch(
+        content,
+        /references\/agent-tiers\.md/,
+        `${relativePath} should not require an unsupported nested skill reference directory`,
+      );
+    }
+  });
+
   it('declares omx with an explicit relative bin path and avoids packaging platform-specific native binaries', () => {
     const packageJsonPath = join(process.cwd(), 'package.json');
     const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as PackageJson;


### PR DESCRIPTION
## Summary

Fixes the installed OMX skill guidance for issue #2908. The published skill surface told agents to read `docs/shared/agent-tiers.md`, but that repo-local file is not available after npm/plugin installation. This keeps the installed guidance self-contained instead of adding unsupported nested `references/` skill assets.

## Changes

- Inline the minimal `agent_type` / `reasoning_effort` routing guidance needed by `$ultrawork`.
- Remove the repo-local `docs/shared/agent-tiers.md` read prerequisite from `$ultrawork` and the deprecated `$ecomode` shim.
- Keep the plugin skill mirror aligned with the canonical root skill.
- Add package contract coverage to prevent packaged skill guidance from depending on `docs/shared/agent-tiers.md` or `references/agent-tiers.md`.

## Validation

- [x] `npm run build`
- [ ] `npm test`
- [ ] `omx doctor` (when setup/config behavior changes)
- [x] `npm run verify:plugin-bundle`
- [x] `node dist/scripts/run-test-files.js dist/cli/__tests__/package-bin-contract.test.js dist/catalog/__tests__/plugin-bundle-ssot.test.js`
- [x] `npm run lint`
- [x] `git diff --check origin/dev...HEAD`
- [x] GitHub commit verification: signed and verified (`02090017`, `reason: valid`)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Closes #2908
