### PR TITLE
[codex] Harden conductor contract and typed-lane fences

### DIFF
--- a/src/leader/__tests__/contract.test.ts
+++ b/src/leader/__tests__/contract.test.ts
@@ -7,6 +7,9 @@ import {
   LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE,
   LEADER_CONDUCTOR_REUSE_AND_LEDGER_RULES,
   LEADER_CONDUCTOR_SILVER_RULE,
+  actionKindForConductorArtifact,
+  authorizeConductorAction,
+  classifyConductorArtifactKind,
 } from '../contract.js';
 
 describe('leader conductor contract', () => {
@@ -48,5 +51,46 @@ describe('leader conductor contract', () => {
         '- ralplan consensus planning may activate Conductor; autopilot rework stays exempt.',
       ].join('\n'),
     );
+  });
+
+  it('classifies and authorizes Conductor writes by phase/lane/action/artifact, not path alone', () => {
+    const stateLedger = classifyConductorArtifactKind('.omx/state/sessions/sess-1/subagent-tracking.json');
+    assert.equal(stateLedger, 'ledger');
+    assert.equal(authorizeConductorAction({
+      phase: 'autopilot-supervision',
+      laneKind: 'main-conductor',
+      actionKind: actionKindForConductorArtifact(stateLedger),
+      artifactKind: stateLedger,
+    }).allowed, true);
+
+    const plan = classifyConductorArtifactKind('.omx/plans/conductor-main-root-orchestration-fix.md');
+    assert.equal(plan, 'substantive-plan-spec-interview-review-qa');
+    assert.equal(authorizeConductorAction({
+      phase: 'ralplan',
+      laneKind: 'main-conductor',
+      actionKind: actionKindForConductorArtifact(plan),
+      artifactKind: plan,
+    }).allowed, false);
+    assert.equal(authorizeConductorAction({
+      phase: 'ralplan',
+      laneKind: 'typed-subagent',
+      actionKind: actionKindForConductorArtifact(plan),
+      artifactKind: plan,
+    }).allowed, true);
+
+    const source = classifyConductorArtifactKind('src/scripts/codex-native-hook.ts');
+    assert.equal(source, 'implementation-source-package-git');
+    assert.equal(authorizeConductorAction({
+      phase: 'autopilot-supervision',
+      laneKind: 'main-conductor',
+      actionKind: actionKindForConductorArtifact(source),
+      artifactKind: source,
+    }).allowed, false);
+    assert.equal(authorizeConductorAction({
+      phase: 'autopilot-supervision',
+      laneKind: 'performer-carveout',
+      actionKind: actionKindForConductorArtifact(source),
+      artifactKind: source,
+    }).allowed, true);
   });
 });

--- a/src/leader/__tests__/contract.test.ts
+++ b/src/leader/__tests__/contract.test.ts
@@ -56,6 +56,10 @@ describe('leader conductor contract', () => {
   it('classifies and authorizes Conductor writes by phase/lane/action/artifact, not path alone', () => {
     const stateLedger = classifyConductorArtifactKind('.omx/state/sessions/sess-1/subagent-tracking.json');
     assert.equal(stateLedger, 'ledger');
+    assert.equal(classifyConductorArtifactKind('.omx/state/subagent-tracking.json'), 'ledger');
+    assert.equal(classifyConductorArtifactKind('src/subagent-tracking.json'), 'implementation-source-package-git');
+    assert.equal(classifyConductorArtifactKind('subagent-tracking.json'), 'implementation-source-package-git');
+    assert.equal(classifyConductorArtifactKind('.omx/plans/subagent-tracking.json'), 'substantive-plan-spec-interview-review-qa');
     assert.equal(authorizeConductorAction({
       phase: 'autopilot-supervision',
       laneKind: 'main-conductor',

--- a/src/leader/contract.ts
+++ b/src/leader/contract.ts
@@ -28,3 +28,124 @@ export const LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE = [
   `- ${LEADER_CONDUCTOR_SILVER_RULE}`,
   ...LEADER_CONDUCTOR_REUSE_AND_LEDGER_RULES.map((line) => `- ${line}`),
 ].join('\n');
+
+export type ConductorPhase =
+  | 'deep-interview'
+  | 'ralplan'
+  | 'autopilot-supervision'
+  | 'ultragoal'
+  | 'team'
+  | 'ralph';
+
+export type ConductorLaneKind =
+  | 'main-conductor'
+  | 'typed-subagent'
+  | 'team-worker'
+  | 'performer-carveout';
+
+export type ConductorActionKind =
+  | 'read-only'
+  | 'orchestration-metadata-write'
+  | 'substantive-deliverable-write'
+  | 'implementation-mutation'
+  | 'unknown-write';
+
+export type ConductorArtifactKind =
+  | 'orchestration-metadata'
+  | 'transport'
+  | 'ledger'
+  | 'substantive-plan-spec-interview-review-qa'
+  | 'implementation-source-package-git'
+  | 'unknown';
+
+export interface ConductorAuthorizationInput {
+  phase: ConductorPhase;
+  laneKind: ConductorLaneKind;
+  actionKind: ConductorActionKind;
+  artifactKind: ConductorArtifactKind;
+}
+
+export interface ConductorAuthorizationDecision {
+  allowed: boolean;
+  reason: string;
+}
+
+export const CONDUCTOR_ORCHESTRATION_METADATA_PREFIXES = [
+  '.omx/state',
+  '.omx/ultragoal',
+  '.omx/ralph',
+  '.omx/team',
+  '.omx/mailbox',
+  '.omx/handoff',
+  '.omx/handoffs',
+  '.omx/goals',
+  '.omx/notepad',
+  '.omx/wiki',
+  '.beads',
+] as const;
+
+const CONDUCTOR_SUBSTANTIVE_DELIVERABLE_PREFIXES = [
+  '.omx/context',
+  '.omx/interviews',
+  '.omx/plans',
+  '.omx/specs',
+  '.omx/reviews',
+  '.omx/qa',
+] as const;
+
+export function classifyConductorArtifactKind(relativePath: string): ConductorArtifactKind {
+  const normalized = relativePath.trim().replace(/^\.\//, '').replace(/\\/g, '/');
+  if (!normalized) return 'unknown';
+  if (normalized === '.omx/state/subagent-tracking.json' || /(^|\/)subagent-tracking\.json$/.test(normalized)) {
+    return 'ledger';
+  }
+  if (normalized.startsWith('.omx/state/')) return 'transport';
+  if (CONDUCTOR_ORCHESTRATION_METADATA_PREFIXES.some((prefix) => normalized === prefix || normalized.startsWith(`${prefix}/`))) {
+    return 'orchestration-metadata';
+  }
+  if (CONDUCTOR_SUBSTANTIVE_DELIVERABLE_PREFIXES.some((prefix) => normalized === prefix || normalized.startsWith(`${prefix}/`))) {
+    return 'substantive-plan-spec-interview-review-qa';
+  }
+  if (normalized.startsWith('.omx/')) return 'unknown';
+  return 'implementation-source-package-git';
+}
+
+export function actionKindForConductorArtifact(artifactKind: ConductorArtifactKind): ConductorActionKind {
+  switch (artifactKind) {
+    case 'orchestration-metadata':
+    case 'transport':
+    case 'ledger':
+      return 'orchestration-metadata-write';
+    case 'substantive-plan-spec-interview-review-qa':
+      return 'substantive-deliverable-write';
+    case 'implementation-source-package-git':
+      return 'implementation-mutation';
+    default:
+      return 'unknown-write';
+  }
+}
+
+export function authorizeConductorAction(input: ConductorAuthorizationInput): ConductorAuthorizationDecision {
+  if (input.actionKind === 'read-only') {
+    return { allowed: true, reason: 'read-only actions are outside the write guard' };
+  }
+  if (input.laneKind === 'typed-subagent' || input.laneKind === 'team-worker' || input.laneKind === 'performer-carveout') {
+    return { allowed: true, reason: 'delegated performer lanes are outside Main-root Conductor write restrictions' };
+  }
+  if (input.laneKind !== 'main-conductor') {
+    return { allowed: false, reason: 'unknown lane kind fails closed' };
+  }
+  if (
+    input.actionKind === 'orchestration-metadata-write'
+    && (input.artifactKind === 'orchestration-metadata' || input.artifactKind === 'transport' || input.artifactKind === 'ledger')
+  ) {
+    return { allowed: true, reason: 'Main-root Conductor may write orchestration metadata, transport, and ledger artifacts' };
+  }
+  if (input.actionKind === 'substantive-deliverable-write') {
+    return { allowed: false, reason: 'Main-root Conductor must delegate substantive plan/spec/interview/review/QA deliverables' };
+  }
+  if (input.actionKind === 'implementation-mutation') {
+    return { allowed: false, reason: 'Main-root Conductor must delegate source/package/git implementation mutations' };
+  }
+  return { allowed: false, reason: 'Main-root Conductor write target is unclassified and fails closed' };
+}

--- a/src/leader/contract.ts
+++ b/src/leader/contract.ts
@@ -96,7 +96,7 @@ const CONDUCTOR_SUBSTANTIVE_DELIVERABLE_PREFIXES = [
 export function classifyConductorArtifactKind(relativePath: string): ConductorArtifactKind {
   const normalized = relativePath.trim().replace(/^\.\//, '').replace(/\\/g, '/');
   if (!normalized) return 'unknown';
-  if (normalized === '.omx/state/subagent-tracking.json' || /(^|\/)subagent-tracking\.json$/.test(normalized)) {
+  if (/^\.omx\/state(?:\/.*)?\/subagent-tracking\.json$/.test(normalized)) {
     return 'ledger';
   }
   if (normalized.startsWith('.omx/state/')) return 'transport';

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -10208,7 +10208,7 @@ exit 0
     }
   });
 
-  it("does not block typed agent-role implementation writes under active ralplan", async () => {
+  it("blocks typed agent-role-only implementation writes under active ralplan", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-typed-agent-role-ralplan-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -10252,6 +10252,68 @@ exit 0
           agent_role: "executor",
           tool_name: "Edit",
           tool_use_id: "tool-typed-executor-ralplan-edit",
+          tool_input: { file_path: "src/implementation.ts", old_string: "a", new_string: "b" },
+        },
+        { cwd },
+      );
+      assert.equal(allowedImplementationEdit.outputJson?.decision, "block");
+      assert.match(String(allowedImplementationEdit.outputJson?.reason ?? ""), /Autopilot planning is active \(phase: ralplan\)/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows typed agent-role implementation writes under active ralplan when trusted provenance is present", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-trusted-typed-agent-role-ralplan-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-trusted-typed-executor-ralplan";
+      const sessionDir = join(stateDir, "sessions", sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, cwd });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "autopilot",
+        phase: "ralplan",
+        session_id: sessionId,
+        thread_id: "thread-trusted-typed-executor-ralplan",
+        active_skills: [
+          {
+            skill: "autopilot",
+            phase: "ralplan",
+            active: true,
+            session_id: sessionId,
+            thread_id: "thread-trusted-typed-executor-ralplan",
+          },
+        ],
+      });
+      await writeJson(join(sessionDir, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "ralplan",
+        started_at: "2026-04-19T00:00:00.000Z",
+        updated_at: "2026-04-19T00:10:00.000Z",
+        session_id: sessionId,
+        thread_id: "thread-trusted-typed-executor-ralplan",
+      });
+
+      const allowedImplementationEdit = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-trusted-typed-executor-ralplan",
+          agent_role: "executor",
+          source: {
+            subagent: {
+              thread_spawn: {
+                parent_thread_id: "thread-trusted-typed-executor-ralplan",
+              },
+            },
+          },
+          tool_name: "Edit",
+          tool_use_id: "tool-trusted-typed-executor-ralplan-edit",
           tool_input: { file_path: "src/implementation.ts", old_string: "a", new_string: "b" },
         },
         { cwd },
@@ -20352,6 +20414,127 @@ exit 0
 
       assert.equal(result.outputJson?.decision, "block");
       assert.match(String(result.outputJson?.reason ?? ""), /Main-root Conductor mode is active \(ultragoal phase: planning\)/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks Main-root ralplan writes even when payload has only a typed agent_role", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralplan-agent-role-main-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-ralplan-agent-role-main";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ralplan", "planning");
+      await writeJson(join(stateDir, "sessions", sessionId, "ralplan-state.json"), {
+        active: true,
+        mode: "ralplan",
+        current_phase: "planning",
+        session_id: sessionId,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-agent-role-main",
+          agent_role: "executor",
+          tool_name: "Edit",
+          tool_input: { file_path: "src/runtime.ts" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /Ralplan is active \(phase: planning\)/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks Main-root conductor writes even when payload has only a typed agent_role", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-conductor-agent-role-main-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-conductor-agent-role-main";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ultragoal", "planning");
+      await writeJson(join(stateDir, "sessions", sessionId, "ultragoal-state.json"), {
+        active: true,
+        mode: "ultragoal",
+        current_phase: "planning",
+        session_id: sessionId,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-conductor-agent-role-main",
+          agent_role: "executor",
+          tool_name: "Edit",
+          tool_input: { file_path: "src/runtime.ts" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /Main-root Conductor mode is active \(ultragoal phase: planning\)/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows conductor writes from tracked typed native subagents", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-conductor-tracked-subagent-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-conductor-tracked-subagent";
+      const leaderThreadId = "thread-conductor-leader";
+      const childThreadId = "thread-conductor-child";
+      const nowIso = new Date().toISOString();
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, native_session_id: leaderThreadId });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ultragoal", "planning");
+      await writeJson(join(stateDir, "sessions", sessionId, "ultragoal-state.json"), {
+        active: true,
+        mode: "ultragoal",
+        current_phase: "planning",
+        session_id: sessionId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: leaderThreadId,
+            updated_at: nowIso,
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "leader", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1 },
+              [childThreadId]: { thread_id: childThreadId, kind: "subagent", mode: "executor", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1 },
+            },
+          },
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: childThreadId,
+          agent_role: "executor",
+          tool_name: "Edit",
+          tool_input: { file_path: "src/runtime.ts" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4252,6 +4252,53 @@ standardMaxRounds = 15
     }
   });
 
+  it("treats installed custom native agent roles as typed lanes for prompt submit", async () => {
+    await withIsolatedHome("custom-native-agent-role", async (homeDir) => {
+      const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-custom-agent-role-autopilot-"));
+      try {
+        const agentsDir = join(homeDir, ".codex", "agents");
+        await mkdir(agentsDir, { recursive: true });
+        await writeFile(
+          join(agentsDir, "custom-executor.toml"),
+          [
+            '# oh-my-codex agent: custom-executor',
+            'name = "custom-executor"',
+            'description = "Custom executor lane"',
+          ].join("\n"),
+          "utf-8",
+        );
+        await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+
+        const result = await dispatchCodexNativeHook(
+          {
+            hook_event_name: "UserPromptSubmit",
+            cwd,
+            session_id: "sess-custom-executor",
+            thread_id: "thread-custom-executor",
+            agent_type: "custom-executor",
+            turn_id: "turn-custom-executor",
+            prompt: "$autopilot continue the current implementation lane",
+          },
+          { cwd },
+        );
+
+        assert.equal(result.omxEventName, "keyword-detector");
+        assert.equal(result.skillState, null);
+        assert.equal(result.outputJson, null);
+        assert.equal(
+          existsSync(join(cwd, ".omx", "state", "sessions", "sess-custom-executor", "autopilot-state.json")),
+          false,
+        );
+        assert.equal(
+          existsSync(join(cwd, ".omx", "state", "sessions", "sess-custom-executor", "skill-active-state.json")),
+          false,
+        );
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+  });
+
   it("does not inject Conductor guidance into typed agent-role autopilot continuations", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-typed-agent-role-active-autopilot-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4218,6 +4218,94 @@ standardMaxRounds = 15
     }
   });
 
+  it("does not activate Conductor guidance for typed agent-role prompts without native subagent tracking", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-typed-agent-role-autopilot-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-typed-executor",
+          thread_id: "thread-typed-executor",
+          agent_role: "executor",
+          turn_id: "turn-typed-executor",
+          prompt: "$autopilot continue the current implementation lane",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState, null);
+      assert.equal(result.outputJson, null);
+      assert.equal(
+        existsSync(join(cwd, ".omx", "state", "sessions", "sess-typed-executor", "autopilot-state.json")),
+        false,
+      );
+      assert.equal(
+        existsSync(join(cwd, ".omx", "state", "sessions", "sess-typed-executor", "skill-active-state.json")),
+        false,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not inject Conductor guidance into typed agent-role autopilot continuations", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-typed-agent-role-active-autopilot-"));
+    try {
+      const sessionId = "sess-typed-executor-active";
+      const sessionDir = join(cwd, ".omx", "state", "sessions", sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "autopilot",
+        keyword: "$autopilot",
+        phase: "planning",
+        initialized_mode: "autopilot",
+        initialized_state_path: `.omx/state/sessions/${sessionId}/autopilot-state.json`,
+        session_id: sessionId,
+        active_skills: [
+          { skill: "autopilot", phase: "planning", active: true, session_id: sessionId },
+        ],
+      });
+      await writeJson(join(sessionDir, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "execution",
+        started_at: "2026-04-19T00:00:00.000Z",
+        updated_at: "2026-04-19T00:10:00.000Z",
+        session_id: sessionId,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-typed-executor-active",
+          turn_id: "turn-typed-executor-active",
+          agent_role: "executor",
+          prompt: "keep going now",
+        },
+        { cwd },
+      );
+
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.doesNotMatch(message, /Conductor mode contract:/);
+      assert.doesNotMatch(message, /Golden Rule: When the Main agent is acting in Conductor mode/);
+      assert.doesNotMatch(message, /Conductor reuse and ledger guidance:/);
+      assert.doesNotMatch(message, /typed subagents never receive this block/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not treat a corrupt leader kind=subagent tracker entry as native subagent prompt scope", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-corrupt-leader-subagent-"));
     try {
@@ -4619,6 +4707,10 @@ standardMaxRounds = 15
       assert.match(message, /Do not advance from deep-interview to ralplan merely because the first question was answered/);
       assert.match(message, /Planner output has been reviewed sequentially by Architect and then Critic/);
       assert.match(message, /do not hand off to Ultragoal or implementation until .*ralplan_architect_review.*ralplan_critic_review/);
+      assert.match(message, /Conductor mode contract:/);
+      assert.match(message, /Golden Rule: When the Main agent is acting in Conductor mode/);
+      assert.match(message, /Conductor reuse and ledger guidance:/);
+      assert.match(message, /typed subagents never receive this block/);
 
       const autopilotState = JSON.parse(await readFile(
         join(cwd, ".omx", "state", "sessions", "sess-autopilot-ralplan-gate", "autopilot-state.json"),
@@ -10106,6 +10198,60 @@ exit 0
           thread_id: "thread-autopilot-rework",
           tool_name: "Edit",
           tool_use_id: "tool-autopilot-rework-src-edit",
+          tool_input: { file_path: "src/implementation.ts", old_string: "a", new_string: "b" },
+        },
+        { cwd },
+      );
+      assert.equal(allowedImplementationEdit.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not block typed agent-role implementation writes under active ralplan", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-typed-agent-role-ralplan-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-typed-executor-ralplan";
+      const sessionDir = join(stateDir, "sessions", sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, cwd });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "autopilot",
+        phase: "ralplan",
+        session_id: sessionId,
+        thread_id: "thread-typed-executor-ralplan",
+        active_skills: [
+          {
+            skill: "autopilot",
+            phase: "ralplan",
+            active: true,
+            session_id: sessionId,
+            thread_id: "thread-typed-executor-ralplan",
+          },
+        ],
+      });
+      await writeJson(join(sessionDir, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "ralplan",
+        started_at: "2026-04-19T00:00:00.000Z",
+        updated_at: "2026-04-19T00:10:00.000Z",
+        session_id: sessionId,
+        thread_id: "thread-typed-executor-ralplan",
+      });
+
+      const allowedImplementationEdit = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-typed-executor-ralplan",
+          agent_role: "executor",
+          tool_name: "Edit",
+          tool_use_id: "tool-typed-executor-ralplan-edit",
           tool_input: { file_path: "src/implementation.ts", old_string: "a", new_string: "b" },
         },
         { cwd },
@@ -20271,6 +20417,32 @@ exit 0
         { cwd },
       );
       assert.equal(allowed.outputJson, null);
+
+      const protectedRawState = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralph-conductor-write",
+          tool_name: "Write",
+          tool_input: { file_path: ".omx/state/sessions/sess-ralph-conductor-write/autopilot-state.json" },
+        },
+        { cwd },
+      );
+      assert.equal(protectedRawState.outputJson?.decision, "block");
+
+      const safeTransport = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralph-conductor-write",
+          tool_name: "Bash",
+          tool_input: { command: "omx state write --input '{\"mode\":\"ralph\",\"current_phase\":\"executing\",\"active\":true}' --json" },
+        },
+        { cwd },
+      );
+      assert.equal(safeTransport.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -6149,8 +6149,8 @@ async function buildRalplanPreToolUseBoundaryOutput(
   stateDir: string,
   resolvedSessionId?: string,
 ): Promise<Record<string, unknown> | null> {
-  if (isTypedAgentRolePayload(payload)) return null;
   const sessionId = safeString(resolvedSessionId ?? readPayloadSessionId(payload)).trim();
+  if (await hasIndependentSubagentOrWorkerProvenanceForPreToolUse(payload, cwd, stateDir, sessionId)) return null;
   const threadId = readPayloadThreadId(payload);
   const activeState = await readActiveRalplanStateForPreToolUse(cwd, stateDir, sessionId, threadId);
   if (!activeState) return null;
@@ -6217,8 +6217,8 @@ async function buildDeepInterviewPreToolUseBoundaryOutput(
   stateDir: string,
   resolvedSessionId?: string,
 ): Promise<Record<string, unknown> | null> {
-  if (isTypedAgentRolePayload(payload)) return null;
   const sessionId = safeString(resolvedSessionId ?? readPayloadSessionId(payload)).trim();
+  if (await hasIndependentSubagentOrWorkerProvenanceForPreToolUse(payload, cwd, stateDir, sessionId)) return null;
   const threadId = readPayloadThreadId(payload);
   const activeState = await readActiveDeepInterviewStateForPreToolUse(cwd, stateDir, sessionId, threadId);
   if (!activeState) return null;
@@ -6386,14 +6386,29 @@ interface ActiveConductorState {
   phase: string;
 }
 
-async function isTypedSubagentOrWorkerForPreToolUse(
+function hasTrustedSubagentThreadSpawnPayload(payload: CodexHookPayload): boolean {
+  const source = safeObject(payload.source);
+  const subagent = safeObject(source.subagent);
+  const threadSpawn = safeObject(subagent.thread_spawn);
+  const parentThreadId = safeString(
+    threadSpawn.parent_thread_id
+      ?? threadSpawn.parentThreadId
+      ?? threadSpawn.leader_thread_id
+      ?? threadSpawn.leaderThreadId,
+  ).trim();
+  if (!parentThreadId) return false;
+  const agentRole = readPayloadAgentRole(payload);
+  return agentRole !== "" && KNOWN_TYPED_AGENT_ROLES.has(agentRole);
+}
+
+async function hasIndependentSubagentOrWorkerProvenanceForPreToolUse(
   payload: CodexHookPayload,
   cwd: string,
   stateDir: string,
   sessionId: string,
 ): Promise<boolean> {
   if (hasTeamWorkerEnvironment()) return true;
-  if (isTypedAgentRolePayload(payload)) return true;
+  if (hasTrustedSubagentThreadSpawnPayload(payload)) return true;
   const threadId = readPayloadThreadId(payload);
   const nativeSessionId = readPayloadSessionId(payload);
   const currentSession = await readUsableSessionStateFromStateDir(cwd, stateDir).catch(() => null);
@@ -6427,7 +6442,7 @@ async function readActiveMainRootConductorStateForPreToolUse(
   }
   const threadId = readPayloadThreadId(payload);
   if (!sessionId) return null;
-  if (await isTypedSubagentOrWorkerForPreToolUse(payload, cwd, stateDir, sessionId)) return null;
+  if (await hasIndependentSubagentOrWorkerProvenanceForPreToolUse(payload, cwd, stateDir, sessionId)) return null;
 
   const canonicalState = await readVisibleSkillActiveStateForStateDir(stateDir, sessionId);
   if (!canonicalState) return null;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -88,7 +88,16 @@ import {
   onSessionStart as buildWikiSessionStartContext,
 } from "../wiki/lifecycle.js";
 import { readAutoresearchCompletionStatus, readAutoresearchModeStateForActiveDecision } from "../autoresearch/skill-validation.js";
-import { normalizeAutopilotPhase } from "../autopilot/fsm.js";
+import { AGENT_DEFINITIONS } from "../agents/definitions.js";
+import { deriveAutopilotChildPhase, normalizeAutopilotPhase } from "../autopilot/fsm.js";
+import {
+  CONDUCTOR_ORCHESTRATION_METADATA_PREFIXES,
+  LEADER_CONDUCTOR_BLOCK,
+  LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE,
+  actionKindForConductorArtifact,
+  authorizeConductorAction,
+  classifyConductorArtifactKind,
+} from "../leader/contract.js";
 import { readRunState } from "../runtime/run-state.js";
 import { evaluateRalphCompletionAuditEvidence, isRalphCompletePhase } from "../ralph/completion-audit.js";
 import {
@@ -194,6 +203,7 @@ const RALPH_LIVE_RISK_PATTERNS = [
   /\b(?:database|db|terraform|kubectl|kubernetes|aws|gcp|azure|external|destructive)\b/i,
   /\b(?:telegram|vps|service|restart|send|notify|notification|notifications|cron)\b/i,
 ] as const;
+const KNOWN_TYPED_AGENT_ROLES = new Set(Object.keys(AGENT_DEFINITIONS));
 const RALPH_TASK_TEXT_FIELDS = [
   "task_description",
   "taskDescription",
@@ -2092,6 +2102,8 @@ function buildAutopilotPromptActivationNote(
     "The ralplan phase is not complete until Planner output has been reviewed sequentially by Architect and then Critic; do not hand off to Ultragoal or implementation until the ralplan state/artifact records both ralplan_architect_review and ralplan_critic_review with approval or an explicit blocker.",
     "Do not silently fall back to ordinary $plan/ralplan-only handling; keep autopilot-state.json, skill-active-state.json, HUD/statusline, and Codex goal-mode handoff guidance visible while the workflow is active.",
     "When Codex goal tools are available, call get_goal/create_goal only from the active thread handoff and treat the active goal as the completion contract until code-review and ultraqa are clean.",
+    LEADER_CONDUCTOR_BLOCK,
+    LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE,
   ].filter(Boolean).join(" ");
 }
 
@@ -2109,6 +2121,9 @@ function buildAdditionalContextMessage(
 ): string | null {
   if (!prompt) return null;
   const promptPriorityMessage = buildPromptPriorityMessage(prompt);
+  if (payload && isTypedAgentRolePayload(payload)) {
+    return promptPriorityMessage;
+  }
   const teamMode = readTeamModeConfig(cwd);
   const matches = detectKeywords(prompt).filter((entry) => teamMode.enabled || entry.skill !== "team");
   const match = matches[0] ?? null;
@@ -2982,6 +2997,31 @@ function readPayloadSessionId(payload: CodexHookPayload): string {
 
 function readPayloadThreadId(payload: CodexHookPayload): string {
   return safeString(payload.owner_codex_thread_id ?? payload.thread_id ?? payload.threadId).trim();
+}
+
+function readPayloadAgentRole(payload: CodexHookPayload): string {
+  const directRole = safeString(
+    payload.agent_role
+      ?? payload.agentRole
+      ?? payload.agent_type
+      ?? payload.agentType,
+  ).trim().toLowerCase();
+  if (directRole) return directRole;
+
+  const source = safeObject(payload.source);
+  const subagent = safeObject(source?.subagent);
+  const threadSpawn = safeObject(subagent?.thread_spawn);
+  return safeString(
+    threadSpawn?.agent_role
+      ?? threadSpawn?.agentRole
+      ?? threadSpawn?.agent_type
+      ?? threadSpawn?.agentType,
+  ).trim().toLowerCase();
+}
+
+function isTypedAgentRolePayload(payload: CodexHookPayload): boolean {
+  const agentRole = readPayloadAgentRole(payload);
+  return agentRole !== "" && KNOWN_TYPED_AGENT_ROLES.has(agentRole);
 }
 
 function readPayloadTurnId(payload: CodexHookPayload): string {
@@ -6109,6 +6149,7 @@ async function buildRalplanPreToolUseBoundaryOutput(
   stateDir: string,
   resolvedSessionId?: string,
 ): Promise<Record<string, unknown> | null> {
+  if (isTypedAgentRolePayload(payload)) return null;
   const sessionId = safeString(resolvedSessionId ?? readPayloadSessionId(payload)).trim();
   const threadId = readPayloadThreadId(payload);
   const activeState = await readActiveRalplanStateForPreToolUse(cwd, stateDir, sessionId, threadId);
@@ -6176,6 +6217,7 @@ async function buildDeepInterviewPreToolUseBoundaryOutput(
   stateDir: string,
   resolvedSessionId?: string,
 ): Promise<Record<string, unknown> | null> {
+  if (isTypedAgentRolePayload(payload)) return null;
   const sessionId = safeString(resolvedSessionId ?? readPayloadSessionId(payload)).trim();
   const threadId = readPayloadThreadId(payload);
   const activeState = await readActiveDeepInterviewStateForPreToolUse(cwd, stateDir, sessionId, threadId);
@@ -6351,6 +6393,7 @@ async function isTypedSubagentOrWorkerForPreToolUse(
   sessionId: string,
 ): Promise<boolean> {
   if (hasTeamWorkerEnvironment()) return true;
+  if (isTypedAgentRolePayload(payload)) return true;
   const threadId = readPayloadThreadId(payload);
   const nativeSessionId = readPayloadSessionId(payload);
   const currentSession = await readUsableSessionStateFromStateDir(cwd, stateDir).catch(() => null);
@@ -6393,6 +6436,25 @@ async function readActiveMainRootConductorStateForPreToolUse(
   ));
   const hasActiveSkill = (skill: string): boolean => activeEntries.some((entry) => entry.skill === skill);
 
+  if (hasActiveSkill("autopilot")) {
+    const state = await readStopSessionPinnedState("autopilot-state.json", cwd, sessionId, stateDir);
+    const childPhase = deriveAutopilotChildPhase(state);
+    const hasMatchingAutopilotEntry = activeEntries.some((entry) => (
+      entry.skill === "autopilot"
+      && normalizeAutopilotPhase(safeString(entry.phase).trim().toLowerCase()) === childPhase
+    ));
+    if (
+      state
+      && childPhase
+      && childPhase !== "deep-interview"
+      && childPhase !== "ralplan"
+      && childPhase !== "rework"
+      && hasMatchingAutopilotEntry
+      && isActiveConductorModeState(state, "autopilot", sessionId)
+    ) {
+      return { mode: "autopilot", phase: childPhase };
+    }
+  }
 
   if (hasActiveSkill("ralph")) {
     const state = await readStopSessionPinnedState("ralph-state.json", cwd, sessionId, stateDir);
@@ -6450,10 +6512,15 @@ function normalizeRepoRelativePath(cwd: string, rawPath: string): string | null 
 function isAllowedConductorMetadataPath(cwd: string, rawPath: string): boolean {
   const relativePath = normalizeRepoRelativePath(cwd, rawPath);
   if (!relativePath) return false;
-  if (relativePath === ".omx/context/ralplan-wrapper-notes.md") return true;
-  return CONDUCTOR_ALLOWED_METADATA_PREFIXES.some((prefix) => (
-    relativePath === prefix || relativePath.startsWith(`${prefix}/`)
-  ));
+  if (isProtectedPlanningStatePath(relativePath)) return false;
+  const artifactKind = classifyConductorArtifactKind(relativePath);
+  const actionKind = actionKindForConductorArtifact(artifactKind);
+  return authorizeConductorAction({
+    phase: "autopilot-supervision",
+    laneKind: "main-conductor",
+    actionKind,
+    artifactKind,
+  }).allowed;
 }
 
 function describeConductorBlockedWrite(toolName: string, blockedPath: string | undefined, pathCount: number): string {
@@ -7234,7 +7301,7 @@ export async function buildConductorPreToolUseWriteGuardOutput(
       additionalContext:
         `${LEADER_CONDUCTOR_GOLDEN_RULE} `
         + "Use specialized agents for source edits and plan/spec authorship. "
-        + `Main-root Conductor may write only workflow state/ledger/mailbox/handoff metadata under ${CONDUCTOR_ALLOWED_METADATA_PREFIXES.join(", ")}. `
+        + `Main-root Conductor may write only orchestration metadata/transport/ledger artifacts under ${CONDUCTOR_ORCHESTRATION_METADATA_PREFIXES.join(", ")}; path location alone is not authorization for substantive deliverables. `
         + "Autopilot rework and typed subagent/worker lanes are exempt from this guard.",
     },
   };
@@ -8712,8 +8779,9 @@ export async function dispatchCodexNativeHook(
   const eventSessionId = canonicalSessionId || nativeSessionId || undefined;
   const sessionIdForState = canonicalSessionId || nativeSessionId;
   let outputJson: Record<string, unknown> | null = null;
+  const typedAgentRolePayload = isTypedAgentRolePayload(payload);
   const isSubagentPromptSubmit = hookEventName === "UserPromptSubmit"
-    ? await isNativeSubagentHook(
+    ? typedAgentRolePayload || await isNativeSubagentHook(
       cwd,
       canonicalSessionId,
       nativeSessionId,

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "child_process";
-import { closeSync, existsSync, openSync, readFileSync, readSync, statSync } from "fs";
+import { closeSync, existsSync, openSync, readFileSync, readSync, readdirSync, statSync } from "fs";
 import { appendFile, mkdir, readFile, readdir, stat, writeFile } from "fs/promises";
 import { extname, isAbsolute, join, relative, resolve } from "path";
 import { pathToFileURL } from "url";
@@ -41,7 +41,7 @@ import {
   writeTeamLeaderAttention,
   writeTeamPhase,
 } from "../team/state.js";
-import { omxNotepadPath, resolveProjectMemoryPath } from "../utils/paths.js";
+import { codexAgentsDir, omxNotepadPath, projectCodexAgentsDir, resolveProjectMemoryPath } from "../utils/paths.js";
 import { findGitLayout } from "../utils/git-layout.js";
 import { getBaseStateDir, getStateFilePath, getStatePath, getAuthoritativeActiveStatePaths } from "../mcp/state-paths.js";
 import {
@@ -204,6 +204,8 @@ const RALPH_LIVE_RISK_PATTERNS = [
   /\b(?:telegram|vps|service|restart|send|notify|notification|notifications|cron)\b/i,
 ] as const;
 const KNOWN_TYPED_AGENT_ROLES = new Set(Object.keys(AGENT_DEFINITIONS));
+let installedTypedAgentRoleNamesCacheKey = "";
+let installedTypedAgentRoleNamesCache: Set<string> = new Set();
 const RALPH_TASK_TEXT_FIELDS = [
   "task_description",
   "taskDescription",
@@ -3019,9 +3021,33 @@ function readPayloadAgentRole(payload: CodexHookPayload): string {
   ).trim().toLowerCase();
 }
 
+function readInstalledTypedAgentRoleNames(): Set<string> {
+  const cacheKey = [codexAgentsDir(), projectCodexAgentsDir()].join("|");
+  if (installedTypedAgentRoleNamesCacheKey === cacheKey) return installedTypedAgentRoleNamesCache;
+
+  const installedRoleNames = new Set<string>();
+  for (const agentsDir of [codexAgentsDir(), projectCodexAgentsDir()]) {
+    try {
+      for (const entry of readdirSync(agentsDir, { withFileTypes: true })) {
+        if (!entry.isFile() || !entry.name.endsWith(".toml")) continue;
+        installedRoleNames.add(entry.name.slice(0, -5).trim().toLowerCase());
+      }
+    } catch {
+      // Ignore missing or unreadable agent directories; built-in definitions remain authoritative.
+    }
+  }
+
+  installedTypedAgentRoleNamesCacheKey = cacheKey;
+  installedTypedAgentRoleNamesCache = installedRoleNames;
+  return installedTypedAgentRoleNamesCache;
+}
+
 function isTypedAgentRolePayload(payload: CodexHookPayload): boolean {
   const agentRole = readPayloadAgentRole(payload);
-  return agentRole !== "" && KNOWN_TYPED_AGENT_ROLES.has(agentRole);
+  return agentRole !== "" && (
+    KNOWN_TYPED_AGENT_ROLES.has(agentRole)
+    || readInstalledTypedAgentRoleNames().has(agentRole)
+  );
 }
 
 function readPayloadTurnId(payload: CodexHookPayload): string {
@@ -6498,19 +6524,6 @@ async function readActiveMainRootConductorStateForPreToolUse(
 
   return null;
 }
-
-const CONDUCTOR_ALLOWED_METADATA_PREFIXES = [
-  ".omx/state",
-  ".omx/context",
-  ".omx/ultragoal",
-  ".omx/ralph",
-  ".omx/team",
-  ".omx/mailbox",
-  ".omx/handoff",
-  ".omx/handoffs",
-  ".omx/goals",
-  ".omx/notepad",
-] as const;
 
 function normalizeRepoRelativePath(cwd: string, rawPath: string): string | null {
   const candidate = rawPath.trim().replace(/^['"]|['"]$/g, "");


### PR DESCRIPTION
## What changed
- Hardened the canonical conductor contract with typed classification and authorization helpers for phases, lanes, actions, and artifact kinds.
- Added regression coverage for Conductor classification/authorization rules.
- Tightened codex-native-hook behavior so typed subagents do not inherit Main-root Conductor guidance or planning blocks.
- Added regression coverage for typed-agent routing and conductor guard behavior.

## Why
The Main-root Conductor should enforce the Golden Rule / Silver Rule at runtime without leaking those rules into typed subagent lanes.

## Validation
- `npm run build`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/team.test.js dist/scripts/__tests__/codex-native-hook.test.js`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js dist/leader/__tests__/contract.test.js`

## Notes
This branch is pushed on top of the current `dev` baseline and keeps PR 3010-related conductor and typed-lane evidence isolated from unrelated work.
