### PR TITLE
Add capabilities lockfile preflight

### DIFF
--- a/omx-capabilities.lock.json
+++ b/omx-capabilities.lock.json
@@ -1,0 +1,1767 @@
+{
+  "kind": "omx_capabilities_lock",
+  "surfaces": {
+    "agents": {
+      "digest": "63c9b3d021698b2bee26e78f3cbf4e554b6f91a773863b18746a37245c87f96b",
+      "files": [
+        {
+          "digest": "df4f90d10549e66ce33e9fad097ecd9ea8fcf08e7a6d7085550c8c95b5336d77",
+          "path": "prompts/analyst.md"
+        },
+        {
+          "digest": "9b3aab70cd1b990ab07b291a4e385af2c96d12050988eeb3a996822d2d15808f",
+          "path": "prompts/api-reviewer.md"
+        },
+        {
+          "digest": "1d1f53da3cd02bcd914dcc21804ffc81402ca7df08676f832a40999bd72a15bc",
+          "path": "prompts/architect.md"
+        },
+        {
+          "digest": "0a7f080af951632f77326cf0b1c83ea8c21d2cc62edb3f4c7cf73d9110e5012c",
+          "path": "prompts/build-fixer.md"
+        },
+        {
+          "digest": "3c29d7060d852aae2a57402e9527fa865b9464cb62ca2bcba7e193106c8d9b73",
+          "path": "prompts/code-reviewer.md"
+        },
+        {
+          "digest": "168e8424fd87342c0bc8338c415a888b993ed899ff7450d642162fcbaf45709f",
+          "path": "prompts/code-simplifier.md"
+        },
+        {
+          "digest": "454e42760521e97ca7559b2d5da8dcff997ea54a369dd9a4b64b1f3460149a95",
+          "path": "prompts/critic.md"
+        },
+        {
+          "digest": "9760e4089f99616c8963975ba4b7d75347c132cbcb62241e2b1927acba981dad",
+          "path": "prompts/debugger.md"
+        },
+        {
+          "digest": "643bc342ffe08e540b0df5c4c936396cc9624cd0b0bef4f3986224c9b06b3cdd",
+          "path": "prompts/dependency-expert.md"
+        },
+        {
+          "digest": "5c4da738867658fd8daf8af50c3208024fdef2bca5ebb40b74b2dfd131478167",
+          "path": "prompts/designer.md"
+        },
+        {
+          "digest": "d74f32aac5824828c36abffa896d2bd2f3a54ee90f04971b8a724fb58bbf51a4",
+          "path": "prompts/executor.md"
+        },
+        {
+          "digest": "5dd14215213fe6356b304b228328f9316a4c9747550f67585c77588b543fd117",
+          "path": "prompts/explore-harness.md"
+        },
+        {
+          "digest": "38101af5220cc3f8ea01f9637bb3ef92092882dc9a2084193e26b84dc5883910",
+          "path": "prompts/explore.md"
+        },
+        {
+          "digest": "8d4d0871382892ce72d72af7b14f923a0e20af6ffbcd7e48dc43fb15cd54c431",
+          "path": "prompts/git-master.md"
+        },
+        {
+          "digest": "6ba3dfee85712504c46f548f442a6a1c53c2914ea8bcfb63ddf77f06b2c69199",
+          "path": "prompts/information-architect.md"
+        },
+        {
+          "digest": "52f8211ee26375e2ae51b97f0719e8d600170dca28177faf60b9d19157e86dd6",
+          "path": "prompts/performance-reviewer.md"
+        },
+        {
+          "digest": "a6312eb91dc046f1c2c29568733cb3c06a925d90641b9a5ab54a0a717bc60902",
+          "path": "prompts/planner.md"
+        },
+        {
+          "digest": "40b39fd90f117a719f2bb2e655df2a9d563c145809b484de3d5a0891bcc2f675",
+          "path": "prompts/product-analyst.md"
+        },
+        {
+          "digest": "5be0afcd4497fa33a90474a2e7d3b7e71a3dcf36db9a2755172d31f3125633ec",
+          "path": "prompts/product-manager.md"
+        },
+        {
+          "digest": "a904daac293ca33f91291442b41a147d2ac2f314ad182cea457ccb97173ef3fe",
+          "path": "prompts/prometheus-strict-metis.md"
+        },
+        {
+          "digest": "3202c0c36c2e759833ee7af4ce9c8620471f80249ba1e0da74beb65e354295e5",
+          "path": "prompts/prometheus-strict-momus.md"
+        },
+        {
+          "digest": "745f2d4563e4f0eeeefbee3ab53dc3daa9ecdea57d749cda7ccdef33e57ee4de",
+          "path": "prompts/prometheus-strict-oracle.md"
+        },
+        {
+          "digest": "5e8a183c3c4ab7bae3b83f70a50f10aa6025a6654f25958ae02fd28fde3d3c23",
+          "path": "prompts/qa-tester.md"
+        },
+        {
+          "digest": "fe3da1a9b85601cb51883bca7158947b17ef2dd19c07d77fe14e2d91dad21f79",
+          "path": "prompts/quality-reviewer.md"
+        },
+        {
+          "digest": "9297e99746cd939187b5b1c627d212b0844e0bd8bcd1aadea1c18dd580b9ba86",
+          "path": "prompts/quality-strategist.md"
+        },
+        {
+          "digest": "34ae0143e3f071caf3bf55e027fe14cc713725229ef385409dfa1c3285921d2b",
+          "path": "prompts/researcher.md"
+        },
+        {
+          "digest": "cc54ccec7352e0616c56009c6ffc9b207f5dfd335fb0b02d445cb3e0d04ba856",
+          "path": "prompts/scholastic.md"
+        },
+        {
+          "digest": "9cf46f8a1c21ef3383be79bfd0430d7ba0ff97120c46011f74d811e6d1d67c9d",
+          "path": "prompts/security-reviewer.md"
+        },
+        {
+          "digest": "def762b90530acbe1c5e8bbc9e4bfc60c8740a3a558dada1afcd5d416b01a4cd",
+          "path": "prompts/sisyphus-lite.md"
+        },
+        {
+          "digest": "8dc0ea45e9edcc294487fa3f6c4988069b58692eee094329b1b454707a1e8b97",
+          "path": "prompts/style-reviewer.md"
+        },
+        {
+          "digest": "0e13c0e5a755881756476bc48ba5f38c6e02506d8db4d96cf543c96343336b62",
+          "path": "prompts/team-executor.md"
+        },
+        {
+          "digest": "86dd2852fd5364cec32882409d1837bab239468754e360a84fd8325eb93c7d2a",
+          "path": "prompts/team-orchestrator.md"
+        },
+        {
+          "digest": "14744da0ded006eec494e2069eaeb2a51f69fbc474fd3a8b1e701e3a9edaf80f",
+          "path": "prompts/test-engineer.md"
+        },
+        {
+          "digest": "783b77204a4e7b0c24414dee76c25ee2d1457e4350672123b70f4acf6d02108f",
+          "path": "prompts/ux-researcher.md"
+        },
+        {
+          "digest": "393a231e8651f230fe4d7906624118bae68d35f88eacd77f2b14962797430cef",
+          "path": "prompts/verifier.md"
+        },
+        {
+          "digest": "357ce4f1c9b4b88bcd82ebde3b69f29899ddc4d4bf45398491c982cfec0e2bfb",
+          "path": "prompts/vision.md"
+        },
+        {
+          "digest": "20a40dd88fc1d8dbe3f088c50919598340336339ce9975dd9956eb604c3b4cac",
+          "path": "prompts/writer.md"
+        },
+        {
+          "digest": "8f7865f21bb0d29df135382c7c140b4f9f95f4ca56cc27ac3ea30ffcb248e805",
+          "path": "templates/model-instructions/explore-lightweight-AGENTS.md"
+        },
+        {
+          "digest": "6705b79aa4059cdf1e7df415b4cd5eb401282e07e64072d531d81e57f0716be2",
+          "path": "templates/model-instructions/sparkshell-lightweight-AGENTS.md"
+        }
+      ]
+    },
+    "configured_tools": {
+      "digest": "4fa5a7b8baf12ed3b3454e5f31909d7596bc65601f323f5032cd5a7db310183e",
+      "disabled_first_party_servers": [],
+      "external_servers": [],
+      "tools": [
+        {
+          "description": "Replace code patterns using AST matching. Use meta-variables in both pattern and replacement. IMPORTANT: dryRun=true (default) only previews changes. Set dryRun=false to apply.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "dryRun": {
+                "description": "Preview only (default: true)",
+                "type": "boolean"
+              },
+              "language": {
+                "enum": [
+                  "javascript",
+                  "typescript",
+                  "tsx",
+                  "python",
+                  "ruby",
+                  "go",
+                  "rust",
+                  "java",
+                  "kotlin",
+                  "swift",
+                  "c",
+                  "cpp",
+                  "csharp",
+                  "html",
+                  "css",
+                  "json",
+                  "yaml"
+                ],
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "pattern": {
+                "description": "Pattern to match",
+                "type": "string"
+              },
+              "replacement": {
+                "description": "Replacement pattern (use same meta-variables)",
+                "type": "string"
+              }
+            },
+            "required": [
+              "pattern",
+              "replacement",
+              "language"
+            ],
+            "type": "object"
+          },
+          "name": "ast_grep_replace",
+          "server": "code_intel"
+        },
+        {
+          "description": "Search for code patterns using AST matching. Uses meta-variables: $NAME (single node), $$$ARGS (multiple nodes). Example: \"function $NAME($$$ARGS)\" finds all function declarations.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "context": {
+                "type": "integer"
+              },
+              "language": {
+                "enum": [
+                  "javascript",
+                  "typescript",
+                  "tsx",
+                  "python",
+                  "ruby",
+                  "go",
+                  "rust",
+                  "java",
+                  "kotlin",
+                  "swift",
+                  "c",
+                  "cpp",
+                  "csharp",
+                  "html",
+                  "css",
+                  "json",
+                  "yaml"
+                ],
+                "type": "string"
+              },
+              "maxResults": {
+                "type": "integer"
+              },
+              "path": {
+                "description": "Directory or file to search in",
+                "type": "string"
+              },
+              "pattern": {
+                "description": "AST pattern with meta-variables ($VAR, $$$VARS)",
+                "type": "string"
+              }
+            },
+            "required": [
+              "pattern",
+              "language"
+            ],
+            "type": "object"
+          },
+          "name": "ast_grep_search",
+          "server": "code_intel"
+        },
+        {
+          "description": "Get diagnostics (errors, warnings) for a file. Uses tsc --noEmit for TypeScript projects.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "file": {
+                "description": "Path to the source file",
+                "type": "string"
+              },
+              "severity": {
+                "enum": [
+                  "error",
+                  "warning",
+                  "info",
+                  "hint"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "file"
+            ],
+            "type": "object"
+          },
+          "name": "lsp_diagnostics",
+          "server": "code_intel"
+        },
+        {
+          "description": "Run project-level diagnostics on a directory using tsc --noEmit. Returns all errors across the project.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "directory": {
+                "description": "Project directory to check",
+                "type": "string"
+              },
+              "strategy": {
+                "description": "Diagnostic strategy (default: auto)",
+                "enum": [
+                  "tsc",
+                  "auto"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "directory"
+            ],
+            "type": "object"
+          },
+          "name": "lsp_diagnostics_directory",
+          "server": "code_intel"
+        },
+        {
+          "description": "Get a hierarchical outline of all symbols in a file (functions, classes, variables, etc.).",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "file": {
+                "description": "Path to the source file",
+                "type": "string"
+              }
+            },
+            "required": [
+              "file"
+            ],
+            "type": "object"
+          },
+          "name": "lsp_document_symbols",
+          "server": "code_intel"
+        },
+        {
+          "description": "Find all references to a symbol across the codebase using grep-based search.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "character": {
+                "description": "Character position (0-indexed)",
+                "type": "integer"
+              },
+              "file": {
+                "description": "Path to the source file",
+                "type": "string"
+              },
+              "includeDeclaration": {
+                "type": "boolean"
+              },
+              "line": {
+                "description": "Line number (1-indexed)",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "file",
+              "line",
+              "character"
+            ],
+            "type": "object"
+          },
+          "name": "lsp_find_references",
+          "server": "code_intel"
+        },
+        {
+          "description": "Get type information and documentation at a specific position in a file (regex-based approximation).",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "character": {
+                "description": "Character position (0-indexed)",
+                "type": "integer"
+              },
+              "file": {
+                "description": "Path to the source file",
+                "type": "string"
+              },
+              "line": {
+                "description": "Line number (1-indexed)",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "file",
+              "line",
+              "character"
+            ],
+            "type": "object"
+          },
+          "name": "lsp_hover",
+          "server": "code_intel"
+        },
+        {
+          "description": "List available diagnostic backends and their installation status.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {},
+            "type": "object"
+          },
+          "name": "lsp_servers",
+          "server": "code_intel"
+        },
+        {
+          "description": "Search for symbols (functions, classes, etc.) across the workspace by name.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "file": {
+                "description": "Any file in the workspace (used to determine project root)",
+                "type": "string"
+              },
+              "query": {
+                "description": "Symbol name or pattern to search",
+                "type": "string"
+              }
+            },
+            "required": [
+              "query",
+              "file"
+            ],
+            "type": "object"
+          },
+          "name": "lsp_workspace_symbols",
+          "server": "code_intel"
+        },
+        {
+          "description": "List known safe result artifact files under .omx plans/specs/goals/context/reports.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "limit": {
+                "type": "number"
+              },
+              "workingDirectory": {
+                "description": "Bounded OMX project/worktree directory",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "hermes_list_artifacts",
+          "server": "hermes"
+        },
+        {
+          "description": "Read structured question lifecycle events for coordinator bridge correlation.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "limit": {
+                "type": "number"
+              },
+              "workingDirectory": {
+                "description": "Bounded OMX project/worktree directory",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "hermes_list_question_events",
+          "server": "hermes"
+        },
+        {
+          "description": "List bounded structured question records without reading terminal UI.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "limit": {
+                "type": "number"
+              },
+              "session_id": {
+                "description": "OMX session_id (A-Z, a-z, 0-9, _, -)",
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "open",
+                  "pending",
+                  "prompting",
+                  "answered",
+                  "aborted",
+                  "error"
+                ],
+                "type": "string"
+              },
+              "workingDirectory": {
+                "description": "Bounded OMX project/worktree directory",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "hermes_list_questions",
+          "server": "hermes"
+        },
+        {
+          "description": "List known OMX session state for a bounded worktree without reading terminal UI.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "workingDirectory": {
+                "description": "Bounded OMX project/worktree directory",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "hermes_list_sessions",
+          "server": "hermes"
+        },
+        {
+          "description": "Read one safe .omx result artifact by relative path with byte truncation.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "max_bytes": {
+                "type": "number"
+              },
+              "path": {
+                "type": "string"
+              },
+              "workingDirectory": {
+                "description": "Bounded OMX project/worktree directory",
+                "type": "string"
+              }
+            },
+            "required": [
+              "path"
+            ],
+            "type": "object"
+          },
+          "name": "hermes_read_artifact",
+          "server": "hermes"
+        },
+        {
+          "description": "Read selected session/mode status JSON from OMX state files.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "session_id": {
+                "description": "OMX session_id (A-Z, a-z, 0-9, _, -)",
+                "type": "string"
+              },
+              "workingDirectory": {
+                "description": "Bounded OMX project/worktree directory",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "hermes_read_status",
+          "server": "hermes"
+        },
+        {
+          "description": "Read the bounded OMX session history log tail, not tmux scrollback.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "lines": {
+                "type": "number"
+              },
+              "workingDirectory": {
+                "description": "Bounded OMX project/worktree directory",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "hermes_read_tail",
+          "server": "hermes"
+        },
+        {
+          "description": "Write a small final/blocker status report for Hermes without owning merge policy.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "allow_mutation": {
+                "description": "Must be true for mutating operations; read tools ignore it.",
+                "type": "boolean"
+              },
+              "blocker": {
+                "type": "string"
+              },
+              "pr_url": {
+                "type": "string"
+              },
+              "session_id": {
+                "description": "OMX session_id (A-Z, a-z, 0-9, _, -)",
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "running",
+                  "blocked",
+                  "failed",
+                  "complete"
+                ],
+                "type": "string"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "workingDirectory": {
+                "description": "Bounded OMX project/worktree directory",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "allow_mutation"
+            ],
+            "type": "object"
+          },
+          "name": "hermes_report_status",
+          "server": "hermes"
+        },
+        {
+          "description": "Queue one explicit prompt for a selected OMX exec session via the audited follow-up queue.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "actor": {
+                "type": "string"
+              },
+              "allow_mutation": {
+                "description": "Must be true for mutating operations; read tools ignore it.",
+                "type": "boolean"
+              },
+              "prompt": {
+                "type": "string"
+              },
+              "session_id": {
+                "description": "OMX session_id (A-Z, a-z, 0-9, _, -)",
+                "type": "string"
+              },
+              "workingDirectory": {
+                "description": "Bounded OMX project/worktree directory",
+                "type": "string"
+              }
+            },
+            "required": [
+              "session_id",
+              "prompt",
+              "allow_mutation"
+            ],
+            "type": "object"
+          },
+          "name": "hermes_send_prompt",
+          "server": "hermes"
+        },
+        {
+          "description": "Start a new isolated OMX tmux session in disposable worktree mode for one bounded prompt.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "allow_mutation": {
+                "description": "Must be true for mutating operations; read tools ignore it.",
+                "type": "boolean"
+              },
+              "prompt": {
+                "type": "string"
+              },
+              "workingDirectory": {
+                "description": "Bounded OMX project/worktree directory",
+                "type": "string"
+              },
+              "worktreeName": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "workingDirectory",
+              "prompt",
+              "allow_mutation"
+            ],
+            "type": "object"
+          },
+          "name": "hermes_start_session",
+          "server": "hermes"
+        },
+        {
+          "description": "Submit a bounded structured answer by question id; never proxies arbitrary terminal input.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "allow_mutation": {
+                "description": "Must be true for mutating operations; read tools ignore it.",
+                "type": "boolean"
+              },
+              "answer": {
+                "type": "object"
+              },
+              "answers": {
+                "items": {
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "question_id": {
+                "type": "string"
+              },
+              "session_id": {
+                "description": "OMX session_id (A-Z, a-z, 0-9, _, -)",
+                "type": "string"
+              },
+              "workingDirectory": {
+                "description": "Bounded OMX project/worktree directory",
+                "type": "string"
+              }
+            },
+            "required": [
+              "question_id",
+              "allow_mutation"
+            ],
+            "type": "object"
+          },
+          "name": "hermes_submit_question_answer",
+          "server": "hermes"
+        },
+        {
+          "description": "Prune Working Memory entries older than N days (default: 7).",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "daysOld": {
+                "description": "Prune entries older than this many days (default: 7)",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "notepad_prune",
+          "server": "memory"
+        },
+        {
+          "description": "Read notepad content. Can read full or a specific section (priority, working, manual).",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "section": {
+                "enum": [
+                  "all",
+                  "priority",
+                  "working",
+                  "manual"
+                ],
+                "type": "string"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "notepad_read",
+          "server": "memory"
+        },
+        {
+          "description": "Get statistics about the notepad (size, entry count, oldest entry).",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "notepad_stats",
+          "server": "memory"
+        },
+        {
+          "description": "Add entry to Manual section. Never auto-pruned.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "content": {
+                "description": "Manual entry content",
+                "type": "string"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "content"
+            ],
+            "type": "object"
+          },
+          "name": "notepad_write_manual",
+          "server": "memory"
+        },
+        {
+          "description": "Write to Priority Context section. Replaces existing. Keep under 500 chars.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "content": {
+                "description": "Priority content (under 500 chars)",
+                "type": "string"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "content"
+            ],
+            "type": "object"
+          },
+          "name": "notepad_write_priority",
+          "server": "memory"
+        },
+        {
+          "description": "Add timestamped entry to Working Memory section.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "content": {
+                "description": "Working memory entry",
+                "type": "string"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "content"
+            ],
+            "type": "object"
+          },
+          "name": "notepad_write_working",
+          "server": "memory"
+        },
+        {
+          "description": "Add a persistent directive to project memory.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "context": {
+                "type": "string"
+              },
+              "directive": {
+                "description": "The directive text",
+                "type": "string"
+              },
+              "priority": {
+                "enum": [
+                  "high",
+                  "normal"
+                ],
+                "type": "string"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "directive"
+            ],
+            "type": "object"
+          },
+          "name": "project_memory_add_directive",
+          "server": "memory"
+        },
+        {
+          "description": "Add a categorized note to project memory.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "category": {
+                "description": "Note category (build, test, deploy, env, architecture)",
+                "type": "string"
+              },
+              "content": {
+                "description": "Note content",
+                "type": "string"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "category",
+              "content"
+            ],
+            "type": "object"
+          },
+          "name": "project_memory_add_note",
+          "server": "memory"
+        },
+        {
+          "description": "Read project memory. Can read full memory or a specific section.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "section": {
+                "enum": [
+                  "all",
+                  "techStack",
+                  "build",
+                  "conventions",
+                  "structure",
+                  "notes",
+                  "directives"
+                ],
+                "type": "string"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "project_memory_read",
+          "server": "memory"
+        },
+        {
+          "description": "Write/update project memory. Can replace entirely or merge.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "memory": {
+                "description": "Memory object to write",
+                "type": "object"
+              },
+              "merge": {
+                "description": "Merge with existing (true) or replace (false)",
+                "type": "boolean"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "memory"
+            ],
+            "type": "object"
+          },
+          "name": "project_memory_write",
+          "server": "memory"
+        },
+        {
+          "description": "Clear/delete state for a specific mode.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "all_sessions": {
+                "description": "Clear matching mode in global and all session scopes",
+                "type": "boolean"
+              },
+              "mode": {
+                "enum": [
+                  "autopilot",
+                  "autoresearch",
+                  "team",
+                  "ralph",
+                  "ultrawork",
+                  "ultraqa",
+                  "ralplan",
+                  "deep-interview",
+                  "skill-active"
+                ],
+                "type": "string"
+              },
+              "session_id": {
+                "description": "Optional session scope ID",
+                "type": "string"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "mode"
+            ],
+            "type": "object"
+          },
+          "name": "state_clear",
+          "server": "state"
+        },
+        {
+          "description": "Get detailed status for a specific mode or all modes.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "mode": {
+                "enum": [
+                  "autopilot",
+                  "autoresearch",
+                  "team",
+                  "ralph",
+                  "ultrawork",
+                  "ultraqa",
+                  "ralplan",
+                  "deep-interview",
+                  "skill-active"
+                ],
+                "type": "string"
+              },
+              "session_id": {
+                "description": "Optional session scope ID",
+                "type": "string"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "state_get_status",
+          "server": "state"
+        },
+        {
+          "description": "List all currently active modes.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "session_id": {
+                "description": "Optional session scope ID",
+                "type": "string"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "state_list_active",
+          "server": "state"
+        },
+        {
+          "description": "Read state for a specific mode. Returns JSON state data or indicates no state exists.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "mode": {
+                "description": "The mode to read state for",
+                "enum": [
+                  "autopilot",
+                  "autoresearch",
+                  "team",
+                  "ralph",
+                  "ultrawork",
+                  "ultraqa",
+                  "ralplan",
+                  "deep-interview",
+                  "skill-active"
+                ],
+                "type": "string"
+              },
+              "session_id": {
+                "description": "Optional session scope ID",
+                "type": "string"
+              },
+              "workingDirectory": {
+                "description": "Working directory override",
+                "type": "string"
+              }
+            },
+            "required": [
+              "mode"
+            ],
+            "type": "object"
+          },
+          "name": "state_read",
+          "server": "state"
+        },
+        {
+          "description": "Write/update state for a specific mode. Creates directories if needed.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "active": {
+                "type": "boolean"
+              },
+              "completed_at": {
+                "type": "string"
+              },
+              "current_phase": {
+                "type": "string"
+              },
+              "error": {
+                "type": "string"
+              },
+              "iteration": {
+                "type": "number"
+              },
+              "lifecycle_outcome": {
+                "enum": [
+                  "finished",
+                  "blocked",
+                  "failed",
+                  "userinterlude",
+                  "askuserQuestion"
+                ],
+                "type": "string"
+              },
+              "max_iterations": {
+                "type": "number"
+              },
+              "mode": {
+                "enum": [
+                  "autopilot",
+                  "autoresearch",
+                  "team",
+                  "ralph",
+                  "ultrawork",
+                  "ultraqa",
+                  "ralplan",
+                  "deep-interview",
+                  "skill-active"
+                ],
+                "type": "string"
+              },
+              "run_outcome": {
+                "enum": [
+                  "continue",
+                  "finish",
+                  "blocked_on_user",
+                  "failed",
+                  "cancelled"
+                ],
+                "type": "string"
+              },
+              "session_id": {
+                "description": "Optional session scope ID",
+                "type": "string"
+              },
+              "started_at": {
+                "type": "string"
+              },
+              "state": {
+                "description": "Additional custom fields",
+                "type": "object"
+              },
+              "task_description": {
+                "type": "string"
+              },
+              "terminal_outcome": {
+                "description": "Legacy alias for lifecycle_outcome; canonical writes should prefer lifecycle_outcome.",
+                "enum": [
+                  "finished",
+                  "blocked",
+                  "failed",
+                  "userinterlude",
+                  "askuserQuestion"
+                ],
+                "type": "string"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "mode"
+            ],
+            "type": "object"
+          },
+          "name": "state_write",
+          "server": "state"
+        },
+        {
+          "description": "Show aggregate statistics for agent flow trace. Includes turn counts, mode usage, token consumption, and timing.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "trace_summary",
+          "server": "trace"
+        },
+        {
+          "description": "Show chronological agent flow trace timeline. Displays turns, mode transitions, and agent activity in time order.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "filter": {
+                "description": "Filter: all (default), turns (agent turns only), modes (mode transitions only)",
+                "enum": [
+                  "all",
+                  "turns",
+                  "modes"
+                ],
+                "type": "string"
+              },
+              "last": {
+                "description": "Show only the last N entries",
+                "type": "number"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "trace_timeline",
+          "server": "trace"
+        },
+        {
+          "description": "Quick-add a single wiki page. Rejects overwrites; use wiki_ingest to merge.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "category": {
+                "enum": [
+                  "architecture",
+                  "decision",
+                  "pattern",
+                  "debugging",
+                  "environment",
+                  "session-log",
+                  "reference",
+                  "convention"
+                ],
+                "type": "string"
+              },
+              "content": {
+                "maxLength": 50000,
+                "type": "string"
+              },
+              "tags": {
+                "items": {
+                  "maxLength": 50,
+                  "type": "string"
+                },
+                "maxItems": 20,
+                "type": "array"
+              },
+              "title": {
+                "maxLength": 200,
+                "type": "string"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title",
+              "content"
+            ],
+            "type": "object"
+          },
+          "name": "wiki_add",
+          "server": "wiki"
+        },
+        {
+          "description": "Delete a wiki page and update the index.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "page": {
+                "type": "string"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "page"
+            ],
+            "type": "object"
+          },
+          "name": "wiki_delete",
+          "server": "wiki"
+        },
+        {
+          "description": "Process knowledge into wiki pages. Creates new pages or merges into existing ones.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "category": {
+                "enum": [
+                  "architecture",
+                  "decision",
+                  "pattern",
+                  "debugging",
+                  "environment",
+                  "session-log",
+                  "reference",
+                  "convention"
+                ],
+                "type": "string"
+              },
+              "confidence": {
+                "enum": [
+                  "high",
+                  "medium",
+                  "low"
+                ],
+                "type": "string"
+              },
+              "content": {
+                "maxLength": 50000,
+                "type": "string"
+              },
+              "sources": {
+                "items": {
+                  "maxLength": 100,
+                  "type": "string"
+                },
+                "maxItems": 10,
+                "type": "array"
+              },
+              "tags": {
+                "items": {
+                  "maxLength": 50,
+                  "type": "string"
+                },
+                "maxItems": 20,
+                "type": "array"
+              },
+              "title": {
+                "maxLength": 200,
+                "type": "string"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title",
+              "content",
+              "tags",
+              "category"
+            ],
+            "type": "object"
+          },
+          "name": "wiki_ingest",
+          "server": "wiki"
+        },
+        {
+          "description": "Run health checks on the wiki.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "wiki_lint",
+          "server": "wiki"
+        },
+        {
+          "description": "List wiki pages and return the index when present.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "wiki_list",
+          "server": "wiki"
+        },
+        {
+          "description": "Search wiki pages by keywords and tags. Returns raw matches for synthesis.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "category": {
+                "enum": [
+                  "architecture",
+                  "decision",
+                  "pattern",
+                  "debugging",
+                  "environment",
+                  "session-log",
+                  "reference",
+                  "convention"
+                ],
+                "type": "string"
+              },
+              "limit": {
+                "maximum": 50,
+                "minimum": 1,
+                "type": "integer"
+              },
+              "query": {
+                "type": "string"
+              },
+              "tags": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "query"
+            ],
+            "type": "object"
+          },
+          "name": "wiki_query",
+          "server": "wiki"
+        },
+        {
+          "description": "Read a specific wiki page.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "page": {
+                "type": "string"
+              },
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "page"
+            ],
+            "type": "object"
+          },
+          "name": "wiki_read",
+          "server": "wiki"
+        },
+        {
+          "description": "Rebuild the wiki index and refresh derived metadata surfaces.",
+          "enabled": true,
+          "inputSchema": {
+            "properties": {
+              "workingDirectory": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "wiki_refresh",
+          "server": "wiki"
+        }
+      ]
+    },
+    "fixtures": {
+      "digest": "88d95e3b00265771de6c023c16df6da41dc90d4b6f6c1b82cab72dd889bcbfae",
+      "fixtures": [
+        {
+          "allowed_tools": [
+            "ast_grep_replace",
+            "ast_grep_search",
+            "hermes_list_artifacts",
+            "hermes_list_question_events",
+            "hermes_list_questions",
+            "hermes_list_sessions",
+            "hermes_read_artifact",
+            "hermes_read_status",
+            "hermes_read_tail",
+            "hermes_report_status",
+            "hermes_send_prompt",
+            "hermes_start_session",
+            "hermes_submit_question_answer",
+            "lsp_diagnostics",
+            "lsp_diagnostics_directory",
+            "lsp_document_symbols",
+            "lsp_find_references",
+            "lsp_hover",
+            "lsp_servers",
+            "lsp_workspace_symbols",
+            "notepad_prune",
+            "notepad_read",
+            "notepad_stats",
+            "notepad_write_manual",
+            "notepad_write_priority",
+            "notepad_write_working",
+            "project_memory_add_directive",
+            "project_memory_add_note",
+            "project_memory_read",
+            "project_memory_write",
+            "state_clear",
+            "state_get_status",
+            "state_list_active",
+            "state_read",
+            "state_write",
+            "trace_summary",
+            "trace_timeline",
+            "wiki_add",
+            "wiki_delete",
+            "wiki_ingest",
+            "wiki_lint",
+            "wiki_list",
+            "wiki_query",
+            "wiki_read",
+            "wiki_refresh"
+          ],
+          "expected_tool": "project_memory_write",
+          "id": "project-memory-write-required-arg",
+          "prompt_id": "missing-required-arg",
+          "required": true
+        },
+        {
+          "allowed_tools": [
+            "ast_grep_replace",
+            "ast_grep_search",
+            "hermes_list_artifacts",
+            "hermes_list_question_events",
+            "hermes_list_questions",
+            "hermes_list_sessions",
+            "hermes_read_artifact",
+            "hermes_read_status",
+            "hermes_read_tail",
+            "hermes_report_status",
+            "hermes_send_prompt",
+            "hermes_start_session",
+            "hermes_submit_question_answer",
+            "lsp_diagnostics",
+            "lsp_diagnostics_directory",
+            "lsp_document_symbols",
+            "lsp_find_references",
+            "lsp_hover",
+            "lsp_servers",
+            "lsp_workspace_symbols",
+            "notepad_prune",
+            "notepad_read",
+            "notepad_stats",
+            "notepad_write_manual",
+            "notepad_write_priority",
+            "notepad_write_working",
+            "project_memory_add_directive",
+            "project_memory_add_note",
+            "project_memory_read",
+            "project_memory_write",
+            "state_clear",
+            "state_get_status",
+            "state_list_active",
+            "state_read",
+            "state_write",
+            "trace_summary",
+            "trace_timeline",
+            "wiki_add",
+            "wiki_delete",
+            "wiki_ingest",
+            "wiki_lint",
+            "wiki_list",
+            "wiki_query",
+            "wiki_read",
+            "wiki_refresh"
+          ],
+          "expected_tool": "project_memory_read",
+          "id": "project-memory-read-known-tool",
+          "prompt_id": "known-tool-success",
+          "required": true
+        },
+        {
+          "allowed_tools": [],
+          "id": "tool-restraint-no-call",
+          "no_tool_calls": true,
+          "prompt_id": "tool-restraint",
+          "required": true
+        }
+      ]
+    },
+    "skills": {
+      "digest": "0e59dbf0f181393ea4fd5b5a10afe938d56b31585ba1952dbcd9d4b028f3fd62",
+      "files": [
+        {
+          "digest": "3b34b200e4797cf0b31a2840ee745565a84bcd59fd0537b41825fa5951087a8c",
+          "path": "skills/ai-slop-cleaner/SKILL.md"
+        },
+        {
+          "digest": "3f64b3f5b888a75e9d6d043b3b87b6961cc780a997ee22f44d77dbb1716dcae5",
+          "path": "skills/analyze/SKILL.md"
+        },
+        {
+          "digest": "496e7a4dedcb55860b38e126d270e08f331d4f695e2dc22fb0249b6104517d0e",
+          "path": "skills/ask-claude/SKILL.md"
+        },
+        {
+          "digest": "04f4dbf8f289f2be15cb986b5aed5b46a7974e5f4655eacbc38696ee3a7f1082",
+          "path": "skills/ask-gemini/SKILL.md"
+        },
+        {
+          "digest": "5301bee75b021060a7021bb27782c904e4bebff1217e158a3107285e649c65ed",
+          "path": "skills/ask/SKILL.md"
+        },
+        {
+          "digest": "55f05e82682133fd7c42f524d69d54ff73b1f1e9d4e65333bead4fa146410197",
+          "path": "skills/autopilot/SKILL.md"
+        },
+        {
+          "digest": "6ca757600cd96cb2c1fe3fe9dac83dbec9a65aa98f12a05abe49e03bb9b3ae6d",
+          "path": "skills/autoresearch-goal/SKILL.md"
+        },
+        {
+          "digest": "5620155f31222fc0b2b76fce133aa7a77ca7d6e89607c65495f9efbb48d53eb2",
+          "path": "skills/autoresearch/SKILL.md"
+        },
+        {
+          "digest": "3d5904298db7125184742e86d075eb331954586e45d2647c09249a3dac38e010",
+          "path": "skills/best-practice-research/SKILL.md"
+        },
+        {
+          "digest": "aafbdee5a0c1df78850f1db9ee078f818d63cc442371ca822ec0df2d52c34e40",
+          "path": "skills/build-fix/SKILL.md"
+        },
+        {
+          "digest": "9dc56f2817d218c696c7de198dc21b7666e8c37d8a78373cc1b04869586ba96b",
+          "path": "skills/cancel/SKILL.md"
+        },
+        {
+          "digest": "529e730550f911b935ebb2f15085e8e148fbd70c85dce93a9b3b6b4f4e8299d7",
+          "path": "skills/code-review/SKILL.md"
+        },
+        {
+          "digest": "c6aa441dda9be9389e8069c8d6e6817f9f4183beaf7cabec22ca4dc793a02d1e",
+          "path": "skills/configure-notifications/SKILL.md"
+        },
+        {
+          "digest": "9979d0d4aef4e917af9559ce952f51530c525263d545c01f4780372078523bb0",
+          "path": "skills/deep-interview/SKILL.md"
+        },
+        {
+          "digest": "2dc38ba1be7baacb09edf09df30d394d7ec24428cc6055ecef23ebb0b7b92fd9",
+          "path": "skills/deepsearch/SKILL.md"
+        },
+        {
+          "digest": "793d9fb7ce9fbcb238ee27c96d31dc2c0edf4d77cdaf28d023138a4197b1f956",
+          "path": "skills/design/SKILL.md"
+        },
+        {
+          "digest": "75acd48ed891b72a5c6be5ecd6606343961830f064e933a6a1650a9f2cef7bdd",
+          "path": "skills/doctor/SKILL.md"
+        },
+        {
+          "digest": "0fab8ea1c8cb5696578ef3b350b45f72177a8074563b5750cc29564bd28613c3",
+          "path": "skills/ecomode/SKILL.md"
+        },
+        {
+          "digest": "70e692291e8f1c58bdf8a42cc1809d9f8d987a900e9b816fb2f51d34869111d0",
+          "path": "skills/frontend-ui-ux/SKILL.md"
+        },
+        {
+          "digest": "d917dbd61c1476133a6fa2e5c3ff3fbd4d56a458fea71aa0594c16b8d998f2b7",
+          "path": "skills/git-master/SKILL.md"
+        },
+        {
+          "digest": "84fda285c398f5a496ce221e931f8395a8864fc592fbf4cb5ef7322f8c5a8785",
+          "path": "skills/help/SKILL.md"
+        },
+        {
+          "digest": "d5c30b632149f1fc06e9945872e3eb02a5efeb93ba66bf512ecae558d1e3b4ea",
+          "path": "skills/hud/SKILL.md"
+        },
+        {
+          "digest": "4c842f56d349dd03ce1d69fff55c0389cd4158f3c802620b936967b41677c687",
+          "path": "skills/note/SKILL.md"
+        },
+        {
+          "digest": "30e994b5217c7ede52b88c65bfc53797a627c8404b7959bd5797888b49beba4a",
+          "path": "skills/omx-setup/SKILL.md"
+        },
+        {
+          "digest": "5adac796c4d807e4d30506a67dd9f39fc8812a0675536140e4566771e4806dfd",
+          "path": "skills/performance-goal/SKILL.md"
+        },
+        {
+          "digest": "f23018b67d7ea59bfca4e5321bfd0c5584f34d547598334fba625869fbdd7a37",
+          "path": "skills/pipeline/SKILL.md"
+        },
+        {
+          "digest": "24ddfa88be1efd06baf8fd93373be6d19ade207a6d2c37822d8dcc08835770ac",
+          "path": "skills/plan/SKILL.md"
+        },
+        {
+          "digest": "43b2639c4dc2ac3853fc141927270ab6c6cb1d791b52934f0eb1a437e57d6b81",
+          "path": "skills/prometheus-strict/SKILL.md"
+        },
+        {
+          "digest": "b81b0739c103e044c97ad808739a83c252d92f486084202374fec69eeb8a194e",
+          "path": "skills/ralph-init/SKILL.md"
+        },
+        {
+          "digest": "fd631c8fd4011af487c5521b2f29c9c31d0f9f90480be294811b9c9ae8da2b6c",
+          "path": "skills/ralph/SKILL.md"
+        },
+        {
+          "digest": "510b639a0e79c611f9f46c4739db2b2ba7873dfc5e41656c506acf3db5fd9467",
+          "path": "skills/ralplan/SKILL.md"
+        },
+        {
+          "digest": "6099f7c30780c96c0bea1a339319e6324eeddabe84003a6d928ccc877bc4d0ec",
+          "path": "skills/review/SKILL.md"
+        },
+        {
+          "digest": "007ac9f94b8d246f64a5c0360408f5682ae43d5468c4415ca9c2f6623e82321c",
+          "path": "skills/security-review/SKILL.md"
+        },
+        {
+          "digest": "b459ca43f1cefbf9a367a39dd0b76283408cdef8cf52ad1890d806359d5bb9bb",
+          "path": "skills/skill/SKILL.md"
+        },
+        {
+          "digest": "9806ce3dff32a149edc61bc62ee20ecadc1cce6fdc9f997f3abc5ec4cc1633d4",
+          "path": "skills/swarm/SKILL.md"
+        },
+        {
+          "digest": "b94bc25930af9f996be7f892b161b53ef9f8cf951784d31806548f5ad45e142c",
+          "path": "skills/tdd/SKILL.md"
+        },
+        {
+          "digest": "2163d2df462e21a9c5734dfbd764044195814937866cfe037b5a860a2f803397",
+          "path": "skills/team/SKILL.md"
+        },
+        {
+          "digest": "c39af0c40fddb921bff9f6e34bc8c85f736265c2935e664709de7b33e2ea94bb",
+          "path": "skills/trace/SKILL.md"
+        },
+        {
+          "digest": "c6d8d253dd0f3041c0c671838a346218a03c1479169777ede02734dffe8d3c73",
+          "path": "skills/ultragoal/SKILL.md"
+        },
+        {
+          "digest": "7c5296ae3961274d26a2c3ed05636c63f745250f37c25017cf854e0151cff7b2",
+          "path": "skills/ultraqa/SKILL.md"
+        },
+        {
+          "digest": "b363978ba2db76b700f51472f963388f686d19e8b8def976b5d7b9b64bfa1b13",
+          "path": "skills/ultrawork/SKILL.md"
+        },
+        {
+          "digest": "ed55aee5968859d4655679f6e7a7dfee1a2a2e9313fdb2c71a2e90824f79f6d7",
+          "path": "skills/visual-ralph/SKILL.md"
+        },
+        {
+          "digest": "abeaa514ff016d8e84db48aa58e278bcf1f62848147d556114e60e4039399c3f",
+          "path": "skills/visual-verdict/SKILL.md"
+        },
+        {
+          "digest": "b4baf27613f89cea1096845f66398e206f88b4eb82252b2c4b4cd8bcd5551f28",
+          "path": "skills/web-clone/SKILL.md"
+        },
+        {
+          "digest": "94c4715d92451a6ae4281bc1690564a659ad68cb58b0938004a49b1079a14241",
+          "path": "skills/wiki/SKILL.md"
+        },
+        {
+          "digest": "d0d46a07b7675ac854d993be56565bc96d0f3c8c0776ec38a58955df3003fe51",
+          "path": "skills/worker/SKILL.md"
+        }
+      ]
+    }
+  },
+  "version": 1
+}

--- a/src/capabilities/__tests__/lockfile.test.ts
+++ b/src/capabilities/__tests__/lockfile.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import {
+  DEFAULT_CAPABILITIES_LOCKFILE,
+  buildCapabilitiesLockfile,
+  checkCapabilitiesPreflight,
+  defaultCapabilitiesLockfilePath,
+  writeCapabilitiesLockfile,
+} from "../lockfile.js";
+
+async function withTempDir<T>(run: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "omx-capabilities-"));
+  try {
+    return await run(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("capabilities lockfile", () => {
+  it("uses a repo-visible default lock path", () => {
+    assert.equal(defaultCapabilitiesLockfilePath("/repo"), join("/repo", DEFAULT_CAPABILITIES_LOCKFILE));
+  });
+
+  it("checks a freshly written lockfile successfully", async () => {
+    await withTempDir(async (dir) => {
+      const path = defaultCapabilitiesLockfilePath(dir);
+      await writeCapabilitiesLockfile(path, await buildCapabilitiesLockfile({ cwd: dir }));
+
+      const result = await checkCapabilitiesPreflight({ cwd: dir });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.observations_checked, false);
+      assert.deepEqual(result.failures, []);
+    });
+  });
+
+  it("validates successful observations", async () => {
+    await withTempDir(async (dir) => {
+      const path = defaultCapabilitiesLockfilePath(dir);
+      await writeCapabilitiesLockfile(path, await buildCapabilitiesLockfile({ cwd: dir }));
+      await writeFile(
+        join(dir, "observations.json"),
+        JSON.stringify({
+          version: 1,
+          kind: "omx_capability_observations",
+          observations: [
+            { fixture_id: "project-memory-write-required-arg", tool_calls: [{ name: "project_memory_write", arguments: { memory: {} } }] },
+            { fixture_id: "project-memory-read-known-tool", tool_calls: [{ name: "project_memory_read", arguments: {} }] },
+            { fixture_id: "tool-restraint-no-call", tool_calls: [] },
+          ],
+        }),
+      );
+
+      const result = await checkCapabilitiesPreflight({ cwd: dir, observationsPath: "observations.json", requireObservations: true });
+
+      assert.equal(result.ok, true);
+      assert.equal(result.observations_checked, true);
+    });
+  });
+
+  it("fails observations missing a required argument", async () => {
+    await withTempDir(async (dir) => {
+      const path = defaultCapabilitiesLockfilePath(dir);
+      await writeCapabilitiesLockfile(path, await buildCapabilitiesLockfile({ cwd: dir }));
+      await writeFile(
+        join(dir, "observations.json"),
+        JSON.stringify({
+          version: 1,
+          kind: "omx_capability_observations",
+          observations: [
+            { fixture_id: "project-memory-write-required-arg", tool_calls: [{ name: "project_memory_write", arguments: {} }] },
+            { fixture_id: "project-memory-read-known-tool", tool_calls: [{ name: "project_memory_read", arguments: {} }] },
+            { fixture_id: "tool-restraint-no-call", tool_calls: [] },
+          ],
+        }),
+      );
+
+      const result = await checkCapabilitiesPreflight({ cwd: dir, observationsPath: "observations.json", requireObservations: true });
+
+      assert.equal(result.ok, false);
+      assert.ok(result.failures.some((failure) => failure.code === "missing_required_arg"));
+    });
+  });
+
+  it("fails hallucinated tool observations", async () => {
+    await withTempDir(async (dir) => {
+      const path = defaultCapabilitiesLockfilePath(dir);
+      await writeCapabilitiesLockfile(path, await buildCapabilitiesLockfile({ cwd: dir }));
+      await writeFile(
+        join(dir, "observations.json"),
+        JSON.stringify({
+          version: 1,
+          kind: "omx_capability_observations",
+          observations: [
+            { fixture_id: "project-memory-write-required-arg", tool_calls: [{ name: "project_memory_write", arguments: { memory: {} } }] },
+            { fixture_id: "project-memory-read-known-tool", tool_calls: [{ name: "imaginary_tool", arguments: {} }] },
+            { fixture_id: "tool-restraint-no-call", tool_calls: [] },
+          ],
+        }),
+      );
+
+      const result = await checkCapabilitiesPreflight({ cwd: dir, observationsPath: "observations.json", requireObservations: true });
+
+      assert.equal(result.ok, false);
+      assert.ok(result.failures.some((failure) => failure.code === "hallucinated_tool"));
+    });
+  });
+
+  it("fails tool-restraint observations that call a tool", async () => {
+    await withTempDir(async (dir) => {
+      const path = defaultCapabilitiesLockfilePath(dir);
+      await writeCapabilitiesLockfile(path, await buildCapabilitiesLockfile({ cwd: dir }));
+      await writeFile(
+        join(dir, "observations.json"),
+        JSON.stringify({
+          version: 1,
+          kind: "omx_capability_observations",
+          observations: [
+            { fixture_id: "project-memory-write-required-arg", tool_calls: [{ name: "project_memory_write", arguments: { memory: {} } }] },
+            { fixture_id: "project-memory-read-known-tool", tool_calls: [{ name: "project_memory_read", arguments: {} }] },
+            { fixture_id: "tool-restraint-no-call", tool_calls: [{ name: "project_memory_read", arguments: {} }] },
+          ],
+        }),
+      );
+
+      const result = await checkCapabilitiesPreflight({ cwd: dir, observationsPath: "observations.json", requireObservations: true });
+
+      assert.equal(result.ok, false);
+      assert.ok(result.failures.some((failure) => failure.code === "unexpected_tool_call"));
+    });
+  });
+
+  it("changes configured tool digest when lockfile tool schema drifts", async () => {
+    await withTempDir(async (dir) => {
+      const path = defaultCapabilitiesLockfilePath(dir);
+      const lock = await buildCapabilitiesLockfile({ cwd: dir });
+      lock.surfaces.configured_tools.digest = "drift";
+      await writeCapabilitiesLockfile(path, lock);
+
+      const result = await checkCapabilitiesPreflight({ cwd: dir });
+
+      assert.equal(result.ok, false);
+      assert.ok(result.failures.some((failure) => failure.code === "configured_tool_surface_mismatch"));
+      assert.match(await readFile(path, "utf8"), /omx_capabilities_lock/);
+    });
+  });
+});

--- a/src/capabilities/lockfile.ts
+++ b/src/capabilities/lockfile.ts
@@ -1,0 +1,454 @@
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
+import TOML from "@iarna/toml";
+
+export const CAPABILITIES_LOCKFILE_VERSION = 1;
+export const DEFAULT_CAPABILITIES_LOCKFILE = "omx-capabilities.lock.json";
+
+export type CapabilityFailureCode =
+  | "lockfile_missing"
+  | "lockfile_invalid_json"
+  | "lockfile_unsupported_version"
+  | "configured_tool_surface_mismatch"
+  | "skill_surface_mismatch"
+  | "agent_surface_mismatch"
+  | "fixture_contract_mismatch"
+  | "external_schema_unavailable"
+  | "observations_missing"
+  | "observations_invalid_json"
+  | "required_observation_missing"
+  | "unknown_fixture"
+  | "duplicate_observation"
+  | "hallucinated_tool"
+  | "unavailable_tool"
+  | "wrong_tool_selected"
+  | "missing_required_arg"
+  | "arg_schema_invalid"
+  | "unexpected_tool_call"
+  | "structured_output_invalid";
+
+export interface CapabilityFailure {
+  code: CapabilityFailureCode;
+  message: string;
+  path?: string;
+  fixture_id?: string;
+  tool?: string;
+}
+
+export interface CapabilityWarning {
+  code: "external_schema_unavailable";
+  message: string;
+  server?: string;
+}
+
+export interface ToolContract {
+  name: string;
+  description?: string;
+  inputSchema?: JsonObject;
+  server: string;
+  enabled: boolean;
+}
+
+export interface ExternalMcpServerContract {
+  name: string;
+  config_digest: string;
+  schema_status: "unavailable";
+}
+
+export interface CapabilitiesLockfile {
+  version: 1;
+  kind: "omx_capabilities_lock";
+  surfaces: {
+    configured_tools: {
+      digest: string;
+      tools: ToolContract[];
+      disabled_first_party_servers: string[];
+      external_servers: ExternalMcpServerContract[];
+    };
+    skills: { digest: string; files: DigestEntry[] };
+    agents: { digest: string; files: DigestEntry[] };
+    fixtures: { digest: string; fixtures: FixtureContract[] };
+  };
+}
+
+export interface DigestEntry {
+  path: string;
+  digest: string;
+}
+
+export interface FixtureContract {
+  id: string;
+  prompt_id: string;
+  required: boolean;
+  allowed_tools: string[];
+  expected_tool?: string;
+  no_tool_calls?: boolean;
+}
+
+export interface CapabilityObservation {
+  fixture_id: string;
+  prompt_id?: string;
+  tool_calls?: Array<{ name?: unknown; arguments?: unknown }>;
+  structured_output?: unknown;
+}
+
+export interface CapabilityObservationsFile {
+  version: 1;
+  kind: "omx_capability_observations";
+  observations: CapabilityObservation[];
+}
+
+export interface CapabilityCheckOptions {
+  cwd?: string;
+  codexHome?: string;
+  lockfilePath?: string;
+  observationsPath?: string;
+  requireObservations?: boolean;
+  strictExternalSchemas?: boolean;
+}
+
+export interface CapabilityCheckResult {
+  ok: boolean;
+  lockfile: string;
+  observations_checked: boolean;
+  digests: Record<string, string>;
+  failures: CapabilityFailure[];
+  warnings: CapabilityWarning[];
+}
+
+type JsonObject = Record<string, unknown>;
+
+const FIRST_PARTY_SERVERS = ["state", "memory", "code_intel", "trace", "wiki", "hermes"] as const;
+const FIRST_PARTY_DISABLE_ENV: Record<string, string> = {
+  state: "OMX_STATE_SERVER_DISABLE_AUTO_START",
+  memory: "OMX_MEMORY_SERVER_DISABLE_AUTO_START",
+  code_intel: "OMX_CODE_INTEL_SERVER_DISABLE_AUTO_START",
+  trace: "OMX_TRACE_SERVER_DISABLE_AUTO_START",
+  wiki: "OMX_WIKI_SERVER_DISABLE_AUTO_START",
+  hermes: "OMX_HERMES_SERVER_DISABLE_AUTO_START",
+};
+
+export function canonicalStringify(value: unknown): string {
+  return `${JSON.stringify(sortJson(value), null, 2)}\n`;
+}
+
+export function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value as JsonObject)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => [key, sortJson(child)]),
+  );
+}
+
+export function defaultCapabilitiesLockfilePath(cwd = process.cwd()): string {
+  return join(cwd, DEFAULT_CAPABILITIES_LOCKFILE);
+}
+
+export async function buildCapabilitiesLockfile(options: CapabilityCheckOptions = {}): Promise<CapabilitiesLockfile> {
+  const cwd = options.cwd ?? process.cwd();
+  const [toolSurface, skills, agents] = await Promise.all([
+    collectConfiguredToolSurface(cwd, options.codexHome),
+    collectDigestEntries(cwd, ["skills"], ["SKILL.md", "catalog.json", "metadata.json"]),
+    collectDigestEntries(cwd, ["prompts", join("templates", "model-instructions")], [".md", ".toml", ".json"]),
+  ]);
+  const fixtures = buildFixtureContracts(toolSurface.tools.filter((tool) => tool.enabled).map((tool) => tool.name));
+  return {
+    version: CAPABILITIES_LOCKFILE_VERSION,
+    kind: "omx_capabilities_lock",
+    surfaces: {
+      configured_tools: toolSurface,
+      skills: { digest: digestEntries(skills), files: skills },
+      agents: { digest: digestEntries(agents), files: agents },
+      fixtures: { digest: sha256(canonicalStringify(fixtures)), fixtures },
+    },
+  };
+}
+
+export async function writeCapabilitiesLockfile(path: string, lockfile: CapabilitiesLockfile): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, canonicalStringify(lockfile), "utf8");
+}
+
+export async function checkCapabilitiesPreflight(options: CapabilityCheckOptions = {}): Promise<CapabilityCheckResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const lockfile = options.lockfilePath ? resolve(cwd, options.lockfilePath) : defaultCapabilitiesLockfilePath(cwd);
+  const failures: CapabilityFailure[] = [];
+  const warnings: CapabilityWarning[] = [];
+  let expected: CapabilitiesLockfile;
+  try {
+    expected = JSON.parse(await readFile(lockfile, "utf8")) as CapabilitiesLockfile;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code === "ENOENT" ? "lockfile_missing" : "lockfile_invalid_json";
+    return emptyResult(lockfile, code, code === "lockfile_missing" ? "Capabilities lockfile is missing." : "Capabilities lockfile is invalid JSON.");
+  }
+  if (expected.version !== CAPABILITIES_LOCKFILE_VERSION || expected.kind !== "omx_capabilities_lock") {
+    return emptyResult(lockfile, "lockfile_unsupported_version", "Capabilities lockfile version is unsupported.");
+  }
+
+  const current = await buildCapabilitiesLockfile({ cwd, codexHome: options.codexHome });
+  compareDigest(failures, "configured_tool_surface_mismatch", "Configured tool surface changed.", expected.surfaces.configured_tools.digest, current.surfaces.configured_tools.digest);
+  compareDigest(failures, "skill_surface_mismatch", "Skill surface changed.", expected.surfaces.skills.digest, current.surfaces.skills.digest);
+  compareDigest(failures, "agent_surface_mismatch", "Agent surface changed.", expected.surfaces.agents.digest, current.surfaces.agents.digest);
+  compareDigest(failures, "fixture_contract_mismatch", "Fixture contracts changed.", expected.surfaces.fixtures.digest, current.surfaces.fixtures.digest);
+
+  for (const server of current.surfaces.configured_tools.external_servers) {
+    const warning = { code: "external_schema_unavailable" as const, server: server.name, message: `External MCP server '${server.name}' has no schema snapshot.` };
+    if (options.strictExternalSchemas) failures.push({ ...warning, code: "external_schema_unavailable" });
+    else warnings.push(warning);
+  }
+
+  const observationsChecked = Boolean(options.observationsPath);
+  if (options.requireObservations && !options.observationsPath) {
+    failures.push({ code: "observations_missing", message: "Capability observations are required." });
+  }
+  if (options.observationsPath) {
+    await validateObservations(resolve(cwd, options.observationsPath), expected, failures);
+  }
+
+  return {
+    ok: failures.length === 0,
+    lockfile,
+    observations_checked: observationsChecked,
+    digests: {
+      configured_tools: current.surfaces.configured_tools.digest,
+      skills: current.surfaces.skills.digest,
+      agents: current.surfaces.agents.digest,
+      fixtures: current.surfaces.fixtures.digest,
+    },
+    failures,
+    warnings,
+  };
+}
+
+function emptyResult(lockfile: string, code: CapabilityFailureCode, message: string): CapabilityCheckResult {
+  return { ok: false, lockfile, observations_checked: false, digests: {}, failures: [{ code, message }], warnings: [] };
+}
+
+function compareDigest(failures: CapabilityFailure[], code: CapabilityFailureCode, message: string, expected: string, actual: string): void {
+  if (expected !== actual) failures.push({ code, message });
+}
+
+async function collectConfiguredToolSurface(cwd: string, codexHome?: string): Promise<CapabilitiesLockfile["surfaces"]["configured_tools"]> {
+  const priorEnv = new Map<string, string | undefined>();
+  const disabledFirstPartyServers = FIRST_PARTY_SERVERS.filter((server) => process.env[FIRST_PARTY_DISABLE_ENV[server]] === "1");
+  for (const envName of Object.values(FIRST_PARTY_DISABLE_ENV)) {
+    priorEnv.set(envName, process.env[envName]);
+    process.env[envName] = "1";
+  }
+  try {
+    const [state, memory, codeIntel, trace, wiki, hermes] = await Promise.all([
+      import("../mcp/state-server.js"),
+      import("../mcp/memory-server.js"),
+      import("../mcp/code-intel-server.js"),
+      import("../mcp/trace-server.js"),
+      import("../mcp/wiki-server.js"),
+      import("../mcp/hermes-server.js"),
+    ]);
+    const builders: Record<string, () => Array<{ name: string; description?: string; inputSchema?: JsonObject }>> = {
+      state: () => state.buildStateServerTools(),
+      memory: () => memory.buildMemoryServerTools(),
+      code_intel: () => codeIntel.buildCodeIntelServerTools(),
+      trace: () => trace.buildTraceServerTools(),
+      wiki: () => wiki.buildWikiServerTools(),
+      hermes: () => hermes.buildHermesServerTools(),
+    };
+    const disabled = disabledFirstPartyServers;
+    const tools = Object.entries(builders).flatMap(([server, build]) =>
+      build().map((tool) => ({ ...normalizeTool(tool), server, enabled: !disabled.includes(server as (typeof FIRST_PARTY_SERVERS)[number]) })),
+    ).sort((a, b) => `${a.server}:${a.name}`.localeCompare(`${b.server}:${b.name}`));
+    const externalServers = await collectExternalMcpServers(cwd, codexHome);
+    const digestInput = { tools, disabled_first_party_servers: disabled, external_servers: externalServers };
+    return { ...digestInput, digest: sha256(canonicalStringify(digestInput)) };
+  } finally {
+    for (const [envName, value] of priorEnv) {
+      if (value === undefined) delete process.env[envName];
+      else process.env[envName] = value;
+    }
+  }
+}
+
+function normalizeTool(tool: { name: string; description?: string; inputSchema?: JsonObject }): ToolContract {
+  return { name: tool.name, description: tool.description, inputSchema: tool.inputSchema, server: "", enabled: true };
+}
+
+async function collectExternalMcpServers(cwd: string, codexHome?: string): Promise<ExternalMcpServerContract[]> {
+  const configPaths = [join(cwd, ".codex", "config.toml")];
+  if (codexHome) configPaths.push(join(codexHome, "config.toml"));
+  const servers = new Map<string, ExternalMcpServerContract>();
+  for (const configPath of configPaths) {
+    if (!existsSync(configPath)) continue;
+    try {
+      const parsed = TOML.parse(await readFile(configPath, "utf8")) as JsonObject;
+      const rawServers = parsed.mcp_servers;
+      if (!rawServers || typeof rawServers !== "object") continue;
+      for (const [name, config] of Object.entries(rawServers as JsonObject)) {
+        if (String(name).startsWith("omx-")) continue;
+        servers.set(name, { name, config_digest: sha256(canonicalStringify(config)), schema_status: "unavailable" });
+      }
+    } catch {
+      continue;
+    }
+  }
+  return [...servers.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function collectDigestEntries(cwd: string, roots: string[], suffixes: string[]): Promise<DigestEntry[]> {
+  const entries: DigestEntry[] = [];
+  for (const root of roots) {
+    await walkDigest(join(cwd, root), cwd, suffixes, entries);
+  }
+  return entries.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+async function walkDigest(dir: string, cwd: string, suffixes: string[], entries: DigestEntry[]): Promise<void> {
+  let children: import("node:fs").Dirent[];
+  try {
+    children = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const child of children) {
+    const path = join(dir, child.name);
+    if (child.isDirectory()) {
+      await walkDigest(path, cwd, suffixes, entries);
+    } else if (suffixes.some((suffix) => child.name === suffix || child.name.endsWith(suffix))) {
+      entries.push({ path: relative(cwd, path).replaceAll("\\", "/"), digest: sha256(await readFile(path, "utf8")) });
+    }
+  }
+}
+
+function digestEntries(entries: DigestEntry[]): string {
+  return sha256(canonicalStringify(entries));
+}
+
+function buildFixtureContracts(allowedTools: string[]): FixtureContract[] {
+  const sortedAllowed = [...allowedTools].sort();
+  const choose = (preferred: string, fallback: string) => sortedAllowed.includes(preferred) ? preferred : fallback;
+  const writeTool = choose("project_memory_write", sortedAllowed[0] ?? "project_memory_write");
+  const readTool = choose("project_memory_read", sortedAllowed[0] ?? "project_memory_read");
+  return [
+    { id: "project-memory-write-required-arg", prompt_id: "missing-required-arg", required: true, allowed_tools: sortedAllowed, expected_tool: writeTool },
+    { id: "project-memory-read-known-tool", prompt_id: "known-tool-success", required: true, allowed_tools: sortedAllowed, expected_tool: readTool },
+    { id: "tool-restraint-no-call", prompt_id: "tool-restraint", required: true, allowed_tools: [], no_tool_calls: true },
+  ];
+}
+
+async function validateObservations(path: string, lockfile: CapabilitiesLockfile, failures: CapabilityFailure[]): Promise<void> {
+  let parsed: CapabilityObservationsFile;
+  try {
+    parsed = JSON.parse(await readFile(path, "utf8")) as CapabilityObservationsFile;
+  } catch {
+    failures.push({ code: "observations_invalid_json", message: "Capability observations are invalid JSON.", path });
+    return;
+  }
+  if (parsed.version !== 1 || parsed.kind !== "omx_capability_observations" || !Array.isArray(parsed.observations)) {
+    failures.push({ code: "observations_invalid_json", message: "Capability observations have an unsupported shape.", path });
+    return;
+  }
+  const fixtures = new Map(lockfile.surfaces.fixtures.fixtures.map((fixture) => [fixture.id, fixture]));
+  const seen = new Set<string>();
+  const availableTools = new Map(lockfile.surfaces.configured_tools.tools.filter((tool) => tool.enabled).map((tool) => [tool.name, tool]));
+  for (const observation of parsed.observations) {
+    const fixture = fixtures.get(observation.fixture_id);
+    if (!fixture) {
+      failures.push({ code: "unknown_fixture", message: `Unknown fixture '${observation.fixture_id}'.`, fixture_id: observation.fixture_id });
+      continue;
+    }
+    if (seen.has(observation.fixture_id)) {
+      failures.push({ code: "duplicate_observation", message: `Duplicate observation for fixture '${observation.fixture_id}'.`, fixture_id: observation.fixture_id });
+      continue;
+    }
+    seen.add(observation.fixture_id);
+    validateObservation(fixture, observation, availableTools, failures);
+  }
+  for (const fixture of fixtures.values()) {
+    if (fixture.required && !seen.has(fixture.id)) {
+      failures.push({ code: "required_observation_missing", message: `Required observation '${fixture.id}' is missing.`, fixture_id: fixture.id });
+    }
+  }
+}
+
+function validateObservation(fixture: FixtureContract, observation: CapabilityObservation, availableTools: Map<string, ToolContract>, failures: CapabilityFailure[]): void {
+  const calls = Array.isArray(observation.tool_calls) ? observation.tool_calls : [];
+  if (fixture.no_tool_calls && calls.length > 0) {
+    failures.push({ code: "unexpected_tool_call", message: `Fixture '${fixture.id}' requires tool restraint.`, fixture_id: fixture.id });
+  }
+  for (const call of calls) {
+    if (typeof call.name !== "string") {
+      failures.push({ code: "arg_schema_invalid", message: "Tool call name must be a string.", fixture_id: fixture.id });
+      continue;
+    }
+    const tool = availableTools.get(call.name);
+    if (!tool) {
+      failures.push({ code: "hallucinated_tool", message: `Tool '${call.name}' is not in the configured surface.`, fixture_id: fixture.id, tool: call.name });
+      continue;
+    }
+    if (!fixture.allowed_tools.includes(call.name)) {
+      failures.push({ code: "unavailable_tool", message: `Tool '${call.name}' is not allowed for fixture '${fixture.id}'.`, fixture_id: fixture.id, tool: call.name });
+    }
+    if (fixture.expected_tool && call.name !== fixture.expected_tool) {
+      failures.push({ code: "wrong_tool_selected", message: `Expected '${fixture.expected_tool}' but observed '${call.name}'.`, fixture_id: fixture.id, tool: call.name });
+    }
+    validateRequiredArgs(tool, call.arguments, fixture.id, failures);
+  }
+}
+
+function validateRequiredArgs(tool: ToolContract, args: unknown, fixtureId: string, failures: CapabilityFailure[]): void {
+  const schema = tool.inputSchema;
+  if (!schema) return;
+  const required = Array.isArray(schema.required) ? schema.required.filter((value): value is string => typeof value === "string") : [];
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    if (required.length > 0) {
+      failures.push({ code: "missing_required_arg", message: `Tool '${tool.name}' is missing required arguments: ${required.join(", ")}.`, fixture_id: fixtureId, tool: tool.name });
+    } else if (schema.type === "object") {
+      failures.push({ code: "arg_schema_invalid", message: `Tool '${tool.name}' arguments must be an object.`, fixture_id: fixtureId, tool: tool.name });
+    }
+    return;
+  }
+  for (const name of required) {
+    if (!Object.prototype.hasOwnProperty.call(args, name)) {
+      failures.push({ code: "missing_required_arg", message: `Tool '${tool.name}' is missing required argument '${name}'.`, fixture_id: fixtureId, tool: tool.name });
+    }
+  }
+  validatePropertyTypes(tool, args as JsonObject, schema, fixtureId, failures);
+}
+
+function validatePropertyTypes(tool: ToolContract, args: JsonObject, schema: JsonObject, fixtureId: string, failures: CapabilityFailure[]): void {
+  if (!schema.properties || typeof schema.properties !== "object" || Array.isArray(schema.properties)) return;
+  for (const [name, rawProperty] of Object.entries(schema.properties as JsonObject)) {
+    if (!Object.prototype.hasOwnProperty.call(args, name)) continue;
+    if (!rawProperty || typeof rawProperty !== "object" || Array.isArray(rawProperty)) continue;
+    const expectedType = (rawProperty as JsonObject).type;
+    if (typeof expectedType !== "string" || isJsonSchemaType(args[name], expectedType)) continue;
+    failures.push({ code: "arg_schema_invalid", message: `Tool '${tool.name}' argument '${name}' must be ${expectedType}.`, fixture_id: fixtureId, tool: tool.name });
+  }
+}
+
+function isJsonSchemaType(value: unknown, expectedType: string): boolean {
+  switch (expectedType) {
+    case "array":
+      return Array.isArray(value);
+    case "object":
+      return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+    case "integer":
+      return Number.isInteger(value);
+    case "number":
+      return typeof value === "number";
+    case "string":
+      return typeof value === "string";
+    case "boolean":
+      return typeof value === "boolean";
+    case "null":
+      return value === null;
+    default:
+      return true;
+  }
+}

--- a/src/cli/__tests__/capabilities.test.ts
+++ b/src/cli/__tests__/capabilities.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+const testDir = join(fileURLToPath(import.meta.url), "..");
+const repoRoot = join(testDir, "..", "..", "..");
+const omxBin = join(repoRoot, "dist", "cli", "omx.js");
+
+async function withTempDir<T>(run: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "omx-capabilities-cli-"));
+  try {
+    return await run(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function runOmx(cwd: string, args: string[]) {
+  return spawnSync(process.execPath, [omxBin, ...args], { cwd, encoding: "utf8" });
+}
+
+async function writeObservations(dir: string, observations: unknown[]): Promise<string> {
+  const path = join(dir, "observations.json");
+  await writeFile(path, JSON.stringify({ version: 1, kind: "omx_capability_observations", observations }, null, 2), "utf8");
+  return path;
+}
+
+const SUCCESS_OBSERVATIONS = [
+  {
+    fixture_id: "project-memory-write-required-arg",
+    tool_calls: [{ name: "project_memory_write", arguments: { memory: { note: "capability preflight fixture" } } }],
+  },
+  {
+    fixture_id: "project-memory-read-known-tool",
+    tool_calls: [{ name: "project_memory_read", arguments: {} }],
+  },
+  {
+    fixture_id: "tool-restraint-no-call",
+    tool_calls: [],
+  },
+];
+
+function hasFailure(stdout: string, code: string): boolean {
+  const parsed = JSON.parse(stdout) as { failures?: Array<{ code?: string }> };
+  return parsed.failures?.some((failure) => failure.code === code) ?? false;
+}
+
+describe("omx capabilities cli", () => {
+  it("routes local help", async () => {
+    await withTempDir(async (dir) => {
+      const result = runOmx(dir, ["capabilities", "--help"]);
+
+      assert.equal(result.status, 0);
+      assert.match(result.stdout, /omx capabilities lock/);
+      assert.doesNotMatch(result.stdout, /Launch Codex CLI/);
+    });
+  });
+
+  it("locks and checks with JSON output", async () => {
+    await withTempDir(async (dir) => {
+      const lock = runOmx(dir, ["capabilities", "lock", "--json"]);
+      assert.equal(lock.status, 0, lock.stderr);
+      const lockJson = JSON.parse(lock.stdout);
+      assert.equal(lockJson.ok, true);
+      assert.match(lockJson.lockfile, /omx-capabilities\.lock\.json$/);
+
+      const check = runOmx(dir, ["capabilities", "check", "--json"]);
+      assert.equal(check.status, 0, check.stderr);
+      const checkJson = JSON.parse(check.stdout);
+      assert.equal(checkJson.ok, true);
+      assert.equal(checkJson.observations_checked, false);
+    });
+  });
+
+  it("checks successful fixture observations", async () => {
+    await withTempDir(async (dir) => {
+      const lock = runOmx(dir, ["capabilities", "lock", "--json"]);
+      assert.equal(lock.status, 0, lock.stderr);
+      const observations = await writeObservations(dir, SUCCESS_OBSERVATIONS);
+
+      const check = runOmx(dir, ["capabilities", "check", "--observations", observations, "--require-observations", "--json"]);
+
+      assert.equal(check.status, 0, check.stderr);
+      const checkJson = JSON.parse(check.stdout);
+      assert.equal(checkJson.ok, true);
+      assert.equal(checkJson.observations_checked, true);
+    });
+  });
+
+  it("exits non-zero for required missing observations", async () => {
+    await withTempDir(async (dir) => {
+      const lock = runOmx(dir, ["capabilities", "lock", "--json"]);
+      assert.equal(lock.status, 0, lock.stderr);
+
+      const check = runOmx(dir, ["capabilities", "check", "--require-observations", "--json"]);
+
+      assert.notEqual(check.status, 0);
+      const checkJson = JSON.parse(check.stdout);
+      assert.equal(checkJson.ok, false);
+      assert.ok(checkJson.failures.some((failure: { code: string }) => failure.code === "observations_missing"));
+    });
+  });
+
+  it("reports missing required tool arguments", async () => {
+    await withTempDir(async (dir) => {
+      const lock = runOmx(dir, ["capabilities", "lock", "--json"]);
+      assert.equal(lock.status, 0, lock.stderr);
+      const observations = await writeObservations(dir, [
+        { fixture_id: "project-memory-write-required-arg", tool_calls: [{ name: "project_memory_write", arguments: {} }] },
+        SUCCESS_OBSERVATIONS[1],
+        SUCCESS_OBSERVATIONS[2],
+      ]);
+
+      const check = runOmx(dir, ["capabilities", "check", "--observations", observations, "--json"]);
+
+      assert.notEqual(check.status, 0);
+      assert.equal(hasFailure(check.stdout, "missing_required_arg"), true);
+    });
+  });
+
+  it("reports hallucinated tools", async () => {
+    await withTempDir(async (dir) => {
+      const lock = runOmx(dir, ["capabilities", "lock", "--json"]);
+      assert.equal(lock.status, 0, lock.stderr);
+      const observations = await writeObservations(dir, [
+        SUCCESS_OBSERVATIONS[0],
+        { fixture_id: "project-memory-read-known-tool", tool_calls: [{ name: "imaginary_tool", arguments: {} }] },
+        SUCCESS_OBSERVATIONS[2],
+      ]);
+
+      const check = runOmx(dir, ["capabilities", "check", "--observations", observations, "--json"]);
+
+      assert.notEqual(check.status, 0);
+      assert.equal(hasFailure(check.stdout, "hallucinated_tool"), true);
+    });
+  });
+
+  it("reports tool-restraint violations", async () => {
+    await withTempDir(async (dir) => {
+      const lock = runOmx(dir, ["capabilities", "lock", "--json"]);
+      assert.equal(lock.status, 0, lock.stderr);
+      const observations = await writeObservations(dir, [
+        SUCCESS_OBSERVATIONS[0],
+        SUCCESS_OBSERVATIONS[1],
+        { fixture_id: "tool-restraint-no-call", tool_calls: [{ name: "project_memory_read", arguments: {} }] },
+      ]);
+
+      const check = runOmx(dir, ["capabilities", "check", "--observations", observations, "--json"]);
+
+      assert.notEqual(check.status, 0);
+      assert.equal(hasFailure(check.stdout, "unexpected_tool_call"), true);
+    });
+  });
+});

--- a/src/cli/capabilities.ts
+++ b/src/cli/capabilities.ts
@@ -1,0 +1,133 @@
+import { resolve } from "node:path";
+import {
+  DEFAULT_CAPABILITIES_LOCKFILE,
+  buildCapabilitiesLockfile,
+  checkCapabilitiesPreflight,
+  defaultCapabilitiesLockfilePath,
+  writeCapabilitiesLockfile,
+  type CapabilityCheckResult,
+} from "../capabilities/lockfile.js";
+
+export const CAPABILITIES_HELP = `omx capabilities - deterministic capability lockfile and observation checks
+
+Usage:
+  omx capabilities lock [--lockfile <path>] [--json]
+  omx capabilities check [--lockfile <path>] [--observations <path>] [--require-observations] [--strict-external-schemas] [--json]
+
+Defaults:
+  lockfile: ${DEFAULT_CAPABILITIES_LOCKFILE}
+`;
+
+interface ParsedCapabilitiesArgs {
+  subcommand?: string;
+  lockfile?: string;
+  observations?: string;
+  requireObservations: boolean;
+  strictExternalSchemas: boolean;
+  json: boolean;
+  help: boolean;
+}
+
+export async function capabilitiesCommand(args: string[], cwd = process.cwd()): Promise<void> {
+  const parsed = parseCapabilitiesArgs(args);
+  if (parsed.help || !parsed.subcommand) {
+    console.log(CAPABILITIES_HELP);
+    return;
+  }
+  const lockfile = parsed.lockfile ? resolve(cwd, parsed.lockfile) : defaultCapabilitiesLockfilePath(cwd);
+  switch (parsed.subcommand) {
+    case "lock": {
+      const built = await buildCapabilitiesLockfile({ cwd });
+      await writeCapabilitiesLockfile(lockfile, built);
+      const result = {
+        ok: true,
+        lockfile,
+        digests: {
+          configured_tools: built.surfaces.configured_tools.digest,
+          skills: built.surfaces.skills.digest,
+          agents: built.surfaces.agents.digest,
+          fixtures: built.surfaces.fixtures.digest,
+        },
+        warnings: built.surfaces.configured_tools.external_servers.map((server) => ({
+          code: "external_schema_unavailable",
+          server: server.name,
+          message: `External MCP server '${server.name}' has no schema snapshot.`,
+        })),
+      };
+      printResult(result, parsed.json);
+      return;
+    }
+    case "check": {
+      const result = await checkCapabilitiesPreflight({
+        cwd,
+        lockfilePath: lockfile,
+        observationsPath: parsed.observations,
+        requireObservations: parsed.requireObservations,
+        strictExternalSchemas: parsed.strictExternalSchemas,
+      });
+      printResult(result, parsed.json);
+      if (!result.ok) process.exitCode = 1;
+      return;
+    }
+    default:
+      throw new Error(`Unknown capabilities subcommand: ${parsed.subcommand}`);
+  }
+}
+
+function parseCapabilitiesArgs(args: string[]): ParsedCapabilitiesArgs {
+  const parsed: ParsedCapabilitiesArgs = {
+    subcommand: args[0],
+    requireObservations: false,
+    strictExternalSchemas: false,
+    json: false,
+    help: false,
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      case "--json":
+        parsed.json = true;
+        break;
+      case "--require-observations":
+        parsed.requireObservations = true;
+        break;
+      case "--strict-external-schemas":
+        parsed.strictExternalSchemas = true;
+        break;
+      case "--lockfile":
+        parsed.lockfile = requireValue(args, index, arg);
+        index += 1;
+        break;
+      case "--observations":
+        parsed.observations = requireValue(args, index, arg);
+        index += 1;
+        break;
+      default:
+        if (arg.startsWith("--")) throw new Error(`Unknown capabilities option: ${arg}`);
+        break;
+    }
+  }
+  return parsed;
+}
+
+function requireValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+function printResult(result: unknown, json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  const check = result as Partial<CapabilityCheckResult> & { lockfile?: string };
+  console.log(`${check.ok ? "OK" : "FAIL"}: capabilities ${check.ok ? "satisfied" : "check failed"}`);
+  if (check.lockfile) console.log(`lockfile: ${check.lockfile}`);
+  for (const warning of check.warnings ?? []) console.warn(`warning ${warning.code}: ${warning.message}`);
+  for (const failure of check.failures ?? []) console.error(`${failure.code}: ${failure.message}`);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -192,6 +192,7 @@ import {
 } from "../notifications/temp-contract.js";
 import { execInjectCommand } from "../exec/followup.js";
 import { imagegenCommand } from "../imagegen/continuation.js";
+import { capabilitiesCommand } from "./capabilities.js";
 
 export function resolveNotifyFallbackWatcherScript(pkgRoot = getPackageRoot()): string {
   return resolveDistScript(pkgRoot, "notify-fallback-watcher.js");
@@ -242,6 +243,8 @@ Usage:
   omx api       Run native omx-api localhost gateway commands (serve|status|stop|generate)
   omx session   Search and summarize local session history (--codex-home <path> escape hatch)
   omx url       Passive URL reader (read <url> --json)
+  omx capabilities
+                Lock/check deterministic configured tool, skill, agent, and observation surfaces
   omx agents-init [path]
                 Bootstrap lightweight AGENTS.md files for a repo/subtree
   omx agents    Manage Codex native agent TOML files
@@ -384,6 +387,7 @@ type CliCommand =
   | "launch"
   | "exec"
   | "mission"
+  | "capabilities"
   | "imagegen"
   | "setup"
   | "update"
@@ -437,6 +441,7 @@ const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "agents-init",
   "deepinit",
   "exec",
+  "capabilities",
   "mission",
   "imagegen",
   "hooks",
@@ -2586,6 +2591,7 @@ export async function main(args: string[]): Promise<void> {
     "exec",
     "mission",
     "imagegen",
+    "capabilities",
     "setup",
     "update",
     "list",
@@ -2719,6 +2725,9 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "api":
         await apiCommand(args.slice(1));
+        break;
+      case "capabilities":
+        await capabilitiesCommand(args.slice(1));
         break;
       case "exec":
         if (launchArgs[0] === "inject") {


### PR DESCRIPTION
Closes #3084.

## Summary
- add `omx capabilities lock` and `omx capabilities check` commands
- write a deterministic `omx-capabilities.lock.json` from configured first-party tool schemas plus skill/agent fixture surfaces
- validate observation fixtures deterministically for success, required args, hallucinated tools, schema shape, and tool restraint without an LLM judge

## Validation
- `npm run build`
- `node dist/scripts/run-test-files.js dist/capabilities/__tests__/lockfile.test.js dist/cli/__tests__/capabilities.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `node dist/cli/omx.js capabilities check --json`

## Scope cuts
- v1 captures external MCP server config digests and warns/fails under strict mode when live schemas are unavailable; it does not snapshot arbitrary external tool schemas yet.
- v1 exposes the preflight gate as CLI/CI plumbing; mission/autopilot automatic blocking can wire to this command separately.
- v1 fixture observations are deterministic JSON inputs; it does not drive live model calls or use judge scoring.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*