### PR TITLE
Fix deep-interview terminal state normalization

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1022,6 +1022,47 @@ describe("cleanupPostLaunchModeStateFiles", () => {
     assert.deepEqual(warnings, []);
   });
 
+  it("normalizes stale terminal deep-interview locks during postLaunch cleanup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-di-terminal-locks-"));
+    const sessionId = "sess-postlaunch-di-terminal-locks";
+    const sessionStateDir = join(wd, ".omx", "state", "sessions", sessionId);
+    const completedAt = "2026-07-09T00:00:00.000Z";
+
+    try {
+      await mkdir(sessionStateDir, { recursive: true });
+      await writeFile(
+        join(sessionStateDir, "deep-interview-state.json"),
+        JSON.stringify({
+          active: false,
+          mode: "deep-interview",
+          current_phase: "cancelled",
+          completed_at: completedAt,
+          input_lock: {
+            active: true,
+            owner: "stale-question",
+          },
+        }, null, 2),
+        "utf-8",
+      );
+
+      await cleanupPostLaunchModeStateFiles(wd, sessionId);
+
+      const deepInterview = JSON.parse(
+        await readFile(join(sessionStateDir, "deep-interview-state.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      const inputLock = deepInterview.input_lock as Record<string, unknown>;
+
+      assert.equal(deepInterview.active, false);
+      assert.equal(deepInterview.current_phase, "cancelled");
+      assert.equal(deepInterview.completed_at, completedAt);
+      assert.equal(inputLock.active, false);
+      assert.equal(inputLock.status, "released");
+      assert.equal(inputLock.released_at, completedAt);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("does not preserve complete Ralph cleanup state without completion-audit evidence", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-postlaunch-ralph-complete-audit-missing-"));
     const sessionId = "sess-postlaunch-ralph-complete-audit-missing";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -72,6 +72,7 @@ import {
   type ModeStateFileRef,
 } from "../mcp/state-paths.js";
 import { evaluateRalphCompletionAuditEvidence, isRalphCompletePhase } from "../ralph/completion-audit.js";
+import { normalizeTerminalWorkflowState } from "../state/terminal-normalization.js";
 import {
   readPersistedSetupPreferences,
   resolveCodexConfigPathForLaunch,
@@ -4847,6 +4848,14 @@ export async function cleanupPostLaunchModeStateFiles(
         && Array.isArray(result.state.active_skills)
         && result.state.active_skills.length > 0;
       if (result.state.active !== true && !skillStateStillVisible) {
+        const completedAt = now().toISOString();
+        const normalized = mode === SKILL_ACTIVE_STATE_MODE
+          ? { state: result.state, changed: false }
+          : normalizeTerminalWorkflowState(result.state, { mode, nowIso: completedAt });
+        if (normalized.changed) {
+          result.state = normalized.state;
+          await writeFile(path, JSON.stringify(result.state, null, 2));
+        }
         if (mode === "ralph") {
           const completedAt = now().toISOString();
           if (markRalphCompletionAuditBlockedForPostLaunch(result.state, cwd, completedAt)) {
@@ -4885,6 +4894,7 @@ export async function cleanupPostLaunchModeStateFiles(
         result.state.active = false;
         result.state.current_phase = "cancelled";
         result.state.completed_at = completedAt;
+        result.state = normalizeTerminalWorkflowState(result.state, { mode, nowIso: completedAt }).state;
         if (mode === "ralph") {
           result.state.interrupted_at = completedAt;
           result.state.stop_reason = cleanPostLaunchString(result.state.stop_reason) || "session_exit";

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -659,6 +659,61 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('normalizes terminal deep-interview snapshots by releasing stale locks', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-di-terminal-normalize-'));
+    try {
+      const completedAt = '2026-07-09T00:00:00.000Z';
+      const writeResponse = await executeStateOperation('state_write', {
+        workingDirectory: wd,
+        mode: 'deep-interview',
+        active: false,
+        current_phase: 'cancelled',
+        completed_at: completedAt,
+        input_lock: {
+          active: true,
+          owner: 'question-round',
+        },
+        approval_lock: {
+          status: 'pending',
+          reviewer: 'user',
+        },
+        question_enforcement: {
+          obligation_id: 'obligation-stale',
+          source: 'omx-question',
+          status: 'pending',
+          lifecycle_outcome: 'askuserQuestion',
+          requested_at: '2026-07-08T23:59:00.000Z',
+        },
+      });
+
+      assert.equal(writeResponse.isError, undefined);
+
+      const readResponse = await executeStateOperation('state_read', {
+        workingDirectory: wd,
+        mode: 'deep-interview',
+      });
+      const readBody = readResponse.payload as Record<string, unknown>;
+      const inputLock = readBody.input_lock as Record<string, unknown>;
+      const approvalLock = readBody.approval_lock as Record<string, unknown>;
+      const questionEnforcement = readBody.question_enforcement as Record<string, unknown>;
+
+      assert.equal(readBody.active, false);
+      assert.equal(readBody.current_phase, 'cancelled');
+      assert.equal(readBody.completed_at, completedAt);
+      assert.equal(readBody.run_outcome, 'cancelled');
+      assert.equal(inputLock.active, false);
+      assert.equal(inputLock.status, 'released');
+      assert.equal(inputLock.released_at, completedAt);
+      assert.equal(approvalLock.active, false);
+      assert.equal(approvalLock.status, 'released');
+      assert.equal(inputLock.release_reason, 'terminal_state_normalization');
+      assert.equal(questionEnforcement.status, 'cleared');
+      assert.equal(questionEnforcement.clear_reason, 'abort');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('writes and reads autoresearch state', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-autoresearch-'));
     try {

--- a/src/state/__tests__/workflow-transition.test.ts
+++ b/src/state/__tests__/workflow-transition.test.ts
@@ -252,6 +252,14 @@ describe('workflow transition rules', () => {
             status: 'complete',
             rationale: 'Requirements have been clarified and handed to ralplan.',
           },
+          input_lock: {
+            active: true,
+            owner: 'handoff-question',
+          },
+          approval_lock: {
+            status: 'pending',
+            reviewer: 'user',
+          },
         }, null, 2),
         'utf-8',
       );
@@ -288,6 +296,12 @@ describe('workflow transition rules', () => {
       const boxedMode = JSON.parse(await readFile(boxedModePath, 'utf-8')) as Record<string, unknown>;
       assert.equal(boxedMode.active, false);
       assert.equal(boxedMode.current_phase, 'completed');
+      const boxedInputLock = boxedMode.input_lock as Record<string, unknown>;
+      const boxedApprovalLock = boxedMode.approval_lock as Record<string, unknown>;
+      assert.equal(boxedInputLock.active, false);
+      assert.equal(boxedInputLock.status, 'released');
+      assert.equal(boxedApprovalLock.active, false);
+      assert.equal(boxedApprovalLock.status, 'released');
 
       const boxedSkill = JSON.parse(await readFile(join(sessionDir, 'skill-active-state.json'), 'utf-8')) as Record<string, unknown>;
       assert.equal(boxedSkill.active, false);

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -23,6 +23,7 @@ import { evaluateRalphCompletionAuditEvidence } from '../ralph/completion-audit.
 import { ensureCanonicalRalphArtifacts } from '../ralph/persistence.js';
 import { RALPH_PHASES, validateAndNormalizeRalphState } from '../ralph/contract.js';
 import { applyRunOutcomeContract } from '../runtime/run-outcome.js';
+import { normalizeTerminalWorkflowState } from './terminal-normalization.js';
 import {
   hasCleanAutopilotReviewAndQaEvidence,
   isAutopilotSuccessfulTerminalState,
@@ -848,6 +849,8 @@ export async function executeStateOperation(
               return;
             }
             Object.assign(mergedRaw, runOutcomeValidation.state);
+            const terminalNormalization = normalizeTerminalWorkflowState(mergedRaw, { mode });
+            Object.assign(mergedRaw, terminalNormalization.state);
           }
 
           if (mode === 'autopilot') {

--- a/src/state/terminal-normalization.ts
+++ b/src/state/terminal-normalization.ts
@@ -1,0 +1,143 @@
+import { clearDeepInterviewQuestionObligation } from '../question/deep-interview.js';
+import { inferRunOutcome, inferTerminalLifecycleOutcome, isTerminalRunOutcome } from '../runtime/run-outcome.js';
+
+const TERMINAL_PHASES = new Set([
+  'complete',
+  'completed',
+  'cancelled',
+  'canceled',
+  'failed',
+  'blocked',
+  'cleared',
+]);
+
+const LOCK_KEYS = new Set([
+  'input_lock',
+  'inputLock',
+  'approval_lock',
+  'approvalLock',
+  'approval_locks',
+  'approvalLocks',
+]);
+
+const POSSIBLE_APPROVAL_MARKER_KEYS = new Set([
+  'approval',
+  'approval_request',
+  'approvalRequest',
+]);
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isTerminalState(state: Record<string, unknown>): boolean {
+  const phase = stringValue(state.current_phase ?? state.currentPhase).toLowerCase();
+  if (state.active === false && TERMINAL_PHASES.has(phase)) return true;
+  if (state.active === false && stringValue(state.completed_at)) return true;
+  if (inferTerminalLifecycleOutcome(state, { includeQuestionEnforcement: false }) !== undefined) return true;
+  return isTerminalRunOutcome(inferRunOutcome(state));
+}
+
+function isActiveOrPendingLock(record: Record<string, unknown>): boolean {
+  const status = stringValue(record.status).toLowerCase();
+  const phase = stringValue(record.phase).toLowerCase();
+  return record.active === true
+    || record.locked === true
+    || record.pending === true
+    || ['active', 'pending', 'waiting', 'waiting_for_user', 'requested', 'required'].includes(status)
+    || ['active', 'pending', 'waiting', 'waiting_for_user', 'requested', 'required'].includes(phase);
+}
+
+function releaseLockValue(value: unknown, releasedAt: string): { value: unknown; changed: boolean } {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const released = value.map((item) => {
+      const result = releaseLockValue(item, releasedAt);
+      changed ||= result.changed;
+      return result.value;
+    });
+    return { value: released, changed };
+  }
+
+  if (!isRecord(value)) return { value, changed: false };
+
+  if (!isActiveOrPendingLock(value)) return { value, changed: false };
+
+  return {
+    value: {
+      ...value,
+      active: false,
+      locked: false,
+      pending: false,
+      status: 'released',
+      released_at: stringValue(value.released_at) || releasedAt,
+      release_reason: stringValue(value.release_reason) || 'terminal_state_normalization',
+    },
+    changed: true,
+  };
+}
+
+function releaseTerminalLocksOnRecord(record: Record<string, unknown>, releasedAt: string): boolean {
+  let changed = false;
+  for (const key of Object.keys(record)) {
+    if (!LOCK_KEYS.has(key) && !POSSIBLE_APPROVAL_MARKER_KEYS.has(key)) continue;
+    const result = releaseLockValue(record[key], releasedAt);
+    if (!result.changed) continue;
+    record[key] = result.value;
+    changed = true;
+  }
+  return changed;
+}
+
+export function normalizeTerminalWorkflowState(
+  state: Record<string, unknown>,
+  options: { mode?: string; nowIso?: string } = {},
+): { state: Record<string, unknown>; changed: boolean } {
+  if (!isTerminalState(state)) return { state, changed: false };
+
+  const next: Record<string, unknown> = { ...state };
+  const completedAt = stringValue(next.completed_at) || options.nowIso || new Date().toISOString();
+  let changed = false;
+
+  if (next.active !== false) {
+    next.active = false;
+    changed = true;
+  }
+  if (!stringValue(next.completed_at)) {
+    next.completed_at = completedAt;
+    changed = true;
+  }
+
+  if (releaseTerminalLocksOnRecord(next, completedAt)) changed = true;
+
+  if (isRecord(next.state)) {
+    const nested = { ...next.state };
+    if (releaseTerminalLocksOnRecord(nested, completedAt)) {
+      next.state = nested;
+      changed = true;
+    }
+  }
+
+  if (options.mode === 'deep-interview' && isRecord(next.question_enforcement)) {
+    const status = stringValue(next.question_enforcement.status).toLowerCase();
+    if (status === 'pending') {
+      const phase = stringValue(next.current_phase).toLowerCase();
+      const clearReason = phase === 'completed' || phase === 'complete' ? 'handoff' : 'abort';
+      const cleared = clearDeepInterviewQuestionObligation(
+        next.question_enforcement as unknown as Parameters<typeof clearDeepInterviewQuestionObligation>[0],
+        clearReason,
+        new Date(completedAt),
+      );
+      if (cleared) {
+        next.question_enforcement = cleared;
+        changed = true;
+      }
+    }
+  }
+
+  return { state: next, changed };
+}

--- a/src/state/workflow-transition-reconcile.ts
+++ b/src/state/workflow-transition-reconcile.ts
@@ -18,6 +18,7 @@ import {
   syncCanonicalSkillStateForMode,
 } from './skill-active.js';
 import { applyRunOutcomeContract } from '../runtime/run-outcome.js';
+import { normalizeTerminalWorkflowState } from './terminal-normalization.js';
 import { clearDeepInterviewQuestionObligation } from '../question/deep-interview.js';
 import {
   buildAutopilotDeepInterviewRalplanGateError,
@@ -155,7 +156,8 @@ async function completeSourceModeState(
       }
     }
     delete nextCandidate.run_outcome;
-    const nextState = applyRunOutcomeContract(nextCandidate, { nowIso }).state as TransitionStateLike;
+    const runOutcomeState = applyRunOutcomeContract(nextCandidate, { nowIso }).state as TransitionStateLike;
+    const nextState = normalizeTerminalWorkflowState(runOutcomeState, { mode: sourceMode, nowIso }).state as TransitionStateLike;
 
     await mkdir(dirname(candidatePath), { recursive: true });
     await writeFile(candidatePath, JSON.stringify(nextState, null, 2));


### PR DESCRIPTION
Closes #3090

## Summary
- Added shared terminal workflow-state normalization for persisted state writes, auto-complete transitions, and postLaunch cleanup.
- Terminal snapshots now force `active:false`, keep terminal metadata, release stale `input_lock` / approval lock markers, and clear pending deep-interview question obligations without bypassing completion gates.
- Added regressions for direct deep-interview terminal writes, transition auto-completion, and observed stale postLaunch cleanup state (`active:false`, `current_phase:"cancelled"`, `completed_at`, `input_lock.active:true`).

## Verification
- `npm install` (to restore missing local dependencies)
- `npm run build`
- `node dist/scripts/run-test-files.js dist/state/__tests__/operations.test.js dist/state/__tests__/workflow-transition.test.js dist/cli/__tests__/index.test.js`
- `npm run build`
- `node dist/scripts/run-test-files.js dist/state/__tests__/operations.test.js`

## Guardrails / risk notes
- Does not make incomplete interviews look complete: Autopilot deep-interview-to-ralplan gate validation remains unchanged and still blocks missing completion/skip evidence.
- The normalizer only applies after a state is already terminal by phase/outcome/completed metadata.
- PR #3091 is already merged and touched `src/scripts/*`; this PR changes state persistence/cleanup files only, so no direct file conflict was observed.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*