### PR TITLE
[codex] fix autopilot ralplan handoff

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7843,6 +7843,58 @@ exit 0
       );
       assert.equal(allowedStateInputFileMutation.outputJson, null);
 
+      const standaloneAutopilotRalplanHandoffPayload = {
+        mode: "autopilot",
+        active: true,
+        current_phase: "ralplan",
+        state: {
+          deep_interview_gate: {
+            status: "complete",
+            rationale: "The bounded PMO catalog task is clear and ready for ralplan handoff.",
+            handoff_summary: "Create the root-level pmo catalog from the captured spec.",
+          },
+        },
+      };
+      const standaloneAutopilotRalplanHandoffInputFile = join(cwd, ".omx", "tmp", "pmo-autopilot-state.json");
+      await mkdir(dirname(standaloneAutopilotRalplanHandoffInputFile), { recursive: true });
+      await writeJson(standaloneAutopilotRalplanHandoffInputFile, standaloneAutopilotRalplanHandoffPayload);
+
+      const blockedStandaloneAutopilotRalplanHandoffWithoutEvidence = await preToolUse(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-standalone-autopilot-ralplan-handoff-without-evidence",
+          tool_input: { command: `omx state write --input-file ${standaloneAutopilotRalplanHandoffInputFile} --json` },
+        },
+        { cwd },
+      );
+      assert.equal(
+        (blockedStandaloneAutopilotRalplanHandoffWithoutEvidence.outputJson as { decision?: string } | null)?.decision,
+        "block",
+      );
+
+      const priorDeepInterviewSpec = join(cwd, ".omx", "specs", "pmo-catalog-spec.md");
+      await mkdir(dirname(priorDeepInterviewSpec), { recursive: true });
+      await writeFile(priorDeepInterviewSpec, "# PMO catalog spec\n");
+      const allowedStandaloneAutopilotRalplanHandoffWithEvidence = await preToolUse(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-di-artifact",
+          tool_name: "Bash",
+          tool_use_id: "tool-di-standalone-autopilot-ralplan-handoff-with-evidence",
+          tool_input: { command: `omx state write --input-file ${standaloneAutopilotRalplanHandoffInputFile} --json` },
+        },
+        { cwd },
+      );
+      assert.equal(
+        allowedStandaloneAutopilotRalplanHandoffWithEvidence.outputJson,
+        null,
+        "a valid autopilot deep-interview -> ralplan state write may use prior durable .omx/specs evidence",
+      );
+
       // A deactivating `omx state write` (or `omx state clear`) ends the planning
       // phase, which the backend does not gate for standalone modes; the hook
       // rejects these deactivation vectors at the transport boundary.

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -6399,6 +6399,33 @@ function isDurableDeepInterviewHandoffEvidencePath(cwd: string, rawPath: string)
     || relativePath.startsWith(".omx/specs/");
 }
 
+function hasExistingDurableDeepInterviewHandoffEvidence(cwd: string): boolean {
+  const roots = [".omx/context", ".omx/interviews", ".omx/specs"] as const;
+  const maxEntries = 2_000;
+  let visited = 0;
+
+  for (const root of roots) {
+    const stack = [resolve(cwd, root)];
+    while (stack.length > 0 && visited < maxEntries) {
+      const current = stack.pop();
+      if (!current) continue;
+      visited += 1;
+      try {
+        const stat = statSync(current);
+        if (stat.isFile()) return true;
+        if (!stat.isDirectory()) continue;
+        for (const entry of readdirSync(current)) {
+          stack.push(join(current, entry));
+        }
+      } catch {
+        // Missing or unreadable roots are not completion evidence.
+      }
+    }
+  }
+
+  return false;
+}
+
 function isAllowedDeepInterviewRalplanHandoffCommand(cwd: string, command: string): boolean {
   const canonicalCommand = canonicalizeOmxStateTransportCommand(command);
   if (hasUnsafeUnquotedHeredocExpansion(canonicalCommand)) return false;
@@ -6414,7 +6441,10 @@ function isAllowedDeepInterviewRalplanHandoffCommand(cwd: string, command: strin
   const payload = readStateWriteInputPayload(cwd, canonicalCommand, command);
   if (!payload || !isDeepInterviewRalplanHandoffStatePayload(payload)) return false;
   const targets = extractDeepInterviewCommandWriteTargets(command);
-  if (targets.length === 0) return false;
+  if (targets.length === 0) {
+    return !hasPriorExecutableCommand(stateWriteOperation.prefix)
+      && hasExistingDurableDeepInterviewHandoffEvidence(cwd);
+  }
   if (!targets.some((target) => isDurableDeepInterviewHandoffEvidencePath(cwd, target))) return false;
   if (!hasOnlyAllowedDeepInterviewRalplanHandoffMutations(cwd, command)) return false;
   return targets.every((target) => isAllowedDeepInterviewArtifactPath(cwd, target));


### PR DESCRIPTION
## What changed
- Relaxed the deep-interview → ralplan PreToolUse gate for Autopilot state writes when durable handoff evidence already exists in `.omx/context`, `.omx/interviews`, or `.omx/specs`.
- Added a regression test that covers a standalone `omx state write --input-file ...` handoff after prior durable evidence exists.

## Why
The tmux session showed Autopilot asking for a manual `$ralplan` handoff because the hook only accepted the transition when the durable evidence and state write happened in the same Bash command. That was too strict for resumed/per-step handoffs.

## Impact
- Preserves the deep-interview gate for unsafe or unevidenced handoffs.
- Allows a valid resumed Autopilot handoff to proceed without forcing a manual re-entry into `ralplan`.
- Keeps implementation/source writes blocked.

## Validation
- `npm run build`
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js`
- `node dist/scripts/run-test-files.js dist/autopilot/__tests__/deep-interview-gate.test.js dist/state/__tests__/operations.test.js`
- `npx biome lint src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts`
