### PR TITLE
Fix Windows MCP duplicate sibling watchdog polling

### DIFF
--- a/src/mcp/__tests__/bootstrap.test.ts
+++ b/src/mcp/__tests__/bootstrap.test.ts
@@ -14,6 +14,8 @@ import {
   resolveCurrentMcpEntrypointMarker,
   resolveDuplicateSiblingWatchdogInitialDelayMs,
   shouldAutoStartMcpServer,
+  shouldStopDuplicateSiblingWatchdogAfterTraffic,
+  shouldRunDuplicateSiblingStartupScanBeforeStopping,
   shouldSelfExitForDuplicateSibling,
   shouldSelfExitForPreTrafficSiblingHardCap,
   shouldSelfExitForPostTrafficSiblingHardCap,
@@ -226,6 +228,18 @@ describe('mcp duplicate sibling detection', () => {
     );
   });
 
+  it('stops duplicate sibling watchdog after stdio traffic only on Windows', () => {
+    assert.equal(shouldStopDuplicateSiblingWatchdogAfterTraffic('win32'), true);
+    assert.equal(shouldStopDuplicateSiblingWatchdogAfterTraffic('linux'), false);
+    assert.equal(shouldStopDuplicateSiblingWatchdogAfterTraffic('darwin'), false);
+  });
+
+  it('runs one pending startup scan before stopping Windows duplicate watchdog', () => {
+    assert.equal(shouldRunDuplicateSiblingStartupScanBeforeStopping(true, 'win32'), true);
+    assert.equal(shouldRunDuplicateSiblingStartupScanBeforeStopping(false, 'win32'), false);
+    assert.equal(shouldRunDuplicateSiblingStartupScanBeforeStopping(true, 'linux'), false);
+  });
+
   it('falls back to argv[1] when no explicit MCP entrypoint marker is set', () => {
     assert.equal(
       resolveCurrentMcpEntrypointMarker({}, '/repo/dist/mcp/state-server.js'),
@@ -319,6 +333,22 @@ describe('mcp duplicate sibling detection', () => {
       throw new Error('powershell unavailable');
     }) as typeof import('node:child_process').execFileSync;
     assert.equal(listProcessTable(failingRead, 'win32'), null);
+  });
+
+  it('keeps Windows path semantics when matching duplicate sibling commands', () => {
+    const processes = [
+      { pid: 101, ppid: 55, command: 'node C:\\Users\\me\\AppData\\Local\\oh-my-codex\\dist\\mcp\\state-server.cjs' },
+      { pid: 140, ppid: 55, command: 'node C:/Users/me/AppData/Local/oh-my-codex/dist/mcp/state-server.cjs' },
+      { pid: 150, ppid: 55, command: 'node C:\\Users\\me\\AppData\\Local\\oh-my-codex\\dist\\mcp\\memory-server.cjs' },
+    ];
+
+    const older = analyzeDuplicateSiblingState(processes, 101, 55, 'state-server.cjs');
+    const newest = analyzeDuplicateSiblingState(processes, 140, 55, 'state-server.cjs');
+
+    assert.equal(older.status, 'older_duplicate');
+    assert.deepEqual(older.matchingPids, [101, 140]);
+    assert.deepEqual(older.newerSiblingPids, [140]);
+    assert.equal(newest.status, 'newest');
   });
 
   it('detects duplicate Windows siblings through the process-table watchdog path', () => {

--- a/src/mcp/bootstrap.ts
+++ b/src/mcp/bootstrap.ts
@@ -470,6 +470,19 @@ export function isParentProcessAlive(
   }
 }
 
+export function shouldStopDuplicateSiblingWatchdogAfterTraffic(
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform === 'win32';
+}
+
+export function shouldRunDuplicateSiblingStartupScanBeforeStopping(
+  hasPendingInitialDelay: boolean,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform === 'win32' && hasPendingInitialDelay;
+}
+
 export function shouldAutoStartMcpServer(
   server: McpServerName,
   env: Record<string, string | undefined> = process.env,
@@ -549,6 +562,26 @@ export function autoStartStdioMcpServer(
   parentWatchdog?.unref();
   let duplicateSiblingWatchdog: ReturnType<typeof setInterval> | null = null;
   let duplicateSiblingInitialDelayTimer: ReturnType<typeof setTimeout> | null = null;
+  const stopDuplicateSiblingWatchdog = (reason: string, options: { runPendingInitialScan?: boolean } = {}) => {
+    let stopped = false;
+    if (duplicateSiblingInitialDelayTimer) {
+      clearTimeout(duplicateSiblingInitialDelayTimer);
+      duplicateSiblingInitialDelayTimer = null;
+      if (options.runPendingInitialScan) {
+        runDuplicateSiblingWatchdog();
+      }
+      stopped = true;
+    }
+    if (duplicateSiblingWatchdog) {
+      clearInterval(duplicateSiblingWatchdog);
+      duplicateSiblingWatchdog = null;
+      stopped = true;
+    }
+    if (stopped) {
+      emitLifecycle('duplicate_sibling_watchdog_stopped', { reason });
+    }
+  };
+
 
   const runDuplicateSiblingWatchdog = () => {
     try {
@@ -659,12 +692,7 @@ export function autoStartStdioMcpServer(
     if (parentWatchdog) {
       clearInterval(parentWatchdog);
     }
-    if (duplicateSiblingInitialDelayTimer) {
-      clearTimeout(duplicateSiblingInitialDelayTimer);
-    }
-    if (duplicateSiblingWatchdog) {
-      clearInterval(duplicateSiblingWatchdog);
-    }
+    stopDuplicateSiblingWatchdog('shutdown');
     process.stdin.off('data', handleStdinData);
     process.stdin.off('end', handleStdinEnd);
     process.stdin.off('close', handleStdinClose);
@@ -689,6 +717,12 @@ export function autoStartStdioMcpServer(
   };
   const handleStdinData = () => {
     lastTrafficAtMs = Date.now();
+    const hasPendingInitialDelay = duplicateSiblingInitialDelayTimer !== null;
+    if (shouldStopDuplicateSiblingWatchdogAfterTraffic()) {
+      stopDuplicateSiblingWatchdog('windows_stdio_traffic', {
+        runPendingInitialScan: shouldRunDuplicateSiblingStartupScanBeforeStopping(hasPendingInitialDelay),
+      });
+    }
   };
   const handleSigterm = () => {
     void shutdown('sigterm');


### PR DESCRIPTION
## Summary
- stop the duplicate sibling watchdog on Windows after MCP stdio traffic so initialized servers do not keep polling Win32_Process periodically
- run one pending startup duplicate scan before stopping when initialization traffic arrives before the delayed scan
- add focused tests for Windows-only stop behavior, pending startup scan policy, and Windows path sibling matching

## Tests
- `npm run build`
- `node dist/scripts/run-test-files.js dist/mcp/__tests__/bootstrap.test.js`
- `node dist/scripts/run-test-files.js dist/mcp/__tests__/server-lifecycle.test.js`
- `npm run lint`
- `npm run check:no-unused`

Fixes #2946

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*