### PR TITLE
fix: keep Ralplan terminal state on the canonical session

### DIFF
--- a/src/auth/__tests__/hotswap.test.ts
+++ b/src/auth/__tests__/hotswap.test.ts
@@ -1,0 +1,203 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runAuthHotswap, type HotswapLifecycle } from "../hotswap.js";
+
+function sessionPointerAbort(cwd: string): Error {
+  return Object.assign(new Error("selected pointer root is unavailable"), {
+    name: "SessionPointerLaunchAbort",
+    committed: false,
+    cwd,
+    code: "session_pointer_context_failure",
+    operation: "pointer-context-resolve",
+    attemptedRootSource: "cwd-default",
+    reason: "selected pointer root is unavailable",
+  });
+}
+
+function lifecycle(overrides: Partial<HotswapLifecycle> = {}): HotswapLifecycle {
+  return {
+    prepareCodexHomeForLaunch: async () => ({}),
+    preLaunch: async () => {},
+    postLaunch: async () => {},
+    cleanupRuntimeCodexHome: async () => {},
+    normalizeCodexLaunchArgs: (args) => args,
+    injectModelInstructionsBypassArgs: (_cwd, args) => args,
+    sessionModelInstructionsPath: (cwd, sessionId) => join(cwd, `${sessionId}.md`),
+    resolveOmxRootForLaunch: () => undefined,
+    resolveNotifyTempContract: (args) => ({
+      contract: { active: false },
+      passthroughArgs: args,
+    }),
+    ...overrides,
+  };
+}
+
+async function writeAuthSlot(home: string, slot = "first"): Promise<string> {
+  const authDir = join(home, ".omx", "auth");
+  const slotPath = join(authDir, `${slot}.json`);
+  await mkdir(authDir, { recursive: true });
+  await writeFile(slotPath, '{"access_token":"slot-secret"}\n');
+  await writeFile(
+    join(authDir, "slots.json"),
+    JSON.stringify({
+      version: 1,
+      currentSlot: slot,
+      slots: [{ slot, createdAt: "now", updatedAt: "now" }],
+    }),
+  );
+  return slotPath;
+}
+
+describe("auth hotswap pointer abort lifecycle", () => {
+  it("skips the initial slot mutation and postLaunch for a typed pointer abort", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-hotswap-pointer-abort-"));
+    const home = join(cwd, "home");
+    const runtimeHome = join(cwd, "runtime-codex-home");
+    const liveAuthPath = join(runtimeHome, "auth.json");
+    let postLaunchCalls = 0;
+    let cleanupCalls = 0;
+    try {
+      await writeAuthSlot(home);
+      await mkdir(runtimeHome, { recursive: true });
+      await writeFile(liveAuthPath, '{"access_token":"live-sentinel"}\n');
+
+      const status = await runAuthHotswap({
+        cwd,
+        home,
+        env: { CODEX_HOME: runtimeHome },
+        argv: [],
+        lifecycle: lifecycle({
+          prepareCodexHomeForLaunch: async () => ({
+            codexHomeOverride: runtimeHome,
+            runtimeCodexHomeForCleanup: runtimeHome,
+          }),
+          preLaunch: async () => {
+            throw sessionPointerAbort(cwd);
+          },
+          postLaunch: async () => {
+            postLaunchCalls += 1;
+          },
+          cleanupRuntimeCodexHome: async () => {
+            cleanupCalls += 1;
+          },
+        }),
+      });
+
+      assert.equal(status, 1);
+      assert.equal(postLaunchCalls, 0);
+      assert.equal(cleanupCalls, 1);
+      assert.equal(
+        await readFile(liveAuthPath, "utf-8"),
+        '{"access_token":"live-sentinel"}\n',
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("runs postLaunch and runtime cleanup after a successful preLaunch then initial useSlot failure", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-hotswap-use-slot-failure-"));
+    const home = join(cwd, "home");
+    const runtimeHome = join(cwd, "runtime-codex-home");
+    let postLaunchCalls = 0;
+    let cleanupCalls = 0;
+    try {
+      const slotPath = await writeAuthSlot(home);
+
+      const status = await runAuthHotswap({
+        cwd,
+        home,
+        env: { CODEX_HOME: runtimeHome },
+        argv: [],
+        lifecycle: lifecycle({
+          prepareCodexHomeForLaunch: async () => ({
+            codexHomeOverride: runtimeHome,
+            runtimeCodexHomeForCleanup: runtimeHome,
+          }),
+          preLaunch: async () => {
+            await rm(slotPath);
+          },
+          postLaunch: async () => {
+            postLaunchCalls += 1;
+          },
+          cleanupRuntimeCodexHome: async () => {
+            cleanupCalls += 1;
+          },
+        }),
+      });
+
+      assert.equal(status, 1);
+      assert.equal(postLaunchCalls, 1);
+      assert.equal(cleanupCalls, 1);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("runs postLaunch and runtime cleanup after a later rotation useSlot failure", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-hotswap-rotation-use-slot-failure-"));
+    const home = join(cwd, "home");
+    const runtimeHome = join(cwd, "runtime-codex-home");
+    const binDir = join(cwd, "bin");
+    const codexLog = join(cwd, "codex.log");
+    const secondSlotPath = join(home, ".omx", "auth", "second.json");
+    let postLaunchCalls = 0;
+    let cleanupCalls = 0;
+    try {
+      await writeAuthSlot(home);
+      await writeFile(secondSlotPath, '{"access_token":"second-secret"}\n');
+      await writeFile(
+        join(home, ".omx", "auth", "slots.json"),
+        JSON.stringify({
+          version: 1,
+          currentSlot: "first",
+          slots: [
+            { slot: "first", createdAt: "now", updatedAt: "now" },
+            { slot: "second", createdAt: "now", updatedAt: "now" },
+          ],
+        }),
+      );
+      await mkdir(binDir, { recursive: true });
+      await writeFile(
+        join(binDir, "codex"),
+        `#!/bin/sh\nprintf 'spawned\\n' >> ${JSON.stringify(codexLog)}\necho token_invalidated >&2\nexit 1\n`,
+      );
+      await chmod(join(binDir, "codex"), 0o755);
+
+      const status = await runAuthHotswap({
+        cwd,
+        home,
+        env: {
+          CODEX_HOME: runtimeHome,
+          PATH: `${binDir}:/usr/bin:/bin`,
+        },
+        argv: [],
+        lifecycle: lifecycle({
+          prepareCodexHomeForLaunch: async () => ({
+            codexHomeOverride: runtimeHome,
+            runtimeCodexHomeForCleanup: runtimeHome,
+          }),
+          preLaunch: async () => {
+            await rm(secondSlotPath);
+          },
+          postLaunch: async () => {
+            postLaunchCalls += 1;
+          },
+          cleanupRuntimeCodexHome: async () => {
+            cleanupCalls += 1;
+          },
+        }),
+      });
+
+      assert.equal(status, 1);
+      assert.equal(await readFile(codexLog, "utf-8"), "spawned\n");
+      assert.equal(postLaunchCalls, 1);
+      assert.equal(cleanupCalls, 1);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/auth/hotswap.ts
+++ b/src/auth/hotswap.ts
@@ -8,6 +8,7 @@ import { redactAuthSecrets } from "./redact.js";
 import { buildRotationPlan, nextSlotAfter } from "./rotation.js";
 import { findLatestRolloutSession } from "./sessions.js";
 import { listSlots, markSlotQuota, readAuthMetadata, useSlot } from "./storage.js";
+import { isSessionPointerLaunchAbort } from "../hooks/session.js";
 
 export interface PreparedHotswapCodexHome {
   codexHomeOverride?: string;
@@ -163,9 +164,18 @@ export async function runAuthHotswap(options: HotswapOptions): Promise<number> {
 
   const exhausted = new Set<string>();
   let resumeArgs: string[] | null = null;
+  let skipPostLaunch = false;
   try {
+    try {
+      await lifecycle.preLaunch(cwd, sessionId, notifyTempResult.contract, prepared.codexHomeOverride, true, false);
+    } catch (err) {
+      if (isSessionPointerLaunchAbort(err)) {
+        skipPostLaunch = true;
+        process.stderr.write(`[omx auth] session pointer launch aborted: ${err.code}\n`);
+      }
+      throw err;
+    }
     await useSlot(currentSlot, liveAuthPath, home);
-    await lifecycle.preLaunch(cwd, sessionId, notifyTempResult.contract, prepared.codexHomeOverride, true, false);
     const baseEnv: NodeJS.ProcessEnv = {
       ...env,
       ...(prepared.codexHomeOverride ? { CODEX_HOME: prepared.codexHomeOverride } : {}),
@@ -230,9 +240,11 @@ export async function runAuthHotswap(options: HotswapOptions): Promise<number> {
     process.stderr.write(`[omx auth] ${redactAuthSecrets(err)}\n`);
     return 1;
   } finally {
-    await lifecycle.postLaunch(cwd, sessionId, prepared.codexHomeOverride, true, prepared.projectLocalCodexHomeForCleanup).catch((err) => {
-      process.stderr.write(`[omx auth] postLaunch warning: ${redactAuthSecrets(err)}\n`);
-    });
+    if (!skipPostLaunch) {
+      await lifecycle.postLaunch(cwd, sessionId, prepared.codexHomeOverride, true, prepared.projectLocalCodexHomeForCleanup).catch((err) => {
+        process.stderr.write(`[omx auth] postLaunch warning: ${redactAuthSecrets(err)}\n`);
+      });
+    }
     await lifecycle.cleanupRuntimeCodexHome(prepared.runtimeCodexHomeForCleanup, prepared.projectLocalCodexHomeForCleanup).catch((err) => {
       process.stderr.write(`[omx auth] cleanup warning: ${redactAuthSecrets(err)}\n`);
     });

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -2965,6 +2965,123 @@ describe("project launch scope helpers", () => {
   });
 });
 
+describe("pointer launch aborts", () => {
+  it("does not launch, tag, or retain a runtime home when a pointer lock is held", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-pointer-lock-launch-"));
+    try {
+      const binDir = join(wd, "bin");
+      const codexLog = join(wd, "codex.log");
+      const tmuxLog = join(wd, "tmux.log");
+      const lockPath = join(wd, ".omx", "state", "session.json.lock");
+      const ownerPath = join(lockPath, "owner.json");
+      const ownerContents = "{malformed-held-lock\n";
+      await mkdir(binDir, { recursive: true });
+      await mkdir(lockPath, { recursive: true });
+      await writeFile(join(wd, ".omx", "setup-scope.json"), JSON.stringify({ scope: "project" }));
+      await writeFile(ownerPath, ownerContents);
+      await writeFile(
+        join(binDir, "codex"),
+        `#!/bin/sh\nprintf 'spawned\\n' >> ${JSON.stringify(codexLog)}\n`,
+      );
+      await writeFile(
+        join(binDir, "tmux"),
+        `#!/bin/sh\ncase "$1" in set-option|display-message) printf '%s\\n' "$*" >> ${JSON.stringify(tmuxLog)} ;; esac\n`,
+      );
+      await chmod(join(binDir, "codex"), 0o755);
+      await chmod(join(binDir, "tmux"), 0o755);
+
+      const { spawnSync } = await import("node:child_process");
+      const result = spawnSync(process.execPath, [join(repoRoot, "dist", "cli", "omx.js"), "launch", "--direct"], {
+        cwd: wd,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: join(wd, "home"),
+          PATH: `${binDir}${delimiter}/usr/bin:/bin`,
+          CODEX_HOME: "",
+          OMX_ROOT: "",
+          OMX_STATE_ROOT: "",
+          OMX_TEAM_STATE_ROOT: "",
+          OMX_SESSION_ID: "",
+          OMX_MCP_WORKDIR_ROOTS: "",
+          OMX_AUTO_UPDATE: "0",
+          OMX_HOOK_DERIVED_SIGNALS: "0",
+          OMX_NOTIFY_FALLBACK: "0",
+          TMUX: "test-socket,1,1",
+          TMUX_PANE: "%1",
+        },
+      });
+
+      assert.equal(result.status, 1, result.stderr || result.stdout);
+      assert.match(result.stderr, /session_pointer_lock_recovery_required/);
+      assert.equal(existsSync(codexLog), false);
+      assert.equal(existsSync(tmuxLog), false);
+      assert.equal(await readFile(ownerPath, "utf-8"), ownerContents);
+      assert.equal(existsSync(join(wd, ".omx", "state", "sessions")), false);
+      const runtimeRoot = join(wd, ".omx", "runtime", "codex-home");
+      assert.deepEqual(existsSync(runtimeRoot) ? await fsReaddir(runtimeRoot) : [], []);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not exec, tag, or retain a runtime home when pointer context root resolution is rejected", async () => {
+    const allowedRoot = await mkdtemp(join(tmpdir(), "omx-pointer-allowed-root-"));
+    const wd = await mkdtemp(join(tmpdir(), "omx-pointer-root-exec-"));
+    try {
+      const binDir = join(wd, "bin");
+      const codexLog = join(wd, "codex.log");
+      const tmuxLog = join(wd, "tmux.log");
+      await mkdir(binDir, { recursive: true });
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(join(wd, ".omx", "setup-scope.json"), JSON.stringify({ scope: "project" }));
+      await writeFile(
+        join(binDir, "codex"),
+        `#!/bin/sh\nprintf 'spawned\\n' >> ${JSON.stringify(codexLog)}\n`,
+      );
+      await writeFile(
+        join(binDir, "tmux"),
+        `#!/bin/sh\ncase "$1" in set-option|display-message) printf '%s\\n' "$*" >> ${JSON.stringify(tmuxLog)} ;; esac\n`,
+      );
+      await chmod(join(binDir, "codex"), 0o755);
+      await chmod(join(binDir, "tmux"), 0o755);
+
+      const { spawnSync } = await import("node:child_process");
+      const result = spawnSync(process.execPath, [join(repoRoot, "dist", "cli", "omx.js"), "exec", "echo", "blocked"], {
+        cwd: wd,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: join(wd, "home"),
+          PATH: `${binDir}${delimiter}/usr/bin:/bin`,
+          CODEX_HOME: "",
+          OMX_ROOT: "",
+          OMX_STATE_ROOT: "",
+          OMX_TEAM_STATE_ROOT: "",
+          OMX_SESSION_ID: "",
+          OMX_AUTO_UPDATE: "0",
+          OMX_HOOK_DERIVED_SIGNALS: "0",
+          OMX_NOTIFY_FALLBACK: "0",
+          OMX_MCP_WORKDIR_ROOTS: allowedRoot,
+          TMUX: "test-socket,1,1",
+          TMUX_PANE: "%1",
+        },
+      });
+
+      assert.equal(result.status, 1, result.stderr || result.stdout);
+      assert.match(result.stderr, /session_pointer_context_failure/);
+      assert.equal(existsSync(codexLog), false);
+      assert.equal(existsSync(tmuxLog), false);
+      assert.equal(existsSync(join(wd, ".omx", "state", "sessions")), false);
+      const runtimeRoot = join(wd, ".omx", "runtime", "codex-home");
+      assert.deepEqual(existsSync(runtimeRoot) ? await fsReaddir(runtimeRoot) : [], []);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(allowedRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("resolveCodexLaunchPolicy", () => {
   it("uses detached tmux on macOS when outside tmux and tmux is available", () => {
     assert.equal(

--- a/src/cli/__tests__/mcp-parity.test.ts
+++ b/src/cli/__tests__/mcp-parity.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { mcpParityCommand } from "../mcp-parity.js";
+import { writeSessionStart } from "../../hooks/session.js";
 
 const originalLog = console.log;
 
@@ -19,6 +20,30 @@ function captureLogs(): string[] {
     logs.push(args.map((arg) => String(arg)).join(" "));
   };
   return logs;
+}
+
+async function writeOwnerEvidenceTmux(cwd: string, ownerSessionId: string, canonicalSessionId: string): Promise<string> {
+  const fakeBinDir = join(cwd, "fake-bin");
+  const tmuxPath = join(fakeBinDir, "tmux");
+  await mkdir(fakeBinDir, { recursive: true });
+  await writeFile(
+    tmuxPath,
+    `#!/usr/bin/env bash
+set -eu
+case "\${1:-}" in
+display-message) printf '%s\n' "omx-owner-evidence" ;;
+show-option|show-options)
+case "\${@: -1}" in
+@omx_pane_instance_id) printf '%s\n' "${ownerSessionId}" ;;
+@omx_instance_id) printf '%s\n' "${canonicalSessionId}" ;;
+esac
+;;
+esac
+`,
+    "utf-8",
+  );
+  await chmod(tmuxPath, 0o755);
+  return fakeBinDir;
 }
 
 describe("mcpParityCommand", () => {
@@ -100,21 +125,65 @@ describe("mcpParityCommand", () => {
     }
   });
 
-  it("writes owner OMX session env state to the canonical native session", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-mcp-parity-owner-session-"));
+  it("rejects unmatched implicit owner environment state writes", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-mcp-parity-unmatched-owner-"));
     const logs = captureLogs();
     const previousSessionId = process.env.OMX_SESSION_ID;
 
     try {
       const stateDir = join(cwd, ".omx", "state");
-      await mkdir(join(stateDir, "sessions", "native-id"), { recursive: true });
-      await writeFile(join(stateDir, "session.json"), JSON.stringify({
-        session_id: "native-id",
-        native_session_id: "native-id",
-        owner_omx_session_id: "omx-owner-id",
-        cwd,
-      }));
-      process.env.OMX_SESSION_ID = "omx-owner-id";
+      await writeSessionStart(cwd, "native-unmatched-id", { nativeSessionId: "native-unmatched-id" });
+      process.env.OMX_SESSION_ID = "omx-unmatched-id";
+
+      await mcpParityCommand("state", [
+        "write",
+        "--input",
+        JSON.stringify({
+          mode: "ralplan",
+          active: true,
+          current_phase: "planning",
+          workingDirectory: cwd,
+        }),
+        "--json",
+      ]);
+
+      assert.match(
+        logs.pop() ?? "",
+        /Cannot resolve writable state scope: OMX_SESSION_ID is not bound to session\.json\./,
+      );
+      assert.equal(existsSync(join(stateDir, "sessions", "native-unmatched-id", "ralplan-state.json")), false);
+      assert.equal(existsSync(join(stateDir, "sessions", "omx-unmatched-id", "ralplan-state.json")), false);
+    } finally {
+      if (typeof previousSessionId === "string") process.env.OMX_SESSION_ID = previousSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("converges owner-present env state writes on the canonical native session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-mcp-parity-owner-session-"));
+    const logs = captureLogs();
+    const previousSessionId = process.env.OMX_SESSION_ID;
+    const previousTmux = process.env.TMUX;
+    const previousTmuxPane = process.env.TMUX_PANE;
+    const previousPath = process.env.PATH;
+
+    try {
+      const canonicalSessionId = "native-id";
+      const ownerSessionId = "omx-owner-id";
+      process.env.OMX_SESSION_ID = ownerSessionId;
+      const stateDir = join(cwd, ".omx", "state");
+      await writeSessionStart(cwd, canonicalSessionId, {
+        nativeSessionId: canonicalSessionId,
+        ownerOmxSessionId: ownerSessionId,
+        ownerAliasVerified: true,
+        tmuxSessionName: "omx-owner-evidence",
+        tmuxPaneId: "%owner",
+      });
+      const fakeBinDir = await writeOwnerEvidenceTmux(cwd, ownerSessionId, canonicalSessionId);
+      process.env.TMUX = "/tmp/omx-owner";
+      process.env.TMUX_PANE = "%owner";
+      process.env.PATH = `${fakeBinDir}:${previousPath ?? ""}`;
 
       await mcpParityCommand("state", [
         "write",
@@ -131,12 +200,18 @@ describe("mcpParityCommand", () => {
       const writeResult = JSON.parse(logs.pop() || "{}") as { path?: string };
       assert.equal(
         writeResult.path,
-        join(stateDir, "sessions", "native-id", "ralplan-state.json"),
+        join(stateDir, "sessions", canonicalSessionId, "ralplan-state.json"),
       );
-      assert.equal(existsSync(join(stateDir, "sessions", "omx-owner-id", "ralplan-state.json")), false);
+      assert.equal(existsSync(join(stateDir, "sessions", ownerSessionId, "ralplan-state.json")), false);
     } finally {
       if (typeof previousSessionId === "string") process.env.OMX_SESSION_ID = previousSessionId;
       else delete process.env.OMX_SESSION_ID;
+      if (typeof previousTmux === "string") process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousTmuxPane === "string") process.env.TMUX_PANE = previousTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof previousPath === "string") process.env.PATH = previousPath;
+      else delete process.env.PATH;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -57,6 +57,44 @@ describe('CLI session-scoped state parity', () => {
     }
   });
 
+  it('does not mutate an unmatched implicit OMX session, including force cleanup', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-cancel-unmatched-session-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'canonical-session';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      const ralphPath = join(sessionDir, 'ralph-state.json');
+      const nativeStopPath = join(sessionDir, 'native-stop-state.json');
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(ralphPath, JSON.stringify({ active: true, current_phase: 'executing' }));
+      await writeFile(nativeStopPath, JSON.stringify({
+        sessions: { [sessionId]: { last_signature: 'ralph-stop|pending' } },
+      }));
+
+      const cancelResult = runOmxWithEnv(
+        wd,
+        { OMX_SESSION_ID: 'unmatched-session' },
+        'cancel',
+        '--force',
+      );
+
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stderr, /OMX_SESSION_ID is not bound to session\.json/);
+      assert.match(cancelResult.stdout, /No active modes to cancel\./);
+      assert.deepEqual(
+        JSON.parse(await readFile(ralphPath, 'utf-8')),
+        { active: true, current_phase: 'executing' },
+      );
+      assert.deepEqual(
+        JSON.parse(await readFile(nativeStopPath, 'utf-8')),
+        { sessions: { [sessionId]: { last_signature: 'ralph-stop|pending' } } },
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('status does not report a root fallback mode as active after current-session clear', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-session-clear-fallback-'));
     try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -69,6 +69,7 @@ import {
   getBaseStateDir,
   getStateDir,
   listModeStateFilesWithScopePreference,
+  resolveWritableStateScope,
   type ModeStateFileRef,
 } from "../mcp/state-paths.js";
 import { evaluateRalphCompletionAuditEvidence, isRalphCompletePhase } from "../ralph/completion-audit.js";
@@ -123,11 +124,14 @@ import {
   writeSessionModelInstructionsFile,
 } from "../hooks/agents-overlay.js";
 import {
+  isSessionPointerLaunchAbort,
+  normalizeSessionId,
   readSessionState,
   writeSessionStart,
   writeSessionEnd,
   resetSessionMetrics,
 } from "../hooks/session.js";
+import { probeActualTmuxInstanceEvidence, tmuxEvidenceBindsCandidate } from "../scripts/notify-hook/managed-tmux.js";
 import {
   buildClientAttachedReconcileHookName,
   buildReconcileHudResizeArgs,
@@ -3271,7 +3275,19 @@ export async function launchWithHud(args: string[]): Promise<void> {
   try {
     await preLaunch(cwd, sessionId, notifyTempResult.contract, codexHomeOverride, enableNotifyFallbackAuthority, worktreeDirty);
   } catch (err) {
-    // preLaunch errors must NOT prevent Codex from starting
+    if (isSessionPointerLaunchAbort(err)) {
+      console.error(`[omx] session pointer launch aborted: ${err.code}`);
+      await cleanupRuntimeCodexHome(
+        preparedCodexHome.runtimeCodexHomeForCleanup,
+        projectLocalCodexHomeForCleanup,
+      ).catch((cleanupErr) => {
+        console.error(
+          `[omx] preLaunch abort cleanup warning: ${cleanupErr instanceof Error ? cleanupErr.message : cleanupErr}`,
+        );
+      });
+      throw err;
+    }
+    // preLaunch errors after pointer commit must not prevent Codex from starting.
     console.error(
       `[omx] preLaunch warning: ${err instanceof Error ? err.message : err}`,
     );
@@ -3386,6 +3402,18 @@ export async function execWithOverlay(args: string[]): Promise<void> {
   try {
     await preLaunch(cwd, sessionId, notifyTempResult.contract, codexHomeOverride, true, worktreeDirty);
   } catch (err) {
+    if (isSessionPointerLaunchAbort(err)) {
+      console.error(`[omx] session pointer launch aborted: ${err.code}`);
+      await cleanupRuntimeCodexHome(
+        preparedCodexHome.runtimeCodexHomeForCleanup,
+        projectLocalCodexHomeForCleanup,
+      ).catch((cleanupErr) => {
+        console.error(
+          `[omx] preLaunch abort cleanup warning: ${cleanupErr instanceof Error ? cleanupErr.message : cleanupErr}`,
+        );
+      });
+      throw err;
+    }
     console.error(
       `[omx] preLaunch warning: ${err instanceof Error ? err.message : err}`,
     );
@@ -3588,6 +3616,24 @@ export function resolveNativeSessionName(
     }
   }
   return buildTmuxSessionName(cwd, sessionId);
+}
+
+async function resolvePreLaunchSessionPointerOptions(): Promise<{
+  ownerAliasVerified?: true;
+  tmuxSessionName?: string;
+  tmuxPaneId?: string;
+}> {
+  const ownerCandidate = normalizeSessionId(process.env.OMX_SESSION_ID);
+  if (!ownerCandidate) return {};
+
+  const evidence = await probeActualTmuxInstanceEvidence(process.env.TMUX_PANE);
+  if (!tmuxEvidenceBindsCandidate(evidence, ownerCandidate)) return {};
+
+  return {
+    ownerAliasVerified: true,
+    ...(evidence.sessionName ? { tmuxSessionName: evidence.sessionName } : {}),
+    ...(evidence.paneTarget ? { tmuxPaneId: evidence.paneTarget } : {}),
+  };
 }
 
 function tagTmuxSessionWithInstance(sessionName: string, sessionId: string): void {
@@ -5003,8 +5049,8 @@ export async function reapPostLaunchOrphanedMcpProcesses(
 /**
  * preLaunch: Prepare environment before Codex starts.
  * 1. Best-effort launch-safe orphan cleanup for detached OMX MCP processes
- * 2. Generate runtime overlay + write session-scoped model instructions file
- * 3. Write session.json
+ * 2. Establish the canonical session pointer
+ * 3. Generate session-scoped launch artifacts and start best-effort helpers
  *
  * Automatic broad stale-session cleanup remains disabled here. Only detached
  * OMX MCP processes without a live Codex ancestor are reaped so new launches
@@ -5036,7 +5082,10 @@ export async function preLaunch(
     // Non-fatal
   }
 
-  // 2. Generate runtime overlay + write session-scoped model instructions file
+  // 2. Establish the canonical pointer before any session-scoped launch artifact.
+  await writeSessionStart(cwd, sessionId, await resolvePreLaunchSessionPointerOptions());
+
+  // 3. Generate runtime overlay + write session-scoped model instructions file
   const orchestrationMode = await resolveSessionOrchestrationMode(
     cwd,
     sessionId,
@@ -5054,12 +5103,11 @@ ${launchAppendix}${dirtyWorktreeGuidance}`
       : `${overlay}${dirtyWorktreeGuidance}`;
   await writeSessionModelInstructionsFile(cwd, sessionId, sessionInstructions);
 
-  // 3. Write session state
+  // 4. Reset session metrics and tag the established session.
   await resetSessionMetrics(cwd, sessionId);
-  await writeSessionStart(cwd, sessionId);
   tagCurrentTmuxSessionWithInstance(sessionId);
 
-  // 4. Start notify fallback watcher (best effort)
+  // 5. Start notify fallback watcher (best effort)
   try {
     await startNotifyFallbackWatcher(cwd, { codexHomeOverride, enableAuthority: enableNotifyFallbackAuthority, sessionId });
   } catch (err) {
@@ -5067,7 +5115,7 @@ ${launchAppendix}${dirtyWorktreeGuidance}`
     // Non-fatal
   }
 
-  // 5. Start derived watcher (best effort, opt-in)
+  // 6. Start derived watcher (best effort, opt-in)
   try {
     await startHookDerivedWatcher(cwd);
   } catch (err) {
@@ -5075,7 +5123,7 @@ ${launchAppendix}${dirtyWorktreeGuidance}`
     // Non-fatal
   }
 
-  // 6. Emit temp notification startup summary + warnings, then send session-start lifecycle notification (best effort)
+  // 7. Emit temp notification startup summary + warnings, then send session-start lifecycle notification (best effort)
   try {
     if (notifyTempContract?.active) {
       process.env[OMX_NOTIFY_TEMP_CONTRACT_ENV] =
@@ -5107,7 +5155,7 @@ ${launchAppendix}${dirtyWorktreeGuidance}`
     // Non-fatal: notification failures must never block launch
   }
 
-  // 7. Dispatch native hook event (best effort)
+  // 8. Dispatch native hook event (best effort)
   try {
     await emitNativeHookEvent(cwd, "session-start", {
       session_id: sessionId,
@@ -6629,6 +6677,7 @@ async function cancelModes(args: string[] = []): Promise<void> {
   const nowIso = new Date().toISOString();
   const force = args.includes("--force");
   try {
+    const writableScope = await resolveWritableStateScope(cwd);
     const loadStates = async (refs: ModeStateFileRef[]) => {
       const loaded = new Map<
       string,
@@ -6667,8 +6716,7 @@ async function cancelModes(args: string[] = []): Promise<void> {
       if (hasActiveWorkflowMode(runDirStates)) states = runDirStates;
     }
 
-    const currentSession = await readSessionState(cwd).catch(() => null);
-    const currentSessionId = typeof currentSession?.session_id === "string" ? currentSession.session_id.trim() : "";
+    const currentSessionId = writableScope.sessionId ?? "";
     const changed = new Set<string>();
     const reported = new Set<string>();
 

--- a/src/hooks/__tests__/notify-hook-managed-tmux.test.ts
+++ b/src/hooks/__tests__/notify-hook-managed-tmux.test.ts
@@ -6,6 +6,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { buildTmuxSessionName } from '../../cli/index.js';
 import {
+  probeActualTmuxInstanceEvidence,
+  tmuxEvidenceBindsCandidate,
   resolveManagedPaneFromAnchor,
   resolveManagedSessionContext,
   resolveManagedSessionPane,
@@ -68,6 +70,150 @@ describe('notify-hook managed tmux windows fallback', () => {
     else delete process.env.TMUX_PANE;
     if (originalTeamWorker !== undefined) process.env.OMX_TEAM_WORKER = originalTeamWorker;
     else delete process.env.OMX_TEAM_WORKER;
+  });
+
+  it('uses the actual pane instance tag without reading a conflicting session tag', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-managed-tmux-evidence-pane-'));
+    try {
+      await withFakeTmux(cwd, `#!/usr/bin/env bash
+set -eu
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  echo "shared-session"
+  exit 0
+fi
+if [[ "$cmd" == "show-option" ]]; then
+  pane_scope=0
+  target=""
+  option=""
+  while (($#)); do
+    case "$1" in
+      -qv) shift ;;
+      -p) pane_scope=1; shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) option="$1"; shift ;;
+    esac
+  done
+  if [[ "$pane_scope" == "1" && "$target" == "%42" && "$option" == "@omx_pane_instance_id" ]]; then
+    echo "omx-pane-owner"
+    exit 0
+  fi
+  echo "session fallback must not be read when the pane is tagged" >&2
+  exit 1
+fi
+exit 1
+`, async () => {
+        process.env.TMUX = '1';
+        process.env.TMUX_PANE = '%42';
+
+        const evidence = await probeActualTmuxInstanceEvidence();
+        assert.equal(evidence.source, 'pane');
+        assert.equal(evidence.instanceId, 'omx-pane-owner');
+        assert.equal(evidence.paneInstanceId, 'omx-pane-owner');
+        assert.equal(evidence.sessionInstanceId, '');
+        assert.equal(evidence.sessionName, 'shared-session');
+        assert.equal(evidence.paneTagStatus, 'present');
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to the actual pane session tag only when the pane tag is absent', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-managed-tmux-evidence-session-'));
+    try {
+      await withFakeTmux(cwd, `#!/usr/bin/env bash
+set -eu
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  echo "shared-session"
+  exit 0
+fi
+if [[ "$cmd" == "show-option" ]]; then
+  pane_scope=0
+  target=""
+  option=""
+  while (($#)); do
+    case "$1" in
+      -qv) shift ;;
+      -p) pane_scope=1; shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) option="$1"; shift ;;
+    esac
+  done
+  if [[ "$pane_scope" == "1" && "$target" == "%42" && "$option" == "@omx_pane_instance_id" ]]; then
+    exit 0
+  fi
+  if [[ "$pane_scope" == "0" && "$target" == "shared-session" && "$option" == "@omx_instance_id" ]]; then
+    echo "omx-session-owner"
+    exit 0
+  fi
+fi
+exit 1
+`, async () => {
+        process.env.TMUX = '1';
+        process.env.TMUX_PANE = '%42';
+
+        const evidence = await probeActualTmuxInstanceEvidence();
+        assert.equal(evidence.source, 'session');
+        assert.equal(evidence.instanceId, 'omx-session-owner');
+        assert.equal(evidence.paneInstanceId, '');
+        assert.equal(evidence.sessionInstanceId, 'omx-session-owner');
+        assert.equal(evidence.sessionName, 'shared-session');
+        assert.equal(evidence.paneTagStatus, 'absent');
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects session-tag fallback when the pane-tag lookup errors', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-managed-tmux-evidence-error-'));
+    try {
+      await withFakeTmux(cwd, `#!/usr/bin/env bash
+set -eu
+cmd="$1"
+shift || true
+if [[ "$cmd" == "display-message" ]]; then
+  echo "shared-session"
+  exit 0
+fi
+if [[ "$cmd" == "show-option" ]]; then
+  pane_scope=0
+  target=""
+  option=""
+  while (($#)); do
+    case "$1" in
+      -qv) shift ;;
+      -p) pane_scope=1; shift ;;
+      -t) target="$2"; shift 2 ;;
+      *) option="$1"; shift ;;
+    esac
+  done
+  if [[ "$pane_scope" == "1" && "$target" == "%42" && "$option" == "@omx_pane_instance_id" ]]; then
+    exit 1
+  fi
+  if [[ "$pane_scope" == "0" && "$target" == "shared-session" && "$option" == "@omx_instance_id" ]]; then
+    echo "omx-session-owner"
+    exit 0
+  fi
+fi
+exit 1
+`, async () => {
+        process.env.TMUX = '1';
+        process.env.TMUX_PANE = '%42';
+
+        const evidence = await probeActualTmuxInstanceEvidence();
+        assert.equal(evidence.source, 'none');
+        assert.equal(evidence.paneTagStatus, 'error');
+        assert.equal(evidence.instanceId, '');
+        assert.equal(tmuxEvidenceBindsCandidate(evidence, 'omx-session-owner'), false);
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it('does not rely on ps ancestry checks on native Windows', async () => {

--- a/src/hooks/__tests__/notify-hook-session-scope.test.ts
+++ b/src/hooks/__tests__/notify-hook-session-scope.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { dirname, join } from 'path';
 import { tmpdir } from 'os';
@@ -327,6 +327,73 @@ describe('notify-hook session-scoped iteration updates', () => {
         (progress.visual_feedback?.[0]?.qualitative_feedback?.next_actions?.length || 0) <= VISUAL_NEXT_ACTIONS_LIMIT,
         true,
       );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('suppresses managed unmatched owner sidefiles without creating either an owner or canonical receipt scope', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-notify-managed-unmatched-'));
+    const home = join(wd, 'home');
+    const fakeBinDir = join(wd, 'bin');
+    const canonicalSessionId = 'omx-canonical';
+    const ownerSessionId = 'omx-unmatched-owner';
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const canonicalDir = join(stateDir, 'sessions', canonicalSessionId);
+      await mkdir(canonicalDir, { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(wd, '.omx', 'managed'), 'test fixture managed workspace');
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: canonicalSessionId,
+        cwd: wd,
+      }, null, 2));
+      await writeFile(join(canonicalDir, 'hud-state.json'), JSON.stringify({ turn_count: 7 }, null, 2));
+      const fakeTmux = join(fakeBinDir, 'tmux');
+      await writeFile(fakeTmux, `#!/usr/bin/env bash
+set -eu
+case "$*" in
+  *"display-message -p -t %owner-pane #S") printf 'managed-session\\n' ;;
+  *"show-option -qv -p -t %owner-pane @omx_pane_instance_id") printf '${ownerSessionId}\\n' ;;
+  *) exit 0 ;;
+esac
+`);
+      await chmod(fakeTmux, 0o755);
+
+      const result = spawnSync(process.execPath, ['dist/scripts/notify-hook.js', JSON.stringify({
+        cwd: wd,
+        session_id: canonicalSessionId,
+        type: 'agent-turn-complete',
+        thread_id: 'th-managed-unmatched',
+        turn_id: 'tu-managed-unmatched',
+        input_messages: [],
+        last_assistant_message: 'Waiting for user input.',
+      })], {
+        cwd: join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..'),
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          HOME: home,
+          CODEX_HOME: join(home, '.codex'),
+          OMX_SESSION_ID: ownerSessionId,
+          OMX_TEAM_WORKER: '',
+          TMUX: '/tmp/tmux-1000/default,1,0',
+          TMUX_PANE: '%owner-pane',
+          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+        },
+      });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+
+      assert.deepEqual(
+        JSON.parse(await readFile(join(canonicalDir, 'hud-state.json'), 'utf-8')),
+        { turn_count: 7 },
+      );
+      assert.equal(existsSync(join(canonicalDir, 'notify-hook-state.json')), false);
+      assert.equal(existsSync(join(canonicalDir, 'idle-notif-cooldown.json')), false);
+      assert.equal(existsSync(join(canonicalDir, 'session-idle-hook-state.json')), false);
+      assert.equal(existsSync(join(canonicalDir, 'lifecycle-notif-state.json')), false);
+      assert.equal(existsSync(join(stateDir, 'sessions', ownerSessionId)), false);
+      assert.equal(existsSync(join(home, '.omx', 'state', 'reply-session-registry.jsonl')), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -1,17 +1,23 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, rename, rm, symlink, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  resetSessionMetrics,
-  reconcileNativeSessionStart,
-  writeSessionStart,
-  writeSessionEnd,
+  __createDefaultPidProbeForTests,
+  __resetSessionPointerTransactionDependenciesForTests,
+  __setSessionPointerTransactionDependenciesForTests,
+  isSessionPointerLaunchAbort,
+  isSessionStale,
+  readSessionPointer,
   readSessionState,
   readUsableSessionState,
-  isSessionStale,
+  reconcileNativeSessionStart,
+  resetSessionMetrics,
+  resolveSessionPointerContext,
+  writeSessionEnd,
+  writeSessionStart,
   type SessionState,
 } from '../session.js';
 
@@ -34,6 +40,61 @@ function makeState(overrides: Partial<SessionState> = {}): SessionState {
     started_at: '2026-02-26T00:00:00.000Z',
     cwd: '/tmp/project',
     pid: 12345,
+    ...overrides,
+  };
+}
+
+const TEST_TOKEN = 'transaction_token_123456';
+const FOREIGN_TOKEN = 'foreign_token_123456789';
+const SUCCESSOR_TOKEN = 'successor_token_123456789';
+
+function codedError(code: string): Error & { code: string } {
+  return Object.assign(new Error(code), { code });
+}
+
+async function withPointerDependencies(
+  overrides: Parameters<typeof __setSessionPointerTransactionDependenciesForTests>[0],
+  run: () => Promise<void>,
+): Promise<void> {
+  __setSessionPointerTransactionDependenciesForTests(overrides);
+  try {
+    await run();
+  } finally {
+    __resetSessionPointerTransactionDependenciesForTests();
+  }
+}
+
+async function withOwnerEnvironment(sessionId: string | undefined, run: () => Promise<void>): Promise<void> {
+  const previous = process.env.OMX_SESSION_ID;
+  if (sessionId === undefined) delete process.env.OMX_SESSION_ID;
+  else process.env.OMX_SESSION_ID = sessionId;
+  try {
+    await run();
+  } finally {
+    if (previous === undefined) delete process.env.OMX_SESSION_ID;
+    else process.env.OMX_SESSION_ID = previous;
+  }
+}
+
+function matchingProcessIdentity() {
+  return { status: 'matching' as const, startTicks: 1 };
+}
+
+async function writeLockOwner(cwd: string, owner: Record<string, unknown>): Promise<string> {
+  const context = resolveSessionPointerContext(cwd);
+  await mkdir(context.lockPath, { recursive: true });
+  await writeFile(join(context.lockPath, 'owner.json'), JSON.stringify(owner), 'utf-8');
+  return context.lockPath;
+}
+
+function validLockOwner(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    version: 1,
+    token: TEST_TOKEN,
+    pid: process.pid,
+    platform: 'linux',
+    pid_start_ticks: 1,
+    created_at: '2026-07-14T00:00:00.000Z',
     ...overrides,
   };
 }
@@ -311,7 +372,7 @@ describe('session lifecycle manager', () => {
         nativeSessionId: 'codex-native-old',
       });
       await reconcileNativeSessionStart(cwd, 'codex-native-new', {
-        pid: 54321,
+        pid: process.pid,
         platform: 'win32',
       });
 
@@ -434,24 +495,30 @@ describe('session lifecycle manager', () => {
     }
   });
 
-  it('falls back to a fresh canonical session when reconciling without authoritative launch state', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-fallback-'));
+  it('preserves foreign selected-pointer evidence instead of replacing it during native reconciliation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-foreign-'));
     try {
       const statePath = join(cwd, '.omx', 'state', 'session.json');
       await resetSessionMetrics(cwd);
       await writeFile(statePath, JSON.stringify({
         session_id: 'sess-other-worktree',
         cwd: join(cwd, '..', 'different-worktree'),
+        pid: process.pid,
+        platform: 'win32',
       }), 'utf-8');
 
-      const reconciled = await reconcileNativeSessionStart(cwd, 'codex-fallback-1', {
-        pid: 67890,
+      await assert.rejects(
+        reconcileNativeSessionStart(cwd, 'codex-fallback-1', { platform: 'win32' }),
+        (error: unknown) => isSessionPointerLaunchAbort(error)
+          && error.code === 'session_pointer_unusable'
+          && error.pointerStatus === 'foreign-cwd',
+      );
+      assert.equal(await readFile(statePath, 'utf-8'), JSON.stringify({
+        session_id: 'sess-other-worktree',
+        cwd: join(cwd, '..', 'different-worktree'),
+        pid: process.pid,
         platform: 'win32',
-      });
-
-      assert.equal(reconciled.session_id, 'codex-fallback-1');
-      assert.equal(reconciled.native_session_id, 'codex-fallback-1');
-      assert.equal(reconciled.pid, 67890);
+      }));
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -599,5 +666,480 @@ describe('isSessionStale', () => {
     });
 
     assert.equal(stale, false);
+  });
+});
+
+describe('session pointer transaction', () => {
+  it('makes root resolution failures pathless typed launch aborts', async () => {
+    await assert.rejects(
+      writeSessionStart('bad\0cwd', 'sess-context'),
+      (error: unknown) => isSessionPointerLaunchAbort(error)
+        && error.code === 'session_pointer_context_failure'
+        && error.operation === 'pointer-context-resolve'
+        && !('pointerPath' in error),
+    );
+  });
+
+  it('classifies only the exact selected pointer as absent, usable, stale, indeterminate, malformed, or foreign', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-status-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      await withPointerDependencies({
+        probePid: () => 'alive',
+        readProcessIdentity: () => matchingProcessIdentity(),
+      }, async () => {
+        assert.equal((await readSessionPointer(context)).status, 'absent');
+        await mkdir(context.baseStateDir, { recursive: true });
+        await writeFile(context.sessionPath, JSON.stringify({
+          session_id: 'sess-usable',
+          started_at: '2026-07-14T00:00:00.000Z',
+          cwd,
+          pid: process.pid,
+          platform: 'linux',
+          pid_start_ticks: 1,
+        }), 'utf-8');
+        assert.equal((await readSessionPointer(context)).status, 'usable');
+
+        __setSessionPointerTransactionDependenciesForTests({
+          probePid: () => 'dead',
+          readProcessIdentity: () => matchingProcessIdentity(),
+        });
+        assert.equal((await readSessionPointer(context)).status, 'stale-dead');
+
+        __setSessionPointerTransactionDependenciesForTests({
+          probePid: () => 'indeterminate',
+          readProcessIdentity: () => matchingProcessIdentity(),
+        });
+        assert.equal((await readSessionPointer(context)).status, 'identity-indeterminate');
+
+        await writeFile(context.sessionPath, '{ not-json', 'utf-8');
+        assert.equal((await readSessionPointer(context)).status, 'malformed');
+        await writeFile(context.sessionPath, JSON.stringify({
+          session_id: 'sess-foreign',
+          started_at: '2026-07-14T00:00:00.000Z',
+          cwd: join(cwd, '..', 'foreign-worktree'),
+          pid: process.pid,
+          platform: 'win32',
+        }), 'utf-8');
+        assert.equal((await readSessionPointer(context)).status, 'foreign-cwd');
+      });
+    } finally {
+      __resetSessionPointerTransactionDependenciesForTests();
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('maps only ESRCH to a definitely dead default PID probe', () => {
+    const alive = __createDefaultPidProbeForTests(() => {});
+    const esrch = __createDefaultPidProbeForTests(() => { throw codedError('ESRCH'); });
+    const eperm = __createDefaultPidProbeForTests(() => { throw codedError('EPERM'); });
+    const unknown = __createDefaultPidProbeForTests(() => { throw codedError('EACCES'); });
+    const noCode = __createDefaultPidProbeForTests(() => { throw new Error('unknown'); });
+    const primitive = __createDefaultPidProbeForTests(() => { throw 'unknown'; });
+    assert.equal(alive(1), 'alive');
+    assert.equal(esrch(1), 'dead');
+    assert.equal(eperm(1), 'indeterminate');
+    assert.equal(unknown(1), 'indeterminate');
+    assert.equal(noCode(1), 'indeterminate');
+    assert.equal(primitive(1), 'indeterminate');
+  });
+
+  it('never reaps dead, reused, indeterminate, missing, or malformed lock evidence', async () => {
+    const cases: Array<{
+      name: string;
+      owner?: Record<string, unknown>;
+      probePid: 'dead' | 'alive' | 'indeterminate';
+      identity?: {
+        status: 'matching' | 'reused' | 'indeterminate';
+        startTicks?: number;
+        cmdlineHash?: string;
+      };
+      expected: string;
+    }> = [
+      { name: 'dead', owner: validLockOwner(), probePid: 'dead', expected: 'dead' },
+      { name: 'reused', owner: validLockOwner(), probePid: 'alive', identity: { status: 'reused', startTicks: 2 }, expected: 'reused' },
+      { name: 'indeterminate-probe', owner: validLockOwner(), probePid: 'indeterminate', expected: 'identity-indeterminate' },
+      { name: 'indeterminate-identity', owner: validLockOwner(), probePid: 'alive', identity: { status: 'indeterminate' }, expected: 'identity-indeterminate' },
+      { name: 'unsubstantiated-reuse', owner: validLockOwner(), probePid: 'alive', identity: { status: 'reused', startTicks: 1 }, expected: 'identity-indeterminate' },
+      { name: 'missing-required-hash', owner: validLockOwner({ pid_cmdline_hash: 'a'.repeat(64) }), probePid: 'alive', identity: matchingProcessIdentity(), expected: 'identity-indeterminate' },
+      { name: 'missing', probePid: 'alive', expected: 'missing' },
+      { name: 'malformed', owner: { version: 1 }, probePid: 'alive', expected: 'malformed' },
+    ];
+
+    for (const testCase of cases) {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-session-lock-${testCase.name}-`));
+      try {
+        const context = resolveSessionPointerContext(cwd);
+        await mkdir(context.lockPath, { recursive: true });
+        if (testCase.owner) {
+          await writeFile(join(context.lockPath, 'owner.json'), JSON.stringify(testCase.owner), 'utf-8');
+        }
+        const before = await readdir(context.lockPath);
+        await withPointerDependencies({
+          token: () => TEST_TOKEN,
+          probePid: () => testCase.probePid,
+          readProcessIdentity: () => testCase.identity ?? matchingProcessIdentity(),
+        }, async () => {
+          await assert.rejects(
+            writeSessionStart(cwd, 'sess-lock', { platform: 'win32' }),
+            (error: unknown) => isSessionPointerLaunchAbort(error)
+              && error.code === 'session_pointer_lock_recovery_required'
+              && error.lockOwnerStatus === testCase.expected,
+          );
+        });
+        assert.deepEqual(await readdir(context.lockPath), before);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('retries a positively matching live owner with the bounded 25/50/100 schedule before timing out', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-timeout-'));
+    try {
+      await writeLockOwner(cwd, validLockOwner());
+      const delays: number[] = [];
+      let now = 0;
+      await withPointerDependencies({
+        nowMs: () => now,
+        sleep: async (ms) => { delays.push(ms); now += ms; },
+        token: () => TEST_TOKEN,
+        probePid: () => 'alive',
+        readProcessIdentity: () => matchingProcessIdentity(),
+      }, async () => {
+        await assert.rejects(
+          writeSessionStart(cwd, 'sess-timeout', { platform: 'win32' }),
+          (error: unknown) => isSessionPointerLaunchAbort(error)
+            && error.code === 'session_pointer_lock_timeout'
+            && error.lockOwnerStatus === 'live',
+        );
+      });
+      assert.deepEqual(delays.slice(0, 3), [25, 50, 100]);
+      assert.equal(delays.at(-1), 25);
+      assert.equal(existsSync(resolveSessionPointerContext(cwd).lockPath), true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rolls back only its unpublished owner artifacts and reports rollback ambiguity', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-owner-publish-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      await withPointerDependencies({
+        token: () => TEST_TOKEN,
+        fs: {
+          writeFile: async (path, data, options) => {
+            if (path.endsWith(`owner.${TEST_TOKEN}.tmp`)) throw new Error('owner write failure');
+            await writeFile(path, data, options);
+          },
+        },
+      }, async () => {
+        await assert.rejects(
+          writeSessionStart(cwd, 'sess-owner-publish', { platform: 'win32' }),
+          (error: unknown) => isSessionPointerLaunchAbort(error)
+            && error.code === 'session_pointer_io_failure'
+            && error.operation === 'lock-owner-publish',
+        );
+      });
+      assert.equal(existsSync(context.lockPath), false);
+
+      await withPointerDependencies({
+        token: () => TEST_TOKEN,
+        fs: {
+          writeFile: async (path, data, options) => {
+            if (path.endsWith(`owner.${TEST_TOKEN}.tmp`)) throw new Error('owner write failure');
+            await writeFile(path, data, options);
+          },
+          rmdir: async (path) => {
+            if (path === context.lockPath) throw new Error('keep lock evidence');
+            await rm(path, { recursive: false });
+          },
+        },
+      }, async () => {
+        await assert.rejects(
+          writeSessionStart(cwd, 'sess-owner-residue', { platform: 'win32' }),
+          (error: unknown) => isSessionPointerLaunchAbort(error)
+            && error.code === 'session_pointer_lock_recovery_required'
+            && error.primaryOperation === 'lock-owner-publish'
+            && error.secondaryFailures?.[0]?.phase === 'remove-unpublished-lock',
+        );
+      });
+      assert.equal(existsSync(context.lockPath), true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('types state-directory, pointer-read, owner-sync, owner-rename, and invalid-token failures before commit', async () => {
+    const failures = [
+      {
+        name: 'state-dir',
+        operation: 'state-dir-create',
+        dependencies: (context: ReturnType<typeof resolveSessionPointerContext>) => ({
+          fs: {
+            mkdir: async (path: string, options?: { recursive?: boolean }) => {
+              if (path === context.baseStateDir) throw new Error('state directory failure');
+              await mkdir(path, options);
+            },
+          },
+        }),
+      },
+      {
+        name: 'pointer-read',
+        operation: 'pointer-read',
+        dependencies: (context: ReturnType<typeof resolveSessionPointerContext>) => ({
+          token: () => TEST_TOKEN,
+          fs: {
+            readFile: async (path: string, encoding: 'utf8') => {
+              if (path === context.sessionPath) throw new Error('pointer read failure');
+              return await readFile(path, encoding);
+            },
+          },
+        }),
+      },
+      {
+        name: 'owner-sync',
+        operation: 'lock-owner-publish',
+        dependencies: (context: ReturnType<typeof resolveSessionPointerContext>) => ({
+          token: () => TEST_TOKEN,
+          fs: {
+            openAndSync: async (path: string) => {
+              if (path === join(context.lockPath, `owner.${TEST_TOKEN}.tmp`)) throw new Error('owner sync failure');
+            },
+          },
+        }),
+      },
+      {
+        name: 'owner-rename',
+        operation: 'lock-owner-publish',
+        dependencies: (context: ReturnType<typeof resolveSessionPointerContext>) => ({
+          token: () => TEST_TOKEN,
+          fs: {
+            rename: async (from: string, to: string) => {
+              if (from === join(context.lockPath, `owner.${TEST_TOKEN}.tmp`)) throw new Error('owner rename failure');
+              await rename(from, to);
+            },
+          },
+        }),
+      },
+    ] as const;
+
+    for (const failure of failures) {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-session-${failure.name}-`));
+      try {
+        const context = resolveSessionPointerContext(cwd);
+        await withPointerDependencies(failure.dependencies(context), async () => {
+          await assert.rejects(
+            writeSessionStart(cwd, 'sess-precommit', { platform: 'win32' }),
+            (error: unknown) => isSessionPointerLaunchAbort(error)
+              && error.code === 'session_pointer_io_failure'
+              && error.operation === failure.operation,
+          );
+        });
+        assert.equal(existsSync(context.lockPath), false);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-invalid-token-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      await withPointerDependencies({ token: () => 'bad' }, async () => {
+        await assert.rejects(
+          writeSessionStart(cwd, 'sess-invalid-token', { platform: 'win32' }),
+          (error: unknown) => isSessionPointerLaunchAbort(error)
+            && error.code === 'session_pointer_io_failure'
+            && error.operation === 'lock-owner-publish',
+        );
+      });
+      assert.equal(existsSync(context.lockPath), false);
+      assert.equal(existsSync(`${context.sessionPath}.tmp-bad`), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('types pointer write, sync, and rename failures and removes only the owned temporary file', async () => {
+    const phases = [
+      { operation: 'pointer-temp-write', fail: 'write' },
+      { operation: 'pointer-fsync', fail: 'sync' },
+      { operation: 'pointer-rename', fail: 'rename' },
+    ] as const;
+    for (const phase of phases) {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-session-${phase.fail}-`));
+      try {
+        const context = resolveSessionPointerContext(cwd);
+        const tempPath = `${context.sessionPath}.tmp-${TEST_TOKEN}`;
+        await withPointerDependencies({
+          token: () => TEST_TOKEN,
+          fs: {
+            writeFile: async (path, data, options) => {
+              await writeFile(path, data, options);
+              if (phase.fail === 'write' && path === tempPath) throw new Error('pointer write failure');
+            },
+            openAndSync: async (path) => {
+              if (phase.fail === 'sync' && path === tempPath) throw new Error('pointer sync failure');
+            },
+            rename: async (from, to) => {
+              if (phase.fail === 'rename' && from === tempPath && to === context.sessionPath) {
+                throw new Error('pointer rename failure');
+              }
+              await rename(from, to);
+            },
+          },
+        }, async () => {
+          await assert.rejects(
+            writeSessionStart(cwd, 'sess-failure', { platform: 'win32' }),
+            (error: unknown) => isSessionPointerLaunchAbort(error)
+              && error.code === 'session_pointer_io_failure'
+              && error.operation === phase.operation,
+          );
+        });
+        assert.equal(existsSync(tempPath), false);
+        assert.equal(existsSync(context.lockPath), false);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('preserves owned pointer residue and ordered cleanup evidence when cleanup or release cannot complete', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-residue-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      const tempPath = `${context.sessionPath}.tmp-${TEST_TOKEN}`;
+      await withPointerDependencies({
+        token: () => TEST_TOKEN,
+        fs: {
+          writeFile: async (path, data, options) => {
+            await writeFile(path, data, options);
+            if (path === tempPath) throw new Error('pointer write failure');
+          },
+          unlink: async (path) => {
+            if (path === tempPath) throw new Error('pointer temp cleanup failure');
+            await rm(path, { force: false });
+          },
+          rmdir: async (path) => {
+            if (path.endsWith(`.release-${TEST_TOKEN}`)) throw new Error('release cleanup failure');
+            await rm(path, { recursive: false });
+          },
+        },
+      }, async () => {
+        await assert.rejects(
+          writeSessionStart(cwd, 'sess-residue', { platform: 'win32' }),
+          (error: unknown) => isSessionPointerLaunchAbort(error)
+            && error.code === 'session_pointer_lock_recovery_required'
+            && error.primaryOperation === 'pointer-temp-write'
+            && error.secondaryFailures?.map((failure) => failure.phase).join(',') === 'remove-pointer-temp,remove-release-dir'
+            && error.secondaryFailures?.[0]?.evidencePath === tempPath,
+        );
+      });
+      assert.equal(existsSync(tempPath), true);
+      assert.equal(existsSync(`${context.lockPath}.release-${TEST_TOKEN}`), true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves foreign pointer temps inert and a successor commits after explicit lock recovery', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-successor-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      const ownTempPath = `${context.sessionPath}.tmp-${TEST_TOKEN}`;
+      const foreignTempPath = `${context.sessionPath}.tmp-${FOREIGN_TOKEN}`;
+      await mkdir(context.baseStateDir, { recursive: true });
+      await writeFile(foreignTempPath, 'foreign transaction evidence', 'utf-8');
+      await withPointerDependencies({
+        token: () => TEST_TOKEN,
+        fs: {
+          writeFile: async (path, data, options) => {
+            await writeFile(path, data, options);
+            if (path === ownTempPath) throw new Error('pointer write failure');
+          },
+          unlink: async (path) => {
+            if (path === ownTempPath) throw new Error('keep own residue');
+            await rm(path, { force: false });
+          },
+          rename: async (from, to) => {
+            if (from === context.lockPath) throw new Error('preserve canonical lock');
+            await rename(from, to);
+          },
+        },
+      }, async () => {
+        await assert.rejects(writeSessionStart(cwd, 'sess-first', { platform: 'win32' }), isSessionPointerLaunchAbort);
+      });
+      assert.equal(existsSync(foreignTempPath), true);
+      assert.equal(existsSync(context.lockPath), true);
+
+      // This is documented stopped-session operator recovery, deliberately not
+      // product transaction behavior.
+      await rm(context.lockPath, { recursive: true, force: true });
+      await withPointerDependencies({ token: () => SUCCESSOR_TOKEN }, async () => {
+        await writeSessionStart(cwd, 'sess-successor', { platform: 'win32' });
+      });
+      assert.equal((await readSessionState(cwd))?.session_id, 'sess-successor');
+      assert.equal(existsSync(ownTempPath), true);
+      assert.equal(existsSync(foreignTempPath), true);
+      assert.equal(existsSync(context.lockPath), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('binds an owner alias only on a verified same-native/absent transition and never during replacement', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-owner-alias-'));
+    try {
+      const nativeOnly = await reconcileNativeSessionStart(cwd, 'native-first', {
+        platform: 'win32',
+        ownerOmxSessionId: 'omx-owner',
+      });
+      assert.equal(nativeOnly.owner_omx_session_id, undefined);
+
+      await withOwnerEnvironment('omx-owner', async () => {
+        const bound = await reconcileNativeSessionStart(cwd, 'native-first', {
+          platform: 'win32',
+          ownerAliasVerified: true,
+        });
+        assert.equal(bound.session_id, 'native-first');
+        assert.equal(bound.owner_omx_session_id, 'omx-owner');
+
+        const replacement = await reconcileNativeSessionStart(cwd, 'native-second', {
+          platform: 'win32',
+          ownerAliasVerified: true,
+        });
+        assert.equal(replacement.session_id, 'native-second');
+        assert.equal(replacement.owner_omx_session_id, 'omx-owner');
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves pointer evidence when history cannot be appended and rejects unusable end states before history or HUD cleanup', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-end-preserve-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      await writeSessionStart(cwd, 'sess-history', { platform: 'win32' });
+      await mkdir(join(cwd, '.omx', 'logs'), { recursive: true });
+      await rm(join(cwd, '.omx', 'logs'), { recursive: true, force: true });
+      await writeFile(join(cwd, '.omx', 'logs'), 'not-a-directory', 'utf-8');
+      await assert.rejects(writeSessionEnd(cwd, 'sess-history'));
+      assert.equal((await readSessionState(cwd))?.session_id, 'sess-history');
+      await rm(join(cwd, '.omx', 'logs'), { force: true });
+
+      await writeFile(context.sessionPath, '{ malformed', 'utf-8');
+      await assert.rejects(
+        writeSessionEnd(cwd, 'sess-history'),
+        (error: unknown) => isSessionPointerLaunchAbort(error)
+          && error.code === 'session_pointer_unusable'
+          && error.pointerStatus === 'malformed',
+      );
+      assert.equal(await readFile(context.sessionPath, 'utf-8'), '{ malformed');
+      assert.equal(existsSync(join(cwd, '.omx', 'logs', 'session-history.jsonl')), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -1,22 +1,35 @@
 /**
- * Session Lifecycle Manager for oh-my-codex
+ * Session lifecycle management.
  *
- * Tracks session start/end, detects stale sessions from crashed launches,
- * and provides structured logging for session events.
+ * The selected state root owns one canonical session pointer. Pointer writes are
+ * serialized by an adjacent lock directory and become visible only after an
+ * atomic rename of a transaction-owned temporary file.
  */
-
-import { readFile, writeFile, mkdir, unlink, appendFile, rm } from 'fs/promises';
+import {
+  appendFile,
+  mkdir as nodeMkdir,
+  open,
+  readFile as nodeReadFile,
+  readdir as nodeReaddir,
+  rename as nodeRename,
+  rmdir as nodeRmdir,
+  rm,
+  unlink as nodeUnlink,
+  writeFile as nodeWriteFile,
+} from 'fs/promises';
+import { readFileSync } from 'fs';
+import { createHash, randomUUID } from 'crypto';
 import { dirname, join } from 'path';
-import { existsSync, readFileSync } from 'fs';
-import { omxRoot, omxStateDir, omxLogsDir, sameFilePath } from '../utils/paths.js';
-import { getStateFilePath } from '../mcp/state-paths.js';
+import { omxRoot, omxLogsDir, sameFilePath } from '../utils/paths.js';
+import {
+  getBaseStateDirWithSource,
+  resolveWorkingDirectoryForState,
+  type StateRootSource,
+} from '../mcp/state-paths.js';
 
 export interface SessionState {
   session_id: string;
   native_session_id?: string;
-  // Native session replacement metadata used when Codex /new swaps the native
-  // session while the original OMX launch wrapper is still responsible for
-  // archiving/cleanup.
   previous_native_session_id?: string;
   native_session_switched_at?: string;
   owner_omx_session_id?: string;
@@ -31,125 +44,219 @@ export interface SessionState {
   tmux_pane_id?: string;
 }
 
+export interface SessionPointerContext {
+  cwd: string;
+  baseStateDir: string;
+  rootSource: StateRootSource;
+  sessionPath: string;
+  lockPath: string;
+}
+
+export type SessionPointerStatus =
+  | 'absent'
+  | 'usable'
+  | 'stale-dead'
+  | 'identity-indeterminate'
+  | 'malformed'
+  | 'foreign-cwd';
+
+export interface SessionPointerReadResult {
+  status: SessionPointerStatus;
+  state?: SessionState;
+  raw?: string;
+}
+
+export type SessionPointerTransactionOperation =
+  | 'pointer-context-resolve'
+  | 'state-dir-create'
+  | 'lock-acquire'
+  | 'lock-owner-publish'
+  | 'pointer-read'
+  | 'pointer-classify'
+  | 'pointer-temp-write'
+  | 'pointer-fsync'
+  | 'pointer-rename'
+  | 'owner-conflict'
+  | 'precommit-cleanup'
+  | 'lock-release';
+
+type AttemptedStateRootSource = StateRootSource | 'unresolved';
+type UnusableSessionPointerStatus = 'malformed' | 'foreign-cwd' | 'identity-indeterminate';
+
+export type SessionPointerCleanupPhase =
+  | 'remove-owner-temp'
+  | 'inspect-unpublished-lock'
+  | 'remove-unpublished-lock'
+  | 'remove-pointer-temp'
+  | 'token-check'
+  | 'rename'
+  | 'remove-release-dir';
+
+export interface SessionPointerSecondaryFailure {
+  operation: 'precommit-cleanup' | 'lock-release';
+  phase: SessionPointerCleanupPhase;
+  ownership: 'held' | 'released' | 'uncertain';
+  message: string;
+  cause?: unknown;
+  evidencePath?: string;
+}
+
+export interface SessionPointerAbortBase extends Error {
+  name: 'SessionPointerLaunchAbort';
+  committed: false;
+  cwd: string;
+  candidateSessionId?: string;
+  canonicalSessionId?: string;
+  reason: string;
+  cause?: unknown;
+}
+
+export interface SessionPointerContextAbort extends SessionPointerAbortBase {
+  code: 'session_pointer_context_failure';
+  operation: 'pointer-context-resolve';
+  attemptedRootSource: AttemptedStateRootSource;
+  pointerPath?: never;
+  lockPath?: never;
+  rootSource?: never;
+}
+
+export interface ResolvedSessionPointerAbort extends SessionPointerAbortBase {
+  code:
+    | 'session_pointer_lock_timeout'
+    | 'session_pointer_lock_recovery_required'
+    | 'session_pointer_unusable'
+    | 'session_pointer_owner_conflict'
+    | 'session_pointer_io_failure';
+  operation: Exclude<SessionPointerTransactionOperation, 'pointer-context-resolve'>;
+  pointerPath: string;
+  lockPath?: string;
+  rootSource: StateRootSource;
+  pointerStatus?: UnusableSessionPointerStatus;
+  lockOwnerStatus?: 'live' | 'dead' | 'reused' | 'identity-indeterminate' | 'missing' | 'malformed';
+  primaryOperation?: Exclude<
+    SessionPointerTransactionOperation,
+    'pointer-context-resolve' | 'precommit-cleanup' | 'lock-release'
+  >;
+  secondaryFailures?: readonly SessionPointerSecondaryFailure[];
+}
+
+export type SessionPointerLaunchAbort =
+  | SessionPointerContextAbort
+  | ResolvedSessionPointerAbort;
+
 const SESSION_FILE = 'session.json';
 const HISTORY_FILE = 'session-history.jsonl';
 const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
-// No age-based threshold: staleness is determined by PID liveness/identity.
-// Long-running sessions (>2h) are legitimate and should not be reaped.
-
-function sessionPath(cwd: string): string {
-  return join(omxStateDir(cwd), SESSION_FILE);
-}
-
-function historyPath(cwd: string): string {
-  return join(omxLogsDir(cwd), HISTORY_FILE);
-}
-
-async function removeDeadSessionHudState(
-  cwd: string,
-  sessionIds: Array<string | undefined>,
-): Promise<void> {
-  const uniqueSessionIds = [...new Set(
-    sessionIds
-      .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
-      .map((value) => value.trim()),
-  )];
-
-  const candidatePaths = [
-    getStateFilePath('hud-state.json', cwd),
-    ...uniqueSessionIds.map((sessionId) => getStateFilePath('hud-state.json', cwd, sessionId)),
-  ];
-
-  await Promise.all(candidatePaths.map(async (path) => {
-    try {
-      await rm(path, { force: true });
-    } catch {
-      // best effort only
-    }
-  }));
-}
+const SESSION_POINTER_TOKEN_PATTERN = /^[A-Za-z0-9_-]{16,128}$/;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+const LOCK_RETRY_DELAYS_MS = [25, 50, 100] as const;
+const DEFAULT_POINTER_TIMEOUT_MS = 5_000;
+const NATIVE_POINTER_TIMEOUT_MS = 2_000;
 
 /**
- * Reset session-scoped HUD/metrics files at launch so stale values do not leak
- * into a new Codex session.
+ * Convert arbitrary input into a valid session ID without exposing validator
+ * exceptions to lifecycle or hook inputs.
  */
-export async function resetSessionMetrics(cwd: string, sessionId?: string): Promise<void> {
-  const omxDir = omxRoot(cwd);
-  const stateDir = omxStateDir(cwd);
-  await mkdir(omxDir, { recursive: true });
-  await mkdir(stateDir, { recursive: true });
-
-  const now = new Date().toISOString();
-  await writeFile(join(omxDir, 'metrics.json'), JSON.stringify({
-    total_turns: 0,
-    session_turns: 0,
-    last_activity: now,
-    session_input_tokens: 0,
-    session_output_tokens: 0,
-    session_total_tokens: 0,
-    five_hour_limit_pct: 0,
-    weekly_limit_pct: 0,
-  }, null, 2));
-
-  const hudStatePath = getStateFilePath('hud-state.json', cwd, sessionId);
-  await mkdir(dirname(hudStatePath), { recursive: true });
-  await writeFile(hudStatePath, JSON.stringify({
-    last_turn_at: now,
-    last_progress_at: now,
-    turn_count: 0,
-    last_agent_output: '',
-  }, null, 2));
+export function normalizeSessionId(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return SESSION_ID_PATTERN.test(trimmed) ? trimmed : undefined;
 }
 
-/**
- * Read current session state. Returns null if no session file exists.
- */
-export async function readSessionState(cwd: string): Promise<SessionState | null> {
-  const path = sessionPath(cwd);
-  if (!existsSync(path)) return null;
+/** Resolve the one exact pointer path used by an operation. */
+export function resolveSessionPointerContext(cwd: string): SessionPointerContext {
+  const normalizedCwd = resolveWorkingDirectoryForState(cwd);
+  const { baseStateDir, rootSource } = getBaseStateDirWithSource(normalizedCwd);
+  const pointerPath = join(baseStateDir, SESSION_FILE);
+  return {
+    cwd: normalizedCwd,
+    baseStateDir,
+    rootSource,
+    sessionPath: pointerPath,
+    lockPath: `${pointerPath}.lock`,
+  };
+}
 
+function attemptedStateRootSource(): AttemptedStateRootSource {
   try {
-    const content = await readFile(path, 'utf-8');
-    return JSON.parse(content) as SessionState;
+    if (process.env.OMX_TEAM_STATE_ROOT?.trim()) return 'team-env';
+    if (process.env.OMX_ROOT?.trim()) return 'omx-root-env';
+    if (process.env.OMX_STATE_ROOT?.trim()) return 'omx-state-root-env';
+    return 'cwd-default';
   } catch {
-    return null;
+    return 'unresolved';
   }
 }
 
-export function isSessionStateAuthoritativeForCwd(state: SessionState, cwd: string): boolean {
-  if (!SESSION_ID_PATTERN.test(state.session_id)) return false;
-
-  if (typeof state.cwd === 'string' && state.cwd.trim() !== '') {
-    return sameFilePath(state.cwd, cwd);
-  }
-
-  return true;
+function contextAbort(cwd: string, candidateSessionId: string | undefined, cause: unknown): SessionPointerContextAbort {
+  return new SessionPointerLaunchAbortError({
+    code: 'session_pointer_context_failure',
+    operation: 'pointer-context-resolve',
+    cwd,
+    ...(candidateSessionId ? { candidateSessionId } : {}),
+    attemptedRootSource: attemptedStateRootSource(),
+    reason: `Unable to resolve the selected session pointer root: ${errorMessage(cause)}`,
+    cause,
+  }) as SessionPointerContextAbort;
 }
 
-export function isSessionStateUsable(
-  state: SessionState,
-  cwd: string,
-  options: SessionStaleCheckOptions = {},
-): boolean {
-  if (!isSessionStateAuthoritativeForCwd(state, cwd)) return false;
-
-  const hasPidMetadata = Number.isInteger(state.pid) && state.pid > 0;
-  const hasLinuxIdentityMetadata = typeof state.pid_start_ticks === 'number'
-    || typeof state.pid_cmdline === 'string';
-  if (hasPidMetadata || hasLinuxIdentityMetadata) {
-    return !isSessionStale(state, options);
-  }
-
-  return true;
+function resolvedAbort(
+  context: SessionPointerContext,
+  input: Omit<ResolvedSessionPointerAbort, 'name' | 'committed' | 'cwd' | 'pointerPath' | 'rootSource' | 'message'>,
+): ResolvedSessionPointerAbort {
+  return new SessionPointerLaunchAbortError({
+    ...input,
+    cwd: context.cwd,
+    pointerPath: context.sessionPath,
+    rootSource: context.rootSource,
+  }) as ResolvedSessionPointerAbort;
 }
 
-export async function readUsableSessionState(
-  cwd: string,
-  options: SessionStaleCheckOptions = {},
-): Promise<SessionState | null> {
-  const state = await readSessionState(cwd);
-  if (!state) return null;
-  return isSessionStateUsable(state, cwd, options) ? state : null;
+class SessionPointerLaunchAbortError extends Error {
+  readonly name = 'SessionPointerLaunchAbort' as const;
+  readonly committed = false as const;
+
+  constructor(fields: Record<string, unknown> & { reason: string; cause?: unknown }) {
+    super(fields.reason);
+    Object.assign(this, fields);
+  }
+}
+
+export function isSessionPointerLaunchAbort(error: unknown): error is SessionPointerLaunchAbort {
+  if (!(error instanceof Error) || error.name !== 'SessionPointerLaunchAbort') return false;
+  const candidate = error as Partial<SessionPointerLaunchAbort>;
+  if (candidate.committed !== false || typeof candidate.cwd !== 'string' || typeof candidate.operation !== 'string') {
+    return false;
+  }
+  return candidate.code === 'session_pointer_context_failure'
+    || candidate.code === 'session_pointer_lock_timeout'
+    || candidate.code === 'session_pointer_lock_recovery_required'
+    || candidate.code === 'session_pointer_unusable'
+    || candidate.code === 'session_pointer_owner_conflict'
+    || candidate.code === 'session_pointer_io_failure';
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
+}
+
+function isNotFound(error: unknown): boolean {
+  return errorCode(error) === 'ENOENT';
+}
+
+function isAlreadyExists(error: unknown): boolean {
+  return errorCode(error) === 'EEXIST';
+}
+
+function hashCmdline(cmdline: string | null | undefined): string | undefined {
+  const normalized = normalizeCmdline(cmdline);
+  return normalized ? createHash('sha256').update(normalized).digest('hex') : undefined;
 }
 
 interface LinuxProcessIdentity {
@@ -157,21 +264,184 @@ interface LinuxProcessIdentity {
   cmdline: string | null;
 }
 
-interface SessionStaleCheckOptions {
+export interface SessionStaleCheckOptions {
   platform?: NodeJS.Platform;
   isPidAlive?: (pid: number) => boolean;
   readLinuxIdentity?: (pid: number) => LinuxProcessIdentity | null;
 }
 
-interface SessionStartOptions {
+export interface SessionStartOptions {
   pid?: number;
   platform?: NodeJS.Platform;
   nativeSessionId?: string;
   previousNativeSessionId?: string;
   nativeSessionSwitchedAt?: string;
+  /**
+   * Compatibility-only metadata. Alias candidacy always comes from
+   * process.env.OMX_SESSION_ID, never from this option.
+   */
   ownerOmxSessionId?: string;
+  /** The caller proved the env candidate with actual tmux pane/session tags. */
+  ownerAliasVerified?: boolean;
   tmuxSessionName?: string;
   tmuxPaneId?: string;
+  context?: SessionPointerContext;
+}
+
+/** @internal Test-only deterministic transaction seam; do not use outside session tests. */
+export type PidProbeResult = 'alive' | 'dead' | 'indeterminate';
+
+/** @internal Test-only deterministic transaction seam; do not use outside session tests. */
+export interface SessionPointerFsDependencies {
+  mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
+  readdir(path: string): Promise<string[]>;
+  readFile(path: string, encoding: 'utf8'): Promise<string>;
+  writeFile(path: string, data: string, options?: { mode?: number; flag?: string }): Promise<void>;
+  openAndSync(path: string): Promise<void>;
+  rename(from: string, to: string): Promise<void>;
+  unlink(path: string): Promise<void>;
+  rmdir(path: string): Promise<void>;
+}
+
+/** @internal Test-only deterministic transaction seam; do not use outside session tests. */
+export interface SessionPointerTransactionDependencies {
+  fs: SessionPointerFsDependencies;
+  nowMs(): number;
+  sleep(ms: number): Promise<void>;
+  token(): string;
+  probePid(pid: number): PidProbeResult;
+  readProcessIdentity(pid: number, platform: NodeJS.Platform): {
+    status: 'matching' | 'reused' | 'indeterminate';
+    startTicks?: number;
+    cmdlineHash?: string;
+  };
+}
+
+const defaultFsDependencies: SessionPointerFsDependencies = {
+  mkdir: async (path, options) => {
+    await nodeMkdir(path, options);
+  },
+  readdir: async (path) => await nodeReaddir(path),
+  readFile: async (path, encoding) => await nodeReadFile(path, encoding),
+  writeFile: async (path, data, options) => {
+    await nodeWriteFile(path, data, options);
+  },
+  openAndSync: async (path) => {
+    const handle = await open(path, 'r');
+    try {
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+  },
+  rename: async (from, to) => {
+    await nodeRename(from, to);
+  },
+  unlink: async (path) => {
+    await nodeUnlink(path);
+  },
+  rmdir: async (path) => {
+    await nodeRmdir(path);
+  },
+};
+
+/** @internal Exposed only so source-module tests can verify default ESRCH handling. */
+export function __createDefaultPidProbeForTests(
+  killZero: (pid: number) => void,
+): (pid: number) => PidProbeResult {
+  return (pid: number): PidProbeResult => {
+    try {
+      killZero(pid);
+      return 'alive';
+    } catch (error) {
+      return errorCode(error) === 'ESRCH' ? 'dead' : 'indeterminate';
+    }
+  };
+}
+
+function defaultProbePid(pid: number): PidProbeResult {
+  return __createDefaultPidProbeForTests((targetPid) => {
+    process.kill(targetPid, 0);
+  })(pid);
+}
+
+function defaultReadProcessIdentity(pid: number, platform: NodeJS.Platform): {
+  status: 'matching' | 'reused' | 'indeterminate';
+  startTicks?: number;
+  cmdlineHash?: string;
+} {
+  if (platform !== 'linux') return { status: 'indeterminate' };
+  const identity = readLinuxProcessIdentity(pid);
+  if (!identity) return { status: 'indeterminate' };
+  const cmdlineHash = hashCmdline(identity.cmdline);
+  return {
+    status: 'matching',
+    startTicks: identity.startTicks,
+    ...(cmdlineHash ? { cmdlineHash } : {}),
+  };
+}
+
+const defaultTransactionDependencies: SessionPointerTransactionDependencies = {
+  fs: defaultFsDependencies,
+  nowMs: () => Date.now(),
+  sleep: async (ms) => await new Promise<void>((resolve) => setTimeout(resolve, ms)),
+  token: () => randomUUID(),
+  probePid: defaultProbePid,
+  readProcessIdentity: defaultReadProcessIdentity,
+};
+
+let transactionDependencies: SessionPointerTransactionDependencies = defaultTransactionDependencies;
+
+/** @internal Source-module test harness. Always reset after a test. */
+export function __setSessionPointerTransactionDependenciesForTests(
+  overrides: Omit<Partial<SessionPointerTransactionDependencies>, 'fs'> & {
+    fs?: Partial<SessionPointerFsDependencies>;
+  },
+): void {
+  transactionDependencies = {
+    ...defaultTransactionDependencies,
+    ...overrides,
+    fs: {
+      ...defaultFsDependencies,
+      ...overrides.fs,
+    },
+  };
+}
+
+/** @internal Source-module test harness. */
+export function __resetSessionPointerTransactionDependenciesForTests(): void {
+  transactionDependencies = defaultTransactionDependencies;
+}
+
+function parseLinuxProcStartTicks(statContent: string): number | null {
+  const commandEnd = statContent.lastIndexOf(')');
+  if (commandEnd === -1) return null;
+  const fields = statContent.slice(commandEnd + 1).trim().split(/\s+/);
+  if (fields.length <= 19) return null;
+  const startTicks = Number(fields[19]);
+  return Number.isInteger(startTicks) && startTicks >= 0 ? startTicks : null;
+}
+
+function normalizeCmdline(cmdline: string | null | undefined): string | null {
+  if (!cmdline) return null;
+  const normalized = cmdline.replace(/\s+/g, ' ').trim();
+  return normalized || null;
+}
+
+function readLinuxProcessIdentity(pid: number): LinuxProcessIdentity | null {
+  try {
+    const startTicks = parseLinuxProcStartTicks(readFileSync(`/proc/${pid}/stat`, 'utf-8'));
+    if (startTicks == null) return null;
+    let cmdline: string | null = null;
+    try {
+      cmdline = readFileSync(`/proc/${pid}/cmdline`, 'utf-8').replace(/\u0000+/g, ' ').trim();
+    } catch {
+      // The start tick is still useful when cmdline access is unavailable.
+    }
+    return { startTicks, cmdline: normalizeCmdline(cmdline) };
+  } catch {
+    return null;
+  }
 }
 
 function defaultIsPidAlive(pid: number): boolean {
@@ -183,43 +453,165 @@ function defaultIsPidAlive(pid: number): boolean {
   }
 }
 
-function parseLinuxProcStartTicks(statContent: string): number | null {
-  const commandEnd = statContent.lastIndexOf(')');
-  if (commandEnd === -1) return null;
+/**
+ * Legacy boolean stale check retained for read compatibility. The pointer
+ * classifier below keeps indeterminate liveness distinct from definitely dead.
+ */
+export function isSessionStale(
+  state: SessionState,
+  options: SessionStaleCheckOptions = {},
+): boolean {
+  if (!Number.isInteger(state.pid) || state.pid <= 0) return true;
+  const isPidAlive = options.isPidAlive ?? defaultIsPidAlive;
+  if (!isPidAlive(state.pid)) return true;
 
-  const remainder = statContent.slice(commandEnd + 1).trim();
-  const fields = remainder.split(/\s+/);
-  if (fields.length <= 19) return null;
+  const platform = options.platform ?? process.platform;
+  if (platform !== 'linux') return false;
 
-  const startTicks = Number(fields[19]);
-  return Number.isFinite(startTicks) ? startTicks : null;
+  const liveIdentity = (options.readLinuxIdentity ?? readLinuxProcessIdentity)(state.pid);
+  if (!liveIdentity || typeof state.pid_start_ticks !== 'number') return true;
+  if (state.pid_start_ticks !== liveIdentity.startTicks) return true;
+
+  const expectedCmdline = normalizeCmdline(state.pid_cmdline);
+  if (!expectedCmdline) return false;
+  const liveCmdline = normalizeCmdline(liveIdentity.cmdline);
+  return !liveCmdline || liveCmdline !== expectedCmdline;
 }
 
-function normalizeCmdline(cmdline: string | null | undefined): string | null {
-  if (!cmdline) return null;
-  const normalized = cmdline.replace(/\s+/g, ' ').trim();
-  return normalized.length > 0 ? normalized : null;
-}
-
-function readLinuxProcessIdentity(pid: number): LinuxProcessIdentity | null {
+export function isSessionStateAuthoritativeForCwd(state: SessionState, cwd: string): boolean {
+  if (!normalizeSessionId(state.session_id)) return false;
+  if (typeof state.cwd !== 'string' || !state.cwd.trim()) return false;
   try {
-    const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
-    const startTicks = parseLinuxProcStartTicks(stat);
-    if (startTicks == null) return null;
+    return sameFilePath(state.cwd, cwd);
+  } catch {
+    return false;
+  }
+}
 
-    let cmdline: string | null = null;
-    try {
-      cmdline = readFileSync(`/proc/${pid}/cmdline`, 'utf-8')
-        .replace(/\u0000+/g, ' ')
-        .trim();
-    } catch {
-      cmdline = null;
-    }
+export function isSessionStateUsable(
+  state: SessionState,
+  cwd: string,
+  options: SessionStaleCheckOptions = {},
+): boolean {
+  if (!normalizeSessionId(state.session_id)) return false;
+  if (typeof state.cwd === 'string' && state.cwd.trim() && !isSessionStateAuthoritativeForCwd(state, cwd)) return false;
+  const hasPidMetadata = Number.isInteger(state.pid) && state.pid > 0;
+  const hasLinuxIdentityMetadata = typeof state.pid_start_ticks === 'number'
+    || typeof state.pid_cmdline === 'string';
+  return !hasPidMetadata && !hasLinuxIdentityMetadata || !isSessionStale(state, options);
+}
 
-    return {
-      startTicks,
-      cmdline: normalizeCmdline(cmdline),
-    };
+function isValidStartTicks(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+function classifySessionProcess(
+  state: SessionState,
+  dependencies: SessionPointerTransactionDependencies,
+): 'usable' | 'stale-dead' | 'identity-indeterminate' {
+  const hasPidMetadata = Number.isInteger(state.pid) && state.pid > 0;
+  const hasIdentityMetadata = typeof state.pid_start_ticks === 'number' || typeof state.pid_cmdline === 'string';
+  if (!hasPidMetadata && !hasIdentityMetadata) return 'usable';
+  if (!hasPidMetadata) return 'identity-indeterminate';
+
+  let pidStatus: PidProbeResult;
+  try {
+    pidStatus = dependencies.probePid(state.pid);
+  } catch {
+    return 'identity-indeterminate';
+  }
+  if (pidStatus === 'dead') return 'stale-dead';
+  if (pidStatus !== 'alive') return 'identity-indeterminate';
+
+  const platform = state.platform ?? process.platform;
+  if (platform !== 'linux') return 'usable';
+  if (!isValidStartTicks(state.pid_start_ticks)) return 'identity-indeterminate';
+
+  let liveIdentity: ReturnType<SessionPointerTransactionDependencies['readProcessIdentity']>;
+  try {
+    liveIdentity = dependencies.readProcessIdentity(state.pid, platform);
+  } catch {
+    return 'identity-indeterminate';
+  }
+  if (!liveIdentity || !isValidStartTicks(liveIdentity.startTicks)) return 'identity-indeterminate';
+  if (liveIdentity.startTicks !== state.pid_start_ticks) return 'stale-dead';
+  if (liveIdentity.status !== 'matching') return 'identity-indeterminate';
+
+  const expectedCmdlineHash = hashCmdline(state.pid_cmdline);
+  if (expectedCmdlineHash && liveIdentity.cmdlineHash !== expectedCmdlineHash) {
+    return 'identity-indeterminate';
+  }
+  return 'usable';
+}
+
+function classifyParsedSessionPointer(
+  context: SessionPointerContext,
+  value: unknown,
+  raw: string,
+): SessionPointerReadResult {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { status: 'malformed', raw };
+  }
+  const state = value as SessionState;
+  if (!normalizeSessionId(state.session_id)) return { status: 'malformed', raw };
+  if (typeof state.cwd === 'string' && state.cwd.trim() && !isSessionStateAuthoritativeForCwd(state, context.cwd)) {
+    return { status: 'foreign-cwd', raw, state };
+  }
+
+  const processStatus = classifySessionProcess(state, transactionDependencies);
+  return { status: processStatus, state, raw };
+}
+
+/** Read and classify only context.sessionPath; no alternate root is consulted. */
+export async function readSessionPointer(context: SessionPointerContext): Promise<SessionPointerReadResult> {
+  let raw: string;
+  try {
+    raw = await transactionDependencies.fs.readFile(context.sessionPath, 'utf8');
+  } catch (error) {
+    if (isNotFound(error)) return { status: 'absent' };
+    throw error;
+  }
+
+  try {
+    return classifyParsedSessionPointer(context, JSON.parse(raw), raw);
+  } catch (error) {
+    if (error instanceof SyntaxError) return { status: 'malformed', raw };
+    throw error;
+  }
+}
+
+export async function readSessionStateFromContext(context: SessionPointerContext): Promise<SessionState | null> {
+  try {
+    const raw = await transactionDependencies.fs.readFile(context.sessionPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as SessionState : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function readUsableSessionStateFromContext(context: SessionPointerContext): Promise<SessionState | null> {
+  const state = await readSessionStateFromContext(context);
+  return state && isSessionStateUsable(state, context.cwd) ? state : null;
+}
+
+/** Read current session state from the exact selected root. */
+export async function readSessionState(cwd: string): Promise<SessionState | null> {
+  try {
+    return await readSessionStateFromContext(resolveSessionPointerContext(cwd));
+  } catch {
+    return null;
+  }
+}
+
+export async function readUsableSessionState(
+  cwd: string,
+  options: SessionStaleCheckOptions = {},
+): Promise<SessionState | null> {
+  try {
+    const context = resolveSessionPointerContext(cwd);
+    const state = await readSessionStateFromContext(context);
+    return state && isSessionStateUsable(state, context.cwd, options) ? state : null;
   } catch {
     return null;
   }
@@ -243,28 +635,12 @@ function createSessionState(
   } = {},
 ): SessionState {
   const nowIso = options.nowIso ?? new Date().toISOString();
-  const nativeSessionId = typeof options.nativeSessionId === 'string' && options.nativeSessionId.trim()
-    ? options.nativeSessionId.trim()
-    : undefined;
-  const tmuxSessionName = typeof options.tmuxSessionName === 'string' && options.tmuxSessionName.trim()
-    ? options.tmuxSessionName.trim()
-    : undefined;
-  const tmuxPaneId = typeof options.tmuxPaneId === 'string' && options.tmuxPaneId.trim()
-    ? options.tmuxPaneId.trim()
-    : undefined;
-  const previousNativeSessionId =
-    typeof options.previousNativeSessionId === 'string' && options.previousNativeSessionId.trim()
-      ? options.previousNativeSessionId.trim()
-      : undefined;
-  const nativeSessionSwitchedAt =
-    typeof options.nativeSessionSwitchedAt === 'string' && options.nativeSessionSwitchedAt.trim()
-      ? options.nativeSessionSwitchedAt.trim()
-      : undefined;
-  const ownerOmxSessionId =
-    typeof options.ownerOmxSessionId === 'string' && options.ownerOmxSessionId.trim()
-      ? options.ownerOmxSessionId.trim()
-      : undefined;
-
+  const nativeSessionId = normalizeNonempty(options.nativeSessionId);
+  const previousNativeSessionId = normalizeNonempty(options.previousNativeSessionId);
+  const nativeSessionSwitchedAt = normalizeNonempty(options.nativeSessionSwitchedAt);
+  const ownerOmxSessionId = normalizeSessionId(options.ownerOmxSessionId);
+  const tmuxSessionName = normalizeNonempty(options.tmuxSessionName);
+  const tmuxPaneId = normalizeNonempty(options.tmuxPaneId);
   return {
     session_id: sessionId,
     ...(nativeSessionId ? { native_session_id: nativeSessionId } : {}),
@@ -275,254 +651,1046 @@ function createSessionState(
     cwd,
     pid,
     platform,
-    pid_start_ticks: linuxIdentity?.startTicks,
-    pid_cmdline: linuxIdentity?.cmdline ?? undefined,
+    ...(linuxIdentity ? { pid_start_ticks: linuxIdentity.startTicks } : {}),
+    ...(linuxIdentity?.cmdline ? { pid_cmdline: linuxIdentity.cmdline } : {}),
     ...(tmuxSessionName ? { tmux_session_name: tmuxSessionName } : {}),
     ...(tmuxPaneId ? { tmux_pane_id: tmuxPaneId } : {}),
   };
 }
 
-/**
- * Check if a session is stale.
- * - If the owning PID is dead, it is stale.
- * - On Linux, require process identity validation (start ticks, optional cmdline).
- *   If identity cannot be validated, treat the session as stale.
- */
-export function isSessionStale(
-  state: SessionState,
-  options: SessionStaleCheckOptions = {},
-): boolean {
-  if (!Number.isInteger(state.pid) || state.pid <= 0) return true;
-
-  const isPidAlive = options.isPidAlive ?? defaultIsPidAlive;
-  if (!isPidAlive(state.pid)) return true;
-
-  const platform = options.platform ?? process.platform;
-  if (platform !== 'linux') return false;
-
-  const readIdentity = options.readLinuxIdentity ?? readLinuxProcessIdentity;
-  const liveIdentity = readIdentity(state.pid);
-  if (!liveIdentity) return true;
-
-  if (typeof state.pid_start_ticks !== 'number') return true;
-  if (state.pid_start_ticks !== liveIdentity.startTicks) return true;
-
-  const expectedCmdline = normalizeCmdline(state.pid_cmdline);
-  if (expectedCmdline) {
-    const liveCmdline = normalizeCmdline(liveIdentity.cmdline);
-    if (!liveCmdline || liveCmdline !== expectedCmdline) return true;
-  }
-
-  return false;
+function normalizeNonempty(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 
-/**
- * Write session start state.
- */
+function resolvePid(options: SessionStartOptions): number {
+  return Number.isInteger(options.pid) && options.pid && options.pid > 0 ? options.pid : process.pid;
+}
+
+function sessionIdentityFor(pid: number, platform: NodeJS.Platform): LinuxProcessIdentity | null {
+  return platform === 'linux' ? readLinuxProcessIdentity(pid) : null;
+}
+
+function currentOwnerAlias(state: SessionState): string | undefined {
+  return normalizeSessionId(state.owner_omx_session_id);
+}
+
+function verifiedOwnerCandidate(
+  context: SessionPointerContext,
+  options: SessionStartOptions,
+): string | undefined {
+  if (context.rootSource === 'team-env' || options.ownerAliasVerified !== true) return undefined;
+  return normalizeSessionId(process.env.OMX_SESSION_ID);
+}
+
+function mergeOwnerAlias(
+  existing: SessionState | undefined,
+  candidate: string | undefined,
+  verified: boolean,
+): string | undefined {
+  const current = existing && currentOwnerAlias(existing);
+  if (current) {
+    if (candidate && candidate !== current) {
+      throw new Error(`Session pointer is already bound to owner ${current}`);
+    }
+    return current;
+  }
+  if (!candidate || !verified || candidate === existing?.session_id) return undefined;
+  return candidate;
+}
+
+function isStartCompatible(existing: SessionState, requestedSessionId: string): boolean {
+  return existing.session_id === requestedSessionId
+    || existing.native_session_id === requestedSessionId
+    || currentOwnerAlias(existing) === requestedSessionId;
+}
+
+function getOmxLaunchSessionId(state: SessionState): string | undefined {
+  if (state.session_id.startsWith('omx-')) return state.session_id;
+  const owner = currentOwnerAlias(state);
+  return owner?.startsWith('omx-') ? owner : undefined;
+}
+
+interface SessionPointerLockOwnerV1 {
+  version: 1;
+  token: string;
+  pid: number;
+  platform: NodeJS.Platform;
+  pid_start_ticks?: number;
+  pid_cmdline_hash?: string;
+  created_at: string;
+}
+
+type LockOwnerStatus = 'live' | 'dead' | 'reused' | 'identity-indeterminate' | 'missing' | 'malformed';
+
+function parseLockOwner(raw: string): SessionPointerLockOwnerV1 | null {
+  try {
+    const value = JSON.parse(raw) as Partial<SessionPointerLockOwnerV1>;
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+    if (value.version !== 1 || !isValidToken(value.token) || typeof value.pid !== 'number' || !Number.isInteger(value.pid) || value.pid <= 0) return null;
+    if (typeof value.platform !== 'string' || !value.platform || typeof value.created_at !== 'string' || !value.created_at) {
+      return null;
+    }
+    if (value.pid_start_ticks !== undefined && !isValidStartTicks(value.pid_start_ticks)) return null;
+    if (value.pid_cmdline_hash !== undefined
+      && (typeof value.pid_cmdline_hash !== 'string' || !SHA256_PATTERN.test(value.pid_cmdline_hash))) {
+      return null;
+    }
+    return value as SessionPointerLockOwnerV1;
+  } catch {
+    return null;
+  }
+}
+
+function isValidToken(value: unknown): value is string {
+  return typeof value === 'string' && SESSION_POINTER_TOKEN_PATTERN.test(value);
+}
+
+async function inspectLockOwner(lockPath: string): Promise<{
+  status: LockOwnerStatus;
+  owner?: SessionPointerLockOwnerV1;
+}> {
+  let raw: string;
+  try {
+    raw = await transactionDependencies.fs.readFile(join(lockPath, 'owner.json'), 'utf8');
+  } catch (error) {
+    return isNotFound(error) ? { status: 'missing' } : { status: 'identity-indeterminate' };
+  }
+
+  const owner = parseLockOwner(raw);
+  if (!owner) return { status: 'malformed' };
+
+  let pidStatus: PidProbeResult;
+  try {
+    pidStatus = transactionDependencies.probePid(owner.pid);
+  } catch {
+    return { status: 'identity-indeterminate', owner };
+  }
+  if (pidStatus === 'dead') return { status: 'dead', owner };
+  if (pidStatus !== 'alive') return { status: 'identity-indeterminate', owner };
+
+  // Without Linux immutable start metadata, a live PID cannot be proved to be
+  // the same process. Preserve the lock instead of guessing.
+  if (owner.platform !== 'linux' || !isValidStartTicks(owner.pid_start_ticks)) {
+    return { status: 'identity-indeterminate', owner };
+  }
+
+  let liveIdentity: ReturnType<SessionPointerTransactionDependencies['readProcessIdentity']>;
+  try {
+    liveIdentity = transactionDependencies.readProcessIdentity(owner.pid, owner.platform);
+  } catch {
+    return { status: 'identity-indeterminate', owner };
+  }
+  if (!liveIdentity || !isValidStartTicks(liveIdentity.startTicks)) {
+    return { status: 'identity-indeterminate', owner };
+  }
+  if (liveIdentity.startTicks !== owner.pid_start_ticks) return { status: 'reused', owner };
+  if (liveIdentity.status !== 'matching') return { status: 'identity-indeterminate', owner };
+  if (owner.pid_cmdline_hash && owner.pid_cmdline_hash !== liveIdentity.cmdlineHash) {
+    return { status: 'identity-indeterminate', owner };
+  }
+  return { status: 'live', owner };
+}
+
+interface HeldPointerLock {
+  context: SessionPointerContext;
+  token: string;
+}
+
+function buildLockOwner(token: string): SessionPointerLockOwnerV1 {
+  let identity: ReturnType<SessionPointerTransactionDependencies['readProcessIdentity']> | undefined;
+  try {
+    identity = transactionDependencies.readProcessIdentity(process.pid, process.platform);
+  } catch {
+    // Publication remains valid with optional identity metadata omitted.
+  }
+  return {
+    version: 1,
+    token,
+    pid: process.pid,
+    platform: process.platform,
+    ...(identity?.status === 'matching' && isValidStartTicks(identity.startTicks)
+      ? { pid_start_ticks: identity.startTicks }
+      : {}),
+    ...(identity?.status === 'matching' && identity.cmdlineHash && SHA256_PATTERN.test(identity.cmdlineHash)
+      ? { pid_cmdline_hash: identity.cmdlineHash }
+      : {}),
+    created_at: new Date(transactionDependencies.nowMs()).toISOString(),
+  };
+}
+
+async function removeOwnedPath(path: string): Promise<SessionPointerSecondaryFailure | undefined> {
+  try {
+    await transactionDependencies.fs.unlink(path);
+    return undefined;
+  } catch (error) {
+    if (isNotFound(error)) return undefined;
+    try {
+      await transactionDependencies.fs.readFile(path, 'utf8');
+    } catch (readError) {
+      if (isNotFound(readError)) return undefined;
+    }
+    return {
+      operation: 'precommit-cleanup',
+      phase: 'remove-pointer-temp',
+      ownership: 'held',
+      message: `Unable to remove transaction-owned pointer temporary file: ${errorMessage(error)}`,
+      cause: error,
+      evidencePath: path,
+    };
+  }
+}
+
+async function rollbackUnpublishedLock(
+  context: SessionPointerContext,
+  ownerTempPath?: string,
+): Promise<SessionPointerSecondaryFailure[]> {
+  const failures: SessionPointerSecondaryFailure[] = [];
+  if (ownerTempPath) {
+    try {
+      await transactionDependencies.fs.unlink(ownerTempPath);
+    } catch (error) {
+      if (!isNotFound(error)) {
+        failures.push({
+          operation: 'precommit-cleanup',
+          phase: 'remove-owner-temp',
+          ownership: 'held',
+          message: `Unable to remove transaction-owned lock owner temporary file: ${errorMessage(error)}`,
+          cause: error,
+          evidencePath: ownerTempPath,
+        });
+      }
+    }
+  }
+
+  let entries: string[];
+  try {
+    entries = await transactionDependencies.fs.readdir(context.lockPath);
+  } catch (error) {
+    failures.push({
+      operation: 'precommit-cleanup',
+      phase: 'inspect-unpublished-lock',
+      ownership: 'uncertain',
+      message: `Unable to inspect unpublished session pointer lock: ${errorMessage(error)}`,
+      cause: error,
+      evidencePath: context.lockPath,
+    });
+    return failures;
+  }
+
+  if (entries.length > 0) {
+    failures.push({
+      operation: 'precommit-cleanup',
+      phase: 'inspect-unpublished-lock',
+      ownership: 'uncertain',
+      message: 'Unpublished session pointer lock contains unexpected evidence.',
+      evidencePath: context.lockPath,
+    });
+    return failures;
+  }
+
+  try {
+    await transactionDependencies.fs.rmdir(context.lockPath);
+  } catch (error) {
+    failures.push({
+      operation: 'precommit-cleanup',
+      phase: 'remove-unpublished-lock',
+      ownership: 'held',
+      message: `Unable to remove empty unpublished session pointer lock: ${errorMessage(error)}`,
+      cause: error,
+      evidencePath: context.lockPath,
+    });
+  }
+  return failures;
+}
+
+async function acquirePointerLock(
+  context: SessionPointerContext,
+  candidateSessionId: string | undefined,
+  timeoutMs: number,
+): Promise<HeldPointerLock> {
+  const deadline = transactionDependencies.nowMs() + timeoutMs;
+  let attempt = 0;
+
+  while (true) {
+    try {
+      await transactionDependencies.fs.mkdir(context.lockPath);
+      break;
+    } catch (error) {
+      if (!isAlreadyExists(error)) {
+        throw resolvedAbort(context, {
+          code: 'session_pointer_io_failure',
+          operation: 'lock-acquire',
+          ...(candidateSessionId ? { candidateSessionId } : {}),
+          lockPath: context.lockPath,
+          reason: `Unable to acquire session pointer lock: ${errorMessage(error)}`,
+          cause: error,
+        });
+      }
+
+      const owner = await inspectLockOwner(context.lockPath);
+      if (owner.status !== 'live') {
+        throw resolvedAbort(context, {
+          code: 'session_pointer_lock_recovery_required',
+          operation: 'lock-acquire',
+          ...(candidateSessionId ? { candidateSessionId } : {}),
+          lockPath: context.lockPath,
+          lockOwnerStatus: owner.status,
+          reason: `Session pointer lock requires explicit recovery (${owner.status}).`,
+        });
+      }
+
+      const remaining = deadline - transactionDependencies.nowMs();
+      if (remaining <= 0) {
+        throw resolvedAbort(context, {
+          code: 'session_pointer_lock_timeout',
+          operation: 'lock-acquire',
+          ...(candidateSessionId ? { candidateSessionId } : {}),
+          lockPath: context.lockPath,
+          lockOwnerStatus: 'live',
+          reason: 'Timed out waiting for the live session pointer lock owner.',
+        });
+      }
+      const delay = Math.min(LOCK_RETRY_DELAYS_MS[Math.min(attempt, LOCK_RETRY_DELAYS_MS.length - 1)], remaining);
+      attempt += 1;
+      try {
+        await transactionDependencies.sleep(delay);
+      } catch (sleepError) {
+        throw resolvedAbort(context, {
+          code: 'session_pointer_io_failure',
+          operation: 'lock-acquire',
+          ...(candidateSessionId ? { candidateSessionId } : {}),
+          lockPath: context.lockPath,
+          reason: `Unable to wait for session pointer lock: ${errorMessage(sleepError)}`,
+          cause: sleepError,
+        });
+      }
+    }
+  }
+
+  let token: string;
+  try {
+    token = transactionDependencies.token();
+  } catch (error) {
+    const primary = resolvedAbort(context, {
+      code: 'session_pointer_io_failure',
+      operation: 'lock-owner-publish',
+      ...(candidateSessionId ? { candidateSessionId } : {}),
+      lockPath: context.lockPath,
+      reason: `Unable to create session pointer lock token: ${errorMessage(error)}`,
+      cause: error,
+    });
+    const failures = await rollbackUnpublishedLock(context);
+    if (failures.length === 0) throw primary;
+    throw recoveryAbort(context, primary, failures, 'precommit-cleanup');
+  }
+
+  if (!isValidToken(token)) {
+    const cause = new Error('Session pointer transaction token is invalid.');
+    const primary = resolvedAbort(context, {
+      code: 'session_pointer_io_failure',
+      operation: 'lock-owner-publish',
+      ...(candidateSessionId ? { candidateSessionId } : {}),
+      lockPath: context.lockPath,
+      reason: cause.message,
+      cause,
+    });
+    const failures = await rollbackUnpublishedLock(context);
+    if (failures.length === 0) throw primary;
+    throw recoveryAbort(context, primary, failures, 'precommit-cleanup');
+  }
+
+  const ownerTempPath = join(context.lockPath, `owner.${token}.tmp`);
+  const ownerPath = join(context.lockPath, 'owner.json');
+  try {
+    await transactionDependencies.fs.writeFile(ownerTempPath, JSON.stringify(buildLockOwner(token)), { mode: 0o600 });
+    await transactionDependencies.fs.openAndSync(ownerTempPath);
+    await transactionDependencies.fs.rename(ownerTempPath, ownerPath);
+  } catch (error) {
+    const primary = resolvedAbort(context, {
+      code: 'session_pointer_io_failure',
+      operation: 'lock-owner-publish',
+      ...(candidateSessionId ? { candidateSessionId } : {}),
+      lockPath: context.lockPath,
+      reason: `Unable to publish session pointer lock owner: ${errorMessage(error)}`,
+      cause: error,
+    });
+    const failures = await rollbackUnpublishedLock(context, ownerTempPath);
+    if (failures.length === 0) throw primary;
+    throw recoveryAbort(context, primary, failures, 'precommit-cleanup');
+  }
+
+  return { context, token };
+}
+
+async function releasePointerLock(lock: HeldPointerLock): Promise<SessionPointerSecondaryFailure[]> {
+  const ownerPath = join(lock.context.lockPath, 'owner.json');
+  let owner: SessionPointerLockOwnerV1 | null = null;
+  try {
+    owner = parseLockOwner(await transactionDependencies.fs.readFile(ownerPath, 'utf8'));
+  } catch {
+    // The error is represented as a token-check uncertainty below.
+  }
+
+  if (!owner || owner.token !== lock.token) {
+    return [{
+      operation: 'lock-release',
+      phase: 'token-check',
+      ownership: 'uncertain',
+      message: 'Unable to prove ownership of the canonical session pointer lock.',
+      evidencePath: lock.context.lockPath,
+    }];
+  }
+
+  const releasePath = `${lock.context.lockPath}.release-${lock.token}`;
+  try {
+    await transactionDependencies.fs.rename(lock.context.lockPath, releasePath);
+  } catch (error) {
+    return [{
+      operation: 'lock-release',
+      phase: 'rename',
+      ownership: 'held',
+      message: `Unable to release the canonical session pointer lock: ${errorMessage(error)}`,
+      cause: error,
+      evidencePath: lock.context.lockPath,
+    }];
+  }
+  try {
+    await transactionDependencies.fs.unlink(join(releasePath, 'owner.json'));
+  } catch (error) {
+    if (!isNotFound(error)) {
+      return [{
+        operation: 'lock-release',
+        phase: 'remove-release-dir',
+        ownership: 'released',
+        message: `Unable to remove released session pointer lock owner: ${errorMessage(error)}`,
+        cause: error,
+        evidencePath: releasePath,
+      }];
+    }
+  }
+
+  try {
+    await transactionDependencies.fs.rmdir(releasePath);
+    return [];
+  } catch (error) {
+    return [{
+      operation: 'lock-release',
+      phase: 'remove-release-dir',
+      ownership: 'released',
+      message: `Unable to remove released session pointer lock evidence: ${errorMessage(error)}`,
+      cause: error,
+      evidencePath: releasePath,
+    }];
+  }
+}
+
+function recoveryAbort(
+  context: SessionPointerContext,
+  primary: ResolvedSessionPointerAbort,
+  failures: readonly SessionPointerSecondaryFailure[],
+  operation: 'precommit-cleanup' | 'lock-release',
+): ResolvedSessionPointerAbort {
+  return resolvedAbort(context, {
+    code: 'session_pointer_lock_recovery_required',
+    operation,
+    ...(primary.candidateSessionId ? { candidateSessionId: primary.candidateSessionId } : {}),
+    ...(primary.canonicalSessionId ? { canonicalSessionId: primary.canonicalSessionId } : {}),
+    lockPath: context.lockPath,
+    ...(primary.pointerStatus ? { pointerStatus: primary.pointerStatus } : {}),
+    reason: `Session pointer cleanup requires explicit recovery after ${primary.operation}.`,
+    cause: primary.cause,
+    primaryOperation: primary.operation as ResolvedSessionPointerAbort['primaryOperation'],
+    secondaryFailures: failures,
+  });
+}
+
+function releaseFailureError(failures: readonly SessionPointerSecondaryFailure[]): Error {
+  const error = new Error('Session pointer committed, but lock release left recovery evidence.');
+  Object.assign(error, { secondaryFailures: failures });
+  return error;
+}
+
+async function finalizePrecommitAbort(
+  lock: HeldPointerLock,
+  primary: ResolvedSessionPointerAbort,
+  pointerTempPath?: string,
+): Promise<ResolvedSessionPointerAbort> {
+  const failures: SessionPointerSecondaryFailure[] = [];
+  if (pointerTempPath) {
+    const pointerTempFailure = await removeOwnedPath(pointerTempPath);
+    if (pointerTempFailure) failures.push(pointerTempFailure);
+  }
+  failures.push(...await releasePointerLock(lock));
+  if (failures.length === 0) return primary;
+  return recoveryAbort(
+    lock.context,
+    primary,
+    failures,
+    pointerTempPath && failures[0]?.phase === 'remove-pointer-temp' ? 'precommit-cleanup' : 'lock-release',
+  );
+}
+
+function unusablePointerAbort(
+  context: SessionPointerContext,
+  candidateSessionId: string | undefined,
+  pointer: SessionPointerReadResult,
+): ResolvedSessionPointerAbort {
+  const pointerStatus = pointer.status === 'malformed'
+    || pointer.status === 'foreign-cwd'
+    || pointer.status === 'identity-indeterminate'
+    ? pointer.status
+    : undefined;
+  return resolvedAbort(context, {
+    code: 'session_pointer_unusable',
+    operation: 'pointer-classify',
+    ...(candidateSessionId ? { candidateSessionId } : {}),
+    ...(pointer.state?.session_id ? { canonicalSessionId: pointer.state.session_id } : {}),
+    lockPath: context.lockPath,
+    ...(pointerStatus ? { pointerStatus } : {}),
+    reason: `Selected session pointer is ${pointer.status} and is preserved.`,
+  });
+}
+
+function ownerConflictAbort(
+  context: SessionPointerContext,
+  candidateSessionId: string,
+  state: SessionState,
+  cause?: unknown,
+): ResolvedSessionPointerAbort {
+  return resolvedAbort(context, {
+    code: 'session_pointer_owner_conflict',
+    operation: 'owner-conflict',
+    candidateSessionId,
+    canonicalSessionId: state.session_id,
+    lockPath: context.lockPath,
+    reason: `Session pointer ${state.session_id} conflicts with requested session ${candidateSessionId}.`,
+    ...(cause ? { cause } : {}),
+  });
+}
+
+interface PointerTransactionResult<T> {
+  context: SessionPointerContext;
+  value: T;
+}
+
+async function writePointerTransaction<T>(
+  cwd: string,
+  candidateSessionId: string | undefined,
+  options: Pick<SessionStartOptions, 'context'>,
+  timeoutMs: number,
+  transition: (pointer: SessionPointerReadResult, context: SessionPointerContext) => T,
+  pointerState: (value: T) => SessionState,
+): Promise<PointerTransactionResult<T>> {
+  let context: SessionPointerContext;
+  try {
+    context = options.context ?? resolveSessionPointerContext(cwd);
+  } catch (error) {
+    throw contextAbort(cwd, candidateSessionId, error);
+  }
+
+  if (!candidateSessionId) {
+    const cause = new Error('A valid session ID is required for pointer mutation.');
+    throw resolvedAbort(context, {
+      code: 'session_pointer_io_failure',
+      operation: 'pointer-classify',
+      lockPath: context.lockPath,
+      reason: cause.message,
+      cause,
+    });
+  }
+
+  try {
+    await transactionDependencies.fs.mkdir(context.baseStateDir, { recursive: true });
+  } catch (error) {
+    throw resolvedAbort(context, {
+      code: 'session_pointer_io_failure',
+      operation: 'state-dir-create',
+      candidateSessionId,
+      lockPath: context.lockPath,
+      reason: `Unable to create selected session state directory: ${errorMessage(error)}`,
+      cause: error,
+    });
+  }
+
+  const lock = await acquirePointerLock(
+    context,
+    candidateSessionId,
+    timeoutMs,
+  );
+  const pointerTempPath = `${context.sessionPath}.tmp-${lock.token}`;
+  let pointerCommitted = false;
+
+  try {
+    let pointer: SessionPointerReadResult;
+    try {
+      pointer = await readSessionPointer(context);
+    } catch (error) {
+      throw resolvedAbort(context, {
+        code: 'session_pointer_io_failure',
+        operation: 'pointer-read',
+        candidateSessionId,
+        lockPath: context.lockPath,
+        reason: `Unable to read selected session pointer: ${errorMessage(error)}`,
+        cause: error,
+      });
+    }
+
+    let next: T;
+    try {
+      next = transition(pointer, context);
+    } catch (error) {
+      if (isSessionPointerLaunchAbort(error)) throw error;
+      const state = pointer.state;
+      throw ownerConflictAbort(context, candidateSessionId, state ?? {
+        session_id: candidateSessionId,
+        started_at: '',
+        cwd: context.cwd,
+        pid: 0,
+      }, error);
+    }
+
+    const serialized = JSON.stringify(pointerState(next), null, 2);
+    try {
+      await transactionDependencies.fs.writeFile(pointerTempPath, serialized, { mode: 0o600, flag: 'wx' });
+    } catch (error) {
+      throw resolvedAbort(context, {
+        code: 'session_pointer_io_failure',
+        operation: 'pointer-temp-write',
+        candidateSessionId,
+        lockPath: context.lockPath,
+        reason: `Unable to write session pointer temporary file: ${errorMessage(error)}`,
+        cause: error,
+      });
+    }
+    try {
+      await transactionDependencies.fs.openAndSync(pointerTempPath);
+    } catch (error) {
+      throw resolvedAbort(context, {
+        code: 'session_pointer_io_failure',
+        operation: 'pointer-fsync',
+        candidateSessionId,
+        lockPath: context.lockPath,
+        reason: `Unable to sync session pointer temporary file: ${errorMessage(error)}`,
+        cause: error,
+      });
+    }
+    try {
+      await transactionDependencies.fs.rename(pointerTempPath, context.sessionPath);
+      pointerCommitted = true;
+    } catch (error) {
+      throw resolvedAbort(context, {
+        code: 'session_pointer_io_failure',
+        operation: 'pointer-rename',
+        candidateSessionId,
+        lockPath: context.lockPath,
+        reason: `Unable to atomically publish session pointer: ${errorMessage(error)}`,
+        cause: error,
+      });
+    }
+
+    const releaseFailures = await releasePointerLock(lock);
+    if (releaseFailures.length > 0) throw releaseFailureError(releaseFailures);
+    return { context, value: next };
+  } catch (error) {
+    if (pointerCommitted) throw error;
+    const primary = isSessionPointerLaunchAbort(error)
+      ? error as ResolvedSessionPointerAbort
+      : resolvedAbort(context, {
+        code: 'session_pointer_io_failure',
+        operation: 'pointer-classify',
+        candidateSessionId,
+        lockPath: context.lockPath,
+        reason: `Session pointer transition failed before commit: ${errorMessage(error)}`,
+        cause: error,
+      });
+    const ownsPointerTemp = primary.operation === 'pointer-temp-write'
+      || primary.operation === 'pointer-fsync'
+      || primary.operation === 'pointer-rename';
+    throw await finalizePrecommitAbort(lock, primary, ownsPointerTemp ? pointerTempPath : undefined);
+  }
+}
+
+function startPointerTransition(
+  requestedSessionId: string,
+  options: SessionStartOptions,
+): (pointer: SessionPointerReadResult, context: SessionPointerContext) => SessionState {
+  return (pointer, context) => {
+    if (pointer.status !== 'absent' && pointer.status !== 'stale-dead' && pointer.status !== 'usable') {
+      throw unusablePointerAbort(context, requestedSessionId, pointer);
+    }
+
+    const existing = pointer.status === 'usable' ? pointer.state : undefined;
+    if (existing && !isStartCompatible(existing, requestedSessionId)) {
+      throw ownerConflictAbort(context, requestedSessionId, existing);
+    }
+
+    const canonicalSessionId = existing?.session_id ?? requestedSessionId;
+    const pid = resolvePid(options);
+    const platform = options.platform ?? process.platform;
+    const ownerCandidate = verifiedOwnerCandidate(context, options);
+    let ownerOmxSessionId: string | undefined;
+    try {
+      ownerOmxSessionId = mergeOwnerAlias(
+        existing,
+        ownerCandidate,
+        ownerCandidate !== undefined,
+      );
+    } catch (error) {
+      throw ownerConflictAbort(context, requestedSessionId, existing ?? {
+        session_id: canonicalSessionId,
+        started_at: '',
+        cwd: context.cwd,
+        pid,
+      }, error);
+    }
+
+    return createSessionState(context.cwd, canonicalSessionId, pid, platform, sessionIdentityFor(pid, platform), {
+      nativeSessionId: options.nativeSessionId ?? existing?.native_session_id,
+      previousNativeSessionId: options.previousNativeSessionId ?? existing?.previous_native_session_id,
+      nativeSessionSwitchedAt: options.nativeSessionSwitchedAt ?? existing?.native_session_switched_at,
+      ...(ownerOmxSessionId ? { ownerOmxSessionId } : {}),
+      tmuxSessionName: options.tmuxSessionName ?? existing?.tmux_session_name,
+      tmuxPaneId: options.tmuxPaneId ?? existing?.tmux_pane_id,
+    });
+  };
+}
+
+/** Write or merge a wrapper-owned canonical pointer through the exact-root transaction. */
 export async function writeSessionStart(
   cwd: string,
   sessionId: string,
   options: SessionStartOptions = {},
 ): Promise<SessionState> {
-  const stateDir = omxStateDir(cwd);
-  await mkdir(stateDir, { recursive: true });
-  const existing = await readSessionState(cwd);
-  const sameSession = existing?.session_id === sessionId;
-  const pid = Number.isInteger(options.pid) && options.pid && options.pid > 0
-    ? options.pid
-    : process.pid;
-  const platform = options.platform ?? process.platform;
-  const linuxIdentity = platform === 'linux'
-    ? readLinuxProcessIdentity(pid)
-    : null;
-  const state = createSessionState(cwd, sessionId, pid, platform, linuxIdentity, {
-    nativeSessionId: options.nativeSessionId ?? (sameSession ? existing?.native_session_id : undefined),
-    previousNativeSessionId: options.previousNativeSessionId ?? (sameSession ? existing?.previous_native_session_id : undefined),
-    nativeSessionSwitchedAt: options.nativeSessionSwitchedAt ?? (sameSession ? existing?.native_session_switched_at : undefined),
-    ownerOmxSessionId: options.ownerOmxSessionId ?? (sameSession ? existing?.owner_omx_session_id : undefined),
-    tmuxSessionName: options.tmuxSessionName ?? (sameSession ? existing?.tmux_session_name : undefined),
-    tmuxPaneId: options.tmuxPaneId ?? (sameSession ? existing?.tmux_pane_id : undefined),
-  });
-
-  await writeFile(sessionPath(cwd), JSON.stringify(state, null, 2));
-  await appendToLog(cwd, {
+  const requestedSessionId = normalizeSessionId(sessionId);
+  const result = await writePointerTransaction(
+    cwd,
+    requestedSessionId,
+    options,
+    DEFAULT_POINTER_TIMEOUT_MS,
+    startPointerTransition(requestedSessionId ?? sessionId, options),
+    (state) => state,
+  );
+  await appendToLogAtContext(result.context, {
     event: 'session_start',
-    session_id: sessionId,
-    ...(state.native_session_id ? { native_session_id: state.native_session_id } : {}),
-    pid,
-    timestamp: state.started_at,
-  });
-  return state;
+    session_id: result.value.session_id,
+    ...(result.value.native_session_id ? { native_session_id: result.value.native_session_id } : {}),
+    pid: result.value.pid,
+    timestamp: result.value.started_at,
+  }).catch(() => {});
+  return result.value;
 }
 
-function getOmxLaunchSessionId(state: SessionState): string | undefined {
-  if (state.session_id.startsWith('omx-')) return state.session_id;
-  if (typeof state.owner_omx_session_id === 'string' && state.owner_omx_session_id.startsWith('omx-')) {
-    return state.owner_omx_session_id;
-  }
-  return undefined;
+interface NativeReconcileTransition {
+  state: SessionState;
+  replacementLog?: Record<string, unknown>;
+}
+
+function reconcileNativeTransition(
+  nativeSessionId: string,
+  options: SessionStartOptions,
+): (pointer: SessionPointerReadResult, context: SessionPointerContext) => NativeReconcileTransition {
+  return (pointer, context) => {
+    if (pointer.status !== 'absent' && pointer.status !== 'stale-dead' && pointer.status !== 'usable') {
+      throw unusablePointerAbort(context, nativeSessionId, pointer);
+    }
+
+    const pid = resolvePid(options);
+    const platform = options.platform ?? process.platform;
+    const linuxIdentity = sessionIdentityFor(pid, platform);
+    const existing = pointer.status === 'usable' ? pointer.state : undefined;
+    const nowIso = new Date().toISOString();
+
+    if (!existing) {
+      const ownerCandidate = verifiedOwnerCandidate(context, options);
+      const ownerOmxSessionId = ownerCandidate;
+      return {
+        state: createSessionState(context.cwd, nativeSessionId, pid, platform, linuxIdentity, {
+          nativeSessionId,
+          ...(ownerOmxSessionId ? { ownerOmxSessionId } : {}),
+        }),
+      };
+    }
+
+    const existingNativeSessionId = normalizeSessionId(existing.native_session_id);
+    if (existingNativeSessionId && existingNativeSessionId !== nativeSessionId) {
+      const ownerOmxSessionId = getOmxLaunchSessionId(existing);
+      return {
+        state: createSessionState(context.cwd, nativeSessionId, pid, platform, linuxIdentity, {
+          nativeSessionId,
+          ...(ownerOmxSessionId ? {
+            previousNativeSessionId: existingNativeSessionId,
+            nativeSessionSwitchedAt: nowIso,
+            ownerOmxSessionId,
+          } : {}),
+        }),
+        ...(ownerOmxSessionId ? {
+          replacementLog: {
+            event: 'native_session_replaced',
+            session_id: ownerOmxSessionId,
+            ...(existing.session_id !== ownerOmxSessionId ? { active_session_id: existing.session_id } : {}),
+            previous_native_session_id: existingNativeSessionId,
+            replaced_by_native_session_id: nativeSessionId,
+            pid,
+            timestamp: nowIso,
+          },
+        } : {}),
+      };
+    }
+
+    const ownerCandidate = verifiedOwnerCandidate(context, options);
+    let ownerOmxSessionId: string | undefined;
+    try {
+      ownerOmxSessionId = mergeOwnerAlias(
+        existing,
+        ownerCandidate,
+        ownerCandidate !== undefined,
+      );
+    } catch (error) {
+      throw ownerConflictAbort(context, nativeSessionId, existing, error);
+    }
+
+    return {
+      state: createSessionState(context.cwd, existing.session_id, pid, platform, linuxIdentity, {
+        nowIso,
+        nativeSessionId,
+        previousNativeSessionId: existing.previous_native_session_id,
+        nativeSessionSwitchedAt: existing.native_session_switched_at,
+        ...(ownerOmxSessionId ? { ownerOmxSessionId } : {}),
+        startedAt: existing.started_at,
+        tmuxSessionName: existing.tmux_session_name,
+        tmuxPaneId: existing.tmux_pane_id,
+      }),
+    };
+  };
 }
 
 /**
- * Reconcile a native/Codex SessionStart with the canonical OMX launch session.
- * Same-native restarts preserve the current logical session and refresh
- * PID/native metadata. Native-session replacements start a fresh native-scoped
- * session to avoid inheriting stale task-scoped state; when the replaced session
- * belongs to an OMX launch wrapper, retain that wrapper as owner for later
- * archive/cleanup and log the replacement chain.
+ * Reconcile a native SessionStart without borrowing another root's pointer.
+ * A different native ID retains the existing OMX owner chain, but never binds a
+ * new owner alias during that replacement transition.
  */
 export async function reconcileNativeSessionStart(
   cwd: string,
   nativeSessionId: string,
   options: SessionStartOptions = {},
 ): Promise<SessionState> {
-  const existing = await readUsableSessionState(cwd, {
-    ...(options.platform ? { platform: options.platform } : {}),
-  });
-  if (!existing) {
-    return await writeSessionStart(cwd, nativeSessionId, {
-      ...options,
-      nativeSessionId,
+  const normalizedNativeSessionId = normalizeSessionId(nativeSessionId);
+  const result = await writePointerTransaction(
+    cwd,
+    normalizedNativeSessionId,
+    options,
+    NATIVE_POINTER_TIMEOUT_MS,
+    reconcileNativeTransition(normalizedNativeSessionId ?? nativeSessionId, options),
+    (transition) => transition.state,
+  );
+  if (result.value.replacementLog) {
+    await appendToLogAtContext(result.context, result.value.replacementLog).catch(() => {});
+  }
+  await appendToLogAtContext(result.context, {
+    event: result.value.replacementLog ? 'session_start' : 'session_start_reconciled',
+    session_id: result.value.state.session_id,
+    native_session_id: normalizedNativeSessionId ?? nativeSessionId,
+    pid: result.value.state.pid,
+    timestamp: result.value.state.native_session_switched_at ?? new Date().toISOString(),
+  }).catch(() => {});
+  return result.value.state;
+}
+
+function historyDirectory(context: SessionPointerContext): string {
+  return join(dirname(context.baseStateDir), 'logs');
+}
+
+function historyPath(context: SessionPointerContext): string {
+  return join(historyDirectory(context), HISTORY_FILE);
+}
+
+async function removeDeadSessionHudState(
+  context: SessionPointerContext,
+  sessionIds: Array<string | undefined>,
+): Promise<void> {
+  const uniqueSessionIds = [...new Set(sessionIds.filter((value): value is string => Boolean(normalizeSessionId(value))))];
+  const candidatePaths = [
+    join(context.baseStateDir, 'hud-state.json'),
+    ...uniqueSessionIds.map((sessionId) => join(context.baseStateDir, 'sessions', sessionId, 'hud-state.json')),
+  ];
+  await Promise.all(candidatePaths.map(async (path) => {
+    try {
+      await rm(path, { force: true });
+    } catch {
+      // HUD cleanup remains best effort after history has been recorded.
+    }
+  }));
+}
+
+/**
+ * Archive first and remove an owned pointer only after that history write
+ * succeeds. Present unusable pointer evidence is never repaired or archived.
+ */
+export async function writeSessionEnd(
+  cwd: string,
+  sessionId: string,
+  options: Pick<SessionStartOptions, 'context'> = {},
+): Promise<void> {
+  const candidateSessionId = normalizeSessionId(sessionId);
+  let context: SessionPointerContext;
+  try {
+    context = options.context ?? resolveSessionPointerContext(cwd);
+  } catch (error) {
+    throw contextAbort(cwd, candidateSessionId, error);
+  }
+  if (!candidateSessionId) {
+    const cause = new Error('A valid session ID is required to end a session pointer.');
+    throw resolvedAbort(context, {
+      code: 'session_pointer_io_failure',
+      operation: 'pointer-classify',
+      lockPath: context.lockPath,
+      reason: cause.message,
+      cause,
     });
   }
 
-  const existingNativeSessionId = typeof existing.native_session_id === 'string'
-    ? existing.native_session_id.trim()
-    : '';
-  if (existingNativeSessionId && existingNativeSessionId !== nativeSessionId) {
-    const ownerOmxSessionId = getOmxLaunchSessionId(existing);
-    if (ownerOmxSessionId) {
-      const pid = Number.isInteger(options.pid) && options.pid && options.pid > 0
-        ? options.pid
-        : process.pid;
-      const nowIso = new Date().toISOString();
-      await appendToLog(cwd, {
-        event: 'native_session_replaced',
-        session_id: ownerOmxSessionId,
-        ...(existing.session_id !== ownerOmxSessionId ? { active_session_id: existing.session_id } : {}),
-        previous_native_session_id: existingNativeSessionId,
-        replaced_by_native_session_id: nativeSessionId,
-        pid,
-        timestamp: nowIso,
-      });
+  try {
+    await transactionDependencies.fs.mkdir(context.baseStateDir, { recursive: true });
+  } catch (error) {
+    throw resolvedAbort(context, {
+      code: 'session_pointer_io_failure',
+      operation: 'state-dir-create',
+      candidateSessionId,
+      lockPath: context.lockPath,
+      reason: `Unable to create selected session state directory: ${errorMessage(error)}`,
+      cause: error,
+    });
+  }
 
-      return await writeSessionStart(cwd, nativeSessionId, {
-        ...options,
-        nativeSessionId,
-        previousNativeSessionId: existingNativeSessionId,
-        nativeSessionSwitchedAt: nowIso,
-        ownerOmxSessionId,
+  const lock = await acquirePointerLock(
+    context,
+    candidateSessionId,
+    DEFAULT_POINTER_TIMEOUT_MS,
+  );
+  let primary: unknown;
+  try {
+    let pointer: SessionPointerReadResult;
+    try {
+      pointer = await readSessionPointer(context);
+    } catch (error) {
+      throw resolvedAbort(context, {
+        code: 'session_pointer_io_failure',
+        operation: 'pointer-read',
+        candidateSessionId,
+        lockPath: context.lockPath,
+        reason: `Unable to read selected session pointer: ${errorMessage(error)}`,
+        cause: error,
       });
     }
+    if (pointer.status !== 'absent' && pointer.status !== 'usable') {
+      throw unusablePointerAbort(context, candidateSessionId, pointer);
+    }
 
-    return await writeSessionStart(cwd, nativeSessionId, {
-      ...options,
-      nativeSessionId,
-    });
+    const state = pointer.state;
+    const ownsCurrentSessionFile = state == null
+      || state.session_id === candidateSessionId
+      || state.native_session_id === candidateSessionId
+      || state.owner_omx_session_id === candidateSessionId;
+    const endTime = new Date().toISOString();
+    const historyEntry = {
+      session_id: ownsCurrentSessionFile
+        ? (state?.owner_omx_session_id === candidateSessionId ? candidateSessionId : state?.session_id || candidateSessionId)
+        : candidateSessionId,
+      ...(ownsCurrentSessionFile && state?.native_session_id ? { native_session_id: state.native_session_id } : {}),
+      started_at: ownsCurrentSessionFile ? state?.started_at || 'unknown' : 'unknown',
+      ended_at: endTime,
+      cwd: context.cwd,
+      pid: ownsCurrentSessionFile ? state?.pid || process.pid : process.pid,
+      ...(ownsCurrentSessionFile && state?.owner_omx_session_id === candidateSessionId && state?.session_id
+        ? { active_session_id: state.session_id }
+        : {}),
+      ...(!ownsCurrentSessionFile && state?.session_id ? { preserved_active_session_id: state.session_id } : {}),
+    };
+
+    await nodeMkdir(historyDirectory(context), { recursive: true });
+    await appendFile(historyPath(context), `${JSON.stringify(historyEntry)}\n`);
+    await removeDeadSessionHudState(context, [
+      ...(ownsCurrentSessionFile ? [state?.session_id, state?.native_session_id] : []),
+      candidateSessionId,
+    ]);
+    if (ownsCurrentSessionFile) {
+      try {
+        await transactionDependencies.fs.unlink(context.sessionPath);
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
+      }
+    }
+    await appendToLogAtContext(context, {
+      event: 'session_end',
+      session_id: historyEntry.session_id,
+      ...(historyEntry.native_session_id ? { native_session_id: historyEntry.native_session_id } : {}),
+      ...(historyEntry.active_session_id ? { active_session_id: historyEntry.active_session_id } : {}),
+      ...(historyEntry.preserved_active_session_id ? { preserved_active_session_id: historyEntry.preserved_active_session_id } : {}),
+      timestamp: endTime,
+    }).catch(() => {});
+  } catch (error) {
+    primary = error;
   }
 
-  const pid = Number.isInteger(options.pid) && options.pid && options.pid > 0
-    ? options.pid
-    : process.pid;
-  const platform = options.platform ?? process.platform;
-  const linuxIdentity = platform === 'linux'
-    ? readLinuxProcessIdentity(pid)
-    : null;
-  const nowIso = new Date().toISOString();
-  const state = createSessionState(cwd, existing.session_id, pid, platform, linuxIdentity, {
-    nowIso,
-    nativeSessionId,
-    previousNativeSessionId: existing.previous_native_session_id,
-    nativeSessionSwitchedAt: existing.native_session_switched_at,
-    ownerOmxSessionId: existing.owner_omx_session_id,
-    startedAt: existing.started_at,
-    tmuxSessionName: existing.tmux_session_name,
-    tmuxPaneId: existing.tmux_pane_id,
-  });
+  const releaseFailures = await releasePointerLock(lock);
+  if (primary) {
+    if (isSessionPointerLaunchAbort(primary) && releaseFailures.length > 0) {
+      throw recoveryAbort(context, primary as ResolvedSessionPointerAbort, releaseFailures, 'lock-release');
+    }
+    throw primary;
+  }
+  if (releaseFailures.length > 0) throw releaseFailureError(releaseFailures);
+}
 
-  await writeFile(sessionPath(cwd), JSON.stringify(state, null, 2));
-  await appendToLog(cwd, {
-    event: 'session_start_reconciled',
-    session_id: state.session_id,
-    native_session_id: nativeSessionId,
-    pid,
-    timestamp: nowIso,
-  });
-  return state;
+/** Reset session-scoped HUD/metrics files at launch. */
+export async function resetSessionMetrics(cwd: string, sessionId?: string): Promise<void> {
+  const context = resolveSessionPointerContext(cwd);
+  const omxDir = omxRoot(context.cwd);
+  await nodeMkdir(omxDir, { recursive: true });
+  await transactionDependencies.fs.mkdir(context.baseStateDir, { recursive: true });
+
+  const now = new Date().toISOString();
+  await nodeWriteFile(join(omxDir, 'metrics.json'), JSON.stringify({
+    total_turns: 0,
+    session_turns: 0,
+    last_activity: now,
+    session_input_tokens: 0,
+    session_output_tokens: 0,
+    session_total_tokens: 0,
+    five_hour_limit_pct: 0,
+    weekly_limit_pct: 0,
+  }, null, 2));
+
+  const normalizedSessionId = normalizeSessionId(sessionId);
+  const hudStatePath = normalizedSessionId
+    ? join(context.baseStateDir, 'sessions', normalizedSessionId, 'hud-state.json')
+    : join(context.baseStateDir, 'hud-state.json');
+  await nodeMkdir(dirname(hudStatePath), { recursive: true });
+  await nodeWriteFile(hudStatePath, JSON.stringify({
+    last_turn_at: now,
+    last_progress_at: now,
+    turn_count: 0,
+    last_agent_output: '',
+  }, null, 2));
+}
+
+async function appendToLogAtContext(
+  context: SessionPointerContext,
+  entry: Record<string, unknown>,
+): Promise<void> {
+  const logsDir = historyDirectory(context);
+  await nodeMkdir(logsDir, { recursive: true });
+  const logFile = join(logsDir, `omx-${new Date().toISOString().slice(0, 10)}.jsonl`);
+  await appendFile(logFile, `${JSON.stringify({ ...entry, _ts: new Date().toISOString() })}\n`);
 }
 
 /**
- * Write session end: archive to history, delete session.json.
- */
-export async function writeSessionEnd(cwd: string, sessionId: string): Promise<void> {
-  const state = await readSessionState(cwd);
-  const endTime = new Date().toISOString();
-  const ownsCurrentSessionFile = state == null
-    || state.session_id === sessionId
-    || state.native_session_id === sessionId
-    || state.owner_omx_session_id === sessionId;
-
-  // Archive to session history
-  const logsDir = omxLogsDir(cwd);
-  await mkdir(logsDir, { recursive: true });
-
-  const historyEntry = {
-    session_id: ownsCurrentSessionFile
-      ? (state?.owner_omx_session_id === sessionId ? sessionId : state?.session_id || sessionId)
-      : sessionId,
-    ...(ownsCurrentSessionFile && state?.native_session_id ? { native_session_id: state.native_session_id } : {}),
-    started_at: ownsCurrentSessionFile ? state?.started_at || 'unknown' : 'unknown',
-    ended_at: endTime,
-    cwd,
-    pid: ownsCurrentSessionFile ? state?.pid || process.pid : process.pid,
-    ...(ownsCurrentSessionFile && state?.owner_omx_session_id === sessionId && state?.session_id
-      ? { active_session_id: state.session_id }
-      : {}),
-    ...(!ownsCurrentSessionFile && state?.session_id
-      ? { preserved_active_session_id: state.session_id }
-      : {}),
-  };
-
-  await appendFile(historyPath(cwd), JSON.stringify(historyEntry) + '\n');
-
-  await removeDeadSessionHudState(cwd, [
-    ...(ownsCurrentSessionFile ? [state?.session_id, state?.native_session_id] : []),
-    sessionId,
-  ]);
-
-  // Delete session.json only when this end event owns the current pointer.
-  if (ownsCurrentSessionFile) {
-    try {
-      await unlink(sessionPath(cwd));
-    } catch { /* already gone */ }
-  }
-
-  await appendToLog(cwd, {
-    event: 'session_end',
-    session_id: ownsCurrentSessionFile
-      ? (state?.owner_omx_session_id === sessionId ? sessionId : state?.session_id || sessionId)
-      : sessionId,
-    ...(ownsCurrentSessionFile && state?.native_session_id ? { native_session_id: state.native_session_id } : {}),
-    ...(ownsCurrentSessionFile && state?.owner_omx_session_id === sessionId && state?.session_id
-      ? { active_session_id: state.session_id }
-      : {}),
-    ...(!ownsCurrentSessionFile && state?.session_id
-      ? { preserved_active_session_id: state.session_id }
-      : {}),
-    timestamp: endTime,
-  });
-}
-
-/**
- * Append a structured JSONL entry to the daily log file.
+ * Append a root log entry for callers that do not already own a pointer
+ * context. Lifecycle transitions use appendToLogAtContext instead.
  */
 export async function appendToLog(cwd: string, entry: Record<string, unknown>): Promise<void> {
   const logsDir = omxLogsDir(cwd);
-  await mkdir(logsDir, { recursive: true });
-
-  const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-  const logFile = join(logsDir, `omx-${date}.jsonl`);
-  const line = JSON.stringify({ ...entry, _ts: new Date().toISOString() }) + '\n';
-
-  await appendFile(logFile, line);
+  await nodeMkdir(logsDir, { recursive: true });
+  const logFile = join(logsDir, `omx-${new Date().toISOString().slice(0, 10)}.jsonl`);
+  await appendFile(logFile, `${JSON.stringify({ ...entry, _ts: new Date().toISOString() })}\n`);
 }

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'fs/promises';
+
 import { existsSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve as resolvePath } from 'path';
@@ -15,13 +16,17 @@ import {
   readCurrentSessionId,
   resolveRuntimeStateScope,
   resolveStateScope,
+  resolveWritableStateScope,
   resolveWorkingDirectoryForState,
   getStateDir,
   getStateFilePath,
   getStatePath,
+  normalizeSessionId,
   validateStateFileName,
   validateStateModeSegment,
   validateSessionId,
+  WRITABLE_STATE_SCOPE_ERRORS,
+
 } from '../state-paths.js';
 
 
@@ -33,7 +38,10 @@ const isolatedEnvKeys = [
   'OMX_SESSION_ID',
   'CODEX_SESSION_ID',
   'SESSION_ID',
+  'TMUX',
+  'TMUX_PANE',
 ] as const;
+
 const originalEnv = Object.fromEntries(
   isolatedEnvKeys.map((key) => [key, process.env[key]]),
 ) as Record<(typeof isolatedEnvKeys)[number], string | undefined>;
@@ -66,6 +74,14 @@ describe('validateSessionId', () => {
     assert.throws(() => validateSessionId(123), /session_id must be a string/);
   });
 });
+describe('normalizeSessionId', () => {
+  it('normalizes usable values without throwing on unusable input', () => {
+    assert.equal(normalizeSessionId(' sess-normalized '), 'sess-normalized');
+    assert.equal(normalizeSessionId('bad/session'), undefined);
+    assert.equal(normalizeSessionId(123), undefined);
+  });
+});
+
 
 describe('validateStateModeSegment', () => {
   it('accepts safe mode names', () => {
@@ -589,4 +605,104 @@ describe('state paths', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+  describe('writable state scope', () => {
+    it('uses root only when session.json is absent and ignores compatibility-only environment aliases', async () => {
+      const wd = await mkRealTemp('omx-writable-root-');
+      try {
+        process.env.CODEX_SESSION_ID = 'compat-read-session';
+
+        const scope = await resolveWritableStateScope(wd);
+        assert.deepEqual(scope, {
+          source: 'root',
+          stateDir: getBaseStateDir(wd),
+        });
+        assert.equal(existsSync(join(wd, '.omx', 'state')), false);
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
+
+    it('uses a usable canonical session.json scope and rejects a present unusable session.json', async () => {
+      const wd = await mkRealTemp('omx-writable-session-');
+      try {
+        const stateDir = getBaseStateDir(wd);
+        await mkdir(stateDir, { recursive: true });
+        await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+          session_id: 'sess-canonical',
+          cwd: wd,
+        }));
+
+        assert.deepEqual(await resolveWritableStateScope(wd), {
+          source: 'session',
+          sessionId: 'sess-canonical',
+          stateDir: join(stateDir, 'sessions', 'sess-canonical'),
+        });
+
+        await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+          session_id: 'sess-unusable',
+          cwd: join(wd, 'other-worktree'),
+        }));
+        await assert.rejects(
+          () => resolveWritableStateScope(wd),
+          (error: unknown) => {
+            assert.equal((error as Error).message, WRITABLE_STATE_SCOPE_ERRORS.unusableSession);
+            return true;
+          },
+        );
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
+
+    it('fails closed for an unmatched OMX_SESSION_ID while preserving explicit fork scope', async () => {
+      const wd = await mkRealTemp('omx-writable-unmatched-env-');
+      try {
+        const stateDir = getBaseStateDir(wd);
+        await mkdir(stateDir, { recursive: true });
+        await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: 'sess-canonical', cwd: wd }));
+        process.env.OMX_SESSION_ID = 'sess-unmatched';
+
+        await assert.rejects(
+          () => resolveWritableStateScope(wd),
+          (error: unknown) => {
+            assert.equal((error as Error).message, WRITABLE_STATE_SCOPE_ERRORS.unboundEnvironment);
+            return true;
+          },
+        );
+        assert.equal(existsSync(join(stateDir, 'sessions', 'sess-unmatched')), false);
+
+        assert.deepEqual(await resolveWritableStateScope(wd, 'explicit-fork'), {
+          source: 'explicit',
+          sessionId: 'explicit-fork',
+          stateDir: join(stateDir, 'sessions', 'explicit-fork'),
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
+
+    it('maps a persisted OMX owner alias to the canonical writable session without re-proving tmux evidence', async () => {
+      const wd = await mkRealTemp('omx-writable-alias-');
+      try {
+        const stateDir = getBaseStateDir(wd);
+        await mkdir(stateDir, { recursive: true });
+        await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+          session_id: 'sess-canonical',
+          native_session_id: 'native-alias',
+          owner_omx_session_id: 'omx-owner-alias',
+          cwd: wd,
+        }));
+        process.env.OMX_SESSION_ID = 'omx-owner-alias';
+
+        assert.deepEqual(await resolveWritableStateScope(wd), {
+          source: 'session',
+          sessionId: 'sess-canonical',
+          stateDir: join(stateDir, 'sessions', 'sess-canonical'),
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
+  });
+
 });

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -15,6 +15,13 @@ const WORKDIR_ALLOWLIST_ENV = 'OMX_MCP_WORKDIR_ROOTS';
 const OMX_ROOT_ENV = 'OMX_ROOT';
 const OMX_STATE_ROOT_ENV = 'OMX_STATE_ROOT';
 const OMX_TEAM_STATE_ROOT_ENV = 'OMX_TEAM_STATE_ROOT';
+const OMX_SESSION_ID_ENV = 'OMX_SESSION_ID';
+
+export const WRITABLE_STATE_SCOPE_ERRORS = {
+  unusableSession: 'Cannot resolve writable state scope: session.json is present but unusable.',
+  unboundEnvironment: 'Cannot resolve writable state scope: OMX_SESSION_ID is not bound to session.json.',
+} as const;
+
 
 export type StateRootSource = 'team-env' | 'omx-root-env' | 'omx-state-root-env' | 'cwd-default';
 export type SessionScopeSource = 'explicit' | 'env' | 'session-json' | 'native-alias' | 'root';
@@ -54,6 +61,12 @@ export interface ModeStateFileRef {
   scope: StateFileScope;
 }
 
+export function normalizeSessionId(sessionId: unknown): string | undefined {
+  if (typeof sessionId !== 'string') return undefined;
+  const normalized = sessionId.trim();
+  return SESSION_ID_PATTERN.test(normalized) ? normalized : undefined;
+}
+
 export function validateSessionId(sessionId: unknown): string | undefined {
   if (sessionId == null) return undefined;
   if (typeof sessionId !== 'string') {
@@ -64,6 +77,7 @@ export function validateSessionId(sessionId: unknown): string | undefined {
   }
   return sessionId;
 }
+
 
 export function validateStateModeSegment(mode: unknown): string {
   if (typeof mode !== 'string') {
@@ -270,15 +284,14 @@ export interface ResolvedStateScope {
 }
 
 function readSessionIdFromEnvironment(env: NodeJS.ProcessEnv = process.env): string | undefined {
-  const candidates = [env.OMX_SESSION_ID, env.CODEX_SESSION_ID, env.SESSION_ID];
+  const candidates = [env[OMX_SESSION_ID_ENV], env.CODEX_SESSION_ID, env.SESSION_ID];
   for (const candidate of candidates) {
-    if (typeof candidate !== 'string') continue;
-    const trimmed = candidate.trim();
-    if (!trimmed) continue;
-    return validateSessionId(trimmed);
+    const sessionId = normalizeSessionId(candidate);
+    if (sessionId) return sessionId;
   }
   return undefined;
 }
+
 
 function resolveCanonicalSessionId(candidate: string | undefined, metadata: ResolvedSessionMetadata | undefined): string | undefined {
   if (!candidate) return undefined;
@@ -304,32 +317,46 @@ async function readUsableSessionStateFromBaseStateDir(
   }
 }
 function normalizeSessionMetadata(state: SessionState | null, sourcePath?: string): ResolvedSessionMetadata | undefined {
-  if (!state?.session_id) return undefined;
+  const sessionId = normalizeSessionId(state?.session_id);
+  if (!state || !sessionId) return undefined;
   const raw = state as SessionState & Record<string, unknown>;
-  const nativeSessionId = typeof state.native_session_id === 'string' && state.native_session_id.trim()
-    ? state.native_session_id.trim()
-    : undefined;
+  const nativeSessionId = normalizeSessionId(state.native_session_id);
   const nativeSessionAliases = [...new Set([
     raw.native_session_id,
     raw.codex_session_id,
     raw.previous_native_session_id,
   ]
-    .filter((value): value is string => typeof value === 'string' && value.trim() !== '')
-    .map((value) => value.trim()))];
+    .map(normalizeSessionId)
+    .filter((value): value is string => Boolean(value)))];
+  const ownerOmxSessionId = normalizeSessionId(raw.owner_omx_session_id);
+  const ownerCodexSessionId = normalizeSessionId(raw.owner_codex_session_id);
+  const ownerCodexThreadId = typeof raw.owner_codex_thread_id === 'string' && raw.owner_codex_thread_id.trim()
+    ? raw.owner_codex_thread_id.trim()
+    : undefined;
+  const leaderPaneId = typeof raw.tmux_pane_id === 'string' && raw.tmux_pane_id.trim()
+    ? raw.tmux_pane_id.trim()
+    : undefined;
+  const tmuxSessionName = typeof raw.tmux_session_name === 'string' && raw.tmux_session_name.trim()
+    ? raw.tmux_session_name.trim()
+    : undefined;
+  const displayName = typeof raw.display_name === 'string' && raw.display_name.trim()
+    ? raw.display_name.trim()
+    : undefined;
   return {
-    sessionId: state.session_id,
+    sessionId,
     ...(nativeSessionId ? { nativeSessionId } : {}),
     nativeSessionAliases,
-    ...(typeof raw.owner_omx_session_id === 'string' && raw.owner_omx_session_id.trim() ? { ownerOmxSessionId: raw.owner_omx_session_id.trim() } : {}),
-    ...(typeof raw.owner_codex_session_id === 'string' && raw.owner_codex_session_id.trim() ? { ownerCodexSessionId: raw.owner_codex_session_id.trim() } : {}),
-    ...(typeof raw.owner_codex_thread_id === 'string' && raw.owner_codex_thread_id.trim() ? { ownerCodexThreadId: raw.owner_codex_thread_id.trim() } : {}),
-    ...(typeof raw.tmux_pane_id === 'string' && raw.tmux_pane_id.trim() ? { leaderPaneId: raw.tmux_pane_id.trim() } : {}),
-    ...(typeof raw.tmux_session_name === 'string' && raw.tmux_session_name.trim() ? { tmuxSessionName: raw.tmux_session_name.trim() } : {}),
-    ...(typeof raw.display_name === 'string' && raw.display_name.trim() ? { displayName: raw.display_name.trim() } : {}),
+    ...(ownerOmxSessionId ? { ownerOmxSessionId } : {}),
+    ...(ownerCodexSessionId ? { ownerCodexSessionId } : {}),
+    ...(ownerCodexThreadId ? { ownerCodexThreadId } : {}),
+    ...(leaderPaneId ? { leaderPaneId } : {}),
+    ...(tmuxSessionName ? { tmuxSessionName } : {}),
+    ...(displayName ? { displayName } : {}),
     raw: state,
     ...(sourcePath ? { sourcePath } : {}),
   };
 }
+
 
 async function readSessionMetadataFromBaseStateDir(
   cwd: string,
@@ -355,6 +382,70 @@ export async function readCurrentSessionId(workingDirectory?: string): Promise<s
   }
 
   return (await readUsableSessionState(cwd))?.session_id;
+}
+
+function isKnownSessionAlias(sessionId: string, metadata: ResolvedSessionMetadata): boolean {
+  return metadata.nativeSessionAliases.includes(sessionId)
+    || metadata.ownerOmxSessionId === sessionId
+    || metadata.ownerCodexSessionId === sessionId;
+}
+
+
+/**
+ * Writable scope precedence:
+ * - explicit session_id preserves explicit fork writes;
+ * - a usable session.json supplies the only implicit session scope;
+ * - OMX_SESSION_ID may bind a known alias only when the live tmux pane proves
+ *   the canonical session tag;
+ * - root writes are allowed only when session.json is absent.
+ */
+export async function resolveWritableStateScope(
+  workingDirectory?: string,
+  explicitSessionId?: string,
+): Promise<ResolvedStateScope> {
+  const cwd = resolveWorkingDirectoryForState(workingDirectory);
+  const baseStateDir = getBaseStateDir(cwd);
+  const metadata = await readSessionMetadataFromBaseStateDir(cwd, baseStateDir);
+  const validatedExplicit = validateSessionId(explicitSessionId);
+  if (validatedExplicit) {
+    const sessionId = resolveCanonicalSessionId(validatedExplicit, metadata) ?? validatedExplicit;
+    return {
+      source: 'explicit',
+      sessionId,
+      stateDir: join(baseStateDir, 'sessions', sessionId),
+    };
+  }
+
+  if (!metadata) {
+    if (existsSync(join(baseStateDir, 'session.json'))) {
+      throw new Error(WRITABLE_STATE_SCOPE_ERRORS.unusableSession);
+    }
+    if (normalizeSessionId(process.env[OMX_SESSION_ID_ENV])) {
+      throw new Error(WRITABLE_STATE_SCOPE_ERRORS.unboundEnvironment);
+    }
+    return {
+      source: 'root',
+      stateDir: baseStateDir,
+    };
+  }
+
+  const envSessionId = normalizeSessionId(process.env[OMX_SESSION_ID_ENV]);
+  if (!envSessionId || envSessionId === metadata.sessionId) {
+    return {
+      source: 'session',
+      sessionId: metadata.sessionId,
+      stateDir: join(baseStateDir, 'sessions', metadata.sessionId),
+    };
+  }
+
+  if (!isKnownSessionAlias(envSessionId, metadata)) {
+    throw new Error(WRITABLE_STATE_SCOPE_ERRORS.unboundEnvironment);
+  }
+  return {
+    source: 'session',
+    sessionId: metadata.sessionId,
+    stateDir: join(baseStateDir, 'sessions', metadata.sessionId),
+  };
 }
 
 export async function resolveStateScope(

--- a/src/modes/__tests__/base-session-scope.test.ts
+++ b/src/modes/__tests__/base-session-scope.test.ts
@@ -4,7 +4,8 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { readModeState, startMode, updateModeState } from '../base.js';
+import { assertModeStartAllowed, readModeState, startMode, updateModeState } from '../base.js';
+
 
 describe('modes/base session-scoped persistence', () => {
   it('writes mode state into the current session scope when session.json exists', async () => {
@@ -159,4 +160,55 @@ describe('modes/base session-scoped persistence', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+  it('fails closed before mode assertion or start can create an unmatched OMX_SESSION_ID scope', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-unmatched-session-'));
+    const previousSessionId = process.env.OMX_SESSION_ID;
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: 'sess-canonical', cwd: wd }));
+      process.env.OMX_SESSION_ID = 'sess-unmatched';
+
+      await assert.rejects(() => assertModeStartAllowed('ralplan', wd), /OMX_SESSION_ID is not bound to session\.json/);
+      await assert.rejects(() => startMode('ralplan', 'must not write', 5, wd), /OMX_SESSION_ID is not bound to session\.json/);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-unmatched')), false);
+      assert.equal(existsSync(join(stateDir, 'ralplan-state.json')), false);
+    } finally {
+      if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves explicit fork updates when the implicit OMX_SESSION_ID is unmatched', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-mode-explicit-fork-'));
+    const previousSessionId = process.env.OMX_SESSION_ID;
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const forkSessionId = 'explicit-fork';
+      const forkStatePath = join(stateDir, 'sessions', forkSessionId, 'ralplan-state.json');
+      await mkdir(join(stateDir, 'sessions', forkSessionId), { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: 'sess-canonical', cwd: wd }));
+      await writeFile(forkStatePath, JSON.stringify({
+        active: true,
+        mode: 'ralplan',
+        iteration: 0,
+        max_iterations: 5,
+        current_phase: 'starting',
+      }));
+      process.env.OMX_SESSION_ID = 'sess-unmatched';
+
+      await updateModeState('ralplan', { current_phase: 'planning', iteration: 1 }, wd, forkSessionId);
+
+      const updated = JSON.parse(await readFile(forkStatePath, 'utf-8')) as Record<string, unknown>;
+      assert.equal(updated.current_phase, 'planning');
+      assert.equal(updated.iteration, 1);
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-unmatched')), false);
+    } finally {
+      if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -26,9 +26,10 @@ import {
   getReadScopedStateDirs,
   getReadScopedStatePaths,
   getStatePath,
-  resolveStateScope,
+  resolveWritableStateScope,
 } from '../mcp/state-paths.js';
 import { completeRalplanSession, validateRalplanTerminalConsensus } from '../state/operations.js';
+
 
 export interface ModeState {
   active: boolean;
@@ -144,7 +145,8 @@ export async function assertModeStartAllowed(
   projectRoot?: string,
 ): Promise<void> {
   if (!isTrackedWorkflowMode(mode)) return;
-  const scope = await resolveStateScope(projectRoot);
+  const scope = await resolveWritableStateScope(projectRoot);
+
   const activeModes = await readActiveWorkflowModes(projectRoot ?? process.cwd(), scope.sessionId);
   assertWorkflowTransitionAllowed(activeModes, mode, 'start');
 }
@@ -158,10 +160,10 @@ export async function startMode(
   maxIterations: number = 50,
   projectRoot?: string
 ): Promise<ModeState> {
+  const scope = await resolveWritableStateScope(projectRoot);
   const dir = stateDir(projectRoot);
   await mkdir(dir, { recursive: true });
 
-  const scope = await resolveStateScope(projectRoot);
   const baseStateDir = getBaseStateDir(projectRoot);
   let transitionMessage: string | undefined;
   if (isTrackedWorkflowMode(mode)) {
@@ -280,7 +282,7 @@ export async function updateModeState(
   explicitSessionId?: string,
   options: UpdateModeStateOptions = {},
 ): Promise<ModeState> {
-  const scope = await resolveStateScope(projectRoot, explicitSessionId);
+  const scope = await resolveWritableStateScope(projectRoot, explicitSessionId);
   const baseStateDir = getBaseStateDir(projectRoot);
   const current = mode === 'ralph' && scope.sessionId
     ? await readModeStateForActiveDecision(mode, scope.sessionId, projectRoot)
@@ -372,7 +374,7 @@ export async function updateModeState(
       cwd,
       baseStateDir,
       state: updated as Record<string, unknown>,
-      explicitSessionId: scope.sessionId,
+      explicitSessionId,
     });
     if (!ralplanCompletionHandled) {
       await syncCanonicalSkillStateForMode({

--- a/src/notifications/__tests__/session-idle-tail-dedupe.test.ts
+++ b/src/notifications/__tests__/session-idle-tail-dedupe.test.ts
@@ -1,99 +1,215 @@
-import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
-const ENV_KEYS = [
-  'CODEX_HOME',
-  'OMX_NOTIFY_TEMP',
-  'OMX_NOTIFY_TEMP_CONTRACT',
-  'OMX_NOTIFY_PROFILE',
-  'OMX_DISCORD_WEBHOOK_URL',
-  'OMX_OPENCLAW',
-] as const;
+const NOTIFICATION_RECEIPT_CHILD = String.raw`
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-function clearEnv(): void {
-  for (const key of ENV_KEYS) delete process.env[key];
+const [mode, notificationModulePath] = process.argv.slice(1);
+const root = process.env.OMX_NOTIFICATION_RECEIPT_ROOT;
+const codexHome = process.env.CODEX_HOME;
+if ((mode !== 'suppressed' && mode !== 'default') || !root || !codexHome || !notificationModulePath) {
+  throw new Error('invalid notification receipt child invocation');
 }
 
-describe('session-idle tmux tail dedupe integration', () => {
-  let notifyLifecycle: typeof import('../index.js').notifyLifecycle;
-  let tempCodexHome = '';
-  let projectPath = '';
-  let originalFetch: typeof globalThis.fetch | undefined;
-  const capturedBodies: Array<Record<string, unknown>> = [];
+const projectPath = join(root, 'project');
+await mkdir(codexHome, { recursive: true });
+await mkdir(projectPath, { recursive: true });
+await writeFile(join(codexHome, '.omx-config.json'), JSON.stringify({
+  notifications: {
+    enabled: true,
+    telegram: {
+      enabled: true,
+      botToken: '123456:receipt-test-token',
+      chatId: 'receipt-test-chat',
+    },
+  },
+}, null, 2));
 
-  beforeEach(async () => {
-    clearEnv();
-    const root = await mkdtemp(join(tmpdir(), 'omx-session-idle-tail-'));
-    tempCodexHome = join(root, '.codex');
-    projectPath = join(root, 'project');
-    await mkdir(tempCodexHome, { recursive: true });
-    await mkdir(projectPath, { recursive: true });
-    await writeFile(join(tempCodexHome, '.omx-config.json'), JSON.stringify({
-      notifications: {
-        enabled: true,
-        events: {
-          'session-idle': {
-            enabled: true,
-            webhook: { enabled: true, url: 'https://example.com/webhook' },
-          },
+const deliveries = [];
+globalThis.fetch = async (_url, init) => {
+  deliveries.push(JSON.parse(String(init?.body || '{}')));
+  return new Response(JSON.stringify({
+    ok: true,
+    result: { message_id: 'message-' + deliveries.length },
+  }), { status: 200, headers: { 'content-type': 'application/json' } });
+};
+
+const { notifyLifecycle } = await import(pathToFileURL(notificationModulePath).href);
+const persistScopedReceipts = mode === 'default';
+const lifecycleSessionId = 'receipt-lifecycle';
+const idleSessionId = 'receipt-idle';
+const lifecyclePath = join(
+  projectPath,
+  '.omx',
+  'state',
+  'sessions',
+  lifecycleSessionId,
+  'lifecycle-notif-state.json',
+);
+const idleStatePath = join(
+  projectPath,
+  '.omx',
+  'state',
+  'sessions',
+  idleSessionId,
+  'idle-notif-cooldown.json',
+);
+const idleLifecyclePath = join(
+  projectPath,
+  '.omx',
+  'state',
+  'sessions',
+  idleSessionId,
+  'lifecycle-notif-state.json',
+);
+const registryPath = join(process.env.HOME, '.omx', 'state', 'reply-session-registry.jsonl');
+const registryLockPath = join(process.env.HOME, '.omx', 'state', 'reply-session-registry.lock');
+
+const firstLifecycle = await notifyLifecycle('session-start', {
+  sessionId: lifecycleSessionId,
+  projectPath,
+}, undefined, { persistScopedReceipts });
+const secondLifecycle = await notifyLifecycle('session-start', {
+  sessionId: lifecycleSessionId,
+  projectPath,
+}, undefined, { persistScopedReceipts });
+const lifecycleDeliveryCount = deliveries.length;
+const idleMessageId = 'message-' + (lifecycleDeliveryCount + 1);
+const idleResult = await notifyLifecycle('session-idle', {
+  sessionId: idleSessionId,
+  projectPath,
+  tmuxPaneId: '%receipt-pane',
+  tmuxSession: 'receipt-session',
+  tmuxTail: 'fresh receipt tail',
+}, undefined, { persistScopedReceipts });
+const registryContents = existsSync(registryPath)
+  ? await readFile(registryPath, 'utf-8')
+  : '';
+
+process.stdout.write(JSON.stringify({
+  schema: 'omx.notification-receipt-child.v1',
+  mode,
+  lifecycle: {
+    firstSuccess: firstLifecycle?.anySuccess === true,
+    secondSuccess: secondLifecycle?.anySuccess === true,
+    deliveryCount: lifecycleDeliveryCount,
+    secondResultCount: secondLifecycle?.results.length ?? -1,
+    receiptExists: existsSync(lifecyclePath),
+  },
+  idle: {
+    success: idleResult?.anySuccess === true,
+    deliveryCount: deliveries.length - lifecycleDeliveryCount,
+    hasMessageId: idleResult?.results.some((result) => result.messageId === idleMessageId) === true,
+    receiptExists: existsSync(idleStatePath),
+    lifecycleReceiptExists: existsSync(idleLifecyclePath),
+    registryExists: existsSync(registryPath),
+    registryLockExists: existsSync(registryLockPath),
+    registryHasMapping: registryContents.includes(idleMessageId) && registryContents.includes(idleSessionId),
+  },
+}) + '\n');
+`;
+
+interface ReceiptChildResult {
+  schema: string;
+  mode: 'suppressed' | 'default';
+  lifecycle: {
+    firstSuccess: boolean;
+    secondSuccess: boolean;
+    deliveryCount: number;
+    secondResultCount: number;
+    receiptExists: boolean;
+  };
+  idle: {
+    success: boolean;
+    deliveryCount: number;
+    hasMessageId: boolean;
+    receiptExists: boolean;
+    lifecycleReceiptExists: boolean;
+    registryExists: boolean;
+    registryLockExists: boolean;
+    registryHasMapping: boolean;
+  };
+}
+
+function runNotificationReceiptChild(mode: ReceiptChildResult['mode']): ReceiptChildResult {
+  const root = mkdtempSync(join(tmpdir(), `omx-notification-receipts-${mode}-`));
+  const notificationModulePath = join(dirname(fileURLToPath(import.meta.url)), '..', 'index.js');
+  const home = join(root, 'home');
+  const codexHome = join(home, '.codex');
+  const project = join(root, 'project');
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      ['--input-type=module', '-e', NOTIFICATION_RECEIPT_CHILD, mode, notificationModulePath],
+      {
+        cwd: root,
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          HOME: home,
+          CODEX_HOME: codexHome,
+          OMX_ROOT: project,
+          OMX_NOTIFICATION_RECEIPT_ROOT: root,
+          OMX_OPENCLAW: '',
+          OMX_NOTIFY_TEMP: '',
+          OMX_NOTIFY_TEMP_CONTRACT: '',
+          OMX_SESSION_ID: '',
+          TMUX: '',
+          TMUX_PANE: '',
         },
-        webhook: { enabled: true, url: 'https://example.com/webhook' },
       },
-    }, null, 2));
-    process.env.CODEX_HOME = tempCodexHome;
-    ({ notifyLifecycle } = await import(`../index.js?session-idle-tail-dedupe=${Date.now()}`));
-    originalFetch = globalThis.fetch;
-    capturedBodies.length = 0;
-    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
-      capturedBodies.push(JSON.parse(String(init?.body || '{}')));
-      return {
-        ok: true,
-        status: 200,
-      } as Response;
-    }) as typeof globalThis.fetch;
-  });
+    );
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    return JSON.parse(result.stdout) as ReceiptChildResult;
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
 
-  afterEach(async () => {
-    if (originalFetch === undefined) {
-      Reflect.deleteProperty(globalThis, 'fetch');
-    } else {
-      globalThis.fetch = originalFetch;
-    }
-    const root = tempCodexHome ? join(tempCodexHome, '..') : '';
-    clearEnv();
-    if (root) await rm(root, { recursive: true, force: true });
-  });
+describe('notification scoped receipt persistence', () => {
+  it('uses child HOME before import to keep suppressed and default receipt behavior isolated', () => {
+    const suppressed = runNotificationReceiptChild('suppressed');
+    const defaultResult = runNotificationReceiptChild('default');
 
-  it('drops unchanged stale tmux tails from repeated idle notifications but keeps fresh tails', async () => {
-    const base = {
-      sessionId: 'sess-idle-tail',
-      projectPath,
-      projectName: 'project',
-    };
+    assert.equal(suppressed.schema, 'omx.notification-receipt-child.v1');
+    assert.equal(suppressed.mode, 'suppressed');
+    assert.equal(suppressed.lifecycle.firstSuccess, true);
+    assert.equal(suppressed.lifecycle.secondSuccess, true);
+    assert.equal(suppressed.lifecycle.deliveryCount, 2);
+    assert.equal(suppressed.lifecycle.secondResultCount, 1);
+    assert.equal(suppressed.lifecycle.receiptExists, false);
+    assert.equal(suppressed.idle.success, true);
+    assert.equal(suppressed.idle.deliveryCount, 1);
+    assert.equal(suppressed.idle.hasMessageId, true);
+    assert.equal(suppressed.idle.receiptExists, false);
+    assert.equal(suppressed.idle.lifecycleReceiptExists, false);
+    assert.equal(suppressed.idle.registryExists, false);
+    assert.equal(suppressed.idle.registryLockExists, false);
+    assert.equal(suppressed.idle.registryHasMapping, false);
 
-    const staleTail = [
-      'risk summary',
-      '{"severity":"error","message":"old metadata"}',
-      'resolved setup failure',
-    ].join('\n');
-
-    const first = await notifyLifecycle('session-idle', { ...base, tmuxTail: staleTail });
-    assert.equal(first?.anySuccess, true);
-    assert.equal(capturedBodies.length, 1);
-    assert.match(String(capturedBodies[0]?.message || ''), /risk summary/);
-
-    const second = await notifyLifecycle('session-idle', { ...base, tmuxTail: staleTail });
-    assert.equal(second?.anySuccess, true);
-    assert.equal(capturedBodies.length, 2);
-    assert.doesNotMatch(String(capturedBodies[1]?.message || ''), /risk summary/);
-    assert.doesNotMatch(String(capturedBodies[1]?.message || ''), /severity/);
-
-    const third = await notifyLifecycle('session-idle', { ...base, tmuxTail: 'fresh setup error' });
-    assert.equal(third?.anySuccess, true);
-    assert.equal(capturedBodies.length, 3);
-    assert.match(String(capturedBodies[2]?.message || ''), /fresh setup error/);
+    assert.equal(defaultResult.schema, 'omx.notification-receipt-child.v1');
+    assert.equal(defaultResult.mode, 'default');
+    assert.equal(defaultResult.lifecycle.firstSuccess, true);
+    assert.equal(defaultResult.lifecycle.secondSuccess, true);
+    assert.equal(defaultResult.lifecycle.deliveryCount, 1);
+    assert.equal(defaultResult.lifecycle.secondResultCount, 0);
+    assert.equal(defaultResult.lifecycle.receiptExists, true);
+    assert.equal(defaultResult.idle.success, true);
+    assert.equal(defaultResult.idle.deliveryCount, 1);
+    assert.equal(defaultResult.idle.hasMessageId, true);
+    assert.equal(defaultResult.idle.receiptExists, true);
+    assert.equal(defaultResult.idle.lifecycleReceiptExists, false);
+    assert.equal(defaultResult.idle.registryExists, true);
+    assert.equal(defaultResult.idle.registryLockExists, false);
+    assert.equal(defaultResult.idle.registryHasMapping, true);
   });
 });

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -199,10 +199,15 @@ export async function shouldDispatchOpenClaw(
  * Reads config, checks if the event is enabled, formats the message,
  * and dispatches to all configured platforms. Non-blocking, swallows errors.
  */
+interface NotificationLifecycleOptions {
+  persistScopedReceipts?: boolean;
+}
+
 export async function notifyLifecycle(
   event: NotificationEvent,
   data: Partial<FullNotificationPayload> & { sessionId: string },
   profileName?: string,
+  options: NotificationLifecycleOptions = {},
 ): Promise<DispatchResult | null> {
   try {
     const config = getNotificationConfig(profileName);
@@ -325,7 +330,7 @@ export async function notifyLifecycle(
     }
 
     const result = await dispatchNotifications(config, event, payload);
-    if (result.anySuccess) {
+    if (result.anySuccess && options.persistScopedReceipts !== false) {
       recordLifecycleNotificationSent(lifecycleStateDir, payload);
       if (event === "session-idle" && sessionIdleTmuxTailAllowed) {
         recordSessionIdleTmuxTailSent(lifecycleStateDir, payload.sessionId, normalizedIdleTmuxTail);
@@ -336,7 +341,7 @@ export async function notifyLifecycle(
       await dispatchOpenClawLater();
     }
 
-    if (result.anySuccess && payload.tmuxPaneId) {
+    if (result.anySuccess && payload.tmuxPaneId && options.persistScopedReceipts !== false) {
       try {
         const { registerMessage } = await import("./session-registry.js");
         for (const r of result.results) {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -280,6 +280,21 @@ exit 0
 `;
 }
 
+function buildSessionOwnerEvidenceTmux(paneInstanceId: string, sessionInstanceId = ""): string {
+  return `#!/usr/bin/env bash
+set -eu
+case "\${1:-}" in
+display-message) printf '%s\n' "omx-owner-evidence" ;;
+show-option|show-options)
+case "\${@: -1}" in
+@omx_pane_instance_id) printf '%s\n' "${paneInstanceId}" ;;
+@omx_instance_id) printf '%s\n' "${sessionInstanceId}" ;;
+esac
+;;
+esac
+`;
+}
+
 async function initTempGitRepo(prefix: string): Promise<string> {
   const cwd = await mkdtemp(join(tmpdir(), prefix));
   execFileSync("git", ["init"], { cwd, stdio: "ignore" });
@@ -2166,6 +2181,252 @@ PY`,
       assert.equal(existsSync(join(stateDir, "sessions", nativeSessionId, "ralplan-state.json")), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("issue #3138 converges owner-env terminal write and native Stop on one canonical scope", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omx-native-hook-3138-"));
+    const fakeBinDir = join(root, "fake-bin");
+    const tmuxPath = join(fakeBinDir, "tmux");
+    const previousSessionId = process.env.OMX_SESSION_ID;
+    const previousTmux = process.env.TMUX;
+    const previousTmuxPane = process.env.TMUX_PANE;
+    const previousPath = process.env.PATH;
+
+    const setOwnerEvidence = async (instanceId: string, sessionInstanceId = ""): Promise<void> => {
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(tmuxPath, buildSessionOwnerEvidenceTmux(instanceId, sessionInstanceId), "utf-8");
+      await chmod(tmuxPath, 0o755);
+      process.env.TMUX = "/tmp/omx-3138";
+      process.env.TMUX_PANE = "%3138";
+      process.env.PATH = `${fakeBinDir}:${previousPath ?? ""}`;
+    };
+
+    try {
+      const cwd = join(root, "bound");
+      const canonicalSessionId = "native-canonical-3138";
+      const nativeSessionId = "native-canonical-3138";
+      const ownerSessionId = "omx-owner-3138";
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(cwd, { recursive: true });
+      await writeSessionStart(cwd, canonicalSessionId, {
+        nativeSessionId,
+        pid: process.pid,
+        tmuxSessionName: "omx-owner-evidence",
+        tmuxPaneId: "%3138",
+      });
+      process.env.OMX_SESSION_ID = ownerSessionId;
+      await setOwnerEvidence(ownerSessionId, canonicalSessionId);
+
+      const beforeAlias = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: nativeSessionId,
+          thread_id: "thread-owner-3138",
+          turn_id: "turn-before-alias-3138",
+          prompt: "$deep-interview establish canonical scope",
+        },
+        { cwd },
+      );
+      assert.equal(beforeAlias.skillState, null);
+      assert.equal(existsSync(join(stateDir, "sessions", canonicalSessionId, "deep-interview-state.json")), false);
+      assert.equal(existsSync(join(stateDir, "sessions", ownerSessionId, "deep-interview-state.json")), false);
+
+      await dispatchCodexNativeHook(
+        { hook_event_name: "SessionStart", cwd, session_id: nativeSessionId },
+        { cwd, sessionOwnerPid: process.pid },
+      );
+      await dispatchCodexNativeHook(
+        { hook_event_name: "SessionStart", cwd, session_id: nativeSessionId, source: "resume" },
+        { cwd, sessionOwnerPid: process.pid },
+      );
+      const reboundPointer = JSON.parse(await readFile(join(stateDir, "session.json"), "utf-8")) as {
+        session_id?: string;
+        native_session_id?: string;
+        owner_omx_session_id?: string;
+      };
+      assert.equal(reboundPointer.session_id, canonicalSessionId);
+      assert.equal(reboundPointer.native_session_id, nativeSessionId);
+      assert.equal(reboundPointer.owner_omx_session_id, ownerSessionId);
+
+      const afterAlias = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd,
+          session_id: nativeSessionId,
+          thread_id: "thread-owner-3138",
+          turn_id: "turn-after-alias-3138",
+          prompt: "$deep-interview establish canonical scope",
+        },
+        { cwd },
+      );
+      assert.equal(afterAlias.skillState?.session_id, canonicalSessionId);
+      assert.equal(existsSync(join(stateDir, "sessions", canonicalSessionId, "deep-interview-state.json")), true);
+      assert.equal(existsSync(join(stateDir, "sessions", ownerSessionId, "deep-interview-state.json")), false);
+
+      const terminalWrite = await executeStateOperation("state_write", {
+        mode: "deep-interview",
+        active: false,
+        current_phase: "complete",
+        workingDirectory: cwd,
+      });
+      assert.notEqual(terminalWrite.isError, true);
+      assert.equal(
+        (terminalWrite.payload as { path?: string }).path,
+        join(stateDir, "sessions", canonicalSessionId, "deep-interview-state.json"),
+      );
+      assert.equal(existsSync(join(stateDir, "sessions", ownerSessionId, "deep-interview-state.json")), false);
+
+      const stop = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: nativeSessionId, thread_id: "thread-owner-3138" },
+        { cwd },
+      );
+      assert.equal(stop.outputJson, null);
+
+      const replacementCwd = join(root, "replacement");
+      const replacementStateDir = join(replacementCwd, ".omx", "state");
+      const replacementOwner = "omx-prior-3138";
+      const replacementCandidate = "omx-replacement-3138";
+      await mkdir(replacementCwd, { recursive: true });
+      await writeSessionStart(replacementCwd, replacementOwner, {
+        nativeSessionId: "native-before-new-3138",
+        pid: process.pid,
+      });
+      process.env.OMX_SESSION_ID = replacementCandidate;
+      await setOwnerEvidence(replacementCandidate);
+      await dispatchCodexNativeHook(
+        { hook_event_name: "SessionStart", cwd: replacementCwd, session_id: "native-after-new-3138" },
+        { cwd: replacementCwd, sessionOwnerPid: process.pid },
+      );
+      const replacementPointer = JSON.parse(await readFile(join(replacementStateDir, "session.json"), "utf-8")) as {
+        session_id?: string;
+        owner_omx_session_id?: string;
+      };
+      assert.equal(replacementPointer.session_id, "native-after-new-3138");
+      assert.equal(replacementPointer.owner_omx_session_id, replacementOwner);
+      assert.notEqual(replacementPointer.owner_omx_session_id, replacementCandidate);
+
+      const nativeOnlyCwd = join(root, "native-only");
+      await mkdir(nativeOnlyCwd, { recursive: true });
+      delete process.env.OMX_SESSION_ID;
+      await dispatchCodexNativeHook(
+        { hook_event_name: "SessionStart", cwd: nativeOnlyCwd, session_id: "native-only-3138" },
+        { cwd: nativeOnlyCwd, sessionOwnerPid: process.pid },
+      );
+      const nativeOnlyPointer = JSON.parse(
+        await readFile(join(nativeOnlyCwd, ".omx", "state", "session.json"), "utf-8"),
+      ) as { session_id?: string; owner_omx_session_id?: string };
+      assert.equal(nativeOnlyPointer.session_id, "native-only-3138");
+      assert.equal(nativeOnlyPointer.owner_omx_session_id, undefined);
+
+      const conflictingCwd = join(root, "conflicting");
+      const conflictingOwner = "omx-conflicting-3138";
+      await mkdir(conflictingCwd, { recursive: true });
+      await writeSessionStart(conflictingCwd, "native-conflicting-3138", {
+        nativeSessionId: "native-conflicting-3138",
+        pid: process.pid,
+      });
+      process.env.OMX_SESSION_ID = conflictingOwner;
+      await setOwnerEvidence("omx-foreign-3138");
+      await dispatchCodexNativeHook(
+        { hook_event_name: "SessionStart", cwd: conflictingCwd, session_id: "native-conflicting-3138" },
+        { cwd: conflictingCwd, sessionOwnerPid: process.pid },
+      );
+      const conflictingPointer = JSON.parse(
+        await readFile(join(conflictingCwd, ".omx", "state", "session.json"), "utf-8"),
+      ) as { owner_omx_session_id?: string };
+      assert.equal(conflictingPointer.owner_omx_session_id, undefined);
+      const conflictingActivation = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "UserPromptSubmit",
+          cwd: conflictingCwd,
+          session_id: "native-conflicting-3138",
+          prompt: "$deep-interview must not create an owner scope",
+        },
+        { cwd: conflictingCwd },
+      );
+      assert.equal(conflictingActivation.skillState, null);
+
+      const staleCwd = join(root, "stale");
+      const staleStatePath = join(staleCwd, ".omx", "state", "session.json");
+      await writeJson(staleStatePath, {
+        session_id: "native-stale-3138",
+        native_session_id: "native-stale-3138",
+        cwd: staleCwd,
+        started_at: "2026-01-01T00:00:00.000Z",
+        pid: 999_999,
+      });
+      process.env.OMX_SESSION_ID = "omx-stale-3138";
+      await setOwnerEvidence("omx-stale-3138");
+      await dispatchCodexNativeHook(
+        { hook_event_name: "SessionStart", cwd: staleCwd, session_id: "native-stale-3138" },
+        { cwd: staleCwd, sessionOwnerPid: process.pid },
+      );
+      const stalePointer = JSON.parse(await readFile(staleStatePath, "utf-8")) as {
+        session_id?: string;
+        owner_omx_session_id?: string;
+      };
+      assert.equal(stalePointer.session_id, "native-stale-3138");
+      assert.equal(stalePointer.owner_omx_session_id, "omx-stale-3138");
+
+      const foreignCwd = join(root, "foreign");
+      const foreignStatePath = join(foreignCwd, ".omx", "state", "session.json");
+      await writeJson(foreignStatePath, {
+        session_id: "native-foreign-3138",
+        native_session_id: "native-foreign-3138",
+        cwd: join(root, "other-worktree"),
+        started_at: "2026-01-01T00:00:00.000Z",
+        pid: process.pid,
+      });
+      const foreignPointerBefore = await readFile(foreignStatePath, "utf-8");
+      process.env.OMX_SESSION_ID = "omx-foreign-3138";
+      await setOwnerEvidence("omx-foreign-3138");
+      const foreignStart = await dispatchCodexNativeHook(
+        { hook_event_name: "SessionStart", cwd: foreignCwd, session_id: "native-foreign-3138" },
+        { cwd: foreignCwd, sessionOwnerPid: process.pid },
+      );
+      assert.equal(foreignStart.outputJson, null);
+      assert.equal(await readFile(foreignStatePath, "utf-8"), foreignPointerBefore);
+      const foreignPointer = JSON.parse(await readFile(foreignStatePath, "utf-8")) as { owner_omx_session_id?: string };
+      assert.equal(foreignPointer.owner_omx_session_id, undefined);
+      const foreignActivation = await dispatchCodexNativeHook({
+        hook_event_name: "UserPromptSubmit",
+        cwd: foreignCwd,
+        session_id: "native-unmatched-foreign-3138",
+        prompt: "$deep-interview must not escape a foreign pointer",
+      }, { cwd: foreignCwd });
+      assert.equal(foreignActivation.skillState, null);
+      assert.equal(existsSync(join(foreignCwd, ".omx", "state", "sessions", "native-unmatched-foreign-3138")), false);
+      assert.equal(existsSync(join(foreignCwd, ".omx", "state", "skill-active-state.json")), false);
+
+      const foreignStop = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd: foreignCwd,
+        session_id: "native-foreign-3138",
+      }, { cwd: foreignCwd });
+      assert.equal(foreignStop.outputJson?.decision, "block");
+      assert.equal(foreignStop.outputJson?.stopReason, "session_pointer_unusable");
+      assert.equal(existsSync(join(foreignCwd, ".omx", "state", "native-stop-state.json")), false);
+
+      const unmatchedStop = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd: conflictingCwd,
+        session_id: "native-unmatched-stop-3138",
+      }, { cwd: conflictingCwd });
+      assert.equal(unmatchedStop.outputJson?.decision, "block");
+      assert.equal(unmatchedStop.outputJson?.stopReason, "session_scope_unmatched");
+      assert.equal(existsSync(join(conflictingCwd, ".omx", "state", "native-stop-state.json")), false);
+    } finally {
+      if (typeof previousSessionId === "string") process.env.OMX_SESSION_ID = previousSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      if (typeof previousTmux === "string") process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousTmuxPane === "string") process.env.TMUX_PANE = previousTmuxPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof previousPath === "string") process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(root, { recursive: true, force: true });
     }
   });
 
@@ -16896,7 +17157,7 @@ PY`,
     }
   });
 
-  it("blocks Stop from session-scoped team mode when session.json points to another session", async () => {
+  it("fails closed on Stop when a session-scoped team id is not bound to session.json", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-session-mismatch-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -16926,13 +17187,9 @@ PY`,
       );
 
       assert.equal(result.omxEventName, "stop");
-      assert.deepEqual(result.outputJson, {
-        decision: "block",
-        reason:
-          `OMX team pipeline is still active (session-live-team) at phase team-exec; continue coordinating until the team reaches a terminal phase.${TEAM_STOP_COMMIT_GUIDANCE}`,
-        stopReason: "team_team-exec",
-        systemMessage: "OMX team pipeline is still active at phase team-exec.",
-      });
+      assert.equal(result.outputJson?.decision, "block");
+      assert.equal(result.outputJson?.stopReason, "session_scope_unmatched");
+      assert.match(String(result.outputJson?.reason ?? ""), /sess-live-team/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -18828,7 +19085,7 @@ PY`,
     }
   });
 
-  it("blocks Stop from session-scoped Ralph state when session.json points to another session", async () => {
+  it("fails closed on Stop when a session-scoped Ralph id is not bound to session.json", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralph-session-mismatch-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -18850,14 +19107,9 @@ PY`,
       );
 
       assert.equal(result.omxEventName, "stop");
-      assert.deepEqual(result.outputJson, {
-        decision: "block",
-        reason:
-          "OMX Ralph is still active (phase: executing; state: .omx/state/sessions/sess-live-ralph/ralph-state.json); continue the task and gather fresh verification evidence before stopping.",
-        stopReason: "ralph_executing",
-        systemMessage:
-          "OMX Ralph is still active (phase: executing; state: .omx/state/sessions/sess-live-ralph/ralph-state.json); continue the task and gather fresh verification evidence before stopping.",
-      });
+      assert.equal(result.outputJson?.decision, "block");
+      assert.equal(result.outputJson?.stopReason, "session_scope_unmatched");
+      assert.match(String(result.outputJson?.reason ?? ""), /sess-live-ralph/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -18892,7 +19144,7 @@ PY`,
     }
   });
 
-  it("does not block Stop from stale current-session Ralph state when session.json points to a dead owner", async () => {
+  it("fails closed on Stop when session.json points to an identity-indeterminate owner", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-stale-current-session-ralph-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -18935,7 +19187,8 @@ PY`,
       );
 
       assert.equal(result.omxEventName, "stop");
-      assert.equal(result.outputJson, null);
+      assert.equal(result.outputJson?.decision, "block");
+      assert.equal(result.outputJson?.stopReason, "session_pointer_unusable");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -19073,6 +19326,7 @@ PY`,
       await mkdir(join(stateDir, "sessions", canonicalSessionId), { recursive: true });
       await writeJson(join(stateDir, "session.json"), {
         session_id: canonicalSessionId,
+        native_session_id: nativeSessionId,
         cwd,
       });
       await writeJson(join(stateDir, "sessions", nativeSessionId, "ralph-state.json"), {
@@ -19135,6 +19389,7 @@ PY`,
       await mkdir(join(stateDir, "sessions", canonicalSessionId), { recursive: true });
       await writeJson(join(stateDir, "session.json"), {
         session_id: canonicalSessionId,
+        native_session_id: nativeSessionId,
         cwd,
       });
       await writeJson(join(stateDir, "sessions", nativeSessionId, "ralph-state.json"), {
@@ -19554,7 +19809,7 @@ PY`,
     }
   });
 
-  it("does not block Stop from root Ralph fallback when an explicit session_id is present and session.json points to another worktree", async () => {
+  it("fails closed on Stop when session.json points to another worktree", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-root-fallback-cwd-mismatch-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -19578,7 +19833,8 @@ PY`,
       );
 
       assert.equal(result.omxEventName, "stop");
-      assert.equal(result.outputJson, null);
+      assert.equal(result.outputJson?.decision, "block");
+      assert.equal(result.outputJson?.stopReason, "session_pointer_unusable");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/fixtures/issue-3138-installed-smoke.ts
+++ b/src/scripts/__tests__/fixtures/issue-3138-installed-smoke.ts
@@ -1,0 +1,634 @@
+import { spawnSync } from 'node:child_process';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { isAbsolute, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SCHEMA = 'omx.issue3138.installed-smoke.v4';
+const MANDATORY_SCENARIOS = [
+  'missing-owner-alias-activation',
+  'unmatched-write',
+  'ordinary-clear',
+  'cancel',
+  'cancel-force',
+  'owner-terminal-native-stop',
+  'all-sessions-clear',
+  'managed-unmatched-idle-delivery-no-receipts',
+  'rejected-root-no-launch',
+  'managed-unmatched-lifecycle-delivery-no-receipts',
+] as const;
+
+type ScenarioName = typeof MANDATORY_SCENARIOS[number];
+
+interface SmokeArguments {
+  packageRoot: string;
+  testedSha: string;
+  tarballSha256: string;
+}
+
+interface ScenarioResult {
+  name: ScenarioName;
+  pass: boolean;
+}
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) fail(message);
+}
+
+function parseArgs(argv: string[]): SmokeArguments {
+  let packageRoot = '';
+  let testedSha = '';
+  let tarballSha256 = '';
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = argv[index + 1];
+    if (arg === '--package-root') {
+      packageRoot = value || '';
+      index += 1;
+      continue;
+    }
+    if (arg === '--tested-sha') {
+      testedSha = value || '';
+      index += 1;
+      continue;
+    }
+    if (arg === '--tarball-sha256') {
+      tarballSha256 = value || '';
+      index += 1;
+      continue;
+    }
+    fail(`unknown installed smoke argument: ${arg}`);
+  }
+
+  assert(isAbsolute(packageRoot), '--package-root must be an absolute installed package path');
+  assert(/(?:^|[\\/])node_modules[\\/]oh-my-codex$/.test(packageRoot), '--package-root must name the installed oh-my-codex package');
+  assert(/^[0-9a-f]{40}$/i.test(testedSha), '--tested-sha must be a 40-character SHA');
+  assert(/^[0-9a-f]{64}$/i.test(tarballSha256), '--tarball-sha256 must be a SHA-256 digest');
+  assert(existsSync(join(packageRoot, 'package.json')), 'installed package.json is missing');
+  assert(existsSync(join(packageRoot, 'dist', 'cli', 'omx.js')), 'installed CLI is missing');
+  return { packageRoot, testedSha, tarballSha256 };
+}
+
+async function importInstalled<T>(packageRoot: string, relativeModulePath: string): Promise<T> {
+  const modulePath = join(packageRoot, relativeModulePath);
+  assert(existsSync(modulePath), `installed module is missing: ${modulePath}`);
+  return await import(pathToFileURL(modulePath).href) as T;
+}
+
+async function readJson<T>(path: string): Promise<T> {
+  return JSON.parse(await readFile(path, 'utf-8')) as T;
+}
+
+async function withEnvironment<T>(
+  updates: Record<string, string | undefined>,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(updates)) previous.set(key, process.env[key]);
+  try {
+    for (const [key, value] of Object.entries(updates)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    return await run();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+async function withWorkspace<T>(name: string, run: (cwd: string, home: string) => Promise<T>): Promise<T> {
+  const root = await mkdtemp(join(tmpdir(), `omx-issue-3138-${name}-`));
+  const cwd = join(root, 'project');
+  const home = join(root, 'home');
+  await mkdir(cwd, { recursive: true });
+  await mkdir(home, { recursive: true });
+  await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+  await writeFile(join(cwd, '.omx', 'managed'), 'issue #3138 installed smoke fixture');
+  try {
+    return await run(cwd, home);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function writeFakeTmux(binDir: string, instanceId: string): Promise<void> {
+  await mkdir(binDir, { recursive: true });
+  const path = join(binDir, 'tmux');
+  await writeFile(path, `#!/usr/bin/env bash
+set -eu
+case "$*" in
+  *"@omx_pane_instance_id"*) printf '${instanceId}\\n' ;;
+  *"@omx_instance_id"*) printf '${instanceId}\\n' ;;
+  *"display-message"*) printf 'issue-3138-smoke\\n' ;;
+  *"list-sessions"*) printf 'issue-3138-smoke\\t${instanceId}\\n' ;;
+  *) exit 0 ;;
+esac
+`);
+  await chmod(path, 0o755);
+}
+
+function installedCliPath(packageRoot: string): string {
+  return join(packageRoot, 'dist', 'cli', 'omx.js');
+}
+
+function runInstalledCli(
+  packageRoot: string,
+  cwd: string,
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+) {
+  return spawnSync(process.execPath, [installedCliPath(packageRoot), ...args], {
+    cwd,
+    encoding: 'utf-8',
+    env,
+  });
+}
+
+function statePath(cwd: string, sessionId: string, mode: string): string {
+  return join(cwd, '.omx', 'state', 'sessions', sessionId, `${mode}-state.json`);
+}
+
+async function writeCanonicalPointer(
+  packageRoot: string,
+  cwd: string,
+  home: string,
+  canonicalSessionId: string,
+  nativeSessionId: string,
+  ownerSessionId?: string,
+): Promise<void> {
+  const session = await importInstalled<{
+    writeSessionStart: (
+      cwd: string,
+      sessionId: string,
+      options: { nativeSessionId?: string; ownerOmxSessionId?: string },
+    ) => Promise<unknown>;
+  }>(packageRoot, 'dist/hooks/session.js');
+  await withEnvironment(cleanEnv(home, cwd), async () => {
+    await session.writeSessionStart(cwd, canonicalSessionId, {
+      nativeSessionId,
+      ...(ownerSessionId ? { ownerOmxSessionId: ownerSessionId } : {}),
+    });
+  });
+}
+
+async function writeModeState(
+  cwd: string,
+  sessionId: string,
+  mode: string,
+  values: Record<string, unknown>,
+): Promise<void> {
+  const path = statePath(cwd, sessionId, mode);
+  await mkdir(join(cwd, '.omx', 'state', 'sessions', sessionId), { recursive: true });
+  await writeFile(path, JSON.stringify({
+    mode,
+    session_id: sessionId,
+    active: true,
+    current_phase: 'executing',
+    ...values,
+  }, null, 2));
+}
+async function writeRalplanConsensusEvidence(cwd: string, sessionId: string): Promise<Record<string, unknown>> {
+  const now = '2026-07-14T00:00:00.000Z';
+  await writeFile(join(cwd, '.omx', 'state', 'subagent-tracking.json'), JSON.stringify({
+    schemaVersion: 1,
+    sessions: {
+      [sessionId]: {
+        session_id: sessionId,
+        leader_thread_id: 'thread-leader',
+        updated_at: now,
+        threads: {
+          'thread-leader': { thread_id: 'thread-leader', kind: 'leader', first_seen_at: now, last_seen_at: now, turn_count: 1 },
+          'thread-architect': { thread_id: 'thread-architect', kind: 'subagent', first_seen_at: now, last_seen_at: now, completed_at: now, turn_count: 1 },
+          'thread-critic': { thread_id: 'thread-critic', kind: 'subagent', first_seen_at: now, last_seen_at: now, completed_at: now, turn_count: 1 },
+        },
+      },
+    },
+  }, null, 2));
+  return {
+    required: true,
+    complete: true,
+    sequence: ['architect-review', 'critic-review'],
+    planning_artifacts_are_not_consensus: true,
+    required_review_roles: ['architect', 'critic'],
+    ralplan_architect_review: {
+      agent_role: 'architect', verdict: 'approve', provenance_kind: 'native_subagent', session_id: sessionId,
+      thread_id: 'thread-architect', artifact_path: '.omx/artifacts/architect.md', tracker_path: '.omx/state/subagent-tracking.json',
+    },
+    ralplan_critic_review: {
+      agent_role: 'critic', verdict: 'approve', provenance_kind: 'native_subagent', session_id: sessionId,
+      thread_id: 'thread-critic', artifact_path: '.omx/artifacts/critic.md', tracker_path: '.omx/state/subagent-tracking.json',
+    },
+  };
+}
+
+function cleanEnv(home: string, cwd: string, extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    HOME: home,
+    CODEX_HOME: join(home, '.codex'),
+    OMX_ROOT: cwd,
+    OMX_STATE_ROOT: undefined,
+    OMX_TEAM_STATE_ROOT: undefined,
+    OMX_MCP_WORKDIR_ROOTS: undefined,
+    OMX_SESSION_ID: undefined,
+    CODEX_SESSION_ID: undefined,
+    SESSION_ID: undefined,
+    OMX_TEAM_WORKER: '',
+    OMX_TEAM_INTERNAL_WORKER: '',
+    OMX_OPENCLAW: '',
+    OMX_NOTIFY_TEMP: '',
+    OMX_NOTIFY_TEMP_CONTRACT: '',
+    TMUX: '',
+    TMUX_PANE: '',
+    ...extra,
+  };
+}
+
+async function scenarioMissingOwnerAliasActivation(packageRoot: string): Promise<void> {
+  await withWorkspace('missing-owner-alias', async (cwd, home) => {
+    const ownerSessionId = 'omx-owner-alias';
+    const nativeSessionId = 'native-owner-alias';
+    const binDir = join(cwd, 'bin');
+    await writeFakeTmux(binDir, ownerSessionId);
+    await withEnvironment(cleanEnv(home, cwd, {
+      OMX_SESSION_ID: ownerSessionId,
+      TMUX: '/tmp/tmux-1000/default,1,0',
+      TMUX_PANE: '%issue3138-owner-pane',
+      PATH: `${binDir}:${process.env.PATH || ''}`,
+    }), async () => {
+      const native = await importInstalled<{
+        dispatchCodexNativeHook: (payload: Record<string, unknown>, options?: Record<string, unknown>) => Promise<{
+          outputJson: Record<string, unknown> | null;
+        }>;
+      }>(packageRoot, 'dist/scripts/codex-native-hook.js');
+      const start = await native.dispatchCodexNativeHook({
+        hook_event_name: 'SessionStart',
+        session_id: nativeSessionId,
+        cwd,
+      }, { cwd, sessionOwnerPid: process.pid });
+      const pointer = await readJson<Record<string, unknown>>(join(cwd, '.omx', 'state', 'session.json'));
+      const canonicalSessionId = String(pointer.session_id || '');
+      assert(canonicalSessionId.length > 0, 'native SessionStart did not establish a canonical pointer');
+      assert(pointer.owner_omx_session_id === ownerSessionId, 'native SessionStart did not bind the verified owner alias');
+      assert(start.outputJson?.decision !== 'block', 'native SessionStart unexpectedly blocked alias activation');
+
+      const prompt = await native.dispatchCodexNativeHook({
+        hook_event_name: 'UserPromptSubmit',
+        session_id: nativeSessionId,
+        thread_id: 'issue3138-owner-thread',
+        turn_id: 'issue3138-owner-turn',
+        cwd,
+        prompt: '$ralph continue verification',
+      }, { cwd });
+      assert(prompt.outputJson?.decision !== 'block', 'owner alias prompt activation unexpectedly blocked');
+      assert(existsSync(statePath(cwd, canonicalSessionId, 'ralph')), 'owner alias activation did not write canonical Ralph state');
+      assert(!existsSync(join(cwd, '.omx', 'state', 'sessions', ownerSessionId)), 'owner alias activation created a split owner scope');
+    });
+  });
+}
+
+async function scenarioUnmatchedWrite(packageRoot: string): Promise<void> {
+  await withWorkspace('unmatched-write', async (cwd, home) => {
+    const canonicalSessionId = 'omx-canonical-write';
+    const ownerSessionId = 'omx-unmatched-write';
+    await writeCanonicalPointer(packageRoot, cwd, home, canonicalSessionId, 'native-unmatched-write');
+    const result = runInstalledCli(packageRoot, cwd, [
+      'state', 'write', '--input', JSON.stringify({
+        mode: 'ralph', active: true, current_phase: 'executing',
+      }), '--json',
+    ], cleanEnv(home, cwd, { OMX_SESSION_ID: ownerSessionId, TMUX: '', TMUX_PANE: '' }));
+    assert(result.status !== 0, 'unmatched owner state write unexpectedly succeeded');
+    assert(!existsSync(statePath(cwd, canonicalSessionId, 'ralph')), 'unmatched owner state write mutated canonical state');
+    assert(!existsSync(join(cwd, '.omx', 'state', 'sessions', ownerSessionId)), 'unmatched owner state write created an owner scope');
+  });
+}
+
+async function scenarioOrdinaryClear(packageRoot: string): Promise<void> {
+  await withWorkspace('ordinary-clear', async (cwd, home) => {
+    const canonicalSessionId = 'omx-canonical-clear';
+    const ownerSessionId = 'omx-unmatched-clear';
+    await writeCanonicalPointer(packageRoot, cwd, home, canonicalSessionId, 'native-unmatched-clear');
+    await writeModeState(cwd, canonicalSessionId, 'ralph', { current_phase: 'executing' });
+    const before = await readFile(statePath(cwd, canonicalSessionId, 'ralph'), 'utf-8');
+    const result = runInstalledCli(packageRoot, cwd, [
+      'state', 'clear', '--mode', 'ralph', '--json',
+    ], cleanEnv(home, cwd, { OMX_SESSION_ID: ownerSessionId, TMUX: '', TMUX_PANE: '' }));
+    assert(result.status !== 0, 'unmatched owner ordinary clear unexpectedly succeeded');
+    assert(await readFile(statePath(cwd, canonicalSessionId, 'ralph'), 'utf-8') === before, 'unmatched owner ordinary clear mutated canonical state');
+    assert(!existsSync(join(cwd, '.omx', 'state', 'sessions', ownerSessionId)), 'ordinary clear created an owner scope');
+  });
+}
+
+async function scenarioCancel(packageRoot: string): Promise<void> {
+  await withWorkspace('cancel', async (cwd, home) => {
+    const canonicalSessionId = 'omx-canonical-cancel';
+    const ownerSessionId = 'omx-unmatched-cancel';
+    await writeCanonicalPointer(packageRoot, cwd, home, canonicalSessionId, 'native-unmatched-cancel');
+    await writeModeState(cwd, canonicalSessionId, 'ralph', { current_phase: 'executing' });
+    const before = await readFile(statePath(cwd, canonicalSessionId, 'ralph'), 'utf-8');
+    const result = runInstalledCli(packageRoot, cwd, ['cancel'], cleanEnv(home, cwd, {
+      OMX_SESSION_ID: ownerSessionId,
+      TMUX: '',
+      TMUX_PANE: '',
+    }));
+    assert(result.status !== null, 'unmatched owner cancel did not exit');
+    assert(await readFile(statePath(cwd, canonicalSessionId, 'ralph'), 'utf-8') === before, 'unmatched owner cancel mutated canonical state');
+    assert(!existsSync(join(cwd, '.omx', 'state', 'sessions', ownerSessionId)), 'cancel created an owner scope');
+  });
+}
+
+async function scenarioCancelForce(packageRoot: string): Promise<void> {
+  await withWorkspace('cancel-force', async (cwd, home) => {
+    const canonicalSessionId = 'omx-canonical-cancel-force';
+    const ownerSessionId = 'omx-unmatched-cancel-force';
+    await writeCanonicalPointer(packageRoot, cwd, home, canonicalSessionId, 'native-unmatched-cancel-force');
+    await writeModeState(cwd, canonicalSessionId, 'ralph', { current_phase: 'executing' });
+    const before = await readFile(statePath(cwd, canonicalSessionId, 'ralph'), 'utf-8');
+    const result = runInstalledCli(packageRoot, cwd, ['cancel', '--force'], cleanEnv(home, cwd, {
+      OMX_SESSION_ID: ownerSessionId,
+      TMUX: '',
+      TMUX_PANE: '',
+    }));
+    assert(result.status !== null, 'unmatched owner force cancel did not exit');
+    assert(await readFile(statePath(cwd, canonicalSessionId, 'ralph'), 'utf-8') === before, 'unmatched owner force cancel mutated canonical state');
+    assert(!existsSync(join(cwd, '.omx', 'state', 'sessions', ownerSessionId)), 'force cancel created an owner scope');
+  });
+}
+
+async function scenarioOwnerTerminalNativeStop(packageRoot: string): Promise<void> {
+  await withWorkspace('owner-terminal-stop', async (cwd, home) => {
+    const canonicalSessionId = 'omx-canonical-terminal';
+    const ownerSessionId = 'omx-owner-terminal';
+    const nativeSessionId = 'native-owner-terminal';
+    const binDir = join(cwd, 'bin');
+    await writeFakeTmux(binDir, ownerSessionId);
+    await writeCanonicalPointer(packageRoot, cwd, home, canonicalSessionId, nativeSessionId);
+    const env = cleanEnv(home, cwd, {
+      OMX_SESSION_ID: ownerSessionId,
+      TMUX: '/tmp/tmux-1000/default,1,0',
+      TMUX_PANE: '%issue3138-terminal-pane',
+      PATH: `${binDir}:${process.env.PATH || ''}`,
+    });
+    const consensusGate = await writeRalplanConsensusEvidence(cwd, canonicalSessionId);
+    await withEnvironment(env, async () => {
+      const native = await importInstalled<{
+        dispatchCodexNativeHook: (payload: Record<string, unknown>, options?: Record<string, unknown>) => Promise<unknown>;
+      }>(packageRoot, 'dist/scripts/codex-native-hook.js');
+      await native.dispatchCodexNativeHook({
+        hook_event_name: 'SessionStart',
+        session_id: nativeSessionId,
+        cwd,
+      }, { cwd, sessionOwnerPid: process.pid });
+    });
+    const terminal = runInstalledCli(packageRoot, cwd, [
+      'state', 'write', '--input', JSON.stringify({
+        mode: 'ralplan', active: false, current_phase: 'complete', completed_at: new Date().toISOString(),
+        ralplan_consensus_gate: consensusGate,
+      }), '--json',
+    ], env);
+    assert(terminal.status === 0, terminal.stderr || terminal.stdout || 'owner terminal state write failed');
+    const terminalState = await readJson<Record<string, unknown>>(statePath(cwd, canonicalSessionId, 'ralplan'));
+    assert(terminalState.active === false && terminalState.current_phase === 'complete', 'owner terminal write did not update canonical state');
+    assert(!existsSync(join(cwd, '.omx', 'state', 'sessions', ownerSessionId)), 'owner terminal write created a split owner scope');
+
+    await withEnvironment(env, async () => {
+      const native = await importInstalled<{
+        dispatchCodexNativeHook: (payload: Record<string, unknown>, options?: Record<string, unknown>) => Promise<{
+          outputJson: Record<string, unknown> | null;
+        }>;
+      }>(packageRoot, 'dist/scripts/codex-native-hook.js');
+      const stop = await native.dispatchCodexNativeHook({
+        hook_event_name: 'Stop',
+        session_id: nativeSessionId,
+        cwd,
+      }, { cwd });
+      assert(stop.outputJson?.decision !== 'block', 'native Stop continued a terminal canonical Ralph plan');
+      assert(!String(stop.outputJson?.stopReason || '').startsWith('skill_ralplan_'), 'native Stop reported a stale Ralph-plan continuation');
+      assert(!String(stop.outputJson?.reason || '').includes('continue_from_artifact'), 'native Stop reported an artifact continuation');
+    });
+  });
+}
+
+async function scenarioAllSessionsClear(packageRoot: string): Promise<void> {
+  await withWorkspace('all-sessions-clear', async (cwd, home) => {
+    const canonicalSessionId = 'omx-canonical-all-clear';
+    const otherSessionId = 'omx-existing-other';
+    const ownerSessionId = 'omx-unmatched-all-clear';
+    await writeCanonicalPointer(packageRoot, cwd, home, canonicalSessionId, 'native-all-clear');
+    await writeModeState(cwd, canonicalSessionId, 'ralph', { current_phase: 'executing' });
+    await writeModeState(cwd, otherSessionId, 'ralph', { current_phase: 'executing' });
+    const result = runInstalledCli(packageRoot, cwd, [
+      'state', 'clear', '--input', JSON.stringify({ mode: 'ralph', all_sessions: true }), '--json',
+    ], cleanEnv(home, cwd, { OMX_SESSION_ID: ownerSessionId, TMUX: '', TMUX_PANE: '' }));
+    assert(result.status === 0, result.stderr || result.stdout || 'all-sessions clear failed');
+    assert(!existsSync(statePath(cwd, canonicalSessionId, 'ralph')), 'all-sessions clear left canonical Ralph state');
+    assert(!existsSync(statePath(cwd, otherSessionId, 'ralph')), 'all-sessions clear left existing secondary Ralph state');
+    assert(!existsSync(join(cwd, '.omx', 'state', 'sessions', ownerSessionId)), 'all-sessions clear initialized an owner scope');
+  });
+}
+
+async function writeNotificationConfig(home: string): Promise<void> {
+  const codexHome = join(home, '.codex');
+  await mkdir(codexHome, { recursive: true });
+  await writeFile(join(codexHome, '.omx-config.json'), JSON.stringify({
+    notifications: {
+      enabled: true,
+      telegram: {
+        enabled: true,
+        botToken: '123456:issue3138-smoke-token',
+        chatId: 'issue3138-smoke-chat',
+      },
+    },
+  }, null, 2));
+}
+
+async function withMockedTelegramDelivery<T>(run: (deliveries: Array<Record<string, unknown>>) => Promise<T>): Promise<T> {
+  const previousFetch = globalThis.fetch;
+  const deliveries: Array<Record<string, unknown>> = [];
+  globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+    deliveries.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>);
+    return new Response(JSON.stringify({ ok: true, result: { message_id: `issue3138-${deliveries.length}` } }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof globalThis.fetch;
+  try {
+    return await run(deliveries);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+}
+
+async function scenarioManagedUnmatchedIdleDeliveryNoReceipts(packageRoot: string): Promise<void> {
+  await withWorkspace('managed-unmatched-idle', async (cwd, home) => {
+    const ownerSessionId = 'omx-unmatched-idle';
+    await writeNotificationConfig(home);
+    await withEnvironment(cleanEnv(home, cwd, { OMX_SESSION_ID: ownerSessionId, TMUX_PANE: '%issue3138-idle-pane' }), async () => {
+      const notifications = await importInstalled<{
+        notifyLifecycle: (
+          event: string,
+          payload: Record<string, unknown>,
+          profileName?: string,
+          options?: { persistScopedReceipts?: boolean },
+        ) => Promise<{ anySuccess: boolean; results: Array<{ messageId?: string }> } | null>;
+      }>(packageRoot, 'dist/notifications/index.js');
+      await withMockedTelegramDelivery(async (deliveries) => {
+        const result = await notifications.notifyLifecycle('session-idle', {
+          sessionId: ownerSessionId,
+          projectPath: cwd,
+          tmuxPaneId: '%issue3138-idle-pane',
+          tmuxSession: 'issue3138-smoke',
+          tmuxTail: 'fresh idle tail',
+        }, undefined, { persistScopedReceipts: false });
+        assert(result?.anySuccess === true, 'managed unmatched idle delivery did not succeed');
+        assert(result.results.some((entry) => entry.messageId === 'issue3138-1'), 'managed unmatched idle delivery omitted the provider message ID');
+        assert(deliveries.length === 1, 'managed unmatched idle delivery did not reach the provider');
+      });
+    });
+    assert(!existsSync(join(cwd, '.omx', 'state', 'sessions', ownerSessionId, 'idle-notif-cooldown.json')), 'managed unmatched idle wrote an idle receipt');
+    assert(!existsSync(join(cwd, '.omx', 'state', 'sessions', ownerSessionId, 'lifecycle-notif-state.json')), 'managed unmatched idle wrote a lifecycle receipt');
+    assert(!existsSync(join(home, '.omx', 'state', 'reply-session-registry.jsonl')), 'managed unmatched idle wrote a reply mapping');
+    assert(!existsSync(join(home, '.omx', 'state', 'reply-session-registry.lock')), 'managed unmatched idle left a reply registry lock');
+  });
+}
+
+async function scenarioRejectedRootNoLaunch(packageRoot: string): Promise<void> {
+  await withWorkspace('rejected-root', async (cwd, home) => {
+    const outsideRoot = await mkdtemp(join(tmpdir(), 'omx-issue-3138-rejected-root-'));
+    const binDir = join(cwd, 'bin');
+    const invocationLog = join(cwd, 'unexpected-launch.log');
+    try {
+      await mkdir(binDir, { recursive: true });
+      for (const command of ['codex', 'tmux']) {
+        const path = join(binDir, command);
+        await writeFile(path, `#!/usr/bin/env bash\nprintf '${command} %s\\n' "$*" >> ${JSON.stringify(invocationLog)}\nexit 0\n`);
+        await chmod(path, 0o755);
+      }
+      const result = runInstalledCli(packageRoot, cwd, ['--dangerously-bypass-approvals-and-sandbox'], cleanEnv(home, cwd, {
+        OMX_ROOT: outsideRoot,
+        OMX_MCP_WORKDIR_ROOTS: cwd,
+        OMX_LAUNCH_POLICY: 'direct',
+        PATH: `${binDir}:${process.env.PATH || ''}`,
+      }));
+      assert(result.status !== 0, 'rejected root direct launch unexpectedly succeeded');
+      assert(/session_pointer_context_failure|outside allowed roots/i.test(`${result.stdout}\n${result.stderr}`), 'rejected root did not report a typed context abort');
+      const invocationText = existsSync(invocationLog) ? await readFile(invocationLog, 'utf-8') : '';
+      assert(!/^codex\b/m.test(invocationText), 'rejected root launched Codex');
+      assert(!/^tmux (?:new-session|set-option|split-window|send-keys)\b/m.test(invocationText), 'rejected root mutated tmux state');
+      assert(!existsSync(join(cwd, '.omx', 'state', 'session.json')), 'rejected root committed a session pointer');
+      assert(!existsSync(join(cwd, '.omx', 'runtime')), 'rejected root created post-launch runtime artifacts');
+    } finally {
+      await rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+}
+
+async function scenarioManagedUnmatchedLifecycleDeliveryNoReceipts(packageRoot: string): Promise<void> {
+  await withWorkspace('managed-unmatched-lifecycle', async (cwd, home) => {
+    const ownerSessionId = 'omx-unmatched-lifecycle';
+    await writeNotificationConfig(home);
+    await withEnvironment(cleanEnv(home, cwd, { OMX_SESSION_ID: ownerSessionId }), async () => {
+      const notifications = await importInstalled<{
+        notifyLifecycle: (
+          event: string,
+          payload: Record<string, unknown>,
+          profileName?: string,
+          options?: { persistScopedReceipts?: boolean },
+        ) => Promise<{ anySuccess: boolean } | null>;
+      }>(packageRoot, 'dist/notifications/index.js');
+      await withMockedTelegramDelivery(async (deliveries) => {
+        const first = await notifications.notifyLifecycle('session-start', {
+          sessionId: ownerSessionId,
+          projectPath: cwd,
+        }, undefined, { persistScopedReceipts: false });
+        const second = await notifications.notifyLifecycle('session-start', {
+          sessionId: ownerSessionId,
+          projectPath: cwd,
+        }, undefined, { persistScopedReceipts: false });
+        assert(first?.anySuccess === true && second?.anySuccess === true, 'managed unmatched lifecycle delivery did not succeed');
+        assert(deliveries.length === 2, 'managed unmatched lifecycle delivery was unexpectedly deduped');
+      });
+    });
+    assert(!existsSync(join(cwd, '.omx', 'state', 'sessions', ownerSessionId, 'lifecycle-notif-state.json')), 'managed unmatched lifecycle wrote a lifecycle receipt');
+  });
+}
+
+async function runScenario(name: ScenarioName, packageRoot: string): Promise<void> {
+  switch (name) {
+    case 'missing-owner-alias-activation':
+      await scenarioMissingOwnerAliasActivation(packageRoot);
+      return;
+    case 'unmatched-write':
+      await scenarioUnmatchedWrite(packageRoot);
+      return;
+    case 'ordinary-clear':
+      await scenarioOrdinaryClear(packageRoot);
+      return;
+    case 'cancel':
+      await scenarioCancel(packageRoot);
+      return;
+    case 'cancel-force':
+      await scenarioCancelForce(packageRoot);
+      return;
+    case 'owner-terminal-native-stop':
+      await scenarioOwnerTerminalNativeStop(packageRoot);
+      return;
+    case 'all-sessions-clear':
+      await scenarioAllSessionsClear(packageRoot);
+      return;
+    case 'managed-unmatched-idle-delivery-no-receipts':
+      await scenarioManagedUnmatchedIdleDeliveryNoReceipts(packageRoot);
+      return;
+    case 'rejected-root-no-launch':
+      await scenarioRejectedRootNoLaunch(packageRoot);
+      return;
+    case 'managed-unmatched-lifecycle-delivery-no-receipts':
+      await scenarioManagedUnmatchedLifecycleDeliveryNoReceipts(packageRoot);
+      return;
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const packageJson = await readJson<{ version?: unknown }>(join(args.packageRoot, 'package.json'));
+  assert(typeof packageJson.version === 'string' && packageJson.version.length > 0, 'installed package version is missing');
+
+  const scenarios: ScenarioResult[] = [];
+  const failures: string[] = [];
+  for (const name of MANDATORY_SCENARIOS) {
+    try {
+      await runScenario(name, args.packageRoot);
+      scenarios.push({ name, pass: true });
+    } catch (error) {
+      scenarios.push({ name, pass: false });
+      failures.push(`${name}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  assert(scenarios.length === MANDATORY_SCENARIOS.length, 'installed smoke omitted a mandatory scenario');
+  assert(new Set(scenarios.map((scenario) => scenario.name)).size === MANDATORY_SCENARIOS.length, 'installed smoke duplicated a mandatory scenario');
+  const report = {
+    schema: SCHEMA,
+    tested_sha: args.testedSha,
+    tarball_sha256: args.tarballSha256,
+    installed_version: packageJson.version,
+    scenarios,
+    ...(failures.length > 0 ? { error: failures.join('\n') } : {}),
+  };
+  process.stdout.write(`${JSON.stringify(report)}\n`);
+  if (failures.length > 0) process.exitCode = 1;
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack || error.message : String(error)}\n`);
+  process.exit(1);
+});

--- a/src/scripts/__tests__/notify-state-io.test.ts
+++ b/src/scripts/__tests__/notify-state-io.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -162,6 +163,48 @@ describe('notify-hook state I/O session authority', () => {
       else delete process.env.OMX_SESSION_ID;
       if (typeof previousCodexSessionId === 'string') process.env.CODEX_SESSION_ID = previousCodexSessionId;
       else delete process.env.CODEX_SESSION_ID;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('maps the recorded OMX owner alias to the canonical session for implicit and explicit writes', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-notify-state-io-owner-alias-'));
+    const previousOmxSessionId = process.env.OMX_SESSION_ID;
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const canonicalSessionId = 'omx-canonical';
+      const ownerSessionId = 'omx-owner';
+      await mkdir(join(stateDir, 'sessions', canonicalSessionId), { recursive: true });
+      await writeFile(
+        join(stateDir, 'session.json'),
+        JSON.stringify({
+          session_id: canonicalSessionId,
+          owner_omx_session_id: ownerSessionId,
+          cwd: wd,
+        }, null, 2),
+        'utf-8',
+      );
+      process.env.OMX_SESSION_ID = ownerSessionId;
+
+      assert.equal(await readCurrentSessionId(stateDir), canonicalSessionId);
+      assert.equal(
+        await resolveScopedStateDir(stateDir),
+        join(stateDir, 'sessions', canonicalSessionId),
+      );
+      assert.equal(
+        await resolveScopedStateDir(stateDir, ownerSessionId),
+        join(stateDir, 'sessions', canonicalSessionId),
+      );
+
+      await writeScopedJson(stateDir, 'hud-state.json', ownerSessionId, { turn_count: 12 });
+      const value = JSON.parse(
+        await readFile(join(stateDir, 'sessions', canonicalSessionId, 'hud-state.json'), 'utf-8'),
+      ) as { turn_count?: unknown };
+      assert.equal(value.turn_count, 12);
+      assert.equal(existsSync(join(stateDir, 'sessions', ownerSessionId)), false);
+    } finally {
+      if (typeof previousOmxSessionId === 'string') process.env.OMX_SESSION_ID = previousOmxSessionId;
+      else delete process.env.OMX_SESSION_ID;
       await rm(wd, { recursive: true, force: true });
     }
   });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -26,11 +26,15 @@ import { resolveCanonicalTeamStateRoot, resolveWorkerNotifyTeamStateRootPath } f
 import { inferTerminalLifecycleOutcome } from "../runtime/run-outcome.js";
 import {
   appendToLog,
+  isSessionPointerLaunchAbort,
   isSessionStale,
   isSessionStateUsable,
+  normalizeSessionId,
+  readSessionPointer,
   readSessionState,
   readUsableSessionState,
   reconcileNativeSessionStart,
+  resolveSessionPointerContext,
   type SessionState,
 } from "../hooks/session.js";
 import {
@@ -44,7 +48,14 @@ import {
 } from "../team/state.js";
 import { codexAgentsDir, omxNotepadPath, projectCodexAgentsDir, resolveProjectMemoryPath } from "../utils/paths.js";
 import { findGitLayout } from "../utils/git-layout.js";
-import { getBaseStateDir, getStateFilePath, getStatePath, getAuthoritativeActiveStatePaths } from "../mcp/state-paths.js";
+import {
+  getAuthoritativeActiveStatePaths,
+  getBaseStateDir,
+  getStateFilePath,
+  getStatePath,
+  resolveWritableStateScope,
+  WRITABLE_STATE_SCOPE_ERRORS,
+} from "../mcp/state-paths.js";
 import {
   detectKeywords,
   detectPrimaryKeyword,
@@ -59,6 +70,7 @@ import {
   normalizeAutoNudgeSignatureText,
   resolveEffectiveAutoNudgeResponse,
 } from "./notify-hook/auto-nudge.js";
+import { probeActualTmuxInstanceEvidence, tmuxEvidenceBindsCandidate } from "./notify-hook/managed-tmux.js";
 import {
   SLOPPY_FALLBACK_GROUNDING_PATTERNS,
   SLOPPY_FALLBACK_IMPLEMENTATION_CONTEXT_PATTERNS,
@@ -234,6 +246,19 @@ const MAX_SESSION_META_LINE_BYTES = 256 * 1024;
 
 function safeString(value: unknown): string {
   return typeof value === "string" ? value : "";
+}
+
+async function resolveVerifiedOwnerOmxSessionId(): Promise<string | undefined> {
+  const candidate = normalizeSessionId(process.env.OMX_SESSION_ID);
+  if (!candidate) return undefined;
+  const evidence = await probeActualTmuxInstanceEvidence(process.env.TMUX_PANE);
+  return tmuxEvidenceBindsCandidate(evidence, candidate) ? candidate : undefined;
+}
+
+function isImplicitWritableScopeFailure(error: unknown): boolean {
+  return error instanceof Error
+    && (error.message === WRITABLE_STATE_SCOPE_ERRORS.unboundEnvironment
+      || error.message === WRITABLE_STATE_SCOPE_ERRORS.unusableSession);
 }
 
 function safeObject(value: unknown): Record<string, unknown> {
@@ -3387,12 +3412,14 @@ async function resolveInternalSessionIdForPayload(
   cwd: string,
   payloadSessionId: string,
   stateDir?: string,
+  pointerSessionState?: SessionState | null,
+  allowUnboundPayloadFallback = true,
 ): Promise<string> {
-  const currentSession = stateDir
+  const currentSession = pointerSessionState ?? (stateDir
     ? await readUsableSessionStateFromStateDir(cwd, stateDir)
-    : await readUsableSessionState(cwd);
+    : await readUsableSessionState(cwd));
   const canonicalSessionId = safeString(currentSession?.session_id).trim();
-  if (!canonicalSessionId) return payloadSessionId;
+  if (!canonicalSessionId) return allowUnboundPayloadFallback ? payloadSessionId : "";
 
   const nativeSessionId = safeString(currentSession?.native_session_id).trim();
   const ownerOmxSessionId = safeString(currentSession?.owner_omx_session_id).trim();
@@ -3400,7 +3427,7 @@ async function resolveInternalSessionIdForPayload(
   if (payloadSessionId === canonicalSessionId) return canonicalSessionId;
   if (nativeSessionId && payloadSessionId === nativeSessionId) return canonicalSessionId;
   if (ownerOmxSessionId && payloadSessionId === ownerOmxSessionId) return canonicalSessionId;
-  return payloadSessionId;
+  return allowUnboundPayloadFallback ? payloadSessionId : "";
 }
 
 async function readRootSessionStateFromStateDir(stateDir: string): Promise<SessionState | null> {
@@ -9376,14 +9403,15 @@ async function buildStopHookOutput(
   payload: CodexHookPayload,
   cwd: string,
   stateDir: string,
-  options: { skipRalphStopBlock?: boolean } = {},
+  options: { skipRalphStopBlock?: boolean; canonicalSessionId?: string } = {},
 ): Promise<Record<string, unknown> | null> {
   if (isStopExempt(payload)) {
     return null;
   }
 
   const sessionId = readPayloadSessionId(payload);
-  const canonicalSessionId = await resolveInternalSessionIdForPayload(cwd, sessionId);
+  const canonicalSessionId = options.canonicalSessionId
+    ?? await resolveInternalSessionIdForPayload(cwd, sessionId);
   const threadId = readPayloadThreadId(payload);
   const suppressParentWorkflowStop = shouldSuppressParentWorkflowStopForSideConversation(payload);
   if (canonicalSessionId) {
@@ -9434,7 +9462,7 @@ async function buildStopHookOutput(
   }
   const ralphState = options.skipRalphStopBlock === true
     ? null
-    : await readActiveRalphState(cwd, stateDir, canonicalSessionId, ralphOwnerContext);
+    : await readActiveRalphState(cwd, stateDir, sessionId || canonicalSessionId, ralphOwnerContext);
   if (!ralphState) {
     const autoresearchState = await readActiveAutoresearchState(cwd, canonicalSessionId);
     if (autoresearchState) {
@@ -9709,9 +9737,9 @@ export async function dispatchCodexNativeHook(
       outputJson: null,
     };
   }
-  // Native hooks must use the same authoritative runtime state root as HUD/MCP
-  // when boxed/team roots are active; do not bypass it with cwd/.omx/state.
-  const stateDir = getBaseStateDir(cwd);
+  // Native hooks must use the exact pointer root selected for this dispatch.
+  const pointerContext = resolveSessionPointerContext(cwd);
+  const stateDir = pointerContext.baseStateDir;
   if (hookEventName !== "Stop") {
     await mkdir(stateDir, { recursive: true });
   }
@@ -9725,7 +9753,15 @@ export async function dispatchCodexNativeHook(
   const nativeSessionId = safeString(payload.session_id ?? payload.sessionId).trim();
   const threadId = safeString(payload.thread_id ?? payload.threadId).trim();
   const turnId = safeString(payload.turn_id ?? payload.turnId).trim();
-  const currentSessionState = await readUsableSessionState(cwd);
+  const pointer = await readSessionPointer(pointerContext);
+  const currentSessionState = pointer.status === "usable" ? pointer.state ?? null : null;
+  let allowImplicitSessionSideEffects = pointer.status === "usable" || pointer.status === "absent";
+  let stopAuthorizationFailure: { stopReason: string; reason: string } | null = allowImplicitSessionSideEffects
+    ? null
+    : {
+      stopReason: "session_pointer_unusable",
+      reason: `OMX cannot authorize Stop while the selected session pointer is ${pointer.status}; repair the pointer evidence before continuing.`,
+    };
   let canonicalSessionId = safeString(currentSessionState?.session_id).trim();
   let resolvedNativeSessionId = nativeSessionId;
   let skipCanonicalSessionStartContext = false;
@@ -9786,23 +9822,54 @@ export async function dispatchCodexNativeHook(
         );
       }
     } else {
-      const sessionState = await reconcileNativeSessionStart(cwd, nativeSessionId, {
-        pid: options.sessionOwnerPid ?? resolveSessionOwnerPid(payload),
-      });
-      canonicalSessionId = safeString(sessionState.session_id).trim();
-      resolvedNativeSessionId = safeString(sessionState.native_session_id).trim() || nativeSessionId;
+      const ownerOmxSessionId = await resolveVerifiedOwnerOmxSessionId();
+      try {
+        const sessionState = await reconcileNativeSessionStart(cwd, nativeSessionId, {
+          context: pointerContext,
+          pid: options.sessionOwnerPid ?? resolveSessionOwnerPid(payload),
+          ...(ownerOmxSessionId
+            ? { ownerOmxSessionId, ownerAliasVerified: true }
+            : {}),
+        });
+        canonicalSessionId = safeString(sessionState.session_id).trim();
+        resolvedNativeSessionId = safeString(sessionState.native_session_id).trim() || nativeSessionId;
+        allowImplicitSessionSideEffects = true;
+        stopAuthorizationFailure = null;
+      } catch (error) {
+        if (!isSessionPointerLaunchAbort(error)) throw error;
+        canonicalSessionId = "";
+        resolvedNativeSessionId = nativeSessionId;
+        skipCanonicalSessionStartContext = true;
+        allowImplicitSessionSideEffects = false;
+        stopAuthorizationFailure = {
+          stopReason: "session_pointer_unusable",
+          reason: `OMX cannot authorize Stop while the selected session pointer is ${pointer.status}; repair the pointer evidence before continuing.`,
+        };
+      }
     }
   } else if (!canonicalSessionId) {
     canonicalSessionId = safeString(currentSessionState?.session_id).trim();
   }
 
   if (hookEventName === "Stop") {
-    const inheritedSessionId = safeString(process.env.OMX_SESSION_ID || process.env.CODEX_SESSION_ID).trim();
+    const stopPayloadSessionId = readPayloadSessionId(payload);
     const stopCanonicalSessionId = await resolveInternalSessionIdForPayload(
       cwd,
-      readPayloadSessionId(payload) || inheritedSessionId,
+      stopPayloadSessionId,
+      undefined,
+      currentSessionState,
+      pointer.status === "absent",
     );
-    if (stopCanonicalSessionId) {
+    if (stopPayloadSessionId && !stopCanonicalSessionId) {
+      canonicalSessionId = "";
+      allowImplicitSessionSideEffects = false;
+      if (!stopAuthorizationFailure) {
+        stopAuthorizationFailure = {
+          stopReason: "session_scope_unmatched",
+          reason: `OMX cannot authorize Stop for unmatched session id ${stopPayloadSessionId}; the selected session pointer remains authoritative.`,
+        };
+      }
+    } else if (stopCanonicalSessionId) {
       canonicalSessionId = stopCanonicalSessionId;
     }
     if (canonicalSessionId && safeString(currentSessionState?.session_id).trim() === canonicalSessionId) {
@@ -9811,8 +9878,8 @@ export async function dispatchCodexNativeHook(
     }
   }
 
-  const eventSessionId = canonicalSessionId || nativeSessionId || undefined;
-  const sessionIdForState = canonicalSessionId || nativeSessionId;
+  let eventSessionId = canonicalSessionId || nativeSessionId || undefined;
+  let sessionIdForState: string | null = canonicalSessionId || null;
   let outputJson: Record<string, unknown> | null = null;
   const typedAgentRolePayload = isTypedAgentRolePayload(payload);
   const isSubagentPromptSubmit = hookEventName === "UserPromptSubmit"
@@ -9841,6 +9908,13 @@ export async function dispatchCodexNativeHook(
         )),
     )).some(Boolean)
     : false;
+  if (isSubagentStop && stopAuthorizationFailure?.stopReason === "session_scope_unmatched") {
+    canonicalSessionId = normalizeSessionId(readPayloadSessionId(payload)) ?? "";
+    allowImplicitSessionSideEffects = true;
+    stopAuthorizationFailure = null;
+    eventSessionId = canonicalSessionId || nativeSessionId || undefined;
+    sessionIdForState = canonicalSessionId || null;
+  }
   const suppressNoisySubagentLifecycleDispatch =
     (isSubagentSessionStart || isSubagentStop)
     && shouldSuppressSubagentLifecycleHookDispatch();
@@ -9849,22 +9923,39 @@ export async function dispatchCodexNativeHook(
     const prompt = readPromptText(payload);
     goalWorkflowAdditionalContext = await buildCompletedGoalCleanupPromptWarning(cwd, prompt).catch(() => null)
       ?? await buildGoalWorkflowReconciliationPromptWarning(cwd, prompt).catch(() => null);
-    ultragoalSteeringAdditionalContext = prompt && !isSubagentPromptSubmit
+    ultragoalSteeringAdditionalContext = prompt && !isSubagentPromptSubmit && allowImplicitSessionSideEffects
       ? await applyUserPromptUltragoalSteering(cwd, prompt).catch((error) => `OMX native UserPromptSubmit rejected bounded .omx/ultragoal steering for G002-cli-and-prompt-submit-bridge: ${error instanceof Error ? error.message : String(error)}`)
       : null;
-    if (prompt && !isSubagentPromptSubmit) {
+    let suppressActivationSeeding = !allowImplicitSessionSideEffects;
+    if (prompt && !isSubagentPromptSubmit && allowImplicitSessionSideEffects) {
+      const rawHookSessionId = canonicalSessionId || nativeSessionId;
+      const normalizedHookSessionId = normalizeSessionId(rawHookSessionId);
+      const explicitHookSessionId = currentSessionState ? undefined : normalizedHookSessionId;
+      if (rawHookSessionId && !normalizedHookSessionId) {
+        suppressActivationSeeding = true;
+      } else {
+        try {
+          const writableScope = await resolveWritableStateScope(cwd, explicitHookSessionId);
+          sessionIdForState = writableScope.sessionId ?? null;
+        } catch (error) {
+          if (!isImplicitWritableScopeFailure(error)) throw error;
+          suppressActivationSeeding = true;
+        }
+      }
+    }
+    if (prompt && !isSubagentPromptSubmit && !suppressActivationSeeding) {
       skillState = buildNativeOutsideTmuxTeamPromptBlockState(
         prompt,
         cwd,
         payload,
-        sessionIdForState,
+        sessionIdForState || undefined,
         threadId || undefined,
         turnId || undefined,
       ) ?? await recordSkillActivation({
         stateDir,
         sourceCwd: cwd,
         text: prompt,
-        sessionId: sessionIdForState,
+        sessionId: sessionIdForState || undefined,
         threadId,
         turnId,
       });
@@ -9899,7 +9990,9 @@ export async function dispatchCodexNativeHook(
                 },
                 suppress_followup: true,
               };
-              writeTriageState({ cwd, sessionId: sessionIdForState || null, state: newState });
+              if (!suppressActivationSeeding) {
+                writeTriageState({ cwd, sessionId: sessionIdForState || null, state: newState });
+              }
             } else if (decision.lane === "LIGHT") {
               if (decision.destination === "explore") {
                 triageAdditionalContext =
@@ -9928,7 +10021,9 @@ export async function dispatchCodexNativeHook(
                   },
                   suppress_followup: true,
                 };
-                writeTriageState({ cwd, sessionId: sessionIdForState || null, state: newState });
+                if (!suppressActivationSeeding) {
+                  writeTriageState({ cwd, sessionId: sessionIdForState || null, state: newState });
+                }
               }
             }
             // lane === "PASS": no context, no state write
@@ -9942,7 +10037,7 @@ export async function dispatchCodexNativeHook(
     const skipHudReconcileForDoctorSmoke = process.env.OMX_NATIVE_HOOK_DOCTOR_SMOKE === "1";
     const skipHudReconcileForTeamWorkerPane = !isSubagentPromptSubmit
       && await isConfirmedTeamWorkerPromptSubmitPane(cwd).catch(() => false);
-    if (!skipHudReconcileForDoctorSmoke && !skipHudReconcileForTeamWorkerPane) {
+    if (allowImplicitSessionSideEffects && !skipHudReconcileForDoctorSmoke && !skipHudReconcileForTeamWorkerPane) {
       const reconcileHudForPromptSubmitFn = options.reconcileHudForPromptSubmitFn ?? reconcileHudForPromptSubmit;
       const hudSessionId = resolveHudReconcileSessionId(
         currentSessionState,
@@ -9959,7 +10054,7 @@ export async function dispatchCodexNativeHook(
     }
   }
 
-  if (omxEventName && !skipCanonicalSessionStartContext && !suppressNoisySubagentLifecycleDispatch) {
+  if (omxEventName && allowImplicitSessionSideEffects && !skipCanonicalSessionStartContext && !suppressNoisySubagentLifecycleDispatch) {
     const baseContext = buildBaseContext(cwd, payload, hookEventName!, canonicalSessionId);
     if (resolvedNativeSessionId) {
       baseContext.native_session_id = resolvedNativeSessionId;
@@ -10028,17 +10123,33 @@ export async function dispatchCodexNativeHook(
       ?? buildMalformedPreToolUseBlockTestOutput(payload)
       ?? buildNativePreToolUseOutput(payload);
   } else if (hookEventName === "PostToolUse") {
-    await recordNativeSubagentCapacityBlocker(cwd, stateDir, payload).catch(() => {});
-    await recordNativeSubagentSupportBlocker(cwd, stateDir, payload).catch(() => {});
-    if (detectMcpTransportFailure(payload)) {
-      await markTeamTransportFailure(cwd, payload);
+    if (allowImplicitSessionSideEffects) {
+      await recordNativeSubagentCapacityBlocker(cwd, stateDir, payload).catch(() => {});
+      await recordNativeSubagentSupportBlocker(cwd, stateDir, payload).catch(() => {});
+      if (detectMcpTransportFailure(payload)) {
+        await markTeamTransportFailure(cwd, payload);
+      }
+      await handleTeamWorkerPostToolUseSuccess(payload, cwd);
     }
     outputJson = buildNativePostToolUseOutput(payload);
-    await handleTeamWorkerPostToolUseSuccess(payload, cwd);
   } else if (hookEventName === "Stop") {
-    outputJson = await buildStopHookOutput(payload, cwd, stateDir, {
-      skipRalphStopBlock: isSubagentStop,
-    }) ?? await buildCompletedGoalCleanupStopOutput(payload, cwd);
+    if (allowImplicitSessionSideEffects) {
+      outputJson = await buildStopHookOutput(payload, cwd, stateDir, {
+        canonicalSessionId: canonicalSessionId || undefined,
+        skipRalphStopBlock: isSubagentStop,
+      }) ?? await buildCompletedGoalCleanupStopOutput(payload, cwd);
+    } else {
+      const failure = stopAuthorizationFailure ?? {
+        stopReason: "session_pointer_unusable",
+        reason: "OMX cannot authorize Stop without a writable session authority.",
+      };
+      outputJson = {
+        decision: "block",
+        stopReason: failure.stopReason,
+        reason: failure.reason,
+        systemMessage: failure.reason,
+      };
+    }
   }
 
   return {

--- a/src/scripts/notify-hook.ts
+++ b/src/scripts/notify-hook.ts
@@ -21,7 +21,7 @@
 import { writeFile, appendFile, mkdir, readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { dirname, join, resolve } from 'path';
-import { isSessionStateUsable } from '../hooks/session.js';
+import { isSessionStateUsable, normalizeSessionId } from '../hooks/session.js';
 
 import { safeString, asNumber } from './notify-hook/utils.js';
 import {
@@ -31,8 +31,12 @@ import {
 } from './notify-hook/payload-parser.js';
 import { getBaseStateDir } from '../mcp/state-paths.js';
 import {
+  getOmxSessionIdFromEnvironment,
   getScopedStatePath,
+  hasExistingScopedSessionDir,
+  isExplicitNotifySessionFork,
   readCurrentSessionId,
+  readNotifySessionMetadata,
   readScopedJsonIfExists,
   getScopedStateDirsForCurrentSession,
   normalizeNotifyState,
@@ -357,6 +361,58 @@ function isNotifyFallbackTaskCompletePayload(payload: Record<string, unknown>): 
   ));
 }
 
+interface LeaderNotifyWriteDecision {
+  allowScopedWrites: boolean;
+  sessionId: string;
+  reason: string;
+}
+
+async function resolveLeaderNotifyWriteDecision(
+  stateDir: string,
+  payloadSessionId: string,
+): Promise<LeaderNotifyWriteDecision> {
+  const metadata = await readNotifySessionMetadata(stateDir);
+  const canonicalSessionId = metadata.sessionId || '';
+  const configuredOmxSessionId = safeString(process.env.OMX_SESSION_ID).trim();
+  const omxSessionId = getOmxSessionIdFromEnvironment();
+  const normalizedPayloadSessionId = payloadSessionId
+    ? normalizeSessionId(payloadSessionId)
+    : undefined;
+
+  if (configuredOmxSessionId && !omxSessionId) {
+    return { allowScopedWrites: false, sessionId: canonicalSessionId, reason: 'omx_session_id_invalid' };
+  }
+  if (payloadSessionId && !normalizedPayloadSessionId) {
+    return { allowScopedWrites: false, sessionId: canonicalSessionId, reason: 'payload_session_id_invalid' };
+  }
+
+  if (metadata.status === 'missing') {
+    if (normalizedPayloadSessionId) {
+      if (omxSessionId && omxSessionId !== normalizedPayloadSessionId) {
+        return { allowScopedWrites: false, sessionId: '', reason: 'session_pointer_missing' };
+      }
+      return { allowScopedWrites: true, sessionId: normalizedPayloadSessionId, reason: 'native_payload_session' };
+    }
+    return { allowScopedWrites: true, sessionId: '', reason: 'root_without_session_pointer' };
+  }
+  if (metadata.status !== 'usable' || !canonicalSessionId) {
+    return { allowScopedWrites: false, sessionId: '', reason: 'session_pointer_unusable' };
+  }
+
+  if (omxSessionId && isExplicitNotifySessionFork(omxSessionId, metadata)) {
+    if (await hasExistingScopedSessionDir(stateDir, omxSessionId)) {
+      return { allowScopedWrites: true, sessionId: omxSessionId, reason: 'explicit_existing_fork' };
+    }
+    return { allowScopedWrites: false, sessionId: canonicalSessionId, reason: 'explicit_fork_scope_missing' };
+  }
+
+  if (omxSessionId && omxSessionId !== canonicalSessionId && !metadata.aliases.includes(omxSessionId)) {
+    return { allowScopedWrites: false, sessionId: canonicalSessionId, reason: 'managed_session_unmatched' };
+  }
+
+  return { allowScopedWrites: true, sessionId: canonicalSessionId, reason: 'canonical_session_pointer' };
+}
+
 async function main() {
   const rawPayload = process.argv[process.argv.length - 1];
   if (!rawPayload || rawPayload.startsWith('-')) {
@@ -396,46 +452,62 @@ async function main() {
   const stateDir = resolvedWorkerStateDir || getBaseStateDir(cwd);
   const logsDir = join(cwd, '.omx', 'logs');
   const omxDir = join(cwd, '.omx');
-  let currentOmxSessionId = '';
+  const leaderWriteDecision = isTeamWorker
+    ? null
+    : await resolveLeaderNotifyWriteDecision(stateDir, payloadSessionId);
+  const canWriteLeaderScopedState = leaderWriteDecision?.allowScopedWrites === true;
+  let currentOmxSessionId = isTeamWorker ? '' : leaderWriteDecision?.sessionId || '';
   const getEffectiveSessionId = () => currentOmxSessionId || payloadSessionId;
 
   // Ensure directories exist
   await mkdir(logsDir, { recursive: true }).catch(() => {});
-  if (workerStateRootResolved) {
+  if (isTeamWorker && workerStateRootResolved) {
     await mkdir(stateDir, { recursive: true }).catch(() => {});
     currentOmxSessionId = await readCurrentSessionId(stateDir).catch(() => '') || '';
+  }
+  if (!isTeamWorker && !canWriteLeaderScopedState) {
+    await logNotifyHookEvent(logsDir, {
+      timestamp: new Date().toISOString(),
+      level: 'warn',
+      type: 'notify_scoped_writes_suppressed',
+      reason: leaderWriteDecision?.reason,
+      session_id: currentOmxSessionId || null,
+      payload_session_id: payloadSessionId || null,
+    }).catch(() => {});
   }
 
   // Turn-level dedupe prevents double-processing when native notify and fallback
   // watcher both emit the same completed turn.
-  try {
-    if (!workerStateRootResolved) throw new Error('worker_state_root_unresolved');
-    const turnId = safeString(payload['turn-id'] || payload.turn_id || '');
-    if (turnId) {
-      const now = Date.now();
-      const threadId = safeString(payload['thread-id'] || payload.thread_id || '');
-      const eventType = safeString(payload.type || 'agent-turn-complete');
-      const key = `${threadId || 'no-thread'}|${turnId}|${eventType}`;
-      const dedupeSessionId = getEffectiveSessionId();
-      const dedupeStatePath = await getScopedStatePath(stateDir, 'notify-hook-state.json', dedupeSessionId);
-      const dedupeState = normalizeNotifyState(
-        await readScopedJsonIfExists(stateDir, 'notify-hook-state.json', dedupeSessionId, null),
-      );
-      dedupeState.recent_turns = pruneRecentTurns(dedupeState.recent_turns, now);
-      if (dedupeState.recent_turns[key]) {
-        process.exit(0);
+  if (isTeamWorker || canWriteLeaderScopedState) {
+    try {
+      if (!workerStateRootResolved) throw new Error('worker_state_root_unresolved');
+      const turnId = safeString(payload['turn-id'] || payload.turn_id || '');
+      if (turnId) {
+        const now = Date.now();
+        const threadId = safeString(payload['thread-id'] || payload.thread_id || '');
+        const eventType = safeString(payload.type || 'agent-turn-complete');
+        const key = `${threadId || 'no-thread'}|${turnId}|${eventType}`;
+        const dedupeSessionId = getEffectiveSessionId();
+        const dedupeStatePath = await getScopedStatePath(stateDir, 'notify-hook-state.json', dedupeSessionId);
+        const dedupeState = normalizeNotifyState(
+          await readScopedJsonIfExists(stateDir, 'notify-hook-state.json', dedupeSessionId, null),
+        );
+        dedupeState.recent_turns = pruneRecentTurns(dedupeState.recent_turns, now);
+        if (dedupeState.recent_turns[key]) {
+          process.exit(0);
+        }
+        dedupeState.recent_turns[key] = now;
+        dedupeState.last_event_at = new Date().toISOString();
+        await mkdir(dirname(dedupeStatePath), { recursive: true }).catch(() => {});
+        await writeFile(dedupeStatePath, JSON.stringify(dedupeState, null, 2)).catch(() => {});
       }
-      dedupeState.recent_turns[key] = now;
-      dedupeState.last_event_at = new Date().toISOString();
-      await mkdir(dirname(dedupeStatePath), { recursive: true }).catch(() => {});
-      await writeFile(dedupeStatePath, JSON.stringify(dedupeState, null, 2)).catch(() => {});
+    } catch {
+      // Non-critical
     }
-  } catch {
-    // Non-critical
   }
 
   // 0.5. Track leader + native subagent thread activity (lead session only)
-  if (!isTeamWorker) {
+  if (!isTeamWorker && canWriteLeaderScopedState) {
     try {
       const threadId = safeString(payload['thread-id'] || payload.thread_id || '');
       const turnId = safeString(payload['turn-id'] || payload.turn_id || '');
@@ -513,14 +585,20 @@ async function main() {
 
   // Reconcile Ralph ownership for same-Codex-session continuation before
   // lifecycle counters or injection read the active scope.
-  if (!isTeamWorker) {
+  if (!isTeamWorker && canWriteLeaderScopedState) {
     try {
       const resumeResult = await reconcileRalphSessionResume({
         stateDir,
         payloadSessionId,
+        env: {
+          ...process.env,
+          OMX_SESSION_ID: getEffectiveSessionId(),
+          CODEX_SESSION_ID: '',
+          SESSION_ID: '',
+        },
         payloadThreadId,
       });
-      currentOmxSessionId = resumeResult.currentOmxSessionId;
+      if (resumeResult.currentOmxSessionId) currentOmxSessionId = resumeResult.currentOmxSessionId;
       if (resumeResult.resumed || resumeResult.updatedCurrentOwner) {
         await logNotifyHookEvent(logsDir, {
           timestamp: new Date().toISOString(),
@@ -547,9 +625,9 @@ async function main() {
 
   // 2. Update active mode state (increment iteration)
   // GUARD: Skip when running inside a team worker to prevent state corruption
-  if (!isTeamWorker) {
+  if (!isTeamWorker && canWriteLeaderScopedState) {
     try {
-      const scopedDirs = await getScopedStateDirsForCurrentSession(stateDir);
+      const scopedDirs = await getScopedStateDirsForCurrentSession(stateDir, getEffectiveSessionId());
       for (const scopedDir of scopedDirs) {
         const stateFiles = await readdir(scopedDir).catch(() => []);
         for (const f of stateFiles) {
@@ -678,7 +756,7 @@ async function main() {
   }
 
   // 4. Write HUD state summary for `omx hud` (lead session only)
-  if (!isTeamWorker) {
+  if (!isTeamWorker && canWriteLeaderScopedState) {
     try {
       const scopedSessionId = getEffectiveSessionId();
       const hudStatePath = await getScopedStatePath(stateDir, 'hud-state.json', scopedSessionId);
@@ -712,38 +790,40 @@ async function main() {
   }
 
   // 4.45. Skill activation tracking: update skill-active-state.json before any nudge logic.
-  try {
-    const { detectKeywords, recordSkillActivation } = await import('../hooks/keyword-detector.js');
-    if (latestUserInput) {
-      const activationSessionId = getEffectiveSessionId();
-      const isAutopilotActivation = detectKeywords(latestUserInput)
-        .some((match) => match.skill === 'autopilot')
-        || isExplicitAutopilotActivationText(latestUserInput);
-      const suppressTerminalReplay = await shouldSuppressAutopilotTerminalReplayActivation(
-        stateDir,
-        payload,
-        isAutopilotActivation,
-        activationSessionId,
-      );
-      if (!suppressTerminalReplay) {
-        await recordSkillActivation({
+  if (isTeamWorker || canWriteLeaderScopedState) {
+    try {
+      const { detectKeywords, recordSkillActivation } = await import('../hooks/keyword-detector.js');
+      if (latestUserInput) {
+        const activationSessionId = getEffectiveSessionId();
+        const isAutopilotActivation = detectKeywords(latestUserInput)
+          .some((match) => match.skill === 'autopilot')
+          || isExplicitAutopilotActivationText(latestUserInput);
+        const suppressTerminalReplay = await shouldSuppressAutopilotTerminalReplayActivation(
           stateDir,
-          sourceCwd: cwd,
-          text: latestUserInput,
-          sessionId: activationSessionId,
-          threadId: payloadThreadId,
-          turnId: safeString(payload['turn-id'] || payload.turn_id || ''),
-        });
+          payload,
+          isAutopilotActivation,
+          activationSessionId,
+        );
+        if (!suppressTerminalReplay) {
+          await recordSkillActivation({
+            stateDir,
+            sourceCwd: cwd,
+            text: latestUserInput,
+            sessionId: activationSessionId,
+            threadId: payloadThreadId,
+            turnId: safeString(payload['turn-id'] || payload.turn_id || ''),
+          });
+        }
       }
+    } catch {
+      // Non-fatal: keyword detector module may not be built yet
     }
-  } catch {
-    // Non-fatal: keyword detector module may not be built yet
-  }
 
-  try {
-    await syncSkillStateFromTurn(stateDir, payload);
-  } catch {
-    // Non-fatal: lifecycle sync should not block the hook
+    try {
+      await syncSkillStateFromTurn(stateDir, payload);
+    } catch {
+      // Non-fatal: lifecycle sync should not block the hook
+    }
   }
 
   const effectiveSessionId = getEffectiveSessionId();
@@ -772,7 +852,7 @@ async function main() {
 
   // 5. Optional tmux prompt injection workaround (non-fatal, opt-in)
   // Skip for team workers - only the lead should inject prompts
-  if (!isTeamWorker) {
+  if (!isTeamWorker && canWriteLeaderScopedState) {
     try {
       await handleTmuxInjection({ payload, cwd, stateDir, logsDir });
     } catch {
@@ -781,7 +861,7 @@ async function main() {
   }
 
   // 5.5. Opportunistic team dispatch drain (leader session only).
-  if (!isTeamWorker) {
+  if (!isTeamWorker && canWriteLeaderScopedState) {
     try {
       await drainPendingTeamDispatch({ cwd, stateDir, logsDir, maxPerTick: 5 } as any);
     } catch {
@@ -790,7 +870,7 @@ async function main() {
   }
 
   // 6. Team leader nudge (lead session only): remind the leader to check teammate/mailbox state.
-  if (!isTeamWorker && !deepInterviewStateActive) {
+  if (!isTeamWorker && canWriteLeaderScopedState && !deepInterviewStateActive) {
     try {
       await maybeNudgeTeamLeader({ cwd, stateDir, logsDir, preComputedLeaderStale });
     } catch {
@@ -866,9 +946,12 @@ async function main() {
       const idleFingerprint = buildIdleNotificationFingerprint(payload);
       const notifySessionId = getEffectiveSessionId();
 
-      const shouldNotifyLifecycle = notifySessionId
-        && shouldSendIdleNotification(stateDir, notifySessionId, idleFingerprint);
-      const shouldDispatchSessionIdleHookEvent = notifySessionId
+      const shouldNotifyLifecycle = notifySessionId && (
+        !canWriteLeaderScopedState
+        || shouldSendIdleNotification(stateDir, notifySessionId, idleFingerprint)
+      );
+      const shouldDispatchSessionIdleHookEvent = canWriteLeaderScopedState
+        && notifySessionId
         && shouldSendSessionIdleHookEvent(stateDir, notifySessionId, idleFingerprint);
 
       if (shouldNotifyLifecycle || shouldDispatchSessionIdleHookEvent) {
@@ -876,8 +959,10 @@ async function main() {
           const idleResult = await notifyLifecycle('session-idle', {
             sessionId: notifySessionId,
             projectPath: cwd,
+          }, undefined, {
+            persistScopedReceipts: canWriteLeaderScopedState,
           });
-          if (idleResult && idleResult.anySuccess) {
+          if (canWriteLeaderScopedState && idleResult && idleResult.anySuccess) {
             recordIdleNotificationSent(stateDir, notifySessionId, idleFingerprint);
           }
         }
@@ -919,7 +1004,7 @@ async function main() {
 
   // 9. Auto-nudge: detect Codex stall patterns and automatically send a continuation prompt.
   //    Works for both leader and worker contexts.
-  if (!deepInterviewStateActive || deepInterviewInputLockActive) {
+  if ((isTeamWorker || canWriteLeaderScopedState) && (!deepInterviewStateActive || deepInterviewInputLockActive)) {
     try {
       await maybeAutoNudge({ cwd, stateDir, logsDir, payload });
     } catch {
@@ -938,6 +1023,7 @@ async function main() {
         logsDir,
         sessionId: getEffectiveSessionId(),
         turnId: safeString(payload['turn-id'] || payload.turn_id || ''),
+        persistRuntimeFeedback: canWriteLeaderScopedState,
       });
     } catch (err) {
       // Structured warning for module import failure (issue #421)
@@ -956,7 +1042,7 @@ async function main() {
 
   // 10. Code simplifier: delegate recently modified files for simplification.
   //     Opt-in via ~/.omx/config.json: { "codeSimplifier": { "enabled": true } }
-  if (!isTeamWorker) {
+  if (!isTeamWorker && canWriteLeaderScopedState) {
     try {
       const { processCodeSimplifier } = await import('../hooks/code-simplifier/index.js');
       const csResult = processCodeSimplifier(cwd, stateDir);

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -82,18 +82,28 @@ function readCurrentTmuxSessionName(): string {
   }
 }
 
-async function readTmuxOption(targetValue: string, optionName: string, { pane = false } = {}): Promise<string> {
+interface TmuxOptionProbe {
+  status: 'present' | 'absent' | 'error';
+  value: string;
+}
+
+async function probeTmuxOption(targetValue: string, optionName: string, { pane = false } = {}): Promise<TmuxOptionProbe> {
   const target = safeString(targetValue).trim();
-  if (!target) return '';
+  if (!target) return { status: 'absent', value: '' };
   const args = ['show-option', '-qv'];
   if (pane) args.push('-p');
   args.push('-t', target, optionName);
   try {
     const result = await runProcess('tmux', args, 2000);
-    return safeString(result.stdout).trim();
+    const value = safeString(result.stdout).trim();
+    return { status: value ? 'present' : 'absent', value };
   } catch {
-    return '';
+    return { status: 'error', value: '' };
   }
+}
+
+async function readTmuxOption(targetValue: string, optionName: string, { pane = false } = {}): Promise<string> {
+  return (await probeTmuxOption(targetValue, optionName, { pane })).value;
 }
 
 async function readTmuxSessionInstanceId(sessionTarget: string): Promise<string> {
@@ -103,6 +113,86 @@ async function readTmuxSessionInstanceId(sessionTarget: string): Promise<string>
 async function readTmuxPaneInstanceId(paneTarget: string): Promise<string> {
   return readTmuxOption(paneTarget, OMX_PANE_INSTANCE_OPTION, { pane: true });
 }
+
+export interface ActualTmuxInstanceEvidence {
+  paneTarget: string;
+  sessionName: string;
+  paneInstanceId: string;
+  sessionInstanceId: string;
+  instanceId: string;
+  source: 'none' | 'pane' | 'session';
+  paneTagStatus: 'not-requested' | 'present' | 'absent' | 'error';
+}
+
+export async function probeActualTmuxInstanceEvidence(paneTarget?: string): Promise<ActualTmuxInstanceEvidence> {
+  const resolvedPaneTarget = safeString(paneTarget ?? process.env.TMUX_PANE ?? '').trim();
+  let sessionName = '';
+  if (resolvedPaneTarget) {
+    try {
+      const result = await runProcess('tmux', ['display-message', '-p', '-t', resolvedPaneTarget, '#S'], 2000);
+      sessionName = safeString(result.stdout).trim();
+    } catch {
+      // A pane target without a session cannot provide session-tag evidence.
+    }
+  } else {
+    sessionName = readCurrentTmuxSessionName();
+  }
+
+  const paneProbe = resolvedPaneTarget
+    ? await probeTmuxOption(resolvedPaneTarget, OMX_PANE_INSTANCE_OPTION, { pane: true })
+    : { status: 'absent' as const, value: '' };
+  const paneTagStatus = resolvedPaneTarget ? paneProbe.status : 'not-requested';
+  if (paneProbe.status === 'present') {
+    return {
+      paneTarget: resolvedPaneTarget,
+      sessionName,
+      paneInstanceId: paneProbe.value,
+      sessionInstanceId: '',
+      instanceId: paneProbe.value,
+      source: 'pane',
+      paneTagStatus,
+    };
+  }
+  if (paneProbe.status === 'error') {
+    return {
+      paneTarget: resolvedPaneTarget,
+      sessionName,
+      paneInstanceId: '',
+      sessionInstanceId: '',
+      instanceId: '',
+      source: 'none',
+      paneTagStatus,
+    };
+  }
+
+  const sessionInstanceId = sessionName
+    ? await readTmuxSessionInstanceId(sessionName)
+    : '';
+  return {
+    paneTarget: resolvedPaneTarget,
+    sessionName,
+    paneInstanceId: '',
+    sessionInstanceId,
+    instanceId: sessionInstanceId,
+    source: sessionInstanceId ? 'session' : 'none',
+    paneTagStatus,
+  };
+}
+
+export function tmuxEvidenceBindsCandidate(
+  evidence: ActualTmuxInstanceEvidence,
+  candidateSessionId: string,
+): boolean {
+  const candidate = safeString(candidateSessionId).trim();
+  if (!candidate) return false;
+  if (evidence.paneTagStatus === 'present') {
+    return evidence.source === 'pane' && evidence.paneInstanceId === candidate;
+  }
+  return evidence.paneTagStatus === 'absent'
+    && evidence.source === 'session'
+    && evidence.sessionInstanceId === candidate;
+}
+
 
 function warnPaneInstanceFallback(paneTarget: string): void {
   // Notify hooks run inside Codex foreground hook surfaces. Keep this
@@ -218,9 +308,10 @@ export async function resolveManagedSessionContext(
         authoritativeSessionCwd,
         canonicalSessionId || invocationSessionId,
       );
-    const currentTmuxSessionName = readCurrentTmuxSessionName();
-    const currentTmuxPaneTarget = safeString(paneTarget || process.env.TMUX_PANE || '').trim();
-    const currentTmuxPaneInstanceId = currentTmuxPaneTarget ? await readTmuxPaneInstanceId(currentTmuxPaneTarget) : '';
+    const evidence = await probeActualTmuxInstanceEvidence(paneTarget);
+    const currentTmuxSessionName = evidence.sessionName || readCurrentTmuxSessionName();
+    const currentTmuxPaneTarget = evidence.paneTarget;
+    const currentTmuxPaneInstanceId = evidence.paneInstanceId;
     if (currentTmuxPaneInstanceId && currentTmuxPaneInstanceId !== invocationSessionId) {
       return {
         managed: false,
@@ -248,7 +339,11 @@ export async function resolveManagedSessionContext(
       };
     }
 
-    const currentTmuxInstanceId = currentTmuxSessionName ? await readTmuxSessionInstanceId(currentTmuxSessionName) : '';
+    const currentTmuxInstanceId = evidence.sessionName === currentTmuxSessionName
+      ? evidence.sessionInstanceId
+      : currentTmuxSessionName
+        ? await readTmuxSessionInstanceId(currentTmuxSessionName)
+        : '';
     if (currentTmuxInstanceId && currentTmuxInstanceId !== invocationSessionId) {
       return {
         managed: false,
@@ -380,13 +475,20 @@ export async function verifyManagedPaneTarget(paneId: string, cwd: string, paylo
   }
 
   try {
-    const sessionResult = await runProcess('tmux', ['display-message', '-p', '-t', paneTarget, '#S'], 2000);
-    const paneSessionName = safeString(sessionResult.stdout).trim();
+    let paneSessionName = safeString(managedContext.currentTmuxSessionName).trim();
+    if (!paneSessionName) {
+      const sessionResult = await runProcess('tmux', ['display-message', '-p', '-t', paneTarget, '#S'], 2000);
+      paneSessionName = safeString(sessionResult.stdout).trim();
+    }
     if (!paneSessionName) {
       return { ok: false, reason: 'pane_session_missing', paneTarget, managedContext };
     }
-    const paneInstanceId = await readTmuxPaneInstanceId(paneTarget);
-    const sessionInstanceId = paneInstanceId ? '' : await readTmuxSessionInstanceId(paneSessionName);
+    const paneInstanceId = safeString(managedContext.currentTmuxPaneInstanceId).trim()
+      || await readTmuxPaneInstanceId(paneTarget);
+    const sessionInstanceId = paneInstanceId
+      ? ''
+      : safeString(managedContext.currentTmuxInstanceId).trim()
+        || await readTmuxSessionInstanceId(paneSessionName);
     if (paneInstanceId && paneInstanceId !== managedContext.invocationSessionId) {
       return { ok: false, reason: 'pane_instance_mismatch', paneTarget, paneSessionName, paneInstanceId, managedContext };
     }

--- a/src/scripts/notify-hook/state-io.ts
+++ b/src/scripts/notify-hook/state-io.ts
@@ -2,7 +2,7 @@
  * State file I/O helpers for notify-hook modules.
  */
 
-import { mkdir, readFile, readdir, writeFile } from 'fs/promises';
+import { mkdir, readFile, readdir, stat, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { validateSessionId } from '../../mcp/state-paths.js';
 import { asNumber, safeString } from './utils.js';
@@ -23,27 +23,87 @@ function isSafeStateFileName(fileName: string): boolean {
     && !fileName.includes('\\');
 }
 
-interface SessionMetadata {
+export interface SessionMetadata {
   sessionId?: string;
-  nativeAliases: string[];
+  aliases: string[];
+  status: 'missing' | 'unusable' | 'usable';
 }
 
 async function readSessionMetadataFromBaseStateDir(baseStateDir: string): Promise<SessionMetadata> {
-  const session = await readJsonIfExists(join(baseStateDir, 'session.json'), null);
+  let session: any;
+  try {
+    session = JSON.parse(await readFile(join(baseStateDir, 'session.json'), 'utf-8'));
+  } catch (error: any) {
+    return { aliases: [], status: error?.code === 'ENOENT' ? 'missing' : 'unusable' };
+  }
+  if (!session || typeof session !== 'object' || Array.isArray(session)) {
+    return { aliases: [], status: 'unusable' };
+  }
+
   let sessionId: string | undefined;
   try {
-    sessionId = validateSessionId(session?.session_id);
+    sessionId = validateSessionId(session.session_id);
   } catch {
-    sessionId = undefined;
+    return { aliases: [], status: 'unusable' };
   }
-  const nativeAliases = [
-    session?.native_session_id,
-    session?.codex_session_id,
-    session?.previous_native_session_id,
+  if (!sessionId) return { aliases: [], status: 'unusable' };
+
+  const aliases = [
+    session.native_session_id,
+    session.codex_session_id,
+    session.previous_native_session_id,
+    session.owner_omx_session_id,
   ]
     .map((value) => safeString(value).trim())
-    .filter(Boolean);
-  return { sessionId, nativeAliases: [...new Set(nativeAliases)] };
+    .filter((value) => {
+      try {
+        return Boolean(validateSessionId(value));
+      } catch {
+        return false;
+      }
+    });
+  return { sessionId, aliases: [...new Set(aliases)], status: 'usable' };
+}
+
+export async function readNotifySessionMetadata(baseStateDir: string): Promise<SessionMetadata> {
+  return readSessionMetadataFromBaseStateDir(baseStateDir);
+}
+
+function readOmxSessionIdFromEnvironment(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const candidate = safeString(env.OMX_SESSION_ID).trim();
+  if (!candidate) return undefined;
+  try {
+    return validateSessionId(candidate);
+  } catch {
+    return undefined;
+  }
+}
+
+export function isExplicitNotifySessionFork(
+  candidateSessionId: string | undefined,
+  metadata: Pick<SessionMetadata, 'sessionId' | 'aliases'>,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const explicitOmxSessionId = readOmxSessionIdFromEnvironment(env);
+  return Boolean(
+    candidateSessionId
+    && explicitOmxSessionId === candidateSessionId
+    && metadata.sessionId
+    && candidateSessionId !== metadata.sessionId
+    && !metadata.aliases.includes(candidateSessionId),
+  );
+}
+
+export async function hasExistingScopedSessionDir(baseStateDir: string, sessionId: string): Promise<boolean> {
+  try {
+    return (await stat(join(baseStateDir, 'sessions', sessionId))).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export function getOmxSessionIdFromEnvironment(): string | undefined {
+  return readOmxSessionIdFromEnvironment();
 }
 
 function readSessionIdFromEnvironment(): string | undefined {
@@ -63,7 +123,7 @@ function readSessionIdFromEnvironment(): string | undefined {
 
 function resolveCanonicalSessionId(candidate: string | undefined, metadata: SessionMetadata): string | undefined {
   if (!candidate) return undefined;
-  return metadata.sessionId && metadata.nativeAliases.includes(candidate)
+  return metadata.sessionId && metadata.aliases.includes(candidate)
     ? metadata.sessionId
     : candidate;
 }

--- a/src/scripts/notify-hook/visual-verdict.ts
+++ b/src/scripts/notify-hook/visual-verdict.ts
@@ -84,7 +84,15 @@ export function parseVisualVerdict(text: any): { verdict: string; raw: string } 
  *
  * Module import failure is handled by the caller in notify-hook.ts.
  */
-export async function maybePersistVisualVerdict({ cwd, payload, stateDir, logsDir, sessionId, turnId }: any): Promise<void> {
+export async function maybePersistVisualVerdict({
+  cwd,
+  payload,
+  stateDir,
+  logsDir,
+  sessionId,
+  turnId,
+  persistRuntimeFeedback = true,
+}: any): Promise<void> {
   const output = safeString(
     payload?.['last-assistant-message'] || payload?.last_assistant_message || '',
   );
@@ -92,17 +100,19 @@ export async function maybePersistVisualVerdict({ cwd, payload, stateDir, logsDi
 
   // Runtime visual feedback (JSON/fenced JSON) for ralph-progress persistence.
   // Non-fatal and observable via warn-level structured logging.
-  try {
-    await maybePersistRuntimeVisualFeedback({ cwd, output, sessionId, stateDir });
-  } catch (err: any) {
-    await logNotifyHookEvent(logsDir, {
-      timestamp: new Date().toISOString(),
-      level: 'warn',
-      type: 'visual_runtime_feedback_persist_failure',
-      error: err?.message || String(err),
-      session_id: sessionId,
-      turn_id: turnId,
-    });
+  if (persistRuntimeFeedback) {
+    try {
+      await maybePersistRuntimeVisualFeedback({ cwd, output, sessionId, stateDir });
+    } catch (err: any) {
+      await logNotifyHookEvent(logsDir, {
+        timestamp: new Date().toISOString(),
+        level: 'warn',
+        type: 'visual_runtime_feedback_persist_failure',
+        error: err?.message || String(err),
+        session_id: sessionId,
+        turn_id: turnId,
+      });
+    }
   }
 
   const parsed = parseVisualVerdict(output);

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -8,6 +8,7 @@ import { tmpdir } from 'node:os';
 import { executeStateOperation } from '../operations.js';
 import { subagentTrackingPath } from '../../subagents/tracker.js';
 import { updateModeState } from '../../modes/base.js';
+import { WRITABLE_STATE_SCOPE_ERRORS } from '../../mcp/state-paths.js';
 
 async function withAmbientTmuxEnv<T>(env: NodeJS.ProcessEnv, run: () => Promise<T>): Promise<T> {
   const previousTmux = process.env.TMUX;
@@ -1764,7 +1765,7 @@ describe('state operations directory initialization', () => {
     }
   });
 
-  it('does not promote stale session metadata when ralplan terminalizes from root scope', async () => {
+  it('fails closed without mutating root state when ralplan terminalization sees a foreign session pointer', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-stale-session-'));
     try {
       const staleSessionId = 'sess-ralplan-stale';
@@ -1816,23 +1817,23 @@ describe('state operations directory initialization', () => {
         },
       });
 
-      assert.equal(response.isError, undefined);
+      assert.equal(response.isError, true);
+      assert.deepEqual(response.payload, { error: WRITABLE_STATE_SCOPE_ERRORS.unusableSession });
       const rootRalplan = JSON.parse(await readFile(join(stateDir, 'ralplan-state.json'), 'utf-8')) as Record<string, unknown>;
-      assert.equal(rootRalplan.active, false);
-      assert.equal(rootRalplan.current_phase, 'complete');
-      assert.equal(rootRalplan.status, 'complete');
-      assert.equal(rootRalplan.session_id, undefined);
+      assert.equal(rootRalplan.active, true);
+      assert.equal(rootRalplan.current_phase, 'planning');
+      assert.equal(rootRalplan.session_id, staleSessionId);
       const rootSkill = JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')) as Record<string, unknown>;
-      assert.equal(rootSkill.active, false);
-      assert.equal(rootSkill.phase, 'complete');
-      assert.deepEqual(rootSkill.active_skills, []);
+      assert.equal(rootSkill.active, true);
+      assert.equal(rootSkill.phase, 'planning');
+      assert.equal(Array.isArray(rootSkill.active_skills), true);
       assert.equal(existsSync(join(sessionDir, 'ralplan-state.json')), false);
       assert.equal(existsSync(join(sessionDir, 'skill-active-state.json')), false);
 
       const listed = await executeStateOperation('state_list_active', {
         workingDirectory: wd,
       });
-      assert.deepEqual(listed.payload, { active_modes: [] });
+      assert.deepEqual(listed.payload, { active_modes: ['ralplan'] });
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -13,7 +13,7 @@ import {
   getStateDir,
   getStatePath,
   resolveRuntimeStateScope,
-  resolveStateScope,
+  resolveWritableStateScope,
   resolveWorkingDirectoryForState,
   validateSessionId,
   validateStateModeSegment,
@@ -545,14 +545,16 @@ export async function completeRalplanSession(options: {
   requireNativeSubagents?: boolean;
 }): Promise<boolean> {
   if (!isCompleteRalplanTerminalState(options.state)) return false;
-  const validationError = validateRalplanTerminalConsensus(options.cwd, options.state, options.explicitSessionId, {
+  const writableScope = await resolveWritableStateScope(options.cwd, options.explicitSessionId);
+  const sessionId = writableScope.sessionId;
+  const validationError = validateRalplanTerminalConsensus(options.cwd, options.state, sessionId, {
     requireNativeSubagents: options.requireNativeSubagents === true,
   });
   if (validationError) throw new Error(validationError);
 
-  const sessionId = optionalSessionId(options.explicitSessionId);
   const completedSessionId = sessionId ?? optionalSessionId(options.state.session_id);
   const rootScopeCompletion = !sessionId;
+
   const nowIso = new Date().toISOString();
   const rootState = buildRalplanTerminalState(options.state, sessionId, nowIso);
   const rootStatePath = getStatePath('ralplan', options.cwd);
@@ -761,13 +763,13 @@ export async function executeStateOperation(
       }
 
       case 'state_write': {
-        const stateScope = await resolveStateScope(cwd, explicitSessionId);
+        const stateScope = await resolveWritableStateScope(cwd, explicitSessionId);
         const effectiveSessionId = stateScope.sessionId;
+        const mode = validateStateModeSegment(rawArgs.mode);
         const { baseStateDir, rootSource } = getBaseStateDirWithSource(cwd);
         await initializeStateEnvironment(cwd, effectiveSessionId, rootSource);
-
-        const mode = validateStateModeSegment(rawArgs.mode);
         const path = getStatePath(mode, cwd, effectiveSessionId);
+
         const {
           mode: _mode,
           workingDirectory: _workingDirectory,
@@ -1020,9 +1022,10 @@ export async function executeStateOperation(
               cwd,
               baseStateDir,
               state: data,
-              explicitSessionId: effectiveSessionId,
+              explicitSessionId,
               requireNativeSubagents: true,
             });
+
           if (!ralplanCompletionHandled) {
             await syncCanonicalSkillStateForMode({
               cwd,
@@ -1047,69 +1050,71 @@ export async function executeStateOperation(
       }
 
       case 'state_clear': {
-        const stateScope = await resolveStateScope(cwd, explicitSessionId);
-        const effectiveSessionId = stateScope.sessionId;
-        const { baseStateDir, rootSource } = getBaseStateDirWithSource(cwd);
-        await initializeStateEnvironment(cwd, effectiveSessionId, rootSource);
-
         const mode = validateStateModeSegment(rawArgs.mode);
         const allSessions = rawArgs.all_sessions === true;
+        const { baseStateDir, rootSource } = getBaseStateDirWithSource(cwd);
 
-        if (!allSessions) {
-          const path = getStatePath(mode, cwd, effectiveSessionId);
-          if (
-            mode !== SKILL_ACTIVE_STATE_MODE
-            && effectiveSessionId
-            && existsSync(getStatePath(mode, cwd))
-          ) {
-            await writeClearedSessionScopedModeState(path, mode, effectiveSessionId);
-          } else if (existsSync(path)) {
+        if (allSessions) {
+          const removedPaths: string[] = [];
+          const paths = await getAllScopedStatePaths(mode, cwd);
+          for (const path of paths) {
+            if (!existsSync(path)) continue;
             await unlink(path);
+            removedPaths.push(path);
           }
-          const nativeStopCleared = effectiveSessionId
-            ? await clearSessionNativeStopState(baseStateDir, effectiveSessionId)
-            : [];
-          if (mode !== SKILL_ACTIVE_STATE_MODE) {
+          const canonicalPaths = mode === SKILL_ACTIVE_STATE_MODE
+            ? []
+            : await getAllScopedStatePaths(SKILL_ACTIVE_STATE_MODE, cwd);
+          if (canonicalPaths.some((path) => existsSync(path))) {
             await syncCanonicalSkillStateForMode({
               cwd,
               baseStateDir,
               mode,
               active: false,
-              sessionId: effectiveSessionId,
               source: 'state-operations',
+              allSessions: true,
             });
           }
-          return { payload: { cleared: true, mode, path, ...(nativeStopCleared.length > 0 ? { native_stop_cleared: nativeStopCleared } : {}) } };
+
+          return {
+            payload: {
+              cleared: true,
+              mode,
+              all_sessions: true,
+              removed: removedPaths.length,
+              paths: removedPaths,
+              warning: 'all_sessions clears global and session-scoped state files',
+            },
+          };
         }
 
-        const removedPaths: string[] = [];
-        const paths = await getAllScopedStatePaths(mode, cwd);
-        for (const path of paths) {
-          if (!existsSync(path)) continue;
+        const stateScope = await resolveWritableStateScope(cwd, explicitSessionId);
+        const effectiveSessionId = stateScope.sessionId;
+        await initializeStateEnvironment(cwd, effectiveSessionId, rootSource);
+        const path = getStatePath(mode, cwd, effectiveSessionId);
+        if (
+          mode !== SKILL_ACTIVE_STATE_MODE
+          && effectiveSessionId
+          && existsSync(getStatePath(mode, cwd))
+        ) {
+          await writeClearedSessionScopedModeState(path, mode, effectiveSessionId);
+        } else if (existsSync(path)) {
           await unlink(path);
-          removedPaths.push(path);
         }
+        const nativeStopCleared = effectiveSessionId
+          ? await clearSessionNativeStopState(baseStateDir, effectiveSessionId)
+          : [];
         if (mode !== SKILL_ACTIVE_STATE_MODE) {
           await syncCanonicalSkillStateForMode({
             cwd,
             baseStateDir,
             mode,
             active: false,
+            sessionId: effectiveSessionId,
             source: 'state-operations',
-            allSessions: true,
           });
         }
-
-        return {
-          payload: {
-            cleared: true,
-            mode,
-            all_sessions: true,
-            removed: removedPaths.length,
-            paths: removedPaths,
-            warning: 'all_sessions clears global and session-scoped state files',
-          },
-        };
+        return { payload: { cleared: true, mode, path, ...(nativeStopCleared.length > 0 ? { native_stop_cleared: nativeStopCleared } : {}) } };
       }
 
       case 'state_list_active': {


### PR DESCRIPTION
Fixes #3138

## Summary
- make the selected `session.json.session_id` the sole implicit writable workflow authority
- bind `OMX_SESSION_ID` owner aliases only when actual tmux evidence proves the candidate, with pane-tag precedence and session-tag fallback only after proven pane-tag absence
- fail closed for foreign, indeterminate, malformed, and unmatched scopes without creating a second owner session
- preserve native-only/root compatibility, canonical terminal persistence, and provider delivery while suppressing scoped notification receipts
- order launch pointer reconciliation before credential slot selection and process spawn, with typed abort cleanup

## Verification
Exact head: `e88ee64f7a44580e1263add0b9cecc12e6695e09`

- `npm run build`
- focused issue #3138 session/state/native/CLI/auth/notify matrix
- `npm run check:no-unused`
- `npm run lint`
- `git diff --check`
- `npm test` (all 372 compiled test files and catalog check)
- packed-install smoke `omx.issue3138.installed-smoke.v4`: all 10 scenarios passed
- packed tarball SHA-256: `0fca55e695106a424c101c716004fa995e3e21ce2ee621efbe449e30e6722694`

The packed smoke covers missing and unmatched aliases, ordinary and all-session clears, cancel/force isolation, owner-terminal/native-Stop convergence, managed provider delivery without receipts, and rejected-root no-launch cleanup.

This PR is not being merged until required CI and a separate exact-head adversarial GJC review pass.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*