### PR TITLE
Protect deep-interview planning gate state writes

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -6737,6 +6737,70 @@ exit 0
       );
       assert.equal(allowedAppendBash.outputJson, null);
 
+      const allowedPlanningStateWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Write",
+          tool_use_id: "tool-di-planning-state-write",
+          tool_input: { file_path: ".omx/state/deep-interview-notes.json", content: "{}\n" },
+        },
+        { cwd },
+      );
+      assert.equal(allowedPlanningStateWrite.outputJson, null);
+
+      const protectedStateFiles = [
+        ".omx/state/sessions/sess-di-artifact/autopilot-state.json",
+        ".omx/state/sessions/sess-di-artifact/deep-interview-state.json",
+        ".omx/state/sessions/sess-di-artifact/skill-active-state.json",
+        ".omx/state/deep-interview-state.json",
+      ];
+      for (const [index, filePath] of protectedStateFiles.entries()) {
+        const protectedWrite = await dispatchCodexNativeHook(
+          {
+            hook_event_name: "PreToolUse",
+            cwd,
+            session_id: "sess-di-artifact",
+            tool_name: "Write",
+            tool_use_id: `tool-di-protected-state-${index}`,
+            tool_input: { file_path: filePath, content: "{}\n" },
+          },
+          { cwd },
+        );
+        assert.equal(
+          (protectedWrite.outputJson as { decision?: string } | null)?.decision,
+          "block",
+          `${filePath} should not be model-writable during deep-interview`,
+        );
+      }
+
+      const blockedStateCliMutation = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-write",
+          tool_input: { command: "omx state write --input '{\"mode\":\"deep-interview\",\"active\":false}' --json" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedStateCliMutation.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const allowedStateRead = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-read",
+          tool_input: { command: "omx state read --json" },
+        },
+        { cwd },
+      );
+      assert.equal(allowedStateRead.outputJson, null);
+
       const blockedBash = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",
@@ -7034,6 +7098,21 @@ exit 0
       );
       assert.equal(allowedStateWrite.outputJson, null);
 
+      const blockedProtectedStatePatch = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-apply-patch",
+          tool_name: "apply_patch",
+          tool_use_id: "tool-di-apply-patch-protected-state",
+          tool_input: {
+            input: "*** Begin Patch\n*** Update File: .omx/state/sessions/sess-di-apply-patch/deep-interview-state.json\n@@\n-{}\n+{\"active\":false}\n*** End Patch\n",
+          },
+        },
+        { cwd },
+      );
+      assert.equal((blockedProtectedStatePatch.outputJson as { decision?: string } | null)?.decision, "block");
+
       const blockedOutsidePath = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",
@@ -7141,6 +7220,31 @@ exit 0
         const writeResult = await preToolUse("Write", `tool-ralplan-write-${path}`, { file_path: path, content: "ok" });
         assert.equal(writeResult.outputJson, null, `Write should be allowed for ${path}`);
       }
+
+      for (const protectedPath of [
+        ".omx/state/sessions/sess-ralplan-guard/ralplan-state.json",
+        ".omx/state/sessions/sess-ralplan-guard/autopilot-state.json",
+        ".omx/state/sessions/sess-ralplan-guard/skill-active-state.json",
+      ]) {
+        const protectedResult = await preToolUse("Write", `tool-ralplan-protected-${protectedPath}`, {
+          file_path: protectedPath,
+          content: "{}",
+        });
+        assert.equal(
+          (protectedResult.outputJson as { decision?: string } | null)?.decision,
+          "block",
+          `${protectedPath} should not be model-writable during ralplan`,
+        );
+      }
+
+      const blockedStateCliMutation = await preToolUse("Bash", "tool-ralplan-state-cli-write", {
+        command: "omx state clear --json",
+      });
+      assert.equal((blockedStateCliMutation.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(
+        String((blockedStateCliMutation.outputJson as { reason?: string } | null)?.reason ?? ""),
+        /omx state mutation is not model-writable/,
+      );
 
       const allowedPatchAdd = await preToolUse("apply_patch", "tool-ralplan-patch-add", {
         input: "*** Begin Patch\n*** Add File: .omx/plans/issue-2863.md\n+# Plan\n*** End Patch\n",

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3143,6 +3143,13 @@ const RALPLAN_ALLOWED_WRITE_PREFIXES = [
   ".beads",
 ] as const;
 
+const PROTECTED_PLANNING_STATE_FILE_NAMES = new Set([
+  "autopilot-state.json",
+  "deep-interview-state.json",
+  "ralplan-state.json",
+  "skill-active-state.json",
+]);
+
 const PLANNING_MODE_IMPLEMENTATION_TOOL_NAMES = new Set([
   "Write",
   "Edit",
@@ -3206,21 +3213,33 @@ function hasExplicitExecutionHandoffSkill(
   ));
 }
 
+function normalizePlanningArtifactRelativePath(cwd: string, rawPath: string): string | null {
+  const trimmed = rawPath.trim().replace(/^['"]|['"]$/g, "");
+  if (!trimmed || trimmed.includes("\0")) return null;
+  try {
+    const absolute = resolve(cwd, trimmed);
+    const relativePath = relative(cwd, absolute).replace(/\\/g, "/");
+    if (!relativePath || relativePath.startsWith("..") || relativePath.startsWith("/")) return null;
+    return relativePath;
+  } catch {
+    return null;
+  }
+}
+
+function isProtectedPlanningStatePath(relativePath: string): boolean {
+  if (relativePath !== ".omx/state" && !relativePath.startsWith(".omx/state/")) return false;
+  const fileName = relativePath.split("/").pop() ?? "";
+  return PROTECTED_PLANNING_STATE_FILE_NAMES.has(fileName);
+}
+
 function isAllowedPlanningArtifactPath(
   cwd: string,
   rawPath: string,
   allowedPrefixes: readonly string[],
 ): boolean {
-  const trimmed = rawPath.trim().replace(/^['"]|['"]$/g, "");
-  if (!trimmed || trimmed.includes("\0")) return false;
-  let relativePath: string;
-  try {
-    const absolute = resolve(cwd, trimmed);
-    relativePath = relative(cwd, absolute).replace(/\\/g, "/");
-  } catch {
-    return false;
-  }
-  if (!relativePath || relativePath.startsWith("..") || relativePath.startsWith("/")) return false;
+  const relativePath = normalizePlanningArtifactRelativePath(cwd, rawPath);
+  if (!relativePath) return false;
+  if (isProtectedPlanningStatePath(relativePath)) return false;
   return allowedPrefixes.some((prefix) => (
     relativePath === prefix || relativePath.startsWith(`${prefix}/`)
   ));
@@ -3466,6 +3485,7 @@ function commandHasDeepInterviewWriteIntent(command: string): boolean {
     || /\btee\s+(?:-a\s+)?[^\s&|;]+/.test(command)
     || /\bsed\s+(?:[^\n;&|]*\s)?-i(?:\b|['"])/.test(command)
     || /\b(?:python3?|node|perl|ruby)\b[\s\S]{0,260}\b(?:writeFileSync|writeFile|write_text|open\([^)]*["']w|File\.write|Path\()/.test(command)
+    || /\bomx\s+state\s+(?:write|clear)\b/.test(command)
     || /\b(?:git\s+(?:checkout|switch|restore|reset|apply|am|merge|rebase)|npm\s+(?:install|i|ci)|pnpm\s+(?:install|i)|yarn\s+(?:install|add))\b/.test(command);
 }
 
@@ -3509,7 +3529,8 @@ function describeImplementationToolBlock(
 
 function isAllowedDeepInterviewBashWrite(cwd: string, command: string): boolean {
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
-  if (/\bomx\s+(?:state\s+(?:write|read|clear)|question)\b/.test(command)) return true;
+  if (/\bomx\s+(?:state\s+read|question)\b/.test(command)) return true;
+  if (/\bomx\s+state\s+(?:write|clear)\b/.test(command)) return false;
   const targets = extractDeepInterviewCommandWriteTargets(command);
   return targets.length > 0 && targets.every((target) => isAllowedDeepInterviewArtifactPath(cwd, target));
 }
@@ -3616,7 +3637,8 @@ function isAllowedRalplanBashWrite(cwd: string, command: string): boolean {
     return beadsCommand.allowed && (targets.length === 0 || hasAllowedTargets);
   }
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
-  if (/\bomx\s+(?:state\s+(?:write|read|clear)|question)\b/.test(command)) return true;
+  if (/\bomx\s+(?:state\s+read|question)\b/.test(command)) return true;
+  if (/\bomx\s+state\s+(?:write|clear)\b/.test(command)) return false;
   return hasAllowedTargets;
 }
 
@@ -3636,6 +3658,9 @@ function buildRalplanBashBlockedDetail(cwd: string, command: string): string {
   }
   if (beadsCommand.present) {
     return "Beads tracker command also performs an implementation write outside allowed planning metadata";
+  }
+  if (/\bomx\s+state\s+(?:write|clear)\b/.test(command)) {
+    return "omx state mutation is not model-writable during gated planning; write planning artifacts instead";
   }
   return "Bash write intent did not identify an allowed planning artifact path or metadata path";
 }


### PR DESCRIPTION
## Summary
- deny protected planning gate/phase-control state filenames under `.omx/state` during deep-interview/ralplan gated planning
- keep legitimate planning artifacts writable under `.omx/context`, `.omx/interviews`, `.omx/plans`, `.omx/specs`, and non-control `.omx/state` files
- block `omx state write/clear` mutations during gated planning while preserving state reads/questions

Fixes #2993

## Tests
- `npm run build`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js --test-name-pattern='deep-interview artifact and state writes|deep-interview apply_patch artifact writes|Ralplan read-only inspection'` (Node ran the full file: 465 passing)
- `npm run lint`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
