### PR TITLE
Fix direct team state root handling

### DIFF
--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -8,6 +8,7 @@ import {
   getAllScopedStateDirs,
   getAllScopedStatePaths,
   getBaseStateDir,
+  getBaseStateDirWithSource,
   getAllSessionScopedStateDirs,
   getAllSessionScopedStatePaths,
   getReadScopedStateFilePaths,
@@ -104,6 +105,10 @@ describe('state paths', () => {
       assert.equal(getBaseStateDir('/tmp/source'), '/tmp/explicit-team-state');
       assert.equal(getStateDir('/tmp/source', 'sess1'), '/tmp/explicit-team-state/sessions/sess1');
       assert.equal(getStatePath('ralph', '/tmp/source', 'sess1'), '/tmp/explicit-team-state/sessions/sess1/ralph-state.json');
+      assert.deepEqual(getBaseStateDirWithSource('/tmp/source'), {
+        baseStateDir: '/tmp/explicit-team-state',
+        rootSource: 'team-env',
+      });
     } finally {
       if (typeof prevRoot === 'string') process.env.OMX_ROOT = prevRoot;
       else delete process.env.OMX_ROOT;
@@ -125,6 +130,10 @@ describe('state paths', () => {
       assert.equal(getBaseStateDir('/tmp/source'), '/tmp/omx-box/.omx/state');
       assert.equal(getStateDir('/tmp/source', 'sess1'), '/tmp/omx-box/.omx/state/sessions/sess1');
       assert.equal(getStatePath('ralph', '/tmp/source', 'sess1'), '/tmp/omx-box/.omx/state/sessions/sess1/ralph-state.json');
+      assert.deepEqual(getBaseStateDirWithSource('/tmp/source'), {
+        baseStateDir: '/tmp/omx-box/.omx/state',
+        rootSource: 'omx-root-env',
+      });
     } finally {
       if (typeof prevRoot === 'string') process.env.OMX_ROOT = prevRoot;
       else delete process.env.OMX_ROOT;
@@ -132,6 +141,28 @@ describe('state paths', () => {
       else delete process.env.OMX_STATE_ROOT;
       if (typeof prevTeamRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamRoot;
       else delete process.env.OMX_TEAM_STATE_ROOT;
+    }
+  });
+
+  it('fails closed when an explicit state root is outside the allowlist', async () => {
+    const allowedRoot = await mkRealTemp('omx-state-root-allowed-');
+    const disallowedRoot = await mkRealTemp('omx-state-root-disallowed-');
+    const prevAllowlist = process.env.OMX_MCP_WORKDIR_ROOTS;
+    const prevTeamRoot = process.env.OMX_TEAM_STATE_ROOT;
+    process.env.OMX_MCP_WORKDIR_ROOTS = allowedRoot;
+    process.env.OMX_TEAM_STATE_ROOT = disallowedRoot;
+    try {
+      assert.throws(
+        () => getBaseStateDirWithSource(join(allowedRoot, 'workspace')),
+        /outside allowed roots \(OMX_MCP_WORKDIR_ROOTS\)/,
+      );
+    } finally {
+      if (typeof prevAllowlist === 'string') process.env.OMX_MCP_WORKDIR_ROOTS = prevAllowlist;
+      else delete process.env.OMX_MCP_WORKDIR_ROOTS;
+      if (typeof prevTeamRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(allowedRoot, { recursive: true, force: true });
+      await rm(disallowedRoot, { recursive: true, force: true });
     }
   });
 

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -226,32 +226,26 @@ function enforceWorkingDirectoryPolicy(resolvedWorkingDirectory: string): string
   return canonicalWorkingDirectory;
 }
 
-function resolveBaseStateDirWithSource(workingDirectory?: string): { baseStateDir: string; rootSource: StateRootSource } {
+export function getBaseStateDirWithSource(workingDirectory?: string): { baseStateDir: string; rootSource: StateRootSource } {
   const teamStateRootOverride = process.env[OMX_TEAM_STATE_ROOT_ENV]?.trim();
   if (typeof teamStateRootOverride === 'string' && teamStateRootOverride !== '') {
-    try {
-      return { baseStateDir: resolveWorkingDirectoryForState(teamStateRootOverride), rootSource: 'team-env' };
-    } catch {}
+    return { baseStateDir: resolveWorkingDirectoryForState(teamStateRootOverride), rootSource: 'team-env' };
   }
 
   const omxRootOverride = process.env[OMX_ROOT_ENV]?.trim();
   if (typeof omxRootOverride === 'string' && omxRootOverride !== '') {
-    try {
-      return { baseStateDir: join(resolveWorkingDirectoryForState(omxRootOverride), '.omx', 'state'), rootSource: 'omx-root-env' };
-    } catch {}
+    return { baseStateDir: join(resolveWorkingDirectoryForState(omxRootOverride), '.omx', 'state'), rootSource: 'omx-root-env' };
   }
 
   const omxStateRootOverride = process.env[OMX_STATE_ROOT_ENV]?.trim();
   if (typeof omxStateRootOverride === 'string' && omxStateRootOverride !== '') {
-    try {
-      return { baseStateDir: join(resolveWorkingDirectoryForState(omxStateRootOverride), '.omx', 'state'), rootSource: 'omx-state-root-env' };
-    } catch {}
+    return { baseStateDir: join(resolveWorkingDirectoryForState(omxStateRootOverride), '.omx', 'state'), rootSource: 'omx-state-root-env' };
   }
 
   return { baseStateDir: join(resolveWorkingDirectoryForState(workingDirectory), '.omx', 'state'), rootSource: 'cwd-default' };
 }
 export function getBaseStateDir(workingDirectory?: string): string {
-  return resolveBaseStateDirWithSource(workingDirectory).baseStateDir;
+  return getBaseStateDirWithSource(workingDirectory).baseStateDir;
 }
 
 export function getStateDir(workingDirectory?: string, sessionId?: string): string {
@@ -399,7 +393,7 @@ export async function resolveRuntimeStateScope(
   explicitSessionId?: string,
 ): Promise<ResolvedRuntimeStateScope> {
   const cwd = resolveWorkingDirectoryForState(workingDirectory);
-  const { baseStateDir, rootSource } = resolveBaseStateDirWithSource(cwd);
+  const { baseStateDir, rootSource } = getBaseStateDirWithSource(cwd);
   const metadata = await readSessionMetadataFromBaseStateDir(cwd, baseStateDir);
   const validatedExplicit = validateSessionId(explicitSessionId);
   const envSessionId = readSessionIdFromEnvironment();

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -51,6 +51,33 @@ async function withOmxRootEnv<T>(root: string, run: () => Promise<T>): Promise<T
     else delete process.env.OMX_TEAM_STATE_ROOT;
   }
 }
+async function withStateRootEnv<T>(env: Partial<Record<'OMX_ROOT' | 'OMX_STATE_ROOT' | 'OMX_TEAM_STATE_ROOT', string>>, run: () => Promise<T>): Promise<T> {
+  const previousOmxRoot = process.env.OMX_ROOT;
+  const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+  const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+  if (typeof env.OMX_ROOT === 'string') process.env.OMX_ROOT = env.OMX_ROOT;
+  else delete process.env.OMX_ROOT;
+  if (typeof env.OMX_STATE_ROOT === 'string') process.env.OMX_STATE_ROOT = env.OMX_STATE_ROOT;
+  else delete process.env.OMX_STATE_ROOT;
+  if (typeof env.OMX_TEAM_STATE_ROOT === 'string') process.env.OMX_TEAM_STATE_ROOT = env.OMX_TEAM_STATE_ROOT;
+  else delete process.env.OMX_TEAM_STATE_ROOT;
+  try {
+    return await run();
+  } finally {
+    if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+    else delete process.env.OMX_ROOT;
+    if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+    else delete process.env.OMX_STATE_ROOT;
+    if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+    else delete process.env.OMX_TEAM_STATE_ROOT;
+  }
+}
+
+function responsePayload<T extends Record<string, unknown>>(response: { payload: unknown; isError?: boolean }): T {
+  assert.equal(response.isError, undefined);
+  assert.ok(response.payload && typeof response.payload === 'object' && !Array.isArray(response.payload));
+  return response.payload as T;
+}
 
 function validExecutionContract(stride: 'task' | 'deliverable' | 'milestone'): Record<string, unknown> {
   const perStride = {
@@ -239,6 +266,135 @@ describe('state operations directory initialization', () => {
       assert.deepEqual(response.payload, { statuses: {} });
     } finally {
       await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('writes and clears session state under OMX_TEAM_STATE_ROOT without creating cwd .omx', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-state-ops-team-root-'));
+    try {
+      const wd = join(root, 'workspace');
+      const teamStateRoot = join(root, 'team-state');
+      await mkdir(wd, { recursive: true });
+
+      await withStateRootEnv({ OMX_TEAM_STATE_ROOT: teamStateRoot }, async () => {
+        const writeResponse = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: 'sess-team-write',
+          mode: 'autoresearch',
+          active: true,
+          current_phase: 'running',
+        });
+        const writePayload = responsePayload<{ path: string }>(writeResponse);
+        assert.equal(writePayload.path, join(teamStateRoot, 'sessions', 'sess-team-write', 'autoresearch-state.json'));
+        assert.equal(existsSync(writePayload.path), true);
+        assert.equal(existsSync(join(teamStateRoot, 'sessions', 'sess-team-write', 'skill-active-state.json')), true);
+        assert.equal(existsSync(join(wd, '.omx')), false);
+
+        const clearResponse = await executeStateOperation('state_clear', {
+          workingDirectory: wd,
+          session_id: 'sess-team-write',
+          mode: 'autoresearch',
+        });
+        const clearPayload = responsePayload<{ path: string }>(clearResponse);
+        assert.equal(clearPayload.path, writePayload.path);
+        assert.equal(existsSync(writePayload.path), false);
+        assert.equal(existsSync(join(teamStateRoot, 'sessions', 'sess-team-write', 'skill-active-state.json')), true);
+        assert.equal(existsSync(join(wd, '.omx')), false);
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('writes and clears session state under OMX_ROOT when cwd is filesystem root', async () => {
+    const boxRoot = await mkdtemp(join(tmpdir(), 'omx-state-ops-omx-root-'));
+    try {
+      await withStateRootEnv({ OMX_ROOT: boxRoot }, async () => {
+        const writeResponse = await executeStateOperation('state_write', {
+          workingDirectory: '/',
+          session_id: 'sess-omx-root',
+          mode: 'autoresearch',
+          active: true,
+          current_phase: 'running',
+        });
+        const writePayload = responsePayload<{ path: string }>(writeResponse);
+        const expectedPath = join(boxRoot, '.omx', 'state', 'sessions', 'sess-omx-root', 'autoresearch-state.json');
+        assert.equal(writePayload.path, expectedPath);
+        assert.equal(existsSync(expectedPath), true);
+
+        const clearResponse = await executeStateOperation('state_clear', {
+          workingDirectory: '/',
+          session_id: 'sess-omx-root',
+          mode: 'autoresearch',
+        });
+        const clearPayload = responsePayload<{ path: string }>(clearResponse);
+        assert.equal(clearPayload.path, expectedPath);
+        assert.equal(existsSync(expectedPath), false);
+
+        const workspace = join(boxRoot, 'workspace');
+        await mkdir(workspace, { recursive: true });
+        const workspaceResponse = await executeStateOperation('state_write', {
+          workingDirectory: workspace,
+          session_id: 'sess-omx-root-workspace',
+          mode: 'autoresearch',
+          active: true,
+          current_phase: 'running',
+        });
+        const workspacePayload = responsePayload<{ path: string }>(workspaceResponse);
+        assert.equal(
+          workspacePayload.path,
+          join(boxRoot, '.omx', 'state', 'sessions', 'sess-omx-root-workspace', 'autoresearch-state.json'),
+        );
+        assert.equal(existsSync(join(workspace, '.omx')), false);
+      });
+    } finally {
+      await rm(boxRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('writes and clears session state under OMX_STATE_ROOT when cwd is filesystem root', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'omx-state-ops-state-root-'));
+    try {
+      await withStateRootEnv({ OMX_STATE_ROOT: stateRoot }, async () => {
+        const writeResponse = await executeStateOperation('state_write', {
+          workingDirectory: '/',
+          session_id: 'sess-state-root',
+          mode: 'autoresearch',
+          active: true,
+          current_phase: 'running',
+        });
+        const writePayload = responsePayload<{ path: string }>(writeResponse);
+        const expectedPath = join(stateRoot, '.omx', 'state', 'sessions', 'sess-state-root', 'autoresearch-state.json');
+        assert.equal(writePayload.path, expectedPath);
+        assert.equal(existsSync(expectedPath), true);
+
+        const clearResponse = await executeStateOperation('state_clear', {
+          workingDirectory: '/',
+          session_id: 'sess-state-root',
+          mode: 'autoresearch',
+        });
+        const clearPayload = responsePayload<{ path: string }>(clearResponse);
+        assert.equal(clearPayload.path, expectedPath);
+        assert.equal(existsSync(expectedPath), false);
+
+        const workspace = join(stateRoot, 'workspace');
+        await mkdir(workspace, { recursive: true });
+        const workspaceResponse = await executeStateOperation('state_write', {
+          workingDirectory: workspace,
+          session_id: 'sess-state-root-workspace',
+          mode: 'autoresearch',
+          active: true,
+          current_phase: 'running',
+        });
+        const workspacePayload = responsePayload<{ path: string }>(workspaceResponse);
+        assert.equal(
+          workspacePayload.path,
+          join(stateRoot, '.omx', 'state', 'sessions', 'sess-state-root-workspace', 'autoresearch-state.json'),
+        );
+        assert.equal(existsSync(join(workspace, '.omx')), false);
+      });
+    } finally {
+      await rm(stateRoot, { recursive: true, force: true });
     }
   });
 

--- a/src/state/__tests__/skill-active.test.ts
+++ b/src/state/__tests__/skill-active.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -16,6 +17,29 @@ async function withTempRepo(prefix: string, run: (cwd: string) => Promise<void>)
     await run(cwd);
   } finally {
     await rm(cwd, { recursive: true, force: true });
+  }
+}
+async function withStateRootEnv<T>(env: Partial<Record<'OMX_ROOT' | 'OMX_STATE_ROOT' | 'OMX_TEAM_STATE_ROOT', string>>, run: () => Promise<T>): Promise<T> {
+  const previousOmxRoot = process.env.OMX_ROOT;
+  const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+  const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+
+  if (typeof env.OMX_ROOT === 'string') process.env.OMX_ROOT = env.OMX_ROOT;
+  else delete process.env.OMX_ROOT;
+  if (typeof env.OMX_STATE_ROOT === 'string') process.env.OMX_STATE_ROOT = env.OMX_STATE_ROOT;
+  else delete process.env.OMX_STATE_ROOT;
+  if (typeof env.OMX_TEAM_STATE_ROOT === 'string') process.env.OMX_TEAM_STATE_ROOT = env.OMX_TEAM_STATE_ROOT;
+  else delete process.env.OMX_TEAM_STATE_ROOT;
+
+  try {
+    return await run();
+  } finally {
+    if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+    else delete process.env.OMX_ROOT;
+    if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+    else delete process.env.OMX_STATE_ROOT;
+    if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+    else delete process.env.OMX_TEAM_STATE_ROOT;
   }
 }
 
@@ -46,6 +70,35 @@ describe('skill-active state helpers', () => {
       assert.equal(entry.phase, 'running');
       assert.equal(entry.active, true);
       assert.equal(entry.session_id, 'sess-1');
+    });
+  });
+
+  it('uses OMX_TEAM_STATE_ROOT for default canonical sync without creating cwd .omx', async () => {
+    await withTempRepo('omx-skill-active-team-root-', async (root) => {
+      const cwd = join(root, 'workspace');
+      const teamStateRoot = join(root, 'team-state');
+      await mkdir(cwd, { recursive: true });
+
+      await withStateRootEnv({ OMX_TEAM_STATE_ROOT: teamStateRoot }, async () => {
+        await syncCanonicalSkillStateForMode({
+          cwd,
+          mode: 'ralph',
+          active: true,
+          currentPhase: 'executing',
+          sessionId: 'sess-team',
+          nowIso: '2026-07-05T00:00:00.000Z',
+        });
+      });
+
+      const sessionState = JSON.parse(
+        await readFile(join(teamStateRoot, 'sessions', 'sess-team', 'skill-active-state.json'), 'utf-8'),
+      ) as { active?: boolean; skill?: string; active_skills?: Array<{ skill: string; session_id?: string }> };
+      assert.equal(sessionState.active, true);
+      assert.equal(sessionState.skill, 'ralph');
+      assert.deepEqual(sessionState.active_skills?.map(({ skill, session_id }) => ({ skill, session_id })), [
+        { skill: 'ralph', session_id: 'sess-team' },
+      ]);
+      assert.equal(existsSync(join(cwd, '.omx')), false);
     });
   });
 

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -7,6 +7,7 @@ import {
   getAllScopedStatePaths,
   getAuthoritativeActiveStateDirs,
   getBaseStateDir,
+  getBaseStateDirWithSource,
   getReadScopedStateDirs,
   getReadScopedStatePaths,
   getStateDir,
@@ -16,6 +17,7 @@ import {
   resolveWorkingDirectoryForState,
   validateSessionId,
   validateStateModeSegment,
+  type StateRootSource,
 } from '../mcp/state-paths.js';
 import { evaluateRalphCompletionAuditEvidence } from '../ralph/completion-audit.js';
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
@@ -210,11 +212,16 @@ function validateStrictReadableMode(mode: unknown): string {
   return normalized;
 }
 
-async function initializeStateEnvironment(cwd: string, effectiveSessionId?: string): Promise<void> {
+async function initializeStateEnvironment(
+  cwd: string,
+  effectiveSessionId?: string,
+  rootSource?: StateRootSource,
+): Promise<void> {
   await mkdir(getStateDir(cwd), { recursive: true });
   if (effectiveSessionId) {
     await mkdir(getStateDir(cwd, effectiveSessionId), { recursive: true });
   }
+  if (rootSource === 'team-env') return;
   const { ensureTmuxHookInitialized } = await import('../cli/tmux-hook.js');
   await ensureTmuxHookInitialized(cwd);
 }
@@ -696,10 +703,10 @@ export async function executeStateOperation(
       case 'state_write': {
         const stateScope = await resolveStateScope(cwd, explicitSessionId);
         const effectiveSessionId = stateScope.sessionId;
-        await initializeStateEnvironment(cwd, effectiveSessionId);
+        const { baseStateDir, rootSource } = getBaseStateDirWithSource(cwd);
+        await initializeStateEnvironment(cwd, effectiveSessionId, rootSource);
 
         const mode = validateStateModeSegment(rawArgs.mode);
-        const baseStateDir = getBaseStateDir(cwd);
         const path = getStatePath(mode, cwd, effectiveSessionId);
         const {
           mode: _mode,
@@ -969,10 +976,10 @@ export async function executeStateOperation(
       case 'state_clear': {
         const stateScope = await resolveStateScope(cwd, explicitSessionId);
         const effectiveSessionId = stateScope.sessionId;
-        await initializeStateEnvironment(cwd, effectiveSessionId);
+        const { baseStateDir, rootSource } = getBaseStateDirWithSource(cwd);
+        await initializeStateEnvironment(cwd, effectiveSessionId, rootSource);
 
         const mode = validateStateModeSegment(rawArgs.mode);
-        const baseStateDir = getBaseStateDir(cwd);
         const allSessions = rawArgs.all_sessions === true;
 
         if (!allSessions) {

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'fs';
 import { mkdir, readFile, readdir, unlink, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
-import { omxStateDir } from '../utils/paths.js';
+import { getBaseStateDir } from '../mcp/state-paths.js';
 import { isTerminalRunOutcome, normalizeRunOutcome, normalizeTerminalLifecycleOutcome } from '../runtime/run-outcome.js';
 import {
   assertWorkflowTransitionAllowed,
@@ -259,7 +259,7 @@ export function getSkillActiveStatePaths(cwd: string, sessionId?: string): {
   rootPath: string;
   sessionPath?: string;
 } {
-  return getSkillActiveStatePathsForStateDir(omxStateDir(cwd), sessionId);
+  return getSkillActiveStatePathsForStateDir(getBaseStateDir(cwd), sessionId);
 }
 
 export function getSkillActiveStatePathsForStateDir(stateDir: string, sessionId?: string): {
@@ -358,7 +358,7 @@ export function tracksCanonicalWorkflowSkill(mode: string): mode is CanonicalWor
 export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkillStateOptions): Promise<void> {
   const {
     cwd,
-    baseStateDir = omxStateDir(cwd),
+    baseStateDir = getBaseStateDir(cwd),
     mode,
     active,
     currentPhase,


### PR DESCRIPTION
## Summary
- Treat `OMX_TEAM_STATE_ROOT` as the authoritative direct state directory from `src/mcp/state-paths.ts`.
- Preserve state root precedence: `OMX_TEAM_STATE_ROOT` > `OMX_ROOT/.omx/state` > `OMX_STATE_ROOT/.omx/state` > `cwd/.omx/state`.
- Avoid cwd `.omx` initialization side effects for `state_write`, `state_clear`, and canonical skill-active sync under direct team state roots.

Fixes #3059

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/state/__tests__/skill-active.test.js dist/state/__tests__/operations.test.js dist/mcp/__tests__/state-paths.test.js`
- `npm run check:no-unused`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
