### PR TITLE
Add local session friction report

### DIFF
--- a/src/cli/__tests__/session-search-help.test.ts
+++ b/src/cli/__tests__/session-search-help.test.ts
@@ -25,11 +25,13 @@ describe('omx session help', () => {
       assert.equal(mainHelp.status, 0, mainHelp.stderr || mainHelp.stdout);
       assert.match(mainHelp.stdout, /omx resume\s+Resume Codex sessions \(supports --project and --codex-home <path>\)/i);
       assert.match(mainHelp.stdout, /omx autoresearch\s+\[DEPRECATED\] Use \$autoresearch; direct CLI launch removed/i);
-      assert.match(mainHelp.stdout, /omx session\s+Search prior local session transcripts \(--codex-home <path> escape hatch\)/i);
+      assert.match(mainHelp.stdout, /omx session\s+Search and summarize local session history \(--codex-home <path> escape hatch\)/i);
 
       const sessionHelp = runOmx(cwd, ['session', '--help']);
       assert.equal(sessionHelp.status, 0, sessionHelp.stderr || sessionHelp.stdout);
       assert.match(sessionHelp.stdout, /omx session search <query>/i);
+      assert.match(sessionHelp.stdout, /omx session friction \[options\]/i);
+      assert.match(sessionHelp.stdout, /Options for friction:/i);
       assert.match(sessionHelp.stdout, /--since <spec>/i);
       assert.match(sessionHelp.stdout, /--codex-home <path>/i);
     } finally {

--- a/src/cli/__tests__/session-search.test.ts
+++ b/src/cli/__tests__/session-search.test.ts
@@ -5,7 +5,7 @@ import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { parseSessionSearchArgs } from '../session-search.js';
+import { parseSessionFrictionArgs, parseSessionSearchArgs } from '../session-search.js';
 
 async function writeRollout(
   codexHomeDir: string,
@@ -45,6 +45,19 @@ describe('parseSessionSearchArgs', () => {
     assert.equal(parsed.json, true);
   });
 });
+
+describe('parseSessionFrictionArgs', () => {
+  it('parses friction flags without accepting positional payloads', () => {
+    const parsed = parseSessionFrictionArgs(['--limit=3', '--project', 'all', '--session', 'abc', '--codex-home', '/tmp/codex', '--json']);
+    assert.equal(parsed.options.limit, 3);
+    assert.equal(parsed.options.project, 'all');
+    assert.equal(parsed.options.session, 'abc');
+    assert.equal(parsed.options.codexHomeDir, '/tmp/codex');
+    assert.equal(parsed.json, true);
+    assert.throws(() => parseSessionFrictionArgs(['raw prompt']), /Unexpected positional argument/);
+  });
+});
+
 
 describe('omx session search', () => {
   it('prints structured JSON results for matching transcripts', async () => {
@@ -192,6 +205,54 @@ describe('omx session search', () => {
       assert.equal(result.status, 0, result.stderr || result.stdout);
       const parsed = JSON.parse(result.stdout) as { results: Array<{ session_id: string }> };
       assert.deepEqual(parsed.results.map((entry) => entry.session_id), ['explicit-session']);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('omx session friction', () => {
+  it('prints public-safe JSON for local session friction', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-friction-cli-'));
+    const codexHomeDir = join(cwd, '.codex-home');
+    try {
+      await writeRollout(codexHomeDir, '2026-06-24T09:00:00.000Z', 'rollout-cli-friction.jsonl', [
+        {
+          type: 'session_meta',
+          timestamp: '2026-06-24T09:00:00.000Z',
+          payload: { id: 'cli-friction', timestamp: '2026-06-24T09:00:00.000Z', cwd },
+        },
+        {
+          type: 'event_msg',
+          timestamp: '2026-06-24T09:01:00.000Z',
+          payload: { type: 'user_message', message: 'do not leak this raw user text' },
+        },
+        {
+          type: 'response_item',
+          timestamp: '2026-06-24T09:02:00.000Z',
+          payload: { type: 'function_call', name: 'bash', arguments: '{"command":"echo secret"}' },
+        },
+      ]);
+
+      const result = runOmx(cwd, ['session', 'friction', '--codex-home', codexHomeDir, '--json'], {
+        CODEX_HOME: codexHomeDir,
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const parsed = JSON.parse(result.stdout) as {
+        privacy: { mode: string; excludes: string[] };
+        sessions: Array<{ session_id: string; counters: { tool_calls: number }; source: { codex_home: string; transcript_ref: string } }>;
+      };
+      assert.equal(parsed.privacy.mode, 'metadata-only');
+      assert.equal(parsed.sessions[0].session_id, 'cli-friction');
+      assert.equal(parsed.sessions[0].counters.tool_calls, 1);
+      assert.equal(parsed.sessions[0].source.codex_home, 'explicit-codex-home');
+      assert.match(parsed.sessions[0].source.transcript_ref, /^[a-f0-9]{12}$/);
+      assert.doesNotMatch(result.stdout, /do not leak/);
+      assert.doesNotMatch(result.stdout, /echo secret/);
+      assert.doesNotMatch(result.stdout, new RegExp(codexHomeDir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+      assert.doesNotMatch(result.stdout, /sessions\//);
+      assert.doesNotMatch(result.stdout, /rollout-cli-friction/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -228,7 +228,7 @@ Usage:
   omx resume    Resume Codex sessions (supports --project and --codex-home <path>)
   omx explore   DEPRECATED compatibility command; use normal repo inspection or omx sparkshell
   omx api       Run native omx-api localhost gateway commands (serve|status|stop|generate)
-  omx session   Search prior local session transcripts (--codex-home <path> escape hatch)
+  omx session   Search and summarize local session history (--codex-home <path> escape hatch)
   omx url       Passive URL reader (read <url> --json)
   omx agents-init [path]
                 Bootstrap lightweight AGENTS.md files for a repo/subtree

--- a/src/cli/session-search.ts
+++ b/src/cli/session-search.ts
@@ -1,11 +1,13 @@
+import { buildSessionFrictionReport, type SessionFrictionReport, type SessionFrictionOptions } from '../session-history/friction.js';
 import { searchSessionHistory, type SessionSearchReport, type SessionSearchOptions } from '../session-history/search.js';
 
-const HELP = `omx session - Search prior local session history
+const HELP = `omx session - Search and summarize local session history
 
 Usage:
   omx session search <query> [options]
+  omx session friction [options]
 
-Options:
+Options for search:
   --limit <n>          Maximum results to return (default: 10)
   --session <id>       Restrict to a specific session id or id fragment
   --since <spec>       Restrict by recency (examples: 7d, 24h, 2026-03-10)
@@ -16,16 +18,30 @@ Options:
   --json               Emit structured JSON
   -h, --help           Show this help
 
+Options for friction:
+  --limit <n>          Maximum sessions to inspect (default: 5)
+  --session <id>       Restrict to a specific session id or id fragment
+  --since <spec>       Restrict by recency (default: 14d)
+  --project <scope>    Filter by project context: current | all | <cwd-fragment>
+  --codex-home <path>  Inspect only the supplied Codex home (escape hatch)
+  --json               Emit structured JSON
+
 Examples:
   omx session search "worker inbox path"
   omx session search all_workers_idle --since 7d --limit 5
-  omx session search "team api" --project current --json
+  omx session friction --project current
+  omx session friction --session <id> --json
 `;
 
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 
 export interface ParsedSessionSearchArgs {
   options: SessionSearchOptions;
+  json: boolean;
+}
+
+export interface ParsedSessionFrictionArgs {
+  options: SessionFrictionOptions;
   json: boolean;
 }
 
@@ -106,6 +122,59 @@ export function parseSessionSearchArgs(args: string[]): ParsedSessionSearchArgs 
   return { options, json };
 }
 
+export function parseSessionFrictionArgs(args: string[]): ParsedSessionFrictionArgs {
+  const options: SessionFrictionOptions = {};
+  let json = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '--json') {
+      json = true;
+      continue;
+    }
+    if (token === '--limit' || token === '--session' || token === '--since' || token === '--project' || token === '--codex-home') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error(`Missing value after ${token}.`);
+      }
+      if (token === '--limit') options.limit = parsePositiveInteger(next, token);
+      if (token === '--session') options.session = next;
+      if (token === '--since') options.since = next;
+      if (token === '--project') options.project = next;
+      if (token === '--codex-home') options.codexHomeDir = next;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith('--limit=')) {
+      options.limit = parsePositiveInteger(token.slice('--limit='.length), '--limit');
+      continue;
+    }
+    if (token.startsWith('--session=')) {
+      options.session = token.slice('--session='.length);
+      continue;
+    }
+    if (token.startsWith('--since=')) {
+      options.since = token.slice('--since='.length);
+      continue;
+    }
+    if (token.startsWith('--project=')) {
+      options.project = token.slice('--project='.length);
+      continue;
+    }
+    if (token.startsWith('--codex-home=')) {
+      options.codexHomeDir = token.slice('--codex-home='.length);
+      continue;
+    }
+    if (token.startsWith('-')) {
+      throw new Error(`Unknown option: ${token}`);
+    }
+    throw new Error(`Unexpected positional argument for friction report: ${token}`);
+  }
+
+  return { options, json };
+}
+
+
 function formatReport(report: SessionSearchReport): string {
   if (report.results.length === 0) {
     return `No session history matches for "${report.query}". Searched ${report.searched_files} transcript(s).`;
@@ -127,6 +196,36 @@ function formatReport(report: SessionSearchReport): string {
   return lines.join('\n');
 }
 
+function formatFrictionReport(report: SessionFrictionReport): string {
+  const lines = [
+    `Session friction report (${report.privacy.mode}; excludes ${report.privacy.excludes.join(', ')}).`,
+    `Scanned ${report.scanned_files} transcript(s) across ${report.sources.length} source(s).`,
+  ];
+
+  if (report.sessions.length === 0) {
+    lines.push('No recent local sessions matched the filters.');
+    return lines.join('\n');
+  }
+
+  for (const session of report.sessions) {
+    lines.push('');
+    lines.push(`session: ${session.session_id}`);
+    lines.push(`cwd: ${session.cwd_basename ?? 'unknown'} (${session.cwd_hash ? `hash:${session.cwd_hash}` : 'hash:unknown'})`);
+    lines.push(`activity: started=${session.started_at ?? 'unknown'} last=${session.last_activity_at ?? 'unknown'} idle=${session.idle_minutes ?? 'unknown'}m age=${session.age_minutes ?? 'unknown'}m`);
+    lines.push(`counts: records=${session.counters.records} user_turns=${session.counters.user_turns} assistant_turns=${session.counters.assistant_turns} tool_calls=${session.counters.tool_calls} tool_outputs=${session.counters.tool_outputs}`);
+    lines.push(`size: approx=${session.context_growth.approx_transcript_kb}KB avg_record=${session.context_growth.avg_record_bytes}B tool_ratio=${session.context_growth.tool_call_ratio}`);
+    lines.push(`idle_gaps: max=${session.idle_gaps.max_gap_minutes ?? 'none'}m over_30m=${session.idle_gaps.gaps_over_30m} over_2h=${session.idle_gaps.gaps_over_2h}`);
+    if (session.tool_names.length > 0) {
+      lines.push(`tools: ${session.tool_names.map((tool) => `${tool.name}(${tool.count})`).join(', ')}`);
+    }
+    lines.push(`risks: ${session.risks.map((risk) => `${risk.severity}:${risk.code}`).join(', ')}`);
+    lines.push(`source: ${session.source.codex_home}:ref:${session.source.transcript_ref}`);
+  }
+
+  return lines.join('\n');
+}
+
+
 export async function sessionCommand(args: string[]): Promise<void> {
   const subcommand = args[0];
   if (!subcommand || HELP_TOKENS.has(subcommand)) {
@@ -134,12 +233,23 @@ export async function sessionCommand(args: string[]): Promise<void> {
     return;
   }
 
-  if (subcommand !== 'search') {
+  if (subcommand !== 'search' && subcommand !== 'friction') {
     throw new Error(`Unknown session subcommand: ${subcommand}\n${HELP}`);
   }
 
   if (args.slice(1).some((token) => HELP_TOKENS.has(token))) {
     console.log(HELP.trim());
+    return;
+  }
+
+  if (subcommand === 'friction') {
+    const parsed = parseSessionFrictionArgs(args.slice(1));
+    const report = await buildSessionFrictionReport(parsed.options);
+    if (parsed.json) {
+      console.log(JSON.stringify(report, null, 2));
+      return;
+    }
+    console.log(formatFrictionReport(report));
     return;
   }
 

--- a/src/session-history/__tests__/friction.test.ts
+++ b/src/session-history/__tests__/friction.test.ts
@@ -1,0 +1,122 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildSessionFrictionReport } from '../friction.js';
+
+async function writeRollout(
+  codexHomeDir: string,
+  isoDate: string,
+  fileName: string,
+  lines: Array<Record<string, unknown> | string>,
+): Promise<void> {
+  const [year, month, day] = isoDate.slice(0, 10).split('-');
+  const dir = join(codexHomeDir, 'sessions', year, month, day);
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, fileName),
+    `${lines.map((line) => typeof line === 'string' ? line : JSON.stringify(line)).join('\n')}\n`,
+    'utf-8',
+  );
+}
+
+describe('buildSessionFrictionReport', () => {
+  it('summarizes metadata-only friction signals without raw transcript payloads', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-friction-'));
+    const codexHomeDir = join(cwd, '.codex-home');
+    try {
+      await writeRollout(codexHomeDir, '2026-06-24T09:00:00.000Z', 'rollout-safe-session.jsonl', [
+        {
+          type: 'session_meta',
+          timestamp: '2026-06-24T09:00:00.000Z',
+          payload: { id: 'safe-session', timestamp: '2026-06-24T09:00:00.000Z', cwd },
+        },
+        {
+          type: 'event_msg',
+          timestamp: '2026-06-24T09:01:00.000Z',
+          payload: { type: 'user_message', message: 'secret prompt must not be emitted sk-test-secret' },
+        },
+        {
+          type: 'response_item',
+          timestamp: '2026-06-24T09:02:00.000Z',
+          payload: { type: 'function_call', name: 'read', arguments: '{"path":"private.txt"}' },
+        },
+        {
+          type: 'response_item',
+          timestamp: '2026-06-24T12:10:00.000Z',
+          payload: { type: 'function_call_output', output: 'private output must not be emitted' },
+        },
+        '{not-json',
+      ]);
+
+      const report = await buildSessionFrictionReport({
+        cwd,
+        codexHomeDirs: [codexHomeDir],
+        now: Date.parse('2026-06-25T12:10:00.000Z'),
+        since: '7d',
+      });
+
+      assert.equal(report.privacy.mode, 'metadata-only');
+      assert.ok(report.privacy.excludes.includes('raw_prompts'));
+      assert.equal(report.sessions.length, 1);
+      const session = report.sessions[0];
+      assert.equal(session.session_id, 'safe-session');
+      assert.equal(session.cwd_basename, cwd.split('/').at(-1));
+      assert.match(session.cwd_hash ?? '', /^[a-f0-9]{12}$/);
+      assert.equal(session.counters.records, 5);
+      assert.equal(session.counters.malformed_records, 1);
+      assert.equal(session.counters.user_turns, 1);
+      assert.equal(session.counters.tool_calls, 1);
+      assert.equal(session.counters.tool_outputs, 1);
+      assert.equal(session.idle_gaps.gaps_over_2h, 1);
+      assert.deepEqual(session.tool_names, [{ name: 'read', count: 1 }]);
+      assert.ok(session.risks.some((risk) => risk.code === 'stale_session'));
+      assert.ok(session.risks.some((risk) => risk.code === 'large_idle_gap'));
+      assert.ok(session.risks.some((risk) => risk.code === 'parse_gaps'));
+
+      assert.match(session.source.transcript_ref, /^[a-f0-9]{12}$/);
+
+      const serialized = JSON.stringify(report);
+      assert.doesNotMatch(serialized, /secret prompt/);
+      assert.doesNotMatch(serialized, /sk-test-secret/);
+      assert.doesNotMatch(serialized, /private output/);
+      assert.doesNotMatch(serialized, /private\.txt/);
+      assert.doesNotMatch(serialized, /\.codex-home/);
+      assert.doesNotMatch(serialized, /sessions\//);
+      assert.doesNotMatch(serialized, /rollout-safe-session/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('defaults to current-project recent sessions and safe source labels', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-friction-current-'));
+    const otherCwd = await mkdtemp(join(tmpdir(), 'omx-session-friction-other-'));
+    const codexHomeDir = join(cwd, '.codex-home');
+    try {
+      await writeRollout(codexHomeDir, '2026-06-24T09:00:00.000Z', 'rollout-current.jsonl', [
+        { type: 'session_meta', timestamp: '2026-06-24T09:00:00.000Z', payload: { id: 'current-session', timestamp: '2026-06-24T09:00:00.000Z', cwd } },
+      ]);
+      await writeRollout(codexHomeDir, '2026-06-24T10:00:00.000Z', 'rollout-other.jsonl', [
+        { type: 'session_meta', timestamp: '2026-06-24T10:00:00.000Z', payload: { id: 'other-session', timestamp: '2026-06-24T10:00:00.000Z', cwd: otherCwd } },
+      ]);
+
+      const report = await buildSessionFrictionReport({
+        cwd,
+        codexHomeDir,
+        now: Date.parse('2026-06-24T11:00:00.000Z'),
+        since: '7d',
+      });
+
+      assert.deepEqual(report.sessions.map((session) => session.session_id), ['current-session']);
+      assert.equal(report.sources[0].codex_home, 'explicit-codex-home');
+      assert.equal(report.sources[0].codex_home.includes(codexHomeDir), false);
+      assert.equal(report.sessions[0].source.codex_home, 'explicit-codex-home');
+      assert.match(report.sessions[0].source.transcript_ref, /^[a-f0-9]{12}$/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(otherCwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/session-history/friction.ts
+++ b/src/session-history/friction.ts
@@ -1,0 +1,444 @@
+import { createHash } from 'node:crypto';
+import { createReadStream, existsSync } from 'node:fs';
+import { readdir, realpath, stat } from 'node:fs/promises';
+import { basename, join, resolve } from 'node:path';
+import { createInterface } from 'node:readline';
+import { discoverProjectRuntimeCodexHomes } from '../cli/project-runtime-codex-homes.js';
+import { codexHome } from '../utils/paths.js';
+import { parseSinceSpec } from './search.js';
+
+type JsonRecord = Record<string, unknown>;
+
+export interface SessionFrictionOptions {
+  limit?: number;
+  session?: string;
+  since?: string;
+  project?: string;
+  cwd?: string;
+  now?: number;
+  codexHomeDir?: string;
+  codexHomeDirs?: string[];
+}
+
+export interface SessionFrictionSourceReport {
+  codex_home: string;
+  scanned_files: number;
+}
+
+export interface SessionFrictionRisk {
+  code: string;
+  severity: 'info' | 'warn' | 'high';
+  message: string;
+}
+
+export interface SessionFrictionSessionReport {
+  session_id: string;
+  started_at: string | null;
+  last_activity_at: string | null;
+  age_minutes: number | null;
+  idle_minutes: number | null;
+  cwd_basename: string | null;
+  cwd_hash: string | null;
+  source: {
+    codex_home: string;
+    transcript_ref: string;
+  };
+  counters: {
+    records: number;
+    malformed_records: number;
+    bytes: number;
+    user_turns: number;
+    assistant_turns: number;
+    tool_calls: number;
+    tool_outputs: number;
+  };
+  context_growth: {
+    approx_transcript_kb: number;
+    avg_record_bytes: number;
+    tool_call_ratio: number;
+  };
+  idle_gaps: {
+    max_gap_minutes: number | null;
+    gaps_over_30m: number;
+    gaps_over_2h: number;
+  };
+  tool_names: Array<{ name: string; count: number }>;
+  risks: SessionFrictionRisk[];
+}
+
+export interface SessionFrictionReport {
+  generated_at: string;
+  privacy: {
+    mode: 'metadata-only';
+    excludes: string[];
+  };
+  scanned_files: number;
+  sources: SessionFrictionSourceReport[];
+  sessions: SessionFrictionSessionReport[];
+}
+
+interface ResolvedCodexHomeSource {
+  dir: string;
+  publicLabel: string;
+}
+
+interface SessionMeta {
+  sessionId: string;
+  timestamp: string | null;
+  cwd: string | null;
+}
+
+const DEFAULT_LIMIT = 5;
+const MAX_LIMIT = 50;
+const DEFAULT_SINCE = '14d';
+const DANGER_BYTES = 1_500_000;
+const WARN_BYTES = 750_000;
+const DANGER_RECORDS = 5000;
+const WARN_RECORDS = 2500;
+const STALE_MINUTES = 24 * 60;
+const OLD_SESSION_MINUTES = 7 * 24 * 60;
+
+function clampLimit(value: number | undefined): number {
+  if (!Number.isInteger(value) || value == null || value <= 0) return DEFAULT_LIMIT;
+  return Math.min(value, MAX_LIMIT);
+}
+
+function safeParseJson(line: string): JsonRecord | null {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    return parsed && typeof parsed === 'object' ? parsed as JsonRecord : null;
+  } catch {
+    return null;
+  }
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value : null;
+}
+
+function asObject(value: unknown): JsonRecord | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonRecord : null;
+}
+
+function extractSessionMeta(parsed: JsonRecord | null): SessionMeta | null {
+  if (!parsed || parsed.type !== 'session_meta') return null;
+  const payload = asObject(parsed.payload);
+  if (!payload) return null;
+  const sessionId = asString(payload.id) ?? asString(payload.session_id) ?? asString(payload.sessionId);
+  if (!sessionId) return null;
+  return {
+    sessionId,
+    timestamp: asString(payload.timestamp) ?? asString(parsed.timestamp),
+    cwd: asString(payload.cwd),
+  };
+}
+
+function extractRecordTimestamp(parsed: JsonRecord | null): number | null {
+  if (!parsed) return null;
+  const candidates = [
+    asString(parsed.timestamp),
+    asString(asObject(parsed.payload)?.timestamp),
+    asString(asObject(parsed.payload)?.created_at),
+  ];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const value = Date.parse(candidate);
+    if (!Number.isNaN(value)) return value;
+  }
+  return null;
+}
+
+function normalizeProjectFilter(project: string | undefined, cwd: string): string | undefined {
+  if (!project) return undefined;
+  const trimmed = project.trim();
+  if (trimmed === '' || trimmed === 'all') return undefined;
+  if (trimmed === 'current') return cwd;
+  return trimmed;
+}
+
+function normalizeDarwinPathAlias(value: string): string {
+  return process.platform === 'darwin' ? value.replaceAll('/private/var/', '/var/') : value;
+}
+
+function matchesFilter(value: string | null, filter: string | undefined): boolean {
+  if (!filter) return true;
+  if (!value) return false;
+  return normalizeDarwinPathAlias(value).toLowerCase().includes(normalizeDarwinPathAlias(filter).toLowerCase());
+}
+
+function stableHash(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 12);
+}
+
+function publicCwdBasename(cwd: string | null): string | null {
+  if (!cwd) return null;
+  return basename(cwd) || null;
+}
+
+function roundMinutes(ms: number): number {
+  return Math.round(ms / 60_000);
+}
+
+function roundOne(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+async function normalizeExistingCodexHomeDirs(candidates: Array<string | ResolvedCodexHomeSource>): Promise<ResolvedCodexHomeSource[]> {
+  const seen = new Set<string>();
+  const dirs: ResolvedCodexHomeSource[] = [];
+  for (const candidate of candidates) {
+    const rawDir = typeof candidate === 'string' ? candidate : candidate.dir;
+    const trimmed = rawDir.trim();
+    if (trimmed === '') continue;
+    const absolute = resolve(trimmed);
+    if (!existsSync(absolute)) continue;
+    const key = await realpath(absolute).catch(() => absolute);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    dirs.push({
+      dir: absolute,
+      publicLabel: typeof candidate === 'string' ? 'codex-home' : candidate.publicLabel,
+    });
+  }
+  return dirs;
+}
+
+async function resolveCodexHomeSources(options: Pick<SessionFrictionOptions, 'cwd' | 'codexHomeDir' | 'codexHomeDirs'>): Promise<ResolvedCodexHomeSource[]> {
+  const cwd = options.cwd ?? process.cwd();
+  if (options.codexHomeDirs && options.codexHomeDirs.length > 0) {
+    return normalizeExistingCodexHomeDirs(options.codexHomeDirs);
+  }
+  if (options.codexHomeDir) {
+    return normalizeExistingCodexHomeDirs([{ dir: options.codexHomeDir, publicLabel: 'explicit-codex-home' }]);
+  }
+  const projectHomes = await discoverProjectRuntimeCodexHomes(cwd);
+  return normalizeExistingCodexHomeDirs([
+    { dir: codexHome(), publicLabel: 'default-codex-home' },
+    ...projectHomes.map((home) => ({
+      dir: home.path,
+      publicLabel: home.source === 'madmax-run' ? home.publicLabel ?? 'madmax:runtime-codex-home' : 'project-runtime-codex-home',
+    })),
+  ]);
+}
+
+async function listRolloutFiles(root: string): Promise<string[]> {
+  if (!existsSync(root)) return [];
+  const files: string[] = [];
+  const queue = [root];
+  while (queue.length > 0) {
+    const dir = queue.pop();
+    if (!dir) continue;
+    const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(path);
+        continue;
+      }
+      if (entry.isFile() && entry.name.startsWith('rollout-') && entry.name.endsWith('.jsonl')) files.push(path);
+    }
+  }
+  return files;
+}
+
+function buildRisks(input: {
+  records: number;
+  bytes: number;
+  malformedRecords: number;
+  idleMinutes: number | null;
+  ageMinutes: number | null;
+  toolCalls: number;
+  userTurns: number;
+  maxGapMinutes: number | null;
+}): SessionFrictionRisk[] {
+  const risks: SessionFrictionRisk[] = [];
+  if (input.bytes >= DANGER_BYTES || input.records >= DANGER_RECORDS) {
+    risks.push({ code: 'context_bloat_high', severity: 'high', message: 'Transcript metadata suggests a very large continuation context.' });
+  } else if (input.bytes >= WARN_BYTES || input.records >= WARN_RECORDS) {
+    risks.push({ code: 'context_bloat_watch', severity: 'warn', message: 'Transcript metadata suggests growing continuation context.' });
+  }
+  if (input.idleMinutes != null && input.idleMinutes >= STALE_MINUTES) {
+    risks.push({ code: 'stale_session', severity: 'warn', message: 'Last observed activity is more than 24 hours old.' });
+  }
+  if (input.ageMinutes != null && input.ageMinutes >= OLD_SESSION_MINUTES) {
+    risks.push({ code: 'long_running_session', severity: 'warn', message: 'Session began more than 7 days ago.' });
+  }
+  if (input.maxGapMinutes != null && input.maxGapMinutes >= 120) {
+    risks.push({ code: 'large_idle_gap', severity: 'info', message: 'Session contains idle gaps over 2 hours, which can make continuation state stale.' });
+  }
+  if (input.toolCalls >= 100 || (input.userTurns > 0 && input.toolCalls / input.userTurns >= 10)) {
+    risks.push({ code: 'tool_heavy', severity: 'warn', message: 'Tool-call volume is high relative to user turns.' });
+  }
+  if (input.malformedRecords > 0) {
+    risks.push({ code: 'parse_gaps', severity: 'info', message: 'Some transcript records could not be parsed as JSON.' });
+  }
+  if (risks.length === 0) {
+    risks.push({ code: 'no_obvious_friction', severity: 'info', message: 'No obvious size, staleness, or tool-volume risk crossed default thresholds.' });
+  }
+  return risks;
+}
+
+async function inspectRolloutFile(filePath: string, source: ResolvedCodexHomeSource, options: { now: number; projectFilter?: string; session?: string; sinceCutoff: number | null }): Promise<SessionFrictionSessionReport | null> {
+  const fileStat = await stat(filePath).catch(() => null);
+  if (!fileStat) return null;
+  if (options.sinceCutoff != null && fileStat.mtimeMs < options.sinceCutoff) return null;
+
+  const stream = createReadStream(filePath, 'utf-8');
+  const reader = createInterface({ input: stream, crlfDelay: Infinity });
+  let meta: SessionMeta | null = null;
+  let records = 0;
+  let malformedRecords = 0;
+  let userTurns = 0;
+  let assistantTurns = 0;
+  let toolCalls = 0;
+  let toolOutputs = 0;
+  let firstTimestamp: number | null = null;
+  let lastTimestamp: number | null = null;
+  let maxGapMs = 0;
+  let gapsOver30m = 0;
+  let gapsOver2h = 0;
+  const toolNames = new Map<string, number>();
+
+  try {
+    for await (const line of reader) {
+      if (line.trim() === '') continue;
+      records += 1;
+      const parsed = safeParseJson(line);
+      if (!parsed) malformedRecords += 1;
+      if (records === 1) {
+        meta = extractSessionMeta(parsed) ?? { sessionId: filePath.split('rollout-')[1]?.replace(/\.jsonl$/, '') ?? basename(filePath, '.jsonl'), timestamp: null, cwd: null };
+        if (!matchesFilter(meta.sessionId, options.session)) return null;
+        if (!matchesFilter(meta.cwd, options.projectFilter)) return null;
+      }
+
+      const timestamp = extractRecordTimestamp(parsed);
+      if (timestamp != null) {
+        if (firstTimestamp == null) firstTimestamp = timestamp;
+        if (lastTimestamp != null && timestamp > lastTimestamp) {
+          const gap = timestamp - lastTimestamp;
+          maxGapMs = Math.max(maxGapMs, gap);
+          if (gap >= 30 * 60_000) gapsOver30m += 1;
+          if (gap >= 120 * 60_000) gapsOver2h += 1;
+        }
+        lastTimestamp = Math.max(lastTimestamp ?? timestamp, timestamp);
+      }
+
+      const type = asString(parsed?.type);
+      const payload = asObject(parsed?.payload);
+      const payloadType = asString(payload?.type);
+      if (type === 'event_msg' && payloadType === 'user_message') userTurns += 1;
+      if (type === 'response_item' && payloadType === 'message') {
+        const role = asString(payload?.role);
+        if (role === 'user') userTurns += 1;
+        if (role === 'assistant') assistantTurns += 1;
+      }
+      if (type === 'response_item' && payloadType === 'function_call') {
+        toolCalls += 1;
+        const name = asString(payload?.name);
+        if (name) toolNames.set(name, (toolNames.get(name) ?? 0) + 1);
+      }
+      if (type === 'response_item' && payloadType === 'function_call_output') toolOutputs += 1;
+    }
+  } finally {
+    reader.close();
+    stream.destroy();
+  }
+
+  if (!meta) return null;
+  const startedAt = meta.timestamp ? Date.parse(meta.timestamp) : firstTimestamp;
+  const lastActivity = lastTimestamp ?? startedAt ?? fileStat.mtimeMs;
+  const ageMinutes = startedAt != null && !Number.isNaN(startedAt) ? Math.max(0, roundMinutes(options.now - startedAt)) : null;
+  const idleMinutes = lastActivity != null && !Number.isNaN(lastActivity) ? Math.max(0, roundMinutes(options.now - lastActivity)) : null;
+  const maxGapMinutes = maxGapMs > 0 ? roundMinutes(maxGapMs) : null;
+
+  return {
+    session_id: meta.sessionId,
+    started_at: startedAt != null && !Number.isNaN(startedAt) ? new Date(startedAt).toISOString() : null,
+    last_activity_at: lastActivity != null && !Number.isNaN(lastActivity) ? new Date(lastActivity).toISOString() : null,
+    age_minutes: ageMinutes,
+    idle_minutes: idleMinutes,
+    cwd_basename: publicCwdBasename(meta.cwd),
+    cwd_hash: meta.cwd ? stableHash(meta.cwd) : null,
+    source: {
+      codex_home: source.publicLabel,
+      transcript_ref: stableHash(`${source.dir}\0${filePath}`),
+    },
+    counters: {
+      records,
+      malformed_records: malformedRecords,
+      bytes: fileStat.size,
+      user_turns: userTurns,
+      assistant_turns: assistantTurns,
+      tool_calls: toolCalls,
+      tool_outputs: toolOutputs,
+    },
+    context_growth: {
+      approx_transcript_kb: roundOne(fileStat.size / 1024),
+      avg_record_bytes: records > 0 ? Math.round(fileStat.size / records) : 0,
+      tool_call_ratio: userTurns > 0 ? roundOne(toolCalls / userTurns) : toolCalls,
+    },
+    idle_gaps: {
+      max_gap_minutes: maxGapMinutes,
+      gaps_over_30m: gapsOver30m,
+      gaps_over_2h: gapsOver2h,
+    },
+    tool_names: [...toolNames.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .slice(0, 10)
+      .map(([name, count]) => ({ name, count })),
+    risks: buildRisks({
+      records,
+      bytes: fileStat.size,
+      malformedRecords,
+      idleMinutes,
+      ageMinutes,
+      toolCalls,
+      userTurns,
+      maxGapMinutes,
+    }),
+  };
+}
+
+export async function buildSessionFrictionReport(options: SessionFrictionOptions = {}): Promise<SessionFrictionReport> {
+  const cwd = options.cwd ?? process.cwd();
+  const now = options.now ?? Date.now();
+  const limit = clampLimit(options.limit);
+  const sinceCutoff = parseSinceSpec(options.since ?? DEFAULT_SINCE, now);
+  const projectFilter = normalizeProjectFilter(options.project ?? 'current', cwd);
+  const sources = await resolveCodexHomeSources({ cwd, codexHomeDir: options.codexHomeDir, codexHomeDirs: options.codexHomeDirs });
+  const sessions: SessionFrictionSessionReport[] = [];
+  const sourceReports: SessionFrictionSourceReport[] = [];
+  let scannedFiles = 0;
+
+  for (const source of sources) {
+    const rolloutRoot = join(source.dir, 'sessions');
+    const files = (await listRolloutFiles(rolloutRoot)).sort((a, b) => b.localeCompare(a));
+    let sourceScanned = 0;
+    for (const filePath of files) {
+      if (sessions.length >= limit) break;
+      sourceScanned += 1;
+      scannedFiles += 1;
+      const session = await inspectRolloutFile(filePath, source, {
+        now,
+        projectFilter,
+        session: options.session,
+        sinceCutoff,
+      });
+      if (session) sessions.push(session);
+    }
+    sourceReports.push({ codex_home: source.publicLabel, scanned_files: sourceScanned });
+  }
+
+  sessions.sort((a, b) => Date.parse(b.last_activity_at ?? '') - Date.parse(a.last_activity_at ?? ''));
+
+  return {
+    generated_at: new Date(now).toISOString(),
+    privacy: {
+      mode: 'metadata-only',
+      excludes: ['raw_prompts', 'raw_messages', 'tool_arguments', 'tool_outputs', 'tokens', 'full_transcripts', 'private_config_values'],
+    },
+    scanned_files: scannedFiles,
+    sources: sourceReports,
+    sessions: sessions.slice(0, limit),
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `omx session friction` under the existing local session namespace.
- Reports metadata-only continuation/friction signals: turn and tool counts, idle gaps, transcript size proxies, stale/long-running/tool-heavy risks, cwd basename/hash, safe source label, and opaque transcript ref.
- Keeps output public-safe by default: no raw prompts/messages, tool args/outputs, tokens, full transcripts, private config values, absolute Codex home/cwd paths, or raw transcript paths.

Fixes #2969

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/session-history/__tests__/friction.test.js dist/session-history/__tests__/search.test.js dist/cli/__tests__/session-search.test.js dist/cli/__tests__/session-search-help.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
- Architect re-review: CLEAR/APPROVE after transcript-path privacy fix.

## Notes
- `.gjc/` runtime state was left uncommitted.
- QA subagent output was schema-flaky; direct focused verification and architect re-review passed after fixing the transcript-path privacy blocker.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
