### PR TITLE
fix: repair Ultragoal conductor provenance regression

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -70,6 +70,17 @@ Setup-owned trust state is limited to those generated wrapper identities; user h
 | `session-idle` | none | `session-idle` | runtime-fallback | Still emitted from runtime/notify path, not native Codex hooks |
 
 
+## PreToolUse: conductor typed-lane recognition
+
+The Main-root Conductor write guard blocks source, package, git, and substantive
+plan/spec/review edits from the leader while allowing workflow metadata writes.
+Delegated performer lanes are exempt only when the event is a known typed role
+and trusted lane provenance exists. Native Codex events may provide that
+provenance either through `source.subagent.thread_spawn.parent_thread_id` or
+through an existing `.omx/state/subagent-tracking.json` entry whose `thread_id`
+is recorded as `kind:"subagent"`. A bare typed role on the leader event is not
+enough to bypass the guard.
+
 ## Document-refresh warning MVP
 
 The native hook adapter includes an agent-only document-refresh warning MVP for

--- a/docs/ultragoal.md
+++ b/docs/ultragoal.md
@@ -66,6 +66,14 @@ omx ultragoal checkpoint --goal-id G001-example --status failed --evidence "bloc
 omx ultragoal complete-goals --retry-failed
 ```
 
+Failed goals remain durable retry/blocker evidence in `.omx/ultragoal`; they
+are not a live execution mode by themselves. `omx status` reports a durable
+failed Ultragoal plan as `FAILED` rather than `ACTIVE`, while `omx cancel`
+continues to cancel only active mode-state entries. HUD and state API readers
+may still expose failed goals as active unresolved durable artifacts; that
+`active` field is a visibility/lifecycle signal, not proof of a cancellable
+runtime mode.
+
 Completed legacy thread-goal blocker handling:
 
 ```sh

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -358,6 +358,76 @@ describe('CLI session-scoped state parity', () => {
     }
   });
 
+  it('reports durable failed Ultragoal artifacts without advertising a cancellable active mode', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-status-failed-ultragoal-'));
+    try {
+      const ultragoalDir = join(wd, '.omx', 'ultragoal');
+      await mkdir(ultragoalDir, { recursive: true });
+      await writeFile(join(ultragoalDir, 'goals.json'), JSON.stringify({
+        version: 1,
+        activeGoalId: 'G001-failed',
+        goals: [
+          {
+            id: 'G001-failed',
+            title: 'Failed story',
+            objective: 'Preserve failed evidence for retry.',
+            status: 'failed',
+          },
+        ],
+      }, null, 2));
+
+      const statusResult = runOmx(wd, 'status');
+      assert.equal(statusResult.status, 0, statusResult.stderr || statusResult.stdout);
+      assert.match(statusResult.stdout, /ultragoal: FAILED \(phase: failed\)/);
+      assert.doesNotMatch(statusResult.stdout, /ultragoal: ACTIVE \(phase: failed\)/);
+
+      const cancelResult = runOmx(wd, 'cancel');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /No active modes to cancel\./);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves active Ultragoal mode status when durable failed artifacts coexist', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-status-active-ultragoal-failed-artifact-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-active-ultragoal-failed-artifact';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      const ultragoalDir = join(wd, '.omx', 'ultragoal');
+      await mkdir(sessionDir, { recursive: true });
+      await mkdir(ultragoalDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(sessionDir, 'ultragoal-state.json'), JSON.stringify({
+        active: true,
+        mode: 'ultragoal',
+        current_phase: 'executing',
+        session_id: sessionId,
+      }, null, 2));
+      await writeFile(join(ultragoalDir, 'goals.json'), JSON.stringify({
+        version: 1,
+        activeGoalId: 'G001-failed',
+        goals: [
+          {
+            id: 'G001-failed',
+            title: 'Failed story',
+            objective: 'Preserve failed evidence for retry.',
+            status: 'failed',
+          },
+        ],
+      }, null, 2));
+
+      const statusResult = runOmx(wd, 'status');
+      assert.equal(statusResult.status, 0, statusResult.stderr || statusResult.stdout);
+      assert.match(statusResult.stdout, /ultragoal: ACTIVE \(phase: executing\)/);
+      assert.doesNotMatch(statusResult.stdout, /ultragoal: FAILED \(phase: failed\)/);
+      assert.doesNotMatch(statusResult.stdout, /No active modes\./);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('cancels linked ultrawork when Ralph is active', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-ralph-link-'));
     try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2858,6 +2858,12 @@ async function readStaleCurrentAutopilotStatus(cwd: string): Promise<StaleCurren
   return { phase: phase ?? "active" };
 }
 
+function formatDurableUltragoalStatusForCli(status: string): string {
+  return status === "failed"
+    ? "ultragoal: FAILED (phase: failed)"
+    : `ultragoal: ACTIVE (phase: ${status})`;
+}
+
 async function showStatus(): Promise<void> {
   const { readFile } = await import("fs/promises");
   const cwd = process.cwd();
@@ -2891,7 +2897,7 @@ async function showStatus(): Promise<void> {
     const ultragoalState = await readUltragoalState(cwd).catch(() => null);
     if (states.length === 0) {
       if (ultragoalState?.active) {
-        console.log(`ultragoal: ACTIVE (phase: ${ultragoalState.status})`);
+        console.log(formatDurableUltragoalStatusForCli(ultragoalState.status ?? "active"));
         return;
       }
       const staleAutopilot = await readStaleCurrentAutopilotStatus(cwd);
@@ -2902,6 +2908,7 @@ async function showStatus(): Promise<void> {
       console.log("No active modes.");
       return;
     }
+    let hasAuthoritativeActiveUltragoalMode = false;
     for (const path of states) {
       const content = await readFile(path, "utf-8");
       let state: Record<string, unknown>;
@@ -2913,13 +2920,16 @@ async function showStatus(): Promise<void> {
       }
       const file = basename(path);
       const mode = file.replace("-state.json", "");
-      if (mode === "ultragoal" && ultragoalState?.active) continue;
+      if (mode === "ultragoal" && state.active === true) {
+        hasAuthoritativeActiveUltragoalMode = true;
+      }
+      if (mode === "ultragoal" && ultragoalState?.active && state.active !== true) continue;
       console.log(
         `${mode}: ${state.active === true ? "ACTIVE" : "inactive"} (phase: ${String(state.current_phase || "n/a")})`,
       );
     }
-    if (ultragoalState?.active) {
-      console.log(`ultragoal: ACTIVE (phase: ${ultragoalState.status})`);
+    if (ultragoalState?.active && !hasAuthoritativeActiveUltragoalMode) {
+      console.log(formatDurableUltragoalStatusForCli(ultragoalState.status ?? "active"));
     }
     if (!hasAuthoritativeActiveMode && !ultragoalState?.active) {
       const staleAutopilot = await readStaleCurrentAutopilotStatus(cwd);

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -21526,6 +21526,200 @@ PY`,
     }
   });
 
+  it("allows conductor writes from tracked typed native subagents when PreToolUse omits thread_spawn source", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-conductor-tracked-subagent-no-source-"));
+    const originalOmxRoot = process.env.OMX_ROOT;
+    const originalOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const originalOmxTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      process.env.OMX_ROOT = cwd;
+      delete process.env.OMX_STATE_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-conductor-tracked-subagent-no-source";
+      const leaderThreadId = "thread-conductor-leader-no-source";
+      const childThreadId = "thread-conductor-child-no-source";
+      const nowIso = new Date().toISOString();
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, native_session_id: leaderThreadId });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ultragoal", "executing");
+      await writeJson(join(stateDir, "sessions", sessionId, "ultragoal-state.json"), {
+        active: true,
+        mode: "ultragoal",
+        current_phase: "executing",
+        session_id: sessionId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: leaderThreadId,
+            updated_at: nowIso,
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "leader", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1 },
+              [childThreadId]: { thread_id: childThreadId, kind: "subagent", mode: "executor", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1 },
+            },
+          },
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: childThreadId,
+          agent_role: "executor",
+          tool_name: "apply_patch",
+          tool_input: { file_path: "configs/ws/kalshi_ws_auth_evidence.json" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      if (originalOmxRoot === undefined) delete process.env.OMX_ROOT;
+      else process.env.OMX_ROOT = originalOmxRoot;
+      if (originalOmxStateRoot === undefined) delete process.env.OMX_STATE_ROOT;
+      else process.env.OMX_STATE_ROOT = originalOmxStateRoot;
+      if (originalOmxTeamStateRoot === undefined) delete process.env.OMX_TEAM_STATE_ROOT;
+      else process.env.OMX_TEAM_STATE_ROOT = originalOmxTeamStateRoot;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks conductor writes when corrupt tracker state labels the leader as a subagent", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-conductor-corrupt-leader-subagent-"));
+    const originalOmxRoot = process.env.OMX_ROOT;
+    const originalOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const originalOmxTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      process.env.OMX_ROOT = cwd;
+      delete process.env.OMX_STATE_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-conductor-corrupt-leader-subagent";
+      const leaderThreadId = "thread-conductor-corrupt-leader";
+      const nowIso = new Date().toISOString();
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, native_session_id: leaderThreadId });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ultragoal", "executing");
+      await writeJson(join(stateDir, "sessions", sessionId, "ultragoal-state.json"), {
+        active: true,
+        mode: "ultragoal",
+        current_phase: "executing",
+        session_id: sessionId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: leaderThreadId,
+            updated_at: nowIso,
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "subagent", mode: "executor", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1 },
+            },
+          },
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: leaderThreadId,
+          agent_role: "executor",
+          tool_name: "apply_patch",
+          tool_input: { file_path: "configs/ws/kalshi_ws_auth_evidence.json" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /Main-root Conductor mode is active \(ultragoal phase: executing\)/);
+    } finally {
+      if (originalOmxRoot === undefined) delete process.env.OMX_ROOT;
+      else process.env.OMX_ROOT = originalOmxRoot;
+      if (originalOmxStateRoot === undefined) delete process.env.OMX_STATE_ROOT;
+      else process.env.OMX_STATE_ROOT = originalOmxStateRoot;
+      if (originalOmxTeamStateRoot === undefined) delete process.env.OMX_TEAM_STATE_ROOT;
+      else process.env.OMX_TEAM_STATE_ROOT = originalOmxTeamStateRoot;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks conductor writes when thread_spawn provenance is attached to the leader thread", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-conductor-thread-spawn-leader-"));
+    const originalOmxRoot = process.env.OMX_ROOT;
+    const originalOmxStateRoot = process.env.OMX_STATE_ROOT;
+    const originalOmxTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      process.env.OMX_ROOT = cwd;
+      delete process.env.OMX_STATE_ROOT;
+      delete process.env.OMX_TEAM_STATE_ROOT;
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-conductor-thread-spawn-leader";
+      const leaderThreadId = "thread-conductor-thread-spawn-leader";
+      const nowIso = new Date().toISOString();
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, native_session_id: leaderThreadId });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ultragoal", "executing");
+      await writeJson(join(stateDir, "sessions", sessionId, "ultragoal-state.json"), {
+        active: true,
+        mode: "ultragoal",
+        current_phase: "executing",
+        session_id: sessionId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: leaderThreadId,
+            updated_at: nowIso,
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "leader", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1 },
+            },
+          },
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: leaderThreadId,
+          agent_role: "executor",
+          source: {
+            subagent: {
+              thread_spawn: {
+                parent_thread_id: leaderThreadId,
+              },
+            },
+          },
+          tool_name: "apply_patch",
+          tool_input: { file_path: "configs/ws/kalshi_ws_auth_evidence.json" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /Main-root Conductor mode is active \(ultragoal phase: executing\)/);
+    } finally {
+      if (originalOmxRoot === undefined) delete process.env.OMX_ROOT;
+      else process.env.OMX_ROOT = originalOmxRoot;
+      if (originalOmxStateRoot === undefined) delete process.env.OMX_STATE_ROOT;
+      else process.env.OMX_STATE_ROOT = originalOmxStateRoot;
+      if (originalOmxTeamStateRoot === undefined) delete process.env.OMX_TEAM_STATE_ROOT;
+      else process.env.OMX_TEAM_STATE_ROOT = originalOmxTeamStateRoot;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("blocks Main-root ralph conductor source and planning artifact writes while allowing .omx workflow state writes", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralph-conductor-write-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -6714,7 +6714,7 @@ async function buildRalplanPreToolUseBoundaryOutput(
   resolvedSessionId?: string,
 ): Promise<Record<string, unknown> | null> {
   const sessionId = safeString(resolvedSessionId ?? readPayloadSessionId(payload)).trim();
-  if (await hasTrustedTypedSubagentThreadSpawnProvenanceForPreToolUse(payload, cwd, sessionId)) return null;
+  if (await hasTrustedTypedSubagentProvenanceForPreToolUse(payload, cwd, sessionId)) return null;
   const threadId = readPayloadThreadId(payload);
   const activeState = await readActiveRalplanStateForPreToolUse(cwd, stateDir, sessionId, threadId);
   if (!activeState) return null;
@@ -6782,7 +6782,7 @@ async function buildDeepInterviewPreToolUseBoundaryOutput(
   resolvedSessionId?: string,
 ): Promise<Record<string, unknown> | null> {
   const sessionId = safeString(resolvedSessionId ?? readPayloadSessionId(payload)).trim();
-  if (await hasTrustedTypedSubagentThreadSpawnProvenanceForPreToolUse(payload, cwd, sessionId)) return null;
+  if (await hasTrustedTypedSubagentProvenanceForPreToolUse(payload, cwd, sessionId)) return null;
   const threadId = readPayloadThreadId(payload);
   const activeState = await readActiveDeepInterviewStateForPreToolUse(cwd, stateDir, sessionId, threadId);
   if (!activeState) return null;
@@ -6950,12 +6950,20 @@ interface ActiveConductorState {
   phase: string;
 }
 
-async function hasTrustedTypedSubagentThreadSpawnProvenanceForPreToolUse(
+async function hasTrustedTypedSubagentProvenanceForPreToolUse(
   payload: CodexHookPayload,
   cwd: string,
   sessionId: string,
 ): Promise<boolean> {
   if (hasTeamWorkerEnvironment()) return true;
+  if (!isTypedAgentRolePayload(payload)) return false;
+  const trackingState = await readSubagentTrackingState(cwd).catch(() => null);
+  const session = trackingState?.sessions?.[sessionId];
+  if (!session) return false;
+
+  const payloadThreadId = readPayloadThreadId(payload);
+  if (payloadThreadId && isTrustedSubagentThread(session, payloadThreadId)) return true;
+
   const source = safeObject(payload.source);
   const subagent = safeObject(source.subagent);
   const threadSpawn = safeObject(subagent.thread_spawn);
@@ -6966,11 +6974,9 @@ async function hasTrustedTypedSubagentThreadSpawnProvenanceForPreToolUse(
       ?? threadSpawn.leaderThreadId,
   ).trim();
   if (!parentThreadId) return false;
-  if (!isTypedAgentRolePayload(payload)) return false;
-  const trackingState = await readSubagentTrackingState(cwd).catch(() => null);
-  const session = trackingState?.sessions?.[sessionId];
-  if (!session) return false;
-  return session.leader_thread_id === parentThreadId || parentThreadId in session.threads;
+  const leaderThreadId = safeString(session.leader_thread_id).trim();
+  if (payloadThreadId && leaderThreadId && payloadThreadId === leaderThreadId) return false;
+  return leaderThreadId === parentThreadId || parentThreadId in session.threads;
 }
 
 function isActiveConductorModeState(state: Record<string, unknown> | null, mode: string, sessionId: string): boolean {
@@ -6999,7 +7005,7 @@ async function readActiveMainRootConductorStateForPreToolUse(
   }
   const threadId = readPayloadThreadId(payload);
   if (!sessionId) return null;
-  if (await hasTrustedTypedSubagentThreadSpawnProvenanceForPreToolUse(payload, cwd, sessionId)) return null;
+  if (await hasTrustedTypedSubagentProvenanceForPreToolUse(payload, cwd, sessionId)) return null;
 
   const canonicalState = await readVisibleSkillActiveStateForStateDir(stateDir, sessionId);
   if (!canonicalState) return null;


### PR DESCRIPTION
## Summary

Fixes an Ultragoal/Conductor regression where typed native subagent PreToolUse events could be blocked when Codex omitted `source.subagent.thread_spawn`, while preserving the Main-root Conductor write guard. Also clarifies failed durable Ultragoal status reporting so failed artifacts are visible as retry/blocker evidence without advertising a cancellable active mode.

## Changes

- Recognize tracked typed native subagent lanes through `.omx/state/subagent-tracking.json` when `thread_spawn` provenance is absent.
- Harden the provenance exemption so leader-thread events cannot bypass Conductor guards through corrupt tracker state or leader-attached `thread_spawn` data.
- Report failed durable Ultragoal artifacts as `ultragoal: FAILED (phase: failed)` in `omx status`, while `omx cancel` continues to cancel only active mode-state entries.
- Add regression tests for tracked typed subagents, leader spoofing guards, and failed durable Ultragoal status/cancel semantics.
- Update native hook and Ultragoal docs for the changed behavior.

## Validation

- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `npx tsc --noEmit`
- [x] `git diff --check`
- [x] `omx doctor` not run; this PR does not change setup/config behavior.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed
- [x] Backward-compatibility impact considered

## Related

Regression report from attached paste; no linked issue.
