### PR TITLE
fix(team): suppress stale leader nudges after shutdown

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -1007,6 +1007,133 @@ describe('notify-hook team leader nudge', () => {
     });
   });
 
+  it('suppresses leader mailbox nudge when team state disappears before injection', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'leader-nudge-teardown-race';
+      const teamDir = join(stateDir, 'team', teamName);
+      const mailboxDir = join(teamDir, 'mailbox');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(mailboxDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'leader-nudge-teardown-race:0',
+        leader_pane_id: '%91',
+        workers: [{ name: 'worker-1', index: 1, pane_id: '%11' }],
+      });
+      await writeJson(join(mailboxDir, 'leader-fixed.json'), {
+        worker: 'leader-fixed',
+        messages: [
+          {
+            message_id: 'late-after-shutdown',
+            from_worker: 'worker-1',
+            to_worker: 'leader-fixed',
+            body: 'Done; please review',
+            created_at: '2026-02-14T00:00:00.000Z',
+          },
+        ],
+      });
+
+      const quotedTeamDir = JSON.stringify(teamDir);
+      await writeFile(fakeTmuxPath, `#!/usr/bin/env bash
+set -eu
+echo "$@" >> "${tmuxLogPath}"
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  target=""
+  format=""
+  while (($#)); do
+    case "$1" in
+      -p) shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) format="$1"; shift ;;
+    esac
+  done
+  case "$format" in
+    "#{pane_id}") echo "$target" ;;
+    "#{pane_in_mode}") echo "0" ;;
+    "#{pane_current_command}") echo "codex" ;;
+    "#{pane_start_command}") echo "codex" ;;
+    "#S") echo "leader-nudge-teardown-race" ;;
+    *) echo "" ;;
+  esac
+  exit 0
+fi
+if [[ "$cmd" == "list-panes" ]]; then
+  echo "%11 12345"
+  exit 0
+fi
+if [[ "$cmd" == "capture-pane" ]]; then
+  rm -rf ${quotedTeamDir}
+  echo "› Ready"
+  exit 0
+fi
+if [[ "$cmd" == "set-buffer" ]]; then
+  printf '%s' "\${@: -1}" > "${tmuxLogPath}.buffer"
+  exit 0
+fi
+if [[ "$cmd" == "show-buffer" ]]; then
+  if [[ -f "${tmuxLogPath}.buffer" ]]; then cat "${tmuxLogPath}.buffer"; fi
+  exit 0
+fi
+if [[ "$cmd" == "paste-buffer" ]]; then
+  target=""
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      -t) target="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  if [[ -f "${tmuxLogPath}.buffer" ]]; then
+    echo "send-keys -t \${target} -l $(cat "${tmuxLogPath}.buffer")" >> "${tmuxLogPath}"
+  fi
+  exit 0
+fi
+if [[ "$cmd" == "delete-buffer" ]]; then
+  rm -f "${tmuxLogPath}.buffer"
+  exit 0
+fi
+if [[ "$cmd" == "send-keys" ]]; then
+  exit 0
+fi
+exit 0
+`);
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir);
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      assert.equal(existsSync(teamDir), false, 'teardown race should remove the canonical team state');
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.doesNotMatch(tmuxLog, /send-keys -t %91 -l Team leader-nudge-teardown-race:/);
+      assert.doesNotMatch(tmuxLog, /paste-buffer -t %91/);
+
+      const deliveryLog = await readTeamDeliveryLog(cwd);
+      assert.ok(deliveryLog.some((entry) =>
+        entry.event === 'nudge_triggered'
+        && entry.team === teamName
+        && entry.to_worker === 'leader-fixed'
+        && entry.transport === 'none'
+        && entry.result === 'suppressed'
+        && entry.reason === 'team_state_gone_or_shutdown'),
+      'teardown-race leader mailbox nudge should be diagnostic suppression, not an actionable injection');
+    });
+  });
+
   it('injects leader nudge into a busy live Codex pane so the message can queue', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -1122,6 +1122,19 @@ exit 0
       assert.doesNotMatch(tmuxLog, /send-keys -t %91 -l Team leader-nudge-teardown-race:/);
       assert.doesNotMatch(tmuxLog, /paste-buffer -t %91/);
 
+      const nudgeStatePath = join(stateDir, 'team-leader-nudge.json');
+      if (existsSync(nudgeStatePath)) {
+        const nudgeState = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
+        assert.equal(nudgeState.progress_by_team?.[teamName], undefined);
+        assert.equal(nudgeState.last_nudged_by_team?.[teamName], undefined);
+        assert.equal(nudgeState.last_idle_nudged_by_team?.[teamName], undefined);
+      }
+      assert.equal(
+        existsSync(join(teamDir, 'leader-attention.json')),
+        false,
+        'removed team must not get recreated by leader-attention bookkeeping',
+      );
+
       const deliveryLog = await readTeamDeliveryLog(cwd);
       assert.ok(deliveryLog.some((entry) =>
         entry.event === 'nudge_triggered'

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -6,6 +6,7 @@ import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { initTeamState, enqueueDispatchRequest, readDispatchRequest } from '../../team/state.js';
+import { maybeNudgeTeamLeader, setLeaderNudgeTestHooksForTests } from '../../scripts/notify-hook/team-leader-nudge.js';
 
 const NOTIFY_HOOK_SCRIPT = new URL('../../../dist/scripts/notify-hook.js', import.meta.url);
 
@@ -109,6 +110,64 @@ async function writeCanonicalTeamFixture(
       updated_at: nowIso,
     });
   }
+}
+
+
+async function withProcessEnv(env: Record<string, string>, run: () => Promise<void>): Promise<void> {
+  const previous: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(env)) {
+    previous[key] = process.env[key];
+    process.env[key] = value;
+  }
+  try {
+    await run();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+async function writeLeaderNudgeRaceFixture(cwd: string, teamName: string): Promise<void> {
+  const stateDir = join(cwd, '.omx', 'state');
+  const logsDir = join(cwd, '.omx', 'logs');
+  const teamDir = join(stateDir, 'team', teamName);
+  await mkdir(join(teamDir, 'mailbox'), { recursive: true });
+  await mkdir(logsDir, { recursive: true });
+  await writeJson(join(stateDir, 'team-state.json'), {
+    active: true,
+    team_name: teamName,
+    current_phase: 'team-exec',
+  });
+  await writeJson(join(teamDir, 'config.json'), {
+    name: teamName,
+    tmux_session: `${teamName}:0`,
+    leader_pane_id: '',
+    workers: [{ name: 'worker-1', index: 1, pane_id: '%11' }],
+  });
+  await mkdir(join(teamDir, 'workers', 'worker-1'), { recursive: true });
+  await writeJson(join(teamDir, 'workers', 'worker-1', 'status.json'), {
+    state: 'idle',
+    updated_at: new Date().toISOString(),
+  });
+  await writeJson(join(teamDir, 'mailbox', 'leader-fixed.json'), {
+    worker: 'leader-fixed',
+    messages: [
+      {
+        message_id: `${teamName}-msg-1`,
+        from_worker: 'worker-1',
+        to_worker: 'leader-fixed',
+        body: 'please review',
+        created_at: '2026-02-14T00:00:00.000Z',
+      },
+    ],
+  });
+}
+
+async function readNudgeState(cwd: string): Promise<Record<string, any>> {
+  const nudgeStatePath = join(cwd, '.omx', 'state', 'team-leader-nudge.json');
+  return JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
 }
 
 async function readTeamDeliveryLog(cwd: string): Promise<Array<Record<string, unknown>>> {
@@ -1190,12 +1249,29 @@ exit 0
       await writeFile(fakeTmuxPath, buildFakeTmuxWithListPanes(tmuxLogPath, ['%11 12345']));
       await chmod(fakeTmuxPath, 0o755);
 
-      const result = runNotifyHook(cwd, fakeBinDir, {
-        OMX_NOTIFY_HOOK_FAULT_REMOVE_TEAM_BEFORE_LEADER_ATTENTION_WRITE: teamName,
-      });
-      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+      try {
+        setLeaderNudgeTestHooksForTests({
+          beforeLeaderAttentionRename: async () => {
+            await rm(teamDir, { recursive: true, force: true });
+          },
+        });
+        await withProcessEnv({
+          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          OMX_TEAM_LEADER_NUDGE_MS: '10000',
+          OMX_TEAM_LEADER_STALE_MS: '10000',
+        }, async () => {
+          await maybeNudgeTeamLeader({
+            cwd,
+            stateDir,
+            logsDir,
+            preComputedLeaderStale: true,
+          });
+        });
+      } finally {
+        setLeaderNudgeTestHooksForTests();
+      }
 
-      assert.equal(existsSync(teamDir), false, 'fault injection should remove canonical team state during persistence');
+      assert.equal(existsSync(teamDir), false, 'test seam should remove canonical team state during persistence');
       assert.equal(
         existsSync(join(teamDir, 'leader-attention.json')),
         false,
@@ -1219,6 +1295,112 @@ exit 0
         && entry.result === 'suppressed'
         && entry.reason === 'team_state_gone_or_shutdown'),
       'late persistence race should emit diagnostic suppression instead of stale bookkeeping');
+    });
+  });
+
+  it('rolls back team nudge bookkeeping when shutdown wins immediately before global nudge-state write', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const teamName = 'nudge-before-global-race';
+      const preservedTeam = 'preserved-live-team';
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+
+      await writeLeaderNudgeRaceFixture(cwd, teamName);
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(fakeTmuxPath, buildFakeTmuxWithListPanes(join(cwd, 'tmux.log'), ['%11 12345']));
+      await chmod(fakeTmuxPath, 0o755);
+      await writeJson(join(stateDir, 'team-leader-nudge.json'), {
+        progress_by_team: { [preservedTeam]: { signature: 'keep' } },
+        last_nudged_by_team: { [preservedTeam]: { at: '2026-02-14T00:00:00.000Z' } },
+        last_idle_nudged_by_team: { [preservedTeam]: { at: '2026-02-14T00:00:00.000Z' } },
+      });
+
+      try {
+        setLeaderNudgeTestHooksForTests({
+          beforeGlobalNudgeStateRename: async () => {
+            await rm(join(stateDir, 'team', teamName), { recursive: true, force: true });
+          },
+        });
+        await withProcessEnv({
+          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          OMX_TEAM_LEADER_NUDGE_MS: '10000',
+          OMX_TEAM_LEADER_STALE_MS: '10000',
+        }, async () => {
+          await maybeNudgeTeamLeader({
+            cwd,
+            stateDir,
+            logsDir,
+            preComputedLeaderStale: true,
+          });
+        });
+      } finally {
+        setLeaderNudgeTestHooksForTests();
+      }
+
+      assert.equal(existsSync(join(stateDir, 'team', teamName)), false);
+      assert.equal(existsSync(join(stateDir, 'team', teamName, 'leader-attention.json')), false);
+      const nudgeState = await readNudgeState(cwd);
+      assert.equal(nudgeState.progress_by_team?.[teamName], undefined);
+      assert.equal(nudgeState.last_nudged_by_team?.[teamName], undefined);
+      assert.equal(nudgeState.last_idle_nudged_by_team?.[teamName], undefined);
+      assert.deepEqual(nudgeState.progress_by_team?.[preservedTeam], { signature: 'keep' });
+      assert.equal(nudgeState.last_nudged_by_team?.[preservedTeam]?.at, '2026-02-14T00:00:00.000Z');
+      assert.equal(nudgeState.last_idle_nudged_by_team?.[preservedTeam]?.at, '2026-02-14T00:00:00.000Z');
+    });
+  });
+
+  it('rolls back team nudge bookkeeping when shutdown wins during global nudge-state write', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const teamName = 'nudge-during-global-race';
+      const preservedTeam = 'preserved-live-team';
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+
+      await writeLeaderNudgeRaceFixture(cwd, teamName);
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(fakeTmuxPath, buildFakeTmuxWithListPanes(join(cwd, 'tmux.log'), ['%11 12345']));
+      await chmod(fakeTmuxPath, 0o755);
+      await writeJson(join(stateDir, 'team-leader-nudge.json'), {
+        progress_by_team: { [preservedTeam]: { signature: 'keep' } },
+        last_nudged_by_team: { [preservedTeam]: { at: '2026-02-14T00:00:00.000Z' } },
+        last_idle_nudged_by_team: { [preservedTeam]: { at: '2026-02-14T00:00:00.000Z' } },
+      });
+
+      try {
+        setLeaderNudgeTestHooksForTests({
+          afterGlobalNudgeStateRename: async () => {
+            await rm(join(stateDir, 'team', teamName), { recursive: true, force: true });
+          },
+        });
+        await withProcessEnv({
+          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          OMX_TEAM_LEADER_NUDGE_MS: '10000',
+          OMX_TEAM_LEADER_STALE_MS: '10000',
+        }, async () => {
+          await maybeNudgeTeamLeader({
+            cwd,
+            stateDir,
+            logsDir,
+            preComputedLeaderStale: true,
+          });
+        });
+      } finally {
+        setLeaderNudgeTestHooksForTests();
+      }
+
+      assert.equal(existsSync(join(stateDir, 'team', teamName)), false);
+      assert.equal(existsSync(join(stateDir, 'team', teamName, 'leader-attention.json')), false);
+      const nudgeState = await readNudgeState(cwd);
+      assert.equal(nudgeState.progress_by_team?.[teamName], undefined);
+      assert.equal(nudgeState.last_nudged_by_team?.[teamName], undefined);
+      assert.equal(nudgeState.last_idle_nudged_by_team?.[teamName], undefined);
+      assert.deepEqual(nudgeState.progress_by_team?.[preservedTeam], { signature: 'keep' });
+      assert.equal(nudgeState.last_nudged_by_team?.[preservedTeam]?.at, '2026-02-14T00:00:00.000Z');
+      assert.equal(nudgeState.last_idle_nudged_by_team?.[preservedTeam]?.at, '2026-02-14T00:00:00.000Z');
     });
   });
 

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -1147,6 +1147,81 @@ exit 0
     });
   });
 
+  it('does not persist bookkeeping when team is removed after the final liveness check', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const teamName = 'leader-nudge-late-persist-race';
+      const teamDir = join(stateDir, 'team', teamName);
+      const mailboxDir = join(teamDir, 'mailbox');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(mailboxDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'leader-nudge-late-persist-race:0',
+        leader_pane_id: '%91',
+        workers: [{ name: 'worker-1', index: 1, pane_id: '%11' }],
+      });
+      await writeJson(join(mailboxDir, 'leader-fixed.json'), {
+        worker: 'leader-fixed',
+        messages: [
+          {
+            message_id: 'late-persist-race',
+            from_worker: 'worker-1',
+            to_worker: 'leader-fixed',
+            body: 'please review before shutdown completes',
+            created_at: '2026-02-14T00:00:00.000Z',
+          },
+        ],
+      });
+
+      await writeFile(fakeTmuxPath, buildFakeTmuxWithListPanes(tmuxLogPath, ['%11 12345']));
+      await chmod(fakeTmuxPath, 0o755);
+
+      const result = runNotifyHook(cwd, fakeBinDir, {
+        OMX_NOTIFY_HOOK_FAULT_REMOVE_TEAM_BEFORE_LEADER_ATTENTION_WRITE: teamName,
+      });
+      assert.equal(result.status, 0, `notify-hook failed: ${result.stderr || result.stdout}`);
+
+      assert.equal(existsSync(teamDir), false, 'fault injection should remove canonical team state during persistence');
+      assert.equal(
+        existsSync(join(teamDir, 'leader-attention.json')),
+        false,
+        'guarded persistence must not recreate leader-attention.json for the removed team',
+      );
+
+      const nudgeStatePath = join(stateDir, 'team-leader-nudge.json');
+      if (existsSync(nudgeStatePath)) {
+        const nudgeState = JSON.parse(await readFile(nudgeStatePath, 'utf-8'));
+        assert.equal(nudgeState.progress_by_team?.[teamName], undefined);
+        assert.equal(nudgeState.last_nudged_by_team?.[teamName], undefined);
+        assert.equal(nudgeState.last_idle_nudged_by_team?.[teamName], undefined);
+      }
+
+      const deliveryLog = await readTeamDeliveryLog(cwd);
+      assert.ok(deliveryLog.some((entry) =>
+        entry.event === 'nudge_triggered'
+        && entry.team === teamName
+        && entry.to_worker === 'leader-fixed'
+        && entry.transport === 'none'
+        && entry.result === 'suppressed'
+        && entry.reason === 'team_state_gone_or_shutdown'),
+      'late persistence race should emit diagnostic suppression instead of stale bookkeeping');
+    });
+  });
+
   it('injects leader nudge into a busy live Codex pane so the message can queue', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -28,6 +28,7 @@ import { TEAM_NAME_SAFE_PATTERN } from '../../team/contracts.js';
 import { isDeepInterviewStateActive } from './auto-nudge.js';
 const LEADER_PANE_MISSING_NO_INJECTION_REASON = 'leader_pane_missing_no_injection';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
+const TEAM_SHUTDOWN_NO_INJECTION_REASON = 'team_state_gone_or_shutdown';
 const LEADER_PANE_SAME_CLASSIFIED_STATE_SUPPRESSED_REASON = 'pane_already_shows_same_classified_state';
 const LEADER_NOTIFICATION_DEFERRED_TYPE = 'leader_notification_deferred';
 const ACK_WITHOUT_START_EVIDENCE_REASON = 'ack_without_start_evidence';
@@ -36,6 +37,50 @@ const ACK_LIKE_PATTERNS = [
   /^(?:ok|okay|k|roger|copy|received|got it|understood|sounds good)[.!]*$/i,
   /^(?:on it|will do|i(?:'|')ll do it|working on it)[.!]*$/i,
 ];
+
+
+async function teamStateAllowsLeaderNudge(stateDir, teamName) {
+  const teamDir = join(stateDir, 'team', teamName);
+  if (!existsSync(teamDir)) return false;
+  if (existsSync(join(teamDir, 'shutdown.json'))) return false;
+
+  const phase = await readJsonIfExists(join(teamDir, 'phase.json'), null);
+  const currentPhase = safeString(phase?.current_phase || phase?.phase || '').trim();
+  if (currentPhase && isTerminalPhase(currentPhase)) return false;
+
+  return true;
+}
+
+async function recordSuppressedLeaderNudge({
+  logsDir,
+  source,
+  teamName,
+  reason,
+  orchestrationIntent = null,
+}) {
+  const nowIso = new Date().toISOString();
+  await logTmuxHookEvent(logsDir, {
+    timestamp: nowIso,
+    type: 'team_leader_nudge_suppressed',
+    team: teamName,
+    worker: 'leader-fixed',
+    to_worker: 'leader-fixed',
+    reason,
+    orchestration_intent: orchestrationIntent,
+    tmux_injection_attempted: false,
+    source_type: 'leader_nudge',
+  }).catch(() => {});
+  await appendTeamDeliveryLog(logsDir, {
+    event: 'nudge_triggered',
+    source,
+    team: teamName,
+    to_worker: 'leader-fixed',
+    transport: 'none',
+    result: 'suppressed',
+    reason,
+    orchestration_intent: orchestrationIntent,
+  }).catch(() => {});
+}
 
 function normalizeValidSessionId(value) {
   const trimmed = safeString(value).trim();
@@ -613,6 +658,15 @@ export async function maybeNudgeTeamLeader({
   const leaderStale = typeof preComputedLeaderStale === 'boolean' ? preComputedLeaderStale : false;
 
   for (const teamName of candidateTeamNames) {
+    if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
+      await recordSuppressedLeaderNudge({
+        logsDir,
+        source,
+        teamName,
+        reason: TEAM_SHUTDOWN_NO_INJECTION_REASON,
+      });
+      continue;
+    }
     let tmuxSession = '';
     let leaderPaneId = '';
     let ownerSessionId = '';
@@ -772,6 +826,16 @@ export async function maybeNudgeTeamLeader({
       text = `Team ${teamName}: ${messages.length} msg(s) for leader. ${buildMailboxCheckReminder(teamName)}`;
     }
 
+    if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
+      await recordSuppressedLeaderNudge({
+        logsDir,
+        source,
+        teamName,
+        reason: TEAM_SHUTDOWN_NO_INJECTION_REASON,
+      });
+      continue;
+    }
+
     const unreadLeaderMessageCount = messages.filter((message) => !safeString(message?.delivered_at).trim()).length;
     nudgeState.progress_by_team[teamName] = {
       signature: progressSnapshot.signature,
@@ -811,6 +875,16 @@ export async function maybeNudgeTeamLeader({
 
     if (!nudgeReason) continue;
     const orchestrationIntent = resolveLeaderNudgeIntent({ nudgeReason, leaderActionState });
+    if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
+      await recordSuppressedLeaderNudge({
+        logsDir,
+        source,
+        teamName,
+        reason: TEAM_SHUTDOWN_NO_INJECTION_REASON,
+        orchestrationIntent,
+      });
+      continue;
+    }
     const capped = text.length > 180 ? `${text.slice(0, 177)}...` : text;
     const markedText = `${capped} ${DEFAULT_MARKER}`;
 
@@ -827,6 +901,16 @@ export async function maybeNudgeTeamLeader({
           worker_count: workerNames.length,
           orchestration_intent: orchestrationIntent,
         };
+      }
+      if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
+        await recordSuppressedLeaderNudge({
+          logsDir,
+          source,
+          teamName,
+          reason: TEAM_SHUTDOWN_NO_INJECTION_REASON,
+          orchestrationIntent,
+        });
+        continue;
       }
       await emitLeaderNudgeDeferredEvent(cwd, teamName, LEADER_PANE_MISSING_NO_INJECTION_REASON, orchestrationIntent, nowIso, {
         tmuxSession,
@@ -886,6 +970,16 @@ export async function maybeNudgeTeamLeader({
           orchestration_intent: orchestrationIntent,
         };
       }
+      if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
+        await recordSuppressedLeaderNudge({
+          logsDir,
+          source,
+          teamName,
+          reason: TEAM_SHUTDOWN_NO_INJECTION_REASON,
+          orchestrationIntent,
+        });
+        continue;
+      }
       await emitLeaderNudgeDeferredEvent(cwd, teamName, deferredReason, orchestrationIntent, nowIso, {
         tmuxSession,
         leaderPaneId,
@@ -939,7 +1033,19 @@ export async function maybeNudgeTeamLeader({
         };
       }
 
-      await emitTeamNudgeEvent(cwd, teamName, nudgeReason, orchestrationIntent, nowIso);
+      if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
+        await recordSuppressedLeaderNudge({
+          logsDir,
+          source,
+          teamName,
+          reason: TEAM_SHUTDOWN_NO_INJECTION_REASON,
+          orchestrationIntent,
+        });
+        continue;
+      }
+      if (await teamStateAllowsLeaderNudge(stateDir, teamName)) {
+        await emitTeamNudgeEvent(cwd, teamName, nudgeReason, orchestrationIntent, nowIso);
+      }
 
       try {
         await logTmuxHookEvent(logsDir, {
@@ -970,6 +1076,17 @@ export async function maybeNudgeTeamLeader({
         visible_injection_suppressed: true,
         suppression_reason: LEADER_PANE_SAME_CLASSIFIED_STATE_SUPPRESSED_REASON,
       }).catch(() => {});
+      continue;
+    }
+
+    if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
+      await recordSuppressedLeaderNudge({
+        logsDir,
+        source,
+        teamName,
+        reason: TEAM_SHUTDOWN_NO_INJECTION_REASON,
+        orchestrationIntent,
+      });
       continue;
     }
 
@@ -1010,7 +1127,9 @@ export async function maybeNudgeTeamLeader({
         };
       }
 
-      await emitTeamNudgeEvent(cwd, teamName, nudgeReason, orchestrationIntent, nowIso);
+      if (await teamStateAllowsLeaderNudge(stateDir, teamName)) {
+        await emitTeamNudgeEvent(cwd, teamName, nudgeReason, orchestrationIntent, nowIso);
+      }
 
       try {
         await logTmuxHookEvent(logsDir, {

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -826,69 +826,45 @@ export async function maybeNudgeTeamLeader({
       text = `Team ${teamName}: ${messages.length} msg(s) for leader. ${buildMailboxCheckReminder(teamName)}`;
     }
 
-    if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
-      await recordSuppressedLeaderNudge({
-        logsDir,
-        source,
-        teamName,
-        reason: TEAM_SHUTDOWN_NO_INJECTION_REASON,
-      });
-      continue;
-    }
-
     const unreadLeaderMessageCount = messages.filter((message) => !safeString(message?.delivered_at).trim()).length;
-    nudgeState.progress_by_team[teamName] = {
-      signature: progressSnapshot.signature,
-      last_progress_at: effectiveProgressAtIso,
-      observed_at: nowIso,
-      missing_signal_workers: progressSnapshot.missingSignalWorkers,
-      work_remaining: progressSnapshot.workRemaining,
-      leader_action_state: leaderActionState,
-      leader_attention_pending: !!nudgeReason,
-      leader_attention_reason: nudgeReason || null,
-      leader_stale: leaderStale,
-      all_workers_idle: allWorkersIdle,
-      pending_task_count:
-        (progressSnapshot.taskCounts.pending || 0)
-        + (progressSnapshot.taskCounts.blocked || 0)
-        + (progressSnapshot.taskCounts.in_progress || 0),
-      unread_leader_message_count: unreadLeaderMessageCount,
-      stalled_for_ms: null,
-      source: source === 'notify_fallback_watcher' ? 'notify_hook' : source,
+    const writeProgressBookkeeping = async () => {
+      nudgeState.progress_by_team[teamName] = {
+        signature: progressSnapshot.signature,
+        last_progress_at: effectiveProgressAtIso,
+        observed_at: nowIso,
+        missing_signal_workers: progressSnapshot.missingSignalWorkers,
+        work_remaining: progressSnapshot.workRemaining,
+        leader_action_state: leaderActionState,
+        leader_attention_pending: !!nudgeReason,
+        leader_attention_reason: nudgeReason || null,
+        leader_stale: leaderStale,
+        all_workers_idle: allWorkersIdle,
+        pending_task_count:
+          (progressSnapshot.taskCounts.pending || 0)
+          + (progressSnapshot.taskCounts.blocked || 0)
+          + (progressSnapshot.taskCounts.in_progress || 0),
+        unread_leader_message_count: unreadLeaderMessageCount,
+        stalled_for_ms: null,
+        source: source === 'notify_fallback_watcher' ? 'notify_hook' : source,
+      };
+      await writeTeamLeaderAttention(teamName, {
+        team_name: teamName,
+        updated_at: nowIso,
+        source: 'notify_hook',
+        leader_decision_state: leaderActionState,
+        leader_attention_pending: !!nudgeReason,
+        leader_attention_reason: nudgeReason || null,
+        attention_reasons: nudgeReason ? [nudgeReason] : [],
+        leader_stale: leaderStale,
+        leader_session_active: true,
+        leader_session_id: currentSessionId || ownerSessionId || null,
+        leader_session_stopped_at: null,
+        unread_leader_message_count: unreadLeaderMessageCount,
+        work_remaining: progressSnapshot.workRemaining,
+        stalled_for_ms: null,
+      }, cwd).catch(() => {});
     };
-    await writeTeamLeaderAttention(teamName, {
-      team_name: teamName,
-      updated_at: nowIso,
-      source: 'notify_hook',
-      leader_decision_state: leaderActionState,
-      leader_attention_pending: !!nudgeReason,
-      leader_attention_reason: nudgeReason || null,
-      attention_reasons: nudgeReason ? [nudgeReason] : [],
-      leader_stale: leaderStale,
-      leader_session_active: true,
-      leader_session_id: currentSessionId || ownerSessionId || null,
-      leader_session_stopped_at: null,
-      unread_leader_message_count: unreadLeaderMessageCount,
-      work_remaining: progressSnapshot.workRemaining,
-      stalled_for_ms: null,
-    }, cwd).catch(() => {});
-
-    if (!nudgeReason) continue;
-    const orchestrationIntent = resolveLeaderNudgeIntent({ nudgeReason, leaderActionState });
-    if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
-      await recordSuppressedLeaderNudge({
-        logsDir,
-        source,
-        teamName,
-        reason: TEAM_SHUTDOWN_NO_INJECTION_REASON,
-        orchestrationIntent,
-      });
-      continue;
-    }
-    const capped = text.length > 180 ? `${text.slice(0, 177)}...` : text;
-    const markedText = `${capped} ${DEFAULT_MARKER}`;
-
-    if (!tmuxTarget) {
+    const markLastNudged = (orchestrationIntent) => {
       nudgeState.last_nudged_by_team[teamName] = {
         at: nowIso,
         last_message_id: newestId || prevMsgId || '',
@@ -902,16 +878,40 @@ export async function maybeNudgeTeamLeader({
           orchestration_intent: orchestrationIntent,
         };
       }
+    };
+    const recordShutdownSuppression = async (orchestrationIntent = null) => {
+      await recordSuppressedLeaderNudge({
+        logsDir,
+        source,
+        teamName,
+        reason: TEAM_SHUTDOWN_NO_INJECTION_REASON,
+        orchestrationIntent,
+      });
+    };
+
+    if (!nudgeReason) {
       if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
-        await recordSuppressedLeaderNudge({
-          logsDir,
-          source,
-          teamName,
-          reason: TEAM_SHUTDOWN_NO_INJECTION_REASON,
-          orchestrationIntent,
-        });
+        await recordShutdownSuppression();
         continue;
       }
+      await writeProgressBookkeeping();
+      continue;
+    }
+    const orchestrationIntent = resolveLeaderNudgeIntent({ nudgeReason, leaderActionState });
+    if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
+      await recordShutdownSuppression(orchestrationIntent);
+      continue;
+    }
+    const capped = text.length > 180 ? `${text.slice(0, 177)}...` : text;
+    const markedText = `${capped} ${DEFAULT_MARKER}`;
+
+    if (!tmuxTarget) {
+      if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
+        await recordShutdownSuppression(orchestrationIntent);
+        continue;
+      }
+      await writeProgressBookkeeping();
+      markLastNudged(orchestrationIntent);
       await emitLeaderNudgeDeferredEvent(cwd, teamName, LEADER_PANE_MISSING_NO_INJECTION_REASON, orchestrationIntent, nowIso, {
         tmuxSession,
         leaderPaneId,
@@ -957,29 +957,12 @@ export async function maybeNudgeTeamLeader({
       const deferredReason = paneGuard.reason === 'pane_running_shell'
         ? LEADER_PANE_SHELL_NO_INJECTION_REASON
         : paneGuard.reason;
-      nudgeState.last_nudged_by_team[teamName] = {
-        at: nowIso,
-        last_message_id: newestId || prevMsgId || '',
-        reason: nudgeReason,
-        orchestration_intent: orchestrationIntent,
-      };
-      if (shouldSendAllIdleNudge) {
-        nudgeState.last_idle_nudged_by_team[teamName] = {
-          at: nowIso,
-          worker_count: workerNames.length,
-          orchestration_intent: orchestrationIntent,
-        };
-      }
       if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
-        await recordSuppressedLeaderNudge({
-          logsDir,
-          source,
-          teamName,
-          reason: TEAM_SHUTDOWN_NO_INJECTION_REASON,
-          orchestrationIntent,
-        });
+        await recordShutdownSuppression(orchestrationIntent);
         continue;
       }
+      await writeProgressBookkeeping();
+      markLastNudged(orchestrationIntent);
       await emitLeaderNudgeDeferredEvent(cwd, teamName, deferredReason, orchestrationIntent, nowIso, {
         tmuxSession,
         leaderPaneId,
@@ -1019,33 +1002,13 @@ export async function maybeNudgeTeamLeader({
     }
 
     if (paneAlreadyShowsVisibleLeaderState(paneGuard.paneCapture, capped)) {
-      nudgeState.last_nudged_by_team[teamName] = {
-        at: nowIso,
-        last_message_id: newestId || prevMsgId || '',
-        reason: nudgeReason,
-        orchestration_intent: orchestrationIntent,
-      };
-      if (shouldSendAllIdleNudge) {
-        nudgeState.last_idle_nudged_by_team[teamName] = {
-          at: nowIso,
-          worker_count: workerNames.length,
-          orchestration_intent: orchestrationIntent,
-        };
-      }
-
       if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
-        await recordSuppressedLeaderNudge({
-          logsDir,
-          source,
-          teamName,
-          reason: TEAM_SHUTDOWN_NO_INJECTION_REASON,
-          orchestrationIntent,
-        });
+        await recordShutdownSuppression(orchestrationIntent);
         continue;
       }
-      if (await teamStateAllowsLeaderNudge(stateDir, teamName)) {
-        await emitTeamNudgeEvent(cwd, teamName, nudgeReason, orchestrationIntent, nowIso);
-      }
+      await writeProgressBookkeeping();
+      markLastNudged(orchestrationIntent);
+      await emitTeamNudgeEvent(cwd, teamName, nudgeReason, orchestrationIntent, nowIso);
 
       try {
         await logTmuxHookEvent(logsDir, {
@@ -1080,13 +1043,7 @@ export async function maybeNudgeTeamLeader({
     }
 
     if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
-      await recordSuppressedLeaderNudge({
-        logsDir,
-        source,
-        teamName,
-        reason: TEAM_SHUTDOWN_NO_INJECTION_REASON,
-        orchestrationIntent,
-      });
+      await recordShutdownSuppression(orchestrationIntent);
       continue;
     }
 
@@ -1113,22 +1070,13 @@ export async function maybeNudgeTeamLeader({
           throw new Error(sendResult.error || sendResult.reason);
         }
       }
-      nudgeState.last_nudged_by_team[teamName] = {
-        at: nowIso,
-        last_message_id: newestId || prevMsgId || '',
-        reason: nudgeReason,
-        orchestration_intent: orchestrationIntent,
-      };
-      if (shouldSendAllIdleNudge) {
-        nudgeState.last_idle_nudged_by_team[teamName] = {
-          at: nowIso,
-          worker_count: workerNames.length,
-          orchestration_intent: orchestrationIntent,
-        };
-      }
-
       if (await teamStateAllowsLeaderNudge(stateDir, teamName)) {
+        await writeProgressBookkeeping();
+        markLastNudged(orchestrationIntent);
         await emitTeamNudgeEvent(cwd, teamName, nudgeReason, orchestrationIntent, nowIso);
+      } else {
+        await recordShutdownSuppression(orchestrationIntent);
+        continue;
       }
 
       try {
@@ -1158,6 +1106,10 @@ export async function maybeNudgeTeamLeader({
         orchestration_intent: orchestrationIntent,
       }).catch(() => {});
     } catch (err) {
+      if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
+        await recordShutdownSuppression(orchestrationIntent);
+        continue;
+      }
       try {
         await logTmuxHookEvent(logsDir, {
           timestamp: nowIso,

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -3,7 +3,7 @@
  * Team leader nudge: remind the leader to check teammate/mailbox state.
  */
 
-import { readFile, writeFile, mkdir, appendFile, readdir, rm } from 'fs/promises';
+import { readFile, writeFile, mkdir, appendFile, readdir, rename, unlink } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join, resolve } from 'path';
 import { readUsableSessionState } from '../../hooks/session.js';
@@ -37,6 +37,65 @@ const ACK_LIKE_PATTERNS = [
   /^(?:on it|will do|i(?:'|')ll do it|working on it)[.!]*$/i,
 ];
 
+let atomicJsonWriteCounter = 0;
+
+// Synchronous test-only callbacks let regression tests emulate filesystem races
+// without shipping env-gated destructive fault injection in the notify hook.
+const leaderNudgeTestHooks = {
+  beforeLeaderAttentionRename: null,
+  afterLeaderAttentionRename: null,
+  beforeGlobalNudgeStateRename: null,
+  afterGlobalNudgeStateRename: null,
+};
+
+export function setLeaderNudgeTestHooksForTests(hooks = {}) {
+  leaderNudgeTestHooks.beforeLeaderAttentionRename = typeof hooks.beforeLeaderAttentionRename === 'function'
+    ? hooks.beforeLeaderAttentionRename
+    : null;
+  leaderNudgeTestHooks.afterLeaderAttentionRename = typeof hooks.afterLeaderAttentionRename === 'function'
+    ? hooks.afterLeaderAttentionRename
+    : null;
+  leaderNudgeTestHooks.beforeGlobalNudgeStateRename = typeof hooks.beforeGlobalNudgeStateRename === 'function'
+    ? hooks.beforeGlobalNudgeStateRename
+    : null;
+  leaderNudgeTestHooks.afterGlobalNudgeStateRename = typeof hooks.afterGlobalNudgeStateRename === 'function'
+    ? hooks.afterGlobalNudgeStateRename
+    : null;
+}
+
+async function atomicWriteJsonNoParentCreate(path, value, { beforeRename = null, afterRename = null } = {}) {
+  const tempPath = `${path}.${process.pid}.${Date.now()}.${++atomicJsonWriteCounter}.tmp`;
+  try {
+    await writeFile(tempPath, JSON.stringify(value, null, 2));
+    if (beforeRename) await beforeRename(tempPath);
+    await rename(tempPath, path);
+    if (afterRename) await afterRename(path);
+  } catch (error) {
+    await unlink(tempPath).catch(() => {});
+    throw error;
+  }
+}
+
+function cloneLeaderNudgeState(state) {
+  return {
+    ...(state && typeof state === 'object' ? state : {}),
+    last_nudged_by_team: { ...(state?.last_nudged_by_team || {}) },
+    last_idle_nudged_by_team: { ...(state?.last_idle_nudged_by_team || {}) },
+    progress_by_team: { ...(state?.progress_by_team || {}) },
+  };
+}
+
+function removeTeamFromLeaderNudgeState(state, teamName) {
+  if (state?.progress_by_team && typeof state.progress_by_team === 'object') {
+    delete state.progress_by_team[teamName];
+  }
+  if (state?.last_nudged_by_team && typeof state.last_nudged_by_team === 'object') {
+    delete state.last_nudged_by_team[teamName];
+  }
+  if (state?.last_idle_nudged_by_team && typeof state.last_idle_nudged_by_team === 'object') {
+    delete state.last_idle_nudged_by_team[teamName];
+  }
+}
 
 async function teamStateAllowsLeaderNudge(stateDir, teamName) {
   const teamDir = join(stateDir, 'team', teamName);
@@ -835,6 +894,15 @@ export async function maybeNudgeTeamLeader({
         orchestrationIntent,
       });
     };
+    const cleanupTeamPersistence = async () => {
+      await unlink(join(stateDir, 'team', teamName, 'leader-attention.json')).catch(() => {});
+      const latestState = await readJsonIfExists(nudgeStatePath, nudgeState);
+      const cleanedState = cloneLeaderNudgeState(latestState);
+      removeTeamFromLeaderNudgeState(cleanedState, teamName);
+      nudgeState = cleanedState;
+      await atomicWriteJsonNoParentCreate(nudgeStatePath, cleanedState).catch(() => {});
+    };
+
     const persistLeaderNudgeBookkeeping = async ({ orchestrationIntent = null, recordLastNudged = false } = {}) => {
       if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
         await recordShutdownSuppression(orchestrationIntent);
@@ -858,33 +926,37 @@ export async function maybeNudgeTeamLeader({
         stalled_for_ms: null,
       };
 
-      // Do not call writeTeamLeaderAttention() here: its atomic writer creates
-      // parent directories. A teardown can remove state/team/<team> after the
-      // advisory liveness checks above, and this persistence path must not
-      // recreate the team directory or leader-attention.json for a dead team.
-      if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
-        await recordShutdownSuppression(orchestrationIntent);
-        return false;
-      }
-      if (process.env.OMX_NOTIFY_HOOK_FAULT_REMOVE_TEAM_BEFORE_LEADER_ATTENTION_WRITE === teamName) {
-        await rm(join(stateDir, 'team', teamName), { recursive: true, force: true }).catch(() => {});
-      }
+      const leaderAttentionPath = join(stateDir, 'team', teamName, 'leader-attention.json');
       try {
-        await writeFile(
-          join(stateDir, 'team', teamName, 'leader-attention.json'),
-          JSON.stringify(leaderAttention, null, 2),
-        );
+        await atomicWriteJsonNoParentCreate(leaderAttentionPath, leaderAttention, {
+          beforeRename: async (tempPath) => {
+            if (leaderNudgeTestHooks.beforeLeaderAttentionRename) {
+              await leaderNudgeTestHooks.beforeLeaderAttentionRename({ stateDir, teamName, tempPath });
+            }
+            if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
+              throw new Error('team_state_gone_or_shutdown_before_leader_attention_rename');
+            }
+          },
+          afterRename: async () => {
+            if (leaderNudgeTestHooks.afterLeaderAttentionRename) {
+              await leaderNudgeTestHooks.afterLeaderAttentionRename({ stateDir, teamName, path: leaderAttentionPath });
+            }
+          },
+        });
       } catch {
+        await unlink(leaderAttentionPath).catch(() => {});
         await recordShutdownSuppression(orchestrationIntent);
         return false;
       }
 
       if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
+        await cleanupTeamPersistence();
         await recordShutdownSuppression(orchestrationIntent);
         return false;
       }
 
-      nudgeState.progress_by_team[teamName] = {
+      const nextNudgeState = cloneLeaderNudgeState(nudgeState);
+      nextNudgeState.progress_by_team[teamName] = {
         signature: progressSnapshot.signature,
         last_progress_at: effectiveProgressAtIso,
         observed_at: nowIso,
@@ -904,21 +976,50 @@ export async function maybeNudgeTeamLeader({
         source: source === 'notify_fallback_watcher' ? 'notify_hook' : source,
       };
       if (recordLastNudged) {
-        nudgeState.last_nudged_by_team[teamName] = {
+        nextNudgeState.last_nudged_by_team[teamName] = {
           at: nowIso,
           last_message_id: newestId || prevMsgId || '',
           reason: nudgeReason,
           orchestration_intent: orchestrationIntent,
         };
         if (shouldSendAllIdleNudge) {
-          nudgeState.last_idle_nudged_by_team[teamName] = {
+          nextNudgeState.last_idle_nudged_by_team[teamName] = {
             at: nowIso,
             worker_count: workerNames.length,
             orchestration_intent: orchestrationIntent,
           };
         }
       }
-      await writeFile(nudgeStatePath, JSON.stringify(nudgeState, null, 2)).catch(() => {});
+
+      try {
+        await atomicWriteJsonNoParentCreate(nudgeStatePath, nextNudgeState, {
+          beforeRename: async (tempPath) => {
+            if (leaderNudgeTestHooks.beforeGlobalNudgeStateRename) {
+              await leaderNudgeTestHooks.beforeGlobalNudgeStateRename({ stateDir, teamName, tempPath });
+            }
+            if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
+              throw new Error('team_state_gone_or_shutdown_before_nudge_state_rename');
+            }
+          },
+          afterRename: async () => {
+            if (leaderNudgeTestHooks.afterGlobalNudgeStateRename) {
+              await leaderNudgeTestHooks.afterGlobalNudgeStateRename({ stateDir, teamName, path: nudgeStatePath });
+            }
+          },
+        });
+      } catch {
+        await cleanupTeamPersistence();
+        await recordShutdownSuppression(orchestrationIntent);
+        return false;
+      }
+
+      if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
+        await cleanupTeamPersistence();
+        await recordShutdownSuppression(orchestrationIntent);
+        return false;
+      }
+
+      nudgeState = nextNudgeState;
       return true;
     };
 

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -3,7 +3,7 @@
  * Team leader nudge: remind the leader to check teammate/mailbox state.
  */
 
-import { readFile, writeFile, mkdir, appendFile, readdir } from 'fs/promises';
+import { readFile, writeFile, mkdir, appendFile, readdir, rm } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join, resolve } from 'path';
 import { readUsableSessionState } from '../../hooks/session.js';
@@ -21,7 +21,6 @@ import {
 import { DEFAULT_MARKER, paneHasActiveTask } from '../tmux-hook-engine.js';
 import { isLeaderRuntimeStale } from '../../team/leader-activity.js';
 import { appendTeamDeliveryLog } from '../../team/delivery-log.js';
-import { writeTeamLeaderAttention } from '../../team/state.js';
 import { readLatestTeamProgressEvidenceMs } from '../../team/progress-evidence.js';
 import { validateSessionId } from '../../mcp/state-paths.js';
 import { TEAM_NAME_SAFE_PATTERN } from '../../team/contracts.js';
@@ -827,7 +826,64 @@ export async function maybeNudgeTeamLeader({
     }
 
     const unreadLeaderMessageCount = messages.filter((message) => !safeString(message?.delivered_at).trim()).length;
-    const writeProgressBookkeeping = async () => {
+    const recordShutdownSuppression = async (orchestrationIntent = null) => {
+      await recordSuppressedLeaderNudge({
+        logsDir,
+        source,
+        teamName,
+        reason: TEAM_SHUTDOWN_NO_INJECTION_REASON,
+        orchestrationIntent,
+      });
+    };
+    const persistLeaderNudgeBookkeeping = async ({ orchestrationIntent = null, recordLastNudged = false } = {}) => {
+      if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
+        await recordShutdownSuppression(orchestrationIntent);
+        return false;
+      }
+
+      const leaderAttention = {
+        team_name: teamName,
+        updated_at: nowIso,
+        source: 'notify_hook',
+        leader_decision_state: leaderActionState,
+        leader_attention_pending: !!nudgeReason,
+        leader_attention_reason: nudgeReason || null,
+        attention_reasons: nudgeReason ? [nudgeReason] : [],
+        leader_stale: leaderStale,
+        leader_session_active: true,
+        leader_session_id: currentSessionId || ownerSessionId || null,
+        leader_session_stopped_at: null,
+        unread_leader_message_count: unreadLeaderMessageCount,
+        work_remaining: progressSnapshot.workRemaining,
+        stalled_for_ms: null,
+      };
+
+      // Do not call writeTeamLeaderAttention() here: its atomic writer creates
+      // parent directories. A teardown can remove state/team/<team> after the
+      // advisory liveness checks above, and this persistence path must not
+      // recreate the team directory or leader-attention.json for a dead team.
+      if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
+        await recordShutdownSuppression(orchestrationIntent);
+        return false;
+      }
+      if (process.env.OMX_NOTIFY_HOOK_FAULT_REMOVE_TEAM_BEFORE_LEADER_ATTENTION_WRITE === teamName) {
+        await rm(join(stateDir, 'team', teamName), { recursive: true, force: true }).catch(() => {});
+      }
+      try {
+        await writeFile(
+          join(stateDir, 'team', teamName, 'leader-attention.json'),
+          JSON.stringify(leaderAttention, null, 2),
+        );
+      } catch {
+        await recordShutdownSuppression(orchestrationIntent);
+        return false;
+      }
+
+      if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
+        await recordShutdownSuppression(orchestrationIntent);
+        return false;
+      }
+
       nudgeState.progress_by_team[teamName] = {
         signature: progressSnapshot.signature,
         last_progress_at: effectiveProgressAtIso,
@@ -847,46 +903,23 @@ export async function maybeNudgeTeamLeader({
         stalled_for_ms: null,
         source: source === 'notify_fallback_watcher' ? 'notify_hook' : source,
       };
-      await writeTeamLeaderAttention(teamName, {
-        team_name: teamName,
-        updated_at: nowIso,
-        source: 'notify_hook',
-        leader_decision_state: leaderActionState,
-        leader_attention_pending: !!nudgeReason,
-        leader_attention_reason: nudgeReason || null,
-        attention_reasons: nudgeReason ? [nudgeReason] : [],
-        leader_stale: leaderStale,
-        leader_session_active: true,
-        leader_session_id: currentSessionId || ownerSessionId || null,
-        leader_session_stopped_at: null,
-        unread_leader_message_count: unreadLeaderMessageCount,
-        work_remaining: progressSnapshot.workRemaining,
-        stalled_for_ms: null,
-      }, cwd).catch(() => {});
-    };
-    const markLastNudged = (orchestrationIntent) => {
-      nudgeState.last_nudged_by_team[teamName] = {
-        at: nowIso,
-        last_message_id: newestId || prevMsgId || '',
-        reason: nudgeReason,
-        orchestration_intent: orchestrationIntent,
-      };
-      if (shouldSendAllIdleNudge) {
-        nudgeState.last_idle_nudged_by_team[teamName] = {
+      if (recordLastNudged) {
+        nudgeState.last_nudged_by_team[teamName] = {
           at: nowIso,
-          worker_count: workerNames.length,
+          last_message_id: newestId || prevMsgId || '',
+          reason: nudgeReason,
           orchestration_intent: orchestrationIntent,
         };
+        if (shouldSendAllIdleNudge) {
+          nudgeState.last_idle_nudged_by_team[teamName] = {
+            at: nowIso,
+            worker_count: workerNames.length,
+            orchestration_intent: orchestrationIntent,
+          };
+        }
       }
-    };
-    const recordShutdownSuppression = async (orchestrationIntent = null) => {
-      await recordSuppressedLeaderNudge({
-        logsDir,
-        source,
-        teamName,
-        reason: TEAM_SHUTDOWN_NO_INJECTION_REASON,
-        orchestrationIntent,
-      });
+      await writeFile(nudgeStatePath, JSON.stringify(nudgeState, null, 2)).catch(() => {});
+      return true;
     };
 
     if (!nudgeReason) {
@@ -894,7 +927,7 @@ export async function maybeNudgeTeamLeader({
         await recordShutdownSuppression();
         continue;
       }
-      await writeProgressBookkeeping();
+      await persistLeaderNudgeBookkeeping();
       continue;
     }
     const orchestrationIntent = resolveLeaderNudgeIntent({ nudgeReason, leaderActionState });
@@ -910,8 +943,9 @@ export async function maybeNudgeTeamLeader({
         await recordShutdownSuppression(orchestrationIntent);
         continue;
       }
-      await writeProgressBookkeeping();
-      markLastNudged(orchestrationIntent);
+      if (!(await persistLeaderNudgeBookkeeping({ orchestrationIntent, recordLastNudged: true }))) {
+        continue;
+      }
       await emitLeaderNudgeDeferredEvent(cwd, teamName, LEADER_PANE_MISSING_NO_INJECTION_REASON, orchestrationIntent, nowIso, {
         tmuxSession,
         leaderPaneId,
@@ -961,8 +995,9 @@ export async function maybeNudgeTeamLeader({
         await recordShutdownSuppression(orchestrationIntent);
         continue;
       }
-      await writeProgressBookkeeping();
-      markLastNudged(orchestrationIntent);
+      if (!(await persistLeaderNudgeBookkeeping({ orchestrationIntent, recordLastNudged: true }))) {
+        continue;
+      }
       await emitLeaderNudgeDeferredEvent(cwd, teamName, deferredReason, orchestrationIntent, nowIso, {
         tmuxSession,
         leaderPaneId,
@@ -1006,8 +1041,9 @@ export async function maybeNudgeTeamLeader({
         await recordShutdownSuppression(orchestrationIntent);
         continue;
       }
-      await writeProgressBookkeeping();
-      markLastNudged(orchestrationIntent);
+      if (!(await persistLeaderNudgeBookkeeping({ orchestrationIntent, recordLastNudged: true }))) {
+        continue;
+      }
       await emitTeamNudgeEvent(cwd, teamName, nudgeReason, orchestrationIntent, nowIso);
 
       try {
@@ -1071,8 +1107,9 @@ export async function maybeNudgeTeamLeader({
         }
       }
       if (await teamStateAllowsLeaderNudge(stateDir, teamName)) {
-        await writeProgressBookkeeping();
-        markLastNudged(orchestrationIntent);
+        if (!(await persistLeaderNudgeBookkeeping({ orchestrationIntent, recordLastNudged: true }))) {
+          continue;
+        }
         await emitTeamNudgeEvent(cwd, teamName, nudgeReason, orchestrationIntent, nowIso);
       } else {
         await recordShutdownSuppression(orchestrationIntent);
@@ -1134,6 +1171,4 @@ export async function maybeNudgeTeamLeader({
       }).catch(() => {});
     }
   }
-
-  await writeFile(nudgeStatePath, JSON.stringify(nudgeState, null, 2)).catch(() => {});
 }


### PR DESCRIPTION
Fixes #2938.

## Summary
- Gate leader mailbox nudges on canonical team state still existing and not being terminal/shutdown.
- Re-check the team state at the pre-injection/deferred-event boundaries so teardown races become diagnostic suppressions instead of actionable leader prompts.
- Add a regression where the team directory is removed during leader nudge readiness checks; no tmux paste/send occurs and delivery is logged as `team_state_gone_or_shutdown`.

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/hooks/__tests__/notify-hook-team-leader-nudge.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- `npx biome lint src/scripts/notify-hook/team-leader-nudge.ts src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
