### PR TITLE
fix: stop seeding legacy multi-agent config

### DIFF
--- a/src/cli/__tests__/doctor-invalid-config.test.ts
+++ b/src/cli/__tests__/doctor-invalid-config.test.ts
@@ -39,6 +39,13 @@ describe('omx doctor invalid config detection', () => {
         `
 model = "gpt-5.6-sol"
 
+[features]
+multi_agent = false
+
+[agents]
+max_threads = 17
+max_depth = 5
+
 [tui]
 status_line = ["model-with-reasoning"]
 
@@ -59,6 +66,8 @@ theme = "base16-ocean-light"
         res.stdout,
         /\[XX\] Config: invalid config\.toml \(possible duplicate TOML table such as \[tui\]\)/,
       );
+      assert.doesNotMatch(res.stdout, /GPT-5\.6 multi-agent compatibility/);
+      assert.doesNotMatch(res.stdout, /All checks passed!/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -24,6 +24,7 @@ import {
 	buildPostCompactSmokeSpawnInvocation,
 	checkNativeHookDistSmoke,
 	classifyPostCompactHookStdout,
+	checkLegacyMultiAgentCompatibility,
 } from "../doctor.js";
 import { buildManagedCodexNativeHookCommand } from "../../config/codex-hooks.js";
 
@@ -1963,6 +1964,114 @@ command = "node"
 				/Legacy skill roots: ~\/\.agents\/skills links to canonical .*\.codex[\\/]+skills; treating both paths as one shared skill root/,
 			);
 			assert.doesNotMatch(res.stdout, /\[!!\] Legacy skill roots:/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("reports retained and custom GPT-5.6 multi-agent settings without diagnosing a clean config", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-multi-agent-"));
+		try {
+			const cleanPath = join(wd, "clean.toml");
+			await writeFile(cleanPath, 'model = "gpt-5.6"\n');
+			assert.equal(
+				await checkLegacyMultiAgentCompatibility(cleanPath, "user"),
+				null,
+			);
+
+			const userPath = join(wd, "user.toml");
+			await writeFile(
+				userPath,
+				"[features]\nmulti_agent = true\n\n[agents]\nmax_threads = 6\nmax_depth = 2\n",
+			);
+			const userCheck = await checkLegacyMultiAgentCompatibility(userPath, "user");
+			assert.ok(userCheck);
+			assert.equal(userCheck.name, "GPT-5.6 multi-agent compatibility");
+			assert.equal(userCheck.status, "warn");
+			assert.match(userCheck.message, new RegExp(`user scope config at ${userPath}`));
+			assert.match(userCheck.message, /features\.multi_agent \(retained-legacy; exact-legacy-value\)/);
+			assert.match(userCheck.message, /agents\.max_threads \(retained-legacy; exact-legacy-value\)/);
+			assert.match(userCheck.message, /agents\.max_depth \(retained-legacy; exact-legacy-value\)/);
+			assert.match(userCheck.message, /historical ownership cannot be proven/);
+			assert.match(userCheck.message, /remove only keys you confirm OMX authored/);
+			assert.match(userCheck.message, /omx setup --scope user/);
+			assert.match(userCheck.message, /Setup does not auto-delete them/);
+
+			const projectPath = join(wd, "project.toml");
+			await writeFile(projectPath, "[agents]\nmax_threads = 8\n");
+			const projectCheck = await checkLegacyMultiAgentCompatibility(projectPath, "project");
+			assert.ok(projectCheck);
+			assert.match(projectCheck.message, new RegExp(`project scope config at ${projectPath}`));
+			assert.match(projectCheck.message, /agents\.max_threads \(custom; custom-value\)/);
+			assert.doesNotMatch(projectCheck.message, /All checks passed/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("reports project-scoped custom values once through the full doctor command", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-project-multi-agent-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(wd, ".codex");
+			await mkdir(home, { recursive: true });
+			await mkdir(codexDir, { recursive: true });
+			await mkdir(join(wd, ".omx"), { recursive: true });
+			await writeFile(
+				join(wd, ".omx", "setup-scope.json"),
+				`${JSON.stringify({ scope: "project" }, null, 2)}\n`,
+			);
+			const configPath = join(codexDir, "config.toml");
+			await writeFile(
+				configPath,
+				"[features]\nmulti_agent = false\n\n[agents]\nmax_threads = 17\nmax_depth = 5\n",
+			);
+
+			const res = runOmx(wd, ["doctor"], { HOME: home });
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Resolved setup scope: project \(from \.omx\/setup-scope\.json\)/,
+			);
+			assert.equal(
+				res.stdout.match(/\[!!\] GPT-5\.6 multi-agent compatibility:/g)?.length,
+				1,
+			);
+			assert.match(res.stdout, new RegExp(`project scope config at ${configPath}`));
+			assert.match(res.stdout, /features\.multi_agent \(custom; custom-value\)/);
+			assert.match(res.stdout, /agents\.max_threads \(custom; custom-value\)/);
+			assert.match(res.stdout, /agents\.max_depth \(custom; custom-value\)/);
+			assert.match(res.stdout, /historical ownership cannot be proven/);
+			assert.match(res.stdout, /remove only keys you confirm OMX authored/);
+			assert.match(res.stdout, /omx setup --scope project/);
+			assert.match(res.stdout, /Setup does not auto-delete them/);
+			assert.match(res.stdout, /Results: \d+ passed, [1-9]\d* warnings, \d+ failed/);
+			assert.doesNotMatch(res.stdout, /All checks passed!/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("counts the multi-agent compatibility warning and suppresses the all-clear footer", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-multi-agent-footer-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(codexDir, "config.toml"),
+				"[features]\nmulti_agent = true\n",
+			);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(res.stdout, /\[!!\] GPT-5\.6 multi-agent compatibility:/);
+			assert.match(res.stdout, /Results: \d+ passed, [1-9]\d* warnings, \d+ failed/);
+			assert.doesNotMatch(res.stdout, /All checks passed!/);
 		} finally {
 			await rm(wd, { recursive: true, force: true });
 		}

--- a/src/cli/__tests__/setup-hooks-shared-ownership.test.ts
+++ b/src/cli/__tests__/setup-hooks-shared-ownership.test.ts
@@ -246,6 +246,14 @@ describe("omx setup/uninstall shared ownership for native hooks", () => {
       const initial = runOmx(wd, ["setup", "--scope", "project"], { HOME: home });
       if (shouldSkipForSpawnPermissions(initial.error)) return;
       assert.equal(initial.status, 0, initial.stderr || initial.stdout);
+      const configPath = join(wd, ".codex", "config.toml");
+      const customAgentPath = join(wd, ".codex", "agents", "custom-role.toml");
+      const generatedConfig = await readFile(configPath, "utf-8");
+      await writeFile(
+        configPath,
+        `${generatedConfig.replace(/^\[features\]$/m, "[features]\nmulti_agent = true").trimEnd()}\n\n[agents]\nmax_threads = 6\nmax_depth = 2\n\n[agents.custom_role]\ndescription = "custom role"\n`,
+      );
+      await writeFile(customAgentPath, 'model = "custom"\n');
 
       const hooksPath = join(wd, ".codex", "hooks.json");
       const generated = await readHooksJson(hooksPath);
@@ -281,16 +289,69 @@ describe("omx setup/uninstall shared ownership for native hooks", () => {
         "uninstall should strip only OMX-managed wrappers",
       );
 
-      const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
+      const config = await readFile(configPath, "utf-8");
       assert.match(
         config,
         /^hooks = true$/m,
         "uninstall should keep native Codex hooks enabled for preserved user hooks",
       );
       assert.doesNotMatch(config, /^codex_hooks = true$/m);
-      assert.doesNotMatch(config, /^multi_agent\s*=/m);
+      assert.match(config, /^multi_agent = true$/m);
       assert.doesNotMatch(config, /^child_agents_md\s*=/m);
       assert.doesNotMatch(config, /^goals\s*=/m);
+      assert.match(config, /^max_threads = 6$/m);
+      assert.match(config, /^max_depth = 2$/m);
+      assert.match(config, /^\[agents\.custom_role\]$/m);
+      assert.match(config, /^description = "custom role"$/m);
+      assert.equal(await readFile(customAgentPath, "utf-8"), 'model = "custom"\n');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it("plugin transition preserves historical multi-agent configuration and custom roles", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-plugin-config-preservation-"));
+    try {
+      const home = join(wd, "home");
+      const codexDir = join(wd, ".codex");
+      await mkdir(join(codexDir, "agents"), { recursive: true });
+      await mkdir(home, { recursive: true });
+      await writeFile(
+        join(codexDir, "config.toml"),
+        [
+          "[features]",
+          "multi_agent = false",
+          "custom_feature = true",
+          "child_agents_md = true",
+          "",
+          "[agents]",
+          "max_threads = 17",
+          "max_depth = 5",
+          "",
+          "[agents.custom_role]",
+          'description = "custom role"',
+          "",
+        ].join("\n"),
+      );
+      await writeFile(join(codexDir, "agents", "custom-role.toml"), "model = \"custom\"\n");
+
+      const result = runOmx(wd, ["setup", "--scope", "project", "--plugin"], {
+        HOME: home,
+      });
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      const config = await readFile(join(codexDir, "config.toml"), "utf-8");
+      assert.match(config, /^multi_agent = false$/m);
+      assert.match(config, /^custom_feature = true$/m);
+      assert.match(config, /^\[agents\]$/m);
+      assert.match(config, /^max_threads = 17$/m);
+      assert.match(config, /^max_depth = 5$/m);
+      assert.match(config, /^\[agents\.custom_role\]$/m);
+      assert.match(config, /^description = "custom role"$/m);
+      assert.equal(
+        await readFile(join(codexDir, "agents", "custom-role.toml"), "utf-8"),
+        "model = \"custom\"\n",
+      );
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -984,7 +984,7 @@ describe("omx setup install mode behavior", () => {
 				assert.match(output, /Next steps:/);
 				assert.match(
 					output,
-					/Native agent defaults configured in config\.toml \[agents\] and TOML files written to \.codex\/agents\//,
+					/Native agent role TOML files written to \.codex\/agents\/; use explicit agent_type when spawning OMX roles/,
 				);
 			});
 		} finally {
@@ -2667,7 +2667,7 @@ describe("omx setup install mode behavior", () => {
 					assert.doesNotMatch(pluginOutput, /user-scope skill delivery mode/);
 					assert.doesNotMatch(
 						pluginOutput,
-						/Native agent defaults configured.*TOML files written to \.codex\/agents\//,
+						/use explicit agent_type when spawning OMX roles/,
 					);
 					assert.doesNotMatch(
 						pluginOutput,
@@ -2702,7 +2702,7 @@ describe("omx setup install mode behavior", () => {
 						});
 						assert.match(
 							legacyOutput,
-							/Native agent defaults configured.*TOML files written to \.codex\/agents\//,
+							/Native agent role TOML files written to \.codex\/agents\//,
 						);
 						assert.match(
 							legacyOutput,

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -228,9 +228,10 @@ describe("omx setup scope behavior", () => {
       assert.equal(existsSync(agentsMdPath), true);
 
       const configToml = await readFile(localConfig, "utf-8");
-      assert.match(configToml, /^\[agents\]$/m);
-      assert.match(configToml, /^max_threads = 6$/m);
-      assert.match(configToml, /^max_depth = 2$/m);
+      assert.doesNotMatch(configToml, /^\[agents\]$/m);
+      assert.doesNotMatch(configToml, /^multi_agent\s*=/m);
+      assert.doesNotMatch(configToml, /^max_threads\s*=/m);
+      assert.doesNotMatch(configToml, /^max_depth\s*=/m);
       assert.doesNotMatch(configToml, /^\[env\]$/m);
       assert.match(configToml, /^\[shell_environment_policy\.set\]$/m);
       assert.match(configToml, /^USE_OMX_EXPLORE_CMD = "0"$/m);
@@ -302,6 +303,17 @@ describe("omx setup scope behavior", () => {
       await writeFile(
         join(codexDir, "config.toml"),
         [
+          "[features]",
+          "multi_agent = false",
+          "custom_feature = true",
+          "",
+          "[agents]",
+          "max_threads = 17",
+          "max_depth = 5",
+          "",
+          "[agents.custom_role]",
+          'description = "keep me"',
+          "",
           "[hooks.state.\"custom:/hooks.json:stop:0:0\"]",
           "trusted_hash = \"sha256:user\"",
           "enabled = false",
@@ -350,6 +362,13 @@ describe("omx setup scope behavior", () => {
         configToml,
         /^\[hooks\.state\.".*\/\.codex\/hooks\.json:stop:0:0"\]$/m,
       );
+      assert.match(configToml, /^multi_agent = false$/m);
+      assert.match(configToml, /^custom_feature = true$/m);
+      assert.match(configToml, /^\[agents\]$/m);
+      assert.match(configToml, /^max_threads = 17$/m);
+      assert.match(configToml, /^max_depth = 5$/m);
+      assert.match(configToml, /^\[agents\.custom_role\]$/m);
+      assert.match(configToml, /^description = "keep me"$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -448,6 +467,11 @@ describe("omx setup scope behavior", () => {
         "utf-8",
       );
       assert.match(agentsMd, /~\/\.codex\/skills/);
+      const userConfigToml = await readFile(join(home, ".codex", "config.toml"), "utf-8");
+      assert.doesNotMatch(userConfigToml, /^multi_agent\s*=/m);
+      assert.doesNotMatch(userConfigToml, /^\[agents\]$/m);
+      assert.doesNotMatch(userConfigToml, /^max_threads\s*=/m);
+      assert.doesNotMatch(userConfigToml, /^max_depth\s*=/m);
       assert.equal(
         await readFile(join(wd, "AGENTS.md"), "utf-8"),
         existingAgents,

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { buildManagedCodexHooksConfig } from '../../config/codex-hooks.js';
+import TOML from '@iarna/toml';
 
 function runOmx(
   cwd: string,
@@ -197,6 +198,13 @@ function buildMixedConfig(): string {
     'command = "custom"',
     'args = ["--flag"]',
     '',
+    '[agents]',
+    'max_threads = 17',
+    'max_depth = 5',
+    '',
+    '[agents.custom_role]',
+    'description = "keep me"',
+    '',
     '# ============================================================',
     '# oh-my-codex (OMX) Configuration',
     '# Managed by omx setup - manual edits preserved on next setup',
@@ -233,6 +241,49 @@ function buildMixedConfig(): string {
     '',
     '[tui]',
     'status_line = ["model-with-reasoning"]',
+    '',
+    '# ============================================================',
+    '# End oh-my-codex',
+    '',
+  ].join('\n');
+}
+
+type MultiAgentPreservationVariant = {
+  name: string;
+  multiAgent: boolean;
+  maxThreads: number;
+  maxDepth: number;
+};
+
+function buildAmbiguousMultiAgentConfig(
+  marker: string,
+  variant: MultiAgentPreservationVariant,
+): string {
+  return [
+    `sentinel = "${marker}"`,
+    '',
+    '[features]',
+    `multi_agent = ${variant.multiAgent}`,
+    'child_agents_md = true',
+    'goals = true',
+    'custom_feature = true',
+    '',
+    '[agents]',
+    `max_threads = ${variant.maxThreads}`,
+    `max_depth = ${variant.maxDepth}`,
+    '',
+    '[agents.custom_role]',
+    `description = "${marker}"`,
+    '',
+    '# ============================================================',
+    '# oh-my-codex (OMX) Configuration',
+    '# Managed by omx setup - manual edits preserved on next setup',
+    '# ============================================================',
+    '',
+    '[mcp_servers.omx_state]',
+    'command = "node"',
+    'args = ["/path/to/state-server.js"]',
+    'enabled = true',
     '',
     '# ============================================================',
     '# End oh-my-codex',
@@ -299,7 +350,7 @@ describe('omx uninstall', () => {
       assert.doesNotMatch(config, /notify\s*=/);
       assert.doesNotMatch(config, /model_reasoning_effort\s*=/);
       assert.doesNotMatch(config, /developer_instructions\s*=/);
-      assert.doesNotMatch(config, /multi_agent\s*=/);
+      assert.match(config, /multi_agent\s*=/);
       assert.doesNotMatch(config, /child_agents_md\s*=/);
       assert.doesNotMatch(config, /^hooks\s*=/m);
       assert.equal(existsSync(join(codexDir, 'hooks.json')), false);
@@ -378,11 +429,17 @@ describe('omx uninstall', () => {
       assert.match(config, /model = "o4-mini"/);
       assert.match(config, /\[mcp_servers\.user_custom\]/);
       assert.match(config, /web_search = true/);
+      assert.match(config, /^multi_agent = true$/m);
+      assert.match(config, /^\[agents\]$/m);
+      assert.match(config, /^max_threads = 17$/m);
+      assert.match(config, /^max_depth = 5$/m);
+      assert.match(config, /^\[agents\.custom_role\]$/m);
+      assert.match(config, /^description = "keep me"$/m);
       // OMX entries removed
       assert.doesNotMatch(config, /omx_state/);
       assert.doesNotMatch(config, /omx_memory/);
       assert.doesNotMatch(config, /notify\s*=.*node/);
-      assert.doesNotMatch(config, /multi_agent/);
+      assert.match(config, /multi_agent\s*=/);
       assert.doesNotMatch(config, /child_agents_md/);
       assert.doesNotMatch(config, /^hooks\s*=/m);
     } finally {
@@ -442,7 +499,7 @@ describe('omx uninstall', () => {
         /^codex_hooks\s*=/m,
         'legacy Codex hook aliases should be normalized during uninstall preservation',
       );
-      assert.doesNotMatch(config, /^multi_agent\s*=/m);
+      assert.match(config, /^multi_agent\s*=/m);
       assert.doesNotMatch(config, /^child_agents_md\s*=/m);
       assert.doesNotMatch(config, /^goals\s*=/m);
     } finally {
@@ -507,6 +564,7 @@ describe('omx uninstall', () => {
       assert.doesNotMatch(config, /^model_context_window = 250000$/m);
       assert.doesNotMatch(config, /^model_auto_compact_token_limit = 200000$/m);
       assert.doesNotMatch(config, /seeded behavioral defaults/);
+      assert.match(config, /^multi_agent = true$/m);
       assert.doesNotMatch(config, /notify\s*=/);
       assert.doesNotMatch(config, /model_reasoning_effort\s*=/);
       assert.doesNotMatch(config, /developer_instructions\s*=/);
@@ -533,6 +591,7 @@ describe('omx uninstall', () => {
       assert.match(config, /^model_context_window = 123456$/m);
       assert.match(config, /^model_auto_compact_token_limit = 200000$/m);
       assert.doesNotMatch(config, /seeded behavioral defaults/);
+      assert.match(config, /^multi_agent = true$/m);
       assert.doesNotMatch(config, /notify\s*=/);
       assert.doesNotMatch(config, /model_reasoning_effort\s*=/);
       assert.doesNotMatch(config, /developer_instructions\s*=/);
@@ -587,6 +646,70 @@ describe('omx uninstall', () => {
     }
   });
 
+  for (const scope of ['user', 'project'] as const) {
+    for (const variant of [
+      { name: 'legacy-looking', multiAgent: true, maxThreads: 6, maxDepth: 2 },
+      { name: 'custom', multiAgent: false, maxThreads: 17, maxDepth: 5 },
+    ] satisfies MultiAgentPreservationVariant[]) {
+      it(`preserves ambiguous multi-agent ownership in ${scope} scope (${variant.name})`, async () => {
+        const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-ownership-'));
+        try {
+          const home = join(wd, 'home');
+          const userConfigPath = join(home, '.codex', 'config.toml');
+          const projectConfigPath = join(wd, '.codex', 'config.toml');
+          const setupStateDir = join(wd, '.omx');
+          await mkdir(join(home, '.codex'), { recursive: true });
+          await mkdir(join(wd, '.codex'), { recursive: true });
+          await mkdir(setupStateDir, { recursive: true });
+
+          const userConfig = buildAmbiguousMultiAgentConfig('user-config', variant);
+          const projectConfig = buildAmbiguousMultiAgentConfig('project-config', variant);
+          await writeFile(userConfigPath, userConfig);
+          await writeFile(projectConfigPath, projectConfig);
+          await writeFile(
+            join(setupStateDir, 'setup-scope.json'),
+            `${JSON.stringify({ scope })}\n`,
+          );
+
+          const selectedPath = scope === 'user' ? userConfigPath : projectConfigPath;
+          const unselectedPath = scope === 'user' ? projectConfigPath : userConfigPath;
+          const unselectedBefore = await readFile(unselectedPath, 'utf-8');
+
+          const res = runOmx(wd, ['uninstall'], { HOME: home });
+          if (shouldSkipForSpawnPermissions(res.error)) return;
+          assert.equal(res.status, 0, res.stderr || res.stdout);
+          assert.match(res.stdout, new RegExp(`Resolved scope: ${scope}`));
+
+          const selectedAfter = await readFile(selectedPath, 'utf-8');
+          const parsed = TOML.parse(selectedAfter) as {
+            sentinel?: unknown;
+            features?: Record<string, unknown>;
+            agents?: Record<string, unknown>;
+          };
+          assert.equal(parsed.sentinel, `${scope}-config`);
+          assert.equal(parsed.features?.multi_agent, variant.multiAgent);
+          assert.equal(parsed.features?.custom_feature, true);
+          assert.equal(parsed.features?.child_agents_md, undefined);
+          assert.equal(parsed.features?.goals, undefined);
+          assert.equal(parsed.agents?.max_threads, variant.maxThreads);
+          assert.equal(parsed.agents?.max_depth, variant.maxDepth);
+          assert.deepEqual(parsed.agents?.custom_role, {
+            description: `${scope}-config`,
+          });
+          assert.doesNotMatch(selectedAfter, /mcp_servers\.omx_state/);
+          assert.doesNotMatch(selectedAfter, /oh-my-codex \(OMX\) Configuration/);
+
+          assert.equal(
+            await readFile(unselectedPath, 'utf-8'),
+            unselectedBefore,
+            'unselected scope config must remain byte-identical',
+          );
+        } finally {
+          await rm(wd, { recursive: true, force: true });
+        }
+      });
+    }
+  }
   it('works with project scope', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
     try {
@@ -945,5 +1068,23 @@ describe('stripOmxFeatureFlags', () => {
     const config = 'model = "o4-mini"\n';
     const result = stripOmxFeatureFlags(config);
     assert.equal(result, config);
+  });
+
+  it('preserves multi_agent when explicitly requested', async () => {
+    const { stripOmxFeatureFlags } = await import('../../config/generator.js');
+    const config = [
+      '[features]',
+      'multi_agent = false',
+      'child_agents_md = true',
+      'goals = true',
+      'web_search = true',
+      '',
+    ].join('\n');
+
+    const result = stripOmxFeatureFlags(config, { preserveMultiAgent: true });
+    assert.match(result, /^multi_agent = false$/m);
+    assert.doesNotMatch(result, /^child_agents_md\s*=/m);
+    assert.doesNotMatch(result, /^goals\s*=/m);
+    assert.match(result, /^web_search = true$/m);
   });
 });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -32,6 +32,7 @@ import { getPackageRoot } from "../utils/package.js";
 import {
 	hasLegacyOmxTeamRunTable,
 	getModelContextRecommendation,
+	analyzeLegacyMultiAgentConfig,
 } from "../config/generator.js";
 import {
 	MANAGED_HOOK_EVENTS,
@@ -325,7 +326,13 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 	checks.push(checkDirectory("Codex home", paths.codexHomeDir));
 
 	// Check 4: Config file
-	checks.push(await checkConfig(paths.configPath));
+	const configCheck = await checkConfig(paths.configPath);
+	checks.push(configCheck);
+	const multiAgentCompatibilityCheck = await checkLegacyMultiAgentCompatibility(
+		paths.configPath,
+		scopeResolution.scope,
+	);
+	if (multiAgentCompatibilityCheck) checks.push(multiAgentCompatibilityCheck);
 
 	// Check 4.1: Model context recommendation
 	const contextRecommendationCheck = await checkModelContextRecommendation(
@@ -1125,6 +1132,41 @@ function validateToml(content: string): string | null {
 			return error.message;
 		}
 		return "unknown TOML parse error";
+	}
+}
+
+export async function checkLegacyMultiAgentCompatibility(
+	configPath: string,
+	scope: DoctorSetupScope,
+): Promise<Check | null> {
+	if (!existsSync(configPath)) return null;
+
+	try {
+		const content = await readFile(configPath, "utf-8");
+		if (validateToml(content)) return null;
+
+		const affected = Object.values(analyzeLegacyMultiAgentConfig(content).assessments).filter(
+			(assessment) => assessment.state !== "absent",
+		);
+		if (affected.length === 0) return null;
+
+		const details = affected
+			.map(
+				({ key, state, reasonCode }) =>
+					`${key} (${state}; ${reasonCode})`,
+			)
+			.join(", ");
+		return {
+			name: "GPT-5.6 multi-agent compatibility",
+			status: "warn",
+			message:
+				`${scope} scope config at ${configPath}: ${details}. ` +
+				"OMX preserves these settings because historical ownership cannot be proven. " +
+				`Back up ${configPath}, remove only keys you confirm OMX authored, rerun omx setup --scope ${scope}, then omx doctor. ` +
+				"Setup does not auto-delete them.",
+		};
+	} catch {
+		return null;
 	}
 }
 

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -2015,7 +2015,7 @@ async function cleanupPluginModeLegacyConfig(
 		options.developerInstructionsDecision,
 	);
 	config = stripOmxSeededBehavioralDefaults(config);
-	config = stripOmxFeatureFlags(config);
+	config = stripOmxFeatureFlags(config, { preserveMultiAgent: true });
 	config = stripManagedCodexHookTrustState(config);
 	config = stripOmxEnvSettings(config);
 	if (preservedFirstPartyMcp) {
@@ -3124,7 +3124,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			"  4. The AGENTS.md orchestration brain is loaded automatically",
 		);
 		console.log(
-			"  5. Native agent defaults configured in config.toml [agents] and TOML files written to .codex/agents/",
+			"  5. Native agent role TOML files written to .codex/agents/; use explicit agent_type when spawning OMX roles",
 		);
 	}
 	console.log(

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -88,7 +88,6 @@ function detectOmxConfigArtifacts(config: string): {
     /^\s*developer_instructions\s*=.*oh-my-codex/m.test(config);
 
   const hasFeatureFlags =
-    /^\s*multi_agent\s*=\s*true/m.test(config) ||
     /^\s*child_agents_md\s*=\s*true/m.test(config) ||
     /^\s*hooks\s*=\s*true/m.test(config) ||
     /^\s*codex_hooks\s*=\s*true/m.test(config) ||
@@ -249,7 +248,7 @@ async function cleanConfig(
   config = stripOmxSeededBehavioralDefaults(config);
 
   // Strip feature flags
-  config = stripOmxFeatureFlags(config);
+  config = stripOmxFeatureFlags(config, { preserveMultiAgent: true });
   if (shouldRestoreHooksFeatureFlag) {
     config = upsertCodexHooksFeatureFlag(
       config,
@@ -504,7 +503,7 @@ function printSummary(summary: UninstallSummary, dryRun: boolean): void {
     }
     if (summary.featureFlagsRemoved) {
       console.log(
-        "    Feature flags (multi_agent, child_agents_md, goals; hooks preserved when user hooks remain)",
+        "    Feature flags (child_agents_md, goals; multi_agent and hooks are preserved when user-owned)",
       );
     }
   } else if (!summary.configCleaned && summary.mcpServersRemoved.length === 0) {

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -9,11 +9,13 @@ import { tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import TOML from "@iarna/toml";
 import {
+  analyzeLegacyMultiAgentConfig,
   buildMergedConfig,
   cleanCodexModelAvailabilityNuxIfNeeded,
   mergeConfig,
   repairConfigIfNeeded,
   stripManagedCodexHookTrustState,
+  stripOmxFeatureFlags,
   upsertManagedCodexHookTrustState,
 } from "../generator.js";
 import { buildManagedCodexHookTrustState } from "../codex-hooks.js";
@@ -242,13 +244,105 @@ describe("config generator idempotency (#384)", () => {
       const toml = await readFile(configPath, "utf-8");
 
       assertSingleOmxBlock(toml);
-      assert.match(toml, /^multi_agent = true$/m);
+      assert.doesNotMatch(toml, /^multi_agent\s*=/m);
       assert.match(toml, /^child_agents_md = true$/m);
       assert.match(toml, /^hooks = true$/m);
       assert.match(toml, /^goals = true$/m);
+      assert.doesNotMatch(toml, /^\[agents\]$/m);
+      assert.doesNotMatch(toml, /^max_threads\s*=/m);
+      assert.doesNotMatch(toml, /^max_depth\s*=/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
+  });
+
+  it("classifies legacy multi-agent keys without mutating config", () => {
+    const absent = analyzeLegacyMultiAgentConfig("");
+    assert.equal(absent.assessments["features.multi_agent"].state, "absent");
+
+    const legacy = analyzeLegacyMultiAgentConfig(
+      [
+        "[features]",
+        "multi_agent = true",
+        "",
+        "[agents]",
+        "max_threads = 6",
+        "max_depth = 2",
+      ].join("\n"),
+    );
+    assert.equal(
+      legacy.assessments["features.multi_agent"].state,
+      "retained-legacy",
+    );
+    assert.equal(legacy.assessments["agents.max_threads"].state, "retained-legacy");
+    assert.equal(legacy.assessments["agents.max_depth"].state, "retained-legacy");
+
+    const custom = analyzeLegacyMultiAgentConfig(
+      "[features]\nmulti_agent = false\n\n[agents]\nmax_threads = 8\nmax_depth = 3\n",
+    );
+    assert.equal(custom.assessments["features.multi_agent"].state, "custom");
+    assert.equal(custom.assessments["agents.max_threads"].state, "custom");
+    assert.equal(custom.assessments["agents.max_depth"].state, "custom");
+
+    const invalid = analyzeLegacyMultiAgentConfig("[features\nmulti_agent = true");
+    assert.equal(invalid.assessments["features.multi_agent"].state, "invalid/duplicate");
+
+    const duplicate = analyzeLegacyMultiAgentConfig(
+      "[features]\nmulti_agent = true\nmulti_agent = false\n",
+    );
+    assert.equal(duplicate.assessments["features.multi_agent"].state, "invalid/duplicate");
+    assert.equal(
+      duplicate.assessments["features.multi_agent"].reasonCode,
+      "toml-duplicate-key",
+    );
+  });
+
+  it("preserves legacy multi-agent values and all role tables across fixed-point merges", () => {
+    const existing = [
+      "[features]",
+      "multi_agent = false",
+      "",
+      "[agents]",
+      "max_threads = 8",
+      "max_depth = 3",
+      "",
+      "[agents.executor]",
+      'config_file = "/custom/executor.toml"',
+      "",
+      '[agents."review bot"]',
+      'config_file = "/custom/review.toml"',
+      "",
+    ].join("\n");
+
+    const merged = buildMergedConfig(existing, "/tmp/omx");
+    assert.match(merged, /^multi_agent = false$/m);
+    assert.match(merged, /^max_threads = 8$/m);
+    assert.match(merged, /^max_depth = 3$/m);
+    assert.match(merged, /^\[agents\.executor\]$/m);
+    assert.match(merged, /^\[agents\."review bot"\]$/m);
+    assert.match(merged, /^config_file = "\/custom\/executor\.toml"$/m);
+    assert.match(merged, /^config_file = "\/custom\/review\.toml"$/m);
+    const parsed = TOML.parse(merged) as {
+      agents?: Record<string, unknown>;
+    };
+    assert.equal(
+      (parsed.agents?.executor as { config_file?: string } | undefined)?.config_file,
+      "/custom/executor.toml",
+    );
+    assert.equal(
+      (parsed.agents?.["review bot"] as { config_file?: string } | undefined)?.config_file,
+      "/custom/review.toml",
+    );
+    assert.equal(buildMergedConfig(merged, "/tmp/omx"), merged);
+  });
+
+  it("can preserve multi_agent while stripping other OMX feature flags", () => {
+    const stripped = stripOmxFeatureFlags(
+      "[features]\nmulti_agent = false\nchild_agents_md = true\nhooks = true\ngoals = true\n",
+      { preserveMultiAgent: true },
+    );
+
+    assert.equal(stripped, "[features]\nmulti_agent = false\n");
   });
 
   it("emits first-party MCP blocks only when explicitly enabled", () => {
@@ -508,11 +602,10 @@ describe("config generator idempotency (#384)", () => {
       assertSingleOmxBlock(toml);
       assert.match(toml, /^\[user\.custom\]$/m, "user section preserved");
       assert.match(toml, /^name = "kept"$/m, "user key preserved");
-      assert.match(toml, /^\[agents\]$/m, "global agents settings added");
-      assert.match(toml, /^max_threads = 6$/m, "global agents max_threads seeded");
-      assert.match(toml, /^max_depth = 2$/m, "global agents max_depth seeded");
-      assert.doesNotMatch(toml, /^\[agents\.executor\]$/m, "legacy OMX agent entry removed");
-      assert.doesNotMatch(toml, /^\[agents\.explore\]$/m, "legacy OMX agent entry removed");
+      assert.match(toml, /^\[agents\.executor\]$/m, "known agent table preserved");
+      assert.match(toml, /^\[agents\.explore\]$/m, "known agent table preserved");
+      assert.match(toml, /^config_file = "\/old\/path\/executor\.toml"$/m);
+      assert.match(toml, /^config_file = "\/old\/path\/explore\.toml"$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -917,17 +1010,16 @@ describe("config generator idempotency (#384)", () => {
     }
   });
 
-  it("writes only the global [agents] defaults into config", async () => {
+  it("does not write retired global [agents] defaults", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
     try {
       const configPath = join(wd, "config.toml");
       await mergeConfig(configPath, wd);
       const toml = await readFile(configPath, "utf-8");
 
-      assert.match(toml, /^\[agents\]$/m, "global [agents] section present");
-      assert.match(toml, /^max_threads = 6$/m, "max_threads default written");
-      assert.match(toml, /^max_depth = 2$/m, "max_depth default written");
-      assert.doesNotMatch(toml, /^\[agents\.[^\]]+\]$/m, "legacy per-agent config_file entries omitted");
+      assert.doesNotMatch(toml, /^\[agents\]$/m);
+      assert.doesNotMatch(toml, /^max_threads\s*=/m);
+      assert.doesNotMatch(toml, /^max_depth\s*=/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -175,7 +175,7 @@ describe('config generator', () => {
 
       // Features correct
       assert.equal((rerun.match(/^\[features\]$/gm) ?? []).length, 1);
-      assert.match(rerun, /^multi_agent = true$/m);
+      assert.doesNotMatch(rerun, /^multi_agent\s*=/m);
       assert.match(rerun, /^child_agents_md = true$/m);
 
       // User content preserved
@@ -259,24 +259,24 @@ describe('config generator', () => {
       // User's feature flag preserved
       assert.match(toml, /^web_search = true$/m);
 
-      // OMX feature flags added
-      assert.match(toml, /^multi_agent = true$/m);
+      // OMX feature flags added without legacy multi-agent configuration
+      assert.doesNotMatch(toml, /^multi_agent\s*=/m);
       assert.match(toml, /^goals = true$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
   });
 
-  it('writes a global [agents] section with OMX defaults', async () => {
+  it('does not write retired global [agents] defaults', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
     try {
       const configPath = join(wd, 'config.toml');
       await mergeConfig(configPath, wd);
       const toml = await readFile(configPath, 'utf-8');
 
-      assert.match(toml, /^\[agents\]$/m);
-      assert.match(toml, /^max_threads = 6$/m);
-      assert.match(toml, /^max_depth = 2$/m);
+      assert.doesNotMatch(toml, /^\[agents\]$/m);
+      assert.doesNotMatch(toml, /^max_threads\s*=/m);
+      assert.doesNotMatch(toml, /^max_depth\s*=/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -303,8 +303,8 @@ describe('config generator', () => {
       // collab must be gone
       assert.ok(!/^\s*collab\s*=/m.test(toml), 'deprecated collab key should be removed');
 
-      // multi_agent replaces it
-      assert.match(toml, /^multi_agent = true$/m);
+      // The retired flag is removed without introducing multi_agent.
+      assert.doesNotMatch(toml, /^multi_agent\s*=/m);
 
       // other user flags preserved
       assert.match(toml, /^web_search = true$/m);
@@ -375,7 +375,7 @@ describe('config generator', () => {
 
       assert.equal((merged.match(/^\[features\]$/gm) ?? []).length, 1);
       assert.match(merged, /^custom_user_flag = false$/m);
-      assert.match(merged, /^multi_agent = true$/m);
+      assert.doesNotMatch(merged, /^multi_agent\s*=/m);
       assert.match(merged, /^child_agents_md = true$/m);
       assert.match(merged, /^hooks = true$/m);
       assert.match(merged, /^goals = true$/m);

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -14,7 +14,6 @@ import { readFile, writeFile } from "fs/promises";
 import { existsSync } from "fs";
 import { join, resolve } from "path";
 import TOML from "@iarna/toml";
-import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { DEFAULT_FRONTIER_MODEL } from "./models.js";
 import type { UnifiedMcpRegistryServer } from "./mcp-registry.js";
 import {
@@ -106,8 +105,97 @@ export const OMX_PLUGIN_DEVELOPER_INSTRUCTIONS =
 const SHARED_MCP_REGISTRY_MARKER = "oh-my-codex (OMX) Shared MCP Registry Sync";
 const SHARED_MCP_REGISTRY_END_MARKER =
   "# End oh-my-codex shared MCP registry sync";
-const OMX_AGENTS_MAX_THREADS = 6;
-const OMX_AGENTS_MAX_DEPTH = 2;
+
+export type LegacyMultiAgentKey =
+  | "features.multi_agent"
+  | "agents.max_threads"
+  | "agents.max_depth";
+
+export type LegacyKeyState =
+  | "absent"
+  | "retained-legacy"
+  | "custom"
+  | "invalid/duplicate";
+
+export type LegacyReasonCode =
+  | "key-absent"
+  | "exact-legacy-value"
+  | "custom-value"
+  | "toml-parse-error"
+  | "toml-duplicate-key";
+
+export interface LegacyKeyAssessment {
+  key: LegacyMultiAgentKey;
+  state: LegacyKeyState;
+  reasonCode: LegacyReasonCode;
+  value?: unknown;
+}
+
+export interface LegacyMultiAgentAnalysis {
+  assessments: Record<LegacyMultiAgentKey, LegacyKeyAssessment>;
+}
+
+const LEGACY_MULTI_AGENT_KEYS: readonly LegacyMultiAgentKey[] = [
+  "features.multi_agent",
+  "agents.max_threads",
+  "agents.max_depth",
+];
+
+const LEGACY_MULTI_AGENT_VALUES: Record<LegacyMultiAgentKey, unknown> = {
+  "features.multi_agent": true,
+  "agents.max_threads": 6,
+  "agents.max_depth": 2,
+};
+
+export function analyzeLegacyMultiAgentConfig(
+  configText: string,
+): LegacyMultiAgentAnalysis {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = TOML.parse(configText) as Record<string, unknown>;
+  } catch (error) {
+    const reasonCode: LegacyReasonCode =
+      /duplicate|redefine|already defined/i.test(String(error))
+        ? "toml-duplicate-key"
+        : "toml-parse-error";
+    return {
+      assessments: Object.fromEntries(
+        LEGACY_MULTI_AGENT_KEYS.map((key) => [
+          key,
+          { key, state: "invalid/duplicate", reasonCode },
+        ]),
+      ) as Record<LegacyMultiAgentKey, LegacyKeyAssessment>,
+    };
+  }
+
+  return {
+    assessments: Object.fromEntries(
+      LEGACY_MULTI_AGENT_KEYS.map((key) => {
+        const [table, entry] = key.split(".");
+        const value = isRecord(parsed[table]) ? parsed[table][entry] : undefined;
+        if (value === undefined) {
+          return [key, { key, state: "absent", reasonCode: "key-absent" }];
+        }
+        if (value === LEGACY_MULTI_AGENT_VALUES[key]) {
+          return [
+            key,
+            {
+              key,
+              state: "retained-legacy",
+              reasonCode: "exact-legacy-value",
+              value,
+            },
+          ];
+        }
+        return [
+          key,
+          { key, state: "custom", reasonCode: "custom-value", value },
+        ];
+      }),
+    ) as Record<LegacyMultiAgentKey, LegacyKeyAssessment>,
+  };
+}
+
 const OMX_EXPLORE_ROUTING_DEFAULT = "0";
 const OMX_EXPLORE_CMD_ENV = "USE_OMX_EXPLORE_CMD";
 const DEFAULT_LAUNCHER_MCP_STARTUP_TIMEOUT_SEC = 15;
@@ -734,7 +822,6 @@ function upsertFeatureFlags(
     const base = config.trimEnd();
     const featureBlock = [
       "[features]",
-      "multi_agent = true",
       "child_agents_md = true",
       hookFeatureFlagLine,
       "goals = true",
@@ -754,8 +841,7 @@ function upsertFeatureFlags(
     }
   }
 
-  // Remove deprecated 'collab' key (superseded by multi_agent) and
-  // the misspelled singular 'goal' flag written by unreleased PR builds.
+  // Remove deprecated collab and unreleased singular goal flags.
   for (let i = sectionEnd - 1; i > featuresStart; i--) {
     if (/^\s*(?:collab|goal)\s*=/.test(lines[i])) {
       lines.splice(i, 1);
@@ -763,21 +849,11 @@ function upsertFeatureFlags(
     }
   }
 
-  let multiAgentIdx = -1;
   let childAgentsIdx = -1;
   for (let i = featuresStart + 1; i < sectionEnd; i++) {
-    if (/^\s*multi_agent\s*=/.test(lines[i])) {
-      multiAgentIdx = i;
-    } else if (/^\s*child_agents_md\s*=/.test(lines[i])) {
+    if (/^\s*child_agents_md\s*=/.test(lines[i])) {
       childAgentsIdx = i;
     }
-  }
-
-  if (multiAgentIdx >= 0) {
-    lines[multiAgentIdx] = "multi_agent = true";
-  } else {
-    lines.splice(sectionEnd, 0, "multi_agent = true");
-    sectionEnd += 1;
   }
 
   if (childAgentsIdx >= 0) {
@@ -1468,58 +1544,15 @@ function upsertEnvSettings(config: string): string {
   return lines.join("\n");
 }
 
-function upsertAgentsSettings(config: string): string {
-  const lines = config.split(/\r?\n/);
-  const agentsStart = lines.findIndex((line) =>
-    /^\s*\[agents\]\s*$/.test(line),
-  );
-
-  if (agentsStart < 0) {
-    const base = config.trimEnd();
-    const agentsBlock = [
-      "[agents]",
-      `max_threads = ${OMX_AGENTS_MAX_THREADS}`,
-      `max_depth = ${OMX_AGENTS_MAX_DEPTH}`,
-      "",
-    ].join("\n");
-    if (base.length === 0) return agentsBlock;
-    return `${base}\n\n${agentsBlock}`;
-  }
-
-  let sectionEnd = lines.length;
-  for (let i = agentsStart + 1; i < lines.length; i++) {
-    if (/^\s*\[\[?[^\]]+\]?\]\s*$/.test(lines[i])) {
-      sectionEnd = i;
-      break;
-    }
-  }
-
-  let maxThreadsIdx = -1;
-  let maxDepthIdx = -1;
-  for (let i = agentsStart + 1; i < sectionEnd; i++) {
-    if (/^\s*max_threads\s*=/.test(lines[i])) {
-      maxThreadsIdx = i;
-    } else if (/^\s*max_depth\s*=/.test(lines[i])) {
-      maxDepthIdx = i;
-    }
-  }
-
-  if (maxThreadsIdx < 0) {
-    lines.splice(sectionEnd, 0, `max_threads = ${OMX_AGENTS_MAX_THREADS}`);
-    sectionEnd += 1;
-  }
-  if (maxDepthIdx < 0) {
-    lines.splice(sectionEnd, 0, `max_depth = ${OMX_AGENTS_MAX_DEPTH}`);
-  }
-
-  return lines.join("\n");
-}
-
 /**
  * Remove OMX-owned feature flags from the [features] section.
+ * If `preserveMultiAgent` is set, retain multi_agent unchanged.
  * If the section becomes empty after removal, remove the section header too.
  */
-export function stripOmxFeatureFlags(config: string): string {
+export function stripOmxFeatureFlags(
+  config: string,
+  options: { preserveMultiAgent?: boolean } = {},
+): string {
   const lines = config.split(/\r?\n/);
   const featuresStart = lines.findIndex((line) =>
     /^\s*\[features\]\s*$/.test(line),
@@ -1536,7 +1569,7 @@ export function stripOmxFeatureFlags(config: string): string {
   }
 
   const omxFlags = [
-    "multi_agent",
+    ...(options.preserveMultiAgent ? [] : ["multi_agent"]),
     "child_agents_md",
     "hooks",
     "codex_hooks",
@@ -1631,11 +1664,6 @@ export function stripOmxEnvSettings(config: string): string {
 // Orphaned OMX table sections (no marker block)
 // ---------------------------------------------------------------------------
 
-/**
- * Check whether a TOML table name belongs to a legacy OMX-managed agent entry.
- * Handles both `agents.name` and `agents."name"` forms.
- */
-
 function isOmxFirstPartyMcpSection(tableName: string): boolean {
   const match = tableName.match(/^mcp_servers\.(?:"([^"]+)"|([A-Za-z0-9_-]+))$/);
   const name = match?.[1] ?? match?.[2];
@@ -1646,20 +1674,11 @@ function isOmxFirstPartyMcpSection(tableName: string): boolean {
   );
 }
 
-function isLegacyOmxAgentSection(tableName: string): boolean {
-  const m = tableName.match(/^agents\.(?:"([^"]+)"|(\w[\w-]*))$/);
-  if (!m) return false;
-  const name = m[1] || m[2] || "";
-  return Object.prototype.hasOwnProperty.call(AGENT_DEFINITIONS, name);
-}
 
 /**
- * Strip OMX-owned table sections that exist outside the marker block.
+ * Strip first-party OMX MCP table sections that exist outside the marker block.
  * This covers legacy configs that were written before markers were added,
  * or configs where the marker was accidentally removed.
- *
- * Targets: exact first-party [mcp_servers.<name>] entries, retired
- * [mcp_servers.omx_team_run], and legacy [agents.<name>] entries.
  */
 function stripOrphanedOmxSections(config: string): string {
   const lines = config.split(/\r?\n/);
@@ -1675,9 +1694,7 @@ function stripOrphanedOmxSections(config: string): string {
       // Note: [tui] is NOT stripped here because it could be user-owned.
       // The marker-based stripExistingOmxBlocks already handles [tui]
       // when it lives inside the OMX marker block.
-      const isOmxSection =
-        isOmxFirstPartyMcpSection(tableName) ||
-        isLegacyOmxAgentSection(tableName);
+      const isOmxSection = isOmxFirstPartyMcpSection(tableName);
 
       if (isOmxSection) {
         // Remove preceding OMX comment lines and blank lines
@@ -2399,7 +2416,7 @@ function getOmxTablesBlock(
  *
  * Layout:
  *   1. OMX top-level keys (notify, model_reasoning_effort, developer_instructions)
- *   2. [features] with multi_agent + child_agents_md + hooks + goals
+ *   2. [features] with child_agents_md + hooks + goals
  *   3. [shell_environment_policy.set] with defaulted deprecated explore-routing opt-out
  *   4. … user sections …
  *   5. OMX [table] sections (mcp_servers, tui)
@@ -2438,11 +2455,11 @@ export function buildMergedConfig(
     !isOmxManagedNotifyCommand(getRootTomlArray(existing, "notify"), pkgRoot)
       ? getRootTomlArray(existing, "notify")
       : null;
-  existing = stripOmxTopLevelKeys(existing);
+  existing = stripOmxTopLevelKeys(existing).trimStart();
   if (userNotifyToPreserve) {
     existing = `${`notify = ${formatTomlStringArray(userNotifyToPreserve)}`}\n${existing.trimStart()}`;
   }
-  existing = stripOrphanedManagedNotify(existing, pkgRoot);
+  existing = stripOrphanedManagedNotify(existing, pkgRoot).trimStart();
   const managedTrustState = buildManagedCodexHookTrustStateForConfig(
     options.codexHooksFile,
     pkgRoot,
@@ -2464,7 +2481,6 @@ export function buildMergedConfig(
   }
   existing = upsertFeatureFlags(existing, options.codexHookFeatureFlag);
   existing = upsertEnvSettings(existing);
-  existing = upsertAgentsSettings(existing);
   const tuiUpsert = includeTui
     ? upsertTuiStatusLine(existing, statusLinePreset, {
         forceStatusLinePreset: options.forceStatusLinePreset,
@@ -2498,13 +2514,14 @@ export function buildMergedConfig(
     existing,
   );
 
-  let body = existing.trimEnd();
+  let body = existing.trim();
   if (sharedRegistryBlock) {
     body = body ? `${body}\n\n${sharedRegistryBlock}` : sharedRegistryBlock;
   }
+  const bodySeparator = body.length > 0 && !/^\s*\[/.test(body) ? "\n" : "\n\n";
 
   return addDefaultLauncherMcpStartupTimeouts(
-    topLines.join("\n") + "\n\n" + body + "\n" + tablesBlock,
+    topLines.join("\n") + bodySeparator + body + "\n" + tablesBlock,
   );
 }
 


### PR DESCRIPTION
## Summary
- stop fresh/full setup from generating or overwriting `features.multi_agent`, `agents.max_threads`, and `agents.max_depth`
- preserve historical values and all role tables because OMX has no immutable per-key ownership evidence
- preserve ambiguous multi-agent settings through plugin transitions and uninstall
- add a scoped `omx doctor` compatibility warning with manual remediation instead of auto-deletion
- keep native role TOMLs and explicit `agent_type` routing intact

## Verification
- `npm test`
- focused compiled generator/setup/doctor/uninstall regression matrix
- `npm run check:no-unused`
- `npm run lint`
- `npm run verify:native-agents`
- `npm run verify:plugin-bundle`
- `git diff --check`
- real built CLI sandbox: fresh project setup omitted all three target keys; a historical `multi_agent = false`, `max_threads = 17`, `max_depth = 5`, custom role table, and custom role file survived setup and uninstall; doctor emitted exactly the scoped compatibility warning
- final cleanup reviews: zero blockers
- final architecture review: CLEAR / APPROVE
- final adversarial QA: PASS

## Live account validation
ChatGPT-account Sol/Terra/Luna and native-spawn cases are **BLOCKED** because the available Codex installation reports API-key auth with no stored ChatGPT tokens. No auth contents or secrets were read or exposed. Deterministic implementation and package/CLI validation passed.

Fixes #3106

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*