### PR TITLE
Prevent conductor deadlock without native subagents

### DIFF
--- a/src/autopilot/__tests__/ralplan-gate.test.ts
+++ b/src/autopilot/__tests__/ralplan-gate.test.ts
@@ -85,6 +85,41 @@ describe('autopilot ralplan gate', () => {
     assert.equal(evidence.source, 'direct-approval');
   });
 
+  it('rejects missing tracker-backed native evidence by default for autopilot ralplan to ultragoal', () => {
+    const decision = canAdvanceAutopilotRalplanToUltragoal({
+      cwd: process.cwd(),
+      sessionId: 'sess-default-native-required',
+      nextState: {
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'ultragoal',
+        ralplan_consensus_gate: {
+          complete: true,
+          sequence: ['architect-review', 'critic-review'],
+          ralplan_architect_review: {
+            agent_role: 'architect',
+            provenance_kind: 'codex_exec',
+            verdict: 'approve',
+            session_id: 'sess-default-native-required',
+            thread_id: 'exec-architect',
+            completed_at: '2026-06-12T10:02:00.000Z',
+          },
+          ralplan_critic_review: {
+            agent_role: 'critic',
+            provenance_kind: 'codex_exec',
+            verdict: 'approve',
+            session_id: 'sess-default-native-required',
+            thread_id: 'exec-critic',
+            completed_at: '2026-06-12T10:03:00.000Z',
+          },
+        },
+      },
+    });
+
+    assert.equal(decision.allowed, false);
+    assert.match(decision.reason, /tracker-backed native architect and critic lanes/);
+  });
+
   it('accepts fresh valid consensus before stale invalid consensus', () => {
     const evidence = buildRalplanConsensusGateFromSources([
       {
@@ -640,6 +675,128 @@ describe('autopilot ralplan gate', () => {
       const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, sessionId, currentState: state });
       assert.equal(decision.allowed, true);
       assert.equal(decision.evidence?.blockedReason, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects unsupported native evidence even with tracker-backed native consensus', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-unsupported-veto-'));
+    const sessionId = 'sess-autopilot-unsupported-veto';
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-06-12T10:03:00.000Z',
+            threads: {
+              'thread-leader': { thread_id: 'thread-leader', kind: 'leader', first_seen_at: '2026-06-12T09:59:00.000Z', last_seen_at: '2026-06-12T09:59:00.000Z', turn_count: 1 },
+              'thread-architect': { thread_id: 'thread-architect', kind: 'subagent', first_seen_at: '2026-06-12T10:02:00.000Z', last_seen_at: '2026-06-12T10:02:00.000Z', completed_at: '2026-06-12T10:02:00.000Z', turn_count: 1 },
+              'thread-critic': { thread_id: 'thread-critic', kind: 'subagent', first_seen_at: '2026-06-12T10:03:00.000Z', last_seen_at: '2026-06-12T10:03:00.000Z', completed_at: '2026-06-12T10:03:00.000Z', turn_count: 1 },
+            },
+          },
+        },
+      }, null, 2));
+
+      const state = {
+        current_phase: 'ralplan',
+        handoff_artifacts: {
+          ralplan: {
+            native_subagent_support: {
+              status: 'unsupported',
+              reason: 'multi_agent_v1_unavailable',
+              source: 'post_tool_failure',
+            },
+          },
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              thread_id: 'thread-architect',
+              completed_at: '2026-06-12T10:02:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              thread_id: 'thread-critic',
+              completed_at: '2026-06-12T10:03:00.000Z',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, sessionId, currentState: state });
+      assert.equal(decision.allowed, false);
+      assert.match(decision.reason, /terminalize non-clean/);
+      assert.match(buildAutopilotRalplanUltragoalGateError(decision), /blocked\/cancelled\/failed/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects handoff-root unsupported native evidence even with tracker-backed native consensus', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-autopilot-ralplan-unsupported-root-veto-'));
+    const sessionId = 'sess-autopilot-unsupported-root-veto';
+    const trackingPath = subagentTrackingPath(cwd);
+    try {
+      await mkdir(join(trackingPath, '..'), { recursive: true });
+      await writeFile(trackingPath, JSON.stringify({
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: 'thread-leader',
+            updated_at: '2026-06-12T10:03:00.000Z',
+            threads: {
+              'thread-leader': { thread_id: 'thread-leader', kind: 'leader', first_seen_at: '2026-06-12T09:59:00.000Z', last_seen_at: '2026-06-12T09:59:00.000Z', turn_count: 1 },
+              'thread-architect': { thread_id: 'thread-architect', kind: 'subagent', first_seen_at: '2026-06-12T10:02:00.000Z', last_seen_at: '2026-06-12T10:02:00.000Z', completed_at: '2026-06-12T10:02:00.000Z', turn_count: 1 },
+              'thread-critic': { thread_id: 'thread-critic', kind: 'subagent', first_seen_at: '2026-06-12T10:03:00.000Z', last_seen_at: '2026-06-12T10:03:00.000Z', completed_at: '2026-06-12T10:03:00.000Z', turn_count: 1 },
+            },
+          },
+        },
+      }, null, 2));
+
+      const state = {
+        current_phase: 'ralplan',
+        handoff_artifacts: {
+          native_subagent_support: {
+            status: 'unsupported',
+            reason: 'multi_agent_v1_unavailable',
+            source: 'post_tool_failure',
+          },
+          ralplan_consensus_gate: {
+            complete: true,
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: {
+              agent_role: 'architect',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              thread_id: 'thread-architect',
+              completed_at: '2026-06-12T10:02:00.000Z',
+            },
+            ralplan_critic_review: {
+              agent_role: 'critic',
+              provenance_kind: 'native_subagent',
+              verdict: 'approve',
+              thread_id: 'thread-critic',
+              completed_at: '2026-06-12T10:03:00.000Z',
+            },
+          },
+        },
+      };
+
+      const decision = canAdvanceAutopilotRalplanToUltragoal({ cwd, sessionId, currentState: state });
+      assert.equal(decision.allowed, false);
+      assert.match(decision.reason, /terminalize non-clean/);
+      assert.match(buildAutopilotRalplanUltragoalGateError(decision), /blocked\/cancelled\/failed/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/autopilot/ralplan-gate.ts
+++ b/src/autopilot/ralplan-gate.ts
@@ -4,6 +4,11 @@ import {
   withParentReturnToRalplanContext,
   type RalplanConsensusGateEvidence,
 } from '../ralplan/consensus-gate.js';
+import {
+  buildUnsupportedNativeSubagentGuidance,
+  isUnsupportedNativeSubagentEvidenceForScope,
+  type NativeSubagentSupportEvidence,
+} from '../leader/contract.js';
 
 type JsonObject = Record<string, unknown>;
 
@@ -18,6 +23,7 @@ export interface AutopilotRalplanUltragoalGateDecision {
   allowed: boolean;
   reason: string;
   evidence?: RalplanConsensusGateEvidence;
+  unsupportedNativeSubagentGuidance?: string;
 }
 
 function safeObject(value: unknown): JsonObject | null {
@@ -36,6 +42,31 @@ function handoffArtifacts(state: JsonObject | null | undefined): JsonObject | nu
 
 function ralplanHandoff(state: JsonObject | null | undefined): JsonObject | null {
   return safeObject(handoffArtifacts(state)?.ralplan);
+}
+function unsupportedNativeSubagentEvidence(
+  state: JsonObject | null | undefined,
+  input: Pick<AutopilotRalplanUltragoalGateInput, 'cwd' | 'sessionId'>,
+): NativeSubagentSupportEvidence | null {
+  const nested = nestedState(state);
+  const handoffRalplan = ralplanHandoff(state);
+  const nestedHandoffRalplan = ralplanHandoff(nested);
+  for (const candidate of [
+    state?.native_subagent_support,
+    nested?.native_subagent_support,
+    handoffArtifacts(state)?.native_subagent_support,
+    handoffArtifacts(nested)?.native_subagent_support,
+    handoffRalplan?.native_subagent_support,
+    nestedHandoffRalplan?.native_subagent_support,
+  ]) {
+    if (isUnsupportedNativeSubagentEvidenceForScope(candidate, input)) return candidate as NativeSubagentSupportEvidence;
+  }
+  return null;
+}
+
+function unsupportedNativeSubagentGuidance(input: AutopilotRalplanUltragoalGateInput): string | null {
+  const evidence = unsupportedNativeSubagentEvidence(input.nextState, input)
+    ?? unsupportedNativeSubagentEvidence(input.currentState, input);
+  return evidence ? buildUnsupportedNativeSubagentGuidance(evidence) : null;
 }
 
 function sourcesForState(label: string, state: JsonObject | null | undefined): Array<{ source: string; value: unknown }> {
@@ -73,6 +104,14 @@ export function canAdvanceAutopilotRalplanToUltragoal(
     sessionId: input.sessionId,
     requireNativeSubagents: true,
   };
+  const unsupportedGuidance = unsupportedNativeSubagentGuidance(input) ?? undefined;
+  if (unsupportedGuidance) {
+    return {
+      allowed: false,
+      reason: 'native subagent support is unavailable; ralplan must terminalize non-clean instead of handing off to ultragoal',
+      unsupportedNativeSubagentGuidance: unsupportedGuidance,
+    };
+  }
   const nextStateEvidence = buildRalplanConsensusGateFromSources(
     sourcesForState('next-autopilot-state', input.nextState),
     options,
@@ -87,12 +126,14 @@ export function canAdvanceAutopilotRalplanToUltragoal(
       allowed: true,
       reason: 'tracker-backed native ralplan architect and critic consensus evidence',
       evidence,
+      unsupportedNativeSubagentGuidance: unsupportedGuidance,
     };
   }
   return {
     allowed: false,
     reason: ralplanConsensusBlockedReason(evidence),
     evidence,
+    unsupportedNativeSubagentGuidance: unsupportedGuidance,
   };
 }
 
@@ -118,8 +159,10 @@ export function buildAutopilotRalplanUltragoalGateError(
       `    session_id: ${review.session_id ?? 'missing'} session_found=${review.session_found ? 'yes' : 'no'}`,
       review.problem ? `    problem: ${review.problem}` : null,
     ].filter((line): line is string => Boolean(line)).join('\n');
+    const guidance = decision.unsupportedNativeSubagentGuidance;
     return [
       `Cannot transition ralplan -> ultragoal: ${decision.reason}.`,
+      guidance ? `Unsupported native recovery: ${guidance}` : null,
       '',
       'Expected:',
       ...diagnostic.expected_schema.map((line) => `  ${line}`),
@@ -137,10 +180,11 @@ export function buildAutopilotRalplanUltragoalGateError(
       '',
       'Docs:',
       `  ${diagnostic.docs}`,
-    ].join('\n');
+    ].filter((line): line is string => line !== null).join('\n');
   }
   const details = decision.evidence?.blockedDetails?.length
     ? ` Details: ${decision.evidence.blockedDetails.join('; ')}.`
     : '';
-  return `Cannot transition ralplan -> ultragoal: ${decision.reason}.${details}`;
+  const guidance = decision.unsupportedNativeSubagentGuidance;
+  return `Cannot transition ralplan -> ultragoal: ${decision.reason}.${details}${guidance ? ` ${guidance}` : ''}`;
 }

--- a/src/leader/__tests__/contract.test.ts
+++ b/src/leader/__tests__/contract.test.ts
@@ -10,6 +10,12 @@ import {
   actionKindForConductorArtifact,
   authorizeConductorAction,
   classifyConductorArtifactKind,
+  LEADER_CONDUCTOR_UNSUPPORTED_NATIVE_DEGRADE_BLOCK,
+  NATIVE_SUBAGENT_SUPPORT_BLOCKER_FILE,
+  buildUnsupportedNativeSubagentGuidance,
+  isUnsupportedNativeSubagentEvidence,
+  isUnsupportedNativeSubagentEvidenceForScope,
+  resolveNativeSubagentSupportStatus,
 } from '../contract.js';
 
 describe('leader conductor contract', () => {
@@ -96,5 +102,147 @@ describe('leader conductor contract', () => {
       actionKind: actionKindForConductorArtifact(source),
       artifactKind: source,
     }).allowed, true);
+  });
+
+  it('resolves native subagent support from explicit runtime evidence only', () => {
+    assert.equal(NATIVE_SUBAGENT_SUPPORT_BLOCKER_FILE, 'native-subagent-support.json');
+    assert.equal(
+      resolveNativeSubagentSupportStatus({
+        payload: { omx_runtime_capabilities: { native_subagents: false, multi_agent_v1: false } },
+      }).status,
+      'unsupported',
+    );
+    assert.equal(
+      resolveNativeSubagentSupportStatus({ payload: { available_tools: ['Read', 'Edit'] } }).reason,
+      'multi_agent_v1_unavailable',
+    );
+    assert.equal(
+      resolveNativeSubagentSupportStatus({ payload: {} }).status,
+      'unknown',
+    );
+    assert.equal(
+      resolveNativeSubagentSupportStatus({ payload: { available_tools: ['Read', 'multi_agent_v1.spawn_agent'] } }).status,
+      'supported',
+    );
+  });
+
+  it('recognizes scoped unsupported native blocker evidence and renders blocker guidance', () => {
+    const evidence = resolveNativeSubagentSupportStatus({
+      cwd: '/repo',
+      sessionId: 'sess-1',
+      persistedSupportBlocker: {
+        status: 'unsupported',
+        reason: 'multi_agent_v1_unavailable',
+        cwd: '/repo',
+        session_id: 'sess-1',
+        error_summary: 'multi_agent_v1.spawn_agent unavailable',
+      },
+    });
+
+    assert.equal(evidence.status, 'unsupported');
+    assert.equal(evidence.reason, 'multi_agent_v1_unavailable');
+    assert.equal(isUnsupportedNativeSubagentEvidence(evidence), true);
+    assert.match(buildUnsupportedNativeSubagentGuidance(evidence), /blocked\/cancelled\/failed/);
+    assert.match(buildUnsupportedNativeSubagentGuidance(evidence), /Do not call multi_agent_v1\.close_agent/);
+    assert.match(LEADER_CONDUCTOR_UNSUPPORTED_NATIVE_DEGRADE_BLOCK, /permission for Main-root source\/package\/git edits/);
+  });
+
+  it('ignores stale or mismatched unsupported native blocker evidence', () => {
+    assert.equal(
+      resolveNativeSubagentSupportStatus({
+        cwd: '/repo-a',
+        sessionId: 'sess-1',
+        persistedSupportBlocker: {
+          status: 'unsupported',
+          reason: 'multi_agent_v1_unavailable',
+          cwd: '/repo-b',
+          session_id: 'sess-1',
+        },
+      }).status,
+      'unknown',
+    );
+    assert.equal(
+      resolveNativeSubagentSupportStatus({
+        nowMs: Date.parse('2026-07-09T00:00:00.000Z'),
+        persistedCapacityBlocker: {
+          reason: 'agent_thread_limit_reached',
+          expires_at: '2026-07-08T00:00:00.000Z',
+        },
+      }).status,
+      'unknown',
+    );
+    assert.equal(
+      resolveNativeSubagentSupportStatus({
+        nowMs: Date.parse('2026-07-09T00:00:00.000Z'),
+        persistedCapacityBlocker: {
+          reason: 'agent_thread_limit_reached',
+        },
+      }).status,
+      'unknown',
+    );
+    assert.equal(
+      resolveNativeSubagentSupportStatus({
+        nowMs: Date.parse('2026-07-09T00:00:00.000Z'),
+        persistedSupportBlocker: {
+          status: 'unsupported',
+          reason: 'agent_thread_limit_reached',
+          expires_at: '2026-07-10T00:00:00.000Z',
+        },
+      }).status,
+      'unknown',
+    );
+    assert.equal(
+      resolveNativeSubagentSupportStatus({
+        nowMs: Date.parse('2026-07-09T00:00:00.000Z'),
+        persistedCapacityBlocker: {
+          reason: 'agent_thread_limit_reached',
+          expires_at: '2026-07-10T00:00:00.000Z',
+        },
+      }).status,
+      'unsupported',
+    );
+    assert.equal(
+      isUnsupportedNativeSubagentEvidence({
+        status: 'unsupported',
+        reason: 'agent_thread_limit_reached',
+        source: 'capacity_blocker',
+        expires_at: '2026-07-10T00:00:00.000Z',
+      }),
+      false,
+    );
+    assert.equal(
+      isUnsupportedNativeSubagentEvidence({
+        status: 'unsupported',
+        reason: 'multi_agent_v1_unavailable',
+      }),
+      false,
+    );
+    assert.equal(
+      isUnsupportedNativeSubagentEvidenceForScope({
+        status: 'unsupported',
+        reason: 'multi_agent_v1_unavailable',
+        source: 'post_tool_failure',
+        session_id: 'sess-1',
+      }),
+      false,
+    );
+    assert.equal(
+      isUnsupportedNativeSubagentEvidenceForScope({
+        status: 'unsupported',
+        reason: 'multi_agent_v1_unavailable',
+        source: 'post_tool_failure',
+        session_id: 'sess-1',
+      }, { sessionId: 'sess-2' }),
+      false,
+    );
+    assert.equal(
+      isUnsupportedNativeSubagentEvidenceForScope({
+        status: 'unsupported',
+        reason: 'multi_agent_v1_unavailable',
+        source: 'post_tool_failure',
+        session_id: 'sess-1',
+      }, { sessionId: 'sess-1' }),
+      true,
+    );
   });
 });

--- a/src/leader/__tests__/contract.test.ts
+++ b/src/leader/__tests__/contract.test.ts
@@ -191,15 +191,26 @@ describe('leader conductor contract', () => {
       }).status,
       'unknown',
     );
+    const capacityOnlyEvidence = resolveNativeSubagentSupportStatus({
+      nowMs: Date.parse('2026-07-09T00:00:00.000Z'),
+      persistedCapacityBlocker: {
+        reason: 'agent_thread_limit_reached',
+        expires_at: '2026-07-10T00:00:00.000Z',
+      },
+    });
+    assert.equal(capacityOnlyEvidence.status, 'unknown');
+    assert.equal(capacityOnlyEvidence.reason, 'agent_thread_limit_reached');
+    assert.equal(capacityOnlyEvidence.source, 'capacity_blocker');
     assert.equal(
       resolveNativeSubagentSupportStatus({
         nowMs: Date.parse('2026-07-09T00:00:00.000Z'),
+        payload: { available_tools: ['Read', 'multi_agent_v1.spawn_agent'] },
         persistedCapacityBlocker: {
           reason: 'agent_thread_limit_reached',
           expires_at: '2026-07-10T00:00:00.000Z',
         },
       }).status,
-      'unsupported',
+      'supported',
     );
     assert.equal(
       isUnsupportedNativeSubagentEvidence({

--- a/src/leader/contract.ts
+++ b/src/leader/contract.ts
@@ -28,6 +28,209 @@ export const LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE = [
   `- ${LEADER_CONDUCTOR_SILVER_RULE}`,
   ...LEADER_CONDUCTOR_REUSE_AND_LEDGER_RULES.map((line) => `- ${line}`),
 ].join('\n');
+export type NativeSubagentSupportStatus = 'supported' | 'unsupported' | 'unknown';
+
+export type NativeSubagentUnsupportedReason =
+  | 'native_subagents_unsupported'
+  | 'multi_agent_v1_unavailable'
+  | 'agent_thread_limit_reached';
+
+export type NativeSubagentSupportEvidenceSource =
+  | 'hook_payload_capability'
+  | 'hook_payload_available_tools'
+  | 'post_tool_failure'
+  | 'persisted_support_blocker'
+  | 'capacity_blocker'
+  | 'default_unknown';
+
+export interface NativeSubagentSupportEvidence {
+  status: NativeSubagentSupportStatus;
+  reason?: NativeSubagentUnsupportedReason;
+  source: NativeSubagentSupportEvidenceSource;
+  evidenceSummary?: string;
+  observedAt?: string;
+  expiresAt?: string;
+}
+
+export interface NativeSubagentCapabilityInput {
+  payload?: Record<string, unknown> | null;
+  persistedSupportBlocker?: Record<string, unknown> | null;
+  persistedCapacityBlocker?: Record<string, unknown> | null;
+  nowMs?: number;
+  cwd?: string;
+  sessionId?: string;
+}
+
+export const NATIVE_SUBAGENT_SUPPORT_BLOCKER_REASONS = [
+  'native_subagents_unsupported',
+  'multi_agent_v1_unavailable',
+  'agent_thread_limit_reached',
+] as const;
+
+export const NATIVE_SUBAGENT_SUPPORT_BLOCKER_FILE = 'native-subagent-support.json';
+
+export const LEADER_CONDUCTOR_UNSUPPORTED_NATIVE_DEGRADE_BLOCK = [
+  'Native subagent support is unavailable in this environment.',
+  'Do not enter or preserve strict Main-root Conductor delegation that requires native subagents or multi_agent_v1.',
+  'Record the unsupported native-subagent blocker, terminalize the workflow as blocked/cancelled/failed, or restart in a runtime with working native subagents.',
+  'Do not treat this as clean ralplan consensus, clean ultragoal final review, or permission for Main-root source/package/git edits.',
+  'Do not call multi_agent_v1.close_agent after native subagent capacity/support failures; stale native handles can hang the turn.',
+].join(' ');
+
+function supportRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function supportString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function supportBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
+function supportArray(value: unknown): unknown[] | null {
+  return Array.isArray(value) ? value : null;
+}
+
+function isNativeSubagentUnsupportedReason(value: unknown): value is NativeSubagentUnsupportedReason {
+  return typeof value === 'string'
+    && (NATIVE_SUBAGENT_SUPPORT_BLOCKER_REASONS as readonly string[]).includes(value);
+}
+
+function isNativeSubagentSupportEvidenceSource(value: unknown): value is NativeSubagentSupportEvidenceSource {
+  return typeof value === 'string'
+    && ['hook_payload_capability', 'hook_payload_available_tools', 'post_tool_failure', 'persisted_support_blocker', 'capacity_blocker', 'default_unknown'].includes(value);
+}
+
+function blockerMatchesScope(blocker: Record<string, unknown>, input: NativeSubagentCapabilityInput): boolean {
+  const expiresAt = supportString(blocker.expires_at ?? blocker.expiresAt);
+  if (expiresAt) {
+    const expiresAtMs = Date.parse(expiresAt);
+    if (!Number.isFinite(expiresAtMs) || expiresAtMs <= (input.nowMs ?? Date.now())) return false;
+  }
+  const blockerCwd = supportString(blocker.cwd);
+  if (blockerCwd && (!input.cwd || blockerCwd !== input.cwd)) return false;
+  const blockerSessionId = supportString(blocker.session_id ?? blocker.sessionId);
+  if (blockerSessionId && (!input.sessionId || blockerSessionId !== input.sessionId)) return false;
+  return true;
+}
+
+function unsupportedEvidenceMatchesScope(record: Record<string, unknown>, input: Pick<NativeSubagentCapabilityInput, 'cwd' | 'sessionId' | 'nowMs'>): boolean {
+  if (!blockerMatchesScope(record, input)) return false;
+  const source = record.source;
+  return isNativeSubagentSupportEvidenceSource(source)
+    && source !== 'capacity_blocker'
+    && source !== 'default_unknown';
+}
+
+function supportEvidenceFromBlocker(
+  blocker: Record<string, unknown> | null | undefined,
+  source: NativeSubagentSupportEvidenceSource,
+  input: NativeSubagentCapabilityInput,
+): NativeSubagentSupportEvidence | null {
+  if (!blocker || !blockerMatchesScope(blocker, input)) return null;
+  const reason = blocker.reason;
+  if (!isNativeSubagentUnsupportedReason(reason)) return null;
+  if (reason === 'agent_thread_limit_reached') {
+    if (source !== 'capacity_blocker') return null;
+    const expiresAt = supportString(blocker.expires_at ?? blocker.expiresAt);
+    const expiresAtMs = expiresAt ? Date.parse(expiresAt) : NaN;
+    if (!Number.isFinite(expiresAtMs) || expiresAtMs <= (input.nowMs ?? Date.now())) return null;
+  }
+  const status = supportString(blocker.status) || 'unsupported';
+  if (status && status !== 'unsupported') return null;
+  return {
+    status: 'unsupported',
+    reason,
+    source,
+    ...(supportString(blocker.error_summary ?? blocker.evidenceSummary ?? blocker.evidence) ? { evidenceSummary: supportString(blocker.error_summary ?? blocker.evidenceSummary ?? blocker.evidence) } : {}),
+    ...(supportString(blocker.observed_at ?? blocker.observedAt) ? { observedAt: supportString(blocker.observed_at ?? blocker.observedAt) } : {}),
+    ...(supportString(blocker.expires_at ?? blocker.expiresAt) ? { expiresAt: supportString(blocker.expires_at ?? blocker.expiresAt) } : {}),
+  };
+}
+
+function capabilityStatusFromRecord(record: Record<string, unknown> | null): NativeSubagentSupportStatus | null {
+  if (!record) return null;
+  const nativeSubagents = supportBoolean(record.native_subagents ?? record.nativeSubagents);
+  const multiAgent = supportBoolean(record.multi_agent_v1 ?? record.multiAgentV1);
+  if (nativeSubagents === false || multiAgent === false) return 'unsupported';
+  if (nativeSubagents === true || multiAgent === true) return 'supported';
+  return null;
+}
+
+function reasonFromCapabilityRecord(record: Record<string, unknown> | null): NativeSubagentUnsupportedReason {
+  const nativeSubagents = supportBoolean(record?.native_subagents ?? record?.nativeSubagents);
+  return nativeSubagents === false ? 'native_subagents_unsupported' : 'multi_agent_v1_unavailable';
+}
+
+function availableToolsEvidence(payload: Record<string, unknown> | null): NativeSubagentSupportEvidence | null {
+  const tools = supportArray(payload?.available_tools ?? payload?.availableTools ?? payload?.tools);
+  if (!tools) return null;
+  const names = tools.map((tool) => typeof tool === 'string'
+    ? tool
+    : supportString(supportRecord(tool)?.name ?? supportRecord(tool)?.tool_name ?? supportRecord(tool)?.toolName)).filter(Boolean);
+  const hasNativeSubagentTool = names.some((name) => /(?:^|\.)spawn_agent$/.test(name) || /multi_agent_v1\.spawn_agent/.test(name) || name === 'task');
+  return hasNativeSubagentTool
+    ? { status: 'supported', source: 'hook_payload_available_tools', evidenceSummary: names.join(', ') }
+    : { status: 'unsupported', reason: 'multi_agent_v1_unavailable', source: 'hook_payload_available_tools', evidenceSummary: names.join(', ') };
+}
+
+export function resolveNativeSubagentSupportStatus(input: NativeSubagentCapabilityInput): NativeSubagentSupportEvidence {
+  const supportBlockerEvidence = supportEvidenceFromBlocker(input.persistedSupportBlocker, 'persisted_support_blocker', input);
+  if (supportBlockerEvidence) return supportBlockerEvidence;
+  const capacityBlockerEvidence = supportEvidenceFromBlocker(input.persistedCapacityBlocker, 'capacity_blocker', input);
+  if (capacityBlockerEvidence) return capacityBlockerEvidence;
+
+  const payload = supportRecord(input.payload);
+  const explicitCapability = supportRecord(payload?.omx_runtime_capabilities)
+    ?? supportRecord(payload?.capabilities);
+  const explicitStatus = capabilityStatusFromRecord(explicitCapability);
+  if (explicitStatus === 'unsupported') {
+    return {
+      status: 'unsupported',
+      reason: reasonFromCapabilityRecord(explicitCapability),
+      source: 'hook_payload_capability',
+      evidenceSummary: 'payload capability reports native subagents or multi_agent_v1 unavailable',
+    };
+  }
+  if (explicitStatus === 'supported') {
+    return {
+      status: 'supported',
+      source: 'hook_payload_capability',
+      evidenceSummary: 'payload capability reports native subagent support',
+    };
+  }
+
+  const toolEvidence = availableToolsEvidence(payload);
+  if (toolEvidence) return toolEvidence;
+
+  return { status: 'unknown', source: 'default_unknown' };
+}
+
+export function isUnsupportedNativeSubagentEvidenceForScope(
+  value: unknown,
+  input: Pick<NativeSubagentCapabilityInput, 'cwd' | 'sessionId' | 'nowMs'> = {},
+): boolean {
+  const record = supportRecord(value);
+  if (!record) return false;
+  if (record.status !== 'unsupported') return false;
+  if (!unsupportedEvidenceMatchesScope(record, input)) return false;
+  if (record.reason === 'agent_thread_limit_reached') return false;
+  return isNativeSubagentUnsupportedReason(record.reason);
+}
+
+export function isUnsupportedNativeSubagentEvidence(value: unknown): boolean {
+  return isUnsupportedNativeSubagentEvidenceForScope(value);
+}
+
+export function buildUnsupportedNativeSubagentGuidance(evidence: NativeSubagentSupportEvidence): string {
+  const reason = evidence.reason ? ` Reason: ${evidence.reason}.` : '';
+  const summary = evidence.evidenceSummary ? ` Evidence: ${evidence.evidenceSummary}.` : '';
+  return `${LEADER_CONDUCTOR_UNSUPPORTED_NATIVE_DEGRADE_BLOCK}${reason}${summary}`;
+}
 
 export type ConductorPhase =
   | 'deep-interview'

--- a/src/leader/contract.ts
+++ b/src/leader/contract.ts
@@ -139,6 +139,14 @@ function supportEvidenceFromBlocker(
     const expiresAt = supportString(blocker.expires_at ?? blocker.expiresAt);
     const expiresAtMs = expiresAt ? Date.parse(expiresAt) : NaN;
     if (!Number.isFinite(expiresAtMs) || expiresAtMs <= (input.nowMs ?? Date.now())) return null;
+    return {
+      status: 'unknown',
+      reason,
+      source,
+      ...(supportString(blocker.error_summary ?? blocker.evidenceSummary ?? blocker.evidence) ? { evidenceSummary: supportString(blocker.error_summary ?? blocker.evidenceSummary ?? blocker.evidence) } : {}),
+      ...(supportString(blocker.observed_at ?? blocker.observedAt) ? { observedAt: supportString(blocker.observed_at ?? blocker.observedAt) } : {}),
+      ...(expiresAt ? { expiresAt } : {}),
+    };
   }
   const status = supportString(blocker.status) || 'unsupported';
   if (status && status !== 'unsupported') return null;
@@ -181,8 +189,6 @@ function availableToolsEvidence(payload: Record<string, unknown> | null): Native
 export function resolveNativeSubagentSupportStatus(input: NativeSubagentCapabilityInput): NativeSubagentSupportEvidence {
   const supportBlockerEvidence = supportEvidenceFromBlocker(input.persistedSupportBlocker, 'persisted_support_blocker', input);
   if (supportBlockerEvidence) return supportBlockerEvidence;
-  const capacityBlockerEvidence = supportEvidenceFromBlocker(input.persistedCapacityBlocker, 'capacity_blocker', input);
-  if (capacityBlockerEvidence) return capacityBlockerEvidence;
 
   const payload = supportRecord(input.payload);
   const explicitCapability = supportRecord(payload?.omx_runtime_capabilities)
@@ -206,6 +212,9 @@ export function resolveNativeSubagentSupportStatus(input: NativeSubagentCapabili
 
   const toolEvidence = availableToolsEvidence(payload);
   if (toolEvidence) return toolEvidence;
+
+  const capacityBlockerEvidence = supportEvidenceFromBlocker(input.persistedCapacityBlocker, 'capacity_blocker', input);
+  if (capacityBlockerEvidence) return capacityBlockerEvidence;
 
   return { status: 'unknown', source: 'default_unknown' };
 }

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -16,7 +16,7 @@ import { createUltraqaStage, buildUltraqaInstruction } from '../stages/ultraqa.j
 import { buildFollowupStaffingPlan } from '../../team/followup-planner.js';
 import { packageRoot } from '../../utils/paths.js';
 import { subagentTrackingPath } from '../../subagents/tracker.js';
-import { LEADER_CONDUCTOR_BLOCK } from '../../leader/contract.js';
+import { LEADER_CONDUCTOR_BLOCK, buildUnsupportedNativeSubagentGuidance } from '../../leader/contract.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1938,6 +1938,35 @@ describe('Default Autopilot Ultragoal Stage Adapters', () => {
     assert.match(artifacts.team_condition as string, /Launch \$team only inside an active Ultragoal story/);
     assert.match(buildUltragoalInstruction('execute me'), /^\$ultragoal /);
     assert.match(buildUltragoalInstruction('execute me'), new RegExp(escapeRegExp(LEADER_CONDUCTOR_BLOCK)));
+    assert.doesNotMatch(buildUltragoalInstruction('execute me'), /Native subagent support is unavailable/);
+    assert.match(buildUltragoalInstruction('execute me', {
+      nativeSubagentSupport: { status: 'unknown', source: 'default_unknown' },
+    }), new RegExp(escapeRegExp(LEADER_CONDUCTOR_BLOCK)));
+    assert.match(buildUltragoalInstruction('execute me', {
+      nativeSubagentSupport: { status: 'supported', source: 'hook_payload_capability' },
+    }), new RegExp(escapeRegExp(LEADER_CONDUCTOR_BLOCK)));
+  });
+
+  it('emits unsupported native subagent guidance for explicit unsupported ultragoal evidence', async () => {
+    const nativeSubagentSupport = {
+      status: 'unsupported' as const,
+      reason: 'multi_agent_v1_unavailable' as const,
+      source: 'hook_payload_capability' as const,
+      evidenceSummary: 'multi_agent_v1 is absent',
+    };
+    const instruction = buildUltragoalInstruction('execute me', { nativeSubagentSupport });
+    assert.doesNotMatch(instruction, /Conductor mode contract:/);
+    assert.match(instruction, new RegExp(escapeRegExp(buildUnsupportedNativeSubagentGuidance(nativeSubagentSupport))));
+
+    const stage = createUltragoalStage();
+    const result = await stage.run(makeCtx({ artifacts: { ralplan: { native_subagent_support: nativeSubagentSupport } } }));
+    const artifacts = result.artifacts as Record<string, unknown>;
+    assert.doesNotMatch(artifacts.instruction as string, /Conductor mode contract:/);
+    assert.match(artifacts.instruction as string, /multi_agent_v1_unavailable/);
+
+    const forged = await stage.run(makeCtx({ artifacts: { ralplan: { native_subagent_support: { status: 'unsupported', reason: 'multi_agent_v1_unavailable' } } } }));
+    const forgedArtifacts = forged.artifacts as Record<string, unknown>;
+    assert.match(forgedArtifacts.instruction as string, /Conductor mode contract:/);
   });
 
   it('creates an ultraqa gate that fails closed without evidence and can record clean skips', async () => {

--- a/src/pipeline/stages/ultragoal.ts
+++ b/src/pipeline/stages/ultragoal.ts
@@ -7,7 +7,12 @@
  */
 
 import type { PipelineStage, StageContext, StageResult } from '../types.js';
-import { LEADER_CONDUCTOR_BLOCK } from '../../leader/contract.js';
+import {
+  LEADER_CONDUCTOR_BLOCK,
+  buildUnsupportedNativeSubagentGuidance,
+  isUnsupportedNativeSubagentEvidenceForScope,
+  type NativeSubagentSupportEvidence,
+} from '../../leader/contract.js';
 
 export interface UltragoalDescriptor {
   task: string;
@@ -18,6 +23,17 @@ export interface UltragoalDescriptor {
   teamCondition: string;
 }
 
+export interface UltragoalInstructionOptions {
+  nativeSubagentSupport?: NativeSubagentSupportEvidence;
+}
+
+function isExplicitUnsupportedNativeSubagentEvidence(
+  value: unknown,
+  input: Pick<StageContext, 'cwd' | 'sessionId'>,
+): value is NativeSubagentSupportEvidence {
+  return isUnsupportedNativeSubagentEvidenceForScope(value, input);
+}
+
 export function createUltragoalStage(): PipelineStage {
   return {
     name: 'ultragoal',
@@ -25,12 +41,16 @@ export function createUltragoalStage(): PipelineStage {
     async run(ctx: StageContext): Promise<StageResult> {
       const startTime = Date.now();
       const ralplanArtifacts = ctx.artifacts.ralplan as Record<string, unknown> | undefined;
+      const nativeSubagentSupport = ralplanArtifacts?.native_subagent_support;
+      const instructionOptions = isExplicitUnsupportedNativeSubagentEvidence(nativeSubagentSupport, ctx)
+        ? { nativeSubagentSupport }
+        : undefined;
       const descriptor: UltragoalDescriptor = {
         task: ctx.task,
         cwd: ctx.cwd,
         sessionId: ctx.sessionId,
         ralplanArtifacts: ralplanArtifacts ?? {},
-        instruction: buildUltragoalInstruction(ctx.task),
+        instruction: buildUltragoalInstruction(ctx.task, instructionOptions),
         teamCondition: 'Launch $team only inside an active Ultragoal story when independent lanes or broad verification make coordinated parallel work useful; Ultragoal remains leader-owned for goal and ledger state.',
       };
 
@@ -48,10 +68,13 @@ export function createUltragoalStage(): PipelineStage {
   };
 }
 
-export function buildUltragoalInstruction(task: string): string {
+export function buildUltragoalInstruction(task: string, options: UltragoalInstructionOptions = {}): string {
+  const conductorGuidance = options.nativeSubagentSupport?.status === 'unsupported'
+    ? buildUnsupportedNativeSubagentGuidance(options.nativeSubagentSupport)
+    : LEADER_CONDUCTOR_BLOCK;
   return [
     `$ultragoal ${JSON.stringify(task)}`,
     '',
-    LEADER_CONDUCTOR_BLOCK,
+    conductorGuidance,
   ].join('\n');
 }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -5039,6 +5039,51 @@ standardMaxRounds = 15
     }
   });
 
+  it("keeps conductor guidance on autopilot activation after capacity-only native subagent evidence", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autopilot-capacity-native-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          session_id: "sess-autopilot-capacity-native",
+          thread_id: "thread-autopilot-capacity-native",
+          turn_id: "turn-autopilot-capacity-native-spawn",
+          tool_name: "multi_agent_v1.spawn_agent",
+          tool_response: { error: "collab spawn failed: agent thread limit reached" },
+        },
+        { cwd },
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-autopilot-capacity-native",
+          thread_id: "thread-autopilot-capacity-native",
+          turn_id: "turn-autopilot-capacity-native-prompt",
+          prompt: "$autopilot implement issue #3078",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "keyword-detector");
+      assert.equal(result.skillState?.skill, "autopilot");
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(message, /Autopilot protocol:/);
+      assert.match(message, /Conductor mode contract:/);
+      assert.match(message, /Golden Rule: When the Main agent is acting in Conductor mode/);
+      assert.match(message, /Conductor reuse and ledger guidance:/);
+      assert.doesNotMatch(message, /Native subagent support is unavailable in this environment/);
+      assert.doesNotMatch(message, /Reason: agent_thread_limit_reached/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("omits conductor block and emits unsupported native guidance for unsupported autopilot first-run payload", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autopilot-unsupported-native-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -5039,6 +5039,37 @@ standardMaxRounds = 15
     }
   });
 
+  it("omits conductor block and emits unsupported native guidance for unsupported autopilot first-run payload", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autopilot-unsupported-native-"));
+    try {
+      await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: "sess-autopilot-unsupported-native",
+          thread_id: "thread-autopilot-unsupported-native",
+          turn_id: "turn-autopilot-unsupported-native",
+          prompt: "$autopilot implement issue #3078",
+          capabilities: { native_subagents: false, multi_agent_v1: false },
+        },
+        { cwd },
+      );
+
+      const message = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(message, /Autopilot protocol:/);
+      assert.doesNotMatch(message, /Conductor mode contract:/);
+      assert.doesNotMatch(message, /Conductor reuse and ledger guidance:/);
+      assert.match(message, /Native subagent support is unavailable in this environment/);
+      assert.match(message, /Reason: native_subagents_unsupported/);
+      assert.match(message, /Do not call multi_agent_v1\.close_agent/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("records ultragoal prompt skill activation with goal-tool handoff guidance", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ultragoal-"));
     try {
@@ -11490,6 +11521,38 @@ PY`,
       assert.equal(blocker.tool_name, "multi_agent_v1.spawn_agent");
       assert.match(String(blocker.error_summary), /agent thread limit reached/);
       assert.ok(Date.parse(String(blocker.expires_at)) > Date.parse(String(blocker.observed_at)));
+      assert.equal(existsSync(join(cwd, ".omx", "state", "native-subagent-support.json")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("records unsupported native subagent support blocker from spawn_agent PostToolUse output", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-subagent-support-record-"));
+    try {
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          session_id: "sess-subagent-support-record",
+          thread_id: "thread-subagent-support-record",
+          turn_id: "turn-subagent-support-record",
+          tool_name: "multi_agent_v1.spawn_agent",
+          tool_response: { error: "unknown tool: multi_agent_v1.spawn_agent is unavailable" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "post-tool-use");
+      const blocker = JSON.parse(
+        await readFile(join(cwd, ".omx", "state", "native-subagent-support.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(blocker.status, "unsupported");
+      assert.equal(blocker.reason, "multi_agent_v1_unavailable");
+      assert.equal(blocker.session_id, "sess-subagent-support-record");
+      assert.equal(blocker.thread_id, "thread-subagent-support-record");
+      assert.equal(blocker.tool_name, "multi_agent_v1.spawn_agent");
+      assert.match(String(blocker.evidence), /unknown tool/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -21454,6 +21517,55 @@ PY`,
 
       assert.equal(result.outputJson?.decision, "block");
       assert.match(String(result.outputJson?.reason ?? ""), /Main-root Conductor mode is active \(ultragoal phase: planning\)/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks unsupported active conductor source edits with native delegation recovery guidance", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-unsupported-conductor-source-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-unsupported-conductor-source";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ultragoal", "planning");
+      await writeJson(join(stateDir, "sessions", sessionId, "ultragoal-state.json"), {
+        active: true,
+        mode: "ultragoal",
+        current_phase: "planning",
+        session_id: sessionId,
+      });
+      await writeJson(join(stateDir, "native-subagent-support.json"), {
+        schema_version: 1,
+        status: "unsupported",
+        reason: "multi_agent_v1_unavailable",
+        session_id: sessionId,
+        evidence: "unknown tool: multi_agent_v1.spawn_agent",
+        observed_at: new Date().toISOString(),
+        cwd,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-unsupported-conductor-source",
+          tool_name: "Write",
+          tool_input: { file_path: "src/runtime.ts", content: "export const value = 1;\n" },
+        },
+        { cwd },
+      );
+
+      const output = result.outputJson as { decision?: string; hookSpecificOutput?: { additionalContext?: string } } | null;
+      const context = String(output?.hookSpecificOutput?.additionalContext ?? "");
+      assert.equal(output?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /Main-root Conductor mode is active \(ultragoal phase: planning\)/);
+      assert.match(context, /Native subagent support is unavailable in this environment/);
+      assert.match(context, /Reason: multi_agent_v1_unavailable/);
+      assert.match(context, /blocked\/cancelled/);
+      assert.match(context, /do not call multi_agent_v1\.close_agent/i);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -94,9 +94,14 @@ import {
   CONDUCTOR_ORCHESTRATION_METADATA_PREFIXES,
   LEADER_CONDUCTOR_BLOCK,
   LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE,
+  NATIVE_SUBAGENT_SUPPORT_BLOCKER_FILE,
   actionKindForConductorArtifact,
   authorizeConductorAction,
+  buildUnsupportedNativeSubagentGuidance,
   classifyConductorArtifactKind,
+  isUnsupportedNativeSubagentEvidence,
+  resolveNativeSubagentSupportStatus,
+  type NativeSubagentUnsupportedReason,
 } from "../leader/contract.js";
 import { readRunState } from "../runtime/run-state.js";
 import { evaluateRalphCompletionAuditEvidence, isRalphCompletePhase } from "../ralph/completion-audit.js";
@@ -2111,12 +2116,23 @@ function buildSkillStateCliInstruction(mode: string, statePath: string): string 
 
 function buildAutopilotPromptActivationNote(
   skillState?: SkillActiveState | null,
-  options: { markedQuestionAnswer?: boolean; cwd?: string } = {},
+  options: { markedQuestionAnswer?: boolean; cwd?: string; payload?: CodexHookPayload; sessionId?: string } = {},
 ): string | null {
   if (skillState?.initialized_mode !== "autopilot") return null;
   const teamHandoff = readTeamModeConfig(options.cwd).enabled
     ? " (+ $team if needed)"
     : "";
+  const stateDir = getBaseStateDir(options.cwd);
+  const nativeSubagentSupport = resolveNativeSubagentSupportStatus({
+    payload: options.payload,
+    persistedSupportBlocker: readJsonSyncIfExists(nativeSubagentSupportBlockerPath(stateDir)),
+    persistedCapacityBlocker: readJsonSyncIfExists(nativeSubagentCapacityBlockerPath(stateDir)),
+    cwd: options.cwd,
+    sessionId: options.sessionId,
+  });
+  const conductorGuidance = nativeSubagentSupport.status === "unsupported"
+    ? buildUnsupportedNativeSubagentGuidance(nativeSubagentSupport)
+    : `${LEADER_CONDUCTOR_BLOCK} ${LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE}`;
   return [
     `Autopilot protocol: the durable default chain is $deep-interview -> $ralplan -> $ultragoal${teamHandoff} -> $code-review -> $ultraqa (deep-interview -> ralplan -> ultragoal -> code-review -> ultraqa).`,
     "Start/resume at current_phase=deep-interview unless the task is clear and bounded; if deep-interview is intentionally skipped, persist and state an explicit deep_interview_gate.skip_reason before moving to ralplan.",
@@ -2128,8 +2144,7 @@ function buildAutopilotPromptActivationNote(
     "The ralplan phase is not complete until Planner output has been reviewed sequentially by Architect and then Critic; do not hand off to Ultragoal or implementation until the ralplan state/artifact records both ralplan_architect_review and ralplan_critic_review with approval or an explicit blocker.",
     "Do not silently fall back to ordinary $plan/ralplan-only handling; keep autopilot-state.json, skill-active-state.json, HUD/statusline, and Codex goal-mode handoff guidance visible while the workflow is active.",
     "When Codex goal tools are available, call get_goal/create_goal only from the active thread handoff and treat the active goal as the completion contract until code-review and ultraqa are clean.",
-    LEADER_CONDUCTOR_BLOCK,
-    LEADER_CONDUCTOR_REUSE_AND_LEDGER_GUIDANCE,
+    conductorGuidance,
   ].filter(Boolean).join(" ");
 }
 
@@ -2161,7 +2176,7 @@ function buildAdditionalContextMessage(
       : null;
     const deepInterviewConfigPromptActivationNote = buildDeepInterviewConfigInstruction(cwd, skillState);
     const markedQuestionAnswer = /^\s*\[omx question answered\]/i.test(prompt);
-    const autopilotPromptActivationNote = buildAutopilotPromptActivationNote(skillState, { markedQuestionAnswer, cwd });
+    const autopilotPromptActivationNote = buildAutopilotPromptActivationNote(skillState, { markedQuestionAnswer, cwd, payload, sessionId: safeString(skillState?.session_id).trim() });
     return [
       `OMX native UserPromptSubmit continued active workflow skill "${continuedSkill}".`,
       promptPriorityMessage,
@@ -2187,7 +2202,7 @@ function buildAdditionalContextMessage(
       ? buildDeepInterviewQuestionBridgeInstruction(cwd, payload)
       : null;
     const deepInterviewConfigPromptActivationNote = buildDeepInterviewConfigInstruction(cwd, skillState);
-    const autopilotPromptActivationNote = buildAutopilotPromptActivationNote(skillState, { markedQuestionAnswer: true, cwd });
+    const autopilotPromptActivationNote = buildAutopilotPromptActivationNote(skillState, { markedQuestionAnswer: true, cwd, payload, sessionId: safeString(skillState?.session_id).trim() });
     return [
       `OMX native UserPromptSubmit continued active workflow skill "${continuedSkill}"; workflow-like tokens inside the marked omx question answer are treated as answer text, not a new workflow activation.`,
       promptPriorityMessage,
@@ -2220,7 +2235,7 @@ function buildAdditionalContextMessage(
   const ultragoalPromptActivationNote = match.skill === "ultragoal"
     ? "Ultragoal protocol: use `omx ultragoal create-goals` / `complete-goals` / `checkpoint` for `.omx/ultragoal` artifacts, then use Codex goal model tools only from the active agent handoff (`get_goal`, `create_goal`, `update_goal`) and never overwrite a different active Codex goal. Ultragoal does not call `/goal clear`; for multiple sequential ultragoal runs in one Codex session/thread, manually clear the completed Codex goal in the UI before creating the next aggregate goal."
     : null;
-  const autopilotPromptActivationNote = buildAutopilotPromptActivationNote(skillState, { cwd });
+  const autopilotPromptActivationNote = buildAutopilotPromptActivationNote(skillState, { cwd, payload, sessionId: safeString(skillState?.session_id).trim() });
   const combinedTransitionMessage = (() => {
     if (!skillState?.transition_message) return null;
     if (matches.length <= 1 || activeSkills.length <= 1) return skillState.transition_message;
@@ -3094,6 +3109,18 @@ function nativeSubagentCapacityBlockerPath(stateDir: string): string {
   return join(stateDir, NATIVE_SUBAGENT_CAPACITY_BLOCKER_FILE);
 }
 
+function nativeSubagentSupportBlockerPath(stateDir: string): string {
+  return join(stateDir, NATIVE_SUBAGENT_SUPPORT_BLOCKER_FILE);
+}
+
+function readJsonSyncIfExists(path: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
 function stringifyUnknown(value: unknown): string {
   if (typeof value === "string") return value;
   if (value === undefined || value === null) return "";
@@ -3119,6 +3146,45 @@ function isNativeSubagentCapacityFailure(payload: CodexHookPayload): boolean {
   if (!/\bagent thread limit reached\b/i.test(evidence)) return false;
   const toolName = safeString(payload.tool_name).trim();
   return !toolName || /(?:spawn_agent|multi_agent|subagent|collab|agent)/i.test(toolName);
+}
+
+function nativeSubagentFailureReason(payload: CodexHookPayload): NativeSubagentUnsupportedReason | null {
+  const evidence = payloadEvidenceText(payload);
+  const toolName = safeString(payload.tool_name).trim();
+  if (toolName && !/(?:spawn_agent|multi_agent|subagent|collab|agent)/i.test(toolName)) return null;
+  if (/\bagent thread limit reached\b/i.test(evidence)) return null;
+  if (/\bnative subagents? (?:unsupported|disabled|not enabled|unavailable|not found)\b/i.test(evidence)) return "native_subagents_unsupported";
+  if (/\bmulti_agent_v1\b/i.test(evidence) && /\b(?:unavailable|unknown tool|disabled|not enabled|not found|unsupported)\b/i.test(evidence)) return "multi_agent_v1_unavailable";
+  if (/\b(?:unknown tool|tool not found|not enabled|disabled|unavailable|unsupported)\b/i.test(evidence)) return "multi_agent_v1_unavailable";
+  return null;
+}
+
+function summarizeNativeSubagentSupportFailure(text: string): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  return (normalized || "native subagent support unavailable").slice(0, 500);
+}
+
+async function recordNativeSubagentSupportBlocker(
+  cwd: string,
+  stateDir: string,
+  payload: CodexHookPayload,
+): Promise<void> {
+  const reason = nativeSubagentFailureReason(payload);
+  if (!reason) return;
+  const nowIso = new Date().toISOString();
+  await mkdir(stateDir, { recursive: true });
+  await writeFile(nativeSubagentSupportBlockerPath(stateDir), JSON.stringify({
+    schema_version: 1,
+    status: "unsupported",
+    reason,
+    ...(readPayloadSessionId(payload) ? { session_id: readPayloadSessionId(payload) } : {}),
+    ...(readPayloadThreadId(payload) ? { thread_id: readPayloadThreadId(payload) } : {}),
+    ...(readPayloadTurnId(payload) ? { turn_id: readPayloadTurnId(payload) } : {}),
+    ...(safeString(payload.tool_name).trim() ? { tool_name: safeString(payload.tool_name).trim() } : {}),
+    evidence: summarizeNativeSubagentSupportFailure(payloadEvidenceText(payload)),
+    observed_at: nowIso,
+    cwd,
+  }, null, 2));
 }
 
 function summarizeCapacityFailure(text: string): string {
@@ -7865,6 +7931,14 @@ export async function buildConductorPreToolUseWriteGuardOutput(
 ): Promise<Record<string, unknown> | null> {
   const activeState = await readActiveMainRootConductorStateForPreToolUse(payload, cwd, stateDir, resolvedSessionId);
   if (!activeState) return null;
+  const nativeSubagentSupport = resolveNativeSubagentSupportStatus({
+    payload,
+    persistedSupportBlocker: await readJsonIfExists(nativeSubagentSupportBlockerPath(stateDir)),
+    persistedCapacityBlocker: await readJsonIfExists(nativeSubagentCapacityBlockerPath(stateDir)),
+    cwd,
+    sessionId: resolvedSessionId || readPayloadSessionId(payload),
+  });
+
 
   const toolName = safeString(payload.tool_name).trim();
   const command = readPreToolUseCommand(payload);
@@ -7891,6 +7965,9 @@ export async function buildConductorPreToolUseWriteGuardOutput(
 
   if (!blocked) return null;
 
+  const unsupportedNativeGuidance = isUnsupportedNativeSubagentEvidence(nativeSubagentSupport)
+    ? ` ${buildUnsupportedNativeSubagentGuidance(nativeSubagentSupport)} Treat the active conductor workflow as blocked/cancelled for native delegation recovery; do not call multi_agent_v1.close_agent.`
+    : "";
   return {
     decision: "block",
     reason: `Main-root Conductor mode is active (${activeState.mode} phase: ${formatPhase(activeState.phase, "active")}); direct plan/code writes are blocked and must be delegated; ${blockedDetail}.`,
@@ -7900,7 +7977,8 @@ export async function buildConductorPreToolUseWriteGuardOutput(
         `${LEADER_CONDUCTOR_GOLDEN_RULE} `
         + "Use specialized agents for source edits and plan/spec authorship. "
         + `Main-root Conductor may write only orchestration metadata/transport/ledger artifacts under ${CONDUCTOR_ORCHESTRATION_METADATA_PREFIXES.join(", ")}; path location alone is not authorization for substantive deliverables. `
-        + "Autopilot rework and typed subagent/worker lanes are exempt from this guard.",
+        + unsupportedNativeGuidance
+        + " Autopilot rework and typed subagent/worker lanes are exempt from this guard.",
     },
   };
 }
@@ -9643,6 +9721,7 @@ export async function dispatchCodexNativeHook(
       ?? buildNativePreToolUseOutput(payload);
   } else if (hookEventName === "PostToolUse") {
     await recordNativeSubagentCapacityBlocker(cwd, stateDir, payload).catch(() => {});
+    await recordNativeSubagentSupportBlocker(cwd, stateDir, payload).catch(() => {});
     if (detectMcpTransportFailure(payload)) {
       await markTeamTransportFailure(cwd, payload);
     }

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -1217,6 +1217,299 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('allows ralplan unsupported native non-clean recovery without tracker-backed consensus', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-unsupported-recovery-'));
+    try {
+      const sessionId = 'sess-ralplan-unsupported-recovery';
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: sessionId,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'blocked',
+        native_subagent_support: {
+          status: 'unsupported',
+          reason: 'multi_agent_v1_unavailable',
+          source: 'post_tool_failure',
+        },
+      });
+
+      assert.equal(response.isError, undefined);
+      const state = JSON.parse(await readFile(join(sessionDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(state.active, false);
+      assert.equal(state.current_phase, 'blocked');
+      assert.equal(state.ralplan_consensus_gate, undefined);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects ralplan clean complete without tracker-backed native consensus after unsupported recovery support', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-clean-still-strict-'));
+    try {
+      const sessionId = 'sess-ralplan-clean-still-strict';
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+        native_subagent_support: {
+          status: 'unsupported',
+          reason: 'multi_agent_v1_unavailable',
+          source: 'post_tool_failure',
+        },
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: sessionId,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        status: 'complete',
+      });
+
+      assert.equal(response.isError, true);
+      assert.match(String((response.payload as { error?: unknown }).error ?? ''), /Cannot complete ralplan cleanly while native subagent support is unavailable/);
+      const state = JSON.parse(await readFile(join(sessionDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(state.active, true);
+      assert.equal(state.current_phase, 'planning');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects ralplan clean complete with unsupported evidence even when native consensus is valid', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-clean-unsupported-valid-consensus-deny-'));
+    try {
+      const sessionId = 'sess-ralplan-clean-unsupported-valid-consensus-deny';
+      await writeNativeSubagentTracking(wd, sessionId);
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: sessionId,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        status: 'complete',
+        native_subagent_support: {
+          status: 'unsupported',
+          reason: 'multi_agent_v1_unavailable',
+          source: 'post_tool_failure',
+        },
+        ralplan_consensus_gate: ralplanConsensusGate(sessionId, 'native_subagent'),
+      });
+
+      assert.equal(response.isError, true);
+      assert.match(String((response.payload as { error?: unknown }).error ?? ''), /Cannot complete ralplan cleanly while native subagent support is unavailable/);
+      const state = JSON.parse(await readFile(join(sessionDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(state.active, true);
+      assert.equal(state.current_phase, 'planning');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects ralplan clean complete with handoff-artifact unsupported evidence', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-clean-handoff-unsupported-deny-'));
+    try {
+      const sessionId = 'sess-ralplan-clean-handoff-unsupported-deny';
+      await writeNativeSubagentTracking(wd, sessionId);
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: sessionId,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        status: 'complete',
+        handoff_artifacts: {
+          ralplan: {
+            native_subagent_support: {
+              status: 'unsupported',
+              reason: 'multi_agent_v1_unavailable',
+              source: 'post_tool_failure',
+            },
+          },
+        },
+        ralplan_consensus_gate: ralplanConsensusGate(sessionId, 'native_subagent'),
+      });
+
+      assert.equal(response.isError, true);
+      assert.match(String((response.payload as { error?: unknown }).error ?? ''), /Cannot complete ralplan cleanly while native subagent support is unavailable/);
+      const state = JSON.parse(await readFile(join(sessionDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(state.active, true);
+      assert.equal(state.current_phase, 'planning');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects ralplan clean complete with nested handoff-artifact unsupported evidence', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-clean-nested-handoff-unsupported-deny-'));
+    try {
+      const sessionId = 'sess-ralplan-clean-nested-handoff-unsupported-deny';
+      await writeNativeSubagentTracking(wd, sessionId);
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: sessionId,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        status: 'complete',
+        state: {
+          handoff_artifacts: {
+            ralplan: {
+              native_subagent_support: {
+                status: 'unsupported',
+                reason: 'multi_agent_v1_unavailable',
+                source: 'post_tool_failure',
+              },
+            },
+          },
+        },
+        ralplan_consensus_gate: ralplanConsensusGate(sessionId, 'native_subagent'),
+      });
+
+      assert.equal(response.isError, true);
+      assert.match(String((response.payload as { error?: unknown }).error ?? ''), /Cannot complete ralplan cleanly while native subagent support is unavailable/);
+      const state = JSON.parse(await readFile(join(sessionDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(state.active, true);
+      assert.equal(state.current_phase, 'planning');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects ralplan clean complete with handoff-root unsupported evidence', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-clean-handoff-root-unsupported-deny-'));
+    try {
+      const sessionId = 'sess-ralplan-clean-handoff-root-unsupported-deny';
+      await writeNativeSubagentTracking(wd, sessionId);
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: sessionId,
+        mode: 'ralplan',
+        active: false,
+        current_phase: 'complete',
+        status: 'complete',
+        handoff_artifacts: {
+          native_subagent_support: {
+            status: 'unsupported',
+            reason: 'multi_agent_v1_unavailable',
+            source: 'post_tool_failure',
+          },
+          ralplan_consensus_gate: ralplanConsensusGate(sessionId, 'native_subagent'),
+        },
+      });
+
+      assert.equal(response.isError, true);
+      assert.match(String((response.payload as { error?: unknown }).error ?? ''), /Cannot complete ralplan cleanly while native subagent support is unavailable/);
+      const state = JSON.parse(await readFile(join(sessionDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(state.active, true);
+      assert.equal(state.current_phase, 'planning');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects ralplan clean status alias with unsupported evidence even when native consensus is valid', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-status-alias-unsupported-deny-'));
+    try {
+      const sessionId = 'sess-ralplan-status-alias-unsupported-deny';
+      await writeNativeSubagentTracking(wd, sessionId);
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd }, null, 2));
+      await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({
+        mode: 'ralplan',
+        active: true,
+        current_phase: 'planning',
+        session_id: sessionId,
+      }, null, 2));
+
+      const response = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        session_id: sessionId,
+        mode: 'ralplan',
+        active: false,
+        status: 'complete',
+        native_subagent_support: {
+          status: 'unsupported',
+          reason: 'multi_agent_v1_unavailable',
+          source: 'post_tool_failure',
+        },
+        ralplan_consensus_gate: ralplanConsensusGate(sessionId, 'native_subagent'),
+      });
+
+      assert.equal(response.isError, true);
+      assert.match(String((response.payload as { error?: unknown }).error ?? ''), /Cannot complete ralplan cleanly while native subagent support is unavailable/);
+      const state = JSON.parse(await readFile(join(sessionDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(state.active, true);
+      assert.equal(state.current_phase, 'planning');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('normalizes currentPhase before gating ralplan terminal writes', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-current-phase-alias-'));
     try {
@@ -3753,6 +4046,42 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('allows Autopilot ralplan unsupported native non-clean recovery', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ralplan-unsupported-recovery-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-ralplan-unsupported-recovery';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+          active: true,
+          mode: 'autopilot',
+          current_phase: 'ralplan',
+        }, null, 2));
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: false,
+          current_phase: 'blocked',
+          native_subagent_support: {
+            status: 'unsupported',
+            reason: 'multi_agent_v1_unavailable',
+            source: 'post_tool_failure',
+          },
+        });
+
+        assert.equal(response.isError, undefined);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.active, false);
+        assert.equal(state.current_phase, 'blocked');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('denies Autopilot ralplan to ultragoal self-write with codex_exec consensus evidence', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ralplan-native-deny-'));
     try {
@@ -3791,6 +4120,95 @@ describe('state operations directory initialization', () => {
         const state = JSON.parse(
           await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8'),
         ) as Record<string, unknown>;
+        assert.equal(state.current_phase, 'ralplan');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies Autopilot ralplan to ultragoal when unsupported native evidence is present', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ralplan-unsupported-ultragoal-deny-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-ralplan-unsupported-ultragoal-deny';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+          active: true,
+          mode: 'autopilot',
+          current_phase: 'ralplan',
+          native_subagent_support: {
+            status: 'unsupported',
+            reason: 'native_subagents_unsupported',
+            source: 'post_tool_failure',
+          },
+        }, null, 2));
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: true,
+          current_phase: 'ultragoal',
+          native_subagent_support: {
+            status: 'unsupported',
+            reason: 'native_subagents_unsupported',
+            source: 'post_tool_failure',
+          },
+        });
+
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ''), /Cannot transition ralplan -> ultragoal/i);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
+        assert.equal(state.current_phase, 'ralplan');
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies Autopilot ralplan to ultragoal with unsupported evidence even when native consensus is valid', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autopilot-ralplan-unsupported-valid-consensus-deny-'));
+    try {
+      await withOmxRootEnv(wd, async () => {
+        const sessionId = 'sess-autopilot-ralplan-unsupported-valid-consensus-deny';
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+        await mkdir(sessionDir, { recursive: true });
+        await writeNativeSubagentTracking(wd, sessionId);
+        await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
+          active: true,
+          mode: 'autopilot',
+          current_phase: 'ralplan',
+          native_subagent_support: {
+            status: 'unsupported',
+            reason: 'multi_agent_v1_unavailable',
+            source: 'post_tool_failure',
+          },
+          state: {
+            handoff_artifacts: {
+              ralplan: {
+                plan_path: '.omx/plans/prd.md',
+                test_spec_path: '.omx/plans/test-spec.md',
+              },
+              ralplan_consensus_gate: ralplanConsensusGate(sessionId, 'native_subagent'),
+            },
+          },
+        }, null, 2));
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          session_id: sessionId,
+          mode: 'autopilot',
+          active: true,
+          current_phase: 'ultragoal',
+        });
+
+        assert.equal(response.isError, true);
+        const error = String((response.payload as { error?: string }).error || '');
+        assert.match(error, /terminalize non-clean/);
+        assert.match(error, /blocked\/cancelled\/failed/);
+        const state = JSON.parse(await readFile(join(sessionDir, 'autopilot-state.json'), 'utf-8')) as Record<string, unknown>;
         assert.equal(state.current_phase, 'ralplan');
       });
     } finally {

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -62,6 +62,9 @@ import {
   canAdvanceAutopilotRalplanToUltragoal,
 } from '../autopilot/ralplan-gate.js';
 import {
+  isUnsupportedNativeSubagentEvidenceForScope,
+} from '../leader/contract.js';
+import {
   buildRalplanConsensusGateFromSources,
 } from '../ralplan/consensus-gate.js';
 
@@ -297,8 +300,61 @@ function isCompleteRalplanTerminalState(state: Record<string, unknown>): boolean
 }
 
 function isRalplanCompleteCloseoutAttempt(state: Record<string, unknown>): boolean {
-  const currentPhase = stringValue(state.current_phase).trim().toLowerCase();
-  return state.active === false && currentPhase === 'complete';
+  return state.active === false && hasCleanTerminalValue(state);
+}
+function stateContainsUnsupportedNativeSubagentEvidence(
+  state: Record<string, unknown>,
+  input: { cwd?: string; sessionId?: string } = {},
+): boolean {
+  const nestedState = objectRecord(state.state);
+  const handoffArtifacts = objectRecord(state.handoff_artifacts);
+  const nestedHandoffArtifacts = objectRecord(nestedState.handoff_artifacts);
+  const ralplanHandoff = objectRecord(handoffArtifacts.ralplan);
+  const nestedRalplanHandoff = objectRecord(nestedHandoffArtifacts.ralplan);
+  return isUnsupportedNativeSubagentEvidenceForScope(state.native_subagent_support, input)
+    || isUnsupportedNativeSubagentEvidenceForScope(nestedState.native_subagent_support, input)
+    || isUnsupportedNativeSubagentEvidenceForScope(handoffArtifacts.native_subagent_support, input)
+    || isUnsupportedNativeSubagentEvidenceForScope(nestedHandoffArtifacts.native_subagent_support, input)
+    || isUnsupportedNativeSubagentEvidenceForScope(ralplanHandoff.native_subagent_support, input)
+    || isUnsupportedNativeSubagentEvidenceForScope(nestedRalplanHandoff.native_subagent_support, input);
+}
+
+function hasNonCleanTerminalValue(state: Record<string, unknown>): boolean {
+  const terminalValues = new Set(['blocked', 'cancelled', 'failed']);
+  return terminalValues.has(stringValue(state.current_phase).trim().toLowerCase())
+    || terminalValues.has(stringValue(state.status).trim().toLowerCase())
+    || terminalValues.has(stringValue(state.outcome).trim().toLowerCase())
+    || terminalValues.has(stringValue(state.terminal_outcome).trim().toLowerCase())
+    || terminalValues.has(stringValue(state.lifecycle_outcome).trim().toLowerCase())
+    || terminalValues.has(stringValue(state.run_outcome).trim().toLowerCase());
+}
+
+function hasCleanTerminalValue(state: Record<string, unknown>): boolean {
+  const terminalValues = [
+    state.current_phase,
+    state.status,
+    state.outcome,
+    state.terminal_outcome,
+    state.lifecycle_outcome,
+    state.run_outcome,
+  ];
+  return terminalValues.some((value) => stringValue(value).trim().toLowerCase() === 'complete');
+}
+
+function hasCompleteRalplanConsensusGate(state: Record<string, unknown>): boolean {
+  const nestedState = objectRecord(state.state);
+  return objectRecord(state.ralplan_consensus_gate).complete === true
+    || objectRecord(nestedState.ralplan_consensus_gate).complete === true;
+}
+
+function isApprovedUnsupportedNativeNonCleanRecoveryState(
+  state: Record<string, unknown>,
+  input: { cwd?: string; sessionId?: string } = {},
+): boolean {
+  if (state.active !== false) return false;
+  if (hasCleanTerminalValue(state)) return false;
+  if (hasCompleteRalplanConsensusGate(state)) return false;
+  return stateContainsUnsupportedNativeSubagentEvidence(state, input) && hasNonCleanTerminalValue(state);
 }
 
 export function validateRalplanTerminalConsensus(
@@ -308,6 +364,9 @@ export function validateRalplanTerminalConsensus(
   options: { requireNativeSubagents?: boolean } = {},
 ): string | null {
   if (!isRalplanCompleteCloseoutAttempt(state)) return null;
+  if (stateContainsUnsupportedNativeSubagentEvidence(state, { cwd, sessionId })) {
+    return 'Cannot complete ralplan cleanly while native subagent support is unavailable; terminalize the workflow as blocked/cancelled/failed or restart in a runtime with working native subagents.';
+  }
   const stateSessionId = sessionId ?? optionalSessionId(state.session_id);
   const gate = buildRalplanConsensusGateFromSources([
     { source: 'state-write-ralplan-terminal', value: state, sessionId: stateSessionId },
@@ -795,7 +854,8 @@ export async function executeStateOperation(
             normalizeCleanAutopilotCompletionEvidence(mergedRaw);
           }
 
-          if (mode === 'ralplan') {
+          const unsupportedNativeNonCleanRecovery = isApprovedUnsupportedNativeNonCleanRecoveryState(mergedRaw, { cwd, sessionId: effectiveSessionId });
+          if (mode === 'ralplan' && !unsupportedNativeNonCleanRecovery) {
             validationError = validateRalplanTerminalConsensus(cwd, mergedRaw, effectiveSessionId, {
               requireNativeSubagents: true,
             });
@@ -805,7 +865,7 @@ export async function executeStateOperation(
           const currentAutopilotChildPhase = mode === 'autopilot'
             ? deriveAutopilotChildPhase({ mode: 'autopilot', ...existing })
             : null;
-          const nextAutopilotChildPhase = mode === 'autopilot'
+          let nextAutopilotChildPhase = mode === 'autopilot'
             ? deriveAutopilotChildPhase({ mode: 'autopilot', ...mergedRaw })
             : null;
 
@@ -825,6 +885,14 @@ export async function executeStateOperation(
           ) {
             validationError = 'Cannot complete Autopilot before ultragoal gate: ralplan may only advance to ultragoal.';
             return;
+          }
+
+          if (
+            mode === 'autopilot'
+            && currentAutopilotChildPhase === 'ralplan'
+            && unsupportedNativeNonCleanRecovery
+          ) {
+            nextAutopilotChildPhase = currentAutopilotChildPhase;
           }
 
           if (mode === 'autopilot') {
@@ -943,13 +1011,15 @@ export async function executeStateOperation(
             await ensureCanonicalRalphArtifacts(cwd, effectiveSessionId);
           }
           const data = JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>;
-          const ralplanCompletionHandled = mode === 'ralplan' && await completeRalplanSession({
-            cwd,
-            baseStateDir,
-            state: data,
-            explicitSessionId: effectiveSessionId,
-            requireNativeSubagents: true,
-          });
+          const ralplanCompletionHandled = mode === 'ralplan'
+            && !isApprovedUnsupportedNativeNonCleanRecoveryState(data, { cwd, sessionId: effectiveSessionId })
+            && await completeRalplanSession({
+              cwd,
+              baseStateDir,
+              state: data,
+              explicitSessionId: effectiveSessionId,
+              requireNativeSubagents: true,
+            });
           if (!ralplanCompletionHandled) {
             await syncCanonicalSkillStateForMode({
               cwd,

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -20,7 +20,7 @@ import {
   type UltragoalPlan,
   type UltragoalSteeringProposal,
 } from '../artifacts.js';
-import { LEADER_CONDUCTOR_BLOCK } from '../../leader/contract.js';
+import { LEADER_CONDUCTOR_BLOCK, buildUnsupportedNativeSubagentGuidance } from '../../leader/contract.js';
 import { steeringFixtures, type SteeringFixtureProposal } from './steering-fixtures.js';
 
 async function withTempRepo<T>(run: (cwd: string) => Promise<T>): Promise<T> {
@@ -322,6 +322,19 @@ describe('ultragoal artifacts', () => {
       assert.match(perStoryInstruction, /independent delegation is unavailable\/skipped\/failed, do not call update_goal/);
       assert.match(perStoryInstruction, /APPROVE \+ CLEAR \+ independent code-reviewer and architect subagent evidence/);
       assert.match(perStoryInstruction, new RegExp(escapeRegExp(LEADER_CONDUCTOR_BLOCK)));
+
+      const nativeSubagentSupport = {
+        status: 'unsupported' as const,
+        reason: 'native_subagents_unsupported' as const,
+        source: 'persisted_support_blocker' as const,
+        evidenceSummary: 'native subagents are disabled in this runtime',
+      };
+      const unsupportedInstruction = buildCodexGoalInstruction(perStory.goal!, perStory.plan, { nativeSubagentSupport });
+      assert.doesNotMatch(unsupportedInstruction, /Conductor mode contract:/);
+      assert.match(unsupportedInstruction, new RegExp(escapeRegExp(buildUnsupportedNativeSubagentGuidance(nativeSubagentSupport))));
+      assert.match(unsupportedInstruction, /record-review-blockers/);
+      assert.match(unsupportedInstruction, /non-clean blocker/);
+      assert.match(unsupportedInstruction, /Native independent review unavailable/);
     });
   });
 
@@ -1017,6 +1030,30 @@ describe('ultragoal artifacts', () => {
               recommendation: 'APPROVE',
               architectStatus: 'CLEAR',
               evidence: 'same execution lane self-reviewed and approved without spawning review subagents',
+            },
+          },
+        }),
+        /independent review unavailable|self-approving/i,
+      );
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: started.goal!.id,
+          status: 'complete',
+          evidence: 'tests passed',
+          codexGoal: { goal: { objective, status: 'complete' } },
+          qualityGate: {
+            ...cleanQualityGate(),
+            codeReview: {
+              recommendation: 'APPROVE',
+              architectStatus: 'CLEAR',
+              evidence: 'native independent review unavailable',
+            },
+            nativeSubagentSupport: {
+              status: 'unsupported',
+              reason: 'native_subagents_unsupported',
+              source: 'persisted_support_blocker',
+              evidenceSummary: 'native subagents are disabled in this runtime',
             },
           },
         }),

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -7,7 +7,11 @@ import {
   parseCodexGoalSnapshot,
   reconcileCodexGoalSnapshot,
 } from '../goal-workflows/codex-goal-snapshot.js';
-import { LEADER_CONDUCTOR_BLOCK } from '../leader/contract.js';
+import {
+  LEADER_CONDUCTOR_BLOCK,
+  buildUnsupportedNativeSubagentGuidance,
+  type NativeSubagentSupportEvidence,
+} from '../leader/contract.js';
 
 export const ULTRAGOAL_DIR = '.omx/ultragoal';
 export const ULTRAGOAL_BRIEF = 'brief.md';
@@ -244,6 +248,10 @@ export interface AddUltragoalGoalOptions {
 export interface RecordFinalReviewBlockersOptions extends AddUltragoalGoalOptions {
   goalId: string;
   codexGoal?: unknown;
+}
+
+export interface CodexGoalInstructionOptions {
+  nativeSubagentSupport?: NativeSubagentSupportEvidence;
 }
 
 export interface UltragoalQualityGate {
@@ -1877,19 +1885,31 @@ export async function recordFinalReviewBlockers(cwd: string, options: RecordFina
   });
 }
 
-export function buildCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalPlan): string {
-  if (codexGoalMode(plan) === 'aggregate') return buildAggregateCodexGoalInstruction(goal, plan);
-  return buildPerStoryCodexGoalInstruction(goal, plan);
+function codexGoalConductorGuidance(options: CodexGoalInstructionOptions): string {
+  if (options.nativeSubagentSupport?.status !== 'unsupported') return LEADER_CONDUCTOR_BLOCK;
+  return [
+    buildUnsupportedNativeSubagentGuidance(options.nativeSubagentSupport),
+    'Native independent review unavailable: do not treat final review as clean, do not call update_goal for clean completion, and use omx ultragoal record-review-blockers to create a non-clean blocker for the missing native independent review.',
+  ].join('\n');
 }
 
-function buildPerStoryCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalPlan): string {
+export function buildCodexGoalInstruction(
+  goal: UltragoalItem,
+  plan: UltragoalPlan,
+  options: CodexGoalInstructionOptions = {},
+): string {
+  if (codexGoalMode(plan) === 'aggregate') return buildAggregateCodexGoalInstruction(goal, plan, options);
+  return buildPerStoryCodexGoalInstruction(goal, plan, options);
+}
+
+function buildPerStoryCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalPlan, options: CodexGoalInstructionOptions): string {
   const createPayload = {
     objective: goal.objective,
     ...(goal.tokenBudget ? { token_budget: goal.tokenBudget } : {}),
   };
   const finalStory = isFinalRunCompletionCandidate(plan, goal);
   return [
-    LEADER_CONDUCTOR_BLOCK,
+    codexGoalConductorGuidance(options),
     '',
     'Ultragoal active-goal handoff',
     `Plan: ${plan.goalsPath}`,
@@ -1938,13 +1958,13 @@ function buildPerStoryCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalP
   ].filter((line): line is string => line !== null).join('\n');
 }
 
-function buildAggregateCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalPlan): string {
+function buildAggregateCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalPlan, options: CodexGoalInstructionOptions): string {
   const objective = plan.codexObjective ?? aggregateCodexObjective(plan.goals);
   const finalStory = isFinalRunCompletionCandidate(plan, goal);
   const createPayload = { objective };
   const checkpointStatus = finalStory ? 'complete' : 'active';
   return [
-    LEADER_CONDUCTOR_BLOCK,
+    codexGoalConductorGuidance(options),
     '',
     'Ultragoal aggregate-goal handoff',
     `Plan: ${plan.goalsPath}`,


### PR DESCRIPTION
## Summary
- Fixes #3078.
- Records explicit unsupported native-subagent evidence and degrades conductor/ultragoal guidance instead of preserving strict native delegation when multi_agent_v1 is unavailable.
- Blocks clean ralplan/autopilot-to-ultragoal completion when scoped unsupported native evidence is present, while allowing non-clean blocked/cancelled/failed recovery.
- Rejects source-less or mismatched scoped unsupported evidence as authoritative.

## Validation
- `npm run build` — passed.
- `node dist/scripts/run-test-files.js dist/autopilot/__tests__/ralplan-gate.test.js dist/leader/__tests__/contract.test.js dist/pipeline/__tests__/stages.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/state/__tests__/operations.test.js dist/ultragoal/__tests__/artifacts.test.js` — passed (25 + 7 + 77 + 505 + 104 + 52 tests).
- `npm run check:no-unused` — passed.
- `git diff --check` — passed.

Full `npm test` was not rerun after session recovery; prior session had a long-running full suite active before tmux vanished, so current validation used the requested minimum matrix plus changed-file focused tests.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*