### PR TITLE
fix: preserve exact planner and architect contracts

### DIFF
--- a/docs/reference/omx-config-schema-routing.md
+++ b/docs/reference/omx-config-schema-routing.md
@@ -141,7 +141,7 @@ These overrides do not change built-in defaults in source. They are user/project
 For a named role, effective model precedence is:
 
 1. `.omx-config.json` `agentModels[role]`
-2. Built-in `exactModel` pins, such as planner/architect/researcher `gpt-5.4-mini`
+2. Built-in `exactModel` pins, such as planner/architect `gpt-5.5` or researcher `gpt-5.4-mini`
 3. Special role logic, such as `executor` using the main/frontier lane
 4. `modelClass` routing: `fast` uses spark/low-complexity, `frontier` uses main/frontier, and `standard` uses the standard lane
 
@@ -216,7 +216,7 @@ Examples:
 
 | Role/category | Examples | Model class behavior |
 | --- | --- | --- |
-| Exact mini planning/research | `planner`, `architect`, `researcher` | Uses the exact `gpt-5.4-mini` pin before model-class routing unless `agentModels[role]` is set; planner/architect keep `frontier-orchestrator` posture and high reasoning, while ralplan's `critic` remains frontier-routed for the consensus gate. In Autopilot, `planning_routing.owner` switches the initial ralplan Planner draft/decomposition to this dedicated `planner` role when `[main]` is cheap/mini or when `agentModels.planner` is configured. |
+| Exact planning/research pins | `planner`, `architect`, `researcher` | Uses the built-in `exactModel` pin before model-class routing unless `agentModels[role]` is set; planner uses exact `gpt-5.5` with medium reasoning, architect uses exact `gpt-5.5` with xhigh reasoning, and researcher stays on exact `gpt-5.4-mini`. Ralplan's `critic` remains frontier-routed for the consensus gate. In Autopilot, `planning_routing.owner` switches the initial ralplan Planner draft/decomposition to this dedicated `planner` role when `[main]` is cheap/mini or when `agentModels.planner` is configured. |
 | Frontier orchestration | `critic`, `code-reviewer`, `security-reviewer`, `team-executor`, `vision` | Native-agent generation uses active `config.toml` root `model` first, then the main/frontier default fallback. |
 | Standard worker/review | `debugger`, `quality-reviewer`, `api-reviewer`, `performance-reviewer`, `dependency-expert`, `writer` | Uses the standard-lane default, which inherits main/frontier unless `OMX_DEFAULT_STANDARD_MODEL` is set. |
 | Fast/low-complexity | `explore`, `style-reviewer` | Uses the spark/low-complexity default. |
@@ -287,7 +287,7 @@ This keeps standard agents inheriting the frontier model by omitting `OMX_DEFAUL
     "explore": "gpt-5.5"
   },
   "agentReasoning": {
-    "planner": "high",
+    "planner": "medium",
     "architect": "xhigh",
     "researcher": "high",
     "explore": "medium",

--- a/docs/shared/agent-tiers.md
+++ b/docs/shared/agent-tiers.md
@@ -46,8 +46,9 @@ Use role to choose responsibility, tier to choose depth, and posture to choose o
   - Best for steerable frontier models and leader-style roles.
   - Prioritizes intent classification, delegation, verification, and architectural judgment.
   - Typical roles: `planner`, `analyst`, `architect`, `critic`, `code-reviewer`.
-  - Ralplan keeps `planner` and `architect` in this posture but pins them to
-    exact `gpt-5.4-mini` with high reasoning; the `critic` consensus gate stays
+  - Ralplan keeps `planner` and `architect` in this posture; `planner`
+    uses exact `gpt-5.5` with medium reasoning, `architect` uses exact
+    `gpt-5.5` with xhigh reasoning, and the `critic` consensus gate stays
     on the frontier lane.
 
 - `deep-worker`:

--- a/plugins/oh-my-codex/skills/ultrawork/references/agent-tiers.md
+++ b/plugins/oh-my-codex/skills/ultrawork/references/agent-tiers.md
@@ -46,8 +46,9 @@ Use role to choose responsibility, tier to choose depth, and posture to choose o
   - Best for steerable frontier models and leader-style roles.
   - Prioritizes intent classification, delegation, verification, and architectural judgment.
   - Typical roles: `planner`, `analyst`, `architect`, `critic`, `code-reviewer`.
-  - Ralplan keeps `planner` and `architect` in this posture but pins them to
-    exact `gpt-5.4-mini` with high reasoning; the `critic` consensus gate stays
+  - Ralplan keeps `planner` and `architect` in this posture; `planner`
+    uses exact `gpt-5.5` with medium reasoning, `architect` uses exact
+    `gpt-5.5` with xhigh reasoning, and the `critic` consensus gate stays
     on the frontier lane.
 
 - `deep-worker`:

--- a/skills/ecomode/references/agent-tiers.md
+++ b/skills/ecomode/references/agent-tiers.md
@@ -47,7 +47,7 @@ Use role to choose responsibility, tier to choose depth, and posture to choose o
   - Prioritizes intent classification, delegation, verification, and architectural judgment.
   - Typical roles: `planner`, `analyst`, `architect`, `critic`, `code-reviewer`.
   - Ralplan keeps `planner` and `architect` in this posture but pins them to
-    exact `gpt-5.4-mini` with high reasoning; the `critic` consensus gate stays
+    exact `gpt-5.5` with role-specific reasoning; the `critic` consensus gate stays
     on the frontier lane.
 
 - `deep-worker`:

--- a/skills/ultrawork/references/agent-tiers.md
+++ b/skills/ultrawork/references/agent-tiers.md
@@ -46,8 +46,9 @@ Use role to choose responsibility, tier to choose depth, and posture to choose o
   - Best for steerable frontier models and leader-style roles.
   - Prioritizes intent classification, delegation, verification, and architectural judgment.
   - Typical roles: `planner`, `analyst`, `architect`, `critic`, `code-reviewer`.
-  - Ralplan keeps `planner` and `architect` in this posture but pins them to
-    exact `gpt-5.4-mini` with high reasoning; the `critic` consensus gate stays
+  - Ralplan keeps `planner` and `architect` in this posture; `planner`
+    uses exact `gpt-5.5` with medium reasoning, `architect` uses exact
+    `gpt-5.5` with xhigh reasoning, and the `critic` consensus gate stays
     on the frontier lane.
 
 - `deep-worker`:

--- a/src/agents/__tests__/definitions.test.ts
+++ b/src/agents/__tests__/definitions.test.ts
@@ -101,13 +101,13 @@ describe('agents/definitions', () => {
     }
   });
 
-  it('pins ralplan thesis and antithesis to exact mini while keeping the critic frontier-gated', () => {
-    assert.equal(AGENT_DEFINITIONS.planner.exactModel, 'gpt-5.4-mini');
-    assert.equal(AGENT_DEFINITIONS.planner.reasoningEffort, 'high');
+  it('pins ralplan thesis and antithesis to exact gpt-5.5 with role-specific reasoning', () => {
+    assert.equal(AGENT_DEFINITIONS.planner.exactModel, 'gpt-5.5');
+    assert.equal(AGENT_DEFINITIONS.planner.reasoningEffort, 'medium');
     assert.equal(AGENT_DEFINITIONS.planner.modelClass, 'frontier');
 
-    assert.equal(AGENT_DEFINITIONS.architect.exactModel, 'gpt-5.4-mini');
-    assert.equal(AGENT_DEFINITIONS.architect.reasoningEffort, 'high');
+    assert.equal(AGENT_DEFINITIONS.architect.exactModel, 'gpt-5.5');
+    assert.equal(AGENT_DEFINITIONS.architect.reasoningEffort, 'xhigh');
     assert.equal(AGENT_DEFINITIONS.architect.modelClass, 'frontier');
 
     assert.equal(AGENT_DEFINITIONS.critic.exactModel, undefined);

--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -161,14 +161,15 @@ describe("agents/native-config", () => {
   });
 
 
-  it("pins ralplan thesis/antithesis to exact gpt-5.5 while keeping researcher on exact mini", () => {
+  it("pins planner and architect to exact gpt-5.5 while keeping researcher on exact mini", () => {
     process.env.OMX_DEFAULT_FRONTIER_MODEL = "gpt-5.5";
     process.env.OMX_DEFAULT_STANDARD_MODEL = "gpt-5.5";
 
     for (const role of ["planner", "architect"] as const) {
       const toml = generateAgentToml(AGENT_DEFINITIONS[role], `${role} prompt`);
       assert.match(toml, /model = "gpt-5\.5"/, `${role} should use exact gpt-5.5`);
-      assert.doesNotMatch(toml, /exact gpt-5\.4-mini model/, `${role} should not receive exact-mini guidance`);
+      assert.match(toml, /exact gpt-5\.5 model/, `${role} should receive exact-gpt-5.5 guidance`);
+      assert.match(toml, /strict execution order: inspect -> plan -> act -> verify/, `${role} should receive the exact-model guardrail`);
       assert.match(toml, /resolved_model: gpt-5\.5/, `${role} should record exact gpt-5.5 metadata`);
     }
 

--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -161,24 +161,27 @@ describe("agents/native-config", () => {
   });
 
 
-  it("pins ralplan thesis/antithesis and researcher to exact gpt-5.4-mini without downgrading judgment roles", () => {
+  it("pins ralplan thesis/antithesis to exact gpt-5.5 while keeping researcher on exact mini", () => {
     process.env.OMX_DEFAULT_FRONTIER_MODEL = "gpt-5.5";
     process.env.OMX_DEFAULT_STANDARD_MODEL = "gpt-5.5";
 
-    for (const role of ["planner", "architect", "researcher"] as const) {
+    for (const role of ["planner", "architect"] as const) {
       const toml = generateAgentToml(AGENT_DEFINITIONS[role], `${role} prompt`);
-      assert.match(toml, /model = "gpt-5\.4-mini"/, `${role} should use exact mini`);
-      assert.match(toml, /exact gpt-5\.4-mini model/, `${role} should receive exact-mini guidance`);
-      assert.match(toml, /resolved_model: gpt-5\.4-mini/, `${role} should record exact mini metadata`);
+      assert.match(toml, /model = "gpt-5\.5"/, `${role} should use exact gpt-5.5`);
+      assert.doesNotMatch(toml, /exact gpt-5\.4-mini model/, `${role} should not receive exact-mini guidance`);
+      assert.match(toml, /resolved_model: gpt-5\.5/, `${role} should record exact gpt-5.5 metadata`);
     }
 
     const plannerToml = generateAgentToml(AGENT_DEFINITIONS.planner, "planner prompt");
-    assert.match(plannerToml, /model_reasoning_effort = "high"/);
+    assert.match(plannerToml, /model_reasoning_effort = "medium"/);
 
     const architectToml = generateAgentToml(AGENT_DEFINITIONS.architect, "architect prompt");
-    assert.match(architectToml, /model_reasoning_effort = "high"/);
+    assert.match(architectToml, /model_reasoning_effort = "xhigh"/);
 
     const researcherToml = generateAgentToml(AGENT_DEFINITIONS.researcher, "researcher prompt");
+    assert.match(researcherToml, /model = "gpt-5\.4-mini"/, "researcher should keep exact mini");
+    assert.match(researcherToml, /exact gpt-5\.4-mini model/, "researcher should receive exact-mini guidance");
+    assert.match(researcherToml, /resolved_model: gpt-5\.4-mini/, "researcher should record exact mini metadata");
     assert.match(researcherToml, /model_reasoning_effort = "high"/);
 
     for (const role of [
@@ -248,23 +251,23 @@ describe("agents/native-config", () => {
     assert.ok(guardIndex > modelDelegationIndex, "leaf guard should override model delegation text");
     assert.ok(metadataIndex > guardIndex, "metadata should remain final non-policy bookkeeping");
 
-    const architectToml = generateAgentToml(
-      AGENT_DEFINITIONS.architect,
-      "architect prompt",
+    const researcherToml = generateAgentToml(
+      AGENT_DEFINITIONS.researcher,
+      "researcher prompt",
     );
-    const exactMiniIndex = architectToml.indexOf(
+    const exactMiniIndex = researcherToml.indexOf(
       "strict execution order: inspect -> plan -> act -> verify",
     );
-    const architectGuardIndex = architectToml.indexOf("<native_subagent_leaf_guard>");
-    const architectMetadataIndex = architectToml.indexOf("## OMX Agent Metadata");
+    const researcherGuardIndex = researcherToml.indexOf("<native_subagent_leaf_guard>");
+    const researcherMetadataIndex = researcherToml.indexOf("## OMX Agent Metadata");
 
-    assert.ok(exactMiniIndex >= 0, "architect should exercise the exact-model overlay path");
+    assert.ok(exactMiniIndex >= 0, "researcher should exercise the exact-mini overlay path");
     assert.ok(
-      architectGuardIndex > exactMiniIndex,
-      "leaf guard should override exact-model overlay guidance",
+      researcherGuardIndex > exactMiniIndex,
+      "leaf guard should override exact-mini overlay guidance",
     );
     assert.ok(
-      architectMetadataIndex > architectGuardIndex,
+      researcherMetadataIndex > researcherGuardIndex,
       "metadata should remain final non-policy bookkeeping for exact-model roles",
     );
 

--- a/src/agents/definitions.ts
+++ b/src/agents/definitions.ts
@@ -7,9 +7,9 @@
 export interface AgentDefinition {
   name: string;
   description: string;
-  reasoningEffort: 'low' | 'medium' | 'high';
+  reasoningEffort: 'low' | 'medium' | 'high' | 'xhigh';
   /** Optional exact model pin for roles that should bypass tier defaults. */
-  exactModel?: 'gpt-5.4-mini';
+  exactModel?: 'gpt-5.4-mini' | 'gpt-5.5';
   posture: 'frontier-orchestrator' | 'deep-worker' | 'fast-lane';
   modelClass: 'frontier' | 'standard' | 'fast';
   routingRole: 'leader' | 'specialist' | 'executor';
@@ -74,8 +74,8 @@ export const AGENT_DEFINITIONS: Record<string, AgentDefinition> = {
   'planner': {
     name: 'planner',
     description: 'Task sequencing, execution plans, risk flags',
-    reasoningEffort: 'high',
-    exactModel: 'gpt-5.4-mini',
+    reasoningEffort: 'medium',
+    exactModel: 'gpt-5.5',
     posture: 'frontier-orchestrator',
     modelClass: 'frontier',
     routingRole: 'leader',
@@ -85,8 +85,8 @@ export const AGENT_DEFINITIONS: Record<string, AgentDefinition> = {
   'architect': {
     name: 'architect',
     description: 'System design, boundaries, interfaces, long-horizon tradeoffs',
-    reasoningEffort: 'high',
-    exactModel: 'gpt-5.4-mini',
+    reasoningEffort: 'xhigh',
+    exactModel: 'gpt-5.5',
     posture: 'frontier-orchestrator',
     modelClass: 'frontier',
     routingRole: 'leader',

--- a/src/agents/native-config.ts
+++ b/src/agents/native-config.ts
@@ -92,17 +92,19 @@ const MODEL_CLASS_OVERLAYS: Record<AgentDefinition["modelClass"], string> = {
   ].join("\n"),
 };
 
-const EXACT_MINI_MODEL_OVERLAY = [
-  "<exact_model_guidance>",
-  "",
-  `This role is executing under the exact ${EXACT_GPT_5_4_MINI_MODEL} model.`,
-  "- Use a strict execution order: inspect -> plan -> act -> verify.",
-  "- Treat completion criteria as explicit: only report done after the requested work is implemented and fresh verification passes.",
-  "- If requirements are ambiguous or a blocker appears, state the blocker plainly and stop guessing until the missing decision is resolved.",
-  "- Do not bluff, pad, or invent results; report missing evidence and incomplete work honestly.",
-  "",
-  "</exact_model_guidance>",
-].join("\n");
+function buildExactModelOverlay(exactModel: string): string {
+  return [
+    "<exact_model_guidance>",
+    "",
+    `This role is executing under the exact ${exactModel} model.`,
+    "- Use a strict execution order: inspect -> plan -> act -> verify.",
+    "- Treat completion criteria as explicit: only report done after the requested work is implemented and fresh verification passes.",
+    "- If requirements are ambiguous or a blocker appears, state the blocker plainly and stop guessing until the missing decision is resolved.",
+    "- Do not bluff, pad, or invent results; report missing evidence and incomplete work honestly.",
+    "",
+    "</exact_model_guidance>",
+  ].join("\n");
+}
 
 const NATIVE_SUBAGENT_LEAF_GUARD = [
   "<native_subagent_leaf_guard>",
@@ -134,6 +136,7 @@ interface RoleInstructionMetadata {
   modelClass: AgentDefinition["modelClass"];
   routingRole: AgentDefinition["routingRole"];
   nativeSubagentDelegation?: AgentDefinition["nativeSubagentDelegation"];
+  exactModel?: AgentDefinition["exactModel"];
 }
 
 interface ComposeRoleInstructionsOptions {
@@ -208,10 +211,6 @@ function shouldInheritRootModelProvider(
   return resolvedModel !== getSparkDefaultModel(options.codexHomeOverride);
 }
 
-function isExactMiniModel(resolvedModel?: string | null): boolean {
-  return resolvedModel?.trim() === EXACT_GPT_5_4_MINI_MODEL;
-}
-
 export function composeRoleInstructions(
   promptContent: string,
   metadata: RoleInstructionMetadata | null,
@@ -230,8 +229,10 @@ export function composeRoleInstructions(
     );
   }
 
-  if (isExactMiniModel(resolvedModel)) {
-    parts.push("", EXACT_MINI_MODEL_OVERLAY);
+  const exactModel = metadata?.exactModel
+    ?? (resolvedModel?.trim() === EXACT_GPT_5_4_MINI_MODEL ? EXACT_GPT_5_4_MINI_MODEL : undefined);
+  if (exactModel && resolvedModel?.trim() === exactModel) {
+    parts.push("", buildExactModelOverlay(exactModel));
   }
 
   if (options.nativeAgent === true && metadata?.nativeSubagentDelegation !== "allowed") {
@@ -276,10 +277,11 @@ export function composeRoleInstructionsForRole(
       ? {
           name: agent.name,
           posture: agent.posture,
-          modelClass: agent.modelClass,
-          routingRole: agent.routingRole,
-          nativeSubagentDelegation: agent.nativeSubagentDelegation,
-        }
+      modelClass: agent.modelClass,
+      routingRole: agent.routingRole,
+      nativeSubagentDelegation: agent.nativeSubagentDelegation,
+      exactModel: agent.exactModel,
+    }
       : null,
     resolvedModel,
   );

--- a/src/autopilot/__tests__/planner-routing.test.ts
+++ b/src/autopilot/__tests__/planner-routing.test.ts
@@ -48,7 +48,7 @@ describe('autopilot planner routing', () => {
     assert.deepEqual(resolveAutopilotPlannerRouting(tempDir), {
       owner: 'main',
       mainModel: 'gpt-5.5',
-      plannerModel: 'gpt-5.4-mini',
+      plannerModel: 'gpt-5.5',
       reason: 'main_not_cheap_or_mini',
       explicitPlannerOverride: false,
     });
@@ -60,7 +60,7 @@ describe('autopilot planner routing', () => {
     assert.deepEqual(resolveAutopilotPlannerRouting(tempDir), {
       owner: 'planner',
       mainModel: 'o4-mini',
-      plannerModel: 'gpt-5.4-mini',
+      plannerModel: 'gpt-5.5',
       reason: 'main_is_cheap_or_mini',
       explicitPlannerOverride: false,
     });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -165,6 +165,8 @@ import { dispatchHookEvent } from "../hooks/extensibility/dispatcher.js";
 import {
   collectInheritableTeamWorkerArgs as collectInheritableTeamWorkerArgsShared,
   resolveTeamWorkerLaunchArgs,
+  parseTeamWorkerLaunchArgs,
+  TEAM_WORKER_INHERITED_MODEL_ENV,
   resolveTeamLowComplexityDefaultModel,
 } from "../team/model-contract.js";
 import {
@@ -3967,6 +3969,7 @@ export function buildDetachedSessionBootstrapSteps(
   env: NodeJS.ProcessEnv = process.env,
   sqliteHomeOverride?: string,
   parentEnvFilePath?: string,
+  inheritedWorkerModel?: string | null,
 ): DetachedSessionTmuxStep[] {
   const detachedLeaderCmd = nativeWindows
     ? "powershell.exe"
@@ -4009,9 +4012,7 @@ export function buildDetachedSessionBootstrapSteps(
     sessionName,
     "-c",
     cwd,
-    ...(workerLaunchArgs
-      ? ["-e", `${TEAM_WORKER_LAUNCH_ARGS_ENV}=${workerLaunchArgs}`]
-      : []),
+    ...(workerLaunchArgs ? ["-e", `${TEAM_WORKER_LAUNCH_ARGS_ENV}=${workerLaunchArgs}`] : []),
     ...Object.entries(hudRuntimeEnv).map(([key, value]) => ["-e", `${key}=${value}`]).flat(),
     ...(codexHomeOverride ? ["-e", `CODEX_HOME=${codexHomeOverride}`] : []),
     ...(sqliteHomeOverride ? ["-e", `${CODEX_SQLITE_HOME_ENV}=${sqliteHomeOverride}`] : []),
@@ -4020,6 +4021,7 @@ export function buildDetachedSessionBootstrapSteps(
     ...(notifyTempContractRaw
       ? ["-e", `${OMX_NOTIFY_TEMP_CONTRACT_ENV}=${notifyTempContractRaw}`]
       : []),
+    ...(inheritedWorkerModel ? ["-e", `${TEAM_WORKER_INHERITED_MODEL_ENV}=${inheritedWorkerModel}`] : []),
     detachedLeaderCmd,
   ];
   const splitCaptureArgs: string[] = [
@@ -4814,6 +4816,10 @@ function runCodex(
     ? buildWindowsPromptCommand("node", [omxBin, "hud", "--watch"])
     : buildTmuxPaneCommand("env", [...hudEnvArgs, "node", omxBin, "hud", "--watch"]);
   const inheritLeaderFlags = process.env[TEAM_INHERIT_LEADER_FLAGS_ENV] !== "0";
+  const inheritedWorkerLaunchArgs = inheritLeaderFlags
+    ? collectInheritableTeamWorkerArgs(launchArgs)
+    : [];
+  const inheritedWorkerModel = parseTeamWorkerLaunchArgs(inheritedWorkerLaunchArgs).modelOverride ?? undefined;
   const workerLaunchArgs = resolveTeamWorkerLaunchArgsEnv(
     process.env[TEAM_WORKER_LAUNCH_ARGS_ENV],
     launchArgs,
@@ -4835,7 +4841,11 @@ function runCodex(
     ...buildHudRuntimeEnv({ sessionId }).env,
   };
   const codexEnv = workerLaunchArgs
-    ? { ...codexEnvWithSession, [TEAM_WORKER_LAUNCH_ARGS_ENV]: workerLaunchArgs }
+    ? {
+        ...codexEnvWithSession,
+        [TEAM_WORKER_LAUNCH_ARGS_ENV]: workerLaunchArgs,
+        ...(inheritedWorkerModel ? { [TEAM_WORKER_INHERITED_MODEL_ENV]: inheritedWorkerModel } : {}),
+      }
     : codexEnvWithSession;
   const codexEnvWithNotify = notifyTempContractRaw
     ? { ...codexEnv, [OMX_NOTIFY_TEMP_CONTRACT_ENV]: notifyTempContractRaw }
@@ -5079,6 +5089,7 @@ function runCodex(
           process.env,
           sqliteHomeOverride,
           detachedParentEnvFilePath,
+          inheritedWorkerModel,
         );
         for (const step of bootstrapSteps) {
           const output = execTmuxFileSync(step.args, {

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -736,7 +736,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.deepEqual(modeState.state.planning_routing, {
         owner: 'main',
         mainModel: 'gpt-5.5',
-        plannerModel: 'gpt-5.4-mini',
+        plannerModel: 'gpt-5.5',
         reason: 'main_not_cheap_or_mini',
         explicitPlannerOverride: false,
       });

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -163,7 +163,7 @@ describe('team model contract', () => {
   it('maps worker roles to default reasoning effort tiers', () => {
     assert.equal(resolveAgentReasoningEffort('explore'), 'low');
     assert.equal(resolveAgentReasoningEffort('executor'), 'medium');
-    assert.equal(resolveAgentReasoningEffort('architect'), 'high');
+    assert.equal(resolveAgentReasoningEffort('architect'), 'xhigh');
     assert.equal(resolveAgentReasoningEffort('does-not-exist'), undefined);
   });
 
@@ -190,6 +190,16 @@ describe('team model contract', () => {
       assert.equal(resolveAgentDefaultModel('executor'), 'gpt-5.5');
       assert.equal(resolveAgentDefaultModel('architect'), 'gpt-5.5');
       assert.equal(resolveAgentDefaultModel('does-not-exist'), undefined);
+    });
+  });
+  it('honors exact model pins before frontier fallback routing', () => {
+    withIsolatedDefaultModelEnv(() => {
+      process.env.OMX_DEFAULT_FRONTIER_MODEL = 'gpt-5.2-frontier';
+
+      assert.equal(resolveAgentDefaultModel('planner'), 'gpt-5.5');
+      assert.equal(resolveAgentDefaultModel('architect'), 'gpt-5.5');
+      assert.equal(resolveAgentDefaultModel('researcher'), 'gpt-5.4-mini');
+      assert.equal(resolveAgentDefaultModel('critic'), 'gpt-5.2-frontier');
     });
   });
 
@@ -230,13 +240,13 @@ describe('team model contract', () => {
         {
           requestedAgentType: 'architect',
           requestedDefaultModel: 'gpt-5.5',
-          requestedDefaultReasoning: 'high',
+          requestedDefaultReasoning: 'xhigh',
           actualModel: 'gpt-5.5',
-          actualReasoning: 'high',
+          actualReasoning: 'xhigh',
           modelSource: 'fallback',
           reasoningSource: 'role-default',
           inheritedParentModel: false,
-          actualLaunchArgs: ['-c', 'model_reasoning_effort="high"', '--model', 'gpt-5.5'],
+          actualLaunchArgs: ['-c', 'model_reasoning_effort="xhigh"', '--model', 'gpt-5.5'],
         },
       );
     });

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -248,6 +248,39 @@ describe('team model contract', () => {
       );
     });
   });
+  it('preserves explicit worker model overrides before exact role defaults', () => {
+    withIsolatedDefaultModelEnv(() => {
+      assert.deepEqual(
+        resolveTeamWorkerLaunchArgs({
+          existingRaw: '--model explicit-worker-model',
+          inheritedArgs: ['--dangerously-bypass-approvals-and-sandbox', '--model', 'gpt-5.4-mini'],
+          fallbackModel: resolveAgentDefaultModel('planner'),
+          preferredReasoning: 'high',
+          honorExactRoleModel: true,
+        }),
+        [
+          '--dangerously-bypass-approvals-and-sandbox',
+          '-c',
+          'model_reasoning_effort="high"',
+          '--model',
+          'explicit-worker-model',
+        ],
+      );
+
+      const diagnostics = resolveTeamWorkerLaunchDiagnostics({
+        requestedAgentType: 'planner',
+        existingRaw: '--model explicit-worker-model',
+        inheritedArgs: ['--model', 'gpt-5.4-mini'],
+        fallbackModel: resolveAgentDefaultModel('planner'),
+        preferredReasoning: 'high',
+        honorExactRoleModel: true,
+      });
+
+      assert.equal(diagnostics.actualModel, 'explicit-worker-model');
+      assert.equal(diagnostics.modelSource, 'env');
+      assert.equal(diagnostics.inheritedParentModel, false);
+    });
+  });
 
   it('preserves inherited mini leader model for roles without exact-model enforcement', () => {
     withIsolatedDefaultModelEnv(() => {

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -229,6 +229,45 @@ describe('team model contract', () => {
     });
   });
 
+  it('lets exact role model defaults override inherited mini leader model when requested', () => {
+    withIsolatedDefaultModelEnv(() => {
+      assert.deepEqual(
+        resolveTeamWorkerLaunchArgs({
+          inheritedArgs: ['--dangerously-bypass-approvals-and-sandbox', '--model', 'gpt-5.4-mini'],
+          fallbackModel: resolveAgentDefaultModel('planner'),
+          preferredReasoning: 'high',
+          honorExactRoleModel: true,
+        }),
+        [
+          '--dangerously-bypass-approvals-and-sandbox',
+          '-c',
+          'model_reasoning_effort="high"',
+          '--model',
+          'gpt-5.5',
+        ],
+      );
+    });
+  });
+
+  it('preserves inherited mini leader model for roles without exact-model enforcement', () => {
+    withIsolatedDefaultModelEnv(() => {
+      assert.deepEqual(
+        resolveTeamWorkerLaunchArgs({
+          inheritedArgs: ['--dangerously-bypass-approvals-and-sandbox', '--model', 'gpt-5.4-mini'],
+          fallbackModel: resolveAgentDefaultModel('executor'),
+          preferredReasoning: resolveAgentReasoningEffort('executor'),
+        }),
+        [
+          '--dangerously-bypass-approvals-and-sandbox',
+          '-c',
+          'model_reasoning_effort="medium"',
+          '--model',
+          'gpt-5.4-mini',
+        ],
+      );
+    });
+  });
+
   it('reports requested versus actual worker launch resolution for role defaults', () => {
     withIsolatedDefaultModelEnv(() => {
       assert.deepEqual(

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -44,7 +44,11 @@ import {
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
   type TeamRuntime,
 } from '../runtime.js';
-import { resolveAgentReasoningEffort, resolveTeamLowComplexityDefaultModel } from '../model-contract.js';
+import {
+  resolveAgentReasoningEffort,
+  resolveTeamLowComplexityDefaultModel,
+  TEAM_WORKER_INHERITED_MODEL_ENV,
+} from '../model-contract.js';
 import { readTeamEvents } from '../state/events.js';
 import { sanitizeTeamName } from '../tmux-session.js';
 import { buildInternalTeamName, resolveTeamIdentityScope } from '../team-identity.js';
@@ -608,19 +612,22 @@ describe('runtime', () => {
     });
   });
 
-  it('resolveWorkerLaunchArgsFromEnv keeps planner on exact gpt-5.5 high when leader is mini', () => {
+  it('resolveWorkerLaunchArgsFromEnv keeps planner on exact gpt-5.5 medium when inherited leader is mini', () => {
     withIsolatedDefaultModelEnv(() => {
       const args = resolveWorkerLaunchArgsFromEnv(
-        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--dangerously-bypass-approvals-and-sandbox' },
+        {
+          OMX_TEAM_WORKER_LAUNCH_ARGS: '--dangerously-bypass-approvals-and-sandbox --model gpt-5.4-mini',
+          [TEAM_WORKER_INHERITED_MODEL_ENV]: 'gpt-5.4-mini',
+        },
         'planner',
-        'gpt-5.4-mini',
-        'high',
+        undefined,
+        resolveAgentReasoningEffort('planner'),
         'codex',
       );
       assert.deepEqual(args, [
         '--dangerously-bypass-approvals-and-sandbox',
         '-c',
-        'model_reasoning_effort="high"',
+        'model_reasoning_effort="medium"',
         '--model',
         'gpt-5.5',
       ]);

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -608,6 +608,25 @@ describe('runtime', () => {
     });
   });
 
+  it('resolveWorkerLaunchArgsFromEnv keeps planner on exact gpt-5.5 high when leader is mini', () => {
+    withIsolatedDefaultModelEnv(() => {
+      const args = resolveWorkerLaunchArgsFromEnv(
+        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--dangerously-bypass-approvals-and-sandbox --model gpt-5.4-mini' },
+        'planner',
+        undefined,
+        'high',
+        'codex',
+      );
+      assert.deepEqual(args, [
+        '--dangerously-bypass-approvals-and-sandbox',
+        '-c',
+        'model_reasoning_effort="high"',
+        '--model',
+        'gpt-5.5',
+      ]);
+    });
+  });
+
   it('resolveWorkerLaunchArgsFromEnv treats *-low aliases as low complexity', () => {
     const args = resolveWorkerLaunchArgsFromEnv(
       { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -611,9 +611,9 @@ describe('runtime', () => {
   it('resolveWorkerLaunchArgsFromEnv keeps planner on exact gpt-5.5 high when leader is mini', () => {
     withIsolatedDefaultModelEnv(() => {
       const args = resolveWorkerLaunchArgsFromEnv(
-        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--dangerously-bypass-approvals-and-sandbox --model gpt-5.4-mini' },
+        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--dangerously-bypass-approvals-and-sandbox' },
         'planner',
-        undefined,
+        'gpt-5.4-mini',
         'high',
         'codex',
       );
@@ -643,6 +643,19 @@ describe('runtime', () => {
     assert.deepEqual(
       resolveWorkerLaunchArgsFromEnv({ OMX_TEAM_WORKER_LAUNCH_ARGS: '--model=gpt-5.3' }, 'explore'),
       ['--model', 'gpt-5.3'],
+    );
+  });
+
+  it('resolveWorkerLaunchArgsFromEnv preserves explicit env model before planner exact model', () => {
+    assert.deepEqual(
+      resolveWorkerLaunchArgsFromEnv(
+        { OMX_TEAM_WORKER_LAUNCH_ARGS: '--model explicit-worker-model' },
+        'planner',
+        'gpt-5.4-mini',
+        'high',
+        'codex',
+      ),
+      ['-c', 'model_reasoning_effort="high"', '--model', 'explicit-worker-model'],
     );
   });
 

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -121,7 +121,7 @@ function resolveTeamWorkerLaunchDiagnosticsFromParts(params: {
   const explicitReasoning = extractReasoningEffort(
     params.envParsed.reasoningOverride ?? params.inheritedParsed.reasoningOverride,
   );
-  const honorsExactRoleModel = params.honorExactRoleModel === true && Boolean(fallbackModel);
+  const honorsExactRoleModel = params.honorExactRoleModel === true && Boolean(fallbackModel) && !envModel;
 
   return {
     requestedAgentType: params.requestedAgentType,
@@ -129,7 +129,7 @@ function resolveTeamWorkerLaunchDiagnosticsFromParts(params: {
     requestedDefaultReasoning,
     actualModel: normalizeOptionalModel(actualParsed.modelOverride),
     actualReasoning: extractReasoningEffort(actualParsed.reasoningOverride),
-    modelSource: honorsExactRoleModel ? 'fallback' : envModel ? 'env' : inheritedModel ? 'inherited' : fallbackModel ? 'fallback' : 'none',
+    modelSource: envModel ? 'env' : honorsExactRoleModel ? 'fallback' : inheritedModel ? 'inherited' : fallbackModel ? 'fallback' : 'none',
     reasoningSource: explicitReasoning ? 'explicit' : requestedDefaultReasoning ? 'role-default' : 'none',
     inheritedParentModel: !honorsExactRoleModel && !envModel && Boolean(inheritedModel),
     actualLaunchArgs: [...params.actualLaunchArgs],
@@ -255,6 +255,7 @@ function selectTeamWorkerModel(params: {
   fallbackModel?: string;
   honorExactRoleModel?: boolean;
 }): string | undefined {
+  if (params.envModel) return params.envModel;
   if (params.honorExactRoleModel) return params.fallbackModel;
   return params.envModel ?? params.inheritedModel ?? params.fallbackModel;
 }

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -53,6 +53,7 @@ export interface ResolveTeamWorkerLaunchArgsOptions {
   inheritedArgs?: string[];
   fallbackModel?: string;
   preferredReasoning?: TeamReasoningEffort;
+  honorExactRoleModel?: boolean;
 }
 
 
@@ -110,6 +111,7 @@ function resolveTeamWorkerLaunchDiagnosticsFromParts(params: {
   preferredReasoning?: TeamReasoningEffort;
   actualLaunchArgs: string[];
   requestedAgentType?: string;
+  honorExactRoleModel?: boolean;
 }): ResolvedTeamWorkerLaunchDiagnostics {
   const envModel = normalizeOptionalModel(params.envParsed.modelOverride);
   const inheritedModel = normalizeOptionalModel(params.inheritedParsed.modelOverride);
@@ -119,6 +121,7 @@ function resolveTeamWorkerLaunchDiagnosticsFromParts(params: {
   const explicitReasoning = extractReasoningEffort(
     params.envParsed.reasoningOverride ?? params.inheritedParsed.reasoningOverride,
   );
+  const honorsExactRoleModel = params.honorExactRoleModel === true && Boolean(fallbackModel);
 
   return {
     requestedAgentType: params.requestedAgentType,
@@ -126,9 +129,9 @@ function resolveTeamWorkerLaunchDiagnosticsFromParts(params: {
     requestedDefaultReasoning,
     actualModel: normalizeOptionalModel(actualParsed.modelOverride),
     actualReasoning: extractReasoningEffort(actualParsed.reasoningOverride),
-    modelSource: envModel ? 'env' : inheritedModel ? 'inherited' : fallbackModel ? 'fallback' : 'none',
+    modelSource: honorsExactRoleModel ? 'fallback' : envModel ? 'env' : inheritedModel ? 'inherited' : fallbackModel ? 'fallback' : 'none',
     reasoningSource: explicitReasoning ? 'explicit' : requestedDefaultReasoning ? 'role-default' : 'none',
-    inheritedParentModel: !envModel && Boolean(inheritedModel),
+    inheritedParentModel: !honorsExactRoleModel && !envModel && Boolean(inheritedModel),
     actualLaunchArgs: [...params.actualLaunchArgs],
   };
 }
@@ -242,6 +245,20 @@ export function normalizeTeamWorkerLaunchArgs(
   return normalized;
 }
 
+function shouldHonorExactRoleModel(options: ResolveTeamWorkerLaunchArgsOptions): boolean {
+  return options.honorExactRoleModel === true && Boolean(options.fallbackModel);
+}
+
+function selectTeamWorkerModel(params: {
+  envModel?: string;
+  inheritedModel?: string;
+  fallbackModel?: string;
+  honorExactRoleModel?: boolean;
+}): string | undefined {
+  if (params.honorExactRoleModel) return params.fallbackModel;
+  return params.envModel ?? params.inheritedModel ?? params.fallbackModel;
+}
+
 export function resolveTeamWorkerLaunchArgs(options: ResolveTeamWorkerLaunchArgsOptions): string[] {
   const envArgs = splitWorkerLaunchArgs(options.existingRaw);
   const inheritedArgs = options.inheritedArgs ?? [];
@@ -252,7 +269,12 @@ export function resolveTeamWorkerLaunchArgs(options: ResolveTeamWorkerLaunchArgs
   const envModel = normalizeOptionalModel(envParsed.modelOverride);
   const inheritedModel = normalizeOptionalModel(inheritedParsed.modelOverride);
   const fallbackModel = normalizeOptionalModel(options.fallbackModel);
-  const selectedModel = envModel ?? inheritedModel ?? fallbackModel;
+  const selectedModel = selectTeamWorkerModel({
+    envModel,
+    inheritedModel,
+    fallbackModel,
+    honorExactRoleModel: shouldHonorExactRoleModel(options),
+  });
   const selectedModelProvider = envParsed.modelProviderOverride ?? inheritedParsed.modelProviderOverride ?? undefined;
   return normalizeTeamWorkerLaunchArgs(allArgs, selectedModel, options.preferredReasoning, selectedModelProvider);
 }
@@ -273,6 +295,7 @@ export function resolveTeamWorkerLaunchDiagnostics(
     preferredReasoning: options.preferredReasoning,
     actualLaunchArgs,
     requestedAgentType: options.requestedAgentType,
+    honorExactRoleModel: shouldHonorExactRoleModel(options),
   });
 }
 
@@ -283,6 +306,16 @@ export function resolveAgentReasoningEffort(
   if (typeof agentType !== 'string' || agentType.trim() === '') return undefined;
   return normalizeOptionalReasoning(getAgentReasoningOverride(agentType, codexHomeOverride))
     ?? normalizeOptionalReasoning(getAgent(agentType)?.reasoningEffort);
+}
+
+export function shouldHonorAgentExactModel(
+  agentType?: string,
+  codexHomeOverride?: string,
+): boolean {
+  if (typeof agentType !== 'string' || agentType.trim() === '') return false;
+  const normalized = agentType.trim().toLowerCase();
+  if (getAgentModelOverride(normalized, codexHomeOverride)) return true;
+  return Boolean(getAgent(normalized)?.exactModel);
 }
 
 export function resolveAgentDefaultModel(

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -295,9 +295,12 @@ export function resolveAgentDefaultModel(
   const modelOverride = getAgentModelOverride(normalized, codexHomeOverride);
   if (modelOverride) return modelOverride;
   if (normalized.endsWith('-low')) return resolveTeamLowComplexityDefaultModel(codexHomeOverride);
+
+  const agent = getAgent(normalized);
+  if (agent?.exactModel) return agent.exactModel;
   if (normalized === 'executor') return getMainDefaultModel(codexHomeOverride);
 
-  switch (getAgent(normalized)?.modelClass) {
+  switch (agent?.modelClass) {
     case 'fast':
       return resolveTeamLowComplexityDefaultModel(codexHomeOverride);
     case 'frontier':

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -14,6 +14,7 @@ const MODEL_FLAG = '--model';
 const CONFIG_FLAG = '-c';
 const REASONING_KEY = 'model_reasoning_effort';
 const MODEL_PROVIDER_KEY = 'model_provider';
+export const TEAM_WORKER_INHERITED_MODEL_ENV = 'OMX_TEAM_WORKER_INHERITED_MODEL';
 
 const LOW_COMPLEXITY_AGENT_TYPES = new Set([
   'explore',
@@ -111,7 +112,6 @@ function resolveTeamWorkerLaunchDiagnosticsFromParts(params: {
   preferredReasoning?: TeamReasoningEffort;
   actualLaunchArgs: string[];
   requestedAgentType?: string;
-  honorExactRoleModel?: boolean;
 }): ResolvedTeamWorkerLaunchDiagnostics {
   const envModel = normalizeOptionalModel(params.envParsed.modelOverride);
   const inheritedModel = normalizeOptionalModel(params.inheritedParsed.modelOverride);
@@ -121,17 +121,24 @@ function resolveTeamWorkerLaunchDiagnosticsFromParts(params: {
   const explicitReasoning = extractReasoningEffort(
     params.envParsed.reasoningOverride ?? params.inheritedParsed.reasoningOverride,
   );
-  const honorsExactRoleModel = params.honorExactRoleModel === true && Boolean(fallbackModel) && !envModel;
+  const selectedModel = normalizeOptionalModel(actualParsed.modelOverride);
 
   return {
     requestedAgentType: params.requestedAgentType,
     requestedDefaultModel: fallbackModel,
     requestedDefaultReasoning,
-    actualModel: normalizeOptionalModel(actualParsed.modelOverride),
+    actualModel: selectedModel,
     actualReasoning: extractReasoningEffort(actualParsed.reasoningOverride),
-    modelSource: envModel ? 'env' : honorsExactRoleModel ? 'fallback' : inheritedModel ? 'inherited' : fallbackModel ? 'fallback' : 'none',
+    modelSource:
+      selectedModel && envModel && selectedModel === envModel && (!inheritedModel || envModel !== inheritedModel)
+        ? 'env'
+        : selectedModel && inheritedModel && selectedModel === inheritedModel
+          ? 'inherited'
+          : selectedModel
+            ? 'fallback'
+            : 'none',
     reasoningSource: explicitReasoning ? 'explicit' : requestedDefaultReasoning ? 'role-default' : 'none',
-    inheritedParentModel: !honorsExactRoleModel && !envModel && Boolean(inheritedModel),
+    inheritedParentModel: Boolean(inheritedModel) && Boolean(selectedModel) && selectedModel === inheritedModel,
     actualLaunchArgs: [...params.actualLaunchArgs],
   };
 }
@@ -255,9 +262,12 @@ function selectTeamWorkerModel(params: {
   fallbackModel?: string;
   honorExactRoleModel?: boolean;
 }): string | undefined {
-  if (params.envModel) return params.envModel;
-  if (params.honorExactRoleModel) return params.fallbackModel;
-  return params.envModel ?? params.inheritedModel ?? params.fallbackModel;
+  const envModel = normalizeOptionalModel(params.envModel);
+  const inheritedModel = normalizeOptionalModel(params.inheritedModel);
+  const fallbackModel = normalizeOptionalModel(params.fallbackModel);
+  if (envModel && envModel !== inheritedModel) return envModel;
+  if (params.honorExactRoleModel && fallbackModel) return fallbackModel;
+  return envModel ?? inheritedModel ?? fallbackModel;
 }
 
 export function resolveTeamWorkerLaunchArgs(options: ResolveTeamWorkerLaunchArgsOptions): string[] {
@@ -296,7 +306,6 @@ export function resolveTeamWorkerLaunchDiagnostics(
     preferredReasoning: options.preferredReasoning,
     actualLaunchArgs,
     requestedAgentType: options.requestedAgentType,
-    honorExactRoleModel: shouldHonorExactRoleModel(options),
   });
 }
 

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -123,6 +123,7 @@ import {
   resolveTeamWorkerLaunchArgs,
   resolveTeamWorkerLaunchDiagnostics,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
+  TEAM_WORKER_INHERITED_MODEL_ENV,
   parseTeamWorkerLaunchArgs,
   resolveAgentDefaultModel,
   resolveAgentReasoningEffort,
@@ -2329,8 +2330,14 @@ export function resolveWorkerLaunchArgsFromEnv(
   preferredReasoning?: TeamReasoningEffort,
   workerCliOverride?: TeamWorkerCli,
 ): string[] {
-  const inheritedArgs = (typeof inheritedLeaderModel === 'string' && inheritedLeaderModel.trim() !== '')
-    ? ['--model', inheritedLeaderModel.trim()]
+  const inheritedFromEnv = typeof env[TEAM_WORKER_INHERITED_MODEL_ENV] === 'string'
+    ? env[TEAM_WORKER_INHERITED_MODEL_ENV]?.trim()
+    : undefined;
+  const effectiveInheritedModel = typeof inheritedLeaderModel === 'string' && inheritedLeaderModel.trim() !== ''
+    ? inheritedLeaderModel.trim()
+    : inheritedFromEnv;
+  const inheritedArgs = effectiveInheritedModel
+    ? ['--model', effectiveInheritedModel]
     : [];
   const fallbackModel = resolveAgentDefaultModel(agentType, env.CODEX_HOME);
   const diagnostics = resolveTeamWorkerLaunchDiagnostics({

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -126,6 +126,7 @@ import {
   parseTeamWorkerLaunchArgs,
   resolveAgentDefaultModel,
   resolveAgentReasoningEffort,
+  shouldHonorAgentExactModel,
   type TeamReasoningEffort,
 } from './model-contract.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
@@ -2337,6 +2338,7 @@ export function resolveWorkerLaunchArgsFromEnv(
     inheritedArgs,
     fallbackModel,
     preferredReasoning,
+    honorExactRoleModel: shouldHonorAgentExactModel(agentType, env.CODEX_HOME),
     requestedAgentType: agentType,
   });
 

--- a/src/utils/__tests__/agents-model-table.test.ts
+++ b/src/utils/__tests__/agents-model-table.test.ts
@@ -82,8 +82,8 @@ describe('agents model table', () => {
     assert.match(table, /\| Spark \(explorer\/fast\) \| `gpt-spark` \| low \|/);
     assert.match(table, /\| Standard \(subagent default\) \| `gpt-standard` \| high \|/);
     assert.match(table, /\| `explore` \| `gpt-spark` \| low \| Fast codebase search and file\/symbol mapping \(fast-lane, fast\) \|/);
-    assert.match(table, /\| `planner` \| `gpt-5\.4-mini` \| high \| Task sequencing, execution plans, risk flags \(frontier-orchestrator, frontier\) \|/);
-    assert.match(table, /\| `architect` \| `gpt-5\.4-mini` \| high \| System design, boundaries, interfaces, long-horizon tradeoffs \(frontier-orchestrator, frontier\) \|/);
+    assert.match(table, /\| `planner` \| `gpt-5\.5` \| medium \| Task sequencing, execution plans, risk flags \(frontier-orchestrator, frontier\) \|/);
+    assert.match(table, /\| `architect` \| `gpt-5\.5` \| xhigh \| System design, boundaries, interfaces, long-horizon tradeoffs \(frontier-orchestrator, frontier\) \|/);
     assert.doesNotMatch(table, /\| `security-reviewer` \|/);
     assert.doesNotMatch(table, /\| `build-fixer` \|/);
     assert.match(table, /\| `code-reviewer` \| `gpt-frontier` \| high \| Comprehensive review across all concerns \(frontier-orchestrator, frontier\) \|/);


### PR DESCRIPTION
Follow-up fix for PR #2976.

Addresses the review findings:
- exact-model guidance now keys off role exact pins (planner/architect and exact-mini roles)
- worker startup now threads inherited leader model separately so planner can honor exact gpt-5.5 without clobbering explicit worker env
- stale ecomode tier mirror updated

Verification:
- npm run build
- node dist/scripts/run-test-files.js dist/agents/__tests__/native-config.test.js dist/team/__tests__/model-contract.test.js dist/team/__tests__/runtime.test.js