### PR TITLE
Fix planning guard Python artifact writes

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1015,6 +1015,27 @@ PY`,
       );
       assert.equal(allowedPythonPlanningArtifactWrite.outputJson, null);
 
+      const blockedPythonPlanningArtifactExecution = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-wrapper-implementation-block",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-wrapper-python-planning-artifact-exec",
+          tool_input: {
+            command: `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/plans/run.sh').write_text('echo ran')
+PY
+sh .omx/plans/run.sh`,
+          },
+        },
+        { cwd },
+      );
+      assert.equal(blockedPythonPlanningArtifactExecution.outputJson && typeof blockedPythonPlanningArtifactExecution.outputJson === "object" ? (blockedPythonPlanningArtifactExecution.outputJson as { decision?: string }).decision : undefined, "block");
+      assert.match(JSON.stringify(blockedPythonPlanningArtifactExecution.outputJson), /same-command|Bash write intent|implementation/i);
+
       const blockedPythonAllowedMkdirDynamicSourceWrite = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",
@@ -7254,6 +7275,29 @@ exit 0
       );
       assert.equal((blockedHandoffWithSameCommandArtifactExecution.outputJson as { decision?: string } | null)?.decision, "block");
       assert.match(String((blockedHandoffWithSameCommandArtifactExecution.outputJson as { reason?: string } | null)?.reason ?? ""), /same-command|Bash write intent|handoff/i);
+
+      const blockedHandoffWithPythonSameCommandArtifactExecution = await preToolUse(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-reported-handoff-with-python-artifact-exec",
+          tool_input: {
+            command: [
+              "python3 - <<'PY'",
+              "from pathlib import Path",
+              "Path('.omx/context/run.sh').write_text('echo ran')",
+              "PY",
+              "sh .omx/context/run.sh",
+              `omx state write --input '${deepInterviewRalplanHandoffState}' --json`,
+            ].join("\n"),
+          },
+        },
+        { cwd },
+      );
+      assert.equal((blockedHandoffWithPythonSameCommandArtifactExecution.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(String((blockedHandoffWithPythonSameCommandArtifactExecution.outputJson as { reason?: string } | null)?.reason ?? ""), /same-command|Bash write intent|handoff/i);
 
       for (const [toolUseId, artifactDir, scriptName, executionLine] of [
         [

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1015,6 +1015,27 @@ PY`,
       );
       assert.equal(allowedPythonPlanningArtifactWrite.outputJson, null);
 
+      const blockedPythonAllowedMkdirDynamicSourceWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-wrapper-implementation-block",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-wrapper-python-allowed-mkdir-dynamic-source-write",
+          tool_input: {
+            command: `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/plans').mkdir(parents=True, exist_ok=True)
+(Path('src') / 'generated.ts').write_text('implementation')
+PY`,
+          },
+        },
+        { cwd },
+      );
+      assert.equal(blockedPythonAllowedMkdirDynamicSourceWrite.outputJson && typeof blockedPythonAllowedMkdirDynamicSourceWrite.outputJson === "object" ? (blockedPythonAllowedMkdirDynamicSourceWrite.outputJson as { decision?: string }).decision : undefined, "block");
+      assert.match(JSON.stringify(blockedPythonAllowedMkdirDynamicSourceWrite.outputJson), /write intent did not identify an allowed planning artifact path/);
+
       const blockedPythonSourceWrite = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",
@@ -10295,6 +10316,16 @@ Path('.omx/plans/rebase-pr3010-ultragoal-fix-plan.md').write_text('planning text
 PY`,
       });
       assert.equal(allowedPythonPlanWrite.outputJson, null);
+
+      const blockedPythonAllowedMkdirDynamicSourceWrite = await preToolUse("Bash", "tool-autopilot-ralplan-python-allowed-mkdir-dynamic-source-write", {
+        command: `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/plans').mkdir(parents=True, exist_ok=True)
+(Path('src') / 'generated.ts').write_text('implementation')
+PY`,
+      });
+      assert.equal((blockedPythonAllowedMkdirDynamicSourceWrite.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(String((blockedPythonAllowedMkdirDynamicSourceWrite.outputJson as { reason?: string } | null)?.reason ?? ""), /write intent did not identify an allowed planning artifact path/);
 
       const blockedPythonSourceWrite = await preToolUse("Bash", "tool-autopilot-ralplan-python-source-write", {
         command: `python3 - <<'PY'

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -994,6 +994,67 @@ describe("codex native hook dispatch", () => {
         { cwd },
       );
       assert.equal(allowedQuotedMention.outputJson, null);
+
+      const allowedPythonPlanningArtifactWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-wrapper-implementation-block",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-wrapper-python-planning-artifact",
+          tool_input: {
+            command: `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/plans').mkdir(parents=True, exist_ok=True)
+Path('.omx/plans/rebase-pr3010-ultragoal-fix-plan.md').write_text('planning text')
+PY`,
+          },
+        },
+        { cwd },
+      );
+      assert.equal(allowedPythonPlanningArtifactWrite.outputJson, null);
+
+      const blockedPythonSourceWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-wrapper-implementation-block",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-wrapper-python-source-write",
+          tool_input: {
+            command: `python3 - <<'PY'
+from pathlib import Path
+Path('src/generated.ts').write_text('implementation')
+PY`,
+          },
+        },
+        { cwd },
+      );
+      assert.equal(blockedPythonSourceWrite.outputJson && typeof blockedPythonSourceWrite.outputJson === "object" ? (blockedPythonSourceWrite.outputJson as { decision?: string }).decision : undefined, "block");
+      assert.match(JSON.stringify(blockedPythonSourceWrite.outputJson), /Bash .* target src\/generated\.ts/);
+
+      const blockedPythonMixedWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-wrapper-implementation-block",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-wrapper-python-mixed-write",
+          tool_input: {
+            command: `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/plans/rebase-pr3010-ultragoal-fix-plan.md').write_text('planning text')
+Path('src/generated.ts').write_text('implementation')
+PY`,
+          },
+        },
+        { cwd },
+      );
+      assert.equal(blockedPythonMixedWrite.outputJson && typeof blockedPythonMixedWrite.outputJson === "object" ? (blockedPythonMixedWrite.outputJson as { decision?: string }).decision : undefined, "block");
+      assert.match(JSON.stringify(blockedPythonMixedWrite.outputJson), /Bash .* target src\/generated\.ts/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -10225,6 +10286,34 @@ exit 0
         { cwd },
       );
       assert.equal(allowedSpecEdit.outputJson, null);
+
+      const allowedPythonPlanWrite = await preToolUse("Bash", "tool-autopilot-ralplan-python-plan-write", {
+        command: `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/plans').mkdir(parents=True, exist_ok=True)
+Path('.omx/plans/rebase-pr3010-ultragoal-fix-plan.md').write_text('planning text')
+PY`,
+      });
+      assert.equal(allowedPythonPlanWrite.outputJson, null);
+
+      const blockedPythonSourceWrite = await preToolUse("Bash", "tool-autopilot-ralplan-python-source-write", {
+        command: `python3 - <<'PY'
+from pathlib import Path
+Path('src/generated.ts').write_text('implementation')
+PY`,
+      });
+      assert.equal((blockedPythonSourceWrite.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(String((blockedPythonSourceWrite.outputJson as { reason?: string } | null)?.reason ?? ""), /src\/generated\.ts/);
+
+      const blockedPythonMixedWrite = await preToolUse("Bash", "tool-autopilot-ralplan-python-mixed-write", {
+        command: `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/plans/rebase-pr3010-ultragoal-fix-plan.md').write_text('planning text')
+Path('src/generated').mkdir(parents=True, exist_ok=True)
+PY`,
+      });
+      assert.equal((blockedPythonMixedWrite.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(String((blockedPythonMixedWrite.outputJson as { reason?: string } | null)?.reason ?? ""), /src\/generated/);
 
       const blockedImplementationEdit = await dispatchCodexNativeHook(
         {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -6837,6 +6837,10 @@ function extractConductorInterpreterWrites(command: string): ConductorInterprete
     const target = safeString(match[2]).trim();
     writes.push({ runtime: "python", targets: target ? [target] : [], unresolved: !target });
   }
+  for (const match of scanCommand.matchAll(/\bpython3?\b[\s\S]{0,520}\bPath\s*\(\s*(["'])([^"']+)\1\s*\)\s*\.\s*mkdir\s*\(/g)) {
+    const target = safeString(match[2]).trim();
+    writes.push({ runtime: "python", targets: target ? [target] : [], unresolved: !target });
+  }
   for (const match of scanCommand.matchAll(/\bpython3?\b[\s\S]{0,520}\bshutil\s*\.\s*(?:copyfile|copy|copy2|copytree|move)\s*\(\s*(["'])([^"']+)\1\s*,\s*(["'])([^"']+)\3/g)) {
     const target = safeString(match[4]).trim();
     writes.push({ runtime: "python", targets: target ? [target] : [], unresolved: !target });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -6186,6 +6186,7 @@ function isAllowedDeepInterviewBashWrite(cwd: string, command: string): boolean 
   if (commandEndsPlanningPhase(cwd, command)) return false;
   if (commandHasUntargetedPlanningForbiddenIntent(command)) return false;
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
+  if (hasUnresolvedConductorInterpreterWrite(command)) return false;
   const targets = extractDeepInterviewCommandWriteTargets(command);
   if (targets.some((target) => !isAllowedDeepInterviewArtifactPath(cwd, target))) return false;
   return targets.length > 0 && targets.every((target) => isAllowedDeepInterviewArtifactPath(cwd, target));
@@ -6302,6 +6303,7 @@ function isAllowedRalplanBashWrite(
   }
   if (commandHasUntargetedPlanningForbiddenIntent(command)) return false;
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
+  if (hasUnresolvedConductorInterpreterWrite(command)) return false;
   if (targets.some((target) => !isAllowedRalplanArtifactPath(cwd, target))) return false;
   return hasAllowedTargets;
 }
@@ -6819,6 +6821,9 @@ interface ConductorInterpreterWrite {
 function extractConductorInterpreterWrites(command: string): ConductorInterpreterWrite[] {
   const writes: ConductorInterpreterWrite[] = [];
   const scanCommand = normalizeShellLineContinuations(command);
+  let recognizedPythonOpenWrites = 0;
+  let recognizedPythonPathMutations = 0;
+  let recognizedPythonShutilMutations = 0;
 
   for (const match of scanCommand.matchAll(/\bnode\b[\s\S]{0,520}\b(?:appendFileSync|writeFileSync|appendFile|writeFile|createWriteStream)\s*\(\s*(["'])([^"']+)\1/g)) {
     const target = safeString(match[2]).trim();
@@ -6832,29 +6837,46 @@ function extractConductorInterpreterWrites(command: string): ConductorInterprete
   for (const match of scanCommand.matchAll(/\bpython3?\b[\s\S]{0,520}\bopen\s*\(\s*(["'])([^"']+)\1\s*,\s*(["'])([^"']*[wax+][^"']*)\3/g)) {
     const target = safeString(match[2]).trim();
     writes.push({ runtime: "python", targets: target ? [target] : [], unresolved: !target });
+    recognizedPythonOpenWrites += 1;
   }
   for (const match of scanCommand.matchAll(/\bpython3?\b[\s\S]{0,520}\bPath\s*\(\s*(["'])([^"']+)\1\s*\)\s*\.\s*(?:write_text|write_bytes)\s*\(/g)) {
     const target = safeString(match[2]).trim();
     writes.push({ runtime: "python", targets: target ? [target] : [], unresolved: !target });
+    recognizedPythonPathMutations += 1;
   }
   for (const match of scanCommand.matchAll(/\bpython3?\b[\s\S]{0,520}\bPath\s*\(\s*(["'])([^"']+)\1\s*\)\s*\.\s*mkdir\s*\(/g)) {
     const target = safeString(match[2]).trim();
     writes.push({ runtime: "python", targets: target ? [target] : [], unresolved: !target });
+    recognizedPythonPathMutations += 1;
   }
   for (const match of scanCommand.matchAll(/\bpython3?\b[\s\S]{0,520}\bshutil\s*\.\s*(?:copyfile|copy|copy2|copytree|move)\s*\(\s*(["'])([^"']+)\1\s*,\s*(["'])([^"']+)\3/g)) {
     const target = safeString(match[4]).trim();
     writes.push({ runtime: "python", targets: target ? [target] : [], unresolved: !target });
+    recognizedPythonShutilMutations += 1;
   }
-  if (/\bpython3?\b[\s\S]{0,520}\bshutil\s*\.\s*(?:copyfile|copy|copy2|copytree|move)\s*\(/.test(scanCommand)
-    && !writes.some((write) => write.runtime === "python")) {
-    writes.push({ runtime: "python", targets: [], unresolved: true });
-  }
-  if (/\bpython3?\b[\s\S]{0,520}\b(?:open\s*\([^)]*,\s*["'][^"']*[wax+]|Path\s*\([^)]*\)\s*\.\s*(?:write_text|write_bytes))/.test(scanCommand)
-    && !writes.some((write) => write.runtime === "python")) {
+  const hasPythonRuntime = /\bpython3?\b/.test(scanCommand);
+  const pythonOpenWriteCalls = hasPythonRuntime
+    ? [...scanCommand.matchAll(/\bopen\s*\([^\n;)]*,\s*["'][^"']*[wax+][^"']*["']/g)].length
+    : 0;
+  const pythonPathMutationCalls = hasPythonRuntime
+    ? [...scanCommand.matchAll(/(?:^|[\n;])\s*(?:\([^\n;#]*\bPath\s*\([^\n;#]*\)[^\n;#]*\)|\bPath\s*\([^\n;#]*\))\s*\.\s*(?:write_text|write_bytes|mkdir)\s*\(/g)].length
+    : 0;
+  const pythonShutilMutationCalls = hasPythonRuntime
+    ? [...scanCommand.matchAll(/\bshutil\s*\.\s*(?:copyfile|copy|copy2|copytree|move)\s*\(/g)].length
+    : 0;
+  if (
+    pythonOpenWriteCalls > recognizedPythonOpenWrites
+    || pythonPathMutationCalls > recognizedPythonPathMutations
+    || pythonShutilMutationCalls > recognizedPythonShutilMutations
+  ) {
     writes.push({ runtime: "python", targets: [], unresolved: true });
   }
 
   return writes;
+}
+
+function hasUnresolvedConductorInterpreterWrite(command: string): boolean {
+  return extractConductorInterpreterWrites(command).some((write) => write.unresolved || write.targets.length === 0);
 }
 
 function commandNameFromShellWord(word: string): string {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -4140,6 +4140,13 @@ function sourcesFileWrittenEarlierInSameCommand(cwd: string, command: string): b
     const assignments = extractCommandLiteralAssignments(normalizedCommand);
     const nextActiveCommands = new Set(activeCommands);
     nextActiveCommands.add(commandKey);
+
+    for (const write of extractConductorInterpreterWrites(currentCommand)) {
+      for (const target of write.targets) {
+        const normalizedTarget = normalizeSameCommandScriptTarget(currentCwd, target, assignments);
+        if (normalizedTarget) writtenTargets.add(normalizedTarget);
+      }
+    }
     let effectiveCwd = currentCwd;
 
     for (const segment of splitShellCommandSegments(normalizedCommand)) {

--- a/src/state/__tests__/planning-gate.test.ts
+++ b/src/state/__tests__/planning-gate.test.ts
@@ -47,6 +47,25 @@ omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralp
     assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
   });
 
+  it('classifies Python literal planning artifact write plus shell execution as implementation', () => {
+    const command = `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/plans/run.sh').write_text('echo pwned')
+PY
+sh .omx/plans/run.sh`;
+
+    assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
+  });
+
+  it('does not classify Python literal planning artifact write without execution as implementation', () => {
+    const command = `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/plans/notes.md').write_text('# Plan notes\\n')
+PY`;
+
+    assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), false);
+  });
+
   it('classifies same-command protected artifact execution through cd plus timeout as implementation', () => {
     const command = `mkdir -p .omx/context
 cat > .omx/context/run.sh <<'SCRIPT'

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -462,10 +462,16 @@ function hasTokenizedExecutionOfPath(command: string, path: string, initialCwd =
 
 function collectProtectedArtifactWritePaths(command: string): Set<string> {
   const paths = new Set<string>();
-  const protectedPath = String.raw`(["']?)((?:\.\/)?\.omx\/(?:context|specs)\/[^"'\s;|&<>]+)\1`;
+  const protectedPath = String.raw`(["']?)((?:\.\/)?\.omx\/(?:context|specs|plans)\/[^"'\s;|&<>]+)\1`;
   const redirectPattern = new RegExp(String.raw`(?:^|[^<])>>?\s*${protectedPath}`, 'g');
 
   for (const match of command.matchAll(redirectPattern)) {
+    const path = match[2]?.trim();
+    if (path) paths.add(normalizeProtectedArtifactPath(path));
+  }
+
+  const pythonPathWritePattern = /\bpython3?\b[\s\S]{0,520}\bPath\s*\(\s*(["'])((?:\.\/)?\.omx\/(?:context|specs|plans)\/[^"']+)\1\s*\)\s*\.\s*(?:write_text|write_bytes)\s*\(/g;
+  for (const match of command.matchAll(pythonPathWritePattern)) {
     const path = match[2]?.trim();
     if (path) paths.add(normalizeProtectedArtifactPath(path));
   }


### PR DESCRIPTION
Fixes #3027.

## Summary
- Treat literal Python `Path(...).mkdir(...)` targets as interpreter write targets so ralplan/autopilot planning guards can prove allowed planning artifact directory creation.
- Keep interpreter writes fail-closed when literal targets are unresolved or outside allowed planning paths.
- Add regressions for the reported `Path('.omx/plans').mkdir(...)` plus `Path(...).write_text(...)` shape, source writes, and mixed allowed+source writes.

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js`
- `npm run check:no-unused`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*