### PR TITLE
Default project setup to plugin mode with plugin cache

### DIFF
--- a/plugins/oh-my-codex/skills/omx-setup/SKILL.md
+++ b/plugins/oh-my-codex/skills/omx-setup/SKILL.md
@@ -35,11 +35,11 @@ Supported setup flags (current implementation):
    - if a TTY user has persisted setup preferences, `omx setup` first summarizes the recorded choices and asks whether to **keep**, **review/change**, or **reset** them
    - else interactive prompt on TTY (default `user`)
    - else default `user` (safe for CI/tests)
-2. If scope is `user`, resolve user skill delivery mode:
+2. Resolve setup install mode:
    - explicit `--plugin`, `--legacy`, or `--install-mode legacy|plugin`, if present
    - persisted install mode in `./.omx/setup-scope.json`, if present and the TTY review decision is `keep`
-   - else discovered installed plugin cache under `${CODEX_HOME:-~/.codex}/plugins/cache/**/.codex-plugin/plugin.json` with `name: oh-my-codex` makes `plugin` the default
-   - else interactive prompt on TTY (`legacy` by default, or `plugin` when a plugin cache is discovered)
+   - else discovered installed plugin cache under `${CODEX_HOME:-~/.codex}/plugins/cache/**/.codex-plugin/plugin.json` with `name: oh-my-codex` makes `plugin` the default for both `user` and `project` scope, so project setup does not duplicate plugin-provided skills/hooks with legacy `.codex/skills` and `.codex/hooks.json`
+   - else in `user` scope, interactive prompt on TTY (`legacy` by default, or `plugin` when a plugin cache is discovered)
    - else default `legacy` unless a plugin cache is discovered
 3. Create directories and persist effective scope/install mode
 4. In legacy mode, install prompts/native agents/skills and merge full config.toml. In plugin mode, archive/remove legacy OMX-managed prompts/skills, refresh installable native agent TOMLs for `agent_type` routing, clean up stale generated non-installable native agents, and keep native Codex hooks installed.
@@ -51,7 +51,7 @@ Supported setup flags (current implementation):
 
 - `omx setup` prompts for scope when no scope is provided and stdin/stdout are TTY. If `./.omx/setup-scope.json` already exists, setup now summarizes the saved choices first and asks whether to keep them, review/change them, or reset and behave like a fresh setup run.
 - Non-interactive setup never blocks for this review prompt: it keeps deterministic CLI/persisted/default behavior for CI and scripted installs.
-- In `user` scope, `omx setup` also prompts for skill delivery mode when no prior install mode is kept; installed plugin cache discovery makes plugin mode the default prompt/non-interactive choice.
+- In `user` scope, `omx setup` also prompts for skill delivery mode when no prior install mode is kept; installed plugin cache discovery makes plugin mode the default prompt/non-interactive choice. In `project` scope, installed plugin cache discovery selects plugin mode non-interactively to avoid overlapping project legacy skills/hooks with plugin-provided surfaces.
 - Local project orchestration file is `./AGENTS.md` (project root).
 - If `AGENTS.md` exists and neither `--force` nor `--merge-agents` is used, interactive TTY runs ask whether to overwrite. Non-interactive runs preserve the file.
 - Use `--merge-agents` to keep existing project guidance while allowing setup to refresh OMX-managed AGENTS sections and the generated model capability table idempotently.
@@ -73,7 +73,7 @@ Use this map when reconciling setup behavior or debugging a confusing install:
 
 | Surface | Owner | Notes |
 | --- | --- | --- |
-| `./.omx/setup-scope.json` | `omx setup` | Persists setup scope and user-scope skill delivery mode. TTY reruns summarize it and offer keep/review/reset. |
+| `./.omx/setup-scope.json` | `omx setup` | Persists setup scope and install mode when needed. TTY reruns summarize it and offer keep/review/reset. |
 | `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content; setup-owned runtime feature flags include `multi_agent`, `child_agents_md`, the Codex hook feature flag (`hooks` or legacy `codex_hooks`), and `goals`. |
 | `~/.codex/hooks.json` / `./.codex/hooks.json` | `omx setup` shared ownership | Setup owns OMX native hook wrappers and preserves user-owned hooks. |
 | prompts, skills, native agents | `omx setup` or Codex plugin delivery | Legacy mode installs local files; plugin mode relies on plugin discovery for bundled skills, archives/removes legacy OMX-managed prompt/skill copies, and refreshes setup-owned native agent TOMLs for `agent_type` routing while cleaning up stale generated/non-installable native agents. |

--- a/skills/omx-setup/SKILL.md
+++ b/skills/omx-setup/SKILL.md
@@ -35,11 +35,11 @@ Supported setup flags (current implementation):
    - if a TTY user has persisted setup preferences, `omx setup` first summarizes the recorded choices and asks whether to **keep**, **review/change**, or **reset** them
    - else interactive prompt on TTY (default `user`)
    - else default `user` (safe for CI/tests)
-2. If scope is `user`, resolve user skill delivery mode:
+2. Resolve setup install mode:
    - explicit `--plugin`, `--legacy`, or `--install-mode legacy|plugin`, if present
    - persisted install mode in `./.omx/setup-scope.json`, if present and the TTY review decision is `keep`
-   - else discovered installed plugin cache under `${CODEX_HOME:-~/.codex}/plugins/cache/**/.codex-plugin/plugin.json` with `name: oh-my-codex` makes `plugin` the default
-   - else interactive prompt on TTY (`legacy` by default, or `plugin` when a plugin cache is discovered)
+   - else discovered installed plugin cache under `${CODEX_HOME:-~/.codex}/plugins/cache/**/.codex-plugin/plugin.json` with `name: oh-my-codex` makes `plugin` the default for both `user` and `project` scope, so project setup does not duplicate plugin-provided skills/hooks with legacy `.codex/skills` and `.codex/hooks.json`
+   - else in `user` scope, interactive prompt on TTY (`legacy` by default, or `plugin` when a plugin cache is discovered)
    - else default `legacy` unless a plugin cache is discovered
 3. Create directories and persist effective scope/install mode
 4. In legacy mode, install prompts/native agents/skills and merge full config.toml. In plugin mode, archive/remove legacy OMX-managed prompts/skills, refresh installable native agent TOMLs for `agent_type` routing, clean up stale generated non-installable native agents, and keep native Codex hooks installed.
@@ -51,7 +51,7 @@ Supported setup flags (current implementation):
 
 - `omx setup` prompts for scope when no scope is provided and stdin/stdout are TTY. If `./.omx/setup-scope.json` already exists, setup now summarizes the saved choices first and asks whether to keep them, review/change them, or reset and behave like a fresh setup run.
 - Non-interactive setup never blocks for this review prompt: it keeps deterministic CLI/persisted/default behavior for CI and scripted installs.
-- In `user` scope, `omx setup` also prompts for skill delivery mode when no prior install mode is kept; installed plugin cache discovery makes plugin mode the default prompt/non-interactive choice.
+- In `user` scope, `omx setup` also prompts for skill delivery mode when no prior install mode is kept; installed plugin cache discovery makes plugin mode the default prompt/non-interactive choice. In `project` scope, installed plugin cache discovery selects plugin mode non-interactively to avoid overlapping project legacy skills/hooks with plugin-provided surfaces.
 - Local project orchestration file is `./AGENTS.md` (project root).
 - If `AGENTS.md` exists and neither `--force` nor `--merge-agents` is used, interactive TTY runs ask whether to overwrite. Non-interactive runs preserve the file.
 - Use `--merge-agents` to keep existing project guidance while allowing setup to refresh OMX-managed AGENTS sections and the generated model capability table idempotently.
@@ -73,7 +73,7 @@ Use this map when reconciling setup behavior or debugging a confusing install:
 
 | Surface | Owner | Notes |
 | --- | --- | --- |
-| `./.omx/setup-scope.json` | `omx setup` | Persists setup scope and user-scope skill delivery mode. TTY reruns summarize it and offer keep/review/reset. |
+| `./.omx/setup-scope.json` | `omx setup` | Persists setup scope and install mode when needed. TTY reruns summarize it and offer keep/review/reset. |
 | `~/.codex/config.toml` / `./.codex/config.toml` | `omx setup` generated blocks + user edits | Setup refreshes OMX-managed blocks while preserving supported manual content; setup-owned runtime feature flags include `multi_agent`, `child_agents_md`, the Codex hook feature flag (`hooks` or legacy `codex_hooks`), and `goals`. |
 | `~/.codex/hooks.json` / `./.codex/hooks.json` | `omx setup` shared ownership | Setup owns OMX native hook wrappers and preserves user-owned hooks. |
 | prompts, skills, native agents | `omx setup` or Codex plugin delivery | Legacy mode installs local files; plugin mode relies on plugin discovery for bundled skills, archives/removes legacy OMX-managed prompt/skill copies, and refreshes setup-owned native agent TOMLs for `agent_type` routing while cleaning up stale generated/non-installable native agents. |

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -126,7 +126,7 @@ describe("notify setup scope", () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-project-no-notify-"));
 		try {
 			await withTempCwd(wd, async () => {
-				await setup({ scope: "project" });
+				await setup({ scope: "project", installMode: "legacy" });
 			});
 			const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
 			assert.doesNotMatch(config, /^notify\s*=/m);
@@ -145,7 +145,7 @@ describe("notify setup scope", () => {
 				'notify = ["node", "/tmp/notify-hook.js"]\napproval_policy = "never"\n',
 			);
 			await withTempCwd(wd, async () => {
-				await setup({ scope: "project" });
+				await setup({ scope: "project", installMode: "legacy" });
 			});
 			const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
 			assert.match(config, /^notify = \["node", "\/tmp\/notify-hook\.js"\]$/m);
@@ -1183,6 +1183,34 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
+	it("defaults project setup to plugin mode when an installed oh-my-codex plugin cache is discovered", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const pluginDir = join(
+						codexHomeDir,
+						"plugins",
+						"cache",
+						"oh-my-codex-local",
+						"oh-my-codex",
+					);
+					await mkdir(join(pluginDir, ".codex-plugin"), { recursive: true });
+					await writeFile(
+						join(pluginDir, ".codex-plugin", "plugin.json"),
+						JSON.stringify({ name: "oh-my-codex", version: "local" }),
+					);
+
+					await setup({ scope: "project" });
+
+					await assertProjectPluginModeArtifacts(wd);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("invalidates stale plugin discovery caches so updated plugin skills refresh", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {
@@ -1368,13 +1396,15 @@ describe("omx setup install mode behavior", () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		let promptCalls = 0;
 		try {
-			await withTempCwd(wd, async () => {
-				await setup({
-					scope: "project",
-					installModePrompt: async () => {
-						promptCalls += 1;
-						return "plugin";
-					},
+			await withIsolatedUserHome(wd, async () => {
+				await withTempCwd(wd, async () => {
+					await setup({
+						scope: "project",
+						installModePrompt: async () => {
+							promptCalls += 1;
+							return "plugin";
+						},
+					});
 				});
 			});
 
@@ -1388,7 +1418,7 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
-	it("does not reuse stale user install mode for project-scoped setup", async () => {
+	it("defaults project setup to plugin mode after user plugin setup installs plugin cache", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {
 			await withIsolatedUserHome(wd, async () => {
@@ -1400,10 +1430,15 @@ describe("omx setup install mode behavior", () => {
 					const persisted = JSON.parse(
 						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
 					) as { scope: string; installMode?: string };
-					assert.deepEqual(persisted, { scope: "project", mcpMode: "none" });
+					assert.deepEqual(persisted, {
+						scope: "project",
+						installMode: "plugin",
+						mcpMode: "none",
+					});
+					assert.equal(existsSync(join(wd, ".codex", "hooks.json")), false);
 					assert.equal(
 						existsSync(join(wd, ".codex", "skills", "ask", "SKILL.md")),
-						true,
+						false,
 					);
 
 					await setup({ scope: "project" });
@@ -1411,14 +1446,18 @@ describe("omx setup install mode behavior", () => {
 					const repeatedPersisted = JSON.parse(
 						await readFile(join(wd, ".omx", "setup-scope.json"), "utf-8"),
 					) as { scope: string; installMode?: string };
-					assert.deepEqual(repeatedPersisted, { scope: "project", mcpMode: "none" });
+					assert.deepEqual(repeatedPersisted, {
+						scope: "project",
+						installMode: "plugin",
+						mcpMode: "none",
+					});
 					assert.equal(
 						existsSync(join(wd, ".codex", "agents", "planner.toml")),
 						true,
 					);
 					assert.equal(
 						existsSync(join(wd, ".codex", "prompts", "executor.md")),
-						true,
+						false,
 					);
 				});
 			});

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1404,9 +1404,13 @@ async function resolveSetupInstallMode(
 		return { installMode: persisted.installMode, source: "persisted" };
 	}
 
-	if (scope !== "user") return null;
-
 	const discoveredPluginCacheDir = await discoverOmxPluginCacheDir();
+	if (scope !== "user") {
+		return discoveredPluginCacheDir
+			? { installMode: "plugin", source: "default" }
+			: null;
+	}
+
 	const defaultMode =
 		persistedReviewDecision === "review" && persisted?.installMode
 			? persisted.installMode


### PR DESCRIPTION
## Summary
- Default project-scope setup to plugin mode when an installed oh-my-codex plugin cache is discoverable.
- Keep legacy project installs available only when no plugin cache exists or an explicit install mode is requested.
- Update setup docs and install-mode coverage for plugin-vs-legacy behavior.

## Tests
- npm run build
- node dist/scripts/run-test-files.js dist/cli/__tests__/setup-install-mode.test.js
- npm run verify:plugin-bundle
- npm run lint && npm run check:no-unused
- git diff --check