### PR TITLE
Fix madmax resume plugin cache preflight

### DIFF
--- a/src/cli/__tests__/plugin-marketplace-idempotent.test.ts
+++ b/src/cli/__tests__/plugin-marketplace-idempotent.test.ts
@@ -58,6 +58,30 @@ describe("plugin marketplace config upserts", () => {
 		assert.doesNotThrow(() => TOML.parse(second));
 	});
 
+	it("normalizes legacy local plugin scalar before emitting plugin table", () => {
+		const repaired = upsertLocalOmxPluginEnablement(
+			[
+				'model = "gpt-5.5"',
+				'',
+				'[plugins]',
+				`"${OMX_LOCAL_PLUGIN_CONFIG_KEY}" = true`,
+				'other-plugin = true',
+				'',
+			].join("\n"),
+		);
+
+		assert.doesNotThrow(() => TOML.parse(repaired));
+		assert.doesNotMatch(repaired, new RegExp(`^"${OMX_LOCAL_PLUGIN_CONFIG_KEY}"\\s*=`, "m"));
+		assert.match(repaired, /^other-plugin = true$/m);
+		assert.equal(
+			countMatches(
+				repaired,
+				/^\[plugins\."oh-my-codex@oh-my-codex-local"\]$/gm,
+			),
+			1,
+		);
+	});
+
 	it("dedupes existing local marketplace and plugin MCP blocks without removing unrelated config", () => {
 		const packageRoot = "/tmp/oh-my-codex-new";
 		const duplicated = [

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import TOML from '@iarna/toml';
 import { chmod, mkdir, mkdtemp, readFile, readdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
@@ -677,6 +678,10 @@ if [ -d "$selected_codex_home/plugins/cache/oh-my-codex-local/oh-my-codex/${stal
       assert.match(result.stdout, /fake-codex:resume session-after-update\b/);
       assert.match(result.stdout, /current-cache=yes/);
       assert.match(result.stdout, /stale-cache=yes/);
+      const repairedConfig = await readFile(join(codexHome, 'config.toml'), 'utf-8');
+      assert.doesNotThrow(() => TOML.parse(repairedConfig));
+      assert.doesNotMatch(repairedConfig, /^"oh-my-codex@oh-my-codex-local"\s*=/m);
+      assert.match(repairedConfig, /^\[plugins\."oh-my-codex@oh-my-codex-local"\]$/m);
       assert.deepEqual(
         new Set(await readdir(join(codexHome, 'plugins', 'cache', 'oh-my-codex-local', 'oh-my-codex'))),
         new Set([packageJson.version, staleVersion]),

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -632,4 +632,111 @@ case "$(cat "$CODEX_HOME/config.toml")" in *'source = "${repoRoot}"'*) echo mark
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('preflights default user plugin cache before madmax resume without restoring stale cache metadata', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-madmax-resume-default-cache-'));
+    try {
+      const home = join(wd, 'home');
+      const codexHome = join(home, '.codex');
+      const staleVersion = '0.0.0-stale';
+      const staleCacheDir = join(codexHome, 'plugins', 'cache', 'oh-my-codex-local', 'oh-my-codex', staleVersion);
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const testDir = dirname(fileURLToPath(import.meta.url));
+      const repoRoot = join(testDir, '..', '..', '..');
+      const packageJson = JSON.parse(await readFile(join(repoRoot, 'package.json'), 'utf-8')) as { version: string };
+      const expectedCacheDir = join(codexHome, 'plugins', 'cache', 'oh-my-codex-local', 'oh-my-codex', packageJson.version);
+
+      await mkdir(join(staleCacheDir, '.codex-plugin'), { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(join(staleCacheDir, '.codex-plugin', 'plugin.json'), JSON.stringify({ name: 'oh-my-codex', version: staleVersion }));
+      await writeFile(join(codexHome, 'config.toml'), '[plugins]\n"oh-my-codex@oh-my-codex-local" = true\n');
+      await writeFile(fakeCodexPath, `#!/bin/sh
+set -eu
+selected_codex_home="\${CODEX_HOME:-$HOME/.codex}"
+printf 'fake-codex:%s\n' "$*"
+printf 'codex-home:%s\n' "$selected_codex_home"
+if [ -f "$selected_codex_home/plugins/cache/oh-my-codex-local/oh-my-codex/${packageJson.version}/.codex-plugin/plugin.json" ]; then echo current-cache=yes; else echo current-cache=no; fi
+if [ -d "$selected_codex_home/plugins/cache/oh-my-codex-local/oh-my-codex/${staleVersion}" ]; then echo stale-cache=yes; else echo stale-cache=no; fi
+`);
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+
+      const result = runOmx(wd, ['--madmax', 'resume', 'session-after-update'], {
+        HOME: home,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+        OMX_LAUNCH_POLICY: 'direct',
+      });
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, /fake-codex:resume session-after-update\b/);
+      assert.match(result.stdout, /current-cache=yes/);
+      assert.match(result.stdout, /stale-cache=no/);
+      assert.deepEqual(await readdir(join(codexHome, 'plugins', 'cache', 'oh-my-codex-local', 'oh-my-codex')), [packageJson.version]);
+      assert.equal(
+        JSON.parse(await readFile(join(expectedCacheDir, '.codex-plugin', 'plugin.json'), 'utf-8')).version,
+        packageJson.version,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps stale plugin cache directories referenced by live resume processes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-madmax-resume-live-cache-'));
+    try {
+      const home = join(wd, 'home');
+      const codexHome = join(home, '.codex');
+      const staleVersion = '0.0.0-live-stale';
+      const staleCacheDir = join(codexHome, 'plugins', 'cache', 'oh-my-codex-local', 'oh-my-codex', staleVersion);
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const testDir = dirname(fileURLToPath(import.meta.url));
+      const repoRoot = join(testDir, '..', '..', '..');
+      const packageJson = JSON.parse(await readFile(join(repoRoot, 'package.json'), 'utf-8')) as { version: string };
+
+      await mkdir(join(staleCacheDir, '.codex-plugin'), { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(join(staleCacheDir, '.codex-plugin', 'plugin.json'), JSON.stringify({ name: 'oh-my-codex', version: staleVersion }));
+      await writeFile(join(codexHome, 'config.toml'), '[plugins]\n"oh-my-codex@oh-my-codex-local" = true\n');
+      await writeFile(fakePsPath, `#!/bin/sh
+printf '123 1 node ${staleCacheDir}/hooks/codex-native-hook.mjs\\n'
+`);
+      await chmod(fakePsPath, 0o755);
+      await writeFile(fakeCodexPath, `#!/bin/sh
+set -eu
+selected_codex_home="\${CODEX_HOME:-$HOME/.codex}"
+printf 'fake-codex:%s\n' "$*"
+if [ -f "$selected_codex_home/plugins/cache/oh-my-codex-local/oh-my-codex/${packageJson.version}/.codex-plugin/plugin.json" ]; then echo current-cache=yes; else echo current-cache=no; fi
+if [ -d "$selected_codex_home/plugins/cache/oh-my-codex-local/oh-my-codex/${staleVersion}" ]; then echo live-stale-cache=yes; else echo live-stale-cache=no; fi
+`);
+      await chmod(fakeCodexPath, 0o755);
+
+      const result = runOmx(wd, ['--madmax', 'resume', 'live-session-after-update'], {
+        HOME: home,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+        OMX_LAUNCH_POLICY: 'direct',
+      });
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, /fake-codex:resume live-session-after-update\b/);
+      assert.match(result.stdout, /current-cache=yes/);
+      assert.match(result.stdout, /live-stale-cache=yes/);
+      assert.deepEqual(
+        new Set(await readdir(join(codexHome, 'plugins', 'cache', 'oh-my-codex-local', 'oh-my-codex'))),
+        new Set([packageJson.version, staleVersion]),
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -633,7 +633,7 @@ case "$(cat "$CODEX_HOME/config.toml")" in *'source = "${repoRoot}"'*) echo mark
     }
   });
 
-  it('preflights default user plugin cache before madmax resume without restoring stale cache metadata', async () => {
+  it('preflights default user plugin cache before madmax resume while preserving stale cache metadata', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-madmax-resume-default-cache-'));
     try {
       const home = join(wd, 'home');
@@ -676,8 +676,11 @@ if [ -d "$selected_codex_home/plugins/cache/oh-my-codex-local/oh-my-codex/${stal
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       assert.match(result.stdout, /fake-codex:resume session-after-update\b/);
       assert.match(result.stdout, /current-cache=yes/);
-      assert.match(result.stdout, /stale-cache=no/);
-      assert.deepEqual(await readdir(join(codexHome, 'plugins', 'cache', 'oh-my-codex-local', 'oh-my-codex')), [packageJson.version]);
+      assert.match(result.stdout, /stale-cache=yes/);
+      assert.deepEqual(
+        new Set(await readdir(join(codexHome, 'plugins', 'cache', 'oh-my-codex-local', 'oh-my-codex'))),
+        new Set([packageJson.version, staleVersion]),
+      );
       assert.equal(
         JSON.parse(await readFile(join(expectedCacheDir, '.codex-plugin', 'plugin.json'), 'utf-8')).version,
         packageJson.version,
@@ -687,7 +690,7 @@ if [ -d "$selected_codex_home/plugins/cache/oh-my-codex-local/oh-my-codex/${stal
     }
   });
 
-  it('keeps stale plugin cache directories referenced by live resume processes', async () => {
+  it('keeps stale plugin cache directories when live resume process does not mention cache path', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-madmax-resume-live-cache-'));
     try {
       const home = join(wd, 'home');
@@ -706,7 +709,7 @@ if [ -d "$selected_codex_home/plugins/cache/oh-my-codex-local/oh-my-codex/${stal
       await writeFile(join(staleCacheDir, '.codex-plugin', 'plugin.json'), JSON.stringify({ name: 'oh-my-codex', version: staleVersion }));
       await writeFile(join(codexHome, 'config.toml'), '[plugins]\n"oh-my-codex@oh-my-codex-local" = true\n');
       await writeFile(fakePsPath, `#!/bin/sh
-printf '123 1 node ${staleCacheDir}/hooks/codex-native-hook.mjs\\n'
+printf '123 1 codex resume live-session-after-update\\n'
 `);
       await chmod(fakePsPath, 0o755);
       await writeFile(fakeCodexPath, `#!/bin/sh

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -36,6 +36,7 @@ import {
   cleanupCommand,
   cleanupOmxMcpProcesses,
   findLaunchSafeCleanupCandidates,
+  listOmxProcesses,
   type CleanupDependencies,
   type CleanupResult,
 } from "./cleanup.js";
@@ -1161,33 +1162,52 @@ export interface ResumePluginPreflightResult {
   configUpdated: boolean;
 }
 
+function commandMentionsPath(command: string, path: string): boolean {
+  const normalizedCommand = command.replace(/\\+/g, "/");
+  const normalizedPath = path.replace(/\\+/g, "/");
+  return normalizedCommand.includes(normalizedPath);
+}
+
+function listLiveOmxProcessesForResumePreflight(): ReturnType<typeof listOmxProcesses> {
+  try {
+    return listOmxProcesses();
+  } catch {
+    return [];
+  }
+}
+
+function isPluginCacheDirReferencedByLiveProcess(cacheDir: string, processes: ReturnType<typeof listOmxProcesses>): boolean {
+  return processes.some((processEntry) => commandMentionsPath(processEntry.command, cacheDir));
+}
+
 export async function preflightResumeOmxPluginState(
   codexHomeDir: string | undefined,
   pkgRoot = getPackageRoot(),
 ): Promise<ResumePluginPreflightResult> {
-  if (!codexHomeDir) {
-    return { status: "unavailable", prunedStaleDirs: [], configUpdated: false };
-  }
-
+  const selectedCodexHomeDir = codexHomeDir && codexHomeDir.trim() !== ""
+    ? codexHomeDir
+    : join(homedir(), ".codex");
   const packagedMarketplace = await resolvePackagedOmxMarketplace(pkgRoot);
   if (!packagedMarketplace) {
     return { status: "unavailable", prunedStaleDirs: [], configUpdated: false };
   }
 
-  const materialized = await materializePackagedOmxPluginCache(codexHomeDir, packagedMarketplace);
+  const materialized = await materializePackagedOmxPluginCache(selectedCodexHomeDir, packagedMarketplace);
   const version = materialized.version ?? (await packagedOmxPluginVersion(packagedMarketplace)) ?? undefined;
-  const currentCacheDir = materialized.cacheDir ?? (version ? join(codexHomeDir, "plugins", "cache", "oh-my-codex-local", "oh-my-codex", version) : undefined);
+  const currentCacheDir = materialized.cacheDir ?? (version ? join(selectedCodexHomeDir, "plugins", "cache", "oh-my-codex-local", "oh-my-codex", version) : undefined);
   const prunedStaleDirs: string[] = [];
+  const liveProcesses = listLiveOmxProcessesForResumePreflight();
 
   if (currentCacheDir) {
-    for (const cacheDir of await discoverOmxPluginCacheDirs(codexHomeDir)) {
+    for (const cacheDir of await discoverOmxPluginCacheDirs(selectedCodexHomeDir)) {
       if (cacheDir === currentCacheDir) continue;
+      if (isPluginCacheDirReferencedByLiveProcess(cacheDir, liveProcesses)) continue;
       await rm(cacheDir, { recursive: true, force: true });
       prunedStaleDirs.push(cacheDir);
     }
   }
 
-  const configPath = join(codexHomeDir, "config.toml");
+  const configPath = join(selectedCodexHomeDir, "config.toml");
   const existingConfig = existsSync(configPath) ? await readFile(configPath, "utf-8") : "";
   const nextConfig = upsertLocalOmxMarketplaceRegistration(
     upsertLocalOmxPluginEnablement(existingConfig),

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -36,7 +36,6 @@ import {
   cleanupCommand,
   cleanupOmxMcpProcesses,
   findLaunchSafeCleanupCandidates,
-  listOmxProcesses,
   type CleanupDependencies,
   type CleanupResult,
 } from "./cleanup.js";
@@ -80,7 +79,6 @@ import {
 } from "./codex-home.js";
 import { discoverProjectRuntimeCodexHomes } from "./project-runtime-codex-homes.js";
 import {
-  discoverOmxPluginCacheDirs,
   materializePackagedOmxPluginCache,
   packagedOmxPluginVersion,
   resolvePackagedOmxMarketplace,
@@ -1162,23 +1160,6 @@ export interface ResumePluginPreflightResult {
   configUpdated: boolean;
 }
 
-function commandMentionsPath(command: string, path: string): boolean {
-  const normalizedCommand = command.replace(/\\+/g, "/");
-  const normalizedPath = path.replace(/\\+/g, "/");
-  return normalizedCommand.includes(normalizedPath);
-}
-
-function listLiveOmxProcessesForResumePreflight(): ReturnType<typeof listOmxProcesses> {
-  try {
-    return listOmxProcesses();
-  } catch {
-    return [];
-  }
-}
-
-function isPluginCacheDirReferencedByLiveProcess(cacheDir: string, processes: ReturnType<typeof listOmxProcesses>): boolean {
-  return processes.some((processEntry) => commandMentionsPath(processEntry.command, cacheDir));
-}
 
 export async function preflightResumeOmxPluginState(
   codexHomeDir: string | undefined,
@@ -1196,16 +1177,6 @@ export async function preflightResumeOmxPluginState(
   const version = materialized.version ?? (await packagedOmxPluginVersion(packagedMarketplace)) ?? undefined;
   const currentCacheDir = materialized.cacheDir ?? (version ? join(selectedCodexHomeDir, "plugins", "cache", "oh-my-codex-local", "oh-my-codex", version) : undefined);
   const prunedStaleDirs: string[] = [];
-  const liveProcesses = listLiveOmxProcessesForResumePreflight();
-
-  if (currentCacheDir) {
-    for (const cacheDir of await discoverOmxPluginCacheDirs(selectedCodexHomeDir)) {
-      if (cacheDir === currentCacheDir) continue;
-      if (isPluginCacheDirReferencedByLiveProcess(cacheDir, liveProcesses)) continue;
-      await rm(cacheDir, { recursive: true, force: true });
-      prunedStaleDirs.push(cacheDir);
-    }
-  }
 
   const configPath = join(selectedCodexHomeDir, "config.toml");
   const existingConfig = existsSync(configPath) ? await readFile(configPath, "utf-8") : "";

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -478,6 +478,32 @@ function localPluginMcpServerTableHeaderPattern(serverName: string): RegExp {
 		`^\\s*\\[plugins\\.${JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\.mcp_servers\\.${serverName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\]\\s*$`,
 	);
 }
+function localPluginScalarLinePattern(): RegExp {
+	return new RegExp(
+		`^\\s*${JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*=.*$`,
+	);
+}
+
+function removeLocalOmxPluginLegacyScalar(config: string): string {
+	const scalarPattern = localPluginScalarLinePattern();
+	const lines = config.split(/\r?\n/);
+	const result: string[] = [];
+	let inPluginsTable = false;
+
+	for (const line of lines) {
+		if (isTomlTableHeader(line)) {
+			inPluginsTable = /^\s*\[plugins\]\s*$/.test(line);
+			result.push(line);
+			continue;
+		}
+
+		if (inPluginsTable && scalarPattern.test(line)) continue;
+		result.push(line);
+	}
+
+	return result.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd();
+}
+
 
 export function hasLocalOmxPluginMcpServerRegistrations(config: string): boolean {
 	const lines = config.split(/\r?\n/);
@@ -544,8 +570,9 @@ function upsertTomlTableBooleanKey(
 }
 
 export function upsertLocalOmxPluginEnablement(config: string): string {
+	const normalized = removeLocalOmxPluginLegacyScalar(config);
 	const stripped = stripTomlTablesByHeaderPattern(
-		config,
+		normalized,
 		localPluginTableHeaderPattern(),
 	).trimEnd();
 	return `${stripped ? `${stripped}\n\n` : ""}[plugins.${JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY)}]\nenabled = true\n`;


### PR DESCRIPTION
## Summary
- Preflight `omx --madmax resume` against the default selected user `CODEX_HOME` when no explicit/project runtime home is selected.
- Materialize the current packaged plugin cache and repair local plugin config before launching so resume cannot restore stale plugin cache/version metadata after update.
- Preserve stale plugin cache directories that are still referenced by live OMX/Codex-related processes, keeping #3024/#3030 live-session safety intact.

Fixes #3034

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/resume.test.js`
- `git diff --check origin/dev...HEAD`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*