### PR TITLE
Fix madmax resume plugin cache preflight

### DIFF
--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -443,6 +443,80 @@ if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-unrelated-session.jsonl" ]; the
     }
   });
 
+  it('preflights madmax resume to current plugin cache after old cache deletion', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-madmax-plugin-preflight-'));
+    try {
+      const home = join(wd, 'home');
+      const runsRoot = join(wd, 'runs');
+      const projectCodexHome = join(wd, '.codex');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const testDir = dirname(fileURLToPath(import.meta.url));
+      const repoRoot = join(testDir, '..', '..', '..');
+      const manifest = JSON.parse(await readFile(join(repoRoot, 'plugins', 'oh-my-codex', '.codex-plugin', 'plugin.json'), 'utf-8')) as { version: string };
+      const currentVersion = manifest.version;
+      const oldVersion = '0.0.0-resume-stale';
+      const oldCacheDir = join(projectCodexHome, 'plugins', 'cache', 'oh-my-codex-local', 'oh-my-codex', oldVersion);
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await mkdir(runsRoot, { recursive: true });
+      await mkdir(join(projectCodexHome, 'sessions', '2026', '06', '17'), { recursive: true });
+      await mkdir(join(oldCacheDir, '.codex-plugin'), { recursive: true });
+      await mkdir(join(oldCacheDir, 'hooks'), { recursive: true });
+      await mkdir(join(wd, '.omx'), { recursive: true });
+      await writeFile(join(projectCodexHome, 'sessions', '2026', '06', '17', 'rollout-stale-session.jsonl'), '{"type":"session_meta","payload":{"id":"stale-session"}}\n');
+      await writeFile(join(projectCodexHome, 'config.toml'), [
+        '[plugins."oh-my-codex@oh-my-codex-local"]',
+        'enabled = true',
+        '',
+        '[marketplaces.oh-my-codex-local]',
+        'source_type = "local"',
+        'source = "/deleted/old/omx"',
+        '',
+      ].join('\n'));
+      await writeFile(join(oldCacheDir, '.codex-plugin', 'plugin.json'), JSON.stringify({
+        name: 'oh-my-codex',
+        version: oldVersion,
+        skills: './skills/',
+        hooks: './hooks/hooks.json',
+      }, null, 2));
+      await writeFile(join(oldCacheDir, 'hooks', 'hooks.json'), '{}\n');
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+      await writeFile(join(runsRoot, 'registry.jsonl'), `${JSON.stringify({ source_cwd: wd, run_dir: join(runsRoot, 'run-associated') })}\n`);
+      await rm(oldCacheDir, { recursive: true, force: true });
+
+      await writeFile(fakeCodexPath, `#!/bin/sh
+printf 'fake-codex:%s\n' "$*"
+printf 'codex-home:%s\n' "$CODEX_HOME"
+if [ -f "$CODEX_HOME/plugins/cache/oh-my-codex-local/oh-my-codex/${currentVersion}/hooks/codex-native-hook.mjs" ]; then echo current-hook-present=yes; else echo current-hook-present=no; fi
+if [ -e "$CODEX_HOME/plugins/cache/oh-my-codex-local/oh-my-codex/${oldVersion}" ]; then echo old-cache-present=yes; else echo old-cache-present=no; fi
+case "$(cat "$CODEX_HOME/config.toml")" in *'source = "${repoRoot}"'*) echo marketplace-current=yes;; *) echo marketplace-current=no;; esac
+`);
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+
+      const result = runOmx(wd, ['--madmax', 'resume', 'stale-session'], {
+        HOME: home,
+        OMX_RUNS_DIR: runsRoot,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      });
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, /fake-codex:.*resume stale-session\b/);
+      assert.match(result.stdout, /current-hook-present=yes/);
+      assert.match(result.stdout, /old-cache-present=no/);
+      assert.match(result.stdout, /marketplace-current=yes/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('keeps madmax runtime history deduped across repeated resume cleanup', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-resume-madmax-dedupe-'));
     try {

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -603,6 +603,32 @@ async function seedStalePluginDiscoveryCache(codexHomeDir: string): Promise<stri
 	return artifactPath;
 }
 
+async function seedOldVersionedPluginDiscoveryCache(codexHomeDir: string): Promise<string> {
+	const artifactPath = join(
+		codexHomeDir,
+		"plugins",
+		"cache",
+		"oh-my-codex-local",
+		"oh-my-codex",
+		"0.0.0",
+	);
+	await mkdir(dirname(artifactPath), { recursive: true });
+	await cp(join(packageRoot, "plugins", "oh-my-codex"), artifactPath, {
+		recursive: true,
+	});
+	await writeFile(
+		join(artifactPath, ".codex-plugin", "plugin.json"),
+		JSON.stringify(
+			{ name: "oh-my-codex", version: "0.0.0", skills: "./skills/", hooks: "./hooks/hooks.json" },
+			null,
+			2,
+		) + "\n",
+	);
+	await mkdir(join(artifactPath, "skills", "old-only"), { recursive: true });
+	await writeFile(join(artifactPath, "skills", "old-only", "SKILL.md"), "# old\n");
+	return artifactPath;
+}
+
 
 async function seedSameVersionPluginCacheWithStaleHooks(codexHomeDir: string): Promise<string> {
 	const cacheDir = await packagedPluginCacheDir(codexHomeDir);
@@ -1188,6 +1214,33 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
+	it("invalidates old versioned plugin cache dirs while materializing the current cache", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const oldCacheDir = await seedOldVersionedPluginDiscoveryCache(codexHomeDir);
+
+					const output = await captureConsoleOutput(async () => {
+						await setup({ scope: "user", installMode: "plugin" });
+					});
+
+					const currentCacheDir = await packagedPluginCacheDir(codexHomeDir);
+					assert.equal(existsSync(oldCacheDir), false);
+					assert.equal(existsSync(join(currentCacheDir, ".codex-plugin", "plugin.json")), true);
+					assert.equal(existsSync(join(currentCacheDir, "hooks", "hooks.json")), true);
+					assert.equal(existsSync(join(currentCacheDir, "hooks", "codex-native-hook.mjs")), true);
+					assert.equal(existsSync(join(currentCacheDir, "hooks", "omx-command.json")), true);
+					assert.equal(existsSync(join(currentCacheDir, "skills", "ask", "SKILL.md")), true);
+					assert.match(output, /Invalidated 1 stale Codex plugin discovery cache entry/);
+					assert.match(output, /Installed local Codex plugin cache/);
+					assert.doesNotMatch(output, /Retained .* old versioned Codex plugin cache/);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 	it("invalidates same-version plugin caches when hook file contents drift", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -78,6 +78,14 @@ import {
   resolveProjectLocalCodexHomeForLaunch,
 } from "./codex-home.js";
 import { discoverProjectRuntimeCodexHomes } from "./project-runtime-codex-homes.js";
+import {
+  discoverOmxPluginCacheDirs,
+  materializePackagedOmxPluginCache,
+  packagedOmxPluginVersion,
+  resolvePackagedOmxMarketplace,
+  upsertLocalOmxMarketplaceRegistration,
+  upsertLocalOmxPluginEnablement,
+} from "./plugin-marketplace.js";
 import { escapeTomlString, readTopLevelTomlString, upsertTopLevelTomlString } from "../utils/toml.js";
 
 export {
@@ -1145,6 +1153,65 @@ export function parseResumeCodexHomeSelection(args: string[]): ResumeCodexHomeSe
   };
 }
 
+export interface ResumePluginPreflightResult {
+  status: "unavailable" | "prepared";
+  version?: string;
+  cacheDir?: string;
+  prunedStaleDirs: string[];
+  configUpdated: boolean;
+}
+
+export async function preflightResumeOmxPluginState(
+  codexHomeDir: string | undefined,
+  pkgRoot = getPackageRoot(),
+): Promise<ResumePluginPreflightResult> {
+  if (!codexHomeDir) {
+    return { status: "unavailable", prunedStaleDirs: [], configUpdated: false };
+  }
+
+  const packagedMarketplace = await resolvePackagedOmxMarketplace(pkgRoot);
+  if (!packagedMarketplace) {
+    return { status: "unavailable", prunedStaleDirs: [], configUpdated: false };
+  }
+
+  const materialized = await materializePackagedOmxPluginCache(codexHomeDir, packagedMarketplace);
+  const version = materialized.version ?? (await packagedOmxPluginVersion(packagedMarketplace)) ?? undefined;
+  const currentCacheDir = materialized.cacheDir ?? (version ? join(codexHomeDir, "plugins", "cache", "oh-my-codex-local", "oh-my-codex", version) : undefined);
+  const prunedStaleDirs: string[] = [];
+
+  if (currentCacheDir) {
+    for (const cacheDir of await discoverOmxPluginCacheDirs(codexHomeDir)) {
+      if (cacheDir === currentCacheDir) continue;
+      await rm(cacheDir, { recursive: true, force: true });
+      prunedStaleDirs.push(cacheDir);
+    }
+  }
+
+  const configPath = join(codexHomeDir, "config.toml");
+  const existingConfig = existsSync(configPath) ? await readFile(configPath, "utf-8") : "";
+  const nextConfig = upsertLocalOmxMarketplaceRegistration(
+    upsertLocalOmxPluginEnablement(existingConfig),
+    pkgRoot,
+  );
+  const configUpdated = nextConfig !== existingConfig;
+  if (configUpdated) {
+    await mkdir(dirname(configPath), { recursive: true });
+    await writeFile(configPath, nextConfig, "utf-8");
+  }
+
+  return {
+    status: "prepared",
+    version,
+    cacheDir: currentCacheDir,
+    prunedStaleDirs,
+    configUpdated,
+  };
+}
+
+function isResumeCodexLaunch(args: string[]): boolean {
+  return args.includes("resume");
+}
+
 async function prepareResumeCodexHomeForLaunch(
   cwd: string,
   sessionId: string,
@@ -1153,10 +1220,12 @@ async function prepareResumeCodexHomeForLaunch(
 ): Promise<{ args: string[]; prepared: PreparedCodexHomeForLaunch }> {
   const selection = parseResumeCodexHomeSelection(args);
   if (selection.explicitCodexHome) {
+    const codexHomeOverride = resolve(selection.explicitCodexHome);
+    await preflightResumeOmxPluginState(codexHomeOverride);
     return {
       args: selection.args,
       prepared: {
-        codexHomeOverride: resolve(selection.explicitCodexHome),
+        codexHomeOverride,
       },
     };
   }
@@ -1167,6 +1236,7 @@ async function prepareResumeCodexHomeForLaunch(
       const emptyRuntimeCodexHome = runtimeCodexHomePath(cwd, sessionId);
       await rm(emptyRuntimeCodexHome, { recursive: true, force: true });
       await mkdir(join(emptyRuntimeCodexHome, "sessions"), { recursive: true });
+      await preflightResumeOmxPluginState(emptyRuntimeCodexHome);
       return {
         args: selection.args,
         prepared: {
@@ -1179,6 +1249,7 @@ async function prepareResumeCodexHomeForLaunch(
       includeHistoryArtifacts: true,
       extraHistoryCodexHomes: projectHomes.slice(1).map((home) => home.path),
     });
+    await preflightResumeOmxPluginState(runtimeCodexHome);
     return {
       args: selection.args,
       prepared: {
@@ -1191,6 +1262,7 @@ async function prepareResumeCodexHomeForLaunch(
     includeHistoryArtifacts: true,
     extraHistoryCodexHomes: projectHomes.map((home) => home.path),
   });
+  await preflightResumeOmxPluginState(prepared.codexHomeOverride);
   return { args: selection.args, prepared };
 }
 
@@ -3029,14 +3101,14 @@ export async function launchWithHud(args: string[]): Promise<void> {
     // Non-fatal: repair failure must not block launch
   }
 
-  const resumePrepared = normalizedArgs[0] === "resume"
+  const resumePrepared = isResumeCodexLaunch(normalizedArgs)
     ? await prepareResumeCodexHomeForLaunch(launchCwd, sessionId, normalizedArgs, process.env)
     : null;
   if (resumePrepared) {
     normalizedArgs = resumePrepared.args;
   }
   const preparedCodexHome = resumePrepared?.prepared ?? await prepareCodexHomeForLaunch(launchCwd, sessionId, process.env, {
-    includeHistoryArtifacts: normalizedArgs[0] === "resume",
+    includeHistoryArtifacts: isResumeCodexLaunch(normalizedArgs),
   });
   const codexHomeOverride = preparedCodexHome.codexHomeOverride;
   const sqliteHomeOverride = preparedCodexHome.sqliteHomeOverride;

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1327,6 +1327,8 @@ async function refreshOmxPluginDiscoveryCache(
 			!skillListChanged
 		) continue;
 
+
+
 		staleDirs.push(cacheDir);
 		if (!options.dryRun) {
 			await rm(cacheDir, { recursive: true, force: true });
@@ -2553,9 +2555,11 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			scopeDirs.codexHomeDir,
 		);
 		if (pluginCacheRefresh.status === "refreshed") {
-			console.log(
-				`  ${dryRun ? "Would invalidate" : "Invalidated"} ${pluginCacheRefresh.staleDirs.length} stale Codex plugin discovery cache entr${pluginCacheRefresh.staleDirs.length === 1 ? "y" : "ies"} so plugin skills refresh from the packaged manifest.`,
-			);
+			if (pluginCacheRefresh.staleDirs.length > 0) {
+				console.log(
+					`  ${dryRun ? "Would invalidate" : "Invalidated"} ${pluginCacheRefresh.staleDirs.length} stale Codex plugin discovery cache entr${pluginCacheRefresh.staleDirs.length === 1 ? "y" : "ies"} so plugin skills refresh from the packaged manifest.`,
+				);
+			}
 		} else if (pluginCacheRefresh.status === "unchanged") {
 			console.log("  Codex plugin discovery cache already matches packaged plugin metadata.");
 		}


### PR DESCRIPTION
## Summary

- retargets #3030 from setup-time old-cache retention to the refined #3024 update/resume boundary
- restores setup/update behavior so stale versioned OMX plugin cache dirs may be invalidated
- adds resume preflight for Codex resume launches, including `omx --madmax resume ...`, to materialize the current packaged plugin cache and repair the selected `CODEX_HOME` marketplace/plugin config before spawning Codex
- adds regression coverage for stale/deleted old plugin cache state being upgraded to the current cache before fake Codex resume invocation

Fixes #3024

## Verification

- npm run build
- npm run check:no-unused
- node dist/scripts/run-test-files.js dist/cli/__tests__/resume.test.js dist/cli/__tests__/setup-install-mode.test.js