### PR TITLE
Fix owner OMX session state canonicalization

### DIFF
--- a/src/cli/__tests__/mcp-parity.test.ts
+++ b/src/cli/__tests__/mcp-parity.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -95,6 +96,49 @@ describe("mcpParityCommand", () => {
     } finally {
       if (typeof previousDisable === "string") process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = previousDisable;
       else delete process.env.OMX_STATE_SERVER_DISABLE_AUTO_START;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("writes owner OMX session env state to the canonical native session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-mcp-parity-owner-session-"));
+    const logs = captureLogs();
+    const previousSessionId = process.env.OMX_SESSION_ID;
+
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(join(stateDir, "sessions", "native-id"), { recursive: true });
+      await writeFile(join(stateDir, "session.json"), JSON.stringify({
+        session_id: "native-id",
+        native_session_id: "native-id",
+        owner_omx_session_id: "omx-owner-id",
+        cwd,
+      }));
+      process.env.OMX_SESSION_ID = "omx-owner-id";
+
+      await mcpParityCommand("state", [
+        "write",
+        "--input",
+        JSON.stringify({
+          mode: "ralplan",
+          active: false,
+          current_phase: "complete",
+          status: "complete",
+          terminal_state: "complete",
+          workingDirectory: cwd,
+        }),
+        "--json",
+      ]);
+
+      const writeResult = JSON.parse(logs.pop() || "{}") as { path?: string };
+      assert.equal(
+        writeResult.path,
+        join(stateDir, "sessions", "native-id", "ralplan-state.json"),
+      );
+      assert.equal(existsSync(join(stateDir, "sessions", "omx-owner-id", "ralplan-state.json")), false);
+    } finally {
+      if (typeof previousSessionId === "string") process.env.OMX_SESSION_ID = previousSessionId;
+      else delete process.env.OMX_SESSION_ID;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -414,6 +414,60 @@ describe('state paths', () => {
   });
 
 
+  it('maps owner OMX session ids through current session and state scope resolution', async () => {
+    const wd = await mkRealTemp('omx-state-paths-owner-alias-');
+    const previousOmxSessionId = process.env.OMX_SESSION_ID;
+    try {
+      const stateDir = getBaseStateDir(wd);
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(join(stateDir, 'sessions', 'native-id'), { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: 'native-id',
+        native_session_id: 'native-id',
+        owner_omx_session_id: 'omx-owner-id',
+        cwd: wd,
+      }));
+      process.env.OMX_SESSION_ID = 'omx-owner-id';
+
+      assert.equal(await readCurrentSessionId(wd), 'native-id');
+      const scope = await resolveStateScope(wd);
+      assert.equal(scope.sessionId, 'native-id');
+      assert.equal(scope.stateDir, join(stateDir, 'sessions', 'native-id'));
+      assert.notEqual(scope.stateDir, join(stateDir, 'sessions', 'omx-owner-id'));
+
+      const runtimeScope = await resolveRuntimeStateScope(wd);
+      assert.equal(runtimeScope.sessionId, 'native-id');
+      assert.equal(runtimeScope.stateDir, join(stateDir, 'sessions', 'native-id'));
+      assert.equal(runtimeScope.source, 'native-alias');
+    } finally {
+      if (typeof previousOmxSessionId === 'string') process.env.OMX_SESSION_ID = previousOmxSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('maps explicit owner OMX session ids through resolveStateScope', async () => {
+    const wd = await mkRealTemp('omx-state-paths-explicit-owner-alias-');
+    try {
+      const stateDir = getBaseStateDir(wd);
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(join(stateDir, 'sessions', 'native-id'), { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: 'native-id',
+        native_session_id: 'native-id',
+        owner_omx_session_id: 'omx-owner-id',
+        cwd: wd,
+      }));
+
+      const scope = await resolveStateScope(wd, 'omx-owner-id');
+      assert.equal(scope.sessionId, 'native-id');
+      assert.equal(scope.stateDir, join(stateDir, 'sessions', 'native-id'));
+      assert.notEqual(scope.stateDir, join(stateDir, 'sessions', 'omx-owner-id'));
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('maps explicit native Codex session aliases through resolveStateScope', async () => {
     const wd = await mkRealTemp('omx-state-paths-explicit-native-alias-');
     try {

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -288,7 +288,10 @@ function readSessionIdFromEnvironment(env: NodeJS.ProcessEnv = process.env): str
 
 function resolveCanonicalSessionId(candidate: string | undefined, metadata: ResolvedSessionMetadata | undefined): string | undefined {
   if (!candidate) return undefined;
-  return metadata?.nativeSessionAliases.includes(candidate) ? metadata.sessionId : candidate;
+  if (!metadata) return candidate;
+  return metadata.nativeSessionAliases.includes(candidate) || metadata.ownerOmxSessionId === candidate
+    ? metadata.sessionId
+    : candidate;
 }
 
 async function readUsableSessionStateFromBaseStateDir(
@@ -404,11 +407,13 @@ export async function resolveRuntimeStateScope(
   let source: SessionScopeSource = 'root';
 
   if (validatedExplicit) {
-    sessionId = metadata?.nativeSessionAliases.includes(validatedExplicit) ? metadata.sessionId : validatedExplicit;
-    source = metadata?.nativeSessionAliases.includes(validatedExplicit) ? 'native-alias' : 'explicit';
+    const canonicalSessionId = resolveCanonicalSessionId(validatedExplicit, metadata);
+    sessionId = canonicalSessionId ?? validatedExplicit;
+    source = metadata && canonicalSessionId === metadata.sessionId && validatedExplicit !== metadata.sessionId ? 'native-alias' : 'explicit';
   } else if (envSessionId) {
-    sessionId = metadata?.nativeSessionAliases.includes(envSessionId) ? metadata.sessionId : envSessionId;
-    source = metadata?.nativeSessionAliases.includes(envSessionId) ? 'native-alias' : 'env';
+    const canonicalSessionId = resolveCanonicalSessionId(envSessionId, metadata);
+    sessionId = canonicalSessionId ?? envSessionId;
+    source = metadata && canonicalSessionId === metadata.sessionId && envSessionId !== metadata.sessionId ? 'native-alias' : 'env';
   } else if (metadata?.sessionId) {
     sessionId = metadata.sessionId;
     source = 'session-json';

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -12233,6 +12233,64 @@ exit 0
     }
   });
 
+  it("does not block Stop after owner-session ralplan CLI completion writes to native canonical state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralplan-owner-alias-complete-"));
+    const previousSessionId = process.env.OMX_SESSION_ID;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const nativeSessionId = "native-id";
+      const ownerSessionId = "omx-owner-id";
+      await mkdir(join(stateDir, "sessions", nativeSessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), {
+        session_id: nativeSessionId,
+        native_session_id: nativeSessionId,
+        owner_omx_session_id: ownerSessionId,
+        cwd,
+      });
+      await writeJson(join(stateDir, "sessions", nativeSessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "ralplan",
+        phase: "planning",
+        session_id: nativeSessionId,
+        active_skills: [{ skill: "ralplan", phase: "planning", active: true, session_id: nativeSessionId }],
+      });
+      await writeJson(join(stateDir, "sessions", nativeSessionId, "ralplan-state.json"), {
+        active: true,
+        mode: "ralplan",
+        current_phase: "planning",
+        session_id: nativeSessionId,
+      });
+      process.env.OMX_SESSION_ID = ownerSessionId;
+
+      const writeResult = await executeStateOperation("state_write", {
+        mode: "ralplan",
+        active: false,
+        current_phase: "complete",
+        status: "complete",
+        terminal_state: "complete",
+        workingDirectory: cwd,
+      });
+
+      assert.notEqual(writeResult.isError, true);
+      assert.equal(existsSync(join(stateDir, "sessions", ownerSessionId, "ralplan-state.json")), false);
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: nativeSessionId,
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      if (typeof previousSessionId === "string") process.env.OMX_SESSION_ID = previousSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not block on stale ralplan skill-active state when the matching mode state is absent", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-stale-skill-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2919,9 +2919,11 @@ async function resolveInternalSessionIdForPayload(
   if (!canonicalSessionId) return payloadSessionId;
 
   const nativeSessionId = safeString(currentSession?.native_session_id).trim();
+  const ownerOmxSessionId = safeString(currentSession?.owner_omx_session_id).trim();
   if (!payloadSessionId) return canonicalSessionId;
   if (payloadSessionId === canonicalSessionId) return canonicalSessionId;
   if (nativeSessionId && payloadSessionId === nativeSessionId) return canonicalSessionId;
+  if (ownerOmxSessionId && payloadSessionId === ownerOmxSessionId) return canonicalSessionId;
   return payloadSessionId;
 }
 


### PR DESCRIPTION
## Summary
- Canonicalize `owner_omx_session_id` to `session.json.session_id` for state-path resolution, including env/explicit session scope paths.
- Keep Stop-hook payload session resolution consistent by treating the owner OMX session id as an alias for the canonical native/internal session.
- Add regressions for owner-session env writes landing in `sessions/native-id`, plus Stop no longer blocking after the terminal CLI state write.

## Verification
- `env -u NODE_OPTIONS PATH=/mnt/offloading/.nvm/versions/node/v25.1.0/bin:$PATH npm run check:no-unused`
- `env -u NODE_OPTIONS PATH=/mnt/offloading/.nvm/versions/node/v25.1.0/bin:$PATH npm run build`
- `env -u NODE_OPTIONS PATH=/mnt/offloading/.nvm/versions/node/v25.1.0/bin:$PATH node dist/scripts/run-test-files.js dist/mcp/__tests__/state-paths.test.js dist/cli/__tests__/mcp-parity.test.js dist/scripts/__tests__/codex-native-hook.test.js`

Fixes #2959.

🤖 Generated with gp-gajae