### PR TITLE
feat(vscode): stream chat session output

### DIFF
--- a/packages/vscode-extension/src/__tests__/sessionTranscript.test.ts
+++ b/packages/vscode-extension/src/__tests__/sessionTranscript.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { formatSessionMessage, trimTranscript } from '../sessionTranscript';
+
+describe('session transcript formatting', () => {
+  it('keeps session metadata before streamed output', () => {
+    assert.equal(formatSessionMessage('Running', {
+      session_id: 'vscode-1',
+      log_path: '/repo/.omx/logs/vscode/vscode-1.log',
+    }, 'hello\n'), [
+      'Status: Running',
+      'Session: vscode-1',
+      'Log: /repo/.omx/logs/vscode/vscode-1.log',
+      '',
+      'hello',
+    ].join('\n'));
+  });
+
+  it('bounds long transcripts from the front', () => {
+    assert.equal(trimTranscript('abcdef', 4), '... trimmed 2 chars ...\ncdef');
+  });
+});

--- a/packages/vscode-extension/src/chatView.ts
+++ b/packages/vscode-extension/src/chatView.ts
@@ -6,11 +6,14 @@ import {
   createConversation,
   listConversations,
   readConversation,
+  updateMessage,
   type ChatConversation,
   type ChatConversationSummary,
 } from './chatStore';
 import { normalizeWebviewMessage } from './chatProtocol';
+import { formatSessionMessage, trimTranscript } from './sessionTranscript';
 import { getWorkspaceRoot, OmxSessionManager } from './sessionManager';
+import type { DirectSessionHandle } from './types';
 import { listVscodeLogs, realPathInsideWorkspace, type VscodeLogSummary } from './workspaceStatus';
 
 interface ChatViewState {
@@ -125,22 +128,73 @@ export class OmxChatPanel {
     const cwd = getWorkspaceRoot();
     const conversation = await this.ensureConversation(text);
     await appendMessage(cwd, conversation.id, { role: 'user', text });
-    await this.refresh();
 
-    try {
-      const handle = await this.sessionManager.start('launch', text);
+    if (this.sessionManager.active) {
       await appendMessage(cwd, conversation.id, {
         role: 'system',
-        text: handle
-          ? `Started OMX session ${handle.session_id}.\nLog: ${handle.log_path}`
-          : 'OMX launch was cancelled.',
+        text: 'An OMX session is already running. Stop it before sending another prompt.',
+      });
+      await this.refresh();
+      return;
+    }
+
+    const pending = await appendMessage(cwd, conversation.id, {
+      role: 'assistant',
+      text: 'Starting OMX session...',
+    });
+    const responseId = pending.messages[pending.messages.length - 1]?.id;
+    let transcript = '';
+    let handle: DirectSessionHandle | null = null;
+    let terminalStatus: string | null = null;
+    let updateQueue: Promise<void> = Promise.resolve();
+    const updateResponse = async (status: string): Promise<void> => {
+      if (!responseId) return;
+      await updateMessage(cwd, conversation.id, responseId, {
+        text: formatSessionMessage(status, handle, transcript),
         session_id: handle?.session_id,
         log_path: handle?.log_path,
       });
+      await this.refresh();
+    };
+    const scheduleResponseUpdate = (status: string): void => {
+      updateQueue = updateQueue
+        .catch(() => undefined)
+        .then(() => updateResponse(status));
+      void updateQueue.catch((error) => {
+        this.output.appendLine(`[omx] chat update failed: ${error instanceof Error ? error.message : String(error)}`);
+      });
+    };
+    await this.refresh();
+
+    try {
+      handle = await this.sessionManager.start('launch', text, {
+        onOutput: (_stream, chunk) => {
+          transcript = trimTranscript(`${transcript}${chunk}`);
+          scheduleResponseUpdate('Running');
+        },
+        onExit: (code, signal) => {
+          terminalStatus = `Exited code=${code ?? 'null'} signal=${signal ?? 'null'}`;
+          scheduleResponseUpdate(terminalStatus);
+        },
+        onError: (error) => {
+          terminalStatus = `Launch error: ${error.message}`;
+          scheduleResponseUpdate(terminalStatus);
+        },
+      });
+      if (handle) {
+        if (!terminalStatus) scheduleResponseUpdate('Running');
+        await updateQueue;
+      } else if (responseId) {
+        await updateMessage(cwd, conversation.id, responseId, { text: 'Launch cancelled.' });
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.output.appendLine(`[omx] chat launch failed: ${message}`);
-      await appendMessage(cwd, conversation.id, { role: 'assistant', text: `Launch failed:\n${message}` });
+      if (responseId) {
+        await updateMessage(cwd, conversation.id, responseId, { text: `Launch failed:\n${message}` });
+      } else {
+        await appendMessage(cwd, conversation.id, { role: 'assistant', text: `Launch failed:\n${message}` });
+      }
     }
     await this.refresh();
   }

--- a/packages/vscode-extension/src/sessionManager.ts
+++ b/packages/vscode-extension/src/sessionManager.ts
@@ -5,6 +5,12 @@ import type { DirectSessionHandle } from './types';
 
 type DirectMode = 'launch' | 'resume';
 
+export interface SessionCallbacks {
+  onOutput?: (stream: 'stdout' | 'stderr', text: string) => void;
+  onExit?: (code: number | null, signal: NodeJS.Signals | null) => void;
+  onError?: (error: Error) => void;
+}
+
 export class OmxSessionManager {
   private activeSession: DirectSessionHandle | null = null;
 
@@ -28,7 +34,11 @@ export class OmxSessionManager {
     await this.start(mode, normalizePrompt(prompt));
   }
 
-  async start(mode: DirectMode, prompt?: string): Promise<DirectSessionHandle | null> {
+  async start(
+    mode: DirectMode,
+    prompt?: string,
+    callbacks: SessionCallbacks = {},
+  ): Promise<DirectSessionHandle | null> {
     const cwd = getWorkspaceRoot();
     const core = await loadOmxCore(this.context);
     const config = vscode.workspace.getConfiguration('omx');
@@ -58,7 +68,7 @@ export class OmxSessionManager {
       dangerousApproved,
       env: launchEnv.env,
     });
-    this.bindSession(handle, mode);
+    this.bindSession(handle, mode, callbacks);
     return handle;
   }
 
@@ -83,25 +93,36 @@ export class OmxSessionManager {
     if (result.stderr) this.output.append(result.stderr);
   }
 
-  private bindSession(handle: DirectSessionHandle, mode: DirectMode): void {
+  private bindSession(handle: DirectSessionHandle, mode: DirectMode, callbacks: SessionCallbacks): void {
     this.activeSession = handle;
     this.output.show(true);
     this.output.appendLine(`[omx] started ${mode} session ${handle.session_id}`);
     this.output.appendLine(`[omx] log: ${handle.log_path}`);
 
-    handle.child.stdout?.on('data', (chunk) => this.output.append(String(chunk)));
-    handle.child.stderr?.on('data', (chunk) => this.output.append(String(chunk)));
+    handle.child.stdout?.on('data', (chunk: Buffer | string) => {
+      const text = String(chunk);
+      this.output.append(text);
+      callbacks.onOutput?.('stdout', text);
+    });
+    handle.child.stderr?.on('data', (chunk: Buffer | string) => {
+      const text = String(chunk);
+      this.output.append(text);
+      callbacks.onOutput?.('stderr', text);
+    });
     handle.child.on('exit', (code, signal) => {
       this.output.appendLine(
         `\n[omx] session ${handle.session_id} exited code=${code ?? 'null'} signal=${signal ?? 'null'}`,
       );
+      callbacks.onExit?.(code, signal);
       if (this.activeSession?.session_id === handle.session_id) {
         this.activeSession = null;
         this.onDidChange();
       }
     });
     handle.child.on('error', (error) => {
-      this.output.appendLine(`[omx] launch error: ${error instanceof Error ? error.message : String(error)}`);
+      const normalized = error instanceof Error ? error : new Error(String(error));
+      this.output.appendLine(`[omx] launch error: ${normalized.message}`);
+      callbacks.onError?.(normalized);
       if (this.activeSession?.session_id === handle.session_id) {
         this.activeSession = null;
         this.onDidChange();

--- a/packages/vscode-extension/src/sessionTranscript.ts
+++ b/packages/vscode-extension/src/sessionTranscript.ts
@@ -1,0 +1,24 @@
+import type { DirectSessionHandle } from './types';
+
+const MAX_TRANSCRIPT_CHARS = 12_000;
+
+export function trimTranscript(value: string, maxChars = MAX_TRANSCRIPT_CHARS): string {
+  if (value.length <= maxChars) return value;
+  return `... trimmed ${value.length - maxChars} chars ...\n${value.slice(-maxChars)}`;
+}
+
+export function formatSessionMessage(
+  status: string,
+  handle: Pick<DirectSessionHandle, 'session_id' | 'log_path'> | null,
+  transcript: string,
+): string {
+  const lines = [`Status: ${status}`];
+  if (handle) {
+    lines.push(`Session: ${handle.session_id}`);
+    lines.push(`Log: ${handle.log_path}`);
+  }
+  if (transcript.trim()) {
+    lines.push('', transcript.trimEnd());
+  }
+  return lines.join('\n');
+}


### PR DESCRIPTION
Summary:
- Stream direct session stdout/stderr into the chat assistant response.
- Update the response on exit/error and keep session/log metadata attached.
- Add bounded transcript formatting coverage.

Validation:
- npm test (packages/vscode-extension)

Size:
- 4 files changed, 134 insertions, 13 deletions (147 total), expected size/M.