### PR TITLE
Fix ralplan terminal Stop cache loop

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -16368,6 +16368,79 @@ PY`,
     }
   });
 
+  it("clears stale ralplan Stop cache when authoritative state is terminal inactive", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralplan-terminal-cache-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-stop-ralplan-terminal-cache";
+      const threadId = "thread-stop-ralplan-terminal-cache";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, cwd });
+      await writeJson(join(stateDir, "skill-active-state.json"), {
+        active: false,
+        skill: "ralplan",
+        phase: "complete",
+        session_id: sessionId,
+        active_skills: [],
+      });
+      await writeJson(join(stateDir, "ralplan-state.json"), {
+        active: false,
+        mode: "ralplan",
+        current_phase: "complete",
+        status: "complete",
+        run_outcome: "complete",
+        session_id: sessionId,
+        cwd,
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: false,
+        skill: "ralplan",
+        phase: "complete",
+        session_id: sessionId,
+        active_skills: [],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "ralplan-state.json"), {
+        active: false,
+        mode: "ralplan",
+        current_phase: "complete",
+        status: "complete",
+        run_outcome: "complete",
+        session_id: sessionId,
+        cwd,
+      });
+      await writeJson(join(stateDir, "native-stop-state.json"), {
+        sessions: {
+          [sessionId]: {
+            last_signature: `skill-stop|${sessionId}|${threadId}|no-message|skill_ralplan_planning_continue_artifact`,
+            updated_at: "2026-07-04T00:00:00.000Z",
+          },
+          [threadId]: {
+            last_signature: `skill-stop|${sessionId}|${threadId}|no-message|skill_ralplan_planning_continue_artifact`,
+            updated_at: "2026-07-04T00:00:00.000Z",
+          },
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: sessionId,
+          thread_id: threadId,
+          stop_hook_active: true,
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+      const stopState = JSON.parse(await readFile(join(stateDir, "native-stop-state.json"), "utf-8")) as { sessions?: Record<string, unknown> };
+      assert.deepEqual(stopState.sessions, {});
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("keeps blocking current session ralplan when canonical root inactive ralplan state lacks project context", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralplan-canonical-root-no-cwd-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -8031,6 +8031,54 @@ function modeStateHasExplicitMatchingCwd(state: Record<string, unknown>, cwd: st
   }
 }
 
+async function clearNativeStopSessionEntries(
+  stateDir: string,
+  payload: CodexHookPayload,
+  canonicalSessionId?: string,
+): Promise<void> {
+  const statePath = join(stateDir, NATIVE_STOP_STATE_FILE);
+  const state = await readJsonIfExists(statePath);
+  if (!state) return;
+
+  const sessions = safeObject(state.sessions);
+  const keys = new Set(uniqueNonEmpty([
+    readNativeStopSessionKey(payload, canonicalSessionId),
+    canonicalSessionId,
+    readPayloadSessionId(payload),
+    readPayloadThreadId(payload),
+  ]));
+  let changed = false;
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(sessions, key)) {
+      delete sessions[key];
+      changed = true;
+    }
+  }
+  if (!changed) return;
+
+  await writeFile(statePath, JSON.stringify({ ...state, sessions }, null, 2));
+}
+
+async function hasAuthoritativeInactiveSkillStopState(
+  cwd: string,
+  stateDir: string,
+  skill: string,
+  sessionId: string,
+  threadId: string,
+): Promise<boolean> {
+  const sessionModeState = await readStopSessionPinnedState(`${skill}-state.json`, cwd, sessionId, stateDir);
+  if (!sessionModeState || !isTerminalOrInactiveModeState(sessionModeState)) return false;
+
+  const canonicalState = await readVisibleSkillActiveStateForStateDir(stateDir, sessionId);
+  if (canonicalState && !rootSkillStateHasNoActiveSkillForStopContext(canonicalState, skill, sessionId, threadId)) {
+    return false;
+  }
+
+  const rootModeState = await readJsonIfExists(join(stateDir, `${skill}-state.json`));
+  if (!rootModeState) return true;
+  if (!modeStateMatchesSkillStopContext(rootModeState, cwd, sessionId)) return true;
+  return isTerminalOrInactiveModeState(rootModeState);
+}
 async function readBlockingSkillForStop(
   cwd: string,
   stateDir: string,
@@ -8939,6 +8987,9 @@ async function buildStopHookOutput(
   const suppressParentWorkflowStop = shouldSuppressParentWorkflowStopForSideConversation(payload);
   if (canonicalSessionId) {
     await reconcileStaleRootSkillActiveStateForStop(cwd, stateDir, canonicalSessionId);
+    if (await hasAuthoritativeInactiveSkillStopState(cwd, stateDir, "ralplan", canonicalSessionId, threadId)) {
+      await clearNativeStopSessionEntries(stateDir, payload, canonicalSessionId);
+    }
   }
   if (suppressParentWorkflowStop) {
     return null;


### PR DESCRIPTION
## Summary
- Clear stale native Stop replay cache entries when ralplan has authoritative terminal/inactive state for the current session.
- Cover the regression with a Stop hook test that verifies cached session/thread signatures are removed and no continuation is emitted.

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js` (498 tests)
- `npm run check:no-unused`
- `npm run lint`

Closes #3057

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*