### PR TITLE
Fix task-scoped aggregate Ultragoal completion state

### DIFF
--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -290,7 +290,7 @@ describe('cli/ultragoal', () => {
       const status = await capture(() => ultragoalCommand(['status']));
       const output = status.stdout.join('\n');
       assert.match(output, /ultragoal aggregate product: complete/);
-      assert.match(output, /microgoal ledger bookkeeping \(progress-only\): 0\/2 complete, 1 pending, 1 in progress/);
+      assert.match(output, /microgoal ledger bookkeeping \(progress-only\): 1\/2 complete, 1 pending, 0 in progress/);
     });
   });
 

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -307,7 +307,7 @@ describe('readUltragoalState', { concurrency: false }, () => {
     });
   });
 
-  it('keeps HUD active when aggregate completion exists but repo-native ultragoal work is still running', async () => {
+  it('treats aggregate completion as terminal for HUD while preserving microgoal bookkeeping counts', async () => {
     await withTempRepo('omx-hud-ultragoal-aggregate-active-', async (cwd) => {
       const ultragoalDir = join(cwd, '.omx', 'ultragoal');
       await mkdir(ultragoalDir, { recursive: true });
@@ -317,7 +317,7 @@ describe('readUltragoalState', { concurrency: false }, () => {
         aggregateCompletion: {
           status: 'complete',
           completedAt: '2026-06-01T12:00:00.000Z',
-          evidence: 'task-scoped Codex aggregate completed before microgoal ledger reconciliation finished',
+          evidence: 'task-scoped Codex aggregate completed after strict reconciliation',
         },
         goals: [
           { id: 'G001-done', title: 'Done', objective: 'Completed prior work', status: 'complete' },
@@ -328,13 +328,40 @@ describe('readUltragoalState', { concurrency: false }, () => {
 
       const state = await readUltragoalState(cwd);
 
-      assert.equal(state?.active, true);
-      assert.equal(state?.status, 'in_progress');
-      assert.equal(state?.activeGoal?.id, 'G002-running');
+      assert.equal(state?.active, false);
+      assert.equal(state?.status, 'complete');
+      assert.equal(state?.activeGoal, undefined);
       assert.equal(state?.complete, 1);
       assert.equal(state?.inProgress, 1);
       assert.equal(state?.pending, 1);
-      assert.deepEqual(state?.ongoingGoals?.map((goal) => goal.id), ['G002-running', 'G003-pending']);
+      assert.deepEqual(state?.ongoingGoals, []);
+    });
+  });
+  it('treats reconciled task-scoped aggregate completion as inactive in HUD state', async () => {
+    await withTempRepo('omx-hud-ultragoal-aggregate-reconciled-', async (cwd) => {
+      const ultragoalDir = join(cwd, '.omx', 'ultragoal');
+      await mkdir(ultragoalDir, { recursive: true });
+      await writeFile(join(ultragoalDir, 'goals.json'), JSON.stringify({
+        version: 1,
+        aggregateCompletion: {
+          status: 'complete',
+          completedAt: '2026-06-01T12:00:00.000Z',
+          evidence: 'task-scoped Codex aggregate completed and active microgoal row was reconciled',
+        },
+        goals: [
+          { id: 'G001-reconciled', title: 'Reconciled', objective: 'Finish active repo-native work', status: 'complete', completedAt: '2026-06-01T12:00:00.000Z' },
+        ],
+      }));
+
+      const state = await readUltragoalState(cwd);
+
+      assert.equal(state?.active, false);
+      assert.equal(state?.status, 'complete');
+      assert.equal(state?.activeGoal, undefined);
+      assert.equal(state?.complete, 1);
+      assert.equal(state?.inProgress, 0);
+      assert.equal(state?.pending, 0);
+      assert.deepEqual(state?.ongoingGoals, []);
     });
   });
 

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -191,6 +191,10 @@ export async function readUltragoalState(cwd: string): Promise<UltragoalStateFor
   const review_blocked_goals = goals.filter((goal) => goal.status === 'review_blocked' && !isNonBlockingSupersededUltragoalGoal(goal, goals)).length;
   const needs_user_decision_goals = goals.filter((goal) => goal.status === 'needs_user_decision' && !isNonBlockingSupersededUltragoalGoal(goal, goals)).length;
   const unresolved_goals = goals.filter((goal) => isHudUnresolvedUltragoalGoal(goal, goals)).length;
+  const aggregateCompletion = plan.aggregateCompletion && typeof plan.aggregateCompletion === 'object' && !Array.isArray(plan.aggregateCompletion)
+    ? plan.aggregateCompletion as { status?: unknown }
+    : null;
+  const aggregateComplete = aggregateCompletion?.status === 'complete';
   const activeGoalId = sanitizeOptionalString(plan.activeGoalId);
   const activeGoal = (
     (activeGoalId ? goals.find((goal) => goal.id === activeGoalId && isHudUnresolvedUltragoalGoal(goal, goals)) : undefined)
@@ -198,7 +202,7 @@ export async function readUltragoalState(cwd: string): Promise<UltragoalStateFor
     ?? goals.find((goal) => isHudUnresolvedUltragoalGoal(goal, goals) && ULTRAGOAL_UNRESOLVED_STATUSES.has(goal.status))
   );
   const activeIndex = activeGoal ? goals.findIndex((goal) => goal.id === activeGoal.id) : -1;
-  const complete = unresolved_goals === 0;
+  const complete = aggregateComplete || unresolved_goals === 0;
   const toHudGoal = ({ goal, index }: { goal: NormalizedUltragoalGoal; index: number }) => ({
     id: goal.id,
     title: goal.title,
@@ -211,7 +215,7 @@ export async function readUltragoalState(cwd: string): Promise<UltragoalStateFor
     .filter(({ goal, index }) => index > activeIndex && goal.status === 'pending' && isHudUnresolvedUltragoalGoal(goal, goals) && goal.id !== activeGoal?.id)
     .slice(0, 3)
     .map(toHudGoal);
-  const orderedOngoingGoals = [
+  const orderedOngoingGoals = complete ? [] : [
     ...(activeGoal && activeIndex >= 0 ? [toHudGoal({ goal: activeGoal, index: activeIndex })] : []),
     ...nextPendingGoals,
   ];
@@ -227,7 +231,7 @@ export async function readUltragoalState(cwd: string): Promise<UltragoalStateFor
     reviewBlocked: review_blocked_goals,
     needsUserDecision: needs_user_decision_goals,
     progressTotal: goals.length,
-    activeGoal: activeGoal && activeIndex >= 0 ? {
+    activeGoal: !complete && activeGoal && activeIndex >= 0 ? {
       id: activeGoal.id,
       title: activeGoal.title,
       objective: activeGoal.objective,

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -436,6 +436,64 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('reports reconciled task-scoped aggregate ultragoal artifacts as inactive in get-status', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ultragoal-reconciled-'));
+    try {
+      await mkdir(join(wd, '.omx', 'ultragoal'), { recursive: true });
+      await writeFile(
+        join(wd, '.omx', 'ultragoal', 'goals.json'),
+        JSON.stringify({
+          aggregateCompletion: {
+            status: 'complete',
+            completedAt: '2026-06-01T12:00:00.000Z',
+            evidence: 'task-scoped Codex aggregate completed and active microgoal row was reconciled',
+          },
+          activeGoalId: 'G002',
+          goals: [{
+            id: 'G001',
+            title: 'Fix duplicate HUD panes',
+            objective: 'Keep one HUD renderer per leader.',
+            status: 'complete',
+            completedAt: '2026-06-01T12:00:00.000Z',
+          }, {
+            id: 'G002',
+            title: 'Still marked running',
+            objective: 'Progress-only row left running by the old aggregate path.',
+            status: 'in_progress',
+          }, {
+            id: 'G003',
+            title: 'Still marked pending',
+            objective: 'Progress-only row left pending by the old aggregate path.',
+            status: 'pending',
+          }],
+        }, null, 2),
+      );
+
+      const activeResponse = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+      });
+      assert.deepEqual(activeResponse.payload, { active_modes: [] });
+
+      const statusResponse = await executeStateOperation('state_get_status', {
+        workingDirectory: wd,
+        mode: 'ultragoal',
+      });
+      const statuses = (statusResponse.payload as {
+        statuses?: Record<string, { active?: boolean; phase?: string; path?: string; source?: string; data?: { activeGoal?: unknown; inProgress?: number; pending?: number; complete?: number } }>;
+      }).statuses || {};
+      assert.equal(statuses.ultragoal?.active, false);
+      assert.equal(statuses.ultragoal?.phase, 'complete');
+      assert.equal(statuses.ultragoal?.path, join(wd, '.omx', 'ultragoal', 'goals.json'));
+      assert.equal(statuses.ultragoal?.source, 'ultragoal-artifacts');
+      assert.equal(statuses.ultragoal?.data?.activeGoal, undefined);
+      assert.equal(statuses.ultragoal?.data?.complete, 1);
+      assert.equal(statuses.ultragoal?.data?.inProgress, 1);
+      assert.equal(statuses.ultragoal?.data?.pending, 1);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('prefers active ultragoal artifacts over stale inactive mode state', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ultragoal-stale-state-'));
     try {

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -457,6 +457,17 @@ describe('ultragoal artifacts', () => {
         () => checkpointUltragoal(cwd, {
           goalId: first.goal!.id,
           status: 'complete',
+          evidence: 'Actual planned work done for .omx/ultragoal/goals.json G001-first; validation complete; reviews clean.',
+          codexGoal: { goal: { objective: 'Audit .omx/ultragoal/goals.json for a different unrelated task', status: 'complete' } },
+          qualityGate: cleanQualityGate(),
+        }),
+        /objective mismatch/,
+      );
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: first.goal!.id,
+          status: 'complete',
           evidence: 'done',
           codexGoal: { goal: { objective: taskObjective, status: 'complete' } },
           qualityGate: cleanQualityGate(),

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -409,8 +409,11 @@ describe('ultragoal artifacts', () => {
       });
 
       assert.equal(reconciled.goals.length, 136);
-      assert.equal(reconciled.goals.filter((goal) => goal.status === 'complete').length, 0);
-      assert.equal(reconciled.goals[0]?.status, 'in_progress');
+      assert.equal(reconciled.goals.filter((candidate) => candidate.status === 'complete').length, 1);
+      assert.equal(reconciled.goals[0]?.status, 'complete');
+      assert.equal(reconciled.goals[0]?.completedAt, '2026-05-04T10:04:00.000Z');
+      assert.match(reconciled.goals[0]?.evidence ?? '', /planned work done/);
+      assert.equal(reconciled.goals[0]?.failureReason, undefined);
       assert.equal(reconciled.activeGoalId, undefined);
       assert.equal(reconciled.aggregateCompletion?.status, 'complete');
       assert.match(reconciled.aggregateCompletion?.evidence ?? '', /planned work done/);
@@ -421,9 +424,9 @@ describe('ultragoal artifacts', () => {
       assert.equal(next.done, true);
 
       const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
-      assert.match(ledger, /microgoal ledger progress remains independent/);
+      assert.match(ledger, /checkpointed active microgoal row was reconciled to complete/);
       assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 1);
-      assert.equal((ledger.match(/"event":"goal_completed"/g) ?? []).length, 0);
+      assert.equal((ledger.match(/"event":"goal_completed"/g) ?? []).length, 1);
     });
   });
 

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -403,6 +403,56 @@ function normalizeObjective(value: string): string {
   return value.replace(/\s+/g, ' ').trim();
 }
 
+const OBJECTIVE_MAPPING_STOP_WORDS = new Set([
+  'about',
+  'active',
+  'aggregate',
+  'audit',
+  'brief',
+  'build',
+  'clean',
+  'codex',
+  'complete',
+  'completed',
+  'different',
+  'evidence',
+  'fix',
+  'goal',
+  'goals',
+  'implementation',
+  'json',
+  'ledger',
+  'omx',
+  'plan',
+  'planned',
+  'reconcile',
+  'task',
+  'tests',
+  'ultragoal',
+  'unrelated',
+  'validation',
+  'work',
+]);
+
+function objectiveMappingTokens(value: string): Set<string> {
+  const tokens = new Set<string>();
+  for (const token of value.toLowerCase().match(/[a-z0-9]+/g) ?? []) {
+    if (token.length < 5) continue;
+    if (OBJECTIVE_MAPPING_STOP_WORDS.has(token)) continue;
+    tokens.add(token);
+  }
+  return tokens;
+}
+
+function objectivesHaveConservativeSpecificTokenOverlap(actual: string, brief: string): boolean {
+  const actualTokens = objectiveMappingTokens(actual);
+  const briefTokens = objectiveMappingTokens(brief);
+  if (actualTokens.size < 4 || briefTokens.size < 4) return false;
+  const shared = [...actualTokens].filter((token) => briefTokens.has(token)).length;
+  const smallerSpecificSetSize = Math.min(actualTokens.size, briefTokens.size);
+  return shared >= 4 && shared / smallerSpecificSetSize >= 0.6;
+}
+
 function normalizeBlockerEvidence(value: string | undefined): string {
   return (value ?? '')
     .toLowerCase()
@@ -483,12 +533,11 @@ function textHasCompletionValidationEvidence(value: string | undefined): boolean
 
 async function snapshotObjectiveMapsToUltragoalPlan(cwd: string, snapshotObjective: string): Promise<boolean> {
   const actual = normalizeObjective(snapshotObjective).toLowerCase();
-  if (textMentionsUltragoalPlanArtifact(actual)) return true;
   if (actual.length < 24) return false;
   try {
     const brief = normalizeObjective(await readFile(ultragoalBriefPath(cwd), 'utf-8')).toLowerCase();
     if (!brief || brief.length < 24) return false;
-    return brief.includes(actual) || actual.includes(brief);
+    return brief.includes(actual) || actual.includes(brief) || objectivesHaveConservativeSpecificTokenOverlap(actual, brief);
   } catch {
     return false;
   }
@@ -1590,7 +1639,7 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
         }
       } else {
         const taskScopedRequirement = aggregateMode && snapshot?.status === 'complete' && Boolean(snapshot.objective)
-          ? ' Completed task-scoped aggregate reconciliation requires the checkpoint goal to be the active in-progress OMX goal, evidence that names that active OMX goal id, names .omx/ultragoal/goals.json or ledger.jsonl, includes completed implementation plus validation/review evidence, and a get_goal objective that maps to the ultragoal brief/artifact.'
+          ? ' Completed task-scoped aggregate reconciliation requires the checkpoint goal to be the active in-progress OMX goal, evidence that names that active OMX goal id, names .omx/ultragoal/goals.json or ledger.jsonl, includes completed implementation plus validation/review evidence, and a get_goal objective that maps to the ultragoal brief.'
           : '';
         const remediation = reconciliation.snapshot.available
           && reconciliation.snapshot.status === 'complete'

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -1626,10 +1626,27 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
     ? validateQualityGate(options.qualityGate, requiredArchitectureInvariants)
     : undefined;
   if (aggregateCompletion) {
+    goal.status = 'complete';
+    goal.completedAt = now;
+    goal.updatedAt = now;
+    goal.evidence = options.evidence;
+    goal.failureReason = undefined;
+    goal.failedAt = undefined;
+    clearGoalBlockerFields(goal);
     plan.aggregateCompletion = aggregateCompletion;
     if (plan.activeGoalId === goal.id) delete plan.activeGoalId;
     plan.updatedAt = now;
     await writePlan(cwd, plan);
+    await appendLedger(cwd, {
+      ts: now,
+      event: 'goal_completed',
+      goalId: goal.id,
+      status: goal.status,
+      evidence: options.evidence,
+      codexGoal: options.codexGoal,
+      qualityGate,
+      message: 'Active repo-native microgoal completed while reconciling a completed task-scoped aggregate Codex goal snapshot.',
+    });
     await appendLedger(cwd, {
       ts: now,
       event: 'aggregate_completed',
@@ -1638,7 +1655,7 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
       evidence: options.evidence,
       codexGoal: options.codexGoal,
       qualityGate,
-      message: 'Aggregate ultragoal plan completed via task-scoped Codex goal snapshot; microgoal ledger progress remains independent.',
+      message: 'Aggregate ultragoal plan completed via task-scoped Codex goal snapshot; checkpointed active microgoal row was reconciled to complete.',
     });
     return plan;
   }


### PR DESCRIPTION
Fixes #3071

## Summary
- Mark the active microgoal row complete when task-scoped aggregate completion reconciles from a completed Codex goal snapshot.
- Preserve aggregate completion as terminal while clearing blocker fields, evidence, and activeGoalId.
- Treat aggregate-complete Ultragoal artifacts as inactive in HUD/state surfaces while preserving microgoal bookkeeping counts.
- Add regressions for durable rows, CLI status, state get-status, and HUD behavior.

## Verification
- node -e "const fs=require('fs'); fs.rmSync('dist',{recursive:true,force:true});" && ./node_modules/.bin/tsc && node -e "require('fs').chmodSync('dist/cli/omx.js', 0o755)" && node dist/scripts/run-test-files.js dist/ultragoal/__tests__/artifacts.test.js dist/cli/__tests__/ultragoal.test.js dist/hud/__tests__/state.test.js dist/state/__tests__/operations.test.js
- ./node_modules/.bin/tsc -p tsconfig.no-unused.json
- ./node_modules/.bin/biome lint src/ultragoal/artifacts.ts src/ultragoal/__tests__/artifacts.test.ts src/cli/__tests__/ultragoal.test.ts src/hud/state.ts src/hud/__tests__/state.test.ts src/state/__tests__/operations.test.ts

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*