### PR TITLE
OWNER_CONFIRMATION_REQUIRED feat: support max per-agent reasoning effort

### DIFF
--- a/docs/reference/omx-config-schema-routing.md
+++ b/docs/reference/omx-config-schema-routing.md
@@ -26,7 +26,7 @@ Current code recognizes these top-level `.omx-config.json` keys:
 | Top-level key | Supported shape | Primary use |
 | --- | --- | --- |
 | `agentModels` | Object mapping agent names to non-empty model strings | Optional per-agent model overrides for generated native agent TOML, AGENTS.md model tables, and role-based worker/Ralph fallback routing. |
-| `agentReasoning` | Object mapping agent names to `low`, `medium`, `high`, or `xhigh` | Optional per-agent reasoning overrides for generated native agent TOML and role-based worker/Ralph staffing guidance. |
+| `agentReasoning` | Object mapping agent names to `low`, `medium`, `high`, `xhigh`, or `max` | Optional per-agent reasoning overrides for generated native agent TOML and role-based worker/Ralph staffing guidance.
 | `env` | Object of non-empty string values | Fallback environment values for model routing and helper launch paths. Model-related supported keys are listed below. |
 | `models` | Object of non-empty string values | Mode defaults and low-complexity model aliases. Supported model-routing keys are listed below. |
 | `notifications` | Object | Notification transports, profiles, templates, cooldowns, replies, and OpenClaw/custom aliases. See the notification summary below and the OpenClaw guide for full examples. |
@@ -152,20 +152,20 @@ For a named role, effective model precedence is:
 
 ### `agentReasoning`
 
-`agentReasoning` is the supported per-agent reasoning override map. Keys are agent names and values must be one of `low`, `medium`, `high`, or `xhigh`.
+`agentReasoning` is the supported **per-agent** reasoning override map. Keys are normalized agent names; configured string values are trimmed and case-normalized to exactly `low`, `medium`, `high`, `xhigh`, or `max`. This normalization is configuration-only: it does not make `max` a root CLI value or launch shorthand.
 
-`xhigh` is the canonical highest reasoning effort token accepted by Codex/OMX. Reported names such as `max` or `ultra` are ambiguous and are not accepted aliases; use `xhigh` instead.
+`max` is passed unchanged to generated native-agent TOML and Team role defaults. Its availability remains capability-dependent on the installed Codex version, selected model, and provider; OMX does not probe capability, downgrade or retry it as `xhigh`, or hide downstream errors. `ultra` is unsupported on OMX-owned `agentReasoning` surfaces and is not an alias for `max`.
 
 ```json
 {
   "agentReasoning": {
-    "architect": "xhigh",
+    "architect": "MAX",
     "critic": "xhigh"
   }
 }
 ```
 
-These overrides do not change built-in defaults in source. They are user/project configuration that applies when OMX resolves role reasoning for generated native agent TOML and role-based team/Ralph staffing/worker guidance. Rerun `omx setup` after changing this map so setup-managed native agent TOML files are regenerated. Malformed agent names, empty values, and unsupported effort values are ignored.
+These overrides do not change built-in defaults in source. Every built-in `AgentDefinition.reasoningEffort` remains required and one of `low`, `medium`, `high`, or `xhigh`; it is never omitted, `max`, or `ultra`. A valid override affects only that normalized agent key. Malformed agent names, empty/non-string values, `ultra`, and unknown values are ignored, so valid sibling overrides remain effective and an affected role keeps its unchanged built-in fallback. Rerun `omx setup --force` after changing this map so setup-managed native agent TOML files are regenerated.
 
 ## Effective model precedence
 
@@ -240,21 +240,17 @@ Use `omx team status <team-name> --model-inspect` when you need inspect hints fo
 
 `.omx-config.json` is **not** the general place to configure root `model_reasoning_effort`. Do not add arbitrary keys such as `reasoningEffort`, `modelReasoningEffort`, `reasoning`, or undeclared per-role reasoning maps. The supported per-agent override map is exactly `agentReasoning`.
 
-Supported reasoning-effort surfaces are:
+Root and per-agent reasoning vocabularies are deliberately separate:
 
-- Active Codex `config.toml` root key: `model_reasoning_effort = "medium"`.
-- `omx reasoning <low|medium|high|xhigh>`, which edits the active Codex `config.toml`.
-- `omx --high` and `omx --xhigh`, which pass `-c model_reasoning_effort="high|xhigh"` to Codex launch.
-- Generated native agent TOML files, where OMX writes each role's built-in `reasoningEffort` metadata.
-- `.omx-config.json` `agentReasoning`, which overrides selected role defaults for generated native agent TOML and role-based team/Ralph reasoning allocation without changing built-in defaults.
-- Team worker launch args, for example:
+- Root `config.toml` accepts `model_reasoning_effort = "low"`, `"medium"`, `"high"`, or `"xhigh"`.
+- `omx reasoning <low|medium|high|xhigh>` edits that root setting. There is no `omx reasoning max`, `omx --max`, or root `max` shorthand.
+- `omx --high` and `omx --xhigh` pass `-c model_reasoning_effort="high|xhigh"` to Codex launch.
+- `.omx-config.json` `agentReasoning` accepts the five configured per-agent values described above and overrides selected role defaults for generated native agent TOML and role-based Team/Ralph staffing without changing built-in defaults.
+- Generated native agent TOML files otherwise write each role's unchanged built-in `reasoningEffort` metadata.
 
-```bash
-OMX_TEAM_WORKER_LAUNCH_ARGS='-c model_reasoning_effort="low" --model gpt-5.6-luna' \
-  omx team 3:explore "map the config surfaces"
-```
+Team runtime can inject a role-default or `agentReasoning`-overridden value when no explicit reasoning override is present. Explicit raw `-c model_reasoning_effort=...` is opaque Codex passthrough: it wins over configured and built-in role defaults, is forwarded unchanged (including `ultra` or future values), and preserves inherited Team explicit reasoning precedence over environment explicit reasoning. OMX does not validate, normalize, downgrade, retry, or claim provider support for that raw value.
 
-Team runtime can also inject role-default or `agentReasoning`-overridden reasoning for Codex workers when no explicit reasoning override is present. Explicit launch args win.
+The launch parser has one narrow end-of-options rule: literal `--max` and `--ultra` are rejected as OMX shorthands before `--`, but `omx -- --max` and `omx -- --ultra` are passed through unchanged to Codex. This does not make unrelated post-`--` arguments an OMX configuration surface.
 
 ## Starter configs
 
@@ -314,10 +310,10 @@ This keeps standard agents inheriting the frontier model by omitting `OMX_DEFAUL
 
 ## Verifying the effective config
 
-After editing `.omx-config.json` or `config.toml`, run setup/doctor from the same shell and project shape that will launch OMX:
+After editing `.omx-config.json` `agentReasoning` or `config.toml`, regenerate setup-managed native agent TOML from the same shell and project shape that will launch OMX:
 
 ```bash
-omx setup
+omx setup --force
 omx doctor
 ```
 

--- a/plugins/oh-my-codex/skills/team/SKILL.md
+++ b/plugins/oh-my-codex/skills/team/SKILL.md
@@ -203,17 +203,21 @@ Default-model rule:
 - Use `OMX_DEFAULT_SPARK_MODEL` for spark/low-complexity worker-default guidance.
 
 Thinking-level rule (critical):
-- **No model-name heuristic mapping.**
-- Team runtime must **not** infer `model_reasoning_effort` from model-name substrings (e.g., `spark`, `high-capability`, `mini`).
-- When the leader assigns teammate roles/tasks, OMX allocates **per-worker reasoning effort dynamically** from the resolved worker role and `agentReasoning` overrides (`low`, `medium`, `high`, `xhigh`).
-- Explicit launch args still win: if `OMX_TEAM_WORKER_LAUNCH_ARGS` already includes `-c model_reasoning_effort=...`, that explicit value overrides dynamic allocation for every worker.
+- **No model-name heuristic mapping.** Team runtime must not infer `model_reasoning_effort` from model-name substrings (for example `spark`, `high-capability`, or `mini`).
+- OMX-owned `agentReasoning` accepts exactly `low`, `medium`, `high`, `xhigh`, and `max`; configured values are case-normalized.
+- Without explicit raw reasoning, Team selects the resolved role default or valid `agentReasoning` override for each worker.
+- `max` is passed to Codex unchanged. Its support is capability-dependent on the selected Codex version, model, and provider; preserve authoritative downstream errors.
+- `ultra` is unsupported in OMX-owned `agentReasoning` and is not an alias for configured `max`. Other invalid configured values retain the built-in role-default fallback.
+- Explicit raw `-c model_reasoning_effort=...` is opaque and wins over configured and built-in role defaults, including `ultra` and future values. Preserve the selected raw token exactly.
+- When both sources provide explicit raw reasoning, inherited Team reasoning wins over environment reasoning. Explicit raw reasoning always wins over the role default.
+- Do not downgrade or retry `max` as `xhigh`; built-in role defaults remain unchanged.
 
 Normalization requirements:
-- Parse both `--model <value>` and `--model=<value>`
-- Remove duplicate/conflicting model flags
-- Emit exactly one final canonical flag: `--model <value>`
-- Preserve unrelated args in worker launch config
-- If explicit reasoning exists, preserve canonical `-c model_reasoning_effort="<level>"`; otherwise inject the worker role's default or `agentReasoning`-overridden reasoning level
+- Parse both `--model <value>` and `--model=<value>`.
+- Remove duplicate/conflicting model flags.
+- Emit exactly one final canonical flag: `--model <value>`.
+- Preserve unrelated args in worker launch config.
+- Preserve the selected explicit raw `-c model_reasoning_effort=...` token exactly; otherwise inject the worker role's default or `agentReasoning`-overridden reasoning level.
 
 ## Required Lifecycle (Operator Contract)
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -203,17 +203,21 @@ Default-model rule:
 - Use `OMX_DEFAULT_SPARK_MODEL` for spark/low-complexity worker-default guidance.
 
 Thinking-level rule (critical):
-- **No model-name heuristic mapping.**
-- Team runtime must **not** infer `model_reasoning_effort` from model-name substrings (e.g., `spark`, `high-capability`, `mini`).
-- When the leader assigns teammate roles/tasks, OMX allocates **per-worker reasoning effort dynamically** from the resolved worker role and `agentReasoning` overrides (`low`, `medium`, `high`, `xhigh`).
-- Explicit launch args still win: if `OMX_TEAM_WORKER_LAUNCH_ARGS` already includes `-c model_reasoning_effort=...`, that explicit value overrides dynamic allocation for every worker.
+- **No model-name heuristic mapping.** Team runtime must not infer `model_reasoning_effort` from model-name substrings (for example `spark`, `high-capability`, or `mini`).
+- OMX-owned `agentReasoning` accepts exactly `low`, `medium`, `high`, `xhigh`, and `max`; configured values are case-normalized.
+- Without explicit raw reasoning, Team selects the resolved role default or valid `agentReasoning` override for each worker.
+- `max` is passed to Codex unchanged. Its support is capability-dependent on the selected Codex version, model, and provider; preserve authoritative downstream errors.
+- `ultra` is unsupported in OMX-owned `agentReasoning` and is not an alias for configured `max`. Other invalid configured values retain the built-in role-default fallback.
+- Explicit raw `-c model_reasoning_effort=...` is opaque and wins over configured and built-in role defaults, including `ultra` and future values. Preserve the selected raw token exactly.
+- When both sources provide explicit raw reasoning, inherited Team reasoning wins over environment reasoning. Explicit raw reasoning always wins over the role default.
+- Do not downgrade or retry `max` as `xhigh`; built-in role defaults remain unchanged.
 
 Normalization requirements:
-- Parse both `--model <value>` and `--model=<value>`
-- Remove duplicate/conflicting model flags
-- Emit exactly one final canonical flag: `--model <value>`
-- Preserve unrelated args in worker launch config
-- If explicit reasoning exists, preserve canonical `-c model_reasoning_effort="<level>"`; otherwise inject the worker role's default or `agentReasoning`-overridden reasoning level
+- Parse both `--model <value>` and `--model=<value>`.
+- Remove duplicate/conflicting model flags.
+- Emit exactly one final canonical flag: `--model <value>`.
+- Preserve unrelated args in worker launch config.
+- Preserve the selected explicit raw `-c model_reasoning_effort=...` token exactly; otherwise inject the worker role's default or `agentReasoning`-overridden reasoning level.
 
 ## Required Lifecycle (Operator Contract)
 

--- a/src/agents/__tests__/definitions.test.ts
+++ b/src/agents/__tests__/definitions.test.ts
@@ -29,6 +29,97 @@ describe('agents/definitions', () => {
     }
   });
 
+  it('requires a four-valued reasoning default on every AgentDefinition', () => {
+    const definitionShape = {
+      name: 'type-contract',
+      description: 'Type contract fixture',
+      posture: 'deep-worker',
+      modelClass: 'standard',
+      routingRole: 'executor',
+      tools: 'execution',
+      category: 'build',
+    } as const;
+    const validDefinition: AgentDefinition = {
+      ...definitionShape,
+      reasoningEffort: 'high',
+    };
+    const reasoningEffortIsRequired:
+      undefined extends AgentDefinition['reasoningEffort'] ? false : true = true;
+    void validDefinition;
+    void reasoningEffortIsRequired;
+
+    // @ts-expect-error AgentDefinition.reasoningEffort is required.
+    const missingReasoningEffort: AgentDefinition = definitionShape;
+    const invalidUndefinedDefinition = {
+      ...definitionShape,
+      reasoningEffort: undefined,
+    } as const;
+    const invalidMaxDefinition = {
+      ...definitionShape,
+      reasoningEffort: 'max',
+    } as const;
+    const invalidUltraDefinition = {
+      ...definitionShape,
+      reasoningEffort: 'ultra',
+    } as const;
+    // @ts-expect-error AgentDefinition.reasoningEffort excludes undefined.
+    const undefinedReasoningEffort: AgentDefinition = invalidUndefinedDefinition;
+    // @ts-expect-error AgentDefinition.reasoningEffort excludes per-agent max.
+    const maxReasoningEffort: AgentDefinition = invalidMaxDefinition;
+    // @ts-expect-error AgentDefinition.reasoningEffort excludes ultra.
+    const ultraReasoningEffort: AgentDefinition = invalidUltraDefinition;
+    void missingReasoningEffort;
+    void undefinedReasoningEffort;
+    void maxReasoningEffort;
+    void ultraReasoningEffort;
+  });
+
+  it('keeps every built-in reasoning default unchanged', () => {
+    const expectedReasoningEfforts = {
+      explore: 'low',
+      analyst: 'medium',
+      planner: 'medium',
+      architect: 'xhigh',
+      debugger: 'high',
+      executor: 'medium',
+      'team-executor': 'medium',
+      verifier: 'high',
+      'style-reviewer': 'low',
+      'quality-reviewer': 'medium',
+      'api-reviewer': 'medium',
+      'security-reviewer': 'medium',
+      'performance-reviewer': 'medium',
+      'code-reviewer': 'high',
+      'dependency-expert': 'high',
+      'test-engineer': 'medium',
+      'quality-strategist': 'medium',
+      'build-fixer': 'high',
+      designer: 'high',
+      writer: 'high',
+      'qa-tester': 'low',
+      'git-master': 'high',
+      'code-simplifier': 'high',
+      researcher: 'high',
+      'product-manager': 'medium',
+      'ux-researcher': 'medium',
+      'information-architect': 'low',
+      'product-analyst': 'low',
+      'prometheus-strict-metis': 'high',
+      'prometheus-strict-momus': 'high',
+      'prometheus-strict-oracle': 'high',
+      critic: 'high',
+      scholastic: 'high',
+      vision: 'low',
+    } as const satisfies Record<string, AgentDefinition['reasoningEffort']>;
+
+    assert.deepEqual(
+      Object.fromEntries(
+        Object.entries(AGENT_DEFINITIONS).map(([name, agent]) => [name, agent.reasoningEffort]),
+      ),
+      expectedReasoningEfforts,
+    );
+  });
+
   it('filters agents by category', () => {
     const buildAgents = getAgentsByCategory('build');
     assert.ok(buildAgents.length > 0);

--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -4,6 +4,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, it } from "node:test";
+import { parse as parseToml } from "@iarna/toml";
 import { AGENT_DEFINITIONS } from "../definitions.js";
 import type { AgentDefinition } from "../definitions.js";
 import type { CatalogManifest } from "../../catalog/schema.js";
@@ -128,6 +129,35 @@ describe("agents/native-config", () => {
       const toml = generateAgentToml(agent, "Architect prompt", { codexHomeOverride: codexHome });
 
       assert.match(toml, /model_reasoning_effort = "xhigh"/);
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  it("transports normalized per-agent max through exact native TOML and falls back from ultra", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "omx-native-config-max-reasoning-"));
+    try {
+      await writeFile(join(codexHome, ".omx-config.json"), JSON.stringify({
+        agentReasoning: {
+          architect: " MAX ",
+          critic: "ultra",
+        },
+      }));
+
+      const maxToml = generateAgentToml(AGENT_DEFINITIONS.architect, "Architect prompt", {
+        codexHomeOverride: codexHome,
+      });
+      assert.match(maxToml, /model_reasoning_effort = "max"/);
+      assert.equal(
+        (parseToml(maxToml) as { model_reasoning_effort?: unknown }).model_reasoning_effort,
+        "max",
+      );
+
+      const fallbackToml = generateAgentToml(AGENT_DEFINITIONS.critic, "Critic prompt", {
+        codexHomeOverride: codexHome,
+      });
+      assert.match(fallbackToml, /model_reasoning_effort = "high"/);
+      assert.doesNotMatch(fallbackToml, /model_reasoning_effort = "ultra"/);
     } finally {
       await rm(codexHome, { recursive: true, force: true });
     }

--- a/src/agents/native-config.ts
+++ b/src/agents/native-config.ts
@@ -18,6 +18,7 @@ import {
   getMainDefaultModel,
   getSparkDefaultModel,
   getStandardDefaultModel,
+  type PerAgentReasoningEffort,
 } from "../config/models.js";
 import { getRootModelName } from "../config/generator.js";
 import { codexAgentsDir } from "../utils/paths.js";
@@ -121,7 +122,7 @@ export interface GeneratedNativeAgentConfig {
   developerInstructions?: string;
   model?: string;
   modelProvider?: string;
-  reasoningEffort?: "low" | "medium" | "high" | "xhigh";
+  reasoningEffort?: PerAgentReasoningEffort;
 }
 
 interface AgentModelResolutionOptions {

--- a/src/auth/hotswap.ts
+++ b/src/auth/hotswap.ts
@@ -60,7 +60,23 @@ export interface CodexRunResult {
 }
 
 export function stripHotswapArg(args: string[]): string[] {
-  return args.filter((arg) => arg !== "--hotswap");
+  const endOfOptionsIndex = args.indexOf("--");
+  const omxArgs = endOfOptionsIndex === -1 ? args : args.slice(0, endOfOptionsIndex);
+  const suffix = endOfOptionsIndex === -1 ? [] : args.slice(endOfOptionsIndex);
+  return [
+    ...omxArgs.filter((arg) => arg !== "--hotswap"),
+    ...suffix,
+  ];
+}
+
+function stripLeaderLaunchPolicyArgs(args: string[]): string[] {
+  const endOfOptionsIndex = args.indexOf("--");
+  const omxArgs = endOfOptionsIndex === -1 ? args : args.slice(0, endOfOptionsIndex);
+  const suffix = endOfOptionsIndex === -1 ? [] : args.slice(endOfOptionsIndex);
+  return [
+    ...omxArgs.filter((arg) => arg !== "--direct" && arg !== "--tmux"),
+    ...suffix,
+  ];
 }
 
 function isAuthInvalidationError(stderr: string | undefined): boolean {
@@ -102,29 +118,89 @@ async function runCodexDirect(
   });
 }
 
+export type CodexGlobalOptionValueArity = "single" | "variadic";
+
+export const CODEX_GLOBAL_OPTIONS_WITH_SPLIT_VALUE = new Map<string, CodexGlobalOptionValueArity>([
+  ["-a", "single"],
+  ["--ask-for-approval", "single"],
+  ["-c", "single"],
+  ["--config", "single"],
+  ["-C", "single"],
+  ["--cd", "single"],
+  ["-i", "variadic"],
+  ["--image", "variadic"],
+  ["-m", "single"],
+  ["--model", "single"],
+  ["-p", "single"],
+  ["--profile", "single"],
+  ["-s", "single"],
+  ["--sandbox", "single"],
+  ["--add-dir", "single"],
+  ["--disable", "single"],
+  ["--enable", "single"],
+  ["--local-provider", "single"],
+  ["--remote", "single"],
+  ["--remote-auth-token-env", "single"],
+]);
+
+export function resolveCodexGlobalOptionValue(
+  arg: string,
+): { valueArity: CodexGlobalOptionValueArity; attached: boolean } | undefined {
+  const exactArity = CODEX_GLOBAL_OPTIONS_WITH_SPLIT_VALUE.get(arg);
+  if (exactArity) return { valueArity: exactArity, attached: false };
+
+  if (arg.startsWith("--")) {
+    const equalsIndex = arg.indexOf("=");
+    if (equalsIndex > 2) {
+      const inlineArity = CODEX_GLOBAL_OPTIONS_WITH_SPLIT_VALUE.get(arg.slice(0, equalsIndex));
+      if (inlineArity) return { valueArity: inlineArity, attached: true };
+    }
+    return undefined;
+  }
+
+  for (const [option, valueArity] of CODEX_GLOBAL_OPTIONS_WITH_SPLIT_VALUE) {
+    if (option.length === 2 && option.startsWith("-") && arg.startsWith(option) && arg.length > 2) {
+      return { valueArity, attached: true };
+    }
+  }
+  return undefined;
+}
+
+const EXPLICIT_SESSION_RESUME_SELECTORS = new Set([
+  "--last",
+  "--all",
+  "--include-non-interactive",
+]);
+
 export function buildResumeArgsWithPreservedFlags(originalArgs: string[], sessionId: string): string[] {
+  const endOfOptionsIndex = originalArgs.indexOf("--");
+  const prefix = endOfOptionsIndex === -1 ? originalArgs : originalArgs.slice(0, endOfOptionsIndex);
+  const suffix = endOfOptionsIndex === -1 ? [] : originalArgs.slice(endOfOptionsIndex);
   const preserved: string[] = [];
-  for (let index = 0; index < originalArgs.length; index++) {
-    const arg = originalArgs[index];
-    if (arg === "--") break;
-    if (arg === "-c" || arg === "--config" || arg === "--model" || arg === "-m") {
+
+  for (let index = 0; index < prefix.length; index += 1) {
+    const arg = prefix[index];
+    if (EXPLICIT_SESSION_RESUME_SELECTORS.has(arg)) continue;
+    const optionValue = resolveCodexGlobalOptionValue(arg);
+    if (optionValue) {
       preserved.push(arg);
-      const value = originalArgs[index + 1];
-      if (value && !value.startsWith("-")) {
-        preserved.push(value);
+      if (optionValue.attached) continue;
+      if (optionValue.valueArity === "variadic") {
+        while (index + 1 < prefix.length && !prefix[index + 1]!.startsWith("-")) {
+          preserved.push(prefix[index + 1]!);
+          index += 1;
+        }
+      } else if (index + 1 < prefix.length) {
+        preserved.push(prefix[index + 1]!);
         index += 1;
       }
       continue;
     }
-    if (
-      arg.startsWith("--config=") ||
-      arg.startsWith("--model=") ||
-      arg === "--dangerously-bypass-approvals-and-sandbox"
-    ) {
-      preserved.push(arg);
-    }
+
+    if (arg.startsWith("-")) preserved.push(arg);
   }
-  return ["resume", sessionId, ...preserved];
+
+  return ["resume", sessionId, ...preserved, ...suffix];
 }
 
 function codexHomeFromAuthPath(authPath: string): string {
@@ -142,7 +218,9 @@ export async function runAuthHotswap(options: HotswapOptions): Promise<number> {
   const lifecycle = options.lifecycle;
   const rawArgs = stripHotswapArg(options.argv);
   const notifyTempResult = lifecycle.resolveNotifyTempContract(rawArgs, env);
-  const normalizedArgs = lifecycle.normalizeCodexLaunchArgs(notifyTempResult.passthroughArgs.filter((arg) => arg !== "--direct" && arg !== "--tmux"));
+  const normalizedArgs = lifecycle.normalizeCodexLaunchArgs(
+    stripLeaderLaunchPolicyArgs(notifyTempResult.passthroughArgs),
+  );
   const config = await readAuthConfig(cwd, home);
   const slots = await listSlots(home);
   if (slots.length === 0) {

--- a/src/autopilot/__tests__/ralplan-gate.test.ts
+++ b/src/autopilot/__tests__/ralplan-gate.test.ts
@@ -1122,7 +1122,7 @@ describe('autopilot ralplan gate', () => {
       assert.match(error, /current_session_id: sess-autopilot-diagnostic-missing-session/);
       assert.match(error, /architect thread_id: thread-architect found: no kind=missing completed=no/);
       assert.match(error, /session_id: sess-autopilot-diagnostic-missing-session session_found=no/);
-      assert.match(error, /Re-run native ralplan Architect\/Critic reviews/);
+      assert.match(error, /Re-run typed native ralplan Architect\/Critic reviews/);
       assert.match(error, /docs\/contracts\/ralplan-consensus-gate\.md/);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/cli/__tests__/auth.test.ts
+++ b/src/cli/__tests__/auth.test.ts
@@ -200,14 +200,71 @@ exit 2
         { slot: "first", createdAt: "now", updatedAt: "now" },
         { slot: "second", createdAt: "now", updatedAt: "now" }
       ] }, null, 2));
-      await writeFakeCodex(bin, `#!/bin/sh\ncount=0\n[ -f ${JSON.stringify(countFile)} ] && count=$(cat ${JSON.stringify(countFile)})\ncount=$((count+1))\nprintf '%s' "$count" > ${JSON.stringify(countFile)}\nprintf '%s\\n' "$*" >> ${JSON.stringify(argvFile)}\nif [ "$count" -eq 1 ]; then mkdir -p "$CODEX_HOME/sessions/2026/05/24"; printf '{}\\n' > "$CODEX_HOME/sessions/2026/05/24/rollout-session-123.jsonl"; echo 'HTTP 429 quota exceeded access_token=stderr-secret Bearer abc.def' >&2; exit 1; fi\ncase "$*" in *"resume session-123"*--model*"gpt-review"*) exit 0;; *) echo 'missing resume args or model flag' >&2; exit 3;; esac\n`);
-      const env = { HOME: home, CODEX_HOME: codexHome, PATH: `${bin}:/usr/bin:/bin` };
-      const result = runOmx(wd, ["--hotswap", "--direct", "--model", "gpt-review"], env);
+      await writeFakeCodex(bin, `#!/bin/sh
+count=0
+[ -f ${JSON.stringify(countFile)} ] && count=$(cat ${JSON.stringify(countFile)})
+count=$((count+1))
+printf '%s' "$count" > ${JSON.stringify(countFile)}
+"$NODE_BINARY" -e 'require("node:fs").appendFileSync(process.argv[1], JSON.stringify(process.argv.slice(2)) + "\\n")' ${JSON.stringify(argvFile)} "$@"
+if [ "$count" -eq 1 ]; then
+  mkdir -p "$CODEX_HOME/sessions/2026/05/24"
+  printf '{}\\n' > "$CODEX_HOME/sessions/2026/05/24/rollout-session-123.jsonl"
+  echo 'HTTP 429 quota exceeded access_token=stderr-secret Bearer abc.def' >&2
+  exit 1
+fi
+exit 0
+`);
+      const env = { HOME: home, CODEX_HOME: codexHome, NODE_BINARY: process.execPath, PATH: `${bin}:/usr/bin:/bin` };
+      const opaqueSuffix = ["--", "--last", "--all", "--include-non-interactive", "--hotswap", "--model", "opaque-model", "literal suffix"];
+      const result = runOmx(wd, [
+        "--hotswap", "--direct", "resume", "--last", "--all", "--include-non-interactive",
+        "--model", "gpt-review", "--remote", "ws://127.0.0.1:4500", ...opaqueSuffix,
+      ], env);
       assert.equal(result.status, 0, result.stderr + result.stdout);
       assert.match(result.stderr, /HTTP 429 quota exceeded/);
-      const argvLog = await readFile(argvFile, "utf-8");
-      assert.match(argvLog, /resume session-123/);
-      assert.match(argvLog, /--model gpt-review/);
+      const spawnArgv = (await readFile(argvFile, "utf-8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as string[]);
+      assert.equal(spawnArgv.length, 2);
+      const modelInstructionsPrefix = `model_instructions_file="${join(wd, ".omx", "state", "sessions")}/`;
+      const modelInstructionsSuffix = "/AGENTS.md\"";
+      const modelInstructionsArg = spawnArgv[0][spawnArgv[0].indexOf("-c") + 1];
+      assert.ok(modelInstructionsArg.startsWith(modelInstructionsPrefix), modelInstructionsArg);
+      assert.ok(modelInstructionsArg.endsWith(modelInstructionsSuffix), modelInstructionsArg);
+      const sessionId = modelInstructionsArg.slice(
+        modelInstructionsPrefix.length,
+        -modelInstructionsSuffix.length,
+      );
+      assert.match(sessionId, /^omx-\d+-[a-z0-9]*$/);
+      const expectedModelInstructionsArg = `${modelInstructionsPrefix}${sessionId}${modelInstructionsSuffix}`;
+      assert.deepEqual(spawnArgv[0], [
+        "resume",
+        "--last",
+        "--all",
+        "--include-non-interactive",
+        "--model",
+        "gpt-review",
+        "--remote",
+        "ws://127.0.0.1:4500",
+        "-c",
+        expectedModelInstructionsArg,
+        ...opaqueSuffix,
+      ]);
+      assert.deepEqual(spawnArgv[1], [
+        "resume",
+        "session-123",
+        "--model",
+        "gpt-review",
+        "--remote",
+        "ws://127.0.0.1:4500",
+        "-c",
+        expectedModelInstructionsArg,
+        ...opaqueSuffix,
+      ]);
+      assert.deepEqual(spawnArgv[1].slice(spawnArgv[1].indexOf("--")), opaqueSuffix);
+      assert.ok(spawnArgv[0].indexOf("-c") < spawnArgv[0].indexOf("--"));
+      assert.ok(spawnArgv[1].indexOf("-c") < spawnArgv[1].indexOf("--"));
       assert.equal(await readFile(join(codexHome, "auth.json"), "utf-8"), '{"access_token":"second-secret"}\n');
       assert.doesNotMatch(result.stderr + result.stdout, /first-secret|second-secret|stderr-secret|abc\.def/);
     } finally {

--- a/src/cli/__tests__/exec.test.ts
+++ b/src/cli/__tests__/exec.test.ts
@@ -223,6 +223,89 @@ describe('omx exec', () => {
     }
   });
 
+  it('passes literal max and ultra after -- with raw config args to Codex exec unchanged', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-exec-reasoning-passthrough-'));
+    try {
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const fakeCapturePath = join(wd, 'fake-codex-argv.json');
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(
+        fakeCodexPath,
+        [
+          '#!/bin/sh',
+          `exec "$NODE_BINARY" -e 'require("node:fs").writeFileSync(process.env.OMX_FAKE_CODEX_CAPTURE_PATH, JSON.stringify(process.argv.slice(1)))' -- "$@"`,
+          '',
+        ].join('\n'),
+      );
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+
+      const result = runOmx(
+        wd,
+        [
+          'exec',
+          '-c',
+          'model_reasoning_effort=MAX',
+          '--',
+          '--max',
+          '--ultra',
+          '-c',
+          'model_reasoning_effort="ultra"',
+          '-c',
+          'model_reasoning_effort=future',
+          'suffix argument with spaces',
+          '',
+          '--',
+          'after second marker',
+        ],
+        {
+          HOME: home,
+          NODE_OPTIONS: '',
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+          NODE_BINARY: process.execPath,
+          OMX_FAKE_CODEX_CAPTURE_PATH: fakeCapturePath,
+        },
+      );
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      const capturedArgv = JSON.parse(await readFile(fakeCapturePath, 'utf-8')) as string[];
+      const firstMarkerIndex = capturedArgv.indexOf('--');
+      assert.equal(firstMarkerIndex, 5);
+      const modelInstructionsArg = capturedArgv[firstMarkerIndex - 1];
+      assert.match(modelInstructionsArg, /^model_instructions_file="[^"\n]+"$/);
+      assert.match(modelInstructionsArg, /\.omx\/state\/sessions\/omx-[^"]+\/AGENTS\.md"$/);
+      assert.equal(capturedArgv.filter((arg) => arg.startsWith('model_instructions_file=')).length, 1);
+      assert.deepEqual(capturedArgv, [
+        'exec',
+        '-c',
+        'model_reasoning_effort=MAX',
+        '-c',
+        modelInstructionsArg,
+        '--',
+        '--max',
+        '--ultra',
+        '-c',
+        'model_reasoning_effort="ultra"',
+        '-c',
+        'model_reasoning_effort=future',
+        'suffix argument with spaces',
+        '',
+        '--',
+        'after second marker',
+      ]);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('passes exec --help through to codex exec', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-exec-help-'));
     try {
@@ -250,6 +333,72 @@ describe('omx exec', () => {
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       assert.match(result.stdout, /fake-codex:exec --help\b/);
       assert.doesNotMatch(result.stdout, /oh-my-codex \(omx\) - Multi-agent orchestration for Codex CLI/i);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('omx reasoning root validation', () => {
+  it('rejects max, ultra, and casing without creating or mutating config.toml', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-root-reasoning-validation-'));
+    try {
+      const codexHome = join(wd, 'codex-home');
+      const configPath = join(codexHome, 'config.toml');
+      const configContents = 'model = "gpt-5"\n';
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(configPath, configContents);
+
+      const maxGuidance = 'Per-agent "max" is configured with agentReasoning; direct -c model_reasoning_effort=... is passed to Codex and remains capability-dependent.';
+      const ultraGuidance = 'Direct -c model_reasoning_effort=... remains opaque Codex passthrough.';
+      const assertFragmentsInOrder = (output: string, fragments: string[]): void => {
+        let previousIndex = -1;
+        for (const fragment of fragments) {
+          const index = output.indexOf(fragment);
+          assert.ok(index > previousIndex, `expected ordered stderr fragment: ${fragment}`);
+          previousIndex = index;
+        }
+      };
+      for (const mode of ['max', 'MAX']) {
+        const result = runOmx(wd, ['reasoning', mode], { CODEX_HOME: codexHome });
+        assert.equal(result.status, 1, result.error || result.stderr || result.stdout);
+        assert.equal(result.stdout, '');
+        assertFragmentsInOrder(result.stderr, [
+          `Reasoning mode "${mode}" is not supported by "omx reasoning".`,
+          maxGuidance,
+          `Invalid reasoning mode "${mode}". Expected one of: low, medium, high, xhigh.`,
+          'Usage: omx reasoning <low|medium|high|xhigh>',
+        ]);
+        assert.equal(await readFile(configPath, 'utf-8'), configContents);
+      }
+
+      for (const mode of ['ultra', 'uLtRa']) {
+        const result = runOmx(wd, ['reasoning', mode], { CODEX_HOME: codexHome });
+        assert.equal(result.status, 1, result.error || result.stderr || result.stdout);
+        assert.equal(result.stdout, '');
+        assertFragmentsInOrder(result.stderr, [
+          `Reasoning mode "${mode}" is not supported by OMX root or per-agent reasoning and is not an alias for "max".`,
+          ultraGuidance,
+          `Invalid reasoning mode "${mode}". Expected one of: low, medium, high, xhigh.`,
+          'Usage: omx reasoning <low|medium|high|xhigh>',
+        ]);
+        assert.equal(await readFile(configPath, 'utf-8'), configContents);
+      }
+
+      const casingResult = runOmx(wd, ['reasoning', 'High'], { CODEX_HOME: codexHome });
+      assert.equal(casingResult.status, 1, casingResult.error || casingResult.stderr || casingResult.stdout);
+      assert.equal(casingResult.stdout, '');
+      assertFragmentsInOrder(casingResult.stderr, [
+        'Invalid reasoning mode "High". Expected one of: low, medium, high, xhigh.',
+        'Usage: omx reasoning <low|medium|high|xhigh>',
+      ]);
+      assert.equal(await readFile(configPath, 'utf-8'), configContents);
+
+      const absentCodexHome = join(wd, 'absent-codex-home');
+      const absentResult = runOmx(wd, ['reasoning', 'MAX'], { CODEX_HOME: absentCodexHome });
+      assert.equal(absentResult.status, 1, absentResult.error || absentResult.stderr || absentResult.stdout);
+      assert.equal(absentResult.stdout, '');
+      assert.equal(existsSync(absentCodexHome), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -16,6 +16,10 @@ import {
   buildWindowsPromptCommand,
   buildTmuxSessionName,
   resolveCliInvocation,
+  parseResumeCodexHomeSelection,
+  isResumeCodexLaunch,
+  CODEX_GLOBAL_OPTIONS_WITH_SPLIT_VALUE,
+  isCodexVersionRequest,
   resolveUpdateChannelArg,
   commandOwnsLocalHelp,
   resolveCodexLaunchPolicy,
@@ -92,6 +96,7 @@ import {
   DETACHED_TMUX_HISTORY_LIMIT,
   isExistingTmuxWindowTooCrampedForLaunchHud,
 } from "../index.js";
+import { buildResumeArgsWithPreservedFlags, stripHotswapArg } from "../../auth/hotswap.js";
 import { mergeConfig, repairConfigIfNeeded } from "../../config/generator.js";
 import { ensureReusableNodeModules } from "../../utils/repo-deps.js";
 import { readAllState } from "../../hud/state.js";
@@ -585,6 +590,37 @@ describe("normalizeCodexLaunchArgs", () => {
     ]);
   });
 
+  it("adds reasoning overrides before a literal -- marker", () => {
+    assert.deepEqual(normalizeCodexLaunchArgs(["--xhigh", "--", "--max"]), [
+      "-c",
+      'model_reasoning_effort="xhigh"',
+      "--",
+      "--max",
+    ]);
+  });
+
+  it("adds bypass and reasoning overrides before preserving raw marker suffix args", () => {
+    assert.deepEqual(
+      normalizeCodexLaunchArgs([
+        "--madmax",
+        "--xhigh",
+        "--",
+        "-c",
+        'model_reasoning_effort="ultra"',
+        "--max",
+      ]),
+      [
+        "--dangerously-bypass-approvals-and-sandbox",
+        "-c",
+        'model_reasoning_effort="xhigh"',
+        "--",
+        "-c",
+        'model_reasoning_effort="ultra"',
+        "--max",
+      ],
+    );
+  });
+
   it("uses the last reasoning shorthand when both are present", () => {
     assert.deepEqual(normalizeCodexLaunchArgs(["--high", "--xhigh"]), [
       "-c",
@@ -592,15 +628,212 @@ describe("normalizeCodexLaunchArgs", () => {
     ]);
   });
 
-  it("rejects ambiguous max and ultra reasoning shorthands", () => {
-    assert.throws(
-      () => normalizeCodexLaunchArgs(["--max"]),
-      /canonical highest reasoning effort is "xhigh".*"max" and "ultra" are not accepted aliases/,
+  it("rejects pre-marker max and ultra reasoning shorthands with approved guidance", () => {
+    const errors = [
+      [
+        "--max",
+        'Unsupported OMX launch shorthand "--max".\nNo --max shorthand exists; use agentReasoning for per-agent "max" or pass -c model_reasoning_effort=... directly to Codex.\nRun "omx help" for usage.',
+      ],
+      [
+        "--ultra",
+        'Unsupported OMX launch shorthand "--ultra".\n"ultra" is not an OMX root or per-agent reasoning value and is not an alias for "max".\nRun "omx help" for usage.',
+      ],
+    ] as const;
+
+    for (const [flag, message] of errors) {
+      assert.throws(() => normalizeCodexLaunchArgs([flag]), { message });
+    }
+  });
+
+  it("preserves literal max and ultra after -- with raw -c arguments", () => {
+    const args = [
+      "-c",
+      "model_reasoning_effort=MAX",
+      "--",
+      "--max",
+      "--ultra",
+      "-c",
+      'model_reasoning_effort="ultra"',
+      "-c",
+      "model_reasoning_effort=future",
+    ];
+    assert.deepEqual(normalizeCodexLaunchArgs(args), args);
+  });
+
+  it("preserves post-marker OMX flags as literal Codex arguments", () => {
+    const args = [
+      "--",
+      "--worktree",
+      "post-marker-branch",
+      "--notify-temp",
+      "--discord",
+      "--custom",
+      "openclaw:ops",
+      "--spark",
+      "resume",
+      "--project",
+      "--codex-home",
+      "/tmp/literal-codex-home",
+      "--version",
+    ];
+    const notifyTempResult = resolveNotifyTempContract(args, {});
+    assert.equal(notifyTempResult.contract.active, false);
+    assert.deepEqual(notifyTempResult.contract.canonicalSelectors, []);
+    assert.deepEqual(notifyTempResult.passthroughArgs, args);
+    assert.equal(resolveWorkerSparkModel(notifyTempResult.passthroughArgs), undefined);
+    assert.equal(isResumeCodexLaunch(args), false);
+    assert.equal(isCodexVersionRequest(args), false);
+    assert.deepEqual(parseResumeCodexHomeSelection(args), {
+      args,
+      explicitCodexHome: undefined,
+      projectOnly: false,
+    });
+    assert.deepEqual(normalizeCodexLaunchArgs(notifyTempResult.passthroughArgs), args);
+  });
+
+  it("parses resume-owned selectors only before the end-of-options marker", () => {
+    assert.deepEqual(
+      parseResumeCodexHomeSelection([
+        "resume",
+        "--codex-home",
+        "/tmp/selected-codex-home",
+        "--project",
+        "--",
+        "--codex-home",
+        "/tmp/literal-codex-home",
+        "--project",
+      ]),
+      {
+        args: [
+          "resume",
+          "--",
+          "--codex-home",
+          "/tmp/literal-codex-home",
+          "--project",
+        ],
+        explicitCodexHome: "/tmp/selected-codex-home",
+        projectOnly: true,
+      },
     );
-    assert.throws(
-      () => normalizeCodexLaunchArgs(["--ultra"]),
-      /canonical highest reasoning effort is "xhigh".*"max" and "ultra" are not accepted aliases/,
+    assert.equal(isResumeCodexLaunch(["resume", "--", "literal"]), true);
+    assert.equal(isCodexVersionRequest(["--version", "--", "literal"]), true);
+  });
+
+  it("removes hotswap only before the end-of-options marker", () => {
+    assert.deepEqual(
+      stripHotswapArg(["--hotswap", "--", "--hotswap", "literal"]),
+      ["--", "--hotswap", "literal"],
     );
+  });
+
+  it("preserves Codex launch authority and the first literal suffix when building quota resume args", () => {
+    assert.deepEqual(
+      buildResumeArgsWithPreservedFlags([
+        "--model", "gpt-review",
+        "--model=gpt-review-fast",
+        "--config", "developer_instructions=enabled",
+        "--config=developer_instructions=overridden",
+        "--add-dir", "src",
+        "--remote", "ws://127.0.0.1:4500",
+        "--remote=ws://127.0.0.1:4501",
+        "--remote-auth-token-env", "CODEX_REMOTE_TOKEN",
+        "--remote-auth-token-env=CODEX_REMOTE_TOKEN_BACKUP",
+        "-i", "one.png",
+        "--image", "two.png",
+        "-i", "three.png,four.png",
+        "--image=five.png,six.png",
+        "-iseven.png,eight.png",
+        "--image=resume", "resume",
+        "--oss",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--model", "gpt-resume",
+        "resume", "old-session",
+        "--last", "--all", "--include-non-interactive",
+        "--", "--hotswap", "--last", "--all", "--include-non-interactive", "--model", "opaque-model", "literal suffix",
+      ], "session-123"),
+      [
+        "resume", "session-123",
+        "--model", "gpt-review",
+        "--model=gpt-review-fast",
+        "--config", "developer_instructions=enabled",
+        "--config=developer_instructions=overridden",
+        "--add-dir", "src",
+        "--remote", "ws://127.0.0.1:4500",
+        "--remote=ws://127.0.0.1:4501",
+        "--remote-auth-token-env", "CODEX_REMOTE_TOKEN",
+        "--remote-auth-token-env=CODEX_REMOTE_TOKEN_BACKUP",
+        "-i", "one.png",
+        "--image", "two.png",
+        "-i", "three.png,four.png",
+        "--image=five.png,six.png",
+        "-iseven.png,eight.png",
+        "--image=resume",
+        "--oss",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--model", "gpt-resume",
+        "--", "--hotswap", "--last", "--all", "--include-non-interactive", "--model", "opaque-model", "literal suffix",
+      ],
+    );
+  });
+
+  it("removes resume selectors only when synthesizing an explicit session", () => {
+    for (const selectors of [
+      ["--last"],
+      ["--all"],
+      ["--include-non-interactive"],
+      ["--last", "--all"],
+      ["--all", "--include-non-interactive"],
+      ["--last", "--all", "--include-non-interactive"],
+    ]) {
+      assert.deepEqual(
+        buildResumeArgsWithPreservedFlags([
+          "resume",
+          ...selectors,
+          "--model", "gpt-review",
+          "--remote", "ws://127.0.0.1:4500",
+          "--", ...selectors, "opaque suffix",
+        ], "session-123"),
+        [
+          "resume", "session-123",
+          "--model", "gpt-review",
+          "--remote", "ws://127.0.0.1:4500",
+          "--", ...selectors, "opaque suffix",
+        ],
+        JSON.stringify(selectors),
+      );
+    }
+  });
+
+  it("treats only split image values as variadic", () => {
+    assert.deepEqual([...CODEX_GLOBAL_OPTIONS_WITH_SPLIT_VALUE], [
+      ["-a", "single"], ["--ask-for-approval", "single"], ["-c", "single"],
+      ["--config", "single"], ["-C", "single"], ["--cd", "single"],
+      ["-i", "variadic"], ["--image", "variadic"], ["-m", "single"],
+      ["--model", "single"], ["-p", "single"], ["--profile", "single"],
+      ["-s", "single"], ["--sandbox", "single"], ["--add-dir", "single"],
+      ["--disable", "single"], ["--enable", "single"], ["--local-provider", "single"],
+      ["--remote", "single"], ["--remote-auth-token-env", "single"],
+    ]);
+    for (const args of [
+      ["--model", "resume"], ["--remote", "resume"],
+      ["--image", "resume"], ["-i", "resume"], ["--image=resume"], ["-iresume"], ["-i=resume"],
+      ["-i", "one.png", "resume"], ["--image", "one.png", "resume"],
+      ["-i", "one.png", "-i", "two.png", "resume"],
+      ["--image", "one.png", "--image", "two.png", "resume"],
+      ["-i", "one.png,two.png", "resume"], ["--image", "one.png,two.png", "resume"],
+      ["exec", "resume"], ["--image", "one.png", "--", "resume"],
+    ]) {
+      assert.equal(isResumeCodexLaunch(args), false, JSON.stringify(args));
+    }
+    for (const args of [
+      ["--model", "gpt-review", "resume"],
+      ["--image=one.png", "resume"], ["-ione.png", "resume"], ["-i=one.png", "resume"],
+      ["--image", "one.png", "--model", "gpt-review", "resume"],
+      ["--image=one.png", "--model=gpt-review", "resume"],
+      ["-ione.png", "--remote", "ws://127.0.0.1:4500", "resume"],
+    ]) {
+      assert.equal(isResumeCodexLaunch(args), true, JSON.stringify(args));
+    }
   });
 
   it("maps --xhigh --madmax to codex-native flags only", () => {
@@ -842,6 +1075,14 @@ describe("resolveNotifyTempContract", () => {
       "custom:my-hook",
     ]);
     assert.equal(parsed.contract.warnings.length >= 1, true);
+  });
+
+  it("does not activate or consume selectors after --", () => {
+    const args = ["--", "--notify-temp", "--discord", "--custom", "openclaw:ops"];
+    const parsed = resolveNotifyTempContract(args, {});
+    assert.equal(parsed.contract.active, false);
+    assert.deepEqual(parsed.contract.selectors, []);
+    assert.deepEqual(parsed.passthroughArgs, args);
   });
 
   it("activates from OMX_NOTIFY_TEMP=1 env parity", () => {
@@ -1735,6 +1976,11 @@ describe("resolveWorkerSparkModel", () => {
     assert.equal(resolveWorkerSparkModel([]), undefined);
   });
 
+  it("returns undefined for spark flags after --", () => {
+    assert.equal(resolveWorkerSparkModel(["--", "--spark"]), undefined);
+    assert.equal(resolveWorkerSparkModel(["--", "--madmax-spark"]), undefined);
+  });
+
   it("reads low-complexity team model from config when codexHomeOverride is provided", async () => {
     // Intentional legacy model fixture: verifies an explicit user override is routed to workers unchanged.
     const codexHome = await mkdtemp(join(tmpdir(), "omx-codex-home-"));
@@ -1987,6 +2233,14 @@ describe("resolveCliInvocation", () => {
     assert.match(HELP, /omx update\s+Install the stable channel now, then refresh setup/);
     assert.match(HELP, /omx update --stable\s+Install\/rollback to npm stable \(oh-my-codex@latest\), then refresh setup/);
     assert.match(HELP, /omx update --dev\s+Install the upstream dev branch, then refresh setup/);
+  });
+
+  it("advertises only the four supported root reasoning modes", () => {
+    assert.match(HELP, /omx reasoning Show or set model reasoning effort \(low\|medium\|high\|xhigh\)/);
+    assert.match(HELP, /--high\s+Launch Codex with high reasoning effort/);
+    assert.match(HELP, /--xhigh\s+Launch Codex with xhigh reasoning effort/);
+    assert.doesNotMatch(HELP, /--max/);
+    assert.doesNotMatch(HELP, /--ultra/);
   });
 
   it("advertises concise launch policy controls in top-level help", () => {
@@ -5975,6 +6229,36 @@ describe("injectModelInstructionsBypassArgs", () => {
       "gpt-5",
       "-c",
       'model_instructions_file="/tmp/my-project/AGENTS.md"',
+    ]);
+  });
+
+  it("inserts model instructions before the end-of-options marker", () => {
+    const args = injectModelInstructionsBypassArgs(
+      "/tmp/my-project",
+      ["--", "--spark", "literal"],
+      {},
+    );
+    assert.deepEqual(args, [
+      "-c",
+      'model_instructions_file="/tmp/my-project/AGENTS.md"',
+      "--",
+      "--spark",
+      "literal",
+    ]);
+  });
+
+  it("does not treat a post-marker model instructions token as an OMX override", () => {
+    const args = injectModelInstructionsBypassArgs(
+      "/tmp/my-project",
+      ["--", "-c", 'model_instructions_file="/tmp/literal.md"'],
+      {},
+    );
+    assert.deepEqual(args, [
+      "-c",
+      'model_instructions_file="/tmp/my-project/AGENTS.md"',
+      "--",
+      "-c",
+      'model_instructions_file="/tmp/literal.md"',
     ]);
   });
 

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -297,6 +297,159 @@ exit 42
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('passes literal max and ultra after -- with raw config args to Codex launch unchanged', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-reasoning-passthrough-'));
+    try {
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const fakeCapturePath = join(wd, 'fake-codex-argv.json');
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(
+        fakeCodexPath,
+        [
+          '#!/bin/sh',
+          `exec "$NODE_BINARY" -e 'require("node:fs").writeFileSync(process.env.OMX_FAKE_CODEX_CAPTURE_PATH, JSON.stringify(process.argv.slice(1)))' -- "$@"`,
+          '',
+        ].join('\n'),
+      );
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+
+      const result = runOmx(
+        wd,
+        [
+          '--direct',
+          '-c',
+          'model_reasoning_effort=MAX',
+          '--',
+          '--max',
+          '--ultra',
+          '-c',
+          'model_reasoning_effort="ultra"',
+          '-c',
+          'model_reasoning_effort=future',
+          'suffix argument with spaces',
+          '',
+          '--',
+          'after second marker',
+        ],
+        {
+          HOME: home,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          NODE_OPTIONS: '',
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+          NODE_BINARY: process.execPath,
+          OMX_FAKE_CODEX_CAPTURE_PATH: fakeCapturePath,
+          TMUX: '',
+          TMUX_PANE: '',
+        },
+      );
+
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      const capturedArgv = JSON.parse(await readFile(fakeCapturePath, 'utf-8')) as string[];
+      const firstMarkerIndex = capturedArgv.indexOf('--');
+      assert.equal(firstMarkerIndex, 4);
+      const modelInstructionsArg = capturedArgv[firstMarkerIndex - 1];
+      assert.match(modelInstructionsArg, /^model_instructions_file="[^"\n]+"$/);
+      assert.match(modelInstructionsArg, /\.omx\/state\/sessions\/omx-[^"]+\/AGENTS\.md"$/);
+      assert.equal(capturedArgv.filter((arg) => arg.startsWith('model_instructions_file=')).length, 1);
+      assert.deepEqual(capturedArgv, [
+        '-c',
+        'model_reasoning_effort=MAX',
+        '-c',
+        modelInstructionsArg,
+        '--',
+        '--max',
+        '--ultra',
+        '-c',
+        'model_reasoning_effort="ultra"',
+        '-c',
+        'model_reasoning_effort=future',
+        'suffix argument with spaces',
+        '',
+        '--',
+        'after second marker',
+      ]);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('treats image values as variadic when detecting resume launches', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-image-resume-'));
+    try {
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'bin');
+      const fakeCapturePath = join(wd, 'fake-codex.json');
+      await mkdir(join(wd, '.omx'), { recursive: true });
+      await mkdir(join(wd, '.codex'), { recursive: true });
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+      await writeFile(join(wd, '.codex', 'state_5.sqlite'), 'resume-only-sentinel');
+      await writeExecutable(
+        join(fakeBin, 'codex'),
+        `#!/bin/sh
+exec "$NODE_BINARY" -e 'const fs = require("node:fs"); const path = require("node:path"); fs.writeFileSync(process.env.OMX_FAKE_CODEX_CAPTURE_PATH, JSON.stringify({ argv: process.argv.slice(1), hasResumeSqlite: fs.existsSync(path.join(process.env.CODEX_HOME, "state_5.sqlite")) }))' -- "$@"
+`,
+      );
+
+      const cases: Array<{ args: string[]; resumes: boolean }> = [
+        { args: ['-i', 'resume'], resumes: false },
+        { args: ['--image', 'resume'], resumes: false },
+        { args: ['--image=resume'], resumes: false },
+        { args: ['-iresume'], resumes: false },
+        { args: ['-i=resume'], resumes: false },
+        { args: ['-i', 'screenshot.png', 'resume'], resumes: false },
+        { args: ['--image', 'screenshot.png', 'resume'], resumes: false },
+        { args: ['--image=screenshot.png', 'resume'], resumes: true },
+        { args: ['-iscreenshot.png', 'resume'], resumes: true },
+        { args: ['-i=screenshot.png', 'resume'], resumes: true },
+        { args: ['-i', 'one.png', '-i', 'two.png', 'resume'], resumes: false },
+        { args: ['--image', 'one.png', '--image', 'two.png', 'resume'], resumes: false },
+        { args: ['-i', 'one.png,two.png', 'resume'], resumes: false },
+        { args: ['--image', 'one.png,two.png', 'resume'], resumes: false },
+        { args: ['--image', 'one.png', '--model', 'gpt-review', 'resume'], resumes: true },
+        { args: ['--image=one.png', '--model=gpt-review', 'resume'], resumes: true },
+      ];
+
+      for (const testCase of cases) {
+        const result = runOmx(
+          wd,
+          ['--direct', ...testCase.args],
+          {
+            HOME: home,
+            PATH: `${fakeBin}:/usr/bin:/bin`,
+            NODE_BINARY: process.execPath,
+            OMX_AUTO_UPDATE: '0',
+            OMX_BYPASS_DEFAULT_SYSTEM_PROMPT: '0',
+            OMX_HOOK_DERIVED_SIGNALS: '0',
+            OMX_NOTIFY_FALLBACK: '0',
+            OMX_FAKE_CODEX_CAPTURE_PATH: fakeCapturePath,
+          },
+        );
+
+        if (shouldSkipForSpawnPermissions(result.error)) return;
+        assert.equal(result.status, 0, `${JSON.stringify(testCase.args)}: ${result.error || result.stderr || result.stdout}`);
+        const captured = JSON.parse(await readFile(fakeCapturePath, 'utf-8')) as {
+          argv: string[];
+          hasResumeSqlite: boolean;
+        };
+        assert.deepEqual(captured.argv, testCase.args);
+        assert.equal(captured.hasResumeSqlite, testCase.resumes, JSON.stringify(testCase.args));
+      }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('ordinary launch root collision guidance', () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -55,7 +55,10 @@ import { adaptCommand } from "./adapt.js";
 import { listCommand } from "./list.js";
 import { authCommand } from "./auth.js";
 import { missionCommand } from "./mission.js";
-import { runAuthHotswap } from "../auth/hotswap.js";
+import {
+  resolveCodexGlobalOptionValue,
+  runAuthHotswap,
+} from "../auth/hotswap.js";
 import {
   MADMAX_FLAG,
   CODEX_BYPASS_FLAG,
@@ -94,8 +97,9 @@ import {
 } from "./plugin-marketplace.js";
 import { escapeTomlString, readTopLevelTomlString, upsertTopLevelTomlString } from "../utils/toml.js";
 import {
-  CANONICAL_REASONING_EFFORTS,
-  isAmbiguousUnsupportedReasoningEffort,
+  ROOT_REASONING_EFFORTS,
+  isUnsupportedRootReasoningEffort,
+  normalizeUnsupportedRootReasoningEffort,
 } from "../config/models.js";
 
 
@@ -374,11 +378,17 @@ const OMX_RALPH_APPEND_INSTRUCTIONS_FILE_ENV =
   "OMX_RALPH_APPEND_INSTRUCTIONS_FILE";
 const OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE_ENV =
   "OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE";
-const REASONING_MODES = CANONICAL_REASONING_EFFORTS;
+const REASONING_MODES = ROOT_REASONING_EFFORTS;
 type ReasoningMode = (typeof REASONING_MODES)[number];
 const REASONING_MODE_SET = new Set<string>(REASONING_MODES);
 const REASONING_USAGE = "Usage: omx reasoning <low|medium|high|xhigh>";
-const AMBIGUOUS_REASONING_MESSAGE = 'Codex/OMX canonical highest reasoning effort is "xhigh"; "max" and "ultra" are not accepted aliases.';
+
+function unsupportedLaunchShorthandError(flag: "--max" | "--ultra"): Error {
+  const guidance = flag === "--max"
+    ? 'No --max shorthand exists; use agentReasoning for per-agent "max" or pass -c model_reasoning_effort=... directly to Codex.'
+    : '"ultra" is not an OMX root or per-agent reasoning value and is not an alias for "max".';
+  return new Error(`Unsupported OMX launch shorthand "${flag}".\n${guidance}\nRun "omx help" for usage.`);
+}
 
 const ALLOWED_SHELLS = new Set([
   "/bin/sh",
@@ -713,6 +723,18 @@ export function resolveSetupTeamModeArg(args: string[]): SetupTeamMode | undefin
   }
 
   return value;
+}
+
+function splitOmxArgsAtEndOfOptions(args: string[]): {
+  omxArgs: string[];
+  suffix: string[];
+} {
+  const endOfOptionsIndex = args.indexOf("--");
+  if (endOfOptionsIndex === -1) return { omxArgs: args, suffix: [] };
+  return {
+    omxArgs: args.slice(0, endOfOptionsIndex),
+    suffix: args.slice(endOfOptionsIndex),
+  };
 }
 
 export function resolveCliInvocation(args: string[]): ResolvedCliInvocation {
@@ -1199,14 +1221,15 @@ export interface ResumeCodexHomeSelection {
 }
 
 export function parseResumeCodexHomeSelection(args: string[]): ResumeCodexHomeSelection {
+  const { omxArgs, suffix } = splitOmxArgsAtEndOfOptions(args);
   const nextArgs: string[] = [];
   let explicitCodexHome: string | undefined;
   let projectOnly = false;
 
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
+  for (let index = 0; index < omxArgs.length; index += 1) {
+    const arg = omxArgs[index];
     if (arg === "--codex-home") {
-      const value = args[index + 1];
+      const value = omxArgs[index + 1];
       if (!value || value.startsWith("-")) {
         throw new Error("Missing value after --codex-home.");
       }
@@ -1229,7 +1252,7 @@ export function parseResumeCodexHomeSelection(args: string[]): ResumeCodexHomeSe
   }
 
   return {
-    args: nextArgs,
+    args: [...nextArgs, ...suffix],
     explicitCodexHome,
     projectOnly,
   };
@@ -1305,8 +1328,30 @@ export async function preflightResumeOmxPluginState(
   };
 }
 
-function isResumeCodexLaunch(args: string[]): boolean {
-  return args.includes("resume");
+export { CODEX_GLOBAL_OPTIONS_WITH_SPLIT_VALUE } from "../auth/hotswap.js";
+
+export function isResumeCodexLaunch(args: string[]): boolean {
+  const { omxArgs } = splitOmxArgsAtEndOfOptions(args);
+  for (let index = 0; index < omxArgs.length; index += 1) {
+    const arg = omxArgs[index];
+    const optionValue = resolveCodexGlobalOptionValue(arg);
+    if (optionValue?.valueArity === "single") {
+      if (!optionValue.attached) index += 1;
+      continue;
+    }
+    if (optionValue?.valueArity === "variadic") {
+      if (optionValue.attached) continue;
+      let nextIndex = index + 1;
+      while (nextIndex < omxArgs.length && !omxArgs[nextIndex]!.startsWith("-")) {
+        nextIndex += 1;
+      }
+      index = nextIndex - 1;
+      continue;
+    }
+    if (arg.startsWith("-")) continue;
+    return arg === "resume";
+  }
+  return false;
 }
 
 async function prepareResumeCodexHomeForLaunch(
@@ -2268,13 +2313,27 @@ function launchArgRequestsDisposableWorktree(arg: string): boolean {
 }
 
 function launchArgsRequestMadmaxIsolation(launchArgs: readonly string[]): boolean {
-  return launchArgs.some(
-    (arg) => arg === MADMAX_FLAG || arg === MADMAX_SPARK_FLAG,
-  );
+  for (const arg of launchArgs) {
+    if (arg === "--") break;
+    if (arg === MADMAX_FLAG || arg === MADMAX_SPARK_FLAG) return true;
+  }
+  return false;
+}
+
+function launchArgsRequestAuthHotswap(launchArgs: readonly string[]): boolean {
+  for (const arg of launchArgs) {
+    if (arg === "--") break;
+    if (arg === "--hotswap") return true;
+  }
+  return false;
 }
 
 function launchArgsRequestDisposableWorktree(launchArgs: readonly string[]): boolean {
-  return launchArgs.some((arg) => launchArgRequestsDisposableWorktree(arg));
+  for (const arg of launchArgs) {
+    if (arg === "--") break;
+    if (launchArgRequestsDisposableWorktree(arg)) return true;
+  }
+  return false;
 }
 
 function clearInheritedMadmaxRootForDisposableWorktreeLaunch(
@@ -2755,7 +2814,8 @@ export async function main(args: string[]): Promise<void> {
   ]);
   const firstArg = args[0];
   const { command, launchArgs } = resolveCliInvocation(args);
-  const flags = new Set(args.filter((a) => a.startsWith("--")));
+  const { omxArgs } = splitOmxArgsAtEndOfOptions(args);
+  const flags = new Set(omxArgs.filter((arg) => arg.startsWith("--")));
   const options = {
     force: flags.has("--force"),
     mergeAgents: undefined,
@@ -2774,7 +2834,7 @@ export async function main(args: string[]): Promise<void> {
   try {
     switch (command) {
       case "launch":
-        if (launchArgs.includes("--hotswap")) {
+        if (launchArgsRequestAuthHotswap(launchArgs)) {
           await launchWithAuthHotswap(launchArgs);
         } else {
           await launchWithHud(launchArgs);
@@ -3114,9 +3174,14 @@ async function reasoningCommand(args: string[]): Promise<void> {
   }
 
   if (!REASONING_MODE_SET.has(mode)) {
-    const guidance = isAmbiguousUnsupportedReasoningEffort(mode)
-      ? `${AMBIGUOUS_REASONING_MESSAGE}\n`
-      : "";
+    const unsupportedMode = isUnsupportedRootReasoningEffort(mode)
+      ? normalizeUnsupportedRootReasoningEffort(mode)
+      : undefined;
+    const guidance = unsupportedMode === "max"
+      ? `Reasoning mode "${mode}" is not supported by "omx reasoning".\nPer-agent "max" is configured with agentReasoning; direct -c model_reasoning_effort=... is passed to Codex and remains capability-dependent.\n`
+      : unsupportedMode === "ultra"
+        ? `Reasoning mode "${mode}" is not supported by OMX root or per-agent reasoning and is not an alias for "max".\nDirect -c model_reasoning_effort=... remains opaque Codex passthrough.\n`
+        : "";
     throw new Error(
       `${guidance}Invalid reasoning mode "${mode}". Expected one of: ${REASONING_MODES.join(", ")}.\n${REASONING_USAGE}`,
     );
@@ -3135,7 +3200,10 @@ async function reasoningCommand(args: string[]): Promise<void> {
 
 export async function launchWithAuthHotswap(args: string[]): Promise<void> {
   const launchCwd = process.cwd();
-  const parsedWorktree = parseWorktreeMode(args);
+  const { omxArgs, suffix } = splitOmxArgsAtEndOfOptions(args);
+  const parsedWorktree = parseWorktreeMode(omxArgs);
+  const hotswapArgs = [...parsedWorktree.remainingArgs, ...suffix];
+
   let cwd = launchCwd;
   let worktreeDirty = false;
   let ensuredLaunchWorktree: ReturnType<typeof ensureWorktree> | undefined;
@@ -3193,7 +3261,7 @@ export async function launchWithAuthHotswap(args: string[]): Promise<void> {
 
   const status = await runAuthHotswap({
     cwd,
-    argv: parsedWorktree.remainingArgs,
+    argv: hotswapArgs,
     lifecycle: {
       prepareCodexHomeForLaunch,
       preLaunch: (launchPath, sessionId, notifyTempContract, codexHomeOverride, enableAuthority) =>
@@ -3240,13 +3308,15 @@ export async function launchWithHud(args: string[]): Promise<void> {
   }
 
   const launchCwd = process.cwd();
-  const parsedWorktree = parseWorktreeMode(args);
+  const { omxArgs, suffix } = splitOmxArgsAtEndOfOptions(args);
+  const parsedWorktree = parseWorktreeMode(omxArgs);
   const notifyTempResult = resolveNotifyTempContract(
     parsedWorktree.remainingArgs,
     process.env,
   );
+  const passthroughArgs = [...notifyTempResult.passthroughArgs, ...suffix];
   const explicitLaunchPolicy = resolveEffectiveLeaderLaunchPolicyOverride(
-    notifyTempResult.passthroughArgs,
+    passthroughArgs,
     process.env,
   );
   const persistentCodexHomeForLaunch = resolveCodexHomeForLaunch(launchCwd, process.env);
@@ -3254,12 +3324,10 @@ export async function launchWithHud(args: string[]): Promise<void> {
     resolveTmuxAwareLaunchPolicy(explicitLaunchPolicy, isNativeWindows());
   const enableNotifyFallbackAuthority = launchPolicy === "direct";
   const workerSparkModel = resolveWorkerSparkModel(
-    notifyTempResult.passthroughArgs,
+    passthroughArgs,
     persistentCodexHomeForLaunch,
   );
-  let normalizedArgs = normalizeCodexLaunchArgs(
-    notifyTempResult.passthroughArgs,
-  );
+  let normalizedArgs = normalizeCodexLaunchArgs(passthroughArgs);
   let cwd = launchCwd;
   let worktreeDirty = false;
   let ensuredLaunchWorktree: ReturnType<typeof ensureWorktree> | undefined;
@@ -3289,7 +3357,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
     }
   }
   const madmaxWorktreeRuntimeContext = captureMadmaxWorktreeRuntimeContext({
-    originalLaunchArgs: args,
+    originalLaunchArgs: omxArgs,
     worktreeEnabled: Boolean(parsedWorktree.mode.enabled && ensuredLaunchWorktree?.enabled),
     sourceCwd: launchCwd,
     worktreeCwd: ensuredLaunchWorktree?.enabled ? ensuredLaunchWorktree.worktreePath : undefined,
@@ -3403,14 +3471,14 @@ export async function launchWithHud(args: string[]): Promise<void> {
 
 export async function execWithOverlay(args: string[]): Promise<void> {
   const launchCwd = process.cwd();
-  const parsedWorktree = parseWorktreeMode(args);
+  const { omxArgs, suffix } = splitOmxArgsAtEndOfOptions(args);
+  const parsedWorktree = parseWorktreeMode(omxArgs);
   const notifyTempResult = resolveNotifyTempContract(
     parsedWorktree.remainingArgs,
     process.env,
   );
-  const normalizedArgs = normalizeCodexLaunchArgs(
-    notifyTempResult.passthroughArgs,
-  );
+  const passthroughArgs = [...notifyTempResult.passthroughArgs, ...suffix];
+  const normalizedArgs = normalizeCodexLaunchArgs(passthroughArgs);
   let cwd = launchCwd;
   let worktreeDirty = false;
   let ensuredLaunchWorktree: ReturnType<typeof ensureWorktree> | undefined;
@@ -3529,7 +3597,8 @@ export async function execWithOverlay(args: string[]): Promise<void> {
 }
 
 export function normalizeCodexLaunchArgs(args: string[]): string[] {
-  const parsed = parseWorktreeMode(args);
+  const { omxArgs, suffix } = splitOmxArgsAtEndOfOptions(args);
+  const parsed = parseWorktreeMode(omxArgs);
   const launchPolicyParsed = splitLeaderLaunchPolicyArgs(parsed.remainingArgs);
   const normalized: string[] = [];
   let wantsBypass = false;
@@ -3562,7 +3631,7 @@ export function normalizeCodexLaunchArgs(args: string[]): string[] {
     }
 
     if (arg === "--max" || arg === "--ultra") {
-      throw new Error(AMBIGUOUS_REASONING_MESSAGE);
+      throw unsupportedLaunchShorthandError(arg);
     }
 
     if (arg === SPARK_FLAG) {
@@ -3587,7 +3656,7 @@ export function normalizeCodexLaunchArgs(args: string[]): string[] {
     normalized.push(CONFIG_FLAG, `${REASONING_KEY}="${reasoningMode}"`);
   }
 
-  return normalized;
+  return [...normalized, ...suffix];
 }
 
 /**
@@ -3600,6 +3669,7 @@ export function resolveWorkerSparkModel(
   codexHomeOverride?: string,
 ): string | undefined {
   for (const arg of args) {
+    if (arg === "--") break;
     if (arg === SPARK_FLAG || arg === MADMAX_SPARK_FLAG) {
       return resolveTeamLowComplexityDefaultModel(codexHomeOverride);
     }
@@ -3782,11 +3852,13 @@ export function injectModelInstructionsBypassArgs(
   defaultFilePath?: string,
 ): string[] {
   if (!shouldBypassDefaultSystemPrompt(env)) return [...args];
-  if (hasModelInstructionsOverride(args)) return [...args];
+  const { omxArgs, suffix } = splitOmxArgsAtEndOfOptions(args);
+  if (hasModelInstructionsOverride(omxArgs)) return [...args];
   return [
-    ...args,
+    ...omxArgs,
     CONFIG_FLAG,
     buildModelInstructionsOverride(cwd, env, defaultFilePath),
+    ...suffix,
   ];
 }
 
@@ -5812,8 +5884,9 @@ function encodePowerShellCommand(commandText: string): string {
   return Buffer.from(commandText, "utf16le").toString("base64");
 }
 
-function isCodexVersionRequest(args: string[]): boolean {
-  return args.some((arg) => CODEX_VERSION_FLAGS.has(arg));
+export function isCodexVersionRequest(args: string[]): boolean {
+  const { omxArgs } = splitOmxArgsAtEndOfOptions(args);
+  return omxArgs.some((arg) => CODEX_VERSION_FLAGS.has(arg));
 }
 
 export function buildWindowsPromptCommand(

--- a/src/config/__tests__/models.test.ts
+++ b/src/config/__tests__/models.test.ts
@@ -4,13 +4,18 @@ import { mkdtemp, rm, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
+  AMBIGUOUS_UNSUPPORTED_REASONING_EFFORTS,
+  CANONICAL_REASONING_EFFORTS,
   DEFAULT_FRONTIER_MODEL,
   DEFAULT_SPARK_MODEL,
   DEFAULT_TEAM_CHILD_MODEL,
   GPT_5_6_MODEL_ALIASES,
-  getAgentReasoningOverride,
-  isKnownCodexModelAlias,
+  KNOWN_CODEX_MODEL_ALIASES,
+  PER_AGENT_REASONING_EFFORTS,
+  ROOT_REASONING_EFFORTS,
+  ROOT_UNSUPPORTED_REASONING_EFFORTS,
   getAgentModelOverride,
+  getAgentReasoningOverride,
   getEnvConfiguredStandardDefaultModel,
   getMainDefaultModel,
   getModelForMode,
@@ -18,10 +23,18 @@ import {
   getStandardDefaultModel,
   getTeamChildModel,
   getTeamLowComplexityModel,
-  readAgentReasoningOverrides,
+  isAmbiguousUnsupportedReasoningEffort,
+  isKnownCodexModelAlias,
+  isUnsupportedRootReasoningEffort,
+  normalizeUnsupportedRootReasoningEffort,
   readAgentModelOverrides,
+  readAgentReasoningOverrides,
   readConfiguredEnvOverrides,
-  KNOWN_CODEX_MODEL_ALIASES,
+  type AmbiguousUnsupportedReasoningEffort,
+  type ConfiguredAgentReasoningEffort,
+  type PerAgentReasoningEffort,
+  type RootReasoningEffort,
+  type RootUnsupportedReasoningEffort,
 } from '../models.js';
 
 describe('getModelForMode', () => {
@@ -272,18 +285,88 @@ describe('getModelForMode', () => {
     assert.equal(getAgentReasoningOverride('executor'), undefined);
   });
 
-  it('rejects ambiguous max and ultra reasoning aliases', async () => {
+  it('accepts normalized per-agent max while omitting unsupported and invalid reasoning values', async () => {
     await writeConfig({
       agentReasoning: {
-        architect: 'max',
+        Architect: 'low',
+        architect: ' MAX ',
         critic: 'ultra',
+        executor: 'invalid',
         planner: 'xhigh',
+        empty: '   ',
+        array: ['max'],
+        object: { effort: 'max' },
+        boolean: true,
+        number: 5,
       },
     });
 
     assert.deepEqual(readAgentReasoningOverrides(), {
+      architect: 'max',
       planner: 'xhigh',
     });
+    assert.equal(getAgentReasoningOverride('ARCHITECT'), 'max');
+    assert.equal(getAgentReasoningOverride('critic'), undefined);
+    assert.equal(getAgentReasoningOverride('executor'), undefined);
+  });
+
+  it('keeps legacy, per-agent, and root reasoning vocabularies distinct', () => {
+    const legacyEffort: ConfiguredAgentReasoningEffort = 'xhigh';
+    const perAgentEffort: PerAgentReasoningEffort = 'max';
+    const rootEffort: RootReasoningEffort = 'xhigh';
+    const rootUnsupportedEffort: RootUnsupportedReasoningEffort = 'max';
+    void legacyEffort;
+    void perAgentEffort;
+    void rootEffort;
+    void rootUnsupportedEffort;
+    const ambiguousUnsupportedEffort: AmbiguousUnsupportedReasoningEffort = 'ultra';
+    void ambiguousUnsupportedEffort;
+
+    // @ts-expect-error Legacy configured reasoning remains four-valued.
+    const legacyMax: ConfiguredAgentReasoningEffort = 'max';
+    // @ts-expect-error Root reasoning remains four-valued.
+    const rootMax: RootReasoningEffort = 'max';
+    // @ts-expect-error Root unsupported tokens exclude unknown values.
+    const rootUnknown: RootUnsupportedReasoningEffort = 'future';
+    void legacyMax;
+    void rootMax;
+    void rootUnknown;
+    // @ts-expect-error Per-agent reasoning excludes ultra.
+    const perAgentUltra: PerAgentReasoningEffort = 'ultra';
+    // @ts-expect-error Legacy unsupported tokens exclude supported values.
+    const ambiguousHigh: AmbiguousUnsupportedReasoningEffort = 'high';
+    void perAgentUltra;
+    void ambiguousHigh;
+
+    assert.deepEqual(CANONICAL_REASONING_EFFORTS, ['low', 'medium', 'high', 'xhigh']);
+    assert.deepEqual(AMBIGUOUS_UNSUPPORTED_REASONING_EFFORTS, ['max', 'ultra']);
+    assert.deepEqual(PER_AGENT_REASONING_EFFORTS, ['low', 'medium', 'high', 'xhigh', 'max']);
+    assert.deepEqual(ROOT_REASONING_EFFORTS, ['low', 'medium', 'high', 'xhigh']);
+    assert.deepEqual(ROOT_UNSUPPORTED_REASONING_EFFORTS, ['max', 'ultra']);
+    assert.notStrictEqual(ROOT_REASONING_EFFORTS, CANONICAL_REASONING_EFFORTS);
+
+    assert.equal(isAmbiguousUnsupportedReasoningEffort('MAX'), true);
+    assert.equal(isAmbiguousUnsupportedReasoningEffort(' max '), false);
+
+    const ambiguousCandidate = 'MAX' as string;
+    if (isAmbiguousUnsupportedReasoningEffort(ambiguousCandidate)) {
+      const narrowedAmbiguousCandidate: AmbiguousUnsupportedReasoningEffort = ambiguousCandidate;
+      void narrowedAmbiguousCandidate;
+    }
+    assert.equal(isUnsupportedRootReasoningEffort('MAX'), true);
+    assert.equal(isUnsupportedRootReasoningEffort('ulTRA'), true);
+    assert.equal(isUnsupportedRootReasoningEffort(' ultra '), false);
+    assert.equal(isUnsupportedRootReasoningEffort('xhigh'), false);
+    assert.equal(normalizeUnsupportedRootReasoningEffort(' MAX '), 'max');
+    assert.equal(normalizeUnsupportedRootReasoningEffort(' Ultra '), 'ultra');
+    assert.equal(normalizeUnsupportedRootReasoningEffort('xhigh'), undefined);
+
+    const rootCandidate = 'MAX' as string;
+    if (isUnsupportedRootReasoningEffort(rootCandidate)) {
+      // @ts-expect-error Root classification must not narrow arbitrary strings.
+      const narrowedRootCandidate: RootUnsupportedReasoningEffort = rootCandidate;
+      void narrowedRootCandidate;
+    }
   });
 
 

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -38,11 +38,22 @@ export interface OmxConfigEnv {
   [key: string]: string | undefined;
 }
 
+/** @deprecated Use the surface-specific per-agent or root reasoning exports instead. */
 export const CANONICAL_REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh'] as const;
 export type ConfiguredAgentReasoningEffort = (typeof CANONICAL_REASONING_EFFORTS)[number];
 
+/** @deprecated Use ROOT_UNSUPPORTED_REASONING_EFFORTS for root diagnostics. */
 export const AMBIGUOUS_UNSUPPORTED_REASONING_EFFORTS = ['max', 'ultra'] as const;
 export type AmbiguousUnsupportedReasoningEffort = (typeof AMBIGUOUS_UNSUPPORTED_REASONING_EFFORTS)[number];
+
+export const PER_AGENT_REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+export type PerAgentReasoningEffort = (typeof PER_AGENT_REASONING_EFFORTS)[number];
+
+export const ROOT_REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh'] as const;
+export type RootReasoningEffort = (typeof ROOT_REASONING_EFFORTS)[number];
+
+export const ROOT_UNSUPPORTED_REASONING_EFFORTS = ['max', 'ultra'] as const;
+export type RootUnsupportedReasoningEffort = (typeof ROOT_UNSUPPORTED_REASONING_EFFORTS)[number];
 
 
 interface OmxConfigFile {
@@ -122,10 +133,23 @@ export function isAmbiguousUnsupportedReasoningEffort(value: string): value is A
   return (AMBIGUOUS_UNSUPPORTED_REASONING_EFFORTS as readonly string[]).includes(value.toLowerCase());
 }
 
-function normalizeAgentReasoningEffort(value: unknown): ConfiguredAgentReasoningEffort | undefined {
+export function isUnsupportedRootReasoningEffort(value: string): boolean {
+  return (ROOT_UNSUPPORTED_REASONING_EFFORTS as readonly string[]).includes(value.toLowerCase());
+}
+
+export function normalizeUnsupportedRootReasoningEffort(
+  value: string,
+): RootUnsupportedReasoningEffort | undefined {
+  const normalized = value.trim().toLowerCase();
+  return (ROOT_UNSUPPORTED_REASONING_EFFORTS as readonly string[]).includes(normalized)
+    ? normalized as RootUnsupportedReasoningEffort
+    : undefined;
+}
+
+function normalizeAgentReasoningEffort(value: unknown): PerAgentReasoningEffort | undefined {
   const normalized = normalizeConfiguredValue(value)?.toLowerCase();
-  if (normalized && (CANONICAL_REASONING_EFFORTS as readonly string[]).includes(normalized)) {
-    return normalized as ConfiguredAgentReasoningEffort;
+  if (normalized && (PER_AGENT_REASONING_EFFORTS as readonly string[]).includes(normalized)) {
+    return normalized as PerAgentReasoningEffort;
   }
   return undefined;
 }
@@ -174,12 +198,12 @@ export function readConfiguredEnvOverrides(codexHomeOverride?: string): NodeJS.P
 
 export function readAgentReasoningOverrides(
   codexHomeOverride?: string,
-): Record<string, ConfiguredAgentReasoningEffort> {
+): Record<string, PerAgentReasoningEffort> {
   const config = readOmxConfigFile(codexHomeOverride);
   const raw = config?.agentReasoning;
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
 
-  const resolved: Record<string, ConfiguredAgentReasoningEffort> = {};
+  const resolved: Record<string, PerAgentReasoningEffort> = {};
   for (const [key, value] of Object.entries(raw)) {
     const role = normalizeAgentName(key);
     const effort = normalizeAgentReasoningEffort(value);
@@ -191,7 +215,7 @@ export function readAgentReasoningOverrides(
 export function getAgentReasoningOverride(
   agentName: string | undefined,
   codexHomeOverride?: string,
-): ConfiguredAgentReasoningEffort | undefined {
+): PerAgentReasoningEffort | undefined {
   const normalized = normalizeAgentName(agentName);
   if (!normalized) return undefined;
   return readAgentReasoningOverrides(codexHomeOverride)[normalized];

--- a/src/notifications/temp-contract.ts
+++ b/src/notifications/temp-contract.ts
@@ -42,6 +42,10 @@ export function parseNotifyTempContractFromArgs(
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
+    if (arg === '--') {
+      passthroughArgs.push(...args.slice(index));
+      break;
+    }
     if (arg === '--notify-temp') {
       cliActivated = true;
       continue;

--- a/src/scripts/__tests__/reasoning-artifact-contract.test.ts
+++ b/src/scripts/__tests__/reasoning-artifact-contract.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { parse as parseToml } from '@iarna/toml';
+import { test } from 'node:test';
+import {
+  assertInstalledReasoningDeclarationContract,
+  assertInstalledRootReasoningHelp,
+  assertInstalledRootReasoningRejection,
+  assertInstalledTeamSkillContract,
+} from '../smoke-packed-install.js';
+
+const root = process.cwd();
+const dist = join(root, 'dist');
+
+function read(relativePath: string): string {
+  return readFileSync(join(root, relativePath), 'utf-8');
+}
+
+test('compiled reasoning artifacts preserve exact surface-specific max contracts', async () => {
+  const requiredArtifacts = [
+    'dist/config/models.js',
+    'dist/config/models.d.ts',
+    'dist/agents/definitions.js',
+    'dist/agents/definitions.d.ts',
+    'dist/agents/native-config.js',
+    'dist/agents/native-config.d.ts',
+    'dist/team/model-contract.js',
+    'dist/team/model-contract.d.ts',
+    'dist/cli/index.js',
+    'dist/cli/index.d.ts',
+    'dist/cli/omx.js',
+    'dist/cli/omx.d.ts',
+  ];
+  for (const relativePath of requiredArtifacts) {
+    assert.equal(existsSync(join(root, relativePath)), true, `missing compiled artifact: ${relativePath}`);
+  }
+
+  const modelsDeclaration = read('dist/config/models.d.ts');
+  const definitionsDeclaration = read('dist/agents/definitions.d.ts');
+  const nativeDeclaration = read('dist/agents/native-config.d.ts');
+  const teamDeclaration = read('dist/team/model-contract.d.ts');
+  assertInstalledReasoningDeclarationContract({
+    models: modelsDeclaration,
+    definitions: definitionsDeclaration,
+    nativeConfig: nativeDeclaration,
+    team: teamDeclaration,
+  });
+
+  const models = await import(pathToFileURL(join(dist, 'config/models.js')).href);
+  assert.deepEqual(models.CANONICAL_REASONING_EFFORTS, ['low', 'medium', 'high', 'xhigh']);
+  assert.deepEqual(models.AMBIGUOUS_UNSUPPORTED_REASONING_EFFORTS, ['max', 'ultra']);
+  assert.deepEqual(models.PER_AGENT_REASONING_EFFORTS, ['low', 'medium', 'high', 'xhigh', 'max']);
+  assert.deepEqual(models.ROOT_REASONING_EFFORTS, ['low', 'medium', 'high', 'xhigh']);
+  assert.deepEqual(models.ROOT_UNSUPPORTED_REASONING_EFFORTS, ['max', 'ultra']);
+  assert.equal(models.isAmbiguousUnsupportedReasoningEffort('MAX'), true);
+  assert.equal(models.isUnsupportedRootReasoningEffort('MAX'), true);
+  assert.equal(models.isUnsupportedRootReasoningEffort('ultra'), true);
+  assert.equal(models.isUnsupportedRootReasoningEffort('xhigh'), false);
+  assert.equal(models.normalizeUnsupportedRootReasoningEffort(' MAX '), 'max');
+  assert.equal(models.normalizeUnsupportedRootReasoningEffort('Ultra'), 'ultra');
+  assert.equal(models.normalizeUnsupportedRootReasoningEffort('xhigh'), undefined);
+
+  const nativeConfig = await import(pathToFileURL(join(dist, 'agents/native-config.js')).href);
+  const definitions = await import(pathToFileURL(join(dist, 'agents/definitions.js')).href);
+  const codexHome = mkdtempSync(join(tmpdir(), 'omx-artifact-max-native-'));
+  try {
+    writeFileSync(join(codexHome, '.omx-config.json'), JSON.stringify({
+      agentReasoning: { architect: ' MAX ', critic: 'ultra' },
+    }));
+    const maxToml = nativeConfig.generateAgentToml(
+      definitions.AGENT_DEFINITIONS.architect,
+      'compiled native max contract',
+      { codexHomeOverride: codexHome },
+    );
+    assert.match(maxToml, /model_reasoning_effort = "max"/);
+    assert.doesNotMatch(maxToml, /model_reasoning_effort = "xhigh"/);
+    assert.equal((parseToml(maxToml) as { model_reasoning_effort?: unknown }).model_reasoning_effort, 'max');
+
+    const fallbackToml = nativeConfig.generateAgentToml(
+      definitions.AGENT_DEFINITIONS.critic,
+      'compiled native ultra fallback contract',
+      { codexHomeOverride: codexHome },
+    );
+    assert.match(fallbackToml, /model_reasoning_effort = "high"/);
+    assert.doesNotMatch(fallbackToml, /model_reasoning_effort = "ultra"/);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+
+  const team = await import(pathToFileURL(join(dist, 'team/model-contract.js')).href);
+  const maxArgs = team.resolveTeamWorkerLaunchArgs({ preferredReasoning: 'max' });
+  assert.deepEqual(maxArgs, ['-c', 'model_reasoning_effort="max"']);
+  assert.equal(maxArgs.includes('model_reasoning_effort="xhigh"'), false);
+  const opaqueUltra = team.resolveTeamWorkerLaunchDiagnostics({
+    existingRaw: '-c model_reasoning_effort="ultra"',
+    preferredReasoning: 'max',
+  });
+  assert.equal(opaqueUltra.reasoningSource, 'explicit');
+  assert.equal(opaqueUltra.actualReasoning, undefined);
+
+  const canonicalSkill = readFileSync(join(root, 'skills/team/SKILL.md'));
+  const pluginSkill = readFileSync(join(root, 'plugins/oh-my-codex/skills/team/SKILL.md'));
+  assertInstalledTeamSkillContract(canonicalSkill, pluginSkill);
+});
+
+test('compiled root reasoning keeps four-value help and rejects max/ultra without mutation', () => {
+  const omxPath = join(dist, 'cli/omx.js');
+  const codexHome = mkdtempSync(join(tmpdir(), 'omx-artifact-root-reasoning-'));
+  try {
+    const env = { ...process.env, CODEX_HOME: codexHome };
+    const configPath = join(codexHome, 'config.toml');
+    const help = spawnSync(process.execPath, [omxPath, 'reasoning'], { encoding: 'utf-8', env });
+    assert.equal(help.status, 0, help.stderr);
+    assertInstalledRootReasoningHelp(help.stdout);
+    const max = spawnSync(process.execPath, [omxPath, 'reasoning', 'max'], { encoding: 'utf-8', env });
+    assertInstalledRootReasoningRejection('max', max, undefined, existsSync(configPath) ? readFileSync(configPath, 'utf-8') : undefined);
+
+    const originalConfig = 'model = "preserve-root-config"\n';
+    writeFileSync(configPath, originalConfig);
+    const ultra = spawnSync(process.execPath, [omxPath, 'reasoning', 'ultra'], { encoding: 'utf-8', env });
+    assertInstalledRootReasoningRejection('ultra', ultra, originalConfig, readFileSync(configPath, 'utf-8'));
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});

--- a/src/scripts/__tests__/smoke-packed-install.test.ts
+++ b/src/scripts/__tests__/smoke-packed-install.test.ts
@@ -1,12 +1,20 @@
 // @ts-nocheck
 import assert from 'node:assert/strict';
-import { access, chmod, mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { EventEmitter } from 'node:events';
 import { tmpdir } from 'node:os';
 import { delimiter, join } from 'node:path';
 import { PassThrough } from 'node:stream';
 import { test } from 'node:test';
 import {
+  assertInstalledPluginSurface,
+  assertInstalledReasoningDeclarationContract,
+  assertInstalledReasoningRuntimeContract,
+  assertInstalledRootReasoningHelp,
+  assertInstalledRootReasoningRejection,
+  assertInstalledTeamSkillContract,
+  assertPackedInstallFileMetadata,
+  buildNativeHookSmokePayload,
   ensureRepoDependencies,
   hasUsableNodeModules,
   buildPackedRegressionEnvironment,
@@ -20,12 +28,16 @@ import {
   PACKED_INSTALL_SMOKE_CORE_COMMANDS,
   appendForeignHookGroups,
   appendDisplayOrderStableForeignHookGroups,
-  buildNativeHookSmokePayload,
   createCodexBatchWriteEnvelope,
   createCodexHooksListEnvelope,
   createCodexInitializeEnvelope,
   foreignHookGroupSnapshot,
   generatedHookTrustState,
+  isForbiddenPackedInstallArtifact,
+  PACKED_INSTALL_FORBIDDEN_ARTIFACT_PATHS,
+  PACKED_INSTALL_REQUIRED_ARTIFACT_PATHS,
+  PACKED_INSTALL_PLUGIN_MCP_TARGETS,
+  parseFakeCodexLaunches,
   parseNpmPackJsonOutput,
   parseCodexHooksListResult,
   probeCodexVersion,
@@ -821,6 +833,17 @@ test('display-order-stable foreign fixture preserves pre-approved group and hand
   );
 });
 
+test('packed install smoke probes every advertised plugin MCP target', () => {
+  assert.deepEqual(PACKED_INSTALL_PLUGIN_MCP_TARGETS, [
+    ['omx_state', 'state', 'omx-state'],
+    ['omx_memory', 'memory', 'omx-memory'],
+    ['omx_code_intel', 'code-intel', 'omx-code-intel'],
+    ['omx_trace', 'trace', 'omx-trace'],
+    ['omx_wiki', 'wiki', 'omx-wiki'],
+    ['omx_hermes', 'hermes', 'omx-hermes'],
+  ]);
+});
+
 test('packed install smoke covers every installed native hook event with minimal payloads', () => {
   assert.deepEqual(PACKED_INSTALL_NATIVE_HOOK_SMOKE_EVENTS, [
     'SessionStart',
@@ -1065,6 +1088,31 @@ test('packed install native hook stdout validation enforces event output contrac
   );
 });
 
+test('fake Codex launch capture preserves argv and runtime side-effect evidence', () => {
+  const capture = `${JSON.stringify({
+    argv: ['--', '--spark'],
+    cwd: '/tmp/omx-packed-launch',
+    hasResumeSqlite: true,
+    OMX_NOTIFY_TEMP_CONTRACT: null,
+    OMX_TEAM_WORKER_LAUNCH_ARGS: null,
+  })}\n`;
+  assert.deepEqual(parseFakeCodexLaunches(capture), [{
+    argv: ['--', '--spark'],
+    cwd: '/tmp/omx-packed-launch',
+    hasResumeSqlite: true,
+    OMX_NOTIFY_TEMP_CONTRACT: null,
+    OMX_TEAM_WORKER_LAUNCH_ARGS: null,
+  }]);
+  assert.throws(
+    () => parseFakeCodexLaunches(`${JSON.stringify({
+      argv: ['--spark'],
+      cwd: '/tmp/omx-packed-launch',
+      OMX_NOTIFY_TEMP_CONTRACT: null,
+    })}\n`),
+    /fake Codex capture did not contain a valid launch record/,
+  );
+});
+
 test('parseNpmPackJsonOutput ignores prepack logs before npm pack JSON', () => {
   const parsed = parseNpmPackJsonOutput([
     '[sync-plugin-mirror] synced 29 canonical skill directories and plugin metadata',
@@ -1077,6 +1125,242 @@ test('parseNpmPackJsonOutput ignores prepack logs before npm pack JSON', () => {
   ].join('\n'));
 
   assert.deepEqual(parsed, [{ filename: 'oh-my-codex-0.15.0.tgz' }]);
+});
+
+test('packed install metadata requires runtime, declarations, Team skills, and plugin assets only', () => {
+  const files = PACKED_INSTALL_REQUIRED_ARTIFACT_PATHS.map((path) => ({ path }));
+  assert.doesNotThrow(() => assertPackedInstallFileMetadata(files));
+  assert.equal(
+    PACKED_INSTALL_REQUIRED_ARTIFACT_PATHS.some((path) => path.startsWith('docs/')),
+    false,
+    'repository documentation must not become an npm package requirement',
+  );
+  assert.throws(
+    () => assertPackedInstallFileMetadata(files.slice(1)),
+    /npm pack is missing required artifact: dist\/config\/models\.js/,
+  );
+  assert.throws(
+    () => assertPackedInstallFileMetadata([...files, { path: 'docs/reference/omx-config-schema-routing.md' }]),
+    /npm pack includes forbidden workspace artifact: docs\/reference\/omx-config-schema-routing\.md/,
+  );
+
+  for (const path of [
+    '.gjc/session/plan.md',
+    'docs/reference/page.md',
+    '.omx/state/team.json',
+    'artifact.tgz',
+    'tmp/smoke-output.txt',
+    'temp/smoke-output.json',
+    'scratch.tmp',
+  ]) {
+    assert.equal(isForbiddenPackedInstallArtifact(path), true, `expected ${path} to be rejected`);
+  }
+  for (const prefix of PACKED_INSTALL_FORBIDDEN_ARTIFACT_PATHS) {
+    assert.equal(isForbiddenPackedInstallArtifact(`${prefix}probe`), true);
+  }
+  assert.equal(isForbiddenPackedInstallArtifact('templates/AGENTS.md'), false);
+  assert.equal(isForbiddenPackedInstallArtifact('dist/notifications/__tests__/temp-mode.test.d.ts'), false);
+});
+
+test('packed install helpers enforce root rejection and no config mutation', () => {
+  const help = 'Usage: omx reasoning <low|medium|high|xhigh>\n  --xhigh\n';
+  assert.doesNotThrow(() => assertInstalledRootReasoningHelp(help));
+  assert.throws(() => assertInstalledRootReasoningHelp(`${help}  --max\n`), /must not advertise --max/);
+
+  const maxStderr = [
+    'Reasoning mode "max" is not supported by "omx reasoning".',
+    'Per-agent "max" is configured with agentReasoning; direct -c model_reasoning_effort=... is passed to Codex and remains capability-dependent.',
+    'Invalid reasoning mode "max". Expected one of: low, medium, high, xhigh.',
+    'Usage: omx reasoning <low|medium|high|xhigh>',
+  ].join('\n');
+  assert.doesNotThrow(() => assertInstalledRootReasoningRejection(
+    'max',
+    { status: 1, stdout: '', stderr: maxStderr },
+    undefined,
+    undefined,
+  ));
+  assert.throws(
+    () => assertInstalledRootReasoningRejection('max', { status: 1, stdout: '', stderr: maxStderr }, undefined, 'created'),
+    /must not create or mutate config\.toml/,
+  );
+
+  const ultraStderr = [
+    'Reasoning mode "ultra" is not supported by OMX root or per-agent reasoning and is not an alias for "max".',
+    'Direct -c model_reasoning_effort=... remains opaque Codex passthrough.',
+    'Invalid reasoning mode "ultra". Expected one of: low, medium, high, xhigh.',
+    'Usage: omx reasoning <low|medium|high|xhigh>',
+  ].join('\n');
+  assert.doesNotThrow(() => assertInstalledRootReasoningRejection(
+    'ultra',
+    { status: 1, stdout: '', stderr: ultraStderr },
+    'model = "preserve"\n',
+    'model = "preserve"\n',
+  ));
+});
+
+test('packed install helpers freeze installed runtime and declaration reasoning contracts', () => {
+  const models = {
+    CANONICAL_REASONING_EFFORTS: ['low', 'medium', 'high', 'xhigh'],
+    AMBIGUOUS_UNSUPPORTED_REASONING_EFFORTS: ['max', 'ultra'],
+    PER_AGENT_REASONING_EFFORTS: ['low', 'medium', 'high', 'xhigh', 'max'],
+    ROOT_REASONING_EFFORTS: ['low', 'medium', 'high', 'xhigh'],
+    ROOT_UNSUPPORTED_REASONING_EFFORTS: ['max', 'ultra'],
+    isAmbiguousUnsupportedReasoningEffort: (value: string) => value.toLowerCase() === 'max' || value.toLowerCase() === 'ultra',
+    isUnsupportedRootReasoningEffort: (value: string) => value.toLowerCase() === 'max' || value.toLowerCase() === 'ultra',
+    normalizeUnsupportedRootReasoningEffort: (value: string) => {
+      const normalized = value.trim().toLowerCase();
+      return normalized === 'max' || normalized === 'ultra' ? normalized : undefined;
+    },
+  };
+  assert.doesNotThrow(() => assertInstalledReasoningRuntimeContract(models));
+
+  const modelsDeclaration = [
+    'export declare const CANONICAL_REASONING_EFFORTS: readonly ["low", "medium", "high", "xhigh"];',
+    'export type ConfiguredAgentReasoningEffort = (typeof CANONICAL_REASONING_EFFORTS)[number];',
+    'export declare const AMBIGUOUS_UNSUPPORTED_REASONING_EFFORTS: readonly ["max", "ultra"];',
+    'export declare const PER_AGENT_REASONING_EFFORTS: readonly ["low", "medium", "high", "xhigh", "max"];',
+    'export type PerAgentReasoningEffort = (typeof PER_AGENT_REASONING_EFFORTS)[number];',
+    'export declare const ROOT_REASONING_EFFORTS: readonly ["low", "medium", "high", "xhigh"];',
+    'export type RootReasoningEffort = (typeof ROOT_REASONING_EFFORTS)[number];',
+    'export declare const ROOT_UNSUPPORTED_REASONING_EFFORTS: readonly ["max", "ultra"];',
+    'export declare function isUnsupportedRootReasoningEffort(value: string): boolean;',
+    'export declare function normalizeUnsupportedRootReasoningEffort(value: string): RootUnsupportedReasoningEffort | undefined;',
+  ].join('\n');
+  const definitionsDeclaration = [
+    'export interface AgentDefinition {',
+    "  reasoningEffort: 'low' | 'medium' | 'high' | 'xhigh';",
+    '}',
+  ].join('\n');
+  assert.doesNotThrow(() => assertInstalledReasoningDeclarationContract({
+    models: modelsDeclaration,
+    definitions: definitionsDeclaration,
+    nativeConfig: 'export interface GeneratedNativeAgentConfig {\n  reasoningEffort?: PerAgentReasoningEffort;\n}',
+    team: 'export type TeamReasoningEffort = PerAgentReasoningEffort;',
+  }));
+  assert.throws(
+    () => assertInstalledReasoningDeclarationContract({
+      models: modelsDeclaration.replace(': boolean;', ': value is RootUnsupportedReasoningEffort;'),
+      definitions: definitionsDeclaration,
+      nativeConfig: 'reasoningEffort?: PerAgentReasoningEffort;',
+      team: 'export type TeamReasoningEffort = PerAgentReasoningEffort;',
+    }),
+    /plain boolean, not a type predicate/,
+  );
+});
+
+test('packed install contract requires canonical/plugin Team skill parity and text', async () => {
+  const canonical = await readFile(join(process.cwd(), 'skills/team/SKILL.md'));
+  const pluginMirror = await readFile(join(process.cwd(), 'plugins/oh-my-codex/skills/team/SKILL.md'));
+  assert.doesNotThrow(() => assertInstalledTeamSkillContract(canonical, pluginMirror));
+});
+
+test('packed install plugin assertions enforce the packaged plugin contract', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'omx-packed-plugin-surface-'));
+  try {
+    const pluginRoot = join(root, 'plugins/oh-my-codex');
+    const pluginManifestPath = join(pluginRoot, '.codex-plugin/plugin.json');
+    const mcpManifestPath = join(pluginRoot, '.mcp.json');
+    const appManifestPath = join(pluginRoot, '.app.json');
+    const hooksManifestPath = join(pluginRoot, 'hooks/hooks.json');
+    const hookLauncherPath = join(pluginRoot, 'hooks/codex-native-hook.mjs');
+    const hookCommand = 'node "${PLUGIN_ROOT}/hooks/codex-native-hook.mjs"';
+    await mkdir(join(pluginRoot, '.codex-plugin'), { recursive: true });
+    await mkdir(join(pluginRoot, 'hooks'), { recursive: true });
+
+    const writeValidPluginSurface = async (): Promise<void> => {
+      await writeFile(pluginManifestPath, JSON.stringify({
+        name: 'oh-my-codex',
+        version: '0.0.0-test',
+        skills: './skills/',
+        mcpServers: './.mcp.json',
+        apps: './.app.json',
+        hooks: './hooks/hooks.json',
+        interface: {
+          displayName: 'OMX',
+          shortDescription: 'Test plugin',
+          longDescription: 'Structurally valid plugin test fixture.',
+          developerName: 'Test',
+          category: 'Developer Tools',
+        },
+      }));
+      await writeFile(mcpManifestPath, JSON.stringify({
+        mcpServers: Object.fromEntries([
+          ['omx_state', 'state'],
+          ['omx_memory', 'memory'],
+          ['omx_code_intel', 'code-intel'],
+          ['omx_trace', 'trace'],
+          ['omx_wiki', 'wiki'],
+          ['omx_hermes', 'hermes'],
+        ].map(([name, service]) => [name, {
+          command: 'omx',
+          args: ['mcp-serve', service],
+          enabled: false,
+        }])),
+      }));
+      await writeFile(appManifestPath, JSON.stringify({ apps: {} }));
+      await writeFile(hooksManifestPath, JSON.stringify({
+        hooks: Object.fromEntries(PACKED_INSTALL_NATIVE_HOOK_SMOKE_EVENTS.map((eventName) => [eventName, [{
+          hooks: [{ type: 'command', command: hookCommand }],
+        }]])),
+      }));
+      await writeFile(hookLauncherPath, [
+        '#!/usr/bin/env node',
+        "import { spawn } from 'node:child_process';",
+        "import { join } from 'node:path';",
+        "const OMX_PLUGIN_HOOK_LAUNCHER_CONTRACT_MARKER = 'omx-plugin-hook-launcher:v1';",
+        "const hookDir = new URL('.', import.meta.url).pathname;",
+        'function readPinnedLauncher() {',
+        "  const launcherPath = join(hookDir, 'omx-command.json');",
+        '  return { command: process.execPath, argsPrefix: [], launcherPath };',
+        '}',
+        'const input = Buffer.from(\'\');',
+        'const { command, argsPrefix } = readPinnedLauncher();',
+        "const child = spawn(command, [...argsPrefix, 'codex-native-hook']);",
+        'child.stdin.end(input);',
+        '',
+      ].join('\n'));
+    };
+
+    await writeValidPluginSurface();
+    assert.doesNotThrow(() => assertInstalledPluginSurface(root));
+
+    await writeValidPluginSurface();
+    await writeFile(hookLauncherPath, [
+      '#!/usr/bin/env node',
+      "const OMX_PLUGIN_HOOK_LAUNCHER_CONTRACT_MARKER = 'omx-plugin-hook-launcher:v1';",
+      'process.stdout.write(OMX_PLUGIN_HOOK_LAUNCHER_CONTRACT_MARKER);',
+      '',
+    ].join('\n'));
+    assert.throws(
+      () => assertInstalledPluginSurface(root),
+      /must read its pinned omx-command\.json delegate configuration/,
+    );
+
+    await writeFile(pluginManifestPath, '{}');
+    assert.throws(() => assertInstalledPluginSurface(root), /plugin\.json\.name/);
+
+    await writeValidPluginSurface();
+    await writeFile(mcpManifestPath, JSON.stringify({ mcpServers: {} }));
+    assert.throws(() => assertInstalledPluginSurface(root), /omx_state/);
+
+    await writeValidPluginSurface();
+    await writeFile(appManifestPath, JSON.stringify({ apps: [] }));
+    assert.throws(() => assertInstalledPluginSurface(root), /\.app\.json\.apps/);
+
+    await writeValidPluginSurface();
+    await writeFile(hooksManifestPath, JSON.stringify({ hooks: {} }));
+    assert.throws(() => assertInstalledPluginSurface(root), /hook event is missing: SessionStart/);
+
+    await writeValidPluginSurface();
+    await writeFile(hookLauncherPath, 'export {};\n');
+    assert.throws(() => assertInstalledPluginSurface(root), /must start with a Node shebang/);
+
+    await writeValidPluginSurface();
+    await writeFile(mcpManifestPath, '{not-json');
+    assert.throws(() => assertInstalledPluginSurface(root), /plugin manifest is not parseable JSON/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test('resolveGitCommonDir resolves relative git common dir output against the repo root', () => {

--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert/strict';
 import {
   chmodSync,
   existsSync,
@@ -19,16 +20,16 @@ import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'node:chil
 import { pathToFileURL } from 'node:url';
 import { TextDecoder } from 'node:util';
 
-import TOML from '@iarna/toml';
+import TOML, { parse as parseToml } from '@iarna/toml';
 import { isManagedCodexHookCommand, planManagedCodexHooksRemoval } from '../config/codex-hooks.js';
 import {
   spawnPlatformCommand,
   spawnPlatformCommandSync,
 } from '../utils/platform-command.js';
-
 import {
   ensureReusableNodeModules,
 } from '../utils/repo-deps.js';
+import { escapeTomlString } from '../utils/toml.js';
 
 
 export {
@@ -1216,12 +1217,787 @@ export function probeCodexVersion(
 ): string {
   return resolvePinnedCodexExecutable(cwd, env, seam).version;
 }
+export const PACKED_INSTALL_PLUGIN_MCP_TARGETS = [
+  ['omx_state', 'state', 'omx-state'],
+  ['omx_memory', 'memory', 'omx-memory'],
+  ['omx_code_intel', 'code-intel', 'omx-code-intel'],
+  ['omx_trace', 'trace', 'omx-trace'],
+  ['omx_wiki', 'wiki', 'omx-wiki'],
+  ['omx_hermes', 'hermes', 'omx-hermes'],
+] as const;
+
+const PACKED_INSTALL_OPERATIONAL_PROBE_TIMEOUT_MS = 5_000;
+
+function buildPackedProbeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of Object.keys(env)) {
+    const upper = key.toUpperCase();
+    if (upper === 'NODE_OPTIONS' || upper.startsWith('OMX_') || upper.startsWith('CODEX_')) {
+      delete env[key];
+    }
+  }
+  return { ...env, ...overrides };
+}
+
+export interface PackedInstallNpmFile {
+  path: string;
+}
+
+export interface PackedInstallNpmPackResult {
+  filename: string;
+  files?: PackedInstallNpmFile[];
+}
+
+export interface PackedInstallCommandResult {
+  status: number | null;
+  stdout?: string | Buffer;
+  stderr?: string | Buffer;
+}
+
+export const PACKED_INSTALL_REQUIRED_ARTIFACT_PATHS = [
+  'dist/config/models.js',
+  'dist/config/models.d.ts',
+  'dist/agents/definitions.js',
+  'dist/agents/definitions.d.ts',
+  'dist/agents/native-config.js',
+  'dist/agents/native-config.d.ts',
+  'dist/team/model-contract.js',
+  'dist/team/model-contract.d.ts',
+  'dist/cli/index.js',
+  'dist/cli/index.d.ts',
+  'dist/cli/omx.js',
+  'dist/cli/omx.d.ts',
+  'skills/team/SKILL.md',
+  'plugins/oh-my-codex/skills/team/SKILL.md',
+  'plugins/oh-my-codex/.codex-plugin/plugin.json',
+  'plugins/oh-my-codex/.mcp.json',
+  'plugins/oh-my-codex/.app.json',
+  'plugins/oh-my-codex/hooks/hooks.json',
+  'plugins/oh-my-codex/hooks/codex-native-hook.mjs',
+] as const;
+
+export const PACKED_INSTALL_FORBIDDEN_ARTIFACT_PATHS = [
+  '.gjc/',
+  'docs/',
+  '.omx/',
+] as const;
+
+function normalizedPackPath(path: string): string {
+  return path.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+export function isForbiddenPackedInstallArtifact(path: string): boolean {
+  const normalized = normalizedPackPath(path);
+  return PACKED_INSTALL_FORBIDDEN_ARTIFACT_PATHS.some((prefix) => normalized.startsWith(prefix))
+    || normalized.endsWith('.tgz')
+    || normalized.endsWith('.tmp')
+    || normalized.endsWith('.temp')
+    || /(^|\/)(?:tmp|temp)\//.test(normalized);
+}
+
+export function assertPackedInstallFileMetadata(files: readonly PackedInstallNpmFile[]): void {
+  const paths = new Set(files.map((file) => normalizedPackPath(file.path)));
+  for (const requiredPath of PACKED_INSTALL_REQUIRED_ARTIFACT_PATHS) {
+    if (!paths.has(requiredPath)) {
+      throw new Error(`npm pack is missing required artifact: ${requiredPath}`);
+    }
+  }
+
+  for (const path of paths) {
+    if (isForbiddenPackedInstallArtifact(path)) {
+      throw new Error(`npm pack includes forbidden workspace artifact: ${path}`);
+    }
+  }
+}
+
+function assertTextIncludes(text: string, expected: string, surface: string): void {
+  if (!text.includes(expected)) {
+    throw new Error(`${surface} is missing required text: ${expected}`);
+  }
+}
+
+function assertTextMatches(text: string, pattern: RegExp, surface: string): void {
+  if (!pattern.test(text)) {
+    throw new Error(`${surface} does not satisfy required pattern: ${pattern}`);
+  }
+}
+
+export function assertInstalledRootReasoningHelp(help: string): void {
+  assertTextIncludes(help, 'Usage: omx reasoning <low|medium|high|xhigh>', 'installed omx help');
+  for (const unsupportedOption of ['--max', '--ultra']) {
+    if (help.includes(unsupportedOption)) {
+      throw new Error(`installed omx help must not advertise ${unsupportedOption}`);
+    }
+  }
+}
+
+export function assertInstalledRootReasoningRejection(
+  mode: 'max' | 'ultra',
+  result: PackedInstallCommandResult,
+  configBefore: string | undefined,
+  configAfter: string | undefined,
+): void {
+  if (result.status !== 1) {
+    throw new Error(`omx reasoning ${mode} must exit 1, received ${String(result.status)}`);
+  }
+  if (String(result.stdout ?? '').trim() !== '') {
+    throw new Error(`omx reasoning ${mode} must not emit success stdout`);
+  }
+  if (configBefore !== configAfter) {
+    throw new Error(`omx reasoning ${mode} must not create or mutate config.toml`);
+  }
+
+  const stderr = String(result.stderr ?? '');
+  const fragments = mode === 'max'
+    ? [
+      'Reasoning mode "max" is not supported by "omx reasoning".',
+      'Per-agent "max" is configured with agentReasoning; direct -c model_reasoning_effort=... is passed to Codex and remains capability-dependent.',
+      'Invalid reasoning mode "max". Expected one of: low, medium, high, xhigh.',
+      'Usage: omx reasoning <low|medium|high|xhigh>',
+    ]
+    : [
+      'Reasoning mode "ultra" is not supported by OMX root or per-agent reasoning and is not an alias for "max".',
+      'Direct -c model_reasoning_effort=... remains opaque Codex passthrough.',
+      'Invalid reasoning mode "ultra". Expected one of: low, medium, high, xhigh.',
+      'Usage: omx reasoning <low|medium|high|xhigh>',
+    ];
+  for (const fragment of fragments) {
+    assertTextIncludes(stderr, fragment, `omx reasoning ${mode} stderr`);
+  }
+}
+
+export function assertInstalledReasoningRuntimeContract(models: Record<string, unknown>): void {
+  const expected = ['low', 'medium', 'high', 'xhigh'];
+  const equalTuple = (name: string, actual: unknown, values: string[]): void => {
+    if (!Array.isArray(actual) || actual.length !== values.length || actual.some((value, index) => value !== values[index])) {
+      throw new Error(`${name} must be exactly ${JSON.stringify(values)}`);
+    }
+  };
+
+  equalTuple('CANONICAL_REASONING_EFFORTS', models.CANONICAL_REASONING_EFFORTS, expected);
+  equalTuple('AMBIGUOUS_UNSUPPORTED_REASONING_EFFORTS', models.AMBIGUOUS_UNSUPPORTED_REASONING_EFFORTS, ['max', 'ultra']);
+  equalTuple('PER_AGENT_REASONING_EFFORTS', models.PER_AGENT_REASONING_EFFORTS, [...expected, 'max']);
+  equalTuple('ROOT_REASONING_EFFORTS', models.ROOT_REASONING_EFFORTS, expected);
+  equalTuple('ROOT_UNSUPPORTED_REASONING_EFFORTS', models.ROOT_UNSUPPORTED_REASONING_EFFORTS, ['max', 'ultra']);
+
+  const isLegacyUnsupported = models.isAmbiguousUnsupportedReasoningEffort;
+  const isRootUnsupported = models.isUnsupportedRootReasoningEffort;
+  const normalizeRootUnsupported = models.normalizeUnsupportedRootReasoningEffort;
+  if (typeof isLegacyUnsupported !== 'function' || isLegacyUnsupported('MAX') !== true) {
+    throw new Error('legacy unsupported reasoning helper must remain case-insensitive');
+  }
+  if (typeof isRootUnsupported !== 'function'
+    || isRootUnsupported('MAX') !== true
+    || isRootUnsupported('ultra') !== true
+    || isRootUnsupported('xhigh') !== false) {
+    throw new Error('root unsupported reasoning helper must be a case-insensitive max/ultra classifier');
+  }
+  if (typeof normalizeRootUnsupported !== 'function'
+    || normalizeRootUnsupported(' MAX ') !== 'max'
+    || normalizeRootUnsupported('Ultra') !== 'ultra'
+    || normalizeRootUnsupported('xhigh') !== undefined) {
+    throw new Error('root unsupported reasoning normalizer must canonicalize only max and ultra');
+  }
+}
+
+export function assertInstalledReasoningDeclarationContract(declarations: {
+  models: string;
+  definitions: string;
+  nativeConfig: string;
+  team: string;
+}): void {
+  const { models, definitions, nativeConfig, team } = declarations;
+  const tuple = (values: string[]): string => values.map((value) => `["']${value}["']`).join('\\s*,\\s*');
+  assertTextMatches(models, new RegExp(`export\\s+declare\\s+const\\s+CANONICAL_REASONING_EFFORTS\\s*:\\s*readonly\\s*\\[\\s*${tuple(['low', 'medium', 'high', 'xhigh'])}\\s*\\]\\s*;`), 'models declaration');
+  assertTextIncludes(models, 'export type ConfiguredAgentReasoningEffort = (typeof CANONICAL_REASONING_EFFORTS)[number];', 'models declaration');
+  assertTextMatches(models, new RegExp(`export\\s+declare\\s+const\\s+AMBIGUOUS_UNSUPPORTED_REASONING_EFFORTS\\s*:\\s*readonly\\s*\\[\\s*${tuple(['max', 'ultra'])}\\s*\\]\\s*;`), 'models declaration');
+  assertTextMatches(models, new RegExp(`export\\s+declare\\s+const\\s+PER_AGENT_REASONING_EFFORTS\\s*:\\s*readonly\\s*\\[\\s*${tuple(['low', 'medium', 'high', 'xhigh', 'max'])}\\s*\\]\\s*;`), 'models declaration');
+  assertTextIncludes(models, 'export type PerAgentReasoningEffort = (typeof PER_AGENT_REASONING_EFFORTS)[number];', 'models declaration');
+  assertTextMatches(models, new RegExp(`export\\s+declare\\s+const\\s+ROOT_REASONING_EFFORTS\\s*:\\s*readonly\\s*\\[\\s*${tuple(['low', 'medium', 'high', 'xhigh'])}\\s*\\]\\s*;`), 'models declaration');
+  assertTextIncludes(models, 'export type RootReasoningEffort = (typeof ROOT_REASONING_EFFORTS)[number];', 'models declaration');
+  assertTextMatches(models, new RegExp(`export\\s+declare\\s+const\\s+ROOT_UNSUPPORTED_REASONING_EFFORTS\\s*:\\s*readonly\\s*\\[\\s*${tuple(['max', 'ultra'])}\\s*\\]\\s*;`), 'models declaration');
+  if (/isUnsupportedRootReasoningEffort\(value: string\): value is/.test(models)) {
+    throw new Error('isUnsupportedRootReasoningEffort must be declared as a plain boolean, not a type predicate');
+  }
+  assertTextIncludes(models, 'export declare function isUnsupportedRootReasoningEffort(value: string): boolean;', 'models declaration');
+  assertTextIncludes(models, 'export declare function normalizeUnsupportedRootReasoningEffort(value: string): RootUnsupportedReasoningEffort | undefined;', 'models declaration');
+
+  const definitionMatch = /export interface AgentDefinition\s*\{([\s\S]*?)\n\}/.exec(definitions);
+  if (!definitionMatch) throw new Error('AgentDefinition declaration is missing');
+  const reasoningField = /\breasoningEffort(\?)?:\s*([^;]+);/.exec(definitionMatch[1]);
+  if (!reasoningField || reasoningField[1] === '?') {
+    throw new Error('AgentDefinition.reasoningEffort must remain required');
+  }
+  if (reasoningField[2] !== "'low' | 'medium' | 'high' | 'xhigh'") {
+    throw new Error(`AgentDefinition.reasoningEffort widened unexpectedly: ${reasoningField[2] ?? 'missing'}`);
+  }
+  if (/\b(?:undefined|max|ultra)\b/.test(reasoningField[2])) {
+    throw new Error('AgentDefinition.reasoningEffort must not allow undefined, max, or ultra');
+  }
+
+  assertTextIncludes(nativeConfig, 'reasoningEffort?: PerAgentReasoningEffort;', 'native config declaration');
+  assertTextIncludes(team, 'export type TeamReasoningEffort = PerAgentReasoningEffort;', 'Team declaration');
+  if (/\bultra\b/.test(team)) {
+    throw new Error('Team declaration must not recognize ultra');
+  }
+}
+
+export function assertInstalledTeamSkillContract(canonical: Buffer, pluginMirror: Buffer): void {
+  if (!canonical.equals(pluginMirror)) {
+    throw new Error('canonical and plugin Team skills must be byte-identical');
+  }
+
+  const skill = canonical.toString('utf-8');
+  assertTextMatches(skill, /agentReasoning[\s\S]{0,240}`low`, `medium`, `high`, `xhigh`,(?: and)? `max`/, 'Team skill');
+  assertTextMatches(skill, /`max`[\s\S]{0,240}passed[\s\S]{0,80}unchanged/i, 'Team skill');
+  assertTextMatches(skill, /`max`[\s\S]{0,240}capability-dependent/i, 'Team skill');
+  assertTextMatches(skill, /`ultra`[\s\S]{0,180}unsupported[\s\S]{0,180}not an alias for[\s\S]{0,100}`max`/i, 'Team skill');
+  assertTextMatches(skill, /invalid configured values[\s\S]{0,180}built-in role-default fallback/i, 'Team skill');
+  assertTextMatches(skill, /explicit raw `-c model_reasoning_effort=\.\.\.`[\s\S]{0,240}opaque[\s\S]{0,240}wins/i, 'Team skill');
+  assertTextMatches(skill, /both sources[\s\S]{0,160}explicit raw reasoning[\s\S]{0,160}inherited Team reasoning[\s\S]{0,160}environment reasoning/i, 'Team skill');
+  assertTextMatches(skill, /do not downgrade or retry `max` as `xhigh`[\s\S]{0,160}built-in role defaults remain unchanged/i, 'Team skill');
+}
+
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readInstalledPluginManifest(packageRoot: string, relativePath: string): Record<string, unknown> {
+  const path = join(packageRoot, relativePath);
+  if (!existsSync(path)) throw new Error(`installed plugin manifest is missing: ${relativePath}`);
+
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(readFileSync(path, 'utf-8'));
+  } catch (error) {
+    throw new Error(`installed plugin manifest is not parseable JSON: ${relativePath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!isJsonRecord(manifest)) {
+    throw new Error(`installed plugin manifest must be a JSON object: ${relativePath}`);
+  }
+  return manifest;
+}
+
+function assertInstalledPluginString(value: unknown, path: string, expected?: string): void {
+  if (typeof value !== 'string' || value.trim() === '' || (expected !== undefined && value !== expected)) {
+    throw new Error(`installed plugin manifest field is invalid: ${path}`);
+  }
+}
+
+function assertInstalledPluginHookLauncherContract(hookSource: string): void {
+  const requiredShape: Array<[RegExp, string]> = [
+    [
+      /['"]omx-command\.json['"]/,
+      'read its pinned omx-command.json delegate configuration',
+    ],
+    [
+      /\bspawn\s*\(\s*command\s*,\s*\[\s*\.\.\.\s*argsPrefix\s*,\s*['"]codex-native-hook['"]\s*\]/s,
+      'spawn the configured delegate with the codex-native-hook argument',
+    ],
+    [
+      /\.stdin\s*\.end\s*\(\s*input\s*\)/,
+      'forward the hook input to the delegate stdin',
+    ],
+  ];
+  for (const [pattern, requirement] of requiredShape) {
+    if (!pattern.test(hookSource)) {
+      throw new Error(`installed plugin native hook launcher must ${requirement}`);
+    }
+  }
+}
+
+export function assertInstalledPluginSurface(packageRoot: string): void {
+  const pluginManifest = readInstalledPluginManifest(packageRoot, 'plugins/oh-my-codex/.codex-plugin/plugin.json');
+  assertInstalledPluginString(pluginManifest.name, 'plugin.json.name', 'oh-my-codex');
+  assertInstalledPluginString(pluginManifest.version, 'plugin.json.version');
+  assertInstalledPluginString(pluginManifest.skills, 'plugin.json.skills', './skills/');
+  assertInstalledPluginString(pluginManifest.mcpServers, 'plugin.json.mcpServers', './.mcp.json');
+  assertInstalledPluginString(pluginManifest.apps, 'plugin.json.apps', './.app.json');
+  assertInstalledPluginString(pluginManifest.hooks, 'plugin.json.hooks', './hooks/hooks.json');
+
+  if (!isJsonRecord(pluginManifest.interface)) {
+    throw new Error('installed plugin manifest field is invalid: plugin.json.interface');
+  }
+  for (const key of ['displayName', 'shortDescription', 'longDescription', 'developerName', 'category']) {
+    assertInstalledPluginString(pluginManifest.interface[key], `plugin.json.interface.${key}`);
+  }
+
+  const mcpManifest = readInstalledPluginManifest(packageRoot, 'plugins/oh-my-codex/.mcp.json');
+  if (!isJsonRecord(mcpManifest.mcpServers)) {
+    throw new Error('installed plugin manifest field is invalid: .mcp.json.mcpServers');
+  }
+  const mcpServers = mcpManifest.mcpServers;
+  for (const [serverName, server] of Object.entries(mcpServers)) {
+    if (!isJsonRecord(server)
+      || typeof server.command !== 'string'
+      || server.command.trim() === ''
+      || !Array.isArray(server.args)
+      || server.args.some((arg) => typeof arg !== 'string')
+      || typeof server.enabled !== 'boolean') {
+      throw new Error(`installed MCP server is invalid: ${serverName}`);
+    }
+  }
+  for (const [serverName, service] of PACKED_INSTALL_PLUGIN_MCP_TARGETS) {
+    const server = mcpServers[serverName];
+    if (!isJsonRecord(server)
+      || server.command !== 'omx'
+      || !Array.isArray(server.args)
+      || server.args.length !== 2
+      || server.args[0] !== 'mcp-serve'
+      || server.args[1] !== service
+      || server.enabled !== false) {
+      throw new Error(`installed MCP server does not match the packaged contract: ${serverName}`);
+    }
+  }
+
+  const appManifest = readInstalledPluginManifest(packageRoot, 'plugins/oh-my-codex/.app.json');
+  if (!isJsonRecord(appManifest.apps)) {
+    throw new Error('installed plugin manifest field is invalid: .app.json.apps');
+  }
+
+  const hooksManifest = readInstalledPluginManifest(packageRoot, 'plugins/oh-my-codex/hooks/hooks.json');
+  if (!isJsonRecord(hooksManifest.hooks)) {
+    throw new Error('installed plugin manifest field is invalid: hooks.json.hooks');
+  }
+  const expectedHookCommand = 'node "${PLUGIN_ROOT}/hooks/codex-native-hook.mjs"';
+  for (const eventName of PACKED_INSTALL_NATIVE_HOOK_SMOKE_EVENTS) {
+    const entries = hooksManifest.hooks[eventName];
+    if (!Array.isArray(entries) || entries.length === 0) {
+      throw new Error(`installed plugin hook event is missing: ${eventName}`);
+    }
+    for (const entry of entries) {
+      if (!isJsonRecord(entry) || !Array.isArray(entry.hooks) || entry.hooks.length === 0) {
+        throw new Error(`installed plugin hook entry is invalid: ${eventName}`);
+      }
+      for (const hook of entry.hooks) {
+        if (!isJsonRecord(hook) || hook.type !== 'command' || hook.command !== expectedHookCommand) {
+          throw new Error(`installed plugin hook command must target the native launcher: ${eventName}`);
+        }
+      }
+    }
+  }
+
+  const hookPath = join(packageRoot, 'plugins/oh-my-codex/hooks/codex-native-hook.mjs');
+  if (!existsSync(hookPath)) {
+    throw new Error('installed plugin native hook launcher is missing');
+  }
+  const hookSource = readFileSync(hookPath, 'utf-8');
+  if (!hookSource.startsWith('#!/usr/bin/env node')) {
+    throw new Error('installed plugin native hook launcher must start with a Node shebang');
+  }
+  if (!/\bconst\s+OMX_PLUGIN_HOOK_LAUNCHER_CONTRACT_MARKER\s*=\s*['"]omx-plugin-hook-launcher:v1['"]/.test(hookSource)) {
+    throw new Error('installed plugin native hook launcher is missing its stable contract marker');
+  }
+  assertInstalledPluginHookLauncherContract(hookSource);
+  const syntaxCheck = spawnSync(process.execPath, ['--check', hookPath], { encoding: 'utf-8' });
+  if (syntaxCheck.error || syntaxCheck.status !== 0) {
+    const detail = String(syntaxCheck.stderr || syntaxCheck.error?.message || 'unknown syntax error').trim();
+    throw new Error(`installed plugin native hook launcher fails Node syntax check: ${detail}`);
+  }
+}
+
+function assertInstalledRequiredArtifacts(packageRoot: string): void {
+  for (const relativePath of PACKED_INSTALL_REQUIRED_ARTIFACT_PATHS) {
+    if (!existsSync(join(packageRoot, relativePath))) {
+      throw new Error(`installed package is missing required artifact: ${relativePath}`);
+    }
+  }
+}
+
+async function assertInstalledReasoningArtifacts(packageRoot: string): Promise<void> {
+  const models = await import(pathToFileURL(join(packageRoot, 'dist/config/models.js')).href) as Record<string, unknown>;
+  const nativeConfig = await import(pathToFileURL(join(packageRoot, 'dist/agents/native-config.js')).href) as Record<string, unknown>;
+  const definitions = await import(pathToFileURL(join(packageRoot, 'dist/agents/definitions.js')).href) as Record<string, unknown>;
+  const team = await import(pathToFileURL(join(packageRoot, 'dist/team/model-contract.js')).href) as Record<string, unknown>;
+
+  assertInstalledReasoningRuntimeContract(models);
+  assertInstalledReasoningDeclarationContract({
+    models: readFileSync(join(packageRoot, 'dist/config/models.d.ts'), 'utf-8'),
+    definitions: readFileSync(join(packageRoot, 'dist/agents/definitions.d.ts'), 'utf-8'),
+    nativeConfig: readFileSync(join(packageRoot, 'dist/agents/native-config.d.ts'), 'utf-8'),
+    team: readFileSync(join(packageRoot, 'dist/team/model-contract.d.ts'), 'utf-8'),
+  });
+
+  const codexHome = mkdtempSync(join(tmpdir(), 'omx-packed-max-native-'));
+  try {
+    writeFileSync(join(codexHome, '.omx-config.json'), JSON.stringify({
+      agentReasoning: { architect: ' MAX ' },
+    }));
+    const generateAgentToml = nativeConfig.generateAgentToml as (
+      agent: unknown,
+      prompt: string,
+      options: { codexHomeOverride: string },
+    ) => string;
+    const agentDefinitions = definitions.AGENT_DEFINITIONS as Record<string, unknown>;
+    const maxToml = generateAgentToml(agentDefinitions.architect, 'installed native max contract', { codexHomeOverride: codexHome });
+    assertTextIncludes(maxToml, 'model_reasoning_effort = "max"', 'installed native TOML');
+    if (maxToml.includes('model_reasoning_effort = "xhigh"')) {
+      throw new Error('installed native TOML must not downgrade max to xhigh');
+    }
+    if ((parseToml(maxToml) as { model_reasoning_effort?: unknown }).model_reasoning_effort !== 'max') {
+      throw new Error('installed native TOML must parse back to exact max');
+    }
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+
+  const resolveTeamWorkerLaunchArgs = team.resolveTeamWorkerLaunchArgs as (options: {
+    existingRaw?: string;
+    preferredReasoning?: string;
+  }) => string[];
+  const resolveTeamWorkerLaunchDiagnostics = team.resolveTeamWorkerLaunchDiagnostics as (options: {
+    existingRaw?: string;
+    preferredReasoning?: string;
+  }) => { actualReasoning?: string; reasoningSource?: string };
+  const maxArgs = resolveTeamWorkerLaunchArgs({ preferredReasoning: 'max' });
+  if (maxArgs.join('\u0000') !== ['-c', 'model_reasoning_effort="max"'].join('\u0000')) {
+    throw new Error(`Team must transport configured max exactly, received ${JSON.stringify(maxArgs)}`);
+  }
+  if (maxArgs.includes('model_reasoning_effort="xhigh"')) {
+    throw new Error('Team must not downgrade max to xhigh');
+  }
+  const opaqueUltra = resolveTeamWorkerLaunchDiagnostics({
+    existingRaw: '-c model_reasoning_effort="ultra"',
+    preferredReasoning: 'max',
+  });
+  if (opaqueUltra.reasoningSource !== 'explicit' || opaqueUltra.actualReasoning !== undefined) {
+    throw new Error('Team must preserve opaque explicit ultra without recognizing it');
+  }
+
+  assertInstalledTeamSkillContract(
+    readFileSync(join(packageRoot, 'skills/team/SKILL.md')),
+    readFileSync(join(packageRoot, 'plugins/oh-my-codex/skills/team/SKILL.md')),
+  );
+  assertInstalledPluginSurface(packageRoot);
+}
+
+function smokeInstalledRootReasoningRejections(omxPath: string, cwd: string): void {
+  const codexHome = mkdtempSync(join(tmpdir(), 'omx-packed-root-reasoning-'));
+  try {
+    const env = buildPackedProbeEnv({ CODEX_HOME: codexHome });
+    const configPath = join(codexHome, 'config.toml');
+    const usageResult = spawnSync(omxPath, ['reasoning'], { cwd, encoding: 'utf-8', env });
+    if (usageResult.status !== 0) {
+      throw new Error(`omx reasoning usage must exit 0, received ${String(usageResult.status)}`);
+    }
+    assertInstalledRootReasoningHelp(String(usageResult.stdout ?? ''));
+    const maxResult = spawnSync(omxPath, ['reasoning', 'max'], { cwd, encoding: 'utf-8', env });
+    assertInstalledRootReasoningRejection('max', maxResult, undefined, existsSync(configPath) ? readFileSync(configPath, 'utf-8') : undefined);
+
+    const originalConfig = 'model = "unchanged-root-model"\n';
+    writeFileSync(configPath, originalConfig);
+    const ultraResult = spawnSync(omxPath, ['reasoning', 'ultra'], { cwd, encoding: 'utf-8', env });
+    assertInstalledRootReasoningRejection('ultra', ultraResult, originalConfig, readFileSync(configPath, 'utf-8'));
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+}
+
+export interface FakeCodexLaunch {
+  argv: string[];
+  cwd: string;
+  hasResumeSqlite: boolean;
+  OMX_NOTIFY_TEMP_CONTRACT: string | null;
+  OMX_TEAM_WORKER_LAUNCH_ARGS: string | null;
+}
+
+export function parseFakeCodexLaunches(capture: string): FakeCodexLaunch[] {
+  const trimmed = capture.trim();
+  if (!trimmed) return [];
+  return trimmed.split('\n').map((line) => {
+    const launch: unknown = JSON.parse(line);
+    if (!isJsonRecord(launch)
+      || !Array.isArray(launch.argv)
+      || launch.argv.some((arg) => typeof arg !== 'string')
+      || typeof launch.cwd !== 'string'
+      || typeof launch.hasResumeSqlite !== 'boolean'
+      || (launch.OMX_NOTIFY_TEMP_CONTRACT !== null && typeof launch.OMX_NOTIFY_TEMP_CONTRACT !== 'string')
+      || (launch.OMX_TEAM_WORKER_LAUNCH_ARGS !== null && typeof launch.OMX_TEAM_WORKER_LAUNCH_ARGS !== 'string')) {
+      throw new Error('fake Codex capture did not contain a valid launch record');
+    }
+    return {
+      argv: launch.argv,
+      cwd: launch.cwd,
+      hasResumeSqlite: launch.hasResumeSqlite,
+      OMX_NOTIFY_TEMP_CONTRACT: launch.OMX_NOTIFY_TEMP_CONTRACT,
+      OMX_TEAM_WORKER_LAUNCH_ARGS: launch.OMX_TEAM_WORKER_LAUNCH_ARGS,
+    };
+  });
+}
+
+function readFakeCodexLaunches(capturePath: string): FakeCodexLaunch[] {
+  if (!existsSync(capturePath)) return [];
+  return parseFakeCodexLaunches(readFileSync(capturePath, 'utf-8'));
+}
+
+function smokeInstalledLaunchArgumentBoundary(omxPath: string): void {
+  const smokeRoot = mkdtempSync(join(tmpdir(), 'omx-packed-launch-boundary-'));
+  const modelInstructionsPath = join(smokeRoot, 'model-instructions.md');
+  try {
+    const fakeBinDir = join(smokeRoot, 'bin');
+    const launchCwd = join(smokeRoot, 'cwd');
+    const codexHome = join(smokeRoot, 'codex-home');
+    const isolatedHome = join(smokeRoot, 'home');
+    const capturePath = join(smokeRoot, 'fake-codex-argv.jsonl');
+    mkdirSync(fakeBinDir, { recursive: true });
+    mkdirSync(launchCwd, { recursive: true });
+    mkdirSync(codexHome, { recursive: true });
+    mkdirSync(isolatedHome, { recursive: true });
+
+    const fakeCodexSource = [
+      'const { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } = require("node:fs");',
+      'const capturePath = process.env.OMX_PACKED_FAKE_CODEX_CAPTURE_PATH;',
+      'if (!capturePath) process.exit(2);',
+      'const priorLaunchCount = existsSync(capturePath) ? readFileSync(capturePath, "utf8").trim().split("\\n").filter(Boolean).length : 0;',
+      'appendFileSync(capturePath, `${JSON.stringify({',
+      '  argv: process.argv.slice(2),',
+      '  cwd: process.cwd(),',
+      '  OMX_NOTIFY_TEMP_CONTRACT: process.env.OMX_NOTIFY_TEMP_CONTRACT ?? null,',
+      '  hasResumeSqlite: existsSync(require("node:path").join(process.env.CODEX_HOME ?? "", "state_5.sqlite")),',
+      '  OMX_TEAM_WORKER_LAUNCH_ARGS: process.env.OMX_TEAM_WORKER_LAUNCH_ARGS ?? null,',
+      '})}\\n`);',
+      'if (process.env.OMX_PACKED_FAKE_CODEX_QUOTA_ON_FIRST === "1" && priorLaunchCount === 0) {',
+      '  const sessionDir = require("node:path").join(process.env.CODEX_HOME ?? "", "sessions", "2026", "07", "13");',
+      '  mkdirSync(sessionDir, { recursive: true });',
+      '  writeFileSync(require("node:path").join(sessionDir, "rollout-packed-session-123.jsonl"), "{}\\n");',
+      '  process.stderr.write("HTTP 429 quota exceeded\\n");',
+      '  process.exit(1);',
+      '}',
+    ].join('\n');
+    if (process.platform === 'win32') {
+      const fakeCodexScript = join(fakeBinDir, 'codex.cjs');
+      writeFileSync(fakeCodexScript, fakeCodexSource);
+      writeFileSync(join(fakeBinDir, 'codex.cmd'), [
+        '@echo off',
+        `"${process.execPath}" "${fakeCodexScript}" %*`,
+      ].join('\r\n'));
+    } else {
+      const fakeCodexPath = join(fakeBinDir, 'codex');
+      writeFileSync(fakeCodexPath, `#!/usr/bin/env node\n${fakeCodexSource}\n`);
+      chmodSync(fakeCodexPath, 0o755);
+    }
+
+    const pathKey = Object.keys(process.env).find((key) => key.toUpperCase() === 'PATH') ?? 'PATH';
+    const env = buildPackedProbeEnv({
+      [pathKey]: `${fakeBinDir}${delimiter}${process.env[pathKey] ?? ''}`,
+      CODEX_HOME: codexHome,
+      HOME: isolatedHome,
+      USERPROFILE: isolatedHome,
+      OMX_BYPASS_DEFAULT_SYSTEM_PROMPT: '1',
+      OMX_MODEL_INSTRUCTIONS_FILE: modelInstructionsPath,
+      OMX_LAUNCH_POLICY: 'direct',
+      OMX_PACKED_FAKE_CODEX_CAPTURE_PATH: capturePath,
+    });
+    delete env.OMX_NOTIFY_TEMP_CONTRACT;
+    delete env.OMX_TEAM_WORKER_LAUNCH_ARGS;
+    writeFileSync(modelInstructionsPath, '# Packed launch boundary instructions\n');
+
+    for (const shorthand of ['--max', '--ultra'] as const) {
+      const result = spawnSync(omxPath, [shorthand], { cwd: launchCwd, encoding: 'utf-8', env });
+      if (result.status !== 1) {
+        throw new Error(`omx ${shorthand} must reject before launching Codex, received ${String(result.status)}`);
+      }
+      assertTextIncludes(String(result.stderr ?? ''), `Unsupported OMX launch shorthand "${shorthand}".`, `omx ${shorthand} stderr`);
+      if (readFakeCodexLaunches(capturePath).length !== 0) {
+        throw new Error(`omx ${shorthand} must not launch Codex before the end-of-options marker`);
+      }
+    }
+
+    for (const expectedArgs of [
+      ['--', '--max'],
+      ['--', '--ultra'],
+      ['--', '-c', 'model_reasoning_effort=opaque-packed-smoke'],
+      ['--', '--worktree', 'post-marker-branch'],
+      ['--', '--notify-temp'],
+      ['--', '--discord'],
+      ['--', '--spark'],
+      ['--', '--hotswap'],
+      ['--', 'resume', '--project', '--codex-home', 'literal-codex-home', '--version'],
+    ]) {
+      writeFileSync(capturePath, '');
+      const result = spawnSync(omxPath, expectedArgs, {
+        cwd: launchCwd,
+        encoding: 'utf-8',
+        env,
+        timeout: PACKED_INSTALL_OPERATIONAL_PROBE_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
+      });
+      if (result.status !== 0) {
+        throw new Error(formatCommandFailure(omxPath, expectedArgs, result));
+      }
+      const launches = readFakeCodexLaunches(capturePath);
+      const launch = launches[0];
+      const expectedCodexArgs = [
+        '-c',
+        `model_instructions_file="${escapeTomlString(modelInstructionsPath)}"`,
+        ...expectedArgs,
+      ];
+      if (launches.length !== 1 || !launch) {
+        throw new Error(`omx must launch exactly one fake Codex process: ${JSON.stringify(launches)}`);
+      }
+      assert.deepStrictEqual(
+        launch.argv,
+        expectedCodexArgs,
+        'omx must inject model instructions before -- and preserve exact post-marker argument boundaries',
+      );
+      if (launch.cwd !== launchCwd) {
+        throw new Error(`omx must not change cwd for post-marker arguments: expected ${launchCwd}, received ${launch.cwd}`);
+      }
+      if (launch.OMX_NOTIFY_TEMP_CONTRACT !== null) {
+        throw new Error(`omx must not activate temporary notification routing for post-marker arguments: ${JSON.stringify(launch)}`);
+      }
+      if (launch.OMX_TEAM_WORKER_LAUNCH_ARGS !== null) {
+        throw new Error(`omx must not enable spark worker routing for post-marker arguments: ${JSON.stringify(launch)}`);
+      }
+    }
+
+    const projectOmxDir = join(launchCwd, '.omx');
+    const projectCodexHome = join(launchCwd, '.codex');
+    mkdirSync(projectOmxDir, { recursive: true });
+    mkdirSync(projectCodexHome, { recursive: true });
+    writeFileSync(join(projectOmxDir, 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+    writeFileSync(join(projectCodexHome, 'state_5.sqlite'), 'resume-only-sentinel');
+    const imageResumeEnv = { ...env };
+    delete imageResumeEnv.CODEX_HOME;
+    const imageResumeCases: Array<{ args: string[]; resumes: boolean }> = [
+      { args: ['-i', 'resume'], resumes: false },
+      { args: ['--image', 'resume'], resumes: false },
+      { args: ['--image=resume'], resumes: false },
+      { args: ['-iresume'], resumes: false },
+      { args: ['-i=resume'], resumes: false },
+      { args: ['-i', 'screenshot.png', 'resume'], resumes: false },
+      { args: ['--image', 'screenshot.png', 'resume'], resumes: false },
+      { args: ['--image=screenshot.png', 'resume'], resumes: true },
+      { args: ['-iscreenshot.png', 'resume'], resumes: true },
+      { args: ['-i=screenshot.png', 'resume'], resumes: true },
+      { args: ['-i', 'one.png', '-i', 'two.png', 'resume'], resumes: false },
+      { args: ['--image', 'one.png', '--image', 'two.png', 'resume'], resumes: false },
+      { args: ['-i', 'one.png,two.png', 'resume'], resumes: false },
+      { args: ['--image', 'one.png,two.png', 'resume'], resumes: false },
+      { args: ['--image', 'one.png', '--model', 'gpt-review', 'resume'], resumes: true },
+      { args: ['--image=one.png', '--model=gpt-review', 'resume'], resumes: true },
+    ];
+    for (const testCase of imageResumeCases) {
+      writeFileSync(capturePath, '');
+      const result = spawnSync(omxPath, ['--direct', ...testCase.args], {
+        cwd: launchCwd,
+        encoding: 'utf-8',
+        env: imageResumeEnv,
+        timeout: PACKED_INSTALL_OPERATIONAL_PROBE_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
+      });
+      assertBoundedProbeExit(`installed image resume arity ${JSON.stringify(testCase.args)}`, result, 0);
+      const launches = readFakeCodexLaunches(capturePath);
+      const launch = launches[0];
+      if (launches.length !== 1 || !launch) {
+        throw new Error(`installed image resume arity must invoke fake Codex exactly once: ${JSON.stringify(launches)}`);
+      }
+      const modelInstructionsArgs = ['-c', `model_instructions_file="${escapeTomlString(modelInstructionsPath)}"`];
+      assert.deepStrictEqual(
+        launch.argv,
+        [...testCase.args, ...modelInstructionsArgs],
+        'installed image resume arity must preserve exact Codex argv',
+      );
+      if (launch.hasResumeSqlite !== testCase.resumes) {
+        throw new Error(`installed image resume arity mismatch for ${JSON.stringify(testCase.args)}: ${JSON.stringify(launch)}`);
+      }
+    }
+
+    const packedAuthDir = join(isolatedHome, '.omx', 'auth');
+    mkdirSync(packedAuthDir, { recursive: true });
+    writeFileSync(join(packedAuthDir, 'first.json'), '{"access_token":"first-secret"}\n');
+    writeFileSync(join(packedAuthDir, 'second.json'), '{"access_token":"second-secret"}\n');
+    writeFileSync(join(packedAuthDir, 'slots.json'), JSON.stringify({
+      version: 1,
+      currentSlot: 'first',
+      slots: [
+        { slot: 'first', createdAt: 'now', updatedAt: 'now' },
+        { slot: 'second', createdAt: 'now', updatedAt: 'now' },
+      ],
+    }, null, 2));
+    writeFileSync(capturePath, '');
+    const quotaSelectors = ['--last', '--all', '--include-non-interactive'];
+    const quotaSuffix = ['--', ...quotaSelectors, '--model', 'opaque-model', 'opaque suffix'];
+    const quotaResult = spawnSync(omxPath, [
+      '--hotswap', '--direct', 'resume', ...quotaSelectors,
+      '--model', 'gpt-review', '--remote', 'ws://127.0.0.1:4500', ...quotaSuffix,
+    ], {
+      cwd: launchCwd,
+      encoding: 'utf-8',
+      env: { ...env, OMX_PACKED_FAKE_CODEX_QUOTA_ON_FIRST: '1' },
+      timeout: PACKED_INSTALL_OPERATIONAL_PROBE_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+    });
+    assertBoundedProbeExit('installed quota hotswap explicit-session retry', quotaResult, 0);
+    const quotaLaunches = readFakeCodexLaunches(capturePath);
+    const generatedInstructions = ['-c', `model_instructions_file="${escapeTomlString(modelInstructionsPath)}"`];
+    assert.deepStrictEqual(quotaLaunches.map((launch) => launch.argv), [
+      [
+        'resume', ...quotaSelectors,
+        '--model', 'gpt-review', '--remote', 'ws://127.0.0.1:4500',
+        ...generatedInstructions, ...quotaSuffix,
+      ],
+      [
+        'resume', 'packed-session-123',
+        '--model', 'gpt-review', '--remote', 'ws://127.0.0.1:4500',
+        ...generatedInstructions, ...quotaSuffix,
+      ],
+    ], 'installed quota retry must remove resume selectors only before the marker');
+
+    const twoMarkerArgs = [
+      '--direct',
+      '--',
+      '--notify-temp',
+      '--spark',
+      '--worktree',
+      'post-marker-worktree',
+      '--hotswap',
+      '--xhigh',
+      '--',
+      '--madmax',
+      '--notify-temp',
+      '--spark',
+      'trailing argument with spaces',
+      '',
+    ];
+    writeFileSync(capturePath, '');
+    const twoMarkerResult = spawnSync(omxPath, twoMarkerArgs, {
+      cwd: launchCwd,
+      encoding: 'utf-8',
+      env,
+      timeout: PACKED_INSTALL_OPERATIONAL_PROBE_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+    });
+    assertBoundedProbeExit('installed first-marker boundary launch', twoMarkerResult, 0);
+    const twoMarkerLaunches = readFakeCodexLaunches(capturePath);
+    if (twoMarkerLaunches.length !== 1 || !twoMarkerLaunches[0]) {
+      throw new Error(`installed first-marker boundary launch must invoke fake Codex exactly once: ${JSON.stringify(twoMarkerLaunches)}`);
+    }
+    const twoMarkerLaunch = twoMarkerLaunches[0];
+    assert.deepStrictEqual(twoMarkerLaunch.argv, [
+      '-c',
+      `model_instructions_file="${escapeTomlString(modelInstructionsPath)}"`,
+      ...twoMarkerArgs.slice(1),
+    ], 'the first literal -- must terminate OMX parsing and preserve every later argv element');
+    if (twoMarkerLaunch.cwd !== launchCwd) {
+      throw new Error(`the first literal -- must preserve launch cwd: expected ${launchCwd}, received ${twoMarkerLaunch.cwd}`);
+    }
+    if (twoMarkerLaunch.OMX_NOTIFY_TEMP_CONTRACT !== null) {
+      throw new Error(`the first literal -- must not activate notification routing: ${JSON.stringify(twoMarkerLaunch)}`);
+    }
+    if (twoMarkerLaunch.OMX_TEAM_WORKER_LAUNCH_ARGS !== null) {
+      throw new Error(`the first literal -- must not activate Team worker routing: ${JSON.stringify(twoMarkerLaunch)}`);
+    }
+  } finally {
+    rmSync(smokeRoot, { recursive: true, force: true });
+  }
+}
 function usage(): string {
   return [
     'Usage: node scripts/smoke-packed-install.mjs',
     '',
     'Creates an npm tarball, installs it into an isolated prefix, and smoke tests the installed omx CLI.',
-    'Release smoke validates installed CLI boot, native-hook dispatch, and the isolated setup/rerun/uninstall lifecycle; Codex trust checks run when the pinned CLI is present.',
+    'Release smoke validates installed CLI boot, native-hook dispatch, packaged artifacts, installed reasoning boundaries, and the isolated setup/rerun/uninstall lifecycle; Codex trust checks run when the pinned CLI is present.',
   ].join('\n');
 }
 
@@ -1496,14 +2272,13 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
       const payload = buildNativeHookSmokePayload(eventName, smokeCwd);
       const result = run(process.execPath, [realpathSync(hookScript)], {
         cwd: smokeCwd,
-        env: {
-          ...process.env,
+        env: buildPackedProbeEnv({
           OMX_NATIVE_HOOK_DOCTOR_SMOKE: '1',
           OMX_ROOT: join(smokeCwd, '.omx-packed-hook-root'),
           OMX_SESSION_ID: `packed-install-smoke-${eventName}`,
           OMX_SOURCE_CWD: smokeCwd,
           OMX_STARTUP_CWD: smokeCwd,
-        },
+        }),
         input: JSON.stringify(payload),
       });
       validateHookStdout(eventName, result.stdout as string);
@@ -4163,13 +4938,265 @@ export async function smokePackedHookTrustLifecycle(
   }
 }
 
-export function parseNpmPackJsonOutput(stdout: string): Array<{ filename: string }> {
+function assertBoundedProbeExit(
+  label: string,
+  result: ReturnType<typeof spawnSync>,
+  expectedStatus: number,
+): void {
+  if ((result.error as NodeJS.ErrnoException | undefined)?.code === 'ETIMEDOUT') {
+    throw new Error(`${label} exceeded ${PACKED_INSTALL_OPERATIONAL_PROBE_TIMEOUT_MS}ms`);
+  }
+  if (result.status !== expectedStatus) {
+    const detail = String(result.stderr ?? result.error?.message ?? '').trim();
+    throw new Error(`${label} must exit ${expectedStatus}, received ${String(result.status)}${detail ? `: ${detail}` : ''}`);
+  }
+}
+
+interface PackedPluginHookDelegateCall {
+  argv: string[];
+  stdin: string;
+  cwd: string;
+}
+
+function readPackedPluginHookDelegateCalls(capturePath: string): PackedPluginHookDelegateCall[] {
+  const capture = existsSync(capturePath) ? readFileSync(capturePath, 'utf-8').trim() : '';
+  if (!capture) return [];
+  return capture.split('\n').map((line) => {
+    const record: unknown = JSON.parse(line);
+    if (!isJsonRecord(record)
+      || !Array.isArray(record.argv)
+      || record.argv.some((arg) => typeof arg !== 'string')
+      || typeof record.stdin !== 'string'
+      || typeof record.cwd !== 'string') {
+      throw new Error('pinned fake plugin hook delegate did not record a valid invocation');
+    }
+    return { argv: record.argv, stdin: record.stdin, cwd: record.cwd };
+  });
+}
+
+function smokeInstalledPluginHookLauncher(packageRoot: string, omxPath: string): void {
+  const smokeRoot = mkdtempSync(join(tmpdir(), 'omx-packed-plugin-hook-smoke-'));
+  const hookDir = join(packageRoot, 'plugins', 'oh-my-codex', 'hooks');
+  const hookLauncherPath = join(hookDir, 'codex-native-hook.mjs');
+  const pinnedLauncherPath = join(hookDir, 'omx-command.json');
+  const originalPinnedLauncher = existsSync(pinnedLauncherPath) ? readFileSync(pinnedLauncherPath) : undefined;
+  const delegatePath = join(smokeRoot, 'pinned-fake-delegate.cjs');
+  const capturePath = join(smokeRoot, 'pinned-fake-delegate.jsonl');
+  const hookCwd = join(smokeRoot, 'cwd');
+  const home = join(smokeRoot, 'home');
+  const codexHome = join(smokeRoot, 'codex-home');
+  const sessionId = 'packed-plugin-hook-session';
+  try {
+    mkdirSync(hookCwd, { recursive: true });
+    mkdirSync(home, { recursive: true });
+    mkdirSync(codexHome, { recursive: true });
+    writeFileSync(delegatePath, [
+      'const { appendFileSync } = require("node:fs");',
+      '(async () => {',
+      'const chunks = [];',
+      'for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));',
+      'const stdin = Buffer.concat(chunks).toString("utf8");',
+      'const payload = JSON.parse(stdin);',
+      'appendFileSync(process.env.OMX_PACKED_PLUGIN_HOOK_CAPTURE_PATH, `${JSON.stringify({ argv: process.argv.slice(2), stdin, cwd: process.cwd() })}\\n`);',
+      'if (payload.delegate_mode === "non-stop-failure") {',
+      '  process.stdout.write("delegate-failure\\n");',
+      '  process.exitCode = 23;',
+      '} else if (payload.delegate_mode === "stop-failure") {',
+      '  process.exitCode = 23;',
+      '} else if (payload.hook_event_name === "Stop") {',
+      '  process.stdout.write("{\\\"decision\\\":\\\"block\\\",\\\"reason\\\":\\\"pinned stop delegate\\\"}\\n");',
+      '} else {',
+      '  process.stdout.write("{\\\"hookSpecificOutput\\\":{\\\"additionalContext\\\":\\\"pinned non-stop delegate\\\"}}\\n");',
+      '}',
+      '})().catch((error) => { console.error(error); process.exitCode = 1; });',
+      '',
+    ].join('\n'));
+    writeFileSync(pinnedLauncherPath, JSON.stringify({
+      command: process.execPath,
+      argsPrefix: [delegatePath],
+    }));
+
+    const env = buildPackedProbeEnv({
+      HOME: home,
+      USERPROFILE: home,
+      CODEX_HOME: codexHome,
+      OMX_AUTO_UPDATE: '0',
+      OMX_NOTIFY_FALLBACK: '0',
+      OMX_HOOK_DERIVED_SIGNALS: '0',
+      OMX_ROOT: join(smokeRoot, '.omx-root'),
+      OMX_STATE_ROOT: '',
+      OMX_TEAM_STATE_ROOT: '',
+      OMX_TEAM_WORKER: '',
+      OMX_TEAM_WORKER_LAUNCH_ARGS: '',
+      OMX_NOTIFY_TEMP_CONTRACT: '',
+      OMX_ENTRY_PATH: omxPath,
+      OMX_CODEX_LAUNCH_ID: 'packed-plugin-hook-launch',
+      OMX_PACKED_PLUGIN_HOOK_CAPTURE_PATH: capturePath,
+    });
+    const runProbe = (
+      name: string,
+      payload: Record<string, unknown>,
+      expectedStatus: number,
+      expectedStdout: string,
+    ): void => {
+      writeFileSync(capturePath, '');
+      const stdin = JSON.stringify(payload);
+      const result = spawnSync(process.execPath, [hookLauncherPath], {
+        cwd: hookCwd,
+        encoding: 'utf-8',
+        env,
+        input: stdin,
+        timeout: PACKED_INSTALL_OPERATIONAL_PROBE_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
+      });
+      assertBoundedProbeExit(`installed plugin hook ${name}`, result, expectedStatus);
+      if (String(result.stdout ?? '') !== expectedStdout) {
+        throw new Error(`installed plugin hook ${name} stdout changed: expected ${JSON.stringify(expectedStdout)}, received ${JSON.stringify(String(result.stdout ?? ''))}`);
+      }
+      assert.deepStrictEqual(readPackedPluginHookDelegateCalls(capturePath), [{
+        argv: ['codex-native-hook'],
+        stdin,
+        cwd: hookCwd,
+      }], `installed plugin hook ${name} must forward exact delegate argv and stdin`);
+    };
+
+    runProbe('non-Stop', {
+      hook_event_name: 'UserPromptSubmit',
+      session_id: sessionId,
+      cwd: hookCwd,
+      prompt: 'packed plugin non-Stop probe',
+    }, 0, '{"hookSpecificOutput":{"additionalContext":"pinned non-stop delegate"}}\n');
+    runProbe('Stop', {
+      hook_event_name: 'Stop',
+      session_id: sessionId,
+      cwd: hookCwd,
+    }, 0, '{"decision":"block","reason":"pinned stop delegate"}\n');
+    runProbe('non-Stop delegate failure', {
+      hook_event_name: 'UserPromptSubmit',
+      session_id: sessionId,
+      cwd: hookCwd,
+      delegate_mode: 'non-stop-failure',
+    }, 23, 'delegate-failure\n');
+
+    writeFileSync(capturePath, '');
+    const failedStopInput = JSON.stringify({
+      hook_event_name: 'Stop',
+      session_id: sessionId,
+      cwd: hookCwd,
+      delegate_mode: 'stop-failure',
+    });
+    const failedStop = spawnSync(process.execPath, [hookLauncherPath], {
+      cwd: hookCwd,
+      encoding: 'utf-8',
+      env,
+      input: failedStopInput,
+      timeout: PACKED_INSTALL_OPERATIONAL_PROBE_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+    });
+    assertBoundedProbeExit('installed plugin hook Stop delegate failure', failedStop, 0);
+    const failedStopOutput: unknown = JSON.parse(String(failedStop.stdout ?? ''));
+    if (!isJsonRecord(failedStopOutput)) {
+      throw new Error('installed plugin hook Stop delegate failure must emit JSON fallback output');
+    }
+    assert.deepStrictEqual({
+      decision: failedStopOutput.decision,
+      stopReason: failedStopOutput.stopReason,
+    }, {
+      decision: 'block',
+      stopReason: 'plugin_stop_hook_launcher_exit',
+    });
+    assertTextMatches(
+      String(failedStopOutput.systemMessage ?? ''),
+      /codex-native-hook exited with code 23/,
+      'installed plugin hook Stop delegate failure',
+    );
+    assert.deepStrictEqual(readPackedPluginHookDelegateCalls(capturePath), [{
+      argv: ['codex-native-hook'],
+      stdin: failedStopInput,
+      cwd: hookCwd,
+    }], 'installed plugin hook Stop failure must still delegate exact argv and stdin');
+  } finally {
+    if (originalPinnedLauncher === undefined) {
+      rmSync(pinnedLauncherPath, { force: true });
+    } else {
+      writeFileSync(pinnedLauncherPath, originalPinnedLauncher);
+    }
+    rmSync(smokeRoot, { recursive: true, force: true });
+  }
+}
+
+function smokeInstalledMcpTargets(omxPath: string): void {
+  const smokeRoot = mkdtempSync(join(tmpdir(), 'omx-packed-mcp-smoke-'));
+  const home = join(smokeRoot, 'home');
+  const codexHome = join(smokeRoot, 'codex-home');
+  const mcpInitialize = `${JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'packed-install-smoke', version: '1' },
+    },
+  })}\n`;
+  try {
+    mkdirSync(home, { recursive: true });
+    mkdirSync(codexHome, { recursive: true });
+    const env = buildPackedProbeEnv({
+      HOME: home,
+      USERPROFILE: home,
+      CODEX_HOME: codexHome,
+      OMX_AUTO_UPDATE: '0',
+      OMX_NOTIFY_FALLBACK: '0',
+      OMX_HOOK_DERIVED_SIGNALS: '0',
+      OMX_ROOT: join(smokeRoot, '.omx-root'),
+      OMX_STATE_ROOT: '',
+      OMX_TEAM_STATE_ROOT: '',
+      OMX_TEAM_WORKER: '',
+      OMX_TEAM_WORKER_LAUNCH_ARGS: '',
+      OMX_NOTIFY_TEMP_CONTRACT: '',
+    });
+    for (const [serverName, target, expectedServerName] of PACKED_INSTALL_PLUGIN_MCP_TARGETS) {
+      const result = spawnSync(omxPath, ['mcp-serve', target], {
+        cwd: smokeRoot,
+        encoding: 'utf-8',
+        env,
+        input: mcpInitialize,
+        timeout: PACKED_INSTALL_OPERATIONAL_PROBE_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
+      });
+      assertBoundedProbeExit(`installed MCP target ${serverName}`, result, 0);
+      const responseText = String(result.stdout ?? '').trim();
+      if (!responseText) {
+        throw new Error(`installed MCP target ${serverName} did not respond before EOF`);
+      }
+      const responses = responseText.split('\n').map((line) => {
+        try {
+          return JSON.parse(line) as unknown;
+        } catch (error) {
+          throw new Error(`installed MCP target ${serverName} emitted non-JSON stdout: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      });
+      const initializeResponse = responses.find((response) => isJsonRecord(response) && response.id === 1);
+      if (!isJsonRecord(initializeResponse)
+        || !isJsonRecord(initializeResponse.result)
+        || !isJsonRecord(initializeResponse.result.serverInfo)
+        || initializeResponse.result.serverInfo.name !== expectedServerName) {
+        throw new Error(`installed MCP target ${serverName} must initialize ${expectedServerName}, received ${JSON.stringify(initializeResponse)}`);
+      }
+    }
+  } finally {
+    rmSync(smokeRoot, { recursive: true, force: true });
+  }
+}
+
+export function parseNpmPackJsonOutput(stdout: string): PackedInstallNpmPackResult[] {
   const start = stdout.lastIndexOf('\n[');
   const jsonText = (start >= 0 ? stdout.slice(start + 1) : stdout).trim();
   if (!jsonText.startsWith('[')) {
     throw new Error(`npm pack did not return JSON output: ${stdout.trim()}`);
   }
-  return JSON.parse(jsonText) as Array<{ filename: string }>;
+  return JSON.parse(jsonText) as PackedInstallNpmPackResult[];
 }
 
 async function main(): Promise<void> {
@@ -4179,6 +5206,19 @@ async function main(): Promise<void> {
   const tempRoot = mkdtempSync(join(tmpdir(), 'omx-packed-install-'));
   const prefixDir = join(tempRoot, 'prefix');
   mkdirSync(prefixDir, { recursive: true });
+  const installHome = join(tempRoot, 'home');
+  const installCodexHome = join(tempRoot, 'codex-home');
+  const installNpmCache = join(tempRoot, 'npm-cache');
+  mkdirSync(installHome, { recursive: true });
+  mkdirSync(installCodexHome, { recursive: true });
+  mkdirSync(installNpmCache, { recursive: true });
+  const installEnv = buildPackedProbeEnv({
+    HOME: installHome,
+    USERPROFILE: installHome,
+    CODEX_HOME: installCodexHome,
+    npm_config_cache: installNpmCache,
+    NPM_CONFIG_CACHE: installNpmCache,
+  });
 
   let tarballPath: string | undefined;
   try {
@@ -4188,15 +5228,27 @@ async function main(): Promise<void> {
 
     const pack = run('npm', ['pack', '--json'], { cwd: repoRoot });
     const packOutput = parseNpmPackJsonOutput(pack.stdout as string);
-    const tarballName = packOutput[0]?.filename;
+    const packedPackage = packOutput[0];
+    const tarballName = packedPackage?.filename;
     if (!tarballName) throw new Error('npm pack did not return a tarball filename');
+    if (!packedPackage.files) throw new Error('npm pack did not return file metadata');
+    assertPackedInstallFileMetadata(packedPackage.files);
     tarballPath = join(repoRoot, tarballName);
 
-    run('npm', ['install', '-g', tarballPath, '--prefix', prefixDir], { cwd: repoRoot });
+    run('npm', ['install', '-g', tarballPath, '--prefix', prefixDir], { cwd: repoRoot, env: installEnv });
+
+    const globalNodeModules = resolveGlobalNodeModules(prefixDir);
+    const packageRoot = join(globalNodeModules, 'oh-my-codex');
+    assertInstalledRequiredArtifacts(packageRoot);
+    await assertInstalledReasoningArtifacts(packageRoot);
 
     const omxPath = join(prefixDir, process.platform === 'win32' ? '' : 'bin', npmBinName('omx'));
+    smokeInstalledRootReasoningRejections(omxPath, repoRoot);
+    smokeInstalledLaunchArgumentBoundary(omxPath);
+    smokeInstalledPluginHookLauncher(packageRoot, omxPath);
+    smokeInstalledMcpTargets(omxPath);
     for (const argv of PACKED_INSTALL_SMOKE_CORE_COMMANDS) {
-      run(omxPath, argv, { cwd: repoRoot });
+      run(omxPath, argv, { cwd: repoRoot, env: installEnv });
     }
     smokeInstalledNativeHookDist(prefixDir);
     const lifecycle = await smokePackedHookTrustLifecycle(omxPath);

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -15,7 +15,9 @@ import {
   splitWorkerLaunchArgs,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
   resolveTeamLowComplexityDefaultModel,
+  type TeamReasoningEffort,
 } from '../model-contract.js';
+import type { PerAgentReasoningEffort } from '../../config/models.js';
 
 
 function expectedLowComplexityModel(): string {
@@ -229,17 +231,20 @@ describe('team model contract', () => {
     assert.equal(resolveAgentReasoningEffort('does-not-exist'), undefined);
   });
 
-  it('maps worker roles through configured per-agent reasoning overrides', async () => {
+  it('maps worker roles through configured per-agent reasoning overrides and invalid fallback', async () => {
     const codexHome = await mkdtemp(join(tmpdir(), 'omx-model-contract-reasoning-'));
     try {
       await writeFile(join(codexHome, '.omx-config.json'), JSON.stringify({
         agentReasoning: {
-          architect: 'xhigh',
+          architect: 'MAX',
+          critic: 'ultra',
+          explore: 'future',
         },
       }));
 
-      assert.equal(resolveAgentReasoningEffort('architect', codexHome), 'xhigh');
+      assert.equal(resolveAgentReasoningEffort('architect', codexHome), 'max');
       assert.equal(resolveAgentReasoningEffort('critic', codexHome), 'high');
+      assert.equal(resolveAgentReasoningEffort('explore', codexHome), 'low');
     } finally {
       await rm(codexHome, { recursive: true, force: true });
     }
@@ -444,6 +449,134 @@ describe('resolveTeamWorkerLaunchArgs - teammate reasoning allocation', () => {
     assert.equal(matches.length, 1, 'reasoning override should appear exactly once');
   });
 
+  it('preserves exact reasoning tokens while normalizing direct worker policy', () => {
+    const existingRaw = `-a on-request -c 'model_reasoning_effort = "MAX"'`;
+
+    assert.deepEqual(
+      resolveTeamWorkerLaunchArgs({ existingRaw, preferredReasoning: 'low' }),
+      ['--ask-for-approval', 'on-request', '-c', 'model_reasoning_effort = "MAX"'],
+    );
+    assert.deepEqual(
+      resolveTeamWorkerLaunchArgs({
+        existingRaw,
+        inheritedArgs: ['-c', 'model_reasoning_effort=future-tier'],
+        preferredReasoning: 'low',
+      }),
+      ['--ask-for-approval', 'on-request', '-c', 'model_reasoning_effort=future-tier'],
+    );
+  });
+
+  it('keeps TeamReasoningEffort exactly aligned with configured per-agent reasoning', () => {
+    const configuredReasoning: PerAgentReasoningEffort = 'max';
+    const teamReasoning: TeamReasoningEffort = configuredReasoning;
+    const exactConfiguredReasoning: PerAgentReasoningEffort = teamReasoning;
+    assert.equal(exactConfiguredReasoning, 'max');
+
+    // @ts-expect-error Team reasoning excludes unsupported configured ultra.
+    const unsupportedReasoning: TeamReasoningEffort = 'ultra';
+    void unsupportedReasoning;
+  });
+
+  it('applies the full frozen Team reasoning precedence and diagnostics matrix', () => {
+    const cases: Array<{
+      name: string;
+      existingRaw?: string;
+      inheritedArgs?: string[];
+      preferredReasoning?: TeamReasoningEffort;
+      expectedReasoningToken?: string;
+      expectedSource: 'explicit' | 'role-default' | 'none';
+      expectedActual?: TeamReasoningEffort;
+    }> = [
+      {
+        name: 'no explicit or role default',
+        expectedSource: 'none',
+      },
+      {
+        name: 'configured max role default',
+        preferredReasoning: 'max',
+        expectedReasoningToken: 'model_reasoning_effort="max"',
+        expectedSource: 'role-default',
+        expectedActual: 'max',
+      },
+      {
+        name: 'known environment explicit reasoning',
+        existingRaw: '-c model_reasoning_effort=MAX',
+        preferredReasoning: 'max',
+        expectedReasoningToken: 'model_reasoning_effort=MAX',
+        expectedSource: 'explicit',
+        expectedActual: 'max',
+      },
+      {
+        name: 'opaque environment ultra reasoning',
+        existingRaw: "-c model_reasoning_effort='ultra'",
+        preferredReasoning: 'max',
+        expectedReasoningToken: "model_reasoning_effort='ultra'",
+        expectedSource: 'explicit',
+      },
+      {
+        name: 'known inherited explicit reasoning',
+        inheritedArgs: ['-c', 'model_reasoning_effort = "MAX"'],
+        preferredReasoning: 'low',
+        expectedReasoningToken: 'model_reasoning_effort = "MAX"',
+        expectedSource: 'explicit',
+        expectedActual: 'max',
+      },
+      {
+        name: 'opaque inherited future reasoning',
+        inheritedArgs: ['-c', 'model_reasoning_effort=future-tier'],
+        preferredReasoning: 'low',
+        expectedReasoningToken: 'model_reasoning_effort=future-tier',
+        expectedSource: 'explicit',
+      },
+      {
+        name: 'inherited explicit reasoning over environment explicit reasoning',
+        existingRaw: '-c model_reasoning_effort=low',
+        inheritedArgs: ['-c', 'model_reasoning_effort=MAX'],
+        preferredReasoning: 'high',
+        expectedReasoningToken: 'model_reasoning_effort=MAX',
+        expectedSource: 'explicit',
+        expectedActual: 'max',
+      },
+      {
+        name: 'last environment explicit reasoning',
+        existingRaw: '-c model_reasoning_effort=low -c model_reasoning_effort=max',
+        preferredReasoning: 'high',
+        expectedReasoningToken: 'model_reasoning_effort=max',
+        expectedSource: 'explicit',
+        expectedActual: 'max',
+      },
+      {
+        name: 'last inherited explicit reasoning over environment reasoning',
+        existingRaw: '-c model_reasoning_effort=low',
+        inheritedArgs: [
+          '-c',
+          'model_reasoning_effort=high',
+          '-c',
+          'model_reasoning_effort=future-tier',
+        ],
+        preferredReasoning: 'max',
+        expectedReasoningToken: 'model_reasoning_effort=future-tier',
+        expectedSource: 'explicit',
+      },
+    ];
+
+    for (const testCase of cases) {
+      const diagnostics = resolveTeamWorkerLaunchDiagnostics({
+        existingRaw: testCase.existingRaw,
+        inheritedArgs: testCase.inheritedArgs,
+        preferredReasoning: testCase.preferredReasoning,
+      });
+
+      assert.deepEqual(
+        diagnostics.actualLaunchArgs,
+        testCase.expectedReasoningToken ? ['-c', testCase.expectedReasoningToken] : [],
+        testCase.name,
+      );
+      assert.equal(diagnostics.reasoningSource, testCase.expectedSource, testCase.name);
+      assert.equal(diagnostics.actualReasoning, testCase.expectedActual, testCase.name);
+      assert.equal(diagnostics.requestedDefaultReasoning, testCase.preferredReasoning, testCase.name);
+    }
+  });
   it('does not inject thinking when model is explicit but reasoning is omitted', () => {
     const result = resolveTeamWorkerLaunchArgs({
       existingRaw: '--model claude-opus-4',

--- a/src/team/__tests__/worktree.test.ts
+++ b/src/team/__tests__/worktree.test.ts
@@ -51,6 +51,13 @@ describe('worktree parser', () => {
     assert.deepEqual(parsed.remainingArgs, ['team', '2:executor', 'task']);
   });
 
+  it('does not parse worktree flags after -- and preserves the suffix', () => {
+    const args = ['--', '--worktree', 'post-marker-branch'];
+    const parsed = parseWorktreeMode(args);
+    assert.deepEqual(parsed.mode, { enabled: false });
+    assert.deepEqual(parsed.remainingArgs, args);
+  });
+
   it('keeps team args flag-free so the CLI can apply automatic default worktrees', () => {
     const parsed = parseWorktreeMode(['ralph', '2:executor', 'task']);
     assert.deepEqual(parsed.mode, { enabled: false });

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -6,6 +6,7 @@ import {
   getMainDefaultModel,
   getSparkDefaultModel,
   getStandardDefaultModel,
+  type PerAgentReasoningEffort,
 } from '../config/models.js';
 
 const MADMAX_FLAG = '--madmax';
@@ -29,7 +30,7 @@ const LOW_COMPLEXITY_AGENT_TYPES = new Set([
 
 // Canonical default only; effective low-complexity resolution flows through resolveTeamLowComplexityDefaultModel().
 export const TEAM_LOW_COMPLEXITY_DEFAULT_MODEL = DEFAULT_SPARK_MODEL;
-export type TeamReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
+export type TeamReasoningEffort = PerAgentReasoningEffort;
 export type TeamWorkerLaunchPolicyKind = 'none' | 'bypass' | 'direct-policy';
 export type TeamWorkerLaunchPolicyClassification = TeamWorkerLaunchPolicyKind | 'mixed-policy';
 
@@ -136,7 +137,7 @@ function normalizeOptionalModel(model?: string | null): string | undefined {
 function normalizeOptionalReasoning(reasoning?: TeamReasoningEffort | string | null): TeamReasoningEffort | undefined {
   if (typeof reasoning !== 'string') return undefined;
   const normalized = reasoning.trim().toLowerCase();
-  if (normalized === 'low' || normalized === 'medium' || normalized === 'high' || normalized === 'xhigh') {
+  if (normalized === 'low' || normalized === 'medium' || normalized === 'high' || normalized === 'xhigh' || normalized === 'max') {
     return normalized;
   }
   return undefined;
@@ -161,9 +162,8 @@ function resolveTeamWorkerLaunchDiagnosticsFromParts(params: {
   const fallbackModel = normalizeOptionalModel(params.fallbackModel);
   const actualParsed = parseTeamWorkerLaunchArgs(params.actualLaunchArgs);
   const requestedDefaultReasoning = normalizeOptionalReasoning(params.preferredReasoning);
-  const explicitReasoning = extractReasoningEffort(
-    params.envParsed.reasoningOverride ?? params.inheritedParsed.reasoningOverride,
-  );
+  const explicitReasoningOverride = params.inheritedParsed.reasoningOverride
+    ?? params.envParsed.reasoningOverride;
   const selectedModel = normalizeOptionalModel(actualParsed.modelOverride);
 
   return {
@@ -180,7 +180,7 @@ function resolveTeamWorkerLaunchDiagnosticsFromParts(params: {
           : selectedModel
             ? 'fallback'
             : 'none',
-    reasoningSource: explicitReasoning ? 'explicit' : requestedDefaultReasoning ? 'role-default' : 'none',
+    reasoningSource: explicitReasoningOverride ? 'explicit' : requestedDefaultReasoning ? 'role-default' : 'none',
     inheritedParentModel: Boolean(inheritedModel) && Boolean(selectedModel) && selectedModel === inheritedModel,
     actualLaunchArgs: [...params.actualLaunchArgs],
   };
@@ -190,13 +190,25 @@ function resolveTeamWorkerLaunchDiagnosticsFromParts(params: {
  * Tokenize OMX_TEAM_WORKER_LAUNCH_ARGS without evaluating shell syntax.
  * Quoting and escaping are intentionally limited to this transport grammar.
  */
-export function splitWorkerLaunchArgs(raw: string | undefined): string[] {
+interface WorkerLaunchArgToken {
+  value: string;
+  source: string;
+}
+
+function tokenizeWorkerLaunchArgs(raw: string | undefined): WorkerLaunchArgToken[] {
   if (raw === undefined || raw === '') return [];
 
-  const args: string[] = [];
+  const args: WorkerLaunchArgToken[] = [];
   let token = '';
   let tokenStarted = false;
+  let tokenStart = 0;
   let quote: 'single' | 'double' | null = null;
+
+  const pushToken = (end: number): void => {
+    args.push({ value: token, source: raw.slice(tokenStart, end) });
+    token = '';
+    tokenStarted = false;
+  };
 
   for (let index = 0; index < raw.length; index += 1) {
     const character = raw[index]!;
@@ -219,13 +231,10 @@ export function splitWorkerLaunchArgs(raw: string | undefined): string[] {
     }
 
     if (/\s/u.test(character)) {
-      if (tokenStarted) {
-        args.push(token);
-        token = '';
-        tokenStarted = false;
-      }
+      if (tokenStarted) pushToken(index);
       continue;
     }
+    if (!tokenStarted) tokenStart = index;
     if (character === "'") {
       quote = 'single';
       tokenStarted = true;
@@ -248,8 +257,48 @@ export function splitWorkerLaunchArgs(raw: string | undefined): string[] {
   if (quote !== null) {
     throw teamWorkerLaunchArgsError('OMX_TEAM_WORKER_LAUNCH_ARGS', 'unterminated quote');
   }
-  if (tokenStarted) args.push(token);
+  if (tokenStarted) pushToken(raw.length);
   return args;
+}
+
+function extractExactEnvironmentReasoningOverride(raw: string | undefined): string | null {
+  const tokens = tokenizeWorkerLaunchArgs(raw);
+  let reasoningOverride: string | null = null;
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index]!;
+    if (token.value === '--') break;
+    if (token.value !== CONFIG_FLAG) continue;
+
+    const configValue = tokens[index + 1];
+    if (!configValue) continue;
+    index += 1;
+    if (!isReasoningOverride(configValue.value)) continue;
+
+    const startsWithGroupingQuote = configValue.source.startsWith('"') || configValue.source.startsWith("'");
+    reasoningOverride = startsWithGroupingQuote ? configValue.value : configValue.source;
+  }
+
+  return reasoningOverride;
+}
+
+function restoreExactEnvironmentReasoningOverride(args: string[], raw: string | undefined): string[] {
+  const exactReasoningOverride = extractExactEnvironmentReasoningOverride(raw);
+  if (exactReasoningOverride === null) return args;
+
+  let reasoningValueIndex: number | null = null;
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === '--') break;
+    if (args[index] !== CONFIG_FLAG || !isReasoningOverride(args[index + 1] ?? '')) continue;
+    reasoningValueIndex = index + 1;
+    index += 1;
+  }
+  if (reasoningValueIndex !== null) args[reasoningValueIndex] = exactReasoningOverride;
+  return args;
+}
+
+export function splitWorkerLaunchArgs(raw: string | undefined): string[] {
+  return tokenizeWorkerLaunchArgs(raw).map((token) => token.value);
 }
 
 /** Serialize worker launch arguments for reversible environment transport. */
@@ -503,7 +552,7 @@ export function normalizeTeamWorkerLaunchArgs(
       : null);
   const selectedModelProvider = preferredModelProviderOverride ?? parsed.modelProviderOverride;
   if (selectedModelProvider) normalized.push(CONFIG_FLAG, canonicalizeConfigStringOverride(selectedModelProvider, MODEL_PROVIDER_KEY));
-  if (selectedReasoning) normalized.push(CONFIG_FLAG, canonicalizeConfigStringOverride(selectedReasoning, REASONING_KEY));
+  if (selectedReasoning) normalized.push(CONFIG_FLAG, selectedReasoning);
 
   const selectedModel = normalizeOptionalModel(preferredModel) ?? normalizeOptionalModel(parsed.modelOverride);
   if (selectedModel) normalized.push(MODEL_FLAG, selectedModel);
@@ -531,7 +580,10 @@ function selectTeamWorkerModel(params: {
 }
 
 export function resolveTeamWorkerLaunchArgs(options: ResolveTeamWorkerLaunchArgsOptions): string[] {
-  const envArgs = splitWorkerLaunchArgs(options.existingRaw);
+  const envArgs = restoreExactEnvironmentReasoningOverride(
+    splitWorkerLaunchArgs(options.existingRaw),
+    options.existingRaw,
+  );
   const inheritedArgs = options.inheritedArgs ?? [];
   const envParsed = parseTeamWorkerLaunchArgs(envArgs, 'OMX_TEAM_WORKER_LAUNCH_ARGS');
   if (envParsed.wantsBypass && envParsed.policyKind === 'direct-policy') {
@@ -567,7 +619,10 @@ export function resolveTeamWorkerLaunchArgs(options: ResolveTeamWorkerLaunchArgs
 export function resolveTeamWorkerLaunchDiagnostics(
   options: ResolveTeamWorkerLaunchArgsOptions & { requestedAgentType?: string },
 ): ResolvedTeamWorkerLaunchDiagnostics {
-  const envArgs = splitWorkerLaunchArgs(options.existingRaw);
+  const envArgs = restoreExactEnvironmentReasoningOverride(
+    splitWorkerLaunchArgs(options.existingRaw),
+    options.existingRaw,
+  );
   const inheritedArgs = options.inheritedArgs ?? [];
   const envParsed = parseTeamWorkerLaunchArgs(envArgs, 'OMX_TEAM_WORKER_LAUNCH_ARGS');
   const inheritedParsed = parseTeamWorkerLaunchArgs(inheritedArgs, 'inherited leader worker launch arguments');

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -308,6 +308,10 @@ export function parseWorktreeMode(args: string[]): ParsedWorktreeMode {
     const rawArg = args[i];
     const arg = String(rawArg || '');
 
+    if (arg === '--') {
+      remaining.push(...args.slice(i));
+      break;
+    }
     if (arg === '--worktree' || arg === '-w') {
       // Peek at the next argument: if it looks like a git branch name (not a
       // flag and not a team worker spec like "3:debugger"), consume it as the


### PR DESCRIPTION
## Summary

Implements issue #3141 with exact capability-dependent `max` support only on per-agent/native/Team surfaces. Root reasoning remains `low|medium|high|xhigh`; there is no `--max`; `omx reasoning max` remains unsupported; configured `ultra` keeps its existing fallback; raw explicit reasoning remains opaque; and `max` is never aliased or downgraded.

## Integration details

- First literal `--` terminates every OMX-owned launch parser; marker/suffix remain exact.
- Quota-driven auth-hotswap resume preserves the marker/suffix.
- Synthesized Codex options remain before the marker.
- Resume classification uses one centralized fixed/variadic Codex global option arity map.
- Current fixed globals include `--remote` and `--remote-auth-token-env`.
- Variadic `-i`/`--image` supports split, `--image=<FILE>`, `-i<FILE>`, and `-i=<FILE>` forms and consumes subsequent non-option image values.
- Values named `resume` cannot trigger resume-only preparation; a later actual positional `resume` after a terminating option remains detected.
- Installed package/plugin/MCP probes run operationally under isolated environments.

## Exact-head verification

Passed on `29c864cc00d2abbc572793fd38780fe30ca1f45e` against base `93eda27d9ec2a52ba0f563f75073c248357ad0c8`:

- full `npm test` in a dedicated isolated detached worktree: all 372 test files passed
- compiled split/attached fixed and variadic resume reproductions
- direct project-scope no-resume-history call-path regression
- hostile-environment packed-install smoke with external CODEX_HOME untouched
- no-unused, lint, native-agent, plugin sync/bundle, catalog, plugin layout 47/47, and npm pack gates
- hosted exact-head checks: 22 successes, 3 expected skipped `PR Base Guidance`, 0 failures/pending
- independent isolated exact-head Architect review: `APPROVE` / `CLEAR`, no findings

The branch is exactly one DCO signed-off commit above `dev`.

## Governance

- [ ] Owner confirmation to merge

Technical approval is complete, but owner confirmation remains the sole merge authorization. Do not merge or enable auto-merge without it.

Refs #3141

Signed-off-by: Yeachan-Heo <54757707+Yeachan-Heo@users.noreply.github.com>