### PR TITLE
Fix ralplan terminalization when runtime tracker lags

### DIFF
--- a/src/ralplan/__tests__/consensus-gate.test.ts
+++ b/src/ralplan/__tests__/consensus-gate.test.ts
@@ -286,6 +286,191 @@ describe('ralplan consensus gate state roots', () => {
     }
   });
 
+  it('accepts ordered native reviews when runtime tracker lags but workspace tracker has completion evidence', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-runtime-lag-'));
+    const boxedRoot = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-runtime-root-'));
+    const previousOmxRoot = process.env.OMX_ROOT;
+    const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const previousOmxTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const sessionId = 'sess-runtime-lag-consensus';
+    try {
+      delete process.env.OMX_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+      process.env.OMX_STATE_ROOT = boxedRoot;
+      const runtimeStateDir = getBaseStateDir(cwd);
+      const runtimeSessionDir = join(runtimeStateDir, 'sessions', sessionId);
+      const workspaceStateDir = join(cwd, '.omx', 'state');
+      const workspaceSessionDir = join(workspaceStateDir, 'sessions', sessionId);
+      await mkdir(runtimeSessionDir, { recursive: true });
+      await mkdir(workspaceSessionDir, { recursive: true });
+      await writeFile(join(runtimeStateDir, 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        native_session_id: 'thread-leader',
+        cwd,
+      }, null, 2));
+      const laggingTracker = {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-07-07T04:31:00.000Z',
+            threads: {
+              'thread-leader': { thread_id: 'thread-leader', kind: 'leader', first_seen_at: '2026-07-07T04:29:00.000Z', last_seen_at: '2026-07-07T04:29:00.000Z', turn_count: 1 },
+              'thread-architect': { thread_id: 'thread-architect', kind: 'subagent', first_seen_at: '2026-07-07T04:30:00.000Z', last_seen_at: '2026-07-07T04:30:00.000Z', turn_count: 1 },
+              'thread-critic': { thread_id: 'thread-critic', kind: 'subagent', first_seen_at: '2026-07-07T04:31:00.000Z', last_seen_at: '2026-07-07T04:31:00.000Z', turn_count: 1 },
+            },
+          },
+        },
+      };
+      const completedTracker = {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-07-07T04:33:00.000Z',
+            threads: {
+              'thread-leader': { thread_id: 'thread-leader', kind: 'leader', first_seen_at: '2026-07-07T04:29:00.000Z', last_seen_at: '2026-07-07T04:29:00.000Z', turn_count: 1 },
+              'thread-architect': { thread_id: 'thread-architect', kind: 'subagent', first_seen_at: '2026-07-07T04:30:00.000Z', last_seen_at: '2026-07-07T04:30:00.000Z', completed_at: '2026-07-07T04:30:00.000Z', turn_count: 1 },
+              'thread-critic': { thread_id: 'thread-critic', kind: 'subagent', first_seen_at: '2026-07-07T04:31:00.000Z', last_seen_at: '2026-07-07T04:31:00.000Z', completed_at: '2026-07-07T04:31:00.000Z', turn_count: 1 },
+            },
+          },
+        },
+      };
+      await writeFile(subagentTrackingPath(cwd), JSON.stringify(laggingTracker, null, 2));
+      await writeFile(join(workspaceStateDir, 'subagent-tracking.json'), JSON.stringify(completedTracker, null, 2));
+      await writeFile(join(runtimeSessionDir, 'ralplan-state.json'), JSON.stringify({
+        active: false,
+        current_phase: 'complete',
+        planning_complete: true,
+        latest_plan_path: '.omx/plans/prd-clickstack-otel-consumer-20260707T043000Z.md',
+        ralplan_consensus_gate: {
+          complete: true,
+          sequence: ['architect-review', 'critic-review'],
+          ralplan_architect_review: {
+            agent_role: 'architect',
+            provenance_kind: 'native_subagent',
+            verdict: 'approve',
+            session_id: sessionId,
+            thread_id: 'thread-architect',
+            tracker_path: '.omx/state/subagent-tracking.json',
+            completed_at: '2026-07-07T04:30:00.000Z',
+          },
+          ralplan_critic_review: {
+            agent_role: 'critic',
+            provenance_kind: 'native_subagent',
+            verdict: 'approve',
+            session_id: sessionId,
+            thread_id: 'thread-critic',
+            tracker_path: '.omx/state/subagent-tracking.json',
+            completed_at: '2026-07-07T04:31:00.000Z',
+          },
+        },
+      }, null, 2));
+
+      const gate = buildRalplanConsensusGateForCwd(cwd, {
+        sessionId,
+        requireNativeSubagents: true,
+      });
+
+      assert.equal(gate.complete, true);
+      assert.equal(gate.blockedReason, null);
+    } finally {
+      if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof previousOmxTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousOmxTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(boxedRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects runtime tracker lag when workspace tracker also lacks completion evidence', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-runtime-lag-incomplete-'));
+    const boxedRoot = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-runtime-incomplete-root-'));
+    const previousOmxRoot = process.env.OMX_ROOT;
+    const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const previousOmxTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const sessionId = 'sess-runtime-lag-incomplete-consensus';
+    try {
+      delete process.env.OMX_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+      process.env.OMX_STATE_ROOT = boxedRoot;
+      const runtimeStateDir = getBaseStateDir(cwd);
+      const runtimeSessionDir = join(runtimeStateDir, 'sessions', sessionId);
+      const workspaceStateDir = join(cwd, '.omx', 'state');
+      await mkdir(runtimeSessionDir, { recursive: true });
+      await mkdir(workspaceStateDir, { recursive: true });
+      await writeFile(join(runtimeStateDir, 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        native_session_id: 'thread-leader',
+        cwd,
+      }, null, 2));
+      const incompleteTracker = {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-07-07T04:31:00.000Z',
+            threads: {
+              'thread-leader': { thread_id: 'thread-leader', kind: 'leader', first_seen_at: '2026-07-07T04:29:00.000Z', last_seen_at: '2026-07-07T04:29:00.000Z', turn_count: 1 },
+              'thread-architect': { thread_id: 'thread-architect', kind: 'subagent', first_seen_at: '2026-07-07T04:30:00.000Z', last_seen_at: '2026-07-07T04:30:00.000Z', turn_count: 1 },
+              'thread-critic': { thread_id: 'thread-critic', kind: 'subagent', first_seen_at: '2026-07-07T04:31:00.000Z', last_seen_at: '2026-07-07T04:31:00.000Z', turn_count: 1 },
+            },
+          },
+        },
+      };
+      await writeFile(subagentTrackingPath(cwd), JSON.stringify(incompleteTracker, null, 2));
+      await writeFile(join(workspaceStateDir, 'subagent-tracking.json'), JSON.stringify(incompleteTracker, null, 2));
+      await writeFile(join(runtimeSessionDir, 'ralplan-state.json'), JSON.stringify({
+        ralplan_consensus_gate: {
+          complete: true,
+          sequence: ['architect-review', 'critic-review'],
+          ralplan_architect_review: {
+            agent_role: 'architect',
+            provenance_kind: 'native_subagent',
+            verdict: 'approve',
+            session_id: sessionId,
+            thread_id: 'thread-architect',
+            tracker_path: '.omx/state/subagent-tracking.json',
+            completed_at: '2026-07-07T04:30:00.000Z',
+          },
+          ralplan_critic_review: {
+            agent_role: 'critic',
+            provenance_kind: 'native_subagent',
+            verdict: 'approve',
+            session_id: sessionId,
+            thread_id: 'thread-critic',
+            tracker_path: '.omx/state/subagent-tracking.json',
+            completed_at: '2026-07-07T04:31:00.000Z',
+          },
+        },
+      }, null, 2));
+
+      const gate = buildRalplanConsensusGateForCwd(cwd, {
+        sessionId,
+        requireNativeSubagents: true,
+      });
+
+      assert.equal(gate.complete, false);
+      assert.equal(gate.blockedReason, 'native_subagent_consensus_evidence_missing');
+      assert.match(gate.blockedDetails?.join(' ') ?? '', /thread-architect is not completed/);
+    } finally {
+      if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+      else delete process.env.OMX_STATE_ROOT;
+      if (typeof previousOmxTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousOmxTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(boxedRoot, { recursive: true, force: true });
+    }
+  });
+
   it('accepts session-scoped tracker-backed reviews without an explicit sessionId option', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-discovered-session-'));
     const boxedRoot = await mkdtemp(join(tmpdir(), 'omx-ralplan-consensus-discovered-root-'));

--- a/src/ralplan/consensus-gate.ts
+++ b/src/ralplan/consensus-gate.ts
@@ -734,12 +734,37 @@ function trackerBackedNativeReviewProblem(
 
   const expectedTrackerPath = subagentTrackingPath(cwd);
   const tracking = readJsonState(expectedTrackerPath);
+  const expectedProblem = trackerThreadProblem(tracking, sessionId, threadId, agentRole, expectedTrackerPath, options.cwd);
+  if (expectedProblem === null) return null;
+
+  const fallbackTrackerPath = findCompletedNativeReviewThreadInLocalTracker(
+    cwd,
+    expectedTrackerPath,
+    sessionId,
+    threadId,
+    agentRole,
+    options.cwd,
+  );
+  if (fallbackTrackerPath) return null;
+
+  return expectedProblem;
+
+}
+
+function trackerThreadProblem(
+  tracking: Record<string, unknown> | null,
+  sessionId: string,
+  threadId: string,
+  agentRole: 'architect' | 'critic',
+  trackerPath: string,
+  cwd: string | undefined,
+): string | null {
   const session = asRecord(asRecord(tracking?.sessions)?.[sessionId]);
   const thread = asRecord(asRecord(session?.threads)?.[threadId]);
-  if (!session) return `${agentRole} tracker session ${sessionId} is missing in ${expectedTrackerPath}; only reviews recorded in OMX subagent-tracking.json count as native lanes`;
-  if (!thread) return `${agentRole} tracker thread ${threadId} is missing in ${expectedTrackerPath}; external/collab subagent reviews are not tracker-backed native lanes`;
+  if (!session) return `${agentRole} tracker session ${sessionId} is missing in ${trackerPath}; only reviews recorded in OMX subagent-tracking.json count as native lanes`;
+  if (!thread) return `${agentRole} tracker thread ${threadId} is missing in ${trackerPath}; external/collab subagent reviews are not tracker-backed native lanes`;
   const leaderThreadId = typeof session.leader_thread_id === 'string' ? session.leader_thread_id.trim() : '';
-  const currentLeaderThreadId = currentSessionNativeLeaderThreadId(options.cwd);
+  const currentLeaderThreadId = currentSessionNativeLeaderThreadId(cwd);
   if (
     (currentLeaderThreadId && currentLeaderThreadId === threadId)
     || (leaderThreadId && leaderThreadId === threadId && thread.kind !== 'subagent')
@@ -747,6 +772,28 @@ function trackerBackedNativeReviewProblem(
   if (thread.kind !== 'subagent') return `${agentRole} tracker thread ${threadId} has kind=${String(thread.kind || 'missing')}`;
   const completedAt = typeof thread.completed_at === 'string' ? thread.completed_at.trim() : '';
   if (!completedAt) return `${agentRole} tracker thread ${threadId} is not completed`;
+  return null;
+}
+
+function findCompletedNativeReviewThreadInLocalTracker(
+  cwd: string,
+  expectedTrackerPath: string,
+  sessionId: string,
+  threadId: string,
+  agentRole: 'architect' | 'critic',
+  leaderCwd: string | undefined,
+): string | null {
+  const fallbackTrackerPaths = uniquePaths([
+    join(localBaseStateDir(cwd), 'subagent-tracking.json'),
+  ]).filter((path) => path !== expectedTrackerPath);
+
+  for (const trackerPath of fallbackTrackerPaths) {
+    const tracking = readJsonState(trackerPath);
+    if (trackerThreadProblem(tracking, sessionId, threadId, agentRole, trackerPath, leaderCwd) === null) {
+      return trackerPath;
+    }
+  }
+
   return null;
 }
 

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -1035,6 +1035,91 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('finalizes ralplan when runtime tracker lags but workspace tracker has completed native reviews', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-runtime-lag-complete-'));
+    const stateRoot = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-runtime-lag-root-'));
+    try {
+      await withStateRootEnv({ OMX_STATE_ROOT: stateRoot }, async () => {
+        const sessionId = 'sess-ralplan-runtime-lag-complete';
+        const runtimeStateDir = join(stateRoot, '.omx', 'state');
+        const sessionDir = join(runtimeStateDir, 'sessions', sessionId);
+        const workspaceStateDir = join(wd, '.omx', 'state');
+        await mkdir(sessionDir, { recursive: true });
+        await mkdir(workspaceStateDir, { recursive: true });
+        await writeFile(join(runtimeStateDir, 'session.json'), JSON.stringify({
+          session_id: sessionId,
+          native_session_id: 'thread-leader',
+          cwd: wd,
+        }, null, 2));
+        const consensusGate = ralplanConsensusGate(sessionId, 'native_subagent') as {
+          ralplan_architect_review: Record<string, unknown>;
+          ralplan_critic_review: Record<string, unknown>;
+        };
+        consensusGate.ralplan_architect_review.completed_at = '2026-07-07T04:30:00.000Z';
+        consensusGate.ralplan_critic_review.completed_at = '2026-07-07T04:31:00.000Z';
+        await writeFile(subagentTrackingPath(wd), JSON.stringify({
+          schemaVersion: 1,
+          sessions: {
+            [sessionId]: {
+              session_id: sessionId,
+              leader_thread_id: 'thread-leader',
+              updated_at: '2026-07-07T04:31:00.000Z',
+              threads: {
+                'thread-leader': { thread_id: 'thread-leader', kind: 'leader', first_seen_at: '2026-07-07T04:29:00.000Z', last_seen_at: '2026-07-07T04:29:00.000Z', turn_count: 1 },
+                'thread-architect': { thread_id: 'thread-architect', kind: 'subagent', first_seen_at: '2026-07-07T04:30:00.000Z', last_seen_at: '2026-07-07T04:30:00.000Z', turn_count: 1 },
+                'thread-critic': { thread_id: 'thread-critic', kind: 'subagent', first_seen_at: '2026-07-07T04:31:00.000Z', last_seen_at: '2026-07-07T04:31:00.000Z', turn_count: 1 },
+              },
+            },
+          },
+        }, null, 2));
+        await writeFile(join(workspaceStateDir, 'subagent-tracking.json'), JSON.stringify({
+          schemaVersion: 1,
+          sessions: {
+            [sessionId]: {
+              session_id: sessionId,
+              leader_thread_id: 'thread-leader',
+              updated_at: '2026-07-07T04:31:00.000Z',
+              threads: {
+                'thread-leader': { thread_id: 'thread-leader', kind: 'leader', first_seen_at: '2026-07-07T04:29:00.000Z', last_seen_at: '2026-07-07T04:29:00.000Z', turn_count: 1 },
+                'thread-architect': { thread_id: 'thread-architect', kind: 'subagent', first_seen_at: '2026-07-07T04:30:00.000Z', last_seen_at: '2026-07-07T04:30:00.000Z', completed_at: '2026-07-07T04:30:00.000Z', turn_count: 1 },
+                'thread-critic': { thread_id: 'thread-critic', kind: 'subagent', first_seen_at: '2026-07-07T04:31:00.000Z', last_seen_at: '2026-07-07T04:31:00.000Z', completed_at: '2026-07-07T04:31:00.000Z', turn_count: 1 },
+              },
+            },
+          },
+        }, null, 2));
+        await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+          mode: 'ralplan',
+          active: true,
+          current_phase: 'planning',
+          session_id: sessionId,
+        }, null, 2));
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'ralplan',
+          active: false,
+          current_phase: 'complete',
+          planning_complete: true,
+          latest_plan_path: '.omx/plans/prd-clickstack-otel-consumer-20260707T043000Z.md',
+          terminal_reason: 'consensus approved despite runtime tracker lag',
+          ralplan_consensus_gate: consensusGate,
+        });
+
+        assert.equal(response.isError, undefined);
+        const sessionRalplan = JSON.parse(await readFile(join(sessionDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(sessionRalplan.active, false);
+        assert.equal(sessionRalplan.current_phase, 'complete');
+        assert.equal(sessionRalplan.status, 'complete');
+        assert.equal(sessionRalplan.terminal_reason, 'consensus approved despite runtime tracker lag');
+        assert.equal((sessionRalplan.ralplan_consensus_gate as Record<string, unknown>).complete, true);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(stateRoot, { recursive: true, force: true });
+    }
+  });
+
   it('rejects forged ralplan complete gates before mutating active session state', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-forged-complete-'));
     try {


### PR DESCRIPTION
## Summary
- keep strict ralplan Architect -> Critic approval validation intact
- accept native subagent completion evidence from the workspace-local tracker when the runtime tracker copy lags without completed_at
- add regressions for runtime tracker lag terminalization and fail-closed incomplete workspace evidence

Fixes #3067.

## Verification
- npm run build
- node dist/scripts/run-test-files.js dist/ralplan/__tests__/consensus-gate.test.js dist/state/__tests__/operations.test.js dist/autopilot/__tests__/ralplan-gate.test.js dist/ralplan/__tests__/runtime.test.js
- npm run check:no-unused
- npm run lint

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*