### PR TITLE
Fix autopilot phase HUD contract

### DIFF
--- a/plugins/oh-my-codex/skills/code-review/SKILL.md
+++ b/plugins/oh-my-codex/skills/code-review/SKILL.md
@@ -67,6 +67,22 @@ Delegates to the `code-reviewer` and `architect` agents in parallel for a two-la
      - Else final recommendation follows the `code-reviewer` lane
    - The final report must make architect blockers impossible to miss
 
+
+## State/HUD Phase Contract
+
+Code-review is a merge-readiness gate and Autopilot child phase, not a standalone tracked mode with a `code-review-state.json` lifecycle. Keep HUD/current-phase state explicit and minimal:
+
+- **Standalone `$code-review` activation**: rely on the hook-owned `skill-active-state.json` entry (`skill:"code-review"`, `phase:"planning"`) for HUD visibility; do not create an ad-hoc `code-review-state.json`.
+- **Inside active Autopilot**: before review work starts, keep `mode:"autopilot"` active and set the supervised phase to `current_phase:"code-review"` / skill-active `phase:"code-review"`; do not activate a peer workflow over Autopilot.
+- **On clean review**: persist the review artifact/verdict under Autopilot `handoff_artifacts.code_review` and transition Autopilot to `current_phase:"ultraqa"` only after durable independent review evidence exists.
+- **On non-clean review**: persist the review artifact/verdict, set Autopilot `current_phase:"rework"` for implementation-only fixes or `current_phase:"ralplan"` when requirements/planning must change, and keep the findings as the scoped handoff.
+
+Minimal Autopilot phase declaration when the review stage begins:
+
+```sh
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"code-review"}' --json
+```
+
 ## Agent Delegation
 
 Do not self-review as a fallback. If the `code-reviewer` or `architect` agent path is missing, unavailable, skipped, or fails, emit a clear unavailable-review result and block approval until the independent lane evidence exists.

--- a/plugins/oh-my-codex/skills/ultragoal/SKILL.md
+++ b/plugins/oh-my-codex/skills/ultragoal/SKILL.md
@@ -17,6 +17,29 @@ Use when the user asks for `ultragoal`, `create-goals`, `complete-goals`, durabl
 
 Existing aggregate plans with the legacy enumerated objective are migrated to the stable pointer objective on read, persisted to `goals.json`, retained in `codexObjectiveAliases` for already-active hidden Codex goal reconciliation, and audited with an `aggregate_objective_migrated` ledger entry.
 
+
+## State/HUD Phase Contract
+
+Ultragoal is both a tracked workflow skill and the Autopilot durable-implementation child phase. Keep the phase/HUD contract explicit at workflow boundaries:
+
+- **Standalone `$ultragoal` activation**: ensure `.omx/state[/sessions/<session>]/ultragoal-state.json` exists with `mode:"ultragoal"`, `active:true`, and a non-empty `current_phase` such as `planning` before or while goals are created. This state is a lightweight HUD/runtime declaration; `.omx/ultragoal/goals.json` and `ledger.jsonl` remain the durable goal source of truth.
+- **During execution**: update `current_phase` to the smallest accurate phase (`planning`, `executing`, `verifying`, `reviewing`, `checkpointing`, or `blocked`) when the visible workflow phase changes.
+- **Inside active Autopilot**: keep `mode:"autopilot"` active and set the supervised phase to `current_phase:"ultragoal"`; do not start a peer Autopilot replacement. Ultragoal's own mode state may still exist as child-phase detail, but Autopilot owns the parent phase.
+- **On handoff to code-review**: persist implementation/test/ledger evidence under Autopilot `handoff_artifacts.ultragoal`, then set Autopilot `current_phase:"code-review"`.
+- **On completion/blocker**: set standalone Ultragoal `active:false,current_phase:"complete"` only when all durable goals are complete; otherwise keep it active with a blocker/review-blocked phase and ledger evidence.
+
+Minimal standalone phase declaration:
+
+```sh
+omx state write --input '{"mode":"ultragoal","active":true,"current_phase":"planning"}' --json
+```
+
+Minimal Autopilot child-phase declaration:
+
+```sh
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ultragoal"}' --json
+```
+
 ## Create goals
 
 1. Run one of:

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -67,6 +67,22 @@ Delegates to the `code-reviewer` and `architect` agents in parallel for a two-la
      - Else final recommendation follows the `code-reviewer` lane
    - The final report must make architect blockers impossible to miss
 
+
+## State/HUD Phase Contract
+
+Code-review is a merge-readiness gate and Autopilot child phase, not a standalone tracked mode with a `code-review-state.json` lifecycle. Keep HUD/current-phase state explicit and minimal:
+
+- **Standalone `$code-review` activation**: rely on the hook-owned `skill-active-state.json` entry (`skill:"code-review"`, `phase:"planning"`) for HUD visibility; do not create an ad-hoc `code-review-state.json`.
+- **Inside active Autopilot**: before review work starts, keep `mode:"autopilot"` active and set the supervised phase to `current_phase:"code-review"` / skill-active `phase:"code-review"`; do not activate a peer workflow over Autopilot.
+- **On clean review**: persist the review artifact/verdict under Autopilot `handoff_artifacts.code_review` and transition Autopilot to `current_phase:"ultraqa"` only after durable independent review evidence exists.
+- **On non-clean review**: persist the review artifact/verdict, set Autopilot `current_phase:"rework"` for implementation-only fixes or `current_phase:"ralplan"` when requirements/planning must change, and keep the findings as the scoped handoff.
+
+Minimal Autopilot phase declaration when the review stage begins:
+
+```sh
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"code-review"}' --json
+```
+
 ## Agent Delegation
 
 Do not self-review as a fallback. If the `code-reviewer` or `architect` agent path is missing, unavailable, skipped, or fails, emit a clear unavailable-review result and block approval until the independent lane evidence exists.

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -17,6 +17,29 @@ Use when the user asks for `ultragoal`, `create-goals`, `complete-goals`, durabl
 
 Existing aggregate plans with the legacy enumerated objective are migrated to the stable pointer objective on read, persisted to `goals.json`, retained in `codexObjectiveAliases` for already-active hidden Codex goal reconciliation, and audited with an `aggregate_objective_migrated` ledger entry.
 
+
+## State/HUD Phase Contract
+
+Ultragoal is both a tracked workflow skill and the Autopilot durable-implementation child phase. Keep the phase/HUD contract explicit at workflow boundaries:
+
+- **Standalone `$ultragoal` activation**: ensure `.omx/state[/sessions/<session>]/ultragoal-state.json` exists with `mode:"ultragoal"`, `active:true`, and a non-empty `current_phase` such as `planning` before or while goals are created. This state is a lightweight HUD/runtime declaration; `.omx/ultragoal/goals.json` and `ledger.jsonl` remain the durable goal source of truth.
+- **During execution**: update `current_phase` to the smallest accurate phase (`planning`, `executing`, `verifying`, `reviewing`, `checkpointing`, or `blocked`) when the visible workflow phase changes.
+- **Inside active Autopilot**: keep `mode:"autopilot"` active and set the supervised phase to `current_phase:"ultragoal"`; do not start a peer Autopilot replacement. Ultragoal's own mode state may still exist as child-phase detail, but Autopilot owns the parent phase.
+- **On handoff to code-review**: persist implementation/test/ledger evidence under Autopilot `handoff_artifacts.ultragoal`, then set Autopilot `current_phase:"code-review"`.
+- **On completion/blocker**: set standalone Ultragoal `active:false,current_phase:"complete"` only when all durable goals are complete; otherwise keep it active with a blocker/review-blocked phase and ledger evidence.
+
+Minimal standalone phase declaration:
+
+```sh
+omx state write --input '{"mode":"ultragoal","active":true,"current_phase":"planning"}' --json
+```
+
+Minimal Autopilot child-phase declaration:
+
+```sh
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ultragoal"}' --json
+```
+
 ## Create goals
 
 1. Run one of:

--- a/src/hooks/__tests__/autopilot-skill-contract.test.ts
+++ b/src/hooks/__tests__/autopilot-skill-contract.test.ts
@@ -7,6 +7,8 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const autopilotSkill = readFileSync(join(__dirname, '../../../skills/autopilot/SKILL.md'), 'utf-8');
 const ralplanSkill = readFileSync(join(__dirname, '../../../skills/ralplan/SKILL.md'), 'utf-8');
+const codeReviewSkill = readFileSync(join(__dirname, '../../../skills/code-review/SKILL.md'), 'utf-8');
+const ultragoalSkill = readFileSync(join(__dirname, '../../../skills/ultragoal/SKILL.md'), 'utf-8');
 const pipelineSkill = readFileSync(join(__dirname, '../../../skills/pipeline/SKILL.md'), 'utf-8');
 const skillsDocs = readFileSync(join(__dirname, '../../../docs/skills.html'), 'utf-8');
 const gettingStartedDocs = readFileSync(join(__dirname, '../../../docs/getting-started.html'), 'utf-8');
@@ -37,6 +39,17 @@ describe('autopilot skill default Ultragoal contract', () => {
     ]) {
       assert.match(autopilotSkill, new RegExp(field));
     }
+  });
+
+  it('documents minimal state/HUD contracts for code-review and ultragoal child phases', () => {
+    assert.match(codeReviewSkill, /State\/HUD Phase Contract/);
+    assert.match(codeReviewSkill, /not a standalone tracked mode with a `code-review-state\.json` lifecycle/i);
+    assert.match(codeReviewSkill, /skill-active-state\.json.*skill:"code-review".*phase:"planning"/s);
+    assert.match(codeReviewSkill, /current_phase":"code-review"/);
+    assert.match(ultragoalSkill, /State\/HUD Phase Contract/);
+    assert.match(ultragoalSkill, /mode:"ultragoal".*active:true.*current_phase/s);
+    assert.match(ultragoalSkill, /current_phase":"ultragoal"/);
+    assert.match(ultragoalSkill, /handoff_artifacts\.ultragoal/);
   });
 
   it('forbids self-attesting clean review and QA gates without durable stage evidence', () => {

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -2778,7 +2778,7 @@ deepMaxRounds = 21
     }
   });
 
-  it('keeps Autopilot visible when a supervised code-review child keyword appears', async () => {
+  it('keeps Autopilot visible and advances HUD phase when a supervised code-review child keyword appears', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-autopilot-child-code-review-'));
     const stateDir = join(cwd, '.omx', 'state');
     const sessionId = 'sess-autopilot-child-code-review';
@@ -2791,12 +2791,21 @@ deepMaxRounds = 21
           active: true,
           skill: 'autopilot',
           keyword: '$autopilot',
-          phase: 'ralplan',
+          phase: 'ultragoal',
           activated_at: '2026-05-30T00:00:00.000Z',
           updated_at: '2026-05-30T00:01:00.000Z',
           source: 'keyword-detector',
           session_id: sessionId,
-          active_skills: [{ skill: 'autopilot', phase: 'ralplan', active: true, session_id: sessionId }],
+          active_skills: [{ skill: 'autopilot', phase: 'ultragoal', active: true, session_id: sessionId }],
+        }, null, 2),
+      );
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, 'autopilot-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'autopilot',
+          current_phase: 'ultragoal',
+          session_id: sessionId,
         }, null, 2),
       );
 
@@ -2811,15 +2820,21 @@ deepMaxRounds = 21
 
       assert.ok(result);
       assert.equal(result.skill, 'autopilot');
-      assert.equal(result.phase, 'ralplan');
+      assert.equal(result.phase, 'code-review');
       assert.equal(result.supervised_child_skill, 'code-review');
       const persisted = JSON.parse(
         await readFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), 'utf-8'),
-      ) as { skill?: string; phase?: string; active_skills?: Array<{ skill?: string }> };
+      ) as { skill?: string; phase?: string; active_skills?: Array<{ skill?: string; phase?: string }> };
       assert.equal(persisted.skill, 'autopilot');
-      assert.equal(persisted.phase, 'ralplan');
-      assert.deepEqual(persisted.active_skills?.map((entry) => entry.skill), ['autopilot']);
+      assert.equal(persisted.phase, 'code-review');
+      assert.deepEqual(persisted.active_skills?.map((entry) => [entry.skill, entry.phase]), [['autopilot', 'code-review']]);
       assert.equal(existsSync(join(stateDir, 'sessions', sessionId, 'code-review-state.json')), false);
+      const autopilot = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8'),
+      ) as { current_phase?: string; thread_id?: string; turn_id?: string };
+      assert.equal(autopilot.current_phase, 'code-review');
+      assert.equal(autopilot.thread_id, 'thread-autopilot-child-code-review');
+      assert.equal(autopilot.turn_id, 'turn-autopilot-child-code-review');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -2911,6 +2926,15 @@ deepMaxRounds = 21
           session_id: sessionId,
         }, null, 2),
       );
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, 'autopilot-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'autopilot',
+          current_phase: 'ultragoal',
+          session_id: sessionId,
+        }, null, 2),
+      );
 
       const result = await recordSkillActivation({
         stateDir,
@@ -2928,6 +2952,10 @@ deepMaxRounds = 21
       ) as { active?: boolean; current_phase?: string };
       assert.equal(ultragoal.active, true);
       assert.equal(ultragoal.current_phase, 'executing');
+      const autopilot = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8'),
+      ) as { current_phase?: string };
+      assert.equal(autopilot.current_phase, 'ultragoal');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -2840,6 +2840,75 @@ deepMaxRounds = 21
     }
   });
 
+  it('repairs stale inactive Autopilot detail when a supervised code-review child keyword appears', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-autopilot-child-stale-detail-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-autopilot-child-stale-detail';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: '$autopilot',
+          phase: 'ultragoal',
+          activated_at: '2026-05-30T00:00:00.000Z',
+          updated_at: '2026-05-30T00:01:00.000Z',
+          source: 'keyword-detector',
+          session_id: sessionId,
+          active_skills: [{ skill: 'autopilot', phase: 'ultragoal', active: true, session_id: sessionId }],
+        }, null, 2),
+      );
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, 'autopilot-state.json'),
+        JSON.stringify({
+          active: false,
+          mode: 'autopilot',
+          current_phase: 'ultragoal',
+          started_at: '2026-05-30T00:00:00.000Z',
+          updated_at: '2026-05-30T00:01:00.000Z',
+          session_id: sessionId,
+        }, null, 2),
+      );
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$code-review inspect before QA',
+        sessionId,
+        threadId: 'thread-autopilot-child-stale-detail',
+        turnId: 'turn-autopilot-child-stale-detail',
+        nowIso: '2026-05-30T00:02:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'autopilot');
+      assert.equal(result.phase, 'code-review');
+      assert.equal(result.supervised_child_skill, 'code-review');
+      assert.equal(result.transition_error, undefined);
+      assert.equal(existsSync(join(stateDir, 'sessions', sessionId, 'code-review-state.json')), false);
+
+      const persisted = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { skill?: string; phase?: string; active_skills?: Array<{ skill?: string; phase?: string }> };
+      assert.equal(persisted.skill, 'autopilot');
+      assert.equal(persisted.phase, 'code-review');
+      assert.deepEqual(persisted.active_skills?.map((entry) => [entry.skill, entry.phase]), [['autopilot', 'code-review']]);
+
+      const autopilot = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, 'autopilot-state.json'), 'utf-8'),
+      ) as { active?: boolean; mode?: string; current_phase?: string; thread_id?: string; turn_id?: string };
+      assert.equal(autopilot.active, true);
+      assert.equal(autopilot.mode, 'autopilot');
+      assert.equal(autopilot.current_phase, 'code-review');
+      assert.equal(autopilot.thread_id, 'thread-autopilot-child-stale-detail');
+      assert.equal(autopilot.turn_id, 'turn-autopilot-child-stale-detail');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('keeps tracked Autopilot child keywords supervised and completes stale child mode state', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-autopilot-child-ultraqa-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -1081,14 +1081,40 @@ const AUTOPILOT_SUPERVISED_TRACKED_CHILD_SKILLS: TrackedWorkflowMode[] = [
   'ultraqa',
 ];
 
+async function persistAutopilotSupervisedChildPhaseState(
+  stateDir: string,
+  sessionId: string | undefined,
+  childSkill: string,
+  nowIso: string,
+  options: { threadId?: string; turnId?: string } = {},
+): Promise<void> {
+  const { absolutePath } = resolveSeedStateFilePath(stateDir, 'autopilot', sessionId);
+  const existing = await readJsonStateIfExists(absolutePath);
+  if (!existing || existing.active !== true || safeString(existing.mode).trim() !== 'autopilot') return;
+
+  await mkdir(dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, JSON.stringify({
+    ...existing,
+    current_phase: childSkill,
+    updated_at: nowIso,
+    session_id: (sessionId ?? safeString(existing.session_id).trim()) || undefined,
+    thread_id: (options.threadId ?? safeString(existing.thread_id).trim()) || undefined,
+    turn_id: (options.turnId ?? safeString(existing.turn_id).trim()) || undefined,
+  }, null, 2));
+}
+
 async function reconcileAutopilotSupervisedChildModeStates(
   cwd: string,
   stateDir: string,
   sessionId: string | undefined,
   childSkill: string,
   nowIso: string,
+  options: { threadId?: string; turnId?: string } = {},
 ): Promise<string[]> {
-  if (!isTrackedWorkflowMode(childSkill)) return [];
+  if (!isTrackedWorkflowMode(childSkill)) {
+    await persistAutopilotSupervisedChildPhaseState(stateDir, sessionId, childSkill, nowIso, options);
+    return [];
+  }
 
   const activeChildModes: TrackedWorkflowMode[] = [];
   for (const mode of AUTOPILOT_SUPERVISED_TRACKED_CHILD_SKILLS) {
@@ -1111,6 +1137,7 @@ async function reconcileAutopilotSupervisedChildModeStates(
     sessionId,
     source: 'autopilot-supervised-child',
   });
+  await persistAutopilotSupervisedChildPhaseState(stateDir, sessionId, childSkill, nowIso, options);
   return transition.completedPaths;
 }
 
@@ -1315,10 +1342,12 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
       session_id: input.sessionId ?? previous.session_id,
       thread_id: input.threadId ?? previous.thread_id,
       turn_id: input.turnId ?? previous.turn_id,
+      phase: match.skill,
       active_skills: listActiveSkills(previous).map((entry) => (
         entry.skill === 'autopilot'
           ? {
               ...entry,
+              phase: match.skill,
               active: true,
               updated_at: nowIso,
               session_id: input.sessionId ?? entry.session_id,
@@ -1331,7 +1360,14 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
       supervised_child_skill: match.skill,
     };
     try {
-      await reconcileAutopilotSupervisedChildModeStates(sourceCwd, input.stateDir, input.sessionId ?? previous.session_id, match.skill, nowIso);
+      await reconcileAutopilotSupervisedChildModeStates(
+        sourceCwd,
+        input.stateDir,
+        input.sessionId ?? previous.session_id,
+        match.skill,
+        nowIso,
+        { threadId: input.threadId, turnId: input.turnId },
+      );
       await writeSkillActiveStateCopiesForStateDir(
         input.stateDir,
         nextState,

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -1089,18 +1089,33 @@ async function persistAutopilotSupervisedChildPhaseState(
   options: { threadId?: string; turnId?: string } = {},
 ): Promise<void> {
   const { absolutePath } = resolveSeedStateFilePath(stateDir, 'autopilot', sessionId);
-  const existing = await readJsonStateIfExists(absolutePath);
-  if (!existing || existing.active !== true || safeString(existing.mode).trim() !== 'autopilot') return;
+  const existingResult = await readJsonStateWithStatus(absolutePath);
+  const existing = existingResult.state;
+  const existingMode = safeString(existing?.mode).trim();
+
+  if (existingResult.status === 'malformed') {
+    throw new Error('Cannot advance supervised Autopilot child phase: autopilot detail state is malformed');
+  }
+  if (existing && existingMode !== 'autopilot') {
+    throw new Error(`Cannot advance supervised Autopilot child phase: expected autopilot detail state, found ${existingMode || 'unknown'}`);
+  }
 
   await mkdir(dirname(absolutePath), { recursive: true });
-  await writeFile(absolutePath, JSON.stringify({
-    ...existing,
-    current_phase: childSkill,
-    updated_at: nowIso,
-    session_id: (sessionId ?? safeString(existing.session_id).trim()) || undefined,
-    thread_id: (options.threadId ?? safeString(existing.thread_id).trim()) || undefined,
-    turn_id: (options.turnId ?? safeString(existing.turn_id).trim()) || undefined,
-  }, null, 2));
+  await writeFile(absolutePath, JSON.stringify(withModeRuntimeContext(
+    existing ?? {},
+    {
+      ...(existing ?? {}),
+      active: true,
+      mode: 'autopilot',
+      current_phase: childSkill,
+      started_at: safeString(existing?.started_at).trim() || nowIso,
+      updated_at: nowIso,
+      session_id: (sessionId ?? safeString(existing?.session_id).trim()) || undefined,
+      thread_id: (options.threadId ?? safeString(existing?.thread_id).trim()) || undefined,
+      turn_id: (options.turnId ?? safeString(existing?.turn_id).trim()) || undefined,
+    },
+    { nowIso },
+  ), null, 2));
 }
 
 async function reconcileAutopilotSupervisedChildModeStates(

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -776,6 +776,35 @@ describe('readAllState canonical skill precedence', () => {
     });
   });
 
+  it('surfaces real keyword-activated ultragoal phase in state and HUD before goals exist', async () => {
+    await withTempRepo('omx-hud-keyword-ultragoal-', async (cwd) => {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionId = 'sess-ultragoal-keyword';
+      await mkdir(join(rootStateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(join(rootStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+
+      await recordSkillActivation({
+        stateDir: rootStateDir,
+        sourceCwd: cwd,
+        text: '$ultragoal create goals for HUD',
+        sessionId,
+        nowIso: '2026-06-01T00:00:00.000Z',
+      });
+
+      const state = await readAllState(cwd);
+      assert.deepEqual(state.ultragoal, {
+        active: true,
+        mode: 'ultragoal',
+        current_phase: 'planning',
+        started_at: '2026-06-01T00:00:00.000Z',
+        updated_at: '2026-06-01T00:00:00.000Z',
+        session_id: sessionId,
+      });
+      const rendered = stripSgr(renderHud(state, 'focused'));
+      assert.ok(rendered.includes('ultragoal:planning'));
+    });
+  });
+
   it('surfaces real keyword-activated code-review phase in state and HUD', async () => {
     await withTempRepo('omx-hud-keyword-code-review-', async (cwd) => {
       const rootStateDir = join(cwd, '.omx', 'state');

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -198,7 +198,10 @@ function renderUltragoal(ctx: HudRenderContext): string | null {
   if (!ctx.ultragoal?.active) return null;
   const total = ctx.ultragoal.progressTotal;
   const complete = ctx.ultragoal.complete;
-  if (!Number.isFinite(total) || total <= 0 || !Number.isFinite(complete)) return null;
+  if (!Number.isFinite(total) || total <= 0 || !Number.isFinite(complete)) {
+    const phase = sanitizeDynamicText(ctx.ultragoal.current_phase || ctx.ultragoal.status || 'active') || 'active';
+    return cyan(`ultragoal:${phase}`);
+  }
 
   const teamSummary = formatTeamSummary(ctx);
   const progress = cyan(`ultragoal ${complete}/${total}${teamSummary ? ` + ${teamSummary}` : ''}`);

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -595,7 +595,8 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
 
   const [
     ralphDetail,
-    ultragoal,
+    ultragoalArtifact,
+    ultragoalDetail,
     ultraworkDetail,
     autopilotDetail,
     ralplanDetail,
@@ -607,6 +608,7 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
   ] = await Promise.all([
     readAuthoritativeModeState<RalphStateForHud>(cwd, 'ralph'),
     readUltragoalState(cwd),
+    readAuthoritativeModeState<UltragoalStateForHud>(cwd, 'ultragoal'),
     readAuthoritativeModeState<UltraworkStateForHud>(cwd, 'ultrawork'),
     readAuthoritativeModeState<AutopilotStateForHud>(cwd, 'autopilot'),
     readAuthoritativeModeState<RalplanStateForHud>(cwd, 'ralplan'),
@@ -620,6 +622,10 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
   const ralph = shouldSurfaceCanonicalSkill(canonicalSkills, 'ralph', ralphDetail)
     ? mergePhase(ralphDetail?.active === true ? ralphDetail : null, canonicalPhaseForSkill(canonicalSkills, 'ralph'))
     : null;
+  const ultragoal = ultragoalArtifact
+    ?? (shouldSurfaceCanonicalSkill(canonicalSkills, 'ultragoal', ultragoalDetail)
+      ? mergePhase(ultragoalDetail?.active === true ? ultragoalDetail : null, canonicalPhaseForSkill(canonicalSkills, 'ultragoal'))
+      : null);
   const ultrawork = shouldSurfaceCanonicalSkill(canonicalSkills, 'ultrawork', ultraworkDetail)
     ? mergePhase(ultraworkDetail?.active === true ? ultraworkDetail : null, canonicalPhaseForSkill(canonicalSkills, 'ultrawork'))
     : null;

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -20,6 +20,11 @@ export interface UltragoalActiveGoalForHud {
 
 export interface UltragoalStateForHud {
   active: boolean;
+  current_phase?: string;
+  mode?: string;
+  started_at?: string;
+  updated_at?: string;
+  session_id?: string;
   status?: string;
   total: number;
   complete: number;

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -16,6 +16,7 @@ export const CANONICAL_WORKFLOW_SKILLS = [
   'autopilot',
   'autoresearch',
   'team',
+  'ultragoal',
   'ralph',
   'ultrawork',
   'ultraqa',


### PR DESCRIPTION
Closes #2994.

## Summary
- Documented the Autopilot child-phase state/HUD contract for code-review and ultragoal.
- Keeps Autopilot visible while supervised child phases advance HUD/current-phase state.
- Surfaces keyword-activated ultragoal HUD state before durable goals exist.

## Verification
- build ✅
- lint ✅
- no-unused ✅
- catalog check ✅
- targeted hook/HUD/state tests ✅
  - includes `node dist/scripts/run-test-files.js dist/state/__tests__/operations.test.js dist/state/__tests__/workflow-transition.test.js` (70+11 pass)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
