### PR TITLE
[codex] follow-up: tighten typed subagent provenance handling

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -782,6 +782,57 @@ describe("codex native hook dispatch", () => {
     }
   });
 
+  it("preserves team-worker typed subagent PreToolUse exemption without thread spawn provenance", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-worker-typed-pretool-exempt-"));
+    const sessionId = "sess-team-worker-typed-pretool-exempt";
+    const stateDir = join(cwd, ".omx", "state");
+    const basePayload = {
+      hook_event_name: "PreToolUse",
+      cwd,
+      session_id: sessionId,
+      thread_id: "thread-team-worker-typed-pretool-exempt",
+      agent_role: "executor",
+      tool_name: "Edit",
+      tool_use_id: "tool-team-worker-typed-pretool-exempt",
+      tool_input: { file_path: "src/runtime.ts", old_string: "a", new_string: "b" },
+    };
+    try {
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "ralplan",
+        phase: "planning",
+        session_id: sessionId,
+        active_skills: [{ skill: "ralplan", phase: "planning", active: true, session_id: sessionId }],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "ralplan-state.json"), {
+        active: true,
+        mode: "ralplan",
+        current_phase: "critic-review",
+        session_id: sessionId,
+      });
+
+      const nonTeamWorkerTypedSubagent = await dispatchCodexNativeHook(basePayload, { cwd });
+      assert.equal(
+        (nonTeamWorkerTypedSubagent.outputJson as { decision?: string } | null)?.decision,
+        "block",
+        "typed/native subagent PreToolUse without trusted thread_spawn provenance must remain protected outside team workers",
+      );
+
+      process.env.OMX_TEAM_INTERNAL_WORKER = "typed-pretool-exempt/worker-1";
+      process.env.OMX_TEAM_WORKER = "typed-pretool-exempt/worker-1";
+
+      const teamWorkerTypedSubagent = await dispatchCodexNativeHook(basePayload, { cwd });
+      assert.equal(
+        teamWorkerTypedSubagent.outputJson,
+        null,
+        "team workers must bypass typed-subagent thread_spawn provenance requirements before planning guards block implementation tools",
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("preserves deep-interview PreToolUse planning guard as hook-specific deny JSON", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-cli-deep-interview-pretool-boundary-"));
     const sessionId = "sess-cli-deep-interview-pretool-boundary";

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -10312,26 +10312,34 @@ exit 0
 
   it("allows typed agent-role implementation writes under active ralplan when trusted provenance is present", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-trusted-typed-agent-role-ralplan-"));
+    const originalOmxRoot = process.env.OMX_ROOT;
+    const originalOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const originalOmxTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
     try {
+      process.env.OMX_ROOT = cwd;
+      delete process.env.OMX_STATE_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
       const stateDir = join(cwd, ".omx", "state");
       const sessionId = "sess-trusted-typed-executor-ralplan";
+      const leaderThreadId = "thread-trusted-typed-executor-ralplan-leader";
+      const childThreadId = "thread-trusted-typed-executor-ralplan";
       const sessionDir = join(stateDir, "sessions", sessionId);
       await mkdir(sessionDir, { recursive: true });
-      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, cwd });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, native_session_id: leaderThreadId, cwd });
       await writeJson(join(sessionDir, "skill-active-state.json"), {
         version: 1,
         active: true,
         skill: "autopilot",
         phase: "ralplan",
         session_id: sessionId,
-        thread_id: "thread-trusted-typed-executor-ralplan",
+        thread_id: leaderThreadId,
         active_skills: [
           {
             skill: "autopilot",
             phase: "ralplan",
             active: true,
             session_id: sessionId,
-            thread_id: "thread-trusted-typed-executor-ralplan",
+            thread_id: leaderThreadId,
           },
         ],
       });
@@ -10342,7 +10350,21 @@ exit 0
         started_at: "2026-04-19T00:00:00.000Z",
         updated_at: "2026-04-19T00:10:00.000Z",
         session_id: sessionId,
-        thread_id: "thread-trusted-typed-executor-ralplan",
+        thread_id: leaderThreadId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: leaderThreadId,
+            updated_at: "2026-04-19T00:10:00.000Z",
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "leader", first_seen_at: "2026-04-19T00:00:00.000Z", last_seen_at: "2026-04-19T00:10:00.000Z", turn_count: 1 },
+              [childThreadId]: { thread_id: childThreadId, kind: "subagent", mode: "executor", first_seen_at: "2026-04-19T00:01:00.000Z", last_seen_at: "2026-04-19T00:10:00.000Z", turn_count: 1, leader_thread_id: leaderThreadId },
+            },
+          },
+        },
       });
 
       const allowedImplementationEdit = await dispatchCodexNativeHook(
@@ -10350,12 +10372,12 @@ exit 0
           hook_event_name: "PreToolUse",
           cwd,
           session_id: sessionId,
-          thread_id: "thread-trusted-typed-executor-ralplan",
+          thread_id: childThreadId,
           agent_role: "executor",
           source: {
             subagent: {
               thread_spawn: {
-                parent_thread_id: "thread-trusted-typed-executor-ralplan",
+                parent_thread_id: leaderThreadId,
               },
             },
           },
@@ -10367,6 +10389,92 @@ exit 0
       );
       assert.equal(allowedImplementationEdit.outputJson, null);
     } finally {
+      if (originalOmxRoot === undefined) delete process.env.OMX_ROOT;
+      else process.env.OMX_ROOT = originalOmxRoot;
+      if (originalOmxStateRoot === undefined) delete process.env.OMX_STATE_ROOT;
+      else process.env.OMX_STATE_ROOT = originalOmxStateRoot;
+      if (originalOmxTeamStateRoot === undefined) delete process.env.OMX_TEAM_STATE_ROOT;
+      else process.env.OMX_TEAM_STATE_ROOT = originalOmxTeamStateRoot;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks typed thread-spawn provenance when the parent belongs to another leader session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-stale-typed-thread-spawn-"));
+    const originalOmxRoot = process.env.OMX_ROOT;
+    const originalOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const originalOmxTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      process.env.OMX_ROOT = cwd;
+      delete process.env.OMX_STATE_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-stale-typed-thread-spawn";
+      const leaderThreadId = "thread-stale-typed-leader";
+      const childThreadId = "thread-stale-typed-child";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, native_session_id: leaderThreadId, cwd });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "autopilot",
+        phase: "ralplan",
+        session_id: sessionId,
+        thread_id: leaderThreadId,
+        active_skills: [
+          { skill: "autopilot", phase: "ralplan", active: true, session_id: sessionId, thread_id: leaderThreadId },
+        ],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "ralplan",
+        session_id: sessionId,
+        thread_id: leaderThreadId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: leaderThreadId,
+            updated_at: "2026-04-19T00:10:00.000Z",
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "leader", first_seen_at: "2026-04-19T00:00:00.000Z", last_seen_at: "2026-04-19T00:10:00.000Z", turn_count: 1 },
+            },
+          },
+        },
+      });
+
+      const blockedImplementationEdit = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: childThreadId,
+          agent_role: "executor",
+          source: {
+            subagent: {
+              thread_spawn: {
+                parent_thread_id: "thread-other-leader",
+              },
+            },
+          },
+          tool_name: "Edit",
+          tool_use_id: "tool-stale-typed-child-edit",
+          tool_input: { file_path: "src/implementation.ts", old_string: "a", new_string: "b" },
+        },
+        { cwd },
+      );
+
+      assert.equal(blockedImplementationEdit.outputJson?.decision, "block");
+    } finally {
+      if (originalOmxRoot === undefined) delete process.env.OMX_ROOT;
+      else process.env.OMX_ROOT = originalOmxRoot;
+      if (originalOmxStateRoot === undefined) delete process.env.OMX_STATE_ROOT;
+      else process.env.OMX_STATE_ROOT = originalOmxStateRoot;
+      if (originalOmxTeamStateRoot === undefined) delete process.env.OMX_TEAM_STATE_ROOT;
+      else process.env.OMX_TEAM_STATE_ROOT = originalOmxTeamStateRoot;
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -20538,7 +20646,13 @@ exit 0
 
   it("allows conductor writes from tracked typed native subagents", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-conductor-tracked-subagent-"));
+    const originalOmxRoot = process.env.OMX_ROOT;
+    const originalOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const originalOmxTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
     try {
+      process.env.OMX_ROOT = cwd;
+      delete process.env.OMX_STATE_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
       const stateDir = join(cwd, ".omx", "state");
       const sessionId = "sess-conductor-tracked-subagent";
       const leaderThreadId = "thread-conductor-leader";
@@ -20575,6 +20689,13 @@ exit 0
           session_id: sessionId,
           thread_id: childThreadId,
           agent_role: "executor",
+          source: {
+            subagent: {
+              thread_spawn: {
+                parent_thread_id: leaderThreadId,
+              },
+            },
+          },
           tool_name: "Edit",
           tool_input: { file_path: "src/runtime.ts" },
         },
@@ -20583,6 +20704,12 @@ exit 0
 
       assert.equal(result.outputJson, null);
     } finally {
+      if (originalOmxRoot === undefined) delete process.env.OMX_ROOT;
+      else process.env.OMX_ROOT = originalOmxRoot;
+      if (originalOmxStateRoot === undefined) delete process.env.OMX_STATE_ROOT;
+      else process.env.OMX_STATE_ROOT = originalOmxStateRoot;
+      if (originalOmxTeamStateRoot === undefined) delete process.env.OMX_TEAM_STATE_ROOT;
+      else process.env.OMX_TEAM_STATE_ROOT = originalOmxTeamStateRoot;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -6176,7 +6176,7 @@ async function buildRalplanPreToolUseBoundaryOutput(
   resolvedSessionId?: string,
 ): Promise<Record<string, unknown> | null> {
   const sessionId = safeString(resolvedSessionId ?? readPayloadSessionId(payload)).trim();
-  if (await hasIndependentSubagentOrWorkerProvenanceForPreToolUse(payload, cwd, stateDir, sessionId)) return null;
+  if (await hasTrustedTypedSubagentThreadSpawnProvenanceForPreToolUse(payload, cwd, sessionId)) return null;
   const threadId = readPayloadThreadId(payload);
   const activeState = await readActiveRalplanStateForPreToolUse(cwd, stateDir, sessionId, threadId);
   if (!activeState) return null;
@@ -6244,7 +6244,7 @@ async function buildDeepInterviewPreToolUseBoundaryOutput(
   resolvedSessionId?: string,
 ): Promise<Record<string, unknown> | null> {
   const sessionId = safeString(resolvedSessionId ?? readPayloadSessionId(payload)).trim();
-  if (await hasIndependentSubagentOrWorkerProvenanceForPreToolUse(payload, cwd, stateDir, sessionId)) return null;
+  if (await hasTrustedTypedSubagentThreadSpawnProvenanceForPreToolUse(payload, cwd, sessionId)) return null;
   const threadId = readPayloadThreadId(payload);
   const activeState = await readActiveDeepInterviewStateForPreToolUse(cwd, stateDir, sessionId, threadId);
   if (!activeState) return null;
@@ -6412,7 +6412,11 @@ interface ActiveConductorState {
   phase: string;
 }
 
-function hasTrustedSubagentThreadSpawnPayload(payload: CodexHookPayload): boolean {
+async function hasTrustedTypedSubagentThreadSpawnProvenanceForPreToolUse(
+  payload: CodexHookPayload,
+  cwd: string,
+  sessionId: string,
+): Promise<boolean> {
   const source = safeObject(payload.source);
   const subagent = safeObject(source.subagent);
   const threadSpawn = safeObject(subagent.thread_spawn);
@@ -6423,23 +6427,12 @@ function hasTrustedSubagentThreadSpawnPayload(payload: CodexHookPayload): boolea
       ?? threadSpawn.leaderThreadId,
   ).trim();
   if (!parentThreadId) return false;
-  const agentRole = readPayloadAgentRole(payload);
-  return agentRole !== "" && KNOWN_TYPED_AGENT_ROLES.has(agentRole);
-}
-
-async function hasIndependentSubagentOrWorkerProvenanceForPreToolUse(
-  payload: CodexHookPayload,
-  cwd: string,
-  stateDir: string,
-  sessionId: string,
-): Promise<boolean> {
+  if (!isTypedAgentRolePayload(payload)) return false;
   if (hasTeamWorkerEnvironment()) return true;
-  if (hasTrustedSubagentThreadSpawnPayload(payload)) return true;
-  const threadId = readPayloadThreadId(payload);
-  const nativeSessionId = readPayloadSessionId(payload);
-  const currentSession = await readUsableSessionStateFromStateDir(cwd, stateDir).catch(() => null);
-  const canonicalLeaderNativeSessionId = safeString(currentSession?.native_session_id).trim();
-  return isNativeSubagentHook(cwd, sessionId, nativeSessionId, threadId, canonicalLeaderNativeSessionId);
+  const trackingState = await readSubagentTrackingState(cwd).catch(() => null);
+  const session = trackingState?.sessions?.[sessionId];
+  if (!session) return false;
+  return session.leader_thread_id === parentThreadId || parentThreadId in session.threads;
 }
 
 function isActiveConductorModeState(state: Record<string, unknown> | null, mode: string, sessionId: string): boolean {
@@ -6468,7 +6461,7 @@ async function readActiveMainRootConductorStateForPreToolUse(
   }
   const threadId = readPayloadThreadId(payload);
   if (!sessionId) return null;
-  if (await hasIndependentSubagentOrWorkerProvenanceForPreToolUse(payload, cwd, stateDir, sessionId)) return null;
+  if (await hasTrustedTypedSubagentThreadSpawnProvenanceForPreToolUse(payload, cwd, sessionId)) return null;
 
   const canonicalState = await readVisibleSkillActiveStateForStateDir(stateDir, sessionId);
   if (!canonicalState) return null;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -6417,6 +6417,7 @@ async function hasTrustedTypedSubagentThreadSpawnProvenanceForPreToolUse(
   cwd: string,
   sessionId: string,
 ): Promise<boolean> {
+  if (hasTeamWorkerEnvironment()) return true;
   const source = safeObject(payload.source);
   const subagent = safeObject(source.subagent);
   const threadSpawn = safeObject(subagent.thread_spawn);
@@ -6428,7 +6429,6 @@ async function hasTrustedTypedSubagentThreadSpawnProvenanceForPreToolUse(
   ).trim();
   if (!parentThreadId) return false;
   if (!isTypedAgentRolePayload(payload)) return false;
-  if (hasTeamWorkerEnvironment()) return true;
   const trackingState = await readSubagentTrackingState(cwd).catch(() => null);
   const session = trackingState?.sessions?.[sessionId];
   if (!session) return false;


### PR DESCRIPTION
## What changed

This follow-up tightens typed subagent handling in the conductor/native hook path:

- typed native subagents remain exempt from Main-root conductor blocks only when they have trusted thread-spawn provenance
- custom installed native agent roles are recognized as typed lanes for prompt activation
- the conductor ledger / metadata classification stays scoped to OMX state paths
- regression coverage was added for trusted typed lanes and stale parent provenance

## Why

This keeps the Main-root conductor fence strict while avoiding false positives for real typed child lanes.

## Validation

- `npm run build`
- `npm run check:no-unused`
- `node --test dist/leader/__tests__/contract.test.js dist/scripts/__tests__/codex-native-hook.test.js`
