### PR TITLE
fix(team): honor explicit worker policy

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -102,6 +102,8 @@ import {
   getTeamLowComplexityModel,
 } from "../../config/models.js";
 import type { ProcessEntry } from "../cleanup.js";
+import { splitWorkerLaunchArgs } from "../../team/model-contract.js";
+
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(testDir, "..", "..", "..");
@@ -1759,7 +1761,7 @@ describe("resolveTeamWorkerLaunchArgsEnv (spark)", () => {
         true,
         expectedLowComplexityModel(),
       ),
-      `--model ${expectedLowComplexityModel()}`,
+      `"--model" "${expectedLowComplexityModel()}"`,
     );
   });
 
@@ -1771,7 +1773,7 @@ describe("resolveTeamWorkerLaunchArgsEnv (spark)", () => {
         true,
         expectedLowComplexityModel(),
       ),
-      "--model gpt-5",
+      '"--model" "gpt-5"',
     );
   });
 
@@ -1783,7 +1785,7 @@ describe("resolveTeamWorkerLaunchArgsEnv (spark)", () => {
         true,
         expectedLowComplexityModel(),
       ),
-      "--model gpt-4.1",
+      '"--model" "gpt-4.1"',
     );
   });
 });
@@ -5612,7 +5614,7 @@ describe("team worker launch arg inheritance helpers", () => {
         ],
         true,
       ),
-      '--no-alt-screen --dangerously-bypass-approvals-and-sandbox -c model_reasoning_effort="xhigh" --model old-b',
+      '"--no-alt-screen" "--dangerously-bypass-approvals-and-sandbox" "-c" "model_reasoning_effort=\\"xhigh\\"" "--model" "old-b"',
     );
   });
 
@@ -5627,7 +5629,7 @@ describe("team worker launch arg inheritance helpers", () => {
         ],
         false,
       ),
-      "--no-alt-screen",
+      '"--no-alt-screen"',
     );
   });
 
@@ -5638,7 +5640,7 @@ describe("team worker launch arg inheritance helpers", () => {
         ["--model=gpt-5.6-terra"],
         true,
       ),
-      "--no-alt-screen --model gpt-5.6-terra",
+      '"--no-alt-screen" "--model" "gpt-5.6-terra"',
     );
   });
 
@@ -5650,7 +5652,7 @@ describe("team worker launch arg inheritance helpers", () => {
         true,
         DEFAULT_FRONTIER_MODEL,
       ),
-      `--no-alt-screen --dangerously-bypass-approvals-and-sandbox --model ${DEFAULT_FRONTIER_MODEL}`,
+      `"--no-alt-screen" "--dangerously-bypass-approvals-and-sandbox" "--model" "${DEFAULT_FRONTIER_MODEL}"`,
     );
   });
 
@@ -5662,7 +5664,7 @@ describe("team worker launch arg inheritance helpers", () => {
         true,
         "fallback-model",
       ),
-      "--model env-model-final",
+      '"--model" "env-model-final"',
     );
   });
 
@@ -5674,7 +5676,67 @@ describe("team worker launch arg inheritance helpers", () => {
         true,
         "fallback-model",
       ),
-      "--no-alt-screen --model inherited-model",
+      '"--no-alt-screen" "--model" "inherited-model"',
+
+    );
+  });
+});
+
+describe("team worker launch argument environment serialization", () => {
+  it("round-trips quoted, empty, and literal args while direct policy suppresses inherited bypass", () => {
+    const raw = resolveTeamWorkerLaunchArgsEnv(
+      '"" "two words" $VAR --sandbox=workspace-write',
+      [
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--model", "leader-model",
+      ],
+      true,
+    );
+    assert.ok(raw);
+    assert.deepEqual(splitWorkerLaunchArgs(raw ?? undefined), [
+      '',
+      'two words',
+      '$VAR',
+      '--sandbox', 'workspace-write',
+      '--model', 'leader-model',
+    ]);
+  });
+
+  it("round-trips Windows paths, including terminal backslashes, through the environment", () => {
+    const path = "C:\\Users\\alice\\file.txt";
+    const terminalPath = "C:\\Users\\alice\\";
+    const raw = resolveTeamWorkerLaunchArgsEnv(
+      [
+        "--add-dir", path,
+        "--add-dir", `"${path}"`,
+        "--add-dir", `'${terminalPath}'`,
+      ].join(" "),
+      [],
+      false,
+    );
+
+    assert.deepEqual(splitWorkerLaunchArgs(raw ?? undefined), [
+      "--add-dir", path,
+      "--add-dir", path,
+      "--add-dir", terminalPath,
+    ]);
+  });
+
+  it("honors the inheritance gate and rejects an explicitly mixed source before transport", () => {
+    const noInheritance = resolveTeamWorkerLaunchArgsEnv(
+      '--ask-for-approval=on-request',
+      ["--dangerously-bypass-approvals-and-sandbox", "--model", "leader-model"],
+      false,
+    );
+    assert.deepEqual(splitWorkerLaunchArgs(noInheritance ?? undefined), [
+      '--ask-for-approval', 'on-request',
+    ]);
+    assert.throws(
+      () => resolveTeamWorkerLaunchArgsEnv(
+        '--dangerously-bypass-approvals-and-sandbox --sandbox workspace-write',
+        [],
+      ),
+      /Invalid OMX_TEAM_WORKER_LAUNCH_ARGS: bypass cannot be combined with direct approval or sandbox policy/,
     );
   });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -183,8 +183,10 @@ import {
   parseTeamWorkerLaunchArgs,
   resolveTeamWorkerLaunchArgs,
   resolveTeamLowComplexityDefaultModel,
+  serializeTeamWorkerLaunchArgs,
   TEAM_WORKER_INHERITED_MODEL_ENV,
 } from "../team/model-contract.js";
+
 import {
   parseWorktreeMode,
   planWorktreeTarget,
@@ -3684,7 +3686,7 @@ export function resolveTeamWorkerLaunchArgsEnv(
     fallbackModel: defaultModel,
   });
   if (normalized.length === 0) return null;
-  return normalized.join(" ");
+  return serializeTeamWorkerLaunchArgs(normalized);
 }
 
 export { readTopLevelTomlString, upsertTopLevelTomlString } from "../utils/toml.js";

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -6,13 +6,17 @@ import { join } from 'node:path';
 import {
   collectInheritableTeamWorkerArgs,
   isLowComplexityAgentType,
+  parseTeamWorkerLaunchArgs,
   resolveAgentDefaultModel,
   resolveAgentReasoningEffort,
   resolveTeamWorkerLaunchArgs,
   resolveTeamWorkerLaunchDiagnostics,
+  serializeTeamWorkerLaunchArgs,
+  splitWorkerLaunchArgs,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
   resolveTeamLowComplexityDefaultModel,
 } from '../model-contract.js';
+
 
 function expectedLowComplexityModel(): string {
   return resolveTeamLowComplexityDefaultModel();
@@ -76,6 +80,64 @@ describe('team model contract', () => {
         'gpt-5.6-sol',
       ]),
       ['-c', 'model_provider="cheapRouter"', '--model', 'gpt-5.6-sol'],
+    );
+  });
+
+  it('ignores leader direct policy selectors while retaining approved inheritable overrides', () => {
+    assert.deepEqual(
+      collectInheritableTeamWorkerArgs([
+        '--ask-for-approval',
+        'on-request',
+        '--sandbox=workspace-write',
+        '--madmax',
+        '-c',
+        'model_provider="leaderRouter"',
+        '-c',
+        'model_reasoning_effort="high"',
+        '--model=leader-model',
+      ]),
+      [
+        '--dangerously-bypass-approvals-and-sandbox',
+        '-c',
+        'model_provider="leaderRouter"',
+        '-c',
+        'model_reasoning_effort="high"',
+        '--model',
+        'leader-model',
+      ],
+    );
+  });
+
+  it('does not validate or inherit malformed direct and config policy tokens from leader arguments', () => {
+    assert.deepEqual(
+      collectInheritableTeamWorkerArgs([
+        '--ask-for-approval',
+        '--sandbox=',
+        '-a=',
+        '-c',
+        'approval_policy=',
+        '--config=sandbox_mode=workspace-write',
+        '-s',
+        'leader-only-positional-token',
+        '-a',
+        'another-positional-token',
+        '--model',
+        'leader-model',
+        '-c',
+        'model_reasoning_effort="high"',
+        '-c',
+        'model_provider="leaderRouter"',
+        '--madmax',
+      ]),
+      [
+        '--dangerously-bypass-approvals-and-sandbox',
+        '-c',
+        'model_provider="leaderRouter"',
+        '-c',
+        'model_reasoning_effort="high"',
+        '--model',
+        'leader-model',
+      ],
     );
   });
 
@@ -388,5 +450,245 @@ describe('resolveTeamWorkerLaunchArgs - teammate reasoning allocation', () => {
     });
     const joined = result.join(' ');
     assert.ok(!joined.includes('model_reasoning_effort'), `Expected no reasoning in: ${joined}`);
+  });
+});
+
+describe('explicit team worker policy contract', () => {
+  it('tokenizes quote-aware launch args and reversibly serializes empty and literal tokens', () => {
+    const quotedDouble = '"double"';
+    const tokens = [
+      '',
+      'two words',
+      'ab cdef',
+      'single\\backslash',
+      quotedDouble,
+      "single'quote",
+      '$VAR',
+      '\\${value}',
+      '\\$(command)',
+      '\\`command`',
+      '*?[glob]',
+      '~;|>redirect',
+      '',
+    ];
+    const raw = [
+      "''",
+      '"two words"',
+      'ab" cd"ef',
+      "'single\\backslash'",
+      `"${quotedDouble.replace(/"/g, '\\"')}"`,
+      '"single\'quote"',
+      '$VAR',
+      '\\${value}',
+      '\\$(command)',
+      '\\`command`',
+      '*?[glob]',
+      '~;|>redirect',
+      '""',
+    ].join(' ');
+
+    assert.deepEqual(splitWorkerLaunchArgs(raw), tokens);
+    assert.deepEqual(splitWorkerLaunchArgs(serializeTeamWorkerLaunchArgs(tokens)), tokens);
+    assert.deepEqual(splitWorkerLaunchArgs('one\u00a0two\tthree\nfour'), ['one', 'two', 'three', 'four']);
+  });
+
+  it('preserves literal Windows backslashes, including terminal backslashes, through transport', () => {
+    const path = 'C:\\Users\\alice\\file.txt';
+    const terminalPath = 'C:\\Users\\alice\\';
+    const raw = [
+      path,
+      terminalPath,
+      `"${path}"`,
+      `'${terminalPath}'`,
+    ].join(' ');
+    const expected = [path, terminalPath, path, terminalPath];
+
+    assert.deepEqual(splitWorkerLaunchArgs(raw), expected);
+    assert.deepEqual(splitWorkerLaunchArgs(serializeTeamWorkerLaunchArgs(expected)), expected);
+  });
+
+  it('preserves raw UNC and device backslash runs unquoted, quoted, and serialized', () => {
+    const uncPath = '\\\\server\\share\\';
+    const devicePath = '\\\\?\\C:\\work';
+    const expected = [uncPath, devicePath];
+
+    assert.deepEqual(splitWorkerLaunchArgs(`${uncPath} ${devicePath}`), expected);
+    assert.deepEqual(splitWorkerLaunchArgs(`'${uncPath}' "${devicePath}"`), expected);
+    assert.equal(
+      serializeTeamWorkerLaunchArgs(expected),
+      "'\\\\server\\share\\' '\\\\?\\C:\\work'",
+    );
+    assert.deepEqual(splitWorkerLaunchArgs(serializeTeamWorkerLaunchArgs(expected)), expected);
+  });
+
+  it('rejects only unterminated quotes while retaining literal malformed-looking escapes', () => {
+    for (const raw of ["'unterminated", '"unterminated']) {
+      assert.throws(
+        () => splitWorkerLaunchArgs(raw),
+        /Invalid OMX_TEAM_WORKER_LAUNCH_ARGS: unterminated quote/,
+      );
+    }
+
+    assert.deepEqual(
+      splitWorkerLaunchArgs(['one\\q', 'two\\', '"three\\q"', '"four\\\\path"'].join(' ')),
+      ['one\\q', 'two\\', 'three\\q', 'four\\\\path'],
+    );
+  });
+
+  it('normalizes every long and short direct policy split and equals form', () => {
+    const cases: Array<{ raw: string; expected: string[] }> = [
+      { raw: '--ask-for-approval on-request', expected: ['--ask-for-approval', 'on-request'] },
+      { raw: '--ask-for-approval=on-request', expected: ['--ask-for-approval', 'on-request'] },
+      { raw: '-a on-request', expected: ['--ask-for-approval', 'on-request'] },
+      { raw: '-a=on-request', expected: ['--ask-for-approval', 'on-request'] },
+      { raw: '--sandbox workspace-write', expected: ['--sandbox', 'workspace-write'] },
+      { raw: '--sandbox=workspace-write', expected: ['--sandbox', 'workspace-write'] },
+      { raw: '-s workspace-write', expected: ['--sandbox', 'workspace-write'] },
+      { raw: '-s=workspace-write', expected: ['--sandbox', 'workspace-write'] },
+    ];
+    for (const { raw, expected } of cases) {
+      assert.deepEqual(resolveTeamWorkerLaunchArgs({ existingRaw: raw }), expected, raw);
+    }
+  });
+
+  it('normalizes approval and sandbox config policy forms without a value allowlist', () => {
+    const cases: Array<{ raw: string; expected: string[] }> = [
+      { raw: '-c approval_policy=custom-approval', expected: ['--ask-for-approval', 'custom-approval'] },
+      { raw: '--config "sandbox_mode = \'workspace-write\'"', expected: ['--sandbox', 'workspace-write'] },
+      { raw: `-c='approval_policy = "on-request"'`, expected: ['--ask-for-approval', 'on-request'] },
+      { raw: '--config=sandbox_mode=workspace-write', expected: ['--sandbox', 'workspace-write'] },
+    ];
+
+    for (const { raw, expected } of cases) {
+      assert.deepEqual(resolveTeamWorkerLaunchArgs({ existingRaw: raw }), expected, raw);
+      assert.equal(parseTeamWorkerLaunchArgs(splitWorkerLaunchArgs(raw)).policyKind, 'direct-policy', raw);
+    }
+  });
+
+  it('preserves unrelated config overrides while extracting only canonical provider and reasoning overrides', () => {
+    assert.deepEqual(
+      resolveTeamWorkerLaunchArgs({
+        existingRaw: '--config unrelated=one -c unrelated=two -c=unrelated=three -c model_provider="envRouter" --config model_reasoning_effort=high',
+      }),
+      [
+        '--config', 'unrelated=one',
+        '-c', 'unrelated=two',
+        '-c=unrelated=three',
+        '--config', 'model_reasoning_effort=high',
+        '-c', 'model_provider="envRouter"',
+      ],
+    );
+  });
+
+  it('rejects missing, empty, and option-shaped direct or config policy values', () => {
+    for (const raw of [
+      '--ask-for-approval', '--sandbox', '-a', '-s',
+      '--ask-for-approval=', '--sandbox=', '-a=', '-s=',
+      '--ask-for-approval --model', '--sandbox=-not-a-value',
+      '-c', '--config', '-c=', '--config=',
+      '-c --sandbox workspace-write', '--config --ask-for-approval on-request',
+      '-c=--sandbox', '--config=--ask-for-approval',
+      '-c approval_policy=', '--config=sandbox_mode=',
+    ]) {
+      assert.throws(
+        () => resolveTeamWorkerLaunchArgs({ existingRaw: raw }),
+        /Invalid OMX_TEAM_WORKER_LAUNCH_ARGS: missing value for (--ask-for-approval|--sandbox|-c|--config)/,
+        raw,
+      );
+    }
+  });
+
+  it('collapses matching direct and config policy values and rejects deterministic conflicts', () => {
+    assert.deepEqual(
+      resolveTeamWorkerLaunchArgs({
+        existingRaw: '-a on-request --config=approval_policy="on-request" -s workspace-write -c=sandbox_mode=workspace-write',
+      }),
+      ['--ask-for-approval', 'on-request', '--sandbox', 'workspace-write'],
+    );
+    assert.equal(parseTeamWorkerLaunchArgs(['-a', ' on-request ']).approvalValue, ' on-request ');
+    assert.throws(
+      () => resolveTeamWorkerLaunchArgs({ existingRaw: '-a " on-request " --ask-for-approval=on-request' }),
+      /conflicting duplicate approval policy/,
+    );
+    assert.throws(
+      () => resolveTeamWorkerLaunchArgs({ existingRaw: '-a on-request -c approval_policy=never' }),
+      /conflicting duplicate approval policy/,
+    );
+    assert.throws(
+      () => resolveTeamWorkerLaunchArgs({ existingRaw: '-c=sandbox_mode=workspace-write --sandbox danger-full-access' }),
+      /conflicting duplicate sandbox policy/,
+    );
+  });
+
+  it('rejects explicit bypass plus direct or config policy but suppresses inherited bypass for policy', () => {
+    for (const existingRaw of [
+      '--dangerously-bypass-approvals-and-sandbox -a on-request',
+      '--madmax --config approval_policy=on-request',
+    ]) {
+      assert.throws(
+        () => resolveTeamWorkerLaunchArgs({ existingRaw }),
+        /Invalid OMX_TEAM_WORKER_LAUNCH_ARGS: bypass cannot be combined with direct approval or sandbox policy/,
+      );
+    }
+    assert.deepEqual(
+      resolveTeamWorkerLaunchArgs({
+        existingRaw: '-s workspace-write --no-alt-screen',
+        inheritedArgs: [
+          '--madmax',
+          '-c', 'model_provider="leader"',
+          '-c', 'model_reasoning_effort="high"',
+          '--model', 'leader-model',
+        ],
+      }),
+      [
+        '--no-alt-screen',
+        '--sandbox', 'workspace-write',
+        '-c', 'model_provider="leader"',
+        '-c', 'model_reasoning_effort="high"',
+        '--model', 'leader-model',
+      ],
+    );
+  });
+
+  it('treats -- and its suffix as positional while keeping generated options before the marker', () => {
+    const suffix = [
+      '--',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--sandbox', 'workspace-write',
+      '-c', 'sandbox_mode=workspace-write',
+      '--model', 'positional-model',
+      '-c', 'model_reasoning_effort=high',
+      '-c', 'model_provider=positional',
+    ];
+    assert.deepEqual(
+      resolveTeamWorkerLaunchArgs({
+        existingRaw: ['-a', 'on-request', ...suffix].join(' '),
+      }),
+      ['--ask-for-approval', 'on-request', ...suffix],
+    );
+    assert.deepEqual(
+      resolveTeamWorkerLaunchArgs({
+        existingRaw: ['--no-alt-screen', '-a', 'on-request', '-c', 'model_provider=envRouter', '--', '--model', 'positional-model'].join(' '),
+        fallbackModel: 'generated-model',
+        preferredReasoning: 'high',
+      }),
+      [
+        '--no-alt-screen',
+        '--ask-for-approval', 'on-request',
+        '-c', 'model_provider="envRouter"',
+        '-c', 'model_reasoning_effort="high"',
+        '--model', 'generated-model',
+        '--', '--model', 'positional-model',
+      ],
+    );
+  });
+
+  it('keeps bypass-only input canonical and exposes direct policy metadata', () => {
+    const parsed = parseTeamWorkerLaunchArgs(['--madmax']);
+    assert.equal(parsed.policyKind, 'bypass');
+    assert.deepEqual(
+      resolveTeamWorkerLaunchArgs({ existingRaw: '--madmax --dangerously-bypass-approvals-and-sandbox' }),
+      ['--dangerously-bypass-approvals-and-sandbox'],
+    );
   });
 });

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -589,16 +589,22 @@ describe('runtime', () => {
   it('rejects explicit mixed worker policy before initial team state or workers are created', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-explicit-policy-'));
     const previousLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'interactive';
     process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = '--dangerously-bypass-approvals-and-sandbox -a on-request';
     try {
       await assert.rejects(
-        () => startTeam('explicit-policy', 'task', 'executor', 1, [{ subject: 's', description: 'd' }], cwd),
+        () => withEmptyPath(() =>
+          startTeam('explicit-policy', 'task', 'executor', 1, [{ subject: 's', description: 'd' }], cwd),
+        ),
         /Invalid OMX_TEAM_WORKER_LAUNCH_ARGS: bypass cannot be combined with direct approval or sandbox policy/,
       );
       assert.equal(existsSync(join(cwd, '.omx', 'state', 'team', 'explicit-policy')), false);
     } finally {
       if (typeof previousLaunchArgs === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = previousLaunchArgs;
       else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import { execFileSync, spawn } from 'child_process';
 import { mkdtemp, rm, writeFile, readFile, mkdir, chmod, readdir } from 'fs/promises';
-import { join, relative } from 'path';
+import { join, relative, dirname } from 'path';
 import { tmpdir } from 'os';
 import { existsSync } from 'fs';
 import { HUD_TMUX_TEAM_HEIGHT_LINES } from '../../hud/constants.js';
@@ -54,6 +54,7 @@ import { readTeamEvents } from '../state/events.js';
 import { sanitizeTeamName } from '../tmux-session.js';
 import { buildInternalTeamName, resolveTeamIdentityScope } from '../team-identity.js';
 import { writePersistedApprovedTeamExecutionBinding } from '../approved-execution.js';
+import { planWorktreeTarget } from '../worktree.js';
 
 const coverageRun = process.env.NODE_V8_COVERAGE ? true : false;
 const skipSlowLifecycleUnderCoverage = coverageRun
@@ -564,6 +565,447 @@ describe('runtime', () => {
       'explore',
     );
     assert.deepEqual(args, ['--no-alt-screen', '--model', expectedLowComplexityModel()]);
+  });
+
+  it('keeps an explicit direct policy authoritative while preserving inherited model and role reasoning', () => {
+    const args = resolveWorkerLaunchArgsFromEnv(
+      {
+        OMX_TEAM_WORKER_LAUNCH_ARGS: '--sandbox=workspace-write',
+        [TEAM_WORKER_INHERITED_MODEL_ENV]: 'leader-model',
+      },
+      'executor',
+      undefined,
+      'medium',
+      'codex',
+    );
+    assert.deepEqual(args, [
+      '--sandbox', 'workspace-write',
+      '-c', 'model_reasoning_effort="medium"',
+      '--model', 'leader-model',
+    ]);
+
+  });
+
+  it('rejects explicit mixed worker policy before initial team state or workers are created', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-explicit-policy-'));
+    const previousLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+    process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = '--dangerously-bypass-approvals-and-sandbox -a on-request';
+    try {
+      await assert.rejects(
+        () => startTeam('explicit-policy', 'task', 'executor', 1, [{ subject: 's', description: 'd' }], cwd),
+        /Invalid OMX_TEAM_WORKER_LAUNCH_ARGS: bypass cannot be combined with direct approval or sandbox policy/,
+      );
+      assert.equal(existsSync(join(cwd, '.omx', 'state', 'team', 'explicit-policy')), false);
+    } finally {
+      if (typeof previousLaunchArgs === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = previousLaunchArgs;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('startTeam launches executor workers with authoritative config policy, positional backslashes, and no bypass', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-direct-policy-start-'));
+    const binDir = join(cwd, 'bin');
+    const capturePath = join(cwd, 'worker-argv.json');
+    const fakeCodexPath = join(binDir, 'codex');
+    let runtime: TeamRuntime | null = null;
+    await mkdir(binDir, { recursive: true });
+    await writeFakePromptWorkerBinary(
+      fakeCodexPath,
+      `fs.writeFileSync(process.env.OMX_POLICY_ARGV_CAPTURE, JSON.stringify(process.argv.slice(2)));
+process.stdin.resume();
+setTimeout(() => process.exit(0), 5000);
+process.on('SIGTERM', () => process.exit(0));`,
+    );
+
+    try {
+      await withIsolatedDefaultModelEnvAsync(async () => {
+        await withPromptModeCodexEnv(binDir, {
+          OMX_BYPASS_DEFAULT_SYSTEM_PROMPT: '0',
+          OMX_POLICY_ARGV_CAPTURE: capturePath,
+          OMX_TEAM_WORKER_LAUNCH_ARGS: String.raw`--config 'sandbox_mode="workspace-write"' -- 'C:\workspace\nested\' '' '--sandbox=read-only' '--madmax'`,
+        }, async () => {
+          const previousArgv = process.argv;
+          process.argv = ['node', 'omx', '--madmax'];
+          try {
+            runtime = await withoutTeamWorkerEnv(() =>
+              startTeam(
+                'direct-policy-start',
+                'launch executor with a direct sandbox policy',
+                'executor',
+                1,
+                [{ subject: 's', description: 'd', owner: 'worker-1' }],
+                cwd,
+              ));
+          } finally {
+            process.argv = previousArgv;
+          }
+        });
+      });
+
+      const workerArgs = JSON.parse(await waitForFileText(capturePath, (content) => content.length > 0)) as string[];
+      assert.deepEqual(workerArgs, [
+        '--sandbox', 'workspace-write',
+        '-c', 'model_reasoning_effort="medium"',
+        '--model', 'gpt-5.6-sol',
+        '--', 'C:\\workspace\\nested\\', '', '--sandbox=read-only', '--madmax',
+      ]);
+      const startedRuntime = runtime as TeamRuntime | null;
+      assert.ok(startedRuntime);
+      await shutdownTeam(startedRuntime.teamName, cwd, { force: true });
+      runtime = null;
+    } finally {
+      const activeRuntime = runtime as TeamRuntime | null;
+      if (activeRuntime) await shutdownTeam(activeRuntime.teamName, cwd, { force: true }).catch(() => {});
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects Claude and Gemini restrictive config policy before prompt worker capture and cleans state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-restrictive-noncodex-'));
+    const binDir = join(cwd, 'bin');
+    const previousPath = process.env.PATH;
+    const previousTmux = process.env.TMUX;
+    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const previousLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+    const previousCapture = process.env.OMX_POLICY_ARGV_CAPTURE;
+    const previousSessionId = process.env.OMX_SESSION_ID;
+    await mkdir(binDir, { recursive: true });
+    try {
+      for (const workerCli of ['claude', 'gemini'] as const) {
+        const capturePath = join(cwd, `${workerCli}-argv.json`);
+        const teamName = `restrictive-${workerCli}`;
+        const teamSessionId = `restrictive-${workerCli}-session`;
+        const internalTeamName = buildInternalTeamName(teamName, resolveTeamIdentityScope({ OMX_SESSION_ID: teamSessionId }));
+        assert.match(internalTeamName, new RegExp(`^${teamName}-[a-f0-9]{8}$`));
+        await writeFile(
+          join(binDir, workerCli),
+          `#!/usr/bin/env node
+require('fs').writeFileSync(process.env.OMX_POLICY_ARGV_CAPTURE, JSON.stringify(process.argv.slice(2)));
+`,
+          { mode: 0o755 },
+        );
+        process.env.PATH = `${binDir}:${previousPath ?? ''}`;
+        delete process.env.TMUX;
+        process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+        process.env.OMX_TEAM_WORKER_CLI = workerCli;
+        process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = `--config 'sandbox_mode="workspace-write"'`;
+        process.env.OMX_SESSION_ID = teamSessionId;
+        process.env.OMX_POLICY_ARGV_CAPTURE = capturePath;
+
+        await assert.rejects(
+          () => withoutTeamWorkerEnv(() =>
+            startTeam(teamName, 'restrictive non-Codex policy', 'executor', 1, [{ subject: 's', description: 'd', owner: 'worker-1' }], cwd)),
+          new RegExp(`Selected team worker CLI "${workerCli}" is incompatible with an explicit approval or sandbox policy\\.`),
+        );
+        assert.equal(existsSync(capturePath), false, `${workerCli} must not be spawned`);
+        assert.equal(
+          existsSync(join(cwd, '.omx', 'state', 'team', internalTeamName)),
+          false,
+          `${workerCli} internal state must be rolled back`,
+        );
+      }
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof previousLaunchArgs === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = previousLaunchArgs;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+      if (typeof previousCapture === 'string') process.env.OMX_POLICY_ARGV_CAPTURE = previousCapture;
+      else delete process.env.OMX_POLICY_ARGV_CAPTURE;
+      if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects mixed CLI restrictive policy before any prompt worker is spawned', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-mixed-policy-rollback-'));
+    const codexBin = join(cwd, 'codex-bin');
+    const nonCodexBin = join(cwd, 'non-codex-bin');
+    const previousPath = process.env.PATH;
+    const previousTmux = process.env.TMUX;
+    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const previousWorkerCliMap = process.env.OMX_TEAM_WORKER_CLI_MAP;
+    const previousLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+    const previousAllowNonTty = process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT;
+    const previousBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const previousSessionId = process.env.OMX_SESSION_ID;
+    const previousCodexCapture = process.env.OMX_CODEX_PID_CAPTURE;
+    const previousNonCodexCapture = process.env.OMX_NON_CODEX_CAPTURE;
+    await mkdir(codexBin, { recursive: true });
+    await mkdir(nonCodexBin, { recursive: true });
+    try {
+      await writeFile(
+        join(codexBin, 'codex'),
+        `#!${process.execPath}
+const fs = require('fs');
+fs.writeFileSync(process.env.OMX_CODEX_PID_CAPTURE, String(process.pid));
+setInterval(() => {}, 1000);
+process.on('SIGTERM', () => process.exit(0));
+`,
+        { mode: 0o755 },
+      );
+      for (const workerCli of ['claude', 'gemini'] as const) {
+        await writeFile(
+          join(nonCodexBin, workerCli),
+          `#!${process.execPath}
+require('fs').writeFileSync(process.env.OMX_NON_CODEX_CAPTURE, process.argv.slice(2).join(' '));
+`,
+          { mode: 0o755 },
+        );
+      }
+
+
+      process.env.PATH = [codexBin, nonCodexBin, previousPath ?? ''].join(':');
+      delete process.env.TMUX;
+      delete process.env.OMX_TEAM_WORKER_CLI;
+      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+      process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = '--config sandbox_mode="workspace-write"';
+      process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT = '1';
+      process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+
+      for (const nonCodexCli of ['claude', 'gemini'] as const) {
+        const teamName = `mixed-${nonCodexCli}-rollback`;
+        const teamSessionId = `mixed-${nonCodexCli}-rollback-session`;
+        const internalTeamName = buildInternalTeamName(teamName, resolveTeamIdentityScope({ OMX_SESSION_ID: teamSessionId }));
+        const codexCapturePath = join(cwd, `${nonCodexCli}-codex.pid`);
+        const nonCodexCapturePath = join(cwd, `${nonCodexCli}-non-codex.argv`);
+        process.env.OMX_SESSION_ID = teamSessionId;
+        process.env.OMX_TEAM_WORKER_CLI_MAP = `codex,${nonCodexCli}`;
+        process.env.OMX_CODEX_PID_CAPTURE = codexCapturePath;
+        process.env.OMX_NON_CODEX_CAPTURE = nonCodexCapturePath;
+
+        await assert.rejects(
+          () => withoutTeamWorkerEnv(() =>
+            startTeam(
+              teamName,
+              'mixed CLI restrictive policy rollback',
+              'executor',
+              2,
+              [
+                { subject: 'codex task', description: 'first worker', owner: 'worker-1' },
+                { subject: 'non-Codex task', description: 'second worker', owner: 'worker-2' },
+              ],
+              cwd,
+            )),
+          new RegExp(`Selected team worker CLI "${nonCodexCli}" is incompatible with an explicit approval or sandbox policy\\.`),
+        );
+
+        assert.equal(existsSync(codexCapturePath), false, 'Codex must not spawn before every worker policy is compatible');
+        assert.equal(existsSync(join(cwd, '.omx', 'state', 'team', internalTeamName)), false);
+        assert.equal(existsSync(join(cwd, '.omx', 'state', 'team', internalTeamName, 'tasks')), false);
+        assert.equal(existsSync(join(cwd, '.omx', 'state', 'team', internalTeamName, 'workers')), false);
+        assert.equal(existsSync(nonCodexCapturePath), false, `${nonCodexCli} must not be spawned`);
+      }
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof previousWorkerCliMap === 'string') process.env.OMX_TEAM_WORKER_CLI_MAP = previousWorkerCliMap;
+      else delete process.env.OMX_TEAM_WORKER_CLI_MAP;
+      if (typeof previousLaunchArgs === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = previousLaunchArgs;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+      if (typeof previousAllowNonTty === 'string') process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT = previousAllowNonTty;
+      else delete process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT;
+      if (typeof previousBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = previousBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      if (typeof previousCodexCapture === 'string') process.env.OMX_CODEX_PID_CAPTURE = previousCodexCapture;
+      else delete process.env.OMX_CODEX_PID_CAPTURE;
+      if (typeof previousNonCodexCapture === 'string') process.env.OMX_NON_CODEX_CAPTURE = previousNonCodexCapture;
+      else delete process.env.OMX_NON_CODEX_CAPTURE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects restrictive later CLI before provisioning or composing a reused worker worktree', async () => {
+    const repo = await initRepo();
+    const teamName = 'reused-worktree-policy';
+    const teamSessionId = 'reused-worktree-policy-session';
+    const internalTeamName = buildInternalTeamName(teamName, resolveTeamIdentityScope({ OMX_SESSION_ID: teamSessionId }));
+    const worktreeMode = { enabled: true, detached: false, name: 'policy-preflight-reuse' } as const;
+    const previousLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const previousWorkerCliMap = process.env.OMX_TEAM_WORKER_CLI_MAP;
+    const previousLaunchArgs = process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+    const previousAllowNonTty = process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT;
+    const previousSessionId = process.env.OMX_SESSION_ID;
+    let workerWorktreePath: string | null = null;
+    let rejectedWorkerWorktreePath: string | null = null;
+    let rejectedWorkerBranchName: string | null = null;
+
+    try {
+      await writeFile(join(repo, '.gitignore'), '.omx/\n', 'utf-8');
+      execFileSync('git', ['add', '.gitignore'], { cwd: repo, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'ignore team worktrees'], { cwd: repo, stdio: 'ignore' });
+
+      const workerWorktreePlan = planWorktreeTarget({
+        cwd: repo,
+        scope: 'team',
+        mode: worktreeMode,
+        teamName: internalTeamName,
+        workerName: 'worker-1',
+      });
+      if (!workerWorktreePlan.enabled || !workerWorktreePlan.branchName) {
+        throw new Error('expected named reusable worker worktree plan');
+      }
+      workerWorktreePath = workerWorktreePlan.worktreePath;
+      await mkdir(dirname(workerWorktreePath), { recursive: true });
+      execFileSync(
+        'git',
+        ['worktree', 'add', '-b', workerWorktreePlan.branchName, workerWorktreePath, 'HEAD'],
+        { cwd: repo, stdio: 'ignore' },
+      );
+
+      const agentsPath = join(workerWorktreePath, 'AGENTS.md');
+      await writeFile(agentsPath, '# Reused worker instructions\n\nKeep this exact content.\n', 'utf-8');
+      execFileSync('git', ['add', 'AGENTS.md'], { cwd: workerWorktreePath, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'seed reusable worker instructions'], { cwd: workerWorktreePath, stdio: 'ignore' });
+      const agentsBefore = await readFile(agentsPath);
+      const indexBefore = execFileSync('git', ['ls-files', '-v', '--', 'AGENTS.md'], {
+        cwd: workerWorktreePath,
+        encoding: 'utf-8',
+      });
+      const statusBefore = execFileSync('git', ['status', '--porcelain=v1', '--untracked-files=all'], {
+        cwd: workerWorktreePath,
+        encoding: 'utf-8',
+      });
+      const rejectedWorkerPlan = planWorktreeTarget({
+        cwd: repo,
+        scope: 'team',
+        mode: worktreeMode,
+        teamName: internalTeamName,
+        workerName: 'worker-2',
+      });
+      if (!rejectedWorkerPlan.enabled || !rejectedWorkerPlan.branchName) {
+        throw new Error('expected named rejected worker worktree plan');
+      }
+      rejectedWorkerWorktreePath = rejectedWorkerPlan.worktreePath;
+      rejectedWorkerBranchName = rejectedWorkerPlan.branchName;
+      const worktreeRegistryBefore = execFileSync('git', ['worktree', 'list', '--porcelain'], {
+        cwd: repo,
+        encoding: 'utf-8',
+      });
+      const sourceStatusBefore = execFileSync('git', ['status', '--porcelain=v1', '--untracked-files=all'], {
+        cwd: repo,
+        encoding: 'utf-8',
+      });
+      const rejectedBranchBefore = execFileSync('git', ['branch', '--list', rejectedWorkerBranchName], {
+        cwd: repo,
+        encoding: 'utf-8',
+      });
+      assert.equal(rejectedBranchBefore, '');
+      assert.equal(existsSync(rejectedWorkerWorktreePath), false);
+
+
+      delete process.env.OMX_TEAM_WORKER_CLI;
+      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+      process.env.OMX_TEAM_WORKER_CLI_MAP = 'codex,claude';
+      process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = '--config sandbox_mode="workspace-write"';
+      process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT = '1';
+      process.env.OMX_SESSION_ID = teamSessionId;
+
+      await assert.rejects(
+        () => withoutTeamWorkerEnv(() =>
+          startTeam(
+            teamName,
+            'reject policy before reused worktree mutation',
+            'executor',
+            2,
+            [
+              { subject: 'Codex task', description: 'first worker', owner: 'worker-1' },
+              { subject: 'Claude task', description: 'later worker', owner: 'worker-2' },
+            ],
+            repo,
+            { worktreeMode },
+          )),
+        /Selected team worker CLI "claude" is incompatible with an explicit approval or sandbox policy\./,
+      );
+
+      assert.deepEqual(await readFile(agentsPath), agentsBefore);
+      assert.equal(
+        execFileSync('git', ['ls-files', '-v', '--', 'AGENTS.md'], {
+          cwd: workerWorktreePath,
+          encoding: 'utf-8',
+        }),
+        indexBefore,
+      );
+      assert.equal(
+        execFileSync('git', ['status', '--porcelain=v1', '--untracked-files=all'], {
+          cwd: workerWorktreePath,
+          encoding: 'utf-8',
+        }),
+        statusBefore,
+      );
+      assert.equal(
+        execFileSync('git', ['worktree', 'list', '--porcelain'], {
+          cwd: repo,
+          encoding: 'utf-8',
+        }),
+        worktreeRegistryBefore,
+      );
+      assert.equal(
+        execFileSync('git', ['status', '--porcelain=v1', '--untracked-files=all'], {
+          cwd: repo,
+          encoding: 'utf-8',
+        }),
+        sourceStatusBefore,
+      );
+      assert.equal(
+        execFileSync('git', ['branch', '--list', rejectedWorkerBranchName], {
+          cwd: repo,
+          encoding: 'utf-8',
+        }),
+        rejectedBranchBefore,
+      );
+      assert.equal(existsSync(rejectedWorkerWorktreePath), false);
+
+      assert.equal(existsSync(join(repo, '.omx', 'state', 'current-task-baseline.json')), false);
+      assert.equal(existsSync(join(repo, '.omx', 'state', 'team', internalTeamName)), false);
+    } finally {
+      if (typeof previousLaunchMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousLaunchMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof previousWorkerCliMap === 'string') process.env.OMX_TEAM_WORKER_CLI_MAP = previousWorkerCliMap;
+      else delete process.env.OMX_TEAM_WORKER_CLI_MAP;
+      if (typeof previousLaunchArgs === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_ARGS = previousLaunchArgs;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+      if (typeof previousAllowNonTty === 'string') process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT = previousAllowNonTty;
+      else delete process.env.OMX_TEST_ALLOW_NONTTY_CODEX_PROMPT;
+      if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      if (workerWorktreePath && existsSync(workerWorktreePath)) {
+        execFileSync('git', ['worktree', 'remove', '--force', workerWorktreePath], { cwd: repo, stdio: 'ignore' });
+      }
+      if (rejectedWorkerWorktreePath && existsSync(rejectedWorkerWorktreePath)) {
+        execFileSync('git', ['worktree', 'remove', '--force', rejectedWorkerWorktreePath], { cwd: repo, stdio: 'ignore' });
+      }
+      if (rejectedWorkerBranchName) {
+        const rejectedBranch = execFileSync('git', ['branch', '--list', rejectedWorkerBranchName], {
+          cwd: repo,
+          encoding: 'utf-8',
+        });
+        if (rejectedBranch.trim() !== '') {
+          execFileSync('git', ['branch', '-D', rejectedWorkerBranchName], { cwd: repo, stdio: 'ignore' });
+        }
+      }
+      await rm(repo, { recursive: true, force: true });
+    }
   });
 
   it('resolveWorkerLaunchArgsFromEnv reads low-complexity model from config when present', async () => {

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -23,6 +23,9 @@ import {
   resolvePersistedApprovedTeamExecutionContinuityState,
   writePersistedApprovedTeamExecutionBinding,
 } from '../approved-execution.js';
+import { TEAM_WORKER_INHERITED_MODEL_ENV } from '../model-contract.js';
+import { buildWorkerProcessLaunchSpec } from '../tmux-session.js';
+
 
 delete process.env.OMX_TEAM_STATE_ROOT;
 
@@ -636,6 +639,106 @@ describe('scaleUp', () => {
     }
   });
 
+  it('rejects explicit mixed worker policy before scale-up creates worker state or a pane', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-scale-up-explicit-policy-'));
+    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-scale-up-explicit-policy-bin-'));
+    const tmuxLogPath = join(fakeBinDir, 'tmux.log');
+    const tmuxStubPath = join(fakeBinDir, 'tmux');
+    const previousPath = process.env.PATH;
+    try {
+      await writeFile(tmuxStubPath, `#!/bin/sh
+printf '%s\n' "$*" >> "${tmuxLogPath}"
+exit 0
+`);
+      await chmod(tmuxStubPath, 0o755);
+      await writeFile(tmuxLogPath, '');
+      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+      await initTeamState('scale-up-explicit-policy', 'task', 'executor', 1, cwd);
+
+      const result = await scaleUp(
+        'scale-up-explicit-policy',
+        1,
+        'executor',
+        [{ subject: 'new task', description: 'new task', owner: 'worker-2' }],
+        cwd,
+        {
+          OMX_TEAM_SCALING_ENABLED: '1',
+          OMX_TEAM_WORKER_LAUNCH_ARGS: '--dangerously-bypass-approvals-and-sandbox --sandbox workspace-write',
+        },
+      );
+      assert.equal(result.ok, false);
+      if (!result.ok) {
+        assert.match(result.error, /Invalid OMX_TEAM_WORKER_LAUNCH_ARGS: bypass cannot be combined with direct approval or sandbox policy/);
+      }
+      const config = await readTeamConfig('scale-up-explicit-policy', cwd);
+      assert.equal(config?.workers.length, 1);
+      assert.equal(config?.next_worker_index, 2);
+      assert.deepEqual(await readScaleUpTaskPayloads('scale-up-explicit-policy', cwd), []);
+      assert.equal(existsSync(join(cwd, '.omx', 'state', 'team', 'scale-up-explicit-policy', 'workers', 'worker-2')), false);
+      assert.equal(existsSync(workerStartupScriptPath(cwd, 'scale-up-explicit-policy', 'worker-2')), false);
+      const tmuxCommands = await readScaleUpTmuxLogCommands(tmuxLogPath);
+      assert.equal(tmuxCommands.some((command) => command.startsWith('split-window ')), false);
+      assert.equal(tmuxCommands.some((command) => command.startsWith('send-keys ')), false);
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(fakeBinDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects Claude and Gemini restrictive config policy before scale-up creates task payloads, worker state, a pane, or process', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-scale-up-restrictive-noncodex-'));
+    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-scale-up-restrictive-noncodex-bin-'));
+    const tmuxLogPath = join(fakeBinDir, 'tmux.log');
+    const tmuxStubPath = join(fakeBinDir, 'tmux');
+    const previousPath = process.env.PATH;
+    try {
+      await writeFile(tmuxStubPath, `#!/bin/sh
+printf '%s\n' "$*" >> "${tmuxLogPath}"
+exit 0
+`);
+      await chmod(tmuxStubPath, 0o755);
+      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+
+      for (const workerCli of ['claude', 'gemini'] as const) {
+        const teamName = `scale-up-restrictive-${workerCli}`;
+        await writeFile(tmuxLogPath, '');
+        await initTeamState(teamName, 'task', 'executor', 1, cwd);
+        const result = await scaleUp(
+          teamName,
+          1,
+          'executor',
+          [{ subject: 'new task', description: 'new task', owner: 'worker-2' }],
+          cwd,
+          {
+            OMX_TEAM_SCALING_ENABLED: '1',
+            OMX_TEAM_WORKER_CLI: workerCli,
+            OMX_TEAM_WORKER_LAUNCH_ARGS: `--config 'sandbox_mode="workspace-write"'`,
+          },
+        );
+        assert.equal(result.ok, false);
+        if (!result.ok) {
+          assert.match(result.error, new RegExp(`Selected team worker CLI "${workerCli}" is incompatible with an explicit approval or sandbox policy\\.`));
+        }
+        const config = await readTeamConfig(teamName, cwd);
+        assert.equal(config?.workers.length, 1);
+        assert.equal(config?.next_worker_index, 2);
+        assert.deepEqual(await readScaleUpTaskPayloads(teamName, cwd), []);
+        assert.equal(existsSync(join(cwd, '.omx', 'state', 'team', teamName, 'workers', 'worker-2')), false);
+        assert.equal(existsSync(workerStartupScriptPath(cwd, teamName, 'worker-2')), false);
+        const tmuxCommands = await readScaleUpTmuxLogCommands(tmuxLogPath);
+        assert.equal(tmuxCommands.some((command) => command.startsWith('split-window ')), false);
+        assert.equal(tmuxCommands.some((command) => command.startsWith('send-keys ')), false);
+      }
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(fakeBinDir, { recursive: true, force: true });
+    }
+  });
+
 
   it('persists scaled-up task roles in canonical task state and inbox ids', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-scale-up-role-'));
@@ -711,6 +814,8 @@ describe('scaleUp', () => {
         [{ subject: 'document routing report only', description: 'document routing report only', owner: 'worker-2', role: 'writer' }],
         cwd,
         { OMX_TEAM_SCALING_ENABLED: '1', OMX_TEAM_SKIP_READY_WAIT: '1' },
+
+
       );
       assert.equal(result.ok, true);
       if (!result.ok) return;
@@ -733,6 +838,136 @@ describe('scaleUp', () => {
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(fakeBinDir, { recursive: true, force: true });
+    }
+  });
+
+  it('covers the scale-up config-policy and no-policy argv matrix', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-scale-up-policy-matrix-'));
+    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-scale-up-policy-matrix-bin-'));
+    const tmuxLogPath = join(fakeBinDir, 'tmux.log');
+    const capturePath = join(cwd, 'worker-argv.txt');
+    const emptyCodexHome = await mkdtemp(join(tmpdir(), 'omx-scale-up-policy-matrix-codex-home-'));
+    const previousPath = process.env.PATH;
+    const previousArgv = process.argv;
+    const previousBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    try {
+      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath);
+      await writeFile(
+        join(fakeBinDir, 'codex'),
+        `#!/bin/sh
+printf '%s\\n' "$@" > '${capturePath}'
+`,
+      );
+      await chmod(join(fakeBinDir, 'codex'), 0o755);
+      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+      process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+
+      const runScaleUpCase = async (params: {
+        teamName: string;
+        role?: string;
+        launchArgs: string;
+        inheritedModel?: string;
+      }): Promise<string[]> => {
+        await writeFile(capturePath, '');
+        await initTeamState(params.teamName, 'task', 'executor', 1, cwd);
+        await configureScaleUpTeamForDirectDispatch(params.teamName, cwd);
+        const result = await scaleUp(
+          params.teamName,
+          1,
+          'executor',
+          [{
+            subject: 'implement task',
+            description: 'implement task',
+            owner: 'worker-2',
+            ...(params.role === undefined ? {} : { role: params.role }),
+          }],
+          cwd,
+          {
+            OMX_TEAM_SCALING_ENABLED: '1',
+            OMX_TEAM_SKIP_READY_WAIT: '1',
+            CODEX_HOME: emptyCodexHome,
+            OMX_TEAM_WORKER_LAUNCH_ARGS: params.launchArgs,
+            ...(params.inheritedModel ? { [TEAM_WORKER_INHERITED_MODEL_ENV]: params.inheritedModel } : {}),
+          },
+        );
+        if (!result.ok) assert.fail(result.error);
+
+        const startupScriptPath = workerStartupScriptPath(cwd, params.teamName, 'worker-2');
+        const scriptResult = execFileSync('/bin/sh', [startupScriptPath], { encoding: 'utf-8' });
+        assert.equal(scriptResult, '');
+        return (await readFile(capturePath, 'utf-8')).trim().split('\n');
+      };
+
+      process.argv = [
+        ...previousArgv.filter((arg) => arg !== '--dangerously-bypass-approvals-and-sandbox' && arg !== '--madmax'),
+        '--madmax',
+      ];
+      const sandboxArgs = await runScaleUpCase({
+        teamName: 'scale-up-sandbox-policy',
+        role: 'executor',
+        launchArgs: String.raw`--config 'sandbox_mode="workspace-write"' -- 'C:\scale-up\nested\' '--sandbox=read-only' '--madmax'`,
+        inheritedModel: 'leader-model',
+      });
+      const expectedSandboxArgs = [
+        '--sandbox', 'workspace-write',
+        '-c', 'model_reasoning_effort="medium"',
+        '--model', 'leader-model',
+        '--', 'C:\\scale-up\\nested\\', '--sandbox=read-only', '--madmax',
+      ];
+      assert.deepEqual(sandboxArgs, expectedSandboxArgs);
+      assert.deepEqual(
+        buildWorkerProcessLaunchSpec(
+          'initial-policy-team',
+          1,
+          expectedSandboxArgs,
+          cwd,
+          { CODEX_HOME: emptyCodexHome },
+          'codex',
+          undefined,
+          'executor',
+        ).args,
+        sandboxArgs,
+      );
+
+      const approvalArgs = await runScaleUpCase({
+        teamName: 'scale-up-approval-policy',
+        role: 'executor',
+        launchArgs: '--ask-for-approval=on-request',
+        inheritedModel: 'leader-model',
+      });
+      assert.deepEqual(approvalArgs, [
+        '--ask-for-approval', 'on-request',
+        '-c', 'model_reasoning_effort="medium"',
+        '--model', 'leader-model',
+      ]);
+
+      process.argv = previousArgv.filter((arg) => arg !== '--dangerously-bypass-approvals-and-sandbox' && arg !== '--madmax');
+      const bypass = '--dangerously-bypass-approvals-and-sandbox';
+      assert.deepEqual(
+        await runScaleUpCase({ teamName: 'scale-up-execution-default', role: 'executor', launchArgs: '--model policy-model' }),
+        ['-c', 'model_reasoning_effort="medium"', '--model', 'policy-model', bypass],
+      );
+      assert.deepEqual(
+        await runScaleUpCase({ teamName: 'scale-up-nonexecution-default', role: 'explore', launchArgs: '--model policy-model' }),
+        ['-c', 'model_reasoning_effort="low"', '--model', 'policy-model'],
+      );
+      assert.deepEqual(
+        await runScaleUpCase({ teamName: 'scale-up-absent-role-default', launchArgs: '--model policy-model' }),
+        ['-c', 'model_reasoning_effort="medium"', '--model', 'policy-model', bypass],
+      );
+      assert.deepEqual(
+        await runScaleUpCase({ teamName: 'scale-up-unknown-role-default', role: 'unknown-role', launchArgs: '--model policy-model' }),
+        ['-c', 'model_reasoning_effort="medium"', '--model', 'policy-model', bypass],
+      );
+    } finally {
+      process.argv = previousArgv;
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = previousBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      await rm(emptyCodexHome, { recursive: true, force: true });
       await rm(cwd, { recursive: true, force: true });
       await rm(fakeBinDir, { recursive: true, force: true });
     }

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1,10 +1,11 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { syncBuiltinESMExports } from 'node:module';
 import { PassThrough } from 'node:stream';
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { tmpdir } from 'os';
 import {
   buildClientAttachedReconcileHookName,
@@ -1115,7 +1116,7 @@ describe('buildWorkerStartupCommand', () => {
     process.env.SHELL = '/bin/bash';
     process.env.OMX_TEAM_WORKER_CLI = 'claude';
     process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
-    process.argv = [...prevArgv, '--madmax'];
+    process.argv = ['node', 'omx', '--madmax'];
     try {
       const cmd = buildWorkerStartupCommand('alpha', 1);
       assert.match(cmd, /exec .*claude/);
@@ -1615,7 +1616,7 @@ describe('buildWorkerStartupCommand', () => {
     process.env.SHELL = '/bin/bash';
     const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
     process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
-    process.argv = [...prevArgv, '--dangerously-bypass-approvals-and-sandbox'];
+    process.argv = ['node', 'omx', '--dangerously-bypass-approvals-and-sandbox'];
     try {
       const cmd = buildWorkerStartupCommand('alpha', 1, ['--dangerously-bypass-approvals-and-sandbox']);
       const matches = cmd.match(/--dangerously-bypass-approvals-and-sandbox/g) || [];
@@ -1635,7 +1636,7 @@ describe('buildWorkerStartupCommand', () => {
     process.env.SHELL = '/bin/bash';
     const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
     process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
-    process.argv = [...prevArgv, '--madmax'];
+    process.argv = ['node', 'omx', '--madmax'];
     try {
       const cmd = buildWorkerStartupCommand('alpha', 1);
       const matches = cmd.match(/--dangerously-bypass-approvals-and-sandbox/g) || [];
@@ -1763,6 +1764,36 @@ describe('buildWorkerStartupCommand', () => {
     }
   });
 
+  it('recognizes every model-instructions config spelling before -- and ignores positional suffixes', () => {
+    const previousBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const customOverride = 'model_instructions_file="/tmp/custom.md"';
+    const configForms = [
+      ['-c', customOverride],
+      ['--config', customOverride],
+      [`-c=${customOverride}`],
+      [`--config=${customOverride}`],
+    ];
+    delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    try {
+      for (const launchArgs of configForms) {
+        const spec = buildWorkerProcessLaunchSpec('alpha', 1, launchArgs, '/tmp/project', {}, 'codex', undefined, 'explore');
+        assert.equal(spec.args.filter((arg) => arg.includes('model_instructions_file=')).length, 1);
+        assert.ok(spec.args.some((arg) => arg.includes(customOverride)));
+      }
+
+      for (const launchArgs of configForms) {
+        const spec = buildWorkerProcessLaunchSpec('alpha', 1, ['--', ...launchArgs], '/tmp/project', {}, 'codex', undefined, 'explore');
+        const marker = spec.args.indexOf('--');
+        assert.ok(marker > 0);
+        assert.ok(spec.args.slice(0, marker).some((arg) => arg.includes('model_instructions_file="/tmp/project/AGENTS.md"')));
+        assert.deepEqual(spec.args.slice(marker + 1), launchArgs);
+      }
+    } finally {
+      if (typeof previousBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = previousBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
 
   it('does not synthesize absent first-party OMX MCP server tables for Codex team workers', async () => {
     const prevBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
@@ -1816,6 +1847,50 @@ describe('buildWorkerStartupCommand', () => {
       else delete process.env.OMX_TEAM_WORKER_MCP_COMPAT;
       if (typeof prevCodexHome === 'string') process.env.CODEX_HOME = prevCodexHome;
       else delete process.env.CODEX_HOME;
+    }
+  });
+
+  it('recognizes every MCP config spelling before -- and inserts generated overrides before positional suffixes', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'omx-team-mcp-config-forms-'));
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-team-mcp-home-'));
+    const previousBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const previousCompat = process.env.OMX_TEAM_WORKER_MCP_COMPAT;
+    const enabledOverride = 'mcp_servers.omx_state.enabled=true';
+    const configForms = [
+      ['-c', enabledOverride],
+      ['--config', enabledOverride],
+      [`-c=${enabledOverride}`],
+      [`--config=${enabledOverride}`],
+    ];
+    try {
+      await writeFile(join(codexHome, 'config.toml'), '[mcp_servers.omx_state]\ncommand = "omx"\n');
+      process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+      delete process.env.OMX_TEAM_WORKER_MCP_COMPAT;
+      const startupEnv = { OMX_TEAM_STATE_ROOT: stateRoot, CODEX_HOME: codexHome };
+
+      for (const [index, launchArgs] of configForms.entries()) {
+        writeWorkerStartupScriptCommand('alpha', index + 1, launchArgs, '/tmp/project', startupEnv, 'codex', undefined, 'explore');
+        const script = await readFile(join(stateRoot, 'team', 'alpha', 'runtime', `worker-${index + 1}-startup.sh`), 'utf-8');
+        assert.equal((script.match(/mcp_servers\.omx_state\.enabled=/g) ?? []).length, 1);
+        assert.match(script, /mcp_servers\.omx_state\.enabled=true/);
+        assert.doesNotMatch(script, /mcp_servers\.omx_state\.enabled=false/);
+      }
+
+      for (const [index, launchArgs] of configForms.entries()) {
+        const workerIndex = index + 10;
+        writeWorkerStartupScriptCommand('alpha', workerIndex, ['--', ...launchArgs], '/tmp/project', startupEnv, 'codex', undefined, 'explore');
+        const script = await readFile(join(stateRoot, 'team', 'alpha', 'runtime', `worker-${workerIndex}-startup.sh`), 'utf-8');
+        const generatedIndex = script.indexOf('mcp_servers.omx_state.enabled=false');
+        const positionalIndex = script.indexOf('mcp_servers.omx_state.enabled=true');
+        assert.ok(generatedIndex >= 0 && generatedIndex < positionalIndex);
+      }
+    } finally {
+      if (typeof previousBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = previousBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof previousCompat === 'string') process.env.OMX_TEAM_WORKER_MCP_COMPAT = previousCompat;
+      else delete process.env.OMX_TEAM_WORKER_MCP_COMPAT;
+      await rm(stateRoot, { recursive: true, force: true });
+      await rm(codexHome, { recursive: true, force: true });
     }
   });
 
@@ -2267,6 +2342,8 @@ describe('team worker CLI helpers', () => {
     assert.equal(resolveTeamWorkerCli(['--model', 'gemini-2.0-pro'], {}), 'gemini');
     assert.equal(resolveTeamWorkerCli(['--model', 'gpt-5'], {}), 'codex');
     assert.equal(resolveTeamWorkerCli([], {}), 'codex');
+    assert.equal(resolveTeamWorkerCli(['--', '--model', 'claude-3-7-sonnet'], {}), 'codex');
+    assert.equal(resolveTeamWorkerCli(['--', '--model=gemini-2.0-pro'], {}), 'codex');
   });
 
   it('resolveTeamWorkerCli accepts explicit gemini override', () => {
@@ -2510,6 +2587,309 @@ describe('team worker launch mode helpers', () => {
       assert.deepEqual(spec.args, ['--model', 'gpt-5.6-luna']);
     } finally {
       if (typeof prevBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = prevBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
+  it('suppresses ambient madmax and role-default bypass for direct Codex policy', () => {
+    const previousArgv = process.argv;
+    const previousBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.argv = ['node', 'omx', '--madmax'];
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      const spec = buildWorkerProcessLaunchSpec(
+        'policy-team',
+        1,
+        ['--ask-for-approval', 'on-request'],
+        '/tmp/workspace',
+        {},
+        'codex',
+        undefined,
+        'executor',
+      );
+      assert.deepEqual(spec.args, ['--ask-for-approval', 'on-request']);
+    } finally {
+      process.argv = previousArgv;
+      if (typeof previousBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = previousBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
+  it('preserves no-policy Codex bypass defaults exactly once for execution, absent, and unknown roles', () => {
+    const previousArgv = process.argv;
+    const previousBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.argv = ['node', 'omx'];
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+
+      for (const role of ['executor', undefined, 'unknown-role']) {
+        const spec = buildWorkerProcessLaunchSpec('policy-team', 1, [], '/tmp/workspace', {}, 'codex', undefined, role);
+        assert.equal(spec.args.filter((arg) => arg === '--dangerously-bypass-approvals-and-sandbox').length, 1, String(role));
+      }
+      const readOnlySpec = buildWorkerProcessLaunchSpec('policy-team', 1, [], '/tmp/workspace', {}, 'codex', undefined, 'explore');
+      assert.equal(readOnlySpec.args.includes('--dangerously-bypass-approvals-and-sandbox'), false);
+      const bypassOnlySpec = buildWorkerProcessLaunchSpec('policy-team', 1, ['--madmax'], '/tmp/workspace', {}, 'codex', undefined, 'executor');
+      assert.deepEqual(bypassOnlySpec.args, ['--dangerously-bypass-approvals-and-sandbox']);
+    } finally {
+      process.argv = previousArgv;
+      if (typeof previousBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = previousBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
+  it('keeps ambient and role-default bypasses before end-of-options while suffix lookalikes remain positional', () => {
+    const previousArgv = process.argv;
+    const previousBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const positionalSuffix = ['--', '--madmax', '--sandbox', 'workspace-write', 'C:\\workspace\\tail\\'];
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      process.argv = ['node', 'omx', '--', '--madmax'];
+      assert.deepEqual(
+        buildWorkerProcessLaunchSpec('policy-team', 1, positionalSuffix, '/tmp/workspace', {}, 'codex', undefined, 'explore').args,
+        positionalSuffix,
+      );
+      assert.deepEqual(
+        buildWorkerProcessLaunchSpec('policy-team', 1, positionalSuffix, '/tmp/workspace', {}, 'codex', undefined, 'executor').args,
+        ['--dangerously-bypass-approvals-and-sandbox', ...positionalSuffix],
+      );
+
+      process.argv = ['node', 'omx', '--madmax', '--', '--sandbox', 'workspace-write'];
+      assert.deepEqual(
+        buildWorkerProcessLaunchSpec('policy-team', 1, positionalSuffix, '/tmp/workspace', {}, 'codex', undefined, 'explore').args,
+        ['--dangerously-bypass-approvals-and-sandbox', ...positionalSuffix],
+      );
+    } finally {
+      process.argv = previousArgv;
+      if (typeof previousBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = previousBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
+  it('fails closed when a mixed final Codex policy reaches the platform boundary', () => {
+    const previousBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      assert.throws(
+        () => buildWorkerProcessLaunchSpec(
+          'policy-team',
+          1,
+          ['--dangerously-bypass-approvals-and-sandbox', '--sandbox', 'workspace-write'],
+          '/tmp/workspace',
+          {},
+          'codex',
+          undefined,
+          'executor',
+        ),
+        /internal_mixed_codex_worker_policy_argv/,
+      );
+    } finally {
+      if (typeof previousBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = previousBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
+  it('executes the generated POSIX startup script with canonical config policy and exact positional argv', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'omx-worker-policy-script-'));
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-worker-policy-codex-home-'));
+    const fakeBin = join(stateRoot, 'bin');
+    const capturePath = join(stateRoot, 'worker-argv.json');
+    const injectionMarkerPath = join(stateRoot, 'injected');
+    const previousBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const previousPath = process.env.PATH;
+    const previousCapture = process.env.OMX_POLICY_ARGV_CAPTURE;
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    process.env.OMX_POLICY_ARGV_CAPTURE = capturePath;
+    try {
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(
+        join(fakeBin, 'codex'),
+        `#!/usr/bin/env node
+require('fs').writeFileSync(process.env.OMX_POLICY_ARGV_CAPTURE, JSON.stringify(process.argv.slice(2)));
+`,
+      );
+      await chmod(join(fakeBin, 'codex'), 0o755);
+      process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
+
+      const positionalSuffix = [
+        'C:\\workspace\\nested\\',
+        '',
+        '--sandbox=read-only',
+        '--madmax',
+        `$(touch ${injectionMarkerPath})`,
+      ];
+      const launchArgs = ['--config', 'sandbox_mode="workspace-write"', '--', ...positionalSuffix];
+      const expectedArgs = ['--sandbox', 'workspace-write', '--', ...positionalSuffix];
+      const workerEnv = { OMX_TEAM_STATE_ROOT: stateRoot, CODEX_HOME: codexHome };
+      const spec = buildWorkerProcessLaunchSpec('policy-team', 1, launchArgs, stateRoot, workerEnv, 'codex', undefined, 'executor');
+      const scriptCommand = writeWorkerStartupScriptCommand(
+        'policy-team',
+        1,
+        launchArgs,
+        stateRoot,
+        workerEnv,
+        'codex',
+        undefined,
+        'executor',
+      );
+      const scriptPath = join(stateRoot, 'team', 'policy-team', 'runtime', 'worker-1-startup.sh');
+      const script = await readFile(scriptPath, 'utf-8');
+      const execution = spawnSync('/bin/sh', [scriptPath], { encoding: 'utf-8' });
+
+      assert.deepEqual(spec.args, expectedArgs);
+      assert.equal(spec.env.CODEX_HOME, codexHome);
+      assert.match(script, new RegExp(escapeRegExp(`export CODEX_HOME='${codexHome}'`)));
+      assert.match(scriptCommand ?? '', /worker-1-startup\.sh/);
+      assert.equal(execution.status, 0, execution.stderr);
+      assert.deepEqual(JSON.parse(await readFile(capturePath, 'utf-8')), expectedArgs);
+      assert.equal(fs.existsSync(injectionMarkerPath), false);
+      assert.doesNotMatch(script, /dangerously-bypass-approvals-and-sandbox/);
+    } finally {
+      if (typeof previousBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = previousBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousCapture === 'string') process.env.OMX_POLICY_ARGV_CAPTURE = previousCapture;
+      else delete process.env.OMX_POLICY_ARGV_CAPTURE;
+      await rm(stateRoot, { recursive: true, force: true });
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  it('captures exact native-Windows harness PowerShell wrapper argv for canonical policy and positional suffixes', async () => {
+    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-worker-policy-win32-'));
+    const capturePath = join(fakeBin, 'powershell-argv.json');
+    const previousPath = process.env.PATH;
+    const previousPathext = process.env.PATHEXT;
+    const previousBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    const previousMsystem = process.env.MSYSTEM;
+    const previousOstype = process.env.OSTYPE;
+    const previousWsl = process.env.WSL_DISTRO_NAME;
+    const previousWslInterop = process.env.WSL_INTEROP;
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    try {
+      const codexPs1Path = join(fakeBin, 'codex.ps1');
+      const powershellExePath = join(fakeBin, 'powershell.exe');
+      await writeFile(codexPs1Path, '');
+      await writeFile(
+        powershellExePath,
+        `#!${process.execPath}
+require('fs').writeFileSync(process.env.OMX_POLICY_ARGV_CAPTURE, JSON.stringify(process.argv.slice(2)));
+`,
+      );
+      await chmod(powershellExePath, 0o755);
+      process.env.PATH = fakeBin;
+      process.env.PATHEXT = '.EXE;.PS1';
+      process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+      delete process.env.MSYSTEM;
+      delete process.env.OSTYPE;
+      delete process.env.WSL_DISTRO_NAME;
+      delete process.env.WSL_INTEROP;
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+      const positionalSuffix = ['C:\\workspace\\nested\\', '', '--sandbox=read-only', '--madmax'];
+      const expectedWorkerArgs = ['--sandbox', 'workspace-write', '--', ...positionalSuffix];
+      const windowsSpec = buildWorkerProcessLaunchSpec(
+        'policy-team',
+        1,
+        ['--config', 'sandbox_mode="workspace-write"', '--', ...positionalSuffix],
+        'C:\\workspace',
+        {},
+        'codex',
+        undefined,
+        'executor',
+      );
+      const execution = spawnSync(windowsSpec.command, windowsSpec.args, {
+        encoding: 'utf-8',
+        env: { ...process.env, ...windowsSpec.env, OMX_POLICY_ARGV_CAPTURE: capturePath },
+      });
+
+      assert.equal(windowsSpec.command, powershellExePath);
+      assert.equal(execution.status, 0, execution.stderr);
+      assert.deepEqual(JSON.parse(await readFile(capturePath, 'utf-8')), [
+        '-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', codexPs1Path, ...expectedWorkerArgs,
+      ]);
+    } finally {
+      if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      if (typeof previousPathext === 'string') process.env.PATHEXT = previousPathext;
+      else delete process.env.PATHEXT;
+      if (typeof previousBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = previousBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      if (typeof previousMsystem === 'string') process.env.MSYSTEM = previousMsystem;
+      else delete process.env.MSYSTEM;
+      if (typeof previousOstype === 'string') process.env.OSTYPE = previousOstype;
+      else delete process.env.OSTYPE;
+      if (typeof previousWsl === 'string') process.env.WSL_DISTRO_NAME = previousWsl;
+      else delete process.env.WSL_DISTRO_NAME;
+      if (typeof previousWslInterop === 'string') process.env.WSL_INTEROP = previousWslInterop;
+      else delete process.env.WSL_INTEROP;
+      await rm(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects Claude and Gemini restrictive policies before permission translation', () => {
+    const previousBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      for (const workerCli of ['claude', 'gemini'] as const) {
+        const incompatibility = new RegExp(`Selected team worker CLI "${workerCli}" is incompatible with an explicit approval or sandbox policy\\.`);
+        assert.throws(
+          () => buildWorkerProcessLaunchSpec(
+            'policy-team', 1, ['--sandbox', 'workspace-write'], '/tmp/workspace', {}, workerCli, 'Read worker inbox', 'executor',
+          ),
+          incompatibility,
+        );
+        assert.throws(
+          () => buildWorkerProcessLaunchSpec(
+            'policy-team', 1, ['--config', 'sandbox_mode="workspace-write"'], '/tmp/workspace', {}, workerCli, 'Read worker inbox', 'executor',
+          ),
+          incompatibility,
+        );
+        const positionalModel = `${workerCli}-positional-model`;
+        const positionalSpec = buildWorkerProcessLaunchSpec(
+          'policy-team',
+          1,
+          ['--config', 'sandbox_mode="workspace-write"', '--', '--model', positionalModel],
+          '/tmp/workspace',
+          {},
+          undefined,
+          undefined,
+          'executor',
+        );
+        assert.equal(positionalSpec.workerCli, 'codex');
+        assert.deepEqual(positionalSpec.args, [
+          '--sandbox', 'workspace-write', '--', '--model', positionalModel,
+        ]);
+      }
+    } finally {
+      if (typeof previousBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = previousBypass;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    }
+  });
+
+  it('preserves Claude and Gemini no-policy and bypass-only permission defaults', () => {
+    const previousBypass = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+    try {
+      assert.deepEqual(
+        buildWorkerProcessLaunchSpec('policy-team', 1, [], '/tmp/workspace', {}, 'claude', undefined, 'executor').args,
+        ['--dangerously-skip-permissions'],
+      );
+      assert.deepEqual(
+        buildWorkerProcessLaunchSpec('policy-team', 1, ['--madmax'], '/tmp/workspace', {}, 'claude', undefined, 'executor').args,
+        ['--dangerously-skip-permissions'],
+      );
+      assert.deepEqual(
+        buildWorkerProcessLaunchSpec('policy-team', 1, [], '/tmp/workspace', {}, 'gemini', 'Read worker inbox', 'executor').args,
+        ['--approval-mode', 'yolo', '-i', 'Read worker inbox'],
+      );
+      assert.deepEqual(
+        buildWorkerProcessLaunchSpec('policy-team', 1, ['--madmax'], '/tmp/workspace', {}, 'gemini', 'Read worker inbox', 'executor').args,
+        ['--approval-mode', 'yolo', '-i', 'Read worker inbox'],
+      );
+    } finally {
+      if (typeof previousBypass === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = previousBypass;
       else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
     }
   });
@@ -3462,6 +3842,140 @@ esac
 });
 
 describe('createTeamSession tmux instance tagging', () => {
+  it('rejects incompatible non-Codex and mixed Codex plans before any direct tmux mutation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-direct-policy-preflight-'));
+    const previousTmux = process.env.TMUX;
+    const previousTmuxPane = process.env.TMUX_PANE;
+    const previousBypassInstructions = process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-direct-policy-preflight-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  -V)
+    echo "tmux 3.4"
+    ;;
+  display-message)
+    echo "leader:0 %1"
+    ;;
+  list-panes)
+    printf "%%1\\tnode\\t'codex'\\n"
+    ;;
+  split-window)
+    echo "%2"
+    ;;
+  *)
+    ;;
+esac
+exit 0
+`,
+        async ({ logPath }) => {
+          const fakeBinDir = dirname(logPath);
+          for (const workerCli of ['codex', 'claude', 'gemini']) {
+            const binaryPath = join(fakeBinDir, workerCli);
+            await writeFile(binaryPath, '#!/bin/sh\nexit 0\n');
+            await chmod(binaryPath, 0o755);
+          }
+
+          process.env.TMUX = 'leader-session,stub,0';
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = '0';
+          const restrictiveArgs = ['--config', 'sandbox_mode="workspace-write"'];
+          const readOnlyPreflightCommands = [
+            '-V',
+            'display-message -p -t %1 #{session_name}:#{window_index} #{pane_id}',
+          ];
+
+
+          for (const workerCli of ['claude', 'gemini'] as const) {
+            for (const scenario of [
+              {
+                name: `direct-${workerCli}-first`,
+                workerCount: 1,
+                workerStartups: [{ workerCli, launchArgs: restrictiveArgs }],
+              },
+              {
+                name: `direct-${workerCli}-later`,
+                workerCount: 2,
+                workerStartups: [
+                  { workerCli: 'codex' as const, launchArgs: restrictiveArgs },
+                  { workerCli, launchArgs: restrictiveArgs },
+                ],
+              },
+            ]) {
+              await writeFile(logPath, '');
+              assert.throws(
+                () => createTeamSession(
+                  scenario.name,
+                  scenario.workerCount,
+                  cwd,
+                  [],
+                  scenario.workerStartups,
+                ),
+                new RegExp(`Selected team worker CLI "${workerCli}" is incompatible with an explicit approval or sandbox policy\\.`),
+              );
+              const tmuxCommands = (await readFile(logPath, 'utf-8')).trim().split('\n');
+              assert.deepEqual(
+                tmuxCommands,
+                readOnlyPreflightCommands,
+
+                `${scenario.name} must reject after read-only availability/context probes and before tagging, HUD cleanup, splits, or process launch`,
+              );
+            }
+          }
+
+          const mixedCodexArgs = [
+            '--dangerously-bypass-approvals-and-sandbox',
+            '--sandbox',
+            'workspace-write',
+          ];
+          for (const scenario of [
+            {
+              name: 'direct-codex-mixed-first',
+              workerCount: 1,
+              workerStartups: [{ workerCli: 'codex' as const, launchArgs: mixedCodexArgs }],
+            },
+            {
+              name: 'direct-codex-mixed-later',
+              workerCount: 2,
+              workerStartups: [
+                { workerCli: 'codex' as const, launchArgs: restrictiveArgs },
+                { workerCli: 'codex' as const, launchArgs: mixedCodexArgs },
+              ],
+            },
+          ]) {
+            await writeFile(logPath, '');
+            assert.throws(
+              () => createTeamSession(
+                scenario.name,
+                scenario.workerCount,
+                cwd,
+                [],
+                scenario.workerStartups,
+              ),
+              /internal_mixed_codex_worker_policy_argv/,
+            );
+            assert.deepEqual(
+              (await readFile(logPath, 'utf-8')).trim().split('\n'),
+              readOnlyPreflightCommands,
+              `${scenario.name} must reject before tagging, HUD cleanup, splits, or process launch`,
+            );
+          }
+        },
+      );
+    } finally {
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof previousBypassInstructions === 'string') process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT = previousBypassInstructions;
+      else delete process.env.OMX_BYPASS_DEFAULT_SYSTEM_PROMPT;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('redraws the leader pane after team layout changes so wrapped diff hunks repaint with gutters', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-redraw-leader-'));
     const prevTmux = process.env.TMUX;

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -12,8 +12,13 @@ const MADMAX_FLAG = '--madmax';
 const CODEX_BYPASS_FLAG = '--dangerously-bypass-approvals-and-sandbox';
 const MODEL_FLAG = '--model';
 const CONFIG_FLAG = '-c';
+const LONG_CONFIG_FLAG = '--config';
+const APPROVAL_POLICY_KEY = 'approval_policy';
+const SANDBOX_MODE_KEY = 'sandbox_mode';
 const REASONING_KEY = 'model_reasoning_effort';
 const MODEL_PROVIDER_KEY = 'model_provider';
+export const TEAM_WORKER_APPROVAL_FLAG = '--ask-for-approval';
+export const TEAM_WORKER_SANDBOX_FLAG = '--sandbox';
 export const TEAM_WORKER_INHERITED_MODEL_ENV = 'OMX_TEAM_WORKER_INHERITED_MODEL';
 
 const LOW_COMPLEXITY_AGENT_TYPES = new Set([
@@ -25,10 +30,16 @@ const LOW_COMPLEXITY_AGENT_TYPES = new Set([
 // Canonical default only; effective low-complexity resolution flows through resolveTeamLowComplexityDefaultModel().
 export const TEAM_LOW_COMPLEXITY_DEFAULT_MODEL = DEFAULT_SPARK_MODEL;
 export type TeamReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
+export type TeamWorkerLaunchPolicyKind = 'none' | 'bypass' | 'direct-policy';
+export type TeamWorkerLaunchPolicyClassification = TeamWorkerLaunchPolicyKind | 'mixed-policy';
 
 export interface ParsedTeamWorkerLaunchArgs {
   passthrough: string[];
+  endOfOptionsIndex: number | null;
   wantsBypass: boolean;
+  approvalValue: string | null;
+  sandboxValue: string | null;
+  policyKind: TeamWorkerLaunchPolicyKind;
   reasoningOverride: string | null;
   modelProviderOverride: string | null;
   modelOverride: string | null;
@@ -57,6 +68,11 @@ export interface ResolveTeamWorkerLaunchArgsOptions {
   honorExactRoleModel?: boolean;
 }
 
+function teamWorkerLaunchArgsError(source: string, reason: string): Error {
+  return new Error(`Invalid ${source}: ${reason}`);
+}
+
+type PolicyAxis = 'approval' | 'sandbox';
 
 function isConfigOverrideForKey(value: string, key: string): boolean {
   return new RegExp(`^${key}\\s*=`).test(value.trim());
@@ -70,6 +86,12 @@ function isModelProviderOverride(value: string): boolean {
   return isConfigOverrideForKey(value, MODEL_PROVIDER_KEY);
 }
 
+function canonicalizeConfigStringOverride(value: string, key: string): string {
+  const extracted = extractConfigStringValue(value, key);
+  if (!extracted) return value;
+  return `${key}="${extracted.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
 function extractConfigStringValue(value: string, key: string): string | null {
   const trimmed = value.trim();
   const match = new RegExp(`^${key}\\s*=\\s*(.+)$`).exec(trimmed);
@@ -78,6 +100,27 @@ function extractConfigStringValue(value: string, key: string): string | null {
   if (raw === '') return null;
   const quoted = /^(?:\"([^\"]*)\"|'([^']*)')$/.exec(raw);
   return (quoted?.[1] ?? quoted?.[2] ?? raw).trim() || null;
+}
+
+function configSelector(arg: string): { value?: string } | null {
+  if (arg === CONFIG_FLAG || arg === LONG_CONFIG_FLAG) return {};
+  if (arg.startsWith(`${CONFIG_FLAG}=`)) return { value: arg.slice(`${CONFIG_FLAG}=`.length) };
+  if (arg.startsWith(`${LONG_CONFIG_FLAG}=`)) return { value: arg.slice(`${LONG_CONFIG_FLAG}=`.length) };
+  return null;
+}
+
+function extractConfigPolicyAssignment(value: string): { axis: PolicyAxis; value: string } | null {
+  const match = new RegExp(`^(${APPROVAL_POLICY_KEY}|${SANDBOX_MODE_KEY})\\s*=\\s*([\\s\\S]*)$`).exec(value.trim());
+  if (!match) return null;
+
+  const rawValue = match[2]!.trim();
+  const quoted = rawValue.length >= 2
+    && ((rawValue.startsWith('"') && rawValue.endsWith('"'))
+      || (rawValue.startsWith("'") && rawValue.endsWith("'")));
+  return {
+    axis: match[1] === APPROVAL_POLICY_KEY ? 'approval' : 'sandbox',
+    value: quoted ? rawValue.slice(1, -1) : rawValue,
+  };
 }
 
 function isValidModelValue(value: string): boolean {
@@ -143,25 +186,234 @@ function resolveTeamWorkerLaunchDiagnosticsFromParts(params: {
   };
 }
 
+/**
+ * Tokenize OMX_TEAM_WORKER_LAUNCH_ARGS without evaluating shell syntax.
+ * Quoting and escaping are intentionally limited to this transport grammar.
+ */
 export function splitWorkerLaunchArgs(raw: string | undefined): string[] {
-  if (!raw || raw.trim() === '') return [];
-  return raw
-    .split(/\s+/)
-    .map((s) => s.trim())
-    .filter(Boolean);
+  if (raw === undefined || raw === '') return [];
+
+  const args: string[] = [];
+  let token = '';
+  let tokenStarted = false;
+  let quote: 'single' | 'double' | null = null;
+
+  for (let index = 0; index < raw.length; index += 1) {
+    const character = raw[index]!;
+    if (quote === 'single') {
+      if (character === "'") quote = null;
+      else token += character;
+      continue;
+    }
+
+    if (quote === 'double') {
+      if (character === '"') {
+        quote = null;
+      } else if (character === '\\' && raw[index + 1] === '"') {
+        token += '"';
+        index += 1;
+      } else {
+        token += character;
+      }
+      continue;
+    }
+
+    if (/\s/u.test(character)) {
+      if (tokenStarted) {
+        args.push(token);
+        token = '';
+        tokenStarted = false;
+      }
+      continue;
+    }
+    if (character === "'") {
+      quote = 'single';
+      tokenStarted = true;
+      continue;
+    }
+    if (character === '"') {
+      quote = 'double';
+      tokenStarted = true;
+      continue;
+    }
+    if (character === '\\') {
+      token += character;
+      tokenStarted = true;
+      continue;
+    }
+    token += character;
+    tokenStarted = true;
+  }
+
+  if (quote !== null) {
+    throw teamWorkerLaunchArgsError('OMX_TEAM_WORKER_LAUNCH_ARGS', 'unterminated quote');
+  }
+  if (tokenStarted) args.push(token);
+  return args;
 }
 
-export function parseTeamWorkerLaunchArgs(args: string[]): ParsedTeamWorkerLaunchArgs {
+/** Serialize worker launch arguments for reversible environment transport. */
+export function serializeTeamWorkerLaunchArgs(args: readonly string[]): string {
+  return args.map((arg) => {
+    if (arg.includes('\\')) return `'${arg.replace(/'/g, `'"'"'`)}'`;
+    return `"${arg.replace(/"/g, '\\"')}"`;
+  }).join(' ');
+}
+
+function parseDirectPolicyValue(
+  value: string | undefined,
+  flag: string,
+  source: string,
+): string {
+  if (typeof value !== 'string') {
+    throw teamWorkerLaunchArgsError(source, `missing value for ${flag}`);
+  }
+  const normalized = value.trim();
+  if (normalized === '' || normalized.startsWith('-')) {
+    throw teamWorkerLaunchArgsError(source, `missing value for ${flag}`);
+  }
+  return value;
+}
+
+function setDirectPolicyValue(
+  existingValue: string | null,
+  value: string,
+  axis: PolicyAxis,
+  source: string,
+): string {
+  if (existingValue !== null && existingValue !== value) {
+    throw teamWorkerLaunchArgsError(source, `conflicting duplicate ${axis} policy`);
+  }
+  return value;
+}
+
+function directPolicySelector(arg: string): { axis: 'approval' | 'sandbox'; flag: string; value?: string } | null {
+  if (arg === TEAM_WORKER_APPROVAL_FLAG || arg === '-a') {
+    return { axis: 'approval', flag: TEAM_WORKER_APPROVAL_FLAG };
+  }
+  if (arg.startsWith(`${TEAM_WORKER_APPROVAL_FLAG}=`)) {
+    return {
+      axis: 'approval',
+      flag: TEAM_WORKER_APPROVAL_FLAG,
+      value: arg.slice(`${TEAM_WORKER_APPROVAL_FLAG}=`.length),
+    };
+  }
+  if (arg.startsWith('-a=')) {
+    return { axis: 'approval', flag: TEAM_WORKER_APPROVAL_FLAG, value: arg.slice(3) };
+  }
+  if (arg === TEAM_WORKER_SANDBOX_FLAG || arg === '-s') {
+    return { axis: 'sandbox', flag: TEAM_WORKER_SANDBOX_FLAG };
+  }
+  if (arg.startsWith(`${TEAM_WORKER_SANDBOX_FLAG}=`)) {
+    return {
+      axis: 'sandbox',
+      flag: TEAM_WORKER_SANDBOX_FLAG,
+      value: arg.slice(`${TEAM_WORKER_SANDBOX_FLAG}=`.length),
+    };
+  }
+  if (arg.startsWith('-s=')) {
+    return { axis: 'sandbox', flag: TEAM_WORKER_SANDBOX_FLAG, value: arg.slice(3) };
+  }
+  return null;
+}
+
+interface ParseTeamWorkerLaunchArgsOptions {
+  directPolicyMode?: 'validate' | 'ignore';
+}
+
+export function parseTeamWorkerLaunchArgs(
+  args: string[],
+  source: string = 'worker launch arguments',
+  options: ParseTeamWorkerLaunchArgsOptions = {},
+): ParsedTeamWorkerLaunchArgs {
+
   const passthrough: string[] = [];
+  let endOfOptionsIndex: number | null = null;
   let wantsBypass = false;
+  let approvalValue: string | null = null;
+  let sandboxValue: string | null = null;
   let reasoningOverride: string | null = null;
   let modelProviderOverride: string | null = null;
   let modelOverride: string | null = null;
 
   for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
+    const arg = args[i]!;
+    if (arg === '--') {
+      endOfOptionsIndex = passthrough.length;
+      passthrough.push(...args.slice(i));
+      break;
+    }
     if (arg === CODEX_BYPASS_FLAG || arg === MADMAX_FLAG) {
       wantsBypass = true;
+      continue;
+    }
+
+    const directPolicy = directPolicySelector(arg);
+    if (directPolicy) {
+      if (options.directPolicyMode === 'ignore') {
+        if (directPolicy.value === undefined && typeof args[i + 1] === 'string' && !args[i + 1]!.startsWith('-')) {
+          i += 1;
+        }
+        continue;
+      }
+
+      const value = parseDirectPolicyValue(
+        directPolicy.value === undefined ? args[i + 1] : directPolicy.value,
+        directPolicy.flag,
+        source,
+      );
+      if (directPolicy.value === undefined) i += 1;
+      if (directPolicy.axis === 'approval') {
+        approvalValue = setDirectPolicyValue(approvalValue, value, 'approval', source);
+      } else {
+        sandboxValue = setDirectPolicyValue(sandboxValue, value, 'sandbox', source);
+      }
+      continue;
+    }
+
+    const config = configSelector(arg);
+    if (config) {
+      const splitConfig = config.value === undefined;
+      const configValue = splitConfig ? args[i + 1] : config.value;
+      const configValueMissing = typeof configValue !== 'string'
+        || configValue.trim() === ''
+        || configValue.trim().startsWith('-');
+      if (configValueMissing) {
+        if (options.directPolicyMode === 'ignore') continue;
+        const configFlag = arg === LONG_CONFIG_FLAG || arg.startsWith(`${LONG_CONFIG_FLAG}=`)
+          ? LONG_CONFIG_FLAG
+          : CONFIG_FLAG;
+        throw teamWorkerLaunchArgsError(source, `missing value for ${configFlag}`);
+      }
+      if (splitConfig) i += 1;
+
+      const configPolicy = typeof configValue === 'string' ? extractConfigPolicyAssignment(configValue) : null;
+      if (configPolicy) {
+        if (options.directPolicyMode === 'ignore') continue;
+
+        const flag = configPolicy.axis === 'approval' ? TEAM_WORKER_APPROVAL_FLAG : TEAM_WORKER_SANDBOX_FLAG;
+        const value = parseDirectPolicyValue(configPolicy.value, flag, source);
+        if (configPolicy.axis === 'approval') {
+          approvalValue = setDirectPolicyValue(approvalValue, value, 'approval', source);
+        } else {
+          sandboxValue = setDirectPolicyValue(sandboxValue, value, 'sandbox', source);
+        }
+        continue;
+      }
+
+      if (arg === CONFIG_FLAG && splitConfig && typeof configValue === 'string') {
+        if (isReasoningOverride(configValue)) {
+          reasoningOverride = configValue;
+          continue;
+        }
+        if (isModelProviderOverride(configValue)) {
+          modelProviderOverride = configValue;
+          continue;
+        }
+      }
+
+      passthrough.push(arg);
+      if (splitConfig && typeof configValue === 'string') passthrough.push(configValue);
       continue;
     }
 
@@ -184,34 +436,35 @@ export function parseTeamWorkerLaunchArgs(args: string[]): ParsedTeamWorkerLaunc
       continue;
     }
 
-    if (arg === CONFIG_FLAG) {
-      const maybeValue = args[i + 1];
-      if (typeof maybeValue === 'string' && isReasoningOverride(maybeValue)) {
-        reasoningOverride = maybeValue;
-        i += 1;
-        continue;
-      }
-      if (typeof maybeValue === 'string' && isModelProviderOverride(maybeValue)) {
-        modelProviderOverride = maybeValue;
-        i += 1;
-        continue;
-      }
-    }
-
     passthrough.push(arg);
   }
 
+  const policyKind: TeamWorkerLaunchPolicyKind = approvalValue !== null || sandboxValue !== null
+    ? 'direct-policy'
+    : wantsBypass
+      ? 'bypass'
+      : 'none';
   return {
     passthrough,
+    endOfOptionsIndex,
     wantsBypass,
+    approvalValue,
+    sandboxValue,
+    policyKind,
     reasoningOverride,
     modelProviderOverride,
     modelOverride,
   };
 }
 
+export function classifyTeamWorkerLaunchPolicy(args: string[]): TeamWorkerLaunchPolicyClassification {
+  const parsed = parseTeamWorkerLaunchArgs(args);
+  if (parsed.wantsBypass && parsed.policyKind === 'direct-policy') return 'mixed-policy';
+  return parsed.policyKind;
+}
+
 export function collectInheritableTeamWorkerArgs(codexArgs: string[]): string[] {
-  const parsed = parseTeamWorkerLaunchArgs(codexArgs);
+  const parsed = parseTeamWorkerLaunchArgs(codexArgs, 'leader arguments', { directPolicyMode: 'ignore' });
 
   const inherited: string[] = [];
   if (parsed.wantsBypass) inherited.push(CODEX_BYPASS_FLAG);
@@ -234,21 +487,28 @@ export function normalizeTeamWorkerLaunchArgs(
   preferredModelProviderOverride?: string,
 ): string[] {
   const parsed = parseTeamWorkerLaunchArgs(args);
-  const normalized = [...parsed.passthrough];
+  const endOfOptionsIndex = parsed.endOfOptionsIndex ?? parsed.passthrough.length;
+  const normalized = parsed.passthrough.slice(0, endOfOptionsIndex);
 
-  if (parsed.wantsBypass) normalized.push(CODEX_BYPASS_FLAG);
+  if (parsed.policyKind === 'direct-policy') {
+    if (parsed.approvalValue !== null) normalized.push(TEAM_WORKER_APPROVAL_FLAG, parsed.approvalValue);
+    if (parsed.sandboxValue !== null) normalized.push(TEAM_WORKER_SANDBOX_FLAG, parsed.sandboxValue);
+  } else if (parsed.wantsBypass) {
+    normalized.push(CODEX_BYPASS_FLAG);
+  }
 
   const selectedReasoning = parsed.reasoningOverride
     ?? (normalizeOptionalReasoning(preferredReasoning)
       ? `${REASONING_KEY}="${normalizeOptionalReasoning(preferredReasoning)}"`
       : null);
   const selectedModelProvider = preferredModelProviderOverride ?? parsed.modelProviderOverride;
-  if (selectedModelProvider) normalized.push(CONFIG_FLAG, selectedModelProvider);
-  if (selectedReasoning) normalized.push(CONFIG_FLAG, selectedReasoning);
+  if (selectedModelProvider) normalized.push(CONFIG_FLAG, canonicalizeConfigStringOverride(selectedModelProvider, MODEL_PROVIDER_KEY));
+  if (selectedReasoning) normalized.push(CONFIG_FLAG, canonicalizeConfigStringOverride(selectedReasoning, REASONING_KEY));
 
   const selectedModel = normalizeOptionalModel(preferredModel) ?? normalizeOptionalModel(parsed.modelOverride);
   if (selectedModel) normalized.push(MODEL_FLAG, selectedModel);
 
+  normalized.push(...parsed.passthrough.slice(endOfOptionsIndex));
   return normalized;
 }
 
@@ -273,10 +533,15 @@ function selectTeamWorkerModel(params: {
 export function resolveTeamWorkerLaunchArgs(options: ResolveTeamWorkerLaunchArgsOptions): string[] {
   const envArgs = splitWorkerLaunchArgs(options.existingRaw);
   const inheritedArgs = options.inheritedArgs ?? [];
-  const allArgs = [...envArgs, ...inheritedArgs];
+  const envParsed = parseTeamWorkerLaunchArgs(envArgs, 'OMX_TEAM_WORKER_LAUNCH_ARGS');
+  if (envParsed.wantsBypass && envParsed.policyKind === 'direct-policy') {
+    throw teamWorkerLaunchArgsError(
+      'OMX_TEAM_WORKER_LAUNCH_ARGS',
+      'bypass cannot be combined with direct approval or sandbox policy',
+    );
+  }
+  const inheritedParsed = parseTeamWorkerLaunchArgs(inheritedArgs, 'inherited leader worker launch arguments');
 
-  const envParsed = parseTeamWorkerLaunchArgs(envArgs);
-  const inheritedParsed = parseTeamWorkerLaunchArgs(inheritedArgs);
   const envModel = normalizeOptionalModel(envParsed.modelOverride);
   const inheritedModel = normalizeOptionalModel(inheritedParsed.modelOverride);
   const fallbackModel = normalizeOptionalModel(options.fallbackModel);
@@ -287,7 +552,16 @@ export function resolveTeamWorkerLaunchArgs(options: ResolveTeamWorkerLaunchArgs
     honorExactRoleModel: shouldHonorExactRoleModel(options),
   });
   const selectedModelProvider = envParsed.modelProviderOverride ?? inheritedParsed.modelProviderOverride ?? undefined;
-  return normalizeTeamWorkerLaunchArgs(allArgs, selectedModel, options.preferredReasoning, selectedModelProvider);
+  const endOfOptionsIndex = envArgs.indexOf('--');
+  const combinedArgs = endOfOptionsIndex === -1
+    ? [...envArgs, ...inheritedArgs]
+    : [...envArgs.slice(0, endOfOptionsIndex), ...inheritedArgs, ...envArgs.slice(endOfOptionsIndex)];
+  return normalizeTeamWorkerLaunchArgs(
+    combinedArgs,
+    selectedModel,
+    options.preferredReasoning,
+    selectedModelProvider,
+  );
 }
 
 export function resolveTeamWorkerLaunchDiagnostics(
@@ -295,8 +569,8 @@ export function resolveTeamWorkerLaunchDiagnostics(
 ): ResolvedTeamWorkerLaunchDiagnostics {
   const envArgs = splitWorkerLaunchArgs(options.existingRaw);
   const inheritedArgs = options.inheritedArgs ?? [];
-  const envParsed = parseTeamWorkerLaunchArgs(envArgs);
-  const inheritedParsed = parseTeamWorkerLaunchArgs(inheritedArgs);
+  const envParsed = parseTeamWorkerLaunchArgs(envArgs, 'OMX_TEAM_WORKER_LAUNCH_ARGS');
+  const inheritedParsed = parseTeamWorkerLaunchArgs(inheritedArgs, 'inherited leader worker launch arguments');
   const actualLaunchArgs = resolveTeamWorkerLaunchArgs(options);
 
   return resolveTeamWorkerLaunchDiagnosticsFromParts({

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -13,6 +13,7 @@ import {
   scrubTeamWorkerHudOwnershipEnv,
   resolveTeamWorkerCli,
   resolveTeamWorkerCliForResolvedLaunchArgs,
+  assertTeamWorkerCliPolicyCompatibility,
   type TeamWorkerCli,
   resolveTeamWorkerLaunchMode,
   type TeamSession,
@@ -120,7 +121,6 @@ import { composeRoleInstructionsForRole } from '../agents/native-config.js';
 import { codexPromptsDir } from '../utils/paths.js';
 import { isTerminalPhase, type TeamPhase, type TerminalPhase } from './orchestrator.js';
 import {
-  resolveTeamWorkerLaunchArgs,
   resolveTeamWorkerLaunchDiagnostics,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
   TEAM_WORKER_INHERITED_MODEL_ENV,
@@ -1640,10 +1640,13 @@ function resolveInstructionStateRoot(worktreePath?: string | null): string | und
   return worktreePath ? WORKTREE_TRIGGER_STATE_ROOT : undefined;
 }
 
-function assertPromptModeWorkerCliSupported(workerCliPlan: readonly TeamWorkerCli[]): void {
+function assertPromptModeWorkerCliSupported(
+  workerCliPlan: readonly TeamWorkerCli[],
+  env: NodeJS.ProcessEnv = process.env,
+): void {
   if (
     workerCliPlan.some((workerCli) => workerCli === 'codex')
-    && process.env[PROMPT_MODE_CODEX_TEST_ALLOW_ENV] !== '1'
+    && env[PROMPT_MODE_CODEX_TEST_ALLOW_ENV] !== '1'
   ) {
     throw new Error(
       `${PROMPT_MODE_CODEX_UNSUPPORTED_REASON}: Codex prompt workers require a terminal; use interactive team mode or set OMX_TEAM_WORKER_CLI=claude/gemini for prompt-mode teammates.`,
@@ -2404,6 +2407,62 @@ function resolveEffectiveWorkerCliForStartupLog(
   return resolveTeamWorkerCli(resolvedLaunchArgs, env);
 }
 
+interface WorkerLaunchPolicyPlan {
+  readonly workerName: string;
+  readonly workerRole: string;
+  readonly taskRoles: readonly string[];
+  readonly preferredReasoning: TeamReasoningEffort | undefined;
+  readonly workerLaunchArgs: readonly string[];
+  readonly workerCli: TeamWorkerCli;
+}
+
+function buildWorkerLaunchPolicyPlan(params: {
+  workerCount: number;
+  tasks: ReadonlyArray<{ owner?: string; role?: string }>;
+  agentType: string;
+  launchEnv: NodeJS.ProcessEnv;
+  codexHomeOverride?: string;
+}): readonly WorkerLaunchPolicyPlan[] {
+  const plans: WorkerLaunchPolicyPlan[] = [];
+
+  for (let workerIndex = 1; workerIndex <= params.workerCount; workerIndex++) {
+    const workerName = `worker-${workerIndex}`;
+    const taskRoles = params.tasks
+      .filter((task) => task.owner === workerName)
+      .map((task) => task.role)
+      .filter((role): role is string => Boolean(role));
+    const uniqueTaskRoles = [...new Set(taskRoles)];
+    const workerRole = taskRoles.length > 0 && uniqueTaskRoles.length === 1
+      ? taskRoles[0]!
+      : params.agentType;
+    const preferredReasoning = resolveAgentReasoningEffort(workerRole, params.codexHomeOverride)
+      ?? resolveAgentReasoningEffort(params.agentType, params.codexHomeOverride);
+    const workerLaunchArgs = resolveWorkerLaunchArgsFromEnv(
+      params.launchEnv,
+      workerRole,
+      undefined,
+      preferredReasoning,
+    );
+    const workerCli = resolveTeamWorkerCliForResolvedLaunchArgs(
+      workerIndex,
+      params.workerCount,
+      workerLaunchArgs,
+      params.launchEnv,
+    );
+
+    plans.push(Object.freeze({
+      workerName,
+      workerRole,
+      taskRoles: Object.freeze(uniqueTaskRoles),
+      preferredReasoning,
+      workerLaunchArgs: Object.freeze([...workerLaunchArgs]),
+      workerCli,
+    }));
+  }
+
+  return Object.freeze(plans);
+}
+
 
 async function writeDecompositionArtifacts(
   teamName: string,
@@ -2467,13 +2526,15 @@ export async function startTeam(
     : (typeof process.env.CODEX_HOME === 'string' && process.env.CODEX_HOME.trim() !== ''
         ? process.env.CODEX_HOME.trim()
         : undefined);
-  const launchEnv = codexHomeOverride
-    ? { ...process.env, CODEX_HOME: codexHomeOverride }
-    : process.env;
+  const launchEnv = {
+    ...process.env,
+    ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
+  };
+  const workerLaunchMode = resolveTeamWorkerLaunchMode(launchEnv);
+
   await assertNestedTeamAllowed(leaderCwd);
   const effectiveWorktreeMode = resolveEffectiveTeamWorktreeMode(leaderCwd, options.worktreeMode);
   const displayName = sanitizeTeamName(teamName);
-  const workerLaunchMode = resolveTeamWorkerLaunchMode(launchEnv);
   const displayMode = workerLaunchMode === 'interactive' ? 'split_pane' : 'auto';
   const rawIdentityScope = resolveTeamIdentityScope(launchEnv);
   const resolvedLeaderSessionId = await resolveLeaderSessionId(leaderCwd, launchEnv);
@@ -2557,11 +2618,33 @@ export async function startTeam(
   for (let i = 1; i <= workerCount; i++) {
     workerWorkspaceByName.set(`worker-${i}`, { cwd: leaderCwd });
   }
+  if (activeWorktreeMode) {
+    assertCleanLeaderWorkspaceForWorkerWorktrees(leaderCwd);
+  }
+
+  const workerLaunchPolicyPlan = buildWorkerLaunchPolicyPlan({
+    workerCount,
+    tasks,
+    agentType,
+    launchEnv,
+    codexHomeOverride,
+  });
+  for (const workerLaunchPolicy of workerLaunchPolicyPlan) {
+    assertTeamWorkerCliPolicyCompatibility(
+      workerLaunchPolicy.workerCli,
+      [...workerLaunchPolicy.workerLaunchArgs],
+    );
+  }
+  if (workerLaunchMode === 'prompt') {
+    assertPromptModeWorkerCliSupported(
+      workerLaunchPolicyPlan.map((workerLaunchPolicy) => workerLaunchPolicy.workerCli),
+      launchEnv,
+    );
+  }
 
   await detectAndCleanStaleTeam(sanitized, leaderCwd, workerCount, options.confirmStaleCleanup);
 
   if (activeWorktreeMode) {
-    assertCleanLeaderWorkspaceForWorkerWorktrees(leaderCwd);
     for (let i = 1; i <= workerCount; i++) {
       const workerName = `worker-${i}`;
       const planned = planWorktreeTarget({
@@ -2594,10 +2677,6 @@ export async function startTeam(
   const createdWorkerPaneIds: string[] = [];
   let createdLeaderPaneId: string | undefined;
   let config: TeamConfig | null = null;
-  const sharedWorkerLaunchArgs = resolveTeamWorkerLaunchArgs({
-    existingRaw: launchEnv.OMX_TEAM_WORKER_LAUNCH_ARGS,
-    fallbackModel: resolveAgentDefaultModel(agentType, codexHomeOverride),
-  });
   const workerReadyTimeoutMs = resolveWorkerReadyTimeoutMs(launchEnv);
   const workerStartupEvidenceTimeoutMs = resolveWorkerStartupEvidenceTimeoutMs(
     launchEnv,
@@ -2735,34 +2814,25 @@ export async function startTeam(
       trigger: string;
       triggerIntent: TeamReminderIntent;
       initialPrompt?: string;
-      workerLaunchArgs: string[];
+      workerLaunchArgs: readonly string[];
       workerCli: TeamWorkerCli;
       toolContext: ReturnType<typeof resolveWorktreeToolContext>;
     }>;
-    const workerCliPlan: TeamWorkerCli[] = [];
 
     for (let i = 1; i <= workerCount; i++) {
-      const workerName = `worker-${i}`;
+      const workerLaunchPolicy = workerLaunchPolicyPlan[i - 1];
+      if (!workerLaunchPolicy) {
+        throw new Error(`missing worker launch policy for worker-${i}`);
+      }
+      const workerName = workerLaunchPolicy.workerName;
       const workerWorkspace = workerWorkspaceByName.get(workerName) ?? { cwd: leaderCwd };
       const workerTasks = allTasks.filter(t => t.owner === workerName);
-      const taskRoles = workerTasks.map(t => t.role).filter(Boolean) as string[];
-      const uniqueTaskRoles = new Set(taskRoles);
-      const workerRole = taskRoles.length > 0 && uniqueTaskRoles.size === 1
-        ? taskRoles[0]
-        : agentType;
-      const runtimeRole = workerRole;
+      const runtimeRole = workerLaunchPolicy.workerRole;
       const rawRolePromptContent = await loadRolePrompt(runtimeRole, join(leaderCwd, '.codex', 'prompts'))
         ?? await loadRolePrompt(runtimeRole, codexPromptsDir());
-      const preferredReasoning = resolveAgentReasoningEffort(runtimeRole, codexHomeOverride)
-        ?? resolveAgentReasoningEffort(agentType, codexHomeOverride);
-      const workerLaunchArgs = resolveWorkerLaunchArgsFromEnv(
-        launchEnv,
-        runtimeRole,
-        undefined,
-        preferredReasoning,
-      );
-      const workerCli = resolveTeamWorkerCliForResolvedLaunchArgs(i, workerCount, workerLaunchArgs, launchEnv);
-      const resolvedWorkerModel = parseTeamWorkerLaunchArgs(workerLaunchArgs).modelOverride ?? undefined;
+      const workerLaunchArgs = workerLaunchPolicy.workerLaunchArgs;
+      const workerCli = workerLaunchPolicy.workerCli;
+      const resolvedWorkerModel = parseTeamWorkerLaunchArgs([...workerLaunchArgs]).modelOverride ?? undefined;
       const rolePromptContent = rawRolePromptContent
         ? composeRoleInstructionsForRole(runtimeRole, rawRolePromptContent, resolvedWorkerModel)
         : null;
@@ -2812,12 +2882,11 @@ export async function startTeam(
       if (initialPrompt) {
         await writeWorkerInbox(sanitized, workerName, inbox, leaderCwd);
       }
-      workerCliPlan.push(workerCli);
       workerBootstrapPlans.push({
         workerName,
         workerWorkspace,
         workerTasks,
-        workerRole,
+        workerRole: runtimeRole,
         rolePromptContent,
         instructionsFilePath,
         inbox,
@@ -2828,9 +2897,6 @@ export async function startTeam(
         workerCli,
         toolContext,
       });
-    }
-    if (workerLaunchMode === 'prompt') {
-      assertPromptModeWorkerCliSupported(workerCliPlan);
     }
 
     const workerStartups = workerBootstrapPlans.map((plan) => {
@@ -2855,7 +2921,7 @@ export async function startTeam(
         cwd: plan.workerWorkspace.cwd,
         env,
         initialPrompt: plan.initialPrompt,
-        launchArgs: plan.workerLaunchArgs,
+        launchArgs: [...plan.workerLaunchArgs],
         workerCli: plan.workerCli,
         workerRole: plan.workerRole,
       };
@@ -2935,7 +3001,7 @@ export async function startTeam(
         sanitized,
         workerCount,
         leaderCwd,
-        sharedWorkerLaunchArgs,
+        Array.from(workerLaunchPolicyPlan[0]?.workerLaunchArgs ?? []),
         workerStartups,
         { ownerSessionId: leaderSessionId, teamPaneOwnerId: config.tmux_pane_owner_id },
       );
@@ -2954,16 +3020,19 @@ export async function startTeam(
       config.resize_hook_name = null;
       config.resize_hook_target = null;
       for (let i = 1; i <= workerCount; i++) {
-        const startup = workerStartups[i - 1] || {};
-        const workerName = `worker-${i}`;
+        const startup = workerStartups[i - 1];
+        const workerLaunchPolicy = workerLaunchPolicyPlan[i - 1];
+        if (!startup || !workerLaunchPolicy) {
+          throw new Error(`missing worker launch plan for worker-${i}`);
+        }
         const child = spawnPromptWorker(
           sanitized,
-          workerName,
+          workerLaunchPolicy.workerName,
           i,
-          startup.cwd || leaderCwd,
-          startup.launchArgs || sharedWorkerLaunchArgs,
-          startup.env || {},
-          startup.workerCli || workerCliPlan[i - 1],
+          startup.cwd,
+          startup.launchArgs,
+          startup.env,
+          startup.workerCli,
           startup.initialPrompt,
           startup.workerRole,
         );
@@ -3011,12 +3080,9 @@ export async function startTeam(
       const initialPrompt = bootstrapPlan.initialPrompt;
       const startupStartedAt = performance.now();
 
-      const taskRoles = workerTasks
-        .map((task) => task.role)
-        .filter((role): role is string => Boolean(role));
-      const uniqueTaskRoles = [...new Set(taskRoles)];
-      if (uniqueTaskRoles.length > 1) {
-        console.log(`[omx:team] ${workerName}: mixed task roles [${uniqueTaskRoles.join(', ')}], falling back to ${agentType}`);
+      const taskRoles = workerLaunchPolicyPlan[workerIndex - 1]?.taskRoles ?? [];
+      if (taskRoles.length > 1) {
+        console.log(`[omx:team] ${workerName}: mixed task roles [${taskRoles.join(', ')}], falling back to ${agentType}`);
       }
 
 
@@ -3027,7 +3093,7 @@ export async function startTeam(
           workerName,
           workerIndex,
           paneId,
-          workerCli: workerCliPlan[workerIndex - 1],
+          workerCli: bootstrapPlan.workerCli,
           inbox,
           triggerMessage: trigger,
           intent: triggerIntent,
@@ -3076,7 +3142,7 @@ export async function startTeam(
             workerName,
             workerIndex,
             paneId,
-            workerCli: workerCliPlan[workerIndex - 1],
+            workerCli: bootstrapPlan.workerCli,
             inbox,
             triggerMessage: trigger,
             intent: triggerIntent,

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -2557,15 +2557,6 @@ export async function startTeam(
     await assertTeamStartupIsNonDestructive(displayName, leaderCwd, leaderSessionId);
   }
 
-  if (workerLaunchMode === 'interactive') {
-    if (!isTmuxAvailable()) {
-      throw new Error('Team mode requires tmux. Install with: apt install tmux / brew install tmux');
-    }
-    if (!hasCurrentTmuxClientContext()) {
-      throw new Error('Team mode requires running inside tmux current leader pane');
-    }
-  }
-
   const teamStateRoot = resolveCanonicalTeamStateRoot(leaderCwd);
   const requestedApprovedExecution = normalizeApprovedTeamExecutionBinding(options.approvedExecution);
   const requestedApprovedExecutionOutcome = requestedApprovedExecution
@@ -2640,6 +2631,14 @@ export async function startTeam(
       workerLaunchPolicyPlan.map((workerLaunchPolicy) => workerLaunchPolicy.workerCli),
       launchEnv,
     );
+  }
+  if (workerLaunchMode === 'interactive') {
+    if (!isTmuxAvailable()) {
+      throw new Error('Team mode requires tmux. Install with: apt install tmux / brew install tmux');
+    }
+    if (!hasCurrentTmuxClientContext()) {
+      throw new Error('Team mode requires running inside tmux current leader pane');
+    }
   }
 
   await detectAndCleanStaleTeam(sanitized, leaderCwd, workerCount, options.confirmStaleCleanup);

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -25,7 +25,9 @@ import {
   trustWorkerMiseConfigIfAvailable,
   writeWorkerStartupScriptCommand,
   resolveTeamWorkerCliForResolvedLaunchArgs,
+  assertTeamWorkerCliPolicyCompatibility,
   tagPaneTeamOwner,
+  type TeamWorkerCli,
 } from './tmux-session.js';
 import { execFileSync, spawnSync } from 'child_process';
 import {
@@ -44,6 +46,7 @@ import {
   teamReadDispatchRequest as readDispatchRequest,
   teamTransitionDispatchRequest as transitionDispatchRequest,
   type TeamConfig,
+  type TeamTask,
   type WorkerInfo,
   type WorkerStatus,
 } from './team-ops.js';
@@ -134,6 +137,76 @@ export interface ScaleDownResult {
 export interface ScaleError {
   ok: false;
   error: string;
+}
+
+type ScaleUpTaskInput = {
+  subject: string;
+  description: string;
+  owner?: string;
+  blocked_by?: string[];
+  role?: string;
+};
+
+interface ScaleUpWorkerLaunchPlan {
+  readonly workerIndex: number;
+  readonly workerName: string;
+  readonly runtimeRole: string;
+  readonly workerLaunchArgs: string[];
+  readonly workerCli: TeamWorkerCli;
+  readonly mixedTaskRoles: readonly string[];
+}
+
+function buildScaleUpWorkerLaunchPlans(params: {
+  count: number;
+  nextWorkerIndex: number;
+  agentType: string;
+  existingTasks: readonly Pick<TeamTask, 'owner' | 'role'>[];
+  incomingTasks: readonly ScaleUpTaskInput[];
+  launchEnv: NodeJS.ProcessEnv;
+  codexHomeOverride?: string;
+}): readonly ScaleUpWorkerLaunchPlan[] {
+  const taskAssignments = [...params.existingTasks, ...params.incomingTasks];
+  const plans: ScaleUpWorkerLaunchPlan[] = [];
+
+  for (let offset = 0; offset < params.count; offset += 1) {
+    const workerIndex = params.nextWorkerIndex + offset;
+    const workerName = `worker-${workerIndex}`;
+    const workerTaskRoles = taskAssignments
+      .filter((task) => task.owner === workerName)
+      .map((task) => task.role)
+      .filter((role): role is string => Boolean(role));
+    const uniqueTaskRoles = new Set(workerTaskRoles);
+    const runtimeRole = workerTaskRoles.length > 0 && uniqueTaskRoles.size === 1
+      ? workerTaskRoles[0]!
+      : params.agentType;
+    const preferredReasoning = resolveAgentReasoningEffort(runtimeRole, params.codexHomeOverride)
+      ?? resolveAgentReasoningEffort(params.agentType, params.codexHomeOverride);
+    const workerLaunchArgs = resolveWorkerLaunchArgsForScaling(
+      params.launchEnv,
+      runtimeRole,
+      preferredReasoning,
+      params.codexHomeOverride,
+    );
+    const workerCli = resolveTeamWorkerCliForResolvedLaunchArgs(
+      offset + 1,
+      params.count,
+      workerLaunchArgs,
+      params.launchEnv,
+    );
+    assertTeamWorkerCliPolicyCompatibility(workerCli, workerLaunchArgs);
+    const immutableWorkerLaunchArgs = [...workerLaunchArgs];
+    Object.freeze(immutableWorkerLaunchArgs);
+    plans.push(Object.freeze({
+      workerIndex,
+      workerName,
+      runtimeRole,
+      workerLaunchArgs: immutableWorkerLaunchArgs,
+      workerCli,
+      mixedTaskRoles: Object.freeze([...uniqueTaskRoles]),
+    }));
+  }
+
+  return Object.freeze(plans);
 }
 
 function resolveInstructionStateRoot(worktreePath?: string | null): string | undefined {
@@ -254,7 +327,7 @@ export async function scaleUp(
   teamName: string,
   count: number,
   agentType: string,
-  tasks: Array<{ subject: string; description: string; owner?: string; blocked_by?: string[]; role?: string }>,
+  tasks: ScaleUpTaskInput[],
   cwd: string,
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<ScaleUpResult | ScaleError> {
@@ -291,6 +364,29 @@ export async function scaleUp(
     const launchEnv = codexHomeOverride
       ? { ...env, CODEX_HOME: codexHomeOverride }
       : env;
+    // Build and validate every launch plan before any task, directory, worktree,
+    // pane, process, or config mutation. The plan is the sole source of launch
+    // policy; later task materialization must not alter it.
+    const initialNextIndex = config.next_worker_index ?? (currentCount + 1);
+    let workerLaunchPlans: readonly ScaleUpWorkerLaunchPlan[];
+    try {
+      const existingTasks = await listTasks(sanitized, leaderCwd);
+      workerLaunchPlans = buildScaleUpWorkerLaunchPlans({
+        count,
+        nextWorkerIndex: initialNextIndex,
+        agentType,
+        existingTasks,
+        incomingTasks: tasks,
+        launchEnv,
+        codexHomeOverride,
+      });
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+    let nextIndex = initialNextIndex;
     const sessionName = config.tmux_session;
     const manifest = await readTeamManifestV2(sanitized, leaderCwd);
     const dispatchPolicy = normalizeTeamPolicy(manifest?.policy, {
@@ -324,9 +420,6 @@ export async function scaleUp(
       await saveTeamConfig(config, leaderCwd);
     }
 
-    // Resolve the monotonic worker index counter
-    let nextIndex = config.next_worker_index ?? (currentCount + 1);
-    const initialNextIndex = nextIndex;
     const addedWorkers: WorkerInfo[] = [];
     const createdTaskIds: string[] = [];
 
@@ -383,8 +476,8 @@ export async function scaleUp(
       return { ok: false, error };
     };
 
-    // Persist incoming tasks first so scaling resolves worker roles and inboxes from
-    // canonical task state (stable task ids, owner, role), matching startTeam().
+    // Persist incoming tasks only after launch policy is frozen; the resulting
+    // task listing is used for inbox and task materialization, never launch policy.
     for (const task of tasks) {
       const createdTask = await createStateTask(sanitized, {
         subject: task.subject,
@@ -396,29 +489,26 @@ export async function scaleUp(
       }, leaderCwd);
       createdTaskIds.push(createdTask.id);
     }
-    const persistedTasks = await listTasks(sanitized, leaderCwd);
+    const materializedTasks = await listTasks(sanitized, leaderCwd);
 
-    for (let i = 0; i < count; i++) {
-      const workerIndex = nextIndex;
-      nextIndex++;
-      const workerName = `worker-${workerIndex}`;
+    for (const workerLaunchPlan of workerLaunchPlans) {
+      const {
+        workerIndex,
+        workerName,
+        runtimeRole,
+        workerLaunchArgs,
+        workerCli,
+      } = workerLaunchPlan;
+      nextIndex = workerIndex + 1;
+      if (workerLaunchPlan.mixedTaskRoles.length > 1) {
+        console.log(`[omx:scaling] ${workerName}: mixed task roles [${workerLaunchPlan.mixedTaskRoles.join(', ')}], falling back to ${agentType}`);
+      }
 
       // Create worker directory
       const workerDirPath = join(leaderCwd, '.omx', 'state', 'team', sanitized, 'workers', workerName);
       await mkdir(workerDirPath, { recursive: true });
 
-      // Resolve per-worker role from assigned task roles before launch so reasoning effort can vary by teammate.
-      const workerTaskRoles = persistedTasks.filter(t => t.owner === workerName).map(t => t.role).filter(Boolean) as string[];
-      const uniqueTaskRoles = new Set(workerTaskRoles);
-      const workerRole = workerTaskRoles.length > 0 && uniqueTaskRoles.size === 1
-        ? workerTaskRoles[0]
-        : agentType;
-      const runtimeRole = workerRole;
-      if (uniqueTaskRoles.size > 1) {
-        console.log(`[omx:scaling] ${workerName}: mixed task roles [${[...uniqueTaskRoles].join(', ')}], falling back to ${agentType}`);
-      }
-
-      const worktreeMode = resolveScaleUpWorktreeMode(config);
+      const worktreeMode = effectiveWorktreeMode;
       const workerWorkspaceResult = worktreeMode.enabled
         ? ensureWorktree(planWorktreeTarget({
             cwd: leaderCwd,
@@ -434,10 +524,6 @@ export async function scaleUp(
       // Build startup command and create tmux pane
       const rawRolePromptContent = await loadRolePrompt(runtimeRole, join(leaderCwd, '.codex', 'prompts'))
         ?? await loadRolePrompt(runtimeRole, codexPromptsDir());
-      const preferredReasoning = resolveAgentReasoningEffort(runtimeRole, codexHomeOverride)
-        ?? resolveAgentReasoningEffort(agentType, codexHomeOverride);
-      const workerLaunchArgs = resolveWorkerLaunchArgsForScaling(launchEnv, runtimeRole, preferredReasoning, codexHomeOverride);
-      const workerCli = resolveTeamWorkerCliForResolvedLaunchArgs(i + 1, count, workerLaunchArgs, launchEnv);
       const resolvedWorkerModel = parseTeamWorkerLaunchArgs(workerLaunchArgs).modelOverride ?? undefined;
       const rolePromptContent = rawRolePromptContent
         ? composeRoleInstructionsForRole(runtimeRole, rawRolePromptContent, resolvedWorkerModel)
@@ -537,7 +623,7 @@ export async function scaleUp(
       const workerInfo: WorkerInfo = {
         name: workerName,
         index: workerIndex,
-        role: workerRole,
+        role: runtimeRole,
         worker_cli: workerCli,
         assigned_tasks: [],
         pid: panePid ?? undefined,
@@ -564,7 +650,7 @@ export async function scaleUp(
       }
 
       // Get assigned tasks for this worker
-      const workerTasks = persistedTasks.filter(t => t.owner === workerName);
+      const workerTasks = materializedTasks.filter(t => t.owner === workerName);
 
       const inbox = generateInitialInbox(workerName, sanitized, agentType, workerTasks, {
         teamStateRoot,

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -22,7 +22,13 @@ import {
   paneLooksReady as sharedPaneLooksReady,
 } from '../scripts/tmux-hook-engine.js';
 import { readActiveProviderEnvOverrides } from '../config/models.js';
-import { extractModelProviderOverrideValue } from './model-contract.js';
+import {
+  classifyTeamWorkerLaunchPolicy,
+  extractModelProviderOverrideValue,
+  normalizeTeamWorkerLaunchArgs,
+  parseTeamWorkerLaunchArgs,
+} from './model-contract.js';
+
 import { sleep, sleepSync } from '../utils/sleep.js';
 import {
   buildPlatformCommandSpec,
@@ -812,22 +818,34 @@ function isModelInstructionsOverride(value: string): boolean {
   return new RegExp(`^${MODEL_INSTRUCTIONS_FILE_KEY}\\s*=`).test(value.trim());
 }
 
-function hasModelInstructionsOverride(args: string[]): boolean {
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
+function someConfigOverrideBeforeEndOfOptions(
+  args: readonly string[],
+  matches: (value: string) => boolean,
+): boolean {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--') break;
+
+    let value: string | undefined;
     if (arg === CONFIG_FLAG || arg === LONG_CONFIG_FLAG) {
-      const maybeValue = args[i + 1];
-      if (typeof maybeValue === 'string' && isModelInstructionsOverride(maybeValue)) {
-        return true;
-      }
+      value = args[index + 1];
+      if (value === '--') break;
+      index += 1;
+    } else if (arg.startsWith(`${CONFIG_FLAG}=`)) {
+      value = arg.slice(`${CONFIG_FLAG}=`.length);
+    } else if (arg.startsWith(`${LONG_CONFIG_FLAG}=`)) {
+      value = arg.slice(`${LONG_CONFIG_FLAG}=`.length);
+    } else {
       continue;
     }
-    if (arg.startsWith(`${LONG_CONFIG_FLAG}=`)) {
-      const inlineValue = arg.slice(`${LONG_CONFIG_FLAG}=`.length);
-      if (isModelInstructionsOverride(inlineValue)) return true;
-    }
+
+    if (typeof value === 'string' && matches(value)) return true;
   }
   return false;
+}
+
+function hasModelInstructionsOverride(args: readonly string[]): boolean {
+  return someConfigOverrideBeforeEndOfOptions(args, isModelInstructionsOverride);
 }
 
 function normalizeTeamWorkerCliMode(raw: string | undefined, sourceEnv: string = OMX_TEAM_WORKER_CLI_ENV): TeamWorkerCliMode {
@@ -850,6 +868,7 @@ function extractModelOverride(args: string[]): string | null {
   let model: string | null = null;
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
+    if (arg === '--') break;
     if (arg === MODEL_FLAG) {
       const maybeValue = args[i + 1];
       if (typeof maybeValue === 'string' && maybeValue.trim() !== '' && !maybeValue.startsWith('-')) {
@@ -992,6 +1011,23 @@ function shouldGrantExecutionBypassForRole(workerRole?: string): boolean {
   return agent.tools === 'execution';
 }
 
+export function assertTeamWorkerCliPolicyCompatibility(workerCli: TeamWorkerCli, launchArgs: string[]): void {
+  const policy = classifyTeamWorkerLaunchPolicy(launchArgs);
+  if ((workerCli === 'claude' || workerCli === 'gemini') && (policy === 'direct-policy' || policy === 'mixed-policy')) {
+    throw new Error(
+      `Selected team worker CLI "${workerCli}" is incompatible with an explicit approval or sandbox policy.`,
+    );
+  }
+}
+
+export function assertTeamWorkerLaunchPolicyInvariant(workerCli: TeamWorkerCli, launchArgs: string[]): void {
+  assertTeamWorkerCliPolicyCompatibility(workerCli, launchArgs);
+  if (workerCli === 'codex' && classifyTeamWorkerLaunchPolicy(launchArgs) === 'mixed-policy') {
+    throw new Error('internal_mixed_codex_worker_policy_argv');
+  }
+}
+
+
 export function translateWorkerLaunchArgsForCli(
   workerCli: TeamWorkerCli,
   args: string[],
@@ -1101,21 +1137,10 @@ export function scrubTeamWorkerHudOwnershipEnv<T extends Record<string, string |
 }
 
 function hasConfigOverride(args: readonly string[], key: string): boolean {
-  const prefix = `${key}=`;
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    if (arg === CONFIG_FLAG || arg === LONG_CONFIG_FLAG) {
-      const value = args[index + 1];
-      if (typeof value === 'string' && value.trim().startsWith(prefix)) return true;
-      index += 1;
-      continue;
-    }
-    if (typeof arg === 'string' && arg.startsWith(`${LONG_CONFIG_FLAG}=`)) {
-      const value = arg.slice(`${LONG_CONFIG_FLAG}=`.length);
-      if (value.trim().startsWith(prefix)) return true;
-    }
-  }
-  return false;
+  return someConfigOverrideBeforeEndOfOptions(args, (value) => {
+    const trimmed = value.trim();
+    return trimmed.startsWith(key) && /^\s*=/.test(trimmed.slice(key.length));
+  });
 }
 
 function shouldDisableOmxMcpForTeamWorker(env: NodeJS.ProcessEnv): boolean {
@@ -1148,21 +1173,48 @@ function appendTeamWorkerMcpDisableOverrides(args: string[], env: NodeJS.Process
     if (!codexConfigDeclaresMcpServer(server, env)) continue;
     const key = `mcp_servers.${server}.enabled`;
     if (hasConfigOverride(args, key)) continue;
-    args.push(CONFIG_FLAG, `${key}=false`);
+    const endOfOptionsIndex = args.indexOf('--');
+    args.splice(endOfOptionsIndex < 0 ? args.length : endOfOptionsIndex, 0, CONFIG_FLAG, `${key}=false`);
   }
 }
 
+function insertArgsBeforeEndOfOptions(args: string[], insertedArgs: readonly string[]): string[] {
+  const endOfOptionsIndex = args.indexOf('--');
+  if (endOfOptionsIndex < 0) return [...args, ...insertedArgs];
+  return [...args.slice(0, endOfOptionsIndex), ...insertedArgs, ...args.slice(endOfOptionsIndex)];
+}
+
+function insertCanonicalCodexBypassBeforeEndOfOptions(args: string[]): string[] {
+  const endOfOptionsIndex = args.indexOf('--');
+  const preMarkerArgs = endOfOptionsIndex < 0 ? args : args.slice(0, endOfOptionsIndex);
+  const postMarkerArgs = endOfOptionsIndex < 0 ? [] : args.slice(endOfOptionsIndex);
+  return [
+    ...preMarkerArgs.filter((arg) => arg !== CODEX_BYPASS_FLAG && arg !== MADMAX_FLAG),
+    CODEX_BYPASS_FLAG,
+    ...postMarkerArgs,
+  ];
+}
+
 function resolveWorkerLaunchArgs(extraArgs: string[] = [], cwd: string = process.cwd(), env: NodeJS.ProcessEnv = process.env): string[] {
-  const merged = [...extraArgs];
-  const wantsBypass = process.argv.includes(CODEX_BYPASS_FLAG) || process.argv.includes(MADMAX_FLAG);
-  if (wantsBypass && !merged.includes(CODEX_BYPASS_FLAG)) {
-    merged.push(CODEX_BYPASS_FLAG);
+  let merged = [...extraArgs];
+  const initialPolicy = classifyTeamWorkerLaunchPolicy(merged);
+  if (initialPolicy === 'direct-policy') {
+    merged = normalizeTeamWorkerLaunchArgs(merged);
+  }
+  const policy = classifyTeamWorkerLaunchPolicy(merged);
+  const ambientWantsBypass = parseTeamWorkerLaunchArgs(process.argv, 'ambient process arguments', { directPolicyMode: 'ignore' }).wantsBypass;
+  if (policy === 'none' || policy === 'bypass') {
+    const wantsBypass = ambientWantsBypass || policy === 'bypass';
+    if (wantsBypass) {
+      merged = insertCanonicalCodexBypassBeforeEndOfOptions(merged);
+    }
   }
   if (shouldBypassDefaultSystemPrompt(env) && !hasModelInstructionsOverride(merged)) {
-    merged.push(CONFIG_FLAG, buildModelInstructionsOverride(cwd, env));
+    merged = insertArgsBeforeEndOfOptions(merged, [CONFIG_FLAG, buildModelInstructionsOverride(cwd, env)]);
   }
   return merged;
 }
+
 
 export function buildWorkerStartupCommand(
   teamName: string,
@@ -1386,11 +1438,16 @@ function buildWorkerProcessLaunchSpecForMode(
   const effectiveEnv: NodeJS.ProcessEnv = { ...process.env, ...extraEnv };
   const fullLaunchArgs = resolveWorkerLaunchArgs(launchArgs, cwd, effectiveEnv);
   const workerCli = workerCliOverride ?? resolveTeamWorkerCli(fullLaunchArgs, effectiveEnv);
+  assertTeamWorkerLaunchPolicyInvariant(workerCli, fullLaunchArgs);
+
   const cliLaunchArgs = translateWorkerLaunchArgsForCli(workerCli, fullLaunchArgs, initialPrompt, workerRole);
+  const launchPolicy = workerCli === 'codex'
+    ? classifyTeamWorkerLaunchPolicy(cliLaunchArgs)
+    : 'none';
   const effectiveCliLaunchArgs = workerCli === 'codex'
     && shouldGrantExecutionBypassForRole(workerRole)
-    && !cliLaunchArgs.includes(CODEX_BYPASS_FLAG)
-    ? [...cliLaunchArgs, CODEX_BYPASS_FLAG]
+    && launchPolicy === 'none'
+    ? insertCanonicalCodexBypassBeforeEndOfOptions(cliLaunchArgs)
     : cliLaunchArgs;
   const workerCodexHomeOverride = typeof effectiveEnv.CODEX_HOME === 'string'
     ? effectiveEnv.CODEX_HOME.trim()
@@ -1405,6 +1462,7 @@ function buildWorkerProcessLaunchSpecForMode(
   const resolvedCliPath = resolveAbsoluteBinaryPath(workerCli);
   const shouldUseNativeWindowsLaunchSpec = process.platform === 'win32'
     && (mode === 'direct-spawn' || !isMsysOrGitBash(effectiveEnv, process.platform));
+
   const platformSpec = shouldUseNativeWindowsLaunchSpec
     ? buildPlatformCommandSpec(workerCli, effectiveCliLaunchArgs, process.platform, effectiveEnv)
     : { command: resolvedCliPath, args: effectiveCliLaunchArgs, resolvedPath: resolvedCliPath };
@@ -1529,12 +1587,26 @@ export function createTeamSession(
   }
   const normalizedWorkerLaunchArgs = resolveWorkerLaunchArgs(workerLaunchArgs, cwd);
   const defaultWorkerCliPlan = resolveTeamWorkerCliPlan(workerCount, normalizedWorkerLaunchArgs, process.env);
-  const workerCliPlan = workerStartups.length > 0
-    ? workerStartups.map((startup, index) => startup.workerCli ?? defaultWorkerCliPlan[index]!)
-    : defaultWorkerCliPlan;
+  const workerCliPlan = Array.from(
+    { length: workerCount },
+    (_, index) => workerStartups[index]?.workerCli ?? defaultWorkerCliPlan[index]!,
+  );
   for (const workerCli of new Set(workerCliPlan)) {
     assertTeamWorkerCliBinaryAvailable(workerCli);
   }
+  const workerLaunchPolicyPlan = Array.from({ length: workerCount }, (_, index) => {
+    const startup = workerStartups[index] ?? {};
+    const workerCwd = startup.cwd || cwd;
+    const workerEnv = startup.env || {};
+    const launchArgs = startup.launchArgs || workerLaunchArgs;
+    const effectiveLaunchArgs = resolveWorkerLaunchArgs(
+      launchArgs,
+      workerCwd,
+      { ...process.env, ...workerEnv },
+    );
+    assertTeamWorkerLaunchPolicyInvariant(workerCliPlan[index]!, effectiveLaunchArgs);
+    return Object.freeze([...launchArgs]);
+  });
 
   const safeTeamName = sanitizeTeamName(teamName);
   let registeredResizeHook: { name: string; target: string } | null = null;
@@ -1587,7 +1659,7 @@ export function createTeamSession(
       const workerCwd = startup.cwd || cwd;
       const tmuxWorkerCwd = translatePathForMsys(workerCwd);
       const workerEnv = startup.env || {};
-      const launchArgsForWorker = startup.launchArgs || workerLaunchArgs;
+      const launchArgsForWorker = [...(workerLaunchPolicyPlan[i - 1] ?? workerLaunchArgs)];
       trustWorkerMiseConfigIfAvailable(workerCwd);
       const cmd = writeWorkerStartupScriptCommand(
         safeTeamName,


### PR DESCRIPTION
## Summary
- make valid direct approval or sandbox selectors in `OMX_TEAM_WORKER_LAUNCH_ARGS` authoritative
- reject explicit bypass/direct-policy mixtures while suppressing inherited, ambient, and role-default bypass
- preserve exact token values with quote-aware no-eval parsing and reversible CLI transport
- enforce the contract across initial startup, direct/POSIX/native-Windows wrapping, and scale-up

## Verification
Exact commit: `c0089eecc514ae8bd1deb9f8b8583b6102f4cb2c`
Base: `origin/dev` at `29bdeb5c5670c133d9f2feda7512ee01e80a63d5`

Passed:
- `npm run build`
- focused five-file matrix: 747/747
- `npm run lint`
- `npm run check:no-unused`
- independent cleanup reviews: PASS, 0 blockers/advisories
- independent architecture review: CLEAR / APPROVE
- independent QA/red-team: passed

`npm test` completed with two unrelated failures in `dist/cli/__tests__/team.test.js`; both reproduce on the clean base commit above. Native Windows coverage is a deterministic wrapper harness, not a live Windows runtime claim.

Closes #3126

—

*[repo owner's gaebal-gajae (clawdbot) 🦞]*