### PR TITLE
Fix Spark native provider inheritance

### DIFF
--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -417,6 +417,43 @@ describe("agents/native-config", () => {
     }
   });
 
+  it("omits inherited custom provider for default Spark-lane native agents", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omx-native-config-spark-provider-"));
+    const codexHome = join(root, ".codex");
+    const promptsDir = join(root, "prompts");
+    const outDir = join(codexHome, "agents");
+    const previousCodexHome = process.env.CODEX_HOME;
+
+    try {
+      process.env.CODEX_HOME = codexHome;
+      await mkdir(promptsDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(codexHome, ".omx-config.json"), JSON.stringify({
+        env: {
+          OMX_DEFAULT_SPARK_MODEL: "gpt-5.4-mini",
+        },
+      }));
+      await writeFile(join(codexHome, "config.toml"), [
+        'model = "gpt-5.5"',
+        'model_provider = "OpenAI"',
+        '',
+      ].join('\n'));
+      await writeFile(join(promptsDir, "explore.md"), "explore prompt");
+
+      await installNativeAgentConfigs(root, {
+        agentsDir: outDir,
+        catalogManifest: manifestWithAgents(["explore"]),
+      });
+      const exploreToml = await readFile(join(outDir, "explore.toml"), "utf8");
+      assert.match(exploreToml, /model = "gpt-5\.4-mini"/);
+      assert.doesNotMatch(exploreToml, /model_provider = /);
+    } finally {
+      if (typeof previousCodexHome === "string") process.env.CODEX_HOME = previousCodexHome;
+      else delete process.env.CODEX_HOME;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("inherits a custom root model for standard agents when no standard override exists", async () => {
     const root = await mkdtemp(join(tmpdir(), "omx-native-config-root-model-"));
     const codexHome = join(root, ".codex");

--- a/src/agents/native-config.ts
+++ b/src/agents/native-config.ts
@@ -198,6 +198,16 @@ function resolveAgentModel(
   }
 }
 
+function shouldInheritRootModelProvider(
+  agent: AgentDefinition,
+  resolvedModel: string,
+  options: AgentModelResolutionOptions = {},
+): boolean {
+  if (agent.modelClass !== "fast") return true;
+  if (getAgentModelOverride(agent.name, options.codexHomeOverride)) return true;
+  return resolvedModel !== getSparkDefaultModel(options.codexHomeOverride);
+}
+
 function isExactMiniModel(resolvedModel?: string | null): boolean {
   return resolvedModel?.trim() === EXACT_GPT_5_4_MINI_MODEL;
 }
@@ -339,7 +349,9 @@ export function generateAgentToml(
   options: AgentModelResolutionOptions = {},
 ): string {
   const resolvedModel = resolveAgentModel(agent, options);
-  const resolvedModelProvider = getCodexConfigRootModelProvider(options.codexHomeOverride);
+  const resolvedModelProvider = shouldInheritRootModelProvider(agent, resolvedModel, options)
+    ? getCodexConfigRootModelProvider(options.codexHomeOverride)
+    : undefined;
   return generateStandaloneAgentToml({
     name: agent.name,
     description: agent.description,


### PR DESCRIPTION
## Summary
- omit inherited root `model_provider` for default Spark-lane native agents so native Spark uses Codex's default provider
- preserve provider inheritance for non-Spark agents and explicit per-agent model overrides
- add regression coverage for the #2936 custom root provider + Spark model setup path

## Verification
- `npm ci`
- `npm run build`
- `node dist/scripts/run-test-files.js dist/agents/__tests__/native-config.test.js dist/cli/__tests__/doctor-spark-routing.test.js`
- `npm run check:no-unused`
- adversarial compiled probe: default explore omits provider, executor inherits provider, explicit explore provider still triggers doctor warning