### PR TITLE
Fix stop keyword path false positive

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -443,6 +443,16 @@ describe('keyword detector team compatibility', () => {
     assert.equal(match.keyword.toLowerCase(), 'stop');
   });
 
+  it('treats comma-delimited slash stop commands as cancel intent', () => {
+    for (const prompt of ['/stop, please', 'Please /stop, now']) {
+      const match = detectPrimaryKeyword(prompt);
+
+      assert.ok(match, `expected cancel match for ${prompt}`);
+      assert.equal(match.skill, 'cancel');
+      assert.equal(match.keyword.toLowerCase(), 'stop');
+    }
+  });
+
   it('does not trigger cancel from stop inside filenames or paths', () => {
     assert.equal(
       detectPrimaryKeyword('inspect .omx/context/stop-hook-invalid-json-handoff-20260629T210626Z.md'),
@@ -452,6 +462,9 @@ describe('keyword detector team compatibility', () => {
       detectPrimaryKeyword('Please summarize /tmp/stop-hook-invalid-json-handoff-20260629T210626Z.md'),
       null,
     );
+    assert.equal(detectPrimaryKeyword('inspect /stop.md'), null);
+    assert.equal(detectPrimaryKeyword('inspect /abort.md'), null);
+    assert.equal(detectPrimaryKeyword('inspect /stop:hook.md'), null);
   });
 
   it('does not trigger cancel from incidental stop/abort test-log prose', () => {

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -435,6 +435,25 @@ describe('keyword detector team compatibility', () => {
     assert.equal(match.keyword.toLowerCase(), 'stop');
   });
 
+  it('treats explicit slash stop commands as cancel intent', () => {
+    const match = detectPrimaryKeyword('/stop');
+
+    assert.ok(match);
+    assert.equal(match.skill, 'cancel');
+    assert.equal(match.keyword.toLowerCase(), 'stop');
+  });
+
+  it('does not trigger cancel from stop inside filenames or paths', () => {
+    assert.equal(
+      detectPrimaryKeyword('inspect .omx/context/stop-hook-invalid-json-handoff-20260629T210626Z.md'),
+      null,
+    );
+    assert.equal(
+      detectPrimaryKeyword('Please summarize /tmp/stop-hook-invalid-json-handoff-20260629T210626Z.md'),
+      null,
+    );
+  });
+
   it('does not trigger cancel from incidental stop/abort test-log prose', () => {
     assert.equal(detectPrimaryKeyword('FAIL should stop retrying after max attempts'), null);
     assert.equal(detectPrimaryKeyword('PASS request aborted when upstream returns 499'), null);

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -858,7 +858,7 @@ const KEYWORD_INTENT_PATTERNS: Record<IntentKeyword, RegExp[]> = {
     /^(?:please\s+)?stop(?:\s+now)?\s*[.!]?\s*$/i,
     /\bcancelomx\b/i,
     /(?:^|[^\w])\$(?:stop|cancel|abort)\b/i,
-    /\/(?:cancel|stop|abort)\b/i,
+    /(?:^|\s)\/(?:cancel|stop|abort)(?=[\s.!?;:]|$)/i,
     /\bstop\s+(?:the\s+)?(?:agent|ralph|autopilot|team|ultrawork|execution|current\s+(?:mode|task|run))\b/i,
     /\b(?:cancel|stop)\s+(?:the\s+)?(?:active|running|current)\s+(?:mode|task|run|execution)\b/i,
   ],
@@ -866,7 +866,7 @@ const KEYWORD_INTENT_PATTERNS: Record<IntentKeyword, RegExp[]> = {
     /^(?:please\s+)?abort(?:\s+now)?\s*[.!]?\s*$/i,
     /\bcancelomx\b/i,
     /(?:^|[^\w])\$(?:stop|cancel|abort)\b/i,
-    /\/(?:cancel|stop|abort)\b/i,
+    /(?:^|\s)\/(?:cancel|stop|abort)(?=[\s.!?;:]|$)/i,
     /\babort\s+(?:the\s+)?(?:agent|ralph|autopilot|team|ultrawork|execution|current\s+(?:mode|task|run))\b/i,
   ],
   parallel: [

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -858,7 +858,7 @@ const KEYWORD_INTENT_PATTERNS: Record<IntentKeyword, RegExp[]> = {
     /^(?:please\s+)?stop(?:\s+now)?\s*[.!]?\s*$/i,
     /\bcancelomx\b/i,
     /(?:^|[^\w])\$(?:stop|cancel|abort)\b/i,
-    /(?:^|\s)\/(?:cancel|stop|abort)(?=[\s.!?;:]|$)/i,
+    /(?:^|\s)\/(?:cancel|stop|abort)(?=[\s,!?;]|$)/i,
     /\bstop\s+(?:the\s+)?(?:agent|ralph|autopilot|team|ultrawork|execution|current\s+(?:mode|task|run))\b/i,
     /\b(?:cancel|stop)\s+(?:the\s+)?(?:active|running|current)\s+(?:mode|task|run|execution)\b/i,
   ],
@@ -866,7 +866,7 @@ const KEYWORD_INTENT_PATTERNS: Record<IntentKeyword, RegExp[]> = {
     /^(?:please\s+)?abort(?:\s+now)?\s*[.!]?\s*$/i,
     /\bcancelomx\b/i,
     /(?:^|[^\w])\$(?:stop|cancel|abort)\b/i,
-    /(?:^|\s)\/(?:cancel|stop|abort)(?=[\s.!?;:]|$)/i,
+    /(?:^|\s)\/(?:cancel|stop|abort)(?=[\s,!?;]|$)/i,
     /\babort\s+(?:the\s+)?(?:agent|ralph|autopilot|team|ultrawork|execution|current\s+(?:mode|task|run))\b/i,
   ],
   parallel: [


### PR DESCRIPTION
## Summary
- Tighten slash cancel/stop/abort keyword matching so `/stop` still works as an explicit command but `stop` inside filenames/paths does not trigger cancel mode.
- Add regression coverage for `.omx/context/stop-hook-...md` and `/tmp/stop-hook-...md` path mentions.

Fixes #3007

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/hooks/__tests__/keyword-detector.test.js` (174/174 passing)
- `npx biome lint src/hooks/keyword-detector.ts src/hooks/__tests__/keyword-detector.test.ts`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
