### PR TITLE
fix(leader): detect native delegation presence and stop misparsing quoted Bash write targets (#3119)

### DIFF
--- a/src/leader/__tests__/contract.test.ts
+++ b/src/leader/__tests__/contract.test.ts
@@ -112,10 +112,14 @@ describe('leader conductor contract', () => {
       }).status,
       'unsupported',
     );
-    assert.equal(
-      resolveNativeSubagentSupportStatus({ payload: { available_tools: ['Read', 'Edit'] } }).reason,
-      'multi_agent_v1_unavailable',
-    );
+    // #3119: a present-but-incomplete tool inventory is NOT explicit negative
+    // evidence. It must resolve to `unknown` (never `unsupported`), and carry
+    // observed-name provenance for diagnosis.
+    const incompleteInventory = resolveNativeSubagentSupportStatus({ payload: { available_tools: ['Read', 'Edit'] } });
+    assert.equal(incompleteInventory.status, 'unknown');
+    assert.equal(incompleteInventory.reason, undefined);
+    assert.equal(incompleteInventory.source, 'hook_payload_available_tools');
+    assert.equal(incompleteInventory.evidenceSummary, 'Read, Edit');
     assert.equal(
       resolveNativeSubagentSupportStatus({ payload: {} }).status,
       'unknown',
@@ -123,6 +127,59 @@ describe('leader conductor contract', () => {
     assert.equal(
       resolveNativeSubagentSupportStatus({ payload: { available_tools: ['Read', 'multi_agent_v1.spawn_agent'] } }).status,
       'supported',
+    );
+  });
+
+  it('recognizes namespaced collaboration spawn tools and rejects near-miss names (#3119)', () => {
+    // Terminology drift: the current Codex App surface exposes delegation as
+    // `collaboration.spawn_agent`. Presence of any namespaced spawn tool (or the
+    // legacy `task` alias) is native delegation support.
+    for (const toolName of ['collaboration.spawn_agent', 'spawn_agent', 'multi_agent_v1.spawn_agent', 'task']) {
+      assert.equal(
+        resolveNativeSubagentSupportStatus({ payload: { available_tools: ['Read', toolName] } }).status,
+        'supported',
+        toolName,
+      );
+    }
+    // Object-form tool descriptors are recognized by name.
+    assert.equal(
+      resolveNativeSubagentSupportStatus({ payload: { available_tools: [{ name: 'collaboration.spawn_agent' }] } }).status,
+      'supported',
+    );
+    // Companion collaboration tools without a spawn tool are not, by themselves,
+    // proof of support: absence of a spawn surface stays `unknown`, not `unsupported`.
+    const companionsOnly = resolveNativeSubagentSupportStatus({
+      payload: { available_tools: ['collaboration.followup_task', 'collaboration.wait_agent'] },
+    });
+    assert.equal(companionsOnly.status, 'unknown');
+    assert.equal(companionsOnly.reason, undefined);
+    // Near-miss names must NOT be treated as spawn tools.
+    for (const toolName of ['respawn_agent', 'spawn_agentx', 'agent', 'spawn_agent_helper']) {
+      assert.equal(
+        resolveNativeSubagentSupportStatus({ payload: { available_tools: ['Read', toolName] } }).status,
+        'unknown',
+        toolName,
+      );
+    }
+    // A live delegation surface outranks an incomplete inventory: a spawn tool
+    // present alongside a future capacity blocker still resolves `supported`.
+    assert.equal(
+      resolveNativeSubagentSupportStatus({
+        nowMs: Date.parse('2026-07-11T00:00:00.000Z'),
+        payload: { available_tools: ['collaboration.spawn_agent'] },
+        persistedCapacityBlocker: { reason: 'agent_thread_limit_reached', expires_at: '2026-07-12T00:00:00.000Z' },
+      }).status,
+      'supported',
+    );
+    // But an incomplete inventory alongside a live capacity blocker keeps the
+    // stronger capacity evidence (delegation exists, temporarily exhausted).
+    assert.equal(
+      resolveNativeSubagentSupportStatus({
+        nowMs: Date.parse('2026-07-11T00:00:00.000Z'),
+        payload: { available_tools: ['Read', 'Edit'] },
+        persistedCapacityBlocker: { reason: 'agent_thread_limit_reached', expires_at: '2026-07-12T00:00:00.000Z' },
+      }).reason,
+      'agent_thread_limit_reached',
     );
   });
 

--- a/src/leader/contract.ts
+++ b/src/leader/contract.ts
@@ -174,16 +174,31 @@ function reasonFromCapabilityRecord(record: Record<string, unknown> | null): Nat
   return nativeSubagents === false ? 'native_subagents_unsupported' : 'multi_agent_v1_unavailable';
 }
 
+const NATIVE_SUBAGENT_SPAWN_TOOL_PATTERN = /(?:^|\.)spawn_agent$/;
+
+// Recognizes native delegation spawn tools across terminology drift: bare
+// `spawn_agent`, and namespaced forms such as `multi_agent_v1.spawn_agent` and
+// the current Codex App `collaboration.spawn_agent`, plus the legacy `task`
+// alias. The suffix anchor keeps `respawn_agent`/`spawn_agentx` from matching.
+function isNativeSubagentSpawnToolName(name: string): boolean {
+  return NATIVE_SUBAGENT_SPAWN_TOOL_PATTERN.test(name) || name === 'task';
+}
+
 function availableToolsEvidence(payload: Record<string, unknown> | null): NativeSubagentSupportEvidence | null {
   const tools = supportArray(payload?.available_tools ?? payload?.availableTools ?? payload?.tools);
   if (!tools) return null;
   const names = tools.map((tool) => typeof tool === 'string'
     ? tool
     : supportString(supportRecord(tool)?.name ?? supportRecord(tool)?.tool_name ?? supportRecord(tool)?.toolName)).filter(Boolean);
-  const hasNativeSubagentTool = names.some((name) => /(?:^|\.)spawn_agent$/.test(name) || /multi_agent_v1\.spawn_agent/.test(name) || name === 'task');
-  return hasNativeSubagentTool
-    ? { status: 'supported', source: 'hook_payload_available_tools', evidenceSummary: names.join(', ') }
-    : { status: 'unsupported', reason: 'multi_agent_v1_unavailable', source: 'hook_payload_available_tools', evidenceSummary: names.join(', ') };
+  const hasNativeSubagentTool = names.some(isNativeSubagentSpawnToolName);
+  if (hasNativeSubagentTool) {
+    return { status: 'supported', source: 'hook_payload_available_tools', evidenceSummary: names.join(', ') };
+  }
+  // A present-but-incomplete tool inventory is NOT explicit negative evidence:
+  // collaboration/deferred tools can be absent from this hook payload while a
+  // spawn surface remains callable. Report `unknown` (with observed-name
+  // provenance) rather than persisting an `unsupported` false negative.
+  return { status: 'unknown', source: 'hook_payload_available_tools', evidenceSummary: names.join(', ') };
 }
 
 export function resolveNativeSubagentSupportStatus(input: NativeSubagentCapabilityInput): NativeSubagentSupportEvidence {
@@ -211,10 +226,15 @@ export function resolveNativeSubagentSupportStatus(input: NativeSubagentCapabili
   }
 
   const toolEvidence = availableToolsEvidence(payload);
-  if (toolEvidence) return toolEvidence;
+  if (toolEvidence?.status === 'supported') return toolEvidence;
 
+  // A capacity blocker means delegation exists but is temporarily exhausted, so
+  // it outranks an incomplete tool inventory. Only fall back to the inventory's
+  // `unknown` (with provenance) when no stronger evidence applies.
   const capacityBlockerEvidence = supportEvidenceFromBlocker(input.persistedCapacityBlocker, 'capacity_blocker', input);
   if (capacityBlockerEvidence) return capacityBlockerEvidence;
+
+  if (toolEvidence) return toolEvidence;
 
   return { status: 'unknown', source: 'default_unknown' };
 }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -22276,6 +22276,140 @@ PY`,
     }
   });
 
+  it("keeps the Conductor unblocked: quoted redirect/source text is not a write target and terminal blocked-state writes survive genuinely unsupported native delegation (#3119)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-conductor-3119-quote-deadlock-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-conductor-3119-quote-deadlock";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ultragoal", "planning");
+      await writeJson(join(stateDir, "sessions", sessionId, "ultragoal-state.json"), {
+        active: true,
+        mode: "ultragoal",
+        current_phase: "planning",
+        session_id: sessionId,
+      });
+      // Native delegation is genuinely unsupported (explicit negative evidence).
+      await writeJson(join(stateDir, "native-subagent-support.json"), {
+        schema_version: 1,
+        status: "unsupported",
+        reason: "multi_agent_v1_unavailable",
+        session_id: sessionId,
+        evidence: "unknown tool: multi_agent_v1.spawn_agent",
+        observed_at: new Date().toISOString(),
+        cwd,
+      });
+
+      const dispatch = (command: string) =>
+        dispatchCodexNativeHook(
+          {
+            hook_event_name: "PreToolUse",
+            cwd,
+            session_id: sessionId,
+            thread_id: "thread-conductor-3119-quote-deadlock",
+            tool_name: "Bash",
+            tool_input: { command },
+          },
+          { cwd },
+        );
+
+      // Deadlock prevention (defect B): the Conductor must still terminalize its
+      // own workflow state even when delegation is genuinely unsupported, even
+      // when the JSON payload contains a `>` character.
+      const terminalBlockedWrite = await dispatch(
+        "omx state write --mode ultragoal --input '{\"active\":true,\"current_phase\":\"blocked\",\"reason\":\"native delegation unavailable -> terminalized\"}' --json",
+      );
+      assert.notEqual((terminalBlockedWrite.outputJson as { decision?: string } | null)?.decision, "block");
+
+      // Defect C: quoted regex/source text with redirect metacharacters is not a
+      // write target, so issue creation is not falsely blocked.
+      const issueCreate = await dispatch(
+        "gh issue create --title x --body 'Guard misparsed regex /[^>]+>{1,2}/ as a redirect target'",
+      );
+      assert.notEqual((issueCreate.outputJson as { decision?: string } | null)?.decision, "block");
+
+      // Fail-closed preserved: a REAL unquoted redirect to a non-metadata path is
+      // still blocked.
+      const realRedirect = await dispatch("printf pwn > src/runtime.ts");
+      assert.equal((realRedirect.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.match(
+        String((realRedirect.outputJson as { reason?: string } | null)?.reason ?? ""),
+        /not workflow state\/ledger\/mailbox\/handoff metadata/,
+      );
+
+      // A real unquoted redirect to allowed workflow metadata still passes.
+      const metadataRedirect = await dispatch("printf blocked > .omx/state/conductor.log");
+      assert.notEqual((metadataRedirect.outputJson as { decision?: string } | null)?.decision, "block");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fail-closed: escaped-quote and ANSI-C quoted redirects to source stay blocked while legit quoted data and nested shells behave (#3119)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-conductor-3119-escaped-quote-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-conductor-3119-escaped-quote";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), { session_id: sessionId });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ultragoal", "planning");
+      await writeJson(join(stateDir, "sessions", sessionId, "ultragoal-state.json"), {
+        active: true,
+        mode: "ultragoal",
+        current_phase: "planning",
+        session_id: sessionId,
+      });
+
+      const dispatch = (command: string) =>
+        dispatchCodexNativeHook(
+          {
+            hook_event_name: "PreToolUse",
+            cwd,
+            session_id: sessionId,
+            thread_id: "thread-conductor-3119-escaped-quote",
+            tool_name: "Bash",
+            tool_input: { command },
+          },
+          { cwd },
+        );
+
+      // A top-level escaped quote (\' \") is a LITERAL char in bash, not a quote
+      // opener, and $'...' is ANSI-C quoting. None of these may hide the real
+      // `>` redirect \u2014 all of these genuinely write src/runtime.ts and MUST block.
+      const mustBlock = [
+        "printf pwn > src/runtime.ts",                        // plain control
+        "printf pwn \\' > src/runtime.ts \\'",                // escaped single quote
+        "printf pwn \\\" > src/runtime.ts \\\"",              // escaped double quote
+        "printf pwn $'\\'' > src/runtime.ts $'\\''",          // ANSI-C escaped quote
+        "bash -c 'printf pwn > src/runtime.ts'",             // nested shell redirect
+      ];
+      for (const command of mustBlock) {
+        const result = await dispatch(command);
+        assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block", command);
+        assert.match(
+          String((result.outputJson as { reason?: string } | null)?.reason ?? ""),
+          /not workflow state\/ledger\/mailbox\/handoff metadata/,
+          command,
+        );
+      }
+
+      // Legitimate quoted DATA metacharacters (single quotes, double quotes,
+      // ANSI-C) are not redirects and must not be falsely blocked.
+      const mustNotBlock = [
+        "gh issue create --title x --body 'a > b regex /[^>]+>{1,2}/'",
+        "echo \"value > threshold\"",
+        "printf $'a>b'",
+      ];
+      for (const command of mustNotBlock) {
+        const result = await dispatch(command);
+        assert.notEqual((result.outputJson as { decision?: string } | null)?.decision, "block", command);
+      }
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("blocks Main-root ralplan writes even when payload has only a typed agent_role", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralplan-agent-role-main-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3877,9 +3877,72 @@ function resolveCommandRedirectTarget(target: string, assignments: Map<string, s
   return resolved !== undefined ? resolved : target;
 }
 
+// Masks redirect metacharacters (`<`/`>`) that appear INSIDE shell quotes so a
+// quoted regex/source value (e.g. `gh issue create --body '...>{1,2}...'` or
+// `omx state write --input '{"reason":"a>b"}'`) is not misread as a redirect
+// write target. Escaped quotes at the top level (`\'`, `\"`) are literal
+// characters and must NOT open a span, and `$'...'` ANSI-C quoting processes
+// backslash escapes (so `\'` does not close it) — otherwise a genuine `>`
+// redirect could be masked behind a false span and its write missed. Only
+// characters inside a real quoted span are masked; unquoted redirect operators
+// survive intact. Unterminated/ambiguous quoting fails closed: the original
+// command is returned unmasked so genuine redirects stay visible to the scan.
+function maskQuotedRedirectMetacharsForCommandScan(command: string): string {
+  let masked = "";
+  // null = unquoted; "'" = single quotes (no escapes); '"' = double quotes
+  // (backslash escapes); "$'" = ANSI-C $'...' (backslash escapes, incl. \').
+  let quote: "'" | "\"" | "$'" | null = null;
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index] ?? "";
+    if (quote === null) {
+      // A backslash escapes the next character at the top level, so an escaped
+      // quote is a literal char and must not open a quoted span.
+      if (char === "\\") {
+        masked += char;
+        const next = command[index + 1];
+        if (next !== undefined) {
+          masked += next;
+          index += 1;
+        }
+        continue;
+      }
+      if (char === "$" && command[index + 1] === "'") {
+        quote = "$'";
+        masked += "$'";
+        index += 1;
+        continue;
+      }
+      if (char === "'" || char === "\"") quote = char;
+      masked += char;
+      continue;
+    }
+    if ((quote === "\"" || quote === "$'") && char === "\\") {
+      // Escapes inside double/ANSI-C spans keep the backslash and its escaped
+      // char (masking a redirect metachar so quoted data cannot be a false
+      // target); the escaped char never closes the span.
+      masked += char;
+      const next = command[index + 1];
+      if (next !== undefined) {
+        masked += next === "<" || next === ">" ? "_" : next;
+        index += 1;
+      }
+      continue;
+    }
+    const closesSpan = quote === "$'" ? char === "'" : char === quote;
+    if (closesSpan) {
+      quote = null;
+      masked += char;
+      continue;
+    }
+    masked += char === "<" || char === ">" ? "_" : char;
+  }
+  if (quote !== null) return command;
+  return masked;
+}
+
 function extractDeepInterviewCommandRedirectTargets(command: string): string[] {
   const targets: string[] = [];
-  const commandOutsideHeredocBodies = stripHeredocBodiesForCommandScan(command);
+  const commandOutsideHeredocBodies = maskQuotedRedirectMetacharsForCommandScan(stripHeredocBodiesForCommandScan(command));
   for (const match of commandOutsideHeredocBodies.matchAll(/(?:^|[^>])>{1,2}\s*(["']?)([^\s&|;<>]+)\1/g)) {
     const candidate = safeString(match[2]).trim();
     if (candidate && !isNullDeviceRedirectTarget(candidate)) targets.push(candidate);
@@ -3977,7 +4040,7 @@ function findGitSubcommandIndex(words: string[], startIndex: number): number | n
 }
 
 
-function commandHasDeepInterviewWriteIntent(command: string): boolean {
+function commandHasDeepInterviewWriteIntent(command: string, depth = 0): boolean {
   return commandInvokesApplyPatch(command)
     || extractDeepInterviewCommandRedirectTargets(command).length > 0
     || /\btee\s+(?:-a\s+)?[^\s&|;]+/.test(command)
@@ -3988,7 +4051,19 @@ function commandHasDeepInterviewWriteIntent(command: string): boolean {
     || extractConductorBashMutations(command).length > 0
     || extractConductorInterpreterWrites(command).length > 0
     || commandHasDestructiveGitSubcommand(command)
-    || commandHasPackageInstallIntent(command);
+    || commandHasPackageInstallIntent(command)
+    // Recurse into wrapped shells (`bash -lc "cat > f"`, `eval`, `env`) and
+    // command substitutions so a real redirect INSIDE a nested command string
+    // is still classified as write intent. This is required because quoted
+    // redirect metacharacters are now masked at the outer scan (#3119): the
+    // mask removes false positives from quoted DATA values while nested-command
+    // recursion re-detects genuine redirects, preserving fail-closed blocking.
+    // The depth guard mirrors evaluateConductorBashWrite's nesting bound;
+    // extractors return strict substrings, so recursion always terminates.
+    || (depth < CONDUCTOR_BASH_MAX_NESTING_DEPTH && (
+      extractNestedShellCommandStringsForStateScan(command).some((nested) => commandHasDeepInterviewWriteIntent(nested, depth + 1))
+      || extractNestedCommandSubstitutionStringsForStateScan(command).some((nested) => commandHasDeepInterviewWriteIntent(nested, depth + 1))
+    ));
 }
 
 function extractDeepInterviewCommandWriteTargets(command: string): string[] {


### PR DESCRIPTION
## Summary

Fixes #3119. Main-root Conductor falsely reported `multi_agent_v1_unavailable` and wedged Ultragoal even when a working `collaboration.spawn_agent` surface was present. Two coupled defects on the same deadlock path are fixed here; the third reported symptom (B) is a consequence of (C) and is proven by a regression test.

## Independent reproduction

- (A) `src/leader/contract.ts` `availableToolsEvidence` returned `status:'unsupported'` whenever `available_tools` was present but lacked a spawn tool — treating an absent/incomplete inventory as explicit negative evidence.
- (C) `src/scripts/codex-native-hook.ts` `extractDeepInterviewCommandRedirectTargets` scanned raw text (only heredoc bodies stripped) and was not quote-aware, so a `>` inside a quoted value was misparsed as a redirect target. Verified: `gh issue create --body 'regex /[^>]+>{1,2}/'` yields a bogus target `{1,2}/`, and `omx state write --input '{"reason":"a>b"}'` yields target `b"}'`.
- (B) `evaluateConductorBashWrite` already allows a clean `omx state write`; it only blocked when (C) misparsed a `>` in the `--input` payload. So B is a direct symptom of C.

## Changes

1. Detection (A): recognize namespaced spawn tools (`collaboration.spawn_agent`, `multi_agent_v1.spawn_agent`, bare `spawn_agent`, legacy `task`); present-but-incomplete inventory resolves to `unknown` (never `unsupported`), with observed-name provenance. `resolveNativeSubagentSupportStatus` short-circuits only on `supported`, preserving capacity-blocker precedence. Explicit negative capability and verified post-tool spawn failure still resolve `unsupported`. No unsafe spawn probe.
2. Quote-aware parser (C): new `maskQuotedRedirectMetacharsForCommandScan` neutralizes `<`/`>` inside quoted spans (fail-closed on malformed quotes) before the redirect regex; `commandHasDeepInterviewWriteIntent` now recurses into wrapped shells/command substitutions so real nested-shell redirects stay blocked.

## Scope (one-issue/one-PR)

- A + C are on the critical path of the same Conductor deadlock and ship together.
- B is validated by a deadlock-prevention regression test rather than a separate authorization change; no genuine extra authorization gap was found.
- #3118 owner-gated role-routing (`agent_type`/`reasoning_effort`) semantics are intentionally NOT touched.

## Fail-closed preservation

Real unquoted redirects to non-metadata paths, wrapped `bash -lc "cat > src/..."` writes, tee/sed/perl/apply_patch, and command-substitution writes all remain blocked. Only quoted DATA metacharacters are neutralized.

## Tests / verification

- New focused tests: alias recognition + negative aliases, incomplete-inventory => unknown (existing `['Read','Edit']` assertion updated), explicit-negative => unsupported, capacity-blocker precedence, provenance; quoted-regex not blocked, terminal `omx state write` with quoted `>` allowed (deadlock prevention), real unquoted redirect still blocked.
- Green: `npm run build`, `npm run lint`, `npm run check:no-unused`, and regressions across `leader/contract` (8), `scripts/codex-native-hook` (514), `autopilot/ralplan-gate` (25), `pipeline/stages` (77), `state/operations` (105), `cli/launch-fallback` (24), `hooks/keyword-detector` (175), `team/runtime` (149).

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
