### PR TITLE
[codex] planning-gate coherence follow-up

### DIFF
--- a/docs/planning-gate-regression-3001.md
+++ b/docs/planning-gate-regression-3001.md
@@ -1,0 +1,81 @@
+# PR #3001 planning-gate regression handoff
+
+## Scope
+
+PR #3001 addresses model/tool-originated transport bypasses that could deactivate protected planning state before an explicit execution handoff.
+
+Protected planning state means active `deep-interview` or `ralplan` state, either session-scoped or standalone/global.
+
+This PR keeps the fix at the native-hook transport boundary:
+
+- Bash `omx state write` / `omx state clear` deactivation vectors.
+- Bash `--input` and `--input-file` payloads where planning `--mode` may be supplied outside JSON.
+- Multiple `omx state write` invocations in one Bash command.
+- Decoy arguments before the actual `omx state write` invocation.
+- MCP structured state tools surfaced to PreToolUse as `mcp__omx_state__state_write` and `mcp__omx_state__state_clear`.
+
+This PR intentionally does not introduce new trusted-wrapper/private-helper state APIs and does not make `src/state/operations.ts` the default enforcement layer for this blocker.
+
+## Incident vs defect vs hotfix vs follow-up
+
+| Category | Finding | Handling |
+| --- | --- | --- |
+| Defect | A model-originated Bash command could pass deactivation intent through `omx state write` when `mode` came from CLI `--mode` rather than JSON. | Hotfix in native hook parser: merge `--mode` into parsed `--input` / `--input-file` payload before deactivation classification. |
+| Defect | A Bash command containing multiple `omx state write` invocations could expose only the first payload to the guard. | Hotfix in native hook parser: fail closed when more than one state-write invocation is detected during active protected planning. |
+| Defect | Arguments before the actual `omx state write` invocation could act as parser decoys. | Hotfix in native hook parser: parse the state-write invocation segment, not the whole Bash command. |
+| Defect | MCP structured state tools could bypass the Bash-specific transport guard. | Hotfix in native hook PreToolUse boundaries: block protected planning deactivation through `mcp__omx_state__state_write` and block `mcp__omx_state__state_clear` while protected planning is active. |
+| Incident classification | A reported `planning-gate` tmux behavior involved runtime/build provenance uncertainty. | Treat as observation-only unless exact-pane evidence proves latest PR #3001 code failed. |
+| Architectural follow-up | Backend state-operation authority/provenance is broader than this PR's transport blocker. | Defer. Optional backend refusal belongs only in a maintainer-requested follow-up or explicit Option D branch. |
+
+## Observed evidence
+
+- The previously observed active runtime path `/Users/vp/.omx-runs/run-20260629070147-62db/.omx/runtime/bin/omx` reported `0.18.16-dev-eae4b3988732`, which predates PR #3001 changes.
+- The source worktree referenced by the incident handoff was observed at local `e100206c`, not the later PR head `30dd6520`.
+- The current PR worktree and PR #3001 head were observed at `30dd6520` during planning.
+
+## Inference / incident classification
+
+- Therefore the runtime incident is not, by itself, proof that latest #3001 code failed. Exact-pane evidence is required before making that claim.
+
+## Regression matrix
+
+Required hook regressions:
+
+- Deep-interview and ralplan implementation writes remain blocked while planning is active.
+- `omx state write --input '{..."active":false...}'` is blocked for protected planning modes.
+- `omx state write --input-file <file>` is blocked when the file payload deactivates protected planning.
+- `--mode deep-interview|ralplan` supplied outside JSON is honored for inline and file payloads.
+- CLI `--mode` overrides conflicting JSON mode for deactivation classification.
+- Multiple detected `omx state write` invocations in one Bash command are blocked.
+- A decoy `--input` before the sole actual `omx state write` invocation does not drive classification.
+- `exec` / `command` dispatch builtins do not bypass dynamic payload classification when options like `--`, `-c`, or `-p` precede the executable payload.
+- Safe non-deactivating `omx state write` remains allowed.
+- `mcp__omx_state__state_write` is blocked for protected planning deactivation or terminal lifecycle payloads.
+- Nested MCP `state` payloads are classified with the same effective fields as backend state writes, with the target `mode` preserved.
+- `mcp__omx_state__state_clear` is blocked while session-scoped or standalone protected planning is active.
+- Non-deactivating MCP `state_write` remains allowed.
+- Explicit handoff/completion paths that do not use backend state operations remain green.
+
+## Runtime diagnostics boundary
+
+Diagnostics may report:
+
+- active `omx` executable path/version/build commit;
+- hook/dist path from config when available;
+- inherited `OMX_ROOT`, `OMX_STATE_ROOT`, `OMXBOX_ACTIVE`;
+- root/session pointer owner;
+- exact tmux pane cwd/pid/title/current path;
+- operator recommendation to manually restart/relaunch affected panes after update.
+
+Diagnostics must not:
+
+- kill panes;
+- mutate state;
+- auto-relaunch sessions;
+- claim stale build caused the incident without exact-pane evidence.
+
+## PR wording
+
+Suggested PR update wording:
+
+> This PR addresses the currently known model/tool-originated transport/path bypasses for planning-phase deactivation and keyword/state parity, including Bash `omx state write/clear`, `--input`/`--input-file`, and MCP structured state tools at the native-hook transport boundary. The observed `planning-gate` tmux incident also showed a stale-runtime/provenance dimension: an active runtime reporting `0.18.16-dev-eae4b3988732` predates #3001, so it cannot prove latest #3001 failure without exact-pane evidence. Diagnostics remain observation-only. Broader state-operation provenance beyond the narrow protected planning deactivation blocker remains a follow-up design item.

--- a/src/autopilot/fsm.ts
+++ b/src/autopilot/fsm.ts
@@ -1,4 +1,4 @@
-const AUTOPILOT_CHILD_PHASES = [
+export const AUTOPILOT_CHILD_PHASES = [
   'deep-interview',
   'ralplan',
   'ultragoal',

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -793,6 +793,42 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('does not let a keyword jump ahead past a planning gate (forward skip)', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-skip-ahead-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      await recordSkillActivation({
+        stateDir,
+        text: 'please run $autopilot',
+        sessionId: 'sess-skip',
+        threadId: 'thread-skip',
+        turnId: 'turn-1',
+        nowIso: '2026-02-25T00:00:00.000Z',
+      });
+
+      // `$ultragoal` while in deep-interview skips the ralplan gate entirely; the
+      // keyword handoff must hold the current phase rather than jump ahead.
+      const result = await recordSkillActivation({
+        stateDir,
+        text: 'jump straight to $ultragoal',
+        sessionId: 'sess-skip',
+        threadId: 'thread-skip',
+        turnId: 'turn-2',
+        nowIso: '2026-02-25T00:01:00.000Z',
+      });
+
+      const autopilotState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-skip', 'autopilot-state.json'), 'utf-8'),
+      ) as { current_phase: string };
+      assert.equal(autopilotState.current_phase, 'deep-interview', 'forward skip must be held');
+      // skill-active phase is kept in sync with the held autopilot phase.
+      assert.equal(result?.phase, 'deep-interview');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('seeds dedicated planner routing in Autopilot state when main is cheap', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-planner-routing-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -773,7 +773,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
       // A bare `$ralplan` keyword handoff must not advance current_phase across the
       // deep-interview -> ralplan gate while the gate is unsatisfied. The keyword
       // path now defers to the same gate as the state_write backend.
-      await recordSkillActivation({
+      const denied = await recordSkillActivation({
         stateDir,
         text: 'continue with $ralplan',
         sessionId: 'sess-gate',
@@ -788,6 +788,17 @@ describe('keyword detector skill-active-state lifecycle', () => {
         'deep-interview',
         'keyword handoff must not skip the deep-interview gate',
       );
+
+      // The visible canonical skill-active state must stay aligned with the held
+      // detail phase (no drift to ralplan) — both the returned state and the
+      // persisted skill-active-state.json mirror.
+      assert.equal(denied?.phase, 'deep-interview');
+      assert.deepEqual(denied?.active_skills?.map((entry) => [entry.skill, entry.phase]), [['autopilot', 'deep-interview']]);
+      const canonical = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-gate', SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { phase?: string; active_skills?: Array<{ skill?: string; phase?: string }> };
+      assert.equal(canonical.phase, 'deep-interview');
+      assert.deepEqual(canonical.active_skills?.map((entry) => [entry.skill, entry.phase]), [['autopilot', 'deep-interview']]);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -824,6 +835,56 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(autopilotState.current_phase, 'deep-interview', 'forward skip must be held');
       // skill-active phase is kept in sync with the held autopilot phase.
       assert.equal(result?.phase, 'deep-interview');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not advance or drift canonical state past an unsatisfied ralplan -> ultragoal gate', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-ralplan-gate-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-ralplan-gate';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      // Supervised Autopilot already in ralplan, with no ralplan consensus evidence
+      // (the ralplan -> ultragoal gate is unsatisfied).
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: '$autopilot',
+          phase: 'ralplan',
+          source: 'keyword-detector',
+          session_id: sessionId,
+          active_skills: [{ skill: 'autopilot', phase: 'ralplan', active: true, session_id: sessionId }],
+        }, null, 2),
+      );
+      const autopilotStatePath = join(stateDir, 'sessions', sessionId, 'autopilot-state.json');
+      await writeFile(
+        autopilotStatePath,
+        JSON.stringify({ active: true, mode: 'autopilot', current_phase: 'ralplan', session_id: sessionId }, null, 2),
+      );
+
+      const denied = await recordSkillActivation({
+        stateDir,
+        text: 'advance to $ultragoal',
+        sessionId,
+        threadId: 'thread-ralplan-gate',
+        turnId: 'turn-ralplan-gate',
+        nowIso: '2026-02-25T00:01:00.000Z',
+      });
+
+      const afterAdvance = JSON.parse(await readFile(autopilotStatePath, 'utf-8')) as { current_phase: string };
+      assert.equal(afterAdvance.current_phase, 'ralplan', 'keyword handoff must not skip the ralplan -> ultragoal gate');
+      assert.equal(denied?.phase, 'ralplan');
+      assert.deepEqual(denied?.active_skills?.map((entry) => [entry.skill, entry.phase]), [['autopilot', 'ralplan']]);
+      const canonical = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { phase?: string; active_skills?: Array<{ skill?: string; phase?: string }> };
+      assert.equal(canonical.phase, 'ralplan');
+      assert.deepEqual(canonical.active_skills?.map((entry) => [entry.skill, entry.phase]), [['autopilot', 'ralplan']]);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -890,6 +890,56 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('does not let an implementation-phase keyword skip the code-review gate to ultraqa', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-ultraqa-skip-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-ultraqa-skip';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      // Supervised Autopilot in an implementation phase (ultragoal). The completion
+      // gate requires code-review before ultraqa.
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE),
+        JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'autopilot',
+          keyword: '$autopilot',
+          phase: 'ultragoal',
+          source: 'keyword-detector',
+          session_id: sessionId,
+          active_skills: [{ skill: 'autopilot', phase: 'ultragoal', active: true, session_id: sessionId }],
+        }, null, 2),
+      );
+      const autopilotStatePath = join(stateDir, 'sessions', sessionId, 'autopilot-state.json');
+      await writeFile(
+        autopilotStatePath,
+        JSON.stringify({ active: true, mode: 'autopilot', current_phase: 'ultragoal', session_id: sessionId }, null, 2),
+      );
+
+      const denied = await recordSkillActivation({
+        stateDir,
+        text: 'run $ultraqa now',
+        sessionId,
+        threadId: 'thread-ultraqa-skip',
+        turnId: 'turn-ultraqa-skip',
+        nowIso: '2026-02-25T00:01:00.000Z',
+      });
+
+      const afterAdvance = JSON.parse(await readFile(autopilotStatePath, 'utf-8')) as { current_phase: string };
+      assert.equal(afterAdvance.current_phase, 'ultragoal', 'keyword handoff must not skip the code-review gate');
+      assert.equal(denied?.phase, 'ultragoal');
+      assert.deepEqual(denied?.active_skills?.map((entry) => [entry.skill, entry.phase]), [['autopilot', 'ultragoal']]);
+      const canonical = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), 'utf-8'),
+      ) as { phase?: string; active_skills?: Array<{ skill?: string; phase?: string }> };
+      assert.equal(canonical.phase, 'ultragoal');
+      assert.deepEqual(canonical.active_skills?.map((entry) => [entry.skill, entry.phase]), [['autopilot', 'ultragoal']]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('seeds dedicated planner routing in Autopilot state when main is cheap', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-planner-routing-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -748,6 +748,51 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('does not advance the supervised child phase past an unsatisfied deep-interview gate via keyword handoff', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-supervised-gate-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+
+      // Activate Autopilot: seeds autopilot-state.json at current_phase=deep-interview
+      // with deep_interview_gate.status="required" (gate not satisfied).
+      const activated = await recordSkillActivation({
+        stateDir,
+        text: 'please run $autopilot',
+        sessionId: 'sess-gate',
+        threadId: 'thread-gate',
+        turnId: 'turn-1',
+        nowIso: '2026-02-25T00:00:00.000Z',
+      });
+      assert.equal(activated?.phase, 'deep-interview');
+
+      const autopilotStatePath = join(stateDir, 'sessions', 'sess-gate', 'autopilot-state.json');
+      const beforeAdvance = JSON.parse(await readFile(autopilotStatePath, 'utf-8')) as { current_phase: string };
+      assert.equal(beforeAdvance.current_phase, 'deep-interview');
+
+      // A bare `$ralplan` keyword handoff must not advance current_phase across the
+      // deep-interview -> ralplan gate while the gate is unsatisfied. The keyword
+      // path now defers to the same gate as the state_write backend.
+      await recordSkillActivation({
+        stateDir,
+        text: 'continue with $ralplan',
+        sessionId: 'sess-gate',
+        threadId: 'thread-gate',
+        turnId: 'turn-2',
+        nowIso: '2026-02-25T00:01:00.000Z',
+      });
+
+      const afterAdvance = JSON.parse(await readFile(autopilotStatePath, 'utf-8')) as { current_phase: string };
+      assert.equal(
+        afterAdvance.current_phase,
+        'deep-interview',
+        'keyword handoff must not skip the deep-interview gate',
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('seeds dedicated planner routing in Autopilot state when main is cheap', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autopilot-planner-routing-'));
     const stateDir = join(cwd, '.omx', 'state');

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -866,6 +866,15 @@ describe('keyword detector skill-active-state lifecycle', () => {
         autopilotStatePath,
         JSON.stringify({ active: true, mode: 'autopilot', current_phase: 'ralplan', session_id: sessionId }, null, 2),
       );
+      await writeFile(
+        join(stateDir, 'sessions', sessionId, 'ralplan-state.json'),
+        JSON.stringify({
+          active: true,
+          mode: 'ralplan',
+          current_phase: 'planning',
+          session_id: sessionId,
+        }, null, 2),
+      );
 
       const denied = await recordSkillActivation({
         stateDir,
@@ -880,6 +889,11 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(afterAdvance.current_phase, 'ralplan', 'keyword handoff must not skip the ralplan -> ultragoal gate');
       assert.equal(denied?.phase, 'ralplan');
       assert.deepEqual(denied?.active_skills?.map((entry) => [entry.skill, entry.phase]), [['autopilot', 'ralplan']]);
+      const ralplanState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, 'ralplan-state.json'), 'utf-8'),
+      ) as { active?: boolean; current_phase?: string };
+      assert.equal(ralplanState.active, true, 'blocked gate must not auto-complete ralplan state');
+      assert.equal(ralplanState.current_phase, 'planning', 'blocked gate must not advance ralplan state');
       const canonical = JSON.parse(
         await readFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), 'utf-8'),
       ) as { phase?: string; active_skills?: Array<{ skill?: string; phase?: string }> };

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -48,6 +48,7 @@ import { resolveAutopilotPlannerRouting } from '../autopilot/planner-routing.js'
 import { deriveAutopilotChildPhase, AUTOPILOT_CHILD_PHASES } from '../autopilot/fsm.js';
 import { canAdvanceAutopilotDeepInterviewToRalplan } from '../autopilot/deep-interview-gate.js';
 import { canAdvanceAutopilotRalplanToUltragoal } from '../autopilot/ralplan-gate.js';
+import { validateAutopilotCompletionTransition } from '../autopilot/completion-gate.js';
 
 export interface KeywordMatch {
   keyword: string;
@@ -1101,6 +1102,14 @@ async function resolveGatedSupervisedChildPhase(
   const currentChildPhase = deriveAutopilotChildPhase(existing);
   const heldPhase = safeString(existing.current_phase).trim() || requestedChildSkill;
   const nextState = { ...existing, current_phase: requestedChildSkill };
+
+  // Reuse the same semantic completion-gate the state_write backend enforces, so
+  // the keyword path can't skip it either — e.g. an implementation phase
+  // (ultragoal/rework/team/ralph) may not jump straight to ultraqa; code-review
+  // must run first.
+  if (validateAutopilotCompletionTransition(existing, nextState)) {
+    return heldPhase;
+  }
 
   if (currentChildPhase === 'deep-interview' && requestedChildSkill === 'ralplan') {
     const gate = await canAdvanceAutopilotDeepInterviewToRalplan({

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -45,7 +45,7 @@ import {
 } from '../config/deep-interview.js';
 import { inferTerminalLifecycleOutcome } from '../runtime/run-outcome.js';
 import { resolveAutopilotPlannerRouting } from '../autopilot/planner-routing.js';
-import { deriveAutopilotChildPhase } from '../autopilot/fsm.js';
+import { deriveAutopilotChildPhase, AUTOPILOT_CHILD_PHASES } from '../autopilot/fsm.js';
 import { canAdvanceAutopilotDeepInterviewToRalplan } from '../autopilot/deep-interview-gate.js';
 import { canAdvanceAutopilotRalplanToUltragoal } from '../autopilot/ralplan-gate.js';
 
@@ -1123,9 +1123,31 @@ async function resolveGatedSupervisedChildPhase(
     return gate.allowed ? requestedChildSkill : heldPhase;
   }
 
+  // From a gated planning phase, the only forward advance is the immediate next
+  // gated phase (handled above). A keyword that jumps further ahead would skip a
+  // gate the state_write backend enforces, so hold the current phase.
+  if (
+    (currentChildPhase === 'deep-interview' || currentChildPhase === 'ralplan')
+    && isForwardChildPhaseSkip(currentChildPhase, requestedChildSkill)
+  ) {
+    return heldPhase;
+  }
+
   return requestedChildSkill;
 }
 
+// True when `requestedChildSkill` is a child phase strictly beyond the immediate
+// next phase after `currentChildPhase` in the canonical Autopilot order — i.e. a
+// forward jump that skips at least one phase.
+function isForwardChildPhaseSkip(currentChildPhase: string, requestedChildSkill: string): boolean {
+  const currentIndex = (AUTOPILOT_CHILD_PHASES as readonly string[]).indexOf(currentChildPhase);
+  const requestedIndex = (AUTOPILOT_CHILD_PHASES as readonly string[]).indexOf(requestedChildSkill);
+  return currentIndex >= 0 && requestedIndex > currentIndex + 1;
+}
+
+// Returns the phase actually written to autopilot-state.json (the gate-held
+// phase when an advance was blocked), so callers can keep skill-active-state in
+// sync with it.
 async function persistAutopilotSupervisedChildPhaseState(
   cwd: string,
   stateDir: string,
@@ -1133,7 +1155,7 @@ async function persistAutopilotSupervisedChildPhaseState(
   childSkill: string,
   nowIso: string,
   options: { threadId?: string; turnId?: string } = {},
-): Promise<void> {
+): Promise<string> {
   const { absolutePath } = resolveSeedStateFilePath(stateDir, 'autopilot', sessionId);
   const existingResult = await readJsonStateWithStatus(absolutePath);
   const existing = existingResult.state;
@@ -1170,6 +1192,8 @@ async function persistAutopilotSupervisedChildPhaseState(
     },
     { nowIso },
   ), null, 2));
+
+  return effectivePhase;
 }
 
 async function reconcileAutopilotSupervisedChildModeStates(
@@ -1179,10 +1203,10 @@ async function reconcileAutopilotSupervisedChildModeStates(
   childSkill: string,
   nowIso: string,
   options: { threadId?: string; turnId?: string } = {},
-): Promise<string[]> {
+): Promise<{ completedPaths: string[]; effectivePhase: string }> {
   if (!isTrackedWorkflowMode(childSkill)) {
-    await persistAutopilotSupervisedChildPhaseState(cwd, stateDir, sessionId, childSkill, nowIso, options);
-    return [];
+    const effectivePhase = await persistAutopilotSupervisedChildPhaseState(cwd, stateDir, sessionId, childSkill, nowIso, options);
+    return { completedPaths: [], effectivePhase };
   }
 
   const activeChildModes: TrackedWorkflowMode[] = [];
@@ -1206,8 +1230,8 @@ async function reconcileAutopilotSupervisedChildModeStates(
     sessionId,
     source: 'autopilot-supervised-child',
   });
-  await persistAutopilotSupervisedChildPhaseState(cwd, stateDir, sessionId, childSkill, nowIso, options);
-  return transition.completedPaths;
+  const effectivePhase = await persistAutopilotSupervisedChildPhaseState(cwd, stateDir, sessionId, childSkill, nowIso, options);
+  return { completedPaths: transition.completedPaths, effectivePhase };
 }
 
 function isDeepInterviewRuntimeConfig(value: unknown): value is DeepInterviewRuntimeConfig {
@@ -1402,34 +1426,11 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
     : null;
 
   if (previous?.active === true && previous.skill === 'autopilot' && isAutopilotSupervisedChildSkill(match.skill)) {
-    const nextState: SkillActiveState = {
-      ...previous,
-      version: 1,
-      active: true,
-      updated_at: nowIso,
-      source: 'keyword-detector',
-      session_id: input.sessionId ?? previous.session_id,
-      thread_id: input.threadId ?? previous.thread_id,
-      turn_id: input.turnId ?? previous.turn_id,
-      phase: match.skill,
-      active_skills: listActiveSkills(previous).map((entry) => (
-        entry.skill === 'autopilot'
-          ? {
-              ...entry,
-              phase: match.skill,
-              active: true,
-              updated_at: nowIso,
-              session_id: input.sessionId ?? entry.session_id,
-              thread_id: input.threadId ?? entry.thread_id,
-              turn_id: input.turnId ?? entry.turn_id,
-            }
-          : entry
-      )),
-      supervised_child_keyword: match.keyword,
-      supervised_child_skill: match.skill,
-    };
     try {
-      await reconcileAutopilotSupervisedChildModeStates(
+      // Reconcile first so skill-active phase reflects the gate-held phase the
+      // autopilot detail state actually advanced to (a blocked advance keeps the
+      // current phase).
+      const { effectivePhase } = await reconcileAutopilotSupervisedChildModeStates(
         sourceCwd,
         input.stateDir,
         input.sessionId ?? previous.session_id,
@@ -1437,12 +1438,39 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
         nowIso,
         { threadId: input.threadId, turnId: input.turnId },
       );
+      const nextState: SkillActiveState = {
+        ...previous,
+        version: 1,
+        active: true,
+        updated_at: nowIso,
+        source: 'keyword-detector',
+        session_id: input.sessionId ?? previous.session_id,
+        thread_id: input.threadId ?? previous.thread_id,
+        turn_id: input.turnId ?? previous.turn_id,
+        phase: effectivePhase,
+        active_skills: listActiveSkills(previous).map((entry) => (
+          entry.skill === 'autopilot'
+            ? {
+                ...entry,
+                phase: effectivePhase,
+                active: true,
+                updated_at: nowIso,
+                session_id: input.sessionId ?? entry.session_id,
+                thread_id: input.threadId ?? entry.thread_id,
+                turn_id: input.turnId ?? entry.turn_id,
+              }
+            : entry
+        )),
+        supervised_child_keyword: match.keyword,
+        supervised_child_skill: match.skill,
+      };
       await writeSkillActiveStateCopiesForStateDir(
         input.stateDir,
         nextState,
         input.sessionId,
         selectRootSkillStateCopy(previousRoot, nextState, input.sessionId),
       );
+      return nextState;
     } catch (error) {
       return {
         ...previous,
@@ -1457,7 +1485,6 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
         transition_error: error instanceof Error ? error.message : String(error),
       };
     }
-    return nextState;
   }
 
   if (isTrackedWorkflowMatch) {

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -45,6 +45,9 @@ import {
 } from '../config/deep-interview.js';
 import { inferTerminalLifecycleOutcome } from '../runtime/run-outcome.js';
 import { resolveAutopilotPlannerRouting } from '../autopilot/planner-routing.js';
+import { deriveAutopilotChildPhase } from '../autopilot/fsm.js';
+import { canAdvanceAutopilotDeepInterviewToRalplan } from '../autopilot/deep-interview-gate.js';
+import { canAdvanceAutopilotRalplanToUltragoal } from '../autopilot/ralplan-gate.js';
 
 export interface KeywordMatch {
   keyword: string;
@@ -1081,7 +1084,50 @@ const AUTOPILOT_SUPERVISED_TRACKED_CHILD_SKILLS: TrackedWorkflowMode[] = [
   'ultraqa',
 ];
 
+// Mirror the `state_write` backend: an Autopilot phase advance across a planning
+// gate boundary (deep-interview -> ralplan, ralplan -> ultragoal) must satisfy
+// the same gate regardless of transport. The keyword handoff previously wrote
+// `current_phase` directly here, bypassing the gate that CLI/MCP `state_write`
+// enforces. When the gate is not satisfied we keep the current phase (do not
+// advance) so a `$child` keyword alone cannot skip the gate.
+async function resolveGatedSupervisedChildPhase(
+  cwd: string,
+  stateDir: string,
+  sessionId: string | undefined,
+  existing: Record<string, unknown> | null,
+  requestedChildSkill: string,
+): Promise<string> {
+  if (!existing) return requestedChildSkill;
+  const currentChildPhase = deriveAutopilotChildPhase(existing);
+  const heldPhase = safeString(existing.current_phase).trim() || requestedChildSkill;
+  const nextState = { ...existing, current_phase: requestedChildSkill };
+
+  if (currentChildPhase === 'deep-interview' && requestedChildSkill === 'ralplan') {
+    const gate = await canAdvanceAutopilotDeepInterviewToRalplan({
+      cwd,
+      sessionId,
+      baseStateDir: stateDir,
+      currentState: existing,
+      nextState,
+    });
+    return gate.allowed ? requestedChildSkill : heldPhase;
+  }
+
+  if (currentChildPhase === 'ralplan' && requestedChildSkill === 'ultragoal') {
+    const gate = canAdvanceAutopilotRalplanToUltragoal({
+      cwd,
+      sessionId,
+      currentState: existing,
+      nextState,
+    });
+    return gate.allowed ? requestedChildSkill : heldPhase;
+  }
+
+  return requestedChildSkill;
+}
+
 async function persistAutopilotSupervisedChildPhaseState(
+  cwd: string,
   stateDir: string,
   sessionId: string | undefined,
   childSkill: string,
@@ -1100,6 +1146,14 @@ async function persistAutopilotSupervisedChildPhaseState(
     throw new Error(`Cannot advance supervised Autopilot child phase: expected autopilot detail state, found ${existingMode || 'unknown'}`);
   }
 
+  const effectivePhase = await resolveGatedSupervisedChildPhase(
+    cwd,
+    stateDir,
+    sessionId,
+    existing,
+    childSkill,
+  );
+
   await mkdir(dirname(absolutePath), { recursive: true });
   await writeFile(absolutePath, JSON.stringify(withModeRuntimeContext(
     existing ?? {},
@@ -1107,7 +1161,7 @@ async function persistAutopilotSupervisedChildPhaseState(
       ...(existing ?? {}),
       active: true,
       mode: 'autopilot',
-      current_phase: childSkill,
+      current_phase: effectivePhase,
       started_at: safeString(existing?.started_at).trim() || nowIso,
       updated_at: nowIso,
       session_id: (sessionId ?? safeString(existing?.session_id).trim()) || undefined,
@@ -1127,7 +1181,7 @@ async function reconcileAutopilotSupervisedChildModeStates(
   options: { threadId?: string; turnId?: string } = {},
 ): Promise<string[]> {
   if (!isTrackedWorkflowMode(childSkill)) {
-    await persistAutopilotSupervisedChildPhaseState(stateDir, sessionId, childSkill, nowIso, options);
+    await persistAutopilotSupervisedChildPhaseState(cwd, stateDir, sessionId, childSkill, nowIso, options);
     return [];
   }
 
@@ -1152,7 +1206,7 @@ async function reconcileAutopilotSupervisedChildModeStates(
     sessionId,
     source: 'autopilot-supervised-child',
   });
-  await persistAutopilotSupervisedChildPhaseState(stateDir, sessionId, childSkill, nowIso, options);
+  await persistAutopilotSupervisedChildPhaseState(cwd, stateDir, sessionId, childSkill, nowIso, options);
   return transition.completedPaths;
 }
 

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -1157,6 +1157,35 @@ function isForwardChildPhaseSkip(currentChildPhase: string, requestedChildSkill:
 // Returns the phase actually written to autopilot-state.json (the gate-held
 // phase when an advance was blocked), so callers can keep skill-active-state in
 // sync with it.
+async function resolveAutopilotSupervisedChildPhaseState(
+  cwd: string,
+  stateDir: string,
+  sessionId: string | undefined,
+  childSkill: string,
+  nowIso: string,
+  options: { threadId?: string; turnId?: string } = {},
+): Promise<string> {
+  const { absolutePath } = resolveSeedStateFilePath(stateDir, 'autopilot', sessionId);
+  const existingResult = await readJsonStateWithStatus(absolutePath);
+  const existing = existingResult.state;
+  const existingMode = safeString(existing?.mode).trim();
+
+  if (existingResult.status === 'malformed') {
+    throw new Error('Cannot advance supervised Autopilot child phase: autopilot detail state is malformed');
+  }
+  if (existing && existingMode !== 'autopilot') {
+    throw new Error(`Cannot advance supervised Autopilot child phase: expected autopilot detail state, found ${existingMode || 'unknown'}`);
+  }
+
+  return resolveGatedSupervisedChildPhase(
+    cwd,
+    stateDir,
+    sessionId,
+    existing,
+    childSkill,
+  );
+}
+
 async function persistAutopilotSupervisedChildPhaseState(
   cwd: string,
   stateDir: string,
@@ -1218,6 +1247,11 @@ async function reconcileAutopilotSupervisedChildModeStates(
     return { completedPaths: [], effectivePhase };
   }
 
+  const effectivePhase = await resolveAutopilotSupervisedChildPhaseState(cwd, stateDir, sessionId, childSkill, nowIso, options);
+  if (effectivePhase !== childSkill) {
+    return { completedPaths: [], effectivePhase };
+  }
+
   const activeChildModes: TrackedWorkflowMode[] = [];
   for (const mode of AUTOPILOT_SUPERVISED_TRACKED_CHILD_SKILLS) {
     const candidatePaths = [
@@ -1239,7 +1273,7 @@ async function reconcileAutopilotSupervisedChildModeStates(
     sessionId,
     source: 'autopilot-supervised-child',
   });
-  const effectivePhase = await persistAutopilotSupervisedChildPhaseState(cwd, stateDir, sessionId, childSkill, nowIso, options);
+  await persistAutopilotSupervisedChildPhaseState(cwd, stateDir, sessionId, childSkill, nowIso, options);
   return { completedPaths: transition.completedPaths, effectivePhase };
 }
 

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -1162,8 +1162,6 @@ async function resolveAutopilotSupervisedChildPhaseState(
   stateDir: string,
   sessionId: string | undefined,
   childSkill: string,
-  nowIso: string,
-  options: { threadId?: string; turnId?: string } = {},
 ): Promise<string> {
   const { absolutePath } = resolveSeedStateFilePath(stateDir, 'autopilot', sessionId);
   const existingResult = await readJsonStateWithStatus(absolutePath);
@@ -1247,7 +1245,7 @@ async function reconcileAutopilotSupervisedChildModeStates(
     return { completedPaths: [], effectivePhase };
   }
 
-  const effectivePhase = await resolveAutopilotSupervisedChildPhaseState(cwd, stateDir, sessionId, childSkill, nowIso, options);
+  const effectivePhase = await resolveAutopilotSupervisedChildPhaseState(cwd, stateDir, sessionId, childSkill);
   if (effectivePhase !== childSkill) {
     return { completedPaths: [], effectivePhase };
   }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -6791,10 +6791,9 @@ exit 0
         );
       }
 
-      // `omx state write` routes through the validated state_write backend, which
-      // enforces the Autopilot phase gate for every transport. The hook defers to
-      // that gate rather than blocking the CLI transport (raw writes to the
-      // protected state files above stay blocked).
+      // A non-deactivating `omx state write` routes through the validated
+      // state_write backend (which enforces the Autopilot phase gate for every
+      // transport), so the hook defers rather than blocking the CLI transport.
       const allowedStateCliMutation = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",
@@ -6802,11 +6801,55 @@ exit 0
           session_id: "sess-di-artifact",
           tool_name: "Bash",
           tool_use_id: "tool-di-state-cli-write",
-          tool_input: { command: "omx state write --input '{\"mode\":\"deep-interview\",\"active\":false}' --json" },
+          tool_input: { command: "omx state write --input '{\"mode\":\"autopilot\",\"current_phase\":\"ralplan\"}' --json" },
         },
         { cwd },
       );
       assert.equal(allowedStateCliMutation.outputJson, null);
+
+      // A deactivating `omx state write` (or `omx state clear`) ends the planning
+      // phase, which the backend does not gate for standalone modes; the hook
+      // rejects these deactivation vectors at the transport boundary.
+      const blockedStateDeactivation = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-deactivate",
+          tool_input: { command: "omx state write --input '{\"mode\":\"deep-interview\",\"active\":false}' --json" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedStateDeactivation.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedStateClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-clear",
+          tool_input: { command: "omx state clear --json" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedStateClear.outputJson as { decision?: string } | null)?.decision, "block");
+
+      // An implementation write smuggled alongside an allowed `omx state` command
+      // must not be short-circuited through the allowance.
+      const blockedChainedWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-chained",
+          tool_input: { command: "printf 'x' > src/evil.ts && omx state read --json" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedChainedWrite.outputJson as { decision?: string } | null)?.decision, "block");
 
       const allowedStateRead = await dispatchCodexNativeHook(
         {
@@ -7257,13 +7300,19 @@ exit 0
         );
       }
 
-      // `omx state` mutations defer to the gate-enforcing state_write backend
-      // (same enforcement for CLI and MCP); the hook no longer blocks the
-      // transport. Raw writes to the protected state files stay blocked above.
+      // A non-deactivating `omx state write` defers to the gate-enforcing
+      // state_write backend (same enforcement for CLI and MCP).
       const allowedStateCliMutation = await preToolUse("Bash", "tool-ralplan-state-cli-write", {
-        command: "omx state clear --json",
+        command: "omx state write --input '{\"mode\":\"autopilot\",\"current_phase\":\"ultragoal\"}' --json",
       });
       assert.equal(allowedStateCliMutation.outputJson, null);
+
+      // Deactivation vectors (`omx state clear`, `active:false`) are still
+      // rejected at the transport boundary.
+      const blockedStateClear = await preToolUse("Bash", "tool-ralplan-state-cli-clear", {
+        command: "omx state clear --json",
+      });
+      assert.equal((blockedStateClear.outputJson as { decision?: string } | null)?.decision, "block");
 
       const allowedPatchAdd = await preToolUse("apply_patch", "tool-ralplan-patch-add", {
         input: "*** Begin Patch\n*** Add File: .omx/plans/issue-2863.md\n+# Plan\n*** End Patch\n",

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -6807,6 +6807,21 @@ exit 0
       );
       assert.equal(allowedStateCliMutation.outputJson, null);
 
+      const allowedStateInputFile = join(cwd, "allowed-state-input.json");
+      await writeJson(allowedStateInputFile, { mode: "deep-interview", current_phase: "intent-first", active: true });
+      const allowedStateInputFileMutation = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-input-file-allowed",
+          tool_input: { command: `omx state write --input-file ${allowedStateInputFile} --json` },
+        },
+        { cwd },
+      );
+      assert.equal(allowedStateInputFileMutation.outputJson, null);
+
       // A deactivating `omx state write` (or `omx state clear`) ends the planning
       // phase, which the backend does not gate for standalone modes; the hook
       // rejects these deactivation vectors at the transport boundary.
@@ -6822,6 +6837,21 @@ exit 0
         { cwd },
       );
       assert.equal((blockedStateDeactivation.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedStateInputFile = join(cwd, "blocked-state-input.json");
+      await writeJson(blockedStateInputFile, { mode: "deep-interview", active: false });
+      const blockedStateDeactivationFile = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-input-file-blocked",
+          tool_input: { command: `omx state write --input-file ${blockedStateInputFile} --json` },
+        },
+        { cwd },
+      );
+      assert.equal((blockedStateDeactivationFile.outputJson as { decision?: string } | null)?.decision, "block");
 
       const blockedStateClear = await dispatchCodexNativeHook(
         {
@@ -6876,6 +6906,62 @@ exit 0
         { cwd },
       );
       assert.equal((blockedBash.outputJson as { decision?: string } | null)?.decision, "block");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks deactivating ralplan state writes from --input-file while allowing non-deactivating ones", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-ralplan-state-input-file-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionDir = join(stateDir, "sessions", "sess-ralplan-input-file");
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: "sess-ralplan-input-file", cwd });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "ralplan",
+        phase: "planning",
+        session_id: "sess-ralplan-input-file",
+        active_skills: [{ skill: "ralplan", phase: "planning", active: true, session_id: "sess-ralplan-input-file" }],
+      });
+      await writeJson(join(sessionDir, "ralplan-state.json"), {
+        active: true,
+        mode: "ralplan",
+        current_phase: "critic-review",
+        session_id: "sess-ralplan-input-file",
+      });
+
+      const allowedPayload = join(cwd, "ralplan-allowed-state.json");
+      await writeJson(allowedPayload, { mode: "ralplan", current_phase: "critic-review", active: true });
+      const allowed = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-ralplan-input-file",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-state-input-file-allowed",
+          tool_input: { command: `omx state write --input-file ${allowedPayload} --json` },
+        },
+        { cwd },
+      );
+      assert.equal(allowed.outputJson, null);
+
+      const blockedPayload = join(cwd, "ralplan-blocked-state.json");
+      await writeJson(blockedPayload, { mode: "ralplan", current_phase: "complete" });
+      const blocked = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-ralplan-input-file",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-state-input-file-blocked",
+          tool_input: { command: `omx state write --input-file ${blockedPayload} --json` },
+        },
+        { cwd },
+      );
+      assert.equal((blocked.outputJson as { decision?: string } | null)?.decision, "block");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -6791,7 +6791,11 @@ exit 0
         );
       }
 
-      const blockedStateCliMutation = await dispatchCodexNativeHook(
+      // `omx state write` routes through the validated state_write backend, which
+      // enforces the Autopilot phase gate for every transport. The hook defers to
+      // that gate rather than blocking the CLI transport (raw writes to the
+      // protected state files above stay blocked).
+      const allowedStateCliMutation = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",
           cwd,
@@ -6802,7 +6806,7 @@ exit 0
         },
         { cwd },
       );
-      assert.equal((blockedStateCliMutation.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal(allowedStateCliMutation.outputJson, null);
 
       const allowedStateRead = await dispatchCodexNativeHook(
         {
@@ -7253,14 +7257,13 @@ exit 0
         );
       }
 
-      const blockedStateCliMutation = await preToolUse("Bash", "tool-ralplan-state-cli-write", {
+      // `omx state` mutations defer to the gate-enforcing state_write backend
+      // (same enforcement for CLI and MCP); the hook no longer blocks the
+      // transport. Raw writes to the protected state files stay blocked above.
+      const allowedStateCliMutation = await preToolUse("Bash", "tool-ralplan-state-cli-write", {
         command: "omx state clear --json",
       });
-      assert.equal((blockedStateCliMutation.outputJson as { decision?: string } | null)?.decision, "block");
-      assert.match(
-        String((blockedStateCliMutation.outputJson as { reason?: string } | null)?.reason ?? ""),
-        /omx state mutation is not model-writable/,
-      );
+      assert.equal(allowedStateCliMutation.outputJson, null);
 
       const allowedPatchAdd = await preToolUse("apply_patch", "tool-ralplan-patch-add", {
         input: "*** Begin Patch\n*** Add File: .omx/plans/issue-2863.md\n+# Plan\n*** End Patch\n",

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7152,6 +7152,47 @@ exit 0
       );
       assert.equal((blockedUnquotedHeredocHyphenDelimiter.outputJson as { decision?: string } | null)?.decision, "block");
 
+      const blockedEscapedNewlineStateClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-escaped-newline-clear",
+          tool_input: { command: "omx \\\nstate \\\nclear --json" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedEscapedNewlineStateClear.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedEscapedNewlineStateWriteInput = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-escaped-newline-write-input",
+          tool_input: { command: "omx state write \\\n--mode deep-interview \\\n--input '{\\\"active\\\":false}' --json" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedEscapedNewlineStateWriteInput.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const escapedNewlineInputFile = join(cwd, "deep-interview-escaped-newline-state.json");
+      await writeJson(escapedNewlineInputFile, { mode: "ralplan", active: false });
+      const blockedEscapedNewlineStateWriteInputFile = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-escaped-newline-write-input-file",
+          tool_input: { command: `omx state write \\\n--mode ralplan \\\n--input-file ${escapedNewlineInputFile} --json` },
+        },
+        { cwd },
+      );
+      assert.equal((blockedEscapedNewlineStateWriteInputFile.outputJson as { decision?: string } | null)?.decision, "block");
+
       const blockedShellStdinHeredoc = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -6807,6 +6807,19 @@ exit 0
       );
       assert.equal(allowedStateCliMutation.outputJson, null);
 
+      const allowedQuotedModeMentionInPayload = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-mode-mention-in-json",
+          tool_input: { command: "omx state write --input '{\"mode\":\"ralph\",\"note\":\"--mode deep-interview\",\"active\":false}' --json" },
+        },
+        { cwd },
+      );
+      assert.equal(allowedQuotedModeMentionInPayload.outputJson, null);
+
       const allowedStateInputFile = join(cwd, "allowed-state-input.json");
       await writeJson(allowedStateInputFile, { mode: "deep-interview", current_phase: "intent-first", active: true });
       const allowedStateInputFileMutation = await dispatchCodexNativeHook(
@@ -6853,6 +6866,199 @@ exit 0
       );
       assert.equal((blockedStateDeactivationFile.outputJson as { decision?: string } | null)?.decision, "block");
 
+      const blockedModeFlagDeactivation = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-mode-flag-deactivate",
+          tool_input: { command: "omx state write --mode deep-interview --input '{\"active\":false}' --json" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedModeFlagDeactivation.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const conflictingModeFlagPayload = join(cwd, "conflicting-mode-flag-state.json");
+      await writeJson(conflictingModeFlagPayload, { mode: "ralph", active: false });
+      const blockedModeFlagFileDeactivation = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-mode-flag-file-deactivate",
+          tool_input: { command: `omx state write --mode deep-interview --input-file ${conflictingModeFlagPayload} --json` },
+        },
+        { cwd },
+      );
+      assert.equal((blockedModeFlagFileDeactivation.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedRepeatedModeFlagDeactivation = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-repeated-mode-flag-deactivate",
+          tool_input: { command: "omx state write --mode ralph --mode deep-interview --input '{\"active\":false}' --json" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedRepeatedModeFlagDeactivation.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedRepeatedInputDeactivation = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-repeated-input-deactivate",
+          tool_input: {
+            command:
+              "omx state write --input '{\"mode\":\"deep-interview\",\"active\":true}' "
+              + "--input '{\"mode\":\"deep-interview\",\"active\":false}' --json",
+          },
+        },
+        { cwd },
+      );
+      assert.equal((blockedRepeatedInputDeactivation.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const repeatedInputFileSafe = join(cwd, "repeated-input-file-safe.json");
+      const repeatedInputFileBlocked = join(cwd, "repeated-input-file-blocked.json");
+      await writeJson(repeatedInputFileSafe, { mode: "deep-interview", current_phase: "intent-first", active: true });
+      await writeJson(repeatedInputFileBlocked, { mode: "deep-interview", active: false });
+      const blockedRepeatedInputFileDeactivation = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-repeated-input-file-deactivate",
+          tool_input: { command: `omx state write --input-file ${repeatedInputFileSafe} --input-file ${repeatedInputFileBlocked} --json` },
+        },
+        { cwd },
+      );
+      assert.equal((blockedRepeatedInputFileDeactivation.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedNestedStateDeactivation = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-nested-state-deactivate",
+          tool_input: { command: "omx state write --mode deep-interview --input '{\"state\":{\"active\":false}}' --json" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedNestedStateDeactivation.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedMultipleStateWrites = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-multiple-writes",
+          tool_input: {
+            command:
+              "omx state write --input '{\"mode\":\"deep-interview\",\"active\":true}' --json && "
+              + "omx state write --input '{\"mode\":\"deep-interview\",\"active\":false}' --json",
+          },
+        },
+        { cwd },
+      );
+      assert.equal((blockedMultipleStateWrites.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const allowedDecoyBeforeStateWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-decoy-before-real-write",
+          tool_input: {
+            command:
+              "printf '%s\\n' \"--input '{\\\"mode\\\":\\\"deep-interview\\\",\\\"active\\\":false}'\" && "
+              + "omx state write --input '{\"mode\":\"deep-interview\",\"active\":true}' --json",
+          },
+        },
+        { cwd },
+      );
+      assert.equal(allowedDecoyBeforeStateWrite.outputJson, null);
+
+      const blockedFileWriteWithLaterSafeDecoy = join(cwd, "blocked-file-before-later-decoy.json");
+      await writeJson(blockedFileWriteWithLaterSafeDecoy, { mode: "deep-interview", active: false });
+      const blockedSegmentedStateWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-bounded-segment",
+          tool_input: {
+            command:
+              `omx state write --input-file ${blockedFileWriteWithLaterSafeDecoy} --json && `
+              + "printf '%s\\n' \"--input '{\\\"mode\\\":\\\"deep-interview\\\",\\\"active\\\":true}'\"",
+          },
+        },
+        { cwd },
+      );
+      assert.equal((blockedSegmentedStateWrite.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const allowedMcpStateWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "mcp__omx_state__state_write",
+          tool_use_id: "tool-di-mcp-state-write-allowed",
+          tool_input: { mode: "deep-interview", current_phase: "intent-first", active: true },
+        },
+        { cwd },
+      );
+      assert.equal(allowedMcpStateWrite.outputJson, null);
+
+      const blockedMcpStateWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "mcp__omx_state__state_write",
+          tool_use_id: "tool-di-mcp-state-write-deactivate",
+          tool_input: { mode: "deep-interview", active: false },
+        },
+        { cwd },
+      );
+      assert.equal((blockedMcpStateWrite.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedNestedMcpStateWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "mcp__omx_state__state_write",
+          tool_use_id: "tool-di-mcp-state-write-nested-deactivate",
+          tool_input: { mode: "deep-interview", state: { active: false } },
+        },
+        { cwd },
+      );
+      assert.equal((blockedNestedMcpStateWrite.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedMcpStateClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "mcp__omx_state__state_clear",
+          tool_use_id: "tool-di-mcp-state-clear",
+          tool_input: { mode: "deep-interview" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedMcpStateClear.outputJson as { decision?: string } | null)?.decision, "block");
+
       const blockedStateClear = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",
@@ -6893,6 +7099,487 @@ exit 0
         { cwd },
       );
       assert.equal(allowedStateRead.outputJson, null);
+
+      const allowedQuotedStateWriteMention = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-quoted-mention",
+          tool_input: { command: "printf '%s\\n' \"omx state write --input '{\\\"mode\\\":\\\"deep-interview\\\",\\\"active\\\":false}'\"" },
+        },
+        { cwd },
+      );
+      assert.equal(allowedQuotedStateWriteMention.outputJson, null);
+
+      const allowedHeredocStateWriteMention = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-heredoc-mention",
+          tool_input: { command: "cat > .omx/context/state-example.md <<'EOF'\nomx state write --input '{\"mode\":\"deep-interview\",\"active\":false}'\nEOF" },
+        },
+        { cwd },
+      );
+      assert.equal(allowedHeredocStateWriteMention.outputJson, null);
+
+      const blockedUnquotedHeredocSubstitution = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-unquoted-heredoc-substitution",
+          tool_input: { command: "cat > .omx/context/state-example.md <<EOF\n$(omx state clear --json)\nEOF" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedUnquotedHeredocSubstitution.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedUnquotedHeredocHyphenDelimiter = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-unquoted-heredoc-hyphen-delimiter",
+          tool_input: { command: "cat > .omx/context/state-example.md <<EOF-1\nsafe\nEOF-1\nomx state clear --json" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedUnquotedHeredocHyphenDelimiter.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedShellStdinHeredoc = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-shell-stdin-heredoc",
+          tool_input: { command: "bash <<'EOF'\nomx state clear --json\nEOF" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedShellStdinHeredoc.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedDotProcessSubstitution = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-dot-process-substitution",
+          tool_input: { command: ". <(printf 'omx state clear --json')" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedDotProcessSubstitution.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedBashProcessSubstitution = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-bash-process-substitution",
+          tool_input: { command: "bash <(printf 'omx state clear --json')" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedBashProcessSubstitution.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedQuotedCommandSubstitutionClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-quoted-substitution-clear",
+          tool_input: { command: "echo \"$(omx state clear --json)\"" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedQuotedCommandSubstitutionClear.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedQuotedCommandSubstitutionWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-quoted-substitution-write",
+          tool_input: { command: "echo \"$(omx state write --input '{\\\"mode\\\":\\\"deep-interview\\\",\\\"active\\\":false}' --json)\"" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedQuotedCommandSubstitutionWrite.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedQuotedBacktickSubstitutionClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-quoted-backtick-clear",
+          tool_input: { command: "echo \"`omx state clear --json`\"" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedQuotedBacktickSubstitutionClear.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedRawNestedCommandSubstitutionClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-raw-nested-substitution-clear",
+          tool_input: { command: "echo $(bash -c 'omx state clear --json')" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedRawNestedCommandSubstitutionClear.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedRawNestedEvalSubstitutionClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-raw-nested-eval-substitution-clear",
+          tool_input: { command: "echo $(eval 'omx state clear --json')" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedRawNestedEvalSubstitutionClear.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedRawNestedBacktickClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-raw-nested-backtick-clear",
+          tool_input: { command: "echo `bash -c 'omx state clear --json'`" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedRawNestedBacktickClear.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedBacktickSubstitutionWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-backtick-write",
+          tool_input: { command: "echo `omx state write --input '{\"mode\":\"deep-interview\",\"active\":false}' --json`" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedBacktickSubstitutionWrite.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedNestedBashClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-nested-bash-clear",
+          tool_input: { command: "bash -c \"omx state clear --json\"" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedNestedBashClear.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedNestedShWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-nested-sh-write",
+          tool_input: { command: "sh -c \"omx state write --mode deep-interview --input '{\\\"active\\\":false}' --json\"" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedNestedShWrite.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedPathQualifiedBashClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-path-bash-clear",
+          tool_input: { command: "/bin/bash -c \"omx state clear --json\"" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedPathQualifiedBashClear.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedLoginBashClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-login-bash-clear",
+          tool_input: { command: "bash -lc \"omx state clear --json\"" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedLoginBashClear.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedDashShellClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-dash-clear",
+          tool_input: { command: "dash -c \"omx state clear --json\"" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedDashShellClear.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedRcfileBashClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-rcfile-bash-clear",
+          tool_input: { command: "bash --rcfile /tmp/empty -c \"omx state clear --json\"" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedRcfileBashClear.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedShellOptionValueBeforeCommandString = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-shell-option-value-before-c",
+          tool_input: { command: "bash -o pipefail -c \"omx state clear --json\"" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedShellOptionValueBeforeCommandString.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedEvalStateClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-eval-clear",
+          tool_input: { command: "eval \"omx state clear --json\"" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedEvalStateClear.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedDynamicEvalStateClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-dynamic-eval-clear",
+          tool_input: { command: "payload='omx state clear --json'; eval \"$payload\"" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedDynamicEvalStateClear.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedDynamicShellStateWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-dynamic-shell-write",
+          tool_input: { command: "payload='omx state write --mode deep-interview --input \"{\\\"active\\\":false}\" --json'; bash -c \"$payload\"" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedDynamicShellStateWrite.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedDynamicTopLevelPayloadCommand = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-dynamic-top-level-payload",
+          tool_input: { command: "payload='omx state clear --json'; $payload" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedDynamicTopLevelPayloadCommand.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedExecPayloadCommand = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-exec-payload",
+          tool_input: { command: "payload='omx state clear --json'; exec $payload" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedExecPayloadCommand.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedCommandPayloadCommand = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-command-payload",
+          tool_input: { command: "payload='omx state clear --json'; command $payload" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedCommandPayloadCommand.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedExecDashDashPayloadCommand = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-exec-dashdash-payload",
+          tool_input: { command: "payload='omx state clear --json'; exec -- $payload" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedExecDashDashPayloadCommand.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedExecOptionPayloadCommand = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-exec-option-payload",
+          tool_input: { command: "payload='omx state clear --json'; exec -c $payload" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedExecOptionPayloadCommand.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedCommandDashDashPayloadCommand = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-command-dashdash-payload",
+          tool_input: { command: "payload='omx state clear --json'; command -- $payload" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedCommandDashDashPayloadCommand.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedCommandOptionPayloadCommand = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-command-option-payload",
+          tool_input: { command: "payload='omx state clear --json'; command -p $payload" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedCommandOptionPayloadCommand.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedDynamicShellSubstitutionPayload = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-dynamic-shell-substitution",
+          tool_input: { command: "bash -c \"$(printf 'omx state clear --json')\"" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedDynamicShellSubstitutionPayload.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedDynamicEvalBacktickPayload = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-dynamic-eval-backtick",
+          tool_input: { command: "eval \"`printf 'omx state clear --json'`\"" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedDynamicEvalBacktickPayload.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const allowedNestedShellSafeLiteral = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-nested-shell-safe-literal",
+          tool_input: { command: "bash -c \"printf safe\"" },
+        },
+        { cwd },
+      );
+      assert.equal(allowedNestedShellSafeLiteral.outputJson, null);
+
+      const allowedQuotedProcessSubstitutionLiteral = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-quoted-process-substitution-literal",
+          tool_input: { command: "bash -c \"printf '<(safe)'\"" },
+        },
+        { cwd },
+      );
+      assert.equal(allowedQuotedProcessSubstitutionLiteral.outputJson, null);
+
+      const allowedQuotedNestedShellMention = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-nested-shell-mention",
+          tool_input: { command: "printf '%s\\n' 'bash -c \"omx state clear --json\"'" },
+        },
+        { cwd },
+      );
+      assert.equal(allowedQuotedNestedShellMention.outputJson, null);
+
+      const allowedQuotedLiteralAfterSubstitution = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-quoted-literal-after-substitution",
+          tool_input: { command: "echo \"$(printf safe) omx state write --input '{\\\"mode\\\":\\\"deep-interview\\\",\\\"active\\\":false}'\"" },
+        },
+        { cwd },
+      );
+      assert.equal(allowedQuotedLiteralAfterSubstitution.outputJson, null);
 
       const blockedBash = await dispatchCodexNativeHook(
         {
@@ -6962,6 +7649,142 @@ exit 0
         { cwd },
       );
       assert.equal((blocked.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedModeFlagTerminal = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-ralplan-input-file",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-state-mode-flag-terminal",
+          tool_input: { command: "omx state write --mode ralplan --input '{\"current_phase\":\"complete\"}' --json" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedModeFlagTerminal.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const allowedModeFlagSafe = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-ralplan-input-file",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-state-mode-flag-safe",
+          tool_input: { command: "omx state write --mode ralplan --input '{\"current_phase\":\"critic-review\",\"active\":true}' --json" },
+        },
+        { cwd },
+      );
+      assert.equal(allowedModeFlagSafe.outputJson, null);
+
+      const blockedRalplanMcpStateWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-ralplan-input-file",
+          tool_name: "mcp__omx_state__state_write",
+          tool_use_id: "tool-ralplan-mcp-state-write-terminal",
+          tool_input: { mode: "ralplan", lifecycle_outcome: "finished" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedRalplanMcpStateWrite.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedNestedRalplanMcpStateWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-ralplan-input-file",
+          tool_name: "mcp__omx_state__state_write",
+          tool_use_id: "tool-ralplan-mcp-state-write-nested-terminal",
+          tool_input: { mode: "ralplan", state: { current_phase: "complete" } },
+        },
+        { cwd },
+      );
+      assert.equal((blockedNestedRalplanMcpStateWrite.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const allowedNestedRalplanMcpStateWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-ralplan-input-file",
+          tool_name: "mcp__omx_state__state_write",
+          tool_use_id: "tool-ralplan-mcp-state-write-nested-safe",
+          tool_input: { mode: "ralplan", state: { current_phase: "critic-review", active: true } },
+        },
+        { cwd },
+      );
+      assert.equal(allowedNestedRalplanMcpStateWrite.outputJson, null);
+
+      const blockedRalplanMcpStateClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-ralplan-input-file",
+          tool_name: "mcp__omx_state__state_clear",
+          tool_use_id: "tool-ralplan-mcp-state-clear",
+          tool_input: { mode: "ralplan" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedRalplanMcpStateClear.outputJson as { decision?: string } | null)?.decision, "block");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks MCP state_clear for standalone protected planning modes", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-standalone-mcp-clear-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(stateDir, { recursive: true });
+
+      await writeJson(join(stateDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "deep-interview",
+        phase: "planning",
+        active_skills: [{ skill: "deep-interview", phase: "planning", active: true }],
+      });
+      await writeJson(join(stateDir, "deep-interview-state.json"), {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+      });
+      const blockedDeepInterviewClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "mcp__omx_state__state_clear",
+          tool_use_id: "tool-standalone-di-mcp-clear",
+          tool_input: { mode: "deep-interview" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedDeepInterviewClear.outputJson as { decision?: string } | null)?.decision, "block");
+
+      await writeJson(join(stateDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "ralplan",
+        phase: "planning",
+        active_skills: [{ skill: "ralplan", phase: "planning", active: true }],
+      });
+      await writeJson(join(stateDir, "ralplan-state.json"), {
+        active: true,
+        mode: "ralplan",
+        current_phase: "critic-review",
+      });
+      const blockedRalplanClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          tool_name: "mcp__omx_state__state_clear",
+          tool_use_id: "tool-standalone-ralplan-mcp-clear",
+          tool_input: { mode: "ralplan" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedRalplanClear.outputJson as { decision?: string } | null)?.decision, "block");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -17344,6 +18167,32 @@ exit 0
       assert.equal(result.outputJson?.decision, "block");
       assert.match(String(result.outputJson?.reason ?? ""), /live root session pointer/i);
       assert.match(String(result.outputJson?.reason ?? ""), /failing closed/i);
+
+      const blockedMcpStateClear = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "019e-ralplan-live-root-unresolved-current",
+          thread_id: "thread-ralplan-live-root-conflict",
+          tool_name: "mcp__omx_state__state_clear",
+          tool_input: { mode: "ralplan" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedMcpStateClear.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedMcpStateWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "019e-ralplan-live-root-unresolved-current",
+          thread_id: "thread-ralplan-live-root-conflict",
+          tool_name: "mcp__omx_state__state_write",
+          tool_input: { mode: "ralplan", active: false },
+        },
+        { cwd },
+      );
+      assert.equal((blockedMcpStateWrite.outputJson as { decision?: string } | null)?.decision, "block");
     } finally {
       await rm(cwd, { recursive: true, force: true });
       await rm(ownerCwd, { recursive: true, force: true });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -6941,6 +6941,24 @@ exit 0
       );
       assert.equal((blockedRepeatedInputFileDeactivation.outputJson as { decision?: string } | null)?.decision, "block");
 
+      const cwdRelativeInputFileRootSafe = join(cwd, "cwd-relative-input-file-safe.json");
+      const cwdRelativeInputFileSubdir = join(cwd, "cwd-relative-input-file-subdir");
+      await mkdir(cwdRelativeInputFileSubdir, { recursive: true });
+      await writeJson(cwdRelativeInputFileRootSafe, { mode: "deep-interview", active: true });
+      await writeJson(join(cwdRelativeInputFileSubdir, "payload.json"), { mode: "deep-interview", active: false });
+      const blockedCwdRelativeInputFileAfterCd = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-state-cli-cwd-relative-input-file-after-cd",
+          tool_input: { command: "cd cwd-relative-input-file-subdir && omx state write --input-file payload.json --json" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedCwdRelativeInputFileAfterCd.outputJson as { decision?: string } | null)?.decision, "block");
+
       const blockedNestedStateDeactivation = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3528,7 +3528,6 @@ function commandHasDeepInterviewWriteIntent(command: string): boolean {
     || /\btee\s+(?:-a\s+)?[^\s&|;]+/.test(command)
     || /\bsed\s+(?:[^\n;&|]*\s)?-i(?:\b|['"])/.test(command)
     || /\b(?:python3?|node|perl|ruby)\b[\s\S]{0,260}\b(?:writeFileSync|writeFile|write_text|open\([^)]*["']w|File\.write|Path\()/.test(command)
-    || /\bomx\s+state\s+(?:write|clear)\b/.test(command)
     || /\b(?:git\s+(?:checkout|switch|restore|reset|apply|am|merge|rebase)|npm\s+(?:install|i|ci)|pnpm\s+(?:install|i)|yarn\s+(?:install|add))\b/.test(command);
 }
 
@@ -3572,8 +3571,12 @@ function describeImplementationToolBlock(
 
 function isAllowedDeepInterviewBashWrite(cwd: string, command: string): boolean {
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
-  if (/\bomx\s+(?:state\s+read|question)\b/.test(command)) return true;
-  if (/\bomx\s+state\s+(?:write|clear)\b/.test(command)) return false;
+  // `omx state` mutations route through the validated `state_write` backend,
+  // which enforces the Autopilot phase gate (ordering + completion/skip
+  // evidence) for every transport. Defer to that gate here instead of blocking
+  // the transport; raw writes to the protected planning-state files are still
+  // rejected below via isAllowedDeepInterviewArtifactPath.
+  if (/\bomx\s+(?:state\s+(?:read|write|clear)|question)\b/.test(command)) return true;
   const targets = extractDeepInterviewCommandWriteTargets(command);
   return targets.length > 0 && targets.every((target) => isAllowedDeepInterviewArtifactPath(cwd, target));
 }
@@ -3680,8 +3683,9 @@ function isAllowedRalplanBashWrite(cwd: string, command: string): boolean {
     return beadsCommand.allowed && (targets.length === 0 || hasAllowedTargets);
   }
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
-  if (/\bomx\s+(?:state\s+read|question)\b/.test(command)) return true;
-  if (/\bomx\s+state\s+(?:write|clear)\b/.test(command)) return false;
+  // See isAllowedDeepInterviewBashWrite: defer `omx state` mutations to the
+  // gate-enforcing state_write backend rather than blocking the CLI transport.
+  if (/\bomx\s+(?:state\s+(?:read|write|clear)|question)\b/.test(command)) return true;
   return hasAllowedTargets;
 }
 
@@ -3701,9 +3705,6 @@ function buildRalplanBashBlockedDetail(cwd: string, command: string): string {
   }
   if (beadsCommand.present) {
     return "Beads tracker command also performs an implementation write outside allowed planning metadata";
-  }
-  if (/\bomx\s+state\s+(?:write|clear)\b/.test(command)) {
-    return "omx state mutation is not model-writable during gated planning; write planning artifacts instead";
   }
   return "Bash write intent did not identify an allowed planning artifact path or metadata path";
 }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3573,24 +3573,89 @@ function describeImplementationToolBlock(
 // backend, so the hook defers to that gate rather than blocking the transport.
 // The backend does NOT gate standalone deep-interview/ralplan *deactivation*,
 // however, so a command that ends the active planning phase from a tool call
-// (`omx state clear`, or an `omx state write` that flips `active` off) is still
-// blocked here. Robustly gating standalone deactivation (and other skip vectors)
-// belongs in the backend; this is transport-level defense-in-depth.
-function commandEndsPlanningPhase(command: string): boolean {
-  return /\bomx\s+state\s+clear\b/.test(command)
-    || (/\bomx\s+state\s+write\b/.test(command) && /["']?active["']?\s*:\s*false\b/.test(command));
+// (`omx state clear`, or an `omx state write` that flips `active` off or writes
+// a terminal planning phase) is still blocked here. Robustly gating standalone
+// deactivation belongs in the backend; this is transport-level defense-in-depth.
+function readStateWriteInputPayload(cwd: string, command: string): Record<string, unknown> | null {
+  if (!/\bomx\s+state\s+write\b/.test(command)) return null;
+
+  const inlineInputMatch = command.match(/--input(?:=|\s+)(?:"([\s\S]*?)"|'([\s\S]*?)'|([^\s;&|]+))/);
+  if (inlineInputMatch) {
+    try {
+      const raw = safeString(inlineInputMatch[1] ?? inlineInputMatch[2] ?? inlineInputMatch[3]);
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? parsed as Record<string, unknown>
+        : null;
+    } catch {
+      return null;
+    }
+  }
+
+  const inputFileMatch = command.match(/--input-file(?:=|\s+)(?:"([^"]+)"|'([^']+)'|([^\s;&|]+))/);
+  if (!inputFileMatch) return null;
+
+  try {
+    const rawPath = safeString(inputFileMatch[1] ?? inputFileMatch[2] ?? inputFileMatch[3]).trim();
+    const raw = readFileSync(resolve(cwd, rawPath), "utf-8");
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isPlanningPhaseDeactivationPayload(payload: Record<string, unknown>): boolean {
+  const mode = safeString(payload.mode).trim().toLowerCase();
+  if (mode !== "deep-interview" && mode !== "ralplan") return false;
+
+  if (payload.active === false) return true;
+
+  const currentPhase = normalizeAutopilotPhase(payload.current_phase ?? payload.currentPhase);
+  if (currentPhase === "complete" || currentPhase === "failed") return true;
+
+  const runOutcome = safeString(payload.run_outcome ?? payload.runOutcome).trim().toLowerCase();
+  if (
+    runOutcome === "finish"
+    || runOutcome === "finished"
+    || runOutcome === "complete"
+    || runOutcome === "completed"
+    || runOutcome === "done"
+    || runOutcome === "blocked_on_user"
+    || runOutcome === "blocked-on-user"
+    || runOutcome === "blocked"
+    || runOutcome === "failed"
+    || runOutcome === "cancelled"
+    || runOutcome === "canceled"
+    || runOutcome === "cancel"
+    || runOutcome === "aborted"
+    || runOutcome === "abort"
+  ) {
+    return true;
+  }
+
+  const lifecycleOutcome = safeString(payload.lifecycle_outcome ?? payload.lifecycleOutcome).trim().toLowerCase();
+  return lifecycleOutcome === "finished"
+    || lifecycleOutcome === "blocked"
+    || lifecycleOutcome === "failed"
+    || lifecycleOutcome === "userinterlude"
+    || lifecycleOutcome === "askuserquestion"
+    || lifecycleOutcome === "ask-user-question";
+}
+
+function commandEndsPlanningPhase(cwd: string, command: string): boolean {
+  if (/\bomx\s+state\s+clear\b/.test(command)) return true;
+  const payload = readStateWriteInputPayload(cwd, command);
+  return payload ? isPlanningPhaseDeactivationPayload(payload) : false;
 }
 
 function isAllowedDeepInterviewBashWrite(cwd: string, command: string): boolean {
-  if (commandEndsPlanningPhase(command)) return false;
+  if (commandEndsPlanningPhase(cwd, command)) return false;
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
   const targets = extractDeepInterviewCommandWriteTargets(command);
-  // A disallowed write target chained alongside an allowed `omx state`/`omx
-  // question` command must not be smuggled through the allowance below.
   if (targets.some((target) => !isAllowedDeepInterviewArtifactPath(cwd, target))) return false;
-  // `omx state` read/write/clear and `omx question` defer to the backend gate;
-  // deactivation is already rejected above.
-  if (/\bomx\s+(?:state\s+(?:read|write|clear)|question)\b/.test(command)) return true;
   return targets.length > 0 && targets.every((target) => isAllowedDeepInterviewArtifactPath(cwd, target));
 }
 
@@ -3695,14 +3760,9 @@ function isAllowedRalplanBashWrite(cwd: string, command: string): boolean {
   if (beadsCommand.present) {
     return beadsCommand.allowed && (targets.length === 0 || hasAllowedTargets);
   }
-  if (commandEndsPlanningPhase(command)) return false;
+  if (commandEndsPlanningPhase(cwd, command)) return false;
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
-  // A disallowed write target chained alongside an allowed `omx state`/`omx
-  // question` command must not be smuggled through the allowance below.
   if (targets.some((target) => !isAllowedRalplanArtifactPath(cwd, target))) return false;
-  // See isAllowedDeepInterviewBashWrite: defer `omx state` mutations to the
-  // gate-enforcing state_write backend (deactivation already rejected above).
-  if (/\bomx\s+(?:state\s+(?:read|write|clear)|question)\b/.test(command)) return true;
   return hasAllowedTargets;
 }
 

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3569,15 +3569,28 @@ function describeImplementationToolBlock(
   return formatPlanningWriteBlockDetail(operationClass, blockedPath, RALPLAN_ALLOWED_WRITE_PREFIXES);
 }
 
+// `omx state` mutations normally route through the gate-enforcing `state_write`
+// backend, so the hook defers to that gate rather than blocking the transport.
+// The backend does NOT gate standalone deep-interview/ralplan *deactivation*,
+// however, so a command that ends the active planning phase from a tool call
+// (`omx state clear`, or an `omx state write` that flips `active` off) is still
+// blocked here. Robustly gating standalone deactivation (and other skip vectors)
+// belongs in the backend; this is transport-level defense-in-depth.
+function commandEndsPlanningPhase(command: string): boolean {
+  return /\bomx\s+state\s+clear\b/.test(command)
+    || (/\bomx\s+state\s+write\b/.test(command) && /["']?active["']?\s*:\s*false\b/.test(command));
+}
+
 function isAllowedDeepInterviewBashWrite(cwd: string, command: string): boolean {
+  if (commandEndsPlanningPhase(command)) return false;
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
-  // `omx state` mutations route through the validated `state_write` backend,
-  // which enforces the Autopilot phase gate (ordering + completion/skip
-  // evidence) for every transport. Defer to that gate here instead of blocking
-  // the transport; raw writes to the protected planning-state files are still
-  // rejected below via isAllowedDeepInterviewArtifactPath.
-  if (/\bomx\s+(?:state\s+(?:read|write|clear)|question)\b/.test(command)) return true;
   const targets = extractDeepInterviewCommandWriteTargets(command);
+  // A disallowed write target chained alongside an allowed `omx state`/`omx
+  // question` command must not be smuggled through the allowance below.
+  if (targets.some((target) => !isAllowedDeepInterviewArtifactPath(cwd, target))) return false;
+  // `omx state` read/write/clear and `omx question` defer to the backend gate;
+  // deactivation is already rejected above.
+  if (/\bomx\s+(?:state\s+(?:read|write|clear)|question)\b/.test(command)) return true;
   return targets.length > 0 && targets.every((target) => isAllowedDeepInterviewArtifactPath(cwd, target));
 }
 
@@ -3682,9 +3695,13 @@ function isAllowedRalplanBashWrite(cwd: string, command: string): boolean {
   if (beadsCommand.present) {
     return beadsCommand.allowed && (targets.length === 0 || hasAllowedTargets);
   }
+  if (commandEndsPlanningPhase(command)) return false;
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
+  // A disallowed write target chained alongside an allowed `omx state`/`omx
+  // question` command must not be smuggled through the allowance below.
+  if (targets.some((target) => !isAllowedRalplanArtifactPath(cwd, target))) return false;
   // See isAllowedDeepInterviewBashWrite: defer `omx state` mutations to the
-  // gate-enforcing state_write backend rather than blocking the CLI transport.
+  // gate-enforcing state_write backend (deactivation already rejected above).
   if (/\bomx\s+(?:state\s+(?:read|write|clear)|question)\b/.test(command)) return true;
   return hasAllowedTargets;
 }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3574,37 +3574,400 @@ function describeImplementationToolBlock(
 // The backend does NOT gate standalone deep-interview/ralplan *deactivation*,
 // however, so a command that ends the active planning phase from a tool call
 // (`omx state clear`, or an `omx state write` that flips `active` off or writes
-// a terminal planning phase) is still blocked here. Robustly gating standalone
-// deactivation belongs in the backend; this is transport-level defense-in-depth.
+// a terminal planning phase) is still blocked here. Broader backend authority
+// belongs to a separate follow-up; this PR keeps the model/tool-originated guard
+// at the native-hook transport boundary.
 function readStateWriteInputPayload(cwd: string, command: string): Record<string, unknown> | null {
-  if (!/\bomx\s+state\s+write\b/.test(command)) return null;
+  const stateWriteIndexes = findUnquotedOmxStateCommandIndexes(command, "write");
+  if (stateWriteIndexes.length === 0) return null;
+  if (stateWriteIndexes.length > 1) return null;
 
-  const inlineInputMatch = command.match(/--input(?:=|\s+)(?:"([\s\S]*?)"|'([\s\S]*?)'|([^\s;&|]+))/);
-  if (inlineInputMatch) {
+  const stateWriteIndex = stateWriteIndexes[0] ?? -1;
+  if (stateWriteIndex < 0) return null;
+  const stateWriteCommand = sliceSingleShellCommandSegment(command, stateWriteIndex);
+  const stateWriteArgs = tokenizeShellWords(stateWriteCommand).slice(3);
+
+  const mergeModeFlag = (payload: Record<string, unknown>): Record<string, unknown> => {
+    const mode = readStateWriteFlagValue(stateWriteArgs, "--mode");
+    return normalizeStateWriteClassificationPayload(mode ? { ...payload, mode } : payload);
+  };
+
+  const inlineInput = readStateWriteFlagValue(stateWriteArgs, "--input");
+  const inputFile = readStateWriteFlagValue(stateWriteArgs, "--input-file");
+  if (inlineInput !== undefined && inputFile !== undefined) return null;
+
+  if (inlineInput !== undefined) {
     try {
-      const raw = safeString(inlineInputMatch[1] ?? inlineInputMatch[2] ?? inlineInputMatch[3]);
-      const parsed = JSON.parse(raw);
+      const parsed = JSON.parse(inlineInput);
       return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-        ? parsed as Record<string, unknown>
+        ? mergeModeFlag(parsed as Record<string, unknown>)
         : null;
     } catch {
       return null;
     }
   }
 
-  const inputFileMatch = command.match(/--input-file(?:=|\s+)(?:"([^"]+)"|'([^']+)'|([^\s;&|]+))/);
-  if (!inputFileMatch) return null;
+  if (inputFile === undefined) return null;
 
   try {
-    const rawPath = safeString(inputFileMatch[1] ?? inputFileMatch[2] ?? inputFileMatch[3]).trim();
-    const raw = readFileSync(resolve(cwd, rawPath), "utf-8");
+    const raw = readFileSync(resolve(cwd, inputFile.trim()), "utf-8");
     const parsed = JSON.parse(raw);
     return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? parsed as Record<string, unknown>
+      ? mergeModeFlag(parsed as Record<string, unknown>)
       : null;
   } catch {
     return null;
   }
+}
+
+function tokenizeShellWords(segment: string): string[] {
+  const words: string[] = [];
+  let current = "";
+  let quote: "'" | "\"" | null = null;
+  for (let index = 0; index < segment.length; index += 1) {
+    const char = segment[index];
+    if (char === "\\" && quote !== "'") {
+      index += 1;
+      current += segment[index] ?? "";
+      continue;
+    }
+    if (char === "'" || char === "\"") {
+      if (quote === char) {
+        quote = null;
+      } else if (!quote) {
+        quote = char;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (!quote && /\s/.test(char)) {
+      if (current) {
+        words.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (current) words.push(current);
+  return words;
+}
+
+function readStateWriteFlagValue(args: string[], flagName: "--input" | "--input-file" | "--mode"): string | undefined {
+  let value: string | undefined;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index] ?? "";
+    if (arg === flagName) {
+      value = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith(`${flagName}=`)) value = arg.slice(flagName.length + 1);
+  }
+  return value;
+}
+
+function findUnquotedOmxStateCommandIndexes(command: string, operation: "write" | "clear"): number[] {
+  command = stripHeredocBodiesForCommandScan(command);
+  const indexes: number[] = [];
+  let quote: "'" | "\"" | null = null;
+  const pattern = new RegExp(`\\bomx\\s+state\\s+${operation}\\b`, "y");
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index];
+    if (char === "\\" && quote !== "'") {
+      index += 1;
+      continue;
+    }
+    if (quote !== "'" && char === "$" && command[index + 1] === "(") {
+      const substitutionEnd = findCommandSubstitutionEnd(command, index + 2);
+      const substitutionBodyEnd = substitutionEnd >= 0 ? substitutionEnd : command.length;
+      const substitutionBody = command.slice(index + 2, substitutionBodyEnd);
+      for (const nestedIndex of findUnquotedOmxStateCommandIndexes(substitutionBody, operation)) {
+        indexes.push(index + 2 + nestedIndex);
+      }
+      index = substitutionEnd >= 0 ? substitutionEnd : command.length;
+      continue;
+    }
+    if (quote !== "'" && char === "`") {
+      const substitutionEnd = findBacktickCommandSubstitutionEnd(command, index + 1);
+      const substitutionBodyEnd = substitutionEnd >= 0 ? substitutionEnd : command.length;
+      const substitutionBody = command.slice(index + 1, substitutionBodyEnd);
+      for (const nestedIndex of findUnquotedOmxStateCommandIndexes(substitutionBody, operation)) {
+        indexes.push(index + 1 + nestedIndex);
+      }
+      index = substitutionEnd >= 0 ? substitutionEnd : command.length;
+      continue;
+    }
+    if (char === "'" || char === "\"") {
+      if (quote === char) {
+        quote = null;
+      } else if (!quote) {
+        quote = char;
+      }
+      continue;
+    }
+    if (quote) continue;
+
+    pattern.lastIndex = index;
+    const match = pattern.exec(command);
+    if (!match) continue;
+    indexes.push(index);
+    index = pattern.lastIndex - 1;
+  }
+  for (const nestedCommand of extractNestedShellCommandStrings(command)) {
+    for (const nestedIndex of findUnquotedOmxStateCommandIndexes(nestedCommand, operation)) {
+      indexes.push(nestedIndex);
+    }
+  }
+  return indexes;
+}
+
+function hasDynamicNestedShellExecution(command: string): boolean {
+  const words = tokenizeShellWords(stripHeredocBodiesForCommandScan(command));
+  let sawCommandWord = false;
+  for (let index = 0; index < words.length; index += 1) {
+    const word = words[index] ?? "";
+    if (!sawCommandWord) {
+      if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(word)) continue;
+      sawCommandWord = true;
+      if (isDynamicNestedCommandString(word)) return true;
+    }
+    if (isCommandDispatchBuiltin(word)) {
+      const dispatchedCommand = extractDispatchBuiltinOperand(words, index + 1, word);
+      if (dispatchedCommand && hasDynamicNestedShellExecution(dispatchedCommand)) return true;
+    }
+    if (containsUnquotedProcessSubstitution(command) && (isNestedShellCommandWord(word) || word === "." || word === "source")) return true;
+    if (isNestedShellCommandWord(word)) {
+      const commandStringIndex = findShellCommandStringArgIndex(words, index + 1);
+      if (commandStringIndex === null && command.includes("<<")) return true;
+      if (commandStringIndex !== null) {
+        const nestedCommand = words[commandStringIndex] ?? "";
+        if (isDynamicNestedCommandString(nestedCommand)) return true;
+      }
+    }
+    if (word === "eval") {
+      const nestedCommand = words.slice(index + 1).join(" ");
+      if (isDynamicNestedCommandString(nestedCommand)) return true;
+    }
+  }
+  return false;
+}
+
+function isCommandDispatchBuiltin(word: string): boolean {
+  return word === "exec" || word === "command" || word === "." || word === "source";
+}
+
+function extractDispatchBuiltinOperand(words: string[], startIndex: number, builtin: string): string {
+  for (let index = startIndex; index < words.length; index += 1) {
+    const option = words[index] ?? "";
+    if (!option) continue;
+    if (option === "--") continue;
+    if (builtin === "exec" && option === "-a") {
+      index += 1;
+      continue;
+    }
+    if (option.startsWith("-")) continue;
+    return words.slice(index).join(" ");
+  }
+  return "";
+}
+
+function extractNestedShellCommandStrings(command: string): string[] {
+  const words = tokenizeShellWords(stripHeredocBodiesForCommandScan(command));
+  const nested: string[] = [];
+  for (let index = 0; index < words.length; index += 1) {
+    const word = words[index] ?? "";
+    if (isNestedShellCommandWord(word)) {
+      const commandStringIndex = findShellCommandStringArgIndex(words, index + 1);
+      if (commandStringIndex !== null) {
+        const nestedCommand = words[commandStringIndex];
+        if (nestedCommand) nested.push(nestedCommand);
+      }
+    }
+    if (word === "eval") {
+      const nestedCommand = words.slice(index + 1).join(" ");
+      if (nestedCommand) nested.push(nestedCommand);
+    }
+  }
+  return nested;
+}
+
+function isNestedShellCommandWord(word: string): boolean {
+  const base = word.split(/[\\/]/).pop() ?? word;
+  return /^(?:bash|sh|zsh|dash|ksh|mksh|ash)$/.test(base);
+}
+
+function findShellCommandStringArgIndex(words: string[], optionStartIndex: number): number | null {
+  for (let index = optionStartIndex; index < words.length; index += 1) {
+    const option = words[index] ?? "";
+    if (option === "--") return null;
+    if (isShellCommandStringOption(option)) return index + 1;
+    if (isShellOptionWithSeparateValue(option)) {
+      index += 1;
+      continue;
+    }
+    if (option.startsWith("-")) continue;
+    return null;
+  }
+  return null;
+}
+
+function isShellCommandStringOption(option: string): boolean {
+  return /^-[^-]*c[^-]*$/.test(option);
+}
+
+function isShellOptionWithSeparateValue(option: string): boolean {
+  return option === "--rcfile" || option === "--init-file" || option === "-o" || option === "-O";
+}
+
+function isDynamicNestedCommandString(command: string): boolean {
+  return /(?:^|[^\\])\$(?:[A-Za-z_][A-Za-z0-9_]*|\{[^}]+\}|\()/.test(command)
+    || /(?:^|[^\\])`/.test(command);
+}
+
+function findCommandSubstitutionEnd(command: string, bodyStartIndex: number): number {
+  let depth = 1;
+  let quote: "'" | "\"" | null = null;
+  for (let index = bodyStartIndex; index < command.length; index += 1) {
+    const char = command[index];
+    if (char === "\\" && quote !== "'") {
+      index += 1;
+      continue;
+    }
+    if (char === "'" || char === "\"") {
+      if (quote === char) {
+        quote = null;
+      } else if (!quote) {
+        quote = char;
+      }
+      continue;
+    }
+    if (quote) continue;
+    if (char === "$" && command[index + 1] === "(") {
+      depth += 1;
+      index += 1;
+      continue;
+    }
+    if (char === ")") {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return -1;
+}
+
+function findBacktickCommandSubstitutionEnd(command: string, bodyStartIndex: number): number {
+  for (let index = bodyStartIndex; index < command.length; index += 1) {
+    const char = command[index];
+    if (char === "\\") {
+      index += 1;
+      continue;
+    }
+    if (char === "`") return index;
+  }
+  return -1;
+}
+
+function containsUnquotedProcessSubstitution(command: string): boolean {
+  let quote: "'" | "\"" | null = null;
+  for (let index = 0; index < command.length - 1; index += 1) {
+    const char = command[index];
+    if (char === "\\" && quote !== "'") {
+      index += 1;
+      continue;
+    }
+    if (char === "'" || char === "\"") {
+      if (quote === char) {
+        quote = null;
+      } else if (!quote) {
+        quote = char;
+      }
+      continue;
+    }
+    if (quote) continue;
+    if (char === "<" && command[index + 1] === "(") return true;
+  }
+  return false;
+}
+
+function stripHeredocBodiesForCommandScan(command: string): string {
+  const lines = command.split("\n");
+  const kept: string[] = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    kept.push(line);
+    const heredocMatch = line.match(/<<-?\s*(?:"([^"]+)"|'([^']+)'|([^\s"'<>|;&]+))/);
+    const delimiter = safeString(heredocMatch?.[1] ?? heredocMatch?.[2] ?? heredocMatch?.[3]).trim();
+    if (!delimiter) continue;
+    index += 1;
+    while (index < lines.length && (lines[index] ?? "").trim() !== delimiter) {
+      kept.push("");
+      index += 1;
+    }
+    if (index < lines.length) kept.push(lines[index] ?? "");
+  }
+  return kept.join("\n");
+}
+
+function hasUnsafeUnquotedHeredocExpansion(command: string): boolean {
+  const lines = command.split("\n");
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    const heredocMatch = line.match(/<<-?\s*(?:"([^"]+)"|'([^']+)'|([^\s"'<>|;&]+))/);
+    if (!heredocMatch) continue;
+    const quoted = Boolean(heredocMatch[1] || heredocMatch[2]);
+    const delimiter = safeString(heredocMatch[1] ?? heredocMatch[2] ?? heredocMatch[3]).trim();
+    if (!delimiter || quoted) continue;
+    index += 1;
+    const bodyLines: string[] = [];
+    while (index < lines.length && (lines[index] ?? "").trim() !== delimiter) {
+      bodyLines.push(lines[index] ?? "");
+      index += 1;
+    }
+    if (isDynamicNestedCommandString(bodyLines.join("\n"))) return true;
+  }
+  return false;
+}
+
+function sliceSingleShellCommandSegment(command: string, startIndex: number): string {
+  let quote: "'" | "\"" | null = null;
+  for (let index = startIndex; index < command.length; index += 1) {
+    const char = command[index];
+    if (char === "\\" && quote !== "'") {
+      index += 1;
+      continue;
+    }
+    if (char === "'" || char === "\"") {
+      if (quote === char) {
+        quote = null;
+      } else if (!quote) {
+        quote = char;
+      }
+      continue;
+    }
+    if (quote) continue;
+    if (char === "\n" || char === ";" || char === "|") return command.slice(startIndex, index);
+    if (char === "&" && command[index + 1] === "&") return command.slice(startIndex, index);
+  }
+  return command.slice(startIndex);
+}
+
+function normalizeStateWriteClassificationPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  const targetMode = safeString(payload.mode).trim();
+  const {
+    mode: _mode,
+    workingDirectory: _workingDirectory,
+    session_id: _sessionId,
+    state,
+    ...fields
+  } = payload;
+  return {
+    ...fields,
+    ...safeObject(state),
+    ...(targetMode ? { mode: targetMode } : {}),
+  };
 }
 
 function isPlanningPhaseDeactivationPayload(payload: Record<string, unknown>): boolean {
@@ -3646,9 +4009,14 @@ function isPlanningPhaseDeactivationPayload(payload: Record<string, unknown>): b
 }
 
 function commandEndsPlanningPhase(cwd: string, command: string): boolean {
-  if (/\bomx\s+state\s+clear\b/.test(command)) return true;
+  if (hasUnsafeUnquotedHeredocExpansion(command)) return true;
+  if (findUnquotedOmxStateCommandIndexes(command, "clear").length > 0) return true;
+  if (hasDynamicNestedShellExecution(command)) return true;
+  const stateWriteCount = findUnquotedOmxStateCommandIndexes(command, "write").length;
+  if (stateWriteCount > 1) return true;
+  if (stateWriteCount === 0) return false;
   const payload = readStateWriteInputPayload(cwd, command);
-  return payload ? isPlanningPhaseDeactivationPayload(payload) : false;
+  return payload ? isPlanningPhaseDeactivationPayload(payload) : true;
 }
 
 function isAllowedDeepInterviewBashWrite(cwd: string, command: string): boolean {
@@ -3808,6 +4176,15 @@ async function buildRalplanPreToolUseBoundaryOutput(
     if (blocked) {
       blockedDetail = buildRalplanBashBlockedDetail(cwd, command);
     }
+  } else if (
+    toolName === "mcp__omx_state__state_clear"
+    || (
+      toolName === "mcp__omx_state__state_write"
+      && isPlanningPhaseDeactivationPayload(normalizeStateWriteClassificationPayload(safeObject(payload.tool_input)))
+    )
+  ) {
+    blocked = true;
+    blockedDetail = `${toolName} would deactivate protected planning state`;
   } else if (PLANNING_MODE_IMPLEMENTATION_TOOL_NAMES.has(toolName)) {
     const toolPathCandidates = collectImplementationToolPathCandidates(payload, toolName, pathCandidates);
     if (toolPathCandidates.length === 0) {
@@ -3862,6 +4239,14 @@ async function buildDeepInterviewPreToolUseBoundaryOutput(
 
   if (toolName === "Bash") {
     blocked = !isAllowedDeepInterviewBashWrite(cwd, command);
+  } else if (
+    toolName === "mcp__omx_state__state_clear"
+    || (
+      toolName === "mcp__omx_state__state_write"
+      && isPlanningPhaseDeactivationPayload(normalizeStateWriteClassificationPayload(safeObject(payload.tool_input)))
+    )
+  ) {
+    blocked = true;
   } else if (DEEP_INTERVIEW_IMPLEMENTATION_TOOL_NAMES.has(toolName)) {
     const candidates = collectImplementationToolPathCandidates(payload, toolName, pathCandidates);
     blocked = candidates.length === 0
@@ -3945,8 +4330,20 @@ async function buildPlanningRootPointerConflictPreToolUseOutput(
     rootSessionId,
     "",
   );
-  if (deepInterviewState && blocksDeepInterviewImplementationWrite(payload, cwd)) {
-    return buildDeepInterviewRootPointerConflictBlock(deepInterviewState);
+  if (deepInterviewState) {
+    const conflictToolName = safeString(payload.tool_name).trim();
+    if (
+      conflictToolName === "mcp__omx_state__state_clear"
+      || (
+        conflictToolName === "mcp__omx_state__state_write"
+        && isPlanningPhaseDeactivationPayload(normalizeStateWriteClassificationPayload(safeObject(payload.tool_input)))
+      )
+    ) {
+      return buildDeepInterviewRootPointerConflictBlock(deepInterviewState);
+    }
+    if (blocksDeepInterviewImplementationWrite(payload, cwd)) {
+      return buildDeepInterviewRootPointerConflictBlock(deepInterviewState);
+    }
   }
 
   const ralplanState = await readActiveRalplanStateForPreToolUse(
@@ -3961,6 +4358,14 @@ async function buildPlanningRootPointerConflictPreToolUseOutput(
   let blocked = false;
   if (toolName === "Bash") {
     blocked = !isAllowedRalplanBashWrite(cwd, readPreToolUseCommand(payload));
+  } else if (
+    toolName === "mcp__omx_state__state_clear"
+    || (
+      toolName === "mcp__omx_state__state_write"
+      && isPlanningPhaseDeactivationPayload(normalizeStateWriteClassificationPayload(safeObject(payload.tool_input)))
+    )
+  ) {
+    blocked = true;
   } else if (PLANNING_MODE_IMPLEMENTATION_TOOL_NAMES.has(toolName)) {
     const toolPathCandidates = collectImplementationToolPathCandidates(
       payload,

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3621,6 +3621,7 @@ function readStateWriteInputPayload(cwd: string, command: string): Record<string
 }
 
 function tokenizeShellWords(segment: string): string[] {
+  segment = normalizeShellLineContinuations(segment);
   const words: string[] = [];
   let current = "";
   let quote: "'" | "\"" | null = null;
@@ -3654,6 +3655,36 @@ function tokenizeShellWords(segment: string): string[] {
   return words;
 }
 
+function normalizeShellLineContinuations(command: string): string {
+  let normalized = "";
+  let quote: "'" | "\"" | null = null;
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index] ?? "";
+    if (char === "'" || char === "\"") {
+      if (quote === char) {
+        quote = null;
+      } else if (!quote) {
+        quote = char;
+      }
+      normalized += char;
+      continue;
+    }
+    if (char === "\\" && quote !== "'") {
+      const next = command[index + 1] ?? "";
+      if (next === "\r" && command[index + 2] === "\n") {
+        index += 2;
+        continue;
+      }
+      if (next === "\n") {
+        index += 1;
+        continue;
+      }
+    }
+    normalized += char;
+  }
+  return normalized;
+}
+
 function readStateWriteFlagValue(args: string[], flagName: "--input" | "--input-file" | "--mode"): string | undefined {
   let value: string | undefined;
   for (let index = 0; index < args.length; index += 1) {
@@ -3669,7 +3700,7 @@ function readStateWriteFlagValue(args: string[], flagName: "--input" | "--input-
 }
 
 function findUnquotedOmxStateCommandIndexes(command: string, operation: "write" | "clear"): number[] {
-  command = stripHeredocBodiesForCommandScan(command);
+  command = normalizeShellLineContinuations(stripHeredocBodiesForCommandScan(command));
   const indexes: number[] = [];
   let quote: "'" | "\"" | null = null;
   const pattern = new RegExp(`\\bomx\\s+state\\s+${operation}\\b`, "y");
@@ -3871,6 +3902,7 @@ function findBacktickCommandSubstitutionEnd(command: string, bodyStartIndex: num
 }
 
 function containsUnquotedProcessSubstitution(command: string): boolean {
+  command = normalizeShellLineContinuations(command);
   let quote: "'" | "\"" | null = null;
   for (let index = 0; index < command.length - 1; index += 1) {
     const char = command[index];
@@ -3912,7 +3944,7 @@ function stripHeredocBodiesForCommandScan(command: string): string {
 }
 
 function hasUnsafeUnquotedHeredocExpansion(command: string): boolean {
-  const lines = command.split("\n");
+  const lines = normalizeShellLineContinuations(command).split("\n");
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? "";
     const heredocMatch = line.match(/<<-?\s*(?:"([^"]+)"|'([^']+)'|([^\s"'<>|;&]+))/);
@@ -3932,6 +3964,7 @@ function hasUnsafeUnquotedHeredocExpansion(command: string): boolean {
 }
 
 function sliceSingleShellCommandSegment(command: string, startIndex: number): string {
+  command = normalizeShellLineContinuations(command);
   let quote: "'" | "\"" | null = null;
   for (let index = startIndex; index < command.length; index += 1) {
     const char = command[index];
@@ -4009,6 +4042,7 @@ function isPlanningPhaseDeactivationPayload(payload: Record<string, unknown>): b
 }
 
 function commandEndsPlanningPhase(cwd: string, command: string): boolean {
+  command = normalizeShellLineContinuations(command);
   if (hasUnsafeUnquotedHeredocExpansion(command)) return true;
   if (findUnquotedOmxStateCommandIndexes(command, "clear").length > 0) return true;
   if (hasDynamicNestedShellExecution(command)) return true;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "child_process";
 import { closeSync, existsSync, openSync, readFileSync, readSync, statSync } from "fs";
 import { appendFile, mkdir, readFile, readdir, stat, writeFile } from "fs/promises";
-import { extname, join, relative, resolve } from "path";
+import { extname, isAbsolute, join, relative, resolve } from "path";
 import { pathToFileURL } from "url";
 import { readModeStateForActiveDecision, readModeStateForSession, updateModeState } from "../modes/base.js";
 import { redactAuthSecrets } from "../auth/redact.js";
@@ -3608,6 +3608,7 @@ function readStateWriteInputPayload(cwd: string, command: string): Record<string
   }
 
   if (inputFile === undefined) return null;
+  if (!isAbsolute(inputFile.trim()) && hasPriorCwdChangingCommand(command.slice(0, stateWriteIndex))) return null;
 
   try {
     const raw = readFileSync(resolve(cwd, inputFile.trim()), "utf-8");
@@ -3618,6 +3619,23 @@ function readStateWriteInputPayload(cwd: string, command: string): Record<string
   } catch {
     return null;
   }
+}
+
+function hasPriorCwdChangingCommand(commandPrefix: string): boolean {
+  const words = tokenizeShellWords(stripHeredocBodiesForCommandScan(commandPrefix));
+  let commandStart = true;
+  for (let index = 0; index < words.length; index += 1) {
+    const word = words[index] ?? "";
+    if (!word) continue;
+    if (word === "&&" || word === "||" || word === ";" || word === "&" || word === "|" || word === "|&") {
+      commandStart = true;
+      continue;
+    }
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(word)) continue;
+    if (commandStart && (word === "cd" || word === "pushd" || word === "popd")) return true;
+    commandStart = false;
+  }
+  return false;
 }
 
 function tokenizeShellWords(segment: string): string[] {


### PR DESCRIPTION
This is the follow-up PR for the planning-gate hardening work after PR #3001 closed.

## What PR #3001 was trying to do
PR #3001 was the planning-gate fix for model/tool-originated paths that could deactivate protected planning state too early. The concrete target was to keep `deep-interview` and `ralplan` planning state safe while still allowing the normal completion/handoff flow.

The original problem space included:
- Bash `omx state write` / `omx state clear` paths that could deactivate planning state
- `--input` / `--input-file` cases where `--mode` could appear outside the JSON payload
- multiple `omx state write` invocations hidden in one shell command
- decoy arguments before the real state-write invocation
- MCP structured state tools exposed through the native hook
- runtime/provenance confusion from stale panes or older builds, which needed to be documented but not treated as enforcement

## Handoff document
For the full regression and handoff notes, see [docs/planning-gate-regression-3001.md](docs/planning-gate-regression-3001.md).

## Architectural goals for the fix
We are trying to close a specific class of incidents rather than introduce a new authority subsystem:

### Incident types we are closing
1. **Model/tool-originated protected-planning deactivation** during `deep-interview` or `ralplan`.
2. **Shell-smuggling / parser-bypass incidents** where a deactivation payload is hidden behind `--mode`, multiple writes, decoy arguments, nested shell execution, or `exec` / `command` dispatch options.
3. **Structured-tool parity gaps** where MCP state tools could bypass the same planning gate that Bash already enforced.
4. **Runtime/provenance confusion incidents** where stale panes or older binaries made it look like the latest code failed, even when the evidence was only operational.

These are described across:
- the PR #3001 review thread and follow-up comments,
- the planning handoff notes,
- and the durable regression doc at `docs/planning-gate-regression-3001.md`.

### Architectural principles applied
- **Transport-boundary enforcement:** keep the guard at the native-hook transport boundary (`PreToolUse`) instead of inventing a new trusted wrapper layer.
- **Fail closed on ambiguity:** when the parser cannot confidently prove safety, block the action.
- **Single policy, multiple transports:** Bash and MCP should share the same protected-planning deactivation predicate.
- **Observation-only diagnostics:** runtime/build provenance is used to classify incidents, not to mutate state.
- **No backend authority expansion for this PR:** do not widen `src/state/operations.ts` into a new trust boundary unless a later maintainer-requested follow-up explicitly requires it.

### State attributes and files we orient on
We block only when the current state indicates active protected planning:

#### Core planning-state files/attributes
- `src/scripts/codex-native-hook.ts`
  - `isPlanningPhaseDeactivationPayload(...)`
  - `commandEndsPlanningPhase(...)`
  - `readStateWriteInputPayload(...)`
  - `extractDispatchBuiltinOperand(...)`
  - `findUnquotedOmxStateCommandIndexes(...)`
- `src/scripts/__tests__/codex-native-hook.test.ts`
  - the protected-planning regressions for Bash, `--mode`, `--input-file`, multiple writes, nested shell execution, `exec` / `command`, and MCP parity
- `docs/planning-gate-regression-3001.md`
  - incident-vs-defect classification and regression matrix

#### Protected planning attributes we treat as authoritative
- `mode`: `deep-interview` or `ralplan`
- `active`: `false` is a deactivation signal
- `current_phase`: terminal values such as `complete` / `failed` / other terminal completion states
- `run_outcome` and `lifecycle_outcome`: terminal completion/failure signals
- MCP `tool_input` payloads for `mcp__omx_state__state_write` and `mcp__omx_state__state_clear`

#### Scope we intentionally do not broaden here
- No new trusted helper or wrapper layer.
- No backend-only enforcement expansion in `src/state/operations.ts` for this PR.
- No automatic pane killing, relaunch, or state mutation from diagnostics.

## Project decisions taken in this follow-up
We kept the implementation at the native-hook transport boundary instead of moving authority into a new backend layer.

### 1) Bash parser hardening stayed in the hook
We kept the Bash-side guard fail-closed and expanded it to cover the real bypass shapes that showed up in review:
- honor CLI `--mode` before deactivation classification
- parse only the actual `omx state write` segment, not the whole shell line
- fail closed on multiple detected state-write invocations
- block dynamic shell dispatch patterns that could smuggle the payload through nested shell execution
- cover `exec` / `command` dispatch builtins even when options such as `--`, `-c`, `-p`, or `-a` appear before the real payload

### 2) MCP parity was implemented at the same boundary
Instead of introducing a new trusted-wrapper or provenance API, we mirrored the same planning-deactivation predicate for MCP state tools in the native hook:
- block `mcp__omx_state__state_clear` while protected planning is active
- block `mcp__omx_state__state_write` when its structured `tool_input` deactivates protected planning
- allow non-deactivating MCP state writes to continue

That keeps Bash and MCP aligned under one transport-policy rule, without inventing a new authority subsystem for this PR.

### 3) No new trusted helper layer was added
We explicitly avoided introducing a new internal-only wrapper/helper or a backend capability model in this PR. That design was rejected because it would add architectural weight without being required for the narrow PR #3001 blocker.

### 4) Diagnostics remain observation-only
The runtime/tmux incident was documented as a provenance and classification problem, not as proof that the latest code was broken. Diagnostics can report build/runtime state, but they do not mutate state, kill panes, or relaunch sessions.

### 5) The PR body/doc now separates hotfix, incident analysis, and follow-up work
The handoff doc distinguishes:
- immediate hook hotfix scope
- observation-only runtime diagnostics
- broader backend provenance / authority follow-up for later

## Validation
- `npm run build`
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js`
- `git diff --check`

## Summary
This follow-up keeps the original PR #3001 intent, but makes the design choice explicit: enforce planning-gate safety at the native-hook transport boundary, keep Bash and MCP policy in sync, avoid introducing a new trusted-wrapper subsystem, and document the runtime incident separately from the actual fix.
