### PR TITLE
Prepare 0.18.14 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [0.18.14] - 2026-06-20
+
+Patch release for the post-`0.18.13` reliability train: agent/model routing diagnostics are clearer, goal/planning workflows are safer, plugin and native-hook behavior is sturdier, HUD/Team/tmux edge cases are tightened, doctor catches root-owned repo artifacts, and resume search discovers madmax run histories.
+
+### Changed
+
+- **Agent/model routing is more transparent** — per-agent model overrides and launch diagnostics expose selected roles, tiers, and launch arguments without changing the default CLI/package contract.
+- **Goal and planning workflow guidance is clearer** — completed Codex goal cleanup, Ralplan transition diagnostics, supervised Autopilot review rework, Beads metadata handling, and goal/skill docs reduce stale or ambiguous handoffs.
+- **Doctor and resume discovery cover more local cases** — root-owned repo artifact detection and madmax run-history discovery improve troubleshooting and continuation.
+
+### Fixed
+
+- **Plugin, setup, and native hooks are safer** — plugin AGENTS policy blocks survive setup, dev plugin cache diagnostics are clearer, bundled skill agent tier references are present, native hooks succeed on null output, PreToolUse stdout/schema behavior is preserved, and Windows native hook command launching avoids shell wrapping.
+- **HUD, Team, and tmux behavior is sturdier** — stale Autopilot HUD state, cramped guard rendering, standalone pane-scoped HUD state, paste-buffer cleanup, worker AGENTS guidance, and HUD pane ownership on shutdown are hardened.
+- **Ralplan and Autopilot gates are fresher** — Ralplan consensus approval/freshness checks, guard/HUD phase authority, stale Autopilot stop state, and Ultragoal architecture invariant handling are tightened.
+
+### PRs
+
+- #2912, #2906, #2905, #2900, #2899, #2897, #2896, #2895, #2894, #2889, #2888, #2884, #2879, #2878, #2877, #2875, #2874, #2873, #2861, #2859, #2852, #2850, #2848, #2828
+
+### Issues
+
+- Held open PRs #2902, #2856, #2840, #2839, and #2838 are excluded from this release candidate unless already in `origin/dev`; prep confirmed they are open and `BEHIND` on base `dev`.
+
+### Verification
+
+- Release readiness evidence is tracked in `docs/qa/release-readiness-0.18.14.md`.
+
 ## [0.18.13] - 2026-06-17
 
 Patch release for the post-`0.18.12` reliability train: project-scoped resume/search discovery is broader, setup and hook handling are safer, ralplan/autopilot consensus gates are fresher, CI/release infrastructure is sturdier, sidecar Team state roots align with runtime behavior, geobench documentation/schema fixes are captured, and release prep selects `0.18.13` rather than `0.19.0` after explicit no-breaking-change review.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "omx-api"
-version = "0.18.13"
+version = "0.18.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -40,14 +40,14 @@ dependencies = [
 
 [[package]]
 name = "omx-explore-harness"
-version = "0.18.13"
+version = "0.18.14"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "omx-mux"
-version = "0.18.13"
+version = "0.18.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime"
-version = "0.18.13"
+version = "0.18.14"
 dependencies = [
  "omx-mux",
  "omx-runtime-core",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime-core"
-version = "0.18.13"
+version = "0.18.14"
 dependencies = [
  "fs2",
  "serde",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "omx-sparkshell"
-version = "0.18.13"
+version = "0.18.14"
 dependencies = [
  "omx-mux",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.18.13"
+version = "0.18.14"
 
 edition = "2021"
 rust-version = "1.73"

--- a/docs/qa/release-readiness-0.18.14.md
+++ b/docs/qa/release-readiness-0.18.14.md
@@ -1,0 +1,111 @@
+# Release readiness: oh-my-codex 0.18.14
+
+## Range
+
+- Previous tag: `v0.18.13`.
+- Candidate branch during prep: `release-0.18.14` from `origin/dev`.
+- Frozen candidate at intake: `c437fcab` (`fix: bundle skill agent tier references (#2912)`) plus local release metadata/collateral updates to `0.18.14`.
+- Compare range for release notes: `origin/main..origin/dev` as requested for this release candidate.
+- Release tag to create after PR, dev/main promotion, and release approval: `v0.18.14`.
+- Explicit release boundary: open PRs #2902, #2856, #2840, #2839, and #2838 are excluded unless already in `origin/dev`; `gh pr view` confirmed each is open with `mergeStateStatus: BEHIND` on base `dev` during prep.
+
+## Evidence lifecycle
+
+This file is the pre-tag release-prep readiness record for the `0.18.14` candidate. PR CI, dev/main promotion, tag-triggered release workflow, GitHub release proof, and npm proof remain owner/final release gates after this branch is reviewed and merged.
+
+## Release scope
+
+`0.18.14` packages the post-`0.18.13` compatibility-preserving hardening train:
+
+- Per-agent model overrides and model-routing launch diagnostics improve operator visibility into role/model selection.
+- Ultragoal, Ralplan, Autopilot, completed-goal cleanup, transition diagnostics, and Beads planning metadata handling are tightened.
+- Plugin bundle, plugin AGENTS policy preservation, dev plugin cache diagnostics, native hook null-output success, PreToolUse stdout/schema handling, and Windows hook command launching are hardened.
+- HUD state/reporting/display behavior, tmux paste-buffer cleanup, Team worker AGENTS guidance preservation, and HUD pane ownership on shutdown are safer.
+- Doctor detects root-owned repo artifacts, and resume search discovers madmax run histories.
+- Workflow docs clarify goal and skill guidance.
+
+## Version decision
+
+- Selected release version: `0.18.14`.
+- Rejected release version: `0.19.0`.
+- Rationale: release-scope review found no removed active command, package bin/engine break, incompatible public schema, or breaking public API change. The current scope is fixes, diagnostics, docs, additive configuration visibility, and compatibility-preserving runtime/hook/setup/plugin/HUD/Team hardening.
+
+## Merged PR / commit inventory
+
+- [#2912](https://github.com/Yeachan-Heo/oh-my-codex/pull/2912) — Bundle skill agent tier references.
+- [#2906](https://github.com/Yeachan-Heo/oh-my-codex/pull/2906) — Fix HUD stale Autopilot reporting.
+- [#2905](https://github.com/Yeachan-Heo/oh-my-codex/pull/2905) — Clarify goal and skill workflow guidance.
+- [#2900](https://github.com/Yeachan-Heo/oh-my-codex/pull/2900) — Add model routing launch diagnostics.
+- [#2899](https://github.com/Yeachan-Heo/oh-my-codex/pull/2899) — Preserve AGENTS guidance in Team worker worktrees.
+- [#2897](https://github.com/Yeachan-Heo/oh-my-codex/pull/2897) — Detect root-owned repo artifacts in doctor.
+- [#2896](https://github.com/Yeachan-Heo/oh-my-codex/pull/2896) — Fix HUD cramped guard and tmux buffer cleanup.
+- [#2895](https://github.com/Yeachan-Heo/oh-my-codex/pull/2895) — Preserve PreToolUse planning guard output.
+- [#2894](https://github.com/Yeachan-Heo/oh-my-codex/pull/2894) — Make completed Codex goal cleanup explicit.
+- [#2889](https://github.com/Yeachan-Heo/oh-my-codex/pull/2889) — Harden dev plugin cache diagnostics.
+- [#2888](https://github.com/Yeachan-Heo/oh-my-codex/pull/2888) — Fix PreToolUse native hook stdout schema.
+- [#2884](https://github.com/Yeachan-Heo/oh-my-codex/pull/2884) — Fix Ralplan consensus gate approval and freshness checks.
+- [#2879](https://github.com/Yeachan-Heo/oh-my-codex/pull/2879) — Fix Ralplan guard and HUD phase authority.
+- [#2878](https://github.com/Yeachan-Heo/oh-my-codex/pull/2878) — Fix stale Autopilot stop state.
+- [#2877](https://github.com/Yeachan-Heo/oh-my-codex/pull/2877) — Preserve plugin AGENTS policy blocks during setup.
+- [#2875](https://github.com/Yeachan-Heo/oh-my-codex/pull/2875) — Allow Beads tracker metadata during planning.
+- [#2874](https://github.com/Yeachan-Heo/oh-my-codex/pull/2874) — Keep native hooks successful on null output.
+- [#2873](https://github.com/Yeachan-Heo/oh-my-codex/pull/2873) — Harden tmux supervisor paste buffers.
+- [#2861](https://github.com/Yeachan-Heo/oh-my-codex/pull/2861) — Keep standalone pane-scoped HUD stable.
+- [#2859](https://github.com/Yeachan-Heo/oh-my-codex/pull/2859) — Avoid shell-wrapping Windows native hook node.
+- [#2852](https://github.com/Yeachan-Heo/oh-my-codex/pull/2852) — Discover madmax run histories for resume search.
+- [#2850](https://github.com/Yeachan-Heo/oh-my-codex/pull/2850) — Add per-agent model overrides.
+- [#2848](https://github.com/Yeachan-Heo/oh-my-codex/pull/2848) — Add Ultragoal architecture invariant gate.
+- [#2828](https://github.com/Yeachan-Heo/oh-my-codex/pull/2828) — Preserve HUD pane ownership on shutdown.
+- `6917f59f` — Explain Ralplan transition validator diagnostics.
+- `e392a190` — Add supervised Autopilot review rework phase.
+
+## Held PR inventory
+
+- [#2902](https://github.com/Yeachan-Heo/oh-my-codex/pull/2902) — open, base `dev`, `BEHIND`; excluded.
+- [#2856](https://github.com/Yeachan-Heo/oh-my-codex/pull/2856) — open, base `dev`, `BEHIND`; excluded.
+- [#2840](https://github.com/Yeachan-Heo/oh-my-codex/pull/2840) — open, base `dev`, `BEHIND`; excluded.
+- [#2839](https://github.com/Yeachan-Heo/oh-my-codex/pull/2839) — open, base `dev`, `BEHIND`; excluded.
+- [#2838](https://github.com/Yeachan-Heo/oh-my-codex/pull/2838) — open, base `dev`, `BEHIND`; excluded.
+
+## Version and lockfile audit
+
+- Root `package.json` and `package-lock.json`: bumped to `0.18.14`.
+- Root `Cargo.toml` workspace package version and root `Cargo.lock` workspace packages (`omx-api`, `omx-explore-harness`, `omx-mux`, `omx-runtime`, `omx-runtime-core`, `omx-sparkshell`): bumped to `0.18.14`.
+- `plugins/oh-my-codex/.codex-plugin/plugin.json`: synced to `0.18.14`.
+- `node dist/scripts/check-version-sync.js --tag v0.18.14`: local release-prep gate.
+
+## Local validation evidence
+
+Commands are run from `/home/bellman/Workspace/oh-my-codex-release-0.18.14` on branch `release-0.18.14`.
+
+- [x] `npm run build` — PASS.
+- [x] `node dist/scripts/check-version-sync.js --tag v0.18.14` — PASS (`package=0.18.14 workspace=0.18.14 tag=v0.18.14`).
+- [x] `npm run verify:native-agents` — PASS (`verified 22 installable native agents and 37 setup prompt assets`).
+- [x] `npm run verify:plugin-bundle` — PASS (`verified 29 canonical skill directories and plugin metadata`).
+- [x] `node dist/scripts/generate-catalog-docs.js --check` — PASS (`catalog check ok`).
+- [x] `npm pack --dry-run` — PASS (`oh-my-codex-0.18.14.tgz`, package size `4.1 MB`, unpacked size `25.5 MB`, `3072` files).
+- [x] `node dist/cli/omx.js --version` — PASS (`oh-my-codex v0.18.14`).
+- [x] `node dist/cli/omx.js --help` — PASS (help rendered successfully).
+- [x] `git diff --check` — PASS.
+
+## CI / publication evidence
+
+- [ ] Release-prep PR CI — pending after PR creation.
+- [ ] Dev/main promotion CI — pending after owner merge/promotion.
+- [ ] Tag-triggered release workflow — owner/final release gate; not run locally.
+- [ ] GitHub release proof — owner/final release gate; not run locally.
+- [ ] npm proof — owner/final release gate; not run locally.
+
+## Current readiness verdict
+
+`RELEASE_PREP_READY`: local release-prep verification passed. PR CI, dev/main promotion, tag-triggered release workflow, GitHub release proof, and npm publication proof remain intentionally unexecuted owner/final release gates.
+
+## Release handoff
+
+Release-prep branch should hand off:
+
+- Release collateral: `CHANGELOG.md`, `RELEASE_BODY.md`, `docs/release-notes-0.18.14.md`, and this readiness file.
+- Version/package metadata: `package.json`, `package-lock.json`, `Cargo.toml`, `Cargo.lock`, and `plugins/oh-my-codex/.codex-plugin/plugin.json`.
+- Concise local verification PASS results from the required release-prep gates above.
+
+Known gaps / pending gates: PR CI, dev/main promotion, tag-triggered release workflow, GitHub release proof, and npm publication proof remain intentionally unexecuted until owner/final release approval.

--- a/docs/release-notes-0.18.14.md
+++ b/docs/release-notes-0.18.14.md
@@ -1,6 +1,6 @@
 # oh-my-codex 0.18.14
 
-> Draft status: release-prep PR body source before tagging. Keep publication proof updates in `docs/qa/release-readiness-0.18.14.md` after PR CI, tag workflow, GitHub release creation, and npm publication.
+> Release note status: pre-tag release-prep draft. Local validation evidence is tracked in `docs/qa/release-readiness-0.18.14.md`; final PR CI, dev/main promotion, tag workflow, GitHub release proof, and npm proof remain publication-stage evidence to append after those gates run.
 
 `0.18.14` is a patch release after `0.18.13` focused on safer workflow orchestration, clearer agent/model routing diagnostics, sturdier plugin/HUD/team behavior, and release-candidate hygiene from the current `origin/dev` delta. It preserves the existing CLI/package contract while tightening setup, hook, HUD, Team, Ralplan, Autopilot, Ultragoal, and plugin-bundle edge cases discovered after `0.18.13`.
 
@@ -48,19 +48,14 @@ Primary merged PR and commit evidence in the current `origin/main..origin/dev` c
 - #2828 — Preserve HUD pane ownership on shutdown.
 - Direct commits — explain Ralplan transition validator diagnostics and add supervised Autopilot review rework phase.
 
+## Issues
+
+Held open PRs #2902, #2856, #2840, #2839, and #2838 remain outside this release candidate. They are behind `dev` and are treated as owner-confirmation/user-facing contract holds rather than `0.18.14` release blockers.
+
 ## Validation
 
 Release readiness evidence is recorded in `docs/qa/release-readiness-0.18.14.md`.
 
 Release-prep gates include version sync for `v0.18.14`, build, native-agent verification, plugin mirror/bundle checks, catalog docs check, dogfooding of built CLI surfaces, `npm pack --dry-run`, and `git diff --check`. Branch CI, dev/main promotion, tag-triggered release workflow, GitHub release proof, and npm publication proof remain publication-stage gates.
-
-The GitHub release workflow remains the authoritative cross-platform native asset gate after tag push, including the uploaded `native-release-manifest.json`.
-
-## Contributors
-
-Thanks to the contributors who landed the `v0.18.13...v0.18.14` delta:
-
-- [@Bellman](https://github.com/Bellman)
-- [@jihun-jeong](https://github.com/jihun-jeong)
 
 **Full Changelog**: [`v0.18.13...v0.18.14`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.18.13...v0.18.14)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-codex",
-  "version": "0.18.13",
+  "version": "0.18.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-codex",
-      "version": "0.18.13",
+      "version": "0.18.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.18.13",
+  "version": "0.18.14",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/oh-my-codex/.codex-plugin/plugin.json
+++ b/plugins/oh-my-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.18.13",
+  "version": "0.18.14",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "author": {
     "name": "Yeachan Heo",


### PR DESCRIPTION
# oh-my-codex 0.18.14 release prep

Prepares the `0.18.14` release candidate from the current `origin/main..origin/dev` delta.

## Scope

- Bumps root npm, Cargo workspace/lockfile, and plugin metadata to `0.18.14`.
- Adds/updates release collateral following the `0.18.13` pattern:
  - `CHANGELOG.md`
  - `RELEASE_BODY.md`
  - `docs/release-notes-0.18.14.md`
  - `docs/qa/release-readiness-0.18.14.md`
- Summarizes only `origin/main..origin/dev` release commits, including skill agent tier references, HUD stale Autopilot reporting, `/goal`/skill docs, model routing diagnostics, doctor root-owned artifacts, Team AGENTS/worktree/HUD handling, PreToolUse/planning hook hardening, Ralplan/Autopilot consensus/guard fixes, tmux paste buffers, setup plugin AGENTS preservation, Beads planning metadata, null hook output, per-agent model overrides, madmax resume search, and the Ultragoal architecture invariant gate.
- Excludes held open PRs #2902/#2856/#2840/#2839/#2838; confirmed open, base `dev`, `BEHIND`.

## Verification

- PASS — `npm run build`
- PASS — `node dist/scripts/check-version-sync.js --tag v0.18.14` (`package=0.18.14 workspace=0.18.14 tag=v0.18.14`)
- PASS — `npm run verify:native-agents` (`verified 22 installable native agents and 37 setup prompt assets`)
- PASS — `npm run verify:plugin-bundle` (`verified 29 canonical skill directories and plugin metadata`)
- PASS — `node dist/scripts/generate-catalog-docs.js --check` (`catalog check ok`)
- PASS — `npm pack --dry-run` (`oh-my-codex-0.18.14.tgz`, package size `4.1 MB`, unpacked size `25.5 MB`, `3072` files)
- PASS — `node dist/cli/omx.js --version` (`oh-my-codex v0.18.14`)
- PASS — `node dist/cli/omx.js --help`
- PASS — `git diff --check`
- PASS — final review gate: `ai-slop-cleaner` no-op scoped cleanup, independent `code-reviewer` APPROVE, independent `architect` CLEAR.

## Not executed by design

- Did not merge any open PR.
- Did not push `main`.
- Did not create or push tag `v0.18.14`.
- Did not run `npm publish`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
