### PR TITLE
Block same-command handoff artifact script execution

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7150,6 +7150,29 @@ exit 0
       );
       assert.equal(reportedHandoffShape.outputJson, null);
 
+      const blockedHandoffWithSameCommandArtifactExecution = await preToolUse(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-reported-handoff-with-artifact-exec",
+          tool_input: {
+            command: [
+              "mkdir -p .omx/context",
+              "cat > .omx/context/run.sh <<'EOF'",
+              "printf '%s\\n' same-command-artifact-executed",
+              "EOF",
+              "sh .omx/context/run.sh",
+              `omx state write --input '${deepInterviewRalplanHandoffState}' --json`,
+            ].join("\n"),
+          },
+        },
+        { cwd },
+      );
+      assert.equal((blockedHandoffWithSameCommandArtifactExecution.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(String((blockedHandoffWithSameCommandArtifactExecution.outputJson as { reason?: string } | null)?.reason ?? ""), /same-command|Bash write intent|handoff/i);
+
       const blockedHandoffWithImplementationWrite = await preToolUse(
         {
           hook_event_name: "PreToolUse",

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7181,6 +7181,36 @@ exit 0
           "cd .omx/context && sh run.sh",
         ],
         [
+          "tool-di-reported-handoff-with-command-cd-relative-sh-exec",
+          ".omx/context",
+          "run.sh",
+          "command cd .omx/context && sh run.sh",
+        ],
+        [
+          "tool-di-reported-handoff-with-builtin-cd-relative-sh-exec",
+          ".omx/context",
+          "run.sh",
+          "builtin cd .omx/context && sh run.sh",
+        ],
+        [
+          "tool-di-reported-handoff-with-cd-double-dash-relative-sh-exec",
+          ".omx/context",
+          "run.sh",
+          "cd -- .omx/context && sh run.sh",
+        ],
+        [
+          "tool-di-reported-handoff-with-cd-physical-relative-sh-exec",
+          ".omx/context",
+          "run.sh",
+          "cd -P .omx/context && sh run.sh",
+        ],
+        [
+          "tool-di-reported-handoff-with-cd-logical-relative-sh-exec",
+          ".omx/context",
+          "run.sh",
+          "cd -L .omx/context && sh run.sh",
+        ],
+        [
           "tool-di-reported-handoff-with-cd-relative-dot-source",
           ".omx/specs",
           "env.sh",

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7173,6 +7173,50 @@ exit 0
       assert.equal((blockedHandoffWithSameCommandArtifactExecution.outputJson as { decision?: string } | null)?.decision, "block");
       assert.match(String((blockedHandoffWithSameCommandArtifactExecution.outputJson as { reason?: string } | null)?.reason ?? ""), /same-command|Bash write intent|handoff/i);
 
+      for (const [toolUseId, artifactDir, scriptName, executionLine] of [
+        [
+          "tool-di-reported-handoff-with-cd-relative-sh-exec",
+          ".omx/context",
+          "run.sh",
+          "cd .omx/context && sh run.sh",
+        ],
+        [
+          "tool-di-reported-handoff-with-cd-relative-dot-source",
+          ".omx/specs",
+          "env.sh",
+          "cd .omx/specs && . env.sh",
+        ],
+        [
+          "tool-di-reported-handoff-with-cd-relative-direct-exec",
+          ".omx/context",
+          "run-relative.sh",
+          "cd .omx/context && ./run-relative.sh",
+        ],
+      ] as const) {
+        const blockedCwdRelativeArtifactExecution = await preToolUse(
+          {
+            hook_event_name: "PreToolUse",
+            cwd,
+            session_id: "sess-di-artifact",
+            tool_name: "Bash",
+            tool_use_id: toolUseId,
+            tool_input: {
+              command: [
+                `mkdir -p ${artifactDir}`,
+                `cat > ${artifactDir}/${scriptName} <<'EOF'`,
+                "printf '%s\\n' same-command-cwd-relative-artifact-executed",
+                "EOF",
+                executionLine,
+                `omx state write --input '${deepInterviewRalplanHandoffState}' --json`,
+              ].join("\n"),
+            },
+          },
+          { cwd },
+        );
+        assert.equal((blockedCwdRelativeArtifactExecution.outputJson as { decision?: string } | null)?.decision, "block", executionLine);
+        assert.match(String((blockedCwdRelativeArtifactExecution.outputJson as { reason?: string } | null)?.reason ?? ""), /same-command|Bash write intent|handoff/i, executionLine);
+      }
+
       const blockedHandoffWithImplementationWrite = await preToolUse(
         {
           hook_event_name: "PreToolUse",

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7192,6 +7192,18 @@ exit 0
           "run-relative.sh",
           "cd .omx/context && ./run-relative.sh",
         ],
+        [
+          "tool-di-reported-handoff-with-env-chdir-relative-sh-exec",
+          ".omx/context",
+          "run.sh",
+          "env -C .omx/context sh run.sh",
+        ],
+        [
+          "tool-di-reported-handoff-with-env-long-chdir-relative-dot-source",
+          ".omx/specs",
+          "env.sh",
+          "env --chdir .omx/specs . env.sh",
+        ],
       ] as const) {
         const blockedCwdRelativeArtifactExecution = await preToolUse(
           {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7193,6 +7193,12 @@ exit 0
           "cd .omx/context && ./run-relative.sh",
         ],
         [
+          "tool-di-reported-handoff-with-setsid-direct-exec",
+          ".omx/context",
+          "run.sh",
+          "setsid ./.omx/context/run.sh",
+        ],
+        [
           "tool-di-reported-handoff-with-env-chdir-relative-sh-exec",
           ".omx/context",
           "run.sh",

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3854,6 +3854,90 @@ function isEnvCwdChangingOption(word: string): boolean {
     || /^-C.+/.test(word);
 }
 
+interface WrappedCommandExecutionContext {
+  index: number;
+  cwd: string;
+}
+
+function resolveEnvWrappedCommandCwd(currentCwd: string, words: string[], envWordIndex: number, operandIndex: number): string | null {
+  let effectiveCwd = currentCwd;
+  for (let index = envWordIndex + 1; index < operandIndex; index += 1) {
+    const word = words[index] ?? "";
+    if (!word || word === "--" || isShellAssignmentWord(word)) continue;
+    if (word === "-S" || word === "--split-string" || word.startsWith("-S") || word.startsWith("--split-string=")) return null;
+    if (word === "-u" || word === "--unset" || word === "-a" || word === "--argv0") {
+      index += 1;
+      continue;
+    }
+    if (word.startsWith("--unset=") || word.startsWith("--argv0=") || /^-u.+/.test(word) || /^-a.+/.test(word)) continue;
+    if (isEnvCwdChangingOption(word)) {
+      let target = "";
+      if (word === "-C" || word === "--chdir") {
+        target = words[index + 1] ?? "";
+        index += 1;
+      } else if (word.startsWith("--chdir=")) {
+        target = word.slice("--chdir=".length);
+      } else if (word.startsWith("-C") && word.length > 2) {
+        target = word.slice(2);
+      }
+      const normalizedTarget = normalizeCommandDirectoryTarget(target);
+      if (normalizedTarget === null) return null;
+      try {
+        effectiveCwd = resolve(effectiveCwd, normalizedTarget);
+      } catch {
+        return null;
+      }
+    }
+  }
+  return effectiveCwd;
+}
+
+function resolveWrappedCommandExecutionContext(words: string[], currentCwd: string, startIndex = 0): WrappedCommandExecutionContext | null {
+  let commandWordIndex = skipShellCommandPositionPrefixWords(words, startIndex);
+  let effectiveCwd = currentCwd;
+  for (let unwrapCount = 0; unwrapCount < 8; unwrapCount += 1) {
+    const commandWord = words[commandWordIndex] ?? "";
+    if (!commandWord) return null;
+
+    const commandWordBase = shellWordBaseName(commandWord);
+    const operandIndex =
+      commandWordBase === "env"
+        ? findEnvDispatchOperandIndex(words, commandWordIndex + 1)
+        : commandWordBase === "command"
+          ? findCommandDispatchOperandIndex(words, commandWordIndex + 1)
+          : commandWordBase === "exec"
+            ? findExecDispatchOperandIndex(words, commandWordIndex + 1)
+            : commandWordBase === "time"
+              ? findTimeDispatchOperandIndex(words, commandWordIndex + 1)
+              : commandWordBase === "timeout"
+                ? findTimeoutDispatchOperandIndex(words, commandWordIndex + 1)
+                : commandWordBase === "nohup"
+                  ? findCommandDispatchOperandIndex(words, commandWordIndex + 1)
+                  : commandWordBase === "coproc"
+                    ? findCoprocDispatchOperandIndex(words, commandWordIndex + 1)
+                    : commandWordBase === "xargs"
+                      ? findXargsDispatchOperandIndex(words, commandWordIndex + 1)
+                      : commandWordBase === "nice"
+                        ? findNiceDispatchOperandIndex(words, commandWordIndex + 1)
+                        : commandWordBase === "stdbuf"
+                          ? findStdbufDispatchOperandIndex(words, commandWordIndex + 1)
+                          : null;
+    if (operandIndex === null) return { index: commandWordIndex, cwd: effectiveCwd };
+
+    if (commandWordBase === "env") {
+      const envCwd = resolveEnvWrappedCommandCwd(effectiveCwd, words, commandWordIndex, operandIndex);
+      if (envCwd === null) return null;
+      effectiveCwd = envCwd;
+    }
+
+    const nextCommandWordIndex = skipShellCommandPositionPrefixWords(words, operandIndex);
+    if (nextCommandWordIndex === commandWordIndex) return { index: commandWordIndex, cwd: effectiveCwd };
+    commandWordIndex = nextCommandWordIndex;
+  }
+
+  return null;
+}
+
 function resolveStateWriteInputFileCwd(cwd: string, commandPrefix: string): string | null {
   const words = tokenizeShellWords(stripHeredocBodiesForCommandScan(commandPrefix));
   let effectiveCwd = cwd;
@@ -4066,20 +4150,22 @@ function sourcesFileWrittenEarlierInSameCommand(cwd: string, command: string): b
         continue;
       }
 
+      const wrappedCommandContext = resolveWrappedCommandExecutionContext(words, effectiveCwd);
+
       for (let index = 0; index < words.length; index += 1) {
         const word = words[index] ?? "";
+        const operandCwd = wrappedCommandContext && index >= wrappedCommandContext.index ? wrappedCommandContext.cwd : effectiveCwd;
         const operand = word === "source" || word === "."
-          ? normalizeSameCommandScriptTarget(effectiveCwd, firstNonOptionSourceOperand(words, index), assignments)
+          ? normalizeSameCommandScriptTarget(operandCwd, firstNonOptionSourceOperand(words, index), assignments)
           : isNestedShellCommandWord(word)
-            ? normalizeSameCommandScriptTarget(effectiveCwd, firstShellScriptOperand(words, index), assignments)
+            ? normalizeSameCommandScriptTarget(operandCwd, firstShellScriptOperand(words, index), assignments)
             : null;
         if (operand && writtenTargets.has(operand)) return true;
       }
 
-      const commandWordIndex = findWrappedCommandPositionIndex(words, 0);
-      const directExecutionTarget = commandWordIndex === null
+      const directExecutionTarget = wrappedCommandContext === null
         ? null
-        : normalizeSameCommandScriptTarget(effectiveCwd, words[commandWordIndex] ?? "", assignments);
+        : normalizeSameCommandScriptTarget(wrappedCommandContext.cwd, words[wrappedCommandContext.index] ?? "", assignments);
       if (directExecutionTarget && writtenTargets.has(directExecutionTarget)) return true;
 
       for (const nestedCommand of extractNestedShellCommandStringsForStateScan(segment)) {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -5991,6 +5991,7 @@ function isAllowedDeepInterviewRalplanHandoffCommand(cwd: string, command: strin
   if (findUnquotedOmxStateCommandIndexes(canonicalCommand, "clear").length > 0) return false;
   if (hasDynamicNestedShellExecution(canonicalCommand)) return false;
   if (commandHasUntargetedPlanningForbiddenIntent(canonicalCommand)) return false;
+  if (sourcesFileWrittenEarlierInSameCommand(cwd, canonicalCommand)) return false;
   const stateWriteOperations = collectOmxStateCommandOperations(canonicalCommand, "write");
   if (stateWriteOperations.length !== 1) return false;
   const stateWriteOperation = stateWriteOperations[0];

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -5134,7 +5134,7 @@ function findWrappedCommandPositionIndex(words: string[], startIndex: number): n
     const operandIndex =
       commandWordBase === "env"
         ? findEnvDispatchOperandIndex(words, commandWordIndex + 1)
-        : commandWordBase === "command"
+        : commandWordBase === "command" || commandWordBase === "builtin"
           ? findCommandDispatchOperandIndex(words, commandWordIndex + 1)
           : commandWordBase === "exec"
             ? findExecDispatchOperandIndex(words, commandWordIndex + 1)

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3911,7 +3911,7 @@ function resolveWrappedCommandExecutionContext(words: string[], currentCwd: stri
               ? findTimeDispatchOperandIndex(words, commandWordIndex + 1)
               : commandWordBase === "timeout"
                 ? findTimeoutDispatchOperandIndex(words, commandWordIndex + 1)
-                : commandWordBase === "nohup"
+                : commandWordBase === "nohup" || commandWordBase === "setsid"
                   ? findCommandDispatchOperandIndex(words, commandWordIndex + 1)
                   : commandWordBase === "coproc"
                     ? findCoprocDispatchOperandIndex(words, commandWordIndex + 1)
@@ -5142,7 +5142,7 @@ function findWrappedCommandPositionIndex(words: string[], startIndex: number): n
               ? findTimeDispatchOperandIndex(words, commandWordIndex + 1)
               : commandWordBase === "timeout"
                 ? findTimeoutDispatchOperandIndex(words, commandWordIndex + 1)
-                : commandWordBase === "nohup"
+                : commandWordBase === "nohup" || commandWordBase === "setsid"
                   ? findCommandDispatchOperandIndex(words, commandWordIndex + 1)
                   : commandWordBase === "coproc"
                     ? findCoprocDispatchOperandIndex(words, commandWordIndex + 1)

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3825,6 +3825,28 @@ function normalizeCommandDirectoryTarget(rawPath: string): string | null {
   return trimmed;
 }
 
+function resolveSimpleCdCommandCwd(currentCwd: string, words: string[]): string | null {
+  const commandIndex = findWrappedCommandPositionIndex(words, 0);
+  if (commandIndex === null || shellWordBaseName(words[commandIndex] ?? "") !== "cd") return null;
+
+  for (let index = commandIndex + 1; index < words.length; index += 1) {
+    const word = words[index] ?? "";
+    if (!word || word === "--") continue;
+    if (word === "-L" || word === "-P" || word === "-e") continue;
+    if (word.startsWith("-")) return null;
+
+    const normalizedTarget = normalizeCommandDirectoryTarget(word);
+    if (normalizedTarget === null) return null;
+    try {
+      return resolve(currentCwd, normalizedTarget);
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
 function isEnvCwdChangingOption(word: string): boolean {
   return word === "-C"
     || word === "--chdir"
@@ -4026,23 +4048,30 @@ function firstShellScriptOperand(words: string[], shellWordIndex: number): strin
 }
 
 function sourcesFileWrittenEarlierInSameCommand(cwd: string, command: string): boolean {
-  const scanCommand = (currentCommand: string, activeCommands: Set<string>, writtenTargets: Set<string>): boolean => {
+  const scanCommand = (currentCwd: string, currentCommand: string, activeCommands: Set<string>, writtenTargets: Set<string>): boolean => {
     const normalizedCommand = stripHeredocBodiesForCommandScan(normalizeShellLineContinuations(currentCommand));
-    const commandKey = normalizedCommand.trim();
-    if (!commandKey || activeCommands.has(commandKey)) return false;
+    const commandKey = `${currentCwd}\0${normalizedCommand.trim()}`;
+    if (!normalizedCommand.trim() || activeCommands.has(commandKey)) return false;
 
     const assignments = extractCommandLiteralAssignments(normalizedCommand);
     const nextActiveCommands = new Set(activeCommands);
     nextActiveCommands.add(commandKey);
+    let effectiveCwd = currentCwd;
 
     for (const segment of splitShellCommandSegments(normalizedCommand)) {
       const words = tokenizeShellWords(segment);
+      const cdCwd = resolveSimpleCdCommandCwd(effectiveCwd, words);
+      if (cdCwd !== null) {
+        effectiveCwd = cdCwd;
+        continue;
+      }
+
       for (let index = 0; index < words.length; index += 1) {
         const word = words[index] ?? "";
         const operand = word === "source" || word === "."
-          ? normalizeSameCommandScriptTarget(cwd, firstNonOptionSourceOperand(words, index), assignments)
+          ? normalizeSameCommandScriptTarget(effectiveCwd, firstNonOptionSourceOperand(words, index), assignments)
           : isNestedShellCommandWord(word)
-            ? normalizeSameCommandScriptTarget(cwd, firstShellScriptOperand(words, index), assignments)
+            ? normalizeSameCommandScriptTarget(effectiveCwd, firstShellScriptOperand(words, index), assignments)
             : null;
         if (operand && writtenTargets.has(operand)) return true;
       }
@@ -4050,15 +4079,15 @@ function sourcesFileWrittenEarlierInSameCommand(cwd: string, command: string): b
       const commandWordIndex = findWrappedCommandPositionIndex(words, 0);
       const directExecutionTarget = commandWordIndex === null
         ? null
-        : normalizeSameCommandScriptTarget(cwd, words[commandWordIndex] ?? "", assignments);
+        : normalizeSameCommandScriptTarget(effectiveCwd, words[commandWordIndex] ?? "", assignments);
       if (directExecutionTarget && writtenTargets.has(directExecutionTarget)) return true;
 
       for (const nestedCommand of extractNestedShellCommandStringsForStateScan(segment)) {
-        if (scanCommand(nestedCommand, nextActiveCommands, writtenTargets)) return true;
+        if (scanCommand(effectiveCwd, nestedCommand, nextActiveCommands, writtenTargets)) return true;
       }
 
       for (const target of extractDeepInterviewCommandWriteTargets(segment)) {
-        const normalizedTarget = normalizeSameCommandScriptTarget(cwd, target, assignments);
+        const normalizedTarget = normalizeSameCommandScriptTarget(effectiveCwd, target, assignments);
         if (normalizedTarget) writtenTargets.add(normalizedTarget);
       }
     }
@@ -4066,7 +4095,7 @@ function sourcesFileWrittenEarlierInSameCommand(cwd: string, command: string): b
     return false;
   };
 
-  return scanCommand(command, new Set(), new Set());
+  return scanCommand(cwd, command, new Set(), new Set());
 }
 
 

--- a/src/state/__tests__/planning-gate.test.ts
+++ b/src/state/__tests__/planning-gate.test.ts
@@ -58,6 +58,25 @@ omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralp
     assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
   });
 
+  it('classifies grouped cwd same-command protected artifact executions as implementation', () => {
+    const executionForms = [
+      '(cd .omx/context && sh run.sh)',
+      '{ cd .omx/context; sh run.sh; }',
+      '(cd .omx/context; sh run.sh)',
+    ];
+
+    for (const executionForm of executionForms) {
+      const command = `mkdir -p .omx/context
+cat > .omx/context/run.sh <<'SCRIPT'
+echo pwned
+SCRIPT
+${executionForm}
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`;
+
+      assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true, executionForm);
+    }
+  });
+
   it('classifies same-command protected artifact execution through bash -lc as implementation', () => {
     const command = `mkdir -p .omx/context
 cat > .omx/context/run.sh <<'SCRIPT'
@@ -301,6 +320,32 @@ omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralp
 
       assert.equal(decision.allowed, false, command);
       assert.equal(decision.gate_fired, true, command);
+      assert.match(decision.reason!, /Bash denied/);
+    }
+  });
+
+  it('denies grouped cwd same-command protected artifact executions', () => {
+    const probes = [
+      `(cd .omx/context && sh run.sh)`,
+      `{ cd .omx/context; sh run.sh; }`,
+      `(cd .omx/context; sh run.sh)`,
+    ];
+
+    for (const executionForm of probes) {
+      const command = `mkdir -p .omx/context
+cat > .omx/context/run.sh <<'SCRIPT'
+echo pwned
+SCRIPT
+${executionForm}
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`;
+      const decision = evaluatePreToolUseGate(
+        { tool_name: 'Bash', tool_input: command },
+        gateState,
+        false,
+      );
+
+      assert.equal(decision.allowed, false, executionForm);
+      assert.equal(decision.gate_fired, true, executionForm);
       assert.match(decision.reason!, /Bash denied/);
     }
   });

--- a/src/state/__tests__/planning-gate.test.ts
+++ b/src/state/__tests__/planning-gate.test.ts
@@ -34,6 +34,28 @@ describe('planning gate: tool classification', () => {
     assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: 'gh pr merge 42' }), true);
   });
 
+  it('classifies same-command protected artifact write plus shell execution as implementation', () => {
+    const command = `mkdir -p .omx/context
+cat > .omx/context/run.sh <<'SCRIPT'
+#!/bin/sh
+mkdir -p src
+printf pwned > src/pwned.ts
+SCRIPT
+sh .omx/context/run.sh
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan","state":{"deep_interview_gate":{"status":"complete","rationale":"done"}}}' --json`;
+
+    assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
+  });
+
+  it('classifies same-command protected artifact write plus source as implementation', () => {
+    const command = `mkdir -p .omx/specs
+printf 'export PWNED=1\n' > .omx/specs/env.sh
+source .omx/specs/env.sh
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`;
+
+    assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
+  });
+
   it('does not classify Read, Glob, Grep, or safe Bash as implementation tools', () => {
     assert.equal(isImplementationToolCall({ tool_name: 'Read' }), false);
     assert.equal(isImplementationToolCall({ tool_name: 'Glob' }), false);
@@ -41,6 +63,16 @@ describe('planning gate: tool classification', () => {
     assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: 'git status' }), false);
     assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: 'npm test' }), false);
     assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: 'ls -la' }), false);
+  });
+
+  it('does not classify protected artifact write plus ralplan handoff without execution as implementation', () => {
+    const command = `mkdir -p .omx/context
+cat > .omx/context/notes.md <<'EOF'
+# Handoff notes
+EOF
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`;
+
+    assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), false);
   });
 
   it('does not classify Bash without tool_input as implementation tool', () => {
@@ -87,6 +119,26 @@ describe('planning gate: downstream_authority=plan_then_execute + no ralplan con
     );
     assert.equal(decision.allowed, false);
     assert.equal(decision.gate_fired, true);
+  });
+
+  it('denies same-command protected artifact write plus execution when no ralplan consensus artifact exists', () => {
+    const command = `mkdir -p .omx/context
+cat > .omx/context/run.sh <<'SCRIPT'
+#!/bin/sh
+mkdir -p src
+printf pwned > src/pwned.ts
+SCRIPT
+sh .omx/context/run.sh
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan","state":{"deep_interview_gate":{"status":"complete","rationale":"done"}}}' --json`;
+    const decision = evaluatePreToolUseGate(
+      { tool_name: 'Bash', tool_input: command },
+      gateState,
+      false,
+    );
+
+    assert.equal(decision.allowed, false);
+    assert.equal(decision.gate_fired, true);
+    assert.match(decision.reason!, /Bash denied/);
   });
 
   it('allows Read when no ralplan consensus artifact exists', () => {

--- a/src/state/__tests__/planning-gate.test.ts
+++ b/src/state/__tests__/planning-gate.test.ts
@@ -58,6 +58,27 @@ omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralp
     assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
   });
 
+  it('classifies same-command protected artifact execution through cd shell wrappers and options as implementation', () => {
+    const executionForms = [
+      'command cd .omx/context && sh run.sh',
+      'builtin cd .omx/context && sh run.sh',
+      'cd -- .omx/context && sh run.sh',
+      'cd -P .omx/context && sh run.sh',
+      'cd -L .omx/context && sh run.sh',
+    ];
+
+    for (const executionForm of executionForms) {
+      const command = `mkdir -p .omx/context
+cat > .omx/context/run.sh <<'SCRIPT'
+echo pwned
+SCRIPT
+${executionForm}
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`;
+
+      assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true, executionForm);
+    }
+  });
+
   it('classifies grouped cwd same-command protected artifact executions as implementation', () => {
     const executionForms = [
       '(cd .omx/context && sh run.sh)',
@@ -320,6 +341,34 @@ omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralp
 
       assert.equal(decision.allowed, false, command);
       assert.equal(decision.gate_fired, true, command);
+      assert.match(decision.reason!, /Bash denied/);
+    }
+  });
+
+  it('denies cd wrapper and option same-command protected artifact executions', () => {
+    const probes = [
+      'command cd .omx/context && sh run.sh',
+      'builtin cd .omx/context && sh run.sh',
+      'cd -- .omx/context && sh run.sh',
+      'cd -P .omx/context && sh run.sh',
+      'cd -L .omx/context && sh run.sh',
+    ];
+
+    for (const executionForm of probes) {
+      const command = `mkdir -p .omx/context
+cat > .omx/context/run.sh <<'SCRIPT'
+echo pwned
+SCRIPT
+${executionForm}
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`;
+      const decision = evaluatePreToolUseGate(
+        { tool_name: 'Bash', tool_input: command },
+        gateState,
+        false,
+      );
+
+      assert.equal(decision.allowed, false, executionForm);
+      assert.equal(decision.gate_fired, true, executionForm);
       assert.match(decision.reason!, /Bash denied/);
     }
   });

--- a/src/state/__tests__/planning-gate.test.ts
+++ b/src/state/__tests__/planning-gate.test.ts
@@ -69,6 +69,24 @@ omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralp
     assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
   });
 
+  it('classifies direct executable artifact paths through direct-exec wrappers as implementation', () => {
+    for (const executionLine of [
+      'command ./.omx/context/run.sh',
+      'nohup ./.omx/context/run.sh',
+      'time ./.omx/context/run.sh',
+      'setsid ./.omx/context/run.sh',
+    ]) {
+      const command = `mkdir -p .omx/context
+cat > .omx/context/run.sh <<'SCRIPT'
+printf '%s\n' pwned > src/pwned.ts
+SCRIPT
+${executionLine}
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan","state":{"deep_interview_gate":{"status":"complete","rationale":"done"}}}' --json`;
+
+      assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true, executionLine);
+    }
+  });
+
   it('classifies same-command protected specs source through cwd-changing shell as implementation', () => {
     const command = `mkdir -p .omx/specs
 printf 'export PWNED=1\n' > .omx/specs/env.sh

--- a/src/state/__tests__/planning-gate.test.ts
+++ b/src/state/__tests__/planning-gate.test.ts
@@ -47,6 +47,70 @@ omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralp
     assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
   });
 
+  it('classifies same-command protected artifact execution through cd plus timeout as implementation', () => {
+    const command = `mkdir -p .omx/context
+cat > .omx/context/run.sh <<'SCRIPT'
+echo pwned
+SCRIPT
+cd .omx/context && timeout 5 sh run.sh
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`;
+
+    assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
+  });
+
+  it('classifies same-command protected artifact execution through bash -lc as implementation', () => {
+    const command = `mkdir -p .omx/context
+cat > .omx/context/run.sh <<'SCRIPT'
+echo pwned
+SCRIPT
+bash -lc 'sh .omx/context/run.sh'
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`;
+
+    assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
+  });
+
+  it('classifies tee writes when the protected executable is a later output file', () => {
+    const command = `mkdir -p .omx/context
+printf 'echo pwned\n' | tee .omx/context/notes.md .omx/context/run.sh
+sh .omx/context/run.sh
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`;
+
+    assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
+  });
+
+  it('classifies same-command protected artifact execution through script interpreters as implementation', () => {
+    const command = `mkdir -p .omx/context
+cat > .omx/context/run.py <<'PY'
+print('pwned')
+PY
+python3 .omx/context/run.py
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`;
+
+    assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
+  });
+
+  it('classifies shell script operands after shell options that consume the next word', () => {
+    const command = `mkdir -p .omx/context
+cat > .omx/context/run.sh <<'SCRIPT'
+echo pwned
+SCRIPT
+bash -o posix .omx/context/run.sh
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`;
+
+    assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
+  });
+
+  it('classifies same-command protected artifact execution through attached env chdir as implementation', () => {
+    const command = `mkdir -p .omx/context
+cat > .omx/context/run.sh <<'SCRIPT'
+echo pwned
+SCRIPT
+env -C.omx/context sh run.sh
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`;
+
+    assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
+  });
+
   it('classifies same-command protected artifact execution through env -C as implementation', () => {
     const command = `mkdir -p .omx/context
 cat > .omx/context/run.sh <<'SCRIPT'
@@ -188,6 +252,57 @@ omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralp
     assert.equal(decision.allowed, false);
     assert.equal(decision.gate_fired, true);
     assert.match(decision.reason!, /Bash denied/);
+  });
+
+  it('denies review5 protected artifact write plus same-command execution probes', () => {
+    const probes = [
+      `mkdir -p .omx/context
+cat > .omx/context/run.sh <<'SCRIPT'
+echo pwned
+SCRIPT
+cd .omx/context && timeout 5 sh run.sh
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`,
+      `mkdir -p .omx/context
+cat > .omx/context/run.sh <<'SCRIPT'
+echo pwned
+SCRIPT
+bash -lc 'sh .omx/context/run.sh'
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`,
+      `mkdir -p .omx/context
+printf 'echo pwned\n' | tee .omx/context/notes.md .omx/context/run.sh
+sh .omx/context/run.sh
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`,
+      `mkdir -p .omx/context
+cat > .omx/context/run.py <<'PY'
+print('pwned')
+PY
+python3 .omx/context/run.py
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`,
+      `mkdir -p .omx/context
+cat > .omx/context/run.sh <<'SCRIPT'
+echo pwned
+SCRIPT
+bash -o posix .omx/context/run.sh
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`,
+      `mkdir -p .omx/context
+cat > .omx/context/run.sh <<'SCRIPT'
+echo pwned
+SCRIPT
+env -C.omx/context sh run.sh
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`,
+    ];
+
+    for (const command of probes) {
+      const decision = evaluatePreToolUseGate(
+        { tool_name: 'Bash', tool_input: command },
+        gateState,
+        false,
+      );
+
+      assert.equal(decision.allowed, false, command);
+      assert.equal(decision.gate_fired, true, command);
+      assert.match(decision.reason!, /Bash denied/);
+    }
   });
 
   it('allows Read when no ralplan consensus artifact exists', () => {

--- a/src/state/__tests__/planning-gate.test.ts
+++ b/src/state/__tests__/planning-gate.test.ts
@@ -47,6 +47,37 @@ omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralp
     assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
   });
 
+  it('classifies same-command protected artifact execution through env -C as implementation', () => {
+    const command = `mkdir -p .omx/context
+cat > .omx/context/run.sh <<'SCRIPT'
+printf '%s\n' pwned > src/pwned.ts
+SCRIPT
+env -C .omx/context sh run.sh
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan","state":{"deep_interview_gate":{"status":"complete","rationale":"done"}}}' --json`;
+
+    assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
+  });
+
+  it('classifies same-command protected artifact execution through env --chdir as implementation', () => {
+    const command = `mkdir -p .omx/context
+cat > .omx/context/run.sh <<'SCRIPT'
+printf '%s\n' pwned > src/pwned.ts
+SCRIPT
+env --chdir=.omx/context sh run.sh
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan","state":{"deep_interview_gate":{"status":"complete","rationale":"done"}}}' --json`;
+
+    assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
+  });
+
+  it('classifies same-command protected specs source through cwd-changing shell as implementation', () => {
+    const command = `mkdir -p .omx/specs
+printf 'export PWNED=1\n' > .omx/specs/env.sh
+env --chdir=.omx/specs sh -c '. env.sh'
+omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan"}' --json`;
+
+    assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
+  });
+
   it('classifies same-command protected artifact write plus source as implementation', () => {
     const command = `mkdir -p .omx/specs
 printf 'export PWNED=1\n' > .omx/specs/env.sh

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -37,6 +37,162 @@ function normalizeProtectedArtifactPath(path: string): string {
   return path.replace(/^\.\//, '');
 }
 
+function normalizeShellPath(path: string): string {
+  return path
+    .replace(/\\/g, '/')
+    .replace(/^\.\//, '')
+    .replace(/\/\.\//g, '/')
+    .replace(/\/+/g, '/');
+}
+
+function joinShellPath(cwd: string, path: string): string {
+  if (!cwd || cwd === '.') return normalizeShellPath(path);
+  if (path.startsWith('/')) return normalizeShellPath(path);
+  return normalizeShellPath(`${cwd}/${path}`);
+}
+
+function sameShellPath(candidate: string, target: string): boolean {
+  return normalizeShellPath(candidate) === normalizeShellPath(target);
+}
+
+function shellWords(statement: string): string[] {
+  const words: string[] = [];
+  let current = '';
+  let quote: 'single' | 'double' | null = null;
+  let escaped = false;
+
+  for (const char of statement) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && quote !== 'single') {
+      escaped = true;
+      continue;
+    }
+    if (char === "'" && quote !== 'double') {
+      quote = quote === 'single' ? null : 'single';
+      continue;
+    }
+    if (char === '"' && quote !== 'single') {
+      quote = quote === 'double' ? null : 'double';
+      continue;
+    }
+    if (/\s/.test(char) && !quote) {
+      if (current) {
+        words.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (current) words.push(current);
+  return words;
+}
+
+function shellStatements(command: string): string[] {
+  return command
+    .split(/(?:\n|;|&&|\|\|)/)
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+}
+
+function isShellName(name: string): boolean {
+  return /^(?:sh|bash|dash|zsh|ksh|fish)$/.test(name);
+}
+
+function resolveCommandOperand(cwd: string, operand: string): string {
+  return joinShellPath(cwd, operand.replace(/^\.\//, ''));
+}
+
+function shellExecutionMatches(words: string[], cwd: string, targetPath: string): boolean {
+  if (words.length === 0) return false;
+  const commandName = words[0]!;
+
+  if (commandName === 'source' || commandName === '.') {
+    const operand = words[1];
+    return Boolean(operand && sameShellPath(resolveCommandOperand(cwd, operand), targetPath));
+  }
+
+  if (isShellName(commandName)) {
+    const args = words.slice(1);
+    for (let index = 0; index < args.length; index += 1) {
+      const word = args[index]!;
+      if (word === '--') continue;
+      if (word === '-c') {
+        const inlineCommand = args[index + 1];
+        return Boolean(inlineCommand && hasTokenizedExecutionOfPath(inlineCommand, targetPath, cwd));
+      }
+      if (word.startsWith('-')) continue;
+      return sameShellPath(resolveCommandOperand(cwd, word), targetPath);
+    }
+    return false;
+  }
+
+  if (commandName.startsWith('./') || commandName.includes('/')) {
+    return sameShellPath(resolveCommandOperand(cwd, commandName), targetPath);
+  }
+
+  return false;
+}
+
+function unwrapEnvCommand(words: string[], cwd: string): { words: string[]; cwd: string } {
+  if (words[0] !== 'env') return { words, cwd };
+
+  let index = 1;
+  let envCwd = cwd;
+  while (index < words.length) {
+    const word = words[index]!;
+    if (word === '--') {
+      index += 1;
+      break;
+    }
+    if (word === '-C' || word === '--chdir') {
+      const next = words[index + 1];
+      if (!next) return { words: [], cwd: envCwd };
+      envCwd = resolveCommandOperand(envCwd, next);
+      index += 2;
+      continue;
+    }
+    if (word.startsWith('--chdir=')) {
+      envCwd = resolveCommandOperand(envCwd, word.slice('--chdir='.length));
+      index += 1;
+      continue;
+    }
+    if (word.startsWith('-')) {
+      index += 1;
+      continue;
+    }
+    if (/^[A-Za-z_][A-Za-z0-9_]*=.*/.test(word)) {
+      index += 1;
+      continue;
+    }
+    break;
+  }
+
+  return { words: words.slice(index), cwd: envCwd };
+}
+
+function hasTokenizedExecutionOfPath(command: string, path: string, initialCwd = ''): boolean {
+  const targetPath = normalizeShellPath(path);
+  let cwd = initialCwd;
+  for (const statement of shellStatements(command)) {
+    const words = shellWords(statement);
+    if (words.length === 0) continue;
+    if (words[0] === 'cd' && words[1]) {
+      cwd = resolveCommandOperand(cwd, words[1]);
+      continue;
+    }
+
+    const unwrapped = unwrapEnvCommand(words, cwd);
+    if (shellExecutionMatches(unwrapped.words, unwrapped.cwd, targetPath)) return true;
+  }
+  return false;
+}
+
 function collectProtectedArtifactWritePaths(command: string): Set<string> {
   const paths = new Set<string>();
   const protectedPath = String.raw`(["']?)((?:\.\/)?\.omx\/(?:context|specs)\/[^"'\s;|&<>]+)\1`;
@@ -66,7 +222,10 @@ function executesOrSourcesPath(command: string, path: string): boolean {
   const directExecPattern = new RegExp(
     String.raw`(?:^|[;&|()\n])\s*(?:\.\/)?${escapedPath}(?:$|[\s;&|)])`,
   );
-  return shellExecPattern.test(command) || sourcePattern.test(command) || directExecPattern.test(command);
+  return shellExecPattern.test(command)
+    || sourcePattern.test(command)
+    || directExecPattern.test(command)
+    || hasTokenizedExecutionOfPath(command, path);
 }
 
 function hasSameCommandProtectedArtifactExecution(command: string): boolean {

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -29,6 +29,53 @@ const DENIED_BASH_PATTERNS: RegExp[] = [
   /\bgh\s+pr\s+merge\b/,
 ];
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalizeProtectedArtifactPath(path: string): string {
+  return path.replace(/^\.\//, '');
+}
+
+function collectProtectedArtifactWritePaths(command: string): Set<string> {
+  const paths = new Set<string>();
+  const protectedPath = String.raw`(["']?)((?:\.\/)?\.omx\/(?:context|specs)\/[^"'\s;|&<>]+)\1`;
+  const redirectPattern = new RegExp(String.raw`(?:^|[^<])>>?\s*${protectedPath}`, 'g');
+  const teePattern = new RegExp(String.raw`\btee\s+(?:-[a-zA-Z]+\s+)*(?:--\s+)?${protectedPath}`, 'g');
+
+  for (const pattern of [redirectPattern, teePattern]) {
+    for (const match of command.matchAll(pattern)) {
+      const path = match[2]?.trim();
+      if (path) paths.add(normalizeProtectedArtifactPath(path));
+    }
+  }
+
+  return paths;
+}
+
+function executesOrSourcesPath(command: string, path: string): boolean {
+  const escapedPath = escapeRegExp(path);
+  const optionalDotSlashPath = String.raw`(?:\.\/)?${escapedPath}`;
+  const quotedPath = String.raw`["']${optionalDotSlashPath}["']|${optionalDotSlashPath}`;
+  const shellExecPattern = new RegExp(
+    String.raw`(?:^|[\s;&|()])(?:sh|bash|dash|zsh|ksh|fish)\s+(?:-[^\s]+\s+)*(${quotedPath})(?:$|[\s;&|)])`,
+  );
+  const sourcePattern = new RegExp(
+    String.raw`(?:^|[\s;&|()])(?:source|\.)\s+(${quotedPath})(?:$|[\s;&|)])`,
+  );
+  const directExecPattern = new RegExp(
+    String.raw`(?:^|[;&|()\n])\s*(?:\.\/)?${escapedPath}(?:$|[\s;&|)])`,
+  );
+  return shellExecPattern.test(command) || sourcePattern.test(command) || directExecPattern.test(command);
+}
+
+function hasSameCommandProtectedArtifactExecution(command: string): boolean {
+  for (const path of collectProtectedArtifactWritePaths(command)) {
+    if (executesOrSourcesPath(command, path)) return true;
+  }
+  return false;
+}
+
 export const PLANNING_GATE_BYPASS_TTL_MS = 10 * 60 * 1000;
 
 export const BYPASS_PLANNING_GATE_PHRASE = 'bypass planning gate';
@@ -36,7 +83,8 @@ export const BYPASS_PLANNING_GATE_PHRASE = 'bypass planning gate';
 export function isImplementationToolCall(input: PreToolUseGateInput): boolean {
   if (IMPLEMENTATION_TOOLS.has(input.tool_name)) return true;
   if (input.tool_name === 'Bash' && typeof input.tool_input === 'string') {
-    return DENIED_BASH_PATTERNS.some((pattern) => pattern.test(input.tool_input!));
+    return DENIED_BASH_PATTERNS.some((pattern) => pattern.test(input.tool_input!))
+      || hasSameCommandProtectedArtifactExecution(input.tool_input);
   }
   return false;
 }

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -93,11 +93,34 @@ function shellWords(statement: string): string[] {
   return words;
 }
 
-function shellStatements(command: string): string[] {
-  const statements: string[] = [];
+interface ShellStatementRecord {
+  text: string;
+  subshellDepth: number;
+  closesSubshells: number;
+}
+
+function shellStatementRecords(command: string): ShellStatementRecord[] {
+  const statements: ShellStatementRecord[] = [];
   let current = '';
   let quote: 'single' | 'double' | null = null;
   let escaped = false;
+  let subshellDepth = 0;
+  let statementSubshellDepth = 0;
+  let closesSubshells = 0;
+
+  const pushStatement = () => {
+    const statement = current.trim();
+    if (statement) {
+      statements.push({
+        text: statement,
+        subshellDepth: statementSubshellDepth,
+        closesSubshells,
+      });
+    }
+    current = '';
+    statementSubshellDepth = subshellDepth;
+    closesSubshells = 0;
+  };
 
   for (let index = 0; index < command.length; index += 1) {
     const char = command[index]!;
@@ -124,20 +147,35 @@ function shellStatements(command: string): string[] {
       continue;
     }
 
-    if (!quote && (char === '\n' || char === ';' || (char === '&' && next === '&') || (char === '|' && next === '|'))) {
-      const statement = current.trim();
-      if (statement) statements.push(statement);
-      current = '';
-      if ((char === '&' && next === '&') || (char === '|' && next === '|')) index += 1;
+    if (!quote && char === '(' && !current.trim()) {
+      subshellDepth += 1;
+      statementSubshellDepth = subshellDepth;
+      current += char;
       continue;
     }
 
     current += char;
+
+    if (!quote && char === ')' && subshellDepth > 0) {
+      subshellDepth -= 1;
+      closesSubshells += 1;
+      continue;
+    }
+
+    if (!quote && (char === '\n' || char === ';' || (char === '&' && next === '&') || (char === '|' && next === '|'))) {
+      current = current.slice(0, -1);
+      pushStatement();
+      if ((char === '&' && next === '&') || (char === '|' && next === '|')) index += 1;
+      continue;
+    }
   }
 
-  const statement = current.trim();
-  if (statement) statements.push(statement);
+  pushStatement();
   return statements;
+}
+
+function shellStatements(command: string): string[] {
+  return shellStatementRecords(command).map((statement) => statement.text);
 }
 
 function isShellName(name: string): boolean {
@@ -320,19 +358,68 @@ function unwrapEnvCommand(words: string[], cwd: string): { words: string[]; cwd:
   return { words: words.slice(index), cwd: envCwd };
 }
 
-function hasTokenizedExecutionOfPath(command: string, path: string, initialCwd = ''): boolean {
-  const targetPath = normalizeShellPath(path);
-  let cwd = initialCwd;
-  for (const statement of shellStatements(command)) {
-    const words = shellWords(statement);
-    if (words.length === 0) continue;
-    if (words[0] === 'cd' && words[1]) {
-      cwd = resolveCommandOperand(cwd, words[1]);
+function groupedShellWords(statement: string): string[] {
+  const words = shellWords(statement);
+  while (words.length > 0) {
+    const first = words[0]!;
+    if (first === '{') {
+      words.shift();
       continue;
     }
+    const stripped = first.replace(/^\(+/, '');
+    if (stripped !== first) {
+      if (stripped) words[0] = stripped;
+      else words.shift();
+      continue;
+    }
+    break;
+  }
 
-    const unwrapped = unwrapExecutionCommand(words, cwd);
-    if (shellExecutionMatches(unwrapped.words, unwrapped.cwd, targetPath)) return true;
+  while (words.length > 0) {
+    const lastIndex = words.length - 1;
+    const last = words[lastIndex]!;
+    if (last === '}') {
+      words.pop();
+      continue;
+    }
+    const stripped = last.replace(/[)}]+$/, '');
+    if (stripped !== last) {
+      if (stripped) words[lastIndex] = stripped;
+      else words.pop();
+      continue;
+    }
+    break;
+  }
+
+  return words;
+}
+
+function scopedCwd(cwds: Map<number, string>, depth: number, initialCwd: string): string {
+  if (cwds.has(depth)) return cwds.get(depth)!;
+  if (depth <= 0) return initialCwd;
+  return scopedCwd(cwds, depth - 1, initialCwd);
+}
+
+function hasTokenizedExecutionOfPath(command: string, path: string, initialCwd = ''): boolean {
+  const targetPath = normalizeShellPath(path);
+  const cwds = new Map<number, string>([[0, initialCwd]]);
+  for (const statement of shellStatementRecords(command)) {
+    const cwd = scopedCwd(cwds, statement.subshellDepth, initialCwd);
+    const words = groupedShellWords(statement.text);
+    if (words.length > 0) {
+      if (words[0] === 'cd' && words[1]) {
+        cwds.set(statement.subshellDepth, resolveCommandOperand(cwd, words[1]));
+      } else {
+        const unwrapped = unwrapExecutionCommand(words, cwd);
+        if (shellExecutionMatches(unwrapped.words, unwrapped.cwd, targetPath)) return true;
+      }
+    }
+
+    if (statement.closesSubshells > 0) {
+      for (let depth = statement.subshellDepth; depth > statement.subshellDepth - statement.closesSubshells; depth -= 1) {
+        cwds.delete(depth);
+      }
+    }
   }
   return false;
 }

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -94,18 +94,92 @@ function shellWords(statement: string): string[] {
 }
 
 function shellStatements(command: string): string[] {
-  return command
-    .split(/(?:\n|;|&&|\|\|)/)
-    .map((statement) => statement.trim())
-    .filter(Boolean);
+  const statements: string[] = [];
+  let current = '';
+  let quote: 'single' | 'double' | null = null;
+  let escaped = false;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index]!;
+    const next = command[index + 1];
+
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && quote !== 'single') {
+      current += char;
+      escaped = true;
+      continue;
+    }
+    if (char === "'" && quote !== 'double') {
+      current += char;
+      quote = quote === 'single' ? null : 'single';
+      continue;
+    }
+    if (char === '"' && quote !== 'single') {
+      current += char;
+      quote = quote === 'double' ? null : 'double';
+      continue;
+    }
+
+    if (!quote && (char === '\n' || char === ';' || (char === '&' && next === '&') || (char === '|' && next === '|'))) {
+      const statement = current.trim();
+      if (statement) statements.push(statement);
+      current = '';
+      if ((char === '&' && next === '&') || (char === '|' && next === '|')) index += 1;
+      continue;
+    }
+
+    current += char;
+  }
+
+  const statement = current.trim();
+  if (statement) statements.push(statement);
+  return statements;
 }
 
 function isShellName(name: string): boolean {
   return /^(?:sh|bash|dash|zsh|ksh|fish)$/.test(name);
 }
 
+function isScriptInterpreterName(name: string): boolean {
+  return /^(?:python[0-9.]?|python3(?:\.[0-9]+)?|node|ruby|perl|php|lua|deno|bun)$/.test(name);
+}
+
+function isProtectedArtifactPath(path: string): boolean {
+  return /^(?:\.\/)?\.omx\/(?:context|specs)\/[^"'\s;|&<>]+$/.test(path);
+}
+
 function resolveCommandOperand(cwd: string, operand: string): string {
   return joinShellPath(cwd, operand.replace(/^\.\//, ''));
+}
+
+function shellScriptOperand(args: string[], cwd: string, targetPath: string): boolean {
+  for (let index = 0; index < args.length; index += 1) {
+    const word = args[index]!;
+    if (word === '--') {
+      const operand = args[index + 1];
+      return Boolean(operand && sameShellPath(resolveCommandOperand(cwd, operand), targetPath));
+    }
+    if (word === '-c' || word === '--command') {
+      const inlineCommand = args[index + 1];
+      return Boolean(inlineCommand && hasTokenizedExecutionOfPath(inlineCommand, targetPath, cwd));
+    }
+    if (/^-[A-Za-z]*c[A-Za-z]*$/.test(word)) {
+      const inlineCommand = args[index + 1];
+      return Boolean(inlineCommand && hasTokenizedExecutionOfPath(inlineCommand, targetPath, cwd));
+    }
+    if (word === '-o' || word === '+o' || word === '-O' || word === '+O' || word === '--init-file' || word === '--rcfile') {
+      index += 1;
+      continue;
+    }
+    if (word.startsWith('--init-file=') || word.startsWith('--rcfile=')) continue;
+    if (word.startsWith('-') || word.startsWith('+')) continue;
+    return sameShellPath(resolveCommandOperand(cwd, word), targetPath);
+  }
+  return false;
 }
 
 function shellExecutionMatches(words: string[], cwd: string, targetPath: string): boolean {
@@ -118,18 +192,11 @@ function shellExecutionMatches(words: string[], cwd: string, targetPath: string)
   }
 
   if (isShellName(commandName)) {
-    const args = words.slice(1);
-    for (let index = 0; index < args.length; index += 1) {
-      const word = args[index]!;
-      if (word === '--') continue;
-      if (word === '-c') {
-        const inlineCommand = args[index + 1];
-        return Boolean(inlineCommand && hasTokenizedExecutionOfPath(inlineCommand, targetPath, cwd));
-      }
-      if (word.startsWith('-')) continue;
-      return sameShellPath(resolveCommandOperand(cwd, word), targetPath);
-    }
-    return false;
+    return shellScriptOperand(words.slice(1), cwd, targetPath);
+  }
+
+  if (isScriptInterpreterName(commandName)) {
+    return shellScriptOperand(words.slice(1), cwd, targetPath);
   }
 
   if (commandName.startsWith('./') || commandName.includes('/')) {
@@ -164,6 +231,26 @@ function findTimeWrapperOperandIndex(words: string[], startIndex: number): numbe
   return null;
 }
 
+function findTimeoutWrapperOperandIndex(words: string[], startIndex: number): number | null {
+  let sawDuration = false;
+  for (let index = startIndex; index < words.length; index += 1) {
+    const word = words[index]!;
+    if (!word || word === '--' || /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(word)) continue;
+    if (word === '-k' || word === '--kill-after' || word === '-s' || word === '--signal') {
+      index += 1;
+      continue;
+    }
+    if (word.startsWith('--kill-after=') || word.startsWith('--signal=')) continue;
+    if (word.startsWith('-')) continue;
+    if (!sawDuration) {
+      sawDuration = true;
+      continue;
+    }
+    return index;
+  }
+  return null;
+}
+
 function unwrapExecutionCommand(words: string[], cwd: string): { words: string[]; cwd: string } {
   let currentWords = words;
   let currentCwd = cwd;
@@ -181,7 +268,9 @@ function unwrapExecutionCommand(words: string[], cwd: string): { words: string[]
       ? findDirectWrapperOperandIndex(currentWords, 1)
       : commandName === 'time'
         ? findTimeWrapperOperandIndex(currentWords, 1)
-        : null;
+        : commandName === 'timeout' || commandName === 'gtimeout'
+          ? findTimeoutWrapperOperandIndex(currentWords, 1)
+          : null;
     if (operandIndex === null) return { words: currentWords, cwd: currentCwd };
     currentWords = currentWords.slice(operandIndex);
   }
@@ -205,6 +294,11 @@ function unwrapEnvCommand(words: string[], cwd: string): { words: string[]; cwd:
       if (!next) return { words: [], cwd: envCwd };
       envCwd = resolveCommandOperand(envCwd, next);
       index += 2;
+      continue;
+    }
+    if (word.startsWith('-C') && word.length > 2) {
+      envCwd = resolveCommandOperand(envCwd, word.slice(2));
+      index += 1;
       continue;
     }
     if (word.startsWith('--chdir=')) {
@@ -247,12 +341,21 @@ function collectProtectedArtifactWritePaths(command: string): Set<string> {
   const paths = new Set<string>();
   const protectedPath = String.raw`(["']?)((?:\.\/)?\.omx\/(?:context|specs)\/[^"'\s;|&<>]+)\1`;
   const redirectPattern = new RegExp(String.raw`(?:^|[^<])>>?\s*${protectedPath}`, 'g');
-  const teePattern = new RegExp(String.raw`\btee\s+(?:-[a-zA-Z]+\s+)*(?:--\s+)?${protectedPath}`, 'g');
 
-  for (const pattern of [redirectPattern, teePattern]) {
-    for (const match of command.matchAll(pattern)) {
-      const path = match[2]?.trim();
-      if (path) paths.add(normalizeProtectedArtifactPath(path));
+  for (const match of command.matchAll(redirectPattern)) {
+    const path = match[2]?.trim();
+    if (path) paths.add(normalizeProtectedArtifactPath(path));
+  }
+
+  for (const statement of shellStatements(command)) {
+    const words = shellWords(statement);
+    const teeIndex = words.findIndex((word) => word === 'tee');
+    if (teeIndex === -1) continue;
+    for (let index = teeIndex + 1; index < words.length; index += 1) {
+      const word = words[index]!;
+      if (word === '--') continue;
+      if (word.startsWith('-')) continue;
+      if (isProtectedArtifactPath(word)) paths.add(normalizeProtectedArtifactPath(word));
     }
   }
 

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -139,6 +139,56 @@ function shellExecutionMatches(words: string[], cwd: string, targetPath: string)
   return false;
 }
 
+function findDirectWrapperOperandIndex(words: string[], startIndex: number): number | null {
+  for (let index = startIndex; index < words.length; index += 1) {
+    const word = words[index]!;
+    if (!word || word === '--' || /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(word)) continue;
+    if (word.startsWith('-')) continue;
+    return index;
+  }
+  return null;
+}
+
+function findTimeWrapperOperandIndex(words: string[], startIndex: number): number | null {
+  for (let index = startIndex; index < words.length; index += 1) {
+    const word = words[index]!;
+    if (!word || word === '--' || /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(word)) continue;
+    if (word === '-f' || word === '--format' || word === '-o' || word === '--output') {
+      index += 1;
+      continue;
+    }
+    if (word.startsWith('--format=') || word.startsWith('--output=')) continue;
+    if (word.startsWith('-')) continue;
+    return index;
+  }
+  return null;
+}
+
+function unwrapExecutionCommand(words: string[], cwd: string): { words: string[]; cwd: string } {
+  let currentWords = words;
+  let currentCwd = cwd;
+  for (let unwrapCount = 0; unwrapCount < 8; unwrapCount += 1) {
+    const commandName = currentWords[0];
+    if (commandName === 'env') {
+      const unwrapped = unwrapEnvCommand(currentWords, currentCwd);
+      if (unwrapped.words === currentWords) return unwrapped;
+      currentWords = unwrapped.words;
+      currentCwd = unwrapped.cwd;
+      continue;
+    }
+
+    const operandIndex = commandName === 'command' || commandName === 'nohup' || commandName === 'setsid'
+      ? findDirectWrapperOperandIndex(currentWords, 1)
+      : commandName === 'time'
+        ? findTimeWrapperOperandIndex(currentWords, 1)
+        : null;
+    if (operandIndex === null) return { words: currentWords, cwd: currentCwd };
+    currentWords = currentWords.slice(operandIndex);
+  }
+
+  return { words: currentWords, cwd: currentCwd };
+}
+
 function unwrapEnvCommand(words: string[], cwd: string): { words: string[]; cwd: string } {
   if (words[0] !== 'env') return { words, cwd };
 
@@ -187,7 +237,7 @@ function hasTokenizedExecutionOfPath(command: string, path: string, initialCwd =
       continue;
     }
 
-    const unwrapped = unwrapEnvCommand(words, cwd);
+    const unwrapped = unwrapExecutionCommand(words, cwd);
     if (shellExecutionMatches(unwrapped.words, unwrapped.cwd, targetPath)) return true;
   }
   return false;

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -316,6 +316,41 @@ function unwrapExecutionCommand(words: string[], cwd: string): { words: string[]
   return { words: currentWords, cwd: currentCwd };
 }
 
+function unwrapCdCommandWords(words: string[]): string[] {
+  let currentWords = words;
+  for (let unwrapCount = 0; unwrapCount < 4; unwrapCount += 1) {
+    const commandName = currentWords[0];
+    if (commandName === 'command') {
+      const operandIndex = findDirectWrapperOperandIndex(currentWords, 1);
+      if (operandIndex === null) return currentWords;
+      currentWords = currentWords.slice(operandIndex);
+      continue;
+    }
+    if (commandName === 'builtin') {
+      currentWords = currentWords.slice(1);
+      continue;
+    }
+    return currentWords;
+  }
+  return currentWords;
+}
+
+function cdOperand(words: string[]): string | null {
+  if (words[0] !== 'cd') return null;
+  for (let index = 1; index < words.length; index += 1) {
+    const word = words[index]!;
+    if (word === '--') continue;
+    if (/^-[LP]+$/.test(word)) continue;
+    return word;
+  }
+  return null;
+}
+
+function cdTransitionTarget(words: string[], cwd: string): string | null {
+  const operand = cdOperand(unwrapCdCommandWords(words));
+  return operand ? resolveCommandOperand(cwd, operand) : null;
+}
+
 function unwrapEnvCommand(words: string[], cwd: string): { words: string[]; cwd: string } {
   if (words[0] !== 'env') return { words, cwd };
 
@@ -407,8 +442,9 @@ function hasTokenizedExecutionOfPath(command: string, path: string, initialCwd =
     const cwd = scopedCwd(cwds, statement.subshellDepth, initialCwd);
     const words = groupedShellWords(statement.text);
     if (words.length > 0) {
-      if (words[0] === 'cd' && words[1]) {
-        cwds.set(statement.subshellDepth, resolveCommandOperand(cwd, words[1]));
+      const cdTarget = cdTransitionTarget(words, cwd);
+      if (cdTarget) {
+        cwds.set(statement.subshellDepth, cdTarget);
       } else {
         const unwrapped = unwrapExecutionCommand(words, cwd);
         if (shellExecutionMatches(unwrapped.words, unwrapped.cwd, targetPath)) return true;


### PR DESCRIPTION
Closes #3049

## Summary
- classify Bash payloads as implementation when they write a `.omx/context/**` or `.omx/specs/**` artifact and execute/source the same path in the same command
- preserve legitimate planning artifact writes plus ralplan handoff state writes when no same-command execution occurs
- add regression coverage for the reported `.omx/context/run.sh` repro and `.omx/specs/env.sh` source variant

## Verification
- `npm install`
- `npm run build`
- `node dist/scripts/run-test-files.js dist/state/__tests__/planning-gate.test.js`
- `npm run check:no-unused`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*