### PR TITLE
Add guarded Minimax workflow with tool-neutral review gates

### DIFF
--- a/plugins/oh-my-codex/skills/minimax/SKILL.md
+++ b/plugins/oh-my-codex/skills/minimax/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: minimax
+description: "[OMX] One-step-ahead adversarial oversight workflow. Use when the user explicitly asks for `$minimax` or a minimax workflow to run a proposer, lookahead reviewer, arbiter loop, with optional independent review escalation for risky diffs."
+---
+
+# Minimax
+
+Minimax is a guarded execution workflow for tasks that are clear enough to start but risky enough that each next move needs adversarial pressure. It runs a stateful loop: **MAX proposes or executes one bounded move, LOOKAHEAD predicts the next move, MIN reviews the transition, and ARBITER decides whether to continue, revise, block, escalate, or complete**.
+
+## Fit
+
+Use Minimax when:
+- The user wants autonomous progress with a one-step-ahead reviewer.
+- The task can drift in scope, public API shape, safety posture, or verification quality.
+- A local executor would move fast, but a conservative critic should guard each transition.
+- Independent review should run only on high-risk or disputed steps.
+
+Do not use Minimax for unclear requirements. Use `$deep-interview` first. Use `$ralplan` first when architecture, product tradeoffs, or acceptance criteria are not settled. Use `$team` when independent implementation lanes matter more than step-by-step oversight.
+
+## Roles
+
+- **MAX**: proposes the highest-value next action and executes only one bounded, reversible step at a time.
+- **LOOKAHEAD**: predicts the next likely move, expected evidence, and failure modes before the workflow commits to another step.
+- **MIN**: reviews the transition from current state to proposed next state. It tries to minimize damage: drift, unsafe changes, missing tests, hidden assumptions, and user-contract expansion.
+- **ARBITER**: makes the final step decision: `continue`, `revise`, `block`, `escalate`, or `complete`.
+- **COUNCIL**: optional high-cost independent review. Use an available review surface that can produce a durable, scoped artifact; do not bake any specific tool, vendor, or integration into Minimax.
+
+The same model context may perform multiple roles for small tasks, but keep the role outputs separate. For meaningful code changes, use role-specific native subagents when available: an implementer for MAX, a critic for MIN, and a verifier or reviewer for ARBITER/COUNCIL.
+
+## State packet
+
+Minimax is a native-hook stateful workflow. Prompt activation seeds `.omx/state/.../minimax-state.json`; bare `continue`, `resume`, or `keep going` resumes the active Minimax state for the current session.
+
+The mode state tracks the current step and completion gate:
+
+```json
+{
+  "active": true,
+  "mode": "minimax",
+  "current_phase": "planning",
+  "step": 1,
+  "packet_dir": ".omx/minimax",
+  "last_packet_path": null,
+  "lookahead_policy": {
+    "schema_version": "minimax-lookahead-policy-v1",
+    "depth": 2,
+    "branch_factor_by_risk": {
+      "low": 1,
+      "medium": 2,
+      "high": 3
+    },
+    "max_branches": 3,
+    "scoring": {
+      "value_weight": 1,
+      "evidence_weight": 1,
+      "reversibility_bonus": 2,
+      "risk_weight": 1,
+      "scope_expansion_weight": 1
+    },
+    "progressive_widening": {
+      "add_branch_when_min_rejects": true,
+      "add_branch_when_risk_high": true,
+      "add_branch_when_verification_weak": true,
+      "add_branch_when_public_contract_changes": true
+    }
+  },
+  "max_next_action": null,
+  "lookahead": null,
+  "min_verdict": "pending",
+  "arbiter_decision": "pending",
+  "last_arbiter_decision": null,
+  "arbiter_history": [],
+  "escalation_history": [],
+  "escalated": false,
+  "verification_evidence": [],
+  "verification_evidence_step": null,
+  "verification_evidence_path": null,
+  "council_evidence_step": null,
+  "completion_gate": {
+    "arbiter_decision_required": "complete",
+    "verification_evidence_required": true,
+    "fresh_verification_evidence_required": true,
+    "council_artifact_required_when_escalated": true
+  },
+  "state": {
+    "role_loop": ["MAX", "LOOKAHEAD", "MIN", "ARBITER"],
+    "council": {
+      "required": false,
+      "artifact_path": null,
+      "verdict": null
+    }
+  }
+}
+```
+
+Before each edit or external action, create a compact packet in the working notes or `.omx/minimax/step-<n>.md` when durable evidence is useful:
+
+```yaml
+step: <n>
+goal: <user-visible objective>
+current_state: <what is true now>
+max_next_action: <one bounded action>
+lookahead: <what this enables next>
+expected_evidence:
+  - <test/check/output that would prove the step>
+risk: low | medium | high
+reversible: true | false
+lookahead_policy:
+  depth: 2
+  branch_factor: 1 | 2 | 3
+branches:
+  - id: A
+    max_action: <candidate bounded action>
+    next_state: <expected state after that action>
+    value: 0-10
+    risk: 0-10
+    evidence_strength: 0-10
+    reversible: true | false
+    scope_expansion: 0-10
+    score: <value + evidence + reversibility bonus - risk - scope expansion>
+selected_branch: A
+min_verdict: pending | continue | revise | block | escalate
+arbiter_decision: pending | continue | revise | block | escalate | complete
+```
+
+Keep packets short. They are guardrails, not planning essays. If a packet is written to disk, update the same packet with MIN and ARBITER decisions before moving to the next step. Keep `minimax-state.json` in sync with the latest packet when the workflow will rely on continuation.
+
+## Bounded branched lookahead
+
+LOOKAHEAD may compare more than one candidate branch when risk justifies it:
+
+- low risk: 1 branch
+- medium risk: 2 branches
+- high risk, public API, security, compatibility, or irreversible work: 3 branches
+
+The default limit is depth 2 and max 3 branches. Use progressive widening only when MIN rejects a branch, risk is high, verification is weak, or the branch changes a public contract. Score branches with the simple policy in the packet: higher user value and stronger evidence help; higher risk and scope expansion hurt; reversible actions get a small bonus. Branch metrics are interpreted on the documented 0-10 range. The scoring weights and progressive widening flags are fixed workflow defaults, not caller configuration knobs.
+
+Select one branch before MAX executes. Do not grow a tree, spawn a team, or convert Minimax into `$ralplan`. If more than three branches or deeper planning seems needed, hand off to `$ralplan` or `$team`.
+
+## Loop
+
+1. **Frame the objective**
+   - Restate the target result, constraints, validation evidence, and stop condition.
+   - If the request is underspecified, hand off to `$deep-interview` or `$ralplan` instead of inventing scope.
+
+2. **MAX step**
+   - Select one bounded next action.
+   - Prefer reversible local edits, targeted tests, and existing repo patterns.
+   - Do not batch unrelated changes to sneak past MIN.
+
+3. **LOOKAHEAD step**
+   - Predict the likely next action after MAX succeeds.
+   - For medium or high risk, compare the bounded branch set from `lookahead_policy` and choose one `selected_branch`.
+   - Name the evidence that should exist before continuing.
+   - Name one plausible failure mode or drift vector.
+
+4. **MIN review**
+   - Compare original intent, current evidence, MAX action, and LOOKAHEAD proposal.
+   - Reject transitions that widen public contracts, skip tests, hide failed evidence, use unsafe automation casually, or create irreversible work without authority.
+   - Prefer minimal repair instructions over broad criticism.
+
+5. **ARBITER decision**
+   - `continue`: MAX may execute the bounded step.
+   - `revise`: MAX must adjust the step before execution.
+   - `block`: stop and report the blocker.
+   - `escalate`: run COUNCIL before changing or submitting.
+   - `complete`: no pending work remains and verification evidence is fresh.
+
+   Store the decision in `arbiter_decision`. Do not mark `complete` until `verification_evidence_path` points to a passing `minimax-verification-v1` JSON artifact for the current `step`, `verification_evidence` summarizes the checks or artifacts that prove the final claim, and `verification_evidence_step` is at least the current `step`. If ARBITER chooses `escalate`, set the sticky `escalated: true`, append `escalate` to `arbiter_history`, and set `state.council.required: true` or `last_arbiter_decision: "escalate"`. Do not clear `escalated` after later `continue` or `revise` steps; a prior escalation keeps the council gate active until a passing council artifact is recorded.
+
+6. **Execute and verify**
+   - Execute only the accepted step.
+   - Run the smallest validation that proves the claim.
+   - Feed the result into the next packet.
+   - Increment `step` after a completed bounded move.
+
+## Continuation and completion
+
+On `continue`, resume from `.omx/state/.../minimax-state.json` instead of starting over. Read the latest `step`, `last_packet_path`, `min_verdict`, `arbiter_decision`, and `verification_evidence` before choosing the next MAX action.
+
+Completion is gated. These gates are invariants; persisted state cannot weaken them. The workflow should remain active if the assistant says it is done but the state lacks:
+- `arbiter_decision: "complete"`
+- non-empty `verification_evidence`
+- a passing JSON `verification_evidence_path` artifact with `schema_version: "minimax-verification-v1"`, `step` at or after the current `step`, and `status: "passed"` or `passed: true`
+- `verification_evidence_step` at or after the current `step`
+- a passing JSON `state.council.artifact_path` or `council_artifact_path` when council review was required or escalation history exists
+- `council_evidence_step` at or after the current `step` when council review is required
+
+For public API, security, package-export, or compatibility-contract changes, require a durable independent-review artifact before final completion unless no review surface is available and the fallback is recorded. The artifact must name the review scope, inputs, reviewer surface, verdict, blocker count, degraded/partial-coverage status, and source evidence. Do not rely on a single prose note, scalar verdict, or assistant-authored summary without underlying review artifacts.
+
+Minimal review artifact shape:
+
+```json
+{
+  "schema_version": "minimax-independent-review-v1",
+  "reviewer_surface": "<independent reviewer or review workflow>",
+  "scope": "<what was reviewed>",
+  "inputs": ["<file/range/log/artifact>"],
+  "verdict": {"status": "pass|no_blockers|block|uncertain", "rationale": "..."},
+  "blockers": [],
+  "blocker_count": 0,
+  "degraded": false
+}
+```
+
+## Council escalation
+
+Escalate when any condition is true:
+- Public API, package exports, security, auth, sandboxing, secrets, data migration, destructive operations, or external production effects are involved.
+- MIN and MAX disagree on safety or scope.
+- A diff is large enough that local review is likely to miss interactions.
+- The step would become user-facing documentation or compatibility contract.
+- Verification is inconclusive but the workflow would otherwise continue.
+
+When an independent review is required, use the narrowest available review surface that can inspect the relevant evidence and write a durable artifact. Include only files, ranges, logs, and context needed for the claim. Treat review findings as claims to verify, not as automatic truth. If no independent review surface is available, record that limitation and use the strongest local verification you can run.
+
+## Stop rules
+
+Stop when:
+- ARBITER marks `complete` with fresh verification evidence.
+- ARBITER marks `block` and no safe local repair remains.
+- The next step needs destructive, irreversible, credential-gated, external-production, or materially scope-changing authority that the user has not granted.
+- The workflow has repeated the same `revise` or `block` condition twice; switch to `$ralplan` for redesign.
+
+## Output shape
+
+For progress updates, keep it short:
+
+```text
+Minimax: step <n>
+MAX: <accepted action/result>
+MIN: <main risk or pass reason>
+ARBITER: <continue|revise|block|escalate|complete>
+Evidence: <test/check/artifact>
+```
+
+For the final response, report changed files, verification evidence, council/reviewer outcome when used, and remaining risks.

--- a/skills/minimax/SKILL.md
+++ b/skills/minimax/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: minimax
+description: "[OMX] One-step-ahead adversarial oversight workflow. Use when the user explicitly asks for `$minimax` or a minimax workflow to run a proposer, lookahead reviewer, arbiter loop, with optional independent review escalation for risky diffs."
+---
+
+# Minimax
+
+Minimax is a guarded execution workflow for tasks that are clear enough to start but risky enough that each next move needs adversarial pressure. It runs a stateful loop: **MAX proposes or executes one bounded move, LOOKAHEAD predicts the next move, MIN reviews the transition, and ARBITER decides whether to continue, revise, block, escalate, or complete**.
+
+## Fit
+
+Use Minimax when:
+- The user wants autonomous progress with a one-step-ahead reviewer.
+- The task can drift in scope, public API shape, safety posture, or verification quality.
+- A local executor would move fast, but a conservative critic should guard each transition.
+- Independent review should run only on high-risk or disputed steps.
+
+Do not use Minimax for unclear requirements. Use `$deep-interview` first. Use `$ralplan` first when architecture, product tradeoffs, or acceptance criteria are not settled. Use `$team` when independent implementation lanes matter more than step-by-step oversight.
+
+## Roles
+
+- **MAX**: proposes the highest-value next action and executes only one bounded, reversible step at a time.
+- **LOOKAHEAD**: predicts the next likely move, expected evidence, and failure modes before the workflow commits to another step.
+- **MIN**: reviews the transition from current state to proposed next state. It tries to minimize damage: drift, unsafe changes, missing tests, hidden assumptions, and user-contract expansion.
+- **ARBITER**: makes the final step decision: `continue`, `revise`, `block`, `escalate`, or `complete`.
+- **COUNCIL**: optional high-cost independent review. Use an available review surface that can produce a durable, scoped artifact; do not bake any specific tool, vendor, or integration into Minimax.
+
+The same model context may perform multiple roles for small tasks, but keep the role outputs separate. For meaningful code changes, use role-specific native subagents when available: an implementer for MAX, a critic for MIN, and a verifier or reviewer for ARBITER/COUNCIL.
+
+## State packet
+
+Minimax is a native-hook stateful workflow. Prompt activation seeds `.omx/state/.../minimax-state.json`; bare `continue`, `resume`, or `keep going` resumes the active Minimax state for the current session.
+
+The mode state tracks the current step and completion gate:
+
+```json
+{
+  "active": true,
+  "mode": "minimax",
+  "current_phase": "planning",
+  "step": 1,
+  "packet_dir": ".omx/minimax",
+  "last_packet_path": null,
+  "lookahead_policy": {
+    "schema_version": "minimax-lookahead-policy-v1",
+    "depth": 2,
+    "branch_factor_by_risk": {
+      "low": 1,
+      "medium": 2,
+      "high": 3
+    },
+    "max_branches": 3,
+    "scoring": {
+      "value_weight": 1,
+      "evidence_weight": 1,
+      "reversibility_bonus": 2,
+      "risk_weight": 1,
+      "scope_expansion_weight": 1
+    },
+    "progressive_widening": {
+      "add_branch_when_min_rejects": true,
+      "add_branch_when_risk_high": true,
+      "add_branch_when_verification_weak": true,
+      "add_branch_when_public_contract_changes": true
+    }
+  },
+  "max_next_action": null,
+  "lookahead": null,
+  "min_verdict": "pending",
+  "arbiter_decision": "pending",
+  "last_arbiter_decision": null,
+  "arbiter_history": [],
+  "escalation_history": [],
+  "escalated": false,
+  "verification_evidence": [],
+  "verification_evidence_step": null,
+  "verification_evidence_path": null,
+  "council_evidence_step": null,
+  "completion_gate": {
+    "arbiter_decision_required": "complete",
+    "verification_evidence_required": true,
+    "fresh_verification_evidence_required": true,
+    "council_artifact_required_when_escalated": true
+  },
+  "state": {
+    "role_loop": ["MAX", "LOOKAHEAD", "MIN", "ARBITER"],
+    "council": {
+      "required": false,
+      "artifact_path": null,
+      "verdict": null
+    }
+  }
+}
+```
+
+Before each edit or external action, create a compact packet in the working notes or `.omx/minimax/step-<n>.md` when durable evidence is useful:
+
+```yaml
+step: <n>
+goal: <user-visible objective>
+current_state: <what is true now>
+max_next_action: <one bounded action>
+lookahead: <what this enables next>
+expected_evidence:
+  - <test/check/output that would prove the step>
+risk: low | medium | high
+reversible: true | false
+lookahead_policy:
+  depth: 2
+  branch_factor: 1 | 2 | 3
+branches:
+  - id: A
+    max_action: <candidate bounded action>
+    next_state: <expected state after that action>
+    value: 0-10
+    risk: 0-10
+    evidence_strength: 0-10
+    reversible: true | false
+    scope_expansion: 0-10
+    score: <value + evidence + reversibility bonus - risk - scope expansion>
+selected_branch: A
+min_verdict: pending | continue | revise | block | escalate
+arbiter_decision: pending | continue | revise | block | escalate | complete
+```
+
+Keep packets short. They are guardrails, not planning essays. If a packet is written to disk, update the same packet with MIN and ARBITER decisions before moving to the next step. Keep `minimax-state.json` in sync with the latest packet when the workflow will rely on continuation.
+
+## Bounded branched lookahead
+
+LOOKAHEAD may compare more than one candidate branch when risk justifies it:
+
+- low risk: 1 branch
+- medium risk: 2 branches
+- high risk, public API, security, compatibility, or irreversible work: 3 branches
+
+The default limit is depth 2 and max 3 branches. Use progressive widening only when MIN rejects a branch, risk is high, verification is weak, or the branch changes a public contract. Score branches with the simple policy in the packet: higher user value and stronger evidence help; higher risk and scope expansion hurt; reversible actions get a small bonus. Branch metrics are interpreted on the documented 0-10 range. The scoring weights and progressive widening flags are fixed workflow defaults, not caller configuration knobs.
+
+Select one branch before MAX executes. Do not grow a tree, spawn a team, or convert Minimax into `$ralplan`. If more than three branches or deeper planning seems needed, hand off to `$ralplan` or `$team`.
+
+## Loop
+
+1. **Frame the objective**
+   - Restate the target result, constraints, validation evidence, and stop condition.
+   - If the request is underspecified, hand off to `$deep-interview` or `$ralplan` instead of inventing scope.
+
+2. **MAX step**
+   - Select one bounded next action.
+   - Prefer reversible local edits, targeted tests, and existing repo patterns.
+   - Do not batch unrelated changes to sneak past MIN.
+
+3. **LOOKAHEAD step**
+   - Predict the likely next action after MAX succeeds.
+   - For medium or high risk, compare the bounded branch set from `lookahead_policy` and choose one `selected_branch`.
+   - Name the evidence that should exist before continuing.
+   - Name one plausible failure mode or drift vector.
+
+4. **MIN review**
+   - Compare original intent, current evidence, MAX action, and LOOKAHEAD proposal.
+   - Reject transitions that widen public contracts, skip tests, hide failed evidence, use unsafe automation casually, or create irreversible work without authority.
+   - Prefer minimal repair instructions over broad criticism.
+
+5. **ARBITER decision**
+   - `continue`: MAX may execute the bounded step.
+   - `revise`: MAX must adjust the step before execution.
+   - `block`: stop and report the blocker.
+   - `escalate`: run COUNCIL before changing or submitting.
+   - `complete`: no pending work remains and verification evidence is fresh.
+
+   Store the decision in `arbiter_decision`. Do not mark `complete` until `verification_evidence_path` points to a passing `minimax-verification-v1` JSON artifact for the current `step`, `verification_evidence` summarizes the checks or artifacts that prove the final claim, and `verification_evidence_step` is at least the current `step`. If ARBITER chooses `escalate`, set the sticky `escalated: true`, append `escalate` to `arbiter_history`, and set `state.council.required: true` or `last_arbiter_decision: "escalate"`. Do not clear `escalated` after later `continue` or `revise` steps; a prior escalation keeps the council gate active until a passing council artifact is recorded.
+
+6. **Execute and verify**
+   - Execute only the accepted step.
+   - Run the smallest validation that proves the claim.
+   - Feed the result into the next packet.
+   - Increment `step` after a completed bounded move.
+
+## Continuation and completion
+
+On `continue`, resume from `.omx/state/.../minimax-state.json` instead of starting over. Read the latest `step`, `last_packet_path`, `min_verdict`, `arbiter_decision`, and `verification_evidence` before choosing the next MAX action.
+
+Completion is gated. These gates are invariants; persisted state cannot weaken them. The workflow should remain active if the assistant says it is done but the state lacks:
+- `arbiter_decision: "complete"`
+- non-empty `verification_evidence`
+- a passing JSON `verification_evidence_path` artifact with `schema_version: "minimax-verification-v1"`, `step` at or after the current `step`, and `status: "passed"` or `passed: true`
+- `verification_evidence_step` at or after the current `step`
+- a passing JSON `state.council.artifact_path` or `council_artifact_path` when council review was required or escalation history exists
+- `council_evidence_step` at or after the current `step` when council review is required
+
+For public API, security, package-export, or compatibility-contract changes, require a durable independent-review artifact before final completion unless no review surface is available and the fallback is recorded. The artifact must name the review scope, inputs, reviewer surface, verdict, blocker count, degraded/partial-coverage status, and source evidence. Do not rely on a single prose note, scalar verdict, or assistant-authored summary without underlying review artifacts.
+
+Minimal review artifact shape:
+
+```json
+{
+  "schema_version": "minimax-independent-review-v1",
+  "reviewer_surface": "<independent reviewer or review workflow>",
+  "scope": "<what was reviewed>",
+  "inputs": ["<file/range/log/artifact>"],
+  "verdict": {"status": "pass|no_blockers|block|uncertain", "rationale": "..."},
+  "blockers": [],
+  "blocker_count": 0,
+  "degraded": false
+}
+```
+
+## Council escalation
+
+Escalate when any condition is true:
+- Public API, package exports, security, auth, sandboxing, secrets, data migration, destructive operations, or external production effects are involved.
+- MIN and MAX disagree on safety or scope.
+- A diff is large enough that local review is likely to miss interactions.
+- The step would become user-facing documentation or compatibility contract.
+- Verification is inconclusive but the workflow would otherwise continue.
+
+When an independent review is required, use the narrowest available review surface that can inspect the relevant evidence and write a durable artifact. Include only files, ranges, logs, and context needed for the claim. Treat review findings as claims to verify, not as automatic truth. If no independent review surface is available, record that limitation and use the strongest local verification you can run.
+
+## Stop rules
+
+Stop when:
+- ARBITER marks `complete` with fresh verification evidence.
+- ARBITER marks `block` and no safe local repair remains.
+- The next step needs destructive, irreversible, credential-gated, external-production, or materially scope-changing authority that the user has not granted.
+- The workflow has repeated the same `revise` or `block` condition twice; switch to `$ralplan` for redesign.
+
+## Output shape
+
+For progress updates, keep it short:
+
+```text
+Minimax: step <n>
+MAX: <accepted action/result>
+MIN: <main risk or pass reason>
+ARBITER: <continue|revise|block|escalate|complete>
+Evidence: <test/check/artifact>
+```
+
+For the final response, report changed files, verification evidence, council/reviewer outcome when used, and remaining risks.

--- a/src/catalog/__tests__/schema.test.ts
+++ b/src/catalog/__tests__/schema.test.ts
@@ -104,4 +104,13 @@ describe('catalog schema', () => {
     assert.equal(ultragoal?.status, 'active');
     assert.equal(ultragoal?.core, true);
   });
+
+  it('includes minimax as an active guarded execution workflow skill', () => {
+    const parsed = validateCatalogManifest(readSourceManifest());
+    const minimax = parsed.skills.find((skill) => skill.name === 'minimax');
+
+    assert.equal(minimax?.category, 'execution');
+    assert.equal(minimax?.status, 'active');
+    assert.equal(minimax?.core, false);
+  });
 });

--- a/src/catalog/generated/public-catalog.json
+++ b/src/catalog/generated/public-catalog.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-06-17T05:57:55.659Z",
+  "generatedAt": "2026-06-24T13:46:05.682Z",
   "version": "2026.02.28.1",
   "counts": {
-    "skillCount": 50,
+    "skillCount": 51,
     "promptCount": 34,
-    "activeSkillCount": 28,
+    "activeSkillCount": 29,
     "activeAgentCount": 20
   },
   "coreSkills": [
@@ -81,6 +81,13 @@
     },
     {
       "name": "pipeline",
+      "category": "execution",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
+      "name": "minimax",
       "category": "execution",
       "status": "active",
       "core": false,

--- a/src/catalog/manifest.json
+++ b/src/catalog/manifest.json
@@ -61,6 +61,12 @@
       "core": false
     },
     {
+      "name": "minimax",
+      "category": "execution",
+      "status": "active",
+      "core": false
+    },
+    {
       "name": "ultragoal",
       "category": "execution",
       "status": "active",

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -230,6 +230,23 @@ describe('keyword detector team compatibility', () => {
     assert.equal(match.keyword.toLowerCase(), '$ultragoal');
   });
 
+
+  it('maps minimax workflow invocations to the minimax skill', () => {
+    const explicit = detectPrimaryKeyword('$minimax harden this public API change');
+    assert.ok(explicit);
+    assert.equal(explicit.skill, 'minimax');
+    assert.equal(explicit.keyword.toLowerCase(), '$minimax');
+
+    const prose = detectPrimaryKeyword('run the minimax workflow on this risky refactor');
+    assert.ok(prose);
+    assert.equal(prose.skill, 'minimax');
+
+    assert.equal(detectPrimaryKeyword('explain the minimax algorithm for chess'), null);
+    assert.equal(detectPrimaryKeyword('compare alpha-beta pruning with minimax search'), null);
+    assert.equal(detectPrimaryKeyword('run the minimax algorithm on this tree'), null);
+    assert.equal(detectPrimaryKeyword('explain the minimax workflow design tradeoffs'), null);
+  });
+
   it('maps explicit $best-practice-research invocation to the best-practice research wrapper', () => {
     const match = detectPrimaryKeyword('$best-practice-research find current official guidance for this API');
     assert.ok(match);
@@ -555,6 +572,8 @@ describe('keyword registry coverage', () => {
     assert.ok(registryKeywords.has('wiki lint'));
     assert.ok(registryKeywords.has('$autoresearch'));
     assert.ok(registryKeywords.has('$ultragoal'));
+    assert.ok(registryKeywords.has('$minimax'));
+    assert.ok(registryKeywords.has('minimax workflow'));
     assert.ok(registryKeywords.has('$prometheus-strict'));
     assert.ok(registryKeywords.has('ultragoal'));
     assert.ok(registryKeywords.has('autopilot'));
@@ -1764,6 +1783,212 @@ describe('keyword detector skill-active-state lifecycle', () => {
     }
   });
 
+  it('seeds durable minimax state for prompt-submit activation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-minimax-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$minimax harden this public API change in src/sdk/client.ts',
+        sessionId: 'sess-minimax',
+        nowIso: '2026-04-18T00:00:00.000Z',
+      });
+
+      assert.ok(result);
+      assert.equal(result.skill, 'minimax');
+      assert.equal(result.phase, 'planning');
+      assert.equal(result.initialized_mode, 'minimax');
+      assert.equal(result.initialized_state_path, '.omx/state/sessions/sess-minimax/minimax-state.json');
+
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', 'sess-minimax', 'minimax-state.json'), 'utf-8'),
+      ) as {
+        mode: string;
+        active: boolean;
+        current_phase: string;
+        step: number;
+        packet_dir: string;
+        min_verdict: string;
+        arbiter_decision: string;
+        verification_evidence_step?: number | null;
+        verification_evidence_path?: string | null;
+        council_evidence_step?: number | null;
+        escalated?: boolean;
+        lookahead_policy?: {
+          schema_version?: string;
+          depth?: number;
+          max_branches?: number;
+          branch_factor_by_risk?: { low?: number; medium?: number; high?: number };
+          progressive_widening?: Record<string, boolean>;
+        };
+        completion_gate?: { verification_evidence_required?: boolean };
+        state?: { role_loop?: string[]; council?: { required?: boolean; artifact_path?: string | null; verdict?: string | null } };
+      };
+      assert.equal(modeState.mode, 'minimax');
+      assert.equal(modeState.active, true);
+      assert.equal(modeState.current_phase, 'planning');
+      assert.equal(modeState.step, 1);
+      assert.equal(modeState.packet_dir, '.omx/minimax');
+      assert.equal(modeState.min_verdict, 'pending');
+      assert.equal(modeState.arbiter_decision, 'pending');
+      assert.equal(modeState.verification_evidence_step, null);
+      assert.equal(modeState.verification_evidence_path, null);
+      assert.equal(modeState.council_evidence_step, null);
+      assert.equal(modeState.escalated, false);
+      assert.equal(modeState.lookahead_policy?.schema_version, 'minimax-lookahead-policy-v1');
+      assert.equal(modeState.lookahead_policy?.depth, 2);
+      assert.equal(modeState.lookahead_policy?.max_branches, 3);
+      assert.equal(modeState.lookahead_policy?.branch_factor_by_risk?.low, 1);
+      assert.equal(modeState.lookahead_policy?.branch_factor_by_risk?.medium, 2);
+      assert.equal(modeState.lookahead_policy?.branch_factor_by_risk?.high, 3);
+      assert.equal(modeState.lookahead_policy?.progressive_widening?.add_branch_when_min_rejects, true);
+      assert.equal(modeState.completion_gate?.verification_evidence_required, true);
+      assert.deepEqual(modeState.state?.role_loop, ['MAX', 'LOOKAHEAD', 'MIN', 'ARBITER']);
+      assert.equal(modeState.state?.council?.required, false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('routes bare continuation to active minimax and preserves existing step state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-minimax-continuation-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-minimax-continuation';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'minimax',
+        keyword: '$minimax',
+        phase: 'executing',
+        activated_at: '2026-04-18T00:00:00.000Z',
+        updated_at: '2026-04-18T00:00:00.000Z',
+        source: 'keyword-detector',
+        session_id: sessionId,
+        active_skills: [{ skill: 'minimax', active: true, phase: 'executing', session_id: sessionId }],
+      }, null, 2));
+      await writeFile(join(stateDir, 'sessions', sessionId, 'minimax-state.json'), JSON.stringify({
+        active: true,
+        mode: 'minimax',
+        current_phase: 'reviewing',
+        started_at: '2026-04-18T00:00:00.000Z',
+        updated_at: '2026-04-18T00:00:00.000Z',
+        session_id: sessionId,
+        step: 3,
+        packet_dir: '.omx/minimax',
+        min_verdict: 'revise',
+        arbiter_decision: 'revise',
+        escalated: true,
+        lookahead_policy: {
+          schema_version: 'minimax-lookahead-policy-v1',
+          depth: 2,
+          branch_factor_by_risk: { low: 1, medium: 1, high: 2 },
+          max_branches: 3,
+        },
+        verification_evidence: ['node --test dist/hooks/__tests__/minimax-skill-contract.test.js'],
+      }, null, 2));
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: 'continue',
+        sessionId,
+        nowIso: '2026-04-18T00:05:00.000Z',
+      });
+
+      assert.equal(result?.skill, 'minimax');
+      assert.equal(result?.keyword, '$minimax');
+      assert.equal(result?.initialized_mode, 'minimax');
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, 'minimax-state.json'), 'utf-8'),
+      ) as {
+        current_phase?: string;
+        step?: number;
+        started_at?: string;
+        min_verdict?: string;
+        arbiter_decision?: string;
+        escalated?: boolean;
+        lookahead_policy?: { branch_factor_by_risk?: { medium?: number } };
+      };
+      assert.equal(modeState.current_phase, 'reviewing');
+      assert.equal(modeState.step, 3);
+      assert.equal(modeState.started_at, '2026-04-18T00:00:00.000Z');
+      assert.equal(modeState.min_verdict, 'revise');
+      assert.equal(modeState.arbiter_decision, 'revise');
+      assert.equal(modeState.escalated, true);
+      assert.equal(modeState.lookahead_policy?.branch_factor_by_risk?.medium, 1);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('resets minimax progress on a fresh explicit minimax activation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-state-minimax-reactivation-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    const sessionId = 'sess-minimax-reactivation';
+    try {
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(join(stateDir, 'sessions', sessionId, SKILL_ACTIVE_STATE_FILE), JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'minimax',
+        keyword: '$minimax',
+        phase: 'executing',
+        activated_at: '2026-04-18T00:00:00.000Z',
+        updated_at: '2026-04-18T00:00:00.000Z',
+        source: 'keyword-detector',
+        session_id: sessionId,
+        active_skills: [{ skill: 'minimax', active: true, phase: 'executing', session_id: sessionId }],
+      }, null, 2));
+      await writeFile(join(stateDir, 'sessions', sessionId, 'minimax-state.json'), JSON.stringify({
+        active: true,
+        mode: 'minimax',
+        current_phase: 'reviewing',
+        started_at: '2026-04-18T00:00:00.000Z',
+        updated_at: '2026-04-18T00:00:00.000Z',
+        session_id: sessionId,
+        step: 7,
+        min_verdict: 'escalate',
+        arbiter_decision: 'complete',
+        escalated: true,
+        verification_evidence: ['old evidence'],
+        verification_evidence_step: 7,
+      }, null, 2));
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$minimax review this different workflow contract change in src/minimax/lookahead.ts',
+        sessionId,
+        nowIso: '2026-04-18T00:10:00.000Z',
+      });
+
+      assert.equal(result?.skill, 'minimax');
+      const modeState = JSON.parse(
+        await readFile(join(stateDir, 'sessions', sessionId, 'minimax-state.json'), 'utf-8'),
+      ) as {
+        current_phase?: string;
+        step?: number;
+        started_at?: string;
+        min_verdict?: string;
+        arbiter_decision?: string;
+        escalated?: boolean;
+        verification_evidence?: string[];
+        verification_evidence_step?: number | null;
+      };
+      assert.equal(modeState.current_phase, 'planning');
+      assert.equal(modeState.step, 1);
+      assert.equal(modeState.started_at, '2026-04-18T00:10:00.000Z');
+      assert.equal(modeState.min_verdict, 'pending');
+      assert.equal(modeState.arbiter_decision, 'pending');
+      assert.equal(modeState.escalated, false);
+      assert.deepEqual(modeState.verification_evidence, []);
+      assert.equal(modeState.verification_evidence_step, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('preserves the planning skill when ralplan and autoresearch are invoked together', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-autoresearch-planning-precedence-'));
     const stateDir = join(cwd, '.omx', 'state');
@@ -1783,6 +2008,30 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.deepEqual(result?.deferred_skills, ['autoresearch']);
       assert.equal(existsSync(join(stateDir, 'sessions', 'sess-autoresearch-precedence', 'ralplan-state.json')), true);
       assert.equal(existsSync(join(stateDir, 'sessions', 'sess-autoresearch-precedence', 'autoresearch-state.json')), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves the planning skill when ralplan and minimax are invoked together', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-keyword-minimax-planning-precedence-'));
+    const stateDir = join(cwd, '.omx', 'state');
+    try {
+      await mkdir(stateDir, { recursive: true });
+
+      const result = await recordSkillActivation({
+        stateDir,
+        text: '$ralplan $minimax design a guarded public API migration',
+        sessionId: 'sess-minimax-precedence',
+        nowIso: '2026-04-18T00:10:00.000Z',
+      });
+
+      assert.equal(result?.transition_error, undefined);
+      assert.equal(result?.skill, 'ralplan');
+      assert.deepEqual(result?.active_skills?.map((entry) => entry.skill), ['ralplan']);
+      assert.deepEqual(result?.deferred_skills, ['minimax']);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-minimax-precedence', 'ralplan-state.json')), true);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-minimax-precedence', 'minimax-state.json')), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -4409,6 +4658,13 @@ describe('applyRalplanGate', () => {
     const result = applyRalplanGate(['autopilot'], 'autopilot build the app');
     assert.equal(result.gateApplied, true);
     assert.ok(result.keywords.includes('ralplan'));
+  });
+
+  it('redirects minimax to ralplan when underspecified', () => {
+    const result = applyRalplanGate(['minimax'], 'minimax harden this');
+    assert.equal(result.gateApplied, true);
+    assert.ok(result.keywords.includes('ralplan'));
+    assert.ok(!result.keywords.includes('minimax'));
   });
 
   it('does not gate well-specified prompts', () => {

--- a/src/hooks/__tests__/minimax-skill-contract.test.ts
+++ b/src/hooks/__tests__/minimax-skill-contract.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const skill = readFileSync(join(process.cwd(), 'skills/minimax/SKILL.md'), 'utf-8');
+const pluginSkill = readFileSync(join(process.cwd(), 'plugins/oh-my-codex/skills/minimax/SKILL.md'), 'utf-8');
+
+describe('minimax skill contract', () => {
+  it('defines the core role loop and decisions', () => {
+    assert.match(skill, /MAX/);
+    assert.match(skill, /LOOKAHEAD/);
+    assert.match(skill, /MIN/);
+    assert.match(skill, /ARBITER/);
+    assert.match(skill, /continue.*revise.*block.*escalate.*complete/s);
+  });
+
+  it('keeps council escalation optional, evidence-based, and tool-neutral', () => {
+    assert.match(skill, /independent review/);
+    assert.match(skill, /durable, scoped artifact/);
+    assert.match(skill, /Treat review findings as claims to verify/);
+    const bannedSpecificCouncil = new RegExp(['file', 'council'].join('[- ]'));
+    const bannedSpecificReviewer = new RegExp(['code', 'review'].join('-'));
+    assert.doesNotMatch(skill, bannedSpecificCouncil);
+    assert.doesNotMatch(skill, bannedSpecificReviewer);
+    assert.doesNotMatch(skill, /--feel-the-agi/);
+  });
+
+  it('requires bounded state packets and fresh verification evidence', () => {
+    assert.match(skill, /.omx\/state\/\.\.\.\/minimax-state\.json/);
+    assert.match(skill, /.omx\/minimax\/step-<n>\.md/);
+    assert.match(skill, /expected_evidence/);
+    assert.match(skill, /arbiter_decision/);
+    assert.match(skill, /verification_evidence/);
+    assert.match(skill, /verification_evidence_step/);
+    assert.match(skill, /fresh verification evidence/);
+    assert.match(skill, /update the same packet with MIN and ARBITER decisions/);
+  });
+
+  it('documents continuation and completion gates', () => {
+    assert.match(skill, /bare `continue`, `resume`, or `keep going` resumes/);
+    assert.match(skill, /Completion is gated/);
+    assert.match(skill, /state\.council\.artifact_path/);
+  });
+
+  it('keeps branched lookahead bounded and scored', () => {
+    assert.match(skill, /Bounded branched lookahead/);
+    assert.match(skill, /low risk: 1 branch/);
+    assert.match(skill, /medium risk: 2 branches/);
+    assert.match(skill, /high risk.*3 branches/);
+    assert.match(skill, /depth 2 and max 3 branches/);
+    assert.match(skill, /progressive widening/);
+    assert.match(skill, /Score branches/);
+    assert.match(skill, /"scoring"/);
+    assert.match(skill, /"progressive_widening"/);
+    assert.match(skill, /0-10 range/);
+    assert.match(skill, /fixed workflow defaults/);
+    assert.match(skill, /Do not grow a tree, spawn a team, or convert Minimax into `\$ralplan`/);
+  });
+
+  it('keeps the plugin mirror in sync with the canonical skill', () => {
+    assert.equal(pluginSkill, skill);
+  });
+});

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -6,6 +6,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { buildTmuxSessionName } from '../../cli/index.js';
+import { syncSkillStateFromTurn } from '../../scripts/notify-hook/auto-nudge.js';
 
 const NOTIFY_HOOK_SCRIPT = new URL('../../../dist/scripts/notify-hook.js', import.meta.url);
 const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead', 'next i should'];
@@ -2903,6 +2904,208 @@ exit 0
     });
   });
 
+  it('keeps minimax active when assistant claims completion without arbiter evidence', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: false, delaySec: 0, stallMs: 0 },
+      });
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeJson(join(sessionStateDir, 'skill-active-state.json'), {
+        active: true,
+        skill: 'minimax',
+        keyword: '$minimax',
+        phase: 'reviewing',
+        source: 'keyword-detector',
+        session_id: 'sess-managed',
+      });
+      await writeJson(join(sessionStateDir, 'minimax-state.json'), {
+        active: true,
+        mode: 'minimax',
+        current_phase: 'reviewing',
+        session_id: 'sess-managed',
+        step: 2,
+        arbiter_decision: 'continue',
+        verification_evidence: [],
+      });
+
+      await syncSkillStateFromTurn(stateDir, {
+        cwd,
+        'session-id': 'sess-managed',
+        'last-assistant-message': 'Completed with final summary.',
+      });
+
+      const skillState = JSON.parse(await readFile(join(sessionStateDir, 'skill-active-state.json'), 'utf-8')) as {
+        active: boolean;
+        phase: string;
+        minimax_completion_reason?: string;
+        arbiter_decision?: string;
+      };
+      assert.equal(skillState.active, true);
+      assert.equal(skillState.phase, 'reviewing');
+      assert.equal(skillState.arbiter_decision, 'continue');
+      assert.equal(skillState.minimax_completion_reason, 'arbiter_not_complete');
+    });
+  });
+
+  it('completes minimax when arbiter decision has verification evidence', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const minimaxDir = join(cwd, '.omx', 'minimax');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await mkdir(minimaxDir, { recursive: true });
+      await writeJson(join(minimaxDir, 'verification-step-4.json'), {
+        schema_version: 'minimax-verification-v1',
+        step: 4,
+        status: 'passed',
+        passed: true,
+      });
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: false, delaySec: 0, stallMs: 0 },
+      });
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeJson(join(sessionStateDir, 'skill-active-state.json'), {
+        active: true,
+        skill: 'minimax',
+        keyword: '$minimax',
+        phase: 'reviewing',
+        source: 'keyword-detector',
+        session_id: 'sess-managed',
+      });
+      await writeJson(join(sessionStateDir, 'minimax-state.json'), {
+        active: true,
+        mode: 'minimax',
+        current_phase: 'reviewing',
+        session_id: 'sess-managed',
+        step: 4,
+        arbiter_decision: 'complete',
+        verification_evidence: ['npm run build', 'targeted minimax tests passed'],
+        verification_evidence_step: 4,
+        verification_evidence_path: '.omx/minimax/verification-step-4.json',
+      });
+
+      await syncSkillStateFromTurn(stateDir, {
+        cwd,
+        'session-id': 'sess-managed',
+        'last-assistant-message': 'Completed with final summary.',
+      });
+
+      const skillState = JSON.parse(await readFile(join(sessionStateDir, 'skill-active-state.json'), 'utf-8')) as {
+        active: boolean;
+        phase: string;
+        minimax_completion_reason?: string;
+        arbiter_decision?: string;
+      };
+      const modeState = JSON.parse(await readFile(join(sessionStateDir, 'minimax-state.json'), 'utf-8')) as {
+        active: boolean;
+        current_phase: string;
+        minimax_completion_reason?: string;
+      };
+      assert.equal(skillState.active, false);
+      assert.equal(skillState.phase, 'completing');
+      assert.equal(skillState.arbiter_decision, 'complete');
+      assert.equal(skillState.minimax_completion_reason, 'arbiter_complete_with_evidence');
+      assert.equal(modeState.active, false);
+      assert.equal(modeState.current_phase, 'complete');
+      assert.equal(modeState.minimax_completion_reason, 'arbiter_complete_with_evidence');
+    });
+  });
+
+  it('keeps minimax active when required council evidence is missing', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const omxDir = join(cwd, '.omx');
+      const stateDir = join(omxDir, 'state');
+      const logsDir = join(omxDir, 'logs');
+      const codexHome = join(cwd, 'codex-home');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const minimaxDir = join(cwd, '.omx', 'minimax');
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(stateDir, { recursive: true });
+      await mkdir(codexHome, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await mkdir(minimaxDir, { recursive: true });
+      await writeJson(join(minimaxDir, 'verification-step-5.json'), {
+        schema_version: 'minimax-verification-v1',
+        step: 5,
+        status: 'passed',
+        passed: true,
+      });
+      await writeJson(join(codexHome, '.omx-config.json'), {
+        autoNudge: { enabled: false, delaySec: 0, stallMs: 0 },
+      });
+      await writeManagedSessionState(stateDir, cwd);
+      const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeJson(join(sessionStateDir, 'skill-active-state.json'), {
+        active: true,
+        skill: 'minimax',
+        keyword: '$minimax',
+        phase: 'reviewing',
+        source: 'keyword-detector',
+        session_id: 'sess-managed',
+      });
+      await writeJson(join(sessionStateDir, 'minimax-state.json'), {
+        active: true,
+        mode: 'minimax',
+        current_phase: 'reviewing',
+        session_id: 'sess-managed',
+        step: 5,
+        arbiter_decision: 'complete',
+        min_verdict: 'escalate',
+        verification_evidence: ['npm run build', 'targeted minimax tests passed'],
+        verification_evidence_step: 5,
+        verification_evidence_path: '.omx/minimax/verification-step-5.json',
+        completion_gate: {
+          council_artifact_required_when_escalated: true,
+        },
+        state: {
+          council: {
+            required: false,
+            artifact_path: null,
+            verdict: null,
+          },
+        },
+      });
+
+      await syncSkillStateFromTurn(stateDir, {
+        cwd,
+        'session-id': 'sess-managed',
+        'last-assistant-message': 'Reviewing required council evidence.',
+      });
+
+      const skillState = JSON.parse(await readFile(join(sessionStateDir, 'skill-active-state.json'), 'utf-8')) as {
+        active: boolean;
+        phase: string;
+        minimax_completion_reason?: string;
+      };
+      assert.equal(skillState.active, true);
+      assert.equal(skillState.phase, 'reviewing');
+      assert.equal(skillState.minimax_completion_reason, 'missing_required_council_artifact');
+    });
+  });
+
   it('releases the deep-interview input lock on success', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');
@@ -2917,7 +3120,7 @@ exit 0
       await mkdir(fakeBinDir, { recursive: true });
 
       await writeJson(join(codexHome, '.omx-config.json'), {
-        autoNudge: { enabled: true, delaySec: 0, stallMs: 0 },
+        autoNudge: { enabled: false, delaySec: 0, stallMs: 0 },
       });
       await writeManagedSessionState(stateDir, cwd);
       const sessionStateDir = join(stateDir, 'sessions', 'sess-managed');

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -45,6 +45,7 @@ import {
 } from '../config/deep-interview.js';
 import { inferTerminalLifecycleOutcome } from '../runtime/run-outcome.js';
 import { resolveAutopilotPlannerRouting } from '../autopilot/planner-routing.js';
+import { normalizeMinimaxLookaheadPolicy } from '../minimax/lookahead.js';
 import { deriveAutopilotChildPhase, AUTOPILOT_CHILD_PHASES } from '../autopilot/fsm.js';
 import { canAdvanceAutopilotDeepInterviewToRalplan } from '../autopilot/deep-interview-gate.js';
 import { canAdvanceAutopilotRalplanToUltragoal } from '../autopilot/ralplan-gate.js';
@@ -123,7 +124,7 @@ export const DEEP_INTERVIEW_STATE_FILE = 'deep-interview-state.json';
 export const DEEP_INTERVIEW_BLOCKED_APPROVAL_INPUTS = ['yes', 'y', 'proceed', 'continue', 'ok', 'sure', 'go ahead', 'next i should'] as const;
 export const DEEP_INTERVIEW_INPUT_LOCK_MESSAGE = 'Deep interview is active; auto-approval shortcuts are blocked until the interview finishes.';
 
-type StatefulSkillMode = 'deep-interview' | 'autopilot' | 'ralph' | 'ralplan' | 'ultragoal' | 'ultrawork' | 'ultraqa' | 'team' | 'autoresearch';
+type StatefulSkillMode = 'deep-interview' | 'autopilot' | 'ralph' | 'ralplan' | 'ultragoal' | 'ultrawork' | 'ultraqa' | 'team' | 'autoresearch' | 'minimax';
 
 interface StatefulSkillSeedConfig {
   mode: StatefulSkillMode;
@@ -140,6 +141,7 @@ const PLANNING_LIKE_WORKFLOW_SKILLS = new Set<TrackedWorkflowMode>([
 const EXECUTION_LIKE_WORKFLOW_SKILLS = new Set<TrackedWorkflowMode>([
   'autopilot',
   'autoresearch',
+  'minimax',
   'ralph',
   'team',
   'ultragoal',
@@ -151,6 +153,7 @@ const STATEFUL_SKILL_SEED_CONFIG: Record<StatefulSkillMode, StatefulSkillSeedCon
   'deep-interview': { mode: 'deep-interview', initialPhase: 'intent-first' },
   autopilot: { mode: 'autopilot', initialPhase: 'deep-interview', includeIteration: true },
   autoresearch: { mode: 'autoresearch', initialPhase: 'executing' },
+  minimax: { mode: 'minimax', initialPhase: 'planning' },
   ralph: { mode: 'ralph', initialPhase: 'starting', includeIteration: true },
   ralplan: { mode: 'ralplan', initialPhase: 'planning' },
   team: { mode: 'team', initialPhase: 'starting', scope: 'root' },
@@ -647,10 +650,14 @@ async function persistStatefulSkillSeedState(
     && existingPhase !== ''
     && !existingModeTerminal
     && (
-      sameActiveSkill
+      (sameActiveSkill && (config.mode !== 'minimax' || options.activeContinuation === true))
       || (config.mode === 'team' && existingModeState?.active === true)
     );
-  const startedAt = previousSkill?.skill === nextSkill.skill && previousSkill.active && !existingModeTerminal
+  const preservePreviousStartedAt = previousSkill?.skill === nextSkill.skill
+    && previousSkill.active
+    && !existingModeTerminal
+    && (config.mode !== 'minimax' || options.activeContinuation === true);
+  const startedAt = preservePreviousStartedAt
     ? safeString(existingModeState?.started_at).trim() || previousSkill.activated_at || nowIso
     : preserveExistingModeState
       ? safeString(existingModeState?.started_at).trim() || nowIso
@@ -686,6 +693,69 @@ async function persistStatefulSkillSeedState(
 
   if (config.mode === 'deep-interview') {
     Object.assign(baseState, buildDeepInterviewConfigStateFields(nextSkill.deep_interview_config));
+  }
+
+  if (config.mode === 'minimax') {
+    const reusableModeState = preserveExistingModeState ? existingModeState : null;
+    const existingState = (reusableModeState?.state && typeof reusableModeState.state === 'object')
+      ? reusableModeState.state as Record<string, unknown>
+      : {};
+    const existingArbiterHistory = Array.isArray(reusableModeState?.arbiter_history)
+      ? reusableModeState.arbiter_history.map((entry) => safeString(entry).trim()).filter(Boolean)
+      : [];
+    const existingEscalationHistory = Array.isArray(reusableModeState?.escalation_history)
+      ? reusableModeState.escalation_history.map((entry) => safeString(entry).trim()).filter(Boolean)
+      : [];
+    const hadEscalation = reusableModeState?.escalated === true
+      || safeString(reusableModeState?.min_verdict).trim().toLowerCase() === 'escalate'
+      || safeString(reusableModeState?.last_arbiter_decision).trim().toLowerCase() === 'escalate'
+      || existingArbiterHistory.some((entry) => entry.toLowerCase() === 'escalate')
+      || existingEscalationHistory.some((entry) => entry.toLowerCase() === 'escalate');
+    baseState.step = typeof reusableModeState?.step === 'number' && Number.isFinite(reusableModeState.step)
+      ? reusableModeState.step
+      : 1;
+    baseState.packet_dir = safeString(reusableModeState?.packet_dir).trim() || '.omx/minimax';
+    baseState.last_packet_path = Object.prototype.hasOwnProperty.call(reusableModeState ?? {}, 'last_packet_path')
+      ? reusableModeState?.last_packet_path
+      : null;
+    baseState.max_next_action = safeString(reusableModeState?.max_next_action).trim() || null;
+    baseState.lookahead = safeString(reusableModeState?.lookahead).trim() || null;
+    baseState.min_verdict = safeString(reusableModeState?.min_verdict).trim() || 'pending';
+    baseState.arbiter_decision = safeString(reusableModeState?.arbiter_decision).trim() || 'pending';
+    baseState.verification_evidence = Array.isArray(reusableModeState?.verification_evidence)
+      ? reusableModeState?.verification_evidence
+      : [];
+    baseState.verification_evidence_step = Object.prototype.hasOwnProperty.call(reusableModeState ?? {}, 'verification_evidence_step')
+      ? reusableModeState?.verification_evidence_step
+      : null;
+    baseState.verification_evidence_path = safeString(reusableModeState?.verification_evidence_path).trim() || null;
+    baseState.council_evidence_step = Object.prototype.hasOwnProperty.call(reusableModeState ?? {}, 'council_evidence_step')
+      ? reusableModeState?.council_evidence_step
+      : null;
+    baseState.escalated = hadEscalation;
+    baseState.last_arbiter_decision = safeString(reusableModeState?.last_arbiter_decision).trim() || null;
+    baseState.arbiter_history = existingArbiterHistory;
+    baseState.escalation_history = existingEscalationHistory;
+    baseState.lookahead_policy = normalizeMinimaxLookaheadPolicy(reusableModeState?.lookahead_policy);
+    baseState.completion_gate = {
+      arbiter_decision_required: 'complete',
+      verification_evidence_required: true,
+      fresh_verification_evidence_required: true,
+      council_artifact_required_when_escalated: true,
+    };
+    baseState.state = {
+      ...existingState,
+      role_loop: Array.isArray(existingState.role_loop)
+        ? existingState.role_loop
+        : ['MAX', 'LOOKAHEAD', 'MIN', 'ARBITER'],
+      council: (existingState.council && typeof existingState.council === 'object')
+        ? existingState.council
+        : {
+            required: false,
+            artifact_path: null,
+            verdict: null,
+          },
+    };
   }
 
   if (config.mode === 'autopilot') {
@@ -813,9 +883,9 @@ const KEYWORD_MAP: Array<{ pattern: RegExp; skill: string; priority: number }> =
   priority: entry.priority,
 }));
 
-const KEYWORDS_REQUIRING_INTENT = new Set(['ralph', 'team', 'stop', 'abort', 'parallel', 'autoresearch', 'ultragoal', 'autopilot']);
+const KEYWORDS_REQUIRING_INTENT = new Set(['ralph', 'team', 'stop', 'abort', 'parallel', 'autoresearch', 'ultragoal', 'autopilot', 'minimax', 'minimax workflow']);
 
-type IntentKeyword = 'ralph' | 'team' | 'stop' | 'abort' | 'parallel' | 'autoresearch' | 'ultragoal' | 'autopilot';
+type IntentKeyword = 'ralph' | 'team' | 'stop' | 'abort' | 'parallel' | 'autoresearch' | 'ultragoal' | 'autopilot' | 'minimax' | 'minimax workflow';
 
 const DEEP_INTERVIEW_ACTIVATION_PATTERNS: RegExp[] = [
   /(?:^|[^\w])\$(?:deep-interview)\b/i,
@@ -840,6 +910,12 @@ const DEEP_INTERVIEW_MANAGEMENT_MENTION_PATTERN = /\b(?:clear|cleanup|clean\s+up
  * "parallel" requires an explicit instruction to run in parallel mode so that
  * CI output like "running 8 tests in parallel" does not trigger ultrawork.
  */
+const MINIMAX_INTENT_PATTERNS: RegExp[] = [
+  /(?:^|[^\w])\$(?:minimax)\b/i,
+  /^\s*\/minimax\b/i,
+  /\b(?:use|run|start|enable|launch|invoke|activate|resume|continue)\s+(?:the\s+)?minimax\s+(?:mode|workflow|skill|loop)\b/i,
+];
+
 const KEYWORD_INTENT_PATTERNS: Record<IntentKeyword, RegExp[]> = {
   ralph: [
     /(?:^|[^\w])\$(?:ralph)\b/i,
@@ -897,6 +973,8 @@ const KEYWORD_INTENT_PATTERNS: Record<IntentKeyword, RegExp[]> = {
     /\b(?:use|run|start|enable|launch|invoke|activate|resume|continue)\s+(?:the\s+)?autopilot(?:\s+(?:mode|workflow|skill|loop|now))?\s*[.!]?\s*$/i,
     /\bautopilot\s+(?:mode|workflow|skill|loop)\b/i,
   ],
+  minimax: MINIMAX_INTENT_PATTERNS,
+  'minimax workflow': MINIMAX_INTENT_PATTERNS,
 };
 
 function hasExplicitPromptsInvocation(text: string): boolean {
@@ -1320,6 +1398,7 @@ function resolveContinuationKeywordMatch(
 
 function initialWorkflowPhaseForMode(mode: TrackedWorkflowMode): SkillActivePhase {
   if (mode === 'autoresearch') return 'executing';
+  if (mode === 'minimax') return 'planning';
   if (mode === 'autopilot') return 'deep-interview';
   return 'planning';
 }
@@ -1677,7 +1756,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
           previous,
           input.text,
           sourceCwd,
-          { activeContinuation: requestedEntry.skill === 'autopilot' && sameSkillContinuation },
+          { activeContinuation: (requestedEntry.skill === 'autopilot' || requestedEntry.skill === 'minimax') && sameSkillContinuation },
         );
         if (requestedEntry.skill === workflowState.skill) {
           nextState = {
@@ -1737,7 +1816,7 @@ export async function recordSkillActivation(input: RecordSkillActivationInput): 
       previous,
       input.text,
       sourceCwd,
-      { activeContinuation: match.skill === 'autopilot' && sameSkillContinuation },
+      { activeContinuation: (match.skill === 'autopilot' || match.skill === 'minimax') && sameSkillContinuation },
     );
     nextState.active_skills = buildActiveSkills(nextState);
     await writeSkillActiveStateCopiesForStateDir(
@@ -1772,6 +1851,7 @@ export const EXECUTION_GATE_KEYWORDS = new Set<string>([
   'autopilot',
   'team',
   'ultrawork',
+  'minimax',
 ]);
 
 /**
@@ -1834,7 +1914,7 @@ export function isUnderspecifiedForExecution(text: string): boolean {
 
   // Strip mode keywords for effective word counting
   const stripped = trimmed
-    .replace(/\b(?:ralph|autopilot|team|ultrawork|ulw)\b/gi, '')
+    .replace(/\b(?:ralph|autopilot|team|ultrawork|ulw|minimax|autoresearch)\b/gi, '')
     .trim();
   const effectiveWords = stripped.split(/\s+/).filter(w => w.length > 0).length;
 

--- a/src/hooks/keyword-registry.ts
+++ b/src/hooks/keyword-registry.ts
@@ -22,6 +22,8 @@ export const KEYWORD_TRIGGER_DEFINITIONS: readonly KeywordTriggerDefinition[] = 
   { keyword: '$ultragoal', skill: 'ultragoal', priority: 10, guidance: 'Activate durable ultragoal planning/execution over Codex goal mode artifacts' },
   { keyword: 'ultragoal', skill: 'ultragoal', priority: 10, guidance: 'Activate durable ultragoal planning/execution over Codex goal mode artifacts' },
   { keyword: '$ultraqa', skill: 'ultraqa', priority: 8, guidance: 'Activate UltraQA cycling workflow' },
+  { keyword: '$minimax', skill: 'minimax', priority: 10, guidance: 'Activate minimax one-step-ahead adversarial oversight workflow' },
+  { keyword: 'minimax workflow', skill: 'minimax', priority: 10, guidance: 'Activate minimax one-step-ahead adversarial oversight workflow' },
   { keyword: '$analyze', skill: 'analyze', priority: 7, guidance: 'Activate deep analysis workflow' },
   { keyword: 'investigate', skill: 'analyze', priority: 7, guidance: 'Activate deep analysis workflow' },
 

--- a/src/minimax/__tests__/lookahead.test.ts
+++ b/src/minimax/__tests__/lookahead.test.ts
@@ -1,0 +1,109 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildDefaultMinimaxLookaheadPolicy,
+  minimaxBranchFactorForRisk,
+  normalizeMinimaxLookaheadPolicy,
+  rankMinimaxLookaheadBranches,
+  scoreMinimaxLookaheadBranch,
+  selectMinimaxLookaheadBranch,
+  selectMinimaxLookaheadBranchesForRisk,
+  type MinimaxLookaheadBranch,
+} from '../lookahead.js';
+
+function branch(overrides: Partial<MinimaxLookaheadBranch>): MinimaxLookaheadBranch {
+  return {
+    id: 'A',
+    max_action: 'Run targeted test',
+    next_state: 'Evidence is fresh',
+    value: 5,
+    risk: 2,
+    evidence_strength: 5,
+    reversible: true,
+    scope_expansion: 0,
+    expected_evidence: ['test output'],
+    ...overrides,
+  };
+}
+
+describe('minimax lookahead policy', () => {
+  it('uses bounded depth and risk-based branch factors', () => {
+    const policy = buildDefaultMinimaxLookaheadPolicy();
+
+    assert.equal(policy.schema_version, 'minimax-lookahead-policy-v1');
+    assert.equal(policy.depth, 2);
+    assert.equal(policy.max_branches, 3);
+    assert.equal(minimaxBranchFactorForRisk('low', policy), 1);
+    assert.equal(minimaxBranchFactorForRisk('medium', policy), 2);
+    assert.equal(minimaxBranchFactorForRisk('high', policy), 3);
+  });
+
+  it('scores value and evidence against risk and scope growth', () => {
+    const score = scoreMinimaxLookaheadBranch(branch({
+      value: 8,
+      evidence_strength: 6,
+      reversible: true,
+      risk: 3,
+      scope_expansion: 2,
+    }));
+
+    assert.equal(score, 11);
+  });
+
+  it('normalizes partial or oversized persisted policies', () => {
+    const policy = normalizeMinimaxLookaheadPolicy({
+      depth: 9,
+      branch_factor_by_risk: { low: 0, medium: 4 },
+      max_branches: 99,
+    });
+
+    assert.equal(policy.depth, 2);
+    assert.equal(policy.max_branches, 3);
+    assert.deepEqual(policy.branch_factor_by_risk, { low: 1, medium: 3, high: 3 });
+    assert.equal(policy.scoring.reversibility_bonus, 2);
+    assert.equal(policy.progressive_widening.add_branch_when_public_contract_changes, true);
+  });
+
+  it('clamps branch metrics to the documented 0-10 range before scoring', () => {
+    assert.equal(scoreMinimaxLookaheadBranch(branch({
+      value: 1000,
+      evidence_strength: 1000,
+      reversible: false,
+      risk: -10,
+      scope_expansion: -10,
+    })), 20);
+  });
+
+  it('ranks by score, lower risk, then stable id', () => {
+    const ranked = rankMinimaxLookaheadBranches([
+      branch({ id: 'C', value: 6, risk: 2, evidence_strength: 4, reversible: false }),
+      branch({ id: 'B', value: 6, risk: 1, evidence_strength: 3, reversible: false }),
+      branch({ id: 'A', value: 10, risk: 7, evidence_strength: 2, reversible: false }),
+    ]);
+
+    assert.deepEqual(ranked.map((item) => item.id), ['B', 'C', 'A']);
+    assert.deepEqual(ranked.map((item) => item.score), [8, 8, 5]);
+  });
+
+  it('selects the top branch or null for empty input', () => {
+    assert.equal(selectMinimaxLookaheadBranch([]), null);
+    assert.equal(selectMinimaxLookaheadBranch([
+      branch({ id: 'risky', value: 9, risk: 8, evidence_strength: 1, reversible: false }),
+      branch({ id: 'safe', value: 5, risk: 1, evidence_strength: 4, reversible: true }),
+    ])?.id, 'safe');
+  });
+
+  it('limits reviewed branches by workflow risk', () => {
+    const branches = [
+      branch({ id: 'A', value: 10, risk: 1 }),
+      branch({ id: 'B', value: 9, risk: 1 }),
+      branch({ id: 'C', value: 8, risk: 1 }),
+      branch({ id: 'D', value: 7, risk: 1 }),
+    ];
+
+    assert.deepEqual(selectMinimaxLookaheadBranchesForRisk(branches, 'low').map((item) => item.id), ['A']);
+    assert.deepEqual(selectMinimaxLookaheadBranchesForRisk(branches, 'medium').map((item) => item.id), ['A', 'B']);
+    assert.deepEqual(selectMinimaxLookaheadBranchesForRisk(branches, 'high').map((item) => item.id), ['A', 'B', 'C']);
+  });
+});

--- a/src/minimax/__tests__/skill-validation.test.ts
+++ b/src/minimax/__tests__/skill-validation.test.ts
@@ -1,0 +1,353 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { assessMinimaxCompletionState } from '../skill-validation.js';
+
+async function writeVerificationArtifact(cwd: string, step: number): Promise<string> {
+  const dir = join(cwd, '.omx', 'minimax');
+  await mkdir(dir, { recursive: true });
+  const relativePath = `.omx/minimax/verification-step-${step}.json`;
+  await writeFile(join(cwd, relativePath), JSON.stringify({
+    schema_version: 'minimax-verification-v1',
+    step,
+    status: 'passed',
+    passed: true,
+  }));
+  return relativePath;
+}
+
+describe('minimax skill validation', () => {
+  it('requires an arbiter complete decision before completion', async () => {
+    const status = await assessMinimaxCompletionState({
+      mode: 'minimax',
+      arbiter_decision: 'continue',
+      verification_evidence: ['tests passed'],
+    }, process.cwd());
+
+    assert.equal(status.complete, false);
+    assert.equal(status.reason, 'arbiter_not_complete');
+    assert.equal(status.arbiterDecision, 'continue');
+  });
+
+  it('requires verification evidence for arbiter complete', async () => {
+    const status = await assessMinimaxCompletionState({
+      mode: 'minimax',
+      arbiter_decision: 'complete',
+    }, process.cwd());
+
+    assert.equal(status.complete, false);
+    assert.equal(status.reason, 'missing_verification_evidence');
+  });
+
+  it('accepts arbiter complete with a passing verification artifact', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-minimax-verification-'));
+    try {
+      const verificationPath = await writeVerificationArtifact(cwd, 1);
+      const status = await assessMinimaxCompletionState({
+        mode: 'minimax',
+        step: 1,
+        arbiter_decision: 'complete',
+        verification_evidence: ['npm run build', 'targeted tests passed'],
+        verification_evidence_step: 1,
+        verification_evidence_path: verificationPath,
+      }, cwd);
+
+      assert.equal(status.complete, true);
+      assert.equal(status.reason, 'arbiter_complete_with_evidence');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not accept self-attested inline evidence without a passing artifact', async () => {
+    const status = await assessMinimaxCompletionState({
+      mode: 'minimax',
+      step: 1,
+      arbiter_decision: 'complete',
+      verification_evidence: ['npm run build'],
+      verification_evidence_step: 1,
+    }, process.cwd());
+
+    assert.equal(status.complete, false);
+    assert.equal(status.reason, 'missing_or_invalid_verification_artifact');
+  });
+
+  it('rejects stale verification evidence when step-scoped evidence is required', async () => {
+    const status = await assessMinimaxCompletionState({
+      mode: 'minimax',
+      step: 4,
+      arbiter_decision: 'complete',
+      verification_evidence: ['old test run'],
+      verification_evidence_step: 3,
+    }, process.cwd());
+
+    assert.equal(status.complete, false);
+    assert.equal(status.reason, 'stale_verification_evidence');
+  });
+
+  it('requires step-scoped verification evidence even when step is omitted', async () => {
+    const status = await assessMinimaxCompletionState({
+      mode: 'minimax',
+      arbiter_decision: 'complete',
+      verification_evidence: ['unscoped test run'],
+      verification_evidence_step: 1,
+    }, process.cwd());
+
+    assert.equal(status.complete, false);
+    assert.equal(status.reason, 'stale_verification_evidence');
+  });
+
+  it('requires passing council evidence when council is required', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-minimax-validation-'));
+    try {
+      const councilDir = join(cwd, '.omx', 'independent-review', 'minimax');
+      await mkdir(councilDir, { recursive: true });
+      const verificationStep1 = await writeVerificationArtifact(cwd, 1);
+      const verificationStep2 = await writeVerificationArtifact(cwd, 2);
+      await writeFile(join(councilDir, 'summary.json'), JSON.stringify({
+        schema_version: 'minimax-independent-review-v1',
+        verdict: { status: 'no_blockers' },
+        blockers: [],
+        blocker_count: 0,
+        degraded: false,
+        reviewer_surface: 'test-reviewer',
+        scope: 'minimax completion gate',
+        inputs: ['changed files', 'test output'],
+      }));
+      await writeFile(join(councilDir, 'partial-review.json'), JSON.stringify({
+        schema_version: 'minimax-independent-review-v1',
+        verdict: { status: 'pass' },
+        blockers: [],
+        blocker_count: 0,
+        degraded: true,
+        reviewer_surface: 'test-reviewer',
+        scope: 'partial review should not pass',
+        inputs: ['changed files'],
+      }));
+      await writeFile(join(councilDir, 'fake-pass.json'), JSON.stringify({
+        verdict: { status: 'pass' },
+        blockers: [],
+        blocker_count: 0,
+        reviewer_surface: 'test-reviewer',
+        scope: 'schema-less review should not pass',
+        inputs: ['changed files'],
+      }));
+      await writeFile(join(councilDir, 'incomplete-summary.json'), JSON.stringify({
+        schema_version: 'minimax-independent-review-v1',
+        verdict: { status: 'no_blockers' },
+        blockers: [],
+      }));
+      await writeFile(join(councilDir, 'invalid.md'), 'No structured verdict here.');
+      await writeFile(join(councilDir, 'scalar.json'), JSON.stringify({
+        verdict: 'pass',
+      }));
+      await writeFile(join(councilDir, 'blocked.json'), JSON.stringify({
+        schema_version: 'minimax-independent-review-v1',
+        verdict: { status: 'pass' },
+        blockers: [{ title: 'real blocker' }],
+        blocker_count: 1,
+        reviewer_surface: 'test-reviewer',
+        scope: 'minimax completion gate',
+        inputs: ['changed files'],
+      }));
+
+      const missingCouncil = await assessMinimaxCompletionState({
+        mode: 'minimax',
+        step: 1,
+        arbiter_decision: 'complete',
+        verification_evidence: ['tests passed'],
+        verification_evidence_step: 1,
+        verification_evidence_path: verificationStep1,
+        council_required: true,
+      }, cwd);
+      assert.equal(missingCouncil.complete, false);
+      assert.equal(missingCouncil.reason, 'missing_required_council_artifact');
+
+      const invalidCouncil = await assessMinimaxCompletionState({
+        mode: 'minimax',
+        step: 1,
+        arbiter_decision: 'complete',
+        verification_evidence: ['tests passed'],
+        verification_evidence_step: 1,
+        verification_evidence_path: verificationStep1,
+        council_required: true,
+        council_artifact_path: '.omx/independent-review/minimax/invalid.md',
+      }, cwd);
+      assert.equal(invalidCouncil.complete, false);
+      assert.equal(invalidCouncil.reason, 'missing_required_council_artifact');
+
+      const scalarCouncil = await assessMinimaxCompletionState({
+        mode: 'minimax',
+        step: 1,
+        arbiter_decision: 'complete',
+        verification_evidence: ['tests passed'],
+        verification_evidence_step: 1,
+        verification_evidence_path: verificationStep1,
+        council_required: true,
+        council_evidence_step: 1,
+        council_artifact_path: '.omx/independent-review/minimax/scalar.json',
+      }, cwd);
+      assert.equal(scalarCouncil.complete, false);
+      assert.equal(scalarCouncil.reason, 'missing_required_council_artifact');
+
+      const fakeCouncil = await assessMinimaxCompletionState({
+        mode: 'minimax',
+        step: 1,
+        arbiter_decision: 'complete',
+        verification_evidence: ['tests passed'],
+        verification_evidence_step: 1,
+        verification_evidence_path: verificationStep1,
+        council_required: true,
+        council_evidence_step: 1,
+        council_artifact_path: '.omx/independent-review/minimax/fake-pass.json',
+      }, cwd);
+      assert.equal(fakeCouncil.complete, false);
+      assert.equal(fakeCouncil.reason, 'missing_required_council_artifact');
+
+      const incompleteSummary = await assessMinimaxCompletionState({
+        mode: 'minimax',
+        step: 1,
+        arbiter_decision: 'complete',
+        verification_evidence: ['tests passed'],
+        verification_evidence_step: 1,
+        verification_evidence_path: verificationStep1,
+        council_required: true,
+        council_evidence_step: 1,
+        council_artifact_path: '.omx/independent-review/minimax/incomplete-summary.json',
+      }, cwd);
+      assert.equal(incompleteSummary.complete, false);
+      assert.equal(incompleteSummary.reason, 'missing_required_council_artifact');
+
+      const blockedCouncil = await assessMinimaxCompletionState({
+        mode: 'minimax',
+        step: 1,
+        arbiter_decision: 'complete',
+        verification_evidence: ['tests passed'],
+        verification_evidence_step: 1,
+        verification_evidence_path: verificationStep1,
+        council_required: true,
+        council_evidence_step: 1,
+        council_artifact_path: '.omx/independent-review/minimax/blocked.json',
+      }, cwd);
+      assert.equal(blockedCouncil.complete, false);
+      assert.equal(blockedCouncil.reason, 'missing_required_council_artifact');
+
+      const withCouncil = await assessMinimaxCompletionState({
+        mode: 'minimax',
+        step: 1,
+        arbiter_decision: 'complete',
+        verification_evidence: ['tests passed'],
+        verification_evidence_step: 1,
+        verification_evidence_path: verificationStep1,
+        council_required: true,
+        council_evidence_step: 1,
+        council_artifact_path: '.omx/independent-review/minimax/summary.json',
+      }, cwd);
+      assert.equal(withCouncil.complete, true);
+      assert.equal(withCouncil.reason, 'arbiter_complete_with_evidence');
+
+      const withPartialReview = await assessMinimaxCompletionState({
+        mode: 'minimax',
+        step: 1,
+        arbiter_decision: 'complete',
+        verification_evidence: ['tests passed'],
+        verification_evidence_step: 1,
+        verification_evidence_path: verificationStep1,
+        council_required: true,
+        council_evidence_step: 1,
+        council_artifact_path: '.omx/independent-review/minimax/partial-review.json',
+      }, cwd);
+      assert.equal(withPartialReview.complete, false);
+      assert.equal(withPartialReview.reason, 'missing_required_council_artifact');
+
+      const staleCouncil = await assessMinimaxCompletionState({
+        mode: 'minimax',
+        step: 2,
+        arbiter_decision: 'complete',
+        verification_evidence: ['tests passed'],
+        verification_evidence_step: 2,
+        verification_evidence_path: verificationStep2,
+        council_required: true,
+        council_evidence_step: 1,
+        council_artifact_path: '.omx/independent-review/minimax/summary.json',
+      }, cwd);
+      assert.equal(staleCouncil.complete, false);
+      assert.equal(staleCouncil.reason, 'stale_council_evidence');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('requires council evidence after a recorded escalation even with seeded council defaults', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-minimax-escalation-'));
+    try {
+      const verificationPath = await writeVerificationArtifact(cwd, 2);
+      const status = await assessMinimaxCompletionState({
+        mode: 'minimax',
+        step: 2,
+        arbiter_decision: 'complete',
+        verification_evidence: ['tests passed'],
+        verification_evidence_step: 2,
+        verification_evidence_path: verificationPath,
+        min_verdict: 'escalate',
+        completion_gate: {
+          council_artifact_required_when_escalated: true,
+        },
+        state: {
+          council: {
+            required: false,
+            artifact_path: null,
+            verdict: null,
+          },
+        },
+      }, cwd);
+
+      assert.equal(status.complete, false);
+      assert.equal(status.reason, 'missing_required_council_artifact');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the council gate sticky after a prior escalation is recorded', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-minimax-sticky-escalation-'));
+    try {
+      const verificationPath = await writeVerificationArtifact(cwd, 4);
+      const status = await assessMinimaxCompletionState({
+        mode: 'minimax',
+        step: 4,
+        arbiter_decision: 'complete',
+        min_verdict: 'continue',
+        escalated: true,
+        verification_evidence: ['tests passed'],
+        verification_evidence_step: 4,
+        verification_evidence_path: verificationPath,
+      }, cwd);
+
+      assert.equal(status.complete, false);
+      assert.equal(status.reason, 'missing_required_council_artifact');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('treats minimax completion gate requirements as non-weakenable invariants', async () => {
+    const status = await assessMinimaxCompletionState({
+      mode: 'minimax',
+      step: 3,
+      arbiter_decision: 'complete',
+      verification_evidence: ['stale test run'],
+      verification_evidence_step: 2,
+      min_verdict: 'escalate',
+      completion_gate: {
+        fresh_verification_evidence_required: false,
+        council_artifact_required_when_escalated: false,
+      },
+    }, process.cwd());
+
+    assert.equal(status.complete, false);
+    assert.equal(status.reason, 'stale_verification_evidence');
+  });
+});

--- a/src/minimax/lookahead.ts
+++ b/src/minimax/lookahead.ts
@@ -1,0 +1,162 @@
+export const MINIMAX_LOOKAHEAD_POLICY_VERSION = 1;
+
+export type MinimaxRiskLevel = 'low' | 'medium' | 'high';
+
+export interface MinimaxLookaheadPolicy {
+  schema_version: 'minimax-lookahead-policy-v1';
+  depth: 1 | 2;
+  branch_factor_by_risk: Record<MinimaxRiskLevel, 1 | 2 | 3>;
+  max_branches: 3;
+  scoring: {
+    value_weight: 1;
+    evidence_weight: 1;
+    reversibility_bonus: 2;
+    risk_weight: 1;
+    scope_expansion_weight: 1;
+  };
+  progressive_widening: {
+    add_branch_when_min_rejects: true;
+    add_branch_when_risk_high: true;
+    add_branch_when_verification_weak: true;
+    add_branch_when_public_contract_changes: true;
+  };
+}
+
+export interface MinimaxLookaheadBranch {
+  id: string;
+  max_action: string;
+  next_state: string;
+  value: number;
+  risk: number;
+  evidence_strength: number;
+  reversible: boolean;
+  scope_expansion: number;
+  expected_evidence: string[];
+  min_risk?: string;
+}
+
+export interface ScoredMinimaxLookaheadBranch extends MinimaxLookaheadBranch {
+  score: number;
+}
+
+function safeRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function clampInteger(value: unknown, fallback: number, min: number, max: number): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(min, Math.round(parsed)));
+}
+
+function normalizeBranchFactor(value: unknown, fallback: 1 | 2 | 3): 1 | 2 | 3 {
+  const clamped = clampInteger(value, fallback, 1, 3);
+  return (clamped === 1 || clamped === 2 || clamped === 3) ? clamped : fallback;
+}
+
+export function buildDefaultMinimaxLookaheadPolicy(): MinimaxLookaheadPolicy {
+  return {
+    schema_version: 'minimax-lookahead-policy-v1',
+    depth: 2,
+    branch_factor_by_risk: {
+      low: 1,
+      medium: 2,
+      high: 3,
+    },
+    max_branches: 3,
+    scoring: {
+      value_weight: 1,
+      evidence_weight: 1,
+      reversibility_bonus: 2,
+      risk_weight: 1,
+      scope_expansion_weight: 1,
+    },
+    progressive_widening: {
+      add_branch_when_min_rejects: true,
+      add_branch_when_risk_high: true,
+      add_branch_when_verification_weak: true,
+      add_branch_when_public_contract_changes: true,
+    },
+  };
+}
+
+export function normalizeMinimaxLookaheadPolicy(rawPolicy: unknown): MinimaxLookaheadPolicy {
+  const defaults = buildDefaultMinimaxLookaheadPolicy();
+  const raw = safeRecord(rawPolicy);
+  const rawBranchFactors = safeRecord(raw.branch_factor_by_risk);
+
+  return {
+    ...defaults,
+    depth: clampInteger(raw.depth, defaults.depth, 1, 2) as 1 | 2,
+    branch_factor_by_risk: {
+      low: normalizeBranchFactor(rawBranchFactors.low, defaults.branch_factor_by_risk.low),
+      medium: normalizeBranchFactor(rawBranchFactors.medium, defaults.branch_factor_by_risk.medium),
+      high: normalizeBranchFactor(rawBranchFactors.high, defaults.branch_factor_by_risk.high),
+    },
+    max_branches: 3,
+    scoring: defaults.scoring,
+    progressive_widening: defaults.progressive_widening,
+  };
+}
+
+export function minimaxBranchFactorForRisk(
+  risk: MinimaxRiskLevel,
+  policy: unknown = buildDefaultMinimaxLookaheadPolicy(),
+): 1 | 2 | 3 {
+  return normalizeMinimaxLookaheadPolicy(policy).branch_factor_by_risk[risk];
+}
+
+function scoreMetric(value: number): number {
+  return Math.min(10, Math.max(0, Number.isFinite(value) ? value : 0));
+}
+
+export function scoreMinimaxLookaheadBranch(
+  branch: MinimaxLookaheadBranch,
+  policy: unknown = buildDefaultMinimaxLookaheadPolicy(),
+): number {
+  const normalizedPolicy = normalizeMinimaxLookaheadPolicy(policy);
+  const score = (scoreMetric(branch.value) * normalizedPolicy.scoring.value_weight)
+    + (scoreMetric(branch.evidence_strength) * normalizedPolicy.scoring.evidence_weight)
+    + (branch.reversible ? normalizedPolicy.scoring.reversibility_bonus : 0)
+    - (scoreMetric(branch.risk) * normalizedPolicy.scoring.risk_weight)
+    - (scoreMetric(branch.scope_expansion) * normalizedPolicy.scoring.scope_expansion_weight);
+  return Math.round(score * 100) / 100;
+}
+
+export function rankMinimaxLookaheadBranches(
+  branches: MinimaxLookaheadBranch[],
+  policy: unknown = buildDefaultMinimaxLookaheadPolicy(),
+): ScoredMinimaxLookaheadBranch[] {
+  const normalizedPolicy = normalizeMinimaxLookaheadPolicy(policy);
+  return branches
+    .map((branch) => ({
+      ...branch,
+      score: scoreMinimaxLookaheadBranch(branch, normalizedPolicy),
+    }))
+    .sort((left, right) => {
+      if (right.score !== left.score) return right.score - left.score;
+      const leftRisk = scoreMetric(left.risk);
+      const rightRisk = scoreMetric(right.risk);
+      if (leftRisk !== rightRisk) return leftRisk - rightRisk;
+      return left.id.localeCompare(right.id);
+    });
+}
+
+export function selectMinimaxLookaheadBranchesForRisk(
+  branches: MinimaxLookaheadBranch[],
+  risk: MinimaxRiskLevel,
+  policy: unknown = buildDefaultMinimaxLookaheadPolicy(),
+): ScoredMinimaxLookaheadBranch[] {
+  const normalizedPolicy = normalizeMinimaxLookaheadPolicy(policy);
+  const branchLimit = Math.min(normalizedPolicy.max_branches, minimaxBranchFactorForRisk(risk, normalizedPolicy));
+  return rankMinimaxLookaheadBranches(branches, normalizedPolicy).slice(0, branchLimit);
+}
+
+export function selectMinimaxLookaheadBranch(
+  branches: MinimaxLookaheadBranch[],
+  policy: unknown = buildDefaultMinimaxLookaheadPolicy(),
+): ScoredMinimaxLookaheadBranch | null {
+  return rankMinimaxLookaheadBranches(branches, policy)[0] ?? null;
+}

--- a/src/minimax/skill-validation.ts
+++ b/src/minimax/skill-validation.ts
@@ -1,0 +1,458 @@
+import { constants as fsConstants } from 'fs';
+import { access, readFile } from 'fs/promises';
+import { isAbsolute, relative, resolve } from 'path';
+import { getAuthoritativeActiveStatePaths, getReadScopedStatePaths } from '../mcp/state-paths.js';
+
+export type MinimaxArbiterDecision = 'pending' | 'continue' | 'revise' | 'block' | 'escalate' | 'complete';
+
+export interface MinimaxCompletionStatus {
+  complete: boolean;
+  reason: string;
+  arbiterDecision: MinimaxArbiterDecision | null;
+  verificationEvidence: string[];
+  verificationEvidencePath: string | null;
+  councilArtifactPath: string | null;
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function safeObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function safeBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
+function safeNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value.trim());
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function lookupObject(raw: Record<string, unknown> | null, ...keys: string[]): Record<string, unknown> | null {
+  if (!raw) return null;
+  for (const key of keys) {
+    const value = safeObject(raw[key]);
+    if (value) return value;
+  }
+  const nestedState = safeObject(raw.state);
+  if (nestedState) {
+    for (const key of keys) {
+      const value = safeObject(nestedState[key]);
+      if (value) return value;
+    }
+  }
+  return null;
+}
+
+function lookupString(raw: Record<string, unknown> | null, ...keys: string[]): string {
+  if (!raw) return '';
+  for (const key of keys) {
+    const direct = safeString(raw[key]);
+    if (direct) return direct;
+  }
+  const nestedState = safeObject(raw.state);
+  if (nestedState) {
+    for (const key of keys) {
+      const nested = safeString(nestedState[key]);
+      if (nested) return nested;
+    }
+  }
+  return '';
+}
+
+function lookupBoolean(raw: Record<string, unknown> | null, ...keys: string[]): boolean | null {
+  if (!raw) return null;
+  for (const key of keys) {
+    const direct = safeBoolean(raw[key]);
+    if (direct !== null) return direct;
+  }
+  const nestedState = safeObject(raw.state);
+  if (nestedState) {
+    for (const key of keys) {
+      const nested = safeBoolean(nestedState[key]);
+      if (nested !== null) return nested;
+    }
+  }
+  return null;
+}
+
+function lookupNumber(raw: Record<string, unknown> | null, ...keys: string[]): number | null {
+  if (!raw) return null;
+  for (const key of keys) {
+    const direct = safeNumber(raw[key]);
+    if (direct !== null) return direct;
+  }
+  const nestedState = safeObject(raw.state);
+  if (nestedState) {
+    for (const key of keys) {
+      const nested = safeNumber(nestedState[key]);
+      if (nested !== null) return nested;
+    }
+  }
+  return null;
+}
+
+function lookupStringArray(raw: Record<string, unknown> | null, ...keys: string[]): string[] {
+  if (!raw) return [];
+  for (const key of keys) {
+    const direct = raw[key];
+    if (Array.isArray(direct)) return direct.map(safeString).filter(Boolean);
+  }
+  const nestedState = safeObject(raw.state);
+  if (nestedState) {
+    for (const key of keys) {
+      const nested = nestedState[key];
+      if (Array.isArray(nested)) return nested.map(safeString).filter(Boolean);
+    }
+  }
+  return [];
+}
+
+export function normalizeMinimaxArbiterDecision(value: unknown): MinimaxArbiterDecision | null {
+  const normalized = safeString(value).toLowerCase();
+  if (normalized === 'pending') return 'pending';
+  if (normalized === 'continue') return 'continue';
+  if (normalized === 'revise') return 'revise';
+  if (normalized === 'block') return 'block';
+  if (normalized === 'escalate') return 'escalate';
+  if (normalized === 'complete' || normalized === 'completed') return 'complete';
+  return null;
+}
+
+function resolveMaybeRelativePath(cwd: string, rawPath: string): string | null {
+  if (!rawPath) return null;
+  const resolved = rawPath.startsWith('/') ? rawPath : resolve(cwd, rawPath);
+  const relativePath = relative(cwd, resolved);
+  if (relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))) {
+    return resolved;
+  }
+  return null;
+}
+
+async function pathExists(path: string | null): Promise<boolean> {
+  if (!path) return false;
+  try {
+    await access(path, fsConstants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function existingPath(cwd: string, rawPath: string): Promise<string | null> {
+  const resolved = resolveMaybeRelativePath(cwd, rawPath);
+  return resolved && await pathExists(resolved) ? resolved : null;
+}
+
+async function readJsonIfExists(path: string | null): Promise<Record<string, unknown> | null> {
+  if (!path || !(await pathExists(path))) return null;
+  try {
+    const parsed = JSON.parse(await readFile(path, 'utf-8')) as unknown;
+    return safeObject(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function isPassingCouncilReviewStatus(value: unknown): boolean {
+  const normalized = safeString(value).toLowerCase();
+  return ['pass', 'passed', 'no_blockers', 'no-blockers'].includes(normalized);
+}
+
+function hasNoStructuredBlockers(artifact: Record<string, unknown>): boolean {
+  const blockers = artifact.blockers;
+  return Array.isArray(blockers) && blockers.length === 0;
+}
+
+function hasZeroReviewBlockers(artifact: Record<string, unknown>): boolean {
+  const blockerCount = safeNumber(artifact.blocker_count) ?? safeNumber(artifact.blockerCount);
+  return blockerCount === 0 && hasNoStructuredBlockers(artifact);
+}
+
+function hasRequiredIndependentReviewFields(artifact: Record<string, unknown>): boolean {
+  const reviewerSurface = lookupString(artifact, 'reviewer_surface', 'reviewerSurface', 'reviewer');
+  const scope = lookupString(artifact, 'review_scope', 'reviewScope', 'scope')
+    || (safeObject(artifact.review_scope) || safeObject(artifact.reviewScope) || safeObject(artifact.scope) ? 'structured-scope' : '');
+  const inputs = artifact.inputs;
+  return Boolean(reviewerSurface && scope && Array.isArray(inputs) && inputs.length > 0);
+}
+
+function reviewCoverageIsComplete(artifact: Record<string, unknown>): boolean {
+  if (lookupBoolean(artifact, 'degraded', 'partial_coverage', 'partialCoverage') === true) return false;
+  const coverage = safeObject(artifact.coverage);
+  if (lookupBoolean(coverage, 'degraded', 'partial', 'partial_coverage', 'partialCoverage') === true) return false;
+  return true;
+}
+
+async function councilArtifactPasses(path: string | null): Promise<boolean> {
+  const artifact = await readJsonIfExists(path);
+  if (!artifact) return false;
+  const schemaVersion = safeString(artifact.schema_version).toLowerCase();
+  const verdict = safeObject(artifact.verdict);
+  if (schemaVersion !== 'minimax-independent-review-v1') return false;
+  if (!verdict || !hasRequiredIndependentReviewFields(artifact)) return false;
+  return reviewCoverageIsComplete(artifact)
+    && hasZeroReviewBlockers(artifact)
+    && isPassingCouncilReviewStatus(verdict.status);
+}
+
+function hasInlineVerificationEvidence(rawState: Record<string, unknown> | null): string[] {
+  const evidence = lookupStringArray(
+    rawState,
+    'verification_evidence',
+    'verificationEvidence',
+    'completion_evidence',
+    'completionEvidence',
+    'evidence',
+  );
+  if (evidence.length > 0) return evidence;
+  const single = lookupString(
+    rawState,
+    'verification_evidence',
+    'verificationEvidence',
+    'completion_evidence',
+    'completionEvidence',
+    'evidence',
+  );
+  return single ? [single] : [];
+}
+
+function completionGateRequiresFreshEvidence(): boolean {
+  return true;
+}
+
+function completionGateRequiresCouncilAfterEscalation(): boolean {
+  return true;
+}
+
+function hasEscalationHistory(rawState: Record<string, unknown> | null): boolean {
+  if (!rawState) return false;
+  if (lookupBoolean(rawState, 'escalated', 'escalation_occurred', 'escalationOccurred') === true) return true;
+  const decisions = lookupStringArray(
+    rawState,
+    'arbiter_history',
+    'arbiterHistory',
+    'arbiter_decision_history',
+    'arbiterDecisionHistory',
+    'escalation_history',
+    'escalationHistory',
+  );
+  if (decisions.some((decision) => normalizeMinimaxArbiterDecision(decision) === 'escalate')) return true;
+  return normalizeMinimaxArbiterDecision(lookupString(rawState, 'last_arbiter_decision', 'lastArbiterDecision')) === 'escalate'
+    || normalizeMinimaxArbiterDecision(lookupString(rawState, 'min_verdict', 'minVerdict')) === 'escalate';
+}
+
+function evidenceIsFreshForCurrentStep(rawState: Record<string, unknown> | null): boolean {
+  if (!completionGateRequiresFreshEvidence()) return true;
+  const step = lookupNumber(rawState, 'step');
+  if (step === null) return false;
+  const evidenceStep = lookupNumber(
+    rawState,
+    'verification_evidence_step',
+    'verificationEvidenceStep',
+    'completion_evidence_step',
+    'completionEvidenceStep',
+  );
+  return evidenceStep !== null && evidenceStep >= step;
+}
+
+function councilEvidenceIsFreshForCurrentStep(rawState: Record<string, unknown> | null): boolean {
+  const step = lookupNumber(rawState, 'step');
+  if (step === null) return false;
+  const council = lookupObject(rawState, 'council');
+  const councilEvidenceStep = lookupNumber(
+    rawState,
+    'council_evidence_step',
+    'councilEvidenceStep',
+  ) ?? lookupNumber(council, 'evidence_step', 'evidenceStep', 'council_evidence_step', 'councilEvidenceStep');
+  return councilEvidenceStep !== null && councilEvidenceStep >= step;
+}
+
+function isPassingVerificationStatus(value: unknown): boolean {
+  const normalized = safeString(value).toLowerCase();
+  return ['pass', 'passed', 'success', 'succeeded', 'complete', 'completed'].includes(normalized);
+}
+
+async function verificationArtifactPasses(path: string | null, rawState: Record<string, unknown> | null): Promise<boolean> {
+  const artifact = await readJsonIfExists(path);
+  if (!artifact) return false;
+  const schemaVersion = safeString(artifact.schema_version).toLowerCase();
+  if (schemaVersion !== 'minimax-verification-v1') return false;
+  const step = lookupNumber(rawState, 'step');
+  const artifactStep = lookupNumber(artifact, 'step', 'verification_step', 'verificationStep');
+  if (step === null || artifactStep === null || artifactStep < step) return false;
+  return lookupBoolean(artifact, 'passed', 'complete', 'valid') === true
+    || isPassingVerificationStatus(artifact.status)
+    || isPassingVerificationStatus(safeObject(artifact.verdict)?.status);
+}
+
+export async function assessMinimaxCompletionState(
+  rawState: Record<string, unknown> | null,
+  cwd: string,
+): Promise<MinimaxCompletionStatus> {
+  if (!rawState) {
+    return {
+      complete: false,
+      reason: 'missing_mode_state',
+      arbiterDecision: null,
+      verificationEvidence: [],
+      verificationEvidencePath: null,
+      councilArtifactPath: null,
+    };
+  }
+
+  const arbiterDecision = normalizeMinimaxArbiterDecision(
+    lookupString(rawState, 'arbiter_decision', 'arbiterDecision'),
+  );
+  const verificationEvidence = hasInlineVerificationEvidence(rawState);
+  const verificationEvidencePathRaw = lookupString(
+    rawState,
+    'verification_evidence_path',
+    'verificationEvidencePath',
+    'completion_artifact_path',
+    'completionArtifactPath',
+  );
+  const council = lookupObject(rawState, 'council');
+  const councilRequiredByFlag = lookupBoolean(rawState, 'council_required', 'councilRequired') === true
+    || lookupBoolean(council, 'required') === true;
+  const councilRequiredByEscalation = completionGateRequiresCouncilAfterEscalation() && hasEscalationHistory(rawState);
+  const councilRequired = councilRequiredByFlag || councilRequiredByEscalation;
+  const councilArtifactPathRaw = lookupString(
+    rawState,
+    'council_artifact_path',
+    'councilArtifactPath',
+  ) || lookupString(council, 'artifact_path', 'artifactPath');
+  const [verificationEvidencePath, councilArtifactPath] = await Promise.all([
+    existingPath(cwd, verificationEvidencePathRaw),
+    existingPath(cwd, councilArtifactPathRaw),
+  ]);
+
+  if (arbiterDecision !== 'complete') {
+    return {
+      complete: false,
+      reason: 'arbiter_not_complete',
+      arbiterDecision,
+      verificationEvidence,
+      verificationEvidencePath,
+      councilArtifactPath,
+    };
+  }
+
+  if (verificationEvidence.length === 0) {
+    return {
+      complete: false,
+      reason: 'missing_verification_evidence',
+      arbiterDecision,
+      verificationEvidence,
+      verificationEvidencePath,
+      councilArtifactPath,
+    };
+  }
+
+  if (!evidenceIsFreshForCurrentStep(rawState)) {
+    return {
+      complete: false,
+      reason: 'stale_verification_evidence',
+      arbiterDecision,
+      verificationEvidence,
+      verificationEvidencePath,
+      councilArtifactPath,
+    };
+  }
+
+  if (!(await verificationArtifactPasses(verificationEvidencePath, rawState))) {
+    return {
+      complete: false,
+      reason: 'missing_or_invalid_verification_artifact',
+      arbiterDecision,
+      verificationEvidence,
+      verificationEvidencePath,
+      councilArtifactPath,
+    };
+  }
+
+  if (councilRequired && !(await councilArtifactPasses(councilArtifactPath))) {
+    return {
+      complete: false,
+      reason: 'missing_required_council_artifact',
+      arbiterDecision,
+      verificationEvidence,
+      verificationEvidencePath,
+      councilArtifactPath,
+    };
+  }
+
+  if (councilRequired && !councilEvidenceIsFreshForCurrentStep(rawState)) {
+    return {
+      complete: false,
+      reason: 'stale_council_evidence',
+      arbiterDecision,
+      verificationEvidence,
+      verificationEvidencePath,
+      councilArtifactPath,
+    };
+  }
+
+  return {
+    complete: true,
+    reason: 'arbiter_complete_with_evidence',
+    arbiterDecision,
+    verificationEvidence,
+    verificationEvidencePath,
+    councilArtifactPath,
+  };
+}
+
+async function readMinimaxModeStateFromPaths(
+  candidates: string[],
+): Promise<Record<string, unknown> | null> {
+  for (const candidatePath of candidates) {
+    if (!(await pathExists(candidatePath))) continue;
+    try {
+      const parsed = JSON.parse(await readFile(candidatePath, 'utf-8')) as unknown;
+      return safeObject(parsed);
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+export async function readMinimaxModeState(
+  cwd: string,
+  sessionId?: string,
+): Promise<Record<string, unknown> | null> {
+  const candidates = await getReadScopedStatePaths('minimax', cwd, sessionId);
+  return readMinimaxModeStateFromPaths(candidates);
+}
+
+export async function readMinimaxModeStateForActiveDecision(
+  cwd: string,
+  sessionId?: string,
+): Promise<Record<string, unknown> | null> {
+  const candidates = await getAuthoritativeActiveStatePaths('minimax', cwd, sessionId);
+  return readMinimaxModeStateFromPaths(candidates);
+}
+
+export async function readMinimaxCompletionStatus(
+  cwd: string,
+  sessionId?: string,
+): Promise<MinimaxCompletionStatus> {
+  const state = await readMinimaxModeState(cwd, sessionId);
+  return assessMinimaxCompletionState(state, cwd);
+}
+
+export async function readMinimaxCompletionStatusForActiveDecision(
+  cwd: string,
+  sessionId?: string,
+): Promise<MinimaxCompletionStatus> {
+  const state = await readMinimaxModeStateForActiveDecision(cwd, sessionId);
+  return assessMinimaxCompletionState(state, cwd);
+}

--- a/src/scripts/notify-hook/auto-nudge.ts
+++ b/src/scripts/notify-hook/auto-nudge.ts
@@ -22,6 +22,7 @@ import { evaluatePaneInjectionReadiness, mapPaneInjectionReadinessReason, sendPa
 import { stripOrchestrationIntentTags } from './orchestration-intent.js';
 import { buildCapturePaneArgv, DEFAULT_MARKER, tmuxHookExplicitlyDisablesInjection } from '../tmux-hook-engine.js';
 import { readAutoresearchCompletionStatus } from '../../autoresearch/skill-validation.js';
+import { readMinimaxCompletionStatusForActiveDecision } from '../../minimax/skill-validation.js';
 import { persistDeepInterviewModeState } from '../../hooks/keyword-detector.js';
 import {
   isManagedOmxSession,
@@ -195,6 +196,22 @@ async function persistSkillActiveState(stateDir, sessionId, state) {
   await writeScopedJson(stateDir, SKILL_ACTIVE_STATE_FILE, sessionId, state).catch(() => {});
 }
 
+async function persistMinimaxModeCompletionState(stateDir, sessionId, completion, nowIso) {
+  const modeState = await readScopedJsonIfExists(stateDir, 'minimax-state.json', sessionId, null);
+  if (!modeState || modeState.mode !== 'minimax') return;
+  await writeScopedJson(stateDir, 'minimax-state.json', sessionId, {
+    ...modeState,
+    active: false,
+    current_phase: 'complete',
+    completed_at: modeState.completed_at || nowIso,
+    updated_at: nowIso,
+    arbiter_decision: completion.arbiterDecision || modeState.arbiter_decision,
+    minimax_completion_reason: completion.reason,
+    verification_evidence_path: completion.verificationEvidencePath,
+    council_artifact_path: completion.councilArtifactPath,
+  }).catch(() => {});
+}
+
 function cloneSkillActiveState(state) {
   if (!state || typeof state !== 'object') return null;
   return {
@@ -233,6 +250,7 @@ export async function syncSkillStateFromTurn(stateDir, payload) {
     : inferredPhase;
   skillState.phase = nextPhase;
   skillState.active = nextPhase !== 'completing';
+  const nowIso = new Date().toISOString();
 
   if (skillState.skill === 'autoresearch') {
     const completion = await readAutoresearchCompletionStatus(payload.cwd || process.cwd(), invocationSessionId);
@@ -248,7 +266,22 @@ export async function syncSkillStateFromTurn(stateDir, payload) {
     }
   }
 
-  const nowIso = new Date().toISOString();
+  if (skillState.skill === 'minimax') {
+    const completion = await readMinimaxCompletionStatusForActiveDecision(payload.cwd || process.cwd(), invocationSessionId);
+    skillState.arbiter_decision = completion.arbiterDecision;
+    skillState.minimax_completion_reason = completion.reason;
+    skillState.verification_evidence_path = completion.verificationEvidencePath;
+    skillState.council_artifact_path = completion.councilArtifactPath;
+    if (completion.complete) {
+      skillState.phase = 'completing';
+      skillState.active = false;
+      await persistMinimaxModeCompletionState(stateDir, invocationSessionId, completion, nowIso);
+    } else if (inferredPhase === 'completing') {
+      skillState.phase = previousPhase === 'completing' ? 'reviewing' : previousPhase;
+      skillState.active = true;
+    }
+  }
+
   skillState.updated_at = nowIso;
   releaseReason = inferDeepInterviewReleaseReason({ skillState, latestUserInput, lastMessage });
   if (releaseReason && isDeepInterviewAutoApprovalLocked(skillState)) {

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -476,6 +476,157 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('writes and reads minimax state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-minimax-'));
+    try {
+      const writeResponse = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'minimax',
+        active: true,
+        current_phase: 'reviewing',
+        step: 2,
+      });
+
+      assert.equal(writeResponse.isError, undefined);
+      assert.deepEqual(writeResponse.payload, {
+        success: true,
+        mode: 'minimax',
+        path: join(wd, '.omx', 'state', 'minimax-state.json'),
+      });
+
+      const readResponse = await executeStateOperation('state_read', {
+        workingDirectory: wd,
+        mode: 'minimax',
+      });
+
+      assert.equal(readResponse.isError, undefined);
+      const readBody = readResponse.payload as Record<string, unknown>;
+      assert.equal(readBody.active, true);
+      assert.equal(readBody.current_phase, 'reviewing');
+      assert.equal(readBody.step, 2);
+      assert.deepEqual((readBody.lookahead_policy as { branch_factor_by_risk?: unknown }).branch_factor_by_risk, {
+        low: 1,
+        medium: 2,
+        high: 3,
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects minimax completion writes without fresh verification evidence', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-minimax-complete-reject-'));
+    try {
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'minimax',
+        active: true,
+        current_phase: 'reviewing',
+        step: 2,
+        arbiter_decision: 'complete',
+        verification_evidence: ['claimed but no artifact'],
+        verification_evidence_step: 2,
+      });
+
+      assert.equal(response.isError, true);
+      assert.match((response.payload as { error?: string }).error || '', /minimax complete state requires fresh verification evidence/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects minimax inactive terminal writes unless they are explicit cancellation states', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-minimax-inactive-reject-'));
+    try {
+      const terminalResponse = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'minimax',
+        active: false,
+      });
+      assert.equal(terminalResponse.isError, true);
+      assert.match((terminalResponse.payload as { error?: string }).error || '', /minimax complete state requires fresh verification evidence/);
+
+      const cancelResponse = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'minimax',
+        active: false,
+        current_phase: 'cancelled',
+      });
+      assert.equal(cancelResponse.isError, undefined);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('allows minimax completion writes with a passing verification artifact', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-minimax-complete-pass-'));
+    try {
+      await mkdir(join(wd, '.omx', 'minimax'), { recursive: true });
+      await writeFile(join(wd, '.omx', 'minimax', 'verification-step-2.json'), JSON.stringify({
+        schema_version: 'minimax-verification-v1',
+        step: 2,
+        status: 'passed',
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'minimax',
+        active: true,
+        current_phase: 'reviewing',
+        step: 2,
+        arbiter_decision: 'complete',
+        verification_evidence: ['node --test dist/minimax/__tests__/lookahead.test.js'],
+        verification_evidence_step: 2,
+        verification_evidence_path: '.omx/minimax/verification-step-2.json',
+      });
+
+      assert.equal(response.isError, undefined);
+      const readResponse = await executeStateOperation('state_read', {
+        workingDirectory: wd,
+        mode: 'minimax',
+      });
+      const readBody = readResponse.payload as Record<string, unknown>;
+      assert.equal(readBody.arbiter_decision, 'complete');
+      assert.equal(readBody.verification_evidence_path, '.omx/minimax/verification-step-2.json');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps minimax escalation sticky across later state writes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-minimax-escalation-'));
+    try {
+      await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'minimax',
+        active: true,
+        current_phase: 'reviewing',
+        escalated: true,
+        arbiter_history: ['escalate'],
+      });
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'minimax',
+        active: true,
+        current_phase: 'reviewing',
+        escalated: false,
+        arbiter_history: ['continue'],
+      });
+
+      assert.equal(response.isError, undefined);
+      const readResponse = await executeStateOperation('state_read', {
+        workingDirectory: wd,
+        mode: 'minimax',
+      });
+      const readBody = readResponse.payload as { escalated?: boolean; arbiter_history?: string[] };
+      assert.equal(readBody.escalated, true);
+      assert.deepEqual(readBody.arbiter_history, ['escalate', 'continue']);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('lists active modes from the explicit session scope without leaking a sibling Ralph session', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-foreign-ralph-scope-'));
     try {

--- a/src/state/__tests__/workflow-transition.test.ts
+++ b/src/state/__tests__/workflow-transition.test.ts
@@ -42,7 +42,7 @@ describe('workflow transition rules', () => {
   it('allows the approved overlap matrix and denies unsupported combinations', () => {
     const cases: Array<{
       current: string[];
-      requested: 'team' | 'ralph' | 'ultrawork' | 'autopilot' | 'autoresearch';
+      requested: 'team' | 'ralph' | 'ultrawork' | 'autopilot' | 'autoresearch' | 'minimax';
       allowed: boolean;
       resulting: string[];
     }> = [
@@ -56,6 +56,9 @@ describe('workflow transition rules', () => {
       { current: ['autopilot'], requested: 'team', allowed: false, resulting: ['autopilot'] },
       { current: ['team'], requested: 'autopilot', allowed: false, resulting: ['team'] },
       { current: ['autoresearch'], requested: 'ralph', allowed: false, resulting: ['autoresearch'] },
+      { current: ['minimax'], requested: 'team', allowed: false, resulting: ['minimax'] },
+      { current: ['ultrawork'], requested: 'minimax', allowed: false, resulting: ['ultrawork'] },
+      { current: ['minimax'], requested: 'ultrawork', allowed: false, resulting: ['minimax'] },
       { current: ['team', 'ralph'], requested: 'ultrawork', allowed: true, resulting: ['team', 'ralph', 'ultrawork'] },
       { current: ['team', 'ultrawork'], requested: 'ralph', allowed: true, resulting: ['team', 'ultrawork', 'ralph'] },
     ];
@@ -92,6 +95,13 @@ describe('workflow transition rules', () => {
     assert.deepEqual(interviewToAutoresearch.resultingModes, ['autoresearch']);
     assert.equal(interviewToAutoresearch.transitionMessage, 'mode transiting: deep-interview -> autoresearch');
 
+    const interviewToMinimax = evaluateWorkflowTransition(['deep-interview'], 'minimax');
+    assert.equal(interviewToMinimax.allowed, true);
+    assert.equal(interviewToMinimax.kind, 'auto-complete');
+    assert.deepEqual(interviewToMinimax.autoCompleteModes, ['deep-interview']);
+    assert.deepEqual(interviewToMinimax.resultingModes, ['minimax']);
+    assert.equal(interviewToMinimax.transitionMessage, 'mode transiting: deep-interview -> minimax');
+
     const interviewToUltragoal = evaluateWorkflowTransition(['deep-interview'], 'ultragoal');
     assert.equal(interviewToUltragoal.allowed, true);
     assert.equal(interviewToUltragoal.kind, 'auto-complete');
@@ -117,6 +127,17 @@ describe('workflow transition rules', () => {
     assert.equal(ralplanToAutoresearch.kind, 'auto-complete');
     assert.deepEqual(ralplanToAutoresearch.autoCompleteModes, ['ralplan']);
     assert.deepEqual(ralplanToAutoresearch.resultingModes, ['autoresearch']);
+
+    const ralplanToMinimax = evaluateWorkflowTransition(['ralplan'], 'minimax');
+    assert.equal(ralplanToMinimax.allowed, true);
+    assert.equal(ralplanToMinimax.kind, 'auto-complete');
+    assert.deepEqual(ralplanToMinimax.autoCompleteModes, ['ralplan']);
+    assert.deepEqual(ralplanToMinimax.resultingModes, ['minimax']);
+
+    const ralplanUltraworkToMinimax = evaluateWorkflowTransition(['ralplan', 'ultrawork'], 'minimax');
+    assert.equal(ralplanUltraworkToMinimax.allowed, false);
+    assert.deepEqual(ralplanUltraworkToMinimax.autoCompleteModes, []);
+    assert.deepEqual(ralplanUltraworkToMinimax.resultingModes, ['ralplan', 'ultrawork']);
   });
 
   it('builds rollback denial guidance for execution-to-planning transitions', () => {

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -59,6 +59,8 @@ import {
   buildAutopilotRalplanUltragoalGateError,
   canAdvanceAutopilotRalplanToUltragoal,
 } from '../autopilot/ralplan-gate.js';
+import { assessMinimaxCompletionState } from '../minimax/skill-validation.js';
+import { normalizeMinimaxLookaheadPolicy } from '../minimax/lookahead.js';
 import {
   buildRalplanConsensusGateFromSources,
 } from '../ralplan/consensus-gate.js';
@@ -97,9 +99,61 @@ function isNextAutopilotPhase(
   return currentOrder >= 0 && nextOrder === currentOrder + 1;
 }
 
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.map((entry) => typeof entry === 'string' ? entry.trim() : '').filter(Boolean)
+    : [];
+}
+
+function hasMinimaxEscalation(state: Record<string, unknown>): boolean {
+  return state.escalated === true
+    || (typeof state.min_verdict === 'string' && state.min_verdict.trim().toLowerCase() === 'escalate')
+    || (typeof state.last_arbiter_decision === 'string' && state.last_arbiter_decision.trim().toLowerCase() === 'escalate')
+    || stringArray(state.arbiter_history).some((entry) => entry.toLowerCase() === 'escalate')
+    || stringArray(state.escalation_history).some((entry) => entry.toLowerCase() === 'escalate');
+}
+
+function preserveMinimaxEscalation(existing: Record<string, unknown>, next: Record<string, unknown>): void {
+  if (!hasMinimaxEscalation(existing) && !hasMinimaxEscalation(next)) return;
+  next.escalated = true;
+  const history = new Set([
+    ...stringArray(existing.arbiter_history),
+    ...stringArray(next.arbiter_history),
+  ]);
+  history.add('escalate');
+  next.arbiter_history = [...history];
+}
+
+function normalizedStringField(state: Record<string, unknown>, key: string): string {
+  const value = state[key];
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function isMinimaxCancellationState(state: Record<string, unknown>): boolean {
+  const terminal = [
+    normalizedStringField(state, 'current_phase'),
+    normalizedStringField(state, 'run_outcome'),
+    normalizedStringField(state, 'lifecycle_outcome'),
+    normalizedStringField(state, 'terminal_outcome'),
+  ];
+  return terminal.some((value) => ['cancelled', 'canceled', 'stopped', 'failed', 'blocked', 'user-stopped'].includes(value));
+}
+
+function isMinimaxCompletionAttempt(state: Record<string, unknown>): boolean {
+  if (normalizedStringField(state, 'arbiter_decision') === 'complete') return true;
+  if (['complete', 'completed'].includes(normalizedStringField(state, 'current_phase'))) return true;
+  if (['success', 'succeeded', 'complete', 'completed', 'finished'].some((value) => [
+    normalizedStringField(state, 'run_outcome'),
+    normalizedStringField(state, 'lifecycle_outcome'),
+    normalizedStringField(state, 'terminal_outcome'),
+  ].includes(value))) return true;
+  return state.active === false && !isMinimaxCancellationState(state);
+}
+
 export const SUPPORTED_STATE_READ_MODES = [
   'autopilot',
   'autoresearch',
+  'minimax',
   'team',
   'ralph',
   'ultrawork',
@@ -786,6 +840,18 @@ export async function executeStateOperation(
 
           if (mode === 'autopilot') {
             normalizeCleanAutopilotCompletionEvidence(mergedRaw);
+          }
+
+          if (mode === 'minimax') {
+            mergedRaw.lookahead_policy = normalizeMinimaxLookaheadPolicy(mergedRaw.lookahead_policy);
+            preserveMinimaxEscalation(existing as Record<string, unknown>, mergedRaw);
+            if (isMinimaxCompletionAttempt(mergedRaw)) {
+              const completion = await assessMinimaxCompletionState(mergedRaw, cwd);
+              if (!completion.complete) {
+                validationError = `minimax complete state requires fresh verification evidence (${completion.reason})`;
+                return;
+              }
+            }
           }
 
           if (mode === 'ralplan') {

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -764,6 +764,7 @@ export function buildPlanningGateLogEvent(
 export const TRACKED_WORKFLOW_MODES = [
   'autopilot',
   'autoresearch',
+  'minimax',
   'team',
   'ultragoal',
   'ralph',
@@ -784,6 +785,7 @@ const ALLOWED_OVERLAP_PAIRS = new Set([
 const AUTO_COMPLETE_TRANSITIONS = new Set([
   'deep-interview->autopilot',
   'deep-interview->autoresearch',
+  'deep-interview->minimax',
   'deep-interview->ralph',
   'deep-interview->team',
   'deep-interview->ultragoal',
@@ -793,6 +795,7 @@ const AUTO_COMPLETE_TRANSITIONS = new Set([
   'ralplan->ralph',
   'ralplan->autopilot',
   'ralplan->autoresearch',
+  'ralplan->minimax',
   'ultragoal->ultraqa',
 ]);
 
@@ -808,6 +811,7 @@ const PLANNING_LIKE_MODES = new Set<TrackedWorkflowMode>([
 const EXECUTION_LIKE_MODES = new Set<TrackedWorkflowMode>([
   'autopilot',
   'autoresearch',
+  'minimax',
   'team',
   'ultragoal',
   'ralph',
@@ -834,6 +838,7 @@ function buildPairKey(a: string, b: string): string {
 }
 
 function isAllowedOverlap(a: TrackedWorkflowMode, b: TrackedWorkflowMode): boolean {
+  if (a === 'minimax' || b === 'minimax') return false;
   if (a === 'ultrawork' || b === 'ultrawork') return true;
   return ALLOWED_OVERLAP_PAIRS.has(buildPairKey(a, b));
 }

--- a/templates/catalog-manifest.json
+++ b/templates/catalog-manifest.json
@@ -73,6 +73,13 @@
       "internalRequired": false
     },
     {
+      "name": "minimax",
+      "category": "execution",
+      "status": "active",
+      "core": false,
+      "internalRequired": false
+    },
+    {
       "name": "ultragoal",
       "category": "execution",
       "status": "active",


### PR DESCRIPTION
## Summary

Adds `$minimax`, a guarded execution workflow for clear but risky tasks where each next move should be checked by a one-step-ahead adversarial review loop.

The workflow is explicit, bounded, stateful, and evidence-gated:
- **MAX** proposes one bounded move.
- **LOOKAHEAD** predicts the next state and likely failure mode.
- **MIN** reviews the transition for drift, missing evidence, or unsafe scope expansion.
- **ARBITER** decides `continue`, `revise`, `block`, `escalate`, or `complete`.

## Why

Existing planning and review workflows are good for broad requirements and validation, but they do not enforce a per-step transition gate. Minimax fills that gap without becoming a general planner or team workflow.

## Tiny flow diagram

```mermaid
flowchart LR
  U[User asks for $minimax] --> M[MAX: one bounded move]
  M --> L[LOOKAHEAD: next state + failure mode]
  L --> N[MIN: challenge transition]
  N --> A{ARBITER}
  A -->|continue| M
  A -->|revise| M
  A -->|block| S[Stop]
  A -->|escalate| R[Independent review artifact]
  R --> M
  A -->|complete + evidence| D[Done]
```

## How Minimax steps work

Minimax is not a fixed-length workflow. It can run as many steps as needed, but each step must be one bounded move.

Per step:
1. MAX proposes or executes one bounded action.
2. LOOKAHEAD predicts the next likely state and failure mode.
3. MIN reviews for drift, missing evidence, unsafe automation, or scope expansion.
4. ARBITER decides whether to continue, revise, block, escalate, or complete.

The total number of steps is open-ended, but lookahead branching is bounded:
- low risk: 1 branch
- medium risk: 2 branches
- high risk: 3 branches
- default lookahead depth: 2
- max branches: 3

Completion is intentionally strict. Minimax should not complete from prose alone; it requires fresh verification evidence and a passing `minimax-verification-v1` artifact. If escalation happened, completion also requires a durable independent-review artifact.

## Example task

User asks:

> `$minimax harden this public API change before merge`

Minimax step 1:
- MAX: inspect the API diff and identify the smallest safe next action.
- LOOKAHEAD: predict the tests/docs needed after that action.
- MIN: reject if the action widens compatibility scope or skips validation.
- ARBITER: continue only if the next action is bounded and reversible.

A later completion must include:
- `arbiter_decision: "complete"`
- non-empty verification evidence
- a passing `minimax-verification-v1` artifact for the current step
- independent-review evidence if escalation was recorded

## Safety properties

- Avoids broad bare triggering for algorithm/search discussion.
- Redirects underspecified execution requests to planning.
- Keeps lookahead bounded rather than growing a tree.
- Keeps escalation sticky across later state writes.
- Uses a generic independent-review artifact contract rather than baking in a specific review tool, vendor, or integration.
- Blocks terminal Minimax state writes that lack fresh verification evidence.

## Testing

- `npm run build`
- `node dist/scripts/run-test-files.js dist/hooks/__tests__/minimax-skill-contract.test.js dist/minimax/__tests__/skill-validation.test.js`
- `node --test --test-name-pattern='minimax' dist/hooks/__tests__/keyword-detector.test.js`
- `npm run sync:plugin:check`
- `git diff --check origin/dev..HEAD`

## Not tested

- Full repository test suite.
