### PR TITLE
Fix ralplan approval handoff and lane reuse

### DIFF
--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -45,7 +45,7 @@ export interface ModeState {
   [key: string]: unknown;
 }
 
-export type ModeName = 'autopilot' | 'autoresearch' | 'deep-interview' | 'ralph' | 'ultrawork' | 'team' | 'ultraqa' | 'ralplan';
+export type ModeName = 'autopilot' | 'autoresearch' | 'deep-interview' | 'ralph' | 'ultrawork' | 'team' | 'ultraqa' | 'ultragoal' | 'ralplan';
 
 /** @deprecated These mode names were removed in v4.6. Use the canonical modes instead. */
 export type DeprecatedModeName = 'ultrapilot' | 'pipeline' | 'ecomode';

--- a/src/pipeline/stages/ralplan.ts
+++ b/src/pipeline/stages/ralplan.ts
@@ -11,6 +11,7 @@ import { isNonCleanReviewVerdict } from '../review-verdict.js';
 import {
   runRalplanConsensus,
   type RalplanConsensusExecutor,
+  type RalplanExecutionLane,
 } from '../../ralplan/runtime.js';
 import {
   buildRalplanConsensusGateForCwd,
@@ -23,6 +24,7 @@ export interface CreateRalplanStageOptions {
   executor?: RalplanConsensusExecutor;
   maxIterations?: number;
   requireNativeSubagents?: boolean;
+  selectedExecutionLane?: RalplanExecutionLane;
 }
 
 /**
@@ -59,6 +61,7 @@ export function createRalplanStage(options: CreateRalplanStageOptions = {}): Pip
             maxIterations: options.maxIterations,
             sessionId: ctx.sessionId,
             requireNativeSubagents: options.requireNativeSubagents,
+            selectedExecutionLane: options.selectedExecutionLane,
           });
 
           const planningArtifacts = readPlanningArtifacts(ctx.cwd);

--- a/src/ralplan/__tests__/runtime.test.ts
+++ b/src/ralplan/__tests__/runtime.test.ts
@@ -178,6 +178,142 @@ describe('ralplan runtime', () => {
     }
   });
 
+  it('records planning-only terminal state when consensus approves without a selected execution lane', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-runtime-planning-only-'));
+    try {
+      const result = await runRalplanConsensus({
+        async draft() {
+          const plansDir = join(cwd, '.omx', 'plans');
+          await mkdir(plansDir, { recursive: true });
+          const prdPath = join(plansDir, 'prd-planning-only.md');
+          await writeFile(prdPath, '# plan\n');
+          await writeFile(join(plansDir, 'test-spec-planning-only.md'), '# tests\n');
+          return { summary: 'draft', planPath: prdPath };
+        },
+        async architectReview() {
+          return { verdict: 'approve', summary: 'architect ok' };
+        },
+        async criticReview() {
+          return { verdict: 'approve', summary: 'critic ok' };
+        },
+      }, { task: 'planning only approval', cwd, maxIterations: 1 });
+
+      assert.equal(result.status, 'completed');
+      assert.equal(result.executionHandoffStarted, false);
+      const finalState = await readModeState('ralplan', cwd);
+      const ralplanHandoff = (finalState?.handoff_artifacts as { ralplan?: Record<string, unknown> } | undefined)?.ralplan;
+      assert.equal(finalState?.selected_execution_lane, 'none');
+      assert.equal(ralplanHandoff?.execution_handoff_status, 'planning_only_terminal');
+      assert.equal(ralplanHandoff?.planning_only_terminal, true);
+      assert.equal(existsSync(getStatePath('ultragoal', cwd)), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('starts the selected execution handoff only after Critic approval completes consensus', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-runtime-execution-handoff-'));
+    try {
+      const result = await runRalplanConsensus({
+        async draft() {
+          const plansDir = join(cwd, '.omx', 'plans');
+          await mkdir(plansDir, { recursive: true });
+          const prdPath = join(plansDir, 'prd-handoff.md');
+          await writeFile(prdPath, '# plan\n');
+          await writeFile(join(plansDir, 'test-spec-handoff.md'), '# tests\n');
+          return { summary: 'draft', planPath: prdPath };
+        },
+        async architectReview() {
+          assert.equal(existsSync(getStatePath('ultragoal', cwd)), false);
+          return { verdict: 'approve', summary: 'architect ok' };
+        },
+        async criticReview() {
+          assert.equal(existsSync(getStatePath('ultragoal', cwd)), false);
+          return { verdict: 'approve', summary: 'critic ok' };
+        },
+      }, { task: 'approval starts ultragoal', cwd, maxIterations: 1, selectedExecutionLane: 'ultragoal' });
+
+      assert.equal(result.status, 'completed');
+      assert.equal(result.executionHandoffStarted, true);
+      const ultragoalState = JSON.parse(await readFile(getStatePath('ultragoal', cwd), 'utf-8')) as Record<string, unknown>;
+      assert.equal(ultragoalState.active, true);
+      assert.equal(ultragoalState.current_phase, 'starting');
+      const finalState = await readModeState('ralplan', cwd);
+      const ralplanHandoff = (finalState?.handoff_artifacts as { ralplan?: Record<string, unknown> } | undefined)?.ralplan;
+      assert.equal(ralplanHandoff?.selected_execution_lane, 'ultragoal');
+      assert.equal(ralplanHandoff?.execution_handoff_status, 'started');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('passes and enforces reusable Architect lane on re-review iterations', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-runtime-architect-reuse-'));
+    try {
+      const architectThreads: Array<string | undefined> = [];
+      const result = await runRalplanConsensus({
+        async draft(ctx) {
+          const plansDir = join(cwd, '.omx', 'plans');
+          await mkdir(plansDir, { recursive: true });
+          const prdPath = join(plansDir, 'prd-reuse.md');
+          await writeFile(prdPath, '# plan\n');
+          await writeFile(join(plansDir, 'test-spec-reuse.md'), '# tests\n');
+          return { summary: `draft-${ctx.iteration}`, planPath: prdPath };
+        },
+        async architectReview(ctx) {
+          architectThreads.push(ctx.reusableRoleLanes.architect?.thread_id);
+          return {
+            verdict: 'approve',
+            summary: `architect-${ctx.iteration}`,
+            agent_role: 'architect',
+            thread_id: ctx.reusableRoleLanes.architect?.thread_id ?? 'thread-architect',
+          };
+        },
+        async criticReview(ctx) {
+          return { verdict: ctx.iteration === 1 ? 'iterate' : 'approve', summary: `critic-${ctx.iteration}` };
+        },
+      }, { task: 'reuse architect lane', cwd, maxIterations: 3 });
+
+      assert.equal(result.status, 'completed');
+      assert.deepEqual(architectThreads, [undefined, 'thread-architect']);
+      assert.deepEqual(result.architectReviews.map((review) => review.thread_id), ['thread-architect', 'thread-architect']);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when a re-review Architect pass spawns a fresh lane without a new-lane reason', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-runtime-architect-reuse-deny-'));
+    try {
+      const result = await runRalplanConsensus({
+        async draft(ctx) {
+          const plansDir = join(cwd, '.omx', 'plans');
+          await mkdir(plansDir, { recursive: true });
+          const prdPath = join(plansDir, 'prd-reuse-deny.md');
+          await writeFile(prdPath, '# plan\n');
+          await writeFile(join(plansDir, 'test-spec-reuse-deny.md'), '# tests\n');
+          return { summary: `draft-${ctx.iteration}`, planPath: prdPath };
+        },
+        async architectReview(ctx) {
+          return {
+            verdict: 'approve',
+            summary: `architect-${ctx.iteration}`,
+            agent_role: 'architect',
+            thread_id: ctx.iteration === 1 ? 'thread-architect-1' : 'thread-architect-2',
+          };
+        },
+        async criticReview(ctx) {
+          return { verdict: ctx.iteration === 1 ? 'iterate' : 'approve', summary: `critic-${ctx.iteration}` };
+        },
+      }, { task: 'reject fresh architect lane', cwd, maxIterations: 3 });
+
+      assert.equal(result.status, 'failed');
+      assert.match(result.error || '', /ralplan_architect_lane_reuse_required/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('fails Autopilot-required consensus when approvals lack native subagent provenance', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-runtime-native-required-missing-'));
     const sessionId = 'sess-ralplan-native-required-missing';

--- a/src/ralplan/runtime.ts
+++ b/src/ralplan/runtime.ts
@@ -13,6 +13,17 @@ export const RALPLAN_ACTIVE_PHASES = [
 export type RalplanActivePhase = (typeof RALPLAN_ACTIVE_PHASES)[number];
 export type RalplanTerminalPhase = 'complete' | 'cancelled' | 'failed';
 export type RalplanReviewVerdict = 'approve' | 'iterate' | 'reject';
+export type RalplanExecutionLane = 'ultragoal' | 'team' | 'ralph' | 'conductor' | 'execution' | 'none';
+
+export interface RalplanReusableRoleLane {
+  agent_role: 'architect' | 'critic';
+  thread_id?: string;
+  lane_id?: string;
+  session_id?: string;
+  native_session_id?: string;
+  tracker_path?: string;
+}
+
 
 export interface RalplanDraftResult {
   summary?: string;
@@ -38,6 +49,7 @@ export interface RalplanReviewResult {
   agent_role?: 'architect' | 'critic';
   lane_id?: string;
   tracker_path?: string;
+  new_lane_reason?: string;
 }
 
 export interface RalplanConsensusGate {
@@ -60,6 +72,10 @@ export interface RalplanConsensusIterationContext {
   priorDrafts: RalplanDraftResult[];
   architectReviews: RalplanReviewResult[];
   criticReviews: RalplanReviewResult[];
+  reusableRoleLanes: {
+    architect?: RalplanReusableRoleLane;
+    critic?: RalplanReusableRoleLane;
+  };
 }
 
 export interface RalplanConsensusExecutor {
@@ -81,6 +97,7 @@ export interface RunRalplanConsensusOptions {
   maxIterations?: number;
   sessionId?: string;
   requireNativeSubagents?: boolean;
+  selectedExecutionLane?: RalplanExecutionLane;
 }
 
 export interface RalplanRuntimeResult {
@@ -95,6 +112,8 @@ export interface RalplanRuntimeResult {
   latestPlanPath?: string;
   artifacts: Record<string, unknown>;
   error?: string;
+  selectedExecutionLane?: RalplanExecutionLane;
+  executionHandoffStarted?: boolean;
 }
 
 interface RalplanModeUpdates {
@@ -264,6 +283,83 @@ function normalizeReviewForLane(
   return { ...review, agent_role: laneRole };
 }
 
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function latestCompatibleRoleLane(
+  reviews: RalplanReviewResult[],
+  role: 'architect' | 'critic',
+  sessionId?: string,
+): RalplanReusableRoleLane | undefined {
+  for (let index = reviews.length - 1; index >= 0; index -= 1) {
+    const review = reviews[index];
+    if (review.agent_role !== role) continue;
+    if (!nonEmptyString(review.thread_id) && !nonEmptyString(review.lane_id)) continue;
+    const reviewSessionId = nonEmptyString(review.session_id);
+    if (sessionId && reviewSessionId && reviewSessionId !== sessionId) continue;
+    return {
+      agent_role: role,
+      ...(nonEmptyString(review.thread_id) ? { thread_id: nonEmptyString(review.thread_id) } : {}),
+      ...(nonEmptyString(review.lane_id) ? { lane_id: nonEmptyString(review.lane_id) } : {}),
+      ...(reviewSessionId ? { session_id: reviewSessionId } : {}),
+      ...(nonEmptyString(review.native_session_id) ? { native_session_id: nonEmptyString(review.native_session_id) } : {}),
+      ...(nonEmptyString(review.tracker_path) ? { tracker_path: nonEmptyString(review.tracker_path) } : {}),
+    };
+  }
+  return undefined;
+}
+
+function assertRoleLaneReuse(
+  priorLane: RalplanReusableRoleLane | undefined,
+  review: RalplanReviewResult,
+  role: 'architect' | 'critic',
+): void {
+  if (!priorLane) return;
+  if (review.agent_role !== role) return;
+  const priorThreadId = nonEmptyString(priorLane.thread_id);
+  const nextThreadId = nonEmptyString(review.thread_id);
+  const priorLaneId = nonEmptyString(priorLane.lane_id);
+  const nextLaneId = nonEmptyString(review.lane_id);
+  const reusedThread = priorThreadId && nextThreadId && priorThreadId === nextThreadId;
+  const reusedLane = priorLaneId && nextLaneId && priorLaneId === nextLaneId;
+  if (reusedThread || reusedLane) return;
+  if (nonEmptyString(review.new_lane_reason)) return;
+  if ((priorThreadId || priorLaneId) && (nextThreadId || nextLaneId)) {
+    throw new Error(`ralplan_${role}_lane_reuse_required`);
+  }
+}
+
+function normalizeExecutionLane(lane: RalplanExecutionLane | undefined): 'ultragoal' | 'team' | 'ralph' | 'none' {
+  if (lane === 'team' || lane === 'ralph' || lane === 'none') return lane;
+  if (lane === 'ultragoal' || lane === 'conductor' || lane === 'execution') return 'ultragoal';
+  return 'none';
+}
+
+function buildRalplanHandoffArtifact(
+  consensusGate: RalplanConsensusGate,
+  options: { selectedExecutionLane?: RalplanExecutionLane; started: boolean },
+): Record<string, unknown> {
+  const selectedExecutionLane = normalizeExecutionLane(options.selectedExecutionLane);
+  return {
+    selected_execution_lane: selectedExecutionLane,
+    execution_handoff_status: selectedExecutionLane === 'none' ? 'planning_only_terminal' : options.started ? 'started' : 'selected_pending_start',
+    planning_only_terminal: selectedExecutionLane === 'none',
+    ralplan_consensus_gate: consensusGate,
+  };
+}
+
+async function startSelectedExecutionLane(
+  cwd: string,
+  task: string,
+  selectedExecutionLane: RalplanExecutionLane | undefined,
+): Promise<boolean> {
+  const lane = normalizeExecutionLane(selectedExecutionLane);
+  if (lane === 'none') return false;
+  await startMode(lane, task, 50, cwd);
+  return true;
+}
+
 async function updateRalplanState(
   cwd: string,
   updates: RalplanModeUpdates,
@@ -298,6 +394,10 @@ export async function runRalplanConsensus(
 
   try {
     while (iteration <= maxIterations) {
+      const reusableRoleLanes = {
+        architect: latestCompatibleRoleLane(architectReviews, 'architect', options.sessionId),
+        critic: latestCompatibleRoleLane(criticReviews, 'critic', options.sessionId),
+      };
       const iterationContext: RalplanConsensusIterationContext = {
         task: options.task,
         cwd,
@@ -305,6 +405,7 @@ export async function runRalplanConsensus(
         priorDrafts: [...drafts],
         architectReviews: [...architectReviews],
         criticReviews: [...criticReviews],
+        reusableRoleLanes,
       };
 
       await updateRalplanState(cwd, {
@@ -340,6 +441,7 @@ export async function runRalplanConsensus(
         ...iterationContext,
         draft,
       }), 'architect', gateOptions);
+      assertRoleLaneReuse(reusableRoleLanes.architect, architectReview, 'architect');
       architectReviews.push(architectReview);
       if (architectReview.artifacts) Object.assign(aggregatedArtifacts, architectReview.artifacts);
       await recordRalplanSubagentTurn(cwd, options.sessionId, {
@@ -411,6 +513,7 @@ export async function runRalplanConsensus(
         draft,
         architectReview,
       }), 'critic', gateOptions);
+      assertRoleLaneReuse(reusableRoleLanes.critic, criticReview, 'critic');
       criticReviews.push(criticReview);
       if (criticReview.artifacts) Object.assign(aggregatedArtifacts, criticReview.artifacts);
       await recordRalplanSubagentTurn(cwd, options.sessionId, {
@@ -473,9 +576,30 @@ export async function runRalplanConsensus(
           planning_complete: true,
           latest_plan_path: latestPlanPath,
           ralplan_consensus_gate: consensusGate,
-          status_message: 'Status: complete — ralplan consensus approved and planning artifacts are ready for handoff.',
+          selected_execution_lane: normalizeExecutionLane(options.selectedExecutionLane),
+          handoff_artifacts: {
+            ralplan: buildRalplanHandoffArtifact(consensusGate, {
+              selectedExecutionLane: options.selectedExecutionLane,
+              started: false,
+            }),
+          },
+          status_message: normalizeExecutionLane(options.selectedExecutionLane) === 'none'
+            ? 'Status: complete — ralplan consensus approved, planning artifacts are ready, and no execution lane was selected.'
+            : 'Status: complete — ralplan consensus approved and planning artifacts are ready for execution handoff.',
           review_history: reviewHistory,
         });
+        const executionHandoffStarted = await startSelectedExecutionLane(cwd, options.task, options.selectedExecutionLane);
+        if (executionHandoffStarted) {
+          await updateRalplanState(cwd, {
+            handoff_artifacts: {
+              ralplan: buildRalplanHandoffArtifact(consensusGate, {
+                selectedExecutionLane: options.selectedExecutionLane,
+                started: true,
+              }),
+            },
+            status_message: `Status: complete — ralplan consensus approved and ${normalizeExecutionLane(options.selectedExecutionLane)} execution handoff started.`,
+          });
+        }
         return {
           status: 'completed',
           iteration,
@@ -487,6 +611,8 @@ export async function runRalplanConsensus(
           ralplanConsensusGate: consensusGate,
           latestPlanPath,
           artifacts: aggregatedArtifacts,
+          selectedExecutionLane: options.selectedExecutionLane,
+          executionHandoffStarted,
         };
       }
 


### PR DESCRIPTION
Closes #3093

## Summary
- Added explicit ralplan terminal handoff state that records planning-only completion when no execution lane is selected.
- Starts the selected execution/conductor handoff after, and only after, Architect→Critic consensus approval and planning artifacts are present.
- Carries reusable role-lane hints into re-review iterations and fails closed when Architect/Critic review lanes change without an explicit new-lane reason.
- Exposes selected ralplan execution lane through the pipeline stage and allows ultragoal mode startup through the shared mode runtime type.

## Verification
- `npm install`
- `npm run build`
- `node dist/scripts/run-test-files.js dist/ralplan/__tests__/runtime.test.js`

## Guardrails / risks
- Execution handoff is gated behind a complete consensus gate plus PRD/test-spec artifacts; the selected lane is not started during Architect or Critic review.
- Default behavior remains planning-only terminal state unless a lane is explicitly selected/configured.
- Role reuse only accepts compatible same-session lane/thread evidence; incompatible fresh lanes require `new_lane_reason` and otherwise fail closed.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*