### PR TITLE
[codex] Skip legacy notify setup on Windows

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -20,6 +20,15 @@ installs and older Codex versions that do not report `plugin_hooks`:
 - `.codex/hooks.json` → registers the OMX-managed native hook command while preserving non-OMX hook entries already in the file
 - `.codex/config.toml` → also records `hooks.state."<hooks.json>:<event>:<group>:<handler>".trusted_hash` for the OMX-owned wrappers so recent Codex releases do not require a manual `/hooks` review for setup-managed hooks
 
+Windows compatibility note: user-scope setup does not install or refresh the
+OMX-managed legacy top-level `notify = [...]` hook on Windows. Native Codex
+hooks remain enabled through `[features].hooks = true` and `hooks.json`; the
+legacy notify path can receive large turn payloads as command-line arguments and
+hit Windows process creation limits before the OMX notify script starts.
+Explicit user-owned `notify` commands are preserved, but OMX-managed
+`notify-hook.js` / `notify-dispatcher.js` entries are removed during Windows
+setup refresh.
+
 Compatibility note: Codex CLI 0.129/0.130 treats `hooks` as the canonical stable feature key and keeps `codex_hooks` only as a legacy alias. Some public hook examples may still show `[features].codex_hooks = true`; OMX-generated fallback config intentionally emits `[features].hooks = true` while setup/uninstall migration paths still accept and normalize older `codex_hooks` entries so existing user configs do not lose hook enablement.
 
 For project scope, `.gitignore` keeps generated `.codex/hooks.json` out of source control.

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -156,6 +156,77 @@ describe("notify setup scope", () => {
 		}
 	});
 
+	it("does not write OMX legacy notify during Windows user-scope setup", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-windows-user-no-notify-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await mkdir(codexHomeDir, { recursive: true });
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", hookCommandPlatform: "win32" });
+				});
+
+				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
+				assert.doesNotMatch(config, /^notify\s*=/m);
+				assert.doesNotMatch(config, /notify-hook\.js|notify-dispatcher\.js/);
+				assert.match(config, /^hooks = true$/m);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves explicit user notify during Windows user-scope setup", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-windows-user-notify-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await mkdir(codexHomeDir, { recursive: true });
+				await writeFile(
+					join(codexHomeDir, "config.toml"),
+					'notify = ["node", "/tmp/user-notify.js"]\napproval_policy = "on-failure"\n',
+				);
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", hookCommandPlatform: "win32" });
+				});
+
+				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
+				assert.match(config, /^notify = \["node", "\/tmp\/user-notify\.js"\]$/m);
+				assert.doesNotMatch(config, /notify-dispatcher\.js/);
+				assert.match(config, /^approval_policy = "on-failure"$/m);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("removes stale OMX-managed notify during Windows user-scope setup", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-windows-stale-notify-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await mkdir(codexHomeDir, { recursive: true });
+				const staleHook = join(
+					"C:\\Users\\Ada\\AppData\\Roaming\\npm\\node_modules\\oh-my-codex",
+					"dist",
+					"scripts",
+					"notify-hook.js",
+				);
+				await writeFile(
+					join(codexHomeDir, "config.toml"),
+					`notify = ["node", "${staleHook.replace(/\\/g, "\\\\")}"]\napproval_policy = "on-failure"\n`,
+				);
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", hookCommandPlatform: "win32" });
+				});
+
+				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
+				assert.doesNotMatch(config, /^notify\s*=/m);
+				assert.doesNotMatch(config, /notify-hook\.js|notify-dispatcher\.js/);
+				assert.match(config, /^approval_policy = "on-failure"$/m);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("wraps and restores an existing user notify", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-user-notify-"));
 		try {
@@ -166,7 +237,7 @@ describe("notify setup scope", () => {
 					'notify = ["node", "/tmp/user-notify.js"]\napproval_policy = "on-failure"\n',
 				);
 				await withTempCwd(wd, async () => {
-					await setup({ scope: "user" });
+					await setup({ scope: "user", hookCommandPlatform: "linux" });
 				});
 
 				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
@@ -184,7 +255,7 @@ describe("notify setup scope", () => {
 				assert.deepEqual(metadata.omxNotify?.slice(0, 1), ["node"]);
 
 				await withTempCwd(wd, async () => {
-					await setup({ scope: "user" });
+					await setup({ scope: "user", hookCommandPlatform: "linux" });
 				});
 				const rerunConfig = await readFile(
 					join(codexHomeDir, "config.toml"),
@@ -257,7 +328,7 @@ describe("notify setup scope", () => {
 				);
 
 				await withTempCwd(wd, async () => {
-					await setup({ scope: "user" });
+					await setup({ scope: "user", hookCommandPlatform: "linux" });
 				});
 
 				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
@@ -320,7 +391,7 @@ describe("notify setup scope", () => {
 				);
 
 				await withTempCwd(wd, async () => {
-					await setup({ scope: "user" });
+					await setup({ scope: "user", hookCommandPlatform: "linux" });
 				});
 
 				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
@@ -382,7 +453,7 @@ describe("notify setup scope", () => {
 				);
 
 				await withTempCwd(wd, async () => {
-					await setup({ scope: "user" });
+					await setup({ scope: "user", hookCommandPlatform: "linux" });
 				});
 
 				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
@@ -445,7 +516,7 @@ approval_policy = "on-failure"
 				);
 
 				await withTempCwd(wd, async () => {
-					await setup({ scope: "user" });
+					await setup({ scope: "user", hookCommandPlatform: "linux" });
 				});
 
 				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
@@ -479,7 +550,7 @@ approval_policy = "on-failure"
 				);
 
 				await withTempCwd(wd, async () => {
-					await setup({ scope: "user" });
+					await setup({ scope: "user", hookCommandPlatform: "linux" });
 				});
 
 				const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -159,6 +159,7 @@ interface PluginDeveloperInstructionsDecision {
 interface SetupOptions {
 	codexFeaturesProbe?: () => string | null;
 	codexVersionProbe?: () => string | null;
+	hookCommandPlatform?: NodeJS.Platform;
 	force?: boolean;
 	mergeAgents?: boolean;
 	dryRun?: boolean;
@@ -2652,6 +2653,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				statusLinePreset,
 				forceStatusLinePreset: force,
 				codexHookFeatureFlag,
+				hookCommandPlatform: options.hookCommandPlatform,
 			},
 		);
 		resolvedConfig = managedConfig.finalConfig;
@@ -4067,8 +4069,9 @@ async function buildNotifyMergePlan(
 	pkgRoot: string,
 	codexHomeDir: string,
 	scope: SetupScope,
+	platform: NodeJS.Platform = process.platform,
 ): Promise<NotifyMergePlan> {
-	if (scope === "project") {
+	if (scope === "project" || platform === "win32") {
 		return { notifyCommand: false };
 	}
 
@@ -4156,6 +4159,7 @@ async function updateManagedConfig(
 		statusLinePreset?: HudPreset;
 		forceStatusLinePreset?: boolean;
 		codexHookFeatureFlag: CodexHookFeatureFlag;
+		hookCommandPlatform?: NodeJS.Platform;
 	},
 ): Promise<ManagedConfigResult> {
 	const existing = existsSync(configPath)
@@ -4185,12 +4189,13 @@ async function updateManagedConfig(
 		pkgRoot,
 		codexHomeDir,
 		scope,
+		options.hookCommandPlatform,
 	);
 	const finalConfig = buildMergedConfig(existing, pkgRoot, {
 		includeTui: omxManagesTui,
 		codexHooksFile: hooksPath,
 		codexHomeDir,
-		hookCommandPlatform: process.platform,
+		hookCommandPlatform: options.hookCommandPlatform ?? process.platform,
 		codexHookFeatureFlag: options.codexHookFeatureFlag,
 		modelOverride,
 		sharedMcpServers: sharedMcpRegistry.servers,


### PR DESCRIPTION
## Summary

- skip installing or refreshing OMX-managed legacy top-level `notify = [...]` during Windows user-scope setup
- preserve explicit user-owned `notify` commands on Windows while removing stale OMX-managed `notify-hook.js` / `notify-dispatcher.js` entries
- document the Windows compatibility behavior and keep the existing non-Windows notify wrapping tests explicit

## Why

Codex native hooks remain enabled through `[features].hooks = true` and `hooks.json`, but the legacy top-level `notify = [...]` path can receive large turn payloads as process arguments. On Windows that can fail at process creation time before the OMX notify script runs. This keeps native hooks enabled while avoiding the Windows-specific legacy notify failure path.

## Validation

Passed:

- `npm run build`
- `npm run lint`
- `node --test --test-name-pattern "notify setup scope" dist\cli\__tests__\setup-install-mode.test.js` (11/11 passing)
- `git diff --check -- src/cli/setup.ts src/cli/__tests__/setup-install-mode.test.ts docs/codex-native-hooks.md` (CRLF conversion warnings only)

Additional local Windows checks run:

- `node dist\scripts\run-test-files.js dist\cli\__tests__\setup-install-mode.test.js` still reports 19 failures in the broader `omx setup install mode behavior` suite around plugin cleanup backup directories; the notify setup scope passes.
- `node dist\scripts\run-test-files.js dist\config\__tests__\generator-notify.test.js` reports one Windows path expectation failure in `escapes Windows-style backslashes for MCP server args`; the notify-disabled preservation/removal tests pass.
- `npm ci` installed dependencies but failed during `prepare` at `spawnSync npm.cmd EINVAL`; direct `npm run build` succeeded afterward.
