### PR TITLE
Fix HUD superseded Ultragoal status

### DIFF
--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -338,6 +338,54 @@ describe('readUltragoalState', { concurrency: false }, () => {
     });
   });
 
+  it('treats superseded pending ultragoal goals as terminal for HUD activity', async () => {
+    await withTempRepo('omx-hud-ultragoal-superseded-terminal-', async (cwd) => {
+      const ultragoalDir = join(cwd, '.omx', 'ultragoal');
+      await mkdir(ultragoalDir, { recursive: true });
+      await writeFile(join(ultragoalDir, 'goals.json'), JSON.stringify({
+        version: 1,
+        activeGoalId: 'G002-old-pending',
+        goals: [
+          { id: 'G001-done', title: 'Done', objective: 'Completed accepted replacement', status: 'complete' },
+          { id: 'G002-old-pending', title: 'Old pending', objective: 'Superseded work that should not remain active in HUD', status: 'pending', steeringStatus: 'superseded', supersededBy: ['G001-done'] },
+        ],
+      }));
+
+      const state = await readUltragoalState(cwd);
+
+      assert.equal(state?.active, false);
+      assert.equal(state?.status, 'complete');
+      assert.equal(state?.pending, 0);
+      assert.equal(state?.activeGoal, undefined);
+      assert.deepEqual(state?.ongoingGoals, []);
+      assert.deepEqual(state?.nextGoals, []);
+    });
+  });
+
+  it('falls through superseded pending activeGoalId to genuinely active pending ultragoal goals', async () => {
+    await withTempRepo('omx-hud-ultragoal-superseded-with-active-pending-', async (cwd) => {
+      const ultragoalDir = join(cwd, '.omx', 'ultragoal');
+      await mkdir(ultragoalDir, { recursive: true });
+      await writeFile(join(ultragoalDir, 'goals.json'), JSON.stringify({
+        version: 1,
+        activeGoalId: 'G002-old-pending',
+        goals: [
+          { id: 'G001-done', title: 'Done', objective: 'Completed old work', status: 'complete' },
+          { id: 'G002-old-pending', title: 'Old pending', objective: 'Superseded work that should not remain active in HUD', status: 'pending', steeringStatus: 'superseded', supersededBy: ['G003-real-pending'] },
+          { id: 'G003-real-pending', title: 'Real pending', objective: 'Still-active replacement work', status: 'pending', supersedes: ['G002-old-pending'] },
+        ],
+      }));
+
+      const state = await readUltragoalState(cwd);
+
+      assert.equal(state?.active, true);
+      assert.equal(state?.status, 'pending');
+      assert.equal(state?.pending, 1);
+      assert.equal(state?.activeGoal?.id, 'G003-real-pending');
+      assert.deepEqual(state?.ongoingGoals?.map((goal) => goal.id), ['G003-real-pending']);
+    });
+  });
+
   it('shows active ultragoal plus the next three pending goals', async () => {
     await withTempRepo('omx-hud-ultragoal-next-pending-', async (cwd) => {
       const ultragoalDir = join(cwd, '.omx', 'ultragoal');

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -362,17 +362,16 @@ describe('readUltragoalState', { concurrency: false }, () => {
     });
   });
 
-  it('falls through superseded pending activeGoalId to genuinely active pending ultragoal goals', async () => {
-    await withTempRepo('omx-hud-ultragoal-superseded-with-active-pending-', async (cwd) => {
+  it('keeps superseded ultragoal goals active until replacements are declared', async () => {
+    await withTempRepo('omx-hud-ultragoal-superseded-without-replacements-', async (cwd) => {
       const ultragoalDir = join(cwd, '.omx', 'ultragoal');
       await mkdir(ultragoalDir, { recursive: true });
       await writeFile(join(ultragoalDir, 'goals.json'), JSON.stringify({
         version: 1,
         activeGoalId: 'G002-old-pending',
         goals: [
-          { id: 'G001-done', title: 'Done', objective: 'Completed old work', status: 'complete' },
-          { id: 'G002-old-pending', title: 'Old pending', objective: 'Superseded work that should not remain active in HUD', status: 'pending', steeringStatus: 'superseded', supersededBy: ['G003-real-pending'] },
-          { id: 'G003-real-pending', title: 'Real pending', objective: 'Still-active replacement work', status: 'pending', supersedes: ['G002-old-pending'] },
+          { id: 'G001-done', title: 'Done', objective: 'Completed prior work', status: 'complete' },
+          { id: 'G002-old-pending', title: 'Old pending', objective: 'Superseded work without an auditable replacement', status: 'pending', steeringStatus: 'superseded' },
         ],
       }));
 
@@ -381,8 +380,57 @@ describe('readUltragoalState', { concurrency: false }, () => {
       assert.equal(state?.active, true);
       assert.equal(state?.status, 'pending');
       assert.equal(state?.pending, 1);
-      assert.equal(state?.activeGoal?.id, 'G003-real-pending');
-      assert.deepEqual(state?.ongoingGoals?.map((goal) => goal.id), ['G003-real-pending']);
+      assert.equal(state?.activeGoal?.id, 'G002-old-pending');
+      assert.deepEqual(state?.ongoingGoals?.map((goal) => goal.id), ['G002-old-pending']);
+    });
+  });
+
+  it('keeps superseded ultragoal goals active until every replacement is resolved', async () => {
+    await withTempRepo('omx-hud-ultragoal-superseded-unresolved-replacement-', async (cwd) => {
+      const ultragoalDir = join(cwd, '.omx', 'ultragoal');
+      await mkdir(ultragoalDir, { recursive: true });
+      await writeFile(join(ultragoalDir, 'goals.json'), JSON.stringify({
+        version: 1,
+        activeGoalId: 'G002-old-pending',
+        goals: [
+          { id: 'G001-done', title: 'Done', objective: 'Completed prior work', status: 'complete' },
+          { id: 'G002-old-pending', title: 'Old pending', objective: 'Superseded work with unfinished replacements', status: 'pending', steeringStatus: 'superseded', supersededBy: ['G003-real-pending'] },
+          { id: 'G003-real-pending', title: 'Real pending', objective: 'Finish replacement work', status: 'pending', supersedes: ['G002-old-pending'] },
+        ],
+      }));
+
+      const state = await readUltragoalState(cwd);
+
+      assert.equal(state?.active, true);
+      assert.equal(state?.status, 'pending');
+      assert.equal(state?.pending, 2);
+      assert.equal(state?.activeGoal?.id, 'G002-old-pending');
+      assert.deepEqual(state?.ongoingGoals?.map((goal) => goal.id), ['G002-old-pending', 'G003-real-pending']);
+    });
+  });
+
+  it('falls through resolved superseded activeGoalId to genuinely active pending ultragoal goals', async () => {
+    await withTempRepo('omx-hud-ultragoal-superseded-with-active-pending-', async (cwd) => {
+      const ultragoalDir = join(cwd, '.omx', 'ultragoal');
+      await mkdir(ultragoalDir, { recursive: true });
+      await writeFile(join(ultragoalDir, 'goals.json'), JSON.stringify({
+        version: 1,
+        activeGoalId: 'G002-old-pending',
+        goals: [
+          { id: 'G001-done', title: 'Done', objective: 'Completed old work', status: 'complete' },
+          { id: 'G002-old-pending', title: 'Old pending', objective: 'Superseded work that should not remain active in HUD', status: 'pending', steeringStatus: 'superseded', supersededBy: ['G003-replacement-done'] },
+          { id: 'G003-replacement-done', title: 'Replacement done', objective: 'Completed replacement work', status: 'complete', supersedes: ['G002-old-pending'] },
+          { id: 'G004-real-pending', title: 'Real pending', objective: 'Still-active follow-up work', status: 'pending' },
+        ],
+      }));
+
+      const state = await readUltragoalState(cwd);
+
+      assert.equal(state?.active, true);
+      assert.equal(state?.status, 'pending');
+      assert.equal(state?.pending, 1);
+      assert.equal(state?.activeGoal?.id, 'G004-real-pending');
+      assert.deepEqual(state?.ongoingGoals?.map((goal) => goal.id), ['G004-real-pending']);
     });
   });
 

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -117,6 +117,7 @@ interface RawUltragoalGoal {
   title?: unknown;
   objective?: unknown;
   status?: unknown;
+  steeringStatus?: unknown;
 }
 
 interface RawUltragoalPlan {
@@ -133,6 +134,7 @@ type NormalizedUltragoalGoal = {
   title: string;
   objective: string;
   status: string;
+  steeringStatus?: string;
 };
 
 function normalizeUltragoalGoal(raw: unknown): NormalizedUltragoalGoal | null {
@@ -142,8 +144,17 @@ function normalizeUltragoalGoal(raw: unknown): NormalizedUltragoalGoal | null {
   const title = sanitizeOptionalString(goal.title);
   const objective = sanitizeOptionalString(goal.objective);
   const status = sanitizeOptionalString(goal.status);
+  const steeringStatus = sanitizeOptionalString(goal.steeringStatus);
   if (!id || !title || !objective || !status) return null;
-  return { id, title, objective, status };
+  return { id, title, objective, status, steeringStatus };
+}
+
+function isSupersededUltragoalGoal(goal: NormalizedUltragoalGoal): boolean {
+  return goal.steeringStatus === 'superseded';
+}
+
+function isHudUnresolvedUltragoalGoal(goal: NormalizedUltragoalGoal): boolean {
+  return !isSupersededUltragoalGoal(goal) && goal.status !== 'complete';
 }
 
 export async function readUltragoalState(cwd: string): Promise<UltragoalStateForHud | null> {
@@ -154,17 +165,17 @@ export async function readUltragoalState(cwd: string): Promise<UltragoalStateFor
   if (goals.length === 0) return null;
 
   const completed_goals = goals.filter((goal) => goal.status === 'complete').length;
-  const pending_goals = goals.filter((goal) => goal.status === 'pending').length;
-  const in_progress_goals = goals.filter((goal) => goal.status === 'in_progress').length;
-  const failed_goals = goals.filter((goal) => goal.status === 'failed').length;
-  const review_blocked_goals = goals.filter((goal) => goal.status === 'review_blocked').length;
-  const needs_user_decision_goals = goals.filter((goal) => goal.status === 'needs_user_decision').length;
-  const unresolved_goals = goals.length - completed_goals;
+  const pending_goals = goals.filter((goal) => goal.status === 'pending' && !isSupersededUltragoalGoal(goal)).length;
+  const in_progress_goals = goals.filter((goal) => goal.status === 'in_progress' && !isSupersededUltragoalGoal(goal)).length;
+  const failed_goals = goals.filter((goal) => goal.status === 'failed' && !isSupersededUltragoalGoal(goal)).length;
+  const review_blocked_goals = goals.filter((goal) => goal.status === 'review_blocked' && !isSupersededUltragoalGoal(goal)).length;
+  const needs_user_decision_goals = goals.filter((goal) => goal.status === 'needs_user_decision' && !isSupersededUltragoalGoal(goal)).length;
+  const unresolved_goals = goals.filter(isHudUnresolvedUltragoalGoal).length;
   const activeGoalId = sanitizeOptionalString(plan.activeGoalId);
   const activeGoal = (
-    (activeGoalId ? goals.find((goal) => goal.id === activeGoalId && goal.status !== 'complete') : undefined)
-    ?? goals.find((goal) => ULTRAGOAL_ACTIVE_STATUSES.has(goal.status))
-    ?? goals.find((goal) => ULTRAGOAL_UNRESOLVED_STATUSES.has(goal.status))
+    (activeGoalId ? goals.find((goal) => goal.id === activeGoalId && isHudUnresolvedUltragoalGoal(goal)) : undefined)
+    ?? goals.find((goal) => !isSupersededUltragoalGoal(goal) && ULTRAGOAL_ACTIVE_STATUSES.has(goal.status))
+    ?? goals.find((goal) => !isSupersededUltragoalGoal(goal) && ULTRAGOAL_UNRESOLVED_STATUSES.has(goal.status))
   );
   const activeIndex = activeGoal ? goals.findIndex((goal) => goal.id === activeGoal.id) : -1;
   const complete = unresolved_goals === 0;
@@ -177,7 +188,7 @@ export async function readUltragoalState(cwd: string): Promise<UltragoalStateFor
   });
   const nextPendingGoals = goals
     .map((goal, index) => ({ goal, index }))
-    .filter(({ goal, index }) => index > activeIndex && goal.status === 'pending' && goal.id !== activeGoal?.id)
+    .filter(({ goal, index }) => index > activeIndex && goal.status === 'pending' && !isSupersededUltragoalGoal(goal) && goal.id !== activeGoal?.id)
     .slice(0, 3)
     .map(toHudGoal);
   const orderedOngoingGoals = [

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -118,6 +118,7 @@ interface RawUltragoalGoal {
   objective?: unknown;
   status?: unknown;
   steeringStatus?: unknown;
+  supersededBy?: unknown;
 }
 
 interface RawUltragoalPlan {
@@ -135,6 +136,7 @@ type NormalizedUltragoalGoal = {
   objective: string;
   status: string;
   steeringStatus?: string;
+  supersededBy: string[];
 };
 
 function normalizeUltragoalGoal(raw: unknown): NormalizedUltragoalGoal | null {
@@ -146,15 +148,33 @@ function normalizeUltragoalGoal(raw: unknown): NormalizedUltragoalGoal | null {
   const status = sanitizeOptionalString(goal.status);
   const steeringStatus = sanitizeOptionalString(goal.steeringStatus);
   if (!id || !title || !objective || !status) return null;
-  return { id, title, objective, status, steeringStatus };
+  return { id, title, objective, status, steeringStatus, supersededBy: Array.isArray(goal.supersededBy) ? goal.supersededBy.map(sanitizeOptionalString).filter((id): id is string => id !== undefined) : [] };
 }
 
-function isSupersededUltragoalGoal(goal: NormalizedUltragoalGoal): boolean {
-  return goal.steeringStatus === 'superseded';
+function isResolvedUltragoalStatus(status: string): boolean {
+  return status === 'complete';
 }
 
-function isHudUnresolvedUltragoalGoal(goal: NormalizedUltragoalGoal): boolean {
-  return !isSupersededUltragoalGoal(goal) && goal.status !== 'complete';
+function isSupersededUltragoalGoalResolved(goal: NormalizedUltragoalGoal, goals: NormalizedUltragoalGoal[]): boolean {
+  if (goal.steeringStatus !== 'superseded') return false;
+  if (goal.supersededBy.length === 0) return false;
+  return goal.supersededBy.every((id) => {
+    const replacement = goals.find((candidate) => candidate.id === id);
+    return replacement !== undefined && isResolvedUltragoalStatus(replacement.status);
+  });
+}
+
+function isNonBlockingSupersededUltragoalGoal(goal: NormalizedUltragoalGoal, goals: NormalizedUltragoalGoal[]): boolean {
+  return isSupersededUltragoalGoalResolved(goal, goals);
+}
+function isHudCompletionBlockingUltragoalGoal(goal: NormalizedUltragoalGoal, goals: NormalizedUltragoalGoal[]): boolean {
+  if (goal.steeringStatus === 'superseded') return !isSupersededUltragoalGoalResolved(goal, goals);
+  if (goal.steeringStatus === 'blocked') return true;
+  return !isResolvedUltragoalStatus(goal.status);
+}
+
+function isHudUnresolvedUltragoalGoal(goal: NormalizedUltragoalGoal, goals: NormalizedUltragoalGoal[]): boolean {
+  return isHudCompletionBlockingUltragoalGoal(goal, goals);
 }
 
 export async function readUltragoalState(cwd: string): Promise<UltragoalStateForHud | null> {
@@ -165,17 +185,17 @@ export async function readUltragoalState(cwd: string): Promise<UltragoalStateFor
   if (goals.length === 0) return null;
 
   const completed_goals = goals.filter((goal) => goal.status === 'complete').length;
-  const pending_goals = goals.filter((goal) => goal.status === 'pending' && !isSupersededUltragoalGoal(goal)).length;
-  const in_progress_goals = goals.filter((goal) => goal.status === 'in_progress' && !isSupersededUltragoalGoal(goal)).length;
-  const failed_goals = goals.filter((goal) => goal.status === 'failed' && !isSupersededUltragoalGoal(goal)).length;
-  const review_blocked_goals = goals.filter((goal) => goal.status === 'review_blocked' && !isSupersededUltragoalGoal(goal)).length;
-  const needs_user_decision_goals = goals.filter((goal) => goal.status === 'needs_user_decision' && !isSupersededUltragoalGoal(goal)).length;
-  const unresolved_goals = goals.filter(isHudUnresolvedUltragoalGoal).length;
+  const pending_goals = goals.filter((goal) => goal.status === 'pending' && !isNonBlockingSupersededUltragoalGoal(goal, goals)).length;
+  const in_progress_goals = goals.filter((goal) => goal.status === 'in_progress' && !isNonBlockingSupersededUltragoalGoal(goal, goals)).length;
+  const failed_goals = goals.filter((goal) => goal.status === 'failed' && !isNonBlockingSupersededUltragoalGoal(goal, goals)).length;
+  const review_blocked_goals = goals.filter((goal) => goal.status === 'review_blocked' && !isNonBlockingSupersededUltragoalGoal(goal, goals)).length;
+  const needs_user_decision_goals = goals.filter((goal) => goal.status === 'needs_user_decision' && !isNonBlockingSupersededUltragoalGoal(goal, goals)).length;
+  const unresolved_goals = goals.filter((goal) => isHudUnresolvedUltragoalGoal(goal, goals)).length;
   const activeGoalId = sanitizeOptionalString(plan.activeGoalId);
   const activeGoal = (
-    (activeGoalId ? goals.find((goal) => goal.id === activeGoalId && isHudUnresolvedUltragoalGoal(goal)) : undefined)
-    ?? goals.find((goal) => !isSupersededUltragoalGoal(goal) && ULTRAGOAL_ACTIVE_STATUSES.has(goal.status))
-    ?? goals.find((goal) => !isSupersededUltragoalGoal(goal) && ULTRAGOAL_UNRESOLVED_STATUSES.has(goal.status))
+    (activeGoalId ? goals.find((goal) => goal.id === activeGoalId && isHudUnresolvedUltragoalGoal(goal, goals)) : undefined)
+    ?? goals.find((goal) => isHudUnresolvedUltragoalGoal(goal, goals) && ULTRAGOAL_ACTIVE_STATUSES.has(goal.status))
+    ?? goals.find((goal) => isHudUnresolvedUltragoalGoal(goal, goals) && ULTRAGOAL_UNRESOLVED_STATUSES.has(goal.status))
   );
   const activeIndex = activeGoal ? goals.findIndex((goal) => goal.id === activeGoal.id) : -1;
   const complete = unresolved_goals === 0;
@@ -188,7 +208,7 @@ export async function readUltragoalState(cwd: string): Promise<UltragoalStateFor
   });
   const nextPendingGoals = goals
     .map((goal, index) => ({ goal, index }))
-    .filter(({ goal, index }) => index > activeIndex && goal.status === 'pending' && !isSupersededUltragoalGoal(goal) && goal.id !== activeGoal?.id)
+    .filter(({ goal, index }) => index > activeIndex && goal.status === 'pending' && isHudUnresolvedUltragoalGoal(goal, goals) && goal.id !== activeGoal?.id)
     .slice(0, 3)
     .map(toHudGoal);
   const orderedOngoingGoals = [


### PR DESCRIPTION
Closes #3052.

## Summary
- Treat `steeringStatus="superseded"` Ultragoal goals as non-active in HUD status derivation.
- Exclude superseded goals from HUD pending/in-progress/failed/review-blocked/needs-user-decision counts and active/next-goal selection.
- Add regressions proving superseded pending goals do not keep HUD active while real pending replacement goals still surface.

## Verification
- `TMUX_PANE= TMUX= npx tsx --test src/hud/__tests__/state.test.ts`
- `npm run build`
- `TMUX_PANE= TMUX= node dist/scripts/run-test-files.js dist/hud/__tests__/state.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`

Note: the stale code-review/skill-active path already has HUD coverage for terminal canonical state and completed code-reviewer subagent history, so this PR keeps the fix scoped to the confirmed Ultragoal superseded-goal root cause.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*