### PR TITLE
fix(hud): make standalone-tmux HUD reconcile non-blocking and self-healing

### DIFF
--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -1907,4 +1907,105 @@ fi
     assert.equal(resized[0]?.paneId, '%2');
     assert.equal(resized[0]?.lines, HUD_TMUX_HEIGHT_LINES);
   });
+
+  it('skips a concurrent reconcile while another holds the cross-process lock', async () => {
+    // The tmux layout/resize hooks re-fire the reconcile while it is mutating the
+    // layout. A second reconcile sharing the same lock dir must back off instead
+    // of racing the first one's split/kill.
+    const lockDir = await mkdtemp(join(tmpdir(), 'omx-hud-reconcile-lock-'));
+    try {
+      const created: string[] = [];
+      const killed: string[] = [];
+
+      const sharedDeps = {
+        env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-lock', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+        lockDir,
+        listCurrentWindowPanes: () => [{ paneId: '%1', currentCommand: 'codex', startCommand: 'codex' }],
+        createHudWatchPane: () => {
+          created.push('create');
+          return '%9';
+        },
+        killTmuxPane: (paneId: string) => {
+          killed.push(paneId);
+          return true;
+        },
+        resizeTmuxPane: () => true,
+        unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+        registerHudResizeHook: noOpRegisterHudResizeHook,
+        resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+      };
+
+      // Pre-seed the lock as if a first reconcile (same key) were still running.
+      const lockKey = 'sess-lock';
+      const lockPath = join(lockDir, `omx-hud-reconcile-${lockKey}.lock`);
+      await writeFile(lockPath, JSON.stringify({ pid: process.pid, ts: Date.now() }), { flag: 'wx' });
+
+      const result = await reconcileHudForPromptSubmit('/repo', sharedDeps);
+
+      assert.equal(result.status, 'skipped_concurrent');
+      assert.equal(result.paneId, null);
+      assert.deepEqual(created, []);
+      assert.deepEqual(killed, []);
+      // The pre-existing live lock is left intact for its holder.
+      assert.equal((await readFile(lockPath, 'utf8')).length > 0, true);
+    } finally {
+      await rm(lockDir, { recursive: true, force: true });
+    }
+  });
+
+  it('steals a stale reconcile lock and proceeds', async () => {
+    const lockDir = await mkdtemp(join(tmpdir(), 'omx-hud-reconcile-lock-'));
+    try {
+      const created: string[] = [];
+
+      const lockPath = join(lockDir, 'omx-hud-reconcile-sess-stale.lock');
+      // A lock written long ago by a holder that is no longer alive.
+      await writeFile(lockPath, JSON.stringify({ pid: 999999, ts: 1 }), { flag: 'wx' });
+
+      const result = await reconcileHudForPromptSubmit('/repo', {
+        env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-stale', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+        lockDir,
+        now: () => 1_000_000, // well beyond the stale threshold relative to ts=1
+        processAlive: () => false,
+        listCurrentWindowPanes: () => [{ paneId: '%1', currentCommand: 'codex', startCommand: 'codex' }],
+        createHudWatchPane: () => {
+          created.push('create');
+          return '%9';
+        },
+        resizeTmuxPane: () => true,
+        unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+        registerHudResizeHook: noOpRegisterHudResizeHook,
+        resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+      });
+
+      assert.equal(result.status, 'recreated');
+      assert.equal(result.paneId, '%9');
+      assert.equal(created.length, 1);
+    } finally {
+      await rm(lockDir, { recursive: true, force: true });
+    }
+  });
+
+  it('removes the reconcile lock after a normal reconcile completes', async () => {
+    const lockDir = await mkdtemp(join(tmpdir(), 'omx-hud-reconcile-lock-'));
+    try {
+      const result = await reconcileHudForPromptSubmit('/repo', {
+        env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-clean', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+        lockDir,
+        listCurrentWindowPanes: () => [{ paneId: '%1', currentCommand: 'codex', startCommand: 'codex' }],
+        createHudWatchPane: () => '%9',
+        resizeTmuxPane: () => true,
+        unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+        registerHudResizeHook: noOpRegisterHudResizeHook,
+        resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+      });
+
+      assert.equal(result.status, 'recreated');
+
+      const lockPath = join(lockDir, 'omx-hud-reconcile-sess-clean.lock');
+      await assert.rejects(readFile(lockPath, 'utf8'), /ENOENT/);
+    } finally {
+      await rm(lockDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -106,7 +106,10 @@ describe('HUD resize hook helpers', () => {
     assert.match(calls[3]?.[4] ?? '', /TMUX/);
     assert.match(calls[3]?.[4] ?? '', /TMUX_PANE/);
     assert.match(calls[3]?.[4] ?? '', /OMX_TMUX_HUD_OWNER/);
-    assert.match(calls[3]?.[4] ?? '', /wait-for/);
+    // The layout-reconcile hook no longer serializes with a blocking `tmux
+    // wait-for`; concurrency is gated non-blockingly inside the reconcile via a
+    // self-healing file lock, so the shell wrapper stays cheap and never blocks.
+    assert.doesNotMatch(calls[3]?.[4] ?? '', /wait-for/);
   });
 
   it('reports partial failure but keeps the resize hook when layout-change hook install fails', () => {

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -1,3 +1,6 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { readAllState, readHudConfig } from './state.js';
 import { getHudRenderMaxLines } from './render.js';
 import { HUD_TMUX_HEIGHT_LINES, isTmuxWindowTooCrampedForHudSplit } from './constants.js';
@@ -114,6 +117,7 @@ export interface ReconcileHudForPromptSubmitResult {
     | 'skipped_not_tmux'
     | 'skipped_no_entry'
     | 'skipped_not_omx_owned_tmux'
+    | 'skipped_concurrent'
     | 'skipped_no_session_id'
     | 'skipped_window_too_cramped'
     | 'unchanged'
@@ -149,6 +153,9 @@ export interface ReconcileHudForPromptSubmitDeps {
   ) => boolean;
   unregisterHudResizeHook?: (leaderPaneId: string | undefined) => boolean;
   readCurrentWindowSize?: (currentPaneId?: string) => { width: number | null; height: number | null };
+  now?: () => number;
+  lockDir?: string;
+  processAlive?: (pid: number) => boolean;
 }
 
 function ensureHudResizeHook(
@@ -222,6 +229,78 @@ function planOwnedHudPaneDedupe(
   };
 }
 
+// A reconcile lock older than this is treated as abandoned and stolen, so a
+// process killed mid-reconcile (e.g. between split-window and the next list)
+// cannot wedge the lock permanently.
+const RECONCILE_LOCK_STALE_MS = 10_000;
+
+function defaultProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: any) {
+    // EPERM means the process exists but we may not signal it; treat as alive.
+    return e?.code === 'EPERM';
+  }
+}
+
+/**
+ * Non-blocking, self-healing cross-process mutex for the standalone-tmux HUD
+ * reconcile. The tmux layout-change/resize hooks fire the reconcile, which
+ * mutates the layout (split/kill panes) and re-fires the hooks. The shell
+ * wrapper no longer serializes with a blocking `tmux wait-for`; concurrency is
+ * gated here instead. Acquisition never blocks: a competing reconcile simply
+ * skips. A lock left behind by a crashed/killed holder is stolen once it is
+ * stale (older than RECONCILE_LOCK_STALE_MS) or its pid is no longer alive, and
+ * a corrupt/unreadable lock file is treated as stealable rather than throwing.
+ */
+function acquireReconcileLock(
+  lockPath: string,
+  now: () => number,
+  processAlive: (pid: number) => boolean,
+): boolean {
+  const writeLock = (flag: 'wx' | 'w'): boolean => {
+    try {
+      fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, ts: now() }), { flag });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  if (writeLock('wx')) return true;
+
+  // Lock file already exists: decide whether the holder is gone/stale.
+  let stealable = false;
+  try {
+    const raw = fs.readFileSync(lockPath, 'utf8');
+    const parsed = JSON.parse(raw) as { pid?: unknown; ts?: unknown };
+    const ts = typeof parsed.ts === 'number' ? parsed.ts : 0;
+    const pid = typeof parsed.pid === 'number' ? parsed.pid : 0;
+    stealable = now() - ts > RECONCILE_LOCK_STALE_MS || !processAlive(pid);
+  } catch {
+    // Corrupt/unreadable lock file — treat as abandoned and stealable.
+    stealable = true;
+  }
+
+  if (!stealable) return false;
+
+  try {
+    fs.unlinkSync(lockPath);
+  } catch {
+    // Best-effort: another reconcile may have already cleaned it up.
+  }
+  return writeLock('w');
+}
+
+function releaseReconcileLock(lockPath: string): void {
+  try {
+    fs.unlinkSync(lockPath);
+  } catch {
+    // Best-effort cleanup; a stale lock is self-healed on next acquisition.
+  }
+}
+
 export async function reconcileHudForPromptSubmit(
   cwd: string,
   deps: ReconcileHudForPromptSubmitDeps = {},
@@ -270,6 +349,28 @@ export async function reconcileHudForPromptSubmit(
   ]
     .map((sessionId) => sessionId?.trim() ?? '')
     .filter((sessionId, index, sessionIds) => sessionId !== '' && sessionIds.indexOf(sessionId) === index);
+
+  // Non-blocking cross-process mutex: the tmux layout/resize hooks fire this
+  // reconcile, which mutates the layout and re-fires the hooks. Acquire a
+  // self-healing file lock so a concurrent reconcile skips instead of piling up
+  // (the shell wrapper no longer blocks on `tmux wait-for`). If we cannot
+  // acquire it, another reconcile is already in flight — bail without touching
+  // the layout.
+  const now = deps.now ?? Date.now;
+  const processAlive = deps.processAlive ?? defaultProcessAlive;
+  const lockDir = deps.lockDir ?? os.tmpdir();
+  const lockKey = (resolvedSessionId || currentPaneId || 'global').replace(/[^A-Za-z0-9._-]/g, '_');
+  const lockPath = path.join(lockDir, `omx-hud-reconcile-${lockKey}.lock`);
+  if (!acquireReconcileLock(lockPath, now, processAlive)) {
+    return {
+      status: 'skipped_concurrent',
+      paneId: null,
+      desiredHeight: null,
+      duplicateCount: 0,
+    };
+  }
+
+  try {
   let panes = listPanes(currentPaneId);
 
   // Reclaim orphaned HUD panes left behind by a destroyed leader before deciding
@@ -448,4 +549,7 @@ export async function reconcileHudForPromptSubmit(
     desiredHeight,
     duplicateCount: postCreate.duplicatePaneIds.length,
   };
+  } finally {
+    releaseReconcileLock(lockPath);
+  }
 }

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -448,9 +448,6 @@ function buildHudLayoutReconcileHookCommand(
   const cwd = options.cwd?.trim() || process.cwd();
   const leaderAlive = buildNestedTmuxCommand(tmuxBin, ['display-message', '-p', '-t', leaderPaneId, '#{pane_id}'], env.TMUX);
   const unregister = buildHudHookUnregisterCommand(tmuxBin, context, env.TMUX);
-  const lockName = `${context.hookName}_layout`;
-  const lock = buildNestedTmuxCommand(tmuxBin, ['wait-for', '-L', lockName], env.TMUX);
-  const unlock = buildNestedTmuxCommand(tmuxBin, ['wait-for', '-U', lockName], env.TMUX);
   const reconcileEnv = buildEnvPrefix({
     TMUX: env.TMUX,
     TMUX_PANE: leaderPaneId,
@@ -469,7 +466,13 @@ function buildHudLayoutReconcileHookCommand(
     'hud',
     '--reconcile-tmux',
   ].join(' ');
-  return `${leaderAlive} >/dev/null 2>&1 && (${lock} >/dev/null 2>&1; ${unregister}; ${reconcile} >/dev/null 2>&1; status=$?; ${unlock} >/dev/null 2>&1; exit $status) || (${unregister})`;
+  // No blocking tmux `wait-for` serialization here: a blocking lock around the
+  // reconcile caused unbounded `sh`-wrapper pile-up under layout churn (every
+  // `window-layout-changed`/`client-resized` fire queued on the lock) and could
+  // deadlock permanently if a reconcile was killed between `-L` and `-U`.
+  // Concurrency is now handled non-blockingly inside the reconcile via a
+  // self-healing file lock, so the shell wrapper stays cheap and never blocks.
+  return `${leaderAlive} >/dev/null 2>&1 && (${unregister}; ${reconcile} >/dev/null 2>&1) || (${unregister})`;
 }
 
 function unregisterLegacyHudResizeHook(


### PR DESCRIPTION
## Summary

Closes #2977.

The standalone-tmux HUD reconcile fork-bombs under 3+ concurrent leaders. The `window-layout-changed`/`client-resized` hooks run `omx hud --reconcile-tmux`, which mutates the layout (split/kill HUD panes) and **re-fires the same hooks** → a feedback loop. The hook command wrapped the reconcile in a **blocking** `tmux wait-for -L/-U` serialization (`src/hud/tmux.ts`, `buildHudLayoutReconcileHookCommand`), so:

- under layout churn the fires **queue on the lock** into 1000+ stuck `sh` wrappers (observed 1380), saturating the tmux server and wedging client input; and
- a reconcile **killed between `-L` and `-U`** leaks the lock → every later reconcile blocks forever (permanent deadlock).

#2861 fixed the cosmetic 2-pane flicker but left this blocking-lock pile-up under more leaders.

## Fix

Make the shell wrapper **non-blocking** and gate concurrency inside the reconcile with a **non-blocking, self-healing cross-process file lock**.

- **`src/hud/tmux.ts`** — drop the blocking `tmux wait-for -L/-U` from the layout-reconcile hook command. It now just runs `leaderAlive && (unregister; reconcile) || unregister`, so the wrapper stays cheap and never blocks. (Comment added explaining the pile-up / deadlock it replaces.)
- **`src/hud/reconcile.ts`** — `reconcileHudForPromptSubmit` acquires a non-blocking file lock (keyed by session id / pane / `global`, under `os.tmpdir()`) right after the existing `skipped_not_omx_owned_tmux` / `skipped_no_entry` guards. A competing reconcile returns the new `skipped_concurrent` status instead of piling up. A lock left by a crashed/killed holder is **stolen** once it is stale (`RECONCILE_LOCK_STALE_MS = 10_000`) or its pid is no longer alive; a corrupt/unreadable lock file is treated as stealable rather than throwing. The lock is released in a `finally`, so a thrown reconcile never leaks it, and a SIGKILL'd holder self-heals on the next run.
  - New `deps`: `now?`, `lockDir?`, `processAlive?` (for tests). New status: `skipped_concurrent`.

## Tests

- **`src/hud/__tests__/reconcile.test.ts`** — three regressions sharing a real tmpdir `lockDir`: (1) a live lock → second reconcile returns `skipped_concurrent` and never touches panes; (2) a stale lock (old `ts` / dead `processAlive`) is stolen and the reconcile proceeds; (3) the lock file is gone after a normal reconcile (finally cleanup).
- **`src/hud/__tests__/tmux.test.ts`** — the layout-hook assertion flips from "contains `wait-for`" to "does not contain `wait-for`" (the blocking serialization is intentionally gone).

## Verification

- `npm run build` (tsc) — clean.
- `node --test dist/hud/__tests__/*.test.js` — **330 pass / 0 fail** (includes #2861's two-pane stability test, still green).
- `biome lint` on the changed files — clean; `npm run check:no-unused` — clean.

## Note / known edge

The common acquire path is atomic (`writeFileSync` with `wx` — exactly one winner). The *steal* path (stale/dead-pid recovery) does an `unlink` + rewrite that is not fully atomic, so two processes racing to steal the **same already-abandoned** lock could let **one** extra reconcile through during crash recovery. That is bounded to a single redundant run — never the unbounded pile-up this fixes — so I kept the simpler form; happy to tighten to an atomic rename-based steal if you'd prefer.

To keep the diff minimal the existing reconcile body is wrapped in `try { … } finally { … }` without re-indenting (biome + strict tsc pass). Glad to reflow for readability if preferred.
