### PR TITLE
Allow planning scratch artifacts

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7395,6 +7395,30 @@ exit 0
       assert.equal((blockedTmpTsxExecution.outputJson as { decision?: string } | null)?.decision, "block");
       assert.match(JSON.stringify(blockedTmpTsxExecution.outputJson), /generated-script transport|\.omx\/tmp/);
 
+      for (const [toolUseId, command] of [
+        ["tool-di-tmp-python-option-txt-exec", "python -X dev .omx/tmp/sess-di-artifact/run.txt"],
+        ["tool-di-tmp-node-require-load", "node --require .omx/tmp/sess-di-artifact/preload -e ''"],
+        ["tool-di-tmp-node-import-load", "node --import .omx/tmp/sess-di-artifact/preload -e ''"],
+        ["tool-di-tmp-bun-require-load", "bun --require .omx/tmp/sess-di-artifact/preload -e ''"],
+        ["tool-di-tmp-bash-rcfile-load", "bash --rcfile .omx/tmp/sess-di-artifact/rc -i -c true"],
+        ["tool-di-tmp-go-run-exec", "go run .omx/tmp/sess-di-artifact/probe.go"],
+        ["tool-di-tmp-deno-run-exec", "deno run .omx/tmp/sess-di-artifact/generated.ts"],
+      ] as const) {
+        const blockedTmpTransport = await preToolUse(
+          {
+            hook_event_name: "PreToolUse",
+            cwd,
+            session_id: "sess-di-artifact",
+            tool_name: "Bash",
+            tool_use_id: toolUseId,
+            tool_input: { command },
+          },
+          { cwd },
+        );
+        assert.equal((blockedTmpTransport.outputJson as { decision?: string } | null)?.decision, "block", command);
+        assert.match(JSON.stringify(blockedTmpTransport.outputJson), /generated-script transport|\.omx\/tmp/);
+      }
+
       const allowedAppendBash = await preToolUse(
         {
           hook_event_name: "PreToolUse",
@@ -7442,6 +7466,28 @@ exit 0
         { cwd },
       );
       assert.equal(reportedHandoffShape.outputJson, null);
+
+      const blockedTmpOnlyHandoffShape = await preToolUse(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-reported-tmp-only-handoff",
+          tool_input: {
+            command: [
+              "mkdir -p .omx/tmp/sess-di-artifact",
+              "cat > .omx/tmp/sess-di-artifact/only.md <<'EOF'",
+              "# Tmp-only scratch",
+              "EOF",
+              `omx state write --input '${deepInterviewRalplanHandoffState}' --json`,
+            ].join("\n"),
+          },
+        },
+        { cwd },
+      );
+      assert.equal((blockedTmpOnlyHandoffShape.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(String((blockedTmpOnlyHandoffShape.outputJson as { reason?: string } | null)?.reason ?? ""), /handoff|Bash write intent|deep-interview/i);
 
       const blockedHandoffWithSameCommandArtifactExecution = await preToolUse(
         {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1047,6 +1047,36 @@ describe("codex native hook dispatch", () => {
       assert.equal((blockedPlanningTmpVersionedInterpreterExecution.outputJson as { decision?: string } | null)?.decision, "block");
       assert.match(JSON.stringify(blockedPlanningTmpVersionedInterpreterExecution.outputJson), /generated-script transport|\.omx\/tmp/);
 
+      const blockedPlanningTmpTsxExecution = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-wrapper-implementation-block",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-wrapper-planning-tmp-tsx-exec",
+          tool_input: { command: "tsx .omx/tmp/sess-ralplan-wrapper/generated.ts" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedPlanningTmpTsxExecution.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(blockedPlanningTmpTsxExecution.outputJson), /generated-script transport|\.omx\/tmp/);
+
+      const blockedPlanningTmpTsxWithOptionsExecution = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-wrapper-implementation-block",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-wrapper-planning-tmp-tsx-options-exec",
+          tool_input: { command: "tsx --tsconfig tsconfig.json watch .omx/tmp/sess-ralplan-wrapper/generated.ts" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedPlanningTmpTsxWithOptionsExecution.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(blockedPlanningTmpTsxWithOptionsExecution.outputJson), /generated-script transport|\.omx\/tmp/);
+
 
       const allowedBeadsMetadataWrite = await dispatchCodexNativeHook(
         {
@@ -7350,6 +7380,20 @@ exit 0
       );
       assert.equal((blockedTmpInterpreterExecution.outputJson as { decision?: string } | null)?.decision, "block");
       assert.match(JSON.stringify(blockedTmpInterpreterExecution.outputJson), /generated-script transport|\.omx\/tmp/);
+
+      const blockedTmpTsxExecution = await preToolUse(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-tmp-tsx-exec",
+          tool_input: { command: "tsx --tsconfig tsconfig.json watch .omx/tmp/sess-di-artifact/generated.ts" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedTmpTsxExecution.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(blockedTmpTsxExecution.outputJson), /generated-script transport|\.omx\/tmp/);
 
       const allowedAppendBash = await preToolUse(
         {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -967,6 +967,23 @@ describe("codex native hook dispatch", () => {
       );
       assert.equal(allowedPlanningArtifactWrite.outputJson, null);
 
+      const allowedPlanningTmpWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-wrapper-implementation-block",
+          tool_name: "Write",
+          tool_use_id: "tool-ralplan-wrapper-planning-tmp",
+          tool_input: {
+            file_path: ".omx/tmp/sess-ralplan-wrapper/notes.md",
+            content: "# Scratch notes\n",
+          },
+        },
+        { cwd },
+      );
+      assert.equal(allowedPlanningTmpWrite.outputJson, null);
+
       const allowedBeadsMetadataWrite = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",
@@ -7204,6 +7221,26 @@ exit 0
         { cwd },
       );
       assert.equal(allowedBash.outputJson, null);
+
+      const allowedTmpBash = await preToolUse(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-tmp-bash",
+          tool_input: {
+            command: [
+              "mkdir -p .omx/tmp/sess-di-artifact",
+              "cat > .omx/tmp/sess-di-artifact/demo.md <<'EOF'",
+              "# Scratch",
+              "EOF",
+            ].join("\n"),
+          },
+        },
+        { cwd },
+      );
+      assert.equal(allowedTmpBash.outputJson, null);
 
       const allowedAppendBash = await preToolUse(
         {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -984,6 +984,70 @@ describe("codex native hook dispatch", () => {
       );
       assert.equal(allowedPlanningTmpWrite.outputJson, null);
 
+      const blockedPlanningTmpScriptWrite = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-wrapper-implementation-block",
+          tool_name: "Write",
+          tool_use_id: "tool-ralplan-wrapper-planning-tmp-script-write",
+          tool_input: {
+            file_path: ".omx/tmp/sess-ralplan-wrapper/run.sh",
+            content: "printf pwned > src/pwned.ts\n",
+          },
+        },
+        { cwd },
+      );
+      assert.equal((blockedPlanningTmpScriptWrite.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(blockedPlanningTmpScriptWrite.outputJson), /\.omx\/tmp|planning artifact paths/);
+
+      const blockedPlanningTmpScriptExecution = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-wrapper-implementation-block",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-wrapper-planning-tmp-script-exec",
+          tool_input: { command: "sh .omx/tmp/sess-ralplan-wrapper/run.sh" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedPlanningTmpScriptExecution.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(blockedPlanningTmpScriptExecution.outputJson), /generated-script transport|\.omx\/tmp/);
+
+      const blockedPlanningTmpExtensionlessExecution = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-wrapper-implementation-block",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-wrapper-planning-tmp-extensionless-exec",
+          tool_input: { command: "./.omx/tmp/sess-ralplan-wrapper/generated" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedPlanningTmpExtensionlessExecution.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(blockedPlanningTmpExtensionlessExecution.outputJson), /generated-script transport|\.omx\/tmp/);
+
+      const blockedPlanningTmpVersionedInterpreterExecution = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-ralplan-wrapper-implementation-block",
+          tool_name: "Bash",
+          tool_use_id: "tool-ralplan-wrapper-planning-tmp-versioned-python-exec",
+          tool_input: { command: "python3.12 .omx/tmp/sess-ralplan-wrapper/generated.txt" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedPlanningTmpVersionedInterpreterExecution.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(blockedPlanningTmpVersionedInterpreterExecution.outputJson), /generated-script transport|\.omx\/tmp/);
+
+
       const allowedBeadsMetadataWrite = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",
@@ -7241,6 +7305,51 @@ exit 0
         { cwd },
       );
       assert.equal(allowedTmpBash.outputJson, null);
+
+      const blockedTmpScriptWrite = await preToolUse(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Write",
+          tool_use_id: "tool-di-tmp-script-write",
+          tool_input: {
+            file_path: ".omx/tmp/sess-di-artifact/run.sh",
+            content: "printf pwned > src/pwned.ts\n",
+          },
+        },
+        { cwd },
+      );
+      assert.equal((blockedTmpScriptWrite.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(blockedTmpScriptWrite.outputJson), /\.omx\/tmp|planning artifact paths/);
+
+      const blockedTmpScriptExecution = await preToolUse(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-tmp-script-exec",
+          tool_input: { command: "sh .omx/tmp/sess-di-artifact/run.sh" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedTmpScriptExecution.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(blockedTmpScriptExecution.outputJson), /generated-script transport|\.omx\/tmp/);
+
+      const blockedTmpInterpreterExecution = await preToolUse(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-tmp-python-exec",
+          tool_input: { command: "python3.12 .omx/tmp/sess-di-artifact/generated.txt" },
+        },
+        { cwd },
+      );
+      assert.equal((blockedTmpInterpreterExecution.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(JSON.stringify(blockedTmpInterpreterExecution.outputJson), /generated-script transport|\.omx\/tmp/);
 
       const allowedAppendBash = await preToolUse(
         {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7403,6 +7403,22 @@ exit 0
         ["tool-di-tmp-bash-rcfile-load", "bash --rcfile .omx/tmp/sess-di-artifact/rc -i -c true"],
         ["tool-di-tmp-go-run-exec", "go run .omx/tmp/sess-di-artifact/probe.go"],
         ["tool-di-tmp-deno-run-exec", "deno run .omx/tmp/sess-di-artifact/generated.ts"],
+        ["tool-di-tmp-python-stdin-exec", "python < .omx/tmp/sess-di-artifact/run.txt"],
+        ["tool-di-tmp-node-stdin-exec", "node < .omx/tmp/sess-di-artifact/run.txt"],
+        ["tool-di-tmp-ruby-stdin-exec", "ruby < .omx/tmp/sess-di-artifact/run.txt"],
+        ["tool-di-tmp-perl-stdin-exec", "perl < .omx/tmp/sess-di-artifact/run.txt"],
+        ["tool-di-tmp-sh-stdin-exec", "sh < .omx/tmp/sess-di-artifact/run.txt"],
+        ["tool-di-tmp-bash-stdin-exec", "bash < .omx/tmp/sess-di-artifact/run.txt"],
+        [
+          "tool-di-tmp-same-command-stdin-exec",
+          [
+            "python3 - <<'PY'",
+            "from pathlib import Path",
+            "Path('.omx/tmp/sess-di-artifact/run.txt').write_text('print(1)')",
+            "PY",
+            "python < .omx/tmp/sess-di-artifact/run.txt",
+          ].join("\n"),
+        ],
       ] as const) {
         const blockedTmpTransport = await preToolUse(
           {
@@ -10420,6 +10436,29 @@ exit 0
         command: "sed -Ei 's/old/new/' .omx/plans/issue-2863.md",
       });
       assert.equal(allowedCombinedSedArtifact.outputJson, null);
+
+      for (const [toolUseId, command] of [
+        ["tool-ralplan-tmp-python-stdin-exec", "python < .omx/tmp/sess-ralplan-guard/run.txt"],
+        ["tool-ralplan-tmp-node-stdin-exec", "node < .omx/tmp/sess-ralplan-guard/run.txt"],
+        ["tool-ralplan-tmp-ruby-stdin-exec", "ruby < .omx/tmp/sess-ralplan-guard/run.txt"],
+        ["tool-ralplan-tmp-perl-stdin-exec", "perl < .omx/tmp/sess-ralplan-guard/run.txt"],
+        ["tool-ralplan-tmp-sh-stdin-exec", "sh < .omx/tmp/sess-ralplan-guard/run.txt"],
+        ["tool-ralplan-tmp-bash-stdin-exec", "bash < .omx/tmp/sess-ralplan-guard/run.txt"],
+        [
+          "tool-ralplan-tmp-same-command-stdin-exec",
+          [
+            "python3 - <<'PY'",
+            "from pathlib import Path",
+            "Path('.omx/tmp/sess-ralplan-guard/run.txt').write_text('print(1)')",
+            "PY",
+            "python < .omx/tmp/sess-ralplan-guard/run.txt",
+          ].join("\n"),
+        ],
+      ] as const) {
+        const blockedTmpStdin = await preToolUse("Bash", toolUseId, { command });
+        assert.equal((blockedTmpStdin.outputJson as { decision?: string } | null)?.decision, "block", command);
+        assert.match(JSON.stringify(blockedTmpStdin.outputJson), /generated-script transport|\.omx\/tmp/);
+      }
 
       const allowedReadOnlyEditors = await preToolUse("Bash", "tool-ralplan-read-only-editors-allow", {
         command: "sed -n '1,20p' src/runtime.ts; perl -ne 'print if $. < 3' src/runtime.ts",

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -4159,6 +4159,23 @@ function firstNonOptionSourceOperand(words: string[], sourceWordIndex: number): 
   return "";
 }
 
+function stdinRedirectOperands(words: string[]): string[] {
+  const operands: string[] = [];
+  for (let index = 0; index < words.length; index += 1) {
+    const word = words[index] ?? "";
+    if (word === "<") {
+      const operand = words[index + 1] ?? "";
+      if (operand) operands.push(operand);
+      index += 1;
+      continue;
+    }
+    if (/^\d*<[^<&].+/.test(word)) {
+      operands.push(word.replace(/^\d*</, ""));
+    }
+  }
+  return operands;
+}
+
 function firstShellScriptOperands(words: string[], shellWordIndex: number): string[] {
   const operands: string[] = [];
   for (let index = shellWordIndex + 1; index < words.length; index += 1) {
@@ -4362,7 +4379,7 @@ function firstPlanningTmpScriptExecutionTarget(cwd: string, command: string): st
         const operands = word === "source" || word === "."
           ? [firstNonOptionSourceOperand(words, index)].filter(Boolean)
           : isScriptInterpreterCommandWord(word)
-            ? firstInterpreterScriptOperands(words, index)
+            ? [...firstInterpreterScriptOperands(words, index), ...stdinRedirectOperands(words)]
             : [];
         for (const operand of operands) {
           const relativePath = normalizeExecutionTarget(operandCwd, operand);

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -4196,6 +4196,15 @@ function isScriptInterpreterCommandWord(word: string): boolean {
     || base === "lua";
 }
 
+function isTsxRuntimeOptionWithSeparateValue(word: string): boolean {
+  return word === "--tsconfig";
+}
+
+function isTsxRuntimeModeWord(word: string): boolean {
+  return word === "watch";
+}
+
+
 function firstInterpreterScriptOperand(words: string[], interpreterWordIndex: number): string {
   const base = shellWordBaseName(words[interpreterWordIndex] ?? "");
   if (isNestedShellCommandWord(base)) return firstShellScriptOperand(words, interpreterWordIndex);
@@ -4210,11 +4219,12 @@ function firstInterpreterScriptOperand(words: string[], interpreterWordIndex: nu
     }
     if (isNodeInterpreterCommandWord(base) || base === "bun" || base === "tsx") {
       if (word === "-e" || word === "--eval" || word === "-p" || word === "--print") return "";
-      if (runtimeOptionConsumesNextWord(word)) {
+      if (runtimeOptionConsumesNextWord(word) || (base === "tsx" && isTsxRuntimeOptionWithSeparateValue(word))) {
         index += 1;
         continue;
       }
       if (word.startsWith("--eval=") || word.startsWith("--print=")) return "";
+      if (base === "tsx" && isTsxRuntimeModeWord(word)) continue;
       if (word.startsWith("-")) continue;
       return word;
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -4159,19 +4159,31 @@ function firstNonOptionSourceOperand(words: string[], sourceWordIndex: number): 
   return "";
 }
 
-function firstShellScriptOperand(words: string[], shellWordIndex: number): string {
+function firstShellScriptOperands(words: string[], shellWordIndex: number): string[] {
+  const operands: string[] = [];
   for (let index = shellWordIndex + 1; index < words.length; index += 1) {
     const word = words[index] ?? "";
     if (!word || word === "--") continue;
-    if (isShellCommandStringOption(word)) return "";
+    if (isShellCommandStringOption(word)) return operands;
     if (isShellOptionWithSeparateValue(word)) {
+      const value = words[index + 1] ?? "";
+      if (value) operands.push(value);
       index += 1;
       continue;
     }
+    if (word.startsWith("--init-file=") || word.startsWith("--rcfile=")) {
+      operands.push(word.slice(word.indexOf("=") + 1));
+      continue;
+    }
     if (word.startsWith("-")) continue;
-    return word;
+    operands.push(word);
+    return operands;
   }
-  return "";
+  return operands;
+}
+
+function firstShellScriptOperand(words: string[], shellWordIndex: number): string {
+  return firstShellScriptOperands(words, shellWordIndex)[0] ?? "";
 }
 
 function isPythonInterpreterCommandWord(base: string): boolean {
@@ -4180,6 +4192,28 @@ function isPythonInterpreterCommandWord(base: string): boolean {
 
 function isNodeInterpreterCommandWord(base: string): boolean {
   return /^(?:node|nodejs)$/.test(base);
+}
+
+function isPythonRuntimeOptionWithSeparateValue(word: string): boolean {
+  return word === "-B"
+    || word === "-b"
+    || word === "-d"
+    || word === "-E"
+    || word === "-i"
+    || word === "-I"
+    || word === "-O"
+    || word === "-OO"
+    || word === "-P"
+    || word === "-q"
+    || word === "-R"
+    || word === "-s"
+    || word === "-S"
+    || word === "-u"
+    || word === "-v"
+    || word === "-V"
+    || word === "--check-hash-based-pycs"
+    || word === "-W"
+    || word === "-X";
 }
 
 function isScriptInterpreterCommandWord(word: string): boolean {
@@ -4193,7 +4227,12 @@ function isScriptInterpreterCommandWord(word: string): boolean {
     || base === "perl"
     || base === "ruby"
     || base === "php"
-    || base === "lua";
+    || base === "lua"
+    || base === "go"
+    || base === "npx"
+    || base === "npm"
+    || base === "pnpm"
+    || base === "yarn";
 }
 
 function isTsxRuntimeOptionWithSeparateValue(word: string): boolean {
@@ -4205,43 +4244,89 @@ function isTsxRuntimeModeWord(word: string): boolean {
 }
 
 
-function firstInterpreterScriptOperand(words: string[], interpreterWordIndex: number): string {
+function firstInterpreterScriptOperands(words: string[], interpreterWordIndex: number): string[] {
   const base = shellWordBaseName(words[interpreterWordIndex] ?? "");
-  if (isNestedShellCommandWord(base)) return firstShellScriptOperand(words, interpreterWordIndex);
+  if (isNestedShellCommandWord(base)) return firstShellScriptOperands(words, interpreterWordIndex);
 
+  const operands: string[] = [];
+  let sawGoRun = false;
+  let sawPackageRunner = base === "npx";
   for (let index = interpreterWordIndex + 1; index < words.length; index += 1) {
     const word = words[index] ?? "";
     if (!word || word === "--") continue;
     if (isPythonInterpreterCommandWord(base)) {
-      if (word === "-c" || word === "-m") return "";
-      if (word.startsWith("-")) continue;
-      return word;
-    }
-    if (isNodeInterpreterCommandWord(base) || base === "bun" || base === "tsx") {
-      if (word === "-e" || word === "--eval" || word === "-p" || word === "--print") return "";
-      if (runtimeOptionConsumesNextWord(word) || (base === "tsx" && isTsxRuntimeOptionWithSeparateValue(word))) {
+      if (word === "-c" || word === "-m") return operands;
+      if (isPythonRuntimeOptionWithSeparateValue(word)) {
         index += 1;
         continue;
       }
-      if (word.startsWith("--eval=") || word.startsWith("--print=")) return "";
+      if (word.startsWith("-W") || word.startsWith("-X")) continue;
+      if (word.startsWith("-")) continue;
+      operands.push(word);
+      return operands;
+    }
+    if (isNodeInterpreterCommandWord(base) || base === "bun" || base === "tsx") {
+      if (word === "-e" || word === "--eval" || word === "-p" || word === "--print") return operands;
+      if (runtimeOptionConsumesNextWord(word) || (base === "tsx" && isTsxRuntimeOptionWithSeparateValue(word))) {
+        const value = words[index + 1] ?? "";
+        if (value && (word === "-r" || word === "--require" || word === "--import" || word === "--loader" || word === "--experimental-loader")) {
+          operands.push(value);
+        }
+        index += 1;
+        continue;
+      }
+      if (word.startsWith("--require=") || word.startsWith("--import=") || word.startsWith("--loader=") || word.startsWith("--experimental-loader=")) {
+        operands.push(word.slice(word.indexOf("=") + 1));
+        continue;
+      }
+      if (word.startsWith("--eval=") || word.startsWith("--print=")) return operands;
       if (base === "tsx" && isTsxRuntimeModeWord(word)) continue;
       if (word.startsWith("-")) continue;
-      return word;
+      operands.push(word);
+      return operands;
     }
     if (base === "deno") {
-      if (word === "eval" || word === "repl") return "";
+      if (word === "eval" || word === "repl") return operands;
       if (word === "run") continue;
       if (word.startsWith("-")) continue;
-      return word;
+      operands.push(word);
+      return operands;
+    }
+    if (base === "go") {
+      if (!sawGoRun) {
+        if (word === "run") {
+          sawGoRun = true;
+          continue;
+        }
+        return operands;
+      }
+      if (word.startsWith("-")) continue;
+      operands.push(word);
+      return operands;
+    }
+    if (base === "npm" || base === "pnpm" || base === "yarn" || base === "npx") {
+      if (!sawPackageRunner) {
+        if (word === "exec" || word === "x" || word === "dlx") {
+          sawPackageRunner = true;
+          continue;
+        }
+        return operands;
+      }
+      if (word.startsWith("-")) continue;
+      if (word === "tsx" || word === "node" || word === "bun" || word === "deno") continue;
+      operands.push(word);
+      return operands;
     }
     if (base === "perl" || base === "ruby" || base === "php" || base === "lua") {
-      if (word === "-e" || word.startsWith("-e")) return "";
+      if (word === "-e" || word.startsWith("-e")) return operands;
       if (word.startsWith("-")) continue;
-      return word;
+      operands.push(word);
+      return operands;
     }
   }
-  return "";
+  return operands;
 }
+
 
 function firstPlanningTmpScriptExecutionTarget(cwd: string, command: string): string | null {
   const scanCommand = (currentCwd: string, currentCommand: string, activeCommands: Set<string>): string | null => {
@@ -4274,15 +4359,15 @@ function firstPlanningTmpScriptExecutionTarget(cwd: string, command: string): st
       for (let index = 0; index < words.length; index += 1) {
         const word = words[index] ?? "";
         const operandCwd = wrappedCommandContext && index >= wrappedCommandContext.index ? wrappedCommandContext.cwd : effectiveCwd;
-        const operand = word === "source" || word === "."
-          ? firstNonOptionSourceOperand(words, index)
+        const operands = word === "source" || word === "."
+          ? [firstNonOptionSourceOperand(words, index)].filter(Boolean)
           : isScriptInterpreterCommandWord(word)
-            ? firstInterpreterScriptOperand(words, index)
-            : "";
-        if (!operand) continue;
-        const relativePath = normalizeExecutionTarget(operandCwd, operand);
-
-        if (relativePath && isPlanningTmpRelativePath(relativePath)) return relativePath;
+            ? firstInterpreterScriptOperands(words, index)
+            : [];
+        for (const operand of operands) {
+          const relativePath = normalizeExecutionTarget(operandCwd, operand);
+          if (relativePath && isPlanningTmpRelativePath(relativePath)) return relativePath;
+        }
       }
 
       if (wrappedCommandContext !== null) {
@@ -6286,6 +6371,17 @@ function hasOnlyAllowedDeepInterviewRalplanHandoffMutations(cwd: string, command
   return true;
 }
 
+function isDurableDeepInterviewHandoffEvidencePath(cwd: string, rawPath: string): boolean {
+  const relativePath = normalizePlanningArtifactRelativePath(cwd, rawPath);
+  if (!relativePath) return false;
+  return relativePath === ".omx/context"
+    || relativePath.startsWith(".omx/context/")
+    || relativePath === ".omx/interviews"
+    || relativePath.startsWith(".omx/interviews/")
+    || relativePath === ".omx/specs"
+    || relativePath.startsWith(".omx/specs/");
+}
+
 function isAllowedDeepInterviewRalplanHandoffCommand(cwd: string, command: string): boolean {
   const canonicalCommand = canonicalizeOmxStateTransportCommand(command);
   if (hasUnsafeUnquotedHeredocExpansion(canonicalCommand)) return false;
@@ -6302,10 +6398,19 @@ function isAllowedDeepInterviewRalplanHandoffCommand(cwd: string, command: strin
   if (!payload || !isDeepInterviewRalplanHandoffStatePayload(payload)) return false;
   const targets = extractDeepInterviewCommandWriteTargets(command);
   if (targets.length === 0) return false;
+  if (!targets.some((target) => isDurableDeepInterviewHandoffEvidencePath(cwd, target))) return false;
   if (!hasOnlyAllowedDeepInterviewRalplanHandoffMutations(cwd, command)) return false;
   return targets.every((target) => isAllowedDeepInterviewArtifactPath(cwd, target));
 }
 
+
+function hasDeepInterviewRalplanHandoffStateMutation(cwd: string, command: string): boolean {
+  const canonicalCommand = canonicalizeOmxStateTransportCommand(command);
+  const stateWriteOperations = collectOmxStateCommandOperations(canonicalCommand, "write");
+  if (stateWriteOperations.length === 0) return false;
+  const payload = readStateWriteInputPayload(cwd, canonicalCommand, command);
+  return payload ? isDeepInterviewRalplanHandoffStatePayload(payload) : false;
+}
 
 function isCompleteRalplanTerminalWritePayload(
   payload: Record<string, unknown>,
@@ -6370,6 +6475,7 @@ function commandEndsPlanningPhase(cwd: string, command: string): boolean {
 
 function isAllowedDeepInterviewBashWrite(cwd: string, command: string): boolean {
   if (isAllowedDeepInterviewRalplanHandoffCommand(cwd, command)) return true;
+  if (hasDeepInterviewRalplanHandoffStateMutation(cwd, command)) return false;
   if (commandEndsPlanningPhase(cwd, command)) return false;
   if (commandHasUntargetedPlanningForbiddenIntent(command)) return false;
   if (firstPlanningTmpScriptExecutionTarget(cwd, command)) return false;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3286,6 +3286,7 @@ const DEEP_INTERVIEW_ALLOWED_WRITE_PREFIXES = [
   ".omx/context",
   ".omx/interviews",
   ".omx/specs",
+  ".omx/tmp",
   ".omx/state",
 ] as const;
 
@@ -3293,6 +3294,7 @@ const RALPLAN_ALLOWED_WRITE_PREFIXES = [
   ".omx/context",
   ".omx/plans",
   ".omx/specs",
+  ".omx/tmp",
   ".omx/state",
   ".beads",
 ] as const;
@@ -6422,7 +6424,7 @@ async function buildRalplanPreToolUseBoundaryOutput(
       hookEventName: "PreToolUse",
       additionalContext:
         `${planningModeDescription}. `
-        + "Write only planning artifacts under `.omx/context/`, `.omx/plans/`, `.omx/specs/`, required `.omx/state/` files, or tracker metadata under `.beads/`. "
+        + "Write only planning artifacts under `.omx/context/`, `.omx/plans/`, `.omx/specs/`, `.omx/tmp/`, required `.omx/state/` files, or tracker metadata under `.beads/`. "
         + "Do not edit implementation files or run implementation-focused writes from planning phases. "
         + `To execute, first process an explicit handoff such as ${formatExecutionHandoffList(cwd)}, which must emit terminal planning state before implementation begins.`,
     },
@@ -6480,7 +6482,7 @@ async function buildDeepInterviewPreToolUseBoundaryOutput(
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       additionalContext:
-        `Deep-interview is requirements/spec mode. Treat detailed user answers as interview/spec material, not implicit implementation authorization. You may write only deep-interview artifacts under \`.omx/context/\`, \`.omx/interviews/\`, \`.omx/specs/\`, or required \`.omx/state/\` files. To implement, first ask for or process an explicit transition such as \`$ralplan\`, \`$autopilot\`, ${formatExecutionHandoffList(cwd)}.`,
+        `Deep-interview is requirements/spec mode. Treat detailed user answers as interview/spec material, not implicit implementation authorization. You may write only deep-interview artifacts under \`.omx/context/\`, \`.omx/interviews/\`, \`.omx/specs/\`, \`.omx/tmp/\`, or required \`.omx/state/\` files. To implement, first ask for or process an explicit transition such as \`$ralplan\`, \`$autopilot\`, ${formatExecutionHandoffList(cwd)}.`,
     },
   };
 }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1561,6 +1561,30 @@ const SOURCE_DIFF_EXTENSIONS = new Set([
   ".tsx",
 ]);
 
+const PLANNING_TMP_SCRIPT_LIKE_EXTENSIONS = new Set([
+  ".bash",
+  ".bat",
+  ".cjs",
+  ".cmd",
+  ".cts",
+  ".fish",
+  ".js",
+  ".jsx",
+  ".ksh",
+  ".mjs",
+  ".mts",
+  ".php",
+  ".pl",
+  ".ps1",
+  ".py",
+  ".rb",
+  ".sh",
+  ".ts",
+  ".tsx",
+  ".zsh",
+]);
+
+
 function gitOutput(cwd: string, args: string[]): string {
   try {
     return execFileSync("git", args, {
@@ -3388,6 +3412,19 @@ function isProtectedPlanningStatePath(relativePath: string): boolean {
   return PROTECTED_PLANNING_STATE_FILE_NAMES.has(fileName);
 }
 
+function isPlanningTmpRelativePath(relativePath: string): boolean {
+  return relativePath === ".omx/tmp" || relativePath.startsWith(".omx/tmp/");
+}
+
+function isAllowedPlanningTmpScratchPath(relativePath: string): boolean {
+  if (!isPlanningTmpRelativePath(relativePath)) return true;
+  const fileName = relativePath.split("/").pop() ?? "";
+  if (!fileName || fileName === "tmp") return true;
+  const extension = extname(fileName).toLowerCase();
+  return !PLANNING_TMP_SCRIPT_LIKE_EXTENSIONS.has(extension);
+}
+
+
 function isAllowedPlanningArtifactPath(
   cwd: string,
   rawPath: string,
@@ -3396,9 +3433,13 @@ function isAllowedPlanningArtifactPath(
   const relativePath = normalizePlanningArtifactRelativePath(cwd, rawPath);
   if (!relativePath) return false;
   if (isProtectedPlanningStatePath(relativePath)) return false;
+  if (isPlanningTmpRelativePath(relativePath)) {
+    return allowedPrefixes.includes(".omx/tmp") && isAllowedPlanningTmpScratchPath(relativePath);
+  }
   return allowedPrefixes.some((prefix) => (
     relativePath === prefix || relativePath.startsWith(`${prefix}/`)
   ));
+
 }
 
 function isAllowedDeepInterviewArtifactPath(cwd: string, rawPath: string): boolean {
@@ -4132,6 +4173,133 @@ function firstShellScriptOperand(words: string[], shellWordIndex: number): strin
   }
   return "";
 }
+
+function isPythonInterpreterCommandWord(base: string): boolean {
+  return /^python(?:[0-9]+(?:\.[0-9]+)*)?$/.test(base);
+}
+
+function isNodeInterpreterCommandWord(base: string): boolean {
+  return /^(?:node|nodejs)$/.test(base);
+}
+
+function isScriptInterpreterCommandWord(word: string): boolean {
+  const base = shellWordBaseName(word);
+  return isNestedShellCommandWord(base)
+    || isNodeInterpreterCommandWord(base)
+    || base === "bun"
+    || base === "tsx"
+    || base === "deno"
+    || isPythonInterpreterCommandWord(base)
+    || base === "perl"
+    || base === "ruby"
+    || base === "php"
+    || base === "lua";
+}
+
+function firstInterpreterScriptOperand(words: string[], interpreterWordIndex: number): string {
+  const base = shellWordBaseName(words[interpreterWordIndex] ?? "");
+  if (isNestedShellCommandWord(base)) return firstShellScriptOperand(words, interpreterWordIndex);
+
+  for (let index = interpreterWordIndex + 1; index < words.length; index += 1) {
+    const word = words[index] ?? "";
+    if (!word || word === "--") continue;
+    if (isPythonInterpreterCommandWord(base)) {
+      if (word === "-c" || word === "-m") return "";
+      if (word.startsWith("-")) continue;
+      return word;
+    }
+    if (isNodeInterpreterCommandWord(base) || base === "bun" || base === "tsx") {
+      if (word === "-e" || word === "--eval" || word === "-p" || word === "--print") return "";
+      if (runtimeOptionConsumesNextWord(word)) {
+        index += 1;
+        continue;
+      }
+      if (word.startsWith("--eval=") || word.startsWith("--print=")) return "";
+      if (word.startsWith("-")) continue;
+      return word;
+    }
+    if (base === "deno") {
+      if (word === "eval" || word === "repl") return "";
+      if (word === "run") continue;
+      if (word.startsWith("-")) continue;
+      return word;
+    }
+    if (base === "perl" || base === "ruby" || base === "php" || base === "lua") {
+      if (word === "-e" || word.startsWith("-e")) return "";
+      if (word.startsWith("-")) continue;
+      return word;
+    }
+  }
+  return "";
+}
+
+function firstPlanningTmpScriptExecutionTarget(cwd: string, command: string): string | null {
+  const scanCommand = (currentCwd: string, currentCommand: string, activeCommands: Set<string>): string | null => {
+    const normalizedCommand = stripHeredocBodiesForCommandScan(normalizeShellLineContinuations(currentCommand));
+    const commandKey = `${currentCwd}\0${normalizedCommand.trim()}`;
+    if (!normalizedCommand.trim() || activeCommands.has(commandKey)) return null;
+
+    const assignments = extractCommandLiteralAssignments(normalizedCommand);
+    const nextActiveCommands = new Set(activeCommands);
+    nextActiveCommands.add(commandKey);
+    let effectiveCwd = currentCwd;
+    const normalizeExecutionTarget = (operandCwd: string, rawPath: string): string | null => {
+      const absoluteTarget = normalizeSameCommandScriptTarget(operandCwd, rawPath, assignments);
+      if (!absoluteTarget) return null;
+      const relativePath = relative(cwd, absoluteTarget).replace(/\\/g, "/");
+      if (!relativePath || relativePath.startsWith("..") || relativePath.startsWith("/")) return null;
+      return relativePath;
+    };
+
+
+    for (const segment of splitShellCommandSegments(normalizedCommand)) {
+      const words = tokenizeShellWords(segment);
+      const cdCwd = resolveSimpleCdCommandCwd(effectiveCwd, words);
+      if (cdCwd !== null) {
+        effectiveCwd = cdCwd;
+        continue;
+      }
+
+      const wrappedCommandContext = resolveWrappedCommandExecutionContext(words, effectiveCwd);
+      for (let index = 0; index < words.length; index += 1) {
+        const word = words[index] ?? "";
+        const operandCwd = wrappedCommandContext && index >= wrappedCommandContext.index ? wrappedCommandContext.cwd : effectiveCwd;
+        const operand = word === "source" || word === "."
+          ? firstNonOptionSourceOperand(words, index)
+          : isScriptInterpreterCommandWord(word)
+            ? firstInterpreterScriptOperand(words, index)
+            : "";
+        if (!operand) continue;
+        const relativePath = normalizeExecutionTarget(operandCwd, operand);
+
+        if (relativePath && isPlanningTmpRelativePath(relativePath)) return relativePath;
+      }
+
+      if (wrappedCommandContext !== null) {
+        const directTarget = words[wrappedCommandContext.index] ?? "";
+        const relativePath = normalizeExecutionTarget(
+          wrappedCommandContext.cwd,
+          directTarget,
+        );
+        if (relativePath && isPlanningTmpRelativePath(relativePath)) return relativePath;
+      }
+
+      for (const nestedCommand of extractNestedShellCommandStringsForStateScan(segment)) {
+        const nestedTarget = scanCommand(effectiveCwd, nestedCommand, nextActiveCommands);
+        if (nestedTarget) return nestedTarget;
+      }
+      for (const nestedCommand of extractNestedCommandSubstitutionStringsForStateScan(segment)) {
+        const nestedTarget = scanCommand(effectiveCwd, nestedCommand, nextActiveCommands);
+        if (nestedTarget) return nestedTarget;
+      }
+    }
+
+    return null;
+  };
+
+  return scanCommand(cwd, command, new Set());
+}
+
 
 function sourcesFileWrittenEarlierInSameCommand(cwd: string, command: string): boolean {
   const scanCommand = (currentCwd: string, currentCommand: string, activeCommands: Set<string>, writtenTargets: Set<string>): boolean => {
@@ -6194,9 +6362,11 @@ function isAllowedDeepInterviewBashWrite(cwd: string, command: string): boolean 
   if (isAllowedDeepInterviewRalplanHandoffCommand(cwd, command)) return true;
   if (commandEndsPlanningPhase(cwd, command)) return false;
   if (commandHasUntargetedPlanningForbiddenIntent(command)) return false;
+  if (firstPlanningTmpScriptExecutionTarget(cwd, command)) return false;
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
   if (hasUnresolvedConductorInterpreterWrite(command)) return false;
   const targets = extractDeepInterviewCommandWriteTargets(command);
+
   if (targets.some((target) => !isAllowedDeepInterviewArtifactPath(cwd, target))) return false;
   return targets.length > 0 && targets.every((target) => isAllowedDeepInterviewArtifactPath(cwd, target));
 }
@@ -6311,9 +6481,11 @@ function isAllowedRalplanBashWrite(
     return isAllowedRalplanTerminalStateWriteCommand(cwd, command, activeState, sessionId);
   }
   if (commandHasUntargetedPlanningForbiddenIntent(command)) return false;
+  if (firstPlanningTmpScriptExecutionTarget(cwd, command)) return false;
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
   if (hasUnresolvedConductorInterpreterWrite(command)) return false;
   if (targets.some((target) => !isAllowedRalplanArtifactPath(cwd, target))) return false;
+
   return hasAllowedTargets;
 }
 
@@ -6327,6 +6499,11 @@ function buildRalplanBashBlockedDetail(cwd: string, command: string): string {
     const operationClass = /\btee\s+(?:-a\s+)?/.test(command) ? "Bash tee write" : "Bash redirect write";
     return `${operationClass} target ${blockedTarget} is not under allowed planning artifact paths or metadata paths (${RALPLAN_ALLOWED_WRITE_PREFIXES.join(", ")})`;
   }
+  const executedTmpTarget = firstPlanningTmpScriptExecutionTarget(cwd, command);
+  if (executedTmpTarget) {
+    return `execution target ${executedTmpTarget} is under .omx/tmp; planning tmp artifacts must not be used as generated-script transport`;
+  }
+
   if (commandHasPackageInstallIntent(command)) {
     return "package installation commands are implementation actions and cannot be combined with allowed planning artifact writes";
   }
@@ -6352,6 +6529,10 @@ function buildDeepInterviewBashBlockedDetail(cwd: string, command: string): stri
   if (blockedTarget) {
     const operationClass = /\btee\s+(?:-a\s+)?/.test(command) ? "Bash tee write" : "Bash write";
     return `${operationClass} target ${blockedTarget} is not under allowed deep-interview artifact paths or metadata paths (${DEEP_INTERVIEW_ALLOWED_WRITE_PREFIXES.join(", ")})`;
+  }
+  const executedTmpTarget = firstPlanningTmpScriptExecutionTarget(cwd, command);
+  if (executedTmpTarget) {
+    return `execution target ${executedTmpTarget} is under .omx/tmp; deep-interview tmp artifacts must not be used as generated-script transport`;
   }
   if (commandHasPackageInstallIntent(command)) {
     return "package installation commands are implementation actions and cannot be combined with allowed deep-interview artifact writes";

--- a/src/state/__tests__/planning-gate.test.ts
+++ b/src/state/__tests__/planning-gate.test.ts
@@ -67,6 +67,16 @@ sh .omx/tmp/sess/run.sh`;
     assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
   });
 
+  it('classifies Python literal tmp artifact write plus tsx execution as implementation', () => {
+    const command = `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/tmp/sess/run.ts').write_text('console.log(1)')
+PY
+tsx .omx/tmp/sess/run.ts`;
+
+    assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
+  });
+
   it('does not classify Python literal tmp artifact write without execution as implementation', () => {
     const command = `python3 - <<'PY'
 from pathlib import Path
@@ -321,6 +331,23 @@ printf pwned > src/pwned.ts
 SCRIPT
 sh .omx/context/run.sh
 omx state write --input '{"mode":"autopilot","active":true,"current_phase":"ralplan","state":{"deep_interview_gate":{"status":"complete","rationale":"done"}}}' --json`;
+    const decision = evaluatePreToolUseGate(
+      { tool_name: 'Bash', tool_input: command },
+      gateState,
+      false,
+    );
+
+    assert.equal(decision.allowed, false);
+    assert.equal(decision.gate_fired, true);
+    assert.match(decision.reason!, /Bash denied/);
+  });
+
+  it('denies same-command tmp TypeScript artifact execution through tsx when no ralplan consensus artifact exists', () => {
+    const command = `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/tmp/sess/run.ts').write_text('console.log(1)')
+PY
+tsx .omx/tmp/sess/run.ts`;
     const decision = evaluatePreToolUseGate(
       { tool_name: 'Bash', tool_input: command },
       gateState,

--- a/src/state/__tests__/planning-gate.test.ts
+++ b/src/state/__tests__/planning-gate.test.ts
@@ -57,6 +57,25 @@ sh .omx/plans/run.sh`;
     assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
   });
 
+  it('classifies Python literal tmp artifact write plus shell execution as implementation', () => {
+    const command = `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/tmp/sess/run.sh').write_text('echo pwned')
+PY
+sh .omx/tmp/sess/run.sh`;
+
+    assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
+  });
+
+  it('does not classify Python literal tmp artifact write without execution as implementation', () => {
+    const command = `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/tmp/sess/notes.md').write_text('# Scratch notes\\n')
+PY`;
+
+    assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), false);
+  });
+
   it('does not classify Python literal planning artifact write without execution as implementation', () => {
     const command = `python3 - <<'PY'
 from pathlib import Path

--- a/src/state/__tests__/planning-gate.test.ts
+++ b/src/state/__tests__/planning-gate.test.ts
@@ -77,6 +77,45 @@ tsx .omx/tmp/sess/run.ts`;
     assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true);
   });
 
+  it('classifies same-command tmp source runner and preload transports as implementation', () => {
+    const commands = [
+      `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/tmp/sess/run.ts').write_text('console.log(1)')
+PY
+tsx --tsconfig tsconfig.json watch .omx/tmp/sess/run.ts`,
+      `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/tmp/sess/run.ts').write_text('console.log(1)')
+PY
+deno run .omx/tmp/sess/run.ts`,
+      `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/tmp/sess/run.txt').write_text('print(1)')
+PY
+python -X dev .omx/tmp/sess/run.txt`,
+      `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/tmp/sess/probe.go').write_text('package main')
+PY
+go run .omx/tmp/sess/probe.go`,
+      `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/tmp/sess/preload').write_text('')
+PY
+node --require .omx/tmp/sess/preload -e ''`,
+      `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/tmp/sess/rc').write_text('')
+PY
+bash --rcfile .omx/tmp/sess/rc -i -c true`,
+    ];
+
+    for (const command of commands) {
+      assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true, command);
+    }
+  });
+
   it('does not classify Python literal tmp artifact write without execution as implementation', () => {
     const command = `python3 - <<'PY'
 from pathlib import Path
@@ -357,6 +396,42 @@ tsx .omx/tmp/sess/run.ts`;
     assert.equal(decision.allowed, false);
     assert.equal(decision.gate_fired, true);
     assert.match(decision.reason!, /Bash denied/);
+  });
+
+  it('denies same-command tmp source runner and preload transports when no ralplan consensus artifact exists', () => {
+    const commands = [
+      `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/tmp/sess/run.ts').write_text('console.log(1)')
+PY
+tsx --tsconfig tsconfig.json watch .omx/tmp/sess/run.ts`,
+      `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/tmp/sess/run.ts').write_text('console.log(1)')
+PY
+deno run .omx/tmp/sess/run.ts`,
+      `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/tmp/sess/run.txt').write_text('print(1)')
+PY
+python -X dev .omx/tmp/sess/run.txt`,
+      `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/tmp/sess/probe.go').write_text('package main')
+PY
+go run .omx/tmp/sess/probe.go`,
+    ];
+
+    for (const command of commands) {
+      const decision = evaluatePreToolUseGate(
+        { tool_name: 'Bash', tool_input: command },
+        gateState,
+        false,
+      );
+      assert.equal(decision.allowed, false, command);
+      assert.equal(decision.gate_fired, true, command);
+      assert.match(decision.reason!, /Bash denied/);
+    }
   });
 
   it('denies review5 protected artifact write plus same-command execution probes', () => {

--- a/src/state/__tests__/planning-gate.test.ts
+++ b/src/state/__tests__/planning-gate.test.ts
@@ -124,6 +124,10 @@ bash --rcfile .omx/tmp/sess/rc -i -c true`,
       'perl < .omx/tmp/s/run.txt',
       'sh < .omx/tmp/s/run.txt',
       'bash < .omx/tmp/s/run.txt',
+      '/usr/bin/python < .omx/tmp/s/run.txt',
+      '/bin/sh < .omx/tmp/s/run.txt',
+      'env /bin/bash < .omx/tmp/s/run.txt',
+      'command /usr/bin/node < .omx/tmp/s/run.txt',
       `python3 - <<'PY'
 from pathlib import Path
 Path('.omx/tmp/s/run.txt').write_text('print(1)')

--- a/src/state/__tests__/planning-gate.test.ts
+++ b/src/state/__tests__/planning-gate.test.ts
@@ -116,6 +116,26 @@ bash --rcfile .omx/tmp/sess/rc -i -c true`,
     }
   });
 
+  it('classifies tmp stdin redirection into interpreters and shells as implementation', () => {
+    const commands = [
+      'python < .omx/tmp/s/run.txt',
+      'node < .omx/tmp/s/run.txt',
+      'ruby < .omx/tmp/s/run.txt',
+      'perl < .omx/tmp/s/run.txt',
+      'sh < .omx/tmp/s/run.txt',
+      'bash < .omx/tmp/s/run.txt',
+      `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/tmp/s/run.txt').write_text('print(1)')
+PY
+python < .omx/tmp/s/run.txt`,
+    ];
+
+    for (const command of commands) {
+      assert.equal(isImplementationToolCall({ tool_name: 'Bash', tool_input: command }), true, command);
+    }
+  });
+
   it('does not classify Python literal tmp artifact write without execution as implementation', () => {
     const command = `python3 - <<'PY'
 from pathlib import Path
@@ -420,6 +440,33 @@ from pathlib import Path
 Path('.omx/tmp/sess/probe.go').write_text('package main')
 PY
 go run .omx/tmp/sess/probe.go`,
+    ];
+
+    for (const command of commands) {
+      const decision = evaluatePreToolUseGate(
+        { tool_name: 'Bash', tool_input: command },
+        gateState,
+        false,
+      );
+      assert.equal(decision.allowed, false, command);
+      assert.equal(decision.gate_fired, true, command);
+      assert.match(decision.reason!, /Bash denied/);
+    }
+  });
+
+  it('denies tmp stdin redirection into interpreters and shells when no ralplan consensus artifact exists', () => {
+    const commands = [
+      'python < .omx/tmp/s/run.txt',
+      'node < .omx/tmp/s/run.txt',
+      'ruby < .omx/tmp/s/run.txt',
+      'perl < .omx/tmp/s/run.txt',
+      'sh < .omx/tmp/s/run.txt',
+      'bash < .omx/tmp/s/run.txt',
+      `python3 - <<'PY'
+from pathlib import Path
+Path('.omx/tmp/s/run.txt').write_text('print(1)')
+PY
+python < .omx/tmp/s/run.txt`,
     ];
 
     for (const command of commands) {

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -187,7 +187,7 @@ function isScriptInterpreterName(name: string): boolean {
 }
 
 function isProtectedArtifactPath(path: string): boolean {
-  return /^(?:\.\/)?\.omx\/(?:context|specs)\/[^"'\s;|&<>]+$/.test(path);
+  return /^(?:\.\/)?\.omx\/(?:context|specs|tmp)\/[^"'\s;|&<>]+$/.test(path);
 }
 
 function resolveCommandOperand(cwd: string, operand: string): string {
@@ -462,7 +462,7 @@ function hasTokenizedExecutionOfPath(command: string, path: string, initialCwd =
 
 function collectProtectedArtifactWritePaths(command: string): Set<string> {
   const paths = new Set<string>();
-  const protectedPath = String.raw`(["']?)((?:\.\/)?\.omx\/(?:context|specs|plans)\/[^"'\s;|&<>]+)\1`;
+  const protectedPath = String.raw`(["']?)((?:\.\/)?\.omx\/(?:context|specs|plans|tmp)\/[^"'\s;|&<>]+)\1`;
   const redirectPattern = new RegExp(String.raw`(?:^|[^<])>>?\s*${protectedPath}`, 'g');
 
   for (const match of command.matchAll(redirectPattern)) {
@@ -470,7 +470,7 @@ function collectProtectedArtifactWritePaths(command: string): Set<string> {
     if (path) paths.add(normalizeProtectedArtifactPath(path));
   }
 
-  const pythonPathWritePattern = /\bpython3?\b[\s\S]{0,520}\bPath\s*\(\s*(["'])((?:\.\/)?\.omx\/(?:context|specs|plans)\/[^"']+)\1\s*\)\s*\.\s*(?:write_text|write_bytes)\s*\(/g;
+  const pythonPathWritePattern = /\bpython3?\b[\s\S]{0,520}\bPath\s*\(\s*(["'])((?:\.\/)?\.omx\/(?:context|specs|plans|tmp)\/[^"']+)\1\s*\)\s*\.\s*(?:write_text|write_bytes)\s*\(/g;
   for (const match of command.matchAll(pythonPathWritePattern)) {
     const path = match[2]?.trim();
     if (path) paths.add(normalizeProtectedArtifactPath(path));

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -55,6 +55,11 @@ function sameShellPath(candidate: string, target: string): boolean {
   return normalizeShellPath(candidate) === normalizeShellPath(target);
 }
 
+function shellCommandBasename(commandName: string): string {
+  const normalized = normalizeShellPath(commandName);
+  return normalized.slice(normalized.lastIndexOf('/') + 1);
+}
+
 function shellWords(statement: string): string[] {
   const words: string[] = [];
   let current = '';
@@ -327,7 +332,8 @@ function scriptInterpreterOperand(args: string[], cwd: string, targetPath: strin
 
 function shellExecutionMatches(words: string[], cwd: string, targetPath: string): boolean {
   if (words.length === 0) return false;
-  const commandName = words[0]!;
+  const rawCommandName = words[0]!;
+  const commandName = shellCommandBasename(rawCommandName);
 
   if (commandName === 'source' || commandName === '.') {
     const operand = words[1];
@@ -344,8 +350,8 @@ function shellExecutionMatches(words: string[], cwd: string, targetPath: string)
       || scriptInterpreterOperand(words.slice(1), cwd, targetPath, commandName);
   }
 
-  if (commandName.startsWith('./') || commandName.includes('/')) {
-    return sameShellPath(resolveCommandOperand(cwd, commandName), targetPath);
+  if (rawCommandName.startsWith('./') || rawCommandName.includes('/')) {
+    return sameShellPath(resolveCommandOperand(cwd, rawCommandName), targetPath);
   }
 
   return false;
@@ -400,7 +406,7 @@ function unwrapExecutionCommand(words: string[], cwd: string): { words: string[]
   let currentWords = words;
   let currentCwd = cwd;
   for (let unwrapCount = 0; unwrapCount < 8; unwrapCount += 1) {
-    const commandName = currentWords[0];
+    const commandName = shellCommandBasename(currentWords[0] ?? '');
     if (commandName === 'env') {
       const unwrapped = unwrapEnvCommand(currentWords, currentCwd);
       if (unwrapped.words === currentWords) return unwrapped;
@@ -426,7 +432,7 @@ function unwrapExecutionCommand(words: string[], cwd: string): { words: string[]
 function unwrapCdCommandWords(words: string[]): string[] {
   let currentWords = words;
   for (let unwrapCount = 0; unwrapCount < 4; unwrapCount += 1) {
-    const commandName = currentWords[0];
+    const commandName = shellCommandBasename(currentWords[0] ?? '');
     if (commandName === 'command') {
       const operandIndex = findDirectWrapperOperandIndex(currentWords, 1);
       if (operandIndex === null) return currentWords;
@@ -459,7 +465,7 @@ function cdTransitionTarget(words: string[], cwd: string): string | null {
 }
 
 function unwrapEnvCommand(words: string[], cwd: string): { words: string[]; cwd: string } {
-  if (words[0] !== 'env') return { words, cwd };
+  if (shellCommandBasename(words[0] ?? '') !== 'env') return { words, cwd };
 
   let index = 1;
   let envCwd = cwd;
@@ -600,7 +606,7 @@ function commandStdinRedirectsPlanningTmpIntoInterpreter(command: string, initia
         cwds.set(statement.subshellDepth, cdTarget);
       } else {
         const unwrapped = unwrapExecutionCommand(words, cwd);
-        const commandName = unwrapped.words[0] ?? '';
+        const commandName = shellCommandBasename(unwrapped.words[0] ?? '');
         if ((isShellName(commandName) || isScriptInterpreterName(commandName))
           && stdinRedirectsPlanningTmp(unwrapped.words.slice(1), unwrapped.cwd)) return true;
       }

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -183,7 +183,7 @@ function isShellName(name: string): boolean {
 }
 
 function isScriptInterpreterName(name: string): boolean {
-  return /^(?:python[0-9.]?|python3(?:\.[0-9]+)?|node|ruby|perl|php|lua|deno|bun)$/.test(name);
+  return /^(?:python[0-9.]?|python3(?:\.[0-9]+)?|node|ruby|perl|php|lua|deno|bun|tsx)$/.test(name);
 }
 
 function isProtectedArtifactPath(path: string): boolean {

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -183,7 +183,7 @@ function isShellName(name: string): boolean {
 }
 
 function isScriptInterpreterName(name: string): boolean {
-  return /^(?:python[0-9.]?|python3(?:\.[0-9]+)?|node|ruby|perl|php|lua|deno|bun|tsx)$/.test(name);
+  return /^(?:python[0-9.]?|python3(?:\.[0-9]+)?|node|nodejs|ruby|perl|php|lua|deno|bun|tsx|go|npx|npm|pnpm|yarn)$/.test(name);
 }
 
 function isProtectedArtifactPath(path: string): boolean {
@@ -194,6 +194,20 @@ function resolveCommandOperand(cwd: string, operand: string): string {
   return joinShellPath(cwd, operand.replace(/^\.\//, ''));
 }
 
+function isPythonRuntimeOptionWithSeparateValue(word: string): boolean {
+  return word === '-W' || word === '-X' || word === '--check-hash-based-pycs';
+}
+
+function runtimeLoadOptionOperandMatches(word: string, args: string[], index: number, cwd: string, targetPath: string): boolean {
+  if (word === '-r' || word === '--require' || word === '--import' || word === '--loader' || word === '--experimental-loader') {
+    const operand = args[index + 1];
+    return Boolean(operand && sameShellPath(resolveCommandOperand(cwd, operand), targetPath));
+  }
+  for (const prefix of ['--require=', '--import=', '--loader=', '--experimental-loader=']) {
+    if (word.startsWith(prefix)) return sameShellPath(resolveCommandOperand(cwd, word.slice(prefix.length)), targetPath);
+  }
+  return false;
+}
 function shellScriptOperand(args: string[], cwd: string, targetPath: string): boolean {
   for (let index = 0; index < args.length; index += 1) {
     const word = args[index]!;
@@ -209,12 +223,86 @@ function shellScriptOperand(args: string[], cwd: string, targetPath: string): bo
       const inlineCommand = args[index + 1];
       return Boolean(inlineCommand && hasTokenizedExecutionOfPath(inlineCommand, targetPath, cwd));
     }
-    if (word === '-o' || word === '+o' || word === '-O' || word === '+O' || word === '--init-file' || word === '--rcfile') {
+    if (word === '--init-file' || word === '--rcfile') {
+      const operand = args[index + 1];
+      if (operand && sameShellPath(resolveCommandOperand(cwd, operand), targetPath)) return true;
       index += 1;
       continue;
     }
-    if (word.startsWith('--init-file=') || word.startsWith('--rcfile=')) continue;
+    if (word.startsWith('--init-file=') || word.startsWith('--rcfile=')) {
+      if (sameShellPath(resolveCommandOperand(cwd, word.slice(word.indexOf('=') + 1)), targetPath)) return true;
+      continue;
+    }
+    if (word === '-o' || word === '+o' || word === '-O' || word === '+O') {
+      index += 1;
+      continue;
+    }
     if (word.startsWith('-') || word.startsWith('+')) continue;
+    return sameShellPath(resolveCommandOperand(cwd, word), targetPath);
+  }
+  return false;
+}
+
+function scriptInterpreterOperand(args: string[], cwd: string, targetPath: string, commandName: string): boolean {
+  let sawGoRun = false;
+  let sawPackageRunner = commandName === 'npx';
+  for (let index = 0; index < args.length; index += 1) {
+    const word = args[index]!;
+    if (!word || word === '--') continue;
+    if (/^python/.test(commandName)) {
+      if (word === '-c' || word === '-m') return false;
+      if (isPythonRuntimeOptionWithSeparateValue(word)) {
+        index += 1;
+        continue;
+      }
+      if (word.startsWith('-W') || word.startsWith('-X')) continue;
+      if (word.startsWith('-')) continue;
+      return sameShellPath(resolveCommandOperand(cwd, word), targetPath);
+    }
+    if (commandName === 'node' || commandName === 'nodejs' || commandName === 'bun' || commandName === 'tsx') {
+      if (word === '-e' || word === '--eval' || word === '-p' || word === '--print') return false;
+      if (runtimeLoadOptionOperandMatches(word, args, index, cwd, targetPath)) return true;
+      if (word === '-r' || word === '--require' || word === '--import' || word === '--loader' || word === '--experimental-loader' || word === '--tsconfig' || word === '-C') {
+        index += 1;
+        continue;
+      }
+      if (word.startsWith('--require=') || word.startsWith('--import=') || word.startsWith('--loader=') || word.startsWith('--experimental-loader=')) continue;
+      if (word.startsWith('--eval=') || word.startsWith('--print=')) return false;
+      if (commandName === 'tsx' && word === 'watch') continue;
+      if (word.startsWith('-')) continue;
+      return sameShellPath(resolveCommandOperand(cwd, word), targetPath);
+    }
+    if (commandName === 'deno') {
+      if (word === 'eval' || word === 'repl') return false;
+      if (word === 'run') continue;
+      if (word.startsWith('-')) continue;
+      return sameShellPath(resolveCommandOperand(cwd, word), targetPath);
+    }
+    if (commandName === 'go') {
+      if (!sawGoRun) {
+        if (word === 'run') {
+          sawGoRun = true;
+          continue;
+        }
+        return false;
+      }
+      if (word.startsWith('-')) continue;
+      return sameShellPath(resolveCommandOperand(cwd, word), targetPath);
+    }
+    if (commandName === 'npm' || commandName === 'pnpm' || commandName === 'yarn' || commandName === 'npx') {
+      if (!sawPackageRunner) {
+        if (word === 'exec' || word === 'x' || word === 'dlx') {
+          sawPackageRunner = true;
+          continue;
+        }
+        return false;
+      }
+      if (word.startsWith('-')) continue;
+      if (word === 'tsx' || word === 'node' || word === 'bun' || word === 'deno') continue;
+      return sameShellPath(resolveCommandOperand(cwd, word), targetPath);
+    }
+    if (word === '-e' || word.startsWith('-e')) return false;
+    if (word.startsWith('-')) continue;
     return sameShellPath(resolveCommandOperand(cwd, word), targetPath);
   }
   return false;
@@ -234,7 +322,7 @@ function shellExecutionMatches(words: string[], cwd: string, targetPath: string)
   }
 
   if (isScriptInterpreterName(commandName)) {
-    return shellScriptOperand(words.slice(1), cwd, targetPath);
+    return scriptInterpreterOperand(words.slice(1), cwd, targetPath, commandName);
   }
 
   if (commandName.startsWith('./') || commandName.includes('/')) {

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -208,6 +208,23 @@ function runtimeLoadOptionOperandMatches(word: string, args: string[], index: nu
   }
   return false;
 }
+
+function stdinRedirectOperandMatches(args: string[], cwd: string, targetPath: string): boolean {
+  for (let index = 0; index < args.length; index += 1) {
+    const word = args[index]!;
+    if (word === '<') {
+      const operand = args[index + 1];
+      if (operand && sameShellPath(resolveCommandOperand(cwd, operand), targetPath)) return true;
+      index += 1;
+      continue;
+    }
+    if (/^\d*<[^<&].+/.test(word)) {
+      const operand = word.replace(/^\d*</, '');
+      if (sameShellPath(resolveCommandOperand(cwd, operand), targetPath)) return true;
+    }
+  }
+  return false;
+}
 function shellScriptOperand(args: string[], cwd: string, targetPath: string): boolean {
   for (let index = 0; index < args.length; index += 1) {
     const word = args[index]!;
@@ -318,11 +335,13 @@ function shellExecutionMatches(words: string[], cwd: string, targetPath: string)
   }
 
   if (isShellName(commandName)) {
-    return shellScriptOperand(words.slice(1), cwd, targetPath);
+    return stdinRedirectOperandMatches(words.slice(1), cwd, targetPath)
+      || shellScriptOperand(words.slice(1), cwd, targetPath);
   }
 
   if (isScriptInterpreterName(commandName)) {
-    return scriptInterpreterOperand(words.slice(1), cwd, targetPath, commandName);
+    return stdinRedirectOperandMatches(words.slice(1), cwd, targetPath)
+      || scriptInterpreterOperand(words.slice(1), cwd, targetPath, commandName);
   }
 
   if (commandName.startsWith('./') || commandName.includes('/')) {
@@ -548,6 +567,54 @@ function hasTokenizedExecutionOfPath(command: string, path: string, initialCwd =
   return false;
 }
 
+function isPlanningTmpShellPath(path: string): boolean {
+  const normalized = normalizeShellPath(path);
+  return normalized === '.omx/tmp' || normalized.startsWith('.omx/tmp/');
+}
+
+function stdinRedirectsPlanningTmp(args: string[], cwd: string): boolean {
+  for (let index = 0; index < args.length; index += 1) {
+    const word = args[index]!;
+    if (word === '<') {
+      const operand = args[index + 1];
+      if (operand && isPlanningTmpShellPath(resolveCommandOperand(cwd, operand))) return true;
+      index += 1;
+      continue;
+    }
+    if (/^\d*<[^<&].+/.test(word)) {
+      const operand = word.replace(/^\d*</, '');
+      if (isPlanningTmpShellPath(resolveCommandOperand(cwd, operand))) return true;
+    }
+  }
+  return false;
+}
+
+function commandStdinRedirectsPlanningTmpIntoInterpreter(command: string, initialCwd = ''): boolean {
+  const cwds = new Map<number, string>([[0, initialCwd]]);
+  for (const statement of shellStatementRecords(command)) {
+    const cwd = scopedCwd(cwds, statement.subshellDepth, initialCwd);
+    const words = groupedShellWords(statement.text);
+    if (words.length > 0) {
+      const cdTarget = cdTransitionTarget(words, cwd);
+      if (cdTarget) {
+        cwds.set(statement.subshellDepth, cdTarget);
+      } else {
+        const unwrapped = unwrapExecutionCommand(words, cwd);
+        const commandName = unwrapped.words[0] ?? '';
+        if ((isShellName(commandName) || isScriptInterpreterName(commandName))
+          && stdinRedirectsPlanningTmp(unwrapped.words.slice(1), unwrapped.cwd)) return true;
+      }
+    }
+
+    if (statement.closesSubshells > 0) {
+      for (let depth = statement.subshellDepth; depth > statement.subshellDepth - statement.closesSubshells; depth -= 1) {
+        cwds.delete(depth);
+      }
+    }
+  }
+  return false;
+}
+
 function collectProtectedArtifactWritePaths(command: string): Set<string> {
   const paths = new Set<string>();
   const protectedPath = String.raw`(["']?)((?:\.\/)?\.omx\/(?:context|specs|plans|tmp)\/[^"'\s;|&<>]+)\1`;
@@ -613,6 +680,7 @@ export function isImplementationToolCall(input: PreToolUseGateInput): boolean {
   if (IMPLEMENTATION_TOOLS.has(input.tool_name)) return true;
   if (input.tool_name === 'Bash' && typeof input.tool_input === 'string') {
     return DENIED_BASH_PATTERNS.some((pattern) => pattern.test(input.tool_input!))
+      || commandStdinRedirectsPlanningTmpIntoInterpreter(input.tool_input)
       || hasSameCommandProtectedArtifactExecution(input.tool_input);
   }
   return false;


### PR DESCRIPTION
## Summary
- Allow deep-interview and ralplan planning modes to write scratch artifacts under `.omx/tmp/`.
- Treat `.omx/tmp/` as protected planning artifact space for artifact-write detection.
- Add focused regression coverage for tmp scratch writes and execution boundaries.

## Verification
- External recovery verification: `git diff --stat --compact-summary` reported 63 insertions / 5 deletions across 4 files.
- External recovery verification: `git diff --check` clean.
- External recovery verification: `npm run build` passed.
- External recovery verification: focused compiled tests passed: 53 pass / 0 fail.
- Local pre-commit review: `git diff --check` clean.

## Owner confirmation
OWNER_CONFIRMATION_REQUIRED

Do not merge until owner confirmation is recorded.