### PR TITLE
fix: add release body contributors section

### DIFF
--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -26,4 +26,8 @@ Release-prep gates include version sync for `v0.18.17`, build, native-agent veri
 
 Open PRs #3018 and #3010 are blocked/dirty/draft and are not included in this release candidate unless separately fixed and merged before publication.
 
+## Contributors
+
+Thanks to the contributors who made this release possible.
+
 **Full Changelog**: [`v0.18.16...v0.18.17`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.18.16...v0.18.17)


### PR DESCRIPTION
## Summary
- add the required ## Contributors section to RELEASE_BODY.md so the release body generator can refresh contributors in the release workflow

## Verification
- npm run build
- GITHUB_REF_NAME=v0.18.17 node dist/scripts/generate-release-body.js --template RELEASE_BODY.md --out /tmp/RELEASE_BODY.generated.md

Note: running the generator command without the workflow-provided GITHUB_REF_NAME fails locally before template validation with: unable to determine current release tag; pass --current-tag or set GITHUB_REF_NAME.