### PR TITLE
fix(codex): preserve foreign hook coordinates

### DIFF
--- a/src/cli/__tests__/doctor-invalid-config.test.ts
+++ b/src/cli/__tests__/doctor-invalid-config.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
@@ -73,7 +73,7 @@ theme = "base16-ocean-light"
     }
   });
 
-  it('fails when hooks.json contains Codex 0.140-incompatible top-level state', async () => {
+  it('fails strict load validation when hooks.json contains top-level state', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-hooks-json-state-'));
     try {
       const home = join(wd, 'home');
@@ -111,9 +111,56 @@ theme = "base16-ocean-light"
       assert.equal(res.status, 0, res.stderr || res.stdout);
       assert.match(
         res.stdout,
-        /\[XX\] Native hooks: top-level state in hooks\.json is incompatible with Codex 0\.140/,
+        /\[XX\] Native hooks: hooks\.json failed strict load validation \(invalid_document\): Codex does not accept unknown root field state; inspect the file manually because doctor will not modify it/,
       );
-      assert.match(res.stdout, /unknown field state, expected hooks/);
+      assert.doesNotMatch(res.stdout, /Run "omx setup" to fix installation issues/);
+      assert.doesNotMatch(res.stdout, /Native hooks:.*--force/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it('fails closed when hooks.json contains invalid UTF-8 bytes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-hooks-json-invalid-utf8-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(join(codexDir, 'config.toml'), 'omx_enabled = true\nhooks = true\n');
+      await writeFile(join(codexDir, 'hooks.json'), Buffer.from([0x7b, 0xff, 0x7d]));
+
+      const res = runOmx(wd, ['doctor'], { HOME: home, CODEX_HOME: codexDir });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(
+        res.stdout,
+        /\[XX\] Native hooks: hooks\.json at .* is not valid UTF-8; inspect the file manually because doctor will not modify it/,
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves a UTF-8 BOM so strict hooks validation rejects it', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-hooks-json-bom-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      const hooksPath = join(codexDir, 'hooks.json');
+      const hooks = Buffer.concat([
+        Buffer.from([0xef, 0xbb, 0xbf]),
+        Buffer.from('{"hooks":{}}\n', 'utf-8'),
+      ]);
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(join(codexDir, 'config.toml'), 'omx_enabled = true\nhooks = true\n');
+      await writeFile(hooksPath, hooks);
+
+      const res = runOmx(wd, ['doctor'], { HOME: home, CODEX_HOME: codexDir });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.match(res.stdout, /hooks\.json failed strict load validation \(invalid_document\)/);
+      assert.deepEqual(await readFile(hooksPath), hooks);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -2,14 +2,16 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
 	cp,
+	link,
 	mkdir,
 	mkdtemp,
 	readFile,
+	rename,
 	rm,
 	symlink,
 	writeFile,
 } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
@@ -2035,16 +2037,20 @@ command = "node"
 		}
 	});
 
-	it("never executes missing, tampered, or historical Windows shim sentinels during verbose validation", async () => {
+	it("never executes missing, tampered, historical, hard-linked, or symlinked Windows shim sentinels during verbose validation", async () => {
 		for (const fixture of [
 			{
 				name: "missing",
 				shimContent: null,
+				hardLink: false,
+				symlinkTarget: null,
 				expected: /referenced Windows native hook shim is missing at/,
 			},
 			{
 				name: "tampered",
 				shimContent: `${buildManagedCodexNativeHookWindowsShimContent(repoRoot())}# verbose-execution sentinel\n`,
+				hardLink: false,
+				symlinkTarget: null,
 				expected: /not an exact current or complete historical generated shim/,
 			},
 			{
@@ -2054,7 +2060,23 @@ command = "node"
 					hookScriptPath:
 						"C:\\Historical Install\\oh-my-codex\\dist\\scripts\\codex-native-hook.js",
 				}),
+				hardLink: false,
+				symlinkTarget: null,
 				expected: /complete historical generated shim.*run "omx setup" to migrate/,
+			},
+			{
+				name: "hard-linked",
+				shimContent: buildManagedCodexNativeHookWindowsShimContent(repoRoot()),
+				hardLink: true,
+				symlinkTarget: null,
+				expected: /is hard-linked; doctor will not execute or modify it/,
+			},
+			{
+				name: "symlinked",
+				shimContent: null,
+				hardLink: false,
+				symlinkTarget: buildManagedCodexNativeHookWindowsShimContent(repoRoot()),
+				expected: /is not a regular file; doctor will not follow or modify it/,
 			},
 		] as const) {
 			const wd = await mkdtemp(join(tmpdir(), `omx-doctor-verbose-windows-shim-${fixture.name}-`));
@@ -2065,9 +2087,17 @@ command = "node"
 				const command = buildWindowsShimCommand(shimPath);
 				await mkdir(codexDir, { recursive: true });
 				await writeFile(hooksPath, buildWindowsShimHooksJson(shimPath, codexDir));
-				if (fixture.shimContent !== null) {
+				if (fixture.symlinkTarget !== null) {
+					const symlinkTargetPath = join(wd, "symlink-target.ps1");
+					await mkdir(dirname(shimPath), { recursive: true });
+					await writeFile(symlinkTargetPath, fixture.symlinkTarget, "utf-8");
+					await symlink(symlinkTargetPath, shimPath);
+				} else if (fixture.shimContent !== null) {
 					await mkdir(dirname(shimPath), { recursive: true });
 					await writeFile(shimPath, fixture.shimContent, "utf-8");
+					if (fixture.hardLink) {
+						await link(shimPath, join(wd, "canonical-shim-hardlink.ps1"));
+					}
 				}
 
 				let spawned = false;
@@ -2086,6 +2116,105 @@ command = "node"
 			} finally {
 				await rm(wd, { recursive: true, force: true });
 			}
+		}
+	});
+
+	it("runs exact current Windows shim bytes in memory after canonical replacement, hard-linking, and ancestor retargeting", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-verbose-windows-shim-in-memory-"));
+		try {
+			const codexDir = join(wd, ".codex");
+			const hooksPath = join(codexDir, "hooks.json");
+			const hooksDir = join(codexDir, "hooks");
+			const shimPath = join(hooksDir, "omx-native-hook-windows-shim.ps1");
+			const command = buildWindowsShimCommand(shimPath);
+			const currentShim = buildManagedCodexNativeHookWindowsShimContent(repoRoot());
+			const sentinel = "# foreign canonical shim sentinel\n";
+			const foreignHooksDir = join(codexDir, "foreign-hooks");
+			const foreignShimPath = join(foreignHooksDir, "omx-native-hook-windows-shim.ps1");
+			const foreignHardLinkPath = join(foreignHooksDir, "foreign-shim-hard-link.ps1");
+			await mkdir(hooksDir, { recursive: true });
+			await writeFile(hooksPath, buildWindowsShimHooksJson(shimPath, codexDir));
+			await writeFile(shimPath, currentShim, "utf-8");
+
+			const check = await checkNativePostCompactHookRuntime(hooksPath, wd, codexDir, {
+				platform: "win32",
+				expectedCommand: command,
+				beforeWindowsShimSmoke: async () => {
+					const parkedHooksDir = join(codexDir, "validated-hooks");
+					await rename(hooksDir, parkedHooksDir);
+					await mkdir(foreignHooksDir, { recursive: true });
+					await writeFile(foreignShimPath, sentinel);
+					await link(foreignShimPath, foreignHardLinkPath);
+					await symlink(foreignHooksDir, hooksDir, "dir");
+				},
+				runner: ((_command: string, args: readonly string[]) => {
+					const encodedCommand = args[args.indexOf("-EncodedCommand") + 1];
+					if (typeof encodedCommand !== "string") {
+						throw new Error("PowerShell smoke must receive an encoded in-memory command");
+					}
+					assert.doesNotMatch(args.join("\u0000"), /(?:^|\u0000)-File(?:\u0000|$)/);
+					const smokeCommand = Buffer.from(encodedCommand, "base64").toString("utf16le");
+					assert.doesNotMatch(smokeCommand, /(?:^|\s)-File(?:\s|$)/);
+					assert.equal(smokeCommand.includes(shimPath), false);
+					assert.match(smokeCommand, /\[ScriptBlock\]::Create\(\$omxShimSource\)/);
+					const encodedShimBytes = /FromBase64String\('([A-Za-z0-9+/=]+)'\)/.exec(smokeCommand)?.[1];
+					if (encodedShimBytes === undefined) {
+						throw new Error("encoded PowerShell smoke command omitted validated shim bytes");
+					}
+					assert.deepEqual(Buffer.from(encodedShimBytes, "base64"), Buffer.from(currentShim, "utf-8"));
+					assert.equal(readFileSync(shimPath, "utf-8"), sentinel);
+					assert.equal(readFileSync(foreignHardLinkPath, "utf-8"), sentinel);
+					return { status: 0, stdout: "", stderr: "" };
+				}) as unknown as typeof spawnSync,
+			});
+
+			assert.equal(check?.status, "pass");
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves a swapped Windows PostCompact smoke root instead of recursively deleting it", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-verbose-windows-smoke-root-"));
+		let foreignSmokeCwd: string | null = null;
+		let parkedSmokeCwd: string | null = null;
+		try {
+			const codexDir = join(wd, ".codex");
+			const hooksPath = join(codexDir, "hooks.json");
+			const hooksDir = join(codexDir, "hooks");
+			const shimPath = join(hooksDir, "omx-native-hook-windows-shim.ps1");
+			const command = buildWindowsShimCommand(shimPath);
+			await mkdir(hooksDir, { recursive: true });
+			await writeFile(hooksPath, buildWindowsShimHooksJson(shimPath, codexDir));
+			await writeFile(shimPath, buildManagedCodexNativeHookWindowsShimContent(repoRoot()), "utf-8");
+
+			const check = await checkNativePostCompactHookRuntime(hooksPath, wd, codexDir, {
+				platform: "win32",
+				expectedCommand: command,
+				beforeWindowsShimSmoke: ({ smokeCwd }) => {
+					foreignSmokeCwd = smokeCwd;
+				},
+				runner: (() => {
+					const currentSmokeCwd = foreignSmokeCwd;
+					if (currentSmokeCwd === null) {
+						throw new Error("Windows smoke root was not captured before execution");
+					}
+					parkedSmokeCwd = `${currentSmokeCwd}-parked`;
+					renameSync(currentSmokeCwd, parkedSmokeCwd);
+					mkdirSync(currentSmokeCwd, { mode: 0o700 });
+					writeFileSync(join(currentSmokeCwd, "foreign-sentinel.txt"), "foreign smoke root\n");
+					return { status: 0, stdout: "", stderr: "" };
+				}) as unknown as typeof spawnSync,
+			});
+
+			assert.equal(check?.status, "warn");
+			assert.match(check?.message ?? "", /temporary PostCompact smoke directory changed during validation/);
+			if (foreignSmokeCwd === null) assert.fail("Windows smoke root was not captured");
+			assert.equal(readFileSync(join(foreignSmokeCwd, "foreign-sentinel.txt"), "utf-8"), "foreign smoke root\n");
+		} finally {
+			if (foreignSmokeCwd !== null) await rm(foreignSmokeCwd, { recursive: true, force: true });
+			if (parkedSmokeCwd !== null) await rm(parkedSmokeCwd, { recursive: true, force: true });
+			await rm(wd, { recursive: true, force: true });
 		}
 	});
 

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -24,6 +24,7 @@ import {
 	checkExploreHarness,
 	checkLegacyMultiAgentCompatibility,
 	checkNativeHookDistSmoke,
+	checkNativePostCompactHookRuntime,
 	checkNativeHooks,
 	classifyPostCompactHookStdout,
 } from "../doctor.js";
@@ -94,10 +95,8 @@ function buildWindowsShimCommand(shimPath: string): string {
 }
 
 function buildWindowsShimHooksJson(shimPath: string, codexHomeDir: string): string {
-	return buildHooksJsonWithPostCompactCommand(
-		buildWindowsShimCommand(shimPath),
-		codexHomeDir,
-	);
+	const command = buildWindowsShimCommand(shimPath);
+	return buildHooksJsonWithPostCompactCommand(command, codexHomeDir, command);
 }
 
 async function installPluginCacheFixture(codexDir: string): Promise<string> {
@@ -149,8 +148,8 @@ async function packagedPluginVersion(): Promise<string> {
 function buildHooksJsonWithPostCompactCommand(
 	postCompactCommand: string,
 	codexHomeDir: string,
+	expectedCommand = currentNativeHookCommand(codexHomeDir),
 ): string {
-	const expectedCommand = currentNativeHookCommand(codexHomeDir);
 	return `${JSON.stringify({
 		hooks: Object.fromEntries(
 			MANAGED_HOOK_EVENTS.map((eventName) => [
@@ -1966,10 +1965,11 @@ command = "node"
 			const shimPath = join(codexDir, "hooks", "omx-native-hook-windows-shim.ps1");
 			await mkdir(dirname(shimPath), { recursive: true });
 			const original = buildWindowsShimHooksJson(shimPath, codexDir);
-			const historicalShim = buildManagedCodexNativeHookWindowsShimContent(
-				join(wd, "historical-oh-my-codex"),
-				{ nodePath: join(wd, "historical", "node.exe") },
-			);
+			const historicalShim = buildManagedCodexNativeHookWindowsShimContent("", {
+				nodePath: "C:\\Historical Node\\node.exe",
+				hookScriptPath:
+					"C:\\Historical Install\\oh-my-codex\\dist\\scripts\\codex-native-hook.js",
+			});
 			await writeFile(hooksPath, original);
 			await writeFile(shimPath, historicalShim, "utf-8");
 
@@ -1983,6 +1983,109 @@ command = "node"
 			assert.equal(await readFile(shimPath, "utf-8"), historicalShim);
 		} finally {
 			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("reports Windows shim integrity before an unsafe managed/foreign group coordinate warning", async () => {
+		for (const fixture of [
+			{
+				name: "missing",
+				shimContent: null,
+				integrity: /referenced Windows native hook shim is missing at/,
+			},
+			{
+				name: "tampered",
+				shimContent: `${buildManagedCodexNativeHookWindowsShimContent(repoRoot())}# mixed-group sentinel\n`,
+				integrity: /not an exact current or complete historical generated shim/,
+			},
+		] as const) {
+			const wd = await mkdtemp(join(tmpdir(), `omx-doctor-windows-shim-${fixture.name}-unsafe-`));
+			try {
+				const codexDir = join(wd, ".codex");
+				const hooksPath = join(codexDir, "hooks.json");
+				const shimPath = join(codexDir, "hooks", "omx-native-hook-windows-shim.ps1");
+				const parsed = JSON.parse(buildWindowsShimHooksJson(shimPath, codexDir)) as {
+					hooks: Record<string, Array<{ hooks: unknown[] }>>;
+				};
+				parsed.hooks.PreToolUse![0]!.hooks.push({
+					type: "command",
+					command: "echo foreign-handler",
+				});
+				await mkdir(codexDir, { recursive: true });
+				await writeFile(hooksPath, `${JSON.stringify(parsed, null, 2)}\n`);
+				if (fixture.shimContent !== null) {
+					await mkdir(dirname(shimPath), { recursive: true });
+					await writeFile(shimPath, fixture.shimContent, "utf-8");
+				}
+
+				const check = await checkNativeHooks(hooksPath, join(codexDir, "config.toml"), {
+					codexHomeDir: codexDir,
+					platform: "win32",
+				});
+				assert.equal(check.status, "fail", fixture.name);
+				assert.match(check.message, fixture.integrity, fixture.name);
+				assert.match(check.message, /unsafe_managed_removal/, fixture.name);
+				assert.ok(
+					check.message.search(fixture.integrity) < check.message.indexOf("unsafe_managed_removal"),
+					`${fixture.name} shim integrity must take precedence over the coordinate warning`,
+				);
+			} finally {
+				await rm(wd, { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("never executes missing, tampered, or historical Windows shim sentinels during verbose validation", async () => {
+		for (const fixture of [
+			{
+				name: "missing",
+				shimContent: null,
+				expected: /referenced Windows native hook shim is missing at/,
+			},
+			{
+				name: "tampered",
+				shimContent: `${buildManagedCodexNativeHookWindowsShimContent(repoRoot())}# verbose-execution sentinel\n`,
+				expected: /not an exact current or complete historical generated shim/,
+			},
+			{
+				name: "historical",
+				shimContent: buildManagedCodexNativeHookWindowsShimContent("", {
+					nodePath: "C:\\Historical Node\\node.exe",
+					hookScriptPath:
+						"C:\\Historical Install\\oh-my-codex\\dist\\scripts\\codex-native-hook.js",
+				}),
+				expected: /complete historical generated shim.*run "omx setup" to migrate/,
+			},
+		] as const) {
+			const wd = await mkdtemp(join(tmpdir(), `omx-doctor-verbose-windows-shim-${fixture.name}-`));
+			try {
+				const codexDir = join(wd, ".codex");
+				const hooksPath = join(codexDir, "hooks.json");
+				const shimPath = join(codexDir, "hooks", "omx-native-hook-windows-shim.ps1");
+				const command = buildWindowsShimCommand(shimPath);
+				await mkdir(codexDir, { recursive: true });
+				await writeFile(hooksPath, buildWindowsShimHooksJson(shimPath, codexDir));
+				if (fixture.shimContent !== null) {
+					await mkdir(dirname(shimPath), { recursive: true });
+					await writeFile(shimPath, fixture.shimContent, "utf-8");
+				}
+
+				let spawned = false;
+				const check = await checkNativePostCompactHookRuntime(hooksPath, wd, codexDir, {
+					platform: "win32",
+					expectedCommand: command,
+					runner: (() => {
+						spawned = true;
+						throw new Error("unverified Windows shim execution");
+					}) as unknown as typeof spawnSync,
+				});
+				assert.equal(spawned, false, `${fixture.name} shim executed`);
+				assert.ok(check, `${fixture.name} shim must produce a safety diagnostic`);
+				assert.notEqual(check.status, "pass", fixture.name);
+				assert.match(check.message, fixture.expected, fixture.name);
+			} finally {
+				await rm(wd, { recursive: true, force: true });
+			}
 		}
 	});
 

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -2218,6 +2218,79 @@ command = "node"
 		}
 	});
 
+	it("preserves a failed PostCompact smoke result when cleanup retains the smoke directory", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-postcompact-smoke-cleanup-failure-"));
+		let smokeCwd: string | null = null;
+		try {
+			const codexDir = join(wd, ".codex");
+			const hooksPath = join(codexDir, "hooks.json");
+			const hooksDir = join(codexDir, "hooks");
+			const shimPath = join(hooksDir, "omx-native-hook-windows-shim.ps1");
+			const command = buildWindowsShimCommand(shimPath);
+			await mkdir(hooksDir, { recursive: true });
+			await writeFile(hooksPath, buildWindowsShimHooksJson(shimPath, codexDir));
+			await writeFile(shimPath, buildManagedCodexNativeHookWindowsShimContent(repoRoot()), "utf-8");
+
+			const check = await checkNativePostCompactHookRuntime(hooksPath, wd, codexDir, {
+				platform: "win32",
+				expectedCommand: command,
+				beforeWindowsShimSmoke: ({ smokeCwd: currentSmokeCwd }) => {
+					smokeCwd = currentSmokeCwd;
+				},
+				runner: (() => {
+					if (smokeCwd === null) {
+						throw new Error("Windows smoke root was not captured before execution");
+					}
+					writeFileSync(join(smokeCwd, "retained-sentinel.txt"), "retained smoke root\n");
+					return { status: 1, stdout: "", stderr: "hook failure" };
+				}) as unknown as typeof spawnSync,
+			});
+
+			assert.equal(check?.status, "fail");
+			assert.match(check?.message ?? "", /PostCompact hook smoke validation exited 1: hook failure/);
+			assert.match(check?.message ?? "", /temporary PostCompact smoke directory could not be removed without recursive deletion/);
+			if (smokeCwd === null) assert.fail("Windows smoke root was not captured");
+			assert.equal(readFileSync(join(smokeCwd, "retained-sentinel.txt"), "utf-8"), "retained smoke root\n");
+		} finally {
+			if (smokeCwd !== null) await rm(smokeCwd, { recursive: true, force: true });
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves a thrown PostCompact smoke error when cleanup also fails", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-postcompact-smoke-thrown-cleanup-"));
+		let smokeCwd: string | null = null;
+		try {
+			const codexDir = join(wd, ".codex");
+			const hooksPath = join(codexDir, "hooks.json");
+			const hooksDir = join(codexDir, "hooks");
+			const shimPath = join(hooksDir, "omx-native-hook-windows-shim.ps1");
+			const command = buildWindowsShimCommand(shimPath);
+			await mkdir(hooksDir, { recursive: true });
+			await writeFile(hooksPath, buildWindowsShimHooksJson(shimPath, codexDir));
+			await writeFile(shimPath, buildManagedCodexNativeHookWindowsShimContent(repoRoot()), "utf-8");
+
+			await assert.rejects(
+				checkNativePostCompactHookRuntime(hooksPath, wd, codexDir, {
+					platform: "win32",
+					expectedCommand: command,
+					beforeWindowsShimSmoke: ({ smokeCwd: currentSmokeCwd }) => {
+						smokeCwd = currentSmokeCwd;
+					},
+					runner: (() => {
+						if (smokeCwd === null) throw new Error("Windows smoke root was not captured before execution");
+						writeFileSync(join(smokeCwd, "retained-sentinel.txt"), "retained smoke root\n");
+						throw new Error("primary spawn failure");
+					}) as unknown as typeof spawnSync,
+				}),
+				/primary spawn failure; temporary PostCompact smoke directory could not be removed without recursive deletion/,
+			);
+		} finally {
+			if (smokeCwd !== null) await rm(smokeCwd, { recursive: true, force: true });
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("reports exact nested legacy hook trust state as migration-required without modifying hooks.json", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-hooks-legacy-trust-"));
 		try {

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -19,14 +19,18 @@ import {
 	withPackagedExploreHarnessLock,
 } from "./packaged-explore-harness-lock.js";
 import {
-	checkExploreHarness,
-	checkExternalCodexProcessGuards,
 	buildPostCompactSmokeSpawnInvocation,
-	checkNativeHookDistSmoke,
-	classifyPostCompactHookStdout,
+	checkExternalCodexProcessGuards,
+	checkExploreHarness,
 	checkLegacyMultiAgentCompatibility,
+	checkNativeHookDistSmoke,
+	checkNativeHooks,
+	classifyPostCompactHookStdout,
 } from "../doctor.js";
-import { buildManagedCodexNativeHookCommand } from "../../config/codex-hooks.js";
+import {
+	buildManagedCodexNativeHookCommand,
+	buildManagedCodexNativeHookWindowsShimContent,
+} from "../../config/codex-hooks.js";
 
 const MANAGED_HOOK_EVENTS = [
 	"SessionStart",
@@ -83,6 +87,17 @@ function currentNativeHookCommand(codexHomeDir: string): string {
 	return buildManagedCodexNativeHookCommand(repoRoot(), {
 		codexHomeDir,
 	});
+}
+
+function buildWindowsShimCommand(shimPath: string): string {
+	return `& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File '${shimPath.replace(/'/g, "''")}'`;
+}
+
+function buildWindowsShimHooksJson(shimPath: string, codexHomeDir: string): string {
+	return buildHooksJsonWithPostCompactCommand(
+		buildWindowsShimCommand(shimPath),
+		codexHomeDir,
+	);
 }
 
 async function installPluginCacheFixture(codexDir: string): Promise<string> {
@@ -1191,7 +1206,7 @@ OMX_LORE_COMMIT_GUARD = "truee"
 			);
 			assert.match(
 				res.stdout,
-				/Native hooks: expected setup-owned hooks\.json is missing at .*\.codex[\\/]+hooks\.json even though config\.toml has OMX entries; run "omx setup --force" to restore native hook coverage/,
+				/Native hooks: expected setup-owned hooks\.json is missing at .*\.codex[\\/]+hooks\.json even though config\.toml has OMX entries; run "omx setup" to restore native hook coverage/,
 			);
 			assert.match(res.stdout, /Prompts: prompts directory not found/);
 		} finally {
@@ -1573,7 +1588,7 @@ OMX_LORE_COMMIT_GUARD = "truee"
 			assert.match(
 				res.stdout,
 				new RegExp(
-					`\\[!!\\] Native hooks: plugin-scoped hooks are enabled, but cached plugin hook files or pinned hook launcher in ${cacheDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} do not match the packaged plugin; setup-owned hooks\\.json is intentionally absent at .*\\.codex[\\/]+hooks\\.json; run "omx setup --plugin --force" to refresh the plugin cache`,
+					`\\[!!\\] Native hooks: plugin-scoped hooks are enabled, but cached plugin hook files or pinned hook launcher in ${cacheDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} do not match the packaged plugin; setup-owned hooks\\.json is intentionally absent at .*\\.codex[\\/]+hooks\\.json; run "omx setup --plugin" to refresh the plugin cache`,
 				),
 			);
 			assert.doesNotMatch(res.stdout, /plugin cache native hook coverage smoke passed/);
@@ -1641,7 +1656,7 @@ OMX_LORE_COMMIT_GUARD = "truee"
 			assert.match(
 				res.stdout,
 				new RegExp(
-					`\\[OK\\] Native hooks: plugin-scoped hooks are enabled; existing hooks\\.json at .*\\.codex[\\/]+hooks\\.json is treated as user-owned because plugin-scoped hooks are enabled, and plugin cache native hook coverage smoke passed via ${join(cacheDir, "hooks", "hooks.json").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
+					`\\[OK\\] Native hooks: plugin-scoped hooks are enabled; existing hooks\\.json at .*\\.codex[\\/]+hooks\\.json is retained read-only and validated separately because plugin-scoped hooks are enabled, and plugin cache native hook coverage smoke passed via ${join(cacheDir, "hooks", "hooks.json").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
 				),
 			);
 			assert.doesNotMatch(res.stdout, /hooks\.json is missing OMX-managed coverage/);
@@ -1687,7 +1702,7 @@ OMX_LORE_COMMIT_GUARD = "truee"
 			assert.equal(res.status, 0, res.stderr || res.stdout);
 			assert.match(
 				res.stdout,
-				/Native hooks: hooks\.json is missing OMX-managed coverage for PreToolUse, PostToolUse, UserPromptSubmit, PreCompact, PostCompact, Stop; run "omx setup --force" to restore native hooks/,
+				/Native hooks: hooks\.json is missing OMX-managed coverage for PreToolUse, PostToolUse, UserPromptSubmit, PreCompact, PostCompact, Stop; run "omx setup" to restore native hooks/,
 			);
 		} finally {
 			await rm(wd, { recursive: true, force: true });
@@ -1766,7 +1781,7 @@ command = "node"
 			assert.equal(res.status, 0, res.stderr || res.stdout);
 			assert.match(
 				res.stdout,
-				/Native hooks: expected setup-owned hooks\.json is missing at .*\.codex[\/]+hooks\.json even though config\.toml has OMX entries; run "omx setup --force" to restore native hook coverage/,
+				/Native hooks: expected setup-owned hooks\.json is missing at .*\.codex[\/]+hooks\.json even though config\.toml has OMX entries; run "omx setup" to restore native hook coverage/,
 			);
 		} finally {
 			await rm(wd, { recursive: true, force: true });
@@ -1789,8 +1804,247 @@ command = "node"
 			assert.equal(res.status, 0, res.stderr || res.stdout);
 			assert.match(
 				res.stdout,
-				/\[XX\] Native hooks: invalid hooks\.json; Codex may skip OMX hook coverage until "omx setup --force" repairs it/,
+				/\[XX\] Native hooks: hooks\.json failed strict load validation \(invalid_document\): hooks\.json must contain a JSON object; inspect the file manually because doctor will not modify it/,
 			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("reports matcher-aware discovery warnings without touching hooks.json", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-hooks-matcher-warning-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(codexDir, "hooks.json"),
+				JSON.stringify({
+					hooks: {
+						SessionStart: [{
+							matcher: "[",
+							hooks: [{ type: "command", command: "echo user-owned" }],
+						}],
+					},
+				}, null, 2) + "\n",
+			);
+
+			const res = runOmx(wd, ["doctor"], { HOME: home, CODEX_HOME: codexDir });
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Native hooks: hooks\.json discovery warnings: SessionStart\[0\]: Codex skips groups whose matcher is not a valid regular expression; Codex may ignore the listed entries, and doctor will not modify them/,
+			);
+			assert.doesNotMatch(res.stdout, /Native hooks:.*--force/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("treats UserPromptSubmit and Stop matcher groups as valid foreign survivors", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-hooks-foreign-survivors-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(codexDir, "hooks.json"),
+				JSON.stringify({
+					hooks: {
+						UserPromptSubmit: [{ matcher: "[", hooks: [{ type: "command", command: "echo prompt" }] }],
+						Stop: [{ matcher: "[", hooks: [{ type: "command", command: "echo stop" }] }],
+					},
+				}, null, 2) + "\n",
+			);
+
+			const res = runOmx(wd, ["doctor"], { HOME: home, CODEX_HOME: codexDir });
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/\[OK\] Native hooks: hooks\.json contains valid foreign hook entries and no OMX-managed wrappers; doctor will preserve the user-owned configuration/,
+			);
+			assert.doesNotMatch(res.stdout, /hooks\.json discovery warnings/);
+			assert.doesNotMatch(res.stdout, /Native hooks:.*--force/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("reports unsafe managed removal without recommending destructive repair", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-hooks-unsafe-removal-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(codexDir, "hooks.json"),
+				JSON.stringify({
+					hooks: {
+						SessionStart: [{
+							matcher: "startup|resume|clear",
+							hooks: [
+								{ type: "command", command: 'node "/repo/dist/scripts/codex-native-hook.js"' },
+								{ type: "command", command: "echo user-owned" },
+							],
+						}],
+					},
+				}, null, 2) + "\n",
+			);
+
+			const res = runOmx(wd, ["doctor"], { HOME: home, CODEX_HOME: codexDir });
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/\[!!\] Native hooks: hooks\.json has OMX entries that cannot be safely removed \(unsafe_managed_removal\): Removing OMX hooks would shift a foreign coordinate or discard opaque metadata; manual cleanup is required because doctor will not overwrite or remove it/,
+			);
+			assert.doesNotMatch(res.stdout, /Native hooks:.*--force/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("fails closed when a Windows native hook references a missing shim", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-windows-shim-missing-"));
+		try {
+			const codexDir = join(wd, ".codex");
+			const hooksPath = join(codexDir, "hooks.json");
+			const shimPath = join(codexDir, "hooks", "omx-native-hook-windows-shim.ps1");
+			await mkdir(codexDir, { recursive: true });
+			const original = buildWindowsShimHooksJson(shimPath, codexDir);
+			await writeFile(hooksPath, original);
+
+			const check = await checkNativeHooks(hooksPath, join(codexDir, "config.toml"), {
+				codexHomeDir: codexDir,
+				platform: "win32",
+			});
+			assert.equal(check.status, "fail");
+			assert.match(check.message, /referenced Windows native hook shim is missing at/);
+			assert.match(check.message, /manually reinstall the matching oh-my-codex version/);
+			assert.doesNotMatch(check.message, /omx setup|--force/);
+			assert.equal(existsSync(shimPath), false);
+			assert.equal(await readFile(hooksPath, "utf-8"), original);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("fails closed when a referenced Windows native hook shim is tampered", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-windows-shim-tampered-"));
+		try {
+			const codexDir = join(wd, ".codex");
+			const hooksPath = join(codexDir, "hooks.json");
+			const shimPath = join(codexDir, "hooks", "omx-native-hook-windows-shim.ps1");
+			await mkdir(dirname(shimPath), { recursive: true });
+			const original = buildWindowsShimHooksJson(shimPath, codexDir);
+			const tamperedShim = `${buildManagedCodexNativeHookWindowsShimContent(repoRoot())}# user change\n`;
+			await writeFile(hooksPath, original);
+			await writeFile(shimPath, tamperedShim, "utf-8");
+
+			const check = await checkNativeHooks(hooksPath, join(codexDir, "config.toml"), {
+				codexHomeDir: codexDir,
+				platform: "win32",
+			});
+			assert.equal(check.status, "fail");
+			assert.match(check.message, /not an exact current or complete historical generated shim/);
+			assert.match(check.message, /modified, truncated, have extra content, or use ambiguous encoding/);
+			assert.doesNotMatch(check.message, /omx setup|--force/);
+			assert.equal(await readFile(hooksPath, "utf-8"), original);
+			assert.equal(await readFile(shimPath, "utf-8"), tamperedShim);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("accepts a complete historical Windows native hook shim without modifying it", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-windows-shim-historical-"));
+		try {
+			const codexDir = join(wd, ".codex");
+			const hooksPath = join(codexDir, "hooks.json");
+			const shimPath = join(codexDir, "hooks", "omx-native-hook-windows-shim.ps1");
+			await mkdir(dirname(shimPath), { recursive: true });
+			const original = buildWindowsShimHooksJson(shimPath, codexDir);
+			const historicalShim = buildManagedCodexNativeHookWindowsShimContent(
+				join(wd, "historical-oh-my-codex"),
+				{ nodePath: join(wd, "historical", "node.exe") },
+			);
+			await writeFile(hooksPath, original);
+			await writeFile(shimPath, historicalShim, "utf-8");
+
+			const check = await checkNativeHooks(hooksPath, join(codexDir, "config.toml"), {
+				codexHomeDir: codexDir,
+				platform: "win32",
+			});
+			assert.equal(check.status, "pass");
+			assert.match(check.message, /includes OMX-managed coverage for all native hook events/);
+			assert.equal(await readFile(hooksPath, "utf-8"), original);
+			assert.equal(await readFile(shimPath, "utf-8"), historicalShim);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("reports exact nested legacy hook trust state as migration-required without modifying hooks.json", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-hooks-legacy-trust-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			const parsed = JSON.parse(
+				buildHooksJsonWithPostCompactCommand(currentNativeHookCommand(codexDir), codexDir),
+			) as { hooks: Record<string, unknown> };
+			parsed.hooks.state = {
+				"custom:/hooks.json:stop:0:0": {
+					trusted_hash: "sha256:legacy",
+					enabled: false,
+				},
+			};
+			const hooksPath = join(codexDir, "hooks.json");
+			const original = `${JSON.stringify(parsed, null, 2)}\n`;
+			await writeFile(hooksPath, original);
+
+			const res = runOmx(wd, ["doctor"], { HOME: home, CODEX_HOME: codexDir });
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/\[!!\] Native hooks: hooks\.json contains 1 exact historical OMX hook trust-state entry that requires migration; run "omx setup" to migrate it after reviewing the configuration/,
+			);
+			assert.doesNotMatch(res.stdout, /Native hooks: hooks\.json includes OMX-managed coverage/);
+			assert.doesNotMatch(res.stdout, /Native hooks:.*--force/);
+			assert.equal(await readFile(hooksPath, "utf-8"), original);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves nonmatching nested hooks.state without reporting a migration", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-hooks-nonlegacy-state-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			const parsed = JSON.parse(
+				buildHooksJsonWithPostCompactCommand(currentNativeHookCommand(codexDir), codexDir),
+			) as { hooks: Record<string, unknown> };
+			parsed.hooks.state = {
+				retained: { custom: true, trusted_hash: "sha256:not-omx" },
+			};
+			const hooksPath = join(codexDir, "hooks.json");
+			const original = `${JSON.stringify(parsed, null, 2)}\n`;
+			await writeFile(hooksPath, original);
+
+			const res = runOmx(wd, ["doctor"], { HOME: home, CODEX_HOME: codexDir });
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/\[OK\] Native hooks: hooks\.json includes OMX-managed coverage for all native hook events/,
+			);
+			assert.doesNotMatch(res.stdout, /Native hooks:.*legacy OMX hook trust-state/);
+			assert.equal(await readFile(hooksPath, "utf-8"), original);
 		} finally {
 			await rm(wd, { recursive: true, force: true });
 		}
@@ -1926,11 +2180,9 @@ command = "node"
 			assert.equal(check.name, "Native hook dist smoke");
 			assert.equal(check.status, "fail");
 			assert.match(check.message, /minimal UserPromptSubmit smoke/);
-			assert.match(
-				check.message,
-				/npm install -g oh-my-codex@0\.18\.0 --force --min-release-age=0 --before=/,
-			);
-			assert.match(check.message, /omx setup --force/);
+			assert.match(check.message, /reinstall the matching oh-my-codex version/);
+			assert.doesNotMatch(check.message, /--force/);
+			assert.match(check.message, /run "omx setup"/);
 		} finally {
 			await rm(wd, { recursive: true, force: true });
 		}
@@ -2072,6 +2324,153 @@ command = "node"
 			assert.match(res.stdout, /\[!!\] GPT-5\.6 multi-agent compatibility:/);
 			assert.match(res.stdout, /Results: \d+ passed, [1-9]\d* warnings, \d+ failed/);
 			assert.doesNotMatch(res.stdout, /All checks passed!/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("validates an existing global hooks.json before reporting plugin-cache status", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-global-invalid-"));
+		try {
+			const codexDir = join(wd, ".codex");
+			const configPath = join(codexDir, "config.toml");
+			const hooksPath = join(codexDir, "hooks.json");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(configPath, "plugin_hooks = true\n");
+			await writeFile(hooksPath, '{"state":{}}\n');
+
+			const check = await checkNativeHooks(hooksPath, configPath, {
+				codexHomeDir: codexDir,
+				installMode: "plugin",
+			});
+
+			assert.equal(check.status, "fail");
+			assert.match(check.message, /plugin-scoped hooks are enabled/);
+			assert.match(check.message, /existing global hooks\.json: hooks\.json failed strict load validation/);
+			assert.match(check.message, /unknown root field state/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("fails plugin mode when an existing global Windows shim is tampered", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-global-shim-"));
+		try {
+			const codexDir = join(wd, ".codex");
+			const configPath = join(codexDir, "config.toml");
+			const hooksPath = join(codexDir, "hooks.json");
+			const shimPath = join(codexDir, "hooks", "omx-native-hook-windows-shim.ps1");
+			await mkdir(dirname(shimPath), { recursive: true });
+			await writeFile(configPath, "plugin_hooks = true\n");
+			await writeFile(
+				hooksPath,
+				`${JSON.stringify({
+					hooks: {
+						PostCompact: [{ hooks: [{ type: "command", command: buildWindowsShimCommand(shimPath) }] }],
+					},
+				})}\n`,
+			);
+			await writeFile(shimPath, "# modified\n");
+
+			const check = await checkNativeHooks(hooksPath, configPath, {
+				codexHomeDir: codexDir,
+				installMode: "plugin",
+				platform: "win32",
+			});
+
+			assert.equal(check.status, "fail");
+			assert.match(check.message, /not an exact current or complete historical generated shim/);
+			assert.match(check.message, /plugin-scoped hooks are enabled/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("fails ambiguous managed handler ownership instead of downgrading it to a warning", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-ambiguous-managed-handler-"));
+		try {
+			const codexDir = join(wd, ".codex");
+			const hooksPath = join(codexDir, "hooks.json");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				hooksPath,
+				`${JSON.stringify({
+					hooks: {
+						SessionStart: [{
+							matcher: "startup|resume|clear",
+							hooks: [{ type: "command", command: "node /repo/dist/scripts/codex-native-hook.js --unexpected" }],
+						}],
+					},
+				})}\n`,
+			);
+
+			const check = await checkNativeHooks(hooksPath, join(codexDir, "config.toml"), {
+				codexHomeDir: codexDir,
+			});
+
+			assert.equal(check.status, "fail");
+			assert.match(check.message, /ambiguous_managed_handler/);
+			assert.match(check.message, /ambiguous or untrusted OMX ownership/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("fails closed instead of recognizing a shell-expanding foreign command as an OMX hook", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-shell-expanding-handler-"));
+		try {
+			const codexDir = join(wd, ".codex");
+			const hooksPath = join(codexDir, "hooks.json");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				hooksPath,
+				`${JSON.stringify({
+					hooks: {
+						SessionStart: [{
+							matcher: "startup|resume|clear",
+							hooks: [{ type: "command", command: 'node "$HOME/repo/dist/scripts/codex-native-hook.js"' }],
+						}],
+					},
+				})}\n`,
+			);
+
+			const check = await checkNativeHooks(hooksPath, join(codexDir, "config.toml"), {
+				codexHomeDir: codexDir,
+			});
+			assert.equal(check.status, "fail");
+			assert.match(check.message, /ambiguous_managed_handler|does not match the managed command grammar/i);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("ignores prompt, agent, and future-event metadata while scanning Windows shim references", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-inert-shim-metadata-"));
+		try {
+			const codexDir = join(wd, ".codex");
+			const hooksPath = join(codexDir, "hooks.json");
+			const missingShimPath = join(codexDir, "hooks", "omx-native-hook-windows-shim.ps1");
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				hooksPath,
+				`${JSON.stringify({
+					hooks: {
+						PostCompact: [{ hooks: [
+							{ type: "prompt", command: buildWindowsShimCommand(missingShimPath) },
+							{ type: "agent", commandWindows: buildWindowsShimCommand(missingShimPath) },
+						] }],
+						FutureSerdeEvent: [{ hooks: [{ type: "command", command: buildWindowsShimCommand(missingShimPath) }] }],
+					},
+				})}\n`,
+			);
+
+			const check = await checkNativeHooks(hooksPath, join(codexDir, "config.toml"), {
+				codexHomeDir: codexDir,
+				platform: "win32",
+			});
+
+			assert.equal(check.status, "warn");
+			assert.match(check.message, /hooks\.json discovery warnings/);
+			assert.doesNotMatch(check.message, /referenced Windows native hook shim/);
 		} finally {
 			await rm(wd, { recursive: true, force: true });
 		}

--- a/src/cli/__tests__/native-hook-claim-journal.test.ts
+++ b/src/cli/__tests__/native-hook-claim-journal.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import {
+	clearNativeHookClaimJournal,
+	persistNativeHookClaimJournal,
+	recoverNativeHookClaimJournal,
+} from "../native-hook-claim-journal.js";
+
+async function markJournalOwnerDead(root: string): Promise<void> {
+	const path = join(root, ".omx", "native-hook-claim-journal.json");
+	const journal = JSON.parse(await readFile(path, "utf-8")) as { ownerPid: number };
+	journal.ownerPid = 2_147_483_647;
+	await writeFile(path, `${JSON.stringify(journal, null, 2)}\n`, "utf-8");
+}
+
+test("claim journal restores an exact original after rename-away interruption", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-recovery-"));
+	try {
+		const canonicalPath = join(root, "hooks.json");
+		const claimPath = join(root, ".hooks.json.omx-claim-test.tmp");
+		const before = Buffer.from('{"hooks":{}}\n');
+		await writeFile(canonicalPath, before);
+		await persistNativeHookClaimJournal(root, {
+			canonicalPath,
+			claimPath,
+			before,
+			after: null,
+		});
+		await rename(canonicalPath, claimPath);
+		await markJournalOwnerDead(root);
+
+		assert.equal(await recoverNativeHookClaimJournal(root), true);
+		assert.deepEqual(await readFile(canonicalPath), before);
+		assert.equal(await recoverNativeHookClaimJournal(root), false);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim journal finalizes an exact installed successor and removes the parked original", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-finalize-"));
+	try {
+		const canonicalPath = join(root, "config.toml");
+		const claimPath = join(root, ".config.toml.omx-claim-test.tmp");
+		const before = Buffer.from('model = "before"\n');
+		const after = Buffer.from('model = "after"\n');
+		await writeFile(claimPath, before);
+		await writeFile(canonicalPath, after);
+		await persistNativeHookClaimJournal(root, {
+			canonicalPath,
+			claimPath,
+			before,
+			after,
+		});
+		await markJournalOwnerDead(root);
+
+		assert.equal(await recoverNativeHookClaimJournal(root), true);
+		assert.deepEqual(await readFile(canonicalPath), after);
+		await assert.rejects(readFile(claimPath), /ENOENT/);
+	} finally {
+		await clearNativeHookClaimJournal(root).catch(() => undefined);
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim journal refuses to overwrite unrecognized canonical content", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-conflict-"));
+	try {
+		const canonicalPath = join(root, "hooks.json");
+		const claimPath = join(root, ".hooks.json.omx-claim-test.tmp");
+		const before = Buffer.from("before\n");
+		await writeFile(claimPath, before);
+		await writeFile(canonicalPath, "foreign\n");
+		await persistNativeHookClaimJournal(root, {
+			canonicalPath,
+			claimPath,
+			before,
+			after: Buffer.from("managed\n"),
+		});
+		await markJournalOwnerDead(root);
+		await assert.rejects(
+			recoverNativeHookClaimJournal(root),
+			/cannot recover without overwriting unrecognized canonical content/,
+		);
+		assert.equal(await readFile(canonicalPath, "utf-8"), "foreign\n");
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim journal refuses to overwrite an existing recovery record", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-existing-"));
+	try {
+		const firstCanonicalPath = join(root, "hooks.json");
+		const firstClaimPath = join(root, ".hooks.json.omx-claim-first.tmp");
+		const first = Buffer.from("first\n");
+		await persistNativeHookClaimJournal(root, {
+			canonicalPath: firstCanonicalPath,
+			claimPath: firstClaimPath,
+			before: first,
+			after: null,
+		});
+		const journalPath = join(root, ".omx", "native-hook-claim-journal.json");
+		const originalJournal = await readFile(journalPath);
+
+		await assert.rejects(
+			persistNativeHookClaimJournal(root, {
+				canonicalPath: join(root, "config.toml"),
+				claimPath: join(root, ".config.toml.omx-claim-second.tmp"),
+				before: Buffer.from("second\n"),
+				after: null,
+			}),
+			/EEXIST/,
+		);
+		assert.deepEqual(await readFile(journalPath), originalJournal);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim journal finalizes a completed deletion after claim removal", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-deleted-"));
+	try {
+		const canonicalPath = join(root, "hooks.json");
+		const claimPath = join(root, ".hooks.json.omx-claim-deleted.tmp");
+		await persistNativeHookClaimJournal(root, {
+			canonicalPath,
+			claimPath,
+			before: Buffer.from("before\n"),
+			after: null,
+		});
+		await markJournalOwnerDead(root);
+
+		assert.equal(await recoverNativeHookClaimJournal(root), true);
+		assert.equal(await recoverNativeHookClaimJournal(root), false);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});

--- a/src/cli/__tests__/setup-hooks-shared-ownership.test.ts
+++ b/src/cli/__tests__/setup-hooks-shared-ownership.test.ts
@@ -26,6 +26,22 @@ type HooksFile = {
   [key: string]: unknown;
 };
 
+const MANAGED_HOOK_EVENTS = [
+  "SessionStart",
+  "PreToolUse",
+  "PostToolUse",
+  "UserPromptSubmit",
+  "PreCompact",
+  "PostCompact",
+  "Stop",
+] as const;
+
+function codexHookEventLabel(eventName: string): string {
+  return eventName
+    .replace(/([A-Z])/g, "_$1")
+    .toLowerCase()
+    .replace(/^_/, "");
+}
 function runOmx(
   cwd: string,
   argv: string[],
@@ -165,6 +181,53 @@ describe("omx setup/uninstall shared ownership for native hooks", () => {
     }
   });
 
+  it("keeps all final trust coordinates stable across a no-op rerun with interleaved foreign groups", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-hooks-final-coordinates-"));
+    try {
+      const home = join(wd, "home");
+      const codexDir = join(wd, ".codex");
+      await mkdir(home, { recursive: true });
+      await mkdir(codexDir, { recursive: true });
+
+      const hooksPath = join(codexDir, "hooks.json");
+      await writeHooksJson(hooksPath, {
+        hooks: Object.fromEntries(
+          MANAGED_HOOK_EVENTS.map((eventName) => [
+            eventName,
+            [makeUserCommandHook(`node "/custom/${eventName}.js"`)],
+          ]),
+        ),
+      });
+
+      const firstSetup = runOmx(wd, ["setup", "--scope", "project"], { HOME: home });
+      if (shouldSkipForSpawnPermissions(firstSetup.error)) return;
+      assert.equal(firstSetup.status, 0, firstSetup.stderr || firstSetup.stdout);
+
+      const firstHooks = await readFile(hooksPath, "utf-8");
+      const configPath = join(codexDir, "config.toml");
+      const firstConfig = await readFile(configPath, "utf-8");
+      const escapedHooksPath = hooksPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      for (const eventName of MANAGED_HOOK_EVENTS) {
+        assert.match(
+          firstConfig,
+          new RegExp(
+            `^\\[hooks\\.state\\."${escapedHooksPath}:${codexHookEventLabel(eventName)}:1:0"\\]$`,
+            "m",
+          ),
+          `${eventName} trust must use its final interleaved group position`,
+        );
+      }
+
+      const secondSetup = runOmx(wd, ["setup", "--scope", "project"], { HOME: home });
+      if (shouldSkipForSpawnPermissions(secondSetup.error)) return;
+      assert.equal(secondSetup.status, 0, secondSetup.stderr || secondSetup.stdout);
+      assert.equal(await readFile(hooksPath, "utf-8"), firstHooks);
+      assert.equal(await readFile(configPath, "utf-8"), firstConfig);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("setup preserves user hooks while deduping stale OMX wrappers", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-hooks-ownership-"));
     try {
@@ -182,7 +245,7 @@ describe("omx setup/uninstall shared ownership for native hooks", () => {
 
       const staleManagedSessionStart = cloneRegistration(generatedSessionStart[0]!);
       if (staleManagedSessionStart.hooks?.[0]) {
-        staleManagedSessionStart.hooks[0].command = 'node "/tmp/old/codex-native-hook.js"';
+        staleManagedSessionStart.hooks[0].command = 'node "/tmp/old/dist/scripts/codex-native-hook.js"';
         staleManagedSessionStart.hooks[0].statusMessage = "stale omx wrapper";
       }
 
@@ -267,8 +330,8 @@ describe("omx setup/uninstall shared ownership for native hooks", () => {
             ...(generated.hooks?.SessionStart ?? []),
           ],
           PostToolUse: [
-            ...(generated.hooks?.PostToolUse ?? []),
             makeUserCommandHook('node "/custom/post-tool.js"'),
+            ...(generated.hooks?.PostToolUse ?? []),
           ],
         },
       });
@@ -352,6 +415,28 @@ describe("omx setup/uninstall shared ownership for native hooks", () => {
         await readFile(join(codexDir, "agents", "custom-role.toml"), "utf-8"),
         "model = \"custom\"\n",
       );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it("preserves malformed hooks.json bytes and creates no native setup artifacts", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-setup-invalid-hooks-"));
+    try {
+      const home = join(wd, "home");
+      const codexDir = join(wd, ".codex");
+      const hooksPath = join(codexDir, "hooks.json");
+      const invalidBytes = Buffer.from([0x7b, 0x80, 0x7d, 0x0a]);
+      await mkdir(home, { recursive: true });
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(hooksPath, invalidBytes);
+
+      const result = runOmx(wd, ["setup", "--scope", "project"], { HOME: home });
+      if (shouldSkipForSpawnPermissions(result.error)) return;
+      assert.notEqual(result.status, 0, result.stderr || result.stdout);
+      assert.match(`${result.stderr}\n${result.stdout}`, /invalid UTF-8/);
+      assert.deepEqual(await readFile(hooksPath), invalidBytes);
+      assert.equal(existsSync(join(codexDir, "config.toml")), false);
+      assert.equal(existsSync(join(wd, ".omx")), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/setup-hooks-trust-e2e.test.ts
+++ b/src/cli/__tests__/setup-hooks-trust-e2e.test.ts
@@ -1,0 +1,395 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import {
+  ManagedCodexHooksPlanError,
+  planManagedCodexHooksRemoval,
+} from '../../config/codex-hooks.js';
+
+import {
+  CODEX_APP_SERVER_TIMEOUTS,
+  CodexAppServer,
+  CodexExecutableNotFoundError,
+  appendDisplayOrderStableForeignHookGroups,
+  approveManagedHooksInCodex,
+  assertCodexBatchWriteResult,
+  assertForeignHookGroupsPreserved,
+  assertGeneratedTrustMatchesCodex,
+  createCodexBatchWriteEnvelope,
+  foreignHookGroupSnapshot,
+  generatedHookTrustState,
+  hookMetadataSnapshot,
+  initializeCodexAppServer,
+  listCodexHooks,
+  managedCodexHooksByEvent,
+  probeCodexVersion,
+  type CodexHookMetadata,
+} from '../../scripts/smoke-packed-install.js';
+
+function isolatedEnv(home: string, codexHome: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, HOME: home, CODEX_HOME: codexHome };
+  for (const key of [
+    'OMX_SESSION_ID',
+    'OMX_RUN_ID',
+    'OMX_ROOT',
+    'OMX_STATE_ROOT',
+    'OMX_ACTIVE_SESSION_PID',
+    'CODEX_SESSION_ID',
+    'TMUX',
+    'TMUX_PANE',
+  ]) {
+    delete env[key];
+  }
+  return env;
+}
+
+function escapedTomlBasicString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function trustedProjectConfig(projectDir: string): string {
+  return [
+    `[projects."${escapedTomlBasicString(projectDir)}"]`,
+    'trust_level = "trusted"',
+    '',
+  ].join('\n');
+}
+
+
+function runRepoOmxResult(projectDir: string, argv: string[], env: NodeJS.ProcessEnv) {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const omxBin = join(testDir, '..', '..', '..', 'dist', 'cli', 'omx.js');
+  return spawnSync(process.execPath, [omxBin, ...argv], {
+    cwd: projectDir,
+    env,
+    encoding: 'utf-8',
+  });
+}
+
+function runRepoOmx(projectDir: string, argv: string[], env: NodeJS.ProcessEnv): void {
+  const result = runRepoOmxResult(projectDir, argv, env);
+  if (result.error) throw result.error;
+  assert.equal(
+    result.status,
+    0,
+    `repo omx ${argv.join(' ')} failed\nstdout:\n${result.stdout || ''}\nstderr:\n${result.stderr || ''}`,
+  );
+}
+
+async function assertNoUninstallTransactionArtifacts(codexDir: string): Promise<void> {
+  const artifacts = (await readdir(codexDir)).filter((entry) => entry.includes('.omx-uninstall-'));
+  assert.deepEqual(
+    artifacts,
+    [],
+    `unsafe uninstall left replacement, staged, or tombstone paths: ${artifacts.join(', ')}`,
+  );
+}
+
+
+async function observeHooks(
+  projectDir: string,
+  hooksPath: string,
+  env: NodeJS.ProcessEnv,
+): Promise<CodexHookMetadata[]> {
+  const server = await CodexAppServer.start({ cwd: projectDir, env });
+  try {
+    await initializeCodexAppServer(server, 'omx-hook-trust-regression');
+    return (await listCodexHooks(server, projectDir, hooksPath)).hooks;
+  } finally {
+    await server.close();
+  }
+}
+
+function assertTrustedOmxHooks(hooks: readonly CodexHookMetadata[]): void {
+  for (const [event, hook] of Object.entries(managedCodexHooksByEvent(hooks))) {
+    assert.equal(hook.trustStatus, 'trusted', `Codex did not trust OMX ${event}`);
+  }
+}
+
+function assertUnapprovedOmxHooks(hooks: readonly CodexHookMetadata[]): void {
+  for (const [event, hook] of Object.entries(managedCodexHooksByEvent(hooks))) {
+    assert.notEqual(hook.trustStatus, 'trusted', `setup-generated trust pre-approved OMX ${event}`);
+  }
+}
+
+function omxMetadataSnapshot(hooks: readonly CodexHookMetadata[]): unknown[] {
+  return hookMetadataSnapshot(Object.values(managedCodexHooksByEvent(hooks)));
+}
+
+function foreignMetadataSnapshot(hooks: readonly CodexHookMetadata[], marker: string) {
+  return hookMetadataSnapshot(hooks.filter((hook) => hook.command.includes(marker)));
+}
+
+
+test('Linux installed-Codex hooks/list preserves full foreign metadata through uninstall (no macOS claim)', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'omx-setup-hooks-trust-e2e-'));
+  const projectDir = resolve(root, 'project');
+  const home = join(root, 'home');
+  const codexHome = join(root, 'codex-home');
+  const hooksPath = join(projectDir, '.codex', 'hooks.json');
+  const configPath = join(projectDir, '.codex', 'config.toml');
+  const foreignMarker = 'omx-hook-trust-e2e-foreign';
+  const env = isolatedEnv(home, codexHome);
+
+  try {
+    await Promise.all([
+      mkdir(projectDir, { recursive: true }),
+      mkdir(home, { recursive: true }),
+      mkdir(codexHome, { recursive: true }),
+      mkdir(join(projectDir, '.codex'), { recursive: true }),
+    ]);
+    await writeFile(join(codexHome, 'config.toml'), trustedProjectConfig(projectDir), 'utf-8');
+    await writeFile(
+      hooksPath,
+      appendDisplayOrderStableForeignHookGroups('{"hooks":{}}', foreignMarker, { appendGroups: true }),
+      'utf-8',
+    );
+    const preSetupForeignRawSnapshot = foreignHookGroupSnapshot(
+      await readFile(hooksPath, 'utf-8'),
+      foreignMarker,
+    );
+    assert.equal(preSetupForeignRawSnapshot.length, 2, 'pre-approved foreign coordinates should be recorded');
+
+    // Linux-only evidence is recorded by this regression; it deliberately makes no macOS claim.
+    let codexVersion: string;
+    try {
+      codexVersion = probeCodexVersion(projectDir, env);
+    } catch (error) {
+      if (error instanceof CodexExecutableNotFoundError) {
+        t.skip('codex executable is absent; installed-Codex boundary is the only skipped condition');
+        return;
+      }
+      throw error;
+    }
+    assert.equal(
+      process.platform,
+      'linux',
+      `This regression records Linux-only Codex evidence (${codexVersion}) and makes no macOS claim.`,
+    );
+
+    const foreignApprovalServer = await CodexAppServer.start({ cwd: projectDir, env });
+    try {
+      await initializeCodexAppServer(foreignApprovalServer, 'omx-hook-trust-regression');
+      const preSetupForeignHooks = (await listCodexHooks(foreignApprovalServer, projectDir, hooksPath)).hooks
+        .filter((hook) => hook.command.includes(foreignMarker));
+      assert.equal(preSetupForeignHooks.length, 2, 'Codex must discover both pre-seeded foreign hooks');
+      assert.ok(
+        preSetupForeignHooks.every((hook) => hook.trustStatus !== 'trusted'),
+        'isolated Codex state must not pre-approve foreign hooks',
+      );
+      const approval = await foreignApprovalServer.request<unknown>(
+        createCodexBatchWriteEnvelope(Object.fromEntries(
+          preSetupForeignHooks.map((hook) => [hook.key, hook.currentHash]),
+        )),
+        CODEX_APP_SERVER_TIMEOUTS.requestMs,
+      );
+      assertCodexBatchWriteResult(approval, join(codexHome, 'config.toml'));
+    } finally {
+      await foreignApprovalServer.close();
+    }
+    const preapprovedForeignMetadata = foreignMetadataSnapshot(
+      await observeHooks(projectDir, hooksPath, env),
+      foreignMarker,
+    );
+    assert.equal(preapprovedForeignMetadata.length, 2);
+    assert.ok(preapprovedForeignMetadata.every((hook) => hook.trustStatus === 'trusted'));
+
+    // First installation appends the seven managed groups after both pre-approved foreign groups.
+    runRepoOmx(projectDir, ['setup', '--scope', 'project', '--merge-agents', '--legacy'], env);
+    const initialHooksContent = await readFile(hooksPath, 'utf-8');
+    const initialConfig = await readFile(configPath, 'utf-8');
+    const initialGeneratedTrust = generatedHookTrustState(initialConfig);
+    assertForeignHookGroupsPreserved(preSetupForeignRawSnapshot, initialHooksContent, foreignMarker);
+
+    const approvalServer = await CodexAppServer.start({ cwd: projectDir, env });
+    try {
+      await initializeCodexAppServer(approvalServer, 'omx-hook-trust-regression');
+      const initialHooks = (await listCodexHooks(approvalServer, projectDir, hooksPath)).hooks;
+      assertGeneratedTrustMatchesCodex(initialGeneratedTrust, initialHooks);
+      assertUnapprovedOmxHooks(initialHooks);
+      await approveManagedHooksInCodex(approvalServer, initialHooks, join(codexHome, 'config.toml'));
+    } finally {
+      await approvalServer.close();
+    }
+
+    // Restart after user-layer approval; setup-generated project trust alone is not the proof.
+    const afterInitialApproval = await observeHooks(projectDir, hooksPath, env);
+    assertTrustedOmxHooks(afterInitialApproval);
+    assert.deepEqual(
+      foreignMetadataSnapshot(afterInitialApproval, foreignMarker),
+      preapprovedForeignMetadata,
+      'setup changed pre-approved foreign key, hash, status, or display order',
+    );
+
+    // Add handlers to a pre-approved group to make foreign display-order changes observable.
+    await writeFile(
+      hooksPath,
+      appendDisplayOrderStableForeignHookGroups(
+        await readFile(hooksPath, 'utf-8'),
+        foreignMarker,
+        { appendGroups: false },
+      ),
+      'utf-8',
+    );
+    const postForeignHooksContent = await readFile(hooksPath, 'utf-8');
+    const postForeignConfig = await readFile(configPath, 'utf-8');
+    const foreignRawSnapshot = foreignHookGroupSnapshot(postForeignHooksContent, foreignMarker);
+    assert.equal(foreignRawSnapshot.length, 4, 'foreign group and handler coordinates should be recorded');
+
+    // Restart after the hooks mutation and snapshot the legitimate post-insertion display ordering.
+    const postForeignHooks = await observeHooks(projectDir, hooksPath, env);
+    assertTrustedOmxHooks(postForeignHooks);
+    const expectedOmxMetadata = omxMetadataSnapshot(postForeignHooks);
+    const expectedForeignMetadata = foreignMetadataSnapshot(postForeignHooks, foreignMarker);
+    assert.equal(expectedForeignMetadata.length, 4, 'Codex must discover all foreign command hooks');
+    assert.deepEqual(
+      expectedForeignMetadata.filter((hook) => !hook.command.includes('-inserted.js')),
+      preapprovedForeignMetadata,
+      'foreign insertion changed pre-approved foreign metadata',
+    );
+
+    // Rerun must refresh OMX in place without moving the foreign groups or handlers.
+    runRepoOmx(projectDir, ['setup', '--scope', 'project', '--merge-agents', '--legacy'], env);
+    assert.equal(await readFile(hooksPath, 'utf-8'), postForeignHooksContent, 'rerun changed hooks.json');
+    assert.equal(await readFile(configPath, 'utf-8'), postForeignConfig, 'rerun changed config.toml');
+    assertForeignHookGroupsPreserved(foreignRawSnapshot, await readFile(hooksPath, 'utf-8'), foreignMarker);
+
+    const afterRerunHooks = await observeHooks(projectDir, hooksPath, env);
+    assertTrustedOmxHooks(afterRerunHooks);
+    assert.deepEqual(omxMetadataSnapshot(afterRerunHooks), expectedOmxMetadata);
+    assert.deepEqual(foreignMetadataSnapshot(afterRerunHooks, foreignMarker), expectedForeignMetadata);
+
+    // A third setup is the idempotence check and must remain a byte no-op at the real boundary.
+    runRepoOmx(projectDir, ['setup', '--scope', 'project', '--merge-agents', '--legacy'], env);
+    assert.equal(await readFile(hooksPath, 'utf-8'), postForeignHooksContent, 'third setup changed hooks.json');
+    assert.equal(await readFile(configPath, 'utf-8'), postForeignConfig, 'third setup changed config.toml');
+    assertForeignHookGroupsPreserved(foreignRawSnapshot, await readFile(hooksPath, 'utf-8'), foreignMarker);
+    const afterNoopHooks = await observeHooks(projectDir, hooksPath, env);
+    assertTrustedOmxHooks(afterNoopHooks);
+    assert.deepEqual(omxMetadataSnapshot(afterNoopHooks), expectedOmxMetadata);
+    assert.deepEqual(foreignMetadataSnapshot(afterNoopHooks, foreignMarker), expectedForeignMetadata);
+
+    runRepoOmx(projectDir, ['uninstall'], env);
+    const afterUninstallHooksContent = await readFile(hooksPath, 'utf-8');
+    assertForeignHookGroupsPreserved(foreignRawSnapshot, afterUninstallHooksContent, foreignMarker);
+    const afterUninstallHooks = await observeHooks(projectDir, hooksPath, env);
+    assert.deepEqual(
+      foreignMetadataSnapshot(afterUninstallHooks, foreignMarker),
+      expectedForeignMetadata,
+      'uninstall changed foreign command key, hash, status, or display order',
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('Linux installed-Codex preserves managed-first foreign order and fails unsafe uninstall without writes', async (t) => {
+  assert.equal(
+    process.platform,
+    'linux',
+    'This Linux-only managed-first regression makes no macOS evidence claim.',
+  );
+  const root = await mkdtemp(join(tmpdir(), 'omx-setup-hooks-managed-first-e2e-'));
+  const projectDir = resolve(root, 'project');
+  const home = join(root, 'home');
+  const codexHome = join(root, 'codex-home');
+  const hooksPath = join(projectDir, '.codex', 'hooks.json');
+  const configPath = join(projectDir, '.codex', 'config.toml');
+  const foreignMarker = 'omx-hook-trust-managed-first-foreign';
+  const env = isolatedEnv(home, codexHome);
+
+  try {
+    await Promise.all([
+      mkdir(join(projectDir, '.codex'), { recursive: true }),
+      mkdir(home, { recursive: true }),
+      mkdir(codexHome, { recursive: true }),
+    ]);
+    await writeFile(join(codexHome, 'config.toml'), trustedProjectConfig(projectDir), 'utf-8');
+    try {
+      probeCodexVersion(projectDir, env);
+    } catch (error) {
+      if (error instanceof CodexExecutableNotFoundError) {
+        t.skip('codex executable is absent; installed-Codex boundary is the only skipped condition');
+        return;
+      }
+      throw error;
+    }
+
+    runRepoOmx(projectDir, ['setup', '--scope', 'project', '--merge-agents', '--legacy'], env);
+    const approvalServer = await CodexAppServer.start({ cwd: projectDir, env });
+    try {
+      await initializeCodexAppServer(approvalServer, 'omx-hook-trust-regression');
+      const initialManagedFirstHooks = (await listCodexHooks(approvalServer, projectDir, hooksPath)).hooks;
+      assertUnapprovedOmxHooks(initialManagedFirstHooks);
+      await approveManagedHooksInCodex(
+        approvalServer,
+        initialManagedFirstHooks,
+        join(codexHome, 'config.toml'),
+      );
+    } finally {
+      await approvalServer.close();
+    }
+
+    await writeFile(
+      hooksPath,
+      appendDisplayOrderStableForeignHookGroups(
+        await readFile(hooksPath, 'utf-8'),
+        foreignMarker,
+        { appendGroups: true },
+      ),
+      'utf-8',
+    );
+    const beforeRerunHooks = await readFile(hooksPath, 'utf-8');
+    const beforeRerunConfig = await readFile(configPath, 'utf-8');
+    const foreignRawSnapshot = foreignHookGroupSnapshot(beforeRerunHooks, foreignMarker);
+    assert.deepEqual(foreignRawSnapshot.map((entry) => (entry as { groupIndex: number }).groupIndex), [1, 2]);
+    const beforeRerunCodexHooks = await observeHooks(projectDir, hooksPath, env);
+    assertTrustedOmxHooks(beforeRerunCodexHooks);
+    const beforeRerunMetadata = hookMetadataSnapshot(beforeRerunCodexHooks);
+
+    runRepoOmx(projectDir, ['setup', '--scope', 'project', '--merge-agents', '--legacy'], env);
+    assert.equal(await readFile(hooksPath, 'utf-8'), beforeRerunHooks, 'rerun reordered managed-first hooks.json');
+    assert.equal(await readFile(configPath, 'utf-8'), beforeRerunConfig, 'rerun changed managed-first config.toml');
+    assertForeignHookGroupsPreserved(foreignRawSnapshot, await readFile(hooksPath, 'utf-8'), foreignMarker);
+    const afterRerunCodexHooks = await observeHooks(projectDir, hooksPath, env);
+    assertTrustedOmxHooks(afterRerunCodexHooks);
+    assert.deepEqual(
+      hookMetadataSnapshot(afterRerunCodexHooks),
+      beforeRerunMetadata,
+      'rerun changed Codex key, hash, trust status, or display order',
+    );
+    const beforeUninstallHooksBytes = await readFile(hooksPath);
+    const beforeUninstallConfigBytes = await readFile(configPath);
+
+    const expectedUnsafeManagedRemovalDiagnostic =
+      'Removing OMX hooks would shift a foreign coordinate or discard opaque metadata.';
+    const unsafeRemoval = planManagedCodexHooksRemoval(beforeRerunHooks, hooksPath);
+    assert.equal(unsafeRemoval.ok, false);
+    if (unsafeRemoval.ok) return;
+    assert.ok(unsafeRemoval.error instanceof ManagedCodexHooksPlanError);
+    assert.equal(unsafeRemoval.error.code, 'unsafe_managed_removal');
+    assert.equal(unsafeRemoval.error.message, expectedUnsafeManagedRemovalDiagnostic);
+
+    const uninstall = runRepoOmxResult(projectDir, ['uninstall'], env);
+    if (uninstall.error) throw uninstall.error;
+    assert.equal(
+      uninstall.status,
+      1,
+      `unsafe uninstall exited ${String(uninstall.status)}, expected 1\nstdout:\n${uninstall.stdout || ''}\nstderr:\n${uninstall.stderr || ''}`,
+    );
+    assert.equal(
+      uninstall.stderr,
+      `Error: ${expectedUnsafeManagedRemovalDiagnostic}\n`,
+      'unsafe uninstall must report the exact unsafe_managed_removal diagnostic',
+    );
+    assert.deepEqual(await readFile(hooksPath), beforeUninstallHooksBytes, 'unsafe uninstall changed raw hooks.json bytes');
+    assert.deepEqual(await readFile(configPath), beforeUninstallConfigBytes, 'unsafe uninstall changed raw config.toml bytes');
+    await assertNoUninstallTransactionArtifacts(join(projectDir, '.codex'));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -5471,6 +5471,126 @@ describe("omx setup install mode behavior", () => {
 			await rm(wd, { recursive: true, force: true });
 		}
 	});
+	it("preserves a foreign inode injected after final setup rename validation", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-final-rename-claim-"));
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const configPath = join(codexHomeDir, "config.toml");
+					const configBefore = Buffer.from('model = "before"\n', "utf-8");
+					const foreignHooks = Buffer.from('{"hooks":{"Stop":[]}}\n', "utf-8");
+					await writeFile(configPath, configBefore);
+					await writeFile(hooksPath, '{"hooks": {}}\n');
+					let foreignInode: number | undefined;
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage, target) => {
+							if (stage !== "after_final_rename_validation" || target.kind !== "hooks") return;
+							const foreignPath = join(codexHomeDir, ".foreign-final-rename-hooks");
+							writeFileSync(foreignPath, foreignHooks);
+							foreignInode = lstatSync(foreignPath).ino;
+							rmSync(hooksPath);
+							renameSync(foreignPath, hooksPath);
+						},
+					);
+					await assert.rejects(
+						setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true }),
+						/precondition changed/,
+					);
+					assert.ok(foreignInode);
+					assert.equal(lstatSync(hooksPath).ino, foreignInode);
+					assert.deepEqual(await readFile(hooksPath), foreignHooks);
+					assert.deepEqual(await readFile(configPath), configBefore);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("preserves a foreign inode injected after final setup removal validation", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-final-remove-claim-"));
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true });
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const configPath = join(codexHomeDir, "config.toml");
+					const configBefore = await readFile(configPath);
+					const foreignHooks = Buffer.from('{"hooks":{"Stop":[]}}\n', "utf-8");
+					let foreignInode: number | undefined;
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage, target) => {
+							if (stage !== "after_final_remove_validation" || target.kind !== "hooks") return;
+							const foreignPath = join(codexHomeDir, ".foreign-final-remove-hooks");
+							writeFileSync(foreignPath, foreignHooks);
+							foreignInode = lstatSync(foreignPath).ino;
+							rmSync(hooksPath);
+							renameSync(foreignPath, hooksPath);
+						},
+					);
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "plugin",
+							pluginAgentsMdPrompt: async () => false,
+							skipNativeAgentRefresh: true,
+						}),
+						/precondition changed/,
+					);
+					assert.ok(foreignInode);
+					assert.equal(lstatSync(hooksPath).ino, foreignInode);
+					assert.deepEqual(await readFile(hooksPath), foreignHooks);
+					assert.deepEqual(await readFile(configPath), configBefore);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("preserves a foreign inode injected after final setup rollback validation", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-final-restore-claim-"));
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const configPath = join(codexHomeDir, "config.toml");
+					const configBefore = Buffer.from('model = "before"\n', "utf-8");
+					const foreignHooks = Buffer.from('{"hooks":{"Stop":[]}}\n', "utf-8");
+					await writeFile(configPath, configBefore);
+					let foreignInode: number | undefined;
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage, target) => {
+							if (stage === "before_temp_write" && target.kind === "config") {
+								throw new Error("injected rollback start");
+							}
+							if (stage !== "after_final_restore_validation" || target.kind !== "hooks") return;
+							const foreignPath = join(codexHomeDir, ".foreign-final-restore-hooks");
+							writeFileSync(foreignPath, foreignHooks);
+							foreignInode = lstatSync(foreignPath).ino;
+							rmSync(hooksPath);
+							renameSync(foreignPath, hooksPath);
+						},
+					);
+					await assert.rejects(
+						setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true }),
+						/rollback failed/,
+					);
+					assert.ok(foreignInode);
+					assert.equal(lstatSync(hooksPath).ino, foreignInode);
+					assert.deepEqual(await readFile(hooksPath), foreignHooks);
+					assert.deepEqual(await readFile(configPath), configBefore);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 });
 
 describe("persisted merge policy lifecycle", () => {

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -1,6 +1,6 @@
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import {
 	chmod,
 	cp,
@@ -18,6 +18,7 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { parse as parseToml } from "@iarna/toml";
 import {
+	decideWindowsNativeHookShimReference,
 	setNativeHookTransactionFailureInjectorForTest,
 	setNativeHookTransactionPlatformForTest,
 	setNativeHookTransactionTemporaryPathForTest,
@@ -35,9 +36,12 @@ import {
 	resolvePackagedOmxMarketplace,
 } from "../plugin-marketplace.js";
 import {
+	buildManagedCodexHookTrustState,
+	buildManagedCodexHooksConfig,
 	buildManagedCodexNativeHookWindowsShimContent,
 	buildManagedCodexNativeHookWindowsShimPath,
 } from "../../config/codex-hooks.js";
+
 
 const packageRoot = process.cwd();
 let previousPathForFakeCodex: string | undefined;
@@ -124,6 +128,32 @@ async function withIsolatedUserHome<T>(
 	try {
 		return await fn(codexHomeDir);
 	} finally {
+		if (typeof previousHome === "string") process.env.HOME = previousHome;
+		else delete process.env.HOME;
+		if (typeof previousCodexHome === "string") {
+			process.env.CODEX_HOME = previousCodexHome;
+		} else {
+			delete process.env.CODEX_HOME;
+		}
+	}
+}
+
+async function withDriveQualifiedWindowsCodexHome<T>(
+	wd: string,
+	fn: (codexHomeDir: string) => Promise<T>,
+): Promise<T> {
+	const previousCwd = process.cwd();
+	const previousHome = process.env.HOME;
+	const previousCodexHome = process.env.CODEX_HOME;
+	const codexHomeDir = "C:\\Users\\omx\\.codex";
+	process.chdir(wd);
+	process.env.HOME = wd;
+	process.env.CODEX_HOME = codexHomeDir;
+	try {
+		await mkdir(codexHomeDir, { recursive: true });
+		return await fn(codexHomeDir);
+	} finally {
+		process.chdir(previousCwd);
 		if (typeof previousHome === "string") process.env.HOME = previousHome;
 		else delete process.env.HOME;
 		if (typeof previousCodexHome === "string") {
@@ -2397,9 +2427,771 @@ describe("omx setup install mode behavior", () => {
 			await rm(wd, { recursive: true, force: true });
 		}
 	});
-	it("removes Windows hooks before deleting the no-longer-referenced shim", async () => {
+	it("fails before plugin transition writes when marker-wrapped trust state has foreign siblings", async () => {
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		const representations = [
+			{
+				name: "inline",
+				render: (key: string, hash: string) => [
+					`hooks = { state = { ${JSON.stringify(key)} = { trusted_hash = ${JSON.stringify(hash)}, foreign = true } } }`,
+				],
+			},
+			{
+				name: "dotted",
+				render: (key: string, hash: string) => [
+					`hooks.state.${JSON.stringify(key)}.trusted_hash = ${JSON.stringify(hash)}`,
+					`hooks.state.${JSON.stringify(key)}.foreign = true`,
+				],
+			},
+			{
+				name: "table",
+				render: (key: string, hash: string) => [
+					`[hooks.state.${JSON.stringify(key)}]`,
+					`trusted_hash = ${JSON.stringify(hash)}`,
+					"foreign = true",
+				],
+			},
+			{
+				name: "separate-foreign-table",
+				render: (key: string, hash: string) => [
+					`[hooks.state.${JSON.stringify(key)}]`,
+					`trusted_hash = ${JSON.stringify(hash)}`,
+					"",
+					'[hooks.state."foreign-key"]',
+					'trusted_hash = "sha256:foreign"',
+				],
+			},
+		] as const;
+		try {
+			for (const representation of representations) {
+				const wd = await mkdtemp(join(tmpdir(), `omx-plugin-trust-${representation.name}-`));
+				try {
+					await withIsolatedUserHome(wd, async (codexHomeDir) => {
+						await withTempCwd(wd, async () => {
+							const configPath = join(codexHomeDir, "config.toml");
+							const hooksPath = join(codexHomeDir, "hooks.json");
+							const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+							const metadataPath = join(codexHomeDir, ".omx", "notify-dispatch.json");
+							const hooks = `${JSON.stringify(
+								buildManagedCodexHooksConfig(packageRoot, {
+									platform: "win32",
+									codexHomeDir,
+								}),
+								null,
+								2,
+							)}\n`;
+							const [key, trust] = Object.entries(
+								buildManagedCodexHookTrustState(hooksPath, packageRoot, {
+									platform: "win32",
+									codexHomeDir,
+									hooksContent: hooks,
+								}),
+							)[0] ?? [];
+							assert.ok(key);
+							assert.ok(trust);
+							const config = [
+								'model = "foreign"',
+								"",
+								"# ============================================================",
+								"# oh-my-codex (OMX) Configuration",
+								"# Managed by omx setup - manual edits preserved on next setup",
+								"# ============================================================",
+								"",
+								...representation.render(key, trust.trusted_hash),
+								"",
+								"# ============================================================",
+								"# End oh-my-codex",
+								"",
+							].join("\n");
+							const metadata = Buffer.from('{"managedBy":"foreign"}\n', "utf-8");
+							const shim = Buffer.from(
+								buildManagedCodexNativeHookWindowsShimContent(packageRoot),
+								"utf-8",
+							);
+							await mkdir(dirname(metadataPath), { recursive: true });
+							await writeFile(configPath, config);
+							await writeFile(hooksPath, hooks);
+							await writeFile(shimPath, shim);
+							await writeFile(metadataPath, metadata);
+
+							await assert.rejects(
+								setup({
+									scope: "user",
+									installMode: "plugin",
+									pluginAgentsMdPrompt: async () => false,
+									codexFeaturesProbe: () =>
+										"hooks stable true\nplugin_hooks experimental true\n",
+								}),
+								(error: unknown) =>
+									typeof error === "object" &&
+									error !== null &&
+									"code" in error &&
+									(error as { code?: unknown }).code === "managed_trust_key_conflict",
+							);
+							assert.deepEqual(await readFile(configPath), Buffer.from(config, "utf-8"));
+							assert.deepEqual(await readFile(hooksPath), Buffer.from(hooks, "utf-8"));
+							assert.deepEqual(await readFile(shimPath), shim);
+							assert.deepEqual(await readFile(metadataPath), metadata);
+							assert.deepEqual(
+								(await readdir(codexHomeDir)).filter((entry) => entry.includes(".omx-")),
+								[],
+							);
+							assert.deepEqual(
+								(await readdir(wd)).filter((entry) => entry.includes(".omx-")),
+								[],
+							);
+						});
+					});
+				} finally {
+					await rm(wd, { recursive: true, force: true });
+				}
+			}
+		} finally {
+			resetPlatform();
+		}
+	});
+	it("fails before plugin transition writes when marker trust has absent or non-managed hooks expectations", async () => {
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		const fixtures = [
+			{ name: "absent", hooks: null },
+			{
+				name: "non-managed",
+				hooks: `${JSON.stringify({
+					hooks: {
+						UserPromptSubmit: [{ hooks: [{ type: "command", command: "echo foreign" }] }],
+					},
+				}, null, 2)}\n`,
+			},
+		] as const;
+		try {
+			for (const fixture of fixtures) {
+				const wd = await mkdtemp(join(tmpdir(), `omx-plugin-marker-${fixture.name}-`));
+				try {
+					await withIsolatedUserHome(wd, async (codexHomeDir) => {
+						await withTempCwd(wd, async () => {
+							const configPath = join(codexHomeDir, "config.toml");
+							const hooksPath = join(codexHomeDir, "hooks.json");
+							const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+							const metadataPath = join(codexHomeDir, ".omx", "notify-dispatch.json");
+							const config = [
+								'model = "foreign"',
+								"",
+								"# ============================================================",
+								"# oh-my-codex (OMX) Configuration",
+								"# Managed by omx setup - manual edits preserved on next setup",
+								"# ============================================================",
+								"",
+								'[hooks.state."foreign-key"]',
+								'trusted_hash = "sha256:foreign"',
+								"",
+								"# ============================================================",
+								"# End oh-my-codex",
+								"",
+							].join("\n");
+							const shim = Buffer.from(
+								buildManagedCodexNativeHookWindowsShimContent(packageRoot),
+								"utf-8",
+							);
+							const metadata = Buffer.from('{"managedBy":"foreign"}\n', "utf-8");
+							await mkdir(dirname(metadataPath), { recursive: true });
+							await writeFile(configPath, config);
+							if (fixture.hooks !== null) await writeFile(hooksPath, fixture.hooks);
+							await writeFile(shimPath, shim);
+							await writeFile(metadataPath, metadata);
+
+							await assert.rejects(
+								setup({
+									scope: "user",
+									installMode: "plugin",
+									pluginAgentsMdPrompt: async () => false,
+									skipNativeAgentRefresh: true,
+									codexFeaturesProbe: () =>
+										"hooks stable true\nplugin_hooks experimental true\n",
+								}),
+								(error: unknown) =>
+									typeof error === "object" &&
+									error !== null &&
+									"code" in error &&
+									(error as { code?: unknown }).code === "managed_trust_key_conflict",
+							);
+							assert.deepEqual(await readFile(configPath), Buffer.from(config, "utf-8"));
+							assert.deepEqual(await readFile(shimPath), shim);
+							assert.deepEqual(await readFile(metadataPath), metadata);
+							if (fixture.hooks === null) {
+								assert.equal(existsSync(hooksPath), false);
+							} else {
+								assert.deepEqual(await readFile(hooksPath), Buffer.from(fixture.hooks, "utf-8"));
+							}
+							assert.deepEqual(
+								(await readdir(codexHomeDir)).filter((entry) => entry.includes(".omx-")),
+								[],
+							);
+							assert.deepEqual(
+								(await readdir(wd)).filter((entry) => entry.includes(".omx-")),
+								[],
+							);
+						});
+					});
+				} finally {
+					await rm(wd, { recursive: true, force: true });
+				}
+			}
+		} finally {
+			resetPlatform();
+		}
+	});
+	it("treats normalized managed Windows shim identity as exact and every distinct target as ambiguous", () => {
+		const shimBasename = "omx-native-hook-windows-shim.ps1";
+		const targetShimPath = `C:\\Users\\alice\\.codex\\hooks\\${shimBasename}`;
+		const futureCommand = (shimPath: string) =>
+			`& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File '${shimPath}'`;
+		const futureHooks = (shimPath: string) =>
+			JSON.stringify({
+				hooks: {
+					FutureEvent: [{ hooks: [{ type: "command", command: futureCommand(shimPath) }] }],
+				},
+			});
+
+		assert.equal(
+			decideWindowsNativeHookShimReference(
+				futureHooks(`c:/users/alice/.codex/hooks/../hooks/${shimBasename.toUpperCase()}`),
+				targetShimPath,
+			),
+			"referenced",
+		);
+		assert.equal(
+			decideWindowsNativeHookShimReference(
+				futureHooks(`D:\\Users\\alice\\.codex\\hooks\\${shimBasename}`),
+				targetShimPath,
+			),
+			"ambiguous",
+		);
+		assert.equal(
+			decideWindowsNativeHookShimReference(
+				futureHooks("D:\\Users\\alice\\.codex\\hooks\\unrelated.ps1"),
+				targetShimPath,
+			),
+			"ambiguous",
+		);
+		assert.equal(
+			decideWindowsNativeHookShimReference(
+				JSON.stringify({
+					hooks: {
+						FutureEvent: [{ hooks: [{ type: "command", command: "& $env:OMX_SHIM" }] }],
+					},
+				}),
+				targetShimPath,
+			),
+			"ambiguous",
+		);
+		for (const command of [
+			"& %OMX_SHIM%",
+			"& !OMX_SHIM!",
+			"& $(Get-Item env:OMX_SHIM)",
+		]) {
+			assert.equal(
+				decideWindowsNativeHookShimReference(
+					JSON.stringify({
+						hooks: {
+							FutureEvent: [{ hooks: [{ type: "command", command }] }],
+						},
+					}),
+					targetShimPath,
+				),
+				"ambiguous",
+				command,
+			);
+		}
+		for (const command of [
+			`Write-Output "don't"; & $env:HOOK_SCRIPT; Write-Output "user's"`,
+			"Invoke-Expression '& $env:HOOK_SCRIPT'",
+			"cmd /c 'call %HOOK_SCRIPT%'",
+			`& ('C:\\Users\\alice\\.codex\\hooks\\omx-native-hook-windows-' + 'shim.ps1')`,
+			"& (Get-Content C:\\shim-path.txt)",
+		]) {
+			assert.equal(
+				decideWindowsNativeHookShimReference(
+					JSON.stringify({
+						hooks: {
+							FutureEvent: [{ hooks: [{ type: "command", command }] }],
+						},
+					}),
+					targetShimPath,
+				),
+				"ambiguous",
+				command,
+			);
+		}
+		assert.equal(
+			decideWindowsNativeHookShimReference(
+				JSON.stringify({
+					hooks: {
+						FutureEvent: [{
+							hooks: [{
+								type: "command",
+								command:
+									"& 'C:\\%OMX_INERT%\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File 'D:\\tools\\unrelated-$env:INERT.ps1'",
+							}],
+						}],
+					},
+				}),
+				targetShimPath,
+			),
+			"ambiguous",
+		);
+		for (const ambiguousPath of [
+			`\\Users\\alice\\.codex\\hooks\\${shimBasename}`,
+			`C:Users\\alice\\.codex\\hooks\\${shimBasename}`,
+			`C:\\\\Users\\alice\\.codex\\hooks\\${shimBasename}`,
+			String.raw`\Users\ALICE~1\.codex\hooks\OMX-NA~1.PS1`,
+			String.raw`C:Users\ALICE~1\.codex\hooks\OMX-NA~1.PS1`,
+			`\\\\?\\C:\\Users\\alice\\.codex\\hooks\\${shimBasename}`,
+			`C:\\$env:USERPROFILE\\hooks\\${shimBasename}`,
+			`.\\hooks\\${shimBasename}`,
+			`D:\\aliases\\${shimBasename}. `,
+			`C:\\Users\\ALICE~1\\.codex\\hooks\\OMX-NA~1.PS1`,
+		]) {
+			assert.equal(
+				decideWindowsNativeHookShimReference(futureHooks(ambiguousPath), targetShimPath),
+				"ambiguous",
+				ambiguousPath,
+			);
+		}
+
+		const uncTargetShimPath = `\\\\server\\share\\users\\alice\\.codex\\hooks\\${shimBasename}`;
+		assert.equal(
+			decideWindowsNativeHookShimReference(
+				futureHooks(`//SERVER/share/users/alice/.codex/hooks/../hooks/${shimBasename.toUpperCase()}`),
+				uncTargetShimPath,
+			),
+			"referenced",
+		);
+	});
+	it("rolls back when an environment-indirected preserved Windows shim drifts during hooks or config writes", async () => {
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		try {
+			for (const mutationKind of ["hooks", "config"] as const) {
+				const wd = await mkdtemp(join(tmpdir(), `omx-plugin-preserved-shim-${mutationKind}-`));
+				let resetFailureInjector: (() => void) | undefined;
+				try {
+					await withIsolatedUserHome(wd, async (codexHomeDir) => {
+						await withTempCwd(wd, async () => {
+							const hooksPath = join(codexHomeDir, "hooks.json");
+							const configPath = join(codexHomeDir, "config.toml");
+							const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+							const managed = buildManagedCodexHooksConfig(packageRoot, {
+								platform: "win32",
+								codexHomeDir,
+							});
+							const hooksBefore = Buffer.from(
+								`${JSON.stringify({
+									...managed,
+									hooks: {
+										...managed.hooks,
+										FutureEvent: [{
+											hooks: [{ type: "command", command: "& $env:OMX_SHIM" }],
+										}],
+									},
+								}, null, 2)}\n`,
+								"utf-8",
+							);
+							const foreignShim = Buffer.from(
+								`# concurrent ${mutationKind} shim replacement\n`,
+								"utf-8",
+							);
+							await writeFile(hooksPath, hooksBefore);
+							await writeFile(
+								shimPath,
+								buildManagedCodexNativeHookWindowsShimContent(packageRoot),
+							);
+							let injected = false;
+							resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+								(stage, target) => {
+									if (
+										stage !== "before_temp_write" ||
+										target.kind !== mutationKind ||
+										injected
+									) {
+										return;
+									}
+									injected = true;
+									writeFileSync(shimPath, foreignShim);
+								},
+							);
+							await assert.rejects(
+								setup({
+									scope: "user",
+									installMode: "plugin",
+									pluginAgentsMdPrompt: async () => false,
+									skipNativeAgentRefresh: true,
+									codexFeaturesProbe: () =>
+										"hooks stable true\nplugin_hooks experimental true\n",
+								}),
+								/precondition changed/,
+							);
+							assert.equal(injected, true, mutationKind);
+							assert.deepEqual(await readFile(shimPath), foreignShim);
+							assert.deepEqual(await readFile(hooksPath), hooksBefore);
+							assert.equal(existsSync(configPath), false);
+						});
+					});
+				} finally {
+					resetFailureInjector?.();
+					await rm(wd, { recursive: true, force: true });
+				}
+			}
+		} finally {
+			resetPlatform();
+		}
+	});
+	it("rolls back when a preserved Windows shim drifts after staged cleanup finalization", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-plugin-preserved-shim-finalization-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const configPath = join(codexHomeDir, "config.toml");
+					const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+					const managed = buildManagedCodexHooksConfig(packageRoot, {
+						platform: "win32",
+						codexHomeDir,
+					});
+					const hooksBefore = Buffer.from(
+						`${JSON.stringify({
+							...managed,
+							hooks: {
+								...managed.hooks,
+								FutureEvent: [{
+									hooks: [{ type: "command", command: "& $env:OMX_SHIM" }],
+								}],
+							},
+						}, null, 2)}\n`,
+						"utf-8",
+					);
+					const foreignShim = Buffer.from("# concurrent finalization shim replacement\n", "utf-8");
+					await writeFile(hooksPath, hooksBefore);
+					await writeFile(
+						shimPath,
+						buildManagedCodexNativeHookWindowsShimContent(packageRoot),
+					);
+					let injected = false;
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage) => {
+							if (stage !== "after_staged_cleanup" || injected) return;
+							injected = true;
+							writeFileSync(shimPath, foreignShim);
+						},
+					);
+
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "plugin",
+							pluginAgentsMdPrompt: async () => false,
+							skipNativeAgentRefresh: true,
+							codexFeaturesProbe: () =>
+								"hooks stable true\nplugin_hooks experimental true\n",
+						}),
+						/precondition changed/,
+					);
+					assert.equal(injected, true);
+					assert.deepEqual(await readFile(shimPath), foreignShim);
+					assert.deepEqual(await readFile(hooksPath), hooksBefore);
+					assert.equal(existsSync(configPath), false);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("preserves a drive-qualified shim for a drive-less future reference and aborts stale plugin transitions", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-plugin-drive-qualified-future-shim-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withDriveQualifiedWindowsCodexHome(wd, async (codexHomeDir) => {
+				const hooksPath = join(codexHomeDir, "hooks.json");
+				const configPath = join(codexHomeDir, "config.toml");
+				const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+				const managed = buildManagedCodexHooksConfig(packageRoot, {
+					platform: "win32",
+					codexHomeDir,
+				});
+				const driveLessFutureShimPath = "\\Users\\omx\\.codex\\hooks\\omx-native-hook-windows-shim.ps1";
+				const futureHooks = `${JSON.stringify({
+					...managed,
+					hooks: {
+						...managed.hooks,
+						FutureEvent: [{
+							hooks: [{
+								type: "command",
+								command: `& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File '${driveLessFutureShimPath}'`,
+							}],
+						}],
+					},
+				}, null, 2)}\n`;
+				const pluginSetup = () => setup({
+					scope: "user",
+					installMode: "plugin",
+					pluginAgentsMdPrompt: async () => false,
+					skipNativeAgentRefresh: true,
+					codexFeaturesProbe: () =>
+						"hooks stable true\nplugin_hooks experimental true\n",
+				});
+				await writeFile(hooksPath, futureHooks);
+				await writeFile(
+					shimPath,
+					buildManagedCodexNativeHookWindowsShimContent(packageRoot),
+				);
+
+				await pluginSetup();
+				assert.equal(existsSync(shimPath), true);
+				assert.match(await readFile(hooksPath, "utf-8"), /FutureEvent/);
+
+				await writeFile(hooksPath, futureHooks);
+				const hooksBefore = await readFile(hooksPath);
+				const configBefore = await readFile(configPath);
+				const foreignShim = Buffer.from("# concurrent foreign shim\n", "utf-8");
+				let injected = false;
+				resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+					(stage, target) => {
+						if (stage !== "before_precondition" || target.kind !== "shim" || injected) {
+							return;
+						}
+						injected = true;
+						writeFileSync(shimPath, foreignShim);
+					},
+				);
+				await assert.rejects(pluginSetup(), /precondition changed/);
+				assert.equal(injected, true);
+				assert.deepEqual(await readFile(shimPath), foreignShim);
+				assert.deepEqual(await readFile(hooksPath), hooksBefore);
+				assert.deepEqual(await readFile(configPath), configBefore);
+			});
+		} finally {
+			resetFailureInjector?.();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("preserves a shim referenced by a Unicode-escaped future hook event", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-plugin-future-shim-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+					const managed = buildManagedCodexHooksConfig(packageRoot, {
+						platform: "win32",
+						codexHomeDir,
+					});
+					const sentinel = "__OMX_ESCAPED_SHIM_COMMAND__";
+					const futureHooks = JSON.stringify(
+						{
+							...managed,
+							hooks: {
+								...managed.hooks,
+								FutureEvent: [{ hooks: [{ type: "command", command: sentinel }] }],
+							},
+						},
+						null,
+						2,
+					).replace(
+						JSON.stringify(sentinel),
+						JSON.stringify(
+							`& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File '${shimPath}'`,
+						).replace(/\\\\/g, "\\u005c"),
+					) + "\n";
+					await writeFile(hooksPath, futureHooks);
+					await writeFile(
+						shimPath,
+						buildManagedCodexNativeHookWindowsShimContent(packageRoot),
+					);
+
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						pluginAgentsMdPrompt: async () => false,
+						skipNativeAgentRefresh: true,
+						codexFeaturesProbe: () =>
+							"hooks stable true\nplugin_hooks experimental true\n",
+					});
+					assert.equal(existsSync(shimPath), true);
+					const finalHooks = await readFile(hooksPath, "utf-8");
+					assert.match(finalHooks, /FutureEvent/);
+					assert.match(finalHooks, /\\u005c/);
+					assert.doesNotMatch(finalHooks, /codex-native-hook\.js/);
+				});
+			});
+		} finally {
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("preserves a shim referenced through a normalized Windows path alias", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-plugin-shim-path-alias-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+					const shimAlias = shimPath
+						.replace(/[\\/]+hooks[\\/]+/i, "\\hooks\\\\.\\")
+						.replace(/omx-native-hook-windows-shim\.ps1$/i, "OMX-NATIVE-HOOK-WINDOWS-SHIM.PS1")
+						.replace(/\\/g, "/");
+					const managed = buildManagedCodexHooksConfig(packageRoot, {
+						platform: "win32",
+						codexHomeDir,
+					});
+					await writeFile(
+						hooksPath,
+						JSON.stringify({
+							...managed,
+							hooks: {
+								...managed.hooks,
+								FutureEvent: [{
+									hooks: [{
+										type: "command",
+										command: `& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File '${shimAlias}'`,
+									}],
+								}],
+							},
+						}, null, 2) + "\n",
+					);
+					await writeFile(
+						shimPath,
+						buildManagedCodexNativeHookWindowsShimContent(packageRoot),
+					);
+
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						pluginAgentsMdPrompt: async () => false,
+						skipNativeAgentRefresh: true,
+						codexFeaturesProbe: () =>
+							"hooks stable true\nplugin_hooks experimental true\n",
+					});
+					assert.equal(existsSync(shimPath), true);
+					assert.match(await readFile(hooksPath, "utf-8"), /FutureEvent/);
+				});
+			});
+		} finally {
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("preserves a shim for a distinct absolute -File target", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-plugin-quoted-inert-shim-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+					const managed = buildManagedCodexHooksConfig(packageRoot, {
+						platform: "win32",
+						codexHomeDir,
+					});
+					await writeFile(
+						hooksPath,
+						JSON.stringify({
+							...managed,
+							hooks: {
+								...managed.hooks,
+								FutureEvent: [{
+									hooks: [{
+										type: "command",
+										command:
+											"& 'C:\\%OMX_INERT%\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File 'D:\\tools\\unrelated-$env:INERT.ps1'",
+									}],
+								}],
+							},
+						}, null, 2) + "\n",
+					);
+					await writeFile(
+						shimPath,
+						buildManagedCodexNativeHookWindowsShimContent(packageRoot),
+					);
+
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						pluginAgentsMdPrompt: async () => false,
+						skipNativeAgentRefresh: true,
+						codexFeaturesProbe: () =>
+							"hooks stable true\nplugin_hooks experimental true\n",
+					});
+					assert.equal(existsSync(shimPath), true);
+					assert.match(await readFile(hooksPath, "utf-8"), /FutureEvent/);
+				});
+			});
+		} finally {
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("does not retain a shim for inert future-event metadata", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-plugin-future-shim-metadata-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+					const managed = buildManagedCodexHooksConfig(packageRoot, {
+						platform: "win32",
+						codexHomeDir,
+					});
+					await writeFile(
+						hooksPath,
+						JSON.stringify(
+							{
+								...managed,
+								hooks: {
+									...managed.hooks,
+									FutureEvent: [
+										{
+											metadata: shimPath,
+											hooks: [{ type: "agent", prompt: shimPath }],
+										},
+									],
+								},
+							},
+							null,
+							2,
+						) + "\n",
+					);
+					await writeFile(
+						shimPath,
+						buildManagedCodexNativeHookWindowsShimContent(packageRoot),
+					);
+
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						pluginAgentsMdPrompt: async () => false,
+						skipNativeAgentRefresh: true,
+						codexFeaturesProbe: () =>
+							"hooks stable true\nplugin_hooks experimental true\n",
+					});
+					assert.equal(existsSync(shimPath), false);
+					assert.match(await readFile(hooksPath, "utf-8"), /FutureEvent/);
+				});
+			});
+		} finally {
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("orders Windows plugin-transition mutations as hooks, shim, then config", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-hook-removal-"));
-		const removalOrder: string[] = [];
+		const forwardOrder: string[] = [];
 		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
 		let resetFailureInjector: (() => void) | undefined;
 		try {
@@ -2416,12 +3208,7 @@ describe("omx setup install mode behavior", () => {
 					assert.equal(existsSync(shimPath), true);
 					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
 						(stage, artifact) => {
-							if (
-								stage === "before_remove" &&
-								(artifact.kind === "hooks" || artifact.kind === "shim")
-							) {
-								removalOrder.push(artifact.kind);
-							}
+							if (stage === "before_temp_write") forwardOrder.push(artifact.kind);
 						},
 					);
 					await setup({
@@ -2436,7 +3223,7 @@ describe("omx setup install mode behavior", () => {
 								"",
 							].join("\n"),
 					});
-					assert.deepEqual(removalOrder, ["hooks", "shim"]);
+					assert.deepEqual(forwardOrder, ["hooks", "shim", "config"]);
 					assert.equal(existsSync(hooksPath), false);
 					assert.equal(existsSync(shimPath), false);
 				});
@@ -2447,8 +3234,9 @@ describe("omx setup install mode behavior", () => {
 			await rm(wd, { recursive: true, force: true });
 		}
 	});
-	it("restores the Windows shim before hooks when plugin-transition deletions roll back", async () => {
+	it("rolls back Windows plugin-transition artifacts in exact reverse order", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-hook-rollback-"));
+		const forwardOrder: string[] = [];
 		const restorationOrder: string[] = [];
 		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
 		let resetFailureInjector: (() => void) | undefined;
@@ -2464,15 +3252,14 @@ describe("omx setup install mode behavior", () => {
 					const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
 					const hooksBefore = await readFile(hooksPath);
 					const shimBefore = await readFile(shimPath);
+					const configBefore = await readFile(join(codexHomeDir, "config.toml"));
 					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
 						(stage, artifact) => {
-							if (stage === "before_readback" && artifact.kind === "shim") {
-								throw new Error("injected Windows shim deletion failure");
+							if (stage === "before_temp_write") forwardOrder.push(artifact.kind);
+							if (stage === "before_readback" && artifact.kind === "config") {
+								throw new Error("injected Windows config replacement failure");
 							}
-							if (
-								stage === "before_rollback_rename" &&
-								(artifact.kind === "hooks" || artifact.kind === "shim")
-							) {
+							if (stage === "before_rollback_rename") {
 								restorationOrder.push(artifact.kind);
 							}
 						},
@@ -2490,9 +3277,11 @@ describe("omx setup install mode behavior", () => {
 									"",
 								].join("\n"),
 						}),
-						/rolled back: injected Windows shim deletion failure/,
+						/rolled back: injected Windows config replacement failure/,
 					);
-					assert.deepEqual(restorationOrder, ["shim", "hooks"]);
+					assert.deepEqual(forwardOrder, ["hooks", "shim", "config"]);
+					assert.deepEqual(restorationOrder, ["config", "shim", "hooks"]);
+					assert.deepEqual(await readFile(join(codexHomeDir, "config.toml")), configBefore);
 					assert.deepEqual(await readFile(shimPath), shimBefore);
 					assert.deepEqual(await readFile(hooksPath), hooksBefore);
 				});
@@ -3830,7 +4619,11 @@ describe("omx setup install mode behavior", () => {
 						const hooksPath = join(codexHomeDir, "hooks.json");
 						const configPath = join(codexHomeDir, "config.toml");
 						const shimBefore = Buffer.from(
-							buildManagedCodexNativeHookWindowsShimContent(join(wd, "previous")),
+							buildManagedCodexNativeHookWindowsShimContent("", {
+								nodePath: "C:\\Historical Node\\node.exe",
+								hookScriptPath:
+									"C:\\Historical Install\\oh-my-codex\\dist\\scripts\\codex-native-hook.js",
+							}),
 							"utf-8",
 						);
 						const hooksBefore = Buffer.from('{"hooks": {}}\n', "utf-8");
@@ -4362,10 +5155,11 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
-	it("does not enter rollback after a second staged-deletion cleanup failure", async () => {
+	it("does not roll back when the second staged-deletion copy drifts after the first cleanup", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-staged-deletion-cleanup-"));
 		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
 		let resetFailureInjector: (() => void) | undefined;
+		let resetTemporaryPath: (() => void) | undefined;
 		try {
 			await withIsolatedUserHome(wd, async (codexHomeDir) => {
 				await withTempCwd(wd, async () => {
@@ -4377,17 +5171,26 @@ describe("omx setup install mode behavior", () => {
 					const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
 					const hooksPath = join(codexHomeDir, "hooks.json");
 					const configPath = join(codexHomeDir, "config.toml");
+					const stagedDeletionPath = (path: string, purpose: "write" | "delete") =>
+						join(dirname(path), `.${basename(path)}.cleanup-${purpose}`);
+					const foreignStagedCopy = Buffer.from("foreign second staged deletion\n", "utf-8");
 					let cleanupCount = 0;
+					let driftedStagedPath: string | undefined;
+					resetTemporaryPath = setNativeHookTransactionTemporaryPathForTest(
+						stagedDeletionPath,
+					);
 					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
 						(stage, target) => {
 							if (
-								stage === "before_staged_cleanup" &&
-								(target.kind === "shim" || target.kind === "hooks")
+								stage !== "before_staged_cleanup" ||
+								(target.kind !== "shim" && target.kind !== "hooks")
 							) {
-								cleanupCount += 1;
-								if (cleanupCount === 2) {
-									throw new Error("injected second staged-deletion cleanup failure");
-								}
+								return;
+							}
+							cleanupCount += 1;
+							if (cleanupCount === 2) {
+								driftedStagedPath = stagedDeletionPath(target.path, "delete");
+								writeFileSync(driftedStagedPath, foreignStagedCopy);
 							}
 						},
 					);
@@ -4401,9 +5204,265 @@ describe("omx setup install mode behavior", () => {
 						/committed but staged deletion cleanup failed/,
 					);
 					assert.equal(cleanupCount, 2);
+					assert.ok(driftedStagedPath);
+					assert.deepEqual(await readFile(driftedStagedPath), foreignStagedCopy);
 					assert.equal(existsSync(shimPath), false);
 					assert.equal(existsSync(hooksPath), false);
 					assert.match(await readFile(configPath, "utf-8"), /^plugin_hooks = true$/m);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			resetTemporaryPath?.();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("treats applied hook, shim, and config snapshots as CAS through commit finalization", async () => {
+		const fixtures = [
+			{
+				name: "later commit",
+				stage: "before_temp_write",
+				target: "shim",
+				drift: "hooks",
+				committed: false,
+			},
+			{
+				name: "staged cleanup",
+				stage: "before_staged_cleanup",
+				target: "hooks",
+				drift: "shim",
+				committed: false,
+			},
+			{
+				name: "finalization",
+				stage: "after_staged_cleanup",
+				target: "config",
+				drift: "config",
+				committed: true,
+			},
+		] as const;
+		for (const fixture of fixtures) {
+			const wd = await mkdtemp(join(tmpdir(), `omx-setup-applied-${fixture.name}-`));
+			const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+			let resetFailureInjector: (() => void) | undefined;
+			try {
+				await withIsolatedUserHome(wd, async (codexHomeDir) => {
+					await withTempCwd(wd, async () => {
+						await setup({
+							scope: "user",
+							installMode: "legacy",
+							skipNativeAgentRefresh: true,
+						});
+						const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+						const hooksPath = join(codexHomeDir, "hooks.json");
+						const configPath = join(codexHomeDir, "config.toml");
+						const before = {
+							shim: await readFile(shimPath),
+							hooks: await readFile(hooksPath),
+							config: await readFile(configPath),
+						};
+						const paths = { shim: shimPath, hooks: hooksPath, config: configPath };
+						const foreign = Buffer.from(`foreign applied ${fixture.drift} ${fixture.name}\n`, "utf-8");
+						let injected = false;
+						resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+							(stage, target) => {
+								if (
+									stage !== fixture.stage ||
+									target.kind !== fixture.target ||
+									injected
+								) {
+									return;
+								}
+								injected = true;
+								writeFileSync(paths[fixture.drift], foreign);
+							},
+						);
+						await assert.rejects(
+							setup({
+								scope: "user",
+								installMode: "plugin",
+								pluginAgentsMdPrompt: async () => false,
+								skipNativeAgentRefresh: true,
+							}),
+							fixture.committed
+								? /committed but staged deletion cleanup failed during finalization/
+								: /rollback failed/,
+						);
+						assert.equal(injected, true, fixture.name);
+						if (fixture.name === "staged cleanup") {
+							assert.equal(existsSync(hooksPath), false);
+							assert.deepEqual(await readFile(shimPath), foreign);
+							assert.notDeepEqual(await readFile(configPath), before.config);
+							return;
+						}
+						if (fixture.committed) {
+							assert.equal(existsSync(hooksPath), false);
+							assert.equal(existsSync(shimPath), false);
+							assert.deepEqual(await readFile(configPath), foreign);
+							return;
+						}
+						assert.deepEqual(
+							await readFile(hooksPath),
+							fixture.drift === "hooks" ? foreign : before.hooks,
+						);
+						assert.deepEqual(
+							await readFile(shimPath),
+							before.shim,
+						);
+						assert.deepEqual(await readFile(configPath), before.config);
+					});
+				});
+			} finally {
+				resetFailureInjector?.();
+				resetPlatform();
+				await rm(wd, { recursive: true, force: true });
+			}
+		}
+	});
+	it("preserves a same-byte foreign replacement made immediately after a native-hook rename", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-immediate-post-rename-"));
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const configPath = join(codexHomeDir, "config.toml");
+					const configBefore = Buffer.from('model = "before"\n', "utf-8");
+					let replacement: Buffer | undefined;
+					let replacedInode: number | undefined;
+					await writeFile(configPath, configBefore);
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage, target) => {
+							if (stage !== "after_rename" || target.kind !== "hooks") return;
+							replacement = readFileSync(hooksPath);
+							const ownedInode = lstatSync(hooksPath).ino;
+							const foreignPath = join(codexHomeDir, ".foreign-hooks-same-byte");
+							writeFileSync(foreignPath, replacement);
+							assert.notEqual(lstatSync(foreignPath).ino, ownedInode);
+							rmSync(hooksPath);
+							renameSync(foreignPath, hooksPath);
+							replacedInode = lstatSync(hooksPath).ino;
+							assert.notEqual(replacedInode, ownedInode);
+						},
+					);
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "legacy",
+							skipNativeAgentRefresh: true,
+							codexFeaturesProbe: () => null,
+							codexVersionProbe: () => null,
+						}),
+						/rollback failed/,
+					);
+					assert.ok(replacement);
+					assert.ok(replacedInode);
+					assert.deepEqual(await readFile(hooksPath), replacement);
+					assert.deepEqual(await readFile(configPath), configBefore);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("preflights every staged native-hook recovery copy before rollback", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-rollback-recovery-preflight-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		let resetFailureInjector: (() => void) | undefined;
+		let resetTemporaryPath: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true });
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+					const configPath = join(codexHomeDir, "config.toml");
+					const configBefore = await readFile(configPath);
+					const stagedHooksPath = join(codexHomeDir, ".hooks-preflight-recovery");
+					resetTemporaryPath = setNativeHookTransactionTemporaryPathForTest(
+						(path, purpose) =>
+							path === hooksPath && purpose === "delete"
+								? stagedHooksPath
+								: join(dirname(path), `.${basename(path)}.${purpose}-preflight`),
+					);
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage, target) => {
+							if (stage !== "before_readback" || target.kind !== "config") return;
+							rmSync(stagedHooksPath);
+							throw new Error("injected missing staged recovery copy");
+						},
+					);
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "plugin",
+							pluginAgentsMdPrompt: async () => false,
+							skipNativeAgentRefresh: true,
+							codexFeaturesProbe: () => "hooks stable true\nplugin_hooks experimental true\n",
+						}),
+						/rollback failed.*recovery preflight/,
+					);
+					assert.equal(existsSync(hooksPath), false);
+					assert.equal(existsSync(shimPath), false);
+					assert.notDeepEqual(await readFile(configPath), configBefore);
+					assert.equal(existsSync(stagedHooksPath), false);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			resetTemporaryPath?.();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("stops later native-hook rollback restores when the first restored artifact drifts", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-rollback-restored-drift-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true });
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+					const configPath = join(codexHomeDir, "config.toml");
+					const configBefore = await readFile(configPath);
+					let injectedFailure = false;
+					let drifted = false;
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage, target) => {
+							if (stage === "before_readback" && target.kind === "config" && !injectedFailure) {
+								injectedFailure = true;
+								throw new Error("injected rollback start failure");
+							}
+							if (stage === "before_rollback_rename" && target.kind === "shim" && !drifted) {
+								const restoredInode = lstatSync(configPath).ino;
+								const foreignPath = join(codexHomeDir, ".foreign-restored-config");
+								writeFileSync(foreignPath, configBefore);
+								assert.notEqual(lstatSync(foreignPath).ino, restoredInode);
+								rmSync(configPath);
+								renameSync(foreignPath, configPath);
+								drifted = lstatSync(configPath).ino !== restoredInode;
+							}
+						},
+					);
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "plugin",
+							pluginAgentsMdPrompt: async () => false,
+							skipNativeAgentRefresh: true,
+							codexFeaturesProbe: () => "hooks stable true\nplugin_hooks experimental true\n",
+						}),
+						/rollback failed/,
+					);
+					assert.equal(injectedFailure, true);
+					assert.equal(drifted, true);
+					assert.deepEqual(await readFile(configPath), configBefore);
+					assert.equal(existsSync(shimPath), false);
+					assert.equal(existsSync(hooksPath), false);
 				});
 			});
 		} finally {

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -1,20 +1,28 @@
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import { existsSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import {
 	chmod,
 	cp,
+	lstat,
 	mkdir,
 	mkdtemp,
 	readFile,
 	readdir,
 	rm,
+	symlink,
 	writeFile,
+	stat,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { parse as parseToml } from "@iarna/toml";
-import { setup } from "../setup.js";
+import {
+	setNativeHookTransactionFailureInjectorForTest,
+	setNativeHookTransactionPlatformForTest,
+	setNativeHookTransactionTemporaryPathForTest,
+	setup,
+} from "../setup.js";
 import { resolveSetupRefreshArgs } from "../update.js";
 import { uninstall } from "../uninstall.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../../config/omx-first-party-mcp.js";
@@ -26,6 +34,10 @@ import {
 	materializePackagedOmxPluginCache,
 	resolvePackagedOmxMarketplace,
 } from "../plugin-marketplace.js";
+import {
+	buildManagedCodexNativeHookWindowsShimContent,
+	buildManagedCodexNativeHookWindowsShimPath,
+} from "../../config/codex-hooks.js";
 
 const packageRoot = process.cwd();
 let previousPathForFakeCodex: string | undefined;
@@ -2385,27 +2397,205 @@ describe("omx setup install mode behavior", () => {
 			await rm(wd, { recursive: true, force: true });
 		}
 	});
+	it("removes Windows hooks before deleting the no-longer-referenced shim", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-hook-removal-"));
+		const removalOrder: string[] = [];
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({
+						scope: "user",
+						installMode: "legacy",
+						skipNativeAgentRefresh: true,
+					});
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+					assert.equal(existsSync(hooksPath), true);
+					assert.equal(existsSync(shimPath), true);
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage, artifact) => {
+							if (
+								stage === "before_remove" &&
+								(artifact.kind === "hooks" || artifact.kind === "shim")
+							) {
+								removalOrder.push(artifact.kind);
+							}
+						},
+					);
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						skipNativeAgentRefresh: true,
+						pluginAgentsMdPrompt: async () => false,
+						codexFeaturesProbe: () =>
+							[
+								"hooks                                   stable             true",
+								"plugin_hooks                            experimental       true",
+								"",
+							].join("\n"),
+					});
+					assert.deepEqual(removalOrder, ["hooks", "shim"]);
+					assert.equal(existsSync(hooksPath), false);
+					assert.equal(existsSync(shimPath), false);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("restores the Windows shim before hooks when plugin-transition deletions roll back", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-hook-rollback-"));
+		const restorationOrder: string[] = [];
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({
+						scope: "user",
+						installMode: "legacy",
+						skipNativeAgentRefresh: true,
+					});
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+					const hooksBefore = await readFile(hooksPath);
+					const shimBefore = await readFile(shimPath);
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage, artifact) => {
+							if (stage === "before_readback" && artifact.kind === "shim") {
+								throw new Error("injected Windows shim deletion failure");
+							}
+							if (
+								stage === "before_rollback_rename" &&
+								(artifact.kind === "hooks" || artifact.kind === "shim")
+							) {
+								restorationOrder.push(artifact.kind);
+							}
+						},
+					);
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "plugin",
+							skipNativeAgentRefresh: true,
+							pluginAgentsMdPrompt: async () => false,
+							codexFeaturesProbe: () =>
+								[
+									"hooks                                   stable             true",
+									"plugin_hooks                            experimental       true",
+									"",
+								].join("\n"),
+						}),
+						/rolled back: injected Windows shim deletion failure/,
+					);
+					assert.deepEqual(restorationOrder, ["shim", "hooks"]);
+					assert.deepEqual(await readFile(shimPath), shimBefore);
+					assert.deepEqual(await readFile(hooksPath), hooksBefore);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
-	it("preserves existing user hooks while using plugin-scoped hooks", async () => {
+	it("preserves foreign native hook enablement when transitioning from plugin fallback", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						codexFeaturesProbe: () =>
+							"hooks                                   stable             true\n",
+					});
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const existingHooks = JSON.parse(await readFile(hooksPath, "utf-8")) as {
+						hooks?: Record<string, Array<Record<string, unknown>>>;
+					};
+					const foreignHookGroup = {
+						hooks: [
+							{
+								type: "command",
+								command: "/usr/bin/python3 /tmp/foreign-hook.py",
+								timeout: 5,
+							},
+						],
+					};
+					const existingRegistrations = existingHooks.hooks ?? {};
+					existingHooks.hooks = {
+						...existingRegistrations,
+						UserPromptSubmit: [
+							foreignHookGroup,
+							...(existingRegistrations.UserPromptSubmit ?? []),
+						],
+					};
+					await writeFile(
+						hooksPath,
+						JSON.stringify(existingHooks, null, 2) + "\n",
+					);
+
+					await setup({ scope: "user", installMode: "plugin" });
+
+					const finalHooksContent = await readFile(hooksPath, "utf-8");
+					const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
+					assert.match(finalHooksContent, /foreign-hook\.py/);
+					assert.doesNotMatch(finalHooksContent, /codex-native-hook\.js/);
+					assert.match(config, /^plugin_hooks = true$/m);
+					assert.match(config, /^hooks = true$/m);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps native hooks enabled for pre-existing foreign hooks in plugin-scoped setup", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {
 			await withIsolatedUserHome(wd, async (codexHomeDir) => {
 				await withTempCwd(wd, async () => {
 					const hooksPath = join(codexHomeDir, "hooks.json");
-					const existingHooks =
-						JSON.stringify({ hooks: { UserPromptSubmit: [] } }, null, 2) + "\n";
-					await writeFile(hooksPath, existingHooks);
+					const foreignHookGroup = {
+						hooks: [
+							{
+								type: "command",
+								command: "/usr/bin/python3 /tmp/foreign-hook.py",
+								timeout: 5,
+							},
+						],
+					};
+					await writeFile(
+						hooksPath,
+						JSON.stringify(
+							{ hooks: { UserPromptSubmit: [foreignHookGroup] } },
+							null,
+							2,
+						) + "\n",
+					);
 
 					await setup({ scope: "user", installMode: "plugin" });
 
-					const hooks = await readFile(hooksPath, "utf-8");
-					assert.match(hooks, /"UserPromptSubmit"/);
-					assert.doesNotMatch(hooks, /codex-native-hook\.js/);
+					const finalHooksContent = await readFile(hooksPath, "utf-8");
+					assert.match(finalHooksContent, /"UserPromptSubmit"/);
+					assert.match(finalHooksContent, /foreign-hook\.py/);
+					assert.doesNotMatch(finalHooksContent, /codex-native-hook\.js/);
 					const config = await readFile(
 						join(codexHomeDir, "config.toml"),
 						"utf-8",
 					);
 					assert.match(config, /^plugin_hooks = true$/m);
+					assert.match(
+						config,
+						/^hooks = true$/m,
+						"plugin-scoped setup must keep native hooks enabled for foreign hooks",
+					);
 				});
 			});
 		} finally {
@@ -3067,6 +3257,1158 @@ describe("omx setup install mode behavior", () => {
 				});
 			});
 		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("fails plugin hook-removal preflight before creating unrelated setup artifacts", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-preflight-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const configPath = join(codexHomeDir, "config.toml");
+					const hooksContent = JSON.stringify(
+						{
+							hooks: {
+								SessionStart: [
+									{
+										matcher: "startup|resume|clear",
+										hooks: [
+											{
+												type: "command",
+												command: 'node "/repo/dist/scripts/codex-native-hook.js"',
+											},
+										],
+									},
+									{ hooks: [{ type: "command", command: "echo foreign" }] },
+								],
+							},
+						},
+						null,
+						2,
+					) + "\n";
+					const configContent = 'model = "foreign-config"\n';
+					await writeFile(hooksPath, hooksContent);
+					await writeFile(configPath, configContent);
+
+					await assert.rejects(
+						() =>
+							setup({
+								scope: "user",
+								installMode: "plugin",
+								mergeAgents: true,
+								codexFeaturesProbe: () =>
+									"hooks                                   stable             true\nplugin_hooks                            experimental       true\n",
+							}),
+						(error: unknown) => {
+							assert.equal(
+								(error as { code?: unknown }).code,
+								"unsafe_managed_removal",
+							);
+							return true;
+						},
+					);
+					assert.equal(await readFile(hooksPath, "utf-8"), hooksContent);
+					assert.equal(await readFile(configPath, "utf-8"), configContent);
+					assert.equal(existsSync(join(wd, ".omx")), false);
+					assert.equal(existsSync(join(codexHomeDir, "prompts")), false);
+					assert.equal(existsSync(join(codexHomeDir, "agents")), false);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("rejects symlinked Codex transaction ancestors without writing foreign storage", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-symlinked-codex-home-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const foreignCodexHome = join(wd, "foreign-codex-home");
+					await mkdir(foreignCodexHome);
+					await writeFile(join(foreignCodexHome, "sentinel.txt"), "foreign\n");
+					await rm(codexHomeDir, { recursive: true, force: true });
+					await symlink(foreignCodexHome, codexHomeDir);
+
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "legacy",
+							skipNativeAgentRefresh: true,
+						}),
+						/ancestor .*symbolic link/,
+					);
+					assert.deepEqual(await readdir(foreignCodexHome), ["sentinel.txt"]);
+					assert.equal(existsSync(join(wd, ".omx")), false);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("rejects a symlinked native artifact parent before touching its target", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-symlinked-native-parent-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const foreignMetadataDir = join(wd, "foreign-native-metadata");
+					await mkdir(foreignMetadataDir);
+					await writeFile(join(foreignMetadataDir, "sentinel.txt"), "foreign\n");
+					await symlink(foreignMetadataDir, join(codexHomeDir, ".omx"));
+
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "legacy",
+							skipNativeAgentRefresh: true,
+						}),
+						/ancestor .*symbolic link/,
+					);
+					assert.deepEqual(await readdir(foreignMetadataDir), ["sentinel.txt"]);
+					assert.equal(existsSync(join(codexHomeDir, "config.toml")), false);
+					assert.equal(existsSync(join(codexHomeDir, "hooks.json")), false);
+					assert.equal(existsSync(join(wd, ".omx")), false);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("revalidates native artifact parent topology immediately before mutation", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-stale-native-parent-"));
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const metadataParent = join(codexHomeDir, ".omx");
+					let injected = false;
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage) => {
+							if (stage !== "before_precondition" || injected) return;
+							injected = true;
+							writeFileSync(metadataParent, "foreign\n");
+						},
+					);
+
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "legacy",
+							skipNativeAgentRefresh: true,
+						}),
+						/ancestor .*not a directory/,
+					);
+					assert.equal(injected, true);
+					assert.equal(await readFile(metadataParent, "utf-8"), "foreign\n");
+					assert.equal(existsSync(join(codexHomeDir, "config.toml")), false);
+					assert.equal(existsSync(join(codexHomeDir, "hooks.json")), false);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects a modified Windows hook shim during setup preflight", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-shim-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+					const modifiedShim = "# modified by user\n";
+					await writeFile(shimPath, modifiedShim);
+
+					await assert.rejects(
+						() =>
+							setup({
+								scope: "user",
+								installMode: "legacy",
+								mergeAgents: true,
+							}),
+						/modified Windows native hook shim/,
+					);
+					assert.equal(await readFile(shimPath, "utf-8"), modifiedShim);
+					assert.equal(existsSync(join(codexHomeDir, "hooks.json")), false);
+					assert.equal(existsSync(join(codexHomeDir, "config.toml")), false);
+					assert.equal(existsSync(join(wd, ".omx")), false);
+				});
+			});
+		} finally {
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("writes hooks, notification metadata, then config/trust and rolls all writes back when config replacement fails", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-hook-transaction-"));
+		const writeOrder: string[] = [];
+		const resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+			(stage, artifact) => {
+				if (stage !== "before_temp_write") return;
+				writeOrder.push(artifact.kind);
+				if (artifact.kind === "config") {
+					throw new Error("injected config replacement failure");
+				}
+			},
+		);
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await writeFile(
+						join(codexHomeDir, "config.toml"),
+						'notify = ["node", "/tmp/user-notify.js"]\n',
+					);
+					await assert.rejects(
+						() =>
+							setup({
+								scope: "user",
+								installMode: "legacy",
+								mergeAgents: true,
+								skipNativeAgentRefresh: true,
+							}),
+						/rolled back: injected config replacement failure/,
+					);
+					assert.deepEqual(writeOrder, ["hooks", "metadata", "config"]);
+					assert.equal(existsSync(join(codexHomeDir, "hooks.json")), false);
+					assert.equal(
+						await readFile(join(codexHomeDir, "config.toml"), "utf-8"),
+						'notify = ["node", "/tmp/user-notify.js"]\n',
+					);
+					assert.equal(
+						existsSync(join(codexHomeDir, ".omx", "notify-dispatch.json")),
+						false,
+					);
+				});
+			});
+		} finally {
+			resetFailureInjector();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("writes the Windows shim, hooks, notification metadata, then config/trust and rolls all writes back", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-hook-transaction-"));
+		const writeOrder: string[] = [];
+		const resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+			(stage, artifact) => {
+				if (stage !== "before_temp_write") return;
+				writeOrder.push(artifact.kind);
+				if (artifact.kind === "config") {
+					throw new Error("injected Windows config replacement failure");
+				}
+			},
+		);
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await writeFile(
+						join(codexHomeDir, "config.toml"),
+						'notify = ["node", "/tmp/user-notify.js"]\n',
+					);
+					const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+					await assert.rejects(
+						() =>
+							setup({
+								scope: "user",
+								installMode: "legacy",
+								mergeAgents: true,
+								skipNativeAgentRefresh: true,
+							}),
+						/rolled back: injected Windows config replacement failure/,
+					);
+					assert.deepEqual(writeOrder, ["shim", "hooks", "metadata", "config"]);
+					assert.equal(existsSync(shimPath), false);
+					assert.equal(existsSync(join(codexHomeDir, "hooks.json")), false);
+					assert.equal(
+						await readFile(join(codexHomeDir, "config.toml"), "utf-8"),
+						'notify = ["node", "/tmp/user-notify.js"]\n',
+					);
+					assert.equal(
+						existsSync(join(codexHomeDir, ".omx", "notify-dispatch.json")),
+						false,
+					);
+				});
+			});
+		} finally {
+			resetFailureInjector();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("aborts stale native snapshots before setup can write unrelated artifacts", async () => {
+		const originalConfig = Buffer.from('model = "before"\n', "utf-8");
+		const originalHooks = Buffer.from('{"hooks": {}}\n', "utf-8");
+		const foreignHooks = Buffer.from('{"hooks": {"Stop": []}}\n', "utf-8");
+		const foreignConfig = Buffer.from('model = "foreign"\n', "utf-8");
+		const fixtures = [
+			{
+				name: "hooks creation",
+				seedHooks: null,
+				mutate: (hooksPath: string, _configPath: string) =>
+					writeFileSync(hooksPath, foreignHooks),
+				expectedHooks: foreignHooks,
+				expectedConfig: originalConfig,
+			},
+			{
+				name: "config modification",
+				seedHooks: originalHooks,
+				mutate: (_hooksPath: string, configPath: string) =>
+					writeFileSync(configPath, foreignConfig),
+				expectedHooks: originalHooks,
+				expectedConfig: foreignConfig,
+			},
+			{
+				name: "hooks deletion",
+				seedHooks: originalHooks,
+				mutate: (hooksPath: string, _configPath: string) => rmSync(hooksPath),
+				expectedHooks: null,
+				expectedConfig: originalConfig,
+			},
+			{
+				name: "config deletion",
+				seedHooks: originalHooks,
+				mutate: (_hooksPath: string, configPath: string) => rmSync(configPath),
+				expectedHooks: originalHooks,
+				expectedConfig: null,
+			},
+		] as const;
+		for (const fixture of fixtures) {
+			const wd = await mkdtemp(join(tmpdir(), "omx-setup-stale-native-"));
+			let resetFailureInjector: (() => void) | undefined;
+			try {
+				await withIsolatedUserHome(wd, async (codexHomeDir) => {
+					await withTempCwd(wd, async () => {
+						const hooksPath = join(codexHomeDir, "hooks.json");
+						const configPath = join(codexHomeDir, "config.toml");
+						await writeFile(configPath, originalConfig);
+						if (fixture.seedHooks) await writeFile(hooksPath, fixture.seedHooks);
+
+						let injected = false;
+						resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+							(stage) => {
+								if (stage !== "before_precondition" || injected) return;
+								injected = true;
+								fixture.mutate(hooksPath, configPath);
+							},
+						);
+						await assert.rejects(
+							setup({
+								scope: "user",
+								installMode: "legacy",
+								skipNativeAgentRefresh: true,
+								codexFeaturesProbe: () => null,
+								codexVersionProbe: () => null,
+							}),
+							/precondition changed/,
+						);
+						assert.equal(injected, true, fixture.name);
+						if (fixture.expectedConfig === null) {
+							assert.equal(existsSync(configPath), false);
+						} else {
+							assert.deepEqual(await readFile(configPath), fixture.expectedConfig);
+						}
+						if (fixture.expectedHooks === null) {
+							assert.equal(existsSync(hooksPath), false);
+						} else {
+							assert.deepEqual(await readFile(hooksPath), fixture.expectedHooks);
+						}
+						assert.equal(existsSync(join(wd, ".omx")), false);
+						assert.equal(existsSync(join(codexHomeDir, "agents")), false);
+					});
+				});
+			} finally {
+				resetFailureInjector?.();
+				await rm(wd, { recursive: true, force: true });
+			}
+		}
+	});
+	it("aborts when notification metadata changes after planning", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-stale-notify-metadata-"));
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const configPath = join(codexHomeDir, "config.toml");
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const metadataPath = join(
+						codexHomeDir,
+						".omx",
+						"notify-dispatch.json",
+					);
+					const configBefore = 'notify = ["node", "/tmp/user-notify.js"]\n';
+					const foreignMetadata = Buffer.from('{"managedBy":"foreign"}\n', "utf-8");
+					await writeFile(configPath, configBefore);
+					await mkdir(dirname(metadataPath), { recursive: true });
+					let injected = false;
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage, target) => {
+							if (
+								stage !== "before_precondition" ||
+								target.kind !== "metadata" ||
+								injected
+							) {
+								return;
+							}
+							injected = true;
+							writeFileSync(metadataPath, foreignMetadata);
+						},
+					);
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "legacy",
+							skipNativeAgentRefresh: true,
+							codexFeaturesProbe: () => null,
+							codexVersionProbe: () => null,
+						}),
+						/precondition changed/,
+					);
+					assert.equal(injected, true);
+					assert.deepEqual(await readFile(metadataPath), foreignMetadata);
+					assert.equal(await readFile(configPath, "utf-8"), configBefore);
+					assert.equal(existsSync(hooksPath), false);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("aborts when the Windows shim changes after planning", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-stale-windows-shim-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({
+						scope: "user",
+						installMode: "legacy",
+						skipNativeAgentRefresh: true,
+						codexFeaturesProbe: () => null,
+						codexVersionProbe: () => null,
+					});
+					const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const configPath = join(codexHomeDir, "config.toml");
+					const configBefore = await readFile(configPath);
+					await writeFile(hooksPath, '{"hooks": {}}\n');
+					const hooksBefore = await readFile(hooksPath);
+					const foreignShim = Buffer.from("# foreign shim\n", "utf-8");
+					let injected = false;
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage, target) => {
+							if (
+								stage === "before_precondition" &&
+								target.kind === "shim" &&
+								!injected
+							) {
+								injected = true;
+								writeFileSync(shimPath, foreignShim);
+							}
+						},
+					);
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "legacy",
+							skipNativeAgentRefresh: true,
+							codexFeaturesProbe: () => null,
+							codexVersionProbe: () => null,
+						}),
+						/precondition changed/,
+					);
+					assert.equal(injected, true);
+					assert.deepEqual(await readFile(shimPath), foreignShim);
+					assert.deepEqual(await readFile(hooksPath), hooksBefore);
+					assert.deepEqual(await readFile(configPath), configBefore);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("never deletes plugin hooks from a stale snapshot", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-plugin-stale-hooks-"));
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true });
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const configPath = join(codexHomeDir, "config.toml");
+					const configBefore = await readFile(configPath);
+					const foreignHooks = Buffer.from('{"hooks": {"Stop": []}}\n', "utf-8");
+					let injected = false;
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage) => {
+							if (stage !== "before_precondition" || injected) return;
+							injected = true;
+							writeFileSync(hooksPath, foreignHooks);
+						},
+					);
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "plugin",
+							pluginAgentsMdPrompt: async () => false,
+							skipNativeAgentRefresh: true,
+						}),
+						/precondition changed/,
+					);
+					assert.equal(injected, true);
+					assert.deepEqual(await readFile(hooksPath), foreignHooks);
+					assert.deepEqual(await readFile(configPath), configBefore);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("never rolls back a concurrent foreign hook replacement", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-stale-rollback-"));
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const configPath = join(codexHomeDir, "config.toml");
+					const hooksBefore = Buffer.from('{"hooks": {}}\n', "utf-8");
+					const configBefore = Buffer.from('model = "before"\n', "utf-8");
+					const foreignHooks = Buffer.from('{"hooks": {"Stop": []}}\n', "utf-8");
+					await writeFile(hooksPath, hooksBefore);
+					await writeFile(configPath, configBefore);
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage, target) => {
+							if (stage !== "before_temp_write" || target.kind !== "config") return;
+							writeFileSync(hooksPath, foreignHooks);
+							throw new Error("injected config replacement failure after foreign hook write");
+						},
+					);
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "legacy",
+							skipNativeAgentRefresh: true,
+							codexFeaturesProbe: () => null,
+							codexVersionProbe: () => null,
+						}),
+						/rollback failed/,
+					);
+					assert.deepEqual(await readFile(hooksPath), foreignHooks);
+					assert.deepEqual(await readFile(configPath), configBefore);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("preserves pre-existing native bytes and modes across injected transaction failures", async () => {
+		const failures = [
+			{ stage: "before_backup", kind: "shim" },
+			{ stage: "before_temp_write", kind: "shim" },
+			{ stage: "before_rename", kind: "hooks" },
+			{ stage: "before_temp_write", kind: "metadata" },
+			{ stage: "before_readback", kind: "config" },
+		] as const;
+		for (const failure of failures) {
+			const wd = await mkdtemp(join(tmpdir(), "omx-setup-transaction-rollback-"));
+			const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+			let resetFailureInjector: (() => void) | undefined;
+			try {
+				await withIsolatedUserHome(wd, async (codexHomeDir) => {
+					await withTempCwd(wd, async () => {
+						const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+						const hooksPath = join(codexHomeDir, "hooks.json");
+						const configPath = join(codexHomeDir, "config.toml");
+						const shimBefore = Buffer.from(
+							buildManagedCodexNativeHookWindowsShimContent(join(wd, "previous")),
+							"utf-8",
+						);
+						const hooksBefore = Buffer.from('{"hooks": {}}\n', "utf-8");
+						const configBefore = Buffer.from(
+							'model = "before"\nnotify = ["node", "/tmp/user-notify.js"]\n',
+							"utf-8",
+						);
+						await mkdir(dirname(shimPath), { recursive: true });
+						await writeFile(shimPath, shimBefore);
+						await writeFile(hooksPath, hooksBefore);
+						await writeFile(configPath, configBefore);
+						await Promise.all([
+							chmod(shimPath, 0o640),
+							chmod(hooksPath, 0o640),
+							chmod(configPath, 0o640),
+						]);
+
+						resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+							(stage, target) => {
+								if (stage === failure.stage && target.kind === failure.kind) {
+									throw new Error(`injected ${failure.stage} ${failure.kind} failure`);
+								}
+							},
+						);
+						await assert.rejects(
+							setup({
+								scope: "user",
+								installMode: "legacy",
+								skipNativeAgentRefresh: true,
+								codexFeaturesProbe: () => null,
+								codexVersionProbe: () => null,
+							}),
+							/injected .* failure/,
+						);
+						assert.deepEqual(await readFile(shimPath), shimBefore, failure.stage);
+						assert.deepEqual(await readFile(hooksPath), hooksBefore, failure.stage);
+						assert.deepEqual(await readFile(configPath), configBefore, failure.stage);
+						assert.equal(
+							existsSync(join(codexHomeDir, ".omx", "notify-dispatch.json")),
+							false,
+							failure.stage,
+						);
+						for (const path of [shimPath, hooksPath, configPath]) {
+							assert.equal((await stat(path)).mode & 0o777, 0o640, path);
+						}
+					});
+				});
+			} finally {
+				resetFailureInjector?.();
+				resetPlatform();
+				await rm(wd, { recursive: true, force: true });
+			}
+		}
+	});
+	it("fails closed when a managed dispatcher metadata snapshot is not valid UTF-8", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-invalid-notify-metadata-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const configPath = join(codexHomeDir, "config.toml");
+					const metadataPath = join(
+						codexHomeDir,
+						".omx",
+						"notify-dispatch.json",
+					);
+					const dispatcherPath = join(
+						packageRoot,
+						"dist",
+						"scripts",
+						"notify-dispatcher.js",
+					);
+					const configBefore = `notify = ${JSON.stringify([
+						"node",
+						dispatcherPath,
+						"--metadata",
+						metadataPath,
+					])}\n`;
+					await mkdir(dirname(metadataPath), { recursive: true });
+					await writeFile(configPath, configBefore);
+					await writeFile(metadataPath, Buffer.from([0xff]));
+
+					await assert.rejects(
+						setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true }),
+						/notification metadata .*invalid UTF-8/,
+					);
+					assert.equal(await readFile(configPath, "utf-8"), configBefore);
+					assert.deepEqual(await readFile(metadataPath), Buffer.from([0xff]));
+					assert.equal(existsSync(join(codexHomeDir, "hooks.json")), false);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps consulted unchanged notification metadata in the native transaction preconditions", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-notify-precondition-"));
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const configPath = join(codexHomeDir, "config.toml");
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const metadataPath = join(
+						codexHomeDir,
+						".omx",
+						"notify-dispatch.json",
+					);
+					await writeFile(
+						configPath,
+						'notify = ["node", "/tmp/user-notify.js"]\n',
+					);
+					await setup({
+						scope: "user",
+						installMode: "legacy",
+						skipNativeAgentRefresh: true,
+					});
+					const configBefore = await readFile(configPath);
+					const hooksBefore = await readFile(hooksPath);
+					const foreignMetadata = Buffer.from('{"managedBy":"foreign"}\n', "utf-8");
+					let injected = false;
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage, target) => {
+							if (
+								stage === "before_precondition" &&
+								target.kind === "metadata" &&
+								!injected
+							) {
+								injected = true;
+								writeFileSync(metadataPath, foreignMetadata);
+							}
+						},
+					);
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "legacy",
+							skipNativeAgentRefresh: true,
+						}),
+						/precondition changed/,
+					);
+					assert.equal(injected, true);
+					assert.deepEqual(await readFile(metadataPath), foreignMetadata);
+					assert.deepEqual(await readFile(configPath), configBefore);
+					assert.deepEqual(await readFile(hooksPath), hooksBefore);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects config decisions whose MCP-removal callback changed the planned config snapshot", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-stale-config-decision-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const configPath = join(codexHomeDir, "config.toml");
+					const configBefore = '[mcp_servers.omx_state]\ncommand = "node"\n';
+					const foreignConfig = 'model = "foreign"\n';
+					await writeFile(configPath, configBefore);
+
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "legacy",
+							skipNativeAgentRefresh: true,
+							firstPartyMcpRemovalPrompt: async () => {
+								await writeFile(configPath, foreignConfig);
+								return false;
+							},
+						}),
+						/precondition changed/,
+					);
+					assert.equal(await readFile(configPath, "utf-8"), foreignConfig);
+					assert.equal(existsSync(join(codexHomeDir, "hooks.json")), false);
+					assert.equal(existsSync(join(codexHomeDir, ".omx")), false);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("fails closed for pre-existing native transaction write temporaries", async () => {
+		const fixtures = ["regular file", "symlink"] as const;
+		for (const fixture of fixtures) {
+			const wd = await mkdtemp(join(tmpdir(), "omx-setup-temp-collision-"));
+			let resetTemporaryPath: (() => void) | undefined;
+			try {
+				await withIsolatedUserHome(wd, async (codexHomeDir) => {
+					await withTempCwd(wd, async () => {
+						const configPath = join(codexHomeDir, "config.toml");
+						const hooksPath = join(codexHomeDir, "hooks.json");
+						const collisionPath = join(codexHomeDir, ".hooks-write-collision");
+						const configBefore = 'model = "before"\n';
+						await writeFile(configPath, configBefore);
+						if (fixture === "regular file") {
+							await writeFile(collisionPath, "collision\n");
+						} else {
+							const targetPath = join(wd, "collision-target");
+							await writeFile(targetPath, "collision\n");
+							await symlink(targetPath, collisionPath);
+						}
+						resetTemporaryPath = setNativeHookTransactionTemporaryPathForTest(
+							(path, purpose) =>
+								path === hooksPath && purpose === "write"
+									? collisionPath
+									: join(dirname(path), `.${purpose}-unused`),
+						);
+
+						await assert.rejects(
+							setup({
+								scope: "user",
+								installMode: "legacy",
+								skipNativeAgentRefresh: true,
+							}),
+							/EEXIST/,
+						);
+						assert.equal(await readFile(collisionPath, "utf-8"), "collision\n");
+						assert.equal(await readFile(configPath, "utf-8"), configBefore);
+						assert.equal(existsSync(hooksPath), false);
+					});
+				});
+			} finally {
+				resetTemporaryPath?.();
+				await rm(wd, { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("fails closed when a non-throwing injector replaces an owned write temporary", async () => {
+		const fixtures = ["regular file", "symlink"] as const;
+		for (const fixture of fixtures) {
+			const wd = await mkdtemp(join(tmpdir(), "omx-setup-write-temp-replacement-"));
+			let resetFailureInjector: (() => void) | undefined;
+			let resetTemporaryPath: (() => void) | undefined;
+			try {
+				await withIsolatedUserHome(wd, async (codexHomeDir) => {
+					await withTempCwd(wd, async () => {
+						const configPath = join(codexHomeDir, "config.toml");
+						const hooksPath = join(codexHomeDir, "hooks.json");
+						const temporaryPath = join(codexHomeDir, ".hooks-write-owned");
+						const foreignTargetPath = join(wd, "foreign-write-temporary-target");
+						const configBefore = Buffer.from('model = "before"\n', "utf-8");
+						const foreignContents = `foreign ${fixture} write temporary\n`;
+						await writeFile(configPath, configBefore);
+						if (fixture === "symlink") {
+							await writeFile(foreignTargetPath, foreignContents);
+						}
+						resetTemporaryPath = setNativeHookTransactionTemporaryPathForTest(
+							(path, purpose) =>
+								path === hooksPath && purpose === "write"
+									? temporaryPath
+									: join(dirname(path), `.${basename(path)}.${purpose}-fallback`),
+						);
+						let injected = false;
+						resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+							(stage, target) => {
+								if (stage !== "before_rename" || target.kind !== "hooks") return;
+								injected = true;
+								rmSync(temporaryPath);
+								if (fixture === "regular file") {
+									writeFileSync(temporaryPath, foreignContents);
+								} else {
+									symlinkSync(foreignTargetPath, temporaryPath);
+								}
+							},
+						);
+
+						await assert.rejects(
+							setup({
+								scope: "user",
+								installMode: "legacy",
+								skipNativeAgentRefresh: true,
+							}),
+							/temporary.*manual recovery/,
+						);
+						assert.equal(injected, true);
+						const replacementStatus = await lstat(temporaryPath);
+						if (fixture === "regular file") {
+							assert.equal(replacementStatus.isFile(), true);
+							assert.equal(await readFile(temporaryPath, "utf-8"), foreignContents);
+						} else {
+							assert.equal(replacementStatus.isSymbolicLink(), true);
+							assert.equal(await readFile(foreignTargetPath, "utf-8"), foreignContents);
+						}
+						assert.equal(existsSync(hooksPath), false);
+						assert.deepEqual(await readFile(configPath), configBefore);
+					});
+				});
+			} finally {
+				resetFailureInjector?.();
+				resetTemporaryPath?.();
+				await rm(wd, { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("fails closed when a non-throwing injector replaces an owned staged deletion", async () => {
+		const fixtures = ["regular file", "symlink"] as const;
+		for (const fixture of fixtures) {
+			const wd = await mkdtemp(join(tmpdir(), "omx-setup-staged-delete-replacement-"));
+			const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+			let resetFailureInjector: (() => void) | undefined;
+			let resetTemporaryPath: (() => void) | undefined;
+			try {
+				await withIsolatedUserHome(wd, async (codexHomeDir) => {
+					await withTempCwd(wd, async () => {
+						await setup({
+							scope: "user",
+							installMode: "legacy",
+							skipNativeAgentRefresh: true,
+						});
+						const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+						const hooksPath = join(codexHomeDir, "hooks.json");
+						const configPath = join(codexHomeDir, "config.toml");
+						const stagedDeletionPath = join(codexHomeDir, ".hooks-delete-owned");
+						const foreignTargetPath = join(wd, "foreign-staged-deletion-target");
+						const shimBefore = await readFile(shimPath);
+						const hooksBefore = await readFile(hooksPath);
+						const configBefore = await readFile(configPath);
+						const foreignContents = `foreign ${fixture} staged deletion\n`;
+						if (fixture === "symlink") {
+							await writeFile(foreignTargetPath, foreignContents);
+						}
+						resetTemporaryPath = setNativeHookTransactionTemporaryPathForTest(
+							(path, purpose) =>
+								path === hooksPath && purpose === "delete"
+									? stagedDeletionPath
+									: join(dirname(path), `.${basename(path)}.${purpose}-fallback`),
+						);
+						let injected = false;
+						resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+							(stage, target) => {
+								if (stage !== "before_remove" || target.kind !== "hooks") return;
+								injected = true;
+								rmSync(stagedDeletionPath);
+								if (fixture === "regular file") {
+									writeFileSync(stagedDeletionPath, foreignContents);
+								} else {
+									symlinkSync(foreignTargetPath, stagedDeletionPath);
+								}
+							},
+						);
+
+						await assert.rejects(
+							setup({
+								scope: "user",
+								installMode: "plugin",
+								pluginAgentsMdPrompt: async () => false,
+								skipNativeAgentRefresh: true,
+							}),
+							/staged deletion.*manual recovery/,
+						);
+						assert.equal(injected, true);
+						const replacementStatus = await lstat(stagedDeletionPath);
+						if (fixture === "regular file") {
+							assert.equal(replacementStatus.isFile(), true);
+							assert.equal(await readFile(stagedDeletionPath, "utf-8"), foreignContents);
+						} else {
+							assert.equal(replacementStatus.isSymbolicLink(), true);
+							assert.equal(await readFile(foreignTargetPath, "utf-8"), foreignContents);
+						}
+						assert.deepEqual(await readFile(shimPath), shimBefore);
+						assert.deepEqual(await readFile(hooksPath), hooksBefore);
+						assert.deepEqual(await readFile(configPath), configBefore);
+					});
+				});
+			} finally {
+				resetFailureInjector?.();
+				resetTemporaryPath?.();
+				resetPlatform();
+				await rm(wd, { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("rolls back a renamed native hook when post-rename verification fails", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-post-rename-rollback-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("linux");
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const configPath = join(codexHomeDir, "config.toml");
+					const hooksBefore = Buffer.from('{"hooks": {}}\n', "utf-8");
+					const configBefore = Buffer.from('model = "before"\n', "utf-8");
+					await writeFile(hooksPath, hooksBefore);
+					await writeFile(configPath, configBefore);
+					await Promise.all([chmod(hooksPath, 0o640), chmod(configPath, 0o640)]);
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage, target) => {
+							if (stage === "after_rename" && target.kind === "hooks") {
+								throw new Error("injected post-rename verification failure");
+							}
+						},
+					);
+
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "legacy",
+							skipNativeAgentRefresh: true,
+							codexFeaturesProbe: () => null,
+							codexVersionProbe: () => null,
+						}),
+						/rolled back: injected post-rename verification failure/,
+					);
+					assert.deepEqual(await readFile(hooksPath), hooksBefore);
+					assert.deepEqual(await readFile(configPath), configBefore);
+					assert.equal((await stat(hooksPath)).mode & 0o777, 0o640);
+					assert.equal((await stat(configPath)).mode & 0o777, 0o640);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("preserves a concurrent replacement after staged source removal for manual recovery", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-post-remove-manual-recovery-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("linux");
+		let resetFailureInjector: (() => void) | undefined;
+		let resetTemporaryPath: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({
+						scope: "user",
+						installMode: "legacy",
+						skipNativeAgentRefresh: true,
+					});
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const configPath = join(codexHomeDir, "config.toml");
+					const stagedDeletionPath = join(codexHomeDir, ".hooks-delete-post-remove");
+					const hooksBefore = await readFile(hooksPath);
+					const configBefore = await readFile(configPath);
+					const foreignHooks = Buffer.from('{"hooks":{"Stop":[]}}\n', "utf-8");
+					resetTemporaryPath = setNativeHookTransactionTemporaryPathForTest(
+						(path, purpose) =>
+							path === hooksPath && purpose === "delete"
+								? stagedDeletionPath
+								: join(dirname(path), `.${basename(path)}.${purpose}-fallback`),
+					);
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage, target) => {
+							if (stage === "after_remove" && target.kind === "hooks") {
+								writeFileSync(hooksPath, foreignHooks);
+								throw new Error("injected post-remove verification failure");
+							}
+						},
+					);
+
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "plugin",
+							skipNativeAgentRefresh: true,
+							pluginAgentsMdPrompt: async () => false,
+							codexFeaturesProbe: () =>
+								[
+									"hooks                                   stable             true",
+									"plugin_hooks                            experimental       true",
+									"",
+								].join("\n"),
+						}),
+						(error: unknown) => {
+							const message = error instanceof Error ? error.message : String(error);
+							assert.match(message, /manual recovery/);
+							assert.ok(message.includes(hooksPath));
+							return true;
+						},
+					);
+					assert.deepEqual(await readFile(hooksPath), foreignHooks);
+					assert.deepEqual(await readFile(configPath), configBefore);
+					assert.deepEqual(await readFile(stagedDeletionPath), hooksBefore);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			resetTemporaryPath?.();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("never removes a concurrent replacement while rolling back a newly created artifact", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-rollback-remove-"));
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const configPath = join(codexHomeDir, "config.toml");
+					const configBefore = Buffer.from(
+						'notify = ["node", "/tmp/user-notify.js"]\n',
+						"utf-8",
+					);
+					const foreignHooks = Buffer.from('{"hooks":{"Stop":[]}}\n', "utf-8");
+					await writeFile(configPath, configBefore);
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage, target) => {
+							if (stage === "before_temp_write" && target.kind === "config") {
+								throw new Error("injected config failure");
+							}
+							if (stage === "before_rollback_remove" && target.kind === "hooks") {
+								writeFileSync(hooksPath, foreignHooks);
+							}
+						},
+					);
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "legacy",
+							skipNativeAgentRefresh: true,
+						}),
+						/rollback failed/,
+					);
+					assert.deepEqual(await readFile(hooksPath), foreignHooks);
+					assert.deepEqual(await readFile(configPath), configBefore);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("does not enter rollback after a second staged-deletion cleanup failure", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-staged-deletion-cleanup-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		let resetFailureInjector: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({
+						scope: "user",
+						installMode: "legacy",
+						skipNativeAgentRefresh: true,
+					});
+					const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const configPath = join(codexHomeDir, "config.toml");
+					let cleanupCount = 0;
+					resetFailureInjector = setNativeHookTransactionFailureInjectorForTest(
+						(stage, target) => {
+							if (
+								stage === "before_staged_cleanup" &&
+								(target.kind === "shim" || target.kind === "hooks")
+							) {
+								cleanupCount += 1;
+								if (cleanupCount === 2) {
+									throw new Error("injected second staged-deletion cleanup failure");
+								}
+							}
+						},
+					);
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "plugin",
+							skipNativeAgentRefresh: true,
+							pluginAgentsMdPrompt: async () => false,
+						}),
+						/committed but staged deletion cleanup failed/,
+					);
+					assert.equal(cleanupCount, 2);
+					assert.equal(existsSync(shimPath), false);
+					assert.equal(existsSync(hooksPath), false);
+					assert.match(await readFile(configPath, "utf-8"), /^plugin_hooks = true$/m);
+				});
+			});
+		} finally {
+			resetFailureInjector?.();
+			resetPlatform();
 			await rm(wd, { recursive: true, force: true });
 		}
 	});

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -20,6 +20,7 @@ import { parse as parseToml } from "@iarna/toml";
 import {
 	decideWindowsNativeHookShimReference,
 	setNativeHookTransactionFailureInjectorForTest,
+	setSetupLatePhaseFailureInjectorForTest,
 	setNativeHookTransactionPlatformForTest,
 	setNativeHookTransactionTemporaryPathForTest,
 	setup,
@@ -5588,6 +5589,44 @@ describe("omx setup install mode behavior", () => {
 			});
 		} finally {
 			resetFailureInjector?.();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("late setup failure transaction boundary", () => {
+	it("does not commit config or hooks when a later setup phase fails", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-late-failure-"));
+		let resetLateFailure: (() => void) | undefined;
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const configPath = join(codexHomeDir, "config.toml");
+					const hooksBefore = Buffer.from('{"hooks":{"FutureEvent":[{"hooks":[{"type":"prompt","prompt":"keep"}]}]}}\n');
+					const configBefore = Buffer.from('[features]\nhooks = true\n');
+					await mkdir(codexHomeDir, { recursive: true });
+					await writeFile(hooksPath, hooksBefore);
+					await writeFile(configPath, configBefore);
+					resetLateFailure = setSetupLatePhaseFailureInjectorForTest(() => {
+						throw new Error("injected late setup phase failure");
+					});
+					await assert.rejects(
+						setup({
+							scope: "user",
+							installMode: "legacy",
+							skipNativeAgentRefresh: true,
+							codexFeaturesProbe: () => null,
+							codexVersionProbe: () => null,
+						}),
+						/injected late setup phase failure/,
+					);
+					assert.deepEqual(await readFile(hooksPath), hooksBefore);
+					assert.deepEqual(await readFile(configPath), configBefore);
+				});
+			});
+		} finally {
+			resetLateFailure?.();
 			await rm(wd, { recursive: true, force: true });
 		}
 	});

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -1120,11 +1120,49 @@ describe("omx setup refresh summary and dry-run behavior", () => {
         await mkdir(join(wd, ".omx", "state"), { recursive: true });
         await mkdir(join(wd, ".codex"), { recursive: true });
         const configPath = join(wd, ".codex", "config.toml");
-        await writeFile(configPath, `${fixture.lines.join("\n")}\n`);
+        const original = `${fixture.lines.join("\n")}\n`;
+        await writeFile(configPath, original);
+        if (fixture.markers) {
+          await assert.rejects(
+            runSetupInTempDir(wd, { scope: "project" }),
+            /Refusing to write invalid planned config\.toml/,
+          );
+          assert.equal(await readFile(configPath, "utf-8"), original);
+          assert.equal(existsSync(join(wd, ".codex", "hooks.json")), false);
+          continue;
+        }
         await runSetupInTempDir(wd, { scope: "project" });
         const refreshed = await readFile(configPath, "utf-8");
         for (const line of fixture.preservedLines) assert.ok(refreshed.includes(line), `missing preserved line: ${line}`);
-        fixture.markers ? assert.match(refreshed, /seeded behavioral defaults/) : assert.doesNotMatch(refreshed, /seeded behavioral defaults/);
+        assert.doesNotMatch(refreshed, /seeded behavioral defaults/);
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+  it("rejects malformed config.toml and hooks.json bytes before any setup mutation", async () => {
+    const fixtures = [
+      { name: "config.toml", path: [".codex", "config.toml"] },
+      { name: "hooks.json", path: [".codex", "hooks.json"] },
+    ] as const;
+    for (const fixture of fixtures) {
+      const wd = await mkdtemp(join(tmpdir(), "omx-setup-invalid-utf8-"));
+      try {
+        const artifactPath = join(wd, ...fixture.path);
+        const invalidBytes = Buffer.from([0x7b, 0x80, 0x7d, 0x0a]);
+        await mkdir(join(wd, ".codex"), { recursive: true });
+        await writeFile(artifactPath, invalidBytes);
+
+        await assert.rejects(
+          runSetupInTempDir(wd, { scope: "project", skipNativeAgentRefresh: true }),
+          /invalid UTF-8/,
+        );
+
+        assert.deepEqual(await readFile(artifactPath), invalidBytes, fixture.name);
+        assert.equal(existsSync(join(wd, ".codex", "config.toml")), fixture.name === "config.toml");
+        assert.equal(existsSync(join(wd, ".codex", "hooks.json")), fixture.name === "hooks.json");
+        assert.equal(existsSync(join(wd, ".omx")), false);
+        assert.equal(existsSync(join(wd, "AGENTS.md")), false);
       } finally {
         await rm(wd, { recursive: true, force: true });
       }

--- a/src/cli/__tests__/setup-scope.test.ts
+++ b/src/cli/__tests__/setup-scope.test.ts
@@ -275,6 +275,7 @@ describe("omx setup scope behavior", () => {
             hooks: {
               SessionStart: [
                 {
+                  matcher: "startup|resume|clear",
                   hooks: [
                     {
                       type: "command",
@@ -321,9 +322,9 @@ describe("omx setup scope behavior", () => {
         ].join("\n"),
       );
 
-      const res = runOmx(wd, ["setup", "--scope", "project"], { HOME: home });
-      if (shouldSkipForSpawnPermissions(res.error)) return;
-      assert.equal(res.status, 0, res.stderr || res.stdout);
+      const setupResult = runOmx(wd, ["setup", "--scope", "project"], { HOME: home });
+      if (shouldSkipForSpawnPermissions(setupResult.error)) return;
+      assert.equal(setupResult.status, 0, setupResult.stderr || setupResult.stdout);
 
       const hooksJson = JSON.parse(
         await readFile(join(codexDir, "hooks.json"), "utf-8"),

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
-import { existsSync, lstatSync, readFileSync, renameSync, rmSync } from 'node:fs';
+import { existsSync, lstatSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
@@ -2984,6 +2984,113 @@ describe('omx uninstall', () => {
         assert.deepEqual(await readFile(configPath), config);
         assert.equal(existsSync(shimPath), false);
         assert.equal(existsSync(hooksPath), false);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it('preserves a foreign inode injected after final uninstall rename validation', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-final-rename-claim-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const config = Buffer.from(buildOmxConfig(), 'utf-8');
+        const foreignConfig = Buffer.from('model = "foreign-final-rename"\n', 'utf-8');
+        await mkdir(codexDir, { recursive: true });
+        await writeFile(configPath, config);
+        let foreignInode: number | undefined;
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionFailureInjector: (stage) => {
+              if (stage !== 'after-final-rename-validation') return;
+              const foreignPath = join(codexDir, '.foreign-final-rename-config');
+              writeFileSync(foreignPath, foreignConfig);
+              foreignInode = lstatSync(foreignPath).ino;
+              rmSync(configPath);
+              renameSync(foreignPath, configPath);
+            },
+          }),
+          /replacement claim.*not the planned artifact/,
+        );
+        assert.ok(foreignInode);
+        assert.equal(lstatSync(configPath).ino, foreignInode);
+        assert.deepEqual(await readFile(configPath), foreignConfig);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it('preserves a foreign inode injected after final uninstall removal validation', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-final-remove-claim-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const config = Buffer.from(buildOmxConfig(), 'utf-8');
+        const hooks = Buffer.from(`${JSON.stringify(buildManagedCodexHooksConfig(packageRoot()), null, 2)}\n`, 'utf-8');
+        const foreignHooks = Buffer.from('{"hooks":{"Stop":[]}}\n', 'utf-8');
+        await mkdir(codexDir, { recursive: true });
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+        let foreignInode: number | undefined;
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionFailureInjector: (stage) => {
+              if (stage !== 'after-final-remove-validation') return;
+              const foreignPath = join(codexDir, '.foreign-final-remove-hooks');
+              writeFileSync(foreignPath, foreignHooks);
+              foreignInode = lstatSync(foreignPath).ino;
+              rmSync(hooksPath);
+              renameSync(foreignPath, hooksPath);
+            },
+          }),
+          /removal claim.*not the planned artifact/,
+        );
+        assert.ok(foreignInode);
+        assert.equal(lstatSync(hooksPath).ino, foreignInode);
+        assert.deepEqual(await readFile(hooksPath), foreignHooks);
+        assert.deepEqual(await readFile(configPath), config);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it('preserves a foreign inode injected after final uninstall rollback validation', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-final-restore-claim-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const config = Buffer.from(buildOmxConfig(), 'utf-8');
+        const hooks = Buffer.from(`${JSON.stringify(buildManagedCodexHooksConfig(packageRoot()), null, 2)}\n`, 'utf-8');
+        const foreignHooks = Buffer.from('{"hooks":{"Stop":[]}}\n', 'utf-8');
+        await mkdir(codexDir, { recursive: true });
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+        let foreignInode: number | undefined;
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionFailureInjector: (stage) => {
+              if (stage === 'before-config-commit') throw new Error('injected rollback start');
+              if (stage !== 'after-final-restore-validation') return;
+              const foreignPath = join(codexDir, '.foreign-final-restore-hooks');
+              writeFileSync(foreignPath, foreignHooks);
+              foreignInode = lstatSync(foreignPath).ino;
+              renameSync(foreignPath, hooksPath);
+            },
+          }),
+          /Uninstall artifact rollback failed/,
+        );
+        assert.ok(foreignInode);
+        assert.equal(lstatSync(hooksPath).ino, foreignInode);
+        assert.deepEqual(await readFile(hooksPath), foreignHooks);
+        assert.deepEqual(await readFile(configPath), config);
       });
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -1,12 +1,18 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { buildManagedCodexHooksConfig } from '../../config/codex-hooks.js';
+import {
+  buildManagedCodexHookTrustState,
+  buildManagedCodexHooksConfig,
+  buildManagedCodexNativeHookWindowsShimContent,
+  buildManagedCodexNativeHookWindowsShimPath,
+} from '../../config/codex-hooks.js';
+import { uninstall } from '../uninstall.js';
 import TOML from '@iarna/toml';
 
 function runOmx(
@@ -36,7 +42,21 @@ function runOmx(
 }
 
 function shouldSkipForSpawnPermissions(err: string): boolean {
-  return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
+  return /(EPERM|EACCES)/i.test(err);
+}
+
+async function withCwd<T>(cwd: string, run: () => Promise<T>): Promise<T> {
+  const previousCwd = process.cwd();
+  process.chdir(cwd);
+  try {
+    return await run();
+  } finally {
+    process.chdir(previousCwd);
+  }
+}
+
+function packageRoot(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 }
 
 /** Build a realistic OMX config.toml for testing */
@@ -395,6 +415,8 @@ describe('omx uninstall', () => {
           managedBy: 'oh-my-codex',
           version: 1,
           previousNotify: ['node', staleDispatcher, '--metadata', metadataPath],
+          omxNotify: ['node', join(stalePkgRoot, 'dist', 'scripts', 'notify-hook.js')],
+          dispatcherNotify: ['node', staleDispatcher, '--metadata', metadataPath],
         }),
       );
 
@@ -447,61 +469,966 @@ describe('omx uninstall', () => {
     }
   });
 
-  it('preserves user hooks while removing OMX-managed wrappers', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
+  it('fails closed for unsupported root metadata in hooks.json', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-invalid-hooks-root-'));
     try {
       const home = join(wd, 'home');
       const codexDir = join(home, '.codex');
+      const configPath = join(codexDir, 'config.toml');
+      const hooksPath = join(codexDir, 'hooks.json');
+      const config = buildOmxConfig().replace(/^hooks = true$/m, 'codex_hooks = true');
+      const hooks = JSON.stringify({
+        version: 1,
+        hooks: {
+          SessionStart: [{
+            hooks: [{ type: 'command', command: 'node "/repo/dist/scripts/codex-native-hook.js"' }],
+          }],
+        },
+      }, null, 2) + '\n';
       await mkdir(codexDir, { recursive: true });
-      await writeFile(
-        join(codexDir, 'config.toml'),
-        buildOmxConfig().replace(/^hooks = true$/m, 'codex_hooks = true'),
-      );
-      await writeFile(
-        join(codexDir, 'hooks.json'),
-        JSON.stringify(
-          {
-            hooks: {
-              SessionStart: [
-                {
-                  hooks: [
-                    { type: 'command', command: 'node "/repo/dist/scripts/codex-native-hook.js"' },
-                    { type: 'command', command: 'echo keep-me' },
-                  ],
-                },
-              ],
-            },
-            version: 1,
-          },
-          null,
-          2,
-        ) + '\n',
-      );
+      await writeFile(configPath, config);
+      await writeFile(hooksPath, hooks);
+
+      const res = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 1, res.stderr || res.stdout);
+      assert.match(res.stderr, /unknown root field version/);
+      assert.equal(await readFile(configPath, 'utf-8'), config);
+      assert.equal(await readFile(hooksPath, 'utf-8'), hooks);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes safely positioned managed wrappers while preserving foreign hooks and the native feature flag', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-safe-foreign-hooks-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      const configPath = join(codexDir, 'config.toml');
+      const hooksPath = join(codexDir, 'hooks.json');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(configPath, buildOmxConfig().replace(/^hooks = true$/m, 'codex_hooks = true'));
+      await writeFile(hooksPath, JSON.stringify({
+        hooks: {
+          SessionStart: [
+            { hooks: [{ type: 'command', command: 'echo keep-me' }] },
+            { matcher: 'startup|resume|clear', hooks: [{ type: 'command', command: 'node "/repo/dist/scripts/codex-native-hook.js"' }] },
+          ],
+        },
+      }, null, 2) + '\n');
 
       const res = runOmx(wd, ['uninstall'], { HOME: home });
       if (shouldSkipForSpawnPermissions(res.error)) return;
       assert.equal(res.status, 0, res.stderr || res.stdout);
-      assert.equal(existsSync(join(codexDir, 'hooks.json')), true);
 
-      const hooks = await readFile(join(codexDir, 'hooks.json'), 'utf-8');
+      const hooks = await readFile(hooksPath, 'utf-8');
       assert.match(hooks, /echo keep-me/);
-      assert.match(hooks, /"version": 1/);
       assert.doesNotMatch(hooks, /codex-native-hook\.js/);
+      const config = await readFile(configPath, 'utf-8');
+      assert.match(config, /^hooks = true$/m);
+      assert.doesNotMatch(config, /^codex_hooks\s*=/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it('fails closed without removing a shell-expanding foreign command that resembles an OMX hook', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-shell-expanding-hook-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      const configPath = join(codexDir, 'config.toml');
+      const hooksPath = join(codexDir, 'hooks.json');
+      const config = buildOmxConfig();
+      const hooks = JSON.stringify({
+        hooks: {
+          SessionStart: [{
+            matcher: 'startup|resume|clear',
+            hooks: [{ type: 'command', command: 'node "$HOME/repo/dist/scripts/codex-native-hook.js"' }],
+          }],
+        },
+      }, null, 2) + '\n';
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(configPath, config);
+      await writeFile(hooksPath, hooks);
 
-      const config = await readFile(join(codexDir, 'config.toml'), 'utf-8');
-      assert.match(
-        config,
-        /^hooks = true$/m,
-        'preserved user hooks should keep the canonical Codex hooks feature enabled',
-      );
-      assert.doesNotMatch(
-        config,
-        /^codex_hooks\s*=/m,
-        'legacy Codex hook aliases should be normalized during uninstall preservation',
-      );
-      assert.match(config, /^multi_agent\s*=/m);
-      assert.doesNotMatch(config, /^child_agents_md\s*=/m);
-      assert.doesNotMatch(config, /^goals\s*=/m);
+      const res = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 1, res.stderr || res.stdout);
+      assert.match(res.stderr, /ambiguous_managed_handler|does not match the managed command grammar/i);
+      assert.equal(await readFile(configPath, 'utf-8'), config);
+      assert.equal(await readFile(hooksPath, 'utf-8'), hooks);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed without cleaning config when managed removal would shift a foreign handler', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-unsafe-foreign-hooks-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      const configPath = join(codexDir, 'config.toml');
+      const hooksPath = join(codexDir, 'hooks.json');
+      const config = buildOmxConfig();
+      const hooks = JSON.stringify({
+        hooks: {
+          SessionStart: [{
+            matcher: 'startup|resume|clear',
+            hooks: [
+              { type: 'command', command: 'node "/repo/dist/scripts/codex-native-hook.js"' },
+              { type: 'command', command: 'echo keep-me' },
+            ],
+          }],
+        },
+      }, null, 2) + '\n';
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(configPath, config);
+      await writeFile(hooksPath, hooks);
+
+      const res = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 1, res.stderr || res.stdout);
+      assert.match(res.stderr, /unsafe_managed_removal|shift a foreign coordinate/i);
+      assert.equal(await readFile(configPath, 'utf-8'), config);
+      assert.equal(await readFile(hooksPath, 'utf-8'), hooks);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rolls back hooks, historical proof-owned shim, and config when shim removal fails', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-shim-rollback-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+        const config = buildOmxConfig();
+        const hooks = `${JSON.stringify(
+          buildManagedCodexHooksConfig(packageRoot(), {
+            platform: 'win32',
+            codexHomeDir: codexDir,
+          }),
+          null,
+          2,
+        )}\n`;
+        const shim = buildManagedCodexNativeHookWindowsShimContent(
+          'C:\\Historical Install\\oh-my-codex',
+          { nodePath: 'D:\\Historical Node\\node.exe' },
+        );
+        await mkdir(codexDir, { recursive: true });
+        await mkdir(dirname(shimPath), { recursive: true });
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+        await writeFile(shimPath, shim);
+
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionPlatform: 'win32',
+            transactionFailureInjector: async (stage) => {
+              if (stage !== 'before-shim-removal') return;
+              assert.equal(existsSync(hooksPath), false, 'hooks must mutate before shim removal');
+              assert.equal(await readFile(configPath, 'utf-8'), config);
+              throw new Error('simulated shim removal failure');
+            },
+          }),
+          /simulated shim removal failure/,
+        );
+
+        assert.equal(await readFile(hooksPath, 'utf-8'), hooks);
+        assert.equal(await readFile(shimPath, 'utf-8'), shim);
+        assert.equal(await readFile(configPath, 'utf-8'), config);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a modified Windows shim before any uninstall artifact write', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-modified-shim-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+        const config = buildOmxConfig();
+        const hooks = `${JSON.stringify(
+          buildManagedCodexHooksConfig(packageRoot(), {
+            platform: 'win32',
+            codexHomeDir: codexDir,
+          }),
+          null,
+          2,
+        )}\n`;
+        const shim = `${buildManagedCodexNativeHookWindowsShimContent(packageRoot())}\n# user edit\n`;
+        await mkdir(codexDir, { recursive: true });
+        await mkdir(dirname(shimPath), { recursive: true });
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+        await writeFile(shimPath, shim);
+
+        await assert.rejects(
+          uninstall({ scope: 'project', transactionPlatform: 'win32' }),
+          /modified native hook Windows shim/,
+        );
+
+        assert.equal(await readFile(hooksPath, 'utf-8'), hooks);
+        assert.equal(await readFile(shimPath, 'utf-8'), shim);
+        assert.equal(await readFile(configPath, 'utf-8'), config);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rolls back hooks, shim, and config when config commit fails after hook mutation', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-config-rollback-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+        const config = buildOmxConfig();
+        const hooks = `${JSON.stringify(
+          buildManagedCodexHooksConfig(packageRoot(), {
+            platform: 'win32',
+            codexHomeDir: codexDir,
+          }),
+          null,
+          2,
+        )}\n`;
+        const shim = buildManagedCodexNativeHookWindowsShimContent(packageRoot());
+        await mkdir(codexDir, { recursive: true });
+        await mkdir(dirname(shimPath), { recursive: true });
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+        await writeFile(shimPath, shim);
+
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionPlatform: 'win32',
+            transactionFailureInjector: async (stage) => {
+              if (stage !== 'after-config-commit') return;
+              assert.equal(existsSync(hooksPath), false, 'hooks must mutate before config commit');
+              assert.equal(existsSync(shimPath), false, 'shim must mutate before config commit');
+              assert.notEqual(await readFile(configPath, 'utf-8'), config);
+              throw new Error('simulated config commit failure');
+            },
+          }),
+          /simulated config commit failure/,
+        );
+
+        assert.equal(await readFile(hooksPath, 'utf-8'), hooks);
+        assert.equal(await readFile(shimPath, 'utf-8'), shim);
+        assert.equal(await readFile(configPath, 'utf-8'), config);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects invalid UTF-8 hooks.json and config.toml before changing either artifact', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-invalid-utf8-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const hooks = Buffer.from([0x7b, 0xff, 0x7d]);
+        const config = Buffer.from([0x6f, 0x6d, 0x78, 0x5f, 0xff]);
+        await mkdir(codexDir, { recursive: true });
+        await writeFile(configPath, buildOmxConfig());
+        await writeFile(hooksPath, hooks);
+
+        await assert.rejects(uninstall({ scope: 'project' }), /not valid UTF-8/);
+        assert.deepEqual(await readFile(hooksPath), hooks);
+
+        await writeFile(hooksPath, JSON.stringify(buildManagedCodexHooksConfig(packageRoot())));
+        await writeFile(configPath, config);
+        await assert.rejects(uninstall({ scope: 'project' }), /not valid UTF-8/);
+        assert.deepEqual(await readFile(configPath), config);
+
+        const bomHooks = Buffer.concat([
+          Buffer.from([0xef, 0xbb, 0xbf]),
+          Buffer.from('{"hooks":{}}\n', 'utf-8'),
+        ]);
+        await writeFile(configPath, buildOmxConfig());
+        await writeFile(hooksPath, bomHooks);
+        await assert.rejects(uninstall({ scope: 'project' }), /must contain a JSON object/);
+        assert.deepEqual(await readFile(hooksPath), bomHooks);
+        assert.equal(existsSync(hooksPath), true);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects symlinked native hook artifacts without following their targets', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-symlink-hooks-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const targetPath = join(wd, 'user-hooks.json');
+        const config = buildOmxConfig();
+        const target = '{"user":"hooks"}\n';
+        await mkdir(codexDir, { recursive: true });
+        await writeFile(configPath, config);
+        await writeFile(targetPath, target);
+        await symlink(targetPath, hooksPath);
+
+        await assert.rejects(uninstall({ scope: 'project' }), /expected a regular file, not a symbolic link/);
+        assert.equal((await lstat(hooksPath)).isSymbolicLink(), true);
+        assert.equal(await readFile(targetPath, 'utf-8'), target);
+        assert.equal(await readFile(configPath, 'utf-8'), config);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('aborts before the first removal when any planned artifact becomes stale', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-stale-snapshot-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const config = buildOmxConfig();
+        const hooks = `${JSON.stringify(buildManagedCodexHooksConfig(packageRoot()), null, 2)}\n`;
+        const staleConfig = `${config}# concurrent user edit\n`;
+        await mkdir(codexDir, { recursive: true });
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionFailureInjector: async (stage) => {
+              if (stage === 'before-hooks-commit') await writeFile(configPath, staleConfig);
+            },
+          }),
+          /planned artifact .* changed, was created, or was removed after planning/,
+        );
+        assert.equal(await readFile(hooksPath, 'utf-8'), hooks);
+        assert.equal(await readFile(configPath, 'utf-8'), staleConfig);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('never replaces a concurrent symlink while rolling back a failed uninstall transaction', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-stale-rollback-link-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+        const replacementPath = join(wd, 'concurrent-user-hooks.json');
+        const config = buildOmxConfig();
+        const hooks = `${JSON.stringify(buildManagedCodexHooksConfig(packageRoot(), {
+          platform: 'win32',
+          codexHomeDir: codexDir,
+        }), null, 2)}\n`;
+        const replacement = '{"user":"replacement"}\n';
+        await mkdir(codexDir, { recursive: true });
+        await mkdir(dirname(shimPath), { recursive: true });
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+        await writeFile(shimPath, buildManagedCodexNativeHookWindowsShimContent(packageRoot()));
+        await writeFile(replacementPath, replacement);
+
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionPlatform: 'win32',
+            transactionFailureInjector: async (stage) => {
+              if (stage !== 'before-shim-removal') return;
+              await symlink(replacementPath, hooksPath);
+              throw new Error('simulated concurrent hook replacement');
+            },
+          }),
+          /Uninstall artifact rollback failed.*(?:Refusing stale rollback|expected a regular file, not a symbolic link)/,
+        );
+        assert.equal((await lstat(hooksPath)).isSymbolicLink(), true);
+        assert.equal(await readFile(replacementPath, 'utf-8'), replacement);
+        assert.equal(await readFile(configPath, 'utf-8'), config);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it('rejects a symlinked controlled ancestor before reading an escaped artifact', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-ancestor-link-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const escapedDir = join(wd, 'escaped-codex');
+        const configPath = join(escapedDir, 'config.toml');
+        const config = buildOmxConfig();
+        await mkdir(escapedDir, { recursive: true });
+        await writeFile(configPath, config);
+        await symlink(
+          escapedDir,
+          codexDir,
+          process.platform === 'win32' ? 'junction' : 'dir',
+        );
+
+        await assert.rejects(
+          uninstall({ scope: 'project' }),
+          /controlled ancestor .* must be a non-symbolic-link directory/,
+        );
+        assert.equal(await readFile(configPath, 'utf-8'), config);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not truncate or follow regular and symlink replacement temporary collisions', async () => {
+    for (const collisionKind of ['regular', 'symlink'] as const) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-uninstall-temp-${collisionKind}-`));
+      try {
+        await withCwd(wd, async () => {
+          const codexDir = join(wd, '.codex');
+          const configPath = join(codexDir, 'config.toml');
+          const collisionPath = join(codexDir, '.config.toml.collision');
+          const collisionTarget = join(wd, 'collision-target');
+          const config = buildOmxConfig();
+          const collision = 'foreign temporary collision\n';
+          await mkdir(codexDir, { recursive: true });
+          await writeFile(configPath, config);
+          if (collisionKind === 'regular') {
+            await writeFile(collisionPath, collision);
+          } else {
+            await writeFile(collisionTarget, collision);
+            await symlink(collisionTarget, collisionPath);
+          }
+
+          await assert.rejects(
+            uninstall({
+              scope: 'project',
+              transactionTemporaryPath: () => collisionPath,
+            }),
+            /EEXIST/,
+          );
+          assert.equal(await readFile(configPath, 'utf-8'), config);
+          assert.equal(
+            await readFile(collisionKind === 'regular' ? collisionPath : collisionTarget, 'utf-8'),
+            collision,
+          );
+          if (collisionKind === 'symlink') {
+            assert.equal((await lstat(collisionPath)).isSymbolicLink(), true);
+          }
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('rejects stale snapshots immediately before forward rename and remove mutations', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-stale-forward-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const config = buildOmxConfig();
+        const concurrentConfig = `${config}# concurrent replacement\n`;
+        await mkdir(codexDir, { recursive: true });
+        await writeFile(configPath, config);
+
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionFailureInjector: async (stage) => {
+              if (stage === 'before-rename') await writeFile(configPath, concurrentConfig);
+            },
+          }),
+          /planned artifact .* changed, was created, or was removed after planning/,
+        );
+        assert.equal(await readFile(configPath, 'utf-8'), concurrentConfig);
+
+        const hooks = `${JSON.stringify(buildManagedCodexHooksConfig(packageRoot()), null, 2)}\n`;
+        const concurrentHooks = '{"foreign":"replacement"}\n';
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionFailureInjector: async (stage) => {
+              if (stage === 'before-remove') await writeFile(hooksPath, concurrentHooks);
+            },
+          }),
+          /planned artifact .* changed, was created, or was removed after planning/,
+        );
+        assert.equal(await readFile(hooksPath, 'utf-8'), concurrentHooks);
+        assert.equal(await readFile(configPath, 'utf-8'), config);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed for non-throwing regular and symlink write-temporary replacements', async () => {
+    for (const replacementKind of ['regular', 'symlink'] as const) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-uninstall-write-temp-${replacementKind}-`));
+      try {
+        await withCwd(wd, async () => {
+          const codexDir = join(wd, '.codex');
+          const configPath = join(codexDir, 'config.toml');
+          const hooksPath = join(codexDir, 'hooks.json');
+          const temporaryPath = join(codexDir, '.config.toml.write-temporary');
+          const replacementTarget = join(wd, 'foreign-write-temporary');
+          const config = Buffer.from(buildOmxConfig());
+          const hooks = Buffer.from('{}\n');
+          const replacement = Buffer.from('foreign write temporary replacement\n');
+          await mkdir(codexDir, { recursive: true });
+          await writeFile(configPath, config);
+          await writeFile(hooksPath, hooks);
+
+          await assert.rejects(
+            uninstall({
+              scope: 'project',
+              transactionTemporaryPath: (_path, purpose) =>
+                purpose === 'write' ? temporaryPath : join(codexDir, '.hooks.json.staged'),
+              transactionFailureInjector: async (stage) => {
+                if (stage !== 'before-rename') return;
+                await rm(temporaryPath, { force: true });
+                if (replacementKind === 'regular') {
+                  await writeFile(temporaryPath, replacement);
+                } else {
+                  await writeFile(replacementTarget, replacement);
+                  await symlink(replacementTarget, temporaryPath);
+                }
+              },
+            }),
+            (error: unknown) => {
+              const message = error instanceof Error ? error.message : String(error);
+              assert.match(message, /planned artifact .* changed, was created, or was removed after planning|expected a regular file, not a symbolic link/);
+              assert.ok(message.includes(temporaryPath));
+              assert.match(message, /preserved temporary .*manual recovery after cleanup verification failed/);
+              return true;
+            },
+          );
+
+          assert.deepEqual(await readFile(configPath), config);
+          assert.deepEqual(await readFile(hooksPath), hooks);
+          if (replacementKind === 'regular') {
+            assert.deepEqual(await readFile(temporaryPath), replacement);
+          } else {
+            assert.equal((await lstat(temporaryPath)).isSymbolicLink(), true);
+            assert.deepEqual(await readFile(replacementTarget), replacement);
+          }
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('fails closed for non-throwing regular and symlink staged-tombstone replacements', async () => {
+    for (const replacementKind of ['regular', 'symlink'] as const) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-uninstall-staged-tombstone-${replacementKind}-`));
+      try {
+        await withCwd(wd, async () => {
+          const codexDir = join(wd, '.codex');
+          const configPath = join(codexDir, 'config.toml');
+          const hooksPath = join(codexDir, 'hooks.json');
+          const stagedPath = join(codexDir, '.hooks.json.staged-tombstone');
+          const replacementTarget = join(wd, 'foreign-staged-tombstone');
+          const config = Buffer.from(buildOmxConfig());
+          const hooks = Buffer.from(`${JSON.stringify(buildManagedCodexHooksConfig(packageRoot()), null, 2)}\n`);
+          const replacement = Buffer.from('foreign staged tombstone replacement\n');
+          await mkdir(codexDir, { recursive: true });
+          await writeFile(configPath, config);
+          await writeFile(hooksPath, hooks);
+
+          await assert.rejects(
+            uninstall({
+              scope: 'project',
+              transactionTemporaryPath: (_path, purpose) =>
+                purpose === 'delete' ? stagedPath : join(codexDir, '.write-temporary'),
+              transactionFailureInjector: async (stage) => {
+                if (stage !== 'before-remove') return;
+                await rm(stagedPath, { force: true });
+                if (replacementKind === 'regular') {
+                  await writeFile(stagedPath, replacement);
+                } else {
+                  await writeFile(replacementTarget, replacement);
+                  await symlink(replacementTarget, stagedPath);
+                }
+              },
+            }),
+            (error: unknown) => {
+              const message = error instanceof Error ? error.message : String(error);
+              assert.match(message, /planned artifact .* changed, was created, or was removed after planning|expected a regular file, not a symbolic link/);
+              assert.ok(message.includes(stagedPath));
+              assert.match(message, /preserved staged deletion .*manual recovery after cleanup verification failed/);
+              return true;
+            },
+          );
+
+          assert.deepEqual(await readFile(configPath), config);
+          assert.deepEqual(await readFile(hooksPath), hooks);
+          if (replacementKind === 'regular') {
+            assert.deepEqual(await readFile(stagedPath), replacement);
+          } else {
+            assert.equal((await lstat(stagedPath)).isSymbolicLink(), true);
+            assert.deepEqual(await readFile(replacementTarget), replacement);
+          }
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('rejects stale snapshots immediately before rollback rename and staged-copy removal', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-stale-rollback-primitives-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const hooks = `${JSON.stringify(buildManagedCodexHooksConfig(packageRoot()), null, 2)}\n`;
+        const config = buildOmxConfig();
+        await mkdir(codexDir, { recursive: true });
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+
+        const concurrentHooks = '{"foreign":"rollback rename"}\n';
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionFailureInjector: async (stage) => {
+              if (stage === 'before-config-commit') throw new Error('stop after hook deletion');
+              if (stage === 'before-rollback-rename') {
+                await writeFile(hooksPath, concurrentHooks);
+              }
+            },
+          }),
+          /Uninstall artifact rollback failed.*Refusing uninstall because planned artifact/,
+        );
+        assert.equal(await readFile(hooksPath, 'utf-8'), concurrentHooks);
+
+        await writeFile(hooksPath, hooks);
+        const stagedPath = join(codexDir, '.hooks.json.rollback-stage');
+        const staleStagedCopy = 'foreign staged copy\n';
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionTemporaryPath: (_path, purpose) =>
+              purpose === 'delete' ? stagedPath : join(codexDir, '.write-temporary'),
+            transactionFailureInjector: async (stage) => {
+              if (stage === 'before-config-commit') throw new Error('stop after hook deletion');
+              if (stage === 'before-rollback-remove') {
+                await writeFile(stagedPath, staleStagedCopy);
+              }
+            },
+          }),
+          /Uninstall artifact rollback failed.*staged deletion cleanup/,
+        );
+        assert.equal(await readFile(hooksPath, 'utf-8'), hooks);
+        assert.equal(await readFile(stagedPath, 'utf-8'), staleStagedCopy);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('cleans staged deletions only after commit and leaves the staged copy recoverable on cleanup failure', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-staged-deletion-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const hooks = `${JSON.stringify(buildManagedCodexHooksConfig(packageRoot()), null, 2)}\n`;
+        const config = buildOmxConfig();
+        const stagedPath = join(codexDir, '.hooks.json.staged');
+        await mkdir(codexDir, { recursive: true });
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+
+        await uninstall({
+          scope: 'project',
+          transactionTemporaryPath: (_path, purpose) =>
+            purpose === 'delete' ? stagedPath : join(codexDir, '.write-temporary'),
+        });
+        assert.equal(existsSync(hooksPath), false);
+        assert.equal(existsSync(stagedPath), false, 'successful commit leaves no staged tombstone');
+
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionTemporaryPath: (_path, purpose) =>
+              purpose === 'delete' ? stagedPath : join(codexDir, '.write-temporary'),
+            transactionFailureInjector: (stage) => {
+              if (stage === 'before-staged-cleanup') {
+                throw new Error('staged deletion cleanup interrupted');
+              }
+            },
+          }),
+          /committed but staged deletion cleanup failed/,
+        );
+        assert.equal(existsSync(hooksPath), false);
+        assert.equal(await readFile(stagedPath, 'utf-8'), hooks);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('strictly validates dispatcher metadata and treats it as a stale read-only transaction precondition', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-notify-metadata-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const metadataPath = join(codexDir, '.omx', 'notify-dispatch.json');
+        const dispatcherPath = join(packageRoot(), 'dist', 'scripts', 'notify-dispatcher.js');
+        const config = buildOmxConfig().replace(
+          /^notify = .*$/m,
+          `notify = ${JSON.stringify(['node', dispatcherPath, '--metadata', metadataPath])}`,
+        );
+        const metadata = {
+          managedBy: 'oh-my-codex',
+          version: 1,
+          previousNotify: ['node', '/tmp/user-notify.js'],
+          omxNotify: ['node', join(packageRoot(), 'dist', 'scripts', 'notify-hook.js')],
+          dispatcherNotify: ['node', dispatcherPath, '--metadata', metadataPath],
+        };
+        await mkdir(dirname(metadataPath), { recursive: true });
+        await writeFile(configPath, config);
+        await writeFile(
+          metadataPath,
+          JSON.stringify({ ...metadata, previousNotify: ['not-a-string', 7] }),
+        );
+
+        await assert.rejects(
+          uninstall({ scope: 'project' }),
+          /previousNotify must be null or an array of strings/,
+        );
+        assert.equal(await readFile(configPath, 'utf-8'), config);
+        await writeFile(metadataPath, Buffer.from([0x7b, 0xff, 0x7d]));
+        await assert.rejects(
+          uninstall({ scope: 'project' }),
+          /not valid UTF-8/,
+        );
+        assert.equal(await readFile(configPath, 'utf-8'), config);
+
+        await writeFile(metadataPath, JSON.stringify(metadata));
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionFailureInjector: async (stage) => {
+              if (stage === 'before-config-commit') {
+                await writeFile(
+                  metadataPath,
+                  JSON.stringify({ ...metadata, previousNotify: ['node', '/tmp/concurrent.js'] }),
+                );
+              }
+            },
+          }),
+          /planned artifact .* changed, was created, or was removed after planning/,
+        );
+        assert.equal(await readFile(configPath, 'utf-8'), config);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not report stale rollback recovery when failure occurs before destructive removal', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-pre-destructive-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const stagedPath = join(codexDir, '.hooks.json.pre-destructive');
+        const config = buildOmxConfig();
+        const hooks = `${JSON.stringify(buildManagedCodexHooksConfig(packageRoot()), null, 2)}\n`;
+        await mkdir(codexDir, { recursive: true });
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionTemporaryPath: (_path, purpose) =>
+              purpose === 'delete' ? stagedPath : join(codexDir, '.write-temporary'),
+            transactionFailureInjector: (stage) => {
+              if (stage === 'before-remove') throw new Error('pre-destructive removal failure');
+            },
+          }),
+          (error: unknown) => {
+            const message = error instanceof Error ? error.message : String(error);
+            assert.match(message, /pre-destructive removal failure/);
+            assert.doesNotMatch(message, /manual recovery|stale rollback/i);
+            return true;
+          },
+        );
+        assert.equal(await readFile(hooksPath, 'utf-8'), hooks);
+        assert.equal(await readFile(configPath, 'utf-8'), config);
+        assert.equal(existsSync(stagedPath), false);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes exact historical root trust state but preserves nonmatching nested state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-legacy-hook-state-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      const configPath = join(codexDir, 'config.toml');
+      const hooksPath = join(codexDir, 'hooks.json');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(configPath, buildOmxConfig());
+      await writeFile(hooksPath, JSON.stringify({
+        state: {
+          [`${hooksPath}:stop:0:0`]: { trusted_hash: 'sha256:historical' },
+        },
+      }, null, 2) + '\n');
+
+      const rootStateCleanup = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(rootStateCleanup.error)) return;
+      assert.equal(rootStateCleanup.status, 0, rootStateCleanup.stderr || rootStateCleanup.stdout);
+      assert.deepEqual(JSON.parse(await readFile(hooksPath, 'utf-8')), {});
+
+      const nestedState = {
+        retained: { custom: true, trusted_hash: 'sha256:not-omx' },
+      };
+      await writeFile(hooksPath, JSON.stringify({
+        hooks: {
+          state: nestedState,
+          SessionStart: [{
+            hooks: [{ type: 'command', command: 'node "/repo/dist/scripts/codex-native-hook.js"' }],
+          }],
+        },
+      }, null, 2) + '\n');
+      const nestedStateCleanup = runOmx(wd, ['uninstall', '--keep-config'], { HOME: home });
+      assert.equal(nestedStateCleanup.status, 0, nestedStateCleanup.stderr || nestedStateCleanup.stdout);
+      const after = JSON.parse(await readFile(hooksPath, 'utf-8')) as {
+        hooks?: { state?: unknown; SessionStart?: unknown };
+      };
+      assert.deepEqual(after.hooks?.state, nestedState);
+      assert.equal(after.hooks?.SessionStart, undefined);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes only trust state at the managed hook coordinates planned from hooks.json', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-hook-trust-coordinates-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      const configPath = join(codexDir, 'config.toml');
+      const hooksPath = join(codexDir, 'hooks.json');
+      const hooks = JSON.stringify({
+        hooks: {
+          SessionStart: [{
+            hooks: [{ type: 'command', command: 'node "/repo/dist/scripts/codex-native-hook.js"' }],
+          }],
+        },
+      }, null, 2) + '\n';
+      const trustState = buildManagedCodexHookTrustState(hooksPath, wd, {
+        hooksContent: hooks,
+      });
+      const [actualKey, actualTrust] = Object.entries(trustState)[0] ?? [];
+      if (!actualKey || !actualTrust) {
+        assert.fail('expected SessionStart managed trust state');
+      }
+      const staleCoordinate = `${hooksPath}:session_start:9:0`;
+      const actualHeader = `[hooks.state.${JSON.stringify(actualKey)}]`;
+      const staleHeader = `[hooks.state.${JSON.stringify(staleCoordinate)}]`;
+      const config = [
+        buildOmxConfig().trimEnd(),
+        '',
+        actualHeader,
+        `trusted_hash = "${actualTrust.trusted_hash}"`,
+        '',
+        staleHeader,
+        `trusted_hash = "${actualTrust.trusted_hash}"`,
+        '',
+      ].join('\n');
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(configPath, config);
+      await writeFile(hooksPath, hooks);
+
+      const res = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      const cleaned = await readFile(configPath, 'utf-8');
+      assert.equal(cleaned.includes(actualHeader), false);
+      assert.equal(cleaned.includes(staleHeader), true);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps empty hooks.json byte-identical during dry-run and no-op uninstall', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-empty-hooks-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      const configPath = join(codexDir, 'config.toml');
+      const hooksPath = join(codexDir, 'hooks.json');
+      const config = buildOmxConfig();
+      const hooks = '{}\n';
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(configPath, config);
+      await writeFile(hooksPath, hooks);
+
+      const dryRun = runOmx(wd, ['uninstall', '--dry-run'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(dryRun.error)) return;
+      assert.equal(dryRun.status, 0, dryRun.stderr || dryRun.stdout);
+      assert.equal(await readFile(configPath, 'utf-8'), config);
+      assert.equal(await readFile(hooksPath, 'utf-8'), hooks);
+
+      const uninstall = runOmx(wd, ['uninstall'], { HOME: home });
+      assert.equal(uninstall.status, 0, uninstall.stderr || uninstall.stdout);
+      assert.equal(await readFile(hooksPath, 'utf-8'), hooks);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed for partial hooks.json corruption before config cleanup', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-corrupt-hooks-'));
+    try {
+      const home = join(wd, 'home');
+      const codexDir = join(home, '.codex');
+      const configPath = join(codexDir, 'config.toml');
+      const hooksPath = join(codexDir, 'hooks.json');
+      const config = buildOmxConfig();
+      const hooks = '{\n  "hooks": { "SessionStart": {} }\n}\n';
+      await mkdir(codexDir, { recursive: true });
+      await writeFile(configPath, config);
+      await writeFile(hooksPath, hooks);
+
+      const res = runOmx(wd, ['uninstall'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 1, res.stderr || res.stdout);
+      assert.match(res.stderr, /SessionStart must be an array/);
+      assert.equal(await readFile(configPath, 'utf-8'), config);
+      assert.equal(await readFile(hooksPath, 'utf-8'), hooks);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -522,10 +1449,11 @@ describe('omx uninstall', () => {
         JSON.stringify({
           hooks: {
             SessionStart: [
+              { hooks: [{ type: 'command', command: 'echo keep-me' }] },
               {
+                matcher: 'startup|resume|clear',
                 hooks: [
                   { type: 'command', command: 'node "/repo/dist/scripts/codex-native-hook.js"' },
-                  { type: 'command', command: 'echo keep-me' },
                 ],
               },
             ],

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -1,8 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { existsSync, lstatSync, readFileSync, renameSync, rmSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -52,6 +52,31 @@ async function withCwd<T>(cwd: string, run: () => Promise<T>): Promise<T> {
     return await run();
   } finally {
     process.chdir(previousCwd);
+  }
+}
+
+async function withDriveQualifiedWindowsCodexHome<T>(
+  wd: string,
+  run: (codexHomeDir: string) => Promise<T>,
+): Promise<T> {
+  const previousHome = process.env.HOME;
+  const previousCodexHome = process.env.CODEX_HOME;
+  const codexHomeDir = 'C:\\Users\\omx\\.codex';
+  process.env.HOME = wd;
+  process.env.CODEX_HOME = codexHomeDir;
+  try {
+    return await withCwd(wd, async () => {
+      await mkdir(codexHomeDir, { recursive: true });
+      return run(codexHomeDir);
+    });
+  } finally {
+    if (typeof previousHome === 'string') process.env.HOME = previousHome;
+    else delete process.env.HOME;
+    if (typeof previousCodexHome === 'string') {
+      process.env.CODEX_HOME = previousCodexHome;
+    } else {
+      delete process.env.CODEX_HOME;
+    }
   }
 }
 
@@ -596,7 +621,540 @@ describe('omx uninstall', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+  it('fails before uninstall writes when marker-wrapped trust state has foreign siblings', async () => {
+    const representations = [
+      {
+        name: 'inline',
+        render: (key: string, hash: string) => [
+          `hooks = { state = { ${JSON.stringify(key)} = { trusted_hash = ${JSON.stringify(hash)}, foreign = true } } }`,
+        ],
+      },
+      {
+        name: 'dotted',
+        render: (key: string, hash: string) => [
+          `hooks.state.${JSON.stringify(key)}.trusted_hash = ${JSON.stringify(hash)}`,
+          `hooks.state.${JSON.stringify(key)}.foreign = true`,
+        ],
+      },
+      {
+        name: 'table',
+        render: (key: string, hash: string) => [
+          `[hooks.state.${JSON.stringify(key)}]`,
+          `trusted_hash = ${JSON.stringify(hash)}`,
+          'foreign = true',
+        ],
+      },
+      {
+        name: 'separate-foreign-table',
+        render: (key: string, hash: string) => [
+          `[hooks.state.${JSON.stringify(key)}]`,
+          `trusted_hash = ${JSON.stringify(hash)}`,
+          '',
+          '[hooks.state."foreign-key"]',
+          'trusted_hash = "sha256:foreign"',
+        ],
+      },
+    ] as const;
+    for (const representation of representations) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-uninstall-trust-${representation.name}-`));
+      try {
+        await withCwd(wd, async () => {
+          const codexDir = join(wd, '.codex');
+          const configPath = join(codexDir, 'config.toml');
+          const hooksPath = join(codexDir, 'hooks.json');
+          const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+          const metadataPath = join(codexDir, '.omx', 'notify-dispatch.json');
+          const hooks = `${JSON.stringify(buildManagedCodexHooksConfig(packageRoot(), {
+            platform: 'win32',
+            codexHomeDir: codexDir,
+          }), null, 2)}\n`;
+          const [key, trust] = Object.entries(buildManagedCodexHookTrustState(
+            hooksPath,
+            packageRoot(),
+            {
+              platform: 'win32',
+              codexHomeDir: codexDir,
+              hooksContent: hooks,
+            },
+          ))[0] ?? [];
+          assert.ok(key);
+          assert.ok(trust);
+          const config = [
+            'model = "foreign"',
+            '',
+            '# ============================================================',
+            '# oh-my-codex (OMX) Configuration',
+            '# Managed by omx setup - manual edits preserved on next setup',
+            '# ============================================================',
+            '',
+            ...representation.render(key, trust.trusted_hash),
+            '',
+            '# ============================================================',
+            '# End oh-my-codex',
+            '',
+          ].join('\n');
+          const metadata = Buffer.from('{"managedBy":"foreign"}\n', 'utf-8');
+          const shim = Buffer.from(
+            buildManagedCodexNativeHookWindowsShimContent(packageRoot()),
+            'utf-8',
+          );
+          await mkdir(dirname(metadataPath), { recursive: true });
+          await writeFile(configPath, config);
+          await writeFile(hooksPath, hooks);
+          await writeFile(shimPath, shim);
+          await writeFile(metadataPath, metadata);
 
+          await assert.rejects(
+            uninstall({ scope: 'project', transactionPlatform: 'win32' }),
+            (error: unknown) =>
+              typeof error === 'object' &&
+              error !== null &&
+              'code' in error &&
+              (error as { code?: unknown }).code === 'managed_trust_key_conflict',
+          );
+          assert.deepEqual(await readFile(configPath), Buffer.from(config, 'utf-8'));
+          assert.deepEqual(await readFile(hooksPath), Buffer.from(hooks, 'utf-8'));
+          assert.deepEqual(await readFile(shimPath), shim);
+          assert.deepEqual(await readFile(metadataPath), metadata);
+          assert.deepEqual(
+            (await readdir(codexDir)).filter((entry) => entry.includes('.omx-')),
+            [],
+          );
+          assert.deepEqual(
+            (await readdir(wd)).filter((entry) => entry.includes('.omx-')),
+            [],
+          );
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+  it('fails before uninstall writes when marker trust has absent or non-managed hooks expectations', async () => {
+    const fixtures = [
+      { name: 'absent', hooks: null },
+      {
+        name: 'non-managed',
+        hooks: `${JSON.stringify({
+          hooks: {
+            UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'echo foreign' }] }],
+          },
+        }, null, 2)}\n`,
+      },
+    ] as const;
+    for (const fixture of fixtures) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-uninstall-marker-${fixture.name}-`));
+      try {
+        await withCwd(wd, async () => {
+          const codexDir = join(wd, '.codex');
+          const configPath = join(codexDir, 'config.toml');
+          const hooksPath = join(codexDir, 'hooks.json');
+          const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+          const metadataPath = join(codexDir, '.omx', 'notify-dispatch.json');
+          const config = buildOmxConfig().replace(
+            '# End oh-my-codex',
+            '[hooks.state."foreign-key"]\ntrusted_hash = "sha256:foreign"\n\n# End oh-my-codex',
+          );
+          const shim = Buffer.from(
+            buildManagedCodexNativeHookWindowsShimContent(packageRoot()),
+            'utf-8',
+          );
+          const metadata = Buffer.from('{"managedBy":"foreign"}\n', 'utf-8');
+          await mkdir(dirname(metadataPath), { recursive: true });
+          await writeFile(configPath, config);
+          if (fixture.hooks !== null) await writeFile(hooksPath, fixture.hooks);
+          await writeFile(shimPath, shim);
+          await writeFile(metadataPath, metadata);
+
+          await assert.rejects(
+            uninstall({ scope: 'project', transactionPlatform: 'win32' }),
+            (error: unknown) =>
+              typeof error === 'object' &&
+              error !== null &&
+              'code' in error &&
+              (error as { code?: unknown }).code === 'managed_trust_key_conflict',
+          );
+          assert.deepEqual(await readFile(configPath), Buffer.from(config, 'utf-8'));
+          assert.deepEqual(await readFile(shimPath), shim);
+          assert.deepEqual(await readFile(metadataPath), metadata);
+          if (fixture.hooks === null) {
+            assert.equal(existsSync(hooksPath), false);
+          } else {
+            assert.deepEqual(await readFile(hooksPath), Buffer.from(fixture.hooks, 'utf-8'));
+          }
+          assert.deepEqual(
+            (await readdir(codexDir)).filter((entry) => entry.includes('.omx-')),
+            [],
+          );
+          assert.deepEqual(
+            (await readdir(wd)).filter((entry) => entry.includes('.omx-')),
+            [],
+          );
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+  it('preserves a shim referenced by a Unicode-escaped future hook event', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-future-shim-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+        const managed = buildManagedCodexHooksConfig(packageRoot(), {
+          platform: 'win32',
+          codexHomeDir: codexDir,
+        });
+        const sentinel = '__OMX_ESCAPED_SHIM_COMMAND__';
+        const hooks = JSON.stringify({
+          ...managed,
+          hooks: {
+            ...managed.hooks,
+            FutureEvent: [{ hooks: [{ type: 'command', command: sentinel }] }],
+          },
+        }, null, 2).replace(
+          JSON.stringify(sentinel),
+          JSON.stringify(
+            `& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File '${shimPath}'`,
+          ).replace(/\\\\/g, '\\u005c'),
+        ) + '\n';
+        await mkdir(codexDir, { recursive: true });
+        await writeFile(configPath, buildOmxConfig());
+        await writeFile(hooksPath, hooks);
+        await writeFile(
+          shimPath,
+          buildManagedCodexNativeHookWindowsShimContent(packageRoot()),
+        );
+
+        await uninstall({ scope: 'project', transactionPlatform: 'win32' });
+        assert.equal(existsSync(shimPath), true);
+        const finalHooks = await readFile(hooksPath, 'utf-8');
+        assert.match(finalHooks, /FutureEvent/);
+        assert.match(finalHooks, /\\u005c/);
+        assert.doesNotMatch(finalHooks, /codex-native-hook\.js/);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it('preserves a drive-qualified shim referenced by a drive-less future hook event', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-drive-qualified-future-shim-'));
+    try {
+      await withDriveQualifiedWindowsCodexHome(wd, async (codexHomeDir) => {
+        const configPath = join(codexHomeDir, 'config.toml');
+        const hooksPath = join(codexHomeDir, 'hooks.json');
+        const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+        const managed = buildManagedCodexHooksConfig(packageRoot(), {
+          platform: 'win32',
+          codexHomeDir,
+        });
+        const driveLessFutureShimPath = '\\Users\\omx\\.codex\\hooks\\omx-native-hook-windows-shim.ps1';
+        const hooks = `${JSON.stringify({
+          ...managed,
+          hooks: {
+            ...managed.hooks,
+            FutureEvent: [{
+              hooks: [{
+                type: 'command',
+                command: `& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File '${driveLessFutureShimPath}'`,
+              }],
+            }],
+          },
+        }, null, 2)}\n`;
+        await writeFile(configPath, buildOmxConfig());
+        await writeFile(hooksPath, hooks);
+        await writeFile(
+          shimPath,
+          buildManagedCodexNativeHookWindowsShimContent(packageRoot()),
+        );
+
+        await uninstall({ scope: 'user', transactionPlatform: 'win32' });
+        assert.equal(existsSync(shimPath), true);
+        const finalHooks = await readFile(hooksPath, 'utf-8');
+        assert.match(finalHooks, /FutureEvent/);
+        assert.doesNotMatch(finalHooks, /codex-native-hook\.js/);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves a shim referenced through a normalized Windows path alias', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-shim-path-alias-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+        const shimAlias = shimPath
+          .replace(/[\\/]+hooks[\\/]+/i, '\\hooks\\\\.\\')
+          .replace(/omx-native-hook-windows-shim\.ps1$/i, 'OMX-NATIVE-HOOK-WINDOWS-SHIM.PS1')
+          .replace(/\\/g, '/');
+        const managed = buildManagedCodexHooksConfig(packageRoot(), {
+          platform: 'win32',
+          codexHomeDir: codexDir,
+        });
+        const hooks = `${JSON.stringify({
+          ...managed,
+          hooks: {
+            ...managed.hooks,
+            FutureEvent: [{
+              hooks: [{
+                type: 'command',
+                command: `& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File '${shimAlias}'`,
+              }],
+            }],
+          },
+        }, null, 2)}\n`;
+        await mkdir(codexDir, { recursive: true });
+        await writeFile(configPath, buildOmxConfig());
+        await writeFile(hooksPath, hooks);
+        await writeFile(
+          shimPath,
+          buildManagedCodexNativeHookWindowsShimContent(packageRoot()),
+        );
+
+        await uninstall({ scope: 'project', transactionPlatform: 'win32' });
+        assert.equal(existsSync(shimPath), true);
+        assert.match(await readFile(hooksPath, 'utf-8'), /FutureEvent/);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it('preserves a shim for a distinct absolute -File target', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-quoted-inert-shim-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+        const managed = buildManagedCodexHooksConfig(packageRoot(), {
+          platform: 'win32',
+          codexHomeDir: codexDir,
+        });
+        const hooks = `${JSON.stringify({
+          ...managed,
+          hooks: {
+            ...managed.hooks,
+            FutureEvent: [{
+              hooks: [{
+                type: 'command',
+                command: "& 'C:\\%OMX_INERT%\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File 'D:\\tools\\unrelated-$env:INERT.ps1'",
+              }],
+            }],
+          },
+        }, null, 2)}\n`;
+        await mkdir(codexDir, { recursive: true });
+        await mkdir(dirname(shimPath), { recursive: true });
+        await writeFile(configPath, buildOmxConfig());
+        await writeFile(hooksPath, hooks);
+        await writeFile(
+          shimPath,
+          buildManagedCodexNativeHookWindowsShimContent(packageRoot()),
+        );
+
+        await uninstall({ scope: 'project', transactionPlatform: 'win32' });
+        assert.equal(existsSync(shimPath), true);
+        assert.match(await readFile(hooksPath, 'utf-8'), /FutureEvent/);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it('treats exact and all ambiguous preserved shim references as read-only transaction preconditions', async () => {
+    const fixtures = [
+      { name: 'normalized-alias-deletion', reference: 'exact', mutation: 'delete' },
+      { name: 'basename-ambiguity-replacement', reference: 'basename', mutation: 'replace' },
+      { name: 'environment-indirection-replacement', reference: 'environment', mutation: 'replace' },
+      { name: 'alternate-absolute-alias-deletion', reference: 'alternate-absolute', mutation: 'delete' },
+      { name: 'rooted-short-name-deletion', reference: 'rooted-short-name', mutation: 'delete' },
+      { name: 'drive-relative-short-name-deletion', reference: 'drive-relative-short-name', mutation: 'delete' },
+      { name: 'distinct-basename-absolute-deletion', reference: 'distinct-basename-absolute', mutation: 'delete' },
+    ] as const;
+    for (const fixture of fixtures) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-uninstall-preserved-shim-${fixture.name}-`));
+      try {
+        await withCwd(wd, async () => {
+          const codexDir = join(wd, '.codex');
+          const configPath = join(codexDir, 'config.toml');
+          const hooksPath = join(codexDir, 'hooks.json');
+          const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+          const shimAlias = shimPath
+            .replace(/[\\/]+hooks[\\/]+/i, '\\hooks\\\\.\\')
+            .replace(/omx-native-hook-windows-shim\.ps1$/i, 'OMX-NATIVE-HOOK-WINDOWS-SHIM.PS1')
+            .replace(/\\/g, '/');
+          const command = fixture.reference === 'exact'
+            ? `& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File '${shimAlias}'`
+            : fixture.reference === 'environment'
+              ? '& $env:OMX_SHIM'
+              : fixture.reference === 'alternate-absolute'
+                ? "& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File 'D:\\aliases\\omx-native-hook-windows-shim.ps1'"
+                : fixture.reference === 'rooted-short-name'
+                  ? "& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File '\\Users\\ALICE~1\\.codex\\hooks\\OMX-NA~1.PS1'"
+                  : fixture.reference === 'drive-relative-short-name'
+                    ? "& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File 'C:Users\\ALICE~1\\.codex\\hooks\\OMX-NA~1.PS1'"
+                    : fixture.reference === 'distinct-basename-absolute'
+                      ? "& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File 'D:\\aliases\\foreign-hook-alias.ps1'"
+                      : 'echo omx-native-hook-windows-shim.ps1';
+          const managed = buildManagedCodexHooksConfig(packageRoot(), {
+            platform: 'win32',
+            codexHomeDir: codexDir,
+          });
+          const hooks = `${JSON.stringify({
+            ...managed,
+            hooks: {
+              ...managed.hooks,
+              FutureEvent: [{ hooks: [{ type: 'command', command }] }],
+            },
+          }, null, 2)}\n`;
+          const config = buildOmxConfig();
+          const shim = Buffer.from(
+            buildManagedCodexNativeHookWindowsShimContent(packageRoot()),
+            'utf-8',
+          );
+          const replacement = Buffer.from('concurrent shim replacement\n', 'utf-8');
+          await mkdir(codexDir, { recursive: true });
+          await writeFile(configPath, config);
+          await writeFile(hooksPath, hooks);
+          await writeFile(shimPath, shim);
+
+          await assert.rejects(
+            uninstall({
+              scope: 'project',
+              transactionPlatform: 'win32',
+              transactionFailureInjector: async (stage) => {
+                if (stage !== 'before-config-commit') return;
+                if (fixture.mutation === 'delete') {
+                  await rm(shimPath);
+                } else {
+                  await writeFile(shimPath, replacement);
+                }
+              },
+            }),
+            /planned artifact .* changed, was created, or was removed after planning/,
+          );
+          assert.deepEqual(await readFile(configPath), Buffer.from(config, 'utf-8'));
+          assert.deepEqual(await readFile(hooksPath), Buffer.from(hooks, 'utf-8'));
+          if (fixture.mutation === 'delete') {
+            assert.equal(existsSync(shimPath), false);
+          } else {
+            assert.deepEqual(await readFile(shimPath), replacement);
+          }
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+  it('rolls back hooks when a preserved environment-indirected shim drifts under --keep-config', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-keep-config-preserved-shim-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+        const managed = buildManagedCodexHooksConfig(packageRoot(), {
+          platform: 'win32',
+          codexHomeDir: codexDir,
+        });
+        const hooks = `${JSON.stringify({
+          ...managed,
+          hooks: {
+            ...managed.hooks,
+            FutureEvent: [{ hooks: [{ type: 'command', command: '& $env:OMX_SHIM' }] }],
+          },
+        }, null, 2)}\n`;
+        const config = buildOmxConfig();
+        const replacement = Buffer.from('concurrent preserved shim replacement\n', 'utf-8');
+        await mkdir(codexDir, { recursive: true });
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+        await writeFile(
+          shimPath,
+          buildManagedCodexNativeHookWindowsShimContent(packageRoot()),
+        );
+
+        let injected = false;
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            keepConfig: true,
+            transactionPlatform: 'win32',
+            transactionFailureInjector: async (stage) => {
+              if (stage !== 'before-rename' || injected) return;
+              injected = true;
+              await writeFile(shimPath, replacement);
+            },
+          }),
+          /planned artifact .* changed, was created, or was removed after planning/,
+        );
+        assert.equal(injected, true);
+        assert.equal(await readFile(configPath, 'utf-8'), config);
+        assert.equal(await readFile(hooksPath, 'utf-8'), hooks);
+        assert.deepEqual(await readFile(shimPath), replacement);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it('rolls back when a preserved Windows shim drifts after staged-cleanup finalization', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-preserved-shim-finalization-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+        const managed = buildManagedCodexHooksConfig(packageRoot(), {
+          platform: 'win32',
+          codexHomeDir: codexDir,
+        });
+        const hooks = `${JSON.stringify({
+          ...managed,
+          hooks: {
+            ...managed.hooks,
+            FutureEvent: [{ hooks: [{ type: 'command', command: '& $env:OMX_SHIM' }] }],
+          },
+        }, null, 2)}\n`;
+        const config = buildOmxConfig();
+        const replacement = Buffer.from('concurrent finalization shim replacement\n', 'utf-8');
+        await mkdir(codexDir, { recursive: true });
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+        await writeFile(
+          shimPath,
+          buildManagedCodexNativeHookWindowsShimContent(packageRoot()),
+        );
+
+        let injected = false;
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionPlatform: 'win32',
+            transactionFailureInjector: async (stage) => {
+              if (stage !== 'after-staged-cleanup' || injected) return;
+              injected = true;
+              await writeFile(shimPath, replacement);
+            },
+          }),
+          /planned artifact .* changed, was created, or was removed after planning/,
+        );
+        assert.equal(injected, true);
+        assert.equal(await readFile(configPath, 'utf-8'), config);
+        assert.equal(await readFile(hooksPath, 'utf-8'), hooks);
+        assert.deepEqual(await readFile(shimPath), replacement);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
   it('rolls back hooks, historical proof-owned shim, and config when shim removal fails', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-shim-rollback-'));
     try {
@@ -1147,7 +1705,8 @@ describe('omx uninstall', () => {
     }
   });
 
-  it('cleans staged deletions only after commit and leaves the staged copy recoverable on cleanup failure', async () => {
+  it('rolls back when staged-deletion cleanup fails before any staged copy is committed', async () => {
+
     const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-staged-deletion-'));
     try {
       await withCwd(wd, async () => {
@@ -1171,27 +1730,206 @@ describe('omx uninstall', () => {
 
         await writeFile(configPath, config);
         await writeFile(hooksPath, hooks);
+        let interrupted = false;
         await assert.rejects(
           uninstall({
             scope: 'project',
             transactionTemporaryPath: (_path, purpose) =>
               purpose === 'delete' ? stagedPath : join(codexDir, '.write-temporary'),
             transactionFailureInjector: (stage) => {
-              if (stage === 'before-staged-cleanup') {
+              if (stage === 'before-staged-cleanup' && !interrupted) {
+                interrupted = true;
                 throw new Error('staged deletion cleanup interrupted');
               }
             },
           }),
-          /committed but staged deletion cleanup failed/,
+          /staged deletion cleanup interrupted/,
         );
-        assert.equal(existsSync(hooksPath), false);
-        assert.equal(await readFile(stagedPath, 'utf-8'), hooks);
+        assert.equal(interrupted, true);
+        assert.equal(await readFile(hooksPath, 'utf-8'), hooks);
+        assert.equal(await readFile(configPath, 'utf-8'), config);
+        assert.equal(existsSync(stagedPath), false);
       });
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
   });
 
+  it('does not roll back when preserved metadata drifts after staged-deletion cleanup finalization', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-second-staged-drift-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+        const metadataPath = join(codexDir, '.omx', 'notify-dispatch.json');
+        const dispatcherPath = join(packageRoot(), 'dist', 'scripts', 'notify-dispatcher.js');
+        const hooks = `${JSON.stringify(buildManagedCodexHooksConfig(packageRoot(), {
+          platform: 'win32',
+          codexHomeDir: codexDir,
+        }), null, 2)}\n`;
+        const metadata = {
+          managedBy: 'oh-my-codex',
+          version: 1,
+          previousNotify: ['node', '/tmp/user-notify.js'],
+          omxNotify: ['node', join(packageRoot(), 'dist', 'scripts', 'notify-hook.js')],
+          dispatcherNotify: ['node', dispatcherPath, '--metadata', metadataPath],
+        };
+        const foreignMetadata = JSON.stringify({
+          ...metadata,
+          previousNotify: ['node', '/tmp/concurrent-notify.js'],
+        });
+        const config = buildOmxConfig().replace(
+          /^notify = .*$/m,
+          `notify = ${JSON.stringify(metadata.dispatcherNotify)}`,
+        );
+        const stagedDeletionPath = (path: string, purpose: 'write' | 'delete') =>
+          join(dirname(path), `.${basename(path)}.cleanup-${purpose}`);
+        await mkdir(dirname(metadataPath), { recursive: true });
+        await mkdir(dirname(shimPath), { recursive: true });
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+        await writeFile(shimPath, buildManagedCodexNativeHookWindowsShimContent(packageRoot()));
+        await writeFile(metadataPath, JSON.stringify(metadata));
+
+        let injected = false;
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionPlatform: 'win32',
+            transactionTemporaryPath: stagedDeletionPath,
+            transactionFailureInjector: async (stage) => {
+              if (stage !== 'after-staged-cleanup' || injected) return;
+              injected = true;
+              await writeFile(metadataPath, foreignMetadata);
+            },
+          }),
+          /committed but staged deletion cleanup failed/,
+        );
+        assert.equal(injected, true);
+        assert.equal(await readFile(metadataPath, 'utf-8'), foreignMetadata);
+        assert.equal(existsSync(hooksPath), false);
+        assert.equal(existsSync(shimPath), false);
+        assert.notEqual(await readFile(configPath, 'utf-8'), config);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it('treats applied hook, shim, and config snapshots as CAS through commit finalization', async () => {
+    const fixtures = [
+      { name: 'later commit', stage: 'before-shim-removal', drift: 'hooks', committed: false },
+      { name: 'staged cleanup', stage: 'before-staged-cleanup', drift: 'shim', committed: false },
+      { name: 'finalization', stage: 'after-staged-cleanup', drift: 'config', committed: true },
+    ] as const;
+    for (const fixture of fixtures) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-uninstall-applied-${fixture.name}-`));
+      try {
+        await withCwd(wd, async () => {
+          const codexDir = join(wd, '.codex');
+          const configPath = join(codexDir, 'config.toml');
+          const hooksPath = join(codexDir, 'hooks.json');
+          const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+          const config = Buffer.from(buildOmxConfig(), 'utf-8');
+          const hooks = Buffer.from(`${JSON.stringify(buildManagedCodexHooksConfig(packageRoot(), {
+            platform: 'win32',
+            codexHomeDir: codexDir,
+          }), null, 2)}\n`, 'utf-8');
+          const shim = Buffer.from(buildManagedCodexNativeHookWindowsShimContent(packageRoot()), 'utf-8');
+          const paths = { config: configPath, hooks: hooksPath, shim: shimPath };
+          const before = { config, hooks, shim };
+          const foreign = Buffer.from(`foreign applied ${fixture.drift} ${fixture.name}\n`, 'utf-8');
+          await mkdir(codexDir, { recursive: true });
+          await mkdir(dirname(shimPath), { recursive: true });
+          await writeFile(configPath, config);
+          await writeFile(hooksPath, hooks);
+          await writeFile(shimPath, shim);
+
+          let injected = false;
+          await assert.rejects(
+            uninstall({
+              scope: 'project',
+              transactionPlatform: 'win32',
+              transactionFailureInjector: async (stage) => {
+                if (stage !== fixture.stage || injected) return;
+                injected = true;
+                await writeFile(paths[fixture.drift], foreign);
+              },
+            }),
+            fixture.committed
+              ? /committed but staged deletion cleanup failed during finalization/
+              : /Uninstall artifact rollback failed/,
+          );
+          assert.equal(injected, true, fixture.name);
+          if (fixture.name === 'staged cleanup') {
+            assert.equal(existsSync(hooksPath), false);
+            assert.deepEqual(await readFile(shimPath), foreign);
+            assert.notDeepEqual(await readFile(configPath), before.config);
+            return;
+          }
+          if (fixture.committed) {
+            assert.equal(existsSync(hooksPath), false);
+            assert.equal(existsSync(shimPath), false);
+            assert.deepEqual(await readFile(configPath), foreign);
+            return;
+          }
+          assert.deepEqual(
+            await readFile(hooksPath),
+            fixture.drift === 'hooks' ? foreign : before.hooks,
+          );
+          assert.deepEqual(
+            await readFile(shimPath),
+            before.shim,
+          );
+          assert.deepEqual(await readFile(configPath), before.config);
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+  it('rolls back registered destinations when post-rename or post-remove verification fails', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-post-apply-recovery-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const config = Buffer.from(buildOmxConfig(), 'utf-8');
+        const hooks = Buffer.from(`${JSON.stringify(buildManagedCodexHooksConfig(packageRoot()), null, 2)}\n`, 'utf-8');
+        await mkdir(codexDir, { recursive: true });
+
+        await writeFile(configPath, config);
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionFailureInjector: (stage) => {
+              if (stage === 'after-rename') throw new Error('post-rename verification failure');
+            },
+          }),
+          /post-rename verification failure/,
+        );
+        assert.deepEqual(await readFile(configPath), config);
+
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionFailureInjector: (stage) => {
+              if (stage === 'after-remove') throw new Error('post-remove verification failure');
+            },
+          }),
+          /post-remove verification failure/,
+        );
+        assert.deepEqual(await readFile(hooksPath), hooks);
+        assert.deepEqual(await readFile(configPath), config);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
   it('strictly validates dispatcher metadata and treats it as a stale read-only transaction precondition', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-notify-metadata-'));
     try {
@@ -2115,6 +2853,138 @@ describe('omx uninstall', () => {
       const migratedRun = runOmx(wd, ['uninstall'], { HOME: migratedHome });
       assert.equal(migratedRun.status, 0, migratedRun.stderr || migratedRun.stdout);
       assert.deepEqual(TOML.parse(await readFile(migratedPath, 'utf-8')), TOML.parse(await readFile(baselinePath, 'utf-8')));
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it('preserves a same-byte foreign replacement made immediately after an uninstall rename', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-immediate-post-rename-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const foreignPath = join(codexDir, '.foreign-config-same-byte');
+        const config = Buffer.from(buildOmxConfig(), 'utf-8');
+        let replacement: Buffer | undefined;
+        let replacedInode: number | undefined;
+        await mkdir(codexDir, { recursive: true });
+        await writeFile(configPath, config);
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionFailureInjector: async (stage) => {
+              if (stage !== 'after-rename') return;
+              replacement = readFileSync(configPath);
+              const ownedInode = lstatSync(configPath).ino;
+              await writeFile(foreignPath, replacement);
+              assert.notEqual(lstatSync(foreignPath).ino, ownedInode);
+              rmSync(configPath);
+              renameSync(foreignPath, configPath);
+              replacedInode = lstatSync(configPath).ino;
+            },
+          }),
+          /Uninstall artifact rollback failed.*recovery preflight/,
+        );
+        assert.ok(replacement);
+        assert.ok(replacedInode);
+        assert.deepEqual(await readFile(configPath), replacement);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it('preflights every staged uninstall recovery copy before rollback', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-rollback-recovery-preflight-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+        const stagedShimPath = join(dirname(shimPath), '.shim-preflight-recovery');
+        const config = Buffer.from(buildOmxConfig(), 'utf-8');
+        const hooks = Buffer.from(`${JSON.stringify(buildManagedCodexHooksConfig(packageRoot(), {
+          platform: 'win32',
+          codexHomeDir: codexDir,
+        }), null, 2)}\n`, 'utf-8');
+        await mkdir(codexDir, { recursive: true });
+        await mkdir(dirname(shimPath), { recursive: true });
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+        await writeFile(shimPath, buildManagedCodexNativeHookWindowsShimContent(packageRoot()));
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionPlatform: 'win32',
+            transactionTemporaryPath: (path, purpose) =>
+              path === shimPath && purpose === 'delete'
+                ? stagedShimPath
+                : join(dirname(path), `.${basename(path)}.${purpose}-preflight`),
+            transactionFailureInjector: async (stage) => {
+              if (stage !== 'after-config-commit') return;
+              await rm(stagedShimPath);
+              throw new Error('injected missing staged recovery copy');
+            },
+          }),
+          /Uninstall artifact rollback failed.*recovery preflight/,
+        );
+        assert.equal(existsSync(hooksPath), false);
+        assert.equal(existsSync(shimPath), false);
+        assert.notDeepEqual(await readFile(configPath), config);
+        assert.equal(existsSync(stagedShimPath), false);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it('stops later uninstall rollback restores when the first restored artifact drifts', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-rollback-restored-drift-'));
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+        const foreignConfigPath = join(codexDir, '.foreign-restored-config');
+        const config = Buffer.from(buildOmxConfig(), 'utf-8');
+        const hooks = Buffer.from(`${JSON.stringify(buildManagedCodexHooksConfig(packageRoot(), {
+          platform: 'win32',
+          codexHomeDir: codexDir,
+        }), null, 2)}\n`, 'utf-8');
+        await mkdir(codexDir, { recursive: true });
+        await mkdir(dirname(shimPath), { recursive: true });
+        await writeFile(configPath, config);
+        await writeFile(hooksPath, hooks);
+        await writeFile(shimPath, buildManagedCodexNativeHookWindowsShimContent(packageRoot()));
+        let rollbackRenameCount = 0;
+        let drifted = false;
+        await assert.rejects(
+          uninstall({
+            scope: 'project',
+            transactionPlatform: 'win32',
+            transactionFailureInjector: async (stage) => {
+              if (stage === 'after-config-commit') {
+                throw new Error('injected rollback start failure');
+              }
+              if (stage !== 'before-rollback-rename') return;
+              rollbackRenameCount += 1;
+              if (rollbackRenameCount !== 2) return;
+              const restoredInode = lstatSync(configPath).ino;
+              await writeFile(foreignConfigPath, config);
+              assert.notEqual(lstatSync(foreignConfigPath).ino, restoredInode);
+              rmSync(configPath);
+              renameSync(foreignConfigPath, configPath);
+              drifted = lstatSync(configPath).ino !== restoredInode;
+            },
+          }),
+          /Uninstall artifact rollback failed/,
+        );
+        assert.equal(rollbackRenameCount, 2);
+        assert.equal(drifted, true);
+        assert.deepEqual(await readFile(configPath), config);
+        assert.equal(existsSync(shimPath), false);
+        assert.equal(existsSync(hooksPath), false);
+      });
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -2631,6 +2631,28 @@ describe('omx uninstall', () => {
     }
   });
 
+  it('removes OMX-managed AGENTS sections while preserving project guidance', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-merged-agents-'));
+    try {
+      const home = join(wd, 'home');
+      await mkdir(home, { recursive: true });
+      await mkdir(join(wd, '.omx'), { recursive: true });
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+      const userGuidance = '# User project instructions\n\nPreserve this guidance.\n';
+      await writeFile(
+        join(wd, 'AGENTS.md'),
+        `${userGuidance}\n<!-- OMX:AGENTS:START -->\n<!-- omx:generated:agents-md -->\n# oh-my-codex - Intelligent Multi-Agent Orchestration\n<!-- OMX:AGENTS:END -->\n`,
+      );
+
+      const res = runOmx(wd, ['uninstall', '--keep-config'], { HOME: home });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.equal(await readFile(join(wd, 'AGENTS.md'), 'utf-8'), userGuidance);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('removes managed user-scope AGENTS.md from CODEX_HOME', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-'));
     try {
@@ -3012,7 +3034,7 @@ describe('omx uninstall', () => {
               renameSync(foreignPath, configPath);
             },
           }),
-          /replacement claim.*not the planned artifact/,
+          /(?:replacement claim.*not the planned artifact|planned artifact .* changed)/,
         );
         assert.ok(foreignInode);
         assert.equal(lstatSync(configPath).ino, foreignInode);

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -40,14 +40,13 @@ import {
 	buildManagedCodexNativeHookWindowsShimContent,
 	classifyManagedCodexNativeHookWindowsShimOwnership,
 	discoverCodexHookConfigPaths,
-	getManagedCodexHookCommandsForEvent,
+	isManagedCodexHookCommand,
 	parseManagedCodexNativeHookWindowsShimCommand,
 	planManagedCodexHooksRemoval,
 	resolveWindowsPowerShellPath,
 	type ManagedCodexHooksPlan,
 	validateCodexHooksConfigStrict,
 } from "../config/codex-hooks.js";
-
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { getDefaultBridge, isBridgeEnabled } from "../runtime/bridge.js";
 import {
@@ -348,18 +347,18 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 	}
 
 	// Check 4.25: Native hooks coverage
-	checks.push(
-		await checkNativeHooks(paths.hooksPath, paths.configPath, {
-			codexHomeDir: paths.codexHomeDir,
-			installMode: scopeResolution.installMode,
-		}),
-	);
+	const nativeHooksCheck = await checkNativeHooks(paths.hooksPath, paths.configPath, {
+		codexHomeDir: paths.codexHomeDir,
+		installMode: scopeResolution.installMode,
+	});
+	checks.push(nativeHooksCheck);
 	checks.push(await checkNativeHookDistSmoke());
 	if (options.verbose) {
 		const postCompactRuntimeCheck = await checkNativePostCompactHookRuntime(
 			paths.hooksPath,
 			cwd,
 			paths.codexHomeDir,
+			{ nativeHooksCheck },
 		);
 		if (postCompactRuntimeCheck) checks.push(postCompactRuntimeCheck);
 	}
@@ -1666,6 +1665,7 @@ function referencedWindowsNativeHookShimPaths(
 		groupIndex: number;
 		handlerIndex?: number;
 	}[],
+	codexHomeDir: string,
 ): string[] {
 	if (!isJsonRecord(root.hooks)) return [];
 
@@ -1693,7 +1693,10 @@ function referencedWindowsNativeHookShimPaths(
 				) continue;
 				const command = effectiveWindowsHookCommand(handler);
 				if (!command) continue;
-				const shimPath = parseManagedCodexNativeHookWindowsShimCommand(command);
+				const shimPath = parseManagedCodexNativeHookWindowsShimCommand(command, {
+					platform: "win32",
+					codexHomeDir,
+				});
 				if (shimPath) shimPaths.add(shimPath);
 			}
 		}
@@ -1704,12 +1707,14 @@ function referencedWindowsNativeHookShimPaths(
 async function checkWindowsNativeHookShims(
 	root: Record<string, unknown>,
 	diagnostics: Parameters<typeof referencedWindowsNativeHookShimPaths>[1],
+	codexHomeDir: string,
+	requireCurrent = false,
 ): Promise<Check | null> {
 	const expected = Buffer.from(
 		buildManagedCodexNativeHookWindowsShimContent(getPackageRoot()),
 		"utf-8",
 	);
-	for (const shimPath of referencedWindowsNativeHookShimPaths(root, diagnostics)) {
+	for (const shimPath of referencedWindowsNativeHookShimPaths(root, diagnostics, codexHomeDir)) {
 		let shimContent: Buffer;
 		try {
 			const shimStat = await lstat(shimPath);
@@ -1733,11 +1738,19 @@ async function checkWindowsNativeHookShims(
 					: `cannot read referenced Windows native hook shim at ${shimPath}; inspect it and manually reinstall the matching oh-my-codex version because doctor will not modify shims`,
 			};
 		}
-		if (classifyManagedCodexNativeHookWindowsShimOwnership(shimContent, expected) === "modified") {
+		const ownership = classifyManagedCodexNativeHookWindowsShimOwnership(shimContent, expected);
+		if (ownership === "modified") {
 			return {
 				name: "Native hooks",
 				status: "fail",
 				message: `referenced Windows native hook shim at ${shimPath} is not an exact current or complete historical generated shim; it may be modified, truncated, have extra content, or use ambiguous encoding. Manually reinstall the matching oh-my-codex version because doctor will not overwrite it`,
+			};
+		}
+		if (requireCurrent && ownership !== "current") {
+			return {
+				name: "Native hooks",
+				status: "warn",
+				message: `referenced Windows native hook shim at ${shimPath} is a complete historical generated shim, but verbose execution requires exact current shim bytes; run "omx setup" to migrate it before retrying`,
 			};
 		}
 	}
@@ -1959,6 +1972,20 @@ function combinePluginAndGlobalNativeHookChecks(plugin: Check, global: Check | n
 	};
 }
 
+function combineNativeHookIntegrityAndRemovalChecks(
+	integrityCheck: Check | null,
+	removalCheck: Check,
+): Check {
+	if (!integrityCheck) return removalCheck;
+	return {
+		name: "Native hooks",
+		status: integrityCheck.status === "fail" || removalCheck.status === "fail"
+			? "fail"
+			: "warn",
+		message: `${integrityCheck.message}; ${removalCheck.message}`,
+	};
+}
+
 async function checkExistingNativeHooks(
 	hooksPath: string,
 	context: NativeHookCheckContext,
@@ -1997,20 +2024,25 @@ async function checkExistingNativeHooks(
 			platform,
 			codexHomeDir: context.codexHomeDir,
 		});
+		const windowsShimCheck = platform === "win32"
+			? await checkWindowsNativeHookShims(
+				validation.root,
+				validation.diagnostics,
+				context.codexHomeDir,
+			)
+			: null;
 		if (!removalPlan.ok) {
 			const removalIsCoordinateOnly = removalPlan.error.code === "unsafe_managed_removal";
-			return {
+			const removalCheck: Check = {
 				name: "Native hooks",
 				status: removalIsCoordinateOnly ? "warn" : "fail",
 				message: removalIsCoordinateOnly
 					? `hooks.json has OMX entries that cannot be safely removed (${removalPlan.error.code}): ${trimNativeHookDetailTerminalPeriod(removalPlan.error.message)}; manual cleanup is required because doctor will not overwrite or remove it`
 					: `hooks.json has ambiguous or untrusted OMX ownership (${removalPlan.error.code}): ${trimNativeHookDetailTerminalPeriod(removalPlan.error.message)}; inspect the file manually because doctor will not overwrite or remove it`,
 			};
+			return combineNativeHookIntegrityAndRemovalChecks(windowsShimCheck, removalCheck);
 		}
-		if (platform === "win32") {
-			const windowsShimCheck = await checkWindowsNativeHookShims(validation.root, validation.diagnostics);
-			if (windowsShimCheck) return windowsShimCheck;
-		}
+		if (windowsShimCheck) return windowsShimCheck;
 		const legacyTrustStateEntries = Object.keys(removalPlan.legacyTrustState).length;
 		if (legacyTrustStateEntries > 0) {
 			return {
@@ -2249,50 +2281,150 @@ export function buildPostCompactSmokeSpawnInvocation(
 	};
 }
 
-async function checkNativePostCompactHookRuntime(
+interface NativePostCompactHookRuntimeOptions {
+	nativeHooksCheck?: Check;
+	platform?: NodeJS.Platform;
+	expectedCommand?: string;
+	runner?: typeof spawnSync;
+}
+
+function getManagedPostCompactHookCommands(
+	content: string,
+	platform: NodeJS.Platform,
+	codexHomeDir: string,
+): string[] | null {
+	const validation = validateCodexHooksConfigStrict(content, {
+		platform,
+		codexHomeDir,
+	});
+	if (!validation.ok) return null;
+	return validation.discoveredCommands
+		.filter((command) => command.eventName === "PostCompact")
+		.map((command) => command.command)
+		.filter((command) =>
+			isManagedCodexHookCommand(command) ||
+			(platform === "win32" && parseManagedCodexNativeHookWindowsShimCommand(command, {
+				platform,
+				codexHomeDir,
+			}) !== null),
+		);
+}
+
+function currentPostCompactCommandCheck(): Check {
+	return {
+		name: "Native PostCompact hook",
+		status: "warn",
+		message:
+			"effective PostCompact OMX command does not match this installation's managed hook command; doctor skipped execution for safety, and rerunning \"omx setup\" should refresh stale hooks.json entries",
+	};
+}
+
+function skippedPostCompactIntegrityCheck(integrityCheck: Check): Check {
+	return {
+		name: "Native PostCompact hook",
+		status: integrityCheck.status === "fail" ? "fail" : "warn",
+		message: `${integrityCheck.message}; doctor skipped execution because native hook integrity validation did not pass`,
+	};
+}
+
+export async function checkNativePostCompactHookRuntime(
 	hooksPath: string,
 	cwd: string,
 	codexHomeDir: string,
+	options: NativePostCompactHookRuntimeOptions = {},
 ): Promise<Check | null> {
 	if (!existsSync(hooksPath)) return null;
+	if (options.nativeHooksCheck && options.nativeHooksCheck.status !== "pass") return null;
 
-	let content: string;
+	const platform = options.platform ?? process.platform;
+	const expectedCommand = options.expectedCommand ?? buildManagedCodexNativeHookCommand(getPackageRoot(), {
+		codexHomeDir,
+		platform,
+	});
+	let content: string | null;
 	try {
-		content = await readFile(hooksPath, "utf-8");
+		content = decodeStrictUtf8(await readFile(hooksPath));
 	} catch {
 		return null;
 	}
+	if (content === null) return null;
 
-	const postCompactCommands = getManagedCodexHookCommandsForEvent(
-		content,
-		"PostCompact",
-	);
-	if (postCompactCommands === null || postCompactCommands.length === 0) {
-		return null;
-	}
-
-	const expectedCommand = buildManagedCodexNativeHookCommand(getPackageRoot(), {
-		codexHomeDir,
-	});
+	const postCompactCommands = getManagedPostCompactHookCommands(content, platform, codexHomeDir);
+	if (postCompactCommands === null || postCompactCommands.length === 0) return null;
 	const uniqueCommands = [...new Set(postCompactCommands)];
 	if (uniqueCommands.length !== 1 || uniqueCommands[0] !== expectedCommand) {
-		return {
-			name: "Native PostCompact hook",
-			status: "warn",
-			message:
-				"effective PostCompact OMX command does not match this installation's managed hook command; doctor skipped execution for safety, and rerunning \"omx setup\" should refresh stale hooks.json entries",
-		};
+		return currentPostCompactCommandCheck();
 	}
 
 	const smokeCwd = await mkdtemp(join(tmpdir(), "omx-doctor-postcompact-"));
 	try {
+		const revalidatedIntegrity = await checkExistingNativeHooks(hooksPath, {
+			codexHomeDir,
+			platform,
+		});
+		if (revalidatedIntegrity.status !== "pass") {
+			return skippedPostCompactIntegrityCheck(revalidatedIntegrity);
+		}
+
+		let revalidatedContent: string | null;
+		try {
+			revalidatedContent = decodeStrictUtf8(await readFile(hooksPath));
+		} catch {
+			return {
+				name: "Native PostCompact hook",
+				status: "warn",
+				message: "hooks.json changed during verbose validation; doctor skipped execution for safety",
+			};
+		}
+		if (revalidatedContent === null) {
+			return {
+				name: "Native PostCompact hook",
+				status: "warn",
+				message: "hooks.json changed during verbose validation; doctor skipped execution for safety",
+			};
+		}
+		const revalidatedCommands = getManagedPostCompactHookCommands(
+			revalidatedContent,
+			platform,
+			codexHomeDir,
+		);
+		if (
+			revalidatedCommands === null ||
+			revalidatedCommands.length === 0 ||
+			new Set(revalidatedCommands).size !== 1 ||
+			revalidatedCommands[0] !== expectedCommand
+		) {
+			return currentPostCompactCommandCheck();
+		}
+
+		if (platform === "win32") {
+			const validation = validateCodexHooksConfigStrict(revalidatedContent, {
+				platform,
+				codexHomeDir,
+			});
+			if (!validation.ok) {
+				return {
+					name: "Native PostCompact hook",
+					status: "warn",
+					message: "hooks.json changed during verbose validation; doctor skipped execution for safety",
+				};
+			}
+			const currentShimCheck = await checkWindowsNativeHookShims(
+				validation.root,
+				validation.diagnostics,
+				codexHomeDir,
+				true,
+			);
+			if (currentShimCheck) return skippedPostCompactIntegrityCheck(currentShimCheck);
+		}
+
 		const payload = JSON.stringify({
 			hook_event_name: "PostCompact",
 			cwd: smokeCwd,
 			session_id: "omx-doctor-postcompact-smoke",
 		});
-		const smokeInvocation = buildPostCompactSmokeSpawnInvocation(expectedCommand);
-		const result = spawnSync(smokeInvocation.command, smokeInvocation.args, {
+		const smokeInvocation = buildPostCompactSmokeSpawnInvocation(expectedCommand, { platform });
+		const result = (options.runner ?? spawnSync)(smokeInvocation.command, smokeInvocation.args, {
 			cwd,
 			encoding: "utf-8",
 			env: {
@@ -2303,7 +2435,6 @@ async function checkNativePostCompactHookRuntime(
 			shell: smokeInvocation.shell,
 			timeout: 5_000,
 		});
-
 		if (result.error) {
 			return {
 				name: "Native PostCompact hook",

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -37,12 +37,17 @@ import {
 import {
 	MANAGED_HOOK_EVENTS,
 	buildManagedCodexNativeHookCommand,
+	buildManagedCodexNativeHookWindowsShimContent,
+	classifyManagedCodexNativeHookWindowsShimOwnership,
 	discoverCodexHookConfigPaths,
-	resolveWindowsPowerShellPath,
 	getManagedCodexHookCommandsForEvent,
-	getMissingManagedCodexHookEvents,
-	hasCodexHooksJsonTopLevelState,
+	parseManagedCodexNativeHookWindowsShimCommand,
+	planManagedCodexHooksRemoval,
+	resolveWindowsPowerShellPath,
+	type ManagedCodexHooksPlan,
+	validateCodexHooksConfigStrict,
 } from "../config/codex-hooks.js";
+
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { getDefaultBridge, isBridgeEnabled } from "../runtime/bridge.js";
 import {
@@ -445,10 +450,11 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 	);
 
 	if (failCount > 0) {
-		console.log('\nRun "omx setup" to fix installation issues.');
+		console.log('\nReview failed checks above. Follow the check-specific recovery guidance; inspect invalid or ambiguous hook documents manually because doctor will not modify them.');
+
 	} else if (warnCount > 0) {
 		console.log(
-			'\nReview warnings above. Use "omx setup --force" only when a warning recommends full replacement; for AGENTS.md preservation prefer "omx setup --merge-agents".',
+			'\nReview warnings above. Follow the check-specific recovery guidance; for AGENTS.md preservation prefer "omx setup --merge-agents".',
 		);
 	} else {
 		console.log("\nAll checks passed! oh-my-codex is ready.");
@@ -1576,10 +1582,12 @@ export async function checkExternalCodexProcessGuards(
 	};
 }
 
-interface NativeHookCheckContext {
+export interface NativeHookCheckContext {
 	codexHomeDir: string;
 	installMode?: SetupInstallMode;
+	platform?: NodeJS.Platform;
 }
+
 
 function isEnabledTomlValue(value: unknown): boolean {
 	return value === true || (typeof value === "string" && ["1", "true", "yes", "on"].includes(value.trim().toLowerCase()));
@@ -1599,6 +1607,164 @@ function configEnablesPluginScopedHooks(configContent: string): boolean {
 	} catch {
 		return /^\s*plugin_hooks\s*=\s*(?:true|1|"true"|"1"|"yes"|"on")\s*$/m.test(configContent);
 	}
+}
+
+function trimNativeHookDetailTerminalPeriod(detail: string): string {
+	return detail.endsWith(".") ? detail.slice(0, -1) : detail;
+}
+
+function formatNativeHookDiagnostics(
+	diagnostics: readonly {
+		eventName: string;
+		groupIndex: number;
+		handlerIndex?: number;
+		message: string;
+	}[],
+): string {
+	return diagnostics
+		.map((diagnostic) => {
+			const coordinate = `${diagnostic.eventName}[${diagnostic.groupIndex}]${
+				diagnostic.handlerIndex === undefined
+					? ""
+					: `.${diagnostic.handlerIndex}`
+			}`;
+			return `${coordinate}: ${trimNativeHookDetailTerminalPeriod(diagnostic.message)}`;
+		})
+		.join("; ");
+}
+
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const WINDOWS_SHIM_SCAN_EVENTS = [
+	"PreToolUse",
+	"PermissionRequest",
+	"PostToolUse",
+	"PreCompact",
+	"PostCompact",
+	"SessionStart",
+	"UserPromptSubmit",
+	"SubagentStart",
+	"SubagentStop",
+	"Stop",
+] as const;
+
+function effectiveWindowsHookCommand(handler: Record<string, unknown>): string | null {
+	const commandWindows = handler.commandWindows;
+	if (typeof commandWindows === "string") return commandWindows;
+	const commandWindowsSnakeCase = handler.command_windows;
+	if (typeof commandWindowsSnakeCase === "string") return commandWindowsSnakeCase;
+	return typeof handler.command === "string" ? handler.command : null;
+}
+
+function referencedWindowsNativeHookShimPaths(
+	root: Record<string, unknown>,
+	diagnostics: readonly {
+		code: string;
+		eventName: string;
+		groupIndex: number;
+		handlerIndex?: number;
+	}[],
+): string[] {
+	if (!isJsonRecord(root.hooks)) return [];
+
+	const skippedGroups = new Set(
+		diagnostics
+			.filter((diagnostic) => diagnostic.code === "invalid_matcher")
+			.map((diagnostic) => `${diagnostic.eventName}:${diagnostic.groupIndex}`),
+	);
+	const skippedHandlers = new Set(
+		diagnostics
+			.filter((diagnostic) => diagnostic.code === "async_command" || diagnostic.code === "empty_command")
+			.map((diagnostic) => `${diagnostic.eventName}:${diagnostic.groupIndex}:${diagnostic.handlerIndex}`),
+	);
+	const shimPaths = new Set<string>();
+	for (const eventName of WINDOWS_SHIM_SCAN_EVENTS) {
+		const eventGroups = root.hooks[eventName];
+		if (!Array.isArray(eventGroups)) continue;
+		for (const [groupIndex, group] of eventGroups.entries()) {
+			if (skippedGroups.has(`${eventName}:${groupIndex}`) || !isJsonRecord(group) || !Array.isArray(group.hooks)) continue;
+			for (const [handlerIndex, handler] of group.hooks.entries()) {
+				if (
+					skippedHandlers.has(`${eventName}:${groupIndex}:${handlerIndex}`) ||
+					!isJsonRecord(handler) ||
+					handler.type !== "command"
+				) continue;
+				const command = effectiveWindowsHookCommand(handler);
+				if (!command) continue;
+				const shimPath = parseManagedCodexNativeHookWindowsShimCommand(command);
+				if (shimPath) shimPaths.add(shimPath);
+			}
+		}
+	}
+	return [...shimPaths];
+}
+
+async function checkWindowsNativeHookShims(
+	root: Record<string, unknown>,
+	diagnostics: Parameters<typeof referencedWindowsNativeHookShimPaths>[1],
+): Promise<Check | null> {
+	const expected = Buffer.from(
+		buildManagedCodexNativeHookWindowsShimContent(getPackageRoot()),
+		"utf-8",
+	);
+	for (const shimPath of referencedWindowsNativeHookShimPaths(root, diagnostics)) {
+		let shimContent: Buffer;
+		try {
+			const shimStat = await lstat(shimPath);
+			if (shimStat.isSymbolicLink() || !shimStat.isFile()) {
+				return {
+					name: "Native hooks",
+					status: "fail",
+					message: `referenced Windows native hook shim at ${shimPath} is not a regular file; doctor will not follow or modify it`,
+				};
+			}
+			shimContent = await readFile(shimPath);
+		} catch (error) {
+			const code = typeof error === "object" && error !== null && "code" in error
+				? String(error.code)
+				: undefined;
+			return {
+				name: "Native hooks",
+				status: "fail",
+				message: code === "ENOENT"
+					? `referenced Windows native hook shim is missing at ${shimPath}; manually reinstall the matching oh-my-codex version because doctor will not create or modify shims`
+					: `cannot read referenced Windows native hook shim at ${shimPath}; inspect it and manually reinstall the matching oh-my-codex version because doctor will not modify shims`,
+			};
+		}
+		if (classifyManagedCodexNativeHookWindowsShimOwnership(shimContent, expected) === "modified") {
+			return {
+				name: "Native hooks",
+				status: "fail",
+				message: `referenced Windows native hook shim at ${shimPath} is not an exact current or complete historical generated shim; it may be modified, truncated, have extra content, or use ambiguous encoding. Manually reinstall the matching oh-my-codex version because doctor will not overwrite it`,
+			};
+		}
+	}
+	return null;
+}
+
+const MANAGED_HOOK_TRUST_KEY_LABELS: Record<
+	(typeof MANAGED_HOOK_EVENTS)[number],
+	string
+> = {
+	SessionStart: "session_start",
+	PreToolUse: "pre_tool_use",
+	PostToolUse: "post_tool_use",
+	UserPromptSubmit: "user_prompt_submit",
+	PreCompact: "pre_compact",
+	PostCompact: "post_compact",
+	Stop: "stop",
+};
+
+function getMissingManagedHookEventsFromPlan(
+	plan: Pick<ManagedCodexHooksPlan, "priorTrustState">,
+): (typeof MANAGED_HOOK_EVENTS)[number][] {
+	return MANAGED_HOOK_EVENTS.filter((eventName) => {
+		const label = MANAGED_HOOK_TRUST_KEY_LABELS[eventName];
+		const keyPattern = new RegExp(`:${label}:\\d+:\\d+$`);
+		return !Object.keys(plan.priorTrustState).some((key) => keyPattern.test(key));
+	});
 }
 
 function pluginHooksJsonHasNativeCoverage(content: string): boolean | null {
@@ -1631,7 +1797,7 @@ async function checkPluginScopedNativeHooks(
 	setupHooksPath: string,
 ): Promise<Check> {
 	const setupHooksPathDescription = existsSync(setupHooksPath)
-		? `existing hooks.json at ${setupHooksPath} is treated as user-owned because plugin-scoped hooks are enabled`
+		? `existing hooks.json at ${setupHooksPath} is retained read-only and validated separately because plugin-scoped hooks are enabled`
 		: `setup-owned hooks.json is intentionally absent at ${setupHooksPath}`;
 	const packagedMarketplace = await resolvePackagedOmxMarketplace(getPackageRoot());
 	if (!packagedMarketplace) {
@@ -1657,7 +1823,7 @@ async function checkPluginScopedNativeHooks(
 			name: "Native hooks",
 			status: "warn",
 			message:
-				`plugin-scoped hooks are enabled, but the expected Codex plugin cache manifest is missing at ${join(expectedCacheDir, ".codex-plugin", "plugin.json")}; ${setupHooksPathDescription}; run "omx setup --plugin --force" to refresh the plugin cache`,
+				`plugin-scoped hooks are enabled, but the expected Codex plugin cache manifest is missing at ${join(expectedCacheDir, ".codex-plugin", "plugin.json")}; ${setupHooksPathDescription}; run "omx setup --plugin" to refresh the plugin cache`,
 		};
 	}
 
@@ -1666,7 +1832,7 @@ async function checkPluginScopedNativeHooks(
 			name: "Native hooks",
 			status: "warn",
 			message:
-				`plugin-scoped hooks are enabled, but the Codex plugin cache manifest points hooks to ${String(state.hooksPointer)} instead of ./hooks/hooks.json at ${expectedHooksPath}; run "omx setup --plugin --force" to refresh the plugin cache`,
+				`plugin-scoped hooks are enabled, but the Codex plugin cache manifest points hooks to ${String(state.hooksPointer)} instead of ./hooks/hooks.json at ${expectedHooksPath}; run "omx setup --plugin" to refresh the plugin cache`,
 		};
 	}
 
@@ -1676,7 +1842,7 @@ async function checkPluginScopedNativeHooks(
 				name: "Native hooks",
 				status: "warn",
 				message:
-					`plugin-scoped hooks are enabled, but expected plugin hook file is missing at ${expectedPath}; ${setupHooksPathDescription}; run "omx setup --plugin --force" to refresh the plugin cache`,
+					`plugin-scoped hooks are enabled, but expected plugin hook file is missing at ${expectedPath}; ${setupHooksPathDescription}; run "omx setup --plugin" to refresh the plugin cache`,
 			};
 		}
 	}
@@ -1686,7 +1852,7 @@ async function checkPluginScopedNativeHooks(
 			name: "Native hooks",
 			status: "warn",
 			message:
-				`plugin-scoped hooks are enabled, but cached plugin hook files or pinned hook launcher in ${expectedCacheDir} do not match the packaged plugin; ${setupHooksPathDescription}; run "omx setup --plugin --force" to refresh the plugin cache`,
+				`plugin-scoped hooks are enabled, but cached plugin hook files or pinned hook launcher in ${expectedCacheDir} do not match the packaged plugin; ${setupHooksPathDescription}; run "omx setup --plugin" to refresh the plugin cache`,
 		};
 	}
 
@@ -1714,7 +1880,7 @@ async function checkPluginScopedNativeHooks(
 			name: "Native hooks",
 			status: "warn",
 			message:
-				`plugin-scoped hooks.json at ${expectedHooksPath} is missing OMX native coverage for one or more events; run "omx setup --plugin --force" to refresh the plugin cache`,
+				`plugin-scoped hooks.json at ${expectedHooksPath} is missing OMX native coverage for one or more events; run "omx setup --plugin" to refresh the plugin cache`,
 		};
 	}
 
@@ -1770,7 +1936,134 @@ async function checkPluginScopedNativeHooks(
 	};
 }
 
-async function checkNativeHooks(
+function decodeStrictUtf8(bytes: Buffer): string | null {
+	try {
+		const content = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(bytes);
+		return Buffer.from(content, "utf-8").equals(bytes) ? content : null;
+	} catch {
+		return null;
+	}
+}
+
+function combinePluginAndGlobalNativeHookChecks(plugin: Check, global: Check | null): Check {
+	if (!global) return plugin;
+	const status = plugin.status === "fail" || global.status === "fail"
+		? "fail"
+		: plugin.status === "warn" || global.status === "warn"
+			? "warn"
+			: "pass";
+	return {
+		name: "Native hooks",
+		status,
+		message: `${plugin.message}; existing global hooks.json: ${global.message}`,
+	};
+}
+
+async function checkExistingNativeHooks(
+	hooksPath: string,
+	context: NativeHookCheckContext,
+): Promise<Check> {
+	const platform = context.platform ?? process.platform;
+	try {
+		const hooksStat = await lstat(hooksPath);
+		if (hooksStat.isSymbolicLink() || !hooksStat.isFile()) {
+			return {
+				name: "Native hooks",
+				status: "fail",
+				message: `hooks.json at ${hooksPath} is not a regular file; doctor will not follow or modify it`,
+			};
+		}
+		const content = decodeStrictUtf8(await readFile(hooksPath));
+		if (content === null) {
+			return {
+				name: "Native hooks",
+				status: "fail",
+				message: `hooks.json at ${hooksPath} is not valid UTF-8; inspect the file manually because doctor will not modify it`,
+			};
+		}
+		const validation = validateCodexHooksConfigStrict(content, {
+			platform,
+			codexHomeDir: context.codexHomeDir,
+		});
+		if (!validation.ok) {
+			return {
+				name: "Native hooks",
+				status: "fail",
+				message: `hooks.json failed strict load validation (${validation.error.code}): ${trimNativeHookDetailTerminalPeriod(validation.error.message)}; inspect the file manually because doctor will not modify it`,
+			};
+		}
+
+		const removalPlan = planManagedCodexHooksRemoval(content, hooksPath, {
+			platform,
+			codexHomeDir: context.codexHomeDir,
+		});
+		if (!removalPlan.ok) {
+			const removalIsCoordinateOnly = removalPlan.error.code === "unsafe_managed_removal";
+			return {
+				name: "Native hooks",
+				status: removalIsCoordinateOnly ? "warn" : "fail",
+				message: removalIsCoordinateOnly
+					? `hooks.json has OMX entries that cannot be safely removed (${removalPlan.error.code}): ${trimNativeHookDetailTerminalPeriod(removalPlan.error.message)}; manual cleanup is required because doctor will not overwrite or remove it`
+					: `hooks.json has ambiguous or untrusted OMX ownership (${removalPlan.error.code}): ${trimNativeHookDetailTerminalPeriod(removalPlan.error.message)}; inspect the file manually because doctor will not overwrite or remove it`,
+			};
+		}
+		if (platform === "win32") {
+			const windowsShimCheck = await checkWindowsNativeHookShims(validation.root, validation.diagnostics);
+			if (windowsShimCheck) return windowsShimCheck;
+		}
+		const legacyTrustStateEntries = Object.keys(removalPlan.legacyTrustState).length;
+		if (legacyTrustStateEntries > 0) {
+			return {
+				name: "Native hooks",
+				status: "warn",
+				message: `hooks.json contains ${legacyTrustStateEntries} exact historical OMX hook trust-state ${legacyTrustStateEntries === 1 ? "entry that requires" : "entries that require"} migration; run "omx setup" to migrate ${legacyTrustStateEntries === 1 ? "it" : "them"} after reviewing the configuration`,
+			};
+		}
+
+		if (validation.diagnostics.length > 0) {
+			return {
+				name: "Native hooks",
+				status: "warn",
+				message: `hooks.json discovery warnings: ${formatNativeHookDiagnostics(validation.diagnostics)}; Codex may ignore the listed entries, and doctor will not modify them`,
+			};
+		}
+
+		const missingEvents = getMissingManagedHookEventsFromPlan(removalPlan);
+		if (
+			removalPlan.hasForeignHooks &&
+			removalPlan.removedCount === 0 &&
+			missingEvents.length === MANAGED_HOOK_EVENTS.length
+		) {
+			return {
+				name: "Native hooks",
+				status: "pass",
+				message:
+					"hooks.json contains valid foreign hook entries and no OMX-managed wrappers; doctor will preserve the user-owned configuration",
+			};
+		}
+		if (missingEvents.length > 0) {
+			return {
+				name: "Native hooks",
+				status: "warn",
+				message: `hooks.json is missing OMX-managed coverage for ${missingEvents.join(", ")}; run "omx setup" to restore native hooks${removalPlan.hasForeignHooks ? "; valid foreign hooks will be preserved" : ""}`,
+			};
+		}
+
+		return {
+			name: "Native hooks",
+			status: "pass",
+			message: `hooks.json includes OMX-managed coverage for all native hook events${removalPlan.hasForeignHooks ? "; valid foreign hooks will be preserved" : ""}`,
+		};
+	} catch {
+		return {
+			name: "Native hooks",
+			status: "fail",
+			message: "cannot read hooks.json",
+		};
+	}
+}
+
+export async function checkNativeHooks(
 	hooksPath: string,
 	configPath: string,
 	context: NativeHookCheckContext,
@@ -1779,7 +2072,13 @@ async function checkNativeHooks(
 		try {
 			const configContent = await readFile(configPath, "utf-8");
 			if (configEnablesPluginScopedHooks(configContent)) {
-				return checkPluginScopedNativeHooks(context.codexHomeDir, hooksPath);
+				const globalCheck = existsSync(hooksPath)
+					? await checkExistingNativeHooks(hooksPath, context)
+					: null;
+				return combinePluginAndGlobalNativeHookChecks(
+					await checkPluginScopedNativeHooks(context.codexHomeDir, hooksPath),
+					globalCheck,
+				);
 			}
 		} catch {
 			// Fall through to the hooks.json checks; the dedicated config check will
@@ -1791,15 +2090,13 @@ async function checkNativeHooks(
 		if (existsSync(configPath)) {
 			try {
 				const configContent = await readFile(configPath, "utf-8");
-				if (context.installMode === "plugin") {
-					if (configHasOmxEntries(configContent)) {
-						return {
-							name: "Native hooks",
-							status: "warn",
-							message:
-								`plugin mode is using legacy native hook fallback, but expected setup-owned hooks.json is missing at ${hooksPath}; run "omx setup --plugin --force" to restore the fallback hook file, or upgrade Codex to plugin_hooks support so setup can use plugin-scoped hooks`,
-						};
-					}
+				if (context.installMode === "plugin" && configHasOmxEntries(configContent)) {
+					return {
+						name: "Native hooks",
+						status: "warn",
+						message:
+							`plugin mode is using legacy native hook fallback, but expected setup-owned hooks.json is missing at ${hooksPath}; run "omx setup --plugin" to restore the fallback hook file, or upgrade Codex to plugin_hooks support so setup can use plugin-scoped hooks`,
+					};
 				}
 
 				if (configHasOmxEntries(configContent)) {
@@ -1807,11 +2104,11 @@ async function checkNativeHooks(
 						name: "Native hooks",
 						status: "warn",
 						message:
-							`expected setup-owned hooks.json is missing at ${hooksPath} even though config.toml has OMX entries; run "omx setup --force" to restore native hook coverage`,
+							`expected setup-owned hooks.json is missing at ${hooksPath} even though config.toml has OMX entries; run "omx setup" to restore native hook coverage`,
 					};
 				}
 			} catch {
-				// fall through to the neutral first-setup path when config cannot be read here;
+				// Fall through to the neutral first-setup path when config cannot be read here;
 				// the dedicated config check will report read failures separately.
 			}
 		}
@@ -1823,48 +2120,7 @@ async function checkNativeHooks(
 		};
 	}
 
-	try {
-		const content = await readFile(hooksPath, "utf-8");
-		const missingEvents = getMissingManagedCodexHookEvents(content);
-		if (missingEvents === null) {
-			return {
-				name: "Native hooks",
-				status: "fail",
-				message:
-					'invalid hooks.json; Codex may skip OMX hook coverage until "omx setup --force" repairs it',
-			};
-		}
-		const hasTopLevelState = hasCodexHooksJsonTopLevelState(content);
-		if (hasTopLevelState === true) {
-			return {
-				name: "Native hooks",
-				status: "fail",
-				message:
-					'top-level state in hooks.json is incompatible with Codex 0.140 (unknown field state, expected hooks); run "omx setup --force" to migrate trust state to config.toml and repair hooks.json',
-			};
-		}
-
-		if (missingEvents.length > 0) {
-			return {
-				name: "Native hooks",
-				status: "warn",
-				message: `hooks.json is missing OMX-managed coverage for ${missingEvents.join(", ")}; run "omx setup --force" to restore native hooks`,
-			};
-		}
-
-		return {
-			name: "Native hooks",
-			status: "pass",
-			message:
-				"hooks.json includes OMX-managed coverage for all native hook events",
-		};
-	} catch {
-		return {
-			name: "Native hooks",
-			status: "fail",
-			message: "cannot read hooks.json",
-		};
-	}
+	return checkExistingNativeHooks(hooksPath, context);
 }
 
 export async function checkNativeHookDistSmoke(
@@ -1874,22 +2130,12 @@ export async function checkNativeHookDistSmoke(
 	const nodePath = options.nodePath ?? process.execPath;
 	const runner = options.runner ?? spawnSync;
 	const scriptPath = join(packageRoot, "dist", "scripts", "codex-native-hook.js");
-	const packageJsonPath = join(packageRoot, "package.json");
-	let packageVersion = "current";
-	try {
-		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as { version?: unknown };
-		if (typeof packageJson.version === "string" && packageJson.version.trim()) {
-			packageVersion = packageJson.version.trim();
-		}
-	} catch {
-		// Keep the generic recovery copy when package metadata is not readable.
-	}
 
 	if (!existsSync(scriptPath)) {
 		return {
 			name: "Native hook dist smoke",
 			status: "fail",
-			message: `installed native hook script is missing at ${scriptPath}; reinstall oh-my-codex and run "omx setup --force"`,
+			message: `installed native hook script is missing at ${scriptPath}; reinstall oh-my-codex and run "omx setup"`,
 		};
 	}
 
@@ -1921,7 +2167,7 @@ export async function checkNativeHookDistSmoke(
 			return {
 				name: "Native hook dist smoke",
 				status: "fail",
-				message: `installed native hook dist smoke failed to run (${result.error.message}); reinstall oh-my-codex and run "omx setup --force"`,
+				message: `installed native hook dist smoke failed to run (${result.error.message}); reinstall oh-my-codex and run "omx setup"`,
 			};
 		}
 		if (result.status !== 0) {
@@ -1931,7 +2177,7 @@ export async function checkNativeHookDistSmoke(
 			return {
 				name: "Native hook dist smoke",
 				status: "fail",
-				message: `installed native hook dist failed a minimal UserPromptSubmit smoke (${detail}); reinstall with "npm install -g oh-my-codex@${packageVersion} --force --min-release-age=0 --before=" and then run "omx setup --force"`,
+				message: `installed native hook dist failed a minimal UserPromptSubmit smoke (${detail}); reinstall the matching oh-my-codex version and then run "omx setup"`,
 			};
 		}
 
@@ -1956,13 +2202,13 @@ export function classifyPostCompactHookStdout(stdout: string): Check | null {
 			name: "Native PostCompact hook",
 			status: "fail",
 			message:
-				"PostCompact hook emitted JSON stdout, but OMX PostCompact must emit no stdout until Codex defines a supported PostCompact output contract; run \"omx setup --force\" after upgrading",
+				"PostCompact hook emitted JSON stdout, but OMX PostCompact must emit no stdout until Codex defines a supported PostCompact output contract; rerun \"omx setup\" after upgrading",
 		};
 	} catch (error) {
 		return {
 			name: "Native PostCompact hook",
 			status: "fail",
-			message: `PostCompact hook emitted invalid JSON stdout (${error instanceof Error ? error.message : String(error)}); run "omx setup --force" after upgrading`,
+			message: `PostCompact hook emitted invalid JSON stdout (${error instanceof Error ? error.message : String(error)}); rerun "omx setup" after upgrading`,
 		};
 	}
 }
@@ -2034,7 +2280,7 @@ async function checkNativePostCompactHookRuntime(
 			name: "Native PostCompact hook",
 			status: "warn",
 			message:
-				"effective PostCompact OMX command does not match this installation's managed hook command; doctor skipped execution for safety, and \"omx setup --force\" should refresh stale hooks.json entries",
+				"effective PostCompact OMX command does not match this installation's managed hook command; doctor skipped execution for safety, and rerunning \"omx setup\" should refresh stale hooks.json entries",
 		};
 	}
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2,6 +2,7 @@
  * omx doctor - Validate oh-my-codex installation
  */
 
+import { recoverNativeHookClaimJournal } from "./native-hook-claim-journal.js";
 import { constants, existsSync, readFileSync, type Stats } from "fs";
 import { access, chown, lstat, mkdtemp, readdir, readFile, rmdir, rm } from "fs/promises";
 import { spawnSync } from "child_process";
@@ -265,6 +266,7 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 	const cwd = process.cwd();
 	const scopeResolution = await resolveDoctorScope(cwd);
 	const paths = resolveDoctorPaths(cwd, scopeResolution.scope);
+	await recoverNativeHookClaimJournal(paths.codexHomeDir);
 	const scopeSourceMessage =
 		scopeResolution.source === "persisted"
 			? " (from .omx/setup-scope.json)"
@@ -2509,7 +2511,10 @@ export async function checkNativePostCompactHookRuntime(
 			"temporary PostCompact smoke directory could not be validated; doctor preserved it for manual recovery and skipped execution for safety",
 		);
 	}
+	let primaryResult: Check | null = null;
+	let primaryError: Error | null = null;
 	try {
+		primaryResult = await (async (): Promise<Check> => {
 		const revalidatedIntegrity = await checkExistingNativeHooks(hooksPath, {
 			codexHomeDir,
 			platform,
@@ -2646,10 +2651,22 @@ export async function checkNativePostCompactHookRuntime(
 			message:
 				"verbose smoke validation confirmed the effective PostCompact hook exits successfully with no stdout",
 		};
+		})();
+	} catch (error) {
+		primaryError = error instanceof Error ? error : new Error(String(error));
+		throw primaryError;
 	} finally {
 		const cleanupCheck = await cleanupSmokeDirectoryIfUnchanged(smokeCwd, smokeDirectory);
-		if (cleanupCheck) return cleanupCheck;
+		if (cleanupCheck) {
+			if (primaryResult) {
+				if (primaryResult.status === "pass") primaryResult.status = cleanupCheck.status;
+				primaryResult.message = `${primaryResult.message}; ${cleanupCheck.message}`;
+			} else if (primaryError) {
+				primaryError.message = `${primaryError.message}; ${cleanupCheck.message}`;
+			}
+		}
 	}
+	return primaryResult;
 }
 
 async function checkNativeHookRuntimeMirrors(

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2,10 +2,10 @@
  * omx doctor - Validate oh-my-codex installation
  */
 
-import { constants, existsSync, readFileSync } from "fs";
-import { access, chown, lstat, mkdtemp, readdir, readFile, rm } from "fs/promises";
+import { constants, existsSync, readFileSync, type Stats } from "fs";
+import { access, chown, lstat, mkdtemp, readdir, readFile, rmdir, rm } from "fs/promises";
 import { spawnSync } from "child_process";
-import { basename, join, relative } from "path";
+import { basename, dirname, join, relative } from "path";
 import { tmpdir } from "os";
 import {
 	codexHome,
@@ -1704,6 +1704,41 @@ function referencedWindowsNativeHookShimPaths(
 	return [...shimPaths];
 }
 
+async function checkWindowsNativeHookShimParentTopology(
+	shimPath: string,
+	codexHomeDir: string,
+): Promise<Check | null> {
+	let ancestorPath = dirname(shimPath);
+	for (;;) {
+		try {
+			const ancestorStat = await lstat(ancestorPath);
+			if (ancestorStat.isSymbolicLink() || !ancestorStat.isDirectory()) {
+				return {
+					name: "Native hooks",
+					status: "fail",
+					message: `referenced Windows native hook shim at ${shimPath} has an unsafe parent topology at ${ancestorPath}; doctor will not follow or modify it`,
+				};
+			}
+		} catch {
+			return {
+				name: "Native hooks",
+				status: "fail",
+				message: `referenced Windows native hook shim at ${shimPath} has a parent topology that cannot be safely validated; doctor will not follow or modify it`,
+			};
+		}
+		if (ancestorPath === codexHomeDir) return null;
+		const parentPath = dirname(ancestorPath);
+		if (parentPath === ancestorPath) {
+			return {
+				name: "Native hooks",
+				status: "fail",
+				message: `referenced Windows native hook shim at ${shimPath} is outside the controlled Codex home topology; doctor will not follow or modify it`,
+			};
+		}
+		ancestorPath = parentPath;
+	}
+}
+
 async function checkWindowsNativeHookShims(
 	root: Record<string, unknown>,
 	diagnostics: Parameters<typeof referencedWindowsNativeHookShimPaths>[1],
@@ -1725,7 +1760,19 @@ async function checkWindowsNativeHookShims(
 					message: `referenced Windows native hook shim at ${shimPath} is not a regular file; doctor will not follow or modify it`,
 				};
 			}
+			if (shimStat.nlink !== 1) {
+				return {
+					name: "Native hooks",
+					status: "fail",
+					message: `referenced Windows native hook shim at ${shimPath} is hard-linked; doctor will not execute or modify it`,
+				};
+			}
 			shimContent = await readFile(shimPath);
+			const topologyCheck = await checkWindowsNativeHookShimParentTopology(
+				shimPath,
+				codexHomeDir,
+			);
+			if (topologyCheck) return topologyCheck;
 		} catch (error) {
 			const code = typeof error === "object" && error !== null && "code" in error
 				? String(error.code)
@@ -2245,7 +2292,6 @@ export function classifyPostCompactHookStdout(stdout: string): Check | null {
 	}
 }
 
-
 interface PostCompactSmokeSpawnInvocation {
 	command: string;
 	args: string[];
@@ -2281,11 +2327,111 @@ export function buildPostCompactSmokeSpawnInvocation(
 	};
 }
 
+function buildInMemoryWindowsShimSmokeInvocation(
+	expectedShimContent: Buffer,
+	options: { env?: NodeJS.ProcessEnv } = {},
+): PostCompactSmokeSpawnInvocation | null {
+	const shimSource = decodeStrictUtf8(expectedShimContent);
+	if (shimSource === null) return null;
+
+	const encodedShimBytes = expectedShimContent.toString("base64");
+	const command = [
+		"$ErrorActionPreference = 'Stop'",
+		`$omxShimSource = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('${encodedShimBytes}'))`,
+		"if ($omxShimSource.Length -gt 0 -and [int][char]$omxShimSource[0] -eq 0xFEFF) { $omxShimSource = $omxShimSource.Substring(1) }",
+		"& ([ScriptBlock]::Create($omxShimSource))",
+		"exit $LASTEXITCODE",
+	].join("; ");
+	return {
+		command: resolveWindowsPowerShellPath(options.env),
+		args: [
+			"-NoProfile",
+			"-ExecutionPolicy",
+			"Bypass",
+			"-EncodedCommand",
+			Buffer.from(command, "utf16le").toString("base64"),
+		],
+		shell: false,
+	};
+}
+
+interface SmokeDirectoryIdentity {
+	dev: number;
+	ino: number;
+}
+
+function smokeDirectoryIdentity(stat: Stats): SmokeDirectoryIdentity | null {
+	if (
+		!stat.isDirectory() ||
+		stat.isSymbolicLink() ||
+		(process.platform !== "win32" && (stat.mode & 0o077) !== 0)
+	) return null;
+	return { dev: stat.dev, ino: stat.ino };
+}
+
+async function readSmokeDirectoryIdentity(
+	smokeCwd: string,
+): Promise<SmokeDirectoryIdentity | null> {
+	try {
+		return smokeDirectoryIdentity(await lstat(smokeCwd));
+	} catch {
+		return null;
+	}
+}
+
+function sameSmokeDirectoryIdentity(
+	expected: SmokeDirectoryIdentity,
+	actual: SmokeDirectoryIdentity | null,
+): boolean {
+	return actual !== null && actual.dev === expected.dev && actual.ino === expected.ino;
+}
+
+function smokeDirectorySafetyCheck(message: string): Check {
+	return {
+		name: "Native PostCompact hook",
+		status: "warn",
+		message,
+	};
+}
+
+async function cleanupSmokeDirectoryIfUnchanged(
+	smokeCwd: string,
+	identity: SmokeDirectoryIdentity,
+): Promise<Check | null> {
+	if (!sameSmokeDirectoryIdentity(identity, await readSmokeDirectoryIdentity(smokeCwd))) {
+		return smokeDirectorySafetyCheck(
+			"temporary PostCompact smoke directory changed during validation; doctor preserved it for manual recovery and skipped cleanup for safety",
+		);
+	}
+	try {
+		// Only remove the empty, identity-checked directory. Never recursively remove
+		// a directory that another process could have replaced or populated.
+		await rmdir(smokeCwd);
+		return null;
+	} catch {
+		return smokeDirectorySafetyCheck(
+			"temporary PostCompact smoke directory could not be removed without recursive deletion; doctor preserved it for manual recovery",
+		);
+	}
+}
+
+function inMemoryWindowsShimSmokeCheck(): Check {
+	return {
+		name: "Native PostCompact hook",
+		status: "warn",
+		message: "doctor could not build an in-memory Windows native hook smoke command from exact validated shim bytes; doctor skipped execution for safety",
+	};
+}
+
 interface NativePostCompactHookRuntimeOptions {
 	nativeHooksCheck?: Check;
 	platform?: NodeJS.Platform;
 	expectedCommand?: string;
 	runner?: typeof spawnSync;
+	beforeWindowsShimSmoke?: (paths: {
+		canonicalShimPath: string;
+		smokeCwd: string;
+	}) => void | Promise<void>;
 }
 
 function getManagedPostCompactHookCommands(
@@ -2357,6 +2503,12 @@ export async function checkNativePostCompactHookRuntime(
 	}
 
 	const smokeCwd = await mkdtemp(join(tmpdir(), "omx-doctor-postcompact-"));
+	const smokeDirectory = await readSmokeDirectoryIdentity(smokeCwd);
+	if (!smokeDirectory) {
+		return smokeDirectorySafetyCheck(
+			"temporary PostCompact smoke directory could not be validated; doctor preserved it for manual recovery and skipped execution for safety",
+		);
+	}
 	try {
 		const revalidatedIntegrity = await checkExistingNativeHooks(hooksPath, {
 			codexHomeDir,
@@ -2418,18 +2570,52 @@ export async function checkNativePostCompactHookRuntime(
 			if (currentShimCheck) return skippedPostCompactIntegrityCheck(currentShimCheck);
 		}
 
+		let smokeInvocation: PostCompactSmokeSpawnInvocation;
+		if (platform === "win32") {
+			const canonicalShimPath = parseManagedCodexNativeHookWindowsShimCommand(expectedCommand, {
+				platform,
+				codexHomeDir,
+			});
+			if (!canonicalShimPath) return currentPostCompactCommandCheck();
+
+			const expectedShimContent = Buffer.from(
+				buildManagedCodexNativeHookWindowsShimContent(getPackageRoot()),
+				"utf-8",
+			);
+			const inMemoryInvocation = buildInMemoryWindowsShimSmokeInvocation(expectedShimContent);
+			if (!inMemoryInvocation) return inMemoryWindowsShimSmokeCheck();
+			smokeInvocation = inMemoryInvocation;
+			try {
+				await options.beforeWindowsShimSmoke?.({ canonicalShimPath, smokeCwd });
+			} catch {
+				return smokeDirectorySafetyCheck(
+					"Windows native hook changed during validation; doctor skipped execution for safety",
+				);
+			}
+		} else {
+			smokeInvocation = buildPostCompactSmokeSpawnInvocation(expectedCommand, { platform });
+		}
+		if (!sameSmokeDirectoryIdentity(smokeDirectory, await readSmokeDirectoryIdentity(smokeCwd))) {
+			return smokeDirectorySafetyCheck(
+				"temporary PostCompact smoke directory changed during validation; doctor preserved it for manual recovery and skipped execution for safety",
+			);
+		}
+
 		const payload = JSON.stringify({
 			hook_event_name: "PostCompact",
 			cwd: smokeCwd,
 			session_id: "omx-doctor-postcompact-smoke",
 		});
-		const smokeInvocation = buildPostCompactSmokeSpawnInvocation(expectedCommand, { platform });
 		const result = (options.runner ?? spawnSync)(smokeInvocation.command, smokeInvocation.args, {
 			cwd,
 			encoding: "utf-8",
 			env: {
 				...process.env,
 				OMX_NATIVE_HOOK_DOCTOR_SMOKE: "1",
+				OMX_ROOT: smokeCwd,
+				OMX_SESSION_ID: "omx-doctor-postcompact-smoke",
+				OMX_SOURCE_CWD: smokeCwd,
+				OMX_STARTUP_CWD: smokeCwd,
 			},
 			input: payload,
 			shell: smokeInvocation.shell,
@@ -2461,7 +2647,8 @@ export async function checkNativePostCompactHookRuntime(
 				"verbose smoke validation confirmed the effective PostCompact hook exits successfully with no stdout",
 		};
 	} finally {
-		await rm(smokeCwd, { recursive: true, force: true });
+		const cleanupCheck = await cleanupSmokeDirectoryIfUnchanged(smokeCwd, smokeDirectory);
+		if (cleanupCheck) return cleanupCheck;
 	}
 }
 

--- a/src/cli/native-hook-claim-journal.ts
+++ b/src/cli/native-hook-claim-journal.ts
@@ -1,0 +1,258 @@
+import { createHash } from "crypto";
+import { constants } from "fs";
+import { copyFile, link, open, lstat, mkdir, readFile, rm } from "fs/promises";
+import { dirname, isAbsolute, join, relative, sep } from "path";
+
+interface ClaimJournalEntry {
+	version: 1;
+	ownerPid: number;
+	canonicalPath: string;
+	claimPath: string;
+	beforeHash: string;
+	afterHash: string | null;
+}
+
+function digest(bytes: Buffer): string {
+	return createHash("sha256").update(bytes).digest("hex");
+}
+
+function isMissing(error: unknown): boolean {
+	return typeof error === "object" && error !== null && "code" in error &&
+		(error as { code?: unknown }).code === "ENOENT";
+}
+
+function assertControlledPath(root: string, path: string): void {
+	const rel = relative(root, path);
+	if (isAbsolute(rel) || rel === ".." || rel.startsWith(`..${sep}`) || rel === "") {
+		throw new Error(`Native hook claim journal path is outside controlled root: ${path}`);
+	}
+}
+
+function processIsAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return typeof error === "object" && error !== null && "code" in error &&
+			(error as { code?: unknown }).code === "EPERM";
+	}
+}
+
+async function fsyncDirectory(path: string): Promise<void> {
+	const handle = await open(path, "r");
+	try {
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
+
+export async function syncNativeHookClaimParent(path: string): Promise<void> {
+	await fsyncDirectory(dirname(path));
+}
+
+export async function restoreNativeHookClaimNoClobber(
+	claimPath: string,
+	destinationPath: string,
+): Promise<void> {
+	const claimStat = await lstat(claimPath);
+	if (claimStat.isSymbolicLink() || !claimStat.isFile() || claimStat.nlink !== 1) {
+		throw new Error(`Native hook claim restore refuses unsafe claim ${claimPath}.`);
+	}
+	const claimBytes = await readFile(claimPath);
+	let linked = false;
+	try {
+		await link(claimPath, destinationPath);
+		linked = true;
+	} catch (error) {
+		const code = typeof error === "object" && error !== null && "code" in error
+			? (error as { code?: unknown }).code
+			: undefined;
+		if (code !== "EPERM" && code !== "ENOTSUP" && code !== "EOPNOTSUPP" && code !== "EXDEV") {
+			throw error;
+		}
+		await copyFile(claimPath, destinationPath, constants.COPYFILE_EXCL);
+	}
+	const destinationHandle = await open(destinationPath, "r");
+	try {
+		await destinationHandle.sync();
+	} finally {
+		await destinationHandle.close();
+	}
+	await fsyncDirectory(dirname(destinationPath));
+	const [currentClaimStat, currentClaimBytes, destinationBytes, destinationStat] = await Promise.all([
+		lstat(claimPath),
+		readFile(claimPath),
+		readFile(destinationPath),
+		lstat(destinationPath),
+	]);
+	if (
+		currentClaimStat.dev !== claimStat.dev ||
+		currentClaimStat.ino !== claimStat.ino ||
+		!currentClaimBytes.equals(claimBytes) ||
+		!destinationBytes.equals(claimBytes) ||
+		(linked && (currentClaimStat.dev !== destinationStat.dev || currentClaimStat.ino !== destinationStat.ino))
+	) {
+		throw new Error(`Native hook claim changed during restore: ${claimPath}.`);
+	}
+	await rm(claimPath);
+	await fsyncDirectory(dirname(claimPath));
+}
+
+async function readRegularBytes(path: string): Promise<Buffer | null> {
+	try {
+		const stat = await lstat(path);
+		if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1) {
+			throw new Error(`Native hook claim journal refuses unsafe artifact ${path}.`);
+		}
+		return await readFile(path);
+	} catch (error) {
+		if (isMissing(error)) return null;
+		throw error;
+	}
+}
+
+function journalPath(root: string): string {
+	return join(root, ".omx", "native-hook-claim-journal.json");
+}
+
+export async function persistNativeHookClaimJournal(
+	root: string,
+	entry: Omit<ClaimJournalEntry, "version" | "ownerPid" | "beforeHash" | "afterHash"> & {
+		before: Buffer;
+		after: Buffer | null;
+	},
+): Promise<void> {
+	assertControlledPath(root, entry.canonicalPath);
+	assertControlledPath(root, entry.claimPath);
+	const directory = dirname(journalPath(root));
+	let directoryCreated = false;
+	try {
+		await lstat(directory);
+	} catch (error) {
+		if (!isMissing(error)) throw error;
+		directoryCreated = true;
+	}
+	await mkdir(directory, { recursive: true });
+	const directoryStat = await lstat(directory);
+	if (directoryStat.isSymbolicLink() || !directoryStat.isDirectory()) {
+		throw new Error(`Native hook claim journal directory is unsafe: ${directory}`);
+	}
+	if (directoryCreated) await fsyncDirectory(dirname(directory));
+	const path = journalPath(root);
+	const payload: ClaimJournalEntry = {
+		version: 1,
+		ownerPid: process.pid,
+		canonicalPath: entry.canonicalPath,
+		claimPath: entry.claimPath,
+		beforeHash: digest(entry.before),
+		afterHash: entry.after === null ? null : digest(entry.after),
+	};
+	const handle = await open(path, "wx", 0o600);
+	try {
+		await handle.writeFile(`${JSON.stringify(payload, null, 2)}\n`, "utf-8");
+		await handle.sync();
+	} catch (error) {
+		await handle.close();
+		await rm(path, { force: true });
+		throw error;
+	}
+	await handle.close();
+	await fsyncDirectory(directory);
+}
+
+export async function clearNativeHookClaimJournal(root: string): Promise<void> {
+	const path = journalPath(root);
+	try {
+		await rm(path);
+		await fsyncDirectory(dirname(path));
+	} catch (error) {
+		if (!isMissing(error)) throw error;
+	}
+}
+
+export async function recoverNativeHookClaimJournal(root: string): Promise<boolean> {
+	const path = journalPath(root);
+	let parsed: ClaimJournalEntry;
+	try {
+		const stat = await lstat(path);
+		if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1) {
+			throw new Error(`Native hook claim journal is unsafe: ${path}`);
+		}
+		parsed = JSON.parse(await readFile(path, "utf-8")) as ClaimJournalEntry;
+	} catch (error) {
+		if (isMissing(error)) return false;
+		throw error;
+	}
+	if (
+		parsed.version !== 1 ||
+		!Number.isSafeInteger(parsed.ownerPid) ||
+		typeof parsed.canonicalPath !== "string" ||
+		typeof parsed.claimPath !== "string" ||
+		typeof parsed.beforeHash !== "string" ||
+		!(typeof parsed.afterHash === "string" || parsed.afterHash === null)
+	) {
+		throw new Error(`Native hook claim journal is malformed: ${path}`);
+	}
+	assertControlledPath(root, parsed.canonicalPath);
+	assertControlledPath(root, parsed.claimPath);
+	if (processIsAlive(parsed.ownerPid)) {
+		throw new Error("Native hook claim journal belongs to a live mutation; recovery refused to mutate it.");
+	}
+	try {
+		const [canonicalStat, claimStat] = await Promise.all([
+			lstat(parsed.canonicalPath),
+			lstat(parsed.claimPath),
+		]);
+		if (
+			!canonicalStat.isSymbolicLink() && canonicalStat.isFile() && canonicalStat.nlink === 2 &&
+			!claimStat.isSymbolicLink() && claimStat.isFile() && claimStat.nlink === 2 &&
+			canonicalStat.dev === claimStat.dev && canonicalStat.ino === claimStat.ino
+		) {
+			const bytes = await readFile(parsed.canonicalPath);
+			if (digest(bytes) !== parsed.beforeHash) {
+				throw new Error("Native hook claim journal cannot finalize a linked restore with changed bytes.");
+			}
+			await rm(parsed.claimPath);
+			await fsyncDirectory(dirname(parsed.claimPath));
+			await clearNativeHookClaimJournal(root);
+			return true;
+		}
+	} catch (error) {
+		if (!isMissing(error)) throw error;
+	}
+	const [canonical, claim] = await Promise.all([
+		readRegularBytes(parsed.canonicalPath),
+		readRegularBytes(parsed.claimPath),
+	]);
+	if (claim === null) {
+		if (canonical === null && parsed.afterHash === null) {
+			await clearNativeHookClaimJournal(root);
+			return true;
+		}
+		if (canonical !== null && parsed.afterHash !== null && digest(canonical) === parsed.afterHash) {
+			await clearNativeHookClaimJournal(root);
+			return true;
+		}
+		if (canonical !== null && digest(canonical) === parsed.beforeHash) {
+			await clearNativeHookClaimJournal(root);
+			return true;
+		}
+		throw new Error("Native hook claim journal cannot recover: claim is missing and canonical bytes are not the recorded original.");
+	}
+	if (digest(claim) !== parsed.beforeHash) {
+		throw new Error("Native hook claim journal cannot recover: claim bytes do not match recorded ownership.");
+	}
+	if (canonical === null) {
+		await restoreNativeHookClaimNoClobber(parsed.claimPath, parsed.canonicalPath);
+		await clearNativeHookClaimJournal(root);
+		return true;
+	}
+	if (parsed.afterHash !== null && digest(canonical) === parsed.afterHash) {
+		await rm(parsed.claimPath);
+		await fsyncDirectory(dirname(parsed.claimPath));
+		await clearNativeHookClaimJournal(root);
+		return true;
+	}
+	throw new Error("Native hook claim journal cannot recover without overwriting unrecognized canonical content.");
+}

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -14,8 +14,11 @@ import {
 	stat,
 	lstat,
 	rm,
+	open,
+	chmod,
 } from "fs/promises";
-import { join, dirname, relative, basename } from "path";
+import { join, dirname, relative, basename, isAbsolute, sep } from "path";
+
 import { existsSync } from "fs";
 import { spawnSync } from "child_process";
 import { createInterface } from "readline/promises";
@@ -57,12 +60,13 @@ import {
 } from "../config/generator.js";
 import type { CodexHookFeatureFlag } from "../config/codex-feature-flags.js";
 import {
-	buildManagedCodexHookTrustState,
 	buildManagedCodexNativeHookWindowsShimContent,
 	buildManagedCodexNativeHookWindowsShimPath,
-	mergeManagedCodexHooksConfig,
-	extractCodexHooksJsonTrustState,
-	removeManagedCodexHooks,
+	planManagedCodexHooksMerge,
+	planManagedCodexHooksRemoval,
+	classifyManagedCodexNativeHookWindowsShimOwnership,
+	ManagedCodexHooksPlanError,
+	validateCodexHooksConfigStrict,
 } from "../config/codex-hooks.js";
 import {
 	getLegacyUnifiedMcpRegistryCandidate,
@@ -226,12 +230,6 @@ interface SetupRunSummary {
 interface SetupBackupContext {
 	backupRoot: string;
 	baseRoot: string;
-}
-
-interface ManagedConfigResult {
-	finalConfig: string;
-	omxManagesTui: boolean;
-	repairedLegacyTeamRunTable: boolean;
 }
 
 interface LegacySkillOverlapNotice {
@@ -430,85 +428,926 @@ function getBackupContext(
 	};
 }
 
-function escapeTomlBasicString(value: string): string {
-	return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-}
-
-function renderHooksJsonTrustStateToml(content: string | null | undefined): string {
-	const trustState = extractCodexHooksJsonTrustState(content);
-	return Object.entries(trustState)
-		.sort(([left], [right]) => left.localeCompare(right))
-		.flatMap(([key, state]) => [
-			`[hooks.state."${escapeTomlBasicString(key)}"]`,
-			`trusted_hash = "${escapeTomlBasicString(state.trusted_hash)}"`,
-			...(typeof state.enabled === "boolean" ? [`enabled = ${state.enabled}`] : []),
-			"",
-		])
-		.join("\n")
-		.trimEnd();
-}
-
-function existingHooksStateKeys(config: string): Set<string> {
-	try {
-		const parsed = TOML.parse(config) as {
-			hooks?: { state?: Record<string, unknown> };
-		};
-		return new Set(Object.keys(parsed.hooks?.state ?? {}));
-	} catch {
-		return new Set();
+function logManagedCodexHooksPlanDiagnostics(
+	diagnostics: readonly { message: string }[] | undefined,
+	options: Pick<SetupOptions, "verbose">,
+): void {
+	if (!options.verbose || !diagnostics) return;
+	for (const diagnostic of diagnostics) {
+		console.log(`  hook plan diagnostic: ${diagnostic.message}`);
 	}
 }
-function appendHooksJsonTrustStateToConfig(
-	config: string,
-	hooksContent: string | null | undefined,
-): string {
-	const existingKeys = existingHooksStateKeys(config);
-	const trustState = extractCodexHooksJsonTrustState(hooksContent);
-	const migratableContent = JSON.stringify({
-		state: Object.fromEntries(
-			Object.entries(trustState).filter(([key]) => !existingKeys.has(key)),
-		),
-	});
-	const trustToml = renderHooksJsonTrustStateToml(migratableContent);
-	if (!trustToml) return config;
-	const base = config.trimEnd();
-	return [
-		base,
-		base ? "" : null,
-		"# Migrated from legacy hooks.json state; kept in Codex config.toml because Codex 0.140 rejects top-level hooks.json state.",
-		trustToml,
-		"",
-	].filter((line): line is string => line !== null).join("\n");
+
+type NativeHookTransactionArtifactKind = "shim" | "hooks" | "config" | "metadata";
+	type NativeHookTransactionFailureStage =
+	| "before_precondition"
+	| "before_backup"
+	| "before_temp_write"
+	| "before_rename"
+	| "after_rename"
+	| "before_remove"
+	| "after_remove"
+	| "before_readback"
+	| "before_rollback"
+	| "before_rollback_rename"
+	| "before_rollback_remove"
+	| "before_staged_cleanup";
+
+type NativeHookTransactionTopology =
+	| { kind: "absent" }
+	| { kind: "regular_file"; mode: number };
+
+interface NativeHookTransactionArtifactSnapshot {
+	bytes: Buffer | null;
+	topology: NativeHookTransactionTopology;
+	device?: number;
+	inode?: number;
+	links?: number;
 }
 
-async function migrateLegacyHooksJsonTrustStateToConfig(
-	configPath: string,
-	hooksContent: string | null | undefined,
+interface NativeHookTransactionArtifact {
+	kind: NativeHookTransactionArtifactKind;
+	path: string;
+	label: string;
+	before: NativeHookTransactionArtifactSnapshot;
+	after: Buffer | null;
+	afterTopology: NativeHookTransactionTopology;
+	hookPlatform?: NodeJS.Platform;
+}
+
+interface NativeHookTransactionPrecondition {
+	kind: NativeHookTransactionArtifactKind;
+	path: string;
+	label: string;
+	before: NativeHookTransactionArtifactSnapshot;
+}
+
+
+type NativeHookTransactionAncestorTopology =
+	| { kind: "absent" }
+	| { kind: "directory"; device: number; inode: number };
+
+interface NativeHookTransactionAncestorSnapshot {
+	path: string;
+	topology: NativeHookTransactionAncestorTopology;
+}
+
+interface NativeHookTransactionAncestorPrecondition {
+	controlledRoot: string;
+	ancestorPaths: string[];
+	snapshots: NativeHookTransactionAncestorSnapshot[];
+}
+
+interface AppliedNativeHookTransactionArtifact {
+	artifact: NativeHookTransactionArtifact;
+	appliedSnapshot: NativeHookTransactionArtifactSnapshot;
+	stagedDeletionPath?: string;
+	stagedDeletionSnapshot?: NativeHookTransactionArtifactSnapshot;
+}
+
+let nativeHookTransactionFailureInjector:
+	| ((
+		stage: NativeHookTransactionFailureStage,
+		target: NativeHookTransactionArtifact | NativeHookTransactionPrecondition,
+	) => void)
+	| undefined;
+let nativeHookTransactionSequence = 0;
+let nativeHookTransactionPlatformOverride: NodeJS.Platform | undefined;
+let nativeHookTransactionTemporaryPathOverride:
+	| ((path: string, purpose: "write" | "delete") => string)
+	| undefined;
+
+/** @internal Test seam for deterministic atomic-write and rollback coverage. */
+export function setNativeHookTransactionFailureInjectorForTest(
+	injector:
+		| ((
+			stage: NativeHookTransactionFailureStage,
+			target: NativeHookTransactionArtifact | NativeHookTransactionPrecondition,
+		) => void)
+		| undefined,
+): () => void {
+	const previous = nativeHookTransactionFailureInjector;
+	nativeHookTransactionFailureInjector = injector;
+	return () => {
+		nativeHookTransactionFailureInjector = previous;
+	};
+}
+
+/** @internal Test seam for deterministic Windows transaction coverage. */
+export function setNativeHookTransactionPlatformForTest(
+	platform: NodeJS.Platform | undefined,
+): () => void {
+	const previous = nativeHookTransactionPlatformOverride;
+	nativeHookTransactionPlatformOverride = platform;
+	return () => {
+		nativeHookTransactionPlatformOverride = previous;
+	};
+}
+
+/** @internal Test seam for deterministic native transaction temporary-path coverage. */
+export function setNativeHookTransactionTemporaryPathForTest(
+	resolver:
+		| ((path: string, purpose: "write" | "delete") => string)
+		| undefined,
+): () => void {
+	const previous = nativeHookTransactionTemporaryPathOverride;
+	nativeHookTransactionTemporaryPathOverride = resolver;
+	return () => {
+		nativeHookTransactionTemporaryPathOverride = previous;
+	};
+}
+
+function nativeHookPlatform(): NodeJS.Platform {
+	return nativeHookTransactionPlatformOverride ?? process.platform;
+}
+
+function hookTransactionBytesEqual(
+	left: Buffer | null,
+	right: Buffer | null,
+): boolean {
+	return left === null || right === null ? left === right : left.equals(right);
+}
+
+function nativeHookTransactionTopologyEqual(
+	left: NativeHookTransactionTopology,
+	right: NativeHookTransactionTopology,
+): boolean {
+	return left.kind === "absent" || right.kind === "absent"
+		? left.kind === right.kind
+		: left.mode === right.mode;
+}
+
+function isMissingPathError(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		(error as { code?: unknown }).code === "ENOENT"
+	);
+}
+
+
+function nativeHookTransactionArtifactAncestorPaths(
+	controlledRoot: string,
+	artifactPaths: readonly string[],
+): string[] {
+	const paths = new Set([controlledRoot]);
+	for (const artifactPath of artifactPaths) {
+		const parentPath = dirname(artifactPath);
+		const fromControlledRoot = relative(controlledRoot, parentPath);
+		if (
+			fromControlledRoot === ".." ||
+			fromControlledRoot.startsWith(`..${sep}`) ||
+			isAbsolute(fromControlledRoot)
+		) {
+			continue;
+		}
+		let ancestorPath = controlledRoot;
+		if (fromControlledRoot !== "") {
+			for (const component of fromControlledRoot.split(sep)) {
+				ancestorPath = join(ancestorPath, component);
+				paths.add(ancestorPath);
+			}
+		}
+	}
+	return [...paths];
+}
+
+async function captureNativeHookTransactionAncestorSnapshots(
+	ancestorPaths: readonly string[],
+): Promise<NativeHookTransactionAncestorSnapshot[]> {
+	const snapshots: NativeHookTransactionAncestorSnapshot[] = [];
+	for (const path of ancestorPaths) {
+		let status;
+		try {
+			status = await lstat(path);
+		} catch (error) {
+			if (isMissingPathError(error)) {
+				snapshots.push({ path, topology: { kind: "absent" } });
+				continue;
+			}
+			throw error;
+		}
+		if (status.isSymbolicLink()) {
+			throw new Error(
+				`Refusing native hook transaction: ancestor ${path} is a symbolic link.`,
+			);
+		}
+		if (!status.isDirectory()) {
+			throw new Error(
+				`Refusing native hook transaction: ancestor ${path} is not a directory.`,
+			);
+		}
+		snapshots.push({
+			path,
+			topology: { kind: "directory", device: status.dev, inode: status.ino },
+		});
+	}
+	return snapshots;
+}
+
+function nativeHookTransactionAncestorTopologyEqual(
+	left: NativeHookTransactionAncestorTopology,
+	right: NativeHookTransactionAncestorTopology,
+): boolean {
+	return left.kind === "absent" || right.kind === "absent"
+		? left.kind === right.kind
+		: left.device === right.device && left.inode === right.inode;
+}
+
+async function captureNativeHookTransactionAncestorPrecondition(
+	controlledRoot: string,
+	artifactPaths: readonly string[],
+): Promise<NativeHookTransactionAncestorPrecondition> {
+	const ancestorPaths = nativeHookTransactionArtifactAncestorPaths(
+		controlledRoot,
+		artifactPaths,
+	);
+	return {
+		controlledRoot,
+		ancestorPaths,
+		snapshots: await captureNativeHookTransactionAncestorSnapshots(ancestorPaths),
+	};
+}
+
+async function assertNativeHookTransactionAncestorPrecondition(
+	precondition: NativeHookTransactionAncestorPrecondition,
+): Promise<void> {
+	const actual = await captureNativeHookTransactionAncestorSnapshots(
+		precondition.ancestorPaths,
+	);
+	for (let index = 0; index < precondition.snapshots.length; index += 1) {
+		const expected = precondition.snapshots[index]!;
+		const current = actual[index]!;
+		if (!nativeHookTransactionAncestorTopologyEqual(current.topology, expected.topology)) {
+			throw new Error(
+				`Native hook transaction precondition changed for ancestor ${expected.path}; refusing to mutate a stale topology.`,
+			);
+		}
+	}
+}
+
+async function refreshNativeHookTransactionAncestorPrecondition(
+	precondition: NativeHookTransactionAncestorPrecondition,
+	artifactPath: string,
+): Promise<void> {
+	const allowedCreatedPaths = new Set(
+		nativeHookTransactionArtifactAncestorPaths(precondition.controlledRoot, [artifactPath]),
+	);
+	const actual = await captureNativeHookTransactionAncestorSnapshots(
+		precondition.ancestorPaths,
+	);
+	for (let index = 0; index < precondition.snapshots.length; index += 1) {
+		const expected = precondition.snapshots[index]!;
+		const current = actual[index]!;
+		if (nativeHookTransactionAncestorTopologyEqual(current.topology, expected.topology)) {
+			continue;
+		}
+		if (
+			expected.topology.kind === "absent" &&
+			current.topology.kind === "directory" &&
+			allowedCreatedPaths.has(expected.path)
+		) {
+			continue;
+		}
+		throw new Error(
+			`Native hook transaction precondition changed for ancestor ${expected.path}; refusing to mutate a stale topology.`,
+		);
+	}
+	precondition.snapshots = actual;
+}
+
+function decodeNativeHookTransactionUtf8(bytes: Buffer, label: string): string {
+	try {
+		const content = new TextDecoder("utf-8", {
+			fatal: true,
+			ignoreBOM: true,
+		}).decode(bytes);
+		if (!Buffer.from(content, "utf-8").equals(bytes)) {
+			throw new Error("decoded text did not round-trip to the original bytes");
+		}
+		return content;
+	} catch (error) {
+		throw new ManagedCodexHooksPlanError(
+			"invalid_document",
+			`Refusing to read ${label}: invalid UTF-8 (${error instanceof Error ? error.message : String(error)}).`,
+			{ label },
+		);
+	}
+}
+
+async function captureNativeHookTransactionArtifact(
+	path: string,
+	label: string,
+): Promise<NativeHookTransactionArtifactSnapshot> {
+	let before;
+	try {
+		before = await lstat(path);
+	} catch (error) {
+		if (isMissingPathError(error)) {
+			return { bytes: null, topology: { kind: "absent" } };
+		}
+		throw error;
+	}
+	if (!before.isFile() || before.nlink !== 1) {
+		throw new Error(
+			`Refusing native hook transaction for ${label}: expected a single-link regular file or absence.`,
+		);
+	}
+	const bytes = await readFile(path);
+	const after = await lstat(path);
+	const beforeTopology = {
+		kind: "regular_file" as const,
+		mode: before.mode & 0o7777,
+	};
+	const afterTopology = {
+		kind: "regular_file" as const,
+		mode: after.mode & 0o7777,
+	};
+	if (
+		!after.isFile() ||
+		after.nlink !== 1 ||
+		!nativeHookTransactionTopologyEqual(beforeTopology, afterTopology) ||
+		before.dev !== after.dev ||
+		before.ino !== after.ino ||
+		before.nlink !== after.nlink
+	) {
+		throw new Error(
+			`Refusing native hook transaction for ${label}: path changed while its snapshot was read.`,
+		);
+	}
+	return {
+		bytes,
+		topology: beforeTopology,
+		device: before.dev,
+		inode: before.ino,
+		links: before.nlink,
+	};
+}
+
+function nativeHookTransactionSnapshotsEqual(
+	left: NativeHookTransactionArtifactSnapshot,
+	right: NativeHookTransactionArtifactSnapshot,
+): boolean {
+	return (
+		hookTransactionBytesEqual(left.bytes, right.bytes) &&
+		nativeHookTransactionTopologyEqual(left.topology, right.topology) &&
+		left.device === right.device &&
+		left.inode === right.inode &&
+		left.links === right.links
+	);
+}
+
+function nativeHookTransactionSnapshotMatchesExpected(
+	snapshot: NativeHookTransactionArtifactSnapshot,
+	expected: Pick<NativeHookTransactionArtifactSnapshot, "bytes" | "topology">,
+): boolean {
+	return (
+		hookTransactionBytesEqual(snapshot.bytes, expected.bytes) &&
+		nativeHookTransactionTopologyEqual(snapshot.topology, expected.topology)
+	);
+}
+
+function nativeHookTransactionOutputTopology(
+	before: NativeHookTransactionArtifactSnapshot,
+	after: Buffer | null,
+): NativeHookTransactionTopology {
+	if (after === null) return { kind: "absent" };
+	return {
+		kind: "regular_file",
+		mode: before.topology.kind === "regular_file" ? before.topology.mode : 0o600,
+	};
+}
+
+function nativeHookTransactionArtifact(
+	kind: NativeHookTransactionArtifactKind,
+	path: string,
+	label: string,
+	before: NativeHookTransactionArtifactSnapshot,
+	after: Buffer | null,
+	hookPlatform?: NodeJS.Platform,
+): NativeHookTransactionArtifact | null {
+	return hookTransactionBytesEqual(before.bytes, after)
+		? null
+		: {
+			kind,
+			path,
+			label,
+			before,
+			after,
+			afterTopology: nativeHookTransactionOutputTopology(before, after),
+			hookPlatform,
+		};
+}
+
+function nativeHookTransactionPrecondition(
+	kind: NativeHookTransactionArtifactKind,
+	path: string,
+	label: string,
+	before: NativeHookTransactionArtifactSnapshot,
+): NativeHookTransactionPrecondition {
+	return { kind, path, label, before };
+}
+
+function assertWindowsNativeHookShimOwnership(
+	shimPath: string,
+	before: Buffer | null,
+	expected: Buffer,
+): void {
+	if (before === null) return;
+	const ownership = classifyManagedCodexNativeHookWindowsShimOwnership(
+		before,
+		expected,
+	);
+	if (ownership === "current" || ownership === "historical") return;
+	throw new Error(
+		`Refusing to replace modified Windows native hook shim ${shimPath}. Restore the complete OMX-generated shim or remove it after verifying no foreign hook references it.`,
+	);
+}
+
+function injectNativeHookTransactionFailure(
+	stage: NativeHookTransactionFailureStage,
+	target: NativeHookTransactionArtifact | NativeHookTransactionPrecondition,
+): void {
+	nativeHookTransactionFailureInjector?.(stage, target);
+}
+
+function nativeHookTransactionTemporaryPath(
+	path: string,
+	purpose: "write" | "delete",
+): string {
+	if (nativeHookTransactionTemporaryPathOverride) {
+		return nativeHookTransactionTemporaryPathOverride(path, purpose);
+	}
+	nativeHookTransactionSequence += 1;
+	return join(
+		dirname(path),
+		`.${basename(path)}.omx-${purpose}-${process.pid}-${nativeHookTransactionSequence}.tmp`,
+	);
+}
+
+async function atomicWriteNativeHookTransactionArtifact(
+	artifact: NativeHookTransactionArtifact,
+	content: Buffer,
+	stage: "write" | "rollback",
+	expectedCurrent: NativeHookTransactionArtifactSnapshot,
+	ancestorPrecondition: NativeHookTransactionAncestorPrecondition,
+	onWriteApplied?: (snapshot: NativeHookTransactionArtifactSnapshot) => void,
+): Promise<void> {
+	const temporaryPath = nativeHookTransactionTemporaryPath(artifact.path, "write");
+	let temporaryCreated = false;
+	let temporarySnapshot: NativeHookTransactionArtifactSnapshot | undefined;
+	try {
+		await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+		await mkdir(dirname(artifact.path), { recursive: true });
+		await refreshNativeHookTransactionAncestorPrecondition(
+			ancestorPrecondition,
+			artifact.path,
+		);
+
+		if (stage === "write") {
+			injectNativeHookTransactionFailure("before_temp_write", artifact);
+		} else {
+			injectNativeHookTransactionFailure("before_rollback", artifact);
+		}
+		await assertNativeHookTransactionArtifactSnapshot(
+			artifact.path,
+			artifact.label,
+			expectedCurrent,
+			stage === "write" ? "precondition" : "rollback",
+		);
+		await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+
+		const handle = await open(
+			temporaryPath,
+			"wx",
+			artifact.afterTopology.kind === "regular_file"
+				? artifact.afterTopology.mode
+				: 0o600,
+		);
+		temporaryCreated = true;
+		try {
+			await handle.writeFile(content);
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+		if (artifact.afterTopology.kind === "regular_file") {
+			await chmod(temporaryPath, artifact.afterTopology.mode);
+		}
+		temporarySnapshot = await assertNativeHookTransactionArtifactState(
+			temporaryPath,
+			`${artifact.label} temporary`,
+			{ bytes: content, topology: artifact.afterTopology },
+			"read-back",
+		);
+		if (stage === "write") {
+			injectNativeHookTransactionFailure("before_rename", artifact);
+		} else {
+			injectNativeHookTransactionFailure("before_rollback_rename", artifact);
+		}
+		await assertNativeHookTransactionArtifactSnapshot(
+			artifact.path,
+			artifact.label,
+			expectedCurrent,
+			stage === "write" ? "precondition" : "rollback",
+		);
+		await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+		await assertNativeHookTransactionArtifactSnapshot(
+			temporaryPath,
+			`${artifact.label} temporary`,
+			temporarySnapshot,
+			"read-back",
+		);
+
+		if (!temporarySnapshot) {
+			throw new Error("temporary path was not fully captured after writing");
+		}
+		await rename(temporaryPath, artifact.path);
+		temporaryCreated = false;
+		if (stage === "write") {
+			onWriteApplied?.(temporarySnapshot);
+			injectNativeHookTransactionFailure("after_rename", artifact);
+		}
+	} catch (error) {
+		if (temporaryCreated) {
+			try {
+				if (!temporarySnapshot) {
+					throw new Error("temporary path was not fully captured after writing");
+				}
+				await assertNativeHookTransactionArtifactSnapshot(
+					temporaryPath,
+					`${artifact.label} temporary`,
+					temporarySnapshot,
+					"read-back",
+				);
+				await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+				await rm(temporaryPath);
+			} catch (cleanupError) {
+				const message = error instanceof Error ? error.message : String(error);
+				throw new Error(
+					`Native hook transaction ${stage} failed (${message}) and preserved temporary ${temporaryPath} for manual recovery after cleanup verification failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+				);
+			}
+		}
+		throw error;
+	}
+}
+
+async function assertNativeHookTransactionArtifactState(
+	path: string,
+	label: string,
+	expected: Pick<NativeHookTransactionArtifactSnapshot, "bytes" | "topology">,
+	context: "precondition" | "rollback" | "read-back",
+): Promise<NativeHookTransactionArtifactSnapshot> {
+	const actual = await captureNativeHookTransactionArtifact(path, label);
+	if (!nativeHookTransactionSnapshotMatchesExpected(actual, expected)) {
+		if (context === "rollback") {
+			throw new Error(
+				`Native hook transaction rollback preserved ${path} for manual recovery because ${label} no longer matches the transaction-owned version.`,
+			);
+		}
+		throw new Error(
+			`Native hook transaction ${context} changed for ${label}; refusing to overwrite concurrent content.`,
+		);
+	}
+	return actual;
+}
+async function assertNativeHookTransactionArtifactSnapshot(
+	path: string,
+	label: string,
+	expected: NativeHookTransactionArtifactSnapshot,
+	context: "precondition" | "rollback" | "read-back",
+): Promise<NativeHookTransactionArtifactSnapshot> {
+	const actual = await captureNativeHookTransactionArtifact(path, label);
+	if (!nativeHookTransactionSnapshotsEqual(actual, expected)) {
+		if (context === "rollback") {
+			throw new Error(
+				`Native hook transaction rollback preserved ${path} for manual recovery because ${label} no longer matches the transaction-owned version.`,
+			);
+		}
+		throw new Error(
+			`Native hook transaction ${context} changed for ${label}; refusing to overwrite concurrent content.`,
+		);
+	}
+	return actual;
+}
+
+async function assertNativeHookTransactionPrecondition(
+	precondition: NativeHookTransactionPrecondition,
+): Promise<void> {
+	await assertNativeHookTransactionArtifactSnapshot(
+		precondition.path,
+		precondition.label,
+		precondition.before,
+		"precondition",
+	);
+}
+
+async function applyNativeHookTransactionArtifact(
+	artifact: NativeHookTransactionArtifact,
+	ancestorPrecondition: NativeHookTransactionAncestorPrecondition,
+	applied: AppliedNativeHookTransactionArtifact[],
+): Promise<AppliedNativeHookTransactionArtifact> {
+	await assertNativeHookTransactionArtifactSnapshot(
+		artifact.path,
+		artifact.label,
+		artifact.before,
+		"precondition",
+	);
+	await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+
+	if (artifact.after !== null) {
+		let entry: AppliedNativeHookTransactionArtifact | undefined;
+		await atomicWriteNativeHookTransactionArtifact(
+			artifact,
+			artifact.after,
+			"write",
+			artifact.before,
+			ancestorPrecondition,
+			(appliedSnapshot) => {
+				entry = { artifact, appliedSnapshot };
+				applied.push(entry);
+			},
+		);
+		if (!entry) {
+			throw new Error("native hook transaction write was not registered as applied");
+		}
+		return entry;
+	}
+
+	const stagedDeletionPath = nativeHookTransactionTemporaryPath(artifact.path, "delete");
+	let stagedDeletionCreated = false;
+	let originalRemoved = false;
+	let stagedDeletionSnapshot: NativeHookTransactionArtifactSnapshot | undefined;
+	try {
+		injectNativeHookTransactionFailure("before_temp_write", artifact);
+		await assertNativeHookTransactionArtifactSnapshot(
+			artifact.path,
+			artifact.label,
+			artifact.before,
+			"precondition",
+		);
+		await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+
+		const handle = await open(
+			stagedDeletionPath,
+			"wx",
+			artifact.before.topology.kind === "regular_file"
+				? artifact.before.topology.mode
+				: 0o600,
+		);
+		stagedDeletionCreated = true;
+		try {
+			await handle.writeFile(artifact.before.bytes!);
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+		if (artifact.before.topology.kind === "regular_file") {
+			await chmod(stagedDeletionPath, artifact.before.topology.mode);
+		}
+		stagedDeletionSnapshot = await assertNativeHookTransactionArtifactState(
+			stagedDeletionPath,
+			`${artifact.label} staged deletion`,
+			{ bytes: artifact.before.bytes, topology: artifact.before.topology },
+			"read-back",
+		);
+		injectNativeHookTransactionFailure("before_remove", artifact);
+		await assertNativeHookTransactionArtifactSnapshot(
+			artifact.path,
+			artifact.label,
+			artifact.before,
+			"precondition",
+		);
+		await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+		await assertNativeHookTransactionArtifactSnapshot(
+			stagedDeletionPath,
+			`${artifact.label} staged deletion`,
+			stagedDeletionSnapshot,
+			"read-back",
+		);
+
+		await rm(artifact.path);
+		originalRemoved = true;
+		const entry: AppliedNativeHookTransactionArtifact = {
+			artifact,
+			appliedSnapshot: { bytes: null, topology: { kind: "absent" } },
+			stagedDeletionPath,
+			stagedDeletionSnapshot,
+		};
+		applied.push(entry);
+		injectNativeHookTransactionFailure("after_remove", artifact);
+		return entry;
+	} catch (error) {
+		if (stagedDeletionCreated && !originalRemoved) {
+			try {
+				if (!stagedDeletionSnapshot) {
+					throw new Error("staged deletion path was not fully captured after writing");
+				}
+				await assertNativeHookTransactionArtifactSnapshot(
+					stagedDeletionPath,
+					`${artifact.label} staged deletion`,
+					stagedDeletionSnapshot,
+					"read-back",
+				);
+				await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+				await rm(stagedDeletionPath);
+			} catch (cleanupError) {
+				const message = error instanceof Error ? error.message : String(error);
+				throw new Error(
+					`Native hook transaction failed (${message}) and preserved staged deletion ${stagedDeletionPath} for manual recovery after cleanup verification failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+				);
+			}
+		}
+		throw error;
+	}
+}
+
+async function verifyNativeHookTransactionArtifact(
+	applied: AppliedNativeHookTransactionArtifact,
+): Promise<void> {
+	const { artifact } = applied;
+	injectNativeHookTransactionFailure("before_readback", artifact);
+	const actual = await captureNativeHookTransactionArtifact(artifact.path, artifact.label);
+	if (!nativeHookTransactionSnapshotsEqual(actual, applied.appliedSnapshot)) {
+		throw new Error(
+			`Native hook transaction read-back changed for ${artifact.label}; refusing to overwrite concurrent content.`,
+		);
+	}
+	if (artifact.after === null) return;
+	const content = decodeNativeHookTransactionUtf8(actual.bytes!, artifact.label);
+	if (artifact.kind === "hooks") {
+		const validation = validateCodexHooksConfigStrict(content, {
+			platform: artifact.hookPlatform,
+		});
+		if (!validation.ok) {
+			throw new Error(
+				`Native hook transaction wrote invalid hooks.json: ${validation.error.message}`,
+			);
+		}
+	}
+	if (artifact.kind === "config") TOML.parse(content);
+}
+
+async function restoreNativeHookTransactionArtifact(
+	applied: AppliedNativeHookTransactionArtifact,
+	ancestorPrecondition: NativeHookTransactionAncestorPrecondition,
+): Promise<void> {
+	const { artifact } = applied;
+	const current = await captureNativeHookTransactionArtifact(artifact.path, artifact.label);
+	if (!nativeHookTransactionSnapshotsEqual(current, applied.appliedSnapshot)) {
+		throw new Error(
+			`Native hook transaction rollback preserved ${artifact.path} for manual recovery because ${artifact.label} no longer matches the transaction-owned version.`,
+		);
+	}
+	if (artifact.before.bytes === null) {
+		injectNativeHookTransactionFailure("before_rollback", artifact);
+		injectNativeHookTransactionFailure("before_rollback_remove", artifact);
+		await assertNativeHookTransactionArtifactSnapshot(
+			artifact.path,
+			artifact.label,
+			applied.appliedSnapshot,
+			"rollback",
+		);
+		await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+
+		await rm(artifact.path);
+	} else {
+		const restoreArtifact: NativeHookTransactionArtifact = {
+			...artifact,
+			after: artifact.before.bytes,
+			afterTopology: artifact.before.topology,
+		};
+		await atomicWriteNativeHookTransactionArtifact(
+			restoreArtifact,
+			artifact.before.bytes,
+			"rollback",
+			applied.appliedSnapshot,
+			ancestorPrecondition,
+		);
+	}
+	const restored = await captureNativeHookTransactionArtifact(artifact.path, artifact.label);
+	if (
+		!nativeHookTransactionSnapshotMatchesExpected(restored, {
+			bytes: artifact.before.bytes,
+			topology: artifact.before.topology,
+		})
+	) {
+		throw new Error(
+			`Native hook transaction rollback preserved ${artifact.path} for manual recovery because ${artifact.label} no longer matches the expected restored version.`,
+		);
+	}
+}
+
+async function cleanupNativeHookTransactionStagedDeletions(
+	applied: readonly AppliedNativeHookTransactionArtifact[],
+	ancestorPrecondition: NativeHookTransactionAncestorPrecondition,
+): Promise<void> {
+	for (const entry of applied) {
+		if (!entry.stagedDeletionPath || !entry.stagedDeletionSnapshot) continue;
+		injectNativeHookTransactionFailure("before_staged_cleanup", entry.artifact);
+		await assertNativeHookTransactionArtifactSnapshot(
+			entry.stagedDeletionPath,
+			`${entry.artifact.label} staged deletion`,
+			entry.stagedDeletionSnapshot,
+			"read-back",
+		);
+		await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+		await rm(entry.stagedDeletionPath);
+	}
+}
+
+async function commitNativeHookTransaction(
+	artifacts: readonly NativeHookTransactionArtifact[],
+	preconditions: readonly NativeHookTransactionPrecondition[],
+	ancestorPrecondition: NativeHookTransactionAncestorPrecondition,
 	backupContext: SetupBackupContext,
 	summary: SetupCategorySummary,
 	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<void> {
-	const existingConfig = existsSync(configPath)
-		? await readFile(configPath, "utf-8")
-		: "";
-	const nextConfig = appendHooksJsonTrustStateToConfig(existingConfig, hooksContent);
-	if (nextConfig === existingConfig) return;
-	if (
-		await ensureBackup(configPath, existsSync(configPath), backupContext, options)
-	) {
-		summary.backedUp += 1;
+	if (options.dryRun) return;
+
+	await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+
+	for (const precondition of preconditions) {
+		injectNativeHookTransactionFailure("before_precondition", precondition);
+		await assertNativeHookTransactionPrecondition(precondition);
 	}
-	if (!options.dryRun) {
-		await mkdir(dirname(configPath), { recursive: true });
-		await writeFile(configPath, nextConfig);
+	if (artifacts.length === 0) return;
+	for (const artifact of artifacts) {
+		injectNativeHookTransactionFailure("before_backup", artifact);
+		if (
+			await ensureBackup(
+				artifact.path,
+				artifact.before.bytes !== null,
+				backupContext,
+				options,
+			)
+		) {
+			summary.backedUp += 1;
+		}
 	}
-	summary.updated += 1;
-	if (options.verbose) {
-		console.log(
-			`  ${options.dryRun ? "would migrate" : "migrated"} legacy hooks.json trust state to ${configPath}`,
+	for (const precondition of preconditions) {
+		await assertNativeHookTransactionPrecondition(precondition);
+	}
+	await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+
+
+	const applied: AppliedNativeHookTransactionArtifact[] = [];
+	try {
+		for (const artifact of artifacts) {
+			const entry = await applyNativeHookTransactionArtifact(
+				artifact,
+				ancestorPrecondition,
+				applied,
+			);
+			await verifyNativeHookTransactionArtifact(entry);
+		}
+	} catch (error) {
+		const rollbackFailures: string[] = [];
+		const restored: AppliedNativeHookTransactionArtifact[] = [];
+		for (const entry of [...applied].reverse()) {
+			try {
+				await restoreNativeHookTransactionArtifact(entry, ancestorPrecondition);
+				restored.push(entry);
+			} catch (rollbackError) {
+				rollbackFailures.push(
+					`${entry.artifact.label}: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+				);
+			}
+		}
+		try {
+			await cleanupNativeHookTransactionStagedDeletions(
+				restored,
+				ancestorPrecondition,
+			);
+		} catch (cleanupError) {
+			rollbackFailures.push(
+				`staged deletion cleanup: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+			);
+		}
+		const message = error instanceof Error ? error.message : String(error);
+		if (rollbackFailures.length > 0) {
+			throw new Error(
+				`Native hook transaction failed (${message}) and rollback failed (${rollbackFailures.join("; ")}).`,
+			);
+		}
+		throw new Error(`Native hook transaction failed and was rolled back: ${message}`);
+	}
+
+	try {
+		await cleanupNativeHookTransactionStagedDeletions(
+			applied,
+			ancestorPrecondition,
+		);
+	} catch (error) {
+		throw new Error(
+			`Native hook transaction committed but staged deletion cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
 		);
 	}
 }
+
 
 async function ensureBackup(
 	destinationPath: string,
@@ -1063,13 +1902,11 @@ function legacyPluginDeveloperInstructionsDecision(
 }
 
 async function resolvePluginDeveloperInstructionsDecision(
+	existingConfig: string,
 	configPath: string,
 	options: Pick<SetupOptions, "pluginDeveloperInstructionsPrompt">,
 ): Promise<PluginDeveloperInstructionsDecision> {
-	const existing = existsSync(configPath)
-		? await readFile(configPath, "utf-8")
-		: "";
-	const value = readRootDeveloperInstructions(existing);
+	const value = readRootDeveloperInstructions(existingConfig);
 	if (value === undefined) {
 		if (options.pluginDeveloperInstructionsPrompt) {
 			return legacyPluginDeveloperInstructionsDecision(
@@ -1752,267 +2589,123 @@ function insertRootTomlKey(config: string, line: string): string {
 	return [...before, line, "", ...after].join("\n") + "\n";
 }
 
-async function ensurePluginMarketplaceRegistration(
-	configPath: string,
-	pkgRoot: string,
-	mcpMode: SetupMcpMode,
-	removeFirstPartyMcp: boolean,
-	backupContext: SetupBackupContext,
-	summary: SetupCategorySummary,
-	options: Pick<SetupOptions, "dryRun" | "verbose">,
-): Promise<"updated" | "unchanged" | "unavailable"> {
-	const packagedMarketplace = await resolvePackagedOmxMarketplace(pkgRoot);
-	if (!packagedMarketplace) {
-		summary.skipped += 1;
-		return "unavailable";
-	}
 
-	const existingConfig = existsSync(configPath)
-		? await readFile(configPath, "utf-8")
-		: "";
-	const nextConfig = upsertLocalOmxMarketplaceRegistration(
-		upsertLocalOmxPluginMcpServerEnablement(
-			upsertLocalOmxPluginEnablement(existingConfig),
-			mcpMode === "compat",
-			{ removeWhenDisabled: removeFirstPartyMcp },
-		),
-		pkgRoot,
-	);
-	const destinationExists = existsSync(configPath);
-
-	if (nextConfig === existingConfig) {
-		summary.unchanged += 1;
-		return "unchanged";
-	}
-
-	if (
-		await ensureBackup(configPath, destinationExists, backupContext, options)
-	) {
-		summary.backedUp += 1;
-	}
-	if (!options.dryRun) {
-		await mkdir(dirname(configPath), { recursive: true });
-		await writeFile(configPath, nextConfig);
-	}
-	summary.updated += 1;
-	if (options.verbose) {
-		console.log(
-			`  ${options.dryRun ? "would register" : "registered"} local Codex plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} from ${pkgRoot}`,
-		);
-	}
-	return "updated";
+interface PluginModeHooksConfigPlan {
+	finalConfig: string;
+	hooksFinalContent: string | null;
+	hooksRemovedCount: number;
+	cleanedLegacyConfig: boolean;
+	diagnostics: readonly { message: string }[];
 }
 
-async function cleanupPluginModeManagedHooksJson(
+function buildPluginModeHooksConfigPlan(
+	existingConfig: string,
 	existingHooksContent: string | null,
-	hooksPath: string,
-	backupContext: SetupBackupContext,
-	summary: SetupCategorySummary,
-	options: Pick<SetupOptions, "dryRun" | "verbose">,
-): Promise<void> {
-	if (existingHooksContent === null) {
-		summary.unchanged += 1;
-		return;
-	}
-
-	const removed = removeManagedCodexHooks(existingHooksContent);
-	if (removed.removedCount === 0) {
-		summary.unchanged += 1;
-		return;
-	}
-
-	if (await ensureBackup(hooksPath, true, backupContext, options)) {
-		summary.backedUp += 1;
-	}
-	if (!options.dryRun) {
-		if (removed.nextContent === null) {
-			await rm(hooksPath, { force: true });
-		} else {
-			await writeFile(hooksPath, removed.nextContent);
-		}
-	}
-	summary.removed += removed.removedCount;
-	if (options.verbose) {
-		console.log(
-			`  ${options.dryRun ? "would remove" : "removed"} ${removed.removedCount} legacy setup-managed hook wrapper(s) from ${hooksPath}`,
-		);
-	}
-}
-
-async function applyPluginModeHooksConfig(
-	configPath: string,
-	hooksPath: string,
 	pkgRoot: string,
+	hooksPath: string,
 	codexHomeDir: string,
-	backupContext: SetupBackupContext,
-	summary: SetupCategorySummary,
-	options: Pick<SetupOptions, "dryRun" | "verbose"> & {
+	options: {
 		codexHookFeatureFlag: CodexHookFeatureFlag;
 		pluginScopedHooks: boolean;
+		preserveFirstPartyMcp?: boolean;
+		developerInstructionsDecision: PluginDeveloperInstructionsDecision;
+		platform: NodeJS.Platform;
 	},
-): Promise<void> {
-	const existingConfig = existsSync(configPath)
-		? await readFile(configPath, "utf-8")
-		: "";
-	const managedTrustState = buildManagedCodexHookTrustState(
-		hooksPath,
-		pkgRoot,
-		{ platform: process.platform, codexHomeDir },
-	);
-	const nextConfigBase = upsertPluginModeRuntimeFeatureFlags(
-		stripManagedCodexHookTrustState(existingConfig, { managedTrustState }),
-		options.codexHookFeatureFlag,
-		{ pluginScopedHooks: options.pluginScopedHooks },
-	);
-	const nextConfig = options.pluginScopedHooks
-		? nextConfigBase
-		: upsertManagedCodexHookTrustState(
-			nextConfigBase,
+): PluginModeHooksConfigPlan {
+	const managedHookOptions = {
+		platform: options.platform,
+		codexHomeDir,
+	} as const;
+	const managedHooksPlan = options.pluginScopedHooks
+		? existingHooksContent === null
+			? null
+			: planManagedCodexHooksRemoval(
+				existingHooksContent,
+				hooksPath,
+				managedHookOptions,
+			)
+		: planManagedCodexHooksMerge(
+			existingHooksContent,
 			pkgRoot,
 			hooksPath,
-			{ platform: process.platform, codexHomeDir },
+			managedHookOptions,
 		);
-	if (nextConfig !== existingConfig) {
-		if (
-			await ensureBackup(
-				configPath,
-				existsSync(configPath),
-				backupContext,
-				options,
-			)
-		) {
-			summary.backedUp += 1;
-		}
-		if (!options.dryRun) {
-			await mkdir(dirname(configPath), { recursive: true });
-			await writeFile(configPath, nextConfig);
-		}
-		summary.updated += 1;
-	} else {
-		summary.unchanged += 1;
-	}
+	if (managedHooksPlan && !managedHooksPlan.ok) throw managedHooksPlan.error;
 
-	const existingHooksContent = existsSync(hooksPath)
-		? await readFile(hooksPath, "utf-8")
-		: null;
-	await migrateLegacyHooksJsonTrustStateToConfig(
-		configPath,
-		existingHooksContent,
-		backupContext,
-		summary,
+	const managedHookTrustState = managedHooksPlan?.finalTrustState ?? {};
+	const priorManagedHookTrustState = managedHooksPlan?.priorTrustState ?? {};
+	const legacyHookTrustState = managedHooksPlan?.legacyTrustState ?? {};
+	const configAfterLegacyCleanup = buildPluginModeLegacyConfig(
+		existingConfig,
 		options,
 	);
-	if (options.pluginScopedHooks) {
-		await cleanupPluginModeManagedHooksJson(
-			existingHooksContent,
-			hooksPath,
-			backupContext,
-			summary,
-			options,
-		);
-	} else {
-		const hooksConfig = mergeManagedCodexHooksConfig(
-			existingHooksContent,
+	const configWithRuntimeFeatures = upsertPluginModeRuntimeFeatureFlags(
+		configAfterLegacyCleanup,
+		options.codexHookFeatureFlag,
+		{
+			pluginScopedHooks: options.pluginScopedHooks,
+			preserveNativeHooks:
+				options.pluginScopedHooks && managedHooksPlan?.hasForeignHooks === true,
+		},
+	);
+	return {
+		finalConfig: upsertManagedCodexHookTrustState(
+			configWithRuntimeFeatures,
 			pkgRoot,
 			hooksPath,
-			{ platform: process.platform, codexHomeDir },
-		);
-		await syncManagedContent(
-			hooksConfig,
-			hooksPath,
-			summary,
-			backupContext,
-			options,
-			`native hooks ${hooksPath}`,
-		);
-		await syncManagedWindowsNativeHookShim(
-			codexHomeDir,
-			pkgRoot,
-			summary,
-			backupContext,
-			options,
-		);
-	}
-
-	if (options.verbose) {
-		const surface = options.pluginScopedHooks
-			? "official plugin-scoped hooks"
-			: `legacy native hooks at ${hooksPath}`;
-		console.log(
-			`  ${options.dryRun ? "would configure" : "configured"} plugin-mode ${surface} and runtime feature flags`,
-		);
-	}
+			{
+				...managedHookOptions,
+				managedTrustState: managedHookTrustState,
+				priorManagedHookTrustState,
+				legacyHookTrustState,
+			},
+		),
+		hooksFinalContent: managedHooksPlan ? managedHooksPlan.finalContent : existingHooksContent,
+	hooksRemovedCount: managedHooksPlan?.removedCount ?? 0,
+		cleanedLegacyConfig: configAfterLegacyCleanup !== existingConfig,
+		diagnostics: managedHooksPlan?.diagnostics ?? [],
+	};
 }
 
-async function applyPluginDeveloperInstructionsDefault(
-	configPath: string,
-	backupContext: SetupBackupContext,
-	summary: SetupCategorySummary,
-	options: Pick<SetupOptions, "dryRun" | "verbose"> & {
-		decision: PluginDeveloperInstructionsDecision;
-	},
-): Promise<"updated" | "exists" | "skipped"> {
-	const existing = existsSync(configPath)
-		? await readFile(configPath, "utf-8")
-		: "";
-	if (options.decision.action === "preserve") {
-		summary.skipped += 1;
-		if (options.verbose) {
-			console.log(
-				`  preserved plugin developer_instructions default: ${options.decision.reason}`,
-			);
-		}
-		return options.decision.state === "missing" ? "skipped" : "exists";
+interface PluginDeveloperInstructionsConfigPlan {
+	finalConfig: string;
+	result: "updated" | "exists" | "skipped";
+}
+
+function buildPluginDeveloperInstructionsConfigPlan(
+	existingConfig: string,
+	decision: PluginDeveloperInstructionsDecision,
+): PluginDeveloperInstructionsConfigPlan {
+	if (decision.action === "preserve") {
+		return {
+			finalConfig: existingConfig,
+			result: decision.state === "missing" ? "skipped" : "exists",
+		};
 	}
 
 	const line = `developer_instructions = ${JSON.stringify(OMX_PLUGIN_DEVELOPER_INSTRUCTIONS)}`;
 	const hasExistingDeveloperInstructions = rootHasTomlKey(
-		existing,
+		existingConfig,
 		"developer_instructions",
 	);
-	if (hasExistingDeveloperInstructions && options.decision.action === "add") {
-		summary.skipped += 1;
-		if (options.verbose) {
-			console.log(
-				"  skipped plugin developer_instructions default: root developer_instructions already exists",
-			);
-		}
-		return "exists";
+	if (hasExistingDeveloperInstructions && decision.action === "add") {
+		return { finalConfig: existingConfig, result: "exists" };
 	}
-
-	const nextConfig = hasExistingDeveloperInstructions
-		? replaceRootTomlKey(existing, "developer_instructions", line)
-		: insertRootTomlKey(existing, line);
-	const destinationExists = existsSync(configPath);
-	if (
-		await ensureBackup(configPath, destinationExists, backupContext, options)
-	) {
-		summary.backedUp += 1;
-	}
-	if (!options.dryRun) {
-		await mkdir(dirname(configPath), { recursive: true });
-		await writeFile(configPath, nextConfig);
-	}
-	summary.updated += 1;
-	if (options.verbose) {
-		console.log(
-			`  ${options.dryRun ? "would add" : "added"} plugin developer_instructions default to ${configPath}`,
-		);
-	}
-	return "updated";
+	return {
+		finalConfig: hasExistingDeveloperInstructions
+			? replaceRootTomlKey(existingConfig, "developer_instructions", line)
+			: insertRootTomlKey(existingConfig, line),
+		result: "updated",
+	};
 }
 
-async function cleanupPluginModeLegacyConfig(
-	configPath: string,
-	backupContext: SetupBackupContext,
-	options: Pick<SetupOptions, "dryRun" | "verbose"> & {
+function buildPluginModeLegacyConfig(
+	original: string,
+	options: {
 		preserveFirstPartyMcp?: boolean;
 		developerInstructionsDecision: PluginDeveloperInstructionsDecision;
 	},
-): Promise<boolean> {
-	if (!existsSync(configPath)) return false;
-
-	const original = await readFile(configPath, "utf-8");
+): string {
 	const preservedFirstPartyMcp = options.preserveFirstPartyMcp
 		? extractFirstPartyOmxMcpSections(original)
 		: "";
@@ -2032,26 +2725,317 @@ async function cleanupPluginModeLegacyConfig(
 		config = `${config.trimEnd()}\n\n${preservedFirstPartyMcp}\n`;
 	}
 	config = config.trim();
-	const nextConfig = config.length > 0 ? `${config}\n` : "";
+	return config.length > 0 ? `${config}\n` : "";
+}
 
-	if (nextConfig === original) return false;
+interface NativeHookSetupTransactionPlan {
+	artifacts: NativeHookTransactionArtifact[];
+	preconditions: NativeHookTransactionPrecondition[];
+	finalConfig: string;
+	hooksRemovedCount: number;
+	pluginScopedHooks: boolean;
+	cleanedLegacyConfig: boolean;
+	pluginMarketplaceResult: "updated" | "unchanged" | "unavailable";
+	pluginDeveloperInstructionsResult: "updated" | "exists" | "skipped";
+	diagnostics: readonly { message: string }[];
+	modelUpgrade?: { currentModel: string; modelOverride: string };
+	repairedLegacyTeamRunTable: boolean;
+}
 
-	if (await ensureBackup(configPath, true, backupContext, options)) {
-		// backup created for pre-existing config
-	}
-	if (!options.dryRun) {
-		if (nextConfig.length === 0) {
-			await rm(configPath, { force: true });
+interface PlanNativeHookSetupTransactionOptions {
+	configPath: string;
+	hooksPath: string;
+	codexHomeDir: string;
+	pkgRoot: string;
+	platform: NodeJS.Platform;
+	isPluginInstallMode: boolean;
+	pluginScopedHooks: boolean;
+	codexHookFeatureFlag: CodexHookFeatureFlag;
+	preserveFirstPartyMcp: boolean;
+	removeFirstPartyMcp: boolean;
+	pluginDeveloperInstructionsDecision: PluginDeveloperInstructionsDecision;
+	pluginMarketplaceAvailable: boolean;
+	sharedMcpRegistry: UnifiedMcpRegistryLoadResult;
+	mcpMode: SetupMcpMode;
+	resolvedScope: SetupScope;
+	modelUpgradePrompt?: SetupOptions["modelUpgradePrompt"];
+	statusLinePreset?: HudPreset;
+	forceStatusLinePreset: boolean;
+	configSnapshot: NativeHookTransactionArtifactSnapshot;
+	notifyMetadataSnapshot?: NativeHookTransactionArtifactSnapshot;
+}
+
+async function planNativeHookSetupTransaction(
+	options: PlanNativeHookSetupTransactionOptions,
+): Promise<NativeHookSetupTransactionPlan> {
+	const existingConfigSnapshot = options.configSnapshot;
+	const existingHooksSnapshot = await captureNativeHookTransactionArtifact(
+		options.hooksPath,
+		`native hooks ${options.hooksPath}`,
+	);
+	const existingConfig = existingConfigSnapshot.bytes
+		? decodeNativeHookTransactionUtf8(
+			existingConfigSnapshot.bytes,
+			`config ${options.configPath}`,
+		)
+		: "";
+	const existingHooksContent = existingHooksSnapshot.bytes
+		? decodeNativeHookTransactionUtf8(
+			existingHooksSnapshot.bytes,
+			`native hooks ${options.hooksPath}`,
+		)
+		: null;
+	let finalConfig = existingConfig;
+	let finalHooksContent = existingHooksContent;
+	let hooksRemovedCount = 0;
+	let cleanedLegacyConfig = false;
+	let pluginMarketplaceResult: NativeHookSetupTransactionPlan["pluginMarketplaceResult"] = "unchanged";
+	let pluginDeveloperInstructionsResult: NativeHookSetupTransactionPlan["pluginDeveloperInstructionsResult"] = "skipped";
+	let diagnostics: readonly { message: string }[] = [];
+	let notifyMetadataArtifact: NativeHookTransactionArtifact | null = null;
+	let notifyMetadataPrecondition: NativeHookTransactionPrecondition | null = null;
+	let modelUpgrade: NativeHookSetupTransactionPlan["modelUpgrade"];
+	let repairedLegacyTeamRunTable = false;
+
+	if (options.isPluginInstallMode) {
+		const pluginPlan = buildPluginModeHooksConfigPlan(
+			existingConfig,
+			existingHooksContent,
+			options.pkgRoot,
+			options.hooksPath,
+			options.codexHomeDir,
+			{
+				codexHookFeatureFlag: options.codexHookFeatureFlag,
+				pluginScopedHooks: options.pluginScopedHooks,
+				preserveFirstPartyMcp: options.preserveFirstPartyMcp,
+				developerInstructionsDecision:
+					options.pluginDeveloperInstructionsDecision,
+				platform: options.platform,
+			},
+		);
+		finalConfig = pluginPlan.finalConfig;
+		finalHooksContent = pluginPlan.hooksFinalContent;
+		hooksRemovedCount = pluginPlan.hooksRemovedCount;
+		cleanedLegacyConfig = pluginPlan.cleanedLegacyConfig;
+		diagnostics = pluginPlan.diagnostics;
+
+		if (options.pluginMarketplaceAvailable) {
+			const withMarketplace = upsertLocalOmxMarketplaceRegistration(
+				upsertLocalOmxPluginMcpServerEnablement(
+					upsertLocalOmxPluginEnablement(finalConfig),
+					options.mcpMode === "compat",
+					{ removeWhenDisabled: options.removeFirstPartyMcp },
+				),
+				options.pkgRoot,
+			);
+			pluginMarketplaceResult =
+				withMarketplace === finalConfig ? "unchanged" : "updated";
+			finalConfig = withMarketplace;
 		} else {
-			await writeFile(configPath, nextConfig);
+			pluginMarketplaceResult = "unavailable";
+		}
+		const developerInstructionsPlan = buildPluginDeveloperInstructionsConfigPlan(
+			finalConfig,
+			options.pluginDeveloperInstructionsDecision,
+		);
+		finalConfig = developerInstructionsPlan.finalConfig;
+		pluginDeveloperInstructionsResult = developerInstructionsPlan.result;
+	} else {
+		const managedHooksPlan = planManagedCodexHooksMerge(
+			existingHooksContent,
+			options.pkgRoot,
+			options.hooksPath,
+			{
+				platform: options.platform,
+				codexHomeDir: options.codexHomeDir,
+			},
+		);
+		if (!managedHooksPlan.ok) throw managedHooksPlan.error;
+		if (managedHooksPlan.finalContent === null) {
+			throw new Error("Native hook merge unexpectedly produced no hooks.json content.");
+		}
+		finalHooksContent = managedHooksPlan.finalContent;
+		hooksRemovedCount = managedHooksPlan.removedCount;
+		diagnostics = managedHooksPlan.diagnostics;
+		const managedConfigPlan = await planManagedConfig(
+			options.hooksPath,
+			options.pkgRoot,
+			options.sharedMcpRegistry,
+			options.mcpMode,
+			options.preserveFirstPartyMcp,
+			options.resolvedScope,
+			options.codexHomeDir,
+			{
+				modelUpgradePrompt: options.modelUpgradePrompt,
+				existingConfig,
+				verbose: false,
+				statusLinePreset: options.statusLinePreset,
+				forceStatusLinePreset: options.forceStatusLinePreset,
+				codexHookFeatureFlag: options.codexHookFeatureFlag,
+				managedHookTrustState: managedHooksPlan.finalTrustState,
+				priorManagedHookTrustState: managedHooksPlan.priorTrustState,
+				legacyHookTrustState: managedHooksPlan.legacyTrustState,
+				hookCommandPlatform: options.platform,
+				notifyMetadataSnapshot: options.notifyMetadataSnapshot,
+			},
+		);
+		finalConfig = managedConfigPlan.finalConfig;
+		if (
+			managedConfigPlan.currentModel &&
+			managedConfigPlan.modelOverride &&
+			managedConfigPlan.currentModel !== managedConfigPlan.modelOverride
+		) {
+			modelUpgrade = {
+				currentModel: managedConfigPlan.currentModel,
+				modelOverride: managedConfigPlan.modelOverride,
+			};
+		}
+		repairedLegacyTeamRunTable = managedConfigPlan.repairedLegacyTeamRunTable;
+		const notifyPlan = managedConfigPlan.notifyPlan;
+		if (notifyPlan.metadataSnapshot && notifyPlan.metadataPath) {
+			notifyMetadataPrecondition = nativeHookTransactionPrecondition(
+				"metadata",
+				notifyPlan.metadataPath,
+				`notification metadata ${notifyPlan.metadataPath}`,
+				notifyPlan.metadataSnapshot,
+			);
+		}
+		if (notifyPlan.metadataPath && notifyPlan.metadata) {
+			const metadataBefore = options.notifyMetadataSnapshot;
+			if (!metadataBefore) {
+				throw new Error(
+					`Missing notification metadata snapshot for ${notifyPlan.metadataPath}; refusing to plan from a newly captured baseline.`,
+				);
+			}
+			notifyMetadataArtifact = nativeHookTransactionArtifact(
+				"metadata",
+				notifyPlan.metadataPath,
+				`notification metadata ${notifyPlan.metadataPath}`,
+				metadataBefore,
+				Buffer.from(JSON.stringify(notifyPlan.metadata, null, 2) + "\n", "utf-8"),
+			);
+			if (!notifyMetadataPrecondition) {
+				notifyMetadataPrecondition = nativeHookTransactionPrecondition(
+					"metadata",
+					notifyPlan.metadataPath,
+					`notification metadata ${notifyPlan.metadataPath}`,
+					metadataBefore,
+				);
+			}
 		}
 	}
-	if (options.verbose) {
-		console.log(
-			`  ${options.dryRun ? "would clean" : nextConfig.length === 0 ? "removed" : "cleaned"} legacy OMX config ${basename(configPath)}`,
+
+	if (options.isPluginInstallMode && options.sharedMcpRegistry.servers.length > 0) {
+		finalConfig = mergeSharedMcpRegistryBlock(
+			finalConfig,
+			options.sharedMcpRegistry.servers,
+			options.sharedMcpRegistry.sourcePath,
 		);
 	}
-	return true;
+	try {
+		TOML.parse(finalConfig);
+	} catch (error) {
+		throw new Error(
+			`Refusing to write invalid planned config.toml: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+
+	const hookArtifact = nativeHookTransactionArtifact(
+		"hooks",
+		options.hooksPath,
+		`native hooks ${options.hooksPath}`,
+		existingHooksSnapshot,
+		finalHooksContent === null ? null : Buffer.from(finalHooksContent, "utf-8"),
+		options.platform,
+	);
+	const configArtifact = nativeHookTransactionArtifact(
+		"config",
+		options.configPath,
+		`config ${options.configPath}`,
+		existingConfigSnapshot,
+		Buffer.from(finalConfig, "utf-8"),
+	);
+
+	let shimArtifact: NativeHookTransactionArtifact | null = null;
+	let shimPrecondition: NativeHookTransactionPrecondition | null = null;
+	if (options.platform === "win32") {
+		const shimPath = buildManagedCodexNativeHookWindowsShimPath(options.codexHomeDir);
+		const shimSnapshot = await captureNativeHookTransactionArtifact(
+			shimPath,
+			`native hook Windows shim ${shimPath}`,
+		);
+		const shimAfter = Buffer.from(
+			buildManagedCodexNativeHookWindowsShimContent(options.pkgRoot),
+			"utf-8",
+		);
+		assertWindowsNativeHookShimOwnership(shimPath, shimSnapshot.bytes, shimAfter);
+		const shimReferencedByFinalHooks = finalHooksContent
+			?.toLowerCase()
+			.includes("omx-native-hook-windows-shim.ps1")
+			?? false;
+		shimArtifact = nativeHookTransactionArtifact(
+			"shim",
+			shimPath,
+			`native hook Windows shim ${shimPath}`,
+			shimSnapshot,
+			options.isPluginInstallMode && options.pluginScopedHooks && !shimReferencedByFinalHooks
+				? null
+				: shimAfter,
+		);
+		shimPrecondition = nativeHookTransactionPrecondition(
+			"shim",
+			shimPath,
+			`native hook Windows shim ${shimPath}`,
+			shimSnapshot,
+		);
+	}
+
+	const windowsShimCreateOrUpdateArtifact =
+		shimArtifact && shimArtifact.after !== null ? shimArtifact : null;
+	const windowsShimDeletionArtifact =
+		shimArtifact && shimArtifact.after === null ? shimArtifact : null;
+	const artifacts = options.platform === "win32"
+		? [
+				windowsShimCreateOrUpdateArtifact,
+				hookArtifact,
+				notifyMetadataArtifact,
+				configArtifact,
+				windowsShimDeletionArtifact,
+			]
+		: [hookArtifact, notifyMetadataArtifact, configArtifact];
+	const preconditions = [
+		shimPrecondition,
+		nativeHookTransactionPrecondition(
+			"hooks",
+			options.hooksPath,
+			`native hooks ${options.hooksPath}`,
+			existingHooksSnapshot,
+		),
+		nativeHookTransactionPrecondition(
+			"config",
+			options.configPath,
+			`config ${options.configPath}`,
+			existingConfigSnapshot,
+		),
+		notifyMetadataPrecondition,
+	];
+	return {
+		artifacts: artifacts.filter(
+			(artifact): artifact is NativeHookTransactionArtifact => artifact !== null,
+		),
+		preconditions: preconditions.filter(
+			(precondition): precondition is NativeHookTransactionPrecondition => precondition !== null,
+		),
+		finalConfig,
+		hooksRemovedCount,
+		pluginScopedHooks: options.pluginScopedHooks,
+		cleanedLegacyConfig,
+		pluginMarketplaceResult,
+		pluginDeveloperInstructionsResult,
+		diagnostics,
+		modelUpgrade,
+		repairedLegacyTeamRunTable,
+	};
 }
 
 export async function setup(options: SetupOptions = {}): Promise<void> {
@@ -2175,9 +3159,45 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		requestedSkipNativeAgentRefresh ||
 		process.env[SKIP_NATIVE_AGENT_REFRESH_ENV] === "1";
 	const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot);
-	const existingConfigForMcpMigration = existsSync(scopeDirs.codexConfigFile)
-		? await readFile(scopeDirs.codexConfigFile, "utf-8")
+	const nativeHookTransactionPlatform = nativeHookPlatform();
+	const nativeHookTransactionAncestorPrecondition =
+		await captureNativeHookTransactionAncestorPrecondition(
+			scopeDirs.codexHomeDir,
+			[
+				scopeDirs.codexConfigFile,
+				scopeDirs.codexHooksFile,
+				getNotifyMetadataPath(scopeDirs.codexHomeDir),
+				...(nativeHookTransactionPlatform === "win32"
+					? [
+							buildManagedCodexNativeHookWindowsShimPath(
+								scopeDirs.codexHomeDir,
+							),
+						]
+					: []),
+			],
+		);
+
+	const existingConfigForMcpMigrationSnapshot =
+		await captureNativeHookTransactionArtifact(
+			scopeDirs.codexConfigFile,
+			`config ${scopeDirs.codexConfigFile}`,
+		);
+	const existingConfigForMcpMigration = existingConfigForMcpMigrationSnapshot.bytes
+		? decodeNativeHookTransactionUtf8(
+			existingConfigForMcpMigrationSnapshot.bytes,
+			`config ${scopeDirs.codexConfigFile}`,
+		)
 		: "";
+	const notifyMetadataSnapshot = configRequiresNotificationMetadataSnapshot(
+		existingConfigForMcpMigration,
+		pkgRoot,
+		resolvedScope.scope,
+	)
+		? await captureNativeHookTransactionArtifact(
+			getNotifyMetadataPath(scopeDirs.codexHomeDir),
+			`notification metadata ${getNotifyMetadataPath(scopeDirs.codexHomeDir)}`,
+		)
+		: undefined;
 	const firstPartyMcpRegistrationKinds = [
 		hasFirstPartyOmxMcpRegistrations(existingConfigForMcpMigration)
 			? "config.toml [mcp_servers.omx_*]"
@@ -2217,14 +3237,15 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 	const pluginDeveloperInstructionsDecision: PluginDeveloperInstructionsDecision =
 		isPluginInstallMode
 			? await resolvePluginDeveloperInstructionsDecision(
-					scopeDirs.codexConfigFile,
-					{ pluginDeveloperInstructionsPrompt },
-				)
+				existingConfigForMcpMigration,
+				scopeDirs.codexConfigFile,
+				{ pluginDeveloperInstructionsPrompt },
+			)
 			: {
-					action: "preserve",
-					state: "custom",
-					reason: "non-plugin setup mode",
-				};
+				action: "preserve",
+				state: "custom",
+				reason: "non-plugin setup mode",
+			};
 	let pluginAgentsMdPathExists = false;
 	let pluginAgentsMdIsSymlink = false;
 	try {
@@ -2244,6 +3265,60 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 					? await pluginAgentsMdPrompt(pluginAgentsMdDst)
 					: await promptForPluginAgentsMdDefault(pluginAgentsMdDst)
 		: false;
+	const codexHookFeatureSupport = resolveCodexHookFeatureSupportForCli({
+		codexFeaturesProbe: options.codexFeaturesProbe,
+		codexVersionProbe: options.codexVersionProbe,
+	});
+	const codexHookFeatureFlag = codexHookFeatureSupport.hookFeatureFlag;
+	const pluginScopedHooksSupported = codexHookFeatureSupport.pluginScopedHooks;
+	const shouldSyncSharedMcpRegistry = resolvedMcpMode.mcpMode === "compat";
+	const registryCandidates = getUnifiedMcpRegistryCandidates();
+	const defaultRegistryCandidates = registryCandidates.slice(0, 1);
+	const sharedMcpRegistry: UnifiedMcpRegistryLoadResult = shouldSyncSharedMcpRegistry
+		? await loadUnifiedMcpRegistry({
+				candidates: options.mcpRegistryCandidates ?? defaultRegistryCandidates,
+			})
+		: { servers: [], warnings: [] };
+	const legacyRegistryCandidate = getLegacyUnifiedMcpRegistryCandidate();
+	const preflightMarketplace = isPluginInstallMode
+		? await resolvePackagedOmxMarketplace(pkgRoot)
+		: null;
+	const statusLinePreset = isPluginInstallMode
+		? undefined
+		: await resolveStatusLinePresetForSetup(projectRoot, { force });
+	const nativeHookSetupTransaction = await planNativeHookSetupTransaction({
+		configPath: scopeDirs.codexConfigFile,
+		hooksPath: scopeDirs.codexHooksFile,
+		codexHomeDir: scopeDirs.codexHomeDir,
+		pkgRoot,
+		platform: nativeHookTransactionPlatform,
+
+		isPluginInstallMode,
+		pluginScopedHooks: pluginScopedHooksSupported,
+		codexHookFeatureFlag,
+		preserveFirstPartyMcp:
+			shouldOfferFirstPartyMcpRemoval && !removeFirstPartyMcpRegistrations,
+		removeFirstPartyMcp: removeFirstPartyMcpRegistrations,
+		pluginDeveloperInstructionsDecision,
+		pluginMarketplaceAvailable: preflightMarketplace !== null,
+		sharedMcpRegistry,
+		mcpMode: resolvedMcpMode.mcpMode,
+		resolvedScope: resolvedScope.scope,
+		modelUpgradePrompt,
+		statusLinePreset,
+		forceStatusLinePreset: force,
+		configSnapshot: existingConfigForMcpMigrationSnapshot,
+		notifyMetadataSnapshot,
+	});
+	const summary = createEmptyRunSummary();
+	await commitNativeHookTransaction(
+		nativeHookSetupTransaction.artifacts,
+		nativeHookSetupTransaction.preconditions,
+		nativeHookTransactionAncestorPrecondition,
+		backupContext,
+		summary.config,
+		{ dryRun, verbose },
+	);
 
 	console.log("oh-my-codex setup");
 	console.log("=================\n");
@@ -2337,7 +3412,6 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 	}
 
 	const catalogCounts = getCatalogHeadlineCounts();
-	const summary = createEmptyRunSummary();
 
 	// Step 2: Install agent prompts
 	console.log("[2/8] Installing agent prompts...");
@@ -2485,14 +3559,8 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 
 	// Step 5: Update config.toml
 	console.log("[5/8] Updating config.toml...");
-	let resolvedConfig = "";
-	let omxManagesTui = false;
-	const codexHookFeatureSupport = resolveCodexHookFeatureSupportForCli({
-		codexFeaturesProbe: options.codexFeaturesProbe,
-		codexVersionProbe: options.codexVersionProbe,
-	});
-	const codexHookFeatureFlag = codexHookFeatureSupport.hookFeatureFlag;
-	const pluginScopedHooksSupported = codexHookFeatureSupport.pluginScopedHooks;
+	const resolvedConfig = nativeHookSetupTransaction.finalConfig;
+	const omxManagesTui = !isPluginInstallMode;
 	if (verbose) {
 		console.log(
 			`  Native Codex hook feature flag: [features].${codexHookFeatureFlag}`,
@@ -2501,15 +3569,6 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			`  Plugin-scoped Codex hooks: ${pluginScopedHooksSupported ? "supported" : "not reported; using legacy setup fallback"}`,
 		);
 	}
-	const shouldSyncSharedMcpRegistry = resolvedMcpMode.mcpMode === "compat";
-	const registryCandidates = getUnifiedMcpRegistryCandidates();
-	const defaultRegistryCandidates = registryCandidates.slice(0, 1);
-	const sharedMcpRegistry: UnifiedMcpRegistryLoadResult = shouldSyncSharedMcpRegistry
-		? await loadUnifiedMcpRegistry({
-				candidates: options.mcpRegistryCandidates ?? defaultRegistryCandidates,
-			})
-		: { servers: [], warnings: [] };
-	const legacyRegistryCandidate = getLegacyUnifiedMcpRegistryCandidate();
 	if (
 		shouldSyncSharedMcpRegistry &&
 		!options.mcpRegistryCandidates &&
@@ -2529,54 +3588,54 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 	for (const warning of sharedMcpRegistry.warnings) {
 		console.log(`  warning: ${warning}`);
 	}
-	if (isPluginInstallMode) {
-		const configCleaned = await cleanupPluginModeLegacyConfig(
-			scopeDirs.codexConfigFile,
-			backupContext,
-			{
-				dryRun,
-				verbose,
-				preserveFirstPartyMcp:
-					shouldOfferFirstPartyMcpRemoval &&
-					!removeFirstPartyMcpRegistrations,
-				developerInstructionsDecision: pluginDeveloperInstructionsDecision,
-			},
-		);
-		if (configCleaned) summary.config.removed += 1;
+	logManagedCodexHooksPlanDiagnostics(nativeHookSetupTransaction.diagnostics, {
+		verbose,
+	});
+	const changedHookArtifact = nativeHookSetupTransaction.artifacts.some(
+		(artifact) => artifact.kind === "hooks",
+	);
+	const changedShimArtifact = nativeHookSetupTransaction.artifacts.some(
+		(artifact) => artifact.kind === "shim",
+	);
+	const changedConfigArtifact = nativeHookSetupTransaction.artifacts.some(
+		(artifact) => artifact.kind === "config",
+	);
+	if (changedHookArtifact) {
+		if (
+			isPluginInstallMode &&
+			nativeHookSetupTransaction.pluginScopedHooks &&
+			nativeHookSetupTransaction.hooksRemovedCount > 0
+		) {
+			summary.config.removed += nativeHookSetupTransaction.hooksRemovedCount;
+		} else {
+			summary.config.updated += 1;
+		}
+	} else if (!isPluginInstallMode || !nativeHookSetupTransaction.pluginScopedHooks) {
+		summary.config.unchanged += 1;
+	}
+	if (changedShimArtifact) summary.config.updated += 1;
+	if (changedConfigArtifact) summary.config.updated += 1;
+	else summary.config.unchanged += 1;
+	if (verbose && nativeHookSetupTransaction.modelUpgrade) {
 		console.log(
-			configCleaned
-				? `  ${dryRun ? "Would clean" : "Cleaned"} legacy OMX config entries for plugin mode.\n`
-				: "  Config refresh skipped; no legacy OMX config entries found.\n",
+			`  ${dryRun ? "would update" : "updated"} root model from ${nativeHookSetupTransaction.modelUpgrade.currentModel} to ${nativeHookSetupTransaction.modelUpgrade.modelOverride}`,
 		);
+	}
 
-		await applyPluginModeHooksConfig(
-			scopeDirs.codexConfigFile,
-			scopeDirs.codexHooksFile,
-			pkgRoot,
-			scopeDirs.codexHomeDir,
-			backupContext,
-			summary.config,
-			{
-				dryRun,
-				verbose,
-				codexHookFeatureFlag,
-				pluginScopedHooks: pluginScopedHooksSupported,
-			},
-		);
-		const pluginMarketplaceResult = await ensurePluginMarketplaceRegistration(
-			scopeDirs.codexConfigFile,
-			pkgRoot,
-			resolvedMcpMode.mcpMode,
-			removeFirstPartyMcpRegistrations,
-			backupContext,
-			summary.config,
-			{ dryRun, verbose },
-		);
-		if (pluginMarketplaceResult === "unavailable") {
+	if (isPluginInstallMode) {
+		if (nativeHookSetupTransaction.cleanedLegacyConfig) {
+			summary.config.removed += 1;
+			console.log(
+				`  ${dryRun ? "Would clean" : "Cleaned"} legacy OMX config entries for plugin mode.\n`,
+			);
+		} else {
+			console.log("  Config refresh skipped; no legacy OMX config entries found.\n");
+		}
+		if (nativeHookSetupTransaction.pluginMarketplaceResult === "unavailable") {
 			console.log(
 				`  warning: packaged ${OMX_LOCAL_MARKETPLACE_NAME} Codex plugin marketplace metadata not found; /skills plugin discovery was not registered.`,
 			);
-		} else if (pluginMarketplaceResult === "updated") {
+		} else if (nativeHookSetupTransaction.pluginMarketplaceResult === "updated") {
 			console.log(
 				`  ${dryRun ? "Would register" : "Registered"} local Codex plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} (${pkgRoot}).`,
 			);
@@ -2585,7 +3644,6 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				`  Local Codex plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} already registered (${pkgRoot}).`,
 			);
 		}
-		const packagedMarketplace = await resolvePackagedOmxMarketplace(pkgRoot);
 		const pluginCacheRefresh = await refreshOmxPluginDiscoveryCache(
 			pkgRoot,
 			{
@@ -2605,7 +3663,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		}
 		const pluginCacheMaterialize = await materializePackagedOmxPluginCache(
 			scopeDirs.codexHomeDir,
-			packagedMarketplace,
+			preflightMarketplace,
 			{ dryRun, teamMode: resolvedTeamMode },
 		);
 		if (pluginCacheMaterialize.status === "materialized") {
@@ -2615,51 +3673,27 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		} else if (pluginCacheMaterialize.status === "unchanged") {
 			console.log("  Local Codex plugin cache already exposes packaged OMX skills.");
 		}
-		if (pluginCacheMaterialize.status === "materialized" || pluginCacheMaterialize.status === "unchanged") {
+		if (
+			pluginCacheMaterialize.status === "materialized" ||
+			pluginCacheMaterialize.status === "unchanged"
+		) {
 			console.log("  Start a new Codex session if /skills still shows stale OMX plugin skill metadata; the current session may keep its in-memory plugin registry until restart.");
 		}
-		if (shouldSyncSharedMcpRegistry) {
-			resolvedConfig = await syncSharedMcpRegistryIntoConfig(
-				scopeDirs.codexConfigFile,
+		if (shouldSyncSharedMcpRegistry && resolvedScope.scope === "user") {
+			await syncClaudeCodeMcpSettings(
 				sharedMcpRegistry,
 				summary.config,
 				backupContext,
 				{ dryRun, verbose },
 			);
-			if (resolvedScope.scope === "user") {
-				await syncClaudeCodeMcpSettings(
-					sharedMcpRegistry,
-					summary.config,
-					backupContext,
-					{ dryRun, verbose },
-				);
-			}
 		}
-		resolvedConfig = existsSync(scopeDirs.codexConfigFile)
-			? await readFile(scopeDirs.codexConfigFile, "utf-8")
-			: "";
 		console.log(
 			pluginScopedHooksSupported
 				? "  Plugin-scoped Codex hooks and runtime feature flags refresh complete (plugin_hooks, goals).\n"
 				: `  Native Codex hooks fallback and runtime feature flags refresh complete (${scopeDirs.codexHooksFile}; hooks, goals).\n`,
 		);
-
 		if (pluginDeveloperInstructionsDecision.action !== "preserve") {
-			const developerInstructionsResult =
-				await applyPluginDeveloperInstructionsDefault(
-					scopeDirs.codexConfigFile,
-					backupContext,
-					summary.config,
-					{
-						dryRun,
-						verbose,
-						decision: pluginDeveloperInstructionsDecision,
-					},
-				);
-			if (developerInstructionsResult === "updated") {
-				resolvedConfig = existsSync(scopeDirs.codexConfigFile)
-					? await readFile(scopeDirs.codexConfigFile, "utf-8")
-					: "";
+			if (nativeHookSetupTransaction.pluginDeveloperInstructionsResult === "updated") {
 				console.log(
 					`  ${dryRun ? "Would add" : "Added"} plugin-mode developer_instructions default (${scopeDirs.codexConfigFile}).\n`,
 				);
@@ -2674,37 +3708,6 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			);
 		}
 	} else {
-		const statusLinePreset = await resolveStatusLinePresetForSetup(
-			projectRoot,
-			{ force },
-		);
-		const managedConfig = await updateManagedConfig(
-			scopeDirs.codexConfigFile,
-			scopeDirs.codexHooksFile,
-			pkgRoot,
-			sharedMcpRegistry,
-			resolvedMcpMode.mcpMode,
-			shouldOfferFirstPartyMcpRemoval && !removeFirstPartyMcpRegistrations,
-			resolvedScope.scope,
-			scopeDirs.codexHomeDir,
-			summary.config,
-			backupContext,
-			{
-				dryRun,
-				modelUpgradePrompt,
-				verbose,
-				statusLinePreset,
-				forceStatusLinePreset: force,
-				codexHookFeatureFlag,
-			},
-		);
-		resolvedConfig = managedConfig.finalConfig;
-		omxManagesTui = managedConfig.omxManagesTui;
-		if (managedConfig.repairedLegacyTeamRunTable) {
-			console.log(
-				"  Removed retired [mcp_servers.omx_team_run] config during refresh.",
-			);
-		}
 		if (shouldSyncSharedMcpRegistry && resolvedScope.scope === "user") {
 			await syncClaudeCodeMcpSettings(
 				sharedMcpRegistry,
@@ -2713,39 +3716,12 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 				{ dryRun, verbose },
 			);
 		}
+		if (nativeHookSetupTransaction.repairedLegacyTeamRunTable) {
+			console.log(
+				"  Removed retired [mcp_servers.omx_team_run] config during refresh.",
+			);
+		}
 		console.log(`  Config refresh complete (${scopeDirs.codexConfigFile}).\n`);
-
-		const existingHooksContent = existsSync(scopeDirs.codexHooksFile)
-			? await readFile(scopeDirs.codexHooksFile, "utf-8")
-			: null;
-		await migrateLegacyHooksJsonTrustStateToConfig(
-			scopeDirs.codexConfigFile,
-			existingHooksContent,
-			backupContext,
-			summary.config,
-			{ dryRun, verbose },
-		);
-		const hooksConfig = mergeManagedCodexHooksConfig(
-			existingHooksContent,
-			pkgRoot,
-			scopeDirs.codexHooksFile,
-			{ platform: process.platform, codexHomeDir: scopeDirs.codexHomeDir },
-		);
-		await syncManagedContent(
-			hooksConfig,
-			scopeDirs.codexHooksFile,
-			summary.config,
-			backupContext,
-			{ dryRun, verbose },
-			`native hooks ${scopeDirs.codexHooksFile}`,
-		);
-		await syncManagedWindowsNativeHookShim(
-			scopeDirs.codexHomeDir,
-			pkgRoot,
-			summary.config,
-			backupContext,
-			{ dryRun, verbose },
-		);
 		console.log(
 			`  Native Codex hooks refresh complete (${scopeDirs.codexHooksFile}).\n`,
 		);
@@ -3442,26 +4418,6 @@ async function syncNativeAgentToml(
 	}
 }
 
-async function syncManagedWindowsNativeHookShim(
-	codexHomeDir: string,
-	pkgRoot: string,
-	summary: SetupCategorySummary,
-	backupContext: SetupBackupContext,
-	options: Pick<SetupOptions, "dryRun" | "verbose">,
-): Promise<void> {
-	if (process.platform !== "win32") return;
-
-	const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
-	const shimContent = buildManagedCodexNativeHookWindowsShimContent(pkgRoot);
-	await syncManagedContent(
-		shimContent,
-		shimPath,
-		summary,
-		backupContext,
-		options,
-		`native hook Windows shim ${shimPath}`,
-	);
-}
 
 async function syncManagedAgentsContent(
 	content: string,
@@ -4105,10 +5061,58 @@ interface NotifyMergePlan {
 	notifyCommand: string[] | false;
 	metadataPath?: string;
 	metadata?: Record<string, unknown>;
+	metadataSnapshot?: NativeHookTransactionArtifactSnapshot;
 }
 
 function getNotifyMetadataPath(codexHomeDir: string): string {
 	return join(codexHomeDir, ".omx", "notify-dispatch.json");
+}
+
+function isOmxDispatcherNotifyCommand(
+	notifyCommand: readonly string[] | null | undefined,
+	pkgRoot: string,
+): boolean {
+	return Boolean(
+		isOmxManagedNotifyCommand(notifyCommand, pkgRoot) &&
+			notifyCommand?.some((part) =>
+				/(?:^|[\\/])notify-dispatcher\.js$/.test(part),
+			),
+	);
+}
+
+function configRequiresNotificationMetadataSnapshot(
+	existingConfig: string,
+	pkgRoot: string,
+	scope: SetupScope,
+): boolean {
+	if (scope === "project") return false;
+	const existingNotify = getRootTomlArray(existingConfig, "notify");
+	return Boolean(
+		existingNotify &&
+			(!isOmxManagedNotifyCommand(existingNotify, pkgRoot) ||
+				isOmxDispatcherNotifyCommand(existingNotify, pkgRoot)),
+	);
+}
+
+function parseNotifyMetadataSnapshot(
+	snapshot: NativeHookTransactionArtifactSnapshot,
+	label: string,
+): Record<string, unknown> | null {
+	if (snapshot.bytes === null) return null;
+	const content = decodeNativeHookTransactionUtf8(snapshot.bytes, label);
+	try {
+		const parsed = JSON.parse(content);
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			throw new Error("expected a JSON object");
+		}
+		return parsed as Record<string, unknown>;
+	} catch (error) {
+		throw new ManagedCodexHooksPlanError(
+			"invalid_document",
+			`Refusing to read ${label}: invalid JSON (${error instanceof Error ? error.message : String(error)}).`,
+			{ label },
+		);
+	}
 }
 
 async function buildNotifyMergePlan(
@@ -4116,6 +5120,7 @@ async function buildNotifyMergePlan(
 	pkgRoot: string,
 	codexHomeDir: string,
 	scope: SetupScope,
+	metadataSnapshot?: NativeHookTransactionArtifactSnapshot,
 ): Promise<NotifyMergePlan> {
 	if (scope === "project") {
 		return { notifyCommand: false };
@@ -4136,45 +5141,44 @@ async function buildNotifyMergePlan(
 	}
 
 	if (isOmxManagedNotifyCommand(existingNotify, pkgRoot)) {
-		if (
-			!existingNotify.some((part) =>
-				/(?:^|[\\/])notify-dispatcher\.js$/.test(part),
-			)
-		) {
+		if (!isOmxDispatcherNotifyCommand(existingNotify, pkgRoot)) {
 			return { notifyCommand: omxNotify };
 		}
-		try {
-			const metadata = JSON.parse(await readFile(metadataPath, "utf-8")) as {
-				previousNotify?: unknown;
-			};
-			const previousNotify = metadata.previousNotify;
-			if (
-				Array.isArray(previousNotify) &&
-				previousNotify.every((item) => typeof item === "string")
-			) {
-				const sanitizedPreviousNotify = sanitizePreviousNotifyCommand(
-					previousNotify,
-					pkgRoot,
-				);
-				if (!sanitizedPreviousNotify) {
-					return { notifyCommand: omxNotify };
-				}
-				return {
-					notifyCommand: dispatcherNotify,
-					metadataPath,
-					metadata: {
-						managedBy: "oh-my-codex",
-						version: 1,
-						previousNotify: sanitizedPreviousNotify,
-						omxNotify,
-						dispatcherNotify,
-					},
-				};
-			}
-		} catch {
-			// Missing dispatcher metadata: fall back to plain OMX notify instead of nesting.
+		if (!metadataSnapshot) {
+			throw new Error(
+				`Missing notification metadata snapshot for ${metadataPath}; refusing to plan from a newly captured baseline.`,
+			);
 		}
-		return { notifyCommand: omxNotify };
+		const metadata = parseNotifyMetadataSnapshot(
+			metadataSnapshot,
+			`notification metadata ${metadataPath}`,
+		);
+		const previousNotify = metadata?.previousNotify;
+		if (
+			Array.isArray(previousNotify) &&
+			previousNotify.every((item) => typeof item === "string")
+		) {
+			const sanitizedPreviousNotify = sanitizePreviousNotifyCommand(
+				previousNotify,
+				pkgRoot,
+			);
+			if (!sanitizedPreviousNotify) {
+				return { notifyCommand: omxNotify, metadataPath, metadataSnapshot };
+			}
+			return {
+				notifyCommand: dispatcherNotify,
+				metadataPath,
+				metadataSnapshot,
+				metadata: {
+					managedBy: "oh-my-codex",
+					version: 1,
+					previousNotify: sanitizedPreviousNotify,
+					omxNotify,
+					dispatcherNotify,
+				},
+			};
+		}
+		return { notifyCommand: omxNotify, metadataPath, metadataSnapshot };
 	}
 
 	return {
@@ -4190,8 +5194,15 @@ async function buildNotifyMergePlan(
 	};
 }
 
-async function updateManagedConfig(
-	configPath: string,
+interface ManagedConfigWritePlan {
+	finalConfig: string;
+	currentModel: string | undefined;
+	modelOverride: string | undefined;
+	notifyPlan: NotifyMergePlan;
+	repairedLegacyTeamRunTable: boolean;
+}
+
+async function planManagedConfig(
 	hooksPath: string,
 	pkgRoot: string,
 	sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
@@ -4199,21 +5210,25 @@ async function updateManagedConfig(
 	preserveExistingFirstPartyMcp: boolean,
 	scope: SetupScope,
 	codexHomeDir: string,
-	summary: SetupCategorySummary,
-	backupContext: SetupBackupContext,
-	options: Pick<SetupOptions, "dryRun" | "verbose" | "modelUpgradePrompt"> & {
+	options: Pick<SetupOptions, "verbose" | "modelUpgradePrompt"> & {
 		statusLinePreset?: HudPreset;
 		forceStatusLinePreset?: boolean;
 		codexHookFeatureFlag: CodexHookFeatureFlag;
+		hookCommandPlatform: NodeJS.Platform;
+		existingConfig?: string;
+		notifyMetadataSnapshot?: NativeHookTransactionArtifactSnapshot;
+		managedHookTrustState: Record<string, { trusted_hash: string }>;
+		priorManagedHookTrustState: Record<string, { trusted_hash: string }>;
+		legacyHookTrustState: Record<
+			string,
+			{ trusted_hash: string; enabled?: boolean }
+		>;
 	},
-): Promise<ManagedConfigResult> {
-	const existing = existsSync(configPath)
-		? await readFile(configPath, "utf-8")
-		: "";
-	const hadLegacyTeamRunTable = hasLegacyOmxTeamRunTable(existing);
-	const currentModel = getRootModelName(existing);
+): Promise<ManagedConfigWritePlan> {
+	const existingConfig = options.existingConfig ?? "";
+	const hadLegacyTeamRunTable = hasLegacyOmxTeamRunTable(existingConfig);
+	const currentModel = getRootModelName(existingConfig);
 	let modelOverride: string | undefined;
-	const omxManagesTui = true;
 
 	if (currentModel && LEGACY_SETUP_MODELS.has(currentModel)) {
 		const shouldPrompt =
@@ -4230,16 +5245,20 @@ async function updateManagedConfig(
 	}
 
 	const notifyPlan = await buildNotifyMergePlan(
-		existing,
+		existingConfig,
 		pkgRoot,
 		codexHomeDir,
 		scope,
+		options.notifyMetadataSnapshot,
 	);
-	const finalConfig = buildMergedConfig(existing, pkgRoot, {
-		includeTui: omxManagesTui,
+	const finalConfig = buildMergedConfig(existingConfig, pkgRoot, {
+		includeTui: true,
 		codexHooksFile: hooksPath,
 		codexHomeDir,
-		hookCommandPlatform: process.platform,
+		hookCommandPlatform: options.hookCommandPlatform,
+		managedHookTrustState: options.managedHookTrustState,
+		priorManagedHookTrustState: options.priorManagedHookTrustState,
+		legacyHookTrustState: options.legacyHookTrustState,
 		codexHookFeatureFlag: options.codexHookFeatureFlag,
 		modelOverride,
 		sharedMcpServers: sharedMcpRegistry.servers,
@@ -4251,108 +5270,17 @@ async function updateManagedConfig(
 		includeFirstPartyMcp: mcpMode === "compat",
 		preserveExistingFirstPartyMcp,
 	});
-	const changed = existing !== finalConfig;
-
-	if (!changed) {
-		summary.unchanged += 1;
-		return {
-			finalConfig,
-			omxManagesTui,
-			repairedLegacyTeamRunTable: false,
-		};
-	}
-
-	if (
-		await ensureBackup(
-			configPath,
-			existsSync(configPath),
-			backupContext,
-			options,
-		)
-	) {
-		summary.backedUp += 1;
-	}
-
-	if (!options.dryRun) {
-		await writeFile(configPath, finalConfig);
-		if (notifyPlan.metadataPath && notifyPlan.metadata) {
-			await mkdir(dirname(notifyPlan.metadataPath), { recursive: true });
-			await writeFile(
-				notifyPlan.metadataPath,
-				JSON.stringify(notifyPlan.metadata, null, 2) + "\n",
-			);
-		}
-	}
-
-	if (
-		options.verbose &&
-		modelOverride &&
-		currentModel &&
-		currentModel !== modelOverride
-	) {
-		console.log(
-			`  ${options.dryRun ? "would update" : "updated"} root model from ${currentModel} to ${modelOverride}`,
-		);
-	}
-
-	summary.updated += 1;
-	if (options.verbose) {
-		console.log(
-			`  ${options.dryRun ? "would update" : "updated"} config ${configPath}`,
-		);
-	}
 	return {
 		finalConfig,
-		omxManagesTui,
+		currentModel,
+		modelOverride,
+		notifyPlan,
 		repairedLegacyTeamRunTable:
 			hadLegacyTeamRunTable && !hasLegacyOmxTeamRunTable(finalConfig),
 	};
 }
 
-async function syncSharedMcpRegistryIntoConfig(
-	configPath: string,
-	sharedMcpRegistry: UnifiedMcpRegistryLoadResult,
-	summary: SetupCategorySummary,
-	backupContext: SetupBackupContext,
-	options: Pick<SetupOptions, "dryRun" | "verbose">,
-): Promise<string> {
-	if (sharedMcpRegistry.servers.length === 0) {
-		return existsSync(configPath) ? await readFile(configPath, "utf-8") : "";
-	}
 
-	const existing = existsSync(configPath)
-		? await readFile(configPath, "utf-8")
-		: "";
-	const finalConfig = mergeSharedMcpRegistryBlock(
-		existing,
-		sharedMcpRegistry.servers,
-		sharedMcpRegistry.sourcePath,
-	);
-	if (existing === finalConfig) {
-		summary.unchanged += 1;
-		return finalConfig;
-	}
-	if (
-		await ensureBackup(
-			configPath,
-			existsSync(configPath),
-			backupContext,
-			options,
-		)
-	) {
-		summary.backedUp += 1;
-	}
-	if (!options.dryRun) {
-		await writeFile(configPath, finalConfig);
-	}
-	summary.updated += 1;
-	if (options.verbose) {
-		console.log(
-			`  ${options.dryRun ? "would sync" : "synced"} shared MCP registry servers into ${configPath}`,
-		);
-	}
-	return finalConfig;
-}
 
 function getClaudeCodeSettingsPath(homeDir = homedir()): string {
 	return join(homeDir, ".claude", "settings.json");

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -15,8 +15,10 @@ import {
 	lstat,
 	rm,
 	open,
+	link,
 	chmod,
 } from "fs/promises";
+
 import { join, dirname, relative, basename, isAbsolute, sep, win32 } from "path";
 
 import { existsSync } from "fs";
@@ -441,20 +443,24 @@ function logManagedCodexHooksPlanDiagnostics(
 }
 
 type NativeHookTransactionArtifactKind = "shim" | "hooks" | "config" | "metadata";
-	type NativeHookTransactionFailureStage =
+type NativeHookTransactionFailureStage =
 	| "before_precondition"
 	| "before_backup"
 	| "before_temp_write"
 	| "before_rename"
+	| "after_final_rename_validation"
 	| "after_rename"
 	| "before_remove"
+	| "after_final_remove_validation"
 	| "after_remove"
 	| "before_readback"
 	| "before_rollback"
 	| "before_rollback_rename"
+	| "after_final_restore_validation"
 	| "before_rollback_remove"
 	| "before_staged_cleanup"
 	| "after_staged_cleanup";
+
 
 type NativeHookTransactionTopology =
 	| { kind: "absent" }
@@ -525,6 +531,8 @@ let nativeHookTransactionTemporaryPathOverride:
 	| ((path: string, purpose: "write" | "delete") => string)
 	| undefined;
 
+
+
 /** @internal Test seam for deterministic atomic-write and rollback coverage. */
 export function setNativeHookTransactionFailureInjectorForTest(
 	injector:
@@ -557,6 +565,8 @@ export function setNativeHookTransactionTemporaryPathForTest(
 	resolver:
 		| ((path: string, purpose: "write" | "delete") => string)
 		| undefined,
+
+
 ): () => void {
 	const previous = nativeHookTransactionTemporaryPathOverride;
 	nativeHookTransactionTemporaryPathOverride = resolver;
@@ -1048,6 +1058,15 @@ function nativeHookTransactionTemporaryPath(
 	);
 }
 
+function nativeHookTransactionClaimPath(path: string): string {
+	nativeHookTransactionSequence += 1;
+	return join(
+		dirname(path),
+		`.${basename(path)}.omx-claim-${process.pid}-${nativeHookTransactionSequence}.tmp`,
+	);
+}
+
+
 async function atomicWriteNativeHookTransactionArtifact(
 	artifact: NativeHookTransactionArtifact,
 	content: Buffer,
@@ -1055,11 +1074,15 @@ async function atomicWriteNativeHookTransactionArtifact(
 	expectedCurrent: NativeHookTransactionArtifactSnapshot,
 	ancestorPrecondition: NativeHookTransactionAncestorPrecondition,
 	onWriteApplied?: (snapshot: NativeHookTransactionArtifactSnapshot) => void,
+	onWriteStabilized?: (snapshot: NativeHookTransactionArtifactSnapshot) => void,
 	assertApplied?: () => Promise<void>,
+
 ): Promise<void> {
 	const temporaryPath = nativeHookTransactionTemporaryPath(artifact.path, "write");
 	let temporaryCreated = false;
 	let temporarySnapshot: NativeHookTransactionArtifactSnapshot | undefined;
+	let claimPath: string | undefined;
+	let claimCreated = false;
 	try {
 		await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
 		await assertApplied?.();
@@ -1125,13 +1148,53 @@ async function atomicWriteNativeHookTransactionArtifact(
 			"read-back",
 		);
 		await assertApplied?.();
+		injectNativeHookTransactionFailure(
+			stage === "write"
+				? "after_final_rename_validation"
+				: "after_final_restore_validation",
+			artifact,
+		);
 
 		if (!temporarySnapshot) {
 			throw new Error("temporary path was not fully captured after writing");
 		}
-		await rename(temporaryPath, artifact.path);
+		await assertNativeHookTransactionArtifactSnapshot(
+			temporaryPath,
+			`${artifact.label} temporary`,
+			temporarySnapshot,
+			"read-back",
+		);
+		if (expectedCurrent.bytes !== null) {
+			claimPath = nativeHookTransactionClaimPath(artifact.path);
+
+
+			await rename(artifact.path, claimPath);
+			claimCreated = true;
+			await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+
+			await assertNativeHookTransactionArtifactSnapshot(
+				claimPath,
+				`${artifact.label} claim`,
+				expectedCurrent,
+				stage === "write" ? "precondition" : "rollback",
+			);
+		}
+		// link() atomically installs only into an absent target; it never replaces a
+		// concurrent object that appeared after the final snapshot validation.
+		const linkedSnapshot: NativeHookTransactionArtifactSnapshot = {
+			...temporarySnapshot,
+			links: (temporarySnapshot.links ?? 0) + 1,
+		};
+		await link(temporaryPath, artifact.path);
+		onWriteApplied?.(linkedSnapshot);
+		await rm(temporaryPath);
 		temporaryCreated = false;
-		onWriteApplied?.(temporarySnapshot);
+		onWriteStabilized?.(temporarySnapshot);
+		if (claimPath) {
+			await rm(claimPath);
+			claimCreated = false;
+		}
+
 		if (stage === "write") {
 			injectNativeHookTransactionFailure("after_rename", artifact);
 		}
@@ -1142,6 +1205,29 @@ async function atomicWriteNativeHookTransactionArtifact(
 			stage === "write" ? "precondition" : "rollback",
 		);
 	} catch (error) {
+		if (claimCreated && claimPath) {
+			try {
+				const claimed = await captureNativeHookTransactionArtifact(
+					claimPath,
+					`${artifact.label} claim`,
+				);
+				await link(claimPath, artifact.path);
+				await rm(claimPath);
+				claimCreated = false;
+				await assertNativeHookTransactionArtifactSnapshot(
+					artifact.path,
+					artifact.label,
+					claimed,
+					stage === "write" ? "precondition" : "rollback",
+				);
+
+			} catch (recoveryError) {
+				const message = error instanceof Error ? error.message : String(error);
+				throw new Error(
+					`Native hook transaction ${stage} failed (${message}) and preserved claim ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
+				);
+			}
+		}
 		if (temporaryCreated) {
 			try {
 				if (!temporarySnapshot) {
@@ -1165,6 +1251,7 @@ async function atomicWriteNativeHookTransactionArtifact(
 		throw error;
 	}
 }
+
 
 async function assertNativeHookTransactionArtifactState(
 	path: string,
@@ -1293,6 +1380,12 @@ async function applyNativeHookTransactionArtifact(
 				entry = { artifact, appliedSnapshot };
 				applied.push(entry);
 			},
+			(stabilizedSnapshot) => {
+				if (!entry) {
+					throw new Error("native hook transaction write was not registered as applied");
+				}
+				entry.appliedSnapshot = stabilizedSnapshot;
+			},
 			() => assertAppliedNativeHookTransactionSnapshots(applied),
 		);
 		if (!entry) {
@@ -1354,9 +1447,17 @@ async function applyNativeHookTransactionArtifact(
 			"read-back",
 		);
 		await assertAppliedNativeHookTransactionSnapshots(applied);
+		injectNativeHookTransactionFailure("after_final_remove_validation", artifact);
+		await assertNativeHookTransactionArtifactSnapshot(
+			stagedDeletionPath,
+			`${artifact.label} staged deletion`,
+			stagedDeletionSnapshot,
+			"read-back",
+		);
+		const claimPath = nativeHookTransactionClaimPath(artifact.path);
 
-		await rm(artifact.path);
-		originalRemoved = true;
+
+		await rename(artifact.path, claimPath);
 		const entry: AppliedNativeHookTransactionArtifact = {
 			artifact,
 			appliedSnapshot: { bytes: null, topology: { kind: "absent" } },
@@ -1364,6 +1465,44 @@ async function applyNativeHookTransactionArtifact(
 			stagedDeletionSnapshot,
 		};
 		applied.push(entry);
+		try {
+
+
+			await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+
+			await assertNativeHookTransactionArtifactSnapshot(
+				claimPath,
+				`${artifact.label} removal claim`,
+				artifact.before,
+				"precondition",
+			);
+		} catch (error) {
+
+			try {
+				const claimed = await captureNativeHookTransactionArtifact(
+					claimPath,
+					`${artifact.label} removal claim`,
+				);
+				await link(claimPath, artifact.path);
+				await rm(claimPath);
+				await assertNativeHookTransactionArtifactSnapshot(
+					artifact.path,
+					artifact.label,
+					claimed,
+					"precondition",
+				);
+				const entryIndex = applied.indexOf(entry);
+				if (entryIndex >= 0) applied.splice(entryIndex, 1);
+			} catch (recoveryError) {
+				throw new Error(
+					`Native hook transaction removal claim failed (${error instanceof Error ? error.message : String(error)}) and preserved ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
+				);
+			}
+			throw error;
+
+		}
+		await rm(claimPath);
+		originalRemoved = true;
 		injectNativeHookTransactionFailure("after_remove", artifact);
 		return entry;
 	} catch (error) {
@@ -1379,7 +1518,28 @@ async function applyNativeHookTransactionArtifact(
 					"read-back",
 				);
 				await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
-				await rm(stagedDeletionPath);
+				const claimPath = nativeHookTransactionClaimPath(artifact.path);
+
+				await rename(stagedDeletionPath, claimPath);
+				try {
+					await assertNativeHookTransactionArtifactSnapshot(
+						claimPath,
+						`${artifact.label} staged deletion cleanup claim`,
+						stagedDeletionSnapshot,
+						"read-back",
+					);
+				} catch (claimError) {
+					try {
+						await link(claimPath, stagedDeletionPath);
+						await rm(claimPath);
+					} catch (recoveryError) {
+						throw new Error(
+							`Native hook transaction staged deletion cleanup claim failed (${claimError instanceof Error ? claimError.message : String(claimError)}) and preserved ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
+						);
+					}
+					throw claimError;
+				}
+				await rm(claimPath);
 			} catch (cleanupError) {
 				const message = error instanceof Error ? error.message : String(error);
 				throw new Error(
@@ -1440,9 +1600,42 @@ async function restoreNativeHookTransactionArtifact(
 		);
 		await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
 		await assertRollbackState();
+		injectNativeHookTransactionFailure("after_final_restore_validation", artifact);
+		const claimPath = nativeHookTransactionClaimPath(artifact.path);
 
-		await rm(artifact.path);
+		await rename(artifact.path, claimPath);
 		applied.appliedSnapshot = { bytes: null, topology: { kind: "absent" } };
+		try {
+
+
+			await assertNativeHookTransactionArtifactSnapshot(
+				claimPath,
+				`${artifact.label} rollback removal claim`,
+				current,
+				"rollback",
+			);
+		} catch (error) {
+			try {
+				const claimed = await captureNativeHookTransactionArtifact(
+					claimPath,
+					`${artifact.label} rollback removal claim`,
+				);
+				await link(claimPath, artifact.path);
+				await rm(claimPath);
+				await assertNativeHookTransactionArtifactSnapshot(
+					artifact.path,
+					artifact.label,
+					claimed,
+					"rollback",
+				);
+			} catch (recoveryError) {
+				throw new Error(
+					`Native hook transaction rollback removal claim failed (${error instanceof Error ? error.message : String(error)}) and preserved ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
+				);
+			}
+			throw error;
+		}
+		await rm(claimPath);
 	} else {
 		const restoreArtifact: NativeHookTransactionArtifact = {
 			...artifact,
@@ -1457,6 +1650,9 @@ async function restoreNativeHookTransactionArtifact(
 			ancestorPrecondition,
 			(restoredSnapshot) => {
 				applied.appliedSnapshot = restoredSnapshot;
+			},
+			(stabilizedSnapshot) => {
+				applied.appliedSnapshot = stabilizedSnapshot;
 			},
 			assertRollbackState,
 		);
@@ -1505,14 +1701,36 @@ async function cleanupNativeHookTransactionStagedDeletions(
 		if (rollbackApplied) {
 			await assertNativeHookTransactionRollbackState(rollbackApplied);
 		}
+		const stagedDeletionPath = entry.stagedDeletionPath;
+		const stagedDeletionSnapshot = entry.stagedDeletionSnapshot;
 		await assertNativeHookTransactionArtifactSnapshot(
-			entry.stagedDeletionPath,
+			stagedDeletionPath,
 			`${entry.artifact.label} staged deletion`,
-			entry.stagedDeletionSnapshot,
+			stagedDeletionSnapshot,
 			"read-back",
 		);
 		await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
-		await rm(entry.stagedDeletionPath);
+		const claimPath = nativeHookTransactionClaimPath(entry.artifact.path);
+		await rename(stagedDeletionPath, claimPath);
+		try {
+			await assertNativeHookTransactionArtifactSnapshot(
+				claimPath,
+				`${entry.artifact.label} staged deletion cleanup claim`,
+				stagedDeletionSnapshot,
+				"read-back",
+			);
+		} catch (error) {
+			try {
+				await link(claimPath, stagedDeletionPath);
+				await rm(claimPath);
+			} catch (recoveryError) {
+				throw new Error(
+					`Native hook transaction staged deletion cleanup claim failed (${error instanceof Error ? error.message : String(error)}) and preserved ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
+				);
+			}
+			throw error;
+		}
+		await rm(claimPath);
 		entry.stagedDeletionCleaned = true;
 		if (rollbackApplied) {
 			await assertNativeHookTransactionRollbackState(rollbackApplied);
@@ -3026,7 +3244,10 @@ function buildPluginModeLegacyConfig(
 		: "";
 	let config = original;
 	config = stripFirstPartyOmxMcpSections(config);
-	config = stripExistingOmxBlocks(config).cleaned;
+	config = stripExistingOmxBlocks(config, {
+		managedTrustState: options.managedHookTrustState,
+		priorManagedHookTrustState: options.priorManagedHookTrustState,
+	}).cleaned;
 	config = stripExistingSharedMcpRegistryBlock(config).cleaned;
 	config = stripPluginModeLegacyRootDefaults(
 		config,

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -15,18 +15,24 @@ import {
 	lstat,
 	rm,
 	open,
-	link,
 	chmod,
 } from "fs/promises";
 
 import { join, dirname, relative, basename, isAbsolute, sep, win32 } from "path";
 
-import { existsSync } from "fs";
+import { constants, existsSync } from "fs";
 import { spawnSync } from "child_process";
 import { createInterface } from "readline/promises";
 import { homedir } from "os";
 import TOML from "@iarna/toml";
 import { createHash } from "crypto";
+import {
+	clearNativeHookClaimJournal,
+	persistNativeHookClaimJournal,
+	recoverNativeHookClaimJournal,
+	syncNativeHookClaimParent,
+	restoreNativeHookClaimNoClobber,
+} from "./native-hook-claim-journal.js";
 import {
 	codexHome,
 	codexConfigPath,
@@ -530,6 +536,7 @@ let nativeHookTransactionPlatformOverride: NodeJS.Platform | undefined;
 let nativeHookTransactionTemporaryPathOverride:
 	| ((path: string, purpose: "write" | "delete") => string)
 	| undefined;
+let setupLatePhaseFailureInjector: (() => void) | undefined;
 
 
 
@@ -546,6 +553,17 @@ export function setNativeHookTransactionFailureInjectorForTest(
 	nativeHookTransactionFailureInjector = injector;
 	return () => {
 		nativeHookTransactionFailureInjector = previous;
+	};
+}
+
+/** @internal Test seam proving native artifacts commit only after later setup phases. */
+export function setSetupLatePhaseFailureInjectorForTest(
+	injector: (() => void) | undefined,
+): () => void {
+	const previous = setupLatePhaseFailureInjector;
+	setupLatePhaseFailureInjector = injector;
+	return () => {
+		setupLatePhaseFailureInjector = previous;
 	};
 }
 
@@ -1066,6 +1084,10 @@ function nativeHookTransactionClaimPath(path: string): string {
 	);
 }
 
+async function restoreNativeHookClaim(claimPath: string, destinationPath: string): Promise<void> {
+	await restoreNativeHookClaimNoClobber(claimPath, destinationPath);
+}
+
 
 async function atomicWriteNativeHookTransactionArtifact(
 	artifact: NativeHookTransactionArtifact,
@@ -1083,6 +1105,7 @@ async function atomicWriteNativeHookTransactionArtifact(
 	let temporarySnapshot: NativeHookTransactionArtifactSnapshot | undefined;
 	let claimPath: string | undefined;
 	let claimCreated = false;
+	let journaledClaim = false;
 	try {
 		await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
 		await assertApplied?.();
@@ -1148,52 +1171,75 @@ async function atomicWriteNativeHookTransactionArtifact(
 			"read-back",
 		);
 		await assertApplied?.();
+		if (!temporarySnapshot) {
+			throw new Error("temporary path was not fully captured after writing");
+		}
 		injectNativeHookTransactionFailure(
 			stage === "write"
 				? "after_final_rename_validation"
 				: "after_final_restore_validation",
 			artifact,
 		);
-
-		if (!temporarySnapshot) {
-			throw new Error("temporary path was not fully captured after writing");
-		}
-		await assertNativeHookTransactionArtifactSnapshot(
-			temporaryPath,
-			`${artifact.label} temporary`,
-			temporarySnapshot,
-			"read-back",
-		);
+		claimPath = nativeHookTransactionClaimPath(artifact.path);
+		const claimRelativePath = relative(ancestorPrecondition.controlledRoot, artifact.path);
+		const canJournalClaim =
+			!isAbsolute(claimRelativePath) &&
+			claimRelativePath !== ".." &&
+			!claimRelativePath.startsWith(`..${sep}`);
 		if (expectedCurrent.bytes !== null) {
-			claimPath = nativeHookTransactionClaimPath(artifact.path);
-
-
+			if (canJournalClaim) {
+				await persistNativeHookClaimJournal(ancestorPrecondition.controlledRoot, {
+					canonicalPath: artifact.path,
+					claimPath,
+					before: expectedCurrent.bytes,
+					after: content,
+				});
+				await refreshNativeHookTransactionAncestorPrecondition(
+					ancestorPrecondition,
+					join(ancestorPrecondition.controlledRoot, ".omx", "native-hook-claim-journal.json"),
+				);
+				journaledClaim = true;
+			}
 			await rename(artifact.path, claimPath);
 			claimCreated = true;
-			await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
-
+			if (journaledClaim) await syncNativeHookClaimParent(claimPath);
 			await assertNativeHookTransactionArtifactSnapshot(
 				claimPath,
-				`${artifact.label} claim`,
+				`${artifact.label} replacement claim`,
 				expectedCurrent,
 				stage === "write" ? "precondition" : "rollback",
 			);
 		}
-		// link() atomically installs only into an absent target; it never replaces a
-		// concurrent object that appeared after the final snapshot validation.
-		const linkedSnapshot: NativeHookTransactionArtifactSnapshot = {
-			...temporarySnapshot,
-			links: (temporarySnapshot.links ?? 0) + 1,
-		};
-		await link(temporaryPath, artifact.path);
-		onWriteApplied?.(linkedSnapshot);
-		await rm(temporaryPath);
-		temporaryCreated = false;
-		onWriteStabilized?.(temporarySnapshot);
-		if (claimPath) {
+		await copyFile(temporaryPath, artifact.path, constants.COPYFILE_EXCL);
+		if (artifact.afterTopology.kind === "regular_file") {
+			await chmod(artifact.path, artifact.afterTopology.mode);
+		}
+		const installedHandle = await open(artifact.path, "r");
+		try {
+			await installedHandle.sync();
+		} finally {
+			await installedHandle.close();
+		}
+		await syncNativeHookClaimParent(artifact.path);
+		const installedSnapshot = await assertNativeHookTransactionArtifactState(
+			artifact.path,
+			artifact.label,
+			{ bytes: content, topology: artifact.afterTopology },
+			stage === "write" ? "precondition" : "rollback",
+		);
+		if (claimCreated && claimPath) {
 			await rm(claimPath);
+			await syncNativeHookClaimParent(claimPath);
 			claimCreated = false;
 		}
+		if (journaledClaim) {
+			await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot);
+			journaledClaim = false;
+		}
+		await rm(temporaryPath);
+		temporaryCreated = false;
+		onWriteApplied?.(installedSnapshot);
+		onWriteStabilized?.(installedSnapshot);
 
 		if (stage === "write") {
 			injectNativeHookTransactionFailure("after_rename", artifact);
@@ -1201,30 +1247,22 @@ async function atomicWriteNativeHookTransactionArtifact(
 		await assertNativeHookTransactionArtifactSnapshot(
 			artifact.path,
 			artifact.label,
-			temporarySnapshot,
+			installedSnapshot,
 			stage === "write" ? "precondition" : "rollback",
 		);
 	} catch (error) {
 		if (claimCreated && claimPath) {
 			try {
-				const claimed = await captureNativeHookTransactionArtifact(
-					claimPath,
-					`${artifact.label} claim`,
-				);
-				await link(claimPath, artifact.path);
-				await rm(claimPath);
+				await restoreNativeHookClaim(claimPath, artifact.path);
+				await syncNativeHookClaimParent(artifact.path);
 				claimCreated = false;
-				await assertNativeHookTransactionArtifactSnapshot(
-					artifact.path,
-					artifact.label,
-					claimed,
-					stage === "write" ? "precondition" : "rollback",
-				);
-
+				if (journaledClaim) {
+					await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot);
+					journaledClaim = false;
+				}
 			} catch (recoveryError) {
-				const message = error instanceof Error ? error.message : String(error);
 				throw new Error(
-					`Native hook transaction ${stage} failed (${message}) and preserved claim ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
+					`Native hook transaction ${stage} failed (${error instanceof Error ? error.message : String(error)}) and preserved ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
 				);
 			}
 		}
@@ -1457,7 +1495,21 @@ async function applyNativeHookTransactionArtifact(
 		const claimPath = nativeHookTransactionClaimPath(artifact.path);
 
 
+		const claimRelativePath = relative(ancestorPrecondition.controlledRoot, artifact.path);
+		const journaledClaim =
+			!isAbsolute(claimRelativePath) &&
+			claimRelativePath !== ".." &&
+			!claimRelativePath.startsWith(`..${sep}`);
+		if (journaledClaim) {
+			await persistNativeHookClaimJournal(ancestorPrecondition.controlledRoot, {
+				canonicalPath: artifact.path,
+				claimPath,
+				before: artifact.before.bytes!,
+				after: null,
+			});
+		}
 		await rename(artifact.path, claimPath);
+		if (journaledClaim) await syncNativeHookClaimParent(claimPath);
 		const entry: AppliedNativeHookTransactionArtifact = {
 			artifact,
 			appliedSnapshot: { bytes: null, topology: { kind: "absent" } },
@@ -1483,8 +1535,11 @@ async function applyNativeHookTransactionArtifact(
 					claimPath,
 					`${artifact.label} removal claim`,
 				);
-				await link(claimPath, artifact.path);
-				await rm(claimPath);
+				await restoreNativeHookClaim(claimPath, artifact.path);
+				if (journaledClaim) await syncNativeHookClaimParent(artifact.path);
+				if (journaledClaim) {
+					await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot);
+				}
 				await assertNativeHookTransactionArtifactSnapshot(
 					artifact.path,
 					artifact.label,
@@ -1502,6 +1557,10 @@ async function applyNativeHookTransactionArtifact(
 
 		}
 		await rm(claimPath);
+		if (journaledClaim) await syncNativeHookClaimParent(claimPath);
+		if (journaledClaim) {
+			await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot);
+		}
 		originalRemoved = true;
 		injectNativeHookTransactionFailure("after_remove", artifact);
 		return entry;
@@ -1530,8 +1589,7 @@ async function applyNativeHookTransactionArtifact(
 					);
 				} catch (claimError) {
 					try {
-						await link(claimPath, stagedDeletionPath);
-						await rm(claimPath);
+						await restoreNativeHookClaim(claimPath, stagedDeletionPath);
 					} catch (recoveryError) {
 						throw new Error(
 							`Native hook transaction staged deletion cleanup claim failed (${claimError instanceof Error ? claimError.message : String(claimError)}) and preserved ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
@@ -1620,8 +1678,7 @@ async function restoreNativeHookTransactionArtifact(
 					claimPath,
 					`${artifact.label} rollback removal claim`,
 				);
-				await link(claimPath, artifact.path);
-				await rm(claimPath);
+				await restoreNativeHookClaim(claimPath, artifact.path);
 				await assertNativeHookTransactionArtifactSnapshot(
 					artifact.path,
 					artifact.label,
@@ -1721,8 +1778,7 @@ async function cleanupNativeHookTransactionStagedDeletions(
 			);
 		} catch (error) {
 			try {
-				await link(claimPath, stagedDeletionPath);
-				await rm(claimPath);
+				await restoreNativeHookClaim(claimPath, stagedDeletionPath);
 			} catch (recoveryError) {
 				throw new Error(
 					`Native hook transaction staged deletion cleanup claim failed (${error instanceof Error ? error.message : String(error)}) and preserved ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
@@ -1736,6 +1792,74 @@ async function cleanupNativeHookTransactionStagedDeletions(
 			await assertNativeHookTransactionRollbackState(rollbackApplied);
 		}
 	}
+}
+
+function nativeHookTransactionBackupPath(
+	artifactPath: string,
+	backupContext: SetupBackupContext,
+): string {
+	const relativePath = relative(backupContext.baseRoot, artifactPath);
+	const safeRelativePath =
+		relativePath.startsWith("..") || relativePath === ""
+			? artifactPath.replace(/^[/]+/, "")
+			: relativePath;
+	return join(backupContext.backupRoot, safeRelativePath);
+}
+
+async function ensureSnapshotBackup(
+	artifact: NativeHookTransactionArtifact,
+	backupContext: SetupBackupContext,
+	options: Pick<SetupOptions, "dryRun" | "verbose">,
+): Promise<boolean> {
+	const bytes = artifact.before.bytes;
+	if (bytes === null) return false;
+	const backupPath = nativeHookTransactionBackupPath(artifact.path, backupContext);
+	if (!options.dryRun) {
+		const relativeParent = relative(backupContext.baseRoot, dirname(backupPath));
+		if (
+			isAbsolute(relativeParent) ||
+			relativeParent === ".." ||
+			relativeParent.startsWith(`..${sep}`)
+		) {
+			throw new Error(`Refusing to back up ${artifact.path} outside controlled backup root.`);
+		}
+		let currentPath = backupContext.baseRoot;
+		for (const component of relativeParent.split(sep).filter(Boolean)) {
+			currentPath = join(currentPath, component);
+			try {
+				const currentStat = await lstat(currentPath);
+				if (currentStat.isSymbolicLink() || !currentStat.isDirectory()) {
+					throw new Error(`Refusing to use unsafe backup ancestor ${currentPath}.`);
+				}
+			} catch (error) {
+				if (!isMissingPathError(error)) throw error;
+				await mkdir(currentPath);
+				const createdStat = await lstat(currentPath);
+				if (createdStat.isSymbolicLink() || !createdStat.isDirectory()) {
+					throw new Error(`Refusing to use unsafe created backup ancestor ${currentPath}.`);
+				}
+			}
+		}
+		const handle = await open(backupPath, "wx", 0o600);
+		try {
+			await handle.writeFile(bytes);
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+		const backupStat = await lstat(backupPath);
+		if (backupStat.isSymbolicLink() || !backupStat.isFile() || backupStat.nlink !== 1) {
+			throw new Error(`Refusing unsafe native hook transaction backup ${backupPath}.`);
+		}
+		const writtenBytes = await readFile(backupPath);
+		if (!writtenBytes.equals(bytes)) {
+			throw new Error(`Native hook transaction backup verification failed for ${backupPath}.`);
+		}
+	}
+	if (options.verbose) {
+		console.log(`  backup ${artifact.path} -> ${backupPath}`);
+	}
+	return true;
 }
 
 async function commitNativeHookTransaction(
@@ -1757,17 +1881,11 @@ async function commitNativeHookTransaction(
 	if (artifacts.length === 0) return;
 	for (const artifact of artifacts) {
 		injectNativeHookTransactionFailure("before_backup", artifact);
-		if (
-			await ensureBackup(
-				artifact.path,
-				artifact.before.bytes !== null,
-				backupContext,
-				options,
-			)
-		) {
+		if (await ensureSnapshotBackup(artifact, backupContext, options)) {
 			summary.backedUp += 1;
 		}
 	}
+
 	await assertUnmutatedNativeHookTransactionPreconditions(preconditions, []);
 	await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
 
@@ -3705,8 +3823,11 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		requestedSkipNativeAgentRefresh ||
 		process.env[SKIP_NATIVE_AGENT_REFRESH_ENV] === "1";
 	const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot);
+	if (!dryRun) {
+		await recoverNativeHookClaimJournal(scopeDirs.codexHomeDir);
+	}
 	const nativeHookTransactionPlatform = nativeHookPlatform();
-	const nativeHookTransactionAncestorPrecondition =
+	let nativeHookTransactionAncestorPrecondition =
 		await captureNativeHookTransactionAncestorPrecondition(
 			scopeDirs.codexHomeDir,
 			[
@@ -3857,13 +3978,12 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		notifyMetadataSnapshot,
 	});
 	const summary = createEmptyRunSummary();
-	await commitNativeHookTransaction(
-		nativeHookSetupTransaction.artifacts,
-		nativeHookSetupTransaction.preconditions,
+	for (const precondition of nativeHookSetupTransaction.preconditions) {
+		injectNativeHookTransactionFailure("before_precondition", precondition);
+		await assertNativeHookTransactionPrecondition(precondition);
+	}
+	await assertNativeHookTransactionAncestorPrecondition(
 		nativeHookTransactionAncestorPrecondition,
-		backupContext,
-		summary.config,
-		{ dryRun, verbose },
 	);
 
 	console.log("oh-my-codex setup");
@@ -4607,6 +4727,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		console.log();
 	}
 
+
 	// Step 7: Set up notify hook
 	console.log("[7/8] Configuring notification hook...");
 	if (isPluginInstallMode) {
@@ -4661,6 +4782,21 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		dryRun,
 		verbose,
 	});
+
+	setupLatePhaseFailureInjector?.();
+	nativeHookTransactionAncestorPrecondition =
+		await captureNativeHookTransactionAncestorPrecondition(
+			scopeDirs.codexHomeDir,
+			nativeHookSetupTransaction.artifacts.map((artifact) => artifact.path),
+		);
+	await commitNativeHookTransaction(
+		nativeHookSetupTransaction.artifacts,
+		nativeHookSetupTransaction.preconditions,
+		nativeHookTransactionAncestorPrecondition,
+		backupContext,
+		summary.config,
+		{ dryRun, verbose },
+	);
 
 	console.log('Setup complete! Run "omx doctor" to verify installation.');
 	console.log("\nNext steps:");

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -17,7 +17,7 @@ import {
 	open,
 	chmod,
 } from "fs/promises";
-import { join, dirname, relative, basename, isAbsolute, sep } from "path";
+import { join, dirname, relative, basename, isAbsolute, sep, win32 } from "path";
 
 import { existsSync } from "fs";
 import { spawnSync } from "child_process";
@@ -66,8 +66,10 @@ import {
 	planManagedCodexHooksRemoval,
 	classifyManagedCodexNativeHookWindowsShimOwnership,
 	ManagedCodexHooksPlanError,
+	type ManagedCodexHookTrustState,
 	validateCodexHooksConfigStrict,
 } from "../config/codex-hooks.js";
+
 import {
 	getLegacyUnifiedMcpRegistryCandidate,
 	getUnifiedMcpRegistryCandidates,
@@ -451,7 +453,8 @@ type NativeHookTransactionArtifactKind = "shim" | "hooks" | "config" | "metadata
 	| "before_rollback"
 	| "before_rollback_rename"
 	| "before_rollback_remove"
-	| "before_staged_cleanup";
+	| "before_staged_cleanup"
+	| "after_staged_cleanup";
 
 type NativeHookTransactionTopology =
 	| { kind: "absent" }
@@ -503,7 +506,12 @@ interface AppliedNativeHookTransactionArtifact {
 	appliedSnapshot: NativeHookTransactionArtifactSnapshot;
 	stagedDeletionPath?: string;
 	stagedDeletionSnapshot?: NativeHookTransactionArtifactSnapshot;
+	stagedDeletionCleaned?: boolean;
+
 }
+
+
+
 
 let nativeHookTransactionFailureInjector:
 	| ((
@@ -865,6 +873,160 @@ function assertWindowsNativeHookShimOwnership(
 	);
 }
 
+type WindowsNativeHookShimReferenceDecision =
+	| "not_referenced"
+	| "referenced"
+	| "ambiguous";
+
+function isWindowsShimReferenceRecord(
+	value: unknown,
+): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeWindowsShimReferencePath(path: string): string | null {
+	const windowsPath = path.replace(/\//g, "\\");
+	if (
+		windowsPath.length === 0 ||
+		/[\0-\x1f\x7f-\x9f`<>"|?*]/.test(windowsPath) ||
+		/^\\\\\.(?:\\|$)/.test(windowsPath)
+	) {
+		return null;
+	}
+	const isDriveAbsolute = /^[A-Za-z]:\\(?:[^\\:]+(?:\\[^\\:]+)*)?$/.test(windowsPath);
+	const isUncAbsolute = /^\\\\[^\\:]+\\[^\\:]+(?:\\[^\\:]+)*$/.test(windowsPath);
+	if (!isDriveAbsolute && !isUncAbsolute) return null;
+	return win32.normalize(windowsPath).toLowerCase();
+}
+
+function windowsShimPathBasename(path: string): string | null {
+	const name = win32.basename(path.replace(/\//g, "\\")).replace(/[. ]+$/, "");
+	return name.length > 0 ? name.toLowerCase() : null;
+}
+
+function decodePowerShellSingleQuotedLiteral(value: string): string {
+	return value.replace(/''/g, "'");
+}
+
+/**
+ * Parses the only foreign command form that proves its -File target is a
+ * static literal. All other PowerShell forms remain ambiguous because they can
+ * construct an executable target dynamically or through a nested evaluator.
+ */
+function decodeWindowsShimReferencePath(command: string): string | null {
+	if (/["`]/.test(command)) return null;
+	const match = command.match(
+		/^\s*&\s+'((?:''|[^'\r\n])*)'\s+-noprofile\s+-executionpolicy\s+bypass\s+-file\s+'((?:''|[^'\r\n])*)'\s*$/i,
+	);
+	if (!match) return null;
+	const powerShellPath = decodePowerShellSingleQuotedLiteral(match[1]);
+	if (
+		windowsShimPathBasename(powerShellPath) !== "powershell.exe" ||
+		normalizeWindowsShimReferencePath(powerShellPath) === null ||
+		hasPotentialWindowsPathAlias(powerShellPath)
+	) {
+		return null;
+	}
+	return decodePowerShellSingleQuotedLiteral(match[2]);
+}
+
+function hasPotentialWindowsPathAlias(path: string): boolean {
+	const windowsPath = path.replace(/\//g, "\\");
+	return windowsPath.split("\\").some(
+		(component) =>
+			component === "." ||
+			component === ".." ||
+			/[. ]$/.test(component) ||
+			/~\d+(?:\.[^\\]*)?$/i.test(component),
+	);
+}
+
+function windowsShimCommandReferenceDecision(
+	command: string,
+	shimPath: string,
+): WindowsNativeHookShimReferenceDecision {
+	const decodedShimPath = decodeWindowsShimReferencePath(command);
+	if (decodedShimPath === null) return "ambiguous";
+
+	const normalizedDecodedPath = normalizeWindowsShimReferencePath(decodedShimPath);
+	const normalizedShimPath = normalizeWindowsShimReferencePath(shimPath);
+	if (normalizedDecodedPath === null || normalizedShimPath === null) {
+		return "ambiguous";
+	}
+	if (normalizedDecodedPath === normalizedShimPath) return "referenced";
+
+	// A distinct fully qualified spelling is not proof that the foreign target
+	// cannot resolve to this shim: reparse points, SUBST, mapped drives, and UNC
+	// aliases can all refer to the same file. No race-safe file-identity proof is
+	// available here, so preserve the proof-owned shim.
+	return "ambiguous";
+}
+
+/**
+ * Decides whether a proof-owned Windows shim must remain after a hooks.json
+ * transition. JSON is strictly validated and decoded before inspection so
+ * escaped paths are handled semantically. Unknown future event members are
+ * scanned only through the established executable group/command shape; prompt
+ * and agent payloads remain inert metadata.
+ */
+export function decideWindowsNativeHookShimReference(
+	finalHooksContent: string | null,
+	shimPath: string,
+): WindowsNativeHookShimReferenceDecision {
+	if (finalHooksContent === null) return "not_referenced";
+	const validation = validateCodexHooksConfigStrict(finalHooksContent, {
+		platform: "win32",
+	});
+	if (!validation.ok) return "ambiguous";
+	const hooks = validation.root.hooks;
+	if (!isWindowsShimReferenceRecord(hooks)) return "not_referenced";
+
+	let ambiguous = false;
+	for (const eventGroups of Object.values(hooks)) {
+		if (!Array.isArray(eventGroups)) continue;
+		for (const group of eventGroups) {
+
+			if (
+				!isWindowsShimReferenceRecord(group) ||
+				!Array.isArray(group.hooks)
+			) {
+				continue;
+			}
+
+			for (const handler of group.hooks) {
+				if (
+					!isWindowsShimReferenceRecord(handler) ||
+					handler.type !== "command"
+				) {
+					continue;
+				}
+				for (const command of [
+					handler.commandWindows,
+					handler.command_windows,
+					handler.command,
+				]) {
+					if (typeof command !== "string") continue;
+					const decision = windowsShimCommandReferenceDecision(command, shimPath);
+					if (decision === "referenced") return decision;
+					if (decision === "ambiguous") ambiguous = true;
+				}
+			}
+		}
+	}
+	return ambiguous ? "ambiguous" : "not_referenced";
+}
+
+function preflightManagedCodexHookTrustState(
+	config: string,
+	priorManagedHookTrustState: Record<string, ManagedCodexHookTrustState>,
+	managedHookTrustState: Record<string, ManagedCodexHookTrustState>,
+): void {
+	stripManagedCodexHookTrustState(config, {
+		priorManagedHookTrustState,
+		managedTrustState: managedHookTrustState,
+	});
+}
+
 function injectNativeHookTransactionFailure(
 	stage: NativeHookTransactionFailureStage,
 	target: NativeHookTransactionArtifact | NativeHookTransactionPrecondition,
@@ -893,12 +1055,14 @@ async function atomicWriteNativeHookTransactionArtifact(
 	expectedCurrent: NativeHookTransactionArtifactSnapshot,
 	ancestorPrecondition: NativeHookTransactionAncestorPrecondition,
 	onWriteApplied?: (snapshot: NativeHookTransactionArtifactSnapshot) => void,
+	assertApplied?: () => Promise<void>,
 ): Promise<void> {
 	const temporaryPath = nativeHookTransactionTemporaryPath(artifact.path, "write");
 	let temporaryCreated = false;
 	let temporarySnapshot: NativeHookTransactionArtifactSnapshot | undefined;
 	try {
 		await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+		await assertApplied?.();
 		await mkdir(dirname(artifact.path), { recursive: true });
 		await refreshNativeHookTransactionAncestorPrecondition(
 			ancestorPrecondition,
@@ -917,6 +1081,7 @@ async function atomicWriteNativeHookTransactionArtifact(
 			stage === "write" ? "precondition" : "rollback",
 		);
 		await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+		await assertApplied?.();
 
 		const handle = await open(
 			temporaryPath,
@@ -959,16 +1124,23 @@ async function atomicWriteNativeHookTransactionArtifact(
 			temporarySnapshot,
 			"read-back",
 		);
+		await assertApplied?.();
 
 		if (!temporarySnapshot) {
 			throw new Error("temporary path was not fully captured after writing");
 		}
 		await rename(temporaryPath, artifact.path);
 		temporaryCreated = false;
+		onWriteApplied?.(temporarySnapshot);
 		if (stage === "write") {
-			onWriteApplied?.(temporarySnapshot);
 			injectNativeHookTransactionFailure("after_rename", artifact);
 		}
+		await assertNativeHookTransactionArtifactSnapshot(
+			artifact.path,
+			artifact.label,
+			temporarySnapshot,
+			stage === "write" ? "precondition" : "rollback",
+		);
 	} catch (error) {
 		if (temporaryCreated) {
 			try {
@@ -1044,6 +1216,58 @@ async function assertNativeHookTransactionPrecondition(
 	);
 }
 
+async function assertUnmutatedNativeHookTransactionPreconditions(
+	preconditions: readonly NativeHookTransactionPrecondition[],
+	applied: readonly AppliedNativeHookTransactionArtifact[],
+): Promise<void> {
+	const mutatedPaths = new Set(applied.map((entry) => entry.artifact.path));
+	for (const precondition of preconditions) {
+		if (mutatedPaths.has(precondition.path)) continue;
+		await assertNativeHookTransactionPrecondition(precondition);
+	}
+}
+
+async function assertAppliedNativeHookTransactionSnapshots(
+	applied: readonly AppliedNativeHookTransactionArtifact[],
+): Promise<void> {
+	for (const entry of applied) {
+		await assertNativeHookTransactionArtifactSnapshot(
+			entry.artifact.path,
+			entry.artifact.label,
+			entry.appliedSnapshot,
+			"precondition",
+		);
+	}
+}
+
+async function assertNativeHookTransactionStagedRecoveryCopies(
+	applied: readonly AppliedNativeHookTransactionArtifact[],
+): Promise<void> {
+	for (const entry of applied) {
+		if (
+			!entry.stagedDeletionPath ||
+			!entry.stagedDeletionSnapshot ||
+			entry.stagedDeletionCleaned
+		) {
+			continue;
+		}
+		await assertNativeHookTransactionArtifactSnapshot(
+			entry.stagedDeletionPath,
+			`${entry.artifact.label} staged deletion`,
+			entry.stagedDeletionSnapshot,
+			"rollback",
+		);
+	}
+}
+
+async function assertNativeHookTransactionRollbackState(
+	applied: readonly AppliedNativeHookTransactionArtifact[],
+): Promise<void> {
+	await assertNativeHookTransactionStagedRecoveryCopies(applied);
+	await assertAppliedNativeHookTransactionSnapshots(applied);
+}
+
+
 async function applyNativeHookTransactionArtifact(
 	artifact: NativeHookTransactionArtifact,
 	ancestorPrecondition: NativeHookTransactionAncestorPrecondition,
@@ -1069,6 +1293,7 @@ async function applyNativeHookTransactionArtifact(
 				entry = { artifact, appliedSnapshot };
 				applied.push(entry);
 			},
+			() => assertAppliedNativeHookTransactionSnapshots(applied),
 		);
 		if (!entry) {
 			throw new Error("native hook transaction write was not registered as applied");
@@ -1089,6 +1314,7 @@ async function applyNativeHookTransactionArtifact(
 			"precondition",
 		);
 		await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+		await assertAppliedNativeHookTransactionSnapshots(applied);
 
 		const handle = await open(
 			stagedDeletionPath,
@@ -1127,6 +1353,7 @@ async function applyNativeHookTransactionArtifact(
 			stagedDeletionSnapshot,
 			"read-back",
 		);
+		await assertAppliedNativeHookTransactionSnapshots(applied);
 
 		await rm(artifact.path);
 		originalRemoved = true;
@@ -1193,6 +1420,7 @@ async function verifyNativeHookTransactionArtifact(
 async function restoreNativeHookTransactionArtifact(
 	applied: AppliedNativeHookTransactionArtifact,
 	ancestorPrecondition: NativeHookTransactionAncestorPrecondition,
+	assertRollbackState: () => Promise<void>,
 ): Promise<void> {
 	const { artifact } = applied;
 	const current = await captureNativeHookTransactionArtifact(artifact.path, artifact.label);
@@ -1211,8 +1439,10 @@ async function restoreNativeHookTransactionArtifact(
 			"rollback",
 		);
 		await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+		await assertRollbackState();
 
 		await rm(artifact.path);
+		applied.appliedSnapshot = { bytes: null, topology: { kind: "absent" } };
 	} else {
 		const restoreArtifact: NativeHookTransactionArtifact = {
 			...artifact,
@@ -1225,9 +1455,18 @@ async function restoreNativeHookTransactionArtifact(
 			"rollback",
 			applied.appliedSnapshot,
 			ancestorPrecondition,
+			(restoredSnapshot) => {
+				applied.appliedSnapshot = restoredSnapshot;
+			},
+			assertRollbackState,
 		);
 	}
-	const restored = await captureNativeHookTransactionArtifact(artifact.path, artifact.label);
+	const restored = await assertNativeHookTransactionArtifactSnapshot(
+		artifact.path,
+		artifact.label,
+		applied.appliedSnapshot,
+		"rollback",
+	);
 	if (
 		!nativeHookTransactionSnapshotMatchesExpected(restored, {
 			bytes: artifact.before.bytes,
@@ -1243,10 +1482,29 @@ async function restoreNativeHookTransactionArtifact(
 async function cleanupNativeHookTransactionStagedDeletions(
 	applied: readonly AppliedNativeHookTransactionArtifact[],
 	ancestorPrecondition: NativeHookTransactionAncestorPrecondition,
+	preconditions?: readonly NativeHookTransactionPrecondition[],
+	rollbackApplied?: readonly AppliedNativeHookTransactionArtifact[],
 ): Promise<void> {
 	for (const entry of applied) {
-		if (!entry.stagedDeletionPath || !entry.stagedDeletionSnapshot) continue;
+		if (
+			!entry.stagedDeletionPath ||
+			!entry.stagedDeletionSnapshot ||
+			entry.stagedDeletionCleaned
+		) {
+			continue;
+		}
 		injectNativeHookTransactionFailure("before_staged_cleanup", entry.artifact);
+		if (preconditions) {
+			await assertUnmutatedNativeHookTransactionPreconditions(
+				preconditions,
+				applied,
+			);
+			await assertAppliedNativeHookTransactionSnapshots(applied);
+		}
+
+		if (rollbackApplied) {
+			await assertNativeHookTransactionRollbackState(rollbackApplied);
+		}
 		await assertNativeHookTransactionArtifactSnapshot(
 			entry.stagedDeletionPath,
 			`${entry.artifact.label} staged deletion`,
@@ -1255,6 +1513,10 @@ async function cleanupNativeHookTransactionStagedDeletions(
 		);
 		await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
 		await rm(entry.stagedDeletionPath);
+		entry.stagedDeletionCleaned = true;
+		if (rollbackApplied) {
+			await assertNativeHookTransactionRollbackState(rollbackApplied);
+		}
 	}
 }
 
@@ -1288,63 +1550,104 @@ async function commitNativeHookTransaction(
 			summary.backedUp += 1;
 		}
 	}
-	for (const precondition of preconditions) {
-		await assertNativeHookTransactionPrecondition(precondition);
-	}
+	await assertUnmutatedNativeHookTransactionPreconditions(preconditions, []);
 	await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
 
-
 	const applied: AppliedNativeHookTransactionArtifact[] = [];
+	let stagedCleanupStarted = false;
 	try {
 		for (const artifact of artifacts) {
+			await assertUnmutatedNativeHookTransactionPreconditions(
+				preconditions,
+				applied,
+			);
+			await assertAppliedNativeHookTransactionSnapshots(applied);
 			const entry = await applyNativeHookTransactionArtifact(
 				artifact,
 				ancestorPrecondition,
 				applied,
 			);
 			await verifyNativeHookTransactionArtifact(entry);
+			await assertUnmutatedNativeHookTransactionPreconditions(
+				preconditions,
+				applied,
+			);
+			await assertAppliedNativeHookTransactionSnapshots(applied);
 		}
+		await assertUnmutatedNativeHookTransactionPreconditions(preconditions, applied);
+		await assertAppliedNativeHookTransactionSnapshots(applied);
+		stagedCleanupStarted = true;
+		await cleanupNativeHookTransactionStagedDeletions(
+			applied,
+			ancestorPrecondition,
+			preconditions,
+		);
+		injectNativeHookTransactionFailure(
+			"after_staged_cleanup",
+			artifacts[artifacts.length - 1],
+		);
+		await assertUnmutatedNativeHookTransactionPreconditions(preconditions, applied);
+		await assertNativeHookTransactionAncestorPrecondition(ancestorPrecondition);
+		await assertAppliedNativeHookTransactionSnapshots(applied);
 	} catch (error) {
+		if (
+			stagedCleanupStarted &&
+			applied.some((entry) => entry.stagedDeletionCleaned)
+		) {
+			throw new Error(
+				`Native hook transaction committed but staged deletion cleanup failed during finalization: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
 		const rollbackFailures: string[] = [];
 		const restored: AppliedNativeHookTransactionArtifact[] = [];
-		for (const entry of [...applied].reverse()) {
-			try {
-				await restoreNativeHookTransactionArtifact(entry, ancestorPrecondition);
-				restored.push(entry);
-			} catch (rollbackError) {
-				rollbackFailures.push(
-					`${entry.artifact.label}: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
-				);
+		try {
+			await assertNativeHookTransactionRollbackState(applied);
+		} catch (rollbackError) {
+			rollbackFailures.push(
+				`recovery preflight: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+			);
+		}
+		if (rollbackFailures.length === 0) {
+			for (const entry of [...applied].reverse()) {
+				try {
+					await assertNativeHookTransactionRollbackState(applied);
+					await restoreNativeHookTransactionArtifact(
+						entry,
+						ancestorPrecondition,
+						() => assertNativeHookTransactionRollbackState(applied),
+					);
+					restored.push(entry);
+					await assertNativeHookTransactionRollbackState(applied);
+				} catch (rollbackError) {
+					rollbackFailures.push(
+						`${entry.artifact.label}: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+					);
+				}
 			}
 		}
-		try {
-			await cleanupNativeHookTransactionStagedDeletions(
-				restored,
-				ancestorPrecondition,
-			);
-		} catch (cleanupError) {
-			rollbackFailures.push(
-				`staged deletion cleanup: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
-			);
+		if (rollbackFailures.length === 0) {
+			try {
+				await assertNativeHookTransactionRollbackState(applied);
+				await cleanupNativeHookTransactionStagedDeletions(
+					restored,
+					ancestorPrecondition,
+					undefined,
+					applied,
+				);
+				await assertNativeHookTransactionRollbackState(applied);
+			} catch (cleanupError) {
+				rollbackFailures.push(
+					`staged deletion cleanup: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+				);
+			}
 		}
 		const message = error instanceof Error ? error.message : String(error);
 		if (rollbackFailures.length > 0) {
 			throw new Error(
-				`Native hook transaction failed (${message}) and rollback failed (${rollbackFailures.join("; ")}).`,
+				`Native hook transaction failed (${message}) and rollback failed; manual recovery is required (${rollbackFailures.join("; ")}).`,
 			);
 		}
 		throw new Error(`Native hook transaction failed and was rolled back: ${message}`);
-	}
-
-	try {
-		await cleanupNativeHookTransactionStagedDeletions(
-			applied,
-			ancestorPrecondition,
-		);
-	} catch (error) {
-		throw new Error(
-			`Native hook transaction committed but staged deletion cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
-		);
 	}
 }
 
@@ -2635,10 +2938,20 @@ function buildPluginModeHooksConfigPlan(
 	const managedHookTrustState = managedHooksPlan?.finalTrustState ?? {};
 	const priorManagedHookTrustState = managedHooksPlan?.priorTrustState ?? {};
 	const legacyHookTrustState = managedHooksPlan?.legacyTrustState ?? {};
+	preflightManagedCodexHookTrustState(
+		existingConfig,
+		priorManagedHookTrustState,
+		managedHookTrustState,
+	);
 	const configAfterLegacyCleanup = buildPluginModeLegacyConfig(
 		existingConfig,
-		options,
+		{
+			...options,
+			managedHookTrustState,
+			priorManagedHookTrustState,
+		},
 	);
+
 	const configWithRuntimeFeatures = upsertPluginModeRuntimeFeatureFlags(
 		configAfterLegacyCleanup,
 		options.codexHookFeatureFlag,
@@ -2704,6 +3017,8 @@ function buildPluginModeLegacyConfig(
 	options: {
 		preserveFirstPartyMcp?: boolean;
 		developerInstructionsDecision: PluginDeveloperInstructionsDecision;
+		managedHookTrustState: Record<string, ManagedCodexHookTrustState>;
+		priorManagedHookTrustState: Record<string, ManagedCodexHookTrustState>;
 	},
 ): string {
 	const preservedFirstPartyMcp = options.preserveFirstPartyMcp
@@ -2719,7 +3034,10 @@ function buildPluginModeLegacyConfig(
 	);
 	config = stripOmxSeededBehavioralDefaults(config);
 	config = stripOmxFeatureFlags(config, { preserveMultiAgent: true });
-	config = stripManagedCodexHookTrustState(config);
+	config = stripManagedCodexHookTrustState(config, {
+		managedTrustState: options.managedHookTrustState,
+		priorManagedHookTrustState: options.priorManagedHookTrustState,
+	});
 	config = stripOmxEnvSettings(config);
 	if (preservedFirstPartyMcp) {
 		config = `${config.trimEnd()}\n\n${preservedFirstPartyMcp}\n`;
@@ -2969,16 +3287,17 @@ async function planNativeHookSetupTransaction(
 			"utf-8",
 		);
 		assertWindowsNativeHookShimOwnership(shimPath, shimSnapshot.bytes, shimAfter);
-		const shimReferencedByFinalHooks = finalHooksContent
-			?.toLowerCase()
-			.includes("omx-native-hook-windows-shim.ps1")
-			?? false;
+		const shimReference = decideWindowsNativeHookShimReference(
+			finalHooksContent,
+			shimPath,
+		);
 		shimArtifact = nativeHookTransactionArtifact(
 			"shim",
 			shimPath,
 			`native hook Windows shim ${shimPath}`,
 			shimSnapshot,
-			options.isPluginInstallMode && options.pluginScopedHooks && !shimReferencedByFinalHooks
+			options.isPluginInstallMode && options.pluginScopedHooks &&
+			shimReference === "not_referenced"
 				? null
 				: shimAfter,
 		);
@@ -2995,12 +3314,18 @@ async function planNativeHookSetupTransaction(
 	const windowsShimDeletionArtifact =
 		shimArtifact && shimArtifact.after === null ? shimArtifact : null;
 	const artifacts = options.platform === "win32"
-		? [
+		? windowsShimDeletionArtifact
+			? [
+				hookArtifact,
+				windowsShimDeletionArtifact,
+				notifyMetadataArtifact,
+				configArtifact,
+			]
+			: [
 				windowsShimCreateOrUpdateArtifact,
 				hookArtifact,
 				notifyMetadataArtifact,
 				configArtifact,
-				windowsShimDeletionArtifact,
 			]
 		: [hookArtifact, notifyMetadataArtifact, configArtifact];
 	const preconditions = [

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -2,15 +2,17 @@
  * omx uninstall - Remove oh-my-codex configuration and installed artifacts
  */
 
-import { readFile, writeFile, readdir, rm } from "fs/promises";
+import { chmod, lstat, open, readFile, readdir, rename, rm } from "fs/promises";
 import { existsSync } from "fs";
-import { join, basename, dirname } from "path";
+import { join, basename, dirname, isAbsolute, relative } from "path";
+import { randomUUID } from "crypto";
 import {
   formatTomlStringArray,
   getRootTomlArray,
   isOmxManagedNotifyCommand,
   sanitizePreviousNotifyCommand,
   stripExistingOmxBlocks,
+  stripManagedCodexHookTrustState,
   stripOmxEnvSettings,
   stripOmxTopLevelKeys,
   stripOmxFeatureFlags,
@@ -18,9 +20,13 @@ import {
   stripOmxSeededBehavioralDefaults,
 } from "../config/generator.js";
 import {
-  hasUserCodexHooksAfterManagedRemoval,
-  parseCodexHooksConfig,
-  removeManagedCodexHooks,
+  buildManagedCodexNativeHookWindowsShimContent,
+  buildManagedCodexNativeHookWindowsShimPath,
+  classifyManagedCodexNativeHookWindowsShimOwnership,
+  planManagedCodexHooksRemoval,
+  ManagedCodexHooksPlanError,
+  type ManagedCodexHookTrustState,
+  type ManagedCodexHooksPlan,
 } from "../config/codex-hooks.js";
 import { getPackageRoot } from "../utils/package.js";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
@@ -30,6 +36,21 @@ import { resolveCodexHookFeatureFlagForCli } from "./codex-feature-probe.js";
 import { readPersistedSetupScope } from "./index.js";
 import { isOmxGeneratedAgentsMd } from "../utils/agents-md.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
+import TOML from "@iarna/toml";
+
+/** @internal Deterministic file-operation seam for uninstall transaction tests. */
+export type UninstallTransactionFailureStage =
+  | "before-hooks-commit"
+  | "before-shim-removal"
+  | "before-config-commit"
+  | "before-temp-write"
+  | "before-rename"
+  | "before-remove"
+  | "before-rollback"
+  | "before-rollback-rename"
+  | "before-rollback-remove"
+  | "before-staged-cleanup"
+  | "after-config-commit";
 
 export interface UninstallOptions {
   codexFeaturesProbe?: () => string | null;
@@ -39,6 +60,17 @@ export interface UninstallOptions {
   verbose?: boolean;
   purge?: boolean;
   scope?: SetupScope;
+  /** @internal */
+  transactionFailureInjector?: (
+    stage: UninstallTransactionFailureStage,
+  ) => void | Promise<void>;
+  /** @internal */
+  transactionPlatform?: NodeJS.Platform;
+  /** @internal */
+  transactionTemporaryPath?: (
+    path: string,
+    purpose: "write" | "delete",
+  ) => string;
 }
 
 interface UninstallSummary {
@@ -63,7 +95,6 @@ function detectOmxConfigArtifacts(config: string): {
   hasTuiSection: boolean;
   hasTopLevelKeys: boolean;
   hasFeatureFlags: boolean;
-  hasExploreRoutingEnv: boolean;
 } {
   const hasMcpServers = OMX_FIRST_PARTY_MCP_SERVER_NAMES.filter((name) =>
     new RegExp(`\\[mcp_servers\\.${name}\\]`).test(config),
@@ -93,7 +124,6 @@ function detectOmxConfigArtifacts(config: string): {
     /^\s*codex_hooks\s*=\s*true/m.test(config) ||
     /^\s*goals\s*=\s*true/m.test(config) ||
     /^\s*goal\s*=\s*true/m.test(config);
-  const hasExploreRoutingEnv = /^\s*USE_OMX_EXPLORE_CMD\s*=/m.test(config);
 
   return {
     hasMcpServers,
@@ -101,7 +131,6 @@ function detectOmxConfigArtifacts(config: string): {
     hasTuiSection,
     hasTopLevelKeys,
     hasFeatureFlags,
-    hasExploreRoutingEnv,
   };
 }
 
@@ -125,17 +154,249 @@ function hasNativeHooksFeatureFlag(config: string): boolean {
     .some((line) => /^\s*(?:hooks|codex_hooks)\s*=\s*true/.test(line));
 }
 
-async function shouldPreserveHooksFeatureFlag(
-  hooksFilePath: string,
-): Promise<boolean> {
-  if (!existsSync(hooksFilePath)) return false;
+type FileIdentityScalar = number | bigint;
 
-  try {
-    const existing = await readFile(hooksFilePath, "utf-8");
-    return hasUserCodexHooksAfterManagedRemoval(existing);
-  } catch {
-    return false;
+interface FileIdentity {
+  dev: FileIdentityScalar;
+  ino: FileIdentityScalar;
+  size: FileIdentityScalar;
+  mode: FileIdentityScalar;
+  mtimeMs: FileIdentityScalar;
+  ctimeMs: FileIdentityScalar;
+  links: FileIdentityScalar;
+}
+
+interface DirectoryTopologyEntry {
+  path: string;
+  identity: Pick<FileIdentity, "dev" | "ino"> | null;
+}
+
+interface FileTopology {
+  root: string;
+  ancestors: DirectoryTopologyEntry[];
+}
+
+interface FileSnapshot {
+  path: string;
+  content: string | null;
+  bytes: Buffer | null;
+  mode: number | null;
+  identity: FileIdentity | null;
+  topology: FileTopology | null;
+}
+
+interface PlannedHooksRemoval {
+  hooks: FileSnapshot;
+  plan?: ManagedCodexHooksPlan;
+  shim?: FileSnapshot;
+}
+
+function fileIdentity(stat: Awaited<ReturnType<typeof lstat>>): FileIdentity {
+  return {
+    dev: stat.dev,
+    ino: stat.ino,
+    size: stat.size,
+    mode: stat.mode,
+    mtimeMs: stat.mtimeMs,
+    ctimeMs: stat.ctimeMs,
+    links: stat.nlink,
+  };
+}
+
+function hasSameFileIdentity(left: FileIdentity, right: FileIdentity): boolean {
+  return left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mode === right.mode &&
+    left.mtimeMs === right.mtimeMs &&
+    left.ctimeMs === right.ctimeMs &&
+    left.links === right.links;
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "ENOENT"
+  );
+}
+
+async function captureControlledTopology(
+  root: string,
+  path: string,
+): Promise<FileTopology> {
+  const parentPath = dirname(path);
+  const relativeParent = relative(root, parentPath);
+  if (
+    isAbsolute(relativeParent) ||
+    relativeParent === ".." ||
+    relativeParent.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) ||
+    relativeParent.startsWith("/")
+  ) {
+    throw new Error(`Refusing to process ${path}: it is outside controlled Codex scope ${root}.`);
   }
+
+  const ancestors: DirectoryTopologyEntry[] = [];
+  let currentPath = root;
+  for (const segment of ["", ...relativeParent.split(/[\\/]/).filter(Boolean)]) {
+    if (segment) currentPath = join(currentPath, segment);
+    try {
+      const stat = await lstat(currentPath);
+      if (stat.isSymbolicLink() || !stat.isDirectory()) {
+        throw new Error(`Refusing to process ${path}: controlled ancestor ${currentPath} must be a non-symbolic-link directory.`);
+      }
+      ancestors.push({
+        path: currentPath,
+        identity: { dev: stat.dev, ino: stat.ino },
+      });
+    } catch (error) {
+      if (!isMissingPathError(error)) throw error;
+      ancestors.push({ path: currentPath, identity: null });
+      break;
+    }
+  }
+  return { root, ancestors };
+}
+
+async function assertControlledTopologyCurrent(topology: FileTopology | null): Promise<void> {
+  if (!topology) return;
+  for (const ancestor of topology.ancestors) {
+    try {
+      const stat = await lstat(ancestor.path);
+      if (
+        ancestor.identity === null ||
+        stat.isSymbolicLink() ||
+        !stat.isDirectory() ||
+        stat.dev !== ancestor.identity.dev ||
+        stat.ino !== ancestor.identity.ino
+      ) {
+        throw new Error(`Refusing uninstall because controlled ancestor ${ancestor.path} changed topology after planning.`);
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("changed topology")) {
+        throw error;
+      }
+      if (isMissingPathError(error) && ancestor.identity === null) continue;
+      if (isMissingPathError(error)) {
+        throw new Error(`Refusing uninstall because controlled ancestor ${ancestor.path} changed topology after planning.`);
+      }
+      throw error;
+    }
+  }
+}
+
+function decodeStrictUtf8(path: string, bytes: Buffer): string {
+  try {
+    const content = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(bytes);
+    if (!Buffer.from(content, "utf-8").equals(bytes)) {
+      throw new Error("decoded text did not round-trip to the original bytes");
+    }
+    return content;
+  } catch {
+    throw new ManagedCodexHooksPlanError(
+      "invalid_document",
+      `Refusing to process ${path}: it is not valid UTF-8.`,
+      { path },
+    );
+  }
+}
+
+async function readFileSnapshot(
+  path: string,
+  options: { strictUtf8?: boolean; controlledRoot?: string } = {},
+): Promise<FileSnapshot> {
+  const topology = options.controlledRoot
+    ? await captureControlledTopology(options.controlledRoot, path)
+    : null;
+  let before: Awaited<ReturnType<typeof lstat>>;
+  try {
+    before = await lstat(path);
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      await assertControlledTopologyCurrent(topology);
+      return {
+        path,
+        content: null,
+        bytes: null,
+        mode: null,
+        identity: null,
+        topology,
+      };
+    }
+    throw error;
+  }
+  if (before.isSymbolicLink() || !before.isFile() || before.nlink !== 1) {
+    throw new Error(`Refusing to process ${path}: expected a regular file, not a symbolic link or other filesystem object.`);
+  }
+  const bytes = await readFile(path);
+  const after = await lstat(path);
+  await assertControlledTopologyCurrent(topology);
+  if (after.isSymbolicLink() || !after.isFile() || after.nlink !== 1 || !hasSameFileIdentity(fileIdentity(before), fileIdentity(after))) {
+    throw new Error(`Refusing to process ${path}: it changed while uninstall was planning.`);
+  }
+  return {
+    path,
+    content: options.strictUtf8 === false ? bytes.toString("utf-8") : decodeStrictUtf8(path, bytes),
+    bytes,
+    mode: after.mode & 0o7777,
+    identity: fileIdentity(after),
+    topology,
+  };
+}
+
+async function planHooksRemoval(
+  hooks: FileSnapshot,
+  pkgRoot: string,
+  platform: NodeJS.Platform,
+  controlledRoot: string,
+): Promise<PlannedHooksRemoval> {
+  let plan: ManagedCodexHooksPlan | undefined;
+  if (hooks.content !== null) {
+    const result = planManagedCodexHooksRemoval(hooks.content, hooks.path, {
+      platform,
+      codexHomeDir: dirname(hooks.path),
+    });
+    if (!result.ok) throw result.error;
+    plan = result;
+  }
+
+  if (platform !== "win32") return { hooks, plan };
+
+  const shimPath = buildManagedCodexNativeHookWindowsShimPath(dirname(hooks.path));
+  const shim = await readFileSnapshot(shimPath, {
+    strictUtf8: false,
+    // On non-Windows hosts the test-only platform seam intentionally produces
+    // a win32 path that the host filesystem cannot place under this root.
+    controlledRoot: platform === process.platform ? controlledRoot : undefined,
+  });
+  if (shim.bytes !== null) {
+    const expectedShim = Buffer.from(
+      buildManagedCodexNativeHookWindowsShimContent(pkgRoot),
+      "utf-8",
+    );
+    if (
+      classifyManagedCodexNativeHookWindowsShimOwnership(
+        shim.bytes,
+        expectedShim,
+      ) === "modified"
+    ) {
+      throw new Error(
+        `Refusing to remove modified native hook Windows shim at ${shim.path}.`,
+      );
+    }
+    if (
+      plan?.finalContent?.toLowerCase().includes(
+        "omx-native-hook-windows-shim.ps1",
+      )
+    ) {
+      throw new Error(
+        `Refusing to remove native hook Windows shim at ${shim.path} while surviving hooks still reference it.`,
+      );
+    }
+  }
+
+  return { hooks, plan, shim };
 }
 
 function insertRootTomlKey(config: string, line: string): string {
@@ -148,82 +409,180 @@ function insertRootTomlKey(config: string, line: string): string {
   return lines.join("\n").replace(/\n{3,}/g, "\n\n");
 }
 
-async function restorePreviousNotifyIfDispatcher(
-  configPath: string,
-  strippedConfig: string,
-  originalConfig: string,
-): Promise<string> {
-  const currentNotify = getRootTomlArray(originalConfig, "notify");
-  if (
-    !isOmxManagedNotifyCommand(currentNotify, getPackageRoot()) ||
-    !currentNotify?.some((part) =>
-      /(?:^|[\\/])notify-dispatcher\.js$/.test(part),
-    )
-  ) {
-    return strippedConfig;
-  }
-
-  const metadataPath = join(dirname(configPath), ".omx", "notify-dispatch.json");
-  try {
-    const metadata = JSON.parse(await readFile(metadataPath, "utf-8")) as {
-      previousNotify?: unknown;
-    };
-    const previousNotify = metadata.previousNotify;
-    if (
-      Array.isArray(previousNotify) &&
-      previousNotify.every((item) => typeof item === "string")
-    ) {
-      const sanitizedPreviousNotify = sanitizePreviousNotifyCommand(
-        previousNotify,
-        getPackageRoot(),
-      );
-      if (sanitizedPreviousNotify) {
-        return insertRootTomlKey(
-          strippedConfig,
-          `notify = ${formatTomlStringArray(sanitizedPreviousNotify)}`,
-        );
-      }
-    }
-  } catch {
-    // Missing or malformed metadata means uninstall falls back to removing OMX notify.
-  }
-  return strippedConfig;
+interface PlannedNotifyMetadata {
+  snapshot: FileSnapshot;
+  previousNotify: string[] | null;
 }
 
-async function cleanConfig(
-  configPath: string,
+function isManagedDispatcherNotify(config: string): boolean {
+  const currentNotify = getRootTomlArray(config, "notify");
+  return Boolean(
+    isOmxManagedNotifyCommand(currentNotify, getPackageRoot()) &&
+      currentNotify?.some((part) =>
+        /(?:^|[\\/])notify-dispatcher\.js$/.test(part),
+      ),
+  );
+}
+
+function invalidNotifyMetadata(path: string, reason: string): ManagedCodexHooksPlanError {
+  return new ManagedCodexHooksPlanError(
+    "invalid_document",
+    `Refusing to use notification metadata ${path}: ${reason}.`,
+    { path },
+  );
+}
+
+function parseNotifyMetadata(
+  snapshot: FileSnapshot,
+  currentNotify: readonly string[],
+): PlannedNotifyMetadata {
+  if (snapshot.content === null) {
+    throw invalidNotifyMetadata(snapshot.path, "the managed dispatcher metadata is missing");
+  }
+  if (!currentNotify.includes(snapshot.path)) {
+    throw invalidNotifyMetadata(snapshot.path, "the managed dispatcher does not reference the controlled metadata path");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(snapshot.content);
+  } catch (error) {
+    throw invalidNotifyMetadata(
+      snapshot.path,
+      `invalid JSON (${error instanceof Error ? error.message : String(error)})`,
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw invalidNotifyMetadata(snapshot.path, "expected a JSON object");
+  }
+  const metadata = parsed as Record<string, unknown>;
+  if (metadata.managedBy !== "oh-my-codex" || metadata.version !== 1) {
+    throw invalidNotifyMetadata(snapshot.path, "expected OMX ownership and version 1");
+  }
+  const validateStringArray = (value: unknown, name: string): string[] => {
+    if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+      throw invalidNotifyMetadata(snapshot.path, `${name} must be an array of strings`);
+    }
+    return [...value];
+  };
+  const previousNotify = metadata.previousNotify;
+  if (
+    !Object.hasOwn(metadata, "previousNotify") ||
+    (previousNotify !== null &&
+      (!Array.isArray(previousNotify) ||
+        !previousNotify.every((item) => typeof item === "string")))
+  ) {
+    throw invalidNotifyMetadata(snapshot.path, "previousNotify must be null or an array of strings");
+  }
+  validateStringArray(metadata.omxNotify, "omxNotify");
+  const dispatcherNotify = validateStringArray(
+    metadata.dispatcherNotify,
+    "dispatcherNotify",
+  );
+  if (
+    dispatcherNotify.length !== currentNotify.length ||
+    dispatcherNotify.some((part, index) => part !== currentNotify[index])
+  ) {
+    throw invalidNotifyMetadata(snapshot.path, "dispatcherNotify does not match the managed dispatcher command");
+  }
+  return {
+    snapshot,
+    previousNotify: Array.isArray(previousNotify) ? [...previousNotify] : null,
+  };
+}
+
+async function planNotifyMetadata(
+  configSnapshot: FileSnapshot,
+  codexHomeDir: string,
+): Promise<PlannedNotifyMetadata | undefined> {
+  if (configSnapshot.content === null || !isManagedDispatcherNotify(configSnapshot.content)) {
+    return undefined;
+  }
+  const currentNotify = getRootTomlArray(configSnapshot.content, "notify");
+  if (!currentNotify) {
+    throw invalidNotifyMetadata(
+      join(codexHomeDir, ".omx", "notify-dispatch.json"),
+      "the managed dispatcher command is invalid",
+    );
+  }
+  let snapshot: FileSnapshot;
+  try {
+    snapshot = await readFileSnapshot(
+      join(codexHomeDir, ".omx", "notify-dispatch.json"),
+      { controlledRoot: codexHomeDir },
+    );
+  } catch (error) {
+    if (error instanceof ManagedCodexHooksPlanError) throw error;
+    throw invalidNotifyMetadata(
+      join(codexHomeDir, ".omx", "notify-dispatch.json"),
+      `unreadable (${error instanceof Error ? error.message : String(error)})`,
+    );
+  }
+  return parseNotifyMetadata(snapshot, currentNotify);
+}
+
+function restorePreviousNotifyIfDispatcher(
+  strippedConfig: string,
+  originalConfig: string,
+  metadataPlan?: PlannedNotifyMetadata,
+): string {
+  if (!isManagedDispatcherNotify(originalConfig)) return strippedConfig;
+  if (!metadataPlan) {
+    throw new Error("Missing planned notification metadata for a managed dispatcher.");
+  }
+  const sanitizedPreviousNotify = sanitizePreviousNotifyCommand(
+    metadataPlan.previousNotify,
+    getPackageRoot(),
+  );
+  return sanitizedPreviousNotify
+    ? insertRootTomlKey(
+        strippedConfig,
+        `notify = ${formatTomlStringArray(sanitizedPreviousNotify)}`,
+      )
+    : strippedConfig;
+}
+
+type ConfigCleanupSummary = Pick<
+  UninstallSummary,
+  | "configCleaned"
+  | "mcpServersRemoved"
+  | "agentEntriesRemoved"
+  | "tuiSectionRemoved"
+  | "topLevelKeysRemoved"
+  | "featureFlagsRemoved"
+>;
+
+interface PlannedConfigCleanup {
+  config: FileSnapshot;
+  finalContent: string | null;
+  result: ConfigCleanupSummary;
+}
+
+async function planConfigCleanup(
+  configSnapshot: FileSnapshot,
   options: Pick<
     UninstallOptions,
-    "dryRun" | "verbose" | "codexFeaturesProbe" | "codexVersionProbe"
+    "codexFeaturesProbe" | "codexVersionProbe"
   > & {
     preserveHooksFeatureFlag?: boolean;
+    priorHookTrustState?: Record<string, ManagedCodexHookTrustState>;
+    notifyMetadata?: PlannedNotifyMetadata;
   },
-): Promise<
-  Pick<
-    UninstallSummary,
-    | "configCleaned"
-    | "mcpServersRemoved"
-    | "agentEntriesRemoved"
-    | "tuiSectionRemoved"
-    | "topLevelKeysRemoved"
-    | "featureFlagsRemoved"
-  >
-> {
-  const result = {
+): Promise<PlannedConfigCleanup> {
+  const result: ConfigCleanupSummary = {
     configCleaned: false,
-    mcpServersRemoved: [] as string[],
+    mcpServersRemoved: [],
     agentEntriesRemoved: 0,
     tuiSectionRemoved: false,
     topLevelKeysRemoved: false,
     featureFlagsRemoved: false,
   };
 
-  if (!existsSync(configPath)) {
-    if (options.verbose) console.log("  config.toml not found, skipping.");
-    return result;
+  const original = configSnapshot.content;
+  if (original === null) {
+    return { config: configSnapshot, finalContent: null, result };
   }
 
-  const original = await readFile(configPath, "utf-8");
   const detected = detectOmxConfigArtifacts(original);
   const shouldRestoreHooksFeatureFlag =
     options.preserveHooksFeatureFlag && hasNativeHooksFeatureFlag(original);
@@ -242,10 +601,20 @@ async function cleanConfig(
   // Strip OMX top-level keys, then restore a pre-existing user notify when
   // setup had wrapped it in the OMX dispatcher.
   config = stripOmxTopLevelKeys(config);
-  config = await restorePreviousNotifyIfDispatcher(configPath, config, original);
+  config = restorePreviousNotifyIfDispatcher(
+    config,
+    original,
+    options.notifyMetadata,
+  );
 
   // Strip OMX-seeded behavioral defaults only when the seeded pair is unchanged.
   config = stripOmxSeededBehavioralDefaults(config);
+
+  // Remove only trust tables whose hashes and coordinates match the planned
+  // managed hooks before their removal. User-owned conflicts remain intact.
+  config = stripManagedCodexHookTrustState(config, {
+    managedTrustState: options.priorHookTrustState,
+  });
 
   // Strip feature flags
   config = stripOmxFeatureFlags(config, { preserveMultiAgent: true });
@@ -264,22 +633,9 @@ async function cleanConfig(
 
   // Normalize trailing whitespace
   config = config.trimEnd() + "\n";
+  result.configCleaned = config !== original;
 
-  if (config !== original) {
-    result.configCleaned = true;
-    if (!options.dryRun) {
-      await writeFile(configPath, config);
-    }
-    if (options.verbose) {
-      console.log(
-        `  ${options.dryRun ? "Would clean" : "Cleaned"} ${configPath}`,
-      );
-    }
-  } else {
-    if (options.verbose) console.log("  No OMX config entries found.");
-  }
-
-  return result;
+  return { config: configSnapshot, finalContent: config, result };
 }
 
 async function removeInstalledPrompts(
@@ -404,35 +760,445 @@ async function removeAgentsMd(
   return true;
 }
 
-async function removeHooksFile(
-  hooksFilePath: string,
-  options: Pick<UninstallOptions, "dryRun" | "verbose">,
-): Promise<boolean> {
-  if (!existsSync(hooksFilePath)) return false;
+type UninstallArtifactKind = "hooks" | "shim" | "config";
 
-  const existing = await readFile(hooksFilePath, "utf-8");
-  const { nextContent, removedCount } = removeManagedCodexHooks(existing);
-  const parsed = parseCodexHooksConfig(existing);
-  const emptyManagedArtifact =
-    parsed !== null &&
-    Object.keys(parsed.hooks).length === 0 &&
-    Object.keys(parsed.root).every((key) => key === "hooks");
+interface PlannedFileMutation {
+  kind: UninstallArtifactKind;
+  snapshot: FileSnapshot;
+  finalContent: string | null;
+  validate?: (content: string) => void;
+}
 
-  if (removedCount === 0 && !emptyManagedArtifact) return false;
+interface UninstallArtifactTransaction {
+  preconditions: FileSnapshot[];
+  hooks?: PlannedFileMutation;
+  shim?: PlannedFileMutation;
+  config?: PlannedFileMutation;
+}
 
-  if (!options.dryRun) {
-    if (nextContent === null || emptyManagedArtifact) {
-      await rm(hooksFilePath, { force: true });
-    } else {
-      await writeFile(hooksFilePath, nextContent);
-    }
+interface MutationExecution {
+  mutation: PlannedFileMutation;
+  phase: "prepared" | "destructive" | "verified";
+  appliedSnapshot?: FileSnapshot;
+  stagedDeletion?: FileSnapshot;
+}
+
+function assertValidHooksJson(content: string): void {
+  JSON.parse(content);
+}
+
+function assertValidToml(content: string): void {
+  TOML.parse(content);
+}
+
+function transactionTemporaryPath(
+  path: string,
+  purpose: "write" | "delete",
+  options: Pick<UninstallOptions, "transactionTemporaryPath">,
+): string {
+  return options.transactionTemporaryPath?.(path, purpose) ?? join(
+    dirname(path),
+    `.${basename(path)}.omx-uninstall-${purpose}-${process.pid}-${randomUUID()}.tmp`,
+  );
+}
+
+function snapshotReadOptions(snapshot: FileSnapshot): {
+  strictUtf8: false;
+  controlledRoot?: string;
+} {
+  return {
+    strictUtf8: false,
+    controlledRoot: snapshot.topology?.root,
+  };
+}
+
+async function captureCurrentSnapshot(reference: FileSnapshot): Promise<FileSnapshot> {
+  return readFileSnapshot(reference.path, snapshotReadOptions(reference));
+}
+
+async function assertSnapshotCurrent(snapshot: FileSnapshot): Promise<void> {
+  await assertControlledTopologyCurrent(snapshot.topology);
+  const current = await captureCurrentSnapshot(snapshot);
+  if (snapshot.bytes === null && current.bytes === null) return;
+  if (
+    snapshot.bytes !== null &&
+    current.bytes !== null &&
+    snapshot.identity !== null &&
+    current.identity !== null &&
+    snapshot.bytes.equals(current.bytes) &&
+    hasSameFileIdentity(snapshot.identity, current.identity)
+  ) {
+    return;
   }
-  if (options.verbose) {
-    console.log(
-      `  ${options.dryRun ? "Would clean" : nextContent === null || emptyManagedArtifact ? "Removed" : "Cleaned"} ${basename(hooksFilePath)}`,
+  throw new Error(`Refusing uninstall because planned artifact ${snapshot.path} changed, was created, or was removed after planning.`);
+}
+
+async function assertSnapshotMatchesPlannedContent(
+  actual: FileSnapshot,
+  expected: FileSnapshot,
+  context: string,
+): Promise<void> {
+  await assertControlledTopologyCurrent(expected.topology);
+  if (
+    actual.bytes === null ||
+    expected.bytes === null ||
+    actual.mode !== expected.mode ||
+    !actual.bytes.equals(expected.bytes)
+  ) {
+    throw new Error(`Uninstall ${context} mismatch for ${expected.path}.`);
+  }
+}
+
+async function assertSnapshotsCurrent(snapshots: readonly FileSnapshot[]): Promise<void> {
+  for (const snapshot of snapshots) await assertSnapshotCurrent(snapshot);
+}
+
+async function removeOwnedTemporary(
+  path: string,
+  snapshot: FileSnapshot | undefined,
+  originalError: unknown,
+  description: "temporary" | "staged deletion",
+): Promise<void> {
+  try {
+    if (!snapshot) {
+      throw new Error(`${description} path was not fully captured after writing.`);
+    }
+    await assertSnapshotCurrent(snapshot);
+    await rm(path);
+  } catch (cleanupError) {
+    const message = originalError instanceof Error
+      ? originalError.message
+      : String(originalError);
+    throw new Error(
+      `Uninstall artifact transaction failed (${message}) and preserved ${description} ${path} for manual recovery after cleanup verification failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
     );
   }
-  return true;
+}
+
+async function atomicReplaceFile(
+  mutation: PlannedFileMutation,
+  expectedCurrent: FileSnapshot,
+  content: Buffer,
+  options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath">,
+  stage: "write" | "rollback",
+  onRename: () => void,
+): Promise<FileSnapshot> {
+  if (mutation.snapshot.mode === null) {
+    throw new Error(`Refusing to replace ${mutation.snapshot.path}: uninstall did not plan a regular-file mode.`);
+  }
+  const temporaryPath = transactionTemporaryPath(mutation.snapshot.path, "write", options);
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  let temporaryCreated = false;
+  let temporarySnapshot: FileSnapshot | undefined;
+  try {
+    await options.transactionFailureInjector?.(
+      stage === "write" ? "before-temp-write" : "before-rollback",
+    );
+    await assertSnapshotCurrent(expectedCurrent);
+    handle = await open(temporaryPath, "wx", mutation.snapshot.mode);
+    temporaryCreated = true;
+    await handle.writeFile(content);
+    await chmod(temporaryPath, mutation.snapshot.mode);
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    temporarySnapshot = await readFileSnapshot(
+      temporaryPath,
+      snapshotReadOptions(mutation.snapshot),
+    );
+    if (
+      temporarySnapshot.bytes === null ||
+      temporarySnapshot.mode !== mutation.snapshot.mode ||
+      !temporarySnapshot.bytes.equals(content)
+    ) {
+      throw new Error(`Read-back verification failed for replacement temporary ${temporaryPath}.`);
+    }
+    await options.transactionFailureInjector?.(
+      stage === "write" ? "before-rename" : "before-rollback-rename",
+    );
+    // Recheck at the mutation primitive immediately before replacing the target.
+    await assertControlledTopologyCurrent(mutation.snapshot.topology);
+    await assertSnapshotCurrent(expectedCurrent);
+    // Recheck the transaction-owned temporary immediately before replacing the target.
+    await assertSnapshotCurrent(temporarySnapshot);
+
+    await rename(temporaryPath, mutation.snapshot.path);
+    temporaryCreated = false;
+    onRename();
+
+    await assertControlledTopologyCurrent(mutation.snapshot.topology);
+    const actual = await captureCurrentSnapshot(mutation.snapshot);
+    if (
+      actual.bytes === null ||
+      actual.mode !== mutation.snapshot.mode ||
+      !actual.bytes.equals(content)
+    ) {
+      throw new Error(`Read-back verification failed for ${mutation.snapshot.path}: content bytes differ.`);
+    }
+    if (stage === "write" && mutation.validate) {
+      mutation.validate(decodeStrictUtf8(mutation.snapshot.path, actual.bytes));
+    }
+    return actual;
+  } catch (error) {
+    await handle?.close().catch(() => undefined);
+    if (temporaryCreated) {
+      await removeOwnedTemporary(
+        temporaryPath,
+        temporarySnapshot,
+        error,
+        "temporary",
+      );
+    }
+    throw error;
+  }
+}
+
+async function stageAndRemoveFile(
+  mutation: PlannedFileMutation,
+  execution: MutationExecution,
+  options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath">,
+): Promise<void> {
+  if (mutation.snapshot.bytes === null || mutation.snapshot.mode === null) {
+    throw new Error(`Refusing to remove ${mutation.snapshot.path}: uninstall did not plan a regular-file snapshot.`);
+  }
+  const stagedPath = transactionTemporaryPath(mutation.snapshot.path, "delete", options);
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  let stagedCreated = false;
+  let removalAttempted = false;
+  try {
+    await options.transactionFailureInjector?.("before-temp-write");
+    await assertSnapshotCurrent(mutation.snapshot);
+    handle = await open(stagedPath, "wx", mutation.snapshot.mode);
+    stagedCreated = true;
+    await handle.writeFile(mutation.snapshot.bytes);
+    await chmod(stagedPath, mutation.snapshot.mode);
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    const stagedDeletion = await readFileSnapshot(
+      stagedPath,
+      snapshotReadOptions(mutation.snapshot),
+    );
+    await assertSnapshotMatchesPlannedContent(
+      stagedDeletion,
+      mutation.snapshot,
+      "staged deletion",
+    );
+    execution.stagedDeletion = stagedDeletion;
+
+    await options.transactionFailureInjector?.("before-remove");
+    // Recheck at the mutation primitive immediately before removing the target.
+    await assertControlledTopologyCurrent(mutation.snapshot.topology);
+    await assertSnapshotCurrent(mutation.snapshot);
+    // Recheck the transaction-owned staged copy immediately before removing the target.
+    await assertSnapshotCurrent(stagedDeletion);
+    removalAttempted = true;
+    await rm(mutation.snapshot.path);
+    execution.phase = "destructive";
+    await assertControlledTopologyCurrent(mutation.snapshot.topology);
+    const absent = await captureCurrentSnapshot(mutation.snapshot);
+    if (absent.bytes !== null) {
+      throw new Error(`Read-back verification failed for ${mutation.snapshot.path}: expected absence.`);
+    }
+    execution.appliedSnapshot = absent;
+    execution.phase = "verified";
+  } catch (error) {
+    await handle?.close().catch(() => undefined);
+    if (stagedCreated && execution.phase === "prepared" && removalAttempted) {
+      try {
+        const current = await captureCurrentSnapshot(mutation.snapshot);
+        if (current.bytes === null) {
+          execution.phase = "destructive";
+          execution.appliedSnapshot = current;
+        }
+      } catch {
+        // Preserve the staged copy for manual recovery when removal state is unknown.
+        execution.phase = "destructive";
+      }
+    }
+    if (stagedCreated && execution.phase === "prepared") {
+      await removeOwnedTemporary(
+        stagedPath,
+        execution.stagedDeletion,
+        error,
+        "staged deletion",
+      );
+    }
+    throw error;
+  }
+}
+
+async function applyFileMutation(
+  execution: MutationExecution,
+  options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath">,
+): Promise<void> {
+  const { mutation } = execution;
+  if (mutation.finalContent === null) {
+    await stageAndRemoveFile(mutation, execution, options);
+    return;
+  }
+  execution.appliedSnapshot = await atomicReplaceFile(
+    mutation,
+    mutation.snapshot,
+    Buffer.from(mutation.finalContent, "utf-8"),
+    options,
+    "write",
+    () => {
+      execution.phase = "destructive";
+    },
+  );
+  execution.phase = "verified";
+}
+
+function mutationStage(kind: UninstallArtifactKind): UninstallTransactionFailureStage {
+  switch (kind) {
+    case "hooks":
+      return "before-hooks-commit";
+    case "shim":
+      return "before-shim-removal";
+    case "config":
+      return "before-config-commit";
+  }
+}
+
+async function restoreFileSnapshot(
+  execution: MutationExecution,
+  options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath">,
+): Promise<void> {
+  const { mutation, appliedSnapshot } = execution;
+  if (!appliedSnapshot) {
+    throw new Error(`Refusing stale rollback for ${mutation.snapshot.path}: the mutation did not produce a verifiable state.`);
+  }
+  await assertSnapshotCurrent(appliedSnapshot);
+  if (execution.stagedDeletion) await assertSnapshotCurrent(execution.stagedDeletion);
+
+  if (mutation.snapshot.bytes === null) {
+    await options.transactionFailureInjector?.("before-rollback");
+    await options.transactionFailureInjector?.("before-rollback-remove");
+    await assertControlledTopologyCurrent(mutation.snapshot.topology);
+    await assertSnapshotCurrent(appliedSnapshot);
+    await rm(mutation.snapshot.path);
+    const absent = await captureCurrentSnapshot(mutation.snapshot);
+    if (absent.bytes !== null) {
+      throw new Error(`Uninstall rollback mismatch for ${mutation.snapshot.path}: expected absence.`);
+    }
+    return;
+  }
+
+  const restored = await atomicReplaceFile(
+    mutation,
+    appliedSnapshot,
+    mutation.snapshot.bytes,
+    options,
+    "rollback",
+    () => undefined,
+  );
+  await assertSnapshotMatchesPlannedContent(restored, mutation.snapshot, "rollback");
+}
+
+async function cleanupStagedDeletions(
+  executions: readonly MutationExecution[],
+  options: Pick<UninstallOptions, "transactionFailureInjector">,
+  stage: "commit" | "rollback",
+): Promise<void> {
+  for (const execution of executions) {
+    if (!execution.stagedDeletion) continue;
+    if (stage === "rollback") {
+      await options.transactionFailureInjector?.("before-rollback-remove");
+    }
+    await options.transactionFailureInjector?.("before-staged-cleanup");
+    // Recheck immediately before removing the transaction-owned staged copy.
+    await assertSnapshotCurrent(execution.stagedDeletion);
+    await rm(execution.stagedDeletion.path);
+  }
+}
+
+async function rollbackArtifactMutations(
+  executions: readonly MutationExecution[],
+  options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath">,
+): Promise<void> {
+  const failures: string[] = [];
+  const restored: MutationExecution[] = [];
+  for (const execution of [...executions].reverse()) {
+    if (execution.phase === "prepared") continue;
+    try {
+      await restoreFileSnapshot(execution, options);
+      restored.push(execution);
+    } catch (error) {
+      failures.push(`${execution.mutation.kind}: ${String(error)}`);
+    }
+  }
+  try {
+    await cleanupStagedDeletions(restored, options, "rollback");
+  } catch (error) {
+    failures.push(`staged deletion cleanup: ${String(error)}`);
+  }
+  if (failures.length > 0) {
+    throw new Error(
+      `Uninstall artifact rollback failed; manual recovery is required: ${failures.join("; ")}`,
+    );
+  }
+}
+
+async function assertUnmutatedTransactionPreconditions(
+  transaction: UninstallArtifactTransaction,
+  executions: readonly MutationExecution[],
+): Promise<void> {
+  const mutatedPaths = new Set(
+    executions
+      .filter((execution) => execution.phase !== "prepared")
+      .map((execution) => execution.mutation.snapshot.path),
+  );
+  await assertSnapshotsCurrent(
+    transaction.preconditions.filter((snapshot) => !mutatedPaths.has(snapshot.path)),
+  );
+}
+
+async function commitUninstallArtifactTransaction(
+  transaction: UninstallArtifactTransaction,
+  options: Pick<
+    UninstallOptions,
+    "transactionFailureInjector" | "transactionTemporaryPath"
+  >,
+): Promise<void> {
+  const mutations = [transaction.hooks, transaction.shim, transaction.config]
+    .filter((mutation): mutation is PlannedFileMutation => mutation !== undefined);
+  for (const mutation of mutations) {
+    if (mutation.finalContent !== null) mutation.validate?.(mutation.finalContent);
+  }
+  await assertSnapshotsCurrent(transaction.preconditions);
+  if (mutations.length === 0) return;
+
+  const executions: MutationExecution[] = [];
+  try {
+    for (const mutation of mutations) {
+      await options.transactionFailureInjector?.(mutationStage(mutation.kind));
+      await assertUnmutatedTransactionPreconditions(transaction, executions);
+      const execution: MutationExecution = { mutation, phase: "prepared" };
+      executions.push(execution);
+      await applyFileMutation(execution, options);
+      if (mutation.kind === "config") {
+        await options.transactionFailureInjector?.("after-config-commit");
+      }
+    }
+  } catch (error) {
+    try {
+      await rollbackArtifactMutations(executions, options);
+    } catch (rollbackError) {
+      throw new Error(
+        `Uninstall artifact transaction failed (${String(error)}); ${String(rollbackError)}`,
+      );
+    }
+    throw error;
+  }
+
+  try {
+    await cleanupStagedDeletions(executions, options, "commit");
+  } catch (error) {
+    throw new Error(
+      `Uninstall artifact transaction committed but staged deletion cleanup failed: ${String(error)}`,
+    );
+  }
 }
 
 async function removeCacheDirectory(
@@ -506,7 +1272,7 @@ function printSummary(summary: UninstallSummary, dryRun: boolean): void {
         "    Feature flags (child_agents_md, goals; multi_agent and hooks are preserved when user-owned)",
       );
     }
-  } else if (!summary.configCleaned && summary.mcpServersRemoved.length === 0) {
+  } else if (summary.mcpServersRemoved.length === 0) {
     console.log("  config.toml: no OMX entries found (or --keep-config used)");
   }
 
@@ -565,6 +1331,74 @@ export async function uninstall(options: UninstallOptions = {}): Promise<void> {
   // Resolve scope (explicit --scope overrides persisted scope)
   const scope = options.scope ?? readPersistedSetupScope(projectRoot) ?? "user";
   const scopeDirs = resolveScopeDirectories(scope, projectRoot);
+  const transactionPlatform = options.transactionPlatform ?? process.platform;
+
+  // Precompute and validate every artifact before the first uninstall write.
+  const hooksSnapshot = await readFileSnapshot(scopeDirs.codexHooksFile, {
+    controlledRoot: scopeDirs.codexHomeDir,
+  });
+  const configSnapshot = await readFileSnapshot(scopeDirs.codexConfigFile, {
+    controlledRoot: scopeDirs.codexHomeDir,
+  });
+  const hooksRemoval = await planHooksRemoval(
+    hooksSnapshot,
+    pkgRoot,
+    transactionPlatform,
+    scopeDirs.codexHomeDir,
+  );
+  const notifyMetadata = keepConfig
+    ? undefined
+    : await planNotifyMetadata(configSnapshot, scopeDirs.codexHomeDir);
+  const preserveHooksFeatureFlag = hooksRemoval.plan?.hasForeignHooks ?? false;
+  const configCleanup = keepConfig
+    ? undefined
+    : await planConfigCleanup(
+        configSnapshot,
+        {
+          preserveHooksFeatureFlag,
+          priorHookTrustState: hooksRemoval.plan?.priorTrustState,
+          notifyMetadata,
+          codexFeaturesProbe: options.codexFeaturesProbe,
+          codexVersionProbe: options.codexVersionProbe,
+        },
+      );
+  const artifactTransaction: UninstallArtifactTransaction = {
+    preconditions: [
+      hooksRemoval.hooks,
+      ...(hooksRemoval.shim ? [hooksRemoval.shim] : []),
+      configSnapshot,
+      ...(notifyMetadata ? [notifyMetadata.snapshot] : []),
+    ],
+    ...(hooksRemoval.plan?.changed
+      ? {
+          hooks: {
+            kind: "hooks",
+            snapshot: hooksRemoval.hooks,
+            finalContent: hooksRemoval.plan.finalContent,
+            validate: assertValidHooksJson,
+          },
+        }
+      : {}),
+    ...(hooksRemoval.shim !== undefined && hooksRemoval.shim.bytes !== null
+      ? {
+          shim: {
+            kind: "shim",
+            snapshot: hooksRemoval.shim,
+            finalContent: null,
+          },
+        }
+      : {}),
+    ...(configCleanup?.result.configCleaned && configCleanup.finalContent !== null
+      ? {
+          config: {
+            kind: "config",
+            snapshot: configCleanup.config,
+            finalContent: configCleanup.finalContent,
+            validate: assertValidToml,
+          },
+        }
+      : {}),
+  };
 
   console.log("oh-my-codex uninstall");
   console.log("=====================\n");
@@ -590,35 +1424,49 @@ export async function uninstall(options: UninstallOptions = {}): Promise<void> {
   };
 
   summary.legacySkillRootWarning = await detectLegacySkillRootWarning(scope);
-  const preserveHooksFeatureFlag = await shouldPreserveHooksFeatureFlag(
-    scopeDirs.codexHooksFile,
-  );
+  summary.hooksFileRemoved =
+    artifactTransaction.hooks !== undefined || artifactTransaction.shim !== undefined;
+  if (configCleanup) Object.assign(summary, configCleanup.result);
 
-  // Step 1: Clean config.toml
-  if (keepConfig) {
-    console.log("[1/5] Skipping config.toml cleanup (--keep-config).");
-  } else {
-    console.log("[1/5] Cleaning config.toml...");
-    const configResult = await cleanConfig(scopeDirs.codexConfigFile, {
-      dryRun,
-      verbose,
-      preserveHooksFeatureFlag,
-      codexFeaturesProbe: options.codexFeaturesProbe,
-      codexVersionProbe: options.codexVersionProbe,
+  // Hooks, proof-owned shim, and config are one compensating transaction. The
+  // config mutation is intentionally last so hooks never reference unwritten trust.
+  console.log("[1/6] Removing native hooks artifact...");
+  if (!keepConfig) console.log("[2/6] Cleaning config.toml...");
+  if (!dryRun) {
+    await commitUninstallArtifactTransaction(artifactTransaction, {
+      transactionFailureInjector: options.transactionFailureInjector,
+      transactionTemporaryPath: options.transactionTemporaryPath,
     });
-    Object.assign(summary, configResult);
   }
-  console.log();
-
-  // Step 2: Remove installed prompts
-  console.log("[2/6] Removing native hooks artifact...");
-  summary.hooksFileRemoved = await removeHooksFile(scopeDirs.codexHooksFile, {
-    dryRun,
-    verbose,
-  });
+  if (verbose) {
+    if (artifactTransaction.hooks) {
+      console.log(
+        `  ${dryRun ? "Would clean" : artifactTransaction.hooks.finalContent === null ? "Removed" : "Cleaned"} ${basename(scopeDirs.codexHooksFile)}`,
+      );
+    }
+    if (artifactTransaction.shim) {
+      console.log(
+        `  ${dryRun ? "Would remove" : "Removed"} ${basename(artifactTransaction.shim.snapshot.path)}`,
+      );
+    }
+  }
   console.log(
     `  ${dryRun ? "Would clean" : "Cleaned"} ${summary.hooksFileRemoved ? 1 : 0} hooks artifact(s).`,
   );
+  console.log();
+
+  // Step 2: config cleanup is calculated before Step 1 and committed last.
+  if (keepConfig) {
+    console.log("[2/6] Skipping config.toml cleanup (--keep-config).");
+  } else if (verbose) {
+    if (configCleanup?.config.content === null) {
+      console.log("  config.toml not found, skipping.");
+    } else if (configCleanup?.result.configCleaned) {
+      console.log(`  ${dryRun ? "Would clean" : "Cleaned"} ${scopeDirs.codexConfigFile}`);
+    } else {
+      console.log("  No OMX config entries found.");
+    }
+  }
   console.log();
 
   // Step 3: Remove installed prompts

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -2,11 +2,18 @@
  * omx uninstall - Remove oh-my-codex configuration and installed artifacts
  */
 
-import { chmod, link, lstat, open, readFile, readdir, rename, rm } from "fs/promises";
+import { chmod, copyFile, lstat, open, readFile, readdir, rename, rm, writeFile } from "fs/promises";
 
-import { existsSync } from "fs";
+import { constants, existsSync } from "fs";
 import { join, basename, dirname, isAbsolute, relative } from "path";
 import { randomUUID } from "crypto";
+import {
+  clearNativeHookClaimJournal,
+  persistNativeHookClaimJournal,
+  recoverNativeHookClaimJournal,
+  syncNativeHookClaimParent,
+  restoreNativeHookClaimNoClobber,
+} from "./native-hook-claim-journal.js";
 import {
   formatTomlStringArray,
   getRootTomlArray,
@@ -40,7 +47,11 @@ import {
 
 import { resolveCodexHookFeatureFlagForCli } from "./codex-feature-probe.js";
 import { readPersistedSetupScope } from "./index.js";
-import { isOmxGeneratedAgentsMd } from "../utils/agents-md.js";
+import {
+  isOmxGeneratedAgentsMd,
+  OMX_MANAGED_AGENTS_END_MARKER,
+  OMX_MANAGED_AGENTS_START_MARKER,
+} from "../utils/agents-md.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import TOML from "@iarna/toml";
 
@@ -770,6 +781,17 @@ async function removeAgentsMd(
 
   try {
     const content = await readFile(agentsMdPath, "utf-8");
+    const startIndex = content.indexOf(OMX_MANAGED_AGENTS_START_MARKER);
+    const endIndex = content.indexOf(OMX_MANAGED_AGENTS_END_MARKER);
+    if (startIndex >= 0 && endIndex > startIndex) {
+      const blockEnd = endIndex + OMX_MANAGED_AGENTS_END_MARKER.length;
+      const preserved = `${content.slice(0, startIndex).trimEnd()}\n${content.slice(blockEnd).trimStart()}`.trim();
+      if (preserved) {
+        if (!options.dryRun) await writeFile(agentsMdPath, `${preserved}\n`, "utf-8");
+        if (options.verbose) console.log("  Removed OMX-managed AGENTS.md sections and preserved user guidance.");
+        return false;
+      }
+    }
     if (!isOmxGeneratedAgentsMd(content)) {
       if (options.verbose)
         console.log("  AGENTS.md is not OMX-generated, skipping.");
@@ -847,6 +869,10 @@ function transactionClaimPath(path: string): string {
     dirname(path),
     `.${basename(path)}.omx-uninstall-claim-${process.pid}-${randomUUID()}.tmp`,
   );
+}
+
+async function restoreUninstallClaim(claimPath: string, destinationPath: string): Promise<void> {
+  await restoreNativeHookClaimNoClobber(claimPath, destinationPath);
 }
 
 
@@ -983,8 +1009,7 @@ async function removeOwnedTemporary(
       await assertSnapshotAtPath(claimPath, snapshot, `${description} cleanup claim`);
     } catch (error) {
       try {
-        await link(claimPath, path);
-        await rm(claimPath);
+        await restoreUninstallClaim(claimPath, path);
       } catch (recoveryError) {
         throw new Error(
           `${error instanceof Error ? error.message : String(error)}; preserved claim ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
@@ -1023,6 +1048,7 @@ async function atomicReplaceFile(
   let temporarySnapshot: FileSnapshot | undefined;
   let claimPath: string | undefined;
   let claimCreated = false;
+  let journaledClaim = false;
   try {
     await options.transactionFailureInjector?.(
       stage === "write" ? "before-temp-write" : "before-rollback",
@@ -1059,52 +1085,79 @@ async function atomicReplaceFile(
         ? "after-final-rename-validation"
         : "after-final-restore-validation",
     );
-    await assertSnapshotCurrent(temporarySnapshot);
-
-    if (expectedCurrent.bytes !== null) {
-      claimPath = transactionClaimPath(mutation.snapshot.path);
-
-
+    if (!temporarySnapshot) {
+      throw new Error(`Replacement temporary ${temporaryPath} was not fully captured before install.`);
+    }
+    claimPath = transactionClaimPath(mutation.snapshot.path);
+    const controlledRoot = mutation.snapshot.topology?.root;
+    if (expectedCurrent.bytes !== null && controlledRoot) {
+      await persistNativeHookClaimJournal(controlledRoot, {
+        canonicalPath: mutation.snapshot.path,
+        claimPath,
+        before: expectedCurrent.bytes,
+        after: content,
+      });
+      journaledClaim = true;
       await rename(mutation.snapshot.path, claimPath);
       claimCreated = true;
+      await syncNativeHookClaimParent(claimPath);
       await assertSnapshotAtPath(claimPath, expectedCurrent, "replacement claim");
     }
-    // link() is a no-overwrite claim of the now-absent destination. It fails
-    // rather than replacing anything concurrently created at that coordinate.
-    await link(temporaryPath, mutation.snapshot.path);
+    await copyFile(temporaryPath, mutation.snapshot.path, constants.COPYFILE_EXCL);
+    await chmod(mutation.snapshot.path, mutation.snapshot.mode);
+    const installedHandle = await open(mutation.snapshot.path, "r");
+    try {
+      await installedHandle.sync();
+    } finally {
+      await installedHandle.close();
+    }
+    await syncNativeHookClaimParent(mutation.snapshot.path);
+    const actual = await captureCurrentSnapshot(mutation.snapshot);
+    if (actual.bytes === null || actual.mode !== mutation.snapshot.mode || !actual.bytes.equals(content)) {
+      throw new Error(`Read-back verification failed for replacement ${mutation.snapshot.path}.`);
+    }
+    if (claimCreated && claimPath) {
+      await rm(claimPath);
+      await syncNativeHookClaimParent(claimPath);
+      claimCreated = false;
+    }
+    if (journaledClaim && controlledRoot) {
+      await clearNativeHookClaimJournal(controlledRoot);
+      journaledClaim = false;
+    }
+    await rm(temporaryPath);
+    temporaryCreated = false;
     const ownership = renamedDestinationOwnership(
-      temporarySnapshot,
+      actual,
       mutation.snapshot.path,
       mutation.snapshot.topology,
     );
     onRename(ownership);
-    await rm(temporaryPath);
-    temporaryCreated = false;
-    if (claimPath) {
-      await rm(claimPath);
-      claimCreated = false;
-    }
 
     if (stage === "write") {
       await options.transactionFailureInjector?.("after-rename");
     }
 
-    const actual = await captureRenamedDestinationOwnership(ownership);
+    const verified = await captureRenamedDestinationOwnership(ownership);
     if (stage === "write" && mutation.validate) {
-      mutation.validate(decodeStrictUtf8(mutation.snapshot.path, actual.bytes!));
+      mutation.validate(decodeStrictUtf8(mutation.snapshot.path, verified.bytes!));
     }
-    return actual;
+    return verified;
   } catch (error) {
     await handle?.close().catch(() => undefined);
     if (claimCreated && claimPath) {
       try {
-        await link(claimPath, mutation.snapshot.path);
-        await rm(claimPath);
+        await restoreUninstallClaim(claimPath, mutation.snapshot.path);
+        await syncNativeHookClaimParent(mutation.snapshot.path);
         claimCreated = false;
+        const controlledRoot = mutation.snapshot.topology?.root;
+        if (journaledClaim && controlledRoot) {
+          await clearNativeHookClaimJournal(controlledRoot);
+          journaledClaim = false;
+        }
       } catch (recoveryError) {
-        const message = error instanceof Error ? error.message : String(error);
         throw new Error(
-          `Uninstall replacement failed (${message}) and preserved claim ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
+          `Uninstall replacement failed (${error instanceof Error ? error.message : String(error)}) and preserved ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
         );
       }
     }
@@ -1166,7 +1219,17 @@ async function stageAndRemoveFile(
     const claimPath = transactionClaimPath(mutation.snapshot.path);
 
 
+    const controlledRoot = mutation.snapshot.topology?.root;
+    if (controlledRoot && mutation.snapshot.bytes !== null) {
+      await persistNativeHookClaimJournal(controlledRoot, {
+        canonicalPath: mutation.snapshot.path,
+        claimPath,
+        before: mutation.snapshot.bytes,
+        after: null,
+      });
+    }
     await rename(mutation.snapshot.path, claimPath);
+    if (controlledRoot) await syncNativeHookClaimParent(claimPath);
     execution.appliedSnapshot = {
       path: mutation.snapshot.path,
       content: null,
@@ -1182,8 +1245,9 @@ async function stageAndRemoveFile(
       await assertSnapshotAtPath(claimPath, mutation.snapshot, "removal claim");
     } catch (error) {
       try {
-        await link(claimPath, mutation.snapshot.path);
-        await rm(claimPath);
+        await restoreUninstallClaim(claimPath, mutation.snapshot.path);
+        if (controlledRoot) await syncNativeHookClaimParent(mutation.snapshot.path);
+        if (controlledRoot) await clearNativeHookClaimJournal(controlledRoot);
         execution.appliedSnapshot = undefined;
         execution.phase = "prepared";
       } catch (recoveryError) {
@@ -1194,6 +1258,8 @@ async function stageAndRemoveFile(
       throw error;
     }
     await rm(claimPath);
+    if (controlledRoot) await syncNativeHookClaimParent(claimPath);
+    if (controlledRoot) await clearNativeHookClaimJournal(controlledRoot);
     await options.transactionFailureInjector?.("after-remove");
     await assertControlledTopologyCurrent(mutation.snapshot.topology);
     const absent = await captureCurrentSnapshot(mutation.snapshot);
@@ -1306,8 +1372,7 @@ async function restoreFileSnapshot(
       await assertSnapshotAtPath(claimPath, appliedSnapshot, "rollback removal claim");
     } catch (error) {
       try {
-        await link(claimPath, mutation.snapshot.path);
-        await rm(claimPath);
+        await restoreUninstallClaim(claimPath, mutation.snapshot.path);
       } catch (recoveryError) {
         throw new Error(
           `Uninstall rollback removal claim failed (${error instanceof Error ? error.message : String(error)}) and preserved ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
@@ -1366,8 +1431,7 @@ async function cleanupStagedDeletions(
       await assertSnapshotAtPath(claimPath, stagedDeletion, "staged deletion cleanup claim");
     } catch (error) {
       try {
-        await link(claimPath, stagedDeletion.path);
-        await rm(claimPath);
+        await restoreUninstallClaim(claimPath, stagedDeletion.path);
       } catch (recoveryError) {
         throw new Error(
           `Uninstall staged deletion cleanup claim failed (${error instanceof Error ? error.message : String(error)}) and preserved ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
@@ -1658,6 +1722,9 @@ export async function uninstall(options: UninstallOptions = {}): Promise<void> {
   // Resolve scope (explicit --scope overrides persisted scope)
   const scope = options.scope ?? readPersistedSetupScope(projectRoot) ?? "user";
   const scopeDirs = resolveScopeDirectories(scope, projectRoot);
+  if (!dryRun) {
+    await recoverNativeHookClaimJournal(scopeDirs.codexHomeDir);
+  }
   const transactionPlatform = options.transactionPlatform ?? process.platform;
 
   // Precompute and validate every artifact before the first uninstall write.

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -31,7 +31,12 @@ import {
 import { getPackageRoot } from "../utils/package.js";
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { detectLegacySkillRootOverlap } from "../utils/paths.js";
-import { resolveScopeDirectories, type SetupScope } from "./setup.js";
+import {
+  decideWindowsNativeHookShimReference,
+  resolveScopeDirectories,
+  type SetupScope,
+} from "./setup.js";
+
 import { resolveCodexHookFeatureFlagForCli } from "./codex-feature-probe.js";
 import { readPersistedSetupScope } from "./index.js";
 import { isOmxGeneratedAgentsMd } from "../utils/agents-md.js";
@@ -45,11 +50,14 @@ export type UninstallTransactionFailureStage =
   | "before-config-commit"
   | "before-temp-write"
   | "before-rename"
+  | "after-rename"
   | "before-remove"
+  | "after-remove"
   | "before-rollback"
   | "before-rollback-rename"
   | "before-rollback-remove"
   | "before-staged-cleanup"
+  | "after-staged-cleanup"
   | "after-config-commit";
 
 export interface UninstallOptions {
@@ -189,6 +197,7 @@ interface PlannedHooksRemoval {
   hooks: FileSnapshot;
   plan?: ManagedCodexHooksPlan;
   shim?: FileSnapshot;
+  preservedShimPrecondition?: FileSnapshot;
 }
 
 function fileIdentity(stat: Awaited<ReturnType<typeof lstat>>): FileIdentity {
@@ -385,15 +394,14 @@ async function planHooksRemoval(
         `Refusing to remove modified native hook Windows shim at ${shim.path}.`,
       );
     }
-    if (
-      plan?.finalContent?.toLowerCase().includes(
-        "omx-native-hook-windows-shim.ps1",
-      )
-    ) {
-      throw new Error(
-        `Refusing to remove native hook Windows shim at ${shim.path} while surviving hooks still reference it.`,
-      );
+    const shimReference = decideWindowsNativeHookShimReference(
+      plan?.finalContent ?? null,
+      shim.path,
+    );
+    if (shimReference !== "not_referenced") {
+      return { hooks, plan, preservedShimPrecondition: shim };
     }
+
   }
 
   return { hooks, plan, shim };
@@ -566,6 +574,7 @@ async function planConfigCleanup(
   > & {
     preserveHooksFeatureFlag?: boolean;
     priorHookTrustState?: Record<string, ManagedCodexHookTrustState>;
+    finalHookTrustState?: Record<string, ManagedCodexHookTrustState>;
     notifyMetadata?: PlannedNotifyMetadata;
   },
 ): Promise<PlannedConfigCleanup> {
@@ -593,6 +602,13 @@ async function planConfigCleanup(
   result.topLevelKeysRemoved = detected.hasTopLevelKeys;
   result.featureFlagsRemoved = detected.hasFeatureFlags;
 
+  // Verify proof ownership against the untouched source before marker stripping
+  // can hide a foreign sibling in an otherwise OMX-looking trust declaration.
+  stripManagedCodexHookTrustState(original, {
+    priorManagedHookTrustState: options.priorHookTrustState,
+    managedTrustState: options.finalHookTrustState,
+  });
+
   // Strip OMX tables block (MCP servers, agents, tui)
   let config = original;
   const { cleaned } = stripExistingOmxBlocks(config);
@@ -613,7 +629,8 @@ async function planConfigCleanup(
   // Remove only trust tables whose hashes and coordinates match the planned
   // managed hooks before their removal. User-owned conflicts remain intact.
   config = stripManagedCodexHookTrustState(config, {
-    managedTrustState: options.priorHookTrustState,
+    priorManagedHookTrustState: options.priorHookTrustState,
+    managedTrustState: options.finalHookTrustState,
   });
 
   // Strip feature flags
@@ -776,12 +793,25 @@ interface UninstallArtifactTransaction {
   config?: PlannedFileMutation;
 }
 
+interface RenamedDestinationOwnership {
+  path: string;
+  bytes: Buffer;
+  mode: number;
+  identity: Pick<FileIdentity, "dev" | "ino">;
+  topology: FileTopology | null;
+}
+
 interface MutationExecution {
   mutation: PlannedFileMutation;
   phase: "prepared" | "destructive" | "verified";
   appliedSnapshot?: FileSnapshot;
+  renamedOwnership?: RenamedDestinationOwnership;
   stagedDeletion?: FileSnapshot;
+  stagedDeletionCleaned?: boolean;
 }
+
+
+
 
 function assertValidHooksJson(content: string): void {
   JSON.parse(content);
@@ -815,6 +845,45 @@ function snapshotReadOptions(snapshot: FileSnapshot): {
 async function captureCurrentSnapshot(reference: FileSnapshot): Promise<FileSnapshot> {
   return readFileSnapshot(reference.path, snapshotReadOptions(reference));
 }
+
+function renamedDestinationOwnership(
+  snapshot: FileSnapshot,
+  destinationPath: string,
+  topology: FileTopology | null,
+): RenamedDestinationOwnership {
+  if (snapshot.bytes === null || snapshot.mode === null || snapshot.identity === null) {
+    throw new Error(`Replacement temporary ${snapshot.path} was not fully captured before rename.`);
+  }
+  return {
+    path: destinationPath,
+    bytes: snapshot.bytes,
+    mode: snapshot.mode,
+    identity: { dev: snapshot.identity.dev, ino: snapshot.identity.ino },
+    topology,
+  };
+}
+
+async function captureRenamedDestinationOwnership(
+  ownership: RenamedDestinationOwnership,
+): Promise<FileSnapshot> {
+  await assertControlledTopologyCurrent(ownership.topology);
+  const current = await readFileSnapshot(ownership.path, {
+    strictUtf8: false,
+    controlledRoot: ownership.topology?.root,
+  });
+  if (
+    current.bytes === null ||
+    current.mode !== ownership.mode ||
+    !current.bytes.equals(ownership.bytes) ||
+    current.identity === null ||
+    current.identity.dev !== ownership.identity.dev ||
+    current.identity.ino !== ownership.identity.ino
+  ) {
+    throw new Error(`Uninstall replacement ownership changed for ${ownership.path}.`);
+  }
+  return current;
+}
+
 
 async function assertSnapshotCurrent(snapshot: FileSnapshot): Promise<void> {
   await assertControlledTopologyCurrent(snapshot.topology);
@@ -881,7 +950,8 @@ async function atomicReplaceFile(
   content: Buffer,
   options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath">,
   stage: "write" | "rollback",
-  onRename: () => void,
+  onRename: (ownership: RenamedDestinationOwnership) => void | Promise<void>,
+  assertApplied?: () => Promise<void>,
 ): Promise<FileSnapshot> {
   if (mutation.snapshot.mode === null) {
     throw new Error(`Refusing to replace ${mutation.snapshot.path}: uninstall did not plan a regular-file mode.`);
@@ -894,6 +964,7 @@ async function atomicReplaceFile(
     await options.transactionFailureInjector?.(
       stage === "write" ? "before-temp-write" : "before-rollback",
     );
+    await assertApplied?.();
     await assertSnapshotCurrent(expectedCurrent);
     handle = await open(temporaryPath, "wx", mutation.snapshot.mode);
     temporaryCreated = true;
@@ -916,6 +987,7 @@ async function atomicReplaceFile(
     await options.transactionFailureInjector?.(
       stage === "write" ? "before-rename" : "before-rollback-rename",
     );
+    await assertApplied?.();
     // Recheck at the mutation primitive immediately before replacing the target.
     await assertControlledTopologyCurrent(mutation.snapshot.topology);
     await assertSnapshotCurrent(expectedCurrent);
@@ -924,19 +996,19 @@ async function atomicReplaceFile(
 
     await rename(temporaryPath, mutation.snapshot.path);
     temporaryCreated = false;
-    onRename();
-
-    await assertControlledTopologyCurrent(mutation.snapshot.topology);
-    const actual = await captureCurrentSnapshot(mutation.snapshot);
-    if (
-      actual.bytes === null ||
-      actual.mode !== mutation.snapshot.mode ||
-      !actual.bytes.equals(content)
-    ) {
-      throw new Error(`Read-back verification failed for ${mutation.snapshot.path}: content bytes differ.`);
+    const ownership = renamedDestinationOwnership(
+      temporarySnapshot,
+      mutation.snapshot.path,
+      mutation.snapshot.topology,
+    );
+    await onRename(ownership);
+    if (stage === "write") {
+      await options.transactionFailureInjector?.("after-rename");
     }
+
+    const actual = await captureRenamedDestinationOwnership(ownership);
     if (stage === "write" && mutation.validate) {
-      mutation.validate(decodeStrictUtf8(mutation.snapshot.path, actual.bytes));
+      mutation.validate(decodeStrictUtf8(mutation.snapshot.path, actual.bytes!));
     }
     return actual;
   } catch (error) {
@@ -957,6 +1029,7 @@ async function stageAndRemoveFile(
   mutation: PlannedFileMutation,
   execution: MutationExecution,
   options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath">,
+  assertApplied: () => Promise<void>,
 ): Promise<void> {
   if (mutation.snapshot.bytes === null || mutation.snapshot.mode === null) {
     throw new Error(`Refusing to remove ${mutation.snapshot.path}: uninstall did not plan a regular-file snapshot.`);
@@ -964,9 +1037,9 @@ async function stageAndRemoveFile(
   const stagedPath = transactionTemporaryPath(mutation.snapshot.path, "delete", options);
   let handle: Awaited<ReturnType<typeof open>> | undefined;
   let stagedCreated = false;
-  let removalAttempted = false;
   try {
     await options.transactionFailureInjector?.("before-temp-write");
+    await assertApplied();
     await assertSnapshotCurrent(mutation.snapshot);
     handle = await open(stagedPath, "wx", mutation.snapshot.mode);
     stagedCreated = true;
@@ -992,30 +1065,26 @@ async function stageAndRemoveFile(
     await assertSnapshotCurrent(mutation.snapshot);
     // Recheck the transaction-owned staged copy immediately before removing the target.
     await assertSnapshotCurrent(stagedDeletion);
-    removalAttempted = true;
+    await assertApplied();
     await rm(mutation.snapshot.path);
+    execution.appliedSnapshot = {
+      path: mutation.snapshot.path,
+      content: null,
+      bytes: null,
+      mode: null,
+      identity: null,
+      topology: mutation.snapshot.topology,
+    };
     execution.phase = "destructive";
+    await options.transactionFailureInjector?.("after-remove");
     await assertControlledTopologyCurrent(mutation.snapshot.topology);
     const absent = await captureCurrentSnapshot(mutation.snapshot);
     if (absent.bytes !== null) {
       throw new Error(`Read-back verification failed for ${mutation.snapshot.path}: expected absence.`);
     }
-    execution.appliedSnapshot = absent;
     execution.phase = "verified";
   } catch (error) {
     await handle?.close().catch(() => undefined);
-    if (stagedCreated && execution.phase === "prepared" && removalAttempted) {
-      try {
-        const current = await captureCurrentSnapshot(mutation.snapshot);
-        if (current.bytes === null) {
-          execution.phase = "destructive";
-          execution.appliedSnapshot = current;
-        }
-      } catch {
-        // Preserve the staged copy for manual recovery when removal state is unknown.
-        execution.phase = "destructive";
-      }
-    }
     if (stagedCreated && execution.phase === "prepared") {
       await removeOwnedTemporary(
         stagedPath,
@@ -1030,23 +1099,33 @@ async function stageAndRemoveFile(
 
 async function applyFileMutation(
   execution: MutationExecution,
+  executions: readonly MutationExecution[],
   options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath">,
 ): Promise<void> {
   const { mutation } = execution;
   if (mutation.finalContent === null) {
-    await stageAndRemoveFile(mutation, execution, options);
+    await stageAndRemoveFile(
+      mutation,
+      execution,
+      options,
+      () => assertAppliedTransactionSnapshots(executions),
+    );
     return;
   }
-  execution.appliedSnapshot = await atomicReplaceFile(
+  const appliedSnapshot = await atomicReplaceFile(
     mutation,
     mutation.snapshot,
     Buffer.from(mutation.finalContent, "utf-8"),
     options,
     "write",
-    () => {
+    (ownership) => {
+      execution.renamedOwnership = ownership;
       execution.phase = "destructive";
     },
+    () => assertAppliedTransactionSnapshots(executions),
   );
+  execution.appliedSnapshot = appliedSnapshot;
+  execution.renamedOwnership = undefined;
   execution.phase = "verified";
 }
 
@@ -1061,23 +1140,46 @@ function mutationStage(kind: UninstallArtifactKind): UninstallTransactionFailure
   }
 }
 
+async function captureRollbackOwnedSnapshot(
+  execution: MutationExecution,
+): Promise<FileSnapshot> {
+  if (execution.appliedSnapshot) {
+    await assertSnapshotCurrent(execution.appliedSnapshot);
+    return execution.appliedSnapshot;
+  }
+  if (execution.renamedOwnership) {
+    return captureRenamedDestinationOwnership(execution.renamedOwnership);
+  }
+  throw new Error(`Refusing stale rollback for ${execution.mutation.snapshot.path}: the mutation did not produce a verifiable state.`);
+}
+
 async function restoreFileSnapshot(
   execution: MutationExecution,
   options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath">,
+  assertRollbackState: () => Promise<void>,
 ): Promise<void> {
-  const { mutation, appliedSnapshot } = execution;
-  if (!appliedSnapshot) {
-    throw new Error(`Refusing stale rollback for ${mutation.snapshot.path}: the mutation did not produce a verifiable state.`);
+  const { mutation } = execution;
+  const appliedSnapshot = await captureRollbackOwnedSnapshot(execution);
+  if (execution.stagedDeletion && !execution.stagedDeletionCleaned) {
+    await assertSnapshotCurrent(execution.stagedDeletion);
   }
-  await assertSnapshotCurrent(appliedSnapshot);
-  if (execution.stagedDeletion) await assertSnapshotCurrent(execution.stagedDeletion);
 
   if (mutation.snapshot.bytes === null) {
     await options.transactionFailureInjector?.("before-rollback");
     await options.transactionFailureInjector?.("before-rollback-remove");
+    await assertRollbackState();
     await assertControlledTopologyCurrent(mutation.snapshot.topology);
     await assertSnapshotCurrent(appliedSnapshot);
     await rm(mutation.snapshot.path);
+    execution.appliedSnapshot = {
+      path: mutation.snapshot.path,
+      content: null,
+      bytes: null,
+      mode: null,
+      identity: null,
+      topology: mutation.snapshot.topology,
+    };
+    execution.renamedOwnership = undefined;
     const absent = await captureCurrentSnapshot(mutation.snapshot);
     if (absent.bytes !== null) {
       throw new Error(`Uninstall rollback mismatch for ${mutation.snapshot.path}: expected absence.`);
@@ -1091,8 +1193,13 @@ async function restoreFileSnapshot(
     mutation.snapshot.bytes,
     options,
     "rollback",
-    () => undefined,
+    (ownership) => {
+      execution.renamedOwnership = ownership;
+    },
+    assertRollbackState,
   );
+  execution.appliedSnapshot = restored;
+  execution.renamedOwnership = undefined;
   await assertSnapshotMatchesPlannedContent(restored, mutation.snapshot, "rollback");
 }
 
@@ -1100,16 +1207,38 @@ async function cleanupStagedDeletions(
   executions: readonly MutationExecution[],
   options: Pick<UninstallOptions, "transactionFailureInjector">,
   stage: "commit" | "rollback",
+  transaction?: UninstallArtifactTransaction,
+  assertRollbackState?: () => Promise<void>,
 ): Promise<void> {
   for (const execution of executions) {
-    if (!execution.stagedDeletion) continue;
+    if (!execution.stagedDeletion || execution.stagedDeletionCleaned) continue;
     if (stage === "rollback") {
       await options.transactionFailureInjector?.("before-rollback-remove");
     }
     await options.transactionFailureInjector?.("before-staged-cleanup");
+    if (transaction) {
+      await assertUnmutatedTransactionPreconditions(transaction, executions);
+      await assertAppliedTransactionSnapshots(executions);
+    }
+    await assertRollbackState?.();
+
     // Recheck immediately before removing the transaction-owned staged copy.
     await assertSnapshotCurrent(execution.stagedDeletion);
     await rm(execution.stagedDeletion.path);
+    execution.stagedDeletionCleaned = true;
+    await assertRollbackState?.();
+  }
+}
+
+async function assertRollbackTransactionState(
+  executions: readonly MutationExecution[],
+): Promise<void> {
+  for (const execution of executions) {
+    if (execution.phase === "prepared") continue;
+    if (execution.stagedDeletion && !execution.stagedDeletionCleaned) {
+      await assertSnapshotCurrent(execution.stagedDeletion);
+    }
+    await captureRollbackOwnedSnapshot(execution);
   }
 }
 
@@ -1119,19 +1248,42 @@ async function rollbackArtifactMutations(
 ): Promise<void> {
   const failures: string[] = [];
   const restored: MutationExecution[] = [];
-  for (const execution of [...executions].reverse()) {
-    if (execution.phase === "prepared") continue;
-    try {
-      await restoreFileSnapshot(execution, options);
-      restored.push(execution);
-    } catch (error) {
-      failures.push(`${execution.mutation.kind}: ${String(error)}`);
+  try {
+    await assertRollbackTransactionState(executions);
+  } catch (error) {
+    failures.push(`recovery preflight: ${String(error)}`);
+  }
+  if (failures.length === 0) {
+    for (const execution of [...executions].reverse()) {
+      if (execution.phase === "prepared") continue;
+      try {
+        await assertRollbackTransactionState(executions);
+        await restoreFileSnapshot(
+          execution,
+          options,
+          () => assertRollbackTransactionState(executions),
+        );
+        restored.push(execution);
+        await assertRollbackTransactionState(executions);
+      } catch (error) {
+        failures.push(`${execution.mutation.kind}: ${String(error)}`);
+      }
     }
   }
-  try {
-    await cleanupStagedDeletions(restored, options, "rollback");
-  } catch (error) {
-    failures.push(`staged deletion cleanup: ${String(error)}`);
+  if (failures.length === 0) {
+    try {
+      await assertRollbackTransactionState(executions);
+      await cleanupStagedDeletions(
+        restored,
+        options,
+        "rollback",
+        undefined,
+        () => assertRollbackTransactionState(executions),
+      );
+      await assertRollbackTransactionState(executions);
+    } catch (error) {
+      failures.push(`staged deletion cleanup: ${String(error)}`);
+    }
   }
   if (failures.length > 0) {
     throw new Error(
@@ -1154,6 +1306,19 @@ async function assertUnmutatedTransactionPreconditions(
   );
 }
 
+async function assertAppliedTransactionSnapshots(
+  executions: readonly MutationExecution[],
+): Promise<void> {
+  for (const execution of executions) {
+    if (execution.phase === "prepared") continue;
+    if (!execution.appliedSnapshot) {
+      throw new Error(`Refusing uninstall because ${execution.mutation.snapshot.path} did not register an applied snapshot.`);
+    }
+    await assertSnapshotCurrent(execution.appliedSnapshot);
+  }
+}
+
+
 async function commitUninstallArtifactTransaction(
   transaction: UninstallArtifactTransaction,
   options: Pick<
@@ -1170,18 +1335,37 @@ async function commitUninstallArtifactTransaction(
   if (mutations.length === 0) return;
 
   const executions: MutationExecution[] = [];
+  let stagedCleanupStarted = false;
   try {
     for (const mutation of mutations) {
       await options.transactionFailureInjector?.(mutationStage(mutation.kind));
       await assertUnmutatedTransactionPreconditions(transaction, executions);
+      await assertAppliedTransactionSnapshots(executions);
       const execution: MutationExecution = { mutation, phase: "prepared" };
       executions.push(execution);
-      await applyFileMutation(execution, options);
+      await applyFileMutation(execution, executions, options);
       if (mutation.kind === "config") {
         await options.transactionFailureInjector?.("after-config-commit");
       }
+      await assertUnmutatedTransactionPreconditions(transaction, executions);
+      await assertAppliedTransactionSnapshots(executions);
     }
+    await assertUnmutatedTransactionPreconditions(transaction, executions);
+    await assertAppliedTransactionSnapshots(executions);
+    stagedCleanupStarted = true;
+    await cleanupStagedDeletions(executions, options, "commit", transaction);
+    await options.transactionFailureInjector?.("after-staged-cleanup");
+    await assertUnmutatedTransactionPreconditions(transaction, executions);
+    await assertAppliedTransactionSnapshots(executions);
   } catch (error) {
+    if (
+      stagedCleanupStarted &&
+      executions.some((execution) => execution.stagedDeletionCleaned)
+    ) {
+      throw new Error(
+        `Uninstall artifact transaction committed but staged deletion cleanup failed during finalization: ${String(error)}`,
+      );
+    }
     try {
       await rollbackArtifactMutations(executions, options);
     } catch (rollbackError) {
@@ -1190,14 +1374,6 @@ async function commitUninstallArtifactTransaction(
       );
     }
     throw error;
-  }
-
-  try {
-    await cleanupStagedDeletions(executions, options, "commit");
-  } catch (error) {
-    throw new Error(
-      `Uninstall artifact transaction committed but staged deletion cleanup failed: ${String(error)}`,
-    );
   }
 }
 
@@ -1357,6 +1533,7 @@ export async function uninstall(options: UninstallOptions = {}): Promise<void> {
         {
           preserveHooksFeatureFlag,
           priorHookTrustState: hooksRemoval.plan?.priorTrustState,
+          finalHookTrustState: hooksRemoval.plan?.finalTrustState,
           notifyMetadata,
           codexFeaturesProbe: options.codexFeaturesProbe,
           codexVersionProbe: options.codexVersionProbe,
@@ -1365,7 +1542,11 @@ export async function uninstall(options: UninstallOptions = {}): Promise<void> {
   const artifactTransaction: UninstallArtifactTransaction = {
     preconditions: [
       hooksRemoval.hooks,
-      ...(hooksRemoval.shim ? [hooksRemoval.shim] : []),
+      ...(hooksRemoval.shim
+        ? [hooksRemoval.shim]
+        : hooksRemoval.preservedShimPrecondition
+          ? [hooksRemoval.preservedShimPrecondition]
+          : []),
       configSnapshot,
       ...(notifyMetadata ? [notifyMetadata.snapshot] : []),
     ],

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -2,7 +2,8 @@
  * omx uninstall - Remove oh-my-codex configuration and installed artifacts
  */
 
-import { chmod, lstat, open, readFile, readdir, rename, rm } from "fs/promises";
+import { chmod, link, lstat, open, readFile, readdir, rename, rm } from "fs/promises";
+
 import { existsSync } from "fs";
 import { join, basename, dirname, isAbsolute, relative } from "path";
 import { randomUUID } from "crypto";
@@ -50,15 +51,19 @@ export type UninstallTransactionFailureStage =
   | "before-config-commit"
   | "before-temp-write"
   | "before-rename"
+  | "after-final-rename-validation"
   | "after-rename"
   | "before-remove"
+  | "after-final-remove-validation"
   | "after-remove"
   | "before-rollback"
   | "before-rollback-rename"
+  | "after-final-restore-validation"
   | "before-rollback-remove"
   | "before-staged-cleanup"
   | "after-staged-cleanup"
   | "after-config-commit";
+
 
 export interface UninstallOptions {
   codexFeaturesProbe?: () => string | null;
@@ -79,6 +84,8 @@ export interface UninstallOptions {
     path: string,
     purpose: "write" | "delete",
   ) => string;
+
+
 }
 
 interface UninstallSummary {
@@ -611,7 +618,10 @@ async function planConfigCleanup(
 
   // Strip OMX tables block (MCP servers, agents, tui)
   let config = original;
-  const { cleaned } = stripExistingOmxBlocks(config);
+  const { cleaned } = stripExistingOmxBlocks(config, {
+    managedTrustState: options.finalHookTrustState,
+    priorManagedHookTrustState: options.priorHookTrustState,
+  });
   config = cleaned;
 
   // Strip OMX top-level keys, then restore a pre-existing user notify when
@@ -832,6 +842,14 @@ function transactionTemporaryPath(
   );
 }
 
+function transactionClaimPath(path: string): string {
+  return join(
+    dirname(path),
+    `.${basename(path)}.omx-uninstall-claim-${process.pid}-${randomUUID()}.tmp`,
+  );
+}
+
+
 function snapshotReadOptions(snapshot: FileSnapshot): {
   strictUtf8: false;
   controlledRoot?: string;
@@ -902,6 +920,30 @@ async function assertSnapshotCurrent(snapshot: FileSnapshot): Promise<void> {
   throw new Error(`Refusing uninstall because planned artifact ${snapshot.path} changed, was created, or was removed after planning.`);
 }
 
+async function assertSnapshotAtPath(
+  path: string,
+  expected: FileSnapshot,
+  context: string,
+): Promise<FileSnapshot> {
+  await assertControlledTopologyCurrent(expected.topology);
+  const actual = await readFileSnapshot(path, snapshotReadOptions(expected));
+  if (
+    expected.bytes === null ||
+    actual.bytes === null ||
+    expected.identity === null ||
+    actual.identity === null ||
+    !expected.bytes.equals(actual.bytes) ||
+    actual.mode !== expected.mode ||
+    actual.identity.dev !== expected.identity.dev ||
+    actual.identity.ino !== expected.identity.ino
+  ) {
+    throw new Error(`Refusing uninstall because ${context} ${path} is not the planned artifact.`);
+  }
+  return actual;
+
+}
+
+
 async function assertSnapshotMatchesPlannedContent(
   actual: FileSnapshot,
   expected: FileSnapshot,
@@ -928,12 +970,29 @@ async function removeOwnedTemporary(
   originalError: unknown,
   description: "temporary" | "staged deletion",
 ): Promise<void> {
+
   try {
     if (!snapshot) {
       throw new Error(`${description} path was not fully captured after writing.`);
     }
     await assertSnapshotCurrent(snapshot);
-    await rm(path);
+    const claimPath = transactionClaimPath(path);
+
+    await rename(path, claimPath);
+    try {
+      await assertSnapshotAtPath(claimPath, snapshot, `${description} cleanup claim`);
+    } catch (error) {
+      try {
+        await link(claimPath, path);
+        await rm(claimPath);
+      } catch (recoveryError) {
+        throw new Error(
+          `${error instanceof Error ? error.message : String(error)}; preserved claim ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
+        );
+      }
+      throw error;
+    }
+    await rm(claimPath);
   } catch (cleanupError) {
     const message = originalError instanceof Error
       ? originalError.message
@@ -944,13 +1003,15 @@ async function removeOwnedTemporary(
   }
 }
 
+
 async function atomicReplaceFile(
   mutation: PlannedFileMutation,
   expectedCurrent: FileSnapshot,
   content: Buffer,
   options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath">,
   stage: "write" | "rollback",
-  onRename: (ownership: RenamedDestinationOwnership) => void | Promise<void>,
+  onRename: (ownership: RenamedDestinationOwnership) => void,
+
   assertApplied?: () => Promise<void>,
 ): Promise<FileSnapshot> {
   if (mutation.snapshot.mode === null) {
@@ -960,6 +1021,8 @@ async function atomicReplaceFile(
   let handle: Awaited<ReturnType<typeof open>> | undefined;
   let temporaryCreated = false;
   let temporarySnapshot: FileSnapshot | undefined;
+  let claimPath: string | undefined;
+  let claimCreated = false;
   try {
     await options.transactionFailureInjector?.(
       stage === "write" ? "before-temp-write" : "before-rollback",
@@ -988,20 +1051,40 @@ async function atomicReplaceFile(
       stage === "write" ? "before-rename" : "before-rollback-rename",
     );
     await assertApplied?.();
-    // Recheck at the mutation primitive immediately before replacing the target.
     await assertControlledTopologyCurrent(mutation.snapshot.topology);
     await assertSnapshotCurrent(expectedCurrent);
-    // Recheck the transaction-owned temporary immediately before replacing the target.
+    await assertSnapshotCurrent(temporarySnapshot);
+    await options.transactionFailureInjector?.(
+      stage === "write"
+        ? "after-final-rename-validation"
+        : "after-final-restore-validation",
+    );
     await assertSnapshotCurrent(temporarySnapshot);
 
-    await rename(temporaryPath, mutation.snapshot.path);
-    temporaryCreated = false;
+    if (expectedCurrent.bytes !== null) {
+      claimPath = transactionClaimPath(mutation.snapshot.path);
+
+
+      await rename(mutation.snapshot.path, claimPath);
+      claimCreated = true;
+      await assertSnapshotAtPath(claimPath, expectedCurrent, "replacement claim");
+    }
+    // link() is a no-overwrite claim of the now-absent destination. It fails
+    // rather than replacing anything concurrently created at that coordinate.
+    await link(temporaryPath, mutation.snapshot.path);
     const ownership = renamedDestinationOwnership(
       temporarySnapshot,
       mutation.snapshot.path,
       mutation.snapshot.topology,
     );
-    await onRename(ownership);
+    onRename(ownership);
+    await rm(temporaryPath);
+    temporaryCreated = false;
+    if (claimPath) {
+      await rm(claimPath);
+      claimCreated = false;
+    }
+
     if (stage === "write") {
       await options.transactionFailureInjector?.("after-rename");
     }
@@ -1013,6 +1096,18 @@ async function atomicReplaceFile(
     return actual;
   } catch (error) {
     await handle?.close().catch(() => undefined);
+    if (claimCreated && claimPath) {
+      try {
+        await link(claimPath, mutation.snapshot.path);
+        await rm(claimPath);
+        claimCreated = false;
+      } catch (recoveryError) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `Uninstall replacement failed (${message}) and preserved claim ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
+        );
+      }
+    }
     if (temporaryCreated) {
       await removeOwnedTemporary(
         temporaryPath,
@@ -1020,10 +1115,12 @@ async function atomicReplaceFile(
         error,
         "temporary",
       );
+
     }
     throw error;
   }
 }
+
 
 async function stageAndRemoveFile(
   mutation: PlannedFileMutation,
@@ -1060,13 +1157,16 @@ async function stageAndRemoveFile(
     execution.stagedDeletion = stagedDeletion;
 
     await options.transactionFailureInjector?.("before-remove");
-    // Recheck at the mutation primitive immediately before removing the target.
     await assertControlledTopologyCurrent(mutation.snapshot.topology);
     await assertSnapshotCurrent(mutation.snapshot);
-    // Recheck the transaction-owned staged copy immediately before removing the target.
     await assertSnapshotCurrent(stagedDeletion);
     await assertApplied();
-    await rm(mutation.snapshot.path);
+    await options.transactionFailureInjector?.("after-final-remove-validation");
+    await assertSnapshotCurrent(stagedDeletion);
+    const claimPath = transactionClaimPath(mutation.snapshot.path);
+
+
+    await rename(mutation.snapshot.path, claimPath);
     execution.appliedSnapshot = {
       path: mutation.snapshot.path,
       content: null,
@@ -1076,6 +1176,24 @@ async function stageAndRemoveFile(
       topology: mutation.snapshot.topology,
     };
     execution.phase = "destructive";
+    try {
+
+
+      await assertSnapshotAtPath(claimPath, mutation.snapshot, "removal claim");
+    } catch (error) {
+      try {
+        await link(claimPath, mutation.snapshot.path);
+        await rm(claimPath);
+        execution.appliedSnapshot = undefined;
+        execution.phase = "prepared";
+      } catch (recoveryError) {
+        throw new Error(
+          `Uninstall removal claim failed (${error instanceof Error ? error.message : String(error)}) and preserved ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
+        );
+      }
+      throw error;
+    }
+    await rm(claimPath);
     await options.transactionFailureInjector?.("after-remove");
     await assertControlledTopologyCurrent(mutation.snapshot.topology);
     const absent = await captureCurrentSnapshot(mutation.snapshot);
@@ -1170,7 +1288,10 @@ async function restoreFileSnapshot(
     await assertRollbackState();
     await assertControlledTopologyCurrent(mutation.snapshot.topology);
     await assertSnapshotCurrent(appliedSnapshot);
-    await rm(mutation.snapshot.path);
+    await options.transactionFailureInjector?.("after-final-restore-validation");
+    const claimPath = transactionClaimPath(mutation.snapshot.path);
+
+    await rename(mutation.snapshot.path, claimPath);
     execution.appliedSnapshot = {
       path: mutation.snapshot.path,
       content: null,
@@ -1180,6 +1301,21 @@ async function restoreFileSnapshot(
       topology: mutation.snapshot.topology,
     };
     execution.renamedOwnership = undefined;
+    try {
+
+      await assertSnapshotAtPath(claimPath, appliedSnapshot, "rollback removal claim");
+    } catch (error) {
+      try {
+        await link(claimPath, mutation.snapshot.path);
+        await rm(claimPath);
+      } catch (recoveryError) {
+        throw new Error(
+          `Uninstall rollback removal claim failed (${error instanceof Error ? error.message : String(error)}) and preserved ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
+        );
+      }
+      throw error;
+    }
+    await rm(claimPath);
     const absent = await captureCurrentSnapshot(mutation.snapshot);
     if (absent.bytes !== null) {
       throw new Error(`Uninstall rollback mismatch for ${mutation.snapshot.path}: expected absence.`);
@@ -1222,9 +1358,24 @@ async function cleanupStagedDeletions(
     }
     await assertRollbackState?.();
 
-    // Recheck immediately before removing the transaction-owned staged copy.
-    await assertSnapshotCurrent(execution.stagedDeletion);
-    await rm(execution.stagedDeletion.path);
+    const stagedDeletion = execution.stagedDeletion;
+    await assertSnapshotCurrent(stagedDeletion);
+    const claimPath = transactionClaimPath(stagedDeletion.path);
+    await rename(stagedDeletion.path, claimPath);
+    try {
+      await assertSnapshotAtPath(claimPath, stagedDeletion, "staged deletion cleanup claim");
+    } catch (error) {
+      try {
+        await link(claimPath, stagedDeletion.path);
+        await rm(claimPath);
+      } catch (recoveryError) {
+        throw new Error(
+          `Uninstall staged deletion cleanup claim failed (${error instanceof Error ? error.message : String(error)}) and preserved ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
+        );
+      }
+      throw error;
+    }
+    await rm(claimPath);
     execution.stagedDeletionCleaned = true;
     await assertRollbackState?.();
   }

--- a/src/compat/__tests__/doctor-contract.test.ts
+++ b/src/compat/__tests__/doctor-contract.test.ts
@@ -18,6 +18,7 @@ const testDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(testDir, '..', '..', '..');
 const defaultTarget = join(repoRoot, 'dist', 'cli', 'omx.js');
 const fixturesRoot = join(repoRoot, 'src', 'compat', 'fixtures', 'doctor');
+const SAFE_DOCTOR_RECOVERY = 'Review warnings above. Follow the check-specific recovery guidance; for AGENTS.md preservation prefer "omx setup --merge-agents".';
 
 function readFixture(name: string): string {
   return readFileSync(join(fixturesRoot, name), 'utf-8');
@@ -85,7 +86,7 @@ function normalizeInstallDoctorOutput(text: string, home: string, cwd: string): 
       if (line.startsWith('Run "omx setup')) {
         return 'Run <SETUP_FOLLOWUP>';
       }
-      if (line.startsWith('Review warnings above. Use "omx setup')) {
+      if (line === SAFE_DOCTOR_RECOVERY) {
         return 'Run <SETUP_FOLLOWUP>';
       }
       return line;
@@ -107,6 +108,8 @@ describe('compat doctor contract', () => {
       assert.equal(result.status, Number.parseInt(readFixture('install-onboarding.exitcode.txt').trim(), 10), result.stderr || result.stdout);
       assert.equal(result.stderr, '');
       assert.equal(normalizeInstallDoctorOutput(result.stdout, home, wd), readFixture('install-onboarding.stdout.txt'));
+      assert.match(result.stdout, new RegExp(SAFE_DOCTOR_RECOVERY.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+      assert.doesNotMatch(result.stdout, /^Review warnings above\.[^\n]*--force/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/compat/__tests__/doctor-contract.test.ts
+++ b/src/compat/__tests__/doctor-contract.test.ts
@@ -19,6 +19,7 @@ const repoRoot = join(testDir, '..', '..', '..');
 const defaultTarget = join(repoRoot, 'dist', 'cli', 'omx.js');
 const fixturesRoot = join(repoRoot, 'src', 'compat', 'fixtures', 'doctor');
 const SAFE_DOCTOR_RECOVERY = 'Review warnings above. Follow the check-specific recovery guidance; for AGENTS.md preservation prefer "omx setup --merge-agents".';
+const SAFE_DOCTOR_FAILURE = 'Review failed checks above. Follow the check-specific recovery guidance; inspect invalid or ambiguous hook documents manually because doctor will not modify them.';
 
 function readFixture(name: string): string {
   return readFileSync(join(fixturesRoot, name), 'utf-8');
@@ -86,7 +87,7 @@ function normalizeInstallDoctorOutput(text: string, home: string, cwd: string): 
       if (line.startsWith('Run "omx setup')) {
         return 'Run <SETUP_FOLLOWUP>';
       }
-      if (line === SAFE_DOCTOR_RECOVERY) {
+      if (line === SAFE_DOCTOR_RECOVERY || line === SAFE_DOCTOR_FAILURE) {
         return 'Run <SETUP_FOLLOWUP>';
       }
       return line;
@@ -108,8 +109,8 @@ describe('compat doctor contract', () => {
       assert.equal(result.status, Number.parseInt(readFixture('install-onboarding.exitcode.txt').trim(), 10), result.stderr || result.stdout);
       assert.equal(result.stderr, '');
       assert.equal(normalizeInstallDoctorOutput(result.stdout, home, wd), readFixture('install-onboarding.stdout.txt'));
-      assert.match(result.stdout, new RegExp(SAFE_DOCTOR_RECOVERY.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-      assert.doesNotMatch(result.stdout, /^Review warnings above\.[^\n]*--force/m);
+      assert.ok(result.stdout.includes(SAFE_DOCTOR_RECOVERY) || result.stdout.includes(SAFE_DOCTOR_FAILURE));
+      assert.doesNotMatch(result.stdout, /^Review (?:warnings|failed checks) above\.[^\n]*--force/m);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -164,7 +164,565 @@ describe("codex hooks helpers", () => {
     const posix = planManagedCodexHooksRemoval(caseVariant, "/hooks.json", { platform: "linux" });
     const windows = planManagedCodexHooksRemoval(caseVariant, "C:\\Users\\Ada\\.codex\\hooks.json", { platform: "win32" });
     assert.equal(posix.ok, false);
-    assert.equal(windows.ok, true);
+    assert.equal(windows.ok, false);
+    if (!windows.ok) assert.equal(windows.error.code, "ambiguous_managed_handler");
+  });
+
+  it("requires absolute, control-free POSIX OMX paths before ownership proof", () => {
+    const historicalCommand = `node "/historical install/O'Brien/dist/scripts/codex-native-hook.js"`;
+    const ownedSource = JSON.stringify({
+      hooks: {
+        PreToolUse: [{ hooks: [{ type: "command", command: historicalCommand }] }],
+      },
+    });
+    const ownedMerge = planManagedCodexHooksMerge(ownedSource, "/repo", "/hooks.json", { platform: "linux" });
+    const ownedRemoval = planManagedCodexHooksRemoval(ownedSource, "/hooks.json", { platform: "linux" });
+    assert.equal(isManagedCodexHookCommand(historicalCommand), true);
+    assert.equal(ownedMerge.ok, true);
+    assert.equal(ownedRemoval.ok, true);
+    if (ownedRemoval.ok) {
+      assert.equal(ownedRemoval.removedCount, 1);
+      assert.equal(ownedRemoval.finalContent, null);
+    }
+
+    const foreignCommand = "node ./foreign-hook.js";
+    const foreignSource = JSON.stringify({
+      hooks: {
+        PreToolUse: [{ hooks: [{ type: "command", command: foreignCommand }] }],
+      },
+    });
+    const foreignMerge = planManagedCodexHooksMerge(foreignSource, "/repo", "/hooks.json", { platform: "linux" });
+    const foreignRemoval = planManagedCodexHooksRemoval(foreignSource, "/hooks.json", { platform: "linux" });
+    assert.equal(foreignMerge.ok, true);
+    assert.equal(foreignRemoval.ok, true);
+    if (foreignMerge.ok) {
+      assert.equal(foreignMerge.hasForeignHooks, true);
+      assert.ok(foreignMerge.finalContent?.includes(foreignCommand));
+    }
+    if (foreignRemoval.ok) assert.equal(foreignRemoval.finalContent, foreignSource);
+
+    const controlCodePoints = [
+      ...Array.from({ length: 0x20 }, (_, codePoint) => codePoint),
+      ...Array.from({ length: 0x21 }, (_, offset) => 0x7f + offset),
+    ];
+    const ambiguousCommands = [
+      "node ./dist/scripts/codex-native-hook.js",
+      "node dist/scripts/codex-native-hook.js",
+      "node ../historical/dist/scripts/codex-native-hook.js",
+      ...controlCodePoints.map(
+        (codePoint) => `node "/historical/dist/scripts/codex-native-hook.js${String.fromCodePoint(codePoint)}"`,
+      ),
+    ];
+    for (const command of ambiguousCommands) {
+      const source = JSON.stringify({
+        hooks: {
+          PreToolUse: [{ hooks: [{ type: "command", command }] }],
+        },
+      });
+      const merge = planManagedCodexHooksMerge(source, "/repo", "/hooks.json", { platform: "linux" });
+      const removal = planManagedCodexHooksRemoval(source, "/hooks.json", { platform: "linux" });
+      const context = JSON.stringify(command);
+      assert.equal(isManagedCodexHookCommand(command), false, context);
+      assert.equal(merge.ok, false, context);
+      assert.equal(removal.ok, false, context);
+      if (!merge.ok) {
+        assert.equal(merge.error.code, "ambiguous_managed_handler", context);
+        assert.equal("finalContent" in merge, false, context);
+      }
+      if (!removal.ok) {
+        assert.equal(removal.error.code, "ambiguous_managed_handler", context);
+        assert.equal("finalContent" in removal, false, context);
+      }
+    }
+  });
+
+  it("fails closed for decoded POSIX OMX spellings across command fields", () => {
+    const exactEscapedCommand = String.raw`node /repo/dist/scripts/codex-native-ho\ok.js`;
+    assert.equal(isManagedCodexHookCommand(exactEscapedCommand), true);
+
+    const decodedNonExactCommands = [
+      ["escaped filename with extra argv", String.raw`node /repo/dist/scripts/codex-native-ho\ok.js --extra`],
+      ["escaped filename with comment", String.raw`node /repo/dist/scripts/codex-native-ho\ok.js # retained comment`],
+      ["backslash-newline filename split", "node /repo/dist/scripts/codex-native-ho\\\nok.js --extra"],
+    ] as const;
+    const commandFields = [
+      ["command", (command: string) => ({ command })],
+      ["commandWindows", (command: string) => ({
+        command: 'node "/repo/dist/scripts/codex-native-hook.js"',
+        commandWindows: command,
+      })],
+      ["command_windows", (command: string) => ({
+        command: 'node "/repo/dist/scripts/codex-native-hook.js"',
+        command_windows: command,
+      })],
+    ] as const;
+
+    for (const [description, command] of decodedNonExactCommands) {
+      for (const [field, commandFieldsForHandler] of commandFields) {
+        const source = JSON.stringify({
+          hooks: {
+            PreToolUse: [{
+              hooks: [{ type: "command", ...commandFieldsForHandler(command) }],
+            }],
+          },
+        });
+        const context = `${field}: ${description}`;
+        const merge = planManagedCodexHooksMerge(source, "/repo", "/hooks.json", { platform: "linux" });
+        const removal = planManagedCodexHooksRemoval(source, "/hooks.json", { platform: "linux" });
+
+        assert.equal(isManagedCodexHookCommand(command), false, context);
+        assert.equal(merge.ok, false, context);
+        assert.equal(removal.ok, false, context);
+        if (!merge.ok) {
+          assert.equal(merge.error.code, "ambiguous_managed_handler", context);
+          assert.equal("finalContent" in merge, false, context);
+        }
+        if (!removal.ok) {
+          assert.equal(removal.error.code, "ambiguous_managed_handler", context);
+          assert.equal("finalContent" in removal, false, context);
+        }
+      }
+    }
+  });
+
+  it("owns only the exact current drive-less Windows shim command from supplied options", () => {
+    const options = {
+      platform: "win32" as const,
+      codexHomeDir: "/fixture codex home",
+      env: { SystemRoot: "C:\\Windows" },
+    };
+    const command = buildManagedCodexNativeHookCommand("/repo", options);
+    const source = JSON.stringify({
+      hooks: {
+        PreToolUse: [{ hooks: [{ type: "command", command }] }],
+      },
+    });
+    const merge = planManagedCodexHooksMerge(source, "/repo", "/fixture codex home/hooks.json", options);
+    const removal = planManagedCodexHooksRemoval(source, "/fixture codex home/hooks.json", options);
+    assert.match(command, /-File '\\fixture codex home\\hooks\\omx-native-hook-windows-shim\.ps1'$/);
+    assert.equal(isManagedCodexHookCommand(command), false);
+    assert.equal(merge.ok, true);
+    assert.equal(removal.ok, true);
+    if (removal.ok) assert.equal(removal.finalContent, null);
+
+    const altered = command.replace("\\fixture codex home\\", "\\foreign codex home\\");
+    const alteredSource = JSON.stringify({
+      hooks: {
+        PreToolUse: [{ hooks: [{ type: "command", command: altered }] }],
+      },
+    });
+    const alteredMerge = planManagedCodexHooksMerge(
+      alteredSource,
+      "/repo",
+      "/fixture codex home/hooks.json",
+      options,
+    );
+    const alteredRemoval = planManagedCodexHooksRemoval(
+      alteredSource,
+      "/fixture codex home/hooks.json",
+      options,
+    );
+    assert.equal(alteredMerge.ok, false);
+    assert.equal(alteredRemoval.ok, false);
+    if (!alteredMerge.ok) assert.equal(alteredMerge.error.code, "ambiguous_managed_handler");
+    if (!alteredRemoval.ok) assert.equal(alteredRemoval.error.code, "ambiguous_managed_handler");
+  });
+
+  it("owns only exact current host-joined Windows shim commands on non-Windows seams", () => {
+    if (process.platform === "win32") return;
+    const env = { SystemRoot: "C:\\Windows" };
+    const fixtures = [
+      {
+        label: "supplied codex home",
+        options: { platform: "win32" as const, codexHomeDir: "/fixture codex home", env },
+        hooksPath: "/fixture codex home/hooks.json",
+        codexHomeDir: "/fixture codex home",
+      },
+      {
+        label: "derived codex home",
+        options: { platform: "win32" as const, env },
+        hooksPath: "/derived codex home/hooks.json",
+        codexHomeDir: "/derived codex home",
+      },
+    ];
+    for (const { label, options, hooksPath, codexHomeDir } of fixtures) {
+      const hostShimPath = join(codexHomeDir, "hooks", "omx-native-hook-windows-shim.ps1");
+      const powerShellPath = resolveWindowsPowerShellPath(env);
+      const command = `& '${powerShellPath}' -NoProfile -ExecutionPolicy Bypass -File '${hostShimPath}'`;
+      const source = JSON.stringify({
+        hooks: {
+          PreToolUse: [{ hooks: [{ type: "command", command }] }],
+        },
+      });
+      const merge = planManagedCodexHooksMerge(source, "/repo", hooksPath, options);
+      const removal = planManagedCodexHooksRemoval(source, hooksPath, options);
+      assert.match(command, /\/hooks\/omx-native-hook-windows-shim\.ps1'$/);
+      assert.equal(isManagedCodexHookCommand(command), false, label);
+      assert.equal(merge.ok, true, label);
+      assert.equal(removal.ok, true, label);
+      if (removal.ok) assert.equal(removal.finalContent, null, label);
+
+      const alteredShimPath = join("/foreign codex home", "hooks", "omx-native-hook-windows-shim.ps1");
+      const altered = command.replace(hostShimPath, alteredShimPath);
+      const alteredSource = JSON.stringify({
+        hooks: {
+          PreToolUse: [{ hooks: [{ type: "command", command: altered }] }],
+        },
+      });
+      const alteredMerge = planManagedCodexHooksMerge(alteredSource, "/repo", hooksPath, options);
+      const alteredRemoval = planManagedCodexHooksRemoval(alteredSource, hooksPath, options);
+      assert.equal(alteredMerge.ok, false, label);
+      assert.equal(alteredRemoval.ok, false, label);
+      if (!alteredMerge.ok) assert.equal(alteredMerge.error.code, "ambiguous_managed_handler", label);
+      if (!alteredRemoval.ok) assert.equal(alteredRemoval.error.code, "ambiguous_managed_handler", label);
+    }
+  });
+
+  it("fails closed for Windows direct command expansion, quoting, wrappers, and invalid cross-fields", () => {
+    const script = "C:\\repo\\dist\\scripts\\codex-native-hook.js";
+    const direct = `node "${script}"`;
+    const invalidDirectCommands = [
+      `node "%OMX_ROOT%\\dist\\scripts\\codex-native-hook.js"`,
+      `node "!OMX_ROOT!\\dist\\scripts\\codex-native-hook.js"`,
+      `node "$(Get-Location)\\dist\\scripts\\codex-native-hook.js"`,
+      `node '${script}'`,
+      `node "${script}`,
+      `node "${script}\\"`,
+      `${direct} & echo injected`,
+      `${direct} ^& echo injected`,
+      `${direct} --extra`,
+      `cmd.exe /d /c ${direct}`,
+      `${direct}\r\necho injected`,
+      `node ".\\dist\\scripts\\codex-native-hook.js"`,
+      `node "C:historical\\dist\\scripts\\codex-native-hook.js"`,
+    ];
+    const crossFieldHandlers = [
+      { command: `node '${script}'`, commandWindows: direct },
+      { command: direct, command_windows: `node '${script}'` },
+      {
+        command: 'node "/repo/dist/scripts/codex-native-hook.js"',
+        commandWindows: "node '/repo/dist/scripts/codex-native-hook.js'",
+      },
+    ];
+    const cases = [
+      ...invalidDirectCommands.map((command) => ({
+        handler: { command },
+        options: { platform: "win32" as const },
+      })),
+      {
+        handler: crossFieldHandlers[0]!,
+        options: { platform: "win32" as const },
+      },
+      {
+        handler: crossFieldHandlers[1]!,
+        options: { platform: "win32" as const },
+      },
+      {
+        handler: crossFieldHandlers[2]!,
+        options: { platform: "linux" as const },
+      },
+    ];
+
+    for (const { handler, options } of cases) {
+      const source = JSON.stringify({
+        hooks: {
+          PreToolUse: [{ hooks: [{ type: "command", ...handler }] }],
+        },
+      });
+      const merge = planManagedCodexHooksMerge(source, "C:\\repo", "C:\\Users\\Ada\\.codex\\hooks.json", options);
+      const removal = planManagedCodexHooksRemoval(source, "C:\\Users\\Ada\\.codex\\hooks.json", options);
+      assert.equal(merge.ok, false, source);
+      assert.equal(removal.ok, false, source);
+      if (!merge.ok) {
+        assert.equal(merge.error.code, "ambiguous_managed_handler", source);
+        assert.equal("finalContent" in merge, false);
+      }
+      if (!removal.ok) {
+        assert.equal(removal.error.code, "ambiguous_managed_handler", source);
+        assert.equal("finalContent" in removal, false);
+      }
+    }
+
+    const staticSpecialPath = `"C:\\Program Files (x86)\\node.exe" "C:\\Users\\O'Brien\\@scope & safe\\dist\\scripts\\codex-native-hook.js"`;
+    assert.equal(isManagedCodexHookCommand(staticSpecialPath), true);
+
+    const validCrossField = JSON.stringify({
+      hooks: {
+        PreToolUse: [{
+          hooks: [{
+            type: "command",
+            command: 'node "/repo/dist/scripts/codex-native-hook.js"',
+            commandWindows: direct,
+          }],
+        }],
+      },
+    });
+    for (const platform of ["linux", "win32"] as const) {
+      const pkgRoot = platform === "win32" ? "C:\\repo" : "/repo";
+      const hooksPath = platform === "win32" ? "C:\\Users\\Ada\\.codex\\hooks.json" : "/hooks.json";
+      const options = { platform };
+      const merge = planManagedCodexHooksMerge(validCrossField, pkgRoot, hooksPath, options);
+      const removal = planManagedCodexHooksRemoval(validCrossField, hooksPath, options);
+      assert.equal(merge.ok, true, `${platform} must accept platform-specific managed command fields`);
+      assert.equal(removal.ok, true, `${platform} must remove platform-specific managed command fields`);
+    }
+  });
+
+  it("fails closed for unqualified direct executables and quoted PowerShell executable paths across command fields", () => {
+    const posixScript = "/historical/dist/scripts/codex-native-hook.js";
+    const windowsScript = "C:\\historical\\dist\\scripts\\codex-native-hook.js";
+    const powerShellExecutable = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
+    const shimPath = "C:\\Users\\Ada\\.codex\\hooks\\omx-native-hook-windows-shim.ps1";
+    const fallbackPosixCommand = `node "${posixScript}"`;
+    const unsafeCommands = [
+      ["POSIX dot-relative executable", `./node "${posixScript}"`, "linux"],
+      ["POSIX parent-relative executable", `../node "${posixScript}"`, "linux"],
+      ["POSIX relative executable", `tools/node "${posixScript}"`, "linux"],
+      ["Windows dot-relative executable", `.\\node.exe "${windowsScript}"`, "win32"],
+      ["Windows relative executable", `tools\\node.exe "${windowsScript}"`, "win32"],
+      ["Windows drive-relative executable", `C:node.exe "${windowsScript}"`, "win32"],
+      [
+        "PowerShell dot-relative executable",
+        `.\\powershell.exe -NoProfile -ExecutionPolicy Bypass -File '${shimPath}'`,
+        "win32",
+      ],
+      [
+        "PowerShell relative executable",
+        `tools\\powershell.exe -NoProfile -ExecutionPolicy Bypass -File '${shimPath}'`,
+        "win32",
+      ],
+      [
+        "PowerShell drive-relative executable",
+        `C:powershell.exe -NoProfile -ExecutionPolicy Bypass -File '${shimPath}'`,
+        "win32",
+      ],
+      [
+        "quoted PowerShell executable without call operator",
+        `'${powerShellExecutable}' -NoProfile -ExecutionPolicy Bypass -File '${shimPath}'`,
+        "win32",
+      ],
+    ] as const;
+
+    const assertAmbiguous = (
+      source: string,
+      platform: "linux" | "win32",
+      context: string,
+    ) => {
+      const pkgRoot = platform === "win32" ? "C:\\repo" : "/repo";
+      const hooksPath = platform === "win32" ? "C:\\Users\\Ada\\.codex\\hooks.json" : "/hooks.json";
+      const merge = planManagedCodexHooksMerge(source, pkgRoot, hooksPath, { platform });
+      const removal = planManagedCodexHooksRemoval(source, hooksPath, { platform });
+      assert.equal(merge.ok, false, context);
+      assert.equal(removal.ok, false, context);
+      if (!merge.ok) {
+        assert.equal(merge.error.code, "ambiguous_managed_handler", context);
+        assert.equal("finalContent" in merge, false, context);
+      }
+      if (!removal.ok) {
+        assert.equal(removal.error.code, "ambiguous_managed_handler", context);
+        assert.equal("finalContent" in removal, false, context);
+      }
+    };
+
+    for (const [spelling, unsafeCommand, primaryPlatform] of unsafeCommands) {
+      assert.equal(isManagedCodexHookCommand(unsafeCommand), false, spelling);
+      assertAmbiguous(
+        JSON.stringify({
+          hooks: {
+            PreToolUse: [{ hooks: [{ type: "command", command: unsafeCommand }] }],
+          },
+        }),
+        primaryPlatform,
+        `${spelling} in command`,
+      );
+      for (const [field, handler] of [
+        ["commandWindows", { command: fallbackPosixCommand, commandWindows: unsafeCommand }],
+        ["command_windows", { command: fallbackPosixCommand, command_windows: unsafeCommand }],
+      ] as const) {
+        assertAmbiguous(
+          JSON.stringify({
+            hooks: {
+              PreToolUse: [{ hooks: [{ type: "command", ...handler }] }],
+            },
+          }),
+          "win32",
+          `${spelling} in ${field}`,
+        );
+      }
+    }
+  });
+
+  it("fails closed for Windows direct-node and PowerShell shim quote concatenation across command fields", () => {
+    const posixScript = "/repo/dist/scripts/codex-native-hook.js";
+    const windowsScript = "C:\\repo\\dist\\scripts\\codex-native-hook.js";
+    const shimPath = "C:\\Users\\Ada\\.codex\\hooks\\omx-native-hook-windows-shim.ps1";
+    const shimPrefix = "powershell.exe -NoProfile -ExecutionPolicy Bypass -File";
+    const malformedCommands = [
+      ["direct doubled", `node "C:\\repo\\dist\\scripts\\codex""-native-hook.js"`],
+      ["direct adjacent", `node ""${windowsScript}""`],
+      ["direct triple", `node """${windowsScript}"""`],
+      ["shim doubled", `${shimPrefix} "C:\\Users\\Ada\\.codex\\hooks\\omx""-native-hook-windows-shim.ps1"`],
+      ["shim adjacent", `${shimPrefix} ""${shimPath}""`],
+      ["shim triple", `${shimPrefix} """${shimPath}"""`],
+    ] as const;
+
+    for (const [spelling, malformed] of malformedCommands) {
+      for (const [field, handler] of [
+        ["command", { command: malformed }],
+        ["commandWindows", { command: `node "${posixScript}"`, commandWindows: malformed }],
+        ["command_windows", { command: `node "${posixScript}"`, command_windows: malformed }],
+      ] as const) {
+        const source = JSON.stringify({
+          hooks: {
+            PreToolUse: [{ hooks: [{ type: "command", ...handler }] }],
+          },
+        });
+        const context = `${spelling} in ${field}: ${source}`;
+        const merge = planManagedCodexHooksMerge(
+          source,
+          "C:\\repo",
+          "C:\\Users\\Ada\\.codex\\hooks.json",
+          { platform: "win32" },
+        );
+        const removal = planManagedCodexHooksRemoval(
+          source,
+          "C:\\Users\\Ada\\.codex\\hooks.json",
+          { platform: "win32" },
+        );
+
+        assert.equal(merge.ok, false, context);
+        assert.equal(removal.ok, false, context);
+        if (!merge.ok) {
+          assert.equal(merge.error.code, "ambiguous_managed_handler", context);
+          assert.equal("finalContent" in merge, false, context);
+        }
+        if (!removal.ok) {
+          assert.equal(removal.error.code, "ambiguous_managed_handler", context);
+          assert.equal("finalContent" in removal, false, context);
+        }
+      }
+    }
+  });
+
+  it("fails closed for invalid Windows path syntax in direct and PowerShell commands", () => {
+    const posixCommand = 'node "/repo/dist/scripts/codex-native-hook.js"';
+    const directExecutable = "C:\\base\\node.exe";
+    const directScript = "C:\\base\\dist\\scripts\\codex-native-hook.js";
+    const powerShellExecutable = "C:\\base\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
+    const shimPath = "C:\\base\\hooks\\omx-native-hook-windows-shim.ps1";
+    const invalidWindowsPaths: Array<[string, (path: string) => string]> = [
+      ["pipe", (path) => path.replace("\\base\\", "\\ba|se\\")],
+      ["angle brackets", (path) => path.replace("\\base\\", "\\ba<>se\\")],
+      ["wildcards", (path) => path.replace("\\base\\", "\\ba?*se\\")],
+      ["embedded quote", (path) => path.replace("\\base\\", '\\ba\\"se\\')],
+      ["control character", (path) => path.replace("\\base\\", "\\ba\u0000se\\")],
+      ["alternate data stream", (path) => path.replace("\\base\\", "\\base:stream\\")],
+      ["extended namespace", (path) => `\\\\?\\${path}`],
+      ["device namespace", (path) => `\\\\.\\${path}`],
+      ["NT device namespace", (path) => `\\Device\\HarddiskVolume2${path.slice(2)}`],
+      ["DOS device name", (path) => path.replace("\\base\\", "\\NUL\\")],
+      ["DOS COM device stem before extension", (path) => path.replace("\\base\\", "\\COM1 .cache\\")],
+      ["DOS NUL device stem before extension", (path) => path.replace("\\base\\", "\\NUL .dir\\")],
+      ["superscript COM device name", (path) => path.replace("\\base\\", "\\COM¹\\")],
+      ["superscript LPT device name", (path) => path.replace("\\base\\", "\\LPT²\\")],
+      ["trailing component period", (path) => path.replace("\\base\\", "\\base.\\")],
+      ["trailing component space", (path) => path.replace("\\base\\", "\\base " + String.fromCharCode(92))],
+    ];
+    const invalidCommands = invalidWindowsPaths.flatMap(([syntax, invalidPath]) => [
+      [`direct executable ${syntax}`, `"${invalidPath(directExecutable)}" "${directScript}"`],
+      [`direct script ${syntax}`, `node "${invalidPath(directScript)}"`],
+      [
+        `PowerShell executable ${syntax}`,
+        `& '${invalidPath(powerShellExecutable)}' -NoProfile -ExecutionPolicy Bypass -File '${shimPath}'`,
+      ],
+      [
+        `PowerShell shim ${syntax}`,
+        `& '${powerShellExecutable}' -NoProfile -ExecutionPolicy Bypass -File '${invalidPath(shimPath)}'`,
+      ],
+    ]);
+
+    const validDirect = '"C:\\Program Files (x86)\\node.exe" "C:\\Users\\O\'Brien\\@scope & safe\\(fixture)\\dist\\scripts\\codex-native-hook.js"';
+    const validUncDirect = '"\\\\server\\share\\node.exe" "\\\\server\\share\\repo\\dist\\scripts\\codex-native-hook.js"';
+    const validShimPath = "C:\\Users\\O'Brien\\@scope & safe\\(fixture)\\.codex\\hooks\\omx-native-hook-windows-shim.ps1";
+    const validPowerShell = "& 'C:\\Program Files (x86)\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File 'C:\\Users\\O''Brien\\@scope & safe\\(fixture)\\.codex\\hooks\\omx-native-hook-windows-shim.ps1'";
+    const rootedPowerShell = "& '\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File '\\Users\\Ada\\.codex\\hooks\\omx-native-hook-windows-shim.ps1'";
+    assert.equal(isManagedCodexHookCommand(validDirect), true);
+    assert.equal(isManagedCodexHookCommand(validUncDirect), true);
+    assert.equal(parseManagedCodexNativeHookWindowsShimCommand(validPowerShell), validShimPath);
+    assert.equal(parseManagedCodexNativeHookWindowsShimCommand(rootedPowerShell), null);
+    assert.equal(isManagedCodexHookCommand(rootedPowerShell), false);
+
+    for (const [spelling, invalid] of invalidCommands) {
+      assert.equal(isManagedCodexHookCommand(invalid), false, spelling);
+      for (const [field, handler] of [
+        ["command", { command: invalid }],
+        ["commandWindows", { command: posixCommand, commandWindows: invalid }],
+        ["command_windows", { command: posixCommand, command_windows: invalid }],
+      ] as const) {
+        const source = JSON.stringify({
+          hooks: {
+            PreToolUse: [{ hooks: [{ type: "command", ...handler }] }],
+          },
+        });
+        const context = `${spelling} in ${field}: ${source}`;
+        const merge = planManagedCodexHooksMerge(
+          source,
+          "C:\\repo",
+          "C:\\Users\\Ada\\.codex\\hooks.json",
+          { platform: "win32" },
+        );
+        const removal = planManagedCodexHooksRemoval(
+          source,
+          "C:\\Users\\Ada\\.codex\\hooks.json",
+          { platform: "win32" },
+        );
+
+        assert.equal(merge.ok, false, context);
+        assert.equal(removal.ok, false, context);
+        if (!merge.ok) {
+          assert.equal(merge.error.code, "ambiguous_managed_handler", context);
+          assert.equal("finalContent" in merge, false, context);
+        }
+        if (!removal.ok) {
+          assert.equal(removal.error.code, "ambiguous_managed_handler", context);
+          assert.equal("finalContent" in removal, false, context);
+        }
+      }
+    }
+  });
+
+  it("preserves compatible mixed matcher source and managed coordinates", () => {
+    const matcherCases = [
+      {
+        eventName: "PreToolUse",
+        eventLabel: "pre_tool_use",
+        matcherSlice: '"matcher" : null',
+      },
+      {
+        eventName: "SessionStart",
+        eventLabel: "session_start",
+        matcherSlice: String.raw`"matcher" : "\u0073tartup\u007cresume\u007cclear"`,
+      },
+    ] as const;
+
+    for (const { eventName, eventLabel, matcherSlice } of matcherCases) {
+      const source = String.raw`{"hooks":{"${eventName}":[{${matcherSlice},"hooks":[{"type":"command","command":"echo foreign"},{"type":"command","command":"node \"/old/dist/scripts/codex-native-hook.js\""}]}]}}`;
+      const merged = planManagedCodexHooksMerge(source, "/repo", "/hooks.json");
+      assert.equal(merged.ok, true, source);
+      if (!merged.ok) continue;
+      assert.equal(merged.coordinateProof.safe, true);
+      assert.equal(merged.hasForeignHooks, true);
+      assert.ok(merged.finalContent?.includes(matcherSlice));
+      assert.ok(merged.finalTrustState[`/hooks.json:${eventLabel}:0:1`]);
+
+      const removal = planManagedCodexHooksRemoval(merged.finalContent!, "/hooks.json");
+      assert.equal(removal.ok, true, merged.finalContent ?? source);
+      if (!removal.ok) continue;
+      assert.equal(removal.coordinateProof.safe, true);
+      assert.ok(removal.finalContent?.includes(matcherSlice));
+      assert.match(removal.finalContent ?? "", /echo foreign/);
+      assert.deepEqual(removal.finalTrustState, {});
+    }
   });
 
   it("emits Windows hooks.json entries with only the cmd-compatible command field", () => {
@@ -319,6 +877,66 @@ describe("codex hooks helpers", () => {
       classifyManagedCodexNativeHookWindowsShimOwnership(historical, expected),
       "historical",
     );
+  });
+
+  it("requires qualified valid paths before recognizing historical Windows shim ownership", () => {
+    const expected = Buffer.from(buildManagedCodexNativeHookWindowsShimContent(
+      "C:\\Current Install\\oh-my-codex",
+      {
+        nodePath: "C:\\Current Node\\node.exe",
+        hookScriptPath: "C:\\Current Install\\oh-my-codex\\dist\\scripts\\codex-native-hook.js",
+      },
+    ), "utf-8");
+    const validNodePath = "D:\\Historical Node\\node.exe";
+    const validHookScriptPath = "D:\\Historical Install\\oh-my-codex\\dist\\scripts\\codex-native-hook.js";
+    const invalidHistoricalPaths = [
+      { nodePath: "node.exe", hookScriptPath: validHookScriptPath },
+      { nodePath: "D:node.exe", hookScriptPath: validHookScriptPath },
+      { nodePath: ".\\node.exe", hookScriptPath: validHookScriptPath },
+      { nodePath: "D:\\bad|node\\node.exe", hookScriptPath: validHookScriptPath },
+      { nodePath: "D:\\bad\u0000node\\node.exe", hookScriptPath: validHookScriptPath },
+      { nodePath: String.raw`\\?\D:\\Historical Node\\node.exe`, hookScriptPath: validHookScriptPath },
+      { nodePath: String.raw`\Device\HarddiskVolume2\node.exe`, hookScriptPath: validHookScriptPath },
+      { nodePath: "D:\\COM¹\\node.exe", hookScriptPath: validHookScriptPath },
+      { nodePath: "D:\\LPT²\\node.exe", hookScriptPath: validHookScriptPath },
+      { nodePath: "D:\\COM1 .cache\\node.exe", hookScriptPath: validHookScriptPath },
+      { nodePath: "D:\\NUL .dir\\node.exe", hookScriptPath: validHookScriptPath },
+      { nodePath: "D:\\Historical Node.\\node.exe", hookScriptPath: validHookScriptPath },
+      { nodePath: "D:\\Historical Node \\node.exe", hookScriptPath: validHookScriptPath },
+      { nodePath: validNodePath, hookScriptPath: ".\\dist\\scripts\\codex-native-hook.js" },
+      { nodePath: validNodePath, hookScriptPath: "D:historical\\dist\\scripts\\codex-native-hook.js" },
+      { nodePath: validNodePath, hookScriptPath: "D:\\bad?script\\dist\\scripts\\codex-native-hook.js" },
+      { nodePath: validNodePath, hookScriptPath: "D:\\bad\u0000script\\dist\\scripts\\codex-native-hook.js" },
+      { nodePath: validNodePath, hookScriptPath: String.raw`\\?\D:\\Historical Install\\dist\\scripts\\codex-native-hook.js` },
+      { nodePath: validNodePath, hookScriptPath: String.raw`\Device\HarddiskVolume2\dist\scripts\codex-native-hook.js` },
+      { nodePath: validNodePath, hookScriptPath: "D:\\Historical Install.\\dist\\scripts\\codex-native-hook.js" },
+      { nodePath: validNodePath, hookScriptPath: "D:\\Historical Install \\dist\\scripts\\codex-native-hook.js" },
+      { nodePath: validNodePath, hookScriptPath: "D:\\COM1 .cache\\dist\\scripts\\codex-native-hook.js" },
+      { nodePath: validNodePath, hookScriptPath: "D:\\NUL .dir\\dist\\scripts\\codex-native-hook.js" },
+    ];
+    const uncHistorical = Buffer.from(buildManagedCodexNativeHookWindowsShimContent(
+      "\\\\server\\share\\Historical Install\\oh-my-codex",
+      {
+        nodePath: "\\\\server\\share\\Node O'Brien\\node.exe",
+        hookScriptPath: "\\\\server\\share\\Historical Install\\O'Brien\\oh-my-codex\\dist\\scripts\\codex-native-hook.js",
+      },
+    ), "utf-8");
+
+    assert.equal(
+      classifyManagedCodexNativeHookWindowsShimOwnership(uncHistorical, expected),
+      "historical",
+    );
+    for (const paths of invalidHistoricalPaths) {
+      const content = Buffer.from(buildManagedCodexNativeHookWindowsShimContent(
+        "D:\\Historical Install\\oh-my-codex",
+        paths,
+      ), "utf-8");
+      assert.equal(
+        classifyManagedCodexNativeHookWindowsShimOwnership(content, expected),
+        "modified",
+        JSON.stringify(paths),
+      );
+    }
   });
 
   it("rejects incomplete, altered, encoding-ambiguous, and unverifiable Windows shim ownership", () => {

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -1613,34 +1613,34 @@ describe("codex hooks helpers", () => {
     assert.equal(Object.hasOwn(cleaned.hooks ?? {}, "state"), false);
   });
 
-  it("preserves executable foreign future-event hooks and reports them after managed removal", () => {
-    const futureEvent = [{
-      matcher: "future-source",
-      hooks: [{
-        type: "command",
-        command: "echo future-hook",
-        statusMessage: "future hook",
-        timeout: 42,
-      }],
-    }];
-    const source = JSON.stringify({
-      hooks: {
-        ...buildManagedCodexHooksConfig("/repo").hooks,
-        FutureEvent: futureEvent,
-      },
-    });
-    const plan = planManagedCodexHooksRemoval(source, "/hooks.json");
+  for (const handler of [
+    { type: "prompt", prompt: "Review the future event." },
+    { type: "agent", prompt: "Handle the future event." },
+  ]) {
+    it(`preserves executable foreign future-event ${handler.type} handlers after managed removal`, () => {
+      const futureEvent = [{
+        matcher: "future-source",
+        hooks: [handler],
+      }];
+      const source = JSON.stringify({
+        hooks: {
+          ...buildManagedCodexHooksConfig("/repo").hooks,
+          FutureEvent: futureEvent,
+        },
+      });
+      const plan = planManagedCodexHooksRemoval(source, "/hooks.json");
 
-    assert.equal(plan.ok, true);
-    if (!plan.ok) return;
-    assert.equal(plan.hasForeignHooks, true);
-    assert.ok(plan.finalContent);
-    assert.deepEqual(
-      (JSON.parse(plan.finalContent) as { hooks?: Record<string, unknown> }).hooks?.FutureEvent,
-      futureEvent,
-    );
-    assert.equal(hasUserCodexHooksAfterManagedRemoval(source), true);
-  });
+      assert.equal(plan.ok, true);
+      if (!plan.ok) return;
+      assert.equal(plan.hasForeignHooks, true);
+      assert.ok(plan.finalContent);
+      assert.deepEqual(
+        (JSON.parse(plan.finalContent) as { hooks?: Record<string, unknown> }).hooks?.FutureEvent,
+        futureEvent,
+      );
+      assert.equal(hasUserCodexHooksAfterManagedRemoval(source), true);
+    });
+  }
 
   it("detects user hooks that remain after managed wrapper removal", () => {
     const managedOnly = JSON.stringify(buildManagedCodexHooksConfig("/repo"));

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -1178,6 +1178,46 @@ describe("codex hooks helpers", () => {
     assert.equal(state[`${hooksPath}:stop:0:0`], undefined);
   });
 
+  it("distinguishes an absent final hooks artifact from fallback and scanned content", () => {
+    const hooksPath = "/home/me/.codex/hooks.json";
+    const fallbackState = buildManagedCodexHookTrustState(hooksPath, "/repo");
+    const fallbackToml = buildManagedCodexHookTrustToml(hooksPath, "/repo");
+    const normalFinalContent = mergeManagedCodexHooksConfig(
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [{ hooks: [{ type: "command", command: "echo foreign" }] }],
+        },
+      }),
+      "/repo",
+      hooksPath,
+    );
+    const normalState = buildManagedCodexHookTrustState(hooksPath, "/repo", {
+      hooksContent: normalFinalContent,
+    });
+    const normalToml = buildManagedCodexHookTrustToml(hooksPath, "/repo", {
+      hooksContent: normalFinalContent,
+    });
+
+    assert.deepEqual(buildManagedCodexHookTrustState(hooksPath, "/repo", { hooksContent: null }), {});
+    assert.equal(buildManagedCodexHookTrustToml(hooksPath, "/repo", { hooksContent: null }), "");
+
+    assert.deepEqual(
+      buildManagedCodexHookTrustState(hooksPath, "/repo", { hooksContent: undefined }),
+      fallbackState,
+    );
+    assert.equal(
+      buildManagedCodexHookTrustToml(hooksPath, "/repo", { hooksContent: undefined }),
+      fallbackToml,
+    );
+
+    assert.deepEqual(buildManagedCodexHookTrustState(hooksPath, "/repo", { hooksContent: "{}" }), {});
+    assert.equal(buildManagedCodexHookTrustToml(hooksPath, "/repo", { hooksContent: "{}" }), "");
+
+    assert.ok(normalState[`${hooksPath}:pre_tool_use:1:0`]);
+    assert.equal(normalState[`${hooksPath}:pre_tool_use:0:0`], undefined);
+    assert.ok(normalToml.includes(`[hooks.state."${hooksPath}:pre_tool_use:1:0"]`));
+  });
+
   it("builds trust state only for generated OMX hook handlers", () => {
     const state = buildManagedCodexHookTrustState("/home/me/.codex/hooks.json", "/repo");
     const keys = Object.keys(state).sort();

--- a/src/config/__tests__/codex-hooks.test.ts
+++ b/src/config/__tests__/codex-hooks.test.ts
@@ -8,6 +8,7 @@ import {
   buildManagedCodexNativeHookCommand,
   buildManagedCodexNativeHookWindowsShimContent,
   buildManagedCodexNativeHookWindowsShimPath,
+  classifyManagedCodexNativeHookWindowsShimOwnership,
   buildManagedCodexHookTrustState,
   buildManagedCodexHookTrustToml,
   buildManagedCodexHooksConfig,
@@ -18,16 +19,23 @@ import {
   getMissingManagedCodexHookEvents,
   hasUserCodexHooksAfterManagedRemoval,
   isRuntimeCodexHomeMirrorPath,
+  isManagedCodexHookCommand,
   mergeManagedCodexHooksConfig,
   removeManagedCodexHooks,
   resolveWindowsPowerShellPath,
+  parseManagedCodexNativeHookWindowsShimCommand,
+  ManagedCodexHooksPlanError,
+  planManagedCodexHooksMerge,
+  planManagedCodexHooksRemoval,
+  scanManagedCodexHookTrustStateFromContent,
+  validateCodexHooksConfigStrict,
 } from "../codex-hooks.js";
 
 describe("codex hooks helpers", () => {
 
   it("uses the current JavaScript runtime for managed hook commands", () => {
     const config = buildManagedCodexHooksConfig("/repo");
-    const command = (config.hooks.SessionStart[0] as { hooks?: Array<{ command?: string }> } | undefined)?.hooks?.[0]?.command;
+    const command = config.hooks.SessionStart[0]?.hooks[0]?.command;
 
     assert.equal(
       command,
@@ -61,9 +69,7 @@ describe("codex hooks helpers", () => {
         env: { SystemRoot: "C:\\Windows" },
       },
     );
-    const command = (config.hooks.SessionStart[0] as {
-      hooks?: Array<{ command?: string }>;
-    } | undefined)?.hooks?.[0]?.command;
+    const command = config.hooks.SessionStart[0]?.hooks[0]?.command;
 
     assert.equal(
       command,
@@ -72,6 +78,93 @@ describe("codex hooks helpers", () => {
     assert.doesNotMatch(command ?? "", /codex-native-hook\.js/);
     assert.doesNotMatch(command ?? "", /^"[A-Z]:\\/i);
     assert.doesNotMatch(command ?? "", /\\"/);
+  });
+
+  it("parses only managed Windows shim commands and returns their validated final path", () => {
+    const shimPath = "C:\\Users\\Ada Lovelace\\.codex\\hooks\\omx-native-hook-windows-shim.ps1";
+    const managed = `& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File '${shimPath}'`;
+
+    assert.equal(parseManagedCodexNativeHookWindowsShimCommand(managed), shimPath);
+    assert.equal(
+      parseManagedCodexNativeHookWindowsShimCommand(
+        `powershell.exe -NoProfile -ExecutionPolicy Bypass -File "${shimPath}"`,
+      ),
+      shimPath,
+    );
+    for (const command of [
+      `${managed} -NoExit`,
+      managed.replace("-ExecutionPolicy Bypass", "-ExecutionPolicy RemoteSigned"),
+      managed.replace("omx-native-hook-windows-shim.ps1", "foreign-hook.ps1"),
+      `${managed}; Write-Host modified`,
+      managed.replace("& ", "'&' "),
+    ]) {
+      assert.equal(parseManagedCodexNativeHookWindowsShimCommand(command), null);
+    }
+  });
+
+  it("accepts quoted POSIX and PowerShell path operators while rejecting unquoted operators", () => {
+    const directCommand = buildManagedCodexNativeHookCommand(
+      "/repo with spaces;|<> (fixture) $literal/O'Brien",
+      { platform: "linux" },
+    );
+    const packageRoot = "D:\\Program Files\\O'Brien\\hook (fixture) $literal\\oh-my-codex";
+    const codexHome = "C:\\Users\\O'Brien\\.codex (fixture) $literal";
+    const shimPath = "C:\\Users\\O'Brien\\.codex (fixture) $literal\\hooks\\omx-native-hook-windows-shim.ps1";
+    const windowsCommand = buildManagedCodexNativeHookCommand(packageRoot, {
+      platform: "win32",
+      codexHomeDir: codexHome,
+      env: { SystemRoot: "C:\\Windows" },
+    });
+
+    assert.match(directCommand, /\\\$literal/);
+    assert.equal(isManagedCodexHookCommand(directCommand), true);
+    assert.equal(isManagedCodexHookCommand(windowsCommand), true);
+    assert.equal(parseManagedCodexNativeHookWindowsShimCommand(windowsCommand), shimPath);
+    assert.match(windowsCommand, /O''Brien/);
+    assert.equal(
+      isManagedCodexHookCommand(
+        'node /repo/dist/scripts/codex-native-hook.js; Write-Host injected',
+      ),
+      false,
+    );
+  });
+
+  it("owns only shell-static command spellings and keeps platform ownership exact", () => {
+    const posixScript = "/repo/dist/scripts/codex-native-hook.js";
+    const windowsScript = "C:\\repo\\DIST\\SCRIPTS\\CODEX-NATIVE-HOOK.JS";
+    const shimPath = "C:\\Users\\Ada\\.codex\\hooks\\omx-native-hook-windows-shim.ps1";
+    const managedWindowsShim = `& 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -NoProfile -ExecutionPolicy Bypass -File '${shimPath}'`;
+
+    assert.equal(isManagedCodexHookCommand(`node '${posixScript}'`), true);
+    assert.equal(isManagedCodexHookCommand(`C:\\Node\\NODE.EXE ${windowsScript}`), true);
+    for (const command of [
+      `node "$HOME${posixScript}"`,
+      `node "$(printf /repo)/dist/scripts/codex-native-hook.js"`,
+      "node /repo/*/dist/scripts/codex-native-hook.js",
+      "node ~/repo/dist/scripts/codex-native-hook.js",
+      "node /repo/{old,new}/dist/scripts/codex-native-hook.js",
+      `node "${posixScript}"; :`,
+    ]) {
+      assert.equal(isManagedCodexHookCommand(command), false, command);
+    }
+    for (const command of [
+      `& "$env:SystemRoot\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File '${shimPath}'`,
+      `& "$([Environment]::GetFolderPath('Windows'))\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File '${shimPath}'`,
+      `${managedWindowsShim}; Write-Host injected`,
+    ]) {
+      assert.equal(parseManagedCodexNativeHookWindowsShimCommand(command), null, command);
+      assert.equal(isManagedCodexHookCommand(command), false, command);
+    }
+
+    const caseVariant = JSON.stringify({
+      hooks: {
+        SessionStart: [{ hooks: [{ type: "command", command: `NODE ${posixScript}` }] }],
+      },
+    });
+    const posix = planManagedCodexHooksRemoval(caseVariant, "/hooks.json", { platform: "linux" });
+    const windows = planManagedCodexHooksRemoval(caseVariant, "C:\\Users\\Ada\\.codex\\hooks.json", { platform: "win32" });
+    assert.equal(posix.ok, false);
+    assert.equal(windows.ok, true);
   });
 
   it("emits Windows hooks.json entries with only the cmd-compatible command field", () => {
@@ -202,6 +295,78 @@ describe("codex hooks helpers", () => {
     assert.deepEqual([...utf8.subarray(0, 3)], [0xef, 0xbb, 0xbf]);
   });
 
+  it("classifies only byte-identical Windows shims as current and complete generated variants as historical", () => {
+    const expected = Buffer.from(buildManagedCodexNativeHookWindowsShimContent(
+      "C:\\Current Install\\oh-my-codex",
+      {
+        nodePath: "C:\\Current Node\\node.exe",
+        hookScriptPath: "C:\\Current Install\\oh-my-codex\\dist\\scripts\\codex-native-hook.js",
+      },
+    ), "utf-8");
+    const historical = Buffer.from(buildManagedCodexNativeHookWindowsShimContent(
+      "C:\\Historical Install\\oh-my-codex",
+      {
+        nodePath: "D:\\Historical Node\\O'Malley\\node",
+        hookScriptPath: "D:\\Historical Install\\O'Malley\\oh-my-codex\\dist\\scripts\\codex-native-hook.js",
+      },
+    ), "utf-8");
+
+    assert.equal(
+      classifyManagedCodexNativeHookWindowsShimOwnership(expected, expected),
+      "current",
+    );
+    assert.equal(
+      classifyManagedCodexNativeHookWindowsShimOwnership(historical, expected),
+      "historical",
+    );
+  });
+
+  it("rejects incomplete, altered, encoding-ambiguous, and unverifiable Windows shim ownership", () => {
+    const expected = Buffer.from(buildManagedCodexNativeHookWindowsShimContent(
+      "C:\\Current Install\\oh-my-codex",
+      {
+        nodePath: "C:\\Current Node\\node.exe",
+        hookScriptPath: "C:\\Current Install\\oh-my-codex\\dist\\scripts\\codex-native-hook.js",
+      },
+    ), "utf-8");
+    const historical = Buffer.from(buildManagedCodexNativeHookWindowsShimContent(
+      "C:\\Historical Install\\oh-my-codex",
+      {
+        nodePath: "D:\\Historical Node\\node.exe",
+        hookScriptPath: "D:\\Historical Install\\oh-my-codex\\dist\\scripts\\codex-native-hook.js",
+      },
+    ), "utf-8");
+    const modifiedFixedStatement = Buffer.from(historical.toString("utf-8").replace(
+      "$process.WaitForExit()",
+      "$process.WaitForExit(1)",
+    ), "utf-8");
+    const unverifiableNode = Buffer.from(historical.toString("utf-8").replace(
+      "D:\\Historical Node\\node.exe",
+      "D:\\Historical Node\\foreign.exe",
+    ), "utf-8");
+    const unverifiableHookScript = Buffer.from(historical.toString("utf-8").replace(
+      "\\dist\\scripts\\codex-native-hook.js",
+      "\\dist\\scripts\\foreign-hook.js",
+    ), "utf-8");
+    const invalidUtf8 = Buffer.from(historical);
+    invalidUtf8[10] = 0xff;
+
+    for (const candidate of [
+      historical.subarray(3),
+      historical.subarray(0, historical.length - 1),
+      Buffer.concat([historical, Buffer.from("# extra\\n", "utf-8")]),
+      modifiedFixedStatement,
+      unverifiableNode,
+      unverifiableHookScript,
+      invalidUtf8,
+    ]) {
+      assert.equal(
+        classifyManagedCodexNativeHookWindowsShimOwnership(candidate, expected),
+        "modified",
+      );
+    }
+  });
+
   it("forwards payload, stdout, stderr, and non-zero exit through the Windows shim when PowerShell is available", async () => {
     const shell = ["pwsh", "powershell.exe", "powershell"].find((candidate) => {
       const probe = spawnSync(candidate, ["-NoProfile", "-Command", "$PSVersionTable.PSVersion.ToString()"], {
@@ -269,6 +434,7 @@ describe("codex hooks helpers", () => {
           hooks: {
             SessionStart: [
               {
+                matcher: "startup|resume|clear",
                 hooks: [
                   { type: "command", command: 'node "/old/dist/scripts/codex-native-hook.js"' },
                   { type: "command", command: "echo keep-me" },
@@ -294,6 +460,104 @@ describe("codex hooks helpers", () => {
     assert.match(JSON.stringify(sessionStart), /echo keep-me/);
     assert.match(JSON.stringify(sessionStart), /echo standalone-user/);
     assert.doesNotMatch(JSON.stringify(sessionStart), /Loading OMX session context/);
+  });
+
+  it("replaces existing managed groups in place without moving foreign groups", () => {
+    const managed = buildManagedCodexHooksConfig("/repo");
+    const original = JSON.stringify({
+      hooks: {
+        SessionStart: [
+          { hooks: [{ type: "command", command: "echo before" }] },
+          {
+            matcher: "startup|resume|clear",
+            hooks: [
+              { type: "command", command: 'node "/old/dist/scripts/codex-native-hook.js"' },
+            ],
+          },
+          { hooks: [{ type: "command", command: "echo after" }] },
+        ],
+        PreToolUse: [
+          { hooks: [{ type: "command", command: "echo pre-before" }] },
+          managed.hooks.PreToolUse[0],
+          { hooks: [{ type: "command", command: "echo pre-after" }] },
+        ],
+      },
+    });
+
+    const first = mergeManagedCodexHooksConfig(original, "/repo", "/hooks.json");
+    const second = mergeManagedCodexHooksConfig(first, "/repo", "/hooks.json");
+    const merged = JSON.parse(first) as {
+      hooks: Record<string, Array<{ matcher?: string; hooks?: Array<{ command?: string }> }>>;
+    };
+
+    assert.equal(second, first);
+    assert.deepEqual(
+      merged.hooks.SessionStart.map((entry) => entry.hooks?.[0]?.command),
+      [
+        "echo before",
+        managed.hooks.SessionStart[0]?.hooks[0]?.command,
+        "echo after",
+      ],
+    );
+    assert.deepEqual(
+      merged.hooks.PreToolUse.map((entry) => entry.hooks?.[0]?.command),
+      [
+        "echo pre-before",
+        managed.hooks.PreToolUse[0]?.hooks[0]?.command,
+        "echo pre-after",
+      ],
+    );
+  });
+
+  it("appends missing managed groups without moving unrelated foreign groups", () => {
+    const merged = JSON.parse(mergeManagedCodexHooksConfig(
+      JSON.stringify({
+        hooks: {
+          Stop: [
+            { hooks: [{ type: "command", command: "echo first" }] },
+            { hooks: [{ type: "command", command: "echo second" }] },
+          ],
+        },
+      }),
+      "/repo",
+      "/hooks.json",
+    )) as { hooks: Record<string, Array<{ hooks?: Array<{ command?: string }> }>> };
+
+    assert.deepEqual(
+      merged.hooks.Stop.map((entry) => entry.hooks?.[0]?.command),
+      [
+        "echo first",
+        "echo second",
+        buildManagedCodexHooksConfig("/repo").hooks.Stop[0]?.hooks[0]?.command,
+      ],
+    );
+  });
+
+  it("derives managed trust keys from the final merged hook group layout", () => {
+    const hooksPath = "/home/me/.codex/hooks.json";
+    const hooksContent = mergeManagedCodexHooksConfig(
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            { hooks: [{ type: "command", command: "echo first" }] },
+            { hooks: [{ type: "command", command: "echo second" }] },
+          ],
+          Stop: [
+            { hooks: [{ type: "command", command: "echo keep" }] },
+          ],
+        },
+      }),
+      "/repo",
+      hooksPath,
+    );
+    const state = buildManagedCodexHookTrustState(hooksPath, "/repo", {
+      hooksContent,
+    });
+
+    assert.ok(state[`${hooksPath}:pre_tool_use:2:0`]);
+    assert.ok(state[`${hooksPath}:stop:1:0`]);
+    assert.equal(state[`${hooksPath}:pre_tool_use:0:0`], undefined);
+    assert.equal(state[`${hooksPath}:stop:0:0`], undefined);
   });
 
   it("builds trust state only for generated OMX hook handlers", () => {
@@ -383,6 +647,32 @@ describe("codex hooks helpers", () => {
     const expectedHash = `sha256:${createHash("sha256").update(canonical).digest("hex")}`;
 
     assert.equal(state[`${hooksPath}:pre_tool_use:0:0`]?.trusted_hash, expectedHash);
+  });
+
+  it("hashes u64 timeout literals without losing values above Number.MAX_SAFE_INTEGER", async () => {
+    const command = buildManagedCodexNativeHookCommand("/repo");
+    const lower = "9007199254740992";
+    const higher = "9007199254740993";
+    const scanTimeout = (timeout: string) => scanManagedCodexHookTrustStateFromContent(
+      `{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":${JSON.stringify(command)},"timeout":${timeout}}]}]}}`,
+      "/hooks.json",
+    );
+    const lowerScan = scanTimeout(lower);
+    const higherScan = scanTimeout(higher);
+    assert.equal(lowerScan.ok, true);
+    assert.equal(higherScan.ok, true);
+    if (!lowerScan.ok || !higherScan.ok) return;
+
+    const key = "/hooks.json:pre_tool_use:0:0";
+    const lowerHash = lowerScan.trustState[key]?.trusted_hash;
+    const higherHash = higherScan.trustState[key]?.trusted_hash;
+    assert.notEqual(lowerHash, higherHash);
+    const canonical = `{"event_name":"pre_tool_use","hooks":[{"async":false,"command":${JSON.stringify(command)},"timeout":${higher},"type":"command"}]}`;
+    const { createHash } = await import("node:crypto");
+    assert.equal(
+      higherHash,
+      `sha256:${createHash("sha256").update(canonical).digest("hex")}`,
+    );
   });
 
   it("serializes managed hook trust state as TOML tables for config.toml", () => {
@@ -528,6 +818,33 @@ describe("codex hooks helpers", () => {
 
     assert.equal(Object.hasOwn(merged, "state"), false);
     assert.equal(Object.hasOwn(merged.hooks, "state"), false);
+
+    const exactNestedPlan = planManagedCodexHooksMerge(
+      JSON.stringify({
+        hooks: {
+          state: {
+            "custom:/hooks.json:stop:0:0": {
+              trusted_hash: "sha256:legacy",
+              enabled: false,
+            },
+          },
+        },
+      }),
+      "/repo",
+      "/hooks.json",
+    );
+    assert.equal(exactNestedPlan.ok, true);
+    if (exactNestedPlan.ok) {
+      assert.deepEqual(exactNestedPlan.legacyTrustState, {
+        "custom:/hooks.json:stop:0:0": {
+          trusted_hash: "sha256:legacy",
+          enabled: false,
+        },
+      });
+      const finalContent = exactNestedPlan.finalContent;
+      assert.ok(finalContent);
+      assert.equal(Object.hasOwn(JSON.parse(finalContent), "hooks"), true);
+    }
   });
 
 
@@ -543,6 +860,7 @@ describe("codex hooks helpers", () => {
       hooks: {
         SessionStart: [
           {
+            matcher: "startup|resume|clear",
             hooks: [
               { type: "command", command: 'node "D:\\old\\dist\\scripts\\codex-native-hook.js"' },
               { type: "command", command: "echo keep-me" },
@@ -598,14 +916,14 @@ describe("codex hooks helpers", () => {
         },
         SessionStart: [
           {
+            matcher: "startup|resume|clear",
             hooks: [
-              { type: "command", command: 'node "/repo/dist/scripts/codex-native-hook.js"' },
               { type: "command", command: "echo keep-me" },
+              { type: "command", command: 'node "/repo/dist/scripts/codex-native-hook.js"' },
             ],
           },
         ],
       },
-      version: 1,
     });
 
     const removedManagedOnly = removeManagedCodexHooks(managedOnly);
@@ -628,7 +946,6 @@ describe("codex hooks helpers", () => {
     assert.ok(removedMixed.nextContent);
     assert.match(removedMixed.nextContent, /echo keep-me/);
     assert.doesNotMatch(removedMixed.nextContent, /codex-native-hook\.js/);
-    assert.match(removedMixed.nextContent, /"version": 1/);
 
     const cleaned = JSON.parse(removedMixed.nextContent) as {
       state?: Record<string, { trusted_hash?: string }>;
@@ -636,6 +953,35 @@ describe("codex hooks helpers", () => {
     };
     assert.equal(Object.hasOwn(cleaned, "state"), false);
     assert.equal(Object.hasOwn(cleaned.hooks ?? {}, "state"), false);
+  });
+
+  it("preserves executable foreign future-event hooks and reports them after managed removal", () => {
+    const futureEvent = [{
+      matcher: "future-source",
+      hooks: [{
+        type: "command",
+        command: "echo future-hook",
+        statusMessage: "future hook",
+        timeout: 42,
+      }],
+    }];
+    const source = JSON.stringify({
+      hooks: {
+        ...buildManagedCodexHooksConfig("/repo").hooks,
+        FutureEvent: futureEvent,
+      },
+    });
+    const plan = planManagedCodexHooksRemoval(source, "/hooks.json");
+
+    assert.equal(plan.ok, true);
+    if (!plan.ok) return;
+    assert.equal(plan.hasForeignHooks, true);
+    assert.ok(plan.finalContent);
+    assert.deepEqual(
+      (JSON.parse(plan.finalContent) as { hooks?: Record<string, unknown> }).hooks?.FutureEvent,
+      futureEvent,
+    );
+    assert.equal(hasUserCodexHooksAfterManagedRemoval(source), true);
   });
 
   it("detects user hooks that remain after managed wrapper removal", () => {
@@ -649,9 +995,10 @@ describe("codex hooks helpers", () => {
         },
         SessionStart: [
           {
+            matcher: "startup|resume|clear",
             hooks: [
-              { type: "command", command: 'node "/repo/dist/scripts/codex-native-hook.js"' },
               { type: "command", command: "echo keep-me" },
+              { type: "command", command: 'node "/repo/dist/scripts/codex-native-hook.js"' },
             ],
           },
         ],
@@ -676,10 +1023,8 @@ describe("codex hooks helpers", () => {
     const config = buildManagedCodexHooksConfig("/repo");
     assert.ok(config.hooks.PreCompact?.length);
     assert.ok(config.hooks.PostCompact?.length);
-    const preCompact = config.hooks.PreCompact as Array<{ hooks?: Array<{ command?: string }> }>;
-    const postCompact = config.hooks.PostCompact as Array<{ hooks?: Array<{ command?: string }> }>;
-    const preCommand = preCompact[0]?.hooks?.[0]?.command;
-    const postCommand = postCompact[0]?.hooks?.[0]?.command;
+    const preCommand = config.hooks.PreCompact[0]?.hooks[0]?.command;
+    const postCommand = config.hooks.PostCompact[0]?.hooks[0]?.command;
     assert.match(String(preCommand), /codex-native-hook\.js/);
     assert.match(String(postCommand), /codex-native-hook\.js/);
     assert.equal(postCommand, preCommand);
@@ -770,5 +1115,508 @@ describe("codex hooks helpers", () => {
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
+  });
+  it("models Codex empty/default/null load behavior without accepting async null", () => {
+    const valid = validateCodexHooksConfigStrict(JSON.stringify({
+      hooks: {
+        PreToolUse: [{
+          matcher: null,
+          hooks: [{
+            type: "command",
+            command: "echo foreign",
+            commandWindows: null,
+            timeout: 0,
+            statusMessage: null,
+          }],
+        }],
+      },
+    }));
+    assert.equal(validateCodexHooksConfigStrict("{}").ok, true);
+    assert.equal(valid.ok, true);
+    if (valid.ok) {
+      assert.equal(valid.groupOccurrences[0]?.groupIndex, 0);
+      assert.equal(valid.handlerOccurrences[0]?.handlerIndex, 0);
+    }
+
+    const invalid = validateCodexHooksConfigStrict(JSON.stringify({
+      hooks: {
+        PreToolUse: [{ hooks: [{ type: "command", command: "echo", async: null }] }],
+      },
+    }));
+    assert.equal(invalid.ok, false);
+  });
+
+  it("matches pinned serde_json strict intake for whitespace, Unicode, numbers, and nesting", () => {
+    const validTimeoutPrefix = '{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"echo","timeout":';
+    for (const content of [
+      "\uFEFF{}",
+      "\v{}",
+      "\f{}",
+      "\u00a0{}",
+      `${validTimeoutPrefix}1e400}]}]}}`,
+      '{"hooks":{"PreToolUse":[{"matcher":"\\uD800","hooks":[{"type":"command","command":"echo"}]}]}}',
+    ]) {
+      assert.equal(validateCodexHooksConfigStrict(content).ok, false, JSON.stringify(content));
+    }
+
+    const withinSerdeDepth = `{"x":${"[".repeat(127)}0${"]".repeat(127)}}`;
+    const beyondSerdeDepth = `{"x":${"[".repeat(128)}0${"]".repeat(128)}}`;
+    const within = validateCodexHooksConfigStrict(withinSerdeDepth);
+    const beyond = validateCodexHooksConfigStrict(beyondSerdeDepth);
+    assert.equal(within.ok, false);
+    assert.equal(beyond.ok, false);
+    if (!within.ok) assert.match(within.error.message, /unknown root field x/);
+    if (!beyond.ok) assert.match(beyond.error.message, /must contain a JSON object/);
+  });
+
+  it("uses the platform-effective Windows command before discovery and skipped-command diagnostics", () => {
+    const withWindowsCommand = JSON.stringify({
+      hooks: {
+        PreToolUse: [{ hooks: [{ type: "command", command: " \t", commandWindows: "echo windows" }] }],
+      },
+    });
+    const windows = validateCodexHooksConfigStrict(withWindowsCommand, { platform: "win32" });
+    assert.equal(windows.ok, true);
+    if (windows.ok) {
+      assert.deepEqual(windows.discoveredCommands.map((entry) => entry.command), ["echo windows"]);
+      assert.equal(windows.diagnostics.some((entry) => entry.code === "empty_command"), false);
+    }
+
+    const withWindowsAlias = JSON.stringify({
+      hooks: {
+        PreToolUse: [{ hooks: [{ type: "command", command: "echo posix", command_windows: " \n" }] }],
+      },
+    });
+    const windowsAlias = validateCodexHooksConfigStrict(withWindowsAlias, { platform: "win32" });
+    const posix = validateCodexHooksConfigStrict(withWindowsAlias, { platform: "linux" });
+    assert.equal(windowsAlias.ok, true);
+    assert.equal(posix.ok, true);
+    if (windowsAlias.ok) {
+      assert.deepEqual(windowsAlias.discoveredCommands, []);
+      assert.equal(windowsAlias.diagnostics.filter((entry) => entry.code === "empty_command").length, 1);
+    }
+    if (posix.ok) assert.deepEqual(posix.discoveredCommands.map((entry) => entry.command), ["echo posix"]);
+  });
+
+  it("accepts Codex's match-all matcher and treats whitespace-only commands as skipped", () => {
+    const strict = validateCodexHooksConfigStrict(JSON.stringify({
+      hooks: {
+        PreToolUse: [{
+          matcher: "*",
+          hooks: [
+            { type: "command", command: " \t" },
+            { type: "command", command: "echo discovered" },
+          ],
+        }],
+      },
+    }));
+    assert.equal(strict.ok, true);
+    if (!strict.ok) return;
+    assert.equal(strict.diagnostics.some((entry) => entry.code === "invalid_matcher"), false);
+    assert.equal(strict.diagnostics.filter((entry) => entry.code === "empty_command").length, 1);
+    assert.deepEqual(strict.discoveredCommands.map((entry) => entry.command), ["echo discovered"]);
+
+    const managed = buildManagedCodexNativeHookCommand("/repo");
+    const plan = planManagedCodexHooksMerge(JSON.stringify({
+      hooks: {
+        PreToolUse: [{
+          hooks: [
+            { type: "command", command: managed },
+            { type: "command", command: "\n\t " },
+          ],
+        }],
+      },
+    }), "/repo", "/hooks.json");
+    assert.equal(plan.ok, false);
+    if (!plan.ok) assert.equal(plan.error.code, "ambiguous_managed_handler");
+  });
+
+  it("uses Rust-regex matcher syntax rather than accepting JavaScript-only assertions", () => {
+    const validateMatcher = (matcher: string) => validateCodexHooksConfigStrict(JSON.stringify({
+      hooks: {
+        PreToolUse: [{
+          matcher,
+          hooks: [{ type: "command", command: "echo matcher" }],
+        }],
+      },
+    }));
+
+    for (const matcher of [
+      "(?i)startup",
+      "(?i:startup)",
+      "(?-i)startup",
+      "(?im-s:startup)",
+      "(?x: start up)",
+      "\\Astartup\\z",
+      "\\a\\x41\\u{1F600}",
+      "\\p{Greek}",
+    ]) {
+      const result = validateMatcher(matcher);
+      assert.equal(result.ok, true, matcher);
+      if (result.ok) {
+        assert.equal(
+          result.diagnostics.some((entry) => entry.code === "invalid_matcher"),
+          false,
+          matcher,
+        );
+      }
+    }
+    for (const matcher of [
+      "(?=startup)startup",
+      "(?<=start)up",
+      "(startup)\\1",
+      "\\q",
+      "\\u0041",
+      "\\x4",
+      "\\p{}",
+      "\\p{NotAUnicodeProperty}",
+      "\\u{D800}",
+      "\\u{DFFF}",
+    ]) {
+      const result = validateMatcher(matcher);
+      assert.equal(result.ok, true, matcher);
+      if (result.ok) {
+        assert.equal(
+          result.diagnostics.some((entry) => entry.code === "invalid_matcher"),
+          true,
+          matcher,
+        );
+      }
+    }
+
+  });
+
+  it("preserves ignored nested events, nonmatching hooks.state, and unknown raw members", () => {
+    const existing = `{"hooks":{"state":{"not":"legacy"},"Future":{"raw":[1,{"keep":true}]},"PreToolUse":[{"opaque":{"source" : [1, 2]},"hooks":[{"type":"command","command":"echo foreign","unknown":{"keep":true}}]}]}}`;
+    const plan = planManagedCodexHooksMerge(existing, "/repo", "/hooks.json");
+
+    assert.equal(plan.ok, true);
+    if (!plan.ok) return;
+    assert.ok(plan.finalContent?.includes(`"state":{"not":"legacy"}`));
+    assert.ok(plan.finalContent?.includes(`"Future":{"raw":[1,{"keep":true}]}`));
+    assert.ok(plan.finalContent?.includes(`"opaque":{"source" : [1, 2]}`));
+    assert.ok(plan.finalContent?.includes(`"unknown":{"keep":true}`));
+  });
+
+  it("migrates only exact historical root state and fails closed for nonmatching root state", () => {
+    const exact = planManagedCodexHooksMerge(JSON.stringify({
+      state: {
+        "/hooks.json:stop:0:0": { trusted_hash: "sha256:legacy", enabled: true },
+      },
+    }), "/repo", "/hooks.json");
+    assert.equal(exact.ok, true);
+    if (exact.ok) {
+      assert.deepEqual(exact.legacyTrustState, {
+        "/hooks.json:stop:0:0": { trusted_hash: "sha256:legacy", enabled: true },
+      });
+      assert.doesNotMatch(exact.finalContent ?? "", /"state"/);
+    }
+
+    const nonmatching = planManagedCodexHooksMerge(JSON.stringify({
+      state: { "/hooks.json:stop:0:0": { trusted_hash: "sha256:legacy", extra: true } },
+    }), "/repo", "/hooks.json");
+    assert.equal(nonmatching.ok, false);
+    if (!nonmatching.ok) assert.equal(nonmatching.error.code, "invalid_document");
+  });
+
+  it("preserves a legacy __proto__ trust key as an own migration entry", () => {
+    const plan = planManagedCodexHooksMerge(
+      '{"state":{"__proto__":{"trusted_hash":"sha256:legacy","enabled":true}}}',
+      "/repo",
+      "/hooks.json",
+    );
+    assert.equal(plan.ok, true);
+    if (!plan.ok) return;
+    assert.equal(Object.hasOwn(plan.legacyTrustState, "__proto__"), true);
+    assert.deepEqual(plan.legacyTrustState["__proto__"], {
+      trusted_hash: "sha256:legacy",
+      enabled: true,
+    });
+  });
+
+  it("coalesces identical root and nested legacy trust state but rejects conflicts", () => {
+    const key = "/hooks.json:stop:0:0";
+    const matching = planManagedCodexHooksMerge(JSON.stringify({
+      state: { [key]: { trusted_hash: "sha256:legacy", enabled: false } },
+      hooks: {
+        state: { [key]: { trusted_hash: "sha256:legacy", enabled: false } },
+      },
+    }), "/repo", "/hooks.json");
+    assert.equal(matching.ok, true);
+    if (matching.ok) {
+      assert.deepEqual(matching.legacyTrustState, {
+        [key]: { trusted_hash: "sha256:legacy", enabled: false },
+      });
+    }
+
+    const conflicting = planManagedCodexHooksMerge(JSON.stringify({
+      state: { [key]: { trusted_hash: "sha256:root", enabled: false } },
+      hooks: {
+        state: { [key]: { trusted_hash: "sha256:nested", enabled: false } },
+      },
+    }), "/repo", "/hooks.json");
+    assert.equal(conflicting.ok, false);
+    if (!conflicting.ok) {
+      assert.equal(conflicting.error.code, "managed_trust_key_conflict");
+      assert.equal("finalContent" in conflicting, false);
+    }
+  });
+
+  it("coalesces every exact duplicate nested legacy state and rejects conflicting duplicates", () => {
+    const key = "/hooks.json:stop:0:0";
+    const identical = planManagedCodexHooksMerge(
+      `{"hooks":{"state":{"${key}":{"trusted_hash":"sha256:legacy","enabled":true}},"state":{"${key}":{"trusted_hash":"sha256:legacy","enabled":true}}}}`,
+      "/repo",
+      "/hooks.json",
+    );
+    assert.equal(identical.ok, true);
+    if (identical.ok) {
+      assert.deepEqual(identical.legacyTrustState, {
+        [key]: { trusted_hash: "sha256:legacy", enabled: true },
+      });
+      assert.doesNotMatch(identical.finalContent ?? "", /"state"/);
+    }
+
+    const conflicting = planManagedCodexHooksMerge(
+      `{"hooks":{"state":{"${key}":{"trusted_hash":"sha256:first"}},"state":{"${key}":{"trusted_hash":"sha256:second"}}}}`,
+      "/repo",
+      "/hooks.json",
+    );
+    assert.equal(conflicting.ok, false);
+    if (!conflicting.ok) assert.equal(conflicting.error.code, "managed_trust_key_conflict");
+
+    const nonLegacyDuplicate = planManagedCodexHooksMerge(
+      '{"hooks":{"state":{"not":"legacy"},"state":{"not":"legacy"}}}',
+      "/repo",
+      "/hooks.json",
+    );
+    assert.equal(nonLegacyDuplicate.ok, false);
+    if (!nonLegacyDuplicate.ok) assert.equal(nonLegacyDuplicate.error.code, "invalid_document");
+  });
+
+  it("records every raw group and handler occurrence across all ten Codex events", () => {
+    const events = [
+      "PreToolUse",
+      "PermissionRequest",
+      "PostToolUse",
+      "PreCompact",
+      "PostCompact",
+      "SessionStart",
+      "UserPromptSubmit",
+      "SubagentStart",
+      "SubagentStop",
+      "Stop",
+    ];
+    const hooks = Object.fromEntries(events.map((eventName) => [eventName, [
+      eventName === "PreToolUse" ? {} : { hooks: [] },
+      {
+        ...(eventName === "PreToolUse" ? { matcher: "(" } : {}),
+        hooks: [
+          { type: "prompt", prompt: "keep" },
+          { type: "agent", prompt: "keep" },
+          { type: "command", command: "", async: true },
+        ],
+      },
+    ]]));
+    const strict = validateCodexHooksConfigStrict(JSON.stringify({ hooks }));
+
+    assert.equal(strict.ok, true);
+    if (!strict.ok) return;
+    assert.equal(strict.groupOccurrences.length, 20);
+    assert.equal(strict.handlerOccurrences.length, 30);
+    assert.equal(strict.discoveredCommands.length, 0);
+    assert.equal(strict.diagnostics.filter((entry) => entry.code === "invalid_matcher").length, 1);
+  });
+
+  it("ignores UserPromptSubmit and Stop matchers for discovery while keeping their coordinates", () => {
+    const existing = JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [{ matcher: "(", hooks: [{ type: "command", command: "echo prompt" }] }],
+        Stop: [{ matcher: "(", hooks: [{ type: "command", command: "echo stop" }] }],
+      },
+    });
+    const strict = validateCodexHooksConfigStrict(existing);
+    assert.equal(strict.ok, true);
+    if (strict.ok) assert.equal(strict.diagnostics.some((entry) => entry.code === "invalid_matcher"), false);
+
+    const plan = planManagedCodexHooksMerge(existing, "/repo", "/hooks.json");
+    assert.equal(plan.ok, true);
+    if (!plan.ok) return;
+    assert.ok(plan.finalTrustState["/hooks.json:user_prompt_submit:1:0"]);
+    assert.ok(plan.finalTrustState["/hooks.json:stop:1:0"]);
+  });
+
+  it("appends each missing OMX event once and makes the third setup byte-identical", () => {
+    const first = planManagedCodexHooksMerge("{}", "/repo", "/hooks.json");
+    assert.equal(first.ok, true);
+    if (!first.ok) return;
+    assert.deepEqual(first.diagnostics, []);
+    const second = planManagedCodexHooksMerge(first.finalContent, "/repo", "/hooks.json");
+    assert.equal(second.ok, true);
+    if (!second.ok) return;
+    assert.equal(second.changed, false);
+    const finalContent = second.finalContent;
+    assert.ok(finalContent);
+    const merged = JSON.parse(finalContent) as { hooks?: Record<string, unknown[]> };
+    assert.deepEqual(Object.keys(merged.hooks ?? {}).sort(), [
+      "PostCompact",
+      "PostToolUse",
+      "PreCompact",
+      "PreToolUse",
+      "SessionStart",
+      "Stop",
+      "UserPromptSubmit",
+    ]);
+  });
+
+  it("replaces a compatible managed handler in place and scans trust from its actual coordinate", () => {
+    const existing = String.raw`{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"echo before"}]},{"opaque":{"keep":[1,2]},"hooks":[{"type":"command","command":"node \"/old/dist/scripts/codex-native-hook.js\"","unknown":{"keep":true}}]},{"hooks":[{"type":"command","command":"echo after"}]}]}}`;
+    const plan = planManagedCodexHooksMerge(existing, "/repo", "/hooks.json");
+
+    assert.equal(plan.ok, true);
+    if (!plan.ok) return;
+    assert.ok(plan.finalContent?.includes(`"opaque":{"keep":[1,2]}`));
+    assert.ok(plan.finalContent?.includes(`"unknown":{"keep":true}`));
+    assert.ok(plan.finalTrustState["/hooks.json:pre_tool_use:1:0"]);
+    const finalContent = plan.finalContent;
+    assert.ok(finalContent);
+    const scan = scanManagedCodexHookTrustStateFromContent(finalContent, "/hooks.json");
+    assert.equal(scan.ok, true);
+    if (scan.ok) assert.deepEqual(scan.trustState, plan.finalTrustState);
+  });
+
+  it("fails closed instead of leaving an opaque managed-only group tombstone during removal", () => {
+    const command = buildManagedCodexHooksConfig("/repo").hooks.PreToolUse[0]!.hooks[0]!.command;
+    const source = JSON.stringify({
+      hooks: {
+        PreToolUse: [{
+          opaque: { preserve: "exactly" },
+          hooks: [{ type: "command", command }],
+        }],
+      },
+    });
+    const original = source;
+    const plan = planManagedCodexHooksRemoval(source, "/hooks.json");
+
+    assert.equal(plan.ok, false);
+    if (plan.ok) return;
+    assert.equal(plan.error.code, "unsafe_managed_removal");
+    assert.deepEqual(plan.error.details, {
+      shifted: {
+        kind: "group",
+        eventName: "PreToolUse",
+        oldCoordinate: [0],
+      },
+    });
+    assert.equal("finalContent" in plan, false);
+    assert.equal(source, original);
+  });
+
+  it("fails closed instead of leaving an opaque duplicate group tombstone during cleanup", () => {
+    const command = buildManagedCodexHooksConfig("/repo").hooks.PreToolUse[0]!.hooks[0]!.command;
+    const source = JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          { hooks: [{ type: "command", command }] },
+          {
+            opaque: { preserve: "exactly" },
+            hooks: [{ type: "command", command }],
+          },
+        ],
+      },
+    });
+    const original = source;
+    const plan = planManagedCodexHooksMerge(source, "/repo", "/hooks.json");
+
+    assert.equal(plan.ok, false);
+    if (plan.ok) return;
+    assert.equal(plan.error.code, "unsafe_managed_removal");
+    assert.deepEqual(plan.error.details, {
+      shifted: {
+        kind: "group",
+        eventName: "PreToolUse",
+        oldCoordinate: [1],
+      },
+    });
+    assert.equal("finalContent" in plan, false);
+    assert.equal(source, original);
+  });
+
+  it("removes a suffix duplicate only when all surviving foreign coordinates stay fixed", () => {
+    const command = buildManagedCodexHooksConfig("/repo").hooks.SessionStart[0]?.hooks[0]?.command;
+    const safe = JSON.stringify({
+      hooks: {
+        SessionStart: [
+          { hooks: [{ type: "command", command: "echo foreign" }] },
+          { matcher: "startup|resume|clear", hooks: [{ type: "command", command }] },
+          { matcher: "startup|resume|clear", hooks: [{ type: "command", command }] },
+        ],
+      },
+    });
+    const plan = planManagedCodexHooksMerge(safe, "/repo", "/hooks.json");
+    assert.equal(plan.ok, true);
+    if (!plan.ok) return;
+    const finalContent = plan.finalContent;
+    assert.ok(finalContent);
+    const merged = JSON.parse(finalContent) as { hooks: { SessionStart: unknown[] } };
+    assert.equal(merged.hooks.SessionStart.length, 2);
+    assert.ok(plan.finalTrustState["/hooks.json:session_start:1:0"]);
+
+    const unsafe = JSON.stringify({
+      hooks: {
+        SessionStart: [
+          { matcher: "startup|resume|clear", hooks: [{ type: "command", command }] },
+          { matcher: "startup|resume|clear", hooks: [{ type: "command", command }] },
+          { hooks: [{ type: "command", command: "echo shifted" }] },
+        ],
+      },
+    });
+    const unsafePlan = planManagedCodexHooksMerge(unsafe, "/repo", "/hooks.json");
+    assert.equal(unsafePlan.ok, false);
+    if (!unsafePlan.ok) assert.equal(unsafePlan.error.code, "unsafe_managed_removal");
+  });
+
+  it("fails closed for unsafe mixed removal and partial-corrupt OMX commands", () => {
+    const command = buildManagedCodexHooksConfig("/repo").hooks.SessionStart[0]?.hooks[0]?.command;
+    const unsafeMixed = planManagedCodexHooksRemoval(JSON.stringify({
+      hooks: {
+        SessionStart: [{
+          matcher: "startup|resume|clear",
+          hooks: [
+            { type: "command", command },
+            { type: "command", command: "echo moved" },
+          ],
+        }],
+      },
+    }), "/hooks.json");
+    assert.equal(unsafeMixed.ok, false);
+    if (!unsafeMixed.ok) assert.equal(unsafeMixed.error.code, "unsafe_managed_removal");
+
+    const partial = planManagedCodexHooksMerge(JSON.stringify({
+      hooks: {
+        PreToolUse: [{
+          hooks: [{ type: "command", command: 'node "/repo/dist/scripts/codex-native-hook.js" --extra' }],
+        }],
+      },
+    }), "/repo", "/hooks.json");
+    assert.equal(partial.ok, false);
+    if (!partial.ok) {
+      assert.ok(partial.error instanceof ManagedCodexHooksPlanError);
+      assert.equal(partial.error.code, "ambiguous_managed_handler");
+      assert.ok(Array.isArray(partial.diagnostics));
+    }
+
+    const sharedSkipped = planManagedCodexHooksMerge(JSON.stringify({
+      hooks: {
+        PreToolUse: [{
+          hooks: [
+            { type: "command", command: buildManagedCodexHooksConfig("/repo").hooks.PreToolUse[0]?.hooks[0]?.command },
+            { type: "command", command: "echo skipped", async: true },
+          ],
+        }],
+      },
+    }), "/repo", "/hooks.json");
+    assert.equal(sharedSkipped.ok, false);
+    if (!sharedSkipped.ok) assert.equal(sharedSkipped.error.code, "ambiguous_managed_handler");
   });
 });

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -15,6 +15,7 @@ import {
   hasExactOmxSeededBehavioralDefaultsPair,
   mergeConfig,
   repairConfigIfNeeded,
+  stripExistingOmxBlocks,
   stripManagedCodexHookTrustState,
   stripOmxFeatureFlags,
   upsertManagedCodexHookTrustState,
@@ -1097,6 +1098,57 @@ describe("config generator idempotency (#384)", () => {
     }
   });
 
+  it("strips only complete exact OMX marker blocks outside TOML values", () => {
+    const start = "# oh-my-codex (OMX) Configuration";
+    const end = "# End oh-my-codex";
+    const decoys = [
+      `basic = "${start}"`,
+      `literal = '${end}'`,
+      'multiline_basic = """',
+      start,
+      end,
+      '"""',
+      "multiline_literal = '''",
+      start,
+      end,
+      "'''",
+      `# Marker-shaped text: ${start}`,
+      `# Marker-shaped text: ${end}`,
+    ];
+    const decoyOnly = [...decoys, ""].join("\n");
+    assert.deepEqual(stripExistingOmxBlocks(decoyOnly), {
+      cleaned: decoyOnly,
+      removed: 0,
+    });
+
+    const incomplete = [...decoys, "", start, "[user.incomplete]", "enabled = true", ""].join("\n");
+    assert.deepEqual(stripExistingOmxBlocks(incomplete), {
+      cleaned: incomplete,
+      removed: 0,
+    });
+
+    const managed = [
+      ...decoys,
+      "",
+      "# ============================================================",
+      start,
+      "[mcp_servers.omx_state]",
+      'command = "node"',
+      end,
+      "",
+      "[user.after]",
+      'name = "kept"',
+      "",
+    ].join("\n");
+    const expected = [...decoys, "", "[user.after]", 'name = "kept"', ""].join("\n");
+
+    assert.deepEqual(stripExistingOmxBlocks(managed), {
+      cleaned: expected,
+      removed: 1,
+    });
+    assert.doesNotThrow(() => TOML.parse(expected));
+  });
+
   it("mergeConfig removes legacy omx_team_run tables during setup upgrade", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
     try {
@@ -1535,6 +1587,423 @@ describe("config generator idempotency (#384)", () => {
         `${name} refresh must preserve the original bytes`,
       );
     }
+  });
+
+  it("fails closed for commented trust assignments inside a managed config marker", () => {
+    const fixture = [
+      "# oh-my-codex (OMX) Configuration",
+      'hooks.state."foreign-key".trusted_hash = "sha256:foreign" # preserve me',
+      "# End oh-my-codex",
+      "",
+    ].join("\n");
+
+    assert.throws(
+      () => stripManagedCodexHookTrustState(fixture, { managedTrustState: {} }),
+      (error: unknown) =>
+        error instanceof ManagedCodexHooksPlanError &&
+        error.code === "managed_trust_key_conflict",
+    );
+  });
+
+  it("fails closed on every non-record hooks.state form inside managed markers", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
+    const fixtures = [
+      ["scalar", 'hooks.state = "foreign"'],
+      ["array", "hooks.state = []"],
+      ["quoted state key", 'hooks."state" = "foreign"'],
+      ["inline non-record", 'hooks = { state = "foreign" }'],
+      [
+        "array of tables",
+        ["[[hooks.state]]", 'trusted_hash = "sha256:foreign"'].join("\n"),
+      ],
+    ] as const;
+
+    for (const [name, value] of fixtures) {
+      const fixture = [
+        "# oh-my-codex (OMX) Configuration",
+        value,
+        "# End oh-my-codex",
+        "",
+      ].join("\n");
+      assert.doesNotThrow(() => TOML.parse(fixture), `${name} fixture must be valid TOML`);
+      assert.throws(
+        () => stripManagedCodexHookTrustState(fixture, { managedTrustState }),
+        (error: unknown) =>
+          error instanceof ManagedCodexHooksPlanError &&
+          error.code === "managed_trust_key_conflict",
+        name,
+      );
+    }
+  });
+
+  it("fails closed before stripping malformed hooks.state spellings", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
+    const key = `${hooksPath}:post_compact:0:0`;
+    const hash = managedTrustState[key]?.trusted_hash;
+    assert.ok(hash);
+    const spellings = [
+      ["quoted state key", 'hooks."state" ='],
+      ["quoted hooks key", '"hooks".state ='],
+      ["fully quoted dotted key", '"hooks"."state" ='],
+      ["whitespace-delimited malformed array", 'hooks \t. "state" \t= ['],
+      ["malformed inline table", 'hooks = { "state" = {'],
+      ["incomplete table header", '[ "hooks" . "state"'],
+      ["incomplete array table header", '[[ "hooks" . "state" ]'],
+      ["incomplete hooks table header prefix", "[hooks"],
+      ["incomplete hooks array table header prefix", "[[hooks"],
+      ["partial hooks array-table closer", "[[hooks] # continuation"],
+      ["whitespace-split hooks array-table closer", "[[hooks] ]"],
+      [
+        "split hooks array-table closer",
+        ["[[hooks]", "]"].join("\n"),
+      ],
+      [
+        "comment-separated hooks assignment continuation",
+        [
+          "hooks # continuation",
+          '= { "state" = { trusted_hash = "sha256:foreign" } }',
+        ].join("\n"),
+      ],
+      [
+        "bare hooks assignment continuation",
+        [
+          "hooks",
+          '= { "state" = { trusted_hash = "sha256:foreign" } }',
+        ].join("\n"),
+      ],
+      [
+        "comment-separated hooks dotted-key continuation",
+        [
+          "hooks # continuation",
+          '. "state" = { trusted_hash = "sha256:foreign" }',
+        ].join("\n"),
+      ],
+      [
+        "comment-separated hooks table-header continuation",
+        ["hooks # continuation", '[ "state" ]'].join("\n"),
+      ],
+      [
+        "comment-separated hooks array-table-header continuation",
+        ["hooks # continuation", '[[ "state" ]]'].join("\n"),
+      ],
+      [
+        "split dotted key",
+        ["hooks .", '"state" = { trusted_hash = "sha256:foreign" }'].join("\n"),
+      ],
+      [
+        "unclosed multiline inline table",
+        ["hooks = {", '"state" = { trusted_hash = "sha256:foreign" }'].join("\n"),
+      ],
+      [
+        "comment-ended inline table continuation",
+        [
+          "hooks = { # continuation",
+          '"state" = { trusted_hash = "sha256:foreign" }',
+        ].join("\n"),
+      ],
+      [
+        "bare hooks assignment with inline-table continuation",
+        [
+          "hooks =",
+          '{ "state" = { trusted_hash = "sha256:foreign" } }',
+        ].join("\n"),
+      ],
+    ] as const;
+
+    for (const [name, spelling] of spellings) {
+      const fixture = [
+        "# oh-my-codex (OMX) Configuration",
+        spelling,
+        "# End oh-my-codex",
+        "",
+        "[user.after]",
+        'value = "preserved"',
+        "",
+      ].join("\n");
+      const original = fixture;
+      const isManagedTrustConflict = (error: unknown): boolean =>
+        error instanceof ManagedCodexHooksPlanError &&
+        error.code === "managed_trust_key_conflict";
+
+      assert.throws(
+        () => buildMergedConfig(fixture, "/tmp/omx", { managedHookTrustState: managedTrustState }),
+        isManagedTrustConflict,
+        `${name} must fail before OMX block stripping`,
+      );
+      assert.equal(fixture, original, `${name} planning must not mutate input`);
+      assert.throws(
+        () => stripExistingOmxBlocks(fixture),
+        isManagedTrustConflict,
+        `${name} must not be erased by direct OMX block stripping`,
+      );
+      assert.equal(fixture, original, `${name} stripping must not mutate input`);
+    }
+
+    const exactQuoted = [
+      "# oh-my-codex (OMX) Configuration",
+      `["hooks"."state"."${key}"]`,
+      `trusted_hash = "${hash}"`,
+      "# End oh-my-codex",
+      "",
+    ].join("\n");
+    assert.doesNotThrow(() =>
+      buildMergedConfig(exactQuoted, "/tmp/omx", { managedHookTrustState: managedTrustState }),
+    );
+  });
+
+  it("fails closed when hooks scope crosses parsed assignments or malformed headers", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
+    const validNestedArrayAssignment = [
+      "values = [",
+      '  ["unrelated"]',
+      "]",
+    ];
+    assert.doesNotThrow(() =>
+      TOML.parse(["[hooks]", ...validNestedArrayAssignment].join("\n")),
+    );
+    const fixtures = [
+      [
+        "parsed nested assignment",
+        ["[hooks]", ...validNestedArrayAssignment, "state ="].join("\n"),
+      ],
+      [
+        "malformed bracket-prefixed line",
+        ["[hooks]", "[broken", "state ="].join("\n"),
+      ],
+    ] as const;
+    const isManagedTrustConflict = (error: unknown): boolean =>
+      error instanceof ManagedCodexHooksPlanError &&
+      error.code === "managed_trust_key_conflict";
+
+    for (const [name, content] of fixtures) {
+      const fixture = [
+        "# oh-my-codex (OMX) Configuration",
+        content,
+        "# End oh-my-codex",
+        "",
+        "[user.after]",
+        'value = "preserved"',
+        "",
+      ].join("\n");
+      const original = fixture;
+
+      assert.throws(
+        () => stripExistingOmxBlocks(fixture),
+        isManagedTrustConflict,
+        `${name} must not be erased by direct OMX block stripping`,
+      );
+      assert.equal(fixture, original, `${name} stripping must not mutate input`);
+      assert.throws(
+        () => buildMergedConfig(fixture, "/tmp/omx", { managedHookTrustState: managedTrustState }),
+        isManagedTrustConflict,
+        `${name} must fail before OMX block stripping`,
+      );
+      assert.equal(fixture, original, `${name} planning must not mutate input`);
+    }
+
+    const validNonHooksHeaderExit = [
+      "# oh-my-codex (OMX) Configuration",
+      "[hooks]",
+      "[unrelated]",
+      "state =",
+      "# End oh-my-codex",
+      "",
+      "[user.after]",
+      'value = "preserved"',
+      "",
+    ].join("\n");
+    const expectedExit = ["[user.after]", 'value = "preserved"', ""].join("\n");
+    assert.deepEqual(stripExistingOmxBlocks(validNonHooksHeaderExit), {
+      cleaned: expectedExit,
+      removed: 1,
+    });
+    assert.doesNotThrow(() =>
+      buildMergedConfig(validNonHooksHeaderExit, "/tmp/omx", {
+        managedHookTrustState: managedTrustState,
+      }),
+    );
+  });
+
+  it("fails closed for hooks array-table openers and preserves unrelated arrays", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
+    const arrayTableOpeners = [
+      ["adjacent", "[[hooks]]"],
+      ["space-split", "[ [hooks]]"],
+      ["tab-split", "[\t[hooks]]"],
+      ["newline-split", ["[[", "hooks]]"].join("\n")],
+      [
+        "two standalone opening brackets followed by independently parsed state",
+        [
+          "[",
+          "[",
+          "hooks]]",
+          'state = { trusted_hash = "sha256:foreign" }',
+        ].join("\n"),
+      ],
+      [
+        "three standalone opening brackets followed by independently parsed state",
+        [
+          "[",
+          "[",
+          "[",
+          "hooks]]]",
+          'state = { trusted_hash = "sha256:foreign" }',
+        ].join("\n"),
+      ],
+      [
+        "comment- and blank-separated standalone opening brackets",
+        [
+          "[",
+          "# opening bracket continuation",
+          "",
+          "[",
+          "",
+          "# another opening bracket continuation",
+          "[",
+          "hooks]]]",
+          'state = { trusted_hash = "sha256:foreign" }',
+        ].join("\n"),
+      ],
+      ["triple", "[[[hooks]]]"],
+      ["extra", "[[[[hooks]]]]"],
+      ["space-newline-split", ["[ [", "hooks]]"].join("\n")],
+      ["tab-newline-split", ["[\t[", "hooks]]"].join("\n")],
+      ["triple-newline-split", ["[[[", "hooks]]]"].join("\n")],
+      ["comment-ended", ["[[ # continuation", "hooks]]"].join("\n")],
+    ] as const;
+    const isManagedTrustConflict = (error: unknown): boolean =>
+      error instanceof ManagedCodexHooksPlanError &&
+      error.code === "managed_trust_key_conflict";
+
+    for (const [name, opener] of arrayTableOpeners) {
+      const fixture = [
+        "# oh-my-codex (OMX) Configuration",
+        opener,
+        "# End oh-my-codex",
+        "",
+        "[user.after]",
+        'value = "preserved"',
+        "",
+      ].join("\n");
+      const original = fixture;
+
+      assert.throws(
+        () =>
+          buildMergedConfig(fixture, "/tmp/omx", {
+            managedHookTrustState: managedTrustState,
+          }),
+        isManagedTrustConflict,
+        `${name} opener must fail before OMX block stripping`,
+      );
+      assert.equal(fixture, original, `${name} planning must not mutate input`);
+      assert.throws(
+        () => stripExistingOmxBlocks(fixture),
+        isManagedTrustConflict,
+        `${name} opener must not be erased by direct OMX block stripping`,
+      );
+      assert.equal(fixture, original, `${name} stripping must not mutate input`);
+    }
+
+    const unrelatedArrays = [
+      "[[user.before]]",
+      'name = "before"',
+      "",
+      "# oh-my-codex (OMX) Configuration",
+      "[[unrelated]]",
+      'name = "inside managed marker"',
+      "# End oh-my-codex",
+      "",
+      "[[user.after]]",
+      'name = "after"',
+      "",
+    ].join("\n");
+    const preservedArrays = [
+      "[[user.before]]",
+      'name = "before"',
+      "",
+      "[[user.after]]",
+      'name = "after"',
+      "",
+    ].join("\n");
+
+    assert.deepEqual(stripExistingOmxBlocks(unrelatedArrays), {
+      cleaned: preservedArrays,
+      removed: 1,
+    });
+    const merged = buildMergedConfig(unrelatedArrays, "/tmp/omx");
+    assert.match(merged, /^\[\[user\.before\]\]$/m);
+    assert.match(merged, /^\[\[user\.after\]\]$/m);
+    assert.doesNotMatch(merged, /^\[\[unrelated\]\]$/m);
+    assert.doesNotThrow(() => TOML.parse(merged));
+  });
+
+  it("removes valid nested hooks arrays inside exact managed marker ranges", () => {
+    const fixture = [
+      "# oh-my-codex (OMX) Configuration",
+      "values = [",
+      "  [",
+      "",
+      "    # a value named hooks is not a table prefix",
+      '    "hooks",',
+      "  ],",
+      "  # nor is this independently nested array",
+      "  [",
+      '    "unrelated",',
+      "  ],",
+      "  [",
+      '    [["hooks"]]',
+      "  ],",
+      "  [",
+      '    [ [ "hooks" ] ]',
+      "  ],",
+      "]",
+      "outer.values = [",
+      '  [["hooks"]]',
+      "]",
+      '"" = [',
+      '  [ [ "hooks" ] ]',
+      "]",
+      "# End oh-my-codex",
+      "",
+      "[user.after]",
+      'value = "preserved"',
+      "",
+    ].join("\n");
+    const expected = ["[user.after]", 'value = "preserved"', ""].join("\n");
+
+    assert.doesNotThrow(() => TOML.parse(fixture));
+    assert.deepEqual(stripExistingOmxBlocks(fixture), { cleaned: expected, removed: 1 });
+
+    const merged = buildMergedConfig(fixture, "/tmp/omx");
+    assert.doesNotMatch(merged, /^values = \[/m);
+    assert.match(merged, /^\[user\.after\]$/m);
+    assert.doesNotThrow(() => TOML.parse(merged));
+  });
+
+  it("ignores inert hooks.state text inside exact managed marker ranges", () => {
+    const fixture = [
+      "# oh-my-codex (OMX) Configuration",
+      '# hooks."state" =',
+      'basic = "hooks.\'state\' ="',
+      "literal = 'hooks = { state = {'",
+      'multiline = """',
+      '[[ "hooks" . "state" ]',
+      'hooks = { "state" = {',
+      '"""',
+      "# End oh-my-codex",
+      "",
+      "[user.after]",
+      'value = "preserved"',
+      "",
+    ].join("\n");
+    const expected = ["[user.after]", 'value = "preserved"', ""].join("\n");
+
+    assert.deepEqual(stripExistingOmxBlocks(fixture), { cleaned: expected, removed: 1 });
+    assert.doesNotThrow(() => buildMergedConfig(fixture, "/tmp/omx"));
   });
 
   it("removes an exact inline state entry within a hooks.state table", () => {

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -34,6 +34,35 @@ function count(text: string, pattern: RegExp): number {
   return (text.match(pattern) ?? []).length;
 }
 
+async function writeSetupGeneratedHookTrustFixture(wd: string): Promise<{
+  configPath: string;
+  hooksPath: string;
+  config: string;
+  trustState: Record<string, { trusted_hash: string }>;
+}> {
+  const configPath = join(wd, "config.toml");
+  const hooksPath = join(wd, "hooks.json");
+  const hooksPlan = planManagedCodexHooksMerge(null, wd, hooksPath);
+  if (!hooksPlan.ok || hooksPlan.finalContent === null) {
+    throw new Error("Expected setup hook plan to produce a hooks artifact.");
+  }
+
+  await writeFile(hooksPath, hooksPlan.finalContent);
+  const config = buildMergedConfig("", wd, {
+    codexHooksFile: hooksPath,
+    codexHooksContent: hooksPlan.finalContent,
+    managedHookTrustState: hooksPlan.finalTrustState,
+    priorManagedHookTrustState: hooksPlan.priorTrustState,
+  });
+  await writeFile(configPath, config);
+  return {
+    configPath,
+    hooksPath,
+    config,
+    trustState: hooksPlan.finalTrustState,
+  };
+}
+
 /** Assert the current OMX block appears exactly once */
 function assertSingleOmxBlock(
   toml: string,
@@ -1149,6 +1178,71 @@ describe("config generator idempotency (#384)", () => {
     assert.doesNotThrow(() => TOML.parse(expected));
   });
 
+  it("keeps OMX delimiter comments inert inside complete TOML assignments", () => {
+    const start = "# oh-my-codex (OMX) Configuration";
+    const end = "# End oh-my-codex";
+    const fixtures = [
+      ["root multiline array", ["root = [", start, end, "]"].join("\n")],
+      ["dotted multiline array", ["outer.value = [", start, end, "]"].join("\n")],
+      ["quoted multiline array", ['"quoted" = [', start, end, "]"].join("\n")],
+      ["empty-quoted multiline array", ['"" = [', start, end, "]"].join("\n")],
+      ["root multiline basic value", ['root_value = """', start, end, '"""'].join("\n")],
+      ["dotted multiline literal value", ["outer.literal = '''", start, end, "'''"].join("\n")],
+    ] as const;
+
+    for (const [name, assignment] of fixtures) {
+      const config = `${assignment}\n`;
+      assert.doesNotThrow(() => TOML.parse(config), `${name} fixture must be valid TOML`);
+      assert.deepEqual(stripExistingOmxBlocks(config), { cleaned: config, removed: 0 }, name);
+
+      const merged = buildMergedConfig(config, "/tmp/omx");
+      assert.ok(merged.includes(assignment), `${name} bytes must survive merging`);
+      assert.doesNotThrow(() => TOML.parse(merged), `${name} merged config must be valid TOML`);
+    }
+  });
+
+  it("rejects marker-contained hook trust state without ownership proof", () => {
+    const start = "# oh-my-codex (OMX) Configuration";
+    const end = "# End oh-my-codex";
+    const fixtures = [
+      ["table", ['[hooks.state."foreign"]', 'trusted_hash = "sha256:foreign"'].join("\n")],
+      ["dotted", 'hooks.state."foreign" = { trusted_hash = "sha256:foreign" }'],
+      ["inline", 'hooks = { state = { foreign = { trusted_hash = "sha256:foreign" } } }'],
+      ["scalar", 'hooks.state = "foreign"'],
+    ] as const;
+    const isManagedTrustConflict = (error: unknown): boolean =>
+      error instanceof ManagedCodexHooksPlanError &&
+      error.code === "managed_trust_key_conflict";
+
+    for (const [name, content] of fixtures) {
+      const config = [start, content, end, ""].join("\n");
+      assert.doesNotThrow(() => TOML.parse(config), `${name} fixture must be valid TOML`);
+      assert.throws(() => stripExistingOmxBlocks(config), isManagedTrustConflict, name);
+      assert.throws(() => buildMergedConfig(config, "/tmp/omx"), isManagedTrustConflict, name);
+    }
+  });
+
+  it("matches managed hooks.state keys case-sensitively", () => {
+    const start = "# oh-my-codex (OMX) Configuration";
+    const end = "# End oh-my-codex";
+    const variants = [
+      'Hooks.state = { foreign = { trusted_hash = "sha256:foreign" } }',
+      'hooks.State = { foreign = { trusted_hash = "sha256:foreign" } }',
+      '"Hooks"."State" = { foreign = { trusted_hash = "sha256:foreign" } }',
+    ];
+
+    for (const variant of variants) {
+      const config = [start, variant, end, ""].join("\n");
+      assert.doesNotThrow(() => TOML.parse(config));
+      assert.equal(
+        stripManagedCodexHookTrustState(config, { managedTrustState: {} }),
+        config,
+        `${variant} must remain foreign`,
+      );
+      assert.doesNotThrow(() => buildMergedConfig(config, "/tmp/omx"));
+    }
+  });
+
   it("mergeConfig removes legacy omx_team_run tables during setup upgrade", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
     try {
@@ -1252,6 +1346,100 @@ describe("config generator idempotency (#384)", () => {
       const repaired = await readFile(configPath, "utf-8");
       assert.equal(count(repaired, /^\[tui\]$/gm), 1, "[tui] should appear once after repair");
       assertSingleOmxBlock(repaired);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("repairs duplicate TUI config with setup-generated hook trust from the current hooks artifact", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const { configPath, config: setupConfig } = await writeSetupGeneratedHookTrustFixture(wd);
+      const trustBlock = setupConfig.match(
+        /# OMX-owned Codex hook trust state\n[\s\S]*?# End OMX-owned Codex hook trust state/,
+      )?.[0];
+      assert.ok(trustBlock, "setup fixture must contain fenced managed hook trust");
+      const setupTrustState = (TOML.parse(setupConfig) as {
+        hooks?: { state?: Record<string, unknown> };
+      }).hooks?.state;
+
+      await writeFile(
+        configPath,
+        `${setupConfig}\n[tui]\nstatus_line = ["git-branch"]\n`,
+      );
+
+      assert.equal(await repairConfigIfNeeded(configPath, wd), true);
+      const repaired = await readFile(configPath, "utf-8");
+      const repairedTrustState = (TOML.parse(repaired) as {
+        hooks?: { state?: Record<string, unknown> };
+      }).hooks?.state;
+
+      assert.equal(count(repaired, /^\[tui\]$/gm), 1);
+      assert.ok(repaired.includes(trustBlock), "repair must preserve setup-generated trust bytes");
+      assert.deepEqual(repairedTrustState, setupTrustState);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed without rewriting managed hook trust when launch repair cannot prove it", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const { configPath, hooksPath, config: setupConfig, trustState } =
+        await writeSetupGeneratedHookTrustFixture(wd);
+      const [firstTrustState] = Object.values(trustState);
+      assert.ok(firstTrustState);
+      const repairTarget = `${setupConfig}\n[tui]\nstatus_line = ["git-branch"]\n`;
+      const conflicting = repairTarget.replace(
+        firstTrustState.trusted_hash,
+        "sha256:conflicting-user-trust",
+      );
+      await writeFile(configPath, conflicting);
+
+      await assert.rejects(
+        repairConfigIfNeeded(configPath, wd),
+        (error: unknown) =>
+          error instanceof ManagedCodexHooksPlanError &&
+          error.code === "managed_trust_key_conflict",
+      );
+      assert.equal(await readFile(configPath, "utf-8"), conflicting);
+
+      const unprovenHooks = [
+        ["invalid", "{ not valid JSON"],
+        [
+          "ambiguous",
+          JSON.stringify({
+            hooks: {
+              SessionStart: [
+                {
+                  hooks: [
+                    {
+                      type: "command",
+                      command: `NODE ${join(wd, "dist", "scripts", "codex-native-hook.js")}`,
+                    },
+                  ],
+                },
+              ],
+            },
+          }),
+        ],
+        ["missing", null],
+      ] as const;
+      for (const [name, hooksContent] of unprovenHooks) {
+        await writeFile(configPath, repairTarget);
+        if (hooksContent === null) {
+          await rm(hooksPath);
+        } else {
+          await writeFile(hooksPath, hooksContent);
+        }
+
+        await assert.rejects(
+          repairConfigIfNeeded(configPath, wd),
+          (error: unknown) => error instanceof ManagedCodexHooksPlanError,
+          name,
+        );
+        assert.equal(await readFile(configPath, "utf-8"), repairTarget, name);
+      }
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -1712,6 +1900,10 @@ describe("config generator idempotency (#384)", () => {
       ],
     ] as const;
 
+    const isManagedTrustConflict = (error: unknown): boolean =>
+      error instanceof ManagedCodexHooksPlanError &&
+      error.code === "managed_trust_key_conflict";
+
     for (const [name, spelling] of spellings) {
       const fixture = [
         "# oh-my-codex (OMX) Configuration",
@@ -1723,9 +1915,6 @@ describe("config generator idempotency (#384)", () => {
         "",
       ].join("\n");
       const original = fixture;
-      const isManagedTrustConflict = (error: unknown): boolean =>
-        error instanceof ManagedCodexHooksPlanError &&
-        error.code === "managed_trust_key_conflict";
 
       assert.throws(
         () => buildMergedConfig(fixture, "/tmp/omx", { managedHookTrustState: managedTrustState }),
@@ -1748,6 +1937,15 @@ describe("config generator idempotency (#384)", () => {
       "# End oh-my-codex",
       "",
     ].join("\n");
+    assert.throws(
+      () => stripExistingOmxBlocks(exactQuoted),
+      isManagedTrustConflict,
+      "direct stripping must not infer ownership without trust expectations",
+    );
+    assert.deepEqual(stripExistingOmxBlocks(exactQuoted, { managedTrustState }), {
+      cleaned: "",
+      removed: 1,
+    });
     assert.doesNotThrow(() =>
       buildMergedConfig(exactQuoted, "/tmp/omx", { managedHookTrustState: managedTrustState }),
     );

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -20,7 +20,12 @@ import {
   upsertManagedCodexHookTrustState,
   stripOmxSeededBehavioralDefaults,
 } from "../generator.js";
-import { buildManagedCodexHookTrustState } from "../codex-hooks.js";
+import {
+  MANAGED_HOOK_EVENTS,
+  ManagedCodexHooksPlanError,
+  buildManagedCodexHookTrustState,
+  planManagedCodexHooksMerge,
+} from "../codex-hooks.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../omx-first-party-mcp.js";
 
 /** Count occurrences of a pattern in text */
@@ -1272,7 +1277,7 @@ describe("config generator idempotency (#384)", () => {
     assert.doesNotThrow(() => TOML.parse(stripped));
   });
 
-  it("preserves same-key user hook trust state and suppresses generated duplicates", () => {
+  it("fails closed on conflicting same-key hook trust state", () => {
     const hooksPath = "/tmp/codex/hooks.json";
     const config = [
       'model = "gpt-5.6-sol"',
@@ -1283,26 +1288,15 @@ describe("config generator idempotency (#384)", () => {
       "",
     ].join("\n");
 
-    const refreshed = upsertManagedCodexHookTrustState(
-      config,
-      "/tmp/omx",
-      hooksPath,
+    assert.throws(
+      () => upsertManagedCodexHookTrustState(config, "/tmp/omx", hooksPath),
+      (error: unknown) =>
+        error instanceof ManagedCodexHooksPlanError &&
+        error.code === "managed_trust_key_conflict",
     );
-
-    assert.match(refreshed, /^trusted_hash = "sha256:user"$/m);
-    assert.match(refreshed, /^enabled = false$/m);
-    assert.equal(
-      count(
-        refreshed,
-        /^\[hooks\.state\."\/tmp\/codex\/hooks\.json:post_compact:0:0"\]$/gm,
-      ),
-      1,
-      "preserved same-key user trust state must not be duplicated",
-    );
-    assert.doesNotThrow(() => TOML.parse(refreshed));
   });
 
-  it("preserves unproven same-key hook trust-state tables", () => {
+  it("fails closed on unproven same-key hook trust-state tables", () => {
     const hooksPath = "/tmp/codex/hooks.json";
     const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
     const fixtures = [
@@ -1353,13 +1347,253 @@ describe("config generator idempotency (#384)", () => {
     ] as const;
 
     for (const [name, table] of fixtures) {
-      const stripped = stripManagedCodexHookTrustState(table.join("\n"), {
-        managedTrustState,
-      });
-      assert.match(
-        stripped,
-        /^\[hooks\.state\."\/tmp\/codex\/hooks\.json:post_compact:0:0"\]/m,
-        `${name} should be preserved`,
+      assert.throws(
+        () =>
+          stripManagedCodexHookTrustState(table.join("\n"), {
+            managedTrustState,
+          }),
+        (error: unknown) =>
+          error instanceof ManagedCodexHooksPlanError &&
+          error.code === "managed_trust_key_conflict",
+        name,
+      );
+    }
+  });
+
+  it("handles semantically equivalent TOML trust-key variants before writing a replacement", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
+    const key = `${hooksPath}:post_compact:0:0`;
+    const hash = managedTrustState[key]?.trusted_hash;
+    assert.ok(hash);
+    const matchingHeaders = [
+      `[hooks.state.'${key}']`,
+      `[hooks.state."${key.replace(/\//g, "\\u002f")}"]`,
+    ];
+
+    for (const header of matchingHeaders) {
+      const matching = [header, `trusted_hash = "${hash}"`, ""].join("\n");
+      const refreshed = upsertManagedCodexHookTrustState(
+        matching,
+        "/tmp/omx",
+        hooksPath,
+        { managedTrustState },
+      );
+      assert.equal(count(refreshed, /^\[hooks\.state\./gm), Object.keys(managedTrustState).length);
+      assert.equal(
+        (TOML.parse(refreshed) as { hooks?: { state?: Record<string, unknown> } })
+          .hooks?.state?.[key] !== undefined,
+        true,
+      );
+    }
+
+    const conflicting = [
+      matchingHeaders[0],
+      'trusted_hash = "sha256:foreign"',
+      "",
+    ].join("\n");
+    assert.throws(
+      () => upsertManagedCodexHookTrustState(conflicting, "/tmp/omx", hooksPath, { managedTrustState }),
+      (error: unknown) =>
+        error instanceof ManagedCodexHooksPlanError &&
+        error.code === "managed_trust_key_conflict",
+    );
+  });
+
+  it("removes only a single exact proven managed dotted hook trust assignment", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
+    const key = `${hooksPath}:post_compact:0:0`;
+    const hash = managedTrustState[key]?.trusted_hash;
+    assert.ok(hash);
+    const exactAssignments = [
+      `hooks.state."${key}".trusted_hash = "${hash}"`,
+      `hooks . state . '${key}' . trusted_hash = "${hash}"`,
+    ];
+    for (const exact of exactAssignments) {
+      assert.equal(
+        stripManagedCodexHookTrustState(exact, { managedTrustState }),
+        "",
+      );
+    }
+    const exact = exactAssignments[1]!;
+    const refreshed = upsertManagedCodexHookTrustState(
+      exact,
+      "/tmp/omx",
+      hooksPath,
+      { managedTrustState },
+    );
+    assert.doesNotMatch(refreshed, /^hooks\s*\.\s*state\s*\./m);
+    assert.equal(count(refreshed, /^\[hooks\.state\./gm), Object.keys(managedTrustState).length);
+  });
+
+  it("fails closed for conflicting, commented, or multi-field managed dotted hook trust assignments", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
+    const key = `${hooksPath}:post_compact:0:0`;
+    const hash = managedTrustState[key]?.trusted_hash;
+    assert.ok(hash);
+    const assignment = `hooks.state.'${key}'.trusted_hash = "${hash}"`;
+    const fixtures = [
+      assignment.replace(hash!, "sha256:foreign"),
+      `${assignment}\nhooks.state.'${key}'.enabled = true`,
+      `${assignment} # user comment`,
+    ];
+
+    for (const fixture of fixtures) {
+      assert.throws(
+        () => stripManagedCodexHookTrustState(fixture, { managedTrustState }),
+        (error: unknown) =>
+          error instanceof ManagedCodexHooksPlanError &&
+          error.code === "managed_trust_key_conflict",
+      );
+    }
+  });
+
+  it("removes exact inline hook trust state without changing adjacent TOML", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
+    const key = `${hooksPath}:post_compact:0:0`;
+    const hash = managedTrustState[key]?.trusted_hash;
+    assert.ok(hash);
+    const exactWholeStatement = `hooks = { state = { "${key}" = { trusted_hash = "${hash}" } } }`;
+    assert.equal(
+      stripManagedCodexHookTrustState(exactWholeStatement, { managedTrustState }),
+      "",
+      "an exact single-field inline hooks state remains removable",
+    );
+    const inline = [
+      'model = "gpt-5.6-sol"',
+      `hooks.state.'${key}' = { trusted_hash = '${hash}' }`,
+      "",
+      "[desktop]",
+      "git-create-pull-request-as-draft = true",
+      "",
+    ].join("\n");
+
+    const stripped = stripManagedCodexHookTrustState(inline, { managedTrustState });
+    assert.doesNotMatch(stripped, /hooks\.state/);
+    assert.match(stripped, /^model = "gpt-5\.6-sol"$/m);
+    assert.match(stripped, /^\[desktop\]$/m);
+    assert.match(stripped, /^git-create-pull-request-as-draft = true$/m);
+    assert.doesNotThrow(() => TOML.parse(stripped));
+
+    const refreshed = upsertManagedCodexHookTrustState(
+      inline,
+      "/tmp/omx",
+      hooksPath,
+      { managedTrustState },
+    );
+    assert.equal(
+      Object.keys(
+        (TOML.parse(refreshed) as { hooks?: { state?: Record<string, unknown> } })
+          .hooks?.state ?? {},
+      ).filter((stateKey) => stateKey === key).length,
+      1,
+    );
+  });
+
+  it("fails closed for inline, dotted, and table hook trust representations with foreign siblings", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
+    const key = `${hooksPath}:post_compact:0:0`;
+    const hash = managedTrustState[key]?.trusted_hash;
+    assert.ok(hash);
+    const fixtures = [
+      [
+        "inline",
+        `hooks = { state = { "${key}" = { trusted_hash = "${hash}" } }, foreign = "keep" }`,
+      ],
+      [
+        "dotted",
+        `hooks.state = { "${key}" = { trusted_hash = "${hash}" }, foreign = "keep" }`,
+      ],
+      [
+        "table",
+        [
+          "[hooks]",
+          `state = { "${key}" = { trusted_hash = "${hash}" } }`,
+          'foreign = "keep"',
+        ].join("\n"),
+      ],
+    ] as const;
+
+    for (const [name, fixture] of fixtures) {
+      assert.doesNotThrow(() => TOML.parse(fixture), `${name} fixture must be valid TOML`);
+      assert.throws(
+        () => stripManagedCodexHookTrustState(fixture, { managedTrustState }),
+        (error: unknown) =>
+          error instanceof ManagedCodexHooksPlanError &&
+          error.code === "managed_trust_key_conflict",
+        `${name} cleanup must preserve the entire foreign-containing representation`,
+      );
+      assert.throws(
+        () => upsertManagedCodexHookTrustState(fixture, "/tmp/omx", hooksPath, { managedTrustState }),
+        (error: unknown) =>
+          error instanceof ManagedCodexHooksPlanError &&
+          error.code === "managed_trust_key_conflict",
+        `${name} refresh must preserve the original bytes`,
+      );
+    }
+  });
+
+  it("removes an exact inline state entry within a hooks.state table", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
+    const key = `${hooksPath}:post_compact:0:0`;
+    const hash = managedTrustState[key]?.trusted_hash;
+    assert.ok(hash);
+    const inline = [
+      "[hooks.state]",
+      `"${key}" = { trusted_hash = "${hash}" }`,
+      "",
+      "[desktop]",
+      "git-create-pull-request-as-draft = true",
+      "",
+    ].join("\n");
+
+    const stripped = stripManagedCodexHookTrustState(inline, { managedTrustState });
+    assert.doesNotMatch(stripped, new RegExp(key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    assert.match(stripped, /^\[hooks\.state\]$/m);
+    assert.match(stripped, /^\[desktop\]$/m);
+    assert.doesNotThrow(() => TOML.parse(stripped));
+  });
+
+  it("fails closed on multi-field, array-like, and mixed managed trust representations", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
+    const key = `${hooksPath}:post_compact:0:0`;
+    const hash = managedTrustState[key]?.trusted_hash;
+    assert.ok(hash);
+    const fixtures = [
+      [
+        `hooks.state."${key}" = { trusted_hash = "${hash}", enabled = false }`,
+        "",
+      ].join("\n"),
+      [
+        `hooks.state."${key}" = [{ trusted_hash = "${hash}" }]`,
+        "",
+      ].join("\n"),
+      [
+        `hooks.state."${key}" = { trusted_hash = "${hash}" }`,
+        `[hooks.state."${key}"]`,
+        `trusted_hash = "${hash}"`,
+        "",
+      ].join("\n"),
+    ];
+
+    for (const fixture of fixtures) {
+      assert.throws(
+        () => stripManagedCodexHookTrustState(fixture, { managedTrustState }),
+        (error: unknown) =>
+          error instanceof ManagedCodexHooksPlanError &&
+          error.code === "managed_trust_key_conflict",
+      );
+      assert.throws(
+        () => buildMergedConfig(fixture, "/tmp/omx", { managedHookTrustState: managedTrustState }),
+        (error: unknown) =>
+          error instanceof ManagedCodexHooksPlanError &&
+          error.code === "managed_trust_key_conflict",
       );
     }
   });
@@ -1422,44 +1656,184 @@ describe("config generator idempotency (#384)", () => {
     assertSingleManagedHookTrustState(repaired);
   });
 
-  it("dedupes stale unfenced managed hook trust-state tables during legacy setup refresh", () => {
+  it("preserves managed-looking trust blocks inside multiline TOML values", () => {
     const hooksPath = "/tmp/codex/hooks.json";
-    const stalePluginModeConfig = [
-      "[features]",
-      "codex_hooks = true",
-      "goals = true",
-      "",
-      '[hooks.state."custom:/hooks.json:stop:0:0"]',
-      'trusted_hash = "sha256:user"',
-      "enabled = false",
-      "",
-      // Regression fixture for #2225: plugin-mode state could be left outside
-      // the managed fence, then legacy setup appended the same table again.
-      '[hooks.state."/tmp/codex/hooks.json:post_compact:0:0"]',
-      'trusted_hash = "sha256:stale-plugin-mode"',
-      "",
+    const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
+    const embeddedTrustBlock = [
+      "# OMX-owned Codex hook trust state",
+      "# Trusts only setup-managed native hook wrappers.",
+      ...Object.entries(managedTrustState)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .flatMap(([key, state]) => [
+          `[hooks.state."${key}"]`,
+          `trusted_hash = "${state.trusted_hash}"`,
+          "",
+        ]),
+      "# End OMX-owned Codex hook trust state",
     ].join("\n");
+    const multilineBasicValue = `basic = """\n${embeddedTrustBlock}\n"""`;
+    const multilineLiteralValue = `literal = '''\n${embeddedTrustBlock}\n'''`;
+    const config = [multilineBasicValue, "", multilineLiteralValue, ""].join("\n");
 
-    const refreshed = buildMergedConfig(stalePluginModeConfig, "/tmp/omx", {
+    const first = upsertManagedCodexHookTrustState(config, "/tmp/omx", hooksPath, {
+      managedTrustState,
+    });
+    const refreshed = upsertManagedCodexHookTrustState(first, "/tmp/omx", hooksPath, {
+      managedTrustState,
+    });
+    const stripped = stripManagedCodexHookTrustState(refreshed, { managedTrustState });
+
+    assert.equal(refreshed, first, "the real managed block should still be replaced idempotently");
+    for (const preserved of [first, stripped]) {
+      assert.ok(preserved.includes(multilineBasicValue));
+      assert.ok(preserved.includes(multilineLiteralValue));
+    }
+    const parsed = TOML.parse(stripped) as {
+      basic?: unknown;
+      literal?: unknown;
+      hooks?: unknown;
+    };
+    assert.equal(parsed.basic, `${embeddedTrustBlock}\n`);
+    assert.equal(parsed.literal, `${embeddedTrustBlock}\n`);
+    assert.equal(parsed.hooks, undefined, "only the real managed trust tables should be stripped");
+
+    const unterminatedMultilineValue = multilineBasicValue.slice(0, -3);
+    assert.equal(
+      stripManagedCodexHookTrustState(unterminatedMultilineValue, { managedTrustState }),
+      unterminatedMultilineValue,
+      "an ambiguous unterminated multiline value must not lose managed-looking content",
+    );
+  });
+
+  it("uses strict final hook coordinates for precomputed managed trust", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const foreignGroup = {
+      hooks: [
+        {
+          type: "command",
+          command: "/usr/bin/python3 /tmp/user-hook.py",
+          timeout: 5,
+        },
+      ],
+    };
+    const existingHooks = JSON.stringify({
+      hooks: Object.fromEntries(
+        MANAGED_HOOK_EVENTS.map((eventName) => [eventName, [foreignGroup]]),
+      ),
+    });
+    const plan = planManagedCodexHooksMerge(
+      existingHooks,
+      "/tmp/omx",
+      hooksPath,
+    );
+    assert.equal(plan.ok, true);
+    if (!plan.ok) return;
+
+    const refreshed = buildMergedConfig("", "/tmp/omx", {
       codexHooksFile: hooksPath,
+      managedHookTrustState: plan.finalTrustState,
+      priorManagedHookTrustState: plan.priorTrustState,
+      legacyHookTrustState: plan.legacyTrustState,
+    });
+    const parsed = TOML.parse(refreshed) as {
+      hooks?: { state?: Record<string, { trusted_hash?: unknown }> };
+    };
+    const trustKeys = Object.keys(parsed.hooks?.state ?? {}).sort();
+
+    assert.deepEqual(trustKeys, Object.keys(plan.finalTrustState).sort());
+    for (const eventName of MANAGED_HOOK_EVENTS) {
+      const eventLabel = eventName
+        .replace(/([A-Z])/g, "_$1")
+        .toLowerCase()
+        .replace(/^_/, "");
+      assert.ok(
+        trustKeys.some((key) => key.includes(`:${eventLabel}:1:0`)),
+        `${eventName} should retain the actual final group index after foreign hooks`,
+      );
+    }
+  });
+
+  it("migrates exact legacy hooks.json state in the same precomputed config plan", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const plan = planManagedCodexHooksMerge(
+      JSON.stringify({
+        state: {
+          "legacy:/hooks.json:stop:0:0": {
+            trusted_hash: "sha256:legacy",
+            enabled: false,
+          },
+        },
+        hooks: {},
+      }),
+      "/tmp/omx",
+      hooksPath,
+    );
+    assert.equal(plan.ok, true);
+    if (!plan.ok) return;
+
+    const refreshed = buildMergedConfig("", "/tmp/omx", {
+      codexHooksFile: hooksPath,
+      managedHookTrustState: plan.finalTrustState,
+      priorManagedHookTrustState: plan.priorTrustState,
+      legacyHookTrustState: plan.legacyTrustState,
     });
 
-    assert.doesNotThrow(() => TOML.parse(refreshed));
-    assert.equal(
-      count(
-        refreshed,
-        /^\[hooks\.state\."\/tmp\/codex\/hooks\.json:post_compact:0:0"\]$/gm,
-      ),
-      1,
-      "legacy refresh should replace the stale plugin-mode managed hook state",
-    );
+    assert.doesNotMatch(plan.finalContent ?? "", /"state"/);
     assert.match(
       refreshed,
-      /^\[hooks\.state\."custom:\/hooks\.json:stop:0:0"\]$/m,
-      "unrelated user hook state should be preserved",
+      /^\[hooks\.state\."legacy:\/hooks\.json:stop:0:0"\]$/m,
     );
+    assert.match(refreshed, /^trusted_hash = "sha256:legacy"$/m);
     assert.match(refreshed, /^enabled = false$/m);
-    assertSingleManagedHookTrustState(refreshed);
+  });
+
+  it("migrates a legacy __proto__ trust key into config.toml", () => {
+    const plan = planManagedCodexHooksMerge(
+      '{"state":{"__proto__":{"trusted_hash":"sha256:legacy","enabled":true}}}',
+      "/tmp/omx",
+      "/tmp/codex/hooks.json",
+    );
+    assert.equal(plan.ok, true);
+    if (!plan.ok) return;
+    const config = buildMergedConfig("", "/tmp/omx", {
+      legacyHookTrustState: plan.legacyTrustState,
+    });
+    assert.match(config, /^\[hooks\.state\."__proto__"\]$/m);
+    assert.match(config, /^trusted_hash = "sha256:legacy"$/m);
+    assert.match(config, /^enabled = true$/m);
+  });
+
+  it("coalesces matching legacy hook trust config tables and rejects hash or enabled collisions", () => {
+    const key = "legacy:/hooks.json:stop:0:0";
+    const legacyHookTrustState = {
+      [key]: { trusted_hash: "sha256:legacy", enabled: false },
+    };
+    const matchingConfig = [
+      `[hooks.state."${key}"]`,
+      'trusted_hash = "sha256:legacy"',
+      "enabled = false",
+      "",
+    ].join("\n");
+    const matching = buildMergedConfig(matchingConfig, "/tmp/omx", {
+      legacyHookTrustState,
+    });
+    assert.equal(
+      count(matching, /^\[hooks\.state\."legacy:\/hooks\.json:stop:0:0"\]$/gm),
+      1,
+    );
+
+    for (const conflictingConfig of [
+      matchingConfig.replace("sha256:legacy", "sha256:other"),
+      matchingConfig.replace("enabled = false", "enabled = true"),
+      matchingConfig.replace("\nenabled = false", ""),
+    ]) {
+      assert.throws(
+        () => buildMergedConfig(conflictingConfig, "/tmp/omx", { legacyHookTrustState }),
+        (error: unknown) =>
+          error instanceof ManagedCodexHooksPlanError &&
+          error.code === "managed_trust_key_conflict",
+      );
+    }
   });
 
   it("syncs shared MCP registry entries in a dedicated managed block", async () => {

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -187,9 +187,10 @@ function resolveManagedCodexHookOptions(
   options: ManagedCodexHookOptions,
   hooksPath: string,
 ): ManagedCodexHookOptions {
+  const platform = options.platform ?? process.platform;
   return {
     ...options,
-    ...(options.platform === "win32" && !options.codexHomeDir
+    ...(platform === "win32" && !options.codexHomeDir
       ? { codexHomeDir: dirname(hooksPath) }
       : {}),
   };
@@ -275,11 +276,13 @@ function decodeGeneratedWindowsProcessArgument(value: string): string | null {
 
 function isProofValidNodeExecutable(nodePath: string): boolean {
   const executable = nodePath.split(/[\\/]/).pop()?.toLowerCase();
-  return executable === "node" || executable === "node.exe";
+  return isQualifiedWindowsFilesystemPath(nodePath) &&
+    (executable === "node" || executable === "node.exe");
 }
 
 function isProofValidNativeHookScriptPath(hookScriptPath: string): boolean {
-  return /(?:^|\\)dist\\scripts\\codex-native-hook\.js$/i.test(hookScriptPath);
+  return isQualifiedWindowsFilesystemPath(hookScriptPath) &&
+    /(?:^|\\)dist\\scripts\\codex-native-hook\.js$/i.test(hookScriptPath);
 }
 
 /**
@@ -1271,6 +1274,7 @@ function tokenizePosixCommand(
   command: string,
   preserveWindowsBackslashes = false,
 ): string[] | null {
+  if (containsControlCharacter(command)) return null;
   const words: string[] = [];
   let word = "";
   let tokenStarted = false;
@@ -1334,14 +1338,154 @@ function tokenizePosixCommand(
   return words.length > 0 ? words : null;
 }
 
-/** Decode only literal PowerShell command words; interpolation is never owned. */
-function tokenizePowerShellCommand(command: string): string[] | null {
+const ALWAYS_UNSAFE_WINDOWS_DIRECT_COMMAND_CHARACTERS = new Set(["%", "!", "$", "`"]);
+const UNQUOTED_UNSAFE_WINDOWS_DIRECT_COMMAND_CHARACTERS = new Set([
+  "&", "|", "<", ">", "(", ")", "^", ";", "@", "*", "?", "[", "]", "{", "}", "~",
+]);
+
+/**
+ * Empty/concatenated double-quote runs have cmd/UCRT and PowerShell parsing
+ * rules that this ownership grammar intentionally does not model. Reject them
+ * before tokenization so they cannot disappear into an owned proof path.
+ */
+function containsAdjacentDoubleQuotes(command: string): boolean {
+  return command.includes('""');
+}
+
+
+/**
+ * Decode only cmd.exe-static argv. This intentionally permits only double-quote
+ * grouping and the CommandLineToArgvW backslash/quote convention; all cmd
+ * expansion and unquoted operator syntax is rejected during tokenization.
+ */
+function tokenizeWindowsDirectCommand(command: string): string[] | null {
+  if (containsControlCharacter(command) || containsAdjacentDoubleQuotes(command)) return null;
+
   const words: string[] = [];
   let word = "";
   let tokenStarted = false;
-  let quote: "'" | '"' | undefined;
-  let callOperatorSeen = false;
+  let quoted = false;
+  for (let index = 0; index < command.length;) {
+    const character = command[index]!;
+    if (
+      ALWAYS_UNSAFE_WINDOWS_DIRECT_COMMAND_CHARACTERS.has(character) ||
+      (!quoted && UNQUOTED_UNSAFE_WINDOWS_DIRECT_COMMAND_CHARACTERS.has(character))
+    ) return null;
+    if (character === "\\") {
+      const start = index;
+      while (command[index] === "\\") index += 1;
+      const count = index - start;
+      if (command[index] === '"') {
+        word += "\\".repeat(Math.floor(count / 2));
+        if (count % 2 === 0) quoted = !quoted;
+        else word += '"';
+        tokenStarted = true;
+        index += 1;
+      } else {
+        word += "\\".repeat(count);
+        tokenStarted = true;
+      }
+      continue;
+    }
+    if (character === '"') {
+      quoted = !quoted;
+      tokenStarted = true;
+      index += 1;
+      continue;
+    }
+    if (isShellWhitespace(character)) {
+      if (quoted) {
+        word += character;
+      } else if (tokenStarted) {
+        words.push(word);
+        word = "";
+        tokenStarted = false;
+      }
+      index += 1;
+      continue;
+    }
+    word += character;
+    tokenStarted = true;
+    index += 1;
+  }
+  if (quoted) return null;
+  if (tokenStarted) words.push(word);
+  return words.length > 0 && words.every((value) => !value.includes('"')) ? words : null;
+}
 
+
+function containsControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)!;
+    if (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f)) return true;
+  }
+  return false;
+}
+
+const WINDOWS_RESERVED_DEVICE_STEM = /^(?:con|prn|aux|nul|com[1-9¹²³]|lpt[1-9¹²³])$/i;
+
+function isReservedWindowsDeviceComponent(component: string): boolean {
+  const dot = component.indexOf(".");
+  const deviceStem = (dot === -1 ? component : component.slice(0, dot)).replace(/ +$/, "");
+  return WINDOWS_RESERVED_DEVICE_STEM.test(deviceStem);
+}
+
+/**
+ * Managed command ownership accepts only ordinary Win32 path syntax. Namespace,
+ * device, stream, and wildcard forms can be lexically static yet resolve outside
+ * the filesystem path the command appears to name, so do not own them.
+ */
+function isValidWindowsFilesystemPath(path: string): boolean {
+  if (!path || containsControlCharacter(path) || /["<>|?*]/.test(path)) return false;
+  if (
+    /^(?:[\\/]{3,}|[\\/]{1,2}[?.][\\/]|[\\/]{1,2}\?\?[\\/]|[\\/](?:device|globalroot)[\\/])/i.test(path)
+  ) return false;
+
+  const firstColon = path.indexOf(":");
+  if (
+    firstColon !== -1 &&
+    (firstColon !== 1 || !/[A-Za-z]/.test(path[0]!) || path.indexOf(":", firstColon + 1) !== -1)
+  ) return false;
+
+  return path.split(/[\\/]+/).every((segment) =>
+    !segment || /^[A-Za-z]:$/.test(segment) ||
+      (!segment.endsWith(".") && !segment.endsWith(" ") && !isReservedWindowsDeviceComponent(segment))
+  );
+}
+
+/** Accept only drive-absolute or complete UNC paths as ownership proof. */
+function isQualifiedWindowsFilesystemPath(path: string): boolean {
+  if (!isValidWindowsFilesystemPath(path)) return false;
+  if (/^[A-Za-z]:[\\/]/.test(path)) return true;
+  if (!/^[\\/]{2}/.test(path)) return false;
+  const uncSegments = path.slice(2).split(/[\\/]+/);
+  return uncSegments.length >= 2 && uncSegments[0]!.length > 0 && uncSegments[1]!.length > 0;
+}
+
+function isAbsolutePosixFilesystemPath(path: string): boolean {
+  return path.startsWith("/") && !containsControlCharacter(path);
+}
+
+interface StaticPowerShellCommandToken {
+  value: string;
+  quoted: boolean;
+}
+
+interface StaticPowerShellCommand {
+  tokens: StaticPowerShellCommandToken[];
+  hasCallOperator: boolean;
+}
+
+/** Decode only literal PowerShell command words; interpolation is never owned. */
+function tokenizePowerShellCommand(command: string): StaticPowerShellCommand | null {
+  const tokens: StaticPowerShellCommandToken[] = [];
+  let word = "";
+  let tokenStarted = false;
+  let tokenQuoted = false;
+  let quote: "'" | '"' | undefined;
+  let hasCallOperator = false;
+
+  if (containsControlCharacter(command) || containsAdjacentDoubleQuotes(command)) return null;
   for (let index = 0; index < command.length; index += 1) {
     const character = command[index]!;
     if (quote === "'") {
@@ -1370,24 +1514,26 @@ function tokenizePowerShellCommand(command: string): string[] | null {
     if (character === "'" || character === '"') {
       quote = character;
       tokenStarted = true;
+      tokenQuoted = true;
       continue;
     }
     if (character === "&") {
       if (
-        callOperatorSeen ||
+        hasCallOperator ||
         tokenStarted ||
-        words.length > 0 ||
+        tokens.length > 0 ||
         !isShellWhitespace(command[index + 1] ?? "")
       ) return null;
-      callOperatorSeen = true;
+      hasCallOperator = true;
       continue;
     }
     if (UNQUOTED_POWERSHELL_ACTIVE_CHARACTERS.has(character)) return null;
     if (isShellWhitespace(character)) {
       if (tokenStarted) {
-        words.push(word);
+        tokens.push({ value: word, quoted: tokenQuoted });
         word = "";
         tokenStarted = false;
+        tokenQuoted = false;
       }
       continue;
     }
@@ -1395,8 +1541,8 @@ function tokenizePowerShellCommand(command: string): string[] | null {
     tokenStarted = true;
   }
   if (quote) return null;
-  if (tokenStarted) words.push(word);
-  return words.length > 0 ? words : null;
+  if (tokenStarted) tokens.push({ value: word, quoted: tokenQuoted });
+  return tokens.length > 0 ? { tokens, hasCallOperator } : null;
 }
 
 function commandBasename(path: string, platform: HookCommandPlatform): string {
@@ -1408,39 +1554,95 @@ function commandBasename(path: string, platform: HookCommandPlatform): string {
 
 function isNativeHookScriptPath(path: string, platform: HookCommandPlatform): boolean {
   return platform === "win32"
-    ? /(?:^|[\\/])dist[\\/]scripts[\\/]codex-native-hook\.js$/i.test(path)
-    : /(?:^|\/)dist\/scripts\/codex-native-hook\.js$/.test(path);
+    ? isQualifiedWindowsFilesystemPath(path) &&
+      /(?:^|[\\/])dist[\\/]scripts[\\/]codex-native-hook\.js$/i.test(path)
+    : isAbsolutePosixFilesystemPath(path) &&
+      /(?:^|\/)dist\/scripts\/codex-native-hook\.js$/.test(path);
 }
 
-function isNativeHookShimPath(path: string): boolean {
+function hasNativeHookShimSuffix(path: string): boolean {
   return /(?:^|[\\/])hooks[\\/]omx-native-hook-windows-shim\.ps1$/i.test(path);
 }
 
+function isNativeHookShimPath(path: string): boolean {
+  return isQualifiedWindowsFilesystemPath(path) && hasNativeHookShimSuffix(path);
+}
+
+function isSupportedDirectNodeExecutablePath(
+  executablePath: string,
+  platform: HookCommandPlatform,
+): boolean {
+  const bareExecutable = platform === "win32" ? executablePath.toLowerCase() : executablePath;
+  const supportedBareExecutable = platform === "win32"
+    ? bareExecutable === "node" || bareExecutable === "node.exe"
+    : bareExecutable === "node";
+  return supportedBareExecutable ||
+    (platform === "win32"
+      ? isQualifiedWindowsFilesystemPath(executablePath)
+      : isAbsolutePosixFilesystemPath(executablePath)) &&
+      (platform === "win32"
+        ? commandBasename(executablePath, "win32") === "node" ||
+          commandBasename(executablePath, "win32") === "node.exe"
+        : commandBasename(executablePath, "linux") === "node");
+}
+
+function isSupportedPowerShellExecutablePath(executablePath: string): boolean {
+  return executablePath.toLowerCase() === "powershell.exe" ||
+    (isQualifiedWindowsFilesystemPath(executablePath) &&
+      commandBasename(executablePath, "win32") === "powershell.exe");
+}
+
 function isValidDirectNodeCommand(command: string, platform: HookCommandPlatform): boolean {
-  const words = tokenizePosixCommand(command, platform === "win32");
-  const executable = words?.[0] === undefined ? "" : commandBasename(words[0], platform);
+  const words = platform === "win32"
+    ? tokenizeWindowsDirectCommand(command)
+    : tokenizePosixCommand(command);
+  const executablePath = words?.[0];
+  const scriptPath = words?.[1];
   return words?.length === 2 &&
-    (platform === "win32" ? executable === "node" || executable === "node.exe" : executable === "node") &&
-    isNativeHookScriptPath(words[1]!, platform);
+    executablePath !== undefined &&
+    scriptPath !== undefined &&
+    isSupportedDirectNodeExecutablePath(executablePath, platform) &&
+    isNativeHookScriptPath(scriptPath, platform);
+}
+
+function hasStaticWindowsShimCommandGrammar(command: string): boolean {
+  const parsed = tokenizePowerShellCommand(command);
+  if (!parsed) return false;
+  const { tokens, hasCallOperator } = parsed;
+  const powerShellToken = tokens[0];
+  const powerShellPath = powerShellToken?.value;
+  const shimPath = tokens[5]?.value;
+  return tokens.length === 6 &&
+    powerShellToken !== undefined &&
+    powerShellPath !== undefined &&
+    shimPath !== undefined &&
+    (!powerShellToken.quoted || hasCallOperator) &&
+    isSupportedPowerShellExecutablePath(powerShellPath) &&
+    isValidWindowsFilesystemPath(shimPath) &&
+    tokens[1]?.value.toLowerCase() === "-noprofile" &&
+    tokens[2]?.value.toLowerCase() === "-executionpolicy" &&
+    tokens[3]?.value.toLowerCase() === "bypass" &&
+    tokens[4]?.value.toLowerCase() === "-file" &&
+    hasNativeHookShimSuffix(shimPath);
 }
 
 /**
  * Parse an OMX Windows shim invocation using the managed-command ownership
  * grammar. Returns the validated shim path; returns null for every other
- * command.
+ * command. Supplying current install options additionally recognizes the exact
+ * non-Windows host-path spelling used by platform-seam validation.
  */
-export function parseManagedCodexNativeHookWindowsShimCommand(command: string): string | null {
-  const words = tokenizePowerShellCommand(command);
-  if (!words) return null;
-  const shimPath = words[5];
-  return words.length === 6 &&
-    commandBasename(words[0]!, "win32") === "powershell.exe" &&
-    words[1]?.toLowerCase() === "-noprofile" &&
-    words[2]?.toLowerCase() === "-executionpolicy" &&
-    words[3]?.toLowerCase() === "bypass" &&
-    words[4]?.toLowerCase() === "-file" &&
-    shimPath !== undefined &&
-    isNativeHookShimPath(shimPath)
+export function parseManagedCodexNativeHookWindowsShimCommand(
+  command: string,
+  options?: ManagedCodexHookOptions,
+): string | null {
+  const parsed = tokenizePowerShellCommand(command);
+  const shimPath = parsed?.tokens[5]?.value;
+  return shimPath !== undefined &&
+      hasStaticWindowsShimCommandGrammar(command) &&
+      (isNativeHookShimPath(shimPath) ||
+        (options !== undefined &&
+          isExactCurrentWindowsShimCommand(command, "win32", options)))
     ? shimPath
     : null;
 }
@@ -1449,13 +1651,123 @@ function isValidWindowsShimCommand(command: string): boolean {
   return parseManagedCodexNativeHookWindowsShimCommand(command) !== null;
 }
 
+const OMX_COMMAND_PATTERN = /(?:codex-native-hook\.js|omx-native-hook-windows-shim\.ps1)/i;
+
+/**
+ * Lex only static POSIX word fragments for ambiguity detection. This is
+ * deliberately more permissive than the ownership grammar: backslash-newline
+ * continuations and escaped characters must identify OMX-looking commands as
+ * ambiguous, never make them owned.
+ */
+function decodedPosixCommandWords(command: string): string[] {
+  const words: string[] = [];
+  let word = "";
+  let quote: "'" | '"' | undefined;
+  const flushWord = (): void => {
+    if (word) words.push(word);
+    word = "";
+  };
+
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index]!;
+    if (quote === "'") {
+      if (character === "'") quote = undefined;
+      else word += character;
+      continue;
+    }
+    if (quote === '"') {
+      if (character === '"') {
+        quote = undefined;
+      } else if (character === "\\") {
+        const escaped = command[index + 1];
+        if (escaped === "\n") {
+          index += 1;
+        } else if (escaped === "\r" && command[index + 2] === "\n") {
+          index += 2;
+        } else if (escaped && ["$", "`", '"', "\\"].includes(escaped)) {
+          word += escaped;
+          index += 1;
+        } else {
+          word += "\\";
+        }
+      } else {
+        word += character;
+      }
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      continue;
+    }
+    if (character === "\\") {
+      const escaped = command[index + 1];
+      if (escaped === "\n") {
+        index += 1;
+      } else if (escaped === "\r" && command[index + 2] === "\n") {
+        index += 2;
+      } else if (escaped) {
+        word += escaped;
+        index += 1;
+      } else {
+        word += character;
+      }
+      continue;
+    }
+    if (isShellWhitespace(character) || UNQUOTED_POSIX_SHELL_ACTIVE_CHARACTERS.has(character)) {
+      flushWord();
+      continue;
+    }
+    word += character;
+  }
+  flushWord();
+  return words;
+}
+
+function commandMentionsDecodedPosixOmx(command: string): boolean {
+  return decodedPosixCommandWords(command).some((word) => OMX_COMMAND_PATTERN.test(word));
+}
+
 function commandMentionsOmx(command: string): boolean {
-  return /(?:codex-native-hook\.js|omx-native-hook-windows-shim\.ps1)/i.test(command);
+  return OMX_COMMAND_PATTERN.test(command) || OMX_COMMAND_PATTERN.test(command.replace(/["']/g, ""));
 }
 
 function isValidManagedCommand(command: string, platform: HookCommandPlatform): boolean {
   return isValidDirectNodeCommand(command, platform) ||
     (platform === "win32" && isValidWindowsShimCommand(command));
+}
+
+function buildExactCurrentWindowsHostShimCommand(
+  options: ManagedCodexHookOptions,
+): string | null {
+  if (
+    process.platform === "win32" ||
+    (options.platform ?? process.platform) !== "win32" ||
+    options.codexHomeDir === undefined
+  ) return null;
+  const shimPath = join(options.codexHomeDir, ...WINDOWS_NATIVE_HOOK_SHIM_RELATIVE_PATH);
+  const powerShellPath = resolveWindowsPowerShellPath(options.env);
+  return `& ${quotePowerShellLiteral(powerShellPath)} -NoProfile -ExecutionPolicy Bypass -File ${quotePowerShellLiteral(shimPath)}`;
+}
+
+/**
+ * A current Windows command may have a drive-less shim path in non-Windows
+ * platform seams. Accept only byte-identical canonical or host-joined command
+ * spellings produced from resolved current options; generic historical
+ * classification remains provenance-qualified.
+ */
+function isExactCurrentWindowsShimCommand(
+  command: string,
+  platform: HookCommandPlatform,
+  options: ManagedCodexHookOptions,
+): boolean {
+  if (
+    platform !== "win32" ||
+    (options.platform ?? process.platform) !== "win32" ||
+    options.codexHomeDir === undefined ||
+    !hasStaticWindowsShimCommandGrammar(command)
+  ) return false;
+  return command === buildManagedCodexNativeHookCommand("", options) ||
+    command === buildExactCurrentWindowsHostShimCommand(options);
 }
 
 function isValidHistoricalManagedCommand(command: string): boolean {
@@ -1466,10 +1778,10 @@ function isValidHistoricalManagedCommand(command: string): boolean {
 
 /**
  * Returns whether a command has the exact approved token grammar of an OMX
- * native hook from this or a historical installation. Ownership intentionally
- * depends on the executable and terminal script/shim suffixes, never a current
- * package-root path. The union is deliberately narrow and accepts only
- * shell-static POSIX, Windows, or PowerShell command spellings.
+ * native hook from this or a historical installation. Ownership requires a
+ * shell-static executable and provenance-qualified terminal script path, but
+ * never a current package-root path. The union is deliberately narrow and
+ * accepts only shell-static POSIX, Windows, or PowerShell command spellings.
  */
 export function isManagedCodexHookCommand(command: string): boolean {
   return isValidHistoricalManagedCommand(command);
@@ -1485,20 +1797,33 @@ function classifyManagedCommand(
   const windows = nullableStringProperty(handler, "commandWindows") ??
     nullableStringProperty(handler, "command_windows");
   const platform = options.platform ?? process.platform;
-  const effective = effectiveCommandForPlatform(handler, platform);
-  const supplied = [command, windows].filter((value): value is string => typeof value === "string");
-  const effectiveOwned = isValidManagedCommand(effective, platform);
-  if (effectiveOwned) {
-    for (const suppliedCommand of supplied) {
-      if (suppliedCommand === effective) continue;
-      if (!isManagedCodexHookCommand(suppliedCommand)) {
-        return "ambiguous";
-      }
+  const commandPlatform = typeof windows === "string" ? "linux" : platform;
+  const supplied = [
+    { command, platform: commandPlatform },
+    ...(typeof windows === "string" ? [{ command: windows, platform: "win32" as const }] : []),
+  ];
+  let hasOwnedCommand = false;
+  let hasForeignAlternative = false;
+  for (const suppliedCommand of supplied) {
+    // Examine static POSIX word decoding before exact grammar validation. A
+    // non-exact invocation can hide an OMX filename with escapes or a line
+    // continuation, and must fail closed rather than become a foreign hook.
+    const mentionsDecodedPosixOmx = commandMentionsDecodedPosixOmx(suppliedCommand.command);
+    if (
+      isValidManagedCommand(suppliedCommand.command, suppliedCommand.platform) ||
+      isExactCurrentWindowsShimCommand(suppliedCommand.command, suppliedCommand.platform, options)
+    ) {
+      hasOwnedCommand = true;
+      continue;
     }
-    return "owned";
+    if (mentionsDecodedPosixOmx || commandMentionsOmx(suppliedCommand.command)) return "ambiguous";
+    hasForeignAlternative = true;
   }
-  return supplied.some(commandMentionsOmx) ? "ambiguous" : "foreign";
+  return hasOwnedCommand
+    ? hasForeignAlternative ? "ambiguous" : "owned"
+    : "foreign";
 }
+
 
 interface ManagedOwner {
   eventName: ManagedHookEventName;
@@ -1534,8 +1859,8 @@ function hasOpaqueProperties(node: JsonObjectNode, known: ReadonlySet<string>): 
   return node.properties.some((property) => !known.has(property.key));
 }
 
-function groupMatcher(node: JsonObjectNode): string | undefined {
-  return stringProperty(node, "matcher");
+function groupMatcher(node: JsonObjectNode): string | null | undefined {
+  return nullableStringProperty(node, "matcher");
 }
 
 function matcherOwnershipError(
@@ -1543,24 +1868,25 @@ function matcherOwnershipError(
   group: RawGroupModel,
 ): ManagedCodexHooksPlanError | null {
   const matcher = groupMatcher(group.node);
-  if (matcherIsAware(eventName) && matcher !== undefined && !isValidCodexMatcher(matcher)) {
+  if (matcherIsAware(eventName) && typeof matcher === "string" && !isValidCodexMatcher(matcher)) {
     return planError("ambiguous_managed_group", "Cannot mutate an OMX group with an invalid matcher.", {
       eventName,
       groupIndex: group.groupIndex,
     });
   }
   const foreignSiblings = group.handlers.some((handler) => !handler.owner);
+
   if (eventName === "SessionStart") {
     const allowed = foreignSiblings
       ? matcher === "startup|resume|clear"
-      : matcher === undefined || matcher === "startup" || matcher === "startup|resume" || matcher === "startup|resume|clear";
+      : matcher === undefined || matcher === null || matcher === "startup" || matcher === "startup|resume" || matcher === "startup|resume|clear";
     if (!allowed) {
       return planError("ambiguous_managed_group", "SessionStart matcher is not compatible with OMX ownership.", {
         eventName,
         groupIndex: group.groupIndex,
       });
     }
-  } else if (matcher !== undefined) {
+  } else if (matcher !== undefined && matcher !== null) {
     return planError("ambiguous_managed_group", "OMX managed groups must not carry a matcher for this event.", {
       eventName,
       groupIndex: group.groupIndex,
@@ -2287,14 +2613,17 @@ export function planManagedCodexHooksMerge(
     }
     const primary = eventOwners[0]!;
     patches.push(...knownFieldPatches(prepared.content, primary.handlerNode, canonicalHookForEvent(canonicalEntry), KNOWN_COMMAND_FIELDS));
-    patches.push(
-      ...knownFieldPatches(
-        prepared.content,
-        primary.groupNode,
-        canonicalMatcherForEvent(canonicalEntry),
-        KNOWN_MATCHER_FIELD,
-      ),
-    );
+    const primaryGroup = ownership.groups.find((group) => group.node === primary.groupNode);
+    if (!primaryGroup?.foreign) {
+      patches.push(
+        ...knownFieldPatches(
+          prepared.content,
+          primary.groupNode,
+          canonicalMatcherForEvent(canonicalEntry),
+          KNOWN_MATCHER_FIELD,
+        ),
+      );
+    }
   }
 
   if (validation.hooksNode && missingEventProperties.length > 0) {

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -179,7 +179,10 @@ export interface ManagedCodexHookOptions {
   nodePath?: string;
   hookScriptPath?: string;
   env?: NodeJS.ProcessEnv;
-  /** Final hooks.json content to derive Codex hook trust keys from. */
+  /**
+   * Final hooks.json content to derive Codex hook trust keys from. Omit it to
+   * retain the historical canonical-builder fallback; null declares no final artifact.
+   */
   hooksContent?: string | null;
 }
 
@@ -2743,6 +2746,7 @@ export function buildManagedCodexHookTrustState(
   options: ManagedCodexHookOptions = {},
 ): Record<string, ManagedCodexHookTrustState> {
   const resolvedOptions = resolveManagedCodexHookOptions(options, hooksPath);
+  if (options.hooksContent === null) return {};
   const content = typeof options.hooksContent === "string"
     ? options.hooksContent
     : serializeCodexHooksConfig(jsonObjectFromUnknown(buildManagedCodexHooksConfig(pkgRoot, resolvedOptions)));

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -14,7 +14,13 @@ export const MANAGED_HOOK_EVENTS = [
 
 type ManagedHookEventName = (typeof MANAGED_HOOK_EVENTS)[number];
 
-type JsonObject = Record<string, unknown>;
+export interface JsonObject {
+  [key: string]: JsonValue;
+}
+
+export interface JsonArray extends Array<JsonValue> {}
+
+export type JsonValue = JsonObject | JsonArray | string | number | boolean | null;
 
 export interface ManagedHookEntry {
   matcher?: string;
@@ -78,14 +84,53 @@ function isPlainObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function setOwnRecordValue<T>(record: Record<string, T>, key: string, value: T): void {
+  Object.defineProperty(record, key, {
+    value,
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  });
+}
+
+function isJsonArray(value: unknown): value is JsonArray {
+  return Array.isArray(value);
+}
+
 function cloneJson<T>(value: T): T {
   return structuredClone(value);
+}
+
+function jsonValueFromUnknown(value: unknown): JsonValue {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError("Managed Codex hook configuration numbers must be finite JSON values.");
+    return value;
+  }
+  if (Array.isArray(value)) return value.map((item) => jsonValueFromUnknown(item));
+  if (typeof value === "object") {
+    const object: JsonObject = {};
+    for (const [key, item] of Object.entries(value)) setOwnRecordValue(object, key, jsonValueFromUnknown(item));
+    return object;
+  }
+  throw new TypeError("Managed Codex hook configuration must be JSON-serializable.");
+}
+
+function jsonObjectFromUnknown(value: unknown): JsonObject {
+  const jsonValue = jsonValueFromUnknown(value);
+  if (typeof jsonValue !== "object" || jsonValue === null || Array.isArray(jsonValue)) {
+    throw new TypeError("Managed Codex hook configuration root must be a JSON object.");
+  }
+  return jsonValue;
 }
 
 type HookCommandPlatform = NodeJS.Platform;
 
 function quoteCommandPart(value: string): string {
-  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  return `"${value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/[$`]/g, "\\$&")}"`;
 }
 
 export function escapeTomlBasicString(value: string): string {
@@ -134,6 +179,20 @@ export interface ManagedCodexHookOptions {
   nodePath?: string;
   hookScriptPath?: string;
   env?: NodeJS.ProcessEnv;
+  /** Final hooks.json content to derive Codex hook trust keys from. */
+  hooksContent?: string | null;
+}
+
+function resolveManagedCodexHookOptions(
+  options: ManagedCodexHookOptions,
+  hooksPath: string,
+): ManagedCodexHookOptions {
+  return {
+    ...options,
+    ...(options.platform === "win32" && !options.codexHomeDir
+      ? { codexHomeDir: dirname(hooksPath) }
+      : {}),
+  };
 }
 
 const DEFAULT_WINDOWS_SYSTEM_ROOT = "C:\\Windows";
@@ -164,6 +223,111 @@ export function buildManagedCodexNativeHookWindowsShimPath(
   codexHomeDir: string,
 ): string {
   return win32.join(codexHomeDir, ...WINDOWS_NATIVE_HOOK_SHIM_RELATIVE_PATH);
+}
+
+export type ManagedCodexNativeHookWindowsShimOwnership =
+  | "current"
+  | "historical"
+  | "modified";
+
+function decodePowerShellSingleQuotedLiteral(value: string): string | null {
+  if (value.length < 2 || value[0] !== "'" || value[value.length - 1] !== "'") return null;
+  let decoded = "";
+  for (let index = 1; index < value.length - 1; index += 1) {
+    const character = value[index]!;
+    if (character !== "'") {
+      decoded += character;
+      continue;
+    }
+    if (index + 1 >= value.length - 1 || value[index + 1] !== "'") return null;
+    decoded += "'";
+    index += 1;
+  }
+  return decoded;
+}
+
+function decodeGeneratedWindowsProcessArgument(value: string): string | null {
+  if (value.length < 2 || value[0] !== '"' || value[value.length - 1] !== '"') return null;
+  let decoded = "";
+  let index = 1;
+  while (index < value.length - 1) {
+    let backslashes = 0;
+    while (value[index] === "\\") {
+      backslashes += 1;
+      index += 1;
+    }
+    if (index === value.length - 1) {
+      if (backslashes % 2 !== 0) return null;
+      decoded += "\\".repeat(backslashes / 2);
+      break;
+    }
+    const character = value[index]!;
+    if (character === '"') {
+      if (backslashes % 2 === 0) return null;
+      decoded += "\\".repeat((backslashes - 1) / 2) + '"';
+    } else {
+      decoded += "\\".repeat(backslashes) + character;
+    }
+    index += 1;
+  }
+  return quoteWindowsProcessArgument(decoded) === value ? decoded : null;
+}
+
+function isProofValidNodeExecutable(nodePath: string): boolean {
+  const executable = nodePath.split(/[\\/]/).pop()?.toLowerCase();
+  return executable === "node" || executable === "node.exe";
+}
+
+function isProofValidNativeHookScriptPath(hookScriptPath: string): boolean {
+  return /(?:^|\\)dist\\scripts\\codex-native-hook\.js$/i.test(hookScriptPath);
+}
+
+/**
+ * Classify a Windows native-hook shim from its raw on-disk bytes. Current
+ * shims must be byte-identical to `expected`; historical shims must be the
+ * complete, BOM-prefixed generated forwarding template with independently
+ * proof-valid variable paths. Every other input is modified.
+ */
+export function classifyManagedCodexNativeHookWindowsShimOwnership(
+  content: Buffer,
+  expected: Buffer,
+): ManagedCodexNativeHookWindowsShimOwnership {
+  if (content.equals(expected)) return "current";
+  if (content[0] !== 0xef || content[1] !== 0xbb || content[2] !== 0xbf) return "modified";
+  const decoded = content.toString("utf-8");
+  if (!Buffer.from(decoded, "utf-8").equals(content) || !decoded.startsWith("\uFEFF")) {
+    return "modified";
+  }
+
+  const lines = decoded.slice(1).split("\n");
+  if (lines.length !== 21 || lines[20] !== "") return "modified";
+  const nodePath = lines[2]?.startsWith("$startInfo.FileName = ")
+    ? decodePowerShellSingleQuotedLiteral(lines[2]!.slice("$startInfo.FileName = ".length))
+    : null;
+  const encodedHookScript = lines[7]?.startsWith("$startInfo.Arguments = ")
+    ? decodePowerShellSingleQuotedLiteral(lines[7]!.slice("$startInfo.Arguments = ".length))
+    : null;
+  const hookScriptPath = encodedHookScript === null
+    ? null
+    : decodeGeneratedWindowsProcessArgument(encodedHookScript);
+  if (
+    nodePath === null ||
+    hookScriptPath === null ||
+    !isProofValidNodeExecutable(nodePath) ||
+    !isProofValidNativeHookScriptPath(hookScriptPath)
+  ) {
+    return "modified";
+  }
+
+  return Buffer.from(
+    buildManagedCodexNativeHookWindowsShimContent("", {
+      nodePath,
+      hookScriptPath,
+    }),
+    "utf-8",
+  ).equals(content)
+    ? "historical"
+    : "modified";
 }
 
 export function buildManagedCodexNativeHookWindowsShimContent(
@@ -212,9 +376,6 @@ export function buildManagedCodexNativeHookCommand(
     ? { platform: optionsOrPlatform }
     : optionsOrPlatform;
   const platform = options.platform ?? process.platform;
-  const hookScript = platform === "win32"
-    ? win32.join(pkgRoot, "dist", "scripts", "codex-native-hook.js")
-    : join(pkgRoot, "dist", "scripts", "codex-native-hook.js");
 
   if (platform === "win32") {
     const codexHomeDir = options.codexHomeDir ?? dirname(pkgRoot);
@@ -222,6 +383,7 @@ export function buildManagedCodexNativeHookCommand(
     const powerShellPath = resolveWindowsPowerShellPath(options.env);
     return `& ${quotePowerShellLiteral(powerShellPath)} -NoProfile -ExecutionPolicy Bypass -File ${quotePowerShellLiteral(shimPath)}`;
   }
+  const hookScript = join(pkgRoot, "dist", "scripts", "codex-native-hook.js");
 
   return `${quoteCommandPart(process.execPath)} ${quoteCommandPart(hookScript)}`;
 }
@@ -284,13 +446,802 @@ export function buildManagedCodexHooksConfig(
   };
 }
 
-export function parseCodexHooksConfig(
+export interface SourceSpan {
+  start: number;
+  end: number;
+}
+
+type JsonNode = JsonObjectNode | JsonArrayNode | JsonScalarNode;
+
+interface JsonObjectNode extends SourceSpan {
+  kind: "object";
+  value: JsonObject;
+  properties: JsonProperty[];
+}
+
+interface JsonArrayNode extends SourceSpan {
+  kind: "array";
+  value: JsonArray;
+  elements: JsonNode[];
+}
+
+interface JsonStringNode extends SourceSpan {
+  kind: "string";
+  value: string;
+  raw: string;
+}
+
+interface JsonNumberNode extends SourceSpan {
+  kind: "number";
+  value: number;
+  raw: string;
+}
+
+interface JsonBooleanNode extends SourceSpan {
+  kind: "boolean";
+  value: boolean;
+  raw: string;
+}
+
+interface JsonNullNode extends SourceSpan {
+  kind: "null";
+  value: null;
+  raw: string;
+}
+
+type JsonScalarNode = JsonStringNode | JsonNumberNode | JsonBooleanNode | JsonNullNode;
+
+interface JsonProperty {
+  key: string;
+  keyNode: JsonStringNode;
+  value: JsonNode;
+}
+
+const CODEX_HOOK_EVENTS = [
+  "PreToolUse",
+  "PermissionRequest",
+  "PostToolUse",
+  "PreCompact",
+  "PostCompact",
+  "SessionStart",
+  "UserPromptSubmit",
+  "SubagentStart",
+  "SubagentStop",
+  "Stop",
+] as const;
+
+type CodexHookEventName = (typeof CODEX_HOOK_EVENTS)[number];
+
+const MATCHER_AWARE_HOOK_EVENTS = new Set<CodexHookEventName>([
+  "PreToolUse",
+  "PermissionRequest",
+  "PostToolUse",
+  "PreCompact",
+  "PostCompact",
+  "SessionStart",
+  "SubagentStart",
+  "SubagentStop",
+]);
+const KNOWN_HOOK_EVENT_FIELDS = new Set<string>(CODEX_HOOK_EVENTS);
+
+const KNOWN_GROUP_FIELDS = new Set(["matcher", "hooks"]);
+const KNOWN_COMMAND_FIELDS = new Set([
+  "type",
+  "command",
+  "commandWindows",
+  "command_windows",
+  "timeout",
+  "async",
+  "statusMessage",
+]);
+const KNOWN_ROOT_FIELDS = new Set(["hooks"]);
+const KNOWN_HANDLER_TYPE_FIELD = new Set(["type"]);
+const KNOWN_LEGACY_TRUST_STATE_ENTRY_FIELDS = new Set(["trusted_hash", "enabled"]);
+const KNOWN_MATCHER_FIELD = new Set(["matcher"]);
+
+export type ManagedCodexHooksPlanErrorCode =
+  | "invalid_document"
+  | "ambiguous_managed_handler"
+  | "ambiguous_managed_group"
+  | "unsafe_managed_removal"
+  | "managed_trust_key_conflict";
+
+export class ManagedCodexHooksPlanError extends Error {
+  readonly code: ManagedCodexHooksPlanErrorCode;
+  readonly details: Readonly<Record<string, unknown>>;
+
+  constructor(
+    code: ManagedCodexHooksPlanErrorCode,
+    message: string,
+    details: Record<string, unknown> = {},
+  ) {
+    super(message);
+    this.name = "ManagedCodexHooksPlanError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export interface CodexHooksDiagnostic {
+  code: "invalid_matcher" | "async_command" | "empty_command" | "unsupported_handler";
+  eventName: CodexHookEventName;
+  groupIndex: number;
+  handlerIndex?: number;
+  message: string;
+}
+
+/** Backwards-compatible singular spelling. */
+export type CodexHookDiagnostic = CodexHooksDiagnostic;
+
+export interface CodexHookGroupOccurrence {
+  eventName: CodexHookEventName;
+  groupIndex: number;
+  span: SourceSpan;
+}
+
+export interface CodexHookHandlerOccurrence {
+  eventName: CodexHookEventName;
+  groupIndex: number;
+  handlerIndex: number;
+  span: SourceSpan;
+}
+
+export interface CodexHookDiscoveryCommand {
+  eventName: CodexHookEventName;
+  groupIndex: number;
+  handlerIndex: number;
+  command: string;
+}
+
+export interface ValidCodexHooksConfigStrict {
+  ok: true;
+  root: JsonObject;
+  diagnostics: CodexHooksDiagnostic[];
+  groupOccurrences: CodexHookGroupOccurrence[];
+  handlerOccurrences: CodexHookHandlerOccurrence[];
+  discoveredCommands: CodexHookDiscoveryCommand[];
+}
+
+export interface InvalidCodexHooksConfigStrict {
+  ok: false;
+  error: ManagedCodexHooksPlanError;
+}
+
+export type CodexHooksConfigStrictResult =
+  | ValidCodexHooksConfigStrict
+  | InvalidCodexHooksConfigStrict;
+
+export interface ManagedCodexHooksCoordinateProof {
+  safe: boolean;
+  shifted?: {
+    kind: "group" | "handler";
+    eventName: CodexHookEventName;
+    oldCoordinate: readonly number[];
+    newCoordinate?: readonly number[];
+  };
+}
+
+export interface ManagedCodexHooksPlan {
+  ok: true;
+  finalContent: string | null;
+  changed: boolean;
+  removedCount: number;
+  finalTrustState: Record<string, ManagedCodexHookTrustState>;
+  hasForeignHooks: boolean;
+  coordinateProof: ManagedCodexHooksCoordinateProof;
+  priorTrustState: Record<string, ManagedCodexHookTrustState>;
+  diagnostics: CodexHooksDiagnostic[];
+  legacyTrustState: Record<string, CodexHooksJsonTrustStateEntry>;
+}
+
+export interface FailedManagedCodexHooksPlan {
+  ok: false;
+  error: ManagedCodexHooksPlanError;
+  diagnostics: CodexHooksDiagnostic[];
+}
+
+export type ManagedCodexHooksPlanResult =
+  | ManagedCodexHooksPlan
+  | FailedManagedCodexHooksPlan;
+
+export interface ManagedCodexHookTrustScan {
+  ok: true;
+  trustState: Record<string, ManagedCodexHookTrustState>;
+  groupOccurrences: CodexHookGroupOccurrence[];
+  handlerOccurrences: CodexHookHandlerOccurrence[];
+}
+
+export type ManagedCodexHookTrustScanResult =
+  | ManagedCodexHookTrustScan
+  | InvalidCodexHooksConfigStrict;
+
+function planError(
+  code: ManagedCodexHooksPlanErrorCode,
+  message: string,
+  details: Record<string, unknown> = {},
+): ManagedCodexHooksPlanError {
+  return new ManagedCodexHooksPlanError(code, message, details);
+}
+
+function planFailure(
+  error: ManagedCodexHooksPlanError,
+  diagnostics: CodexHooksDiagnostic[] = [],
+): FailedManagedCodexHooksPlan {
+  return { ok: false, error, diagnostics };
+}
+
+function isManagedHookEventName(value: string): value is ManagedHookEventName {
+  return (MANAGED_HOOK_EVENTS as readonly string[]).includes(value);
+}
+
+
+function matcherIsAware(eventName: CodexHookEventName): boolean {
+  return MATCHER_AWARE_HOOK_EVENTS.has(eventName);
+}
+
+function containsRustUnsupportedJavaScriptMatcherSyntax(matcher: string): boolean {
+  for (let index = 0; index < matcher.length; index += 1) {
+    if (matcher[index] === "\\") {
+      const escaped = matcher[index + 1];
+      if (!escaped || !isValidRustRegexEscape(matcher, index)) return true;
+      index = skipRustRegexEscape(matcher, index) - 1;
+      continue;
+    }
+    if (matcher[index] !== "(" || matcher[index + 1] !== "?") continue;
+    const marker = matcher[index + 2];
+    if (marker === "=" || marker === "!") return true;
+    if (marker === "<" && (matcher[index + 3] === "=" || matcher[index + 3] === "!")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const RUST_SIMPLE_REGEX_ESCAPES = new Set([
+  "A", "B", "D", "S", "W", "a", "b", "d", "f", "n", "r", "s", "t", "v", "w", "z",
+]);
+const RUST_ESCAPABLE_REGEX_PUNCTUATION = new Set([
+  "\\", ".", "*", "+", "?", "(", ")", "|", "[", "]", "{", "}", "^", "$", "-", "/",
+]);
+
+function isHexadecimal(value: string): boolean {
+  return /^[0-9A-Fa-f]+$/.test(value);
+}
+
+function skipRustRegexEscape(matcher: string, index: number): number {
+  const kind = matcher[index + 1];
+  if ((kind === "p" || kind === "P" || kind === "u") && matcher[index + 2] === "{") {
+    const end = matcher.indexOf("}", index + 3);
+    return end >= 0 ? end + 1 : matcher.length;
+  }
+  return index + 2 + (kind === "x" ? 2 : 0);
+}
+
+function isValidRustUnicodeProperty(property: string): boolean {
+  const candidates = [property];
+  const equals = property.indexOf("=");
+  if (equals >= 0) {
+    const name = property.slice(0, equals).toLowerCase();
+    const value = property.slice(equals + 1);
+    const normalizedName = name === "gc" || name === "general_category"
+      ? "General_Category"
+      : name === "sc" || name === "script"
+        ? "Script"
+        : name === "scx" || name === "script_extensions"
+          ? "Script_Extensions"
+          : property.slice(0, equals);
+    candidates.push(`${normalizedName}=${value}`);
+  } else {
+    candidates.push(`Script=${property}`);
+  }
+  return candidates.some((candidate) => {
+    try {
+      new RegExp(`\\p{${candidate}}`, "u");
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function isValidRustRegexEscape(matcher: string, index: number): boolean {
+  const kind = matcher[index + 1];
+  if (!kind) return false;
+  if (RUST_SIMPLE_REGEX_ESCAPES.has(kind) || RUST_ESCAPABLE_REGEX_PUNCTUATION.has(kind)) return true;
+  if (kind === "x") return matcher[index + 3] !== undefined && isHexadecimal(matcher.slice(index + 2, index + 4));
+  if (kind === "u") {
+    if (matcher[index + 2] !== "{") return false;
+    const end = matcher.indexOf("}", index + 3);
+    const codePoint = end >= 0 ? matcher.slice(index + 3, end) : "";
+    if (codePoint.length === 0 || codePoint.length > 6 || !isHexadecimal(codePoint)) return false;
+    const value = Number.parseInt(codePoint, 16);
+    return value <= 0x10ffff && (value < 0xd800 || value > 0xdfff);
+  }
+  if (kind === "p" || kind === "P") {
+    if (matcher[index + 2] !== "{") return false;
+    const end = matcher.indexOf("}", index + 3);
+    return end > index + 3 && isValidRustUnicodeProperty(matcher.slice(index + 3, end));
+  }
+  return false;
+}
+
+
+function normalizeRustMatcherForJavaScriptValidation(matcher: string): string {
+  return matcher
+    .replace(/\\[pP]\{[^}]+\}/g, ".")
+    .replace(/\\u\{([0-9A-Fa-f]{1,6})\}/g, (_match, codePoint: string) =>
+      String.fromCodePoint(Number.parseInt(codePoint, 16)))
+    .replace(/\\A/g, "^")
+    .replace(/\\z/g, "$")
+    .replace(/\\a/g, "\\x07")
+    .replace(/\(\?P<([A-Za-z_][A-Za-z0-9_]*)>/g, "(?<$1>")
+    .replace(
+      /\(\?([imsuUxR]*)(?:-([imsuUxR]+))?([:)])/g,
+      (_match, enabled: string, disabled: string | undefined, terminator: string) =>
+        enabled || disabled ? terminator === ":" ? "(?:" : "" : _match,
+    );
+}
+
+function isValidCodexMatcher(matcher: string): boolean {
+  if (matcher === "*") return true;
+  if (containsRustUnsupportedJavaScriptMatcherSyntax(matcher)) return false;
+  try {
+    new RegExp(normalizeRustMatcherForJavaScriptValidation(matcher));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function commandIsSkipped(command: string): boolean {
+  return command.trim().length === 0;
+}
+
+function containsLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      if (index + 1 >= value.length) return true;
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return true;
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function parseJsonSource(content: string): JsonNode | null {
+  let cursor = 0;
+  let nesting = 0;
+
+  const skipWhitespace = (): void => {
+    while ([" ", "\n", "\r", "\t"].includes(content[cursor] ?? "")) cursor += 1;
+  };
+
+  const parseString = (): JsonStringNode | null => {
+    const start = cursor;
+    if (content[cursor] !== '"') return null;
+    cursor += 1;
+    let escaped = false;
+    while (cursor < content.length) {
+      const char = content[cursor++]!;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        const raw = content.slice(start, cursor);
+        try {
+          const value = JSON.parse(raw) as unknown;
+          if (typeof value !== "string" || containsLoneSurrogate(value)) return null;
+          return { kind: "string", start, end: cursor, raw, value };
+        } catch {
+          return null;
+        }
+      }
+    }
+    return null;
+  };
+
+  const parseValue = (): JsonNode | null => {
+    skipWhitespace();
+    const start = cursor;
+    const current = content[cursor];
+    if (current === "{") {
+      if (nesting >= 128) return null;
+      nesting += 1;
+      try {
+        cursor += 1;
+        skipWhitespace();
+        const properties: JsonProperty[] = [];
+        const value: JsonObject = {};
+        if (content[cursor] === "}") {
+          cursor += 1;
+          return { kind: "object", start, end: cursor, value, properties };
+        }
+        while (cursor < content.length) {
+          skipWhitespace();
+          const keyNode = parseString();
+          if (!keyNode) return null;
+          skipWhitespace();
+          if (content[cursor] !== ":") return null;
+          cursor += 1;
+          const child = parseValue();
+          if (!child) return null;
+          properties.push({ key: keyNode.value, keyNode, value: child });
+          setOwnRecordValue(value, keyNode.value, child.value);
+          skipWhitespace();
+          if (content[cursor] === "}") {
+            cursor += 1;
+            return { kind: "object", start, end: cursor, value, properties };
+          }
+          if (content[cursor] !== ",") return null;
+          cursor += 1;
+        }
+        return null;
+      } finally {
+        nesting -= 1;
+      }
+    }
+    if (current === "[") {
+      if (nesting >= 128) return null;
+      nesting += 1;
+      try {
+        cursor += 1;
+        skipWhitespace();
+        const elements: JsonNode[] = [];
+        const value: JsonArray = [];
+        if (content[cursor] === "]") {
+          cursor += 1;
+          return { kind: "array", start, end: cursor, value, elements };
+        }
+        while (cursor < content.length) {
+          const child = parseValue();
+          if (!child) return null;
+          elements.push(child);
+          value.push(child.value);
+          skipWhitespace();
+          if (content[cursor] === "]") {
+            cursor += 1;
+            return { kind: "array", start, end: cursor, value, elements };
+          }
+          if (content[cursor] !== ",") return null;
+          cursor += 1;
+        }
+        return null;
+      } finally {
+        nesting -= 1;
+      }
+    }
+    if (current === '"') return parseString();
+    if (content.startsWith("true", cursor)) {
+      cursor += 4;
+      return { kind: "boolean", start, end: cursor, raw: "true", value: true };
+    }
+    if (content.startsWith("false", cursor)) {
+      cursor += 5;
+      return { kind: "boolean", start, end: cursor, raw: "false", value: false };
+    }
+    if (content.startsWith("null", cursor)) {
+      cursor += 4;
+      return { kind: "null", start, end: cursor, raw: "null", value: null };
+    }
+    const number = /-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/.exec(content.slice(cursor));
+    if (!number || number.index !== 0) return null;
+    const value = Number(number[0]);
+    if (!Number.isFinite(value)) return null;
+    cursor += number[0].length;
+    return {
+      kind: "number",
+      start,
+      end: cursor,
+      raw: number[0],
+      value,
+    };
+  };
+
+  const root = parseValue();
+  skipWhitespace();
+  return root && cursor === content.length ? root : null;
+}
+
+function objectProperty(node: JsonObjectNode, key: string): JsonProperty | undefined {
+  return node.properties.find((property) => property.key === key);
+}
+
+function duplicateKnownProperty(node: JsonObjectNode, known: ReadonlySet<string>): string | undefined {
+  const seen = new Set<string>();
+  for (const property of node.properties) {
+    if (!known.has(property.key)) continue;
+    if (seen.has(property.key)) return property.key;
+    seen.add(property.key);
+  }
+  return undefined;
+}
+
+function stringProperty(node: JsonObjectNode, key: string): string | undefined {
+  const property = objectProperty(node, key);
+  return property?.value.kind === "string" ? property.value.value : undefined;
+}
+
+function nullableStringProperty(node: JsonObjectNode, key: string): string | null | undefined {
+  const property = objectProperty(node, key);
+  if (!property) return undefined;
+  if (property.value.kind === "null") return null;
+  return property.value.kind === "string" ? property.value.value : undefined;
+}
+
+function effectiveCommandForPlatform(
+  handler: JsonObjectNode,
+  platform: HookCommandPlatform,
+): string {
+  const command = stringProperty(handler, "command")!;
+  if (platform !== "win32") return command;
+  const windows = nullableStringProperty(handler, "commandWindows") ??
+    nullableStringProperty(handler, "command_windows");
+  return windows === undefined || windows === null ? command : windows;
+}
+
+function isU64Node(node: JsonNode): boolean {
+  if (node.kind !== "number" || !/^(?:0|[1-9]\d*)$/.test(node.raw)) return false;
+  const maximum = "18446744073709551615";
+  return node.raw.length < maximum.length ||
+    (node.raw.length === maximum.length && node.raw <= maximum);
+}
+
+function validateCommandHandler(
+  node: JsonObjectNode,
+  eventName: CodexHookEventName,
+  groupIndex: number,
+  handlerIndex: number,
+): ManagedCodexHooksPlanError | null {
+  const duplicate = duplicateKnownProperty(node, KNOWN_COMMAND_FIELDS);
+  if (duplicate) {
+    return planError("invalid_document", `Duplicate command hook field ${duplicate}.`, {
+      eventName,
+      groupIndex,
+      handlerIndex,
+    });
+  }
+  if (stringProperty(node, "command") === undefined) {
+    return planError("invalid_document", "Command hooks require a string command.", {
+      eventName,
+      groupIndex,
+      handlerIndex,
+    });
+  }
+  const windows = objectProperty(node, "commandWindows");
+  const windowsAlias = objectProperty(node, "command_windows");
+  if (windows && windowsAlias) {
+    return planError("invalid_document", "Command hook Windows aliases cannot both be present.", {
+      eventName,
+      groupIndex,
+      handlerIndex,
+    });
+  }
+  for (const property of [windows, windowsAlias]) {
+    if (property && property.value.kind !== "string" && property.value.kind !== "null") {
+      return planError("invalid_document", "Command hook Windows command must be a string or null.", {
+        eventName,
+        groupIndex,
+        handlerIndex,
+      });
+    }
+  }
+  const timeout = objectProperty(node, "timeout");
+  if (timeout && timeout.value.kind !== "null" && !isU64Node(timeout.value)) {
+    return planError("invalid_document", "Command hook timeout must be an unsigned 64-bit integer or null.", {
+      eventName,
+      groupIndex,
+      handlerIndex,
+    });
+  }
+  const asynchronous = objectProperty(node, "async");
+  if (asynchronous && asynchronous.value.kind !== "boolean") {
+    return planError("invalid_document", "Command hook async must be a boolean.", {
+      eventName,
+      groupIndex,
+      handlerIndex,
+    });
+  }
+  const status = objectProperty(node, "statusMessage");
+  if (status && status.value.kind !== "string" && status.value.kind !== "null") {
+    return planError("invalid_document", "Command hook statusMessage must be a string or null.", {
+      eventName,
+      groupIndex,
+      handlerIndex,
+    });
+  }
+  return null;
+}
+
+interface StrictDocument {
+  content: string;
+  rootNode: JsonObjectNode;
+  hooksNode?: JsonObjectNode;
+  result: ValidCodexHooksConfigStrict;
+}
+
+function validateCodexHooksDocument(
   content: string,
-): ParsedCodexHooksConfig | null {
+  options: ManagedCodexHookOptions = {},
+): StrictDocument | InvalidCodexHooksConfigStrict {
+  const root = parseJsonSource(content);
+  if (!root || root.kind !== "object") {
+    return { ok: false, error: planError("invalid_document", "hooks.json must contain a JSON object.") };
+  }
+  const duplicateRoot = duplicateKnownProperty(root, KNOWN_ROOT_FIELDS);
+  if (duplicateRoot) {
+    return { ok: false, error: planError("invalid_document", `Duplicate root field ${duplicateRoot}.`) };
+  }
+  const rootUnknown = root.properties.find((property) => !KNOWN_ROOT_FIELDS.has(property.key));
+  if (rootUnknown) {
+    return {
+      ok: false,
+      error: planError("invalid_document", `Codex does not accept unknown root field ${rootUnknown.key}.`),
+    };
+  }
+
+  const hooksProperty = objectProperty(root, "hooks");
+  if (hooksProperty && hooksProperty.value.kind !== "object") {
+    return { ok: false, error: planError("invalid_document", "Root hooks must be an object when present.") };
+  }
+  const hooksNode = hooksProperty?.value.kind === "object" ? hooksProperty.value : undefined;
+  const duplicateEvent = hooksNode && duplicateKnownProperty(hooksNode, KNOWN_HOOK_EVENT_FIELDS);
+  if (duplicateEvent) {
+    return { ok: false, error: planError("invalid_document", `Duplicate hooks event ${duplicateEvent}.`) };
+  }
+  const diagnostics: CodexHooksDiagnostic[] = [];
+  const groupOccurrences: CodexHookGroupOccurrence[] = [];
+  const handlerOccurrences: CodexHookHandlerOccurrence[] = [];
+  const discoveredCommands: CodexHookDiscoveryCommand[] = [];
+  const platform = options.platform ?? process.platform;
+
+  for (const eventName of CODEX_HOOK_EVENTS) {
+    const eventProperty = hooksNode ? objectProperty(hooksNode, eventName) : undefined;
+    if (!eventProperty) continue;
+    if (eventProperty.value.kind !== "array") {
+      return {
+        ok: false,
+        error: planError("invalid_document", `${eventName} must be an array of matcher groups.`, { eventName }),
+      };
+    }
+    for (const [groupIndex, groupNode] of eventProperty.value.elements.entries()) {
+      if (groupNode.kind !== "object") {
+        return {
+          ok: false,
+          error: planError("invalid_document", "Hook matcher groups must be objects.", { eventName, groupIndex }),
+        };
+      }
+      groupOccurrences.push({ eventName, groupIndex, span: groupNode });
+      const duplicate = duplicateKnownProperty(groupNode, KNOWN_GROUP_FIELDS);
+      if (duplicate) {
+        return {
+          ok: false,
+          error: planError("invalid_document", `Duplicate matcher group field ${duplicate}.`, { eventName, groupIndex }),
+        };
+      }
+      const matcher = objectProperty(groupNode, "matcher");
+      if (matcher && matcher.value.kind !== "string" && matcher.value.kind !== "null") {
+        return {
+          ok: false,
+          error: planError("invalid_document", "Hook matcher must be a string or null.", { eventName, groupIndex }),
+        };
+      }
+      const hooks = objectProperty(groupNode, "hooks");
+      if (hooks && hooks.value.kind !== "array") {
+        return {
+          ok: false,
+          error: planError("invalid_document", "Matcher group hooks must be an array when present.", { eventName, groupIndex }),
+        };
+      }
+      const invalidMatcher =
+        matcherIsAware(eventName) && matcher?.value.kind === "string" &&
+        !isValidCodexMatcher(matcher.value.value);
+      if (invalidMatcher) {
+        diagnostics.push({
+          code: "invalid_matcher",
+          eventName,
+          groupIndex,
+          message: "Codex skips groups whose matcher is not a valid regular expression.",
+        });
+      }
+      const handlers = hooks?.value.kind === "array" ? hooks.value.elements : [];
+      for (const [handlerIndex, handlerNode] of handlers.entries()) {
+        handlerOccurrences.push({ eventName, groupIndex, handlerIndex, span: handlerNode });
+        if (handlerNode.kind !== "object") {
+          return {
+            ok: false,
+            error: planError("invalid_document", "Hook handlers must be objects.", { eventName, groupIndex, handlerIndex }),
+          };
+        }
+        const duplicateType = duplicateKnownProperty(handlerNode, KNOWN_HANDLER_TYPE_FIELD);
+        if (duplicateType) {
+          return {
+            ok: false,
+            error: planError("invalid_document", "Duplicate hook handler type field.", { eventName, groupIndex, handlerIndex }),
+          };
+        }
+        const type = stringProperty(handlerNode, "type");
+        if (type !== "command" && type !== "prompt" && type !== "agent") {
+          return {
+            ok: false,
+            error: planError("invalid_document", "Hook handler type must be command, prompt, or agent.", {
+              eventName,
+              groupIndex,
+              handlerIndex,
+            }),
+          };
+        }
+        if (type !== "command") {
+          diagnostics.push({
+            code: "unsupported_handler",
+            eventName,
+            groupIndex,
+            handlerIndex,
+            message: `Codex preserves but does not discover ${type} hook handlers.`,
+          });
+          continue;
+        }
+        const commandError = validateCommandHandler(handlerNode, eventName, groupIndex, handlerIndex);
+        if (commandError) return { ok: false, error: commandError };
+        const command = effectiveCommandForPlatform(handlerNode, platform);
+        const asyncProperty = objectProperty(handlerNode, "async");
+        const asynchronous = asyncProperty?.value.kind === "boolean" &&
+          asyncProperty.value.value === true;
+        if (asynchronous) {
+          diagnostics.push({
+            code: "async_command",
+            eventName,
+            groupIndex,
+            handlerIndex,
+            message: "Codex skips async command hook handlers.",
+          });
+        } else if (commandIsSkipped(command)) {
+          diagnostics.push({
+            code: "empty_command",
+            eventName,
+            groupIndex,
+            handlerIndex,
+            message: "Codex skips empty command hook handlers.",
+          });
+        } else if (!invalidMatcher) {
+          discoveredCommands.push({ eventName, groupIndex, handlerIndex, command });
+        }
+      }
+    }
+  }
+
+  return {
+    content,
+    rootNode: root,
+    hooksNode,
+    result: {
+      ok: true,
+      root: cloneJson(root.value),
+      diagnostics,
+      groupOccurrences,
+      handlerOccurrences,
+      discoveredCommands,
+    },
+  };
+}
+
+export function validateCodexHooksConfigStrict(
+  content: string,
+  options: ManagedCodexHookOptions = {},
+): CodexHooksConfigStrictResult {
+  const result = validateCodexHooksDocument(content, options);
+  return "result" in result ? result.result : result;
+}
+
+/** Compatibility-only permissive JSON intake; strict plans never use this parser. */
+export function parseCodexHooksConfig(content: string): ParsedCodexHooksConfig | null {
   try {
     const parsed = JSON.parse(content) as unknown;
     if (!isPlainObject(parsed)) return null;
-
     return {
       root: cloneJson(parsed),
       hooks: isPlainObject(parsed.hooks) ? cloneJson(parsed.hooks) : {},
@@ -300,144 +1251,530 @@ export function parseCodexHooksConfig(
   }
 }
 
-function isOmxManagedHookCommand(command: string): boolean {
-  return /(?:^|[\\/])codex-native-hook\.js(?:["'\s]|$)/.test(command)
-    || /(?:^|[\\/])omx-native-hook-windows-shim\.ps1(?:["'\s]|$)/i.test(command);
+const UNQUOTED_POSIX_SHELL_ACTIVE_CHARACTERS = new Set([
+  "\r", "\n", ";", "|", "&", "<", ">", "`", "$", "(", ")", "*", "?", "[", "]", "{", "}", "~", "!", "#",
+]);
+const UNQUOTED_POWERSHELL_ACTIVE_CHARACTERS = new Set([
+  "\r", "\n", ";", "|", "<", ">", "`", "$", "(", ")", "*", "?", "[", "]", "{", "}", "~", "!", "#", "@", "%", "^",
+]);
+
+function isShellWhitespace(character: string): boolean {
+  return character === " " || character === "\t" || character === "\r" || character === "\n";
 }
 
-function countManagedHooksInEntry(entry: unknown): number {
-  if (!isPlainObject(entry) || !Array.isArray(entry.hooks)) {
-    return 0;
-  }
-
-  return entry.hooks.filter((hook) => {
-    return isPlainObject(hook)
-      && hook.type === "command"
-      && typeof hook.command === "string"
-      && isOmxManagedHookCommand(hook.command);
-  }).length;
-}
-
-export function getMissingManagedCodexHookEvents(
-  content: string,
-): ManagedHookEventName[] | null {
-  const parsed = parseCodexHooksConfig(content);
-  if (!parsed) return null;
-
-  return MANAGED_HOOK_EVENTS.filter((eventName) => {
-    const entries = Array.isArray(parsed.hooks[eventName])
-      ? parsed.hooks[eventName]
-      : [];
-    return !entries.some((entry) => countManagedHooksInEntry(entry) > 0);
-  });
-}
-
-export function getManagedCodexHookCommandsForEvent(
-  content: string,
-  eventName: ManagedHookEventName,
+/**
+ * Decode only shell-static POSIX words. The decoder preserves enough quote and
+ * escape provenance to reject interpolation and shell-active syntax instead of
+ * merely comparing the decoded argument values.
+ */
+function tokenizePosixCommand(
+  command: string,
+  preserveWindowsBackslashes = false,
 ): string[] | null {
-  const parsed = parseCodexHooksConfig(content);
-  if (!parsed) return null;
+  const words: string[] = [];
+  let word = "";
+  let tokenStarted = false;
+  let quote: "'" | '"' | undefined;
 
-  const entries = Array.isArray(parsed.hooks[eventName])
-    ? parsed.hooks[eventName]
-    : [];
-  const commands: string[] = [];
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index]!;
+    if (quote === "'") {
+      if (character === "'") quote = undefined;
+      else word += character;
+      continue;
+    }
+    if (quote === '"') {
+      if (character === '"') {
+        quote = undefined;
+      } else if (character === "$" || character === "`") {
+        return null;
+      } else if (character === "\\" && !preserveWindowsBackslashes) {
+        const escaped = command[index + 1];
+        if (!escaped || escaped === "\r" || escaped === "\n") return null;
+        if (["$", "`", '"', "\\"].includes(escaped)) {
+          word += escaped;
+          index += 1;
+        } else {
+          // POSIX preserves a backslash in double quotes unless it quotes a
+          // shell-active character. Keep it so suffix comparisons are exact.
+          word += "\\";
+        }
+      } else {
+        word += character;
+      }
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      tokenStarted = true;
+      continue;
+    }
+    if (UNQUOTED_POSIX_SHELL_ACTIVE_CHARACTERS.has(character)) return null;
+    if (character === "\\" && !preserveWindowsBackslashes) {
+      const escaped = command[index + 1];
+      if (!escaped || escaped === "\r" || escaped === "\n") return null;
+      word += escaped;
+      tokenStarted = true;
+      index += 1;
+      continue;
+    }
+    if (isShellWhitespace(character)) {
+      if (tokenStarted) {
+        words.push(word);
+        word = "";
+        tokenStarted = false;
+      }
+      continue;
+    }
+    word += character;
+    tokenStarted = true;
+  }
+  if (quote) return null;
+  if (tokenStarted) words.push(word);
+  return words.length > 0 ? words : null;
+}
 
-  for (const entry of entries) {
-    if (!isPlainObject(entry) || !Array.isArray(entry.hooks)) continue;
-    for (const hook of entry.hooks) {
+/** Decode only literal PowerShell command words; interpolation is never owned. */
+function tokenizePowerShellCommand(command: string): string[] | null {
+  const words: string[] = [];
+  let word = "";
+  let tokenStarted = false;
+  let quote: "'" | '"' | undefined;
+  let callOperatorSeen = false;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index]!;
+    if (quote === "'") {
+      if (character !== "'") {
+        word += character;
+        continue;
+      }
+      if (command[index + 1] === "'") {
+        word += "'";
+        index += 1;
+        continue;
+      }
+      quote = undefined;
+      continue;
+    }
+    if (quote === '"') {
+      if (character === '"') {
+        quote = undefined;
+      } else if (character === "$" || character === "`") {
+        return null;
+      } else {
+        word += character;
+      }
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      tokenStarted = true;
+      continue;
+    }
+    if (character === "&") {
       if (
-        isPlainObject(hook) &&
-        hook.type === "command" &&
-        typeof hook.command === "string" &&
-        isOmxManagedHookCommand(hook.command)
-      ) {
-        commands.push(hook.command);
+        callOperatorSeen ||
+        tokenStarted ||
+        words.length > 0 ||
+        !isShellWhitespace(command[index + 1] ?? "")
+      ) return null;
+      callOperatorSeen = true;
+      continue;
+    }
+    if (UNQUOTED_POWERSHELL_ACTIVE_CHARACTERS.has(character)) return null;
+    if (isShellWhitespace(character)) {
+      if (tokenStarted) {
+        words.push(word);
+        word = "";
+        tokenStarted = false;
+      }
+      continue;
+    }
+    word += character;
+    tokenStarted = true;
+  }
+  if (quote) return null;
+  if (tokenStarted) words.push(word);
+  return words.length > 0 ? words : null;
+}
+
+function commandBasename(path: string, platform: HookCommandPlatform): string {
+  const executable = platform === "win32"
+    ? path.split(/[\\/]/).pop()
+    : path.split("/").pop();
+  return platform === "win32" ? executable?.toLowerCase() ?? "" : executable ?? "";
+}
+
+function isNativeHookScriptPath(path: string, platform: HookCommandPlatform): boolean {
+  return platform === "win32"
+    ? /(?:^|[\\/])dist[\\/]scripts[\\/]codex-native-hook\.js$/i.test(path)
+    : /(?:^|\/)dist\/scripts\/codex-native-hook\.js$/.test(path);
+}
+
+function isNativeHookShimPath(path: string): boolean {
+  return /(?:^|[\\/])hooks[\\/]omx-native-hook-windows-shim\.ps1$/i.test(path);
+}
+
+function isValidDirectNodeCommand(command: string, platform: HookCommandPlatform): boolean {
+  const words = tokenizePosixCommand(command, platform === "win32");
+  const executable = words?.[0] === undefined ? "" : commandBasename(words[0], platform);
+  return words?.length === 2 &&
+    (platform === "win32" ? executable === "node" || executable === "node.exe" : executable === "node") &&
+    isNativeHookScriptPath(words[1]!, platform);
+}
+
+/**
+ * Parse an OMX Windows shim invocation using the managed-command ownership
+ * grammar. Returns the validated shim path; returns null for every other
+ * command.
+ */
+export function parseManagedCodexNativeHookWindowsShimCommand(command: string): string | null {
+  const words = tokenizePowerShellCommand(command);
+  if (!words) return null;
+  const shimPath = words[5];
+  return words.length === 6 &&
+    commandBasename(words[0]!, "win32") === "powershell.exe" &&
+    words[1]?.toLowerCase() === "-noprofile" &&
+    words[2]?.toLowerCase() === "-executionpolicy" &&
+    words[3]?.toLowerCase() === "bypass" &&
+    words[4]?.toLowerCase() === "-file" &&
+    shimPath !== undefined &&
+    isNativeHookShimPath(shimPath)
+    ? shimPath
+    : null;
+}
+
+function isValidWindowsShimCommand(command: string): boolean {
+  return parseManagedCodexNativeHookWindowsShimCommand(command) !== null;
+}
+
+function commandMentionsOmx(command: string): boolean {
+  return /(?:codex-native-hook\.js|omx-native-hook-windows-shim\.ps1)/i.test(command);
+}
+
+function isValidManagedCommand(command: string, platform: HookCommandPlatform): boolean {
+  return isValidDirectNodeCommand(command, platform) ||
+    (platform === "win32" && isValidWindowsShimCommand(command));
+}
+
+function isValidHistoricalManagedCommand(command: string): boolean {
+  return isValidDirectNodeCommand(command, "linux") ||
+    isValidDirectNodeCommand(command, "win32") ||
+    isValidWindowsShimCommand(command);
+}
+
+/**
+ * Returns whether a command has the exact approved token grammar of an OMX
+ * native hook from this or a historical installation. Ownership intentionally
+ * depends on the executable and terminal script/shim suffixes, never a current
+ * package-root path. The union is deliberately narrow and accepts only
+ * shell-static POSIX, Windows, or PowerShell command spellings.
+ */
+export function isManagedCodexHookCommand(command: string): boolean {
+  return isValidHistoricalManagedCommand(command);
+}
+
+type ManagedCommandClassification = "owned" | "foreign" | "ambiguous";
+
+function classifyManagedCommand(
+  handler: JsonObjectNode,
+  options: ManagedCodexHookOptions,
+): ManagedCommandClassification {
+  const command = stringProperty(handler, "command")!;
+  const windows = nullableStringProperty(handler, "commandWindows") ??
+    nullableStringProperty(handler, "command_windows");
+  const platform = options.platform ?? process.platform;
+  const effective = effectiveCommandForPlatform(handler, platform);
+  const supplied = [command, windows].filter((value): value is string => typeof value === "string");
+  const effectiveOwned = isValidManagedCommand(effective, platform);
+  if (effectiveOwned) {
+    for (const suppliedCommand of supplied) {
+      if (suppliedCommand === effective) continue;
+      if (!isManagedCodexHookCommand(suppliedCommand)) {
+        return "ambiguous";
+      }
+    }
+    return "owned";
+  }
+  return supplied.some(commandMentionsOmx) ? "ambiguous" : "foreign";
+}
+
+interface ManagedOwner {
+  eventName: ManagedHookEventName;
+  groupIndex: number;
+  handlerIndex: number;
+  groupNode: JsonObjectNode;
+  handlerNode: JsonObjectNode;
+  opaqueHandler: boolean;
+}
+
+interface RawHandlerModel {
+  node: JsonObjectNode;
+  owner?: ManagedOwner;
+  foreign: boolean;
+  discoverySkipped?: boolean;
+}
+
+interface RawGroupModel {
+  eventName: CodexHookEventName;
+  groupIndex: number;
+  node: JsonObjectNode;
+  handlers: RawHandlerModel[];
+  opaque: boolean;
+  foreign: boolean;
+}
+
+interface OwnershipModel {
+  owners: ManagedOwner[];
+  groups: RawGroupModel[];
+}
+
+function hasOpaqueProperties(node: JsonObjectNode, known: ReadonlySet<string>): boolean {
+  return node.properties.some((property) => !known.has(property.key));
+}
+
+function groupMatcher(node: JsonObjectNode): string | undefined {
+  return stringProperty(node, "matcher");
+}
+
+function matcherOwnershipError(
+  eventName: ManagedHookEventName,
+  group: RawGroupModel,
+): ManagedCodexHooksPlanError | null {
+  const matcher = groupMatcher(group.node);
+  if (matcherIsAware(eventName) && matcher !== undefined && !isValidCodexMatcher(matcher)) {
+    return planError("ambiguous_managed_group", "Cannot mutate an OMX group with an invalid matcher.", {
+      eventName,
+      groupIndex: group.groupIndex,
+    });
+  }
+  const foreignSiblings = group.handlers.some((handler) => !handler.owner);
+  if (eventName === "SessionStart") {
+    const allowed = foreignSiblings
+      ? matcher === "startup|resume|clear"
+      : matcher === undefined || matcher === "startup" || matcher === "startup|resume" || matcher === "startup|resume|clear";
+    if (!allowed) {
+      return planError("ambiguous_managed_group", "SessionStart matcher is not compatible with OMX ownership.", {
+        eventName,
+        groupIndex: group.groupIndex,
+      });
+    }
+  } else if (matcher !== undefined) {
+    return planError("ambiguous_managed_group", "OMX managed groups must not carry a matcher for this event.", {
+      eventName,
+      groupIndex: group.groupIndex,
+    });
+  }
+  return null;
+}
+
+function inspectOwnership(
+  document: StrictDocument,
+  options: ManagedCodexHookOptions,
+): OwnershipModel | ManagedCodexHooksPlanError {
+  const groups: RawGroupModel[] = [];
+  const owners: ManagedOwner[] = [];
+  for (const eventName of CODEX_HOOK_EVENTS) {
+    const event = document.hooksNode ? objectProperty(document.hooksNode, eventName) : undefined;
+    if (!event || event.value.kind !== "array") continue;
+    for (const [groupIndex, groupNode] of event.value.elements.entries()) {
+      if (groupNode.kind !== "object") continue;
+      const hooks = objectProperty(groupNode, "hooks");
+      const handlerNodes = hooks?.value.kind === "array" ? hooks.value.elements : [];
+      const handlers: RawHandlerModel[] = [];
+      for (const [handlerIndex, handlerNode] of handlerNodes.entries()) {
+        if (handlerNode.kind !== "object") continue;
+        const type = stringProperty(handlerNode, "type");
+        let classification: ManagedCommandClassification = "foreign";
+        if (type === "command") classification = classifyManagedCommand(handlerNode, options);
+        if (classification === "ambiguous") {
+          return planError("ambiguous_managed_handler", "A command mentions OMX but does not match the managed command grammar.", {
+            eventName,
+            groupIndex,
+            handlerIndex,
+          });
+        }
+        const asyncProperty = type === "command"
+          ? objectProperty(handlerNode, "async")
+          : undefined;
+        const asynchronous = asyncProperty?.value.kind === "boolean" &&
+          asyncProperty.value.value === true;
+        if (classification !== "owned" || !isManagedHookEventName(eventName)) {
+          if (classification === "owned") {
+            return planError("ambiguous_managed_handler", "An OMX command is attached to an unmanaged Codex event.", {
+              eventName,
+              groupIndex,
+              handlerIndex,
+            });
+          }
+          const foreignCommandIsSkipped = type === "command" && (
+            commandIsSkipped(effectiveCommandForPlatform(handlerNode, options.platform ?? process.platform)) || asynchronous
+          );
+          handlers.push({ node: handlerNode, foreign: true, discoverySkipped: foreignCommandIsSkipped });
+          continue;
+        }
+        const command = effectiveCommandForPlatform(handlerNode, options.platform ?? process.platform);
+        if (asynchronous || commandIsSkipped(command)) {
+          return planError("ambiguous_managed_handler", "Cannot mutate skipped OMX command handlers.", {
+            eventName,
+            groupIndex,
+            handlerIndex,
+          });
+        }
+        const owner: ManagedOwner = {
+          eventName,
+          groupIndex,
+          handlerIndex,
+          groupNode,
+          handlerNode,
+          opaqueHandler: hasOpaqueProperties(handlerNode, KNOWN_COMMAND_FIELDS),
+        };
+        owners.push(owner);
+        handlers.push({ node: handlerNode, owner, foreign: false });
+      }
+      const group: RawGroupModel = {
+        eventName,
+        groupIndex,
+        node: groupNode,
+        handlers,
+        opaque: hasOpaqueProperties(groupNode, KNOWN_GROUP_FIELDS),
+        foreign: false,
+      };
+      group.foreign = handlers.length === 0 || handlers.some((handler) => handler.foreign);
+      groups.push(group);
+      const groupOwners = handlers.flatMap((handler) => handler.owner ? [handler.owner] : []);
+      if (groupOwners.length > 0) {
+        if (handlers.some((handler) => handler.discoverySkipped)) {
+          return planError("ambiguous_managed_handler", "Cannot mutate an OMX group that also contains a skipped command handler.", {
+            eventName,
+            groupIndex,
+          });
+        }
+        const error = matcherOwnershipError(eventName as ManagedHookEventName, group);
+        if (error) return error;
       }
     }
   }
-
-  return commands;
+  return { owners, groups };
 }
 
-function stripManagedHooksFromEntry(entry: unknown): {
-  entry: unknown | null;
-  removedCount: number;
-} {
-  if (!isPlainObject(entry) || !Array.isArray(entry.hooks)) {
-    return { entry: cloneJson(entry), removedCount: 0 };
+interface SourcePatch extends SourceSpan {
+  text: string;
+}
+
+function applySourcePatches(content: string, patches: SourcePatch[]): string {
+  const ordered = [...patches].sort((left, right) => left.start - right.start || left.end - right.end);
+  for (let index = 1; index < ordered.length; index += 1) {
+    if (ordered[index - 1]!.end > ordered[index]!.start) {
+      throw new Error("Overlapping source patches are not permitted.");
+    }
+  }
+  let result = content;
+  for (const patch of ordered.reverse()) {
+    result = result.slice(0, patch.start) + patch.text + result.slice(patch.end);
+  }
+  return result;
+}
+
+function propertyRemovalPatch(object: JsonObjectNode, property: JsonProperty): SourcePatch {
+  if (object.properties.length === 1) {
+    return { start: object.start + 1, end: object.end - 1, text: "" };
+  }
+  const index = object.properties.indexOf(property);
+  if (index < object.properties.length - 1) {
+    return { start: property.keyNode.start, end: object.properties[index + 1]!.keyNode.start, text: "" };
+  }
+  return { start: object.properties[index - 1]!.value.end, end: property.value.end, text: "" };
+}
+
+
+function appendObjectPropertyPatch(object: JsonObjectNode, key: string, value: string): SourcePatch {
+  const prefix = object.properties.length === 0 ? "" : ",";
+  return { start: object.end - 1, end: object.end - 1, text: `${prefix}${JSON.stringify(key)}:${value}` };
+}
+
+function appendObjectPropertiesPatch(
+  object: JsonObjectNode,
+  entries: ReadonlyArray<readonly [string, string]>,
+): SourcePatch {
+  const prefix = object.properties.length === 0 ? "" : ",";
+  const text = entries
+    .map(([key, value]) => `${JSON.stringify(key)}:${value}`)
+    .join(",");
+  return { start: object.end - 1, end: object.end - 1, text: `${prefix}${text}` };
+}
+
+
+function appendArrayElementPatch(array: JsonArrayNode, value: string): SourcePatch {
+  const prefix = array.elements.length === 0 ? "" : ",";
+  return { start: array.end - 1, end: array.end - 1, text: `${prefix}${value}` };
+}
+
+function knownFieldPatches(
+  content: string,
+  node: JsonObjectNode,
+  desired: Record<string, unknown>,
+  known: ReadonlySet<string>,
+): SourcePatch[] {
+  const removedProperties = node.properties.filter((property) =>
+    known.has(property.key) && !Object.hasOwn(desired, property.key)
+  );
+  if (removedProperties.length > 1) {
+    const members = node.properties.flatMap((property) => {
+      if (!known.has(property.key)) return [content.slice(property.keyNode.start, property.value.end)];
+      if (!Object.hasOwn(desired, property.key)) return [];
+      return [`${JSON.stringify(property.key)}:${JSON.stringify(desired[property.key])}`];
+    });
+    for (const [key, value] of Object.entries(desired)) {
+      if (!objectProperty(node, key)) members.push(`${JSON.stringify(key)}:${JSON.stringify(value)}`);
+    }
+    return [{ start: node.start, end: node.end, text: `{${members.join(",")}}` }];
   }
 
-  const nextHooks = entry.hooks.filter((hook) => {
-    if (!isPlainObject(hook)) return true;
-    return !(
-      hook.type === "command" &&
-      typeof hook.command === "string" &&
-      isOmxManagedHookCommand(hook.command)
-    );
-  });
-
-  const removedCount = entry.hooks.length - nextHooks.length;
-  if (removedCount === 0) {
-    return { entry: cloneJson(entry), removedCount: 0 };
+  const patches: SourcePatch[] = [];
+  for (const property of node.properties) {
+    if (!known.has(property.key)) continue;
+    if (Object.hasOwn(desired, property.key)) {
+      patches.push({
+        start: property.value.start,
+        end: property.value.end,
+        text: JSON.stringify(desired[property.key]),
+      });
+    } else {
+      patches.push(propertyRemovalPatch(node, property));
+    }
   }
-
-  if (nextHooks.length === 0) {
-    return { entry: null, removedCount };
+  for (const [key, value] of Object.entries(desired)) {
+    if (!objectProperty(node, key)) patches.push(appendObjectPropertyPatch(node, key, JSON.stringify(value)));
   }
-
-  return {
-    entry: {
-      ...cloneJson(entry),
-      hooks: nextHooks,
-    },
-    removedCount,
-  };
+  return patches;
 }
 
 function serializeCodexHooksConfig(root: JsonObject): string {
   return JSON.stringify(root, null, 2) + "\n";
 }
 
-function canonicalJson(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map((item) => canonicalJson(item));
-  }
+class CanonicalJsonNumber {
+  constructor(readonly raw: string) {}
+}
+
+function canonicalJsonString(value: unknown): string {
+  if (value instanceof CanonicalJsonNumber) return value.raw;
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalJsonString(item)).join(",")}]`;
   if (isPlainObject(value)) {
-    return Object.fromEntries(
-      Object.keys(value)
-        .sort()
-        .map((key) => [key, canonicalJson(value[key])]),
-    );
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJsonString(value[key])}`)
+      .join(",")}}`;
   }
-  return value;
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) throw new TypeError("Codex hook trust identity must be JSON-serializable.");
+  return serialized;
 }
 
-function versionForCodexTomlIdentity(value: JsonObject): string {
-  const canonical = canonicalJson(value);
-  const serialized = JSON.stringify(canonical);
-  return `sha256:${createHash("sha256").update(serialized).digest("hex")}`;
-}
-
-function normalizedCommandHookIdentity(
-  eventName: ManagedHookEventName,
-  entry: ManagedHookEntry,
-  hook: ManagedHookEntry["hooks"][number],
-): JsonObject {
-  return {
-    event_name: CODEX_HOOK_EVENT_LABELS[eventName],
-    ...(entry.matcher ? { matcher: entry.matcher } : {}),
-    hooks: [
-      {
-        type: "command",
-        command: hook.command,
-        timeout: Math.max(1, hook.timeout ?? 600),
-        async: false,
-        ...(hook.statusMessage ? { statusMessage: hook.statusMessage } : {}),
-      },
-    ],
-  };
+function versionForCodexTomlIdentity(value: unknown): string {
+  return `sha256:${createHash("sha256").update(canonicalJsonString(value)).digest("hex")}`;
 }
 
 function managedHookStateKey(
@@ -449,42 +1786,640 @@ function managedHookStateKey(
   return `${hooksPath}:${CODEX_HOOK_EVENT_LABELS[eventName]}:${groupIndex}:${handlerIndex}`;
 }
 
+function canonicalHookForEvent(entry: ManagedHookEntry): Record<string, unknown> {
+  const hook = entry.hooks[0]!;
+  return {
+    type: "command",
+    command: hook.command,
+    ...(typeof hook.timeout === "number" ? { timeout: hook.timeout } : {}),
+  };
+}
+
+function canonicalGroupForEvent(entry: ManagedHookEntry): Record<string, unknown> {
+  return {
+    ...(entry.matcher ? { matcher: entry.matcher } : {}),
+    hooks: [canonicalHookForEvent(entry)],
+  };
+}
+
+function canonicalMatcherForEvent(entry: ManagedHookEntry): Record<string, unknown> {
+  return entry.matcher ? { matcher: entry.matcher } : {};
+}
+
+function removesAllGroupHandlers(
+  group: RawGroupModel,
+  ownersToRemove: ReadonlySet<ManagedOwner>,
+): boolean {
+  return group.handlers.length > 0 &&
+    group.handlers.every((handler) => handler.owner && ownersToRemove.has(handler.owner));
+}
+
+function removalProof(
+  model: OwnershipModel,
+  ownersToRemove: ReadonlySet<ManagedOwner>,
+): ManagedCodexHooksCoordinateProof {
+  for (const group of model.groups) {
+    if (group.opaque && removesAllGroupHandlers(group, ownersToRemove)) {
+      return {
+        safe: false,
+        shifted: {
+          kind: "group",
+          eventName: group.eventName,
+          oldCoordinate: [group.groupIndex],
+        },
+      };
+    }
+  }
+  for (const owner of ownersToRemove) {
+    if (owner.opaqueHandler) {
+      return {
+        safe: false,
+        shifted: {
+          kind: "handler",
+          eventName: owner.eventName,
+          oldCoordinate: [owner.groupIndex, owner.handlerIndex],
+        },
+      };
+    }
+  }
+
+  const byEvent = new Map<CodexHookEventName, RawGroupModel[]>();
+  for (const group of model.groups) {
+    const eventGroups = byEvent.get(group.eventName) ?? [];
+    eventGroups.push(group);
+    byEvent.set(group.eventName, eventGroups);
+  }
+  for (const [eventName, groups] of byEvent) {
+    const removedGroups = new Set<RawGroupModel>();
+    for (const group of groups) {
+      if (!group.opaque && removesAllGroupHandlers(group, ownersToRemove)) {
+        removedGroups.add(group);
+      }
+    }
+    const survivors = groups.filter((group) => !removedGroups.has(group));
+    for (const group of groups) {
+      const newGroupIndex = survivors.indexOf(group);
+      if (group.foreign && newGroupIndex !== group.groupIndex) {
+        return {
+          safe: false,
+          shifted: {
+            kind: "group",
+            eventName,
+            oldCoordinate: [group.groupIndex],
+            ...(newGroupIndex >= 0 ? { newCoordinate: [newGroupIndex] } : {}),
+          },
+        };
+      }
+      if (newGroupIndex < 0) continue;
+      const remainingHandlers = group.handlers.filter((handler) => !handler.owner || !ownersToRemove.has(handler.owner));
+      for (const [handlerIndex, handler] of group.handlers.entries()) {
+        if (!handler.foreign || ownersToRemove.has(handler.owner!)) continue;
+        const newHandlerIndex = remainingHandlers.indexOf(handler);
+        if (newHandlerIndex !== handlerIndex) {
+          return {
+            safe: false,
+            shifted: {
+              kind: "handler",
+              eventName,
+              oldCoordinate: [group.groupIndex, handlerIndex],
+              newCoordinate: [newGroupIndex, newHandlerIndex],
+            },
+          };
+        }
+      }
+    }
+  }
+  return { safe: true };
+}
+
+function fullRemovalGroupKeys(
+  model: OwnershipModel,
+  ownersToRemove: ReadonlySet<ManagedOwner>,
+): Map<CodexHookEventName, Set<number>> {
+  const keys = new Map<CodexHookEventName, Set<number>>();
+  for (const group of model.groups) {
+    const removable = !group.opaque && removesAllGroupHandlers(group, ownersToRemove);
+    if (!removable) continue;
+    const eventKeys = keys.get(group.eventName) ?? new Set<number>();
+    eventKeys.add(group.groupIndex);
+    keys.set(group.eventName, eventKeys);
+  }
+  return keys;
+}
+
+function arrayWithoutElements(
+  content: string,
+  array: JsonArrayNode,
+  removed: ReadonlySet<JsonNode>,
+): SourcePatch {
+  const values: string[] = [];
+  for (const element of array.elements) {
+    if (!removed.has(element)) values.push(content.slice(element.start, element.end));
+  }
+  return { start: array.start, end: array.end, text: `[${values.join(",")}]` };
+}
+
+function eventArrayForGroup(document: StrictDocument, eventName: CodexHookEventName): JsonArrayNode | undefined {
+  const event = document.hooksNode ? objectProperty(document.hooksNode, eventName) : undefined;
+  return event?.value.kind === "array" ? event.value : undefined;
+}
+
+function pruneRemovedManagedEventProperties(
+  content: string,
+  deletedEvents: ReadonlySet<CodexHookEventName>,
+  options: ManagedCodexHookOptions,
+): string | null | ManagedCodexHooksPlanError {
+  let current = content;
+  for (;;) {
+    const validation = validateCodexHooksDocument(current, options);
+    if (!("result" in validation)) return validation.error;
+    let emptyEvent: CodexHookEventName | undefined;
+    for (const eventName of deletedEvents) {
+      const event = validation.hooksNode ? objectProperty(validation.hooksNode, eventName) : undefined;
+      if (event?.value.kind === "array" && event.value.elements.length === 0) {
+        emptyEvent = eventName;
+        break;
+      }
+    }
+    if (emptyEvent === undefined) {
+      if (!validation.hooksNode || validation.hooksNode.properties.length > 0) return current;
+      const hooks = objectProperty(validation.rootNode, "hooks");
+      if (!hooks) return validation.rootNode.properties.length === 0 ? null : current;
+      current = applySourcePatches(current, [propertyRemovalPatch(validation.rootNode, hooks)]);
+      const afterRoot = validateCodexHooksDocument(current, options);
+      if (!("result" in afterRoot)) return afterRoot.error;
+      return afterRoot.rootNode.properties.length === 0 ? null : current;
+    }
+    const property = objectProperty(validation.hooksNode!, emptyEvent)!;
+    current = applySourcePatches(current, [propertyRemovalPatch(validation.hooksNode!, property)]);
+  }
+}
+
+function applyCoordinateSafeRemovals(
+  content: string,
+  model: OwnershipModel,
+  ownersToRemove: ReadonlySet<ManagedOwner>,
+  options: ManagedCodexHookOptions,
+): string | null | ManagedCodexHooksPlanError {
+  const fullGroups = fullRemovalGroupKeys(model, ownersToRemove);
+  const partialPatches: SourcePatch[] = [];
+  for (const group of model.groups) {
+    if (fullGroups.get(group.eventName)?.has(group.groupIndex)) continue;
+    const hooks = objectProperty(group.node, "hooks")?.value;
+    if (hooks?.kind !== "array") continue;
+    const removedHandlers = new Set<JsonNode>(group.handlers
+      .filter((handler) => handler.owner && ownersToRemove.has(handler.owner))
+      .map((handler) => handler.node));
+    if (removedHandlers.size > 0) partialPatches.push(arrayWithoutElements(content, hooks, removedHandlers));
+  }
+  let current = partialPatches.length > 0 ? applySourcePatches(content, partialPatches) : content;
+  if (fullGroups.size === 0) return current;
+
+  const afterPartial = validateCodexHooksDocument(current, options);
+  if (!("result" in afterPartial)) return afterPartial.error;
+  const afterOwnership = inspectOwnership(afterPartial, options);
+  if (afterOwnership instanceof ManagedCodexHooksPlanError) return afterOwnership;
+  const groupPatches: SourcePatch[] = [];
+  const deletedEvents = new Set<CodexHookEventName>();
+  for (const [eventName, groupIndices] of fullGroups) {
+    const array = eventArrayForGroup(afterPartial, eventName);
+    if (!array) continue;
+    const removedGroups = new Set<JsonNode>(afterOwnership.groups
+      .filter((group) => group.eventName === eventName && groupIndices.has(group.groupIndex))
+      .map((group) => group.node));
+    if (removedGroups.size === 0) continue;
+    groupPatches.push(arrayWithoutElements(current, array, removedGroups));
+    if (removedGroups.size === array.elements.length) deletedEvents.add(eventName);
+  }
+  current = groupPatches.length > 0 ? applySourcePatches(current, groupPatches) : current;
+  return pruneRemovedManagedEventProperties(current, deletedEvents, options);
+}
+
+function exactLegacyState(node: JsonNode): Record<string, CodexHooksJsonTrustStateEntry> | null {
+  if (node.kind !== "object") return null;
+  const entries: Record<string, CodexHooksJsonTrustStateEntry> = {};
+  const seenKeys = new Set<string>();
+  for (const property of node.properties) {
+    if (seenKeys.has(property.key)) return null;
+    seenKeys.add(property.key);
+    if (property.value.kind !== "object") return null;
+    const entry = property.value;
+    if (entry.properties.some((member) => member.key !== "trusted_hash" && member.key !== "enabled")) return null;
+    if (duplicateKnownProperty(entry, KNOWN_LEGACY_TRUST_STATE_ENTRY_FIELDS)) return null;
+    const hash = stringProperty(entry, "trusted_hash");
+    const enabled = objectProperty(entry, "enabled");
+    if (!hash || (enabled && enabled.value.kind !== "boolean")) return null;
+    setOwnRecordValue(entries, property.key, {
+      trusted_hash: hash,
+      ...(enabled?.value.kind === "boolean" ? { enabled: enabled.value.value } : {}),
+    });
+  }
+  return entries;
+}
+
+function identicalLegacyTrustStateEntry(
+  left: CodexHooksJsonTrustStateEntry,
+  right: CodexHooksJsonTrustStateEntry,
+): boolean {
+  return left.trusted_hash === right.trusted_hash &&
+    Object.hasOwn(left, "enabled") === Object.hasOwn(right, "enabled") &&
+    left.enabled === right.enabled;
+}
+
+function mergeLegacyTrustState(
+  target: Record<string, CodexHooksJsonTrustStateEntry>,
+  incoming: Record<string, CodexHooksJsonTrustStateEntry>,
+  source: "root" | "hooks.state",
+): ManagedCodexHooksPlanError | null {
+  const conflictingKeys: string[] = [];
+  for (const [key, entry] of Object.entries(incoming)) {
+    const existing = Object.hasOwn(target, key) ? target[key] : undefined;
+    if (existing === undefined) {
+      setOwnRecordValue(target, key, entry);
+      continue;
+    }
+    if (!identicalLegacyTrustStateEntry(existing, entry)) conflictingKeys.push(key);
+  }
+  if (conflictingKeys.length === 0) return null;
+  const keys = conflictingKeys.sort((left, right) => left.localeCompare(right));
+  return planError(
+    "managed_trust_key_conflict",
+    `Conflicting legacy hook trust state appears in root state and ${source}.`,
+    { keys, source },
+  );
+}
+
+interface PreparedDocument {
+  content: string;
+  legacyTrustState: Record<string, CodexHooksJsonTrustStateEntry>;
+}
+
+function prepareLegacyState(content: string): PreparedDocument | InvalidCodexHooksConfigStrict {
+  const root = parseJsonSource(content);
+  if (!root || root.kind !== "object") {
+    return { ok: false, error: planError("invalid_document", "hooks.json must contain a JSON object.") };
+  }
+  const legacyTrustState: Record<string, CodexHooksJsonTrustStateEntry> = {};
+  const rootStates = root.properties.filter((property) => property.key === "state");
+  if (rootStates.length > 1) {
+    return { ok: false, error: planError("invalid_document", "Duplicate top-level state is not supported.") };
+  }
+  if (rootStates.length === 1) {
+    const exact = exactLegacyState(rootStates[0]!.value);
+    if (!exact) {
+      return { ok: false, error: planError("invalid_document", "Top-level state is not an exact historical OMX trust map.") };
+    }
+    const conflict = mergeLegacyTrustState(legacyTrustState, exact, "root");
+    if (conflict) return { ok: false, error: conflict };
+  }
+
+  const hooks = objectProperty(root, "hooks");
+  const nestedStates = hooks?.value.kind === "object"
+    ? hooks.value.properties.filter((property) => property.key === "state")
+    : [];
+  const exactNestedStates = nestedStates.map((state) => exactLegacyState(state.value));
+  let nestedStatesToRemove = 0;
+  if (nestedStates.length > 1 && exactNestedStates.some((state) => state === null)) {
+    return {
+      ok: false,
+      error: planError("invalid_document", "Duplicate hooks.state entries must be exact historical OMX trust maps."),
+    };
+  }
+  if (nestedStates.length === 0 || exactNestedStates[0] !== null) {
+    for (const exact of exactNestedStates) {
+      if (!exact) continue;
+      const conflict = mergeLegacyTrustState(legacyTrustState, exact, "hooks.state");
+      if (conflict) return { ok: false, error: conflict };
+    }
+    nestedStatesToRemove = exactNestedStates.length;
+  }
+
+  let preparedContent = content;
+  if (rootStates.length === 1) {
+    const currentRoot = parseJsonSource(preparedContent)! as JsonObjectNode;
+    preparedContent = applySourcePatches(preparedContent, [
+      propertyRemovalPatch(currentRoot, objectProperty(currentRoot, "state")!),
+    ]);
+  }
+  for (let index = 0; index < nestedStatesToRemove; index += 1) {
+    const currentRoot = parseJsonSource(preparedContent)! as JsonObjectNode;
+    const currentHooks = objectProperty(currentRoot, "hooks")?.value;
+    if (currentHooks?.kind !== "object") {
+      return { ok: false, error: planError("invalid_document", "hooks.json changed while preparing legacy state.") };
+    }
+    const currentState = objectProperty(currentHooks, "state");
+    if (!currentState) {
+      return { ok: false, error: planError("invalid_document", "hooks.state changed while preparing legacy state.") };
+    }
+    preparedContent = applySourcePatches(preparedContent, [propertyRemovalPatch(currentHooks, currentState)]);
+  }
+  return { content: preparedContent, legacyTrustState };
+}
+
+function trustFromDocument(
+  document: StrictDocument,
+  hooksPath: string,
+  options: ManagedCodexHookOptions,
+): ManagedCodexHookTrustScanResult {
+  const ownership = inspectOwnership(document, options);
+  if (ownership instanceof ManagedCodexHooksPlanError) return { ok: false, error: ownership };
+  const trustState: Record<string, ManagedCodexHookTrustState> = {};
+  for (const owner of ownership.owners) {
+    const group = owner.groupNode;
+    const handler = owner.handlerNode;
+    const command = effectiveCommandForPlatform(handler, options.platform ?? process.platform);
+    const timeout = objectProperty(handler, "timeout");
+    const timeoutValue = timeout?.value.kind === "number"
+      ? timeout.value.raw === "0"
+        ? 1
+        : new CanonicalJsonNumber(timeout.value.raw)
+      : 600;
+    const status = nullableStringProperty(handler, "statusMessage");
+    const matcher = matcherIsAware(owner.eventName) ? groupMatcher(group) : undefined;
+    setOwnRecordValue(
+      trustState,
+      managedHookStateKey(hooksPath, owner.eventName, owner.groupIndex, owner.handlerIndex),
+      {
+        trusted_hash: versionForCodexTomlIdentity({
+          event_name: CODEX_HOOK_EVENT_LABELS[owner.eventName],
+          ...(matcher ? { matcher } : {}),
+          hooks: [{
+            type: "command",
+            command,
+            timeout: timeoutValue,
+            async: false,
+            ...(status !== undefined && status !== null ? { statusMessage: status } : {}),
+          }],
+        }),
+      },
+    );
+  }
+  return {
+    ok: true,
+    trustState,
+    groupOccurrences: document.result.groupOccurrences,
+    handlerOccurrences: document.result.handlerOccurrences,
+  };
+}
+
+export function scanManagedCodexHookTrustStateFromContent(
+  content: string,
+  hooksPath: string,
+  options: ManagedCodexHookOptions = {},
+): ManagedCodexHookTrustScanResult {
+  const validation = validateCodexHooksDocument(content, options);
+  if (!("result" in validation)) return validation;
+  return trustFromDocument(validation, hooksPath, options);
+}
+
+function hasExecutableForeignCommandInUnknownEvent(
+  event: JsonProperty,
+  platform: HookCommandPlatform,
+): boolean {
+  if (KNOWN_HOOK_EVENT_FIELDS.has(event.key) || event.value.kind !== "array") return false;
+  for (const group of event.value.elements) {
+    if (group.kind !== "object") continue;
+    const hooks = objectProperty(group, "hooks")?.value;
+    if (hooks?.kind !== "array") continue;
+    for (const handler of hooks.elements) {
+      if (handler.kind !== "object" || stringProperty(handler, "type") !== "command") continue;
+      const asynchronous = objectProperty(handler, "async");
+      if (asynchronous?.value.kind === "boolean" && asynchronous.value.value) continue;
+      const command = platform === "win32"
+        ? nullableStringProperty(handler, "commandWindows") ??
+          nullableStringProperty(handler, "command_windows") ??
+          stringProperty(handler, "command")
+        : stringProperty(handler, "command");
+      if (typeof command === "string" && !commandIsSkipped(command)) return true;
+    }
+  }
+  return false;
+}
+
+function foreignHooksInDocument(document: StrictDocument, options: ManagedCodexHookOptions): boolean {
+  const ownership = inspectOwnership(document, options);
+  return ownership instanceof ManagedCodexHooksPlanError ||
+    ownership.groups.some((group) => group.foreign) ||
+    document.hooksNode?.properties.some((event) =>
+      hasExecutableForeignCommandInUnknownEvent(event, options.platform ?? process.platform)) === true;
+}
+
+function finalizePlan(
+  originalContent: string | null | undefined,
+  finalContent: string | null,
+  removedCount: number,
+  coordinateProof: ManagedCodexHooksCoordinateProof,
+  legacyTrustState: Record<string, CodexHooksJsonTrustStateEntry>,
+  hooksPath: string,
+  options: ManagedCodexHookOptions,
+  priorTrustState: Record<string, ManagedCodexHookTrustState>,
+): ManagedCodexHooksPlanResult {
+  if (finalContent === null) {
+    return {
+      ok: true,
+      finalContent: null,
+      changed: originalContent !== null && originalContent !== undefined,
+      removedCount,
+      finalTrustState: {},
+      priorTrustState,
+      hasForeignHooks: false,
+      coordinateProof,
+      diagnostics: [],
+      legacyTrustState,
+    };
+  }
+  const validation = validateCodexHooksDocument(finalContent, options);
+  if (!("result" in validation)) return planFailure(validation.error);
+  const scan = trustFromDocument(validation, hooksPath, options);
+  if (!scan.ok) return planFailure(scan.error, validation.result.diagnostics);
+  return {
+    ok: true,
+    finalContent,
+    changed: finalContent !== originalContent,
+    removedCount,
+    finalTrustState: scan.trustState,
+    priorTrustState,
+    hasForeignHooks: foreignHooksInDocument(validation, options),
+    coordinateProof,
+    diagnostics: validation.result.diagnostics,
+    legacyTrustState,
+  };
+}
+
+export function planManagedCodexHooksMerge(
+  existingContent: string | null | undefined,
+  pkgRoot: string,
+  hooksPath: string,
+  options: ManagedCodexHookOptions = {},
+): ManagedCodexHooksPlanResult {
+  const resolvedOptions = resolveManagedCodexHookOptions(options, hooksPath);
+  if (typeof existingContent !== "string") {
+    const content = serializeCodexHooksConfig(jsonObjectFromUnknown(buildManagedCodexHooksConfig(pkgRoot, resolvedOptions)));
+    return finalizePlan(existingContent, content, 0, { safe: true }, {}, hooksPath, resolvedOptions, {});
+  }
+  const prepared = prepareLegacyState(existingContent);
+  if (!("content" in prepared)) return planFailure(prepared.error);
+  const validation = validateCodexHooksDocument(prepared.content, resolvedOptions);
+  if (!("result" in validation)) return planFailure(validation.error);
+  const priorScan = trustFromDocument(validation, hooksPath, resolvedOptions);
+  if (!priorScan.ok) return planFailure(priorScan.error, validation.result.diagnostics);
+  const ownership = inspectOwnership(validation, resolvedOptions);
+  if (ownership instanceof ManagedCodexHooksPlanError) return planFailure(ownership, validation.result.diagnostics);
+  const managed = buildManagedCodexHooksConfig(pkgRoot, resolvedOptions);
+  const patches: SourcePatch[] = [];
+  const missingEventProperties: Array<readonly [string, string]> = [];
+
+  for (const eventName of MANAGED_HOOK_EVENTS) {
+    const eventOwners = ownership.owners.filter((owner) => owner.eventName === eventName)
+      .sort((left, right) => left.groupIndex - right.groupIndex || left.handlerIndex - right.handlerIndex);
+    const canonicalEntry = managed.hooks[eventName][0]!;
+    if (eventOwners.length === 0) {
+      const eventArray = eventArrayForGroup(validation, eventName);
+      if (eventArray) {
+        patches.push(appendArrayElementPatch(eventArray, JSON.stringify(canonicalGroupForEvent(canonicalEntry))));
+      } else if (validation.hooksNode) {
+        missingEventProperties.push([
+          eventName,
+          JSON.stringify([canonicalGroupForEvent(canonicalEntry)]),
+        ]);
+      }
+      continue;
+    }
+    const primary = eventOwners[0]!;
+    patches.push(...knownFieldPatches(prepared.content, primary.handlerNode, canonicalHookForEvent(canonicalEntry), KNOWN_COMMAND_FIELDS));
+    patches.push(
+      ...knownFieldPatches(
+        prepared.content,
+        primary.groupNode,
+        canonicalMatcherForEvent(canonicalEntry),
+        KNOWN_MATCHER_FIELD,
+      ),
+    );
+  }
+
+  if (validation.hooksNode && missingEventProperties.length > 0) {
+    patches.push(appendObjectPropertiesPatch(validation.hooksNode, missingEventProperties));
+  }
+  if (!validation.hooksNode) patches.push(appendObjectPropertyPatch(validation.rootNode, "hooks", JSON.stringify(managed.hooks)));
+
+  let intermediate: string;
+  try {
+    intermediate = applySourcePatches(prepared.content, patches);
+  } catch (error) {
+    return planFailure(planError("invalid_document", "Overlapping source edits prevented a safe merge.", { cause: String(error) }), validation.result.diagnostics);
+  }
+  const afterMerge = validateCodexHooksDocument(intermediate, resolvedOptions);
+  if (!("result" in afterMerge)) return planFailure(afterMerge.error);
+  const afterOwnership = inspectOwnership(afterMerge, resolvedOptions);
+  if (afterOwnership instanceof ManagedCodexHooksPlanError) return planFailure(afterOwnership, afterMerge.result.diagnostics);
+  const removeOwners = new Set<ManagedOwner>();
+  for (const eventName of MANAGED_HOOK_EVENTS) {
+    const eventOwners = afterOwnership.owners.filter((owner) => owner.eventName === eventName)
+      .sort((left, right) => left.groupIndex - right.groupIndex || left.handlerIndex - right.handlerIndex);
+    for (const duplicate of eventOwners.slice(1)) removeOwners.add(duplicate);
+  }
+  const proof = removalProof(afterOwnership, removeOwners);
+  if (!proof.safe) {
+    return {
+      ok: false,
+      error: planError("unsafe_managed_removal", "Removing duplicate OMX hooks would shift a foreign coordinate or discard opaque metadata.", proof.shifted ? { shifted: proof.shifted } : {}),
+      diagnostics: afterMerge.result.diagnostics,
+    };
+  }
+  let finalContent: string | null | ManagedCodexHooksPlanError;
+  try {
+    finalContent = applyCoordinateSafeRemovals(intermediate, afterOwnership, removeOwners, resolvedOptions);
+  } catch (error) {
+    return planFailure(planError("invalid_document", "Source edits prevented a safe duplicate cleanup.", { cause: String(error) }), afterMerge.result.diagnostics);
+  }
+  if (finalContent instanceof ManagedCodexHooksPlanError) return planFailure(finalContent, afterMerge.result.diagnostics);
+  return finalizePlan(existingContent, finalContent, removeOwners.size, proof, prepared.legacyTrustState, hooksPath, resolvedOptions, priorScan.trustState);
+}
+
+export function planManagedCodexHooksRemoval(
+  existingContent: string,
+  hooksPath: string,
+  options: ManagedCodexHookOptions = {},
+): ManagedCodexHooksPlanResult {
+  const resolvedOptions = resolveManagedCodexHookOptions(options, hooksPath);
+  const prepared = prepareLegacyState(existingContent);
+  if (!("content" in prepared)) return planFailure(prepared.error);
+  const validation = validateCodexHooksDocument(prepared.content, resolvedOptions);
+  if (!("result" in validation)) return planFailure(validation.error);
+  const priorScan = trustFromDocument(validation, hooksPath, resolvedOptions);
+  if (!priorScan.ok) return planFailure(priorScan.error, validation.result.diagnostics);
+  const ownership = inspectOwnership(validation, resolvedOptions);
+  if (ownership instanceof ManagedCodexHooksPlanError) return planFailure(ownership, validation.result.diagnostics);
+  const removeOwners = new Set(ownership.owners);
+  const proof = removalProof(ownership, removeOwners);
+  if (!proof.safe) {
+    return {
+      ok: false,
+      error: planError("unsafe_managed_removal", "Removing OMX hooks would shift a foreign coordinate or discard opaque metadata.", proof.shifted ? { shifted: proof.shifted } : {}),
+      diagnostics: validation.result.diagnostics,
+    };
+  }
+  let finalContent: string | null | ManagedCodexHooksPlanError;
+  try {
+    finalContent = applyCoordinateSafeRemovals(prepared.content, ownership, removeOwners, resolvedOptions);
+  } catch (error) {
+    return planFailure(planError("invalid_document", "Source edits prevented safe removal.", { cause: String(error) }), validation.result.diagnostics);
+  }
+  if (finalContent instanceof ManagedCodexHooksPlanError) return planFailure(finalContent, validation.result.diagnostics);
+  return finalizePlan(existingContent, finalContent, removeOwners.size, proof, prepared.legacyTrustState, hooksPath, resolvedOptions, priorScan.trustState);
+}
+
+function codexHookEntries(
+  hooks: JsonObject,
+  eventName: ManagedHookEventName,
+): JsonArray {
+  const entries = hooks[eventName];
+  return isJsonArray(entries) ? entries : [];
+}
+
+export function getMissingManagedCodexHookEvents(content: string): ManagedHookEventName[] | null {
+  const parsed = parseCodexHooksConfig(content);
+  if (!parsed) return null;
+  return MANAGED_HOOK_EVENTS.filter((eventName) =>
+    !codexHookEntries(parsed.hooks, eventName).some((entry) =>
+      isPlainObject(entry) && isJsonArray(entry.hooks) && entry.hooks.some((hook) =>
+        isPlainObject(hook) && hook.type === "command" && typeof hook.command === "string" &&
+        isValidManagedCommand(hook.command, process.platform),
+      ),
+    ),
+  );
+}
+
+export function getManagedCodexHookCommandsForEvent(
+  content: string,
+  eventName: ManagedHookEventName,
+): string[] | null {
+  const parsed = parseCodexHooksConfig(content);
+  if (!parsed) return null;
+  return codexHookEntries(parsed.hooks, eventName).flatMap((entry) =>
+    isPlainObject(entry) && isJsonArray(entry.hooks)
+      ? entry.hooks.flatMap((hook) =>
+        isPlainObject(hook) && hook.type === "command" && typeof hook.command === "string" &&
+        isValidManagedCommand(hook.command, process.platform)
+          ? [hook.command]
+          : [],
+      )
+      : [],
+  );
+}
+
 export function buildManagedCodexHookTrustState(
   hooksPath: string,
   pkgRoot: string,
   options: ManagedCodexHookOptions = {},
 ): Record<string, ManagedCodexHookTrustState> {
-  const managedConfig = buildManagedCodexHooksConfig(pkgRoot, {
-    ...options,
-    ...(options.platform === "win32" && !options.codexHomeDir
-      ? { codexHomeDir: dirname(hooksPath) }
-      : {}),
-  });
-  const state: Record<string, ManagedCodexHookTrustState> = {};
-
-  for (const eventName of MANAGED_HOOK_EVENTS) {
-    const entries = managedConfig.hooks[eventName] as ManagedHookEntry[];
-    entries.forEach((entry, groupIndex) => {
-      entry.hooks.forEach((hook, handlerIndex) => {
-        if (hook.type !== "command" || !isOmxManagedHookCommand(hook.command)) {
-          return;
-        }
-        const key = managedHookStateKey(
-          hooksPath,
-          eventName,
-          groupIndex,
-          handlerIndex,
-        );
-        state[key] = {
-          trusted_hash: versionForCodexTomlIdentity(
-            normalizedCommandHookIdentity(eventName, entry, hook),
-          ),
-        };
-      });
-    });
-  }
-
-  return state;
+  const resolvedOptions = resolveManagedCodexHookOptions(options, hooksPath);
+  const content = typeof options.hooksContent === "string"
+    ? options.hooksContent
+    : serializeCodexHooksConfig(jsonObjectFromUnknown(buildManagedCodexHooksConfig(pkgRoot, resolvedOptions)));
+  const scan = scanManagedCodexHookTrustStateFromContent(content, hooksPath, resolvedOptions);
+  if (!scan.ok) throw scan.error;
+  return scan.trustState;
 }
 
 export function buildManagedCodexHookTrustToml(
@@ -630,10 +2565,10 @@ function collectTrustStateEntries(
     if (!isPlainObject(rawEntry) || typeof rawEntry.trusted_hash !== "string") {
       continue;
     }
-    entries[key] = {
+    setOwnRecordValue(entries, key, {
       trusted_hash: rawEntry.trusted_hash,
       ...(typeof rawEntry.enabled === "boolean" ? { enabled: rawEntry.enabled } : {}),
-    };
+    });
   }
   return entries;
 }
@@ -662,127 +2597,38 @@ export function mergeManagedCodexHooksConfig(
   hooksPathOrOptions?: string | ManagedCodexHookOptions,
   options: ManagedCodexHookOptions = {},
 ): string {
-  const hooksPath = typeof hooksPathOrOptions === "string" ? hooksPathOrOptions : undefined;
+  const hooksPath = typeof hooksPathOrOptions === "string" ? hooksPathOrOptions : "";
   const providedOptions = typeof hooksPathOrOptions === "object" && hooksPathOrOptions !== null
     ? hooksPathOrOptions
     : options;
-  const resolvedOptions = {
-    ...providedOptions,
-    ...(hooksPath && providedOptions.platform === "win32" && !providedOptions.codexHomeDir
-      ? { codexHomeDir: dirname(hooksPath) }
-      : {}),
-  };
-  const managedConfig = buildManagedCodexHooksConfig(pkgRoot, resolvedOptions);
-  const parsed =
-    typeof existingContent === "string"
-      ? parseCodexHooksConfig(existingContent)
-      : null;
-
-  const nextRoot = parsed ? cloneJson(parsed.root) : {};
-  const nextHooks = parsed ? cloneJson(parsed.hooks) : {};
-  delete nextRoot.state;
-  delete nextHooks.state;
-
-  for (const eventName of MANAGED_HOOK_EVENTS) {
-    const existingEntries = Array.isArray(nextHooks[eventName])
-      ? nextHooks[eventName]
-      : [];
-    const preservedEntries: unknown[] = [];
-
-    for (const entry of existingEntries) {
-      const stripped = stripManagedHooksFromEntry(entry);
-      if (stripped.entry !== null) {
-        preservedEntries.push(stripped.entry);
-      }
-    }
-
-    nextHooks[eventName] = [
-      ...preservedEntries,
-      ...managedConfig.hooks[eventName].map((entry) => cloneJson(entry)),
-    ];
-  }
-
-
-  if (Object.keys(nextHooks).length > 0) {
-    nextRoot.hooks = nextHooks;
-  } else {
-    delete nextRoot.hooks;
-  }
-
-  return serializeCodexHooksConfig(nextRoot);
+  const plan = planManagedCodexHooksMerge(existingContent, pkgRoot, hooksPath, providedOptions);
+  if (!plan.ok) throw plan.error;
+  return plan.finalContent ?? "";
 }
 
 export function removeManagedCodexHooks(
   existingContent: string,
 ): RemoveManagedCodexHooksResult {
-  const parsed = parseCodexHooksConfig(existingContent);
-  if (!parsed) {
-    return { nextContent: existingContent, removedCount: 0 };
-  }
-
-  const nextRoot = cloneJson(parsed.root);
-  const nextHooks = cloneJson(parsed.hooks);
-  delete nextRoot.state;
-  delete nextHooks.state;
-  let removedCount = 0;
-
-  for (const [eventName, rawEntries] of Object.entries(nextHooks)) {
-    if (!Array.isArray(rawEntries)) continue;
-
-    const preservedEntries: unknown[] = [];
-    for (const entry of rawEntries) {
-      const stripped = stripManagedHooksFromEntry(entry);
-      removedCount += stripped.removedCount;
-      if (stripped.entry !== null) {
-        preservedEntries.push(stripped.entry);
-      }
-    }
-
-    if (preservedEntries.length > 0) {
-      nextHooks[eventName] = preservedEntries;
-    } else {
-      delete nextHooks[eventName];
-    }
-  }
-
-  if (removedCount === 0) {
-    return { nextContent: existingContent, removedCount: 0 };
-  }
-
-  const hasRemainingHookEntries = Object.keys(nextHooks).length > 0;
-  if (hasRemainingHookEntries) {
-    nextRoot.hooks = nextHooks;
-  } else {
-    delete nextRoot.hooks;
-  }
-
-  if (Object.keys(nextRoot).length === 0) {
-    return { nextContent: null, removedCount };
-  }
-
-  return {
-    nextContent: serializeCodexHooksConfig(nextRoot),
-    removedCount,
-  };
+  const plan = planManagedCodexHooksRemoval(existingContent, "");
+  if (!plan.ok) throw plan.error;
+  return { nextContent: plan.finalContent, removedCount: plan.removedCount };
 }
 
 export function hasCodexHookEntries(content: string): boolean {
   const parsed = parseCodexHooksConfig(content);
   if (!parsed) return false;
-
   return Object.entries(parsed.hooks).some(([eventName, rawEntries]) => {
-    if (eventName === "state" || !Array.isArray(rawEntries)) return false;
-    return rawEntries.some((entry) => {
-      return isPlainObject(entry) &&
-        Array.isArray(entry.hooks) &&
-        entry.hooks.length > 0;
-    });
+    if (eventName === "state" || !isJsonArray(rawEntries)) return false;
+    return rawEntries.some((entry) =>
+      isPlainObject(entry) && isJsonArray(entry.hooks) && entry.hooks.length > 0,
+    );
   });
 }
 
 export function hasUserCodexHooksAfterManagedRemoval(
   existingContent: string,
 ): boolean {
-  const { nextContent } = removeManagedCodexHooks(existingContent);
-  return nextContent !== null && hasCodexHookEntries(nextContent);
+  const plan = planManagedCodexHooksRemoval(existingContent, "");
+  if (!plan.ok) throw plan.error;
+  return plan.finalContent !== null && hasCodexHookEntries(plan.finalContent);
 }

--- a/src/config/codex-hooks.ts
+++ b/src/config/codex-hooks.ts
@@ -2501,7 +2501,7 @@ export function scanManagedCodexHookTrustStateFromContent(
   return trustFromDocument(validation, hooksPath, options);
 }
 
-function hasExecutableForeignCommandInUnknownEvent(
+function hasExecutableForeignHandlerInUnknownEvent(
   event: JsonProperty,
   platform: HookCommandPlatform,
 ): boolean {
@@ -2511,7 +2511,10 @@ function hasExecutableForeignCommandInUnknownEvent(
     const hooks = objectProperty(group, "hooks")?.value;
     if (hooks?.kind !== "array") continue;
     for (const handler of hooks.elements) {
-      if (handler.kind !== "object" || stringProperty(handler, "type") !== "command") continue;
+      if (handler.kind !== "object") continue;
+      const type = stringProperty(handler, "type");
+      if (type === "prompt" || type === "agent") return true;
+      if (type !== "command") continue;
       const asynchronous = objectProperty(handler, "async");
       if (asynchronous?.value.kind === "boolean" && asynchronous.value.value) continue;
       const command = platform === "win32"
@@ -2530,7 +2533,7 @@ function foreignHooksInDocument(document: StrictDocument, options: ManagedCodexH
   return ownership instanceof ManagedCodexHooksPlanError ||
     ownership.groups.some((group) => group.foreign) ||
     document.hooksNode?.properties.some((event) =>
-      hasExecutableForeignCommandInUnknownEvent(event, options.platform ?? process.platform)) === true;
+      hasExecutableForeignHandlerInUnknownEvent(event, options.platform ?? process.platform)) === true;
 }
 
 function finalizePlan(

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -31,6 +31,8 @@ import {
 import {
   buildManagedCodexHookTrustState,
   escapeTomlBasicString,
+  ManagedCodexHooksPlanError,
+  type CodexHooksJsonTrustStateEntry,
   type ManagedCodexHookTrustState,
   type ManagedCodexHookOptions,
 } from "./codex-hooks.js";
@@ -41,6 +43,13 @@ interface MergeOptions {
   codexHooksFile?: string;
   codexHomeDir?: string;
   hookCommandPlatform?: ManagedCodexHookOptions["platform"];
+  codexHooksContent?: string | null;
+  /** Trust keys scanned from the already-planned final hooks.json content. */
+  managedHookTrustState?: Record<string, ManagedCodexHookTrustState>;
+  /** Trust keys scanned from the prior hooks.json content for proof-based cleanup. */
+  priorManagedHookTrustState?: Record<string, ManagedCodexHookTrustState>;
+  /** Exact historical hooks.json state extracted by a strict hooks plan. */
+  legacyHookTrustState?: Record<string, CodexHooksJsonTrustStateEntry>;
   codexHookFeatureFlag?: CodexHookFeatureFlag;
   modelOverride?: string;
   sharedMcpServers?: UnifiedMcpRegistryServer[];
@@ -1130,158 +1139,562 @@ interface HookTrustStateStripResult {
   preservedConflictKeys: Set<string>;
 }
 
-interface HooksStateHeader {
-  key: string;
-  hasInlineComment: boolean;
+type ManagedHookTrustStateExpectations = ReadonlyMap<string, ReadonlySet<string>>;
+
+type TomlSourceStringMode =
+  | "basic"
+  | "literal"
+  | "multiline-basic"
+  | "multiline-literal";
+
+interface TomlSourceLexicalAnalysis {
+  lines: string[];
+  lineStartsOutsideMultiline: boolean[];
+  lineHasTomlComment: boolean[];
+  isUnambiguous: boolean;
 }
 
-function decodeTomlBasicString(raw: string): string | undefined {
-  try {
-    const parsed = TOML.parse(`value = "${raw}"`) as { value?: unknown };
-    return typeof parsed.value === "string" ? parsed.value : undefined;
-  } catch {
-    return undefined;
+function isMultilineTomlString(mode: TomlSourceStringMode | undefined): boolean {
+  return mode === "multiline-basic" || mode === "multiline-literal";
+}
+
+/**
+ * Tracks only lexical boundaries needed to safely associate source lines with
+ * TOML statements. TOML's parser gives us semantics; this prevents source
+ * repair from treating table-like text in a multiline value as syntax.
+ */
+function analyzeTomlSource(config: string): TomlSourceLexicalAnalysis {
+  const lines = config.split(/\r?\n/);
+  const lineStartsOutsideMultiline: boolean[] = [];
+  const lineHasTomlComment: boolean[] = [];
+  let mode: TomlSourceStringMode | undefined;
+  let isUnambiguous = true;
+
+  for (const line of lines) {
+    lineStartsOutsideMultiline.push(!isMultilineTomlString(mode));
+    let hasComment = false;
+
+    for (let index = 0; index < line.length; index += 1) {
+      const character = line[index]!;
+      if (mode === "basic") {
+        if (character === "\\") {
+          index += 1;
+        } else if (character === "\"") {
+          mode = undefined;
+        }
+        continue;
+      }
+      if (mode === "literal") {
+        if (character === "'") mode = undefined;
+        continue;
+      }
+      if (mode === "multiline-basic" || mode === "multiline-literal") {
+        const delimiter = mode === "multiline-basic" ? "\"" : "'";
+        if (mode === "multiline-basic" && character === "\\") {
+          index += 1;
+          continue;
+        }
+        if (character !== delimiter) continue;
+
+        let runEnd = index + 1;
+        while (line[runEnd] === delimiter) runEnd += 1;
+        if (runEnd - index >= 3) {
+          // TOML permits one or two delimiter characters immediately before
+          // the closing triple delimiter as string content.
+          mode = undefined;
+          index = runEnd - 1;
+        }
+        continue;
+      }
+
+      if (character === "#") {
+        hasComment = true;
+        break;
+      }
+      if (character !== "\"" && character !== "'") continue;
+
+      const isMultiline =
+        line[index + 1] === character && line[index + 2] === character;
+      if (isMultiline) {
+        mode = character === "\"" ? "multiline-basic" : "multiline-literal";
+        index += 2;
+      } else {
+        mode = character === "\"" ? "basic" : "literal";
+      }
+    }
+
+    lineHasTomlComment.push(hasComment);
+    if (mode === "basic" || mode === "literal") isUnambiguous = false;
+  }
+
+  if (isMultilineTomlString(mode)) isUnambiguous = false;
+  return { lines, lineStartsOutsideMultiline, lineHasTomlComment, isUnambiguous };
+}
+
+interface TomlSourceTableHeader {
+  parsed: Record<string, unknown> | undefined;
+}
+
+interface TomlSourceTableScope {
+  parsed: Record<string, unknown> | undefined;
+  hasComment: boolean;
+}
+
+interface ManagedHookTrustStateSourceRepresentation {
+  start: number;
+  end: number;
+  stateEntryCount: number;
+  value: unknown;
+  hasComment: boolean;
+  hasExactSemanticScope: boolean;
+  insideManagedMarkerBlock: boolean;
+}
+
+function managedHookTrustStateExpectations(
+  ...states: Array<ManagedCodexHookTrustStateMap | undefined>
+): ManagedHookTrustStateExpectations {
+  const expectations = new Map<string, Set<string>>();
+  for (const state of states) {
+    if (!state) continue;
+    for (const [key, entry] of Object.entries(state)) {
+      const hashes = expectations.get(key) ?? new Set<string>();
+      hashes.add(entry.trusted_hash);
+      expectations.set(key, hashes);
+    }
+  }
+  return expectations;
+}
+
+function tomlHooksStateEntries(
+  parsed: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!parsed) return undefined;
+  const hooks = parsed.hooks;
+  if (!isPlainTomlRecord(hooks)) return undefined;
+  const state = hooks.state;
+  return isPlainTomlRecord(state) ? state : undefined;
+}
+
+function hasOnlyManagedHookTrustStateField(
+  parsed: Record<string, unknown> | undefined,
+  key: string,
+): boolean {
+  if (!parsed || Object.keys(parsed).length !== 1 || !Object.hasOwn(parsed, "hooks")) {
+    return false;
+  }
+  const hooks = parsed.hooks;
+  if (!isPlainTomlRecord(hooks) || Object.keys(hooks).length !== 1 || !Object.hasOwn(hooks, "state")) {
+    return false;
+  }
+  const state = hooks.state;
+  return isPlainTomlRecord(state) &&
+    Object.keys(state).length === 1 &&
+    Object.hasOwn(state, key);
+}
+
+function parseTomlSourceTableHeader(line: string): TomlSourceTableHeader | undefined {
+  const start = line.search(/\S/);
+  if (start === -1 || line[start] !== "[") return undefined;
+
+  const array = line[start + 1] === "[";
+  let quote: "\"" | "'" | undefined;
+  let escaped = false;
+  for (let index = start + (array ? 2 : 1); index < line.length; index += 1) {
+    const character = line[index]!;
+    if (quote === "\"") {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (quote === "'") {
+      if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === "\"" || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character !== "]") continue;
+
+    const end = array ? index + 2 : index + 1;
+    if (array && line[index + 1] !== "]") return undefined;
+    const suffix = line.slice(end).trimStart();
+    if (suffix.length > 0 && !suffix.startsWith("#")) return undefined;
+    return { parsed: safeParseToml(line.slice(start, end)) };
+  }
+  return undefined;
+}
+
+function sourceRangeHasTomlComment(
+  source: TomlSourceLexicalAnalysis,
+  start: number,
+  end: number,
+): boolean {
+  for (let index = start; index < end; index += 1) {
+    if (source.lineHasTomlComment[index]) return true;
+  }
+  return false;
+}
+
+function addManagedHookTrustStateSourceRepresentations(
+  representations: Map<string, ManagedHookTrustStateSourceRepresentation[]>,
+  expectations: ManagedHookTrustStateExpectations,
+  source: TomlSourceLexicalAnalysis,
+  start: number,
+  end: number,
+  parsed: Record<string, unknown> | undefined,
+  insideManagedMarkerBlock: boolean,
+  containingTableScope?: TomlSourceTableScope,
+  fallbackKeys: readonly string[] = [],
+): void {
+  const state = tomlHooksStateEntries(parsed);
+  const hasComment = sourceRangeHasTomlComment(source, start, end);
+  if (state) {
+    const stateEntryCount = Object.keys(state).length;
+    for (const [key, value] of Object.entries(state)) {
+      if (!expectations.has(key)) continue;
+      const hasExactSemanticScope = hasOnlyManagedHookTrustStateField(parsed, key) &&
+        (!containingTableScope ||
+          (!containingTableScope.hasComment &&
+            hasOnlyManagedHookTrustStateField(containingTableScope.parsed, key)));
+
+      const entries = representations.get(key) ?? [];
+      entries.push({
+        start,
+        end,
+        stateEntryCount,
+        value,
+        hasComment,
+        hasExactSemanticScope,
+        insideManagedMarkerBlock,
+      });
+      representations.set(key, entries);
+    }
+    return;
+  }
+
+  for (const key of fallbackKeys) {
+    if (!expectations.has(key)) continue;
+    const entries = representations.get(key) ?? [];
+    entries.push({
+      start,
+      end,
+      stateEntryCount: 0,
+      value: undefined,
+      hasComment,
+      hasExactSemanticScope: false,
+      insideManagedMarkerBlock,
+    });
+    representations.set(key, entries);
   }
 }
 
-function parseHooksStateHeader(line: string): HooksStateHeader | undefined {
-  const match = line.match(
-    /^\s*\[hooks\.state\."((?:\\.|[^"\\])*)"\]\s*(#.*)?$/,
-  );
-  if (!match) return undefined;
-  const key = decodeTomlBasicString(match[1] ?? "");
-  if (key === undefined) return undefined;
-  return { key, hasInlineComment: match[2] !== undefined };
+function collectManagedHookTrustStateSourceRepresentations(
+  config: string,
+  expectations: ManagedHookTrustStateExpectations,
+): {
+  source: TomlSourceLexicalAnalysis;
+  representations: Map<string, ManagedHookTrustStateSourceRepresentation[]>;
+} {
+  const source = analyzeTomlSource(config);
+  const { lines } = source;
+  const headers: Array<{ index: number; header: TomlSourceTableHeader }> = [];
+  for (const [index, line] of lines.entries()) {
+    if (!source.lineStartsOutsideMultiline[index]) continue;
+    const header = parseTomlSourceTableHeader(line);
+    if (header) headers.push({ index, header });
+  }
+
+  const boundaries = new Set<number>(headers.map(({ index }) => index));
+  for (const [index, line] of lines.entries()) {
+    if (
+      source.lineStartsOutsideMultiline[index] &&
+      line.trim() === OMX_HOOK_TRUST_END_MARKER
+    ) {
+      boundaries.add(index);
+    }
+  }
+  const sortedBoundaries = [...boundaries].sort((left, right) => left - right);
+  const representations = new Map<string, ManagedHookTrustStateSourceRepresentation[]>();
+  const managedMarkerRanges: SourceSpan[] = [];
+  for (let start = 0; start < lines.length; start += 1) {
+    if (
+      !source.lineStartsOutsideMultiline[start] ||
+      lines[start]?.trim() !== OMX_HOOK_TRUST_START_MARKER
+    ) continue;
+    const end = lines.findIndex(
+      (line, index) =>
+        index > start &&
+        source.lineStartsOutsideMultiline[index] &&
+        line.trim() === OMX_HOOK_TRUST_END_MARKER,
+    );
+    const nestedStart = lines.findIndex(
+      (line, index) =>
+        index > start &&
+        source.lineStartsOutsideMultiline[index] &&
+        line.trim() === OMX_HOOK_TRUST_START_MARKER,
+    );
+    if (end === -1 || (nestedStart !== -1 && nestedStart < end)) continue;
+    managedMarkerRanges.push({ start, end });
+    start = end;
+  }
+  const isInsideManagedMarkerBlock = (start: number, end: number): boolean =>
+    managedMarkerRanges.some((range) => start > range.start && end <= range.end);
+
+  const collectAssignments = (
+    start: number,
+    end: number,
+    prefix: string | undefined,
+    containingTableScope?: TomlSourceTableScope,
+  ): void => {
+    for (let cursor = start; cursor < end;) {
+      const line = lines[cursor] ?? "";
+      if (
+        !source.lineStartsOutsideMultiline[cursor] ||
+        line.trim().length === 0 ||
+        source.lineHasTomlComment[cursor]
+      ) {
+        cursor += 1;
+        continue;
+      }
+
+      let parsed: Record<string, unknown> | undefined;
+      let statementEnd = cursor + 1;
+      for (; statementEnd <= end; statementEnd += 1) {
+        const statement = lines.slice(cursor, statementEnd).join("\n");
+        parsed = safeParseToml(prefix ? `${prefix}\n${statement}` : statement);
+        if (parsed) break;
+      }
+      if (!parsed) {
+        cursor += 1;
+        continue;
+      }
+      addManagedHookTrustStateSourceRepresentations(
+        representations,
+        expectations,
+        source,
+        cursor,
+        statementEnd,
+        parsed,
+        isInsideManagedMarkerBlock(cursor, statementEnd),
+        containingTableScope,
+      );
+      cursor = statementEnd;
+    }
+  };
+
+  const rootEnd = sortedBoundaries[0] ?? lines.length;
+  collectAssignments(0, rootEnd, undefined);
+  for (const { index, header } of headers) {
+    const boundaryIndex = sortedBoundaries.findIndex((boundary) => boundary === index);
+    const end = boundaryIndex === -1
+      ? lines.length
+      : (sortedBoundaries[boundaryIndex + 1] ?? lines.length);
+    const tableScope = {
+      parsed: safeParseToml(lines.slice(index, end).join("\n")),
+      hasComment: sourceRangeHasTomlComment(source, index, end),
+    };
+    const headerState = tomlHooksStateEntries(header.parsed);
+    const directKeys = Object.keys(headerState ?? {}).filter((key) => expectations.has(key));
+    if (directKeys.length > 0) {
+      addManagedHookTrustStateSourceRepresentations(
+        representations,
+        expectations,
+        source,
+        index,
+        end,
+        tableScope.parsed,
+        isInsideManagedMarkerBlock(index, end),
+        undefined,
+        directKeys,
+      );
+      continue;
+    }
+    collectAssignments(index + 1, end, lines[index], tableScope);
+  }
+
+  return { source, representations };
 }
 
-function isTomlTableHeader(line: string): boolean {
-  return /^\s*\[\[?[^\]]+\]?\]\s*(?:#.*)?$/.test(line);
-}
-
-function isExactlyManagedHookTrustBody(
-  bodyLines: readonly string[],
-  expectedHash: string,
+function isExactlyManagedHookTrustStateValue(
+  value: unknown,
+  expectedHashes: ReadonlySet<string>,
 ): boolean {
-  const nonBlank = bodyLines.filter((line) => line.trim().length > 0);
-  if (nonBlank.length !== 1) return false;
+  return isPlainTomlRecord(value) &&
+    Object.keys(value).length === 1 &&
+    Object.hasOwn(value, "trusted_hash") &&
+    typeof value.trusted_hash === "string" &&
+    expectedHashes.has(value.trusted_hash);
+}
 
-  const expected = expectedHash.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`^\\s*trusted_hash\\s*=\\s*"${expected}"\\s*$`).test(
-    nonBlank[0] ?? "",
-  );
+function removeEmptyManagedHookTrustStateMarkerBlocks(
+  source: TomlSourceLexicalAnalysis,
+  removed: Set<number>,
+): void {
+  const { lines } = source;
+  for (let start = 0; start < lines.length; start += 1) {
+    if (
+      !source.lineStartsOutsideMultiline[start] ||
+      lines[start]?.trim() !== OMX_HOOK_TRUST_START_MARKER
+    ) continue;
+    const end = lines.findIndex(
+      (line, index) =>
+        index > start &&
+        source.lineStartsOutsideMultiline[index] &&
+        line.trim() === OMX_HOOK_TRUST_END_MARKER,
+    );
+    const nestedStart = lines.findIndex(
+      (line, index) =>
+        index > start &&
+        source.lineStartsOutsideMultiline[index] &&
+        line.trim() === OMX_HOOK_TRUST_START_MARKER,
+    );
+    if (end === -1 || (nestedStart !== -1 && nestedStart < end)) continue;
+
+    let onlyOwnedMarkerContent = true;
+    for (let index = start + 1; index < end; index += 1) {
+      const trimmed = lines[index]!.trim();
+      if (
+        removed.has(index) ||
+        trimmed.length === 0 ||
+        trimmed === "# Trusts only setup-managed native hook wrappers."
+      ) continue;
+      onlyOwnedMarkerContent = false;
+      break;
+    }
+    if (!onlyOwnedMarkerContent) continue;
+
+    removed.add(start);
+    removed.add(end);
+    for (let index = start + 1; index < end; index += 1) {
+      if (lines[index]?.trim() === "# Trusts only setup-managed native hook wrappers.") {
+        removed.add(index);
+      }
+    }
+    start = end;
+  }
 }
 
 function stripProofManagedCodexHookTrustStateTables(
   config: string,
-  managedTrustState: ManagedCodexHookTrustStateMap,
+  expectations: ManagedHookTrustStateExpectations,
 ): HookTrustStateStripResult {
-  if (Object.keys(managedTrustState).length === 0) {
+  if (expectations.size === 0) {
     return { config, preservedConflictKeys: new Set() };
   }
 
-  const lines = config.split(/\r?\n/);
-  const kept: string[] = [];
+  const { source, representations } = collectManagedHookTrustStateSourceRepresentations(
+    config,
+    expectations,
+  );
+  if (!source.isUnambiguous) {
+    return { config, preservedConflictKeys: new Set() };
+  }
+  const { lines } = source;
   const preservedConflictKeys = new Set<string>();
+  const removals = new Map<string, SourceSpan>();
+  const parsedConfigState = tomlHooksStateEntries(safeParseToml(config));
 
-  for (let i = 0; i < lines.length;) {
-    const header = parseHooksStateHeader(lines[i] ?? "");
-    if (!header) {
-      kept.push(lines[i]);
-      i += 1;
-      continue;
+  for (const key of Object.keys(parsedConfigState ?? {})) {
+    if (expectations.has(key) && !representations.has(key)) {
+      preservedConflictKeys.add(key);
     }
-
-    let tableEnd = lines.length;
-    for (let next = i + 1; next < lines.length; next += 1) {
-      if (isTomlTableHeader(lines[next] ?? "")) {
-        tableEnd = next;
-        break;
-      }
-    }
-
-    const expectedState = managedTrustState[header.key];
-    const removable =
-      expectedState !== undefined &&
-      !header.hasInlineComment &&
-      isExactlyManagedHookTrustBody(
-        lines.slice(i + 1, tableEnd),
-        expectedState.trusted_hash,
-      );
-
-    if (removable) {
-      i = tableEnd;
-      continue;
-    }
-
-    if (expectedState !== undefined) {
-      preservedConflictKeys.add(header.key);
-    }
-
-    kept.push(...lines.slice(i, tableEnd));
-    i = tableEnd;
   }
 
-  return { config: kept.join("\n"), preservedConflictKeys };
+  for (const [key, sourceRepresentations] of representations) {
+    const expectedHashes = expectations.get(key)!;
+    const isExactOwnedRepresentation = (
+      representation: ManagedHookTrustStateSourceRepresentation,
+    ): boolean =>
+      representation.stateEntryCount === 1 &&
+      !representation.hasComment &&
+      representation.hasExactSemanticScope &&
+      isExactlyManagedHookTrustStateValue(representation.value, expectedHashes);
+    const mayRemoveAll = sourceRepresentations.length === 1
+      ? isExactOwnedRepresentation(sourceRepresentations[0]!)
+      : sourceRepresentations.every(
+        (representation) =>
+          representation.insideManagedMarkerBlock &&
+          isExactOwnedRepresentation(representation),
+      );
+    if (!mayRemoveAll) {
+      preservedConflictKeys.add(key);
+      continue;
+    }
+    for (const representation of sourceRepresentations) {
+      removals.set(`${representation.start}:${representation.end}`, {
+        start: representation.start,
+        end: representation.end,
+      });
+    }
+  }
+
+  if (removals.size === 0) {
+    return { config, preservedConflictKeys };
+  }
+
+  const removed = new Set<number>();
+  for (const range of removals.values()) {
+    for (let index = range.start; index < range.end; index += 1) {
+      removed.add(index);
+    }
+  }
+  removeEmptyManagedHookTrustStateMarkerBlocks(source, removed);
+  return {
+    config: lines.filter((_, index) => !removed.has(index)).join("\n").trimEnd(),
+    preservedConflictKeys,
+  };
 }
 
-function stripManagedCodexHookTrustStateWithResult(
+function stripManagedCodexHookTrustStateForRefresh(
   config: string,
-  options: { managedTrustState?: ManagedCodexHookTrustStateMap } = {},
+  priorManagedTrustState: ManagedCodexHookTrustStateMap | undefined,
+  finalManagedTrustState: ManagedCodexHookTrustStateMap,
 ): HookTrustStateStripResult {
-  const lines = config.split(/\r?\n/);
-  const kept: string[] = [];
+  return stripProofManagedCodexHookTrustStateTables(
+    config,
+    managedHookTrustStateExpectations(priorManagedTrustState, finalManagedTrustState),
+  );
+}
 
-  for (let i = 0; i < lines.length;) {
-    const trimmed = lines[i].trim();
-    if (trimmed !== OMX_HOOK_TRUST_START_MARKER) {
-      kept.push(lines[i]);
-      i += 1;
-      continue;
-    }
+function rejectManagedCodexHookTrustStateConflicts(
+  conflicts: ReadonlySet<string>,
+): void {
+  if (conflicts.size === 0) return;
 
-    const nextEndIdx = lines.findIndex(
-      (line, index) => index > i && line.trim() === OMX_HOOK_TRUST_END_MARKER,
-    );
-    const nextStartIdx = lines.findIndex(
-      (line, index) => index > i && line.trim() === OMX_HOOK_TRUST_START_MARKER,
-    );
-
-    if (nextEndIdx === -1 || (nextStartIdx !== -1 && nextStartIdx < nextEndIdx)) {
-      kept.push(lines[i]);
-      i += 1;
-      continue;
-    }
-
-    i = nextEndIdx + 1;
-  }
-
-  const withoutFenced = kept.join("\n");
-  const proofStripped = options.managedTrustState
-    ? stripProofManagedCodexHookTrustStateTables(
-        withoutFenced,
-        options.managedTrustState,
-      )
-    : { config: withoutFenced, preservedConflictKeys: new Set<string>() };
-
-  return {
-    config: proofStripped.config.replace(/\n{3,}/g, "\n\n").trimEnd(),
-    preservedConflictKeys: proofStripped.preservedConflictKeys,
-  };
+  const keys = [...conflicts].sort((left, right) => left.localeCompare(right));
+  throw new ManagedCodexHooksPlanError(
+    "managed_trust_key_conflict",
+    `Refusing to replace existing Codex hook trust state for ${keys.join(", ")}. Remove or reconcile the conflicting [hooks.state] entry before running setup.`,
+    { keys },
+  );
 }
 
 export function stripManagedCodexHookTrustState(
   config: string,
-  options: { managedTrustState?: ManagedCodexHookTrustStateMap } = {},
+  options: {
+    managedTrustState?: ManagedCodexHookTrustStateMap;
+    priorManagedHookTrustState?: ManagedCodexHookTrustStateMap;
+  } = {},
 ): string {
-  return stripManagedCodexHookTrustStateWithResult(config, options).config;
+  const stripped = stripManagedCodexHookTrustStateForRefresh(
+    config,
+    options.priorManagedHookTrustState,
+    options.managedTrustState ?? {},
+  );
+  rejectManagedCodexHookTrustStateConflicts(stripped.preservedConflictKeys);
+  return stripped.config;
 }
 
 function renderManagedCodexHookTrustToml(
   managedTrustState: ManagedCodexHookTrustStateMap,
-  excludedKeys: ReadonlySet<string> = new Set(),
 ): string {
   return Object.entries(managedTrustState)
-    .filter(([key]) => !excludedKeys.has(key))
     .sort(([left], [right]) => left.localeCompare(right))
     .flatMap(([key, hookState]) => [
       `[hooks.state."${escapeTomlBasicString(key)}"]`,
@@ -1292,11 +1705,100 @@ function renderManagedCodexHookTrustToml(
     .trimEnd();
 }
 
+function identicalLegacyHookTrustStateEntry(
+  existing: unknown,
+  expected: CodexHooksJsonTrustStateEntry,
+): boolean {
+  if (!isPlainTomlRecord(existing)) return false;
+  if (
+    !Object.hasOwn(existing, "trusted_hash") ||
+    typeof existing.trusted_hash !== "string" ||
+    existing.trusted_hash !== expected.trusted_hash ||
+    Object.keys(existing).some((key) => key !== "trusted_hash" && key !== "enabled")
+  ) {
+    return false;
+  }
+  return Object.hasOwn(existing, "enabled") === Object.hasOwn(expected, "enabled") &&
+    existing.enabled === expected.enabled;
+}
+
+function legacyHookTrustStateConflict(keys: readonly string[], reason?: string): never {
+  throw new ManagedCodexHooksPlanError(
+    "managed_trust_key_conflict",
+    `Refusing to migrate legacy Codex hook trust state into conflicting config.toml entries for ${keys.join(", ")}.`,
+    { keys: [...keys], ...(reason ? { reason } : {}) },
+  );
+}
+
+function appendLegacyHookTrustState(
+  config: string,
+  legacyTrustState: Record<string, CodexHooksJsonTrustStateEntry> | undefined,
+): string {
+  if (!legacyTrustState || Object.keys(legacyTrustState).length === 0) {
+    return config;
+  }
+
+  const parsed = safeParseToml(config);
+  const keys = Object.keys(legacyTrustState).sort((left, right) => left.localeCompare(right));
+  if (!parsed) legacyHookTrustStateConflict(keys, "config_parse_failure");
+  const hooks = parsed.hooks;
+  if (hooks !== undefined && !isPlainTomlRecord(hooks)) {
+    legacyHookTrustStateConflict(keys, "hooks_table_invalid");
+  }
+  const hookState = isPlainTomlRecord(hooks) ? hooks.state : undefined;
+  if (hookState !== undefined && !isPlainTomlRecord(hookState)) {
+    legacyHookTrustStateConflict(keys, "hooks_state_table_invalid");
+  }
+  const existingTrustState = isPlainTomlRecord(hookState) ? hookState : {};
+  const entriesToAppend = Object.entries(legacyTrustState)
+    .filter(([key]) => !Object.hasOwn(existingTrustState, key));
+  const conflictingKeys = Object.entries(legacyTrustState)
+    .filter(([key, expected]) =>
+      Object.hasOwn(existingTrustState, key) &&
+      !identicalLegacyHookTrustStateEntry(existingTrustState[key], expected)
+    )
+    .map(([key]) => key)
+    .sort((left, right) => left.localeCompare(right));
+  if (conflictingKeys.length > 0) legacyHookTrustStateConflict(conflictingKeys);
+  const trustToml = entriesToAppend
+    .sort(([left], [right]) => left.localeCompare(right))
+    .flatMap(([key, state]) => [
+      `[hooks.state."${escapeTomlBasicString(key)}"]`,
+      `trusted_hash = "${escapeTomlBasicString(state.trusted_hash)}"`,
+      ...(typeof state.enabled === "boolean" ? [`enabled = ${state.enabled}`] : []),
+      "",
+    ])
+    .join("\n")
+    .trimEnd();
+  if (!trustToml) return config;
+
+  const base = config.trimEnd();
+  return [
+    base,
+    base ? "" : null,
+    "# Migrated from legacy hooks.json state; kept in Codex config.toml because Codex 0.140 rejects top-level hooks.json state.",
+    trustToml,
+    "",
+  ].filter((line): line is string => line !== null).join("\n");
+}
+
+function managedCodexHookOptionsFromMergeOptions(
+  options: MergeOptions,
+): ManagedCodexHookOptions {
+  return {
+    codexHomeDir: options.codexHomeDir,
+    platform: options.hookCommandPlatform,
+    hooksContent: options.codexHooksContent,
+  };
+}
+
 function buildManagedCodexHookTrustStateForConfig(
   codexHooksFile: string | undefined,
   pkgRoot: string,
   options: ManagedCodexHookOptions = {},
+  precomputedTrustState?: ManagedCodexHookTrustStateMap,
 ): ManagedCodexHookTrustStateMap {
+  if (precomputedTrustState) return precomputedTrustState;
   if (!codexHooksFile) return {};
   return buildManagedCodexHookTrustState(codexHooksFile, pkgRoot, options);
 }
@@ -1305,37 +1807,52 @@ export function upsertManagedCodexHookTrustState(
   config: string,
   pkgRoot: string,
   codexHooksFile: string | undefined,
-  options: ManagedCodexHookOptions = {},
+  options: ManagedCodexHookOptions & {
+    managedTrustState?: ManagedCodexHookTrustStateMap;
+    priorManagedHookTrustState?: ManagedCodexHookTrustStateMap;
+    legacyHookTrustState?: Record<string, CodexHooksJsonTrustStateEntry>;
+  } = {},
 ): string {
   const managedTrustState = buildManagedCodexHookTrustStateForConfig(
     codexHooksFile,
     pkgRoot,
     options,
+    options.managedTrustState,
   );
-  const strippedResult = stripManagedCodexHookTrustStateWithResult(config, {
+  const strippedResult = stripManagedCodexHookTrustStateForRefresh(
+    config,
+    options.priorManagedHookTrustState,
     managedTrustState,
-  });
-  const stripped = strippedResult.config;
-  const hookTrustToml = renderManagedCodexHookTrustToml(
-    managedTrustState,
+  );
+  rejectManagedCodexHookTrustStateConflicts(
     strippedResult.preservedConflictKeys,
   );
-  if (!hookTrustToml) return `${stripped}\n`;
-  return [
-    stripped,
-    "",
-    OMX_HOOK_TRUST_START_MARKER,
-    "# Trusts only setup-managed native hook wrappers.",
-    hookTrustToml,
-    OMX_HOOK_TRUST_END_MARKER,
-    "",
-  ].filter((line, index) => index !== 0 || line.length > 0).join("\n");
+  const stripped = strippedResult.config.trimEnd();
+  const hookTrustToml = renderManagedCodexHookTrustToml(managedTrustState);
+  if (!hookTrustToml) {
+    return appendLegacyHookTrustState(
+      `${stripped}\n`,
+      options.legacyHookTrustState,
+    );
+  }
+  return appendLegacyHookTrustState(
+    [
+      stripped,
+      "",
+      OMX_HOOK_TRUST_START_MARKER,
+      "# Trusts only setup-managed native hook wrappers.",
+      hookTrustToml,
+      OMX_HOOK_TRUST_END_MARKER,
+      "",
+    ].filter((line, index) => index !== 0 || line.length > 0).join("\n"),
+    options.legacyHookTrustState,
+  );
 }
 
 export function upsertPluginModeRuntimeFeatureFlags(
   config: string,
   codexHookFeatureFlag: CodexHookFeatureFlag = DEFAULT_CODEX_HOOK_FEATURE_FLAG,
-  options: { pluginScopedHooks?: boolean } = {},
+  options: { pluginScopedHooks?: boolean; preserveNativeHooks?: boolean } = {},
 ): string {
   const lines = config.split(/\r?\n/);
   const featuresStart = lines.findIndex((line) =>
@@ -1350,6 +1867,9 @@ export function upsertPluginModeRuntimeFeatureFlags(
     const featureBlock = [
       "[features]",
       hookFeatureFlagLine,
+      ...(options.pluginScopedHooks && options.preserveNativeHooks
+        ? [formatCodexHookFeatureFlagLine(codexHookFeatureFlag)]
+        : []),
       "goals = true",
       "",
     ].join("\n");
@@ -1376,14 +1896,28 @@ export function upsertPluginModeRuntimeFeatureFlags(
     }
   }
 
-  ({ sectionEnd } = options.pluginScopedHooks
-    ? upsertPluginScopedHookFeatureFlagInSection(lines, featuresStart, sectionEnd)
-    : upsertCodexHookFeatureFlagInSection(
+  if (options.pluginScopedHooks) {
+    ({ sectionEnd } = upsertPluginScopedHookFeatureFlagInSection(
+      lines,
+      featuresStart,
+      sectionEnd,
+    ));
+    if (options.preserveNativeHooks) {
+      ({ sectionEnd } = upsertCodexHookFeatureFlagInSection(
         lines,
         featuresStart,
         sectionEnd,
         codexHookFeatureFlag,
       ));
+    }
+  } else {
+    ({ sectionEnd } = upsertCodexHookFeatureFlagInSection(
+      lines,
+      featuresStart,
+      sectionEnd,
+      codexHookFeatureFlag,
+    ));
+  }
 
   let goalsIdx = -1;
   for (let i = featuresStart + 1; i < sectionEnd; i++) {
@@ -2378,8 +2912,8 @@ function getOmxTablesBlock(
   statusLinePreset: HudPreset = DEFAULT_STATUS_LINE_PRESET,
   codexHooksFile?: string,
   hookOptions: ManagedCodexHookOptions = {},
+  managedHookTrustState?: ManagedCodexHookTrustStateMap,
   includeFirstPartyMcp = false,
-  excludedHookTrustStateKeys: ReadonlySet<string> = new Set(),
 ): string {
   const lines = [
     "",
@@ -2412,8 +2946,8 @@ function getOmxTablesBlock(
       codexHooksFile,
       pkgRoot,
       hookOptions,
+      managedHookTrustState,
     ),
-    excludedHookTrustStateKeys,
   );
   if (hookTrustToml) {
     lines.push("");
@@ -2462,6 +2996,21 @@ export function buildMergedConfig(
   options: MergeOptions = {},
 ): string {
   let existing = stripOmxSeededBehavioralDefaults(existingConfig);
+  const hookOptions = managedCodexHookOptionsFromMergeOptions(options);
+  const managedTrustState = buildManagedCodexHookTrustStateForConfig(
+    options.codexHooksFile,
+    pkgRoot,
+    hookOptions,
+    options.managedHookTrustState,
+  );
+  const preflightHookTrustStrip = stripManagedCodexHookTrustStateForRefresh(
+    existing,
+    options.priorManagedHookTrustState,
+    managedTrustState,
+  );
+  rejectManagedCodexHookTrustStateConflicts(
+    preflightHookTrustStrip.preservedConflictKeys,
+  );
   const preservedFirstPartyMcpSections =
     options.preserveExistingFirstPartyMcp === true &&
     options.includeFirstPartyMcp !== true
@@ -2495,17 +3044,14 @@ export function buildMergedConfig(
     existing = `${`notify = ${formatTomlStringArray(userNotifyToPreserve)}`}\n${existing.trimStart()}`;
   }
   existing = stripOrphanedManagedNotify(existing, pkgRoot).trimStart();
-  const managedTrustState = buildManagedCodexHookTrustStateForConfig(
-    options.codexHooksFile,
-    pkgRoot,
-    {
-      codexHomeDir: options.codexHomeDir,
-      platform: options.hookCommandPlatform,
-    },
-  );
-  const hookTrustStrip = stripManagedCodexHookTrustStateWithResult(existing, {
+  const hookTrustStrip = stripManagedCodexHookTrustStateForRefresh(
+    existing,
+    options.priorManagedHookTrustState,
     managedTrustState,
-  });
+  );
+  rejectManagedCodexHookTrustStateConflicts(
+    hookTrustStrip.preservedConflictKeys,
+  );
   existing = hookTrustStrip.config;
   if (options.modelOverride) {
     existing = stripRootLevelKeys(existing, ["model"]);
@@ -2536,12 +3082,9 @@ export function buildMergedConfig(
     includeTui && !tuiUpsert.hadExistingTui,
     statusLinePreset,
     options.codexHooksFile,
-    {
-      codexHomeDir: options.codexHomeDir,
-      platform: options.hookCommandPlatform,
-    },
+    hookOptions,
+    managedTrustState,
     options.includeFirstPartyMcp === true,
-    hookTrustStrip.preservedConflictKeys,
   );
   const sharedRegistryBlock = getSharedMcpRegistryBlock(
     options.sharedMcpServers ?? [],
@@ -2555,9 +3098,10 @@ export function buildMergedConfig(
   }
   const bodySeparator = body.length > 0 && !/^\s*\[/.test(body) ? "\n" : "\n\n";
 
-  return addDefaultLauncherMcpStartupTimeouts(
+  const merged = addDefaultLauncherMcpStartupTimeouts(
     topLines.join("\n") + bodySeparator + body + "\n" + tablesBlock,
   );
+  return appendLegacyHookTrustState(merged, options.legacyHookTrustState);
 }
 
 /**

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -248,6 +248,7 @@ const OMX_PRESET_STATUS_LINE_VALUES: ReadonlySet<string> = new Set(
 const LEGACY_OMX_TEAM_RUN_TABLE_PATTERN =
   /^\s*\[mcp_servers\.(?:"omx_team_run"|omx_team_run)\]\s*$/m;
 const OMX_CONFIG_MARKER = "oh-my-codex (OMX) Configuration";
+const OMX_CONFIG_START_MARKER = `# ${OMX_CONFIG_MARKER}`;
 const OMX_CONFIG_END_MARKER = "# End oh-my-codex";
 
 const CODEX_MODEL_AVAILABILITY_NUX_TABLE_PATTERN = /^\s*\[tui\.model_availability_nux\]\s*(?:#.*)?$/;
@@ -1231,6 +1232,354 @@ function analyzeTomlSource(config: string): TomlSourceLexicalAnalysis {
   return { lines, lineStartsOutsideMultiline, lineHasTomlComment, isUnambiguous };
 }
 
+interface TomlSourceKeySegment {
+  key?: string;
+  end: number;
+  incomplete: boolean;
+}
+
+function skipTomlSourceWhitespace(line: string, index: number): number {
+  let cursor = index;
+  while (line[cursor] === " " || line[cursor] === "\t") cursor += 1;
+  return cursor;
+}
+
+function parseTomlSourceKeySegment(
+  line: string,
+  index: number,
+): TomlSourceKeySegment | undefined {
+  const start = skipTomlSourceWhitespace(line, index);
+  const first = line[start];
+  if (!first) return undefined;
+  if (first !== '"' && first !== "'") {
+    const match = /^[A-Za-z0-9_-]+/.exec(line.slice(start));
+    if (!match) return undefined;
+    return { key: match[0], end: start + match[0].length, incomplete: false };
+  }
+
+  let cursor = start + 1;
+  let escaped = false;
+  for (; cursor < line.length; cursor += 1) {
+    const character = line[cursor]!;
+    if (first === '"' && escaped) {
+      escaped = false;
+      continue;
+    }
+    if (first === '"' && character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (character !== first) continue;
+    const token = line.slice(start, cursor + 1);
+    const parsed = safeParseToml(`${token} = true`);
+    const keys = parsed ? Object.keys(parsed) : [];
+    const hasKey = keys.length === 1;
+    return {
+      ...(hasKey ? { key: keys[0] } : {}),
+      end: cursor + 1,
+      incomplete: !hasKey,
+    };
+  }
+  return { end: line.length, incomplete: true };
+}
+
+function isTomlSourceKey(segment: TomlSourceKeySegment, key: string): boolean {
+  return segment.key?.toLowerCase() === key;
+}
+
+function findTomlSourceAssignmentSeparator(line: string): number | undefined {
+  let segment = parseTomlSourceKeySegment(line, 0);
+  if (!segment || segment.incomplete) return undefined;
+  let cursor = skipTomlSourceWhitespace(line, segment.end);
+  while (line[cursor] === ".") {
+    segment = parseTomlSourceKeySegment(line, cursor + 1);
+    if (!segment || segment.incomplete) return undefined;
+    cursor = skipTomlSourceWhitespace(line, segment.end);
+  }
+  return line[cursor] === "=" ? cursor : undefined;
+}
+
+function advancePastInlineTomlValue(line: string, index: number): number {
+  let braces = 0;
+  let brackets = 0;
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+  for (let cursor = index; cursor < line.length; cursor += 1) {
+    const character = line[cursor]!;
+    if (quote) {
+      if (quote === '"' && escaped) {
+        escaped = false;
+      } else if (quote === '"' && character === "\\") {
+        escaped = true;
+      } else if (character === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character === "#") return line.length;
+    if (character === "{") {
+      braces += 1;
+      continue;
+    }
+    if (character === "}") {
+      if (braces === 0 && brackets === 0) return cursor;
+      braces = Math.max(0, braces - 1);
+      continue;
+    }
+    if (character === "[") {
+      brackets += 1;
+      continue;
+    }
+    if (character === "]") {
+      brackets = Math.max(0, brackets - 1);
+      continue;
+    }
+    if (character === "," && braces === 0 && brackets === 0) return cursor + 1;
+  }
+  return line.length;
+}
+
+function inlineTomlTableMaySpellStateKey(line: string, index: number): boolean {
+  let cursor = index;
+  while (cursor < line.length) {
+    cursor = skipTomlSourceWhitespace(line, cursor);
+    // A comment cannot close the surrounding inline table.
+    if (line[cursor] === "#") return true;
+    if (line[cursor] === "}") return false;
+    const segment = parseTomlSourceKeySegment(line, cursor);
+    if (!segment) return true;
+    if (segment.incomplete || isTomlSourceKey(segment, "state")) return true;
+    cursor = skipTomlSourceWhitespace(line, segment.end);
+    if (line[cursor] !== "=") return true;
+    cursor = advancePastInlineTomlValue(line, cursor + 1);
+    if (line[cursor] === "}") return false;
+  }
+  // The unclosed inline table can acquire a state member on a following
+  // unparsed line, so it is not safe to strip the containing marker block.
+  return true;
+}
+
+function lineMaySpellHooksState(line: string): boolean {
+  let cursor = skipTomlSourceWhitespace(line, 0);
+  if (line[cursor] === "[") {
+    if (line[cursor + 1] === "[") {
+      cursor = skipTomlSourceWhitespace(line, cursor + 2);
+    } else {
+      cursor = skipTomlSourceWhitespace(line, cursor + 1);
+    }
+  }
+  const hooks = parseTomlSourceKeySegment(line, cursor);
+  if (!hooks || !isTomlSourceKey(hooks, "hooks")) return false;
+  cursor = skipTomlSourceWhitespace(line, hooks.end);
+  if (line[cursor] === ".") {
+    const state = parseTomlSourceKeySegment(line, cursor + 1);
+    // A dangling dot can be completed by a following unparsed state key.
+    return state === undefined || state.incomplete || isTomlSourceKey(state, "state");
+  }
+  if (line[cursor] !== "=") return false;
+  cursor = skipTomlSourceWhitespace(line, cursor + 1);
+  // A bare assignment or comment cannot prove that a following unparsed line
+  // does not continue an inline hooks table with a state member.
+  if (cursor >= line.length || line[cursor] === "#") return true;
+  return line[cursor] === "{" && inlineTomlTableMaySpellStateKey(line, cursor + 1);
+}
+
+interface TomlSourceArrayTableOpener {
+  firstKey: TomlSourceKeySegment | undefined;
+  openerOnly: boolean;
+}
+
+/**
+ * Detects a potential array-table opener without accepting malformed spacing
+ * or extra opening brackets as TOML syntax. Array tables rooted at `hooks`
+ * have no proof-owned representation, so their first key segment is enough
+ * to retain a managed marker block rather than strip it.
+ */
+function parseTomlSourceArrayTableOpener(
+  line: string,
+): TomlSourceArrayTableOpener | undefined {
+  let cursor = skipTomlSourceWhitespace(line, 0);
+  if (line[cursor] !== "[") return undefined;
+
+  const hasExactAdjacentOpener = line[cursor + 1] === "[";
+  if (hasExactAdjacentOpener) {
+    cursor += 2;
+  } else {
+    cursor = skipTomlSourceWhitespace(line, cursor + 1);
+    if (line[cursor] !== "[") return undefined;
+    cursor += 1;
+  }
+
+  cursor = skipTomlSourceWhitespace(line, cursor);
+  while (line[cursor] === "[") {
+    cursor = skipTomlSourceWhitespace(line, cursor + 1);
+  }
+
+  const firstKey = parseTomlSourceKeySegment(line, cursor);
+  return {
+    firstKey,
+    openerOnly:
+      firstKey === undefined &&
+      (cursor >= line.length || line[cursor] === "#"),
+  };
+}
+
+function hasIncompleteTomlSourceHooksKeyPrefix(line: string): boolean {
+  let cursor = skipTomlSourceWhitespace(line, 0);
+  let tableHeader = false;
+  let arrayTableHeader = false;
+  if (line[cursor] === "[") {
+    tableHeader = true;
+    if (line[cursor + 1] === "[") {
+      arrayTableHeader = true;
+      cursor = skipTomlSourceWhitespace(line, cursor + 2);
+    } else {
+      cursor = skipTomlSourceWhitespace(line, cursor + 1);
+    }
+  }
+  const hooks = parseTomlSourceKeySegment(line, cursor);
+  if (!hooks || !isTomlSourceKey(hooks, "hooks")) return false;
+  cursor = skipTomlSourceWhitespace(line, hooks.end);
+  if (!tableHeader) return cursor >= line.length || line[cursor] === "#";
+  if (line[cursor] !== "]" || (arrayTableHeader && line[cursor + 1] !== "]")) {
+    return true;
+  }
+  const suffix = line.slice(cursor + (arrayTableHeader ? 2 : 1)).trimStart();
+  return suffix.length > 0 && !suffix.startsWith("#");
+}
+
+function isTomlSourceHooksKeyContinuationSeparator(line: string): boolean {
+  const cursor = skipTomlSourceWhitespace(line, 0);
+  return line[cursor] === "." || line[cursor] === "=" || line[cursor] === "[";
+}
+
+function isTomlSourceBlankOrComment(line: string): boolean {
+  return /^\s*(?:#.*)?$/.test(line);
+}
+
+function isTomlSourceStandaloneOpeningBracket(line: string): boolean {
+  const cursor = skipTomlSourceWhitespace(line, 0);
+  if (line[cursor] !== "[") return false;
+  const next = skipTomlSourceWhitespace(line, cursor + 1);
+  return next >= line.length || line[next] === "#";
+}
+
+function firstTomlSourceKeyFollowingOpeningBrackets(
+  line: string,
+): TomlSourceKeySegment | undefined {
+  let cursor = skipTomlSourceWhitespace(line, 0);
+  while (line[cursor] === "[") {
+    cursor = skipTomlSourceWhitespace(line, cursor + 1);
+  }
+  return parseTomlSourceKeySegment(line, cursor);
+}
+
+function lineMaySpellStateKey(line: string): boolean {
+  const state = parseTomlSourceKeySegment(line, 0);
+  return state !== undefined && (state.incomplete || isTomlSourceKey(state, "state"));
+}
+
+function isTomlSourceHooksTableHeader(
+  parsed: Record<string, unknown> | undefined,
+): boolean {
+  const hooks = parsed?.hooks;
+  return parsed !== undefined &&
+    Object.keys(parsed).length === 1 &&
+    isPlainTomlRecord(hooks) &&
+    Object.keys(hooks).length === 0;
+}
+
+function hasUnprovenManagedMarkerHooksStateSyntax(
+  source: TomlSourceLexicalAnalysis,
+  managedMarkerRanges: readonly SourceSpan[],
+  parsedStatementSpans: readonly SourceSpan[],
+  parsedAssignmentSpans: readonly SourceSpan[],
+): boolean {
+  const parsedLines = new Set<number>();
+  const parsedStatementStartLines = new Set<number>();
+  for (const span of parsedStatementSpans) {
+    parsedStatementStartLines.add(span.start);
+    for (let index = span.start; index < span.end; index += 1) parsedLines.add(index);
+  }
+  const parsedAssignmentLines = new Set<number>();
+  for (const span of parsedAssignmentSpans) {
+    for (let index = span.start; index < span.end; index += 1) {
+      parsedAssignmentLines.add(index);
+    }
+  }
+  const managedContentLines = new Set<number>();
+  for (const range of managedMarkerRanges) {
+    for (let index = range.start + 1; index < range.end; index += 1) {
+      managedContentLines.add(index);
+    }
+  }
+
+  let insideHooksTable = false;
+  let hasIncompleteHooksKeyPrefix = false;
+  let hasIncompleteHooksArrayTableOpener = false;
+  for (let index = 0; index < source.lines.length; index += 1) {
+    if (!source.lineStartsOutsideMultiline[index]) {
+      hasIncompleteHooksKeyPrefix = false;
+      hasIncompleteHooksArrayTableOpener = false;
+      continue;
+    }
+    const line = source.lines[index] ?? "";
+    const isParsedAssignmentLine = parsedAssignmentLines.has(index);
+    if (!isParsedAssignmentLine) {
+      const header = parseTomlSourceTableHeader(line);
+      if (header?.parsed) {
+        insideHooksTable = isTomlSourceHooksTableHeader(header.parsed);
+      }
+    }
+    if (!managedContentLines.has(index)) {
+      hasIncompleteHooksKeyPrefix = false;
+      hasIncompleteHooksArrayTableOpener = false;
+      continue;
+    }
+    const isParsedStatementLine = parsedLines.has(index);
+    const isParsedStatementStartLine = parsedStatementStartLines.has(index);
+    if (hasIncompleteHooksKeyPrefix) {
+      if (isTomlSourceBlankOrComment(line)) continue;
+      if (isTomlSourceHooksKeyContinuationSeparator(line)) return true;
+      hasIncompleteHooksKeyPrefix = false;
+    }
+    // Parsed statements can contain nested arrays whose standalone brackets and
+    // quoted "hooks" values must not contribute to malformed-header tracking.
+    if (hasIncompleteHooksArrayTableOpener && !isParsedStatementLine) {
+      if (isTomlSourceBlankOrComment(line)) continue;
+      const firstKey = firstTomlSourceKeyFollowingOpeningBrackets(line);
+      if (firstKey) {
+        if (isTomlSourceKey(firstKey, "hooks")) return true;
+        hasIncompleteHooksArrayTableOpener = false;
+      }
+    }
+    const arrayTableOpener = !isParsedStatementLine || isParsedStatementStartLine
+      ? parseTomlSourceArrayTableOpener(line)
+      : undefined;
+    if (arrayTableOpener?.firstKey && isTomlSourceKey(arrayTableOpener.firstKey, "hooks")) {
+      return true;
+    }
+    if (arrayTableOpener?.openerOnly && !isParsedStatementLine) {
+      hasIncompleteHooksArrayTableOpener = true;
+    }
+    if (!isParsedStatementLine && isTomlSourceStandaloneOpeningBracket(line)) {
+      hasIncompleteHooksArrayTableOpener = true;
+    }
+    if (isParsedStatementLine) continue;
+    if (lineMaySpellHooksState(line) || (insideHooksTable && lineMaySpellStateKey(line))) {
+      return true;
+    }
+    const hasIncompleteHooksPrefix = hasIncompleteTomlSourceHooksKeyPrefix(line);
+    if (hasIncompleteHooksPrefix && /^\s*\[\[?/.test(line)) return true;
+    hasIncompleteHooksKeyPrefix = hasIncompleteHooksPrefix;
+  }
+  return false;
+}
+
 interface TomlSourceTableHeader {
   parsed: Record<string, unknown> | undefined;
 }
@@ -1265,13 +1614,43 @@ function managedHookTrustStateExpectations(
   return expectations;
 }
 
+function managedHookTrustCoordinateFamily(key: string): string | undefined {
+  const match = /^(.*):([a-z_]+):\d+:\d+$/.exec(key);
+  return match ? `${match[1]}:${match[2]}` : undefined;
+}
+
+function expectedManagedHookTrustHashes(
+  expectations: ManagedHookTrustStateExpectations,
+  key: string,
+  allowCoordinateDrift: boolean,
+): ReadonlySet<string> | undefined {
+  const exact = expectations.get(key);
+  if (exact || !allowCoordinateDrift) return exact;
+  const family = managedHookTrustCoordinateFamily(key);
+  if (!family) return undefined;
+  const hashes = new Set<string>();
+  for (const [expectedKey, expectedHashes] of expectations) {
+    if (managedHookTrustCoordinateFamily(expectedKey) !== family) continue;
+    for (const hash of expectedHashes) hashes.add(hash);
+  }
+  return hashes.size > 0 ? hashes : undefined;
+}
+
+function tomlHooksStateValue(
+  parsed: Record<string, unknown> | undefined,
+): unknown {
+  if (!parsed) return undefined;
+  const hooks = parsed.hooks;
+  if (!isPlainTomlRecord(hooks) || !Object.hasOwn(hooks, "state")) {
+    return undefined;
+  }
+  return hooks.state;
+}
+
 function tomlHooksStateEntries(
   parsed: Record<string, unknown> | undefined,
 ): Record<string, unknown> | undefined {
-  if (!parsed) return undefined;
-  const hooks = parsed.hooks;
-  if (!isPlainTomlRecord(hooks)) return undefined;
-  const state = hooks.state;
+  const state = tomlHooksStateValue(parsed);
   return isPlainTomlRecord(state) ? state : undefined;
 }
 
@@ -1341,9 +1720,62 @@ function sourceRangeHasTomlComment(
   return false;
 }
 
+function collectMarkerRanges(
+  source: TomlSourceLexicalAnalysis,
+  startMarker: string,
+  endMarker: string,
+  includeUnterminatedRange = false,
+): SourceSpan[] {
+  const ranges: SourceSpan[] = [];
+  for (let start = 0; start < source.lines.length; start += 1) {
+    if (
+      !source.lineStartsOutsideMultiline[start] ||
+      source.lines[start]?.trim() !== startMarker
+    ) continue;
+    const end = source.lines.findIndex(
+      (line, index) =>
+        index > start &&
+        source.lineStartsOutsideMultiline[index] &&
+        line.trim() === endMarker,
+    );
+    const nestedStart = source.lines.findIndex(
+      (line, index) =>
+        index > start &&
+        source.lineStartsOutsideMultiline[index] &&
+        line.trim() === startMarker,
+    );
+    if (end === -1 || (nestedStart !== -1 && nestedStart < end)) {
+      if (includeUnterminatedRange) ranges.push({ start, end: source.lines.length });
+      continue;
+    }
+    ranges.push({ start, end });
+    start = end;
+  }
+  return ranges;
+}
+
+function recordManagedMarkerHooksStateSourceSpan(
+  spans: SourceSpan[],
+  invalidSpans: SourceSpan[],
+  start: number,
+  end: number,
+  parsed: Record<string, unknown> | undefined,
+  insideManagedMarkerBlock: boolean,
+): void {
+  if (!insideManagedMarkerBlock) return;
+  const state = tomlHooksStateValue(parsed);
+  if (state === undefined) return;
+  const span = { start, end };
+  spans.push(span);
+  if (!isPlainTomlRecord(state) || Object.keys(state).length === 0) {
+    invalidSpans.push(span);
+  }
+}
+
 function addManagedHookTrustStateSourceRepresentations(
   representations: Map<string, ManagedHookTrustStateSourceRepresentation[]>,
-  expectations: ManagedHookTrustStateExpectations,
+  markerContainedHooksStateSpans: SourceSpan[],
+  invalidMarkerContainedHooksStateSpans: SourceSpan[],
   source: TomlSourceLexicalAnalysis,
   start: number,
   end: number,
@@ -1352,17 +1784,23 @@ function addManagedHookTrustStateSourceRepresentations(
   containingTableScope?: TomlSourceTableScope,
   fallbackKeys: readonly string[] = [],
 ): void {
+  recordManagedMarkerHooksStateSourceSpan(
+    markerContainedHooksStateSpans,
+    invalidMarkerContainedHooksStateSpans,
+    start,
+    end,
+    parsed,
+    insideManagedMarkerBlock,
+  );
   const state = tomlHooksStateEntries(parsed);
   const hasComment = sourceRangeHasTomlComment(source, start, end);
   if (state) {
     const stateEntryCount = Object.keys(state).length;
     for (const [key, value] of Object.entries(state)) {
-      if (!expectations.has(key)) continue;
       const hasExactSemanticScope = hasOnlyManagedHookTrustStateField(parsed, key) &&
         (!containingTableScope ||
           (!containingTableScope.hasComment &&
             hasOnlyManagedHookTrustStateField(containingTableScope.parsed, key)));
-
       const entries = representations.get(key) ?? [];
       entries.push({
         start,
@@ -1379,7 +1817,6 @@ function addManagedHookTrustStateSourceRepresentations(
   }
 
   for (const key of fallbackKeys) {
-    if (!expectations.has(key)) continue;
     const entries = representations.get(key) ?? [];
     entries.push({
       start,
@@ -1396,17 +1833,36 @@ function addManagedHookTrustStateSourceRepresentations(
 
 function collectManagedHookTrustStateSourceRepresentations(
   config: string,
-  expectations: ManagedHookTrustStateExpectations,
 ): {
   source: TomlSourceLexicalAnalysis;
   representations: Map<string, ManagedHookTrustStateSourceRepresentation[]>;
+  managedMarkerRanges: SourceSpan[];
+  markerContainedHooksStateSpans: SourceSpan[];
+  invalidMarkerContainedHooksStateSpans: SourceSpan[];
+  parsedStatementSpans: SourceSpan[];
+  parsedAssignmentSpans: SourceSpan[];
 } {
+
   const source = analyzeTomlSource(config);
   const { lines } = source;
+  const parsedAssignmentSpans: SourceSpan[] = [];
+  for (let cursor = 0; cursor < lines.length; cursor += 1) {
+    if (!source.lineStartsOutsideMultiline[cursor]) continue;
+    const line = lines[cursor] ?? "";
+    if (findTomlSourceAssignmentSeparator(line) === undefined) continue;
+
+    for (let statementEnd = cursor + 1; statementEnd <= lines.length; statementEnd += 1) {
+      if (!safeParseToml(lines.slice(cursor, statementEnd).join("\n"))) continue;
+      parsedAssignmentSpans.push({ start: cursor, end: statementEnd });
+      cursor = statementEnd - 1;
+      break;
+    }
+  }
   const headers: Array<{ index: number; header: TomlSourceTableHeader }> = [];
   for (const [index, line] of lines.entries()) {
     if (!source.lineStartsOutsideMultiline[index]) continue;
     const header = parseTomlSourceTableHeader(line);
+    if (parsedAssignmentSpans.some((span) => span.start < index && index < span.end)) continue;
     if (header) headers.push({ index, header });
   }
 
@@ -1414,38 +1870,33 @@ function collectManagedHookTrustStateSourceRepresentations(
   for (const [index, line] of lines.entries()) {
     if (
       source.lineStartsOutsideMultiline[index] &&
-      line.trim() === OMX_HOOK_TRUST_END_MARKER
+      (line.trim() === OMX_HOOK_TRUST_END_MARKER ||
+        line.trim() === OMX_CONFIG_END_MARKER)
     ) {
       boundaries.add(index);
     }
   }
   const sortedBoundaries = [...boundaries].sort((left, right) => left - right);
   const representations = new Map<string, ManagedHookTrustStateSourceRepresentation[]>();
-  const managedMarkerRanges: SourceSpan[] = [];
-  for (let start = 0; start < lines.length; start += 1) {
-    if (
-      !source.lineStartsOutsideMultiline[start] ||
-      lines[start]?.trim() !== OMX_HOOK_TRUST_START_MARKER
-    ) continue;
-    const end = lines.findIndex(
-      (line, index) =>
-        index > start &&
-        source.lineStartsOutsideMultiline[index] &&
-        line.trim() === OMX_HOOK_TRUST_END_MARKER,
-    );
-    const nestedStart = lines.findIndex(
-      (line, index) =>
-        index > start &&
-        source.lineStartsOutsideMultiline[index] &&
-        line.trim() === OMX_HOOK_TRUST_START_MARKER,
-    );
-    if (end === -1 || (nestedStart !== -1 && nestedStart < end)) continue;
-    managedMarkerRanges.push({ start, end });
-    start = end;
-  }
+  const markerContainedHooksStateSpans: SourceSpan[] = [];
+  const invalidMarkerContainedHooksStateSpans: SourceSpan[] = [];
+  const parsedStatementSpans: SourceSpan[] = [];
+
+  const managedMarkerRanges = [
+    ...collectMarkerRanges(
+      source,
+      OMX_HOOK_TRUST_START_MARKER,
+      OMX_HOOK_TRUST_END_MARKER,
+    ),
+    ...collectMarkerRanges(
+      source,
+      OMX_CONFIG_START_MARKER,
+      OMX_CONFIG_END_MARKER,
+      true,
+    ),
+  ];
   const isInsideManagedMarkerBlock = (start: number, end: number): boolean =>
     managedMarkerRanges.some((range) => start > range.start && end <= range.end);
-
   const collectAssignments = (
     start: number,
     end: number,
@@ -1457,7 +1908,8 @@ function collectManagedHookTrustStateSourceRepresentations(
       if (
         !source.lineStartsOutsideMultiline[cursor] ||
         line.trim().length === 0 ||
-        source.lineHasTomlComment[cursor]
+        line.trim() === OMX_HOOK_TRUST_START_MARKER ||
+        line.trim() === OMX_CONFIG_START_MARKER
       ) {
         cursor += 1;
         continue;
@@ -1474,9 +1926,11 @@ function collectManagedHookTrustStateSourceRepresentations(
         cursor += 1;
         continue;
       }
+      parsedStatementSpans.push({ start: cursor, end: statementEnd });
       addManagedHookTrustStateSourceRepresentations(
         representations,
-        expectations,
+        markerContainedHooksStateSpans,
+        invalidMarkerContainedHooksStateSpans,
         source,
         cursor,
         statementEnd,
@@ -1499,17 +1953,28 @@ function collectManagedHookTrustStateSourceRepresentations(
       parsed: safeParseToml(lines.slice(index, end).join("\n")),
       hasComment: sourceRangeHasTomlComment(source, index, end),
     };
+    if (tableScope.parsed) parsedStatementSpans.push({ start: index, end });
+    const insideManagedMarkerBlock = isInsideManagedMarkerBlock(index, end);
+    recordManagedMarkerHooksStateSourceSpan(
+      markerContainedHooksStateSpans,
+      invalidMarkerContainedHooksStateSpans,
+      index,
+      end,
+      tableScope.parsed,
+      insideManagedMarkerBlock,
+    );
     const headerState = tomlHooksStateEntries(header.parsed);
-    const directKeys = Object.keys(headerState ?? {}).filter((key) => expectations.has(key));
+    const directKeys = Object.keys(headerState ?? {});
     if (directKeys.length > 0) {
       addManagedHookTrustStateSourceRepresentations(
         representations,
-        expectations,
+        markerContainedHooksStateSpans,
+        invalidMarkerContainedHooksStateSpans,
         source,
         index,
         end,
         tableScope.parsed,
-        isInsideManagedMarkerBlock(index, end),
+        insideManagedMarkerBlock,
         undefined,
         directKeys,
       );
@@ -1518,7 +1983,15 @@ function collectManagedHookTrustStateSourceRepresentations(
     collectAssignments(index + 1, end, lines[index], tableScope);
   }
 
-  return { source, representations };
+  return {
+    source,
+    representations,
+    managedMarkerRanges,
+    markerContainedHooksStateSpans,
+    invalidMarkerContainedHooksStateSpans,
+    parsedStatementSpans,
+    parsedAssignmentSpans,
+  };
 }
 
 function isExactlyManagedHookTrustStateValue(
@@ -1530,6 +2003,46 @@ function isExactlyManagedHookTrustStateValue(
     Object.hasOwn(value, "trusted_hash") &&
     typeof value.trusted_hash === "string" &&
     expectedHashes.has(value.trusted_hash);
+}
+
+function managedMarkerTrustStateConflicts(
+  source: TomlSourceLexicalAnalysis,
+  representations: ReadonlyMap<string, readonly ManagedHookTrustStateSourceRepresentation[]>,
+  managedMarkerRanges: readonly SourceSpan[],
+  markerContainedHooksStateSpans: readonly SourceSpan[],
+  invalidMarkerContainedHooksStateSpans: readonly SourceSpan[],
+  parsedStatementSpans: readonly SourceSpan[],
+  parsedAssignmentSpans: readonly SourceSpan[],
+  expectations: ManagedHookTrustStateExpectations,
+): Set<string> {
+  const conflicts = new Set<string>();
+  if (invalidMarkerContainedHooksStateSpans.length > 0 ||
+    hasUnprovenManagedMarkerHooksStateSyntax(
+      source,
+      managedMarkerRanges,
+      [...markerContainedHooksStateSpans, ...parsedStatementSpans],
+      parsedAssignmentSpans,
+    )) {
+    conflicts.add("marker-contained hooks.state");
+  }
+
+  for (const [key, sourceRepresentations] of representations) {
+    for (const representation of sourceRepresentations) {
+      if (!representation.insideManagedMarkerBlock) continue;
+      const expectedHashes = expectedManagedHookTrustHashes(
+        expectations,
+        key,
+        true,
+      );
+      const isExactOwnedRepresentation = expectedHashes !== undefined &&
+        representation.stateEntryCount === 1 &&
+        !representation.hasComment &&
+        representation.hasExactSemanticScope &&
+        isExactlyManagedHookTrustStateValue(representation.value, expectedHashes);
+      if (!source.isUnambiguous || !isExactOwnedRepresentation) conflicts.add(key);
+    }
+  }
+  return conflicts;
 }
 
 function removeEmptyManagedHookTrustStateMarkerBlocks(
@@ -1584,19 +2097,29 @@ function stripProofManagedCodexHookTrustStateTables(
   config: string,
   expectations: ManagedHookTrustStateExpectations,
 ): HookTrustStateStripResult {
-  if (expectations.size === 0) {
-    return { config, preservedConflictKeys: new Set() };
-  }
-
-  const { source, representations } = collectManagedHookTrustStateSourceRepresentations(
-    config,
+  const {
+    source,
+    representations,
+    managedMarkerRanges,
+    markerContainedHooksStateSpans,
+    invalidMarkerContainedHooksStateSpans,
+    parsedStatementSpans,
+    parsedAssignmentSpans,
+  } = collectManagedHookTrustStateSourceRepresentations(config);
+  const preservedConflictKeys = managedMarkerTrustStateConflicts(
+    source,
+    representations,
+    managedMarkerRanges,
+    markerContainedHooksStateSpans,
+    invalidMarkerContainedHooksStateSpans,
+    parsedStatementSpans,
+    parsedAssignmentSpans,
     expectations,
   );
   if (!source.isUnambiguous) {
-    return { config, preservedConflictKeys: new Set() };
+    return { config, preservedConflictKeys };
   }
   const { lines } = source;
-  const preservedConflictKeys = new Set<string>();
   const removals = new Map<string, SourceSpan>();
   const parsedConfigState = tomlHooksStateEntries(safeParseToml(config));
 
@@ -1607,14 +2130,27 @@ function stripProofManagedCodexHookTrustStateTables(
   }
 
   for (const [key, sourceRepresentations] of representations) {
-    const expectedHashes = expectations.get(key)!;
     const isExactOwnedRepresentation = (
       representation: ManagedHookTrustStateSourceRepresentation,
-    ): boolean =>
-      representation.stateEntryCount === 1 &&
-      !representation.hasComment &&
-      representation.hasExactSemanticScope &&
-      isExactlyManagedHookTrustStateValue(representation.value, expectedHashes);
+    ): boolean => {
+      const expectedHashes = expectedManagedHookTrustHashes(
+        expectations,
+        key,
+        representation.insideManagedMarkerBlock,
+      );
+      return expectedHashes !== undefined &&
+        representation.stateEntryCount === 1 &&
+        !representation.hasComment &&
+        representation.hasExactSemanticScope &&
+        isExactlyManagedHookTrustStateValue(representation.value, expectedHashes);
+    };
+    if (!sourceRepresentations.some((representation) =>
+      expectedManagedHookTrustHashes(
+        expectations,
+        key,
+        representation.insideManagedMarkerBlock,
+      ) !== undefined
+    )) continue;
     const mayRemoveAll = sourceRepresentations.length === 1
       ? isExactOwnedRepresentation(sourceRepresentations[0]!)
       : sourceRepresentations.every(
@@ -2545,42 +3081,58 @@ export function stripExistingOmxBlocks(config: string): {
   cleaned: string;
   removed: number;
 } {
-  let cleaned = config;
-  let removed = 0;
-
-  while (true) {
-    const markerIdx = cleaned.indexOf(OMX_CONFIG_MARKER);
-    if (markerIdx < 0) break;
-
-    let blockStart = cleaned.lastIndexOf("\n", markerIdx);
-    blockStart = blockStart >= 0 ? blockStart + 1 : 0;
-
-    const previousLineEnd = blockStart - 1;
-    if (previousLineEnd >= 0) {
-      const previousLineStart = cleaned.lastIndexOf("\n", previousLineEnd - 1);
-      const previousLine = cleaned.slice(
-        previousLineStart + 1,
-        previousLineEnd,
-      );
-      if (/^# =+$/.test(previousLine.trim())) {
-        blockStart = previousLineStart >= 0 ? previousLineStart + 1 : 0;
-      }
-    }
-
-    let blockEnd = cleaned.length;
-    const endIdx = cleaned.indexOf(OMX_CONFIG_END_MARKER, markerIdx);
-    if (endIdx >= 0) {
-      const endLineBreak = cleaned.indexOf("\n", endIdx);
-      blockEnd = endLineBreak >= 0 ? endLineBreak + 1 : cleaned.length;
-    }
-
-    const before = cleaned.slice(0, blockStart).trimEnd();
-    const after = cleaned.slice(blockEnd).trimStart();
-    cleaned = [before, after].filter(Boolean).join("\n\n");
-    removed += 1;
+  const source = analyzeTomlSource(config);
+  const markerRanges = collectMarkerRanges(
+    source,
+    OMX_CONFIG_START_MARKER,
+    OMX_CONFIG_END_MARKER,
+  );
+  if (markerRanges.length === 0) return { cleaned: config, removed: 0 };
+  const { parsedAssignmentSpans, parsedStatementSpans } =
+    collectManagedHookTrustStateSourceRepresentations(config);
+  if (hasUnprovenManagedMarkerHooksStateSyntax(
+    source,
+    markerRanges,
+    parsedStatementSpans,
+    parsedAssignmentSpans,
+  )) {
+    rejectManagedCodexHookTrustStateConflicts(new Set(["marker-contained hooks.state"]));
   }
+  if (!source.isUnambiguous) return { cleaned: config, removed: 0 };
 
-  return { cleaned, removed };
+  const lines = sourceLines(config);
+  if (markerRanges.some((range) => !lines[range.start] || !lines[range.end])) {
+    return { cleaned: config, removed: 0 };
+  }
+  const removalRanges = markerRanges.map((range) => {
+    const startLine = lines[range.start]!;
+    const endLine = lines[range.end]!;
+    const previousLine = lines[range.start - 1];
+    const start = previousLine && /^# =+$/.test(previousLine.content.trim())
+      ? previousLine.start
+      : startLine.start;
+    return { start, end: endLine.end };
+  });
+
+  const segments: string[] = [];
+  let cursor = 0;
+  for (const range of removalRanges) {
+    segments.push(config.slice(cursor, range.start));
+    cursor = range.end;
+  }
+  segments.push(config.slice(cursor));
+
+  const cleaned = segments
+    .map((segment, index) =>
+      index === 0
+        ? segment.trimEnd()
+        : index === segments.length - 1
+        ? segment.trimStart()
+        : segment.trim()
+    )
+    .filter(Boolean)
+    .join("\n\n");
+  return { cleaned, removed: markerRanges.length };
 }
 
 export function stripExistingSharedMcpRegistryBlock(config: string): {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -32,10 +32,12 @@ import {
   buildManagedCodexHookTrustState,
   escapeTomlBasicString,
   ManagedCodexHooksPlanError,
+  scanManagedCodexHookTrustStateFromContent,
   type CodexHooksJsonTrustStateEntry,
   type ManagedCodexHookTrustState,
   type ManagedCodexHookOptions,
 } from "./codex-hooks.js";
+
 import type { HudPreset } from "../hud/types.js";
 
 interface MergeOptions {
@@ -1284,7 +1286,7 @@ function parseTomlSourceKeySegment(
 }
 
 function isTomlSourceKey(segment: TomlSourceKeySegment, key: string): boolean {
-  return segment.key?.toLowerCase() === key;
+  return segment.key === key;
 }
 
 function findTomlSourceAssignmentSeparator(line: string): number | undefined {
@@ -1725,23 +1727,29 @@ function collectMarkerRanges(
   startMarker: string,
   endMarker: string,
   includeUnterminatedRange = false,
+  inertAssignmentSpans: readonly SourceSpan[] = [],
 ): SourceSpan[] {
+  const isInsideInertAssignment = (line: number): boolean =>
+    inertAssignmentSpans.some((span) => span.start <= line && line < span.end);
   const ranges: SourceSpan[] = [];
   for (let start = 0; start < source.lines.length; start += 1) {
     if (
       !source.lineStartsOutsideMultiline[start] ||
+      isInsideInertAssignment(start) ||
       source.lines[start]?.trim() !== startMarker
     ) continue;
     const end = source.lines.findIndex(
       (line, index) =>
         index > start &&
         source.lineStartsOutsideMultiline[index] &&
+        !isInsideInertAssignment(index) &&
         line.trim() === endMarker,
     );
     const nestedStart = source.lines.findIndex(
       (line, index) =>
         index > start &&
         source.lineStartsOutsideMultiline[index] &&
+        !isInsideInertAssignment(index) &&
         line.trim() === startMarker,
     );
     if (end === -1 || (nestedStart !== -1 && nestedStart < end)) {
@@ -1887,12 +1895,15 @@ function collectManagedHookTrustStateSourceRepresentations(
       source,
       OMX_HOOK_TRUST_START_MARKER,
       OMX_HOOK_TRUST_END_MARKER,
+      false,
+      parsedAssignmentSpans,
     ),
     ...collectMarkerRanges(
       source,
       OMX_CONFIG_START_MARKER,
       OMX_CONFIG_END_MARKER,
       true,
+      parsedAssignmentSpans,
     ),
   ];
   const isInsideManagedMarkerBlock = (start: number, end: number): boolean =>
@@ -2016,7 +2027,9 @@ function managedMarkerTrustStateConflicts(
   expectations: ManagedHookTrustStateExpectations,
 ): Set<string> {
   const conflicts = new Set<string>();
-  if (invalidMarkerContainedHooksStateSpans.length > 0 ||
+  const isInsideManagedMarkerRange = (span: SourceSpan): boolean =>
+    managedMarkerRanges.some((range) => span.start > range.start && span.end <= range.end);
+  if (invalidMarkerContainedHooksStateSpans.some(isInsideManagedMarkerRange) ||
     hasUnprovenManagedMarkerHooksStateSyntax(
       source,
       managedMarkerRanges,
@@ -2028,7 +2041,7 @@ function managedMarkerTrustStateConflicts(
 
   for (const [key, sourceRepresentations] of representations) {
     for (const representation of sourceRepresentations) {
-      if (!representation.insideManagedMarkerBlock) continue;
+      if (!isInsideManagedMarkerRange(representation)) continue;
       const expectedHashes = expectedManagedHookTrustHashes(
         expectations,
         key,
@@ -3077,27 +3090,40 @@ function upsertTuiStatusLine(
 // OMX [table] sections block (appended at end of file)
 // ---------------------------------------------------------------------------
 
-export function stripExistingOmxBlocks(config: string): {
+export function stripExistingOmxBlocks(
+  config: string,
+  options: {
+    managedTrustState?: ManagedCodexHookTrustStateMap;
+    priorManagedHookTrustState?: ManagedCodexHookTrustStateMap;
+  } = {},
+): {
   cleaned: string;
   removed: number;
 } {
-  const source = analyzeTomlSource(config);
+  const inventory = collectManagedHookTrustStateSourceRepresentations(config);
+  const { source } = inventory;
   const markerRanges = collectMarkerRanges(
     source,
     OMX_CONFIG_START_MARKER,
     OMX_CONFIG_END_MARKER,
+    false,
+    inventory.parsedAssignmentSpans,
   );
   if (markerRanges.length === 0) return { cleaned: config, removed: 0 };
-  const { parsedAssignmentSpans, parsedStatementSpans } =
-    collectManagedHookTrustStateSourceRepresentations(config);
-  if (hasUnprovenManagedMarkerHooksStateSyntax(
+  const conflicts = managedMarkerTrustStateConflicts(
     source,
+    inventory.representations,
     markerRanges,
-    parsedStatementSpans,
-    parsedAssignmentSpans,
-  )) {
-    rejectManagedCodexHookTrustStateConflicts(new Set(["marker-contained hooks.state"]));
-  }
+    inventory.markerContainedHooksStateSpans,
+    inventory.invalidMarkerContainedHooksStateSpans,
+    inventory.parsedStatementSpans,
+    inventory.parsedAssignmentSpans,
+    managedHookTrustStateExpectations(
+      options.priorManagedHookTrustState,
+      options.managedTrustState,
+    ),
+  );
+  rejectManagedCodexHookTrustStateConflicts(conflicts);
   if (!source.isUnambiguous) return { cleaned: config, removed: 0 };
 
   const lines = sourceLines(config);
@@ -3575,7 +3601,10 @@ export function buildMergedConfig(
     extractCustomizedTuiSectionsFromOmxBlocks(existing);
 
   if (existing.includes(OMX_CONFIG_MARKER)) {
-    const stripped = stripExistingOmxBlocks(existing);
+    const stripped = stripExistingOmxBlocks(existing, {
+      managedTrustState,
+      priorManagedHookTrustState: options.priorManagedHookTrustState,
+    });
     existing = stripped.cleaned;
     if (customizedManagedTuiSections.length > 0) {
       existing = `${existing.trimEnd()}\n\n${customizedManagedTuiSections.join("\n\n")}\n`;
@@ -3667,6 +3696,58 @@ export function buildMergedConfig(
  *
  * Returns `true` if a repair was performed.
  */
+function managedHookTrustProofRequiredForRepair(config: string): boolean {
+  const inventory = collectManagedHookTrustStateSourceRepresentations(config);
+  return managedMarkerTrustStateConflicts(
+    inventory.source,
+    inventory.representations,
+    inventory.managedMarkerRanges,
+    inventory.markerContainedHooksStateSpans,
+    inventory.invalidMarkerContainedHooksStateSpans,
+    inventory.parsedStatementSpans,
+    inventory.parsedAssignmentSpans,
+    managedHookTrustStateExpectations(),
+  ).size > 0;
+}
+
+async function launchRepairOptionsWithManagedHookTrustProof(
+  configPath: string,
+  config: string,
+  options: MergeOptions,
+): Promise<MergeOptions> {
+  if (!managedHookTrustProofRequiredForRepair(config)) {
+
+    return options;
+  }
+
+  const hooksPath = options.codexHooksFile ?? resolve(configPath, "..", "hooks.json");
+  let hooksContent: string;
+  try {
+    hooksContent = await readFile(hooksPath, "utf-8");
+  } catch (error) {
+    throw new ManagedCodexHooksPlanError(
+      "invalid_document",
+      `Cannot safely repair config.toml because the current hooks artifact at ${hooksPath} could not be read.`,
+      { cause: String(error), hooksPath },
+    );
+  }
+
+  const trustScan = scanManagedCodexHookTrustStateFromContent(
+    hooksContent,
+    hooksPath,
+    managedCodexHookOptionsFromMergeOptions(options),
+  );
+  if (!trustScan.ok) throw trustScan.error;
+
+  return {
+    ...options,
+    codexHooksFile: hooksPath,
+    codexHooksContent: hooksContent,
+    managedHookTrustState: trustScan.trustState,
+    priorManagedHookTrustState: trustScan.trustState,
+  };
+}
+
 export async function repairConfigIfNeeded(
   configPath: string,
   pkgRoot: string,
@@ -3682,8 +3763,14 @@ export async function repairConfigIfNeeded(
   if (tuiCount <= 1 && !hasLegacyTeamRunTable && !hasLauncherTimeoutGap)
     return false;
 
-  // Managed config compatibility issue detected — run full merge to repair
-  const repaired = buildMergedConfig(content, pkgRoot, options);
+  // Managed config compatibility issue detected — derive proof from the current
+  // hooks artifact before any marker stripping can replace managed trust state.
+  const repairOptions = await launchRepairOptionsWithManagedHookTrustProof(
+    configPath,
+    content,
+    options,
+  );
+  const repaired = buildMergedConfig(content, pkgRoot, repairOptions);
   if (repaired === content) return false;
   await writeFile(configPath, repaired);
   return true;
@@ -3700,12 +3787,6 @@ export async function mergeConfig(
     existing = await readFile(configPath, "utf-8");
   }
 
-  if (existing.includes("oh-my-codex (OMX) Configuration")) {
-    const stripped = stripExistingOmxBlocks(existing);
-    if (options.verbose && stripped.removed > 0) {
-      console.log("  Updating existing OMX config block.");
-    }
-  }
 
   const finalConfig = buildMergedConfig(existing, pkgRoot, options);
 

--- a/src/scripts/__tests__/smoke-packed-install.test.ts
+++ b/src/scripts/__tests__/smoke-packed-install.test.ts
@@ -379,6 +379,124 @@ test('packed lifecycle treats only the production command grammar as managed own
     /Expected exactly one OMX SessionStart hook from Codex, received 0/,
   );
 });
+test('packed lifecycle resolves Windows npm shims through safe command specs for version probes and app-server', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'omx-codex-windows-shim-'));
+  const fakeChild = () => {
+    const child = Object.assign(new EventEmitter(), {
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      kill: () => {
+        queueMicrotask(() => child.emit('close', 0, null));
+        return true;
+      },
+    });
+    child.stdin.once('finish', () => queueMicrotask(() => child.emit('close', 0, null)));
+    queueMicrotask(() => child.emit('spawn'));
+    return child;
+  };
+
+  try {
+    for (const extension of ['.cmd', '.ps1']) {
+      const bin = join(root, extension.slice(1));
+      const codexPath = join(bin, `codex${extension}`);
+      const powershellPath = join(bin, 'powershell.exe');
+      await mkdir(bin, { recursive: true });
+      await Promise.all([writeFile(codexPath, ''), writeFile(powershellPath, '')]);
+
+      const versionSpawns: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = [];
+      const appSpawns: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = [];
+      const seam = {
+        platform: 'win32' as const,
+        spawnSyncImpl: ((command: string, args: string[], options: Record<string, unknown>) => {
+          versionSpawns.push({ command, args, options });
+          return { status: 0, stdout: 'codex-cli 0.142.5\n', stderr: '', error: undefined };
+        }) as never,
+        spawnImpl: ((command: string, args: string[], options: Record<string, unknown>) => {
+          appSpawns.push({ command, args, options });
+          return fakeChild();
+        }) as never,
+      };
+      const env = { PATH: bin, PATHEXT: extension.toUpperCase() };
+
+      assert.equal(probeCodexVersion(root, env, seam), 'codex-cli 0.142.5');
+      const server = await CodexAppServer.start({ cwd: root, env, commandSeam: seam });
+      await server.close();
+
+      assert.equal(versionSpawns.length, 2);
+      assert.deepEqual(versionSpawns.map(({ command, args, options }) => ({ command, args, options })),
+        extension === '.cmd'
+          ? [
+            {
+              command: 'cmd.exe',
+              args: ['/d', '/s', '/c', `""${codexPath}" "--version""`],
+              options: {
+                cwd: root,
+                env,
+                encoding: 'utf-8',
+                timeout: CODEX_APP_SERVER_TIMEOUTS.versionProbeMs,
+                killSignal: 'SIGKILL',
+                windowsHide: true,
+                windowsVerbatimArguments: true,
+              },
+            },
+            {
+              command: 'cmd.exe',
+              args: ['/d', '/s', '/c', `""${codexPath}" "--version""`],
+              options: {
+                cwd: root,
+                env,
+                encoding: 'utf-8',
+                timeout: CODEX_APP_SERVER_TIMEOUTS.versionProbeMs,
+                killSignal: 'SIGKILL',
+                windowsHide: true,
+                windowsVerbatimArguments: true,
+              },
+            },
+          ]
+          : [
+            {
+              command: powershellPath,
+              args: ['-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', codexPath, '--version'],
+              options: {
+                cwd: root,
+                env,
+                encoding: 'utf-8',
+                timeout: CODEX_APP_SERVER_TIMEOUTS.versionProbeMs,
+                killSignal: 'SIGKILL',
+                windowsHide: true,
+              },
+            },
+            {
+              command: powershellPath,
+              args: ['-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', codexPath, '--version'],
+              options: {
+                cwd: root,
+                env,
+                encoding: 'utf-8',
+                timeout: CODEX_APP_SERVER_TIMEOUTS.versionProbeMs,
+                killSignal: 'SIGKILL',
+                windowsHide: true,
+              },
+            },
+          ],
+      );
+      assert.deepEqual(appSpawns, extension === '.cmd'
+        ? [{
+          command: 'cmd.exe',
+          args: ['/d', '/s', '/c', `""${codexPath}" "app-server" "--stdio""`],
+          options: { cwd: root, env, stdio: 'pipe', windowsHide: true, windowsVerbatimArguments: true },
+        }]
+        : [{
+          command: powershellPath,
+          args: ['-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', codexPath, 'app-server', '--stdio'],
+          options: { cwd: root, env, stdio: 'pipe', windowsHide: true },
+        }]);
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
 
 test('packed lifecycle bypasses an unrelated codex binary shadowing the pinned CLI', async () => {
   if (process.platform === 'win32') return;
@@ -707,9 +825,25 @@ test('packed lifecycle and native hook smoke share the seven managed event names
   assert.deepEqual(MANAGED_CODEX_HOOK_EVENTS, PACKED_INSTALL_NATIVE_HOOK_SMOKE_EVENTS);
 });
 
-test('packed install native hook stdout validation allows empty or JSON output only', () => {
+test('packed install native hook stdout validation enforces event output contracts', () => {
   assert.doesNotThrow(() => validateHookStdout('PostCompact', ''));
   assert.doesNotThrow(() => validateHookStdout('Stop', '{}\n'));
+  assert.throws(
+    () => validateHookStdout('PostCompact', '{}\n'),
+    /PostCompact must emit empty stdout/,
+  );
+  for (const value of ['\n', ' ', ' \r\n']) {
+    assert.throws(
+      () => validateHookStdout('PostCompact', value),
+      /PostCompact must emit empty stdout/,
+    );
+  }
+  for (const value of ['null', '[]', '"text"', '1']) {
+    assert.throws(
+      () => validateHookStdout('Stop', value),
+      /non-object JSON stdout payload/,
+    );
+  }
   assert.throws(
     () => validateHookStdout('UserPromptSubmit', '{not json'),
     /native hook UserPromptSubmit emitted invalid JSON stdout/,

--- a/src/scripts/__tests__/smoke-packed-install.test.ts
+++ b/src/scripts/__tests__/smoke-packed-install.test.ts
@@ -1,22 +1,55 @@
 // @ts-nocheck
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { EventEmitter } from 'node:events';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
+import { PassThrough } from 'node:stream';
 import { test } from 'node:test';
 import {
-  ensureRepoDependencies,
-  hasUsableNodeModules,
-  buildNativeHookSmokePayload,
+  CODEX_APP_SERVER_TIMEOUTS,
+  CodexAppServer,
+  CodexExecutableNotFoundError,
+  MANAGED_CODEX_HOOK_EVENTS,
   PACKED_INSTALL_NATIVE_HOOK_SMOKE_EVENTS,
   PACKED_INSTALL_SMOKE_CORE_COMMANDS,
+  appendForeignHookGroups,
+  appendDisplayOrderStableForeignHookGroups,
+  buildNativeHookSmokePayload,
+  createCodexBatchWriteEnvelope,
+  createCodexHooksListEnvelope,
+  createCodexInitializeEnvelope,
+  foreignHookGroupSnapshot,
+  generatedHookTrustState,
+  hasUsableNodeModules,
   parseNpmPackJsonOutput,
+  parseCodexHooksListResult,
+  probeCodexVersion,
   resolveGitCommonDir,
   resolveReusableNodeModulesSource,
   validateHookStdout,
+  ensureRepoDependencies,
+  assertCodexBatchWriteResult,
+  assertGeneratedTrustMatchesCodex,
+  managedCodexHooksByEvent,
 } from '../smoke-packed-install.js';
 
-test('packed install smoke stays limited to boot + core commands', () => {
+function createFakeCodexAppServer(
+  onRequest: (request: Record<string, unknown>, child: EventEmitter & Record<string, unknown>) => void,
+): CodexAppServer {
+  const child = Object.assign(new EventEmitter(), {
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    kill: () => true,
+  });
+  child.stdin.on('data', (chunk: Buffer) => onRequest(JSON.parse(chunk.toString('utf-8')), child));
+  child.stdin.on('finish', () => child.emit('close', 0, null));
+  return new CodexAppServer(child as never);
+}
+
+
+test('packed install smoke retains narrow boot commands and adds the isolated lifecycle separately', () => {
   assert.deepEqual(PACKED_INSTALL_SMOKE_CORE_COMMANDS, [
     ['--help'],
     ['version'],
@@ -30,6 +63,624 @@ test('packed install smoke stays limited to boot + core commands', () => {
   assert.equal(
     PACKED_INSTALL_SMOKE_CORE_COMMANDS.some((argv) => argv.includes('sparkshell')),
     true,
+  );
+});
+
+test('packed lifecycle keeps the pinned newline-delimited Codex app-server envelopes literal', () => {
+  assert.deepEqual(createCodexInitializeEnvelope('omx-hook-trust-regression'), {
+    id: 1,
+    method: 'initialize',
+    params: {
+      clientInfo: { name: 'omx-hook-trust-regression', version: '1.0.0' },
+      capabilities: null,
+    },
+  });
+  assert.deepEqual(createCodexHooksListEnvelope('/tmp/project'), {
+    id: 2,
+    method: 'hooks/list',
+    params: { cwds: ['/tmp/project'] },
+  });
+  assert.deepEqual(createCodexBatchWriteEnvelope({ first: 'sha256:first', second: 'sha256:second' }), {
+    id: 3,
+    method: 'config/batchWrite',
+    params: {
+      edits: [{
+        keyPath: 'hooks.state',
+        value: {
+          first: { trusted_hash: 'sha256:first' },
+          second: { trusted_hash: 'sha256:second' },
+        },
+        mergeStrategy: 'upsert',
+      }],
+      filePath: null,
+      expectedVersion: null,
+      reloadUserConfig: true,
+    },
+  });
+  assert.deepEqual(CODEX_APP_SERVER_TIMEOUTS, {
+    versionProbeMs: 2_000,
+    initializeMs: 15_000,
+    requestMs: 10_000,
+    shutdownMs: 5_000,
+  });
+});
+test('Codex app-server accepts method-bearing notifications but rejects invalid idless envelopes', async () => {
+  const accepted = createFakeCodexAppServer((request, child) => {
+    child.stdout.write(`${JSON.stringify({ method: 'thread/started', params: { thread: 'fake' } })}\n`);
+    child.stdout.write(`${JSON.stringify({ id: request.id, result: { ok: true } })}\n`);
+  });
+  assert.deepEqual(await accepted.request({ id: 1, method: 'hooks/list' }, 100), { ok: true });
+  await accepted.close();
+
+  for (const envelope of [
+    { result: { invalid: true } },
+    { error: { code: -1, message: 'invalid' } },
+    { unknown: true },
+    { method: '   ' },
+    { method: 'thread/started', result: { invalid: true } },
+  ]) {
+    const server = createFakeCodexAppServer((_request, child) => {
+      child.stdout.write(`${JSON.stringify(envelope)}\n`);
+    });
+    await assert.rejects(
+      server.request({ id: 1, method: 'hooks/list' }, 100),
+      /invalid idless JSON-RPC envelope/,
+    );
+    await assert.rejects(server.close(), /invalid idless JSON-RPC envelope/);
+  }
+});
+
+test('Codex app-server rejects id-bearing envelopes that mix response and request fields', async () => {
+  for (const envelope of [
+    { id: 1, method: 'thread/started', result: { invalid: true } },
+    { id: 1, params: { thread: 'fake' }, result: { invalid: true } },
+    { id: 1, method: 'thread/started', params: {}, error: { code: -1, message: 'invalid' } },
+    { id: 1, result: { invalid: true }, error: { code: -1, message: 'invalid' } },
+    { id: 1 },
+  ]) {
+    const server = createFakeCodexAppServer((_request, child) => {
+      child.stdout.write(`${JSON.stringify(envelope)}\n`);
+    });
+    await assert.rejects(
+      server.request({ id: 1, method: 'hooks/list' }, 100),
+      /codex app-server response/,
+    );
+    await assert.rejects(server.close(), /codex app-server response/);
+  }
+});
+
+test('Codex app-server validates JSON-RPC error response shapes', async () => {
+  const valid = createFakeCodexAppServer((_request, child) => {
+    child.stdout.write(`${JSON.stringify({
+      id: 1,
+      error: { code: -32600, message: 'invalid request', data: { source: 'fake' } },
+    })}\n`);
+  });
+  await assert.rejects(valid.request({ id: 1, method: 'hooks/list' }, 100), /returned JSON-RPC error/);
+  await valid.close();
+
+  for (const error of [
+    null,
+    {},
+    { code: '-32600', message: 'invalid request' },
+    { code: -32600, message: null },
+  ]) {
+    const server = createFakeCodexAppServer((_request, child) => {
+      child.stdout.write(`${JSON.stringify({ id: 1, error })}\n`);
+    });
+    await assert.rejects(
+      server.request({ id: 1, method: 'hooks/list' }, 100),
+      /malformed JSON-RPC error/,
+    );
+    await assert.rejects(server.close(), /malformed JSON-RPC error/);
+  }
+});
+
+test('Codex app-server incrementally decodes split UTF-8 responses and rejects invalid byte sequences', async () => {
+  const split = createFakeCodexAppServer((_request, child) => {
+    child.stdout.write(Buffer.from('{"id":1,"result":"', 'utf-8'));
+    child.stdout.write(Buffer.from([0xe2, 0x82]));
+    child.stdout.write(Buffer.from([0xac]));
+    child.stdout.write(Buffer.from('"}\n', 'utf-8'));
+  });
+  assert.equal(await split.request({ id: 1, method: 'hooks/list' }, 100), '€');
+  await split.close();
+
+  for (const writeInvalidResponse of [
+    (child: EventEmitter & Record<string, unknown>) => {
+      child.stdout.write(Buffer.from('{"id":1,"result":"', 'utf-8'));
+      child.stdout.write(Buffer.from([0xff]));
+      child.stdout.write(Buffer.from('"}\n', 'utf-8'));
+    },
+    (child: EventEmitter & Record<string, unknown>) => {
+      child.stdout.write(Buffer.from('{"id":1,"result":"', 'utf-8'));
+      child.stdout.write(Buffer.from([0xc3]));
+    },
+  ]) {
+    const server = createFakeCodexAppServer((_request, child) => writeInvalidResponse(child));
+    const request = server.request({ id: 1, method: 'hooks/list' }, 100);
+    await assert.rejects(
+      Promise.all([request, server.close()]),
+      /invalid UTF-8 stdout/,
+    );
+  }
+});
+
+
+test('Codex app-server rejects non-empty unterminated stdout when the server closes', async () => {
+  const server = createFakeCodexAppServer((_request, child) => {
+    child.stdout.write('{"id":1');
+  });
+  const request = server.request({ id: 1, method: 'hooks/list' }, 100);
+  await assert.rejects(
+    Promise.all([request, server.close()]),
+    /unterminated JSON-RPC stdout/,
+  );
+});
+
+test('packed lifecycle parses the pinned hooks/list eventName schema', () => {
+  const project = '/tmp/project';
+  const hooksPath = '/tmp/project/.codex/hooks.json';
+  const parsed = parseCodexHooksListResult({
+    data: [{
+      cwd: project,
+      hooks: [{
+        eventName: 'preToolUse',
+        command: 'node hook.js',
+        sourcePath: hooksPath,
+        key: `${hooksPath}:pre_tool_use:0:0`,
+        currentHash: 'sha256:current',
+        displayOrder: 0,
+        trustStatus: 'trusted',
+      }],
+      warnings: [],
+      errors: [],
+    }],
+  }, project, hooksPath);
+
+  assert.equal(parsed.hooks[0]?.event, 'PreToolUse');
+  assert.equal(parsed.hooks[0]?.trustStatus, 'trusted');
+});
+
+test('packed lifecycle normalizes omitted enabled handlers and rejects disabled or non-integer hook metadata', () => {
+  const project = '/tmp/project';
+  const hooksPath = '/tmp/project/.codex/hooks.json';
+  const response = {
+    data: [{
+      cwd: project,
+      hooks: [{
+        eventName: 'preToolUse',
+        command: 'node hook.js',
+        sourcePath: hooksPath,
+        key: `${hooksPath}:pre_tool_use:0:0`,
+        currentHash: 'sha256:current',
+        displayOrder: 0,
+        trustStatus: 'trusted',
+      }],
+      warnings: [],
+      errors: [],
+    }],
+  };
+  assert.doesNotThrow(() => parseCodexHooksListResult(response, project, hooksPath));
+
+  for (const update of [
+    { enabled: false },
+    { enabled: 'true' },
+    { enabled: true, displayOrder: 0.5 },
+    { enabled: true, displayOrder: -1 },
+  ]) {
+    const invalid = structuredClone(response);
+    Object.assign(invalid.data[0]!.hooks[0]!, update);
+    assert.throws(
+      () => parseCodexHooksListResult(invalid, project, hooksPath),
+      /enabled command handler|invalid hooks\[0\]\.displayOrder/,
+    );
+  }
+});
+
+
+test('packed lifecycle requires exactly seven generated OMX trust keys and an isolated approval target', () => {
+  const hooks = MANAGED_CODEX_HOOK_EVENTS.map((event, index) => ({
+    event,
+    command: 'node /tmp/omx/dist/scripts/codex-native-hook.js',
+    sourcePath: '/tmp/project/.codex/hooks.json',
+    key: `/tmp/project/.codex/hooks.json:${event}:${index}:0`,
+    currentHash: `sha256:${event}`,
+    displayOrder: index,
+    trustStatus: 'untrusted',
+  }));
+  const trust = Object.fromEntries(hooks.map((hook) => [hook.key, hook.currentHash]));
+  assert.doesNotThrow(() => assertGeneratedTrustMatchesCodex(trust, hooks));
+  assert.throws(
+    () => assertGeneratedTrustMatchesCodex({
+      ...trust,
+      '/tmp/project/.codex/hooks.json:foreign:0:0': 'sha256:foreign',
+    }, hooks),
+    /exactly the 7 current OMX hooks with no stale keys/,
+  );
+  assert.throws(
+    () => assertGeneratedTrustMatchesCodex(Object.fromEntries(Object.entries(trust).slice(0, -1)), hooks),
+    /exactly the 7 current OMX hooks with no stale keys/,
+  );
+  assert.doesNotThrow(() => assertCodexBatchWriteResult({
+    filePath: '/tmp/isolated-codex-home/config.toml',
+    status: 'ok',
+    version: null,
+  }, '/tmp/isolated-codex-home/config.toml'));
+  assert.throws(
+    () => assertCodexBatchWriteResult({
+      filePath: '/home/user/.codex/config.toml',
+      status: 'ok',
+      version: null,
+    }, '/tmp/isolated-codex-home/config.toml'),
+    /expected isolated user config/,
+  );
+});
+
+test('packed lifecycle fails closed on malformed project hooks.state entries and stale raw keys', () => {
+  const hooks = MANAGED_CODEX_HOOK_EVENTS.map((event, index) => ({
+    event,
+    command: 'node /tmp/omx/dist/scripts/codex-native-hook.js',
+    sourcePath: '/tmp/project/.codex/hooks.json',
+    key: `/tmp/project/.codex/hooks.json:${event}:${index}:0`,
+    currentHash: `sha256:${event}`,
+    displayOrder: index,
+    trustStatus: 'untrusted',
+  }));
+  const validConfig = [
+    '[hooks.state]',
+    ...hooks.map((hook) => `${JSON.stringify(hook.key)} = { trusted_hash = ${JSON.stringify(hook.currentHash)} }`),
+  ].join('\n');
+
+  const generatedTrust = generatedHookTrustState(validConfig);
+  assert.doesNotThrow(() => assertGeneratedTrustMatchesCodex(generatedTrust, hooks));
+
+  for (const malformedEntry of [
+    'first = "sha256:first"',
+    'first = {}',
+    'first = { trusted_hash = "" }',
+    'first = { trusted_hash = 1 }',
+    'first = { trusted_hash = "sha256:first", extra = "unexpected" }',
+  ]) {
+    assert.throws(
+      () => generatedHookTrustState(`[hooks.state]\n${malformedEntry}`),
+      /invalid hooks\.state entry first/,
+    );
+  }
+
+  const staleRawTrust = generatedHookTrustState(`${validConfig}\nforeign = { trusted_hash = "sha256:foreign" }`);
+  assert.throws(
+    () => assertGeneratedTrustMatchesCodex(staleRawTrust, hooks),
+    /exactly the 7 current OMX hooks with no stale keys/,
+  );
+
+  const protoRawTrust = generatedHookTrustState(
+    `${validConfig}\n__proto__ = { trusted_hash = "sha256:proto" }`,
+  );
+  assert.equal(Object.hasOwn(protoRawTrust, '__proto__'), true);
+  assert.throws(
+    () => assertGeneratedTrustMatchesCodex(protoRawTrust, hooks),
+    /exactly the 7 current OMX hooks with no stale keys/,
+  );
+});
+test('packed lifecycle treats only the production command grammar as managed ownership', () => {
+  const hooks = MANAGED_CODEX_HOOK_EVENTS.map((event, index) => ({
+    event,
+    command: 'node /tmp/omx/dist/scripts/codex-native-hook.js',
+    sourcePath: '/tmp/project/.codex/hooks.json',
+    key: `/tmp/project/.codex/hooks.json:${event}:${index}:0`,
+    currentHash: `sha256:${event}`,
+    displayOrder: index,
+    trustStatus: 'untrusted',
+  }));
+  hooks[0]!.command = 'node /tmp/foreign-codex-native-hook.js';
+  assert.throws(
+    () => managedCodexHooksByEvent(hooks),
+    /Expected exactly one OMX SessionStart hook from Codex, received 0/,
+  );
+});
+
+test('packed lifecycle bypasses an unrelated codex binary shadowing the pinned CLI', async () => {
+  if (process.platform === 'win32') return;
+  const root = await mkdtemp(join(tmpdir(), 'omx-codex-path-'));
+  const shadowDir = join(root, 'shadow');
+  const pinnedDir = join(root, 'pinned');
+  try {
+    await Promise.all([
+      mkdir(shadowDir, { recursive: true }),
+      mkdir(pinnedDir, { recursive: true }),
+    ]);
+    const shadow = join(shadowDir, 'codex');
+    const pinned = join(pinnedDir, 'codex');
+    await Promise.all([
+      writeFile(shadow, '#!/bin/sh\necho "codex 0.2.3"\n'),
+      writeFile(pinned, '#!/bin/sh\necho "codex-cli 0.142.5"\n'),
+    ]);
+    await Promise.all([chmod(shadow, 0o755), chmod(pinned, 0o755)]);
+
+    assert.equal(
+      probeCodexVersion(root, { PATH: `${shadowDir}${delimiter}${pinnedDir}` }),
+      'codex-cli 0.142.5',
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('packed lifecycle deduplicates repeated PATH entries before enforcing the candidate budget', async () => {
+  if (process.platform === 'win32') return;
+  const root = await mkdtemp(join(tmpdir(), 'omx-codex-path-dedup-'));
+  const shadowDir = join(root, 'shadow');
+  const pinnedDir = join(root, 'pinned');
+  try {
+    await Promise.all([
+      mkdir(shadowDir, { recursive: true }),
+      mkdir(pinnedDir, { recursive: true }),
+    ]);
+    await Promise.all([
+      writeFile(join(shadowDir, 'codex'), '#!/bin/sh\necho "codex 0.2.3"\n'),
+      writeFile(join(pinnedDir, 'codex'), '#!/bin/sh\necho "codex-cli 0.142.5"\n'),
+    ]);
+    await Promise.all([
+      chmod(join(shadowDir, 'codex'), 0o755),
+      chmod(join(pinnedDir, 'codex'), 0o755),
+    ]);
+
+    assert.equal(
+      probeCodexVersion(root, {
+        PATH: [...Array.from({ length: 40 }, () => shadowDir), pinnedDir].join(delimiter),
+      }),
+      'codex-cli 0.142.5',
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('packed lifecycle accepts only the exact stable pinned Codex version output', async () => {
+  if (process.platform === 'win32') return;
+  const root = await mkdtemp(join(tmpdir(), 'omx-codex-version-'));
+  const candidateDir = join(root, 'candidate');
+  const executable = join(candidateDir, 'codex');
+  const candidates = [
+    { output: 'codex-cli 0.142.5', stderr: '', accepted: true },
+    { output: 'codex-cli 0.142.5', stderr: 'warning: harmless test diagnostic', accepted: true },
+    { output: 'codex-cli 0.142.5\nextra output', stderr: '', accepted: false },
+    { output: 'codex-cli 0.142.5-beta', stderr: '', accepted: false },
+    { output: 'codex-cli 0.142.5+meta', stderr: '', accepted: false },
+    { output: 'codex-cli 0.142.5.1', stderr: '', accepted: false },
+    { output: 'codex-cli v0.142.5', stderr: '', accepted: false },
+    { output: 'codex-cli 0-142-5', stderr: '', accepted: false },
+    { output: 'codex-cli 0.142.5', stderr: 'unexpected version probe error', accepted: false },
+  ];
+  try {
+    await mkdir(candidateDir, { recursive: true });
+    for (const candidate of candidates) {
+      await writeFile(
+        executable,
+        `#!/bin/sh\nprintf '%s\\n' '${candidate.output}'\n${candidate.stderr ? `printf '%s\\n' '${candidate.stderr}' >&2\n` : ''}`,
+      );
+      await chmod(executable, 0o755);
+      if (candidate.accepted) {
+        assert.equal(probeCodexVersion(root, { PATH: candidateDir }), 'codex-cli 0.142.5');
+      } else {
+        assert.throws(
+          () => probeCodexVersion(root, { PATH: candidateDir }),
+          /Unsupported installed Codex version for the 0\.142\.5 boundary/,
+        );
+      }
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+test('packed lifecycle does not classify an installed Codex with a broken shebang as absent', async () => {
+  if (process.platform === 'win32') return;
+  const root = await mkdtemp(join(tmpdir(), 'omx-codex-broken-shebang-'));
+  const candidateDir = join(root, 'candidate');
+  const executable = join(candidateDir, 'codex');
+  try {
+    await mkdir(candidateDir, { recursive: true });
+    await writeFile(executable, '#!/definitely-not-an-installed-interpreter\n');
+    await chmod(executable, 0o755);
+    assert.throws(
+      () => probeCodexVersion(root, { PATH: candidateDir }),
+      /launch returned ENOENT after an existing candidate was observed/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('packed lifecycle does not classify a dangling Codex candidate as absent', async () => {
+  if (process.platform === 'win32') return;
+  const root = await mkdtemp(join(tmpdir(), 'omx-codex-dangling-'));
+  const candidateDir = join(root, 'candidate');
+  try {
+    await mkdir(candidateDir, { recursive: true });
+    await symlink(join(root, 'missing-codex'), join(candidateDir, 'codex'));
+    assert.throws(
+      () => probeCodexVersion(root, { PATH: candidateDir }),
+      /candidate exists but its target is unavailable/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+test('packed lifecycle does not classify a dangling PATH entry as absent', async () => {
+  if (process.platform === 'win32') return;
+  const root = await mkdtemp(join(tmpdir(), 'omx-codex-dangling-path-'));
+  const danglingPathEntry = join(root, 'dangling-path-entry');
+  try {
+    await symlink(join(root, 'missing-path-entry'), danglingPathEntry);
+    assert.throws(
+      () => probeCodexVersion(root, { PATH: danglingPathEntry }),
+      /PATH entry exists but its target is unavailable/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('packed lifecycle bounds all slow Codex candidates with a global deadline', async () => {
+  if (process.platform === 'win32') return;
+  const root = await mkdtemp(join(tmpdir(), 'omx-codex-global-deadline-'));
+  const slowDirs = ['slow-one', 'slow-two', 'slow-three'].map((name) => join(root, name));
+  try {
+    await Promise.all(slowDirs.map((dir) => mkdir(dir, { recursive: true })));
+    await Promise.all(slowDirs.map(async (dir) => {
+      const executable = join(dir, 'codex');
+      await writeFile(executable, '#!/bin/sh\nexec /bin/sleep 30\n');
+      await chmod(executable, 0o755);
+    }));
+    const startedAt = Date.now();
+    assert.throws(
+      () => probeCodexVersion(root, { PATH: slowDirs.join(delimiter) }),
+      /global deadline/,
+    );
+    assert.ok(Date.now() - startedAt < 6_500, 'the global version-resolution deadline must force termination');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('packed lifecycle fails before probing the 33rd unique PATH candidate', async () => {
+  if (process.platform === 'win32') return;
+  const root = await mkdtemp(join(tmpdir(), 'omx-codex-candidate-budget-'));
+  const candidateDirs = Array.from({ length: 33 }, (_value, index) => join(root, `candidate-${index}`));
+  const thirtyThirdProbe = join(root, '33rd-candidate-was-probed');
+  try {
+    await Promise.all(candidateDirs.map((dir) => mkdir(dir, { recursive: true })));
+    await Promise.all(candidateDirs.map(async (dir, index) => {
+      const executable = join(dir, 'codex');
+      await writeFile(
+        executable,
+        index === candidateDirs.length - 1
+          ? `#!/bin/sh\n: > ${JSON.stringify(thirtyThirdProbe)}\nprintf '%s\\n' 'codex-cli 0.142.5'\n`
+          : '#!/bin/sh\nexit 1\n',
+      );
+      await chmod(executable, 0o755);
+    }));
+    assert.throws(
+      () => probeCodexVersion(root, { PATH: candidateDirs.join(delimiter) }),
+      /32-candidate PATH budget/,
+    );
+    await assert.rejects(access(thirtyThirdProbe));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('packed lifecycle continues after a timed-out version probe candidate', async () => {
+  if (process.platform === 'win32') return;
+  const root = await mkdtemp(join(tmpdir(), 'omx-codex-timeout-'));
+  const slowDir = join(root, 'slow');
+  const pinnedDir = join(root, 'pinned');
+  try {
+    await Promise.all([mkdir(slowDir, { recursive: true }), mkdir(pinnedDir, { recursive: true })]);
+    await Promise.all([
+      writeFile(join(slowDir, 'codex'), '#!/bin/sh\nexec /bin/sleep 30\n'),
+      writeFile(join(pinnedDir, 'codex'), '#!/bin/sh\nprintf \'%s\\n\' \'codex-cli 0.142.5\'\n'),
+    ]);
+    await Promise.all([chmod(join(slowDir, 'codex'), 0o755), chmod(join(pinnedDir, 'codex'), 0o755)]);
+
+    const startedAt = Date.now();
+    assert.equal(probeCodexVersion(root, { PATH: `${slowDir}${delimiter}${pinnedDir}` }), 'codex-cli 0.142.5');
+    assert.ok(Date.now() - startedAt < 5_000, 'a timed-out candidate must not block later PATH candidates');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('packed lifecycle fails instead of skipping when Codex disappears after start version validation', async () => {
+  if (process.platform === 'win32') return;
+  const root = await mkdtemp(join(tmpdir(), 'omx-codex-disappears-after-version-'));
+  const candidateDir = join(root, 'candidate');
+  const executable = join(candidateDir, 'codex');
+  try {
+    await mkdir(candidateDir, { recursive: true });
+    await writeFile(executable, [
+      '#!/bin/sh',
+      'state="${0}.version-count"',
+      'if [ "$1" = "--version" ]; then',
+      '  if [ -f "$state" ]; then /bin/rm -f "$0"; else : > "$state"; fi',
+      '  printf \'%s\\n\' \'codex-cli 0.142.5\'',
+      '  exit 0',
+      'fi',
+      'exit 1',
+      '',
+    ].join('\n'));
+    await chmod(executable, 0o755);
+    assert.equal(probeCodexVersion(root, { PATH: candidateDir }), 'codex-cli 0.142.5');
+
+    await assert.rejects(
+      CodexAppServer.start({ cwd: root, env: { PATH: candidateDir } }),
+      (error: NodeJS.ErrnoException) => {
+        assert.equal(error instanceof CodexExecutableNotFoundError, false);
+        assert.equal(error.code, 'ENOENT');
+        return true;
+      },
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('packed lifecycle preserves the true-absence Codex skip signal', async () => {
+  if (process.platform === 'win32') return;
+  const root = await mkdtemp(join(tmpdir(), 'omx-codex-absent-'));
+  try {
+    assert.throws(
+      () => probeCodexVersion(root, { PATH: root }),
+      CodexExecutableNotFoundError,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('packed lifecycle pre-seeds and preserves nested foreign group and handler coordinates', () => {
+  const marker = 'packed-foreign-fixture';
+  const seeded = appendForeignHookGroups('{"hooks":{}}', marker, { appendGroups: true });
+  const inserted = appendForeignHookGroups(seeded, marker, { appendGroups: false });
+  const snapshot = foreignHookGroupSnapshot(inserted, marker);
+
+  assert.equal(snapshot.length, 4);
+  assert.deepEqual(
+    snapshot.map((entry) => ({
+      event: entry.event,
+      groupIndex: entry.groupIndex,
+      handlerIndex: entry.handlerIndex,
+    })),
+    [
+      { event: 'PreToolUse', groupIndex: 0, handlerIndex: 0 },
+      { event: 'PreToolUse', groupIndex: 0, handlerIndex: 1 },
+      { event: 'PostToolUse', groupIndex: 0, handlerIndex: 0 },
+      { event: 'PostToolUse', groupIndex: 0, handlerIndex: 1 },
+    ],
+  );
+  assert.match(inserted, /foreign_group_metadata/);
+  assert.match(inserted, /foreign_handler_metadata/);
+});
+
+test('display-order-stable foreign fixture preserves pre-approved group and handler coordinates', () => {
+  const marker = 'packed-display-order-fixture';
+  const seeded = appendDisplayOrderStableForeignHookGroups('{"hooks":{}}', marker, { appendGroups: true });
+  const inserted = appendDisplayOrderStableForeignHookGroups(seeded, marker, { appendGroups: false });
+  const snapshot = foreignHookGroupSnapshot(inserted, marker);
+
+  assert.deepEqual(
+    snapshot.map((entry) => ({
+      event: entry.event,
+      groupIndex: entry.groupIndex,
+      handlerIndex: entry.handlerIndex,
+    })),
+    [
+      { event: 'PreToolUse', groupIndex: 0, handlerIndex: 0 },
+      { event: 'PreToolUse', groupIndex: 1, handlerIndex: 0 },
+      { event: 'PreToolUse', groupIndex: 1, handlerIndex: 1 },
+      { event: 'PreToolUse', groupIndex: 1, handlerIndex: 2 },
+    ],
   );
 });
 
@@ -50,6 +701,10 @@ test('packed install smoke covers every installed native hook event with minimal
     assert.equal(typeof payload.session_id, 'string');
     assert.equal(payload.cwd, '/tmp/omx-packed-hook-smoke');
   }
+});
+
+test('packed lifecycle and native hook smoke share the seven managed event names', () => {
+  assert.deepEqual(MANAGED_CODEX_HOOK_EVENTS, PACKED_INSTALL_NATIVE_HOOK_SMOKE_EVENTS);
 });
 
 test('packed install native hook stdout validation allows empty or JSON output only', () => {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -9960,6 +9960,14 @@ export async function dispatchCodexNativeHook(
 ): Promise<NativeHookDispatchResult> {
   const hookEventName = readHookEventName(payload);
   const cwd = options.cwd ?? (safeString(payload.cwd).trim() || process.cwd());
+  if (hookEventName === "PostCompact" && process.env.OMX_NATIVE_HOOK_DOCTOR_SMOKE === "1") {
+    return {
+      hookEventName,
+      omxEventName: mapCodexHookEventToOmxEvent(hookEventName),
+      skillState: null,
+      outputJson: null,
+    };
+  }
   if (hookEventName === "Stop" && !hasNativeStopRuntimeSurface(cwd)) {
     return {
       hookEventName,

--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -1,4 +1,5 @@
 import {
+  existsSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
@@ -17,6 +18,10 @@ import { TextDecoder } from 'node:util';
 
 import TOML from '@iarna/toml';
 import { isManagedCodexHookCommand, planManagedCodexHooksRemoval } from '../config/codex-hooks.js';
+import {
+  spawnPlatformCommand,
+  spawnPlatformCommandSync,
+} from '../utils/platform-command.js';
 
 import {
   ensureReusableNodeModules,
@@ -214,11 +219,18 @@ function versionProbeDeadlineError(): Error {
   );
 }
 
-function* streamPathEntries(pathValue: string, deadline: number): Iterable<string> {
+export interface CodexCommandSpawnSeam {
+  platform?: NodeJS.Platform;
+  spawnSyncImpl?: typeof spawnSync;
+  spawnImpl?: typeof spawn;
+}
+
+function* streamPathEntries(pathValue: string, deadline: number, platform: NodeJS.Platform): Iterable<string> {
+  const pathDelimiter = platform === 'win32' ? ';' : delimiter;
   let start = 0;
   for (let index = 0; index < pathValue.length; index += 1) {
     if ((index & 0x3ff) === 0 && Date.now() >= deadline) throw versionProbeDeadlineError();
-    if (pathValue[index] !== delimiter) continue;
+    if (pathValue[index] !== pathDelimiter) continue;
     yield pathValue.slice(start, index);
     start = index + 1;
   }
@@ -226,26 +238,36 @@ function* streamPathEntries(pathValue: string, deadline: number): Iterable<strin
   yield pathValue.slice(start);
 }
 
+function codexCandidatePaths(pathEntry: string, env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string[] {
+  if (platform !== 'win32') return [join(pathEntry, 'codex')];
+  const pathext = String(env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD;.PS1')
+    .split(';')
+    .map((extension) => extension.trim().toLowerCase())
+    .filter(Boolean);
+  return [...new Set([...pathext.map((extension) => join(pathEntry, `codex${extension}`)), join(pathEntry, 'codex')])];
+}
+
 function resolvePinnedCodexExecutable(
   cwd: string,
   env: NodeJS.ProcessEnv,
+  seam: CodexCommandSpawnSeam = {},
 ): { executable: string; version: string } {
+  const platform = seam.platform ?? process.platform;
   const deadline = Date.now() + CODEX_VERSION_PROBE_DEADLINE_MS;
   const pathValue = env.PATH ?? env.Path ?? '';
   const observed: string[] = [];
-  const seenExecutables = new Set<string>();
+  const seenPathEntries = new Set<string>();
 
-  for (const entry of streamPathEntries(pathValue, deadline)) {
+  for (const entry of streamPathEntries(pathValue, deadline, platform)) {
     if (Date.now() >= deadline) throw versionProbeDeadlineError();
     const pathEntry = resolve(cwd, entry || '.');
-    const executable = join(pathEntry, 'codex');
-    if (seenExecutables.has(executable)) continue;
-    if (seenExecutables.size === CODEX_VERSION_PROBE_CANDIDATE_BUDGET) {
+    if (seenPathEntries.has(pathEntry)) continue;
+    if (seenPathEntries.size === CODEX_VERSION_PROBE_CANDIDATE_BUDGET) {
       throw new Error(
         `Codex version resolution exceeded the ${CODEX_VERSION_PROBE_CANDIDATE_BUDGET}-candidate PATH budget`,
       );
     }
-    seenExecutables.add(executable);
+    seenPathEntries.add(pathEntry);
     const remainingMs = deadline - Date.now();
     if (remainingMs <= 0) throw versionProbeDeadlineError();
 
@@ -263,11 +285,20 @@ function resolvePinnedCodexExecutable(
       continue;
     }
 
-    let before = inspectCodexCandidate(executable);
-    if (before.kind === 'absent') {
-      before = inspectCodexCandidate(executable);
-      if (before.kind === 'absent') continue;
+    let selected: { executable: string; before: CodexCandidateInspection } | null = null;
+    for (const executable of codexCandidatePaths(pathEntry, env, platform)) {
+      if (Date.now() >= deadline) throw versionProbeDeadlineError();
+      let before = inspectCodexCandidate(executable);
+      if (before.kind === 'absent') {
+        before = inspectCodexCandidate(executable);
+        if (before.kind === 'absent') continue;
+      }
+      selected = { executable, before };
+      break;
     }
+    if (!selected) continue;
+
+    const { executable, before } = selected;
     if (before.kind === 'dangling') {
       observed.push(`${executable}: candidate exists but its target is unavailable (dangling or changed during probe)`);
       continue;
@@ -277,13 +308,13 @@ function resolvePinnedCodexExecutable(
       continue;
     }
 
-    const result = spawnSync(executable, ['--version'], {
+    const { result } = spawnPlatformCommandSync(executable, ['--version'], {
       cwd,
       env,
       encoding: 'utf-8',
       timeout: Math.max(1, Math.min(CODEX_APP_SERVER_TIMEOUTS.versionProbeMs, remainingMs)),
       killSignal: 'SIGKILL',
-    });
+    }, platform, env, undefined, seam.spawnSyncImpl ?? spawnSync);
     if (Date.now() >= deadline) throw versionProbeDeadlineError();
     if (isNodeErrorWithCode(result.error, 'ENOENT')) {
       const after = inspectCodexCandidate(executable);
@@ -374,15 +405,18 @@ export class CodexAppServer {
   static async start(options: {
     cwd: string;
     env: NodeJS.ProcessEnv;
+    commandSeam?: CodexCommandSpawnSeam;
   }): Promise<CodexAppServer> {
-    const { executable } = resolvePinnedCodexExecutable(options.cwd, options.env);
-    const child = spawn(executable, ['app-server', '--stdio'], {
+    const seam = options.commandSeam;
+    const platform = seam?.platform ?? process.platform;
+    const { executable } = resolvePinnedCodexExecutable(options.cwd, options.env, seam);
+    const { child } = spawnPlatformCommand(executable, ['app-server', '--stdio'], {
       cwd: options.cwd,
       env: options.env,
       stdio: 'pipe',
-    });
+    }, platform, options.env, undefined, seam?.spawnImpl ?? spawn);
 
-    const server = new CodexAppServer(child);
+    const server = new CodexAppServer(child as ChildProcessWithoutNullStreams);
     try {
       await server.waitForStartup();
     } catch (error) {
@@ -982,8 +1016,12 @@ export function assertForeignHookGroupsPreserved(
 }
 
 
-export function probeCodexVersion(cwd: string, env: NodeJS.ProcessEnv): string {
-  return resolvePinnedCodexExecutable(cwd, env).version;
+export function probeCodexVersion(
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  seam?: CodexCommandSpawnSeam,
+): string {
+  return resolvePinnedCodexExecutable(cwd, env, seam).version;
 }
 
 function usage(): string {
@@ -1082,14 +1120,22 @@ function resolveGlobalNodeModules(prefixDir: string): string {
 }
 
 export function validateHookStdout(eventName: string, stdout: string): void {
+  if (eventName === 'PostCompact') {
+    if (stdout.length === 0) return;
+    throw new Error('native hook PostCompact must emit empty stdout');
+  }
   const trimmed = stdout.trim();
   if (!trimmed) return;
+  let parsed: unknown;
   try {
-    JSON.parse(trimmed);
+    parsed = JSON.parse(trimmed);
   } catch (error) {
     throw new Error(
       `native hook ${eventName} emitted invalid JSON stdout: ${error instanceof Error ? error.message : String(error)}`,
     );
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`native hook ${eventName} emitted a non-object JSON stdout payload`);
   }
 }
 
@@ -1384,6 +1430,8 @@ export async function smokePackedHookTrustLifecycle(
   const hooksPath = join(projectDir, '.codex', 'hooks.json');
   const configPath = join(projectDir, '.codex', 'config.toml');
   const marker = 'omx-packed-foreign';
+  const agentsPath = join(projectDir, 'AGENTS.md');
+  const foreignAgentsContent = '# User project instructions\n\nPreserve this packed lifecycle guidance.\n';
   const env = isolatedSmokeEnv(home, codexHome);
 
   try {
@@ -1392,6 +1440,7 @@ export async function smokePackedHookTrustLifecycle(
     mkdirSync(codexHome, { recursive: true });
     mkdirSync(join(projectDir, '.codex'), { recursive: true });
     writeFileSync(join(codexHome, 'config.toml'), trustedProjectConfig(projectDir), 'utf-8');
+    writeFileSync(agentsPath, foreignAgentsContent, 'utf-8');
 
     // Pre-seed foreign groups so uninstall may safely remove OMX's appended suffix.
     writeFileSync(
@@ -1448,10 +1497,15 @@ export async function smokePackedHookTrustLifecycle(
       );
     }
 
-    run(omxPath, ['setup', '--scope', 'project', '--merge-agents', '--legacy'], {
+    const setupResult = run(omxPath, ['setup', '--scope', 'project', '--merge-agents', '--legacy'], {
       cwd: projectDir,
       env,
     });
+    if (!existsSync(agentsPath) || !readFileSync(agentsPath, 'utf-8').includes(foreignAgentsContent.trim())) {
+      throw new Error(
+        `packed setup --merge-agents did not preserve pre-existing user AGENTS.md guidance; stdout=${JSON.stringify(String(setupResult.stdout || ''))} stderr=${JSON.stringify(String(setupResult.stderr || ''))}`,
+      );
+    }
 
     const initialHooksContent = readFileSync(hooksPath, 'utf-8');
     assertForeignHookGroupsPreserved(preSetupForeignSnapshot, initialHooksContent, marker);
@@ -1563,6 +1617,10 @@ export async function smokePackedHookTrustLifecycle(
         throw new Error('third packed setup changed Codex hook metadata or display order');
       }
     }
+    run(omxPath, ['doctor', '--verbose'], { cwd: projectDir, env });
+    if (!existsSync(agentsPath) || !readFileSync(agentsPath, 'utf-8').includes(foreignAgentsContent.trim())) {
+      throw new Error('packed doctor lifecycle did not preserve pre-existing user AGENTS.md guidance');
+    }
 
     run(omxPath, ['uninstall'], { cwd: projectDir, env });
     const afterUninstallHooksContent = readFileSync(hooksPath, 'utf-8');
@@ -1571,6 +1629,9 @@ export async function smokePackedHookTrustLifecycle(
     }
     assertNoEmptyManagedEventGroups(afterUninstallHooksContent);
     assertForeignHookGroupsPreserved(foreignSnapshot, afterUninstallHooksContent, marker);
+    if (!existsSync(agentsPath) || !readFileSync(agentsPath, 'utf-8').includes(foreignAgentsContent.trim())) {
+      throw new Error('packed uninstall removed pre-existing user AGENTS.md guidance');
+    }
     const afterUninstallConfig = readFileSync(configPath, 'utf-8');
     assertNoSetupOwnedTrustKeys(afterUninstallConfig, generatedTrust);
     assertNativeHooksEnabledForForeignGroups(afterUninstallConfig);

--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -1,16 +1,27 @@
 import {
+  lstatSync,
+  mkdirSync,
   mkdtempSync,
+  readFileSync,
+  readdirSync,
   realpathSync,
   rmSync,
+  statSync,
+  writeFileSync,
 } from 'node:fs';
-import { mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { spawnSync } from 'node:child_process';
+import { delimiter, join, resolve } from 'node:path';
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
+import { TextDecoder } from 'node:util';
+
+import TOML from '@iarna/toml';
+import { isManagedCodexHookCommand, planManagedCodexHooksRemoval } from '../config/codex-hooks.js';
+
 import {
   ensureReusableNodeModules,
 } from '../utils/repo-deps.js';
+
 
 export {
   hasUsableNodeModules,
@@ -25,7 +36,7 @@ export const PACKED_INSTALL_SMOKE_CORE_COMMANDS = [
   ['sparkshell', '--help'],
 ] as const;
 
-export const PACKED_INSTALL_NATIVE_HOOK_SMOKE_EVENTS = [
+export const MANAGED_CODEX_HOOK_EVENTS = [
   'SessionStart',
   'PreToolUse',
   'PostToolUse',
@@ -35,12 +46,952 @@ export const PACKED_INSTALL_NATIVE_HOOK_SMOKE_EVENTS = [
   'Stop',
 ] as const;
 
+export const PACKED_INSTALL_NATIVE_HOOK_SMOKE_EVENTS = MANAGED_CODEX_HOOK_EVENTS;
+
+export type ManagedCodexHookEvent = typeof MANAGED_CODEX_HOOK_EVENTS[number];
+
+export const CODEX_APP_SERVER_TIMEOUTS = {
+  versionProbeMs: 2_000,
+  initializeMs: 15_000,
+  requestMs: 10_000,
+  shutdownMs: 5_000,
+} as const;
+
+const CODEX_TRUST_STATUSES = new Set([
+  'managed',
+  'untrusted',
+  'trusted',
+  'modified',
+]);
+
+const CODEX_EVENT_LABELS: Readonly<Record<string, string>> = {
+  preToolUse: 'PreToolUse',
+  permissionRequest: 'PermissionRequest',
+  postToolUse: 'PostToolUse',
+  preCompact: 'PreCompact',
+  postCompact: 'PostCompact',
+  sessionStart: 'SessionStart',
+  userPromptSubmit: 'UserPromptSubmit',
+  subagentStart: 'SubagentStart',
+  subagentStop: 'SubagentStop',
+  stop: 'Stop',
+};
+
+const PINNED_CODEX_VERSION = '0.142.5';
+const PINNED_CODEX_VERSION_OUTPUT = `codex-cli ${PINNED_CODEX_VERSION}`;
+const CODEX_APP_SERVER_MAX_STDOUT_FRAME_LENGTH = 1_048_576;
+
+type JsonRecord = Record<string, unknown>;
+
+type JsonRpcEnvelope = {
+  id?: number;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: unknown;
+};
+
+type JsonRpcRequestEnvelope = JsonRpcEnvelope & {
+  id: number;
+  method: string;
+};
+
+
+type PendingRequest = {
+  method: string;
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+  timeout: NodeJS.Timeout;
+};
+
+export interface CodexHookMetadata {
+  event: ManagedCodexHookEvent | string;
+  command: string;
+  sourcePath: string;
+  key: string;
+  currentHash: string;
+  displayOrder: number;
+  trustStatus: 'managed' | 'untrusted' | 'trusted' | 'modified';
+}
+
+export interface CodexHooksListEntry {
+  cwd: string;
+  hooks: CodexHookMetadata[];
+  warnings: unknown[];
+  errors: unknown[];
+}
+
+export class CodexExecutableNotFoundError extends Error {
+  constructor() {
+    super('codex executable was not found');
+    this.name = 'CodexExecutableNotFoundError';
+  }
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNodeErrorWithCode(value: unknown, code: string): boolean {
+  return value instanceof Error
+    && isRecord(value)
+    && value.code === code;
+}
+
+function compactDiagnostic(value: string, limit = 4_000): string {
+  return value.length <= limit ? value : value.slice(-limit);
+}
+
+function protocolError(message: string, stderr = ''): Error {
+  return new Error(`${message}${stderr.trim() ? `\nCodex stderr:\n${compactDiagnostic(stderr)}` : ''}`);
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Codex hooks/list response is missing ${label}`);
+  }
+  return value;
+}
+
+function requireRecord(value: unknown, label: string): JsonRecord {
+  if (!isRecord(value)) throw new Error(`Codex response has malformed ${label}`);
+  return value;
+}
+
+function hasExactPinnedCodexVersionStdout(stdout: string): boolean {
+  return stdout === PINNED_CODEX_VERSION_OUTPUT
+    || stdout === `${PINNED_CODEX_VERSION_OUTPUT}\n`
+    || stdout === `${PINNED_CODEX_VERSION_OUTPUT}\r\n`;
+}
+
+function hasOnlyBenignCodexVersionStderr(stderr: string): boolean {
+  const diagnostics = stderr.split(/\r?\n/).map((line) => line.trim()).filter((line) => line.length > 0);
+  return diagnostics.every((line) => /^(?:warning|note): /i.test(line));
+}
+
+function formatVersionProbeOutput(stdout: string, stderr: string): string {
+  return [
+    `stdout=${JSON.stringify(compactDiagnostic(stdout))}`,
+    ...(stderr.length === 0 ? [] : [`stderr=${JSON.stringify(compactDiagnostic(stderr))}`]),
+  ].join(' ');
+}
+
+const CODEX_VERSION_PROBE_CANDIDATE_BUDGET = 32;
+const CODEX_VERSION_PROBE_DEADLINE_MS = 5_000;
+
+type CodexCandidateInspection =
+  | { kind: 'absent' }
+  | { kind: 'present' }
+  | { kind: 'dangling' }
+  | { kind: 'uninspectable'; error: Error };
+
+function inspectCodexCandidate(executable: string): CodexCandidateInspection {
+  try {
+    lstatSync(executable);
+  } catch (error) {
+    if (isNodeErrorWithCode(error, 'ENOENT')) return { kind: 'absent' };
+    return {
+      kind: 'uninspectable',
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+
+  try {
+    statSync(executable);
+    return { kind: 'present' };
+  } catch (error) {
+    if (isNodeErrorWithCode(error, 'ENOENT')) return { kind: 'dangling' };
+    return {
+      kind: 'uninspectable',
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+}
+
+function versionProbeDeadlineError(): Error {
+  return new Error(
+    `Codex version resolution exceeded the ${CODEX_VERSION_PROBE_DEADLINE_MS}ms global deadline`,
+  );
+}
+
+function* streamPathEntries(pathValue: string, deadline: number): Iterable<string> {
+  let start = 0;
+  for (let index = 0; index < pathValue.length; index += 1) {
+    if ((index & 0x3ff) === 0 && Date.now() >= deadline) throw versionProbeDeadlineError();
+    if (pathValue[index] !== delimiter) continue;
+    yield pathValue.slice(start, index);
+    start = index + 1;
+  }
+  if (Date.now() >= deadline) throw versionProbeDeadlineError();
+  yield pathValue.slice(start);
+}
+
+function resolvePinnedCodexExecutable(
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): { executable: string; version: string } {
+  const deadline = Date.now() + CODEX_VERSION_PROBE_DEADLINE_MS;
+  const pathValue = env.PATH ?? env.Path ?? '';
+  const observed: string[] = [];
+  const seenExecutables = new Set<string>();
+
+  for (const entry of streamPathEntries(pathValue, deadline)) {
+    if (Date.now() >= deadline) throw versionProbeDeadlineError();
+    const pathEntry = resolve(cwd, entry || '.');
+    const executable = join(pathEntry, 'codex');
+    if (seenExecutables.has(executable)) continue;
+    if (seenExecutables.size === CODEX_VERSION_PROBE_CANDIDATE_BUDGET) {
+      throw new Error(
+        `Codex version resolution exceeded the ${CODEX_VERSION_PROBE_CANDIDATE_BUDGET}-candidate PATH budget`,
+      );
+    }
+    seenExecutables.add(executable);
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) throw versionProbeDeadlineError();
+
+    let pathEntryState = inspectCodexCandidate(pathEntry);
+    if (pathEntryState.kind === 'absent') {
+      pathEntryState = inspectCodexCandidate(pathEntry);
+      if (pathEntryState.kind === 'absent') continue;
+    }
+    if (pathEntryState.kind === 'dangling') {
+      observed.push(`${pathEntry}: PATH entry exists but its target is unavailable (dangling or changed during probe)`);
+      continue;
+    }
+    if (pathEntryState.kind === 'uninspectable') {
+      observed.push(`${pathEntry}: PATH entry cannot be inspected (${pathEntryState.error.message})`);
+      continue;
+    }
+
+    let before = inspectCodexCandidate(executable);
+    if (before.kind === 'absent') {
+      before = inspectCodexCandidate(executable);
+      if (before.kind === 'absent') continue;
+    }
+    if (before.kind === 'dangling') {
+      observed.push(`${executable}: candidate exists but its target is unavailable (dangling or changed during probe)`);
+      continue;
+    }
+    if (before.kind === 'uninspectable') {
+      observed.push(`${executable}: candidate cannot be inspected (${before.error.message})`);
+      continue;
+    }
+
+    const result = spawnSync(executable, ['--version'], {
+      cwd,
+      env,
+      encoding: 'utf-8',
+      timeout: Math.max(1, Math.min(CODEX_APP_SERVER_TIMEOUTS.versionProbeMs, remainingMs)),
+      killSignal: 'SIGKILL',
+    });
+    if (Date.now() >= deadline) throw versionProbeDeadlineError();
+    if (isNodeErrorWithCode(result.error, 'ENOENT')) {
+      const after = inspectCodexCandidate(executable);
+      observed.push(
+        `${executable}: launch returned ENOENT after an existing candidate was observed (${after.kind})`,
+      );
+      continue;
+    }
+    if (isNodeErrorWithCode(result.error, 'ETIMEDOUT')) {
+      observed.push(`${executable}: version probe timed out after ${CODEX_APP_SERVER_TIMEOUTS.versionProbeMs}ms and was force-terminated`);
+      continue;
+    }
+    if (result.error) {
+      observed.push(`${executable}: version probe failed (${result.error.message})`);
+      continue;
+    }
+    if (result.status !== 0) {
+      observed.push(`${executable}: exit ${String(result.status)}`);
+      continue;
+    }
+
+    const stdout = String(result.stdout ?? '');
+    const stderr = String(result.stderr ?? '');
+    if (hasExactPinnedCodexVersionStdout(stdout) && hasOnlyBenignCodexVersionStderr(stderr)) {
+      return { executable, version: PINNED_CODEX_VERSION_OUTPUT };
+    }
+    observed.push(`${executable}: ${formatVersionProbeOutput(stdout, stderr)}`);
+  }
+
+  if (Date.now() >= deadline) throw versionProbeDeadlineError();
+  if (observed.length === 0) throw new CodexExecutableNotFoundError();
+  throw new Error(
+    `Unsupported installed Codex version for the ${PINNED_CODEX_VERSION} boundary:\n${observed.join('\n')}`,
+  );
+}
+
+
+/**
+ * Newline-delimited JSON-RPC client for the installed Codex app-server boundary.
+ * It accepts no protocol fallback: malformed messages, request errors, unexpected
+ * exits, and cleanup failures are test failures.
+ */
+export class CodexAppServer {
+  private readonly pending = new Map<number, PendingRequest>();
+  private readonly closePromise: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+  private readonly stdoutDecoder = new TextDecoder('utf-8', { fatal: true });
+  private stderr = '';
+  private stdoutBuffer = '';
+  private failure: Error | null = null;
+  private closing = false;
+  private spawned = false;
+
+  private constructor(private readonly child: ChildProcessWithoutNullStreams) {
+    this.closePromise = new Promise((resolveClose) => {
+      child.once('close', (code, signal) => {
+        const exit = { code, signal };
+        this.flushStdoutDecoder();
+        if (this.stdoutBuffer.length > 0) {
+          this.fail(protocolError(
+            `codex app-server closed with unterminated JSON-RPC stdout: ${JSON.stringify(compactDiagnostic(this.stdoutBuffer))}`,
+            this.stderr,
+          ));
+        }
+        if (!this.closing) {
+          this.fail(protocolError(
+            `codex app-server exited unexpectedly (code ${String(code)}, signal ${String(signal)})`,
+            this.stderr,
+          ));
+        }
+        resolveClose(exit);
+      });
+    });
+
+    child.once('spawn', () => {
+      this.spawned = true;
+    });
+    child.once('error', (error) => {
+      this.fail(error instanceof Error ? error : new Error(String(error)));
+    });
+    child.stdout.on('data', (chunk: Buffer) => this.onStdout(chunk));
+    child.stderr.setEncoding('utf-8');
+    child.stderr.on('data', (chunk: string) => {
+      this.stderr = compactDiagnostic(this.stderr + chunk);
+    });
+  }
+
+
+  static async start(options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+  }): Promise<CodexAppServer> {
+    const { executable } = resolvePinnedCodexExecutable(options.cwd, options.env);
+    const child = spawn(executable, ['app-server', '--stdio'], {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: 'pipe',
+    });
+
+    const server = new CodexAppServer(child);
+    try {
+      await server.waitForStartup();
+    } catch (error) {
+      try {
+        await server.close();
+      } catch {
+        // Preserve the startup failure as the primary diagnostic.
+      }
+      throw error;
+    }
+    return server;
+  }
+
+  private async waitForStartup(): Promise<void> {
+    const started = new Promise<void>((resolveStarted, rejectStarted) => {
+      if (this.spawned) {
+        resolveStarted();
+        return;
+      }
+      this.child.once('spawn', resolveStarted);
+      this.child.once('error', rejectStarted);
+    });
+    await this.withTimeout(started, CODEX_APP_SERVER_TIMEOUTS.initializeMs, 'codex app-server did not start');
+  }
+
+  private onStdout(chunk: Buffer): void {
+    let decoded: string;
+    try {
+      decoded = this.stdoutDecoder.decode(chunk, { stream: true });
+    } catch {
+      this.fail(protocolError('codex app-server emitted invalid UTF-8 stdout', this.stderr));
+      return;
+    }
+    this.onStdoutText(decoded);
+  }
+
+  private flushStdoutDecoder(): void {
+    try {
+      const decoded = this.stdoutDecoder.decode();
+      if (decoded) this.onStdoutText(decoded);
+    } catch {
+      this.fail(protocolError('codex app-server emitted invalid UTF-8 stdout', this.stderr));
+    }
+  }
+
+  private onStdoutText(chunk: string): void {
+    this.stdoutBuffer += chunk;
+    while (true) {
+      const newline = this.stdoutBuffer.indexOf('\n');
+      const frameLength = Buffer.byteLength(
+        newline < 0 ? this.stdoutBuffer : this.stdoutBuffer.slice(0, newline),
+        'utf-8',
+      );
+      if (frameLength > CODEX_APP_SERVER_MAX_STDOUT_FRAME_LENGTH) {
+        this.fail(protocolError('codex app-server emitted an oversized JSON-RPC stdout frame', this.stderr));
+        return;
+      }
+      if (newline < 0) return;
+      const line = this.stdoutBuffer.slice(0, newline).trim();
+      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
+      if (!line) continue;
+      let envelope: unknown;
+      try {
+        envelope = JSON.parse(line);
+      } catch {
+        this.fail(protocolError(`codex app-server emitted malformed JSON-RPC stdout: ${line}`, this.stderr));
+        return;
+      }
+      if (!isRecord(envelope)) {
+        this.fail(protocolError('codex app-server emitted a non-object JSON-RPC envelope', this.stderr));
+        return;
+      }
+      this.onEnvelope(envelope);
+    }
+  }
+
+  private isMethodBearingNotification(envelope: JsonRecord): boolean {
+    return !Object.hasOwn(envelope, 'id')
+      && typeof envelope.method === 'string'
+      && envelope.method.trim().length > 0
+      && !Object.hasOwn(envelope, 'result')
+      && !Object.hasOwn(envelope, 'error');
+  }
+
+  private validateResponseEnvelope(envelope: JsonRecord): string | null {
+    if (Object.hasOwn(envelope, 'method') || Object.hasOwn(envelope, 'params')) {
+      return 'codex app-server response mixed request or notification fields with an id';
+    }
+    const hasResult = Object.hasOwn(envelope, 'result');
+    const hasError = Object.hasOwn(envelope, 'error');
+    if (hasResult === hasError) {
+      return 'codex app-server response must contain exactly one of result or error';
+    }
+    if (hasError) {
+      const error = envelope.error;
+      if (!isRecord(error)
+        || typeof error.code !== 'number'
+        || !Number.isFinite(error.code)
+        || typeof error.message !== 'string') {
+        return 'codex app-server response has malformed JSON-RPC error';
+      }
+    }
+    return null;
+  }
+
+  private onEnvelope(envelope: JsonRecord): void {
+    if (!Object.hasOwn(envelope, 'id')) {
+      if (!this.isMethodBearingNotification(envelope)) {
+        this.fail(protocolError('codex app-server emitted an invalid idless JSON-RPC envelope', this.stderr));
+      }
+      return;
+    }
+    if (typeof envelope.id !== 'number') {
+      this.fail(protocolError('codex app-server response had a non-numeric id', this.stderr));
+      return;
+    }
+    const validationError = this.validateResponseEnvelope(envelope);
+    if (validationError) {
+      this.fail(protocolError(validationError, this.stderr));
+      return;
+    }
+    const pending = this.pending.get(envelope.id);
+    if (!pending) {
+      this.fail(protocolError(`codex app-server returned an unexpected response id ${envelope.id}`, this.stderr));
+      return;
+    }
+    this.pending.delete(envelope.id);
+    clearTimeout(pending.timeout);
+    if (Object.hasOwn(envelope, 'error')) {
+      pending.reject(protocolError(
+        `codex app-server ${pending.method} returned JSON-RPC error ${JSON.stringify(envelope.error)}`,
+        this.stderr,
+      ));
+      return;
+    }
+    pending.resolve(envelope.result);
+  }
+
+
+  private fail(error: Error): void {
+    if (this.failure) return;
+    this.failure = error;
+    for (const [id, pending] of this.pending) {
+      this.pending.delete(id);
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+    }
+  }
+
+  private withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+    return new Promise<T>((resolvePromise, rejectPromise) => {
+      const timeout = setTimeout(() => rejectPromise(protocolError(message, this.stderr)), timeoutMs);
+      promise.then(
+        (value) => {
+          clearTimeout(timeout);
+          resolvePromise(value);
+        },
+        (error: unknown) => {
+          clearTimeout(timeout);
+          rejectPromise(error);
+        },
+      );
+    });
+  }
+
+  async request<T = unknown>(envelope: Required<Pick<JsonRpcEnvelope, 'id' | 'method'>> & JsonRpcEnvelope, timeoutMs: number): Promise<T> {
+    if (this.failure) throw this.failure;
+    if (!Number.isInteger(envelope.id) || envelope.id <= 0 || !envelope.method) {
+      throw new Error('Codex JSON-RPC request requires a positive numeric id and method');
+    }
+    if (this.pending.has(envelope.id)) {
+      throw new Error(`duplicate Codex JSON-RPC request id ${envelope.id}`);
+    }
+    const response = new Promise<unknown>((resolveResponse, rejectResponse) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(envelope.id);
+        rejectResponse(protocolError(
+          `codex app-server ${envelope.method} request ${envelope.id} timed out after ${timeoutMs}ms`,
+          this.stderr,
+        ));
+      }, timeoutMs);
+      this.pending.set(envelope.id, {
+        method: envelope.method,
+        resolve: resolveResponse,
+        reject: rejectResponse,
+        timeout,
+      });
+    });
+    this.child.stdin.write(`${JSON.stringify(envelope)}\n`, 'utf-8', (error) => {
+      if (error) this.fail(error instanceof Error ? error : new Error(String(error)));
+    });
+    return await response as T;
+  }
+
+  notify(envelope: Omit<JsonRpcEnvelope, 'id'>): void {
+    if (this.failure) throw this.failure;
+    if (!envelope.method) throw new Error('Codex JSON-RPC notification requires a method');
+    this.child.stdin.write(`${JSON.stringify(envelope)}\n`, 'utf-8', (error) => {
+      if (error) this.fail(error instanceof Error ? error : new Error(String(error)));
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.closing) return;
+    this.closing = true;
+    this.child.stdin.end();
+    let exit: { code: number | null; signal: NodeJS.Signals | null };
+    try {
+      exit = await this.withTimeout(
+        this.closePromise,
+        CODEX_APP_SERVER_TIMEOUTS.shutdownMs,
+        'codex app-server did not exit after stdin closed',
+      );
+    } catch (error) {
+      this.child.kill('SIGKILL');
+      try {
+        await this.withTimeout(
+          this.closePromise,
+          CODEX_APP_SERVER_TIMEOUTS.shutdownMs,
+          'codex app-server did not exit after SIGKILL',
+        );
+      } catch {
+        // Preserve the original graceful-cleanup failure, which has better diagnostics.
+      }
+      throw error;
+    }
+    if (exit.code !== 0 || exit.signal !== null) {
+      throw protocolError(
+        `codex app-server exited abnormally during cleanup (code ${String(exit.code)}, signal ${String(exit.signal)})`,
+        this.stderr,
+      );
+    }
+    if (this.failure) throw this.failure;
+  }
+}
+
+export function createCodexInitializeEnvelope(clientName: string): JsonRpcRequestEnvelope {
+  return {
+    id: 1,
+    method: 'initialize',
+    params: {
+      clientInfo: { name: clientName, version: '1.0.0' },
+      capabilities: null,
+    },
+  };
+}
+
+export const CODEX_INITIALIZED_ENVELOPE: JsonRpcEnvelope = { method: 'initialized' };
+
+export function createCodexHooksListEnvelope(projectCwd: string): JsonRpcRequestEnvelope {
+  return {
+    id: 2,
+    method: 'hooks/list',
+    params: { cwds: [projectCwd] },
+  };
+}
+
+export function createCodexBatchWriteEnvelope(trustByKey: Record<string, string>): JsonRpcRequestEnvelope {
+  return {
+    id: 3,
+    method: 'config/batchWrite',
+    params: {
+      edits: [{
+        keyPath: 'hooks.state',
+        value: Object.fromEntries(
+          Object.entries(trustByKey).map(([key, currentHash]) => [key, { trusted_hash: currentHash }]),
+        ),
+        mergeStrategy: 'upsert',
+      }],
+      filePath: null,
+      expectedVersion: null,
+      reloadUserConfig: true,
+    },
+  };
+}
+
+export async function initializeCodexAppServer(server: CodexAppServer, clientName: string): Promise<void> {
+  await server.request(createCodexInitializeEnvelope(clientName), CODEX_APP_SERVER_TIMEOUTS.initializeMs);
+  server.notify(CODEX_INITIALIZED_ENVELOPE);
+}
+
+export async function listCodexHooks(
+  server: CodexAppServer,
+  projectCwd: string,
+  hooksPath: string,
+): Promise<CodexHooksListEntry> {
+  const result = await server.request<unknown>(
+    createCodexHooksListEnvelope(projectCwd),
+    CODEX_APP_SERVER_TIMEOUTS.requestMs,
+  );
+  return parseCodexHooksListResult(result, projectCwd, hooksPath);
+}
+
+export function parseCodexHooksListResult(
+  result: unknown,
+  projectCwd: string,
+  hooksPath: string,
+): CodexHooksListEntry {
+  const resultRecord = requireRecord(result, 'hooks/list result');
+  if (!Array.isArray(resultRecord.data) || resultRecord.data.length !== 1) {
+    throw new Error('Codex hooks/list response must contain exactly one data entry');
+  }
+  const entry = requireRecord(resultRecord.data[0], 'hooks/list data entry');
+  if (entry.cwd !== projectCwd) {
+    throw new Error(`Codex hooks/list response cwd mismatch: expected ${projectCwd}, got ${String(entry.cwd)}`);
+  }
+  if (!Array.isArray(entry.hooks) || !Array.isArray(entry.warnings) || !Array.isArray(entry.errors)) {
+    throw new Error('Codex hooks/list response must contain hooks, warnings, and errors arrays');
+  }
+  if (entry.warnings.length !== 0 || entry.errors.length !== 0) {
+    throw new Error(`Codex hooks/list reported warnings/errors: ${JSON.stringify({ warnings: entry.warnings, errors: entry.errors })}`);
+  }
+
+  const hooks = entry.hooks.map((value, index) => {
+    const hook = requireRecord(value, `hooks/list hook ${index}`);
+    const rawEvent = requireString(hook.eventName, `hooks[${index}].eventName`);
+    const event = CODEX_EVENT_LABELS[rawEvent] ?? rawEvent;
+    const command = requireString(hook.command, `hooks[${index}].command`);
+    const enabled = hook.enabled === undefined ? true : hook.enabled;
+    if (enabled !== true) {
+      throw new Error(`Codex hooks/list hook ${index} is not an enabled command handler`);
+    }
+    const sourcePath = requireString(hook.sourcePath, `hooks[${index}].sourcePath`);
+    const key = requireString(hook.key, `hooks[${index}].key`);
+    const currentHash = requireString(hook.currentHash, `hooks[${index}].currentHash`);
+    const displayOrder = hook.displayOrder;
+    if (typeof displayOrder !== 'number' || !Number.isSafeInteger(displayOrder) || displayOrder < 0) {
+      throw new Error(`Codex hooks/list response has invalid hooks[${index}].displayOrder`);
+    }
+    const trustStatus = requireString(hook.trustStatus, `hooks[${index}].trustStatus`);
+    if (!CODEX_TRUST_STATUSES.has(trustStatus)) {
+      throw new Error(`Codex hooks/list response has unsupported trustStatus ${trustStatus}`);
+    }
+
+
+    if (sourcePath !== hooksPath) {
+      throw new Error(`Codex hooks/list sourcePath mismatch: expected ${hooksPath}, got ${sourcePath}`);
+    }
+    return {
+      event,
+      command,
+      sourcePath,
+      key,
+      currentHash,
+      displayOrder,
+      trustStatus: trustStatus as CodexHookMetadata['trustStatus'],
+    };
+  });
+
+  return {
+    cwd: projectCwd,
+    hooks,
+    warnings: entry.warnings,
+    errors: entry.errors,
+  };
+}
+
+
+
+export function managedCodexHooksByEvent(hooks: readonly CodexHookMetadata[]): Record<ManagedCodexHookEvent, CodexHookMetadata> {
+  const result = {} as Record<ManagedCodexHookEvent, CodexHookMetadata>;
+  for (const event of MANAGED_CODEX_HOOK_EVENTS) {
+    const matching = hooks.filter((hook) => hook.event === event && isManagedCodexHookCommand(hook.command));
+    if (matching.length !== 1) {
+      throw new Error(`Expected exactly one OMX ${event} hook from Codex, received ${matching.length}`);
+    }
+    result[event] = matching[0]!;
+  }
+  return result;
+}
+
+export function generatedHookTrustState(configToml: string): Record<string, string> {
+  const parsed = TOML.parse(configToml) as { hooks?: { state?: Record<string, unknown> } };
+  const state = parsed.hooks?.state;
+  if (!isRecord(state)) throw new Error('setup config.toml is missing hooks.state');
+  const trust = Object.create(null) as Record<string, string>;
+  for (const [key, value] of Object.entries(state)) {
+    if (!isRecord(value)) {
+      throw new Error(`setup config.toml has invalid hooks.state entry ${key}: expected an object`);
+    }
+    const entryKeys = Object.keys(value);
+    if (entryKeys.length !== 1 || entryKeys[0] !== 'trusted_hash') {
+      throw new Error(`setup config.toml has invalid hooks.state entry ${key}: expected only trusted_hash`);
+    }
+    if (typeof value.trusted_hash !== 'string' || value.trusted_hash.trim().length === 0) {
+      throw new Error(`setup config.toml has invalid hooks.state entry ${key}: trusted_hash must be non-empty`);
+    }
+    trust[key] = value.trusted_hash;
+  }
+  return trust;
+}
+
+export function managedTrustByKey(hooks: readonly CodexHookMetadata[]): Record<string, string> {
+  return Object.fromEntries(
+    Object.values(managedCodexHooksByEvent(hooks)).map((hook) => [hook.key, hook.currentHash]),
+  );
+}
+
+export function assertGeneratedTrustMatchesCodex(
+  generatedTrust: Record<string, string>,
+  hooks: readonly CodexHookMetadata[],
+): void {
+  const expected = managedTrustByKey(hooks);
+  const expectedKeys = Object.keys(expected).sort();
+  const actualKeys = Object.keys(generatedTrust).sort();
+  if (actualKeys.length !== MANAGED_CODEX_HOOK_EVENTS.length
+    || actualKeys.length !== expectedKeys.length
+    || actualKeys.some((key, index) => key !== expectedKeys[index])) {
+    throw new Error(
+      `Generated trust must contain exactly the ${MANAGED_CODEX_HOOK_EVENTS.length} current OMX hooks with no stale keys`,
+    );
+  }
+  for (const [key, currentHash] of Object.entries(expected)) {
+    if (generatedTrust[key] !== currentHash) {
+      throw new Error(`Generated hook trust does not equal Codex hooks/list metadata for ${key}`);
+    }
+  }
+}
+
+export async function approveManagedHooksInCodex(
+  server: CodexAppServer,
+  hooks: readonly CodexHookMetadata[],
+  expectedConfigPath: string,
+): Promise<void> {
+  const result = await server.request<unknown>(
+    createCodexBatchWriteEnvelope(managedTrustByKey(hooks)),
+    CODEX_APP_SERVER_TIMEOUTS.requestMs,
+  );
+  assertCodexBatchWriteResult(result, expectedConfigPath);
+}
+
+export function assertCodexBatchWriteResult(result: unknown, expectedConfigPath: string): void {
+  const response = requireRecord(result, 'config/batchWrite result');
+  if (response.filePath !== expectedConfigPath) {
+    throw new Error(
+      `Codex config/batchWrite wrote ${String(response.filePath)}, expected isolated user config ${expectedConfigPath}`,
+    );
+  }
+  if (response.status !== 'ok' && response.status !== 'okOverridden') {
+    throw new Error(`Codex config/batchWrite returned unsupported status ${String(response.status)}`);
+  }
+  if (!Object.hasOwn(response, 'version')) {
+    throw new Error('Codex config/batchWrite result is missing version');
+  }
+}
+
+export function hookMetadataSnapshot(hooks: readonly CodexHookMetadata[]): Array<Pick<CodexHookMetadata, 'event' | 'command' | 'key' | 'currentHash' | 'displayOrder' | 'trustStatus'>> {
+  return hooks
+    .map(({ event, command, key, currentHash, displayOrder, trustStatus }) => ({
+      event,
+      command,
+      key,
+      currentHash,
+      displayOrder,
+      trustStatus,
+    }))
+    .sort((left, right) => left.displayOrder - right.displayOrder);
+}
+
+export function appendForeignHookGroups(
+  hooksContent: string,
+  marker: string,
+  options: { appendGroups: boolean },
+): string {
+  const parsed = JSON.parse(hooksContent) as { hooks?: Record<string, unknown> };
+  if (!isRecord(parsed.hooks)) throw new Error('hooks.json is missing hooks object');
+  const hooks = parsed.hooks as Record<string, unknown>;
+  const foreignCommand = (event: string, suffix = '') =>
+    `${JSON.stringify(process.execPath)} ${JSON.stringify(`${marker}-${event}${suffix}.js`)}`;
+  const foreignGroup = (event: string) => ({
+    ...(event === 'PreToolUse' ? { matcher: 'Bash' } : {}),
+    foreign_group_metadata: {
+      marker,
+      nested: { keep: ['foreign', event], depth: { value: 7 } },
+    },
+    hooks: [{
+      type: 'command',
+      command: foreignCommand(event),
+      statusMessage: `${marker} ${event}`,
+      foreign_handler_metadata: { marker, event, values: [1, { two: true }] },
+    }],
+  });
+  for (const event of ['PreToolUse', 'PostToolUse'] as const) {
+    const existing = hooks[event];
+    if (existing !== undefined && !Array.isArray(existing)) {
+      throw new Error(`hooks.${event} is not an array`);
+    }
+    const entries = (existing ?? []) as unknown[];
+    if (options.appendGroups) {
+      entries.push(foreignGroup(event));
+    } else {
+      const group = entries.find((entry): entry is JsonRecord => isRecord(entry)
+        && Array.isArray(entry.hooks)
+        && entry.hooks.some((hook) => isRecord(hook) && typeof hook.command === 'string' && hook.command.includes(marker)));
+      if (!group) {
+        throw new Error(`missing pre-seeded foreign ${event} group`);
+      }
+      const groupHooks = group.hooks;
+      if (!Array.isArray(groupHooks)) {
+        throw new Error(`missing pre-seeded foreign ${event} handler array`);
+      }
+      groupHooks.push({
+        type: 'command',
+        command: foreignCommand(event, '-inserted'),
+        statusMessage: `${marker} inserted ${event}`,
+        foreign_handler_metadata: { marker, inserted: true, nested: { event } },
+      });
+    }
+    hooks[event] = entries;
+  }
+  return JSON.stringify(parsed, null, 2) + '\n';
+}
+
+export function appendDisplayOrderStableForeignHookGroups(
+  hooksContent: string,
+  marker: string,
+  options: { appendGroups: boolean },
+): string {
+  const parsed = JSON.parse(hooksContent) as { hooks?: Record<string, unknown> };
+  if (!isRecord(parsed.hooks)) throw new Error('hooks.json is missing hooks object');
+  const hooks = parsed.hooks as Record<string, unknown>;
+  const event = 'PreToolUse';
+  const existing = hooks[event];
+  if (existing !== undefined && !Array.isArray(existing)) {
+    throw new Error(`hooks.${event} is not an array`);
+  }
+  const entries = (existing ?? []) as unknown[];
+  const foreignCommand = (groupLabel: string, suffix = '') =>
+    `${JSON.stringify(process.execPath)} ${JSON.stringify(`${marker}-${event}-${groupLabel}${suffix}.js`)}`;
+  if (options.appendGroups) {
+    for (const groupLabel of ['first', 'second']) {
+      entries.push({
+        ...(groupLabel === 'first' ? { matcher: 'Bash' } : {}),
+        foreign_group_metadata: {
+          marker,
+          groupLabel,
+          nested: { keep: ['foreign', event, groupLabel], depth: { value: 7 } },
+        },
+        hooks: [{
+          type: 'command',
+          command: foreignCommand(groupLabel),
+          statusMessage: `${marker} ${event} ${groupLabel}`,
+          foreign_handler_metadata: { marker, event, groupLabel, values: [1, { two: true }] },
+        }],
+      });
+    }
+  } else {
+    const groupLabel = 'second';
+    const group = entries.find((entry): entry is JsonRecord => isRecord(entry)
+      && Array.isArray(entry.hooks)
+      && entry.hooks.some((hook) => isRecord(hook)
+        && hook.command === foreignCommand(groupLabel)));
+    if (!group || !Array.isArray(group.hooks)) {
+      throw new Error(`missing pre-seeded foreign ${event} ${groupLabel} group`);
+    }
+    for (const insertionLabel of ['one', 'two']) {
+      group.hooks.push({
+        type: 'command',
+        command: foreignCommand(groupLabel, `-${insertionLabel}-inserted`),
+        statusMessage: `${marker} inserted ${event} ${insertionLabel}`,
+        foreign_handler_metadata: { marker, inserted: true, insertionLabel, nested: { event } },
+      });
+    }
+  }
+  hooks[event] = entries;
+  return JSON.stringify(parsed, null, 2) + '\n';
+}
+
+
+export function foreignHookGroupSnapshot(hooksContent: string, marker: string): unknown[] {
+  const parsed = JSON.parse(hooksContent) as { hooks?: Record<string, unknown> };
+  if (!isRecord(parsed.hooks)) throw new Error('hooks.json is missing hooks object');
+  const result: unknown[] = [];
+  for (const [event, entries] of Object.entries(parsed.hooks)) {
+    if (!Array.isArray(entries)) continue;
+    entries.forEach((entry, groupIndex) => {
+      if (!isRecord(entry) || !Array.isArray(entry.hooks)) return;
+      entry.hooks.forEach((hook, handlerIndex) => {
+        if (isRecord(hook) && typeof hook.command === 'string' && hook.command.includes(marker)) {
+          result.push({ event, groupIndex, handlerIndex, group: structuredClone(entry), handler: structuredClone(hook) });
+        }
+      });
+    });
+  }
+  return result;
+}
+
+export function assertForeignHookGroupsPreserved(
+  expected: unknown[],
+  actualContent: string,
+  marker: string,
+): void {
+  const actual = foreignHookGroupSnapshot(actualContent, marker);
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`Foreign hook groups or metadata changed: ${JSON.stringify({ expected, actual })}`);
+  }
+}
+
+
+export function probeCodexVersion(cwd: string, env: NodeJS.ProcessEnv): string {
+  return resolvePinnedCodexExecutable(cwd, env).version;
+}
+
 function usage(): string {
   return [
     'Usage: node scripts/smoke-packed-install.mjs',
     '',
     'Creates an npm tarball, installs it into an isolated prefix, and smoke tests the installed omx CLI.',
-    'Release smoke stays intentionally minimal: install + boot + 1-2 core commands only.',
+    'Release smoke validates installed CLI boot, native-hook dispatch, and the isolated setup/rerun/uninstall lifecycle; Codex trust checks run when the pinned CLI is present.',
   ].join('\n');
 }
 
@@ -216,6 +1167,507 @@ function smokeInstalledNativeHookDist(prefixDir: string): void {
   }
 }
 
+function sameJson(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function isolatedSmokeEnv(home: string, codexHome: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, HOME: home, CODEX_HOME: codexHome };
+  for (const key of [
+    'OMX_SESSION_ID',
+    'OMX_RUN_ID',
+    'OMX_ROOT',
+    'OMX_STATE_ROOT',
+    'OMX_ACTIVE_SESSION_PID',
+    'CODEX_SESSION_ID',
+    'TMUX',
+    'TMUX_PANE',
+  ]) {
+    delete env[key];
+  }
+  return env;
+}
+
+function trustedProjectConfig(projectDir: string): string {
+  const escapedProjectDir = projectDir.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `[projects."${escapedProjectDir}"]\ntrust_level = "trusted"\n`;
+}
+
+
+function rawManagedHookCount(hooksContent: string): number {
+  const parsed = JSON.parse(hooksContent) as { hooks?: Record<string, unknown> };
+  if (!isRecord(parsed.hooks)) throw new Error('hooks.json is missing hooks object');
+  return Object.values(parsed.hooks).flatMap((entries) => Array.isArray(entries) ? entries : [])
+    .flatMap((entry) => isRecord(entry) && Array.isArray(entry.hooks) ? entry.hooks : [])
+    .filter((hook) => isRecord(hook)
+      && typeof hook.command === 'string'
+      && isManagedCodexHookCommand(hook.command)).length;
+}
+
+function assertNoEmptyManagedEventGroups(hooksContent: string): void {
+  const parsed = JSON.parse(hooksContent) as { hooks?: Record<string, unknown> };
+  if (!isRecord(parsed.hooks)) throw new Error('hooks.json is missing hooks object');
+  for (const event of MANAGED_CODEX_HOOK_EVENTS) {
+    const entries = parsed.hooks[event];
+    if (!Array.isArray(entries)) continue;
+    entries.forEach((entry, groupIndex) => {
+      if (isRecord(entry) && (!Array.isArray(entry.hooks) || entry.hooks.length === 0)) {
+        throw new Error(`packed uninstall left an empty ${event} group at coordinate ${groupIndex}`);
+      }
+    });
+  }
+}
+
+function assertNoSetupOwnedTrustKeys(configToml: string, setupTrust: Record<string, string>): void {
+  const parsed = TOML.parse(configToml) as { hooks?: { state?: Record<string, unknown> } };
+  const state = parsed.hooks?.state;
+  if (!isRecord(state)) return;
+  const retained = Object.keys(setupTrust).filter((key) => Object.hasOwn(state, key));
+  if (retained.length > 0) {
+    throw new Error(`packed uninstall retained setup-owned OMX hook trust keys: ${retained.join(', ')}`);
+  }
+}
+
+function assertNativeHooksEnabledForForeignGroups(configToml: string): void {
+  const parsed = TOML.parse(configToml) as { features?: Record<string, unknown> };
+  const features = parsed.features;
+  if (!isRecord(features) || (features.hooks !== true && features.codex_hooks !== true)) {
+    throw new Error('packed uninstall disabled native hooks despite preserved foreign hook groups');
+  }
+}
+
+function assertNoUninstallTransactionArtifacts(codexDir: string): void {
+  const artifacts = readdirSync(codexDir).filter((entry) => entry.includes('.omx-uninstall-'));
+  if (artifacts.length > 0) {
+    throw new Error(`unsafe packed uninstall left replacement, staged, or tombstone paths: ${artifacts.join(', ')}`);
+  }
+}
+
+function preToolUseGroupIndices(hooksContent: string, marker: string): {
+  foreignIndices: number[];
+  managedIndices: number[];
+} {
+  const parsed = JSON.parse(hooksContent) as { hooks?: Record<string, unknown> };
+  if (!isRecord(parsed.hooks)) throw new Error('hooks.json is missing hooks object');
+  const entries = parsed.hooks.PreToolUse;
+  if (!Array.isArray(entries)) throw new Error('hooks.PreToolUse is missing');
+  const foreignIndices: number[] = [];
+  const managedIndices: number[] = [];
+  entries.forEach((entry, index) => {
+    if (!isRecord(entry) || !Array.isArray(entry.hooks)) return;
+    if (entry.hooks.some((hook) => isRecord(hook)
+      && typeof hook.command === 'string'
+      && hook.command.includes(marker))) {
+      foreignIndices.push(index);
+    }
+    if (entry.hooks.some((hook) => isRecord(hook)
+      && typeof hook.command === 'string'
+      && isManagedCodexHookCommand(hook.command))) {
+      managedIndices.push(index);
+    }
+  });
+  return { foreignIndices, managedIndices };
+}
+
+function assertManagedHooksAppendAfterForeign(hooksContent: string, marker: string): void {
+  const { foreignIndices, managedIndices } = preToolUseGroupIndices(hooksContent, marker);
+  if (
+    foreignIndices.length !== 2 ||
+    managedIndices.length !== 1 ||
+    managedIndices[0]! <= Math.max(...foreignIndices)
+  ) {
+    throw new Error('packed first install did not append the OMX PreToolUse group after both foreign groups');
+  }
+}
+
+function assertManagedHooksRemainBeforeForeign(hooksContent: string, marker: string): void {
+  const { foreignIndices, managedIndices } = preToolUseGroupIndices(hooksContent, marker);
+  if (
+    foreignIndices.length !== 2 ||
+    managedIndices.length !== 1 ||
+    managedIndices[0]! >= Math.min(...foreignIndices)
+  ) {
+    throw new Error('packed setup rerun reordered the managed-first PreToolUse topology');
+  }
+}
+
+
+
+function assertTrustedManagedHooks(hooks: readonly CodexHookMetadata[]): void {
+  for (const [event, hook] of Object.entries(managedCodexHooksByEvent(hooks))) {
+    if (hook.trustStatus !== 'trusted') {
+      throw new Error(`Codex did not trust OMX ${event}; received ${hook.trustStatus}`);
+    }
+  }
+}
+
+function assertManagedHooksNotAlreadyTrusted(hooks: readonly CodexHookMetadata[]): void {
+  for (const [event, hook] of Object.entries(managedCodexHooksByEvent(hooks))) {
+    if (hook.trustStatus === 'trusted') {
+      throw new Error(`setup-generated project trust unexpectedly pre-approved OMX ${event}`);
+    }
+  }
+}
+function preseededForeignHookMetadata(
+  hooks: readonly CodexHookMetadata[],
+  marker: string,
+): Array<Pick<CodexHookMetadata, 'event' | 'command' | 'key' | 'currentHash' | 'displayOrder' | 'trustStatus'>> {
+  return hookMetadataSnapshot(
+    hooks.filter((hook) => hook.command.includes(marker) && !hook.command.includes('-inserted.js')),
+  );
+}
+
+function assertPreseededForeignHookEvidence(
+  expected: readonly Pick<CodexHookMetadata, 'event' | 'command' | 'key' | 'currentHash' | 'displayOrder' | 'trustStatus'>[],
+  actualHooks: readonly CodexHookMetadata[],
+  codexUserConfig: string,
+  marker: string,
+  phase: string,
+): void {
+  const actual = preseededForeignHookMetadata(actualHooks, marker);
+  if (actual.length !== 2) {
+    throw new Error(`Codex ${phase} did not report exactly two pre-seeded foreign hooks; received ${actual.length}`);
+  }
+  if (!sameJson(actual, expected)) {
+    const changes = expected.flatMap((expectedHook, index) =>
+      Object.entries(expectedHook).flatMap(([field, expectedValue]) => {
+        const actualValue = actual[index]?.[field as keyof typeof expectedHook];
+        return actualValue === expectedValue
+          ? []
+          : [`${expectedHook.event}.${field}: ${JSON.stringify(expectedValue)} -> ${JSON.stringify(actualValue)}`];
+      }));
+    throw new Error(
+      `Codex ${phase} changed pre-seeded foreign hook key, hash, coordinate, or display order: ${changes.join('; ')}`,
+    );
+  }
+  if (actual.some((hook) => hook.trustStatus !== 'trusted')) {
+    throw new Error(`Codex ${phase} did not retain trusted status for every pre-seeded foreign hook`);
+  }
+  const trust = generatedHookTrustState(codexUserConfig);
+  for (const hook of actual) {
+    if (trust[hook.key] !== hook.currentHash) {
+      throw new Error(`Codex ${phase} did not retain the foreign trust entry for ${hook.key}`);
+    }
+  }
+}
+
+async function observeInstalledCodexHooks(
+  projectDir: string,
+  hooksPath: string,
+  env: NodeJS.ProcessEnv,
+): Promise<CodexHooksListEntry> {
+  const server = await CodexAppServer.start({ cwd: projectDir, env });
+  try {
+    await initializeCodexAppServer(server, 'omx-packed-install-smoke');
+    return await listCodexHooks(server, projectDir, hooksPath);
+  } finally {
+    await server.close();
+  }
+}
+
+export interface PackedHookTrustLifecycleResult {
+  codexVersion: string | null;
+}
+
+/**
+ * Exercise setup and removal against the installed package. The deterministic
+ * filesystem lifecycle always runs; the installed-Codex trust leg is skipped
+ * only when the `codex` executable is absent.
+ */
+export async function smokePackedHookTrustLifecycle(
+  omxPath: string,
+): Promise<PackedHookTrustLifecycleResult> {
+  const lifecycleRoot = mkdtempSync(join(tmpdir(), 'omx-packed-hook-trust-'));
+  const projectDir = resolve(lifecycleRoot, 'project');
+  const home = join(lifecycleRoot, 'home');
+  const codexHome = join(lifecycleRoot, 'codex-home');
+  const hooksPath = join(projectDir, '.codex', 'hooks.json');
+  const configPath = join(projectDir, '.codex', 'config.toml');
+  const marker = 'omx-packed-foreign';
+  const env = isolatedSmokeEnv(home, codexHome);
+
+  try {
+    mkdirSync(projectDir, { recursive: true });
+    mkdirSync(home, { recursive: true });
+    mkdirSync(codexHome, { recursive: true });
+    mkdirSync(join(projectDir, '.codex'), { recursive: true });
+    writeFileSync(join(codexHome, 'config.toml'), trustedProjectConfig(projectDir), 'utf-8');
+
+    // Pre-seed foreign groups so uninstall may safely remove OMX's appended suffix.
+    writeFileSync(
+      hooksPath,
+      appendDisplayOrderStableForeignHookGroups('{"hooks":{}}', marker, { appendGroups: true }),
+      'utf-8',
+    );
+    const preSetupForeignSnapshot = foreignHookGroupSnapshot(readFileSync(hooksPath, 'utf-8'), marker);
+    if (preSetupForeignSnapshot.length !== 2) {
+      throw new Error(`expected two pre-seeded foreign hook coordinates, received ${preSetupForeignSnapshot.length}`);
+    }
+
+    let codexVersion: string | null;
+    try {
+      codexVersion = probeCodexVersion(projectDir, env);
+    } catch (error) {
+      if (!(error instanceof CodexExecutableNotFoundError)) throw error;
+      codexVersion = null;
+    }
+
+    const codexUserConfigPath = join(codexHome, 'config.toml');
+    let approvedPreSetupForeignMetadata: Array<Pick<CodexHookMetadata, 'event' | 'command' | 'key' | 'currentHash' | 'displayOrder' | 'trustStatus'>> | null = null;
+    if (codexVersion !== null) {
+      const server = await CodexAppServer.start({ cwd: projectDir, env });
+      try {
+        await initializeCodexAppServer(server, 'omx-packed-install-smoke');
+        const preSetupCodexHooks = await listCodexHooks(server, projectDir, hooksPath);
+        const preSetupForeignHooks = preSetupCodexHooks.hooks.filter((hook) =>
+          hook.command.includes(marker) && !hook.command.includes('-inserted.js'));
+        if (preSetupForeignHooks.length !== 2) {
+          throw new Error(`Codex hooks/list did not report exactly two pre-seeded foreign hooks; received ${preSetupForeignHooks.length}`);
+        }
+        if (preSetupForeignHooks.some((hook) => hook.trustStatus === 'trusted')) {
+          throw new Error('isolated Codex approval state unexpectedly pre-approved a foreign hook before setup');
+        }
+        const approval = await server.request<unknown>(
+          createCodexBatchWriteEnvelope(Object.fromEntries(
+            preSetupForeignHooks.map((hook) => [hook.key, hook.currentHash]),
+          )),
+          CODEX_APP_SERVER_TIMEOUTS.requestMs,
+        );
+        assertCodexBatchWriteResult(approval, codexUserConfigPath);
+      } finally {
+        await server.close();
+      }
+      const approved = await observeInstalledCodexHooks(projectDir, hooksPath, env);
+      approvedPreSetupForeignMetadata = preseededForeignHookMetadata(approved.hooks, marker);
+      assertPreseededForeignHookEvidence(
+        approvedPreSetupForeignMetadata,
+        approved.hooks,
+        readFileSync(codexUserConfigPath, 'utf-8'),
+        marker,
+        'pre-setup approval',
+      );
+    }
+
+    run(omxPath, ['setup', '--scope', 'project', '--merge-agents', '--legacy'], {
+      cwd: projectDir,
+      env,
+    });
+
+    const initialHooksContent = readFileSync(hooksPath, 'utf-8');
+    assertForeignHookGroupsPreserved(preSetupForeignSnapshot, initialHooksContent, marker);
+    if (rawManagedHookCount(initialHooksContent) !== MANAGED_CODEX_HOOK_EVENTS.length) {
+      throw new Error('packed setup did not install exactly seven managed native hooks');
+    }
+    assertManagedHooksAppendAfterForeign(initialHooksContent, marker);
+    const generatedTrust = generatedHookTrustState(readFileSync(configPath, 'utf-8'));
+
+    let postForeignCodexHooks: CodexHookMetadata[] | null = null;
+    if (codexVersion !== null) {
+      const server = await CodexAppServer.start({ cwd: projectDir, env });
+      try {
+        await initializeCodexAppServer(server, 'omx-packed-install-smoke');
+        const initialCodexHooks = await listCodexHooks(server, projectDir, hooksPath);
+        assertGeneratedTrustMatchesCodex(generatedTrust, initialCodexHooks.hooks);
+        assertManagedHooksNotAlreadyTrusted(initialCodexHooks.hooks);
+        await approveManagedHooksInCodex(server, initialCodexHooks.hooks, codexUserConfigPath);
+      } finally {
+        await server.close();
+      }
+      const afterSetup = await observeInstalledCodexHooks(projectDir, hooksPath, env);
+      assertTrustedManagedHooks(afterSetup.hooks);
+      assertPreseededForeignHookEvidence(
+        approvedPreSetupForeignMetadata!,
+        afterSetup.hooks,
+        readFileSync(codexUserConfigPath, 'utf-8'),
+        marker,
+        'setup',
+      );
+    }
+
+    writeFileSync(
+      hooksPath,
+      appendDisplayOrderStableForeignHookGroups(readFileSync(hooksPath, 'utf-8'), marker, { appendGroups: false }),
+      'utf-8',
+    );
+    const postForeignHooksContent = readFileSync(hooksPath, 'utf-8');
+    const postForeignConfigContent = readFileSync(configPath, 'utf-8');
+
+    const foreignSnapshot = foreignHookGroupSnapshot(postForeignHooksContent, marker);
+    if (foreignSnapshot.length !== 4) {
+      throw new Error(`expected four foreign hook coordinates after insertion, received ${foreignSnapshot.length}`);
+    }
+    if (codexVersion !== null) {
+      const inspected = await observeInstalledCodexHooks(projectDir, hooksPath, env);
+      assertTrustedManagedHooks(inspected.hooks);
+      postForeignCodexHooks = inspected.hooks;
+      assertPreseededForeignHookEvidence(
+        approvedPreSetupForeignMetadata!,
+        inspected.hooks,
+        readFileSync(codexUserConfigPath, 'utf-8'),
+        marker,
+        'foreign insertion before setup rerun',
+      );
+    }
+
+    run(omxPath, ['setup', '--scope', 'project', '--merge-agents', '--legacy'], {
+      cwd: projectDir,
+      env,
+    });
+    const afterRerunHooksContent = readFileSync(hooksPath, 'utf-8');
+    if (afterRerunHooksContent !== postForeignHooksContent) {
+      throw new Error('packed setup rerun changed hooks.json after foreign insertion');
+    }
+    if (readFileSync(configPath, 'utf-8') !== postForeignConfigContent) {
+      throw new Error('packed setup rerun changed config.toml after foreign insertion');
+    }
+
+    assertForeignHookGroupsPreserved(foreignSnapshot, afterRerunHooksContent, marker);
+    if (postForeignCodexHooks !== null) {
+      const afterRerun = await observeInstalledCodexHooks(projectDir, hooksPath, env);
+      assertTrustedManagedHooks(afterRerun.hooks);
+      assertPreseededForeignHookEvidence(
+        approvedPreSetupForeignMetadata!,
+        afterRerun.hooks,
+        readFileSync(codexUserConfigPath, 'utf-8'),
+        marker,
+        'setup rerun',
+      );
+      if (!sameJson(hookMetadataSnapshot(afterRerun.hooks), hookMetadataSnapshot(postForeignCodexHooks))) {
+        throw new Error('packed setup rerun changed Codex hook metadata or display order');
+      }
+    }
+
+    run(omxPath, ['setup', '--scope', 'project', '--merge-agents', '--legacy'], {
+      cwd: projectDir,
+      env,
+    });
+    const afterNoopHooksContent = readFileSync(hooksPath, 'utf-8');
+    if (afterNoopHooksContent !== postForeignHooksContent) {
+      throw new Error('third packed setup was not a hooks.json byte no-op');
+    }
+    if (readFileSync(configPath, 'utf-8') !== postForeignConfigContent) {
+      throw new Error('third packed setup was not a config.toml byte no-op');
+    }
+    assertForeignHookGroupsPreserved(foreignSnapshot, afterNoopHooksContent, marker);
+    if (postForeignCodexHooks !== null) {
+      const afterNoop = await observeInstalledCodexHooks(projectDir, hooksPath, env);
+      assertTrustedManagedHooks(afterNoop.hooks);
+      assertPreseededForeignHookEvidence(
+        approvedPreSetupForeignMetadata!,
+        afterNoop.hooks,
+        readFileSync(codexUserConfigPath, 'utf-8'),
+        marker,
+        'third setup',
+      );
+      if (!sameJson(hookMetadataSnapshot(afterNoop.hooks), hookMetadataSnapshot(postForeignCodexHooks))) {
+        throw new Error('third packed setup changed Codex hook metadata or display order');
+      }
+    }
+
+    run(omxPath, ['uninstall'], { cwd: projectDir, env });
+    const afterUninstallHooksContent = readFileSync(hooksPath, 'utf-8');
+    if (rawManagedHookCount(afterUninstallHooksContent) !== 0) {
+      throw new Error('packed uninstall retained an OMX-managed native hook');
+    }
+    assertNoEmptyManagedEventGroups(afterUninstallHooksContent);
+    assertForeignHookGroupsPreserved(foreignSnapshot, afterUninstallHooksContent, marker);
+    const afterUninstallConfig = readFileSync(configPath, 'utf-8');
+    assertNoSetupOwnedTrustKeys(afterUninstallConfig, generatedTrust);
+    assertNativeHooksEnabledForForeignGroups(afterUninstallConfig);
+    if (postForeignCodexHooks !== null) {
+      const afterUninstall = await observeInstalledCodexHooks(projectDir, hooksPath, env);
+      const foreignIdentity = (hooks: readonly CodexHookMetadata[]) =>
+        hookMetadataSnapshot(hooks.filter((hook) => hook.command.includes(marker)));
+      const foreignBefore = foreignIdentity(postForeignCodexHooks);
+      const foreignAfter = foreignIdentity(afterUninstall.hooks);
+      if (!sameJson(foreignAfter, foreignBefore)) {
+        throw new Error('packed uninstall changed foreign Codex hook metadata or display order');
+      }
+    }
+
+    const managedFirstProjectDir = resolve(lifecycleRoot, 'managed-first-project');
+    const managedFirstHooksPath = join(managedFirstProjectDir, '.codex', 'hooks.json');
+    const managedFirstConfigPath = join(managedFirstProjectDir, '.codex', 'config.toml');
+    const managedFirstMarker = 'omx-packed-managed-first-foreign';
+    mkdirSync(join(managedFirstProjectDir, '.codex'), { recursive: true });
+    run(omxPath, ['setup', '--scope', 'project', '--merge-agents', '--legacy'], {
+      cwd: managedFirstProjectDir,
+      env,
+    });
+    writeFileSync(
+      managedFirstHooksPath,
+      appendDisplayOrderStableForeignHookGroups(
+        readFileSync(managedFirstHooksPath, 'utf-8'),
+        managedFirstMarker,
+        { appendGroups: true },
+      ),
+      'utf-8',
+    );
+    const managedFirstBeforeRerunHooks = readFileSync(managedFirstHooksPath, 'utf-8');
+    const managedFirstBeforeRerunConfig = readFileSync(managedFirstConfigPath, 'utf-8');
+    const managedFirstForeignSnapshot = foreignHookGroupSnapshot(managedFirstBeforeRerunHooks, managedFirstMarker);
+    if (managedFirstForeignSnapshot.length !== 2) {
+      throw new Error('packed managed-first fixture did not append both foreign hook groups');
+    }
+    assertManagedHooksRemainBeforeForeign(managedFirstBeforeRerunHooks, managedFirstMarker);
+
+    run(omxPath, ['setup', '--scope', 'project', '--merge-agents', '--legacy'], {
+      cwd: managedFirstProjectDir,
+      env,
+    });
+    if (readFileSync(managedFirstHooksPath, 'utf-8') !== managedFirstBeforeRerunHooks) {
+      throw new Error('packed setup rerun reordered managed-first foreign hook groups');
+    }
+    if (readFileSync(managedFirstConfigPath, 'utf-8') !== managedFirstBeforeRerunConfig) {
+      throw new Error('packed setup rerun changed managed-first config.toml');
+    }
+    assertForeignHookGroupsPreserved(
+      managedFirstForeignSnapshot,
+      readFileSync(managedFirstHooksPath, 'utf-8'),
+      managedFirstMarker,
+    );
+    const managedFirstBeforeUninstallHooksBytes = readFileSync(managedFirstHooksPath);
+    const managedFirstBeforeUninstallConfigBytes = readFileSync(managedFirstConfigPath);
+
+    const expectedUnsafeManagedRemovalDiagnostic =
+      'Removing OMX hooks would shift a foreign coordinate or discard opaque metadata.';
+    const unsafeRemoval = planManagedCodexHooksRemoval(managedFirstBeforeRerunHooks, managedFirstHooksPath);
+    if (
+      unsafeRemoval.ok ||
+      unsafeRemoval.error.code !== 'unsafe_managed_removal' ||
+      unsafeRemoval.error.message !== expectedUnsafeManagedRemovalDiagnostic
+    ) {
+      throw new Error('packed managed-first fixture did not return the exact unsafe_managed_removal diagnostic');
+    }
+    const failedUninstall = spawnSync(omxPath, ['uninstall'], {
+      cwd: managedFirstProjectDir,
+      env,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    });
+    if (failedUninstall.error) throw failedUninstall.error;
+    if (failedUninstall.status !== 1) {
+      throw new Error(
+        `packed unsafe uninstall exited ${String(failedUninstall.status)}, expected 1\nstdout:\n${failedUninstall.stdout || ''}\nstderr:\n${failedUninstall.stderr || ''}`,
+      );
+    }
+    if (failedUninstall.stderr !== `Error: ${expectedUnsafeManagedRemovalDiagnostic}\n`) {
+      throw new Error(`packed unsafe uninstall returned an unexpected diagnostic: ${failedUninstall.stderr || ''}`);
+    }
+    if (!readFileSync(managedFirstHooksPath).equals(managedFirstBeforeUninstallHooksBytes)) {
+      throw new Error('unsafe packed uninstall changed raw hooks.json bytes');
+    }
+    if (!readFileSync(managedFirstConfigPath).equals(managedFirstBeforeUninstallConfigBytes)) {
+      throw new Error('unsafe packed uninstall changed raw config.toml bytes');
+    }
+    assertNoUninstallTransactionArtifacts(join(managedFirstProjectDir, '.codex'));
+
+    return { codexVersion };
+  } finally {
+    rmSync(lifecycleRoot, { recursive: true, force: true });
+  }
+}
+
 export function parseNpmPackJsonOutput(stdout: string): Array<{ filename: string }> {
   const start = stdout.lastIndexOf('\n[');
   const jsonText = (start >= 0 ? stdout.slice(start + 1) : stdout).trim();
@@ -252,6 +1704,12 @@ async function main(): Promise<void> {
       run(omxPath, argv, { cwd: repoRoot });
     }
     smokeInstalledNativeHookDist(prefixDir);
+    const lifecycle = await smokePackedHookTrustLifecycle(omxPath);
+    console.log(
+      lifecycle.codexVersion !== null
+        ? `packed install smoke: installed Codex 0.142.5 lifecycle passed (${lifecycle.codexVersion})`
+        : 'packed install smoke: Codex executable absent; installed-Codex trust leg skipped after deterministic lifecycle',
+    );
 
     console.log('packed install smoke: PASS');
   } finally {


### PR DESCRIPTION
## Summary

- refresh healthy OMX Codex hook handlers in place instead of rebuilding event arrays
- append one canonical group only when a managed event is missing
- prove every surviving foreign group/handler keeps its exact absolute coordinate before any managed removal
- fail closed with `unsafe_managed_removal` and zero artifact writes when removal would shift foreign trust identity
- preserve foreign JSON/TOML metadata, final-coordinate trust, Windows shim ownership, and transactional rollback/manual recovery

## Review status

A finalized exact-head Architect review found additional fail-closed ownership and preservation blockers after the initial delivery. The PR remains open and unmerged while those findings are repaired and the complete verification/review sequence is rerun. The head and evidence below will be updated only after a clean replacement signed commit.

## Verified before the blocker review

- `npm run build`
- exact focused contract suite: 383 passed, including two real Linux `codex-cli 0.142.5` app-server scenarios
- `npx tsc --noEmit`
- `npm run check:no-unused`
- `npm run lint`
- full `npm test`
- `npm run smoke:packed-install`

Linux runtime evidence is Linux-only; the packed lifecycle remains cross-platform. This PR is intentionally not merged by the delivery workflow.

Fixes #3147

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*