### PR TITLE
fix: handle invalid mission summary JSON

### DIFF
--- a/src/cli/__tests__/mission.test.ts
+++ b/src/cli/__tests__/mission.test.ts
@@ -107,6 +107,24 @@ describe("omx mission", () => {
     });
   });
 
+  it("reports invalid summary JSON as a mission error", async () => {
+    await withTempDir(async (cwd) => {
+      const summaryPath = join(cwd, "summary.json");
+      await writeFile(summaryPath, "{not json", "utf-8");
+
+      const err: string[] = [];
+      await missionCommand(["status", "demo", "--summary", summaryPath], {
+        cwd,
+        stdout: () => undefined,
+        stderr: (line) => err.push(line),
+      });
+
+      assert.deepEqual(err, [`[mission] Invalid mission summary at ${summaryPath}.`]);
+      assert.equal(process.exitCode, 1);
+      process.exitCode = undefined;
+    });
+  });
+
   it("resumes durable summaries by skipping passed tasks and retrying stale running work", async () => {
     await withTempDir(async (cwd) => {
       await writeFile(join(cwd, "mission.md"), "First\nSecond\nThird\n", "utf-8");

--- a/src/cli/mission.ts
+++ b/src/cli/mission.ts
@@ -289,7 +289,12 @@ async function readSummary(summaryPath: string): Promise<MissionSummary> {
   } catch {
     throw new MissionCommandError(`No mission summary found at ${summaryPath}.`);
   }
-  const summary = JSON.parse(raw) as MissionSummary;
+  let summary: MissionSummary;
+  try {
+    summary = JSON.parse(raw) as MissionSummary;
+  } catch {
+    throw new MissionCommandError(`Invalid mission summary at ${summaryPath}.`);
+  }
   if (summary.version !== 1 || !Array.isArray(summary.tasks)) {
     throw new MissionCommandError(`Invalid mission summary at ${summaryPath}.`);
   }


### PR DESCRIPTION
Summary:
- Convert malformed mission summary JSON into the existing mission error path.
- Add a regression test for `omx mission status --summary` with invalid JSON.

Why:
- `readSummary()` already reports missing and structurally invalid summaries as `MissionCommandError`, but malformed JSON leaked a raw `SyntaxError`.

Validation:
- [x] `npm run build`
- [x] `npm run lint`
- [x] `node dist/scripts/run-test-files.js dist/cli/__tests__/mission.test.js`
- [x] `git diff --check`