### PR TITLE
[codex] Harden ralplan consensus review evidence

### DIFF
--- a/src/ralplan/__tests__/runtime.test.ts
+++ b/src/ralplan/__tests__/runtime.test.ts
@@ -210,8 +210,160 @@ describe('ralplan runtime', () => {
 
       assert.equal(result.status, 'failed');
       assert.equal(result.ralplanConsensusGate.complete, false);
-      assert.equal(result.ralplanConsensusGate.blocked_reason, 'native_subagent_consensus_evidence_missing');
-      assert.equal(result.error, 'ralplan_consensus_not_reached_after_1_iterations');
+      assert.equal(result.ralplanConsensusGate.blocked_reason, 'architect_review_missing_or_not_approved');
+      assert.match(result.error || '', /ralplan_architect_review_role_missing/);
+      assert.equal(result.architectReviews.length, 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects planner-as-architect review role when native evidence is required', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-runtime-planner-as-architect-'));
+    const sessionId = 'sess-ralplan-planner-as-architect';
+    try {
+      await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
+      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+
+      const result = await runRalplanConsensus({
+        async draft() {
+          const plansDir = join(cwd, '.omx', 'plans');
+          await mkdir(plansDir, { recursive: true });
+          const prdPath = join(plansDir, 'prd-planner-as-architect.md');
+          await writeFile(prdPath, '# plan\n');
+          await writeFile(join(plansDir, 'test-spec-planner-as-architect.md'), '# tests\n');
+          return { summary: 'draft', planPath: prdPath };
+        },
+        async architectReview() {
+          return {
+            verdict: 'approve',
+            summary: 'planner incorrectly reported as architect',
+            provenance_kind: 'native_subagent',
+            session_id: sessionId,
+            thread_id: 'thread-architect',
+            agent_role: 'planner' as never,
+          };
+        },
+        async criticReview() {
+          return { verdict: 'approve', summary: 'should not run', agent_role: 'critic' };
+        },
+      }, {
+        task: 'reject planner-as-architect native review',
+        cwd,
+        sessionId,
+        maxIterations: 1,
+        requireNativeSubagents: true,
+      });
+
+      assert.equal(result.status, 'failed');
+      assert.match(result.error || '', /ralplan_architect_review_role_mismatch/);
+      assert.equal(result.architectReviews.length, 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects native/thread-backed missing-role reviews instead of rewriting them into consensus roles', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-runtime-native-missing-role-'));
+    const sessionId = 'sess-ralplan-native-missing-role';
+    try {
+      await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
+      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeNativeSubagentTracking(cwd, sessionId);
+
+      const result = await runRalplanConsensus({
+        async draft() {
+          const plansDir = join(cwd, '.omx', 'plans');
+          await mkdir(plansDir, { recursive: true });
+          const prdPath = join(plansDir, 'prd-native-missing-role.md');
+          await writeFile(prdPath, '# plan\n');
+          await writeFile(join(plansDir, 'test-spec-native-missing-role.md'), '# tests\n');
+          return { summary: 'draft', planPath: prdPath };
+        },
+        async architectReview() {
+          return {
+            verdict: 'approve',
+            summary: 'native architect omitted role',
+            provenance_kind: 'native_subagent',
+            session_id: sessionId,
+            thread_id: 'thread-architect',
+            tracker_path: '.omx/state/subagent-tracking.json',
+          };
+        },
+        async criticReview() {
+          return {
+            verdict: 'approve',
+            summary: 'native critic ok',
+            provenance_kind: 'native_subagent',
+            session_id: sessionId,
+            thread_id: 'thread-critic',
+            agent_role: 'critic',
+            tracker_path: '.omx/state/subagent-tracking.json',
+          };
+        },
+      }, {
+        task: 'reject native missing-role review',
+        cwd,
+        sessionId,
+        maxIterations: 1,
+        requireNativeSubagents: true,
+      });
+
+      assert.equal(result.status, 'failed');
+      assert.match(result.error || '', /ralplan_architect_review_role_missing/);
+      assert.equal(result.architectReviews.length, 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves existing tracker completion for review threads without native-required mode', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-runtime-preserve-completion-'));
+    const sessionId = 'sess-ralplan-preserve-completion';
+    const completedAt = '2026-05-28T00:00:00.000Z';
+    try {
+      await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
+      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeNativeSubagentTracking(cwd, sessionId);
+
+      const result = await runRalplanConsensus({
+        async draft() {
+          const plansDir = join(cwd, '.omx', 'plans');
+          await mkdir(plansDir, { recursive: true });
+          const prdPath = join(plansDir, 'prd-preserve-completion.md');
+          await writeFile(prdPath, '# plan\n');
+          await writeFile(join(plansDir, 'test-spec-preserve-completion.md'), '# tests\n');
+          return { summary: 'draft', planPath: prdPath };
+        },
+        async architectReview() {
+          return {
+            verdict: 'approve',
+            summary: 'architect ok',
+            thread_id: 'thread-architect',
+            agent_role: 'architect',
+          };
+        },
+        async criticReview() {
+          return {
+            verdict: 'approve',
+            summary: 'critic ok',
+            thread_id: 'thread-critic',
+            agent_role: 'critic',
+          };
+        },
+      }, {
+        task: 'preserve existing review completion evidence',
+        cwd,
+        sessionId,
+        maxIterations: 1,
+      });
+
+      assert.equal(result.status, 'completed');
+      const tracking = JSON.parse(await readFile(subagentTrackingPath(cwd), 'utf-8')) as {
+        sessions?: Record<string, { threads?: Record<string, { completed_at?: string }> }>;
+      };
+      assert.equal(tracking.sessions?.[sessionId]?.threads?.['thread-architect']?.completed_at, completedAt);
+      assert.equal(tracking.sessions?.[sessionId]?.threads?.['thread-critic']?.completed_at, completedAt);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/ralplan/runtime.ts
+++ b/src/ralplan/runtime.ts
@@ -35,7 +35,7 @@ export interface RalplanReviewResult {
   thread_id?: string;
   native_session_id?: string;
   artifact_path?: string;
-  agent_role?: 'planner' | 'architect' | 'critic';
+  agent_role?: 'architect' | 'critic';
   lane_id?: string;
   tracker_path?: string;
 }
@@ -242,6 +242,28 @@ function buildRalplanConsensusGate(
   };
 }
 
+
+function hasNativeOrThreadEvidence(review: RalplanReviewResult): boolean {
+  return review.provenance_kind === 'native_subagent'
+    || Boolean(review.thread_id?.trim())
+    || Boolean(review.native_session_id?.trim())
+    || Boolean(review.tracker_path?.trim());
+}
+
+function normalizeReviewForLane(
+  review: RalplanReviewResult,
+  laneRole: 'architect' | 'critic',
+  options: { requireNativeSubagents?: boolean },
+): RalplanReviewResult {
+  if (review.agent_role !== undefined && review.agent_role !== laneRole) {
+    throw new Error(`ralplan_${laneRole}_review_role_mismatch: expected agent_role=${laneRole}, received ${String(review.agent_role)}`);
+  }
+  if (review.agent_role === undefined && (options.requireNativeSubagents || hasNativeOrThreadEvidence(review))) {
+    throw new Error(`ralplan_${laneRole}_review_role_missing: native or thread-backed ${laneRole} review must declare agent_role=${laneRole}`);
+  }
+  return { ...review, agent_role: laneRole };
+}
+
 async function updateRalplanState(
   cwd: string,
   updates: RalplanModeUpdates,
@@ -314,10 +336,10 @@ export async function runRalplanConsensus(
         ralplan_consensus_gate: buildRalplanConsensusGate(architectReviews, criticReviews, gateOptions),
         review_history: buildReviewHistory(drafts, architectReviews, criticReviews),
       });
-      const architectReview = await executor.architectReview({
+      const architectReview = normalizeReviewForLane(await executor.architectReview({
         ...iterationContext,
         draft,
-      });
+      }), 'architect', gateOptions);
       architectReviews.push(architectReview);
       if (architectReview.artifacts) Object.assign(aggregatedArtifacts, architectReview.artifacts);
       await recordRalplanSubagentTurn(cwd, options.sessionId, {
@@ -326,7 +348,7 @@ export async function runRalplanConsensus(
         laneId: architectReview.lane_id,
         scope: options.task,
         summary: architectReview.summary,
-        preserveCompletionEvidence: Boolean(options.requireNativeSubagents),
+        preserveCompletionEvidence: true,
       });
 
       if (architectReview.verdict !== 'approve') {
@@ -384,11 +406,11 @@ export async function runRalplanConsensus(
         ralplan_consensus_gate: buildRalplanConsensusGate(architectReviews, criticReviews, gateOptions),
         review_history: buildReviewHistory(drafts, architectReviews, criticReviews),
       });
-      const criticReview = await executor.criticReview({
+      const criticReview = normalizeReviewForLane(await executor.criticReview({
         ...iterationContext,
         draft,
         architectReview,
-      });
+      }), 'critic', gateOptions);
       criticReviews.push(criticReview);
       if (criticReview.artifacts) Object.assign(aggregatedArtifacts, criticReview.artifacts);
       await recordRalplanSubagentTurn(cwd, options.sessionId, {
@@ -397,7 +419,7 @@ export async function runRalplanConsensus(
         laneId: criticReview.lane_id,
         scope: options.task,
         summary: criticReview.summary,
-        preserveCompletionEvidence: Boolean(options.requireNativeSubagents),
+        preserveCompletionEvidence: true,
       });
 
       const reviewHistory = buildReviewHistory(drafts, architectReviews, criticReviews);


### PR DESCRIPTION
## Summary

Post-merge follow-up for #3040 review comments. This PR carries the previously local two-file fix from `ac55e4c8` onto current `origin/dev` after #3040 merged as `ffd1cb8c`.

This is limited to ralplan consensus review evidence hardening. It is not part of the shell/parser guard scope, and it does not recreate the deleted Slice A/B/C/D branch naming.

## Follow-up comments

- https://github.com/Yeachan-Heo/oh-my-codex/pull/3040#discussion_r3510116125 — reject planner roles in consensus reviews.
- https://github.com/Yeachan-Heo/oh-my-codex/pull/3040#discussion_r3510116130 — preserve completed native reviews during bookkeeping.

## Validation

- `npm run build`
- `node dist/scripts/run-test-files.js dist/ralplan/__tests__/runtime.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check origin/dev...HEAD`
