### PR TITLE
docs(vscode): refresh extension readme

### DIFF
--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -1,32 +1,127 @@
 # Oh My Codex VS Code Extension
 
-This package is the planned desktop VS Code surface for OMX, landed in small reviewable layers.
+The Oh My Codex VS Code extension is the editor-facing UI for OMX. It gives a
+workspace a local Chat surface for launching direct OMX sessions, watching
+session output, reopening recent logs, and running quick health checks without
+switching to a terminal pane.
 
-## Scope
+![OMX VS Code extension UI preview](./resources/omx-chat-preview.svg)
 
-This layer wires these commands to the shared direct-session API:
+## What It Does
 
-- `OMX: Open Chat`, `OMX: Start Direct Session`, `OMX: Resume Direct Session`
-- `OMX: Stop Active Session`, `OMX: Run Doctor`
+- Starts and resumes direct OMX sessions from VS Code commands.
+- Uses Chat as the primary input surface for prompts.
+- Streams direct-session stdout and stderr into the assistant response.
+- Stores local chat transcripts under the active workspace.
+- Lists recent OMX/VS Code logs and opens only logs that resolve inside the
+  active workspace.
+- Runs `omx doctor` from the extension command surface.
 
-Control Center, Log Explorer, Activity Bar views, and dashboard webviews are
-follow-up PRs after their core APIs and tests.
+## Install From A Checkout
 
-## Design constraints
+This package currently targets local checkout and contributor workflows. It is
+not yet published as a stable Marketplace extension.
 
-- Reuse root `src/vscode` APIs for launch args, PATH resolution, dangerous flag checks, and redacted logs.
-- Keep extension code thin; core OMX behavior stays in the root package.
-- Keep each upstream PR under 500 additions plus deletions.
-- Do not commit generated artifacts: `dist/`, `node_modules/`, or `*.vsix`.
-
-## Development
+Build the repository root first so the extension can load the shared VS Code
+core API from `dist/vscode/index.js`:
 
 ```bash
 npm run build
+```
+
+Then install and verify the extension package:
+
+```bash
 cd packages/vscode-extension
 npm install
 npm test
 ```
 
-The extension loads `../../dist/vscode/index.js` by default. Supported settings are
-`omx.command`, `omx.defaultArgs`, `omx.extraPath`, `omx.coreModulePath`, and `omx.confirmDangerousLaunches`.
+To install a local VSIX into VS Code:
+
+```bash
+cd packages/vscode-extension
+npx @vscode/vsce package
+code --install-extension ./oh-my-codex-vscode-*.vsix --force
+```
+
+Reload the VS Code window after installing or replacing a local VSIX.
+
+## Run From Source
+
+For extension development, run the TypeScript compiler in watch mode:
+
+```bash
+cd packages/vscode-extension
+npm install
+npm run watch
+```
+
+Open the repository in VS Code and launch an Extension Development Host from the
+extension package. The extension expects a built OMX core API. If the active
+workspace is not the repository root, set `omx.coreModulePath` to an absolute
+path for `dist/vscode/index.js`.
+
+## Configuration
+
+Supported settings:
+
+- `omx.command`: Optional OMX executable path or command. When empty, the
+  extension prefers the active workspace's `dist/cli/omx.js`, then falls back to
+  `omx` on `PATH`.
+- `omx.defaultArgs`: Default arguments appended to direct sessions.
+- `omx.extraPath`: Extra directories prepended to `PATH` when launching OMX.
+- `omx.coreModulePath`: Optional absolute path to the compiled OMX VS Code core
+  module.
+- `omx.confirmDangerousLaunches`: Require confirmation before launch arguments
+  include approval-bypass flags.
+
+Example workspace setting:
+
+```json
+{
+  "omx.coreModulePath": "/path/to/oh-my-codex/dist/vscode/index.js",
+  "omx.defaultArgs": ["--model", "gpt-5-codex"]
+}
+```
+
+## Data And Logs
+
+The extension writes local VS Code chat state under:
+
+```text
+.omx/vscode/conversations/
+```
+
+Session and extension logs stay in the repository's OMX log locations. Log open
+actions resolve real paths before opening a file, so symlinked or direct paths
+outside the active workspace are rejected.
+
+## Current Status
+
+The extension is an MVP-quality package in the repository. The current surface
+is intentionally narrow: Chat, direct session lifecycle commands, streamed
+session output, local transcripts, recent log access, and a doctor command.
+
+The package is suitable for local development and dogfooding. It still needs
+release packaging, more polished navigation, and broader UX hardening before it
+should be treated as a stable end-user extension.
+
+## Roadmap
+
+- Make Chat the default Activity Bar entry for everyday OMX work.
+- Package the extension with a reliable bundled or discoverable OMX core API.
+- Add richer session lifecycle controls, including clearer resume and stop
+  states.
+- Expand log review into a focused Log Explorer with filtering and scoped
+  previews.
+- Add configuration UI for command, model, default args, and environment setup.
+- Increase integration coverage for webview state, extension activation, and
+  local VSIX packaging.
+
+## Development Notes
+
+Do not commit generated artifacts such as `dist/`, `node_modules/`, or
+`*.vsix`. Keep the extension code thin and reuse the shared root `src/vscode`
+APIs for launch args, PATH resolution, dangerous flag checks, session launches,
+and redacted logs.

--- a/packages/vscode-extension/resources/omx-chat-preview.svg
+++ b/packages/vscode-extension/resources/omx-chat-preview.svg
@@ -1,0 +1,56 @@
+<svg width="920" height="560" viewBox="0 0 920 560" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">OMX VS Code extension UI preview</title>
+  <desc id="desc">A VS Code window preview showing the OMX Activity Bar entry, Chat surface, running session status, assistant output, and recent logs.</desc>
+  <rect width="920" height="560" rx="18" fill="#1F1F24"/>
+  <rect x="16" y="16" width="888" height="528" rx="12" fill="#25262D" stroke="#41424D"/>
+  <rect x="16" y="16" width="888" height="38" rx="12" fill="#30313A"/>
+  <circle cx="40" cy="35" r="5" fill="#EC6A5E"/>
+  <circle cx="58" cy="35" r="5" fill="#F5BF4F"/>
+  <circle cx="76" cy="35" r="5" fill="#61C554"/>
+  <text x="460" y="39" fill="#C9D1D9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="13" text-anchor="middle">Oh My Codex - VS Code</text>
+
+  <rect x="16" y="54" width="54" height="490" fill="#2B2C34"/>
+  <rect x="27" y="84" width="32" height="32" rx="8" fill="#3B82F6"/>
+  <path d="M34 96C34 93.8 35.8 92 38 92H48C50.2 92 52 93.8 52 96V106C52 108.2 50.2 110 48 110H38C35.8 110 34 108.2 34 106V96Z" stroke="#FFFFFF" stroke-width="1.8"/>
+  <path d="M38 105V97L43 101L48 97V105" stroke="#FFFFFF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="43" cy="147" r="15" stroke="#8B949E" stroke-width="2"/>
+  <path d="M36 180H50M36 188H50M36 196H45" stroke="#8B949E" stroke-width="2" stroke-linecap="round"/>
+  <path d="M35 232H51M43 224V240" stroke="#8B949E" stroke-width="2" stroke-linecap="round"/>
+
+  <rect x="70" y="54" width="250" height="490" fill="#202127"/>
+  <rect x="86" y="76" width="218" height="32" rx="6" fill="#2F313A" stroke="#464854"/>
+  <text x="102" y="97" fill="#E6EDF3" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="13">OMX Chat</text>
+  <rect x="86" y="124" width="144" height="28" rx="5" fill="#3B82F6"/>
+  <text x="104" y="143" fill="#FFFFFF" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12">Current workspace</text>
+  <rect x="86" y="166" width="218" height="70" rx="8" fill="#292B33" stroke="#444753"/>
+  <text x="102" y="190" fill="#E6EDF3" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="13">Running</text>
+  <text x="102" y="212" fill="#9DA7B3" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12">vscode-2026-06-24</text>
+  <rect x="86" y="252" width="218" height="34" rx="6" fill="#2F313A" stroke="#464854"/>
+  <text x="102" y="274" fill="#C9D1D9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12">Stop</text>
+  <text x="166" y="274" fill="#C9D1D9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12">Doctor</text>
+  <text x="236" y="274" fill="#C9D1D9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12">Open log</text>
+  <text x="86" y="326" fill="#9DA7B3" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12">Recent logs</text>
+  <rect x="86" y="342" width="218" height="32" rx="5" fill="#292B33"/>
+  <text x="102" y="363" fill="#C9D1D9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12">vscode-2026-06-24.log</text>
+  <rect x="86" y="382" width="218" height="32" rx="5" fill="#292B33"/>
+  <text x="102" y="403" fill="#C9D1D9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12">session-output.log</text>
+
+  <rect x="320" y="54" width="584" height="490" fill="#1E1F25"/>
+  <rect x="344" y="80" width="536" height="74" rx="10" fill="#29303A" stroke="#3E4653"/>
+  <text x="364" y="105" fill="#9DA7B3" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12">user</text>
+  <text x="364" y="130" fill="#E6EDF3" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15">Summarize the failing test run and suggest the next command.</text>
+
+  <rect x="344" y="176" width="536" height="180" rx="10" fill="#262933" stroke="#3E4653"/>
+  <text x="364" y="202" fill="#9DA7B3" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12">assistant · streaming session output</text>
+  <text x="364" y="232" fill="#E6EDF3" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="14">Status: Running</text>
+  <text x="364" y="257" fill="#C9D1D9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="14">Session: vscode-2026-06-24</text>
+  <text x="364" y="282" fill="#C9D1D9" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="14">Log: .omx/logs/vscode/session-output.log</text>
+  <rect x="364" y="305" width="418" height="18" rx="4" fill="#3B82F6" opacity="0.32"/>
+  <rect x="364" y="330" width="286" height="12" rx="4" fill="#8B949E" opacity="0.55"/>
+
+  <rect x="344" y="388" width="536" height="78" rx="10" fill="#20242C" stroke="#3E4653"/>
+  <text x="364" y="414" fill="#9DA7B3" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12">composer</text>
+  <rect x="364" y="430" width="416" height="20" rx="5" fill="#303642"/>
+  <rect x="794" y="426" width="66" height="30" rx="6" fill="#3B82F6"/>
+  <text x="827" y="446" fill="#FFFFFF" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" text-anchor="middle">Send</text>
+</svg>


### PR DESCRIPTION
Summary:
- Replace the PR-layering README text with extension-facing documentation.
- Add local checkout install/build steps, source development notes, settings, data/log locations, current status, and roadmap.
- Add an SVG UI preview asset for the Chat-oriented VS Code experience.

Validation:
- git diff --cached --check
- xmllint --noout packages/vscode-extension/resources/omx-chat-preview.svg

Size:
- 2 files changed, 167 insertions, 16 deletions (183 total), expected size/M.