### PR TITLE
Fix MSYS team worker startup script paths

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1282,26 +1282,34 @@ describe('buildWorkerStartupCommand', () => {
     }
   });
 
-  it('does not use startup scripts on win32/MSYS so existing tmux path translation remains in force', () => {
+  it('uses a generated startup script with MSYS paths on win32/MSYS', async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
     const prevMsystem = process.env.MSYSTEM;
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const stateRoot = 'C:\\omx-state';
     try {
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
       process.env.MSYSTEM = 'MINGW64';
-      assert.equal(
-        writeWorkerStartupScriptCommand(
-          'alpha',
-          1,
-          ['--model', 'gpt-5'],
-          'C:\\repo',
-          { OMX_TEAM_STATE_ROOT: 'C:\\repo\\.omx\\state' },
-        ),
-        null,
+      process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+      const cmd = writeWorkerStartupScriptCommand(
+        'alpha',
+        1,
+        ['--model', 'gpt-5'],
+        'C:\\repo',
+        { OMX_TEAM_STATE_ROOT: stateRoot },
+        'gemini',
       );
+      assert.equal(cmd, `exec /bin/sh '/c/omx-state/team/alpha/runtime/worker-1-startup.sh'`);
+      const script = await readFile(join(stateRoot, 'team', 'alpha', 'runtime', 'worker-1-startup.sh'), 'utf-8');
+      assert.match(script, /^cd '\/c\/repo'$/m);
+      assert.match(script, /^exec '\/bin\/sh' -c /m);
     } finally {
+      await rm(stateRoot, { recursive: true, force: true });
       if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
       if (typeof prevMsystem === 'string') process.env.MSYSTEM = prevMsystem;
       else delete process.env.MSYSTEM;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
     }
   });
 

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1313,6 +1313,58 @@ describe('buildWorkerStartupCommand', () => {
     }
   });
 
+  it('does not emit cmd.exe flag wrappers for MSYS startup scripts with cmd shims', async () => {
+    const fakeRoot = await mkdtemp(join(tmpdir(), 'omx-worker-startup-msys-cmd-shim-'));
+    const fakeBin = join(fakeRoot, 'bin dir');
+    const stateRoot = join(fakeRoot, 'state root');
+    const startupScriptPath = join(stateRoot, 'team', 'alpha', 'runtime', 'worker-1-startup.sh');
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    const prevPath = process.env.PATH;
+    const prevPathext = process.env.PATHEXT;
+    const prevMsystem = process.env.MSYSTEM;
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    try {
+      await mkdir(fakeBin, { recursive: true });
+      const geminiCmdPath = join(fakeBin, 'gemini.cmd');
+      await writeFile(geminiCmdPath, '@echo off\r\n');
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      process.env.PATH = fakeBin;
+      process.env.PATHEXT = '.CMD';
+      process.env.MSYSTEM = 'MINGW64';
+      process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+
+      const cmd = writeWorkerStartupScriptCommand(
+        'alpha',
+        1,
+        ['--model', 'gemini-2.5-pro'],
+        'C:\\repo with space',
+        { OMX_TEAM_STATE_ROOT: stateRoot },
+        'gemini',
+      );
+
+      assert.equal(cmd, `exec /bin/sh '${startupScriptPath}'`);
+      const script = await readFile(startupScriptPath, 'utf-8');
+      assert.doesNotMatch(script, /cmd\.exe/i);
+      assert.doesNotMatch(script, /'\/d'|'\/s'|'\/c'|\s\/d\s|\s\/s\s|\s\/c\s/i);
+      assert.match(script, /^cd '\/c\/repo with space'$/m);
+      assert.match(script, /^exec '\/bin\/sh' -c /m);
+      assert.match(script, new RegExp(escapeRegExp(geminiCmdPath)));
+      assert.match(script, /--approval-mode/);
+      assert.match(script, /yolo/);
+    } finally {
+      await rm(fakeRoot, { recursive: true, force: true });
+      if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+      if (typeof prevPath === 'string') process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      if (typeof prevPathext === 'string') process.env.PATHEXT = prevPathext;
+      else delete process.env.PATHEXT;
+      if (typeof prevMsystem === 'string') process.env.MSYSTEM = prevMsystem;
+      else delete process.env.MSYSTEM;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
   it('writes a short worker startup script under team runtime state when available', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-worker-startup-script-'));
     const stateRoot = join(wd, '.omx', 'state');

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1365,6 +1365,58 @@ describe('buildWorkerStartupCommand', () => {
     }
   });
 
+  it('wraps MSYS prompt worker cmd shims for shell-free Windows spawn', async () => {
+    const fakeRoot = await mkdtemp(join(tmpdir(), 'omx-worker-process-msys-bat-shim-'));
+    const fakeBin = join(fakeRoot, 'bin dir');
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    const prevPath = process.env.PATH;
+    const prevPathext = process.env.PATHEXT;
+    const prevMsystem = process.env.MSYSTEM;
+    const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const prevComSpec = process.env.ComSpec;
+    try {
+      await mkdir(fakeBin, { recursive: true });
+      const geminiBatPath = join(fakeBin, 'gemini.bat');
+      await writeFile(geminiBatPath, '@echo off\r\n');
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      process.env.PATH = fakeBin;
+      process.env.PATHEXT = '.BAT';
+      process.env.MSYSTEM = 'MINGW64';
+      process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+      process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe';
+
+      const spec = buildWorkerProcessLaunchSpec(
+        'alpha',
+        1,
+        ['--model', 'gemini-2.5-pro'],
+        'C:\\repo with space',
+        {},
+        'gemini',
+      );
+
+      assert.equal(spec.command, 'C:\\Windows\\System32\\cmd.exe');
+      assert.deepEqual(spec.args.slice(0, 3), ['/d', '/s', '/c']);
+      assert.match(spec.args[3] ?? '', new RegExp(escapeRegExp(geminiBatPath)));
+      assert.match(spec.args[3] ?? '', /--approval-mode/);
+      assert.match(spec.args[3] ?? '', /yolo/);
+      assert.equal(spec.env.OMX_LEADER_CLI_PATH, geminiBatPath);
+      assert.notEqual(spec.command, geminiBatPath);
+    } finally {
+      await rm(fakeRoot, { recursive: true, force: true });
+      if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+      if (typeof prevPath === 'string') process.env.PATH = prevPath;
+      else delete process.env.PATH;
+      if (typeof prevPathext === 'string') process.env.PATHEXT = prevPathext;
+      else delete process.env.PATHEXT;
+      if (typeof prevMsystem === 'string') process.env.MSYSTEM = prevMsystem;
+      else delete process.env.MSYSTEM;
+      if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof prevComSpec === 'string') process.env.ComSpec = prevComSpec;
+      else delete process.env.ComSpec;
+    }
+  });
+
   it('writes a short worker startup script under team runtime state when available', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-worker-startup-script-'));
     const stateRoot = join(wd, '.omx', 'state');

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1194,7 +1194,7 @@ export function buildWorkerStartupCommand(
   }
   const resolvedLeaderNodePath = processSpec.env[OMX_LEADER_NODE_PATH_ENV]?.trim() || resolveLeaderNodePath();
   const leaderNodeDir = /[\\/]/.test(resolvedLeaderNodePath)
-    ? resolvedLeaderNodePath.replace(/[\\/][^\\/]+$/, '')
+    ? translatePathForMsys(resolvedLeaderNodePath.replace(/[\\/][^\\/]+$/, ''))
     : '';
   if (isNativeWindows()) {
     const powershellPath = resolveNativeWindowsPowerShellPath();
@@ -1222,8 +1222,8 @@ export function buildWorkerStartupCommand(
 
   const launchSpec = buildWorkerLaunchSpec(process.env.SHELL);
   const pathPrefix = leaderNodeDir ? `export PATH=${shellQuoteSingle(leaderNodeDir)}:$PATH; ` : '';
-  const quotedArgs = startupArgs.map(shellQuoteSingle).join(' ');
-  const quotedCommand = shellQuoteSingle(processSpec.command);
+  const quotedArgs = startupArgs.map((arg) => shellQuoteSingle(translatePathForMsys(arg))).join(' ');
+  const quotedCommand = shellQuoteSingle(translatePathForMsys(processSpec.command));
   const cliInvocation = quotedArgs.length > 0 ? `exec ${quotedCommand} ${quotedArgs}` : `exec ${quotedCommand}`;
   // Keep worker tmux panes non-interactive and rc-free by default. PR #2283
   // blocked rc sourcing for detached leader/HUD panes, but team workers still
@@ -1256,12 +1256,12 @@ function buildWorkerStartupScriptContent(
 ): string {
   const resolvedLeaderNodePath = processSpec.env[OMX_LEADER_NODE_PATH_ENV]?.trim() || resolveLeaderNodePath();
   const leaderNodeDir = /[\\/]/.test(resolvedLeaderNodePath)
-    ? resolvedLeaderNodePath.replace(/[\\/][^\\/]+$/, '')
+    ? translatePathForMsys(resolvedLeaderNodePath.replace(/[\\/][^\\/]+$/, ''))
     : '';
   const launchSpec = buildWorkerLaunchSpec(process.env.SHELL);
   const pathPrefix = leaderNodeDir ? `export PATH=${shellQuoteSingle(leaderNodeDir)}:$PATH\n` : '';
-  const quotedArgs = startupArgs.map(shellQuoteSingle).join(' ');
-  const quotedCommand = shellQuoteSingle(processSpec.command);
+  const quotedArgs = startupArgs.map((arg) => shellQuoteSingle(translatePathForMsys(arg))).join(' ');
+  const quotedCommand = shellQuoteSingle(translatePathForMsys(processSpec.command));
   const cliInvocation = quotedArgs.length > 0 ? `exec ${quotedCommand} ${quotedArgs}` : `exec ${quotedCommand}`;
   const rcPrefix = shouldSourceTeamWorkerShellRc({ ...process.env, ...extraEnv }) && launchSpec.rcFile
     ? `if [ -f ${launchSpec.rcFile} ]; then . ${launchSpec.rcFile}; fi\n`
@@ -1277,7 +1277,7 @@ function buildWorkerStartupScriptContent(
     '#!/bin/sh',
     'set -eu',
     `unset ${OMX_TMUX_HUD_OWNER_ENV} ${OMX_TMUX_HUD_LEADER_PANE_ENV}`,
-    `cd ${shellQuoteSingle(cwd)}`,
+    `cd ${shellQuoteSingle(translatePathForMsys(cwd))}`,
     envExports,
     `exec ${shellQuoteSingle(launchSpec.shell)} -c ${shellQuoteSingle(`${rcPrefix}${pathPrefix}${cliInvocation}`)}`,
     '',
@@ -1294,7 +1294,7 @@ export function writeWorkerStartupScriptCommand(
   initialPrompt?: string,
   workerRole?: string,
 ): string | null {
-  if (process.platform === 'win32') return null;
+  if (process.platform === 'win32' && !isMsysOrGitBash()) return null;
   const stateRoot = extraEnv[OMX_TEAM_STATE_ROOT_ENV]?.trim();
   if (!stateRoot) return null;
 
@@ -1321,7 +1321,7 @@ export function writeWorkerStartupScriptCommand(
   mkdirSync(dirname(scriptPath), { recursive: true });
   writeFileSync(scriptPath, buildWorkerStartupScriptContent(processSpec, startupEnv, startupArgs, cwd, extraEnv), 'utf-8');
   chmodSync(scriptPath, 0o700);
-  return `exec /bin/sh ${shellQuoteSingle(scriptPath)}`;
+  return `exec /bin/sh ${shellQuoteSingle(translatePathForMsys(scriptPath))}`;
 }
 
 export function buildWorkerProcessLaunchSpec(
@@ -1354,7 +1354,7 @@ export function buildWorkerProcessLaunchSpec(
     : undefined;
 
   const resolvedCliPath = resolveAbsoluteBinaryPath(workerCli);
-  const platformSpec = isNativeWindows()
+  const platformSpec = process.platform === 'win32'
     ? buildPlatformCommandSpec(workerCli, effectiveCliLaunchArgs, process.platform, effectiveEnv)
     : { command: resolvedCliPath, args: effectiveCliLaunchArgs };
   const resolvedLauncherPath = platformSpec.resolvedPath || resolvedCliPath;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1174,7 +1174,7 @@ export function buildWorkerStartupCommand(
   initialPrompt?: string,
   workerRole?: string,
 ): string {
-  const processSpec = buildWorkerProcessLaunchSpec(
+  const processSpec = buildWorkerStartupProcessLaunchSpec(
     teamName,
     workerIndex,
     launchArgs,
@@ -1298,7 +1298,7 @@ export function writeWorkerStartupScriptCommand(
   const stateRoot = extraEnv[OMX_TEAM_STATE_ROOT_ENV]?.trim();
   if (!stateRoot) return null;
 
-  const processSpec = buildWorkerProcessLaunchSpec(
+  const processSpec = buildWorkerStartupProcessLaunchSpec(
     teamName,
     workerIndex,
     launchArgs,
@@ -1324,7 +1324,56 @@ export function writeWorkerStartupScriptCommand(
   return `exec /bin/sh ${shellQuoteSingle(translatePathForMsys(scriptPath))}`;
 }
 
+type WorkerProcessLaunchMode = 'direct-spawn' | 'posix-startup-script';
+
 export function buildWorkerProcessLaunchSpec(
+  teamName: string,
+  workerIndex: number,
+  launchArgs: string[] = [],
+  cwd: string = process.cwd(),
+  extraEnv: Record<string, string> = {},
+  workerCliOverride?: TeamWorkerCli,
+  initialPrompt?: string,
+  workerRole?: string,
+): WorkerProcessLaunchSpec {
+  return buildWorkerProcessLaunchSpecForMode(
+    'direct-spawn',
+    teamName,
+    workerIndex,
+    launchArgs,
+    cwd,
+    extraEnv,
+    workerCliOverride,
+    initialPrompt,
+    workerRole,
+  );
+}
+
+function buildWorkerStartupProcessLaunchSpec(
+  teamName: string,
+  workerIndex: number,
+  launchArgs: string[] = [],
+  cwd: string = process.cwd(),
+  extraEnv: Record<string, string> = {},
+  workerCliOverride?: TeamWorkerCli,
+  initialPrompt?: string,
+  workerRole?: string,
+): WorkerProcessLaunchSpec {
+  return buildWorkerProcessLaunchSpecForMode(
+    'posix-startup-script',
+    teamName,
+    workerIndex,
+    launchArgs,
+    cwd,
+    extraEnv,
+    workerCliOverride,
+    initialPrompt,
+    workerRole,
+  );
+}
+
+function buildWorkerProcessLaunchSpecForMode(
+  mode: WorkerProcessLaunchMode,
   teamName: string,
   workerIndex: number,
   launchArgs: string[] = [],
@@ -1354,9 +1403,11 @@ export function buildWorkerProcessLaunchSpec(
     : undefined;
 
   const resolvedCliPath = resolveAbsoluteBinaryPath(workerCli);
-  const platformSpec = process.platform === 'win32' && !isMsysOrGitBash(effectiveEnv, process.platform)
+  const shouldUseNativeWindowsLaunchSpec = process.platform === 'win32'
+    && (mode === 'direct-spawn' || !isMsysOrGitBash(effectiveEnv, process.platform));
+  const platformSpec = shouldUseNativeWindowsLaunchSpec
     ? buildPlatformCommandSpec(workerCli, effectiveCliLaunchArgs, process.platform, effectiveEnv)
-    : { command: resolvedCliPath, args: effectiveCliLaunchArgs };
+    : { command: resolvedCliPath, args: effectiveCliLaunchArgs, resolvedPath: resolvedCliPath };
   const resolvedLauncherPath = platformSpec.resolvedPath || resolvedCliPath;
   const modelProviderOverride = workerCli === 'codex'
     ? extractModelProviderOverrideValue(effectiveCliLaunchArgs)

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1354,7 +1354,7 @@ export function buildWorkerProcessLaunchSpec(
     : undefined;
 
   const resolvedCliPath = resolveAbsoluteBinaryPath(workerCli);
-  const platformSpec = process.platform === 'win32'
+  const platformSpec = process.platform === 'win32' && !isMsysOrGitBash(effectiveEnv, process.platform)
     ? buildPlatformCommandSpec(workerCli, effectiveCliLaunchArgs, process.platform, effectiveEnv)
     : { command: resolvedCliPath, args: effectiveCliLaunchArgs };
   const resolvedLauncherPath = platformSpec.resolvedPath || resolvedCliPath;


### PR DESCRIPTION
## Summary
- allow win32 MSYS/Git Bash team workers to use generated startup scripts instead of fragile inline startup
- translate MSYS-facing cwd, launcher, args, leader PATH bootstrap, and startup script invocation paths
- preserve native Windows PowerShell startup and POSIX tmux/cmutex behavior

## Verification
- npm run build
- node dist/scripts/run-test-files.js dist/team/__tests__/tmux-session.test.js
- node dist/scripts/run-test-files.js dist/team/__tests__/worker-runtime-identity.test.js

Fixes #3016

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*