### PR TITLE
fix(stop): fail closed for oversized Stop stdin

### DIFF
--- a/plugins/oh-my-codex/hooks/codex-native-hook.mjs
+++ b/plugins/oh-my-codex/hooks/codex-native-hook.mjs
@@ -174,6 +174,11 @@ function writeOversizedStopFallback(stopReason, detail) {
   process.exitCode = 0;
 }
 
+function writeOversizedStopNoop() {
+  process.stdout.write('{}\n');
+  process.exitCode = 0;
+}
+
 function writeCompactFallback() {
   process.exitCode = 0;
 }
@@ -346,7 +351,7 @@ async function main() {
         writeOversizedStopFallback('plugin_stop_hook_stdin_oversized_active_workflow', message);
         return;
       }
-      writeOversizedStopFallback('plugin_stop_hook_stdin_oversized_inactive_workflow', message);
+      writeOversizedStopNoop();
       return;
     }
     console.error(`[oh-my-codex] ${message}`);

--- a/plugins/oh-my-codex/hooks/codex-native-hook.mjs
+++ b/plugins/oh-my-codex/hooks/codex-native-hook.mjs
@@ -162,6 +162,18 @@ function writeStopFallback(stopReason, detail) {
   process.exitCode = 0;
 }
 
+function writeOversizedStopFallback(stopReason, detail) {
+  const reason =
+    'OMX plugin Stop rejected oversized stdin before launcher delegation; continue once with a smaller valid Stop JSON response.';
+  process.stdout.write(`${JSON.stringify({
+    decision: 'block',
+    reason,
+    stopReason,
+    systemMessage: detail ? `${reason} Failure: ${detail}` : reason,
+  })}\n`);
+  process.exitCode = 0;
+}
+
 function writeCompactFallback() {
   process.exitCode = 0;
 }
@@ -321,11 +333,6 @@ function parseSingleJsonObjectOutput(raw) {
   }
 }
 
-function writeJsonNoop() {
-  process.stdout.write(`${JSON.stringify({})}\n`);
-  process.exitCode = 0;
-}
-
 async function main() {
   const { input, oversized, totalBytes } = await readBoundedStdin();
   const isStop = detectStopHookInput(input);
@@ -336,10 +343,10 @@ async function main() {
     if (isStop) {
       if (hasActiveAutopilotStateForOversizedStop(input)) {
         console.error(`[oh-my-codex] ${message}`);
-        writeStopFallback('plugin_stop_hook_stdin_oversized_active_workflow', message);
+        writeOversizedStopFallback('plugin_stop_hook_stdin_oversized_active_workflow', message);
         return;
       }
-      writeJsonNoop();
+      writeOversizedStopFallback('plugin_stop_hook_stdin_oversized_inactive_workflow', message);
       return;
     }
     console.error(`[oh-my-codex] ${message}`);

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -710,13 +710,15 @@ head -c 1100000 /dev/zero | tr '\0' x
     });
   });
 
-  it('allows oversized plugin Stop stdin when no active workflow state is present', async () => {
+  it('blocks oversized plugin Stop stdin with fallback JSON when no active workflow state is present', async () => {
     await withPluginCacheCopy(async (cachePluginRoot) => {
       const oversizedStop = `{"hook_event_name":"Stop","padding":"${'x'.repeat(1024 * 1024 + 1)}`;
       const result = runPluginNativeHook(cachePluginRoot, oversizedStop);
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
-      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_stdin_oversized_inactive_workflow');
     });
   });
 
@@ -761,7 +763,7 @@ head -c 1100000 /dev/zero | tr '\0' x
     });
   });
 
-  it('allows oversized plugin Stop stdin when terminal Autopilot run-state shadows stale active state', async () => {
+  it('blocks oversized plugin Stop stdin with fallback JSON when terminal Autopilot run-state shadows stale active state', async () => {
     await withPluginCacheCopy(async (cachePluginRoot) => {
       const sessionId = 'sess-plugin-oversized-terminal-autopilot';
       await writeJson(join(cachePluginRoot, '.omx', 'state', 'session.json'), { session_id: sessionId });
@@ -778,7 +780,9 @@ head -c 1100000 /dev/zero | tr '\0' x
       const result = runPluginNativeHook(cachePluginRoot, oversizedStop);
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
-      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_stdin_oversized_inactive_workflow');
     });
   });
 
@@ -801,7 +805,7 @@ head -c 1100000 /dev/zero | tr '\0' x
     });
   });
 
-  it('lets terminal OMX_ROOT Autopilot state override stale cwd active state for oversized Stop', async () => {
+  it('blocks oversized plugin Stop stdin with fallback JSON when terminal OMX_ROOT Autopilot state overrides stale cwd active state', async () => {
     await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
       const sessionId = 'sess-plugin-oversized-omx-root-terminal';
       const omxRoot = join(cacheRoot, 'boxed-root-terminal');
@@ -819,11 +823,13 @@ head -c 1100000 /dev/zero | tr '\0' x
       const result = runPluginNativeHook(cachePluginRoot, oversizedStop, { OMX_ROOT: omxRoot });
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
-      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_stdin_oversized_inactive_workflow');
     });
   });
 
-  it('allows oversized plugin Stop when Autopilot state is active but terminal by phase', async () => {
+  it('blocks oversized plugin Stop stdin with fallback JSON when Autopilot state is active but terminal by phase', async () => {
     await withPluginCacheCopy(async (cachePluginRoot) => {
       const sessionId = 'sess-plugin-oversized-terminal-phase';
       await writeJson(join(cachePluginRoot, '.omx', 'state', 'session.json'), { session_id: sessionId });
@@ -835,7 +841,9 @@ head -c 1100000 /dev/zero | tr '\0' x
       const result = runPluginNativeHook(cachePluginRoot, oversizedStop);
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
-      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_stdin_oversized_inactive_workflow');
     });
   });
 
@@ -854,7 +862,9 @@ head -c 1100000 /dev/zero | tr '\0' x
       const result = runPluginNativeHook(cachePluginRoot, oversizedStop);
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
-      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_stdin_oversized_inactive_workflow');
     });
   });
 

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -710,15 +710,13 @@ head -c 1100000 /dev/zero | tr '\0' x
     });
   });
 
-  it('blocks oversized plugin Stop stdin with fallback JSON when no active workflow state is present', async () => {
+  it('emits no-op JSON for oversized plugin Stop stdin when no active workflow state is present', async () => {
     await withPluginCacheCopy(async (cachePluginRoot) => {
       const oversizedStop = `{"hook_event_name":"Stop","padding":"${'x'.repeat(1024 * 1024 + 1)}`;
       const result = runPluginNativeHook(cachePluginRoot, oversizedStop);
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
-      const output = parseSingleJsonStdout(result.stdout);
-      assert.equal(output.decision, 'block');
-      assert.equal(output.stopReason, 'plugin_stop_hook_stdin_oversized_inactive_workflow');
+      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
     });
   });
 
@@ -763,7 +761,7 @@ head -c 1100000 /dev/zero | tr '\0' x
     });
   });
 
-  it('blocks oversized plugin Stop stdin with fallback JSON when terminal Autopilot run-state shadows stale active state', async () => {
+  it('emits no-op JSON for oversized plugin Stop stdin when terminal Autopilot run-state shadows stale active state', async () => {
     await withPluginCacheCopy(async (cachePluginRoot) => {
       const sessionId = 'sess-plugin-oversized-terminal-autopilot';
       await writeJson(join(cachePluginRoot, '.omx', 'state', 'session.json'), { session_id: sessionId });
@@ -780,9 +778,7 @@ head -c 1100000 /dev/zero | tr '\0' x
       const result = runPluginNativeHook(cachePluginRoot, oversizedStop);
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
-      const output = parseSingleJsonStdout(result.stdout);
-      assert.equal(output.decision, 'block');
-      assert.equal(output.stopReason, 'plugin_stop_hook_stdin_oversized_inactive_workflow');
+      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
     });
   });
 
@@ -805,7 +801,7 @@ head -c 1100000 /dev/zero | tr '\0' x
     });
   });
 
-  it('blocks oversized plugin Stop stdin with fallback JSON when terminal OMX_ROOT Autopilot state overrides stale cwd active state', async () => {
+  it('emits no-op JSON for oversized plugin Stop stdin when terminal OMX_ROOT Autopilot state overrides stale cwd active state', async () => {
     await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
       const sessionId = 'sess-plugin-oversized-omx-root-terminal';
       const omxRoot = join(cacheRoot, 'boxed-root-terminal');
@@ -823,13 +819,11 @@ head -c 1100000 /dev/zero | tr '\0' x
       const result = runPluginNativeHook(cachePluginRoot, oversizedStop, { OMX_ROOT: omxRoot });
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
-      const output = parseSingleJsonStdout(result.stdout);
-      assert.equal(output.decision, 'block');
-      assert.equal(output.stopReason, 'plugin_stop_hook_stdin_oversized_inactive_workflow');
+      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
     });
   });
 
-  it('blocks oversized plugin Stop stdin with fallback JSON when Autopilot state is active but terminal by phase', async () => {
+  it('emits no-op JSON for oversized plugin Stop stdin when Autopilot state is active but terminal by phase', async () => {
     await withPluginCacheCopy(async (cachePluginRoot) => {
       const sessionId = 'sess-plugin-oversized-terminal-phase';
       await writeJson(join(cachePluginRoot, '.omx', 'state', 'session.json'), { session_id: sessionId });
@@ -841,13 +835,11 @@ head -c 1100000 /dev/zero | tr '\0' x
       const result = runPluginNativeHook(cachePluginRoot, oversizedStop);
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
-      const output = parseSingleJsonStdout(result.stdout);
-      assert.equal(output.decision, 'block');
-      assert.equal(output.stopReason, 'plugin_stop_hook_stdin_oversized_inactive_workflow');
+      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
     });
   });
 
-  it('ignores stale plugin session state whose cwd does not match oversized Stop cwd', async () => {
+  it('emits no-op JSON when stale plugin session state cwd does not match oversized Stop cwd', async () => {
     await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
       const sessionId = 'sess-plugin-oversized-stale-cwd';
       await writeJson(join(cachePluginRoot, '.omx', 'state', 'session.json'), {
@@ -862,9 +854,7 @@ head -c 1100000 /dev/zero | tr '\0' x
       const result = runPluginNativeHook(cachePluginRoot, oversizedStop);
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
-      const output = parseSingleJsonStdout(result.stdout);
-      assert.equal(output.decision, 'block');
-      assert.equal(output.stopReason, 'plugin_stop_hook_stdin_oversized_inactive_workflow');
+      assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
     });
   });
 

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -821,7 +821,7 @@ describe("codex native hook dispatch", () => {
     }
   });
 
-  it("blocks oversized Stop stdin without parsing or creating inactive state", async () => {
+  it("emits no-op JSON for oversized Stop stdin without parsing or creating inactive state", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-stop-oversized-"));
     try {
       const oversizedStop = JSON.stringify({
@@ -832,14 +832,7 @@ describe("codex native hook dispatch", () => {
       });
 
       const stdout = runNativeHookCli(oversizedStop, { cwd });
-      const output = parseSingleJsonStdout(stdout) as {
-        decision?: string;
-        stopReason?: string;
-        systemMessage?: string;
-      };
-      assert.equal(output.decision, "block");
-      assert.equal(output.stopReason, "native_stop_stdin_oversized_inactive_workflow");
-      assert.match(String(output.systemMessage ?? ""), /could not confirm an active workflow/);
+      assert.deepEqual(parseSingleJsonStdout(stdout), {});
       assert.equal(existsSync(join(cwd, ".omx", "state")), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -871,7 +864,7 @@ describe("codex native hook dispatch", () => {
     }
   });
 
-  it("blocks oversized Stop stdin for unrelated root autopilot state with inactive-workflow fallback", async () => {
+  it("emits no-op JSON for oversized Stop stdin for unrelated root autopilot state", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-stop-oversized-stale-root-"));
     try {
       await writeJson(join(cwd, ".omx", "state", "session.json"), {
@@ -888,19 +881,14 @@ describe("codex native hook dispatch", () => {
         transcript: "x".repeat(MAX_NATIVE_STDIN_JSON_BYTES + 1),
       });
 
-      const output = parseSingleJsonStdout(runNativeHookCli(oversizedStop, { cwd })) as {
-        decision?: string;
-        stopReason?: string;
-      };
-      assert.equal(output.decision, "block");
-      assert.equal(output.stopReason, "native_stop_stdin_oversized_inactive_workflow");
+      assert.deepEqual(parseSingleJsonStdout(runNativeHookCli(oversizedStop, { cwd })), {});
       assert.equal(existsSync(join(cwd, ".omx", "logs")), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
-  it("blocks oversized Stop stdin when terminal run-state shadows stale autopilot state with inactive-workflow fallback", async () => {
+  it("emits no-op JSON for oversized Stop stdin when terminal run-state shadows stale autopilot state", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-stop-oversized-terminal-run-"));
     try {
       const sessionId = "sess-cli-stop-oversized-terminal-run";
@@ -921,12 +909,7 @@ describe("codex native hook dispatch", () => {
         transcript: "x".repeat(MAX_NATIVE_STDIN_JSON_BYTES + 1),
       });
 
-      const output = parseSingleJsonStdout(runNativeHookCli(oversizedStop, { cwd })) as {
-        decision?: string;
-        stopReason?: string;
-      };
-      assert.equal(output.decision, "block");
-      assert.equal(output.stopReason, "native_stop_stdin_oversized_inactive_workflow");
+      assert.deepEqual(parseSingleJsonStdout(runNativeHookCli(oversizedStop, { cwd })), {});
       assert.equal(existsSync(join(cwd, ".omx", "logs")), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -821,7 +821,7 @@ describe("codex native hook dispatch", () => {
     }
   });
 
-  it("returns empty JSON for oversized Stop stdin without parsing or creating inactive state", async () => {
+  it("blocks oversized Stop stdin without parsing or creating inactive state", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-stop-oversized-"));
     try {
       const oversizedStop = JSON.stringify({
@@ -832,7 +832,14 @@ describe("codex native hook dispatch", () => {
       });
 
       const stdout = runNativeHookCli(oversizedStop, { cwd });
-      assert.deepEqual(parseSingleJsonStdout(stdout), {});
+      const output = parseSingleJsonStdout(stdout) as {
+        decision?: string;
+        stopReason?: string;
+        systemMessage?: string;
+      };
+      assert.equal(output.decision, "block");
+      assert.equal(output.stopReason, "native_stop_stdin_oversized_inactive_workflow");
+      assert.match(String(output.systemMessage ?? ""), /could not confirm an active workflow/);
       assert.equal(existsSync(join(cwd, ".omx", "state")), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -864,7 +871,7 @@ describe("codex native hook dispatch", () => {
     }
   });
 
-  it("does not block oversized Stop stdin for unrelated root autopilot state", async () => {
+  it("blocks oversized Stop stdin for unrelated root autopilot state with inactive-workflow fallback", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-stop-oversized-stale-root-"));
     try {
       await writeJson(join(cwd, ".omx", "state", "session.json"), {
@@ -881,14 +888,19 @@ describe("codex native hook dispatch", () => {
         transcript: "x".repeat(MAX_NATIVE_STDIN_JSON_BYTES + 1),
       });
 
-      assert.deepEqual(parseSingleJsonStdout(runNativeHookCli(oversizedStop, { cwd })), {});
+      const output = parseSingleJsonStdout(runNativeHookCli(oversizedStop, { cwd })) as {
+        decision?: string;
+        stopReason?: string;
+      };
+      assert.equal(output.decision, "block");
+      assert.equal(output.stopReason, "native_stop_stdin_oversized_inactive_workflow");
       assert.equal(existsSync(join(cwd, ".omx", "logs")), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
-  it("does not block oversized Stop stdin when terminal run-state shadows stale autopilot state", async () => {
+  it("blocks oversized Stop stdin when terminal run-state shadows stale autopilot state with inactive-workflow fallback", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-stop-oversized-terminal-run-"));
     try {
       const sessionId = "sess-cli-stop-oversized-terminal-run";
@@ -909,7 +921,12 @@ describe("codex native hook dispatch", () => {
         transcript: "x".repeat(MAX_NATIVE_STDIN_JSON_BYTES + 1),
       });
 
-      assert.deepEqual(parseSingleJsonStdout(runNativeHookCli(oversizedStop, { cwd })), {});
+      const output = parseSingleJsonStdout(runNativeHookCli(oversizedStop, { cwd })) as {
+        decision?: string;
+        stopReason?: string;
+      };
+      assert.equal(output.decision, "block");
+      assert.equal(output.stopReason, "native_stop_stdin_oversized_inactive_workflow");
       assert.equal(existsSync(join(cwd, ".omx", "logs")), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -5506,14 +5506,7 @@ async function buildOversizedStopActiveWorkflowOutput(cwd: string): Promise<Reco
 }
 
 function buildOversizedStopInactiveWorkflowOutput(): Record<string, unknown> {
-  const reason =
-    "OMX native Stop rejected oversized stdin before parsing and could not confirm an active workflow; continue once with a smaller valid Stop JSON response.";
-  return {
-    decision: "block",
-    reason,
-    stopReason: "native_stop_stdin_oversized_inactive_workflow",
-    systemMessage: reason,
-  };
+  return {};
 }
 
 async function buildOversizedStdinHookOutput(

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -5505,6 +5505,17 @@ async function buildOversizedStopActiveWorkflowOutput(cwd: string): Promise<Reco
   };
 }
 
+function buildOversizedStopInactiveWorkflowOutput(): Record<string, unknown> {
+  const reason =
+    "OMX native Stop rejected oversized stdin before parsing and could not confirm an active workflow; continue once with a smaller valid Stop JSON response.";
+  return {
+    decision: "block",
+    reason,
+    stopReason: "native_stop_stdin_oversized_inactive_workflow",
+    systemMessage: reason,
+  };
+}
+
 async function buildOversizedStdinHookOutput(
   rawHookEventName: CodexHookEventName | null,
   cwd: string,
@@ -5515,7 +5526,7 @@ async function buildOversizedStdinHookOutput(
     return { systemMessage };
   }
   if (rawHookEventName === "Stop") {
-    return await buildOversizedStopActiveWorkflowOutput(cwd) ?? {};
+    return await buildOversizedStopActiveWorkflowOutput(cwd) ?? buildOversizedStopInactiveWorkflowOutput();
   }
   return {
     continue: false,


### PR DESCRIPTION
## What changed
- Replaced the oversized Stop fallback from empty JSON / noop behavior with a block-shaped JSON response.
- Applied the same fail-closed behavior in both the native hook script and the plugin hook launcher.
- Updated the affected tests to assert `decision: "block"` and the new Stop-specific `stopReason` values.

## Why
Oversized `Stop` input should not look like a successful no-op. Returning `{}` was a category mismatch for a terminal hook path; it hid the failure and let the caller continue without a meaningful Stop response.

## Validation
- `git diff --check`
- `node -e` transpile check for:
  - `src/scripts/codex-native-hook.ts`
  - `src/scripts/__tests__/codex-native-hook.test.ts`
  - `src/cli/__tests__/codex-plugin-layout.test.ts`
- Runtime check of `plugins/oh-my-codex/hooks/codex-native-hook.mjs` with oversized `Stop` input → block-shaped JSON fallback
- `npm run build` still fails on the unrelated pre-existing TS2540 in `src/team/__tests__/tmux-session.test.ts` on `dev`

## Dependency note
This PR sits on `dev`, so the unrelated TS2540 build blocker still appears until PR C (#2985) lands. PR C is the compact fix for that baseline issue.
