### PR TITLE
fix(hooks): trust delegated collaboration child provenance under Conductor guard (#3116)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -2,7 +2,8 @@
   "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "files": {
     "includes": ["src/**/*.ts", "bin/**/*.js", "scripts/**/*.js"],
-    "ignoreUnknown": true
+    "ignoreUnknown": true,
+    "maxSize": 2097152
   },
   "linter": {
     "enabled": true,

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -74,12 +74,24 @@ Setup-owned trust state is limited to those generated wrapper identities; user h
 
 The Main-root Conductor write guard blocks source, package, git, and substantive
 plan/spec/review edits from the leader while allowing workflow metadata writes.
-Delegated performer lanes are exempt only when the event is a known typed role
-and trusted lane provenance exists. Native Codex events may provide that
-provenance either through `source.subagent.thread_spawn.parent_thread_id` or
-through an existing `.omx/state/subagent-tracking.json` entry whose `thread_id`
-is recorded as `kind:"subagent"`. A bare typed role on the leader event is not
-enough to bypass the guard.
+Trust for delegated performer lanes is scoped by guard:
+
+- Planning boundary guards (`ralplan`, `deep-interview`) exempt a delegated lane
+  only when the event is a known typed role (catalog-bounded or an installed
+  `*.toml` role) **and** trusted lane provenance exists. This keeps untyped
+  `collaboration.spawn_agent` children from writing source before an execution
+  handoff/approval.
+- The Main-root Conductor / Ralph executing guard additionally trusts a delegated
+  lane on trusted provenance alone, regardless of role label, so native
+  `collaboration.spawn_agent` children and descendants can perform bounded writes
+  during execution (#3116).
+
+Native Codex events may provide that provenance either through
+`source.subagent.thread_spawn.parent_thread_id` or through an existing
+`.omx/state/subagent-tracking.json` entry whose `thread_id` is recorded as
+`kind:"subagent"`. The session leader thread is never trusted through either
+path, so a bare typed role on the leader event — or provenance attached to the
+leader thread — is not enough to bypass the guard.
 
 ## Document-refresh warning MVP
 

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -11814,6 +11814,175 @@ PY`,
     }
   });
 
+  it("keeps untyped collaboration child implementation writes blocked under active ralplan planning while typed trusted agents pass (#3116)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3116-ralplan-untyped-"));
+    process.env.OMX_ROOT = cwd;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-3116-ralplan-untyped";
+      const leaderThreadId = "thread-3116-ralplan-untyped-leader";
+      const childThreadId = "thread-3116-ralplan-untyped-child";
+      const sessionDir = join(stateDir, "sessions", sessionId);
+      const nowIso = new Date().toISOString();
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, native_session_id: leaderThreadId, cwd });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "autopilot",
+        phase: "ralplan",
+        session_id: sessionId,
+        thread_id: leaderThreadId,
+        active_skills: [
+          { skill: "autopilot", phase: "ralplan", active: true, session_id: sessionId, thread_id: leaderThreadId },
+        ],
+      });
+      await writeJson(join(sessionDir, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "ralplan",
+        session_id: sessionId,
+        thread_id: leaderThreadId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: leaderThreadId,
+            updated_at: nowIso,
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "leader", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1 },
+              [childThreadId]: { thread_id: childThreadId, kind: "subagent", mode: "collaboration-child", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1, leader_thread_id: leaderThreadId },
+            },
+          },
+        },
+      });
+
+      // Untyped tracked/spawn-provenance child must NOT bypass the ralplan planning guard.
+      const untypedChild = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: childThreadId,
+          agent_role: "collaboration-child",
+          source: {
+            subagent: { thread_spawn: { parent_thread_id: leaderThreadId } },
+          },
+          tool_name: "Edit",
+          tool_input: { file_path: "src/implementation.ts", old_string: "a", new_string: "b" },
+        },
+        { cwd },
+      );
+      assert.equal(untypedChild.outputJson?.decision, "block");
+
+      // A typed trusted agent retains its existing planning exemption.
+      const typedChild = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: childThreadId,
+          agent_role: "executor",
+          source: {
+            subagent: { thread_spawn: { parent_thread_id: leaderThreadId } },
+          },
+          tool_name: "Edit",
+          tool_input: { file_path: "src/implementation.ts", old_string: "a", new_string: "b" },
+        },
+        { cwd },
+      );
+      assert.equal(typedChild.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps untyped collaboration child implementation writes blocked under active deep-interview planning while typed trusted agents pass (#3116)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3116-di-untyped-"));
+    process.env.OMX_ROOT = cwd;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-3116-di-untyped";
+      const leaderThreadId = "thread-3116-di-untyped-leader";
+      const childThreadId = "thread-3116-di-untyped-child";
+      const sessionDir = join(stateDir, "sessions", sessionId);
+      const nowIso = new Date().toISOString();
+      await mkdir(sessionDir, { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, native_session_id: leaderThreadId, cwd });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "deep-interview",
+        phase: "planning",
+        session_id: sessionId,
+        thread_id: leaderThreadId,
+        active_skills: [
+          { skill: "deep-interview", phase: "planning", active: true, session_id: sessionId, thread_id: leaderThreadId },
+        ],
+      });
+      await writeJson(join(sessionDir, "deep-interview-state.json"), {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+        session_id: sessionId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: leaderThreadId,
+            updated_at: nowIso,
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "leader", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1 },
+              [childThreadId]: { thread_id: childThreadId, kind: "subagent", mode: "collaboration-child", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1, leader_thread_id: leaderThreadId },
+            },
+          },
+        },
+      });
+
+      // Untyped tracked/spawn-provenance child must NOT bypass the deep-interview planning guard.
+      const untypedChild = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: childThreadId,
+          agent_role: "collaboration-child",
+          source: {
+            subagent: { thread_spawn: { parent_thread_id: leaderThreadId } },
+          },
+          tool_name: "Edit",
+          tool_input: { file_path: "src/implementation.ts", old_string: "a", new_string: "b" },
+        },
+        { cwd },
+      );
+      assert.equal(untypedChild.outputJson?.decision, "block");
+
+      // A typed trusted agent retains its existing planning exemption.
+      const typedChild = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: childThreadId,
+          agent_role: "executor",
+          source: {
+            subagent: { thread_spawn: { parent_thread_id: leaderThreadId } },
+          },
+          tool_name: "Edit",
+          tool_input: { file_path: "src/implementation.ts", old_string: "a", new_string: "b" },
+        },
+        { cwd },
+      );
+      assert.equal(typedChild.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("allows null-device fd redirects while deep-interview blocks real Bash writes", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-deep-interview-null-redirect-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -22726,6 +22726,78 @@ PY`,
     }
   });
 
+  it("fails closed when session.json carries only owner session ids without a leader thread anchor (#3117 P4)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3117-owner-only-anchor-"));
+    process.env.OMX_ROOT = cwd;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-3117-p4-owner-only";
+      const leaderThreadId = "thread-3117-p4-leader";
+      const childThreadId = "thread-3117-p4-child";
+      const untrackedThreadId = "thread-3117-p4-untracked";
+      const sessionPath = join(stateDir, "session.json");
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ralph", "executing");
+      await writeJson(join(stateDir, "sessions", sessionId, "ralph-state.json"), {
+        active: true,
+        mode: "ralph",
+        current_phase: "executing",
+        session_id: sessionId,
+      });
+      // Corrupt tracker for the evaluated session: no leader_thread_id, leader mislabeled kind:"subagent".
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "subagent", mode: "collaboration-child" },
+              [childThreadId]: { thread_id: childThreadId, kind: "subagent", mode: "collaboration-child" },
+            },
+          },
+        },
+      });
+
+      const dispatchThread = async (threadId: string) => dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: threadId,
+          tool_name: "apply_patch",
+          tool_input: { file_path: "src/feature.ts" },
+        },
+        { cwd },
+      );
+
+      // session.json maps to the evaluated session via owner ids but has NO
+      // native_session_id: owner session ids are not leader thread anchors, so trust
+      // must fail closed rather than treat their presence as an anchor (#3117 P4).
+      await writeJson(sessionPath, {
+        session_id: sessionId,
+        owner_omx_session_id: "owner-omx-3117-p4",
+        owner_codex_session_id: "owner-codex-3117-p4",
+      });
+      const ownerOnlyLeader = await dispatchThread(leaderThreadId);
+      assert.equal(ownerOnlyLeader.outputJson?.decision, "block");
+      assert.match(String(ownerOnlyLeader.outputJson?.reason ?? ""), /Main-root Conductor mode is active \(ralph phase: executing\)/);
+      // Control: an untracked thread also stays blocked under the same state.
+      const ownerOnlyUntracked = await dispatchThread(untrackedThreadId);
+      assert.equal(ownerOnlyUntracked.outputJson?.decision, "block");
+
+      // Control: once a genuine native_session_id leader thread anchor exists for this
+      // session, the leader is blocked via that anchor while a real child is trusted.
+      await writeJson(sessionPath, { session_id: sessionId, native_session_id: leaderThreadId });
+      const anchoredLeader = await dispatchThread(leaderThreadId);
+      assert.equal(anchoredLeader.outputJson?.decision, "block");
+      assert.match(String(anchoredLeader.outputJson?.reason ?? ""), /Main-root Conductor mode is active \(ralph phase: executing\)/);
+      const anchoredChild = await dispatchThread(childThreadId);
+      assert.equal(anchoredChild.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("blocks conductor writes when thread_spawn provenance is attached to the leader thread", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-conductor-thread-spawn-leader-"));
     const originalOmxRoot = process.env.OMX_ROOT;

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -22541,6 +22541,124 @@ PY`,
     }
   });
 
+  it("blocks a corrupt kind:subagent leader that omits leader_thread_id via native session identity while still trusting a real non-leader child (#3117 P2)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3117-corrupt-leader-no-lead-"));
+    process.env.OMX_ROOT = cwd;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-3117-corrupt-leader-no-lead";
+      const leaderThreadId = "thread-3117-corrupt-leader-no-lead-leader";
+      const childThreadId = "thread-3117-corrupt-leader-no-lead-child";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      // native_session_id anchors the leader identity even though the tracker omits
+      // leader_thread_id and corruptly labels the leader kind:"subagent".
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, native_session_id: leaderThreadId });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ralph", "executing");
+      await writeJson(join(stateDir, "sessions", sessionId, "ralph-state.json"), {
+        active: true,
+        mode: "ralph",
+        current_phase: "executing",
+        session_id: sessionId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "subagent", mode: "collaboration-child" },
+              [childThreadId]: { thread_id: childThreadId, kind: "subagent", mode: "collaboration-child" },
+            },
+          },
+        },
+      });
+
+      // Untyped leader payload must stay blocked: leader identity is anchored to
+      // native_session_id, not the corrupt tracker kind.
+      const untypedLeader = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: leaderThreadId,
+          tool_name: "apply_patch",
+          tool_input: { file_path: "src/feature.ts" },
+        },
+        { cwd },
+      );
+      assert.equal(untypedLeader.outputJson?.decision, "block");
+      assert.match(String(untypedLeader.outputJson?.reason ?? ""), /Main-root Conductor mode is active \(ralph phase: executing\)/);
+
+      // Control: a genuine non-leader child stays trusted (P1 preserved).
+      const untypedChild = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: childThreadId,
+          tool_name: "apply_patch",
+          tool_input: { file_path: "src/feature.ts" },
+        },
+        { cwd },
+      );
+      assert.equal(untypedChild.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for untyped provenance when no authoritative leader anchor exists (#3117 P2)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3117-no-leader-anchor-"));
+    process.env.OMX_ROOT = cwd;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-3117-no-leader-anchor";
+      const leaderThreadId = "thread-3117-no-leader-anchor-leader";
+      const childThreadId = "thread-3117-no-leader-anchor-child";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      // No native_session_id / owner ids and no tracker leader_thread_id: the leader is
+      // unidentifiable, so untyped provenance must not be inferred from kind:"subagent".
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ralph", "executing");
+      await writeJson(join(stateDir, "sessions", sessionId, "ralph-state.json"), {
+        active: true,
+        mode: "ralph",
+        current_phase: "executing",
+        session_id: sessionId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "subagent", mode: "collaboration-child" },
+              [childThreadId]: { thread_id: childThreadId, kind: "subagent", mode: "collaboration-child" },
+            },
+          },
+        },
+      });
+
+      for (const threadId of [leaderThreadId, childThreadId]) {
+        const result = await dispatchCodexNativeHook(
+          {
+            hook_event_name: "PreToolUse",
+            cwd,
+            session_id: sessionId,
+            thread_id: threadId,
+            tool_name: "apply_patch",
+            tool_input: { file_path: "src/feature.ts" },
+          },
+          { cwd },
+        );
+        assert.equal(result.outputJson?.decision, "block", threadId);
+        assert.match(String(result.outputJson?.reason ?? ""), /Main-root Conductor mode is active \(ralph phase: executing\)/);
+      }
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("blocks conductor writes when thread_spawn provenance is attached to the leader thread", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-conductor-thread-spawn-leader-"));
     const originalOmxRoot = process.env.OMX_ROOT;

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -22659,6 +22659,73 @@ PY`,
     }
   });
 
+  it("does not borrow leader anchors from a foreign root session.json when evaluating another session (#3117 P3)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3117-cross-session-anchor-"));
+    process.env.OMX_ROOT = cwd;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const foreignSessionId = "sess-3117-p3-foreign-A";
+      const foreignLeaderThreadId = "thread-3117-p3-A-leader";
+      const sessionId = "sess-3117-p3-checked-B";
+      const leaderThreadId = "thread-3117-p3-B-leader";
+      const childThreadId = "thread-3117-p3-B-child";
+      const sessionPath = join(stateDir, "session.json");
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ralph", "executing");
+      await writeJson(join(stateDir, "sessions", sessionId, "ralph-state.json"), {
+        active: true,
+        mode: "ralph",
+        current_phase: "executing",
+        session_id: sessionId,
+      });
+      // Evaluated session B has a corrupt tracker: no leader_thread_id, leader mislabeled kind:"subagent".
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "subagent", mode: "collaboration-child" },
+              [childThreadId]: { thread_id: childThreadId, kind: "subagent", mode: "collaboration-child" },
+            },
+          },
+        },
+      });
+
+      const dispatchThread = async (threadId: string) => dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: threadId,
+          tool_name: "apply_patch",
+          tool_input: { file_path: "src/feature.ts" },
+        },
+        { cwd },
+      );
+
+      // Root session.json owns a DIFFERENT session A: its native/owner ids must not
+      // anchor session B, so B's mislabeled leader stays blocked (fail closed).
+      await writeJson(sessionPath, { session_id: foreignSessionId, native_session_id: foreignLeaderThreadId });
+      const foreignLeader = await dispatchThread(leaderThreadId);
+      assert.equal(foreignLeader.outputJson?.decision, "block");
+      assert.match(String(foreignLeader.outputJson?.reason ?? ""), /Main-root Conductor mode is active \(ralph phase: executing\)/);
+      const foreignChild = await dispatchThread(childThreadId);
+      assert.equal(foreignChild.outputJson?.decision, "block");
+
+      // Control: when the root session.json owns the evaluated session B, its
+      // native_session_id anchors the leader (blocked) while a genuine child is trusted.
+      await writeJson(sessionPath, { session_id: sessionId, native_session_id: leaderThreadId });
+      const ownedLeader = await dispatchThread(leaderThreadId);
+      assert.equal(ownedLeader.outputJson?.decision, "block");
+      assert.match(String(ownedLeader.outputJson?.reason ?? ""), /Main-root Conductor mode is active \(ralph phase: executing\)/);
+      const ownedChild = await dispatchThread(childThreadId);
+      assert.equal(ownedChild.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("blocks conductor writes when thread_spawn provenance is attached to the leader thread", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-conductor-thread-spawn-leader-"));
     const originalOmxRoot = process.env.OMX_ROOT;

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -22441,6 +22441,434 @@ PY`,
     }
   });
 
+  it("denies Main-root conductor apply_patch from the session leader thread during active Ralph (#3116)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3116-root-denial-"));
+    process.env.OMX_ROOT = cwd;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-3116-root-denial";
+      const leaderThreadId = "thread-3116-root-denial-leader";
+      const nowIso = new Date().toISOString();
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, native_session_id: leaderThreadId });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ralph", "executing");
+      await writeJson(join(stateDir, "sessions", sessionId, "ralph-state.json"), {
+        active: true,
+        mode: "ralph",
+        current_phase: "executing",
+        session_id: sessionId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: leaderThreadId,
+            updated_at: nowIso,
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "leader", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1 },
+            },
+          },
+        },
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: leaderThreadId,
+          tool_name: "apply_patch",
+          tool_input: { file_path: "src/feature.ts" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /Main-root Conductor mode is active \(ralph phase: executing\)/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows apply_patch from an untyped collaboration.spawn_agent child tracked as a subagent during active Ralph (#3116)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3116-trusted-child-"));
+    process.env.OMX_ROOT = cwd;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-3116-trusted-child";
+      const leaderThreadId = "thread-3116-trusted-child-leader";
+      const childThreadId = "thread-3116-trusted-child-worker";
+      const nowIso = new Date().toISOString();
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, native_session_id: leaderThreadId });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ralph", "executing");
+      await writeJson(join(stateDir, "sessions", sessionId, "ralph-state.json"), {
+        active: true,
+        mode: "ralph",
+        current_phase: "executing",
+        session_id: sessionId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: leaderThreadId,
+            updated_at: nowIso,
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "leader", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1 },
+              [childThreadId]: { thread_id: childThreadId, kind: "subagent", mode: "collaboration-child", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1, leader_thread_id: leaderThreadId },
+            },
+          },
+        },
+      });
+
+      // Untyped role (not in the typed-agent catalog) must not defeat tracker-backed trust.
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: childThreadId,
+          agent_role: "collaboration-child",
+          source: {
+            subagent: {
+              thread_spawn: {
+                parent_thread_id: leaderThreadId,
+                depth: 1,
+                agent_nickname: "Helper",
+              },
+            },
+          },
+          tool_name: "apply_patch",
+          tool_input: { file_path: "src/feature.ts" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows apply_patch from untyped collaboration descendants via tracked thread and tracked parent chain (#3116)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3116-descendant-"));
+    process.env.OMX_ROOT = cwd;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-3116-descendant";
+      const leaderThreadId = "thread-3116-descendant-leader";
+      const childThreadId = "thread-3116-descendant-child";
+      const grandchildThreadId = "thread-3116-descendant-grandchild";
+      const greatGrandchildThreadId = "thread-3116-descendant-great-grandchild";
+      const nowIso = new Date().toISOString();
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, native_session_id: leaderThreadId });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ralph", "executing");
+      await writeJson(join(stateDir, "sessions", sessionId, "ralph-state.json"), {
+        active: true,
+        mode: "ralph",
+        current_phase: "executing",
+        session_id: sessionId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: leaderThreadId,
+            updated_at: nowIso,
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "leader", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1 },
+              [childThreadId]: { thread_id: childThreadId, kind: "subagent", mode: "collaboration-child", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1, leader_thread_id: leaderThreadId },
+              [grandchildThreadId]: { thread_id: grandchildThreadId, kind: "subagent", mode: "collaboration-child", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1, leader_thread_id: childThreadId },
+            },
+          },
+        },
+      });
+
+      // (a) A descendant whose own thread is tracked as a subagent is trusted directly.
+      const trackedDescendant = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: grandchildThreadId,
+          tool_name: "apply_patch",
+          tool_input: { file_path: "src/feature.ts" },
+        },
+        { cwd },
+      );
+      assert.equal(trackedDescendant.outputJson, null);
+
+      // (b) A not-yet-tracked descendant is trusted when its runtime spawn parent is a tracked thread.
+      const chainedDescendant = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: greatGrandchildThreadId,
+          agent_role: "collaboration-child",
+          source: {
+            subagent: {
+              thread_spawn: {
+                parent_thread_id: grandchildThreadId,
+                depth: 3,
+              },
+            },
+          },
+          tool_name: "apply_patch",
+          tool_input: { file_path: "src/feature.ts" },
+        },
+        { cwd },
+      );
+      assert.equal(chainedDescendant.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves the session-pinned Ralph state so collaboration children edit while the leader stays blocked (#3116)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3116-pinned-state-"));
+    process.env.OMX_ROOT = cwd;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-3116-pinned-state";
+      const leaderThreadId = "thread-3116-pinned-state-leader";
+      const childThreadId = "thread-3116-pinned-state-child";
+      const nowIso = new Date().toISOString();
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      // Native session id differs from the canonical session id: the guard must resolve it.
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, native_session_id: leaderThreadId });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ralph", "executing");
+      const ralphStatePath = join(stateDir, "sessions", sessionId, "ralph-state.json");
+      await writeJson(ralphStatePath, {
+        active: true,
+        mode: "ralph",
+        current_phase: "executing",
+        session_id: sessionId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: leaderThreadId,
+            updated_at: nowIso,
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "leader", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1 },
+              [childThreadId]: { thread_id: childThreadId, kind: "subagent", mode: "collaboration-child", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1, leader_thread_id: leaderThreadId },
+            },
+          },
+        },
+      });
+
+      // Payload carries the native session id, which must map to the canonical session.
+      const childEdit = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: leaderThreadId,
+          thread_id: childThreadId,
+          tool_name: "apply_patch",
+          tool_input: { file_path: "src/feature.ts" },
+        },
+        { cwd },
+      );
+      assert.equal(childEdit.outputJson, null);
+
+      const leaderEdit = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: leaderThreadId,
+          thread_id: leaderThreadId,
+          tool_name: "apply_patch",
+          tool_input: { file_path: "src/feature.ts" },
+        },
+        { cwd },
+      );
+      assert.equal(leaderEdit.outputJson?.decision, "block");
+      assert.match(String(leaderEdit.outputJson?.reason ?? ""), /Main-root Conductor mode is active \(ralph phase: executing\)/);
+
+      // The guard reads the session-pinned phase: flipping it to "starting" releases the leader too.
+      await writeJson(ralphStatePath, {
+        active: true,
+        mode: "ralph",
+        current_phase: "starting",
+        session_id: sessionId,
+      });
+      const leaderEditAfterStarting = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: leaderThreadId,
+          thread_id: leaderThreadId,
+          tool_name: "apply_patch",
+          tool_input: { file_path: "src/feature.ts" },
+        },
+        { cwd },
+      );
+      assert.equal(leaderEditAfterStarting.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("trusts the native collaboration.spawn_agent child surface via runtime spawn provenance during active Ralph (#3116)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3116-collab-surface-"));
+    process.env.OMX_ROOT = cwd;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-3116-collab-surface";
+      const leaderThreadId = "thread-3116-collab-surface-leader";
+      const childThreadId = "thread-3116-collab-surface-child";
+      const nowIso = new Date().toISOString();
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, native_session_id: leaderThreadId });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ralph", "executing");
+      await writeJson(join(stateDir, "sessions", sessionId, "ralph-state.json"), {
+        active: true,
+        mode: "ralph",
+        current_phase: "executing",
+        session_id: sessionId,
+      });
+      // Child SessionStart has not been recorded yet: only the leader is tracked.
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: leaderThreadId,
+            updated_at: nowIso,
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "leader", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1 },
+            },
+          },
+        },
+      });
+
+      // No typed agent_role at all: a raw collaboration.spawn_agent child payload shape.
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: childThreadId,
+          source: {
+            subagent: {
+              thread_spawn: {
+                parent_thread_id: leaderThreadId,
+                depth: 1,
+                agent_nickname: "Implementer",
+              },
+            },
+          },
+          tool_name: "apply_patch",
+          tool_input: { file_path: "src/feature.ts" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("denies spoofed or untrusted collaboration provenance while the main root stays protected during active Ralph (#3116)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3116-spoof-denial-"));
+    process.env.OMX_ROOT = cwd;
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-3116-spoof-denial";
+      const leaderThreadId = "thread-3116-spoof-denial-leader";
+      const nowIso = new Date().toISOString();
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId, native_session_id: leaderThreadId });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ralph", "executing");
+      await writeJson(join(stateDir, "sessions", sessionId, "ralph-state.json"), {
+        active: true,
+        mode: "ralph",
+        current_phase: "executing",
+        session_id: sessionId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: leaderThreadId,
+            updated_at: nowIso,
+            threads: {
+              [leaderThreadId]: { thread_id: leaderThreadId, kind: "leader", first_seen_at: nowIso, last_seen_at: nowIso, turn_count: 1 },
+            },
+          },
+        },
+      });
+
+      // (a) Untracked thread whose declared parent is neither the leader nor a tracked thread.
+      const orphanParent = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-3116-spoof-orphan",
+          agent_role: "collaboration-child",
+          source: {
+            subagent: {
+              thread_spawn: { parent_thread_id: "thread-3116-spoof-outsider" },
+            },
+          },
+          tool_name: "apply_patch",
+          tool_input: { file_path: "src/feature.ts" },
+        },
+        { cwd },
+      );
+      assert.equal(orphanParent.outputJson?.decision, "block");
+      assert.match(String(orphanParent.outputJson?.reason ?? ""), /Main-root Conductor mode is active \(ralph phase: executing\)/);
+
+      // (b) Untyped child with no provenance at all (no tracker thread, no spawn source).
+      const noProvenance = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-3116-spoof-bare",
+          agent_role: "collaboration-child",
+          tool_name: "apply_patch",
+          tool_input: { file_path: "src/feature.ts" },
+        },
+        { cwd },
+      );
+      assert.equal(noProvenance.outputJson?.decision, "block");
+
+      // (c) Spawn provenance attached to the leader thread cannot promote the main root.
+      const leaderSelfSpawn = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: leaderThreadId,
+          agent_role: "collaboration-child",
+          source: {
+            subagent: {
+              thread_spawn: { parent_thread_id: leaderThreadId },
+            },
+          },
+          tool_name: "apply_patch",
+          tool_input: { file_path: "src/feature.ts" },
+        },
+        { cwd },
+      );
+      assert.equal(leaderSelfSpawn.outputJson?.decision, "block");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("blocks Main-root ralph conductor source and planning artifact writes while allowing .omx workflow state writes", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralph-conductor-write-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -7214,6 +7214,7 @@ async function hasTrustedTypedSubagentProvenanceForPreToolUse(
   payload: CodexHookPayload,
   cwd: string,
   sessionId: string,
+  options: { allowUntypedProvenance?: boolean } = {},
 ): Promise<boolean> {
   if (hasTeamWorkerEnvironment()) return true;
   const trackingState = await readSubagentTrackingState(cwd).catch(() => null);
@@ -7227,12 +7228,20 @@ async function hasTrustedTypedSubagentProvenanceForPreToolUse(
   // payload provenance is (possibly corruptly) attached to the leader thread.
   if (payloadThreadId && leaderThreadId && payloadThreadId === leaderThreadId) return false;
 
+  // Planning boundary guards (ralplan, deep-interview) still require a recognized
+  // typed agent role, so an untyped collaboration.spawn_agent child cannot write
+  // before an execution handoff/approval. Only the Main-root Conductor/Ralph
+  // executing guard opts into untyped tracker/runtime provenance (#3116, #3117).
+  if (options.allowUntypedProvenance !== true && !isTypedAgentRolePayload(payload)) {
+    return false;
+  }
+
   // Tracker-backed provenance: the payload's own thread is a recorded, non-leader
   // subagent for this session. This is the non-spoofable trust anchor that lets
-  // native collaboration.spawn_agent children and their descendants edit even when
-  // they carry no recognized typed agent role (#3116). subagent-tracking.json is
-  // derived from child SessionStart transcript metadata, not the live tool-call
-  // payload, so a delegated executor is recognized regardless of its role label.
+  // native collaboration.spawn_agent children and their descendants edit under the
+  // Conductor guard even when they carry no recognized typed agent role (#3116).
+  // subagent-tracking.json is derived from child SessionStart transcript metadata,
+  // not the live tool-call payload.
   if (payloadThreadId && isTrustedSubagentThread(session, payloadThreadId)) return true;
 
   // Runtime-attached spawn provenance: trust a genuine spawned subagent turn whose
@@ -7240,8 +7249,7 @@ async function hasTrustedTypedSubagentProvenanceForPreToolUse(
   // comes from the runtime-set source.subagent.thread_spawn (not agent-controlled tool
   // arguments); an absent parent is rejected, the leader self-guard above blocks the
   // main root, and cross-session parents fail because they are not in this session's
-  // tracked threads (#3116). Recognized typed roles and untyped collaboration children
-  // are trusted through the same provenance check.
+  // tracked threads (#3116).
   const source = safeObject(payload.source);
   const subagent = safeObject(source.subagent);
   const threadSpawn = safeObject(subagent.thread_spawn);
@@ -7281,7 +7289,7 @@ async function readActiveMainRootConductorStateForPreToolUse(
   }
   const threadId = readPayloadThreadId(payload);
   if (!sessionId) return null;
-  if (await hasTrustedTypedSubagentProvenanceForPreToolUse(payload, cwd, sessionId)) return null;
+  if (await hasTrustedTypedSubagentProvenanceForPreToolUse(payload, cwd, sessionId, { allowUntypedProvenance: true })) return null;
 
   const canonicalState = await readVisibleSkillActiveStateForStateDir(stateDir, sessionId);
   if (!canonicalState) return null;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -7224,21 +7224,26 @@ async function hasTrustedTypedSubagentProvenanceForPreToolUse(
 
   const payloadThreadId = readPayloadThreadId(payload);
 
-  // Resolve the Main-root leader identity from BOTH the tracker's leader_thread_id and
-  // the canonical session's runtime identity (session.json native/owner ids). The
-  // tracker alone is insufficient: it can omit leader_thread_id or corruptly label the
-  // leader kind:"subagent", so leader identity is anchored to runtime-set session
-  // evidence that the agent does not control (#3117 P2).
+  // Resolve the Main-root leader identity from the tracker's leader_thread_id plus the
+  // canonical session's runtime identity (session.json native/owner ids). The tracker
+  // alone is insufficient: it can omit leader_thread_id or corruptly label the leader
+  // kind:"subagent", so leader identity is anchored to runtime-set session evidence the
+  // agent does not control (#3117 P2). The session.json anchors are only folded in when
+  // that root session pointer provably maps to the sessionId under evaluation; a
+  // stale/foreign session.json (a session-replacement state this hook handles elsewhere)
+  // must not supply another session's leader anchors here (#3117 P3).
   const sessionState = await readRootSessionStateFromStateDir(stateDir).catch(() => null);
   const trackerLeaderThreadId = safeString(session.leader_thread_id).trim();
   const leaderIdentityAnchors = new Set<string>();
-  for (const anchor of [
-    trackerLeaderThreadId,
-    safeString(sessionState?.native_session_id).trim(),
-    safeString(sessionState?.owner_codex_session_id).trim(),
-    safeString(sessionState?.owner_omx_session_id).trim(),
-  ]) {
-    if (anchor) leaderIdentityAnchors.add(anchor);
+  if (trackerLeaderThreadId) leaderIdentityAnchors.add(trackerLeaderThreadId);
+  if (sessionState && sessionId && payloadMatchesSessionPointer(sessionId, sessionState)) {
+    for (const anchor of [
+      safeString(sessionState.native_session_id).trim(),
+      safeString(sessionState.owner_codex_session_id).trim(),
+      safeString(sessionState.owner_omx_session_id).trim(),
+    ]) {
+      if (anchor) leaderIdentityAnchors.add(anchor);
+    }
   }
 
   // Leader self-guard: the Main-root Conductor is never a delegated executor. Block it

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -6974,7 +6974,7 @@ async function buildRalplanPreToolUseBoundaryOutput(
   resolvedSessionId?: string,
 ): Promise<Record<string, unknown> | null> {
   const sessionId = safeString(resolvedSessionId ?? readPayloadSessionId(payload)).trim();
-  if (await hasTrustedTypedSubagentProvenanceForPreToolUse(payload, cwd, sessionId)) return null;
+  if (await hasTrustedTypedSubagentProvenanceForPreToolUse(payload, cwd, stateDir, sessionId)) return null;
   const threadId = readPayloadThreadId(payload);
   const activeState = await readActiveRalplanStateForPreToolUse(cwd, stateDir, sessionId, threadId);
   if (!activeState) return null;
@@ -7042,7 +7042,7 @@ async function buildDeepInterviewPreToolUseBoundaryOutput(
   resolvedSessionId?: string,
 ): Promise<Record<string, unknown> | null> {
   const sessionId = safeString(resolvedSessionId ?? readPayloadSessionId(payload)).trim();
-  if (await hasTrustedTypedSubagentProvenanceForPreToolUse(payload, cwd, sessionId)) return null;
+  if (await hasTrustedTypedSubagentProvenanceForPreToolUse(payload, cwd, stateDir, sessionId)) return null;
   const threadId = readPayloadThreadId(payload);
   const activeState = await readActiveDeepInterviewStateForPreToolUse(cwd, stateDir, sessionId, threadId);
   if (!activeState) return null;
@@ -7213,6 +7213,7 @@ interface ActiveConductorState {
 async function hasTrustedTypedSubagentProvenanceForPreToolUse(
   payload: CodexHookPayload,
   cwd: string,
+  stateDir: string,
   sessionId: string,
   options: { allowUntypedProvenance?: boolean } = {},
 ): Promise<boolean> {
@@ -7222,26 +7223,47 @@ async function hasTrustedTypedSubagentProvenanceForPreToolUse(
   if (!session) return false;
 
   const payloadThreadId = readPayloadThreadId(payload);
-  const leaderThreadId = safeString(session.leader_thread_id).trim();
-  // The Main-root Conductor (the session leader thread) is never a delegated
-  // executor. Protect it ahead of every trust path below, even when tracker or
-  // payload provenance is (possibly corruptly) attached to the leader thread.
-  if (payloadThreadId && leaderThreadId && payloadThreadId === leaderThreadId) return false;
 
-  // Planning boundary guards (ralplan, deep-interview) still require a recognized
-  // typed agent role, so an untyped collaboration.spawn_agent child cannot write
-  // before an execution handoff/approval. Only the Main-root Conductor/Ralph
-  // executing guard opts into untyped tracker/runtime provenance (#3116, #3117).
+  // Resolve the Main-root leader identity from BOTH the tracker's leader_thread_id and
+  // the canonical session's runtime identity (session.json native/owner ids). The
+  // tracker alone is insufficient: it can omit leader_thread_id or corruptly label the
+  // leader kind:"subagent", so leader identity is anchored to runtime-set session
+  // evidence that the agent does not control (#3117 P2).
+  const sessionState = await readRootSessionStateFromStateDir(stateDir).catch(() => null);
+  const trackerLeaderThreadId = safeString(session.leader_thread_id).trim();
+  const leaderIdentityAnchors = new Set<string>();
+  for (const anchor of [
+    trackerLeaderThreadId,
+    safeString(sessionState?.native_session_id).trim(),
+    safeString(sessionState?.owner_codex_session_id).trim(),
+    safeString(sessionState?.owner_omx_session_id).trim(),
+  ]) {
+    if (anchor) leaderIdentityAnchors.add(anchor);
+  }
+
+  // Leader self-guard: the Main-root Conductor is never a delegated executor. Block it
+  // ahead of every trust path, even when tracker or payload provenance is (possibly
+  // corruptly) attached to the leader thread.
+  if (payloadThreadId && leaderIdentityAnchors.has(payloadThreadId)) return false;
+
+  // Fail closed: without an authoritative leader anchor we cannot affirm the payload is
+  // a non-leader delegated performer rather than a mislabeled leader, so we refuse trust
+  // instead of inferring it from a corrupt tracker kind:"subagent" alone (#3117 P2).
+  if (leaderIdentityAnchors.size === 0) return false;
+
+  // Planning boundary guards (ralplan, deep-interview) still require a recognized typed
+  // agent role, so an untyped collaboration.spawn_agent child cannot write before an
+  // execution handoff/approval. Only the Main-root Conductor/Ralph executing guard opts
+  // into untyped tracker/runtime provenance (#3116, #3117).
   if (options.allowUntypedProvenance !== true && !isTypedAgentRolePayload(payload)) {
     return false;
   }
 
   // Tracker-backed provenance: the payload's own thread is a recorded, non-leader
-  // subagent for this session. This is the non-spoofable trust anchor that lets
-  // native collaboration.spawn_agent children and their descendants edit under the
-  // Conductor guard even when they carry no recognized typed agent role (#3116).
-  // subagent-tracking.json is derived from child SessionStart transcript metadata,
-  // not the live tool-call payload.
+  // subagent for this session — the non-spoofable anchor that lets native
+  // collaboration.spawn_agent children/descendants edit under the Conductor guard even
+  // without a recognized typed role (#3116). subagent-tracking.json is derived from
+  // child SessionStart transcript metadata, not the live tool-call payload.
   if (payloadThreadId && isTrustedSubagentThread(session, payloadThreadId)) return true;
 
   // Runtime-attached spawn provenance: trust a genuine spawned subagent turn whose
@@ -7260,7 +7282,7 @@ async function hasTrustedTypedSubagentProvenanceForPreToolUse(
       ?? threadSpawn.leaderThreadId,
   ).trim();
   if (!parentThreadId) return false;
-  return leaderThreadId === parentThreadId || parentThreadId in session.threads;
+  return leaderIdentityAnchors.has(parentThreadId) || parentThreadId in session.threads;
 }
 
 function isActiveConductorModeState(state: Record<string, unknown> | null, mode: string, sessionId: string): boolean {
@@ -7289,7 +7311,7 @@ async function readActiveMainRootConductorStateForPreToolUse(
   }
   const threadId = readPayloadThreadId(payload);
   if (!sessionId) return null;
-  if (await hasTrustedTypedSubagentProvenanceForPreToolUse(payload, cwd, sessionId, { allowUntypedProvenance: true })) return null;
+  if (await hasTrustedTypedSubagentProvenanceForPreToolUse(payload, cwd, stateDir, sessionId, { allowUntypedProvenance: true })) return null;
 
   const canonicalState = await readVisibleSkillActiveStateForStateDir(stateDir, sessionId);
   if (!canonicalState) return null;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -7224,26 +7224,23 @@ async function hasTrustedTypedSubagentProvenanceForPreToolUse(
 
   const payloadThreadId = readPayloadThreadId(payload);
 
-  // Resolve the Main-root leader identity from the tracker's leader_thread_id plus the
-  // canonical session's runtime identity (session.json native/owner ids). The tracker
-  // alone is insufficient: it can omit leader_thread_id or corruptly label the leader
-  // kind:"subagent", so leader identity is anchored to runtime-set session evidence the
-  // agent does not control (#3117 P2). The session.json anchors are only folded in when
-  // that root session pointer provably maps to the sessionId under evaluation; a
-  // stale/foreign session.json (a session-replacement state this hook handles elsewhere)
-  // must not supply another session's leader anchors here (#3117 P3).
+  // Resolve the Main-root leader THREAD identity from the tracker's leader_thread_id
+  // plus the canonical session's native_session_id (the leader's native thread). Only
+  // genuine leader-thread identifiers may anchor the leader: owner_*_session_id are
+  // session-level ids, not thread anchors, so they must NOT populate this set — their
+  // mere presence would make it non-empty and suppress the fail-closed guard below
+  // without ever excluding the leader thread (#3117 P4). The native_session_id anchor is
+  // honored only when the root session pointer provably maps to the sessionId under
+  // evaluation, so a stale/foreign session.json cannot supply another session's leader
+  // anchor (#3117 P3); the tracker alone is insufficient because it can omit
+  // leader_thread_id or corruptly label the leader kind:"subagent" (#3117 P2).
   const sessionState = await readRootSessionStateFromStateDir(stateDir).catch(() => null);
   const trackerLeaderThreadId = safeString(session.leader_thread_id).trim();
   const leaderIdentityAnchors = new Set<string>();
   if (trackerLeaderThreadId) leaderIdentityAnchors.add(trackerLeaderThreadId);
   if (sessionState && sessionId && payloadMatchesSessionPointer(sessionId, sessionState)) {
-    for (const anchor of [
-      safeString(sessionState.native_session_id).trim(),
-      safeString(sessionState.owner_codex_session_id).trim(),
-      safeString(sessionState.owner_omx_session_id).trim(),
-    ]) {
-      if (anchor) leaderIdentityAnchors.add(anchor);
-    }
+    const nativeSessionId = safeString(sessionState.native_session_id).trim();
+    if (nativeSessionId) leaderIdentityAnchors.add(nativeSessionId);
   }
 
   // Leader self-guard: the Main-root Conductor is never a delegated executor. Block it

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -7216,14 +7216,32 @@ async function hasTrustedTypedSubagentProvenanceForPreToolUse(
   sessionId: string,
 ): Promise<boolean> {
   if (hasTeamWorkerEnvironment()) return true;
-  if (!isTypedAgentRolePayload(payload)) return false;
   const trackingState = await readSubagentTrackingState(cwd).catch(() => null);
   const session = trackingState?.sessions?.[sessionId];
   if (!session) return false;
 
   const payloadThreadId = readPayloadThreadId(payload);
+  const leaderThreadId = safeString(session.leader_thread_id).trim();
+  // The Main-root Conductor (the session leader thread) is never a delegated
+  // executor. Protect it ahead of every trust path below, even when tracker or
+  // payload provenance is (possibly corruptly) attached to the leader thread.
+  if (payloadThreadId && leaderThreadId && payloadThreadId === leaderThreadId) return false;
+
+  // Tracker-backed provenance: the payload's own thread is a recorded, non-leader
+  // subagent for this session. This is the non-spoofable trust anchor that lets
+  // native collaboration.spawn_agent children and their descendants edit even when
+  // they carry no recognized typed agent role (#3116). subagent-tracking.json is
+  // derived from child SessionStart transcript metadata, not the live tool-call
+  // payload, so a delegated executor is recognized regardless of its role label.
   if (payloadThreadId && isTrustedSubagentThread(session, payloadThreadId)) return true;
 
+  // Runtime-attached spawn provenance: trust a genuine spawned subagent turn whose
+  // declared parent maps to this session's leader or a tracked thread. parentThreadId
+  // comes from the runtime-set source.subagent.thread_spawn (not agent-controlled tool
+  // arguments); an absent parent is rejected, the leader self-guard above blocks the
+  // main root, and cross-session parents fail because they are not in this session's
+  // tracked threads (#3116). Recognized typed roles and untyped collaboration children
+  // are trusted through the same provenance check.
   const source = safeObject(payload.source);
   const subagent = safeObject(source.subagent);
   const threadSpawn = safeObject(subagent.thread_spawn);
@@ -7234,8 +7252,6 @@ async function hasTrustedTypedSubagentProvenanceForPreToolUse(
       ?? threadSpawn.leaderThreadId,
   ).trim();
   if (!parentThreadId) return false;
-  const leaderThreadId = safeString(session.leader_thread_id).trim();
-  if (payloadThreadId && leaderThreadId && payloadThreadId === leaderThreadId) return false;
   return leaderThreadId === parentThreadId || parentThreadId in session.threads;
 }
 


### PR DESCRIPTION
## Summary

Fixes #3116. During an active Ralph run on the Codex App native-hook surface (outside tmux), `collaboration.spawn_agent` child agents and their descendants could inspect files and run commands but every `apply_patch` was denied with:

```
Main-root Conductor mode is active (ralph phase: executing)
```

### Root cause

`hasTrustedTypedSubagentProvenanceForPreToolUse` (in `src/scripts/codex-native-hook.ts`) gated **all** provenance recognition behind `isTypedAgentRolePayload`, which only matches the fixed typed-agent catalog (`executor`, `architect`, `critic`, …). Collaboration children carry arbitrary or absent role labels, so their legitimately tracker-backed subagent provenance (`kind: "subagent"` in `subagent-tracking.json`, populated from child SessionStart transcript metadata) was never consulted — they fell through to the Main-root Conductor guard and were blocked, even though they are not the leader. The guard reads the session-pinned `ralph-state.json`, which is why changing the session-pinned `current_phase` unblocked edits but changing the root mirror did not.

### Fix

Trust is now anchored on non-spoofable provenance, independent of the typed-role catalog:

1. **Leader self-guard first** — if the payload thread is the session leader, it is never trusted (main-root stays protected, even against corrupt tracker labels or leader-attached `thread_spawn`).
2. **Tracker-backed provenance** — a recorded non-leader `subagent` thread for this session is trusted regardless of role label. This covers collaboration children and descendants (each is recorded on its own SessionStart). `subagent-tracking.json` is derived from transcript metadata, not the live tool-call payload.
3. **Runtime spawn provenance** — a genuine `source.subagent.thread_spawn` parent mapping to the session leader or a tracked thread is trusted. The parent is runtime-set (not agent-controlled), absent parents are rejected, and cross-session parents fail because they are not in this session's tracked threads.

This does not broadly weaken the guard, trust environment flags, or accept spoofable provenance: the main root is always protected, and only delegated, session-scoped subagents gain bounded write access. `isTypedAgentRolePayload` remains used by other call sites, so no dead code.

## Tests

Added six focused regression tests in `src/scripts/__tests__/codex-native-hook.test.ts`:

- root denial (leader thread stays blocked during `ralph` `executing`)
- trusted untyped collaboration child allowance (tracker-backed)
- descendant behavior (tracked own thread **and** tracked parent chain)
- session-pinned Ralph state resolution (native→canonical session mapping; child edits while leader blocked; flipping the pinned phase to `starting` releases the leader — mirroring the reporter's workaround)
- native `collaboration.spawn_agent` surface (runtime spawn provenance, no typed role)
- spoof/untrusted denial (orphan parent, no provenance, leader-attached spawn)

## Verification

- `npm run build` — clean
- `npm run lint` — clean
- `npm run check:no-unused` — clean
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js` — 519 pass / 0 fail
- `npm run test:recent-bug-regressions:compiled` — all suites pass
- `npm run test:explicit-terminal-contract:compiled` — all suites pass

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
