### PR TITLE
Fix root-owned artifact warning in omx doctor

### DIFF
--- a/src/cli/__tests__/doctor-artifact-ownership.test.ts
+++ b/src/cli/__tests__/doctor-artifact-ownership.test.ts
@@ -77,6 +77,37 @@ describe("repo artifact ownership doctor check", () => {
 		}
 	});
 
+	it("reports owner-mismatched files for non-root doctor runs", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-artifacts-"));
+		try {
+			const artifact = join(wd, ".beads", "state.json");
+			await mkdir(join(wd, ".beads"), { recursive: true });
+			await writeFile(artifact, "{}\n");
+
+			const check = await checkRepoArtifactOwnership(wd, {
+				currentUid: 1000,
+				statPath: async (path) => {
+					const info = await lstat(path);
+					if (path === artifact) {
+						return new Proxy(info, {
+							get(target, property, receiver) {
+								if (property === "uid") return 1001;
+								if (property === "gid") return 1001;
+								return Reflect.get(target, property, receiver);
+							},
+						});
+					}
+					return info;
+				},
+			});
+
+			assert.equal(check.status, "warn");
+			assert.match(check.message, /\.beads[\\/]state\.json \(owner-mismatch uid=1001 gid=1001\)/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("reports non-writable files under repo-local artifact directories", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-artifacts-"));
 		try {

--- a/src/cli/__tests__/doctor-artifact-ownership.test.ts
+++ b/src/cli/__tests__/doctor-artifact-ownership.test.ts
@@ -42,6 +42,41 @@ describe("repo artifact ownership doctor check", () => {
 		}
 	});
 
+	it("does not warn about root-owned repo artifacts when doctor runs as root", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-artifacts-"));
+		try {
+			const artifact = join(wd, ".omx", "plans", "root-owned.md");
+			await mkdir(join(wd, ".omx", "plans"), { recursive: true });
+			await writeFile(artifact, "# plan\n");
+
+			const check = await checkRepoArtifactOwnership(wd, {
+				currentUid: 0,
+				currentGid: 0,
+				statPath: async (path) => {
+					const info = await lstat(path);
+					if (path === artifact) {
+						return new Proxy(info, {
+							get(target, property, receiver) {
+								if (property === "uid") return 0;
+								if (property === "gid") return 0;
+								return Reflect.get(target, property, receiver);
+							},
+						});
+					}
+					return info;
+				},
+			});
+
+			assert.equal(check.status, "pass");
+			assert.equal(
+				check.message,
+				"repo-local .omx/.beads artifacts are writable by the current user",
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("reports non-writable files under repo-local artifact directories", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-artifacts-"));
 		try {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1005,8 +1005,9 @@ async function collectRepoArtifactOwnershipIssues(
 		const uid = typeof info.uid === "number" ? info.uid : undefined;
 		const gid = typeof info.gid === "number" ? info.gid : undefined;
 		let reason: RepoArtifactIssue["reason"] | null = null;
-		if (uid === 0) reason = "root-owned";
-		else if (shouldReportOwnerMismatch(uid, currentUid)) reason = "owner-mismatch";
+		if (uid === 0) {
+			if (currentUid !== 0) reason = "root-owned";
+		} else if (shouldReportOwnerMismatch(uid, currentUid)) reason = "owner-mismatch";
 		else {
 			try {
 				await accessPath(path, constants.W_OK);

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -970,6 +970,7 @@ function shouldReportOwnerMismatch(
 	uid: number | undefined,
 	currentUid: number | undefined,
 ): boolean {
+	if (currentUid === 0) return false;
 	if (typeof uid !== "number") return false;
 	if (uid === 0) return true;
 	return typeof currentUid === "number" && uid !== currentUid;


### PR DESCRIPTION
## Summary
- Suppress repo artifact ownership warnings for root-owned `.omx/.beads` entries when `omx doctor` runs as root
- Add regression coverage for root execution

## Verification
- Targeted typecheck passed for `src/cli/doctor.ts` and `src/cli/__tests__/doctor-artifact-ownership.test.ts`