### PR TITLE
Fix Windows psmux question renderer

### DIFF
--- a/src/question/__tests__/renderer.test.ts
+++ b/src/question/__tests__/renderer.test.ts
@@ -57,15 +57,26 @@ describe('resolveQuestionRendererStrategy', () => {
     );
   });
 
-  it('uses a detached Windows console for native psmux return bridges', () => {
+  it('uses an interactive shell pane for native Windows psmux sessions', () => {
     assert.equal(
       resolveQuestionRendererStrategy(
         { TMUX: 'psmux-session', TMUX_PANE: '%44' } as NodeJS.ProcessEnv,
         'C:/Program Files/psmux/psmux.exe',
         { platform: 'win32' },
       ),
-      'windows-console',
+      'windows-psmux-shell-pane',
     );
+    assert.equal(
+      resolveQuestionRendererStrategy(
+        { TMUX: 'socket,1,0', TMUX_PANE: '%45' } as NodeJS.ProcessEnv,
+        'C:/Program Files/psmux/psmux.exe',
+        { platform: 'win32' },
+      ),
+      'windows-psmux-shell-pane',
+    );
+  });
+
+  it('keeps the detached Windows console path for explicit non-psmux return bridges', () => {
     assert.equal(
       resolveQuestionRendererStrategy(
         { OMX_QUESTION_RETURN_PANE: '%45' } as NodeJS.ProcessEnv,
@@ -776,7 +787,61 @@ describe('launchQuestionRenderer', () => {
     assert.ok(calls.some((call) => call.join(' ') === 'list-panes -t %78 -F #{pane_dead}\t#{pane_id}'));
   });
 
-  it('opens a detached Windows console instead of a psmux split pane when a return bridge is present', () => {
+  it('opens a visible Windows psmux shell pane and injects the question UI command literally', () => {
+    const tmuxCalls: string[][] = [];
+    const spawnCalls: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = [];
+    const result = launchQuestionRenderer(
+      {
+        cwd: '/repo',
+        recordPath: '/repo/.omx/state/sessions/s1/questions/question-bridge.json',
+        sessionId: 's1',
+        nowIso: '2026-04-24T00:00:00.000Z',
+        env: { TMUX: 'psmux-session', TMUX_PANE: '%44' } as NodeJS.ProcessEnv,
+        platform: 'win32',
+      },
+      {
+        execTmux: (args) => {
+          tmuxCalls.push(args);
+          if (args[0] === 'new-window') return '%55\n';
+          if (args[0] === 'list-panes' && args[2] === '%55') return '0\t%55\n';
+          return '';
+        },
+        spawnDetachedRenderer: (command, args, options) => {
+          spawnCalls.push({ command, args, options: options as Record<string, unknown> });
+          return { pid: 1234, unref: () => {} };
+        },
+        sleepSync: () => {},
+      },
+    );
+
+    assert.equal(result.renderer, 'tmux-pane');
+    assert.equal(result.target, '%55');
+    assert.equal(result.return_target, '%44');
+    assert.equal(result.return_transport, 'tmux-send-keys');
+    assert.deepEqual(spawnCalls, []);
+    assert.equal(tmuxCalls.some((call) => call[0] === 'split-window'), false);
+    assert.deepEqual(tmuxCalls[0], [
+      'new-window',
+      '-n',
+      'OMX Question',
+      '-P',
+      '-F',
+      '#{pane_id}',
+      '-c',
+      '/repo',
+    ]);
+    assert.deepEqual(tmuxCalls[1], ['list-panes', '-t', '%55', '-F', '#{pane_dead}\t#{pane_id}']);
+    const literalSend = tmuxCalls.find((call) => call[0] === 'send-keys' && call.includes('-l'));
+    assert.ok(literalSend);
+    assert.deepEqual(literalSend.slice(0, 6), ['send-keys', '-t', '%55', '-l', '--', literalSend[5] ?? '']);
+    assert.match(literalSend[5] ?? '', /^set "OMX_SESSION_ID=s1" && set "OMX_QUESTION_RETURN_TARGET=%%44" && set "OMX_QUESTION_RETURN_TRANSPORT=tmux-send-keys" && /);
+    assert.match(literalSend[5] ?? '', /"question" "--ui" "--state-path" "\/repo\/\.omx\/state\/sessions\/s1\/questions\/question-bridge\.json"$/);
+    assert.deepEqual(tmuxCalls.filter((call) => call[0] === 'send-keys' && call.includes('C-m')), [
+      ['send-keys', '-t', '%55', 'C-m'],
+    ]);
+  });
+
+  it('keeps the detached Windows console path for explicit non-psmux return bridges', () => {
     const tmuxCalls: string[][] = [];
     const spawnCalls: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = [];
     const result = launchQuestionRenderer(
@@ -785,7 +850,7 @@ describe('launchQuestionRenderer', () => {
         recordPath: 'C:/repo/.omx/state/sessions/s1/questions/question-bridge.json',
         sessionId: 's1',
         nowIso: '2026-04-24T00:00:00.000Z',
-        env: { TMUX: 'psmux-session', TMUX_PANE: '%44' } as NodeJS.ProcessEnv,
+        env: { OMX_QUESTION_RETURN_PANE: '%44' } as NodeJS.ProcessEnv,
         platform: 'win32',
       },
       {

--- a/src/question/renderer.ts
+++ b/src/question/renderer.ts
@@ -14,7 +14,8 @@ import { resolveOmxCliEntryPath } from '../utils/paths.js';
 import { createInitialInteractiveSelectionState, createInitialQuestionWizardState, renderInteractiveQuestionFrame, renderQuestionWizardFrame } from './ui.js';
 import type { NormalizedQuestionItem, QuestionAnswer, QuestionRecord, QuestionRendererState } from './types.js';
 
-export type QuestionRendererStrategy = 'inside-tmux' | 'detached-tmux' | 'inline-tty' | 'windows-console' | 'test-noop' | 'unsupported';
+export type QuestionRendererStrategy = 'inside-tmux' | 'detached-tmux' | 'inline-tty' | 'windows-console' | 'windows-psmux-shell-pane' | 'test-noop' | 'unsupported';
+
 
 export interface LaunchQuestionRendererOptions {
   cwd: string;
@@ -57,16 +58,25 @@ function hasInteractiveQuestionTty(options?: {
   return stdinIsTTY && stdoutIsTTY;
 }
 
-function hasWindowsPsmuxReturnBridge(
+function hasNativeWindowsPsmuxBridge(
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform,
 ): boolean {
   if (platform !== 'win32') return false;
-  if (hasExplicitQuestionPaneTarget(env)) return true;
   const tmux = safeString(env.TMUX).trim().toLowerCase();
+  if (!tmux) return false;
   const tmuxPane = safeString(env.TMUX_PANE).trim();
-  return tmux !== '' && (tmux.includes('psmux') || isPaneId(tmuxPane));
+  return tmux.includes('psmux') || isPaneId(tmuxPane);
 }
+
+function hasWindowsConsoleReturnBridge(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): boolean {
+  if (platform !== 'win32') return false;
+  return hasExplicitQuestionPaneTarget(env);
+}
+
 
 export function resolveQuestionRendererStrategy(
   env: NodeJS.ProcessEnv = process.env,
@@ -83,7 +93,8 @@ export function resolveQuestionRendererStrategy(
 ): QuestionRendererStrategy {
   const platform = options?.platform ?? process.platform;
   if (safeString(env.OMX_QUESTION_TEST_RENDERER).trim() === 'noop') return 'test-noop';
-  if (hasWindowsPsmuxReturnBridge(env, platform)) return 'windows-console';
+  if (hasNativeWindowsPsmuxBridge(env, platform)) return 'windows-psmux-shell-pane';
+  if (hasWindowsConsoleReturnBridge(env, platform)) return 'windows-console';
   if (safeString(env.TMUX).trim() !== '') return 'inside-tmux';
   if (hasExplicitQuestionPaneTarget(env)) return 'inside-tmux';
   if (options?.cwd && readPersistedQuestionReturnTarget(options.cwd, options.sessionId)) return 'inside-tmux';
@@ -411,6 +422,76 @@ function buildWindowsConsoleStartCommand(command: string, args: string[]): strin
     quoteCmdArg(command),
     ...args.map(quoteCmdArg),
   ].join(' ');
+}
+
+function quoteWindowsInteractiveCmdArg(value: string): string {
+  return `"${value.replace(/%/g, '%%').replace(/"/g, '""')}"`;
+}
+
+function buildWindowsPsmuxQuestionUiCommand(
+  recordPath: string,
+  options: {
+    cwd: string;
+    env?: NodeJS.ProcessEnv;
+    sessionId?: string;
+    returnTarget?: string;
+  },
+): string {
+  const envEntries: Array<[string, string]> = [];
+  if (options.sessionId) envEntries.push(['OMX_SESSION_ID', options.sessionId]);
+  if (options.returnTarget) {
+    envEntries.push(['OMX_QUESTION_RETURN_TARGET', options.returnTarget]);
+    envEntries.push(['OMX_QUESTION_RETURN_TRANSPORT', 'tmux-send-keys']);
+  }
+  const envPrefix = envEntries.map(([key, value]) => `set "${key}=${value.replace(/%/g, '%%').replace(/"/g, '""')}"`).join(' && ');
+  const command = [process.execPath, ...resolveQuestionUiProcessArgs(recordPath, options)]
+    .map((token) => quoteWindowsInteractiveCmdArg(token))
+    .join(' ');
+  return envPrefix ? `${envPrefix} && ${command}` : command;
+}
+
+function launchWindowsPsmuxShellQuestionPane(
+  execTmux: ExecTmuxSync,
+  sleepImpl: SleepSync,
+  recordPath: string,
+  options: {
+    cwd: string;
+    env?: NodeJS.ProcessEnv;
+    sessionId?: string;
+    returnTarget?: string;
+    launchedAt: string;
+  },
+): QuestionRendererState {
+  const rawPane = execTmux([
+    'new-window',
+    '-n',
+    'OMX Question',
+    '-P',
+    '-F',
+    '#{pane_id}',
+    '-c',
+    options.cwd,
+  ]);
+  const paneId = parsePaneIdFromTmuxOutput(rawPane);
+  if (!paneId) throw new Error('Failed to create psmux question renderer shell pane.');
+  sleepImpl(QUESTION_RENDERER_PANE_SETTLE_MS);
+  if (!isLaunchedQuestionPaneAlive(paneId, execTmux)) {
+    throw new Error(`Question UI psmux pane ${paneId} disappeared immediately after launch.`);
+  }
+
+  const command = buildWindowsPsmuxQuestionUiCommand(recordPath, options);
+  for (const argv of buildSendPaneArgvs(paneId, command, false)) {
+    execTmux(argv);
+  }
+  sleepImpl(QUESTION_TEXT_SETTLE_MS);
+  execTmux(['send-keys', '-t', paneId, 'C-m']);
+
+  return {
+    renderer: 'tmux-pane',
+    target: paneId,
+    launched_at: options.launchedAt,
+    ...(options.returnTarget ? { return_target: options.returnTarget, return_transport: 'tmux-send-keys' as const } : {}),
+  };
 }
 
 function defaultSpawnDetachedRenderer(command: string, args: string[], options: SpawnOptions): Pick<ChildProcess, 'pid' | 'unref'> {
@@ -763,6 +844,20 @@ export function launchQuestionRenderer(
     returnTarget,
     underCmux: isRunningUnderCmux(env),
   });
+
+  if (strategy === 'windows-psmux-shell-pane') {
+    supersedeLiveQuestionsForSession(options.cwd, options.sessionId, execTmux, {
+      excludeRecordPath: options.recordPath,
+      nowIso: launchedAt,
+    });
+    return launchWindowsPsmuxShellQuestionPane(execTmux, sleepImpl, options.recordPath, {
+      cwd: options.cwd,
+      env: options.env,
+      sessionId: options.sessionId,
+      returnTarget,
+      launchedAt,
+    });
+  }
 
   if (strategy === 'inside-tmux') {
     const splitTarget = returnTarget ? ['-t', returnTarget] : [];


### PR DESCRIPTION
Fixes #3013.

## Summary
- Detect native Windows psmux sessions separately from explicit non-psmux return bridges.
- Open a visible psmux shell pane for `omx question` and inject the UI command literally with `tmux send-keys`.
- Keep the detached Windows console path for explicit non-psmux return bridge launches.

## Validation
- `npm run build`
- `node dist/scripts/run-test-files.js dist/question/__tests__/renderer.test.js` (51/51)
- `node dist/scripts/run-test-files.js dist/notifications/__tests__/tmux-detector.test.js` (30/30)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*