### PR TITLE
Add passive URL reader

### DIFF
--- a/docs/url-reader.md
+++ b/docs/url-reader.md
@@ -10,7 +10,8 @@ The v0 reader is intentionally conservative:
 - no global binary or `PATH` ownership changes
 - only `http:` and `https:` URLs are supported
 - local, loopback, private, link-local, unique-local, multicast, reserved, and internal network addresses are blocked before fetching
-- hostnames are resolved before fetching; any unsafe resolved address blocks the read
+- IPv6 unique-local (`fc00::/7`), link-local (`fe80::/10`), multicast (`ff00::/8`), loopback, unspecified, documentation/protocol-assignment ranges, and IPv4-mapped unsafe IPv4 addresses are blocked; public IPv6 is allowed
+- hostnames are resolved before fetching; any unsafe resolved address blocks the read using the same address classifier as literal URLs
 - redirects are followed manually and every redirect target is re-validated before the next fetch
 - bounded response reads before text decoding
 - structured `verdict` values: `ok`, `redirect`, `blocked`, or `error`

--- a/docs/url-reader.md
+++ b/docs/url-reader.md
@@ -8,6 +8,10 @@ The v0 reader is intentionally conservative:
 - no browser automation or browser dependency
 - no cookie injection, challenge solving, or bot-detection bypass
 - no global binary or `PATH` ownership changes
+- only `http:` and `https:` URLs are supported
+- local, loopback, private, link-local, unique-local, multicast, reserved, and internal network addresses are blocked before fetching
+- hostnames are resolved before fetching; any unsafe resolved address blocks the read
+- redirects are followed manually and every redirect target is re-validated before the next fetch
 - bounded response reads before text decoding
 - structured `verdict` values: `ok`, `redirect`, `blocked`, or `error`
 

--- a/docs/url-reader.md
+++ b/docs/url-reader.md
@@ -1,0 +1,22 @@
+# Passive URL reader
+
+`omx url read <url> --json` performs a passive, bounded fetch of a user-supplied
+HTTP(S) URL and emits structured JSON for automation.
+
+The v0 reader is intentionally conservative:
+
+- no browser automation or browser dependency
+- no cookie injection, challenge solving, or bot-detection bypass
+- no global binary or `PATH` ownership changes
+- bounded response reads before text decoding
+- structured `verdict` values: `ok`, `redirect`, `blocked`, or `error`
+
+Example:
+
+```sh
+omx url read https://example.com --json
+```
+
+The JSON result includes the input URL, final URL, HTTP status, content type,
+redirect flag, best-effort title/snippet for text-like responses, blocked/challenge
+signals, truncation metadata, and safe error details when the read fails.

--- a/docs/url-reader.md
+++ b/docs/url-reader.md
@@ -10,7 +10,7 @@ The v0 reader is intentionally conservative:
 - no global binary or `PATH` ownership changes
 - only `http:` and `https:` URLs are supported
 - local, loopback, private, link-local, unique-local, multicast, reserved, and internal network addresses are blocked before fetching
-- IPv6 unique-local (`fc00::/7`), link-local (`fe80::/10`), multicast (`ff00::/8`), loopback, unspecified, documentation/protocol-assignment ranges, and IPv4-mapped unsafe IPv4 addresses are blocked; public IPv6 is allowed
+- IPv6 special-purpose/reserved ranges are blocked, including local-use IPv4/IPv6 translation (`64:ff9b:1::/48`), discard-only/dummy prefixes (`100::/64`, `100:0:0:1::/64`), IETF protocol assignments (`2001::/23`), documentation (`2001:db8::/32`, `3fff::/20`), 6to4 (`2002::/16`), segment routing SIDs (`5f00::/16`), unique-local (`fc00::/7`), link-local (`fe80::/10`), multicast (`ff00::/8`), loopback, unspecified, and IPv4-mapped unsafe IPv4 addresses; public IPv6 is allowed
 - hostnames are resolved before fetching; any unsafe resolved address blocks the read using the same address classifier as literal URLs
 - redirects are followed manually and every redirect target is re-validated before the next fetch
 - bounded response reads before text decoding

--- a/src/cli/__tests__/url.test.ts
+++ b/src/cli/__tests__/url.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { parseUrlReadArgs, urlCommand } from "../url.js";
+
+function runOmx(cwd: string, argv: string[]) {
+	const testDir = dirname(fileURLToPath(import.meta.url));
+	const repoRoot = join(testDir, "..", "..", "..");
+	const omxBin = join(repoRoot, "dist", "cli", "omx.js");
+	return spawnSync(process.execPath, [omxBin, ...argv], {
+		cwd,
+		encoding: "utf-8",
+		env: {
+			...process.env,
+			OMX_AUTO_UPDATE: "0",
+			OMX_NOTIFY_FALLBACK: "0",
+			OMX_HOOK_DERIVED_SIGNALS: "0",
+		},
+	});
+}
+
+describe("omx url", () => {
+	it("documents passive URL reader in top-level and nested help", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-url-help-"));
+		try {
+			const mainHelp = runOmx(cwd, ["--help"]);
+			assert.equal(mainHelp.status, 0, mainHelp.stderr || mainHelp.stdout);
+			assert.match(
+				mainHelp.stdout,
+				/omx url\s+Passive URL reader \(read <url> --json\)/i,
+			);
+
+			const urlHelp = runOmx(cwd, ["url", "--help"]);
+			assert.equal(urlHelp.status, 0, urlHelp.stderr || urlHelp.stdout);
+			assert.match(urlHelp.stdout, /Usage:\s*\n\s*omx url read <url> --json/i);
+			assert.match(
+				urlHelp.stdout,
+				/does not bypass challenges, use a browser, inject cookies/i,
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("requires explicit JSON output for passive reads", () => {
+		assert.throws(
+			() => parseUrlReadArgs(["https://example.test/"]),
+			/Missing required --json flag/,
+		);
+		assert.deepEqual(parseUrlReadArgs(["https://example.test/", "--json"]), {
+			url: "https://example.test/",
+			json: true,
+		});
+	});
+
+	it("prints structured JSON from an injected fetch implementation", async () => {
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (message?: unknown) => {
+			logs.push(String(message));
+		};
+		try {
+			await urlCommand(["read", "https://example.test/", "--json"], {
+				fetch: async () => ({
+					status: 200,
+					statusText: "OK",
+					url: "https://example.test/",
+					redirected: false,
+					body: new ReadableStream({
+						start(controller) {
+							controller.enqueue(
+								new TextEncoder().encode(
+									"<title>Example</title><body>Hello</body>",
+								),
+							);
+							controller.close();
+						},
+					}),
+					headers: {
+						get: (name: string) =>
+							name.toLowerCase() === "content-type" ? "text/html" : null,
+					},
+				}),
+			});
+		} finally {
+			console.log = originalLog;
+		}
+
+		const parsed = JSON.parse(logs.join("\n"));
+		assert.equal(parsed.verdict, "ok");
+		assert.equal(parsed.title, "Example");
+		assert.equal(parsed.error, null);
+	});
+});

--- a/src/cli/__tests__/url.test.ts
+++ b/src/cli/__tests__/url.test.ts
@@ -48,11 +48,11 @@ describe("omx url", () => {
 
 	it("requires explicit JSON output for passive reads", () => {
 		assert.throws(
-			() => parseUrlReadArgs(["https://example.test/"]),
+			() => parseUrlReadArgs(["http://example.test/"]),
 			/Missing required --json flag/,
 		);
-		assert.deepEqual(parseUrlReadArgs(["https://example.test/", "--json"]), {
-			url: "https://example.test/",
+		assert.deepEqual(parseUrlReadArgs(["http://example.test/", "--json"]), {
+			url: "http://example.test/",
 			json: true,
 		});
 	});
@@ -64,12 +64,12 @@ describe("omx url", () => {
 			logs.push(String(message));
 		};
 		try {
-			await urlCommand(["read", "https://example.test/", "--json"], {
+			await urlCommand(["read", "http://example.test/", "--json"], {
 				resolveHostname: async () => ["93.184.216.34"],
 				fetch: async () => ({
 					status: 200,
 					statusText: "OK",
-					url: "https://example.test/",
+					url: "http://example.test/",
 					redirected: false,
 					body: new ReadableStream({
 						start(controller) {

--- a/src/cli/__tests__/url.test.ts
+++ b/src/cli/__tests__/url.test.ts
@@ -65,6 +65,7 @@ describe("omx url", () => {
 		};
 		try {
 			await urlCommand(["read", "https://example.test/", "--json"], {
+				resolveHostname: async () => ["93.184.216.34"],
 				fetch: async () => ({
 					status: 200,
 					statusText: "OK",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -45,6 +45,7 @@ import { apiCommand } from "./api.js";
 import { agentsInitCommand } from "./agents-init.js";
 import { agentsCommand } from "./agents.js";
 import { sessionCommand } from "./session-search.js";
+import { urlCommand } from "./url.js";
 import { autoresearchCommand } from "./autoresearch.js";
 import { autoresearchGoalCommand } from "./autoresearch-goal.js";
 import { mcpParityCommand } from "./mcp-parity.js";
@@ -228,6 +229,7 @@ Usage:
   omx explore   DEPRECATED compatibility command; use normal repo inspection or omx sparkshell
   omx api       Run native omx-api localhost gateway commands (serve|status|stop|generate)
   omx session   Search prior local session transcripts (--codex-home <path> escape hatch)
+  omx url       Passive URL reader (read <url> --json)
   omx agents-init [path]
                 Bootstrap lightweight AGENTS.md files for a repo/subtree
   omx agents    Manage Codex native agent TOML files
@@ -388,6 +390,7 @@ type CliCommand =
   | "sparkshell"
   | "team"
   | "session"
+  | "url"
   | "resume"
   | "version"
   | "tmux-hook"
@@ -438,6 +441,7 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "performance-goal",
   "resume",
   "session",
+  "url",
   "api",
   "sparkshell",
   "team",
@@ -2501,6 +2505,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "session":
         await sessionCommand(args.slice(1));
+        break;
+      case "url":
+        await urlCommand(args.slice(1));
         break;
       case "ralph":
         await ralphCommand(args.slice(1));

--- a/src/cli/url.ts
+++ b/src/cli/url.ts
@@ -14,8 +14,10 @@ Examples:
   omx url read https://example.com --json
 
 This command passively reads a user-supplied URL and classifies the reachable
-response. It does not bypass challenges, use a browser, inject cookies, or take
-over any global binary/PATH ownership.
+response. It only supports http(s), resolves hosts before fetch, blocks local or
+internal network targets, and re-validates redirects before following them. It
+does not bypass challenges, use a browser, inject cookies, or take over any
+global binary/PATH ownership.
 `;
 
 const HELP_TOKENS = new Set(["--help", "-h", "help"]);

--- a/src/cli/url.ts
+++ b/src/cli/url.ts
@@ -1,0 +1,81 @@
+import { readUrl } from "../url-reader/index.js";
+import type { UrlReaderOptions } from "../url-reader/types.js";
+
+const HELP = `omx url - Passive URL reader
+
+Usage:
+  omx url read <url> --json
+
+Options:
+  --json       Emit structured JSON (required for v0)
+  -h, --help   Show this help
+
+Examples:
+  omx url read https://example.com --json
+
+This command passively reads a user-supplied URL and classifies the reachable
+response. It does not bypass challenges, use a browser, inject cookies, or take
+over any global binary/PATH ownership.
+`;
+
+const HELP_TOKENS = new Set(["--help", "-h", "help"]);
+
+export interface ParsedUrlReadArgs {
+	url: string;
+	json: boolean;
+}
+
+export function parseUrlReadArgs(args: string[]): ParsedUrlReadArgs {
+	let json = false;
+	const positionals: string[] = [];
+
+	for (const token of args) {
+		if (token === "--json") {
+			json = true;
+			continue;
+		}
+		if (HELP_TOKENS.has(token)) {
+			return { url: "", json: false };
+		}
+		if (token.startsWith("-")) {
+			throw new Error(`Unknown option: ${token}\n${HELP}`);
+		}
+		positionals.push(token);
+	}
+
+	if (positionals.length === 0) {
+		throw new Error(`Missing URL.\n${HELP}`);
+	}
+	if (positionals.length > 1) {
+		throw new Error(`Unexpected extra argument: ${positionals[1]}\n${HELP}`);
+	}
+	if (!json) {
+		throw new Error(`Missing required --json flag.\n${HELP}`);
+	}
+
+	return { url: positionals[0], json };
+}
+
+export async function urlCommand(
+	args: string[],
+	options: UrlReaderOptions = {},
+): Promise<void> {
+	const subcommand = args[0];
+	if (!subcommand || HELP_TOKENS.has(subcommand)) {
+		console.log(HELP.trim());
+		return;
+	}
+
+	if (subcommand !== "read") {
+		throw new Error(`Unknown url subcommand: ${subcommand}\n${HELP}`);
+	}
+
+	if (args.slice(1).some((token) => HELP_TOKENS.has(token))) {
+		console.log(HELP.trim());
+		return;
+	}
+
+	const parsed = parseUrlReadArgs(args.slice(1));
+	const result = await readUrl(parsed.url, options);
+	console.log(JSON.stringify(result, null, 2));
+}

--- a/src/cli/url.ts
+++ b/src/cli/url.ts
@@ -15,9 +15,13 @@ Examples:
 
 This command passively reads a user-supplied URL and classifies the reachable
 response. It only supports http(s), resolves hosts before fetch, blocks local or
-internal network targets, and re-validates redirects before following them. It
-does not bypass challenges, use a browser, inject cookies, or take over any
-global binary/PATH ownership.
+internal network targets, and re-validates redirects before following them. To
+avoid DNS rebinding/TOCTOU in the Node v0 runtime, HTTP hostname requests are
+sent to a validated pinned IP with the original Host header; HTTPS hostnames are
+blocked because this fetch path cannot safely pin the TCP connection while also
+preserving TLS SNI/certificate validation. Direct public IP HTTPS URLs remain
+allowed. It does not bypass challenges, use a browser, inject cookies, or take
+over any global binary/PATH ownership.
 `;
 
 const HELP_TOKENS = new Set(["--help", "-h", "help"]);

--- a/src/url-reader/__tests__/url-reader.test.ts
+++ b/src/url-reader/__tests__/url-reader.test.ts
@@ -178,6 +178,12 @@ describe("readUrl", () => {
 	it("blocks unsafe IPv6 literals before fetch", async () => {
 		const unsafeUrls = [
 			"http://[::]/secret",
+			"http://[64:ff9b:1::10.0.0.1]/secret",
+			"http://[100::1]/secret",
+			"http://[100:0:0:1::1]/secret",
+			"http://[2002:0a00:0001::1]/secret",
+			"http://[3fff::1]/secret",
+			"http://[5f00::1]/secret",
 			"http://[fc00::1]/secret",
 			"http://[fd12:3456:789a::1]/secret",
 			"http://[fe80::1]/secret",
@@ -244,7 +250,18 @@ describe("readUrl", () => {
 	});
 
 	it("blocks hostnames that resolve to unsafe IPv6 addresses", async () => {
-		const unsafeAddresses = ["fc00::1", "fd12:3456:789a::1", "fe80::1", "ff02::1"];
+		const unsafeAddresses = [
+			"64:ff9b:1::10.0.0.1",
+			"100::1",
+			"100:0:0:1::1",
+			"2002:0a00:0001::1",
+			"3fff::1",
+			"5f00::1",
+			"fc00::1",
+			"fd12:3456:789a::1",
+			"fe80::1",
+			"ff02::1",
+		];
 
 		for (const address of unsafeAddresses) {
 			let fetched = false;
@@ -415,6 +432,12 @@ describe("readUrl", () => {
 
 	it("blocks redirects to unsafe IPv6 literal targets before following", async () => {
 		const redirectTargets = [
+			"http://[64:ff9b:1::10.0.0.1]/secret",
+			"http://[100::1]/secret",
+			"http://[100:0:0:1::1]/secret",
+			"http://[2002:0a00:0001::1]/secret",
+			"http://[3fff::1]/secret",
+			"http://[5f00::1]/secret",
 			"http://[fc00::1]/secret",
 			"http://[fe80::1]/secret",
 			"http://[ff02::1]/secret",
@@ -445,7 +468,17 @@ describe("readUrl", () => {
 	});
 
 	it("blocks redirects to hostnames resolving to unsafe IPv6 before following", async () => {
-		const unsafeAddresses = ["fc00::1", "fe80::1", "ff02::1"];
+		const unsafeAddresses = [
+			"64:ff9b:1::10.0.0.1",
+			"100::1",
+			"100:0:0:1::1",
+			"2002:0a00:0001::1",
+			"3fff::1",
+			"5f00::1",
+			"fc00::1",
+			"fe80::1",
+			"ff02::1",
+		];
 
 		for (const address of unsafeAddresses) {
 			const fetched: string[] = [];

--- a/src/url-reader/__tests__/url-reader.test.ts
+++ b/src/url-reader/__tests__/url-reader.test.ts
@@ -30,8 +30,11 @@ function response(
 }
 
 describe("readUrl", () => {
+	const publicResolver = async () => ["93.184.216.34"];
+
 	it("returns ok with title and snippet for reachable HTML", async () => {
 		const result = await readUrl("https://example.test/page", {
+			resolveHostname: publicResolver,
 			fetch: async () =>
 				response({
 					url: "https://example.test/page",
@@ -49,6 +52,7 @@ describe("readUrl", () => {
 
 	it("classifies challenge-like responses as blocked", async () => {
 		const result = await readUrl("https://example.test/protected", {
+			resolveHostname: publicResolver,
 			fetch: async () =>
 				response({
 					status: 403,
@@ -71,6 +75,7 @@ describe("readUrl", () => {
 			{ code: "ECONNREFUSED" },
 		);
 		const result = await readUrl("https://example.test/fail", {
+			resolveHostname: publicResolver,
 			fetch: async () => {
 				throw error;
 			},
@@ -85,6 +90,7 @@ describe("readUrl", () => {
 
 	it("reports redirects with final URL and readable metadata", async () => {
 		const result = await readUrl("https://example.test/start", {
+			resolveHostname: publicResolver,
 			fetch: async () =>
 				response({
 					url: "https://example.test/final",
@@ -111,6 +117,7 @@ describe("readUrl", () => {
 		});
 
 		const result = await readUrl("https://example.test/large", {
+			resolveHostname: publicResolver,
 			maxBytes: 128,
 			fetch: async () =>
 				response({
@@ -127,10 +134,126 @@ describe("readUrl", () => {
 		assert.equal(cancelCalled, true);
 	});
 
-	it("rejects unsupported protocols with an error verdict", async () => {
+	it("rejects unsupported protocols with a blocked verdict", async () => {
 		const result = await readUrl("file:///tmp/example");
 
-		assert.equal(result.verdict, "error");
+		assert.equal(result.verdict, "blocked");
 		assert.equal(result.error?.name, "UnsupportedProtocolError");
+		assert.ok(result.signals.includes("unsupported-protocol"));
+	});
+
+	it("blocks localhost names before fetch", async () => {
+		let fetched = false;
+		const result = await readUrl("http://localhost/admin", {
+			fetch: async () => {
+				fetched = true;
+				return response({});
+			},
+		});
+
+		assert.equal(result.verdict, "blocked");
+		assert.equal(result.error?.name, "UnsafeUrlError");
+		assert.ok(result.signals.includes("localhost-name"));
+		assert.equal(fetched, false);
+	});
+
+	it("blocks IPv4 loopback before fetch", async () => {
+		const result = await readUrl("http://127.0.0.1:8080/secret", {
+			fetch: async () => response({}),
+		});
+
+		assert.equal(result.verdict, "blocked");
+		assert.ok(result.signals.includes("unsafe-address"));
+	});
+
+	it("blocks IPv6 loopback before fetch", async () => {
+		const result = await readUrl("http://[::1]/secret", {
+			fetch: async () => response({}),
+		});
+
+		assert.equal(result.verdict, "blocked");
+		assert.ok(result.signals.includes("unsafe-address"));
+	});
+
+	it("blocks private IPv4 before fetch", async () => {
+		const result = await readUrl("http://10.0.0.5/metadata", {
+			fetch: async () => response({}),
+		});
+
+		assert.equal(result.verdict, "blocked");
+		assert.ok(result.signals.includes("unsafe-address"));
+	});
+
+	it("blocks link-local IPv4 before fetch", async () => {
+		const result = await readUrl("http://169.254.169.254/latest/meta-data/", {
+			fetch: async () => response({}),
+		});
+
+		assert.equal(result.verdict, "blocked");
+		assert.ok(result.signals.includes("unsafe-address"));
+	});
+
+	it("blocks hostnames that resolve to private addresses", async () => {
+		let fetched = false;
+		const result = await readUrl("https://internal.example.test/", {
+			resolveHostname: async () => ["192.168.1.10"],
+			fetch: async () => {
+				fetched = true;
+				return response({});
+			},
+		});
+
+		assert.equal(result.verdict, "blocked");
+		assert.ok(result.signals.includes("unsafe-address"));
+		assert.equal(fetched, false);
+	});
+
+	it("blocks redirects to localhost before following", async () => {
+		const fetched: string[] = [];
+		const result = await readUrl("https://example.test/start", {
+			resolveHostname: publicResolver,
+			fetch: async (url) => {
+				fetched.push(url);
+				return response({
+					status: 302,
+					statusText: "Found",
+					url,
+					headers: {
+						get: (name: string) =>
+							name.toLowerCase() === "location" ? "http://localhost/secret" : null,
+					},
+				});
+			},
+		});
+
+		assert.equal(result.verdict, "blocked");
+		assert.ok(result.signals.includes("localhost-name"));
+		assert.deepEqual(fetched, ["https://example.test/start"]);
+	});
+
+	it("blocks redirects to private targets before following", async () => {
+		const fetched: string[] = [];
+		const result = await readUrl("https://example.test/start", {
+			resolveHostname: async (hostname) =>
+				hostname === "private.example.test" ? ["10.0.0.2"] : ["93.184.216.34"],
+			fetch: async (url) => {
+				fetched.push(url);
+				return response({
+					status: 302,
+					statusText: "Found",
+					url,
+					headers: {
+						get: (name: string) =>
+							name.toLowerCase() === "location"
+								? "http://private.example.test/secret"
+								: null,
+					},
+				});
+			},
+		});
+
+		assert.equal(result.verdict, "blocked");
+		assert.ok(result.signals.includes("unsafe-address"));
+		assert.deepEqual(fetched, ["https://example.test/start"]);
 	});
 });

--- a/src/url-reader/__tests__/url-reader.test.ts
+++ b/src/url-reader/__tests__/url-reader.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { type FetchLikeResponse, readUrl } from "../index.js";
+
+function streamFrom(text: string): ReadableStream<Uint8Array> {
+	return new ReadableStream({
+		start(controller) {
+			controller.enqueue(new TextEncoder().encode(text));
+			controller.close();
+		},
+	});
+}
+
+function response(
+	overrides: Partial<FetchLikeResponse> & { bodyText?: string },
+): FetchLikeResponse {
+	return {
+		status: overrides.status ?? 200,
+		statusText: overrides.statusText ?? "OK",
+		url: overrides.url ?? "https://example.test/",
+		redirected: overrides.redirected ?? false,
+		body: overrides.body ?? streamFrom(overrides.bodyText ?? ""),
+		headers: overrides.headers ?? {
+			get: (name: string) =>
+				name.toLowerCase() === "content-type"
+					? "text/html; charset=utf-8"
+					: null,
+		},
+	};
+}
+
+describe("readUrl", () => {
+	it("returns ok with title and snippet for reachable HTML", async () => {
+		const result = await readUrl("https://example.test/page", {
+			fetch: async () =>
+				response({
+					url: "https://example.test/page",
+					bodyText:
+						"<html><head><title>Example &amp; Demo</title><script>ignore()</script></head><body><h1>Hello world</h1></body></html>",
+				}),
+		});
+
+		assert.equal(result.verdict, "ok");
+		assert.equal(result.status, 200);
+		assert.equal(result.title, "Example & Demo");
+		assert.match(result.snippet ?? "", /Hello world/);
+		assert.doesNotMatch(result.snippet ?? "", /ignore/);
+	});
+
+	it("classifies challenge-like responses as blocked", async () => {
+		const result = await readUrl("https://example.test/protected", {
+			fetch: async () =>
+				response({
+					status: 403,
+					statusText: "Forbidden",
+					bodyText:
+						"<title>Just a moment...</title><body>Verify you are human before continuing.</body>",
+				}),
+		});
+
+		assert.equal(result.verdict, "blocked");
+		assert.equal(result.status, 403);
+		assert.ok(result.signals.includes("status-403"));
+		assert.ok(result.signals.includes("just-a-moment-marker"));
+		assert.ok(result.signals.includes("human-verification-marker"));
+	});
+
+	it("returns safe error details when fetch fails", async () => {
+		const error = Object.assign(
+			new Error("connection refused token=redacted"),
+			{ code: "ECONNREFUSED" },
+		);
+		const result = await readUrl("https://example.test/fail", {
+			fetch: async () => {
+				throw error;
+			},
+		});
+
+		assert.equal(result.verdict, "error");
+		assert.equal(result.status, null);
+		assert.equal(result.error?.name, "Error");
+		assert.equal(result.error?.code, "ECONNREFUSED");
+		assert.doesNotMatch(JSON.stringify(result.error), /stack/i);
+	});
+
+	it("reports redirects with final URL and readable metadata", async () => {
+		const result = await readUrl("https://example.test/start", {
+			fetch: async () =>
+				response({
+					url: "https://example.test/final",
+					redirected: true,
+					bodyText: "<title>Final</title><body>Final content</body>",
+				}),
+		});
+
+		assert.equal(result.verdict, "redirect");
+		assert.equal(result.redirected, true);
+		assert.equal(result.final_url, "https://example.test/final");
+		assert.equal(result.title, "Final");
+	});
+
+	it("caps streamed body reads before decoding", async () => {
+		let cancelCalled = false;
+		const body = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				controller.enqueue(new TextEncoder().encode("x".repeat(1024)));
+			},
+			cancel() {
+				cancelCalled = true;
+			},
+		});
+
+		const result = await readUrl("https://example.test/large", {
+			maxBytes: 128,
+			fetch: async () =>
+				response({
+					url: "https://example.test/large",
+					body,
+					bodyText: undefined,
+				}),
+		});
+
+		assert.equal(result.verdict, "ok");
+		assert.equal(result.truncated, true);
+		assert.equal(result.bytes_read, 128);
+		assert.equal(result.snippet?.length, 128);
+		assert.equal(cancelCalled, true);
+	});
+
+	it("rejects unsupported protocols with an error verdict", async () => {
+		const result = await readUrl("file:///tmp/example");
+
+		assert.equal(result.verdict, "error");
+		assert.equal(result.error?.name, "UnsupportedProtocolError");
+	});
+});

--- a/src/url-reader/__tests__/url-reader.test.ts
+++ b/src/url-reader/__tests__/url-reader.test.ts
@@ -33,11 +33,11 @@ describe("readUrl", () => {
 	const publicResolver = async () => ["93.184.216.34"];
 
 	it("returns ok with title and snippet for reachable HTML", async () => {
-		const result = await readUrl("https://example.test/page", {
+		const result = await readUrl("http://example.test/page", {
 			resolveHostname: publicResolver,
 			fetch: async () =>
 				response({
-					url: "https://example.test/page",
+					url: "http://example.test/page",
 					bodyText:
 						"<html><head><title>Example &amp; Demo</title><script>ignore()</script></head><body><h1>Hello world</h1></body></html>",
 				}),
@@ -51,7 +51,7 @@ describe("readUrl", () => {
 	});
 
 	it("classifies challenge-like responses as blocked", async () => {
-		const result = await readUrl("https://example.test/protected", {
+		const result = await readUrl("http://example.test/protected", {
 			resolveHostname: publicResolver,
 			fetch: async () =>
 				response({
@@ -74,7 +74,7 @@ describe("readUrl", () => {
 			new Error("connection refused token=redacted"),
 			{ code: "ECONNREFUSED" },
 		);
-		const result = await readUrl("https://example.test/fail", {
+		const result = await readUrl("http://example.test/fail", {
 			resolveHostname: publicResolver,
 			fetch: async () => {
 				throw error;
@@ -89,11 +89,11 @@ describe("readUrl", () => {
 	});
 
 	it("reports redirects with final URL and readable metadata", async () => {
-		const result = await readUrl("https://example.test/start", {
+		const result = await readUrl("http://example.test/start", {
 			resolveHostname: publicResolver,
 			fetch: async () =>
 				response({
-					url: "https://example.test/final",
+					url: "http://example.test/final",
 					redirected: true,
 					bodyText: "<title>Final</title><body>Final content</body>",
 				}),
@@ -101,7 +101,7 @@ describe("readUrl", () => {
 
 		assert.equal(result.verdict, "redirect");
 		assert.equal(result.redirected, true);
-		assert.equal(result.final_url, "https://example.test/final");
+		assert.equal(result.final_url, "http://example.test/final");
 		assert.equal(result.title, "Final");
 	});
 
@@ -116,12 +116,12 @@ describe("readUrl", () => {
 			},
 		});
 
-		const result = await readUrl("https://example.test/large", {
+		const result = await readUrl("http://example.test/large", {
 			resolveHostname: publicResolver,
 			maxBytes: 128,
 			fetch: async () =>
 				response({
-					url: "https://example.test/large",
+					url: "http://example.test/large",
 					body,
 					bodyText: undefined,
 				}),
@@ -230,7 +230,7 @@ describe("readUrl", () => {
 
 	it("blocks hostnames that resolve to private addresses", async () => {
 		let fetched = false;
-		const result = await readUrl("https://internal.example.test/", {
+		const result = await readUrl("http://internal.example.test/", {
 			resolveHostname: async () => ["192.168.1.10"],
 			fetch: async () => {
 				fetched = true;
@@ -248,7 +248,7 @@ describe("readUrl", () => {
 
 		for (const address of unsafeAddresses) {
 			let fetched = false;
-			const result = await readUrl("https://internal-v6.example.test/", {
+			const result = await readUrl("http://internal-v6.example.test/", {
 				resolveHostname: async () => [address],
 				fetch: async () => {
 					fetched = true;
@@ -262,9 +262,111 @@ describe("readUrl", () => {
 		}
 	});
 
+
+	it("pins HTTP hostname fetches to the resolved public address and preserves Host", async () => {
+		const fetched: Array<{ url: string; host: string | undefined }> = [];
+		const result = await readUrl("http://example.test:8080/page", {
+			resolveHostname: async () => ["93.184.216.34"],
+			fetch: async (url, init) => {
+				fetched.push({
+					url,
+					host: (init?.headers as Record<string, string> | undefined)?.host,
+				});
+				return response({
+					url: "http://example.test:8080/page",
+					bodyText: "<title>Pinned</title>",
+				});
+			},
+		});
+
+		assert.equal(result.verdict, "ok");
+		assert.deepEqual(fetched, [
+			{ url: "http://93.184.216.34:8080/page", host: "example.test:8080" },
+		]);
+	});
+
+	it("prevents DNS rebinding by never fetching the original HTTP hostname", async () => {
+		let resolveCount = 0;
+		const fetched: string[] = [];
+		const result = await readUrl("http://rebind.example.test/path", {
+			resolveHostname: async () => {
+				resolveCount += 1;
+				return resolveCount === 1 ? ["93.184.216.34"] : ["127.0.0.1"];
+			},
+			fetch: async (url) => {
+				fetched.push(url);
+				assert.notEqual(new URL(url).hostname, "rebind.example.test");
+				return response({ url: "http://rebind.example.test/path", bodyText: "safe" });
+			},
+		});
+
+		assert.equal(result.verdict, "ok");
+		assert.equal(resolveCount, 1);
+		assert.deepEqual(fetched, ["http://93.184.216.34/path"]);
+	});
+
+	it("pins redirect HTTP hostname fetches to the resolved public address", async () => {
+		const fetched: string[] = [];
+		const result = await readUrl("http://example.test/start", {
+			resolveHostname: async (hostname) =>
+				hostname === "redirect.example.test" ? ["93.184.216.35"] : ["93.184.216.34"],
+			fetch: async (url) => {
+				fetched.push(url);
+				if (fetched.length === 1) {
+					return response({
+						status: 302,
+						statusText: "Found",
+						url,
+						headers: {
+							get: (name: string) =>
+								name.toLowerCase() === "location"
+									? "http://redirect.example.test/final"
+									: null,
+						},
+					});
+				}
+				return response({ url: "http://redirect.example.test/final", bodyText: "final" });
+			},
+		});
+
+		assert.equal(result.verdict, "redirect");
+		assert.deepEqual(fetched, [
+			"http://93.184.216.34/start",
+			"http://93.184.216.35/final",
+		]);
+	});
+
+	it("blocks HTTPS hostname targets because this runtime cannot safely pin TLS/SNI", async () => {
+		let fetched = false;
+		const result = await readUrl("https://example.test/", {
+			resolveHostname: async () => ["93.184.216.34"],
+			fetch: async () => {
+				fetched = true;
+				return response({});
+			},
+		});
+
+		assert.equal(result.verdict, "blocked");
+		assert.ok(result.signals.includes("https-hostname-not-pinned"));
+		assert.equal(fetched, false);
+	});
+
+	it("still allows direct public IP HTTPS targets", async () => {
+		const fetched: string[] = [];
+		const result = await readUrl("https://93.184.216.34/", {
+			fetch: async (url) => {
+				fetched.push(url);
+				return response({ url, bodyText: "ip" });
+			},
+		});
+
+		assert.equal(result.verdict, "ok");
+		assert.deepEqual(fetched, ["https://93.184.216.34/"]);
+	});
+
 	it("blocks redirects to localhost before following", async () => {
 		const fetched: string[] = [];
-		const result = await readUrl("https://example.test/start", {
+		const result = await readUrl("http://example.test/start", {
 			resolveHostname: publicResolver,
 			fetch: async (url) => {
 				fetched.push(url);
@@ -282,12 +384,12 @@ describe("readUrl", () => {
 
 		assert.equal(result.verdict, "blocked");
 		assert.ok(result.signals.includes("localhost-name"));
-		assert.deepEqual(fetched, ["https://example.test/start"]);
+		assert.deepEqual(fetched, ["http://93.184.216.34/start"]);
 	});
 
 	it("blocks redirects to private targets before following", async () => {
 		const fetched: string[] = [];
-		const result = await readUrl("https://example.test/start", {
+		const result = await readUrl("http://example.test/start", {
 			resolveHostname: async (hostname) =>
 				hostname === "private.example.test" ? ["10.0.0.2"] : ["93.184.216.34"],
 			fetch: async (url) => {
@@ -308,7 +410,7 @@ describe("readUrl", () => {
 
 		assert.equal(result.verdict, "blocked");
 		assert.ok(result.signals.includes("unsafe-address"));
-		assert.deepEqual(fetched, ["https://example.test/start"]);
+		assert.deepEqual(fetched, ["http://93.184.216.34/start"]);
 	});
 
 	it("blocks redirects to unsafe IPv6 literal targets before following", async () => {
@@ -320,7 +422,7 @@ describe("readUrl", () => {
 
 		for (const target of redirectTargets) {
 			const fetched: string[] = [];
-			const result = await readUrl("https://example.test/start", {
+			const result = await readUrl("http://example.test/start", {
 				resolveHostname: publicResolver,
 				fetch: async (url) => {
 					fetched.push(url);
@@ -338,7 +440,7 @@ describe("readUrl", () => {
 
 			assert.equal(result.verdict, "blocked", target);
 			assert.ok(result.signals.includes("unsafe-address"), target);
-			assert.deepEqual(fetched, ["https://example.test/start"], target);
+			assert.deepEqual(fetched, ["http://93.184.216.34/start"], target);
 		}
 	});
 
@@ -347,7 +449,7 @@ describe("readUrl", () => {
 
 		for (const address of unsafeAddresses) {
 			const fetched: string[] = [];
-			const result = await readUrl("https://example.test/start", {
+			const result = await readUrl("http://example.test/start", {
 				resolveHostname: async (hostname) =>
 					hostname === "unsafe-v6.example.test" ? [address] : ["93.184.216.34"],
 				fetch: async (url) => {
@@ -368,7 +470,7 @@ describe("readUrl", () => {
 
 			assert.equal(result.verdict, "blocked", address);
 			assert.ok(result.signals.includes("unsafe-address"), address);
-			assert.deepEqual(fetched, ["https://example.test/start"], address);
+			assert.deepEqual(fetched, ["http://93.184.216.34/start"], address);
 		}
 	});
 });

--- a/src/url-reader/__tests__/url-reader.test.ts
+++ b/src/url-reader/__tests__/url-reader.test.ts
@@ -175,6 +175,41 @@ describe("readUrl", () => {
 		assert.ok(result.signals.includes("unsafe-address"));
 	});
 
+	it("blocks unsafe IPv6 literals before fetch", async () => {
+		const unsafeUrls = [
+			"http://[::]/secret",
+			"http://[fc00::1]/secret",
+			"http://[fd12:3456:789a::1]/secret",
+			"http://[fe80::1]/secret",
+			"http://[ff02::1]/secret",
+			"http://[::ffff:10.0.0.5]/secret",
+			"http://[::ffff:127.0.0.1]/secret",
+			"http://[::ffff:169.254.169.254]/secret",
+		];
+
+		for (const url of unsafeUrls) {
+			let fetched = false;
+			const result = await readUrl(url, {
+				fetch: async () => {
+					fetched = true;
+					return response({});
+				},
+			});
+
+			assert.equal(result.verdict, "blocked", url);
+			assert.ok(result.signals.includes("unsafe-address"), url);
+			assert.equal(fetched, false, url);
+		}
+	});
+
+	it("allows public IPv6 literals", async () => {
+		const result = await readUrl("http://[2606:4700:4700::1111]/", {
+			fetch: async () => response({ url: "http://[2606:4700:4700::1111]/" }),
+		});
+
+		assert.equal(result.verdict, "ok");
+	});
+
 	it("blocks private IPv4 before fetch", async () => {
 		const result = await readUrl("http://10.0.0.5/metadata", {
 			fetch: async () => response({}),
@@ -206,6 +241,25 @@ describe("readUrl", () => {
 		assert.equal(result.verdict, "blocked");
 		assert.ok(result.signals.includes("unsafe-address"));
 		assert.equal(fetched, false);
+	});
+
+	it("blocks hostnames that resolve to unsafe IPv6 addresses", async () => {
+		const unsafeAddresses = ["fc00::1", "fd12:3456:789a::1", "fe80::1", "ff02::1"];
+
+		for (const address of unsafeAddresses) {
+			let fetched = false;
+			const result = await readUrl("https://internal-v6.example.test/", {
+				resolveHostname: async () => [address],
+				fetch: async () => {
+					fetched = true;
+					return response({});
+				},
+			});
+
+			assert.equal(result.verdict, "blocked", address);
+			assert.ok(result.signals.includes("unsafe-address"), address);
+			assert.equal(fetched, false, address);
+		}
 	});
 
 	it("blocks redirects to localhost before following", async () => {
@@ -255,5 +309,66 @@ describe("readUrl", () => {
 		assert.equal(result.verdict, "blocked");
 		assert.ok(result.signals.includes("unsafe-address"));
 		assert.deepEqual(fetched, ["https://example.test/start"]);
+	});
+
+	it("blocks redirects to unsafe IPv6 literal targets before following", async () => {
+		const redirectTargets = [
+			"http://[fc00::1]/secret",
+			"http://[fe80::1]/secret",
+			"http://[ff02::1]/secret",
+		];
+
+		for (const target of redirectTargets) {
+			const fetched: string[] = [];
+			const result = await readUrl("https://example.test/start", {
+				resolveHostname: publicResolver,
+				fetch: async (url) => {
+					fetched.push(url);
+					return response({
+						status: 302,
+						statusText: "Found",
+						url,
+						headers: {
+							get: (name: string) =>
+								name.toLowerCase() === "location" ? target : null,
+						},
+					});
+				},
+			});
+
+			assert.equal(result.verdict, "blocked", target);
+			assert.ok(result.signals.includes("unsafe-address"), target);
+			assert.deepEqual(fetched, ["https://example.test/start"], target);
+		}
+	});
+
+	it("blocks redirects to hostnames resolving to unsafe IPv6 before following", async () => {
+		const unsafeAddresses = ["fc00::1", "fe80::1", "ff02::1"];
+
+		for (const address of unsafeAddresses) {
+			const fetched: string[] = [];
+			const result = await readUrl("https://example.test/start", {
+				resolveHostname: async (hostname) =>
+					hostname === "unsafe-v6.example.test" ? [address] : ["93.184.216.34"],
+				fetch: async (url) => {
+					fetched.push(url);
+					return response({
+						status: 302,
+						statusText: "Found",
+						url,
+						headers: {
+							get: (name: string) =>
+								name.toLowerCase() === "location"
+									? "http://unsafe-v6.example.test/secret"
+									: null,
+						},
+					});
+				},
+			});
+
+			assert.equal(result.verdict, "blocked", address);
+			assert.ok(result.signals.includes("unsafe-address"), address);
+			assert.deepEqual(fetched, ["https://example.test/start"], address);
+		}
 	});
 });

--- a/src/url-reader/index.ts
+++ b/src/url-reader/index.ts
@@ -341,11 +341,17 @@ function isSafeIpv6(address: string): boolean {
 	if (ipv4Mapped) return isSafeIpv4(ipv4Mapped);
 
 	if (value === 0n || value === 1n) return false;
+	if (inIpv6Range(value, ipv6Prefix("64:ff9b:1::"), 48)) return false; // local-use IPv4/IPv6 translation
+	if (inIpv6Range(value, ipv6Prefix("100::"), 64)) return false; // discard-only
+	if (inIpv6Range(value, ipv6Prefix("100:0:0:1::"), 64)) return false; // dummy prefix
+	if (inIpv6Range(value, ipv6Prefix("2001::"), 23)) return false; // IETF protocol assignments
+	if (inIpv6Range(value, ipv6Prefix("2001:db8::"), 32)) return false; // documentation/reserved
+	if (inIpv6Range(value, ipv6Prefix("2002::"), 16)) return false; // 6to4 transition addresses
+	if (inIpv6Range(value, ipv6Prefix("3fff::"), 20)) return false; // documentation/reserved
+	if (inIpv6Range(value, ipv6Prefix("5f00::"), 16)) return false; // segment routing SIDs
 	if (inIpv6Range(value, ipv6Prefix("fc00::"), 7)) return false; // unique local
 	if (inIpv6Range(value, ipv6Prefix("fe80::"), 10)) return false; // link local
 	if (inIpv6Range(value, ipv6Prefix("ff00::"), 8)) return false; // multicast
-	if (inIpv6Range(value, ipv6Prefix("2001:db8::"), 32)) return false; // documentation/reserved
-	if (inIpv6Range(value, ipv6Prefix("2001::"), 23)) return false; // IETF protocol assignments
 	return true;
 }
 

--- a/src/url-reader/index.ts
+++ b/src/url-reader/index.ts
@@ -1,0 +1,292 @@
+import type {
+	FetchLike,
+	FetchLikeResponse,
+	UrlReadError,
+	UrlReaderOptions,
+	UrlReadResult,
+	UrlReadVerdict,
+} from "./types.js";
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_BYTES = 256 * 1024;
+const USER_AGENT = "oh-my-codex-url-reader/0";
+
+const BLOCKED_STATUS_CODES = new Set([401, 403, 407, 423, 429, 451, 503]);
+const TEXT_CONTENT_TYPES = [
+	"text/",
+	"application/json",
+	"application/xml",
+	"application/xhtml+xml",
+	"application/rss+xml",
+	"application/atom+xml",
+	"application/ld+json",
+];
+
+const CHALLENGE_MARKERS: Array<[RegExp, string]> = [
+	[/captcha/i, "captcha-marker"],
+	[/cloudflare|cf-chl|cf_clearance/i, "cloudflare-marker"],
+	[/access denied/i, "access-denied-marker"],
+	[/just a moment/i, "just-a-moment-marker"],
+	[/verify\s+you\s+are\s+human/i, "human-verification-marker"],
+	[/bot\s+detection|automated\s+traffic/i, "bot-detection-marker"],
+	[/\bblocked\b/i, "blocked-marker"],
+	[/\bchallenge\b/i, "challenge-marker"],
+];
+
+export type {
+	FetchLike,
+	FetchLikeResponse,
+	UrlReadError,
+	UrlReaderOptions,
+	UrlReadResult,
+	UrlReadVerdict,
+};
+
+export async function readUrl(
+	inputUrl: string,
+	options: UrlReaderOptions = {},
+): Promise<UrlReadResult> {
+	const normalizedInput = inputUrl.trim();
+	const fetchImpl =
+		options.fetch ?? (globalThis.fetch as unknown as FetchLike | undefined);
+	const timeoutMs = normalizePositiveInteger(
+		options.timeoutMs,
+		DEFAULT_TIMEOUT_MS,
+	);
+	const maxBytes = normalizePositiveInteger(
+		options.maxBytes,
+		DEFAULT_MAX_BYTES,
+	);
+
+	let parsed: URL;
+	try {
+		parsed = new URL(normalizedInput);
+	} catch (error) {
+		return errorResult(normalizedInput, normalizeError(error));
+	}
+
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+		return errorResult(normalizedInput, {
+			name: "UnsupportedProtocolError",
+			message: `Unsupported URL protocol: ${parsed.protocol}`,
+		});
+	}
+
+	if (!fetchImpl) {
+		return errorResult(normalizedInput, {
+			name: "FetchUnavailableError",
+			message: "No fetch implementation is available in this runtime.",
+		});
+	}
+
+	try {
+		const response = await fetchImpl(parsed.toString(), {
+			method: "GET",
+			redirect: "follow",
+			signal: AbortSignal.timeout(timeoutMs),
+			headers: {
+				"user-agent": USER_AGENT,
+				accept:
+					"text/html,application/xhtml+xml,application/xml;q=0.9,application/json;q=0.8,text/plain;q=0.7,*/*;q=0.1",
+			},
+		});
+		return await resultFromResponse(normalizedInput, response, maxBytes);
+	} catch (error) {
+		return errorResult(normalizedInput, normalizeError(error));
+	}
+}
+
+async function resultFromResponse(
+	inputUrl: string,
+	response: FetchLikeResponse,
+	maxBytes: number,
+): Promise<UrlReadResult> {
+	const contentType = response.headers.get("content-type");
+	const read = await readBoundedBody(response, maxBytes);
+	const text = decodeBody(read.bytes, contentType);
+	const signals = classifySignals(response, text);
+	const redirected = response.redirected || urlsDiffer(inputUrl, response.url);
+	const verdict: UrlReadVerdict =
+		signals.length > 0 ? "blocked" : redirected ? "redirect" : "ok";
+	const textLike = isTextLike(contentType);
+
+	return {
+		input_url: inputUrl,
+		final_url: response.url || inputUrl,
+		verdict,
+		status: response.status,
+		status_text: response.statusText || null,
+		content_type: contentType,
+		redirected,
+		title: textLike ? extractTitle(text) : null,
+		snippet: textLike ? buildSnippet(text) : null,
+		signals,
+		truncated: read.truncated,
+		bytes_read: read.bytesRead,
+		error: null,
+	};
+}
+
+async function readBoundedBody(
+	response: FetchLikeResponse,
+	maxBytes: number,
+): Promise<{ bytes: Uint8Array; bytesRead: number; truncated: boolean }> {
+	if (!response.body) {
+		return { bytes: new Uint8Array(), bytesRead: 0, truncated: false };
+	}
+
+	const reader = response.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let bytesRead = 0;
+	let truncated = false;
+
+	try {
+		while (bytesRead < maxBytes) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (!value || value.byteLength === 0) continue;
+			const remaining = maxBytes - bytesRead;
+			if (value.byteLength > remaining) {
+				chunks.push(value.slice(0, remaining));
+				bytesRead += remaining;
+				truncated = true;
+				break;
+			}
+			chunks.push(value);
+			bytesRead += value.byteLength;
+		}
+
+		if (bytesRead >= maxBytes) truncated = true;
+	} finally {
+		if (truncated) {
+			await reader.cancel().catch(() => undefined);
+		} else {
+			reader.releaseLock();
+		}
+	}
+
+	const bytes = new Uint8Array(bytesRead);
+	let offset = 0;
+	for (const chunk of chunks) {
+		bytes.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+
+	return { bytes, bytesRead, truncated };
+}
+
+function classifySignals(response: FetchLikeResponse, text: string): string[] {
+	const signals = new Set<string>();
+	if (BLOCKED_STATUS_CODES.has(response.status)) {
+		signals.add(`status-${response.status}`);
+	}
+	for (const [pattern, signal] of CHALLENGE_MARKERS) {
+		if (pattern.test(text)) signals.add(signal);
+	}
+	return [...signals];
+}
+
+function decodeBody(bytes: Uint8Array, contentType: string | null): string {
+	if (bytes.byteLength === 0) return "";
+	const charset = /charset=([^;]+)/i.exec(contentType ?? "")?.[1]?.trim();
+	try {
+		return new TextDecoder(charset || "utf-8", { fatal: false }).decode(bytes);
+	} catch {
+		return new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+	}
+}
+
+function extractTitle(text: string): string | null {
+	const match = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(text);
+	if (!match) return null;
+	const title = decodeHtmlEntities(stripTags(match[1]))
+		.replace(/\s+/g, " ")
+		.trim();
+	return title === "" ? null : title.slice(0, 200);
+}
+
+function buildSnippet(text: string): string | null {
+	const withoutScripts = text
+		.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+		.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ");
+	const normalized = decodeHtmlEntities(stripTags(withoutScripts))
+		.replace(/\s+/g, " ")
+		.trim();
+	if (normalized === "") return null;
+	return normalized.slice(0, 500);
+}
+
+function stripTags(text: string): string {
+	return text.replace(/<[^>]+>/g, " ");
+}
+
+function decodeHtmlEntities(text: string): string {
+	return text
+		.replace(/&nbsp;/gi, " ")
+		.replace(/&amp;/gi, "&")
+		.replace(/&lt;/gi, "<")
+		.replace(/&gt;/gi, ">")
+		.replace(/&quot;/gi, '"')
+		.replace(/&#39;/g, "'");
+}
+
+function isTextLike(contentType: string | null): boolean {
+	if (!contentType) return true;
+	const normalized = contentType.toLowerCase();
+	return TEXT_CONTENT_TYPES.some(
+		(prefix) => normalized.startsWith(prefix) || normalized.includes(prefix),
+	);
+}
+
+function urlsDiffer(inputUrl: string, finalUrl: string): boolean {
+	if (!finalUrl) return false;
+	try {
+		return new URL(inputUrl).toString() !== new URL(finalUrl).toString();
+	} catch {
+		return inputUrl !== finalUrl;
+	}
+}
+
+function normalizePositiveInteger(
+	value: number | undefined,
+	fallback: number,
+): number {
+	return typeof value === "number" && Number.isInteger(value) && value > 0
+		? value
+		: fallback;
+}
+
+function normalizeError(error: unknown): UrlReadError {
+	if (error instanceof Error) {
+		const errorWithCode = error as Error & { code?: unknown };
+		const code =
+			typeof errorWithCode.code === "string" ? errorWithCode.code : undefined;
+		return {
+			name: error.name || "Error",
+			message: error.message || "URL read failed.",
+			...(code ? { code } : {}),
+		};
+	}
+	return {
+		name: "Error",
+		message: typeof error === "string" ? error : "URL read failed.",
+	};
+}
+
+function errorResult(inputUrl: string, error: UrlReadError): UrlReadResult {
+	return {
+		input_url: inputUrl,
+		final_url: null,
+		verdict: "error",
+		status: null,
+		status_text: null,
+		content_type: null,
+		redirected: false,
+		title: null,
+		snippet: null,
+		signals: [],
+		truncated: false,
+		bytes_read: 0,
+		error,
+	};
+}

--- a/src/url-reader/index.ts
+++ b/src/url-reader/index.ts
@@ -13,6 +13,8 @@ const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_MAX_BYTES = 256 * 1024;
 const DEFAULT_MAX_REDIRECTS = 10;
 const USER_AGENT = "oh-my-codex-url-reader/0";
+const DEFAULT_HTTP_PORT = "80";
+const DEFAULT_HTTPS_PORT = "443";
 
 const BLOCKED_STATUS_CODES = new Set([401, 403, 407, 423, 429, 451, 503]);
 const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
@@ -74,9 +76,6 @@ export async function readUrl(
 		return errorResult(normalizedInput, normalizeError(error));
 	}
 
-	const unsafeInput = await validateSafeUrl(parsed, options);
-	if (unsafeInput) return unsafeInput;
-
 	if (!fetchImpl) {
 		return errorResult(normalizedInput, {
 			name: "FetchUnavailableError",
@@ -118,23 +117,19 @@ async function fetchWithSafeRedirects(
 	let redirected = false;
 
 	for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount += 1) {
-		const unsafe = await validateSafeUrl(
+		const safeTarget = await prepareSafeFetchTarget(
 			currentUrl,
 			options,
 			redirected,
 			initialUrl.toString(),
 		);
-		if (unsafe) return { blocked: unsafe };
+		if ("blocked" in safeTarget) return { blocked: safeTarget.blocked };
 
-		const response = await fetchImpl(currentUrl.toString(), {
+		const response = await fetchImpl(safeTarget.fetchUrl.toString(), {
 			method: "GET",
 			redirect: "manual",
 			signal: AbortSignal.timeout(timeoutMs),
-			headers: {
-				"user-agent": USER_AGENT,
-				accept:
-					"text/html,application/xhtml+xml,application/xml;q=0.9,application/json;q=0.8,text/plain;q=0.7,*/*;q=0.1",
-			},
+			headers: safeTarget.headers,
 		});
 
 		if (!REDIRECT_STATUS_CODES.has(response.status)) {
@@ -156,13 +151,13 @@ async function fetchWithSafeRedirects(
 			};
 		}
 
-		const unsafeRedirect = await validateSafeUrl(
+		const unsafeRedirect = await prepareSafeFetchTarget(
 			nextUrl,
 			options,
 			true,
 			initialUrl.toString(),
 		);
-		if (unsafeRedirect) return { blocked: unsafeRedirect };
+		if ("blocked" in unsafeRedirect) return { blocked: unsafeRedirect.blocked };
 		currentUrl = nextUrl;
 		redirected = true;
 	}
@@ -175,56 +170,124 @@ async function fetchWithSafeRedirects(
 	};
 }
 
-async function validateSafeUrl(
+interface SafeFetchTarget {
+	fetchUrl: URL;
+	headers: Record<string, string>;
+}
+
+async function prepareSafeFetchTarget(
 	url: URL,
 	options: UrlReaderOptions,
 	redirect = false,
 	inputUrl = url.toString(),
-): Promise<UrlReadResult | null> {
+): Promise<SafeFetchTarget | { blocked: UrlReadResult }> {
+	const validation = await validateAndResolveSafeUrl(url, options, redirect, inputUrl);
+	if ("blocked" in validation) return validation;
+
+	const hostname = normalizeHostname(url.hostname);
+	const ipVersion = isIP(hostname);
+	const headers = defaultFetchHeaders();
+
+	if (ipVersion !== 0) {
+		return { fetchUrl: url, headers };
+	}
+
+	if (url.protocol === "https:") {
+		return {
+			blocked: blockedResult(inputUrl, "https-hostname-not-pinned", {
+				name: "UnsafeUrlError",
+				message: redirect
+					? "Blocked URL redirect because HTTPS hostname targets cannot be connection-pinned safely in this runtime."
+					: "Blocked URL read because HTTPS hostname targets cannot be connection-pinned safely in this runtime.",
+			}),
+		};
+	}
+
+	const fetchUrl = new URL(url.toString());
+	fetchUrl.hostname = formatHostnameForUrl(validation.address);
+	headers.host = originalHttpHostHeader(url);
+	return { fetchUrl, headers };
+}
+
+async function validateAndResolveSafeUrl(
+	url: URL,
+	options: UrlReaderOptions,
+	redirect = false,
+	inputUrl = url.toString(),
+): Promise<{ address: string } | { blocked: UrlReadResult }> {
 	if (url.protocol !== "http:" && url.protocol !== "https:") {
-		return blockedResult(inputUrl, "unsupported-protocol", {
-			name: "UnsupportedProtocolError",
-			message: `Blocked URL read because protocol ${url.protocol} is not supported.`,
-		});
+		return {
+			blocked: blockedResult(inputUrl, "unsupported-protocol", {
+				name: "UnsupportedProtocolError",
+				message: `Blocked URL read because protocol ${url.protocol} is not supported.`,
+			}),
+		};
 	}
 
 	const hostname = normalizeHostname(url.hostname);
 	if (isLocalhostName(hostname)) {
-		return blockedResult(inputUrl, "localhost-name", {
-			name: "UnsafeUrlError",
-			message: redirect
-				? "Blocked URL redirect to a local hostname."
-				: "Blocked URL read for a local hostname.",
-		});
+		return {
+			blocked: blockedResult(inputUrl, "localhost-name", {
+				name: "UnsafeUrlError",
+				message: redirect
+					? "Blocked URL redirect to a local hostname."
+					: "Blocked URL read for a local hostname.",
+			}),
+		};
 	}
 
 	let addresses: string[];
 	try {
 		addresses = await resolveHostname(hostname, options);
 	} catch {
-		return blockedResult(inputUrl, "dns-resolution-failed", {
-			name: "DnsResolutionError",
-			message: "Blocked URL read because the hostname could not be resolved safely.",
-		});
+		return {
+			blocked: blockedResult(inputUrl, "dns-resolution-failed", {
+				name: "DnsResolutionError",
+				message: "Blocked URL read because the hostname could not be resolved safely.",
+			}),
+		};
 	}
 
 	if (addresses.length === 0) {
-		return blockedResult(inputUrl, "dns-resolution-empty", {
-			name: "DnsResolutionError",
-			message: "Blocked URL read because the hostname did not resolve to an address.",
-		});
+		return {
+			blocked: blockedResult(inputUrl, "dns-resolution-empty", {
+				name: "DnsResolutionError",
+				message: "Blocked URL read because the hostname did not resolve to an address.",
+			}),
+		};
 	}
 
 	if (addresses.some((address) => !isSafeIpAddress(address))) {
-		return blockedResult(inputUrl, "unsafe-address", {
-			name: "UnsafeUrlError",
-			message: redirect
-				? "Blocked URL redirect because the target resolves to an unsafe network address."
-				: "Blocked URL read because the target resolves to an unsafe network address.",
-		});
+		return {
+			blocked: blockedResult(inputUrl, "unsafe-address", {
+				name: "UnsafeUrlError",
+				message: redirect
+					? "Blocked URL redirect because the target resolves to an unsafe network address."
+					: "Blocked URL read because the target resolves to an unsafe network address.",
+			}),
+		};
 	}
 
-	return null;
+	return { address: addresses[0] };
+}
+
+function defaultFetchHeaders(): Record<string, string> {
+	return {
+		"user-agent": USER_AGENT,
+		accept:
+			"text/html,application/xhtml+xml,application/xml;q=0.9,application/json;q=0.8,text/plain;q=0.7,*/*;q=0.1",
+	};
+}
+
+function originalHttpHostHeader(url: URL): string {
+	const hostname = normalizeHostname(url.hostname);
+	const defaultPort = url.protocol === "https:" ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
+	const bracketedHostname = isIP(hostname) === 6 ? `[${hostname}]` : hostname;
+	return url.port && url.port !== defaultPort ? `${bracketedHostname}:${url.port}` : bracketedHostname;
+}
+
+function formatHostnameForUrl(address: string): string {
+	return isIP(address) === 6 ? `[${address}]` : address;
 }
 
 function normalizeHostname(hostname: string): string {

--- a/src/url-reader/index.ts
+++ b/src/url-reader/index.ts
@@ -271,20 +271,30 @@ function isSafeIpv4(address: string): boolean {
 }
 
 function isSafeIpv6(address: string): boolean {
-	const ipv4Mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(address);
-	if (ipv4Mapped) return isSafeIpv4(ipv4Mapped[1]);
 	const value = ipv6ToBigInt(address);
 	if (value === null) return false;
-	if (inIpv6Range(value, 0xffffn << 32n, 96)) {
-		return isSafeIpv4(bigIntToIpv4(value & 0xffffffffn));
-	}
+
+	const ipv4Mapped = ipv4FromIpv6Mapped(value);
+	if (ipv4Mapped) return isSafeIpv4(ipv4Mapped);
+
 	if (value === 0n || value === 1n) return false;
-	if (inIpv6Range(value, 0xfc00n << 120n, 7)) return false; // unique local
-	if (inIpv6Range(value, 0xfe80n << 120n, 10)) return false; // link local
-	if (inIpv6Range(value, 0xff00n << 120n, 8)) return false; // multicast
-	if (inIpv6Range(value, 0x20010db8n << 96n, 32)) return false; // documentation/reserved
-	if (inIpv6Range(value, 0x20010000n << 96n, 23)) return false; // IETF protocol assignments
+	if (inIpv6Range(value, ipv6Prefix("fc00::"), 7)) return false; // unique local
+	if (inIpv6Range(value, ipv6Prefix("fe80::"), 10)) return false; // link local
+	if (inIpv6Range(value, ipv6Prefix("ff00::"), 8)) return false; // multicast
+	if (inIpv6Range(value, ipv6Prefix("2001:db8::"), 32)) return false; // documentation/reserved
+	if (inIpv6Range(value, ipv6Prefix("2001::"), 23)) return false; // IETF protocol assignments
 	return true;
+}
+
+function ipv4FromIpv6Mapped(value: bigint): string | null {
+	if (!inIpv6Range(value, 0xffffn << 32n, 96)) return null;
+	return bigIntToIpv4(value & 0xffffffffn);
+}
+
+function ipv6Prefix(address: string): bigint {
+	const value = ipv6ToBigInt(address);
+	if (value === null) throw new Error(`Invalid IPv6 prefix: ${address}`);
+	return value;
 }
 
 function inIpv6Range(value: bigint, prefixValue: bigint, prefixBits: number): boolean {

--- a/src/url-reader/index.ts
+++ b/src/url-reader/index.ts
@@ -1,3 +1,5 @@
+import { lookup as dnsLookup } from "node:dns/promises";
+import { isIP } from "node:net";
 import type {
 	FetchLike,
 	FetchLikeResponse,
@@ -9,9 +11,12 @@ import type {
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_MAX_BYTES = 256 * 1024;
+const DEFAULT_MAX_REDIRECTS = 10;
 const USER_AGENT = "oh-my-codex-url-reader/0";
 
 const BLOCKED_STATUS_CODES = new Set([401, 403, 407, 423, 429, 451, 503]);
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
+const LOCALHOST_NAMES = new Set(["localhost", "localhost.localdomain"]);
 const TEXT_CONTENT_TYPES = [
 	"text/",
 	"application/json",
@@ -57,6 +62,10 @@ export async function readUrl(
 		options.maxBytes,
 		DEFAULT_MAX_BYTES,
 	);
+	const maxRedirects = normalizePositiveInteger(
+		options.maxRedirects,
+		DEFAULT_MAX_REDIRECTS,
+	);
 
 	let parsed: URL;
 	try {
@@ -65,12 +74,8 @@ export async function readUrl(
 		return errorResult(normalizedInput, normalizeError(error));
 	}
 
-	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-		return errorResult(normalizedInput, {
-			name: "UnsupportedProtocolError",
-			message: `Unsupported URL protocol: ${parsed.protocol}`,
-		});
-	}
+	const unsafeInput = await validateSafeUrl(parsed, options);
+	if (unsafeInput) return unsafeInput;
 
 	if (!fetchImpl) {
 		return errorResult(normalizedInput, {
@@ -80,9 +85,50 @@ export async function readUrl(
 	}
 
 	try {
-		const response = await fetchImpl(parsed.toString(), {
+		const response = await fetchWithSafeRedirects(
+			parsed,
+			fetchImpl,
+			options,
+			timeoutMs,
+			maxRedirects,
+		);
+		if ("blocked" in response) return response.blocked;
+		return await resultFromResponse(
+			normalizedInput,
+			response.response,
+			maxBytes,
+			response.redirected,
+		);
+	} catch (error) {
+		return errorResult(normalizedInput, normalizeError(error));
+	}
+}
+
+async function fetchWithSafeRedirects(
+	initialUrl: URL,
+	fetchImpl: FetchLike,
+	options: UrlReaderOptions,
+	timeoutMs: number,
+	maxRedirects: number,
+): Promise<
+	| { response: FetchLikeResponse; redirected: boolean }
+	| { blocked: UrlReadResult }
+> {
+	let currentUrl = initialUrl;
+	let redirected = false;
+
+	for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount += 1) {
+		const unsafe = await validateSafeUrl(
+			currentUrl,
+			options,
+			redirected,
+			initialUrl.toString(),
+		);
+		if (unsafe) return { blocked: unsafe };
+
+		const response = await fetchImpl(currentUrl.toString(), {
 			method: "GET",
-			redirect: "follow",
+			redirect: "manual",
 			signal: AbortSignal.timeout(timeoutMs),
 			headers: {
 				"user-agent": USER_AGENT,
@@ -90,22 +136,205 @@ export async function readUrl(
 					"text/html,application/xhtml+xml,application/xml;q=0.9,application/json;q=0.8,text/plain;q=0.7,*/*;q=0.1",
 			},
 		});
-		return await resultFromResponse(normalizedInput, response, maxBytes);
-	} catch (error) {
-		return errorResult(normalizedInput, normalizeError(error));
+
+		if (!REDIRECT_STATUS_CODES.has(response.status)) {
+			return { response, redirected: redirected || response.redirected };
+		}
+
+		const location = response.headers.get("location");
+		if (!location) return { response, redirected };
+
+		let nextUrl: URL;
+		try {
+			nextUrl = new URL(location, currentUrl);
+		} catch {
+			return {
+				blocked: blockedResult(currentUrl.toString(), "unsafe-redirect-url", {
+					name: "UnsafeUrlError",
+					message: "Blocked URL redirect because the target URL is invalid.",
+				}),
+			};
+		}
+
+		const unsafeRedirect = await validateSafeUrl(
+			nextUrl,
+			options,
+			true,
+			initialUrl.toString(),
+		);
+		if (unsafeRedirect) return { blocked: unsafeRedirect };
+		currentUrl = nextUrl;
+		redirected = true;
 	}
+
+	return {
+		blocked: blockedResult(initialUrl.toString(), "too-many-redirects", {
+			name: "TooManyRedirectsError",
+			message: "Blocked URL read after too many redirects.",
+		}),
+	};
+}
+
+async function validateSafeUrl(
+	url: URL,
+	options: UrlReaderOptions,
+	redirect = false,
+	inputUrl = url.toString(),
+): Promise<UrlReadResult | null> {
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		return blockedResult(inputUrl, "unsupported-protocol", {
+			name: "UnsupportedProtocolError",
+			message: `Blocked URL read because protocol ${url.protocol} is not supported.`,
+		});
+	}
+
+	const hostname = normalizeHostname(url.hostname);
+	if (isLocalhostName(hostname)) {
+		return blockedResult(inputUrl, "localhost-name", {
+			name: "UnsafeUrlError",
+			message: redirect
+				? "Blocked URL redirect to a local hostname."
+				: "Blocked URL read for a local hostname.",
+		});
+	}
+
+	let addresses: string[];
+	try {
+		addresses = await resolveHostname(hostname, options);
+	} catch {
+		return blockedResult(inputUrl, "dns-resolution-failed", {
+			name: "DnsResolutionError",
+			message: "Blocked URL read because the hostname could not be resolved safely.",
+		});
+	}
+
+	if (addresses.length === 0) {
+		return blockedResult(inputUrl, "dns-resolution-empty", {
+			name: "DnsResolutionError",
+			message: "Blocked URL read because the hostname did not resolve to an address.",
+		});
+	}
+
+	if (addresses.some((address) => !isSafeIpAddress(address))) {
+		return blockedResult(inputUrl, "unsafe-address", {
+			name: "UnsafeUrlError",
+			message: redirect
+				? "Blocked URL redirect because the target resolves to an unsafe network address."
+				: "Blocked URL read because the target resolves to an unsafe network address.",
+		});
+	}
+
+	return null;
+}
+
+function normalizeHostname(hostname: string): string {
+	return hostname.toLowerCase().replace(/^\[(.*)\]$/, "$1").replace(/\.$/, "");
+}
+
+function isLocalhostName(hostname: string): boolean {
+	return LOCALHOST_NAMES.has(hostname) || hostname.endsWith(".localhost");
+}
+
+async function resolveHostname(
+	hostname: string,
+	options: UrlReaderOptions,
+): Promise<string[]> {
+	if (isIP(hostname) !== 0) return [hostname];
+	if (options.resolveHostname) return options.resolveHostname(hostname);
+	const records = await dnsLookup(hostname, { all: true, verbatim: true });
+	return records.map((record) => record.address);
+}
+
+function isSafeIpAddress(address: string): boolean {
+	const normalized = normalizeHostname(address);
+	const version = isIP(normalized);
+	if (version === 4) return isSafeIpv4(normalized);
+	if (version === 6) return isSafeIpv6(normalized);
+	return false;
+}
+
+function isSafeIpv4(address: string): boolean {
+	const parts = address.split(".").map((part) => Number.parseInt(part, 10));
+	if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
+	const [a, b, c] = parts as [number, number, number, number];
+	if (a === 0 || a === 10 || a === 127 || a >= 224) return false;
+	if (a === 100 && b >= 64 && b <= 127) return false;
+	if (a === 169 && b === 254) return false;
+	if (a === 172 && b >= 16 && b <= 31) return false;
+	if (a === 192 && b === 168) return false;
+	if (a === 192 && b === 0) return false;
+	if (a === 192 && b === 88 && c === 99) return false;
+	if (a === 198 && (b === 18 || b === 19)) return false;
+	if (a === 198 && b === 51 && c === 100) return false;
+	if (a === 203 && b === 0 && c === 113) return false;
+	return true;
+}
+
+function isSafeIpv6(address: string): boolean {
+	const ipv4Mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(address);
+	if (ipv4Mapped) return isSafeIpv4(ipv4Mapped[1]);
+	const value = ipv6ToBigInt(address);
+	if (value === null) return false;
+	if (inIpv6Range(value, 0xffffn << 32n, 96)) {
+		return isSafeIpv4(bigIntToIpv4(value & 0xffffffffn));
+	}
+	if (value === 0n || value === 1n) return false;
+	if (inIpv6Range(value, 0xfc00n << 120n, 7)) return false; // unique local
+	if (inIpv6Range(value, 0xfe80n << 120n, 10)) return false; // link local
+	if (inIpv6Range(value, 0xff00n << 120n, 8)) return false; // multicast
+	if (inIpv6Range(value, 0x20010db8n << 96n, 32)) return false; // documentation/reserved
+	if (inIpv6Range(value, 0x20010000n << 96n, 23)) return false; // IETF protocol assignments
+	return true;
+}
+
+function inIpv6Range(value: bigint, prefixValue: bigint, prefixBits: number): boolean {
+	const shift = BigInt(128 - prefixBits);
+	return value >> shift === prefixValue >> shift;
+}
+
+function bigIntToIpv4(value: bigint): string {
+	return [24n, 16n, 8n, 0n]
+		.map((shift) => Number((value >> shift) & 0xffn))
+		.join(".");
+}
+
+function ipv6ToBigInt(address: string): bigint | null {
+	let normalized = address.toLowerCase();
+	const zoneIndex = normalized.indexOf("%");
+	if (zoneIndex >= 0) normalized = normalized.slice(0, zoneIndex);
+	const ipv4Tail = /(.*:)(\d+\.\d+\.\d+\.\d+)$/.exec(normalized);
+	if (ipv4Tail) {
+		const ipv4 = ipv4Tail[2].split(".").map((part) => Number.parseInt(part, 10));
+		if (ipv4.length !== 4 || ipv4.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return null;
+		normalized = `${ipv4Tail[1]}${((ipv4[0] << 8) | ipv4[1]).toString(16)}:${((ipv4[2] << 8) | ipv4[3]).toString(16)}`;
+	}
+	const halves = normalized.split("::");
+	if (halves.length > 2) return null;
+	const left = halves[0] ? halves[0].split(":") : [];
+	const right = halves.length === 2 && halves[1] ? halves[1].split(":") : [];
+	const missing = 8 - left.length - right.length;
+	if (missing < 0 || (halves.length === 1 && missing !== 0)) return null;
+	const groups = [...left, ...Array<string>(missing).fill("0"), ...right];
+	if (groups.length !== 8) return null;
+	let value = 0n;
+	for (const group of groups) {
+		if (!/^[0-9a-f]{1,4}$/.test(group)) return null;
+		value = (value << 16n) + BigInt(Number.parseInt(group, 16));
+	}
+	return value;
 }
 
 async function resultFromResponse(
 	inputUrl: string,
 	response: FetchLikeResponse,
 	maxBytes: number,
+	safeRedirected = false,
 ): Promise<UrlReadResult> {
 	const contentType = response.headers.get("content-type");
 	const read = await readBoundedBody(response, maxBytes);
 	const text = decodeBody(read.bytes, contentType);
 	const signals = classifySignals(response, text);
-	const redirected = response.redirected || urlsDiffer(inputUrl, response.url);
+	const redirected = safeRedirected || response.redirected || urlsDiffer(inputUrl, response.url);
 	const verdict: UrlReadVerdict =
 		signals.length > 0 ? "blocked" : redirected ? "redirect" : "ok";
 	const textLike = isTextLike(contentType);
@@ -270,6 +499,24 @@ function normalizeError(error: unknown): UrlReadError {
 	return {
 		name: "Error",
 		message: typeof error === "string" ? error : "URL read failed.",
+	};
+}
+
+function blockedResult(inputUrl: string, signal: string, error: UrlReadError): UrlReadResult {
+	return {
+		input_url: inputUrl,
+		final_url: null,
+		verdict: "blocked",
+		status: null,
+		status_text: null,
+		content_type: null,
+		redirected: false,
+		title: null,
+		snippet: null,
+		signals: [signal],
+		truncated: false,
+		bytes_read: 0,
+		error,
 	};
 }
 

--- a/src/url-reader/types.ts
+++ b/src/url-reader/types.ts
@@ -1,0 +1,45 @@
+export type UrlReadVerdict = "ok" | "blocked" | "error" | "redirect";
+
+export interface UrlReadError {
+	name: string;
+	message: string;
+	code?: string;
+}
+
+export interface UrlReadResult {
+	input_url: string;
+	final_url: string | null;
+	verdict: UrlReadVerdict;
+	status: number | null;
+	status_text: string | null;
+	content_type: string | null;
+	redirected: boolean;
+	title: string | null;
+	snippet: string | null;
+	signals: string[];
+	truncated: boolean;
+	bytes_read: number;
+	error: UrlReadError | null;
+}
+
+export interface FetchLikeResponse {
+	readonly status: number;
+	readonly statusText: string;
+	readonly url: string;
+	readonly redirected: boolean;
+	readonly body: ReadableStream<Uint8Array> | null;
+	readonly headers: {
+		get(name: string): string | null;
+	};
+}
+
+export type FetchLike = (
+	input: string,
+	init?: RequestInit,
+) => Promise<FetchLikeResponse>;
+
+export interface UrlReaderOptions {
+	fetch?: FetchLike;
+	timeoutMs?: number;
+	maxBytes?: number;
+}

--- a/src/url-reader/types.ts
+++ b/src/url-reader/types.ts
@@ -38,8 +38,12 @@ export type FetchLike = (
 	init?: RequestInit,
 ) => Promise<FetchLikeResponse>;
 
+export type ResolveHostname = (hostname: string) => Promise<string[]>;
+
 export interface UrlReaderOptions {
 	fetch?: FetchLike;
+	resolveHostname?: ResolveHostname;
 	timeoutMs?: number;
 	maxBytes?: number;
+	maxRedirects?: number;
 }


### PR DESCRIPTION
Closes #2955.

## Summary
- Adds passive v0 `omx url read <url> --json` command and top-level help entry.
- Adds internal URL reader module with bounded fetch/read, text title/snippet extraction, and structured `ok`/`redirect`/`blocked`/`error` verdicts.
- Adds mocked coverage for reachable, blocked/challenge, fetch error, redirect, truncation, and unsupported protocol paths.
- Documents the conservative boundary: no browser automation, no challenge bypass, no cookie injection, and no global binary/PATH ownership.

## Verification
Using a local Node 20 runner binary for commands only because `/usr/bin/node` is Node 12 in this environment; no global PATH/binary changes were made.

- `npm run build`
- `node dist/scripts/run-test-files.js dist/url-reader/__tests__/url-reader.test.js dist/cli/__tests__/url.test.js`
