### PR TITLE
fix(planning-gate): single-source phase-gate enforcement across CLI/MCP/keyword transports

### DIFF
--- a/src/autopilot/fsm.ts
+++ b/src/autopilot/fsm.ts
@@ -1,4 +1,4 @@
-const AUTOPILOT_CHILD_PHASES = [
+export const AUTOPILOT_CHILD_PHASES = [
   'deep-interview',
   'ralplan',
   'ultragoal',

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -793,6 +793,42 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('does not let a keyword jump ahead past a planning gate (forward skip)', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-skip-ahead-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await recordSkillActivation({
+        stateDir,
+        text: 'please run $autopilot',
+        sessionId: 'sess-skip',
+        threadId: 'thread-skip',
+        turnId: 'turn-1',
+        nowIso: '2026-02-25T00:00:00.000Z',
+      });
+
+      // `$ultragoal` while in deep-interview skips the ralplan gate entirely; the
+      // keyword handoff must hold the current phase rather than jump ahead.
+      const result = await recordSkillActivation({
+        stateDir,
+        text: 'jump straight to $ultragoal',
+        sessionId: 'sess-skip',
+        threadId: 'thread-skip',
+        turnId: 'turn-2',
+        nowIso: '2026-02-25T00:01:00.000Z',
+      });
+
+      const autopilotState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-skip', 'autopilot-state.json'), 'utf-8'),
+      ) as { current_phase: string };
+      assert.equal(autopilotState.current_phase, 'deep-interview', 'forward skip must be held');
+      // skill-active phase is kept in sync with the held autopilot phase.
+      assert.equal(result?.phase, 'deep-interview');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('seeds dedicated planner routing in Autopilot state when main is cheap', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-planner-routing-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -773,7 +773,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
       // A bare `$ralplan` keyword handoff must not advance current_phase across the
       // deep-interview -> ralplan gate while the gate is unsatisfied. The keyword
       // path now defers to the same gate as the state_write backend.
-      await recordSkillActivation({
+      const denied = await recordSkillActivation({
         stateDir,
         text: 'continue with $ralplan',
         sessionId: 'sess-gate',
@@ -788,6 +788,17 @@ describe('keyword detector skill-active-state lifecycle', () => {
         'deep-interview',
         'keyword handoff must not skip the deep-interview gate',
       );
+
+      // The visible canonical skill-active state must stay aligned with the held
+      // detail phase (no drift to ralplan) — both the returned state and the
+      // persisted skill-active-state.json mirror.
+      assert.equal(denied?.phase, 'deep-interview');
+      assert.deepEqual(denied?.active_skills?.map((entry) => [entry.skill, entry.phase]), [['autopilot', 'deep-interview']]);
+      const canonical = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-gate', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { phase?: string; active_skills?: Array<{ skill?: string; phase?: string }> };
+      assert.equal(canonical.phase, 'deep-interview');
+      assert.deepEqual(canonical.active_skills?.map((entry) => [entry.skill, entry.phase]), [['autopilot', 'deep-interview']]);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -824,6 +835,56 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(autopilotState.current_phase, 'deep-interview', 'forward skip must be held');
       // skill-active phase is kept in sync with the held autopilot phase.
       assert.equal(result?.phase, 'deep-interview');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not advance or drift canonical state past an unsatisfied ralplan -> ultragoal gate', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-ralplan-gate-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-ralplan-gate';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      // Supervised Autopilot already in ralplan, with no ralplan consensus evidence
+      // (the ralplan -> ultragoal gate is unsatisfied).
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: '$autopilot',
+          phase: 'ralplan',
+          source: 'keyword-detector',
+          session_id: sessionId,
+          active_skills: [{ skill: 'autopilot', phase: 'ralplan', active: true, session_id: sessionId }],
+        }, null, 2),
+      );
+      const autopilotStatePath = join(stateDir, 'sessions', sessionId, 'autopilot-state.json');
+      await writeFile(
+        autopilotStatePath,
+        JSON.stringify({ active: true, mode: 'autopilot', current_phase: 'ralplan', session_id: sessionId }, null, 2),
+      );
+
+      const denied = await recordSkillActivation({
+        stateDir,
+        text: 'advance to $ultragoal',
+        sessionId,
+        threadId: 'thread-ralplan-gate',
+        turnId: 'turn-ralplan-gate',
+        nowIso: '2026-02-25T00:01:00.000Z',
+      });
+
+      const afterAdvance = JSON.parse(await readFile(autopilotStatePath, 'utf-8')) as { current_phase: string };
+      assert.equal(afterAdvance.current_phase, 'ralplan', 'keyword handoff must not skip the ralplan -> ultragoal gate');
+      assert.equal(denied?.phase, 'ralplan');
+      assert.deepEqual(denied?.active_skills?.map((entry) => [entry.skill, entry.phase]), [['autopilot', 'ralplan']]);
+      const canonical = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { phase?: string; active_skills?: Array<{ skill?: string; phase?: string }> };
+      assert.equal(canonical.phase, 'ralplan');
+      assert.deepEqual(canonical.active_skills?.map((entry) => [entry.skill, entry.phase]), [['autopilot', 'ralplan']]);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -890,6 +890,56 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('does not let an implementation-phase keyword skip the code-review gate to ultraqa', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-ultraqa-skip-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-ultraqa-skip';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      // Supervised Autopilot in an implementation phase (ultragoal). The completion
+      // gate requires code-review before ultraqa.
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: '$autopilot',
+          phase: 'ultragoal',
+          source: 'keyword-detector',
+          session_id: sessionId,
+          active_skills: [{ skill: 'autopilot', phase: 'ultragoal', active: true, session_id: sessionId }],
+        }, null, 2),
+      );
+      const autopilotStatePath = join(stateDir, 'sessions', sessionId, 'autopilot-state.json');
+      await writeFile(
+        autopilotStatePath,
+        JSON.stringify({ active: true, mode: 'autopilot', current_phase: 'ultragoal', session_id: sessionId }, null, 2),
+      );
+
+      const denied = await recordSkillActivation({
+        stateDir,
+        text: 'run $ultraqa now',
+        sessionId,
+        threadId: 'thread-ultraqa-skip',
+        turnId: 'turn-ultraqa-skip',
+        nowIso: '2026-02-25T00:01:00.000Z',
+      });
+
+      const afterAdvance = JSON.parse(await readFile(autopilotStatePath, 'utf-8')) as { current_phase: string };
+      assert.equal(afterAdvance.current_phase, 'ultragoal', 'keyword handoff must not skip the code-review gate');
+      assert.equal(denied?.phase, 'ultragoal');
+      assert.deepEqual(denied?.active_skills?.map((entry) => [entry.skill, entry.phase]), [['autopilot', 'ultragoal']]);
+      const canonical = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { phase?: string; active_skills?: Array<{ skill?: string; phase?: string }> };
+      assert.equal(canonical.phase, 'ultragoal');
+      assert.deepEqual(canonical.active_skills?.map((entry) => [entry.skill, entry.phase]), [['autopilot', 'ultragoal']]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('seeds dedicated planner routing in Autopilot state when main is cheap', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-planner-routing-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -748,6 +748,51 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('does not advance the supervised child phase past an unsatisfied deep-interview gate via keyword handoff', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-supervised-gate-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+
+      // Activate Autopilot: seeds autopilot-state.json at current_phase=deep-interview
+      // with deep_interview_gate.status="required" (gate not satisfied).
+      const activated = await recordSkillActivation({
+        stateDir,
+        text: 'please run $autopilot',
+        sessionId: 'sess-gate',
+        threadId: 'thread-gate',
+        turnId: 'turn-1',
+        nowIso: '2026-02-25T00:00:00.000Z',
+      });
+      assert.equal(activated?.phase, 'deep-interview');
+
+      const autopilotStatePath = join(stateDir, 'sessions', 'sess-gate', 'autopilot-state.json');
+      const beforeAdvance = JSON.parse(await readFile(autopilotStatePath, 'utf-8')) as { current_phase: string };
+      assert.equal(beforeAdvance.current_phase, 'deep-interview');
+
+      // A bare `$ralplan` keyword handoff must not advance current_phase across the
+      // deep-interview -> ralplan gate while the gate is unsatisfied. The keyword
+      // path now defers to the same gate as the state_write backend.
+      await recordSkillActivation({
+        stateDir,
+        text: 'continue with $ralplan',
+        sessionId: 'sess-gate',
+        threadId: 'thread-gate',
+        turnId: 'turn-2',
+        nowIso: '2026-02-25T00:01:00.000Z',
+      });
+
+      const afterAdvance = JSON.parse(await readFile(autopilotStatePath, 'utf-8')) as { current_phase: string };
+      assert.equal(
+        afterAdvance.current_phase,
+        'deep-interview',
+        'keyword handoff must not skip the deep-interview gate',
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('seeds dedicated planner routing in Autopilot state when main is cheap', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-planner-routing-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -48,6 +48,7 @@ import { resolveAutopilotPlannerRouting } from '../autopilot/planner-routing.js'
 import { deriveAutopilotChildPhase, AUTOPILOT_CHILD_PHASES } from '../autopilot/fsm.js';
 import { canAdvanceAutopilotDeepInterviewToRalplan } from '../autopilot/deep-interview-gate.js';
 import { canAdvanceAutopilotRalplanToUltragoal } from '../autopilot/ralplan-gate.js';
+import { validateAutopilotCompletionTransition } from '../autopilot/completion-gate.js';
 
 export interface KeywordMatch {
   keyword: string;
@@ -1101,6 +1102,14 @@ async function resolveGatedSupervisedChildPhase(
   const currentChildPhase = deriveAutopilotChildPhase(existing);
   const heldPhase = safeString(existing.current_phase).trim() || requestedChildSkill;
   const nextState = { ...existing, current_phase: requestedChildSkill };
+
+  // Reuse the same semantic completion-gate the state_write backend enforces, so
+  // the keyword path can't skip it either — e.g. an implementation phase
+  // (ultragoal/rework/team/ralph) may not jump straight to ultraqa; code-review
+  // must run first.
+  if (validateAutopilotCompletionTransition(existing, nextState)) {
+    return heldPhase;
+  }
 
   if (currentChildPhase === 'deep-interview' && requestedChildSkill === 'ralplan') {
     const gate = await canAdvanceAutopilotDeepInterviewToRalplan({

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -45,7 +45,7 @@ import {
 } from '../config/deep-interview.js';
 import { inferTerminalLifecycleOutcome } from '../runtime/run-outcome.js';
 import { resolveAutopilotPlannerRouting } from '../autopilot/planner-routing.js';
-import { deriveAutopilotChildPhase } from '../autopilot/fsm.js';
+import { deriveAutopilotChildPhase, AUTOPILOT_CHILD_PHASES } from '../autopilot/fsm.js';
 import { canAdvanceAutopilotDeepInterviewToRalplan } from '../autopilot/deep-interview-gate.js';
 import { canAdvanceAutopilotRalplanToUltragoal } from '../autopilot/ralplan-gate.js';
 
@@ -1123,9 +1123,31 @@ async function resolveGatedSupervisedChildPhase(
     return gate.allowed ? requestedChildSkill : heldPhase;
   }
 
+  // From a gated planning phase, the only forward advance is the immediate next
+  // gated phase (handled above). A keyword that jumps further ahead would skip a
+  // gate the state_write backend enforces, so hold the current phase.
+  if (
+    (currentChildPhase === 'deep-interview' || currentChildPhase === 'ralplan')
+    && isForwardChildPhaseSkip(currentChildPhase, requestedChildSkill)
+  ) {
+    return heldPhase;
+  }
+
   return requestedChildSkill;
 }
 
+// True when `requestedChildSkill` is a child phase strictly beyond the immediate
+// next phase after `currentChildPhase` in the canonical Autopilot order — i.e. a
+// forward jump that skips at least one phase.
+function isForwardChildPhaseSkip(currentChildPhase: string, requestedChildSkill: string): boolean {
+  const currentIndex = (AUTOPILOT_CHILD_PHASES as readonly string[]).indexOf(currentChildPhase);
+  const requestedIndex = (AUTOPILOT_CHILD_PHASES as readonly string[]).indexOf(requestedChildSkill);
+  return currentIndex >= 0 && requestedIndex > currentIndex + 1;
+}
+
+// Returns the phase actually written to autopilot-state.json (the gate-held
+// phase when an advance was blocked), so callers can keep skill-active-state in
+// sync with it.
 async function persistAutopilotSupervisedChildPhaseState(
   cwd: string,
   stateDir: string,
@@ -1133,7 +1155,7 @@ async function persistAutopilotSupervisedChildPhaseState(
   childSkill: string,
   nowIso: string,
   options: { threadId?: string; turnId?: string } = {},
-): Promise<void> {
+): Promise<string> {
   const { absolutePath } = resolveSeedStateFilePath(stateDir, 'autopilot', sessionId);
   const existingResult = await readJsonStateWithStatus(absolutePath);
   const existing = existingResult.state;
@@ -1170,6 +1192,8 @@ async function persistAutopilotSupervisedChildPhaseState(
     },
     { nowIso },
   ), null, 2));
+
+  return effectivePhase;
 }
 
 async function reconcileAutopilotSupervisedChildModeStates(
@@ -1179,10 +1203,10 @@ async function reconcileAutopilotSupervisedChildModeStates(
   childSkill: string,
   nowIso: string,
   options: { threadId?: string; turnId?: string } = {},
-): Promise<string[]> {
+): Promise<{ completedPaths: string[]; effectivePhase: string }> {
   if (!isTrackedWorkflowMode(childSkill)) {
-    await persistAutopilotSupervisedChildPhaseState(cwd, stateDir, sessionId, childSkill, nowIso, options);
-    return [];
+    const effectivePhase = await persistAutopilotSupervisedChildPhaseState(cwd, stateDir, sessionId, childSkill, nowIso, options);
+    return { completedPaths: [], effectivePhase };
   }
 
   const activeChildModes: TrackedWorkflowMode[] = [];
@@ -1206,8 +1230,8 @@ async function reconcileAutopilotSupervisedChildModeStates(
     sessionId,
     source: 'autopilot-supervised-child',
   });
-  await persistAutopilotSupervisedChildPhaseState(cwd, stateDir, sessionId, childSkill, nowIso, options);
-  return transition.completedPaths;
+  const effectivePhase = await persistAutopilotSupervisedChildPhaseState(cwd, stateDir, sessionId, childSkill, nowIso, options);
+  return { completedPaths: transition.completedPaths, effectivePhase };
 }
 
 function isDeepInterviewRuntimeConfig(value: unknown): value is DeepInterviewRuntimeConfig {
@@ -1402,34 +1426,11 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     : null;
 
   if (previous?.active === true && previous.skill === 'autopilot' && isAutopilotSupervisedChildSkill(match.skill)) {
-    const nextState: SkillActiveState = {
-      ...previous,
-      version: 1,
-      active: true,
-      updated_at: nowIso,
-      source: 'keyword-detector',
-      session_id: input.sessionId ?? previous.session_id,
-      thread_id: input.threadId ?? previous.thread_id,
-      turn_id: input.turnId ?? previous.turn_id,
-      phase: match.skill,
-      active_skills: listActiveSkills(previous).map((entry) => (
-        entry.skill === 'autopilot'
-          ? {
-              ...entry,
-              phase: match.skill,
-              active: true,
-              updated_at: nowIso,
-              session_id: input.sessionId ?? entry.session_id,
-              thread_id: input.threadId ?? entry.thread_id,
-              turn_id: input.turnId ?? entry.turn_id,
-            }
-          : entry
-      )),
-      supervised_child_keyword: match.keyword,
-      supervised_child_skill: match.skill,
-    };
     try {
-      await reconcileAutopilotSupervisedChildModeStates(
+      // Reconcile first so skill-active phase reflects the gate-held phase the
+      // autopilot detail state actually advanced to (a blocked advance keeps the
+      // current phase).
+      const { effectivePhase } = await reconcileAutopilotSupervisedChildModeStates(
         sourceCwd,
         input.stateDir,
         input.sessionId ?? previous.session_id,
@@ -1437,12 +1438,39 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
         nowIso,
         { threadId: input.threadId, turnId: input.turnId },
       );
+      const nextState: SkillActiveState = {
+        ...previous,
+        version: 1,
+        active: true,
+        updated_at: nowIso,
+        source: 'keyword-detector',
+        session_id: input.sessionId ?? previous.session_id,
+        thread_id: input.threadId ?? previous.thread_id,
+        turn_id: input.turnId ?? previous.turn_id,
+        phase: effectivePhase,
+        active_skills: listActiveSkills(previous).map((entry) => (
+          entry.skill === 'autopilot'
+            ? {
+                ...entry,
+                phase: effectivePhase,
+                active: true,
+                updated_at: nowIso,
+                session_id: input.sessionId ?? entry.session_id,
+                thread_id: input.threadId ?? entry.thread_id,
+                turn_id: input.turnId ?? entry.turn_id,
+              }
+            : entry
+        )),
+        supervised_child_keyword: match.keyword,
+        supervised_child_skill: match.skill,
+      };
       await writeSkillActiveStateCopiesForStateDir(
         input.stateDir,
         nextState,
         input.sessionId,
         selectRootSkillStateCopy(previousRoot, nextState, input.sessionId),
       );
+      return nextState;
     } catch (error) {
       return {
         ...previous,
@@ -1457,7 +1485,6 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
         transition_error: error instanceof Error ? error.message : String(error),
       };
     }
-    return nextState;
   }
 
   if (isTrackedWorkflowMatch) {

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -45,6 +45,9 @@ import {
 } from '../config/deep-interview.js';
 import { inferTerminalLifecycleOutcome } from '../runtime/run-outcome.js';
 import { resolveAutopilotPlannerRouting } from '../autopilot/planner-routing.js';
+import { deriveAutopilotChildPhase } from '../autopilot/fsm.js';
+import { canAdvanceAutopilotDeepInterviewToRalplan } from '../autopilot/deep-interview-gate.js';
+import { canAdvanceAutopilotRalplanToUltragoal } from '../autopilot/ralplan-gate.js';
 
 export interface KeywordMatch {
   keyword: string;
@@ -1081,7 +1084,50 @@ const AUTOPILOT_SUPERVISED_TRACKED_CHILD_SKILLS: TrackedWorkflowMode[] = [
   'ultraqa',
 ];
 
+// Mirror the `state_write` backend: an Autopilot phase advance across a planning
+// gate boundary (deep-interview -> ralplan, ralplan -> ultragoal) must satisfy
+// the same gate regardless of transport. The keyword handoff previously wrote
+// `current_phase` directly here, bypassing the gate that CLI/MCP `state_write`
+// enforces. When the gate is not satisfied we keep the current phase (do not
+// advance) so a `$child` keyword alone cannot skip the gate.
+async function resolveGatedSupervisedChildPhase(
+  cwd: string,
+  stateDir: string,
+  sessionId: string | undefined,
+  existing: Record<string, unknown> | null,
+  requestedChildSkill: string,
+): Promise<string> {
+  if (!existing) return requestedChildSkill;
+  const currentChildPhase = deriveAutopilotChildPhase(existing);
+  const heldPhase = safeString(existing.current_phase).trim() || requestedChildSkill;
+  const nextState = { ...existing, current_phase: requestedChildSkill };
+
+  if (currentChildPhase === 'deep-interview' && requestedChildSkill === 'ralplan') {
+    const gate = await canAdvanceAutopilotDeepInterviewToRalplan({
+      cwd,
+      sessionId,
+      baseStateDir: stateDir,
+      currentState: existing,
+      nextState,
+    });
+    return gate.allowed ? requestedChildSkill : heldPhase;
+  }
+
+  if (currentChildPhase === 'ralplan' && requestedChildSkill === 'ultragoal') {
+    const gate = canAdvanceAutopilotRalplanToUltragoal({
+      cwd,
+      sessionId,
+      currentState: existing,
+      nextState,
+    });
+    return gate.allowed ? requestedChildSkill : heldPhase;
+  }
+
+  return requestedChildSkill;
+}
+
 async function persistAutopilotSupervisedChildPhaseState(
+  cwd: string,
   stateDir: string,
   sessionId: string | undefined,
   childSkill: string,
@@ -1100,6 +1146,14 @@ async function persistAutopilotSupervisedChildPhaseState(
     throw new Error(`Cannot advance supervised Autopilot child phase: expected autopilot detail state, found ${existingMode || 'unknown'}`);
   }
 
+  const effectivePhase = await resolveGatedSupervisedChildPhase(
+    cwd,
+    stateDir,
+    sessionId,
+    existing,
+    childSkill,
+  );
+
   await mkdir(dirname(absolutePath), { recursive: true });
   await writeFile(absolutePath, JSON.stringify(withModeRuntimeContext(
     existing ?? {},
@@ -1107,7 +1161,7 @@ async function persistAutopilotSupervisedChildPhaseState(
       ...(existing ?? {}),
       active: true,
       mode: 'autopilot',
-      current_phase: childSkill,
+      current_phase: effectivePhase,
       started_at: safeString(existing?.started_at).trim() || nowIso,
       updated_at: nowIso,
       session_id: (sessionId ?? safeString(existing?.session_id).trim()) || undefined,
@@ -1127,7 +1181,7 @@ async function reconcileAutopilotSupervisedChildModeStates(
   options: { threadId?: string; turnId?: string } = {},
 ): Promise<string[]> {
   if (!isTrackedWorkflowMode(childSkill)) {
-    await persistAutopilotSupervisedChildPhaseState(stateDir, sessionId, childSkill, nowIso, options);
+    await persistAutopilotSupervisedChildPhaseState(cwd, stateDir, sessionId, childSkill, nowIso, options);
     return [];
   }
 
@@ -1152,7 +1206,7 @@ async function reconcileAutopilotSupervisedChildModeStates(
     sessionId,
     source: 'autopilot-supervised-child',
   });
-  await persistAutopilotSupervisedChildPhaseState(stateDir, sessionId, childSkill, nowIso, options);
+  await persistAutopilotSupervisedChildPhaseState(cwd, stateDir, sessionId, childSkill, nowIso, options);
   return transition.completedPaths;
 }
 

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -6791,10 +6791,9 @@ exit 0
         );
       }
 
-      // `omx state write` routes through the validated state_write backend, which
-      // enforces the Autopilot phase gate for every transport. The hook defers to
-      // that gate rather than blocking the CLI transport (raw writes to the
-      // protected state files above stay blocked).
+      // A non-deactivating `omx state write` routes through the validated
+      // state_write backend (which enforces the Autopilot phase gate for every
+      // transport), so the hook defers rather than blocking the CLI transport.
       const allowedStateCliMutation = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",
@@ -6802,11 +6801,55 @@ exit 0
           session_id: "sess-di-artifact",
           tool_name: "Bash",
           tool_use_id: "tool-di-state-cli-write",
-          tool_input: { command: "omx state write --input '{\"mode\":\"deep-interview\",\"active\":false}' --json" },
+          tool_input: { command: "omx state write --input '{\"mode\":\"autopilot\",\"current_phase\":\"ralplan\"}' --json" },
         },
         { cwd },
       );
       assert.equal(allowedStateCliMutation.outputJson, null);
+
+      // A deactivating `omx state write` (or `omx state clear`) ends the planning
+      // phase, which the backend does not gate for standalone modes; the hook
+      // rejects these deactivation vectors at the transport boundary.
+      const blockedStateDeactivation = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-deactivate",
+          tool_input: { command: "omx state write --input '{\"mode\":\"deep-interview\",\"active\":false}' --json" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedStateDeactivation.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedStateClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-clear",
+          tool_input: { command: "omx state clear --json" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedStateClear.outputJson as { decision?: string } | null)?.decision, "block");
+
+      // An implementation write smuggled alongside an allowed `omx state` command
+      // must not be short-circuited through the allowance.
+      const blockedChainedWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-chained",
+          tool_input: { command: "printf 'x' > src/evil.ts && omx state read --json" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedChainedWrite.outputJson as { decision?: string } | null)?.decision, "block");
 
       const allowedStateRead = await dispatchCodexNativeHook(
         {
@@ -7257,13 +7300,19 @@ exit 0
         );
       }
 
-      // `omx state` mutations defer to the gate-enforcing state_write backend
-      // (same enforcement for CLI and MCP); the hook no longer blocks the
-      // transport. Raw writes to the protected state files stay blocked above.
+      // A non-deactivating `omx state write` defers to the gate-enforcing
+      // state_write backend (same enforcement for CLI and MCP).
       const allowedStateCliMutation = await preToolUse("Bash", "tool-ralplan-state-cli-write", {
-        command: "omx state clear --json",
+        command: "omx state write --input '{\"mode\":\"autopilot\",\"current_phase\":\"ultragoal\"}' --json",
       });
       assert.equal(allowedStateCliMutation.outputJson, null);
+
+      // Deactivation vectors (`omx state clear`, `active:false`) are still
+      // rejected at the transport boundary.
+      const blockedStateClear = await preToolUse("Bash", "tool-ralplan-state-cli-clear", {
+        command: "omx state clear --json",
+      });
+      assert.equal((blockedStateClear.outputJson as { decision?: string } | null)?.decision, "block");
 
       const allowedPatchAdd = await preToolUse("apply_patch", "tool-ralplan-patch-add", {
         input: "*** Begin Patch\n*** Add File: .omx/plans/issue-2863.md\n+# Plan\n*** End Patch\n",

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -6807,6 +6807,21 @@ exit 0
       );
       assert.equal(allowedStateCliMutation.outputJson, null);
 
+      const allowedStateInputFile = join(cwd, "allowed-state-input.json");
+      await writeJson(allowedStateInputFile, { mode: "deep-interview", current_phase: "intent-first", active: true });
+      const allowedStateInputFileMutation = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-input-file-allowed",
+          tool_input: { command: `omx state write --input-file ${allowedStateInputFile} --json` },
+        },
+        { cwd },
+      );
+      assert.equal(allowedStateInputFileMutation.outputJson, null);
+
       // A deactivating `omx state write` (or `omx state clear`) ends the planning
       // phase, which the backend does not gate for standalone modes; the hook
       // rejects these deactivation vectors at the transport boundary.
@@ -6822,6 +6837,21 @@ exit 0
         { cwd },
       );
       assert.equal((blockedStateDeactivation.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedStateInputFile = join(cwd, "blocked-state-input.json");
+      await writeJson(blockedStateInputFile, { mode: "deep-interview", active: false });
+      const blockedStateDeactivationFile = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-input-file-blocked",
+          tool_input: { command: `omx state write --input-file ${blockedStateInputFile} --json` },
+        },
+        { cwd },
+      );
+      assert.equal((blockedStateDeactivationFile.outputJson as { decision?: string } | null)?.decision, "block");
 
       const blockedStateClear = await dispatchCodexNativeHook(
         {
@@ -6876,6 +6906,62 @@ exit 0
         { cwd },
       );
       assert.equal((blockedBash.outputJson as { decision?: string } | null)?.decision, "block");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks deactivating ralplan state writes from --input-file while allowing non-deactivating ones", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-ralplan-state-input-file-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionDir = join(stateDir, "sessions", "sess-ralplan-input-file");
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-ralplan-input-file", cwd });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "ralplan",
+        phase: "planning",
+        session_id: "sess-ralplan-input-file",
+        active_skills: [{ skill: "ralplan", phase: "planning", active: true, session_id: "sess-ralplan-input-file" }],
+      });
+      await writeJson(join(sessionDir, "ralplan-state.json"), {
+        active: true,
+        mode: "ralplan",
+        current_phase: "critic-review",
+        session_id: "sess-ralplan-input-file",
+      });
+
+      const allowedPayload = join(cwd, "ralplan-allowed-state.json");
+      await writeJson(allowedPayload, { mode: "ralplan", current_phase: "critic-review", active: true });
+      const allowed = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-ralplan-input-file",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-state-input-file-allowed",
+          tool_input: { command: `omx state write --input-file ${allowedPayload} --json` },
+        },
+        { cwd },
+      );
+      assert.equal(allowed.outputJson, null);
+
+      const blockedPayload = join(cwd, "ralplan-blocked-state.json");
+      await writeJson(blockedPayload, { mode: "ralplan", current_phase: "complete" });
+      const blocked = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-ralplan-input-file",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-state-input-file-blocked",
+          tool_input: { command: `omx state write --input-file ${blockedPayload} --json` },
+        },
+        { cwd },
+      );
+      assert.equal((blocked.outputJson as { decision?: string } | null)?.decision, "block");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -6791,7 +6791,11 @@ exit 0
         );
       }
 
-      const blockedStateCliMutation = await dispatchCodexNativeHook(
+      // `omx state write` routes through the validated state_write backend, which
+      // enforces the Autopilot phase gate for every transport. The hook defers to
+      // that gate rather than blocking the CLI transport (raw writes to the
+      // protected state files above stay blocked).
+      const allowedStateCliMutation = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",
           cwd,
@@ -6802,7 +6806,7 @@ exit 0
         },
         { cwd },
       );
-      assert.equal((blockedStateCliMutation.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal(allowedStateCliMutation.outputJson, null);
 
       const allowedStateRead = await dispatchCodexNativeHook(
         {
@@ -7253,14 +7257,13 @@ exit 0
         );
       }
 
-      const blockedStateCliMutation = await preToolUse("Bash", "tool-ralplan-state-cli-write", {
+      // `omx state` mutations defer to the gate-enforcing state_write backend
+      // (same enforcement for CLI and MCP); the hook no longer blocks the
+      // transport. Raw writes to the protected state files stay blocked above.
+      const allowedStateCliMutation = await preToolUse("Bash", "tool-ralplan-state-cli-write", {
         command: "omx state clear --json",
       });
-      assert.equal((blockedStateCliMutation.outputJson as { decision?: string } | null)?.decision, "block");
-      assert.match(
-        String((blockedStateCliMutation.outputJson as { reason?: string } | null)?.reason ?? ""),
-        /omx state mutation is not model-writable/,
-      );
+      assert.equal(allowedStateCliMutation.outputJson, null);
 
       const allowedPatchAdd = await preToolUse("apply_patch", "tool-ralplan-patch-add", {
         input: "*** Begin Patch\n*** Add File: .omx/plans/issue-2863.md\n+# Plan\n*** End Patch\n",

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3528,7 +3528,6 @@ function commandHasDeepInterviewWriteIntent(command: string): boolean {
     || /\btee\s+(?:-a\s+)?[^\s&|;]+/.test(command)
     || /\bsed\s+(?:[^\n;&|]*\s)?-i(?:\b|['"])/.test(command)
     || /\b(?:python3?|node|perl|ruby)\b[\s\S]{0,260}\b(?:writeFileSync|writeFile|write_text|open\([^)]*["']w|File\.write|Path\()/.test(command)
-    || /\bomx\s+state\s+(?:write|clear)\b/.test(command)
     || /\b(?:git\s+(?:checkout|switch|restore|reset|apply|am|merge|rebase)|npm\s+(?:install|i|ci)|pnpm\s+(?:install|i)|yarn\s+(?:install|add))\b/.test(command);
 }
 
@@ -3572,8 +3571,12 @@ function describeImplementationToolBlock(
 
 function isAllowedDeepInterviewBashWrite(cwd: string, command: string): boolean {
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
-  if (/\bomx\s+(?:state\s+read|question)\b/.test(command)) return true;
-  if (/\bomx\s+state\s+(?:write|clear)\b/.test(command)) return false;
+  // `omx state` mutations route through the validated `state_write` backend,
+  // which enforces the Autopilot phase gate (ordering + completion/skip
+  // evidence) for every transport. Defer to that gate here instead of blocking
+  // the transport; raw writes to the protected planning-state files are still
+  // rejected below via isAllowedDeepInterviewArtifactPath.
+  if (/\bomx\s+(?:state\s+(?:read|write|clear)|question)\b/.test(command)) return true;
   const targets = extractDeepInterviewCommandWriteTargets(command);
   return targets.length > 0 && targets.every((target) => isAllowedDeepInterviewArtifactPath(cwd, target));
 }
@@ -3680,8 +3683,9 @@ function isAllowedRalplanBashWrite(cwd: string, command: string): boolean {
     return beadsCommand.allowed && (targets.length === 0 || hasAllowedTargets);
   }
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
-  if (/\bomx\s+(?:state\s+read|question)\b/.test(command)) return true;
-  if (/\bomx\s+state\s+(?:write|clear)\b/.test(command)) return false;
+  // See isAllowedDeepInterviewBashWrite: defer `omx state` mutations to the
+  // gate-enforcing state_write backend rather than blocking the CLI transport.
+  if (/\bomx\s+(?:state\s+(?:read|write|clear)|question)\b/.test(command)) return true;
   return hasAllowedTargets;
 }
 
@@ -3701,9 +3705,6 @@ function buildRalplanBashBlockedDetail(cwd: string, command: string): string {
   }
   if (beadsCommand.present) {
     return "Beads tracker command also performs an implementation write outside allowed planning metadata";
-  }
-  if (/\bomx\s+state\s+(?:write|clear)\b/.test(command)) {
-    return "omx state mutation is not model-writable during gated planning; write planning artifacts instead";
   }
   return "Bash write intent did not identify an allowed planning artifact path or metadata path";
 }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3573,24 +3573,89 @@ function describeImplementationToolBlock(
 // backend, so the hook defers to that gate rather than blocking the transport.
 // The backend does NOT gate standalone deep-interview/ralplan *deactivation*,
 // however, so a command that ends the active planning phase from a tool call
-// (`omx state clear`, or an `omx state write` that flips `active` off) is still
-// blocked here. Robustly gating standalone deactivation (and other skip vectors)
-// belongs in the backend; this is transport-level defense-in-depth.
-function commandEndsPlanningPhase(command: string): boolean {
-  return /\bomx\s+state\s+clear\b/.test(command)
-    || (/\bomx\s+state\s+write\b/.test(command) && /["']?active["']?\s*:\s*false\b/.test(command));
+// (`omx state clear`, or an `omx state write` that flips `active` off or writes
+// a terminal planning phase) is still blocked here. Robustly gating standalone
+// deactivation belongs in the backend; this is transport-level defense-in-depth.
+function readStateWriteInputPayload(cwd: string, command: string): Record<string, unknown> | null {
+  if (!/\bomx\s+state\s+write\b/.test(command)) return null;
+
+  const inlineInputMatch = command.match(/--input(?:=|\s+)(?:"([\s\S]*?)"|'([\s\S]*?)'|([^\s;&|]+))/);
+  if (inlineInputMatch) {
+    try {
+      const raw = safeString(inlineInputMatch[1] ?? inlineInputMatch[2] ?? inlineInputMatch[3]);
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? parsed as Record<string, unknown>
+        : null;
+    } catch {
+      return null;
+    }
+  }
+
+  const inputFileMatch = command.match(/--input-file(?:=|\s+)(?:"([^"]+)"|'([^']+)'|([^\s;&|]+))/);
+  if (!inputFileMatch) return null;
+
+  try {
+    const rawPath = safeString(inputFileMatch[1] ?? inputFileMatch[2] ?? inputFileMatch[3]).trim();
+    const raw = readFileSync(resolve(cwd, rawPath), "utf-8");
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isPlanningPhaseDeactivationPayload(payload: Record<string, unknown>): boolean {
+  const mode = safeString(payload.mode).trim().toLowerCase();
+  if (mode !== "deep-interview" && mode !== "ralplan") return false;
+
+  if (payload.active === false) return true;
+
+  const currentPhase = normalizeAutopilotPhase(payload.current_phase ?? payload.currentPhase);
+  if (currentPhase === "complete" || currentPhase === "failed") return true;
+
+  const runOutcome = safeString(payload.run_outcome ?? payload.runOutcome).trim().toLowerCase();
+  if (
+    runOutcome === "finish"
+    || runOutcome === "finished"
+    || runOutcome === "complete"
+    || runOutcome === "completed"
+    || runOutcome === "done"
+    || runOutcome === "blocked_on_user"
+    || runOutcome === "blocked-on-user"
+    || runOutcome === "blocked"
+    || runOutcome === "failed"
+    || runOutcome === "cancelled"
+    || runOutcome === "canceled"
+    || runOutcome === "cancel"
+    || runOutcome === "aborted"
+    || runOutcome === "abort"
+  ) {
+    return true;
+  }
+
+  const lifecycleOutcome = safeString(payload.lifecycle_outcome ?? payload.lifecycleOutcome).trim().toLowerCase();
+  return lifecycleOutcome === "finished"
+    || lifecycleOutcome === "blocked"
+    || lifecycleOutcome === "failed"
+    || lifecycleOutcome === "userinterlude"
+    || lifecycleOutcome === "askuserquestion"
+    || lifecycleOutcome === "ask-user-question";
+}
+
+function commandEndsPlanningPhase(cwd: string, command: string): boolean {
+  if (/\bomx\s+state\s+clear\b/.test(command)) return true;
+  const payload = readStateWriteInputPayload(cwd, command);
+  return payload ? isPlanningPhaseDeactivationPayload(payload) : false;
 }
 
 function isAllowedDeepInterviewBashWrite(cwd: string, command: string): boolean {
-  if (commandEndsPlanningPhase(command)) return false;
+  if (commandEndsPlanningPhase(cwd, command)) return false;
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
   const targets = extractDeepInterviewCommandWriteTargets(command);
-  // A disallowed write target chained alongside an allowed `omx state`/`omx
-  // question` command must not be smuggled through the allowance below.
   if (targets.some((target) => !isAllowedDeepInterviewArtifactPath(cwd, target))) return false;
-  // `omx state` read/write/clear and `omx question` defer to the backend gate;
-  // deactivation is already rejected above.
-  if (/\bomx\s+(?:state\s+(?:read|write|clear)|question)\b/.test(command)) return true;
   return targets.length > 0 && targets.every((target) => isAllowedDeepInterviewArtifactPath(cwd, target));
 }
 
@@ -3695,14 +3760,9 @@ function isAllowedRalplanBashWrite(cwd: string, command: string): boolean {
   if (beadsCommand.present) {
     return beadsCommand.allowed && (targets.length === 0 || hasAllowedTargets);
   }
-  if (commandEndsPlanningPhase(command)) return false;
+  if (commandEndsPlanningPhase(cwd, command)) return false;
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
-  // A disallowed write target chained alongside an allowed `omx state`/`omx
-  // question` command must not be smuggled through the allowance below.
   if (targets.some((target) => !isAllowedRalplanArtifactPath(cwd, target))) return false;
-  // See isAllowedDeepInterviewBashWrite: defer `omx state` mutations to the
-  // gate-enforcing state_write backend (deactivation already rejected above).
-  if (/\bomx\s+(?:state\s+(?:read|write|clear)|question)\b/.test(command)) return true;
   return hasAllowedTargets;
 }
 

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3569,15 +3569,28 @@ function describeImplementationToolBlock(
   return formatPlanningWriteBlockDetail(operationClass, blockedPath, RALPLAN_ALLOWED_WRITE_PREFIXES);
 }
 
+// `omx state` mutations normally route through the gate-enforcing `state_write`
+// backend, so the hook defers to that gate rather than blocking the transport.
+// The backend does NOT gate standalone deep-interview/ralplan *deactivation*,
+// however, so a command that ends the active planning phase from a tool call
+// (`omx state clear`, or an `omx state write` that flips `active` off) is still
+// blocked here. Robustly gating standalone deactivation (and other skip vectors)
+// belongs in the backend; this is transport-level defense-in-depth.
+function commandEndsPlanningPhase(command: string): boolean {
+  return /\bomx\s+state\s+clear\b/.test(command)
+    || (/\bomx\s+state\s+write\b/.test(command) && /["']?active["']?\s*:\s*false\b/.test(command));
+}
+
 function isAllowedDeepInterviewBashWrite(cwd: string, command: string): boolean {
+  if (commandEndsPlanningPhase(command)) return false;
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
-  // `omx state` mutations route through the validated `state_write` backend,
-  // which enforces the Autopilot phase gate (ordering + completion/skip
-  // evidence) for every transport. Defer to that gate here instead of blocking
-  // the transport; raw writes to the protected planning-state files are still
-  // rejected below via isAllowedDeepInterviewArtifactPath.
-  if (/\bomx\s+(?:state\s+(?:read|write|clear)|question)\b/.test(command)) return true;
   const targets = extractDeepInterviewCommandWriteTargets(command);
+  // A disallowed write target chained alongside an allowed `omx state`/`omx
+  // question` command must not be smuggled through the allowance below.
+  if (targets.some((target) => !isAllowedDeepInterviewArtifactPath(cwd, target))) return false;
+  // `omx state` read/write/clear and `omx question` defer to the backend gate;
+  // deactivation is already rejected above.
+  if (/\bomx\s+(?:state\s+(?:read|write|clear)|question)\b/.test(command)) return true;
   return targets.length > 0 && targets.every((target) => isAllowedDeepInterviewArtifactPath(cwd, target));
 }
 
@@ -3682,9 +3695,13 @@ function isAllowedRalplanBashWrite(cwd: string, command: string): boolean {
   if (beadsCommand.present) {
     return beadsCommand.allowed && (targets.length === 0 || hasAllowedTargets);
   }
+  if (commandEndsPlanningPhase(command)) return false;
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
+  // A disallowed write target chained alongside an allowed `omx state`/`omx
+  // question` command must not be smuggled through the allowance below.
+  if (targets.some((target) => !isAllowedRalplanArtifactPath(cwd, target))) return false;
   // See isAllowedDeepInterviewBashWrite: defer `omx state` mutations to the
-  // gate-enforcing state_write backend rather than blocking the CLI transport.
+  // gate-enforcing state_write backend (deactivation already rejected above).
   if (/\bomx\s+(?:state\s+(?:read|write|clear)|question)\b/.test(command)) return true;
   return hasAllowedTargets;
 }


### PR DESCRIPTION
## Summary

Makes Autopilot planning-phase gate enforcement **single-source and transport-agnostic**. The merged #2999/#2996 pair inadvertently inverted the safety posture: the *gate-validated* transition path was blocked during deep-interview/ralplan, while the *gate-bypassing* paths stayed open. This PR fixes that with two coordinated changes, keeps the genuine protection from #2999, and is deadlock-free by construction.

Base: `dev` (on top of #3000).

## The problem (from reviewing #2992–#2999)

The `state_write` backend (`src/state/operations.ts`) already enforces the Autopilot phase gate on **every** write — for both `omx state write` (CLI) and `omx_state` (MCP) — via `canAdvanceAutopilotDeepInterviewToRalplan` / `canAdvanceAutopilotRalplanToUltragoal` (ordering + completion/skip evidence). Against that backdrop:

- **#2999** blocked the **Bash `omx state write|clear`** transport during planning. But the equivalent **MCP** path to the same validated backend stayed open (asymmetry), the block was **redundant** with the backend gate, and it **broke the CLI-first loop**, which must persist `handoff_artifacts`/gate evidence and advance phases via `omx state write`.
- **#2996** added a keyword-handoff phase write, `persistAutopilotSupervisedChildPhaseState` (`src/hooks/keyword-detector.ts`), which writes `current_phase` **directly via `writeFile`, without the gate**. So advancing by emitting `$ralplan` / `$ultragoal` **bypasses** exactly the gate `state_write` enforces.

Net effect: the system blocked the *validated* path and left the *unvalidated* ones (keyword handoff, MCP) open — i.e. `$ralplan` alone could skip the deep-interview gate (a re-opening of #2993 via a different door).

## Changes

### Part A — defer `omx state` mutations to the gate, not the transport
`src/scripts/codex-native-hook.ts`

`isAllowedDeepInterviewBashWrite` / `isAllowedRalplanBashWrite` no longer block `omx state write|clear`; they defer to the gate-enforcing `state_write` backend (identical enforcement for CLI and MCP). The reverted `commandHasDeepInterviewWriteIntent` clause and the "not model-writable" detail message go with it.

**Kept:** the protected-file rule (`isProtectedPlanningStatePath` / `PROTECTED_PLANNING_STATE_FILE_NAMES`) still rejects raw `Write`/`Edit`/Bash-redirects to `autopilot-state.json`, `deep-interview-state.json`, `ralplan-state.json`, `skill-active-state.json` — those bypass the backend gate and are the genuinely unvalidated vector.

### Part B — gate the keyword handoff
`src/hooks/keyword-detector.ts`

`persistAutopilotSupervisedChildPhaseState` now routes its `current_phase` advance through a new `resolveGatedSupervisedChildPhase`, which evaluates the **same** `canAdvance…` gates as `state_write` for the two gated boundaries (deep-interview→ralplan, ralplan→ultragoal). If the gate is not satisfied, the current phase is held (no advance), so a `$child` keyword cannot skip the gate. Non-gated transitions are unaffected.

### Why it can't deadlock
Part A re-allows the gated `omx state write`, so the leader can persist completion/skip evidence during planning; once persisted, the advance gate passes on every transport (CLI, MCP, and now the keyword handoff). Before this PR, a CLI-first/non-MCP loop could only advance by *bypassing* the gate via the keyword path.

## Result
- Every phase-advance transport (CLI, MCP, keyword) enforces the **same** gate.
- Raw-file protection from #2999 preserved.
- CLI/MCP asymmetry and the CLI-first stall removed.

## Out of scope (needs a product decision)
`deep_interview_gate.skip_authorized_by_user` has **no provenance enforcement**: it is read in `src/autopilot/deep-interview-gate.ts` (the only occurrence repo-wide) but never set by trusted code, so a model can set it itself and satisfy `isSkipGate` on any transport. Closing this requires a genuine user-authorization channel (e.g. an `omx question` answer that the model can't fabricate) and a decision on how users authorize a deep-interview skip. Happy to follow up once the direction is set.

## Validation
- `npm run build` green.
- `scripts/__tests__/codex-native-hook.test.js`: **467/467** (the two #2999 tests that asserted the Bash-transport block were updated to assert the corrected behavior — `omx state write` allowed/deferred, protected raw-file writes still blocked).
- New test in `hooks/__tests__/keyword-detector.test.js`: asserts `$ralplan` does **not** advance `current_phase` past an unsatisfied deep-interview gate.
- Pre-existing failures in `state` / `modes` / `autopilot` / `cli` suites **reproduce identically on clean `origin/dev`** (local model-config classification + sandbox PID semantics) and are unrelated to this change.

> Note: an end-to-end Autopilot loop run (with and without MCP) is worth doing before merge — I validated the pieces at unit level but can't drive the live loop here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
