### PR TITLE
[codex] PR3010 slice A: conductor reuse ledger

### DIFF
--- a/src/cli/__tests__/ralph-goal-mode-contract.test.ts
+++ b/src/cli/__tests__/ralph-goal-mode-contract.test.ts
@@ -4,9 +4,17 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildRalphAppendInstructions } from '../ralph.js';
+import {
+  LEADER_CONDUCTOR_BLOCK,
+  LEADER_CONDUCTOR_GOLDEN_RULE,
+} from '../../leader/contract.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ralphSkill = readFileSync(join(__dirname, '../../../skills/ralph/SKILL.md'), 'utf-8');
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 describe('ralph goal mode integration contract', () => {
   it('uses agent_type-based native subagent examples instead of legacy delegate role syntax', () => {
@@ -42,6 +50,9 @@ describe('ralph goal mode integration contract', () => {
     });
 
     assert.match(instructions, /Goal mode guidance/i);
+    assert.match(instructions, /Conductor philosophy:/i);
+    assert.match(instructions, new RegExp(escapeRegExp(LEADER_CONDUCTOR_BLOCK)));
+    assert.match(instructions, new RegExp(escapeRegExp(LEADER_CONDUCTOR_GOLDEN_RULE)));
     assert.match(instructions, /get_goal/i);
     assert.match(instructions, /create_goal/i);
     assert.match(instructions, /update_goal\(\{status: "complete"\}\)/i);

--- a/src/cli/__tests__/ralph-goal-mode-contract.test.ts
+++ b/src/cli/__tests__/ralph-goal-mode-contract.test.ts
@@ -7,6 +7,7 @@ import { buildRalphAppendInstructions } from '../ralph.js';
 import {
   LEADER_CONDUCTOR_BLOCK,
   LEADER_CONDUCTOR_GOLDEN_RULE,
+  LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE,
 } from '../../leader/contract.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -53,6 +54,7 @@ describe('ralph goal mode integration contract', () => {
     assert.match(instructions, /Conductor philosophy:/i);
     assert.match(instructions, new RegExp(escapeRegExp(LEADER_CONDUCTOR_BLOCK)));
     assert.match(instructions, new RegExp(escapeRegExp(LEADER_CONDUCTOR_GOLDEN_RULE)));
+    assert.match(instructions, new RegExp(escapeRegExp(LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE)));
     assert.match(instructions, /get_goal/i);
     assert.match(instructions, /create_goal/i);
     assert.match(instructions, /update_goal\(\{status: "complete"\}\)/i);

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -9,6 +9,7 @@ import {
   buildFollowupStaffingPlan,
   resolveAvailableAgentTypes,
 } from '../team/followup-planner.js';
+import { LEADER_CONDUCTOR_BLOCK } from '../leader/contract.js';
 
 export const RALPH_HELP = `omx ralph - Launch Codex with ralph persistence mode active
 
@@ -241,6 +242,8 @@ export function buildRalphAppendInstructions(
   return [
     '<ralph_native_subagents>',
     'You are in OMX Ralph persistence mode.',
+    'Conductor philosophy:',
+    LEADER_CONDUCTOR_BLOCK,
     `Primary task: ${task}`,
     'Parallelism guidance:',
     '- Prefer Codex native subagents for independent parallel subtasks.',

--- a/src/cli/ralph.ts
+++ b/src/cli/ralph.ts
@@ -9,7 +9,10 @@ import {
   buildFollowupStaffingPlan,
   resolveAvailableAgentTypes,
 } from '../team/followup-planner.js';
-import { LEADER_CONDUCTOR_BLOCK } from '../leader/contract.js';
+import {
+  LEADER_CONDUCTOR_BLOCK,
+  LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE,
+} from '../leader/contract.js';
 
 export const RALPH_HELP = `omx ralph - Launch Codex with ralph persistence mode active
 
@@ -244,6 +247,7 @@ export function buildRalphAppendInstructions(
     'You are in OMX Ralph persistence mode.',
     'Conductor philosophy:',
     LEADER_CONDUCTOR_BLOCK,
+    LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE,
     `Primary task: ${task}`,
     'Parallelism guidance:',
     '- Prefer Codex native subagents for independent parallel subtasks.',

--- a/src/leader/__tests__/contract.test.ts
+++ b/src/leader/__tests__/contract.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  LEADER_CONDUCTOR_BLOCK,
+  LEADER_CONDUCTOR_DELEGATION_NOTE,
+  LEADER_CONDUCTOR_GOLDEN_RULE,
+  LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE,
+  LEADER_CONDUCTOR_REUSE_AND_LEDGER_RULES,
+  LEADER_CONDUCTOR_SILVER_RULE,
+} from '../contract.js';
+
+describe('leader conductor contract', () => {
+  it('exports the exact canonical Golden Rule string', () => {
+    assert.equal(
+      LEADER_CONDUCTOR_GOLDEN_RULE,
+      'When the Main agent is acting in Conductor mode, NEVER make plan or code changes directly. ALWAYS delegate implementation to specialized agents. Your role is to guide, review, and orchestrate.',
+    );
+  });
+
+  it('exports the exact canonical conductor block without ledger/reuse guidance', () => {
+    assert.deepEqual(LEADER_CONDUCTOR_REUSE_AND_LEDGER_RULES, [
+      'Conductor mode is a Main-root contract only; typed subagents never receive this block.',
+      'Use .omx/state/subagent-tracking.json as the source of truth for saved subagent ids and recovery order.',
+      'On SessionStart, eagerly attempt resume_agent(<subagent id>) for every saved subagent id before spawning any replacement agent.',
+      'ralplan consensus planning may activate Conductor; autopilot rework stays exempt.',
+    ]);
+
+    assert.equal(
+      LEADER_CONDUCTOR_BLOCK,
+      [
+        'Conductor mode contract:',
+        `- Golden Rule: ${LEADER_CONDUCTOR_GOLDEN_RULE}`,
+        `- ${LEADER_CONDUCTOR_DELEGATION_NOTE}`,
+      ].join('\n'),
+    );
+    assert.doesNotMatch(LEADER_CONDUCTOR_BLOCK, /resume_agent|subagent-tracking|Silver Rule/);
+  });
+
+  it('exports separate conductor reuse and ledger guidance', () => {
+    assert.equal(
+      LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE,
+      [
+        'Conductor reuse and ledger guidance:',
+        `- ${LEADER_CONDUCTOR_SILVER_RULE}`,
+        '- Conductor mode is a Main-root contract only; typed subagents never receive this block.',
+        '- Use .omx/state/subagent-tracking.json as the source of truth for saved subagent ids and recovery order.',
+        '- On SessionStart, eagerly attempt resume_agent(<subagent id>) for every saved subagent id before spawning any replacement agent.',
+        '- ralplan consensus planning may activate Conductor; autopilot rework stays exempt.',
+      ].join('\n'),
+    );
+  });
+});

--- a/src/leader/contract.ts
+++ b/src/leader/contract.ts
@@ -1,0 +1,30 @@
+export const LEADER_CONDUCTOR_PHILOSOPHY =
+  'Conductor Philosophy: The core principle of OMX is: You are the conductor, not the performer.';
+
+export const LEADER_CONDUCTOR_GOLDEN_RULE =
+  'When the Main agent is acting in Conductor mode, NEVER make plan or code changes directly. ALWAYS delegate implementation to specialized agents. Your role is to guide, review, and orchestrate.';
+
+export const LEADER_CONDUCTOR_SILVER_RULE =
+  'Silver Rule: When follow-up work targets an existing role/lane, reuse or resume the assigned specialized agent whenever available before spawning a replacement.';
+
+export const LEADER_CONDUCTOR_DELEGATION_NOTE =
+  'Delegation note: assign bounded implementation, planning, review, and verification work to the appropriate specialized agents; Main owns orchestration, integration, and final judgment only.';
+
+export const LEADER_CONDUCTOR_REUSE_AND_LEDGER_RULES = [
+  'Conductor mode is a Main-root contract only; typed subagents never receive this block.',
+  'Use .omx/state/subagent-tracking.json as the source of truth for saved subagent ids and recovery order.',
+  'On SessionStart, eagerly attempt resume_agent(<subagent id>) for every saved subagent id before spawning any replacement agent.',
+  'ralplan consensus planning may activate Conductor; autopilot rework stays exempt.',
+] as const;
+
+export const LEADER_CONDUCTOR_BLOCK = [
+  'Conductor mode contract:',
+  `- Golden Rule: ${LEADER_CONDUCTOR_GOLDEN_RULE}`,
+  `- ${LEADER_CONDUCTOR_DELEGATION_NOTE}`,
+].join('\n');
+
+export const LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE = [
+  'Conductor reuse and ledger guidance:',
+  `- ${LEADER_CONDUCTOR_SILVER_RULE}`,
+  ...LEADER_CONDUCTOR_REUSE_AND_LEDGER_RULES.map((line) => `- ${line}`),
+].join('\n');

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -16,6 +16,7 @@ import { createUltraqaStage, buildUltraqaInstruction } from '../stages/ultraqa.j
 import { buildFollowupStaffingPlan } from '../../team/followup-planner.js';
 import { packageRoot } from '../../utils/paths.js';
 import { subagentTrackingPath } from '../../subagents/tracker.js';
+import { LEADER_CONDUCTOR_BLOCK } from '../../leader/contract.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1936,6 +1937,7 @@ describe('Default Autopilot Ultragoal Stage Adapters', () => {
     assert.deepEqual(descriptor.ralplanArtifacts, { plan: 'approved' });
     assert.match(artifacts.team_condition as string, /Launch \$team only inside an active Ultragoal story/);
     assert.match(buildUltragoalInstruction('execute me'), /^\$ultragoal /);
+    assert.match(buildUltragoalInstruction('execute me'), new RegExp(escapeRegExp(LEADER_CONDUCTOR_BLOCK)));
   });
 
   it('creates an ultraqa gate that fails closed without evidence and can record clean skips', async () => {

--- a/src/pipeline/stages/ultragoal.ts
+++ b/src/pipeline/stages/ultragoal.ts
@@ -7,6 +7,7 @@
  */
 
 import type { PipelineStage, StageContext, StageResult } from '../types.js';
+import { LEADER_CONDUCTOR_BLOCK } from '../../leader/contract.js';
 
 export interface UltragoalDescriptor {
   task: string;
@@ -48,5 +49,9 @@ export function createUltragoalStage(): PipelineStage {
 }
 
 export function buildUltragoalInstruction(task: string): string {
-  return `$ultragoal ${JSON.stringify(task)}`;
+  return [
+    `$ultragoal ${JSON.stringify(task)}`,
+    '',
+    LEADER_CONDUCTOR_BLOCK,
+  ].join('\n');
 }

--- a/src/ralplan/__tests__/runtime.test.ts
+++ b/src/ralplan/__tests__/runtime.test.ts
@@ -217,6 +217,71 @@ describe('ralplan runtime', () => {
     }
   });
 
+  it('does not fabricate native tracker completion from approved review bookkeeping alone', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-runtime-native-bookkeeping-only-'));
+    const sessionId = 'sess-ralplan-native-bookkeeping-only';
+    try {
+      await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
+      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+
+      const result = await runRalplanConsensus({
+        async draft() {
+          const plansDir = join(cwd, '.omx', 'plans');
+          await mkdir(plansDir, { recursive: true });
+          const prdPath = join(plansDir, 'prd-native-bookkeeping-only.md');
+          await writeFile(prdPath, '# plan\n');
+          await writeFile(join(plansDir, 'test-spec-native-bookkeeping-only.md'), '# tests\n');
+          return { summary: 'draft', planPath: prdPath };
+        },
+        async architectReview() {
+          return {
+            verdict: 'approve',
+            summary: 'native architect ok',
+            provenance_kind: 'native_subagent',
+            session_id: sessionId,
+            thread_id: 'thread-architect',
+            artifact_path: '.omx/artifacts/architect.md',
+            agent_role: 'architect',
+            tracker_path: '.omx/state/subagent-tracking.json',
+          };
+        },
+        async criticReview() {
+          return {
+            verdict: 'approve',
+            summary: 'native critic ok',
+            provenance_kind: 'native_subagent',
+            session_id: sessionId,
+            thread_id: 'thread-critic',
+            artifact_path: '.omx/artifacts/critic.md',
+            agent_role: 'critic',
+            tracker_path: '.omx/state/subagent-tracking.json',
+          };
+        },
+      }, {
+        task: 'require native reviews without fabricated completion',
+        cwd,
+        sessionId,
+        maxIterations: 1,
+        requireNativeSubagents: true,
+      });
+
+      assert.equal(result.status, 'failed');
+      assert.equal(result.ralplanConsensusGate.complete, false);
+      assert.equal(result.ralplanConsensusGate.blocked_reason, 'native_subagent_consensus_evidence_missing');
+      assert.equal(result.error, 'ralplan_consensus_not_reached_after_1_iterations');
+
+      const tracking = JSON.parse(await readFile(subagentTrackingPath(cwd), 'utf-8')) as {
+        sessions?: Record<string, {
+          threads?: Record<string, { completed_at?: string }>;
+        }>;
+      };
+      assert.equal(tracking.sessions?.[sessionId]?.threads?.['thread-architect']?.completed_at, undefined);
+      assert.equal(tracking.sessions?.[sessionId]?.threads?.['thread-critic']?.completed_at, undefined);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('accepts Autopilot-required consensus with tracker-backed native architect and critic lanes', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-runtime-native-required-ok-'));
     const sessionId = 'sess-ralplan-native-required-ok';

--- a/src/ralplan/runtime.ts
+++ b/src/ralplan/runtime.ts
@@ -1,5 +1,6 @@
 import { cancelMode, readModeState, startMode, updateModeState } from '../modes/base.js';
 import { isPlanningComplete, readPlanningArtifacts } from '../planning/artifacts.js';
+import { recordSubagentTurnForSession } from '../subagents/tracker.js';
 import { buildRalplanConsensusGateFromSources } from './consensus-gate.js';
 
 export const RALPLAN_ACTIVE_PHASES = [
@@ -17,6 +18,12 @@ export interface RalplanDraftResult {
   summary?: string;
   planPath?: string;
   artifacts?: Record<string, unknown>;
+  session_id?: string;
+  thread_id?: string;
+  native_session_id?: string;
+  agent_role?: 'planner' | 'architect' | 'critic' | 'executor';
+  lane_id?: string;
+  tracker_path?: string;
 }
 
 export interface RalplanReviewResult {
@@ -28,7 +35,8 @@ export interface RalplanReviewResult {
   thread_id?: string;
   native_session_id?: string;
   artifact_path?: string;
-  agent_role?: 'architect' | 'critic';
+  agent_role?: 'planner' | 'architect' | 'critic';
+  lane_id?: string;
   tracker_path?: string;
 }
 
@@ -124,6 +132,36 @@ function buildReviewHistory(
     });
   }
   return entries;
+}
+
+async function recordRalplanSubagentTurn(
+  cwd: string,
+  sessionId: string | undefined,
+  input: {
+    threadId?: string;
+    role?: 'planner' | 'architect' | 'critic' | 'executor';
+    laneId?: string;
+    scope?: string;
+    summary?: string;
+    completed?: boolean;
+    completionSource?: string;
+  },
+): Promise<void> {
+  const normalizedSessionId = sessionId?.trim();
+  const normalizedThreadId = input.threadId?.trim();
+  if (!normalizedSessionId || !normalizedThreadId) return;
+
+  await recordSubagentTurnForSession(cwd, {
+    sessionId: normalizedSessionId,
+    threadId: normalizedThreadId,
+    mode: input.role,
+    ...(input.role ? { role: input.role } : {}),
+    ...(input.laneId ? { laneId: input.laneId } : input.role ? { laneId: input.role } : {}),
+    ...(input.scope ? { scope: input.scope } : {}),
+    ...(input.summary?.trim() ? { lastHandoffSummary: input.summary.trim() } : {}),
+    ...(input.completed ? { completed: true, completionSource: input.completionSource } : {}),
+    kind: 'subagent',
+  }).catch(() => {});
 }
 
 function buildRalplanConsensusGate(
@@ -256,6 +294,15 @@ export async function runRalplanConsensus(
       drafts.push(draft);
       if (draft.artifacts) Object.assign(aggregatedArtifacts, draft.artifacts);
       if (draft.planPath) latestPlanPath = draft.planPath;
+      await recordRalplanSubagentTurn(cwd, options.sessionId, {
+        threadId: draft.thread_id,
+        role: draft.agent_role ?? undefined,
+        laneId: draft.lane_id,
+        scope: options.task,
+        summary: draft.summary,
+        completed: true,
+        completionSource: 'ralplan-draft',
+      });
 
       await updateRalplanState(cwd, {
         iteration,
@@ -271,6 +318,15 @@ export async function runRalplanConsensus(
       });
       architectReviews.push(architectReview);
       if (architectReview.artifacts) Object.assign(aggregatedArtifacts, architectReview.artifacts);
+      await recordRalplanSubagentTurn(cwd, options.sessionId, {
+        threadId: architectReview.thread_id,
+        role: architectReview.agent_role,
+        laneId: architectReview.lane_id,
+        scope: options.task,
+        summary: architectReview.summary,
+        completed: true,
+        completionSource: 'ralplan-architect-review',
+      });
 
       if (architectReview.verdict !== 'approve') {
         const reviewHistory = buildReviewHistory(drafts, architectReviews, criticReviews);
@@ -334,6 +390,15 @@ export async function runRalplanConsensus(
       });
       criticReviews.push(criticReview);
       if (criticReview.artifacts) Object.assign(aggregatedArtifacts, criticReview.artifacts);
+      await recordRalplanSubagentTurn(cwd, options.sessionId, {
+        threadId: criticReview.thread_id,
+        role: criticReview.agent_role,
+        laneId: criticReview.lane_id,
+        scope: options.task,
+        summary: criticReview.summary,
+        completed: true,
+        completionSource: 'ralplan-critic-review',
+      });
 
       const reviewHistory = buildReviewHistory(drafts, architectReviews, criticReviews);
       const consensusGate = buildRalplanConsensusGate(architectReviews, criticReviews, gateOptions);

--- a/src/ralplan/runtime.ts
+++ b/src/ralplan/runtime.ts
@@ -145,6 +145,7 @@ async function recordRalplanSubagentTurn(
     summary?: string;
     completed?: boolean;
     completionSource?: string;
+    preserveCompletionEvidence?: boolean;
   },
 ): Promise<void> {
   const normalizedSessionId = sessionId?.trim();
@@ -160,6 +161,7 @@ async function recordRalplanSubagentTurn(
     ...(input.scope ? { scope: input.scope } : {}),
     ...(input.summary?.trim() ? { lastHandoffSummary: input.summary.trim() } : {}),
     ...(input.completed ? { completed: true, completionSource: input.completionSource } : {}),
+    ...(input.preserveCompletionEvidence ? { preserveCompletionEvidence: true } : {}),
     kind: 'subagent',
   }).catch(() => {});
 }
@@ -324,8 +326,7 @@ export async function runRalplanConsensus(
         laneId: architectReview.lane_id,
         scope: options.task,
         summary: architectReview.summary,
-        completed: true,
-        completionSource: 'ralplan-architect-review',
+        preserveCompletionEvidence: Boolean(options.requireNativeSubagents),
       });
 
       if (architectReview.verdict !== 'approve') {
@@ -396,8 +397,7 @@ export async function runRalplanConsensus(
         laneId: criticReview.lane_id,
         scope: options.task,
         summary: criticReview.summary,
-        completed: true,
-        completionSource: 'ralplan-critic-review',
+        preserveCompletionEvidence: Boolean(options.requireNativeSubagents),
       });
 
       const reviewHistory = buildReviewHistory(drafts, architectReviews, criticReviews);

--- a/src/subagents/__tests__/tracker.test.ts
+++ b/src/subagents/__tests__/tracker.test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+  buildSubagentResumeLedger,
   createSubagentTrackingState,
   recordSubagentTurn,
+  selectReusableSubagentEntry,
   summarizeSubagentSession,
 } from '../tracker.js';
 
@@ -41,6 +43,10 @@ describe('subagents/tracker', () => {
       allThreadIds: ['leader-thread', 'sub-thread-1', 'sub-thread-2'],
       allSubagentThreadIds: ['sub-thread-1', 'sub-thread-2'],
       activeSubagentThreadIds: ['sub-thread-1', 'sub-thread-2'],
+      savedSubagents: [
+        { agentId: 'sub-thread-1', threadId: 'sub-thread-1', role: 'ralph', laneId: 'ralph', status: 'available' },
+        { agentId: 'sub-thread-2', threadId: 'sub-thread-2', role: 'ralph', laneId: 'ralph', status: 'available' },
+      ],
       updatedAt: '2026-03-17T00:01:00.000Z',
     });
 
@@ -281,6 +287,107 @@ describe('subagents/tracker', () => {
     assert.equal(thread?.last_completed_turn_id, undefined);
     assert.equal(thread?.completion_source, undefined);
     assert.equal(thread?.last_turn_id, 'turn-3');
+  });
+
+  it('records role and lane metadata for restart resume/reuse summaries', () => {
+    let state = createSubagentTrackingState();
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-conductor',
+      threadId: 'thread-leader',
+      timestamp: '2026-06-29T00:00:00.000Z',
+      mode: 'ralph',
+      kind: 'leader',
+    });
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-conductor',
+      threadId: 'thread-executor',
+      timestamp: '2026-06-29T00:00:30.000Z',
+      mode: 'executor',
+      role: 'executor',
+      laneId: 'implementation-fix',
+      scope: 'runtime hook guard',
+      agentNickname: 'worker-1',
+      kind: 'subagent',
+      leaderThreadId: 'thread-leader',
+    });
+
+    const summary = summarizeSubagentSession(state, 'sess-conductor', {
+      now: '2026-06-29T00:01:00.000Z',
+      activeWindowMs: 120_000,
+    });
+
+    assert.deepEqual(summary?.savedSubagents, [
+      {
+        agentId: 'thread-executor',
+        threadId: 'thread-executor',
+        role: 'executor',
+        laneId: 'implementation-fix',
+        scope: 'runtime hook guard',
+        agentNickname: 'worker-1',
+        status: 'available',
+      },
+    ]);
+    assert.equal(state.sessions['sess-conductor']?.threads['thread-executor']?.role, 'executor');
+    assert.equal(state.sessions['sess-conductor']?.threads['thread-executor']?.lane_id, 'implementation-fix');
+  });
+
+  it('builds a reusable ledger that preserves unavailable status and handoff summaries', () => {
+    let state = createSubagentTrackingState();
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-conductor',
+      threadId: 'thread-leader',
+      timestamp: '2026-06-29T00:00:00.000Z',
+      mode: 'ralph',
+      kind: 'leader',
+    });
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-conductor',
+      threadId: 'thread-architect',
+      timestamp: '2026-06-29T00:00:30.000Z',
+      mode: 'architect',
+      role: 'architect',
+      laneId: 'plan-review',
+      scope: 'runtime hook guard',
+      agentNickname: 'reviewer-1',
+      kind: 'subagent',
+      leaderThreadId: 'thread-leader',
+      lastHandoffSummary: 'architect reviewed v1 and requested reuse of the same lane',
+      status: 'available',
+    });
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-conductor',
+      threadId: 'thread-critic',
+      timestamp: '2026-06-29T00:01:00.000Z',
+      mode: 'critic',
+      role: 'critic',
+      laneId: 'risk-review',
+      scope: 'runtime hook guard',
+      kind: 'subagent',
+      leaderThreadId: 'thread-leader',
+      lastHandoffSummary: 'critic paused pending planner response',
+      status: 'unavailable',
+    });
+
+    const ledger = buildSubagentResumeLedger(state, 'sess-conductor', {
+      now: '2026-06-29T00:01:30.000Z',
+      activeWindowMs: 120_000,
+    });
+
+    assert.ok(ledger);
+    assert.deepEqual(ledger?.resumeTargets.map((entry) => entry.agentId), ['thread-architect', 'thread-critic']);
+    assert.equal(ledger?.savedSubagents.find((entry) => entry.agentId === 'thread-architect')?.status, 'available');
+    assert.equal(ledger?.savedSubagents.find((entry) => entry.agentId === 'thread-architect')?.lastHandoffSummary, 'architect reviewed v1 and requested reuse of the same lane');
+    assert.equal(ledger?.savedSubagents.find((entry) => entry.agentId === 'thread-critic')?.status, 'unavailable');
+    assert.equal(ledger?.savedSubagents.find((entry) => entry.agentId === 'thread-critic')?.lastHandoffSummary, 'critic paused pending planner response');
+    assert.deepEqual(
+      selectReusableSubagentEntry(ledger?.resumeTargets ?? [], {
+        role: 'architect',
+        laneId: 'plan-review',
+        scope: 'runtime hook guard',
+      })?.agentId,
+      'thread-architect',
+    );
+    assert.deepEqual(ledger?.unavailableSubagents.map((entry) => entry.agentId), ['thread-critic']);
   });
 
 });

--- a/src/subagents/__tests__/tracker.test.ts
+++ b/src/subagents/__tests__/tracker.test.ts
@@ -417,6 +417,23 @@ describe('subagents/tracker', () => {
     assert.equal(
       selectReusableSubagentEntry([
         {
+          agentId: 'thread-critic',
+          threadId: 'thread-critic',
+          role: 'critic',
+          laneId: 'risk-review',
+          scope: 'runtime hook guard',
+          status: 'unavailable',
+        },
+      ], {
+        role: 'critic',
+        laneId: 'risk-review',
+        scope: 'runtime hook guard',
+      }),
+      null,
+    );
+    assert.equal(
+      selectReusableSubagentEntry([
+        {
           agentId: 'thread-executor',
           threadId: 'thread-executor',
           role: 'executor',

--- a/src/subagents/__tests__/tracker.test.ts
+++ b/src/subagents/__tests__/tracker.test.ts
@@ -250,6 +250,43 @@ describe('subagents/tracker', () => {
     );
   });
 
+  it('preserves explicit unavailable and closed status in summaries even when threads are still recent', () => {
+    let state = createSubagentTrackingState();
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-1',
+      threadId: 'leader-thread',
+      turnId: 'turn-1',
+      timestamp: '2026-03-17T00:00:00.000Z',
+      mode: 'ralplan',
+    });
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-1',
+      threadId: 'sub-thread-unavailable',
+      turnId: 'turn-2',
+      timestamp: '2026-03-17T00:00:30.000Z',
+      mode: 'architect',
+      status: 'unavailable',
+    });
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-1',
+      threadId: 'sub-thread-closed',
+      turnId: 'turn-3',
+      timestamp: '2026-03-17T00:00:45.000Z',
+      mode: 'critic',
+      status: 'closed',
+    });
+
+    const summary = summarizeSubagentSession(state, 'sess-1', {
+      now: '2026-03-17T00:01:00.000Z',
+      activeWindowMs: 120_000,
+    });
+
+    assert.deepEqual(summary?.savedSubagents, [
+      { agentId: 'sub-thread-closed', threadId: 'sub-thread-closed', role: 'critic', laneId: 'critic', status: 'closed' },
+      { agentId: 'sub-thread-unavailable', threadId: 'sub-thread-unavailable', role: 'architect', laneId: 'architect', status: 'unavailable' },
+    ]);
+  });
+
   it('reactivates a notify-fallback-completed subagent thread after a later non-complete turn', () => {
     let state = createSubagentTrackingState();
     state = recordSubagentTurn(state, {

--- a/src/subagents/__tests__/tracker.test.ts
+++ b/src/subagents/__tests__/tracker.test.ts
@@ -281,10 +281,17 @@ describe('subagents/tracker', () => {
       activeWindowMs: 120_000,
     });
 
+    const ledger = buildSubagentResumeLedger(state, 'sess-1', {
+      now: '2026-03-17T00:01:00.000Z',
+      activeWindowMs: 120_000,
+    });
+
+    assert.deepEqual(summary?.activeSubagentThreadIds, []);
     assert.deepEqual(summary?.savedSubagents, [
       { agentId: 'sub-thread-closed', threadId: 'sub-thread-closed', role: 'critic', laneId: 'critic', status: 'closed' },
       { agentId: 'sub-thread-unavailable', threadId: 'sub-thread-unavailable', role: 'architect', laneId: 'architect', status: 'unavailable' },
     ]);
+    assert.deepEqual(ledger?.activeSubagentThreadIds, []);
   });
 
   it('reactivates a notify-fallback-completed subagent thread after a later non-complete turn', () => {
@@ -317,9 +324,19 @@ describe('subagents/tracker', () => {
       now: '2026-03-17T00:01:15.000Z',
       activeWindowMs: 120_000,
     });
+    const ledger = buildSubagentResumeLedger(state, 'sess-1', {
+      now: '2026-03-17T00:01:15.000Z',
+      activeWindowMs: 120_000,
+    });
     const thread = state.sessions['sess-1']?.threads['sub-thread-1'];
 
     assert.deepEqual(summary?.activeSubagentThreadIds, ['sub-thread-1']);
+    assert.deepEqual(summary?.savedSubagents, [
+      { agentId: 'sub-thread-1', threadId: 'sub-thread-1', role: 'architect', laneId: 'architect', status: 'available' },
+    ]);
+    assert.deepEqual(ledger?.activeSubagentThreadIds, ['sub-thread-1']);
+    assert.equal(ledger?.savedSubagents[0]?.status, 'available');
+    assert.equal(thread?.status, undefined);
     assert.equal(thread?.completed_at, undefined);
     assert.equal(thread?.last_completed_turn_id, undefined);
     assert.equal(thread?.completion_source, undefined);

--- a/src/subagents/__tests__/tracker.test.ts
+++ b/src/subagents/__tests__/tracker.test.ts
@@ -387,6 +387,50 @@ describe('subagents/tracker', () => {
       })?.agentId,
       'thread-architect',
     );
+    assert.equal(
+      selectReusableSubagentEntry([
+        {
+          agentId: 'thread-executor',
+          threadId: 'thread-executor',
+          role: 'executor',
+          laneId: 'plan-review',
+          scope: 'runtime hook guard',
+          status: 'available',
+          lastSeenAt: '2026-06-29T00:01:25.000Z',
+        },
+        {
+          agentId: 'thread-architect',
+          threadId: 'thread-architect',
+          role: 'architect',
+          laneId: 'plan-review',
+          scope: 'runtime hook guard',
+          status: 'closed',
+          lastSeenAt: '2026-06-29T00:01:20.000Z',
+        },
+      ], {
+        role: 'architect',
+        laneId: 'plan-review',
+        scope: 'runtime hook guard',
+      })?.agentId,
+      'thread-architect',
+    );
+    assert.equal(
+      selectReusableSubagentEntry([
+        {
+          agentId: 'thread-executor',
+          threadId: 'thread-executor',
+          role: 'executor',
+          laneId: 'plan-review',
+          scope: 'runtime hook guard',
+          status: 'available',
+        },
+      ], {
+        role: 'architect',
+        laneId: 'plan-review',
+        scope: 'runtime hook guard',
+      }),
+      null,
+    );
     assert.deepEqual(ledger?.unavailableSubagents.map((entry) => entry.agentId), ['thread-critic']);
   });
 

--- a/src/subagents/__tests__/tracker.test.ts
+++ b/src/subagents/__tests__/tracker.test.ts
@@ -488,4 +488,59 @@ describe('subagents/tracker', () => {
     assert.deepEqual(ledger?.unavailableSubagents.map((entry) => entry.agentId), ['thread-critic']);
   });
 
+  it('preserves explicit closed ledger status so older available lanes win reuse selection', () => {
+    let state = createSubagentTrackingState();
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-conductor',
+      threadId: 'thread-leader',
+      timestamp: '2026-06-29T00:00:00.000Z',
+      mode: 'ralph',
+      kind: 'leader',
+    });
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-conductor',
+      threadId: 'thread-available-older',
+      timestamp: '2026-06-29T00:00:30.000Z',
+      mode: 'executor',
+      role: 'executor',
+      laneId: 'implementation-fix',
+      scope: 'conductor reuse ledger',
+      kind: 'subagent',
+      leaderThreadId: 'thread-leader',
+      status: 'available',
+    });
+    state = recordSubagentTurn(state, {
+      sessionId: 'sess-conductor',
+      threadId: 'thread-closed-recent',
+      timestamp: '2026-06-29T00:01:30.000Z',
+      mode: 'executor',
+      role: 'executor',
+      laneId: 'implementation-fix',
+      scope: 'conductor reuse ledger',
+      kind: 'subagent',
+      leaderThreadId: 'thread-leader',
+      status: 'closed',
+    });
+
+    const ledger = buildSubagentResumeLedger(state, 'sess-conductor', {
+      now: '2026-06-29T00:01:45.000Z',
+      activeWindowMs: 120_000,
+    });
+
+    assert.ok(ledger);
+    assert.equal(ledger.savedSubagents.find((entry) => entry.agentId === 'thread-closed-recent')?.status, 'closed');
+    assert.deepEqual(ledger.resumeTargets.map((entry) => entry.agentId), [
+      'thread-available-older',
+      'thread-closed-recent',
+    ]);
+    assert.equal(
+      selectReusableSubagentEntry(ledger.resumeTargets, {
+        role: 'executor',
+        laneId: 'implementation-fix',
+        scope: 'conductor reuse ledger',
+      })?.agentId,
+      'thread-available-older',
+    );
+  });
+
 });

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -6,6 +6,8 @@ import { getBaseStateDir } from '../state/paths.js';
 export const SUBAGENT_TRACKING_SCHEMA_VERSION = 1;
 export const DEFAULT_SUBAGENT_ACTIVE_WINDOW_MS = 120_000;
 
+export type SubagentAvailabilityStatus = 'available' | 'closed' | 'unavailable';
+
 export interface TrackedSubagentThread {
   thread_id: string;
   kind: 'leader' | 'subagent';
@@ -16,7 +18,17 @@ export interface TrackedSubagentThread {
   last_completed_turn_id?: string;
   turn_count: number;
   mode?: string;
+  role?: string;
+  lane_id?: string;
+  scope?: string;
+  agent_nickname?: string;
   completion_source?: string;
+  status?: SubagentAvailabilityStatus;
+  last_handoff_summary?: string;
+  resume_requested_at?: string;
+  resume_completed_at?: string;
+  resume_failed_at?: string;
+  resume_failure_reason?: string;
 }
 
 export interface TrackedSubagentSession {
@@ -37,10 +49,20 @@ export interface RecordSubagentTurnInput {
   turnId?: string;
   timestamp?: string;
   mode?: string;
+  role?: string;
+  laneId?: string;
+  scope?: string;
+  agentNickname?: string;
   kind?: 'leader' | 'subagent';
   leaderThreadId?: string;
   completed?: boolean;
   completionSource?: string;
+  status?: SubagentAvailabilityStatus;
+  lastHandoffSummary?: string;
+  resumeRequestedAt?: string;
+  resumeCompletedAt?: string;
+  resumeFailedAt?: string;
+  resumeFailureReason?: string;
 }
 
 export interface SubagentSessionSummary {
@@ -49,7 +71,34 @@ export interface SubagentSessionSummary {
   allThreadIds: string[];
   allSubagentThreadIds: string[];
   activeSubagentThreadIds: string[];
+  savedSubagents: SubagentResumeEntry[];
   updatedAt?: string;
+}
+
+export interface SubagentResumeEntry {
+  agentId: string;
+  threadId: string;
+  role?: string;
+  laneId?: string;
+  scope?: string;
+  agentNickname?: string;
+  status: SubagentAvailabilityStatus;
+}
+
+export interface SubagentLedgerEntry extends SubagentResumeEntry {
+  lastSeenAt?: string;
+  completedAt?: string;
+  lastHandoffSummary?: string;
+  resumeRequestedAt?: string;
+  resumeCompletedAt?: string;
+  resumeFailedAt?: string;
+  resumeFailureReason?: string;
+}
+
+export interface SubagentResumeLedger extends SubagentSessionSummary {
+  savedSubagents: SubagentLedgerEntry[];
+  resumeTargets: SubagentLedgerEntry[];
+  unavailableSubagents: SubagentLedgerEntry[];
 }
 
 export function subagentTrackingPath(cwd: string): string {
@@ -60,6 +109,78 @@ export function createSubagentTrackingState(): SubagentTrackingState {
   return {
     schemaVersion: SUBAGENT_TRACKING_SCHEMA_VERSION,
     sessions: {},
+  };
+}
+
+function normalizeSubagentStatus(value: unknown): SubagentAvailabilityStatus | undefined {
+  const normalized = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  if (normalized === 'available' || normalized === 'closed' || normalized === 'unavailable') {
+    return normalized;
+  }
+  return undefined;
+}
+
+function readOptionalTrimmedString(value: unknown): string | undefined {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  return normalized ? normalized : undefined;
+}
+
+function rankSubagentStatus(status: SubagentAvailabilityStatus): number {
+  if (status === 'available') return 0;
+  if (status === 'closed') return 1;
+  return 2;
+}
+
+function compareOptionalTimestampDesc(left?: string, right?: string): number {
+  const leftMs = left ? Date.parse(left) : Number.NaN;
+  const rightMs = right ? Date.parse(right) : Number.NaN;
+  const leftValid = Number.isFinite(leftMs);
+  const rightValid = Number.isFinite(rightMs);
+  if (leftValid && rightValid && leftMs !== rightMs) return rightMs - leftMs;
+  if (leftValid !== rightValid) return leftValid ? -1 : 1;
+  return 0;
+}
+
+function compareResumeEntries(left: SubagentLedgerEntry, right: SubagentLedgerEntry): number {
+  const leftStatusRank = rankSubagentStatus(left.status);
+  const rightStatusRank = rankSubagentStatus(right.status);
+  if (leftStatusRank !== rightStatusRank) return leftStatusRank - rightStatusRank;
+
+  const leftActivityRank = left.lastSeenAt ? 0 : 1;
+  const rightActivityRank = right.lastSeenAt ? 0 : 1;
+  if (leftActivityRank !== rightActivityRank) return leftActivityRank - rightActivityRank;
+
+  const lastSeenComparison = compareOptionalTimestampDesc(left.lastSeenAt, right.lastSeenAt);
+  if (lastSeenComparison !== 0) return lastSeenComparison;
+
+  const leftCompletedComparison = compareOptionalTimestampDesc(left.completedAt, right.completedAt);
+  if (leftCompletedComparison !== 0) return leftCompletedComparison;
+
+  return left.agentId.localeCompare(right.agentId);
+}
+
+function normalizeLedgerEntry(
+  thread: TrackedSubagentThread,
+  status: SubagentAvailabilityStatus,
+  active: boolean,
+): SubagentLedgerEntry {
+  const role = thread.role ?? thread.mode;
+  const laneId = thread.lane_id ?? thread.agent_nickname ?? role;
+  return {
+    agentId: thread.thread_id,
+    threadId: thread.thread_id,
+    ...(role ? { role } : {}),
+    ...(laneId ? { laneId } : {}),
+    ...(thread.scope ? { scope: thread.scope } : {}),
+    ...(thread.agent_nickname ? { agentNickname: thread.agent_nickname } : {}),
+    status: active && status !== 'unavailable' ? 'available' : status === 'available' ? 'available' : status,
+    ...(thread.last_seen_at ? { lastSeenAt: thread.last_seen_at } : {}),
+    ...(thread.completed_at ? { completedAt: thread.completed_at } : {}),
+    ...(thread.last_handoff_summary ? { lastHandoffSummary: thread.last_handoff_summary } : {}),
+    ...(thread.resume_requested_at ? { resumeRequestedAt: thread.resume_requested_at } : {}),
+    ...(thread.resume_completed_at ? { resumeCompletedAt: thread.resume_completed_at } : {}),
+    ...(thread.resume_failed_at ? { resumeFailedAt: thread.resume_failed_at } : {}),
+    ...(thread.resume_failure_reason ? { resumeFailureReason: thread.resume_failure_reason } : {}),
   };
 }
 
@@ -117,7 +238,27 @@ export function normalizeSubagentTrackingState(input: unknown): SubagentTracking
           ? candidate.turn_count
           : 1,
         ...(typeof candidate.mode === 'string' && candidate.mode.trim().length > 0 ? { mode: candidate.mode } : {}),
+        ...(typeof candidate.role === 'string' && candidate.role.trim().length > 0 ? { role: candidate.role.trim() } : {}),
+        ...(typeof candidate.lane_id === 'string' && candidate.lane_id.trim().length > 0 ? { lane_id: candidate.lane_id.trim() } : {}),
+        ...(typeof candidate.scope === 'string' && candidate.scope.trim().length > 0 ? { scope: candidate.scope.trim() } : {}),
+        ...(typeof candidate.agent_nickname === 'string' && candidate.agent_nickname.trim().length > 0 ? { agent_nickname: candidate.agent_nickname.trim() } : {}),
         ...(typeof candidate.completion_source === 'string' && candidate.completion_source.trim().length > 0 ? { completion_source: candidate.completion_source } : {}),
+        ...(normalizeSubagentStatus(candidate.status) ? { status: normalizeSubagentStatus(candidate.status) } : {}),
+        ...(typeof candidate.last_handoff_summary === 'string' && candidate.last_handoff_summary.trim().length > 0
+          ? { last_handoff_summary: candidate.last_handoff_summary.trim() }
+          : {}),
+        ...(typeof candidate.resume_requested_at === 'string' && candidate.resume_requested_at.trim().length > 0
+          ? { resume_requested_at: candidate.resume_requested_at.trim() }
+          : {}),
+        ...(typeof candidate.resume_completed_at === 'string' && candidate.resume_completed_at.trim().length > 0
+          ? { resume_completed_at: candidate.resume_completed_at.trim() }
+          : {}),
+        ...(typeof candidate.resume_failed_at === 'string' && candidate.resume_failed_at.trim().length > 0
+          ? { resume_failed_at: candidate.resume_failed_at.trim() }
+          : {}),
+        ...(typeof candidate.resume_failure_reason === 'string' && candidate.resume_failure_reason.trim().length > 0
+          ? { resume_failure_reason: candidate.resume_failure_reason.trim() }
+          : {}),
       };
     }
 
@@ -207,6 +348,11 @@ export function recordSubagentTurn(
     : requestedKind === 'leader' && existingKind === 'subagent'
       ? 'subagent'
       : requestedKind ?? (threadId === leaderThreadId ? 'leader' : existingKind ?? 'subagent');
+  const requestedStatus = normalizeSubagentStatus(input.status);
+  const preservedStatus = normalizeSubagentStatus(existingThread?.status);
+  const status = requestedStatus
+    ?? (input.completed ? 'closed' : undefined)
+    ?? preservedStatus;
   const nextThread: TrackedSubagentThread = {
     thread_id: threadId,
     kind,
@@ -222,6 +368,28 @@ export function recordSubagentTurn(
         }
       : {}),
     ...(input.mode?.trim() ? { mode: input.mode.trim() } : existingThread?.mode ? { mode: existingThread.mode } : {}),
+    ...(input.role?.trim() ? { role: input.role.trim() } : existingThread?.role ? { role: existingThread.role } : {}),
+    ...(input.laneId?.trim() ? { lane_id: input.laneId.trim() } : existingThread?.lane_id ? { lane_id: existingThread.lane_id } : {}),
+    ...(input.scope?.trim() ? { scope: input.scope.trim() } : existingThread?.scope ? { scope: existingThread.scope } : {}),
+    ...(input.agentNickname?.trim()
+      ? { agent_nickname: input.agentNickname.trim() }
+      : existingThread?.agent_nickname ? { agent_nickname: existingThread.agent_nickname } : {}),
+    ...(status ? { status } : {}),
+    ...(input.lastHandoffSummary?.trim()
+      ? { last_handoff_summary: input.lastHandoffSummary.trim() }
+      : existingThread?.last_handoff_summary ? { last_handoff_summary: existingThread.last_handoff_summary } : {}),
+    ...(input.resumeRequestedAt?.trim()
+      ? { resume_requested_at: input.resumeRequestedAt.trim() }
+      : existingThread?.resume_requested_at ? { resume_requested_at: existingThread.resume_requested_at } : {}),
+    ...(input.resumeCompletedAt?.trim()
+      ? { resume_completed_at: input.resumeCompletedAt.trim() }
+      : existingThread?.resume_completed_at ? { resume_completed_at: existingThread.resume_completed_at } : {}),
+    ...(input.resumeFailedAt?.trim()
+      ? { resume_failed_at: input.resumeFailedAt.trim() }
+      : existingThread?.resume_failed_at ? { resume_failed_at: existingThread.resume_failed_at } : {}),
+    ...(input.resumeFailureReason?.trim()
+      ? { resume_failure_reason: input.resumeFailureReason.trim() }
+      : existingThread?.resume_failure_reason ? { resume_failure_reason: existingThread.resume_failure_reason } : {}),
   };
 
   const threads = {
@@ -277,6 +445,21 @@ export function summarizeSubagentSession(
     if (!Number.isFinite(seenAt)) return false;
     return nowMs - seenAt <= activeWindowMs;
   });
+  const activeSubagentThreadIdSet = new Set(activeSubagentThreadIds);
+  const savedSubagents = allSubagentThreadIds.map((threadId): SubagentResumeEntry => {
+    const thread = session.threads[threadId]!;
+    const role = thread.role ?? thread.mode;
+    const laneId = thread.lane_id ?? thread.agent_nickname ?? role;
+    return {
+      agentId: thread.thread_id,
+      threadId: thread.thread_id,
+      ...(role ? { role } : {}),
+      ...(laneId ? { laneId } : {}),
+      ...(thread.scope ? { scope: thread.scope } : {}),
+      ...(thread.agent_nickname ? { agentNickname: thread.agent_nickname } : {}),
+      status: activeSubagentThreadIdSet.has(threadId) ? 'available' : 'closed',
+    };
+  });
 
   return {
     sessionId,
@@ -284,8 +467,91 @@ export function summarizeSubagentSession(
     allThreadIds,
     allSubagentThreadIds,
     activeSubagentThreadIds,
+    savedSubagents,
     updatedAt: session.updated_at,
   };
+}
+
+export function buildSubagentResumeLedger(
+  state: SubagentTrackingState,
+  sessionId: string,
+  options: { now?: string | Date; activeWindowMs?: number } = {},
+): SubagentResumeLedger | null {
+  const summary = summarizeSubagentSession(state, sessionId, options);
+  if (!summary) return null;
+
+  const normalized = normalizeSubagentTrackingState(state);
+  const session = normalized.sessions[sessionId];
+  if (!session) return null;
+
+  const activeSubagentThreadIdSet = new Set(summary.activeSubagentThreadIds);
+  const savedSubagents = summary.savedSubagents.map((entry): SubagentLedgerEntry => {
+    const thread = session.threads[entry.threadId];
+    if (!thread) return { ...entry } as SubagentLedgerEntry;
+    const computedStatus = thread.status ?? entry.status;
+    const active = activeSubagentThreadIdSet.has(entry.threadId);
+    return normalizeLedgerEntry(thread, computedStatus, active);
+  });
+
+  const resumeTargets = [...savedSubagents].sort(compareResumeEntries);
+  const unavailableSubagents = savedSubagents.filter((entry) => entry.status === 'unavailable');
+
+  return {
+    ...summary,
+    savedSubagents,
+    resumeTargets,
+    unavailableSubagents,
+  };
+}
+
+export async function readSubagentSessionLedger(
+  cwd: string,
+  sessionId: string,
+  options: { now?: string | Date; activeWindowMs?: number } = {},
+): Promise<SubagentResumeLedger | null> {
+  return buildSubagentResumeLedger(await readSubagentTrackingState(cwd), sessionId, options);
+}
+
+export function selectReusableSubagentEntry(
+  entries: readonly SubagentLedgerEntry[],
+  criteria: {
+    role?: string;
+    laneId?: string;
+    scope?: string;
+    agentNickname?: string;
+  } = {},
+): SubagentLedgerEntry | null {
+  const normalizedRole = readOptionalTrimmedString(criteria.role);
+  const normalizedLaneId = readOptionalTrimmedString(criteria.laneId);
+  const normalizedScope = readOptionalTrimmedString(criteria.scope);
+  const normalizedAgentNickname = readOptionalTrimmedString(criteria.agentNickname);
+
+  const scoredEntries = entries
+    .map((entry, index) => {
+      const statusRank = rankSubagentStatus(entry.status);
+      let score = 0;
+      if (entry.status === 'available') score += 100;
+      else if (entry.status === 'closed') score += 60;
+      else score -= 100;
+
+      if (normalizedRole && entry.role === normalizedRole) score += 30;
+      if (normalizedLaneId && entry.laneId === normalizedLaneId) score += 24;
+      if (normalizedScope && entry.scope === normalizedScope) score += 18;
+      if (normalizedAgentNickname && entry.agentNickname === normalizedAgentNickname) score += 12;
+      if (entry.lastSeenAt) score += 6;
+      if (entry.lastHandoffSummary) score += 4;
+
+      return { entry, index, score, statusRank };
+    })
+    .sort((left, right) => {
+      if (right.score !== left.score) return right.score - left.score;
+      if (left.statusRank !== right.statusRank) return left.statusRank - right.statusRank;
+      const leftActivity = compareOptionalTimestampDesc(left.entry.lastSeenAt, right.entry.lastSeenAt);
+      if (leftActivity !== 0) return leftActivity;
+      return left.index - right.index;
+    });
+
+  return scoredEntries[0]?.entry ?? null;
 }
 
 export async function readSubagentSessionSummary(

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -526,7 +526,15 @@ export function selectReusableSubagentEntry(
   const normalizedScope = readOptionalTrimmedString(criteria.scope);
   const normalizedAgentNickname = readOptionalTrimmedString(criteria.agentNickname);
 
-  const scoredEntries = entries
+  const matchingEntries = entries.filter((entry) => {
+    if (normalizedRole && entry.role !== normalizedRole) return false;
+    if (normalizedLaneId && entry.laneId !== normalizedLaneId) return false;
+    if (normalizedScope && entry.scope !== normalizedScope) return false;
+    if (normalizedAgentNickname && entry.agentNickname !== normalizedAgentNickname) return false;
+    return true;
+  });
+
+  const scoredEntries = matchingEntries
     .map((entry, index) => {
       const statusRank = rankSubagentStatus(entry.status);
       let score = 0;

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -527,6 +527,7 @@ export function selectReusableSubagentEntry(
   const normalizedAgentNickname = readOptionalTrimmedString(criteria.agentNickname);
 
   const matchingEntries = entries.filter((entry) => {
+    if (entry.status === 'unavailable') return false;
     if (normalizedRole && entry.role !== normalizedRole) return false;
     if (normalizedLaneId && entry.laneId !== normalizedLaneId) return false;
     if (normalizedScope && entry.scope !== normalizedScope) return false;

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -350,10 +350,13 @@ export function recordSubagentTurn(
       : requestedKind ?? (threadId === leaderThreadId ? 'leader' : existingKind ?? 'subagent');
   const requestedStatus = normalizeSubagentStatus(input.status);
   const preservedStatus = normalizeSubagentStatus(existingThread?.status);
+  const preserveCompletionEvidence = input.preserveCompletionEvidence === true;
+  const clearsPriorCompletion = input.completed !== true
+    && preserveCompletionEvidence !== true
+    && Boolean(existingThread?.completed_at);
   const status = requestedStatus
     ?? (input.completed ? 'closed' : undefined)
-    ?? preservedStatus;
-  const preserveCompletionEvidence = input.preserveCompletionEvidence === true;
+    ?? (clearsPriorCompletion ? undefined : preservedStatus);
   const preservedCompletion = preserveCompletionEvidence && existingThread?.completed_at
     ? {
         completed_at: existingThread.completed_at,
@@ -449,6 +452,8 @@ export function summarizeSubagentSession(
     const thread = session.threads[threadId];
     if (!thread) return false;
     if (thread.completed_at) return false;
+    const status = normalizeSubagentStatus(thread.status);
+    if (status === 'closed' || status === 'unavailable') return false;
     const seenAt = Date.parse(thread.last_seen_at);
     if (!Number.isFinite(seenAt)) return false;
     return nowMs - seenAt <= activeWindowMs;

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -63,6 +63,7 @@ export interface RecordSubagentTurnInput {
   resumeCompletedAt?: string;
   resumeFailedAt?: string;
   resumeFailureReason?: string;
+  preserveCompletionEvidence?: boolean;
 }
 
 export interface SubagentSessionSummary {
@@ -353,6 +354,14 @@ export function recordSubagentTurn(
   const status = requestedStatus
     ?? (input.completed ? 'closed' : undefined)
     ?? preservedStatus;
+  const preserveCompletionEvidence = input.preserveCompletionEvidence === true;
+  const preservedCompletion = preserveCompletionEvidence && existingThread?.completed_at
+    ? {
+        completed_at: existingThread.completed_at,
+        ...(existingThread.last_completed_turn_id ? { last_completed_turn_id: existingThread.last_completed_turn_id } : {}),
+        ...(existingThread.completion_source ? { completion_source: existingThread.completion_source } : {}),
+      }
+    : {};
   const nextThread: TrackedSubagentThread = {
     thread_id: threadId,
     kind,
@@ -366,7 +375,7 @@ export function recordSubagentTurn(
           ...(input.turnId?.trim() ? { last_completed_turn_id: input.turnId.trim() } : {}),
           ...(input.completionSource?.trim() ? { completion_source: input.completionSource.trim() } : {}),
         }
-      : {}),
+      : preservedCompletion),
     ...(input.mode?.trim() ? { mode: input.mode.trim() } : existingThread?.mode ? { mode: existingThread.mode } : {}),
     ...(input.role?.trim() ? { role: input.role.trim() } : existingThread?.role ? { role: existingThread.role } : {}),
     ...(input.laneId?.trim() ? { lane_id: input.laneId.trim() } : existingThread?.lane_id ? { lane_id: existingThread.lane_id } : {}),
@@ -457,7 +466,7 @@ export function summarizeSubagentSession(
       ...(laneId ? { laneId } : {}),
       ...(thread.scope ? { scope: thread.scope } : {}),
       ...(thread.agent_nickname ? { agentNickname: thread.agent_nickname } : {}),
-      status: activeSubagentThreadIdSet.has(threadId) ? 'available' : 'closed',
+      status: thread.status ?? (activeSubagentThreadIdSet.has(threadId) ? 'available' : 'closed'),
     };
   });
 

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -163,7 +163,6 @@ function compareResumeEntries(left: SubagentLedgerEntry, right: SubagentLedgerEn
 function normalizeLedgerEntry(
   thread: TrackedSubagentThread,
   status: SubagentAvailabilityStatus,
-  active: boolean,
 ): SubagentLedgerEntry {
   const role = thread.role ?? thread.mode;
   const laneId = thread.lane_id ?? thread.agent_nickname ?? role;
@@ -174,7 +173,7 @@ function normalizeLedgerEntry(
     ...(laneId ? { laneId } : {}),
     ...(thread.scope ? { scope: thread.scope } : {}),
     ...(thread.agent_nickname ? { agentNickname: thread.agent_nickname } : {}),
-    status: active && status !== 'unavailable' ? 'available' : status === 'available' ? 'available' : status,
+    status,
     ...(thread.last_seen_at ? { lastSeenAt: thread.last_seen_at } : {}),
     ...(thread.completed_at ? { completedAt: thread.completed_at } : {}),
     ...(thread.last_handoff_summary ? { lastHandoffSummary: thread.last_handoff_summary } : {}),
@@ -493,13 +492,11 @@ export function buildSubagentResumeLedger(
   const session = normalized.sessions[sessionId];
   if (!session) return null;
 
-  const activeSubagentThreadIdSet = new Set(summary.activeSubagentThreadIds);
   const savedSubagents = summary.savedSubagents.map((entry): SubagentLedgerEntry => {
     const thread = session.threads[entry.threadId];
     if (!thread) return { ...entry } as SubagentLedgerEntry;
     const computedStatus = thread.status ?? entry.status;
-    const active = activeSubagentThreadIdSet.has(entry.threadId);
-    return normalizeLedgerEntry(thread, computedStatus, active);
+    return normalizeLedgerEntry(thread, computedStatus);
   });
 
   const resumeTargets = [...savedSubagents].sort(compareResumeEntries);

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -20,6 +20,7 @@ import {
   type UltragoalPlan,
   type UltragoalSteeringProposal,
 } from '../artifacts.js';
+import { LEADER_CONDUCTOR_BLOCK } from '../../leader/contract.js';
 import { steeringFixtures, type SteeringFixtureProposal } from './steering-fixtures.js';
 
 async function withTempRepo<T>(run: (cwd: string) => Promise<T>): Promise<T> {
@@ -52,6 +53,10 @@ function cleanQualityGate(): object {
     },
 
   };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 async function writeFixturePlan(cwd: string, plan: UltragoalPlan): Promise<void> {
@@ -280,6 +285,7 @@ describe('ultragoal artifacts', () => {
       assert.match(instruction, /Complete the durable ultragoal plan/);
       assert.match(instruction, /including later accepted\/appended stories/);
       assert.match(instruction, /\.omx\/ultragoal\/ledger\.jsonl/);
+      assert.match(instruction, new RegExp(escapeRegExp(LEADER_CONDUCTOR_BLOCK)));
       assert.match(instruction, /Complete first milestone/);
       assert.match(instruction, /does not call \/goal clear/);
       assert.match(instruction, /manually run \/goal clear/);
@@ -301,6 +307,7 @@ describe('ultragoal artifacts', () => {
       assert.match(aggregateInstruction, /independentReview evidence from both code-reviewer and architect subagents/);
       assert.match(aggregateInstruction, /independent delegation is unavailable\/skipped\/failed, do not call update_goal/);
       assert.match(aggregateInstruction, /APPROVE \+ CLEAR \+ independent code-reviewer and architect subagent evidence/);
+      assert.match(aggregateInstruction, new RegExp(escapeRegExp(LEADER_CONDUCTOR_BLOCK)));
 
       await createUltragoalPlan(cwd, {
         brief: 'brief',
@@ -314,6 +321,7 @@ describe('ultragoal artifacts', () => {
       assert.match(perStoryInstruction, /independentReview evidence from both code-reviewer and architect subagents/);
       assert.match(perStoryInstruction, /independent delegation is unavailable\/skipped\/failed, do not call update_goal/);
       assert.match(perStoryInstruction, /APPROVE \+ CLEAR \+ independent code-reviewer and architect subagent evidence/);
+      assert.match(perStoryInstruction, new RegExp(escapeRegExp(LEADER_CONDUCTOR_BLOCK)));
     });
   });
 

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -7,6 +7,7 @@ import {
   parseCodexGoalSnapshot,
   reconcileCodexGoalSnapshot,
 } from '../goal-workflows/codex-goal-snapshot.js';
+import { LEADER_CONDUCTOR_BLOCK } from '../leader/contract.js';
 
 export const ULTRAGOAL_DIR = '.omx/ultragoal';
 export const ULTRAGOAL_BRIEF = 'brief.md';
@@ -1822,6 +1823,8 @@ function buildPerStoryCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalP
   };
   const finalStory = isFinalRunCompletionCandidate(plan, goal);
   return [
+    LEADER_CONDUCTOR_BLOCK,
+    '',
     'Ultragoal active-goal handoff',
     `Plan: ${plan.goalsPath}`,
     `Ledger: ${plan.ledgerPath}`,
@@ -1875,6 +1878,8 @@ function buildAggregateCodexGoalInstruction(goal: UltragoalItem, plan: Ultragoal
   const createPayload = { objective };
   const checkpointStatus = finalStory ? 'complete' : 'active';
   return [
+    LEADER_CONDUCTOR_BLOCK,
+    '',
     'Ultragoal aggregate-goal handoff',
     `Plan: ${plan.goalsPath}`,
     `Ledger: ${plan.ledgerPath}`,


### PR DESCRIPTION
### Why this PR exists

This PR is not about cosmetics or wording polish. It fixes a **runtime/conduct problem** in OMX: when the Main agent is in **Conductor** mode, it must behave like an orchestrator, not like a performer that directly edits code or planning artifacts.

In short, this change makes the philosophy **enforceable at runtime** instead of leaving it as text-only guidance.

---

### What spec and rules this PR is based on

The primary source of truth is the plan:

- `.omx/plans/ultragoal-ralph-conductor-fix-plan.md`

That plan fixes three core requirements:

1. **Conductor Philosophy**: the Main agent is the conductor, not the performer.
2. **Golden Rule**: when the Main agent is acting in Conductor mode, it must **not** make plan/code changes directly; it must **delegate**.
3. **Silver Rule**: reuse already-created specialized subagents whenever possible instead of spawning new ones unnecessarily.

The plan also explicitly requires:

- a tracker-backed ledger for subagent ownership and reuse;
- reuse/resume of the same `agent_id` when role/lane/scope are unchanged;
- typed subagents must **not** be treated as Conductor.

So this is not just a style preference. It is a **behavioral contract**.

---

### What this PR changes

#### 1) Canonical contract for Conductor mode

`src/leader/contract.ts` now contains a single canonical contract:

- **Golden Rule**: Main-root Conductor must not directly make plan/code changes.
- **Silver Rule**: reuse/resume specialized agents whenever possible.
- plus delegation and reuse/ledger guidance.

This matters because the same meaning is no longer spread across multiple prompts. It now lives as one source of truth.

#### 2) Reuse guidance is injected into Ralph launch instructions

`src/cli/ralph.ts` now includes the reuse/ledger guidance alongside the main Conductor block so that the launcher actually communicates both parts of the contract:

- the Main agent is the conductor, not the performer;
- Main should resume/reuse already-created specialists before spawning replacements.

That keeps the Silver Rule visible at the point where the Conductor session starts.

#### 3) Reusable subagent ledger

`src/subagents/tracker.ts` now behaves more like a real ledger for follow-up work:

- `status`: `available | closed | unavailable`
- `last_handoff_summary`
- resume/reconnect metadata
- helper functions to build a reusable ledger and select the best existing instance

The intent is simple:

- if an `architect`, `critic`, `executor`, `planner`, `verifier`, `code-reviewer`, `scholastic`, or `test-engineer` already handled a particular role/lane/scope, then follow-up work should go back to the **same instance** whenever possible;
- if there are parallel lanes, multiple instances of the same role are allowed, but the Conductor must disambiguate them through the ledger.

That is the engineering version of the Silver Rule.

---

### What changes in behavior

#### Main-root Conductor now actually stays Conductor

For `ralph`, `ralplan`, `ultragoal`, and the relevant conductor sub-phases, the Main agent should no longer behave like an implementation performer or directly edit source.

#### Typed subagents remain typed subagents

`planner`, `executor`, `architect`, `critic`, `scholastic`, and the other specialized agents do **not** inherit the Conductor block as if they were the Main runtime.

This is essential: **Planner is a specialized subagent**, not a second Conductor. Conductor is a temporary runtime role for the Main agent only.

#### Reuse instead of respawn

If there is already a live/compatible instance for the same role + lane + scope, the system should return to the same `agent_id` rather than spawning yet another one.

That reduces:

- context drift,
- token waste,
- the chance that a new agent re-litigates the same review from scratch,
- the risk of divergent review feedback across different instances of the same role.

---

### What reviewers should focus on

Please look at these three things in particular:

1. **The runtime contract reaches Ralph launch instructions**, not just a helper constant.
2. **Typed subagents do not inherit the conductor block.**
3. **Ledger / reuse semantics**:
   - same role/lane/scope → same reusable agent when available;
   - unavailable/closed → new instances only when necessary;
   - parallel lanes are distinguished by the ledger.

### Validation already run

I already ran:

```bash
npm run build
node --test dist/cli/__tests__/ralph-goal-mode-contract.test.js dist/subagents/__tests__/tracker.test.js
```

Result: **14 passed, 0 failed**.

### Bottom line

This PR makes the OMX conductor/reuse contract **operational**, not just declarative:

- **Golden Rule** keeps the Main-root Conductor from directly modifying code or plans;
- **Silver Rule** keeps the system from endlessly respawning duplicate specialists;
- the runtime wiring and reusable ledger make that durable across long sessions, restarts, and review/rework cycles.
