### PR TITLE
Follow-up: exact-role scale-up CLI resolver

### DIFF
--- a/src/team/__tests__/worker-runtime-identity.test.ts
+++ b/src/team/__tests__/worker-runtime-identity.test.ts
@@ -335,7 +335,7 @@ process.on('SIGTERM', () => process.exit(0));
         subject: 'architecture follow-up',
         description: 'exact-role scale-up regression',
         status: 'pending',
-        owner: 'worker-2',
+        owner: 'worker-3',
         role: 'architect',
       }, cwd);
 
@@ -345,6 +345,7 @@ process.on('SIGTERM', () => process.exit(0));
       config.tmux_session = 'omx-team-exact-role-cli';
       config.leader_pane_id = '%11';
       config.workers[0]!.pane_id = '%21';
+      config.next_worker_index = 3;
       await saveTeamConfig(config, cwd);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'exact-role-cli', 'manifest.v2.json');
@@ -359,7 +360,7 @@ process.on('SIGTERM', () => process.exit(0));
         'exact-role-cli',
         1,
         'executor',
-        [{ subject: 'architecture follow-up', description: 'exact-role scale-up regression', owner: 'worker-2', role: 'architect' }],
+        [{ subject: 'architecture follow-up', description: 'exact-role scale-up regression', owner: 'worker-3', role: 'architect' }],
         cwd,
         {
           OMX_TEAM_SCALING_ENABLED: '1',
@@ -371,17 +372,17 @@ process.on('SIGTERM', () => process.exit(0));
       assert.equal(result.ok, true);
       if (!result.ok) return;
 
-      const workerIdentity = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'team', 'exact-role-cli', 'workers', 'worker-2', 'identity.json'), 'utf-8')) as { worker_cli?: string; role?: string };
+      const workerIdentity = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'team', 'exact-role-cli', 'workers', 'worker-3', 'identity.json'), 'utf-8')) as { worker_cli?: string; role?: string };
       assert.equal(workerIdentity.role, 'architect');
       assert.equal(workerIdentity.worker_cli, 'codex');
 
-      const startupScript = await readFile(join(cwd, '.omx', 'state', 'team', 'exact-role-cli', 'runtime', 'worker-2-startup.sh'), 'utf-8');
+      const startupScript = await readFile(join(cwd, '.omx', 'state', 'team', 'exact-role-cli', 'runtime', 'worker-3-startup.sh'), 'utf-8');
       assert.match(startupScript, /codex/);
       assert.doesNotMatch(startupScript, /\bclaude\b/);
       assert.doesNotMatch(startupScript, /\bgemini\b/);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /worker-2-startup\.sh/);
+      assert.match(tmuxLog, /worker-3-startup\.sh/);
       assert.doesNotMatch(tmuxLog, /\bclaude\b/);
       assert.doesNotMatch(tmuxLog, /\bgemini\b/);
     } finally {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -12,6 +12,7 @@ import {
   buildWorkerProcessLaunchSpec,
   scrubTeamWorkerHudOwnershipEnv,
   resolveTeamWorkerCli,
+  resolveTeamWorkerCliForResolvedLaunchArgs,
   type TeamWorkerCli,
   resolveTeamWorkerLaunchMode,
   type TeamSession,
@@ -137,6 +138,8 @@ import { hasStructuredVerificationEvidence } from '../verification/verifier.js';
 import { buildRebalanceDecisions } from './rebalance-policy.js';
 import { getStatePath } from '../mcp/state-paths.js';
 import { readModeState, updateModeState } from '../modes/base.js';
+
+export { resolveTeamWorkerCliForResolvedLaunchArgs };
 import {
   buildApprovedTeamHandoffSection,
   buildApprovedTeamExecutionBinding,
@@ -2399,63 +2402,6 @@ function resolveEffectiveWorkerCliForStartupLog(
   }
 
   return resolveTeamWorkerCli(resolvedLaunchArgs, env);
-}
-
-export function resolveTeamWorkerCliForResolvedLaunchArgs(
-  workerIndex: number,
-  workerCount: number,
-  resolvedLaunchArgs: string[],
-  env: NodeJS.ProcessEnv = process.env,
-): TeamWorkerCli {
-  if (!Number.isInteger(workerCount) || workerCount < 1) {
-    throw new Error(`workerCount must be >= 1 (got ${workerCount})`);
-  }
-  if (!Number.isInteger(workerIndex) || workerIndex < 1 || workerIndex > workerCount) {
-    throw new Error(`workerIndex must be within 1..${workerCount} (got ${workerIndex})`);
-  }
-
-  const rawMap = String(env.OMX_TEAM_WORKER_CLI_MAP ?? '').trim();
-  const autoCli = resolveTeamWorkerCli(resolvedLaunchArgs, {
-    ...env,
-    OMX_TEAM_WORKER_CLI: 'auto',
-  });
-  const normalizeEntry = (entry: string): TeamWorkerCli | 'auto' | null => {
-    const normalized = entry.trim().toLowerCase();
-    if (normalized === 'auto' || normalized === 'codex' || normalized === 'claude' || normalized === 'gemini') {
-      return normalized;
-    }
-    return null;
-  };
-  const invalidMapError = () => new Error(
-    `Invalid ${OMX_TEAM_WORKER_CLI_MAP_ENV} value "${env[OMX_TEAM_WORKER_CLI_MAP_ENV]}". `
-      + `Expected comma-separated values: auto|codex|claude|gemini.`,
-  );
-
-  if (rawMap === '') {
-    return resolveTeamWorkerCli(resolvedLaunchArgs, env);
-  }
-
-  const entries = rawMap.split(',').map((part) => part.trim());
-  if (entries.length === 0 || entries.every((part) => part.length === 0)) {
-    throw invalidMapError();
-  }
-  if (entries.some((part) => part.length === 0)) {
-    throw new Error(
-      `Invalid ${OMX_TEAM_WORKER_CLI_MAP_ENV} value "${env[OMX_TEAM_WORKER_CLI_MAP_ENV]}". `
-        + `Empty entries are not allowed.`,
-    );
-  }
-  if (entries.length !== 1 && entries.length !== workerCount) {
-    throw new Error(
-      `Invalid ${OMX_TEAM_WORKER_CLI_MAP_ENV} length ${entries.length}; `
-        + `expected 1 or ${workerCount} comma-separated values.`,
-    );
-  }
-
-  const entry = entries.length === 1 ? entries[0] as string : entries[workerIndex - 1];
-  const mode = normalizeEntry(entry);
-  if (!mode) throw invalidMapError();
-  return mode === 'auto' ? autoCli : mode;
 }
 
 

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1632,7 +1632,6 @@ const PROMPT_WORKER_EXIT_POLL_MS = 100;
 const STARTUP_DISPATCH_RETRIES = 3;
 const STARTUP_DISPATCH_RETRY_DELAY_S = 3;
 const PROMPT_MODE_CODEX_UNSUPPORTED_REASON = 'prompt_mode_codex_requires_tty';
-const OMX_TEAM_WORKER_CLI_MAP_ENV = 'OMX_TEAM_WORKER_CLI_MAP';
 // Test-only escape hatch for fake prompt workers that intentionally do not require a real TTY.
 const PROMPT_MODE_CODEX_TEST_ALLOW_ENV = 'OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT';
 

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -24,6 +24,7 @@ import {
   buildWorkerStartupCommand,
   trustWorkerMiseConfigIfAvailable,
   writeWorkerStartupScriptCommand,
+  resolveTeamWorkerCliForResolvedLaunchArgs,
   tagPaneTeamOwner,
 } from './tmux-session.js';
 import { execFileSync, spawnSync } from 'child_process';
@@ -72,7 +73,6 @@ import {
   TEAM_WORKER_INHERITED_MODEL_ENV,
   type TeamReasoningEffort,
 } from './model-contract.js';
-import { resolveTeamWorkerCliForResolvedLaunchArgs } from './runtime.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
 import {
   ensureWorktree,
@@ -279,7 +279,6 @@ export async function scaleUp(
 
     const maxWorkers = config.max_workers;
     const currentCount = config.workers.length;
-    const targetWorkerCount = currentCount + count;
     if (currentCount + count > maxWorkers) {
       return {
         ok: false,
@@ -438,7 +437,7 @@ export async function scaleUp(
       const preferredReasoning = resolveAgentReasoningEffort(runtimeRole, codexHomeOverride)
         ?? resolveAgentReasoningEffort(agentType, codexHomeOverride);
       const workerLaunchArgs = resolveWorkerLaunchArgsForScaling(launchEnv, runtimeRole, preferredReasoning, codexHomeOverride);
-      const workerCli = resolveTeamWorkerCliForResolvedLaunchArgs(workerIndex, targetWorkerCount, workerLaunchArgs, launchEnv);
+      const workerCli = resolveTeamWorkerCliForResolvedLaunchArgs(i + 1, count, workerLaunchArgs, launchEnv);
       const resolvedWorkerModel = parseTeamWorkerLaunchArgs(workerLaunchArgs).modelOverride ?? undefined;
       const rolePromptContent = rawRolePromptContent
         ? composeRoleInstructionsForRole(runtimeRole, rawRolePromptContent, resolvedWorkerModel)

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -927,6 +927,63 @@ export function resolveTeamWorkerCliPlan(
   });
 }
 
+export function resolveTeamWorkerCliForResolvedLaunchArgs(
+  workerIndex: number,
+  workerCount: number,
+  resolvedLaunchArgs: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): TeamWorkerCli {
+  if (!Number.isInteger(workerCount) || workerCount < 1) {
+    throw new Error(`workerCount must be >= 1 (got ${workerCount})`);
+  }
+  if (!Number.isInteger(workerIndex) || workerIndex < 1 || workerIndex > workerCount) {
+    throw new Error(`workerIndex must be within 1..${workerCount} (got ${workerIndex})`);
+  }
+
+  const rawMap = String(env.OMX_TEAM_WORKER_CLI_MAP ?? '').trim();
+  const autoCli = resolveTeamWorkerCli(resolvedLaunchArgs, {
+    ...env,
+    OMX_TEAM_WORKER_CLI: 'auto',
+  });
+  const normalizeEntry = (entry: string): TeamWorkerCli | 'auto' | null => {
+    const normalized = entry.trim().toLowerCase();
+    if (normalized === 'auto' || normalized === 'codex' || normalized === 'claude' || normalized === 'gemini') {
+      return normalized;
+    }
+    return null;
+  };
+  const invalidMapError = () => new Error(
+    `Invalid ${OMX_TEAM_WORKER_CLI_MAP_ENV} value "${env[OMX_TEAM_WORKER_CLI_MAP_ENV]}". `
+      + `Expected comma-separated values: auto|codex|claude|gemini.`,
+  );
+
+  if (rawMap === '') {
+    return resolveTeamWorkerCli(resolvedLaunchArgs, env);
+  }
+
+  const entries = rawMap.split(',').map((part) => part.trim());
+  if (entries.length === 0 || entries.every((part) => part.length === 0)) {
+    throw invalidMapError();
+  }
+  if (entries.some((part) => part.length === 0)) {
+    throw new Error(
+      `Invalid ${OMX_TEAM_WORKER_CLI_MAP_ENV} value "${env[OMX_TEAM_WORKER_CLI_MAP_ENV]}". `
+        + `Empty entries are not allowed.`,
+    );
+  }
+  if (entries.length !== 1 && entries.length !== workerCount) {
+    throw new Error(
+      `Invalid ${OMX_TEAM_WORKER_CLI_MAP_ENV} length ${entries.length}; `
+        + `expected 1 or ${workerCount} comma-separated values.`,
+    );
+  }
+
+  const entry = entries.length === 1 ? entries[0] as string : entries[workerIndex - 1];
+  const mode = normalizeEntry(entry);
+  if (!mode) throw invalidMapError();
+  return mode === 'auto' ? autoCli : mode;
+}
+
 function shouldGrantExecutionBypassForRole(workerRole?: string): boolean {
   const normalizedRole = workerRole?.trim().toLowerCase();
   if (!normalizedRole) return true;


### PR DESCRIPTION
## Follow-up to PR #2990

This PR is a follow-up to merged PR #2990 on `dev`.
It tightens the exact-role scale-up fix so the worker CLI resolver stays shared, the scale-up path stays on the final per-worker launch args, and the regression covers the scale-down gap case.

## What changed
- Recompute worker CLI from the resolved per-worker launch args during scale-up.
- Carry inherited leader model routing into exact-role resolution.
- Extract the exact-role CLI resolver into the shared tmux-session layer so scaling and runtime share one pure helper.
- Keep the final worker bootstrap aligned with the resolved role contract.
- Add a regression test that covers a scale-down gap / monotonic worker-index case.

## Why
A stale shared-args path could preserve inherited non-Codex model routing too early and select the wrong worker CLI during scale-up.
The earlier implementation also conflated worker identity with contiguous lookup position, which could fail after scale-down.

## Verification
- `npm run test:team:worker-runtime-identity`
- `npm run lint`
