### PR TITLE
Fix Windows native hook PowerShell quoting

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -21,6 +21,7 @@ import {
 import {
 	checkExploreHarness,
 	checkExternalCodexProcessGuards,
+	buildPostCompactSmokeSpawnInvocation,
 	checkNativeHookDistSmoke,
 	classifyPostCompactHookStdout,
 } from "../doctor.js";
@@ -1833,6 +1834,28 @@ command = "node"
 		);
 		assert.equal(unsupportedJson?.status, "fail");
 		assert.match(unsupportedJson?.message ?? "", /must emit no stdout/);
+	});
+
+	it("routes Windows PostCompact smoke validation through PowerShell -Command", () => {
+		const expectedCommand =
+			"& 'C:\\Program Files\\PowerShell\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File 'C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1'";
+		const invocation = buildPostCompactSmokeSpawnInvocation(expectedCommand, {
+			platform: "win32",
+			env: { SystemRoot: "C:\\Windows" },
+		});
+
+		assert.equal(
+			invocation.command,
+			"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+		);
+		assert.deepEqual(invocation.args, [
+			"-NoProfile",
+			"-ExecutionPolicy",
+			"Bypass",
+			"-Command",
+			expectedCommand,
+		]);
+		assert.equal(invocation.shell, false);
 	});
 
 	it("verbose doctor smoke-validates the current PostCompact command with no stdout", async () => {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -37,6 +37,7 @@ import {
 	MANAGED_HOOK_EVENTS,
 	buildManagedCodexNativeHookCommand,
 	discoverCodexHookConfigPaths,
+	resolveWindowsPowerShellPath,
 	getManagedCodexHookCommandsForEvent,
 	getMissingManagedCodexHookEvents,
 	hasCodexHooksJsonTopLevelState,
@@ -1956,6 +1957,42 @@ export function classifyPostCompactHookStdout(stdout: string): Check | null {
 	}
 }
 
+
+interface PostCompactSmokeSpawnInvocation {
+	command: string;
+	args: string[];
+	shell: boolean;
+}
+
+export function buildPostCompactSmokeSpawnInvocation(
+	expectedCommand: string,
+	options: {
+		platform?: NodeJS.Platform;
+		env?: NodeJS.ProcessEnv;
+	} = {},
+): PostCompactSmokeSpawnInvocation {
+	const platform = options.platform ?? process.platform;
+	if (platform === "win32") {
+		return {
+			command: resolveWindowsPowerShellPath(options.env),
+			args: [
+				"-NoProfile",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-Command",
+				expectedCommand,
+			],
+			shell: false,
+		};
+	}
+
+	return {
+		command: expectedCommand,
+		args: [],
+		shell: true,
+	};
+}
+
 async function checkNativePostCompactHookRuntime(
 	hooksPath: string,
 	cwd: string,
@@ -1998,7 +2035,8 @@ async function checkNativePostCompactHookRuntime(
 			cwd: smokeCwd,
 			session_id: "omx-doctor-postcompact-smoke",
 		});
-		const result = spawnSync(expectedCommand, {
+		const smokeInvocation = buildPostCompactSmokeSpawnInvocation(expectedCommand);
+		const result = spawnSync(smokeInvocation.command, smokeInvocation.args, {
 			cwd,
 			encoding: "utf-8",
 			env: {
@@ -2006,7 +2044,7 @@ async function checkNativePostCompactHookRuntime(
 				OMX_NATIVE_HOOK_DOCTOR_SMOKE: "1",
 			},
 			input: payload,
-			shell: true,
+			shell: smokeInvocation.shell,
 			timeout: 5_000,
 		});
 

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -52,7 +52,7 @@ describe("codex hooks helpers", () => {
     );
   });
 
-  it("uses a cmd.exe-compatible Windows shim command without quoting the executable", () => {
+  it("uses a PowerShell -Command-safe Windows shim command with single-quoted literals", () => {
     const config = buildManagedCodexHooksConfig(
       "D:\\Program Files\\nvm\\v24.12.0\\node_modules\\oh-my-codex",
       {
@@ -67,10 +67,11 @@ describe("codex hooks helpers", () => {
 
     assert.equal(
       command,
-      'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1"',
+      "& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File 'C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1'",
     );
     assert.doesNotMatch(command ?? "", /codex-native-hook\.js/);
     assert.doesNotMatch(command ?? "", /^"[A-Z]:\\/i);
+    assert.doesNotMatch(command ?? "", /\\"/);
   });
 
   it("emits Windows hooks.json entries with only the cmd-compatible command field", () => {
@@ -94,7 +95,7 @@ describe("codex hooks helpers", () => {
     assert.equal(commandHook?.command_windows, undefined);
     assert.equal(
       commandHook?.command,
-      'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1"',
+      "& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File 'C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1'",
     );
   });
 
@@ -110,7 +111,7 @@ describe("codex hooks helpers", () => {
 
     assert.equal(
       command,
-      'E:\\WINNT\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1"',
+      "& 'E:\\WINNT\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File 'C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1'",
     );
   });
 
@@ -150,7 +151,7 @@ describe("codex hooks helpers", () => {
 
     assert.ok(commands.includes("echo keep-me"));
     assert.ok(commands.includes(
-      'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1"',
+      "& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File 'C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1'",
     ));
   });
 

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -92,10 +92,6 @@ export function escapeTomlBasicString(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
-function quoteWindowsShellArgument(value: string): string {
-  return `"${value.replace(/"/g, '\\"')}"`;
-}
-
 function quotePowerShellLiteral(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
 }
@@ -224,7 +220,7 @@ export function buildManagedCodexNativeHookCommand(
     const codexHomeDir = options.codexHomeDir ?? dirname(pkgRoot);
     const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
     const powerShellPath = resolveWindowsPowerShellPath(options.env);
-    return `${powerShellPath} -NoProfile -ExecutionPolicy Bypass -File ${quoteWindowsShellArgument(shimPath)}`;
+    return `& ${quotePowerShellLiteral(powerShellPath)} -NoProfile -ExecutionPolicy Bypass -File ${quotePowerShellLiteral(shimPath)}`;
   }
 
   return `${quoteCommandPart(process.execPath)} ${quoteCommandPart(hookScript)}`;


### PR DESCRIPTION
## Summary
- generate Windows native hook commands with the PowerShell call operator plus single-quoted literals
- avoid double-quote sequences that Codex CLI/Rust Command::arg() turns into PowerShell-hostile backslash-quote text under PowerShell -Command
- update native hook regression coverage for regenerated hooks.json command shape

Fixes #2940.

## Verification
- npm run build
- node dist/scripts/run-test-files.js dist/config/__tests__/codex-hooks.test.js dist/cli/__tests__/doctor-warning-copy.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js