### PR TITLE
fix(ultragoal): guard ralplan handoff goal derivation

### DIFF
--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -173,6 +173,49 @@ describe('ultragoal artifacts', () => {
     });
   });
 
+  it('does not atomize RALPLAN review and consensus sections into pseudo-goals', async () => {
+    await withTempRepo(async (cwd) => {
+      const brief = [
+        '# Approved RALPLAN handoff',
+        '',
+        'Review artifact:',
+        '- G104 verdict: APPROVE after evidence review',
+        '- Review artifact: .gjc/plans/ralplan/run/review.md',
+        '- Critic review: verification is concrete',
+        '',
+        'Consensus status:',
+        '- Planner consensus: approved',
+        '- Architect review: CLEAR',
+        '- Implementation notes remain advisory until converted to compact goals',
+        '',
+        'Verification checklist:',
+        '- Run targeted tests',
+        '- Run build checks',
+      ].join('\n');
+
+      const plan = await createUltragoalPlan(cwd, { brief });
+
+      assert.equal(plan.goals.length, 1);
+      assert.equal(plan.goals[0]?.title, '# Approved RALPLAN handoff');
+      assert.doesNotMatch(plan.goals[0]?.id ?? '', /g104|verdict|review-artifact|consensus-status/);
+    });
+  });
+
+  it('fails closed for broad implicit plan-like markdown without compact stories', async () => {
+    await withTempRepo(async (cwd) => {
+      const broadBrief = [
+        '# RALPLAN approved handoff',
+        'Consensus status: approved for execution.',
+        ...Array.from({ length: 21 }, (_, index) => `- Review or handoff detail ${index + 1}`),
+      ].join('\n');
+
+      await assert.rejects(
+        () => createUltragoalPlan(cwd, { brief: broadBrief }),
+        /Refusing to derive 21 implicit ultragoal goals.*--goal "Title::Objective".*### Stories\/### Goals/s,
+      );
+    });
+  });
+
   it('keeps later sibling stories after an indented plain-label note', async () => {
     await withTempRepo(async (cwd) => {
       const plan = await createUltragoalPlan(cwd, {

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -345,8 +345,14 @@ function normalizeIndentedAtxStorySectionLabel(value: string): string | undefine
   return sectionLooksStory(atx) ? atx : undefined;
 }
 
+const MAX_IMPLICIT_MARKDOWN_GOALS = 20;
+
+function sectionLooksPlanReview(section: string | undefined): boolean {
+  return /^(?:review(?:\s+artifact)?|review\s+findings?|findings?|verdict|status|consensus(?:\s+status)?|decision\s+log|approval(?:\s+status)?|implementation\s+notes?|handoff|context|background|summary|scope)$/.test(section ?? '');
+}
+
 function sectionLooksNonStory(section: string | undefined): boolean {
-  return /^(?:acceptance\s+criteria|verification(?:\s+checklist)?|validation(?:\s+checklist)?|checklist|evidence|constraints?|risks?|immediate\s+next\s+actions?|next\s+actions?|follow-?ups?|notes?)$/.test(section ?? '');
+  return /^(?:acceptance\s+criteria|verification(?:\s+checklist)?|validation(?:\s+checklist)?|checklist|evidence|constraints?|risks?|immediate\s+next\s+actions?|next\s+actions?|follow-?ups?|notes?)$/.test(section ?? '') || sectionLooksPlanReview(section);
 }
 
 function sectionLooksStory(section: string | undefined): boolean {
@@ -405,6 +411,25 @@ function topLevelStoryItems(items: readonly MarkdownListItem[]): MarkdownListIte
   const candidates = storySectionItems.length > 0 ? storySectionItems : storyItems;
   const minIndent = Math.min(...candidates.map((item) => item.indent));
   return candidates.filter((item) => item.indent === minIndent);
+}
+
+function hasExplicitStorySection(items: readonly MarkdownListItem[]): boolean {
+  return items.some((item) => sectionLooksStory(item.section));
+}
+
+function briefLooksPlanLikeHandoff(lines: readonly string[]): boolean {
+  return lines.some((line) => {
+    const label = normalizeSectionLabel(line);
+    if (sectionLooksPlanReview(label)) return true;
+    return /\b(?:RALPLAN|G\d{3,}\s+(?:verdict|review|status)|review\s+artifact|consensus\s+status|planner\s+consensus|critic\s+review|architect\s+review)\b/i.test(line);
+  });
+}
+
+function assertSafeImplicitMarkdownGoalCount(brief: string, parsedItems: readonly MarkdownListItem[], parentItems: readonly MarkdownListItem[]): void {
+  if (hasExplicitStorySection(parsedItems)) return;
+  if (parentItems.length <= MAX_IMPLICIT_MARKDOWN_GOALS) return;
+  const sourceKind = briefLooksPlanLikeHandoff(brief.split(/\r?\n/)) ? 'plan/review handoff markdown' : 'broad markdown';
+  throw new UltragoalError(`Refusing to derive ${parentItems.length} implicit ultragoal goals from ${sourceKind}. Pass compact executable stories with repeated --goal "Title::Objective" entries, or rewrite the brief with an explicit ### Stories/### Goals section containing no more than ${MAX_IMPLICIT_MARKDOWN_GOALS} parent stories.`);
 }
 
 function normalizeObjective(value: string): string {
@@ -733,6 +758,7 @@ export function deriveGoalCandidates(brief: string): Array<{ title: string; obje
   const lines = brief.split(/\r?\n/);
   const parsedItems = parseMarkdownListItems(lines);
   const parentItems = topLevelStoryItems(parsedItems);
+  assertSafeImplicitMarkdownGoalCount(brief, parsedItems, parentItems);
   const listGoals = parentItems
     .map((item, index) => selectedItemObjective(item, lines, parentItems[index + 1]?.lineIndex))
     .filter((objective, index, all) => all.findIndex((candidate) => candidate === objective) === index);


### PR DESCRIPTION
## Summary
- exclude RALPLAN review/consensus/status-style sections from implicit Ultragoal story derivation
- fail closed when broad markdown would create more than 20 implicit goals without an explicit Stories/Goals section
- add regression coverage for issue #3095 handoff atomization and fail-closed behavior

Closes #3095

## Verification
- npm run build
- node dist/scripts/run-test-files.js dist/ultragoal/__tests__/artifacts.test.js dist/cli/__tests__/ultragoal.test.js
- npm run check:no-unused
- npm run lint

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*