### PR TITLE
Route cheap Autopilot planning to planner

### DIFF
--- a/docs/reference/omx-config-schema-routing.md
+++ b/docs/reference/omx-config-schema-routing.md
@@ -114,7 +114,7 @@ Supported model-routing keys:
 | Key shape | Purpose |
 | --- | --- |
 | `default` | Fallback for `getModelForMode(mode)` when the requested mode has no explicit key. |
-| Any mode key, for example `team`, `autopilot`, `ralph` | Explicit model for that mode when code calls `getModelForMode("mode")`. |
+| Any mode key, for example `team`, `autopilot`, `ralph` | Explicit model for that mode when code calls `getModelForMode("mode")`. If `models.autopilot` or the inherited main/default model is cheap/mini, Autopilot records dedicated planner ownership for heavy ralplan planning. |
 | `team_low_complexity` | Low-complexity team/spark model override. |
 | `team-low-complexity` | Alias for `team_low_complexity`. |
 | `teamLowComplexity` | Alias for `team_low_complexity`. |
@@ -216,7 +216,7 @@ Examples:
 
 | Role/category | Examples | Model class behavior |
 | --- | --- | --- |
-| Exact mini planning/research | `planner`, `architect`, `researcher` | Uses the exact `gpt-5.4-mini` pin before model-class routing unless `agentModels[role]` is set; planner/architect keep `frontier-orchestrator` posture and high reasoning, while ralplan's `critic` remains frontier-routed for the consensus gate. |
+| Exact mini planning/research | `planner`, `architect`, `researcher` | Uses the exact `gpt-5.4-mini` pin before model-class routing unless `agentModels[role]` is set; planner/architect keep `frontier-orchestrator` posture and high reasoning, while ralplan's `critic` remains frontier-routed for the consensus gate. In Autopilot, `planning_routing.owner` switches the initial ralplan Planner draft/decomposition to this dedicated `planner` role when `[main]` is cheap/mini or when `agentModels.planner` is configured. |
 | Frontier orchestration | `critic`, `code-reviewer`, `security-reviewer`, `team-executor`, `vision` | Native-agent generation uses active `config.toml` root `model` first, then the main/frontier default fallback. |
 | Standard worker/review | `debugger`, `quality-reviewer`, `api-reviewer`, `performance-reviewer`, `dependency-expert`, `writer` | Uses the standard-lane default, which inherits main/frontier unless `OMX_DEFAULT_STANDARD_MODEL` is set. |
 | Fast/low-complexity | `explore`, `style-reviewer` | Uses the spark/low-complexity default. |

--- a/plugins/oh-my-codex/skills/autopilot/SKILL.md
+++ b/plugins/oh-my-codex/skills/autopilot/SKILL.md
@@ -37,7 +37,8 @@ Autopilot must not run a separate broad expansion/planning/execution/QA/validati
 
 2. **Phase `ralplan`** — consensus planning gate
    - Ground the task with pre-context intake and the deep-interview artifact.
-   - Run or resume `$ralplan` to produce/update PRD and test-spec artifacts.
+   - Current ownership rule: Autopilot records `planning_routing` in state before heavy planning. When the Autopilot/main model resolves to a cheap/mini lane (for example `o4-mini`, `*-mini`, `*spark*`, or an explicitly cheap/economy/lite model name), the initial planning/decomposition owner is dedicated `[planner]`; otherwise `[main]` may keep ownership for backward compatibility. A configured `agentModels.planner` is an explicit opt-in that forces dedicated `[planner]` ownership even when `[main]` is not cheap/mini.
+   - Run or resume `$ralplan` to produce/update PRD and test-spec artifacts. If `planning_routing.owner` is `planner`, use the dedicated `[planner]` role for the initial Planner draft/decomposition before the Architect→Critic consensus gates.
    - PRD/test-spec files alone are not completion evidence. Ralplan may hand off only after durable consensus evidence records a subsequent `Architect` approval first and a subsequent `Critic` approval second.
    - When returning from a non-clean review or QA pass, include `return_to_ralplan_reason` and the findings as first-class planning input.
    - If either review is missing, blocked, out of order, or non-approving, remain in `ralplan` or report an explicit blocker/max-iteration outcome; do not progress to `$ultragoal`, `$team`, `$ralph`, or implementation.

--- a/plugins/oh-my-codex/skills/ralplan/SKILL.md
+++ b/plugins/oh-my-codex/skills/ralplan/SKILL.md
@@ -42,7 +42,7 @@ $plan --consensus --interactive <arguments>
 ```
 
 The consensus workflow:
-1. **Planner** creates an adaptive plan (right-sized to task scope; do not default to exactly five steps) and a compact **RALPLAN-DR summary** before review:
+1. **Planner** creates an adaptive plan (right-sized to task scope; do not default to exactly five steps) and a compact **RALPLAN-DR summary** before review. Current `[main]` vs `[planner]` behavior: standalone `$ralplan` may be authored by the active main planning lane unless the caller/runtime supplies a dedicated planner routing record; inside `$autopilot`, state field `planning_routing.owner:"planner"` means the initial Planner draft/decomposition must use dedicated `[planner]`. Set `.omx-config.json` `agentModels.planner` to opt into a specific planner model and force dedicated planner ownership for complex Autopilot planning even when `[main]` is not cheap/mini. The RALPLAN-DR summary includes:
    - Principles (3-5)
    - Decision Drivers (top 3)
    - Viable Options (>=2) with bounded pros/cons

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -37,7 +37,8 @@ Autopilot must not run a separate broad expansion/planning/execution/QA/validati
 
 2. **Phase `ralplan`** — consensus planning gate
    - Ground the task with pre-context intake and the deep-interview artifact.
-   - Run or resume `$ralplan` to produce/update PRD and test-spec artifacts.
+   - Current ownership rule: Autopilot records `planning_routing` in state before heavy planning. When the Autopilot/main model resolves to a cheap/mini lane (for example `o4-mini`, `*-mini`, `*spark*`, or an explicitly cheap/economy/lite model name), the initial planning/decomposition owner is dedicated `[planner]`; otherwise `[main]` may keep ownership for backward compatibility. A configured `agentModels.planner` is an explicit opt-in that forces dedicated `[planner]` ownership even when `[main]` is not cheap/mini.
+   - Run or resume `$ralplan` to produce/update PRD and test-spec artifacts. If `planning_routing.owner` is `planner`, use the dedicated `[planner]` role for the initial Planner draft/decomposition before the Architect→Critic consensus gates.
    - PRD/test-spec files alone are not completion evidence. Ralplan may hand off only after durable consensus evidence records a subsequent `Architect` approval first and a subsequent `Critic` approval second.
    - When returning from a non-clean review or QA pass, include `return_to_ralplan_reason` and the findings as first-class planning input.
    - If either review is missing, blocked, out of order, or non-approving, remain in `ralplan` or report an explicit blocker/max-iteration outcome; do not progress to `$ultragoal`, `$team`, `$ralph`, or implementation.

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -42,7 +42,7 @@ $plan --consensus --interactive <arguments>
 ```
 
 The consensus workflow:
-1. **Planner** creates an adaptive plan (right-sized to task scope; do not default to exactly five steps) and a compact **RALPLAN-DR summary** before review:
+1. **Planner** creates an adaptive plan (right-sized to task scope; do not default to exactly five steps) and a compact **RALPLAN-DR summary** before review. Current `[main]` vs `[planner]` behavior: standalone `$ralplan` may be authored by the active main planning lane unless the caller/runtime supplies a dedicated planner routing record; inside `$autopilot`, state field `planning_routing.owner:"planner"` means the initial Planner draft/decomposition must use dedicated `[planner]`. Set `.omx-config.json` `agentModels.planner` to opt into a specific planner model and force dedicated planner ownership for complex Autopilot planning even when `[main]` is not cheap/mini. The RALPLAN-DR summary includes:
    - Principles (3-5)
    - Decision Drivers (top 3)
    - Viable Options (>=2) with bounded pros/cons

--- a/src/autopilot/__tests__/planner-routing.test.ts
+++ b/src/autopilot/__tests__/planner-routing.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  getDefaultPlannerModel,
+  isCheapOrMiniModelName,
+  resolveAutopilotPlannerRouting,
+} from '../planner-routing.js';
+
+async function writeConfig(codexHome: string, config: Record<string, unknown>): Promise<void> {
+  await writeFile(join(codexHome, '.omx-config.json'), JSON.stringify(config));
+}
+
+describe('autopilot planner routing', () => {
+  let tempDir: string;
+  let originalCodexHome: string | undefined;
+  let originalFrontier: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'omx-autopilot-planner-routing-'));
+    originalCodexHome = process.env.CODEX_HOME;
+    originalFrontier = process.env.OMX_DEFAULT_FRONTIER_MODEL;
+    process.env.CODEX_HOME = tempDir;
+    delete process.env.OMX_DEFAULT_FRONTIER_MODEL;
+  });
+
+  afterEach(async () => {
+    if (originalCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = originalCodexHome;
+    if (originalFrontier === undefined) delete process.env.OMX_DEFAULT_FRONTIER_MODEL;
+    else process.env.OMX_DEFAULT_FRONTIER_MODEL = originalFrontier;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('classifies cheap and mini model names without matching unrelated words', () => {
+    assert.equal(isCheapOrMiniModelName('o4-mini'), true);
+    assert.equal(isCheapOrMiniModelName('gpt-5.3-codex-spark'), true);
+    assert.equal(isCheapOrMiniModelName('vendor/cheap-router'), true);
+    assert.equal(isCheapOrMiniModelName('gpt-5.5'), false);
+    assert.equal(isCheapOrMiniModelName('dominican-router'), false);
+  });
+
+  it('keeps planning on main when autopilot main is not cheap and no planner override exists', async () => {
+    await writeConfig(tempDir, { models: { autopilot: 'gpt-5.5' } });
+
+    assert.deepEqual(resolveAutopilotPlannerRouting(tempDir), {
+      owner: 'main',
+      mainModel: 'gpt-5.5',
+      plannerModel: 'gpt-5.4-mini',
+      reason: 'main_not_cheap_or_mini',
+      explicitPlannerOverride: false,
+    });
+  });
+
+  it('routes complex autopilot planning to planner when autopilot main is cheap or mini', async () => {
+    await writeConfig(tempDir, { models: { autopilot: 'o4-mini' } });
+
+    assert.deepEqual(resolveAutopilotPlannerRouting(tempDir), {
+      owner: 'planner',
+      mainModel: 'o4-mini',
+      plannerModel: 'gpt-5.4-mini',
+      reason: 'main_is_cheap_or_mini',
+      explicitPlannerOverride: false,
+    });
+  });
+
+  it('lets agentModels.planner explicitly opt into dedicated planner ownership', async () => {
+    await writeConfig(tempDir, {
+      models: { autopilot: 'gpt-5.5' },
+      agentModels: { planner: 'gpt-5.5-planner' },
+    });
+
+    assert.deepEqual(resolveAutopilotPlannerRouting(tempDir), {
+      owner: 'planner',
+      mainModel: 'gpt-5.5',
+      plannerModel: 'gpt-5.5-planner',
+      reason: 'explicit_planner_override',
+      explicitPlannerOverride: true,
+    });
+    assert.equal(getDefaultPlannerModel(tempDir), 'gpt-5.5-planner');
+  });
+});

--- a/src/autopilot/planner-routing.ts
+++ b/src/autopilot/planner-routing.ts
@@ -1,0 +1,81 @@
+import { AGENT_DEFINITIONS } from '../agents/definitions.js';
+import {
+  getAgentModelOverride,
+  getMainDefaultModel,
+  getModelForMode,
+} from '../config/models.js';
+
+export type AutopilotPlanningOwner = 'main' | 'planner';
+
+export interface AutopilotPlannerRoutingDecision {
+  owner: AutopilotPlanningOwner;
+  mainModel: string;
+  plannerModel: string;
+  reason: 'main_is_cheap_or_mini' | 'explicit_planner_override' | 'main_not_cheap_or_mini';
+  explicitPlannerOverride: boolean;
+}
+
+const CHEAP_OR_MINI_MODEL_PATTERN = /(?:^|[-_:/\s])(?:o\d+-mini|mini|nano|small|cheap|economy|spark|lite|flash)(?:$|[-_:/\s])/i;
+
+function normalizeModelName(value: string): string {
+  return value.trim();
+}
+
+export function isCheapOrMiniModelName(model: string): boolean {
+  const normalized = normalizeModelName(model);
+  if (!normalized) return false;
+  return CHEAP_OR_MINI_MODEL_PATTERN.test(normalized);
+}
+
+export function getDefaultPlannerModel(codexHomeOverride?: string): string {
+  return getAgentModelOverride('planner', codexHomeOverride)
+    ?? AGENT_DEFINITIONS.planner.exactModel
+    ?? getMainDefaultModel(codexHomeOverride);
+}
+
+/**
+ * Decide who owns heavy Autopilot planning before the ralplan consensus gates.
+ *
+ * Backward compatibility: when the Autopilot/main model is not recognizably
+ * cheap/mini and no planner override exists, planning remains on main. When a
+ * maintainer deliberately makes main cheap, or configures `agentModels.planner`,
+ * Autopilot records a dedicated planner owner so the ralplan draft/decomposition
+ * phase does not silently stay on the economy lane.
+ */
+export function resolveAutopilotPlannerRouting(
+  codexHomeOverride?: string,
+): AutopilotPlannerRoutingDecision {
+  const mainModel = getModelForMode('autopilot', codexHomeOverride);
+  const explicitPlannerModel = getAgentModelOverride('planner', codexHomeOverride);
+  const plannerModel = explicitPlannerModel ?? getDefaultPlannerModel(codexHomeOverride);
+  const explicitPlannerOverride = Boolean(explicitPlannerModel);
+  const mainIsCheapOrMini = isCheapOrMiniModelName(mainModel);
+
+  if (explicitPlannerOverride) {
+    return {
+      owner: 'planner',
+      mainModel,
+      plannerModel,
+      reason: 'explicit_planner_override',
+      explicitPlannerOverride,
+    };
+  }
+
+  if (mainIsCheapOrMini) {
+    return {
+      owner: 'planner',
+      mainModel,
+      plannerModel,
+      reason: 'main_is_cheap_or_mini',
+      explicitPlannerOverride,
+    };
+  }
+
+  return {
+    owner: 'main',
+    mainModel,
+    plannerModel,
+    reason: 'main_not_cheap_or_mini',
+    explicitPlannerOverride,
+  };
+}

--- a/src/hooks/__tests__/autopilot-skill-contract.test.ts
+++ b/src/hooks/__tests__/autopilot-skill-contract.test.ts
@@ -57,6 +57,14 @@ describe('autopilot skill default Ultragoal contract', () => {
     assert.match(autopilotSkill, /do not progress to `\$ultragoal`, `\$team`, `\$ralph`, or implementation/i);
   });
 
+  it('documents dedicated planner routing when Autopilot main is cheap or mini', () => {
+    assert.match(autopilotSkill, /planning_routing/i);
+    assert.match(autopilotSkill, /cheap\/mini lane[\s\S]*`\[main\]`/i);
+    assert.match(autopilotSkill, /dedicated `\[planner\]`/i);
+    assert.match(ralplanSkill, /`agentModels\.planner`/i);
+    assert.match(ralplanSkill, /initial Planner draft/i);
+  });
+
   it('documents optional deep-interview execution contract validation without broadness inference', () => {
     assert.match(autopilotSkill, /execution_contract_required:true/i);
     assert.match(autopilotSkill, /execution_contract/i);

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -693,6 +693,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
           review_verdict: unknown;
           qa_verdict: unknown;
           return_to_ralplan_reason: string | null;
+          planning_routing: Record<string, unknown>;
         };
       };
       assert.equal(modeState.mode, 'autopilot');
@@ -732,6 +733,13 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(modeState.state.review_verdict, null);
       assert.equal(modeState.state.qa_verdict, null);
       assert.equal(modeState.state.return_to_ralplan_reason, null);
+      assert.deepEqual(modeState.state.planning_routing, {
+        owner: 'main',
+        mainModel: 'gpt-5.5',
+        plannerModel: 'gpt-5.4-mini',
+        reason: 'main_not_cheap_or_mini',
+        explicitPlannerOverride: false,
+      });
       const snapshot = await readFile(join(cwd, '.omx', 'context', 'please-run-and-keep-going-20260225T000000Z.md'), 'utf-8');
       assert.match(snapshot, /activation prompt \/ task seed: please run \$autopilot and keep going/);
       assert.match(snapshot, /scope note: this seed captures the Autopilot activation prompt/);
@@ -739,6 +747,48 @@ describe('keyword detector skill-active-state lifecycle', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('seeds dedicated planner routing in Autopilot state when main is cheap', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-planner-routing-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-keyword-codex-home-'));
+    const previousCodexHome = process.env.CODEX_HOME;
+    try {
+      process.env.CODEX_HOME = codexHome;
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(codexHome, '.omx-config.json'), JSON.stringify({
+        models: { autopilot: 'o4-mini' },
+        agentModels: { planner: 'gpt-5.5-planner' },
+      }));
+
+      await recordSkillActivation({
+        stateDir,
+        sourceCwd: cwd,
+        text: '$autopilot implement issue #2918',
+        sessionId: 'sess-planner-routing',
+        threadId: 'thread-planner-routing',
+        turnId: 'turn-planner-routing',
+        nowIso: AUTOPILOT_TEST_NOW,
+      });
+
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-planner-routing', 'autopilot-state.json'), 'utf-8'),
+      ) as { state?: { planning_routing?: Record<string, unknown> } };
+      assert.deepEqual(modeState.state?.planning_routing, {
+        owner: 'planner',
+        mainModel: 'o4-mini',
+        plannerModel: 'gpt-5.5-planner',
+        reason: 'explicit_planner_override',
+        explicitPlannerOverride: true,
+      });
+    } finally {
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
   it('migrates legacy Autopilot context snapshot paths into handoff artifacts', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-legacy-context-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -44,6 +44,7 @@ import {
   type DeepInterviewRuntimeConfig,
 } from '../config/deep-interview.js';
 import { inferTerminalLifecycleOutcome } from '../runtime/run-outcome.js';
+import { resolveAutopilotPlannerRouting } from '../autopilot/planner-routing.js';
 
 export interface KeywordMatch {
   keyword: string;
@@ -769,6 +770,9 @@ async function persistStatefulSkillSeedState(
             skip_reason: null,
             rationale: 'Autopilot starts at the deep-interview gate by default; clear bounded tasks may skip only with an explicit persisted skip reason.',
           },
+      planning_routing: existingState.planning_routing && typeof existingState.planning_routing === 'object'
+        ? existingState.planning_routing
+        : resolveAutopilotPlannerRouting(process.env.CODEX_HOME),
     };
   }
 


### PR DESCRIPTION
## Summary
- Add deterministic Autopilot planner routing so cheap/mini `[main]` models delegate heavy planning ownership to `[planner]` when a planner lane is configured.
- Preserve existing behavior for frontier/non-cheap main models unless an explicit planner override is present.
- Document the current `$autopilot` / `$ralplan` `[main]` vs `[planner]` split and the `agentModels.planner` opt-in.
- Add regression coverage for planner selection and prompt routing contract surfaces.

Fixes #2918

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/autopilot/__tests__/planner-routing.test.js dist/hooks/__tests__/keyword-detector.test.js dist/hooks/__tests__/autopilot-skill-contract.test.js dist/config/__tests__/models.test.js`
- `npm run check:no-unused`
- `npm run lint`
- `npm run verify:plugin-bundle`
- `npm run verify:native-agents`

## Notes
Native child-agent review was intentionally not used for this lane because #2916 exposed close/wait fragility and the task explicitly constrained the session to avoid native child agents.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
