### PR TITLE
Gate plugin hooks to omx-launched sessions

### DIFF
--- a/plugins/oh-my-codex/hooks/codex-native-hook.mjs
+++ b/plugins/oh-my-codex/hooks/codex-native-hook.mjs
@@ -131,6 +131,15 @@ function detectCompactHookInput(input) {
   }
 }
 
+function isOmxLauncherSession() {
+  return typeof process.env.OMX_ENTRY_PATH === 'string' && process.env.OMX_ENTRY_PATH.trim() !== '';
+}
+
+function writePlainCodexNoop(isStop) {
+  if (isStop) process.stdout.write('{}\n');
+  process.exitCode = 0;
+}
+
 async function readBoundedStdin() {
   const chunks = [];
   let totalBytes = 0;
@@ -342,6 +351,11 @@ async function main() {
   const { input, oversized, totalBytes } = await readBoundedStdin();
   const isStop = detectStopHookInput(input);
   const isCompact = detectCompactHookInput(input);
+
+  if (!isOmxLauncherSession()) {
+    writePlainCodexNoop(isStop);
+    return;
+  }
 
   if (oversized) {
     const message = `plugin hook stdin exceeded ${MAX_WRAPPER_STDIN_BYTES} bytes before launcher delegation; totalBytes>${totalBytes}`;

--- a/plugins/oh-my-codex/hooks/codex-native-hook.mjs
+++ b/plugins/oh-my-codex/hooks/codex-native-hook.mjs
@@ -140,20 +140,29 @@ function writePlainCodexNoop(isStop) {
   process.exitCode = 0;
 }
 
-async function readBoundedStdin() {
+async function readBoundedStdin({ drainOversized = false } = {}) {
   const chunks = [];
   let totalBytes = 0;
+  let storedBytes = 0;
+  let oversized = false;
   for await (const rawChunk of process.stdin) {
     const chunk = Buffer.isBuffer(rawChunk) ? rawChunk : Buffer.from(rawChunk);
     totalBytes += chunk.length;
-    if (totalBytes > MAX_WRAPPER_STDIN_BYTES) {
-      const remaining = MAX_WRAPPER_STDIN_BYTES - Buffer.concat(chunks).length;
+
+    if (oversized) continue;
+
+    const remaining = MAX_WRAPPER_STDIN_BYTES - storedBytes;
+    if (chunk.length > remaining) {
       if (remaining > 0) chunks.push(chunk.subarray(0, remaining));
-      return { input: Buffer.concat(chunks), oversized: true, totalBytes };
+      storedBytes += Math.max(remaining, 0);
+      oversized = true;
+      if (!drainOversized) return { input: Buffer.concat(chunks), oversized: true, totalBytes };
+      continue;
     }
     chunks.push(chunk);
+    storedBytes += chunk.length;
   }
-  return { input: Buffer.concat(chunks), oversized: false, totalBytes };
+  return { input: Buffer.concat(chunks), oversized, totalBytes };
 }
 
 function stopFallbackOutput(stopReason, detail) {
@@ -365,11 +374,12 @@ function parseSingleJsonObjectOutput(raw) {
 }
 
 async function main() {
-  const { input, oversized, totalBytes } = await readBoundedStdin();
+  const launchedByOmx = isOmxLauncherSession();
+  const { input, oversized, totalBytes } = await readBoundedStdin({ drainOversized: !launchedByOmx });
   const isStop = detectStopHookInput(input);
   const isCompact = detectCompactHookInput(input);
 
-  if (!isOmxLauncherSession()) {
+  if (!launchedByOmx) {
     writePlainCodexNoop(isStop);
     return;
   }

--- a/plugins/oh-my-codex/hooks/codex-native-hook.mjs
+++ b/plugins/oh-my-codex/hooks/codex-native-hook.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
 import { extname } from 'node:path';
-import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -131,8 +131,52 @@ function detectCompactHookInput(input) {
   }
 }
 
-function isOmxLauncherSession() {
-  return typeof process.env.OMX_ENTRY_PATH === 'string' && process.env.OMX_ENTRY_PATH.trim() !== '';
+function parseHookPayload(input) {
+  try {
+    const parsed = JSON.parse(input.toString('utf8'));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function sanitizeLaunchId(value) {
+  return String(value ?? '').trim().replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 128);
+}
+
+function resolveLaunchClaimPath(payload, launchId) {
+  const cwd = typeof payload.cwd === 'string' && payload.cwd.trim() ? payload.cwd : process.cwd();
+  const stateRoot = typeof process.env.OMX_ROOT === 'string' && process.env.OMX_ROOT.trim()
+    ? process.env.OMX_ROOT.trim()
+    : join(cwd, '.omx');
+  return join(stateRoot, 'state', 'plugin-hook-launches', `${sanitizeLaunchId(launchId)}.json`);
+}
+
+function hookPayloadSessionId(input, payload) {
+  const parsedSessionId = typeof payload.session_id === 'string' ? payload.session_id.trim() : '';
+  if (parsedSessionId) return parsedSessionId;
+  return extractTopLevelStringField(input.toString('utf8'), ['session_id', 'sessionId'])?.trim() ?? '';
+}
+
+function isOmxLauncherSession(input, payload) {
+  const launchId = process.env.OMX_CODEX_LAUNCH_ID?.trim();
+  const entryPath = process.env.OMX_ENTRY_PATH?.trim();
+  const sessionId = hookPayloadSessionId(input, payload);
+  if (!launchId || !entryPath || !sessionId) return false;
+
+  const claimPath = resolveLaunchClaimPath(payload, launchId);
+
+  try {
+    if (existsSync(claimPath)) {
+      const claimed = JSON.parse(readFileSync(claimPath, 'utf8'));
+      return claimed?.sessionId === sessionId;
+    }
+    mkdirSync(dirname(claimPath), { recursive: true });
+    writeFileSync(claimPath, `${JSON.stringify({ sessionId })}\n`, { encoding: 'utf8', mode: 0o600 });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function writePlainCodexNoop(isStop) {
@@ -374,8 +418,9 @@ function parseSingleJsonObjectOutput(raw) {
 }
 
 async function main() {
-  const launchedByOmx = isOmxLauncherSession();
-  const { input, oversized, totalBytes } = await readBoundedStdin({ drainOversized: !launchedByOmx });
+  const { input, oversized, totalBytes } = await readBoundedStdin({ drainOversized: true });
+  const payload = parseHookPayload(input);
+  const launchedByOmx = isOmxLauncherSession(input, payload);
   const isStop = detectStopHookInput(input);
   const isCompact = detectCompactHookInput(input);
 

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -238,6 +238,7 @@ async function assertPluginHookLaunchesPostCompactFromCache(): Promise<void> {
         OMX_SESSION_ID: 'omx-plugin-hook-postcompact-smoke',
         OMX_SOURCE_CWD: cacheRoot,
         OMX_ENTRY_PATH: omxBin,
+        OMX_CODEX_LAUNCH_ID: 'omx-plugin-hook-postcompact-smoke-launch',
         OMX_STARTUP_CWD: cacheRoot,
       },
     });
@@ -294,6 +295,7 @@ async function assertPluginHookDelegatesPostCompactToPinnedCommand(): Promise<vo
         OMX_SESSION_ID: 'omx-plugin-hook-postcompact-delegate',
         OMX_SOURCE_CWD: cacheRoot,
         OMX_ENTRY_PATH: omxBin,
+        OMX_CODEX_LAUNCH_ID: 'omx-plugin-hook-postcompact-delegate-launch',
         OMX_STARTUP_CWD: cacheRoot,
       },
     });
@@ -362,6 +364,7 @@ function pluginHookEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     'OMX_SESSION_ID',
     'CODEX_SESSION_ID',
     'OMX_ENTRY_PATH',
+    'OMX_CODEX_LAUNCH_ID',
     'OMX_STARTUP_CWD',
   ]) {
     delete env[key];
@@ -369,6 +372,7 @@ function pluginHookEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return {
     ...env,
     OMX_ENTRY_PATH: omxBin,
+    OMX_CODEX_LAUNCH_ID: 'omx-plugin-layout-launch',
     OMX_STARTUP_CWD: root,
     ...overrides,
   };
@@ -489,6 +493,7 @@ describe('official Codex plugin layout', () => {
         JSON.stringify({ hook_event_name: 'UserPromptSubmit', prompt: '$ralplan smoke' }),
         {
           OMX_ENTRY_PATH: '',
+          OMX_CODEX_LAUNCH_ID: '',
           OMX_NATIVE_HOOK_COMMAND: commandPath,
         },
       );
@@ -502,6 +507,7 @@ describe('official Codex plugin layout', () => {
         JSON.stringify({ hook_event_name: 'Stop', session_id: 'plain-codex-stop' }),
         {
           OMX_ENTRY_PATH: '',
+          OMX_CODEX_LAUNCH_ID: '',
           OMX_NATIVE_HOOK_COMMAND: commandPath,
         },
       );
@@ -518,6 +524,7 @@ describe('official Codex plugin layout', () => {
         }),
         {
           OMX_ENTRY_PATH: '',
+          OMX_CODEX_LAUNCH_ID: '',
           OMX_NATIVE_HOOK_COMMAND: commandPath,
         },
       );
@@ -536,6 +543,7 @@ describe('official Codex plugin layout', () => {
         }),
         {
           OMX_ENTRY_PATH: '',
+          OMX_CODEX_LAUNCH_ID: '',
           OMX_NATIVE_HOOK_COMMAND: commandPath,
         },
       );
@@ -543,6 +551,55 @@ describe('official Codex plugin layout', () => {
       assert.equal(oversizedStop.error, undefined, oversizedStop.error?.message ?? '');
       assert.equal(oversizedStop.status, 0, oversizedStop.stderr || oversizedStop.stdout);
       assert.deepEqual(parseSingleJsonStdout(oversizedStop.stdout), {});
+      await assert.rejects(readFile(calledPath, 'utf-8'), { code: 'ENOENT' });
+    });
+  });
+
+  it('no-ops plugin hooks for nested plain Codex sessions that inherit omx launch env', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const calledPath = join(cacheRoot, 'called.txt');
+      const commandPath = join(cacheRoot, process.platform === 'win32' ? 'record-inherited-called.cmd' : 'record-inherited-called.sh');
+      if (process.platform === 'win32') {
+        await writeFile(commandPath, `@echo off\r\necho %* > "${calledPath}"\r\necho {}\r\n`, 'utf-8');
+      } else {
+        await writeFile(commandPath, `#!/bin/sh\necho "$@" > "${calledPath}"\nprintf '{}\\n'\n`, 'utf-8');
+        await chmod(commandPath, 0o755);
+      }
+
+      const inheritedEnv = {
+        OMX_ROOT: join(cacheRoot, '.omx-root'),
+        OMX_ENTRY_PATH: omxBin,
+        OMX_CODEX_LAUNCH_ID: 'inherited-launch-token',
+        OMX_NATIVE_HOOK_COMMAND: commandPath,
+      };
+      const owner = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({
+          hook_event_name: 'UserPromptSubmit',
+          session_id: 'owner-codex-session',
+          session_pid: 111,
+          prompt: '$ralplan smoke',
+        }),
+        inheritedEnv,
+      );
+
+      assert.equal(owner.status, 0, owner.stderr || owner.stdout);
+      assert.equal((await readFile(calledPath, 'utf-8')).trim(), 'codex-native-hook');
+      await rm(calledPath, { force: true });
+
+      const nestedPlainCodex = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({
+          hook_event_name: 'UserPromptSubmit',
+          session_id: 'nested-plain-codex-session',
+          session_pid: 222,
+          prompt: '$ralplan nested',
+        }),
+        inheritedEnv,
+      );
+
+      assert.equal(nestedPlainCodex.status, 0, nestedPlainCodex.stderr || nestedPlainCodex.stdout);
+      assert.equal(nestedPlainCodex.stdout, '');
       await assert.rejects(readFile(calledPath, 'utf-8'), { code: 'ENOENT' });
     });
   });
@@ -851,7 +908,7 @@ head -c 1100000 /dev/zero | tr '\0' x
     await withPluginCacheCopy(async (cachePluginRoot) => {
       await writeFile(join(cachePluginRoot, 'hooks', 'omx-command.json'), '{"command":', 'utf-8');
 
-      const result = runPluginNativeHook(cachePluginRoot, '{"hook_event_name":"Stop",');
+      const result = runPluginNativeHook(cachePluginRoot, '{"hook_event_name":"Stop","session_id":"sess-plugin-malformed-stop",');
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
       const output = parseSingleJsonStdout(result.stdout);
@@ -864,7 +921,7 @@ head -c 1100000 /dev/zero | tr '\0' x
     await withPluginCacheCopy(async (cachePluginRoot) => {
       await writeFile(join(cachePluginRoot, 'hooks', 'omx-command.json'), '{"command":', 'utf-8');
 
-      const result = runPluginNativeHook(cachePluginRoot, '{"name":"Stop",');
+      const result = runPluginNativeHook(cachePluginRoot, '{"name":"Stop","session_id":"sess-plugin-malformed-name-stop",');
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
       const output = parseSingleJsonStdout(result.stdout);
@@ -909,6 +966,7 @@ head -c 1100000 /dev/zero | tr '\0' x
 
       const result = runPluginNativeHook(cachePluginRoot, JSON.stringify({
         hook_event_name: 'UserPromptSubmit',
+        session_id: 'sess-plugin-invalid-launcher-user-prompt',
         prompt: 'hello',
       }));
 
@@ -951,6 +1009,7 @@ head -c 1100000 /dev/zero | tr '\0' x
 
       const result = runPluginNativeHook(cachePluginRoot, JSON.stringify({
         hook_event_name: 'PreToolUse',
+        session_id: 'sess-plugin-nested-stop-text',
         tool_input: { name: 'Stop' },
       }));
 
@@ -966,7 +1025,7 @@ head -c 1100000 /dev/zero | tr '\0' x
 
       const result = runPluginNativeHook(
         cachePluginRoot,
-        '{"hook_event_name":"PreToolUse","tool_input":{"name":"Stop"},',
+        '{"hook_event_name":"PreToolUse","session_id":"sess-plugin-malformed-non-stop","tool_input":{"name":"Stop"},',
       );
 
       assert.equal(result.status, 1);
@@ -1125,7 +1184,10 @@ head -c 1100000 /dev/zero | tr '\0' x
 
   it('fails oversized non-Stop plugin stdin without Stop JSON', async () => {
     await withPluginCacheCopy(async (cachePluginRoot) => {
-      const result = runPluginNativeHook(cachePluginRoot, 'x'.repeat(1024 * 1024 + 1));
+      const result = runPluginNativeHook(
+        cachePluginRoot,
+        `{"hook_event_name":"UserPromptSubmit","session_id":"sess-plugin-oversized-non-stop","padding":"${'x'.repeat(1024 * 1024 + 1)}`,
+      );
 
       assert.equal(result.status, 1);
       assert.equal(result.stdout, '');

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -237,6 +237,7 @@ async function assertPluginHookLaunchesPostCompactFromCache(): Promise<void> {
         OMX_ROOT: join(cacheRoot, '.omx-root'),
         OMX_SESSION_ID: 'omx-plugin-hook-postcompact-smoke',
         OMX_SOURCE_CWD: cacheRoot,
+        OMX_ENTRY_PATH: omxBin,
         OMX_STARTUP_CWD: cacheRoot,
       },
     });
@@ -292,6 +293,7 @@ async function assertPluginHookDelegatesPostCompactToPinnedCommand(): Promise<vo
         OMX_ROOT: join(cacheRoot, '.omx-root'),
         OMX_SESSION_ID: 'omx-plugin-hook-postcompact-delegate',
         OMX_SOURCE_CWD: cacheRoot,
+        OMX_ENTRY_PATH: omxBin,
         OMX_STARTUP_CWD: cacheRoot,
       },
     });
@@ -353,10 +355,23 @@ async function withPluginCacheCopy<T>(run: (cachePluginRoot: string, cacheRoot: 
 
 function pluginHookEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   const env = { ...process.env };
-  for (const key of ['OMX_TEAM_STATE_ROOT', 'OMX_ROOT', 'OMX_STATE_ROOT', 'OMX_SESSION_ID', 'CODEX_SESSION_ID']) {
+  for (const key of [
+    'OMX_TEAM_STATE_ROOT',
+    'OMX_ROOT',
+    'OMX_STATE_ROOT',
+    'OMX_SESSION_ID',
+    'CODEX_SESSION_ID',
+    'OMX_ENTRY_PATH',
+    'OMX_STARTUP_CWD',
+  ]) {
     delete env[key];
   }
-  return { ...env, ...overrides };
+  return {
+    ...env,
+    OMX_ENTRY_PATH: omxBin,
+    OMX_STARTUP_CWD: root,
+    ...overrides,
+  };
 }
 
 function runPluginNativeHook(
@@ -456,6 +471,45 @@ describe('official Codex plugin layout', () => {
     assert.match(launcher, /return \{ \.\.\.options, windowsHide: true \};/);
     assert.match(launcher, /return \{ \.\.\.options, shell: true, windowsHide: true \};/);
     assert.doesNotMatch(launcher, /shell:\s*process\.platform === 'win32'/);
+  });
+
+  it('no-ops plugin hooks when Codex was not launched through omx', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const calledPath = join(cacheRoot, 'called.txt');
+      const commandPath = join(cacheRoot, process.platform === 'win32' ? 'record-called.cmd' : 'record-called.sh');
+      if (process.platform === 'win32') {
+        await writeFile(commandPath, `@echo off\r\necho called > "${calledPath}"\r\necho {}\r\n`, 'utf-8');
+      } else {
+        await writeFile(commandPath, `#!/bin/sh\necho called > "${calledPath}"\nprintf '{}\\n'\n`, 'utf-8');
+        await chmod(commandPath, 0o755);
+      }
+
+      const userPrompt = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({ hook_event_name: 'UserPromptSubmit', prompt: '$ralplan smoke' }),
+        {
+          OMX_ENTRY_PATH: '',
+          OMX_NATIVE_HOOK_COMMAND: commandPath,
+        },
+      );
+
+      assert.equal(userPrompt.status, 0, userPrompt.stderr || userPrompt.stdout);
+      assert.equal(userPrompt.stdout, '');
+      await assert.rejects(readFile(calledPath, 'utf-8'), { code: 'ENOENT' });
+
+      const stop = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({ hook_event_name: 'Stop', session_id: 'plain-codex-stop' }),
+        {
+          OMX_ENTRY_PATH: '',
+          OMX_NATIVE_HOOK_COMMAND: commandPath,
+        },
+      );
+
+      assert.equal(stop.status, 0, stop.stderr || stop.stdout);
+      assert.deepEqual(parseSingleJsonStdout(stop.stdout), {});
+      await assert.rejects(readFile(calledPath, 'utf-8'), { code: 'ENOENT' });
+    });
   });
 
   it('emits Stop JSON when the plugin hook pinned launcher is invalid', async () => {

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -509,6 +509,41 @@ describe('official Codex plugin layout', () => {
       assert.equal(stop.status, 0, stop.stderr || stop.stdout);
       assert.deepEqual(parseSingleJsonStdout(stop.stdout), {});
       await assert.rejects(readFile(calledPath, 'utf-8'), { code: 'ENOENT' });
+
+      const oversizedUserPrompt = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({
+          hook_event_name: 'UserPromptSubmit',
+          prompt: 'x'.repeat(2 * 1024 * 1024),
+        }),
+        {
+          OMX_ENTRY_PATH: '',
+          OMX_NATIVE_HOOK_COMMAND: commandPath,
+        },
+      );
+
+      assert.equal(oversizedUserPrompt.error, undefined, oversizedUserPrompt.error?.message ?? '');
+      assert.equal(oversizedUserPrompt.status, 0, oversizedUserPrompt.stderr || oversizedUserPrompt.stdout);
+      assert.equal(oversizedUserPrompt.stdout, '');
+      await assert.rejects(readFile(calledPath, 'utf-8'), { code: 'ENOENT' });
+
+      const oversizedStop = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({
+          hook_event_name: 'Stop',
+          session_id: 'plain-codex-oversized-stop',
+          padding: 'x'.repeat(2 * 1024 * 1024),
+        }),
+        {
+          OMX_ENTRY_PATH: '',
+          OMX_NATIVE_HOOK_COMMAND: commandPath,
+        },
+      );
+
+      assert.equal(oversizedStop.error, undefined, oversizedStop.error?.message ?? '');
+      assert.equal(oversizedStop.status, 0, oversizedStop.stderr || oversizedStop.stdout);
+      assert.deepEqual(parseSingleJsonStdout(oversizedStop.stdout), {});
+      await assert.rejects(readFile(calledPath, 'utf-8'), { code: 'ENOENT' });
     });
   });
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1730,6 +1730,7 @@ async function checkPluginScopedNativeHooks(
 				OMX_ROOT: join(smokeCwd, ".omx-doctor-root"),
 				OMX_SESSION_ID: "omx-doctor-plugin-hook-smoke",
 				OMX_SOURCE_CWD: smokeCwd,
+				OMX_ENTRY_PATH: join(getPackageRoot(), "dist", "cli", "omx.js"),
 				OMX_STARTUP_CWD: smokeCwd,
 			},
 			input: payload,

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1731,6 +1731,7 @@ async function checkPluginScopedNativeHooks(
 				OMX_SESSION_ID: "omx-doctor-plugin-hook-smoke",
 				OMX_SOURCE_CWD: smokeCwd,
 				OMX_ENTRY_PATH: join(getPackageRoot(), "dist", "cli", "omx.js"),
+				OMX_CODEX_LAUNCH_ID: "omx-doctor-plugin-hook-smoke-launch",
 				OMX_STARTUP_CWD: smokeCwd,
 			},
 			input: payload,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,7 +8,7 @@ import { basename, dirname, join, posix, resolve, win32 } from "path";
 import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "fs";
 import { copyFile, cp, lstat, mkdir, readFile, readdir, rm, stat, symlink, utimes, writeFile } from "fs/promises";
 import { constants as osConstants, homedir } from "os";
-import { createHash } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import {
   setup,
   SETUP_MCP_MODES,
@@ -5114,6 +5114,7 @@ function runCodex(
   );
   const codexEnvWithSession = {
     ...codexBaseEnv,
+    OMX_CODEX_LAUNCH_ID: randomUUID(),
     ...buildHudRuntimeEnv({ sessionId }).env,
   };
   const codexEnv = workerLaunchArgs


### PR DESCRIPTION
## Summary
- No-op the plugin hook launcher for plain Codex sessions without OMX_ENTRY_PATH.
- Preserve plugin hook delegation for Codex sessions launched through omx.
- Keep Stop hook no-op output as `{}` when the launcher is inactive, and update tests plus doctor smoke env.

## Tests
- npm run build
- node dist/scripts/run-test-files.js dist/cli/__tests__/codex-plugin-layout.test.js
- npm run verify:plugin-bundle
- npm run lint && npm run check:no-unused
- git diff --check
- Manual QA: direct plugin hook invocation without OMX_ENTRY_PATH did not call delegate; OMX_ENTRY_PATH invocation delegated to `codex-native-hook`; plain Stop emitted `{}` without delegate.