### PR TITLE
Fix setup plugin config dedupe

### DIFF
--- a/src/cli/__tests__/plugin-marketplace-idempotent.test.ts
+++ b/src/cli/__tests__/plugin-marketplace-idempotent.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import TOML from "@iarna/toml";
+import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../../config/omx-first-party-mcp.js";
+import {
+	OMX_LOCAL_MARKETPLACE_NAME,
+	OMX_LOCAL_PLUGIN_CONFIG_KEY,
+	upsertLocalOmxMarketplaceRegistration,
+	upsertLocalOmxPluginEnablement,
+	upsertLocalOmxPluginMcpServerEnablement,
+} from "../plugin-marketplace.js";
+
+function countMatches(content: string, pattern: RegExp): number {
+	return [...content.matchAll(pattern)].length;
+}
+
+function applyPluginModeConfig(content: string, packageRoot: string): string {
+	return upsertLocalOmxMarketplaceRegistration(
+		upsertLocalOmxPluginMcpServerEnablement(
+			upsertLocalOmxPluginEnablement(content),
+			true,
+		),
+		packageRoot,
+	);
+}
+
+describe("plugin marketplace config upserts", () => {
+	it("keeps repeated plugin-mode setup config updates idempotent", () => {
+		const packageRoot = "/tmp/oh-my-codex";
+		const first = applyPluginModeConfig('model = "gpt-5.5"\n', packageRoot);
+		const second = applyPluginModeConfig(first, packageRoot);
+
+		assert.equal(second, first);
+		assert.equal(
+			countMatches(second, /^\[marketplaces\.oh-my-codex-local\]$/gm),
+			1,
+		);
+		assert.equal(
+			countMatches(
+				second,
+				/^\[plugins\."oh-my-codex@oh-my-codex-local"\]$/gm,
+			),
+			1,
+		);
+		for (const serverName of OMX_FIRST_PARTY_MCP_SERVER_NAMES) {
+			assert.equal(
+				countMatches(
+					second,
+					new RegExp(
+						`^\\[plugins\\.${JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\.mcp_servers\\.${serverName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\]$`,
+						"gm",
+					),
+				),
+				1,
+				`${serverName} should be emitted once`,
+			);
+		}
+		assert.doesNotThrow(() => TOML.parse(second));
+	});
+
+	it("dedupes existing local marketplace and plugin MCP blocks without removing unrelated config", () => {
+		const packageRoot = "/tmp/oh-my-codex-new";
+		const duplicated = [
+			'model = "gpt-5.5"',
+			'',
+			'[mcp_servers.user_tool]',
+			'command = "user-tool"',
+			'',
+			`[plugins.${JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY)}]`,
+			'enabled = false',
+			'',
+			`[plugins.${JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY)}]`,
+			'enabled = false',
+			'',
+			`[plugins.${JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY)}.mcp_servers.omx_state]`,
+			'enabled = false',
+			'',
+			`[plugins.${JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY)}.mcp_servers.omx_state]`,
+			'enabled = false',
+			'',
+			`[marketplaces.${OMX_LOCAL_MARKETPLACE_NAME}]`,
+			'source_type = "local"',
+			'source = "/tmp/old"',
+			'',
+			`[marketplaces.${OMX_LOCAL_MARKETPLACE_NAME}]`,
+			'source_type = "local"',
+			'source = "/tmp/older"',
+			'',
+		].join("\n");
+
+		assert.throws(() => TOML.parse(duplicated), /redefine|duplicate/i);
+
+		const repaired = applyPluginModeConfig(duplicated, packageRoot);
+
+		assert.doesNotThrow(() => TOML.parse(repaired));
+		assert.match(repaired, /^\[mcp_servers\.user_tool\]$/m);
+		assert.match(repaired, /^command = "user-tool"$/m);
+		assert.equal(
+			countMatches(repaired, /^\[marketplaces\.oh-my-codex-local\]$/gm),
+			1,
+		);
+		assert.match(repaired, new RegExp(`^source = ${JSON.stringify(packageRoot)}$`, "m"));
+		assert.equal(
+			countMatches(
+				repaired,
+				/^\[plugins\."oh-my-codex@oh-my-codex-local"\.mcp_servers\.omx_state\]$/gm,
+			),
+			1,
+		);
+	});
+});

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -424,25 +424,28 @@ function isTomlTableHeader(line: string): boolean {
 	return /^\s*\[/.test(line);
 }
 
-export function stripLocalOmxMarketplaceRegistration(config: string): string {
+function stripTomlTablesByHeaderPattern(config: string, headerPattern: RegExp): string {
 	const lines = config.split(/\r?\n/);
-	const headerPattern = marketplaceTableHeaderPattern();
-	const start = lines.findIndex((line) => headerPattern.test(line));
-	if (start < 0) return config;
+	const result: string[] = [];
 
-	let end = lines.length;
-	for (let index = start + 1; index < lines.length; index += 1) {
-		if (isTomlTableHeader(lines[index])) {
-			end = index;
-			break;
+	for (let index = 0; index < lines.length; ) {
+		if (headerPattern.test(lines[index])) {
+			index += 1;
+			while (index < lines.length && !isTomlTableHeader(lines[index])) {
+				index += 1;
+			}
+			continue;
 		}
+
+		result.push(lines[index]);
+		index += 1;
 	}
 
-	const nextLines = [...lines.slice(0, start), ...lines.slice(end)];
-	return nextLines
-		.join("\n")
-		.replace(/\n{3,}/g, "\n\n")
-		.trimEnd();
+	return result.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd();
+}
+
+export function stripLocalOmxMarketplaceRegistration(config: string): string {
+	return stripTomlTablesByHeaderPattern(config, marketplaceTableHeaderPattern());
 }
 
 export function buildLocalOmxMarketplaceRegistration(
@@ -484,22 +487,14 @@ export function hasLocalOmxPluginMcpServerRegistrations(config: string): boolean
 }
 
 export function stripLocalOmxPluginMcpServerRegistrations(config: string): string {
-	let lines = config.split(/\r?\n/);
+	let next = config;
 	for (const serverName of OMX_FIRST_PARTY_MCP_SERVER_NAMES) {
-		const headerPattern = localPluginMcpServerTableHeaderPattern(serverName);
-		const start = lines.findIndex((line) => headerPattern.test(line));
-		if (start < 0) continue;
-
-		let end = lines.length;
-		for (let index = start + 1; index < lines.length; index += 1) {
-			if (isTomlTableHeader(lines[index])) {
-				end = index;
-				break;
-			}
-		}
-		lines = [...lines.slice(0, start), ...lines.slice(end)];
+		next = stripTomlTablesByHeaderPattern(
+			next,
+			localPluginMcpServerTableHeaderPattern(serverName),
+		);
 	}
-	return lines.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd();
+	return next;
 }
 
 function upsertTomlTableBooleanKey(
@@ -549,42 +544,11 @@ function upsertTomlTableBooleanKey(
 }
 
 export function upsertLocalOmxPluginEnablement(config: string): string {
-	const lines = config.split(/\r?\n/);
-	const headerPattern = localPluginTableHeaderPattern();
-	const start = lines.findIndex((line) => headerPattern.test(line));
-
-	if (start < 0) {
-		const base = config.trimEnd();
-		return `${base ? `${base}\n\n` : ""}[plugins.${JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY)}]\nenabled = true\n`;
-	}
-
-	let end = lines.length;
-	for (let index = start + 1; index < lines.length; index += 1) {
-		if (isTomlTableHeader(lines[index])) {
-			end = index;
-			break;
-		}
-	}
-
-	let enabledIndex = -1;
-	for (let index = start + 1; index < end; index += 1) {
-		if (/^\s*enabled\s*=/.test(lines[index])) {
-			if (enabledIndex < 0) {
-				enabledIndex = index;
-				lines[index] = "enabled = true";
-			} else {
-				lines.splice(index, 1);
-				index -= 1;
-				end -= 1;
-			}
-		}
-	}
-
-	if (enabledIndex < 0) {
-		lines.splice(start + 1, 0, "enabled = true");
-	}
-
-	return lines.join("\n").replace(/\n*$/, "\n");
+	const stripped = stripTomlTablesByHeaderPattern(
+		config,
+		localPluginTableHeaderPattern(),
+	).trimEnd();
+	return `${stripped ? `${stripped}\n\n` : ""}[plugins.${JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY)}]\nenabled = true\n`;
 }
 
 export function upsertLocalOmxPluginMcpServerEnablement(
@@ -599,7 +563,7 @@ export function upsertLocalOmxPluginMcpServerEnablement(
 	if (!enabled) {
 		return config;
 	}
-	let next = config;
+	let next = stripLocalOmxPluginMcpServerRegistrations(config);
 	for (const serverName of OMX_FIRST_PARTY_MCP_SERVER_NAMES) {
 		const header = `[plugins.${JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY)}.mcp_servers.${serverName}]`;
 		const headerPattern = localPluginMcpServerTableHeaderPattern(serverName);


### PR DESCRIPTION
## Summary
- make local plugin marketplace and first-party plugin MCP config upserts remove all prior managed duplicate tables before writing the canonical block
- keep unrelated user config intact while repairing duplicate plugin-mode blocks
- add regression coverage for repeated plugin-mode config writes and preexisting duplicate TOML tables

Fixes #2947.

## Tests
- npm run build
- node dist/scripts/run-test-files.js dist/cli/__tests__/plugin-marketplace-idempotent.test.js
- node dist/scripts/run-test-files.js dist/cli/__tests__/codex-plugin-layout.test.js
- node dist/scripts/run-test-files.js dist/cli/__tests__/setup-install-mode.test.js
- npm run lint
- npm run check:no-unused

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*