### PR TITLE
Add mission queue runner MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ These are useful, but they are not the main onboarding path.
 
 ### Mission queue runner
 
-Use `omx mission` when you have a short checklist of OmX/Codex prompts that should run one after another instead of opening a separate shell command for each prompt. Start with `omx mission plan ./mission.md` or `omx mission ./mission.md --dry-run` to validate parsing and inspect the durable summary, then run `omx mission run ./mission.md -- --model gpt-5` when the prompts are ready. See [`docs/mission.md`](./docs/mission.md) for input format, status output, and artifact details.
+Use `omx mission` when you have a short checklist of OmX/Codex prompts that should run one after another instead of opening a separate shell command for each prompt. Start with `omx mission plan ./mission.md` or `omx mission ./mission.md --dry-run` to validate parsing and inspect the durable summary, then run `omx mission run ./mission.md -- --model gpt-5` when the prompts are ready. Interrupted runs can be inspected with `omx mission status ./mission.md`, continued with `omx mission resume ./mission.md`, and repaired task-by-task with `omx mission rerun ./mission.md --task task-002`. See [`docs/mission.md`](./docs/mission.md) for input format, status output, and artifact details.
 
 ### Team runtime
 

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ These are useful, but they are not the main onboarding path.
 
 ### Mission queue runner
 
-Use `omx mission` when you have a short checklist of OmX/Codex prompts that should run one after another instead of opening a separate shell command for each prompt. Start with `omx mission plan ./mission.md` or `omx mission ./mission.md --dry-run` to validate parsing and inspect the durable summary, then run `omx mission run ./mission.md -- --model gpt-5` when the prompts are ready. Interrupted runs can be inspected with `omx mission status ./mission.md`, continued with `omx mission resume ./mission.md`, and repaired task-by-task with `omx mission rerun ./mission.md --task task-002`. See [`docs/mission.md`](./docs/mission.md) for input format, status output, and artifact details.
+Use `omx mission` when you have a short checklist of OmX/Codex prompts that should run one after another instead of opening a separate shell command for each prompt. Start with `omx mission plan ./mission.md` or `omx mission ./mission.md --dry-run` to validate parsing and inspect the durable summary, then run `omx mission run ./mission.md -- --model gpt-5` when the prompts are ready. Interrupted runs can be inspected with `omx mission status ./mission.md`, continued with `omx mission resume ./mission.md`, operator-blocked with `omx mission mark ./mission.md --task task-002 --status blocked`, and repaired task-by-task with `omx mission rerun ./mission.md --task task-002`. See [`docs/mission.md`](./docs/mission.md) for input format, status output, and artifact details.
 
 ### Team runtime
 

--- a/README.md
+++ b/README.md
@@ -299,10 +299,15 @@ Inside an Ultragoal story, use `$team` only when that story benefits from coordi
 | `$team "..."` | coordinated parallel execution when the work is big enough |
 | `/skills` | browsing installed skills and supporting helpers |
 | `/goal ...` | durable objective/checkpoint structure for tasks that must reconcile progress across turns |
+| `omx mission <file>` | sequential prompt/checklist batch runs through `omx exec`, with `.omx/missions/<slug>/summary.json` and `ledger.jsonl` operator artifacts |
 
 ## Advanced / operator surfaces
 
 These are useful, but they are not the main onboarding path.
+
+### Mission queue runner
+
+Use `omx mission` when you have a short checklist of OmX/Codex prompts that should run one after another instead of opening a separate shell command for each prompt. Start with `omx mission plan ./mission.md` or `omx mission ./mission.md --dry-run` to validate parsing and inspect the durable summary, then run `omx mission run ./mission.md -- --model gpt-5` when the prompts are ready. See [`docs/mission.md`](./docs/mission.md) for input format, status output, and artifact details.
 
 ### Team runtime
 

--- a/docs/mission.md
+++ b/docs/mission.md
@@ -7,6 +7,9 @@
 ```sh
 omx mission ./mission.md --dry-run
 omx mission run ./mission.md --continue-on-error -- --model gpt-5
+omx mission status ./mission.md
+omx mission resume ./mission.md -- --model gpt-5
+omx mission rerun ./mission.md --task task-002
 ```
 
 ## Input format
@@ -26,6 +29,9 @@ Use one prompt per non-empty line. Markdown bullets, numbered lists, and task ch
 - Each task is passed to `omx exec` as its prompt. Arguments after `--` are forwarded to `codex exec` for every task.
 - The run stops on the first failed task unless `--continue-on-error` is set.
 - `omx mission plan <file>` or `--dry-run` validates parsing and writes the same durable summary without executing Codex.
+- `omx mission status <file|slug>` reads an existing `summary.json` and prints the current task states without executing anything.
+- `omx mission resume <file>` reads the existing summary for that mission, skips tasks already marked `passed`, treats stale `running` tasks as retryable, and continues the remaining tasks.
+- `omx mission rerun <file> --task <id>` reruns one specific task from the existing summary, including a previously failed or passed task.
 
 ## Artifacts
 

--- a/docs/mission.md
+++ b/docs/mission.md
@@ -9,6 +9,7 @@ omx mission ./mission.md --dry-run
 omx mission run ./mission.md --continue-on-error -- --model gpt-5
 omx mission status ./mission.md
 omx mission resume ./mission.md -- --model gpt-5
+omx mission mark ./mission.md --task task-002 --status blocked
 omx mission rerun ./mission.md --task task-002
 ```
 
@@ -29,9 +30,10 @@ Use one prompt per non-empty line. Markdown bullets, numbered lists, and task ch
 - Each task is passed to `omx exec` as its prompt. Arguments after `--` are forwarded to `codex exec` for every task.
 - The run stops on the first failed task unless `--continue-on-error` is set.
 - `omx mission plan <file>` or `--dry-run` validates parsing and writes the same durable summary without executing Codex.
-- `omx mission status <file|slug>` reads an existing `summary.json` and prints the current task states without executing anything.
-- `omx mission resume <file>` reads the existing summary for that mission, skips tasks already marked `passed`, treats stale `running` tasks as retryable, and continues the remaining tasks.
-- `omx mission rerun <file> --task <id>` reruns one specific task from the existing summary, including a previously failed or passed task.
+- `omx mission status <file|slug>` reads an existing `summary.json` and prints the current task states without executing anything. Status counts include `passed`, `failed`, `skipped`, `blocked`, `needs-human-review`, and `planned`.
+- `omx mission mark <file|slug> --task <id> --status <blocked|needs-human-review>` lets an operator preserve non-execution blockers in the durable summary without collapsing them into pass/fail/skipped.
+- `omx mission resume <file>` reads the existing summary for that mission, skips tasks already marked `passed`, leaves `blocked` and `needs-human-review` tasks untouched for operator follow-up, treats stale `running` tasks as retryable, and continues failed/skipped/planned/pending tasks. The command exits non-zero when blocked/review/failure states remain.
+- `omx mission rerun <file> --task <id>` reruns one specific task from the existing summary, including a previously failed, blocked, needs-human-review, or passed task. The command exits non-zero if the mission is still not fully passed afterward.
 
 ## Artifacts
 
@@ -39,5 +41,7 @@ Each run writes operator-readable state under `.omx/missions/<slug>/`:
 
 - `summary.json` — task list, per-task status, exit codes, counts, and forwarded Codex args.
 - `ledger.jsonl` — append-style lifecycle events for the mission and each task.
+
+Summary-level status is `running` while work is active, then `blocked` when any task is blocked, `needs-human-review` when any remaining task needs review, `failed` when any task failed, `passed` only when every task passed, and otherwise `planned`.
 
 Use `--summary <path>` to write `summary.json` somewhere else. The ledger still stays under `.omx/missions/<slug>/ledger.jsonl`.

--- a/docs/mission.md
+++ b/docs/mission.md
@@ -1,0 +1,37 @@
+# `omx mission`
+
+`omx mission` runs a simple prompt or checklist file as a sequential batch of `omx exec` tasks.
+
+## Usage
+
+```sh
+omx mission ./mission.md --dry-run
+omx mission run ./mission.md --continue-on-error -- --model gpt-5
+```
+
+## Input format
+
+Use one prompt per non-empty line. Markdown bullets, numbered lists, and task checkboxes are accepted; headings and HTML comments are ignored.
+
+```md
+# Release checklist
+- [ ] Audit the failing test output and identify the smallest fix.
+- [ ] Apply the fix and update focused tests.
+- [ ] Summarize verification evidence for the PR.
+```
+
+## Behavior
+
+- `omx mission <file>` and `omx mission run <file>` execute tasks in file order.
+- Each task is passed to `omx exec` as its prompt. Arguments after `--` are forwarded to `codex exec` for every task.
+- The run stops on the first failed task unless `--continue-on-error` is set.
+- `omx mission plan <file>` or `--dry-run` validates parsing and writes the same durable summary without executing Codex.
+
+## Artifacts
+
+Each run writes operator-readable state under `.omx/missions/<slug>/`:
+
+- `summary.json` — task list, per-task status, exit codes, counts, and forwarded Codex args.
+- `ledger.jsonl` — append-style lifecycle events for the mission and each task.
+
+Use `--summary <path>` to write `summary.json` somewhere else. The ledger still stays under `.omx/missions/<slug>/ledger.jsonl`.

--- a/src/cli/__tests__/mission.test.ts
+++ b/src/cli/__tests__/mission.test.ts
@@ -91,6 +91,86 @@ describe("omx mission", () => {
     });
   });
 
+  it("reports status from an existing summary by file or slug", async () => {
+    await withTempDir(async (cwd) => {
+      await writeFile(join(cwd, "mission.md"), "First\nSecond\n", "utf-8");
+      await missionCommand(["mission.md", "--dry-run", "--slug", "demo"], { cwd, stdout: () => undefined });
+
+      const byFile: string[] = [];
+      await missionCommand(["status", "mission.md", "--slug", "demo"], { cwd, stdout: (line) => byFile.push(line) });
+      assert.match(byFile.join("\n"), /mission status: demo \[planned\]/);
+      assert.match(byFile.join("\n"), /\[planned\] task-001 line 1: First/);
+
+      const bySlug: string[] = [];
+      await missionCommand(["status", "demo"], { cwd, stdout: (line) => bySlug.push(line) });
+      assert.match(bySlug.join("\n"), /summary: .*\.omx.*missions.*demo.*summary\.json/);
+    });
+  });
+
+  it("resumes durable summaries by skipping passed tasks and retrying stale running work", async () => {
+    await withTempDir(async (cwd) => {
+      await writeFile(join(cwd, "mission.md"), "First\nSecond\nThird\n", "utf-8");
+      await missionCommand(["run", "mission.md", "--slug", "demo", "--continue-on-error"], {
+        cwd,
+        stdout: () => undefined,
+        runTask: async (prompt) => prompt === "First" ? 0 : 9,
+      });
+      process.exitCode = undefined;
+
+      const summaryPath = join(cwd, ".omx", "missions", "demo", "summary.json");
+      const interrupted = JSON.parse(await readFile(summaryPath, "utf-8"));
+      interrupted.status = "running";
+      interrupted.completed_at = undefined;
+      interrupted.tasks[1].status = "running";
+      interrupted.tasks[1].completed_at = undefined;
+      await writeFile(summaryPath, `${JSON.stringify(interrupted, null, 2)}\n`, "utf-8");
+
+      const seen: string[] = [];
+      await missionCommand(["resume", "mission.md", "--slug", "demo", "--continue-on-error"], {
+        cwd,
+        stdout: () => undefined,
+        runTask: async (prompt) => {
+          seen.push(prompt);
+          return 0;
+        },
+      });
+
+      assert.deepEqual(seen, ["Second", "Third"]);
+      const resumed = JSON.parse(await readFile(summaryPath, "utf-8"));
+      assert.equal(resumed.status, "passed");
+      assert.deepEqual(resumed.tasks.map((task: { status: string }) => task.status), ["passed", "passed", "passed"]);
+      const ledger = await readFile(join(cwd, ".omx", "missions", "demo", "ledger.jsonl"), "utf-8");
+      assert.match(ledger, /mission_resumed/);
+    });
+  });
+
+  it("reruns one requested task from the existing summary", async () => {
+    await withTempDir(async (cwd) => {
+      await writeFile(join(cwd, "mission.md"), "First\nSecond\nThird\n", "utf-8");
+      await missionCommand(["run", "mission.md", "--slug", "demo", "--continue-on-error"], {
+        cwd,
+        stdout: () => undefined,
+        runTask: async (prompt) => prompt === "Second" ? 4 : 0,
+      });
+      process.exitCode = undefined;
+
+      const seen: string[] = [];
+      await missionCommand(["rerun", "mission.md", "--slug", "demo", "--task", "task-002"], {
+        cwd,
+        stdout: () => undefined,
+        runTask: async (prompt) => {
+          seen.push(prompt);
+          return 0;
+        },
+      });
+
+      assert.deepEqual(seen, ["Second"]);
+      const summary = JSON.parse(await readFile(join(cwd, ".omx", "missions", "demo", "summary.json"), "utf-8"));
+      assert.equal(summary.status, "passed");
+      assert.deepEqual(summary.tasks.map((task: { status: string }) => task.status), ["passed", "passed", "passed"]);
+    });
+  });
+
   it("documents mission in top-level help", () => {
     assert.match(HELP, /omx mission <file>/);
     assert.match(HELP, /prompt\/checklist file sequentially through omx exec/);

--- a/src/cli/__tests__/mission.test.ts
+++ b/src/cli/__tests__/mission.test.ts
@@ -1,0 +1,98 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HELP } from "../index.js";
+import { missionCommand, parseMissionTasks } from "../mission.js";
+
+async function withTempDir<T>(run: (cwd: string) => Promise<T>): Promise<T> {
+  const cwd = await mkdtemp(join(tmpdir(), "omx-mission-"));
+  try {
+    return await run(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+describe("omx mission", () => {
+  it("parses simple prompt lists and markdown checklists", () => {
+    const tasks = parseMissionTasks([
+      "# Mission",
+      "",
+      "- [ ] Inspect the failure",
+      "- [x] Keep the passing behavior",
+      "1. Write focused tests",
+      "<!-- comment -->",
+      "Plain prompt",
+    ].join("\n"));
+
+    assert.deepEqual(tasks.map((task) => [task.id, task.source_line, task.prompt]), [
+      ["task-001", 3, "Inspect the failure"],
+      ["task-002", 4, "Keep the passing behavior"],
+      ["task-003", 5, "Write focused tests"],
+      ["task-004", 7, "Plain prompt"],
+    ]);
+  });
+
+  it("writes a dry-run summary and ledger without executing tasks", async () => {
+    await withTempDir(async (cwd) => {
+      await writeFile(join(cwd, "mission.md"), "- [ ] First prompt\n- [ ] Second prompt\n", "utf-8");
+      const out: string[] = [];
+      let runCount = 0;
+
+      await missionCommand(["mission.md", "--dry-run", "--slug", "demo"], {
+        cwd,
+        now: () => new Date("2026-07-06T00:00:00.000Z"),
+        stdout: (line) => out.push(line),
+        runTask: async () => {
+          runCount += 1;
+          return 0;
+        },
+      });
+
+      assert.equal(runCount, 0);
+      assert.match(out.join("\n"), /mission planned: demo \(2 tasks\)/);
+      const summary = JSON.parse(await readFile(join(cwd, ".omx", "missions", "demo", "summary.json"), "utf-8"));
+      assert.equal(summary.status, "planned");
+      assert.equal(summary.counts.total, 2);
+      assert.equal(summary.counts.planned, 2);
+      assert.deepEqual(summary.tasks.map((task: { status: string }) => task.status), ["planned", "planned"]);
+      const ledger = await readFile(join(cwd, ".omx", "missions", "demo", "ledger.jsonl"), "utf-8");
+      assert.match(ledger, /mission_planned/);
+    });
+  });
+
+  it("runs tasks sequentially, records failures, and skips remaining tasks by default", async () => {
+    await withTempDir(async (cwd) => {
+      await writeFile(join(cwd, "mission.md"), "First\nSecond\nThird\n", "utf-8");
+      const seen: Array<{ prompt: string; args: string[] }> = [];
+      const exits = [0, 7];
+
+      await missionCommand(["run", "mission.md", "--slug", "demo", "--", "--model", "gpt-5"], {
+        cwd,
+        stdout: () => undefined,
+        runTask: async (prompt, args) => {
+          seen.push({ prompt, args });
+          return exits.shift() ?? 0;
+        },
+      });
+
+      assert.deepEqual(seen, [
+        { prompt: "First", args: ["--model", "gpt-5"] },
+        { prompt: "Second", args: ["--model", "gpt-5"] },
+      ]);
+      const summary = JSON.parse(await readFile(join(cwd, ".omx", "missions", "demo", "summary.json"), "utf-8"));
+      assert.equal(summary.status, "failed");
+      assert.deepEqual(summary.tasks.map((task: { status: string }) => task.status), ["passed", "failed", "skipped"]);
+      assert.equal(summary.counts.failed, 1);
+      assert.equal(summary.counts.skipped, 1);
+      process.exitCode = undefined;
+    });
+  });
+
+  it("documents mission in top-level help", () => {
+    assert.match(HELP, /omx mission <file>/);
+    assert.match(HELP, /prompt\/checklist file sequentially through omx exec/);
+  });
+});

--- a/src/cli/__tests__/mission.test.ts
+++ b/src/cli/__tests__/mission.test.ts
@@ -171,6 +171,78 @@ describe("omx mission", () => {
     });
   });
 
+  it("marks blocked and needs-human-review tasks in status counts", async () => {
+    await withTempDir(async (cwd) => {
+      await writeFile(join(cwd, "mission.md"), "First\nSecond\nThird\n", "utf-8");
+      await missionCommand(["run", "mission.md", "--slug", "demo"], {
+        cwd,
+        stdout: () => undefined,
+        runTask: async () => 0,
+      });
+
+      await missionCommand(["mark", "demo", "--task", "task-002", "--status", "blocked"], { cwd, stdout: () => undefined });
+      await missionCommand(["mark", "demo", "--task", "task-003", "--status", "needs-human-review"], { cwd, stdout: () => undefined });
+
+      const out: string[] = [];
+      await missionCommand(["status", "demo"], { cwd, stdout: (line) => out.push(line) });
+      const status = out.join("\n");
+      assert.match(status, /mission status: demo \[blocked\]/);
+      assert.match(status, /1\/3 passed, 0 failed, 0 skipped, 1 blocked, 1 needs-human-review, 0 planned/);
+      assert.match(status, /\[blocked\] task-002 line 2: Second/);
+      assert.match(status, /\[needs-human-review\] task-003 line 3: Third/);
+
+      const summary = JSON.parse(await readFile(join(cwd, ".omx", "missions", "demo", "summary.json"), "utf-8"));
+      assert.equal(summary.status, "blocked");
+      assert.equal(summary.counts.blocked, 1);
+      assert.equal(summary.counts["needs-human-review"], 1);
+      const ledger = await readFile(join(cwd, ".omx", "missions", "demo", "ledger.jsonl"), "utf-8");
+      assert.match(ledger, /task_marked/);
+    });
+  });
+
+  it("leaves operator-marked tasks on resume and allows explicit rerun", async () => {
+    await withTempDir(async (cwd) => {
+      await writeFile(join(cwd, "mission.md"), "First\nSecond\nThird\n", "utf-8");
+      await missionCommand(["run", "mission.md", "--slug", "demo"], {
+        cwd,
+        stdout: () => undefined,
+        runTask: async () => 0,
+      });
+      await missionCommand(["mark", "mission.md", "--slug", "demo", "--task", "task-002", "--status", "blocked"], { cwd, stdout: () => undefined });
+      await missionCommand(["mark", "mission.md", "--slug", "demo", "--task", "task-003", "--status", "needs-human-review"], { cwd, stdout: () => undefined });
+
+      const resumedPrompts: string[] = [];
+      await missionCommand(["resume", "mission.md", "--slug", "demo"], {
+        cwd,
+        stdout: () => undefined,
+        runTask: async (prompt) => {
+          resumedPrompts.push(prompt);
+          return 0;
+        },
+      });
+      assert.deepEqual(resumedPrompts, []);
+      assert.equal(process.exitCode, 1);
+      process.exitCode = undefined;
+
+      const rerunPrompts: string[] = [];
+      await missionCommand(["rerun", "mission.md", "--slug", "demo", "--task", "task-002"], {
+        cwd,
+        stdout: () => undefined,
+        runTask: async (prompt) => {
+          rerunPrompts.push(prompt);
+          return 0;
+        },
+      });
+      assert.deepEqual(rerunPrompts, ["Second"]);
+
+      const summary = JSON.parse(await readFile(join(cwd, ".omx", "missions", "demo", "summary.json"), "utf-8"));
+      assert.equal(summary.status, "needs-human-review");
+      assert.deepEqual(summary.tasks.map((task: { status: string }) => task.status), ["passed", "passed", "needs-human-review"]);
+      assert.equal(process.exitCode, 1);
+      process.exitCode = undefined;
+    });
+  });
+
   it("documents mission in top-level help", () => {
     assert.match(HELP, /omx mission <file>/);
     assert.match(HELP, /prompt\/checklist file sequentially through omx exec/);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -53,6 +53,7 @@ import { mcpServeCommand } from "./mcp-serve.js";
 import { adaptCommand } from "./adapt.js";
 import { listCommand } from "./list.js";
 import { authCommand } from "./auth.js";
+import { missionCommand } from "./mission.js";
 import { runAuthHotswap } from "../auth/hotswap.js";
 import {
   MADMAX_FLAG,
@@ -216,6 +217,8 @@ Usage:
   omx exec      Run codex exec non-interactively with OMX AGENTS/overlay injection
   omx exec inject <session-id> --prompt <text>
                 Queue audited follow-up instructions for a running non-interactive exec job
+  omx mission <file>
+                Run a prompt/checklist file sequentially through omx exec with durable summary
   omx imagegen continuation <session-id> --artifact <name>
                 Queue a Stop-hook continuation for built-in image generation turns
   omx setup     Install skills, prompts, CLI-first config, and scope-specific AGENTS.md
@@ -380,6 +383,7 @@ const TMUX_EXTENDED_KEYS_LOCK_STALE_MS = 30_000;
 type CliCommand =
   | "launch"
   | "exec"
+  | "mission"
   | "imagegen"
   | "setup"
   | "update"
@@ -433,6 +437,7 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "agents-init",
   "deepinit",
   "exec",
+  "mission",
   "imagegen",
   "hooks",
   "list",
@@ -2573,6 +2578,7 @@ export async function main(args: string[]): Promise<void> {
   const knownCommands = new Set([
     "launch",
     "exec",
+    "mission",
     "imagegen",
     "setup",
     "update",
@@ -2714,6 +2720,18 @@ export async function main(args: string[]): Promise<void> {
         } else {
           await execWithOverlay(launchArgs);
         }
+        break;
+      case "mission":
+        await missionCommand(args.slice(1), {
+          runTask: async (prompt, codexArgs) => {
+            const priorExitCode = process.exitCode;
+            process.exitCode = undefined;
+            await execWithOverlay([...codexArgs, prompt]);
+            const exitCode = typeof process.exitCode === "number" ? process.exitCode : 0;
+            process.exitCode = priorExitCode;
+            return exitCode;
+          },
+        });
         break;
       case "imagegen":
         await imagegenCommand(args.slice(1));

--- a/src/cli/mission.ts
+++ b/src/cli/mission.ts
@@ -8,6 +8,9 @@ Usage:
   omx mission <file> [--dry-run] [--continue-on-error] [--summary <path>] [--slug <name>] [--json] [-- <codex exec args...>]
   omx mission run <file> [options]
   omx mission plan <file> [--json]
+  omx mission status <file|slug> [--json] [--summary <path>]
+  omx mission resume <file> [--continue-on-error] [--summary <path>] [--json] [-- <codex exec args...>]
+  omx mission rerun <file> --task <id> [--summary <path>] [--json] [-- <codex exec args...>]
 
 Input format:
   - One task per non-empty line
@@ -20,10 +23,13 @@ Artifacts:
 
 Examples:
   omx mission ./mission.md --dry-run
-  omx mission run ./prompts.txt --continue-on-error -- --model gpt-5
+  omx mission status ./mission.md
+  omx mission resume ./mission.md -- --model gpt-5
+  omx mission rerun ./mission.md --task task-002
 `;
 
 type MissionTaskStatus = "pending" | "planned" | "running" | "passed" | "failed" | "skipped";
+type MissionAction = "run" | "plan" | "status" | "resume" | "rerun";
 
 export interface MissionTask {
   id: string;
@@ -59,13 +65,23 @@ export interface MissionCommandOptions {
 }
 
 interface ParsedMissionArgs {
+  action: MissionAction;
   file: string;
   dryRun: boolean;
   continueOnError: boolean;
   json: boolean;
   slug?: string;
   summaryPath?: string;
+  taskId?: string;
   codexArgs: string[];
+}
+
+interface MissionPaths {
+  inputPath: string;
+  slug: string;
+  missionRoot: string;
+  summaryPath: string;
+  ledgerPath: string;
 }
 
 class MissionCommandError extends Error {}
@@ -122,27 +138,38 @@ function parseMissionArgs(args: string[]): ParsedMissionArgs {
   if (command === "help" || command === "--help" || command === "-h") {
     throw new MissionCommandError(MISSION_HELP);
   }
+
+  let action: MissionAction = "run";
   if (command === "run") rest = rest.slice(1);
-  else if (command === "plan") rest = ["--dry-run", ...rest.slice(1)];
+  else if (command === "plan") {
+    action = "plan";
+    rest = rest.slice(1);
+  } else if (command === "status" || command === "resume" || command === "rerun") {
+    action = command;
+    rest = rest.slice(1);
+  }
 
   const separator = rest.indexOf("--");
   const commandArgs = separator >= 0 ? rest.slice(0, separator) : rest;
   const codexArgs = separator >= 0 ? rest.slice(separator + 1) : [];
 
   let file: string | undefined;
-  let dryRun = false;
+  let dryRun = action === "plan";
   let continueOnError = false;
   let json = false;
   let slug: string | undefined;
   let summaryPath: string | undefined;
+  let taskId: string | undefined;
 
   for (let index = 0; index < commandArgs.length; index += 1) {
     const arg = commandArgs[index] ?? "";
     if (arg === "--dry-run") {
+      if (action !== "run") throw new MissionCommandError(`--dry-run is only supported for mission run/plan.`);
       dryRun = true;
       continue;
     }
     if (arg === "--continue-on-error") {
+      if (action === "status") throw new MissionCommandError(`--continue-on-error is not supported for mission status.`);
       continueOnError = true;
       continue;
     }
@@ -168,6 +195,15 @@ function parseMissionArgs(args: string[]): ParsedMissionArgs {
       index += 1;
       continue;
     }
+    if (arg.startsWith("--task=")) {
+      taskId = arg.slice("--task=".length);
+      continue;
+    }
+    if (arg === "--task") {
+      taskId = readValue(commandArgs, index, arg);
+      index += 1;
+      continue;
+    }
     if (arg.startsWith("--")) throw new MissionCommandError(`Unknown mission option: ${arg}`);
     if (!file) {
       file = arg;
@@ -177,7 +213,9 @@ function parseMissionArgs(args: string[]): ParsedMissionArgs {
   }
 
   if (!file) throw new MissionCommandError(`Missing mission input file.\n\n${MISSION_HELP}`);
-  return { file, dryRun, continueOnError, json, slug, summaryPath, codexArgs };
+  if (action !== "rerun" && taskId) throw new MissionCommandError(`--task is only supported for mission rerun.`);
+  if (action === "rerun" && !taskId) throw new MissionCommandError(`mission rerun requires --task <id>.`);
+  return { action, file, dryRun, continueOnError, json, slug, summaryPath, taskId, codexArgs };
 }
 
 function missionCounts(tasks: MissionTask[]): MissionSummary["counts"] {
@@ -188,6 +226,13 @@ function missionCounts(tasks: MissionTask[]): MissionSummary["counts"] {
     failed: tasks.filter((task) => task.status === "failed").length,
     skipped: tasks.filter((task) => task.status === "skipped").length,
   };
+}
+
+function missionStatus(tasks: MissionTask[]): MissionSummary["status"] {
+  if (tasks.some((task) => task.status === "running")) return "running";
+  if (tasks.some((task) => task.status === "failed")) return "failed";
+  if (tasks.length > 0 && tasks.every((task) => task.status === "passed")) return "passed";
+  return "planned";
 }
 
 async function persistSummary(summaryPath: string, summary: MissionSummary): Promise<void> {
@@ -201,6 +246,90 @@ async function appendLedger(ledgerPath: string, event: Record<string, unknown>):
   await writeFile(ledgerPath, `${existing}${JSON.stringify(event)}\n`, "utf-8");
 }
 
+function resolveMissionPaths(cwd: string, parsed: ParsedMissionArgs): MissionPaths {
+  const looksLikePath = parsed.file.includes("/") || parsed.file.includes("\\") || parsed.file.endsWith(".md") || parsed.file.endsWith(".txt");
+  const inputPath = isAbsolute(parsed.file) ? parsed.file : resolve(cwd, parsed.file);
+  const baseSlug = parsed.slug ?? (parsed.action === "status" && !looksLikePath ? parsed.file : slugify(basename(inputPath, extname(inputPath))));
+  const slug = slugify(baseSlug);
+  const missionRoot = join(omxRoot(cwd), "missions", slug);
+  const summaryPath = parsed.summaryPath
+    ? (isAbsolute(parsed.summaryPath) ? parsed.summaryPath : resolve(cwd, parsed.summaryPath))
+    : join(missionRoot, "summary.json");
+  const ledgerPath = join(missionRoot, "ledger.jsonl");
+  return { inputPath, slug, missionRoot, summaryPath, ledgerPath };
+}
+
+async function readSummary(summaryPath: string): Promise<MissionSummary> {
+  let raw: string;
+  try {
+    raw = await readFile(summaryPath, "utf-8");
+  } catch {
+    throw new MissionCommandError(`No mission summary found at ${summaryPath}.`);
+  }
+  const summary = JSON.parse(raw) as MissionSummary;
+  if (summary.version !== 1 || !Array.isArray(summary.tasks)) {
+    throw new MissionCommandError(`Invalid mission summary at ${summaryPath}.`);
+  }
+  return summary;
+}
+
+function syncSummary(summary: MissionSummary, updates: Partial<Pick<MissionSummary, "status" | "dry_run" | "continue_on_error" | "codex_args">>): void {
+  Object.assign(summary, updates);
+  summary.counts = missionCounts(summary.tasks);
+}
+
+async function runSelectedTasks(
+  summary: MissionSummary,
+  paths: MissionPaths,
+  parsed: ParsedMissionArgs,
+  now: () => Date,
+  stdout: (line: string) => void,
+  runTask: (prompt: string, codexArgs: string[]) => Promise<number>,
+  shouldRun: (task: MissionTask) => boolean,
+): Promise<void> {
+  let failed = false;
+  for (const task of summary.tasks) {
+    if (!shouldRun(task)) continue;
+    if (failed && !parsed.continueOnError) {
+      task.status = "skipped";
+      delete task.started_at;
+      delete task.completed_at;
+      delete task.exit_code;
+      continue;
+    }
+
+    task.status = "running";
+    task.started_at = now().toISOString();
+    delete task.completed_at;
+    delete task.exit_code;
+    syncSummary(summary, { status: "running" });
+    await persistSummary(paths.summaryPath, summary);
+    await appendLedger(paths.ledgerPath, { event: "task_started", at: task.started_at, slug: summary.slug, task_id: task.id, index: task.index, prompt: task.prompt });
+    stdout(`[running] ${task.id}/${summary.tasks.length}: ${task.prompt}`);
+
+    const exitCode = await runTask(task.prompt, parsed.codexArgs);
+    task.exit_code = exitCode;
+    task.completed_at = now().toISOString();
+    task.status = exitCode === 0 ? "passed" : "failed";
+    if (exitCode !== 0) failed = true;
+    syncSummary(summary, { status: missionStatus(summary.tasks) });
+    await persistSummary(paths.summaryPath, summary);
+    await appendLedger(paths.ledgerPath, { event: "task_completed", at: task.completed_at, slug: summary.slug, task_id: task.id, status: task.status, exit_code: exitCode });
+    stdout(`[${task.status}] ${task.id}/${summary.tasks.length}: exit ${exitCode}`);
+  }
+}
+
+function printStatus(summary: MissionSummary, summaryPath: string, json: boolean, stdout: (line: string) => void): void {
+  if (json) {
+    stdout(JSON.stringify({ ok: summary.status === "passed", summary_path: summaryPath, summary }, null, 2));
+    return;
+  }
+  stdout(`mission status: ${summary.slug} [${summary.status}]`);
+  stdout(`tasks: ${summary.counts.passed}/${summary.counts.total} passed, ${summary.counts.failed} failed, ${summary.counts.skipped} skipped, ${summary.counts.planned} planned`);
+  for (const task of summary.tasks) stdout(`[${task.status}] ${task.id} line ${task.source_line}: ${task.prompt}`);
+  stdout(`summary: ${summaryPath}`);
+}
+
 export async function missionCommand(args: string[], options: MissionCommandOptions = {}): Promise<void> {
   const cwd = options.cwd ?? process.cwd();
   const now = options.now ?? (() => new Date());
@@ -209,23 +338,64 @@ export async function missionCommand(args: string[], options: MissionCommandOpti
 
   try {
     const parsed = parseMissionArgs(args);
-    const inputPath = isAbsolute(parsed.file) ? parsed.file : resolve(cwd, parsed.file);
-    const input = await readFile(inputPath, "utf-8");
+    const paths = resolveMissionPaths(cwd, parsed);
+
+    if (parsed.action === "status") {
+      const summary = await readSummary(paths.summaryPath);
+      syncSummary(summary, { status: missionStatus(summary.tasks) });
+      printStatus(summary, paths.summaryPath, parsed.json, stdout);
+      return;
+    }
+
+    if (parsed.action === "resume" || parsed.action === "rerun") {
+      const summary = await readSummary(paths.summaryPath);
+      const runTask = options.runTask;
+      if (!runTask) throw new MissionCommandError("Mission execution requires a task runner; use status for read-only inspection.");
+      if (parsed.action === "rerun" && !summary.tasks.some((task) => task.id === parsed.taskId)) {
+        throw new MissionCommandError(`No mission task found for --task ${parsed.taskId}.`);
+      }
+
+      summary.input_path = paths.inputPath;
+      summary.dry_run = false;
+      summary.continue_on_error = parsed.continueOnError;
+      summary.codex_args = parsed.codexArgs;
+      summary.status = "running";
+      delete summary.completed_at;
+      for (const task of summary.tasks) {
+        if (task.status === "running") task.status = "pending";
+      }
+      syncSummary(summary, { status: "running" });
+      await persistSummary(paths.summaryPath, summary);
+      await appendLedger(paths.ledgerPath, { event: parsed.action === "resume" ? "mission_resumed" : "mission_rerun_started", at: now().toISOString(), slug: summary.slug, summary_path: paths.summaryPath, task_id: parsed.taskId });
+
+      const shouldRun = parsed.action === "resume"
+        ? (task: MissionTask) => task.status !== "passed"
+        : (task: MissionTask) => task.id === parsed.taskId;
+      await runSelectedTasks(summary, paths, parsed, now, stdout, runTask, shouldRun);
+      summary.status = missionStatus(summary.tasks);
+      summary.completed_at = now().toISOString();
+      summary.counts = missionCounts(summary.tasks);
+      await persistSummary(paths.summaryPath, summary);
+      await appendLedger(paths.ledgerPath, { event: "mission_completed", at: summary.completed_at, slug: summary.slug, status: summary.status, counts: summary.counts });
+      if (parsed.json) stdout(JSON.stringify({ ok: summary.status === "passed", summary_path: paths.summaryPath, ledger_path: paths.ledgerPath, summary }, null, 2));
+      else {
+        stdout(`mission ${parsed.action} ${summary.status}: ${summary.slug}`);
+        stdout(`summary: ${paths.summaryPath}`);
+        stdout(`ledger: ${paths.ledgerPath}`);
+      }
+      if (summary.status === "failed") process.exitCode = 1;
+      return;
+    }
+
+    const input = await readFile(paths.inputPath, "utf-8");
     const tasks = parseMissionTasks(input);
     if (tasks.length === 0) throw new MissionCommandError(`No runnable mission tasks found in ${parsed.file}.`);
 
-    const baseSlug = parsed.slug ?? slugify(basename(inputPath, extname(inputPath)));
-    const slug = slugify(baseSlug);
-    const missionRoot = join(omxRoot(cwd), "missions", slug);
-    const summaryPath = parsed.summaryPath
-      ? (isAbsolute(parsed.summaryPath) ? parsed.summaryPath : resolve(cwd, parsed.summaryPath))
-      : join(missionRoot, "summary.json");
-    const ledgerPath = join(missionRoot, "ledger.jsonl");
     const startedAt = now().toISOString();
     const summary: MissionSummary = {
       version: 1,
-      slug,
-      input_path: inputPath,
+      slug: paths.slug,
+      input_path: paths.inputPath,
       dry_run: parsed.dryRun,
       continue_on_error: parsed.continueOnError,
       started_at: startedAt,
@@ -239,14 +409,14 @@ export async function missionCommand(args: string[], options: MissionCommandOpti
       for (const task of summary.tasks) task.status = "planned";
       summary.counts = missionCounts(summary.tasks);
       summary.completed_at = now().toISOString();
-      await persistSummary(summaryPath, summary);
-      await appendLedger(ledgerPath, { event: "mission_planned", at: summary.completed_at, slug, total: tasks.length, summary_path: summaryPath });
-      if (parsed.json) stdout(JSON.stringify({ ok: true, summary_path: summaryPath, ledger_path: ledgerPath, summary }, null, 2));
+      await persistSummary(paths.summaryPath, summary);
+      await appendLedger(paths.ledgerPath, { event: "mission_planned", at: summary.completed_at, slug: paths.slug, total: tasks.length, summary_path: paths.summaryPath });
+      if (parsed.json) stdout(JSON.stringify({ ok: true, summary_path: paths.summaryPath, ledger_path: paths.ledgerPath, summary }, null, 2));
       else {
-        stdout(`mission planned: ${slug} (${tasks.length} tasks)`);
+        stdout(`mission planned: ${paths.slug} (${tasks.length} tasks)`);
         for (const task of summary.tasks) stdout(`[planned] ${task.id} line ${task.source_line}: ${task.prompt}`);
-        stdout(`summary: ${summaryPath}`);
-        stdout(`ledger: ${ledgerPath}`);
+        stdout(`summary: ${paths.summaryPath}`);
+        stdout(`ledger: ${paths.ledgerPath}`);
       }
       return;
     }
@@ -254,44 +424,21 @@ export async function missionCommand(args: string[], options: MissionCommandOpti
     const runTask = options.runTask;
     if (!runTask) throw new MissionCommandError("Mission execution requires a task runner; use --dry-run for parser/plan validation.");
 
-    await persistSummary(summaryPath, summary);
-    await appendLedger(ledgerPath, { event: "mission_started", at: startedAt, slug, total: tasks.length, summary_path: summaryPath });
+    await persistSummary(paths.summaryPath, summary);
+    await appendLedger(paths.ledgerPath, { event: "mission_started", at: startedAt, slug: paths.slug, total: tasks.length, summary_path: paths.summaryPath });
+    await runSelectedTasks(summary, paths, parsed, now, stdout, runTask, () => true);
 
-    let failed = false;
-    for (const task of summary.tasks) {
-      if (failed && !parsed.continueOnError) {
-        task.status = "skipped";
-        continue;
-      }
-      task.status = "running";
-      task.started_at = now().toISOString();
-      summary.counts = missionCounts(summary.tasks);
-      await persistSummary(summaryPath, summary);
-      await appendLedger(ledgerPath, { event: "task_started", at: task.started_at, slug, task_id: task.id, index: task.index, prompt: task.prompt });
-      stdout(`[running] ${task.id}/${summary.tasks.length}: ${task.prompt}`);
-
-      const exitCode = await runTask(task.prompt, parsed.codexArgs);
-      task.exit_code = exitCode;
-      task.completed_at = now().toISOString();
-      task.status = exitCode === 0 ? "passed" : "failed";
-      if (exitCode !== 0) failed = true;
-      summary.counts = missionCounts(summary.tasks);
-      await persistSummary(summaryPath, summary);
-      await appendLedger(ledgerPath, { event: "task_completed", at: task.completed_at, slug, task_id: task.id, status: task.status, exit_code: exitCode });
-      stdout(`[${task.status}] ${task.id}/${summary.tasks.length}: exit ${exitCode}`);
-    }
-
-    summary.status = summary.tasks.some((task) => task.status === "failed") ? "failed" : "passed";
+    summary.status = missionStatus(summary.tasks);
     summary.completed_at = now().toISOString();
     summary.counts = missionCounts(summary.tasks);
-    await persistSummary(summaryPath, summary);
-    await appendLedger(ledgerPath, { event: "mission_completed", at: summary.completed_at, slug, status: summary.status, counts: summary.counts });
+    await persistSummary(paths.summaryPath, summary);
+    await appendLedger(paths.ledgerPath, { event: "mission_completed", at: summary.completed_at, slug: paths.slug, status: summary.status, counts: summary.counts });
 
-    if (parsed.json) stdout(JSON.stringify({ ok: summary.status === "passed", summary_path: summaryPath, ledger_path: ledgerPath, summary }, null, 2));
+    if (parsed.json) stdout(JSON.stringify({ ok: summary.status === "passed", summary_path: paths.summaryPath, ledger_path: paths.ledgerPath, summary }, null, 2));
     else {
-      stdout(`mission ${summary.status}: ${slug}`);
-      stdout(`summary: ${summaryPath}`);
-      stdout(`ledger: ${ledgerPath}`);
+      stdout(`mission ${summary.status}: ${paths.slug}`);
+      stdout(`summary: ${paths.summaryPath}`);
+      stdout(`ledger: ${paths.ledgerPath}`);
     }
     if (summary.status === "failed") process.exitCode = 1;
   } catch (error) {

--- a/src/cli/mission.ts
+++ b/src/cli/mission.ts
@@ -9,6 +9,7 @@ Usage:
   omx mission run <file> [options]
   omx mission plan <file> [--json]
   omx mission status <file|slug> [--json] [--summary <path>]
+  omx mission mark <file|slug> --task <id> --status <blocked|needs-human-review> [--json] [--summary <path>]
   omx mission resume <file> [--continue-on-error] [--summary <path>] [--json] [-- <codex exec args...>]
   omx mission rerun <file> --task <id> [--summary <path>] [--json] [-- <codex exec args...>]
 
@@ -25,11 +26,12 @@ Examples:
   omx mission ./mission.md --dry-run
   omx mission status ./mission.md
   omx mission resume ./mission.md -- --model gpt-5
+  omx mission mark ./mission.md --task task-002 --status needs-human-review
   omx mission rerun ./mission.md --task task-002
 `;
 
-type MissionTaskStatus = "pending" | "planned" | "running" | "passed" | "failed" | "skipped";
-type MissionAction = "run" | "plan" | "status" | "resume" | "rerun";
+type MissionTaskStatus = "pending" | "planned" | "running" | "passed" | "failed" | "skipped" | "blocked" | "needs-human-review";
+type MissionAction = "run" | "plan" | "status" | "mark" | "resume" | "rerun";
 
 export interface MissionTask {
   id: string;
@@ -50,8 +52,8 @@ export interface MissionSummary {
   continue_on_error: boolean;
   started_at: string;
   completed_at?: string;
-  status: "planned" | "running" | "passed" | "failed";
-  counts: Record<"total" | "planned" | "passed" | "failed" | "skipped", number>;
+  status: "planned" | "running" | "passed" | "failed" | "blocked" | "needs-human-review";
+  counts: Record<"total" | "planned" | "passed" | "failed" | "skipped" | "blocked" | "needs-human-review", number>;
   codex_args: string[];
   tasks: MissionTask[];
 }
@@ -73,6 +75,7 @@ interface ParsedMissionArgs {
   slug?: string;
   summaryPath?: string;
   taskId?: string;
+  markStatus?: Extract<MissionTaskStatus, "blocked" | "needs-human-review">;
   codexArgs: string[];
 }
 
@@ -144,7 +147,7 @@ function parseMissionArgs(args: string[]): ParsedMissionArgs {
   else if (command === "plan") {
     action = "plan";
     rest = rest.slice(1);
-  } else if (command === "status" || command === "resume" || command === "rerun") {
+  } else if (command === "status" || command === "mark" || command === "resume" || command === "rerun") {
     action = command;
     rest = rest.slice(1);
   }
@@ -160,6 +163,7 @@ function parseMissionArgs(args: string[]): ParsedMissionArgs {
   let slug: string | undefined;
   let summaryPath: string | undefined;
   let taskId: string | undefined;
+  let markStatus: Extract<MissionTaskStatus, "blocked" | "needs-human-review"> | undefined;
 
   for (let index = 0; index < commandArgs.length; index += 1) {
     const arg = commandArgs[index] ?? "";
@@ -204,6 +208,19 @@ function parseMissionArgs(args: string[]): ParsedMissionArgs {
       index += 1;
       continue;
     }
+    if (arg.startsWith("--status=")) {
+      const value = arg.slice("--status=".length);
+      if (value !== "blocked" && value !== "needs-human-review") throw new MissionCommandError(`Unsupported mission mark status: ${value}`);
+      markStatus = value;
+      continue;
+    }
+    if (arg === "--status") {
+      const value = readValue(commandArgs, index, arg);
+      if (value !== "blocked" && value !== "needs-human-review") throw new MissionCommandError(`Unsupported mission mark status: ${value}`);
+      markStatus = value;
+      index += 1;
+      continue;
+    }
     if (arg.startsWith("--")) throw new MissionCommandError(`Unknown mission option: ${arg}`);
     if (!file) {
       file = arg;
@@ -213,9 +230,11 @@ function parseMissionArgs(args: string[]): ParsedMissionArgs {
   }
 
   if (!file) throw new MissionCommandError(`Missing mission input file.\n\n${MISSION_HELP}`);
-  if (action !== "rerun" && taskId) throw new MissionCommandError(`--task is only supported for mission rerun.`);
+  if (action !== "rerun" && action !== "mark" && taskId) throw new MissionCommandError(`--task is only supported for mission mark/rerun.`);
   if (action === "rerun" && !taskId) throw new MissionCommandError(`mission rerun requires --task <id>.`);
-  return { action, file, dryRun, continueOnError, json, slug, summaryPath, taskId, codexArgs };
+  if (action !== "mark" && markStatus) throw new MissionCommandError(`--status is only supported for mission mark.`);
+  if (action === "mark" && (!taskId || !markStatus)) throw new MissionCommandError(`mission mark requires --task <id> --status <blocked|needs-human-review>.`);
+  return { action, file, dryRun, continueOnError, json, slug, summaryPath, taskId, markStatus, codexArgs };
 }
 
 function missionCounts(tasks: MissionTask[]): MissionSummary["counts"] {
@@ -225,11 +244,15 @@ function missionCounts(tasks: MissionTask[]): MissionSummary["counts"] {
     passed: tasks.filter((task) => task.status === "passed").length,
     failed: tasks.filter((task) => task.status === "failed").length,
     skipped: tasks.filter((task) => task.status === "skipped").length,
+    blocked: tasks.filter((task) => task.status === "blocked").length,
+    "needs-human-review": tasks.filter((task) => task.status === "needs-human-review").length,
   };
 }
 
 function missionStatus(tasks: MissionTask[]): MissionSummary["status"] {
   if (tasks.some((task) => task.status === "running")) return "running";
+  if (tasks.some((task) => task.status === "blocked")) return "blocked";
+  if (tasks.some((task) => task.status === "needs-human-review")) return "needs-human-review";
   if (tasks.some((task) => task.status === "failed")) return "failed";
   if (tasks.length > 0 && tasks.every((task) => task.status === "passed")) return "passed";
   return "planned";
@@ -249,7 +272,7 @@ async function appendLedger(ledgerPath: string, event: Record<string, unknown>):
 function resolveMissionPaths(cwd: string, parsed: ParsedMissionArgs): MissionPaths {
   const looksLikePath = parsed.file.includes("/") || parsed.file.includes("\\") || parsed.file.endsWith(".md") || parsed.file.endsWith(".txt");
   const inputPath = isAbsolute(parsed.file) ? parsed.file : resolve(cwd, parsed.file);
-  const baseSlug = parsed.slug ?? (parsed.action === "status" && !looksLikePath ? parsed.file : slugify(basename(inputPath, extname(inputPath))));
+  const baseSlug = parsed.slug ?? ((parsed.action === "status" || parsed.action === "mark") && !looksLikePath ? parsed.file : slugify(basename(inputPath, extname(inputPath))));
   const slug = slugify(baseSlug);
   const missionRoot = join(omxRoot(cwd), "missions", slug);
   const summaryPath = parsed.summaryPath
@@ -325,7 +348,7 @@ function printStatus(summary: MissionSummary, summaryPath: string, json: boolean
     return;
   }
   stdout(`mission status: ${summary.slug} [${summary.status}]`);
-  stdout(`tasks: ${summary.counts.passed}/${summary.counts.total} passed, ${summary.counts.failed} failed, ${summary.counts.skipped} skipped, ${summary.counts.planned} planned`);
+  stdout(`tasks: ${summary.counts.passed}/${summary.counts.total} passed, ${summary.counts.failed} failed, ${summary.counts.skipped} skipped, ${summary.counts.blocked} blocked, ${summary.counts["needs-human-review"]} needs-human-review, ${summary.counts.planned} planned`);
   for (const task of summary.tasks) stdout(`[${task.status}] ${task.id} line ${task.source_line}: ${task.prompt}`);
   stdout(`summary: ${summaryPath}`);
 }
@@ -344,6 +367,25 @@ export async function missionCommand(args: string[], options: MissionCommandOpti
       const summary = await readSummary(paths.summaryPath);
       syncSummary(summary, { status: missionStatus(summary.tasks) });
       printStatus(summary, paths.summaryPath, parsed.json, stdout);
+      return;
+    }
+
+    if (parsed.action === "mark") {
+      const summary = await readSummary(paths.summaryPath);
+      const task = summary.tasks.find((candidate) => candidate.id === parsed.taskId);
+      if (!task) throw new MissionCommandError(`No mission task found for --task ${parsed.taskId}.`);
+      task.status = parsed.markStatus ?? task.status;
+      task.completed_at = now().toISOString();
+      delete task.exit_code;
+      syncSummary(summary, { status: missionStatus(summary.tasks) });
+      await persistSummary(paths.summaryPath, summary);
+      await appendLedger(paths.ledgerPath, { event: "task_marked", at: task.completed_at, slug: summary.slug, task_id: task.id, status: task.status });
+      if (parsed.json) stdout(JSON.stringify({ ok: true, summary_path: paths.summaryPath, ledger_path: paths.ledgerPath, summary }, null, 2));
+      else {
+        stdout(`mission task marked ${task.status}: ${summary.slug} ${task.id}`);
+        stdout(`summary: ${paths.summaryPath}`);
+        stdout(`ledger: ${paths.ledgerPath}`);
+      }
       return;
     }
 
@@ -369,7 +411,7 @@ export async function missionCommand(args: string[], options: MissionCommandOpti
       await appendLedger(paths.ledgerPath, { event: parsed.action === "resume" ? "mission_resumed" : "mission_rerun_started", at: now().toISOString(), slug: summary.slug, summary_path: paths.summaryPath, task_id: parsed.taskId });
 
       const shouldRun = parsed.action === "resume"
-        ? (task: MissionTask) => task.status !== "passed"
+        ? (task: MissionTask) => task.status !== "passed" && task.status !== "blocked" && task.status !== "needs-human-review"
         : (task: MissionTask) => task.id === parsed.taskId;
       await runSelectedTasks(summary, paths, parsed, now, stdout, runTask, shouldRun);
       summary.status = missionStatus(summary.tasks);
@@ -383,7 +425,7 @@ export async function missionCommand(args: string[], options: MissionCommandOpti
         stdout(`summary: ${paths.summaryPath}`);
         stdout(`ledger: ${paths.ledgerPath}`);
       }
-      if (summary.status === "failed") process.exitCode = 1;
+      if (summary.status !== "passed") process.exitCode = 1;
       return;
     }
 

--- a/src/cli/mission.ts
+++ b/src/cli/mission.ts
@@ -1,0 +1,306 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, dirname, extname, isAbsolute, join, resolve } from "node:path";
+import { omxRoot } from "../utils/paths.js";
+
+export const MISSION_HELP = `omx mission - Run a prompt checklist sequentially through omx exec
+
+Usage:
+  omx mission <file> [--dry-run] [--continue-on-error] [--summary <path>] [--slug <name>] [--json] [-- <codex exec args...>]
+  omx mission run <file> [options]
+  omx mission plan <file> [--json]
+
+Input format:
+  - One task per non-empty line
+  - Markdown bullets, numbered lists, and checkboxes are accepted
+  - Markdown headings and HTML comments are ignored
+
+Artifacts:
+  .omx/missions/<slug>/summary.json
+  .omx/missions/<slug>/ledger.jsonl
+
+Examples:
+  omx mission ./mission.md --dry-run
+  omx mission run ./prompts.txt --continue-on-error -- --model gpt-5
+`;
+
+type MissionTaskStatus = "pending" | "planned" | "running" | "passed" | "failed" | "skipped";
+
+export interface MissionTask {
+  id: string;
+  index: number;
+  prompt: string;
+  source_line: number;
+  status: MissionTaskStatus;
+  started_at?: string;
+  completed_at?: string;
+  exit_code?: number;
+}
+
+export interface MissionSummary {
+  version: 1;
+  slug: string;
+  input_path: string;
+  dry_run: boolean;
+  continue_on_error: boolean;
+  started_at: string;
+  completed_at?: string;
+  status: "planned" | "running" | "passed" | "failed";
+  counts: Record<"total" | "planned" | "passed" | "failed" | "skipped", number>;
+  codex_args: string[];
+  tasks: MissionTask[];
+}
+
+export interface MissionCommandOptions {
+  cwd?: string;
+  now?: () => Date;
+  stdout?: (line: string) => void;
+  stderr?: (line: string) => void;
+  runTask?: (prompt: string, codexArgs: string[]) => Promise<number>;
+}
+
+interface ParsedMissionArgs {
+  file: string;
+  dryRun: boolean;
+  continueOnError: boolean;
+  json: boolean;
+  slug?: string;
+  summaryPath?: string;
+  codexArgs: string[];
+}
+
+class MissionCommandError extends Error {}
+
+function stripTaskMarker(line: string): string {
+  return line
+    .replace(/^\s*(?:[-*+]\s+)?\[(?: |x|X)\]\s+/, "")
+    .replace(/^\s*[-*+]\s+/, "")
+    .replace(/^\s*\d+[.)]\s+/, "")
+    .trim();
+}
+
+export function parseMissionTasks(input: string): MissionTask[] {
+  const tasks: MissionTask[] = [];
+  const lines = input.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const raw = lines[index] ?? "";
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    if (trimmed.startsWith("#")) continue;
+    if (/^<!--.*-->$/.test(trimmed)) continue;
+
+    const prompt = stripTaskMarker(raw);
+    if (!prompt) continue;
+    tasks.push({
+      id: `task-${String(tasks.length + 1).padStart(3, "0")}`,
+      index: tasks.length + 1,
+      prompt,
+      source_line: index + 1,
+      status: "pending",
+    });
+  }
+  return tasks;
+}
+
+function slugify(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+  return slug || "mission";
+}
+
+function readValue(args: readonly string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) throw new MissionCommandError(`Missing value for ${flag}.`);
+  return value;
+}
+
+function parseMissionArgs(args: string[]): ParsedMissionArgs {
+  let rest = [...args];
+  const command = rest[0];
+  if (command === "help" || command === "--help" || command === "-h") {
+    throw new MissionCommandError(MISSION_HELP);
+  }
+  if (command === "run") rest = rest.slice(1);
+  else if (command === "plan") rest = ["--dry-run", ...rest.slice(1)];
+
+  const separator = rest.indexOf("--");
+  const commandArgs = separator >= 0 ? rest.slice(0, separator) : rest;
+  const codexArgs = separator >= 0 ? rest.slice(separator + 1) : [];
+
+  let file: string | undefined;
+  let dryRun = false;
+  let continueOnError = false;
+  let json = false;
+  let slug: string | undefined;
+  let summaryPath: string | undefined;
+
+  for (let index = 0; index < commandArgs.length; index += 1) {
+    const arg = commandArgs[index] ?? "";
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (arg === "--continue-on-error") {
+      continueOnError = true;
+      continue;
+    }
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg.startsWith("--summary=")) {
+      summaryPath = arg.slice("--summary=".length);
+      continue;
+    }
+    if (arg === "--summary") {
+      summaryPath = readValue(commandArgs, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--slug=")) {
+      slug = arg.slice("--slug=".length);
+      continue;
+    }
+    if (arg === "--slug") {
+      slug = readValue(commandArgs, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--")) throw new MissionCommandError(`Unknown mission option: ${arg}`);
+    if (!file) {
+      file = arg;
+      continue;
+    }
+    throw new MissionCommandError(`Unexpected mission argument: ${arg}`);
+  }
+
+  if (!file) throw new MissionCommandError(`Missing mission input file.\n\n${MISSION_HELP}`);
+  return { file, dryRun, continueOnError, json, slug, summaryPath, codexArgs };
+}
+
+function missionCounts(tasks: MissionTask[]): MissionSummary["counts"] {
+  return {
+    total: tasks.length,
+    planned: tasks.filter((task) => task.status === "planned").length,
+    passed: tasks.filter((task) => task.status === "passed").length,
+    failed: tasks.filter((task) => task.status === "failed").length,
+    skipped: tasks.filter((task) => task.status === "skipped").length,
+  };
+}
+
+async function persistSummary(summaryPath: string, summary: MissionSummary): Promise<void> {
+  await mkdir(dirname(summaryPath), { recursive: true });
+  await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf-8");
+}
+
+async function appendLedger(ledgerPath: string, event: Record<string, unknown>): Promise<void> {
+  await mkdir(dirname(ledgerPath), { recursive: true });
+  const existing = await readFile(ledgerPath, "utf-8").catch(() => "");
+  await writeFile(ledgerPath, `${existing}${JSON.stringify(event)}\n`, "utf-8");
+}
+
+export async function missionCommand(args: string[], options: MissionCommandOptions = {}): Promise<void> {
+  const cwd = options.cwd ?? process.cwd();
+  const now = options.now ?? (() => new Date());
+  const stdout = options.stdout ?? ((line: string) => console.log(line));
+  const stderr = options.stderr ?? ((line: string) => console.error(line));
+
+  try {
+    const parsed = parseMissionArgs(args);
+    const inputPath = isAbsolute(parsed.file) ? parsed.file : resolve(cwd, parsed.file);
+    const input = await readFile(inputPath, "utf-8");
+    const tasks = parseMissionTasks(input);
+    if (tasks.length === 0) throw new MissionCommandError(`No runnable mission tasks found in ${parsed.file}.`);
+
+    const baseSlug = parsed.slug ?? slugify(basename(inputPath, extname(inputPath)));
+    const slug = slugify(baseSlug);
+    const missionRoot = join(omxRoot(cwd), "missions", slug);
+    const summaryPath = parsed.summaryPath
+      ? (isAbsolute(parsed.summaryPath) ? parsed.summaryPath : resolve(cwd, parsed.summaryPath))
+      : join(missionRoot, "summary.json");
+    const ledgerPath = join(missionRoot, "ledger.jsonl");
+    const startedAt = now().toISOString();
+    const summary: MissionSummary = {
+      version: 1,
+      slug,
+      input_path: inputPath,
+      dry_run: parsed.dryRun,
+      continue_on_error: parsed.continueOnError,
+      started_at: startedAt,
+      status: parsed.dryRun ? "planned" : "running",
+      counts: missionCounts(tasks),
+      codex_args: parsed.codexArgs,
+      tasks,
+    };
+
+    if (parsed.dryRun) {
+      for (const task of summary.tasks) task.status = "planned";
+      summary.counts = missionCounts(summary.tasks);
+      summary.completed_at = now().toISOString();
+      await persistSummary(summaryPath, summary);
+      await appendLedger(ledgerPath, { event: "mission_planned", at: summary.completed_at, slug, total: tasks.length, summary_path: summaryPath });
+      if (parsed.json) stdout(JSON.stringify({ ok: true, summary_path: summaryPath, ledger_path: ledgerPath, summary }, null, 2));
+      else {
+        stdout(`mission planned: ${slug} (${tasks.length} tasks)`);
+        for (const task of summary.tasks) stdout(`[planned] ${task.id} line ${task.source_line}: ${task.prompt}`);
+        stdout(`summary: ${summaryPath}`);
+        stdout(`ledger: ${ledgerPath}`);
+      }
+      return;
+    }
+
+    const runTask = options.runTask;
+    if (!runTask) throw new MissionCommandError("Mission execution requires a task runner; use --dry-run for parser/plan validation.");
+
+    await persistSummary(summaryPath, summary);
+    await appendLedger(ledgerPath, { event: "mission_started", at: startedAt, slug, total: tasks.length, summary_path: summaryPath });
+
+    let failed = false;
+    for (const task of summary.tasks) {
+      if (failed && !parsed.continueOnError) {
+        task.status = "skipped";
+        continue;
+      }
+      task.status = "running";
+      task.started_at = now().toISOString();
+      summary.counts = missionCounts(summary.tasks);
+      await persistSummary(summaryPath, summary);
+      await appendLedger(ledgerPath, { event: "task_started", at: task.started_at, slug, task_id: task.id, index: task.index, prompt: task.prompt });
+      stdout(`[running] ${task.id}/${summary.tasks.length}: ${task.prompt}`);
+
+      const exitCode = await runTask(task.prompt, parsed.codexArgs);
+      task.exit_code = exitCode;
+      task.completed_at = now().toISOString();
+      task.status = exitCode === 0 ? "passed" : "failed";
+      if (exitCode !== 0) failed = true;
+      summary.counts = missionCounts(summary.tasks);
+      await persistSummary(summaryPath, summary);
+      await appendLedger(ledgerPath, { event: "task_completed", at: task.completed_at, slug, task_id: task.id, status: task.status, exit_code: exitCode });
+      stdout(`[${task.status}] ${task.id}/${summary.tasks.length}: exit ${exitCode}`);
+    }
+
+    summary.status = summary.tasks.some((task) => task.status === "failed") ? "failed" : "passed";
+    summary.completed_at = now().toISOString();
+    summary.counts = missionCounts(summary.tasks);
+    await persistSummary(summaryPath, summary);
+    await appendLedger(ledgerPath, { event: "mission_completed", at: summary.completed_at, slug, status: summary.status, counts: summary.counts });
+
+    if (parsed.json) stdout(JSON.stringify({ ok: summary.status === "passed", summary_path: summaryPath, ledger_path: ledgerPath, summary }, null, 2));
+    else {
+      stdout(`mission ${summary.status}: ${slug}`);
+      stdout(`summary: ${summaryPath}`);
+      stdout(`ledger: ${ledgerPath}`);
+    }
+    if (summary.status === "failed") process.exitCode = 1;
+  } catch (error) {
+    if (error instanceof MissionCommandError) {
+      if (error.message === MISSION_HELP) stdout(MISSION_HELP);
+      else stderr(`[mission] ${error.message}`);
+      if (error.message !== MISSION_HELP) process.exitCode = 1;
+      return;
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- add `omx mission` for sequential prompt/checklist batch runs through `omx exec`
- persist per-task status, summary JSON, and ledger JSONL under `.omx/missions/<slug>/`
- document the MVP and cover parser, dry-run, execution status, and help behavior

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/mission.test.js dist/cli/__tests__/exec.test.js`
- `node dist/cli/omx.js mission --help && node dist/cli/omx.js --help`
- `npx biome lint src/cli/mission.ts src/cli/__tests__/mission.test.ts`

Closes #3060

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*