### PR TITLE
fix(tmux): preserve attached session scrollback

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -5121,14 +5121,20 @@ exit 0
     assert.equal(names.includes("register-resize-hook"), true);
     assert.equal(names.includes("reconcile-hud-resize"), true);
     assert.equal(DETACHED_TMUX_HISTORY_LIMIT, 500);
-    const historyHook = steps.find((step) => step.name === "register-detached-history-prune-hook");
-    assert.ok(historyHook);
-    assert.deepEqual(historyHook.args.slice(0, 3), ["set-hook", "-t", "omx-demo"]);
-    assert.match(historyHook.args[3] || "", /^client-detached\[[0-9]+\]$/);
+    assert.equal(names.includes("bound-unattached-history"), false);
+    const pruneHook = steps.find((step) => step.name === "register-detached-history-prune-hook");
+    assert.ok(pruneHook);
+    assert.deepEqual(pruneHook.args.slice(0, 3), ["set-hook", "-t", "omx-demo"]);
+    assert.match(pruneHook.args[3] || "", /^client-detached\[[0-9]+\]$/);
     assert.equal(
-      historyHook.args[4],
-      `if-shell -F '#{==:#{session_attached},0}' 'run-shell -b "tmux clear-history -t %leader >/dev/null 2>&1 || true"'`,
+      pruneHook.args[4],
+      `if-shell -F '#{==:#{session_attached},0}' 'run-shell -b "tmux set-option -pq -t %leader history-limit 500 >/dev/null 2>&1 || true; tmux clear-history -t %leader >/dev/null 2>&1 || true"'`,
     );
+    const restoreHook = steps.find((step) => step.name === "register-attached-history-restore-hook");
+    assert.ok(restoreHook);
+    assert.deepEqual(restoreHook.args.slice(0, 3), ["set-hook", "-t", "omx-demo"]);
+    assert.match(restoreHook.args[3] || "", /^client-attached\[[0-9]+\]$/);
+    assert.equal(restoreHook.args[4], "set-option -puq -t %leader history-limit");
   });
 
   it("detached history prune hook tolerates a dead leader pane", () => {
@@ -5141,11 +5147,36 @@ exit 0
       true,
       "%leader",
     );
-    const historyHook = steps.find((step) => step.name === "register-detached-history-prune-hook");
-    assert.ok(historyHook);
-    const hookCommand = historyHook.args[4] || "";
+    const pruneHook = steps.find((step) => step.name === "register-detached-history-prune-hook");
+    assert.ok(pruneHook);
+    const hookCommand = pruneHook.args[4] || "";
     assert.match(hookCommand, /run-shell -b/);
+    assert.match(hookCommand, /set-option -pq .* history-limit 500/);
+    assert.match(hookCommand, /clear-history/);
     assert.match(hookCommand, />\/dev\/null 2>&1 \|\| true/);
+  });
+
+  it("bounds history immediately when a detached session will not attach", () => {
+    const steps = buildDetachedSessionFinalizeSteps(
+      "omx-demo",
+      "%12",
+      "3",
+      true,
+      false,
+      false,
+      "%leader",
+    );
+    const boundStep = steps.find((step) => step.name === "bound-unattached-history");
+    assert.deepEqual(boundStep?.args, [
+      "set-option",
+      "-pq",
+      "-t",
+      "%leader",
+      "history-limit",
+      "500",
+    ]);
+    const clearStep = steps.find((step) => step.name === "clear-unattached-history");
+    assert.deepEqual(clearStep?.args, ["clear-history", "-t", "%leader"]);
   });
 
   it("buildDetachedSessionFinalizeSteps skips attach for Hermes MCP bridge launches", () => {

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -439,6 +439,11 @@ exit 0
       assert.match(tmuxLog, /tmux:new-session /);
       assert.match(tmuxLog, /tmux:split-window /);
       assert.doesNotMatch(tmuxLog, /tmux:attach-session/);
+      assert.match(
+        tmuxLog,
+        new RegExp(`tmux:set-option -pq -t %12 history-limit ${DETACHED_TMUX_HISTORY_LIMIT}`),
+      );
+      assert.match(tmuxLog, /tmux:clear-history -t %12/);
       assert.doesNotMatch(result.stderr, /failed to attach detached tmux session/);
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -905,11 +910,17 @@ exit 0
       assert.doesNotMatch(tmuxLog, /tmux:show-options -gv history-limit/);
       assert.doesNotMatch(tmuxLog, /tmux:set-option -g[q ]+history-limit/);
       assert.match(tmuxLog, /tmux:new-session .* -s /);
-      assert.match(tmuxLog, new RegExp(`tmux:set-option -q -t .* history-limit ${DETACHED_TMUX_HISTORY_LIMIT}`));
-      assert.match(tmuxLog, new RegExp(`tmux:set-option -pq -t %12 history-limit ${DETACHED_TMUX_HISTORY_LIMIT}`));
+      const historyMutationLines = tmuxLog
+        .split('\n')
+        .filter((line) => line.startsWith('tmux:set-option') && line.includes('history-limit'));
+      assert.deepEqual(historyMutationLines, []);
       assert.match(
         tmuxLog,
-        /tmux:set-hook -t .* client-detached\[[0-9]+\] if-shell -F '#\{==:#\{session_attached\},0\}' 'run-shell -b "tmux clear-history -t %12 >\/dev\/null 2>&1 \|\| true"'/,
+        /tmux:set-hook -t .* client-detached\[[0-9]+\].*tmux set-option -pq -t %12 history-limit 500.*tmux clear-history -t %12/,
+      );
+      assert.match(
+        tmuxLog,
+        /tmux:set-hook -t .* client-attached\[[0-9]+\] set-option -puq -t %12 history-limit/,
       );
       assert.match(tmuxLog, new RegExp(`tmux:split-window -v -l ${HUD_TMUX_HEIGHT_LINES} .* -t `));
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1480,25 +1480,23 @@ export function registerDetachedHudLayoutReconcileHook(options: {
 export const DETACHED_TMUX_HISTORY_LIMIT = 500;
 const TMUX_HOOK_INDEX_MAX = 1_000_000;
 
-function setDetachedTmuxSessionHistoryLimit(
-  sessionName: string,
-  leaderPaneId?: string | null,
-): void {
+function setDetachedTmuxPaneHistoryLimit(leaderPaneId: string): void {
   const boundedHistoryLimit = String(DETACHED_TMUX_HISTORY_LIMIT);
-  try {
-    execTmuxFileSync(
-      ["set-option", "-q", "-t", sessionName, "history-limit", boundedHistoryLimit],
-      { stdio: "ignore" },
-    );
-  } catch (err) {
-    logCliOperationFailure(err);
-  }
-  if (!leaderPaneId) return;
   try {
     execTmuxFileSync(
       ["set-option", "-pq", "-t", leaderPaneId, "history-limit", boundedHistoryLimit],
       { stdio: "ignore" },
     );
+  } catch (err) {
+    logCliOperationFailure(err);
+  }
+}
+
+function restoreDetachedTmuxPaneHistoryLimit(leaderPaneId: string): void {
+  try {
+    execTmuxFileSync(["set-option", "-puq", "-t", leaderPaneId, "history-limit"], {
+      stdio: "ignore",
+    });
   } catch (err) {
     logCliOperationFailure(err);
   }
@@ -1558,16 +1556,24 @@ function buildDetachedHistoryPruneHookCommand(leaderPaneId: string): string {
   // The leader pane can be gone by the time the hook fires (e.g. crashed
   // leader with a lingering session); suppress errors so tmux does not queue
   // "(null):0: can't find pane" for the next attaching client.
-  return `if-shell -F '#{==:#{session_attached},0}' 'run-shell -b "tmux clear-history -t ${leaderPaneId} >/dev/null 2>&1 || true"'`;
+  return `if-shell -F '#{==:#{session_attached},0}' 'run-shell -b "tmux set-option -pq -t ${leaderPaneId} history-limit ${DETACHED_TMUX_HISTORY_LIMIT} >/dev/null 2>&1 || true; tmux clear-history -t ${leaderPaneId} >/dev/null 2>&1 || true"'`;
 }
 
-function buildDetachedHistoryPruneHookSlot(sessionName: string, leaderPaneId: string): string {
-  const key = `${sessionName}:${leaderPaneId}:omx-history-prune`;
+function buildDetachedHistoryRestoreHookCommand(leaderPaneId: string): string {
+  return `set-option -puq -t ${leaderPaneId} history-limit`;
+}
+
+function buildDetachedHistoryHookSlot(
+  eventName: "client-attached" | "client-detached",
+  sessionName: string,
+  leaderPaneId: string,
+): string {
+  const key = `${sessionName}:${leaderPaneId}:omx-history:${eventName}`;
   let hash = 0;
   for (let i = 0; i < key.length; i++) {
     hash = ((hash << 5) - hash + key.charCodeAt(i)) | 0;
   }
-  return `client-detached[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
+  return `${eventName}[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
 }
 
 function hasErrnoCode(error: unknown, code: string): boolean {
@@ -4428,14 +4434,41 @@ export function buildDetachedSessionFinalizeSteps(
 ): DetachedSessionTmuxStep[] {
   const steps: DetachedSessionTmuxStep[] = [];
   if (!nativeWindows && leaderPaneId) {
+    if (!attachSession) {
+      steps.push({
+        name: "bound-unattached-history",
+        args: [
+          "set-option",
+          "-pq",
+          "-t",
+          leaderPaneId,
+          "history-limit",
+          String(DETACHED_TMUX_HISTORY_LIMIT),
+        ],
+      });
+      steps.push({
+        name: "clear-unattached-history",
+        args: ["clear-history", "-t", leaderPaneId],
+      });
+    }
     steps.push({
       name: "register-detached-history-prune-hook",
       args: [
         "set-hook",
         "-t",
         sessionName,
-        buildDetachedHistoryPruneHookSlot(sessionName, leaderPaneId),
+        buildDetachedHistoryHookSlot("client-detached", sessionName, leaderPaneId),
         buildDetachedHistoryPruneHookCommand(leaderPaneId),
+      ],
+    });
+    steps.push({
+      name: "register-attached-history-restore-hook",
+      args: [
+        "set-hook",
+        "-t",
+        sessionName,
+        buildDetachedHistoryHookSlot("client-attached", sessionName, leaderPaneId),
+        buildDetachedHistoryRestoreHookCommand(leaderPaneId),
       ],
     });
   }
@@ -5361,11 +5394,8 @@ function runCodex(
         isReusableMadmaxDetachedActiveRecord(activeRecord)
       ) {
         cleanupCurrentMadmaxReuseRunRoot(process.env, runsRoot);
-        setDetachedTmuxSessionHistoryLimit(
-          activeRecord.tmux_session_name,
-          activeRecord.tmux_pane_id!,
-        );
         if (!shouldAttachDetachedTmuxSession(process.env)) {
+          setDetachedTmuxPaneHistoryLimit(activeRecord.tmux_pane_id!);
           clearDetachedTmuxSessionHistoryIfUnattached(
             activeRecord.tmux_session_name,
             activeRecord.tmux_pane_id!,
@@ -5375,6 +5405,7 @@ function runCodex(
           );
           return { postLaunchHandledExternally: true };
         }
+        restoreDetachedTmuxPaneHistoryLimit(activeRecord.tmux_pane_id!);
         process.stderr.write(
           `[omx] madmax detached launch already active for this context; attaching ${activeRecord.tmux_session_name} instead of starting a duplicate.\n`,
         );
@@ -5460,7 +5491,6 @@ function runCodex(
             const leaderPaneId = parsePaneIdFromTmuxOutput(output || "");
             if (leaderPaneId) {
               detachedLeaderPaneId = leaderPaneId;
-              setDetachedTmuxSessionHistoryLimit(sessionName, leaderPaneId);
               if (activeRecordPath && contextKey) {
                 writeMadmaxDetachedActiveRecord(activeRecordPath, {
                   version: 1,


### PR DESCRIPTION
## Summary

- let OMX-created tmux leader panes inherit the user's configured history limit while a client is attached
- apply the 500-line safety bound and clear stale leader history only when the final client detaches
- restore the inherited pane history limit when a client reattaches
- keep intentionally unattached Hermes bridge sessions bounded immediately

## Why

The detached-history safeguard added for #2597 prevents stale Codex panes from consuming multiple gigabytes of tmux memory, but applying the 500-line limit before the initial attach also truncates active interactive sessions. Users with a larger tmux `history-limit` cannot scroll back to the beginning of a long OMX conversation even while the session is still attached.

This keeps the memory protection at the lifecycle boundary where it is needed while preserving normal interactive scrollback:

1. Attached: inherit the session/global tmux history policy.
2. Final detach: cap the OMX leader pane at 500 lines and clear stale history.
3. Reattach: unset the pane override and inherit the user's tmux policy again.

HUD resize, client-attached reconciliation, mouse, notification, and attach callbacks are unchanged.

## Related issues

- #206 reports that scrolling and copying become unreliable in normal `omx --xhigh --madmax` sessions.
- #215 documents active tmux scrollback being obscured by live OMX output injection and establishes the expectation that users can inspect earlier output while a session is running.
- #1925 documents broader multi-project tmux growth reaching 4–11 GiB and causing OOM failures.
- #2597 is the direct detached-pane memory report behind the current safeguard, including pane histories reaching 8.8–67 GB.
- #1899 separately notes that unavailable scrollback made detached-launch failure recovery and diagnosis harder.

This PR addresses the lifecycle overlap among those reports: retain the user's scrollback policy while attached, then apply the bounded-history safeguard when OMX is actually detached.

## Validation

- `npm run build`
- targeted detached-session lifecycle tests: 8/8 passed
- `node dist/scripts/run-test-files.js dist/cli/__tests__/launch-fallback.test.js`: 24/24 passed
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
- real tmux lifecycle probe: inherited `50000` -> detached `500` -> reattached `50000`

## Impact

Long-running attached OMX conversations retain the scrollback configured by the user. Fully detached or intentionally unattached OMX leader panes remain bounded against the stale-TUI memory growth reported in #2597.
