### PR TITLE
fix(hooks): keep Stop responses schema-safe

### DIFF
--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -728,6 +728,38 @@ exit 7
       assert.doesNotMatch(result.stdout, /plugin_stop_hook_launcher/);
     });
   });
+  it('forwards the complete valid Stop child decision unchanged', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const childOutput = {
+        decision: 'block',
+        reason: 'Autopilot workflow is still active.',
+        stopReason: 'autopilot_ultragoal',
+        systemMessage: 'Autopilot diagnostic: complete the active workflow before stopping.',
+      };
+      const childJson = JSON.stringify(childOutput);
+      const commandPath = join(cacheRoot, process.platform === 'win32' ? 'complete-valid-json.cmd' : 'complete-valid-json.sh');
+      if (process.platform === 'win32') {
+        await writeFile(commandPath, `@echo off\r\necho ${childJson}\r\nexit /b 0\r\n`, 'utf-8');
+      } else {
+        await writeFile(commandPath, `#!/bin/sh
+printf '${childJson}\n'
+`, 'utf-8');
+        await chmod(commandPath, 0o755);
+      }
+
+      const result = runPluginNativeHook(
+        cachePluginRoot,
+        JSON.stringify({ hook_event_name: 'Stop', session_id: 'sess-plugin-complete-valid-json-stop' }),
+        { OMX_NATIVE_HOOK_COMMAND: commandPath },
+      );
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.equal(result.stderr, '');
+      const output = parseSingleJsonStdout(result.stdout);
+      assert.deepEqual(Object.keys(output).sort(), ['decision', 'reason', 'stopReason', 'systemMessage']);
+      assert.deepEqual(output, childOutput);
+    });
+  });
 
   it('preserves valid pretty-printed Stop child JSON', async () => {
     await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1584,13 +1584,56 @@ PY`,
         cwd,
         session_id: sessionId,
         thread_id: "thread-autopilot-diagnostic",
-      }, { cwd })) as { decision?: string; reason?: string; statePath?: string; canonicalDisagreement?: string };
+      }, { cwd }));
 
       assert.equal(output.decision, "block");
+      assert.equal(output.stopReason, "autopilot_ultragoal");
       assert.match(String(output.reason ?? ""), /state: \.omx\/state\/sessions\/sess-autopilot-diagnostic\/autopilot-state\.json/);
       assert.match(String(output.reason ?? ""), /canonical: canonical_agrees/);
-      assert.equal(output.statePath, ".omx/state/sessions/sess-autopilot-diagnostic/autopilot-state.json");
-      assert.equal(output.canonicalDisagreement, "canonical_agrees");
+      assert.match(String(output.systemMessage ?? ""), /state: \.omx\/state\/sessions\/sess-autopilot-diagnostic\/autopilot-state\.json/);
+      assert.match(String(output.systemMessage ?? ""), /canonical: canonical_agrees/);
+      assert.deepEqual(Object.keys(output).sort(), ["decision", "reason", "stopReason", "systemMessage"]);
+      assert.equal("statePath" in output, false);
+      assert.equal("canonicalDisagreement" in output, false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps canonical phase disagreements in active Autopilot Stop diagnostics", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-autopilot-canonical-phase-"));
+    try {
+      const sessionId = "sess-autopilot-canonical-phase";
+      await writeJson(join(cwd, ".omx", "state", "session.json"), { session_id: sessionId, cwd });
+      await writeJson(join(cwd, ".omx", "state", "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "autopilot",
+        phase: "execution",
+        session_id: sessionId,
+        active_skills: [{ skill: "autopilot", phase: "execution", active: true, session_id: sessionId }],
+      });
+      await writeJson(join(cwd, ".omx", "state", "sessions", sessionId, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "ultragoal",
+        session_id: sessionId,
+      });
+
+      const output = parseSingleJsonStdout(runNativeHookCli({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        thread_id: "thread-autopilot-canonical-phase",
+      }, { cwd }));
+
+      assert.equal(output.decision, "block");
+      assert.equal(output.stopReason, "autopilot_ultragoal");
+      assert.match(String(output.reason ?? ""), /canonical: canonical_phase:execution/);
+      assert.match(String(output.systemMessage ?? ""), /canonical: canonical_phase:execution/);
+      assert.deepEqual(Object.keys(output).sort(), ["decision", "reason", "stopReason", "systemMessage"]);
+      assert.equal("statePath" in output, false);
+      assert.equal("canonicalDisagreement" in output, false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -18387,21 +18430,20 @@ PY`,
       execFileSync("git", ["commit", "-m", "init"], { cwd, stdio: "ignore" });
       await writeFile(join(cwd, "src", "scripts", "codex-native-hook.ts"), "export const hook = 2;\n", "utf-8");
 
-      const result = await dispatchCodexNativeHook(
-        {
-          hook_event_name: "Stop",
-          cwd,
-          session_id: "sess-stop-doc-refresh",
-          last_assistant_message: "Launch-ready: yes",
-        },
-        { cwd },
-      );
+      const output = parseSingleJsonStdout(runNativeHookCli({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "sess-stop-doc-refresh",
+        last_assistant_message: "Launch-ready: yes",
+      }, { cwd }));
 
-      assert.equal(result.omxEventName, "stop");
-      assert.equal((result.outputJson as { decision?: string } | null)?.decision, undefined);
-      assert.equal((result.outputJson as { hookSpecificOutput?: { hookEventName?: string } } | null)?.hookSpecificOutput?.hookEventName, "Stop");
-      assert.match(JSON.stringify(result.outputJson), /Document-refresh warning/);
-      assert.match(JSON.stringify(result.outputJson), /staged \+ unstaged changes/);
+      assert.deepEqual(Object.keys(output).sort(), ["systemMessage"]);
+      assert.equal("hookSpecificOutput" in output, false);
+      assert.equal("decision" in output, false);
+      assert.equal("reason" in output, false);
+      assert.equal("stopReason" in output, false);
+      assert.match(String(output.systemMessage ?? ""), /Document-refresh warning/);
+      assert.match(String(output.systemMessage ?? ""), /staged \+ unstaged changes/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -130,7 +130,6 @@ import {
 } from "../question/deep-interview.js";
 import { readAutopilotDeepInterviewQuestionWaitState } from "../question/autopilot-wait.js";
 import {
-  buildDocumentRefreshAdvisoryOutput,
   evaluateFinalHandoffDocumentRefresh,
   isFinalHandoffDocumentRefreshCandidate,
 } from "../document-refresh/enforcer.js";
@@ -2740,8 +2739,6 @@ async function buildModeBasedStopOutput(
     reason: `OMX ${mode} is still active (phase: ${phase}; ${diagnostic}); continue the task and gather fresh verification evidence before stopping.`,
     stopReason: `${mode}_${phase}`,
     systemMessage,
-    statePath,
-    canonicalDisagreement,
   };
 }
 
@@ -9544,7 +9541,7 @@ async function buildStopHookOutput(
             documentRefreshWarning.triggeringPaths.join("|"),
             canonicalSessionId,
           ),
-          buildDocumentRefreshAdvisoryOutput(documentRefreshWarning, "Stop"),
+          { systemMessage: documentRefreshWarning.message },
           canonicalSessionId,
           { allowRepeatDuringStopHook: false },
         );


### PR DESCRIPTION
## Summary

- remove internal `statePath` and `canonicalDisagreement` fields from active Autopilot Stop responses while preserving both diagnostics in accepted text fields
- emit final-handoff document-refresh Stop advisories as `systemMessage` only, preserving the PreToolUse hook-specific contract
- add exact wire-key regressions for canonical agreement/disagreement and real plugin-wrapper forwarding

## Contract evidence

Pinned Codex 0.144.1 Stop schema commit: `44918ea10c0f99151c6710411b4322c2f5c96bea`.

Before:
- Autopilot unexpected keys: `canonicalDisagreement`, `statePath`
- document-refresh unexpected key: `hookSpecificOutput`

After:
- Autopilot keys: `decision`, `reason`, `stopReason`, `systemMessage`
- document-refresh keys: `systemMessage`
- unexpected keys: none

## Validation

- [x] `npm ci`
- [x] `npm run build`
- [x] focused compiled native-hook + plugin-layout suites: 513 + 47 passing
- [x] pinned schema red/green fixtures
- [x] `npm run check:no-unused`
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run sync:plugin:check`
- [x] `npm run verify:plugin-bundle`
- [x] `npm run test:recent-bug-regressions:compiled`
- [x] `npm test`
- [x] `npm run test:ci:compiled`
- [x] `git diff --check`
- [x] exact-head cleanup review: zero blockers
- [x] exact-head red-team Architect: CLEAR / APPROVE
- [x] exact-head adversarial Executor QA: passed

`dist/` is ignored build output and was regenerated from source, never staged.

Document-refresh: not-needed | Existing native Stop documentation already states the corrected continuation contract; the patch removes runtime-only protocol fields without changing documented behavior.

## Related

Refs #3113