### PR TITLE
Fix Autopilot planning guard read-only Bash

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -9614,6 +9614,44 @@ exit 0
         thread_id: "thread-autopilot-ralplan-artifact",
       });
 
+      const preToolUse = async (tool_name: string, tool_use_id: string, tool_input: Record<string, unknown>) => dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-autopilot-ralplan-artifact",
+          thread_id: "thread-autopilot-ralplan-artifact",
+          tool_name,
+          tool_use_id,
+          tool_input,
+        },
+        { cwd },
+      );
+
+      const issueReadOnlyEvidenceCommand = [
+        "printf 'collecting planning evidence\\n'",
+        "ROOT=$(git rev-parse --show-toplevel)",
+        "BASE=$(git merge-base HEAD origin/dev)",
+        "git log --oneline ${BASE}..HEAD",
+        "git diff --name-status ${BASE}..HEAD",
+        "sed -n '1,120p' src/scripts/codex-native-hook.ts",
+        "grep -RIn 'commandHasDeepInterviewWriteIntent' src/scripts/codex-native-hook.ts",
+        "printf '%s\\n' \"$ROOT\"",
+      ].join("; ");
+      const allowedIssueReadOnlyBash = await preToolUse("Bash", "tool-autopilot-ralplan-read-only-bash", {
+        command: issueReadOnlyEvidenceCommand,
+      });
+      assert.equal(allowedIssueReadOnlyBash.outputJson, null);
+
+      for (const command of ["git merge origin/dev", "git reset --hard HEAD"]) {
+        const blockedDestructiveGit = await preToolUse("Bash", `tool-autopilot-ralplan-${command.replace(/[^a-z0-9]+/gi, "-")}`, {
+          command,
+        });
+        assert.equal(
+          (blockedDestructiveGit.outputJson as { decision?: string } | null)?.decision,
+          "block",
+          `${command} should stay blocked during Autopilot ralplan`,
+        );
+      }
       const allowedPlanWrite = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -9642,7 +9642,7 @@ exit 0
       });
       assert.equal(allowedIssueReadOnlyBash.outputJson, null);
 
-      for (const command of ["git merge origin/dev", "git reset --hard HEAD"]) {
+      for (const command of ["git merge origin/dev", "git reset --hard HEAD", "git checkout-index -f -a", "git merge-file ours base theirs"]) {
         const blockedDestructiveGit = await preToolUse("Bash", `tool-autopilot-ralplan-${command.replace(/[^a-z0-9]+/gi, "-")}`, {
           command,
         });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3560,7 +3560,46 @@ function extractDeepInterviewCommandRedirectTargets(command: string): string[] {
 }
 
 function commandHasDestructiveGitSubcommand(command: string): boolean {
-  return /\bgit\s+(?:checkout|switch|restore|reset|apply|am|merge|rebase)(?=$|[\s;&|()<>])/.test(command);
+  const destructiveSubcommands = new Set([
+    "am",
+    "apply",
+    "checkout",
+    "merge",
+    "rebase",
+    "reset",
+    "restore",
+    "switch",
+  ]);
+
+  for (const segment of splitShellCommandSegments(stripHeredocBodiesForCommandScan(command))) {
+    const words = tokenizeShellWords(segment);
+    for (let index = 0; index < words.length; index += 1) {
+      if (shellWordBaseName(words[index] ?? "") !== "git") continue;
+      const subcommandIndex = findGitSubcommandIndex(words, index + 1);
+      if (subcommandIndex === null) continue;
+      const subcommand = words[subcommandIndex] ?? "";
+      if (destructiveSubcommands.has(subcommand)) return true;
+      if (subcommand.startsWith("checkout-")) return true;
+      if (subcommand.startsWith("merge-") && subcommand !== "merge-base") return true;
+    }
+  }
+  return false;
+}
+
+function findGitSubcommandIndex(words: string[], startIndex: number): number | null {
+  for (let index = startIndex; index < words.length; index += 1) {
+    const word = words[index] ?? "";
+    if (!word || word === "--") continue;
+    if (isShellAssignmentWord(word)) continue;
+    if (word === "-C" || word === "-c" || word === "--git-dir" || word === "--work-tree" || word === "--namespace") {
+      index += 1;
+      continue;
+    }
+    if (word.startsWith("--git-dir=") || word.startsWith("--work-tree=") || word.startsWith("--namespace=")) continue;
+    if (word.startsWith("-")) continue;
+    return index;
+  }
+  return null;
 }
 
 function commandHasDeepInterviewWriteIntent(command: string): boolean {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3559,13 +3559,18 @@ function extractDeepInterviewCommandRedirectTargets(command: string): string[] {
   return targets;
 }
 
+function commandHasDestructiveGitSubcommand(command: string): boolean {
+  return /\bgit\s+(?:checkout|switch|restore|reset|apply|am|merge|rebase)(?=$|[\s;&|()<>])/.test(command);
+}
+
 function commandHasDeepInterviewWriteIntent(command: string): boolean {
   return commandInvokesApplyPatch(command)
     || extractDeepInterviewCommandRedirectTargets(command).length > 0
     || /\btee\s+(?:-a\s+)?[^\s&|;]+/.test(command)
     || /\bsed\s+(?:[^\n;&|]*\s)?-i(?:\b|['"])/.test(command)
     || /\b(?:python3?|node|perl|ruby)\b[\s\S]{0,260}\b(?:writeFileSync|writeFile|write_text|open\([^)]*["']w|File\.write|Path\()/.test(command)
-    || /\b(?:git\s+(?:checkout|switch|restore|reset|apply|am|merge|rebase)|npm\s+(?:install|i|ci)|pnpm\s+(?:install|i)|yarn\s+(?:install|add))\b/.test(command);
+    || commandHasDestructiveGitSubcommand(command)
+    || /\b(?:npm\s+(?:install|i|ci)|pnpm\s+(?:install|i)|yarn\s+(?:install|add))\b/.test(command);
 }
 
 function extractDeepInterviewCommandWriteTargets(command: string): string[] {


### PR DESCRIPTION
## Summary
- Tighten the planning Bash write-intent classifier so destructive `git merge` detection no longer matches read-only `git merge-base`.
- Add Autopilot ralplan regressions proving the issue evidence-gathering Bash is allowed while `git merge origin/dev` and `git reset --hard HEAD` remain blocked.

Fixes #3023.

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js` — 474 passing

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*