### PR TITLE
feat(vscode): add chat webview

### DIFF
--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -6,10 +6,11 @@ This package is the planned desktop VS Code surface for OMX, landed in small rev
 
 This layer wires these commands to the shared direct-session API:
 
-- `OMX: Start Direct Session`, `OMX: Resume Direct Session`, `OMX: Stop Active Session`, `OMX: Run Doctor`
+- `OMX: Open Chat`, `OMX: Start Direct Session`, `OMX: Resume Direct Session`
+- `OMX: Stop Active Session`, `OMX: Run Doctor`
 
-Chat, Control Center, Log Explorer, Activity Bar views, and dashboard webviews
-are follow-up PRs after their core APIs and tests.
+Control Center, Log Explorer, Activity Bar views, and dashboard webviews are
+follow-up PRs after their core APIs and tests.
 
 ## Design constraints
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -16,6 +16,11 @@
   "contributes": {
     "commands": [
       {
+        "command": "omx.openChat",
+        "title": "Open Chat",
+        "category": "OMX"
+      },
+      {
         "command": "omx.start",
         "title": "Start Direct Session",
         "category": "OMX"

--- a/packages/vscode-extension/src/__tests__/chatProtocol.test.ts
+++ b/packages/vscode-extension/src/__tests__/chatProtocol.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { normalizeWebviewMessage } from '../chatProtocol';
+
+describe('webview protocol', () => {
+  it('accepts only known commands', () => {
+    assert.deepEqual(normalizeWebviewMessage({ command: 'send', text: 'hello' }), { command: 'send', text: 'hello' });
+    assert.deepEqual(normalizeWebviewMessage({ command: 'stop', text: 'ignored' }), { command: 'stop' });
+    assert.equal(normalizeWebviewMessage({ command: 'deleteEverything' }), null);
+    assert.equal(normalizeWebviewMessage(null), null);
+  });
+
+  it('drops non-string path and id payloads', () => {
+    assert.deepEqual(normalizeWebviewMessage({ command: 'openLog', logPath: 123 }), {
+      command: 'openLog',
+      logPath: undefined,
+    });
+    assert.deepEqual(normalizeWebviewMessage({ command: 'selectConversation', conversationId: {} }), {
+      command: 'selectConversation',
+      conversationId: undefined,
+    });
+  });
+});

--- a/packages/vscode-extension/src/__tests__/workspaceStatus.test.ts
+++ b/packages/vscode-extension/src/__tests__/workspaceStatus.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { describe, it } from 'node:test';
+import { listVscodeLogs, pathInsideWorkspace, realPathInsideWorkspace } from '../workspaceStatus';
+
+describe('workspace status helpers', () => {
+  it('lists recent VSCode logs without creating state', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'omx-vscode-status-'));
+    assert.deepEqual(await listVscodeLogs(cwd), []);
+    const logDir = path.join(cwd, '.omx', 'logs', 'vscode');
+    await mkdir(logDir, { recursive: true });
+    await writeFile(path.join(logDir, 'a.log'), 'first');
+    await writeFile(path.join(logDir, 'ignore.txt'), 'nope');
+    const logs = await listVscodeLogs(cwd);
+    assert.equal(logs.length, 1);
+    assert.equal(logs[0]?.name, 'a.log');
+    assert.equal(logs[0]?.size, 5);
+  });
+
+  it('keeps direct log paths scoped to the workspace', () => {
+    const cwd = path.join(tmpdir(), 'omx-vscode-status');
+    assert.equal(pathInsideWorkspace(cwd, path.join(cwd, '.omx', 'logs', 'vscode', 'a.log')), true);
+    assert.equal(pathInsideWorkspace(cwd, path.join(cwd, '..', 'outside.log')), false);
+  });
+
+  it('rejects symlinked log paths that escape the workspace', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'omx-vscode-status-'));
+    const outside = await mkdtemp(path.join(tmpdir(), 'omx-vscode-outside-'));
+    await mkdir(path.join(cwd, '.omx', 'logs', 'vscode'), { recursive: true });
+    const outsideLog = path.join(outside, 'run.log');
+    const linkedLog = path.join(cwd, '.omx', 'logs', 'vscode', 'linked.log');
+    await writeFile(outsideLog, 'outside');
+    await symlink(outsideLog, linkedLog);
+    assert.equal(await realPathInsideWorkspace(cwd, linkedLog), false);
+  });
+});

--- a/packages/vscode-extension/src/chatProtocol.ts
+++ b/packages/vscode-extension/src/chatProtocol.ts
@@ -1,0 +1,32 @@
+export type WebviewCommand =
+  | { command: 'send'; text: string }
+  | { command: 'newConversation' }
+  | { command: 'selectConversation'; conversationId?: string }
+  | { command: 'openLog'; logPath?: string }
+  | { command: 'stop' }
+  | { command: 'doctor' }
+  | { command: 'refresh' };
+
+export function normalizeWebviewMessage(value: unknown): WebviewCommand | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.command !== 'string') return null;
+  switch (record.command) {
+    case 'send':
+      return { command: 'send', text: typeof record.text === 'string' ? record.text : '' };
+    case 'newConversation':
+    case 'stop':
+    case 'doctor':
+    case 'refresh':
+      return { command: record.command };
+    case 'selectConversation':
+      return {
+        command: 'selectConversation',
+        conversationId: typeof record.conversationId === 'string' ? record.conversationId : undefined,
+      };
+    case 'openLog':
+      return { command: 'openLog', logPath: typeof record.logPath === 'string' ? record.logPath : undefined };
+    default:
+      return null;
+  }
+}

--- a/packages/vscode-extension/src/chatView.ts
+++ b/packages/vscode-extension/src/chatView.ts
@@ -1,0 +1,295 @@
+import { randomUUID } from 'node:crypto';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import {
+  appendMessage,
+  createConversation,
+  listConversations,
+  readConversation,
+  type ChatConversation,
+  type ChatConversationSummary,
+} from './chatStore';
+import { normalizeWebviewMessage } from './chatProtocol';
+import { getWorkspaceRoot, OmxSessionManager } from './sessionManager';
+import { listVscodeLogs, realPathInsideWorkspace, type VscodeLogSummary } from './workspaceStatus';
+
+interface ChatViewState {
+  activeConversationId: string | null;
+  conversations: ChatConversationSummary[];
+  conversation: ChatConversation | null;
+  activeSession: {
+    session_id: string;
+    log_path: string;
+    started_at: string;
+  } | null;
+  logs: VscodeLogSummary[];
+}
+
+export class OmxChatPanel {
+  private panel: vscode.WebviewPanel | undefined;
+  private activeConversationId: string | null = null;
+
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly sessionManager: OmxSessionManager,
+    private readonly output: vscode.OutputChannel,
+  ) {}
+
+  async open(): Promise<void> {
+    if (this.panel) {
+      this.panel.reveal(vscode.ViewColumn.Beside);
+      await this.refresh();
+      return;
+    }
+
+    const panel = vscode.window.createWebviewPanel('omx.chat', 'OMX Chat', vscode.ViewColumn.Beside, {
+      enableScripts: true,
+      retainContextWhenHidden: true,
+    });
+    this.panel = panel;
+    panel.webview.html = renderChatHtml(randomUUID());
+    panel.onDidDispose(() => {
+      this.panel = undefined;
+    }, null, this.context.subscriptions);
+    panel.webview.onDidReceiveMessage((message) => {
+      void this.handleMessage(message);
+    }, null, this.context.subscriptions);
+    await this.refresh();
+  }
+
+  async refresh(): Promise<void> {
+    if (!this.panel) return;
+    try {
+      await this.panel.webview.postMessage({ type: 'state', state: await this.buildState() });
+    } catch (error) {
+      await this.panel.webview.postMessage({
+        type: 'error',
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async buildState(): Promise<ChatViewState> {
+    const cwd = getWorkspaceRoot();
+    const [conversations, logs] = await Promise.all([listConversations(cwd), listVscodeLogs(cwd, 8)]);
+    if (!this.activeConversationId && conversations[0]) this.activeConversationId = conversations[0].id;
+    const conversation = this.activeConversationId ? await readConversation(cwd, this.activeConversationId) : null;
+    if (this.activeConversationId && !conversation) this.activeConversationId = null;
+    const active = this.sessionManager.active;
+    return {
+      activeConversationId: conversation?.id ?? null,
+      conversations,
+      conversation,
+      activeSession: active
+        ? { session_id: active.session_id, log_path: active.log_path, started_at: active.started_at }
+        : null,
+      logs,
+    };
+  }
+
+  private async handleMessage(rawMessage: unknown): Promise<void> {
+    const message = normalizeWebviewMessage(rawMessage);
+    if (!message) return;
+    switch (message.command) {
+      case 'send':
+        await this.send(message.text ?? '');
+        break;
+      case 'newConversation':
+        this.activeConversationId = (await createConversation(getWorkspaceRoot())).id;
+        await this.refresh();
+        break;
+      case 'selectConversation':
+        this.activeConversationId = message.conversationId ?? null;
+        await this.refresh();
+        break;
+      case 'openLog':
+        await this.openLog(message.logPath);
+        break;
+      case 'stop':
+        this.sessionManager.stop();
+        await this.refresh();
+        break;
+      case 'doctor':
+        await this.sessionManager.doctor();
+        await this.refresh();
+        break;
+      case 'refresh':
+        await this.refresh();
+        break;
+    }
+  }
+
+  private async send(rawText: string): Promise<void> {
+    const text = rawText.trim();
+    if (!text) return;
+    const cwd = getWorkspaceRoot();
+    const conversation = await this.ensureConversation(text);
+    await appendMessage(cwd, conversation.id, { role: 'user', text });
+    await this.refresh();
+
+    try {
+      const handle = await this.sessionManager.start('launch', text);
+      await appendMessage(cwd, conversation.id, {
+        role: 'system',
+        text: handle
+          ? `Started OMX session ${handle.session_id}.\nLog: ${handle.log_path}`
+          : 'OMX launch was cancelled.',
+        session_id: handle?.session_id,
+        log_path: handle?.log_path,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.output.appendLine(`[omx] chat launch failed: ${message}`);
+      await appendMessage(cwd, conversation.id, { role: 'assistant', text: `Launch failed:\n${message}` });
+    }
+    await this.refresh();
+  }
+
+  private async ensureConversation(initialText: string): Promise<ChatConversation> {
+    const cwd = getWorkspaceRoot();
+    if (this.activeConversationId) {
+      const existing = await readConversation(cwd, this.activeConversationId);
+      if (existing) return existing;
+    }
+    const created = await createConversation(cwd, initialText);
+    this.activeConversationId = created.id;
+    return created;
+  }
+
+  private async openLog(logPath: string | undefined): Promise<void> {
+    if (!logPath) return;
+    const cwd = getWorkspaceRoot();
+    if (!await realPathInsideWorkspace(cwd, logPath)) {
+      await vscode.window.showErrorMessage('OMX refused to open a log outside the active workspace.');
+      return;
+    }
+    const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.resolve(logPath)));
+    await vscode.window.showTextDocument(document, { preview: true });
+  }
+}
+
+function renderChatHtml(nonce: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body { margin: 0; color: var(--vscode-foreground); background: var(--vscode-editor-background); font-family: var(--vscode-font-family); }
+    .layout { display: grid; grid-template-columns: minmax(150px, 220px) 1fr; height: 100vh; }
+    aside { border-right: 1px solid var(--vscode-panel-border); overflow: auto; }
+    main { display: grid; grid-template-rows: auto 1fr auto; min-width: 0; }
+    header, form { display: flex; gap: 8px; padding: 10px; border-bottom: 1px solid var(--vscode-panel-border); }
+    form { border-top: 1px solid var(--vscode-panel-border); border-bottom: 0; }
+    button, textarea { color: var(--vscode-input-foreground); background: var(--vscode-input-background); border: 1px solid var(--vscode-input-border); border-radius: 4px; }
+    button { padding: 6px 8px; cursor: pointer; }
+    button.primary { color: var(--vscode-button-foreground); background: var(--vscode-button-background); border-color: var(--vscode-button-background); }
+    textarea { flex: 1; min-height: 52px; resize: vertical; padding: 8px; font-family: inherit; }
+    .conversation, .log { display: block; width: 100%; padding: 10px; text-align: left; border-width: 0 0 1px; border-radius: 0; }
+    .conversation.active { background: var(--vscode-list-activeSelectionBackground); color: var(--vscode-list-activeSelectionForeground); }
+    .logs { border-top: 1px solid var(--vscode-panel-border); padding-top: 8px; }
+    .messages { overflow: auto; padding: 14px; }
+    .message { margin: 0 0 14px; }
+    .meta { color: var(--vscode-descriptionForeground); font-size: 12px; margin-bottom: 4px; }
+    .bubble { white-space: pre-wrap; overflow-wrap: anywhere; padding: 10px; border: 1px solid var(--vscode-panel-border); border-radius: 6px; }
+    .user .bubble { background: var(--vscode-input-background); }
+    .empty, .error { color: var(--vscode-descriptionForeground); padding: 14px; }
+    .error { color: var(--vscode-errorForeground); }
+  </style>
+</head>
+<body>
+  <div class="layout">
+    <aside>
+      <header><button id="new">New</button><button id="refresh">Refresh</button></header>
+      <div id="conversations"></div>
+      <section class="logs"><div class="meta">Recent logs</div><div id="logs"></div></section>
+    </aside>
+    <main>
+      <header><div id="status" class="meta"></div><button id="stop">Stop</button><button id="doctor">Doctor</button></header>
+      <div id="messages" class="messages"></div>
+      <form id="form"><textarea id="input" rows="3"></textarea><button class="primary" type="submit">Send</button></form>
+    </main>
+  </div>
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    const conversationsEl = document.getElementById('conversations');
+    const logsEl = document.getElementById('logs');
+    const messagesEl = document.getElementById('messages');
+    const statusEl = document.getElementById('status');
+    const inputEl = document.getElementById('input');
+    document.getElementById('new').addEventListener('click', () => post('newConversation'));
+    document.getElementById('refresh').addEventListener('click', () => post('refresh'));
+    document.getElementById('stop').addEventListener('click', () => post('stop'));
+    document.getElementById('doctor').addEventListener('click', () => post('doctor'));
+    document.getElementById('form').addEventListener('submit', (event) => {
+      event.preventDefault();
+      const text = inputEl.value;
+      inputEl.value = '';
+      post('send', { text });
+    });
+    function post(command, payload = {}) { vscode.postMessage({ command, ...payload }); }
+    function renderState(state) {
+      const messages = state.conversation ? state.conversation.messages || [] : [];
+      statusEl.textContent = state.activeSession ? 'Running ' + state.activeSession.session_id : 'Idle';
+      conversationsEl.textContent = '';
+      for (const item of state.conversations || []) {
+        const button = document.createElement('button');
+        button.className = 'conversation' + (item.id === state.activeConversationId ? ' active' : '');
+        button.textContent = item.title + ' · ' + item.message_count;
+        button.addEventListener('click', () => post('selectConversation', { conversationId: item.id }));
+        conversationsEl.appendChild(button);
+      }
+      logsEl.textContent = '';
+      for (const log of state.logs || []) {
+        const button = document.createElement('button');
+        button.className = 'log';
+        button.textContent = log.name + ' · ' + log.size + ' bytes';
+        button.addEventListener('click', () => post('openLog', { logPath: log.path }));
+        logsEl.appendChild(button);
+      }
+      messagesEl.textContent = '';
+      if (!messages.length) {
+        messagesEl.appendChild(empty('No messages yet.'));
+        return;
+      }
+      for (const message of messages) {
+        const row = document.createElement('div');
+        row.className = 'message ' + message.role;
+        const meta = document.createElement('div');
+        meta.className = 'meta';
+        meta.textContent = message.role + ' · ' + new Date(message.created_at).toLocaleString();
+        const bubble = document.createElement('div');
+        bubble.className = 'bubble';
+        bubble.textContent = message.text || '';
+        row.appendChild(meta);
+        row.appendChild(bubble);
+        if (message.log_path) {
+          const open = document.createElement('button');
+          open.textContent = 'Open log';
+          open.addEventListener('click', () => post('openLog', { logPath: message.log_path }));
+          row.appendChild(open);
+        }
+        messagesEl.appendChild(row);
+      }
+      messagesEl.scrollTop = messagesEl.scrollHeight;
+    }
+    function empty(text) {
+      const node = document.createElement('div');
+      node.className = 'empty';
+      node.textContent = text;
+      return node;
+    }
+    window.addEventListener('message', (event) => {
+      if (event.data.type === 'state') renderState(event.data.state);
+      if (event.data.type === 'error') {
+        messagesEl.textContent = '';
+        const node = empty(event.data.message);
+        node.className = 'error';
+        messagesEl.appendChild(node);
+      }
+    });
+  </script>
+</body>
+</html>`;
+}

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,29 +1,39 @@
 import * as vscode from 'vscode';
+import { OmxChatPanel } from './chatView';
 import { getWorkspaceRoot, OmxSessionManager } from './sessionManager';
 
 export function activate(context: vscode.ExtensionContext): void {
   const output = vscode.window.createOutputChannel('OMX');
   const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+  let chatPanel: OmxChatPanel | undefined;
   const sessionManager = new OmxSessionManager(context, output, () => {
     refreshStatusBar(statusBar, sessionManager);
+    void chatPanel?.refresh();
   });
+  chatPanel = new OmxChatPanel(context, sessionManager, output);
 
-  statusBar.command = 'omx.start';
+  statusBar.command = 'omx.openChat';
   statusBar.text = 'OMX';
-  statusBar.tooltip = 'Start an OMX direct session';
+  statusBar.tooltip = 'Open OMX Chat';
   statusBar.show();
 
   context.subscriptions.push(
     output,
     statusBar,
+    vscode.commands.registerCommand('omx.openChat', async () => {
+      await chatPanel.open();
+    }),
     vscode.commands.registerCommand('omx.start', async () => {
       await sessionManager.promptAndStart('launch');
+      await chatPanel.refresh();
     }),
     vscode.commands.registerCommand('omx.resume', async () => {
       await sessionManager.promptAndStart('resume');
+      await chatPanel.refresh();
     }),
     vscode.commands.registerCommand('omx.stop', () => {
       sessionManager.stop();
+      void chatPanel.refresh();
     }),
     vscode.commands.registerCommand('omx.doctor', async () => {
       await sessionManager.doctor();
@@ -45,5 +55,5 @@ function refreshStatusBar(statusBar: vscode.StatusBarItem, sessionManager: OmxSe
     return;
   }
   statusBar.text = 'OMX';
-  statusBar.tooltip = 'Start an OMX direct session';
+  statusBar.tooltip = 'Open OMX Chat';
 }

--- a/packages/vscode-extension/src/workspaceStatus.ts
+++ b/packages/vscode-extension/src/workspaceStatus.ts
@@ -1,0 +1,50 @@
+import { readdir, realpath, stat } from 'node:fs/promises';
+import * as path from 'node:path';
+
+export interface VscodeLogSummary {
+  path: string;
+  name: string;
+  updated_at: string;
+  size: number;
+}
+
+export async function listVscodeLogs(cwd: string, limit = 8): Promise<VscodeLogSummary[]> {
+  const dir = path.join(cwd, '.omx', 'logs', 'vscode');
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) return [];
+    throw error;
+  }
+
+  const logs: VscodeLogSummary[] = [];
+  for (const name of entries) {
+    if (!name.endsWith('.log')) continue;
+    const filePath = path.join(dir, name);
+    const info = await stat(filePath);
+    if (!info.isFile()) continue;
+    logs.push({ path: filePath, name, updated_at: info.mtime.toISOString(), size: info.size });
+  }
+  return logs.sort((a, b) => b.updated_at.localeCompare(a.updated_at)).slice(0, Math.max(0, limit));
+}
+
+export function pathInsideWorkspace(cwd: string, candidate: string): boolean {
+  const root = path.resolve(cwd);
+  const resolved = path.resolve(candidate);
+  return resolved === root || resolved.startsWith(`${root}${path.sep}`);
+}
+
+export async function realPathInsideWorkspace(cwd: string, candidate: string): Promise<boolean> {
+  try {
+    const root = await realpath(cwd);
+    const resolved = await realpath(candidate);
+    return resolved === root || resolved.startsWith(`${root}${path.sep}`);
+  } catch {
+    return false;
+  }
+}
+
+function isNodeErrorCode(error: unknown, code: string): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === code;
+}


### PR DESCRIPTION
## Summary
- Add the VSCode OMX Chat webview on top of the merged extension foundation and chat store
- Wire conversation list, message send, log open, stop, doctor, and refresh actions
- Validate webview messages through a small protocol module
- Keep log opening scoped to the active workspace, including realpath checks for symlink escapes
- Surface recent VSCode session logs in the chat sidebar

## Validation
- cd packages/vscode-extension && npm test

## Size
- 8 files, 460 insertions, 6 deletions
- 466 total changes, below the size/XL threshold of 500

## Notes
- Follows #2932 after the file-backed chat store merged
- Leaves richer streaming transcript updates for a later PR so this webview layer stays size/L