### PR TITLE
fix(ultragoal): resolve review-blocker ancestor chains

### DIFF
--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -55,6 +55,34 @@ function cleanQualityGate(): object {
   };
 }
 
+async function createReviewBlockerResolverChain(
+  cwd: string,
+  depth: number,
+): Promise<{ objective: string; goalIds: string[]; leafGoalId: string }> {
+  await createUltragoalPlan(cwd, {
+    brief: 'brief',
+    goals: [{ title: 'Final', objective: 'Complete final milestone.' }],
+  });
+  let current = await startNextUltragoal(cwd);
+  const objective = current.plan.codexObjective!;
+  const goalIds = [current.goal!.id];
+
+  for (let level = 0; level < depth; level += 1) {
+    const blocked = await recordFinalReviewBlockers(cwd, {
+      goalId: current.goal!.id,
+      title: `Resolve final code-review blockers level ${level + 1}`,
+      objective: `Fix final code-review blockers at resolver level ${level + 1} and rerun final gates.`,
+      evidence: `code-reviewer REQUEST CHANGES at resolver level ${level + 1}`,
+      codexGoal: { goal: { objective, status: 'active' } },
+    });
+    current = await startNextUltragoal(cwd);
+    assert.equal(current.goal?.id, blocked.addedGoal.id);
+    goalIds.push(current.goal!.id);
+  }
+
+  return { objective, goalIds, leafGoalId: goalIds.at(-1)! };
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -402,12 +430,31 @@ describe('ultragoal artifacts', () => {
         }),
         /expected active/,
       );
-      await checkpointUltragoal(cwd, {
+      const firstCheckpoint = {
         goalId: first.goal!.id,
-        status: 'complete',
+        status: 'complete' as const,
         evidence: 'unit tests passed',
         codexGoal: { goal: { objective: aggregateObjective, status: 'active' } },
-      });
+      };
+      await checkpointUltragoal(cwd, firstCheckpoint);
+      await checkpointUltragoal(cwd, firstCheckpoint);
+      const ledgerPath = join(cwd, '.omx/ultragoal/ledger.jsonl');
+      const retained = (await readFile(ledgerPath, 'utf-8'))
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .filter((line) => {
+          const entry = JSON.parse(line) as { event?: string; goalId?: string };
+          return entry.event !== 'goal_completed' || entry.goalId !== first.goal!.id;
+        });
+      await writeFile(ledgerPath, `${retained.join('\n')}\n`);
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          ...firstCheckpoint,
+          codexGoal: { goal: { objective: 'FORGED NON-FINAL OBJECTIVE', status: 'failed' } },
+        }),
+        /Completed checkpoint replay rejected/,
+      );
+      await checkpointUltragoal(cwd, firstCheckpoint);
       const second = await startNextUltragoal(cwd);
       assert.equal(second.goal?.id, 'G002-second');
 
@@ -455,14 +502,16 @@ describe('ultragoal artifacts', () => {
       const first = await startNextUltragoal(cwd);
       assert.equal(first.goal?.id, 'G001-micro-goal-1');
 
-      const reconciled = await checkpointUltragoal(cwd, {
+      const checkpoint = {
         goalId: first.goal!.id,
-        status: 'complete',
+        status: 'complete' as const,
         evidence: 'Actual planned work done for .omx/ultragoal/goals.json G001-micro-goal-1; validation complete; reviews clean.',
         codexGoal: { goal: { objective: taskObjective, status: 'complete' } },
         qualityGate: cleanQualityGate(),
         now: new Date('2026-05-04T10:04:00Z'),
-      });
+      };
+      const reconciled = await checkpointUltragoal(cwd, checkpoint);
+      await checkpointUltragoal(cwd, checkpoint);
 
       assert.equal(reconciled.goals.length, 136);
       assert.equal(reconciled.goals.filter((candidate) => candidate.status === 'complete').length, 1);
@@ -881,7 +930,347 @@ describe('ultragoal artifacts', () => {
     });
   });
 
-  it('does not reconcile a review-blocked parent from a non-designated resolver goal', async () => {
+  it('recursively completes a two-level review-blocker resolver chain and records every completion once', async () => {
+    await withTempRepo(async (cwd) => {
+      const chain = await createReviewBlockerResolverChain(cwd, 2);
+      const evidence = `${chain.leafGoalId} fixed the full resolver chain; final gate passed for .omx/ultragoal/goals.json`;
+      const checkpoint = {
+        goalId: chain.leafGoalId,
+        status: 'complete' as const,
+        evidence,
+        codexGoal: { goal: { objective: chain.objective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      };
+
+      const completed = await checkpointUltragoal(cwd, checkpoint);
+      const summary = summarizeUltragoalPlan(completed);
+      assert.equal(summary.complete, 3);
+      assert.equal(summary.reviewBlocked, 0);
+      assert.equal(summary.artifactComplete, true);
+      assert.equal(summary.aggregateComplete, true);
+      for (let index = 0; index < chain.goalIds.length - 1; index += 1) {
+        const parent = completed.goals.find((goal) => goal.id === chain.goalIds[index]);
+        assert.equal(parent?.status, 'complete');
+        assert.equal(parent?.reviewBlockerResolution?.status, 'complete');
+        assert.equal(parent?.reviewBlockerResolution?.resolverGoalId, chain.goalIds[index + 1]);
+        assert.equal(parent?.reviewBlockerResolution?.evidence, evidence);
+        assert.equal(parent?.evidence, `code-reviewer REQUEST CHANGES at resolver level ${index + 1}`);
+      }
+
+      await checkpointUltragoal(cwd, checkpoint);
+      const ledger = (await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8'))
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as { event?: string; goalId?: string });
+      for (const goalId of chain.goalIds) {
+        assert.equal(ledger.filter((entry) => entry.event === 'goal_completed' && entry.goalId === goalId).length, 1);
+      }
+      assert.equal(ledger.filter((entry) => entry.event === 'aggregate_completed').length, 1);
+    });
+  });
+
+  it('replays a normal final checkpoint exactly once and still requires its quality gate for ledger repair', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'Normal final checkpoint replay',
+        goals: [{ title: 'Final', objective: 'Complete the final implementation.' }],
+      });
+      const started = await startNextUltragoal(cwd);
+      const objective = started.plan.codexObjective!;
+      const checkpoint = {
+        goalId: started.goal!.id,
+        status: 'complete' as const,
+        evidence: 'Final planned work completed for .omx/ultragoal/goals.json; tests and review passed.',
+        codexGoal: { goal: { objective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      };
+      await checkpointUltragoal(cwd, checkpoint);
+      await checkpointUltragoal(cwd, checkpoint);
+
+      const ledgerPath = join(cwd, '.omx/ultragoal/ledger.jsonl');
+      const original = await readFile(ledgerPath, 'utf-8');
+      assert.equal((original.match(/"event":"goal_completed"/g) ?? []).length, 1);
+      assert.equal((original.match(/"event":"aggregate_completed"/g) ?? []).length, 0);
+      const retained = original
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .filter((line) => {
+          const entry = JSON.parse(line) as { event?: string };
+          return entry.event !== 'goal_completed' && entry.event !== 'aggregate_completed';
+        });
+      await writeFile(ledgerPath, `${retained.join('\n')}\n`);
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          ...checkpoint,
+          codexGoal: { goal: { objective: 'FORGED FINAL OBJECTIVE', status: 'failed' } },
+        }),
+        /Completed checkpoint replay rejected/,
+      );
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, { ...checkpoint, qualityGate: undefined }),
+        /quality[- ]gate/i,
+      );
+      await checkpointUltragoal(cwd, checkpoint);
+      const repaired = await readFile(ledgerPath, 'utf-8');
+      assert.equal((repaired.match(/"event":"goal_completed"/g) ?? []).length, 1);
+      assert.equal((repaired.match(/"event":"aggregate_completed"/g) ?? []).length, 0);
+    });
+  });
+
+  it('fails closed when completed checkpoint replay changes the aggregate Codex goal snapshot', async () => {
+    await withTempRepo(async (cwd) => {
+      const chain = await createReviewBlockerResolverChain(cwd, 2);
+      const evidence = `${chain.leafGoalId} fixed the full resolver chain; final gate passed for .omx/ultragoal/goals.json`;
+      const checkpoint = {
+        goalId: chain.leafGoalId,
+        status: 'complete' as const,
+        evidence,
+        codexGoal: { goal: { objective: chain.objective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      };
+      await checkpointUltragoal(cwd, checkpoint);
+      const ledgerPath = join(cwd, '.omx/ultragoal/ledger.jsonl');
+      const retained = (await readFile(ledgerPath, 'utf-8'))
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .filter((line) => {
+          const entry = JSON.parse(line) as { event?: string };
+          return entry.event !== 'goal_completed' && entry.event !== 'aggregate_completed';
+        });
+      await writeFile(ledgerPath, `${retained.join('\n')}\n`);
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          ...checkpoint,
+          codexGoal: { goal: { objective: 'FORGED DIFFERENT OBJECTIVE', status: 'failed' } },
+        }),
+        /Conflicting aggregate Codex goal snapshot/,
+      );
+      assert.doesNotMatch(await readFile(ledgerPath, 'utf-8'), /FORGED DIFFERENT OBJECTIVE/);
+    });
+  });
+
+  it('fails closed on conflicting payloads that reuse a completion ledger idempotency key', async () => {
+    await withTempRepo(async (cwd) => {
+      const chain = await createReviewBlockerResolverChain(cwd, 1);
+      const evidence = `${chain.leafGoalId} fixed the resolver chain; final gate passed for .omx/ultragoal/goals.json`;
+      const checkpoint = {
+        goalId: chain.leafGoalId,
+        status: 'complete' as const,
+        evidence,
+        codexGoal: { goal: { objective: chain.objective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      };
+      await checkpointUltragoal(cwd, checkpoint);
+      const ledgerPath = join(cwd, '.omx/ultragoal/ledger.jsonl');
+      const original = (await readFile(ledgerPath, 'utf-8')).split(/\r?\n/).filter(Boolean);
+      const targetIndex = original.findIndex((line) => (
+        (JSON.parse(line) as { idempotencyKey?: string }).idempotencyKey === `checkpoint:${chain.leafGoalId}:goal_completed`
+      ));
+      assert.notEqual(targetIndex, -1);
+
+      const mutations: Array<(entry: Record<string, unknown>) => void> = [
+        (entry) => { entry.event = 'goal_failed'; },
+        (entry) => { entry.goalId = 'G999-forged'; },
+        (entry) => { entry.evidence = 'forged evidence'; },
+        (entry) => { entry.codexGoal = { goal: { objective: 'forged snapshot', status: 'failed' } }; },
+        (entry) => { entry.qualityGate = { finalReview: 'FAIL' }; },
+      ];
+      for (const mutate of mutations) {
+        const lines = [...original];
+        const conflicting = JSON.parse(lines[targetIndex]) as Record<string, unknown>;
+        mutate(conflicting);
+        lines[targetIndex] = JSON.stringify(conflicting);
+        await writeFile(ledgerPath, `${lines.join('\n')}\n`);
+        await assert.rejects(
+          () => checkpointUltragoal(cwd, checkpoint),
+          /Conflicting ultragoal ledger entry for idempotency key/,
+        );
+      }
+    });
+  });
+
+  it('recursively completes review-blocker resolver chains deeper than two levels', async () => {
+    await withTempRepo(async (cwd) => {
+      const chain = await createReviewBlockerResolverChain(cwd, 4);
+      const completed = await checkpointUltragoal(cwd, {
+        goalId: chain.leafGoalId,
+        status: 'complete',
+        evidence: `${chain.leafGoalId} completed planned work for .omx/ultragoal/goals.json; tests and final review passed`,
+        codexGoal: { goal: { objective: chain.objective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      });
+      const summary = summarizeUltragoalPlan(completed);
+      assert.equal(summary.complete, 5);
+      assert.equal(summary.reviewBlocked, 0);
+      assert.equal(summary.artifactComplete, true);
+      assert.equal(summary.aggregateComplete, true);
+    });
+  });
+
+  it('fails closed on missing, inconsistent, branching, completed-mismatch, and cyclic resolver provenance', async () => {
+    const cases: Array<{
+      name: string;
+      mutate: (plan: UltragoalPlan, goalIds: string[]) => void;
+      expected: RegExp;
+    }> = [
+      {
+        name: 'missing parent',
+        mutate: (plan, goalIds) => {
+          plan.goals.find((goal) => goal.id === goalIds.at(-1))!.resolvesReviewBlockedGoalId = 'G999-missing-parent';
+        },
+        expected: /Missing review-blocked parent|Invalid designated resolver link/,
+      },
+      {
+        name: 'inconsistent reverse link',
+        mutate: (plan, goalIds) => {
+          plan.goals.find((goal) => goal.id === goalIds[1])!.reviewBlockerResolution!.resolverGoalId = 'G999-wrong-resolver';
+        },
+        expected: /Invalid designated resolver link|Missing designated review-blocker resolver/,
+      },
+      {
+        name: 'multiple parent claims',
+        mutate: (plan, goalIds) => {
+          const leafId = goalIds.at(-1)!;
+          plan.goals.push({
+            id: 'G999-branch-parent',
+            title: 'Branch parent',
+            objective: 'Claim the same resolver from another parent.',
+            status: 'review_blocked',
+            attempt: 1,
+            createdAt: '2026-07-11T00:00:00.000Z',
+            updatedAt: '2026-07-11T00:00:00.000Z',
+            reviewBlockerResolution: { resolverGoalId: leafId, status: 'pending' },
+          });
+        },
+        expected: /Invalid designated resolver link/,
+      },
+      {
+        name: 'completed intermediate provenance mismatch',
+        mutate: (plan, goalIds) => {
+          plan.goals.find((goal) => goal.id === goalIds[1])!.status = 'complete';
+        },
+        expected: /Invalid designated resolver provenance/,
+      },
+      {
+        name: 'cycle',
+        mutate: (plan, goalIds) => {
+          const root = plan.goals.find((goal) => goal.id === goalIds[0])!;
+          const leaf = plan.goals.find((goal) => goal.id === goalIds.at(-1))!;
+          root.resolvesReviewBlockedGoalId = leaf.id;
+          leaf.status = 'review_blocked';
+          leaf.reviewBlockerResolution = { resolverGoalId: root.id, status: 'pending' };
+        },
+        expected: /resolver cycle detected/i,
+      },
+    ];
+
+    for (const testCase of cases) {
+      await withTempRepo(async (cwd) => {
+        const chain = await createReviewBlockerResolverChain(cwd, 2);
+        const planPath = join(cwd, '.omx/ultragoal/goals.json');
+        const tampered = JSON.parse(await readFile(planPath, 'utf-8')) as UltragoalPlan;
+        testCase.mutate(tampered, chain.goalIds);
+        const expectedLeafStatus = tampered.goals.find((goal) => goal.id === chain.leafGoalId)?.status;
+        await writeFile(planPath, `${JSON.stringify(tampered, null, 2)}\n`);
+
+        await assert.rejects(
+          () => checkpointUltragoal(cwd, {
+            goalId: chain.leafGoalId,
+            status: 'complete',
+            evidence: `${testCase.name} must fail closed for .omx/ultragoal/goals.json`,
+            codexGoal: { goal: { objective: chain.objective, status: 'complete' } },
+            qualityGate: cleanQualityGate(),
+          }),
+          testCase.expected,
+        );
+        const after = await readUltragoalPlan(cwd);
+        assert.equal(after.goals.find((goal) => goal.id === chain.leafGoalId)?.status, expectedLeafStatus);
+        assert.equal(after.aggregateCompletion, undefined);
+      });
+    }
+  });
+
+  it('validates disconnected resolver graph components before aggregate completion', async () => {
+    const cases: Array<{
+      name: string;
+      append: (plan: UltragoalPlan) => void;
+      expected: RegExp;
+    }> = [
+      {
+        name: 'dangling parent',
+        append: (plan) => {
+          plan.goals.push({
+            id: 'G900-off-chain-resolver', title: 'Off-chain resolver', objective: 'Invalid dangling resolver.',
+            status: 'complete', attempt: 1, createdAt: '2026-07-11T00:00:00.000Z', updatedAt: '2026-07-11T00:00:00.000Z',
+            completedAt: '2026-07-11T00:00:00.000Z', evidence: 'off-chain', resolvesReviewBlockedGoalId: 'G999-missing',
+          });
+        },
+        expected: /Missing review-blocked parent/,
+      },
+      {
+        name: 'cycle',
+        append: (plan) => {
+          plan.goals.push(
+            {
+              id: 'G910-cycle-a', title: 'Cycle A', objective: 'Invalid cycle A.', status: 'complete', attempt: 1,
+              createdAt: '2026-07-11T00:00:00.000Z', updatedAt: '2026-07-11T00:00:00.000Z', completedAt: '2026-07-11T00:00:00.000Z',
+              evidence: 'cycle', resolvesReviewBlockedGoalId: 'G911-cycle-b',
+              reviewBlockerResolution: { resolverGoalId: 'G911-cycle-b', status: 'complete', resolvedAt: '2026-07-11T00:00:00.000Z', evidence: 'cycle' },
+            },
+            {
+              id: 'G911-cycle-b', title: 'Cycle B', objective: 'Invalid cycle B.', status: 'complete', attempt: 1,
+              createdAt: '2026-07-11T00:00:00.000Z', updatedAt: '2026-07-11T00:00:00.000Z', completedAt: '2026-07-11T00:00:00.000Z',
+              evidence: 'cycle', resolvesReviewBlockedGoalId: 'G910-cycle-a',
+              reviewBlockerResolution: { resolverGoalId: 'G910-cycle-a', status: 'complete', resolvedAt: '2026-07-11T00:00:00.000Z', evidence: 'cycle' },
+            },
+          );
+        },
+        expected: /resolver cycle detected/i,
+      },
+      {
+        name: 'multiple parent claim',
+        append: (plan) => {
+          plan.goals.push(
+            {
+              id: 'G920-claimed-resolver', title: 'Claimed resolver', objective: 'Invalid shared resolver.', status: 'complete', attempt: 1,
+              createdAt: '2026-07-11T00:00:00.000Z', updatedAt: '2026-07-11T00:00:00.000Z', completedAt: '2026-07-11T00:00:00.000Z',
+              evidence: 'shared', resolvesReviewBlockedGoalId: 'G921-parent-a',
+            },
+            ...['G921-parent-a', 'G922-parent-b'].map((id) => ({
+              id, title: id, objective: 'Invalid duplicate parent claim.', status: 'complete' as const, attempt: 1,
+              createdAt: '2026-07-11T00:00:00.000Z', updatedAt: '2026-07-11T00:00:00.000Z', completedAt: '2026-07-11T00:00:00.000Z',
+              evidence: 'shared', reviewBlockerResolution: { resolverGoalId: 'G920-claimed-resolver', status: 'complete' as const, resolvedAt: '2026-07-11T00:00:00.000Z', evidence: 'shared' },
+            })),
+          );
+        },
+        expected: /Invalid designated resolver link/,
+      },
+    ];
+
+    for (const testCase of cases) {
+      await withTempRepo(async (cwd) => {
+        const chain = await createReviewBlockerResolverChain(cwd, 1);
+        const planPath = join(cwd, '.omx/ultragoal/goals.json');
+        const tampered = JSON.parse(await readFile(planPath, 'utf-8')) as UltragoalPlan;
+        testCase.append(tampered);
+        await writeFile(planPath, `${JSON.stringify(tampered, null, 2)}\n`);
+        await assert.rejects(
+          () => checkpointUltragoal(cwd, {
+            goalId: chain.leafGoalId,
+            status: 'complete',
+            evidence: `${testCase.name} must fail closed for .omx/ultragoal/goals.json`,
+            codexGoal: { goal: { objective: chain.objective, status: 'complete' } },
+            qualityGate: cleanQualityGate(),
+          }),
+          testCase.expected,
+        );
+      });
+    }
+  });
+
+  it('rejects a non-designated resolver goal instead of completing it without provenance', async () => {
     await withTempRepo(async (cwd) => {
       await createUltragoalPlan(cwd, {
         brief: 'brief',
@@ -913,20 +1302,18 @@ describe('ultragoal artifacts', () => {
       tampered.activeGoalId = 'G999-forged-resolver';
       await writeFile(planPath, `${JSON.stringify(tampered, null, 2)}\n`);
 
-      const completed = await checkpointUltragoal(cwd, {
-        goalId: 'G999-forged-resolver',
-        status: 'complete',
-        evidence: 'forged resolver completed with tests but is not the designated review blocker resolver',
-        codexGoal: { goal: { objective, status: 'active' } },
-      });
-      const parent = completed.goals.find((goal) => goal.id === blocked.blockedGoal.id);
-      const summary = summarizeUltragoalPlan(completed);
-
-      assert.equal(parent?.status, 'review_blocked');
-      assert.equal(parent?.reviewBlockerResolution?.resolverGoalId, blocked.addedGoal.id);
-      assert.equal(summary.reviewBlocked, 1);
-      assert.equal(summary.aggregateComplete, false);
-      assert.equal(summary.artifactComplete, false);
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: 'G999-forged-resolver',
+          status: 'complete',
+          evidence: 'forged resolver completed with tests but is not the designated review blocker resolver',
+          codexGoal: { goal: { objective, status: 'active' } },
+        }),
+        /Invalid designated resolver link/,
+      );
+      const unchanged = await readUltragoalPlan(cwd);
+      assert.equal(unchanged.goals.find((goal) => goal.id === 'G999-forged-resolver')?.status, 'in_progress');
+      assert.equal(unchanged.goals.find((goal) => goal.id === blocked.blockedGoal.id)?.status, 'review_blocked');
     });
   });
 
@@ -971,7 +1358,7 @@ describe('ultragoal artifacts', () => {
           codexGoal: { goal: { objective: taskObjective, status: 'complete' } },
           qualityGate: cleanQualityGate(),
         }),
-        /Completed task-scoped aggregate reconciliation (?:requires|is not allowed)|objective mismatch/,
+        /Invalid designated resolver link|Completed task-scoped aggregate reconciliation (?:requires|is not allowed)|objective mismatch/,
       );
 
       const plan = await readUltragoalPlan(cwd);

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { appendFile, mkdir, open, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
 import {
   formatCodexGoalReconciliation,
   buildCompletedCodexGoalRemediation,
@@ -580,10 +581,132 @@ function unresolvedReviewBlockedGoals(plan: UltragoalPlan): UltragoalItem[] {
   return plan.goals.filter((candidate) => candidate.status === 'review_blocked' && !isReviewBlockedResolved(candidate, plan));
 }
 
-function isDesignatedReviewBlockerResolver(goal: UltragoalItem, parent: UltragoalItem | undefined): boolean {
-  return parent?.status === 'review_blocked'
-    && goal.resolvesReviewBlockedGoalId === parent.id
-    && parent.reviewBlockerResolution?.resolverGoalId === goal.id;
+interface ReviewBlockerAncestorLink {
+  resolver: UltragoalItem;
+  parent: UltragoalItem;
+  alreadyResolved: boolean;
+}
+
+function collectReviewBlockerAncestorChain(
+  plan: UltragoalPlan,
+  completedResolver: UltragoalItem,
+): ReviewBlockerAncestorLink[] {
+  const chain: ReviewBlockerAncestorLink[] = [];
+  const visited = new Set<string>([completedResolver.id]);
+  let resolver = completedResolver;
+
+  while (true) {
+    const parentId = resolver.resolvesReviewBlockedGoalId;
+    const claimedParents = plan.goals.filter(
+      (candidate) => candidate.reviewBlockerResolution?.resolverGoalId === resolver.id,
+    );
+
+    if (!parentId) {
+      if (claimedParents.length > 0) {
+        throw new UltragoalError(
+          `Invalid designated resolver link: ${resolver.id} is claimed by ${claimedParents.map((candidate) => candidate.id).join(', ')} but does not name a review-blocked parent.`,
+        );
+      }
+      break;
+    }
+    if (visited.has(parentId)) {
+      throw new UltragoalError(`Review blocker resolver cycle detected at ${parentId}.`);
+    }
+    visited.add(parentId);
+
+    const parent = plan.goals.find((candidate) => candidate.id === parentId);
+    if (!parent) {
+      throw new UltragoalError(`Missing review-blocked parent: ${parentId}.`);
+    }
+    if (claimedParents.length !== 1 || claimedParents[0]?.id !== parentId) {
+      const claims = claimedParents.length > 0
+        ? claimedParents.map((candidate) => candidate.id).join(', ')
+        : 'none';
+      throw new UltragoalError(
+        `Invalid designated resolver link: ${resolver.id} points to ${parentId}, but reverse claims are ${claims}.`,
+      );
+    }
+
+    const resolution = parent.reviewBlockerResolution;
+    const pending = parent.status === 'review_blocked'
+      && resolution?.resolverGoalId === resolver.id
+      && resolution.status === 'pending';
+    const alreadyResolved = parent.status === 'complete'
+      && resolution?.resolverGoalId === resolver.id
+      && resolution.status === 'complete'
+      && Boolean(parent.completedAt)
+      && Boolean(resolution.resolvedAt)
+      && Boolean(resolution.evidence);
+    if (!pending && !alreadyResolved) {
+      throw new UltragoalError(
+        `Invalid designated resolver provenance: ${resolver.id} -> ${parentId}; expected a review_blocked/pending or complete/complete matching link.`,
+      );
+    }
+
+    chain.push({ resolver, parent, alreadyResolved });
+    resolver = parent;
+  }
+
+  return chain;
+}
+
+function validateReviewBlockerResolverGraph(plan: UltragoalPlan): void {
+  const goalIds = new Set<string>();
+  for (const goal of plan.goals) {
+    if (goalIds.has(goal.id)) {
+      throw new UltragoalError(`Duplicate ultragoal id in review blocker resolver graph: ${goal.id}.`);
+    }
+    goalIds.add(goal.id);
+  }
+
+  for (const parent of plan.goals) {
+    const resolverId = parent.reviewBlockerResolution?.resolverGoalId;
+    if (!resolverId) continue;
+    const resolver = plan.goals.find((candidate) => candidate.id === resolverId);
+    if (!resolver) {
+      throw new UltragoalError(`Missing designated review-blocker resolver: ${resolverId} for ${parent.id}.`);
+    }
+    if (resolver.resolvesReviewBlockedGoalId !== parent.id) {
+      throw new UltragoalError(
+        `Invalid designated resolver link: ${parent.id} claims ${resolverId}, but that resolver points to ${resolver.resolvesReviewBlockedGoalId ?? 'none'}.`,
+      );
+    }
+  }
+
+  for (const resolver of plan.goals) {
+    if (resolver.resolvesReviewBlockedGoalId) collectReviewBlockerAncestorChain(plan, resolver);
+  }
+}
+
+function resolveReviewBlockerAncestors(
+  plan: UltragoalPlan,
+  completedResolver: UltragoalItem,
+  evidence: string | undefined,
+  now: string,
+): UltragoalItem[] {
+  const resolved: UltragoalItem[] = [];
+  for (const link of collectReviewBlockerAncestorChain(plan, completedResolver)) {
+    if (link.alreadyResolved) {
+      if (link.parent.reviewBlockerResolution?.evidence !== evidence) {
+        throw new UltragoalError(
+          `Conflicting completed resolver evidence for ${link.resolver.id} -> ${link.parent.id}.`,
+        );
+      }
+      continue;
+    }
+    link.parent.status = 'complete';
+    link.parent.completedAt = now;
+    link.parent.updatedAt = now;
+    link.parent.reviewBlockerResolution = {
+      resolverGoalId: link.resolver.id,
+      status: 'complete',
+      resolvedAt: now,
+      evidence,
+    };
+    clearGoalBlockerFields(link.parent);
+    resolved.push(link.parent);
+  }
+  return resolved;
 }
 
 function canUseCleanFinalResolverPathForReviewBlockedParent(
@@ -592,11 +715,16 @@ function canUseCleanFinalResolverPathForReviewBlockedParent(
   finalRunCheckpoint: boolean,
   allowActiveFinalCodexGoal: boolean | undefined,
 ): boolean {
+  const pendingAncestorIds = new Set(
+    collectReviewBlockerAncestorChain(plan, goal)
+      .filter((link) => !link.alreadyResolved)
+      .map((link) => link.parent.id),
+  );
   const unresolvedReviewBlocked = unresolvedReviewBlockedGoals(plan);
-  if (unresolvedReviewBlocked.length !== 1) return false;
+  if (pendingAncestorIds.size === 0 || unresolvedReviewBlocked.length !== pendingAncestorIds.size) return false;
   return finalRunCheckpoint
     && !allowActiveFinalCodexGoal
-    && isDesignatedReviewBlockerResolver(goal, unresolvedReviewBlocked[0]);
+    && unresolvedReviewBlocked.every((candidate) => pendingAncestorIds.has(candidate.id));
 }
 
 async function canReconcileCompletedTaskScopedAggregateSnapshot(
@@ -718,14 +846,13 @@ function isCompletionBlocking(goal: UltragoalItem, plan: UltragoalPlan): boolean
   return !isResolvedStatus(goal.status);
 }
 
-function isCompletionBlockingForFinalCandidate(candidate: UltragoalItem, finalCandidate: UltragoalItem, plan: UltragoalPlan): boolean {
-  if (candidate.id === finalCandidate.id) return false;
-  if (candidate.status === 'review_blocked' && candidate.reviewBlockerResolution?.resolverGoalId === finalCandidate.id) return false;
+function isCompletionBlockingForFinalCandidate(candidate: UltragoalItem, completionCandidateIds: ReadonlySet<string>, plan: UltragoalPlan): boolean {
+  if (completionCandidateIds.has(candidate.id)) return false;
   if (candidate.steeringStatus === 'superseded') {
     const replacements = candidate.supersededBy ?? [];
     if (replacements.length === 0) return true;
     return !replacements.every((id) => {
-      if (id === finalCandidate.id) return true;
+      if (completionCandidateIds.has(id)) return true;
       const replacement = plan.goals.find((goal) => goal.id === id);
       return replacement !== undefined && isResolvedStatus(replacement.status);
     });
@@ -738,7 +865,12 @@ function isScheduleEligible(goal: UltragoalItem): boolean {
 }
 
 export function isFinalRunCompletionCandidate(plan: UltragoalPlan, goal: UltragoalItem): boolean {
-  return plan.goals.every((candidate) => !isCompletionBlockingForFinalCandidate(candidate, goal, plan));
+  validateReviewBlockerResolverGraph(plan);
+  const completionCandidateIds = new Set([
+    goal.id,
+    ...collectReviewBlockerAncestorChain(plan, goal).map((link) => link.parent.id),
+  ]);
+  return plan.goals.every((candidate) => !isCompletionBlockingForFinalCandidate(candidate, completionCandidateIds, plan));
 }
 
 export function isUltragoalDone(plan: UltragoalPlan): boolean {
@@ -831,6 +963,38 @@ async function appendLedger(cwd: string, entry: UltragoalLedgerEntry): Promise<v
   await mkdir(ultragoalDir(cwd), { recursive: true });
   const path = ultragoalLedgerPath(cwd);
   await appendFile(path, `${JSON.stringify(entry)}\n`);
+}
+
+async function appendLedgerOnce(cwd: string, entry: UltragoalLedgerEntry): Promise<void> {
+  if (!entry.idempotencyKey) {
+    await appendLedger(cwd, entry);
+    return;
+  }
+  let existing: UltragoalLedgerEntry[] = [];
+  try {
+    const raw = await readFile(ultragoalLedgerPath(cwd), 'utf-8');
+    existing = raw.split(/\r?\n/).filter(Boolean).map((line) => JSON.parse(line) as UltragoalLedgerEntry);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw new UltragoalError(`Cannot reconcile idempotent ultragoal ledger entry ${entry.idempotencyKey}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  const normalizedEntry = JSON.parse(JSON.stringify(entry)) as UltragoalLedgerEntry;
+  const keyedMatches = existing.filter((candidate) => candidate.idempotencyKey === entry.idempotencyKey);
+  for (const candidate of keyedMatches) {
+    if (!isDeepStrictEqual(candidate, normalizedEntry)) {
+      throw new UltragoalError(`Conflicting ultragoal ledger entry for idempotency key ${entry.idempotencyKey}.`);
+    }
+  }
+  if (keyedMatches.length > 0) return;
+
+  const { idempotencyKey: _entryKey, ...entryPayload } = normalizedEntry;
+  const legacyDuplicate = existing.some((candidate) => {
+    if (candidate.idempotencyKey) return false;
+    const { idempotencyKey: _candidateKey, ...candidatePayload } = candidate;
+    return isDeepStrictEqual(candidatePayload, entryPayload);
+  });
+  if (!legacyDuplicate) await appendLedger(cwd, entry);
 }
 
 export async function readUltragoalPlan(cwd: string): Promise<UltragoalPlan> {
@@ -1572,6 +1736,112 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
   const goal = plan.goals.find((candidate) => candidate.id === options.goalId);
   if (!goal) throw new UltragoalError(`Unknown ultragoal id: ${options.goalId}`);
   const now = iso(options.now);
+  if (options.status === 'complete') validateReviewBlockerResolverGraph(plan);
+  const resolverChain = options.status === 'complete'
+    ? collectReviewBlockerAncestorChain(plan, goal)
+    : [];
+  if (options.status === 'complete' && goal.status === 'complete') {
+    if (goal.evidence !== options.evidence) {
+      throw new UltragoalError(`Conflicting completed checkpoint evidence for ${goal.id}.`);
+    }
+    const resolverChainComplete = resolverChain.every((link) => link.alreadyResolved);
+    const aggregateSatisfied = resolverChain.length === 0
+      || codexGoalMode(plan) !== 'aggregate'
+      || plan.aggregateCompletion?.status === 'complete';
+    if (resolverChainComplete && aggregateSatisfied) {
+      for (const link of resolverChain) {
+        if (link.parent.reviewBlockerResolution?.evidence !== options.evidence) {
+          throw new UltragoalError(
+            `Conflicting completed resolver evidence for ${link.resolver.id} -> ${link.parent.id}.`,
+          );
+        }
+      }
+      if (plan.aggregateCompletion && plan.aggregateCompletion.evidence !== options.evidence) {
+        throw new UltragoalError(`Conflicting aggregate completion evidence for ${goal.id}.`);
+      }
+      if (plan.aggregateCompletion && !isDeepStrictEqual(plan.aggregateCompletion.codexGoal, options.codexGoal)) {
+        throw new UltragoalError(`Conflicting aggregate Codex goal snapshot for ${goal.id}.`);
+      }
+      if (!plan.aggregateCompletion) {
+        const aggregateMode = codexGoalMode(plan) === 'aggregate';
+        const finalRunCheckpoint = isFinalRunCompletionCandidate(plan, goal);
+        const replayReconciliation = reconcileCodexGoalSnapshot(
+          options.codexGoal === undefined ? null : parseCodexGoalSnapshot(options.codexGoal),
+          {
+            expectedObjective: expectedCodexObjective(plan, goal),
+            acceptedObjectives: aggregateMode ? compatibleCodexObjectives(plan) : undefined,
+            allowedStatuses: aggregateMode
+              ? (finalRunCheckpoint && !options.allowActiveFinalCodexGoal ? ['complete'] : ['active'])
+              : ['complete'],
+            requireSnapshot: true,
+            requireComplete: !aggregateMode || (finalRunCheckpoint && !options.allowActiveFinalCodexGoal),
+          },
+        );
+        if (!replayReconciliation.ok) {
+          throw new UltragoalError(`Completed checkpoint replay rejected: ${formatCodexGoalReconciliation(replayReconciliation)}`);
+        }
+      }
+      const replayCodexGoal = plan.aggregateCompletion?.codexGoal ?? options.codexGoal;
+      const replayNeedsQualityGate = resolverChain.length > 0
+        || plan.aggregateCompletion?.status === 'complete'
+        || (isFinalRunCompletionCandidate(plan, goal) && !options.allowActiveFinalCodexGoal);
+      const requiredArchitectureInvariants = replayNeedsQualityGate
+        ? await collectRequiredArchitectureInvariants(cwd)
+        : [];
+      const qualityGate = replayNeedsQualityGate
+        ? validateQualityGate(options.qualityGate, requiredArchitectureInvariants)
+        : undefined;
+      const replaySnapshot = parseCodexGoalSnapshot(replayCodexGoal);
+      const taskScopedAggregateReplay = resolverChain.length === 0
+        && plan.aggregateCompletion?.status === 'complete'
+        && replaySnapshot.available
+        && replaySnapshot.status === 'complete'
+        && Boolean(replaySnapshot.objective)
+        && normalizeObjective(replaySnapshot.objective ?? '') !== normalizeObjective(expectedCodexObjective(plan, goal));
+      await appendLedgerOnce(cwd, {
+        ts: goal.completedAt ?? now,
+        event: 'goal_completed',
+        goalId: goal.id,
+        status: goal.status,
+        evidence: options.evidence,
+        codexGoal: replayCodexGoal,
+        qualityGate,
+        idempotencyKey: `checkpoint:${goal.id}:goal_completed`,
+        message: taskScopedAggregateReplay
+          ? 'Active repo-native microgoal completed while reconciling a completed task-scoped aggregate Codex goal snapshot.'
+          : undefined,
+      });
+      for (const link of resolverChain) {
+        await appendLedgerOnce(cwd, {
+          ts: link.parent.reviewBlockerResolution?.resolvedAt ?? link.parent.completedAt ?? now,
+          event: 'goal_completed',
+          goalId: link.parent.id,
+          status: link.parent.status,
+          evidence: options.evidence,
+          codexGoal: replayCodexGoal,
+          qualityGate,
+          idempotencyKey: `checkpoint:${goal.id}:resolved:${link.parent.id}`,
+          message: `Review-blocked final story resolved by ${link.resolver.id} through resolver chain; original failed review remains in prior final_review_failed/goal_review_blocked ledger entries.`,
+        });
+      }
+      if (plan.aggregateCompletion?.status === 'complete') {
+        await appendLedgerOnce(cwd, {
+          ts: plan.aggregateCompletion.completedAt,
+          event: 'aggregate_completed',
+          goalId: goal.id,
+          status: goal.status,
+          evidence: options.evidence,
+          codexGoal: replayCodexGoal,
+          qualityGate,
+          idempotencyKey: `checkpoint:${goal.id}:aggregate_completed`,
+          message: taskScopedAggregateReplay
+            ? 'Aggregate ultragoal plan completed via task-scoped Codex goal snapshot; checkpointed active microgoal row was reconciled to complete.'
+            : 'Aggregate ultragoal plan completed with a clean final quality gate.',
+        });
+      }
+      return plan;
+    }
+  }
   if (options.status === 'blocked') {
     if (goal.status !== 'in_progress') {
       throw new UltragoalError(`Cannot record a blocked checkpoint for ${goal.id} while it is ${goal.status}; start or resume the ultragoal before recording a non-terminal blocker.`);
@@ -1686,12 +1956,7 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
         throw new UltragoalError(`${formatCodexGoalReconciliation(reconciliation)}${taskScopedRequirement}${remediation}`);
       }
     }
-    const designatedReviewBlockerResolver = goal.resolvesReviewBlockedGoalId
-      ? isDesignatedReviewBlockerResolver(
-        goal,
-        plan.goals.find((candidate) => candidate.id === goal.resolvesReviewBlockedGoalId),
-      )
-      : false;
+    const designatedReviewBlockerResolver = resolverChain.length > 0;
     if (aggregateMode && finalRunCheckpoint && !options.allowActiveFinalCodexGoal && designatedReviewBlockerResolver) {
       normalFinalAggregateCompletion = {
         status: 'complete',
@@ -1720,7 +1985,7 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
     if (plan.activeGoalId === goal.id) delete plan.activeGoalId;
     plan.updatedAt = now;
     await writePlan(cwd, plan);
-    await appendLedger(cwd, {
+    await appendLedgerOnce(cwd, {
       ts: now,
       event: 'goal_completed',
       goalId: goal.id,
@@ -1728,9 +1993,10 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
       evidence: options.evidence,
       codexGoal: options.codexGoal,
       qualityGate,
+      idempotencyKey: `checkpoint:${goal.id}:goal_completed`,
       message: 'Active repo-native microgoal completed while reconciling a completed task-scoped aggregate Codex goal snapshot.',
     });
-    await appendLedger(cwd, {
+    await appendLedgerOnce(cwd, {
       ts: now,
       event: 'aggregate_completed',
       goalId: goal.id,
@@ -1738,6 +2004,7 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
       evidence: options.evidence,
       codexGoal: options.codexGoal,
       qualityGate,
+      idempotencyKey: `checkpoint:${goal.id}:aggregate_completed`,
       message: 'Aggregate ultragoal plan completed via task-scoped Codex goal snapshot; checkpointed active microgoal row was reconciled to complete.',
     });
     return plan;
@@ -1751,21 +2018,10 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
     goal.failedAt = undefined;
     clearGoalBlockerFields(goal);
     if (normalFinalAggregateCompletion) plan.aggregateCompletion = normalFinalAggregateCompletion;
-    const resolvedParent = goal.resolvesReviewBlockedGoalId
-      ? plan.goals.find((candidate) => candidate.id === goal.resolvesReviewBlockedGoalId)
-      : undefined;
-    if (resolvedParent?.status === 'review_blocked' && resolvedParent.reviewBlockerResolution?.resolverGoalId === goal.id && qualityGate) {
-      resolvedParent.status = 'complete';
-      resolvedParent.completedAt = now;
-      resolvedParent.updatedAt = now;
-      resolvedParent.reviewBlockerResolution = {
-        resolverGoalId: goal.id,
-        status: 'complete',
-        resolvedAt: now,
-        evidence: options.evidence,
-      };
-      clearGoalBlockerFields(resolvedParent);
+    if (resolverChain.length > 0 && !qualityGate) {
+      throw new UltragoalError('Review-blocker resolver chain completion requires a clean final quality gate.');
     }
+    if (qualityGate) resolveReviewBlockerAncestors(plan, goal, options.evidence, now);
     if (plan.activeGoalId === goal.id) delete plan.activeGoalId;
   } else {
     const blocker = classifyExternalAuthorizationBlocker(options.evidence);
@@ -1787,7 +2043,7 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
   plan.updatedAt = now;
   await writePlan(cwd, plan);
   const blockerEvent = goal.status === 'needs_user_decision';
-  await appendLedger(cwd, {
+  await appendLedgerOnce(cwd, {
     ts: now,
     event: options.status === 'complete' ? 'goal_completed' : blockerEvent ? 'goal_needs_user_decision' : 'goal_failed',
     goalId: goal.id,
@@ -1798,27 +2054,28 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
     blockerSignature: goal.blockerSignature,
     blockerOccurrenceCount: goal.blockerOccurrenceCount,
     requiredExternalDecision: goal.requiredExternalDecision,
+    idempotencyKey: options.status === 'complete' ? `checkpoint:${goal.id}:goal_completed` : undefined,
     message: blockerEvent
       ? `Blocked on repeated external authorization. Required decision: ${goal.requiredExternalDecision}.`
       : undefined,
   });
-  if (options.status === 'complete' && goal.resolvesReviewBlockedGoalId) {
-    const resolvedParent = plan.goals.find((candidate) => candidate.id === goal.resolvesReviewBlockedGoalId);
-    if (resolvedParent?.reviewBlockerResolution?.status === 'complete' && resolvedParent.reviewBlockerResolution.resolverGoalId === goal.id) {
-      await appendLedger(cwd, {
+  if (options.status === 'complete') {
+    for (const link of resolverChain) {
+      await appendLedgerOnce(cwd, {
         ts: now,
         event: 'goal_completed',
-        goalId: resolvedParent.id,
-        status: resolvedParent.status,
+        goalId: link.parent.id,
+        status: link.parent.status,
         evidence: options.evidence,
         codexGoal: options.codexGoal,
         qualityGate,
-        message: `Review-blocked final story resolved by ${goal.id}; original failed review remains in prior final_review_failed/goal_review_blocked ledger entries.`,
+        idempotencyKey: `checkpoint:${goal.id}:resolved:${link.parent.id}`,
+        message: `Review-blocked final story resolved by ${link.resolver.id} through resolver chain; original failed review remains in prior final_review_failed/goal_review_blocked ledger entries.`,
       });
     }
   }
   if (normalFinalAggregateCompletion) {
-    await appendLedger(cwd, {
+    await appendLedgerOnce(cwd, {
       ts: now,
       event: 'aggregate_completed',
       goalId: goal.id,
@@ -1826,6 +2083,7 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
       evidence: options.evidence,
       codexGoal: options.codexGoal,
       qualityGate,
+      idempotencyKey: `checkpoint:${goal.id}:aggregate_completed`,
       message: 'Aggregate ultragoal plan completed with a clean final quality gate.',
     });
   }


### PR DESCRIPTION
## Summary

A completed resolver previously settled only its direct `resolvedParent`. Resolver chains such as `G001 -> G002 -> G003` therefore left review-blocked ancestors unresolved.

## Changes

- Recursively settle designated review-blocked ancestors during resolver completion.
- Fail closed for missing, inconsistent, branching, completed-mismatch, or cyclic resolver provenance.
- Emit one idempotent `goal_completed` ledger event for each ancestor.

## Validation

- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] `node dist/scripts/run-test-files.js dist/ultragoal/__tests__/artifacts.test.js` (61/61)
- [x] `npm test`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs not updated: internal state-machine integrity fix; no CLI or guidance contract changes
- [x] Backward-compatibility impact considered: valid single-level chains retain behavior; malformed resolver graphs now fail closed

## Related

N/A