### PR TITLE
Fix resume updated sort mtimes

### DIFF
--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import TOML from '@iarna/toml';
-import { chmod, mkdir, mkdtemp, readFile, readdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat, symlink, utimes, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -568,6 +568,60 @@ case "$(cat "$CODEX_HOME/config.toml")" in *'source = "${repoRoot}"'*) echo mark
         await readFile(join(projectCodexHome, 'session_index.jsonl'), 'utf-8'),
         '{"id":"project-session"}\n{"id":"madmax-session"}\n',
       );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves transcript mtimes while materializing runtime history for updated sort', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-updated-sort-mtime-'));
+    try {
+      const home = join(wd, 'home');
+      const projectCodexHome = join(wd, '.codex');
+      const previousRuntimeCodexHome = join(wd, '.omx', 'runtime', 'codex-home', 'omx-existing-runtime');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const oldRolloutPath = join(projectCodexHome, 'sessions', '2024', '01', '02', 'rollout-old-a.jsonl');
+      const newerRolloutPath = join(projectCodexHome, 'sessions', '2024', '03', '04', 'rollout-old-b.jsonl');
+      const oldMtime = new Date('2024-01-02T03:04:05Z');
+      const newerMtime = new Date('2024-03-04T05:06:07Z');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await mkdir(dirname(oldRolloutPath), { recursive: true });
+      await mkdir(dirname(newerRolloutPath), { recursive: true });
+      await mkdir(previousRuntimeCodexHome, { recursive: true });
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+      await writeFile(join(projectCodexHome, 'config.toml'), 'model = "gpt-5.5"\n');
+      await writeFile(oldRolloutPath, '{"type":"session_meta","payload":{"id":"old-a"}}\n');
+      await writeFile(newerRolloutPath, '{"type":"session_meta","payload":{"id":"old-b"}}\n');
+      await utimes(oldRolloutPath, oldMtime, oldMtime);
+      await utimes(newerRolloutPath, newerMtime, newerMtime);
+      await symlink(join(projectCodexHome, 'sessions'), join(previousRuntimeCodexHome, 'sessions'), 'dir');
+
+      await writeFile(fakeCodexPath, `#!/bin/sh
+printf 'fake-codex:%s\\n' "$*"
+find "$CODEX_HOME/sessions" -type f -name '*.jsonl' -exec stat -c '%y %n' {} \\; | sort
+`);
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+
+      const result = runOmx(wd, ['resume', '--sort', 'updated'], {
+        HOME: home,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      });
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, /fake-codex:resume --sort updated\b/);
+      assert.match(result.stdout, /2024-01-02 03:04:05\.\d+ .*rollout-old-a\.jsonl/);
+      assert.match(result.stdout, /2024-03-04 05:06:07\.\d+ .*rollout-old-b\.jsonl/);
+      assert.equal((await stat(oldRolloutPath)).mtime.toISOString(), oldMtime.toISOString());
+      assert.equal((await stat(newerRolloutPath)).mtime.toISOString(), newerMtime.toISOString());
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -183,7 +183,8 @@ if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-runtime-session.jsonl" ]; then 
     try {
       const home = join(wd, 'home');
       const projectCodexHome = join(wd, '.codex');
-      const previousRuntimeCodexHome = join(wd, '.omx', 'runtime', 'codex-home', 'omx-existing-runtime');
+      const previousRuntimeCodexHome = join(wd, '.omx', 'runtime', 'codex-home', 'omx-existing-runtime-a');
+      const duplicateRuntimeCodexHome = join(wd, '.omx', 'runtime', 'codex-home', 'omx-existing-runtime-b');
       const fakeBin = join(wd, 'bin');
       const fakeCodexPath = join(fakeBin, 'codex');
       const fakePsPath = join(fakeBin, 'ps');
@@ -194,6 +195,7 @@ if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-runtime-session.jsonl" ]; then 
       await mkdir(join(wd, '.omx'), { recursive: true });
       await mkdir(dirname(projectRolloutPath), { recursive: true });
       await mkdir(previousRuntimeCodexHome, { recursive: true });
+      await mkdir(duplicateRuntimeCodexHome, { recursive: true });
       await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
       await writeFile(join(projectCodexHome, 'config.toml'), 'model = "gpt-5.5"\n');
       await writeFile(projectRolloutPath, '{"type":"session_meta","payload":{"id":"project-session"}}\n');
@@ -202,10 +204,15 @@ if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-runtime-session.jsonl" ]; then 
       await symlink(join(projectCodexHome, 'sessions'), join(previousRuntimeCodexHome, 'sessions'), 'dir');
       await symlink(join(projectCodexHome, 'history.jsonl'), join(previousRuntimeCodexHome, 'history.jsonl'));
       await symlink(join(projectCodexHome, 'session_index.jsonl'), join(previousRuntimeCodexHome, 'session_index.jsonl'));
+      await symlink(join(projectCodexHome, 'sessions'), join(duplicateRuntimeCodexHome, 'sessions'), 'dir');
+      await symlink(join(projectCodexHome, 'history.jsonl'), join(duplicateRuntimeCodexHome, 'history.jsonl'));
+      await symlink(join(projectCodexHome, 'session_index.jsonl'), join(duplicateRuntimeCodexHome, 'session_index.jsonl'));
 
       await writeFile(fakeCodexPath, `#!/bin/sh
 printf 'fake-codex:%s\n' "$*"
 printf 'codex-home:%s\n' "$CODEX_HOME"
+printf 'history-lines:%s\n' "$(wc -l < "$CODEX_HOME/history.jsonl")"
+printf 'index-lines:%s\n' "$(wc -l < "$CODEX_HOME/session_index.jsonl")"
 if [ -f "$CODEX_HOME/sessions/2026/06/18/rollout-project-session.jsonl" ]; then echo project-rollout-present=yes; else echo project-rollout-present=no; fi
 `);
       await chmod(fakeCodexPath, 0o755);
@@ -224,6 +231,10 @@ if [ -f "$CODEX_HOME/sessions/2026/06/18/rollout-project-session.jsonl" ]; then 
       assert.doesNotMatch(result.stderr, /EISDIR/);
       assert.match(result.stdout, /fake-codex:resume\b/);
       assert.match(result.stdout, /project-rollout-present=yes/);
+      assert.match(result.stdout, /history-lines:1\b/);
+      assert.match(result.stdout, /index-lines:1\b/);
+      assert.equal(await readFile(join(projectCodexHome, 'history.jsonl'), 'utf-8'), '{"session_id":"project-session"}\n');
+      assert.equal(await readFile(join(projectCodexHome, 'session_index.jsonl'), 'utf-8'), '{"id":"project-session"}\n');
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { chmod, mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, readdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -173,6 +173,57 @@ if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-runtime-session.jsonl" ]; then 
       assert.match(result.stdout, /fake-codex:resume\b/);
       assert.match(result.stdout, /codex-home:.*\.omx\/runtime\/codex-home\//);
       assert.match(result.stdout, /runtime-rollout-present=yes/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('merges symlinked project runtime history during plain resume', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-symlinked-runtime-history-'));
+    try {
+      const home = join(wd, 'home');
+      const projectCodexHome = join(wd, '.codex');
+      const previousRuntimeCodexHome = join(wd, '.omx', 'runtime', 'codex-home', 'omx-existing-runtime');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const projectRolloutPath = join(projectCodexHome, 'sessions', '2026', '06', '18', 'rollout-project-session.jsonl');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await mkdir(join(wd, '.omx'), { recursive: true });
+      await mkdir(dirname(projectRolloutPath), { recursive: true });
+      await mkdir(previousRuntimeCodexHome, { recursive: true });
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+      await writeFile(join(projectCodexHome, 'config.toml'), 'model = "gpt-5.5"\n');
+      await writeFile(projectRolloutPath, '{"type":"session_meta","payload":{"id":"project-session"}}\n');
+      await writeFile(join(projectCodexHome, 'history.jsonl'), '{"session_id":"project-session"}\n');
+      await writeFile(join(projectCodexHome, 'session_index.jsonl'), '{"id":"project-session"}\n');
+      await symlink(join(projectCodexHome, 'sessions'), join(previousRuntimeCodexHome, 'sessions'), 'dir');
+      await symlink(join(projectCodexHome, 'history.jsonl'), join(previousRuntimeCodexHome, 'history.jsonl'));
+      await symlink(join(projectCodexHome, 'session_index.jsonl'), join(previousRuntimeCodexHome, 'session_index.jsonl'));
+
+      await writeFile(fakeCodexPath, `#!/bin/sh
+printf 'fake-codex:%s\n' "$*"
+printf 'codex-home:%s\n' "$CODEX_HOME"
+if [ -f "$CODEX_HOME/sessions/2026/06/18/rollout-project-session.jsonl" ]; then echo project-rollout-present=yes; else echo project-rollout-present=no; fi
+`);
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+
+      const result = runOmx(wd, ['resume'], {
+        HOME: home,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      });
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.doesNotMatch(result.stderr, /EISDIR/);
+      assert.match(result.stdout, /fake-codex:resume\b/);
+      assert.match(result.stdout, /project-rollout-present=yes/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,7 +6,7 @@
 import { execFileSync, spawn } from "child_process";
 import { basename, dirname, join, posix, resolve, win32 } from "path";
 import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "fs";
-import { copyFile, cp, lstat, mkdir, readFile, readdir, rm, stat, symlink, writeFile } from "fs/promises";
+import { copyFile, cp, lstat, mkdir, readFile, readdir, rm, stat, symlink, utimes, writeFile } from "fs/promises";
 import { constants as osConstants, homedir } from "os";
 import { createHash } from "crypto";
 import {
@@ -839,6 +839,12 @@ async function linkOrCopyCodexHomeEntry(source: string, destination: string): Pr
   }
 }
 
+async function copyFilePreservingTimestamps(source: string, destination: string): Promise<void> {
+  await copyFile(source, destination);
+  const sourceStat = await stat(source);
+  await utimes(destination, sourceStat.atime, sourceStat.mtime);
+}
+
 function isCodexSqliteArtifact(entryName: string): boolean {
   return /^(?:state|logs)_\d+\.sqlite(?:-(?:shm|wal))?$/.test(entryName);
 }
@@ -906,7 +912,7 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
     if (sourceStat.isSymbolicLink()) continue;
     const destination = join(projectCodexHome, entryName);
     if (sourceStat.isDirectory()) {
-      await cp(source, destination, { recursive: true, force: true, verbatimSymlinks: true });
+      await cp(source, destination, { recursive: true, force: true, preserveTimestamps: true, verbatimSymlinks: true });
       continue;
     }
     if (entryName === "history.jsonl" || entryName === "session_index.jsonl") {
@@ -914,7 +920,7 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
       continue;
     }
     if (sourceStat.isFile()) {
-      await copyFile(source, destination);
+      await copyFilePreservingTimestamps(source, destination);
     }
   }
 }
@@ -948,10 +954,10 @@ async function materializeProjectLaunchRuntimeHistoryEntries(
     await rm(destination, { recursive: true, force: true });
     const sourceStat = await lstat(source);
     if (sourceStat.isDirectory()) {
-      await cp(source, destination, { recursive: true, force: true, dereference: true });
+      await cp(source, destination, { recursive: true, force: true, dereference: true, preserveTimestamps: true });
       continue;
     }
-    await copyFile(source, destination);
+    await copyFilePreservingTimestamps(source, destination);
   }
 }
 
@@ -969,7 +975,7 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
     const sourceStat = await stat(source);
     if (sourceStat.isDirectory()) {
       await mkdir(destination, { recursive: true });
-      await cp(source, destination, { recursive: true, force: true, dereference: true });
+      await cp(source, destination, { recursive: true, force: true, dereference: true, preserveTimestamps: true });
       mergedHistorySourceRealpaths.add(sourceRealpath);
       continue;
     }
@@ -979,7 +985,7 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
       const destinationStat = await stat(destination);
       if (!destinationStat.isFile()) {
         await rm(destination, { recursive: true, force: true });
-        await copyFile(source, destination);
+        await copyFilePreservingTimestamps(source, destination);
         mergedHistorySourceRealpaths.add(sourceRealpath);
         continue;
       }
@@ -990,7 +996,7 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
       mergedHistorySourceRealpaths.add(sourceRealpath);
       continue;
     }
-    await copyFile(source, destination);
+    await copyFilePreservingTimestamps(source, destination);
     mergedHistorySourceRealpaths.add(sourceRealpath);
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -944,15 +944,19 @@ async function materializeProjectLaunchRuntimeHistoryEntries(
 async function mergeProjectLaunchRuntimeHistoryEntries(
   runtimeCodexHome: string,
   sourceCodexHome: string,
+  mergedHistorySourceRealpaths: Set<string>,
 ): Promise<void> {
   for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
     const source = join(sourceCodexHome, entryName);
     if (!existsSync(source)) continue;
+    const sourceRealpath = realpathSync(source);
+    if (mergedHistorySourceRealpaths.has(sourceRealpath)) continue;
     const destination = join(runtimeCodexHome, entryName);
     const sourceStat = await stat(source);
     if (sourceStat.isDirectory()) {
       await mkdir(destination, { recursive: true });
       await cp(source, destination, { recursive: true, force: true, dereference: true });
+      mergedHistorySourceRealpaths.add(sourceRealpath);
       continue;
     }
     if (entryName === "sessions") continue;
@@ -962,15 +966,18 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
       if (!destinationStat.isFile()) {
         await rm(destination, { recursive: true, force: true });
         await copyFile(source, destination);
+        mergedHistorySourceRealpaths.add(sourceRealpath);
         continue;
       }
       const existing = await readFile(destination, "utf-8").catch(() => "");
       const addition = await readFile(source, "utf-8");
       const separator = existing === "" || existing.endsWith("\n") || addition === "" ? "" : "\n";
       await writeFile(destination, `${existing}${separator}${addition}`, "utf-8");
+      mergedHistorySourceRealpaths.add(sourceRealpath);
       continue;
     }
     await copyFile(source, destination);
+    mergedHistorySourceRealpaths.add(sourceRealpath);
   }
 }
 
@@ -1036,9 +1043,14 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
   }
   await ensureProjectLaunchRuntimeHistoryLinks(runtimeCodexHome, projectCodexHome);
   if (options.includeHistoryArtifacts === true && (options.extraHistoryCodexHomes?.length ?? 0) > 0) {
+    const mergedHistorySourceRealpaths = new Set<string>();
+    for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
+      const source = join(projectCodexHome, entryName);
+      if (existsSync(source)) mergedHistorySourceRealpaths.add(realpathSync(source));
+    }
     await materializeProjectLaunchRuntimeHistoryEntries(runtimeCodexHome, projectCodexHome);
     for (const extraCodexHome of options.extraHistoryCodexHomes ?? []) {
-      await mergeProjectLaunchRuntimeHistoryEntries(runtimeCodexHome, extraCodexHome);
+      await mergeProjectLaunchRuntimeHistoryEntries(runtimeCodexHome, extraCodexHome, mergedHistorySourceRealpaths);
     }
   }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,7 +6,7 @@
 import { execFileSync, spawn } from "child_process";
 import { basename, dirname, join, posix, resolve, win32 } from "path";
 import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "fs";
-import { copyFile, cp, lstat, mkdir, readFile, readdir, rm, symlink, writeFile } from "fs/promises";
+import { copyFile, cp, lstat, mkdir, readFile, readdir, rm, stat, symlink, writeFile } from "fs/promises";
 import { constants as osConstants, homedir } from "os";
 import { createHash } from "crypto";
 import {
@@ -949,13 +949,21 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
     const source = join(sourceCodexHome, entryName);
     if (!existsSync(source)) continue;
     const destination = join(runtimeCodexHome, entryName);
-    const sourceStat = await lstat(source);
+    const sourceStat = await stat(source);
     if (sourceStat.isDirectory()) {
       await mkdir(destination, { recursive: true });
       await cp(source, destination, { recursive: true, force: true, dereference: true });
       continue;
     }
+    if (entryName === "sessions") continue;
+    if (!sourceStat.isFile()) continue;
     if (existsSync(destination)) {
+      const destinationStat = await stat(destination);
+      if (!destinationStat.isFile()) {
+        await rm(destination, { recursive: true, force: true });
+        await copyFile(source, destination);
+        continue;
+      }
       const existing = await readFile(destination, "utf-8").catch(() => "");
       const addition = await readFile(source, "utf-8");
       const separator = existing === "" || existing.endsWith("\n") || addition === "" ? "" : "\n";


### PR DESCRIPTION
## Summary
- Preserve Codex transcript mtimes when `omx resume` materializes or merges runtime history.
- Add a regression test for `omx resume --sort updated` so copied transcripts keep their original updated times.
- Rebase the branch onto the latest `origin/dev` changes.

## Root Cause
When a project already had a generated runtime Codex home, `omx resume` rebuilt a fresh runtime `CODEX_HOME` and copied history artifacts into it. The directory copy and file copy paths reset transcript mtimes to the current launch time. Codex uses those file mtimes for updated sorting, so every copied session appeared as if it had just run.

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/resume.test.js`
- `npm run lint`
- `git diff --check`

## Manual QA
Ran a fake-Codex CLI scenario for `omx resume --sort updated` with two old transcripts and a prior runtime home. The runtime `CODEX_HOME` observed by Codex preserved the original `2024-01-02T03:04:05Z` and `2024-03-04T05:06:07Z` transcript mtimes instead of rewriting them to the current launch time.

Also checked:
- Missing `--codex-home` value reports `Error: Missing value after --codex-home.`
- `omx resume --help` is still forwarded to Codex.
