### PR TITLE
fix(plugin): accept last-line Stop hook JSON after launcher noise

### DIFF
--- a/plugins/oh-my-codex/hooks/codex-native-hook.mjs
+++ b/plugins/oh-my-codex/hooks/codex-native-hook.mjs
@@ -336,6 +336,11 @@ function parseJsonObjectCandidate(text) {
   }
 }
 
+function isJsonObjectLookingLine(text) {
+  return text.startsWith('{') && text.endsWith('}');
+}
+
+
 function parseSingleJsonObjectOutput(raw) {
   const text = String(raw ?? '').trim();
   if (!text) return null;
@@ -344,7 +349,10 @@ function parseSingleJsonObjectOutput(raw) {
 
   const lines = text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
   const lastLine = lines.at(-1);
-  if (!lastLine || !lastLine.startsWith('{') || !lastLine.endsWith('}')) return null;
+  if (!lastLine || !isJsonObjectLookingLine(lastLine)) return null;
+  for (const line of lines.slice(0, -1)) {
+    if (parseJsonObjectCandidate(line) || isJsonObjectLookingLine(line)) return null;
+  }
   return parseJsonObjectCandidate(lastLine);
 }
 

--- a/plugins/oh-my-codex/hooks/codex-native-hook.mjs
+++ b/plugins/oh-my-codex/hooks/codex-native-hook.mjs
@@ -336,10 +336,9 @@ function parseJsonObjectCandidate(text) {
   }
 }
 
-function isJsonObjectLookingLine(text) {
-  return text.startsWith('{') && text.endsWith('}');
+function isJsonObjectFragmentLine(text) {
+  return text.startsWith('{') || text.endsWith('}') || /^"[^"]+"\s*:/.test(text);
 }
-
 
 function parseSingleJsonObjectOutput(raw) {
   const text = String(raw ?? '').trim();
@@ -349,9 +348,9 @@ function parseSingleJsonObjectOutput(raw) {
 
   const lines = text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
   const lastLine = lines.at(-1);
-  if (!lastLine || !isJsonObjectLookingLine(lastLine)) return null;
+  if (!lastLine || !lastLine.startsWith('{') || !lastLine.endsWith('}')) return null;
   for (const line of lines.slice(0, -1)) {
-    if (parseJsonObjectCandidate(line) || isJsonObjectLookingLine(line)) return null;
+    if (parseJsonObjectCandidate(line) || isJsonObjectFragmentLine(line)) return null;
   }
   return parseJsonObjectCandidate(lastLine);
 }

--- a/plugins/oh-my-codex/hooks/codex-native-hook.mjs
+++ b/plugins/oh-my-codex/hooks/codex-native-hook.mjs
@@ -326,9 +326,7 @@ function hasActiveAutopilotStateForOversizedStop(input) {
 }
 
 
-function parseSingleJsonObjectOutput(raw) {
-  const text = String(raw ?? '').trim();
-  if (!text) return null;
+function parseJsonObjectCandidate(text) {
   try {
     const parsed = JSON.parse(text);
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
@@ -336,6 +334,18 @@ function parseSingleJsonObjectOutput(raw) {
   } catch {
     return null;
   }
+}
+
+function parseSingleJsonObjectOutput(raw) {
+  const text = String(raw ?? '').trim();
+  if (!text) return null;
+  const direct = parseJsonObjectCandidate(text);
+  if (direct) return direct;
+
+  const lines = text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  const lastLine = lines.at(-1);
+  if (!lastLine || !lastLine.startsWith('{') || !lastLine.endsWith('}')) return null;
+  return parseJsonObjectCandidate(lastLine);
 }
 
 async function main() {

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -583,6 +583,35 @@ exit 7
     });
   });
 
+  it('preserves valid pretty-printed Stop child JSON', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const commandPath = join(cacheRoot, process.platform === 'win32' ? 'pretty-valid-json.cmd' : 'pretty-valid-json.sh');
+      if (process.platform === 'win32') {
+        await writeFile(commandPath, '@echo off\r\necho {\r\necho   "decision": "block",\r\necho   "stopReason": "pretty_child_json"\r\necho }\r\nexit /b 0\r\n', 'utf-8');
+      } else {
+        await writeFile(commandPath, `#!/bin/sh
+printf '{\n'
+printf '  "decision": "block",\n'
+printf '  "stopReason": "pretty_child_json"\n'
+printf '}\n'
+`, 'utf-8');
+        await chmod(commandPath, 0o755);
+      }
+
+      const result = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({ hook_event_name: 'Stop', session_id: 'sess-plugin-pretty-valid-json-stop' }),
+        { OMX_NATIVE_HOOK_COMMAND: commandPath },
+      );
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'pretty_child_json');
+      assert.doesNotMatch(result.stdout, /plugin_stop_hook_launcher_invalid_stdout/);
+    });
+  });
+
   it('preserves valid Stop child JSON when stdout includes prior launcher noise', async () => {
     await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
       const commandPath = join(cacheRoot, process.platform === 'win32' ? 'noisy-valid-json.cmd' : 'noisy-valid-json.sh');
@@ -666,6 +695,37 @@ printf '{"decision":"block","stopReason":"second_json"}\n'
       assert.doesNotMatch(result.stdout, /first_json/);
       assert.doesNotMatch(result.stdout, /second_json/);
       assert.doesNotMatch(result.stdout, /trailing runtime noise/);
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_launcher_invalid_stdout');
+    });
+  });
+
+  it('rejects pretty Stop child JSON followed by final JSON log noise', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const commandPath = join(cacheRoot, process.platform === 'win32' ? 'pretty-json-final-log.cmd' : 'pretty-json-final-log.sh');
+      if (process.platform === 'win32') {
+        await writeFile(commandPath, '@echo off\r\necho {\r\necho   "decision": "block",\r\necho   "stopReason": "real_block"\r\necho }\r\necho {"level":"info"}\r\nexit /b 0\r\n', 'utf-8');
+      } else {
+        await writeFile(commandPath, `#!/bin/sh
+printf '{\n'
+printf '  "decision": "block",\n'
+printf '  "stopReason": "real_block"\n'
+printf '}\n'
+printf '{"level":"info"}\n'
+`, 'utf-8');
+        await chmod(commandPath, 0o755);
+      }
+
+      const result = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({ hook_event_name: 'Stop', session_id: 'sess-plugin-pretty-json-final-log-stop' }),
+        { OMX_NATIVE_HOOK_COMMAND: commandPath },
+      );
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.doesNotMatch(result.stdout, /real_block/);
+      assert.doesNotMatch(result.stdout, /level/);
       const output = parseSingleJsonStdout(result.stdout);
       assert.equal(output.decision, 'block');
       assert.equal(output.stopReason, 'plugin_stop_hook_launcher_invalid_stdout');

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -642,6 +642,36 @@ printf 'trailing runtime noise\n'
     });
   });
 
+  it('rejects Stop child JSON when an earlier JSON decision is followed by noise and final JSON', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const commandPath = join(cacheRoot, process.platform === 'win32' ? 'json-noise-json.cmd' : 'json-noise-json.sh');
+      if (process.platform === 'win32') {
+        await writeFile(commandPath, '@echo off\r\necho {"decision":"block","stopReason":"first_json"}\r\necho trailing runtime noise\r\necho {"decision":"block","stopReason":"second_json"}\r\nexit /b 0\r\n', 'utf-8');
+      } else {
+        await writeFile(commandPath, `#!/bin/sh
+printf '{"decision":"block","stopReason":"first_json"}\n'
+printf 'trailing runtime noise\n'
+printf '{"decision":"block","stopReason":"second_json"}\n'
+`, 'utf-8');
+        await chmod(commandPath, 0o755);
+      }
+
+      const result = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({ hook_event_name: 'Stop', session_id: 'sess-plugin-json-noise-json-stop' }),
+        { OMX_NATIVE_HOOK_COMMAND: commandPath },
+      );
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.doesNotMatch(result.stdout, /first_json/);
+      assert.doesNotMatch(result.stdout, /second_json/);
+      assert.doesNotMatch(result.stdout, /trailing runtime noise/);
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_launcher_invalid_stdout');
+    });
+  });
+
   it('replaces oversized Stop child stdout with fallback Stop JSON', async () => {
     await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
       const commandPath = join(cacheRoot, process.platform === 'win32' ? 'oversized-stop-stdout.cmd' : 'oversized-stop-stdout.sh');

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -583,6 +583,65 @@ exit 7
     });
   });
 
+  it('preserves valid Stop child JSON when stdout includes prior launcher noise', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const commandPath = join(cacheRoot, process.platform === 'win32' ? 'noisy-valid-json.cmd' : 'noisy-valid-json.sh');
+      if (process.platform === 'win32') {
+        await writeFile(commandPath, '@echo off\r\necho runtime notice before json\r\necho {"decision":"block","stopReason":"autopilot_ultragoal"}\r\nexit /b 0\r\n', 'utf-8');
+      } else {
+        await writeFile(commandPath, `#!/bin/sh
+printf 'runtime notice before json\n'
+printf '{"decision":"block","stopReason":"autopilot_ultragoal"}\n'
+`, 'utf-8');
+        await chmod(commandPath, 0o755);
+      }
+
+      const result = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({
+          hook_event_name: 'Stop',
+          session_id: 'omx-1783508412223-c32f1l',
+          cwd: cacheRoot,
+        }),
+        { OMX_NATIVE_HOOK_COMMAND: commandPath },
+      );
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.doesNotMatch(result.stdout, /runtime notice before json/);
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'autopilot_ultragoal');
+      assert.doesNotMatch(result.stdout, /plugin_stop_hook_launcher_invalid_stdout/);
+    });
+  });
+
+  it('rejects Stop child JSON when later stdout noise follows it', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const commandPath = join(cacheRoot, process.platform === 'win32' ? 'valid-json-trailing-noise.cmd' : 'valid-json-trailing-noise.sh');
+      if (process.platform === 'win32') {
+        await writeFile(commandPath, '@echo off\r\necho {"decision":"block","stopReason":"child_valid_json"}\r\necho trailing runtime noise\r\nexit /b 0\r\n', 'utf-8');
+      } else {
+        await writeFile(commandPath, `#!/bin/sh
+printf '{"decision":"block","stopReason":"child_valid_json"}\n'
+printf 'trailing runtime noise\n'
+`, 'utf-8');
+        await chmod(commandPath, 0o755);
+      }
+
+      const result = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({ hook_event_name: 'Stop', session_id: 'sess-plugin-trailing-noise-stop' }),
+        { OMX_NATIVE_HOOK_COMMAND: commandPath },
+      );
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.doesNotMatch(result.stdout, /trailing runtime noise/);
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.equal(output.decision, 'block');
+      assert.equal(output.stopReason, 'plugin_stop_hook_launcher_invalid_stdout');
+    });
+  });
+
   it('replaces oversized Stop child stdout with fallback Stop JSON', async () => {
     await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
       const commandPath = join(cacheRoot, process.platform === 'win32' ? 'oversized-stop-stdout.cmd' : 'oversized-stop-stdout.sh');


### PR DESCRIPTION
## Summary
- Accept Stop hook child stdout when the final non-empty line is a JSON object, preserving existing strict rejection for trailing noise.
- Keep full multi-line JSON object parsing unchanged.
- Add focused plugin layout tests for noisy prefix stdout and trailing-noise rejection.

## Validation
- npm run build
- node dist/scripts/run-test-files.js dist/cli/__tests__/codex-plugin-layout.test.js
- npm run lint
- git diff --check

Fixes #3081

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*