### PR TITLE
Fix deep-interview runtime state allowlist

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -7917,6 +7917,70 @@ exit 0
         );
       }
 
+      const runtimeRoot = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-deep-interview-runtime-root-"));
+      const previousOmxRoot = process.env.OMX_ROOT;
+      const runtimeSessionId = "sess-di-runtime-artifact";
+      const runtimeStateDir = join(runtimeRoot, ".omx", "state");
+      const runtimeSessionDir = join(runtimeStateDir, "sessions", runtimeSessionId);
+      try {
+        process.env.OMX_ROOT = runtimeRoot;
+        await mkdir(runtimeSessionDir, { recursive: true });
+        await writeJson(join(runtimeStateDir, "session.json"), { session_id: runtimeSessionId, cwd });
+        await writeJson(join(runtimeSessionDir, "skill-active-state.json"), {
+          version: 1,
+          active: true,
+          skill: "deep-interview",
+          phase: "planning",
+          session_id: runtimeSessionId,
+          thread_id: threadId,
+          active_skills: [{ skill: "deep-interview", phase: "planning", active: true, session_id: runtimeSessionId, thread_id: threadId }],
+        });
+        await writeJson(join(runtimeSessionDir, "deep-interview-state.json"), {
+          active: true,
+          mode: "deep-interview",
+          current_phase: "intent-first",
+          session_id: runtimeSessionId,
+          thread_id: threadId,
+        });
+
+        const allowedRuntimeStateWrite = await dispatchCodexNativeHook({
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: runtimeSessionId,
+          thread_id: threadId,
+          tool_name: "Write",
+          tool_use_id: "tool-di-runtime-state-write",
+          tool_input: { file_path: join(runtimeSessionDir, "deep-interview-state.json"), content: "{}\n" },
+        }, { cwd });
+        assert.equal(allowedRuntimeStateWrite.outputJson, null);
+
+        const blockedRuntimeStatePeerWrite = await dispatchCodexNativeHook({
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: runtimeSessionId,
+          thread_id: threadId,
+          tool_name: "Write",
+          tool_use_id: "tool-di-runtime-peer-state-write",
+          tool_input: { file_path: join(runtimeRoot, ".omx", "state", "sessions", "../outside", "deep-interview-state.json"), content: "{}\n" },
+        }, { cwd });
+        assert.equal((blockedRuntimeStatePeerWrite.outputJson as { decision?: string } | null)?.decision, "block");
+
+        const blockedRuntimeUnrelatedWrite = await dispatchCodexNativeHook({
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: runtimeSessionId,
+          thread_id: threadId,
+          tool_name: "Write",
+          tool_use_id: "tool-di-runtime-unrelated-write",
+          tool_input: { file_path: join(runtimeRoot, "unrelated", "deep-interview-state.json"), content: "{}\n" },
+        }, { cwd });
+        assert.equal((blockedRuntimeUnrelatedWrite.outputJson as { decision?: string } | null)?.decision, "block");
+      } finally {
+        if (typeof previousOmxRoot === "string") process.env.OMX_ROOT = previousOmxRoot;
+        else delete process.env.OMX_ROOT;
+        await rm(runtimeRoot, { recursive: true, force: true });
+      }
+
       // Cross-mode non-terminal `omx state write` payloads are activations,
       // because state_write normalizes them to active=true after the hook.
       const blockedStateCliMutation = await preToolUse(

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3395,6 +3395,8 @@ const PROTECTED_PLANNING_STATE_FILE_NAMES = new Set([
   "ralplan-state.json",
   "skill-active-state.json",
 ]);
+const RUNTIME_SESSION_ID_SEGMENT_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+
 
 const PLANNING_MODE_IMPLEMENTATION_TOOL_NAMES = new Set([
   "Write",
@@ -3485,6 +3487,33 @@ function isProtectedPlanningStatePath(relativePath: string): boolean {
   const fileName = relativePath.split("/").pop() ?? "";
   return PROTECTED_PLANNING_STATE_FILE_NAMES.has(fileName);
 }
+function isAllowedAuthoritativeRuntimePlanningStatePath(cwd: string, rawPath: string): boolean {
+  const trimmed = rawPath.trim().replace(/^['"]|['"]$/g, "");
+  if (!trimmed || trimmed.includes("\0")) return false;
+
+  let targetPath: string;
+  let baseStateDir: string;
+  try {
+    targetPath = resolve(cwd, trimmed);
+    baseStateDir = resolve(getBaseStateDir(cwd));
+  } catch {
+    return false;
+  }
+
+  const localStateDir = resolve(cwd, ".omx", "state");
+  if (baseStateDir === localStateDir) return false;
+
+  const relativeToBase = relative(baseStateDir, targetPath).replace(/\\/g, "/");
+  if (!relativeToBase || relativeToBase.startsWith("..") || relativeToBase.startsWith("/")) return false;
+
+  const segments = relativeToBase.split("/");
+  if (segments.length !== 3 || segments[0] !== "sessions") return false;
+  const sessionId = segments[1] ?? "";
+  const fileName = segments[2] ?? "";
+  return RUNTIME_SESSION_ID_SEGMENT_PATTERN.test(sessionId)
+    && PROTECTED_PLANNING_STATE_FILE_NAMES.has(fileName);
+}
+
 
 function isPlanningTmpRelativePath(relativePath: string): boolean {
   return relativePath === ".omx/tmp" || relativePath.startsWith(".omx/tmp/");
@@ -3505,8 +3534,8 @@ function isAllowedPlanningArtifactPath(
   allowedPrefixes: readonly string[],
 ): boolean {
   const relativePath = normalizePlanningArtifactRelativePath(cwd, rawPath);
-  if (!relativePath) return false;
-  if (isProtectedPlanningStatePath(relativePath)) return false;
+  if (!relativePath) return isAllowedAuthoritativeRuntimePlanningStatePath(cwd, rawPath);
+  if (isProtectedPlanningStatePath(relativePath)) return isAllowedAuthoritativeRuntimePlanningStatePath(cwd, rawPath);
   if (isPlanningTmpRelativePath(relativePath)) {
     return allowedPrefixes.includes(".omx/tmp") && isAllowedPlanningTmpScratchPath(relativePath);
   }


### PR DESCRIPTION
## Summary
- Allows deep-interview planning guards to accept protected workflow state files only when they are under the authoritative runtime state root resolved from `OMX_ROOT`/state-root configuration, such as `~/.omx-runs/<run>/.omx/state/sessions/<session>/deep-interview-state.json`.
- Keeps source-worktree `.omx/state` protected state files blocked for direct model writes.
- Adds regression coverage for runtime state acceptance and unrelated runtime/outside paths still being rejected.

## Verification
- `npm ci`
- `npm run build`
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js`

## Risk / guardrails
- The exception is scoped to session paths under the resolved authoritative runtime state root and only for protected planning state filenames (`autopilot-state.json`, `deep-interview-state.json`, `ralplan-state.json`, `skill-active-state.json`).
- The local source-tree `.omx/state` protected-file block remains unchanged, preserving the existing deep-interview planning-mode write boundary.
- Arbitrary runtime-root paths, non-session paths, and unrelated paths continue to fail closed.

Closes #3089

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
