### PR TITLE
fix(team): make PowerShell psmux pane creation safe

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3787,21 +3787,23 @@ describe("tmux HUD pane helpers", () => {
     assert.deepEqual(buildHudPaneCleanupTargets(["%3"], "%4"), ["%3", "%4"]);
   });
 
-  it("listCurrentWindowHudPaneIds scopes tmux pane listing to the emitting pane", () => {
+  it("listCurrentWindowHudPaneIds excludes snapshots without complete current ownership", () => {
     const calls: string[][] = [];
-    const panes = listCurrentWindowHudPaneIds("%leader", (args) => {
+    const panes = listCurrentWindowHudPaneIds("%1", (args) => {
       calls.push(args);
+      if (args.at(-1) === "#{pane_id}") return "%1\n%2\n";
       return [
-        "%leader\tcodex\tcodex",
-        "%hud\tnode\tnode /tmp/bin/omx.js hud --watch",
+        "%1\x1fcodex\x1f0\x1f0\x1f100\x1f40\x1f39\x1f100\x1f40\x1fcodex\x1f/repo\x1f0\x1f101",
+        "%2\x1fnode\x1f0\x1f40\x1f100\x1f3\x1f42\x1f100\x1f43\x1fexec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%1' node /tmp/bin/dist/cli/omx.js hud --watch\x1f/repo\x1f0\x1f202",
       ].join("\n");
     });
 
-    assert.deepEqual(panes, ["%hud"]);
-    assert.deepEqual(calls[0], [
+    assert.deepEqual(panes, []);
+    assert.deepEqual(calls[0], ["list-panes", "-t", "%1", "-F", "#{pane_id}"]);
+    assert.deepEqual(calls[1], [
       "list-panes",
       "-t",
-      "%leader",
+      "%1",
       "-F",
       [
         "#{pane_id}",
@@ -3815,38 +3817,71 @@ describe("tmux HUD pane helpers", () => {
         "#{window_height}",
         "#{pane_start_command}",
         "#{pane_current_path}",
+        "#{pane_dead}",
+        "#{pane_pid}",
       ].join("\x1f"),
     ]);
   });
 
-  it("createHudWatchPane splits from the emitting pane target when provided", () => {
+  it("createHudWatchPane rejects an incomplete synthetic source incarnation", () => {
     const calls: string[][] = [];
+    const options = new Map<string, string>();
+    let splitCreated = false;
+    let splitMarker = "";
     const paneId = createSharedHudWatchPane(
       "/repo",
       "node /repo/dist/cli/omx.js hud --watch",
-      { heightLines: 3, targetPaneId: "%leader" },
+      { heightLines: 3, targetPaneId: "%1" },
       (args) => {
         calls.push(args);
-        return "%hud\n";
+        if (args[0] === "display-message") {
+          const format = args.at(-1);
+          if (format === "#{pane_id}\t#{pane_dead}\t#{pane_pid}\t#{session_id}\t#{window_id}") {
+            return "%1\t0\t101\t$7\t@1";
+          }
+          if (format === "#{session_id}\t#{window_id}") return "$7\t@1";
+        }
+        if (args[0] === "list-panes") {
+          const format = args.at(-1);
+          const panes = splitCreated ? ["%1", "%2"] : ["%1"];
+          if (format === "#{pane_id}") return `${panes.join("\n")}\n`;
+          if (format === "#{pane_id}\t#{pane_start_command}") {
+            return [
+              "%1\tcodex",
+              `%2\tOMX_TMUX_SPLIT_OPERATION_MARKER='${splitMarker}'; export OMX_TMUX_SPLIT_OPERATION_MARKER; exec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%1' node /repo/dist/cli/omx.js hud --watch`,
+            ].join("\n");
+          }
+          if (format === "#{pane_id}\t#{pane_dead}\t#{pane_pid}") {
+            return "%1\t0\t101\n%2\t0\t202\n";
+          }
+        }
+        if (args[0] === "set-option") {
+          options.set(args[2]!, args[3]!);
+          return "";
+        }
+        if (args[0] === "show-options") return `${options.get(args.at(-1)!) ?? ""}\n`;
+        if (args[0] === "if-shell") {
+          assert.equal(args[1], "-F");
+          assert.equal(args[2], "-t");
+          assert.equal(args[3], "%1");
+          assert.match(args[4]!, /#\{pane_id\},%1/);
+          assert.match(args[4]!, /#\{pane_pid\},101/);
+          assert.match(args[4]!, /#\{session_id\},\$1/);
+          assert.match(args[4]!, /#\{window_id\},@1/);
+          splitCreated = true;
+          const marker = /OMX_TMUX_SPLIT_OPERATION_MARKER='([\w-]+)'/.exec(args[5]!);
+          const receipt = /display-message -p (__omx_hud_split_[\w-]+)/.exec(args[5]!);
+          assert.ok(marker, "guarded split must bind an operation marker");
+          assert.ok(receipt, "guarded split must emit an exact receipt");
+          splitMarker = marker[1]!;
+          return `${receipt[1]}\n`;
+        }
+        throw new Error(`unexpected tmux command: ${args.join(" ")}`);
       },
     );
 
-    assert.equal(paneId, "%hud");
-    assert.deepEqual(calls[0], [
-      "split-window",
-      "-v",
-      "-l",
-      "3",
-      "-d",
-      "-t",
-      "%leader",
-      "-c",
-      "/repo",
-      "-P",
-      "-F",
-      "#{pane_id}",
-      "node /repo/dist/cli/omx.js hud --watch",
-    ]);
+    assert.equal(paneId, null);
+    assert.equal(calls.some((args) => args[0] === "if-shell"), false);
   });
 });
 

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -97,10 +97,54 @@ async function wrapFakeTmuxWithDetachedLeader(fakeTmuxPath: string): Promise<voi
   const implementationPath = `${fakeTmuxPath}.impl`;
   await rename(fakeTmuxPath, implementationPath);
   await writeExecutable(fakeTmuxPath, `#!/bin/sh
+if [ "$1" = "display-message" ] && [ "$2" = "-p" ] && [ "$3" = "-t" ] && case "$5" in *'#{session_created}'*'#{window_id}'*'#{pane_pid}'*) true;; *) false;; esac; then
+  session=$(cat /tmp/omx-test-detached-session-name 2>/dev/null || printf omx-test)
+  printf '%s\t$1\t1\t0\t@1\t%s\t123\n' "$session" "$4"
+  exit 0
+fi
+if [ "$1" = "set-option" ] && [ "$2" = "-t" ] && [ "$4" = "@omx_instance_id" ]; then
+  printf '%s' "$5" > /tmp/omx-test-detached-owner-id
+fi
+if [ "$1" = "list-panes" ] && case "$*" in *'#{session_created}'*'#{@omx_instance_id}'*) true;; *) false;; esac; then
+  ${JSON.stringify(implementationPath)} "$@" >/dev/null 2>&1 || true
+  session=$(cat /tmp/omx-test-detached-session-name 2>/dev/null || printf omx-test)
+  owner=$(cat /tmp/omx-test-detached-owner-id 2>/dev/null || printf '')
+  printf '%%12\t0\t123\t%s\t$1\t1\t%s\n' "$session" "$owner"
+  exit 0
+fi
+if [ "$1" = "if-shell" ] && [ "$2" = "-F" ] && [ "$3" = "-t" ]; then
+  if [ -f "$0.detached-recycled" ] && [ "$4" = "%99" ]; then ${JSON.stringify(implementationPath)} __nested_hud_guard_denied__ %99 999 '$2' @2; exit 0; fi
+  ${JSON.stringify(implementationPath)} "$@" >/dev/null 2>&1 || true
+  success="$6"
+  receipt=$(printf '%s' "$success" | sed -n 's/.*\\(omx_detached_[A-Za-z0-9-]*\\).*/\\1/p')
+  case "\${OMX_TEST_DETACHED_RECYCLE:-}" in
+    split) case "$success" in *split-window*) exit 0;; esac ;;
+    finalization) case "$*" in
+      *split-window*) : > "$0.detached-split-seen" ;;
+      *"if-shell -F -t '%99'"*) if [ -f "$0.detached-split-seen" ]; then
+        ${JSON.stringify(implementationPath)} __recycled__ %99 999 '$2' @2
+        : > "$0.detached-recycled"
+        eval "set -- $success"
+        "$0" "$@" >/dev/null
+      fi ;;
+    esac ;;
+  esac
+  [ -n "$receipt" ] || exit 1
+  case "$success" in
+    *split-window*) printf '%%99\t456\t$1\t@1\t%s\n' "$receipt" ;;
+    *) printf '%s\n' "$receipt" ;;
+  esac
+  exit 0
+fi
 output=$(${JSON.stringify(implementationPath)} "$@")
 status=$?
 printf '%s' "$output"
 if [ "$status" -eq 0 ] && [ "$1" = "new-session" ]; then
+  previous=''
+  for arg in "$@"; do
+    if [ "$previous" = '-s' ]; then printf '%s' "$arg" > /tmp/omx-test-detached-session-name; break; fi
+    previous="$arg"
+  done
   for last_arg do :; done
   pane=$(printf '%s' "$output" | sed -n '1p')
   TMUX=/tmp/omx-test-tmux,1,0 TMUX_PANE="$pane" nohup /bin/sh -c "$last_arg" </dev/null >/tmp/omx-test-detached-leader.log 2>&1 &
@@ -130,10 +174,54 @@ async function createLaunchFixture(
   const tmuxImpl = join(fakeBin, 'tmux-impl');
   await writeExecutable(tmuxImpl, tmuxScript(tmuxLogPath));
   await writeExecutable(join(fakeBin, 'tmux'), `#!/bin/sh
+if [ "$1" = "display-message" ] && [ "$2" = "-p" ] && [ "$3" = "-t" ] && case "$5" in *'#{session_created}'*'#{window_id}'*'#{pane_pid}'*) true;; *) false;; esac; then
+  session=$(cat /tmp/omx-test-detached-session-name 2>/dev/null || printf omx-test)
+  printf '%s\t$1\t1\t0\t@1\t%s\t123\n' "$session" "$4"
+  exit 0
+fi
+if [ "$1" = "set-option" ] && [ "$2" = "-t" ] && [ "$4" = "@omx_instance_id" ]; then
+  printf '%s' "$5" > /tmp/omx-test-detached-owner-id
+fi
+if [ "$1" = "list-panes" ] && case "$*" in *'#{session_created}'*'#{@omx_instance_id}'*) true;; *) false;; esac; then
+  ${JSON.stringify(tmuxImpl)} "$@" >/dev/null 2>&1 || true
+  session=$(cat /tmp/omx-test-detached-session-name 2>/dev/null || printf omx-test)
+  owner=$(cat /tmp/omx-test-detached-owner-id 2>/dev/null || printf '')
+  printf '%%12\t0\t123\t%s\t$1\t1\t%s\n' "$session" "$owner"
+  exit 0
+fi
+if [ "$1" = "if-shell" ] && [ "$2" = "-F" ] && [ "$3" = "-t" ]; then
+  if [ -f "$0.detached-recycled" ] && [ "$4" = "%99" ]; then ${JSON.stringify(tmuxImpl)} __nested_hud_guard_denied__ %99 999 '$2' @2; exit 0; fi
+  ${JSON.stringify(tmuxImpl)} "$@" >/dev/null 2>&1 || true
+  success="$6"
+  receipt=$(printf '%s' "$success" | sed -n 's/.*\\(omx_detached_[A-Za-z0-9-]*\\).*/\\1/p')
+  case "\${OMX_TEST_DETACHED_RECYCLE:-}" in
+    split) case "$success" in *split-window*) exit 0;; esac ;;
+    finalization) case "$*" in
+      *split-window*) : > "$0.detached-split-seen" ;;
+      *"if-shell -F -t '%99'"*) if [ -f "$0.detached-split-seen" ]; then
+        ${JSON.stringify(tmuxImpl)} __recycled__ %99 999 '$2' @2
+        : > "$0.detached-recycled"
+        eval "set -- $success"
+        "$0" "$@" >/dev/null
+      fi ;;
+    esac ;;
+  esac
+  [ -n "$receipt" ] || exit 1
+  case "$success" in
+    *split-window*) printf '%%99\t456\t$1\t@1\t%s\n' "$receipt" ;;
+    *) printf '%s\n' "$receipt" ;;
+  esac
+  exit 0
+fi
 output=$(${JSON.stringify(tmuxImpl)} "$@")
 status=$?
 printf '%s' "$output"
 if [ "$status" -eq 0 ] && [ "$1" = "new-session" ]; then
+  previous=''
+  for arg in "$@"; do
+    if [ "$previous" = '-s' ]; then printf '%s' "$arg" > /tmp/omx-test-detached-session-name; break; fi
+    previous="$arg"
+  done
   for last_arg do :; done
   pane=$(printf '%s' "$output" | sed -n '1p')
   TMUX=/tmp/omx-test-tmux,1,0 TMUX_PANE="$pane" nohup /bin/sh -c "$last_arg" </dev/null >/tmp/omx-test-detached-leader.log 2>&1 &
@@ -815,7 +903,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       assert.match(tmuxLog, /tmux:new-session /);
-      assert.match(tmuxLog, /tmux:split-window /);
+      assert.match(tmuxLog, /tmux:if-shell -F -t %12 .*split-window/);
       assert.doesNotMatch(tmuxLog, /tmux:attach-session/);
       assert.doesNotMatch(result.stderr, /failed to attach detached tmux session/);
     } finally {
@@ -1172,7 +1260,9 @@ exit 0
         registryEntries[1]!.detached_launch_context,
         'independent launches must get distinct active-detached lock identities',
       );
-      assert.equal((await readdir(join(runs, 'active-detached'))).length, 2);
+      const activeDetachedEntries = await readdir(join(runs, 'active-detached'));
+      assert.equal(activeDetachedEntries.filter((entry) => entry.endsWith('.json')).length, 2);
+      assert.equal(activeDetachedEntries.filter((entry) => entry.endsWith('.lock')).length, 0);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal((tmuxLog.match(/tmux:new-session/g) || []).length, 2);
@@ -1215,6 +1305,46 @@ exit 0
       assert.equal(second.status, 0, second.error || second.stderr || second.stdout);
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal((tmuxLog.match(/tmux:new-session/g) || []).length, 2);
+    } finally {
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
+    }
+  });
+
+  it('denies detached HUD finalization when the receipted pane id is recycled', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-detached-hud-recycle-'));
+    try {
+      const { env, tmuxLogPath } = await createLaunchFixture(
+        wd,
+        (logPath) => `#!/bin/sh
+printf 'tmux:%s\n' "$*" >> "${logPath}"
+case "$1" in
+  -V) printf 'tmux 3.4\n'; exit 0 ;;
+  has-session) exit 1 ;;
+  new-session) printf '%%12\n'; exit 0 ;;
+  split-window) printf '%%99\n'; exit 0 ;;
+  display-message) printf '0\n'; exit 0 ;;
+  show-options) printf 'off\n'; exit 0 ;;
+  set-option|set-hook|attach-session|kill-session|run-shell|resize-pane) exit 0 ;;
+esac
+exit 0
+`,
+      );
+      const result = runOmx(wd, ['--madmax', '--tmux'], {
+        ...env,
+        OMX_LAUNCH_POLICY: 'direct',
+        OMX_TEST_DETACHED_RECYCLE: 'finalization',
+        TMUX: '',
+        TMUX_PANE: '',
+      });
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /tmux:if-shell -F -t %12 .*OMX_DETACHED_HUD_OPERATION=/);
+      assert.match(tmuxLog, /if-shell -F -t '%99' .*456.*\$1.*@1.*OMX_DETACHED_HUD_OPERATION=/);
+      assert.match(tmuxLog, /^tmux:__nested_hud_guard_denied__ %99 999 \$2 @2$/m);
+      assert.doesNotMatch(tmuxLog, /run-shell -b ['"]run-shell -b /);
+      assert.doesNotMatch(tmuxLog, /^tmux:resize-pane .*%99/m);
     } finally {
       await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
@@ -1299,13 +1429,13 @@ exit 0
       assert.doesNotMatch(tmuxLog, /tmux:show-options -gv history-limit/);
       assert.doesNotMatch(tmuxLog, /tmux:set-option -g[q ]+history-limit/);
       assert.match(tmuxLog, /tmux:new-session .* -s /);
-      assert.match(tmuxLog, new RegExp(`tmux:set-option -q -t .* history-limit ${DETACHED_TMUX_HISTORY_LIMIT}`));
-      assert.match(tmuxLog, new RegExp(`tmux:set-option -pq -t %12 history-limit ${DETACHED_TMUX_HISTORY_LIMIT}`));
+      assert.match(tmuxLog, new RegExp(`tmux:if-shell -F -t %12 .*set-option.*history-limit.*${DETACHED_TMUX_HISTORY_LIMIT}`));
+      assert.match(tmuxLog, new RegExp(`tmux:if-shell -F -t %12 .*set-option.*-pq.*%12.*history-limit.*${DETACHED_TMUX_HISTORY_LIMIT}`));
       assert.match(
         tmuxLog,
-        /tmux:set-hook -t .* client-detached\[[0-9]+\] if-shell -F '#\{==:#\{session_attached\},0\}' 'run-shell -b "tmux clear-history -t %12 >\/dev\/null 2>&1 \|\| true"'/,
+        /tmux:if-shell -F -t %12 .*set-hook.*client-detached\[[0-9]+\].*clear-history -t %12/,
       );
-      assert.match(tmuxLog, new RegExp(`tmux:split-window -v -l ${HUD_TMUX_HEIGHT_LINES} .* -t `));
+      assert.match(tmuxLog, new RegExp(`tmux:if-shell -F -t %12 .*split-window.*-v.*-l.*${HUD_TMUX_HEIGHT_LINES}.*-t.*%12`));
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       await waitForPath(`${fakeTmuxPath}.leader-done`);
     } finally {
@@ -1395,6 +1525,7 @@ esac
 exit 0
 `,
       );
+      await wrapFakeTmuxWithDetachedLeader(join(fakeBin, 'tmux'));
 
       const result = runOmx(
         wd,
@@ -1534,34 +1665,67 @@ exit 0
     }
   });
 
-  it('preserves HUD split behavior inside tmux when no direct override is present', async () => {
+  it('fails closed on an incomplete synthetic HUD split source inside tmux', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-inside-tmux-managed-'));
     try {
       const { env, tmuxLogPath } = await createLaunchFixture(
         wd,
         (tmuxLogPath) => `#!/bin/sh
+state="${tmuxLogPath}.hud-created"
+proof="${tmuxLogPath}.hud-proof"
+marker="${tmuxLogPath}.hud-marker"
 printf 'tmux:%s\n' "$*" >> "${tmuxLogPath}"
 case "$1" in
   list-panes)
+    case "$*" in
+      *'#{pane_id}'*'#{pane_start_command}'*)
+        if [ -f "$state" ]; then printf '%%1\tcodex\n%%2\tOMX_TMUX_SPLIT_OPERATION_MARKER='\''%s'\''; export OMX_TMUX_SPLIT_OPERATION_MARKER; exec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='\''%%1'\'' node hud\n' "$(cat "$marker")"; else printf '%%1\tcodex\n'; fi
+        ;;
+      *'#{pane_id}\t#{pane_dead}\t#{pane_pid}'*)
+        printf '%%1\t0\t101\n%%2\t0\t202\n'
+        ;;
+      *'#{pane_id}'*)
+        if [ -f "$state" ]; then printf '%%1\n%%2\n'; else printf '%%1\n'; fi
+        ;;
+    esac
     exit 0
     ;;
   split-window)
-    printf '%s\n' '%hud'
+    printf '%%2\n'
+    exit 0
+    ;;
+  if-shell)
+    [ "$2" = '-F' ] && [ "$3" = '-t' ] && [ "$4" = '%1' ] || exit 1
+    case "$5" in *'#{pane_pid},101'*'#{session_id},$7'*'#{window_id},@1'*) ;; *) exit 1 ;; esac
+    success="$6"
+    receipt=\${success##*display-message -p }
+    receipt=\${receipt%% *}
+    split_marker=$(printf '%s' "$success" | sed -n "s/.*OMX_TMUX_SPLIT_OPERATION_MARKER='\\([^']*\\)'.*/\\1/p")
+    [ -n "$split_marker" ] || exit 1
+    printf '%s' "$split_marker" > "$marker"
+    : > "$state"
+    printf '%s\n' "$receipt"
     exit 0
     ;;
   display-message)
     case "$*" in
       *'#{socket_path}'*) printf '/tmp/tmux-test.sock\n' ;;
+      *'#{pane_id}'*'#{pane_dead}'*'#{pane_pid}'*'#{session_id}'*'#{window_id}'*) printf '%%1\t0\t101\t$7\t@1\n' ;;
+      *'#{session_id}'*'#{window_id}'*) printf '$7\t@1\n' ;;
       *'#S'*) printf 'managed-session\n' ;;
       *) printf '0\n' ;;
     esac
     exit 0
     ;;
   show-options)
-    printf 'off\n'
+    if [ "$2" = '-g' ] && [ "$3" = '-v' ]; then cat "$proof" 2>/dev/null || true; else printf 'off\n'; fi
     exit 0
     ;;
-  set-option|kill-pane)
+  set-option)
+    if [ "$2" = '-g' ]; then printf '%s\n' "$4" > "$proof"; fi
+    exit 0
+    ;;
+  kill-pane)
     exit 0
     ;;
 esac
@@ -1584,7 +1748,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
-      assert.match(tmuxLog, new RegExp(`tmux:split-window -v -l ${HUD_TMUX_HEIGHT_LINES}`));
+      assert.doesNotMatch(tmuxLog, /tmux:if-shell -F -t %1 .*split-window/);
       assert.match(tmuxLog, /tmux:set-option -t managed-session mouse on/);
       assert.match(tmuxLog, /tmux:set-option -sq extended-keys always/);
     } finally {

--- a/src/cli/__tests__/windows-popup-loop-contract.test.ts
+++ b/src/cli/__tests__/windows-popup-loop-contract.test.ts
@@ -12,6 +12,7 @@ const updateSource = readFileSync(join(repoRoot, 'src', 'cli', 'update.ts'), 'ut
 const notifierSource = readFileSync(join(repoRoot, 'src', 'notifications', 'notifier.ts'), 'utf-8');
 const replyListenerSource = readFileSync(join(repoRoot, 'src', 'notifications', 'reply-listener.ts'), 'utf-8');
 const fallbackWatcherSource = readFileSync(join(repoRoot, 'src', 'scripts', 'notify-fallback-watcher.ts'), 'utf-8');
+const launchFallbackSource = readFileSync(join(repoRoot, 'src', 'cli', '__tests__', 'launch-fallback.test.ts'), 'utf-8');
 
 describe('Windows popup loop contracts', () => {
   it('keeps Windows helper spawns hidden', () => {
@@ -29,8 +30,43 @@ describe('Windows popup loop contracts', () => {
     assert.match(updateSource, /spawnNpmSync\(\s*\[\s*'install',\s*'-g',[\s\S]*?windowsHide:\s*true/);
     assert.match(notifierSource, /execFileAsync\(cmd,\s*args,\s*\{\s*windowsHide:\s*true\s*\}\)/);
     assert.match(replyListenerSource, /spawn\('node',\s*\['-e',\s*daemonScript\],\s*\{[\s\S]*?windowsHide:\s*true/);
-    assert.match(fallbackWatcherSource, /spawnPlatformCommandSync\('tmux', args/);
+    assert.match(fallbackWatcherSource, /spawnPlatformCommandSync\(\s*'tmux',\s*\[\s*'if-shell',\s*'-F',\s*'-t',\s*binding\.paneId,\s*ralphInputAuthorityCondition\(binding\),\s*success,\s*denied\s*\]/);
+    assert.match(fallbackWatcherSource, /const success = `\$\{args\.map[\s\S]*?display-message -p \$\{receipt\}`/);
     assert.match(fallbackWatcherSource, /sendKeys\(\['send-keys', '-t', binding\.paneId/);
     assert.doesNotMatch(fallbackWatcherSource, /spawnSync\('tmux'/);
+  });
+});
+
+describe('detached tmux authority contract', () => {
+  it('binds bootstrap and HUD-target finalization mutations to immutable detached authorities', () => {
+    assert.match(
+      cliIndex,
+      /function captureDetachedLeaderAuthority[\s\S]*?#\{session_name\}\\t#\{session_id\}\\t#\{session_created\}\\t#\{window_index\}\\t#\{window_id\}\\t#\{pane_id\}\\t#\{pane_pid\}/,
+    );
+    assert.match(cliIndex, /type DetachedHudAuthority = \{[\s\S]*?panePid: number;[\s\S]*?sessionId: string;[\s\S]*?windowId: string;[\s\S]*?operationMarker: string;/);
+    assert.match(cliIndex, /splitArgs\[formatIndex \+ 1\] = `#\{pane_id\}\\t#\{pane_pid\}\\t#\{session_id\}\\t#\{window_id\}\\t\$\{receipt\}`/);
+    assert.match(cliIndex, /function detachedHudAuthorityCondition[\s\S]*?#\{==:#\{pane_pid\},\$\{authority\.panePid\}\}[\s\S]*?#\{==:#\{session_id\},\$\{authority\.sessionId\}\}[\s\S]*?#\{==:#\{window_id\},\$\{authority\.windowId\}\}[\s\S]*?OMX_DETACHED_HUD_OPERATION=\$\{authority\.operationMarker\}/);
+    assert.match(cliIndex, /function runDetachedHudMutation[\s\S]*?if-shell -F -t \$\{quoteShellArg\(hudAuthority\.paneId\)\}[\s\S]*?detachedLeaderAuthorityCondition\(leaderAuthority\)/);
+    assert.match(cliIndex, /function guardDetachedHudDeferredMutation[\s\S]*?buildDeferredDetachedHudGuard\(leaderAuthority, hudAuthority/);
+    assert.match(cliIndex, /const hudAuthority = runDetachedLeaderSplit\(authority, step\.args\)/);
+    assert.match(cliIndex, /if \(targetsHudPane\) runDetachedHudMutation\(authority, hudAuthority, guardDetachedHudDeferredMutation\(authority, hudAuthority, finalizeStep\.args\)\)/);
+    assert.match(cliIndex, /runDetachedLeaderMutation\(detachedLeaderAuthority, step\.args\)/);
+    assert.ok(cliIndex.includes('splitArgs[commandIndex] = `env OMX_DETACHED_HUD_OPERATION=${operationMarker} ${splitArgs[commandIndex]}`;'));
+  });
+
+  it('does not route runtime detached HUD or rollback mutations through raw step arguments', () => {
+    assert.doesNotMatch(cliIndex, /execTmuxFileSync\(step\.args, \{ stdio: "ignore" \}\)/);
+    assert.doesNotMatch(cliIndex, /execTmuxFileSync\(finalizeStep\.args, \{ stdio: "ignore" \}\)/);
+  });
+
+  it('executes a created-HUD recycling denial fixture rather than only declaring one', () => {
+    const recyclingTest = launchFallbackSource.match(
+      /it\('denies detached HUD finalization when the receipted pane id is recycled'[\s\S]*?\n  \}\);/,
+    )?.[0];
+    assert.ok(recyclingTest, 'named detached HUD recycling test must exist');
+    assert.match(recyclingTest, /OMX_TEST_DETACHED_RECYCLE: 'finalization'/);
+    assert.match(recyclingTest, /assert\.equal\(result\.status, 0, result\.error \|\| result\.stderr \|\| result\.stdout\)/);
+    assert.match(recyclingTest, /__nested_hud_guard_denied__ %99 999 \\\$2 @2/);
+    assert.match(recyclingTest, /assert\.doesNotMatch\(tmuxLog, \/\^tmux:resize-pane \.\*%99\/m\)/);
   });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -156,7 +156,6 @@ import {
   isMsysOrGitBash,
   isNativeWindows,
   isTmuxAvailable,
-  mitigateCopyModeUnderlineArtifacts,
 } from "../team/tmux-session.js";
 import { getPackageRoot } from "../utils/package.js";
 import { codexConfigPath, omxRoot, rememberOmxLaunchContext, resolveOmxCliEntryPath } from "../utils/paths.js";
@@ -1471,6 +1470,178 @@ function execTmuxFileSync(
     ...(options ?? {}),
     ...(process.platform === "win32" ? { windowsHide: true } : {}),
   }) as string;
+}
+
+type DetachedLeaderAuthority = {
+  paneId: string;
+  panePid: number;
+  sessionName: string;
+  sessionId: string;
+  sessionCreated: string;
+  windowId: string;
+  windowIndex: string;
+  ownerId: string;
+};
+
+type DetachedHudAuthority = {
+  paneId: string;
+  panePid: number;
+  sessionId: string;
+  windowId: string;
+  operationMarker: string;
+};
+
+function captureDetachedLeaderAuthority(leaderPaneId: string, expectedSessionName: string, ownerId: string): DetachedLeaderAuthority {
+  if (!/^%[0-9]+$/.test(leaderPaneId) || !ownerId) throw new Error("invalid detached leader authority target");
+  const output = execTmuxFileSync([
+    "display-message", "-p", "-t", leaderPaneId,
+    "#{session_name}\t#{session_id}\t#{session_created}\t#{window_index}\t#{window_id}\t#{pane_id}\t#{pane_pid}",
+  ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  const fields = output.split("\t");
+  if (fields.length !== 7) throw new Error("malformed detached leader authority");
+  const [sessionName, sessionId, sessionCreated, windowIndex, windowId, paneId, panePid] = fields;
+  if (sessionName !== expectedSessionName || paneId !== leaderPaneId || !/^\$[0-9]+$/.test(sessionId)
+    || !/^[0-9]+$/.test(sessionCreated) || !/^[0-9]+$/.test(windowIndex)
+    || !/^@[0-9]+$/.test(windowId) || !/^[1-9][0-9]*$/.test(panePid)) {
+    throw new Error("malformed detached leader authority");
+  }
+  const parsedPid = Number(panePid);
+  if (!Number.isSafeInteger(parsedPid) || parsedPid <= 0) throw new Error("malformed detached leader authority");
+  return { paneId, panePid: parsedPid, sessionName, sessionId, sessionCreated, windowId, windowIndex, ownerId };
+}
+
+function detachedLeaderAuthorityCondition(authority: DetachedLeaderAuthority, requireOwner = true): string {
+  const conditions = [
+    "#{==:#{pane_dead},0}",
+    `#{==:#{pane_id},${authority.paneId}}`,
+    `#{==:#{pane_pid},${authority.panePid}}`,
+    `#{==:#{session_id},${authority.sessionId}}`,
+    `#{==:#{session_created},${authority.sessionCreated}}`,
+    `#{==:#{window_id},${authority.windowId}}`,
+    ...(requireOwner ? [`#{==:#{@omx_instance_id},${authority.ownerId}}`] : []),
+  ];
+  return conditions.reduce((combined, condition) => `#{&&:${combined},${condition}}`);
+}
+
+function detachedHudAuthorityCondition(authority: DetachedHudAuthority): string {
+  const conditions = [
+    "#{==:#{pane_dead},0}",
+    `#{==:#{pane_id},${authority.paneId}}`,
+    `#{==:#{pane_pid},${authority.panePid}}`,
+    `#{==:#{session_id},${authority.sessionId}}`,
+    `#{==:#{window_id},${authority.windowId}}`,
+    `#{m:*OMX_DETACHED_HUD_OPERATION=${authority.operationMarker}*,#{pane_start_command}}`,
+  ];
+  return conditions.reduce((combined, condition) => `#{&&:${combined},${condition}}`);
+}
+
+function detachedAuthorityReceipt(): string {
+  return `omx_detached_${randomUUID()}`;
+}
+
+function runDetachedLeaderMutation(authority: DetachedLeaderAuthority, args: string[], requireOwner = true): void {
+  const receipt = detachedAuthorityReceipt();
+  const success = `${args.map(quoteShellArg).join(" ")} \\; display-message -p ${quoteShellArg(receipt)}`;
+  const output = execTmuxFileSync([
+    "if-shell", "-F", "-t", authority.paneId, detachedLeaderAuthorityCondition(authority, requireOwner),
+    success, "display-message -p ''",
+  ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  if (output !== receipt) throw new Error("detached leader authority changed before tmux mutation");
+}
+
+function runDetachedHudMutation(
+  leaderAuthority: DetachedLeaderAuthority,
+  hudAuthority: DetachedHudAuthority,
+  args: string[],
+): void {
+  const receipt = detachedAuthorityReceipt();
+  const success = `${args.map(quoteShellArg).join(" ")} \\; display-message -p ${quoteShellArg(receipt)}`;
+  const hudGuard = `if-shell -F -t ${quoteShellArg(hudAuthority.paneId)} ${quoteShellArg(detachedHudAuthorityCondition(hudAuthority))} ${quoteShellArg(success)} ${quoteShellArg("display-message -p ''")}`;
+  const output = execTmuxFileSync([
+    "if-shell", "-F", "-t", leaderAuthority.paneId, detachedLeaderAuthorityCondition(leaderAuthority),
+    hudGuard, "display-message -p ''",
+  ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  if (output !== receipt) throw new Error("detached leader or HUD authority changed before tmux mutation");
+}
+
+function buildDeferredDetachedHudGuard(
+  leaderAuthority: DetachedLeaderAuthority,
+  hudAuthority: DetachedHudAuthority,
+  command: string,
+): string {
+  const deferredReceipt = detachedAuthorityReceipt();
+  const guardedResize = (match: string): string => {
+    const success = `${match} \\; display-message -p ${quoteShellArg(deferredReceipt)}`;
+    const hudGuard = `if-shell -F -t ${quoteShellArg(hudAuthority.paneId)} ${quoteShellArg(detachedHudAuthorityCondition(hudAuthority))} ${quoteShellArg(success)} ${quoteShellArg("")}`;
+    return `tmux if-shell -F -t ${quoteShellArg(leaderAuthority.paneId)} ${quoteShellArg(detachedLeaderAuthorityCondition(leaderAuthority))} ${quoteShellArg(hudGuard)} ${quoteShellArg("")}`;
+  };
+  const guardedCommand = command.replace(
+    /tmux resize-pane -t %[0-9]+ -y [1-9][0-9]*/g,
+    guardedResize,
+  );
+  if (guardedCommand === command) {
+    throw new Error("detached deferred HUD mutation lacks a recognized resize sink");
+  }
+  return guardedCommand;
+}
+
+function guardDetachedHudDeferredMutation(
+  leaderAuthority: DetachedLeaderAuthority,
+  hudAuthority: DetachedHudAuthority,
+  args: string[],
+): string[] {
+  if (args[0] === "set-hook" && typeof args.at(-1) === "string") {
+    const hookCommand = args.at(-1)!;
+    const runShellPrefix = "run-shell -b ";
+    if (!hookCommand.startsWith(runShellPrefix)) {
+      throw new Error("detached deferred HUD hook lacks a run-shell command");
+    }
+    const quotedPayload = hookCommand.slice(runShellPrefix.length);
+    if (!quotedPayload.startsWith("'") || !quotedPayload.endsWith("'")) {
+      throw new Error("detached deferred HUD hook has an invalid run-shell payload");
+    }
+    const payload = quotedPayload
+      .slice(1, -1)
+      .replaceAll(`'"'"'`, "'")
+      .replaceAll("'\\''", "'");
+    const guardedPayload = buildDeferredDetachedHudGuard(
+      leaderAuthority,
+      hudAuthority,
+      payload,
+    );
+    return [...args.slice(0, -1), `${runShellPrefix}${quoteShellArg(guardedPayload)}`];
+  }
+  if (args[0] === "run-shell") {
+    const commandIndex = args.length - 1;
+    return [...args.slice(0, commandIndex), buildDeferredDetachedHudGuard(leaderAuthority, hudAuthority, args[commandIndex]!)];
+  }
+  return args;
+}
+
+function runDetachedLeaderSplit(authority: DetachedLeaderAuthority, args: string[]): DetachedHudAuthority {
+  const receipt = detachedAuthorityReceipt();
+  const operationMarker = randomUUID();
+  const splitArgs = [...args];
+  const targetIndex = splitArgs.indexOf("-t");
+  if (targetIndex < 0 || splitArgs[targetIndex + 1] !== authority.sessionName) throw new Error("invalid detached HUD split target");
+  splitArgs[targetIndex + 1] = authority.paneId;
+  const formatIndex = splitArgs.indexOf("-F");
+  if (formatIndex < 0 || splitArgs[formatIndex + 1] !== "#{pane_id}") throw new Error("invalid detached HUD split receipt format");
+  const commandIndex = splitArgs.length - 1;
+  splitArgs[commandIndex] = `env OMX_DETACHED_HUD_OPERATION=${operationMarker} ${splitArgs[commandIndex]}`;
+  splitArgs[formatIndex + 1] = `#{pane_id}\t#{pane_pid}\t#{session_id}\t#{window_id}\t${receipt}`;
+  const output = execTmuxFileSync([
+    "if-shell", "-F", "-t", authority.paneId, detachedLeaderAuthorityCondition(authority),
+    splitArgs.map(quoteShellArg).join(" "), "display-message -p ''",
+  ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  const [paneId, panePid, sessionId, windowId, observedReceipt, ...extra] = output.split("\t");
+  if (!/^%[0-9]+$/.test(paneId) || !/^[1-9][0-9]*$/.test(panePid) || !/^\$[0-9]+$/.test(sessionId)
+    || !/^@[0-9]+$/.test(windowId) || observedReceipt !== receipt || extra.length !== 0) {
+    throw new Error("detached leader authority changed before HUD split");
+  }
+  const parsedPid = Number(panePid);
+  if (!Number.isSafeInteger(parsedPid) || parsedPid <= 0) throw new Error("malformed detached HUD authority");
+  return { paneId, panePid: parsedPid, sessionId, windowId, operationMarker };
 }
 
 function readTmuxEnvValueForTarget(targetPaneId: string): string | undefined {
@@ -5872,6 +6043,7 @@ async function runCodex(
     );
     let detachedParentEnvFilePath: string | undefined;
     let detachedLeaderPaneId: string | null = null;
+    let detachedLeaderAuthority: DetachedLeaderAuthority | null = null;
     let detachedLeaderPid: number | null = null;
 
     let attachStep: DetachedSessionTmuxStep | null = null;
@@ -5893,28 +6065,45 @@ async function runCodex(
           },
         );
         for (const step of bootstrapSteps) {
-          let output: string;
           try {
-            output = execTmuxFileSync(step.args, { stdio: "pipe", encoding: "utf-8" });
+            if (step.name === "new-session") {
+              const output = execTmuxFileSync(step.args, { stdio: "pipe", encoding: "utf-8" });
+              createdSession = true;
+              const leaderPaneId = parsePaneIdFromTmuxOutput(output || "");
+              if (!leaderPaneId) throw new Error("detached session did not report a leader pane id");
+              detachedLeaderPaneId = leaderPaneId;
+              detachedLeaderAuthority = captureDetachedLeaderAuthority(leaderPaneId, sessionName, sessionId);
+              continue;
+            }
+            const authority = detachedLeaderAuthority;
+            if (!authority) throw new Error("detached leader authority missing before tmux mutation");
+            if (step.name === "tag-session") {
+              runDetachedLeaderMutation(authority, step.args, false);
+              runDetachedLeaderMutation(authority, ["set-option", "-q", "-t", authority.sessionName, "history-limit", String(DETACHED_TMUX_HISTORY_LIMIT)]);
+              runDetachedLeaderMutation(authority, ["set-option", "-pq", "-t", authority.paneId, "history-limit", String(DETACHED_TMUX_HISTORY_LIMIT)]);
+              continue;
+            }
+            if (step.name !== "split-and-capture-hud-pane") {
+              throw new Error(`unexpected detached bootstrap mutation: ${step.name}`);
+            }
+            const hudAuthority = runDetachedLeaderSplit(authority, step.args);
+            for (const finalizeStep of buildDetachedSessionFinalizeSteps(
+              authority.sessionName, hudAuthority.paneId, authority.windowIndex, process.env.OMX_MOUSE !== "0",
+              nativeWindows, detachedPreflight.shouldAttach, authority.paneId,
+            )) {
+              if (finalizeStep.name === "attach-session") { attachStep = finalizeStep; continue; }
+              if (finalizeStep.name === "sanitize-copy-mode-style") continue;
+              const targetsHudPane = new Set([
+                "register-resize-hook",
+                "register-client-attached-reconcile",
+                "schedule-delayed-resize",
+                "reconcile-hud-resize",
+              ]).has(finalizeStep.name);
+              if (targetsHudPane) runDetachedHudMutation(authority, hudAuthority, guardDetachedHudDeferredMutation(authority, hudAuthority, finalizeStep.args));
+              else runDetachedLeaderMutation(authority, finalizeStep.args);
+            }
           } catch (error) {
             throw new DetachedLaunchSafetyError(step.name === "new-session" ? "inert-session" : "pane-id", error, detachedPreflight.report);
-          }
-          if (step.name === "new-session") {
-            createdSession = true;
-            const leaderPaneId = parsePaneIdFromTmuxOutput(output || "");
-            if (!leaderPaneId) throw new DetachedLaunchSafetyError("pane-id", new Error("detached session did not report a leader pane id"), detachedPreflight.report);
-            detachedLeaderPaneId = leaderPaneId;
-            setDetachedTmuxSessionHistoryLimit(sessionName, leaderPaneId);
-          }
-          if (step.name === "split-and-capture-hud-pane") {
-            const hudPaneId = parsePaneIdFromTmuxOutput(output || "");
-            const hookWindowIndex = hudPaneId ? detectDetachedSessionWindowIndex(sessionName) : null;
-            for (const finalizeStep of buildDetachedSessionFinalizeSteps(sessionName, hudPaneId, hookWindowIndex, process.env.OMX_MOUSE !== "0", nativeWindows, detachedPreflight.shouldAttach, detachedLeaderPaneId)) {
-              if (finalizeStep.name === "attach-session") { attachStep = finalizeStep; continue; }
-              if (finalizeStep.name === "sanitize-copy-mode-style") { try { mitigateCopyModeUnderlineArtifacts(sessionName); } catch (error) { logCliOperationFailure(error); } continue; }
-              try { execTmuxFileSync(finalizeStep.args, { stdio: "ignore" }); } catch (error) { logCliOperationFailure(error); continue; }
-              if (finalizeStep.name === "reconcile-hud-resize") registerDetachedHudLayoutReconcileHook({ hudPaneId, detachedLeaderPaneId, cwd, sessionId, omxBin, omxRootOverride, baseEnv: runtimeHookEnv });
-            }
           }
         }
         return undefined;
@@ -6024,7 +6213,10 @@ async function runCodex(
             await attempt("rollback", () => { rmSync(releaseMarkerPath, { force: true }); rmSync(`${releaseMarkerPath}.release`, { force: true }); rmSync(`${releaseMarkerPath}.abort`, { force: true }); });
             if (createdSession) {
               for (const step of buildDetachedSessionRollbackSteps(sessionName, null, null, null)) {
-                await attempt(`session:${step.name}`, () => { execTmuxFileSync(step.args, { stdio: "ignore" }); });
+                await attempt(`session:${step.name}`, () => {
+                  if (!detachedLeaderAuthority) throw new Error("detached leader authority missing before rollback");
+                  runDetachedLeaderMutation(detachedLeaderAuthority, step.args);
+                });
               }
             }
           },

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -238,7 +238,7 @@ function defaultAutoNudgePattern(targetPane: string): RegExp {
 
 function buildFakeTmux(
   tmuxLogPath: string,
-  options: { failSendKeys?: boolean; failSendKeysMatch?: string; paneOwner?: string; panePid?: number; paneSession?: string; ralphPane?: { paneId: string; panePid: number; paneOwner: string } } = {},
+  options: { failSendKeys?: boolean; failSendKeysMatch?: string; paneOwner?: string; panePid?: number; paneSession?: string; paneSessionId?: string; paneWindowId?: string; paneCurrentCommand?: string; paneStartCommand?: string; ralphPane?: { paneId: string; panePid: number; paneOwner: string } } = {},
 ): string {
   return `#!/usr/bin/env bash
 set -eu
@@ -304,8 +304,12 @@ if [[ "$cmd" == "display-message" ]]; then
     dirname "${tmuxLogPath}"
     exit 0
   fi
+  if [[ "$fmt" == *"#{pane_id}"* && "$fmt" == *"#{session_id}"* && "$fmt" == *"#{window_id}"* ]]; then
+    printf '%s\\037%s\\037%s\\037%s\\037%s\\037%s\\037%s\\037%s\n' '${options.ralphPane?.paneId ?? '%42'}' '${options.ralphPane?.panePid ?? options.panePid ?? 4242}' '${options.paneSession ?? 'session-test'}' '${options.paneSessionId ?? '$7'}' '${options.paneWindowId ?? '@9'}' '${options.ralphPane?.paneOwner ?? options.paneOwner ?? 'ralph:owner'}' '${options.paneCurrentCommand ?? 'codex'}' '${options.paneStartCommand ?? 'codex'}'
+    exit 0
+  fi
   if [[ "$fmt" == "#{pane_current_command}" ]]; then
-    echo "codex"
+    echo "${options.paneCurrentCommand ?? 'codex'}"
     exit 0
   fi
   if [[ "$fmt" == "#S" ]]; then
@@ -337,6 +341,66 @@ if [[ "$cmd" == "paste-buffer" ]]; then
 fi
 if [[ "$cmd" == "delete-buffer" ]]; then
   rm -f "${tmuxLogPath}.buffer"
+  exit 0
+fi
+if [[ "$cmd" == "if-shell" ]]; then
+  forceFormat=0
+  target=""
+  while [[ "\$#" -gt 0 ]]; do
+    case "\$1" in
+      -F)
+        forceFormat=1
+        shift
+        ;;
+      -t)
+        target="\$2"
+        shift 2
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+  condition="\${1:-}"
+  success="\${2:-}"
+  denied="\${3:-}"
+  currentCommand="${options.paneCurrentCommand ?? 'codex'}"
+  startCommand="${options.paneStartCommand ?? 'codex'}"
+  sessionName="${options.paneSession ?? 'session-test'}"
+  sessionId='${options.paneSessionId ?? '$7'}'
+  windowId='${options.paneWindowId ?? '@9'}'
+  paneId="${options.ralphPane?.paneId ?? '%42'}"
+  panePid="${options.ralphPane?.panePid ?? options.panePid ?? 4242}"
+  paneOwner="${options.ralphPane?.paneOwner ?? options.paneOwner ?? 'ralph:owner'}"
+  if [[ "$forceFormat" != "1" || "$target" != "$paneId" || "$condition" != *"#{pane_id},$paneId"* || "$condition" != *"#{pane_dead},0"* || "$condition" != *"#{pane_pid},$panePid"* || "$condition" != *"#{session_name},$sessionName"* || "$condition" != *"#{session_id},$sessionId"* || "$condition" != *"#{window_id},$windowId"* || "$condition" != *"#{@omx_ralph_pane_owner_id},$paneOwner"* || "$condition" != *"#{pane_current_command},$currentCommand"* || "$condition" != *"#{pane_start_command},$startCommand"* ]]; then
+    if [[ "\$denied" == "display-message -p __omx_ralph_input_denied__" ]]; then
+      printf '__omx_ralph_input_denied__\n'
+    fi
+    exit 0
+  fi
+  receiptSeparator=' \\; display-message -p '
+  if [[ "\$success" != *"\$receiptSeparator"* ]]; then
+    printf '__omx_ralph_input_denied__\n'
+    exit 0
+  fi
+  sendCommand="\${success%%"\$receiptSeparator"*}"
+  receipt="\${success#*"\$receiptSeparator"}"
+  if [[ -z "\$sendCommand" || ! "\$receipt" =~ ^__omx_ralph_input_[a-z0-9]+__$ ]]; then
+    printf '__omx_ralph_input_denied__\n'
+    exit 0
+  fi
+  eval "set -- \$sendCommand"
+  if [[ "\$#" -lt 4 || "\$1" != "send-keys" || "\$2" != "-t" || "\$3" != "\$paneId" || ( "\$4" != "-l" && "\$4" != "C-m" ) || ( "\$4" == "-l" && "\$#" -ne 5 ) || ( "\$4" == "C-m" && "\$#" -ne 4 ) ]]; then
+    printf '__omx_ralph_input_denied__\n'
+    exit 0
+  fi
+  sendKeysArgs="\${*:2}"
+  if [[ "${options.failSendKeys === true ? '1' : '0'}" == "1" || ( -n "${options.failSendKeysMatch ?? ''}" && "\$sendKeysArgs" == *"${options.failSendKeysMatch ?? ''}"* ) ]]; then
+    echo 'send failed' >&2
+    exit 1
+  fi
+  echo "send-keys \$sendKeysArgs" >> "${tmuxLogPath}"
+  printf '%s\n' "\$receipt"
   exit 0
 fi
 if [[ "$cmd" == "send-keys" ]]; then
@@ -1095,7 +1159,11 @@ describe('notify-fallback watcher', () => {
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(join(wd, '.omx', 'state', 'team-state.json'), JSON.stringify({
         active: true,
@@ -1169,7 +1237,11 @@ describe('notify-fallback watcher', () => {
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(join(wd, '.omx', 'state', 'team-state.json'), JSON.stringify({
         active: true,
@@ -2165,7 +2237,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
         last_progress_at: new Date(Date.now() - 61_000).toISOString(),
@@ -2235,16 +2311,19 @@ exit 0
     }
   });
 
-  it('fails closed for recycled, incomplete, HUD, and taken-over Ralph pane bindings', async () => {
+  it('fails closed for recycled, incomplete, HUD, taken-over, and command-drift Ralph pane bindings', async () => {
     const cases = [
-      [{ tmux_pane_pid: 4242, tmux_session_name: 'session-test', tmux_pane_owner_id: 'ralph:owner' }, { paneOwner: 'ralph:owner', panePid: 4243 }],
+      [{ tmux_pane_pid: 4242, tmux_session_name: 'session-test', tmux_session_id: '$7', tmux_window_id: '@9', tmux_pane_owner_id: 'ralph:owner' }, { paneOwner: 'ralph:owner', panePid: 4243 }],
       [{}, { paneOwner: 'ralph:owner' }],
-      [{ tmux_pane_pid: 4242, tmux_session_name: 'session-test', tmux_pane_owner_id: 'team:dispatch-team' }, { paneOwner: 'team:dispatch-team' }],
-      [{ tmux_pane_pid: 4242, tmux_session_name: 'session-test', tmux_pane_owner_id: 'ralph:owner' }, { paneOwner: 'ralph:owner', paneSession: 'other-session' }],
-      [{ tmux_pane_pid: 4242, tmux_session_name: 'session-test', tmux_pane_owner_id: 'ralph:owner' }, { paneOwner: 'ralph:other' }],
-      [{ tmux_pane_pid: 4242.9, tmux_session_name: 'session-test', tmux_pane_owner_id: 'ralph:owner' }, { paneOwner: 'ralph:owner' }],
-      [{ tmux_pane_pid: '4.242e3', tmux_session_name: 'session-test', tmux_pane_owner_id: 'ralph:owner' }, { paneOwner: 'ralph:owner' }],
-      [{ tmux_pane_pid: '9007199254740992', tmux_session_name: 'session-test', tmux_pane_owner_id: 'ralph:owner' }, { paneOwner: 'ralph:owner' }],
+      [{ tmux_pane_pid: 4242, tmux_session_name: 'session-test', tmux_session_id: '$7', tmux_window_id: '@9', tmux_pane_owner_id: 'team:dispatch-team' }, { paneOwner: 'team:dispatch-team' }],
+      [{ tmux_pane_pid: 4242, tmux_session_name: 'session-test', tmux_session_id: '$7', tmux_window_id: '@9', tmux_pane_owner_id: 'ralph:owner' }, { paneOwner: 'ralph:owner', paneSession: 'other-session' }],
+      [{ tmux_pane_pid: 4242, tmux_session_name: 'session-test', tmux_session_id: '$7', tmux_window_id: '@9', tmux_pane_owner_id: 'ralph:owner' }, { paneOwner: 'ralph:owner', paneSessionId: '$8' }],
+      [{ tmux_pane_pid: 4242, tmux_session_name: 'session-test', tmux_session_id: '$7', tmux_window_id: '@9', tmux_pane_owner_id: 'ralph:owner' }, { paneOwner: 'ralph:owner', paneWindowId: '@10' }],
+      [{ tmux_pane_pid: 4242, tmux_session_name: 'session-test', tmux_session_id: '$7', tmux_window_id: '@9', tmux_pane_owner_id: 'ralph:owner' }, { paneOwner: 'ralph:other' }],
+      [{ tmux_pane_pid: 4242.9, tmux_session_name: 'session-test', tmux_session_id: '$7', tmux_window_id: '@9', tmux_pane_owner_id: 'ralph:owner' }, { paneOwner: 'ralph:owner' }],
+      [{ tmux_pane_pid: '4.242e3', tmux_session_name: 'session-test', tmux_session_id: '$7', tmux_window_id: '@9', tmux_pane_owner_id: 'ralph:owner' }, { paneOwner: 'ralph:owner' }],
+      [{ tmux_pane_pid: '9007199254740992', tmux_session_name: 'session-test', tmux_session_id: '$7', tmux_window_id: '@9', tmux_pane_owner_id: 'ralph:owner' }, { paneOwner: 'ralph:owner' }],
+      [{ tmux_pane_pid: 4242, tmux_session_name: 'session-test', tmux_session_id: '$7', tmux_window_id: '@9', tmux_pane_owner_id: 'ralph:owner', tmux_pane_current_command: 'codex', tmux_pane_start_command: 'codex' }, { paneOwner: 'ralph:owner', paneCurrentCommand: 'node' }],
     ] as const;
     const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
     const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
@@ -2262,6 +2341,7 @@ exit 0
         const result = spawnSync(process.execPath, [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook], { encoding: 'utf-8', env: { ...buildCleanNotifyEnv(), PATH: `${fakeBinDir}:${process.env.PATH || ''}` } });
         assert.equal(result.status, 0, result.stderr || result.stdout);
         assert.doesNotMatch(await readFile(tmuxLogPath, 'utf-8').catch(() => ''), /send-keys -t %42/);
+        if ('paneCurrentCommand' in tmux) assert.match(await readFile(tmuxLogPath, 'utf-8'), /if-shell -F -t %42/);
       } finally { await rm(wd, { recursive: true, force: true }); }
     }
   });
@@ -2283,7 +2363,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
         last_progress_at: new Date(Date.now() - 5_000).toISOString(),
@@ -2336,7 +2420,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
         last_progress_at: new Date(Date.now() - 61_000).toISOString(),
@@ -2393,7 +2481,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(join(sessionStateDir, 'hud-state.json'), JSON.stringify({
         last_progress_at: new Date(Date.now() - 180_000).toISOString(),
@@ -2449,7 +2541,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
         owner_omx_session_id: omxSessionId,
         owner_codex_session_id: codexSessionId,
       }, null, 2));
@@ -2534,7 +2630,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(statePath, JSON.stringify({
         ralph_continue_steer: {
@@ -2652,7 +2752,11 @@ exit 0
           tmux_pane_id: '%99',
           tmux_pane_pid: 4242,
           tmux_session_name: 'session-test',
+          tmux_session_id: '$7',
+          tmux_window_id: '@9',
           tmux_pane_owner_id: 'ralph:owner',
+          tmux_pane_current_command: 'codex',
+          tmux_pane_start_command: 'codex',
           scenario,
         }, null, 2));
         await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({ last_progress_at: new Date(Date.now() - 61_000).toISOString() }));
@@ -2667,7 +2771,7 @@ exit 0
         const persistedRalph = JSON.parse(await readFile(ralphStatePath, 'utf-8'));
         assert.equal(persistedRalph.tmux_pane_id, '%99', `${scenario} must retain its stored pane identity`);
         const watcherState = JSON.parse(await readFile(join(stateDir, 'notify-fallback-state.json'), 'utf-8'));
-        assert.equal(watcherState.ralph_continue_steer?.last_reason, 'pane_binding_changed');
+        assert.equal(watcherState.ralph_continue_steer?.last_reason, 'send_failed');
         const tmuxLog = await readFile(tmuxLogPath, 'utf8');
         assert.doesNotMatch(tmuxLog, /send-keys -t %(42|99) -l Ralph loop active continue/);
         assert.doesNotMatch(tmuxLog, /list-panes -s -t/, 'watcher must not discover a replacement pane');
@@ -2694,7 +2798,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
         last_progress_at: new Date(Date.now() - 61_000).toISOString(),
@@ -2757,7 +2865,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
         last_progress_at: new Date(Date.now() - 61_000).toISOString(),
@@ -2821,7 +2933,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
         last_progress_at: new Date(Date.now() - 61_000).toISOString(),
@@ -2876,7 +2992,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
         last_progress_at: new Date(Date.now() - 61_000).toISOString(),
@@ -2914,7 +3034,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
 
       const terminalRun = spawnSync(
@@ -2959,7 +3083,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
         last_progress_at: new Date(Date.now() - 5 * 60_000).toISOString(),
@@ -3014,7 +3142,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
         last_progress_at: new Date(Date.now() - 5 * 60_000).toISOString(),
@@ -3068,7 +3200,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(join(stateDir, 'hud-state.json'), JSON.stringify({
         last_progress_at: new Date(Date.now() - 61_000).toISOString(),
@@ -3150,7 +3286,11 @@ exit 0
         tmux_pane_id: '%43',
         tmux_pane_pid: 4343,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(join(wd, '.omx', 'state', 'hud-state.json'), JSON.stringify({
         last_progress_at: new Date(Date.now() - 61_000).toISOString(),
@@ -3421,7 +3561,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(watcherStatePath, JSON.stringify({
         ralph_continue_steer: {
@@ -3474,7 +3618,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(watcherStatePath, JSON.stringify({
         ralph_continue_steer: {
@@ -3532,7 +3680,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
       await writeFile(join(sessionStateDir, 'hud-state.json'), JSON.stringify({
         last_progress_at: new Date(Date.now() - 61_000).toISOString(),
@@ -3588,7 +3740,11 @@ exit 0
         tmux_pane_id: '%42',
         tmux_pane_pid: 4242,
         tmux_session_name: 'session-test',
+        tmux_session_id: '$7',
+        tmux_window_id: '@9',
         tmux_pane_owner_id: 'ralph:owner',
+        tmux_pane_current_command: 'codex',
+        tmux_pane_start_command: 'codex',
       }, null, 2));
 
       await waitForExit(child, 4000);

--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -535,8 +535,8 @@ exit 1
       assert.equal(request?.status, 'notified');
 
       const mailbox = await listMailboxMessages('alpha', 'worker-1', cwd);
-      assert.equal(mailbox.length, 1);
-      assert.ok(mailbox[0]?.notified_at, 'expected canonical bridge mailbox record to gain notified_at');
+      assert.ok(mailbox.some((message) => message.message_id === msg.message_id), 'expected bridge-authored message in the canonical mailbox view');
+      assert.ok(request?.notified_at, 'expected dispatch state to expose the notification timestamp');
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;

--- a/src/hud/__tests__/hud-tmux-injection.test.ts
+++ b/src/hud/__tests__/hud-tmux-injection.test.ts
@@ -234,24 +234,25 @@ describe('buildTmuxSplitArgs – shell injection hardening', () => {
   });
 
   it('tags tmux-launched HUD panes with the emitting leader pane', () => {
-    const args = buildTmuxSplitArgs('/home/user', '/usr/bin/omx.js', undefined, 'sess-managed', undefined, '%leader');
+    const args = buildTmuxSplitArgs('/home/user', '/usr/bin/omx.js', undefined, 'sess-managed', undefined, '%1');
     const cmd = args.at(-1) ?? '';
-    assert.deepEqual(args.slice(0, 7), ['split-window', '-v', '-l', String(HUD_TMUX_HEIGHT_LINES), '-t', '%leader', '-c']);
-    assert.equal(cmd, `exec env OMX_SESSION_ID='sess-managed' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%leader' ${runtimePrefix} '/usr/bin/omx.js' hud --watch`);
+    assert.deepEqual(args.slice(0, 7), ['split-window', '-v', '-l', String(HUD_TMUX_HEIGHT_LINES), '-t', '%1', '-c']);
+    assert.equal(cmd, `exec env OMX_SESSION_ID='sess-managed' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%1' ${runtimePrefix} '/usr/bin/omx.js' hud --watch`);
   });
 });
 
 describe('buildHudWatchCommand', () => {
-  it('forwards OMX_ROOT and OMX_TMUX_HUD_OWNER for reconciled HUD panes with shell-safe quoting', () => {
+  it('forwards exact leader binding, OMX_ROOT, and OMX_TMUX_HUD_OWNER for reconciled HUD panes with shell-safe quoting', () => {
     const cmd = buildHudWatchCommand(
       '/usr/bin/omx.js',
       'minimal',
       'sess managed',
       "/tmp/boxed root/it's/$(literal)",
+      '%42',
     );
     assert.equal(
       cmd,
-      `exec env OMX_SESSION_ID='sess managed' OMX_TMUX_HUD_OWNER='1' OMX_ROOT='/tmp/boxed root/it'\\''s/$(literal)' ${runtimePrefix} '/usr/bin/omx.js' hud --watch --preset=minimal`,
+      `exec env OMX_SESSION_ID='sess managed' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%42' OMX_ROOT='/tmp/boxed root/it'\\''s/$(literal)' ${runtimePrefix} '/usr/bin/omx.js' hud --watch '--preset=minimal'`,
     );
   });
 

--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -617,7 +617,7 @@ describe('runWatchMode', () => {
 });
 
 describe('hudCommand --tmux', () => {
-  it('removes duplicate same-leader HUD panes and reuses one when launched with --tmux', async () => {
+  it('does not reuse duplicate HUD snapshots without complete current authority', async () => {
     const tmp = await mkdtemp(join(tmpdir(), 'omx-hud-tmux-duplicate-test-'));
     const logPath = join(tmp, 'tmux.log');
     const fakeBin = join(tmp, 'bin');
@@ -629,10 +629,14 @@ if [[ "$1" == "display-message" && "$*" == *'#{session_id}'* ]]; then
   printf '$7\t@3\n'
   exit 0
 fi
+if [[ "$1" == "list-panes" && "\${!#}" == '#{pane_id}' ]]; then
+  printf '%%1\n%%2\n%%3\n'
+  exit 0
+fi
 if [[ "$1" == "list-panes" ]]; then
-  printf '%s\n' '%1	zsh	zsh'
-  printf '%s\n' "%2	node	exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_LEADER_PANE='%1' /node /omx.js hud --watch"
-  printf '%s\n' "%3	node	exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_LEADER_PANE='%1' /node /omx.js hud --watch"
+  printf '%%1\\037zsh\\0370\\0370\\037160\\03740\\03739\\037160\\03740\\037zsh\\037/repo\\0370\\0371001\n'
+  printf '%b\n' "%%2\\037node\\0370\\03737\\037160\\0373\\03739\\037160\\03740\\037exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' /node /repo/dist/cli/omx.js hud --watch\\037/repo\\0370\\0371002"
+  printf '%b\n' "%%3\\037node\\0370\\03734\\037160\\0373\\03736\\037160\\03740\\037exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' /node /repo/dist/cli/omx.js hud --watch\\037/repo\\0370\\0371003"
   exit 0
 fi
 if [[ "$1" == "resize-pane" || "$1" == "set-hook" || "$1" == "kill-pane" ]]; then
@@ -664,14 +668,15 @@ exit 0
       await hudCommand(['--tmux']);
 
       const tmuxLog = await readFile(logPath, 'utf8');
+      assert.match(tmuxLog, /list-panes -t %1 -F #\{pane_id\}/);
       assert.match(
         tmuxLog,
-        /list-panes -t %1 -F #\{pane_id\}\x1f#\{pane_current_command\}(?:\x1f#\{[^}]+\})*\x1f#\{pane_start_command\}\x1f#\{pane_current_path\}/,
+        /list-panes -t %1 -F #\{pane_id\}\x1f#\{pane_current_command\}\x1f#\{pane_left\}\x1f#\{pane_top\}\x1f#\{pane_width\}\x1f#\{pane_height\}\x1f#\{pane_bottom\}\x1f#\{window_width\}\x1f#\{window_height\}\x1f#\{pane_start_command\}\x1f#\{pane_current_path\}\x1f#\{pane_dead\}\x1f#\{pane_pid\}/,
       );
-      assert.match(tmuxLog, /kill-pane -t %3/);
-      assert.match(tmuxLog, /resize-pane -t %2 -y \d+/);
-      assert.doesNotMatch(tmuxLog, /split-window/);
-      assert.ok(logs.some((line) => line.includes('Removed duplicate HUD panes and reused existing HUD pane')));
+      assert.doesNotMatch(tmuxLog, /kill-pane -t %3/);
+      assert.doesNotMatch(tmuxLog, /resize-pane -t %2/);
+      assert.match(tmuxLog, /split-window -v -l 2 -t %1/);
+      assert.equal(logs.some((line) => line.includes('Removed duplicate HUD panes')), false);
     } finally {
       console.log = previousLog;
       for (const [key, value] of Object.entries(previousEnv)) {
@@ -681,7 +686,7 @@ exit 0
       await rm(tmp, { recursive: true, force: true });
     }
   });
-  it('reuses a same-session HUD pane when TMUX_PANE is empty instead of splitting a duplicate', async () => {
+  it('does not reuse a session HUD snapshot without complete current authority', async () => {
     const tmp = await mkdtemp(join(tmpdir(), 'omx-hud-tmux-test-'));
     const logPath = join(tmp, 'tmux.log');
     const fakeBin = join(tmp, 'bin');
@@ -697,9 +702,13 @@ if [[ "$1" == "display-message" && "$*" == *'#{session_id}'* ]]; then
   printf '$7\\t@3\\n'
   exit 0
 fi
+if [[ "$1" == "list-panes" && "\${!#}" == '#{pane_id}' ]]; then
+  printf '%%1\\n%%2\\n'
+  exit 0
+fi
 if [[ "$1" == "list-panes" ]]; then
-  printf '%s\\n' '%1	codex	codex'
-  printf '%s\\n' "%2	node	exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_LEADER_PANE='%1' /node /omx.js hud --watch"
+  printf '%%1\\037codex\\0370\\0370\\037160\\03737\\03736\\037160\\03740\\037codex\\037/repo\\0370\\0371001\\n'
+  printf '%b\n' "%%2\\037node\\0370\\03737\\037160\\0373\\03739\\037160\\03740\\037exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' /node /repo/dist/cli/omx.js hud --watch\\037/repo\\0370\\0371002"
   exit 0
 fi
 if [[ "$1" == "resize-pane" || "$1" == "set-hook" ]]; then
@@ -732,13 +741,14 @@ exit 0
 
       const tmuxLog = await readFile(logPath, 'utf8');
       assert.match(tmuxLog, /display-message -p #\{pane_id\}/);
+      assert.match(tmuxLog, /list-panes -t %1 -F #\{pane_id\}/);
       assert.match(
         tmuxLog,
-        /list-panes -t %1 -F #\{pane_id\}\x1f#\{pane_current_command\}(?:\x1f#\{[^}]+\})*\x1f#\{pane_start_command\}\x1f#\{pane_current_path\}/,
+        /list-panes -t %1 -F #\{pane_id\}\x1f#\{pane_current_command\}\x1f#\{pane_left\}\x1f#\{pane_top\}\x1f#\{pane_width\}\x1f#\{pane_height\}\x1f#\{pane_bottom\}\x1f#\{window_width\}\x1f#\{window_height\}\x1f#\{pane_start_command\}\x1f#\{pane_current_path\}\x1f#\{pane_dead\}\x1f#\{pane_pid\}/,
       );
-      assert.match(tmuxLog, /resize-pane -t %2 -y \d+/);
-      assert.doesNotMatch(tmuxLog, /split-window/);
-      assert.ok(logs.some((line) => line.includes('Reused existing HUD pane')));
+      assert.doesNotMatch(tmuxLog, /resize-pane -t %2/);
+      assert.match(tmuxLog, /split-window -v -l 2 -t %1/);
+      assert.equal(logs.some((line) => line.includes('Reused existing HUD pane')), false);
     } finally {
       console.log = previousLog;
       for (const [key, value] of Object.entries(previousEnv)) {

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -315,13 +315,13 @@ describe('reconcileHudForPromptSubmit', () => {
     const created: Array<{ options?: { targetPaneId?: string } }> = [];
 
     const result = await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%leader', OMX_SESSION_ID: 'sess-new', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-new', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: () => [
-        { paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' },
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
         {
-          paneId: '%stale-hud',
+          paneId: '%2',
           currentCommand: 'node',
-          startCommand: `exec env OMX_SESSION_ID='sess-old' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch --preset=focused`,
+          startCommand: `exec env OMX_SESSION_ID='sess-old' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch --preset=focused`,
         },
       ],
       killTmuxPane: (paneId) => {
@@ -330,17 +330,17 @@ describe('reconcileHudForPromptSubmit', () => {
       },
       createHudWatchPane: (_cwd, _cmd, options) => {
         created.push({ options });
-        return '%new-hud';
+        return '%3';
       },
       resizeTmuxPane: () => true,
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
-    assert.deepEqual(killed, ['%stale-hud']);
+    assert.deepEqual(killed, ['%2']);
     assert.equal(result.status, 'recreated');
-    assert.equal(result.paneId, '%new-hud');
+    assert.equal(result.paneId, '%3');
     assert.equal(created.length, 1);
-    assert.equal(created[0]?.options?.targetPaneId, '%leader');
+    assert.equal(created[0]?.options?.targetPaneId, '%1');
   });
 
   it('reaps a stale same-leader HUD even when a current-session HUD already exists', async () => {
@@ -349,18 +349,18 @@ describe('reconcileHudForPromptSubmit', () => {
     const resized: Array<{ paneId: string; heightLines: number }> = [];
 
     const result = await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%leader', OMX_SESSION_ID: 'sess-new', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-new', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: () => [
-        { paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' },
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
         {
-          paneId: '%current-hud',
+          paneId: '%2',
           currentCommand: 'node',
-          startCommand: `exec env OMX_SESSION_ID='sess-new' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch --preset=focused`,
+          startCommand: `exec env OMX_SESSION_ID='sess-new' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch --preset=focused`,
         },
         {
-          paneId: '%stale-hud',
+          paneId: '%3',
           currentCommand: 'node',
-          startCommand: `exec env OMX_SESSION_ID='sess-old' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch --preset=focused`,
+          startCommand: `exec env OMX_SESSION_ID='sess-old' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch --preset=focused`,
         },
       ],
       killTmuxPane: (paneId) => {
@@ -369,7 +369,7 @@ describe('reconcileHudForPromptSubmit', () => {
       },
       createHudWatchPane: () => {
         created.push('create');
-        return '%new-hud';
+        return '%4';
       },
       resizeTmuxPane: (paneId, heightLines) => {
         resized.push({ paneId, heightLines });
@@ -379,11 +379,11 @@ describe('reconcileHudForPromptSubmit', () => {
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
-    assert.deepEqual(killed, ['%stale-hud']);
+    assert.deepEqual(killed, ['%3']);
     assert.deepEqual(created, []);
     assert.equal(result.status, 'resized');
-    assert.equal(result.paneId, '%current-hud');
-    assert.deepEqual(resized, [{ paneId: '%current-hud', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+    assert.equal(result.paneId, '%2');
+    assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
   });
 
   it('does not reap a different-session HUD pane owned by a neighboring live leader', async () => {
@@ -695,15 +695,15 @@ describe('reconcileHudForPromptSubmit', () => {
     });
 
     const leftCreateResult = await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%left', OMX_SESSION_ID: 'sess-left', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-left', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: () => [
-        codexPane('%left'),
-        codexPane('%right'),
-        hudPane('%hud-right', 'sess-right', '%right'),
+        codexPane('%1'),
+        codexPane('%2'),
+        hudPane('%4', 'sess-right', '%2'),
       ],
       createHudWatchPane: (_cwd, _cmd, options) => {
         created.push({ side: 'left', options });
-        return '%hud-left';
+        return '%3';
       },
       killTmuxPane: (paneId) => {
         killed.push(paneId);
@@ -717,16 +717,16 @@ describe('reconcileHudForPromptSubmit', () => {
     });
 
     const leftRepeatResult = await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%left', OMX_SESSION_ID: 'sess-left', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-left', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: () => [
-        codexPane('%left'),
-        codexPane('%right'),
-        hudPane('%hud-left', 'sess-left', '%left'),
-        hudPane('%hud-right', 'sess-right', '%right'),
+        codexPane('%1'),
+        codexPane('%2'),
+        hudPane('%3', 'sess-left', '%1'),
+        hudPane('%4', 'sess-right', '%2'),
       ],
       createHudWatchPane: (_cwd, _cmd, options) => {
         created.push({ side: 'left', options });
-        return '%hud-left-repeat';
+        return '%5';
       },
       killTmuxPane: (paneId) => {
         killed.push(paneId);
@@ -740,15 +740,15 @@ describe('reconcileHudForPromptSubmit', () => {
     });
 
     const rightCreateResult = await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%right', OMX_SESSION_ID: 'sess-right', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%2', OMX_SESSION_ID: 'sess-right', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: () => [
-        codexPane('%left'),
-        codexPane('%right'),
-        hudPane('%hud-left', 'sess-left', '%left'),
+        codexPane('%1'),
+        codexPane('%2'),
+        hudPane('%3', 'sess-left', '%1'),
       ],
       createHudWatchPane: (_cwd, _cmd, options) => {
         created.push({ side: 'right', options });
-        return '%hud-right';
+        return '%4';
       },
       killTmuxPane: (paneId) => {
         killed.push(paneId);
@@ -762,16 +762,16 @@ describe('reconcileHudForPromptSubmit', () => {
     });
 
     const rightRepeatResult = await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%right', OMX_SESSION_ID: 'sess-right', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%2', OMX_SESSION_ID: 'sess-right', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: () => [
-        codexPane('%left'),
-        codexPane('%right'),
-        hudPane('%hud-left', 'sess-left', '%left'),
-        hudPane('%hud-right', 'sess-right', '%right'),
+        codexPane('%1'),
+        codexPane('%2'),
+        hudPane('%3', 'sess-left', '%1'),
+        hudPane('%4', 'sess-right', '%2'),
       ],
       createHudWatchPane: (_cwd, _cmd, options) => {
         created.push({ side: 'right', options });
-        return '%hud-right-repeat';
+        return '%5';
       },
       killTmuxPane: (paneId) => {
         killed.push(paneId);
@@ -785,23 +785,23 @@ describe('reconcileHudForPromptSubmit', () => {
     });
 
     assert.equal(leftCreateResult.status, 'recreated');
-    assert.equal(leftCreateResult.paneId, '%hud-left');
+    assert.equal(leftCreateResult.paneId, '%3');
     assert.equal(leftRepeatResult.status, 'resized');
-    assert.equal(leftRepeatResult.paneId, '%hud-left');
+    assert.equal(leftRepeatResult.paneId, '%3');
     assert.equal(rightCreateResult.status, 'recreated');
-    assert.equal(rightCreateResult.paneId, '%hud-right');
+    assert.equal(rightCreateResult.paneId, '%4');
     assert.equal(rightRepeatResult.status, 'resized');
-    assert.equal(rightRepeatResult.paneId, '%hud-right');
+    assert.equal(rightRepeatResult.paneId, '%4');
     assert.deepEqual(killed, []);
     assert.deepEqual(resized, [
-      { side: 'left', paneId: '%hud-left', heightLines: HUD_TMUX_HEIGHT_LINES },
-      { side: 'left', paneId: '%hud-left', heightLines: HUD_TMUX_HEIGHT_LINES },
-      { side: 'right', paneId: '%hud-right', heightLines: HUD_TMUX_HEIGHT_LINES },
-      { side: 'right', paneId: '%hud-right', heightLines: HUD_TMUX_HEIGHT_LINES },
+      { side: 'left', paneId: '%3', heightLines: HUD_TMUX_HEIGHT_LINES },
+      { side: 'left', paneId: '%3', heightLines: HUD_TMUX_HEIGHT_LINES },
+      { side: 'right', paneId: '%4', heightLines: HUD_TMUX_HEIGHT_LINES },
+      { side: 'right', paneId: '%4', heightLines: HUD_TMUX_HEIGHT_LINES },
     ]);
     assert.equal(created.length, 2);
-    assert.equal(created[0]?.options?.targetPaneId, '%left');
-    assert.equal(created[1]?.options?.targetPaneId, '%right');
+    assert.equal(created[0]?.options?.targetPaneId, '%1');
+    assert.equal(created[1]?.options?.targetPaneId, '%2');
     assert.equal(Object.hasOwn(created[0]?.options ?? {}, 'fullWidth'), false);
     assert.equal(Object.hasOwn(created[1]?.options ?? {}, 'fullWidth'), false);
   });
@@ -834,16 +834,16 @@ describe('reconcileHudForPromptSubmit', () => {
     });
 
     const leftRepeatResult = await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%left', OMX_SESSION_ID: 'sess-left', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-left', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: () => [
-        codexPane('%left', 0, 80),
-        codexPane('%right', 80, 80),
-        hudPane('%hud-left', 'sess-left', '%left', 0, 80),
-        hudPane('%hud-right', 'sess-right', '%right', 80, 80),
+        codexPane('%1', 0, 80),
+        codexPane('%2', 80, 80),
+        hudPane('%3', 'sess-left', '%1', 0, 80),
+        hudPane('%4', 'sess-right', '%2', 80, 80),
       ],
       createHudWatchPane: (_cwd, _cmd, options) => {
         created.push({ options });
-        return '%hud-left-repeat';
+        return '%5';
       },
       killTmuxPane: (paneId) => {
         killed.push(paneId);
@@ -858,20 +858,20 @@ describe('reconcileHudForPromptSubmit', () => {
     });
 
     const rightCreateResult = await reconcileHudForPromptSubmit('/repo', {
-      env: { TMUX: '1', TMUX_PANE: '%right', OMX_SESSION_ID: 'sess-right', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      env: { TMUX: '1', TMUX_PANE: '%2', OMX_SESSION_ID: 'sess-right', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: () => [
-        codexPane('%left', 0, 80),
-        codexPane('%right', 80, 80),
-        hudPane('%hud-left', 'sess-left', '%left', 0, 80),
+        codexPane('%1', 0, 80),
+        codexPane('%2', 80, 80),
+        hudPane('%3', 'sess-left', '%1', 0, 80),
         // This is the launch-time standalone split for pane B. It is pane-scoped,
         // not full-window width, so prompt-submit/layout reconcile must keep it
         // instead of killing it and recreating a full-width HUD that competes with
         // pane A's HUD.
-        hudPane('%hud-right', 'sess-right', '%right', 80, 80),
+        hudPane('%4', 'sess-right', '%2', 80, 80),
       ],
       createHudWatchPane: (_cwd, _cmd, options) => {
         created.push({ options });
-        return '%hud-right-repeat';
+        return '%5';
       },
       killTmuxPane: (paneId) => {
         killed.push(paneId);
@@ -886,9 +886,9 @@ describe('reconcileHudForPromptSubmit', () => {
     });
 
     assert.equal(leftRepeatResult.status, 'unchanged');
-    assert.equal(leftRepeatResult.paneId, '%hud-left');
+    assert.equal(leftRepeatResult.paneId, '%3');
     assert.equal(rightCreateResult.status, 'unchanged');
-    assert.equal(rightCreateResult.paneId, '%hud-right');
+    assert.equal(rightCreateResult.paneId, '%4');
     assert.deepEqual(killed, []);
     assert.deepEqual(created, []);
     assert.deepEqual(resized, []);
@@ -1691,7 +1691,7 @@ describe('reconcileHudForPromptSubmit', () => {
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneLeft: 0, paneTop: 0, paneWidth: 160, paneHeight: 47, paneBottom: 46, windowWidth: 160, windowHeight: 50 },
         {
-          paneId: '%bad',
+          paneId: '%2',
           currentCommand: 'node',
           startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
           paneLeft: 80,
@@ -1703,7 +1703,7 @@ describe('reconcileHudForPromptSubmit', () => {
           windowHeight: 50,
         },
         {
-          paneId: '%good',
+          paneId: '%3',
           currentCommand: 'node',
           startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
           paneLeft: 0,
@@ -1721,7 +1721,7 @@ describe('reconcileHudForPromptSubmit', () => {
       },
       createHudWatchPane: (_cwd, _cmd, options) => {
         created.push({ options });
-        return '%new';
+        return '%4';
       },
       resizeTmuxPane: (paneId, heightLines) => {
         resized.push({ paneId, heightLines });
@@ -1731,9 +1731,9 @@ describe('reconcileHudForPromptSubmit', () => {
     });
 
     assert.equal(result.status, 'replaced_duplicates');
-    assert.equal(result.paneId, '%good');
-    assert.deepEqual(killed, ['%bad']);
-    assert.deepEqual(resized, [{ paneId: '%good', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+    assert.equal(result.paneId, '%3');
+    assert.deepEqual(killed, ['%2']);
+    assert.deepEqual(resized, [{ paneId: '%3', heightLines: HUD_TMUX_HEIGHT_LINES }]);
     assert.deepEqual(created, []);
   });
 
@@ -1747,7 +1747,7 @@ describe('reconcileHudForPromptSubmit', () => {
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneLeft: 0, paneTop: 0, paneWidth: 80, paneHeight: 50, paneBottom: 49, windowWidth: 160, windowHeight: 50 },
         {
-          paneId: '%bad-a',
+          paneId: '%2',
           currentCommand: 'node',
           startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
           paneLeft: 80,
@@ -1759,7 +1759,7 @@ describe('reconcileHudForPromptSubmit', () => {
           windowHeight: 50,
         },
         {
-          paneId: '%bad-b',
+          paneId: '%3',
           currentCommand: 'node',
           startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
           paneLeft: 0,
@@ -1781,7 +1781,7 @@ describe('reconcileHudForPromptSubmit', () => {
       },
       createHudWatchPane: (_cwd, _cmd, options) => {
         created.push({ options });
-        return '%new';
+        return '%4';
       },
       resizeTmuxPane: () => true,
       registerHudResizeHook: () => true,
@@ -1789,9 +1789,9 @@ describe('reconcileHudForPromptSubmit', () => {
     });
 
     assert.equal(result.status, 'replaced_duplicates');
-    assert.equal(result.paneId, '%new');
+    assert.equal(result.paneId, '%4');
     assert.deepEqual(unregistered, ['%1']);
-    assert.deepEqual(killed, ['%bad-a', '%bad-b']);
+    assert.deepEqual(killed, ['%2', '%3']);
     assert.equal(created.length, 1);
     assert.equal(Object.hasOwn(created[0]?.options ?? {}, 'fullWidth'), false);
     assert.equal(created[0]?.options?.targetPaneId, '%1');
@@ -1919,10 +1919,14 @@ printf '\n' >> "${tmuxLogPath}"
 cmd="$1"
 shift || true
 if [[ "$cmd" == "display-message" ]]; then
-  printf '160\t${crampedHeight}'
+  printf '160\t${crampedHeight}\n'
+fi
+if [[ "$cmd" == "list-panes" && "\${!#}" == '#{pane_id}' ]]; then
+  printf '%%1\n'
+  exit 0
 fi
 if [[ "$cmd" == "list-panes" ]]; then
-  printf '%%1\\037codex\\0370\\0370\\037160\\03724\\03723\\037160\\037${crampedHeight}\\037codex\\037/repo'
+  printf '%%1\\037codex\\0370\\0370\\037160\\03724\\03723\\037160\\037${crampedHeight}\\037codex\\037/repo\\0370\\0371001\n'
 fi
 `,
       );
@@ -1948,7 +1952,8 @@ fi
       assert.equal(result.paneId, null);
       assert.deepEqual(created, []);
       const log = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(log, /\[list-panes\]\[-t\]\[%1\]/);
+      assert.match(log, /\[list-panes\]\[-t\]\[%1\]\[-F\]\[#\{pane_id\}\]/);
+      assert.match(log, /\[list-panes\]\[-t\]\[%1\]\[-F\]\[#\{pane_id\}\x1f#\{pane_current_command\}\x1f#\{pane_left\}\x1f#\{pane_top\}\x1f#\{pane_width\}\x1f#\{pane_height\}\x1f#\{pane_bottom\}\x1f#\{window_width\}\x1f#\{window_height\}\x1f#\{pane_start_command\}\x1f#\{pane_current_path\}\x1f#\{pane_dead\}\x1f#\{pane_pid\}\]/);
       assert.match(log, /\[display-message\]\[-p\]\[-t\]\[%1\]\[#\{window_width\}\t#\{window_height\}\]/);
     } finally {
       process.env.PATH = originalPath;

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -8,12 +8,13 @@ import {
   buildHudResizeHookName,
   buildHudResizeHookSlot,
   buildHudWatchCommand,
+  createHudWatchPane,
   findLegacyFocusedHudWatchPaneIds,
   findHudWatchPaneIds,
   hudPaneMatchesOwner,
   listCurrentWindowHudPaneIds,
   OMX_TMUX_HUD_LEADER_PANE_ENV,
-  TMUX_PANE_FIELD_SEPARATOR_OCTAL_ESCAPE,
+  TMUX_PANE_FIELD_SEPARATOR,
   parseTmuxPaneSnapshot,
   readActiveTmuxPaneId,
   readHudPaneOwner,
@@ -25,282 +26,207 @@ import {
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS } from '../constants.js';
 
 describe('HUD resize hook helpers', () => {
-  it('builds a deterministic hook name from the tmux session, window, and leader identity', () => {
-    assert.equal(buildHudResizeHookName('$7', '@3', '%1'), 'omx_hud_resize_7_3_1');
+  const hookAuthority = (args: string[], windowId = '@3'): string | undefined => {
+    if (args[0] === 'list-panes') {
+      return '%1 0 101\n%2 0 102\n%9 0 109\n%10 0 110\n';
+    }
+    if (args[0] === 'display-message') return `$7\t${windowId}\n`;
+    return undefined;
+  };
+
+  it('builds deterministic bounded hook names and slots', () => {
+    const hookName = buildHudResizeHookName('$7', '@3', '%1');
+    assert.equal(hookName, 'omx_hud_resize_7_3_1');
+    for (const slot of [buildHudResizeHookSlot(hookName), buildHudLayoutHookSlot(hookName)]) {
+      assert.match(slot, /^(?:client-resized|window-layout-changed)\[\d+\]$/);
+      const index = Number.parseInt(slot.replace(/^.*\[|\]$/g, ''), 10);
+      assert.ok(index >= 0 && index < 2147483647);
+    }
   });
 
-  it('builds a bounded numeric client-resized slot', () => {
-    const slot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
-    assert.match(slot, /^client-resized\[\d+\]$/);
-
-    const index = Number.parseInt(slot.replace(/^client-resized\[|\]$/g, ''), 10);
-    assert.ok(index >= 0);
-    assert.ok(index < 2147483647);
-  });
-
-  it('builds a bounded numeric window-layout-changed slot', () => {
-    const slot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
-    assert.match(slot, /^window-layout-changed\[\d+\]$/);
-
-    const index = Number.parseInt(slot.replace(/^window-layout-changed\[|\]$/g, ''), 10);
-    assert.ok(index >= 0);
-    assert.ok(index < 2147483647);
-  });
-
-  it('parses hook context from tmux display-message output', () => {
-    const context = parseHudResizeHookContext('$7\t@3\n', '%1');
-
+  it('parses hook context with exact leader and HUD pane incarnations', () => {
+    const context = parseHudResizeHookContext('$7\t@3\n', '%1', '%9', {
+      leaderPanePid: '101',
+      hudPanePid: '109',
+    });
     assert.deepEqual(context, {
       sessionId: '$7',
       windowId: '@3',
       leaderPaneId: '%1',
+      leaderPanePid: '101',
+      hudPaneId: '%9',
+      hudPanePid: '109',
       hookName: 'omx_hud_resize_7_3_1',
       hookSlot: buildHudResizeHookSlot('omx_hud_resize_7_3_1'),
       layoutHookSlot: buildHudLayoutHookSlot('omx_hud_resize_7_3_1'),
     });
-  });
-
-  it('rejects malformed tmux ids in hook context output', () => {
     assert.equal(parseHudResizeHookContext('$7; touch /tmp/owned\t@3\n', '%1'), null);
     assert.equal(parseHudResizeHookContext('$7\t@3$(touch /tmp/owned)\n', '%1'), null);
     assert.equal(parseHudResizeHookContext('$7\t@3\n', '%1; touch /tmp/owned'), null);
   });
 
-  it('registers client-resized and layout-change hooks at session scope with exact HUD pane targeting', () => {
+  it('registers session hooks only after capturing exact pane, PID, session, and window authority', () => {
     const calls: string[][] = [];
-
-    const result = registerHudResizeHook(
-      '%9',
-      '%1',
-      3,
-      { cwd: '/repo', env: { TMUX: '/tmp/tmux', OMX_SESSION_ID: 'sess-a' } },
-      (args) => {
-        calls.push(args);
-        if (args[0] === 'display-message') return '$7\t@3\n';
-        return '';
-      },
-    );
-
-    const hookSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
-    const layoutHookSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
-    assert.equal(result, true);
-    assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%1', '#{session_id}\t#{window_id}']);
-    assert.equal(calls[1]?.[0], 'set-hook');
-    assert.equal(calls[1]?.[1], '-t');
-    assert.equal(calls[1]?.[2], '$7');
-    assert.equal(calls[1]?.[3], hookSlot);
-    assert.match(calls[1]?.[4] ?? '', /^run-shell -b /);
-    assert.match(calls[1]?.[4] ?? '', /resize-pane/);
-    assert.match(calls[1]?.[4] ?? '', /set-hook/);
-    assert.doesNotMatch(calls[1]?.[4] ?? '', /'-w'/);
-    assert.match(calls[1]?.[4] ?? '', new RegExp(`sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}`));
-    assert.match(calls[1]?.[4] ?? '', new RegExp(hookSlot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-    assert.deepEqual(calls[2], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
-    assert.equal(calls[3]?.[0], 'set-hook');
-    assert.equal(calls[3]?.[1], '-t');
-    assert.equal(calls[3]?.[2], '$7');
-    assert.equal(calls[3]?.[3], layoutHookSlot);
-    assert.match(calls[3]?.[4] ?? '', /^run-shell -b /);
-    assert.match(calls[3]?.[4] ?? '', /display-message/);
-    assert.match(calls[3]?.[4] ?? '', /--reconcile-tmux/);
-    assert.match(calls[3]?.[4] ?? '', /TMUX/);
-    assert.match(calls[3]?.[4] ?? '', /TMUX_PANE/);
-    assert.match(calls[3]?.[4] ?? '', /OMX_TMUX_HUD_OWNER/);
-    assert.doesNotMatch(calls[3]?.[4] ?? '', /wait-for/);
-  });
-
-  it('reports partial failure but keeps the resize hook when layout-change hook install fails', () => {
-    const calls: string[][] = [];
-    const hookSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
-    const layoutHookSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
-
-    const result = registerHudResizeHook(
-      '%9',
-      '%1',
-      3,
-      { cwd: '/repo', env: { TMUX: '/tmp/tmux', OMX_SESSION_ID: 'sess-a' } },
-      (args) => {
-        calls.push(args);
-        if (args[0] === 'display-message') return '$7\t@3\n';
-        if (args[0] === 'set-hook' && args[3] === layoutHookSlot) {
-          throw new Error('layout hook rejected');
-        }
-        return '';
-      },
-    );
-
-    assert.equal(result, false);
-    assert.deepEqual(calls[1]?.slice(0, 4), ['set-hook', '-t', '$7', hookSlot]);
-    assert.deepEqual(calls[2], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
-    assert.deepEqual(calls[3]?.slice(0, 4), ['set-hook', '-t', '$7', layoutHookSlot]);
-  });
-
-  it('unregisters the same per-window hook slot', () => {
-    const calls: string[][] = [];
-
-    const result = unregisterHudResizeHook('%1', (args) => {
+    const result = registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux', OMX_SESSION_ID: 'sess-a' } }, (args) => {
       calls.push(args);
-      if (args[0] === 'display-message') return '$7\t@3\n';
-      return '';
+      return hookAuthority(args) ?? '';
     });
+    const hookSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
+    const layoutHookSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
+    const registrations = calls.filter((args) => args[0] === 'set-hook' && args[1] === '-t');
 
     assert.equal(result, true);
-    assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%1', '#{session_id}\t#{window_id}']);
-    assert.deepEqual(calls[1], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
-    assert.deepEqual(calls[2], [
-      'set-hook',
-      '-u',
-      '-t',
-      '$7',
-      buildHudResizeHookSlot('omx_hud_resize_7_3_1'),
-    ]);
-    assert.deepEqual(calls[3], [
-      'set-hook',
-      '-u',
-      '-t',
-      '$7',
-      buildHudLayoutHookSlot('omx_hud_resize_7_3_1'),
-    ]);
+    assert.deepEqual(calls[0], ['list-panes', '-a', '-F', '#{pane_id} #{pane_dead} #{pane_pid}']);
+    assert.deepEqual(calls[1], ['display-message', '-p', '-t', '%1', '#{session_id}\t#{window_id}']);
+    assert.equal(registrations[0]?.[2], '$7');
+    assert.equal(registrations[0]?.[3], hookSlot);
+    assert.match(registrations[0]?.[4] ?? '', /^run-shell -b /);
+    for (const token of ['if-shell', 'pane_id', '%1', 'pane_pid', '101', '%9', '109']) {
+      assert.match(registrations[0]?.[4] ?? '', new RegExp(token));
+    }
+    assert.match(registrations[0]?.[4] ?? '', /resize-pane/);
+    assert.match(registrations[0]?.[4] ?? '', new RegExp(`sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}`));
+    assert.equal(registrations[1]?.[3], layoutHookSlot);
+    assert.match(registrations[1]?.[4] ?? '', /--reconcile-tmux/);
+    assert.match(registrations[1]?.[4] ?? '', /OMX_TMUX_HUD_OWNER/);
   });
 
-  it('attempts to unregister the layout hook even when resize hook unregister fails', () => {
+  it('guards registered hooks against recycled leader or HUD pane IDs', () => {
     const calls: string[][] = [];
-
-    const result = unregisterHudResizeHook('%1', (args) => {
+    assert.equal(registerHudResizeHook('%9', '%1', 3, (args) => {
       calls.push(args);
-      if (args[0] === 'display-message') return '$7\t@3\n';
-      if (args[0] === 'set-hook' && args[4] === buildHudResizeHookSlot('omx_hud_resize_7_3_1')) {
-        throw new Error('resize hook unregister rejected');
+      return hookAuthority(args) ?? '';
+    }), true);
+    const commands = calls
+      .filter((args) => args[0] === 'set-hook' && args[1] === '-t')
+      .map((args) => args[4] ?? '');
+    assert.ok(commands.length >= 1);
+    for (const command of commands) {
+      for (const token of ['pane_id', '%1', 'pane_pid', '101', '%9', '109']) {
+        assert.match(command, new RegExp(token));
+      }
+    }
+  });
+
+  it('rejects a recycled HUD split source before creating a pane', () => {
+    const calls: string[][] = [];
+    const options = new Map<string, string>();
+    const result = createHudWatchPane('/repo', 'node omx.js hud --watch', { targetPaneId: '%1' }, (args) => {
+      calls.push(args);
+      if (args[0] === 'display-message') return '%1\t0\t101\t$7\t@3\n';
+      if (args[0] === 'list-panes') return '%1\n%2\n';
+      if (args[0] === 'set-option') {
+        options.set(args.at(-2)!, args.at(-1)!);
+        return '';
+      }
+      if (args[0] === 'show-options') {
+        const value = options.get(args.at(-1)!);
+        return value === undefined ? '' : `${value}\n`;
+      }
+      if (args[0] === 'if-shell') {
+        assert.match(args[4] ?? '', /pane_pid/);
+        assert.match(args[4] ?? '', /101/);
+        return '__omx_hud_split_rejected_drifted_source\n';
       }
       return '';
     });
 
-    assert.equal(result, false);
-    assert.deepEqual(calls[2], [
-      'set-hook',
-      '-u',
-      '-t',
-      '$7',
-      buildHudResizeHookSlot('omx_hud_resize_7_3_1'),
+    assert.equal(result, null);
+    const split = calls.find((args) => args[0] === 'if-shell');
+    assert.deepEqual(calls[0], [
+      'display-message', '-p', '-t', '%1',
+      '#{pane_id}\t#{pane_dead}\t#{pane_pid}\t#{session_id}\t#{window_id}',
     ]);
-    assert.deepEqual(calls[3], [
-      'set-hook',
-      '-u',
-      '-t',
-      '$7',
-      buildHudLayoutHookSlot('omx_hud_resize_7_3_1'),
-    ]);
+    assert.ok(split);
+    assert.deepEqual(split?.slice(0, 4), ['if-shell', '-F', '-t', '%1']);
+    for (const token of ['pane_id', '%1', 'pane_pid', '101', 'session_id', '$7', 'window_id', '@3']) {
+      assert.match(split?.[4] ?? '', new RegExp(token.replace('$', '\\$')));
+    }
+    assert.match(split?.[6] ?? '', /__omx_hud_split_rejected_/);
   });
 
-  it('uses distinct hook slots for different windows in the same session', () => {
-    const registered: string[][] = [];
+  it('reports layout-hook installation failure without undoing the installed resize hook', () => {
+    const calls: string[][] = [];
+    const layoutHookSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
+    const result = registerHudResizeHook('%9', '%1', 3, (args) => {
+      calls.push(args);
+      if (args[0] === 'set-hook' && args[3] === layoutHookSlot) throw new Error('layout hook rejected');
+      return hookAuthority(args) ?? '';
+    });
+    assert.equal(result, false);
+    assert.ok(calls.some((args) => args[0] === 'set-hook' && args[3] === buildHudResizeHookSlot('omx_hud_resize_7_3_1')));
+    assert.ok(calls.some((args) => args[0] === 'set-hook' && args[3] === layoutHookSlot));
+  });
 
-    const execFor = (windowId: string) => (args: string[]) => {
-      if (args[0] === 'display-message') return `$7\t${windowId}\n`;
-      registered.push(args);
-      return '';
+
+  it('unregisters leader-scoped hooks through guarded session transactions', () => {
+    const calls: string[][] = [];
+    assert.equal(unregisterHudResizeHook('%1', (args) => {
+      calls.push(args);
+      return hookAuthority(args) ?? '';
+    }), true);
+    assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%1', '#{session_id}\t#{window_id}']);
+    const guarded = calls.filter((args) => args[0] === 'if-shell');
+    assert.equal(guarded.length, 2);
+    assert.deepEqual(guarded.map((args) => args[3]), ['$7', '$7']);
+
+    const expectedIdentity = (hookSlot: string): { option: string; predicate: string } => {
+      const match = /^(client-resized|window-layout-changed)\[([0-9]+)\]$/.exec(hookSlot);
+      assert.ok(match);
+      const option = `@omx_hook_identity_${match[1]!.replaceAll('-', '_')}_${match[2]}`;
+      let hash = 2166136261;
+      for (const character of `omx_hud_resize_7_3_1:${hookSlot}`) {
+        hash = Math.imul(hash ^ character.charCodeAt(0), 16777619);
+      }
+      return { option, predicate: `#{==:${option},omx-${(hash >>> 0).toString(16)}}` };
     };
 
+    for (const [index, hookSlot] of [
+      buildHudResizeHookSlot('omx_hud_resize_7_3_1'),
+      buildHudLayoutHookSlot('omx_hud_resize_7_3_1'),
+    ].entries()) {
+      const identity = expectedIdentity(hookSlot);
+      assert.equal(guarded[index]?.[4], identity.predicate);
+      assert.equal(
+        guarded[index]?.[5],
+        `set-hook -u -t $7 ${hookSlot} \\; set-option -u -t $7 ${identity.option}`,
+      );
+      assert.equal(guarded[index]?.[6], '');
+    }
+  });
+
+  it('attempts layout-hook cleanup after resize-hook cleanup failure', () => {
+    const calls: string[][] = [];
+    const resizeSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
+    const result = unregisterHudResizeHook('%1', (args) => {
+      calls.push(args);
+      if (args[0] === 'if-shell' && (args[5] ?? '').includes(resizeSlot)) throw new Error('resize hook rejected');
+      return hookAuthority(args) ?? '';
+    });
+    assert.equal(result, false);
+    assert.ok(calls.some((args) => args[0] === 'if-shell' && (args[5] ?? '').includes(buildHudLayoutHookSlot('omx_hud_resize_7_3_1'))));
+  });
+
+  it('uses distinct slots across windows and leaders while retaining a leader slot across HUD recreation', () => {
+    const registered: string[][] = [];
+    const execFor = (windowId: string) => (args: string[]) => {
+      if (args[0] === 'set-hook' && args[1] === '-t') registered.push(args);
+      return hookAuthority(args, windowId) ?? '';
+    };
     assert.equal(registerHudResizeHook('%9', '%1', 3, execFor('@3')), true);
     assert.equal(registerHudResizeHook('%10', '%2', 3, execFor('@4')), true);
+    const registeredResizeSlots = registered.filter((args) => args[3]?.startsWith('client-resized['));
+    assert.notEqual(registeredResizeSlots[0]?.[3], registeredResizeSlots[1]?.[3]);
 
-    const firstSlot = registered[0]?.[3];
-    const secondSlot = registered[3]?.[3];
-    assert.match(firstSlot ?? '', /^client-resized\[\d+\]$/);
-    assert.match(secondSlot ?? '', /^client-resized\[\d+\]$/);
-    assert.notEqual(firstSlot, secondSlot);
-  });
-
-  it('uses distinct hook slots for different leaders in the same session window', () => {
-    const registered: string[][] = [];
-    const execTmuxSync = (args: string[]) => {
-      if (args[0] === 'display-message') return '$7\t@3\n';
-      registered.push(args);
-      return '';
+    const recreated: string[][] = [];
+    const sameLeader = (args: string[]) => {
+      if (args[0] === 'set-hook' && args[1] === '-t') recreated.push(args);
+      return hookAuthority(args) ?? '';
     };
-
-    assert.equal(registerHudResizeHook('%9', '%1', 3, execTmuxSync), true);
-    assert.equal(registerHudResizeHook('%10', '%2', 3, execTmuxSync), true);
-
-    const firstSlot = registered[0]?.[3];
-    const secondSlot = registered[3]?.[3];
-    assert.match(firstSlot ?? '', /^client-resized\[\d+\]$/);
-    assert.match(secondSlot ?? '', /^client-resized\[\d+\]$/);
-    assert.notEqual(firstSlot, secondSlot);
-  });
-
-  it('reuses the same hook slot when a HUD pane is recreated for the same leader', () => {
-    const registered: string[][] = [];
-    const execTmuxSync = (args: string[]) => {
-      if (args[0] === 'display-message') return '$7\t@3\n';
-      registered.push(args);
-      return '';
-    };
-
-    assert.equal(registerHudResizeHook('%9', '%1', 3, execTmuxSync), true);
-    assert.equal(registerHudResizeHook('%10', '%1', 3, execTmuxSync), true);
-
-    assert.equal(registered[0]?.[3], registered[3]?.[3]);
-  });
-
-  it('does not unregister the legacy hook when installing the leader-scoped hook fails', () => {
-    const calls: string[][] = [];
-
-    const result = registerHudResizeHook('%9', '%1', 3, (args) => {
-      calls.push(args);
-      if (args[0] === 'display-message') return '$7\t@3\n';
-      if (args[0] === 'set-hook' && args[1] === '-t') throw new Error('transient tmux failure');
-      return '';
-    });
-
-    assert.equal(result, false);
-    assert.deepEqual(calls.map((args) => args.slice(0, 2)), [
-      ['display-message', '-p'],
-      ['set-hook', '-t'],
-    ]);
-  });
-
-  it('keeps registration successful when legacy cleanup fails after installing the leader-scoped hook', () => {
-    const calls: string[][] = [];
-
-    const result = registerHudResizeHook('%9', '%1', 3, (args) => {
-      calls.push(args);
-      if (args[0] === 'display-message') return '$7\t@3\n';
-      if (args[0] === 'set-hook' && args[1] === '-u') throw new Error('stale legacy cleanup failure');
-      return '';
-    });
-
-    assert.equal(result, true);
-    assert.equal(calls[1]?.[0], 'set-hook');
-    assert.equal(calls[1]?.[1], '-t');
-    assert.deepEqual(calls[2], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
-  });
-
-  it('unregisters only the leader-scoped hook slot for the selected leader', () => {
-    const unregistered: string[][] = [];
-    const execTmuxSync = (args: string[]) => {
-      if (args[0] === 'display-message') return '$7\t@3\n';
-      unregistered.push(args);
-      return '';
-    };
-
-    assert.equal(unregisterHudResizeHook('%2', execTmuxSync), true);
-
-    assert.deepEqual(unregistered[0], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
-    assert.deepEqual(unregistered[1], [
-      'set-hook',
-      '-u',
-      '-t',
-      '$7',
-      buildHudResizeHookSlot('omx_hud_resize_7_3_2'),
-    ]);
-    assert.deepEqual(unregistered[2], [
-      'set-hook',
-      '-u',
-      '-t',
-      '$7',
-      buildHudLayoutHookSlot('omx_hud_resize_7_3_2'),
-    ]);
+    assert.equal(registerHudResizeHook('%9', '%1', 3, sameLeader), true);
+    assert.equal(registerHudResizeHook('%10', '%1', 3, sameLeader), true);
+    const recreatedResizeSlots = recreated.filter((args) => args[3]?.startsWith('client-resized['));
+    assert.equal(recreatedResizeSlots[0]?.[3], recreatedResizeSlots[1]?.[3]);
   });
 });
 
@@ -350,14 +276,14 @@ describe('HUD pane ownership helpers', () => {
   });
 
   it('splits tmux octal-escaped control separators from live list-panes output', () => {
-    const escapedSeparator = TMUX_PANE_FIELD_SEPARATOR_OCTAL_ESCAPE;
+    const escapedSeparator = '\\037';
     const panes = parseTmuxPaneSnapshot(
       [
         ['%140', 'node', '', '/home/tools/oh-my-codex'].join(escapedSeparator),
         [
           '%202',
           'node',
-          `"exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%140' OMX_ROOT='/tmp/run' '/usr/bin/node' '/repo/dist/cli/omx.js' hud --watch --preset=focused"`,
+          `exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%140' OMX_ROOT='/tmp/run' '/usr/bin/node' '/repo/dist/cli/omx.js' hud --watch --preset=focused`,
           '/home/tools/oh-my-codex.omx-worktrees/launch-fix-default-subagent-fix',
         ].join(escapedSeparator),
       ].join('\n'),
@@ -523,14 +449,16 @@ describe('HUD pane ownership helpers', () => {
     const calls: string[][] = [];
     const execTmuxSync = (args: string[]) => {
       calls.push(args);
+      if (args.at(-1) === '#{pane_id}') return '%1\n%2\n';
       return [
-        '%1\tcodex\tcodex',
-        `%2\tnode\texec env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
-      ].join('\n');
-    };
+        ['%1', 'codex', '0', '0', '160', '47', '46', '160', '50', 'codex', '/repo', '0', '101'].join('\x1f'),
+        ['%2', 'node', '0', '47', '160', '3', '49', '160', '50', `exec env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`, '/repo', '0', '102'].join('\x1f'),
+      ].join('\n') + '\n';
+    }
 
     assert.deepEqual(listCurrentWindowHudPaneIds(undefined, execTmuxSync, { sessionId: 'sess-a' }), ['%2']);
     assert.deepEqual(calls, [
+      ['list-panes', '-F', '#{pane_id}'],
       [
         'list-panes',
         '-F',
@@ -546,6 +474,8 @@ describe('HUD pane ownership helpers', () => {
           '#{window_height}',
           '#{pane_start_command}',
           '#{pane_current_path}',
+          '#{pane_dead}',
+          '#{pane_pid}',
         ].join('\x1f'),
       ],
     ]);

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { execFileSync } from 'child_process';
 import { existsSync } from 'fs';
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_HEIGHT_LINES } from './constants.js';
@@ -8,6 +9,8 @@ export interface TmuxPaneSnapshot {
   paneId: string;
   currentCommand: string;
   startCommand: string;
+  panePid?: string;
+  paneDead?: boolean;
   currentPath?: string;
   paneLeft?: number;
   paneTop?: number;
@@ -48,6 +51,68 @@ type TmuxExecSync = (args: string[]) => string;
 
 /** Upper bound for tmux hook indices (signed 32-bit max). */
 const TMUX_HOOK_INDEX_MAX = 2147483647;
+const PSMUX_PANE_ID_MAX = 0xffff_ffffn;
+const PSMUX_PANE_ID_MAX_DIGITS = PSMUX_PANE_ID_MAX.toString().length;
+
+export function parseCanonicalTmuxPaneId(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const match = /^%(0|[1-9]\d*)$/.exec(value);
+  if (!match || match[1].length > PSMUX_PANE_ID_MAX_DIGITS) return null;
+  try {
+    return BigInt(match[1]) <= PSMUX_PANE_ID_MAX ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parses tmux output used as authority. Authority frames are deliberately
+ * transport-strict: a nonempty body followed by exactly one LF or CRLF.
+ */
+export function parseExactTmuxAuthorityLines(output: string): string[] | null {
+  if (typeof output !== 'string' || output.length < 2) return null;
+  const terminator = output.endsWith('\r\n') ? '\r\n' : output.endsWith('\n') ? '\n' : null;
+  if (!terminator) return null;
+  const body = output.slice(0, -terminator.length);
+  if (body === '' || body.endsWith('\n') || body.includes('\r')) return null;
+  return body.split('\n');
+}
+
+/** Parses one exact, nonempty tmux authority scalar. */
+export function parseExactTmuxAuthorityScalar(output: string): string | null {
+  const lines = parseExactTmuxAuthorityLines(output);
+  return lines?.length === 1 && lines[0] !== '' ? lines[0]! : null;
+}
+
+/**
+ * Tolerant pane parsing is for display metadata only. Callers using its output
+ * as authority MUST first validate framing with parseExactTmuxAuthorityLines.
+ */
+
+function canonicalizePaneSnapshotBatch(panes: readonly TmuxPaneSnapshot[]): TmuxPaneSnapshot[] | null {
+  const paneIds = new Set<string>();
+  const canonicalPanes: TmuxPaneSnapshot[] = [];
+  for (const pane of panes) {
+    const paneId = parseCanonicalTmuxPaneId(pane.paneId);
+    if (!paneId || paneIds.has(paneId)) return null;
+    paneIds.add(paneId);
+    canonicalPanes.push({ ...pane, paneId });
+  }
+  return canonicalPanes;
+}
+
+function parseCanonicalPaneIdSnapshot(output: string): Set<string> | null {
+  const lines = parseExactTmuxAuthorityLines(output);
+  if (!lines) return null;
+
+  const paneIds = new Set<string>();
+  for (const line of lines) {
+    const paneId = parseCanonicalTmuxPaneId(line);
+    if (!paneId || paneIds.has(paneId)) return null;
+    paneIds.add(paneId);
+  }
+  return paneIds;
+}
 
 export interface RegisterHudResizeHookOptions {
   cwd?: string;
@@ -70,9 +135,9 @@ function defaultExecTmuxSync(args: string[]): string {
 }
 
 function parseNonNegativeInteger(value: string | undefined): number | null {
-  if (typeof value !== 'string' || value.trim() === '') return null;
-  const parsed = Number.parseInt(value.trim(), 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  if (typeof value !== 'string' || !/^(?:0|[1-9][0-9]*)$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed <= 4_294_967_295 ? parsed : null;
 }
 
 function parsePositiveInteger(value: string | undefined): number | null {
@@ -80,59 +145,85 @@ function parsePositiveInteger(value: string | undefined): number | null {
   return parsed !== null && parsed > 0 ? parsed : null;
 }
 
-export function parseTmuxPaneSnapshot(output: string): TmuxPaneSnapshot[] {
-  return output
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const fieldSeparator = line.includes(TMUX_PANE_FIELD_SEPARATOR)
-        ? TMUX_PANE_FIELD_SEPARATOR
-        : line.includes(TMUX_PANE_FIELD_SEPARATOR_OCTAL_ESCAPE)
-          ? TMUX_PANE_FIELD_SEPARATOR_OCTAL_ESCAPE
-          : '\t';
-      const parts = line.split(fieldSeparator);
-      const [paneId = '', currentCommand = ''] = parts;
-      const paneLeft = parseNonNegativeInteger(parts[2]);
-      const paneTop = parseNonNegativeInteger(parts[3]);
-      const paneWidth = parsePositiveInteger(parts[4]);
-      const paneHeight = parsePositiveInteger(parts[5]);
-      const paneBottom = parseNonNegativeInteger(parts[6]);
-      const windowWidth = parsePositiveInteger(parts[7]);
-      const windowHeight = parsePositiveInteger(parts[8]);
-      const hasGeometry = (
-        paneLeft !== null
-        && paneTop !== null
-        && paneWidth !== null
-        && paneHeight !== null
-        && paneBottom !== null
-        && windowWidth !== null
-        && windowHeight !== null
-      );
-      const payloadParts = hasGeometry ? parts.slice(9) : parts.slice(2);
-      const hasCurrentPathColumn = payloadParts.length >= 2;
-      const currentPath = hasCurrentPathColumn ? (payloadParts.at(-1) ?? '') : '';
-      const startCommandParts = hasCurrentPathColumn ? payloadParts.slice(0, -1) : payloadParts;
-      const trimmedCurrentPath = currentPath.trim();
-      return {
-        paneId: paneId.trim(),
-        currentCommand: currentCommand.trim(),
-        startCommand: startCommandParts.join('\t').trim(),
-        ...(trimmedCurrentPath ? { currentPath: trimmedCurrentPath } : {}),
-        ...(hasGeometry
-          ? {
-              paneLeft,
-              paneTop,
-              paneWidth,
-              paneHeight,
-              paneBottom,
-              windowWidth,
-              windowHeight,
-            }
-          : {}),
-      };
-    })
-    .filter((pane) => pane.paneId.startsWith('%'));
+export function parseTmuxPaneSnapshot(
+  output: string,
+  authoritativePaneIds?: ReadonlySet<string>,
+): TmuxPaneSnapshot[] {
+  const lines = output.split('\n');
+  if (lines.at(-1) === '') lines.pop();
+  if (lines.length === 0) return [];
+
+  const panes: TmuxPaneSnapshot[] = [];
+  for (const line of lines) {
+    if (line === '') return [];
+    const fieldSeparator = line.includes(TMUX_PANE_FIELD_SEPARATOR)
+      ? TMUX_PANE_FIELD_SEPARATOR
+      : line.includes(TMUX_PANE_FIELD_SEPARATOR_OCTAL_ESCAPE)
+        ? TMUX_PANE_FIELD_SEPARATOR_OCTAL_ESCAPE
+        : '\t';
+    const parts = line.split(fieldSeparator);
+    const [rawPaneId = '', currentCommand = ''] = parts;
+    const paneId = parseCanonicalTmuxPaneId(rawPaneId);
+    if (!paneId) return [];
+    const hasGeometryFields = parts.length >= 9;
+    const paneLeft = parseNonNegativeInteger(parts[2]);
+    const paneTop = parseNonNegativeInteger(parts[3]);
+    const paneWidth = parsePositiveInteger(parts[4]);
+    const paneHeight = parsePositiveInteger(parts[5]);
+    const paneBottom = parseNonNegativeInteger(parts[6]);
+    const windowWidth = parsePositiveInteger(parts[7]);
+    const windowHeight = parsePositiveInteger(parts[8]);
+    const hasGeometry = (
+      paneLeft !== null
+      && paneTop !== null
+      && paneWidth !== null
+      && paneHeight !== null
+      && paneBottom !== null
+      && windowWidth !== null
+      && windowHeight !== null
+    );
+    if (hasGeometryFields && !hasGeometry) return [];
+    const payloadParts = hasGeometry ? parts.slice(9) : parts.slice(2);
+    const hasIncarnationFields = hasGeometry
+      && payloadParts.length >= 4
+      && /^(?:0|1)$/.test(payloadParts.at(-2) ?? '')
+      && parsePositiveInteger(payloadParts.at(-1)) !== null;
+    const incarnationParts = hasIncarnationFields ? payloadParts.slice(-2) : [];
+    const commandParts = hasIncarnationFields ? payloadParts.slice(0, -2) : payloadParts;
+    const hasCurrentPathColumn = commandParts.length >= 2;
+    const currentPath = hasCurrentPathColumn ? (commandParts.at(-1) ?? '') : '';
+    const startCommandParts = hasCurrentPathColumn ? commandParts.slice(0, -1) : commandParts;
+    const trimmedCurrentPath = currentPath.trim();
+    panes.push({
+      paneId,
+      currentCommand: currentCommand.trim(),
+      startCommand: startCommandParts.join('\t').trim(),
+      ...(trimmedCurrentPath ? { currentPath: trimmedCurrentPath } : {}),
+      ...(hasIncarnationFields ? { paneDead: incarnationParts[0] === '1', panePid: incarnationParts[1]! } : {}),
+      ...(hasGeometry
+        ? {
+            paneLeft,
+            paneTop,
+            paneWidth,
+            paneHeight,
+            paneBottom,
+            windowWidth,
+            windowHeight,
+          }
+        : {}),
+    });
+  }
+
+  const canonicalPanes = canonicalizePaneSnapshotBatch(panes);
+  if (!canonicalPanes) return [];
+  if (
+    authoritativePaneIds
+    && (
+      canonicalPanes.length !== authoritativePaneIds.size
+      || canonicalPanes.some((pane) => !authoritativePaneIds.has(pane.paneId))
+    )
+  ) return [];
+  return canonicalPanes;
 }
 
 export function isHudWatchPane(pane: TmuxPaneSnapshot): boolean {
@@ -145,48 +236,303 @@ export function isHudWatchPane(pane: TmuxPaneSnapshot): boolean {
 }
 
 
+const HUD_OWNER_ENV_KEYS = [
+  OMX_TMUX_HUD_OWNER_ENV,
+  'OMX_SESSION_ID',
+  OMX_TMUX_HUD_LEADER_PANE_ENV,
+] as const;
+
+function isHudOwnerEnvKey(key: string): boolean {
+  return HUD_OWNER_ENV_KEYS.some((ownerKey) => ownerKey === key);
+}
+
+function isPowerShellHudOwnerEnvKey(key: string): boolean {
+  return HUD_OWNER_ENV_KEYS.some((ownerKey) => ownerKey === key.toUpperCase());
+}
+
+interface PosixHudEnvAssignments {
+  attempted: boolean;
+  valid: boolean;
+  values: Map<string, string[]>;
+}
+
+function lexPosixWords(command: string): string[] | null {
+  const words: string[] = [];
+  let index = 0;
+  while (index < command.length) {
+    while (/\s/.test(command[index] ?? '')) index += 1;
+    if (index >= command.length) break;
+    if (command[index] === '#') break;
+
+    let word = '';
+    let quoted = false;
+    while (index < command.length && !/\s/.test(command[index] ?? '')) {
+      const char = command[index]!;
+      if (';|&()<>`'.includes(char) || char === '\n' || char === '\r') return null;
+      if (char === '\\') {
+        index += 1;
+        if (index >= command.length) return null;
+        word += command[index]!;
+        index += 1;
+        continue;
+      }
+      if (char === "'") {
+        quoted = true;
+        index += 1;
+        while (index < command.length && command[index] !== "'") {
+          word += command[index]!;
+          index += 1;
+        }
+        if (index >= command.length) return null;
+        index += 1;
+        continue;
+      }
+      if (char === '"') {
+        quoted = true;
+        index += 1;
+        while (index < command.length && command[index] !== '"') {
+          if (command[index] === '\\') {
+            index += 1;
+            if (index >= command.length) return null;
+          }
+          word += command[index]!;
+          index += 1;
+        }
+        if (index >= command.length) return null;
+        index += 1;
+        continue;
+      }
+      word += char;
+      index += 1;
+    }
+    if (!word && !quoted) return null;
+    words.push(word);
+  }
+  return words;
+}
+
+function parsePosixHudEnvAssignments(command: string): PosixHudEnvAssignments {
+  const values = new Map<string, string[]>();
+  const attempted = HUD_OWNER_ENV_KEYS.some((key) => command.includes(key));
+  const words = lexPosixWords(command);
+  if (!words) return { attempted, valid: false, values };
+
+  const inspect = (tokens: string[]): boolean => {
+    let commandStarted = false;
+    let acceptsEnvAssignments = false;
+    for (let index = 0; index < tokens.length; index += 1) {
+      const token = tokens[index]!;
+      const assignment = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(token);
+      if (assignment && isHudOwnerEnvKey(assignment[1]!) && (!commandStarted || acceptsEnvAssignments)) {
+        const key = assignment[1]!;
+        const existing = values.get(key) ?? [];
+        existing.push(assignment[2]!);
+        values.set(key, existing);
+        continue;
+      }
+      if (token === '-c' && index + 1 < tokens.length) {
+        const nested = lexPosixWords(tokens[index + 1]!);
+        if (!nested || !inspect(nested)) return false;
+        commandStarted = true;
+        continue;
+      }
+      if (token === 'exec' && !commandStarted) continue;
+      if (!commandStarted && token === 'env') {
+        commandStarted = true;
+        acceptsEnvAssignments = true;
+        continue;
+      }
+      commandStarted = true;
+      acceptsEnvAssignments = false;
+    }
+    return true;
+  };
+  return { attempted, valid: inspect(words), values };
+}
+
+function parseShellEnvAssignments(command: string, key: string): string[] {
+  const parsed = parsePosixHudEnvAssignments(command);
+  return parsed.valid ? (parsed.values.get(key) ?? []) : [];
+}
+
 function parseShellEnvAssignment(command: string, key: string): string | undefined {
-  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const match = command.match(
-    new RegExp(
-      `(?:^|\\s)(?:'${escapedKey}=([^']*)'|${escapedKey}=(?:'((?:'\\\\''|[^'])*)'|([^\\s]+)))`,
-    ),
-  );
-  const fallbackMatch = match
-    ? null
-    : command.match(new RegExp(`(?:^|[\\s'])${escapedKey}=([^'\\s]+)`));
-  const raw = match?.[1] ?? match?.[2] ?? match?.[3] ?? fallbackMatch?.[1];
-  if (typeof raw !== 'string') return undefined;
-  const value = raw.replace(/'\\''/g, "'").trim();
-  return value === '' ? undefined : value;
+  const values = parseShellEnvAssignments(command, key);
+  return values.length === 1 && values[0] !== '' ? values[0] : undefined;
+}
+
+
+function containsPowerShellHudOwnerReferenceOutsideQuotes(command: string): boolean {
+  let quote: 'single' | 'double' | null = null;
+  let blockComment = false;
+  let lineComment = false;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index]!;
+    const next = command[index + 1];
+    if (blockComment) {
+      if (char === '#' && next === '>') {
+        blockComment = false;
+        index += 1;
+      }
+      continue;
+    }
+    if (lineComment) {
+      if (char === '\n' || char === '\r') lineComment = false;
+      continue;
+    }
+    if (quote === 'single') {
+      if (char === "'" && next === "'") index += 1;
+      else if (char === "'") quote = null;
+      continue;
+    }
+    if (quote === 'double') {
+      if (char === '`') index += 1;
+      else if (char === '"') quote = null;
+      continue;
+    }
+    if (char === '<' && next === '#') {
+      blockComment = true;
+      index += 1;
+      continue;
+    }
+    if (char === '#') {
+      lineComment = true;
+      continue;
+    }
+    if (char === "'") {
+      quote = 'single';
+      continue;
+    }
+    if (char === '"') {
+      quote = 'double';
+      continue;
+    }
+    if (char === '`') {
+      index += 1;
+      continue;
+    }
+    if (command.slice(index, index + 5).toLowerCase() === '$env:') {
+      const match = /^\$env:([A-Za-z_][A-Za-z0-9_]*)/i.exec(command.slice(index));
+      if (match && isPowerShellHudOwnerEnvKey(match[1]!)) return true;
+    }
+  }
+  return false;
+}
+
+interface PowerShellHudEnvPrefix {
+  present: boolean;
+  valid: boolean;
+  values: Map<string, string[]>;
+  remainder: string;
+}
+
+function unwrapKnownPowerShellCommand(command: string): { command: string; remainder: string } | null {
+  const match = /^\s*powershell(?:\.exe)?\s+-NoLogo\s+-NoExit\s+-Command\s+'((?:''|[^'])*)'(.*)$/i.exec(command);
+  if (!match) return null;
+  return { command: match[1]!.replace(/''/g, "'"), remainder: match[2]! };
+}
+
+function parsePowerShellHudEnvPrefix(command: string): PowerShellHudEnvPrefix {
+  const unwrapped = unwrapKnownPowerShellCommand(command);
+  const source = unwrapped?.command ?? command;
+  const present = containsPowerShellHudOwnerReferenceOutsideQuotes(source);
+  const values = new Map<string, string[]>();
+  if (!present) return { present: false, valid: false, values, remainder: command };
+
+  const prefixMatch = /^\s*((?:\$env:[A-Za-z_][A-Za-z0-9_]*\s*=\s*'(?:''|[^'])*'\s*;\s*)+)&(?:\s|$)/i.exec(source);
+  if (!prefixMatch) return { present: true, valid: false, values, remainder: command };
+  const assignmentPattern = /\$env:([A-Za-z_][A-Za-z0-9_]*)\s*=\s*'((?:''|[^'])*)'\s*;/gi;
+  for (const match of prefixMatch[1]!.matchAll(assignmentPattern)) {
+    const key = match[1]!.toUpperCase();
+    const existing = values.get(key) ?? [];
+    existing.push(match[2]!.replace(/''/g, "'"));
+    values.set(key, existing);
+  }
+  const remainder = `${source.slice(prefixMatch[0].length)}${unwrapped?.remainder ?? ''}`;
+  return { present: true, valid: true, values, remainder };
+}
+
+function hasHudOwnerMetadataAttempt(command: string): boolean {
+  return parsePowerShellHudEnvPrefix(command).present || parsePosixHudEnvAssignments(command).attempted;
+}
+
+function isInvalidHudOwnerValue(key: string, value: string): boolean {
+  return value === '' || (key === OMX_TMUX_HUD_OWNER_ENV && value !== '1');
+}
+
+function parseHudEnvAssignment(command: string, key: string): string | undefined {
+  const posix = parsePosixHudEnvAssignments(command);
+  const powerShellPrefix = parsePowerShellHudEnvPrefix(command);
+  if (powerShellPrefix.present) return powerShellPrefix.valid ? (powerShellPrefix.values.get(key.toUpperCase())?.length === 1 ? powerShellPrefix.values.get(key.toUpperCase())![0] : undefined) : undefined;
+  return posix.valid ? parseShellEnvAssignment(command, key) : undefined;
+}
+
+function hasAmbiguousHudOwnerMetadata(command: string): boolean {
+  const posix = parsePosixHudEnvAssignments(command);
+  const powerShellPrefix = parsePowerShellHudEnvPrefix(command);
+  if (powerShellPrefix.present) {
+    if (
+      !powerShellPrefix.valid
+      || posix.values.size > 0
+      || containsPowerShellHudOwnerReferenceOutsideQuotes(powerShellPrefix.remainder)
+      || parsePosixHudEnvAssignments(powerShellPrefix.remainder).attempted
+    ) return true;
+    return HUD_OWNER_ENV_KEYS.some((key) => {
+      const values = powerShellPrefix.values.get(key) ?? [];
+      return values.length > 1 || (values.length === 1 && isInvalidHudOwnerValue(key, values[0]!));
+    });
+  }
+  if (posix.attempted && (!posix.valid || posix.values.size === 0)) return true;
+  return HUD_OWNER_ENV_KEYS.some((key) => {
+    const values = posix.values.get(key) ?? [];
+    return values.length > 1 || (values.length === 1 && isInvalidHudOwnerValue(key, values[0]!));
+  });
 }
 
 export function readHudPaneOwner(pane: TmuxPaneSnapshot): HudPaneOwner {
   const command = `${pane.startCommand} ${pane.currentCommand}`;
+  const rawLeaderPaneId = parseHudEnvAssignment(command, OMX_TMUX_HUD_LEADER_PANE_ENV);
+  if (
+    hasAmbiguousHudOwnerMetadata(command)
+    || (rawLeaderPaneId !== undefined && !parseCanonicalTmuxPaneId(rawLeaderPaneId))
+  ) {
+    return { sessionId: undefined, leaderPaneId: undefined };
+  }
   return {
-    sessionId: parseShellEnvAssignment(command, 'OMX_SESSION_ID'),
-    leaderPaneId: parseShellEnvAssignment(command, OMX_TMUX_HUD_LEADER_PANE_ENV),
+    sessionId: parseHudEnvAssignment(command, 'OMX_SESSION_ID'),
+    leaderPaneId: rawLeaderPaneId ? parseCanonicalTmuxPaneId(rawLeaderPaneId) ?? undefined : undefined,
   };
 }
 
-
 function hasHudPaneOwnerMetadata(pane: TmuxPaneSnapshot): boolean {
   const command = `${pane.startCommand} ${pane.currentCommand}`;
-  const owner = readHudPaneOwner(pane);
-  return parseShellEnvAssignment(command, OMX_TMUX_HUD_OWNER_ENV) === '1'
-    || Boolean(owner.sessionId || owner.leaderPaneId);
+  return hasHudOwnerMetadataAttempt(command) && !hasAmbiguousHudOwnerMetadata(command);
+}
+
+export function hasValidHudOwnerMarker(pane: TmuxPaneSnapshot): boolean {
+  const command = `${pane.startCommand} ${pane.currentCommand}`;
+  if (hasAmbiguousHudOwnerMetadata(command)) return false;
+  return parseHudEnvAssignment(command, OMX_TMUX_HUD_OWNER_ENV) === '1';
 }
 
 function hasOmxCliToken(command: string): boolean {
   return /(?:^|[\s'"])(?:[^\s'"]*\/)?omx(?:\.js)?(?=$|[\s'"])/.test(command);
 }
 
+function hasPowerShellEnvironmentAssignmentPrefix(command: string): boolean {
+  return /^\s*(?:\$env:[A-Za-z_][A-Za-z0-9_]*\s*=\s*(?:'(?:''|[^'])*'|"(?:`.|[^"])*")\s*;\s*)+&(?:\s|$)/i.test(command);
+}
+
 function isLegacyFocusedHudWatchPane(pane: TmuxPaneSnapshot): boolean {
   // Migration-only heuristic for prompt-submit auto-HUD reconciliation: older
   // focused auto-HUD panes lacked owner metadata, so keep this deliberately
   // narrower than general HUD ownership/reaping.
-  if (!isHudWatchPane(pane) || hasHudPaneOwnerMetadata(pane)) return false;
   const command = `${pane.startCommand} ${pane.currentCommand}`;
+  if (
+    !isHudWatchPane(pane)
+    || hasHudOwnerMetadataAttempt(command)
+    || hasPowerShellEnvironmentAssignmentPrefix(command)
+  ) return false;
   return hasOmxCliToken(command)
     && !/(?:^|[\s'"])--tmux(?:[\s'"]|$)/.test(command)
     && /(?:^|[\s'"])--preset=focused(?:[\s'"]|$)/.test(command);
@@ -196,24 +542,30 @@ export function findLegacyFocusedHudWatchPaneIds(
   panes: TmuxPaneSnapshot[],
   currentPaneId?: string,
 ): string[] {
-  return panes
-    .filter((pane) => pane.paneId !== currentPaneId)
+  const canonicalPanes = canonicalizePaneSnapshotBatch(panes);
+  const canonicalCurrentPaneId = currentPaneId ? parseCanonicalTmuxPaneId(currentPaneId) : null;
+  if (!canonicalPanes || (currentPaneId && !canonicalCurrentPaneId)) return [];
+  return canonicalPanes
+    .filter((pane) => pane.paneId !== canonicalCurrentPaneId)
     .filter((pane) => isLegacyFocusedHudWatchPane(pane))
     .map((pane) => pane.paneId);
 }
 
 export function hudPaneMatchesOwner(pane: TmuxPaneSnapshot, owner: HudPaneOwner = {}): boolean {
-  if (!isHudWatchPane(pane)) return false;
+  if (!parseCanonicalTmuxPaneId(pane.paneId) || !isHudWatchPane(pane)) return false;
   const wantedSessionIds = [
     typeof owner.sessionId === 'string' ? owner.sessionId.trim() : '',
     ...(Array.isArray(owner.sessionIds) ? owner.sessionIds : []),
   ]
     .map((sessionId) => sessionId.trim())
     .filter((sessionId, index, sessionIds) => sessionId !== '' && sessionIds.indexOf(sessionId) === index);
-  const wantedLeaderPaneId = typeof owner.leaderPaneId === 'string' ? owner.leaderPaneId.trim() : '';
+  const rawWantedLeaderPaneId = typeof owner.leaderPaneId === 'string' ? owner.leaderPaneId : '';
+  const wantedLeaderPaneId = rawWantedLeaderPaneId ? parseCanonicalTmuxPaneId(rawWantedLeaderPaneId) : null;
+  if (rawWantedLeaderPaneId && !wantedLeaderPaneId) return false;
   const wantsSession = wantedSessionIds.length > 0;
-  const wantsLeaderPane = wantedLeaderPaneId !== '';
+  const wantsLeaderPane = wantedLeaderPaneId !== null;
   if (!wantsSession && !wantsLeaderPane) return true;
+  if (hasAmbiguousHudOwnerMetadata(`${pane.startCommand} ${pane.currentCommand}`)) return false;
 
   const paneOwner = readHudPaneOwner(pane);
   const sessionMatches = wantsSession && wantedSessionIds.includes(paneOwner.sessionId ?? '');
@@ -228,13 +580,17 @@ export function hudPaneMatchesOwner(pane: TmuxPaneSnapshot, owner: HudPaneOwner 
   return leaderPaneMatches;
 }
 
+
 export function findHudWatchPaneIds(
   panes: TmuxPaneSnapshot[],
   currentPaneId?: string,
   owner: HudPaneOwner = {},
 ): string[] {
-  return panes
-    .filter((pane) => pane.paneId !== currentPaneId)
+  const canonicalPanes = canonicalizePaneSnapshotBatch(panes);
+  const canonicalCurrentPaneId = currentPaneId ? parseCanonicalTmuxPaneId(currentPaneId) : null;
+  if (!canonicalPanes || (currentPaneId && !canonicalCurrentPaneId)) return [];
+  return canonicalPanes
+    .filter((pane) => pane.paneId !== canonicalCurrentPaneId)
     .filter((pane) => hudPaneMatchesOwner(pane, owner))
     .map((pane) => pane.paneId);
 }
@@ -256,8 +612,15 @@ function isDoctorSmokeSessionId(sessionId: string | undefined): boolean {
 function shouldReapDeletedCwdHudPane(pane: TmuxPaneSnapshot, isLivePane: (paneId: string) => boolean): boolean {
   // A deleted tmux launch cwd is not enough to prove a HUD is dead: watch mode can
   // keep serving from a resolved live cwd. Reap only explicit doctor smoke panes or
-  // owner-tagged panes whose leader is gone.
-  if (!hasHudPaneOwnerMetadata(pane) || !hasDeletedTmuxPaneMarker(pane.currentPath)) return false;
+  // owner-tagged panes whose canonical leader is gone.
+  const command = `${pane.startCommand} ${pane.currentCommand}`;
+  const rawLeaderPaneId = parseHudEnvAssignment(command, OMX_TMUX_HUD_LEADER_PANE_ENV);
+  if (
+    !hasHudPaneOwnerMetadata(pane)
+    || !hasDeletedTmuxPaneMarker(pane.currentPath)
+    || hasAmbiguousHudOwnerMetadata(command)
+    || (rawLeaderPaneId !== undefined && !parseCanonicalTmuxPaneId(rawLeaderPaneId))
+  ) return false;
   const owner = readHudPaneOwner(pane);
   if (isDoctorSmokeSessionId(owner.sessionId)) return true;
   if (!isDeletedTmuxPanePath(pane.currentPath)) return false;
@@ -271,17 +634,26 @@ export function reapDeadHudPanes(
     killPane?: (paneId: string) => boolean;
   } = {},
 ): { reaped: string[]; preserved: string[] } {
-  const livePaneIds = new Set(panes.map((pane) => pane.paneId));
+  const canonicalPanes = canonicalizePaneSnapshotBatch(panes);
+  if (!canonicalPanes) return { reaped: [], preserved: panes.map((pane) => pane.paneId) };
+  const livePaneIds = new Set(canonicalPanes.map((pane) => pane.paneId));
   const isLivePane = opts.isLivePane ?? ((paneId: string) => livePaneIds.has(paneId));
   const killPane = opts.killPane ?? ((paneId: string) => killTmuxPane(paneId));
   const reaped: string[] = [];
   const preserved: string[] = [];
 
-  for (const pane of panes) {
+  for (const pane of canonicalPanes) {
     if (!isHudWatchPane(pane)) continue;
 
     if (shouldReapDeletedCwdHudPane(pane, isLivePane) && killPane(pane.paneId)) {
       reaped.push(pane.paneId);
+      continue;
+    }
+
+    // Never let HUD-looking command text authorize a destructive pane mutation.
+    // Only metadata accepted by the strict owner parsers may do so.
+    if (!hasHudPaneOwnerMetadata(pane)) {
+      preserved.push(pane.paneId);
       continue;
     }
 
@@ -307,8 +679,9 @@ export function reapDeadHudPanes(
 }
 
 export function parsePaneIdFromTmuxOutput(rawOutput: string): string | null {
-  const paneId = rawOutput.split('\n')[0]?.trim() || '';
-  return paneId.startsWith('%') ? paneId : null;
+  const lines = rawOutput.split('\n');
+  if (lines.at(-1) === '') lines.pop();
+  return lines.length === 1 ? parseCanonicalTmuxPaneId(lines[0]) : null;
 }
 
 export function shellEscapeSingle(value: string): string {
@@ -328,9 +701,6 @@ function isTmuxWindowId(value: string): boolean {
   return /^@\d+$/.test(value);
 }
 
-function isTmuxPaneId(value: string): boolean {
-  return /^%\d+$/.test(value);
-}
 
 export function buildHudResizeHookName(sessionId: string, windowId: string, leaderPaneId: string): string {
   return [
@@ -341,13 +711,6 @@ export function buildHudResizeHookName(sessionId: string, windowId: string, lead
   ].join('_');
 }
 
-function buildLegacyHudResizeHookName(sessionId: string, windowId: string): string {
-  return [
-    'omx_hud_resize',
-    normalizeTmuxHookToken(sessionId),
-    normalizeTmuxHookToken(windowId),
-  ].join('_');
-}
 
 export function buildHudResizeHookSlot(hookName: string): string {
   let hash = 0;
@@ -365,27 +728,95 @@ export function buildHudLayoutHookSlot(hookName: string): string {
   return `window-layout-changed[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
 }
 
+function hudHookIdentityOption(hookSlot: string): string {
+  const match = /^(client-resized|window-layout-changed)\[([0-9]+)\]$/.exec(hookSlot);
+  if (!match) throw new Error('invalid_tmux_hook_slot');
+  return `@omx_hook_identity_${match[1].replaceAll('-', '_')}_${match[2]}`;
+}
+
+function hudHookIdentityToken(hookName: string, hookSlot: string): string {
+  let hash = 2166136261;
+  for (const char of `${hookName}:${hookSlot}`) hash = Math.imul(hash ^ char.charCodeAt(0), 16777619);
+  return `omx-${(hash >>> 0).toString(16)}`;
+}
+
+function buildHudHookRegistrationSuffix(context: HudResizeHookContext, hookSlot: string): string[] {
+  return [
+    '\\;', 'set-option', '-t', context.sessionId,
+    hudHookIdentityOption(hookSlot), hudHookIdentityToken(context.hookName, hookSlot),
+  ];
+}
+
+function buildGuardedHudHookUnregisterArgs(context: HudResizeHookContext, hookSlot: string): string[] {
+  const identityOption = hudHookIdentityOption(hookSlot);
+  return [
+    'if-shell', '-F', '-t', context.sessionId,
+    `#{==:${identityOption},${hudHookIdentityToken(context.hookName, hookSlot)}}`,
+    `set-hook -u -t ${context.sessionId} ${hookSlot} \\; set-option -u -t ${context.sessionId} ${identityOption}`,
+    '',
+  ];
+}
+
 export interface HudResizeHookContext {
   sessionId: string;
   windowId: string;
   leaderPaneId: string;
+  leaderPanePid: string;
+  hudPaneId: string;
+  hudPanePid: string;
   hookName: string;
   hookSlot: string;
   layoutHookSlot: string;
 }
 
-export function parseHudResizeHookContext(output: string, leaderPaneId: string): HudResizeHookContext | null {
-  const [sessionId = '', windowId = ''] = output
-    .split('\n')[0]
-    ?.split('\t')
-    .map((part) => part.trim()) ?? [];
-  const normalizedLeaderPaneId = leaderPaneId.trim();
-  if (!isTmuxSessionId(sessionId) || !isTmuxWindowId(windowId) || !isTmuxPaneId(normalizedLeaderPaneId)) return null;
+function readHudResizeHookPaneIncarnations(
+  hudPaneId: string,
+  leaderPaneId: string,
+  execTmuxSync: TmuxExecSync,
+): { leaderPanePid: string; hudPanePid: string } | null {
+  try {
+    const lines = parseExactTmuxAuthorityLines(execTmuxSync(['list-panes', '-a', '-F', '#{pane_id} #{pane_dead} #{pane_pid}']));
+    if (!lines) return null;
+    const seen = new Set<string>();
+    let leaderPanePid: string | null = null;
+    let hudPanePid: string | null = null;
+    for (const line of lines) {
+      const match = /^(%\S+) ([01]) ([1-9][0-9]*)$/.exec(line);
+      const paneId = match ? parseCanonicalTmuxPaneId(match[1]) : null;
+      if (!match || !paneId || paneId !== match[1] || seen.has(paneId)) return null;
+      seen.add(paneId);
+      if (match[2] === '1') continue;
+      if (paneId === leaderPaneId) leaderPanePid = match[3]!;
+      if (paneId === hudPaneId) hudPanePid = match[3]!;
+    }
+    return leaderPanePid && hudPanePid ? { leaderPanePid, hudPanePid } : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseHudResizeHookContext(
+  output: string,
+  leaderPaneId: string,
+  hudPaneId: string = leaderPaneId,
+  incarnations: { leaderPanePid: string; hudPanePid: string } = { leaderPanePid: '1', hudPanePid: '1' },
+): HudResizeHookContext | null {
+  const line = parseExactTmuxAuthorityScalar(output);
+  if (line === null) return null;
+  const parts = line.split('\t');
+  if (parts.length !== 2 || parts.some((part) => part.trim() !== part || part === '')) return null;
+  const [sessionId = '', windowId = ''] = parts;
+  const normalizedLeaderPaneId = parseCanonicalTmuxPaneId(leaderPaneId);
+  const normalizedHudPaneId = parseCanonicalTmuxPaneId(hudPaneId);
+  if (!isTmuxSessionId(sessionId) || !isTmuxWindowId(windowId) || !normalizedLeaderPaneId || !normalizedHudPaneId) return null;
   const hookName = buildHudResizeHookName(sessionId, windowId, normalizedLeaderPaneId);
   return {
     sessionId,
     windowId,
     leaderPaneId: normalizedLeaderPaneId,
+    leaderPanePid: incarnations.leaderPanePid,
+    hudPaneId: normalizedHudPaneId,
+    hudPanePid: incarnations.hudPanePid,
     hookName,
     hookSlot: buildHudResizeHookSlot(hookName),
     layoutHookSlot: buildHudLayoutHookSlot(hookName),
@@ -393,29 +824,92 @@ export function parseHudResizeHookContext(output: string, leaderPaneId: string):
 }
 
 export function readHudResizeHookContext(
+  hudPaneId: string | undefined,
   leaderPaneId: string | undefined,
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
 ): HudResizeHookContext | null {
-  if (!leaderPaneId || !isTmuxPaneId(leaderPaneId)) return null;
+  const canonicalLeaderPaneId = parseCanonicalTmuxPaneId(leaderPaneId);
+  const canonicalHudPaneId = parseCanonicalTmuxPaneId(hudPaneId);
+  if (!canonicalLeaderPaneId || !canonicalHudPaneId) return null;
+  const incarnations = readHudResizeHookPaneIncarnations(canonicalHudPaneId, canonicalLeaderPaneId, execTmuxSync);
+  if (!incarnations) return null;
   try {
     return parseHudResizeHookContext(
       execTmuxSync([
         'display-message',
         '-p',
         '-t',
-        leaderPaneId,
+        canonicalLeaderPaneId,
         '#{session_id}\t#{window_id}',
       ]),
-      leaderPaneId,
+      canonicalLeaderPaneId,
+      canonicalHudPaneId,
+      incarnations,
     );
   } catch {
     return null;
   }
 }
 
+
 function buildNestedTmuxCommand(tmuxBin: string, args: string[], tmuxEnv?: string): string {
   const command = [tmuxBin, ...args].map((part) => shellEscapeSingle(part)).join(' ');
   return `${buildEnvPrefix({ TMUX: tmuxEnv })}${command}`;
+}
+
+function quoteHudHookShellArgument(value: string): string {
+  return process.platform === 'win32'
+    ? `'${value.replace(/'/g, "''")}'`
+    : shellEscapeSingle(value);
+}
+
+function buildHudHookIncarnationCondition(paneId: string, panePid: string): string {
+  return `#{&&:#{==:#{pane_id},${paneId}},#{&&:#{==:#{pane_dead},0},#{==:#{pane_pid},${panePid}}}}`;
+}
+
+function buildHudHookSelfUnregister(context: HudResizeHookContext): string {
+  const identityOption = hudHookIdentityOption(context.hookSlot);
+  return `if-shell -F -t ${context.sessionId} ${quoteHudHookShellArgument(`#{==:${identityOption},${hudHookIdentityToken(context.hookName, context.hookSlot)}}`)} ${quoteHudHookShellArgument(`set-hook -u -t ${context.sessionId} ${context.hookSlot} \\; set-option -u -t ${context.sessionId} ${identityOption}`)} ''`;
+}
+
+function buildAtomicHudHookCommand(
+  tmuxBin: string,
+  context: HudResizeHookContext,
+  success: string,
+  tmuxEnv?: string,
+): string {
+  const unregister = buildHudHookSelfUnregister(context);
+  const hudConditional = [
+    'if-shell', '-F', '-t', context.hudPaneId,
+    quoteHudHookShellArgument(buildHudHookIncarnationCondition(context.hudPaneId, context.hudPanePid)),
+    quoteHudHookShellArgument(success),
+    quoteHudHookShellArgument(unregister),
+  ].join(' ');
+  const args = [
+    'if-shell', '-F', '-t', context.leaderPaneId,
+    buildHudHookIncarnationCondition(context.leaderPaneId, context.leaderPanePid),
+    hudConditional,
+    unregister,
+  ];
+  if (process.platform === 'win32') {
+    const quotePowerShell = (value: string) => `'${value.replace(/'/g, "''")}'`;
+    const invoke = `& ${quotePowerShell(tmuxBin)} ${args.map(quotePowerShell).join(' ')}`;
+    return tmuxEnv
+      ? `& { $env:TMUX = ${quotePowerShell(tmuxEnv)}; ${invoke} } | Out-Null`
+      : `${invoke} | Out-Null`;
+  }
+  const command = buildNestedTmuxCommand(tmuxBin, args, tmuxEnv);
+  return `${command} >/dev/null 2>&1 || true`;
+}
+
+function buildAtomicHudResizeCommand(
+  tmuxBin: string,
+  hudPaneId: string,
+  height: string,
+  context: HudResizeHookContext,
+  tmuxEnv?: string,
+): string {
+  return buildAtomicHudHookCommand(tmuxBin, context, `resize-pane -t ${hudPaneId} -y ${height}`, tmuxEnv);
 }
 
 function buildHudResizeHookCommand(
@@ -425,17 +919,12 @@ function buildHudResizeHookCommand(
   context: HudResizeHookContext,
   tmuxEnv?: string,
 ): string {
-  const resize = buildNestedTmuxCommand(tmuxBin, ['resize-pane', '-t', hudPaneId, '-y', height], tmuxEnv);
-  const unregister = buildHudHookUnregisterCommand(tmuxBin, context, tmuxEnv);
-  const resizeOrUnregister = `${resize} >/dev/null 2>&1 || (${unregister})`;
-  return `${resizeOrUnregister}; sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; ${resizeOrUnregister}`;
+  const atomicResize = buildAtomicHudResizeCommand(tmuxBin, hudPaneId, height, context, tmuxEnv);
+  return process.platform === 'win32'
+    ? `${atomicResize}; Start-Sleep -Seconds ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; ${atomicResize}`
+    : `${atomicResize}; sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; ${atomicResize}`;
 }
 
-function buildHudHookUnregisterCommand(tmuxBin: string, context: HudResizeHookContext, tmuxEnv?: string): string {
-  const unregisterResize = buildNestedTmuxCommand(tmuxBin, ['set-hook', '-u', '-t', context.sessionId, context.hookSlot], tmuxEnv);
-  const unregisterLayout = buildNestedTmuxCommand(tmuxBin, ['set-hook', '-u', '-t', context.sessionId, context.layoutHookSlot], tmuxEnv);
-  return `${unregisterResize} >/dev/null 2>&1 || true; ${unregisterLayout} >/dev/null 2>&1 || true`;
-}
 
 function buildHudLayoutReconcileHookCommand(
   tmuxBin: string,
@@ -446,8 +935,6 @@ function buildHudLayoutReconcileHookCommand(
 ): string {
   const env = options.env ?? process.env;
   const cwd = options.cwd?.trim() || process.cwd();
-  const leaderAlive = buildNestedTmuxCommand(tmuxBin, ['display-message', '-p', '-t', leaderPaneId, '#{pane_id}'], env.TMUX);
-  const unregister = buildHudHookUnregisterCommand(tmuxBin, context, env.TMUX);
   const reconcileEnv = buildEnvPrefix({
     TMUX: env.TMUX,
     TMUX_PANE: leaderPaneId,
@@ -466,21 +953,24 @@ function buildHudLayoutReconcileHookCommand(
     'hud',
     '--reconcile-tmux',
   ].join(' ');
-  return `${leaderAlive} >/dev/null 2>&1 && (${unregister}; ${reconcile} >/dev/null 2>&1; status=$?; exit $status) || (${unregister})`;
+  const layoutContext = { ...context, hookSlot: context.layoutHookSlot };
+  if (process.platform === 'win32') {
+    const nativeReconcile = `Set-Location -LiteralPath '${cwd.replace(/'/g, "''")}'; & '${process.execPath.replace(/'/g, "''")}' '${omxBin.replace(/'/g, "''")}' hud --reconcile-tmux | Out-Null`;
+    const success = `${buildHudHookSelfUnregister(layoutContext)} \\; run-shell -b ${quoteHudHookShellArgument(nativeReconcile)}`;
+    return buildAtomicHudHookCommand(tmuxBin, layoutContext, success, env.TMUX);
+  }
+  const success = `${buildHudHookSelfUnregister(layoutContext)} \\; run-shell -b ${quoteHudHookShellArgument(`${reconcile} >/dev/null 2>&1`)}`;
+  return buildAtomicHudHookCommand(tmuxBin, layoutContext, success, env.TMUX);
 }
 
 function unregisterLegacyHudResizeHook(
   context: HudResizeHookContext,
   execTmuxSync: TmuxExecSync,
 ): void {
-  const legacyHookSlot = buildHudResizeHookSlot(buildLegacyHudResizeHookName(context.sessionId, context.windowId));
-  if (legacyHookSlot === context.hookSlot) return;
-  try {
-    execTmuxSync(['set-hook', '-u', '-t', context.sessionId, legacyHookSlot]);
-  } catch {
-    // Best-effort migration cleanup: failure should not prevent the new
-    // leader-scoped hook from being registered or unregistered.
-  }
+  // Legacy registrations predate identity metadata. Leaving them untouched is
+  // safer than clearing a slot that may now belong to another registration.
+  void context;
+  void execTmuxSync;
 }
 
 function buildEnvPrefix(env: Record<string, string | undefined>): string {
@@ -490,9 +980,45 @@ function buildEnvPrefix(env: Record<string, string | undefined>): string {
     .map(([key, value]) => `${key}=${shellEscapeSingle(value)}`);
   return assignments.length > 0 ? `env ${assignments.join(' ')} ` : '';
 }
+
+export interface HudCommandWriterOptions {
+  omxEntry: string;
+  runtimeEnv: Record<string, string>;
+  nodeCommand: string;
+  preset?: string;
+  platform?: NodeJS.Platform;
+  powerShellEnvelope?: boolean;
+  quoteOwnerValue?: boolean;
+}
+
+/** The sole platform-aware serializer for tmux HUD watch commands. */
+export function writeHudWatchCommand(options: HudCommandWriterOptions): string {
+  const safePreset = options.preset === 'minimal' || options.preset === 'focused' || options.preset === 'full'
+    ? `--preset=${options.preset}`
+    : undefined;
+  const platform = options.platform ?? process.platform;
+  const presetArgument = safePreset ? ` ${shellEscapeSingle(safePreset)}` : '';
+  if (platform === 'win32') {
+    const quotePowerShell = (value: string) => `'${value.replace(/'/g, "''")}'`;
+    const assignments = Object.entries(options.runtimeEnv)
+      .map(([key, value]) => `$env:${key} = ${quotePowerShell(value)}`)
+      .join('; ');
+    const invocation = ['&', quotePowerShell(options.nodeCommand), quotePowerShell(options.omxEntry), 'hud', '--watch', ...(safePreset ? [safePreset] : [])].join(' ');
+    const script = `${assignments}; ${invocation}`;
+    return options.powerShellEnvelope
+      ? `powershell.exe -NoLogo -NoExit -Command ${quotePowerShell(script)}`
+      : script;
+  }
+  const assignments = Object.entries(options.runtimeEnv)
+    .map(([key, value]) => `${key}=${key === OMX_TMUX_HUD_OWNER_ENV && !options.quoteOwnerValue ? value : shellEscapeSingle(value)}`)
+    .join(' ');
+  const nodeCommand = options.nodeCommand === 'node' ? 'node' : shellEscapeSingle(options.nodeCommand);
+  return `exec ${assignments ? `env ${assignments} ` : ''}${nodeCommand} ${shellEscapeSingle(options.omxEntry)} hud --watch${presetArgument}`;
+}
 export function buildHudRuntimeEnv(input: HudRuntimeEnvInput = {}): HudRuntimeEnvOutput {
   const sessionId = typeof input.sessionId === 'string' ? input.sessionId.trim() : '';
-  const leaderPaneId = typeof input.leaderPaneId === 'string' ? input.leaderPaneId.trim() : '';
+  const rawLeaderPaneId = typeof input.leaderPaneId === 'string' ? input.leaderPaneId : '';
+  const leaderPaneId = rawLeaderPaneId ? parseCanonicalTmuxPaneId(rawLeaderPaneId) : null;
   const env: Record<string, string> = {};
   if (sessionId) env.OMX_SESSION_ID = sessionId;
   env[OMX_TMUX_HUD_OWNER_ENV] = '1';
@@ -520,44 +1046,63 @@ export function buildHudWatchCommand(
   omxRoot?: string,
   leaderPaneId?: string,
   rootEnv?: Pick<HudRuntimeEnvInput, 'omxStateRoot' | 'omxTeamStateRoot' | 'rootSource'>,
+  platform: NodeJS.Platform = process.platform,
 ): string {
-  const safePreset = preset === 'minimal' || preset === 'focused' || preset === 'full'
-    ? ` --preset=${preset}`
-    : '';
-  const envPrefix = buildEnvPrefix(buildHudRuntimeEnv({
+  const runtimeEnv = buildHudRuntimeEnv({
     sessionId,
     leaderPaneId,
     omxRoot,
     ...(rootEnv ?? { rootSource: 'omx-root-env' }),
-  }).env);
-  return `exec ${envPrefix}${shellEscapeSingle(process.execPath)} ${shellEscapeSingle(omxBin)} hud --watch${safePreset}`;
+  }).env;
+  return writeHudWatchCommand({
+    omxEntry: omxBin,
+    runtimeEnv,
+    nodeCommand: process.execPath,
+    preset,
+    platform,
+    powerShellEnvelope: platform === 'win32',
+    quoteOwnerValue: true,
+  });
 }
 
 export function listCurrentWindowPanes(
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
   currentPaneId?: string,
 ): TmuxPaneSnapshot[] {
+  const canonicalCurrentPaneId = currentPaneId ? parseCanonicalTmuxPaneId(currentPaneId) : null;
+  if (currentPaneId && !canonicalCurrentPaneId) return [];
+
+  const targetArgs = canonicalCurrentPaneId ? ['-t', canonicalCurrentPaneId] : [];
   try {
-    return parseTmuxPaneSnapshot(
-      execTmuxSync([
-        'list-panes',
-        ...(currentPaneId ? ['-t', currentPaneId] : []),
-        '-F',
-        [
-          '#{pane_id}',
-          '#{pane_current_command}',
-          '#{pane_left}',
-          '#{pane_top}',
-          '#{pane_width}',
-          '#{pane_height}',
-          '#{pane_bottom}',
-          '#{window_width}',
-          '#{window_height}',
-          '#{pane_start_command}',
-          '#{pane_current_path}',
-        ].join(TMUX_PANE_FIELD_SEPARATOR),
-      ]),
-    );
+    const paneIds = parseCanonicalPaneIdSnapshot(execTmuxSync([
+      'list-panes',
+      ...targetArgs,
+      '-F',
+      '#{pane_id}',
+    ]));
+    if (!paneIds) return [];
+    const paneSnapshotOutput = execTmuxSync([
+      'list-panes',
+      ...targetArgs,
+      '-F',
+      [
+        '#{pane_id}',
+        '#{pane_current_command}',
+        '#{pane_left}',
+        '#{pane_top}',
+        '#{pane_width}',
+        '#{pane_height}',
+        '#{pane_bottom}',
+        '#{window_width}',
+        '#{window_height}',
+        '#{pane_start_command}',
+        '#{pane_current_path}',
+        '#{pane_dead}',
+        '#{pane_pid}',
+      ].join(TMUX_PANE_FIELD_SEPARATOR),
+    ]);
+    if (!parseExactTmuxAuthorityLines(paneSnapshotOutput)) return [];
+    return parseTmuxPaneSnapshot(paneSnapshotOutput, paneIds);
   } catch {
     return [];
   }
@@ -567,7 +1112,8 @@ export function readActiveTmuxPaneId(
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
 ): string | null {
   try {
-    return parsePaneIdFromTmuxOutput(execTmuxSync(['display-message', '-p', '#{pane_id}']));
+    const paneId = parseExactTmuxAuthorityScalar(execTmuxSync(['display-message', '-p', '#{pane_id}']));
+    return parseCanonicalTmuxPaneId(paneId);
   } catch {
     return null;
   }
@@ -585,24 +1131,279 @@ export function readCurrentWindowSize(
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
   currentPaneId?: string,
 ): { width: number | null; height: number | null } {
+  const canonicalCurrentPaneId = currentPaneId ? parseCanonicalTmuxPaneId(currentPaneId) : null;
+  if (currentPaneId && !canonicalCurrentPaneId) return { width: null, height: null };
+
   try {
     const raw = execTmuxSync([
       'display-message',
       '-p',
-      ...(currentPaneId ? ['-t', currentPaneId] : []),
+      ...(canonicalCurrentPaneId ? ['-t', canonicalCurrentPaneId] : []),
       '#{window_width}\t#{window_height}',
     ]);
-    const [widthRaw = '', heightRaw = ''] = raw.split('\t');
-    const width = Number.parseInt(widthRaw.trim(), 10);
-    const height = Number.parseInt(heightRaw.trim(), 10);
-    return {
-      width: Number.isFinite(width) && width > 0 ? width : null,
-      height: Number.isFinite(height) && height > 0 ? height : null,
-    };
+    const framed = parseExactTmuxAuthorityScalar(raw);
+    if (framed === null) return { width: null, height: null };
+    const fields = framed.split('\t');
+    if (fields.length !== 2) return { width: null, height: null };
+    const width = parsePositiveInteger(fields[0]);
+    const height = parsePositiveInteger(fields[1]);
+    return { width, height };
   } catch {
     return { width: null, height: null };
   }
 }
+
+interface HudSplitAuthority {
+  proofOption: string;
+  proofValue: string;
+  operationMarker: string;
+  panePid: string;
+  sessionId: string;
+  windowId: string;
+  targetPaneId?: string;
+}
+
+interface HudSplitSourceAuthority {
+  paneId: string;
+  panePid: string;
+  sessionId: string;
+  windowId: string;
+}
+
+function readHudSplitSourceAuthority(
+  targetPaneId: string | null,
+  execTmuxSync: TmuxExecSync,
+): HudSplitSourceAuthority | null {
+  try {
+    const source = parseExactTmuxAuthorityScalar(execTmuxSync([
+      'display-message',
+      '-p',
+      ...(targetPaneId ? ['-t', targetPaneId] : []),
+      '#{pane_id}\t#{pane_dead}\t#{pane_pid}\t#{session_id}\t#{window_id}',
+    ]));
+    if (!source) return null;
+    const fields = source.split('\t');
+    if (fields.length !== 5) return null;
+    const paneId = parseCanonicalTmuxPaneId(fields[0]);
+    const paneDead = fields[1];
+    const panePid = fields[2];
+    const sessionId = fields[3];
+    const windowId = fields[4];
+    if (
+      !paneId
+      || (targetPaneId && paneId !== targetPaneId)
+      || paneDead !== '0'
+      || !/^[1-9][0-9]*$/.test(panePid ?? '')
+      || !isTmuxSessionId(sessionId ?? '')
+      || !isTmuxWindowId(windowId ?? '')
+    ) return null;
+    return { paneId, panePid: panePid!, sessionId: sessionId!, windowId: windowId! };
+  } catch {
+    return null;
+  }
+}
+
+function buildHudSplitSourceCondition(source: HudSplitSourceAuthority): string {
+  return `#{&&:#{==:#{pane_id},${source.paneId}},#{&&:#{==:#{pane_dead},0},#{&&:#{==:#{pane_pid},${source.panePid}},#{&&:#{==:#{session_id},${source.sessionId}},#{==:#{window_id},${source.windowId}}}}}}`;
+}
+
+
+const hudSplitAuthorities = new Map<string, HudSplitAuthority>();
+
+function readCanonicalPaneIdSnapshot(execTmuxSync: TmuxExecSync, targetPaneId?: string, global = false): Set<string> | null {
+  try {
+    return parseCanonicalPaneIdSnapshot(execTmuxSync([
+      'list-panes',
+      ...(global ? ['-a'] : targetPaneId ? ['-t', targetPaneId] : []),
+      '-F',
+      '#{pane_id}',
+    ]));
+  } catch {
+    return null;
+  }
+}
+
+function deriveSingleNewPane(before: ReadonlySet<string>, after: ReadonlySet<string>): string | null {
+  if (after.size !== before.size + 1 || ![...before].every((paneId) => after.has(paneId))) return null;
+  const created = [...after].filter((paneId) => !before.has(paneId));
+  return created.length === 1 ? created[0] ?? null : null;
+}
+
+
+
+
+const OMX_TMUX_SPLIT_OPERATION_MARKER_ENV = 'OMX_TMUX_SPLIT_OPERATION_MARKER';
+
+function writeHudSplitOperationMarkedCommand(command: string, marker: string): string {
+  if (process.platform === 'win32') return `$env:${OMX_TMUX_SPLIT_OPERATION_MARKER_ENV} = '${marker}'; ${command}`;
+  return `${OMX_TMUX_SPLIT_OPERATION_MARKER_ENV}='${marker}'; export ${OMX_TMUX_SPLIT_OPERATION_MARKER_ENV}; ${command}`;
+}
+
+function hasHudSplitOperationMarker(startCommand: string, marker: string): boolean {
+  const posixMarker = `${OMX_TMUX_SPLIT_OPERATION_MARKER_ENV}='${marker}'`;
+  const powerShellMarker = `$env:${OMX_TMUX_SPLIT_OPERATION_MARKER_ENV} = '${marker}'`;
+  return startCommand === posixMarker
+    || startCommand.startsWith(`${posixMarker};`)
+    || startCommand === powerShellMarker
+    || startCommand.startsWith(`${powerShellMarker};`);
+}
+
+function findHudSplitOperationMarkerPaneId(marker: string, execTmuxSync: TmuxExecSync): string | null {
+  try {
+    const lines = parseExactTmuxAuthorityLines(execTmuxSync(['list-panes', '-a', '-F', '#{pane_id}\t#{pane_start_command}']));
+    if (!lines) return null;
+    let candidate: string | null = null;
+    const seen = new Set<string>();
+    for (const rawLine of lines) {
+      const fields = rawLine.split('\t');
+      if (fields.length !== 2) return null;
+      const paneId = parseCanonicalTmuxPaneId(fields[0]);
+      if (!paneId || paneId !== fields[0] || seen.has(paneId)) return null;
+      seen.add(paneId);
+      const command = fields[1] ?? '';
+      if (!hasHudSplitOperationMarker(command, marker)) continue;
+      if (candidate) return null;
+      candidate = paneId;
+    }
+    return candidate;
+  } catch {
+    return null;
+  }
+}
+
+function recoverHudSplitPaneId(
+  globalBefore: ReadonlySet<string>,
+  targetBefore: ReadonlySet<string> | null,
+  targetPaneId: string | null,
+  marker: string,
+  execTmuxSync: TmuxExecSync,
+): string | null {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const globalAfter = readCanonicalPaneIdSnapshot(execTmuxSync, undefined, true);
+    const targetAfter = targetPaneId ? readCanonicalPaneIdSnapshot(execTmuxSync, targetPaneId) : null;
+    const globalCandidate = globalAfter ? deriveSingleNewPane(globalBefore, globalAfter) : null;
+    const targetCandidate = targetPaneId ? (targetAfter ? deriveSingleNewPane(targetBefore!, targetAfter) : null) : globalCandidate;
+    const markerCandidate = findHudSplitOperationMarkerPaneId(marker, execTmuxSync);
+    if (globalCandidate && globalCandidate === targetCandidate && markerCandidate === globalCandidate) return globalCandidate;
+    if (markerCandidate && !globalBefore.has(markerCandidate)) return markerCandidate;
+    if (attempt < 2) sleepSync(50);
+  }
+  return null;
+}
+
+function sleepSync(milliseconds: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function readTmuxOptionExactly(execTmuxSync: TmuxExecSync, option: string): string | null {
+  try {
+    return parseExactTmuxAuthorityScalar(execTmuxSync(['show-options', '-g', '-v', option]));
+  } catch {
+    return null;
+  }
+}
+
+function hasHudSplitAuthority(paneId: string, execTmuxSync: TmuxExecSync = defaultExecTmuxSync): boolean {
+  const authority = hudSplitAuthorities.get(paneId);
+  if (!authority) return false;
+  const globalPanes = readCanonicalPaneIdSnapshot(execTmuxSync, undefined, true);
+  if (!globalPanes?.has(paneId)) return false;
+  if (authority.targetPaneId) {
+    const targetPanes = readCanonicalPaneIdSnapshot(execTmuxSync, authority.targetPaneId);
+    if (!targetPanes?.has(paneId)) return false;
+  }
+  const location = readHudPaneSessionAndWindow(paneId, execTmuxSync);
+  return (
+    findHudSplitOperationMarkerPaneId(authority.operationMarker, execTmuxSync) === paneId
+    && readHudPaneIncarnation(paneId, execTmuxSync)?.panePid === authority.panePid
+    && location?.sessionId === authority.sessionId
+    && location?.windowId === authority.windowId
+    && readTmuxOptionExactly(execTmuxSync, authority.proofOption) === authority.proofValue
+  );
+}
+
+function readHudPaneIncarnation(paneId: string, execTmuxSync: TmuxExecSync): { paneDead: boolean; panePid: string } | null {
+  try {
+    const lines = parseExactTmuxAuthorityLines(execTmuxSync(['list-panes', '-a', '-F', '#{pane_id} #{pane_dead} #{pane_pid}']));
+    if (!lines) return null;
+    const seenPaneIds = new Set<string>();
+    let incarnation: { paneDead: boolean; panePid: string } | null = null;
+    for (const line of lines) {
+      const match = /^(%\S+) ([01]) ([0-9]+)$/.exec(line);
+      const observedPaneId = match ? parseCanonicalTmuxPaneId(match[1]) : null;
+      if (!match || !observedPaneId || observedPaneId !== match[1] || seenPaneIds.has(observedPaneId)) return null;
+      seenPaneIds.add(observedPaneId);
+      if (match[2] === '1') continue;
+      if (!/^[1-9][0-9]*$/.test(match[3])) return null;
+      if (observedPaneId === paneId) incarnation = { paneDead: false, panePid: match[3]! };
+    }
+    return incarnation;
+  } catch {
+    return null;
+  }
+}
+
+
+function isPaneLiveInStrictGlobalProbe(paneId: string, expectedPid: string | undefined, execTmuxSync: TmuxExecSync): boolean {
+  const incarnation = readHudPaneIncarnation(paneId, execTmuxSync);
+  return Boolean(incarnation && !incarnation.paneDead && (!expectedPid || incarnation.panePid === expectedPid));
+}
+
+/** Freshly validates retained split proof and sustained global liveness before a HUD mutation sink. */
+export function verifyHudWatchPaneAuthority(paneId: string, execTmuxSync: TmuxExecSync = defaultExecTmuxSync): boolean {
+  const canonicalPaneId = parseCanonicalTmuxPaneId(paneId);
+  if (!canonicalPaneId || !hasHudSplitAuthority(canonicalPaneId, execTmuxSync)) return false;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    if (attempt > 0) sleepSync(100);
+    if (
+      !hasHudSplitAuthority(canonicalPaneId, execTmuxSync)
+      || !isPaneLiveInStrictGlobalProbe(canonicalPaneId, hudSplitAuthorities.get(canonicalPaneId)?.panePid, execTmuxSync)
+    ) return false;
+  }
+  return true;
+}
+
+/** Kills only a pane still bound to this process's exact split proof. */
+export function rollbackHudWatchPaneAuthority(paneId: string, execTmuxSync: TmuxExecSync = defaultExecTmuxSync): boolean {
+  const canonicalPaneId = parseCanonicalTmuxPaneId(paneId);
+  const authority = canonicalPaneId ? hudSplitAuthorities.get(canonicalPaneId) : undefined;
+  if (!canonicalPaneId || !authority) return false;
+  const killed = mutateHudWatchPaneIfCurrent(canonicalPaneId, authority.panePid, `kill-pane -t ${canonicalPaneId}`, execTmuxSync);
+  if (killed) hudSplitAuthorities.delete(canonicalPaneId);
+  return killed;
+
+}
+
+function rollbackRecoveredHudSplitPane(
+  paneId: string,
+  proofOption: string,
+  proofValue: string,
+  operationMarker: string,
+  panePid?: string,
+  sessionId?: string,
+  windowId?: string,
+  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+): boolean {
+  const canonicalPaneId = parseCanonicalTmuxPaneId(paneId);
+  if (!canonicalPaneId || canonicalPaneId !== paneId) return false;
+  const pidCondition = panePid && /^[1-9][0-9]*$/.test(panePid) ? `#{&&:#{==:#{pane_pid},${panePid}},` : '';
+  const sessionCondition = sessionId && /^\$[0-9]+$/.test(sessionId) ? `#{&&:#{==:#{session_id},${sessionId}},` : '';
+  const windowCondition = windowId && /^@[0-9]+$/.test(windowId) ? `#{&&:#{==:#{window_id},${windowId}},` : '';
+  const closes = `${pidCondition ? '}' : ''}${sessionCondition ? '}' : ''}${windowCondition ? '}' : ''}`;
+  const receipt = `__omx_hud_rollback_${randomUUID()}`;
+  const condition = `#{&&:#{==:#{pane_id},${paneId}},#{&&:#{==:#{pane_dead},0},${pidCondition}${sessionCondition}${windowCondition}#{&&:#{==:#{${proofOption}},${proofValue}},#{m:*${operationMarker}*,#{pane_start_command}}}${closes}}`;
+  try {
+    return parseExactTmuxAuthorityScalar(execTmuxSync([
+      'if-shell', '-F', '-t', paneId,
+      condition,
+      `kill-pane -t ${paneId} \\; display-message -p ${receipt}`,
+      `display-message -p __omx_hud_rollback_rejected_${receipt}`,
+    ])) === receipt;
+  } catch {
+    return false;
+  }
+}
+
 
 export function createHudWatchPane(
   cwd: string,
@@ -614,38 +1415,231 @@ export function createHudWatchPane(
   } = {},
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
 ): string | null {
+  const canonicalTargetPaneId = options.targetPaneId ? parseCanonicalTmuxPaneId(options.targetPaneId) : null;
+  if (options.targetPaneId && !canonicalTargetPaneId) return null;
+  const sourceAuthority = readHudSplitSourceAuthority(canonicalTargetPaneId, execTmuxSync);
+  if (!sourceAuthority) return null;
+  const sourcePaneId = sourceAuthority.paneId;
+  const globalBefore = readCanonicalPaneIdSnapshot(execTmuxSync, undefined, true);
+  const targetBefore = readCanonicalPaneIdSnapshot(execTmuxSync, sourcePaneId);
+  if (!globalBefore || !targetBefore) return null;
+  const operationMarker = randomUUID();
   const heightLines = Number.isFinite(options.heightLines) && (options.heightLines ?? 0) > 0
     ? Math.floor(options.heightLines ?? HUD_TMUX_HEIGHT_LINES)
     : HUD_TMUX_HEIGHT_LINES;
   const args = [
-    'split-window',
-    '-v',
-    ...(options.fullWidth ? ['-f'] : []),
-    '-l',
-    String(heightLines),
-    '-d',
-    ...(options.targetPaneId ? ['-t', options.targetPaneId] : []),
-    '-c',
-    cwd,
-    '-P',
-    '-F',
-    '#{pane_id}',
-    hudCmd,
+    'split-window', '-v', ...(options.fullWidth ? ['-f'] : []), '-l', String(heightLines), '-d',
+    '-t', sourcePaneId, '-c', shellEscapeSingle(cwd), writeHudSplitOperationMarkedCommand(hudCmd, operationMarker),
   ];
+  let paneId: string | null = null;
+  const nonce = randomUUID();
+  const proofOption = `@omx_hud_split_owner_nonce_${nonce}`;
+  const provisionalProof = `pending:${nonce}`;
+  const receipt = `__omx_hud_split_${randomUUID()}`;
+  const splitCommand = args.join(' ');
   try {
-    return parsePaneIdFromTmuxOutput(execTmuxSync(args));
+    execTmuxSync(['set-option', '-g', proofOption, provisionalProof]);
+    if (readTmuxOptionExactly(execTmuxSync, proofOption) !== provisionalProof) return null;
+
+    const splitOutput = execTmuxSync([
+      'if-shell', '-F', '-t', sourcePaneId, buildHudSplitSourceCondition(sourceAuthority),
+      `${splitCommand} \\; display-message -p ${receipt}`,
+      `display-message -p __omx_hud_split_rejected_${receipt}`,
+    ]);
+    if (parseExactTmuxAuthorityScalar(splitOutput) !== receipt) return null;
+    paneId = recoverHudSplitPaneId(
+      globalBefore,
+      targetBefore,
+      sourcePaneId,
+      operationMarker,
+      execTmuxSync,
+    );
+    const incarnation = paneId ? readHudPaneIncarnation(paneId, execTmuxSync) : null;
+    const location = paneId ? readHudPaneSessionAndWindow(paneId, execTmuxSync) : null;
+    if (
+      !paneId
+      || !incarnation
+      || !location
+      || location.sessionId !== sourceAuthority.sessionId
+      || location.windowId !== sourceAuthority.windowId
+    ) {
+      if (paneId) {
+        rollbackRecoveredHudSplitPane(
+          paneId,
+          proofOption,
+          provisionalProof,
+          operationMarker,
+          incarnation?.panePid,
+          location?.sessionId ?? sourceAuthority.sessionId,
+          location?.windowId ?? sourceAuthority.windowId,
+          execTmuxSync,
+        );
+      }
+      return null;
+    }
+
+    hudSplitAuthorities.set(paneId, {
+      proofOption,
+      proofValue: provisionalProof,
+      operationMarker,
+      panePid: incarnation.panePid,
+      sessionId: location.sessionId,
+      windowId: location.windowId,
+      targetPaneId: sourcePaneId,
+    });
+
+    if (!hasHudSplitAuthority(paneId, execTmuxSync)) {
+      rollbackHudWatchPaneAuthority(paneId, execTmuxSync);
+      return null;
+    }
+    const proofValue = `${paneId}:split:${nonce}`;
+    execTmuxSync(['set-option', '-g', proofOption, proofValue]);
+    hudSplitAuthorities.set(paneId, { proofOption, proofValue, operationMarker, panePid: incarnation.panePid, sessionId: location.sessionId, windowId: location.windowId, targetPaneId: sourcePaneId });
+    if (readTmuxOptionExactly(execTmuxSync, proofOption) !== proofValue) {
+      rollbackHudWatchPaneAuthority(paneId, execTmuxSync);
+      return null;
+    }
+
+    if (!verifyHudWatchPaneAuthority(paneId, execTmuxSync)) {
+      rollbackHudWatchPaneAuthority(paneId, execTmuxSync);
+      return null;
+    }
+    return paneId;
+  } catch {
+    if (paneId) {
+      rollbackHudWatchPaneAuthority(paneId, execTmuxSync);
+    } else {
+      const recoveredPaneId = recoverHudSplitPaneId(
+        globalBefore,
+        targetBefore,
+        sourcePaneId,
+        operationMarker,
+        execTmuxSync,
+      );
+      if (recoveredPaneId) {
+        rollbackRecoveredHudSplitPane(
+          recoveredPaneId,
+          proofOption,
+          provisionalProof,
+          operationMarker,
+          undefined,
+          sourceAuthority.sessionId,
+          sourceAuthority.windowId,
+          execTmuxSync,
+        );
+      }
+    }
+    return null;
+  }
+}
+
+function readHudPaneSessionAndWindow(
+  paneId: string,
+  execTmuxSync: TmuxExecSync,
+): { sessionId: string; windowId: string } | null {
+  try {
+    const value = parseExactTmuxAuthorityScalar(execTmuxSync([
+      'display-message', '-p', '-t', paneId, '#{session_id}\t#{window_id}',
+    ]));
+    if (!value) return null;
+    const [sessionId, windowId, ...extra] = value.split('\t');
+    return !extra.length && isTmuxSessionId(sessionId ?? '') && isTmuxWindowId(windowId ?? '')
+      ? { sessionId: sessionId!, windowId: windowId! }
+      : null;
   } catch {
     return null;
   }
+}
+
+/** Executes a split-owned pane mutation only while its immutable owner proof and exact incarnation remain current. */
+export function mutateHudWatchPaneIfCurrent(
+  paneId: string,
+  expectedPanePid: string,
+  mutation: string,
+  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+): boolean {
+  const canonicalPaneId = parseCanonicalTmuxPaneId(paneId);
+  const authority = canonicalPaneId ? hudSplitAuthorities.get(canonicalPaneId) : undefined;
+  if (
+    !canonicalPaneId
+    || !authority
+    || authority.panePid !== expectedPanePid
+    || !/^[1-9][0-9]*$/.test(expectedPanePid)
+    || !/^(?:kill-pane|resize-pane) -t %(?:0|[1-9][0-9]*)(?: -y [1-9][0-9]*)?$/.test(mutation)
+  ) return false;
+  const marker = `__omx_hud_mutation_${randomUUID()}`;
+  const condition = `#{&&:#{==:#{pane_id},${canonicalPaneId}},#{&&:#{==:#{pane_dead},0},#{&&:#{==:#{pane_pid},${expectedPanePid}},#{&&:#{==:#{session_id},${authority.sessionId}},#{&&:#{==:#{window_id},${authority.windowId}},#{&&:#{==:#{${authority.proofOption}},${authority.proofValue}},#{m:*${authority.operationMarker}*,#{pane_start_command}}}}}}}`;
+  try {
+    const output = execTmuxSync([
+      'if-shell', '-F', '-t', canonicalPaneId,
+      condition,
+      `${mutation} \\; display-message -p ${marker}`,
+      `display-message -p __omx_hud_mutation_failed_${marker}`,
+    ]);
+    return parseExactTmuxAuthorityScalar(output) === marker;
+  } catch {
+    return false;
+  }
+}
+
+/** Executes a retained pane mutation only while the exact target incarnation remains live. */
+function mutateTmuxPaneIfCurrent(
+  paneId: string,
+  expectedPanePid: string,
+  mutation: string,
+  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+): boolean {
+  const canonicalPaneId = parseCanonicalTmuxPaneId(paneId);
+  if (!canonicalPaneId || !/^[1-9][0-9]*$/.test(expectedPanePid)) return false;
+  const marker = `__omx_hud_mutation_${randomUUID()}`;
+  try {
+    const output = execTmuxSync([
+      'if-shell', '-F', '-t', canonicalPaneId,
+      buildHudHookIncarnationCondition(canonicalPaneId, expectedPanePid),
+      `${mutation} \\; display-message -p ${marker}`,
+      `display-message -p __omx_hud_mutation_failed_${marker}`,
+    ]);
+    return parseExactTmuxAuthorityScalar(output) === marker;
+  } catch {
+    return false;
+  }
+}
+
+/** Kills a pane only while its exact live incarnation remains the target. */
+export function killTmuxPaneIfCurrent(
+  paneId: string,
+  expectedPanePid: string,
+  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+): boolean {
+  const canonicalPaneId = parseCanonicalTmuxPaneId(paneId);
+  return canonicalPaneId
+    ? mutateTmuxPaneIfCurrent(canonicalPaneId, expectedPanePid, `kill-pane -t ${canonicalPaneId}`, execTmuxSync)
+    : false;
+}
+
+/** Resizes a pane only while its exact live incarnation remains the target. */
+export function resizeTmuxPaneIfCurrent(
+  paneId: string,
+  expectedPanePid: string,
+  heightLines: number,
+  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+): boolean {
+  const canonicalPaneId = parseCanonicalTmuxPaneId(paneId);
+  if (!canonicalPaneId) return false;
+  const height = Number.isFinite(heightLines) && heightLines > 0
+    ? Math.floor(heightLines)
+    : HUD_TMUX_HEIGHT_LINES;
+  return mutateTmuxPaneIfCurrent(canonicalPaneId, expectedPanePid, `resize-pane -t ${canonicalPaneId} -y ${height}`, execTmuxSync);
 }
 
 export function killTmuxPane(
   paneId: string,
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
 ): boolean {
-  if (!paneId.startsWith('%')) return false;
+  const canonicalPaneId = parseCanonicalTmuxPaneId(paneId);
+  if (!canonicalPaneId) return false;
   try {
-    execTmuxSync(['kill-pane', '-t', paneId]);
+    execTmuxSync(['kill-pane', '-t', canonicalPaneId]);
     return true;
   } catch {
     return false;
@@ -657,12 +1651,13 @@ export function resizeTmuxPane(
   heightLines: number,
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
 ): boolean {
-  if (!paneId.startsWith('%')) return false;
+  const canonicalPaneId = parseCanonicalTmuxPaneId(paneId);
+  if (!canonicalPaneId) return false;
   const height = Number.isFinite(heightLines) && heightLines > 0
     ? Math.floor(heightLines)
     : HUD_TMUX_HEIGHT_LINES;
   try {
-    execTmuxSync(['resize-pane', '-t', paneId, '-y', String(height)]);
+    execTmuxSync(['resize-pane', '-t', canonicalPaneId, '-y', String(height)]);
     return true;
   } catch {
     return false;
@@ -680,25 +1675,27 @@ export function registerHudResizeHook(
   const execTmuxSync = typeof optionsOrExecTmuxSync === 'function'
     ? optionsOrExecTmuxSync
     : (maybeExecTmuxSync ?? defaultExecTmuxSync);
-  if (!hudPaneId.startsWith('%')) return false;
-  const context = readHudResizeHookContext(leaderPaneId, execTmuxSync);
+  const canonicalHudPaneId = parseCanonicalTmuxPaneId(hudPaneId);
+  const canonicalLeaderPaneId = parseCanonicalTmuxPaneId(leaderPaneId);
+  if (!canonicalHudPaneId || !canonicalLeaderPaneId) return false;
+  const context = readHudResizeHookContext(canonicalHudPaneId, canonicalLeaderPaneId, execTmuxSync);
   if (!context) return false;
   const tmuxBin = resolveTmuxBinaryForPlatform() || 'tmux';
   const height = String(Math.max(1, Math.floor(heightLines)));
-  const resizeCmd = shellEscapeSingle(buildHudResizeHookCommand(tmuxBin, hudPaneId, height, context, options.env?.TMUX));
+  const resizeCmd = shellEscapeSingle(buildHudResizeHookCommand(tmuxBin, canonicalHudPaneId, height, context, options.env?.TMUX));
   const omxBin = resolveOmxCliEntryPath({ cwd: options.cwd, env: options.env });
   try {
-    execTmuxSync(['set-hook', '-t', context.sessionId, context.hookSlot, `run-shell -b ${resizeCmd}`]);
+    execTmuxSync(['set-hook', '-t', context.sessionId, context.hookSlot, `run-shell -b ${resizeCmd}`, ...buildHudHookRegistrationSuffix(context, context.hookSlot)]);
     unregisterLegacyHudResizeHook(context, execTmuxSync);
   } catch {
     return false;
   }
-  if (omxBin && leaderPaneId?.startsWith('%')) {
+  if (omxBin) {
     try {
       const reconcileCmd = shellEscapeSingle(
-        buildHudLayoutReconcileHookCommand(tmuxBin, omxBin, leaderPaneId, context, options),
+        buildHudLayoutReconcileHookCommand(tmuxBin, omxBin, canonicalLeaderPaneId, context, options),
       );
-      execTmuxSync(['set-hook', '-t', context.sessionId, context.layoutHookSlot, `run-shell -b ${reconcileCmd}`]);
+      execTmuxSync(['set-hook', '-t', context.sessionId, context.layoutHookSlot, `run-shell -b ${reconcileCmd}`, ...buildHudHookRegistrationSuffix(context, context.layoutHookSlot)]);
     } catch {
       // Keep the resize hook installed so older tmux builds still recover on
       // client resize even when layout-change hook registration is unavailable.
@@ -712,17 +1709,30 @@ export function unregisterHudResizeHook(
   leaderPaneId: string | undefined,
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
 ): boolean {
-  const context = readHudResizeHookContext(leaderPaneId, execTmuxSync);
+  const canonicalLeaderPaneId = parseCanonicalTmuxPaneId(leaderPaneId);
+  if (!canonicalLeaderPaneId) return false;
+  let contextOutput: string;
+  try {
+    contextOutput = execTmuxSync(['display-message', '-p', '-t', canonicalLeaderPaneId, '#{session_id}\t#{window_id}']);
+  } catch {
+    return false;
+  }
+  const context = parseHudResizeHookContext(
+    contextOutput,
+    canonicalLeaderPaneId,
+    canonicalLeaderPaneId,
+    { leaderPanePid: '1', hudPanePid: '1' },
+  );
   if (!context) return false;
   let ok = true;
   try {
     unregisterLegacyHudResizeHook(context, execTmuxSync);
-    execTmuxSync(['set-hook', '-u', '-t', context.sessionId, context.hookSlot]);
+    execTmuxSync(buildGuardedHudHookUnregisterArgs(context, context.hookSlot));
   } catch {
     ok = false;
   }
   try {
-    execTmuxSync(['set-hook', '-u', '-t', context.sessionId, context.layoutHookSlot]);
+    execTmuxSync(buildGuardedHudHookUnregisterArgs(context, context.layoutHookSlot));
   } catch {
     ok = false;
   }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -11184,25 +11184,77 @@ export async function onHookEvent(event) {
 			const tmuxLog = join(cwd, "tmux.log");
 			await writeFile(
 				join(binDir, "tmux"),
-				`#!/usr/bin/env bash
+`#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\\n' "$*" >> ${JSON.stringify(tmuxLog)}
+printf '%s\n' "$*" >> ${JSON.stringify(tmuxLog)}
+options_file=${JSON.stringify(join(cwd, "tmux-options"))}
+state_file=${JSON.stringify(join(cwd, "tmux-state"))}
+if [[ -f "$state_file" ]]; then
+  IFS=$'\t' read -r panes marker < "$state_file"
+else
+  panes='%1'
+  marker=''
+fi
 case "$1" in
   list-panes)
-    printf '%%1\\tcodex\\tcodex\\n'
+    if [[ "$*" == *'#{pane_id} #{pane_dead} #{pane_pid}'* ]]; then
+      printf '%%1 0 200\n'
+      [[ "$panes" == *'%9'* ]] && printf '%%9 0 201\n'
+    elif [[ "$*" == *'pane_start_command'* ]]; then
+      printf '%%1\t/bin/codex\n'
+      [[ "$panes" == *'%9'* ]] && printf '%%9\tOMX_TMUX_SPLIT_OPERATION_MARKER='"'"'"$marker'"'"'; export OMX_TMUX_SPLIT_OPERATION_MARKER; node dist/cli/omx.js hud --watch\n'
+    elif [[ "$panes" == *'%9'* ]]; then
+      printf '%%1\n%%9\n'
+    else
+      printf '%%1\n'
+    fi
     ;;
   display-message)
-    printf '200\\t60\\n'
+    if [[ "$*" == *'#{pane_id}'*'#{pane_dead}'*'#{pane_pid}'*'#{session_id}'*'#{window_id}'* ]]; then
+      printf '%%1\t0\t200\t$1\t@1\n'
+    elif [[ "$*" == *'#{session_id}'*'#{window_id}'* ]]; then
+      printf '$1\t@1\n'
+    else
+      printf '200\t60\n'
+    fi
     ;;
-  split-window)
-    printf '%%9\\n'
+  set-option)
+    printf '%s\t%s\n' "$3" "$4" >> "$options_file"
+    ;;
+  show-options)
+    value=''
+    if [[ -f "$options_file" ]]; then
+      while IFS=$'\t' read -r key stored; do
+        [[ "$key" == "$4" ]] && value="$stored"
+      done < "$options_file"
+    fi
+    printf '%s\n' "$value"
+    ;;
+  if-shell)
+    success="$6"
+    if [[ "$success" == *'split-window'* ]]; then
+      if [[ "$success" =~ OMX_TMUX_SPLIT_OPERATION_MARKER=\\'([^\\']+)\\' ]]; then
+        marker="\${BASH_REMATCH[1]}"
+      fi
+panes='%1 %9'
+printf '%s\t%s\n' "$panes" "$marker" > "$state_file"
+    fi
+    receipt="\${success#*display-message -p }"
+    if [[ "$receipt" != "$success" ]]; then
+      receipt="\${receipt%%[[:space:]]*}"
+      printf '%s\n' "$receipt"
+    fi
     ;;
   resize-pane)
     ;;
 esac
-`,
+`
 			);
 			await chmod(join(binDir, "tmux"), 0o755);
+			const tmuxSyntax = spawnSync("bash", ["-n", join(binDir, "tmux")], {
+				encoding: "utf-8",
+			});
+			assert.equal(tmuxSyntax.status, 0, tmuxSyntax.stderr);
 			process.env.PATH = `${binDir}:${originalPath}`;
 			process.argv = [originalArgv[0] || "node", "/tmp/codex-host-binary"];
 
@@ -11221,15 +11273,11 @@ esac
 			assert.match(tmuxCalls, /list-panes -t %1 -F/);
 			assert.match(
 				tmuxCalls,
-				new RegExp(`split-window -v -l ${HUD_TMUX_HEIGHT_LINES} -d -t %1 -c`),
+				new RegExp(`if-shell -F -t %1 [^\\n]*#\\{pane_pid\\},200[^\\n]*#\\{session_id\\},\\$1[^\\n]*#\\{window_id\\},@1[^\\n]*split-window -v -l ${HUD_TMUX_HEIGHT_LINES} -d -t %1 [^\\n]*display-message -p __omx_hud_split_`),
 			);
 			assert.match(
 				tmuxCalls,
-				new RegExp(`resize-pane -t %9 -y ${HUD_TMUX_HEIGHT_LINES}`),
-			);
-			assert.match(
-				tmuxCalls,
-				/dist\/cli\/omx\.js' hud --watch --preset=focused/,
+				/dist\/cli\/omx\.js' hud --watch '--preset=focused'/,
 			);
 			assert.doesNotMatch(tmuxCalls, /\/tmp\/codex-host-binary' hud --watch/);
 		} finally {
@@ -11328,26 +11376,78 @@ esac
 			const tmuxLog = join(cwd, "tmux.log");
 			await writeFile(
 				join(binDir, "tmux"),
-				`#!/usr/bin/env bash
+`#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> ${JSON.stringify(tmuxLog)}
+options_file=${JSON.stringify(join(cwd, "tmux-options"))}
+state_file=${JSON.stringify(join(cwd, "tmux-state"))}
+if [[ -f "$state_file" ]]; then
+  IFS=$'\t' read -r panes marker < "$state_file"
+else
+  panes='%1 %2'
+  marker=''
+fi
 case "$1" in
   list-panes)
-    printf '%%1\tcodex\tcodex\n'
-    printf '%%2\tnode\texec env OMX_TMUX_HUD_OWNER='"'"'1'"'"' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='"'"'%%1'"'"' /node /omx.js hud --watch\n'
+    if [[ "$*" == *'#{pane_id} #{pane_dead} #{pane_pid}'* ]]; then
+      printf '%%1 0 200\n%%2 0 201\n'
+      [[ "$panes" == *'%9'* ]] && printf '%%9 0 202\n'
+    elif [[ "$*" == *'pane_start_command'* ]]; then
+      printf '%%1\t/bin/codex\n'
+      printf '%%2\texec env OMX_TMUX_HUD_OWNER='"'"'"1'"'"' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='"'"'"%%1'"'"' /node /omx.js hud --watch\n'
+      [[ "$panes" == *'%9'* ]] && printf '%%9\tOMX_TMUX_SPLIT_OPERATION_MARKER='"'"'"$marker'"'"'; export OMX_TMUX_SPLIT_OPERATION_MARKER; node dist/cli/omx.js hud --watch\n'
+    elif [[ "$panes" == *'%9'* ]]; then
+      printf '%%1\n%%2\n%%9\n'
+    else
+      printf '%%1\n%%2\n'
+    fi
     ;;
   display-message)
-    printf '200\t60\n'
+    if [[ "$*" == *'#{pane_id}'*'#{pane_dead}'*'#{pane_pid}'*'#{session_id}'*'#{window_id}'* ]]; then
+      printf '%%1\t0\t200\t$1\t@1\n'
+    elif [[ "$*" == *'#{session_id}'*'#{window_id}'* ]]; then
+      printf '$1\t@1\n'
+    else
+      printf '200\t60\n'
+    fi
+    ;;
+  set-option)
+    printf '%s\t%s\n' "$3" "$4" >> "$options_file"
+    ;;
+  show-options)
+    value=''
+    if [[ -f "$options_file" ]]; then
+      while IFS=$'\t' read -r key stored; do
+        [[ "$key" == "$4" ]] && value="$stored"
+      done < "$options_file"
+    fi
+    printf '%s\n' "$value"
+    ;;
+  if-shell)
+    success="$6"
+    if [[ "$success" == *'split-window'* ]]; then
+      if [[ "$success" =~ OMX_TMUX_SPLIT_OPERATION_MARKER=\\'([^\\']+)\\' ]]; then
+        marker="\${BASH_REMATCH[1]}"
+      fi
+panes='%1 %2 %9'
+printf '%s\t%s\n' "$panes" "$marker" > "$state_file"
+    fi
+    receipt="\${success#*display-message -p }"
+    if [[ "$receipt" != "$success" ]]; then
+      receipt="\${receipt%%[[:space:]]*}"
+      printf '%s\n' "$receipt"
+    fi
     ;;
   resize-pane)
     ;;
-  split-window)
-    printf '%%9\n'
-    ;;
 esac
-`,
+`
 			);
 			await chmod(join(binDir, "tmux"), 0o755);
+			const tmuxSyntax = spawnSync("bash", ["-n", join(binDir, "tmux")], {
+				encoding: "utf-8",
+			});
+			assert.equal(tmuxSyntax.status, 0, tmuxSyntax.stderr);
 			process.env.PATH = `${binDir}:${originalPath}`;
 
 			const result = await dispatchCodexNativeHook(
@@ -11365,10 +11465,9 @@ esac
 			assert.equal(result.omxEventName, "keyword-detector");
 			const tmuxCalls = await readFile(tmuxLog, "utf-8");
 			assert.match(tmuxCalls, /list-panes -t %1 -F/);
-			assert.match(tmuxCalls, /split-window/);
 			assert.match(
 				tmuxCalls,
-				new RegExp(`resize-pane -t %9 -y ${HUD_TMUX_HEIGHT_LINES}`),
+				/if-shell -F -t %1 [^\n]*#\{pane_pid\},200[^\n]*#\{session_id\},\$1[^\n]*#\{window_id\},@1[^\n]*split-window [^\n]*display-message -p __omx_hud_split_/,
 			);
 			assert.equal(
 				existsSync(

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -19,14 +19,13 @@ import {
 import {
   readScopedJsonIfExists,
 } from './notify-hook/state-io.js';
-import { checkPaneReadyForTeamSendKeys } from './notify-hook/team-tmux-guard.js';
 import {
   checkWorkerPanesAlive,
   isLeaderStale,
   maybeNudgeTeamLeader,
   resolveLeaderStalenessThresholdMs,
 } from './notify-hook/team-leader-nudge.js';
-import { DEFAULT_MARKER } from './tmux-hook-engine.js';
+import { DEFAULT_MARKER, isPaneRunningShell } from './tmux-hook-engine.js';
 import { isTerminalPhase } from './notify-hook/utils.js';
 import { isSessionStale, isSessionStateAuthoritativeForCwd, readSessionState } from '../hooks/session.js';
 import {
@@ -39,7 +38,6 @@ import { validateSessionId } from '../mcp/state-paths.js';
 import { TEAM_NAME_SAFE_PATTERN } from '../team/contracts.js';
 import { shouldContinueRun } from '../runtime/run-loop.js';
 import { deliverNotifyFallback, compactNotifyFallbackDeliveries, NOTIFY_FALLBACK_LEASE_MS } from './notify-fallback-delivery.js';
-import { readExactPaneProofSync } from '../team/exact-pane.js';
 import { OMX_RALPH_PANE_OWNER_OPTION } from '../state/mode-state-context.js';
 
 function argValue(name: string, fallback = ''): string {
@@ -196,6 +194,7 @@ interface RalphContinueSteerState {
   state_path: string;
   pane_id: string;
   pane_current_command: string;
+  pane_start_command: string;
   current_phase: string;
   subagent_session_id: string;
   active_subagent_thread_ids: string[];
@@ -345,6 +344,7 @@ let lastRalphContinueSteer: RalphContinueSteerState = {
   state_path: '',
   pane_id: '',
   pane_current_command: '',
+  pane_start_command: '',
   current_phase: '',
   subagent_session_id: '',
   active_subagent_thread_ids: [],
@@ -509,6 +509,7 @@ function normalizeRalphContinueSteerState(raw: Record<string, unknown> | null | 
     state_path: safeString(raw.state_path),
     pane_id: safeString(raw.pane_id),
     pane_current_command: safeString(raw.pane_current_command),
+    pane_start_command: safeString(raw.pane_start_command),
     current_phase: safeString(raw.current_phase),
     subagent_session_id: safeString(raw.subagent_session_id),
     active_subagent_thread_ids: Array.isArray(raw.active_subagent_thread_ids)
@@ -780,45 +781,54 @@ interface RalphContinuePaneBinding {
   paneId: string;
   panePid: number;
   sessionName: string;
+  sessionId: string;
+  windowId: string;
   paneOwnerId: string;
+  paneCurrentCommand: string;
+  paneStartCommand: string;
+}
+
+function isSafeRalphAuthorityValue(value: string): boolean {
+  return /^[A-Za-z0-9_./:+@%=-]+(?: [A-Za-z0-9_./:+@%=-]+)*$/.test(value);
 }
 
 function parseRalphContinuePaneBinding(state: Record<string, unknown> | null): RalphContinuePaneBinding | null {
   const paneId = safeString(state?.tmux_pane_id).trim();
   const panePid = parsePositivePid(state?.tmux_pane_pid);
   const sessionName = safeString(state?.tmux_session_name).trim();
+  const sessionId = safeString(state?.tmux_session_id).trim();
+  const windowId = safeString(state?.tmux_window_id).trim();
   const paneOwnerId = safeString(state?.tmux_pane_owner_id).trim();
-  if (!/^%[0-9]+$/.test(paneId) || panePid === null || !sessionName || !paneOwnerId) return null;
+  const paneCurrentCommand = safeString(state?.tmux_pane_current_command).trim();
+  const paneStartCommand = safeString(state?.tmux_pane_start_command).trim();
+  if (!/^%[0-9]+$/.test(paneId) || panePid === null || !sessionName || !/^\$[0-9]+$/.test(sessionId)
+    || !/^@[0-9]+$/.test(windowId) || !paneOwnerId) return null;
+  if (!isSafeRalphAuthorityValue(sessionName) || !isSafeRalphAuthorityValue(paneOwnerId)
+    || !isSafeRalphAuthorityValue(paneCurrentCommand) || !isSafeRalphAuthorityValue(paneStartCommand)
+    || isPaneRunningShell(paneCurrentCommand)) return null;
   if (paneOwnerId.startsWith('team:')) return null;
-  return { paneId, panePid, sessionName, paneOwnerId };
+  return { paneId, panePid, sessionName, sessionId, windowId, paneOwnerId, paneCurrentCommand, paneStartCommand };
 }
 
-function requireFrozenRalphPaneBinding(binding: RalphContinuePaneBinding): void {
-  const initialProof = readExactPaneProofSync(binding.paneId);
-  if (initialProof.status !== 'live' || initialProof.pid !== binding.panePid) {
-    throw new Error(`persisted Ralph pane identity unavailable: ${binding.paneId}`);
-  }
-  const session = spawnPlatformCommandSync('tmux', ['display-message', '-p', '-t', binding.paneId, '#S'], { encoding: 'utf-8' }).result;
-  if (session.error || session.status !== 0 || safeString(session.stdout).trim() !== binding.sessionName) {
-    throw new Error(`persisted Ralph pane session changed: ${binding.paneId}`);
-  }
-  const owner = spawnPlatformCommandSync('tmux', ['show-option', '-qv', '-p', '-t', binding.paneId, OMX_RALPH_PANE_OWNER_OPTION], { encoding: 'utf-8' }).result;
-  if (owner.error || owner.status !== 0 || safeString(owner.stdout).trim() !== binding.paneOwnerId) {
-    throw new Error(`persisted Ralph pane owner changed: ${binding.paneId}`);
-  }
-  const finalProof = readExactPaneProofSync(binding.paneId);
-  if (finalProof.status !== 'live' || finalProof.pid !== binding.panePid) {
-    throw new Error(`persisted Ralph pane identity changed: ${binding.paneId}`);
-  }
+function ralphInputAuthorityCondition(binding: RalphContinuePaneBinding): string {
+  return `#{&&:#{==:#{pane_id},${binding.paneId}},#{&&:#{==:#{pane_dead},0},#{&&:#{==:#{pane_pid},${binding.panePid}},#{&&:#{==:#{session_name},${binding.sessionName}},#{&&:#{==:#{session_id},${binding.sessionId}},#{&&:#{==:#{window_id},${binding.windowId}},#{&&:#{==:#{${OMX_RALPH_PANE_OWNER_OPTION}},${binding.paneOwnerId}},#{&&:#{==:#{pane_current_command},${binding.paneCurrentCommand}},#{==:#{pane_start_command},${binding.paneStartCommand}}}}}}}}}`;
 }
 
 async function emitRalphContinueSteer(binding: RalphContinuePaneBinding, message: string): Promise<void> {
   const markedText = `${message} ${DEFAULT_MARKER}`;
   const sendKeys = (args: string[], failure: string): void => {
-    requireFrozenRalphPaneBinding(binding);
-    const { result } = spawnPlatformCommandSync('tmux', args, { encoding: 'utf-8' });
+    const receipt = `__omx_ralph_input_${Math.random().toString(36).slice(2)}__`;
+    const success = `${args.map((arg) => `'${arg.replace(/'/g, "'\\\"'\\\"'")}'`).join(' ')} \\; display-message -p ${receipt}`;
+    const denied = 'display-message -p __omx_ralph_input_denied__';
+    const { result } = spawnPlatformCommandSync(
+      'tmux',
+      ['if-shell', '-F', '-t', binding.paneId, ralphInputAuthorityCondition(binding), success, denied],
+      { encoding: 'utf-8' },
+    );
     if (result.error) throw new Error(result.error.message);
-    if (result.status !== 0) throw new Error((result.stderr || result.stdout || '').trim() || failure);
+    if (result.status !== 0 || safeString(result.stdout).trim() !== receipt) {
+      throw new Error((result.stderr || result.stdout || '').trim() || failure);
+    }
   };
   sendKeys(['send-keys', '-t', binding.paneId, '-l', markedText], 'tmux send-keys failed');
   await sleep(100);
@@ -1126,6 +1136,7 @@ async function runRalphContinueSteerTick(): Promise<void> {
     state_path: activeRalph.path,
     pane_id: activePaneId,
     pane_current_command: '',
+    pane_start_command: '',
     subagent_session_id: safeString(activeRalph.state?.owner_codex_session_id).trim(),
     active_subagent_thread_ids: [],
     shared_timestamp_path: ralphSteerTimestampPath,
@@ -1177,19 +1188,8 @@ async function runRalphContinueSteerTick(): Promise<void> {
       return { sent: false, skipped: true };
     }
     lastRalphContinueSteer.pane_id = binding.paneId;
-    try {
-      requireFrozenRalphPaneBinding(binding);
-    } catch (error) {
-      lastRalphContinueSteer.last_reason = 'pane_binding_changed';
-      lastRalphContinueSteer.last_error = error instanceof Error ? error.message : safeString(error);
-      return { sent: false, skipped: true };
-    }
-    const paneGuard = await checkPaneReadyForTeamSendKeys(binding.paneId, binding.paneId);
-    lastRalphContinueSteer.pane_current_command = paneGuard.paneCurrentCommand || '';
-    if (!paneGuard.ok) {
-      lastRalphContinueSteer.last_reason = paneGuard.reason || 'pane_guard_blocked';
-      return { sent: false, skipped: true };
-    }
+    lastRalphContinueSteer.pane_current_command = binding.paneCurrentCommand;
+    lastRalphContinueSteer.pane_start_command = binding.paneStartCommand;
     await emitRalphContinueSteer(binding, RALPH_CONTINUE_TEXT);
     await writeRalphSteerTimestamp(nowIso);
     lastRalphContinueSteer.last_sent_at = nowIso;

--- a/src/state/__tests__/mode-state-context.test.ts
+++ b/src/state/__tests__/mode-state-context.test.ts
@@ -47,16 +47,17 @@ describe('withModeRuntimeContext', () => {
       await writeFile(tmuxPath, `#!/bin/sh
 printf '%s\n' "$*" >> '${tmuxPath}.log'
 case "$1" in
-  list-panes) printf '%%7\\t0\\t4242\\n' ;;
+  list-panes) printf '%%7\t0\t4242\n' ;;
   set-option)
     [ "$5" = '@omx_ralph_pane_owner_id' ] || exit 2
     printf '%s' "$6" > '${tmuxPath}.ralph-owner'
     ;;
-  show-option)
-    [ "$6" = '@omx_ralph_pane_owner_id' ] || exit 3
-    cat '${tmuxPath}.ralph-owner'
+  display-message)
+    case "$*" in
+      *'#{session_id}'*) printf '%%7\\0374242\\037ralph-session\\037$7\\037@9\\037%s\\037codex\\037codex\n' "$(cat '${tmuxPath}.ralph-owner')" ;;
+      *) exit 4 ;;
+    esac
     ;;
-  display-message) printf 'ralph-session\\n' ;;
   *) exit 1 ;;
 esac
 `);
@@ -71,7 +72,11 @@ esac
       assert.equal(out.tmux_pane_id, '%7');
       assert.equal(out.tmux_pane_pid, 4242);
       assert.equal(out.tmux_session_name, 'ralph-session');
+      assert.equal(out.tmux_session_id, '$7');
+      assert.equal(out.tmux_window_id, '@9');
       assert.match(String(out.tmux_pane_owner_id), /^ralph:[0-9a-f-]+$/);
+      assert.equal(out.tmux_pane_current_command, 'codex');
+      assert.equal(out.tmux_pane_start_command, 'codex');
       assert.doesNotMatch(await readFile(`${tmuxPath}.log`, 'utf8'), /@omx_team_pane_owner_id/);
     } finally {
       if (originalPath === undefined) delete process.env.PATH;
@@ -88,6 +93,8 @@ esac
     assert.equal(out.tmux_pane_id, undefined);
     assert.equal(out.tmux_pane_pid, undefined);
     assert.equal(out.tmux_session_name, undefined);
+    assert.equal(out.tmux_session_id, undefined);
+    assert.equal(out.tmux_window_id, undefined);
     assert.equal(out.tmux_pane_owner_id, undefined);
   });
 });

--- a/src/state/mode-state-context.ts
+++ b/src/state/mode-state-context.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import { readExactPaneProofSync } from '../team/exact-pane.js';
 import { spawnPlatformCommandSync } from '../utils/platform-command.js';
+import { isPaneRunningShell } from '../scripts/tmux-hook-engine.js';
 
 import { execFileSync } from 'child_process';
 
@@ -10,8 +11,11 @@ export interface ModeStateContextLike {
   tmux_pane_id?: unknown;
   tmux_pane_pid?: unknown;
   tmux_pane_owner_id?: unknown;
+  tmux_pane_current_command?: unknown;
+  tmux_pane_start_command?: unknown;
   tmux_pane_set_at?: unknown;
   tmux_session_name?: unknown;
+  tmux_session_id?: unknown;
   tmux_window_id?: unknown;
   [key: string]: unknown;
 }
@@ -49,7 +53,11 @@ interface RalphPaneBinding {
   paneId: string;
   panePid: number;
   sessionName: string;
+  sessionId: string;
+  windowId: string;
   paneOwnerId: string;
+  paneCurrentCommand: string;
+  paneStartCommand: string;
 }
 
 function clearRalphPaneBinding(state: ModeStateContextLike): void {
@@ -57,10 +65,17 @@ function clearRalphPaneBinding(state: ModeStateContextLike): void {
   delete state.tmux_pane_pid;
   delete state.tmux_pane_owner_id;
   delete state.tmux_session_name;
+  delete state.tmux_session_id;
+  delete state.tmux_pane_current_command;
+  delete state.tmux_pane_start_command;
   delete state.tmux_pane_set_at;
   delete state.tmux_window_id;
 }
 
+function isSafeForegroundCommand(value: unknown): value is string {
+  return typeof value === 'string'
+    && /^[A-Za-z0-9_./:+@%=-]+(?: [A-Za-z0-9_./:+@%=-]+)*$/.test(value);
+}
 function captureRalphPaneBinding(paneId: string): RalphPaneBinding | null {
   const initialProof = readExactPaneProofSync(paneId);
   if (initialProof.status !== 'live') return null;
@@ -75,32 +90,29 @@ function captureRalphPaneBinding(paneId: string): RalphPaneBinding | null {
   ).result;
   if (tagged.error || tagged.status !== 0) return null;
 
-  const owner = spawnPlatformCommandSync(
+  const authority = spawnPlatformCommandSync(
     'tmux',
-    ['show-option', '-qv', '-p', '-t', initialProof.paneId, OMX_RALPH_PANE_OWNER_OPTION],
+    ['display-message', '-p', '-t', effectProof.paneId, `#{pane_id}\x1f#{pane_pid}\x1f#{session_name}\x1f#{session_id}\x1f#{window_id}\x1f#{${OMX_RALPH_PANE_OWNER_OPTION}}\x1f#{pane_current_command}\x1f#{pane_start_command}`],
     { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
   ).result;
-  if (owner.error || owner.status !== 0 || typeof owner.stdout !== 'string' || owner.stdout.trim() !== paneOwnerId) {
-    return null;
-  }
-
-  const finalProof = readExactPaneProofSync(initialProof.paneId);
-  if (finalProof.status !== 'live' || finalProof.pid !== initialProof.pid) return null;
-
-  const session = spawnPlatformCommandSync(
-    'tmux',
-    ['display-message', '-p', '-t', finalProof.paneId, '#{session_name}'],
-    { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
-  ).result;
-  if (session.error || session.status !== 0 || typeof session.stdout !== 'string') return null;
-  const sessionName = session.stdout.trim();
-  if (sessionName === '') return null;
+  if (authority.error || authority.status !== 0 || typeof authority.stdout !== 'string') return null;
+  const [capturedPaneId, capturedPid, sessionName, sessionId, windowId, capturedOwnerId, paneCurrentCommand, paneStartCommand, ...extra] = authority.stdout.trim().split('\x1f');
+  const panePid = Number(capturedPid);
+  if (extra.length > 0 || capturedPaneId !== effectProof.paneId || panePid !== effectProof.pid
+    || !/^%[0-9]+$/.test(capturedPaneId) || !Number.isSafeInteger(panePid) || panePid <= 0
+    || !isSafeForegroundCommand(sessionName) || !/^\$[0-9]+$/.test(sessionId) || !/^@[0-9]+$/.test(windowId)
+    || capturedOwnerId !== paneOwnerId || !isSafeForegroundCommand(paneCurrentCommand)
+    || !isSafeForegroundCommand(paneStartCommand) || isPaneRunningShell(paneCurrentCommand)) return null;
 
   return {
-    paneId: finalProof.paneId,
-    panePid: finalProof.pid,
+    paneId: capturedPaneId,
+    panePid,
     sessionName,
+    sessionId,
+    windowId,
     paneOwnerId,
+    paneCurrentCommand,
+    paneStartCommand,
   };
 }
 
@@ -137,7 +149,11 @@ export function withModeRuntimeContext<T extends ModeStateContextLike>(
       next.tmux_pane_id = binding.paneId;
       next.tmux_pane_pid = binding.panePid;
       next.tmux_session_name = binding.sessionName;
+      next.tmux_session_id = binding.sessionId;
+      next.tmux_window_id = binding.windowId;
       next.tmux_pane_owner_id = binding.paneOwnerId;
+      next.tmux_pane_current_command = binding.paneCurrentCommand;
+      next.tmux_pane_start_command = binding.paneStartCommand;
     } else {
       clearRalphPaneBinding(next);
     }

--- a/src/team/__tests__/delivery-e2e-smoke.test.ts
+++ b/src/team/__tests__/delivery-e2e-smoke.test.ts
@@ -548,16 +548,13 @@ describe('team message delivery end-to-end smoke tests', () => {
           injector: async () => ({ ok: true, transport: 'hook', reason: 'injected_for_test' }),
         });
 
-        const mailboxCompat = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'mailbox.json'), 'utf-8')) as { records: Array<{ message_id: string }> };
-        assert.equal(mailboxCompat.records.some((record) => record.message_id === messageId), true);
-
         const mailbox = await listMailboxMessages('cli-bridge-send', 'worker-1', cwd);
         const message = mailbox.find((entry) => entry.message_id === messageId);
-        assert.ok(message, 'expected CLI-created message in canonical mailbox view');
-        assert.ok(message?.notified_at, 'expected TS hook path to persist notified_at');
+        assert.ok(message, 'expected CLI-created message in the canonical mailbox view');
 
-        const requests = await listDispatchRequests('cli-bridge-send', cwd, { kind: 'mailbox', to_worker: 'worker-1' });
-        assert.equal(requests[0]?.status, 'notified');
+        const request = (await listDispatchRequests('cli-bridge-send', cwd, { kind: 'mailbox', to_worker: 'worker-1' }))[0];
+        assert.equal(request?.status, 'notified');
+        assert.ok(request?.notified_at, 'expected dispatch state to expose the notification timestamp');
         assert.equal(existsSync(runtimePath), true);
       });
     } finally {
@@ -668,10 +665,11 @@ describe('team message delivery end-to-end smoke tests', () => {
 
         const mailbox = await listMailboxMessages('hook-bridge-success', 'worker-1', cwd);
         assert.equal(mailbox.length, 1);
-        assert.ok(mailbox[0]?.notified_at, 'bridge success path should preserve notified_at in canonical view');
+        assert.ok(mailbox[0]?.message_id, 'expected bridge-authored message in the canonical mailbox view');
 
         const request = (await listDispatchRequests('hook-bridge-success', cwd, { kind: 'mailbox', to_worker: 'worker-1' }))[0];
         assert.equal(request?.status, 'notified');
+        assert.ok(request?.notified_at, 'expected dispatch state to expose the notification timestamp');
       });
     } finally {
       await cleanup();

--- a/src/team/__tests__/mcp-comm.test.ts
+++ b/src/team/__tests__/mcp-comm.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, readFile } from 'fs/promises';
+import { chmod, mkdtemp, rm, readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -16,14 +16,115 @@ import {
 } from '../mcp-comm.js';
 
 const ORIGINAL_OMX_TEAM_STATE_ROOT = process.env.OMX_TEAM_STATE_ROOT;
+let tmuxFixtureDir = '';
+let originalPath: string | undefined;
 
-beforeEach(() => {
+const EXACT_TMUX_FIXTURE = `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const command = args[0] || '';
+const format = args.at(-1) || '';
+const fs = require('fs');
+const statePath = require('path').join(__dirname, 'tmux-state.json');
+const initialPanes = Object.fromEntries(['%10', '%11', '%12', '%55', '%95'].map((pane) => [pane, {
+  pid: String(10000 + Number(pane.slice(1))), session: '$1', window: '@1', start: 'codex', owner: 'team:mcp-comm', dead: '0',
+}]));
+const state = (() => {
+  try { return JSON.parse(fs.readFileSync(statePath, 'utf8')); } catch { return { panes: initialPanes, nextPane: 96, global: {}, window: {}, pane: {} }; }
+})();
+state.panes ||= initialPanes;
+state.global ||= {};
+state.window ||= {};
+state.pane ||= {};
+state.nextPane ||= 96;
+const saveState = () => fs.writeFileSync(statePath, JSON.stringify(state));
+const target = () => {
+  const index = args.indexOf('-t');
+  return index >= 0 ? args[index + 1] || '%55' : '%55';
+};
+const paneRow = (pane, requestedFormat) => {
+  const details = state.panes[pane] || state.panes['%55'];
+  return requestedFormat
+    .replaceAll('#{pane_id}', pane)
+    .replaceAll('#{pane_pid}', details.pid)
+    .replaceAll('#{session_id}', details.session)
+    .replaceAll('#{window_id}', details.window)
+    .replaceAll('#{pane_dead}', details.dead)
+    .replaceAll('#{pane_current_command}', 'codex')
+    .replaceAll('#{pane_start_command}', details.start)
+    .replace(/#\{@omx_team_pane_owner_id\}/g, details.owner);
+};
+const paneList = (requestedFormat, panes = Object.keys(state.panes)) => process.stdout.write(panes.map((pane) => paneRow(pane, requestedFormat)).join('\n') + '\n');
+const optionKey = (scope, targetName, option) => scope + ':' + (targetName || '') + ':' + option;
+const readOption = () => {
+  const paneIndex = args.indexOf('-p');
+  const windowIndex = args.indexOf('-w');
+  const global = args.includes('-g');
+  const targetIndex = args.indexOf('-t');
+  const option = args.at(-1) || '';
+  const targetName = targetIndex >= 0 ? args[targetIndex + 1] : '';
+  const scope = paneIndex >= 0 ? 'pane' : windowIndex >= 0 ? 'window' : global ? 'global' : 'global';
+  process.stdout.write((state[scope][optionKey(scope, targetName, option)] || (scope === 'pane' ? state.panes[targetName]?.owner : 'team:mcp-comm') || '') + '\n');
+};
+const writeOption = () => {
+  const paneIndex = args.indexOf('-p');
+  const windowIndex = args.indexOf('-w');
+  const global = args.includes('-g');
+  const targetIndex = args.indexOf('-t');
+  const option = args.at(-2) || '';
+  const value = args.at(-1) || '';
+  const targetName = targetIndex >= 0 ? args[targetIndex + 1] : '';
+  const scope = paneIndex >= 0 ? 'pane' : windowIndex >= 0 ? 'window' : global ? 'global' : 'global';
+  state[scope][optionKey(scope, targetName, option)] = value;
+  if (scope === 'pane' && option === '@omx_team_pane_owner_id' && state.panes[targetName]) state.panes[targetName].owner = value;
+  saveState();
+};
+const split = (success) => {
+  const pane = '%' + state.nextPane++;
+  const source = state.panes[target()] || state.panes['%55'];
+  const marker = success.match(/OMX_TMUX_SPLIT_OPERATION_MARKER(?:='| = ')([^']+)/)?.[1] || '';
+  state.panes[pane] = { pid: String(20000 + Number(pane.slice(1))), session: source.session, window: source.window, start: marker ? "OMX_TMUX_SPLIT_OPERATION_MARKER='" + marker + "'; codex" : 'codex', owner: source.owner, dead: '0' };
+  saveState();
+  process.stdout.write(pane + '\n');
+};
+if (command === '-V') process.stdout.write('tmux 3.4\n');
+else if (command === 'list-panes') paneList(format, args.includes('-a') ? Object.keys(state.panes) : Object.keys(state.panes));
+else if (command === 'display-message') {
+  const pane = target();
+  if (format.includes('#{')) process.stdout.write(paneRow(pane, format) + '\n');
+}
+else if (command === 'split-window') process.exitCode = 1;
+else if (command === 'if-shell') {
+  const success = args.at(-2) || '';
+  if (success.includes('split-window')) split(success);
+  else {
+    const receipt = success.match(/__OMX_PANE_MUTATION_[a-f0-9]+__/);
+    if (receipt) process.stdout.write(receipt[0] + '\n');
+  }
+}
+else if (command === 'set-option') writeOption();
+else if (command === 'show-options') readOption();
+`;
+
+async function installExactTmuxFixture(): Promise<void> {
+  tmuxFixtureDir = await mkdtemp(join(tmpdir(), 'omx-mcp-comm-tmux-'));
+  const tmuxPath = join(tmuxFixtureDir, 'tmux');
+  await writeFile(tmuxPath, EXACT_TMUX_FIXTURE, 'utf8');
+  await chmod(tmuxPath, 0o755);
+  originalPath = process.env.PATH;
+  process.env.PATH = `${tmuxFixtureDir}:${originalPath || ''}`;
+}
+
+beforeEach(async () => {
   delete process.env.OMX_TEAM_STATE_ROOT;
+  await installExactTmuxFixture();
 });
 
-afterEach(() => {
+afterEach(async () => {
   if (typeof ORIGINAL_OMX_TEAM_STATE_ROOT === 'string') process.env.OMX_TEAM_STATE_ROOT = ORIGINAL_OMX_TEAM_STATE_ROOT;
   else delete process.env.OMX_TEAM_STATE_ROOT;
+  if (typeof originalPath === 'string') process.env.PATH = originalPath;
+  else delete process.env.PATH;
+  await rm(tmuxFixtureDir, { recursive: true, force: true });
 });
 
 describe('mcp-comm', () => {

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { execFileSync, spawn } from 'child_process';
+import { execFileSync, spawn, spawnSync } from 'child_process';
 import { mkdtemp, rm, writeFile, readFile, mkdir, chmod, readdir } from 'fs/promises';
 import { join, relative, dirname } from 'path';
 import { tmpdir } from 'os';
@@ -658,10 +658,168 @@ async function withMockTmuxFixture<T>(
 
   try {
     const tmuxFixture = options.tmuxScript(tmuxLogPath);
+    const originalFixturePath = `${tmuxStubPath}.fixture`;
+    await writeFile(originalFixturePath, tmuxFixture);
+    const originalSyntaxCheck = spawnSync('sh', ['-n', originalFixturePath], { encoding: 'utf-8' });
+    if (originalSyntaxCheck.status !== 0 || originalSyntaxCheck.error) {
+      throw new Error(`invalid original mock tmux shell fixture: ${originalSyntaxCheck.error?.message ?? originalSyntaxCheck.stderr ?? 'sh -n failed'}`);
+    }
     const fixtureDefinesGlobalExactPaneSnapshot = tmuxFixture.includes('-a -F #{pane_id}');
+    const sourceAuthorityTmuxFixture = tmuxFixture.replace(
+      '#!/bin/sh\n',
+      `#!/bin/sh
+# Every current-dev start fixture must provide the complete source-pane incarnation
+# captured by createTeamSession. Keep this narrow so command-specific fixture
+# behavior remains authoritative.
+log_command() {
+  printf '%s\n' "$*" >> "${tmuxLogPath}"
+}
+canonical_pane_pid() {
+  if [ -f "$0.actual-pid-$1" ]; then cat "$0.actual-pid-$1"; else printf '%s' "$((2000000000 + $1 * 1111))"; fi
+}
+actual_pane_pid() {
+  pane_number="$1"
+  if [ -f "$0.actual-pid-$pane_number" ]; then
+    IFS= read -r pane_pid < "$0.actual-pid-$pane_number" || true
+    case "$pane_pid" in *[!0-9]*|'') ;; *) printf '%s' "$pane_pid"; return ;; esac
+  fi
+  canonical_pane_pid "$pane_number"
+}
+owner_target() {
+  previous=''
+  for argument in "$@"; do
+    if [ "$previous" = '-t' ]; then
+      printf '%s' "$argument"
+      return
+    fi
+    previous="$argument"
+  done
+}
+# Capture the exact session/window/pane incarnation the production code binds
+# every source-authorized operation to. The generic fixture owns only this
+# canonical query; test scripts retain their command-specific topology.
+if [ "\${1:-}" = "display-message" ] && [ "\${2:-}" = "-p" ] && [ "\${3:-}" = "-t" ] \
+  && [ "\${5:-}" = "#{session_name}\t#{session_id}\t#{session_created}\t#{window_index}\t#{window_id}\t#{pane_id}\t#{pane_pid}" ]; then
+  case "\${4:-}" in
+    %*)
+      pane_number="\${4#%}"
+      case "$pane_number" in *[!0-9]*|'') exit 1 ;; esac
+      if [ ! -f "$0.actual-pid-$pane_number" ]; then
+        observed_pid="$("$0" list-panes -a -F '#{pane_id}\\t#{pane_dead}\\t#{pane_pid}' 2>/dev/null | awk -F '\\t' -v pane="\${4}" '$1 == pane && $2 == "0" && $3 ~ /^[1-9][0-9]*$/ { print $3; exit }')"
+        [ -z "$observed_pid" ] || printf '%s' "$observed_pid" > "$0.actual-pid-$pane_number"
+      fi
+      pane_pid="$(actual_pane_pid "$pane_number")"
+      : > "$0.source-proof-$pane_number"
+      log_command "$@"
+      printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' 'leader' '$1' '1700000000' '0' '@1' "\${4}" "$pane_pid"
+      exit 0
+      ;;
+  esac
+fi
+# Match the immediately following exact-pane liveness proof to the seven-field
+# capture above, without changing later command-specific global snapshots.
+if [ "\${1:-}" = "list-panes" ] && [ "\${2:-}" = "-a" ] && [ "\${3:-}" = "-F" ] && [ "\${4:-}" = "#{pane_id}\t#{pane_dead}\t#{pane_pid}" ]; then
+  for source_proof in "$0".source-proof-*; do
+    [ -e "$source_proof" ] || continue
+    pane_number="\${source_proof##*-}"
+    case "$pane_number" in *[!0-9]*|'') continue ;; esac
+    log_command "$@"
+    printf '%%%s\t0\t%s\n' "$pane_number" "$(actual_pane_pid "$pane_number")"
+    rm -f "$source_proof"
+    exit 0
+  done
+fi
+# A source-authorized tmux operation is one server-side transaction. Emulate
+# the guarded branch rather than letting fixture scripts accidentally treat
+# if-shell as an unconditional success. Tests that model a failed/drifted
+# transaction continue to do so by making their source query/proof invalid.
+if [ "\${1:-}" = "if-shell" ] && [ "\${2:-}" = "-F" ] && [ "\${3:-}" = "-t" ]; then
+  source_pane="\${4:-}"
+  predicate="\${5:-}"
+  effect="\${6:-}"
+  pane_number="\${source_pane#%}"
+  case "$pane_number" in *[!0-9]*|'') log_command "$@"; exit 0 ;; esac
+  quote="'"
+  double_quote='"'
+  pane_pid="$(actual_pane_pid "$pane_number")"
+  case "$predicate" in
+    *"#{==:#{pane_id},$source_pane}"*"#{==:#{pane_pid},$pane_pid}"*'#{==:#{session_id},$1}'*'#{==:#{session_created},1700000000}'*'#{==:#{window_id},@1}'*) ;;
+    *) source_pane='' ;;
+  esac
+  if [ -n "$source_pane" ]; then
+  log_command "$@"
+  if [ "\${effect#*split-window}" != "$effect" ]; then
+    receipt="$(printf '%s' "$effect" | sed -n 's/.*\\(omx_source_[A-Za-z0-9_]*\\).*/\\1/p')"
+    effect_command="\${effect%% \\; display-message*}"
+    eval "set -- $effect_command"
+    split_output="$("$0" "$@")" || exit 1
+    created_pane="$(printf '%s\\n' "$split_output" | awk -F '\\t' 'NR == 1 { print $1 }')"
+    case "$created_pane" in %*) ;; *) exit 1 ;; esac
+    pane_number="\${created_pane#%}"
+    created_pid="$("$0" list-panes -a -F '#{pane_id}\\t#{pane_dead}\\t#{pane_pid}' 2>/dev/null | awk -F '\\t' -v pane="$created_pane" '$1 == pane && $2 == "0" && $3 ~ /^[1-9][0-9]*$/ { print $3; exit }')"
+    [ -z "$created_pid" ] || printf '%s' "$created_pid" > "$0.actual-pid-$pane_number"
+    printf '%s\\t%s\\n' "$created_pane" "$receipt"
+    exit 0
+  fi
+  # Owner markers are part of the authority contract and must survive the
+  # guarded tagging transaction for subsequent source/final-sink proofs.
+  case "$effect" in
+    *'@omx_team_pane_owner_id '*)
+      tag_target="\${effect#* -t }"
+      tag_target="\${tag_target%% *}"
+      owner_value="\${effect##*@omx_team_pane_owner_id }"
+      owner_value="\${owner_value%% *}"
+      owner_value="\${owner_value#"$double_quote"}"
+      owner_value="\${owner_value%"$double_quote"}"
+      owner_value="\${owner_value#"$quote"}"
+      owner_value="\${owner_value%"$quote"}"
+      printf '%s' "$owner_value" > "$0.owner-\${tag_target#%}"
+      ;;
+  esac
+  receipt="\${effect##*display-message -p }"
+  receipt="\${receipt#"$quote"}"
+  receipt="\${receipt%"$quote"}"
+  printf '%s\n' "$receipt"
+  exit 0
+  fi
+fi
+# Keep owner-tag reads and writes coherent even in compact fixtures that do not
+# spell out the tmux option commands themselves.
+if [ "\${1:-}" = "set-option" ]; then
+  owner_key=''
+  for argument in "$@"; do [ "$argument" = '@omx_team_pane_owner_id' ] && owner_key=1; done
+  if [ -n "$owner_key" ]; then
+    target="$(owner_target "$@")"
+    owner_value=''
+    previous=''
+    for argument in "$@"; do
+      if [ "$previous" = '@omx_team_pane_owner_id' ]; then owner_value="$argument"; break; fi
+      previous="$argument"
+    done
+    if [ -n "$target" ] && [ -n "$owner_value" ]; then
+      log_command "$@"
+      printf '%s' "$owner_value" > "$0.owner-\${target#%}"
+      exit 0
+    fi
+  fi
+fi
+if [ "\${1:-}" = "show-option" ] || [ "\${1:-}" = "show-options" ]; then
+  owner_key=''
+  for argument in "$@"; do [ "$argument" = '@omx_team_pane_owner_id' ] && owner_key=1; done
+  if [ -n "$owner_key" ]; then
+    target="$(owner_target "$@")"
+    if [ -f "$0.owner-\${target#%}" ]; then
+      log_command "$@"
+      cat "$0.owner-\${target#%}"
+      exit 0
+    fi
+  fi
+fi
+`,
+    );
     const compatibleTmuxFixture = fixtureDefinesGlobalExactPaneSnapshot
-      ? tmuxFixture
-      : tmuxFixture.replace(
+      ? sourceAuthorityTmuxFixture
+      : sourceAuthorityTmuxFixture.replace(
         '#!/bin/sh\n',
         `#!/bin/sh
 # Legacy fixtures without a global snapshot get deterministic, valid live panes.
@@ -677,6 +835,10 @@ fi
 `,
       );
     await writeFile(tmuxStubPath, compatibleTmuxFixture);
+    const wrapperSyntaxCheck = spawnSync('sh', ['-n', tmuxStubPath], { encoding: 'utf-8' });
+    if (wrapperSyntaxCheck.status !== 0 || wrapperSyntaxCheck.error) {
+      throw new Error(`invalid generated mock tmux shell wrapper: ${wrapperSyntaxCheck.error?.message ?? wrapperSyntaxCheck.stderr ?? 'sh -n failed'}`);
+    }
     await chmod(tmuxStubPath, 0o755);
 
     for (const binary of options.binaries ?? []) {
@@ -2471,9 +2633,9 @@ esac
           assert.equal(manifest.leader?.session_id, '%1');
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id %1/);
-          assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id %1/);
-          assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id %1/);
+          assert.match(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id '%1'/);
+          assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id '%1'/);
+          assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id '%1'/);
           assert.match(tmuxLog, /exec env OMX_SESSION_ID='%1' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%1' .*hud --watch/);
 
           await shutdownTeam(runtime.teamName, cwd, { force: true }).catch(() => {});
@@ -2636,13 +2798,13 @@ esac
           assert.equal(manifest.leader?.session_id, 'logical-session-from-env');
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /set-option -t leader @omx_instance_id logical-session-from-env/);
-          assert.match(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id logical-session-from-env/);
-          assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id logical-session-from-env/);
-          assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id logical-session-from-env/);
-          assert.match(tmuxLog, /set-option -p -t %1 @omx_team_pane_owner_id team:pane-owner-env-isolat-[a-f0-9]{8}/);
-          assert.match(tmuxLog, /set-option -p -t %2 @omx_team_pane_owner_id team:pane-owner-env-isolat-[a-f0-9]{8}/);
-          assert.match(tmuxLog, /set-option -p -t %3 @omx_team_pane_owner_id team:pane-owner-env-isolat-[a-f0-9]{8}/);
+          assert.match(tmuxLog, /set-option -t \$1 @omx_instance_id 'logical-session-from-env'/);
+          assert.match(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id 'logical-session-from-env'/);
+          assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id 'logical-session-from-env'/);
+          assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id 'logical-session-from-env'/);
+          assert.match(tmuxLog, /set-option -p -t %1 @omx_team_pane_owner_id 'team:pane-owner-env-isolat-[a-f0-9]{8}'/);
+          assert.match(tmuxLog, /set-option -p -t %2 @omx_team_pane_owner_id 'team:pane-owner-env-isolat-[a-f0-9]{8}'/);
+          assert.match(tmuxLog, /set-option -p -t %3 @omx_team_pane_owner_id 'team:pane-owner-env-isolat-[a-f0-9]{8}'/);
           assert.doesNotMatch(tmuxLog, /set-option -p -t %1 @omx_team_pane_owner_id logical-session-from-env/);
           assert.match(tmuxLog, /exec env OMX_SESSION_ID='logical-session-from-env' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%1' .*hud --watch/);
 
@@ -4680,7 +4842,7 @@ esac
               [{ subject: 's', description: 'd', owner: 'worker-1' }],
               cwd,
             )),
-            /startup_rollback_pane_proof_unavailable:%2:malformed_snapshot/,
+            /create_team_session_cleanup_incomplete/,
           );
 
           const runtimeTeamName = await resolveRuntimeTeamName(cwd, 'team-partial-create-proof');
@@ -4693,7 +4855,7 @@ esac
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.match(tmuxLog, /list-panes -a -F #\{pane_id\}\t#\{pane_dead\}\t#\{pane_pid\}/);
-          assert.doesNotMatch(tmuxLog, /kill-pane -t %2/);
+          assert.equal(tmuxLog.match(/kill-pane -t %2/g)?.length ?? 0, 1);
         },
       );
     } finally {
@@ -4783,7 +4945,7 @@ esac
               [{ subject: 's', description: 'd', owner: 'worker-1' }],
               cwd,
             )),
-            /exact_pane_proof_unavailable:%1:malformed_snapshot/,
+            /exact_pane_proof_unavailable:%2:malformed_snapshot/,
           );
 
           const runtimeTeamName = await resolveRuntimeTeamName(cwd, 'team-no-resource-create-proof');
@@ -5754,7 +5916,7 @@ exit 0
           assert.equal(tmuxLog.match(/set-hook -t leader:0 client-attached\[\d+\]/g)?.length ?? 0, 2);
           assert.match(tmuxLog, /snapshot=\$\(tmux list-panes -a -F/);
           assert.ok((tmuxLog.match(/list-panes -a -F '#\{pane_id\}\\t#\{pane_dead\}\\t#\{pane_pid\}'/g)?.length ?? 0) >= 6);
-          assert.ok((tmuxLog.match(/select-layout -t leader:0 main-vertical/g)?.length ?? 0) >= 2);
+          assert.ok((tmuxLog.match(/select-layout -t @1 main-vertical/g)?.length ?? 0) >= 2);
           assert.equal(tmuxLog.match(/kill-pane -t %3/g)?.length ?? 0, 2);
         },
       );
@@ -8179,7 +8341,12 @@ case "$1" in
     ;;
   show-option|show-options) echo 'team:team-detached-hud-shutdown' ;;
   kill-pane) : > "${tmuxLogPath}.hud-killed" ;;
-  if-shell) : > "${tmuxLogPath}.session-killed" ;;
+  if-shell)
+    case "\${5:-}" in
+      *'#{==:#{pane_dead},0}'*'#{==:#{pane_id},%1}'*'#{==:#{pane_pid},4241}'*'#{==:#{@omx_team_pane_owner_id},team:team-detached-hud-shutdown}'*'#{==:#{session_id},$81}'*'#{==:#{session_created},1700000001}'*) : > "${tmuxLogPath}.session-killed" ;;
+      *) exit 1 ;;
+    esac
+    ;;
   list-sessions)
     if [ -f "${tmuxLogPath}.session-killed" ]; then
       printf '%s\n' 'no server running on /tmp/tmux-1000/default' >&2
@@ -8243,7 +8410,12 @@ case "$1" in
     esac
     ;;
   show-option|show-options) echo 'team:team-postkill-query-fail' ;;
-  if-shell) : > "${tmuxLogPath}.session-killed" ;;
+  if-shell)
+    case "\${5:-}" in
+      *'#{==:#{pane_dead},0}'*'#{==:#{pane_id},%1}'*'#{==:#{pane_pid},4241}'*'#{==:#{@omx_team_pane_owner_id},team:team-postkill-query-fail}'*'#{==:#{session_id},$1}'*'#{==:#{session_created},1700000000}'*) : > "${tmuxLogPath}.session-killed" ;;
+      *) exit 1 ;;
+    esac
+    ;;
   list-sessions)
     if [ -f "${tmuxLogPath}.session-killed" ]; then
       if [ -f "${tmuxLogPath}.allow-retry" ]; then
@@ -8468,7 +8640,12 @@ case "$1" in
     esac ;;
   show-option|show-options) echo 'team:intent-receipt' ;;
   list-sessions) [ -f "${tmuxLogPath}.killed" ] || printf 'omx-team-intent-receipt\t$71\t1700000010\n' ;;
-  if-shell) : > "${tmuxLogPath}.killed" ;;
+  if-shell)
+    case "\${5:-}" in
+      *'#{==:#{pane_dead},0}'*'#{==:#{pane_id},%1}'*'#{==:#{pane_pid},4241}'*'#{==:#{@omx_team_pane_owner_id},team:intent-receipt}'*'#{==:#{session_id},$71}'*'#{==:#{session_created},1700000010}'*) : > "${tmuxLogPath}.killed" ;;
+      *) exit 1 ;;
+    esac
+    ;;
   *) exit 0 ;;
 esac
 `,

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -227,6 +227,7 @@ async function writeReadyContextPack(
 async function writeSuccessfulScaleUpTmuxStub(
   fakeBinDir: string,
   tmuxLogPath: string,
+  failGuardedSendKeys = false,
 ): Promise<void> {
   const tmuxStubPath = join(fakeBinDir, 'tmux');
   await writeFile(
@@ -236,24 +237,63 @@ async function writeSuccessfulScaleUpTmuxStub(
       'set -eu',
       `printf '%s\n' "$*" >> "${tmuxLogPath}"`,
       'case "${1:-}" in',
-          '  show-option) echo "team:scale-up" ;;',
       '  -V)',
       '    echo "tmux 3.2a"',
       '    ;;',
+      '  display-message)',
+      '    case "$*" in',
+      '      *"-t %32 "*) echo "%32\\t42425\\tomx-team-scale-up\\t\\$1\\t@1\\tteam:scale-up" ;;',
+      '      *"-t %33 "*) echo "%33\\t42426\\tomx-team-scale-up\\t\\$1\\t@1\\tteam:scale-up" ;;',
+      '      *"-t %31 "*) echo "%31\\t42424\\tomx-team-scale-up\\t\\$1\\t@1\\tteam:scale-up" ;;',
+      '      *"-t %21 "*) echo "%21\\t42421\\tomx-team-scale-up\\t\\$1\\t@1\\tteam:scale-up" ;;',
+      '      *) echo "%11\\t42411\\tomx-team-scale-up\\t\\$1\\t@1\\tteam:scale-up" ;;',
+      '    esac',
+      '    ;;',
+      '  if-shell)',
+      '    case "${2:-}" in',
+      '      -F)',
+      '        if [ "${3:-}" = "-t" ]; then',
+      '          target="${4:-}"',
+      '          condition="${5:-}"',
+      '          success="${6:-}"',
+      '        else',
+      '          target=""',
+      '          condition="${3:-}"',
+      '          success="${4:-}"',
+      '        fi',
+      '        ;;',
+      '      *) exit 1 ;;',
+      '    esac',
+      '    case "$target:$condition" in',
+      '      %21:*) ;;',
+      '      %31:*) ;;',
+      '      %32:*) ;;',
+      '      %33:*) ;;',
+      '      *) exit 1 ;;',
+      '    esac',
+      "    receipt=\"$(printf '%s' \"$success\" | sed -En 's/.*(omx-scale-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}).*/\\1/p')\"",
+      '    [ -n "$receipt" ] || exit 1',
+      '    case "$success" in',
+      `      *split-window*) case "$target" in %21) : > "${join(fakeBinDir, 'created-%31')}"; printf '%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n' '%31' '42424' 'omx-team-scale-up' '$1' '@1' "$receipt" ;; %31) : > "${join(fakeBinDir, 'created-%32')}"; printf '%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n' '%32' '42425' 'omx-team-scale-up' '$1' '@1' "$receipt" ;; %32) : > "${join(fakeBinDir, 'created-%33')}"; printf '%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n' '%33' '42426' 'omx-team-scale-up' '$1' '@1' "$receipt" ;; *) exit 1 ;; esac ;;`,
+      ...(failGuardedSendKeys ? ['      *send-keys*) exit 1 ;;'] : []),
+      '      *"\'set-option\'"*|*"\'send-keys\'"*|*"\'kill-pane\'"*|*set-option*|*send-keys*|*kill-pane*) printf "%s\\n" "$receipt" ;;',
+      '      *) exit 1 ;;',
+      '    esac',
+      '    ;;',
       '  split-window)',
-      '    echo "%31"',
+      '    case "$*" in',
+      `      *"-t %21 "*) : > "${join(fakeBinDir, 'created-%31')}"; echo "%31\\t42424\\tomx-team-scale-up\\t\\$1\\t@1" ;;`,
+      `      *"-t %31 "*) : > "${join(fakeBinDir, 'created-%32')}"; echo "%32\\t42425\\tomx-team-scale-up\\t\\$1\\t@1" ;;`,
+      `      *"-t %32 "*) : > "${join(fakeBinDir, 'created-%33')}"; echo "%33\\t42426\\tomx-team-scale-up\\t\\$1\\t@1" ;;`,
+      '      *) exit 1 ;;',
+      '    esac',
       '    ;;',
       '  list-panes)',
-      '    case "$*" in',
-      '      *"#{pane_id}\t#{pane_dead}\t#{pane_pid}"*)',
-      "        printf '%s\t%s\t%s\n' '%11' '0' '42411'",
-      "        printf '%s\t%s\t%s\n' '%21' '0' '42421'",
-      `        if [ ! -f "${join(fakeBinDir, 'killed-%31')}" ]; then printf '%s\\t%s\\t%s\\n' '%31' '0' '42424'; fi`,
-      '        ;;',
-      '      *)',
-      '        echo "42424"',
-      '        ;;',
-      '    esac',
+      "    printf '%s\\t%s\\t%s\\n' '%11' '0' '42411'",
+      "    printf '%s\\t%s\\t%s\\n' '%21' '0' '42421'",
+      `    if [ -f "${join(fakeBinDir, 'created-%31')}" ] && [ ! -f "${join(fakeBinDir, 'killed-%31')}" ]; then printf '%s\\t%s\\t%s\\n' '%31' '0' '42424'; fi`,
+      `    if [ -f "${join(fakeBinDir, 'created-%32')}" ] && [ ! -f "${join(fakeBinDir, 'killed-%32')}" ]; then printf '%s\\t%s\\t%s\\n' '%32' '0' '42425'; fi`,
+      `    if [ -f "${join(fakeBinDir, 'created-%33')}" ] && [ ! -f "${join(fakeBinDir, 'killed-%33')}" ]; then printf '%s\\t%s\\t%s\\n' '%33' '0' '42426'; fi`,
       '    ;;',
       '  show-option)',
       '    case "$*" in',
@@ -261,22 +301,22 @@ async function writeSuccessfulScaleUpTmuxStub(
       '      *) exit 1 ;;',
       '    esac',
       '    ;;',
-      '  send-keys)',
-      '    ;;',
+      '  set-option) ;;',
+      '  send-keys) ;;',
       '  kill-pane)',
       `    : > "${join(fakeBinDir, 'killed-')}$3"`,
       '    ;;',
-      '  capture-pane)',
-      '    echo ""',
-      '    ;;',
+      '  capture-pane) echo "" ;;',
       'esac',
       'exit 0',
       '',
     ].join('\n'),
   );
+  execFileSync('sh', ['-n', tmuxStubPath], { stdio: 'pipe' });
   await chmod(tmuxStubPath, 0o755);
   await writeFile(tmuxLogPath, '');
 }
+
 
 async function configureScaleUpTeamForDirectDispatch(teamName: string, cwd: string): Promise<void> {
   const config = await readTeamConfig(teamName, cwd);
@@ -284,7 +324,7 @@ async function configureScaleUpTeamForDirectDispatch(teamName: string, cwd: stri
   if (!config) {
     throw new Error(`missing team config for ${teamName}`);
   }
-  config.tmux_session = `omx-team-${teamName}`;
+  config.tmux_session = 'omx-team-scale-up';
   config.tmux_pane_owner_id = 'team:scale-up';
   config.leader_pane_id = '%11';
 
@@ -311,6 +351,17 @@ async function readScaleUpTmuxLogCommands(tmuxLogPath: string): Promise<string[]
   const content = await readFile(tmuxLogPath, 'utf-8');
   const trimmed = content.trim();
   return trimmed === '' ? [] : trimmed.split('\n');
+}
+
+function isGuardedScaleMutation(command: string, mutation: string, target?: string): boolean {
+  return command.startsWith('if-shell -F -t ')
+    && command.includes(mutation)
+    && (target === undefined || command.includes(`-t '${target}'`) || command.includes(`-t ${target}`))
+    && /omx-scale-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(command);
+}
+
+function guardedScaleSplitCount(commands: readonly string[]): number {
+  return commands.filter((command) => isGuardedScaleMutation(command, 'split-window')).length;
 }
 
 async function readScaleUpTaskPayloads(teamName: string, cwd: string): Promise<string[]> {
@@ -847,51 +898,10 @@ exit 0
     const cwd = await mkdtemp(join(tmpdir(), 'omx-scale-up-role-'));
     const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-scale-up-role-bin-'));
     const tmuxLogPath = join(fakeBinDir, 'tmux.log');
-    const tmuxStubPath = join(fakeBinDir, 'tmux');
     const previousPath = process.env.PATH;
 
     try {
-      await writeFile(
-        tmuxStubPath,
-        [
-          '#!/bin/sh',
-          'set -eu',
-          `printf '\%s\n' "$*" >> "${tmuxLogPath}"`,
-          'case "${1:-}" in',
-          '  show-option) echo "team:scale-up-role" ;;',
-          '  -V)',
-          '    echo "tmux 3.2a"',
-          '    ;;',
-          '  split-window)',
-          '    echo "%31"',
-          '    ;;',
-          '  list-panes)',
-          '    case "$*" in',
-          '      *"#{pane_id}\t#{pane_dead}\t#{pane_pid}"*)',
-          "        printf '%s\\t%s\\t%s\\n' '%11' '0' '42411'",
-          "        printf '%s\\t%s\\t%s\\n' '%21' '0' '42421'",
-          `        if [ ! -f "${join(fakeBinDir, 'scale-up-role-killed-%31')}" ]; then printf '%s\\t%s\\t%s\\n' '%31' '0' '42424'; fi`,
-          '        ;;',
-          '      *)',
-          '        echo "42424"',
-          '        ;;',
-          '    esac',
-          '    ;;',
-          '  send-keys)',
-          '    ;;',
-          '  kill-pane)',
-          `    : > "${join(fakeBinDir, 'scale-up-role-killed-')}$3"`,
-          '    ;;',
-          '  capture-pane)',
-          '    echo ""',
-          '    ;;',
-          'esac',
-          'exit 0',
-          '',
-        ].join('\n'),
-      );
-      await chmod(tmuxStubPath, 0o755);
-      await writeFile(tmuxLogPath, '');
+      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath);
       process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
 
       await mkdir(join(cwd, '.codex', 'prompts'), { recursive: true });
@@ -910,10 +920,10 @@ exit 0
       const config = await readTeamConfig('scale-up-role', cwd);
       assert.ok(config);
       if (!config) return;
-      config.tmux_session = 'omx-team-scale-up-role';
+      config.tmux_session = 'omx-team-scale-up';
       config.leader_pane_id = '%11';
 
-      config.tmux_pane_owner_id = 'team:scale-up-role';
+      config.tmux_pane_owner_id = 'team:scale-up';
       config.workers[0]!.pane_id = '%21';
       config.workers[0]!.pid = 42421;
       await saveTeamConfig(config, cwd);
@@ -936,7 +946,7 @@ exit 0
 
 
       );
-      assert.equal(result.ok, true);
+      assert.equal(result.ok, true, result.ok ? 'ok' : result.error);
       if (!result.ok) return;
 
       const createdTask = await readTask('scale-up-role', '2', cwd);
@@ -952,7 +962,8 @@ exit 0
 
       const tmuxCommands = await readScaleUpTmuxLogCommands(tmuxLogPath);
       assert.ok(tmuxCommands.some((command) => (
-        command === 'set-option -p -t %31 @omx_team_pane_owner_id team:scale-up-role'
+        isGuardedScaleMutation(command, 'set-option', '%31')
+        && command.includes('@omx_team_pane_owner_id')
       )));
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
@@ -1112,8 +1123,27 @@ printf '%s\\n' "$@" > '${capturePath}'
           '  -V)',
           '    echo "tmux 3.2a"',
           '    ;;',
+          '  display-message)',
+          '    case "$*" in',
+          '      *"-t %31 "*) echo "%31\\t42424\\tomx-team-scale-up\\t\\$1\\t@1\\tteam:scale-up-owner-tag-rollback" ;;',
+          '      *"-t %21 "*) echo "%21\\t42421\\tomx-team-scale-up\\t\\$1\\t@1\\tteam:scale-up-owner-tag-rollback" ;;',
+          '      *) exit 1 ;;',
+          '    esac',
+          '    ;;',
+          '  if-shell)',
+          '    [ "${2:-}" = "-F" ] && [ "${3:-}" = "-t" ] || exit 1',
+          '    success="${6:-}"',
+          "    receipt=\"$(printf '%s' \"$success\" | sed -En 's/.*(omx-scale-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}).*/\\1/p')\"",
+          '    [ -n "$receipt" ] || exit 1',
+          '    case "$success" in',
+          '      *split-window*) printf "%s\\t%s\\n" "%31\\t42424\\tomx-team-scale-up\\t\\$1\\t@1" "$receipt" ;;',
+          '      *set-option*) exit 1 ;;',
+          '      *kill-pane*) printf "%s\\n" "$receipt" ;;',
+          '      *) exit 1 ;;',
+          '    esac',
+          '    ;;',
           '  split-window)',
-          '    echo "%31"',
+          '    echo "%31\\t42424\\tomx-team-scale-up\\t\\$1\\t@1"',
           '    ;;',
           '  set-option)',
           '    case "$*" in',
@@ -1145,6 +1175,7 @@ printf '%s\\n' "$@" > '${capturePath}'
         ].join('\n'),
       );
       await chmod(tmuxStubPath, 0o755);
+      execFileSync('sh', ['-n', tmuxStubPath], { stdio: 'pipe' });
       await writeFile(tmuxLogPath, '');
       process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
       process.env.OMX_RUNTIME_BRIDGE = '0';
@@ -1167,30 +1198,11 @@ printf '%s\\n' "$@" > '${capturePath}'
       );
       assert.equal(result.ok, false);
       if (result.ok) return;
-      assert.match(result.error, /scale_up_rollback_cleanup_debt:pane_owner_unverified:%31/);
-
+      assert.equal(result.error, 'scale_up_split_target_authority_lost:%21');
       const config = await readTeamConfig('scale-up-owner-tag-rollback', cwd);
-      assert.deepEqual(config?.workers.map((worker) => worker.name), ['worker-1', 'worker-2']);
-      assert.equal(config?.workers[1]?.pane_id, '%31');
-      assert.equal(config?.next_worker_index, 3);
-      assert.equal((await readTask('scale-up-owner-tag-rollback', '1', cwd))?.owner, 'worker-2');
-      assert.equal(existsSync(
-        join(cwd, '.omx', 'state', 'team', 'scale-up-owner-tag-rollback', 'workers', 'worker-2', 'identity.json'),
-      ), false);
-      assert.equal(existsSync(
-        join(cwd, '.omx', 'state', 'team', 'scale-up-owner-tag-rollback', 'workers', 'worker-2', 'inbox.md'),
-      ), false);
-      const dispatch = JSON.parse(await readFile(
-        join(cwd, '.omx', 'state', 'team', 'scale-up-owner-tag-rollback', 'dispatch', 'requests.json'),
-        'utf8',
-      )) as Array<{ to_worker?: string }>;
-      assert.equal(dispatch.some((request) => request.to_worker === 'worker-2'), false);
-      assert.equal((await listDispatchRequests('scale-up-owner-tag-rollback', cwd, { to_worker: 'worker-2' })).length, 0);
-
+      assert.deepEqual(config?.workers.map((worker) => worker.name), ['worker-1']);
+      assert.equal(await readTask('scale-up-owner-tag-rollback', '1', cwd), null);
       const tmuxCommands = await readScaleUpTmuxLogCommands(tmuxLogPath);
-      assert.ok(tmuxCommands.some((command) => (
-        command === 'set-option -p -t %31 @omx_team_pane_owner_id team:scale-up-owner-tag-rollback'
-      )));
       assert.equal(tmuxCommands.some((command) => command === 'kill-pane -t %31'), false);
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
@@ -1217,6 +1229,7 @@ printf '%s\\n' "$@" > '${capturePath}'
         'case "${1:-}" in',
         '  -V) echo "tmux 3.2a" ;;',
         '  show-option) echo "team:scale-up" ;;',
+        '  display-message) echo "%21\\t42421\\tomx-team-scale-up\\t\\$1\\t@1\\tteam:scale-up" ;;',
         '  split-window) : > "' + splitPath + '"; echo "%31" ;;',
         '  list-panes)',
         '    if [ -f "' + splitPath + '" ]; then printf "malformed pane snapshot\\n"; else',
@@ -1241,10 +1254,9 @@ printf '%s\\n' "$@" > '${capturePath}'
 
       assert.equal(result.ok, false);
       if (result.ok) return;
-      assert.match(result.error, /scale_up_rollback_cleanup_debt:pane_pid_unpinned:%31/);
+      assert.match(result.error, /scale_up_split_target_authority_lost:%21/);
       const config = await readTeamConfig(teamName, cwd);
-      assert.equal(config?.workers[1]?.pane_id, '%31');
-      assert.equal(config?.workers[1]?.pid, undefined);
+      assert.equal(config?.workers.length, 1);
       const tmuxCommands = await readScaleUpTmuxLogCommands(tmuxLogPath);
       assert.equal(tmuxCommands.some((command) => command === 'kill-pane -t %31'), false);
     } finally {
@@ -1269,8 +1281,27 @@ printf '%s\\n' "$@" > '${capturePath}'
         `printf '%s\\n' "$*" >> "${tmuxLogPath}"`,
         'case "${1:-}" in',
           '  show-option) echo "team:scale-up" ;;',
+        '  display-message)',
+        '    case "$*" in',
+        '      *"-t %31 "*) echo "%31\\t42424\\tomx-team-scale-up\\t\\$1\\t@1\\tteam:scale-up" ;;',
+        '      *"-t %21 "*) echo "%21\\t42421\\tomx-team-scale-up\\t\\$1\\t@1\\tteam:scale-up" ;;',
+        '      *) exit 1 ;;',
+        '    esac',
+        '    ;;',
+        '  if-shell)',
+        '    [ "${2:-}" = "-F" ] && [ "${3:-}" = "-t" ] || exit 1',
+        '    success="${6:-}"',
+        "    receipt=\"$(printf '%s' \"$success\" | sed -En 's/.*(omx-scale-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}).*/\\1/p')\"",
+        '    [ -n "$receipt" ] || exit 1',
+        '    case "$success" in',
+        '      *set-option*) printf "recycled\\n" ;;',
+        '      *split-window*) printf "%s\\t%s\\n" "%31\\t42424\\tomx-team-scale-up\\t\\$1\\t@1" "$receipt" ;;',
+        '      *kill-pane*) printf "%s\\n" "$receipt" ;;',
+        '      *) exit 1 ;;',
+        '    esac',
+        '    ;;',
         '  -V) echo "tmux 3.2a" ;;',
-        '  split-window) echo "%31" ;;',
+        '  split-window) echo "%31\\t42424\\tomx-team-scale-up\\t\\$1\\t@1" ;;',
         '  list-panes)',
         `    count_file="${join(fakeBinDir, 'proof-count')}"`,
         '    count=0; [ ! -f "$count_file" ] || count=$(cat "$count_file")',
@@ -1291,6 +1322,7 @@ printf '%s\\n' "$@" > '${capturePath}'
         '',
       ].join('\n'));
       await chmod(tmuxStubPath, 0o755);
+      execFileSync('sh', ['-n', tmuxStubPath], { stdio: 'pipe' });
       await writeFile(tmuxLogPath, '');
       process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
 
@@ -1303,13 +1335,10 @@ printf '%s\\n' "$@" > '${capturePath}'
 
       assert.equal(result.ok, false);
       if (result.ok) return;
-      assert.match(result.error, /scale_up_rollback_cleanup_debt:pane_owner_unverified:%31/);
+      assert.equal(result.error, 'scale_up_split_target_authority_lost:%21');
       const config = await readTeamConfig(teamName, cwd);
-      assert.equal(config?.workers[1]?.pane_id, '%31');
-      assert.equal(config?.workers[1]?.pid, 42424);
+      assert.deepEqual(config?.workers.map((worker) => worker.name), ['worker-1']);
       const tmuxCommands = await readScaleUpTmuxLogCommands(tmuxLogPath);
-      assert.equal(tmuxCommands.some((command) => command.includes('set-option -p -t %31 @omx_team_pane_owner_id')), false);
-      assert.equal(tmuxCommands.some((command) => command.startsWith('split-window ')), true);
       assert.equal(tmuxCommands.some((command) => command === 'kill-pane -t %31'), false);
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
@@ -1369,7 +1398,7 @@ printf '%s\\n' "$@" > '${capturePath}'
       assert.match(inbox, /G001-team-runtime-bridge/);
       assert.match(inbox, /workers do not own Ultragoal goal state/i);
       assert.match(inbox, /omx ultragoal checkpoint --goal-id G001-team-runtime-bridge/);
-      assert.ok(tmuxCommands.some((command) => command.startsWith('split-window ')));
+      assert.equal(guardedScaleSplitCount(tmuxCommands), 1);
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;
@@ -1412,7 +1441,7 @@ printf '%s\\n' "$@" > '${capturePath}'
       const tmuxCommands = await readScaleUpTmuxLogCommands(tmuxLogPath);
       assert.match(inbox, /Implement generic follow-up/);
       assert.doesNotMatch(inbox, /## Approved Handoff Context/);
-      assert.ok(tmuxCommands.some((command) => command.startsWith('split-window ')));
+      assert.equal(guardedScaleSplitCount(tmuxCommands), 1);
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;
@@ -1458,7 +1487,7 @@ printf '%s\\n' "$@" > '${capturePath}'
       assert.match(inbox, /## Approved Handoff Context/);
       assert.match(inbox, /Use the approved plan and matching test specs as the execution baseline/);
       assert.doesNotMatch(inbox, /Approved context pack|Context pack index/);
-      assert.ok(tmuxCommands.some((command) => command.startsWith('split-window ')));
+      assert.equal(guardedScaleSplitCount(tmuxCommands), 1);
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;
@@ -1533,7 +1562,7 @@ printf '%s\\n' "$@" > '${capturePath}'
       assert.match(inbox, /Read the approved repository slice first\./);
       assert.match(inbox, /Use the approved plan and matching test specs as the execution baseline/);
       assert.doesNotMatch(inbox, /Approved context pack|Build refs|Verify refs|Scope refs|query the canonical pack|Context pack index/);
-      assert.ok(tmuxCommands.some((command) => command.startsWith('split-window ')));
+      assert.equal(guardedScaleSplitCount(tmuxCommands), 1);
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;
@@ -1575,7 +1604,7 @@ printf '%s\\n' "$@" > '${capturePath}'
             { OMX_TEAM_SCALING_ENABLED: '1', OMX_TEAM_SKIP_READY_WAIT: '1' },
           );
           const tmuxCommands = await readScaleUpTmuxLogCommands(tmuxLogPath);
-          const splitWindowCommands = tmuxCommands.filter((command) => command.startsWith('split-window '));
+          const splitWindowCommands = tmuxCommands.filter((command) => isGuardedScaleMutation(command, 'split-window'));
           const inboxes = await Promise.all(tasks.map(async (task) => {
             const inboxPath = join(
               cwd,
@@ -1779,6 +1808,7 @@ printf '%s\\n' "$@" > '${capturePath}'
         ].join('\n'),
       );
       await chmod(tmuxStubPath, 0o755);
+      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath);
       await writeFile(tmuxLogPath, '');
       process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
       delete process.env.CODEX_HOME;
@@ -1812,7 +1842,7 @@ printf '%s\\n' "$@" > '${capturePath}'
       const config = await readTeamConfig('scale-up-project-reasoning', cwd);
       assert.ok(config);
       if (!config) return;
-      config.tmux_session = 'omx-team-scale-up-project-reasoning';
+      config.tmux_session = 'omx-team-scale-up';
       config.leader_pane_id = '%11';
 
       config.tmux_pane_owner_id = 'team:scale-up';
@@ -1871,48 +1901,10 @@ printf '%s\\n' "$@" > '${capturePath}'
   it('removes generated worktree-root AGENTS when scale-up rolls back', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-scale-up-rollback-worktree-'));
     const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-scale-up-rollback-worktree-bin-'));
-    const tmuxStubPath = join(fakeBinDir, 'tmux');
     const previousPath = process.env.PATH;
 
     try {
-      await writeFile(
-        tmuxStubPath,
-        `#!/bin/sh
-set -eu
-	case "\${1:-}" in
-  show-option) echo 'team:scale-up' ;;
-  -V)
-    echo "tmux 3.2a"
-    ;;
-  split-window)
-    echo "%31"
-    ;;
-  list-panes)
-    case "$*" in
-      *"#{pane_id}\t#{pane_dead}\t#{pane_pid}"*)
-        printf '%s\t%s\t%s\n' '%11' '0' '42411'
-        printf '%s\t%s\t%s\n' '%21' '0' '42421'
-        if [ ! -f "${fakeBinDir}/killed-%31" ]; then printf '%s\t%s\t%s\n' '%31' '0' '42424'; fi
-        ;;
-      *)
-        echo "42424"
-        ;;
-    esac
-    ;;
-  send-keys)
-    exit 1
-    ;;
-  kill-pane)
-    : > "${fakeBinDir}/killed-$3"
-    ;;
-  capture-pane)
-    echo ""
-    ;;
-esac
-exit 0
-`,
-      );
-      await chmod(tmuxStubPath, 0o755);
+      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, join(fakeBinDir, 'tmux.log'), true);
       process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
 
       await mkdir(join(cwd, '.codex', 'prompts'), { recursive: true });
@@ -1928,7 +1920,7 @@ exit 0
       const config = await readTeamConfig('rollback-worktree', cwd);
       assert.ok(config);
       if (!config) return;
-      config.tmux_session = 'omx-team-rollback-worktree';
+      config.tmux_session = 'omx-team-scale-up';
       config.leader_pane_id = '%11';
 
       config.tmux_pane_owner_id = 'team:scale-up';
@@ -2010,6 +2002,7 @@ exit 0
 `,
       );
       await chmod(tmuxStubPath, 0o755);
+      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, join(fakeBinDir, 'tmux.log'));
       process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
 
       await mkdir(join(cwd, '.codex', 'prompts'), { recursive: true });
@@ -2025,7 +2018,7 @@ exit 0
       const config = await readTeamConfig('canonical-root', cwd);
       assert.ok(config);
       if (!config) return;
-      config.tmux_session = 'omx-team-canonical-root';
+      config.tmux_session = 'omx-team-scale-up';
       config.leader_pane_id = '%11';
 
       config.tmux_pane_owner_id = 'team:scale-up';
@@ -2115,6 +2108,7 @@ exit 0
 `,
       );
       await chmod(tmuxStubPath, 0o755);
+      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, join(fakeBinDir, 'tmux.log'));
       process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
 
       await mkdir(join(cwd, '.codex', 'prompts'), { recursive: true });
@@ -2133,7 +2127,7 @@ exit 0
       const config = await readTeamConfig('frontier-role', cwd);
       assert.ok(config);
       if (!config) return;
-      config.tmux_session = 'omx-team-frontier-role';
+      config.tmux_session = 'omx-team-scale-up';
       config.leader_pane_id = '%11';
 
       config.tmux_pane_owner_id = 'team:scale-up';
@@ -2214,6 +2208,7 @@ exit 0
 `,
       );
       await chmod(tmuxStubPath, 0o755);
+      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, join(fakeBinDir, 'tmux.log'));
       process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
 
       await mkdir(join(cwd, '.codex', 'prompts'), { recursive: true });
@@ -2229,7 +2224,7 @@ exit 0
       const config = await readTeamConfig('mini-tuned-root', cwd);
       assert.ok(config);
       if (!config) return;
-      config.tmux_session = 'omx-team-mini-tuned-root';
+      config.tmux_session = 'omx-team-scale-up';
       config.leader_pane_id = '%11';
 
       config.tmux_pane_owner_id = 'team:scale-up';
@@ -2276,47 +2271,10 @@ exit 0
     const cwd = await mkdtemp(join(tmpdir(), 'omx-scale-up-layout-'));
     const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-scale-up-layout-bin-'));
     const tmuxLogPath = join(fakeBinDir, 'tmux.log');
-    const tmuxStubPath = join(fakeBinDir, 'tmux');
     const previousPath = process.env.PATH;
 
     try {
-      await writeFile(
-        tmuxStubPath,
-        `#!/bin/sh
-set -eu
-printf '%s\\n' "$*" >> "${tmuxLogPath}"
-case "\${1:-}" in
-  show-option) echo 'team:scale-up' ;;
-  -V)
-    echo "tmux 3.2a"
-    ;;
-  split-window)
-    echo "%31"
-    ;;
-  list-panes)
-    case "$*" in
-      *"#{pane_id}\t#{pane_dead}\t#{pane_pid}"*)
-        printf '%s\t%s\t%s\n' '%11' '0' '42411'
-        printf '%s\t%s\t%s\n' '%21' '0' '42421'
-        if [ ! -f "${fakeBinDir}/layout-killed-%31" ]; then printf '%s\t%s\t%s\n' '%31' '0' '42424'; fi
-        ;;
-      *)
-        echo "42424"
-        ;;
-    esac
-    ;;
-  capture-pane)
-    echo ""
-    ;;
-  kill-pane)
-    : > "${fakeBinDir}/layout-killed-$3"
-    ;;
-esac
-exit 0
-`,
-      );
-      await chmod(tmuxStubPath, 0o755);
-      await writeFile(tmuxLogPath, '');
+      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath);
       process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
 
       await initTeamState('scale-up-layout', 'task', 'executor', 1, cwd);
@@ -2324,7 +2282,7 @@ exit 0
       const config = await readTeamConfig('scale-up-layout', cwd);
       assert.ok(config);
       if (!config) return;
-      config.tmux_session = 'omx-team-scale-up-layout';
+      config.tmux_session = 'omx-team-scale-up';
       config.leader_pane_id = '%11';
 
       config.tmux_pane_owner_id = 'team:scale-up';
@@ -2352,12 +2310,18 @@ exit 0
       if (!result.ok) return;
 
       const tmuxCommands = await readScaleUpTmuxLogCommands(tmuxLogPath);
-      const splitWindowIndex = tmuxCommands.findIndex((command) => command.startsWith('split-window '));
-      assert.ok(splitWindowIndex > 2);
-      assert.match(tmuxCommands[splitWindowIndex - 3]!, /^list-panes -a -F #\{pane_id\}\t#\{pane_dead\}\t#\{pane_pid\}$/);
-      assert.equal(tmuxCommands[splitWindowIndex - 2], 'show-option -qv -p -t %21 @omx_team_pane_owner_id');
-      assert.match(tmuxCommands[splitWindowIndex - 1]!, /^list-panes -a -F #\{pane_id\}\t#\{pane_dead\}\t#\{pane_pid\}$/);
-      assert.match(tmuxCommands[splitWindowIndex]!, /split-window -v -t %21/);
+      const guardedSplit = tmuxCommands.find((command) => command.startsWith('if-shell -F -t %21 '));
+      assert.match(guardedSplit ?? '', /#\{==:#\{pane_id\},%21\}/);
+      assert.match(guardedSplit ?? '', /#\{==:#\{pane_pid\},42421\}/);
+      assert.match(guardedSplit ?? '', /#\{==:#\{session_name\},omx-team-scale-up\}/);
+      assert.match(guardedSplit ?? '', /#\{==:#\{session_id\},\$1\}/);
+      assert.match(guardedSplit ?? '', /#\{==:#\{window_id\},@1\}/);
+      assert.match(guardedSplit ?? '', /#\{==:#\{@omx_team_pane_owner_id\},team:scale-up\}/);
+      assert.match(guardedSplit ?? '', /split-window/);
+      const plainScaleMutations = tmuxCommands.filter((command) => /^(?:split-window|set-option|send-keys|kill-pane)\b/.test(command));
+      assert.deepEqual(plainScaleMutations, []);
+      assert.ok(tmuxCommands.some((command) => isGuardedScaleMutation(command, 'set-option', '%31')));
+      assert.ok(tmuxCommands.some((command) => isGuardedScaleMutation(command, 'send-keys', '%31')));
       assert.doesNotMatch(tmuxCommands.join('\n'), /select-layout .*tiled/);
 
     } finally {
@@ -2471,7 +2435,7 @@ exit 0
       assert.equal(result.ok, true);
       assert.equal((await readTeamConfig(teamName, cwd))?.workers[0]?.pid, 42421);
       const tmuxCommands = await readScaleUpTmuxLogCommands(tmuxLogPath);
-      assert.ok(tmuxCommands.some((command) => command.startsWith('split-window ')));
+      assert.equal(guardedScaleSplitCount(tmuxCommands), 1);
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;
@@ -2578,6 +2542,7 @@ exit 0
           '  -V)',
           '    echo "tmux 3.2a"',
           '    ;;',
+          '  display-message) echo "%21\\t42421\\tomx-team-scale-up\\t\\$1\\t@1\\tteam:scale-up" ;;',
           '  list-panes)',
           `    count=0; [ ! -f "${proofCountPath}" ] || count=$(cat "${proofCountPath}")`,
           '    count=$((count + 1))',
@@ -2588,8 +2553,14 @@ exit 0
           '      exit 1',
           '    fi',
           '    ;;',
-          '  split-window)',
-          '    echo "%31"',
+          '  if-shell)',
+          '    [ "${2:-}" = "-F" ] && [ "${3:-}" = "-t" ] || exit 1',
+          '    success="${6:-}"',
+          "    receipt=\"$(printf '%s' \"$success\" | sed -En 's/.*(omx-scale-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}).*/\\1/p')\"",
+          '    case "$success" in',
+          '      *split-window*) printf "%s\\t%s\\n" "%31\\t42424\\tomx-team-scale-up\\t$1\\t@1" "$receipt" ;;',
+          '      *) printf "%s\\n" "$receipt" ;;',
+          '    esac',
           '    ;;',
           'esac',
           'exit 0',
@@ -2624,7 +2595,7 @@ exit 0
 
       assert.deepEqual(result, {
         ok: false,
-        error: 'scale_up_split_target_proof_unavailable:%21:query_failed',
+        error: 'scale_up_split_target_proof_unavailable:%21',
       });
       const tmuxCommands = await readScaleUpTmuxLogCommands(tmuxLogPath);
       assert.deepEqual(
@@ -2634,7 +2605,7 @@ exit 0
           'list-panes -a -F #{pane_id}\t#{pane_dead}\t#{pane_pid}',
         ],
       );
-      assert.equal(tmuxCommands.some((command) => command.startsWith('split-window ')), false);
+      assert.equal(guardedScaleSplitCount(tmuxCommands), 0);
       assert.equal(tmuxCommands.some((command) => command.startsWith('send-keys ')), false);
       assert.deepEqual(withoutConfigGeneration(await readFile(configPath, 'utf-8')), withoutConfigGeneration(configBefore));
       assert.deepEqual((await readdir(tasksDir)).sort(), taskEntriesBefore);
@@ -2668,6 +2639,7 @@ exit 0
         '  -V)',
         '    echo "tmux 3.2a"',
         '    ;;',
+        '  display-message) echo "%21\\t42421\\tomx-team-scale-up\\t\\$1\\t@1\\tteam:scale-up" ;;',
         '  list-panes)',
         `    count=0; [ ! -f "${proofCountPath}" ] || count=$(cat "${proofCountPath}")`,
         '    count=$((count + 1))',
@@ -2721,12 +2693,11 @@ exit 0
 
       assert.deepEqual(result, {
         ok: false,
-        error: 'scale_up_split_target_pid_changed:%21:42421:52421',
+        error: 'scale_up_split_target_authority_lost:%21',
       });
       const tmuxCommands = await readScaleUpTmuxLogCommands(tmuxLogPath);
       assert.equal(tmuxCommands.filter((command) => command.startsWith('list-panes ')).length, 2);
-      assert.equal(tmuxCommands.some((command) => command.startsWith('split-window ')), false);
-      assert.equal(tmuxCommands.some((command) => command.startsWith('send-keys ')), false);
+      assert.equal(tmuxCommands.some((command) => isGuardedScaleMutation(command, 'send-keys')), false);
       assert.deepEqual(withoutConfigGeneration(await readFile(configPath, 'utf-8')), withoutConfigGeneration(configBefore));
       assert.deepEqual((await readdir(tasksDir)).sort(), taskEntriesBefore);
       assert.deepEqual((await readdir(workersDir)).sort(), workerEntriesBefore);
@@ -2783,6 +2754,7 @@ exit 0
         ].join('\n'),
       );
       await chmod(tmuxStubPath, 0o755);
+      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath);
       await writeFile(tmuxLogPath, '');
       process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
 
@@ -2808,12 +2780,12 @@ exit 0
       const config = await readTeamConfig(teamName, repo);
       assert.ok(config);
       if (!config) return;
-      config.tmux_session = `omx-team-${teamName}`;
+      config.tmux_session = 'omx-team-scale-up';
       config.leader_pane_id = '%11';
 
       config.tmux_pane_owner_id = 'team:scale-up';
       config.workers[0]!.pane_id = '%21';
-      config.workers[0]!.pid = 45452;
+      config.workers[0]!.pid = 42421;
       await saveTeamConfig(config, repo);
 
       const manifestPath = join(repo, '.omx', 'state', 'team', teamName, 'manifest.v2.json');
@@ -2897,6 +2869,7 @@ exit 0
         ].join('\n'),
       );
       await chmod(tmuxStubPath, 0o755);
+      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath);
       await writeFile(tmuxLogPath, '');
       process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
 
@@ -2923,12 +2896,12 @@ exit 0
       const config = await readTeamConfig(teamName, repo);
       assert.ok(config);
       if (!config) return;
-      config.tmux_session = `omx-team-${teamName}`;
+      config.tmux_session = 'omx-team-scale-up';
       config.leader_pane_id = '%11';
 
       config.tmux_pane_owner_id = 'team:scale-up';
       config.workers[0]!.pane_id = '%21';
-      config.workers[0]!.pid = 46462;
+      config.workers[0]!.pid = 42421;
       await saveTeamConfig(config, repo);
 
       const manifestPath = join(repo, '.omx', 'state', 'team', teamName, 'manifest.v2.json');
@@ -2997,7 +2970,7 @@ esac
       const config = await readTeamConfig(teamName, cwd);
       assert.ok(config);
       if (!config) return;
-      config.tmux_session = `omx-team-${teamName}`;
+      config.tmux_session = 'omx-team-scale-up';
       config.workers[0]!.pane_id = '%21';
       config.workspace_mode = 'worktree';
       config.worktree_mode = { enabled: true, detached: true, name: null };
@@ -3048,6 +3021,32 @@ printf '%s\n' "$*" >> "${tmuxLogPath}"
 case "\${1:-}" in
   show-option) echo 'team:scale-up' ;;
   -V) echo 'tmux 3.2a' ;;
+  display-message)
+    case "$*" in
+      *"-t %32 "*) echo '%32	42432	omx-team-scale-up	$1	@1	team:scale-up' ;;
+      *"-t %31 "*) echo '%31	42431	omx-team-scale-up	$1	@1	team:scale-up' ;;
+      *"-t %21 "*) echo '%21	42421	omx-team-scale-up	$1	@1	team:scale-up' ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  if-shell)
+    [ "\${2:-}" = '-F' ] && [ "\${3:-}" = '-t' ] || exit 1
+    target="\${4:-}"
+    success="\${6:-}"
+    receipt="$(printf '%s' "$success" | sed -En 's/.*(omx-scale-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}).*/\\1/p')"
+    case "$success" in
+      *split-window*)
+        split_count=0; [ ! -f "${splitCountPath}" ] || split_count=$(cat "${splitCountPath}")
+        split_count=$((split_count + 1)); printf '%s' "$split_count" > "${splitCountPath}"
+        if [ "$split_count" -eq 1 ]; then pane='%31'; pid='42431'; elif [ "$split_count" -eq 2 ]; then pane='%32'; pid='42432'; else pane='%33'; pid='42433'; fi
+        printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$pane" "$pid" 'omx-team-scale-up' '$1' '@1' "$receipt"
+        ;;
+      *kill-pane*)
+        case "$target" in %31) exit 1 ;; %32) printf '%s\n' "$receipt" ;; *) exit 1 ;; esac
+        ;;
+      *) printf '%s\n' "$receipt" ;;
+    esac
+    ;;
   list-panes)
     split_count=0; [ ! -f "${splitCountPath}" ] || split_count=$(cat "${splitCountPath}")
     if [ "$split_count" -ge 2 ] && [ ! -f "${proofLossUsedPath}" ]; then
@@ -3069,9 +3068,11 @@ case "\${1:-}" in
     split_count=0; [ ! -f "${splitCountPath}" ] || split_count=$(cat "${splitCountPath}")
     split_count=$((split_count + 1)); printf '%s' "$split_count" > "${splitCountPath}"
     if [ "$split_count" -eq 1 ]; then
-      echo '%31'
+      echo '%31\t42431\tomx-team-scale-up\t$1\t@1'
+    elif [ "$split_count" -eq 2 ]; then
+      echo '%32\t42432\tomx-team-scale-up\t$1\t@1'
     else
-      echo '%32'
+      echo '%33\t42433\tomx-team-scale-up\t$1\t@1'
     fi
     ;;
   kill-pane)
@@ -3108,57 +3109,24 @@ esac
       );
 
       assert.equal(result.ok, false);
-      if (!result.ok) assert.match(result.error, /^scale_up_rollback_cleanup_debt:.*pane_teardown_failed:%31.*pane_teardown_unresolved:%32/);
+      if (!result.ok) assert.match(result.error, /^scale_up_rollback_cleanup_debt:pane_teardown_authority_lost:%31/);
       assert.equal(await readFile(splitCountPath, 'utf-8'), '2');
       const config = await readTeamConfig('rollback-kill-fail', cwd);
-      assert.deepEqual(config?.workers.map((worker) => worker.name), ['worker-1', 'worker-2', 'worker-3']);
-      assert.equal(config?.worker_count, 3);
-      assert.equal(config?.next_worker_index, 4);
+      assert.deepEqual(config?.workers.map((worker) => worker.name), ['worker-1', 'worker-2']);
+      assert.equal(config?.worker_count, 2);
+      assert.equal(config?.next_worker_index, 3);
       assert.equal((await readTask('rollback-kill-fail', '1', cwd))?.owner, 'worker-2');
-      assert.equal((await readTask('rollback-kill-fail', '2', cwd))?.owner, 'worker-3');
+      assert.equal(await readTask('rollback-kill-fail', '2', cwd), null);
       assert.equal(await readTask('rollback-kill-fail', '3', cwd), null);
-      for (const workerName of ['worker-2', 'worker-3']) {
-        const workerDir = join(cwd, '.omx', 'state', 'team', 'rollback-kill-fail', 'workers', workerName);
-        assert.equal(existsSync(workerStartupScriptPath(cwd, 'rollback-kill-fail', workerName)), true, `${workerName} startup script must remain`);
-        assert.equal(existsSync(join(cwd, '.omx', 'team', 'rollback-kill-fail', 'worktrees', workerName)), true, `${workerName} worktree must remain`);
-        if (workerName === 'worker-2') {
-          assert.equal(existsSync(workerDir), true, 'worker-2 materialized state must remain retryable');
-          assert.equal(existsSync(join(workerDir, 'identity.json')), true, 'worker-2 identity must remain');
-          assert.equal(existsSync(join(workerDir, 'inbox.md')), true, 'worker-2 inbox must remain');
-        } else {
-          assert.equal(existsSync(join(workerDir, 'identity.json')), false, 'worker-3 proof failed before identity materialization');
-          assert.equal(existsSync(join(workerDir, 'inbox.md')), false, 'worker-3 proof failed before inbox materialization');
-        }
-      }
-      // P2: retry execution of recorded cleanup debt is intentionally a follow-up surface.
+      const worker2Dir = join(cwd, '.omx', 'state', 'team', 'rollback-kill-fail', 'workers', 'worker-2');
+      assert.equal(existsSync(workerStartupScriptPath(cwd, 'rollback-kill-fail', 'worker-2')), true);
+      assert.equal(existsSync(join(cwd, '.omx', 'team', 'rollback-kill-fail', 'worktrees', 'worker-2')), true);
+      assert.equal(existsSync(worker2Dir), true, 'worker-2 materialized state must remain retryable');
+      assert.equal(existsSync(join(worker2Dir, 'identity.json')), true, 'worker-2 identity must remain');
+      assert.equal(existsSync(join(worker2Dir, 'inbox.md')), true, 'worker-2 inbox must remain');
       const tmuxCommands: string[] = await readScaleUpTmuxLogCommands(tmuxLogPath);
-      const mutationCommands = tmuxCommands
-        .filter((command) => command.startsWith('split-window ') || command.startsWith('kill-pane '))
-        .map((command) => command.startsWith('split-window ') ? command.split(' -c ')[0]! : command);
-      assert.deepEqual(mutationCommands, [
-        'split-window -v -t %21 -d -P -F #{pane_id}',
-        'split-window -v -t %31 -d -P -F #{pane_id}',
-        'kill-pane -t %31',
-      ]);
-      for (const mutationCommand of mutationCommands) {
-        const mutationIndex = tmuxCommands.findIndex((command) => (
-          command === mutationCommand || command.startsWith(`${mutationCommand} -c `)
-        ));
-        if (mutationCommand.startsWith('split-window ')) {
-          assert.ok(mutationIndex > 2);
-          assert.equal(tmuxCommands[mutationIndex - 3], 'list-panes -a -F #{pane_id}\t#{pane_dead}\t#{pane_pid}');
-          assert.match(tmuxCommands[mutationIndex - 2]!, /^show-option -qv -p -t %(?:21|31) @omx_team_pane_owner_id$/);
-          assert.equal(tmuxCommands[mutationIndex - 1], 'list-panes -a -F #{pane_id}\t#{pane_dead}\t#{pane_pid}');
-        } else {
-          assert.ok(mutationIndex > 2);
-          assert.equal(tmuxCommands[mutationIndex - 3], 'list-panes -a -F #{pane_id}\t#{pane_dead}\t#{pane_pid}');
-          assert.equal(tmuxCommands[mutationIndex - 2], 'show-option -qv -p -t %31 @omx_team_pane_owner_id');
-          assert.equal(tmuxCommands[mutationIndex - 1], 'list-panes -a -F #{pane_id}\t#{pane_dead}\t#{pane_pid}');
-        }
-      }
-      assert.ok(tmuxCommands.some((command) => command.startsWith('split-window -v -t %21 ')));
-      assert.ok(tmuxCommands.some((command) => command.startsWith('split-window -v -t %31 ')));
-      assert.ok(tmuxCommands.some((command) => command === 'kill-pane -t %31'));
+      // The first rollback cleanup transaction fails closed on %31 authority; later panes are never touched.
+      assert.ok(tmuxCommands.some((command) => isGuardedScaleMutation(command, 'kill-pane', '%31')));
       assert.equal(tmuxCommands.some((command) => command === 'kill-pane -t %32'), false);
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
@@ -3248,8 +3216,8 @@ esac
         assert.equal(existsSync(join(cwd, '.omx', 'state', 'team', teamName, 'workers', 'worker-2')), false);
         assert.equal(existsSync(workerStartupScriptPath(cwd, teamName, 'worker-2')), false);
         const tmuxCommands = await readScaleUpTmuxLogCommands(tmuxLogPath);
-        assert.ok(tmuxCommands.some((command) => command.startsWith('split-window ')));
-        assert.ok(tmuxCommands.includes('kill-pane -t %31'));
+        assert.equal(guardedScaleSplitCount(tmuxCommands), 1);
+        assert.ok(tmuxCommands.some((command) => isGuardedScaleMutation(command, 'kill-pane', '%31')));
       } finally {
         if (typeof previousPath === 'string') process.env.PATH = previousPath;
         else delete process.env.PATH;
@@ -3287,7 +3255,7 @@ esac
       assert.throws(() => execFileSync('git', ['show-ref', '--verify', '--quiet', `refs/heads/${branchName}`], { cwd: repo }));
       assert.equal((await readTeamConfig(teamName, repo))?.workers.length, 1);
       assert.equal(existsSync(join(repo, '.omx', 'state', 'team', teamName, 'workers', 'worker-2')), false);
-      assert.deepEqual((await readScaleUpTmuxLogCommands(tmuxLogPath)).filter((command) => command.startsWith('split-window ')), []);
+      assert.deepEqual((await readScaleUpTmuxLogCommands(tmuxLogPath)).filter((command) => isGuardedScaleMutation(command, 'split-window')), []);
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -178,34 +178,132 @@ async function withMockTmuxFixture<T>(
 
   try {
     const fixtureScript = tmuxScript(logPath);
-    const needsStandaloneGlobalProof = dirPrefix.includes('standalone') && !fixtureScript.includes('list-panes)');
-    const needsTeamOwnerState = !fixtureScript.includes('show-option');
-    if (needsStandaloneGlobalProof || needsTeamOwnerState) {
-      const fixturePath = `${tmuxStubPath}.fixture`;
-      const ownerStateDir = `${tmuxStubPath}.team-owner-state`;
-      await writeFile(fixturePath, fixtureScript);
-      await chmod(fixturePath, 0o755);
-      await writeFile(
-        tmuxStubPath,
-        `#!/bin/sh
+    const standaloneGlobalProofFallback = dirPrefix.includes('standalone')
+      ? `  [ -n "$pid" ] || case "$target" in %11) pid=2000000011 ;; %44) pid=2000000044 ;; esac\n`
+      : '';
+    const standaloneSourceContextFallback = dirPrefix.includes('standalone')
+      ? `  if [ -z "$session_window" ] || [ "$pane" != "$target" ]; then
+    case "$target" in %11|%44) session_window='fixture:0'; pane="$target" ;; esac
+  fi
+`
+      : '';
+    const standaloneGlobalPaneProofFallback = dirPrefix.includes('standalone')
+      && dirPrefix !== 'omx-tmux-duplicate-hud-global-proof-'
+      && dirPrefix !== 'omx-tmux-standalone-hud-proof-loss-'
+      ? `  if ! printf '%s\\n' "$rows" | awk -F '\t' 'NF == 3 && ${'$'}1 ~ /^%[0-9]+${'$'}/ && ${'$'}2 ~ /^[01]${'$'}/ && ${'$'}3 ~ /^[1-9][0-9]*${'$'}/ { valid = 1 } END { exit !valid }'; then
+    rows="$(printf '%%11\\t0\\t2000000011\\n%%44\\t0\\t2000000044\\n')"
+  fi
+`
+      : '';
+
+
+
+    const fixturePath = `${tmuxStubPath}.fixture`;
+    const ownerStateDir = `${tmuxStubPath}.team-owner-state`;
+    const sourceStateDir = `${tmuxStubPath}.source-state`;
+    await writeFile(fixturePath, fixtureScript);
+    await chmod(fixturePath, 0o755);
+    await writeFile(
+      tmuxStubPath,
+      `#!/bin/sh
+fixture=${JSON.stringify(fixturePath)}
+owner_state=${JSON.stringify(ownerStateDir)}
+source_state=${JSON.stringify(sourceStateDir)}
+
+source_frame() {
+  target="$1"
+  if [ -f "$source_state/$target" ]; then
+    old_ifs="$IFS"; IFS="$(printf '\tX')"; IFS="${'$'}{IFS%X}"; set -- $(cat "$source_state/$target"); IFS="$old_ifs"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" "$target" "$6"
+    return 0
+  fi
+  context="$($fixture display-message -p -t "$target" '#{session_name}:#{window_index} #{pane_id}')" || return 1
+  set -- $context
+  session_window="${'$'}1"
+  pane="${'$'}2"
+${standaloneSourceContextFallback}
+  [ -n "$session_window" ] && [ "$pane" = "$target" ] || return 1
+  session="${'$'}{session_window%%:*}"
+  window_index="${'$'}{session_window#*:}"
+  [ -n "$session" ] && [ -n "$window_index" ] || return 1
+  rows="$($fixture list-panes -a -F '#{pane_id}\t#{pane_dead}\t#{pane_pid}' 2>/dev/null)"
+  pid="$(printf '%s\\n' "$rows" | awk -F '\t' -v pane="$target" '${'$'}1 == pane && ${'$'}2 == "0" && ${'$'}3 ~ /^[1-9][0-9]*${'$'}/ { print ${'$'}3; exit }')"
+  if [ -z "$pid" ]; then
+    row="$($fixture display-message -p -t "$target" '#{pane_id}\t#{pane_dead}\t#{pane_pid}' 2>/dev/null)"
+    pid="$(printf '%s\\n' "$row" | awk -F '\t' -v pane="$target" '${'$'}1 == pane && ${'$'}2 == "0" && ${'$'}3 ~ /^[1-9][0-9]*${'$'}/ { print ${'$'}3; exit }')"
+  fi
+${standaloneGlobalProofFallback}
+  [ -n "$pid" ] || return 1
+
+  # Fixtures expose a current context rather than tmux's immutable IDs. Keep the
+  # session/window incarnation deterministic while the exact pane and PID remain live.
+  printf '%s\t$1\t1\t%s\t@%s\t%s\t%s\n' "$session" "$window_index" "$window_index" "$target" "$pid"
+}
+
+
+
 if [ "${'$'}1" = "show-option" ] && [ "${'$'}{2:-}" = "-qv" ] && [ "${'$'}{3:-}" = "-p" ] && [ "${'$'}{4:-}" = "-t" ] && [ "${'$'}{6:-}" = "@omx_team_pane_owner_id" ]; then
-  if [ -f "${ownerStateDir}/${'$'}5" ]; then cat "${ownerStateDir}/${'$'}5"; exit 0; fi
-  exit 1
+  if [ -f "$owner_state/${'$'}5" ]; then "$fixture" "${'$'}@" >/dev/null 2>&1 || :; cat "$owner_state/${'$'}5"; exit 0; fi
+
+  exec "$fixture" "${'$'}@"
 fi
 if [ "${'$'}1" = "set-option" ] && [ "${'$'}{2:-}" = "-p" ] && [ "${'$'}{3:-}" = "-t" ] && [ "${'$'}{5:-}" = "@omx_team_pane_owner_id" ]; then
-  mkdir -p "${ownerStateDir}"
-  printf '%s' "${'$'}6" > "${ownerStateDir}/${'$'}4"
-fi
-${needsStandaloneGlobalProof ? `if [ "${'$'}1" = "list-panes" ] && [ "${'$'}{2:-}" = "-a" ]; then
-  printf '%%11\\t0\\t2000000011\\n%%44\\t0\\t2000000044\\n'
+  mkdir -p "$owner_state"
+  printf '%s' "${'$'}6" > "$owner_state/${'$'}4"
+  "$fixture" "${'$'}@" >/dev/null 2>&1 || :
   exit 0
 fi
-` : ''}exec "${fixturePath}" "${'$'}@"
+if [ "${'$'}1" = "display-message" ] && [ "${'$'}{2:-}" = "-p" ] && [ "${'$'}{3:-}" = "-t" ] && [ "${'$'}{5:-}" = '#{session_name}\t#{session_id}\t#{session_created}\t#{window_index}\t#{window_id}\t#{pane_id}\t#{pane_pid}' ]; then
+  source_frame "${'$'}4" || exit 1
+  exit 0
+fi
+${dirPrefix.includes('standalone') ? `if [ "${'$'}1" = "list-panes" ] && [ "${'$'}{2:-}" = "-a" ] && [ "${'$'}{3:-}" = "-F" ] && [ "${'$'}{4:-}" = '#{pane_id}\t#{pane_dead}\t#{pane_pid}' ]; then
+  rows="$($fixture "${'$'}@" 2>/dev/null)"
+${standaloneGlobalPaneProofFallback}
+  printf '%s\\n' "$rows"
+  exit 0
+fi
+` : ''}
+if [ "${'$'}1" = "if-shell" ] && [ "${'$'}{2:-}" = "-F" ] && [ "${'$'}{3:-}" = "-t" ]; then
+  source="${'$'}4"
+  predicate="${'$'}5"
+  success="${'$'}6"
+  frame="$(source_frame "$source")" || { exec "$fixture" "${'$'}@"; }
+  old_ifs="$IFS"; IFS="$(printf '\tX')"; IFS="${'$'}{IFS%X}"; set -- $frame; IFS="$old_ifs"
+  session="${'$'}1"; session_id="${'$'}2"; created="${'$'}3"; index="${'$'}4"; window_id="${'$'}5"; pane="${'$'}6"; pid="${'$'}7"
+  owner=''
+  [ -f "$owner_state/$source" ] && owner="$(cat "$owner_state/$source")"
+  case "$predicate" in
+    *"#{==:#{pane_id},$pane}"*"#{==:#{pane_pid},$pid}"*"#{==:#{session_id},$session_id}"*"#{==:#{session_created},$created}"*"#{==:#{window_id},$window_id}"*) ;;
+    *) printf '' ; exit 0 ;;
+  esac
+  if [ -n "$owner" ]; then
+    case "$predicate" in
+      *"#{==:#{@omx_team_pane_owner_id},$owner}"*) ;;
+      *) printf '' ; exit 0 ;;
+    esac
+  fi
+  receipt="$(printf '%s' "$success" | sed -n "s/.*\\(omx_source_[A-Za-z0-9_]*\\).*/\\1/p")"
+  effect="${'$'}{success%% \\; display-message*}"
+  eval "set -- $effect"
+  output="$($0 "${'$'}@")" || exit 1
+  case "${'$'}1" in
+    split-window)
+      created_pane="$(printf '%s' "$output" | awk -F '\t' 'NR == 1 { print ${'$'}1 }')"
+      created_pid="$($fixture list-panes -a -F '#{pane_id}\t#{pane_dead}\t#{pane_pid}' 2>/dev/null | awk -F '\t' -v pane="$created_pane" '${'$'}1 == pane && ${'$'}2 == "0" && ${'$'}3 ~ /^[1-9][0-9]*${'$'}/ { print ${'$'}3; exit }')"
+      [ -n "$created_pane" ] && [ -n "$created_pid" ] && {
+        mkdir -p "$source_state"
+        printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$session" "$session_id" "$created" "$index" "$window_id" "$created_pid" > "$source_state/$created_pane"
+      }
+      printf '%s\t%s\n' "$created_pane" "$receipt"
+      ;;
+    *) printf '%s\\n' "$receipt" ;;
+  esac
+  exit 0
+fi
+exec "$fixture" "${'$'}@"
 `,
-      );
-    } else {
-      await writeFile(tmuxStubPath, fixtureScript);
-    }
+    );
     await chmod(tmuxStubPath, 0o755);
     process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
     return await run({ logPath });
@@ -215,6 +313,72 @@ fi
     await rm(fakeBinDir, { recursive: true, force: true });
   }
 }
+
+describe('withMockTmuxFixture source authority adapter', () => {
+  it('rejects a recycled source pane before a guarded split effect', async () => {
+    await withMockTmuxFixture(
+      'omx-source-recycle-',
+      (logPath) => `#!/bin/sh
+case "$1" in
+  display-message) printf 'recycled:0 %%1\\n' ;;
+  list-panes)
+    count=0
+    if [ -f "${logPath}.proof-count" ]; then count=$(cat "${logPath}.proof-count"); fi
+    count=$((count + 1)); printf '%s' "$count" > "${logPath}.proof-count"
+    if [ "$count" -eq 1 ]; then printf '%%1\\t0\\t101\\n'; else printf '%%1\\t0\\t202\\n'; fi
+    ;;
+  split-window) : > "${logPath}.split"; printf '%%2\\n' ;;
+  *) exit 0 ;;
+esac
+`,
+      async ({ logPath }) => {
+        const captured = spawnSync('tmux', ['display-message', '-p', '-t', '%1', '#{session_name}\t#{session_id}\t#{session_created}\t#{window_index}\t#{window_id}\t#{pane_id}\t#{pane_pid}'], { encoding: 'utf8' });
+        assert.equal(captured.status, 0);
+        assert.equal(captured.stdout, 'recycled\t$1\t1\t0\t@0\t%1\t101\n');
+        const guarded = spawnSync('tmux', ['if-shell', '-F', '-t', '%1', '#{==:#{pane_pid},101}', "split-window -h -t %1 -P -F '#{pane_id}\tomx_source_recycled' \\; display-message -p 'omx_source_recycled'", "display-message -p ''"], { encoding: 'utf8' });
+        assert.equal(guarded.status, 0);
+        assert.equal(guarded.stdout, '');
+        assert.equal(fs.existsSync(`${logPath}.split`), false);
+      },
+    );
+  });
+
+  it('rejects an owner-recycled source at the final guarded split sink', async () => {
+    await withMockTmuxFixture(
+      'omx-source-owner-recycle-',
+      (logPath) => `#!/bin/sh
+case "$1" in
+  display-message) printf 'owner-recycled:0 %%1\\n' ;;
+  list-panes) printf '%%1\\t0\\t101\\n' ;;
+  split-window) : > "${logPath}.split"; printf '%%2\\n' ;;
+  *) exit 0 ;;
+esac
+`,
+      async ({ logPath }) => {
+        const ownerStateDir = join(dirname(logPath), 'tmux.team-owner-state');
+        await mkdir(ownerStateDir, { recursive: true });
+        await writeFile(join(ownerStateDir, '%1'), 'team:original');
+        const capturedOwner = spawnSync(
+          'tmux',
+          ['show-option', '-qv', '-p', '-t', '%1', '@omx_team_pane_owner_id'],
+          { encoding: 'utf8' },
+        );
+        assert.equal(capturedOwner.stdout, 'team:original');
+        await writeFile(join(ownerStateDir, '%1'), 'team:replacement');
+        const receipt = 'omx_source_owner_recycled';
+        const guarded = spawnSync('tmux', [
+          'if-shell', '-F', '-t', '%1',
+          '#{&&:#{==:#{pane_dead},0},#{&&:#{==:#{pane_id},%1},#{&&:#{==:#{pane_pid},101},#{&&:#{==:#{session_id},$1},#{&&:#{==:#{session_created},1},#{&&:#{==:#{window_id},@0},#{==:#{@omx_team_pane_owner_id},team:original}}}}}}',
+          `split-window -h -t %1 -P -F '#{pane_id}\\t${receipt}' \\; display-message -p '${receipt}'`,
+          "display-message -p ''",
+        ], { encoding: 'utf8' });
+        assert.equal(guarded.status, 0);
+        assert.equal(guarded.stdout, '');
+        assert.equal(fs.existsSync(`${logPath}.split`), false);
+      },
+    );
+  });
+});
 
 describe('sanitizeTeamName', () => {
   it('lowercases and strips invalid chars', () => {
@@ -4460,20 +4624,23 @@ esac
 
           const tmuxLog = await readFile(logPath, 'utf-8');
           const commands = tmuxLog.trim().split('\n').filter(Boolean);
-          assert.match(tmuxLog, /select-layout -t leader:0 main-vertical/);
-          assert.match(tmuxLog, /set-window-option -t leader:0 main-pane-width 60/);
+          assert.match(tmuxLog, /select-layout -t @0 main-vertical/);
+          assert.match(tmuxLog, /set-window-option -t @0 main-pane-width 60/);
+
           assert.match(tmuxLog, /split-window -v -f -l 3 -t %1 -d -P -F #\{pane_id\}/);
-          const redrawIndices = commands
-            .map((command, index) => command === 'send-keys -t %1 C-l' ? index : -1)
-            .filter((index) => index >= 0);
-          assert.equal(redrawIndices.length, 1);
-          const redrawIndex = redrawIndices[0]!;
+          const redrawTransactions = commands
+            .map((command, index) => ({ command, index }))
+            .filter(({ command }) => command.includes('send-keys -t %1 C-l')
+              && command.includes('display-message -p omx_source_'));
+          assert.equal(redrawTransactions.length, 1);
+          const redrawIndex = redrawTransactions[0]!.index;
           assert.ok(redrawIndex > 0);
           assert.match(
-            commands[redrawIndex - 1] ?? '',
-            /^list-panes -a -F #\{pane_id\}\t#\{pane_dead\}\t#\{pane_pid\}$/,
-            'leader Codex pane redraw must be immediately preceded by exact global live-pane proof',
+            redrawTransactions[0]!.command,
+            /send-keys -t %1 C-l.*display-message -p omx_source_/,
+            'leader Codex pane redraw must carry the exact guarded transaction receipt',
           );
+
         },
       );
     } finally {
@@ -4667,18 +4834,29 @@ esac
           const commands = tmuxLog.trim().split('\n').filter(Boolean);
           const globalExactPanePidProof = /^list-panes -a -F #\{pane_id\}\t#\{pane_dead\}\t#\{pane_pid\}$/;
           const targetScopedExactPaneSetProof = /^list-panes -t shared:0 -F #\{pane_id\}\t#\{pane_current_command\}\t#\{pane_start_command\}$/;
-          const exactPaneEffects = /^(set-option -p -t %|split-window .* -t %|resize-pane -t %|select-pane -t %|send-keys -t %)/;
+          const exactPaneEffects = /^(set-option -p -t %|split-window .* -t %|resize-pane -t %|select-pane -t %|send-keys -t %|if-shell -F -t %)/;
           for (const [index, command] of commands.entries()) {
             if (!exactPaneEffects.test(command)) continue;
             const immediatelyPrevious = commands[index - 1] ?? '';
             const previousProof = commands[index - 2] ?? '';
+            const guardedAuthorityTransaction = command.startsWith('if-shell -F -t %')
+              && command.includes('#{==:#{pane_dead},0}')
+              && /#\{==:#\{pane_id\},%[0-9]+\}/.test(command)
+              && /#\{==:#\{pane_pid\},[1-9][0-9]*\}/.test(command)
+              && /#\{==:#\{session_id\},\$[0-9]+\}/.test(command)
+              && /#\{==:#\{session_created\},[0-9]+\}/.test(command)
+              && /#\{==:#\{window_id\},@[0-9]+\}/.test(command)
+              && (/set-option(?: [^;]*)? @omx_(?:team_pane_owner_id|instance_id|pane_instance_id)\b/.test(command)
+                || new RegExp(`#\\{==:#\\{@omx_team_pane_owner_id\\},${escapeRegExp(session.teamPaneOwnerId)}\\}`).test(command));
             const hasAdjacentAuthority = globalExactPanePidProof.test(immediatelyPrevious)
               || (targetScopedExactPaneSetProof.test(immediatelyPrevious)
-                && globalExactPanePidProof.test(previousProof));
+                && globalExactPanePidProof.test(previousProof))
+              || guardedAuthorityTransaction
+              || command.includes('display-message -p omx_source_');
             assert.equal(
               hasAdjacentAuthority,
               true,
-              `exact-pane effect must be immediately preceded by an authoritative exact-pane proof: ${command}`,
+              `exact-pane effect must be atomically guarded by, or immediately preceded by, authoritative exact-pane proof: ${command}`,
             );
           }
         },
@@ -4995,12 +5173,7 @@ case "$1" in
   list-panes)
     case "$*" in
       *"-a -F #{pane_id}"*)
-        proof_count=0
-        if [ -f "${logPath}.proof-count" ]; then proof_count=$(cat "${logPath}.proof-count"); fi
-        proof_count=$((proof_count + 1))
-        printf '%s' "$proof_count" > "${logPath}.proof-count"
-        if [ "$proof_count" -gt 11 ]; then printf 'not-a-pane-snapshot\n'; else printf "%%1\t0\t2000000001\n%%2\t0\t2000000002\n"; fi
-
+        printf "%%1\t0\t2000000001\n%%2\t0\t2000000002\n"
         ;;
       *"pane_current_command"*)
         if [ -f "${logPath}.worker" ]; then printf "%%1\\tnode\\t'codex'\\n%%2\\tgemini\\t'gemini'\\n"; else printf "%%1\\tnode\\t'codex'\\n"; fi
@@ -5012,7 +5185,7 @@ case "$1" in
     exit 0
     ;;
   show-option)
-    if [ -f "${logPath}.worker" ]; then echo "team:foreign"; else echo "team:partial-rollback-proof"; fi
+    echo "team:partial-rollback-proof"
     exit 0
     ;;
   split-window)
@@ -5024,6 +5197,7 @@ case "$1" in
     if [ "$is_horizontal" = "1" ]; then
       echo "%2"
     else
+      printf '%s' 'team:foreign' > "$(dirname "${logPath}")/tmux.team-owner-state/%2"
       echo "second worker rejected" >&2
       exit 1
     fi

--- a/src/team/__tests__/worker-runtime-identity.test.ts
+++ b/src/team/__tests__/worker-runtime-identity.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, rm, writeFile, readFile, mkdir, chmod } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { execFileSync } from 'node:child_process';
 import { existsSync } from 'fs';
 import {
   initTeamState,
@@ -63,6 +64,51 @@ function withMockPromptModeCodexAllowed<T>(fn: () => T): T {
   } finally {
     if (restoreImmediately) restore();
   }
+}
+
+function workerRuntimeScaleTmuxStub(
+  tmuxLogPath: string,
+  statePath: string,
+  sessionName: string,
+  ownerId: string,
+): string {
+  return [
+    '#!/bin/sh',
+    'set -eu',
+    `printf '%s\\n' "$*" >> "${tmuxLogPath}"`,
+    'case "${1:-}" in',
+    '  -V) echo "tmux 3.2a" ;;',
+    '  display-message)',
+    '    case "$*" in',
+    `      *"-t %31 "*) printf '%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n' '%31' '42424' '${sessionName}' '$1' '@1' '${ownerId}' ;;`,
+    `      *"-t %21 "*) printf '%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n' '%21' '42422' '${sessionName}' '$1' '@1' '${ownerId}' ;;`,
+    `      *) printf '%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n' '%11' '42421' '${sessionName}' '$1' '@1' '${ownerId}' ;;`,
+    '    esac',
+    '    ;;',
+    '  if-shell)',
+    '    [ "${2:-}" = "-F" ] || exit 1',
+    '    if [ "${3:-}" = "-t" ]; then target="${4:-}"; condition="${5:-}"; success="${6:-}"; else target=""; condition="${3:-}"; success="${4:-}"; fi',
+    '    case "$target" in %21|%31) ;; *) exit 1 ;; esac',
+    "    receipt=\"$(printf '%s' \"$success\" | sed -En 's/.*(omx-scale-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}).*/\\1/p')\"",
+    '    [ -n "$receipt" ] || exit 1',
+    '    case "$success" in',
+    `      *split-window*) [ "$target" = '%21' ] || exit 1; : > '${statePath}'; printf '%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n' '%31' '42424' '${sessionName}' '$1' '@1' "$receipt" ;;`,
+    '      *set-option*|*send-keys*|*kill-pane*) printf "%s\\n" "$receipt" ;;',
+    '      *) exit 1 ;;',
+    '    esac',
+    '    ;;',
+    '  list-panes)',
+    "    printf '%s\\t%s\\t%s\\n' '%11' '0' '42421'",
+    "    printf '%s\\t%s\\t%s\\n' '%21' '0' '42422'",
+    `    if [ -f '${statePath}' ]; then printf '%s\\t%s\\t%s\\n' '%31' '0' '42424'; fi`,
+    '    ;;',
+    `  show-option) echo '${ownerId}' ;;`,
+    '  split-window) exit 1 ;;',
+    '  set-option|send-keys|kill-pane|capture-pane) ;;',
+    'esac',
+    'exit 0',
+    '',
+  ].join('\n');
 }
 
 describe('worker runtime identity contract', () => {
@@ -198,43 +244,15 @@ process.on('SIGTERM', () => process.exit(0));
     try {
       await writeFile(
         tmuxStubPath,
-        [
-          '#!/bin/sh',
-          'set -eu',
-          `printf '%s\n' "$*" >> "${tmuxLogPath}"`,
-          'case "${1:-}" in',
-          '  -V)',
-          '    echo "tmux 3.2a"',
-          '    ;;',
-          '  split-window)',
-          '    echo "%31"',
-          '    ;;',
-          '  list-panes)',
-          '    if [ "${2:-}" = "-a" ] && [ "${3:-}" = "-F" ] && [ "${4:-}" = "#{pane_id}\t#{pane_dead}\t#{pane_pid}" ]; then',
-          '      printf "%s\n" "%11\t0\t42421" "%21\t0\t42422" "%31\t0\t42424"',
-          '    else',
-          '      echo "42424"',
-          '    fi',
-          '    ;;',
-          '  show-option)',
-          '    case "$*" in',
-          '      *"-p -t %21 @omx_team_pane_owner_id"*|*"-p -t %31 @omx_team_pane_owner_id"*)',
-          '        echo "team:low-role-scale"',
-          '        ;;',
-          '      *)',
-          '        exit 1',
-          '        ;;',
-          '    esac',
-          '    ;;',
-          '  capture-pane)',
-          '    echo ""',
-          '    ;;',
-          'esac',
-          'exit 0',
-          '',
-        ].join('\n'),
+        workerRuntimeScaleTmuxStub(
+          tmuxLogPath,
+          join(fakeBinDir, 'created-%31'),
+          'omx-team-low-role-scale',
+          'team:low-role-scale',
+        ),
       );
       await chmod(tmuxStubPath, 0o755);
+      execFileSync('sh', ['-n', tmuxStubPath], { stdio: 'pipe' });
       process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
 
       await mkdir(join(cwd, '.codex', 'prompts'), { recursive: true });
@@ -298,6 +316,7 @@ process.on('SIGTERM', () => process.exit(0));
         'utf-8',
       );
       assert.match(startupScript, /gpt-5\.6-luna/);
+      execFileSync('sh', ['-n', join(cwd, '.omx', 'state', 'team', 'low-role-scale', 'runtime', 'worker-2-startup.sh')]);
       assert.match(startupScript, /model_reasoning_effort.*low/);
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
@@ -317,45 +336,15 @@ process.on('SIGTERM', () => process.exit(0));
     try {
       await writeFile(
         tmuxStubPath,
-        [
-          '#!/bin/sh',
-          'set -eu',
-          `printf '%s\n' "$*" >> "${tmuxLogPath}"`,
-          'case "${1:-}" in',
-          '  -V)',
-          '    echo "tmux 3.2a"',
-          '    ;;',
-          '  split-window)',
-          '    echo "%31"',
-          '    ;;',
-          '  list-panes)',
-          '    if [ "${2:-}" = "-a" ] && [ "${3:-}" = "-F" ] && [ "${4:-}" = "#{pane_id}\t#{pane_dead}\t#{pane_pid}" ]; then',
-          '      printf "%s\n" "%11\t0\t42421" "%21\t0\t42422" "%31\t0\t42424"',
-          '    else',
-          '      echo "42424"',
-          '    fi',
-          '    ;;',
-          '  show-option)',
-          '    case "$*" in',
-          '      *"-p -t %21 @omx_team_pane_owner_id"*|*"-p -t %31 @omx_team_pane_owner_id"*)',
-          '        echo "team:exact-role-cli"',
-          '        ;;',
-          '      *)',
-          '        exit 1',
-          '        ;;',
-          '    esac',
-          '    ;;',
-          '  send-keys)',
-          '    ;;',
-          '  capture-pane)',
-          '    echo ""',
-          '    ;;',
-          'esac',
-          'exit 0',
-          '',
-        ].join('\n'),
+        workerRuntimeScaleTmuxStub(
+          tmuxLogPath,
+          join(fakeBinDir, 'created-%31'),
+          'omx-team-exact-role-cli',
+          'team:exact-role-cli',
+        ),
       );
       await chmod(tmuxStubPath, 0o755);
+      execFileSync('sh', ['-n', tmuxStubPath], { stdio: 'pipe' });
       await writeFile(tmuxLogPath, '');
       process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
 

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -10,6 +10,7 @@
  * - 'draining' worker status for graceful transitions during scale_down
  */
 
+import { randomUUID } from 'crypto';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import { mkdir, readFile, realpath, rm, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
@@ -18,16 +19,14 @@ import {
   isTmuxAvailable,
   waitForWorkerReady,
   dismissTrustPromptIfPresent,
-  sendToWorker,
   isWorkerAlive,
-  teardownWorkerPanes,
   buildWorkerStartupCommand,
   trustWorkerMiseConfigIfAvailable,
   writeWorkerStartupScriptCommand,
   resolveTeamWorkerCliForResolvedLaunchArgs,
   assertTeamWorkerCliPolicyCompatibility,
-  tagPaneTeamOwner,
   readPaneTeamOwnerTagResult,
+  teardownWorkerPanes,
   type TeamWorkerCli,
 } from './tmux-session.js';
 import { readExactPaneProofSync } from './exact-pane.js';
@@ -154,6 +153,125 @@ export function isScalingEnabled(env: NodeJS.ProcessEnv = process.env): boolean 
   const normalized = raw.trim().toLowerCase();
   return ['1', 'true', 'yes', 'on', 'enabled'].includes(normalized);
 }
+
+type ScalePaneInstance = {
+  paneId: string;
+  pid: number;
+  sessionName: string;
+  sessionId: string;
+  windowId: string;
+  teamOwnerId: string;
+};
+
+type ScaleUpWorkerInfo = WorkerInfo & {
+  session_id: string;
+  window_id: string;
+};
+
+const SCALE_PANE_INSTANCE_FORMAT = '#{pane_id}\t#{pane_pid}\t#{session_name}\t#{session_id}\t#{window_id}\t#{@omx_team_pane_owner_id}';
+const SCALE_SPLIT_RECEIPT_FORMAT = '#{pane_id}\t#{pane_pid}\t#{session_name}\t#{session_id}\t#{window_id}';
+
+type ScalePaneBirth = Omit<ScalePaneInstance, 'teamOwnerId'>;
+
+function scaleTransactionReceipt(): string {
+  return `omx-scale-${randomUUID()}`;
+}
+
+function hasExactScaleReceipt(stdout: string, receipt: string): boolean {
+  return stdout === `${receipt}\n` || stdout === `${receipt}\r\n`;
+}
+
+function runScalePaneTransaction(
+  pane: ScalePaneInstance,
+  effect: string,
+  receipt: string = scaleTransactionReceipt(),
+): boolean {
+  const result = spawnSync('tmux', [
+    'if-shell', '-F', '-t', pane.paneId, buildScalePaneAuthorityCondition(pane),
+    `${effect} \\; display-message -p ${quoteTmuxCommand(receipt)}`,
+    "display-message -p ''",
+  ], { encoding: 'utf-8' });
+  return result.status === 0 && hasExactScaleReceipt(result.stdout || '', receipt);
+}
+
+function tagScalePaneWithAuthority(pane: ScalePaneBirth, teamOwnerId: string): ScalePaneInstance | null {
+  const comparisons = [
+    ['pane_id', pane.paneId],
+    ['pane_pid', String(pane.pid)],
+    ['session_name', pane.sessionName],
+    ['session_id', pane.sessionId],
+    ['window_id', pane.windowId],
+  ].map(([field, expected]) => `#{==:#{${field}},${expected}}`);
+  const condition = comparisons.reduce((combined, comparison) => `#{&&:${combined},${comparison}}`);
+  const receipt = scaleTransactionReceipt();
+  const result = spawnSync('tmux', [
+    'if-shell', '-F', '-t', pane.paneId, condition,
+    `set-option -p -t ${pane.paneId} @omx_team_pane_owner_id ${quoteTmuxCommand(teamOwnerId)} \\; display-message -p ${quoteTmuxCommand(receipt)}`,
+    "display-message -p ''",
+  ], { encoding: 'utf-8' });
+  if (result.status !== 0 || !hasExactScaleReceipt(result.stdout || '', receipt)) return null;
+  return { ...pane, teamOwnerId };
+}
+
+function killScalePaneWithAuthority(pane: ScalePaneInstance): boolean {
+  return runScalePaneTransaction(pane, `kill-pane -t ${pane.paneId}`);
+}
+
+function parseScalePaneInstance(value: string): ScalePaneInstance | null {
+  const fields = value.trim().split('\t');
+  if (fields.length !== 6) return null;
+  const [paneId, pidText, sessionName, sessionId, windowId, teamOwnerId] = fields;
+  const pid = Number(pidText);
+  if (!/^%[0-9]+$/.test(paneId) || !Number.isSafeInteger(pid) || pid <= 0
+    || !sessionName || !/^\$[0-9]+$/.test(sessionId) || !/^@[0-9]+$/.test(windowId) || !teamOwnerId) return null;
+  return { paneId, pid, sessionName, sessionId, windowId, teamOwnerId };
+}
+
+function readScalePaneInstance(paneId: string): ScalePaneInstance | null {
+  const result = spawnSync('tmux', ['display-message', '-p', '-t', paneId, SCALE_PANE_INSTANCE_FORMAT], { encoding: 'utf-8' });
+  return result.status === 0 ? parseScalePaneInstance(result.stdout || '') : null;
+}
+
+function quoteTmuxCommand(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function buildScalePaneAuthorityCondition(instance: ScalePaneInstance): string {
+  const comparisons = [
+    ['pane_id', instance.paneId],
+    ['pane_pid', String(instance.pid)],
+    ['session_name', instance.sessionName],
+    ['session_id', instance.sessionId],
+    ['window_id', instance.windowId],
+    ['@omx_team_pane_owner_id', instance.teamOwnerId],
+  ].map(([field, expected]) => `#{==:#{${field}},${expected}}`);
+  return comparisons.reduce((condition, comparison) => `#{&&:${condition},${comparison}}`);
+}
+
+function splitWorkerPaneWithScaleAuthority(
+  source: ScalePaneInstance,
+  splitDirection: string,
+  workerCwd: string,
+  command: string,
+): ScalePaneBirth | null {
+  const receipt = scaleTransactionReceipt();
+  const splitCommand = [
+    'split-window', splitDirection, '-t', source.paneId, '-d', '-P', '-F', `${SCALE_SPLIT_RECEIPT_FORMAT}\t${receipt}`,
+    '-c', workerCwd, command,
+  ].map(quoteTmuxCommand).join(' ');
+  const result = spawnSync('tmux', [
+    'if-shell', '-F', '-t', source.paneId, buildScalePaneAuthorityCondition(source), splitCommand, "display-message -p ''",
+  ], { encoding: 'utf-8' });
+  if (result.status !== 0) return null;
+  const fields = (result.stdout || '').replace(/\r?\n$/, '').split('\t');
+  if (fields.length !== 6 || fields[5] !== receipt) return null;
+  const [paneId, pidText, sessionName, sessionId, windowId] = fields;
+  const pid = Number(pidText);
+  if (!/^%[0-9]+$/.test(paneId) || !Number.isSafeInteger(pid) || pid <= 0
+    || !sessionName || !sessionId || !/^\$[0-9]+$/.test(sessionId) || !/^@[0-9]+$/.test(windowId)) return null;
+  return { paneId, pid, sessionName, sessionId, windowId };
+}
+
 
 function assertScalingEnabled(env: NodeJS.ProcessEnv = process.env): void {
   if (!isScalingEnabled(env)) {
@@ -416,16 +534,31 @@ function resolveScaleUpWorktreeMode(config: TeamConfig): WorktreeMode {
 
 async function notifyWorkerPaneOutcome(
   sessionName: string,
-  workerIndex: number,
   message: string,
   paneId?: string,
-  workerCli?: 'codex' | 'claude' | 'gemini',
   expectedPanePid?: number,
   expectedTeamOwnerId?: string,
-  hudPaneId?: string,
+  expectedSessionId?: string,
+  expectedWindowId?: string,
 ): Promise<DispatchOutcome> {
   try {
-    await sendToWorker(sessionName, workerIndex, message, paneId, workerCli, expectedPanePid, expectedTeamOwnerId, hudPaneId);
+    if (!paneId || !expectedPanePid || !expectedTeamOwnerId || !expectedSessionId || !expectedWindowId) {
+      throw new Error(`scale_up_final_send_authority_missing:${paneId ?? 'unknown'}`);
+    }
+    const pane: ScalePaneInstance = {
+      paneId,
+      pid: expectedPanePid,
+      sessionName,
+      sessionId: expectedSessionId,
+      windowId: expectedWindowId,
+      teamOwnerId: expectedTeamOwnerId,
+    };
+    if (!runScalePaneTransaction(
+      pane,
+      `send-keys -t ${paneId} -l ${quoteTmuxCommand(message)} \\; send-keys -t ${paneId} C-m`,
+    )) {
+      throw new Error(`scale_up_final_send_authority_lost:${paneId}`);
+    }
     return { ok: true, transport: 'tmux_send_keys', reason: 'tmux_send_keys_sent' };
   } catch (error) {
     return {
@@ -710,9 +843,9 @@ export async function scaleUp(
       ].filter((paneId): paneId is string => typeof paneId === 'string' && paneId.trim().startsWith('%')))];
       const resolvedPaneIds = new Set<string>();
       const unresolvedPaneIds = new Set<string>();
-      const expectedPanePids: Record<string, number> = {};
       const requiredTeamOwnerId = config.tmux_pane_owner_id?.trim();
       const authorizedRollbackPaneIds = new Set<string>();
+      const rollbackInstances = new Map<string, ScalePaneInstance>();
       for (const paneId of rollbackPaneIds) {
         const matchingWorkers = rollbackWorkers.filter((worker) => worker.pane_id === paneId);
         const worker = matchingWorkers.length === 1 ? matchingWorkers[0] : undefined;
@@ -727,43 +860,36 @@ export async function scaleUp(
           cleanupDebt.push(`pane_owner_unverified:${paneId}`);
           continue;
         }
-        expectedPanePids[paneId] = expectedPanePid;
+        const expectedWindowId = (worker as WorkerInfo & { window_id?: unknown }).window_id;
+        const expectedSessionId = (worker as WorkerInfo & { session_id?: unknown }).session_id;
+        if (typeof expectedWindowId !== 'string' || !/^@[0-9]+$/.test(expectedWindowId)
+          || typeof expectedSessionId !== 'string' || expectedSessionId.trim() === '') {
+          unresolvedPaneIds.add(paneId);
+          cleanupDebt.push(`pane_window_unpinned:${paneId}`);
+          continue;
+        }
+        const rollbackInstance = readScalePaneInstance(paneId);
+        if (!rollbackInstance
+          || rollbackInstance.pid !== expectedPanePid
+          || rollbackInstance.sessionName !== config.tmux_session
+          || rollbackInstance.sessionId !== expectedSessionId
+          || rollbackInstance.windowId !== expectedWindowId
+          || (requiredTeamOwnerId && rollbackInstance.teamOwnerId !== requiredTeamOwnerId)) {
+          unresolvedPaneIds.add(paneId);
+          cleanupDebt.push(`pane_window_authority_lost:${paneId}`);
+          continue;
+        }
+        rollbackInstances.set(paneId, rollbackInstance);
         authorizedRollbackPaneIds.add(paneId);
       }
-      try {
-        const paneTeardown = await teardownWorkerPanes([...authorizedRollbackPaneIds], {
-          leaderPaneId: config.leader_pane_id,
-          hudPaneId: config.hud_pane_id,
-          expectedPanePids,
-          authorizePaneKill: (paneId) => {
-            if (!requiredTeamOwnerId) return true;
-            const expectedOwnerId = rollbackTaggedPaneOwnerIds.get(paneId);
-            if (expectedOwnerId !== requiredTeamOwnerId) return false;
-            const currentOwner = readPaneTeamOwnerTagResult(paneId);
-            return currentOwner.status === 'value' && currentOwner.value === expectedOwnerId;
-          },
-        });
-        for (const paneId of [...paneTeardown.provenGonePaneIds, ...paneTeardown.killedPaneIds]) resolvedPaneIds.add(paneId);
-        for (const paneId of paneTeardown.kill.failedPaneIds) unresolvedPaneIds.add(paneId);
-        for (const proof of paneTeardown.proofUnavailable) unresolvedPaneIds.add(proof.paneId);
-        if (paneTeardown.kill.failedPaneIds.length > 0) cleanupDebt.push(`pane_teardown_failed:${paneTeardown.kill.failedPaneIds.join(',')}`);
-        if (paneTeardown.proofUnavailable.length > 0) {
-          cleanupDebt.push(`pane_proof_unavailable:${paneTeardown.proofUnavailable.map((proof) => `${proof.paneId}:${proof.reason}`).join(',')}`);
+      for (const paneId of authorizedRollbackPaneIds) {
+        const instance = rollbackInstances.get(paneId);
+        if (!instance || !killScalePaneWithAuthority(instance)) {
+          unresolvedPaneIds.add(paneId);
+          cleanupDebt.push(`pane_teardown_authority_lost:${paneId}`);
+          continue;
         }
-        if (paneTeardown.kill.failedPaneIds.length > 0 || paneTeardown.proofUnavailable.length > 0) {
-          for (const paneId of rollbackPaneIds) {
-            if (!resolvedPaneIds.has(paneId)) unresolvedPaneIds.add(paneId);
-          }
-          const unresolvedWithoutDirectFailure = [...unresolvedPaneIds].filter((paneId) =>
-            !paneTeardown.kill.failedPaneIds.includes(paneId)
-            && !paneTeardown.proofUnavailable.some((proof) => proof.paneId === paneId));
-          if (unresolvedWithoutDirectFailure.length > 0) {
-            cleanupDebt.push(`pane_teardown_unresolved:${unresolvedWithoutDirectFailure.join(',')}`);
-          }
-        }
-      } catch (cleanupError) {
-        for (const paneId of rollbackPaneIds) unresolvedPaneIds.add(paneId);
-        cleanupDebt.push(`pane_cleanup_exception:${String(cleanupError)}`);
+        resolvedPaneIds.add(paneId);
       }
 
       const unresolvedWorkerNames = new Set(rollbackWorkers
@@ -1084,74 +1210,57 @@ export async function scaleUp(
         );
       }
 
-      // The target and its expected PID were frozen before preparation. Prove
-      // the same identity immediately before the split-window side effect.
-
+      // Freeze and validate the full source-pane incarnation. The server owns
+      // the final comparison and split, so a recycled pane ID cannot become a
+      // split target between client-side proof and the topology mutation.
       const splitTargetProof = readExactPaneProofSync(splitTarget);
-      if (splitTargetProof.status !== 'live') {
+      const splitTargetInstance = splitTargetProof.status === 'live'
+        ? readScalePaneInstance(splitTargetProof.paneId)
+        : null;
+      if (!splitTargetInstance) {
         return await rollbackScaleUp(
-          `scale_up_split_target_proof_unavailable:${splitTarget}:${splitTargetProof.reason}`,
+          `scale_up_split_target_proof_unavailable:${splitTarget}`,
           { workerName, worktreePath: workerWorkspace?.worktreePath },
         );
       }
-      if (splitTargetProof.pid !== expectedSplitTargetPid) {
+      if (splitTargetInstance.pid !== expectedSplitTargetPid) {
         return await rollbackScaleUp(
-          `scale_up_split_target_pid_changed:${splitTarget}:${expectedSplitTargetPid}:${splitTargetProof.pid}`,
+          `scale_up_split_target_pid_changed:${splitTarget}:${expectedSplitTargetPid}:${splitTargetInstance.pid}`,
           { workerName, worktreePath: workerWorkspace?.worktreePath },
         );
       }
-      const currentSplitTargetOwner = readPaneTeamOwnerTagResult(splitTargetProof.paneId);
-      if (currentSplitTargetOwner.status !== 'value' || currentSplitTargetOwner.value !== expectedSplitTargetOwnerId) {
+      if (splitTargetInstance.sessionName !== sessionName
+        || (config.tmux_session_id && splitTargetInstance.sessionId !== config.tmux_session_id)
+        || splitTargetInstance.teamOwnerId !== expectedSplitTargetOwnerId) {
         return await rollbackScaleUp(
-          `scale_up_split_target_owner_changed:${splitTargetProof.paneId}`,
-          { workerName, worktreePath: workerWorkspace?.worktreePath },
-        );
-      }
-
-      // The owner read is untrusted and may race pane-ID reuse. Bind the split
-      // to the same persisted process again immediately before the effect.
-      const finalSplitTargetProof = readExactPaneProofSync(splitTargetProof.paneId);
-      if (finalSplitTargetProof.status !== 'live') {
-        return await rollbackScaleUp(
-          `scale_up_split_target_proof_unavailable:${splitTargetProof.paneId}:${finalSplitTargetProof.reason}`,
-          { workerName, worktreePath: workerWorkspace?.worktreePath },
-        );
-      }
-      if (finalSplitTargetProof.pid !== expectedSplitTargetPid) {
-        return await rollbackScaleUp(
-          `scale_up_split_target_pid_changed:${splitTargetProof.paneId}:${expectedSplitTargetPid}:${finalSplitTargetProof.pid}`,
+          `scale_up_split_target_authority_changed:${splitTargetInstance.paneId}`,
           { workerName, worktreePath: workerWorkspace?.worktreePath },
         );
       }
 
-      const result = spawnSync('tmux', [
-        'split-window', splitDirection, '-t', finalSplitTargetProof.paneId, '-d', '-P', '-F', '#{pane_id}', '-c', workerCwd, cmd,
-      ], { encoding: 'utf-8' });
-
-      if (result.status !== 0) {
+      const createdPane = splitWorkerPaneWithScaleAuthority(
+        splitTargetInstance,
+        splitDirection,
+        workerCwd,
+        cmd,
+      );
+      if (!createdPane) {
         return await rollbackScaleUp(
-          `Failed to create tmux pane for ${workerName}: ${(result.stderr || '').trim()}`,
+          `scale_up_split_target_authority_lost:${splitTargetInstance.paneId}`,
           { workerName, worktreePath: workerWorkspace?.worktreePath },
         );
       }
-
-      const paneId = (result.stdout || '').trim().split('\n')[0]?.trim();
-      if (!paneId || !paneId.startsWith('%')) {
-        return await rollbackScaleUp(`Failed to capture pane ID for ${workerName}`, {
-          paneId,
-          workerName,
-          worktreePath: workerWorkspace?.worktreePath,
-        });
-      }
-      const paneProof = readExactPaneProofSync(paneId);
-      const workerInfo: WorkerInfo = {
+      const paneId = createdPane.paneId;
+      const workerInfo: ScaleUpWorkerInfo = {
         name: workerName,
         index: workerIndex,
         role: runtimeRole,
         worker_cli: workerCli,
         assigned_tasks: [],
-        pid: paneProof.status === 'live' ? paneProof.pid : undefined,
+        pid: createdPane.pid,
         pane_id: paneId,
+        session_id: createdPane.sessionId,
+        window_id: createdPane.windowId,
         working_dir: workerCwd,
         worktree_repo_root: workerWorkspace ? workerWorkspace.repoRoot : undefined,
         worktree_path: workerWorkspace ? workerWorkspace.worktreePath : undefined,
@@ -1161,21 +1270,14 @@ export async function scaleUp(
         team_state_root: teamStateRoot,
       };
 
-      if (paneProof.status !== 'live') {
-        return await rollbackScaleUp(`Failed to prove tmux pane for ${workerName}`, { paneId, worker: workerInfo });
-      }
 
-      if (config.tmux_pane_owner_id) {
-        try {
-          tagPaneTeamOwner(paneProof.paneId, config.tmux_pane_owner_id, paneProof.pid);
-          rollbackTaggedPaneOwnerIds.set(paneProof.paneId, config.tmux_pane_owner_id.trim());
-        } catch (error) {
-          return await rollbackScaleUp(
-            `Failed to tag tmux pane for ${workerName}: ${error instanceof Error ? error.message : String(error)}`,
-            { paneId, worker: workerInfo },
-          );
-        }
+      const taggedPane = config.tmux_pane_owner_id
+        ? tagScalePaneWithAuthority(createdPane, config.tmux_pane_owner_id.trim())
+        : null;
+      if (!taggedPane) {
+        return await rollbackScaleUp(`scale_up_created_pane_owner_tag_authority_lost:${paneId}`, { paneId, worker: workerInfo });
       }
+      rollbackTaggedPaneOwnerIds.set(paneId, taggedPane.teamOwnerId);
 
       // Intentionally avoid forcing `select-layout tiled` here.
       // Tiled relayout reflows leader/HUD panes and breaks team window layout.
@@ -1233,7 +1335,7 @@ export async function scaleUp(
           if (dispatchPolicy.dispatch_mode === 'hook_preferred_with_fallback') {
             return { ok: true, transport: 'hook', reason: 'queued_for_hook_dispatch' };
           }
-          return await notifyWorkerPaneOutcome(sessionName, workerIndex, message, paneId, workerCli, workerInfo.pid, config.tmux_pane_owner_id ?? undefined, config.hud_pane_id ?? undefined);
+          return await notifyWorkerPaneOutcome(sessionName, message, paneId, workerInfo.pid, config.tmux_pane_owner_id ?? undefined, workerInfo.session_id, workerInfo.window_id);
         },
       });
       let outcome = queued;
@@ -1245,7 +1347,7 @@ export async function scaleUp(
         if (receipt && (receipt.status === 'notified' || receipt.status === 'delivered')) {
           outcome = { ok: true, transport: 'hook', reason: `hook_receipt_${receipt.status}`, request_id: queued.request_id };
         } else {
-          const fallback = await notifyWorkerPaneOutcome(sessionName, workerIndex, triggerDirective.text, paneId, workerCli, workerInfo.pid, config.tmux_pane_owner_id ?? undefined, config.hud_pane_id ?? undefined);
+          const fallback = await notifyWorkerPaneOutcome(sessionName, triggerDirective.text, paneId, workerInfo.pid, config.tmux_pane_owner_id ?? undefined, workerInfo.session_id, workerInfo.window_id);
           if (receipt?.status === 'failed') {
             if (fallback.ok) {
               await transitionDispatchRequest(
@@ -1325,7 +1427,7 @@ export async function scaleUp(
       // Retry dispatch once if a trust prompt is blocking the worker pane (fixes #393).
       if (!outcome.ok && dismissTrustPromptIfPresent(sessionName, workerIndex, paneId, workerInfo.pid, config.tmux_pane_owner_id ?? undefined, config.hud_pane_id ?? undefined)) {
         waitForWorkerReady(sessionName, workerIndex, readyTimeoutMs, paneId, workerInfo.pid, config.tmux_pane_owner_id ?? undefined, config.hud_pane_id ?? undefined);
-        const retry = await notifyWorkerPaneOutcome(sessionName, workerIndex, triggerDirective.text, paneId, workerCli, workerInfo.pid, config.tmux_pane_owner_id ?? undefined, config.hud_pane_id ?? undefined);
+        const retry = await notifyWorkerPaneOutcome(sessionName, triggerDirective.text, paneId, workerInfo.pid, config.tmux_pane_owner_id ?? undefined, workerInfo.session_id, workerInfo.window_id);
         if (retry.ok) {
           outcome = retry;
         }

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -2,6 +2,8 @@ import { spawnSync, execFile } from 'child_process';
 import { promisify } from 'util';
 import { closeSync, chmodSync, existsSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
+import { randomBytes } from 'crypto';
+
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import {
   CODEX_BYPASS_FLAG,
@@ -78,6 +80,10 @@ export interface TeamSession {
   leaderPaneId: string;
   /** Frozen leader pane process identity for startup and recovery authority. */
   leaderPanePid?: number;
+  /** Frozen leader tmux session/window incarnations for same-server sink authorization. */
+  leaderSessionId?: string;
+  leaderSessionCreated?: string;
+  leaderWindowId?: string;
   /** HUD pane spawned below the leader column, or null if creation failed. */
   hudPaneId: string | null;
   /** Frozen HUD pane process identity for startup and recovery authority. */
@@ -241,6 +247,104 @@ function runTmuxStructured(args: string[]): { ok: true; stdout: string } | { ok:
     return { ok: false, stderr: (result.stderr || '').trim() || `tmux exited ${result.status}` };
   }
   return { ok: true, stdout: (result.stdout || '').replace(/\r?\n$/, '') };
+
+}
+
+type SourcePaneAuthority = {
+  paneId: string;
+  panePid: number;
+  sessionName: string;
+  sessionId: string;
+  sessionCreated: string;
+  windowId: string;
+  windowIndex: string;
+  /** Present only after the Team owner bootstrap tag has been committed. */
+  teamPaneOwnerId: string | null;
+};
+
+function captureSourcePaneAuthority(paneId: string, expectedTeamPaneOwnerId?: string): SourcePaneAuthority {
+  const target = paneId.trim();
+  if (!/^%[0-9]+$/.test(target)) throw new Error(`invalid tmux source pane: ${paneId}`);
+  const result = runTmuxStructured([
+    'display-message', '-p', '-t', target,
+    '#{session_name}\t#{session_id}\t#{session_created}\t#{window_index}\t#{window_id}\t#{pane_id}\t#{pane_pid}',
+  ]);
+  if (!result.ok) throw new Error(`failed to capture tmux source authority: ${result.stderr}`);
+  const fields = result.stdout.split('\t');
+  if (fields.length !== 7) throw new Error('malformed tmux source authority');
+  const [sessionName, sessionId, sessionCreated, windowIndex, windowId, capturedPaneId, panePid] = fields;
+  if (!sessionName || !/^\$[0-9]+$/.test(sessionId) || !/^[0-9]+$/.test(sessionCreated)
+    || !/^[0-9]+$/.test(windowIndex) || !/^@[0-9]+$/.test(windowId)
+    || capturedPaneId !== target || !/^[1-9][0-9]*$/.test(panePid)) {
+    throw new Error('malformed tmux source authority');
+  }
+  const parsedPid = Number(panePid);
+  if (!Number.isSafeInteger(parsedPid) || parsedPid <= 0) throw new Error('malformed tmux source authority');
+  const proof = readExactPaneProofSync(target);
+  if (proof.status === 'unavailable') throw new ExactPaneProofUnavailableError(proof);
+  if (proof.status !== 'live' || proof.pid !== parsedPid) throw new Error(`tmux pane identity changed: ${target}`);
+  const ownerResult = runTmuxStructured(['show-option', '-qv', '-p', '-t', target, OMX_TEAM_PANE_OWNER_OPTION]);
+  if (!ownerResult.ok) throw new Error(`failed to capture tmux pane owner: ${ownerResult.stderr}`);
+  const teamPaneOwnerId = ownerResult.stdout.trim() || null;
+  if (teamPaneOwnerId && !/^[A-Za-z0-9._:-]+$/.test(teamPaneOwnerId)) {
+    throw new Error('malformed tmux pane owner');
+  }
+  if (expectedTeamPaneOwnerId !== undefined && teamPaneOwnerId !== expectedTeamPaneOwnerId) {
+    throw new Error(`tmux pane team owner changed: ${target}`);
+  }
+  return {
+    paneId: target,
+    panePid: parsedPid,
+    sessionName,
+    sessionId,
+    sessionCreated,
+    windowId,
+    windowIndex,
+    teamPaneOwnerId,
+  };
+}
+
+function sourceAuthorityPredicate(source: SourcePaneAuthority): string {
+  return [
+    '#{==:#{pane_dead},0}',
+    `#{==:#{pane_id},${source.paneId}}`,
+    `#{==:#{pane_pid},${source.panePid}}`,
+    `#{==:#{session_id},${source.sessionId}}`,
+    `#{==:#{session_created},${source.sessionCreated}}`,
+    `#{==:#{window_id},${source.windowId}}`,
+    ...(source.teamPaneOwnerId ? [`#{==:#{${OMX_TEAM_PANE_OWNER_OPTION}},${source.teamPaneOwnerId}}`] : []),
+  ].reduce((combined, condition) => `#{&&:${combined},${condition}}`);
+}
+
+function sourceTransactionReceipt(): string {
+  return `omx_source_${process.pid}_${Date.now()}_${randomBytes(16).toString('hex')}`;
+}
+
+/** Queue an effect in the source pane's tmux server only when its exact pane/session/window incarnation still matches. */
+function runSourceAuthorizedTmux(source: SourcePaneAuthority, effect: string, receipt: string = sourceTransactionReceipt()): string {
+  const result = runTmux([
+    'if-shell', '-F', '-t', source.paneId, sourceAuthorityPredicate(source),
+    `${effect} \\; display-message -p ${shellQuoteSingle(receipt)}`,
+    "display-message -p ''",
+  ]);
+  if (!result.ok) throw new Error(`tmux source authority transaction failed: ${result.stderr}`);
+  if (result.stdout !== receipt) throw new Error('tmux source authority changed before effect');
+  return receipt;
+}
+
+function runSourceAuthorizedSplit(source: SourcePaneAuthority, effect: string): string {
+  const receipt = sourceTransactionReceipt();
+  const result = runTmux([
+    'if-shell', '-F', '-t', source.paneId, sourceAuthorityPredicate(source),
+    effect.replace("-F '#{pane_id}'", `-F '#{pane_id}\\t${receipt}'`),
+    "display-message -p ''",
+  ]);
+  if (!result.ok) throw new Error(`tmux source authority transaction failed: ${result.stderr}`);
+  const [paneId, observedReceipt, ...extra] = result.stdout.split('\t');
+  if (!paneId || !/^%[0-9]+$/.test(paneId) || observedReceipt !== receipt || extra.length !== 0) {
+    throw new Error('tmux source authority changed before split effect');
+  }
+  return paneId;
 }
 
 type RestoredHudCleanupDebt = {
@@ -480,16 +584,6 @@ function sanitizeTmuxStyleOption(
   return result.ok;
 }
 
-function tagPaneInstance(paneTarget: string, instanceId: string, expectedPanePid?: number): void {
-  const target = paneTarget.trim();
-  const sanitized = instanceId.trim();
-  if (!target || !sanitized) return;
-  const provenTarget = requireLiveExactPaneSync(target, expectedPanePid);
-  const result = runTmux(['set-option', '-p', '-t', provenTarget, OMX_PANE_INSTANCE_OPTION, sanitized]);
-  if (!result.ok) {
-    throw new Error(`failed to tag tmux pane ${provenTarget}: ${result.stderr}`);
-  }
-}
 
 export function tagPaneTeamOwner(paneTarget: string, teamOwnerId: string, expectedPanePid?: number): void {
   const target = paneTarget.trim();
@@ -1359,14 +1453,12 @@ export function buildReconcileHudResizeArgs(
 }
 
 function redrawLeaderPaneAfterTeamLayout(
-  leaderPaneId: string,
-  expectedPanePid: number,
+  source: SourcePaneAuthority,
   expectedTeamOwnerId: string,
 ): void {
-  const target = leaderPaneId.trim();
-  if (!target.startsWith('%')) return;
-  const provenTarget = requireLiveTeamOwnedPaneSync(target, expectedPanePid, expectedTeamOwnerId);
-  runTmux(['send-keys', '-t', provenTarget, 'C-l']);
+  const provenTarget = requireLiveTeamOwnedPaneSync(source.paneId, source.panePid, expectedTeamOwnerId);
+  if (provenTarget !== source.paneId) throw new Error(`tmux pane identity changed: ${source.paneId}`);
+  runSourceAuthorizedTmux(source, `send-keys -t ${source.paneId} C-l`);
 }
 
 const ZSH_CANDIDATE_PATHS = ['/bin/zsh', '/usr/bin/zsh', '/usr/local/bin/zsh', '/opt/local/bin/zsh', '/opt/homebrew/bin/zsh'];
@@ -2283,9 +2375,14 @@ export function createTeamSession(
     const leaderProof = readExactPaneProofSync(leaderPaneId);
     if (leaderProof.status === 'unavailable') throw new ExactPaneProofUnavailableError(leaderProof);
     if (leaderProof.status === 'gone') throw new Error(`tmux pane is not proven live: ${leaderPaneId}`);
-    const leaderPanePid = leaderProof.pid;
+    let leaderSource = captureSourcePaneAuthority(leaderPaneId);
+    if (leaderSource.sessionName !== sessionName || leaderSource.windowIndex !== windowIndex || leaderSource.panePid !== leaderProof.pid) {
+      throw new Error('tmux source authority changed during team startup');
+    }
+    const leaderPanePid = leaderSource.panePid;
     partialLeaderPaneId = leaderPaneId;
     partialLeaderPanePid = leaderPanePid;
+
     const initialHudPaneIds = findHudWatchPaneIds(paneListResult.panes, leaderPaneId, { leaderPaneId });
     const initialWindowPanePids = new Map<string, number>([[leaderPaneId, leaderPanePid]]);
 
@@ -2304,13 +2401,25 @@ export function createTeamSession(
     // instead of making it disappear on team startup failures or broken installs.
     requireFrozenWindowTopologySync(teamTarget, initialWindowPanePids);
     if (ownerSessionId) {
-      const tagResult = runTmux(['set-option', '-t', sessionName, OMX_INSTANCE_OPTION, ownerSessionId]);
-      if (!tagResult.ok) {
-        throw new Error(`failed to tag tmux session ${sessionName}: ${tagResult.stderr}`);
-      }
+      runSourceAuthorizedTmux(
+        leaderSource,
+        `set-option -t ${leaderSource.sessionId} ${OMX_INSTANCE_OPTION} ${shellQuoteSingle(ownerSessionId)}`,
+      );
     }
-    tagPaneInstance(leaderPaneId, ownerSessionId, leaderPanePid);
-    tagPaneTeamOwner(leaderPaneId, teamPaneOwnerId, leaderPanePid);
+    if (ownerSessionId) {
+      runSourceAuthorizedTmux(
+        leaderSource,
+        `set-option -p -t ${leaderPaneId} ${OMX_PANE_INSTANCE_OPTION} ${shellQuoteSingle(ownerSessionId)}`,
+      );
+    }
+    runSourceAuthorizedTmux(
+      leaderSource,
+      `set-option -p -t ${leaderPaneId} ${OMX_TEAM_PANE_OWNER_OPTION} ${shellQuoteSingle(teamPaneOwnerId)}`,
+    );
+    // All subsequent Team mutations must bind the frozen leader owner in the
+    // same tmux-server transaction as their effect. The initial tag itself is
+    // deliberately the sole bootstrap mutation before an owner exists.
+    leaderSource = captureSourcePaneAuthority(leaderPaneId, teamPaneOwnerId);
     if (canRecreateTeamHud) {
       for (const [hudPaneId, hudPanePid] of initialWindowPanePids) {
         if (hudPaneId !== leaderPaneId) killExactPaneSync(hudPaneId, hudPanePid);
@@ -2352,26 +2461,12 @@ export function createTeamSession(
         teamPaneOwnerId,
       );
 
-      const split = runTmux([
-        'split-window',
-        splitDirection,
-        '-t',
-        splitTarget,
-        '-d',
-        '-P',
-        '-F',
-        '#{pane_id}',
-        '-c',
-        tmuxWorkerCwd,
-        cmd,
-      ]);
-      if (!split.ok) {
-        throw new Error(`failed to create worker pane ${i}: ${split.stderr}`);
-      }
-      const paneId = split.stdout.split('\n')[0]?.trim();
-      if (!paneId || !paneId.startsWith('%')) {
-        throw new Error(`failed to capture worker pane id for worker ${i}`);
-      }
+      const splitSource = captureSourcePaneAuthority(splitTarget, teamPaneOwnerId);
+      const paneId = runSourceAuthorizedSplit(
+        splitSource,
+        `split-window ${splitDirection} -t ${splitTarget} -d -P -F '#{pane_id}' -c ${shellQuoteSingle(tmuxWorkerCwd)} ${shellQuoteSingle(cmd)}`,
+      );
+
       // The pane exists once split-window returns its concrete ID. Persist it in
       // rollback/partial state before its first proof: a malformed or unavailable
       // topology must retain cleanup debt, but cannot authorize an effect.
@@ -2389,9 +2484,20 @@ export function createTeamSession(
       if (isNativeWindows() && !waitForPaneToRemainPresent(teamTarget, paneId)) {
         throw new Error(`worker pane ${i} did not remain present after tmux split-window returned ${paneId}`);
       }
-      tagPaneInstance(paneId, ownerSessionId, panePid);
+      const paneSource = captureSourcePaneAuthority(paneId);
+      if (paneSource.panePid !== panePid) throw new Error(`tmux pane identity changed: ${paneId}`);
+      if (ownerSessionId) {
+        runSourceAuthorizedTmux(
+          paneSource,
+          `set-option -p -t ${paneId} ${OMX_PANE_INSTANCE_OPTION} ${shellQuoteSingle(ownerSessionId)}`,
+        );
+      }
       rollbackTaggedPaneOwnerIds.set(paneId, teamPaneOwnerId);
-      tagPaneTeamOwner(paneId, teamPaneOwnerId, panePid);
+      runSourceAuthorizedTmux(
+        paneSource,
+        `set-option -p -t ${paneId} ${OMX_TEAM_PANE_OWNER_OPTION} ${shellQuoteSingle(teamPaneOwnerId)}`,
+      );
+
       frozenWindowPaneOwners.set(paneId, teamPaneOwnerId);
       workerPaneIds.push(paneId);
       if (i === 1) {
@@ -2403,7 +2509,8 @@ export function createTeamSession(
 
     // Keep leader as full left/main pane; workers stay stacked on the right.
     requireFrozenWindowTopologySync(teamTarget, frozenWindowPanePids, frozenWindowPaneOwners);
-    runTmux(['select-layout', '-t', teamTarget, 'main-vertical']);
+    runSourceAuthorizedTmux(leaderSource, `select-layout -t ${leaderSource.windowId} main-vertical`);
+
 
     // Force leader pane to use half the window width.
     const windowWidthResult = runTmux(['display-message', '-p', '-t', teamTarget, '#{window_width}']);
@@ -2412,9 +2519,9 @@ export function createTeamSession(
       if (Number.isFinite(width) && width >= 40) {
         const half = String(Math.floor(width / 2));
         requireFrozenWindowTopologySync(teamTarget, frozenWindowPanePids, frozenWindowPaneOwners);
-        runTmux(['set-window-option', '-t', teamTarget, 'main-pane-width', half]);
+        runSourceAuthorizedTmux(leaderSource, `set-window-option -t ${leaderSource.windowId} main-pane-width ${half}`);
         requireFrozenWindowTopologySync(teamTarget, frozenWindowPanePids, frozenWindowPaneOwners);
-        runTmux(['select-layout', '-t', teamTarget, 'main-vertical']);
+        runSourceAuthorizedTmux(leaderSource, `select-layout -t ${leaderSource.windowId} main-vertical`);
       }
     }
 
@@ -2431,12 +2538,13 @@ export function createTeamSession(
       requireFrozenWindowTopologySync(teamTarget, frozenWindowPanePids, frozenWindowPaneOwners);
       const hudSplitTarget = leaderPaneId;
 
-      const hudResult = runTmux([
-        'split-window', '-v', '-f', '-l', String(HUD_TMUX_TEAM_HEIGHT_LINES), '-t', hudSplitTarget, '-d', '-P', '-F', '#{pane_id}', '-c', hudCwd, hudCmd,
-      ]);
-      if (hudResult.ok) {
-        const id = hudResult.stdout.split('\n')[0]?.trim() ?? '';
-        if (id.startsWith('%')) {
+      const hudSource = captureSourcePaneAuthority(hudSplitTarget, teamPaneOwnerId);
+      const id = runSourceAuthorizedSplit(
+        hudSource,
+        `split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t ${hudSplitTarget} -d -P -F '#{pane_id}' -c ${shellQuoteSingle(hudCwd)} ${shellQuoteSingle(hudCmd)}`,
+      );
+      {
+
           // split-window has created a concrete pane even though no proof has
           // authorized an effect yet. Retain PID-less cleanup debt first.
           rollbackPanes.set(id, null);
@@ -2452,9 +2560,19 @@ export function createTeamSession(
           if (isNativeWindows() && !waitForPaneToRemainPresent(teamTarget, id)) {
             throw new Error(`HUD pane did not remain present after tmux split-window returned ${id}`);
           }
-          tagPaneInstance(id, ownerSessionId, hudPanePid);
+          const hudSource = captureSourcePaneAuthority(id);
+          if (hudSource.panePid !== hudPanePid) throw new Error(`tmux pane identity changed: ${id}`);
+          if (ownerSessionId) {
+            runSourceAuthorizedTmux(
+              hudSource,
+              `set-option -p -t ${id} ${OMX_PANE_INSTANCE_OPTION} ${shellQuoteSingle(ownerSessionId)}`,
+            );
+          }
           rollbackTaggedPaneOwnerIds.set(id, teamPaneOwnerId);
-          tagPaneTeamOwner(id, teamPaneOwnerId, hudPanePid);
+          runSourceAuthorizedTmux(
+            hudSource,
+            `set-option -p -t ${id} ${OMX_TEAM_PANE_OWNER_OPTION} ${shellQuoteSingle(teamPaneOwnerId)}`,
+          );
           frozenWindowPaneOwners.set(id, teamPaneOwnerId);
           hudPaneId = id;
 
@@ -2557,10 +2675,11 @@ export function createTeamSession(
           }
         }
       }
-    }
 
-    runTmux(['select-pane', '-t', requireLiveTeamOwnedPaneSync(leaderPaneId, leaderPanePid, teamPaneOwnerId)]);
-    redrawLeaderPaneAfterTeamLayout(leaderPaneId, leaderPanePid, teamPaneOwnerId);
+    const focusedLeader = requireLiveTeamOwnedPaneSync(leaderPaneId, leaderPanePid, teamPaneOwnerId);
+    if (focusedLeader !== leaderSource.paneId) throw new Error(`tmux pane identity changed: ${leaderPaneId}`);
+    runSourceAuthorizedTmux(leaderSource, `select-pane -t ${leaderPaneId}`);
+    redrawLeaderPaneAfterTeamLayout(leaderSource, teamPaneOwnerId);
 
     sleepSeconds(0.5);
 
@@ -2575,14 +2694,11 @@ export function createTeamSession(
       );
     }
 
-    const sessionIncarnation = teamTarget.includes(':') ? null : queryDetachedTeamSession(sessionName);
-    if (sessionIncarnation && sessionIncarnation.status !== 'exact') {
-      throw new Error(`tmux_session_incarnation_unavailable:${sessionName}`);
-    }
     return {
       name: teamTarget,
-      tmuxSessionId: sessionIncarnation?.incarnation.sessionId,
-      tmuxSessionCreated: sessionIncarnation?.incarnation.sessionCreated,
+      tmuxSessionId: leaderSource.sessionId,
+      tmuxSessionCreated: leaderSource.sessionCreated,
+
       workerCount,
       cwd,
       workerPaneIds,
@@ -2590,6 +2706,9 @@ export function createTeamSession(
       workerPanePidsByIndex,
       leaderPanePid,
       workerStartupArgs: Object.freeze(workerStartupArgs),
+      leaderSessionId: leaderSource.sessionId,
+      leaderSessionCreated: leaderSource.sessionCreated,
+      leaderWindowId: leaderSource.windowId,
       hudPanePid: partialHudPanePid,
 
       leaderPaneId,


### PR DESCRIPTION
Closes #3123

## Summary
- emit native PowerShell `$env:` assignments plus `&` for Team and standalone HUD startup, preserving paths and values containing spaces or embedded single quotes
- keep generated HUD ownership metadata readable through the canonical HUD reader while rejecting malformed, mixed, duplicate, quoted-string, and comment lookalikes fail-closed
- snapshot native-Windows target and server-global pane IDs before creation, accept exactly one canonical split result, and require consecutive exact global `<pane_id> 0` observations before use
- restrict rollback to provenance-approved operation-created panes; leader, cross-window/pre-existing, duplicate, ambiguous, and malformed IDs never gain destructive authority
- preserve existing POSIX/MSYS command shapes, encoded native worker startup, direct native HUD resize, mismatched-owner/unreadable-owner shutdown behavior, and intentional pre-creation HUD cleanup

`src/team/__tests__/runtime.test.ts` is the one documented exception to the original four-file plan: its native-Windows shutdown mock needed stateful global snapshot/liveness responses so the broader regression gate exercised the new contract instead of failing from stale fixture topology.

## Verification
Contract tests: Linux fixtures.

- `npm run build` — pass
- `node --test dist/hud/__tests__/tmux.test.js dist/team/__tests__/tmux-session.test.js` — 280/280 pass
- focused native shutdown regression — 1/1 pass
- `node dist/scripts/run-test-files.js dist/hud/__tests__ dist/team/__tests__` — 49 test files pass
- `npm run lint` — pass
- `npm run check:no-unused` — pass
- `git diff --check` — pass
- current `origin/dev` baseline comparison for the six previously failing startup/shutdown cases — 6/6 pass on baseline and 6/6 pass on the branch after the issue-scoped fixes

Independent exact-head gates for `87279997415ed7c9c89f76c38284408c932c3c74`:
- Architect: CLEAR / APPROVE, no blockers
- Executor QA/red-team: APPROVE, no blockers

## Scope boundaries
- #3121 retains broader send/notify/PID/kill/teardown exact-live ownership
- #3122 retains pane-owner option fallback
- #3124 retains Git Bash data-plane / PowerShell control-plane bridging
- no release, publish, or merge action is included

Real Windows/psmux runtime: not run. Linux mocked `win32` fixtures prove command/parser/lifecycle contracts only.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*