### PR TITLE
fix(team): exclude OMX .omx/ state from clean-workspace preflight

### DIFF
--- a/src/team/__tests__/worktree.test.ts
+++ b/src/team/__tests__/worktree.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -10,6 +10,7 @@ import {
   planWorktreeTarget,
   ensureWorktree,
   rollbackProvisionedWorktrees,
+  assertCleanLeaderWorkspaceForWorkerWorktrees,
 } from '../worktree.js';
 
 async function initRepo(): Promise<string> {
@@ -327,6 +328,39 @@ describe('worktree ensure + rollback', () => {
       assert.equal(existsSync(ensured.worktreePath), false);
       // Branch is preserved when skipBranchDeletion is true (ralph policy)
       assert.equal(branchExists(repo, 'feature/ralph-keep'), true);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('assertCleanLeaderWorkspaceForWorkerWorktrees', () => {
+  it('ignores OMX-generated .omx artifacts so back-to-back launches are not blocked', async () => {
+    const repo = await initRepo();
+    try {
+      // Simulate the untracked state a prior team run leaves behind.
+      await mkdir(join(repo, '.omx', 'logs'), { recursive: true });
+      await mkdir(join(repo, '.omx', 'reports'), { recursive: true });
+      await mkdir(join(repo, '.omx', 'state'), { recursive: true });
+      await writeFile(join(repo, '.omx', 'logs', 'team-dispatch.jsonl'), '{}\n', 'utf-8');
+      await writeFile(join(repo, '.omx', 'reports', 'team-commit-hygiene.md'), '# report\n', 'utf-8');
+      await writeFile(join(repo, '.omx', 'state', 'dispatch.json'), '{}\n', 'utf-8');
+
+      // .omx-only dirtiness must NOT block a launch.
+      assert.doesNotThrow(() => assertCleanLeaderWorkspaceForWorkerWorktrees(repo));
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('still rejects real uncommitted work outside .omx', async () => {
+    const repo = await initRepo();
+    try {
+      await writeFile(join(repo, 'notes.txt'), 'local only\n', 'utf-8');
+      await assert.throws(
+        () => assertCleanLeaderWorkspaceForWorkerWorktrees(repo),
+        /leader_workspace_dirty_for_worktrees:.*notes\.txt.*commit_or_stash_before_omx_team/s,
+      );
     } finally {
       await rm(repo, { recursive: true, force: true });
     }

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -149,8 +149,20 @@ export function readWorkspaceStatusLines(cwd: string): string[] {
     .filter(Boolean);
 }
 
+/**
+ * `.omx/` holds OMX-generated artifacts (team/dispatch state, logs, reports).
+ * OMX writes these itself during a team run, so they must never gate a launch —
+ * otherwise the first run leaves untracked `.omx/` files that block every
+ * subsequent launch with `leader_workspace_dirty_for_worktrees`.
+ */
+function isOmxManagedStatusLine(line: string): boolean {
+  // `git status --porcelain` prefixes each entry with a 2-char status + space.
+  const path = line.slice(3).trim().replace(/^"(.*)"$/, '$1');
+  return path.startsWith('.omx/') || path.startsWith('.omx\\');
+}
+
 export function assertCleanLeaderWorkspaceForWorkerWorktrees(cwd: string): void {
-  const lines = readWorkspaceStatusLines(cwd);
+  const lines = readWorkspaceStatusLines(cwd).filter((line) => !isOmxManagedStatusLine(line));
   if (lines.length === 0) return;
   const preview = lines.slice(0, 8).join(' | ');
   throw new Error(


### PR DESCRIPTION
## Problem

`assertCleanLeaderWorkspaceForWorkerWorktrees` rejects a team launch if the leader workspace has *any* uncommitted file. This includes OMX's own generated state under `.omx/` (team/dispatch state, logs, commit-hygiene reports, etc.).

Because **every** team run writes files under `.omx/`, the first launch in a repo leaves untracked `.omx/` artifacts that block **all subsequent launches** with:

```
Error: leader_workspace_dirty_for_worktrees:<repo>:?? .omx/logs/... | ?? .omx/reports/... | ?? .omx/state/dispatch.json:commit_or_stash_before_omx_team
```

The only workaround is a manual `git add .omx && git commit` (or stash) between every run — which is pure friction, since those files are tool-generated, not the user's work.

## Root cause

`readWorkspaceStatusLines` runs `git status --porcelain --untracked-files=all` and the preflight treats every line as a blocker. OMX-managed state is indistinguishable from real uncommitted work to this check.

## Fix

Filter `.omx/` entries (matching both `.omx/` and `.omx\` path separators) out of the status lines before deciding the workspace is dirty. Real uncommitted work **outside** `.omx/` still fails the preflight exactly as before — the safety guarantee is preserved.

```ts
function isOmxManagedStatusLine(line: string): boolean {
  const path = line.slice(3).trim().replace(/^"(.*)"$/, '$1');
  return path.startsWith('.omx/') || path.startsWith('.omx\\');
}

export function assertCleanLeaderWorkspaceForWorkerWorktrees(cwd: string): void {
  const lines = readWorkspaceStatusLines(cwd).filter((line) => !isOmxManagedStatusLine(line));
  if (lines.length === 0) return;
  ...
}
```

## Tests

Adds two regression tests in `worktree.test.ts`:

- ✅ `.omx/`-only dirtiness (logs/reports/state) does **not** block a launch.
- ✅ real uncommitted work outside `.omx/` (e.g. `notes.txt`) **still** throws `leader_workspace_dirty_for_worktrees`.

Both pass. (Two unrelated symlink-based tests in the same file fail on Windows without developer-mode symlink privileges — pre-existing, not affected by this change.)

## Verification

Reproduced the failure end-to-end on Windows (`omx v0.12.5`): a second `omx team` launch immediately after the first failed with `leader_workspace_dirty_for_worktrees` due to `.omx/` artifacts. After this fix, back-to-back launches succeed with no manual commit/stash.

---
This is scoped to a single clearly-correct change; it does not touch readiness timeouts or trust-prompt handling.
