### PR TITLE
Fix HUD stale review status

### DIFF
--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'node:os';
 import { basename, join, relative } from 'node:path';
 import { renderHud } from '../render.js';
 import { recordSkillActivation } from '../../hooks/keyword-detector.js';
+import { createSubagentTrackingState, recordSubagentTurn, writeSubagentTrackingState } from '../../subagents/tracker.js';
 import {
   buildGitBranchLabel,
   readGitBranch,
@@ -858,6 +859,88 @@ describe('readAllState canonical skill precedence', () => {
       assert.equal(state.codeReview, null);
       assert.equal(state.ultraqa, null);
       assert.deepEqual(state.autopilot, { active: true, mode: 'autopilot', current_phase: 'ralplan' });
+    });
+  });
+
+  it('surfaces live code-reviewer subagent evidence when canonical autopilot state is inactive', async () => {
+    await withTempRepo('omx-hud-inactive-autopilot-live-review-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-inactive-autopilot-review';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: false,
+        skill: 'autopilot',
+        phase: 'reviewing',
+        session_id: sessionId,
+      }));
+      await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+        active: false,
+        mode: 'autopilot',
+        current_phase: 'reviewing',
+        session_id: sessionId,
+      }));
+
+      let tracking = createSubagentTrackingState();
+      tracking = recordSubagentTurn(tracking, {
+        sessionId,
+        threadId: 'thread-leader',
+        kind: 'leader',
+        timestamp: '2026-06-25T00:00:00.000Z',
+      });
+      tracking = recordSubagentTurn(tracking, {
+        sessionId,
+        threadId: 'thread-code-reviewer',
+        kind: 'subagent',
+        leaderThreadId: 'thread-leader',
+        mode: 'code-reviewer',
+        timestamp: new Date().toISOString(),
+      });
+      await writeSubagentTrackingState(cwd, tracking);
+
+      const state = await readAllState(cwd);
+      assert.equal(state.autopilot, null);
+      assert.deepEqual(state.codeReview, { active: true, current_phase: 'reviewing', source: 'subagent-tracking' });
+      assert.equal(stripSgr(renderHud(state, 'focused')).includes('code-review:reviewing'), true);
+    });
+  });
+
+  it('does not surface completed code-reviewer subagent history over inactive canonical state', async () => {
+    await withTempRepo('omx-hud-inactive-autopilot-completed-review-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-inactive-autopilot-completed-review';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: false,
+        skill: 'autopilot',
+        phase: 'reviewing',
+        session_id: sessionId,
+      }));
+
+      let tracking = createSubagentTrackingState();
+      tracking = recordSubagentTurn(tracking, {
+        sessionId,
+        threadId: 'thread-leader',
+        kind: 'leader',
+        timestamp: '2026-06-25T00:00:00.000Z',
+      });
+      tracking = recordSubagentTurn(tracking, {
+        sessionId,
+        threadId: 'thread-code-reviewer',
+        kind: 'subagent',
+        leaderThreadId: 'thread-leader',
+        mode: 'code-reviewer',
+        completed: true,
+        timestamp: new Date().toISOString(),
+      });
+      await writeSubagentTrackingState(cwd, tracking);
+
+      const state = await readAllState(cwd);
+      assert.equal(state.autopilot, null);
+      assert.equal(state.codeReview, null);
     });
   });
 

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -906,6 +906,53 @@ describe('readAllState canonical skill precedence', () => {
     });
   });
 
+  it('does not surface live code-reviewer subagent evidence over active Autopilot planning', async () => {
+    await withTempRepo('omx-hud-active-autopilot-live-review-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-active-autopilot-review';
+      const sessionDir = join(rootStateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        active: true,
+        skill: 'autopilot',
+        phase: 'planning',
+        session_id: sessionId,
+        active_skills: [{ skill: 'autopilot', phase: 'planning', active: true, session_id: sessionId }],
+      }));
+      await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'planning',
+        session_id: sessionId,
+      }));
+
+      let tracking = createSubagentTrackingState();
+      tracking = recordSubagentTurn(tracking, {
+        sessionId,
+        threadId: 'thread-leader',
+        kind: 'leader',
+        timestamp: '2026-06-25T00:00:00.000Z',
+      });
+      tracking = recordSubagentTurn(tracking, {
+        sessionId,
+        threadId: 'thread-code-reviewer',
+        kind: 'subagent',
+        leaderThreadId: 'thread-leader',
+        mode: 'code-reviewer',
+        timestamp: new Date().toISOString(),
+      });
+      await writeSubagentTrackingState(cwd, tracking);
+
+      const state = await readAllState(cwd);
+      assert.deepEqual(state.autopilot, { active: true, mode: 'autopilot', current_phase: 'planning', session_id: sessionId });
+      assert.equal(state.codeReview, null);
+      const rendered = stripSgr(renderHud(state, 'focused'));
+      assert.equal(rendered.includes('autopilot:planning'), true);
+      assert.equal(rendered.includes('code-review:reviewing'), false);
+    });
+  });
+
   it('does not surface completed code-reviewer subagent history over inactive canonical state', async () => {
     await withTempRepo('omx-hud-inactive-autopilot-completed-review-', async (cwd) => {
       const rootStateDir = join(cwd, '.omx', 'state');

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -15,6 +15,11 @@ import { getBaseStateDir, getStateFilePath, readCurrentSessionId, resolveRuntime
 import { teamReadPhase as readTeamPhase } from '../team/team-ops.js';
 
 import { listActiveSkills, readVisibleSkillActiveStateForStateDir } from '../state/skill-active.js';
+import {
+  readSubagentTrackingState,
+  summarizeSubagentSession,
+  type SubagentTrackingState,
+} from '../subagents/tracker.js';
 import type {
   RalphStateForHud,
   UltragoalStateForHud,
@@ -537,15 +542,47 @@ function supervisedAutopilotStage<T extends { active?: boolean; current_phase?: 
     : null;
 }
 
+function hasLiveCodeReviewSubagentEvidence(
+  tracking: SubagentTrackingState,
+  sessionId: string | undefined,
+): boolean {
+  if (!sessionId) return false;
+  const summary = summarizeSubagentSession(tracking, sessionId);
+  if (!summary || summary.activeSubagentThreadIds.length === 0) return false;
+  const session = tracking.sessions[sessionId];
+  if (!session) return false;
+  return summary.activeSubagentThreadIds.some((threadId) => {
+    const mode = sanitizeOptionalString(session.threads[threadId]?.mode)?.toLowerCase();
+    return mode === 'code-reviewer' || mode === 'code-review';
+  });
+}
+
+function codeReviewFromSubagentEvidence(
+  canonicalSkills: Map<string, { phase?: string }>,
+  tracking: SubagentTrackingState,
+  sessionId: string | undefined,
+): CodeReviewStateForHud | null {
+  if (!hasLiveCodeReviewSubagentEvidence(tracking, sessionId)) return null;
+  const phase = normalizeCanonicalHudPhase(canonicalPhaseForSkill(canonicalSkills, 'autopilot'));
+  return {
+    active: true,
+    current_phase: phase === 'reviewing' || phase === 'review' || phase === 'code-review'
+      ? phase
+      : 'reviewing',
+    source: 'subagent-tracking',
+  };
+}
+
 /** Read all state files and build the full render context */
 export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFAULT_HUD_CONFIG): Promise<HudRenderContext> {
   const version = readVersion();
   const gitBranch = buildGitBranchLabel(cwd, config);
-  const [metrics, hudNotify, session, currentSessionId] = await Promise.all([
+  const [metrics, hudNotify, session, currentSessionId, subagentTracking] = await Promise.all([
     readMetrics(cwd),
     readHudNotifyState(cwd),
     readSessionState(cwd),
     readCurrentSessionId(cwd),
+    readSubagentTrackingState(cwd),
   ]);
   const stateDir = getBaseStateDir(cwd);
   const canonicalSkillState = await readVisibleSkillActiveStateForStateDir(stateDir, currentSessionId);
@@ -608,7 +645,8 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
       mergePhase<CodeReviewStateForHud>(null, canonicalPhaseForSkill(canonicalSkills, 'code-review')),
       'canonical-skill',
     )
-    : supervisedAutopilotStage<CodeReviewStateForHud>(autopilot, 'code-review');
+    : supervisedAutopilotStage<CodeReviewStateForHud>(autopilot, 'code-review')
+      ?? codeReviewFromSubagentEvidence(canonicalSkills, subagentTracking, currentSessionId);
   const ultraqa = shouldSurfaceCanonicalSkill(canonicalSkills, 'ultraqa', ultraqaDetail)
     ? (() => {
       const detail = ultraqaDetail?.active === true ? ultraqaDetail : null;

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -561,7 +561,9 @@ function codeReviewFromSubagentEvidence(
   canonicalSkills: Map<string, { phase?: string }>,
   tracking: SubagentTrackingState,
   sessionId: string | undefined,
+  autopilot: AutopilotStateForHud | null,
 ): CodeReviewStateForHud | null {
+  if (autopilot?.active === true) return null;
   if (!hasLiveCodeReviewSubagentEvidence(tracking, sessionId)) return null;
   const phase = normalizeCanonicalHudPhase(canonicalPhaseForSkill(canonicalSkills, 'autopilot'));
   return {
@@ -646,7 +648,7 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
       'canonical-skill',
     )
     : supervisedAutopilotStage<CodeReviewStateForHud>(autopilot, 'code-review')
-      ?? codeReviewFromSubagentEvidence(canonicalSkills, subagentTracking, currentSessionId);
+      ?? codeReviewFromSubagentEvidence(canonicalSkills, subagentTracking, currentSessionId, autopilot);
   const ultraqa = shouldSurfaceCanonicalSkill(canonicalSkills, 'ultraqa', ultraqaDetail)
     ? (() => {
       const detail = ultraqaDetail?.active === true ? ultraqaDetail : null;

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -72,7 +72,7 @@ export interface AutoresearchStateForHud {
   current_phase?: string;
 }
 
-export type LateGateHudSource = 'canonical-skill' | 'autopilot';
+export type LateGateHudSource = 'canonical-skill' | 'autopilot' | 'subagent-tracking';
 
 /** Code-review state for HUD display */
 export interface CodeReviewStateForHud {


### PR DESCRIPTION
Fixes #2971

## Summary
- Treat live `subagent-tracking.json` code-reviewer activity as HUD review evidence when canonical Autopilot skill state is inactive/stale.
- Preserve suppression of completed historical code-reviewer threads so old tracking history does not resurrect inactive review status.
- Add focused HUD state tests covering inactive Autopilot plus live/completed code-reviewer tracking evidence.

## Verification
- `npm run build`
- `node --test dist/hud/__tests__/state.test.js dist/hud/__tests__/render.test.js`
- `npm run check:no-unused`
- `npx biome lint src/hud/state.ts src/hud/types.ts src/hud/__tests__/state.test.ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*