### PR TITLE
Fix merge-agents generated AGENTS idempotency

### DIFF
--- a/src/cli/__tests__/setup-agents-overwrite.test.ts
+++ b/src/cli/__tests__/setup-agents-overwrite.test.ts
@@ -228,6 +228,56 @@ describe('omx setup AGENTS refresh behavior', () => {
     }
   });
 
+  it('keeps --merge-agents idempotent for already generated AGENTS.md and refreshes stale model rows', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-agents-'));
+    const restoreTty = setMockTty(false);
+    const home = join(wd, 'home');
+    const restoreHome = setMockHome(home);
+    const template = readFileSync(join(process.cwd(), 'templates', 'AGENTS.md'), 'utf-8');
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      const existing = upsertAgentsModelTable(
+        addGeneratedAgentsMarker(template),
+        {
+          frontierModel: 'stale-frontier',
+          sparkModel: 'stale-spark',
+          subagentDefaultModel: 'stale-frontier',
+        },
+      );
+      await writeFile(join(wd, 'AGENTS.md'), existing);
+
+      const output = await runSetupWithCapturedLogs(wd, {
+        scope: 'project',
+        mergeAgents: true,
+      });
+
+      const agentsContent = await readFile(join(wd, 'AGENTS.md'), 'utf-8');
+      const expectedContext = resolveAgentsModelTableContext(
+        await readFile(join(wd, '.codex', 'config.toml'), 'utf-8'),
+        { codexHomeOverride: join(wd, '.codex') },
+      );
+
+      assert.match(output, /Merged OMX-managed AGENTS\.md sections into project root\./);
+      assert.equal(countOccurrences(agentsContent, '<!-- omx:generated:agents-md -->'), 1);
+      assert.equal(countOccurrences(agentsContent, OMX_MANAGED_AGENTS_START_MARKER), 0);
+      assert.equal(countOccurrences(agentsContent, OMX_MANAGED_AGENTS_END_MARKER), 0);
+      assert.match(
+        agentsContent,
+        new RegExp(`\\| Frontier \\(leader\\) \\| \`${expectedContext.frontierModel}\` \\| high \\|`),
+      );
+      assert.match(
+        agentsContent,
+        new RegExp(`\\| Spark \\(explorer\\/fast\\) \\| \`${expectedContext.sparkModel}\` \\| low \\|`),
+      );
+      assert.doesNotMatch(agentsContent, /stale-frontier/);
+      assert.doesNotMatch(agentsContent, /stale-spark/);
+    } finally {
+      restoreHome();
+      restoreTty();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('refreshes only the explicit OMX-owned model block inside a user-authored AGENTS.md', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-setup-agents-'));
     const restoreTty = setMockTty(false);

--- a/src/utils/agents-md.ts
+++ b/src/utils/agents-md.ts
@@ -108,6 +108,10 @@ export function upsertManagedAgentsBlock(
     return next.endsWith('\n') ? next : `${next}\n`
   }
 
+  if (isOmxGeneratedAgentsMd(normalizedExisting)) {
+    return preserveUserOmxPolicyBlocks(normalizedExisting, normalizedManaged)
+  }
+
   return `${normalizedExisting.trimEnd()}\n\n${block}\n`
 }
 


### PR DESCRIPTION
## Summary
- Make `omx setup --merge-agents` refresh an already generated `AGENTS.md` directly instead of wrapping it in a nested `OMX:AGENTS` managed block.
- Preserve explicit user-authored `AGENTS.md` wrapper behavior by replacing existing `OMX:AGENTS` blocks before treating generated files as fully managed.
- Add regression coverage for stale model rows and nested generated block prevention.

Fixes #2934.

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/setup-agents-overwrite.test.js`
- `npm run check:no-unused`
- `npm run lint`

## Notes
- `.gjc/` session artifacts were left untracked and are not included in the commit.
- Bundled QA/review subagents exceeded the useful wait window during delivery; final delivery relies on the focused verification above plus the returned architect/QA receipts when they completed.