### PR TITLE
Clarify dev version policy after release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "omx-api"
-version = "0.18.17"
+version = "0.18.18"
 dependencies = [
  "serde",
  "serde_json",
@@ -40,14 +40,14 @@ dependencies = [
 
 [[package]]
 name = "omx-explore-harness"
-version = "0.18.17"
+version = "0.18.18"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "omx-mux"
-version = "0.18.17"
+version = "0.18.18"
 dependencies = [
  "serde",
  "serde_json",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime"
-version = "0.18.17"
+version = "0.18.18"
 dependencies = [
  "omx-mux",
  "omx-runtime-core",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime-core"
-version = "0.18.17"
+version = "0.18.18"
 dependencies = [
  "fs2",
  "serde",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "omx-sparkshell"
-version = "0.18.17"
+version = "0.18.18"
 dependencies = [
  "omx-mux",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.18.17"
+version = "0.18.18"
 
 edition = "2021"
 rust-version = "1.73"

--- a/RELEASE_PROTOCOL.md
+++ b/RELEASE_PROTOCOL.md
@@ -81,7 +81,8 @@ Before merging to `main` or tagging:
    - GitHub release exists and is non-draft/non-prerelease.
    - Native assets and manifest are attached.
    - `npm view oh-my-codex version` returns the release version.
-6. Fast-forward `dev` to the shipped `main` commit and wait for final `dev` CI green.
+6. Fast-forward `dev` to the shipped `main` commit and wait for final shipped-commit `dev` CI green.
+7. Immediately bump `dev` package/plugin/Cargo metadata to the next development base version (for example, after publishing `v0.18.17`, commit `0.18.18` on `dev`) so dev installs display as `v<next>-dev-<revision>` instead of sharing the just-published stable base.
 
 ## 6. Post-publish corrections
 
@@ -97,7 +98,7 @@ If release notes are found incomplete after npm publish:
 
 A release is complete only when all are true:
 
-- `main`, `dev`, and the release tag point to the intended shipped commit, or any deliberate post-publish docs-only divergence is documented.
+- `main` and the release tag point to the intended shipped commit, and `dev` either still points to that shipped commit or contains only documented post-publish corrections plus the next development base-version bump.
 - GitHub release workflow is green.
 - npm shows the expected version.
 - GitHub release body accurately summarizes the full compare range.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-codex",
-  "version": "0.18.17",
+  "version": "0.18.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-codex",
-      "version": "0.18.17",
+      "version": "0.18.18",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.18.17",
+  "version": "0.18.18",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/oh-my-codex/.codex-plugin/plugin.json
+++ b/plugins/oh-my-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.18.17",
+  "version": "0.18.18",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "author": {
     "name": "Yeachan Heo",

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -622,6 +622,12 @@ command = "node"
 					`Skills: plugin marketplace oh-my-codex-local is registered, but installed Codex plugin cache manifest version 0\\.0\\.0-stale does not match packaged version ${version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}; run "omx setup --plugin --force" so /skills can discover OMX plugin skills`,
 				),
 			);
+			assert.match(
+				res.stdout,
+				new RegExp(
+					`Plugin versions: expected cache directory .*${version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} is not materialized with packaged plugin manifest version ${version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}; run "omx setup --plugin --force" to refresh the plugin cache`,
+				),
+			);
 		} finally {
 			await rm(wd, { recursive: true, force: true });
 		}
@@ -658,6 +664,10 @@ command = "node"
 			assert.match(
 				res.stdout,
 				/Skills: plugin marketplace oh-my-codex-local is registered, but no installed Codex plugin cache was found; run "omx setup --plugin --force" so \/skills can discover OMX plugin skills/,
+			);
+			assert.match(
+				res.stdout,
+				/Plugin versions: expected cache directory .* is not materialized with packaged plugin manifest version .*; run "omx setup --plugin --force" to refresh the plugin cache/,
 			);
 		} finally {
 			await rm(wd, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- bump dev package/Cargo/plugin metadata to 0.18.18 after the 0.18.17 release
- document the post-publish dev base-version bump in the release protocol
- assert stale/missing plugin-cache doctor warnings recommend `omx setup --plugin --force`

Fixes #3021

## Verification
- npm run build
- node dist/scripts/run-test-files.js dist/cli/__tests__/doctor-warning-copy.test.js
- node dist/scripts/run-test-files.js dist/cli/__tests__/version-sync-contract.test.js dist/cli/__tests__/version.test.js dist/utils/__tests__/version.test.js dist/utils/__tests__/dep-versions.test.js dist/cli/__tests__/codex-plugin-layout.test.js
- node dist/scripts/check-version-sync.js
- npm run verify:plugin-bundle
- git diff --check