### PR TITLE
fix(mcp): stop duplicate watchdog after stdio traffic

### DIFF
--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -17,6 +17,7 @@ import {
   shouldSelfExitForDuplicateSibling,
   shouldSelfExitForPreTrafficSiblingHardCap,
   shouldSelfExitForPostTrafficSiblingHardCap,
+  shouldPersistDuplicateSiblingWatchdogAfterTraffic,
   type McpServerName,
 } from '../bootstrap.js';
 import {
@@ -103,16 +104,21 @@ describe('mcp parent watchdog liveness checks', () => {
 });
 
 describe('mcp shared stdio lifecycle contract', () => {
-  it('keeps server connection immediate and duplicate process-table scans delayed', async () => {
+  it('keeps server connection immediate and duplicate process-table scans startup-scoped', async () => {
     const src = await readFile(join(process.cwd(), 'src/mcp/bootstrap.ts'), 'utf8');
     const connectIndex = src.indexOf('server.connect(transport)');
     const duplicateDelayIndex = src.indexOf('duplicateSiblingInitialDelayTimer = setTimeout');
+    const trafficCleanupIndex = src.indexOf('clearInterval(duplicateSiblingWatchdog)');
 
     assert.ok(connectIndex > 0, 'bootstrap should still connect the MCP transport');
     assert.ok(duplicateDelayIndex > 0, 'bootstrap should delay duplicate-sibling process scans');
     assert.ok(
       connectIndex > duplicateDelayIndex,
       'duplicate-sibling scan delay must not wrap or delay server.connect',
+    );
+    assert.ok(
+      trafficCleanupIndex > duplicateDelayIndex,
+      'duplicate-sibling watchdog should be canceled after first stdio traffic by default',
     );
     assert.match(
       src,
@@ -160,6 +166,22 @@ describe('mcp shared stdio lifecycle contract', () => {
 });
 
 describe('mcp duplicate sibling detection', () => {
+  it('does not persist the duplicate sibling watchdog after stdio traffic unless explicitly requested', () => {
+    assert.equal(shouldPersistDuplicateSiblingWatchdogAfterTraffic({}), false);
+    assert.equal(
+      shouldPersistDuplicateSiblingWatchdogAfterTraffic({
+        OMX_MCP_DUPLICATE_SIBLING_WATCHDOG_PERSIST_AFTER_TRAFFIC: '1',
+      }),
+      true,
+    );
+    assert.equal(
+      shouldPersistDuplicateSiblingWatchdogAfterTraffic({
+        OMX_MCP_DUPLICATE_SIBLING_WATCHDOG_PERSIST_AFTER_TRAFFIC: 'true',
+      }),
+      true,
+    );
+  });
+
   it('resolves deterministic bounded initial duplicate scan delays', () => {
     const stateDelay = resolveDuplicateSiblingWatchdogInitialDelayMs(
       'state',

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -22,6 +22,7 @@ const DUPLICATE_SIBLING_PRE_TRAFFIC_GRACE_ENV = 'OMX_MCP_DUPLICATE_SIBLING_PRE_T
 const DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_ENV = 'OMX_MCP_DUPLICATE_SIBLING_POST_TRAFFIC_IDLE_MS';
 const DUPLICATE_SIBLING_INITIAL_DELAY_ENV = 'OMX_MCP_DUPLICATE_SIBLING_INITIAL_DELAY_MS';
 const DUPLICATE_SIBLING_INITIAL_DELAY_MAX_ENV = 'OMX_MCP_DUPLICATE_SIBLING_INITIAL_DELAY_MAX_MS';
+const DUPLICATE_SIBLING_WATCHDOG_PERSIST_AFTER_TRAFFIC_ENV = 'OMX_MCP_DUPLICATE_SIBLING_WATCHDOG_PERSIST_AFTER_TRAFFIC';
 const MAX_SIBLINGS_PER_ENTRYPOINT_ENV = 'OMX_MCP_MAX_SIBLINGS_PER_ENTRYPOINT';
 export const MCP_ENTRYPOINT_MARKER_ENV = 'OMX_MCP_ENTRYPOINT_MARKER';
 const DEFAULT_PARENT_WATCHDOG_INTERVAL_MS = 1_000;
@@ -59,6 +60,7 @@ interface LifecycleTimingConfig {
   duplicateSiblingInitialDelayMs: number | null;
   duplicateSiblingInitialDelayMaxMs: number;
   maxSiblingsPerEntrypoint: number;
+  duplicateSiblingWatchdogPersistsAfterTraffic: boolean;
 }
 
 const SERVER_ENTRYPOINT: Record<McpServerName, string> = {
@@ -311,6 +313,26 @@ function readPositiveIntegerEnv(
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function readBooleanEnv(
+  env: Record<string, string | undefined>,
+  name: string,
+  fallback: boolean,
+): boolean {
+  const raw = env[name];
+  if (typeof raw !== 'string' || raw.trim() === '') return fallback;
+  return raw === '1' || raw.toLowerCase() === 'true';
+}
+
+export function shouldPersistDuplicateSiblingWatchdogAfterTraffic(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return readBooleanEnv(
+    env,
+    DUPLICATE_SIBLING_WATCHDOG_PERSIST_AFTER_TRAFFIC_ENV,
+    false,
+  );
+}
+
 function resolveLifecycleTimingConfig(
   env: Record<string, string | undefined>,
 ): LifecycleTimingConfig {
@@ -350,6 +372,7 @@ function resolveLifecycleTimingConfig(
       MAX_SIBLINGS_PER_ENTRYPOINT_ENV,
       DEFAULT_MAX_SIBLINGS_PER_ENTRYPOINT,
     ) ?? DEFAULT_MAX_SIBLINGS_PER_ENTRYPOINT,
+    duplicateSiblingWatchdogPersistsAfterTraffic: shouldPersistDuplicateSiblingWatchdogAfterTraffic(env),
   };
 }
 
@@ -689,6 +712,17 @@ export function autoStartStdioMcpServer(
   };
   const handleStdinData = () => {
     lastTrafficAtMs = Date.now();
+    if (!lifecycleTiming.duplicateSiblingWatchdogPersistsAfterTraffic) {
+      if (duplicateSiblingInitialDelayTimer) {
+        clearTimeout(duplicateSiblingInitialDelayTimer);
+        duplicateSiblingInitialDelayTimer = null;
+      }
+      if (duplicateSiblingWatchdog) {
+        clearInterval(duplicateSiblingWatchdog);
+        duplicateSiblingWatchdog = null;
+      }
+      duplicateObservedAtMs = null;
+    }
   };
   const handleSigterm = () => {
     void shutdown('sigterm');


### PR DESCRIPTION
Fixes #2946.

## Summary
- scope duplicate sibling watchdog polling to startup unless explicitly enabled
- stop repeated Windows process-table scans after stdio traffic is observed
- add/update MCP bootstrap regression coverage for the startup-scoped behavior

## Verification
- `npm run build`
- `node --test dist/mcp/__tests__/bootstrap.test.js`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*