### PR TITLE
Constrain ralplan stop overrides to project scope

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -12200,6 +12200,7 @@ exit 0
         mode: "ralplan",
         current_phase: "complete",
         session_id: sessionId,
+        cwd,
       });
       await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
         active: true,
@@ -12231,6 +12232,63 @@ exit 0
 
       assert.equal(result.omxEventName, "stop");
       assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps blocking current session ralplan when canonical root inactive ralplan state lacks project context", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralplan-canonical-root-no-cwd-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-stop-ralplan-canonical-root-no-cwd";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "skill-active-state.json"), {
+        active: false,
+        skill: "ralplan",
+        phase: "complete",
+        session_id: sessionId,
+        active_skills: [],
+      });
+      await writeJson(join(stateDir, "ralplan-state.json"), {
+        active: false,
+        mode: "ralplan",
+        current_phase: "complete",
+        session_id: sessionId,
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "ralplan",
+        phase: "planning",
+        session_id: sessionId,
+        active_skills: [{
+          skill: "ralplan",
+          phase: "planning",
+          active: true,
+          session_id: sessionId,
+        }],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "ralplan-state.json"), {
+        active: true,
+        mode: "ralplan",
+        current_phase: "planning",
+        session_id: sessionId,
+        cwd,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: sessionId,
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson?.decision, "block");
+      assert.equal(result.outputJson?.stopReason, "skill_ralplan_planning_continue_artifact");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -12442,6 +12500,7 @@ exit 0
         active: false,
         mode: "ralplan",
         current_phase: "complete",
+        cwd,
         planning_complete: true,
         latest_plan_path: ".omx/plans/prd-issue-2923.md",
         updated_at: "2026-06-21T08:05:00.000Z",
@@ -12459,6 +12518,128 @@ exit 0
 
       assert.equal(result.omxEventName, "stop");
       assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps blocking current session ralplan when newer unscoped root completion belongs to another worktree", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralplan-cross-worktree-root-complete-"));
+    try {
+      const otherWorktree = join(tmpdir(), "omx-native-hook-other-worktree-2925");
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-stop-ralplan-cross-worktree-root";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "ralplan",
+        phase: "planning",
+        session_id: sessionId,
+        active_skills: [{
+          skill: "ralplan",
+          phase: "planning",
+          active: true,
+          session_id: sessionId,
+        }],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "ralplan-state.json"), {
+        active: true,
+        mode: "ralplan",
+        current_phase: "planning",
+        session_id: sessionId,
+        cwd,
+        updated_at: "2026-06-21T08:00:00.000Z",
+      });
+      await writeJson(join(stateDir, "skill-active-state.json"), {
+        active: false,
+        skill: "ralplan",
+        phase: "complete",
+        active_skills: [],
+      });
+      await writeJson(join(stateDir, "ralplan-state.json"), {
+        active: false,
+        mode: "ralplan",
+        current_phase: "complete",
+        cwd: otherWorktree,
+        planning_complete: true,
+        latest_plan_path: ".omx/plans/prd-issue-2925.md",
+        updated_at: "2026-06-21T08:05:00.000Z",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: sessionId,
+          tool_name: "apply_patch",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson?.decision, "block");
+      assert.equal(result.outputJson?.stopReason, "skill_ralplan_planning_continue_artifact");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps blocking current session ralplan when newer unscoped root completion lacks project context", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralplan-root-complete-no-cwd-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-stop-ralplan-root-complete-no-cwd";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "ralplan",
+        phase: "planning",
+        session_id: sessionId,
+        active_skills: [{
+          skill: "ralplan",
+          phase: "planning",
+          active: true,
+          session_id: sessionId,
+        }],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "ralplan-state.json"), {
+        active: true,
+        mode: "ralplan",
+        current_phase: "planning",
+        session_id: sessionId,
+        cwd,
+        updated_at: "2026-06-21T08:00:00.000Z",
+      });
+      await writeJson(join(stateDir, "skill-active-state.json"), {
+        active: false,
+        skill: "ralplan",
+        phase: "complete",
+        active_skills: [],
+      });
+      await writeJson(join(stateDir, "ralplan-state.json"), {
+        active: false,
+        mode: "ralplan",
+        current_phase: "complete",
+        planning_complete: true,
+        latest_plan_path: ".omx/plans/prd-issue-2925.md",
+        updated_at: "2026-06-21T08:05:00.000Z",
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: sessionId,
+          tool_name: "apply_patch",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson?.decision, "block");
+      assert.equal(result.outputJson?.stopReason, "skill_ralplan_planning_continue_artifact");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -12488,6 +12669,7 @@ exit 0
         mode: "ralplan",
         current_phase: "complete",
         session_id: sessionId,
+        cwd,
       });
       await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
         active: true,

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3558,6 +3558,22 @@ function modeStateMatchesSkillStopContext(
   return true;
 }
 
+function modeStateHasExplicitMatchingCwd(state: Record<string, unknown>, cwd: string): boolean {
+  const stateCwd = safeString(
+    state.cwd
+      ?? state.workingDirectory
+      ?? state.working_directory
+      ?? state.project_path,
+  ).trim();
+  if (!stateCwd) return false;
+
+  try {
+    return resolve(stateCwd) === resolve(cwd);
+  } catch {
+    return false;
+  }
+}
+
 async function readBlockingSkillForStop(
   cwd: string,
   stateDir: string,
@@ -3696,12 +3712,15 @@ async function unscopedRootRalplanStateIsNewerTerminalPlanningCompletion(
   rootState: Record<string, unknown>,
   rootPath: string,
   sessionPath: string,
+  cwd: string,
   threadId: string,
 ): Promise<boolean> {
   if (hasExplicitSessionScope(rootState)) return false;
 
   const stateThreadId = safeString(rootState.owner_codex_thread_id ?? rootState.thread_id).trim();
   if (threadId && stateThreadId && stateThreadId !== threadId) return false;
+
+  if (!modeStateHasExplicitMatchingCwd(rootState, cwd)) return false;
 
   const phase = safeString(rootState.current_phase ?? rootState.currentPhase).trim().toLowerCase();
   if (phase !== "complete" && phase !== "completed") return false;
@@ -3733,13 +3752,15 @@ async function shouldIgnoreSessionSkillBlockerForCanonicalInactiveRoot(
   if (!rootModeState) return false;
   if (!isTerminalOrInactiveModeState(rootModeState)) return false;
 
-  const canonicalRoot = rootModeStateIsCanonicalForStopContext(rootModeState, cwd, sessionId, threadId);
+  const canonicalRoot = rootModeStateIsCanonicalForStopContext(rootModeState, cwd, sessionId, threadId)
+    && (skill !== "ralplan" || modeStateHasExplicitMatchingCwd(rootModeState, cwd));
   const freshUnscopedRoot = canonicalRoot || skill !== "ralplan"
     ? false
     : await unscopedRootRalplanStateIsNewerTerminalPlanningCompletion(
       rootModeState,
       rootModeStatePath,
       join(stateDir, "sessions", sessionId, `${skill}-state.json`),
+      cwd,
       threadId,
     );
   if (!canonicalRoot && !freshUnscopedRoot) return false;


### PR DESCRIPTION
## Summary
- Require ralplan root Stop suppression to prove explicit same-cwd/project scope before clearing session-local blockers.
- Preserve the same-scope #2923 stale planning completion escape hatch when terminal completion state is newer and has `planning_complete=true` plus `latest_plan_path`.
- Add regressions for canonical root state without project context, newer root completion from another worktree, and newer root completion missing project context.

Fixes #2925

## Tests
- `npm run build`
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js` (452 tests)
- `git diff --check`
- Independent review: code-reviewer APPROVE, architect CLEAR
