### PR TITLE
Fix Windows omx update npm.cmd EINVAL fallback

### DIFF
--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -593,9 +593,17 @@ describe('maybeCheckAndPromptUpdate', () => {
 });
 
 describe('direct npm spawn fallback', () => {
-  function enoentResult() {
-    const error = Object.assign(new Error('spawnSync npm ENOENT'), { code: 'ENOENT' });
+  function spawnErrorResult(code: string) {
+    const error = Object.assign(new Error(`spawnSync npm ${code}`), { code });
     return { status: null, signal: null, error, stdout: '', stderr: '', output: [null, '', ''], pid: 0 };
+  }
+
+  function enoentResult() {
+    return spawnErrorResult('ENOENT');
+  }
+
+  function einvalResult() {
+    return spawnErrorResult('EINVAL');
   }
 
   function okResult(stdout = '') {
@@ -617,6 +625,77 @@ describe('direct npm spawn fallback', () => {
     assert.deepEqual(calls.map((call) => call.command), ['npm', 'npm.cmd']);
     assert.deepEqual(calls[0].args, ['install', '-g', 'oh-my-codex@latest']);
     assert.deepEqual(calls[1].args, ['install', '-g', 'oh-my-codex@latest']);
+  });
+
+  it('falls back through cmd.exe when win32 npm.cmd cannot be spawned', () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+
+    const result = runGlobalUpdate(
+      ((command: string, args: readonly string[]) => {
+        calls.push({ command, args: args as string[] });
+        if (command === 'npm') return enoentResult();
+        if (command === 'npm.cmd') return einvalResult();
+        return okResult();
+      }) as unknown as typeof import('node:child_process').spawnSync,
+      'win32',
+    );
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(calls.map((call) => call.command), ['npm', 'npm.cmd', 'cmd.exe']);
+    assert.deepEqual(calls[0].args, ['install', '-g', 'oh-my-codex@latest']);
+    assert.deepEqual(calls[1].args, ['install', '-g', 'oh-my-codex@latest']);
+    assert.deepEqual(calls[2].args, ['/d', '/s', '/c', 'npm', 'install', '-g', 'oh-my-codex@latest']);
+  });
+
+  it('uses cmd.exe for win32 global installs when direct npm returns EINVAL', () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+
+    const result = runGlobalUpdate(
+      ((command: string, args: readonly string[]) => {
+        calls.push({ command, args: args as string[] });
+        return command === 'npm' ? einvalResult() : okResult();
+      }) as unknown as typeof import('node:child_process').spawnSync,
+      'win32',
+    );
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(calls.map((call) => call.command), ['npm', 'cmd.exe']);
+    assert.deepEqual(calls[1].args, ['/d', '/s', '/c', 'npm', 'install', '-g', 'oh-my-codex@latest']);
+  });
+
+  it('does not shell-wrap non-target win32 npm operations when npm.cmd returns EINVAL', () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+
+    const root = resolveGlobalInstallRoot(
+      ((command: string, args: readonly string[]) => {
+        calls.push({ command, args: args as string[] });
+        if (command === 'npm') return enoentResult();
+        if (command === 'npm.cmd') return einvalResult();
+        return okResult('unexpected');
+      }) as unknown as typeof import('node:child_process').spawnSync,
+      'win32',
+    );
+
+    assert.equal(root, null);
+    assert.deepEqual(calls.map((call) => call.command), ['npm', 'npm.cmd']);
+    assert.deepEqual(calls[0].args, ['root', '-g']);
+    assert.deepEqual(calls[1].args, ['root', '-g']);
+  });
+
+  it('keeps the direct npm path when it succeeds', () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+
+    const result = runGlobalUpdate(
+      ((command: string, args: readonly string[]) => {
+        calls.push({ command, args: args as string[] });
+        return okResult();
+      }) as unknown as typeof import('node:child_process').spawnSync,
+      'win32',
+    );
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(calls.map((call) => call.command), ['npm']);
+    assert.deepEqual(calls[0].args, ['install', '-g', 'oh-my-codex@latest']);
   });
 
   it('does not fall back to npm.cmd for non-Windows ENOENT failures', () => {
@@ -682,6 +761,31 @@ describe('direct npm spawn fallback', () => {
         delete process.env.npm_config_location;
       }
     }
+  });
+
+  it('does not use cmd.exe for win32 dev-channel npm packaging when npm.cmd returns EINVAL', () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+
+    const result = runGlobalUpdate(
+      'github:Yeachan-Heo/oh-my-codex#dev',
+      ((command: string, args: readonly string[]) => {
+        calls.push({ command, args: args as string[] });
+        if (command === 'git' && args[0] === 'clone') {
+          mkdirSync(String(args[args.length - 1]), { recursive: true });
+          return okResult();
+        }
+        if (command === 'git' && args[0] === 'rev-parse') return okResult('1234567890abcdef\n');
+        if (command === 'npm') return enoentResult();
+        if (command === 'npm.cmd') return einvalResult();
+        return okResult();
+      }) as unknown as typeof import('node:child_process').spawnSync,
+      'win32',
+    );
+
+    assert.equal(result.ok, false);
+    assert.match(result.stderr, /EINVAL/);
+    assert.deepEqual(calls.map((call) => call.command), ['git', 'git', 'npm', 'npm.cmd']);
+    assert.equal(calls.some((call) => call.command === 'cmd.exe'), false);
   });
 
   it('falls back to npm.cmd for win32 global-root lookup when direct npm spawn returns ENOENT', () => {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -159,12 +159,12 @@ async function getCurrentVersion(): Promise<string | null> {
   }
 }
 
-function isEnoentSpawnError(error: unknown): boolean {
+function isSpawnErrorCode(error: unknown, codes: string[]): boolean {
   return Boolean(
     error &&
     typeof error === 'object' &&
     'code' in error &&
-    (error as NodeJS.ErrnoException).code === 'ENOENT',
+    codes.includes(String((error as NodeJS.ErrnoException).code)),
   );
 }
 
@@ -175,10 +175,34 @@ function spawnNpmSync(
   platform: NodeJS.Platform = process.platform,
 ): ReturnType<SpawnSyncLike> {
   const result = spawnProcess('npm', args, options);
-  if (platform === 'win32' && isEnoentSpawnError(result.error)) {
+  if (platform === 'win32' && isSpawnErrorCode(result.error, ['ENOENT'])) {
     return spawnProcess('npm.cmd', args, options);
   }
   return result;
+}
+
+function spawnGlobalNpmInstallSync(
+  installSource: string,
+  options: SpawnSyncOptions,
+  spawnProcess: SpawnSyncLike = spawnSync,
+  platform: NodeJS.Platform = process.platform,
+): ReturnType<SpawnSyncLike> {
+  const args = ['install', '-g', installSource];
+  const result = spawnProcess('npm', args, options);
+  if (platform !== 'win32' || !isSpawnErrorCode(result.error, ['ENOENT', 'EINVAL'])) {
+    return result;
+  }
+
+  if (isSpawnErrorCode(result.error, ['ENOENT'])) {
+    const cmdShimResult = spawnProcess('npm.cmd', args, options);
+    if (!isSpawnErrorCode(cmdShimResult.error, ['ENOENT', 'EINVAL'])) {
+      return cmdShimResult;
+    }
+  }
+
+  // Some Windows/npm shim layouts reject direct npm/npm.cmd spawn with EINVAL;
+  // cmd.exe can still resolve and run npm from the user's configured PATH.
+  return spawnProcess('cmd.exe', ['/d', '/s', '/c', 'npm', ...args], options);
 }
 
 function commandFailure(stderr: unknown, status: number | null, label: string): RunGlobalUpdateResult {
@@ -357,8 +381,8 @@ export function runGlobalUpdate(
     return runDevGlobalUpdate(spawnProcess, resolvedPlatform);
   }
 
-  const result = spawnNpmSync(
-    ['install', '-g', installSource],
+  const result = spawnGlobalNpmInstallSync(
+    installSource,
     {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary
- add a dedicated Windows-safe stable/global npm install spawn path for `omx update`
- fall back through `cmd.exe /d /s /c npm install -g ...` when direct `npm`/`npm.cmd` launch hits Windows ENOENT/EINVAL
- keep shared npm spawning, dev-channel packaging, global-root lookup, and non-Windows behavior on their existing direct paths

Fixes #2926.

## Tests
- `npm run build`
- `node --test dist/cli/__tests__/update.test.js`
- `npm run lint`
- `git diff --check`

## Review
- Independent code-reviewer: APPROVE
- Independent architect: CLEAR
