### PR TITLE
Fix resume history merge for symlinked runtime homes

### DIFF
--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -183,7 +183,8 @@ if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-runtime-session.jsonl" ]; then 
     try {
       const home = join(wd, 'home');
       const projectCodexHome = join(wd, '.codex');
-      const previousRuntimeCodexHome = join(wd, '.omx', 'runtime', 'codex-home', 'omx-existing-runtime');
+      const previousRuntimeCodexHome = join(wd, '.omx', 'runtime', 'codex-home', 'omx-existing-runtime-a');
+      const duplicateRuntimeCodexHome = join(wd, '.omx', 'runtime', 'codex-home', 'omx-existing-runtime-b');
       const fakeBin = join(wd, 'bin');
       const fakeCodexPath = join(fakeBin, 'codex');
       const fakePsPath = join(fakeBin, 'ps');
@@ -194,6 +195,7 @@ if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-runtime-session.jsonl" ]; then 
       await mkdir(join(wd, '.omx'), { recursive: true });
       await mkdir(dirname(projectRolloutPath), { recursive: true });
       await mkdir(previousRuntimeCodexHome, { recursive: true });
+      await mkdir(duplicateRuntimeCodexHome, { recursive: true });
       await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
       await writeFile(join(projectCodexHome, 'config.toml'), 'model = "gpt-5.5"\n');
       await writeFile(projectRolloutPath, '{"type":"session_meta","payload":{"id":"project-session"}}\n');
@@ -202,10 +204,15 @@ if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-runtime-session.jsonl" ]; then 
       await symlink(join(projectCodexHome, 'sessions'), join(previousRuntimeCodexHome, 'sessions'), 'dir');
       await symlink(join(projectCodexHome, 'history.jsonl'), join(previousRuntimeCodexHome, 'history.jsonl'));
       await symlink(join(projectCodexHome, 'session_index.jsonl'), join(previousRuntimeCodexHome, 'session_index.jsonl'));
+      await symlink(join(projectCodexHome, 'sessions'), join(duplicateRuntimeCodexHome, 'sessions'), 'dir');
+      await symlink(join(projectCodexHome, 'history.jsonl'), join(duplicateRuntimeCodexHome, 'history.jsonl'));
+      await symlink(join(projectCodexHome, 'session_index.jsonl'), join(duplicateRuntimeCodexHome, 'session_index.jsonl'));
 
       await writeFile(fakeCodexPath, `#!/bin/sh
 printf 'fake-codex:%s\n' "$*"
 printf 'codex-home:%s\n' "$CODEX_HOME"
+printf 'history-lines:%s\n' "$(wc -l < "$CODEX_HOME/history.jsonl")"
+printf 'index-lines:%s\n' "$(wc -l < "$CODEX_HOME/session_index.jsonl")"
 if [ -f "$CODEX_HOME/sessions/2026/06/18/rollout-project-session.jsonl" ]; then echo project-rollout-present=yes; else echo project-rollout-present=no; fi
 `);
       await chmod(fakeCodexPath, 0o755);
@@ -224,6 +231,10 @@ if [ -f "$CODEX_HOME/sessions/2026/06/18/rollout-project-session.jsonl" ]; then 
       assert.doesNotMatch(result.stderr, /EISDIR/);
       assert.match(result.stdout, /fake-codex:resume\b/);
       assert.match(result.stdout, /project-rollout-present=yes/);
+      assert.match(result.stdout, /history-lines:1\b/);
+      assert.match(result.stdout, /index-lines:1\b/);
+      assert.equal(await readFile(join(projectCodexHome, 'history.jsonl'), 'utf-8'), '{"session_id":"project-session"}\n');
+      assert.equal(await readFile(join(projectCodexHome, 'session_index.jsonl'), 'utf-8'), '{"id":"project-session"}\n');
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { chmod, mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, readdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -173,6 +173,57 @@ if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-runtime-session.jsonl" ]; then 
       assert.match(result.stdout, /fake-codex:resume\b/);
       assert.match(result.stdout, /codex-home:.*\.omx\/runtime\/codex-home\//);
       assert.match(result.stdout, /runtime-rollout-present=yes/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('merges symlinked project runtime history during plain resume', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-symlinked-runtime-history-'));
+    try {
+      const home = join(wd, 'home');
+      const projectCodexHome = join(wd, '.codex');
+      const previousRuntimeCodexHome = join(wd, '.omx', 'runtime', 'codex-home', 'omx-existing-runtime');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const projectRolloutPath = join(projectCodexHome, 'sessions', '2026', '06', '18', 'rollout-project-session.jsonl');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await mkdir(join(wd, '.omx'), { recursive: true });
+      await mkdir(dirname(projectRolloutPath), { recursive: true });
+      await mkdir(previousRuntimeCodexHome, { recursive: true });
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+      await writeFile(join(projectCodexHome, 'config.toml'), 'model = "gpt-5.5"\n');
+      await writeFile(projectRolloutPath, '{"type":"session_meta","payload":{"id":"project-session"}}\n');
+      await writeFile(join(projectCodexHome, 'history.jsonl'), '{"session_id":"project-session"}\n');
+      await writeFile(join(projectCodexHome, 'session_index.jsonl'), '{"id":"project-session"}\n');
+      await symlink(join(projectCodexHome, 'sessions'), join(previousRuntimeCodexHome, 'sessions'), 'dir');
+      await symlink(join(projectCodexHome, 'history.jsonl'), join(previousRuntimeCodexHome, 'history.jsonl'));
+      await symlink(join(projectCodexHome, 'session_index.jsonl'), join(previousRuntimeCodexHome, 'session_index.jsonl'));
+
+      await writeFile(fakeCodexPath, `#!/bin/sh
+printf 'fake-codex:%s\n' "$*"
+printf 'codex-home:%s\n' "$CODEX_HOME"
+if [ -f "$CODEX_HOME/sessions/2026/06/18/rollout-project-session.jsonl" ]; then echo project-rollout-present=yes; else echo project-rollout-present=no; fi
+`);
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+
+      const result = runOmx(wd, ['resume'], {
+        HOME: home,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      });
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.doesNotMatch(result.stderr, /EISDIR/);
+      assert.match(result.stdout, /fake-codex:resume\b/);
+      assert.match(result.stdout, /project-rollout-present=yes/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -944,15 +944,19 @@ async function materializeProjectLaunchRuntimeHistoryEntries(
 async function mergeProjectLaunchRuntimeHistoryEntries(
   runtimeCodexHome: string,
   sourceCodexHome: string,
+  mergedHistorySourceRealpaths: Set<string>,
 ): Promise<void> {
   for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
     const source = join(sourceCodexHome, entryName);
     if (!existsSync(source)) continue;
+    const sourceRealpath = realpathSync(source);
+    if (mergedHistorySourceRealpaths.has(sourceRealpath)) continue;
     const destination = join(runtimeCodexHome, entryName);
     const sourceStat = await stat(source);
     if (sourceStat.isDirectory()) {
       await mkdir(destination, { recursive: true });
       await cp(source, destination, { recursive: true, force: true, dereference: true });
+      mergedHistorySourceRealpaths.add(sourceRealpath);
       continue;
     }
     if (entryName === "sessions") continue;
@@ -962,15 +966,18 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
       if (!destinationStat.isFile()) {
         await rm(destination, { recursive: true, force: true });
         await copyFile(source, destination);
+        mergedHistorySourceRealpaths.add(sourceRealpath);
         continue;
       }
       const existing = await readFile(destination, "utf-8").catch(() => "");
       const addition = await readFile(source, "utf-8");
       const separator = existing === "" || existing.endsWith("\n") || addition === "" ? "" : "\n";
       await writeFile(destination, `${existing}${separator}${addition}`, "utf-8");
+      mergedHistorySourceRealpaths.add(sourceRealpath);
       continue;
     }
     await copyFile(source, destination);
+    mergedHistorySourceRealpaths.add(sourceRealpath);
   }
 }
 
@@ -1036,9 +1043,14 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
   }
   await ensureProjectLaunchRuntimeHistoryLinks(runtimeCodexHome, projectCodexHome);
   if (options.includeHistoryArtifacts === true && (options.extraHistoryCodexHomes?.length ?? 0) > 0) {
+    const mergedHistorySourceRealpaths = new Set<string>();
+    for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
+      const source = join(projectCodexHome, entryName);
+      if (existsSync(source)) mergedHistorySourceRealpaths.add(realpathSync(source));
+    }
     await materializeProjectLaunchRuntimeHistoryEntries(runtimeCodexHome, projectCodexHome);
     for (const extraCodexHome of options.extraHistoryCodexHomes ?? []) {
-      await mergeProjectLaunchRuntimeHistoryEntries(runtimeCodexHome, extraCodexHome);
+      await mergeProjectLaunchRuntimeHistoryEntries(runtimeCodexHome, extraCodexHome, mergedHistorySourceRealpaths);
     }
   }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,7 +6,7 @@
 import { execFileSync, spawn } from "child_process";
 import { basename, dirname, join, posix, resolve, win32 } from "path";
 import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "fs";
-import { copyFile, cp, lstat, mkdir, readFile, readdir, rm, symlink, writeFile } from "fs/promises";
+import { copyFile, cp, lstat, mkdir, readFile, readdir, rm, stat, symlink, writeFile } from "fs/promises";
 import { constants as osConstants, homedir } from "os";
 import { createHash } from "crypto";
 import {
@@ -949,13 +949,21 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
     const source = join(sourceCodexHome, entryName);
     if (!existsSync(source)) continue;
     const destination = join(runtimeCodexHome, entryName);
-    const sourceStat = await lstat(source);
+    const sourceStat = await stat(source);
     if (sourceStat.isDirectory()) {
       await mkdir(destination, { recursive: true });
       await cp(source, destination, { recursive: true, force: true, dereference: true });
       continue;
     }
+    if (entryName === "sessions") continue;
+    if (!sourceStat.isFile()) continue;
     if (existsSync(destination)) {
+      const destinationStat = await stat(destination);
+      if (!destinationStat.isFile()) {
+        await rm(destination, { recursive: true, force: true });
+        await copyFile(source, destination);
+        continue;
+      }
       const existing = await readFile(destination, "utf-8").catch(() => "");
       const addition = await readFile(source, "utf-8");
       const separator = existing === "" || existing.endsWith("\n") || addition === "" ? "" : "\n";


### PR DESCRIPTION
## Summary
- Follow symlink targets when merging project runtime Codex history during resume preparation.
- Avoid reading the destination sessions directory as a file when an older runtime home links sessions back to the project Codex home.
- Add a regression test that reproduces the symlinked runtime history layout seen in project-scoped resume flows.

## Verification
- npm run build && node --test dist/cli/__tests__/resume.test.js
- npx tsc --noEmit
- npx biome lint src/cli/index.ts src/cli/__tests__/resume.test.ts
- Manual smoke: ran the built local OMX CLI against ~/work/omx-test with a fake codex binary and verified resume preparation no longer raises EISDIR.