### PR TITLE
feat(vscode): add extension foundation

### DIFF
--- a/packages/vscode-extension/.vscodeignore
+++ b/packages/vscode-extension/.vscodeignore
@@ -1,0 +1,7 @@
+src/**
+tsconfig.json
+*.map
+*.vsix
+node_modules/**
+out/**
+test/**

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -1,0 +1,31 @@
+# Oh My Codex VS Code Extension
+
+This package is the planned desktop VS Code surface for OMX, landed in small reviewable layers.
+
+## Scope
+
+This layer wires these commands to the shared direct-session API:
+
+- `OMX: Start Direct Session`, `OMX: Resume Direct Session`, `OMX: Stop Active Session`, `OMX: Run Doctor`
+
+Chat, Control Center, Log Explorer, Activity Bar views, and dashboard webviews
+are follow-up PRs after their core APIs and tests.
+
+## Design constraints
+
+- Reuse root `src/vscode` APIs for launch args, PATH resolution, dangerous flag checks, and redacted logs.
+- Keep extension code thin; core OMX behavior stays in the root package.
+- Keep each upstream PR under 500 additions plus deletions.
+- Do not commit generated artifacts: `dist/`, `node_modules/`, or `*.vsix`.
+
+## Development
+
+```bash
+npm run build
+cd packages/vscode-extension
+npm install
+npm test
+```
+
+The extension loads `../../dist/vscode/index.js` by default. Supported settings are
+`omx.command`, `omx.defaultArgs`, `omx.extraPath`, `omx.coreModulePath`, and `omx.confirmDangerousLaunches`.

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "oh-my-codex-vscode",
+  "displayName": "Oh My Codex",
+  "description": "VSCode UI for launching, monitoring, and reviewing OMX work without tmux panes.",
+  "version": "0.5.7",
+  "publisher": "omx",
+  "license": "MIT",
+  "type": "commonjs",
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "omx.start",
+        "title": "Start Direct Session",
+        "category": "OMX"
+      },
+      {
+        "command": "omx.resume",
+        "title": "Resume Direct Session",
+        "category": "OMX"
+      },
+      {
+        "command": "omx.stop",
+        "title": "Stop Active Session",
+        "category": "OMX"
+      },
+      {
+        "command": "omx.doctor",
+        "title": "Run Doctor",
+        "category": "OMX"
+      }
+    ],
+    "configuration": {
+      "title": "Oh My Codex",
+      "properties": {
+        "omx.command": {
+          "type": "string",
+          "default": "",
+          "description": "Optional OMX executable used for direct launches and doctor checks. When empty, the extension uses the workspace dist/cli/omx.js before falling back to omx on PATH."
+        },
+        "omx.defaultArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Default Codex/OMX launch arguments appended to direct sessions."
+        },
+        "omx.extraPath": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Extra PATH directories prepended when launching OMX and Codex from VSCode."
+        },
+        "omx.coreModulePath": {
+          "type": "string",
+          "default": "",
+          "description": "Optional absolute path to the compiled OMX VSCode core module. Defaults to the repository root dist/vscode/index.js."
+        },
+        "omx.confirmDangerousLaunches": {
+          "type": "boolean",
+          "default": true,
+          "description": "Require confirmation before launching sessions with madmax/yolo/bypass approval flags."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p .",
+    "test": "npm run compile && node --test dist/__tests__/*.test.js",
+    "watch": "tsc -watch -p ."
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "@types/vscode": "^1.90.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/packages/vscode-extension/src/__tests__/sessionOptions.test.ts
+++ b/packages/vscode-extension/src/__tests__/sessionOptions.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  buildLaunchPreviewArgs,
+  normalizePrompt,
+  resolveOmxCommand,
+} from '../sessionOptions';
+
+describe('sessionOptions', () => {
+  it('normalizes optional prompts', () => {
+    assert.equal(normalizePrompt(undefined), undefined);
+    assert.equal(normalizePrompt('   '), undefined);
+    assert.equal(normalizePrompt('  ship it  '), 'ship it');
+  });
+
+  it('builds preview args without mutating configured defaults', () => {
+    const defaults = ['--model', 'gpt-5'];
+    const preview = buildLaunchPreviewArgs(defaults, '  review logs  ');
+
+    assert.deepEqual(preview, ['--model', 'gpt-5', 'review logs']);
+    assert.deepEqual(defaults, ['--model', 'gpt-5']);
+    assert.notEqual(preview, defaults);
+  });
+
+  it('resolves configured command before workspace fallback', () => {
+    assert.equal(resolveOmxCommand('/repo', '  /bin/omx  '), '/bin/omx');
+    assert.equal(resolveOmxCommand('/__omx_missing_workspace__', ''), 'omx');
+  });
+});

--- a/packages/vscode-extension/src/core.ts
+++ b/packages/vscode-extension/src/core.ts
@@ -1,0 +1,77 @@
+import { existsSync } from 'node:fs';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import * as vscode from 'vscode';
+import type { OmxCore } from './types';
+
+let cachedCore: OmxCore | null = null;
+
+function configuredCoreModulePath(): string | null {
+  const configured = vscode.workspace.getConfiguration('omx').get<string>('coreModulePath')?.trim();
+  return configured || null;
+}
+
+function extensionBundledCoreModulePath(context: vscode.ExtensionContext): string {
+  return path.join(context.extensionPath, '..', '..', 'dist', 'vscode', 'index.js');
+}
+
+function workspaceCoreModulePaths(): string[] {
+  return (vscode.workspace.workspaceFolders ?? []).map((folder) =>
+    path.join(folder.uri.fsPath, 'dist', 'vscode', 'index.js'),
+  );
+}
+
+async function importCoreModule(modulePath: string): Promise<OmxCore> {
+  const specifier = path.isAbsolute(modulePath) || modulePath.startsWith('.')
+    ? pathToFileURL(path.resolve(modulePath)).href
+    : modulePath;
+  const imported = await import(specifier) as Partial<OmxCore>;
+  if (
+    typeof imported.buildDirectSessionArgs !== 'function' ||
+    typeof imported.resolveVscodeLaunchEnv !== 'function' ||
+    typeof imported.launchDirectSession !== 'function' ||
+    typeof imported.launchRequiresDangerousApproval !== 'function' ||
+    typeof imported.runOmxCatalogCommand !== 'function'
+  ) {
+    throw new Error(`OMX core module at ${modulePath} does not expose the VSCode API surface`);
+  }
+  return imported as OmxCore;
+}
+
+export async function loadOmxCore(context: vscode.ExtensionContext): Promise<OmxCore> {
+  if (cachedCore) return cachedCore;
+
+  const configured = configuredCoreModulePath();
+  const candidates = [
+    ...(configured ? [configured] : []),
+    ...workspaceCoreModulePaths(),
+    extensionBundledCoreModulePath(context),
+    'oh-my-codex',
+  ];
+
+  const errors: string[] = [];
+  for (const candidate of candidates) {
+    if (candidate !== 'oh-my-codex' && !existsSync(path.resolve(candidate))) {
+      errors.push(`${candidate}: not found`);
+      continue;
+    }
+    try {
+      cachedCore = await importCoreModule(candidate);
+      return cachedCore;
+    } catch (error) {
+      errors.push(`${candidate}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  throw new Error(
+    [
+      'Unable to load OMX VSCode core API.',
+      'Run `npm run build` at the repository root, install the oh-my-codex package, or set `omx.coreModulePath`.',
+      ...errors.map((entry) => `- ${entry}`),
+    ].join('\n'),
+  );
+}
+
+export function clearCoreCache(): void {
+  cachedCore = null;
+}

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,0 +1,49 @@
+import * as vscode from 'vscode';
+import { getWorkspaceRoot, OmxSessionManager } from './sessionManager';
+
+export function activate(context: vscode.ExtensionContext): void {
+  const output = vscode.window.createOutputChannel('OMX');
+  const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+  const sessionManager = new OmxSessionManager(context, output, () => {
+    refreshStatusBar(statusBar, sessionManager);
+  });
+
+  statusBar.command = 'omx.start';
+  statusBar.text = 'OMX';
+  statusBar.tooltip = 'Start an OMX direct session';
+  statusBar.show();
+
+  context.subscriptions.push(
+    output,
+    statusBar,
+    vscode.commands.registerCommand('omx.start', async () => {
+      await sessionManager.promptAndStart('launch');
+    }),
+    vscode.commands.registerCommand('omx.resume', async () => {
+      await sessionManager.promptAndStart('resume');
+    }),
+    vscode.commands.registerCommand('omx.stop', () => {
+      sessionManager.stop();
+    }),
+    vscode.commands.registerCommand('omx.doctor', async () => {
+      await sessionManager.doctor();
+    }),
+  );
+
+  refreshStatusBar(statusBar, sessionManager);
+}
+
+export function deactivate(): void {
+  // Child processes are owned by OmxSessionManager and stopped through the command surface.
+}
+
+function refreshStatusBar(statusBar: vscode.StatusBarItem, sessionManager: OmxSessionManager): void {
+  const active = sessionManager.active;
+  if (active) {
+    statusBar.text = `OMX: ${active.session_id}`;
+    statusBar.tooltip = `Running in ${getWorkspaceRoot()}\nLog: ${active.log_path}`;
+    return;
+  }
+  statusBar.text = 'OMX';
+  statusBar.tooltip = 'Start an OMX direct session';
+}

--- a/packages/vscode-extension/src/sessionManager.ts
+++ b/packages/vscode-extension/src/sessionManager.ts
@@ -1,0 +1,129 @@
+import * as vscode from 'vscode';
+import { loadOmxCore } from './core';
+import { buildLaunchPreviewArgs, normalizePrompt, resolveOmxCommand } from './sessionOptions';
+import type { DirectSessionHandle } from './types';
+
+type DirectMode = 'launch' | 'resume';
+
+export class OmxSessionManager {
+  private activeSession: DirectSessionHandle | null = null;
+
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly output: vscode.OutputChannel,
+    private readonly onDidChange: () => void,
+  ) {}
+
+  get active(): DirectSessionHandle | null {
+    return this.activeSession;
+  }
+
+  async promptAndStart(mode: DirectMode): Promise<void> {
+    const prompt = await vscode.window.showInputBox({
+      title: mode === 'resume' ? 'Resume OMX session' : 'Start OMX session',
+      prompt: 'Optional prompt passed to OMX',
+      ignoreFocusOut: true,
+    });
+    if (prompt === undefined) return;
+    await this.start(mode, normalizePrompt(prompt));
+  }
+
+  async start(mode: DirectMode, prompt?: string): Promise<DirectSessionHandle | null> {
+    const cwd = getWorkspaceRoot();
+    const core = await loadOmxCore(this.context);
+    const config = vscode.workspace.getConfiguration('omx');
+    const omxCommand = resolveOmxCommand(cwd, config.get<string>('command'));
+    const launchEnv = core.resolveVscodeLaunchEnv({
+      cwd,
+      omxCommand,
+      extraPath: config.get<string[]>('extraPath') ?? [],
+    });
+    const codexArgs = config.get<string[]>('defaultArgs') ?? [];
+    const launchArgs = core.buildDirectSessionArgs({
+      mode,
+      codexArgs: buildLaunchPreviewArgs(codexArgs, prompt),
+    });
+    const needsApproval = core.launchRequiresDangerousApproval(launchArgs);
+    const dangerousApproved = needsApproval
+      ? await confirmDangerousLaunch(launchArgs, config)
+      : false;
+    if (needsApproval && !dangerousApproved) return null;
+
+    const handle = core.launchDirectSession({
+      cwd,
+      mode,
+      prompt,
+      codexArgs,
+      omxCommand,
+      dangerousApproved,
+      env: launchEnv.env,
+    });
+    this.bindSession(handle, mode);
+    return handle;
+  }
+
+  stop(): void {
+    const active = this.activeSession;
+    if (!active) return;
+    active.stop();
+    this.output.appendLine(`[omx] stop requested for ${active.session_id}`);
+  }
+
+  async doctor(): Promise<void> {
+    const cwd = getWorkspaceRoot();
+    const core = await loadOmxCore(this.context);
+    const result = core.runOmxCatalogCommand({
+      cwd,
+      omxCommand: resolveOmxCommand(cwd, vscode.workspace.getConfiguration('omx').get<string>('command')),
+      args: ['doctor'],
+    });
+    this.output.show(true);
+    this.output.appendLine(`[omx] doctor exited code=${result.code ?? 'null'}`);
+    if (result.stdout) this.output.append(result.stdout);
+    if (result.stderr) this.output.append(result.stderr);
+  }
+
+  private bindSession(handle: DirectSessionHandle, mode: DirectMode): void {
+    this.activeSession = handle;
+    this.output.show(true);
+    this.output.appendLine(`[omx] started ${mode} session ${handle.session_id}`);
+    this.output.appendLine(`[omx] log: ${handle.log_path}`);
+
+    handle.child.stdout?.on('data', (chunk) => this.output.append(String(chunk)));
+    handle.child.stderr?.on('data', (chunk) => this.output.append(String(chunk)));
+    handle.child.on('exit', (code, signal) => {
+      this.output.appendLine(
+        `\n[omx] session ${handle.session_id} exited code=${code ?? 'null'} signal=${signal ?? 'null'}`,
+      );
+      if (this.activeSession?.session_id === handle.session_id) {
+        this.activeSession = null;
+        this.onDidChange();
+      }
+    });
+    handle.child.on('error', (error) => {
+      this.output.appendLine(`[omx] launch error: ${error instanceof Error ? error.message : String(error)}`);
+      if (this.activeSession?.session_id === handle.session_id) {
+        this.activeSession = null;
+        this.onDidChange();
+      }
+    });
+    this.onDidChange();
+  }
+}
+
+async function confirmDangerousLaunch(
+  launchArgs: string[],
+  config: vscode.WorkspaceConfiguration,
+): Promise<boolean> {
+  if (!config.get<boolean>('confirmDangerousLaunches', true)) return true;
+  const choice = await vscode.window.showWarningMessage(
+    `OMX will launch with approval-bypass flags: ${launchArgs.join(' ')}`,
+    { modal: true },
+    'Launch',
+  );
+  return choice === 'Launch';
+}
+
+export function getWorkspaceRoot(): string {
+  return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? process.cwd();
+}

--- a/packages/vscode-extension/src/sessionOptions.ts
+++ b/packages/vscode-extension/src/sessionOptions.ts
@@ -1,0 +1,19 @@
+import { existsSync } from 'node:fs';
+import * as path from 'node:path';
+
+export function normalizePrompt(prompt: string | undefined): string | undefined {
+  const normalized = prompt?.trim();
+  return normalized || undefined;
+}
+
+export function buildLaunchPreviewArgs(defaultArgs: readonly string[], prompt: string | undefined): string[] {
+  const normalizedPrompt = normalizePrompt(prompt);
+  return normalizedPrompt ? [...defaultArgs, normalizedPrompt] : [...defaultArgs];
+}
+
+export function resolveOmxCommand(cwd: string, configuredCommand: string | undefined): string {
+  const configured = configuredCommand?.trim();
+  if (configured) return configured;
+  const workspaceCommand = path.join(cwd, 'dist', 'cli', 'omx.js');
+  return existsSync(workspaceCommand) ? workspaceCommand : 'omx';
+}

--- a/packages/vscode-extension/src/types.ts
+++ b/packages/vscode-extension/src/types.ts
@@ -1,0 +1,54 @@
+import type { ChildProcess } from 'node:child_process';
+
+export interface DirectSessionHandle {
+  session_id: string;
+  cwd: string;
+  command: string;
+  args: string[];
+  pid?: number;
+  log_path: string;
+  started_at: string;
+  child: ChildProcess;
+  stop: (signal?: NodeJS.Signals | number) => boolean;
+}
+
+export interface OmxCommandResult {
+  command: string;
+  args: string[];
+  stdout: string;
+  stderr: string;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
+
+export interface OmxCore {
+  buildDirectSessionArgs(options?: { mode?: 'launch' | 'resume'; codexArgs?: string[] }): string[];
+  resolveVscodeLaunchEnv(options: {
+    cwd: string;
+    omxCommand?: string;
+    baseEnv?: NodeJS.ProcessEnv;
+    extraPath?: string[];
+  }): {
+    env: NodeJS.ProcessEnv;
+    pathKey: string;
+    pathEntries: string[];
+    codexPath: string | null;
+  };
+  launchDirectSession(options: {
+    cwd: string;
+    mode?: 'launch' | 'resume';
+    prompt?: string;
+    codexArgs?: string[];
+    omxCommand?: string;
+    dangerousApproved?: boolean;
+    env?: NodeJS.ProcessEnv;
+  }): DirectSessionHandle;
+  launchRequiresDangerousApproval(args: readonly string[]): boolean;
+  runOmxCatalogCommand(options: {
+    cwd: string;
+    omxCommand?: string;
+    args: string[];
+    env?: NodeJS.ProcessEnv;
+    timeoutMs?: number;
+  }): OmxCommandResult;
+}

--- a/packages/vscode-extension/tsconfig.json
+++ b/packages/vscode-extension/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node", "vscode"],
+    "sourceMap": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- Add a minimal VSCode extension package under packages/vscode-extension
- Wire command-palette direct session start/resume/stop/doctor commands
- Add core API loading diagnostics and a tested sessionOptions helper

## Validation
- cd packages/vscode-extension && npm test

## Notes
- Follows #2856 now that the VSCode direct-session API is merged
- Keeps this first extension PR command-only and under the size/XL threshold