### PR TITLE
docs: avoid stale catalog counts in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,8 +69,8 @@ If `node_modules` is already fresh and you are iterating locally, you can skip `
 ## Project structure
 
 - `src/` -- TypeScript source (CLI, config, agents, MCP servers, hooks, modes, team, verification)
-- `prompts/` -- 30 agent prompt markdown files (installed to `~/.codex/prompts/`)
-- `skills/` -- 39 skill directories with `SKILL.md` (installed to `~/.codex/skills/`)
+- `prompts/` -- agent prompt markdown files (installed to `~/.codex/prompts/`)
+- `skills/` -- skill directories with `SKILL.md` (installed to `~/.codex/skills/`)
 - `templates/` -- `AGENTS.md` orchestration brain template
 
 ### Adding a new agent prompt

--- a/src/scripts/generate-catalog-docs.ts
+++ b/src/scripts/generate-catalog-docs.ts
@@ -17,6 +17,7 @@ const docsToScan = [
   join(root, 'docs', 'skills.html'),
   join(root, 'docs', 'agents.html'),
   join(root, 'README.md'),
+  join(root, 'CONTRIBUTING.md'),
   join(root, 'src', 'cli', 'setup.ts'),
   join(root, 'src', 'cli', 'doctor.ts'),
 ];


### PR DESCRIPTION
Summary:
- Remove stale hardcoded prompt and skill counts from the contributing guide's project structure section.
- Include `CONTRIBUTING.md` in the catalog docs hardcoded-count scan.

Why:
- The catalog counts move over time, so contributor-facing docs should not drift as prompts or skills are added or removed.

Validation:
- [x] `npm run build`
- [x] `npm run lint`
- [x] `node dist/scripts/generate-catalog-docs.js --check`
- [x] `git diff --check`