### PR TITLE
Fix madmax worktree runtime roots

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -50,6 +50,7 @@ import {
   resolveOmxRootForLaunch,
   resolveDisposableWorktreeOmxRootForLaunch,
   prepareCodexHomeForLaunch,
+  captureMadmaxWorktreeRuntimeContext,
   persistProjectLaunchRuntimeAuthState,
   persistProjectLaunchRuntimeProjectTrustState,
   cleanupRuntimeCodexHome,
@@ -211,6 +212,65 @@ describe("madmax state isolation", () => {
     assert.equal(
       shouldAutoIsolateMadmaxLaunch("launch", ["--madmax"], { OMX_NO_BOX: "1" }, "/repo"),
       false,
+    );
+  });
+
+  it("captures madmax worktree context from parsed worktree state, not remaining args", () => {
+    const sourceCwd = "/repo/source";
+    const worktreeCwd = "/repo/.worktrees/session";
+    const runDir = "/runs/run-issue-3043";
+    const context = captureMadmaxWorktreeRuntimeContext({
+      originalLaunchArgs: ["--madmax", "--worktree", "--version"],
+      worktreeEnabled: true,
+      sourceCwd,
+      worktreeCwd,
+      env: {
+        OMX_ROOT: runDir,
+        OMXBOX_ACTIVE: "1",
+        OMX_SOURCE_CWD: sourceCwd,
+        OMX_MADMAX_DETACHED_CONTEXT: "ctx-3043",
+      },
+    });
+
+    assert.deepEqual(context, {
+      omxRoot: runDir,
+      sourceCwd,
+      worktreeCwd,
+      madmaxDetachedContext: "ctx-3043",
+      boxedActive: true,
+    });
+  });
+
+  it("does not capture ordinary worktree or unboxed madmax launches", () => {
+    assert.equal(
+      captureMadmaxWorktreeRuntimeContext({
+        originalLaunchArgs: ["--worktree"],
+        worktreeEnabled: true,
+        sourceCwd: "/repo/source",
+        worktreeCwd: "/repo/.worktrees/session",
+        env: { OMX_ROOT: "/runs/run", OMXBOX_ACTIVE: "1" },
+      }),
+      undefined,
+    );
+    assert.equal(
+      captureMadmaxWorktreeRuntimeContext({
+        originalLaunchArgs: ["--madmax", "--worktree"],
+        worktreeEnabled: true,
+        sourceCwd: "/repo/source",
+        worktreeCwd: "/repo/.worktrees/session",
+        env: { OMX_ROOT: "/runs/run" },
+      }),
+      undefined,
+    );
+    assert.equal(
+      captureMadmaxWorktreeRuntimeContext({
+        originalLaunchArgs: ["--madmax", "--worktree"],
+        worktreeEnabled: false,
+        sourceCwd: "/repo/source",
+        worktreeCwd: "/repo/.worktrees/session",
+        env: { OMX_ROOT: "/runs/run", OMXBOX_ACTIVE: "1" },
+      }),
+      undefined,
     );
   });
 
@@ -3778,10 +3838,10 @@ exit 0
 
   it("runCodex builds inside-tmux HUD command through explicit runtime-root resolver", async () => {
     const source = await readFile(join(repoRoot, 'src', 'cli', 'index.ts'), 'utf-8');
-    assert.match(source, /const hudRuntimeRoot = resolveHudRuntimeRootForLaunch\(cwd, process\.env\);/);
+    assert.match(source, /const hudRuntimeRoot: HudRuntimeRootForLaunch = runtimeContext\s*\? \{ omxRoot: runtimeContext\.omxRoot, rootSource: 'omx-root-env' \}\s*: resolveHudRuntimeRootForLaunch\(cwd, process\.env\);/);
     assert.match(
       source,
-      /const hudEnvArgs = Object\.entries\(buildHudRuntimeEnv\(\{\s*sessionId,\s*leaderPaneId: currentPaneId,\s*\.\.\.hudRuntimeRoot,\s*\}\)\.env\)\.map\(\(\[key, value\]\) => `\$\{key\}=\$\{value\}`\)/,
+      /const hudRuntimeEnv = \{\s*\.\.\.buildHudRuntimeEnv\(\{\s*sessionId,\s*leaderPaneId: currentPaneId,\s*\.\.\.hudRuntimeRoot,\s*\}\)\.env,\s*\.\.\.runtimeEnvOverlay,\s*\};\s*const hudEnvArgs = Object\.entries\(hudRuntimeEnv\)\.map\(\(\[key, value\]\) => `\$\{key\}=\$\{value\}`\)/,
     );
     assert.match(source, /if \(env\.OMX_TEAM_STATE_ROOT\?\.trim\(\)\) return 'team-env';\s*if \(env\.OMX_ROOT\?\.trim\(\) \|\| omxRootOverride\) return 'omx-root-env';\s*if \(env\.OMX_STATE_ROOT\?\.trim\(\)\) return 'omx-state-root-env';/);
     assert.match(
@@ -3794,7 +3854,7 @@ exit 0
     const source = await readFile(join(repoRoot, 'src', 'cli', 'index.ts'), 'utf-8');
     assert.match(
       source,
-      /registerInsideTmuxHudResizeHook\(\{\s*hudPaneId,\s*currentPaneId,\s*cwd,\s*sessionId,\s*omxRootOverride,\s*\}\)/,
+      /registerInsideTmuxHudResizeHook\(\{\s*hudPaneId,\s*currentPaneId,\s*cwd,\s*sessionId,\s*omxRootOverride,\s*baseEnv: runtimeHookEnv,\s*\}\)/,
     );
     assert.match(
       source,

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { execFileSync, spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
@@ -314,6 +314,67 @@ printf 'fake-codex:%s\n' "$*"
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('keeps direct madmax worktree launches bound to the boxed run root', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-madmax-worktree-root-'));
+    try {
+      const repo = await createGitRepo(wd);
+      const runs = join(wd, 'runs');
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'bin');
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeExecutable(
+        join(fakeBin, 'codex'),
+        `#!/bin/sh
+printf 'fake-codex-pwd:%s\n' "$PWD"
+printf 'fake-codex-omx-root:%s\n' "$OMX_ROOT"
+printf 'fake-codex-box:%s\n' "$OMXBOX_ACTIVE"
+printf 'fake-codex-source:%s\n' "$OMX_SOURCE_CWD"
+printf 'fake-codex-context:%s\n' "$OMX_MADMAX_DETACHED_CONTEXT"
+printf 'fake-codex:%s\n' "$*"
+`,
+      );
+      await writeExecutable(join(fakeBin, 'ps'), '#!/bin/sh\nexit 0\n');
+
+      const result = runOmx(repo, ['--direct', '--madmax', '--worktree', '--version'], {
+        HOME: home,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+        OMX_RUNS_DIR: runs,
+        OMX_ROOT: '',
+        OMX_STATE_ROOT: '',
+        TMUX: '',
+        TMUX_PANE: '',
+      });
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      const worktreePath = join(dirname(repo), `${basename(repo)}.omx-worktrees`, 'launch-detached');
+      const normalizedStdout = normalizeDarwinTmpPath(result.stdout);
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(
+        normalizedStdout,
+        new RegExp(`fake-codex-pwd:${escapeRegExp(normalizeDarwinTmpPath(worktreePath))}`),
+      );
+      const rootMatch = normalizedStdout.match(/fake-codex-omx-root:(.*)/);
+      assert.ok(rootMatch, normalizedStdout);
+      const boxedRoot = rootMatch[1];
+      assert.match(boxedRoot, new RegExp(`^${escapeRegExp(normalizeDarwinTmpPath(runs))}/run-`));
+      assert.notEqual(boxedRoot, normalizeDarwinTmpPath(repo));
+      assert.notEqual(boxedRoot, normalizeDarwinTmpPath(worktreePath));
+      assert.match(normalizedStdout, /fake-codex-box:1/);
+      assert.match(
+        normalizedStdout,
+        new RegExp(`fake-codex-source:${escapeRegExp(normalizeDarwinTmpPath(repo))}`),
+      );
+      assert.match(normalizedStdout, /fake-codex-context:[0-9a-f]{32}/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('Hermes MCP tmux bridge launch', () => {
@@ -484,6 +545,95 @@ exit 0
       assert.match(activeRecords, /"tmux_session_name"/);
       assert.match(activeRecords, /"session_id"/);
       assert.match(activeRecords, /"tmux_pane_id": "%12"/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('records boxed runtime identity for detached madmax worktree launches', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-madmax-worktree-detached-'));
+    try {
+      const repo = await createGitRepo(wd);
+      const runs = join(wd, 'runs');
+      const instanceMarker = join(wd, 'active-instance');
+      const { env, tmuxLogPath } = await createLaunchFixture(
+        wd,
+        (logPath) => `#!/bin/sh
+printf 'tmux:%s\n' "$*" >> "${logPath}"
+case "$1" in
+  -V)
+    printf 'tmux 3.4\n'
+    exit 0
+    ;;
+  has-session)
+    exit 1
+    ;;
+  new-session)
+    printf '%%77\n'
+    exit 0
+    ;;
+  split-window)
+    printf '%%78\n'
+    exit 0
+    ;;
+  display-message)
+    if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then
+      printf '/tmp/tmux-test.sock\n'
+    elif [ "$2" = '-p' ] && [ "$5" = '#{session_name}' ]; then
+      printf 'detached-session\n'
+    elif [ "$2" = '-p' ] && [ "$5" = '#{session_attached}' ]; then
+      printf '1\n'
+    else
+      printf '0\n'
+    fi
+    exit 0
+    ;;
+  show-options)
+    if [ "$5" = '@omx_instance_id' ] && [ -f "${instanceMarker}" ]; then
+      cat "${instanceMarker}"
+      exit 0
+    fi
+    printf 'off\n'
+    exit 0
+    ;;
+  set-option)
+    if [ "$4" = '@omx_instance_id' ]; then
+      printf '%s\n' "$5" > "${instanceMarker}"
+    fi
+    exit 0
+    ;;
+  set-hook|attach-session|kill-session|run-shell|resize-pane)
+    exit 0
+    ;;
+esac
+exit 0
+`,
+      );
+
+      const result = runOmx(repo, ['--madmax', '--worktree', '--tmux'], {
+        ...env,
+        OMX_RUNS_DIR: runs,
+        TMUX: '',
+        TMUX_PANE: '',
+      });
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+
+      const activeFiles = await readdir(join(runs, 'active-detached'));
+      assert.equal(activeFiles.length, 1);
+      const activeRecord = JSON.parse(await readFile(join(runs, 'active-detached', activeFiles[0]), 'utf-8'));
+      const worktreePath = join(dirname(repo), `${basename(repo)}.omx-worktrees`, 'launch-detached');
+      assert.match(activeRecord.run_dir, new RegExp(`^${escapeRegExp(normalizeDarwinTmpPath(runs))}/run-`));
+      assert.equal(normalizeDarwinTmpPath(activeRecord.source_cwd), normalizeDarwinTmpPath(repo));
+      assert.equal(normalizeDarwinTmpPath(activeRecord.worktree_cwd), normalizeDarwinTmpPath(worktreePath));
+      assert.equal(activeRecord.session_id.startsWith('omx-'), true);
+      assert.equal(activeRecord.tmux_pane_id, '%77');
+
+      const tmuxLog = normalizeDarwinTmpPath(await readFile(tmuxLogPath, 'utf-8'));
+      assert.match(tmuxLog, new RegExp(`-e OMX_ROOT=${escapeRegExp(normalizeDarwinTmpPath(activeRecord.run_dir))}`));
+      assert.match(tmuxLog, /-e OMXBOX_ACTIVE=1/);
+      assert.match(tmuxLog, new RegExp(`-e OMX_SOURCE_CWD=${escapeRegExp(normalizeDarwinTmpPath(repo))}`));
+      assert.match(tmuxLog, new RegExp(`-e OMX_MADMAX_DETACHED_CONTEXT=${escapeRegExp(activeRecord.context_key)}`));
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -199,6 +199,55 @@ describe('CLI session-scoped state parity', () => {
     }
   });
 
+  it('finds hook-visible run-dir session state from an explicit worktree_cwd alias', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-worktree-alias-source-'));
+    const worktree = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-worktree-alias-wt-'));
+    const runsRoot = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-worktree-alias-runs-'));
+    try {
+      const sessionId = 'sess-run-dir-worktree-alias';
+      const runDir = join(runsRoot, 'run-20260610121751-a11a');
+      const runStateDir = join(runDir, '.omx', 'state');
+      const runSessionDir = join(runStateDir, 'sessions', sessionId);
+      await mkdir(runSessionDir, { recursive: true });
+      await mkdir(join(worktree, '.omx', 'state'), { recursive: true });
+      await mkdir(join(runsRoot, 'active-detached'), { recursive: true });
+      await writeFile(join(runStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(join(runSessionDir, 'autopilot-state.json'), JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'deep-interview',
+      }, null, 2));
+      await writeFile(join(runsRoot, 'active-detached', 'ctx-worktree-alias.json'), `${JSON.stringify({
+        version: 1,
+        context_key: 'ctx-worktree-alias',
+        created_at: '2026-06-10T12:17:51.000Z',
+        source_cwd: wd,
+        worktree_cwd: worktree,
+        argv: ['--madmax', '--worktree', '--tmux'],
+        run_dir: runDir,
+        tmux_session_name: 'omx-detached',
+        session_id: sessionId,
+        tmux_pane_id: '%42',
+      })}\n`);
+
+      const statusResult = runOmxWithEnv(worktree, { OMX_RUNS_DIR: runsRoot }, 'status');
+      assert.equal(statusResult.status, 0, statusResult.stderr || statusResult.stdout);
+      assert.match(statusResult.stdout, /autopilot: ACTIVE \(phase: deep-interview\)/);
+
+      const cancelResult = runOmxWithEnv(worktree, { OMX_RUNS_DIR: runsRoot }, 'cancel');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /Cancelled: autopilot/);
+
+      const autopilot = JSON.parse(await readFile(join(runSessionDir, 'autopilot-state.json'), 'utf-8'));
+      assert.equal(autopilot.active, false);
+      assert.equal(autopilot.current_phase, 'cancelled');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(worktree, { recursive: true, force: true });
+      await rm(runsRoot, { recursive: true, force: true });
+    }
+  });
+
   it('reports stale current-autopilot in status when no authoritative active modes exist', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-status-stale-current-autopilot-'));
     try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2052,6 +2052,60 @@ export function resolveDisposableWorktreeOmxRootForLaunch(
   return ensuredWorktree.repoRoot;
 }
 
+interface MadmaxWorktreeRuntimeContext {
+  omxRoot: string;
+  omxStateRoot?: string;
+  sourceCwd: string;
+  worktreeCwd?: string;
+  madmaxDetachedContext?: string;
+  boxedActive?: true;
+}
+
+function buildMadmaxWorktreeRuntimeEnvOverlay(
+  runtimeContext?: MadmaxWorktreeRuntimeContext,
+): NodeJS.ProcessEnv {
+  if (!runtimeContext) return {};
+  return {
+    OMX_ROOT: runtimeContext.omxRoot,
+    ...(runtimeContext.omxStateRoot ? { OMX_STATE_ROOT: runtimeContext.omxStateRoot } : {}),
+    ...(runtimeContext.boxedActive ? { OMXBOX_ACTIVE: "1" } : {}),
+    OMX_SOURCE_CWD: runtimeContext.sourceCwd,
+    ...(runtimeContext.madmaxDetachedContext
+      ? { [OMX_MADMAX_DETACHED_CONTEXT_ENV]: runtimeContext.madmaxDetachedContext }
+      : {}),
+  };
+}
+
+export function captureMadmaxWorktreeRuntimeContext(options: {
+  originalLaunchArgs: readonly string[];
+  worktreeEnabled: boolean;
+  sourceCwd: string;
+  worktreeCwd?: string;
+  env?: NodeJS.ProcessEnv;
+}): MadmaxWorktreeRuntimeContext | undefined {
+  const env = options.env ?? process.env;
+  if (!options.worktreeEnabled) return undefined;
+  if (!launchArgsRequestMadmaxIsolation(options.originalLaunchArgs)) return undefined;
+  if (env.OMXBOX_ACTIVE !== "1") return undefined;
+
+  const inheritedRoot = resolveInheritedMadmaxRoot(env);
+  if (!inheritedRoot) return undefined;
+
+  const sourceCwd = env.OMX_SOURCE_CWD?.trim() || options.sourceCwd;
+  const worktreeCwd = options.worktreeCwd?.trim();
+  const omxStateRoot = env.OMX_STATE_ROOT?.trim();
+  const madmaxDetachedContext = env[OMX_MADMAX_DETACHED_CONTEXT_ENV]?.trim();
+
+  return {
+    omxRoot: resolveLaunchPath(options.sourceCwd, inheritedRoot),
+    ...(omxStateRoot ? { omxStateRoot: resolveLaunchPath(options.sourceCwd, omxStateRoot) } : {}),
+    sourceCwd,
+    ...(worktreeCwd && worktreeCwd !== sourceCwd ? { worktreeCwd } : {}),
+    ...(madmaxDetachedContext ? { madmaxDetachedContext } : {}),
+    boxedActive: true,
+  };
+}
+
 function applyDisposableWorktreeOmxRootForLaunch(
   ensuredWorktree: { enabled: true; repoRoot: string } | { enabled: false } | undefined,
   env: NodeJS.ProcessEnv = process.env,
@@ -2145,6 +2199,7 @@ interface MadmaxDetachedActiveRecord {
   context_key: string;
   created_at: string;
   source_cwd: string;
+  worktree_cwd?: string;
   argv: string[];
   run_dir: string;
   tmux_session_name: string;
@@ -2259,6 +2314,7 @@ function readMadmaxDetachedActiveRecord(
       tmux_session_name: parsed.tmux_session_name,
       ...(typeof parsed.session_id === "string" ? { session_id: parsed.session_id } : {}),
       ...(typeof parsed.tmux_pane_id === "string" ? { tmux_pane_id: parsed.tmux_pane_id } : {}),
+      ...(typeof parsed.worktree_cwd === "string" ? { worktree_cwd: parsed.worktree_cwd } : {}),
     };
   } catch {
     return null;
@@ -3056,6 +3112,13 @@ export async function launchWithHud(args: string[]): Promise<void> {
       }
     }
   }
+  const madmaxWorktreeRuntimeContext = captureMadmaxWorktreeRuntimeContext({
+    originalLaunchArgs: args,
+    worktreeEnabled: Boolean(parsedWorktree.mode.enabled && ensuredLaunchWorktree?.enabled),
+    sourceCwd: launchCwd,
+    worktreeCwd: ensuredLaunchWorktree?.enabled ? ensuredLaunchWorktree.worktreePath : undefined,
+    env: process.env,
+  });
   clearInheritedMadmaxRootForDisposableWorktreeLaunch(parsedWorktree.remainingArgs);
   applyDisposableWorktreeOmxRootForLaunch(ensuredLaunchWorktree);
 
@@ -3132,6 +3195,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
       effectiveExplicitLaunchPolicy,
       projectLocalCodexHomeForCleanup,
       preparedCodexHome.runtimeCodexHomeForCleanup,
+      madmaxWorktreeRuntimeContext,
     );
     postLaunchHandledExternally = launchResult.postLaunchHandledExternally;
   } finally {
@@ -4184,6 +4248,9 @@ export function buildDetachedSessionBootstrapSteps(
     ...(sqliteHomeOverride ? ["-e", `${CODEX_SQLITE_HOME_ENV}=${sqliteHomeOverride}`] : []),
     ...(env.OMXBOX_ACTIVE ? ["-e", `OMXBOX_ACTIVE=${env.OMXBOX_ACTIVE}`] : []),
     ...(env.OMX_SOURCE_CWD ? ["-e", `OMX_SOURCE_CWD=${env.OMX_SOURCE_CWD}`] : []),
+    ...(env[OMX_MADMAX_DETACHED_CONTEXT_ENV]
+      ? ["-e", `${OMX_MADMAX_DETACHED_CONTEXT_ENV}=${env[OMX_MADMAX_DETACHED_CONTEXT_ENV]}`]
+      : []),
     ...(notifyTempContractRaw
       ? ["-e", `${OMX_NOTIFY_TEMP_CONTRACT_ENV}=${notifyTempContractRaw}`]
       : []),
@@ -4958,6 +5025,7 @@ function runCodex(
   explicitLaunchPolicy?: CodexLaunchPolicy,
   projectLocalCodexHomeForCleanup?: string,
   runtimeCodexHomeForCleanup?: string,
+  runtimeContext?: MadmaxWorktreeRuntimeContext,
 ): { postLaunchHandledExternally: boolean } {
   const launchArgs = injectModelInstructionsBypassArgs(
     cwd,
@@ -4970,14 +5038,21 @@ function runCodex(
   if (!omxBin) {
     throw new Error("Unable to resolve OMX launcher path for tmux HUD bootstrap");
   }
-  const omxRootOverride = resolveOmxRootForLaunch(cwd, process.env);
+  const runtimeEnvOverlay = buildMadmaxWorktreeRuntimeEnvOverlay(runtimeContext);
+  const omxRootOverride = runtimeContext?.omxRoot ?? resolveOmxRootForLaunch(cwd, process.env);
   const currentPaneId = process.env.TMUX_PANE;
-  const hudRuntimeRoot = resolveHudRuntimeRootForLaunch(cwd, process.env);
-  const hudEnvArgs = Object.entries(buildHudRuntimeEnv({
-    sessionId,
-    leaderPaneId: currentPaneId,
-    ...hudRuntimeRoot,
-  }).env).map(([key, value]) => `${key}=${value}`);
+  const hudRuntimeRoot: HudRuntimeRootForLaunch = runtimeContext
+    ? { omxRoot: runtimeContext.omxRoot, rootSource: 'omx-root-env' }
+    : resolveHudRuntimeRootForLaunch(cwd, process.env);
+  const hudRuntimeEnv = {
+    ...buildHudRuntimeEnv({
+      sessionId,
+      leaderPaneId: currentPaneId,
+      ...hudRuntimeRoot,
+    }).env,
+    ...runtimeEnvOverlay,
+  };
+  const hudEnvArgs = Object.entries(hudRuntimeEnv).map(([key, value]) => `${key}=${value}`);
   const hudCmd = nativeWindows
     ? buildWindowsPromptCommand("node", [omxBin, "hud", "--watch"])
     : buildTmuxPaneCommand("env", [...hudEnvArgs, "node", omxBin, "hud", "--watch"]);
@@ -4999,6 +5074,7 @@ function runCodex(
       ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
       ...(sqliteHomeOverride ? { [CODEX_SQLITE_HOME_ENV]: sqliteHomeOverride } : {}),
       ...(omxRootOverride ? { OMX_ROOT: omxRootOverride } : {}),
+      ...runtimeEnvOverlay,
     },
     omxBin,
   );
@@ -5016,6 +5092,7 @@ function runCodex(
   const codexEnvWithNotify = notifyTempContractRaw
     ? { ...codexEnv, [OMX_NOTIFY_TEMP_CONTRACT_ENV]: notifyTempContractRaw }
     : codexEnv;
+  const runtimeHookEnv = { ...process.env, ...runtimeEnvOverlay };
 
   const { launchPolicy } = resolveTmuxAwareLaunchPolicy(
     explicitLaunchPolicy,
@@ -5061,6 +5138,7 @@ function runCodex(
           cwd,
           sessionId,
           omxRootOverride,
+          baseEnv: runtimeHookEnv,
         });
       } catch (err) {
         logCliOperationFailure(err);
@@ -5088,6 +5166,7 @@ function runCodex(
           cwd,
           sessionId,
           omxRootOverride,
+          baseEnv: runtimeHookEnv,
         });
       } catch (err) {
         logCliOperationFailure(err);
@@ -5154,7 +5233,7 @@ function runCodex(
       : null;
     const sessionName = buildDetachedTmuxSessionName(cwd, sessionId);
     const launchDetachedSession = (): { postLaunchHandledExternally: boolean } => {
-      const contextKey = process.env[OMX_MADMAX_DETACHED_CONTEXT_ENV]?.trim();
+      const contextKey = runtimeContext?.madmaxDetachedContext ?? process.env[OMX_MADMAX_DETACHED_CONTEXT_ENV]?.trim();
       const runsRoot = resolveMadmaxRunsRoot(process.env);
       const activeRecordPath = contextKey
         ? madmaxDetachedActiveRecordPath(runsRoot, contextKey)
@@ -5252,7 +5331,7 @@ function runCodex(
           projectLocalCodexHomeForCleanup,
           runtimeCodexHomeForCleanup,
           omxRootOverride,
-          process.env,
+          runtimeHookEnv,
           sqliteHomeOverride,
           detachedParentEnvFilePath,
           inheritedWorkerModel,
@@ -5273,9 +5352,10 @@ function runCodex(
                   version: 1,
                   context_key: contextKey,
                   created_at: new Date().toISOString(),
-                  source_cwd: process.env.OMX_SOURCE_CWD || cwd,
+                  source_cwd: runtimeContext?.sourceCwd ?? process.env.OMX_SOURCE_CWD ?? cwd,
+                  ...(runtimeContext?.worktreeCwd ? { worktree_cwd: runtimeContext.worktreeCwd } : {}),
                   argv: args,
-                  run_dir: process.env.OMX_ROOT || cwd,
+                  run_dir: runtimeContext?.omxRoot ?? process.env.OMX_ROOT ?? cwd,
                   tmux_session_name: sessionName,
                   session_id: sessionId,
                   tmux_pane_id: leaderPaneId,
@@ -5375,6 +5455,7 @@ function runCodex(
                   sessionId,
                   omxBin,
                   omxRootOverride,
+                  baseEnv: runtimeHookEnv,
                 });
               }
             }
@@ -6344,6 +6425,7 @@ async function listHookVisibleRunDirStateRefs(cwd: string): Promise<ModeStateFil
     if (!raw || typeof raw !== "object") return;
     const record = raw as Record<string, unknown>;
     const sourceCwd = typeof record.source_cwd === "string" ? record.source_cwd.trim() : "";
+    const worktreeCwd = typeof record.worktree_cwd === "string" ? record.worktree_cwd.trim() : "";
     const runDir = typeof record.run_dir === "string"
       ? record.run_dir.trim()
       : typeof record.cwd === "string"
@@ -6352,7 +6434,10 @@ async function listHookVisibleRunDirStateRefs(cwd: string): Promise<ModeStateFil
     if (!sourceCwd || !runDir) return;
 
     try {
-      if (canonicalizePathForRunDirMatch(sourceCwd) !== canonicalCwd) return;
+      if (
+        canonicalizePathForRunDirMatch(sourceCwd) !== canonicalCwd &&
+        (!worktreeCwd || canonicalizePathForRunDirMatch(worktreeCwd) !== canonicalCwd)
+      ) return;
       const resolvedRunDir = resolve(runDir);
       if (
         resolvedRunDir !== canonicalRunsRoot


### PR DESCRIPTION
Fixes #3043.\n\n## Summary\n- capture madmax worktree runtime identity before launch args are normalized\n- keep direct and detached madmax worktree launches bound to the boxed run root\n- preserve explicit worktree cwd aliases for session-scoped runtime cleanup/status\n\n## Verification\n- npm run build\n- node dist/scripts/run-test-files.js dist/cli/__tests__/index.test.js dist/cli/__tests__/launch-fallback.test.js dist/cli/__tests__/session-scoped-runtime.test.js