### PR TITLE
Fix completed goal cleanup Stop guard

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3345,7 +3345,7 @@ standardMaxRounds = 15
     }
   });
 
-  it("blocks explicit create_goal attempts even when adjacent text explains not to call it", async () => {
+  it("blocks explicit create_goal attempts when fresh native-goal cleanup evidence remains", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-completed-goal-mixed-stop-"));
     try {
       await writeJson(join(cwd, ".omx", "ultragoal", "goals.json"), {
@@ -3359,7 +3359,7 @@ standardMaxRounds = 15
         cwd,
         session_id: "sess-completed-goal-mixed-stop",
         thread_id: "thread-completed-goal-mixed-stop",
-        last_user_message: "Do not call create_goal until cleanup is explicit.",
+        last_user_message: "get_goal reports a completed Codex goal still attached to this thread; do not call create_goal until cleanup is explicit.",
         last_assistant_message: "I am starting another run now; create_goal payload follows.",
       }, { cwd });
 
@@ -3372,7 +3372,7 @@ standardMaxRounds = 15
     }
   });
 
-  it("blocks Stop when a final answer starts another goal over completed state", async () => {
+  it("does not block Stop when completed durable history alone precedes another goal", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-completed-goal-stop-"));
     try {
       await writeJson(join(cwd, ".omx", "ultragoal", "goals.json"), {
@@ -3386,15 +3386,13 @@ standardMaxRounds = 15
         cwd,
         session_id: "sess-completed-goal-stop",
         thread_id: "thread-completed-goal-stop",
-        last_assistant_message: "Starting another ultragoal now; create_goal payload follows.",
+        last_assistant_message: "Starting another ultragoal now; create_goal payload follows after /goal clear already cleared native state.",
       }, { cwd });
 
       const output = JSON.stringify(result.outputJson);
-      assert.equal(result.outputJson?.decision, "block");
-      assert.equal(result.outputJson?.stopReason, "completed_codex_goal_cleanup_required");
-      assert.match(output, /run \/goal clear/);
-      assert.match(output, /before calling create_goal/);
-      assert.match(output, /hooks only nudge and must not mutate Codex goal state/);
+      assert.notEqual(result.outputJson?.decision, "block");
+      assert.notEqual(result.outputJson?.stopReason, "completed_codex_goal_cleanup_required");
+      assert.doesNotMatch(output, /run \/goal clear/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2457,6 +2457,12 @@ function looksLikeCreateGoalAttempt(text: string): boolean {
 function looksLikeCompletedGoalCleanupAttempt(text: string): boolean {
   return looksLikeGoalCreationAttempt(text) || looksLikeCreateGoalAttempt(text);
 }
+function hasFreshNativeGoalCleanupEvidence(text: string): boolean {
+  return /\b(?:get_goal|Codex goal|native goal|active goal|thread goal)\b.{0,120}\b(?:reports?|returns?|shows?|status|state|still|attached|pending|cleanup|required|requires?)\b.{0,120}\b(?:complete|completed|attached|pending|cleanup|required|clear)\b/i.test(text)
+    || /\b(?:complete|completed|attached|pending|cleanup|required|clear)\b.{0,120}\b(?:get_goal|Codex goal|native goal|active goal|thread goal)\b/i.test(text)
+    || /\b(?:pending[-_ ]cleanup|native[-_ ]goal[-_ ]cleanup|completed[-_ ]codex[-_ ]goal[-_ ]cleanup)\b/i.test(text);
+}
+
 
 async function findCompletedGoalWorkflowCleanupNotice(cwd: string): Promise<string | null> {
   const ultragoal = await readJsonIfExists(join(cwd, ".omx", "ultragoal", "goals.json"));
@@ -2500,6 +2506,7 @@ async function buildCompletedGoalCleanupStopOutput(payload: CodexHookPayload, cw
     safeString(payload.last_assistant_message ?? payload.lastAssistantMessage),
   ].join("\n");
   if (!looksLikeCompletedGoalCleanupAttempt(text)) return null;
+  if (!hasFreshNativeGoalCleanupEvidence(text)) return null;
   const notice = await findCompletedGoalWorkflowCleanupNotice(cwd);
   if (!notice) return null;
   const systemMessage = `${notice} Do not continue into create_goal until cleanup is explicit; hooks only nudge and must not mutate Codex goal state.`;


### PR DESCRIPTION
## Summary
- Stop no longer hard-blocks new Codex goal attempts from completed durable .omx goal history alone.
- completed_codex_goal_cleanup_required now requires fresh native-goal or pending-cleanup evidence in the Stop text.
- Existing explicit create_goal cleanup blocking remains covered when get_goal/native-goal evidence is present.

## Verification
- npm run build
- node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js

*[repo owner's gaebal-gajae (clawdbot) 🦞]*