### PR TITLE
[codex] Guard ralplan terminal closeout state writes

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -161,6 +161,12 @@ The approved explicit terminal stop model adds a canonical lifecycle layer for a
 Hook readers should prefer explicit lifecycle metadata over assistant-text heuristics when those signals are available.
 During migration, legacy `blocked_on_user` still suppresses continuation, but `cancelled` should be treated as internal legacy/admin compatibility rather than a canonical user-facing outcome.
 
+For `ralplan`, native `PreToolUse` allows only a standalone terminal
+`omx state write` transport for the current session's complete closeout
+(`active:false`, `current_phase:"complete"`). The state backend remains the
+authority for consensus validation and root/session terminalization, so compound
+Bash commands that add any suffix after the closeout command stay blocked.
+
 There is still no distinct native Codex `ask-user-question` hook today. That means `askuserQuestion` classification remains a runtime/fallback responsibility unless a future native hook surface exposes first-class question-stop metadata.
 
 ## Combined workflow note

--- a/src/cli/__tests__/mcp-parity.test.ts
+++ b/src/cli/__tests__/mcp-parity.test.ts
@@ -121,10 +121,8 @@ describe("mcpParityCommand", () => {
         "--input",
         JSON.stringify({
           mode: "ralplan",
-          active: false,
-          current_phase: "complete",
-          status: "complete",
-          terminal_state: "complete",
+          active: true,
+          current_phase: "planning",
           workingDirectory: cwd,
         }),
         "--json",

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -28,7 +28,7 @@ import {
   getStatePath,
   resolveStateScope,
 } from '../mcp/state-paths.js';
-import { completeRalplanSession } from '../state/operations.js';
+import { completeRalplanSession, validateRalplanTerminalConsensus } from '../state/operations.js';
 
 export interface ModeState {
   active: boolean;
@@ -303,6 +303,14 @@ export async function updateModeState(
     updatedBase.owner_omx_session_id = scope.sessionId;
   }
   const normalizedBase = normalizeModeStateOrThrow(mode, updatedBase as ModeState);
+  if (mode === 'ralplan') {
+    const validationError = validateRalplanTerminalConsensus(
+      projectRoot ?? process.cwd(),
+      normalizedBase as Record<string, unknown>,
+      scope.sessionId,
+    );
+    if (validationError) throw new Error(validationError);
+  }
   if (mode === 'autopilot') {
     const isPipelineOrchestratorProgressWrite = options.trustedPipelineProgress === true;
     const currentAutopilotChildPhase = deriveAutopilotChildPhase({ ...current, mode: 'autopilot' });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -8620,7 +8620,7 @@ exit 0
     }
   });
 
-  it("blocks deactivating ralplan state writes from --input-file while allowing non-deactivating ones", async () => {
+  it("allows complete ralplan terminal state writes while blocking partial deactivation writes", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-ralplan-state-input-file-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -8672,6 +8672,47 @@ exit 0
       );
       assert.equal((blocked.outputJson as { decision?: string } | null)?.decision, "block");
 
+      const terminalPayload = join(cwd, "ralplan-terminal-state.json");
+      await writeJson(terminalPayload, {
+        mode: "ralplan",
+        active: false,
+        current_phase: "complete",
+        session_id: "sess-ralplan-input-file",
+        terminal_reason: "consensus approved bounded no-op",
+      });
+      const allowedTerminalFile = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-ralplan-input-file",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-state-input-file-terminal-allowed",
+          tool_input: { command: `omx state write --input-file ${terminalPayload} --json` },
+        },
+        { cwd },
+      );
+      assert.equal(allowedTerminalFile.outputJson, null);
+
+      const mismatchedTerminalPayload = join(cwd, "ralplan-terminal-state-mismatched.json");
+      await writeJson(mismatchedTerminalPayload, {
+        mode: "ralplan",
+        active: false,
+        current_phase: "complete",
+        session_id: "other-session",
+      });
+      const blockedMismatchedTerminalFile = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-ralplan-input-file",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-state-input-file-terminal-mismatched",
+          tool_input: { command: `omx state write --input-file ${mismatchedTerminalPayload} --json` },
+        },
+        { cwd },
+      );
+      assert.equal((blockedMismatchedTerminalFile.outputJson as { decision?: string } | null)?.decision, "block");
+
       const terminalCurrentPhaseAliases = ["finish", "finished", "complete", "completed", "done", "blocked", "blocked-on-user", "blocked_on_user", "failed", "fail", "error", "cancelled", "canceled", "cancel", "aborted", "abort", "userinterlude", "user-interlude", "interrupted", "interrupt", "askuserquestion", "ask-user-question", "askuser", "question"] as const;
       for (const alias of terminalCurrentPhaseAliases) {
         const blockedAliasPayload = join(cwd, `ralplan-blocked-state-${alias}.json`);
@@ -8706,6 +8747,67 @@ exit 0
         { cwd },
       );
       assert.equal((blockedModeFlagTerminal.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const allowedModeFlagTerminal = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-ralplan-input-file",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-state-mode-flag-terminal-allowed",
+          tool_input: {
+            command: "omx state write --mode ralplan --input '{\"active\":false,\"current_phase\":\"complete\"}' --json",
+          },
+        },
+        { cwd },
+      );
+      assert.equal(allowedModeFlagTerminal.outputJson, null);
+
+      const blockedTerminalThenImplementationWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-ralplan-input-file",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-state-terminal-then-implementation-write",
+          tool_input: {
+            command: "omx state write --mode ralplan --input '{\"active\":false,\"current_phase\":\"complete\"}' --json && printf bad > src/leak.ts",
+          },
+        },
+        { cwd },
+      );
+      assert.equal(
+        (blockedTerminalThenImplementationWrite.outputJson as { decision?: string } | null)?.decision,
+        "block",
+      );
+
+      for (const [toolUseId, suffix] of [
+        ["tool-ralplan-state-terminal-then-touch", "&& touch src/leak.ts"],
+        ["tool-ralplan-state-terminal-then-rm", "; rm src/leak.ts"],
+        ["tool-ralplan-state-terminal-then-readonly", "&& pwd"],
+        ["tool-ralplan-state-terminal-command-substitution", "$(touch src/leak.ts)"],
+        ["tool-ralplan-state-terminal-backtick-substitution", "`touch src/leak.ts`"],
+        ["tool-ralplan-state-terminal-process-substitution", "<(touch src/leak.ts)"],
+      ] as const) {
+        const blockedTerminalThenSuffix = await dispatchCodexNativeHook(
+          {
+            hook_event_name: "PreToolUse",
+            cwd,
+            session_id: "sess-ralplan-input-file",
+            tool_name: "Bash",
+            tool_use_id: toolUseId,
+            tool_input: {
+              command: `omx state write --mode ralplan --input '{"active":false,"current_phase":"complete"}' --json ${suffix}`,
+            },
+          },
+          { cwd },
+        );
+        assert.equal(
+          (blockedTerminalThenSuffix.outputJson as { decision?: string } | null)?.decision,
+          "block",
+          `${suffix} suffix should keep ralplan terminal state writes standalone`,
+        );
+      }
 
       for (const alias of terminalCurrentPhaseAliases) {
         const blockedModeFlagAlias = await dispatchCodexNativeHook(
@@ -9497,8 +9599,9 @@ exit 0
       });
       assert.equal(allowedStateCliMutation.outputJson, null);
 
-      // Deactivation vectors (`omx state clear`, `active:false`) are still
-      // rejected at the transport boundary.
+      // Broad deactivation vectors such as `omx state clear` are still rejected
+      // at the transport boundary; complete consensus terminal writes are
+      // covered by the state-write closeout tests.
       const blockedStateClear = await preToolUse("Bash", "tool-ralplan-state-cli-clear", {
         command: "omx state clear --json",
       });
@@ -15005,6 +15108,47 @@ exit 0
         current_phase: "planning",
         session_id: nativeSessionId,
       });
+      const now = "2026-06-30T00:00:00.000Z";
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [nativeSessionId]: {
+            session_id: nativeSessionId,
+            leader_thread_id: "thread-leader",
+            updated_at: now,
+            threads: {
+              "thread-leader": { thread_id: "thread-leader", kind: "leader", first_seen_at: now, last_seen_at: now, turn_count: 1 },
+              "thread-architect": { thread_id: "thread-architect", kind: "subagent", first_seen_at: now, last_seen_at: now, completed_at: now, turn_count: 1 },
+              "thread-critic": { thread_id: "thread-critic", kind: "subagent", first_seen_at: now, last_seen_at: now, completed_at: now, turn_count: 1 },
+            },
+          },
+        },
+      });
+      const consensusGate = {
+        required: true,
+        complete: true,
+        sequence: ["architect-review", "critic-review"],
+        planning_artifacts_are_not_consensus: true,
+        required_review_roles: ["architect", "critic"],
+        ralplan_architect_review: {
+          agent_role: "architect",
+          verdict: "approve",
+          provenance_kind: "native_subagent",
+          session_id: nativeSessionId,
+          thread_id: "thread-architect",
+          artifact_path: ".omx/artifacts/architect.md",
+          tracker_path: ".omx/state/subagent-tracking.json",
+        },
+        ralplan_critic_review: {
+          agent_role: "critic",
+          verdict: "approve",
+          provenance_kind: "native_subagent",
+          session_id: nativeSessionId,
+          thread_id: "thread-critic",
+          artifact_path: ".omx/artifacts/critic.md",
+          tracker_path: ".omx/state/subagent-tracking.json",
+        },
+      };
       process.env.OMX_SESSION_ID = ownerSessionId;
 
       const writeResult = await executeStateOperation("state_write", {
@@ -15013,6 +15157,7 @@ exit 0
         current_phase: "complete",
         status: "complete",
         terminal_state: "complete",
+        ralplan_consensus_gate: consensusGate,
         workingDirectory: cwd,
       });
 
@@ -19637,6 +19782,21 @@ exit 0
         { cwd },
       );
       assert.equal((blockedMcpStateWrite.outputJson as { decision?: string } | null)?.decision, "block");
+
+      const blockedOmittedSessionTerminalWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "019e-ralplan-live-root-unresolved-current",
+          thread_id: "thread-ralplan-live-root-conflict",
+          tool_name: "Bash",
+          tool_input: {
+            command: "omx state write --mode ralplan --input '{\"active\":false,\"current_phase\":\"complete\"}' --json",
+          },
+        },
+        { cwd },
+      );
+      assert.equal((blockedOmittedSessionTerminalWrite.outputJson as { decision?: string } | null)?.decision, "block");
     } finally {
       await rm(cwd, { recursive: true, force: true });
       await rm(ownerCwd, { recursive: true, force: true });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3985,12 +3985,13 @@ function describeImplementationToolBlock(
 
 // `omx state` mutations normally route through the gate-enforcing `state_write`
 // backend, so the hook defers to that gate rather than blocking the transport.
-// The backend does NOT gate standalone deep-interview/ralplan *deactivation*,
-// and it normalizes non-terminal tracked-workflow writes to `active=true`, so
-// commands that would implicitly activate a tracked workflow while planning is
-// still protected are blocked here. Broader backend authority belongs to a
-// separate follow-up; this PR keeps the model/tool-originated guard at the
-// native-hook transport boundary.
+// The backend does NOT gate generic standalone deep-interview/ralplan
+// *deactivation*, and it normalizes non-terminal tracked-workflow writes to
+// `active=true`, so commands that would implicitly activate a tracked workflow
+// while planning is still protected are blocked here. Ralplan terminal closeout
+// is the narrow exception: the backend has a dedicated completeRalplanSession
+// path that coherently terminalizes root and session state when the payload is a
+// complete consensus-approved terminal state.
 function readStateWriteInputPayload(
   cwd: string,
   command: string,
@@ -5691,12 +5692,37 @@ function hasUnsafeUnquotedHeredocExpansion(command: string): boolean {
   return false;
 }
 
+function hasUnquotedShellSubstitution(command: string): boolean {
+  command = normalizeShellLineContinuations(command);
+  let quote: "'" | "\"" | null = null;
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index] ?? "";
+    if (char === "\\" && quote !== "'") {
+      index += 1;
+      continue;
+    }
+    if (char === "'" || char === "\"") {
+      if (quote === char) {
+        quote = null;
+      } else if (!quote) {
+        quote = char;
+      }
+      continue;
+    }
+    if (quote === "'") continue;
+    if (char === "$" && command[index + 1] === "(") return true;
+    if (char === "`") return true;
+    if ((char === "<" || char === ">") && command[index + 1] === "(") return true;
+  }
+  return false;
+}
+
 function normalizeStateWriteClassificationPayload(payload: Record<string, unknown>): Record<string, unknown> {
   const targetMode = safeString(payload.mode).trim();
+  const targetSessionId = safeString(payload.session_id).trim();
   const {
     mode: _mode,
     workingDirectory: _workingDirectory,
-    session_id: _sessionId,
     state,
     ...fields
   } = payload;
@@ -5704,6 +5730,7 @@ function normalizeStateWriteClassificationPayload(payload: Record<string, unknow
     ...fields,
     ...safeObject(state),
     ...(targetMode ? { mode: targetMode } : {}),
+    ...(targetSessionId ? { session_id: targetSessionId } : {}),
   };
   if (normalized.current_phase === undefined && normalized.currentPhase !== undefined) {
     normalized.current_phase = normalized.currentPhase;
@@ -5738,6 +5765,53 @@ function isPlanningPhaseDeactivationPayload(payload: Record<string, unknown>): b
 
   if (payload.active === false) return true;
   return inferTerminalLifecycleOutcome(payload, { includeQuestionEnforcement: false }) !== undefined;
+}
+
+function isCompleteRalplanTerminalWritePayload(
+  payload: Record<string, unknown>,
+  activeState: Record<string, unknown>,
+  sessionId: string,
+): boolean {
+  if (!sessionId) return false;
+  const mode = safeString(payload.mode).trim().toLowerCase();
+  if (mode !== "ralplan") return false;
+  const phase = safeString(payload.current_phase ?? payload.currentPhase).trim().toLowerCase();
+  if (payload.active !== false || phase !== "complete") return false;
+
+  const payloadSessionId = safeString(payload.session_id).trim();
+  const activeSessionId = safeString(
+    activeState.session_id
+      ?? activeState.owner_omx_session_id
+      ?? activeState.codex_session_id
+      ?? activeState.owner_codex_session_id,
+  ).trim();
+  if (payloadSessionId && sessionId && payloadSessionId !== sessionId) return false;
+  if (payloadSessionId && activeSessionId && payloadSessionId !== activeSessionId) return false;
+  return true;
+}
+
+function isAllowedRalplanTerminalStateWriteCommand(
+  cwd: string,
+  command: string,
+  activeState: Record<string, unknown>,
+  sessionId: string,
+): boolean {
+  const canonicalCommand = canonicalizeOmxStateTransportCommand(command);
+  if (hasUnsafeUnquotedHeredocExpansion(canonicalCommand)) return false;
+  if (hasUnquotedShellSubstitution(canonicalCommand)) return false;
+  if (splitStateScanSegments(canonicalCommand).length !== 1) return false;
+  if (sourcesFileWrittenEarlierInSameCommand(cwd, canonicalCommand)) return false;
+  if (findUnquotedOmxStateCommandIndexes(canonicalCommand, "clear").length > 0) return false;
+  if (hasDynamicNestedShellExecution(canonicalCommand)) return false;
+  if (commandHasDeepInterviewWriteIntent(canonicalCommand)) return false;
+
+  const operations = collectOmxStateCommandOperations(canonicalCommand, "write");
+  if (operations.length !== 1) return false;
+  const operation = operations[0];
+  if (!operation || operation.nested || hasPriorExecutableCommand(operation.prefix)) return false;
+
+  const payload = readStateWriteInputPayload(cwd, canonicalCommand, command);
+  return payload ? isCompleteRalplanTerminalWritePayload(payload, activeState, sessionId) : false;
 }
 
 function commandEndsPlanningPhase(cwd: string, command: string): boolean {
@@ -5855,7 +5929,12 @@ async function readActiveRalplanStateForPreToolUse(
   return hasActiveAutopilotSkill ? autopilotState : null;
 }
 
-function isAllowedRalplanBashWrite(cwd: string, command: string): boolean {
+function isAllowedRalplanBashWrite(
+  cwd: string,
+  command: string,
+  activeState: Record<string, unknown>,
+  sessionId: string,
+): boolean {
   const beadsCommand = classifyRalplanBeadsMetadataCommand(cwd, command);
   const targets = extractDeepInterviewCommandWriteTargets(command);
   const hasAllowedTargets = targets.length > 0
@@ -5864,7 +5943,9 @@ function isAllowedRalplanBashWrite(cwd: string, command: string): boolean {
   if (beadsCommand.present) {
     return beadsCommand.allowed && (targets.length === 0 || hasAllowedTargets);
   }
-  if (commandEndsPlanningPhase(cwd, command)) return false;
+  if (commandEndsPlanningPhase(cwd, command)) {
+    return isAllowedRalplanTerminalStateWriteCommand(cwd, command, activeState, sessionId);
+  }
   if (commandHasUntargetedPlanningForbiddenIntent(command)) return false;
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
   if (targets.some((target) => !isAllowedRalplanArtifactPath(cwd, target))) return false;
@@ -5915,7 +5996,7 @@ async function buildRalplanPreToolUseBoundaryOutput(
   let blockedDetail = "implementation/write tools are blocked until an explicit execution handoff workflow is activated";
 
   if (toolName === "Bash") {
-    blocked = !isAllowedRalplanBashWrite(cwd, command);
+    blocked = !isAllowedRalplanBashWrite(cwd, command, activeState, sessionId);
     if (blocked) {
       blockedDetail = buildRalplanBashBlockedDetail(cwd, command);
     }
@@ -6100,7 +6181,9 @@ async function buildPlanningRootPointerConflictPreToolUseOutput(
   const toolName = safeString(payload.tool_name).trim();
   let blocked = false;
   if (toolName === "Bash") {
-    blocked = !isAllowedRalplanBashWrite(cwd, readPreToolUseCommand(payload));
+    const command = readPreToolUseCommand(payload);
+    blocked = commandEndsPlanningPhase(cwd, command)
+      || !isAllowedRalplanBashWrite(cwd, command, ralplanState, rootSessionId);
   } else if (
     toolName === "mcp__omx_state__state_clear"
     || (

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -141,6 +141,15 @@ function ralplanConsensusGate(
   };
 }
 
+async function writeNativeRalplanConsensusGate(
+  cwd: string,
+  sessionId: string,
+  threadOverrides: { architect?: string; critic?: string } = {},
+): Promise<Record<string, unknown>> {
+  await writeNativeSubagentTracking(cwd, sessionId);
+  return ralplanConsensusGate(sessionId, 'native_subagent', threadOverrides);
+}
+
 async function createFakeTmuxBin(wd: string): Promise<string> {
   const fakeBin = join(wd, 'bin');
   await mkdir(fakeBin, { recursive: true });
@@ -785,6 +794,7 @@ describe('state operations directory initialization', () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-complete-'));
     try {
       const sessionId = 'sess-ralplan-complete';
+      const consensusGate = await writeNativeRalplanConsensusGate(wd, sessionId);
       const stateDir = join(wd, '.omx', 'state');
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
@@ -835,11 +845,7 @@ describe('state operations directory initialization', () => {
           verdict: 'APPROVE',
           artifact_path: '.omx/plans/critic.md',
         },
-        ralplan_consensus_gate: {
-          complete: true,
-          architect_verdict: 'APPROVE',
-          critic_verdict: 'APPROVE',
-        },
+        ralplan_consensus_gate: consensusGate,
       });
 
       assert.equal(response.isError, undefined);
@@ -873,10 +879,129 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('rejects forged ralplan complete gates before mutating active session state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-forged-complete-'));
+    try {
+      const sessionId = 'sess-ralplan-forged-complete';
+      await writeNativeSubagentTracking(wd, sessionId);
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        cwd: wd,
+      }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        ralplan_consensus_gate: {
+          complete: true,
+        },
+      });
+
+      assert.equal(response.isError, true);
+      assert.match(String((response.payload as { error?: unknown }).error ?? ''), /tracker-backed native architect and critic consensus evidence/);
+      const sessionRalplan = JSON.parse(await readFile(join(sessionDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(sessionRalplan.active, true);
+      assert.equal(sessionRalplan.current_phase, 'planning');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('normalizes currentPhase before gating ralplan terminal writes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-current-phase-alias-'));
+    try {
+      const sessionId = 'sess-ralplan-current-phase-alias';
+      await writeNativeSubagentTracking(wd, sessionId);
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        cwd: wd,
+      }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'ralplan',
+        active: false,
+        currentPhase: 'complete',
+      });
+
+      assert.equal(response.isError, true);
+      assert.match(String((response.payload as { error?: unknown }).error ?? ''), /tracker-backed native architect and critic consensus evidence/);
+      const sessionRalplan = JSON.parse(await readFile(join(sessionDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(sessionRalplan.active, true);
+      assert.equal(sessionRalplan.current_phase, 'planning');
+      assert.equal(sessionRalplan.currentPhase, undefined);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('reuses existing tracker-backed ralplan consensus when terminal writes omit gate payload', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-existing-consensus-'));
+    try {
+      const sessionId = 'sess-ralplan-existing-consensus';
+      const consensusGate = await writeNativeRalplanConsensusGate(wd, sessionId);
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        cwd: wd,
+      }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+        ralplan_consensus_gate: consensusGate,
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        terminal_reason: 'existing tracker-backed consensus complete',
+      });
+
+      assert.equal(response.isError, undefined);
+      const sessionRalplan = JSON.parse(await readFile(join(sessionDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(sessionRalplan.active, false);
+      assert.equal(sessionRalplan.current_phase, 'complete');
+      const finalGate = sessionRalplan.ralplan_consensus_gate as Record<string, unknown>;
+      assert.equal(finalGate.complete, true);
+      assert.deepEqual(finalGate.required_review_roles, ['architect', 'critic']);
+      assert.equal((finalGate.ralplan_architect_review as Record<string, unknown>).provenance_kind, 'native_subagent');
+      assert.equal((finalGate.ralplan_critic_review as Record<string, unknown>).provenance_kind, 'native_subagent');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('finalizes completed ralplan updateModeState writes across root and current session state', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-complete-update-mode-'));
     try {
       const sessionId = 'sess-ralplan-complete-update-mode';
+      const consensusGate = await writeNativeRalplanConsensusGate(wd, sessionId);
       const stateDir = join(wd, '.omx', 'state');
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
@@ -916,9 +1041,7 @@ describe('state operations directory initialization', () => {
         active: false,
         current_phase: 'complete',
         terminal_reason: 'runtime consensus complete',
-        ralplan_consensus_gate: {
-          complete: true,
-        },
+        ralplan_consensus_gate: consensusGate,
       }, wd);
 
       const rootRalplan = JSON.parse(await readFile(join(stateDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
@@ -956,10 +1079,49 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('rejects forged ralplan complete gates from updateModeState before mutating active state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-update-mode-forged-complete-'));
+    try {
+      const sessionId = 'sess-ralplan-update-mode-forged-complete';
+      await writeNativeSubagentTracking(wd, sessionId);
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        cwd: wd,
+      }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+
+      await assert.rejects(
+        updateModeState('ralplan', {
+          active: false,
+          current_phase: 'complete',
+          ralplan_consensus_gate: {
+            complete: true,
+          },
+        }, wd),
+        /architect and critic consensus evidence/,
+      );
+
+      const sessionRalplan = JSON.parse(await readFile(join(sessionDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(sessionRalplan.active, true);
+      assert.equal(sessionRalplan.current_phase, 'planning');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('does not promote stale session metadata when ralplan terminalizes from root scope', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-stale-session-'));
     try {
       const staleSessionId = 'sess-ralplan-stale';
+      const consensusGate = await writeNativeRalplanConsensusGate(wd, staleSessionId);
       const stateDir = join(wd, '.omx', 'state');
       const sessionDir = join(stateDir, 'sessions', staleSessionId);
       await mkdir(stateDir, { recursive: true });
@@ -1001,8 +1163,9 @@ describe('state operations directory initialization', () => {
         current_phase: 'complete',
         status: 'complete',
         terminal_reason: 'consensus approved bounded no-op',
-        ralplan_consensus_gate: {
-          complete: true,
+        state: {
+          session_id: staleSessionId,
+          ralplan_consensus_gate: consensusGate,
         },
       });
 
@@ -1031,6 +1194,8 @@ describe('state operations directory initialization', () => {
   it('does not hide unrelated root detail state when ralplan terminalizes without canonical state', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-root-detail-only-'));
     try {
+      const sessionId = 'sess-ralplan-root-detail-only';
+      const consensusGate = await writeNativeRalplanConsensusGate(wd, sessionId);
       const stateDir = join(wd, '.omx', 'state');
       await mkdir(stateDir, { recursive: true });
       await writeFile(join(stateDir, 'team-state.json'), JSON.stringify({
@@ -1044,8 +1209,9 @@ describe('state operations directory initialization', () => {
         mode: 'ralplan',
         active: false,
         current_phase: 'complete',
-        ralplan_consensus_gate: {
-          complete: true,
+        state: {
+          session_id: sessionId,
+          ralplan_consensus_gate: consensusGate,
         },
       });
 
@@ -1065,6 +1231,7 @@ describe('state operations directory initialization', () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-preserve-root-'));
     try {
       const sessionId = 'sess-ralplan-preserve-root';
+      const consensusGate = await writeNativeRalplanConsensusGate(wd, sessionId);
       const stateDir = join(wd, '.omx', 'state');
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
@@ -1120,9 +1287,7 @@ describe('state operations directory initialization', () => {
         current_phase: 'complete',
         status: 'complete',
         terminal_reason: 'consensus approved bounded no-op',
-        ralplan_consensus_gate: {
-          complete: true,
-        },
+        ralplan_consensus_gate: consensusGate,
       });
 
       assert.equal(response.isError, undefined);
@@ -1165,6 +1330,7 @@ describe('state operations directory initialization', () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-legacy-root-detail-'));
     try {
       const sessionId = 'sess-ralplan-legacy-root-detail';
+      const consensusGate = await writeNativeRalplanConsensusGate(wd, sessionId);
       const stateDir = join(wd, '.omx', 'state');
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
@@ -1199,9 +1365,7 @@ describe('state operations directory initialization', () => {
         mode: 'ralplan',
         active: false,
         current_phase: 'complete',
-        ralplan_consensus_gate: {
-          complete: true,
-        },
+        ralplan_consensus_gate: consensusGate,
       });
 
       assert.equal(response.isError, undefined);
@@ -1226,6 +1390,7 @@ describe('state operations directory initialization', () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-empty-root-mirror-'));
     try {
       const sessionId = 'sess-ralplan-empty-root-mirror';
+      const consensusGate = await writeNativeRalplanConsensusGate(wd, sessionId);
       const stateDir = join(wd, '.omx', 'state');
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
@@ -1273,9 +1438,7 @@ describe('state operations directory initialization', () => {
         mode: 'ralplan',
         active: false,
         current_phase: 'complete',
-        ralplan_consensus_gate: {
-          complete: true,
-        },
+        ralplan_consensus_gate: consensusGate,
       });
 
       assert.equal(response.isError, undefined);
@@ -1300,6 +1463,7 @@ describe('state operations directory initialization', () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-preserve-root-tombstone-'));
     try {
       const sessionId = 'sess-ralplan-root-tombstone';
+      const consensusGate = await writeNativeRalplanConsensusGate(wd, sessionId);
       const stateDir = join(wd, '.omx', 'state');
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
@@ -1341,9 +1505,7 @@ describe('state operations directory initialization', () => {
         mode: 'ralplan',
         active: false,
         current_phase: 'complete',
-        ralplan_consensus_gate: {
-          complete: true,
-        },
+        ralplan_consensus_gate: consensusGate,
       });
 
       assert.equal(response.isError, undefined);
@@ -1367,6 +1529,7 @@ describe('state operations directory initialization', () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-terminal-reason-only-'));
     try {
       const sessionId = 'sess-ralplan-terminal-reason-only';
+      const consensusGate = await writeNativeRalplanConsensusGate(wd, sessionId);
       const stateDir = join(wd, '.omx', 'state');
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
@@ -1405,9 +1568,7 @@ describe('state operations directory initialization', () => {
         mode: 'ralplan',
         active: false,
         current_phase: 'complete',
-        ralplan_consensus_gate: {
-          complete: true,
-        },
+        ralplan_consensus_gate: consensusGate,
       });
 
       assert.equal(response.isError, undefined);
@@ -1432,6 +1593,7 @@ describe('state operations directory initialization', () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-lifecycle-nonterminal-'));
     try {
       const sessionId = 'sess-ralplan-lifecycle-nonterminal';
+      const consensusGate = await writeNativeRalplanConsensusGate(wd, sessionId);
       const stateDir = join(wd, '.omx', 'state');
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
@@ -1470,9 +1632,7 @@ describe('state operations directory initialization', () => {
         mode: 'ralplan',
         active: false,
         current_phase: 'complete',
-        ralplan_consensus_gate: {
-          complete: true,
-        },
+        ralplan_consensus_gate: consensusGate,
       });
 
       assert.equal(response.isError, undefined);
@@ -1497,6 +1657,7 @@ describe('state operations directory initialization', () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-preserve-'));
     try {
       const sessionId = 'sess-ralplan-preserve';
+      const consensusGate = await writeNativeRalplanConsensusGate(wd, sessionId);
       const stateDir = join(wd, '.omx', 'state');
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
@@ -1548,9 +1709,7 @@ describe('state operations directory initialization', () => {
         current_phase: 'complete',
         status: 'complete',
         terminal_reason: 'consensus approved bounded no-op',
-        ralplan_consensus_gate: {
-          complete: true,
-        },
+        ralplan_consensus_gate: consensusGate,
       });
 
       assert.equal(response.isError, undefined);
@@ -1587,6 +1746,7 @@ describe('state operations directory initialization', () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-partial-session-skill-'));
     try {
       const sessionId = 'sess-ralplan-partial-session-skill';
+      const consensusGate = await writeNativeRalplanConsensusGate(wd, sessionId);
       const stateDir = join(wd, '.omx', 'state');
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
@@ -1643,9 +1803,7 @@ describe('state operations directory initialization', () => {
         mode: 'ralplan',
         active: false,
         current_phase: 'complete',
-        ralplan_consensus_gate: {
-          complete: true,
-        },
+        ralplan_consensus_gate: consensusGate,
       });
 
       assert.equal(response.isError, undefined);
@@ -1677,6 +1835,7 @@ describe('state operations directory initialization', () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-terminal-session-skill-'));
     try {
       const sessionId = 'sess-ralplan-terminal-session-skill';
+      const consensusGate = await writeNativeRalplanConsensusGate(wd, sessionId);
       const stateDir = join(wd, '.omx', 'state');
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
@@ -1729,9 +1888,7 @@ describe('state operations directory initialization', () => {
         mode: 'ralplan',
         active: false,
         current_phase: 'complete',
-        ralplan_consensus_gate: {
-          complete: true,
-        },
+        ralplan_consensus_gate: consensusGate,
       });
 
       assert.equal(response.isError, undefined);
@@ -1764,6 +1921,7 @@ describe('state operations directory initialization', () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-session-detail-only-'));
     try {
       const sessionId = 'sess-ralplan-session-detail-only';
+      const consensusGate = await writeNativeRalplanConsensusGate(wd, sessionId);
       const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
       await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
@@ -1785,9 +1943,7 @@ describe('state operations directory initialization', () => {
         mode: 'ralplan',
         active: false,
         current_phase: 'complete',
-        ralplan_consensus_gate: {
-          complete: true,
-        },
+        ralplan_consensus_gate: consensusGate,
       });
 
       assert.equal(response.isError, undefined);
@@ -1807,6 +1963,7 @@ describe('state operations directory initialization', () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-root-only-skill-'));
     try {
       const sessionId = 'sess-ralplan-root-only-skill';
+      const consensusGate = await writeNativeRalplanConsensusGate(wd, sessionId);
       const stateDir = join(wd, '.omx', 'state');
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
@@ -1845,9 +2002,7 @@ describe('state operations directory initialization', () => {
         mode: 'ralplan',
         active: false,
         current_phase: 'complete',
-        ralplan_consensus_gate: {
-          complete: true,
-        },
+        ralplan_consensus_gate: consensusGate,
       });
 
       assert.equal(response.isError, undefined);

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -59,6 +59,9 @@ import {
   buildAutopilotRalplanUltragoalGateError,
   canAdvanceAutopilotRalplanToUltragoal,
 } from '../autopilot/ralplan-gate.js';
+import {
+  buildRalplanConsensusGateFromSources,
+} from '../ralplan/consensus-gate.js';
 
 
 const AUTOPILOT_CHILD_PHASE_ORDER: AutopilotChildPhase[] = [
@@ -244,6 +247,21 @@ function optionalSessionId(value: unknown): string | undefined {
   }
 }
 
+function normalizeCurrentPhaseAliasForWrite(
+  state: Record<string, unknown>,
+  fields: Record<string, unknown>,
+  customState: unknown,
+): void {
+  const hasCanonicalPhase = hasExplicitStateField(fields, customState, 'current_phase');
+  const hasAliasPhase = hasExplicitStateField(fields, customState, 'currentPhase');
+  if (!hasCanonicalPhase && hasAliasPhase) {
+    state.current_phase = state.currentPhase;
+  }
+  if (hasCanonicalPhase || hasAliasPhase) {
+    delete state.currentPhase;
+  }
+}
+
 function normalizeCleanAutopilotCompletionEvidence(state: Record<string, unknown>): void {
   if (!isAutopilotSuccessfulTerminalState(state) || !hasCleanAutopilotReviewAndQaEvidence(state)) return;
 
@@ -269,6 +287,42 @@ function isCompleteRalplanTerminalState(state: Record<string, unknown>): boolean
   return state.active === false
     && currentPhase === 'complete'
     && gate.complete === true;
+}
+
+function isRalplanCompleteCloseoutAttempt(state: Record<string, unknown>): boolean {
+  const currentPhase = stringValue(state.current_phase).trim().toLowerCase();
+  return state.active === false && currentPhase === 'complete';
+}
+
+export function validateRalplanTerminalConsensus(
+  cwd: string,
+  state: Record<string, unknown>,
+  sessionId: string | undefined,
+  options: { requireNativeSubagents?: boolean } = {},
+): string | null {
+  if (!isRalplanCompleteCloseoutAttempt(state)) return null;
+  const stateSessionId = sessionId ?? optionalSessionId(state.session_id);
+  const gate = buildRalplanConsensusGateFromSources([
+    { source: 'state-write-ralplan-terminal', value: state, sessionId: stateSessionId },
+  ], {
+    cwd,
+    sessionId: stateSessionId,
+    requireNativeSubagents: options.requireNativeSubagents === true,
+  });
+  if (gate.complete === true) {
+    if (options.requireNativeSubagents === true) {
+      state.ralplan_consensus_gate = {
+        ...objectRecord(state.ralplan_consensus_gate),
+        ...gate,
+      };
+    }
+    return null;
+  }
+  const details = gate.blockedDetails?.length ? ` Details: ${gate.blockedDetails.join('; ')}.` : '';
+  const evidenceDescription = options.requireNativeSubagents === true
+    ? 'tracker-backed native architect and critic consensus evidence'
+    : 'architect and critic consensus evidence';
+  return `ralplan complete state requires ${evidenceDescription} (${gate.blockedReason ?? 'missing_consensus'}).${details}`;
 }
 
 function buildRalplanTerminalState(
@@ -421,8 +475,13 @@ export async function completeRalplanSession(options: {
   baseStateDir: string;
   state: Record<string, unknown>;
   explicitSessionId?: string;
+  requireNativeSubagents?: boolean;
 }): Promise<boolean> {
   if (!isCompleteRalplanTerminalState(options.state)) return false;
+  const validationError = validateRalplanTerminalConsensus(options.cwd, options.state, options.explicitSessionId, {
+    requireNativeSubagents: options.requireNativeSubagents === true,
+  });
+  if (validationError) throw new Error(validationError);
 
   const sessionId = optionalSessionId(options.explicitSessionId);
   const completedSessionId = sessionId ?? optionalSessionId(options.state.session_id);
@@ -668,6 +727,7 @@ export async function executeStateOperation(
             ...fields,
             ...((customState as Record<string, unknown>) || {}),
           } as Record<string, unknown>;
+          normalizeCurrentPhaseAliasForWrite(mergedRaw, fields, customState);
           delete mergedRaw.trustedPipelineProgress;
           if (!hasExplicitStateField(fields, customState, 'run_outcome')) {
             delete mergedRaw.run_outcome;
@@ -726,6 +786,13 @@ export async function executeStateOperation(
 
           if (mode === 'autopilot') {
             normalizeCleanAutopilotCompletionEvidence(mergedRaw);
+          }
+
+          if (mode === 'ralplan') {
+            validationError = validateRalplanTerminalConsensus(cwd, mergedRaw, effectiveSessionId, {
+              requireNativeSubagents: true,
+            });
+            if (validationError) return;
           }
 
           const currentAutopilotChildPhase = mode === 'autopilot'
@@ -874,6 +941,7 @@ export async function executeStateOperation(
             baseStateDir,
             state: data,
             explicitSessionId: effectiveSessionId,
+            requireNativeSubagents: true,
           });
           if (!ralplanCompletionHandled) {
             await syncCanonicalSkillStateForMode({


### PR DESCRIPTION
## Summary

Tightens ralplan terminal state closeout so native PreToolUse allows only a standalone terminal `omx state write` transport for the current session, while backend state operations remain the consensus authority before root/session terminalization.

This follows up the stale ralplan hook-state work by closing the mismatch where planning content could be complete but the native hook transport either blocked legitimate terminal metadata or allowed too much shell shape around that metadata.

## Changes

- Validate ralplan terminal consensus before complete-state mutation in `state_write`, `completeRalplanSession`, and standalone `updateModeState` paths.
- Allow native PreToolUse Bash transport only for standalone ralplan terminal closeout payloads (`active:false`, `current_phase:"complete"`) for the current session.
- Reject compound suffixes plus `$()`, backtick, and process-substitution shell side effects around terminal closeout commands.
- Refresh native hook docs with the ralplan closeout transport contract.
- Add regression coverage for forged consensus, tracker-backed consensus reuse, root/session terminalization, MCP parity, and transport bypass shapes.

## Validation

- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `npx tsc --noEmit`
- [x] `npm run coverage:team-critical`
- [x] `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js dist/state/__tests__/operations.test.js dist/cli/__tests__/mcp-parity.test.js dist/ralplan/__tests__/runtime.test.js dist/hooks/__tests__/explicit-terminal-stop-docs-contract.test.js dist/hooks/__tests__/explicit-terminal-stop-model-docs-contract.test.js`

Local `npm test` caveat: I reran the full suite after rebasing onto current `dev`. It completed the full 366-file runner and had one local failure in `dist/cli/__tests__/resume.test.js`: the fake `codex resume` script prints `history-lines:       1` and `index-lines:       1` from macOS `wc -l`, while the test regex expects `history-lines:1` with no padding. The behavior under test succeeded (`project-rollout-present=yes`, exactly one history line, exactly one index line); the failure is the test assertion's host-format assumption around `wc -l` output. This PR does not change resume code or that test path, so I am treating it as an out-of-scope local test brittleness rather than a blocker for the ralplan/native-hook diff.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when behavior changed
- [x] Backward-compatibility impact considered

## Related

Follow-up to #3015 and the stale ralplan terminal-state closeout path.


