### PR TITLE
Fail closed on live root planning pointer conflicts

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -83,6 +83,22 @@ async function writeNativeMappedSessionState(
   });
 }
 
+async function writeLiveNativeMappedSessionState(
+  cwd: string,
+  stateDir: string,
+  sessionId: string,
+  nativeSessionId: string,
+): Promise<void> {
+  await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+  await writeJson(join(stateDir, "session.json"), {
+    session_id: sessionId,
+    native_session_id: nativeSessionId,
+    cwd,
+    pid: process.pid,
+    platform: "darwin",
+  });
+}
+
 async function writeSessionSkillActiveState(
   stateDir: string,
   sessionId: string,
@@ -17048,6 +17064,80 @@ exit 0
       assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
       assert.match(JSON.stringify(result.outputJson), /(?:Ralplan|Autopilot planning) is active \(phase: ralplan\)/);
       assert.match(JSON.stringify(result.outputJson), /implementation\/write tools are blocked/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for implementation writes when a different live root session owns active ralplan state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralplan-live-root-conflict-"));
+    const ownerCwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralplan-live-root-owner-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const ownerSessionId = "sess-ralplan-live-root-owner";
+      const ownerNativeSessionId = "019e-ralplan-live-root-owner";
+      await writeLiveNativeMappedSessionState(ownerCwd, stateDir, ownerSessionId, ownerNativeSessionId);
+      await writeSessionSkillActiveState(stateDir, ownerSessionId, "ralplan", "planning");
+      await writeJson(join(stateDir, "sessions", ownerSessionId, "ralplan-state.json"), {
+        active: true,
+        mode: "ralplan",
+        current_phase: "planning",
+        session_id: ownerSessionId,
+        cwd: ownerCwd,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "019e-ralplan-live-root-unresolved-current",
+          thread_id: "thread-ralplan-live-root-conflict",
+          tool_name: "Edit",
+          tool_input: { file_path: "src/runtime.ts" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /live root session pointer/i);
+      assert.match(String(result.outputJson?.reason ?? ""), /failing closed/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(ownerCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves authoritative owner planning artifact writes with a live root session pointer", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralplan-live-root-owner-pass-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-ralplan-live-root-owner-pass";
+      const nativeSessionId = "019e-ralplan-live-root-owner-pass";
+      await writeLiveNativeMappedSessionState(cwd, stateDir, sessionId, nativeSessionId);
+      await writeSessionSkillActiveState(stateDir, sessionId, "ralplan", "planning");
+      await writeJson(join(stateDir, "sessions", sessionId, "ralplan-state.json"), {
+        active: true,
+        mode: "ralplan",
+        current_phase: "planning",
+        session_id: sessionId,
+        cwd,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: nativeSessionId,
+          thread_id: "thread-ralplan-live-root-owner-pass",
+          tool_name: "Bash",
+          tool_input: { command: "cat <<'EOF' > .omx/plans/live-root-owner.md\nplanning\nEOF" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "pre-tool-use");
+      assert.equal(result.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -24,6 +24,7 @@ import {
 import { resolveCanonicalTeamStateRoot, resolveWorkerNotifyTeamStateRootPath } from "../team/state-root.js";
 import {
   appendToLog,
+  isSessionStale,
   isSessionStateUsable,
   readSessionState,
   readUsableSessionState,
@@ -3100,6 +3101,48 @@ async function resolveInternalSessionIdForPayload(
   return payloadSessionId;
 }
 
+async function readRootSessionStateFromStateDir(stateDir: string): Promise<SessionState | null> {
+  const sessionPath = join(stateDir, "session.json");
+  if (!existsSync(sessionPath)) return null;
+
+  try {
+    const content = await readFile(sessionPath, "utf-8");
+    return JSON.parse(content) as SessionState;
+  } catch {
+    return null;
+  }
+}
+
+function payloadMatchesSessionPointer(payloadSessionId: string, state: SessionState): boolean {
+  const canonicalSessionId = safeString(state.session_id).trim();
+  const nativeSessionId = safeString(state.native_session_id).trim();
+  const ownerOmxSessionId = safeString(state.owner_omx_session_id).trim();
+  if (!payloadSessionId) return true;
+  return payloadSessionId === canonicalSessionId
+    || (nativeSessionId !== "" && payloadSessionId === nativeSessionId)
+    || (ownerOmxSessionId !== "" && payloadSessionId === ownerOmxSessionId);
+}
+
+function isRootSessionPointerLive(state: SessionState): boolean {
+  const hasPidMetadata = Number.isInteger(state.pid) && state.pid > 0;
+  if (!hasPidMetadata) return false;
+  return !isSessionStale(state, {
+    ...(state.platform ? { platform: state.platform } : {}),
+  });
+}
+
+async function readLiveRootSessionPointerConflict(
+  stateDir: string,
+  payloadSessionId: string,
+): Promise<SessionState | null> {
+  if (!payloadSessionId) return null;
+  const rootState = await readRootSessionStateFromStateDir(stateDir);
+  if (!rootState) return null;
+  if (payloadMatchesSessionPointer(payloadSessionId, rootState)) return null;
+  if (!isRootSessionPointerLive(rootState)) return null;
+  return rootState;
+}
+
 async function readUsableSessionStateFromStateDir(
   cwd: string,
   stateDir: string,
@@ -3734,6 +3777,96 @@ async function buildDeepInterviewPreToolUseBoundaryOutput(
         `Deep-interview is requirements/spec mode. Treat detailed user answers as interview/spec material, not implicit implementation authorization. You may write only deep-interview artifacts under \`.omx/context/\`, \`.omx/interviews/\`, \`.omx/specs/\`, or required \`.omx/state/\` files. To implement, first ask for or process an explicit transition such as \`$ralplan\`, \`$autopilot\`, ${formatExecutionHandoffList(cwd)}.`,
     },
   };
+}
+
+function blocksDeepInterviewImplementationWrite(payload: CodexHookPayload, cwd: string): boolean {
+  const toolName = safeString(payload.tool_name).trim();
+  if (toolName === "Bash") {
+    return !isAllowedDeepInterviewBashWrite(cwd, readPreToolUseCommand(payload));
+  }
+  if (!DEEP_INTERVIEW_IMPLEMENTATION_TOOL_NAMES.has(toolName)) return false;
+  const candidates = collectImplementationToolPathCandidates(
+    payload,
+    toolName,
+    readPreToolUsePathCandidates(payload),
+  );
+  return candidates.length === 0
+    || !candidates.every((candidate) => isAllowedDeepInterviewArtifactPath(cwd, candidate));
+}
+
+function buildDeepInterviewRootPointerConflictBlock(activeState: Record<string, unknown>): Record<string, unknown> {
+  const phase = formatPhase(activeState.current_phase ?? activeState.currentPhase, "planning");
+  return {
+    decision: "block",
+    reason: `Deep-interview is active in the live root session pointer (phase: ${phase}), but the current native session could not be authoritatively resolved to that owner; failing closed for planning-write protection.`,
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      additionalContext:
+        "OMX detected a live root session pointer owned by another session while a deep-interview planning phase is active. "
+        + "This indicates collapsed session-root isolation. Do not perform implementation writes from this unresolved session; use the owning OMX session or restart with an isolated OMX_ROOT.",
+    },
+  };
+}
+
+function buildRalplanRootPointerConflictBlock(activeState: Record<string, unknown>): Record<string, unknown> {
+  const phase = formatPhase(activeState.current_phase ?? activeState.currentPhase, "planning");
+  const activeMode = safeString(activeState.mode).trim().toLowerCase();
+  const planningModeLabel = activeMode === "autopilot" ? "Autopilot planning" : "Ralplan";
+  return {
+    decision: "block",
+    reason: `${planningModeLabel} is active in the live root session pointer (phase: ${phase}), but the current native session could not be authoritatively resolved to that owner; failing closed for planning-write protection.`,
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      additionalContext:
+        "OMX detected a live root session pointer owned by another session while a ralplan/autopilot planning phase is active. "
+        + "This indicates collapsed session-root isolation. Do not perform implementation writes from this unresolved session; use the owning OMX session or restart with an isolated OMX_ROOT.",
+    },
+  };
+}
+
+async function buildPlanningRootPointerConflictPreToolUseOutput(
+  payload: CodexHookPayload,
+  cwd: string,
+  stateDir: string,
+  rootState: SessionState | null,
+): Promise<Record<string, unknown> | null> {
+  const rootSessionId = safeString(rootState?.session_id).trim();
+  if (!rootSessionId) return null;
+  const ownerCwd = safeString(rootState?.cwd).trim() || cwd;
+
+  const deepInterviewState = await readActiveDeepInterviewStateForPreToolUse(
+    ownerCwd,
+    stateDir,
+    rootSessionId,
+    "",
+  );
+  if (deepInterviewState && blocksDeepInterviewImplementationWrite(payload, cwd)) {
+    return buildDeepInterviewRootPointerConflictBlock(deepInterviewState);
+  }
+
+  const ralplanState = await readActiveRalplanStateForPreToolUse(
+    ownerCwd,
+    stateDir,
+    rootSessionId,
+    "",
+  );
+  if (!ralplanState) return null;
+
+  const toolName = safeString(payload.tool_name).trim();
+  let blocked = false;
+  if (toolName === "Bash") {
+    blocked = !isAllowedRalplanBashWrite(cwd, readPreToolUseCommand(payload));
+  } else if (PLANNING_MODE_IMPLEMENTATION_TOOL_NAMES.has(toolName)) {
+    const toolPathCandidates = collectImplementationToolPathCandidates(
+      payload,
+      toolName,
+      readPreToolUsePathCandidates(payload),
+    );
+    blocked = toolPathCandidates.length === 0
+      || toolPathCandidates.some((candidate) => !isAllowedRalplanArtifactPath(cwd, candidate));
+  }
+
+  return blocked ? buildRalplanRootPointerConflictBlock(ralplanState) : null;
 }
 
 function matchesSkillStopContext(
@@ -5329,11 +5462,13 @@ export async function dispatchCodexNativeHook(
     }
   } else if (hookEventName === "PreToolUse") {
     const payloadSessionId = readPayloadSessionId(payload);
+    const rootPointerConflict = await readLiveRootSessionPointerConflict(stateDir, payloadSessionId);
     const preToolUseSessionId = payloadSessionId
       ? await resolveInternalSessionIdForPayload(cwd, payloadSessionId, stateDir)
       : "";
     outputJson = await buildDeepInterviewPreToolUseBoundaryOutput(payload, cwd, stateDir, preToolUseSessionId)
       ?? await buildRalplanPreToolUseBoundaryOutput(payload, cwd, stateDir, preToolUseSessionId)
+      ?? await buildPlanningRootPointerConflictPreToolUseOutput(payload, cwd, stateDir, rootPointerConflict)
       ?? await buildNativeSubagentCapacityCloseGuardOutput(payload, cwd, stateDir)
       ?? buildNativePreToolUseOutput(payload);
   } else if (hookEventName === "PostToolUse") {


### PR DESCRIPTION
## Summary
- fail closed during PreToolUse planning-write checks when a different live root `session.json` owner is detected and the current native session cannot be authoritatively resolved
- preserve normal owner-session behavior and allowed planning artifact writes
- add focused regressions for live root pointer mismatch and authoritative owner pass-through

Fixes #2992

## Verification
- `npm ci`
- `npm run build && node --test dist/scripts/__tests__/codex-native-hook.test.js --test-name-pattern='live root session pointer|live-root'`
- `npm run lint`
- `git diff --check -- src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*