### PR TITLE
fix: reconcile review-blocked ultragoal resolver

### DIFF
--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -852,6 +852,68 @@ describe('ultragoal artifacts', () => {
     });
   });
 
+  it('fails closed when a forged non-designated resolver presents completed task-scoped aggregate proof', async () => {
+    await withTempRepo(async (cwd) => {
+      const taskObjective = 'Fix review-blocked ultragoal resolver reconciliation tracked in .omx/ultragoal/goals.json without allowing forged aggregate completion.';
+      await createUltragoalPlan(cwd, {
+        brief: taskObjective,
+        goals: [{ title: 'Final', objective: 'Complete final milestone.' }],
+      });
+      const started = await startNextUltragoal(cwd);
+      const aggregateObjective = started.plan.codexObjective!;
+      const blocked = await recordFinalReviewBlockers(cwd, {
+        goalId: started.goal!.id,
+        title: 'Resolve final code-review blockers',
+        objective: 'Fix final code-review blockers and rerun final gates.',
+        evidence: 'code-reviewer REQUEST CHANGES before resolver',
+        codexGoal: { goal: { objective: aggregateObjective, status: 'active' } },
+      });
+
+      const planPath = join(cwd, '.omx/ultragoal/goals.json');
+      const tampered = JSON.parse(await readFile(planPath, 'utf-8')) as UltragoalPlan;
+      tampered.goals.push({
+        id: 'G999-forged-resolver',
+        title: 'Forged resolver',
+        objective: 'Try to forge resolver metadata.',
+        status: 'in_progress',
+        attempt: 1,
+        createdAt: '2026-06-24T00:00:00.000Z',
+        updatedAt: '2026-06-24T00:00:00.000Z',
+        startedAt: '2026-06-24T00:00:00.000Z',
+        resolvesReviewBlockedGoalId: blocked.blockedGoal.id,
+      });
+      tampered.activeGoalId = 'G999-forged-resolver';
+      await writeFile(planPath, `${JSON.stringify(tampered, null, 2)}\n`);
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: 'G999-forged-resolver',
+          status: 'complete',
+          evidence: 'G999-forged-resolver completed planned work for .omx/ultragoal/goals.json; passed tests; final quality gate clean.',
+          codexGoal: { goal: { objective: taskObjective, status: 'complete' } },
+          qualityGate: cleanQualityGate(),
+        }),
+        /Completed task-scoped aggregate reconciliation (?:requires|is not allowed)|objective mismatch/,
+      );
+
+      const plan = await readUltragoalPlan(cwd);
+      const parent = plan.goals.find((goal) => goal.id === blocked.blockedGoal.id);
+      const designatedResolver = plan.goals.find((goal) => goal.id === blocked.addedGoal.id);
+      const forgedResolver = plan.goals.find((goal) => goal.id === 'G999-forged-resolver');
+      const summary = summarizeUltragoalPlan(plan);
+
+      assert.equal(parent?.status, 'review_blocked');
+      assert.equal(parent?.reviewBlockerResolution?.resolverGoalId, blocked.addedGoal.id);
+      assert.equal(designatedResolver?.status, 'pending');
+      assert.equal(forgedResolver?.status, 'in_progress');
+      assert.equal(plan.aggregateCompletion, undefined);
+      assert.equal(summary.reviewBlocked, 1);
+      assert.equal(summary.aggregateComplete, false);
+      assert.equal(summary.artifactComplete, false);
+      assert.equal(isUltragoalDone(plan), false);
+    });
+  });
+
   it('records final per-story review blockers without claiming Codex completion', async () => {
     await withTempRepo(async (cwd) => {
       await createUltragoalPlan(cwd, {

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -734,6 +734,12 @@ describe('ultragoal artifacts', () => {
 
       assert.equal(result.blockedGoal.status, 'review_blocked');
       assert.equal(result.addedGoal.status, 'pending');
+      assert.equal(result.addedGoal.resolvesReviewBlockedGoalId, result.blockedGoal.id);
+      assert.deepEqual(result.blockedGoal.reviewBlockerResolution, {
+        resolverGoalId: result.addedGoal.id,
+        status: 'pending',
+        evidence: 'code-review REQUEST CHANGES',
+      });
       assert.equal(result.plan.activeGoalId, undefined);
       assert.equal(result.plan.codexObjective, objective);
 
@@ -743,6 +749,106 @@ describe('ultragoal artifacts', () => {
       const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
       assert.match(ledger, /"event":"final_review_failed"/);
       assert.match(ledger, /"event":"goal_review_blocked"/);
+    });
+  });
+
+  it('reconciles a review-blocked final story when the appended resolver completes with a clean quality gate', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [{ title: 'Final', objective: 'Complete final milestone.' }],
+      });
+      const started = await startNextUltragoal(cwd);
+      const objective = started.plan.codexObjective!;
+
+      const blocked = await recordFinalReviewBlockers(cwd, {
+        goalId: started.goal!.id,
+        title: 'Resolve final code-review blockers',
+        objective: 'Fix final code-review blockers and rerun final gates.',
+        evidence: 'code-reviewer REQUEST CHANGES before resolver',
+        codexGoal: { goal: { objective, status: 'active' } },
+      });
+      assert.equal(blocked.blockedGoal.status, 'review_blocked');
+      assert.equal(summarizeUltragoalPlan(blocked.plan).reviewBlocked, 1);
+
+      const resolver = await startNextUltragoal(cwd);
+      assert.equal(resolver.goal?.id, blocked.addedGoal.id);
+      assert.equal(isFinalRunCompletionCandidate(resolver.plan, resolver.goal!), true);
+
+      const completed = await checkpointUltragoal(cwd, {
+        goalId: blocked.addedGoal.id,
+        status: 'complete',
+        evidence: `${blocked.addedGoal.id} fixed blockers; final gate passed for .omx/ultragoal/goals.json`,
+        codexGoal: { goal: { objective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      });
+      const parent = completed.goals.find((goal) => goal.id === blocked.blockedGoal.id);
+      const summary = summarizeUltragoalPlan(completed);
+
+      assert.equal(parent?.status, 'complete');
+      assert.equal(parent?.reviewBlockerResolution?.status, 'complete');
+      assert.equal(parent?.reviewBlockerResolution?.resolverGoalId, blocked.addedGoal.id);
+      assert.equal(summary.complete, 2);
+      assert.equal(summary.reviewBlocked, 0);
+      assert.equal(summary.steeringBlocked, 0);
+      assert.equal(summary.aggregateComplete, true);
+      assert.equal(summary.artifactComplete, true);
+      assert.equal(isUltragoalDone(completed), true);
+
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.match(ledger, /"event":"final_review_failed"/);
+      assert.match(ledger, /code-reviewer REQUEST CHANGES before resolver/);
+      assert.match(ledger, /Review-blocked final story resolved by/);
+      assert.match(ledger, /"event":"aggregate_completed"/);
+    });
+  });
+
+  it('does not reconcile a review-blocked parent from a non-designated resolver goal', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [{ title: 'Final', objective: 'Complete final milestone.' }],
+      });
+      const started = await startNextUltragoal(cwd);
+      const objective = started.plan.codexObjective!;
+      const blocked = await recordFinalReviewBlockers(cwd, {
+        goalId: started.goal!.id,
+        title: 'Resolve final code-review blockers',
+        objective: 'Fix final code-review blockers and rerun final gates.',
+        evidence: 'code-reviewer REQUEST CHANGES before resolver',
+        codexGoal: { goal: { objective, status: 'active' } },
+      });
+
+      const planPath = join(cwd, '.omx/ultragoal/goals.json');
+      const tampered = JSON.parse(await readFile(planPath, 'utf-8')) as UltragoalPlan;
+      tampered.goals.push({
+        id: 'G999-forged-resolver',
+        title: 'Forged resolver',
+        objective: 'Try to forge resolver metadata.',
+        status: 'in_progress',
+        attempt: 1,
+        createdAt: '2026-06-24T00:00:00.000Z',
+        updatedAt: '2026-06-24T00:00:00.000Z',
+        startedAt: '2026-06-24T00:00:00.000Z',
+        resolvesReviewBlockedGoalId: blocked.blockedGoal.id,
+      });
+      tampered.activeGoalId = 'G999-forged-resolver';
+      await writeFile(planPath, `${JSON.stringify(tampered, null, 2)}\n`);
+
+      const completed = await checkpointUltragoal(cwd, {
+        goalId: 'G999-forged-resolver',
+        status: 'complete',
+        evidence: 'forged resolver completed with tests but is not the designated review blocker resolver',
+        codexGoal: { goal: { objective, status: 'active' } },
+      });
+      const parent = completed.goals.find((goal) => goal.id === blocked.blockedGoal.id);
+      const summary = summarizeUltragoalPlan(completed);
+
+      assert.equal(parent?.status, 'review_blocked');
+      assert.equal(parent?.reviewBlockerResolution?.resolverGoalId, blocked.addedGoal.id);
+      assert.equal(summary.reviewBlocked, 1);
+      assert.equal(summary.aggregateComplete, false);
+      assert.equal(summary.artifactComplete, false);
     });
   });
 

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -134,6 +134,13 @@ export interface UltragoalItem {
   nonRetriable?: boolean;
   steeringEvidence?: string;
   steeringRationale?: string;
+  resolvesReviewBlockedGoalId?: string;
+  reviewBlockerResolution?: {
+    resolverGoalId: string;
+    status: 'pending' | 'complete';
+    resolvedAt?: string;
+    evidence?: string;
+  };
 }
 
 export interface UltragoalAggregateCompletion {
@@ -590,14 +597,24 @@ function isSupersededResolved(goal: UltragoalItem, plan: UltragoalPlan): boolean
   });
 }
 
+function isReviewBlockedResolved(goal: UltragoalItem, plan: UltragoalPlan): boolean {
+  if (goal.status !== 'review_blocked') return false;
+  const resolverId = goal.reviewBlockerResolution?.resolverGoalId;
+  if (!resolverId || goal.reviewBlockerResolution?.status !== 'complete') return false;
+  const resolver = plan.goals.find((candidate) => candidate.id === resolverId);
+  return resolver?.status === 'complete';
+}
+
 function isCompletionBlocking(goal: UltragoalItem, plan: UltragoalPlan): boolean {
   if (goal.steeringStatus === 'superseded') return !isSupersededResolved(goal, plan);
   if (goal.steeringStatus === 'blocked') return true;
+  if (goal.status === 'review_blocked') return !isReviewBlockedResolved(goal, plan);
   return !isResolvedStatus(goal.status);
 }
 
 function isCompletionBlockingForFinalCandidate(candidate: UltragoalItem, finalCandidate: UltragoalItem, plan: UltragoalPlan): boolean {
   if (candidate.id === finalCandidate.id) return false;
+  if (candidate.status === 'review_blocked' && candidate.reviewBlockerResolution?.resolverGoalId === finalCandidate.id) return false;
   if (candidate.steeringStatus === 'superseded') {
     const replacements = candidate.supersededBy ?? [];
     if (replacements.length === 0) return true;
@@ -789,14 +806,16 @@ export async function createUltragoalPlan(cwd: string, options: CreateUltragoalO
   });
 }
 
-export function summarizeUltragoalPlan(plan: UltragoalPlan): { total: number; pending: number; inProgress: number; complete: number; failed: number; reviewBlocked: number; needsUserDecision: number; superseded: number; steeringBlocked: number; aggregateComplete: boolean; artifactComplete: boolean; activeGoalId?: string } {
+export function summarizeUltragoalPlan(plan: UltragoalPlan): { total: number; pending: number; inProgress: number; complete: number; failed: number; reviewBlocked: number; historicalReviewBlocked: number; needsUserDecision: number; superseded: number; steeringBlocked: number; aggregateComplete: boolean; artifactComplete: boolean; activeGoalId?: string } {
+  const activeReviewBlocked = plan.goals.filter((goal) => goal.status === 'review_blocked' && !isReviewBlockedResolved(goal, plan)).length;
   return {
     total: plan.goals.length,
     pending: plan.goals.filter((goal) => goal.status === 'pending').length,
     inProgress: plan.goals.filter((goal) => goal.status === 'in_progress').length,
     complete: plan.goals.filter((goal) => goal.status === 'complete').length,
     failed: plan.goals.filter((goal) => goal.status === 'failed').length,
-    reviewBlocked: plan.goals.filter((goal) => goal.status === 'review_blocked').length,
+    reviewBlocked: activeReviewBlocked,
+    historicalReviewBlocked: plan.goals.filter((goal) => goal.status === 'review_blocked').length - activeReviewBlocked,
     needsUserDecision: plan.goals.filter((goal) => goal.status === 'needs_user_decision').length,
     superseded: plan.goals.filter((goal) => goal.steeringStatus === 'superseded').length,
     steeringBlocked: plan.goals.filter((goal) => goal.steeringStatus === 'blocked').length,
@@ -831,7 +850,7 @@ export function parseUltragoalSteeringDirective(raw: string): UltragoalSteeringP
 }
 
 
-function appendGoalToPlan(plan: UltragoalPlan, options: AddUltragoalGoalOptions, nowOverride?: string): UltragoalItem {
+function appendGoalToPlan(plan: UltragoalPlan, options: AddUltragoalGoalOptions & { resolvesReviewBlockedGoalId?: string }, nowOverride?: string): UltragoalItem {
   const now = nowOverride ?? iso(options.now);
   const title = assertNonEmpty(options.title, '--title');
   const objective = assertNonEmpty(options.objective, '--objective');
@@ -844,6 +863,7 @@ function appendGoalToPlan(plan: UltragoalPlan, options: AddUltragoalGoalOptions,
     createdAt: now,
     updatedAt: now,
     evidence: options.evidence,
+    resolvesReviewBlockedGoalId: options.resolvesReviewBlockedGoalId,
   };
   plan.goals.push(goal);
   plan.updatedAt = now;
@@ -1501,6 +1521,7 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
     return plan;
   }
   let aggregateCompletion: UltragoalAggregateCompletion | undefined;
+  let normalFinalAggregateCompletion: UltragoalAggregateCompletion | undefined;
   if (options.status === 'complete') {
     const expectedObjective = expectedCodexObjective(plan, goal);
     const aggregateMode = codexGoalMode(plan) === 'aggregate';
@@ -1546,6 +1567,21 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
         throw new UltragoalError(`${formatCodexGoalReconciliation(reconciliation)}${taskScopedRequirement}${remediation}`);
       }
     }
+    const designatedReviewBlockerResolver = goal.resolvesReviewBlockedGoalId
+      ? plan.goals.some((candidate) => (
+        candidate.id === goal.resolvesReviewBlockedGoalId
+        && candidate.status === 'review_blocked'
+        && candidate.reviewBlockerResolution?.resolverGoalId === goal.id
+      ))
+      : false;
+    if (aggregateMode && finalRunCheckpoint && !options.allowActiveFinalCodexGoal && designatedReviewBlockerResolver) {
+      normalFinalAggregateCompletion = {
+        status: 'complete',
+        completedAt: now,
+        evidence: assertNonEmpty(options.evidence, '--evidence'),
+        codexGoal: options.codexGoal,
+      };
+    }
     if (finalRunCheckpoint && !options.allowActiveFinalCodexGoal) goal.evidence = options.evidence;
   }
   const requiredArchitectureInvariants = options.status === 'complete' && (aggregateCompletion !== undefined || (isFinalRunCompletionCandidate(plan, goal) && !options.allowActiveFinalCodexGoal))
@@ -1579,6 +1615,22 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
     goal.failureReason = undefined;
     goal.failedAt = undefined;
     clearGoalBlockerFields(goal);
+    if (normalFinalAggregateCompletion) plan.aggregateCompletion = normalFinalAggregateCompletion;
+    const resolvedParent = goal.resolvesReviewBlockedGoalId
+      ? plan.goals.find((candidate) => candidate.id === goal.resolvesReviewBlockedGoalId)
+      : undefined;
+    if (resolvedParent?.status === 'review_blocked' && resolvedParent.reviewBlockerResolution?.resolverGoalId === goal.id && qualityGate) {
+      resolvedParent.status = 'complete';
+      resolvedParent.completedAt = now;
+      resolvedParent.updatedAt = now;
+      resolvedParent.reviewBlockerResolution = {
+        resolverGoalId: goal.id,
+        status: 'complete',
+        resolvedAt: now,
+        evidence: options.evidence,
+      };
+      clearGoalBlockerFields(resolvedParent);
+    }
     if (plan.activeGoalId === goal.id) delete plan.activeGoalId;
   } else {
     const blocker = classifyExternalAuthorizationBlocker(options.evidence);
@@ -1615,6 +1667,33 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
       ? `Blocked on repeated external authorization. Required decision: ${goal.requiredExternalDecision}.`
       : undefined,
   });
+  if (options.status === 'complete' && goal.resolvesReviewBlockedGoalId) {
+    const resolvedParent = plan.goals.find((candidate) => candidate.id === goal.resolvesReviewBlockedGoalId);
+    if (resolvedParent?.reviewBlockerResolution?.status === 'complete' && resolvedParent.reviewBlockerResolution.resolverGoalId === goal.id) {
+      await appendLedger(cwd, {
+        ts: now,
+        event: 'goal_completed',
+        goalId: resolvedParent.id,
+        status: resolvedParent.status,
+        evidence: options.evidence,
+        codexGoal: options.codexGoal,
+        qualityGate,
+        message: `Review-blocked final story resolved by ${goal.id}; original failed review remains in prior final_review_failed/goal_review_blocked ledger entries.`,
+      });
+    }
+  }
+  if (normalFinalAggregateCompletion) {
+    await appendLedger(cwd, {
+      ts: now,
+      event: 'aggregate_completed',
+      goalId: goal.id,
+      status: goal.status,
+      evidence: options.evidence,
+      codexGoal: options.codexGoal,
+      qualityGate,
+      message: 'Aggregate ultragoal plan completed with a clean final quality gate.',
+    });
+  }
   return plan;
   });
 }
@@ -1649,7 +1728,7 @@ export async function recordFinalReviewBlockers(cwd: string, options: RecordFina
     throw new UltragoalError(formatCodexGoalReconciliation(reconciliation));
   }
 
-  const addedGoal = appendGoalToPlan(plan, { ...options, now: options.now });
+  const addedGoal = appendGoalToPlan(plan, { ...options, now: options.now, resolvesReviewBlockedGoalId: goal.id });
   goal.status = 'review_blocked';
   goal.reviewBlockedAt = now;
   goal.updatedAt = now;
@@ -1657,6 +1736,11 @@ export async function recordFinalReviewBlockers(cwd: string, options: RecordFina
   goal.failedAt = undefined;
   goal.failureReason = undefined;
   goal.evidence = options.evidence;
+  goal.reviewBlockerResolution = {
+    resolverGoalId: addedGoal.id,
+    status: 'pending',
+    evidence: options.evidence,
+  };
   if (plan.activeGoalId === goal.id) delete plan.activeGoalId;
   plan.updatedAt = now;
 

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -493,6 +493,29 @@ async function snapshotObjectiveMapsToUltragoalPlan(cwd: string, snapshotObjecti
   }
 }
 
+function unresolvedReviewBlockedGoals(plan: UltragoalPlan): UltragoalItem[] {
+  return plan.goals.filter((candidate) => candidate.status === 'review_blocked' && !isReviewBlockedResolved(candidate, plan));
+}
+
+function isDesignatedReviewBlockerResolver(goal: UltragoalItem, parent: UltragoalItem | undefined): boolean {
+  return parent?.status === 'review_blocked'
+    && goal.resolvesReviewBlockedGoalId === parent.id
+    && parent.reviewBlockerResolution?.resolverGoalId === goal.id;
+}
+
+function canUseCleanFinalResolverPathForReviewBlockedParent(
+  plan: UltragoalPlan,
+  goal: UltragoalItem,
+  finalRunCheckpoint: boolean,
+  allowActiveFinalCodexGoal: boolean | undefined,
+): boolean {
+  const unresolvedReviewBlocked = unresolvedReviewBlockedGoals(plan);
+  if (unresolvedReviewBlocked.length !== 1) return false;
+  return finalRunCheckpoint
+    && !allowActiveFinalCodexGoal
+    && isDesignatedReviewBlockerResolver(goal, unresolvedReviewBlocked[0]);
+}
+
 async function canReconcileCompletedTaskScopedAggregateSnapshot(
   cwd: string,
   plan: UltragoalPlan,
@@ -1544,14 +1567,26 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
         && snapshot.status === 'complete'
         && Boolean(snapshot.objective)
         && normalizeObjective(snapshot.objective ?? '') !== normalizeObjective(expectedObjective)
-        && await canReconcileCompletedTaskScopedAggregateSnapshot(cwd, plan, goal, snapshot.objective ?? '', options.evidence);
+        && await canReconcileCompletedTaskScopedAggregateSnapshot(
+          cwd,
+          plan,
+          goal,
+          snapshot.objective ?? '',
+          options.evidence,
+        );
       if (completedTaskScopedAggregateSnapshot) {
-        aggregateCompletion = {
-          status: 'complete',
-          completedAt: now,
-          evidence: assertNonEmpty(options.evidence, '--evidence'),
-          codexGoal: options.codexGoal,
-        };
+        if (unresolvedReviewBlockedGoals(plan).length > 0) {
+          if (!canUseCleanFinalResolverPathForReviewBlockedParent(plan, goal, finalRunCheckpoint, options.allowActiveFinalCodexGoal)) {
+            throw new UltragoalError('Completed task-scoped aggregate reconciliation is not allowed while unresolved review_blocked parent goals exist; only the parent\'s designated resolver may continue through the clean final quality gate path.');
+          }
+        } else {
+          aggregateCompletion = {
+            status: 'complete',
+            completedAt: now,
+            evidence: assertNonEmpty(options.evidence, '--evidence'),
+            codexGoal: options.codexGoal,
+          };
+        }
       } else {
         const taskScopedRequirement = aggregateMode && snapshot?.status === 'complete' && Boolean(snapshot.objective)
           ? ' Completed task-scoped aggregate reconciliation requires the checkpoint goal to be the active in-progress OMX goal, evidence that names that active OMX goal id, names .omx/ultragoal/goals.json or ledger.jsonl, includes completed implementation plus validation/review evidence, and a get_goal objective that maps to the ultragoal brief/artifact.'
@@ -1568,11 +1603,10 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
       }
     }
     const designatedReviewBlockerResolver = goal.resolvesReviewBlockedGoalId
-      ? plan.goals.some((candidate) => (
-        candidate.id === goal.resolvesReviewBlockedGoalId
-        && candidate.status === 'review_blocked'
-        && candidate.reviewBlockerResolution?.resolverGoalId === goal.id
-      ))
+      ? isDesignatedReviewBlockerResolver(
+        goal,
+        plan.goals.find((candidate) => candidate.id === goal.resolvesReviewBlockedGoalId),
+      )
       : false;
     if (aggregateMode && finalRunCheckpoint && !options.allowActiveFinalCodexGoal && designatedReviewBlockerResolver) {
       normalFinalAggregateCompletion = {


### PR DESCRIPTION
Fixes #2961.

## Summary
- link appended final-review resolver goals back to their designated review-blocked parent
- reconcile the review-blocked parent and aggregate completion when the designated resolver completes with a clean final gate
- keep forged/non-designated resolver metadata from clearing the parent or aggregate completion

## Verification
- NODE_OPTIONS cleared; Node v25.1.0
- npm run build
- node --test dist/ultragoal/__tests__/artifacts.test.js
- npm run verify:native-agents
- npm run verify:plugin-bundle
- node dist/scripts/generate-catalog-docs.js --check