### PR TITLE
Fix ralplan terminal session state

### DIFF
--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -28,6 +28,7 @@ import {
   getStatePath,
   resolveStateScope,
 } from '../mcp/state-paths.js';
+import { completeRalplanSession } from '../state/operations.js';
 
 export interface ModeState {
   active: boolean;
@@ -358,15 +359,24 @@ export async function updateModeState(
   await writeFile(getStatePath(mode, projectRoot, scope.sessionId), JSON.stringify(updated, null, 2));
   await syncRunStateFromModeState(updated, projectRoot, scope.sessionId);
   if (isTrackedWorkflowMode(mode)) {
-    await syncCanonicalSkillStateForMode({
-      cwd: projectRoot ?? process.cwd(),
+    const cwd = projectRoot ?? process.cwd();
+    const ralplanCompletionHandled = mode === 'ralplan' && await completeRalplanSession({
+      cwd,
       baseStateDir,
-      mode,
-      active: updated.active === true,
-      currentPhase: typeof updated.current_phase === 'string' ? updated.current_phase : undefined,
-      sessionId: scope.sessionId,
-      source: 'updateModeState',
+      state: updated as Record<string, unknown>,
+      explicitSessionId: scope.sessionId,
     });
+    if (!ralplanCompletionHandled) {
+      await syncCanonicalSkillStateForMode({
+        cwd,
+        baseStateDir,
+        mode,
+        active: updated.active === true,
+        currentPhase: typeof updated.current_phase === 'string' ? updated.current_phase : undefined,
+        sessionId: scope.sessionId,
+        source: 'updateModeState',
+      });
+    }
   }
   return updated;
 }

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -1546,7 +1546,7 @@ describe('state operations directory initialization', () => {
     }
   });
 
-  it('clears stale terminal markers when preserving same-session root mirror skills', async () => {
+  it('clears stale terminal phase aliases when preserving same-session root mirror skills', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-terminal-session-skill-'));
     try {
       const sessionId = 'sess-ralplan-terminal-session-skill';
@@ -1589,7 +1589,7 @@ describe('state operations directory initialization', () => {
         version: 1,
         active: false,
         skill: 'ralplan',
-        phase: 'complete',
+        phase: 'blocked',
         session_id: sessionId,
         completed_at: '2026-06-30T00:00:00.000Z',
         terminal_reason: 'stale terminal marker',

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'node:os';
 
 import { executeStateOperation } from '../operations.js';
 import { subagentTrackingPath } from '../../subagents/tracker.js';
+import { updateModeState } from '../../modes/base.js';
 
 async function withAmbientTmuxEnv<T>(env: NodeJS.ProcessEnv, run: () => Promise<T>): Promise<T> {
   const previousTmux = process.env.TMUX;
@@ -775,6 +776,966 @@ describe('state operations directory initialization', () => {
       };
       assert.equal(cleared.active, false);
       assert.deepEqual(cleared.active_skills, []);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('finalizes completed ralplan writes across root and current session state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-complete-'));
+    try {
+      const sessionId = 'sess-ralplan-complete';
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        cwd: wd,
+      }, null, 2));
+      await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+      const staleSkillState = {
+        version: 1,
+        active: true,
+        skill: 'ralplan',
+        phase: 'planning',
+        updated_at: '2026-06-30T00:00:00.000Z',
+        session_id: sessionId,
+        active_skills: [{
+          skill: 'ralplan',
+          phase: 'planning',
+          active: true,
+          session_id: sessionId,
+        }],
+      };
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify(staleSkillState, null, 2));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify(staleSkillState, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        terminal_reason: 'consensus approved bounded no-op',
+        ralplan_architect_review: {
+          verdict: 'APPROVE',
+          artifact_path: '.omx/plans/architect.md',
+        },
+        ralplan_critic_review: {
+          verdict: 'APPROVE',
+          artifact_path: '.omx/plans/critic.md',
+        },
+        ralplan_consensus_gate: {
+          complete: true,
+          architect_verdict: 'APPROVE',
+          critic_verdict: 'APPROVE',
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      const rootRalplan = JSON.parse(await readFile(join(stateDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      const sessionRalplan = JSON.parse(await readFile(join(sessionDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      for (const state of [rootRalplan, sessionRalplan]) {
+        assert.equal(state.active, false);
+        assert.equal(state.current_phase, 'complete');
+        assert.equal(state.status, 'complete');
+        assert.equal(state.terminal_reason, 'consensus approved bounded no-op');
+        assert.equal((state.ralplan_consensus_gate as Record<string, unknown>).complete, true);
+        assert.equal(state.session_id, sessionId);
+      }
+
+      const rootSkill = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as Record<string, unknown>;
+      const sessionSkill = JSON.parse(await readFile(join(sessionDir, 'skill-active-state.json'), 'utf-8')) as Record<string, unknown>;
+      for (const state of [rootSkill, sessionSkill]) {
+        assert.equal(state.active, false);
+        assert.equal(state.phase, 'complete');
+        assert.equal(state.terminal_reason, 'consensus approved bounded no-op');
+        assert.deepEqual(state.active_skills, []);
+      }
+      assert.equal(sessionSkill.session_id, sessionId);
+
+      const listed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+      assert.deepEqual(listed.payload, { active_modes: [] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('finalizes completed ralplan updateModeState writes across root and current session state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-complete-update-mode-'));
+    try {
+      const sessionId = 'sess-ralplan-complete-update-mode';
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        cwd: wd,
+      }, null, 2));
+      await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+      const staleSkillState = {
+        version: 1,
+        active: true,
+        skill: 'ralplan',
+        phase: 'planning',
+        session_id: sessionId,
+        active_skills: [{
+          skill: 'ralplan',
+          phase: 'planning',
+          active: true,
+          session_id: sessionId,
+        }],
+      };
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify(staleSkillState, null, 2));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify(staleSkillState, null, 2));
+
+      await updateModeState('ralplan', {
+        active: false,
+        current_phase: 'complete',
+        terminal_reason: 'runtime consensus complete',
+        ralplan_consensus_gate: {
+          complete: true,
+        },
+      }, wd);
+
+      const rootRalplan = JSON.parse(await readFile(join(stateDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      const sessionRalplan = JSON.parse(await readFile(join(sessionDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      for (const state of [rootRalplan, sessionRalplan]) {
+        assert.equal(state.active, false);
+        assert.equal(state.current_phase, 'complete');
+        assert.equal(state.status, 'complete');
+        assert.equal(state.terminal_reason, 'runtime consensus complete');
+        assert.equal((state.ralplan_consensus_gate as Record<string, unknown>).complete, true);
+        assert.equal(state.session_id, sessionId);
+      }
+
+      const rootSkill = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as Record<string, unknown>;
+      const sessionSkill = JSON.parse(await readFile(join(sessionDir, 'skill-active-state.json'), 'utf-8')) as Record<string, unknown>;
+      for (const state of [rootSkill, sessionSkill]) {
+        assert.equal(state.active, false);
+        assert.equal(state.phase, 'complete');
+        assert.equal(state.terminal_reason, 'runtime consensus complete');
+        assert.deepEqual(state.active_skills, []);
+      }
+
+      const rootListed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+      assert.deepEqual(rootListed.payload, { active_modes: [] });
+
+      const sessionListed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: sessionId,
+      });
+      assert.deepEqual(sessionListed.payload, { active_modes: [] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not promote stale session metadata when ralplan terminalizes from root scope', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-stale-session-'));
+    try {
+      const staleSessionId = 'sess-ralplan-stale';
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', staleSessionId);
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: staleSessionId,
+        cwd: join(wd, 'different-project'),
+      }, null, 2));
+      await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: staleSessionId,
+      }, null, 2));
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'ralplan',
+        phase: 'planning',
+        session_id: staleSessionId,
+        active_skills: [
+          {
+            skill: 'ralplan',
+            phase: 'planning',
+            active: true,
+          },
+          {
+            skill: 'ralplan',
+            phase: 'planning',
+            active: true,
+            session_id: staleSessionId,
+          },
+        ],
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        status: 'complete',
+        terminal_reason: 'consensus approved bounded no-op',
+        ralplan_consensus_gate: {
+          complete: true,
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      const rootRalplan = JSON.parse(await readFile(join(stateDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(rootRalplan.active, false);
+      assert.equal(rootRalplan.current_phase, 'complete');
+      assert.equal(rootRalplan.status, 'complete');
+      assert.equal(rootRalplan.session_id, undefined);
+      const rootSkill = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(rootSkill.active, false);
+      assert.equal(rootSkill.phase, 'complete');
+      assert.deepEqual(rootSkill.active_skills, []);
+      assert.equal(existsSync(join(sessionDir, 'ralplan-state.json')), false);
+      assert.equal(existsSync(join(sessionDir, 'skill-active-state.json')), false);
+
+      const listed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+      assert.deepEqual(listed.payload, { active_modes: [] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not hide unrelated root detail state when ralplan terminalizes without canonical state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-root-detail-only-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'team-state.json'), JSON.stringify({
+        mode: 'team',
+        active: true,
+        current_phase: 'running',
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        ralplan_consensus_gate: {
+          complete: true,
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      assert.equal(existsSync(join(stateDir, 'skill-active-state.json')), false);
+
+      const listed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+      assert.deepEqual(listed.payload, { active_modes: ['team'] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves an unrelated active root ralplan when a session ralplan terminalizes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-preserve-root-'));
+    try {
+      const sessionId = 'sess-ralplan-preserve-root';
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+      }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'ralplan',
+        phase: 'planning',
+        active_skills: [
+          {
+            skill: 'ralplan',
+            phase: 'planning',
+            active: true,
+          },
+          {
+            skill: 'ralplan',
+            phase: 'planning',
+            active: true,
+            session_id: sessionId,
+          },
+        ],
+      }, null, 2));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'ralplan',
+        phase: 'planning',
+        session_id: sessionId,
+        active_skills: [{
+          skill: 'ralplan',
+          phase: 'planning',
+          active: true,
+          session_id: sessionId,
+        }],
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: sessionId,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        status: 'complete',
+        terminal_reason: 'consensus approved bounded no-op',
+        ralplan_consensus_gate: {
+          complete: true,
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      const rootRalplan = JSON.parse(await readFile(join(stateDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(rootRalplan.active, true);
+      assert.equal(rootRalplan.current_phase, 'planning');
+      assert.equal(rootRalplan.session_id, undefined);
+
+      const sessionRalplan = JSON.parse(await readFile(join(sessionDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(sessionRalplan.active, false);
+      assert.equal(sessionRalplan.current_phase, 'complete');
+      assert.equal(sessionRalplan.session_id, sessionId);
+
+      const rootSkill = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as {
+        active: boolean;
+        skill: string;
+        phase: string;
+        active_skills?: Array<{ skill: string; session_id?: string }>;
+      };
+      assert.equal(rootSkill.active, true);
+      assert.equal(rootSkill.skill, 'ralplan');
+      assert.deepEqual(rootSkill.active_skills, [{ skill: 'ralplan', phase: 'planning', active: true }]);
+
+      const rootListed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+      assert.deepEqual(rootListed.payload, { active_modes: ['ralplan'] });
+
+      const sessionListed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: sessionId,
+      });
+      assert.deepEqual(sessionListed.payload, { active_modes: [] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not hide a legacy active root ralplan detail state when a session ralplan terminalizes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-legacy-root-detail-'));
+    try {
+      const sessionId = 'sess-ralplan-legacy-root-detail';
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+      }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'ralplan',
+        phase: 'planning',
+        session_id: sessionId,
+        active_skills: [{
+          skill: 'ralplan',
+          phase: 'planning',
+          active: true,
+          session_id: sessionId,
+        }],
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: sessionId,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        ralplan_consensus_gate: {
+          complete: true,
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      assert.equal(existsSync(join(stateDir, 'skill-active-state.json')), false);
+
+      const rootListed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+      assert.deepEqual(rootListed.payload, { active_modes: ['ralplan'] });
+
+      const sessionListed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: sessionId,
+      });
+      assert.deepEqual(sessionListed.payload, { active_modes: [] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes an empty session-only root mirror when a session ralplan terminalizes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-empty-root-mirror-'));
+    try {
+      const sessionId = 'sess-ralplan-empty-root-mirror';
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+      }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'ralplan',
+        phase: 'planning',
+        session_id: sessionId,
+        active_skills: [{
+          skill: 'ralplan',
+          phase: 'planning',
+          active: true,
+          session_id: sessionId,
+        }],
+      }, null, 2));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'ralplan',
+        phase: 'planning',
+        session_id: sessionId,
+        active_skills: [{
+          skill: 'ralplan',
+          phase: 'planning',
+          active: true,
+          session_id: sessionId,
+        }],
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: sessionId,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        ralplan_consensus_gate: {
+          complete: true,
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      assert.equal(existsSync(join(stateDir, 'skill-active-state.json')), false);
+
+      const rootListed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+      assert.deepEqual(rootListed.payload, { active_modes: ['ralplan'] });
+
+      const sessionListed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: sessionId,
+      });
+      assert.deepEqual(sessionListed.payload, { active_modes: [] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves terminal root canonical tombstones when a session ralplan terminalizes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-preserve-root-tombstone-'));
+    try {
+      const sessionId = 'sess-ralplan-root-tombstone';
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'team-state.json'), JSON.stringify({
+        mode: 'team',
+        active: true,
+        current_phase: 'running',
+      }, null, 2));
+      await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+      }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: false,
+        skill: 'team',
+        phase: 'complete',
+        completed_at: '2026-06-30T00:00:00.000Z',
+        active_skills: [{
+          skill: 'team',
+          active: true,
+        }],
+      }, null, 2));
+
+      const before = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+      assert.deepEqual(before.payload, { active_modes: [] });
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: sessionId,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        ralplan_consensus_gate: {
+          complete: true,
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      const rootSkill = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as {
+        active: boolean;
+        phase?: string;
+        completed_at?: string;
+      };
+      assert.equal(rootSkill.active, false);
+      assert.equal(rootSkill.phase, 'complete');
+      assert.equal(rootSkill.completed_at, '2026-06-30T00:00:00.000Z');
+
+      const rootListed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+      assert.deepEqual(rootListed.payload, { active_modes: [] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves unrelated active session skills when ralplan terminalizes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-preserve-'));
+    try {
+      const sessionId = 'sess-ralplan-preserve';
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        cwd: wd,
+      }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+      await writeFile(join(sessionDir, 'autoresearch-state.json'), JSON.stringify({
+        mode: 'autoresearch',
+        active: true,
+        current_phase: 'running',
+        session_id: sessionId,
+      }, null, 2));
+      const mixedSkillState = {
+        version: 1,
+        active: true,
+        skill: 'ralplan',
+        phase: 'planning',
+        updated_at: '2026-06-30T00:00:00.000Z',
+        session_id: sessionId,
+        active_skills: [
+          {
+            skill: 'ralplan',
+            phase: 'planning',
+            active: true,
+            session_id: sessionId,
+          },
+          {
+            skill: 'autoresearch',
+            phase: 'running',
+            active: true,
+            session_id: sessionId,
+          },
+        ],
+      };
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify(mixedSkillState, null, 2));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify(mixedSkillState, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        status: 'complete',
+        terminal_reason: 'consensus approved bounded no-op',
+        ralplan_consensus_gate: {
+          complete: true,
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      const rootSkill = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as {
+        active: boolean;
+        skill: string;
+        phase: string;
+        active_skills?: Array<{ skill: string; phase?: string; session_id?: string }>;
+      };
+      const sessionSkill = JSON.parse(await readFile(join(sessionDir, 'skill-active-state.json'), 'utf-8')) as {
+        active: boolean;
+        skill: string;
+        phase: string;
+        active_skills?: Array<{ skill: string; phase?: string; session_id?: string }>;
+      };
+      for (const state of [rootSkill, sessionSkill]) {
+        assert.equal(state.active, true);
+        assert.equal(state.skill, 'autoresearch');
+        assert.equal(state.phase, 'running');
+        assert.deepEqual(state.active_skills?.map((entry) => entry.skill), ['autoresearch']);
+        assert.deepEqual(state.active_skills?.map((entry) => entry.session_id), [sessionId]);
+      }
+
+      const listed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+      assert.deepEqual(listed.payload, { active_modes: ['autoresearch'] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves same-session root mirror skills when session canonical state is partial', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-partial-session-skill-'));
+    try {
+      const sessionId = 'sess-ralplan-partial-session-skill';
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+      await writeFile(join(sessionDir, 'team-state.json'), JSON.stringify({
+        mode: 'team',
+        active: true,
+        current_phase: 'running',
+        session_id: sessionId,
+      }, null, 2));
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'ralplan',
+        phase: 'planning',
+        session_id: sessionId,
+        active_skills: [
+          {
+            skill: 'ralplan',
+            phase: 'planning',
+            active: true,
+            session_id: sessionId,
+          },
+          {
+            skill: 'team',
+            phase: 'running',
+            active: true,
+            session_id: sessionId,
+          },
+        ],
+      }, null, 2));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'ralplan',
+        phase: 'planning',
+        session_id: sessionId,
+        active_skills: [{
+          skill: 'ralplan',
+          phase: 'planning',
+          active: true,
+          session_id: sessionId,
+        }],
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: sessionId,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        ralplan_consensus_gate: {
+          complete: true,
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      const sessionSkill = JSON.parse(await readFile(join(sessionDir, 'skill-active-state.json'), 'utf-8')) as {
+        active: boolean;
+        skill: string;
+        phase: string;
+        session_id?: string;
+        active_skills?: Array<{ skill: string; phase?: string; session_id?: string }>;
+      };
+      assert.equal(sessionSkill.active, true);
+      assert.equal(sessionSkill.skill, 'team');
+      assert.equal(sessionSkill.phase, 'running');
+      assert.equal(sessionSkill.session_id, sessionId);
+      assert.deepEqual(sessionSkill.active_skills?.map((entry) => entry.skill), ['team']);
+      assert.deepEqual(sessionSkill.active_skills?.map((entry) => entry.session_id), [sessionId]);
+
+      const sessionListed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: sessionId,
+      });
+      assert.deepEqual(sessionListed.payload, { active_modes: ['team'] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('clears stale terminal markers when preserving same-session root mirror skills', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-terminal-session-skill-'));
+    try {
+      const sessionId = 'sess-ralplan-terminal-session-skill';
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+      await writeFile(join(sessionDir, 'team-state.json'), JSON.stringify({
+        mode: 'team',
+        active: true,
+        current_phase: 'running',
+        session_id: sessionId,
+      }, null, 2));
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'ralplan',
+        phase: 'planning',
+        session_id: sessionId,
+        active_skills: [
+          {
+            skill: 'ralplan',
+            phase: 'planning',
+            active: true,
+            session_id: sessionId,
+          },
+          {
+            skill: 'team',
+            active: true,
+            session_id: sessionId,
+          },
+        ],
+      }, null, 2));
+      await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: false,
+        skill: 'ralplan',
+        phase: 'complete',
+        session_id: sessionId,
+        completed_at: '2026-06-30T00:00:00.000Z',
+        terminal_reason: 'stale terminal marker',
+        active_skills: [],
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: sessionId,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        ralplan_consensus_gate: {
+          complete: true,
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      const sessionSkill = JSON.parse(await readFile(join(sessionDir, 'skill-active-state.json'), 'utf-8')) as {
+        active: boolean;
+        skill: string;
+        phase: string;
+        completed_at?: string;
+        terminal_reason?: string;
+        active_skills?: Array<{ skill: string; phase?: string; session_id?: string }>;
+      };
+      assert.equal(sessionSkill.active, true);
+      assert.equal(sessionSkill.skill, 'team');
+      assert.equal(sessionSkill.phase, '');
+      assert.equal(sessionSkill.completed_at, undefined);
+      assert.equal(sessionSkill.terminal_reason, undefined);
+      assert.deepEqual(sessionSkill.active_skills?.map((entry) => entry.skill), ['team']);
+
+      const sessionListed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: sessionId,
+      });
+      assert.deepEqual(sessionListed.payload, { active_modes: ['team'] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not hide detail-only active session state when ralplan terminalizes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-session-detail-only-'));
+    try {
+      const sessionId = 'sess-ralplan-session-detail-only';
+      const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+      await writeFile(join(sessionDir, 'autoresearch-state.json'), JSON.stringify({
+        mode: 'autoresearch',
+        active: true,
+        current_phase: 'running',
+        session_id: sessionId,
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: sessionId,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        ralplan_consensus_gate: {
+          complete: true,
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      assert.equal(existsSync(join(sessionDir, 'skill-active-state.json')), false);
+
+      const listed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: sessionId,
+      });
+      assert.deepEqual(listed.payload, { active_modes: ['autoresearch'] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not seed session canonical state from root-only skills when ralplan terminalizes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-root-only-skill-'));
+    try {
+      const sessionId = 'sess-ralplan-root-only-skill';
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'autoresearch-state.json'), JSON.stringify({
+        mode: 'autoresearch',
+        active: true,
+        current_phase: 'running',
+      }, null, 2));
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'autoresearch',
+        phase: 'running',
+        active_skills: [{
+          skill: 'autoresearch',
+          phase: 'running',
+          active: true,
+        }],
+      }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+      await writeFile(join(sessionDir, 'team-state.json'), JSON.stringify({
+        mode: 'team',
+        active: true,
+        current_phase: 'running',
+        session_id: sessionId,
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: sessionId,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        ralplan_consensus_gate: {
+          complete: true,
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      assert.equal(existsSync(join(sessionDir, 'skill-active-state.json')), false);
+
+      const rootListed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+      assert.deepEqual(rootListed.payload, { active_modes: ['autoresearch'] });
+
+      const sessionListed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: sessionId,
+      });
+      assert.deepEqual(sessionListed.payload, { active_modes: ['team'] });
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -1363,6 +1363,71 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('removes terminal_reason-only active root canonical state when a session ralplan terminalizes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-terminal-reason-only-'));
+    try {
+      const sessionId = 'sess-ralplan-terminal-reason-only';
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+      }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'ralplan',
+        terminal_reason: 'stale reason without terminal marker',
+        active_skills: [{
+          skill: 'ralplan',
+          active: true,
+          session_id: sessionId,
+        }],
+      }, null, 2));
+
+      const before = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: sessionId,
+      });
+      assert.deepEqual(before.payload, { active_modes: ['ralplan'] });
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: sessionId,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        ralplan_consensus_gate: {
+          complete: true,
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      assert.equal(existsSync(join(stateDir, 'skill-active-state.json')), false);
+
+      const rootListed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+      assert.deepEqual(rootListed.payload, { active_modes: ['ralplan'] });
+
+      const sessionListed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: sessionId,
+      });
+      assert.deepEqual(sessionListed.payload, { active_modes: [] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('preserves unrelated active session skills when ralplan terminalizes', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-preserve-'));
     try {

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -1296,7 +1296,7 @@ describe('state operations directory initialization', () => {
     }
   });
 
-  it('preserves terminal root canonical tombstones when a session ralplan terminalizes', async () => {
+  it('preserves run_outcome-only root canonical tombstones when a session ralplan terminalizes', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-preserve-root-tombstone-'));
     try {
       const sessionId = 'sess-ralplan-root-tombstone';
@@ -1321,10 +1321,9 @@ describe('state operations directory initialization', () => {
       }, null, 2));
       await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
         version: 1,
-        active: false,
+        active: true,
         skill: 'team',
-        phase: 'complete',
-        completed_at: '2026-06-30T00:00:00.000Z',
+        run_outcome: 'finish',
         active_skills: [{
           skill: 'team',
           active: true,
@@ -1350,12 +1349,10 @@ describe('state operations directory initialization', () => {
       assert.equal(response.isError, undefined);
       const rootSkill = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as {
         active: boolean;
-        phase?: string;
-        completed_at?: string;
+        run_outcome?: string;
       };
-      assert.equal(rootSkill.active, false);
-      assert.equal(rootSkill.phase, 'complete');
-      assert.equal(rootSkill.completed_at, '2026-06-30T00:00:00.000Z');
+      assert.equal(rootSkill.active, true);
+      assert.equal(rootSkill.run_outcome, 'finish');
 
       const rootListed = await executeStateOperation('state_list_active', {
         workingDirectory: wd,

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -1428,6 +1428,71 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('removes non-terminal lifecycle_outcome root canonical state when a session ralplan terminalizes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-lifecycle-nonterminal-'));
+    try {
+      const sessionId = 'sess-ralplan-lifecycle-nonterminal';
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+      }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+      await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'ralplan',
+        lifecycle_outcome: 'progress',
+        active_skills: [{
+          skill: 'ralplan',
+          active: true,
+          session_id: sessionId,
+        }],
+      }, null, 2));
+
+      const before = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: sessionId,
+      });
+      assert.deepEqual(before.payload, { active_modes: ['ralplan'] });
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: sessionId,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        ralplan_consensus_gate: {
+          complete: true,
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      assert.equal(existsSync(join(stateDir, 'skill-active-state.json')), false);
+
+      const rootListed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+      assert.deepEqual(rootListed.payload, { active_modes: ['ralplan'] });
+
+      const sessionListed = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: sessionId,
+      });
+      assert.deepEqual(sessionListed.payload, { active_modes: [] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('preserves unrelated active session skills when ralplan terminalizes', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-preserve-'));
     try {

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -355,7 +355,6 @@ function isTerminalSkillActiveTombstone(state: SkillActiveStateLike | null): boo
   if (state.active === false) return true;
   if (isTerminalSkillActivePhase(state.phase)) return true;
   if (stringValue(state.completed_at).trim()) return true;
-  if (stringValue(state.terminal_reason).trim()) return true;
   if (isTerminalSkillActivePhase(state.run_outcome)) return true;
   if (stringValue(state.lifecycle_outcome).trim() || stringValue(state.terminal_outcome).trim()) return true;
   return false;

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { mkdir, readFile, readdir, rename, unlink, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import { withModeRuntimeContext } from './mode-state-context.js';
 import {
@@ -29,10 +29,13 @@ import {
 import { readUltragoalState } from '../hud/state.js';
 import {
   SKILL_ACTIVE_STATE_MODE,
+  getSkillActiveStatePathsForStateDir,
   listActiveSkills,
   readSkillActiveState,
   readVisibleSkillActiveStateForStateDir,
   syncCanonicalSkillStateForMode,
+  type SkillActiveEntry,
+  type SkillActiveStateLike,
   writeSkillActiveStateCopiesForStateDir,
 } from './skill-active.js';
 import {
@@ -227,6 +230,24 @@ function objectRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
 }
 
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function optionalSessionId(value: unknown): string | undefined {
+  try {
+    return validateSessionId(stringValue(value).trim());
+  } catch {
+    return undefined;
+  }
+}
+
+const TERMINAL_SKILL_PHASES = new Set(['complete', 'completed', 'cancelled', 'canceled', 'failed', 'cleared']);
+
+function isTerminalSkillPhase(value: unknown): boolean {
+  return TERMINAL_SKILL_PHASES.has(stringValue(value).trim().toLowerCase());
+}
+
 function normalizeCleanAutopilotCompletionEvidence(state: Record<string, unknown>): void {
   if (!isAutopilotSuccessfulTerminalState(state) || !hasCleanAutopilotReviewAndQaEvidence(state)) return;
 
@@ -244,6 +265,231 @@ function normalizeCleanAutopilotCompletionEvidence(state: Record<string, unknown
   nestedState.qa_verdict = qaVerdict;
   nestedState.return_to_ralplan_reason = null;
   state.state = nestedState;
+}
+
+function isCompleteRalplanTerminalState(state: Record<string, unknown>): boolean {
+  const currentPhase = stringValue(state.current_phase).trim().toLowerCase();
+  const gate = objectRecord(state.ralplan_consensus_gate);
+  return state.active === false
+    && currentPhase === 'complete'
+    && gate.complete === true;
+}
+
+function buildRalplanTerminalState(
+  state: Record<string, unknown>,
+  sessionId: string | undefined,
+  nowIso: string,
+): Record<string, unknown> {
+  const completedAt = stringValue(state.completed_at).trim() || nowIso;
+  const terminalReason = stringValue(state.terminal_reason).trim() || 'ralplan consensus complete';
+  return withModeRuntimeContext(state, {
+    ...state,
+    mode: 'ralplan',
+    active: false,
+    current_phase: 'complete',
+    status: 'complete',
+    updated_at: nowIso,
+    completed_at: completedAt,
+    terminal_reason: terminalReason,
+    session_id: sessionId,
+    ralplan_consensus_gate: {
+      ...objectRecord(state.ralplan_consensus_gate),
+      complete: true,
+    },
+  });
+}
+
+function buildRalplanTerminalSkillState(
+  base: SkillActiveStateLike | null,
+  terminalState: Record<string, unknown>,
+  sessionId: string | undefined,
+  nowIso: string,
+): SkillActiveStateLike {
+  const completedAt = stringValue(terminalState.completed_at).trim() || nowIso;
+  const terminalReason = stringValue(terminalState.terminal_reason).trim() || 'ralplan consensus complete';
+  return {
+    ...(base ?? {}),
+    version: 1,
+    active: false,
+    skill: 'ralplan',
+    keyword: stringValue(base?.keyword).trim() || 'ralplan',
+    phase: 'complete',
+    activated_at: stringValue(base?.activated_at).trim() || stringValue(terminalState.started_at).trim() || nowIso,
+    updated_at: nowIso,
+    completed_at: completedAt,
+    source: stringValue(base?.source).trim() || 'state-operations',
+    ...(sessionId ? { session_id: sessionId } : {}),
+    terminal_reason: terminalReason,
+    active_skills: [],
+  };
+}
+
+function clearRalplanSkillTerminalMarkers(state: SkillActiveStateLike): SkillActiveStateLike {
+  const next = { ...state };
+  if (isTerminalSkillPhase(next.phase)) delete next.phase;
+  delete next.completed_at;
+  delete next.cancel_reason;
+  delete next.run_outcome;
+  delete next.lifecycle_outcome;
+  delete next.terminal_outcome;
+  delete next.terminal_reason;
+  return next;
+}
+
+function buildRalplanSkillStateFromEntries(
+  base: SkillActiveStateLike | null,
+  terminalState: Record<string, unknown>,
+  entries: SkillActiveEntry[],
+  sessionId: string | undefined,
+  nowIso: string,
+): SkillActiveStateLike {
+  if (entries.length === 0) {
+    return buildRalplanTerminalSkillState(base, terminalState, sessionId, nowIso);
+  }
+
+  const primary = entries[0] as SkillActiveEntry;
+  const activeBase = clearRalplanSkillTerminalMarkers(base ?? {});
+  return {
+    ...activeBase,
+    version: 1,
+    active: true,
+    skill: primary.skill,
+    keyword: stringValue(activeBase.keyword).trim(),
+    phase: primary.phase || stringValue(activeBase.phase).trim(),
+    activated_at: primary.activated_at || stringValue(base?.activated_at).trim() || nowIso,
+    updated_at: nowIso,
+    source: stringValue(activeBase.source).trim() || 'state-operations',
+    session_id: primary.session_id || undefined,
+    thread_id: primary.thread_id || stringValue(activeBase.thread_id).trim() || undefined,
+    turn_id: primary.turn_id || stringValue(activeBase.turn_id).trim() || undefined,
+    active_skills: entries,
+  };
+}
+
+function isTerminalSkillActiveTombstone(state: SkillActiveStateLike | null): boolean {
+  if (!state) return false;
+  if (state.active === false) return true;
+  if (isTerminalSkillPhase(state.phase)) return true;
+  if (stringValue(state.completed_at).trim()) return true;
+  if (stringValue(state.terminal_reason).trim()) return true;
+  if (stringValue(state.lifecycle_outcome).trim() || stringValue(state.terminal_outcome).trim()) return true;
+  return false;
+}
+
+function filterCompletedRalplanRootEntries(
+  entries: SkillActiveEntry[],
+  completedSessionId: string | undefined,
+  rootScopeCompletion: boolean,
+): SkillActiveEntry[] {
+  return entries.filter((entry) => {
+    const entrySessionId = stringValue(entry.session_id).trim();
+    if (entry.skill !== 'ralplan') return true;
+    if (completedSessionId && entrySessionId === completedSessionId) return false;
+    if (rootScopeCompletion && entrySessionId.length === 0) return false;
+    return true;
+  });
+}
+
+function filterCompletedRalplanSessionEntries(entries: SkillActiveEntry[], sessionId: string): SkillActiveEntry[] {
+  return entries.filter((entry) => {
+    const entrySessionId = stringValue(entry.session_id).trim();
+    return entrySessionId === sessionId && entry.skill !== 'ralplan';
+  });
+}
+
+function skillActiveEntryKey(entry: Pick<SkillActiveEntry, 'skill' | 'session_id'>): string {
+  return `${entry.skill}::${stringValue(entry.session_id).trim()}`;
+}
+
+function collectCompletedRalplanSessionEntries(
+  sessionState: SkillActiveStateLike | null,
+  rootState: SkillActiveStateLike | null,
+  sessionId: string,
+): SkillActiveEntry[] {
+  const entries = new Map<string, SkillActiveEntry>();
+  for (const entry of filterCompletedRalplanSessionEntries(listActiveSkills(rootState ?? {}), sessionId)) {
+    entries.set(skillActiveEntryKey(entry), entry);
+  }
+  for (const entry of filterCompletedRalplanSessionEntries(listActiveSkills(sessionState ?? {}), sessionId)) {
+    entries.set(skillActiveEntryKey(entry), entry);
+  }
+  return [...entries.values()];
+}
+
+async function writeAtomicJson(path: string, value: unknown): Promise<void> {
+  const serialized = JSON.stringify(value, null, 2);
+  JSON.parse(serialized);
+  await mkdir(dirname(path), { recursive: true });
+  await writeAtomicFile(path, serialized);
+}
+
+async function readJsonRecordIfExists(path: string): Promise<Record<string, unknown> | null> {
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(await readFile(path, 'utf-8')) as unknown;
+    return objectRecord(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function shouldWriteRootRalplanTerminalState(rootState: Record<string, unknown> | null, sessionId: string | undefined): boolean {
+  if (!sessionId) return true;
+  return optionalSessionId(rootState?.session_id) === sessionId;
+}
+
+export async function completeRalplanSession(options: {
+  cwd: string;
+  baseStateDir: string;
+  state: Record<string, unknown>;
+  explicitSessionId?: string;
+}): Promise<boolean> {
+  if (!isCompleteRalplanTerminalState(options.state)) return false;
+
+  const sessionId = optionalSessionId(options.explicitSessionId);
+  const completedSessionId = sessionId ?? optionalSessionId(options.state.session_id);
+  const rootScopeCompletion = !sessionId;
+  const nowIso = new Date().toISOString();
+  const rootState = buildRalplanTerminalState(options.state, sessionId, nowIso);
+  const rootStatePath = getStatePath('ralplan', options.cwd);
+  const existingRootState = await readJsonRecordIfExists(rootStatePath);
+  const shouldWriteRootState = shouldWriteRootRalplanTerminalState(existingRootState, sessionId);
+
+  if (shouldWriteRootState) {
+    await writeAtomicJson(rootStatePath, rootState);
+  }
+  if (sessionId) {
+    await writeAtomicJson(
+      getStatePath('ralplan', options.cwd, sessionId),
+      buildRalplanTerminalState(options.state, sessionId, nowIso),
+    );
+  }
+
+  const { rootPath, sessionPath } = getSkillActiveStatePathsForStateDir(options.baseStateDir, sessionId);
+  const rootSkillState = await readSkillActiveState(rootPath);
+  const rootEntries = filterCompletedRalplanRootEntries(
+    listActiveSkills(rootSkillState ?? {}),
+    completedSessionId,
+    rootScopeCompletion,
+  );
+  if (rootEntries.length > 0 || (shouldWriteRootState && rootSkillState !== null)) {
+    await writeAtomicJson(rootPath, buildRalplanSkillStateFromEntries(rootSkillState, rootState, rootEntries, undefined, nowIso));
+  } else if (rootSkillState !== null && !isTerminalSkillActiveTombstone(rootSkillState)) {
+    await unlink(rootPath).catch(() => {});
+  }
+  if (sessionPath && sessionId) {
+    const sessionSkillState = await readSkillActiveState(sessionPath);
+    const sessionEntries = collectCompletedRalplanSessionEntries(sessionSkillState, rootSkillState, sessionId);
+    if (sessionEntries.length > 0 || sessionSkillState !== null) {
+      await writeAtomicJson(
+        sessionPath,
+        sessionEntries.length > 0
+          ? buildRalplanSkillStateFromEntries(sessionSkillState ?? rootSkillState, rootState, sessionEntries, sessionId, nowIso)
+          : buildRalplanTerminalSkillState(sessionSkillState, rootState, sessionId, nowIso),
+      );
+    }
+  }
+  return true;
 }
 
 export async function listStateStatuses(
@@ -645,15 +891,23 @@ export async function executeStateOperation(
             await ensureCanonicalRalphArtifacts(cwd, effectiveSessionId);
           }
           const data = JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>;
-          await syncCanonicalSkillStateForMode({
+          const ralplanCompletionHandled = mode === 'ralplan' && await completeRalplanSession({
             cwd,
             baseStateDir,
-            mode,
-            active: data.active === true,
-            currentPhase: typeof data.current_phase === 'string' ? data.current_phase : undefined,
-            sessionId: effectiveSessionId,
-            source: 'state-operations',
+            state: data,
+            explicitSessionId: effectiveSessionId,
           });
+          if (!ralplanCompletionHandled) {
+            await syncCanonicalSkillStateForMode({
+              cwd,
+              baseStateDir,
+              mode,
+              active: data.active === true,
+              currentPhase: typeof data.current_phase === 'string' ? data.current_phase : undefined,
+              sessionId: effectiveSessionId,
+              source: 'state-operations',
+            });
+          }
         }
 
         return {

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -29,7 +29,9 @@ import {
 import { readUltragoalState } from '../hud/state.js';
 import {
   SKILL_ACTIVE_STATE_MODE,
+  clearTerminalSkillActiveMarkers,
   getSkillActiveStatePathsForStateDir,
+  isTerminalSkillActivePhase,
   listActiveSkills,
   readSkillActiveState,
   readVisibleSkillActiveStateForStateDir,
@@ -242,12 +244,6 @@ function optionalSessionId(value: unknown): string | undefined {
   }
 }
 
-const TERMINAL_SKILL_PHASES = new Set(['complete', 'completed', 'cancelled', 'canceled', 'failed', 'cleared']);
-
-function isTerminalSkillPhase(value: unknown): boolean {
-  return TERMINAL_SKILL_PHASES.has(stringValue(value).trim().toLowerCase());
-}
-
 function normalizeCleanAutopilotCompletionEvidence(state: Record<string, unknown>): void {
   if (!isAutopilotSuccessfulTerminalState(state) || !hasCleanAutopilotReviewAndQaEvidence(state)) return;
 
@@ -324,18 +320,6 @@ function buildRalplanTerminalSkillState(
   };
 }
 
-function clearRalplanSkillTerminalMarkers(state: SkillActiveStateLike): SkillActiveStateLike {
-  const next = { ...state };
-  if (isTerminalSkillPhase(next.phase)) delete next.phase;
-  delete next.completed_at;
-  delete next.cancel_reason;
-  delete next.run_outcome;
-  delete next.lifecycle_outcome;
-  delete next.terminal_outcome;
-  delete next.terminal_reason;
-  return next;
-}
-
 function buildRalplanSkillStateFromEntries(
   base: SkillActiveStateLike | null,
   terminalState: Record<string, unknown>,
@@ -348,7 +332,7 @@ function buildRalplanSkillStateFromEntries(
   }
 
   const primary = entries[0] as SkillActiveEntry;
-  const activeBase = clearRalplanSkillTerminalMarkers(base ?? {});
+  const activeBase = clearTerminalSkillActiveMarkers(base ?? {});
   return {
     ...activeBase,
     version: 1,
@@ -369,7 +353,7 @@ function buildRalplanSkillStateFromEntries(
 function isTerminalSkillActiveTombstone(state: SkillActiveStateLike | null): boolean {
   if (!state) return false;
   if (state.active === false) return true;
-  if (isTerminalSkillPhase(state.phase)) return true;
+  if (isTerminalSkillActivePhase(state.phase)) return true;
   if (stringValue(state.completed_at).trim()) return true;
   if (stringValue(state.terminal_reason).trim()) return true;
   if (stringValue(state.lifecycle_outcome).trim() || stringValue(state.terminal_outcome).trim()) return true;

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -356,6 +356,7 @@ function isTerminalSkillActiveTombstone(state: SkillActiveStateLike | null): boo
   if (isTerminalSkillActivePhase(state.phase)) return true;
   if (stringValue(state.completed_at).trim()) return true;
   if (stringValue(state.terminal_reason).trim()) return true;
+  if (isTerminalSkillActivePhase(state.run_outcome)) return true;
   if (stringValue(state.lifecycle_outcome).trim() || stringValue(state.terminal_outcome).trim()) return true;
   return false;
 }

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -31,7 +31,7 @@ import {
   SKILL_ACTIVE_STATE_MODE,
   clearTerminalSkillActiveMarkers,
   getSkillActiveStatePathsForStateDir,
-  isTerminalSkillActivePhase,
+  isTerminalSkillActiveState,
   listActiveSkills,
   readSkillActiveState,
   readVisibleSkillActiveStateForStateDir,
@@ -351,13 +351,7 @@ function buildRalplanSkillStateFromEntries(
 }
 
 function isTerminalSkillActiveTombstone(state: SkillActiveStateLike | null): boolean {
-  if (!state) return false;
-  if (state.active === false) return true;
-  if (isTerminalSkillActivePhase(state.phase)) return true;
-  if (stringValue(state.completed_at).trim()) return true;
-  if (isTerminalSkillActivePhase(state.run_outcome)) return true;
-  if (stringValue(state.lifecycle_outcome).trim() || stringValue(state.terminal_outcome).trim()) return true;
-  return false;
+  return state !== null && isTerminalSkillActiveState(state);
 }
 
 function filterCompletedRalplanRootEntries(

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -167,7 +167,7 @@ function sanitizeWriterBaseForSession(
   return inherited;
 }
 
-function isTerminalSkillActivePhase(phase: unknown): boolean {
+export function isTerminalSkillActivePhase(phase: unknown): boolean {
   const normalized = safeString(phase).trim().toLowerCase();
   if (!normalized) return false;
   if (normalized === 'cleared') return true;
@@ -186,7 +186,7 @@ function isTerminalSkillActiveState(state: SkillActiveStateLike): boolean {
   return Boolean(lifecycleOutcome);
 }
 
-function clearTerminalSkillActiveMarkers<T extends SkillActiveStateLike>(state: T): T {
+export function clearTerminalSkillActiveMarkers<T extends SkillActiveStateLike>(state: T): T {
   const next = { ...state };
   if (isTerminalSkillActivePhase(next.phase)) delete next.phase;
   delete next.completed_at;
@@ -194,6 +194,7 @@ function clearTerminalSkillActiveMarkers<T extends SkillActiveStateLike>(state: 
   delete next.run_outcome;
   delete next.lifecycle_outcome;
   delete next.terminal_outcome;
+  delete next.terminal_reason;
   return next;
 }
 

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -176,7 +176,7 @@ export function isTerminalSkillActivePhase(phase: unknown): boolean {
   return Boolean(normalizeTerminalLifecycleOutcome(normalized).outcome);
 }
 
-function isTerminalSkillActiveState(state: SkillActiveStateLike): boolean {
+export function isTerminalSkillActiveState(state: SkillActiveStateLike): boolean {
   if (state.active === false) return true;
   if (isTerminalSkillActivePhase(state.phase)) return true;
   if (safeString(state.completed_at).trim().length > 0) return true;


### PR DESCRIPTION
## Summary
- finalize ralplan terminal writes across same-session root/session state without reviving stale session metadata
- preserve unrelated active root and session workflows, including detail-only legacy state, while clearing completed ralplan canonical entries
- remove the duplicated tombstone predicate in `operations.ts` by reusing canonical `isTerminalSkillActiveState` from `skill-active.ts`
- keep canonical terminal markers such as terminal `run_outcome` and normalized terminal lifecycle outcomes preserved as tombstones, while leaving `terminal_reason` as explanatory metadata only
- add focused state-operation regressions for stale session ids, root/session canonical mirrors, detail-only active workflows, terminal phase aliases, run-outcome-only tombstones, terminal-reason-only active cleanup, and non-terminal `lifecycle_outcome` cleanup

## Central Review Issue
The repeated Codex comments were all symptoms of one drift point: `operations.ts` had its own terminal/tombstone detection instead of using the canonical skill-active visibility rules. That local predicate first missed terminal phase aliases, then missed terminal `run_outcome`, then over-corrected by treating `terminal_reason` and any non-empty lifecycle value as terminal. The latest patch makes `completeRalplanSession` use the same canonical `isTerminalSkillActiveState` logic as `listActiveSkills`, so future root/session canonical cleanup decisions normalize terminal state consistently.

## Validation
- `npm run build`
- `node dist/scripts/run-test-files.js dist/state/__tests__/operations.test.js dist/state/__tests__/skill-active.test.js dist/runtime/__tests__/run-outcome.test.js`
- `npm run check:no-unused`
- `npm run lint -- src/state/operations.ts src/state/skill-active.ts src/state/__tests__/operations.test.ts`
- `git diff --check`
- `omx exec review --uncommitted` (clean; no actionable defects; rebuilt and passed `dist/state/__tests__/operations.test.js`)
- `npm test` (ran full suite; one unrelated local failure remains in `dist/cli/__tests__/resume.test.js`: the test expects `/history-lines:1\b/`, while macOS `wc -l` output is padded as `history-lines:       1`; the touched state/runtime suites passed during the full run)
- GitHub CI on head `1926fc91` is fully green, including Lint, Typecheck, Build dist artifact, all Node test lanes, Coverage Gate, Ralph Persistence Gate, and CI Status

## Notes
- Current PR base is `dev`; the branch is current with `upstream/dev` (`0 5`) and in sync with `origin/codex/ralplan-terminal-state`.
- All prior review threads, including the `run_outcome` and lifecycle tombstone comments, are now outdated on GitHub after the canonical predicate reuse. The PR still shows `CHANGES_REQUESTED` until the older maintainer review is superseded or dismissed by maintainer re-review.
