### PR TITLE
Fix resume plugin preflight opt-in

### DIFF
--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -801,4 +801,46 @@ if [ -d "$selected_codex_home/plugins/cache/oh-my-codex-local/oh-my-codex/${stal
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('does not bootstrap plugin mode during clean legacy resume', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-clean-legacy-'));
+    try {
+      const home = join(wd, 'home');
+      const codexHome = join(home, '.codex');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(fakeCodexPath, `#!/bin/sh
+set -eu
+selected_codex_home="\${CODEX_HOME:-$HOME/.codex}"
+printf 'fake-codex:%s\n' "$*"
+if [ -f "$selected_codex_home/config.toml" ]; then echo config-created=yes; else echo config-created=no; fi
+if [ -d "$selected_codex_home/plugins/cache/oh-my-codex-local/oh-my-codex" ]; then echo plugin-cache-created=yes; else echo plugin-cache-created=no; fi
+`);
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+
+      const result = runOmx(wd, ['resume', 'legacy-session'], {
+        HOME: home,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+        OMX_LAUNCH_POLICY: 'direct',
+      });
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, /fake-codex:resume legacy-session\b/);
+      assert.match(result.stdout, /config-created=no/);
+      assert.match(result.stdout, /plugin-cache-created=no/);
+      await assert.rejects(readFile(join(codexHome, 'config.toml'), 'utf-8'), /ENOENT/);
+      await assert.rejects(readFile(join(codexHome, 'plugins', 'cache', 'oh-my-codex-local', 'oh-my-codex'), 'utf-8'), /ENOENT/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -80,6 +80,8 @@ import {
 } from "./codex-home.js";
 import { discoverProjectRuntimeCodexHomes } from "./project-runtime-codex-homes.js";
 import {
+  discoverOmxPluginCacheDirs,
+  hasLocalOmxPluginEnablement,
   materializePackagedOmxPluginCache,
   packagedOmxPluginVersion,
   resolvePackagedOmxMarketplace,
@@ -1169,21 +1171,46 @@ export function parseResumeCodexHomeSelection(args: string[]): ResumeCodexHomeSe
 }
 
 export interface ResumePluginPreflightResult {
-  status: "unavailable" | "prepared";
+  status: "unavailable" | "skipped" | "prepared";
   version?: string;
   cacheDir?: string;
   prunedStaleDirs: string[];
   configUpdated: boolean;
 }
 
+export interface ResumePluginPreflightOptions {
+  projectRoot?: string;
+}
+
+async function shouldPreflightResumeOmxPluginState(
+  selectedCodexHomeDir: string,
+  existingConfig: string,
+  options: ResumePluginPreflightOptions,
+): Promise<boolean> {
+  if (hasLocalOmxPluginEnablement(existingConfig)) return true;
+  if (
+    options.projectRoot &&
+    readPersistedSetupPreferences(options.projectRoot)?.installMode === "plugin"
+  ) {
+    return true;
+  }
+  return (await discoverOmxPluginCacheDirs(selectedCodexHomeDir)).length > 0;
+}
 
 export async function preflightResumeOmxPluginState(
   codexHomeDir: string | undefined,
   pkgRoot = getPackageRoot(),
+  options: ResumePluginPreflightOptions = {},
 ): Promise<ResumePluginPreflightResult> {
   const selectedCodexHomeDir = codexHomeDir && codexHomeDir.trim() !== ""
     ? codexHomeDir
     : join(homedir(), ".codex");
+  const configPath = join(selectedCodexHomeDir, "config.toml");
+  const existingConfig = existsSync(configPath) ? await readFile(configPath, "utf-8") : "";
+  if (!(await shouldPreflightResumeOmxPluginState(selectedCodexHomeDir, existingConfig, options))) {
+    return { status: "skipped", prunedStaleDirs: [], configUpdated: false };
+  }
+
   const packagedMarketplace = await resolvePackagedOmxMarketplace(pkgRoot);
   if (!packagedMarketplace) {
     return { status: "unavailable", prunedStaleDirs: [], configUpdated: false };
@@ -1194,8 +1221,6 @@ export async function preflightResumeOmxPluginState(
   const currentCacheDir = materialized.cacheDir ?? (version ? join(selectedCodexHomeDir, "plugins", "cache", "oh-my-codex-local", "oh-my-codex", version) : undefined);
   const prunedStaleDirs: string[] = [];
 
-  const configPath = join(selectedCodexHomeDir, "config.toml");
-  const existingConfig = existsSync(configPath) ? await readFile(configPath, "utf-8") : "";
   const nextConfig = upsertLocalOmxMarketplaceRegistration(
     upsertLocalOmxPluginEnablement(existingConfig),
     pkgRoot,
@@ -1228,7 +1253,7 @@ async function prepareResumeCodexHomeForLaunch(
   const selection = parseResumeCodexHomeSelection(args);
   if (selection.explicitCodexHome) {
     const codexHomeOverride = resolve(selection.explicitCodexHome);
-    await preflightResumeOmxPluginState(codexHomeOverride);
+    await preflightResumeOmxPluginState(codexHomeOverride, getPackageRoot(), { projectRoot: cwd });
     return {
       args: selection.args,
       prepared: {
@@ -1243,7 +1268,7 @@ async function prepareResumeCodexHomeForLaunch(
       const emptyRuntimeCodexHome = runtimeCodexHomePath(cwd, sessionId);
       await rm(emptyRuntimeCodexHome, { recursive: true, force: true });
       await mkdir(join(emptyRuntimeCodexHome, "sessions"), { recursive: true });
-      await preflightResumeOmxPluginState(emptyRuntimeCodexHome);
+      await preflightResumeOmxPluginState(emptyRuntimeCodexHome, getPackageRoot(), { projectRoot: cwd });
       return {
         args: selection.args,
         prepared: {
@@ -1256,7 +1281,7 @@ async function prepareResumeCodexHomeForLaunch(
       includeHistoryArtifacts: true,
       extraHistoryCodexHomes: projectHomes.slice(1).map((home) => home.path),
     });
-    await preflightResumeOmxPluginState(runtimeCodexHome);
+    await preflightResumeOmxPluginState(runtimeCodexHome, getPackageRoot(), { projectRoot: cwd });
     return {
       args: selection.args,
       prepared: {
@@ -1269,7 +1294,7 @@ async function prepareResumeCodexHomeForLaunch(
     includeHistoryArtifacts: true,
     extraHistoryCodexHomes: projectHomes.map((home) => home.path),
   });
-  await preflightResumeOmxPluginState(prepared.codexHomeOverride);
+  await preflightResumeOmxPluginState(prepared.codexHomeOverride, getPackageRoot(), { projectRoot: cwd });
   return { args: selection.args, prepared };
 }
 

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -484,6 +484,44 @@ function localPluginScalarLinePattern(): RegExp {
 	);
 }
 
+function localPluginScalarBooleanPattern(): RegExp {
+	return new RegExp(
+		`^\\s*${JSON.stringify(OMX_LOCAL_PLUGIN_CONFIG_KEY).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*=\\s*(true|false)\\s*(?:#.*)?$`,
+	);
+}
+
+function tomlBooleanLiteralIsTrue(value: string): boolean {
+	return /^\s*true\s*(?:#.*)?$/.test(value);
+}
+
+export function hasLocalOmxPluginEnablement(config: string): boolean {
+	const modernHeaderPattern = localPluginTableHeaderPattern();
+	const legacyScalarPattern = localPluginScalarBooleanPattern();
+	const lines = config.split(/\r?\n/);
+	let inLocalPluginTable = false;
+	let inPluginsTable = false;
+
+	for (const line of lines) {
+		if (isTomlTableHeader(line)) {
+			inLocalPluginTable = modernHeaderPattern.test(line);
+			inPluginsTable = /^\s*\[plugins\]\s*$/.test(line);
+			continue;
+		}
+
+		if (inLocalPluginTable) {
+			const enabled = /^\s*enabled\s*=\s*(.*)$/.exec(line);
+			if (enabled && tomlBooleanLiteralIsTrue(enabled[1])) return true;
+		}
+
+		if (inPluginsTable) {
+			const legacy = legacyScalarPattern.exec(line);
+			if (legacy?.[1] === "true") return true;
+		}
+	}
+
+	return false;
+}
+
 function removeLocalOmxPluginLegacyScalar(config: string): string {
 	const scalarPattern = localPluginScalarLinePattern();
 	const lines = config.split(/\r?\n/);


### PR DESCRIPTION
## Summary
- Make `omx resume` plugin cache preflight opt-in instead of bootstrapping plugin mode in a clean legacy environment.
- Keep the existing repair path for already-enabled plugin installs, existing OMX plugin cache directories, and persisted `installMode: \"plugin\"` setup preferences.
- Add a regression test proving clean legacy resume does not create `config.toml` or `plugins/cache/oh-my-codex-local`.

## Wrong Case Details
Before this change, a plain `omx resume` on a clean legacy setup had surprising filesystem side effects. The user did not run `omx setup --plugin`, did not have `.omx/setup-scope.json` with `installMode: \"plugin\"`, and did not have an existing OMX Codex plugin cache. Even so, resume preflight unconditionally called `materializePackagedOmxPluginCache(...)` and then rewrote the selected `CODEX_HOME/config.toml` with local marketplace and plugin enablement entries.

That meant a command whose visible intent was only to resume a Codex session silently converted the selected Codex home into a plugin-enabled home. In practice it created paths like `~/.codex/plugins/cache/oh-my-codex-local/oh-my-codex/<version>/` and inserted `[plugins.\"oh-my-codex@oh-my-codex-local\"] enabled = true` plus the `oh-my-codex-local` marketplace registration. This is wrong for clean legacy users because resume should repair an already-selected plugin delivery mode, not choose plugin delivery mode on their behalf.

The fix treats resume preflight as a repair step only. It now runs when one of these opt-in signals exists:
- the selected `CODEX_HOME/config.toml` already enables `oh-my-codex@oh-my-codex-local`, including the legacy scalar form;
- the selected `CODEX_HOME` already contains an OMX plugin cache;
- the current project has persisted setup preferences with `installMode: \"plugin\"`.

Without one of those signals, resume skips plugin preflight and leaves the Codex home untouched.

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/resume.test.js`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/plugin-marketplace-idempotent.test.js dist/cli/__tests__/setup-install-mode.test.js`
- `npm run check:no-unused`
- `npx biome lint src/cli/index.ts src/cli/plugin-marketplace.ts src/cli/__tests__/resume.test.ts`
- `git diff --check`