### PR TITLE
fix(team): coalesce mailbox reminder queues

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -319,6 +319,197 @@ describe('notify-hook team dispatch consumer', () => {
     }
   });
 
+  it('uses Team-scoped bridge mailbox delivery state when suppressing stale reminders', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-bridge-mailbox-'));
+    const previousRuntimeBridge = process.env.OMX_RUNTIME_BRIDGE;
+    try {
+      process.env.OMX_RUNTIME_BRIDGE = '0';
+      await initTeamState('alpha-bridge-mailbox', 'task', 'executor', 1, cwd);
+      await initTeamState('beta-bridge-mailbox', 'task', 'executor', 1, cwd);
+      const msg = await sendDirectMessage('alpha-bridge-mailbox', 'worker-1', 'worker-1', 'hello', cwd);
+      const otherTeamMsg = await sendDirectMessage('beta-bridge-mailbox', 'leader-fixed', 'worker-1', 'other team', cwd);
+      const queued = await enqueueDispatchRequest('alpha-bridge-mailbox', {
+        kind: 'mailbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        message_id: msg.message_id,
+        trigger_message: 'check mailbox',
+        intent: 'pending-mailbox-review',
+      }, cwd);
+      if (previousRuntimeBridge === undefined) delete process.env.OMX_RUNTIME_BRIDGE;
+      else process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+
+      await writeFile(join(cwd, '.omx', 'state', 'mailbox.json'), JSON.stringify({
+        records: [
+          {
+            message_id: msg.message_id,
+            from_worker: 'worker-1',
+            to_worker: 'worker-1',
+            body: 'hello',
+            created_at: msg.created_at,
+            notified_at: null,
+            delivered_at: new Date().toISOString(),
+          },
+          {
+            message_id: otherTeamMsg.message_id,
+            from_worker: 'leader-fixed',
+            to_worker: 'worker-1',
+            body: 'other team',
+            created_at: otherTeamMsg.created_at,
+            notified_at: null,
+            delivered_at: null,
+          },
+        ],
+      }, null, 2));
+
+      let injectCount = 0;
+      const modulePath = new URL('../../../dist/scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
+      const mod = await import(pathToFileURL(modulePath).href);
+      const result = await mod.drainPendingTeamDispatch({
+        cwd,
+        maxPerTick: 5,
+        injector: async () => {
+          injectCount += 1;
+          return { ok: true, reason: 'should_not_inject' };
+        },
+      });
+
+      assert.equal(result.processed, 1);
+      assert.equal(injectCount, 0);
+      const request = await readDispatchRequest('alpha-bridge-mailbox', queued.request.request_id, cwd);
+      assert.equal(request?.status, 'delivered');
+      assert.equal(request?.last_reason, 'mailbox_already_delivered');
+      const legacyMailbox = JSON.parse(await readFile(
+        join(cwd, '.omx', 'state', 'team', 'alpha-bridge-mailbox', 'mailbox', 'worker-1.json'),
+        'utf8',
+      ));
+      assert.equal(legacyMailbox.messages[0]?.delivered_at, undefined);
+    } finally {
+      if (previousRuntimeBridge === undefined) delete process.env.OMX_RUNTIME_BRIDGE;
+      else process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to legacy mailbox state when the bridge lacks the requested message', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-bridge-mailbox-miss-'));
+    const previousRuntimeBridge = process.env.OMX_RUNTIME_BRIDGE;
+    try {
+      process.env.OMX_RUNTIME_BRIDGE = '0';
+      await initTeamState('alpha-bridge-mailbox-miss', 'task', 'executor', 1, cwd);
+      const msg = await sendDirectMessage('alpha-bridge-mailbox-miss', 'worker-1', 'worker-1', 'legacy hello', cwd);
+      const queued = await enqueueDispatchRequest('alpha-bridge-mailbox-miss', {
+        kind: 'mailbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        message_id: msg.message_id,
+        trigger_message: 'check mailbox',
+        intent: 'pending-mailbox-review',
+      }, cwd);
+      if (previousRuntimeBridge === undefined) delete process.env.OMX_RUNTIME_BRIDGE;
+      else process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+
+      await writeFile(join(cwd, '.omx', 'state', 'mailbox.json'), JSON.stringify({
+        records: [{
+          message_id: 'unrelated-bridge-message',
+          from_worker: 'worker-1',
+          to_worker: 'worker-1',
+          body: 'already delivered',
+          created_at: msg.created_at,
+          notified_at: null,
+          delivered_at: new Date().toISOString(),
+        }],
+      }, null, 2));
+
+      let injectCount = 0;
+      const modulePath = new URL('../../../dist/scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
+      const mod = await import(pathToFileURL(modulePath).href);
+      const result = await mod.drainPendingTeamDispatch({
+        cwd,
+        maxPerTick: 5,
+        injector: async () => {
+          injectCount += 1;
+          return { ok: true, reason: 'legacy_mailbox_injected' };
+        },
+      });
+
+      assert.equal(result.processed, 1);
+      assert.equal(injectCount, 1);
+      const request = await readDispatchRequest('alpha-bridge-mailbox-miss', queued.request.request_id, cwd);
+      assert.equal(request?.status, 'notified');
+      assert.equal(request?.last_reason, 'legacy_mailbox_injected');
+    } finally {
+      if (previousRuntimeBridge === undefined) delete process.env.OMX_RUNTIME_BRIDGE;
+      else process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps a coalesced reminder live for a legacy-only unread Team message', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-mixed-mailbox-'));
+    const previousRuntimeBridge = process.env.OMX_RUNTIME_BRIDGE;
+    try {
+      process.env.OMX_RUNTIME_BRIDGE = '0';
+      await initTeamState('mixed-mailbox', 'task', 'executor', 1, cwd);
+      const first = await sendDirectMessage('mixed-mailbox', 'leader-fixed', 'worker-1', 'bridge-visible', cwd);
+      const firstRequest = await enqueueDispatchRequest('mixed-mailbox', {
+        kind: 'mailbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        message_id: first.message_id,
+        trigger_message: 'check mailbox',
+        intent: 'pending-mailbox-review',
+      }, cwd);
+      const second = await sendDirectMessage('mixed-mailbox', 'leader-fixed', 'worker-1', 'legacy-only', cwd);
+      const coalesced = await enqueueDispatchRequest('mixed-mailbox', {
+        kind: 'mailbox',
+        to_worker: 'worker-1',
+        worker_index: 1,
+        message_id: second.message_id,
+        trigger_message: 'check mailbox again',
+        intent: 'pending-mailbox-review',
+      }, cwd);
+      assert.equal(coalesced.deduped, true);
+      assert.equal(coalesced.request.request_id, firstRequest.request.request_id);
+      if (previousRuntimeBridge === undefined) delete process.env.OMX_RUNTIME_BRIDGE;
+      else process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+
+      await writeFile(join(cwd, '.omx', 'state', 'mailbox.json'), JSON.stringify({
+        records: [{
+          message_id: first.message_id,
+          from_worker: 'leader-fixed',
+          to_worker: 'worker-1',
+          body: 'bridge-visible',
+          created_at: first.created_at,
+          notified_at: null,
+          delivered_at: new Date().toISOString(),
+        }],
+      }, null, 2));
+
+      let injectCount = 0;
+      const modulePath = new URL('../../../dist/scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
+      const mod = await import(pathToFileURL(modulePath).href);
+      const result = await mod.drainPendingTeamDispatch({
+        cwd,
+        maxPerTick: 5,
+        injector: async () => {
+          injectCount += 1;
+          return { ok: true, reason: 'coalesced_legacy_message_injected' };
+        },
+      });
+
+      assert.equal(result.processed, 1);
+      assert.equal(injectCount, 1);
+      const request = await readDispatchRequest('mixed-mailbox', firstRequest.request.request_id, cwd);
+      assert.equal(request?.status, 'notified');
+      assert.equal(request?.last_reason, 'coalesced_legacy_message_injected');
+    } finally {
+      if (previousRuntimeBridge === undefined) delete process.env.OMX_RUNTIME_BRIDGE;
+      else process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('leader-fixed dispatch remains pending with leader_pane_missing_deferred when pane missing', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
     try {

--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -10,6 +10,7 @@ import {
   readDispatchRequest,
   listMailboxMessages,
   sendDirectMessage,
+  markMessageDelivered,
   readTeamConfig,
   saveTeamConfig,
 } from '../../team/state.js';
@@ -277,6 +278,47 @@ describe('notify-hook team dispatch consumer', () => {
     }
   });
 
+  it('suppresses a stale mailbox reminder after its mailbox has been drained', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-stale-'));
+    try {
+      await initTeamState('alpha-stale', 'task', 'executor', 1, cwd);
+      const msg = await sendDirectMessage('alpha-stale', 'worker-1', 'leader-fixed', 'hello', cwd);
+      const queued = await enqueueDispatchRequest('alpha-stale', {
+        kind: 'mailbox',
+        to_worker: 'leader-fixed',
+        message_id: msg.message_id,
+        trigger_message: 'check mailbox',
+        intent: 'pending-mailbox-review',
+      }, cwd);
+      await markMessageDelivered('alpha-stale', 'leader-fixed', msg.message_id, cwd);
+
+      let injectCount = 0;
+      const modulePath = new URL('../../../dist/scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
+      const mod = await import(pathToFileURL(modulePath).href);
+      const result = await mod.drainPendingTeamDispatch({
+        cwd,
+        maxPerTick: 5,
+        injector: async () => {
+          injectCount += 1;
+          return { ok: true, reason: 'should_not_inject' };
+        },
+      });
+
+      assert.equal(result.processed, 1);
+      assert.equal(injectCount, 0);
+      const request = await readDispatchRequest('alpha-stale', queued.request.request_id, cwd);
+      assert.equal(request?.status, 'delivered');
+      assert.equal(request?.last_reason, 'mailbox_already_delivered');
+      const cooldown = JSON.parse(await readFile(
+        join(cwd, '.omx', 'state', 'team', 'alpha-stale', 'dispatch', 'trigger-cooldown.json'),
+        'utf8',
+      ));
+      assert.deepEqual(cooldown.by_trigger, {});
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('leader-fixed dispatch remains pending with leader_pane_missing_deferred when pane missing', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
     try {
@@ -472,6 +514,7 @@ exit 1
         worker_index: 1,
         message_id: msg.message_id,
         trigger_message: 'check mailbox',
+        intent: 'pending-mailbox-review',
       }, cwd);
 
       const modulePath = new URL('../../../dist/scripts/notify-hook/team-dispatch.js', import.meta.url).pathname;
@@ -485,6 +528,11 @@ exit 1
       assert.equal(result.processed, 1);
       const request = await readDispatchRequest('alpha', queued.request.request_id, cwd);
       assert.equal(request?.status, 'notified');
+      assert.equal(request?.intent, 'pending-mailbox-review');
+
+      const dispatch = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'dispatch.json'), 'utf8'));
+      const record = dispatch.records.find((entry: { request_id?: string }) => entry.request_id === queued.request.request_id);
+      assert.equal(record?.metadata?.intent, 'pending-mailbox-review');
 
       const mailbox = await listMailboxMessages('alpha', 'worker-1', cwd);
       assert.equal(mailbox.length, 1);

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -1033,10 +1033,18 @@ describe('notify-hook team leader nudge', () => {
         worker: 'leader-fixed',
         messages: [
           {
+            message_id: 'm0-delivered',
+            from_worker: 'worker-1',
+            to_worker: 'leader-fixed',
+            body: 'old update',
+            created_at: '2026-02-13T00:00:00.000Z',
+            delivered_at: '2026-02-13T00:01:00.000Z',
+          },
+          {
             message_id: 'm1',
             from_worker: 'worker-1',
             to_worker: 'leader-fixed',
-            body: 'ACK',
+            body: 'please review',
             created_at: '2026-02-14T00:00:00.000Z',
           },
         ],
@@ -1053,6 +1061,7 @@ describe('notify-hook team leader nudge', () => {
       assert.match(tmuxLog, /-t %91/);
       assert.doesNotMatch(tmuxLog, /-t devsess:0/);
       assert.match(tmuxLog, /Team alpha:/);
+      assert.match(tmuxLog, /Team alpha: 1 msg\(s\) for leader\./);
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should include injection marker');
 
       const deliveryLog = await readTeamDeliveryLog(cwd);

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -1075,6 +1075,74 @@ describe('notify-hook team leader nudge', () => {
     });
   });
 
+  it('uses bridge delivery state for Team-scoped leader unread attention', async () => {
+    await withTempWorkingDir(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      const logsDir = join(cwd, '.omx', 'logs');
+      const teamName = 'bridge-leader-delivered';
+      const teamDir = join(stateDir, 'team', teamName);
+      const mailboxDir = join(teamDir, 'mailbox');
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const fakeTmuxPath = join(fakeBinDir, 'tmux');
+      const tmuxLogPath = join(cwd, 'tmux.log');
+      const messageId = 'bridge-delivered-leader-message';
+
+      await mkdir(logsDir, { recursive: true });
+      await mkdir(mailboxDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeJson(join(stateDir, 'team-state.json'), {
+        active: true,
+        team_name: teamName,
+        current_phase: 'team-exec',
+      });
+      await writeJson(join(teamDir, 'config.json'), {
+        name: teamName,
+        tmux_session: 'bridge-leader-delivered:0',
+        leader_pane_id: '%91',
+      });
+      await writeJson(join(mailboxDir, 'leader-fixed.json'), {
+        worker: 'leader-fixed',
+        messages: [{
+          message_id: messageId,
+          from_worker: 'worker-1',
+          to_worker: 'leader-fixed',
+          body: 'already handled',
+          created_at: '2026-02-14T00:00:00.000Z',
+        }],
+      });
+      await writeJson(join(stateDir, 'mailbox.json'), {
+        records: [{
+          message_id: messageId,
+          from_worker: 'worker-1',
+          to_worker: 'leader-fixed',
+          body: 'already handled',
+          created_at: '2026-02-14T00:00:00.000Z',
+          notified_at: '2026-02-14T00:00:30.000Z',
+          delivered_at: '2026-02-14T00:01:00.000Z',
+        }],
+      });
+      await writeFile(fakeTmuxPath, buildFakeTmux(tmuxLogPath));
+      await chmod(fakeTmuxPath, 0o755);
+
+      await withProcessEnv({ PATH: `${fakeBinDir}:${process.env.PATH || ''}` }, async () => {
+        await maybeNudgeTeamLeader({
+          cwd,
+          stateDir,
+          logsDir,
+          preComputedLeaderStale: false,
+        });
+      });
+
+      if (existsSync(tmuxLogPath)) {
+        assert.doesNotMatch(await readFile(tmuxLogPath, 'utf-8'), /send-keys/);
+      }
+      const attention = JSON.parse(await readFile(join(teamDir, 'leader-attention.json'), 'utf-8'));
+      assert.equal(attention.unread_leader_message_count, 0);
+      assert.equal(attention.leader_attention_pending, false);
+      assert.equal(attention.leader_attention_reason, null);
+    });
+  });
+
   it('suppresses leader mailbox nudge when team state disappears before injection', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');
@@ -1696,7 +1764,7 @@ exit 0
 
 
 
-  it('does not re-nudge for the same fresh mailbox message on repeated notify-hook runs', async () => {
+  it('keeps the fresh-mailbox high-water mark when the newest message is delivered', async () => {
     await withTempWorkingDir(async (cwd) => {
       const omxDir = join(cwd, '.omx');
       const stateDir = join(omxDir, 'state');
@@ -1750,9 +1818,89 @@ exit 0
       const second = runNotifyHook(cwd, fakeBinDir, { OMX_TEAM_LEADER_NUDGE_MS: '600000' });
       assert.equal(second.status, 0, `notify-hook failed: ${second.stderr || second.stdout}`);
 
+      await writeJson(join(mailboxDir, 'leader-fixed.json'), {
+        worker: 'leader-fixed',
+        messages: [
+          {
+            message_id: 'same-msg-1',
+            from_worker: 'worker-1',
+            to_worker: 'leader-fixed',
+            body: 'please review',
+            created_at: '2026-02-14T00:00:00.000Z',
+          },
+          {
+            message_id: 'new-msg-2',
+            from_worker: 'worker-1',
+            to_worker: 'leader-fixed',
+            body: 'new review',
+            created_at: '2026-02-14T00:01:00.000Z',
+          },
+        ],
+      });
+      const third = runNotifyHook(cwd, fakeBinDir, { OMX_TEAM_LEADER_NUDGE_MS: '600000' });
+      assert.equal(third.status, 0, `notify-hook failed: ${third.stderr || third.stdout}`);
+
+      await writeJson(join(mailboxDir, 'leader-fixed.json'), {
+        worker: 'leader-fixed',
+        messages: [
+          {
+            message_id: 'same-msg-1',
+            from_worker: 'worker-1',
+            to_worker: 'leader-fixed',
+            body: 'please review',
+            created_at: '2026-02-14T00:00:00.000Z',
+          },
+          {
+            message_id: 'new-msg-2',
+            from_worker: 'worker-1',
+            to_worker: 'leader-fixed',
+            body: 'new review',
+            created_at: '2026-02-14T00:01:00.000Z',
+            delivered_at: new Date().toISOString(),
+          },
+        ],
+      });
+      const fourth = runNotifyHook(cwd, fakeBinDir, { OMX_TEAM_LEADER_NUDGE_MS: '600000' });
+      assert.equal(fourth.status, 0, `notify-hook failed: ${fourth.stderr || fourth.stdout}`);
+
+      await writeJson(join(mailboxDir, 'leader-fixed.json'), {
+        worker: 'leader-fixed',
+        messages: [
+          {
+            message_id: 'same-msg-1',
+            from_worker: 'worker-1',
+            to_worker: 'leader-fixed',
+            body: 'please review',
+            created_at: '2026-02-14T00:00:00.000Z',
+            delivered_at: new Date().toISOString(),
+          },
+          {
+            message_id: 'new-msg-2',
+            from_worker: 'worker-1',
+            to_worker: 'leader-fixed',
+            body: 'new review',
+            created_at: '2026-02-14T00:01:00.000Z',
+            delivered_at: new Date().toISOString(),
+          },
+          {
+            message_id: 'delivered-msg-3',
+            from_worker: 'worker-1',
+            to_worker: 'leader-fixed',
+            body: 'already read',
+            created_at: '2026-02-14T00:02:00.000Z',
+            delivered_at: new Date().toISOString(),
+          },
+        ],
+      });
+      const fifth = runNotifyHook(cwd, fakeBinDir, { OMX_TEAM_LEADER_NUDGE_MS: '600000' });
+      assert.equal(fifth.status, 0, `notify-hook failed: ${fifth.stderr || fifth.stdout}`);
+
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      const sends = tmuxLog.match(/send-keys -t %97 -l Team fresh-mailbox-bounded: 1 msg\(s\) for leader\./g) || [];
-      assert.equal(sends.length, 1, 'same mailbox message should not trigger repeated non-stale nudges');
+      const sends = tmuxLog.match(/send-keys -t %97 -l Team fresh-mailbox-bounded: [12] msg\(s\) for leader\./g) || [];
+      assert.equal(sends.length, 2, 'delivering the newest message must not reclassify an older covered message as new');
+      assert.doesNotMatch(tmuxLog, /Team fresh-mailbox-bounded: 0 msg\(s\) for leader\./);
+      const nudgeState = JSON.parse(await readFile(join(stateDir, 'team-leader-nudge.json'), 'utf-8'));
+      assert.equal(nudgeState.last_nudged_by_team[teamName]?.last_message_id, 'new-msg-2');
     });
   });
 

--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -158,6 +158,7 @@ async function readBridgeDispatchRequests(stateDir, teamName) {
         worker_index: typeof metadata.worker_index === 'number' ? metadata.worker_index : undefined,
         pane_id: safeString(metadata.pane_id).trim() || undefined,
         trigger_message: safeString(metadata.trigger_message).trim() || safeString(record.reason).trim() || safeString(record.request_id).trim(),
+        intent: safeString(metadata.intent).trim() || undefined,
         message_id: safeString(metadata.message_id).trim() || undefined,
         inbox_correlation_key: safeString(metadata.inbox_correlation_key).trim() || undefined,
         transport_preference: safeString(metadata.transport_preference).trim() || 'hook_preferred_with_fallback',
@@ -196,6 +197,7 @@ const DEFAULT_DISPATCH_TRIGGER_COOLDOWN_MS = 30 * 1000;
 const DISPATCH_TRIGGER_COOLDOWN_ENV = 'OMX_TEAM_DISPATCH_TRIGGER_COOLDOWN_MS';
 const LEADER_PANE_MISSING_DEFERRED_REASON = 'leader_pane_missing_deferred';
 const LEADER_NOTIFICATION_DEFERRED_TYPE = 'leader_notification_deferred';
+const MAILBOX_ALREADY_DELIVERED_REASON = 'mailbox_already_delivered';
 
 async function emitOperationalHookEvent(cwd, eventName, context) {
   try {
@@ -435,6 +437,7 @@ function serializeDispatchRequestRecord(request) {
       worker_index: Number.isFinite(request.worker_index) ? Number(request.worker_index) : undefined,
       pane_id: safeString(request.pane_id).trim() || undefined,
       trigger_message: safeString(request.trigger_message).trim(),
+      intent: safeString(request.intent).trim() || undefined,
       message_id: safeString(request.message_id).trim() || undefined,
       inbox_correlation_key: safeString(request.inbox_correlation_key).trim() || undefined,
       transport_preference: safeString(request.transport_preference).trim() || 'hook_preferred_with_fallback',
@@ -542,22 +545,42 @@ async function finalizeClaimedDispatchRequest({
     const nowIso = new Date().toISOString();
     let mutated = false;
 
-    mutated = reserveDispatchCooldowns({
-      issueCooldownMs,
-      triggerCooldownMs,
-      issueCooldownByIssue,
-      triggerCooldownByKey,
-      issueKey,
-      triggerKey,
-      requestId: request.request_id,
-    }) || mutated;
+    if (result.reason !== MAILBOX_ALREADY_DELIVERED_REASON) {
+      mutated = reserveDispatchCooldowns({
+        issueCooldownMs,
+        triggerCooldownMs,
+        issueCooldownByIssue,
+        triggerCooldownByKey,
+        issueKey,
+        triggerKey,
+        requestId: request.request_id,
+      }) || mutated;
+    }
 
     request.attempt_count = Number.isFinite(request.attempt_count) ? Math.max(0, request.attempt_count + 1) : 1;
     request.updated_at = nowIso;
 
     if (result.ok) {
       const MAX_UNCONFIRMED_ATTEMPTS = 3;
-      if (result.reason === 'tmux_send_keys_unconfirmed' && request.attempt_count < MAX_UNCONFIRMED_ATTEMPTS) {
+      if (result.reason === MAILBOX_ALREADY_DELIVERED_REASON) {
+        request.status = 'delivered';
+        request.notified_at = request.notified_at || nowIso;
+        request.delivered_at = nowIso;
+        request.last_reason = result.reason;
+        runtimeExec({ command: 'MarkNotified', request_id: request.request_id, channel: 'mailbox_state' }, stateDir, teamName);
+        runtimeExec({ command: 'MarkDelivered', request_id: request.request_id }, stateDir, teamName);
+        summary.processed += 1;
+        mutated = true;
+        await appendDispatchLog(logsDir, {
+          type: 'dispatch_suppressed',
+          team: teamName,
+          request_id: request.request_id,
+          worker: request.to_worker,
+          message_id: request.message_id || null,
+          reason: result.reason,
+          ...buildDispatchAttemptEvidence(result),
+        });
+      } else if (result.reason === 'tmux_send_keys_unconfirmed' && request.attempt_count < MAX_UNCONFIRMED_ATTEMPTS) {
         request.last_reason = result.reason;
         summary.skipped += 1;
         mutated = true;
@@ -929,6 +952,50 @@ function shouldSkipRequest(request) {
   return preference !== '' && preference !== 'hook_preferred_with_fallback';
 }
 
+async function mailboxReminderStillNeeded(stateDir, teamName, teamDirPath, request) {
+  if (request.kind !== 'mailbox') return true;
+  const workerName = safeString(request.to_worker).trim();
+  if (!workerName) return true;
+  const mailbox = await readJson(join(teamDirPath, 'mailbox', `${workerName}.json`), null);
+  const legacyMessages = mailbox && Array.isArray(mailbox.messages) ? mailbox.messages : [];
+  const bridgeMailboxPath = join(stateDir, 'mailbox.json');
+  if (existsSync(bridgeMailboxPath)) {
+    try {
+      const bridgeMailbox = JSON.parse(await readFile(bridgeMailboxPath, 'utf8'));
+      if (bridgeMailbox && typeof bridgeMailbox === 'object') {
+        const records = Array.isArray(bridgeMailbox.records) ? bridgeMailbox.records : [];
+        const requestedMessageId = safeString(request.message_id).trim();
+        const hasRequestedMessage = requestedMessageId !== '' && records.some((message) =>
+          safeString(message?.message_id).trim() === requestedMessageId
+          && safeString(message?.to_worker).trim() === workerName);
+        if (hasRequestedMessage) {
+          const bridgeByMessageId = new Map(records
+            .filter((message) => safeString(message?.to_worker).trim() === workerName)
+            .map((message) => [safeString(message?.message_id).trim(), message])
+            .filter(([messageId]) => Boolean(messageId)));
+          const mergedTeamMessages = legacyMessages.map((message) =>
+            bridgeByMessageId.get(safeString(message?.message_id).trim()) ?? message);
+          if (!legacyMessages.some((message) => safeString(message?.message_id).trim() === requestedMessageId)) {
+            mergedTeamMessages.push(bridgeByMessageId.get(requestedMessageId));
+          }
+          return mergedTeamMessages.some((message) =>
+            message && !safeString(message?.delivered_at).trim());
+        }
+      }
+    } catch (error) {
+      recordBridgeFallback({
+        stateDir,
+        team: teamName,
+        operation: 'readBridgeMailboxMessages',
+        fallbackTarget: 'legacy_mailbox',
+        reason: `parse_failed:${bridgeErrorReason(error)}`,
+      });
+    }
+  }
+  if (!mailbox || !Array.isArray(mailbox.messages)) return true;
+  return legacyMessages.some((message) => !safeString(message?.delivered_at).trim());
+}
+
 async function updateMailboxNotified(stateDir, teamName, workerName, messageId) {
   const teamDirPath = join(stateDir, 'team', teamName);
   const mailboxPath = join(teamDirPath, 'mailbox', `${workerName}.json`);
@@ -1021,6 +1088,16 @@ export async function drainPendingTeamDispatch({
         if (!request || typeof request !== 'object') continue;
         if (shouldSkipRequest(request)) {
           skipped += 1;
+          continue;
+        }
+
+        if (!await mailboxReminderStillNeeded(stateDir, teamName, teamDirPath, request)) {
+          const lease = await tryAcquireDispatchRequestLease(teamDirPath, request.request_id);
+          if (!lease) {
+            skipped += 1;
+            continue;
+          }
+          claims.push({ request: { ...request }, lease });
           continue;
         }
 
@@ -1129,7 +1206,14 @@ export async function drainPendingTeamDispatch({
     try {
       for (const claim of claims) {
         try {
-          const result = await injector(claim.request, config, resolve(cwd), stateDir);
+          const reminderNeeded = await mailboxReminderStillNeeded(stateDir, teamName, teamDirPath, claim.request);
+          const result = reminderNeeded
+            ? await injector(claim.request, config, resolve(cwd), stateDir)
+            : {
+                ok: true,
+                reason: MAILBOX_ALREADY_DELIVERED_REASON,
+                tmux_injection_attempted: false,
+              };
           const delta = await finalizeClaimedDispatchRequest({
             claim,
             result,

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -497,6 +497,33 @@ function normalizeMailboxMessages(rawMailbox) {
   return [];
 }
 
+async function readTeamMailboxMessages(stateDir, teamName, workerName) {
+  const legacyMailbox = await readJsonIfExists(
+    join(stateDir, 'team', teamName, 'mailbox', `${workerName}.json`),
+    null,
+  );
+  const legacyMessages = normalizeMailboxMessages(legacyMailbox);
+  const bridgeMailbox = await readJsonIfExists(join(stateDir, 'mailbox.json'), null);
+  const bridgeRecords = bridgeMailbox && Array.isArray(bridgeMailbox.records)
+    ? bridgeMailbox.records
+    : null;
+  if (!bridgeRecords) return legacyMessages;
+
+  const bridgeByMessageId = new Map(bridgeRecords
+    .filter((message) => safeString(message?.to_worker).trim() === workerName)
+    .map((message) => [safeString(message?.message_id).trim(), message])
+    .filter(([messageId]) => Boolean(messageId)));
+  return legacyMessages.map((message) => {
+    const bridgeMessage = bridgeByMessageId.get(safeString(message?.message_id).trim());
+    if (!bridgeMessage) return message;
+    return {
+      ...message,
+      ...bridgeMessage,
+      body: safeString(bridgeMessage?.body).trim() || message?.body,
+    };
+  });
+}
+
 function normalizeMessageIdentity(msg) {
   if (!msg || typeof msg !== 'object') return '';
   const explicitId = safeString(msg.message_id || '').trim();
@@ -744,14 +771,9 @@ export async function maybeNudgeTeamLeader({
       // ignore
     }
     if (currentSessionId && ownerSessionId && ownerSessionId !== currentSessionId) continue;
-    let mailbox = null;
-    try {
-      const mailboxPath = join(omxDir, 'state', 'team', teamName, 'mailbox', 'leader-fixed.json');
-      mailbox = await readJsonIfExists(mailboxPath, null);
-    } catch {
-      mailbox = null;
-    }
-    const messages = normalizeMailboxMessages(mailbox);
+    const messages = await readTeamMailboxMessages(stateDir, teamName, 'leader-fixed').catch(() => []);
+    const unreadMessages = messages.filter((message) => !safeString(message?.delivered_at).trim());
+    const unreadLeaderMessageCount = unreadMessages.length;
     const newest = messages.length > 0 ? messages[messages.length - 1] : null;
     const newestId = normalizeMessageIdentity(newest);
 
@@ -845,7 +867,9 @@ export async function maybeNudgeTeamLeader({
     // This keeps the leader pane quieter when the leader is not actually stale.
     const stalePanesNudge = paneStatus.alive && leaderStale && !hasFreshProgressEvidence;
     const staleFollowupDue = stalePanesNudge && dueByTime;
-    const hasActionableNewMessage = hasNewMessage && (allowFreshMailboxNudges || leaderStale);
+    const hasActionableNewMessage = unreadLeaderMessageCount > 0
+      && hasNewMessage
+      && (allowFreshMailboxNudges || leaderStale);
 
     let nudgeReason = '';
     let text = '';
@@ -872,7 +896,7 @@ export async function maybeNudgeTeamLeader({
     } else if (stalePanesNudge && hasActionableNewMessage) {
       nudgeReason = 'stale_leader_with_messages';
       text =
-        `Team ${teamName}: leader stale, ${paneStatus.paneCount} pane(s) active, ${messages.length} msg(s) pending. `
+        `Team ${teamName}: leader stale, ${paneStatus.paneCount} pane(s) active, ${unreadLeaderMessageCount} msg(s) pending. `
         + buildMailboxCheckReminder(teamName);
     } else if (staleFollowupDue) {
       nudgeReason = 'stale_leader_panes_alive';
@@ -881,10 +905,9 @@ export async function maybeNudgeTeamLeader({
         + leaderActionGuidance;
     } else if (hasActionableNewMessage) {
       nudgeReason = 'new_mailbox_message';
-      text = `Team ${teamName}: ${messages.length} msg(s) for leader. ${buildMailboxCheckReminder(teamName)}`;
+      text = `Team ${teamName}: ${unreadLeaderMessageCount} msg(s) for leader. ${buildMailboxCheckReminder(teamName)}`;
     }
 
-    const unreadLeaderMessageCount = messages.filter((message) => !safeString(message?.delivered_at).trim()).length;
     const recordShutdownSuppression = async (orchestrationIntent = null) => {
       await recordSuppressedLeaderNudge({
         logsDir,

--- a/src/team/__tests__/delivery-e2e-smoke.test.ts
+++ b/src/team/__tests__/delivery-e2e-smoke.test.ts
@@ -349,7 +349,7 @@ describe('team message delivery end-to-end smoke tests', () => {
     }
   });
 
-  it('worker -> leader: concurrent worker sends preserve every message across mailbox and dispatch seams', async () => {
+  it('worker -> leader: concurrent sends preserve every message behind one leader reminder', async () => {
     const { cwd, cleanup } = await setupTeam('worker-leader-concurrent', 3);
     try {
       await withFakeTmux(cwd, async () => {
@@ -359,11 +359,16 @@ describe('team message delivery end-to-end smoke tests', () => {
           'worker-3': '%12',
         });
 
-        await Promise.all([
+        const results = await Promise.all([
           executeTeamApiOperation('send-message', { team_name: 'worker-leader-concurrent', from_worker: 'worker-1', to_worker: 'leader-fixed', body: 'msg-1' }, cwd),
           executeTeamApiOperation('send-message', { team_name: 'worker-leader-concurrent', from_worker: 'worker-2', to_worker: 'leader-fixed', body: 'msg-2' }, cwd),
           executeTeamApiOperation('send-message', { team_name: 'worker-leader-concurrent', from_worker: 'worker-3', to_worker: 'leader-fixed', body: 'msg-3' }, cwd),
         ]);
+        assert.equal(results.every((result) => result.ok), true);
+        const coalesced = results.filter((result) =>
+          result.ok
+          && (result.data.dispatch as { reason?: string } | undefined)?.reason === 'mailbox_reminder_coalesced');
+        assert.equal(coalesced.length, 2);
 
         const mailbox = await listMailboxMessages('worker-leader-concurrent', 'leader-fixed', cwd);
         const workerMessages = mailbox.filter((message) =>
@@ -371,13 +376,14 @@ describe('team message delivery end-to-end smoke tests', () => {
         assert.equal(workerMessages.length, 3);
         assert.deepEqual(new Set(workerMessages.map((message) => message.body)), new Set(['msg-1', 'msg-2', 'msg-3']));
         assert.equal(new Set(workerMessages.map((message) => message.message_id)).size, 3);
-        assert.equal(workerMessages.filter((message) => message.notified_at).length, 3);
+        assert.equal(workerMessages.filter((message) => message.notified_at).length, 1);
+        assert.equal(mailbox.filter((message) => message.from_worker === 'system').length, 0);
 
         const requests = await listDispatchRequests('worker-leader-concurrent', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
         const workerMessageIds = new Set(workerMessages.map((message) => message.message_id));
         const workerRequests = requests.filter((request) => request.message_id && workerMessageIds.has(request.message_id));
-        assert.equal(workerRequests.length, 3);
-        assert.equal(workerRequests.filter((request) => request.status === 'notified').length, 3);
+        assert.equal(workerRequests.length, 1);
+        assert.equal(workerRequests[0]?.status, 'notified');
       });
     } finally {
       await cleanup();
@@ -402,6 +408,43 @@ describe('team message delivery end-to-end smoke tests', () => {
 
         const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
         assert.match(tmuxLog, /send-keys -t %10/);
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('leader -> worker: burst sends persist every body behind one worker reminder', async () => {
+    const { cwd, cleanup } = await setupTeam('leader-worker-burst', 1);
+    try {
+      await withFakeTmux(cwd, async (tmuxLogPath) => {
+        await configurePaneIds('leader-worker-burst', cwd, '%95', { 'worker-1': '%10' });
+        const bodies = Array.from({ length: 8 }, (_, index) => `burst-${index + 1}`);
+        const results = await Promise.all(bodies.map((body) => executeTeamApiOperation('send-message', {
+          team_name: 'leader-worker-burst',
+          from_worker: 'leader-fixed',
+          to_worker: 'worker-1',
+          body,
+        }, cwd)));
+
+        assert.equal(results.every((result) => result.ok), true);
+        const coalesced = results.filter((result) =>
+          result.ok
+          && (result.data.dispatch as { reason?: string } | undefined)?.reason === 'mailbox_reminder_coalesced');
+        assert.equal(coalesced.length, bodies.length - 1);
+
+        const mailbox = await listMailboxMessages('leader-worker-burst', 'worker-1', cwd);
+        assert.equal(mailbox.length, bodies.length);
+        assert.deepEqual(new Set(mailbox.map((message) => message.body)), new Set(bodies));
+        assert.equal(new Set(mailbox.map((message) => message.message_id)).size, bodies.length);
+        assert.equal(mailbox.filter((message) => message.notified_at).length, 1);
+
+        const requests = await listDispatchRequests('leader-worker-burst', cwd, { kind: 'mailbox', to_worker: 'worker-1' });
+        assert.equal(requests.length, 1);
+        assert.equal(requests[0]?.status, 'notified');
+
+        const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+        assert.equal((tmuxLog.match(/You have 1 new message\(s\)/g) ?? []).length, 1);
       });
     } finally {
       await cleanup();

--- a/src/team/__tests__/mcp-comm.test.ts
+++ b/src/team/__tests__/mcp-comm.test.ts
@@ -174,6 +174,43 @@ describe('mcp-comm', () => {
     }
   });
 
+  it('queueDirectMailboxMessage coalesces different mailbox messages behind one pending reminder', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-mcp-comm-coalesce-'));
+    try {
+      await initTeamState('alpha-coalesce', 'task', 'executor', 1, cwd);
+      let notifyCount = 0;
+      const send = async (body: string) => await queueDirectMailboxMessage({
+        teamName: 'alpha-coalesce',
+        fromWorker: 'leader-fixed',
+        toWorker: 'worker-1',
+        toWorkerIndex: 1,
+        body,
+        triggerMessage: 'check mailbox',
+        intent: 'pending-mailbox-review',
+        cwd,
+        transportPreference: 'hook_preferred_with_fallback',
+        fallbackAllowed: true,
+        notify: async () => {
+          notifyCount += 1;
+          return { ok: true, transport: 'hook', reason: 'queued_for_hook_dispatch' };
+        },
+      });
+
+      const first = await send('first body');
+      const second = await send('second body');
+
+      assert.equal(first.reason, 'queued_for_hook_dispatch');
+      assert.equal(second.ok, true);
+      assert.equal(second.reason, 'mailbox_reminder_coalesced');
+      assert.equal(second.request_id, first.request_id);
+      assert.equal(notifyCount, 1);
+      assert.equal((await listMailboxMessages('alpha-coalesce', 'worker-1', cwd)).length, 2);
+      assert.equal((await listDispatchRequests('alpha-coalesce', cwd, { kind: 'mailbox', to_worker: 'worker-1' })).length, 1);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('queueBroadcastMailboxMessage notifies and marks notified per recipient', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-mcp-comm-'));
     try {

--- a/src/team/__tests__/mcp-comm.test.ts
+++ b/src/team/__tests__/mcp-comm.test.ts
@@ -211,6 +211,67 @@ describe('mcp-comm', () => {
     }
   });
 
+  it('does not report an overlapping direct mailbox send as successfully coalesced', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-mcp-comm-direct-overlap-'));
+    let releaseFirstNotify: () => void = () => {};
+    try {
+      await initTeamState('alpha-direct-overlap', 'task', 'executor', 1, cwd);
+      let firstNotifyStarted!: () => void;
+      const firstStarted = new Promise<void>((resolve) => {
+        firstNotifyStarted = resolve;
+      });
+      const firstNotifyGate = new Promise<void>((resolve) => {
+        releaseFirstNotify = resolve;
+      });
+
+      const firstPromise = queueDirectMailboxMessage({
+        teamName: 'alpha-direct-overlap',
+        fromWorker: 'leader-fixed',
+        toWorker: 'worker-1',
+        toWorkerIndex: 1,
+        body: 'first body',
+        triggerMessage: 'check mailbox',
+        intent: 'pending-mailbox-review',
+        cwd,
+        transportPreference: 'transport_direct',
+        fallbackAllowed: false,
+        notify: async () => {
+          firstNotifyStarted();
+          await firstNotifyGate;
+          return { ok: false, transport: 'tmux_send_keys', reason: 'first_direct_send_failed' };
+        },
+      });
+      await firstStarted;
+
+      const second = await queueDirectMailboxMessage({
+        teamName: 'alpha-direct-overlap',
+        fromWorker: 'leader-fixed',
+        toWorker: 'worker-1',
+        toWorkerIndex: 1,
+        body: 'second body',
+        triggerMessage: 'check mailbox',
+        intent: 'pending-mailbox-review',
+        cwd,
+        transportPreference: 'transport_direct',
+        fallbackAllowed: false,
+        notify: async () => ({ ok: false, transport: 'tmux_send_keys', reason: 'second_direct_send_failed' }),
+      });
+      releaseFirstNotify();
+      const first = await firstPromise;
+
+      assert.equal(first.ok, false);
+      assert.equal(second.ok, false);
+      assert.equal(second.reason, 'second_direct_send_failed');
+      assert.notEqual(second.request_id, first.request_id);
+      const requests = await listDispatchRequests('alpha-direct-overlap', cwd, { kind: 'mailbox' });
+      assert.equal(requests.length, 2);
+      assert.deepEqual(requests.map((request) => request.status), ['failed', 'failed']);
+    } finally {
+      releaseFirstNotify();
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('queueBroadcastMailboxMessage notifies and marks notified per recipient', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-mcp-comm-'));
     try {

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -9634,6 +9634,7 @@ esac
           const mailbox = await listMailboxMessages('team-leader-inject', 'leader-fixed', cwd);
           assert.ok(mailbox.some((m: { notified_at?: string }) => typeof m.notified_at === 'string' && m.notified_at.length > 0));
           assert.equal(mailbox[0]?.body, 'hello leader');
+          assert.equal(mailbox.filter((message) => message.from_worker === 'system').length, 0);
 
           const requests = await listDispatchRequests('team-leader-inject', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
           const latest = requests[requests.length - 1];

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -19,6 +19,7 @@ import {
   listDispatchRequests,
   enqueueDispatchRequest,
   sendDirectMessage,
+  markMessageDelivered,
   transitionDispatchRequest,
   updateWorkerHeartbeat,
   writeAtomic,
@@ -9449,7 +9450,7 @@ esac
           dirPrefix: 'omx-runtime-coalesced-pending-bin-',
           tmuxScript: () => `#!/bin/sh
 if [ "$1" = "list-panes" ]; then
-  echo "0 1234"
+  echo "0 ${process.pid}"
 fi
 `,
         },
@@ -9474,6 +9475,90 @@ fi
           await monitorTeam('team-coalesced-pending', cwd);
           const snapshot = await readMonitorSnapshot('team-coalesced-pending', cwd);
           assert.equal(snapshot?.mailboxNotifiedByMessageId[message.message_id], undefined);
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('monitorTeam makes failed direct mailbox reminders terminal before retrying newer mail', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-direct-reminder-retry-'));
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-direct-reminder-retry-bin-',
+          tmuxScript: () => `#!/bin/sh
+if [ "$1" = "-V" ]; then
+  echo "tmux 3.4"
+  exit 0
+fi
+if [ "$1" = "list-panes" ]; then
+  echo "0 ${process.pid}"
+  exit 0
+fi
+if [ "$1" = "send-keys" ]; then
+  exit 1
+fi
+exit 0
+`,
+        },
+        async () => {
+          await initTeamState('team-direct-reminder-retry', 'direct reminder retry', 'executor', 1, cwd);
+          const manifestPath = join(
+            cwd,
+            '.omx',
+            'state',
+            'team',
+            'team-direct-reminder-retry',
+            'manifest.v2.json',
+          );
+          const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
+          manifest.policy = { ...(manifest.policy || {}), dispatch_mode: 'transport_direct' };
+          await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+          const firstMessage = await sendDirectMessage(
+            'team-direct-reminder-retry',
+            'leader-fixed',
+            'worker-1',
+            'first',
+            cwd,
+          );
+          await monitorTeam('team-direct-reminder-retry', cwd);
+
+          const firstRequests = await listDispatchRequests(
+            'team-direct-reminder-retry',
+            cwd,
+            { kind: 'mailbox', to_worker: 'worker-1' },
+          );
+          assert.equal(firstRequests.length, 1);
+          assert.equal(firstRequests[0]?.status, 'failed');
+          assert.match(firstRequests[0]?.last_reason ?? '', /^tmux_send_keys_failed:/);
+
+          await markMessageDelivered(
+            'team-direct-reminder-retry',
+            'worker-1',
+            firstMessage.message_id,
+            cwd,
+          );
+          const secondMessage = await sendDirectMessage(
+            'team-direct-reminder-retry',
+            'leader-fixed',
+            'worker-1',
+            'second',
+            cwd,
+          );
+          await monitorTeam('team-direct-reminder-retry', cwd);
+
+          const requests = await listDispatchRequests(
+            'team-direct-reminder-retry',
+            cwd,
+            { kind: 'mailbox', to_worker: 'worker-1' },
+          );
+          assert.equal(requests.length, 2);
+          assert.notEqual(requests[1]?.request_id, requests[0]?.request_id);
+          assert.equal(requests[1]?.message_id, secondMessage.message_id);
+          assert.equal(requests[1]?.status, 'failed');
         },
       );
     } finally {

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -17,6 +17,8 @@ import {
   saveTeamConfig,
   listMailboxMessages,
   listDispatchRequests,
+  enqueueDispatchRequest,
+  sendDirectMessage,
   transitionDispatchRequest,
   updateWorkerHeartbeat,
   writeAtomic,
@@ -9433,6 +9435,46 @@ esac
       assert.ok(
         diskSnap3.mailboxNotifiedByMessageId['msg-unnotified'],
         'notified message must remain in snapshot on third poll (no duplicate notification)',
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('monitorTeam does not mark a coalesced pending reminder as notified', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-coalesced-pending-'));
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-coalesced-pending-bin-',
+          tmuxScript: () => `#!/bin/sh
+if [ "$1" = "list-panes" ]; then
+  echo "0 1234"
+fi
+`,
+        },
+        async () => {
+          await initTeamState('team-coalesced-pending', 'coalesced pending reminder', 'executor', 1, cwd);
+          const message = await sendDirectMessage(
+            'team-coalesced-pending',
+            'leader-fixed',
+            'worker-1',
+            'hello',
+            cwd,
+          );
+          await enqueueDispatchRequest('team-coalesced-pending', {
+            kind: 'mailbox',
+            to_worker: 'worker-1',
+            worker_index: 1,
+            message_id: message.message_id,
+            trigger_message: 'check mailbox',
+            intent: 'pending-mailbox-review',
+          }, cwd);
+
+          await monitorTeam('team-coalesced-pending', cwd);
+          const snapshot = await readMonitorSnapshot('team-coalesced-pending', cwd);
+          assert.equal(snapshot?.mailboxNotifiedByMessageId[message.message_id], undefined);
+        },
       );
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -483,6 +483,21 @@ exit 1
 
       const notified = await markDispatchRequestNotified('team-dispatch', first.request.request_id, {}, cwd);
       assert.equal(notified?.status, 'notified');
+
+      const coalescedWhileNotified = await enqueueDispatchRequest(
+        'team-dispatch',
+        {
+          kind: 'mailbox',
+          to_worker: 'worker-1',
+          message_id: 'msg-3',
+          trigger_message: 'check mailbox while reminder is in flight',
+          intent: 'pending-mailbox-review',
+        },
+        cwd,
+      );
+      assert.equal(coalescedWhileNotified.deduped, true);
+      assert.equal(coalescedWhileNotified.request.request_id, first.request.request_id);
+
       const notifiedAgain = await markDispatchRequestNotified('team-dispatch', first.request.request_id, {}, cwd);
       assert.equal(notifiedAgain?.status, 'notified');
       const delivered = await markDispatchRequestDelivered('team-dispatch', first.request.request_id, {}, cwd);

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -467,6 +467,20 @@ exit 1
       assert.equal(dup.deduped, true);
       assert.equal(dup.request.request_id, first.request.request_id);
 
+      const coalesced = await enqueueDispatchRequest(
+        'team-dispatch',
+        {
+          kind: 'mailbox',
+          to_worker: 'worker-1',
+          message_id: 'msg-2',
+          trigger_message: 'check mailbox again',
+          intent: 'pending-mailbox-review',
+        },
+        cwd,
+      );
+      assert.equal(coalesced.deduped, true);
+      assert.equal(coalesced.request.request_id, first.request.request_id);
+
       const notified = await markDispatchRequestNotified('team-dispatch', first.request.request_id, {}, cwd);
       assert.equal(notified?.status, 'notified');
       const notifiedAgain = await markDispatchRequestNotified('team-dispatch', first.request.request_id, {}, cwd);

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -441,12 +441,13 @@ exit 1
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-dispatch-store-'));
     try {
       await initTeamState('team-dispatch', 't', 'executor', 1, cwd);
+      const firstMessage = await sendDirectMessage('team-dispatch', 'leader-fixed', 'worker-1', 'first message', cwd);
       const first = await enqueueDispatchRequest(
         'team-dispatch',
         {
           kind: 'mailbox',
           to_worker: 'worker-1',
-          message_id: 'msg-1',
+          message_id: firstMessage.message_id,
           trigger_message: 'check mailbox',
           intent: 'pending-mailbox-review',
         },
@@ -459,7 +460,7 @@ exit 1
         {
           kind: 'mailbox',
           to_worker: 'worker-1',
-          message_id: 'msg-1',
+          message_id: firstMessage.message_id,
           trigger_message: 'check mailbox',
         },
         cwd,
@@ -504,8 +505,102 @@ exit 1
       assert.equal(delivered?.status, 'delivered');
       const listed = await listDispatchRequests('team-dispatch', cwd);
       assert.equal(listed.length, 1);
-      assert.equal(listed[0]?.message_id, 'msg-1');
+      assert.equal(listed[0]?.message_id, firstMessage.message_id);
       assert.equal(listed[0]?.intent, 'pending-mailbox-review');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not coalesce behind a notified reminder whose mailbox message was delivered', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-dispatch-delivered-reminder-'));
+    try {
+      await initTeamState('dispatch-delivered', 't', 'executor', 1, cwd);
+      const firstMessage = await sendDirectMessage(
+        'dispatch-delivered',
+        'leader-fixed',
+        'worker-1',
+        'first message',
+        cwd,
+      );
+      const first = await enqueueDispatchRequest(
+        'dispatch-delivered',
+        {
+          kind: 'mailbox',
+          to_worker: 'worker-1',
+          message_id: firstMessage.message_id,
+          trigger_message: 'check mailbox',
+          intent: 'pending-mailbox-review',
+        },
+        cwd,
+      );
+      await markDispatchRequestNotified('dispatch-delivered', first.request.request_id, {}, cwd);
+      await markMessageDelivered('dispatch-delivered', 'worker-1', firstMessage.message_id, cwd);
+
+      const secondMessage = await sendDirectMessage(
+        'dispatch-delivered',
+        'leader-fixed',
+        'worker-1',
+        'second message',
+        cwd,
+      );
+      const second = await enqueueDispatchRequest(
+        'dispatch-delivered',
+        {
+          kind: 'mailbox',
+          to_worker: 'worker-1',
+          message_id: secondMessage.message_id,
+          trigger_message: 'check mailbox again',
+          intent: 'pending-mailbox-review',
+        },
+        cwd,
+      );
+
+      assert.equal(second.deduped, false);
+      assert.notEqual(second.request.request_id, first.request.request_id);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('refreshes the worker target when coalescing mailbox reminders', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-dispatch-refresh-target-'));
+    try {
+      await initTeamState('dispatch-refresh-target', 't', 'executor', 1, cwd);
+      const first = await enqueueDispatchRequest(
+        'dispatch-refresh-target',
+        {
+          kind: 'mailbox',
+          to_worker: 'worker-1',
+          worker_index: 1,
+          pane_id: '%11',
+          message_id: 'refresh-target-1',
+          trigger_message: 'check mailbox',
+          intent: 'pending-mailbox-review',
+        },
+        cwd,
+      );
+      const second = await enqueueDispatchRequest(
+        'dispatch-refresh-target',
+        {
+          kind: 'mailbox',
+          to_worker: 'worker-1',
+          worker_index: 2,
+          pane_id: '%22',
+          message_id: 'refresh-target-2',
+          trigger_message: 'check mailbox again',
+          intent: 'pending-mailbox-review',
+        },
+        cwd,
+      );
+
+      assert.equal(second.deduped, true);
+      assert.equal(second.request.request_id, first.request.request_id);
+      assert.equal(second.request.worker_index, 2);
+      assert.equal(second.request.pane_id, '%22');
+      const stored = await readDispatchRequest('dispatch-refresh-target', first.request.request_id, cwd);
+      assert.equal(stored?.worker_index, 2);
+      assert.equal(stored?.pane_id, '%22');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/mcp-comm.ts
+++ b/src/team/mcp-comm.ts
@@ -286,13 +286,30 @@ export async function queueDirectMailboxMessage(params: QueueDirectMessageParams
   );
 
   if (queued.deduped) {
-    return {
-      ok: false,
-      transport: 'none',
-      reason: 'duplicate_pending_dispatch_request',
+    const hookReminderInFlight = queued.request.transport_preference === 'hook_preferred_with_fallback';
+    const outcome: DispatchOutcome = {
+      ok: hookReminderInFlight,
+      transport: hookReminderInFlight
+        ? (params.toWorker === 'leader-fixed' ? 'mailbox' : 'hook')
+        : 'none',
+      reason: hookReminderInFlight ? 'mailbox_reminder_coalesced' : 'mailbox_reminder_in_flight',
       request_id: queued.request.request_id,
       message_id: message.message_id,
+      to_worker: params.toWorker,
     };
+    await logDispatchOutcome({
+      cwd: params.cwd,
+      teamName: params.teamName,
+      source: 'team.mcp-comm',
+      requestId: queued.request.request_id,
+      messageId: message.message_id,
+      toWorker: params.toWorker,
+      dispatchKind: 'mailbox',
+      outcome,
+      intent: params.intent,
+      transportPreference: params.transportPreference,
+    });
+    return outcome;
   }
 
   const notifyOutcome = await Promise.resolve(params.notify(
@@ -402,10 +419,11 @@ export async function queueBroadcastMailboxMessage(params: QueueBroadcastParams)
     );
 
     if (queued.deduped) {
+      const hookReminderInFlight = queued.request.transport_preference === 'hook_preferred_with_fallback';
       outcomes.push({
-        ok: false,
-        transport: 'none',
-        reason: 'duplicate_pending_dispatch_request',
+        ok: hookReminderInFlight,
+        transport: hookReminderInFlight ? 'hook' : 'none',
+        reason: hookReminderInFlight ? 'mailbox_reminder_coalesced' : 'mailbox_reminder_in_flight',
         request_id: queued.request.request_id,
         message_id: message.message_id,
         to_worker: recipient.workerName,

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -5193,25 +5193,29 @@ async function deliverPendingMailboxMessages(
     //   - notified_at is set in the mailbox file (persisted by markMessageNotified), or
     //   - the message_id exists in previousNotifications from the last snapshot.
     // Both checks use Boolean() so an empty-string value is treated as unnotified.
+    const reminderInFlight = pending.some(
+      (m) => Boolean(m.notified_at || previousNotifications[m.message_id]),
+    );
+    if (reminderInFlight) continue;
+
     const unnotified = pending.filter(
       (m) => !m.notified_at && !previousNotifications[m.message_id],
     );
     if (unnotified.length === 0) continue;
     if (!worker.alive) continue;
 
-    for (const msg of unnotified) {
-      const outcome = await dispatchPendingMailboxMessage({
-        teamName,
-        workerName: worker.name,
-        workerInfo,
-        messageId: msg.message_id,
-        config,
-        dispatchPolicy,
-        cwd,
-      });
-      if (outcome.ok) {
-        nextNotifications[msg.message_id] = new Date().toISOString();
-      }
+    const msg = unnotified[0];
+    const outcome = await dispatchPendingMailboxMessage({
+      teamName,
+      workerName: worker.name,
+      workerInfo,
+      messageId: msg.message_id,
+      config,
+      dispatchPolicy,
+      cwd,
+    });
+    if (outcome.ok && !isCoalescedMailboxReminderOutcome(outcome)) {
+      nextNotifications[msg.message_id] = new Date().toISOString();
     }
   }
 
@@ -5281,12 +5285,11 @@ async function dispatchPendingMailboxMessage(params: {
   );
 
   if (queued.deduped) {
+    const hookReminderInFlight = transportPreference === 'hook_preferred_with_fallback';
     return {
-      ok: true,
-      transport: transportPreference === 'transport_direct'
-        ? 'tmux_send_keys'
-        : (transportPreference === 'prompt_stdin' ? 'prompt_stdin' : 'hook'),
-      reason: 'mailbox_reminder_coalesced',
+      ok: hookReminderInFlight,
+      transport: hookReminderInFlight ? 'hook' : 'none',
+      reason: hookReminderInFlight ? 'mailbox_reminder_coalesced' : 'mailbox_reminder_in_flight',
       request_id: queued.request.request_id,
       message_id: messageId,
     };
@@ -5322,6 +5325,15 @@ async function dispatchPendingMailboxMessage(params: {
     await markDispatchRequestNotified(
       teamName,
       queued.request.request_id,
+      { message_id: messageId, last_reason: outcome.reason },
+      cwd,
+    ).catch(() => null);
+  } else {
+    await transitionDispatchRequest(
+      teamName,
+      queued.request.request_id,
+      'pending',
+      'failed',
       { message_id: messageId, last_reason: outcome.reason },
       cwd,
     ).catch(() => null);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -5146,15 +5146,10 @@ async function finalizeHookPreferredMailboxDispatch(params: {
   return outcome;
 }
 
-async function notifyLeaderAsync(config: TeamConfig, message: string, cwd: string): Promise<DispatchOutcome> {
-  // Canonical leader delivery is durable mailbox persistence plus HUD-owned
-  // authority processing. Team runtime must not directly inject into the
-  // leader pane from this fallback path.
-  const { notifyLeaderMailboxAsync } = await import('./tmux-session.js');
-  const persisted = await notifyLeaderMailboxAsync(config.name, 'system', message, cwd);
-  if (!persisted) {
-    return { ok: false, transport: 'mailbox', reason: 'leader_mailbox_notify_failed' };
-  }
+async function notifyLeaderAsync(config: TeamConfig, _message: string, _cwd: string): Promise<DispatchOutcome> {
+  // queueDirectMailboxMessage has already persisted the original worker
+  // message. Leader attention is HUD-owned, so do not echo the reminder back
+  // into the same mailbox as a second synthetic `system` message.
   if (!config.leader_pane_id) {
     return { ok: true, transport: 'mailbox', reason: 'leader_pane_missing_mailbox_persisted' };
   }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -5243,6 +5243,10 @@ function isExistingMailboxNotificationOutcome(outcome: DispatchOutcome): boolean
   return outcome.ok && outcome.reason === 'existing_message_already_notified';
 }
 
+function isCoalescedMailboxReminderOutcome(outcome: DispatchOutcome): boolean {
+  return outcome.ok && outcome.reason === 'mailbox_reminder_coalesced';
+}
+
 async function dispatchPendingMailboxMessage(params: {
   teamName: string;
   workerName: string;
@@ -5275,6 +5279,18 @@ async function dispatchPendingMailboxMessage(params: {
     },
     cwd,
   );
+
+  if (queued.deduped) {
+    return {
+      ok: true,
+      transport: transportPreference === 'transport_direct'
+        ? 'tmux_send_keys'
+        : (transportPreference === 'prompt_stdin' ? 'prompt_stdin' : 'hook'),
+      reason: 'mailbox_reminder_coalesced',
+      request_id: queued.request.request_id,
+      message_id: messageId,
+    };
+  }
 
   if (transportPreference === 'hook_preferred_with_fallback') {
     return await finalizeQueuedMailboxDispatch({
@@ -5358,6 +5374,9 @@ async function finalizeQueuedMailboxDispatch(params: {
   if (isExistingMailboxNotificationOutcome(queuedOutcome)) {
     return queuedOutcome;
   }
+  if (isCoalescedMailboxReminderOutcome(queuedOutcome)) {
+    return queuedOutcome;
+  }
   if (!queuedOutcome.request_id || !messageId) {
     return { ...queuedOutcome, ok: false, reason: 'dispatch_request_missing_id' };
   }
@@ -5417,6 +5436,7 @@ async function sendLeaderMailboxMessage(params: {
 
   if (
     !isExistingMailboxNotificationOutcome(queuedOutcome)
+    && !isCoalescedMailboxReminderOutcome(queuedOutcome)
     && transportPreference === 'hook_preferred_with_fallback'
     && !config.leader_pane_id
   ) {
@@ -5448,6 +5468,7 @@ async function sendLeaderMailboxMessage(params: {
 
   if (
     !isExistingMailboxNotificationOutcome(queuedOutcome)
+    && !isCoalescedMailboxReminderOutcome(queuedOutcome)
     && transportPreference === 'transport_direct'
     && !config.leader_pane_id
   ) {

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -1535,6 +1535,21 @@ async function readLegacyMailbox(teamName: string, workerName: string, cwd: stri
   }
 }
 
+async function isMailboxMessageUndelivered(
+  teamName: string,
+  workerName: string,
+  messageId: string,
+  cwd: string,
+): Promise<boolean> {
+  const mailbox = await readMailbox(teamName, workerName, cwd);
+  const current = mailbox.messages.find((message) => message.message_id === messageId);
+  if (current) return !current.delivered_at;
+
+  const legacyMailbox = await readLegacyMailbox(teamName, workerName, cwd);
+  const legacy = legacyMailbox.messages.find((message) => message.message_id === messageId);
+  return Boolean(legacy && !legacy.delivered_at);
+}
+
 async function writeMailbox(teamName: string, mailbox: TeamMailbox, cwd: string): Promise<void> {
   const p = mailboxPath(teamName, mailbox.worker, cwd);
   await writeAtomic(p, JSON.stringify(mailbox, null, 2));
@@ -1641,6 +1656,8 @@ export async function enqueueDispatchRequest(
     withDispatchLock,
     readDispatchRequests,
     writeDispatchRequests,
+    isMailboxMessageUndelivered: async (workerName, messageId) =>
+      await isMailboxMessageUndelivered(teamName, workerName, messageId, cwd),
   });
 }
 

--- a/src/team/state/dispatch.ts
+++ b/src/team/state/dispatch.ts
@@ -133,7 +133,9 @@ function equivalentPendingDispatch(existing: TeamDispatchRequest, input: TeamDis
   if (existing.to_worker !== input.to_worker) return false;
 
   if (input.kind === 'mailbox') {
-    return Boolean(input.message_id) && existing.message_id === input.message_id;
+    if (Boolean(input.message_id) && existing.message_id === input.message_id) return true;
+    return input.intent === 'pending-mailbox-review'
+      && existing.intent === 'pending-mailbox-review';
   }
 
   if (input.kind === 'inbox' && input.inbox_correlation_key) {

--- a/src/team/state/dispatch.ts
+++ b/src/team/state/dispatch.ts
@@ -55,6 +55,7 @@ interface DispatchDeps {
   withDispatchLock: <T>(teamName: string, cwd: string, fn: () => Promise<T>) => Promise<T>;
   readDispatchRequests: (teamName: string, cwd: string) => Promise<TeamDispatchRequest[]>;
   writeDispatchRequests: (teamName: string, requests: TeamDispatchRequest[], cwd: string) => Promise<void>;
+  isMailboxMessageUndelivered?: (workerName: string, messageId: string) => Promise<boolean>;
 }
 
 function isDispatchKind(value: unknown): value is TeamDispatchRequestKind {
@@ -127,15 +128,20 @@ export function normalizeDispatchRequest(
   });
 }
 
-function equivalentPendingDispatch(existing: TeamDispatchRequest, input: TeamDispatchRequestInput): boolean {
-  if (existing.status !== 'pending') return false;
+function equivalentActiveDispatch(existing: TeamDispatchRequest, input: TeamDispatchRequestInput): boolean {
+  const inputTransport = input.transport_preference ?? 'hook_preferred_with_fallback';
+  const coalescibleMailboxReminder = input.kind === 'mailbox'
+    && input.intent === 'pending-mailbox-review'
+    && existing.intent === 'pending-mailbox-review'
+    && inputTransport === 'hook_preferred_with_fallback'
+    && existing.transport_preference === 'hook_preferred_with_fallback';
+  if (existing.status !== 'pending' && !(coalescibleMailboxReminder && existing.status === 'notified')) return false;
   if (existing.kind !== input.kind) return false;
   if (existing.to_worker !== input.to_worker) return false;
 
   if (input.kind === 'mailbox') {
     if (Boolean(input.message_id) && existing.message_id === input.message_id) return true;
-    return input.intent === 'pending-mailbox-review'
-      && existing.intent === 'pending-mailbox-review';
+    return coalescibleMailboxReminder;
   }
 
   if (input.kind === 'inbox' && input.inbox_correlation_key) {
@@ -247,8 +253,40 @@ export async function enqueueDispatchRequest(
 
   const queued = await deps.withDispatchLock(deps.teamName, deps.cwd, async () => {
     const requests = await deps.readDispatchRequests(deps.teamName, deps.cwd);
-    const existing = requests.find((req) => equivalentPendingDispatch(req, requestInput));
-    if (existing) return { request: existing, deduped: true };
+    let existing: TeamDispatchRequest | undefined;
+    for (const candidate of requests) {
+      if (!equivalentActiveDispatch(candidate, requestInput)) continue;
+      if (candidate.status === 'notified') {
+        const stillUndelivered = candidate.message_id && deps.isMailboxMessageUndelivered
+          ? await deps.isMailboxMessageUndelivered(candidate.to_worker, candidate.message_id).catch(() => false)
+          : false;
+        if (!stillUndelivered) continue;
+      }
+      existing = candidate;
+      break;
+    }
+    if (existing) {
+      const workerIndex = requestInput.worker_index ?? existing.worker_index;
+      const paneId = requestInput.pane_id ?? existing.pane_id;
+      if (
+        workerIndex === existing.worker_index
+        && paneId === existing.pane_id
+        && requestInput.trigger_message === existing.trigger_message
+      ) {
+        return { request: existing, deduped: true };
+      }
+      const refreshed = {
+        ...existing,
+        worker_index: workerIndex,
+        pane_id: paneId,
+        trigger_message: requestInput.trigger_message,
+        updated_at: new Date().toISOString(),
+      };
+      const index = requests.findIndex((request) => request.request_id === existing.request_id);
+      requests[index] = refreshed;
+      await deps.writeDispatchRequests(deps.teamName, requests, deps.cwd);
+      return { request: refreshed, deduped: true };
+    }
 
     const nowIso = new Date().toISOString();
     const request = normalizeDispatchRequest(


### PR DESCRIPTION
## Summary

- coalesce recipient-scoped mailbox review reminders while preserving every durable mailbox message
- keep at most one pending or in-flight reminder per recipient and suppress stale reminders after delivery
- stop duplicating worker-to-leader messages as synthetic `system` mailbox entries and aggregate leader attention from unread messages
- add burst regressions for both worker-to-leader and leader-to-worker delivery paths

## Root cause

Mailbox delivery durability and UI notification scheduling were coupled too closely. Each durable message could create its own `pending-mailbox-review` dispatch request, the monitor could reschedule multiple unread messages in one poll, and worker-to-leader delivery additionally wrote a synthetic leader mailbox echo. Under bursty Team traffic these independent paths produced repeated, identical `You have 1 new message(s)` queue notifications even though one reminder was sufficient to draw attention to the same recipient mailbox.

## Behavior after this change

Individual messages remain durable and independently deliverable. Notification requests are coalesced by recipient across both pending and notified states, the monitor schedules only the oldest unnotified mailbox item per recipient per poll, stale dispatches are revalidated before injection, and leader nudges count unread original messages without creating wrapper messages.

## Validation

- `npm run lint`
- `npx tsc --noEmit`
- `npm run check:no-unused`
- `npm run build`
- `npm run verify:native-agents`
- `npm run verify:plugin-bundle`
- targeted Team state, MCP communication, notify-hook dispatch/nudge, runtime, and delivery E2E suites
- `npm run coverage:team-critical:compiled`
- `npm run test:ralph-persistence:compiled`
- `npm run test:team:cross-rebase-smoke:compiled`
- CI-equivalent smoke suite in an isolated environment: 64/64 passed

## Commit structure

1. coalesce pending mailbox reminders
2. bound mailbox reminders in flight
3. aggregate leader mailbox attention
4. cover mailbox reminder bursts
