### PR TITLE
fix: stop completed-goal cleanup loop

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3284,6 +3284,94 @@ standardMaxRounds = 15
     }
   });
 
+  it("does not block ordinary Stop after completed Ultragoal cleanup remains", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-completed-ultragoal-ordinary-stop-"));
+    try {
+      await writeJson(join(cwd, ".omx", "ultragoal", "goals.json"), {
+        version: 1,
+        aggregateCompletion: { status: "complete", completedAt: "2026-05-20T00:00:00.000Z" },
+        goals: [{ id: "G001-done", status: "complete", objective: "Done" }],
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-completed-ultragoal-ordinary-stop",
+        thread_id: "thread-completed-ultragoal-ordinary-stop",
+        last_assistant_message: "Implemented the requested fix and verified the focused tests.",
+      }, { cwd });
+
+      const output = JSON.stringify(result.outputJson);
+      assert.notEqual(result.outputJson?.decision, "block");
+      assert.notEqual(result.outputJson?.stopReason, "completed_codex_goal_cleanup_required");
+      assert.doesNotMatch(output, /run \/goal clear/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat explanatory create_goal warnings as completed-goal cleanup attempts", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-completed-goal-explainer-stop-"));
+    try {
+      await writeJson(join(cwd, ".omx", "ultragoal", "goals.json"), {
+        version: 1,
+        aggregateCompletion: { status: "complete", completedAt: "2026-05-20T00:00:00.000Z" },
+        goals: [{ id: "G001-done", status: "complete", objective: "Done" }],
+      });
+
+      for (const [index, last_assistant_message] of [
+        "Do not call create_goal until the user has explicitly cleared the old goal state.",
+        "No create_goal attempt was made; this is only the final summary.",
+        "I am not calling create_goal; the completed work is summarized above.",
+        "I am not starting another goal; cleanup is already documented.",
+        "Do not start another goal until cleanup is explicit.",
+        "Do not create a new ultragoal; this is only a final summary.",
+      ].entries()) {
+        const result = await dispatchCodexNativeHook({
+          hook_event_name: "Stop",
+          cwd,
+          session_id: `sess-completed-goal-explainer-stop-${index}`,
+          thread_id: `thread-completed-goal-explainer-stop-${index}`,
+          last_assistant_message,
+        }, { cwd });
+
+        const output = JSON.stringify(result.outputJson);
+        assert.notEqual(result.outputJson?.decision, "block");
+        assert.notEqual(result.outputJson?.stopReason, "completed_codex_goal_cleanup_required");
+        assert.doesNotMatch(output, /run \/goal clear/);
+      }
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks explicit create_goal attempts even when adjacent text explains not to call it", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-completed-goal-mixed-stop-"));
+    try {
+      await writeJson(join(cwd, ".omx", "ultragoal", "goals.json"), {
+        version: 1,
+        aggregateCompletion: { status: "complete", completedAt: "2026-05-20T00:00:00.000Z" },
+        goals: [{ id: "G001-done", status: "complete", objective: "Done" }],
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-completed-goal-mixed-stop",
+        thread_id: "thread-completed-goal-mixed-stop",
+        last_user_message: "Do not call create_goal until cleanup is explicit.",
+        last_assistant_message: "I am starting another run now; create_goal payload follows.",
+      }, { cwd });
+
+      const output = JSON.stringify(result.outputJson);
+      assert.equal(result.outputJson?.decision, "block");
+      assert.equal(result.outputJson?.stopReason, "completed_codex_goal_cleanup_required");
+      assert.match(output, /run \/goal clear/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("blocks Stop when a final answer starts another goal over completed state", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-completed-goal-stop-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2412,6 +2412,55 @@ function looksLikeNewGoalPrompt(text: string): boolean {
   return /(?:\b(?:start|create|begin|new|another)\b.{0,80}\b(?:goal|ultragoal|performance[-\s]goal|autoresearch[-\s]goal)\b|\b(?:goal|ultragoal|performance[-\s]goal|autoresearch[-\s]goal)\b.{0,80}\b(?:start|create|begin|new|another)\b)/i.test(text);
 }
 
+function sentenceWindowAround(text: string, start: number, end: number): string {
+  const rawBefore = text.slice(Math.max(0, start - 80), start);
+  const rawAfter = text.slice(end, Math.min(text.length, end + 80));
+  const before = rawBefore.slice(Math.max(rawBefore.lastIndexOf("\n"), rawBefore.lastIndexOf("."), rawBefore.lastIndexOf("!"), rawBefore.lastIndexOf("?")) + 1);
+  const sentenceEndOffsets = [rawAfter.indexOf("\n"), rawAfter.indexOf("."), rawAfter.indexOf("!"), rawAfter.indexOf("?")].filter((index) => index >= 0);
+  const after = sentenceEndOffsets.length > 0 ? rawAfter.slice(0, Math.min(...sentenceEndOffsets)) : rawAfter;
+  return `${before}${text.slice(start, end)}${after}`;
+}
+
+function isNegatedGoalAttemptWindow(window: string): boolean {
+  return /\b(?:do\s+not|don't|never|must\s+not|should\s+not|cannot|can't|not|no)\b.{0,50}\b(?:start|create|begin|new|another|goal|ultragoal|performance[-\s]goal|autoresearch[-\s]goal)\b/i.test(window)
+    || /\b(?:without|instead\s+of)\b.{0,30}\b(?:start|create|begin|new|another)?\b.{0,30}\b(?:goal|ultragoal|performance[-\s]goal|autoresearch[-\s]goal)\b/i.test(window)
+    || /\b(?:goal|ultragoal|performance[-\s]goal|autoresearch[-\s]goal)\b.{0,30}\b(?:is|was|already)\b.{0,30}\b(?:documented|complete|completed|done|unavailable|not\s+needed)\b/i.test(window);
+}
+
+function looksLikeGoalCreationAttempt(text: string): boolean {
+  const candidatePattern = /\b(?:start|create|begin|new|another|goal|ultragoal|performance[-\s]goal|autoresearch[-\s]goal)\b/gi;
+  for (const match of text.matchAll(candidatePattern)) {
+    const start = match.index ?? 0;
+    const end = start + match[0].length;
+    const window = sentenceWindowAround(text, start, end);
+    if (isNegatedGoalAttemptWindow(window)) continue;
+    if (/(?:\b(?:start|create|begin|new|another)\b.{0,80}\b(?:goal|ultragoal|performance[-\s]goal|autoresearch[-\s]goal)\b|\b(?:goal|ultragoal|performance[-\s]goal|autoresearch[-\s]goal)\b.{0,80}\b(?:start|create|begin|new|another)\b)/i.test(window)) return true;
+  }
+  return false;
+}
+
+function looksLikeCreateGoalAttempt(text: string): boolean {
+  const candidatePattern = /\bcreate_goal\s*(?:\(|\b)/gi;
+  for (const match of text.matchAll(candidatePattern)) {
+    const start = match.index ?? 0;
+    const end = start + match[0].length;
+    const window = sentenceWindowAround(text, start, end);
+    if (/(?:\bno\s+create_goal\s+attempt\b|\b(?:do\s+not|don't|never|must\s+not|should\s+not|cannot|can't|not)\b.{0,40}\bcreate_goal\b|\bwithout\s+create_goal\b|\bfailed\s+to\s+call\s+create_goal\b|\bcreate_goal\s+(?:is|was)\s+(?:unavailable|not\s+available|not\s+called)\b)/i.test(window)) {
+      continue;
+    }
+    if (/\b(?:call|calling|called|invoke|invoking|start|starting|create|creating|begin|beginning|attempt|attempting|try|trying|continue\s+to|proceed\s+to)\b.{0,80}\bcreate_goal\b/i.test(window)
+      || /\bcreate_goal\b.{0,80}\b(?:payload|call|tool|now|next|follows|follow|start|starting|create|creating|begin|beginning|attempt|attempting)\b/i.test(window)
+      || /\bcreate_goal\s*\(/i.test(match[0])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function looksLikeCompletedGoalCleanupAttempt(text: string): boolean {
+  return looksLikeGoalCreationAttempt(text) || looksLikeCreateGoalAttempt(text);
+}
+
 async function findCompletedGoalWorkflowCleanupNotice(cwd: string): Promise<string | null> {
   const ultragoal = await readJsonIfExists(join(cwd, ".omx", "ultragoal", "goals.json"));
   const aggregateCompletion = safeObject(ultragoal?.aggregateCompletion);
@@ -2442,7 +2491,7 @@ async function findCompletedGoalWorkflowCleanupNotice(cwd: string): Promise<stri
 }
 
 async function buildCompletedGoalCleanupPromptWarning(cwd: string, prompt: string): Promise<string | null> {
-  if (!looksLikeNewGoalPrompt(prompt)) return null;
+  if (!looksLikeCompletedGoalCleanupAttempt(prompt)) return null;
   const notice = await findCompletedGoalWorkflowCleanupNotice(cwd);
   if (!notice) return null;
   return `${notice} Do not continue into create_goal until cleanup is explicit; hooks only nudge and must not mutate Codex goal state.`;
@@ -2453,7 +2502,7 @@ async function buildCompletedGoalCleanupStopOutput(payload: CodexHookPayload, cw
     safeString(payload.last_user_message ?? payload.lastUserMessage),
     safeString(payload.last_assistant_message ?? payload.lastAssistantMessage),
   ].join("\n");
-  if (!looksLikeNewGoalPrompt(text)) return null;
+  if (!looksLikeCompletedGoalCleanupAttempt(text)) return null;
   const notice = await findCompletedGoalWorkflowCleanupNotice(cwd);
   if (!notice) return null;
   const systemMessage = `${notice} Do not continue into create_goal until cleanup is explicit; hooks only nudge and must not mutate Codex goal state.`;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2408,9 +2408,6 @@ function reportsBlockedUltragoalCompletedAggregateMicrogoalLoop(goal: Record<str
     && /\b(?:unreconcilable|mismatch|loop|already complete|already completed|blocks?)\b/i.test(evidence);
 }
 
-function looksLikeNewGoalPrompt(text: string): boolean {
-  return /(?:\b(?:start|create|begin|new|another)\b.{0,80}\b(?:goal|ultragoal|performance[-\s]goal|autoresearch[-\s]goal)\b|\b(?:goal|ultragoal|performance[-\s]goal|autoresearch[-\s]goal)\b.{0,80}\b(?:start|create|begin|new|another)\b)/i.test(text);
-}
 
 function sentenceWindowAround(text: string, start: number, end: number): string {
   const rawBefore = text.slice(Math.max(0, start - 80), start);


### PR DESCRIPTION
## Summary\n- scope completed-goal cleanup detection to sentence-window candidate classifiers\n- handle both literal create_goal attempts and natural-language next-goal attempts with local negation/explanation filtering\n- add Stop-hook regressions for ordinary completed-state Stop, explanatory negated create_goal/natural-language text, and mixed explicit attempts\n\n## Evidence\n- PATH=$HOME/.nvm/versions/node/v20.20.2/bin:$PATH NODE_OPTIONS= npm run build\n- PATH=$HOME/.nvm/versions/node/v20.20.2/bin:$PATH NODE_OPTIONS= node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js\n\nFixes #2954