### PR TITLE
fix: recover ultragoal null get_goal loops

### DIFF
--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -582,6 +582,31 @@ describe('cli/ultragoal', () => {
     });
   });
 
+  it('rejects null get_goal snapshots for completion without mutating OMX progress', async () => {
+    await withCwd(async (cwd) => {
+      await capture(() => ultragoalCommand(['create-goals', '--brief', '- First milestone']));
+      await capture(() => ultragoalCommand(['complete-goals']));
+
+      const rejected = await capture(() => ultragoalCommand([
+        'checkpoint',
+        '--goal-id', 'G001-first-milestone',
+        '--status', 'complete',
+        '--evidence', 'tests passed',
+        '--codex-goal-json', '{"goal":null}',
+        '--json',
+      ]));
+
+      assert.equal(rejected.exitCode, 1);
+      assert.match(rejected.stderr.join('\n'), /no active goal\/null/);
+      assert.match(rejected.stderr.join('\n'), /call create_goal/);
+      assert.match(rejected.stderr.join('\n'), /do not mark complete from OMX state alone/);
+
+      const plan = JSON.parse(await readFile(join(cwd, '.omx/ultragoal/goals.json'), 'utf-8')) as { activeGoalId?: string; goals: Array<{ status: string }> };
+      assert.equal(plan.activeGoalId, 'G001-first-milestone');
+      assert.equal(plan.goals[0].status, 'in_progress');
+    });
+  });
+
   it('fails closed for malformed final quality-gate json', async () => {
     await withCwd(async (cwd) => {
       await capture(() => ultragoalCommand(['create-goals', '--brief', '- First milestone']));

--- a/src/goal-workflows/__tests__/codex-goal-snapshot.test.ts
+++ b/src/goal-workflows/__tests__/codex-goal-snapshot.test.ts
@@ -52,6 +52,18 @@ describe('codex goal snapshot reconciliation', () => {
     assert.match(required.errors.join('\n'), /call get_goal/);
   });
 
+  it('treats get_goal null as no active goal without permitting completion', () => {
+    const required = reconcileCodexGoalSnapshot(
+      parseCodexGoalSnapshot({ goal: null }),
+      { expectedObjective: 'Ship', requireSnapshot: true, requireComplete: true },
+    );
+
+    assert.equal(required.ok, false);
+    assert.match(required.errors.join('\n'), /no active goal\/null/);
+    assert.match(required.errors.join('\n'), /call create_goal/);
+    assert.match(required.errors.join('\n'), /do not mark complete from OMX state alone/);
+  });
+
   it('keeps required reconciliation strict when get_goal is unavailable', () => {
     const result = reconcileCodexGoalSnapshot(
       parseCodexGoalSnapshot({ error: 'SqliteError: no such table: thread_goals' }),

--- a/src/goal-workflows/codex-goal-snapshot.ts
+++ b/src/goal-workflows/codex-goal-snapshot.ts
@@ -164,7 +164,7 @@ export function reconcileCodexGoalSnapshot(
     const diagnostic = effectiveSnapshot.unavailableReason === 'db_schema_context_error'
       ? ' Codex goal state is unavailable due to a DB/schema/context error; this is distinct from a normal missing or incomplete goal.'
       : '';
-    const message = `Codex goal snapshot is absent or reports no active goal; call get_goal and pass its JSON with --codex-goal-json.${diagnostic}${detail}`;
+    const message = `Codex goal snapshot is absent or reports no active goal/null; call get_goal and pass its JSON with --codex-goal-json. If get_goal reports no active goal/null while OMX still has in-progress workflow state, call create_goal with the intended workflow objective before checkpointing; do not mark complete from OMX state alone.${diagnostic}${detail}`;
     if (options.requireSnapshot) errors.push(message);
     else warnings.push(message);
     return { ok: errors.length === 0, snapshot: effectiveSnapshot, warnings, errors };

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3871,6 +3871,40 @@ standardMaxRounds = 15
     }
   });
 
+  it("blocks ultragoal Stop with no-active-goal recovery before completion checkpointing", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ultragoal-null-goal-stop-"));
+    try {
+      await writeJson(join(cwd, ".omx", "ultragoal", "goals.json"), {
+        version: 1,
+        activeGoalId: "G002-resolve-final-independent-review-gat",
+        codexGoalMode: "aggregate",
+        codexObjective: "Complete the durable ultragoal plan in .omx/ultragoal/goals.json.",
+        goals: [
+          { id: "G001-final-review", status: "review_blocked", objective: "Resolve review." },
+          { id: "G002-resolve-final-independent-review-gat", status: "in_progress", objective: "Resolve final independent review gate." },
+        ],
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-ultragoal-null-goal-stop",
+        thread_id: "thread-ultragoal-null-goal-stop",
+        last_assistant_message: "Goal complete. get_goal returned null, so I will checkpoint G002 complete from OMX state.",
+      }, { cwd });
+
+      const output = JSON.stringify(result.outputJson);
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(output, /no active goal\/null/);
+      assert.match(output, /do not checkpoint complete or record a blocker from the empty snapshot/);
+      assert.match(output, /call create_goal/);
+      assert.match(output, /Complete the durable ultragoal plan/);
+      assert.match(output, /Hooks must not mutate Codex goal state/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not block ultragoal Stop for ordinary prose about a goal to complete work", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ultragoal-ordinary-stop-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2742,10 +2742,12 @@ async function findActiveGoalWorkflowReconciliationRequirement(cwd: string): Pro
   }
   if (activeUltragoal) {
     const goalId = safeString(activeUltragoal.id) || "<goal-id>";
+    const codexObjective = safeString(ultragoal?.codexObjective) || safeString(activeUltragoal.objective) || "<intended ultragoal objective>";
     return {
       workflow: "ultragoal",
       command: `omx ultragoal checkpoint --goal-id ${goalId} --status complete --codex-goal-json '<get_goal JSON or path>' --evidence '<evidence>'`,
       remediation: [
+        `If get_goal returns no active goal/null while ${goalId} remains in_progress in .omx/ultragoal/goals.json, do not checkpoint complete or record a blocker from the empty snapshot; call create_goal with objective ${JSON.stringify(codexObjective)} and continue the active OMX story until real completion evidence exists.`,
         `If get_goal returns a completed task-scoped objective for the same aggregate ultragoal plan, checkpoint ${goalId} with evidence naming ${goalId} plus .omx/ultragoal/goals.json or ledger.jsonl and pass final quality-gate JSON; OMX will reconcile the completed planned scope without mutating Codex goal state.`,
         `If get_goal instead returns a different completed legacy objective and complete checkpointing fails, do not repeat --status complete in this thread.`,
         `Record the non-terminal blocker with: omx ultragoal checkpoint --goal-id ${goalId} --status blocked --codex-goal-json '<different completed get_goal JSON or path>' --evidence '<completed legacy Codex goal blocks create_goal in this thread>'.`,


### PR DESCRIPTION
## Summary
- Treat `get_goal` null/no-active-goal snapshots as a strict incomplete Codex goal state, with guidance to call `create_goal` before checkpointing instead of marking OMX completion from durable state alone.
- Add Ultragoal Stop-hook remediation for the issue #3019 loop where `.omx/ultragoal/goals.json` still has an in-progress story but Codex `get_goal` returns null.
- Cover null snapshots at the shared reconciliation, CLI checkpoint, and native Stop-hook layers.

## Verification
- `npm install`
- `npm run build`
- `node dist/scripts/run-test-files.js dist/goal-workflows/__tests__/codex-goal-snapshot.test.js dist/cli/__tests__/ultragoal.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- `npm run lint`

Fixes #3019

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*