### PR TITLE
Fix HUD reconcile live stale lock handling

### DIFF
--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -1,7 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
 import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
+import { dirname } from 'node:path';
 import { join } from 'node:path';
 import { OMX_TMUX_HUD_OWNER_ENV, reconcileHudForPromptSubmit } from '../reconcile.js';
 import { HUD_TMUX_HEIGHT_LINES, HUD_TMUX_ULTRAGOAL_HEIGHT_LINES, HUD_TMUX_MIN_LAUNCH_WINDOW_HEIGHT_LINES } from '../constants.js';
@@ -9,6 +11,18 @@ import { OMX_TMUX_HUD_LEADER_PANE_ENV } from '../tmux.js';
 
 const noOpRegisterHudResizeHook = () => true;
 const noOpUnregisterHudResizeHook = () => true;
+
+async function writeHudReconcileLock(cwd: string, owner: Record<string, unknown>): Promise<string> {
+  const lockPath = join(cwd, '.omx', 'state', 'hud-reconcile.lock');
+  await mkdir(dirname(lockPath), { recursive: true });
+  await mkdir(lockPath, { recursive: true });
+  await writeFile(join(lockPath, 'owner.json'), `${JSON.stringify(owner, null, 2)}\n`);
+  return lockPath;
+}
+
+async function readLockOwner(lockPath: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(join(lockPath, 'owner.json'), 'utf-8')) as Record<string, unknown>;
+}
 
 describe('reconcileHudForPromptSubmit', () => {
   it('skips reconciliation outside tmux', async () => {
@@ -70,6 +84,121 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(result.paneId, null);
     assert.equal(created.length, 0);
     assert.equal(resized.length, 0);
+  });
+
+  it('skips concurrent reconciliation for a stale lock whose holder pid is still live without mutating panes or lock metadata', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-reconcile-live-lock-'));
+    try {
+      const lockPath = await writeHudReconcileLock(cwd, {
+        token: 'live-holder',
+        pid: 4242,
+        acquired_at: new Date(1_000).toISOString(),
+      });
+      const originalOwner = await readLockOwner(lockPath);
+      let listed = false;
+      let killed = false;
+      let created = false;
+      let resized = false;
+
+      const result = await reconcileHudForPromptSubmit(cwd, {
+        env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+        nowMs: () => 20_000,
+        isProcessLive: (pid) => {
+          assert.equal(pid, 4242);
+          return true;
+        },
+        listCurrentWindowPanes: () => {
+          listed = true;
+          return [{ paneId: '%1', currentCommand: 'codex', startCommand: 'codex' }];
+        },
+        killTmuxPane: () => {
+          killed = true;
+          return true;
+        },
+        createHudWatchPane: () => {
+          created = true;
+          return '%hud';
+        },
+        resizeTmuxPane: () => {
+          resized = true;
+          return true;
+        },
+        resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+      });
+
+      assert.equal(result.status, 'skipped_concurrent');
+      assert.equal(result.paneId, null);
+      assert.equal(listed, false);
+      assert.equal(killed, false);
+      assert.equal(created, false);
+      assert.equal(resized, false);
+      assert.deepEqual(await readLockOwner(lockPath), originalOwner);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('treats EPERM-equivalent stale lock liveness as concurrent and preserves the lock', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-reconcile-eperm-lock-'));
+    try {
+      const lockPath = await writeHudReconcileLock(cwd, {
+        token: 'eperm-holder',
+        pid: 4343,
+        acquired_at: new Date(1_000).toISOString(),
+      });
+      const originalOwner = await readLockOwner(lockPath);
+
+      const result = await reconcileHudForPromptSubmit(cwd, {
+        env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+        nowMs: () => 20_000,
+        isProcessLive: () => null,
+        listCurrentWindowPanes: () => {
+          assert.fail('unknown liveness must not enter reconciliation');
+        },
+        resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+      });
+
+      assert.equal(result.status, 'skipped_concurrent');
+      assert.deepEqual(await readLockOwner(lockPath), originalOwner);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('recovers a stale reconcile lock after the recorded holder is dead', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-reconcile-dead-lock-'));
+    try {
+      const lockPath = await writeHudReconcileLock(cwd, {
+        token: 'dead-holder',
+        pid: 4444,
+        acquired_at: new Date(1_000).toISOString(),
+      });
+      const created: string[] = [];
+
+      const result = await reconcileHudForPromptSubmit(cwd, {
+        env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+        nowMs: () => 20_000,
+        isProcessLive: (pid) => {
+          assert.equal(pid, 4444);
+          return false;
+        },
+        listCurrentWindowPanes: () => [{ paneId: '%1', currentCommand: 'codex', startCommand: 'codex' }],
+        createHudWatchPane: () => {
+          created.push('create');
+          return '%hud';
+        },
+        resizeTmuxPane: () => true,
+        unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+        registerHudResizeHook: noOpRegisterHudResizeHook,
+        resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+      });
+
+      assert.equal(result.status, 'recreated');
+      assert.deepEqual(created, ['create']);
+      assert.equal(existsSync(lockPath), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it('recreates a missing HUD in explicit OMX-owned tmux with a session id', async () => {

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -106,7 +106,7 @@ describe('HUD resize hook helpers', () => {
     assert.match(calls[3]?.[4] ?? '', /TMUX/);
     assert.match(calls[3]?.[4] ?? '', /TMUX_PANE/);
     assert.match(calls[3]?.[4] ?? '', /OMX_TMUX_HUD_OWNER/);
-    assert.match(calls[3]?.[4] ?? '', /wait-for/);
+    assert.doesNotMatch(calls[3]?.[4] ?? '', /wait-for/);
   });
 
   it('reports partial failure but keeps the resize hook when layout-change hook install fails', () => {

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -1,3 +1,6 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import { readAllState, readHudConfig } from './state.js';
 import { getHudRenderMaxLines } from './render.js';
 import { HUD_TMUX_HEIGHT_LINES, isTmuxWindowTooCrampedForHudSplit } from './constants.js';
@@ -120,6 +123,7 @@ export interface ReconcileHudForPromptSubmitResult {
     | 'resized'
     | 'recreated'
     | 'replaced_duplicates'
+    | 'skipped_concurrent'
     | 'failed';
   paneId: string | null;
   desiredHeight: number | null;
@@ -149,6 +153,8 @@ export interface ReconcileHudForPromptSubmitDeps {
   ) => boolean;
   unregisterHudResizeHook?: (leaderPaneId: string | undefined) => boolean;
   readCurrentWindowSize?: (currentPaneId?: string) => { width: number | null; height: number | null };
+  nowMs?: () => number;
+  isProcessLive?: (pid: number) => boolean | null;
 }
 
 function ensureHudResizeHook(
@@ -222,6 +228,135 @@ function planOwnedHudPaneDedupe(
   };
 }
 
+const HUD_RECONCILE_LOCK_STALE_MS = 10_000;
+
+interface HudReconcileLock {
+  path: string;
+  token: string;
+}
+
+interface HudReconcileLockOwner {
+  token?: unknown;
+  pid?: unknown;
+  acquired_at?: unknown;
+}
+
+function parseIsoMs(value: unknown): number | null {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function defaultIsProcessLive(pid: number): boolean | null {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | null)?.code;
+    if (code === 'ESRCH') return false;
+    if (code === 'EPERM') return true;
+    return null;
+  }
+}
+
+async function readHudReconcileLockOwner(lockPath: string): Promise<HudReconcileLockOwner | null> {
+  return readFile(join(lockPath, 'owner.json'), 'utf-8')
+    .then((content) => JSON.parse(content) as HudReconcileLockOwner)
+    .catch(() => null);
+}
+
+async function tryCreateHudReconcileLock(lockPath: string, nowMs: number): Promise<HudReconcileLock | null> {
+  const token = randomUUID();
+  let createdDir = false;
+  try {
+    await mkdir(lockPath, { recursive: false });
+    createdDir = true;
+    await writeFile(join(lockPath, 'owner.json'), JSON.stringify({
+      token,
+      pid: process.pid,
+      acquired_at: new Date(nowMs).toISOString(),
+    }, null, 2));
+    return { path: lockPath, token };
+  } catch {
+    if (createdDir) await rm(lockPath, { recursive: true, force: true }).catch(() => {});
+    return null;
+  }
+}
+
+async function restoreMovedLock(fromPath: string, toPath: string): Promise<void> {
+  const restored = await rename(fromPath, toPath).then(() => true).catch(() => false);
+  if (!restored) await rm(fromPath, { recursive: true, force: true }).catch(() => {});
+}
+
+async function acquireHudReconcileLock(
+  lockPath: string,
+  nowMs: number,
+  staleMs: number,
+  isProcessLive: (pid: number) => boolean | null,
+): Promise<HudReconcileLock | null> {
+  const created = await tryCreateHudReconcileLock(lockPath, nowMs);
+  if (created) return created;
+
+  const observedOwner = await readHudReconcileLockOwner(lockPath);
+  const lockStat = await stat(lockPath).catch(() => null);
+  if (!lockStat) return null;
+
+  const ownerPid = typeof observedOwner?.pid === 'number' && Number.isInteger(observedOwner.pid) && observedOwner.pid > 0
+    ? observedOwner.pid
+    : null;
+  const ownerAcquiredMs = parseIsoMs(observedOwner?.acquired_at);
+  const lockAgeMs = ownerAcquiredMs === null ? nowMs - lockStat.mtimeMs : nowMs - ownerAcquiredMs;
+  if (lockAgeMs <= staleMs) return null;
+
+  if (ownerPid !== null) {
+    const liveness = isProcessLive(ownerPid);
+    if (liveness !== false) return null;
+  }
+
+  const reapPath = `${lockPath}.stale.${process.pid}.${nowMs}.${randomUUID()}`;
+  try {
+    await rename(lockPath, reapPath);
+  } catch {
+    return null;
+  }
+
+  const reapedOwner = await readHudReconcileLockOwner(reapPath);
+  const reapedStat = await stat(reapPath).catch(() => null);
+  const reapedOwnerAcquiredMs = parseIsoMs(reapedOwner?.acquired_at);
+  const reapedAgeMs = reapedOwnerAcquiredMs === null && reapedStat
+    ? nowMs - reapedStat.mtimeMs
+    : reapedOwnerAcquiredMs === null ? 0 : nowMs - reapedOwnerAcquiredMs;
+  const reapedObservedLock = observedOwner?.token === reapedOwner?.token
+    && reapedStat?.mtimeMs === lockStat.mtimeMs
+    && reapedAgeMs > staleMs;
+
+  if (!reapedObservedLock) {
+    await restoreMovedLock(reapPath, lockPath);
+    return null;
+  }
+
+  await rm(reapPath, { recursive: true, force: true }).catch(() => {});
+  return tryCreateHudReconcileLock(lockPath, nowMs);
+}
+
+async function releaseHudReconcileLock(lock: HudReconcileLock): Promise<void> {
+  const releasePath = `${lock.path}.release.${process.pid}.${Date.now()}.${lock.token}`;
+  try {
+    await rename(lock.path, releasePath);
+  } catch {
+    return;
+  }
+
+  const releaseOwner = await readHudReconcileLockOwner(releasePath);
+  if (releaseOwner?.token === lock.token) {
+    await rm(releasePath, { recursive: true, force: true }).catch(() => {});
+    return;
+  }
+
+  await restoreMovedLock(releasePath, lock.path);
+}
+
+
 export async function reconcileHudForPromptSubmit(
   cwd: string,
   deps: ReconcileHudForPromptSubmitDeps = {},
@@ -260,6 +395,27 @@ export async function reconcileHudForPromptSubmit(
   const createPane = deps.createHudWatchPane ?? ((hudCwd, hudCmd, options) => createHudWatchPane(hudCwd, hudCmd, options));
   const killPane = deps.killTmuxPane ?? ((paneId) => killTmuxPane(paneId));
   const resizePane = deps.resizeTmuxPane ?? ((paneId, lines) => resizeTmuxPane(paneId, lines));
+
+  const lockPath = join(cwd, '.omx', 'state', 'hud-reconcile.lock');
+  const lockDirReady = await mkdir(dirname(lockPath), { recursive: true }).then(() => true).catch(() => false);
+  const lock = lockDirReady
+    ? await acquireHudReconcileLock(
+      lockPath,
+      deps.nowMs?.() ?? Date.now(),
+      HUD_RECONCILE_LOCK_STALE_MS,
+      deps.isProcessLive ?? defaultIsProcessLive,
+    )
+    : null;
+  if (lockDirReady && !lock) {
+    return {
+      status: 'skipped_concurrent',
+      paneId: null,
+      desiredHeight: null,
+      duplicateCount: 0,
+    };
+  }
+
+  try {
 
   const currentPaneId = env.TMUX_PANE?.trim();
   const resolvedSessionId = deps.sessionId?.trim() || env.OMX_SESSION_ID?.trim() || undefined;
@@ -448,4 +604,7 @@ export async function reconcileHudForPromptSubmit(
     desiredHeight,
     duplicateCount: postCreate.duplicatePaneIds.length,
   };
+  } finally {
+    if (lock) await releaseHudReconcileLock(lock);
+  }
 }

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -448,9 +448,6 @@ function buildHudLayoutReconcileHookCommand(
   const cwd = options.cwd?.trim() || process.cwd();
   const leaderAlive = buildNestedTmuxCommand(tmuxBin, ['display-message', '-p', '-t', leaderPaneId, '#{pane_id}'], env.TMUX);
   const unregister = buildHudHookUnregisterCommand(tmuxBin, context, env.TMUX);
-  const lockName = `${context.hookName}_layout`;
-  const lock = buildNestedTmuxCommand(tmuxBin, ['wait-for', '-L', lockName], env.TMUX);
-  const unlock = buildNestedTmuxCommand(tmuxBin, ['wait-for', '-U', lockName], env.TMUX);
   const reconcileEnv = buildEnvPrefix({
     TMUX: env.TMUX,
     TMUX_PANE: leaderPaneId,
@@ -469,7 +466,7 @@ function buildHudLayoutReconcileHookCommand(
     'hud',
     '--reconcile-tmux',
   ].join(' ');
-  return `${leaderAlive} >/dev/null 2>&1 && (${lock} >/dev/null 2>&1; ${unregister}; ${reconcile} >/dev/null 2>&1; status=$?; ${unlock} >/dev/null 2>&1; exit $status) || (${unregister})`;
+  return `${leaderAlive} >/dev/null 2>&1 && (${unregister}; ${reconcile} >/dev/null 2>&1; status=$?; exit $status) || (${unregister})`;
 }
 
 function unregisterLegacyHudResizeHook(


### PR DESCRIPTION
## Summary
- Replace blocking tmux wait-for layout reconcile serialization with a non-blocking file lock inside HUD reconciliation.
- Preserve parseable stale locks when the holder PID is still live or liveness is unknown/EPERM-equivalent, returning skipped_concurrent without pane/layout mutation.
- Recover stale reconcile locks only when the recorded holder is dead, and keep existing HUD stale/corrupt recovery paths covered by regression tests.

## Verification
- npm run build
- node dist/scripts/run-test-files.js dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/tmux.test.js

Fixes #2977

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*