### PR TITLE
[codex] Fix auth slot isolation and invalid token rotation

### DIFF
--- a/src/auth/hotswap.ts
+++ b/src/auth/hotswap.ts
@@ -62,6 +62,10 @@ export function stripHotswapArg(args: string[]): string[] {
   return args.filter((arg) => arg !== "--hotswap");
 }
 
+function isAuthInvalidationError(stderr: string | undefined): boolean {
+  return /token_invalidated|refresh_token_invalidated|authentication token has been invalidated/i.test(stderr || "");
+}
+
 async function runCodexDirect(
   cwd: string,
   args: string[],
@@ -180,23 +184,34 @@ export async function runAuthHotswap(options: HotswapOptions): Promise<number> {
       process.stderr.write(`[omx auth] using slot ${currentSlot}\n`);
       const result = await runCodexDirect(cwd, attemptArgs, baseEnv);
       if (result.status === 0) return 0;
-      if (!isQuotaError({ status: result.status, signal: result.signal, stderr: result.stderr }, config)) {
+      const authInvalid = isAuthInvalidationError(result.stderr);
+      const quota = isQuotaError({ status: result.status, signal: result.signal, stderr: result.stderr }, config);
+      if (!quota && !authInvalid) {
         return result.status || 1;
       }
 
-      await markSlotQuota(currentSlot, home);
+      if (quota) await markSlotQuota(currentSlot, home);
       exhausted.add(currentSlot);
       if (plan.mode === "manual") {
+        const reason = authInvalid ? "token invalidated" : "quota detected";
         process.stderr.write(
-          `[omx auth] quota detected for slot ${currentSlot}; rotation=manual, run \`omx auth use <slot>\` to switch accounts.\n`,
+          `[omx auth] ${reason} for slot ${currentSlot}; rotation=manual, run \`omx auth use <slot>\` or \`omx auth add ${currentSlot} --device-auth\`.\n`,
         );
         return 1;
       }
 
       const next = nextSlotAfter(plan.order, currentSlot, exhausted);
       if (!next) {
-        process.stderr.write(`[omx auth] all slots exhausted: ${[...exhausted].join(", ")}\n`);
+        process.stderr.write(`[omx auth] all slots exhausted or invalid: ${[...exhausted].join(", ")}\n`);
         return 1;
+      }
+      if (authInvalid) {
+        process.stderr.write(
+          `[omx auth] token invalidated for slot ${currentSlot}; rotating to slot ${next}. Refresh it later with \`omx auth add ${currentSlot} --device-auth\`.\n`,
+        );
+        currentSlot = next;
+        await useSlot(currentSlot, liveAuthPath, home);
+        continue;
       }
       const latest = await findLatestRolloutSession(codexHomeFromAuthPath(liveAuthPath), home);
       if (!latest) {

--- a/src/cli/__tests__/auth.test.ts
+++ b/src/cli/__tests__/auth.test.ts
@@ -77,6 +77,40 @@ describe("omx auth CLI", () => {
     }
   });
 
+  it("adds slots through isolated login CODEX_HOME and forwards device auth", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-auth-isolated-add-"));
+    try {
+      const home = join(wd, "home");
+      const codexHome = join(home, ".codex");
+      const bin = join(wd, "bin");
+      const loginEnvFile = join(wd, "login-codex-home.txt");
+      const loginArgsFile = join(wd, "login-args.txt");
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(codexHome, "auth.json"), '{"access_token":"live-primary"}\n');
+      await writeFakeCodex(bin, `#!/bin/sh
+if [ "$1" = "login" ]; then
+  printf '%s\n' "$CODEX_HOME" > ${JSON.stringify(loginEnvFile)}
+  printf '%s\n' "$*" > ${JSON.stringify(loginArgsFile)}
+  mkdir -p "$CODEX_HOME"
+  printf '{"access_token":"new-secondary"}\n' > "$CODEX_HOME/auth.json"
+  exit 0
+fi
+echo unexpected "$@" >&2
+exit 2
+`);
+      const env = { HOME: home, CODEX_HOME: codexHome, PATH: `${bin}:/usr/bin:/bin` };
+      const add = runOmx(wd, ["auth", "add", "secondary", "--device-auth"], env);
+      assert.equal(add.status, 0, add.stderr);
+      assert.equal(await readFile(join(codexHome, "auth.json"), "utf-8"), '{"access_token":"live-primary"}\n');
+      assert.equal(await readFile(join(home, ".omx", "auth", "secondary.json"), "utf-8"), '{"access_token":"new-secondary"}\n');
+      assert.equal(await readFile(loginArgsFile, "utf-8"), "login --device-auth\n");
+      assert.notEqual((await readFile(loginEnvFile, "utf-8")).trim(), codexHome);
+      assert.doesNotMatch(add.stdout + add.stderr, /live-primary|new-secondary/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("sets subscription Codex defaults when auth add sees empty config", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-auth-defaults-"));
     try {
@@ -119,9 +153,10 @@ describe("omx auth CLI", () => {
       const bin = join(wd, "bin");
       await mkdir(join(wd, ".omx"), { recursive: true });
       await writeFile(join(wd, ".omx", "setup-scope.json"), '{"scope":"project"}\n');
-      const expectedCodexHome = join(await realpath(wd), ".codex");
+      const expectedLiveCodexHome = join(await realpath(wd), ".codex");
+      const loginEnvFile = join(wd, "login-codex-home.txt");
       await writeFakeCodex(bin, `#!/bin/sh
-if [ "$1" = "login" ]; then case "$CODEX_HOME" in ${JSON.stringify(expectedCodexHome)}) mkdir -p "$CODEX_HOME"; printf '{"access_token":"project-secret"}\n' > "$CODEX_HOME/auth.json"; exit 0;; *) echo "wrong CODEX_HOME=$CODEX_HOME" >&2; exit 4;; esac; fi
+if [ "$1" = "login" ]; then printf '%s\n' "$CODEX_HOME" > ${JSON.stringify(loginEnvFile)}; mkdir -p "$CODEX_HOME"; printf '{"access_token":"project-secret"}\n' > "$CODEX_HOME/auth.json"; exit 0; fi
 echo unexpected "$@" >&2
 exit 2
 `);
@@ -130,6 +165,8 @@ exit 2
       assert.equal(add.status, 0, add.stderr);
       assert.doesNotMatch(add.stdout + add.stderr, /project-secret/);
       assert.equal(await readFile(join(home, ".omx", "auth", "project.json"), "utf-8"), '{"access_token":"project-secret"}\n');
+      assert.equal(await readFile(join(expectedLiveCodexHome, "auth.json"), "utf-8"), '{"access_token":"project-secret"}\n');
+      assert.notEqual((await readFile(loginEnvFile, "utf-8")).trim(), expectedLiveCodexHome);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -178,6 +215,44 @@ exit 2
     }
   });
 
+  it("skips invalidated hotswap slots without requiring a rollout session", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-auth-invalidated-hotswap-"));
+    try {
+      const home = join(wd, "home");
+      const codexHome = join(home, ".codex");
+      const authDir = join(home, ".omx", "auth");
+      const bin = join(wd, "bin");
+      const argvFile = join(wd, "argv.log");
+      await mkdir(authDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(authDir, "first.json"), '{"access_token":"first-secret"}\n');
+      await writeFile(join(authDir, "second.json"), '{"access_token":"second-secret"}\n');
+      await writeFile(join(authDir, "slots.json"), JSON.stringify({ version: 1, currentSlot: "first", slots: [
+        { slot: "first", createdAt: "now", updatedAt: "now" },
+        { slot: "second", createdAt: "now", updatedAt: "now" }
+      ] }, null, 2));
+      await writeFakeCodex(bin, `#!/bin/sh
+printf '%s\n' "$*" >> ${JSON.stringify(argvFile)}
+if grep -q first-secret "$CODEX_HOME/auth.json"; then
+  echo 'HTTP 401 token_invalidated refresh_token_invalidated' >&2
+  exit 1
+fi
+grep -q second-secret "$CODEX_HOME/auth.json" || exit 4
+exit 0
+`);
+      const result = runOmx(wd, ["--hotswap", "--direct", "--model", "gpt-review"], { HOME: home, CODEX_HOME: codexHome, PATH: `${bin}:/usr/bin:/bin` });
+      assert.equal(result.status, 0, result.stderr + result.stdout);
+      assert.match(result.stderr, /token invalidated for slot first; rotating to slot second/);
+      const argvLog = await readFile(argvFile, "utf-8");
+      assert.doesNotMatch(argvLog, /resume/);
+      assert.match(argvLog, /--model gpt-review/);
+      assert.equal(await readFile(join(codexHome, "auth.json"), "utf-8"), '{"access_token":"second-secret"}\n');
+      assert.doesNotMatch(result.stderr + result.stdout, /first-secret|second-secret/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("emits one clean error when all hotswap slots are exhausted", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-auth-exhausted-"));
     try {
@@ -196,7 +271,7 @@ exit 2
       await writeFakeCodex(bin, `#!/bin/sh\nmkdir -p "$CODEX_HOME/sessions/2026/05/24"\nprintf '{}\\n' > "$CODEX_HOME/sessions/2026/05/24/rollout-session-429.jsonl"\necho 'HTTP 429 quota exceeded' >&2\nexit 1\n`);
       const result = runOmx(wd, ["--hotswap", "--direct"], { HOME: home, CODEX_HOME: codexHome, PATH: `${bin}:/usr/bin:/bin` });
       assert.equal(result.status, 1);
-      const matches = result.stderr.match(/all slots exhausted: first, second/g) ?? [];
+      const matches = result.stderr.match(/all slots exhausted or invalid: first, second/g) ?? [];
       assert.equal(matches.length, 1, result.stderr);
       assert.doesNotMatch(result.stderr + result.stdout, /first-secret|second-secret/);
     } finally {

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -1,5 +1,6 @@
 import { dirname, join } from "path";
-import { mkdir, readFile, writeFile } from "fs/promises";
+import { homedir } from "os";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { spawnPlatformCommandSync, classifySpawnError } from "../utils/platform-command.js";
 import { readAuthConfig } from "../auth/config.js";
 import { resolveLiveAuthPath } from "../auth/paths.js";
@@ -9,7 +10,9 @@ import { readTopLevelTomlString, upsertTopLevelTomlString } from "../utils/toml.
 
 export const AUTH_HELP = `
 Usage:
-  omx auth add <slot>      Log in with Codex OAuth and store auth.json as a named slot
+  omx auth add <slot> [codex login flags]
+                Log in with Codex OAuth and store auth.json as a named slot
+                Supported flags include: --device-auth, --with-api-key, --with-access-token
   omx auth list [--json]   List registered auth slots and local quota metadata
   omx auth use <slot>      Atomically switch live Codex auth.json to a slot
   omx auth --help          Show this help
@@ -24,8 +27,18 @@ const DEFAULT_SUBSCRIPTION_MODEL = "gpt-5-codex";
 const DEFAULT_SUBSCRIPTION_MODEL_PROVIDER = "openai-chatgpt";
 
 
-function runCodexLogin(cwd: string, env: NodeJS.ProcessEnv): void {
-  const { result } = spawnPlatformCommandSync("codex", ["login"], {
+function validateCodexLoginArgs(args: string[]): void {
+  const allowed = new Set(["--device-auth", "--with-api-key", "--with-access-token"]);
+  for (const arg of args) {
+    if (!allowed.has(arg)) {
+      throw new Error(`unsupported codex login flag for omx auth add: ${arg}`);
+    }
+  }
+}
+
+function runCodexLogin(cwd: string, env: NodeJS.ProcessEnv, loginArgs: string[] = []): void {
+  validateCodexLoginArgs(loginArgs);
+  const { result } = spawnPlatformCommandSync("codex", ["login", ...loginArgs], {
     cwd,
     env,
     stdio: "inherit",
@@ -42,6 +55,22 @@ function runCodexLogin(cwd: string, env: NodeJS.ProcessEnv): void {
     throw new Error(`codex login exited with code ${result.status ?? 1}`);
   }
 }
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await readFile(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function createIsolatedLoginCodexHome(home: string | undefined): Promise<string> {
+  const base = join(home || homedir(), ".omx");
+  await mkdir(base, { recursive: true, mode: 0o700 });
+  return await mkdtemp(join(base, "auth-login-"));
+}
+
 async function ensureSubscriptionCodexDefaults(codexHome: string): Promise<void> {
   const configPath = join(codexHome, "config.toml");
   let existing = "";
@@ -76,12 +105,23 @@ export async function authCommand(args: string[], env: NodeJS.ProcessEnv = proce
 
   if (command === "add") {
     const slot = args[1];
-    if (!slot) throw new Error("Usage: omx auth add <slot>");
+    if (!slot) throw new Error("Usage: omx auth add <slot> [--device-auth|--with-api-key|--with-access-token]");
+    const loginArgs = args.slice(2);
     const liveAuthPath = resolveLiveAuthPath(cwd, env, home);
-    runCodexLogin(cwd, { ...env, CODEX_HOME: dirname(liveAuthPath) });
-    const record = await addSlotFromAuthFile(slot, liveAuthPath, home);
-    await ensureSubscriptionCodexDefaults(dirname(liveAuthPath));
-    console.log(`Added auth slot ${record.slot}`);
+    const hadLiveAuth = await fileExists(liveAuthPath);
+    const tempCodexHome = await createIsolatedLoginCodexHome(home);
+    try {
+      runCodexLogin(cwd, { ...env, CODEX_HOME: tempCodexHome }, loginArgs);
+      const tempAuthPath = join(tempCodexHome, "auth.json");
+      const record = await addSlotFromAuthFile(slot, tempAuthPath, home);
+      await ensureSubscriptionCodexDefaults(dirname(liveAuthPath));
+      if (!hadLiveAuth) {
+        await useSlot(slot, liveAuthPath, home);
+      }
+      console.log(`Added auth slot ${record.slot}`);
+    } finally {
+      await rm(tempCodexHome, { recursive: true, force: true }).catch(() => undefined);
+    }
     return;
   }
 


### PR DESCRIPTION
# Fix auth slot isolation and invalid token rotation

## Summary

This patch fixes two auth-slot edge cases in `omx auth` / `--hotswap`:

1. `omx auth add <slot>` now logs in via an isolated temporary `CODEX_HOME` before storing the resulting `auth.json` as a slot.
   - This prevents adding a second account from overwriting live `~/.codex/auth.json` during login.
   - It also forwards supported `codex login` flags such as `--device-auth`, which is needed on remote/headless servers.
2. `omx --hotswap` now treats `token_invalidated` / `refresh_token_invalidated` as a rotatable auth failure.
   - Invalidated slots are skipped without requiring a rollout session.
   - Quota behavior still uses rollout resume semantics as before.

## Root cause

Previously `omx auth add secondary --device-auth` effectively ran `codex login` against the same live `CODEX_HOME` used by the current slot. In practice, logging into a second ChatGPT/Codex account can invalidate the previous refresh token. The old primary slot then fails at startup with ChatGPT backend 401 errors such as:

```text
token_invalidated
refresh_token_invalidated
Your authentication token has been invalidated. Please try signing in again.
```

Because `--hotswap` only treated quota/429 as rotatable, an invalidated slot could fail the whole launch instead of moving to the next valid slot.

## Changes

- Add `omx auth add <slot> [codex login flags]` support for:
  - `--device-auth`
  - `--with-api-key`
  - `--with-access-token`
- Run `codex login` in an isolated temp Codex home under `~/.omx/auth-login-*` and copy the temp `auth.json` into the slot.
- Preserve the existing live `auth.json` when adding additional slots.
- Populate live auth from the new slot only when there was no existing live auth.
- Rotate past `token_invalidated` / `refresh_token_invalidated` during hotswap without requiring a rollout session.
- Add regression coverage for isolated login, project-scope auth add, forwarded `--device-auth`, and invalid-token hotswap rotation.

## Validation

```bash
npm run build
node dist/scripts/run-test-files.js dist/cli/__tests__/auth.test.js
npm run lint
```

All passed locally.
