### PR TITLE
feat(vscode): add chat activity view

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -13,6 +13,14 @@
     "Other"
   ],
   "main": "./dist/extension.js",
+  "activationEvents": [
+    "onView:omx.chat",
+    "onCommand:omx.openChat",
+    "onCommand:omx.start",
+    "onCommand:omx.resume",
+    "onCommand:omx.stop",
+    "onCommand:omx.doctor"
+  ],
   "contributes": {
     "commands": [
       {
@@ -41,6 +49,43 @@
         "category": "OMX"
       }
     ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "omx",
+          "title": "OMX",
+          "icon": "resources/omx.svg"
+        }
+      ]
+    },
+    "views": {
+      "omx": [
+        {
+          "id": "omx.chat",
+          "name": "Chat",
+          "type": "webview"
+        }
+      ]
+    },
+    "menus": {
+      "view/title": [
+        {
+          "command": "omx.start",
+          "when": "view == omx.chat",
+          "group": "navigation@1"
+        },
+        {
+          "command": "omx.stop",
+          "when": "view == omx.chat",
+          "group": "navigation@2"
+        },
+        {
+          "command": "omx.doctor",
+          "when": "view == omx.chat",
+          "group": "navigation@3"
+        }
+      ]
+    },
     "configuration": {
       "title": "Oh My Codex",
       "properties": {
@@ -74,6 +119,12 @@
           "type": "boolean",
           "default": true,
           "description": "Require confirmation before launching sessions with madmax/yolo/bypass approval flags."
+        },
+        "omx.refreshIntervalMs": {
+          "type": "number",
+          "default": 1500,
+          "minimum": 500,
+          "description": "Minimum refresh interval for session and log state in milliseconds."
         }
       }
     }

--- a/packages/vscode-extension/resources/omx.svg
+++ b/packages/vscode-extension/resources/omx.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 7.5C4 5.6 5.6 4 7.5 4H16.5C18.4 4 20 5.6 20 7.5V16.5C20 18.4 18.4 20 16.5 20H7.5C5.6 20 4 18.4 4 16.5V7.5Z" stroke="currentColor" stroke-width="1.6"/>
+  <path d="M8 15.5V8.5L12 12L16 8.5V15.5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/vscode-extension/src/chatHtml.ts
+++ b/packages/vscode-extension/src/chatHtml.ts
@@ -1,0 +1,177 @@
+export function renderChatHtml(nonce: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    * { box-sizing: border-box; }
+    body { margin: 0; color: var(--vscode-foreground); background: var(--vscode-editor-background); font-family: var(--vscode-font-family); font-size: var(--vscode-font-size); }
+    .app { display: grid; grid-template-rows: auto auto 1fr auto auto; height: 100vh; min-width: 0; }
+    .toolbar, .session, .composer, .logs { padding: 8px; border-bottom: 1px solid var(--vscode-panel-border); }
+    .toolbar { display: grid; grid-template-columns: 1fr auto auto; gap: 6px; align-items: center; }
+    .session { display: grid; gap: 6px; color: var(--vscode-descriptionForeground); }
+    .session-row { display: flex; gap: 6px; align-items: center; min-width: 0; }
+    .session-id { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--vscode-foreground); }
+    .messages { overflow: auto; padding: 10px 8px; }
+    .message { margin: 0 0 12px; }
+    .meta { color: var(--vscode-descriptionForeground); font-size: 11px; margin-bottom: 4px; }
+    .bubble { white-space: pre-wrap; overflow-wrap: anywhere; padding: 8px; border: 1px solid var(--vscode-panel-border); border-radius: 6px; line-height: 1.45; }
+    .user .bubble { background: var(--vscode-input-background); }
+    .assistant .bubble { background: var(--vscode-editorWidget-background); }
+    .system .bubble { color: var(--vscode-descriptionForeground); }
+    .composer { display: grid; grid-template-columns: 1fr auto; gap: 6px; border-top: 1px solid var(--vscode-panel-border); border-bottom: 0; }
+    textarea, select, button { font: inherit; color: var(--vscode-input-foreground); background: var(--vscode-input-background); border: 1px solid var(--vscode-input-border); border-radius: 4px; }
+    textarea { min-height: 64px; max-height: 180px; resize: vertical; padding: 8px; }
+    button { padding: 5px 8px; cursor: pointer; color: var(--vscode-button-foreground); background: var(--vscode-button-secondaryBackground); border-color: var(--vscode-button-secondaryBackground); }
+    button.primary { background: var(--vscode-button-background); border-color: var(--vscode-button-background); }
+    button:disabled { opacity: 0.55; cursor: default; }
+    select { width: 100%; min-width: 0; padding: 5px 6px; }
+    .logs { display: grid; gap: 6px; border-top: 1px solid var(--vscode-panel-border); border-bottom: 0; max-height: 25vh; overflow: auto; }
+    .log-item { width: 100%; text-align: left; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .empty, .error { color: var(--vscode-descriptionForeground); padding: 10px 2px; }
+    .error { color: var(--vscode-errorForeground); }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <div class="toolbar">
+      <select id="conversation"></select>
+      <button id="new">New</button>
+      <button id="refresh">Refresh</button>
+    </div>
+    <div class="session">
+      <div class="session-row"><span id="sessionState">Idle</span><span id="sessionId" class="session-id"></span></div>
+      <div class="session-row"><button id="stop">Stop</button><button id="doctor">Doctor</button><button id="activeLog">Open log</button></div>
+    </div>
+    <div id="messages" class="messages"></div>
+    <form id="form" class="composer"><textarea id="input" rows="3"></textarea><button id="send" class="primary" type="submit">Send</button></form>
+    <div id="logs" class="logs"></div>
+  </div>
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    const conversationEl = document.getElementById('conversation');
+    const messagesEl = document.getElementById('messages');
+    const inputEl = document.getElementById('input');
+    const sendEl = document.getElementById('send');
+    const stopEl = document.getElementById('stop');
+    const activeLogEl = document.getElementById('activeLog');
+    const sessionStateEl = document.getElementById('sessionState');
+    const sessionIdEl = document.getElementById('sessionId');
+    const logsEl = document.getElementById('logs');
+    let latestState = null;
+
+    document.getElementById('new').addEventListener('click', () => post('newConversation'));
+    document.getElementById('refresh').addEventListener('click', () => post('refresh'));
+    document.getElementById('doctor').addEventListener('click', () => post('doctor'));
+    stopEl.addEventListener('click', () => post('stop'));
+    activeLogEl.addEventListener('click', () => {
+      if (latestState && latestState.activeSession) post('openLog', { logPath: latestState.activeSession.log_path });
+    });
+    conversationEl.addEventListener('change', () => post('selectConversation', { conversationId: conversationEl.value }));
+    document.getElementById('form').addEventListener('submit', (event) => {
+      event.preventDefault();
+      const text = inputEl.value;
+      inputEl.value = '';
+      post('send', { text });
+    });
+
+    function post(command, payload = {}) { vscode.postMessage({ command, ...payload }); }
+
+    function renderState(state) {
+      latestState = state;
+      renderConversations(state);
+      renderSession(state.activeSession);
+      renderMessages(state.conversation ? state.conversation.messages || [] : []);
+      renderLogs(state.logs || []);
+    }
+
+    function renderConversations(state) {
+      conversationEl.textContent = '';
+      if (!state.conversations || state.conversations.length === 0) {
+        const option = document.createElement('option');
+        option.value = '';
+        option.textContent = 'New conversation';
+        conversationEl.appendChild(option);
+        return;
+      }
+      for (const item of state.conversations) {
+        const option = document.createElement('option');
+        option.value = item.id;
+        option.textContent = item.title + ' (' + item.message_count + ')';
+        option.selected = item.id === state.activeConversationId;
+        conversationEl.appendChild(option);
+      }
+    }
+
+    function renderSession(active) {
+      const running = Boolean(active);
+      sessionStateEl.textContent = running ? 'Running' : 'Idle';
+      sessionIdEl.textContent = running ? active.session_id : '';
+      stopEl.disabled = !running;
+      activeLogEl.disabled = !running;
+      sendEl.disabled = running;
+      inputEl.disabled = running;
+    }
+
+    function renderMessages(messages) {
+      messagesEl.textContent = '';
+      if (!messages.length) {
+        messagesEl.appendChild(empty('No messages yet.'));
+        return;
+      }
+      for (const message of messages) {
+        const row = document.createElement('div');
+        row.className = 'message ' + message.role;
+        const meta = document.createElement('div');
+        meta.className = 'meta';
+        meta.textContent = message.role + ' · ' + new Date(message.created_at).toLocaleString();
+        const bubble = document.createElement('div');
+        bubble.className = 'bubble';
+        bubble.textContent = message.text || '';
+        row.appendChild(meta);
+        row.appendChild(bubble);
+        if (message.log_path) {
+          const open = document.createElement('button');
+          open.textContent = 'Open log';
+          open.addEventListener('click', () => post('openLog', { logPath: message.log_path }));
+          row.appendChild(open);
+        }
+        messagesEl.appendChild(row);
+      }
+      messagesEl.scrollTop = messagesEl.scrollHeight;
+    }
+
+    function renderLogs(logs) {
+      logsEl.textContent = '';
+      if (!logs.length) return;
+      for (const log of logs) {
+        const button = document.createElement('button');
+        button.className = 'log-item';
+        button.textContent = log.name;
+        button.addEventListener('click', () => post('openLog', { logPath: log.path }));
+        logsEl.appendChild(button);
+      }
+    }
+
+    function empty(text) {
+      const node = document.createElement('div');
+      node.className = 'empty';
+      node.textContent = text;
+      return node;
+    }
+
+    window.addEventListener('message', (event) => {
+      if (event.data.type === 'state') renderState(event.data.state);
+      if (event.data.type === 'error') {
+        messagesEl.textContent = '';
+        const node = empty(event.data.message);
+        node.className = 'error';
+        messagesEl.appendChild(node);
+      }
+    });
+  </script>
+</body>
+</html>`;
+}

--- a/packages/vscode-extension/src/chatView.ts
+++ b/packages/vscode-extension/src/chatView.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
+import { renderChatHtml } from './chatHtml';
 import {
   appendMessage,
   createConversation,
@@ -28,8 +29,8 @@ interface ChatViewState {
   logs: VscodeLogSummary[];
 }
 
-export class OmxChatPanel {
-  private panel: vscode.WebviewPanel | undefined;
+export class OmxChatViewProvider implements vscode.WebviewViewProvider {
+  private view: vscode.WebviewView | null = null;
   private activeConversationId: string | null = null;
 
   constructor(
@@ -38,34 +39,33 @@ export class OmxChatPanel {
     private readonly output: vscode.OutputChannel,
   ) {}
 
-  async open(): Promise<void> {
-    if (this.panel) {
-      this.panel.reveal(vscode.ViewColumn.Beside);
-      await this.refresh();
-      return;
-    }
-
-    const panel = vscode.window.createWebviewPanel('omx.chat', 'OMX Chat', vscode.ViewColumn.Beside, {
-      enableScripts: true,
-      retainContextWhenHidden: true,
-    });
-    this.panel = panel;
-    panel.webview.html = renderChatHtml(randomUUID());
-    panel.onDidDispose(() => {
-      this.panel = undefined;
+  resolveWebviewView(webviewView: vscode.WebviewView): void {
+    this.view = webviewView;
+    webviewView.webview.options = { enableScripts: true };
+    webviewView.webview.html = renderChatHtml(randomUUID());
+    const disposables: vscode.Disposable[] = [];
+    webviewView.onDidDispose(() => {
+      for (const disposable of disposables) disposable.dispose();
+      this.view = null;
     }, null, this.context.subscriptions);
-    panel.webview.onDidReceiveMessage((message) => {
+    webviewView.webview.onDidReceiveMessage((message) => {
       void this.handleMessage(message);
-    }, null, this.context.subscriptions);
+    }, null, disposables);
+    void this.refresh();
+  }
+
+  async reveal(): Promise<void> {
+    await vscode.commands.executeCommand('workbench.view.extension.omx');
+    await vscode.commands.executeCommand('omx.chat.focus').then(undefined, () => undefined);
     await this.refresh();
   }
 
   async refresh(): Promise<void> {
-    if (!this.panel) return;
+    if (!this.view) return;
     try {
-      await this.panel.webview.postMessage({ type: 'state', state: await this.buildState() });
+      await this.view.webview.postMessage({ type: 'state', state: await this.buildState() });
     } catch (error) {
-      await this.panel.webview.postMessage({
+      await this.view.webview.postMessage({
         type: 'error',
         message: error instanceof Error ? error.message : String(error),
       });
@@ -220,130 +220,4 @@ export class OmxChatPanel {
     const document = await vscode.workspace.openTextDocument(vscode.Uri.file(path.resolve(logPath)));
     await vscode.window.showTextDocument(document, { preview: true });
   }
-}
-
-function renderChatHtml(nonce: string): string {
-  return `<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <style>
-    body { margin: 0; color: var(--vscode-foreground); background: var(--vscode-editor-background); font-family: var(--vscode-font-family); }
-    .layout { display: grid; grid-template-columns: minmax(150px, 220px) 1fr; height: 100vh; }
-    aside { border-right: 1px solid var(--vscode-panel-border); overflow: auto; }
-    main { display: grid; grid-template-rows: auto 1fr auto; min-width: 0; }
-    header, form { display: flex; gap: 8px; padding: 10px; border-bottom: 1px solid var(--vscode-panel-border); }
-    form { border-top: 1px solid var(--vscode-panel-border); border-bottom: 0; }
-    button, textarea { color: var(--vscode-input-foreground); background: var(--vscode-input-background); border: 1px solid var(--vscode-input-border); border-radius: 4px; }
-    button { padding: 6px 8px; cursor: pointer; }
-    button.primary { color: var(--vscode-button-foreground); background: var(--vscode-button-background); border-color: var(--vscode-button-background); }
-    textarea { flex: 1; min-height: 52px; resize: vertical; padding: 8px; font-family: inherit; }
-    .conversation, .log { display: block; width: 100%; padding: 10px; text-align: left; border-width: 0 0 1px; border-radius: 0; }
-    .conversation.active { background: var(--vscode-list-activeSelectionBackground); color: var(--vscode-list-activeSelectionForeground); }
-    .logs { border-top: 1px solid var(--vscode-panel-border); padding-top: 8px; }
-    .messages { overflow: auto; padding: 14px; }
-    .message { margin: 0 0 14px; }
-    .meta { color: var(--vscode-descriptionForeground); font-size: 12px; margin-bottom: 4px; }
-    .bubble { white-space: pre-wrap; overflow-wrap: anywhere; padding: 10px; border: 1px solid var(--vscode-panel-border); border-radius: 6px; }
-    .user .bubble { background: var(--vscode-input-background); }
-    .empty, .error { color: var(--vscode-descriptionForeground); padding: 14px; }
-    .error { color: var(--vscode-errorForeground); }
-  </style>
-</head>
-<body>
-  <div class="layout">
-    <aside>
-      <header><button id="new">New</button><button id="refresh">Refresh</button></header>
-      <div id="conversations"></div>
-      <section class="logs"><div class="meta">Recent logs</div><div id="logs"></div></section>
-    </aside>
-    <main>
-      <header><div id="status" class="meta"></div><button id="stop">Stop</button><button id="doctor">Doctor</button></header>
-      <div id="messages" class="messages"></div>
-      <form id="form"><textarea id="input" rows="3"></textarea><button class="primary" type="submit">Send</button></form>
-    </main>
-  </div>
-  <script nonce="${nonce}">
-    const vscode = acquireVsCodeApi();
-    const conversationsEl = document.getElementById('conversations');
-    const logsEl = document.getElementById('logs');
-    const messagesEl = document.getElementById('messages');
-    const statusEl = document.getElementById('status');
-    const inputEl = document.getElementById('input');
-    document.getElementById('new').addEventListener('click', () => post('newConversation'));
-    document.getElementById('refresh').addEventListener('click', () => post('refresh'));
-    document.getElementById('stop').addEventListener('click', () => post('stop'));
-    document.getElementById('doctor').addEventListener('click', () => post('doctor'));
-    document.getElementById('form').addEventListener('submit', (event) => {
-      event.preventDefault();
-      const text = inputEl.value;
-      inputEl.value = '';
-      post('send', { text });
-    });
-    function post(command, payload = {}) { vscode.postMessage({ command, ...payload }); }
-    function renderState(state) {
-      const messages = state.conversation ? state.conversation.messages || [] : [];
-      statusEl.textContent = state.activeSession ? 'Running ' + state.activeSession.session_id : 'Idle';
-      conversationsEl.textContent = '';
-      for (const item of state.conversations || []) {
-        const button = document.createElement('button');
-        button.className = 'conversation' + (item.id === state.activeConversationId ? ' active' : '');
-        button.textContent = item.title + ' · ' + item.message_count;
-        button.addEventListener('click', () => post('selectConversation', { conversationId: item.id }));
-        conversationsEl.appendChild(button);
-      }
-      logsEl.textContent = '';
-      for (const log of state.logs || []) {
-        const button = document.createElement('button');
-        button.className = 'log';
-        button.textContent = log.name + ' · ' + log.size + ' bytes';
-        button.addEventListener('click', () => post('openLog', { logPath: log.path }));
-        logsEl.appendChild(button);
-      }
-      messagesEl.textContent = '';
-      if (!messages.length) {
-        messagesEl.appendChild(empty('No messages yet.'));
-        return;
-      }
-      for (const message of messages) {
-        const row = document.createElement('div');
-        row.className = 'message ' + message.role;
-        const meta = document.createElement('div');
-        meta.className = 'meta';
-        meta.textContent = message.role + ' · ' + new Date(message.created_at).toLocaleString();
-        const bubble = document.createElement('div');
-        bubble.className = 'bubble';
-        bubble.textContent = message.text || '';
-        row.appendChild(meta);
-        row.appendChild(bubble);
-        if (message.log_path) {
-          const open = document.createElement('button');
-          open.textContent = 'Open log';
-          open.addEventListener('click', () => post('openLog', { logPath: message.log_path }));
-          row.appendChild(open);
-        }
-        messagesEl.appendChild(row);
-      }
-      messagesEl.scrollTop = messagesEl.scrollHeight;
-    }
-    function empty(text) {
-      const node = document.createElement('div');
-      node.className = 'empty';
-      node.textContent = text;
-      return node;
-    }
-    window.addEventListener('message', (event) => {
-      if (event.data.type === 'state') renderState(event.data.state);
-      if (event.data.type === 'error') {
-        messagesEl.textContent = '';
-        const node = empty(event.data.message);
-        node.className = 'error';
-        messagesEl.appendChild(node);
-      }
-    });
-  </script>
-</body>
-</html>`;
 }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,16 +1,23 @@
 import * as vscode from 'vscode';
-import { OmxChatPanel } from './chatView';
+import { OmxChatViewProvider } from './chatView';
 import { getWorkspaceRoot, OmxSessionManager } from './sessionManager';
+
+let refreshTimer: NodeJS.Timeout | undefined;
 
 export function activate(context: vscode.ExtensionContext): void {
   const output = vscode.window.createOutputChannel('OMX');
   const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
-  let chatPanel: OmxChatPanel | undefined;
-  const sessionManager = new OmxSessionManager(context, output, () => {
+  let chatView: OmxChatViewProvider;
+  let sessionManager: OmxSessionManager;
+
+  const refreshAll = async () => {
+    await chatView.refresh();
     refreshStatusBar(statusBar, sessionManager);
-    void chatPanel?.refresh();
+  };
+  sessionManager = new OmxSessionManager(context, output, () => {
+    void refreshAll();
   });
-  chatPanel = new OmxChatPanel(context, sessionManager, output);
+  chatView = new OmxChatViewProvider(context, sessionManager, output);
 
   statusBar.command = 'omx.openChat';
   statusBar.text = 'OMX';
@@ -20,31 +27,38 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     output,
     statusBar,
+    vscode.window.registerWebviewViewProvider('omx.chat', chatView, {
+      webviewOptions: { retainContextWhenHidden: true },
+    }),
     vscode.commands.registerCommand('omx.openChat', async () => {
-      await chatPanel.open();
+      await chatView.reveal();
     }),
     vscode.commands.registerCommand('omx.start', async () => {
       await sessionManager.promptAndStart('launch');
-      await chatPanel.refresh();
+      await refreshAll();
     }),
     vscode.commands.registerCommand('omx.resume', async () => {
       await sessionManager.promptAndStart('resume');
-      await chatPanel.refresh();
+      await refreshAll();
     }),
-    vscode.commands.registerCommand('omx.stop', () => {
+    vscode.commands.registerCommand('omx.stop', async () => {
       sessionManager.stop();
-      void chatPanel.refresh();
+      await refreshAll();
     }),
     vscode.commands.registerCommand('omx.doctor', async () => {
       await sessionManager.doctor();
+      await refreshAll();
     }),
   );
 
-  refreshStatusBar(statusBar, sessionManager);
+  registerWorkspaceWatchers(context, refreshAll);
+  configureRefreshTimer(context, refreshAll);
+  void refreshAll();
 }
 
 export function deactivate(): void {
-  // Child processes are owned by OmxSessionManager and stopped through the command surface.
+  if (refreshTimer) clearInterval(refreshTimer);
+  refreshTimer = undefined;
 }
 
 function refreshStatusBar(statusBar: vscode.StatusBarItem, sessionManager: OmxSessionManager): void {
@@ -56,4 +70,24 @@ function refreshStatusBar(statusBar: vscode.StatusBarItem, sessionManager: OmxSe
   }
   statusBar.text = 'OMX';
   statusBar.tooltip = 'Open OMX Chat';
+}
+
+function configureRefreshTimer(context: vscode.ExtensionContext, refreshAll: () => Promise<void>): void {
+  const intervalMs = Math.max(500, vscode.workspace.getConfiguration('omx').get<number>('refreshIntervalMs', 1500));
+  refreshTimer = setInterval(() => {
+    void refreshAll();
+  }, intervalMs);
+  context.subscriptions.push({ dispose: () => refreshTimer && clearInterval(refreshTimer) });
+}
+
+function registerWorkspaceWatchers(context: vscode.ExtensionContext, refreshAll: () => Promise<void>): void {
+  const folder = vscode.workspace.workspaceFolders?.[0];
+  if (!folder) return;
+  for (const pattern of ['.omx/logs/**', '.omx/vscode/**']) {
+    const watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(folder, pattern));
+    watcher.onDidCreate(() => void refreshAll(), null, context.subscriptions);
+    watcher.onDidChange(() => void refreshAll(), null, context.subscriptions);
+    watcher.onDidDelete(() => void refreshAll(), null, context.subscriptions);
+    context.subscriptions.push(watcher);
+  }
 }


### PR DESCRIPTION
Summary:
- Move the OMX chat surface from an ad hoc webview panel into a contributed Activity Bar webview view.
- Split the chat HTML into chatHtml.ts and add the activity bar icon/resource contribution.
- Refresh chat/session/log state from workspace watchers and a configurable refresh interval.

Validation:
- npm test (packages/vscode-extension)
- git diff --cached --check

Size:
- 5 files changed, 300 insertions, 160 deletions (460 total), expected size/L.