### PR TITLE
Add GPT-5.6 model aliases

### DIFF
--- a/docs/reference/omx-config-schema-routing.md
+++ b/docs/reference/omx-config-schema-routing.md
@@ -109,6 +109,9 @@ For `omx sparkshell`, the documented helper-specific environment keys are:
 
 `models` maps mode names to explicit model overrides. Values must be non-empty strings.
 
+Known Codex/OpenAI-compatible model aliases include the built-in `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, plus the GPT-5.6 aliases `gpt-5.6-terra`, `gpt-5.6-luna`, and `gpt-5.6-sol`. Model override fields remain non-empty strings so provider-specific model names stay backward-compatible; the known-alias list is used for display and contract tests, not as a closed allow-list.
+
+
 Supported model-routing keys:
 
 | Key shape | Purpose |
@@ -150,6 +153,8 @@ For a named role, effective model precedence is:
 ### `agentReasoning`
 
 `agentReasoning` is the supported per-agent reasoning override map. Keys are agent names and values must be one of `low`, `medium`, `high`, or `xhigh`.
+
+`xhigh` is the canonical highest reasoning effort token accepted by Codex/OMX. Reported names such as `max` or `ultra` are ambiguous and are not accepted aliases; use `xhigh` instead.
 
 ```json
 {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -589,6 +589,17 @@ describe("normalizeCodexLaunchArgs", () => {
     ]);
   });
 
+  it("rejects ambiguous max and ultra reasoning shorthands", () => {
+    assert.throws(
+      () => normalizeCodexLaunchArgs(["--max"]),
+      /canonical highest reasoning effort is "xhigh".*"max" and "ultra" are not accepted aliases/,
+    );
+    assert.throws(
+      () => normalizeCodexLaunchArgs(["--ultra"]),
+      /canonical highest reasoning effort is "xhigh".*"max" and "ultra" are not accepted aliases/,
+    );
+  });
+
   it("maps --xhigh --madmax to codex-native flags only", () => {
     assert.deepEqual(normalizeCodexLaunchArgs(["--xhigh", "--madmax"]), [
       "--dangerously-bypass-approvals-and-sandbox",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -90,6 +90,11 @@ import {
   upsertLocalOmxPluginEnablement,
 } from "./plugin-marketplace.js";
 import { escapeTomlString, readTopLevelTomlString, upsertTopLevelTomlString } from "../utils/toml.js";
+import {
+  CANONICAL_REASONING_EFFORTS,
+  isAmbiguousUnsupportedReasoningEffort,
+} from "../config/models.js";
+
 
 export {
   readPersistedSetupPreferences,
@@ -357,10 +362,12 @@ const OMX_RALPH_APPEND_INSTRUCTIONS_FILE_ENV =
   "OMX_RALPH_APPEND_INSTRUCTIONS_FILE";
 const OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE_ENV =
   "OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE";
-const REASONING_MODES = ["low", "medium", "high", "xhigh"] as const;
+const REASONING_MODES = CANONICAL_REASONING_EFFORTS;
 type ReasoningMode = (typeof REASONING_MODES)[number];
 const REASONING_MODE_SET = new Set<string>(REASONING_MODES);
 const REASONING_USAGE = "Usage: omx reasoning <low|medium|high|xhigh>";
+const AMBIGUOUS_REASONING_MESSAGE = 'Codex/OMX canonical highest reasoning effort is "xhigh"; "max" and "ultra" are not accepted aliases.';
+
 const ALLOWED_SHELLS = new Set([
   "/bin/sh",
   "/bin/bash",
@@ -3027,8 +3034,11 @@ async function reasoningCommand(args: string[]): Promise<void> {
   }
 
   if (!REASONING_MODE_SET.has(mode)) {
+    const guidance = isAmbiguousUnsupportedReasoningEffort(mode)
+      ? `${AMBIGUOUS_REASONING_MESSAGE}\n`
+      : "";
     throw new Error(
-      `Invalid reasoning mode "${mode}". Expected one of: ${REASONING_MODES.join(", ")}.\n${REASONING_USAGE}`,
+      `${guidance}Invalid reasoning mode "${mode}". Expected one of: ${REASONING_MODES.join(", ")}.\n${REASONING_USAGE}`,
     );
   }
 
@@ -3440,6 +3450,10 @@ export function normalizeCodexLaunchArgs(args: string[]): string[] {
     if (arg === XHIGH_REASONING_FLAG) {
       reasoningMode = "xhigh";
       continue;
+    }
+
+    if (arg === "--max" || arg === "--ultra") {
+      throw new Error(AMBIGUOUS_REASONING_MESSAGE);
     }
 
     if (arg === SPARK_FLAG) {

--- a/src/config/__tests__/models.test.ts
+++ b/src/config/__tests__/models.test.ts
@@ -7,7 +7,9 @@ import {
   DEFAULT_FRONTIER_MODEL,
   DEFAULT_SPARK_MODEL,
   DEFAULT_TEAM_CHILD_MODEL,
+  GPT_5_6_MODEL_ALIASES,
   getAgentReasoningOverride,
+  isKnownCodexModelAlias,
   getAgentModelOverride,
   getEnvConfiguredStandardDefaultModel,
   getMainDefaultModel,
@@ -19,6 +21,7 @@ import {
   readAgentReasoningOverrides,
   readAgentModelOverrides,
   readConfiguredEnvOverrides,
+  KNOWN_CODEX_MODEL_ALIASES,
 } from '../models.js';
 
 describe('getModelForMode', () => {
@@ -269,6 +272,21 @@ describe('getModelForMode', () => {
     assert.equal(getAgentReasoningOverride('executor'), undefined);
   });
 
+  it('rejects ambiguous max and ultra reasoning aliases', async () => {
+    await writeConfig({
+      agentReasoning: {
+        architect: 'max',
+        critic: 'ultra',
+        planner: 'xhigh',
+      },
+    });
+
+    assert.deepEqual(readAgentReasoningOverrides(), {
+      planner: 'xhigh',
+    });
+  });
+
+
   it('reads normalized per-agent model overrides from .omx-config.json', async () => {
     await writeConfig({
       agentModels: {
@@ -277,16 +295,30 @@ describe('getModelForMode', () => {
         executor: '',
         researcher: 42,
         'bad role': 'gpt-5',
+        reviewer: ' gpt-5.6-terra ',
       },
     });
 
     assert.deepEqual(readAgentModelOverrides(), {
       architect: 'gpt-5.5',
       critic: 'gpt-5.4',
+      reviewer: 'gpt-5.6-terra',
     });
     assert.equal(getAgentModelOverride('ARCHITECT'), 'gpt-5.5');
     assert.equal(getAgentModelOverride('executor'), undefined);
     assert.equal(getAgentModelOverride('bad role'), undefined);
+  });
+
+  it('lists GPT-5.6 Terra/Luna/Sol as known Codex model aliases', () => {
+    assert.deepEqual([...GPT_5_6_MODEL_ALIASES], [
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+      'gpt-5.6-sol',
+    ]);
+    for (const alias of GPT_5_6_MODEL_ALIASES) {
+      assert.equal(isKnownCodexModelAlias(alias), true);
+      assert.equal(KNOWN_CODEX_MODEL_ALIASES.includes(alias), true);
+    }
   });
 
   it('keeps explicit low-complexity config ahead of OMX_DEFAULT_SPARK_MODEL', async () => {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -38,7 +38,12 @@ export interface OmxConfigEnv {
   [key: string]: string | undefined;
 }
 
-export type ConfiguredAgentReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
+export const CANONICAL_REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh'] as const;
+export type ConfiguredAgentReasoningEffort = (typeof CANONICAL_REASONING_EFFORTS)[number];
+
+export const AMBIGUOUS_UNSUPPORTED_REASONING_EFFORTS = ['max', 'ultra'] as const;
+export type AmbiguousUnsupportedReasoningEffort = (typeof AMBIGUOUS_UNSUPPORTED_REASONING_EFFORTS)[number];
+
 
 interface OmxConfigFile {
   agentReasoning?: Record<string, unknown>;
@@ -97,6 +102,19 @@ function readModelsBlock(codexHomeOverride?: string): ModelsConfig | null {
 export const DEFAULT_FRONTIER_MODEL = 'gpt-5.5';
 export const DEFAULT_STANDARD_MODEL = 'gpt-5.4-mini';
 export const DEFAULT_SPARK_MODEL = 'gpt-5.3-codex-spark';
+export const GPT_5_6_MODEL_ALIASES = ['gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-5.6-sol'] as const;
+export const KNOWN_CODEX_MODEL_ALIASES = [
+  DEFAULT_FRONTIER_MODEL,
+  DEFAULT_STANDARD_MODEL,
+  DEFAULT_SPARK_MODEL,
+  ...GPT_5_6_MODEL_ALIASES,
+] as const;
+export type KnownCodexModelAlias = (typeof KNOWN_CODEX_MODEL_ALIASES)[number];
+
+export function isKnownCodexModelAlias(model: string): model is KnownCodexModelAlias {
+  return (KNOWN_CODEX_MODEL_ALIASES as readonly string[]).includes(model);
+}
+
 export const DEFAULT_TEAM_CHILD_MODEL = DEFAULT_STANDARD_MODEL;
 
 function normalizeConfiguredValue(value: unknown): string | undefined {
@@ -105,15 +123,14 @@ function normalizeConfiguredValue(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+export function isAmbiguousUnsupportedReasoningEffort(value: string): value is AmbiguousUnsupportedReasoningEffort {
+  return (AMBIGUOUS_UNSUPPORTED_REASONING_EFFORTS as readonly string[]).includes(value.toLowerCase());
+}
+
 function normalizeAgentReasoningEffort(value: unknown): ConfiguredAgentReasoningEffort | undefined {
   const normalized = normalizeConfiguredValue(value)?.toLowerCase();
-  if (
-    normalized === 'low' ||
-    normalized === 'medium' ||
-    normalized === 'high' ||
-    normalized === 'xhigh'
-  ) {
-    return normalized;
+  if (normalized && (CANONICAL_REASONING_EFFORTS as readonly string[]).includes(normalized)) {
+    return normalized as ConfiguredAgentReasoningEffort;
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary
- add GPT-5.6 Terra/Luna/Sol to the known Codex model alias contract while keeping provider-specific model overrides backward-compatible
- centralize canonical reasoning efforts and reject ambiguous --max/--ultra launch shorthands instead of forwarding them silently
- document xhigh as the canonical highest reasoning token and add focused model/effort tests

## Verification
- npm ci
- npm run build
- node dist/scripts/run-test-files.js dist/config/__tests__/models.test.js dist/cli/__tests__/index.test.js dist/utils/__tests__/agents-model-table.test.js
- npm run lint
- git diff --check

Closes #3103

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*