### PR TITLE
Fix deprecated explore doctor warning on Windows

### DIFF
--- a/src/cli/__tests__/doctor-explore-deprecated.test.ts
+++ b/src/cli/__tests__/doctor-explore-deprecated.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { checkExploreHarness } from "../doctor.js";
+
+describe("doctor deprecated explore harness UX", () => {
+	it("reports OK on Windows when deprecated explore routing is disabled by default", () => {
+		const check = checkExploreHarness("win32", {} as NodeJS.ProcessEnv);
+
+		assert.equal(check.name, "Explore Harness");
+		assert.equal(check.status, "pass");
+		assert.match(check.message, /omx explore is hard-deprecated/i);
+		assert.match(check.message, /explore routing is disabled by default/i);
+		assert.match(check.message, /omx sparkshell/i);
+		assert.doesNotMatch(check.message, /not ready on Windows/i);
+	});
+
+	it("preserves the Windows warning when explore routing is explicitly enabled", () => {
+		const check = checkExploreHarness("win32", {
+			USE_OMX_EXPLORE_CMD: "1",
+		} as NodeJS.ProcessEnv);
+
+		assert.equal(check.name, "Explore Harness");
+		assert.equal(check.status, "warn");
+		assert.match(check.message, /not ready on Windows/i);
+		assert.match(check.message, /OMX_EXPLORE_BIN/);
+		assert.match(check.message, /omx sparkshell/i);
+	});
+
+	it("preserves explicit custom harness override diagnostics", () => {
+		const check = checkExploreHarness("win32", {
+			OMX_EXPLORE_BIN: "missing-custom-harness.exe",
+		} as NodeJS.ProcessEnv);
+
+		assert.equal(check.name, "Explore Harness");
+		assert.equal(check.status, "warn");
+		assert.match(check.message, /OMX_EXPLORE_BIN is set but path was not found/);
+	});
+});

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -155,13 +155,33 @@ function buildHooksJsonWithPostCompactCommand(
 }
 
 describe("omx doctor onboarding warning copy", () => {
-	it("warns that the built-in explore harness is not ready on Windows", () => {
+	it("does not warn about the Windows explore harness when deprecated explore routing is disabled by default", () => {
 		const check = checkExploreHarness("win32", {} as NodeJS.ProcessEnv);
+
+		assert.equal(check.name, "Explore Harness");
+		assert.equal(check.status, "pass");
+		assert.match(check.message, /omx explore is hard-deprecated/i);
+		assert.match(check.message, /explore routing is disabled by default/i);
+		assert.match(check.message, /omx sparkshell/i);
+		assert.doesNotMatch(check.message, /not ready on Windows/i);
+	});
+
+	it("still warns about the Windows built-in explore harness when deprecated routing is explicitly enabled", () => {
+		const check = checkExploreHarness("win32", { USE_OMX_EXPLORE_CMD: "1" } as NodeJS.ProcessEnv);
 
 		assert.equal(check.name, "Explore Harness");
 		assert.equal(check.status, "warn");
 		assert.match(check.message, /not ready on Windows/i);
 		assert.match(check.message, /OMX_EXPLORE_BIN/);
+		assert.match(check.message, /omx sparkshell/i);
+	});
+
+	it("preserves warnings for explicit custom explore harness overrides", () => {
+		const check = checkExploreHarness("win32", { OMX_EXPLORE_BIN: "missing-custom-harness.exe" } as NodeJS.ProcessEnv);
+
+		assert.equal(check.name, "Explore Harness");
+		assert.equal(check.status, "warn");
+		assert.match(check.message, /OMX_EXPLORE_BIN is set but path was not found/);
 	});
 
 	it("treats user-managed MCP servers as preserved under CLI-first defaults", async () => {
@@ -679,6 +699,7 @@ enabled = true
 					CODEX_HOME: join(home, ".codex"),
 					PATH: fakeBin,
 					OMX_EXPLORE_BIN: "",
+					USE_OMX_EXPLORE_CMD: "1",
 				});
 				if (shouldSkipForSpawnPermissions(res.error)) return;
 				assert.equal(res.status, 0, res.stderr || res.stdout);
@@ -750,6 +771,7 @@ enabled = true
 						CODEX_HOME: join(home, ".codex"),
 						PATH: fakeBin,
 						OMX_EXPLORE_BIN: "",
+						USE_OMX_EXPLORE_CMD: "1",
 					});
 					if (shouldSkipForSpawnPermissions(res.error)) return;
 					assert.equal(res.status, 0, res.stderr || res.stdout);

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1333,11 +1333,6 @@ function checkExploreRoutingFromState(state: ExploreRoutingState): Check {
 	};
 }
 
-async function checkExploreRouting(configPath: string): Promise<Check> {
-	return checkExploreRoutingFromState(await resolveExploreRoutingState(configPath));
-}
-
-
 const LORE_COMMIT_GUARD_EXPLICIT_OPT_OUT_VALUES = new Set([
 	"0",
 	"false",

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -312,7 +312,12 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 	checks.push(checkNodeVersion());
 
 	// Check 2.5: Explore harness readiness
-	checks.push(checkExploreHarness());
+	const exploreRoutingState = await resolveExploreRoutingState(paths.configPath);
+	checks.push(
+		checkExploreHarness(process.platform, process.env, {
+			exploreRoutingEnabled: exploreRoutingState.enabled,
+		}),
+	);
 
 	// Check 3: Codex home directory
 	checks.push(checkDirectory("Codex home", paths.codexHomeDir));
@@ -346,7 +351,7 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 	if (runtimeMirrorCheck) checks.push(runtimeMirrorCheck);
 
 	// Check 4.5: Explore routing default
-	checks.push(await checkExploreRouting(paths.configPath));
+	checks.push(checkExploreRoutingFromState(exploreRoutingState));
 
 	// Check 4.6: Lore commit guard default
 	checks.push(await checkLoreCommitGuard(paths.configPath));
@@ -827,7 +832,19 @@ function checkNodeVersion(): Check {
 export function checkExploreHarness(
 	platform: NodeJS.Platform = process.platform,
 	env: NodeJS.ProcessEnv = process.env,
+	options: { exploreRoutingEnabled?: boolean } = {},
 ): Check {
+	const override = env[EXPLORE_BIN_ENV]?.trim();
+	const exploreRoutingEnabled = options.exploreRoutingEnabled ?? isExploreCommandRoutingEnabled(env);
+	if (!override && !exploreRoutingEnabled) {
+		return {
+			name: "Explore Harness",
+			status: "pass",
+			message:
+				"skipped: omx explore is hard-deprecated and explore routing is disabled by default; use omx sparkshell for shell-native read-only evidence",
+		};
+	}
+
 	const packageRoot = getPackageRoot();
 	const manifestPath = join(packageRoot, "crates", "omx-explore", "Cargo.toml");
 	if (!existsSync(manifestPath)) {
@@ -839,7 +856,6 @@ export function checkExploreHarness(
 		};
 	}
 
-	const override = env[EXPLORE_BIN_ENV]?.trim();
 	if (override) {
 		const resolved = join(packageRoot, override);
 		if (existsSync(override) || existsSync(resolved)) {
@@ -1220,10 +1236,53 @@ async function checkModelContextRecommendation(
 	}
 }
 
-async function checkExploreRouting(configPath: string): Promise<Check> {
-	const envValue = process.env[OMX_EXPLORE_CMD_ENV];
+type ExploreRoutingState =
+	| { source: "env"; enabled: boolean }
+	| { source: "config"; enabled: boolean }
+	| { source: "default"; enabled: false; reason: "missing-config" | "unset" }
+	| { source: "unreadable"; enabled: false };
+
+async function resolveExploreRoutingState(
+	configPath: string,
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<ExploreRoutingState> {
+	const envValue = env[OMX_EXPLORE_CMD_ENV];
 	if (typeof envValue === "string") {
-		if (isExploreCommandRoutingEnabled(process.env)) {
+		return { source: "env", enabled: isExploreCommandRoutingEnabled(env) };
+	}
+
+	if (!existsSync(configPath)) {
+		return { source: "default", enabled: false, reason: "missing-config" };
+	}
+
+	try {
+		const content = await readFile(configPath, "utf-8");
+		const parsed = parseToml(content) as {
+			env?: Record<string, unknown>;
+			shell_environment_policy?: { set?: Record<string, unknown> };
+		};
+		const configuredValue =
+			parsed?.shell_environment_policy?.set?.USE_OMX_EXPLORE_CMD ??
+			parsed?.env?.USE_OMX_EXPLORE_CMD;
+
+		if (typeof configuredValue === "string") {
+			return {
+				source: "config",
+				enabled: isExploreCommandRoutingEnabled({
+					USE_OMX_EXPLORE_CMD: configuredValue,
+				}),
+			};
+		}
+
+		return { source: "default", enabled: false, reason: "unset" };
+	} catch {
+		return { source: "unreadable", enabled: false };
+	}
+}
+
+function checkExploreRoutingFromState(state: ExploreRoutingState): Check {
+	if (state.source === "env") {
+		if (state.enabled) {
 			return {
 				name: "Explore routing",
 				status: "warn",
@@ -1239,55 +1298,45 @@ async function checkExploreRouting(configPath: string): Promise<Check> {
 		};
 	}
 
-	if (!existsSync(configPath)) {
+	if (state.source === "config") {
+		if (state.enabled) {
+			return {
+				name: "Explore routing",
+				status: "warn",
+				message:
+					'deprecated compatibility routing enabled in config.toml; set USE_OMX_EXPLORE_CMD = "0" under [shell_environment_policy.set] and use normal Codex repo inspection or omx sparkshell instead',
+			};
+		}
 		return {
 			name: "Explore routing",
 			status: "pass",
-			message: "deprecated by default (config.toml not found yet)",
+			message:
+				"deprecated compatibility routing disabled in config.toml (recommended)",
 		};
 	}
 
-	try {
-		const content = await readFile(configPath, "utf-8");
-		const parsed = parseToml(content) as {
-			env?: Record<string, unknown>;
-			shell_environment_policy?: { set?: Record<string, unknown> };
-		};
-		const configuredValue =
-			parsed?.shell_environment_policy?.set?.USE_OMX_EXPLORE_CMD ??
-			parsed?.env?.USE_OMX_EXPLORE_CMD;
-
-		if (typeof configuredValue === "string") {
-			if (isExploreCommandRoutingEnabled({
-				USE_OMX_EXPLORE_CMD: configuredValue,
-			})) {
-				return {
-					name: "Explore routing",
-					status: "warn",
-					message:
-						'deprecated compatibility routing enabled in config.toml; set USE_OMX_EXPLORE_CMD = "0" under [shell_environment_policy.set] and use normal Codex repo inspection or omx sparkshell instead',
-				};
-			}
-			return {
-				name: "Explore routing",
-				status: "pass",
-				message: "deprecated compatibility routing disabled in config.toml (recommended)",
-			};
-		}
-
-		return {
-			name: "Explore routing",
-			status: "pass",
-			message: "deprecated by default",
-		};
-	} catch {
+	if (state.source === "unreadable") {
 		return {
 			name: "Explore routing",
 			status: "fail",
 			message: "cannot read config.toml for explore routing check",
 		};
 	}
+
+	return {
+		name: "Explore routing",
+		status: "pass",
+		message:
+			state.reason === "missing-config"
+				? "deprecated by default (config.toml not found yet)"
+				: "deprecated by default",
+	};
 }
+
+async function checkExploreRouting(configPath: string): Promise<Check> {
+	return checkExploreRoutingFromState(await resolveExploreRoutingState(configPath));
+}
+
 
 const LORE_COMMIT_GUARD_EXPLICIT_OPT_OUT_VALUES = new Set([
 	"0",


### PR DESCRIPTION
## Summary
- Stop warning about the built-in Explore Harness when deprecated `omx explore` routing is disabled by default.
- Preserve existing readiness warnings when users explicitly opt into deprecated explore routing or set `OMX_EXPLORE_BIN`.
- Keep doctor wording pointed at `omx sparkshell` as the supported shell-native read-only evidence path.
- Add a focused Windows/deprecated-routing regression test for doctor Explore Harness UX.

Fixes #2927

## Verification
- `npm run build`
- `npm run lint`
- `node --test dist/cli/__tests__/doctor-explore-deprecated.test.js dist/cli/__tests__/explore-windows-diagnostics.test.js dist/hooks/__tests__/explore-routing.test.js`

## Note
- A broader local run of `dist/cli/__tests__/doctor-warning-copy.test.js` exposed a pre-existing setup-oriented side effect where later tests lose `dist/cli/omx.js` under this Node runtime; the focused regression suite above avoids that unrelated failure mode.