### PR TITLE
refactor(planning-guard): compact #2997/#2998 helpers + review findings for #2996/#2999

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2005,7 +2005,8 @@ function launchArgRequestsDisposableWorktree(arg: string): boolean {
   return arg === "--worktree" ||
     arg === "-w" ||
     arg.startsWith("--worktree=") ||
-    arg.startsWith("-w=") ||
+    // Covers both `-w=<name>` and `-w<name>`; an explicit `-w=` check would be a
+    // strict subset of this clause, so it is omitted as redundant.
     (arg.startsWith("-w") && arg.length > 2);
 }
 

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3819,34 +3819,36 @@ function blocksDeepInterviewImplementationWrite(payload: CodexHookPayload, cwd: 
     || !candidates.every((candidate) => isAllowedDeepInterviewArtifactPath(cwd, candidate));
 }
 
-function buildDeepInterviewRootPointerConflictBlock(activeState: Record<string, unknown>): Record<string, unknown> {
+// Shared builder for the "live root session pointer owned by another session"
+// fail-closed block. Deep-interview and ralplan/autopilot only differ in the
+// human-readable mode label and phase-description fragment; the decision,
+// structure, and guidance are identical.
+function buildRootPointerConflictBlock(
+  activeState: Record<string, unknown>,
+  planningModeLabel: string,
+  planningPhaseDescription: string,
+): Record<string, unknown> {
   const phase = formatPhase(activeState.current_phase ?? activeState.currentPhase, "planning");
-  return {
-    decision: "block",
-    reason: `Deep-interview is active in the live root session pointer (phase: ${phase}), but the current native session could not be authoritatively resolved to that owner; failing closed for planning-write protection.`,
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      additionalContext:
-        "OMX detected a live root session pointer owned by another session while a deep-interview planning phase is active. "
-        + "This indicates collapsed session-root isolation. Do not perform implementation writes from this unresolved session; use the owning OMX session or restart with an isolated OMX_ROOT.",
-    },
-  };
-}
-
-function buildRalplanRootPointerConflictBlock(activeState: Record<string, unknown>): Record<string, unknown> {
-  const phase = formatPhase(activeState.current_phase ?? activeState.currentPhase, "planning");
-  const activeMode = safeString(activeState.mode).trim().toLowerCase();
-  const planningModeLabel = activeMode === "autopilot" ? "Autopilot planning" : "Ralplan";
   return {
     decision: "block",
     reason: `${planningModeLabel} is active in the live root session pointer (phase: ${phase}), but the current native session could not be authoritatively resolved to that owner; failing closed for planning-write protection.`,
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       additionalContext:
-        "OMX detected a live root session pointer owned by another session while a ralplan/autopilot planning phase is active. "
+        `OMX detected a live root session pointer owned by another session while a ${planningPhaseDescription} is active. `
         + "This indicates collapsed session-root isolation. Do not perform implementation writes from this unresolved session; use the owning OMX session or restart with an isolated OMX_ROOT.",
     },
   };
+}
+
+function buildDeepInterviewRootPointerConflictBlock(activeState: Record<string, unknown>): Record<string, unknown> {
+  return buildRootPointerConflictBlock(activeState, "Deep-interview", "deep-interview planning phase");
+}
+
+function buildRalplanRootPointerConflictBlock(activeState: Record<string, unknown>): Record<string, unknown> {
+  const activeMode = safeString(activeState.mode).trim().toLowerCase();
+  const planningModeLabel = activeMode === "autopilot" ? "Autopilot planning" : "Ralplan";
+  return buildRootPointerConflictBlock(activeState, planningModeLabel, "ralplan/autopilot planning phase");
 }
 
 async function buildPlanningRootPointerConflictPreToolUseOutput(


### PR DESCRIPTION
## Summary

Follow-up to the four merged planning-guard PRs (#2996 / #2997 / #2998 / #2999, addressing issues #2992–#2995). This PR contains **only behavior-preserving compaction** of the code those PRs introduced, plus a detailed analysis of two deeper coherence problems I found while reviewing the set — which are intentionally **not** changed here because they invert just-merged behavior and need a design decision (see *Findings → recommended follow-up*).

Base: `dev`.

## What this PR changes (compaction, no behavior change)

1. **`src/cli/index.ts` (#2997 cleanup).** Removed the redundant `arg.startsWith("-w=")` clause in `launchArgRequestsDisposableWorktree`. `-w=<name>` is a strict subset of the existing `arg.startsWith("-w") && arg.length > 2` clause, so the separate check could never change the result. Added a one-line comment explaining the coverage.

2. **`src/scripts/codex-native-hook.ts` (#2998 cleanup).** Collapsed the two near-identical root-pointer fail-closed builders (`buildDeepInterviewRootPointerConflictBlock` / `buildRalplanRootPointerConflictBlock`) into a single `buildRootPointerConflictBlock(activeState, planningModeLabel, planningPhaseDescription)`. The two named wrappers are retained so call sites are untouched and the emitted `reason` / `additionalContext` strings are byte-identical to before — existing assertions in `codex-native-hook.test.ts` continue to hold.

### Validation
- `npm run build` green.
- Changed paths pass: `cli/__tests__/index.test.js` isolation/worktree pattern **26/26**, `scripts/__tests__/codex-native-hook.test.js` planning-guard/conflict pattern **96/96**.
- The only failing test in `index.test.js`, `releaseTmuxExtendedKeysLease restores when all remaining holders are dead`, **also fails on clean `origin/dev`** (it depends on PID-liveness semantics not available in this sandbox) and is unrelated to this change.

## Why the merged set works — and where it doesn't (review findings)

The four PRs correctly fix the primary chain: #2997 restores per-launch root isolation (the real root cause of #2995 — a `--madmax`/`--worktree` launch reusing an inherited `OMX_ROOT`), and #2998 adds the fail-closed defense for collapsed roots. #2995 looks closeable on the back of #2997.

However, #2999 (gate-write protection) and #2996 (phase contract) interact in a way that **inverts the safety posture** for the deep-interview / ralplan planning phases. I'm flagging this rather than patching it, because the fix changes the behavior these PRs just established and should be a deliberate design call.

**Finding 1 — the gate-validated transition path is blocked, the gate-bypassing one is open.**
- The state backend `state_write` (`src/state/operations.ts`) enforces the autopilot phase gate on **every** write, for both transports — `omx state write` (CLI) and `omx_state` (MCP) — via `canAdvanceAutopilotDeepInterviewToRalplan` / `canAdvanceAutopilotRalplanToUltragoal` (ordering + completion/skip evidence).
- #2999 blocks the **Bash `omx state write|clear`** path (and raw edits to the protected state files) during deep-interview/ralplan. So the model's *gate-validated* CLI transition is blocked, while the MCP path to the same validated backend stays open — an inconsistent transport asymmetry.
- Meanwhile #2996's keyword-handoff path, `persistAutopilotSupervisedChildPhaseState` (`src/hooks/keyword-detector.ts`), writes `current_phase` **directly via `writeFile`, without invoking the gate**. So advancing by invoking `$ralplan` / `$ultragoal` bypasses exactly the gate that `state_write` enforces.
- Net effect: the protection blocks the *validated* path and leaves the *unvalidated* paths (keyword handoff, MCP) open. A CLI-first autopilot loop (which `codex-native-hook.ts:2034` and `skills/autopilot/SKILL.md` both still recommend, and which must persist `handoff_artifacts`/gate evidence to `autopilot-state.json`) can stall, because the only evidence-persistence path left open during planning is MCP.

**Finding 2 — `deep_interview_gate.skip_authorized_by_user` has no provenance enforcement.**
- `isSkipGate` (`src/autopilot/deep-interview-gate.ts:319`) accepts a skip only when `skip_authorized_by_user === true` (plus reason/timestamp/source/session). But that field is **only ever read** — no trusted code path sets it (repo-wide, the single occurrence is the read at :319). A model can therefore set it itself, so the "user-authorized" requirement is forgeable. #2999's transport block is effectively papering over this on the Bash/file transports while MCP remains open.

### Recommended follow-up (separate, design-reviewed PR)
Resolve both with a single coherent rule instead of transport-level blocks:
1. Make the keyword-handoff transition (`persistAutopilotSupervisedChildPhaseState`) defer to the same `canAdvance…` gate as `state_write`, so no transition path bypasses the gate.
2. Enforce provenance for `skip_authorized_by_user` in `state_write` (only honor a false→true transition that is backed by a real user-authorization record, e.g. a deep-interview `omx question` answer), so a skip cannot be self-attested on any transport.
3. Once 1+2 hold, relax #2999's blanket Bash `omx state write|clear` block (keep the raw-file protection), which restores the CLI-first loop and removes the CLI/MCP asymmetry.

I'm happy to open that as a follow-up PR if the direction looks right; it deliberately isn't bundled here so this cleanup stays low-risk and the design change gets its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
