### PR TITLE
feat: canonical repo/worktree context for CodeGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ clean, commit, or stash that worktree before relying on it for isolation.
 For `omx team`, workers already use dedicated worktrees automatically by
 default; `--worktree` on `omx team` is only a legacy-compatible override.
 
+Repo-aware tools receive the same canonical context in launch, team-worker, and autoresearch runtimes: `OMX_REPO_ROOT`, `OMX_WORKTREE_ROOT`, `OMX_GIT_COMMON_DIR`, `OMX_WORKTREE_SCOPE`, `OMX_CODEGRAPH_MODE`, and `OMX_CODEGRAPH_PROJECT_PATH`. `OMX_CODEGRAPH_MODE=auto` prefers a worktree-local `.codegraph/codegraph.db`, then a leader/repo `.codegraph/codegraph.db`, otherwise resolves to `off`. Explicit `shared`, `local`, and `off` are honored. OMX does not install CodeGraph, auto-index worktrees, or copy/symlink `.codegraph`; shared leader indexes are useful for baseline navigation but are not branch-accurate for worktree-only changes.
+
 If you want a one-off launch with no OMX tmux/HUD management, use `--direct`:
 
 ```bash

--- a/src/autoresearch/runtime.ts
+++ b/src/autoresearch/runtime.ts
@@ -8,6 +8,7 @@ import {
   type AutoresearchKeepPolicy,
   type AutoresearchMissionContract,
 } from './contracts.js';
+import { renderCodeGraphInstructions, resolveWorktreeToolContext, type WorktreeToolContext } from '../utils/worktree-tool-context.js';
 
 export type AutoresearchCandidateStatus = 'candidate' | 'noop' | 'abort' | 'interrupted';
 export type AutoresearchDecisionStatus = 'baseline' | 'keep' | 'discard' | 'ambiguous' | 'noop' | 'abort' | 'interrupted' | 'error';
@@ -644,6 +645,7 @@ export function buildAutoresearchInstructions(
     keepPolicy: AutoresearchKeepPolicy;
     previousIterationOutcome?: string | null;
     recentLedgerSummary?: AutoresearchInstructionLedgerSummary[];
+    toolContext?: WorktreeToolContext;
   },
 ): string {
   return [
@@ -661,6 +663,7 @@ export function buildAutoresearchInstructions(
     `Results file: ${context.resultsFile}`,
     `Candidate artifact: ${context.candidateFile}`,
     `Keep policy: ${context.keepPolicy}`,
+    ...(context.toolContext && renderCodeGraphInstructions(context.toolContext) ? ['', renderCodeGraphInstructions(context.toolContext)] : []),
     '',
     'Iteration state snapshot:',
     '```json',
@@ -776,6 +779,12 @@ async function writeInstructionsFile(contract: AutoresearchMissionContract, mani
       keepPolicy: manifest.keep_policy,
       previousIterationOutcome: instructionContext.previousIterationOutcome,
       recentLedgerSummary: instructionContext.recentLedgerSummary,
+      toolContext: resolveWorktreeToolContext({
+        cwd: manifest.worktree_path,
+        scope: 'autoresearch',
+        repoRoot: manifest.repo_root,
+        worktreeRoot: manifest.worktree_path,
+      }),
     })}\n`,
     'utf-8',
   );

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -186,6 +186,7 @@ import {
   ensureWorktree,
 } from "../team/worktree.js";
 import { ensureReusableNodeModules } from "../utils/repo-deps.js";
+import { resolveWorktreeToolContext, worktreeToolContextEnv } from "../utils/worktree-tool-context.js";
 import {
   OMX_NOTIFY_TEMP_CONTRACT_ENV,
   parseNotifyTempContractFromArgs,
@@ -2160,6 +2161,21 @@ function applyDisposableWorktreeOmxRootForLaunch(
   env.OMX_ROOT = omxRootOverride;
 }
 
+function applyWorktreeToolContextForLaunch(
+  cwd: string,
+  ensuredWorktree: { enabled: true; repoRoot: string; worktreePath: string } | { enabled: false } | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  const context = resolveWorktreeToolContext({
+    cwd,
+    scope: "launch",
+    repoRoot: ensuredWorktree?.enabled ? ensuredWorktree.repoRoot : undefined,
+    worktreeRoot: ensuredWorktree?.enabled ? ensuredWorktree.worktreePath : cwd,
+    env,
+  });
+  Object.assign(env, worktreeToolContextEnv(context));
+}
+
 function launchArgRequestsDisposableWorktree(arg: string): boolean {
   return arg === "--worktree" ||
     arg === "-w" ||
@@ -3061,6 +3077,7 @@ export async function launchWithAuthHotswap(args: string[]): Promise<void> {
   }
   clearInheritedMadmaxRootForDisposableWorktreeLaunch(parsedWorktree.remainingArgs);
   applyDisposableWorktreeOmxRootForLaunch(ensuredLaunchWorktree);
+  applyWorktreeToolContextForLaunch(cwd, ensuredLaunchWorktree);
 
   try {
     await maybeCheckAndPromptUpdate(cwd);
@@ -3190,6 +3207,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
   });
   clearInheritedMadmaxRootForDisposableWorktreeLaunch(parsedWorktree.remainingArgs);
   applyDisposableWorktreeOmxRootForLaunch(ensuredLaunchWorktree);
+  applyWorktreeToolContextForLaunch(cwd, ensuredLaunchWorktree);
 
   const sessionId = `omx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   try {
@@ -3318,6 +3336,7 @@ export async function execWithOverlay(args: string[]): Promise<void> {
 
   clearInheritedMadmaxRootForDisposableWorktreeLaunch(parsedWorktree.remainingArgs);
   applyDisposableWorktreeOmxRootForLaunch(ensuredLaunchWorktree);
+  applyWorktreeToolContextForLaunch(cwd, ensuredLaunchWorktree);
 
   const sessionId = `omx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 

--- a/src/team/__tests__/worker-bootstrap.test.ts
+++ b/src/team/__tests__/worker-bootstrap.test.ts
@@ -126,6 +126,34 @@ describe("worker bootstrap", () => {
     assert.doesNotMatch(overlay, /tasks\/\{id\}\.json/);
   });
 
+  it("includes concise CodeGraph guidance for shared leader indexes", () => {
+    const content = generateWorkerRootAgentsContent({
+      teamName: "alpha",
+      workerName: "worker-1",
+      workerRole: "executor",
+      rolePromptContent: "execute",
+      teamStateRoot: "/repo/.omx/state",
+      leaderCwd: "/repo",
+      worktreePath: "/repo/.omx/team/alpha/worktrees/worker-1",
+      toolContext: {
+        repoRoot: "/repo",
+        worktreeRoot: "/repo/.omx/team/alpha/worktrees/worker-1",
+        gitCommonDir: "/repo/.git",
+        worktreeScope: "team",
+        codeGraphMode: "shared",
+        codeGraphProjectPath: "/repo",
+        codeGraphDbPath: "/repo/.codegraph/codegraph.db",
+        codeGraphSource: "leader-shared",
+        requestedCodeGraphMode: "auto",
+      },
+    });
+
+    assert.match(content, /## CodeGraph/);
+    assert.match(content, /shared leader index/);
+    assert.match(content, /not branch-accurate for worktree-only changes/);
+    assert.match(content, /does not install CodeGraph, auto-index worktrees, or copy\/symlink/);
+  });
+
   it("applyWorkerOverlay appends to existing AGENTS.md content", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-worker-bootstrap-"));
     try {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -138,6 +138,7 @@ import { hasStructuredVerificationEvidence } from '../verification/verifier.js';
 import { buildRebalanceDecisions } from './rebalance-policy.js';
 import { getStatePath } from '../mcp/state-paths.js';
 import { readModeState, updateModeState } from '../modes/base.js';
+import { resolveWorktreeToolContext, worktreeToolContextEnv } from '../utils/worktree-tool-context.js';
 
 export { resolveTeamWorkerCliForResolvedLaunchArgs };
 import {
@@ -2736,6 +2737,7 @@ export async function startTeam(
       initialPrompt?: string;
       workerLaunchArgs: string[];
       workerCli: TeamWorkerCli;
+      toolContext: ReturnType<typeof resolveWorktreeToolContext>;
     }>;
     const workerCliPlan: TeamWorkerCli[] = [];
 
@@ -2765,6 +2767,13 @@ export async function startTeam(
         ? composeRoleInstructionsForRole(runtimeRole, rawRolePromptContent, resolvedWorkerModel)
         : null;
       const workerWorktreePath = workerWorkspace.worktreePath ?? undefined;
+      const toolContext = resolveWorktreeToolContext({
+        cwd: workerWorkspace.cwd,
+        scope: 'team',
+        repoRoot: workerWorkspace.worktreeRepoRoot ?? leaderCwd,
+        worktreeRoot: workerWorkspace.worktreePath ?? workerWorkspace.cwd,
+        env: launchEnv,
+      });
       const fallbackInstructionsPath = workerInstructionsPath ?? join(leaderCwd, 'AGENTS.md');
       const instructionsFilePath = workerWorktreePath
         ? await writeWorkerWorktreeRootAgentsFile({
@@ -2775,6 +2784,7 @@ export async function startTeam(
           teamStateRoot,
           leaderCwd,
           worktreePath: workerWorktreePath,
+          toolContext,
         })
         : rolePromptContent
           ? await writeWorkerRoleInstructionsFile(sanitized, workerName, leaderCwd, fallbackInstructionsPath, runtimeRole, rolePromptContent)
@@ -2816,6 +2826,7 @@ export async function startTeam(
         initialPrompt,
         workerLaunchArgs,
         workerCli,
+        toolContext,
       });
     }
     if (workerLaunchMode === 'prompt') {
@@ -2829,6 +2840,7 @@ export async function startTeam(
         [MODEL_INSTRUCTIONS_FILE_ENV]: plan.instructionsFilePath,
         OMX_TEAM_DISPLAY_NAME: displayName,
         ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
+        ...worktreeToolContextEnv(plan.toolContext),
       };
       if (plan.workerWorkspace.worktreePath) {
         env.OMX_TEAM_WORKTREE_PATH = plan.workerWorkspace.worktreePath;

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -17,6 +17,7 @@ import {
   type TeamWorkerGoalInstruction,
 } from "./goal-workflow.js";
 import { normalizeTeamTaskCoordinationPlanForRender } from "./coordination-protocol.js";
+import { renderCodeGraphInstructions, type WorktreeToolContext } from "../utils/worktree-tool-context.js";
 
 const TEAM_OVERLAY_START = "<!-- OMX:TEAM:WORKER:START -->";
 const TEAM_OVERLAY_END = "<!-- OMX:TEAM:WORKER:END -->";
@@ -35,6 +36,7 @@ interface WorkerRootAgentsOptions {
   teamStateRoot: string;
   leaderCwd: string;
   worktreePath: string;
+  toolContext?: WorktreeToolContext;
 }
 
 interface WorkerRootAgentsBackup {
@@ -87,6 +89,9 @@ This file is generated for a live OMX team worker run and is disposable.
 - Task directory: ${options.teamStateRoot}/team/${options.teamName}/tasks
 - Worker status path: ${options.teamStateRoot}/team/${options.teamName}/workers/${options.workerName}/status.json
 - Worker identity path: ${options.teamStateRoot}/team/${options.teamName}/workers/${options.workerName}/identity.json
+${options.toolContext ? `
+${renderCodeGraphInstructions(options.toolContext)}
+` : ""}
 
 ## Protocol
 1. Read your inbox at \`${options.teamStateRoot}/team/${options.teamName}/workers/${options.workerName}/inbox.md\`.

--- a/src/utils/__tests__/worktree-tool-context.test.ts
+++ b/src/utils/__tests__/worktree-tool-context.test.ts
@@ -1,0 +1,130 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  renderCodeGraphInstructions,
+  resolveWorktreeToolContext,
+  worktreeToolContextEnv,
+} from '../worktree-tool-context.js';
+
+async function initRepo(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-codegraph-context-'));
+  execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  await writeFile(join(cwd, 'README.md'), 'hello\n', 'utf-8');
+  execFileSync('git', ['add', 'README.md'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd, stdio: 'ignore' });
+  return cwd;
+}
+
+async function writeCodeGraphDb(projectPath: string): Promise<void> {
+  await mkdir(join(projectPath, '.codegraph'), { recursive: true });
+  await writeFile(join(projectPath, '.codegraph', 'codegraph.db'), 'fixture\n', 'utf-8');
+}
+
+function addWorktree(repo: string, path: string, branch: string): void {
+  execFileSync('git', ['worktree', 'add', '-b', branch, path, 'HEAD'], { cwd: repo, stdio: 'ignore' });
+}
+
+function siblingWorktreePath(repo: string, name: string): string {
+  return join(repo, '..', `${basename(repo)}-${name}`);
+}
+
+describe('resolveWorktreeToolContext', () => {
+  it('uses sibling launch worktree with shared leader CodeGraph in auto mode', async () => {
+    const repo = await initRepo();
+    try {
+      await writeCodeGraphDb(repo);
+      const worktree = siblingWorktreePath(repo, 'sibling-launch');
+      addWorktree(repo, worktree, 'feat/sibling-launch');
+
+      const context = resolveWorktreeToolContext({ cwd: worktree, scope: 'launch', repoRoot: repo, worktreeRoot: worktree, env: {} });
+      assert.equal(context.repoRoot, repo);
+      assert.equal(context.worktreeRoot, worktree);
+      assert.equal(context.codeGraphMode, 'shared');
+      assert.equal(context.codeGraphProjectPath, repo);
+      assert.equal(worktreeToolContextEnv(context).OMX_WORKTREE_SCOPE, 'launch');
+      assert.match(renderCodeGraphInstructions(context), /shared leader index/);
+      assert.match(renderCodeGraphInstructions(context), /not branch-accurate for worktree-only changes/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('uses nested team leader CodeGraph as shared context', async () => {
+    const repo = await initRepo();
+    try {
+      const leaderWorktree = join(repo, '.omx', 'team', 'parent', 'worktrees', 'worker-1');
+      addWorktree(repo, leaderWorktree, 'parent/worker-1');
+      await writeCodeGraphDb(leaderWorktree);
+      const nestedWorker = join(repo, '.omx', 'team', 'nested', 'worktrees', 'worker-1');
+      addWorktree(repo, nestedWorker, 'nested/worker-1');
+
+      const context = resolveWorktreeToolContext({
+        cwd: nestedWorker,
+        scope: 'team',
+        repoRoot: leaderWorktree,
+        worktreeRoot: nestedWorker,
+        env: {},
+      });
+      assert.equal(context.codeGraphMode, 'shared');
+      assert.equal(context.codeGraphProjectPath, leaderWorktree);
+      assert.equal(worktreeToolContextEnv(context).OMX_REPO_ROOT, leaderWorktree);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers worktree-local CodeGraph over shared leader CodeGraph', async () => {
+    const repo = await initRepo();
+    try {
+      await writeCodeGraphDb(repo);
+      const worktree = siblingWorktreePath(repo, 'local-precedence');
+      addWorktree(repo, worktree, 'feat/local-precedence');
+      await writeCodeGraphDb(worktree);
+
+      const context = resolveWorktreeToolContext({ cwd: worktree, scope: 'team', repoRoot: repo, worktreeRoot: worktree, env: {} });
+      assert.equal(context.codeGraphMode, 'local');
+      assert.equal(context.codeGraphProjectPath, worktree);
+      assert.doesNotMatch(renderCodeGraphInstructions(context), /not branch-accurate/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('turns auto mode off when no CodeGraph database exists', async () => {
+    const repo = await initRepo();
+    try {
+      const worktree = siblingWorktreePath(repo, 'no-codegraph');
+      addWorktree(repo, worktree, 'feat/no-codegraph');
+
+      const context = resolveWorktreeToolContext({ cwd: worktree, scope: 'launch', repoRoot: repo, worktreeRoot: worktree, env: {} });
+      assert.equal(context.codeGraphMode, 'off');
+      assert.equal(context.codeGraphProjectPath, '');
+      assert.equal(renderCodeGraphInstructions(context), '');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('honors explicit shared local auto and off modes', async () => {
+    const repo = await initRepo();
+    try {
+      await writeCodeGraphDb(repo);
+      const worktree = siblingWorktreePath(repo, 'explicit-modes');
+      addWorktree(repo, worktree, 'feat/explicit-modes');
+
+      assert.equal(resolveWorktreeToolContext({ cwd: worktree, scope: 'launch', repoRoot: repo, worktreeRoot: worktree, env: { OMX_CODEGRAPH_MODE: 'shared' } }).codeGraphMode, 'shared');
+      assert.equal(resolveWorktreeToolContext({ cwd: worktree, scope: 'launch', repoRoot: repo, worktreeRoot: worktree, env: { OMX_CODEGRAPH_MODE: 'local' } }).codeGraphMode, 'local');
+      assert.equal(resolveWorktreeToolContext({ cwd: worktree, scope: 'launch', repoRoot: repo, worktreeRoot: worktree, env: { OMX_CODEGRAPH_MODE: 'auto' } }).codeGraphMode, 'shared');
+      assert.equal(resolveWorktreeToolContext({ cwd: worktree, scope: 'launch', repoRoot: repo, worktreeRoot: worktree, env: { OMX_CODEGRAPH_MODE: 'off' } }).codeGraphMode, 'off');
+      assert.equal(resolveWorktreeToolContext({ cwd: worktree, scope: 'launch', repoRoot: repo, worktreeRoot: worktree, env: { OMX_CODEGRAPH_MODE: 'shared', OMX_CODEGRAPH_REQUESTED_MODE: 'auto' } }).codeGraphMode, 'shared');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/utils/worktree-tool-context.ts
+++ b/src/utils/worktree-tool-context.ts
@@ -1,0 +1,143 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+export type WorktreeToolScope = 'launch' | 'team' | 'autoresearch' | 'repo';
+export type RequestedCodeGraphMode = 'auto' | 'shared' | 'local' | 'off';
+export type ResolvedCodeGraphMode = 'shared' | 'local' | 'off';
+
+export interface WorktreeToolContext {
+  repoRoot: string;
+  worktreeRoot: string;
+  gitCommonDir: string;
+  worktreeScope: WorktreeToolScope;
+  codeGraphMode: ResolvedCodeGraphMode;
+  codeGraphProjectPath: string;
+  codeGraphDbPath: string;
+  codeGraphSource: 'worktree-local' | 'leader-shared' | 'none';
+  requestedCodeGraphMode: RequestedCodeGraphMode;
+}
+
+export interface ResolveWorktreeToolContextOptions {
+  cwd: string;
+  scope: WorktreeToolScope;
+  repoRoot?: string | null;
+  worktreeRoot?: string | null;
+  env?: NodeJS.ProcessEnv;
+}
+
+function readGit(cwd: string, args: string[]): string | null {
+  const result = spawnSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+  if (result.status !== 0) return null;
+  const value = (result.stdout || '').trim();
+  return value || null;
+}
+
+function resolveGitRoot(cwd: string): string | null {
+  const value = readGit(cwd, ['rev-parse', '--show-toplevel']);
+  return value ? resolve(value) : null;
+}
+
+function resolveGitCommonDir(cwd: string, fallbackRoot: string): string {
+  const value = readGit(cwd, ['rev-parse', '--git-common-dir']);
+  return value ? resolve(cwd, value) : join(fallbackRoot, '.git');
+}
+
+function normalizeRequestedCodeGraphMode(env: NodeJS.ProcessEnv): RequestedCodeGraphMode {
+  const raw = String(env.OMX_CODEGRAPH_REQUESTED_MODE ?? env.OMX_CODEGRAPH_MODE ?? 'auto').trim().toLowerCase();
+  if (raw === '' || raw === 'auto') return 'auto';
+  if (raw === 'shared' || raw === 'local' || raw === 'off') return raw;
+  return 'auto';
+}
+
+function resolveCodeGraphDbPath(projectPath: string): string {
+  return join(projectPath, '.codegraph', 'codegraph.db');
+}
+
+export function resolveWorktreeToolContext(options: ResolveWorktreeToolContextOptions): WorktreeToolContext {
+  const env = options.env ?? process.env;
+  const worktreeRoot = resolve(options.worktreeRoot?.trim() || resolveGitRoot(options.cwd) || options.cwd);
+  const repoRoot = resolve(options.repoRoot?.trim() || resolveGitRoot(options.cwd) || worktreeRoot);
+  const gitCommonDir = resolveGitCommonDir(worktreeRoot, repoRoot);
+  const requestedCodeGraphMode = normalizeRequestedCodeGraphMode(env);
+  const localDbPath = resolveCodeGraphDbPath(worktreeRoot);
+  const sharedDbPath = resolveCodeGraphDbPath(repoRoot);
+  const hasLocalDb = existsSync(localDbPath);
+  const hasSharedDb = existsSync(sharedDbPath);
+
+  let codeGraphMode: ResolvedCodeGraphMode = 'off';
+  let codeGraphProjectPath = '';
+  let codeGraphDbPath = '';
+  let codeGraphSource: WorktreeToolContext['codeGraphSource'] = 'none';
+
+  if (requestedCodeGraphMode === 'local') {
+    codeGraphMode = 'local';
+    codeGraphProjectPath = worktreeRoot;
+    codeGraphDbPath = localDbPath;
+    codeGraphSource = 'worktree-local';
+  } else if (requestedCodeGraphMode === 'shared') {
+    codeGraphMode = 'shared';
+    codeGraphProjectPath = repoRoot;
+    codeGraphDbPath = sharedDbPath;
+    codeGraphSource = 'leader-shared';
+  } else if (requestedCodeGraphMode === 'auto') {
+    if (hasLocalDb) {
+      codeGraphMode = 'local';
+      codeGraphProjectPath = worktreeRoot;
+      codeGraphDbPath = localDbPath;
+      codeGraphSource = 'worktree-local';
+    } else if (hasSharedDb) {
+      codeGraphMode = 'shared';
+      codeGraphProjectPath = repoRoot;
+      codeGraphDbPath = sharedDbPath;
+      codeGraphSource = 'leader-shared';
+    }
+  }
+
+  return {
+    repoRoot,
+    worktreeRoot,
+    gitCommonDir,
+    worktreeScope: options.scope,
+    codeGraphMode,
+    codeGraphProjectPath,
+    codeGraphDbPath,
+    codeGraphSource,
+    requestedCodeGraphMode,
+  };
+}
+
+export function worktreeToolContextEnv(context: WorktreeToolContext): Record<string, string> {
+  return {
+    OMX_REPO_ROOT: context.repoRoot,
+    OMX_WORKTREE_ROOT: context.worktreeRoot,
+    OMX_GIT_COMMON_DIR: context.gitCommonDir,
+    OMX_WORKTREE_SCOPE: context.worktreeScope,
+    OMX_CODEGRAPH_MODE: context.codeGraphMode,
+    OMX_CODEGRAPH_PROJECT_PATH: context.codeGraphProjectPath,
+    OMX_CODEGRAPH_REQUESTED_MODE: context.requestedCodeGraphMode,
+  };
+}
+
+export function renderCodeGraphInstructions(context: WorktreeToolContext): string {
+  if (context.codeGraphMode === 'off') return '';
+  const modeLine = context.codeGraphMode === 'local'
+    ? `- Mode: local worktree index (${context.codeGraphProjectPath})`
+    : `- Mode: shared leader index (${context.codeGraphProjectPath})`;
+  const warning = context.codeGraphMode === 'shared'
+    ? '\n- Warning: the shared leader CodeGraph index is not branch-accurate for worktree-only changes; verify changed files directly in this worktree.'
+    : '';
+  return [
+    '## CodeGraph',
+    modeLine,
+    `- Project path: ${context.codeGraphProjectPath}`,
+    `- Database: ${context.codeGraphDbPath || '(not found yet)'}`,
+    '- OMX does not install CodeGraph, auto-index worktrees, or copy/symlink `.codegraph` for this run.',
+    warning.trim(),
+  ].filter(Boolean).join('\n');
+}


### PR DESCRIPTION
## Summary
- add resolveWorktreeToolContext for canonical OMX repo/worktree env and CodeGraph mode resolution
- thread OMX_REPO_ROOT, OMX_WORKTREE_ROOT, OMX_GIT_COMMON_DIR, OMX_WORKTREE_SCOPE, OMX_CODEGRAPH_MODE, and OMX_CODEGRAPH_PROJECT_PATH through launch, team workers, and autoresearch instructions
- add worker CodeGraph guidance plus resolver/worker tests and README coverage

## Verification
- npm run build
- npm run check:no-unused
- node dist/scripts/run-test-files.js dist/utils/__tests__/worktree-tool-context.test.js dist/team/__tests__/worker-bootstrap.test.js
- node dist/scripts/run-test-files.js dist/utils/__tests__/worktree-tool-context.test.js dist/team/__tests__/worker-bootstrap.test.js dist/autoresearch/__tests__/runtime.test.js dist/team/__tests__/runtime.test.js

Closes #3101

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*