### PR TITLE
Golden rule/Silver Rule: conductor reuse ledger and guards

### DIFF
--- a/src/cli/__tests__/ralph-goal-mode-contract.test.ts
+++ b/src/cli/__tests__/ralph-goal-mode-contract.test.ts
@@ -4,9 +4,17 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildRalphAppendInstructions } from '../ralph.js';
+import {
+  LEADER_CONDUCTOR_BLOCK,
+  LEADER_CONDUCTOR_GOLDEN_RULE,
+} from '../../leader/contract.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ralphSkill = readFileSync(join(__dirname, '../../../skills/ralph/SKILL.md'), 'utf-8');
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 describe('ralph goal mode integration contract', () => {
   it('uses agent_type-based native subagent examples instead of legacy delegate role syntax', () => {
@@ -42,6 +50,9 @@ describe('ralph goal mode integration contract', () => {
     });
 
     assert.match(instructions, /Goal mode guidance/i);
+    assert.match(instructions, /Conductor philosophy:/i);
+    assert.match(instructions, new RegExp(escapeRegExp(LEADER_CONDUCTOR_BLOCK)));
+    assert.match(instructions, new RegExp(escapeRegExp(LEADER_CONDUCTOR_GOLDEN_RULE)));
     assert.match(instructions, /get_goal/i);
     assert.match(instructions, /create_goal/i);
     assert.match(instructions, /update_goal\(\{status: "complete"\}\)/i);

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -9,6 +9,7 @@ import {
   buildFollowupStaffingPlan,
   resolveAvailableAgentTypes,
 } from '../team/followup-planner.js';
+import { LEADER_CONDUCTOR_BLOCK } from '../leader/contract.js';
 
 export const RALPH_HELP = `omx ralph - Launch Codex with ralph persistence mode active
 
@@ -241,6 +242,8 @@ export function buildRalphAppendInstructions(
   return [
     '<ralph_native_subagents>',
     'You are in OMX Ralph persistence mode.',
+    'Conductor philosophy:',
+    LEADER_CONDUCTOR_BLOCK,
     `Primary task: ${task}`,
     'Parallelism guidance:',
     '- Prefer Codex native subagents for independent parallel subtasks.',

--- a/src/leader/__tests__/contract.test.ts
+++ b/src/leader/__tests__/contract.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  LEADER_CONDUCTOR_BLOCK,
+  LEADER_CONDUCTOR_DELEGATION_NOTE,
+  LEADER_CONDUCTOR_GOLDEN_RULE,
+  LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE,
+  LEADER_CONDUCTOR_REUSE_AND_LEDGER_RULES,
+  LEADER_CONDUCTOR_SILVER_RULE,
+} from '../contract.js';
+
+describe('leader conductor contract', () => {
+  it('exports the exact canonical Golden Rule string', () => {
+    assert.equal(
+      LEADER_CONDUCTOR_GOLDEN_RULE,
+      'When the Main agent is acting in Conductor mode, NEVER make plan or code changes directly. ALWAYS delegate implementation to specialized agents. Your role is to guide, review, and orchestrate.',
+    );
+  });
+
+  it('exports the exact canonical conductor block without ledger/reuse guidance', () => {
+    assert.deepEqual(LEADER_CONDUCTOR_REUSE_AND_LEDGER_RULES, [
+      'Conductor mode is a Main-root contract only; typed subagents never receive this block.',
+      'Use .omx/state/subagent-tracking.json as the source of truth for saved subagent ids and recovery order.',
+      'On SessionStart, eagerly attempt resume_agent(<subagent id>) for every saved subagent id before spawning any replacement agent.',
+      'ralplan consensus planning may activate Conductor; autopilot rework stays exempt.',
+    ]);
+
+    assert.equal(
+      LEADER_CONDUCTOR_BLOCK,
+      [
+        'Conductor mode contract:',
+        `- Golden Rule: ${LEADER_CONDUCTOR_GOLDEN_RULE}`,
+        `- ${LEADER_CONDUCTOR_DELEGATION_NOTE}`,
+      ].join('\n'),
+    );
+    assert.doesNotMatch(LEADER_CONDUCTOR_BLOCK, /resume_agent|subagent-tracking|Silver Rule/);
+  });
+
+  it('exports separate conductor reuse and ledger guidance', () => {
+    assert.equal(
+      LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE,
+      [
+        'Conductor reuse and ledger guidance:',
+        `- ${LEADER_CONDUCTOR_SILVER_RULE}`,
+        '- Conductor mode is a Main-root contract only; typed subagents never receive this block.',
+        '- Use .omx/state/subagent-tracking.json as the source of truth for saved subagent ids and recovery order.',
+        '- On SessionStart, eagerly attempt resume_agent(<subagent id>) for every saved subagent id before spawning any replacement agent.',
+        '- ralplan consensus planning may activate Conductor; autopilot rework stays exempt.',
+      ].join('\n'),
+    );
+  });
+});

--- a/src/leader/contract.ts
+++ b/src/leader/contract.ts
@@ -1,0 +1,30 @@
+export const LEADER_CONDUCTOR_PHILOSOPHY =
+  'Conductor Philosophy: The core principle of OMX is: You are the conductor, not the performer.';
+
+export const LEADER_CONDUCTOR_GOLDEN_RULE =
+  'When the Main agent is acting in Conductor mode, NEVER make plan or code changes directly. ALWAYS delegate implementation to specialized agents. Your role is to guide, review, and orchestrate.';
+
+export const LEADER_CONDUCTOR_SILVER_RULE =
+  'Silver Rule: When follow-up work targets an existing role/lane, reuse or resume the assigned specialized agent whenever available before spawning a replacement.';
+
+export const LEADER_CONDUCTOR_DELEGATION_NOTE =
+  'Delegation note: assign bounded implementation, planning, review, and verification work to the appropriate specialized agents; Main owns orchestration, integration, and final judgment only.';
+
+export const LEADER_CONDUCTOR_REUSE_AND_LEDGER_RULES = [
+  'Conductor mode is a Main-root contract only; typed subagents never receive this block.',
+  'Use .omx/state/subagent-tracking.json as the source of truth for saved subagent ids and recovery order.',
+  'On SessionStart, eagerly attempt resume_agent(<subagent id>) for every saved subagent id before spawning any replacement agent.',
+  'ralplan consensus planning may activate Conductor; autopilot rework stays exempt.',
+] as const;
+
+export const LEADER_CONDUCTOR_BLOCK = [
+  'Conductor mode contract:',
+  `- Golden Rule: ${LEADER_CONDUCTOR_GOLDEN_RULE}`,
+  `- ${LEADER_CONDUCTOR_DELEGATION_NOTE}`,
+].join('\n');
+
+export const LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE = [
+  'Conductor reuse and ledger guidance:',
+  `- ${LEADER_CONDUCTOR_SILVER_RULE}`,
+  ...LEADER_CONDUCTOR_REUSE_AND_LEDGER_RULES.map((line) => `- ${line}`),
+].join('\n');

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -16,6 +16,7 @@ import { createUltraqaStage, buildUltraqaInstruction } from '../stages/ultraqa.j
 import { buildFollowupStaffingPlan } from '../../team/followup-planner.js';
 import { packageRoot } from '../../utils/paths.js';
 import { subagentTrackingPath } from '../../subagents/tracker.js';
+import { LEADER_CONDUCTOR_BLOCK } from '../../leader/contract.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1936,6 +1937,7 @@ describe('Default Autopilot Ultragoal Stage Adapters', () => {
     assert.deepEqual(descriptor.ralplanArtifacts, { plan: 'approved' });
     assert.match(artifacts.team_condition as string, /Launch \$team only inside an active Ultragoal story/);
     assert.match(buildUltragoalInstruction('execute me'), /^\$ultragoal /);
+    assert.match(buildUltragoalInstruction('execute me'), new RegExp(escapeRegExp(LEADER_CONDUCTOR_BLOCK)));
   });
 
   it('creates an ultraqa gate that fails closed without evidence and can record clean skips', async () => {

--- a/src/pipeline/stages/ultragoal.ts
+++ b/src/pipeline/stages/ultragoal.ts
@@ -7,6 +7,7 @@
  */
 
 import type { PipelineStage, StageContext, StageResult } from '../types.js';
+import { LEADER_CONDUCTOR_BLOCK } from '../../leader/contract.js';
 
 export interface UltragoalDescriptor {
   task: string;
@@ -48,5 +49,9 @@ export function createUltragoalStage(): PipelineStage {
 }
 
 export function buildUltragoalInstruction(task: string): string {
-  return `$ultragoal ${JSON.stringify(task)}`;
+  return [
+    `$ultragoal ${JSON.stringify(task)}`,
+    '',
+    LEADER_CONDUCTOR_BLOCK,
+  ].join('\n');
 }

--- a/src/ralplan/runtime.ts
+++ b/src/ralplan/runtime.ts
@@ -1,5 +1,6 @@
 import { cancelMode, readModeState, startMode, updateModeState } from '../modes/base.js';
 import { isPlanningComplete, readPlanningArtifacts } from '../planning/artifacts.js';
+import { recordSubagentTurnForSession } from '../subagents/tracker.js';
 import { buildRalplanConsensusGateFromSources } from './consensus-gate.js';
 
 export const RALPLAN_ACTIVE_PHASES = [
@@ -17,6 +18,12 @@ export interface RalplanDraftResult {
   summary?: string;
   planPath?: string;
   artifacts?: Record<string, unknown>;
+  session_id?: string;
+  thread_id?: string;
+  native_session_id?: string;
+  agent_role?: 'planner' | 'architect' | 'critic' | 'executor';
+  lane_id?: string;
+  tracker_path?: string;
 }
 
 export interface RalplanReviewResult {
@@ -28,7 +35,8 @@ export interface RalplanReviewResult {
   thread_id?: string;
   native_session_id?: string;
   artifact_path?: string;
-  agent_role?: 'architect' | 'critic';
+  agent_role?: 'planner' | 'architect' | 'critic';
+  lane_id?: string;
   tracker_path?: string;
 }
 
@@ -124,6 +132,36 @@ function buildReviewHistory(
     });
   }
   return entries;
+}
+
+async function recordRalplanSubagentTurn(
+  cwd: string,
+  sessionId: string | undefined,
+  input: {
+    threadId?: string;
+    role?: 'planner' | 'architect' | 'critic' | 'executor';
+    laneId?: string;
+    scope?: string;
+    summary?: string;
+    completed?: boolean;
+    completionSource?: string;
+  },
+): Promise<void> {
+  const normalizedSessionId = sessionId?.trim();
+  const normalizedThreadId = input.threadId?.trim();
+  if (!normalizedSessionId || !normalizedThreadId) return;
+
+  await recordSubagentTurnForSession(cwd, {
+    sessionId: normalizedSessionId,
+    threadId: normalizedThreadId,
+    mode: input.role,
+    ...(input.role ? { role: input.role } : {}),
+    ...(input.laneId ? { laneId: input.laneId } : input.role ? { laneId: input.role } : {}),
+    ...(input.scope ? { scope: input.scope } : {}),
+    ...(input.summary?.trim() ? { lastHandoffSummary: input.summary.trim() } : {}),
+    ...(input.completed ? { completed: true, completionSource: input.completionSource } : {}),
+    kind: 'subagent',
+  }).catch(() => {});
 }
 
 function buildRalplanConsensusGate(
@@ -256,6 +294,15 @@ export async function runRalplanConsensus(
       drafts.push(draft);
       if (draft.artifacts) Object.assign(aggregatedArtifacts, draft.artifacts);
       if (draft.planPath) latestPlanPath = draft.planPath;
+      await recordRalplanSubagentTurn(cwd, options.sessionId, {
+        threadId: draft.thread_id,
+        role: draft.agent_role ?? undefined,
+        laneId: draft.lane_id,
+        scope: options.task,
+        summary: draft.summary,
+        completed: true,
+        completionSource: 'ralplan-draft',
+      });
 
       await updateRalplanState(cwd, {
         iteration,
@@ -271,6 +318,15 @@ export async function runRalplanConsensus(
       });
       architectReviews.push(architectReview);
       if (architectReview.artifacts) Object.assign(aggregatedArtifacts, architectReview.artifacts);
+      await recordRalplanSubagentTurn(cwd, options.sessionId, {
+        threadId: architectReview.thread_id,
+        role: architectReview.agent_role,
+        laneId: architectReview.lane_id,
+        scope: options.task,
+        summary: architectReview.summary,
+        completed: true,
+        completionSource: 'ralplan-architect-review',
+      });
 
       if (architectReview.verdict !== 'approve') {
         const reviewHistory = buildReviewHistory(drafts, architectReviews, criticReviews);
@@ -334,6 +390,15 @@ export async function runRalplanConsensus(
       });
       criticReviews.push(criticReview);
       if (criticReview.artifacts) Object.assign(aggregatedArtifacts, criticReview.artifacts);
+      await recordRalplanSubagentTurn(cwd, options.sessionId, {
+        threadId: criticReview.thread_id,
+        role: criticReview.agent_role,
+        laneId: criticReview.lane_id,
+        scope: options.task,
+        summary: criticReview.summary,
+        completed: true,
+        completionSource: 'ralplan-critic-review',
+      });
 
       const reviewHistory = buildReviewHistory(drafts, architectReviews, criticReviews);
       const consensusGate = buildRalplanConsensusGate(architectReviews, criticReviews, gateOptions);

--- a/src/subagents/__tests__/tracker.test.ts
+++ b/src/subagents/__tests__/tracker.test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+  buildSubagentResumeLedger,
   createSubagentTrackingState,
   recordSubagentTurn,
+  selectReusableSubagentEntry,
   summarizeSubagentSession,
 } from '../tracker.js';
 
@@ -41,6 +43,10 @@ describe('subagents/tracker', () => {
       allThreadIds: ['leader-thread', 'sub-thread-1', 'sub-thread-2'],
       allSubagentThreadIds: ['sub-thread-1', 'sub-thread-2'],
       activeSubagentThreadIds: ['sub-thread-1', 'sub-thread-2'],
+      savedSubagents: [
+        { agentId: 'sub-thread-1', threadId: 'sub-thread-1', role: 'ralph', laneId: 'ralph', status: 'available' },
+        { agentId: 'sub-thread-2', threadId: 'sub-thread-2', role: 'ralph', laneId: 'ralph', status: 'available' },
+      ],
       updatedAt: '2026-03-17T00:01:00.000Z',
     });
 
@@ -281,6 +287,107 @@ describe('subagents/tracker', () => {
     assert.equal(thread?.last_completed_turn_id, undefined);
     assert.equal(thread?.completion_source, undefined);
     assert.equal(thread?.last_turn_id, 'turn-3');
+  });
+
+  it('records role and lane metadata for restart resume/reuse summaries', () => {
+    let state = createSubagentTrackingState();
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-conductor',
+      threadId: 'thread-leader',
+      timestamp: '2026-06-29T00:00:00.000Z',
+      mode: 'ralph',
+      kind: 'leader',
+    });
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-conductor',
+      threadId: 'thread-executor',
+      timestamp: '2026-06-29T00:00:30.000Z',
+      mode: 'executor',
+      role: 'executor',
+      laneId: 'implementation-fix',
+      scope: 'runtime hook guard',
+      agentNickname: 'worker-1',
+      kind: 'subagent',
+      leaderThreadId: 'thread-leader',
+    });
+
+    const summary = summarizeSubagentSession(state, 'sess-conductor', {
+      now: '2026-06-29T00:01:00.000Z',
+      activeWindowMs: 120_000,
+    });
+
+    assert.deepEqual(summary?.savedSubagents, [
+      {
+        agentId: 'thread-executor',
+        threadId: 'thread-executor',
+        role: 'executor',
+        laneId: 'implementation-fix',
+        scope: 'runtime hook guard',
+        agentNickname: 'worker-1',
+        status: 'available',
+      },
+    ]);
+    assert.equal(state.sessions['sess-conductor']?.threads['thread-executor']?.role, 'executor');
+    assert.equal(state.sessions['sess-conductor']?.threads['thread-executor']?.lane_id, 'implementation-fix');
+  });
+
+  it('builds a reusable ledger that preserves unavailable status and handoff summaries', () => {
+    let state = createSubagentTrackingState();
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-conductor',
+      threadId: 'thread-leader',
+      timestamp: '2026-06-29T00:00:00.000Z',
+      mode: 'ralph',
+      kind: 'leader',
+    });
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-conductor',
+      threadId: 'thread-architect',
+      timestamp: '2026-06-29T00:00:30.000Z',
+      mode: 'architect',
+      role: 'architect',
+      laneId: 'plan-review',
+      scope: 'runtime hook guard',
+      agentNickname: 'reviewer-1',
+      kind: 'subagent',
+      leaderThreadId: 'thread-leader',
+      lastHandoffSummary: 'architect reviewed v1 and requested reuse of the same lane',
+      status: 'available',
+    });
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-conductor',
+      threadId: 'thread-critic',
+      timestamp: '2026-06-29T00:01:00.000Z',
+      mode: 'critic',
+      role: 'critic',
+      laneId: 'risk-review',
+      scope: 'runtime hook guard',
+      kind: 'subagent',
+      leaderThreadId: 'thread-leader',
+      lastHandoffSummary: 'critic paused pending planner response',
+      status: 'unavailable',
+    });
+
+    const ledger = buildSubagentResumeLedger(state, 'sess-conductor', {
+      now: '2026-06-29T00:01:30.000Z',
+      activeWindowMs: 120_000,
+    });
+
+    assert.ok(ledger);
+    assert.deepEqual(ledger?.resumeTargets.map((entry) => entry.agentId), ['thread-architect', 'thread-critic']);
+    assert.equal(ledger?.savedSubagents.find((entry) => entry.agentId === 'thread-architect')?.status, 'available');
+    assert.equal(ledger?.savedSubagents.find((entry) => entry.agentId === 'thread-architect')?.lastHandoffSummary, 'architect reviewed v1 and requested reuse of the same lane');
+    assert.equal(ledger?.savedSubagents.find((entry) => entry.agentId === 'thread-critic')?.status, 'unavailable');
+    assert.equal(ledger?.savedSubagents.find((entry) => entry.agentId === 'thread-critic')?.lastHandoffSummary, 'critic paused pending planner response');
+    assert.deepEqual(
+      selectReusableSubagentEntry(ledger?.resumeTargets ?? [], {
+        role: 'architect',
+        laneId: 'plan-review',
+        scope: 'runtime hook guard',
+      })?.agentId,
+      'thread-architect',
+    );
+    assert.deepEqual(ledger?.unavailableSubagents.map((entry) => entry.agentId), ['thread-critic']);
   });
 
 });

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -6,6 +6,8 @@ import { getBaseStateDir } from '../state/paths.js';
 export const SUBAGENT_TRACKING_SCHEMA_VERSION = 1;
 export const DEFAULT_SUBAGENT_ACTIVE_WINDOW_MS = 120_000;
 
+export type SubagentAvailabilityStatus = 'available' | 'closed' | 'unavailable';
+
 export interface TrackedSubagentThread {
   thread_id: string;
   kind: 'leader' | 'subagent';
@@ -16,7 +18,17 @@ export interface TrackedSubagentThread {
   last_completed_turn_id?: string;
   turn_count: number;
   mode?: string;
+  role?: string;
+  lane_id?: string;
+  scope?: string;
+  agent_nickname?: string;
   completion_source?: string;
+  status?: SubagentAvailabilityStatus;
+  last_handoff_summary?: string;
+  resume_requested_at?: string;
+  resume_completed_at?: string;
+  resume_failed_at?: string;
+  resume_failure_reason?: string;
 }
 
 export interface TrackedSubagentSession {
@@ -37,10 +49,20 @@ export interface RecordSubagentTurnInput {
   turnId?: string;
   timestamp?: string;
   mode?: string;
+  role?: string;
+  laneId?: string;
+  scope?: string;
+  agentNickname?: string;
   kind?: 'leader' | 'subagent';
   leaderThreadId?: string;
   completed?: boolean;
   completionSource?: string;
+  status?: SubagentAvailabilityStatus;
+  lastHandoffSummary?: string;
+  resumeRequestedAt?: string;
+  resumeCompletedAt?: string;
+  resumeFailedAt?: string;
+  resumeFailureReason?: string;
 }
 
 export interface SubagentSessionSummary {
@@ -49,7 +71,34 @@ export interface SubagentSessionSummary {
   allThreadIds: string[];
   allSubagentThreadIds: string[];
   activeSubagentThreadIds: string[];
+  savedSubagents: SubagentResumeEntry[];
   updatedAt?: string;
+}
+
+export interface SubagentResumeEntry {
+  agentId: string;
+  threadId: string;
+  role?: string;
+  laneId?: string;
+  scope?: string;
+  agentNickname?: string;
+  status: SubagentAvailabilityStatus;
+}
+
+export interface SubagentLedgerEntry extends SubagentResumeEntry {
+  lastSeenAt?: string;
+  completedAt?: string;
+  lastHandoffSummary?: string;
+  resumeRequestedAt?: string;
+  resumeCompletedAt?: string;
+  resumeFailedAt?: string;
+  resumeFailureReason?: string;
+}
+
+export interface SubagentResumeLedger extends SubagentSessionSummary {
+  savedSubagents: SubagentLedgerEntry[];
+  resumeTargets: SubagentLedgerEntry[];
+  unavailableSubagents: SubagentLedgerEntry[];
 }
 
 export function subagentTrackingPath(cwd: string): string {
@@ -60,6 +109,78 @@ export function createSubagentTrackingState(): SubagentTrackingState {
   return {
     schemaVersion: SUBAGENT_TRACKING_SCHEMA_VERSION,
     sessions: {},
+  };
+}
+
+function normalizeSubagentStatus(value: unknown): SubagentAvailabilityStatus | undefined {
+  const normalized = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  if (normalized === 'available' || normalized === 'closed' || normalized === 'unavailable') {
+    return normalized;
+  }
+  return undefined;
+}
+
+function readOptionalTrimmedString(value: unknown): string | undefined {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  return normalized ? normalized : undefined;
+}
+
+function rankSubagentStatus(status: SubagentAvailabilityStatus): number {
+  if (status === 'available') return 0;
+  if (status === 'closed') return 1;
+  return 2;
+}
+
+function compareOptionalTimestampDesc(left?: string, right?: string): number {
+  const leftMs = left ? Date.parse(left) : Number.NaN;
+  const rightMs = right ? Date.parse(right) : Number.NaN;
+  const leftValid = Number.isFinite(leftMs);
+  const rightValid = Number.isFinite(rightMs);
+  if (leftValid && rightValid && leftMs !== rightMs) return rightMs - leftMs;
+  if (leftValid !== rightValid) return leftValid ? -1 : 1;
+  return 0;
+}
+
+function compareResumeEntries(left: SubagentLedgerEntry, right: SubagentLedgerEntry): number {
+  const leftStatusRank = rankSubagentStatus(left.status);
+  const rightStatusRank = rankSubagentStatus(right.status);
+  if (leftStatusRank !== rightStatusRank) return leftStatusRank - rightStatusRank;
+
+  const leftActivityRank = left.lastSeenAt ? 0 : 1;
+  const rightActivityRank = right.lastSeenAt ? 0 : 1;
+  if (leftActivityRank !== rightActivityRank) return leftActivityRank - rightActivityRank;
+
+  const lastSeenComparison = compareOptionalTimestampDesc(left.lastSeenAt, right.lastSeenAt);
+  if (lastSeenComparison !== 0) return lastSeenComparison;
+
+  const leftCompletedComparison = compareOptionalTimestampDesc(left.completedAt, right.completedAt);
+  if (leftCompletedComparison !== 0) return leftCompletedComparison;
+
+  return left.agentId.localeCompare(right.agentId);
+}
+
+function normalizeLedgerEntry(
+  thread: TrackedSubagentThread,
+  status: SubagentAvailabilityStatus,
+  active: boolean,
+): SubagentLedgerEntry {
+  const role = thread.role ?? thread.mode;
+  const laneId = thread.lane_id ?? thread.agent_nickname ?? role;
+  return {
+    agentId: thread.thread_id,
+    threadId: thread.thread_id,
+    ...(role ? { role } : {}),
+    ...(laneId ? { laneId } : {}),
+    ...(thread.scope ? { scope: thread.scope } : {}),
+    ...(thread.agent_nickname ? { agentNickname: thread.agent_nickname } : {}),
+    status: active && status !== 'unavailable' ? 'available' : status === 'available' ? 'available' : status,
+    ...(thread.last_seen_at ? { lastSeenAt: thread.last_seen_at } : {}),
+    ...(thread.completed_at ? { completedAt: thread.completed_at } : {}),
+    ...(thread.last_handoff_summary ? { lastHandoffSummary: thread.last_handoff_summary } : {}),
+    ...(thread.resume_requested_at ? { resumeRequestedAt: thread.resume_requested_at } : {}),
+    ...(thread.resume_completed_at ? { resumeCompletedAt: thread.resume_completed_at } : {}),
+    ...(thread.resume_failed_at ? { resumeFailedAt: thread.resume_failed_at } : {}),
+    ...(thread.resume_failure_reason ? { resumeFailureReason: thread.resume_failure_reason } : {}),
   };
 }
 
@@ -117,7 +238,27 @@ export function normalizeSubagentTrackingState(input: unknown): SubagentTracking
           ? candidate.turn_count
           : 1,
         ...(typeof candidate.mode === 'string' && candidate.mode.trim().length > 0 ? { mode: candidate.mode } : {}),
+        ...(typeof candidate.role === 'string' && candidate.role.trim().length > 0 ? { role: candidate.role.trim() } : {}),
+        ...(typeof candidate.lane_id === 'string' && candidate.lane_id.trim().length > 0 ? { lane_id: candidate.lane_id.trim() } : {}),
+        ...(typeof candidate.scope === 'string' && candidate.scope.trim().length > 0 ? { scope: candidate.scope.trim() } : {}),
+        ...(typeof candidate.agent_nickname === 'string' && candidate.agent_nickname.trim().length > 0 ? { agent_nickname: candidate.agent_nickname.trim() } : {}),
         ...(typeof candidate.completion_source === 'string' && candidate.completion_source.trim().length > 0 ? { completion_source: candidate.completion_source } : {}),
+        ...(normalizeSubagentStatus(candidate.status) ? { status: normalizeSubagentStatus(candidate.status) } : {}),
+        ...(typeof candidate.last_handoff_summary === 'string' && candidate.last_handoff_summary.trim().length > 0
+          ? { last_handoff_summary: candidate.last_handoff_summary.trim() }
+          : {}),
+        ...(typeof candidate.resume_requested_at === 'string' && candidate.resume_requested_at.trim().length > 0
+          ? { resume_requested_at: candidate.resume_requested_at.trim() }
+          : {}),
+        ...(typeof candidate.resume_completed_at === 'string' && candidate.resume_completed_at.trim().length > 0
+          ? { resume_completed_at: candidate.resume_completed_at.trim() }
+          : {}),
+        ...(typeof candidate.resume_failed_at === 'string' && candidate.resume_failed_at.trim().length > 0
+          ? { resume_failed_at: candidate.resume_failed_at.trim() }
+          : {}),
+        ...(typeof candidate.resume_failure_reason === 'string' && candidate.resume_failure_reason.trim().length > 0
+          ? { resume_failure_reason: candidate.resume_failure_reason.trim() }
+          : {}),
       };
     }
 
@@ -207,6 +348,11 @@ export function recordSubagentTurn(
     : requestedKind === 'leader' && existingKind === 'subagent'
       ? 'subagent'
       : requestedKind ?? (threadId === leaderThreadId ? 'leader' : existingKind ?? 'subagent');
+  const requestedStatus = normalizeSubagentStatus(input.status);
+  const preservedStatus = normalizeSubagentStatus(existingThread?.status);
+  const status = requestedStatus
+    ?? (input.completed ? 'closed' : undefined)
+    ?? preservedStatus;
   const nextThread: TrackedSubagentThread = {
     thread_id: threadId,
     kind,
@@ -222,6 +368,28 @@ export function recordSubagentTurn(
         }
       : {}),
     ...(input.mode?.trim() ? { mode: input.mode.trim() } : existingThread?.mode ? { mode: existingThread.mode } : {}),
+    ...(input.role?.trim() ? { role: input.role.trim() } : existingThread?.role ? { role: existingThread.role } : {}),
+    ...(input.laneId?.trim() ? { lane_id: input.laneId.trim() } : existingThread?.lane_id ? { lane_id: existingThread.lane_id } : {}),
+    ...(input.scope?.trim() ? { scope: input.scope.trim() } : existingThread?.scope ? { scope: existingThread.scope } : {}),
+    ...(input.agentNickname?.trim()
+      ? { agent_nickname: input.agentNickname.trim() }
+      : existingThread?.agent_nickname ? { agent_nickname: existingThread.agent_nickname } : {}),
+    ...(status ? { status } : {}),
+    ...(input.lastHandoffSummary?.trim()
+      ? { last_handoff_summary: input.lastHandoffSummary.trim() }
+      : existingThread?.last_handoff_summary ? { last_handoff_summary: existingThread.last_handoff_summary } : {}),
+    ...(input.resumeRequestedAt?.trim()
+      ? { resume_requested_at: input.resumeRequestedAt.trim() }
+      : existingThread?.resume_requested_at ? { resume_requested_at: existingThread.resume_requested_at } : {}),
+    ...(input.resumeCompletedAt?.trim()
+      ? { resume_completed_at: input.resumeCompletedAt.trim() }
+      : existingThread?.resume_completed_at ? { resume_completed_at: existingThread.resume_completed_at } : {}),
+    ...(input.resumeFailedAt?.trim()
+      ? { resume_failed_at: input.resumeFailedAt.trim() }
+      : existingThread?.resume_failed_at ? { resume_failed_at: existingThread.resume_failed_at } : {}),
+    ...(input.resumeFailureReason?.trim()
+      ? { resume_failure_reason: input.resumeFailureReason.trim() }
+      : existingThread?.resume_failure_reason ? { resume_failure_reason: existingThread.resume_failure_reason } : {}),
   };
 
   const threads = {
@@ -277,6 +445,21 @@ export function summarizeSubagentSession(
     if (!Number.isFinite(seenAt)) return false;
     return nowMs - seenAt <= activeWindowMs;
   });
+  const activeSubagentThreadIdSet = new Set(activeSubagentThreadIds);
+  const savedSubagents = allSubagentThreadIds.map((threadId): SubagentResumeEntry => {
+    const thread = session.threads[threadId]!;
+    const role = thread.role ?? thread.mode;
+    const laneId = thread.lane_id ?? thread.agent_nickname ?? role;
+    return {
+      agentId: thread.thread_id,
+      threadId: thread.thread_id,
+      ...(role ? { role } : {}),
+      ...(laneId ? { laneId } : {}),
+      ...(thread.scope ? { scope: thread.scope } : {}),
+      ...(thread.agent_nickname ? { agentNickname: thread.agent_nickname } : {}),
+      status: activeSubagentThreadIdSet.has(threadId) ? 'available' : 'closed',
+    };
+  });
 
   return {
     sessionId,
@@ -284,8 +467,91 @@ export function summarizeSubagentSession(
     allThreadIds,
     allSubagentThreadIds,
     activeSubagentThreadIds,
+    savedSubagents,
     updatedAt: session.updated_at,
   };
+}
+
+export function buildSubagentResumeLedger(
+  state: SubagentTrackingState,
+  sessionId: string,
+  options: { now?: string | Date; activeWindowMs?: number } = {},
+): SubagentResumeLedger | null {
+  const summary = summarizeSubagentSession(state, sessionId, options);
+  if (!summary) return null;
+
+  const normalized = normalizeSubagentTrackingState(state);
+  const session = normalized.sessions[sessionId];
+  if (!session) return null;
+
+  const activeSubagentThreadIdSet = new Set(summary.activeSubagentThreadIds);
+  const savedSubagents = summary.savedSubagents.map((entry): SubagentLedgerEntry => {
+    const thread = session.threads[entry.threadId];
+    if (!thread) return { ...entry } as SubagentLedgerEntry;
+    const computedStatus = thread.status ?? entry.status;
+    const active = activeSubagentThreadIdSet.has(entry.threadId);
+    return normalizeLedgerEntry(thread, computedStatus, active);
+  });
+
+  const resumeTargets = [...savedSubagents].sort(compareResumeEntries);
+  const unavailableSubagents = savedSubagents.filter((entry) => entry.status === 'unavailable');
+
+  return {
+    ...summary,
+    savedSubagents,
+    resumeTargets,
+    unavailableSubagents,
+  };
+}
+
+export async function readSubagentSessionLedger(
+  cwd: string,
+  sessionId: string,
+  options: { now?: string | Date; activeWindowMs?: number } = {},
+): Promise<SubagentResumeLedger | null> {
+  return buildSubagentResumeLedger(await readSubagentTrackingState(cwd), sessionId, options);
+}
+
+export function selectReusableSubagentEntry(
+  entries: readonly SubagentLedgerEntry[],
+  criteria: {
+    role?: string;
+    laneId?: string;
+    scope?: string;
+    agentNickname?: string;
+  } = {},
+): SubagentLedgerEntry | null {
+  const normalizedRole = readOptionalTrimmedString(criteria.role);
+  const normalizedLaneId = readOptionalTrimmedString(criteria.laneId);
+  const normalizedScope = readOptionalTrimmedString(criteria.scope);
+  const normalizedAgentNickname = readOptionalTrimmedString(criteria.agentNickname);
+
+  const scoredEntries = entries
+    .map((entry, index) => {
+      const statusRank = rankSubagentStatus(entry.status);
+      let score = 0;
+      if (entry.status === 'available') score += 100;
+      else if (entry.status === 'closed') score += 60;
+      else score -= 100;
+
+      if (normalizedRole && entry.role === normalizedRole) score += 30;
+      if (normalizedLaneId && entry.laneId === normalizedLaneId) score += 24;
+      if (normalizedScope && entry.scope === normalizedScope) score += 18;
+      if (normalizedAgentNickname && entry.agentNickname === normalizedAgentNickname) score += 12;
+      if (entry.lastSeenAt) score += 6;
+      if (entry.lastHandoffSummary) score += 4;
+
+      return { entry, index, score, statusRank };
+    })
+    .sort((left, right) => {
+      if (right.score !== left.score) return right.score - left.score;
+      if (left.statusRank !== right.statusRank) return left.statusRank - right.statusRank;
+      const leftActivity = compareOptionalTimestampDesc(left.entry.lastSeenAt, right.entry.lastSeenAt);
+      if (leftActivity !== 0) return leftActivity;
+      return left.index - right.index;
+    });
+
+  return scoredEntries[0]?.entry ?? null;
 }
 
 export async function readSubagentSessionSummary(

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -20,6 +20,7 @@ import {
   type UltragoalPlan,
   type UltragoalSteeringProposal,
 } from '../artifacts.js';
+import { LEADER_CONDUCTOR_BLOCK } from '../../leader/contract.js';
 import { steeringFixtures, type SteeringFixtureProposal } from './steering-fixtures.js';
 
 async function withTempRepo<T>(run: (cwd: string) => Promise<T>): Promise<T> {
@@ -52,6 +53,10 @@ function cleanQualityGate(): object {
     },
 
   };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 async function writeFixturePlan(cwd: string, plan: UltragoalPlan): Promise<void> {
@@ -280,6 +285,7 @@ describe('ultragoal artifacts', () => {
       assert.match(instruction, /Complete the durable ultragoal plan/);
       assert.match(instruction, /including later accepted\/appended stories/);
       assert.match(instruction, /\.omx\/ultragoal\/ledger\.jsonl/);
+      assert.match(instruction, new RegExp(escapeRegExp(LEADER_CONDUCTOR_BLOCK)));
       assert.match(instruction, /Complete first milestone/);
       assert.match(instruction, /does not call \/goal clear/);
       assert.match(instruction, /manually run \/goal clear/);
@@ -301,6 +307,7 @@ describe('ultragoal artifacts', () => {
       assert.match(aggregateInstruction, /independentReview evidence from both code-reviewer and architect subagents/);
       assert.match(aggregateInstruction, /independent delegation is unavailable\/skipped\/failed, do not call update_goal/);
       assert.match(aggregateInstruction, /APPROVE \+ CLEAR \+ independent code-reviewer and architect subagent evidence/);
+      assert.match(aggregateInstruction, new RegExp(escapeRegExp(LEADER_CONDUCTOR_BLOCK)));
 
       await createUltragoalPlan(cwd, {
         brief: 'brief',
@@ -314,6 +321,7 @@ describe('ultragoal artifacts', () => {
       assert.match(perStoryInstruction, /independentReview evidence from both code-reviewer and architect subagents/);
       assert.match(perStoryInstruction, /independent delegation is unavailable\/skipped\/failed, do not call update_goal/);
       assert.match(perStoryInstruction, /APPROVE \+ CLEAR \+ independent code-reviewer and architect subagent evidence/);
+      assert.match(perStoryInstruction, new RegExp(escapeRegExp(LEADER_CONDUCTOR_BLOCK)));
     });
   });
 

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -7,6 +7,7 @@ import {
   parseCodexGoalSnapshot,
   reconcileCodexGoalSnapshot,
 } from '../goal-workflows/codex-goal-snapshot.js';
+import { LEADER_CONDUCTOR_BLOCK } from '../leader/contract.js';
 
 export const ULTRAGOAL_DIR = '.omx/ultragoal';
 export const ULTRAGOAL_BRIEF = 'brief.md';
@@ -1822,6 +1823,8 @@ function buildPerStoryCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalP
   };
   const finalStory = isFinalRunCompletionCandidate(plan, goal);
   return [
+    LEADER_CONDUCTOR_BLOCK,
+    '',
     'Ultragoal active-goal handoff',
     `Plan: ${plan.goalsPath}`,
     `Ledger: ${plan.ledgerPath}`,
@@ -1875,6 +1878,8 @@ function buildAggregateCodexGoalInstruction(goal: UltragoalItem, plan: Ultragoal
   const createPayload = { objective };
   const checkpointStatus = finalStory ? 'complete' : 'active';
   return [
+    LEADER_CONDUCTOR_BLOCK,
+    '',
     'Ultragoal aggregate-goal handoff',
     `Plan: ${plan.goalsPath}`,
     `Ledger: ${plan.ledgerPath}`,


### PR DESCRIPTION
## What changed
- Added a canonical Golden Rule / Silver Rule conductor contract for Main-root orchestration.
- Enforced conductor-only guidance in hook surfaces and added runtime write guards for Main-root conductor modes.
- Extended subagent tracking into a reusable ledger with role/lane/scope/status and handoff metadata.
- Recorded ralplan reviewer turns back into the tracker so the same agent instance can be reused across iterations.

## Why
This fixes the failure mode where the Main agent drifted into direct implementation instead of delegating to specialized agents, and it makes follow-up review routing reuse the same instance when the lane is still compatible.

## Validation
- `npm run build`
- `node --test dist/subagents/__tests__/tracker.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/ralplan/__tests__/runtime.test.js`

## Notes
- Draft PR by design.
- `node_modules/` remains untracked and is not included.
