### PR TITLE
Fix exact-role worker CLI resolution in scale-up

### DIFF
--- a/src/team/__tests__/worker-runtime-identity.test.ts
+++ b/src/team/__tests__/worker-runtime-identity.test.ts
@@ -288,4 +288,107 @@ process.on('SIGTERM', () => process.exit(0));
       await rm(fakeBinDir, { recursive: true, force: true });
     }
   });
+
+  it('scaleUp recomputes worker CLI from exact-role-resolved launch args instead of inherited non-Codex model routing', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-identity-scale-exact-'));
+    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-runtime-identity-scale-exact-bin-'));
+    const tmuxStubPath = join(fakeBinDir, 'tmux');
+    const tmuxLogPath = join(fakeBinDir, 'tmux.log');
+    const previousPath = process.env.PATH;
+
+    try {
+      await writeFile(
+        tmuxStubPath,
+        [
+          '#!/bin/sh',
+          'set -eu',
+          `printf '%s\n' "$*" >> "${tmuxLogPath}"`,
+          'case "${1:-}" in',
+          '  -V)',
+          '    echo "tmux 3.2a"',
+          '    ;;',
+          '  split-window)',
+          '    echo "%31"',
+          '    ;;',
+          '  list-panes)',
+          '    echo "42424"',
+          '    ;;',
+          '  send-keys)',
+          '    ;;',
+          '  capture-pane)',
+          '    echo ""',
+          '    ;;',
+          'esac',
+          'exit 0',
+          '',
+        ].join('\n'),
+      );
+      await chmod(tmuxStubPath, 0o755);
+      await writeFile(tmuxLogPath, '');
+      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+
+      await mkdir(join(cwd, '.omx', 'state', 'team', 'exact-role-cli'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'state', 'team', 'exact-role-cli', 'worker-agents.md'), '# Base worker instructions\n');
+
+      await initTeamState('exact-role-cli', 'task', 'executor', 1, cwd);
+      await createTask('exact-role-cli', {
+        subject: 'architecture follow-up',
+        description: 'exact-role scale-up regression',
+        status: 'pending',
+        owner: 'worker-2',
+        role: 'architect',
+      }, cwd);
+
+      const config = await readTeamConfig('exact-role-cli', cwd);
+      assert.ok(config);
+      if (!config) return;
+      config.tmux_session = 'omx-team-exact-role-cli';
+      config.leader_pane_id = '%11';
+      config.workers[0]!.pane_id = '%21';
+      await saveTeamConfig(config, cwd);
+
+      const manifestPath = join(cwd, '.omx', 'state', 'team', 'exact-role-cli', 'manifest.v2.json');
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as { policy?: Record<string, unknown> };
+      manifest.policy = {
+        ...(manifest.policy ?? {}),
+        dispatch_mode: 'transport_direct',
+      };
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+      const result = await scaleUp(
+        'exact-role-cli',
+        1,
+        'executor',
+        [{ subject: 'architecture follow-up', description: 'exact-role scale-up regression', owner: 'worker-2', role: 'architect' }],
+        cwd,
+        {
+          OMX_TEAM_SCALING_ENABLED: '1',
+          OMX_TEAM_SKIP_READY_WAIT: '1',
+          OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen',
+          OMX_TEAM_WORKER_INHERITED_MODEL: 'claude-sonnet-4-6',
+        },
+      );
+      assert.equal(result.ok, true);
+      if (!result.ok) return;
+
+      const workerIdentity = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'team', 'exact-role-cli', 'workers', 'worker-2', 'identity.json'), 'utf-8')) as { worker_cli?: string; role?: string };
+      assert.equal(workerIdentity.role, 'architect');
+      assert.equal(workerIdentity.worker_cli, 'codex');
+
+      const startupScript = await readFile(join(cwd, '.omx', 'state', 'team', 'exact-role-cli', 'runtime', 'worker-2-startup.sh'), 'utf-8');
+      assert.match(startupScript, /codex/);
+      assert.doesNotMatch(startupScript, /\bclaude\b/);
+      assert.doesNotMatch(startupScript, /\bgemini\b/);
+
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /worker-2-startup\.sh/);
+      assert.doesNotMatch(tmuxLog, /\bclaude\b/);
+      assert.doesNotMatch(tmuxLog, /\bgemini\b/);
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(fakeBinDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -24,7 +24,6 @@ import {
   buildWorkerStartupCommand,
   trustWorkerMiseConfigIfAvailable,
   writeWorkerStartupScriptCommand,
-  resolveTeamWorkerCliPlan,
   tagPaneTeamOwner,
 } from './tmux-session.js';
 import { execFileSync, spawnSync } from 'child_process';
@@ -69,8 +68,11 @@ import {
   resolveTeamWorkerLaunchArgs,
   resolveAgentDefaultModel,
   resolveAgentReasoningEffort,
+  shouldHonorAgentExactModel,
+  TEAM_WORKER_INHERITED_MODEL_ENV,
   type TeamReasoningEffort,
 } from './model-contract.js';
+import { resolveTeamWorkerCliForResolvedLaunchArgs } from './runtime.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
 import {
   ensureWorktree,
@@ -277,6 +279,7 @@ export async function scaleUp(
 
     const maxWorkers = config.max_workers;
     const currentCount = config.workers.length;
+    const targetWorkerCount = currentCount + count;
     if (currentCount + count > maxWorkers) {
       return {
         ok: false,
@@ -396,10 +399,6 @@ export async function scaleUp(
     }
     const persistedTasks = await listTasks(sanitized, leaderCwd);
 
-    // Resolve shared worker launch args for CLI selection.
-    const sharedWorkerLaunchArgs = resolveWorkerLaunchArgsForScaling(launchEnv, agentType, undefined, codexHomeOverride);
-    const workerCliPlan = resolveTeamWorkerCliPlan(count, sharedWorkerLaunchArgs, launchEnv);
-
     for (let i = 0; i < count; i++) {
       const workerIndex = nextIndex;
       nextIndex++;
@@ -439,6 +438,7 @@ export async function scaleUp(
       const preferredReasoning = resolveAgentReasoningEffort(runtimeRole, codexHomeOverride)
         ?? resolveAgentReasoningEffort(agentType, codexHomeOverride);
       const workerLaunchArgs = resolveWorkerLaunchArgsForScaling(launchEnv, runtimeRole, preferredReasoning, codexHomeOverride);
+      const workerCli = resolveTeamWorkerCliForResolvedLaunchArgs(workerIndex, targetWorkerCount, workerLaunchArgs, launchEnv);
       const resolvedWorkerModel = parseTeamWorkerLaunchArgs(workerLaunchArgs).modelOverride ?? undefined;
       const rolePromptContent = rawRolePromptContent
         ? composeRoleInstructionsForRole(runtimeRole, rawRolePromptContent, resolvedWorkerModel)
@@ -477,7 +477,7 @@ export async function scaleUp(
         workerLaunchArgs,
         workerCwd,
         extraEnv,
-        workerCliPlan[i],
+        workerCli,
         undefined,
         runtimeRole,
       ) ?? buildWorkerStartupCommand(
@@ -486,7 +486,7 @@ export async function scaleUp(
         workerLaunchArgs,
         workerCwd,
         extraEnv,
-        workerCliPlan[i],
+        workerCli,
         undefined,
         runtimeRole,
       );
@@ -539,7 +539,7 @@ export async function scaleUp(
         name: workerName,
         index: workerIndex,
         role: workerRole,
-        worker_cli: workerCliPlan[i],
+        worker_cli: workerCli,
         assigned_tasks: [],
         pid: panePid ?? undefined,
         pane_id: paneId,
@@ -598,7 +598,7 @@ export async function scaleUp(
           if (dispatchPolicy.dispatch_mode === 'hook_preferred_with_fallback') {
             return { ok: true, transport: 'hook', reason: 'queued_for_hook_dispatch' };
           }
-          return await notifyWorkerPaneOutcome(sessionName, workerIndex, message, paneId, workerCliPlan[i]);
+          return await notifyWorkerPaneOutcome(sessionName, workerIndex, message, paneId, workerCli);
         },
       });
       let outcome = queued;
@@ -610,7 +610,7 @@ export async function scaleUp(
         if (receipt && (receipt.status === 'notified' || receipt.status === 'delivered')) {
           outcome = { ok: true, transport: 'hook', reason: `hook_receipt_${receipt.status}`, request_id: queued.request_id };
         } else {
-          const fallback = await notifyWorkerPaneOutcome(sessionName, workerIndex, triggerDirective.text, paneId, workerCliPlan[i]);
+          const fallback = await notifyWorkerPaneOutcome(sessionName, workerIndex, triggerDirective.text, paneId, workerCli);
           if (receipt?.status === 'failed') {
             if (fallback.ok) {
               await transitionDispatchRequest(
@@ -690,7 +690,7 @@ export async function scaleUp(
       // Retry dispatch once if a trust prompt is blocking the worker pane (fixes #393).
       if (!outcome.ok && dismissTrustPromptIfPresent(sessionName, workerIndex, paneId)) {
         waitForWorkerReady(sessionName, workerIndex, readyTimeoutMs, paneId);
-        const retry = await notifyWorkerPaneOutcome(sessionName, workerIndex, triggerDirective.text, paneId, workerCliPlan[i]);
+        const retry = await notifyWorkerPaneOutcome(sessionName, workerIndex, triggerDirective.text, paneId, workerCli);
         if (retry.ok) {
           outcome = retry;
         }
@@ -920,7 +920,10 @@ function resolveWorkerLaunchArgsForScaling(
   preferredReasoning?: TeamReasoningEffort,
   codexHomeOverride?: string,
 ): string[] {
-  const inheritedArgs: string[] = [];
+  const inheritedLeaderModel = typeof env[TEAM_WORKER_INHERITED_MODEL_ENV] === 'string'
+    ? env[TEAM_WORKER_INHERITED_MODEL_ENV]?.trim()
+    : undefined;
+  const inheritedArgs = inheritedLeaderModel ? ['--model', inheritedLeaderModel] : [];
   const fallbackModel = resolveAgentDefaultModel(agentType, codexHomeOverride ?? env.CODEX_HOME);
 
   return resolveTeamWorkerLaunchArgs({
@@ -928,5 +931,6 @@ function resolveWorkerLaunchArgsForScaling(
     inheritedArgs,
     fallbackModel,
     preferredReasoning,
+    honorExactRoleModel: shouldHonorAgentExactModel(agentType, codexHomeOverride),
   });
 }


### PR DESCRIPTION
## Follow-up to PR #2989

This PR is a follow-up to merged PR #2989 on `dev`.
It fixes the scale-up path so exact-role workers recompute their CLI from the final per-worker launch args instead of stale shared launch args.

## What changed
- Recompute worker CLI from the resolved per-worker launch args during scale-up.
- Carry inherited leader model routing into exact-role resolution.
- Extract the exact-role CLI resolver into the shared tmux-session layer so scaling and runtime use the same pure helper.
- Keep the final worker bootstrap aligned with the resolved role contract.
- Add a regression test that covers a scale-down gap / monotonic worker-index case.

## Why
A stale shared-args path could preserve inherited non-Codex model routing too early and select the wrong worker CLI during scale-up.
The previous implementation also conflated worker identity with contiguous lookup position, which could fail after scale-down.

## Verification
- `npm run test:team:worker-runtime-identity`
- `npm run lint`
