### PR TITLE
fix(state): establish authoritative runtime root

### DIFF
--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -31,7 +31,7 @@ describe('CLI session-scoped state parity', () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-session-scope-'));
     try {
       await mkdir(join(wd, '.omx', 'state'), { recursive: true });
-      await writeFile(join(wd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: 'sess1' }));
+      await writeFile(join(wd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: 'sess1', cwd: wd, state_root: join(wd, '.omx', 'state') }));
       const scopedDir = join(wd, '.omx', 'state', 'sessions', 'sess1');
       await mkdir(scopedDir, { recursive: true });
       await writeFile(join(scopedDir, 'team-state.json'), JSON.stringify({
@@ -66,7 +66,7 @@ describe('CLI session-scoped state parity', () => {
       const ralphPath = join(sessionDir, 'ralph-state.json');
       const nativeStopPath = join(sessionDir, 'native-stop-state.json');
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: stateDir }));
       await writeFile(ralphPath, JSON.stringify({ active: true, current_phase: 'executing' }));
       await writeFile(nativeStopPath, JSON.stringify({
         sessions: { [sessionId]: { last_signature: 'ralph-stop|pending' } },
@@ -102,7 +102,7 @@ describe('CLI session-scoped state parity', () => {
       const sessionId = 'sess-clear';
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: stateDir }));
       await writeFile(join(stateDir, 'deep-interview-state.json'), JSON.stringify({
         active: true,
         mode: 'deep-interview',
@@ -436,7 +436,7 @@ describe('CLI session-scoped state parity', () => {
       const ultragoalDir = join(wd, '.omx', 'ultragoal');
       await mkdir(sessionDir, { recursive: true });
       await mkdir(ultragoalDir, { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: stateDir }));
       await writeFile(join(sessionDir, 'ultragoal-state.json'), JSON.stringify({
         active: true,
         mode: 'ultragoal',
@@ -473,7 +473,7 @@ describe('CLI session-scoped state parity', () => {
       const sessionId = 'sess-link';
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: stateDir }));
 
       await writeFile(join(sessionDir, 'ralph-state.json'), JSON.stringify({
         active: true,
@@ -514,7 +514,7 @@ describe('CLI session-scoped state parity', () => {
       const sessionB = join(stateDir, 'sessions', 'sessB');
       await mkdir(sessionA, { recursive: true });
       await mkdir(sessionB, { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: 'sessA' }));
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: 'sessA', cwd: wd, state_root: stateDir }));
 
       await writeFile(join(sessionA, 'ralph-state.json'), JSON.stringify({
         active: true,

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1403,7 +1403,7 @@ describe('teamCommand shutdown --force parsing', () => {
       await mkdir(join(wd, '.omx', 'state'), { recursive: true });
       await writeFile(
         join(wd, '.omx', 'state', 'session.json'),
-        JSON.stringify({ session_id: 'sess-team-shutdown-state' }),
+        JSON.stringify({ session_id: 'sess-team-shutdown-state', cwd: wd, state_root: join(wd, '.omx', 'state') }),
       );
       await initTeamState(
         'team-shutdown-mode-state',

--- a/src/hooks/extensibility/__tests__/dispatcher.test.ts
+++ b/src/hooks/extensibility/__tests__/dispatcher.test.ts
@@ -161,6 +161,48 @@ export async function onHookEvent(event, sdk) {
     }
   });
 
+  it('resolves plugin authority from options.env instead of ambient process.env', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-dispatch-env-source-'));
+    const stateRoot = await mkdtemp(join(tmpdir(), 'omx-dispatch-env-authority-'));
+    const ambientRoot = await mkdtemp(join(tmpdir(), 'omx-dispatch-env-ambient-'));
+    const previousTeamRoot = process.env.OMX_TEAM_STATE_ROOT;
+    try {
+      process.env.OMX_TEAM_STATE_ROOT = ambientRoot;
+      const dir = join(cwd, '.omx', 'hooks');
+      const sessionDir = join(stateRoot, 'sessions', 'sess-env');
+      await mkdir(dir, { recursive: true });
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateRoot, 'session.json'), JSON.stringify({ session_id: 'sess-env', cwd, state_root: stateRoot }));
+      await writeFile(join(sessionDir, 'hud-state.json'), JSON.stringify({ turn_count: 8 }));
+      await writeFile(
+        join(dir, 'env-root-reader.mjs'),
+        `import { writeFile } from 'node:fs/promises';
+export async function onHookEvent(event, sdk) {
+  await writeFile(process.env.OMX_TEST_DISPATCH_OUTPUT, JSON.stringify(await sdk.omx.hud.read()));
+}`,
+      );
+      const outputPath = join(cwd, 'dispatch-output.json');
+      const result = await dispatchHookEvent(buildHookEvent('session-start', { session_id: 'sess-env' }), {
+        cwd,
+        env: {
+          ...process.env,
+          OMX_TEAM_STATE_ROOT: stateRoot,
+          OMX_HOOK_PLUGINS: '1',
+          OMX_TEST_DISPATCH_OUTPUT: outputPath,
+        },
+      });
+
+      assert.equal(result.results[0]?.ok, true);
+      assert.deepEqual(JSON.parse(await readFile(outputPath, 'utf8')), { turn_count: 8 });
+    } finally {
+      if (previousTeamRoot === undefined) delete process.env.OMX_TEAM_STATE_ROOT;
+      else process.env.OMX_TEAM_STATE_ROOT = previousTeamRoot;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(stateRoot, { recursive: true, force: true });
+      await rm(ambientRoot, { recursive: true, force: true });
+    }
+  });
+
   it('returns null HUD state through the runner when the default state root is absent', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-dispatch-missing-root-'));
     try {

--- a/src/hooks/extensibility/__tests__/dispatcher.test.ts
+++ b/src/hooks/extensibility/__tests__/dispatcher.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { describe, it } from 'node:test';
 import { isHookPluginFeatureEnabled, dispatchHookEvent } from '../dispatcher.js';
 import { buildHookEvent } from '../events.js';
@@ -166,8 +166,10 @@ export async function onHookEvent(event, sdk) {
     const stateRoot = await mkdtemp(join(tmpdir(), 'omx-dispatch-env-authority-'));
     const ambientRoot = await mkdtemp(join(tmpdir(), 'omx-dispatch-env-ambient-'));
     const previousTeamRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const previousAllowlist = process.env.OMX_MCP_WORKDIR_ROOTS;
     try {
       process.env.OMX_TEAM_STATE_ROOT = ambientRoot;
+      process.env.OMX_MCP_WORKDIR_ROOTS = ambientRoot;
       const dir = join(cwd, '.omx', 'hooks');
       const sessionDir = join(stateRoot, 'sessions', 'sess-env');
       await mkdir(dir, { recursive: true });
@@ -187,6 +189,7 @@ export async function onHookEvent(event, sdk) {
         env: {
           ...process.env,
           OMX_TEAM_STATE_ROOT: stateRoot,
+          OMX_MCP_WORKDIR_ROOTS: [cwd, stateRoot].join(delimiter),
           OMX_HOOK_PLUGINS: '1',
           OMX_TEST_DISPATCH_OUTPUT: outputPath,
         },
@@ -197,6 +200,8 @@ export async function onHookEvent(event, sdk) {
     } finally {
       if (previousTeamRoot === undefined) delete process.env.OMX_TEAM_STATE_ROOT;
       else process.env.OMX_TEAM_STATE_ROOT = previousTeamRoot;
+      if (previousAllowlist === undefined) delete process.env.OMX_MCP_WORKDIR_ROOTS;
+      else process.env.OMX_MCP_WORKDIR_ROOTS = previousAllowlist;
       await rm(cwd, { recursive: true, force: true });
       await rm(stateRoot, { recursive: true, force: true });
       await rm(ambientRoot, { recursive: true, force: true });

--- a/src/hooks/extensibility/__tests__/dispatcher.test.ts
+++ b/src/hooks/extensibility/__tests__/dispatcher.test.ts
@@ -160,6 +160,33 @@ export async function onHookEvent(event, sdk) {
     }
   });
 
+  it('returns null HUD state through the runner when the default state root is absent', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-dispatch-missing-root-'));
+    try {
+      const dir = join(cwd, '.omx', 'hooks');
+      await mkdir(dir, { recursive: true });
+      await writeFile(
+        join(dir, 'missing-root-reader.mjs'),
+        `import { writeFile } from 'node:fs/promises';
+export async function onHookEvent(event, sdk) {
+  const hud = await sdk.omx.hud.read();
+  await writeFile(process.env.OMX_TEST_DISPATCH_OUTPUT, JSON.stringify(hud));
+}`,
+      );
+      const outputPath = join(cwd, 'dispatch-output.json');
+
+      const result = await dispatchHookEvent(buildHookEvent('session-start'), {
+        cwd,
+        env: { ...process.env, OMX_HOOK_PLUGINS: '1', OMX_TEST_DISPATCH_OUTPUT: outputPath },
+      });
+
+      assert.equal(result.results[0]?.ok, true);
+      assert.equal(JSON.parse(await readFile(outputPath, 'utf8')), null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('does not execute plugin top-level code in the parent process', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-dispatch-'));
     try {

--- a/src/hooks/extensibility/__tests__/dispatcher.test.ts
+++ b/src/hooks/extensibility/__tests__/dispatcher.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -323,6 +324,7 @@ export async function onHookEvent() {}
 
   it('dedupes repeated native lifecycle hook dispatches for the same session/turn fingerprint', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-dispatch-dedupe-'));
+    const stateRoot = await mkdtemp(join(tmpdir(), 'omx-dispatch-dedupe-root-'));
     try {
       const dir = join(cwd, '.omx', 'hooks');
       await mkdir(dir, { recursive: true });
@@ -341,10 +343,12 @@ export async function onHookEvent() {}
 
       const first = await dispatchHookEvent(event, {
         cwd,
+        stateRoot,
         env: { ...process.env, OMX_HOOK_PLUGINS: '1' },
       });
       const second = await dispatchHookEvent(event, {
         cwd,
+        stateRoot,
         env: { ...process.env, OMX_HOOK_PLUGINS: '1' },
       });
 
@@ -355,8 +359,11 @@ export async function onHookEvent() {}
       assert.equal(second.enabled, true);
       assert.equal(second.reason, 'deduped');
       assert.equal(second.results.length, 0);
+      assert.equal(existsSync(join(stateRoot, 'sessions', 'sess-1', 'lifecycle-notif-state.json')), true);
+      assert.equal(existsSync(join(cwd, '.omx', 'state', 'sessions', 'sess-1', 'lifecycle-notif-state.json')), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
+      await rm(stateRoot, { recursive: true, force: true });
     }
   });
 });

--- a/src/hooks/extensibility/__tests__/dispatcher.test.ts
+++ b/src/hooks/extensibility/__tests__/dispatcher.test.ts
@@ -135,7 +135,7 @@ describe('dispatchHookEvent', () => {
       const sessionDir = join(stateRoot, 'sessions', 'sess-dispatch');
       await mkdir(dir, { recursive: true });
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(stateRoot, 'session.json'), JSON.stringify({ session_id: 'sess-dispatch' }));
+      await writeFile(join(stateRoot, 'session.json'), JSON.stringify({ session_id: 'sess-dispatch', cwd, state_root: stateRoot }));
       await writeFile(join(sessionDir, 'hud-state.json'), JSON.stringify({ turn_count: 7 }));
       await writeFile(
         join(dir, 'root-reader.mjs'),

--- a/src/hooks/extensibility/__tests__/dispatcher.test.ts
+++ b/src/hooks/extensibility/__tests__/dispatcher.test.ts
@@ -126,6 +126,40 @@ describe('dispatchHookEvent', () => {
     }
   });
 
+  it('forwards explicit stateRoot through the plugin runner to HUD reads', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-dispatch-root-source-'));
+    const stateRoot = await mkdtemp(join(tmpdir(), 'omx-dispatch-root-authority-'));
+    try {
+      const dir = join(cwd, '.omx', 'hooks');
+      const sessionDir = join(stateRoot, 'sessions', 'sess-dispatch');
+      await mkdir(dir, { recursive: true });
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateRoot, 'session.json'), JSON.stringify({ session_id: 'sess-dispatch' }));
+      await writeFile(join(sessionDir, 'hud-state.json'), JSON.stringify({ turn_count: 7 }));
+      await writeFile(
+        join(dir, 'root-reader.mjs'),
+        `import { writeFile } from 'node:fs/promises';
+export async function onHookEvent(event, sdk) {
+  const hud = await sdk.omx.hud.read();
+  await writeFile(process.env.OMX_TEST_DISPATCH_OUTPUT, JSON.stringify(hud));
+}`,
+      );
+      const outputPath = join(cwd, 'dispatch-output.json');
+
+      const result = await dispatchHookEvent(buildHookEvent('session-start'), {
+        cwd,
+        stateRoot,
+        env: { ...process.env, OMX_HOOK_PLUGINS: '1', OMX_TEST_DISPATCH_OUTPUT: outputPath },
+      });
+
+      assert.equal(result.results[0]?.ok, true);
+      assert.deepEqual(JSON.parse(await readFile(outputPath, 'utf8')), { turn_count: 7 });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(stateRoot, { recursive: true, force: true });
+    }
+  });
+
   it('does not execute plugin top-level code in the parent process', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-dispatch-'));
     try {

--- a/src/hooks/extensibility/__tests__/sdk.test.ts
+++ b/src/hooks/extensibility/__tests__/sdk.test.ts
@@ -486,6 +486,16 @@ exit 1
           await writeFile(join(stateRoot, 'session.json'), JSON.stringify({ session_id: 'sess-file-escaped' }));
           sdk = createHookPluginSdk({ cwd, stateRoot, pluginName: 'test', event: makeEvent() });
           assert.equal(await sdk.omx.hud.read(), null);
+
+          const siblingDir = join(stateRoot, 'sessions', 'sess-sibling');
+          const siblingTargetDir = join(stateRoot, 'sessions', 'sess-sibling-target');
+          await mkdir(siblingDir, { recursive: true });
+          await mkdir(siblingTargetDir, { recursive: true });
+          await writeFile(join(siblingTargetDir, 'hud-state.json'), JSON.stringify({ turn_count: 55 }));
+          await symlink(join(siblingTargetDir, 'hud-state.json'), join(siblingDir, 'hud-state.json'), 'file');
+          await writeFile(join(stateRoot, 'session.json'), JSON.stringify({ session_id: 'sess-sibling' }));
+          sdk = createHookPluginSdk({ cwd, stateRoot, pluginName: 'test', event: makeEvent() });
+          assert.equal(await sdk.omx.hud.read(), null);
         }
       } finally {
         await rm(cwd, { recursive: true, force: true });

--- a/src/hooks/extensibility/__tests__/sdk.test.ts
+++ b/src/hooks/extensibility/__tests__/sdk.test.ts
@@ -437,6 +437,7 @@ exit 1
         await writeFile(join(stateRoot, 'session.json'), JSON.stringify({
           session_id: 'sess-authority',
           cwd,
+          state_root: stateRoot,
         }));
         await writeFile(join(stateRoot, 'sessions', 'sess-authority', 'hud-state.json'), JSON.stringify({
           last_turn_at: 'authoritative',
@@ -447,12 +448,61 @@ exit 1
           cwd,
           stateRoot,
           pluginName: 'test',
-          event: makeEvent(),
+          event: { ...makeEvent(), session_id: 'sess-authority' },
         });
         assert.deepEqual(await sdk.omx.hud.read(), {
           last_turn_at: 'authoritative',
           turn_count: 3,
         });
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+        await rm(stateRoot, { recursive: true, force: true });
+      }
+    });
+
+    it('requires a usable pointer and bound hook session for explicit HUD reads', async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'omx-sdk-hud-binding-source-'));
+      const stateRoot = await mkdtemp(join(tmpdir(), 'omx-sdk-hud-binding-root-'));
+      try {
+        const sessionDir = join(stateRoot, 'sessions', 'sess-canonical');
+        await mkdir(sessionDir, { recursive: true });
+        await writeFile(join(sessionDir, 'hud-state.json'), JSON.stringify({ turn_count: 4 }));
+        await writeFile(join(stateRoot, 'session.json'), JSON.stringify({
+          session_id: 'sess-canonical',
+          native_session_id: 'sess-native',
+          cwd,
+          state_root: stateRoot,
+        }));
+
+        let sdk = createHookPluginSdk({
+          cwd,
+          stateRoot,
+          pluginName: 'test',
+          event: { ...makeEvent(), session_id: 'sess-native' },
+        });
+        assert.deepEqual(await sdk.omx.hud.read(), { turn_count: 4 });
+
+        sdk = createHookPluginSdk({
+          cwd,
+          stateRoot,
+          pluginName: 'test',
+          event: { ...makeEvent(), session_id: 'sess-foreign' },
+        });
+        assert.equal(await sdk.omx.hud.read(), null);
+
+        await writeFile(join(stateRoot, 'session.json'), JSON.stringify({
+          session_id: 'sess-canonical',
+          cwd,
+          state_root: stateRoot,
+          pid: 2_147_483_647,
+        }));
+        sdk = createHookPluginSdk({
+          cwd,
+          stateRoot,
+          pluginName: 'test',
+          event: { ...makeEvent(), session_id: 'sess-canonical' },
+        });
+        assert.equal(await sdk.omx.hud.read(), null);
       } finally {
         await rm(cwd, { recursive: true, force: true });
         await rm(stateRoot, { recursive: true, force: true });
@@ -471,8 +521,8 @@ exit 1
         await mkdir(join(stateRoot, 'sessions'), { recursive: true });
         await writeFile(join(outside, 'hud-state.json'), JSON.stringify({ turn_count: 99 }));
         await symlink(outside, join(stateRoot, 'sessions', 'sess-escaped'), process.platform === 'win32' ? 'junction' : 'dir');
-        await writeFile(join(stateRoot, 'session.json'), JSON.stringify({ session_id: 'sess-escaped' }));
-        sdk = createHookPluginSdk({ cwd, stateRoot, pluginName: 'test', event: makeEvent() });
+        await writeFile(join(stateRoot, 'session.json'), JSON.stringify({ session_id: 'sess-escaped', cwd, state_root: stateRoot }));
+        sdk = createHookPluginSdk({ cwd, stateRoot, pluginName: 'test', event: { ...makeEvent(), session_id: 'sess-escaped' } });
         assert.equal(await sdk.omx.hud.read(), null);
 
         if (process.platform !== 'win32') {
@@ -483,8 +533,8 @@ exit 1
             join(fileSessionDir, 'hud-state.json'),
             'file',
           );
-          await writeFile(join(stateRoot, 'session.json'), JSON.stringify({ session_id: 'sess-file-escaped' }));
-          sdk = createHookPluginSdk({ cwd, stateRoot, pluginName: 'test', event: makeEvent() });
+          await writeFile(join(stateRoot, 'session.json'), JSON.stringify({ session_id: 'sess-file-escaped', cwd, state_root: stateRoot }));
+          sdk = createHookPluginSdk({ cwd, stateRoot, pluginName: 'test', event: { ...makeEvent(), session_id: 'sess-file-escaped' } });
           assert.equal(await sdk.omx.hud.read(), null);
 
           const siblingDir = join(stateRoot, 'sessions', 'sess-sibling');
@@ -493,8 +543,8 @@ exit 1
           await mkdir(siblingTargetDir, { recursive: true });
           await writeFile(join(siblingTargetDir, 'hud-state.json'), JSON.stringify({ turn_count: 55 }));
           await symlink(join(siblingTargetDir, 'hud-state.json'), join(siblingDir, 'hud-state.json'), 'file');
-          await writeFile(join(stateRoot, 'session.json'), JSON.stringify({ session_id: 'sess-sibling' }));
-          sdk = createHookPluginSdk({ cwd, stateRoot, pluginName: 'test', event: makeEvent() });
+          await writeFile(join(stateRoot, 'session.json'), JSON.stringify({ session_id: 'sess-sibling', cwd, state_root: stateRoot }));
+          sdk = createHookPluginSdk({ cwd, stateRoot, pluginName: 'test', event: { ...makeEvent(), session_id: 'sess-sibling' } });
           assert.equal(await sdk.omx.hud.read(), null);
         }
       } finally {

--- a/src/hooks/extensibility/__tests__/sdk.test.ts
+++ b/src/hooks/extensibility/__tests__/sdk.test.ts
@@ -424,6 +424,41 @@ exit 1
       }
     });
 
+    it('honors explicit stateRoot when reading session-scoped HUD state', async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'omx-sdk-hud-source-'));
+      const stateRoot = await mkdtemp(join(tmpdir(), 'omx-sdk-hud-authority-'));
+      try {
+        await writeOmxStateFile(cwd, 'session.json', { session_id: 'stale-source', cwd });
+        await writeOmxStateFile(cwd, join('sessions', 'stale-source', 'hud-state.json'), {
+          last_turn_at: 'stale-source',
+          turn_count: 99,
+        });
+        await mkdir(join(stateRoot, 'sessions', 'sess-authority'), { recursive: true });
+        await writeFile(join(stateRoot, 'session.json'), JSON.stringify({
+          session_id: 'sess-authority',
+          cwd,
+        }));
+        await writeFile(join(stateRoot, 'sessions', 'sess-authority', 'hud-state.json'), JSON.stringify({
+          last_turn_at: 'authoritative',
+          turn_count: 3,
+        }));
+
+        const sdk = createHookPluginSdk({
+          cwd,
+          stateRoot,
+          pluginName: 'test',
+          event: makeEvent(),
+        });
+        assert.deepEqual(await sdk.omx.hud.read(), {
+          last_turn_at: 'authoritative',
+          turn_count: 3,
+        });
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+        await rm(stateRoot, { recursive: true, force: true });
+      }
+    });
+
     it('returns null for missing omx reader files', async () => {
       const cwd = await mkdtemp(join(tmpdir(), 'omx-sdk-'));
       try {

--- a/src/hooks/extensibility/__tests__/sdk.test.ts
+++ b/src/hooks/extensibility/__tests__/sdk.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { describe, it } from 'node:test';
@@ -456,6 +456,28 @@ exit 1
       } finally {
         await rm(cwd, { recursive: true, force: true });
         await rm(stateRoot, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects invalid and symlink-escaped sessions under explicit stateRoot', async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'omx-sdk-hud-containment-source-'));
+      const stateRoot = await mkdtemp(join(tmpdir(), 'omx-sdk-hud-containment-root-'));
+      const outside = await mkdtemp(join(tmpdir(), 'omx-sdk-hud-containment-outside-'));
+      try {
+        await writeFile(join(stateRoot, 'session.json'), JSON.stringify({ session_id: '../outside' }));
+        let sdk = createHookPluginSdk({ cwd, stateRoot, pluginName: 'test', event: makeEvent() });
+        assert.equal(await sdk.omx.hud.read(), null);
+
+        await mkdir(join(stateRoot, 'sessions'), { recursive: true });
+        await writeFile(join(outside, 'hud-state.json'), JSON.stringify({ turn_count: 99 }));
+        await symlink(outside, join(stateRoot, 'sessions', 'sess-escaped'), process.platform === 'win32' ? 'junction' : 'dir');
+        await writeFile(join(stateRoot, 'session.json'), JSON.stringify({ session_id: 'sess-escaped' }));
+        sdk = createHookPluginSdk({ cwd, stateRoot, pluginName: 'test', event: makeEvent() });
+        assert.equal(await sdk.omx.hud.read(), null);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+        await rm(stateRoot, { recursive: true, force: true });
+        await rm(outside, { recursive: true, force: true });
       }
     });
 

--- a/src/hooks/extensibility/__tests__/sdk.test.ts
+++ b/src/hooks/extensibility/__tests__/sdk.test.ts
@@ -542,6 +542,27 @@ exit 1
         sdk = createHookPluginSdk({ cwd, stateRoot, pluginName: 'test', event: { ...makeEvent(), session_id: 'sess-escaped' } });
         assert.equal(await sdk.omx.hud.read(), null);
 
+        const crossSessionTarget = join(stateRoot, 'sessions', 'sess-cross-target');
+        await mkdir(crossSessionTarget, { recursive: true });
+        await writeFile(join(crossSessionTarget, 'hud-state.json'), JSON.stringify({ turn_count: 77 }));
+        await symlink(
+          crossSessionTarget,
+          join(stateRoot, 'sessions', 'sess-cross'),
+          process.platform === 'win32' ? 'junction' : 'dir',
+        );
+        await writeFile(join(stateRoot, 'session.json'), JSON.stringify({
+          session_id: 'sess-cross',
+          cwd,
+          state_root: stateRoot,
+        }));
+        sdk = createHookPluginSdk({
+          cwd,
+          stateRoot,
+          pluginName: 'test',
+          event: { ...makeEvent(), session_id: 'sess-cross' },
+        });
+        assert.equal(await sdk.omx.hud.read(), null);
+
         if (process.platform !== 'win32') {
           const fileSessionDir = join(stateRoot, 'sessions', 'sess-file-escaped');
           await mkdir(fileSessionDir, { recursive: true });

--- a/src/hooks/extensibility/__tests__/sdk.test.ts
+++ b/src/hooks/extensibility/__tests__/sdk.test.ts
@@ -474,6 +474,19 @@ exit 1
         await writeFile(join(stateRoot, 'session.json'), JSON.stringify({ session_id: 'sess-escaped' }));
         sdk = createHookPluginSdk({ cwd, stateRoot, pluginName: 'test', event: makeEvent() });
         assert.equal(await sdk.omx.hud.read(), null);
+
+        if (process.platform !== 'win32') {
+          const fileSessionDir = join(stateRoot, 'sessions', 'sess-file-escaped');
+          await mkdir(fileSessionDir, { recursive: true });
+          await symlink(
+            join(outside, 'hud-state.json'),
+            join(fileSessionDir, 'hud-state.json'),
+            'file',
+          );
+          await writeFile(join(stateRoot, 'session.json'), JSON.stringify({ session_id: 'sess-file-escaped' }));
+          sdk = createHookPluginSdk({ cwd, stateRoot, pluginName: 'test', event: makeEvent() });
+          assert.equal(await sdk.omx.hud.read(), null);
+        }
       } finally {
         await rm(cwd, { recursive: true, force: true });
         await rm(stateRoot, { recursive: true, force: true });

--- a/src/hooks/extensibility/__tests__/sdk.test.ts
+++ b/src/hooks/extensibility/__tests__/sdk.test.ts
@@ -470,6 +470,7 @@ exit 1
         await writeFile(join(stateRoot, 'session.json'), JSON.stringify({
           session_id: 'sess-canonical',
           native_session_id: 'sess-native',
+          owner_codex_session_id: 'sess-owner-codex',
           cwd,
           state_root: stateRoot,
         }));
@@ -481,6 +482,22 @@ exit 1
           event: { ...makeEvent(), session_id: 'sess-native' },
         });
         assert.deepEqual(await sdk.omx.hud.read(), { turn_count: 4 });
+
+        sdk = createHookPluginSdk({
+          cwd,
+          stateRoot,
+          pluginName: 'test',
+          event: { ...makeEvent(), session_id: 'sess-owner-codex' },
+        });
+        assert.deepEqual(await sdk.omx.hud.read(), { turn_count: 4 });
+
+        sdk = createHookPluginSdk({
+          cwd,
+          stateRoot,
+          pluginName: 'test',
+          event: { ...makeEvent(), session_id: '../invalid' },
+        });
+        assert.equal(await sdk.omx.hud.read(), null);
 
         sdk = createHookPluginSdk({
           cwd,

--- a/src/hooks/extensibility/dispatcher.ts
+++ b/src/hooks/extensibility/dispatcher.ts
@@ -266,6 +266,7 @@ async function runPluginRunner(
 				pluginPath: plugin.path,
 				event,
 				sideEffectsEnabled,
+				stateRoot: options.stateRoot,
 			}),
 		);
 		child.stdin.end();

--- a/src/hooks/extensibility/dispatcher.ts
+++ b/src/hooks/extensibility/dispatcher.ts
@@ -311,8 +311,8 @@ export async function dispatchHookEvent(
 	options: HookDispatchOptions = {},
 ): Promise<HookDispatchResult> {
 	const cwd = options.cwd || process.cwd();
-	const stateRoot = options.stateRoot ?? getBaseStateDir(cwd);
 	const env = options.env || process.env;
+	const stateRoot = options.stateRoot ?? getBaseStateDir(cwd, env);
 	const runtimeHookDispatchEnabled =
 		shouldForceEnableRuntimeHookDispatch(event) || isHookPluginsEnabled(env);
 	const enabled = options.enabled ?? runtimeHookDispatchEnabled;

--- a/src/hooks/extensibility/dispatcher.ts
+++ b/src/hooks/extensibility/dispatcher.ts
@@ -4,6 +4,7 @@ import { appendFile, mkdir } from "fs/promises";
 import { join } from "path";
 import { getPackageRoot } from "../../utils/package.js";
 import { omxRoot } from "../../utils/paths.js";
+import { getBaseStateDir } from "../../mcp/state-paths.js";
 import {
 	createLifecycleBroadcastFingerprint,
 	recordLifecycleHookBroadcastSent,
@@ -266,7 +267,7 @@ async function runPluginRunner(
 				pluginPath: plugin.path,
 				event,
 				sideEffectsEnabled,
-				stateRoot: options.stateRoot,
+				stateRoot: options.stateRoot ?? getBaseStateDir(options.cwd),
 			}),
 		);
 		child.stdin.end();
@@ -310,6 +311,7 @@ export async function dispatchHookEvent(
 	options: HookDispatchOptions = {},
 ): Promise<HookDispatchResult> {
 	const cwd = options.cwd || process.cwd();
+	const stateRoot = options.stateRoot ?? getBaseStateDir(cwd);
 	const env = options.env || process.env;
 	const runtimeHookDispatchEnabled =
 		shouldForceEnableRuntimeHookDispatch(event) || isHookPluginsEnabled(env);
@@ -374,7 +376,7 @@ export async function dispatchHookEvent(
 		const result = await runPluginRunner(
 			plugin,
 			event,
-			{ ...options, cwd, env },
+			{ ...options, cwd, env, stateRoot },
 			sideEffectsEnabled,
 		);
 		summary.results.push(result);

--- a/src/hooks/extensibility/dispatcher.ts
+++ b/src/hooks/extensibility/dispatcher.ts
@@ -343,7 +343,7 @@ export async function dispatchHookEvent(
 	if (
 		dedupeFingerprint
 		&& !shouldSendLifecycleHookBroadcast(
-			join(omxRoot(cwd), "state"),
+			stateRoot,
 			event.session_id,
 			event.event,
 			dedupeFingerprint,
@@ -397,7 +397,7 @@ export async function dispatchHookEvent(
 
 	if (dedupeFingerprint && summary.results.some((result) => result.ok)) {
 		recordLifecycleHookBroadcastSent(
-			join(omxRoot(cwd), "state"),
+			stateRoot,
 			event.session_id,
 			event.event,
 			dedupeFingerprint,

--- a/src/hooks/extensibility/plugin-runner.ts
+++ b/src/hooks/extensibility/plugin-runner.ts
@@ -11,6 +11,7 @@ interface RunnerRequest {
   pluginPath: string;
   event: HookEventEnvelope;
   sideEffectsEnabled?: boolean;
+  stateRoot?: string;
 }
 
 interface RunnerResult {
@@ -62,6 +63,7 @@ async function main(): Promise<void> {
       pluginName: pluginId,
       event: request.event,
       sideEffectsEnabled: request.sideEffectsEnabled !== false,
+      stateRoot: request.stateRoot,
     });
 
     await Promise.resolve(loaded.onHookEvent(request.event, sdk));

--- a/src/hooks/extensibility/sdk.ts
+++ b/src/hooks/extensibility/sdk.ts
@@ -23,7 +23,7 @@ export function createHookPluginSdk(options: HookPluginSdkOptions): HookPluginSd
     }),
     log: createHookPluginLogger(options.cwd, pluginName, options.event),
     state: createHookPluginStateApi(options.cwd, pluginName),
-    omx: createHookPluginOmxApi(options.cwd, options.stateRoot),
+    omx: createHookPluginOmxApi(options.cwd, options.stateRoot, options.event.session_id),
   };
 }
 

--- a/src/hooks/extensibility/sdk.ts
+++ b/src/hooks/extensibility/sdk.ts
@@ -10,6 +10,7 @@ interface HookPluginSdkOptions {
   pluginName: string;
   event: HookEventEnvelope;
   sideEffectsEnabled?: boolean;
+  stateRoot?: string;
 }
 
 export function createHookPluginSdk(options: HookPluginSdkOptions): HookPluginSdk {
@@ -22,7 +23,7 @@ export function createHookPluginSdk(options: HookPluginSdkOptions): HookPluginSd
     }),
     log: createHookPluginLogger(options.cwd, pluginName, options.event),
     state: createHookPluginStateApi(options.cwd, pluginName),
-    omx: createHookPluginOmxApi(options.cwd),
+    omx: createHookPluginOmxApi(options.cwd, options.stateRoot),
   };
 }
 

--- a/src/hooks/extensibility/sdk/paths.ts
+++ b/src/hooks/extensibility/sdk/paths.ts
@@ -23,6 +23,6 @@ export function hookPluginLogPath(cwd: string, now = new Date()): string {
   return join(omxRoot(cwd), 'logs', `hooks-${day}.jsonl`);
 }
 
-export function omxRootStateFilePath(cwd: string, fileName: string): string {
-  return join(omxRoot(cwd), 'state', fileName);
+export function omxRootStateFilePath(cwd: string, fileName: string, stateRoot?: string): string {
+  return join(stateRoot ?? join(omxRoot(cwd), 'state'), fileName);
 }

--- a/src/hooks/extensibility/sdk/runtime-state.ts
+++ b/src/hooks/extensibility/sdk/runtime-state.ts
@@ -1,4 +1,4 @@
-import { existsSync, realpathSync } from 'fs';
+import { existsSync, lstatSync, realpathSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { isAbsolute, join, relative } from 'path';
 import type {
@@ -55,6 +55,8 @@ async function readHudState(cwd: string, stateRoot?: string, requestedSessionId?
         || normalizedRequestedSessionId === metadata.ownerCodexSessionId;
       if (!requestedIsBound) return null;
       const sessionDir = join(canonicalStateRoot, 'sessions', metadata.sessionId);
+      const sessionsDir = join(canonicalStateRoot, 'sessions');
+      if (lstatSync(sessionsDir).isSymbolicLink() || lstatSync(sessionDir).isSymbolicLink()) return null;
       const hudStatePath = join(sessionDir, 'hud-state.json');
       if (!existsSync(hudStatePath)) return null;
       const canonicalSessionDir = realpathSync.native(sessionDir);

--- a/src/hooks/extensibility/sdk/runtime-state.ts
+++ b/src/hooks/extensibility/sdk/runtime-state.ts
@@ -9,7 +9,7 @@ import type {
   HookPluginSdk,
 } from '../types.js';
 import { omxRootStateFilePath } from './paths.js';
-import { getReadScopedStateFilePaths, normalizeSessionId } from '../../../mcp/state-paths.js';
+import { getReadScopedStateFilePaths, normalizeSessionId, readSessionMetadataFromBaseStateDir } from '../../../mcp/state-paths.js';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -39,16 +39,19 @@ function isContainedPath(path: string, root: string): boolean {
   return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
 }
 
-async function readHudState(cwd: string, stateRoot?: string): Promise<HookPluginOmxHudState | null> {
+async function readHudState(cwd: string, stateRoot?: string, requestedSessionId?: string): Promise<HookPluginOmxHudState | null> {
   if (stateRoot) {
     try {
       const canonicalStateRoot = realpathSync.native(stateRoot);
-      const session = await readOmxStateFile<HookPluginOmxSessionState>(
-        join(canonicalStateRoot, 'session.json'),
-        normalizeSessionState,
-      );
-      if (!session) return null;
-      const sessionDir = join(canonicalStateRoot, 'sessions', session.session_id);
+      const metadata = await readSessionMetadataFromBaseStateDir(cwd, canonicalStateRoot);
+      if (!metadata) return null;
+      const normalizedRequestedSessionId = normalizeSessionId(requestedSessionId);
+      const requestedIsBound = !normalizedRequestedSessionId
+        || normalizedRequestedSessionId === metadata.sessionId
+        || metadata.nativeSessionAliases.includes(normalizedRequestedSessionId)
+        || normalizedRequestedSessionId === metadata.ownerOmxSessionId;
+      if (!requestedIsBound) return null;
+      const sessionDir = join(canonicalStateRoot, 'sessions', metadata.sessionId);
       const hudStatePath = join(sessionDir, 'hud-state.json');
       if (!existsSync(hudStatePath)) return null;
       const canonicalSessionDir = realpathSync.native(sessionDir);
@@ -66,7 +69,7 @@ async function readHudState(cwd: string, stateRoot?: string): Promise<HookPlugin
   return readOmxStateFile<HookPluginOmxHudState>(hudStatePath);
 }
 
-export function createHookPluginOmxApi(cwd: string, stateRoot?: string): HookPluginSdk['omx'] {
+export function createHookPluginOmxApi(cwd: string, stateRoot?: string, requestedSessionId?: string): HookPluginSdk['omx'] {
   return {
     session: {
       read: () => readOmxStateFile<HookPluginOmxSessionState>(
@@ -75,7 +78,7 @@ export function createHookPluginOmxApi(cwd: string, stateRoot?: string): HookPlu
       ),
     },
     hud: {
-      read: () => readHudState(cwd, stateRoot),
+      read: () => readHudState(cwd, stateRoot, requestedSessionId),
     },
     notifyFallback: {
       read: () => readOmxStateFile<HookPluginOmxNotifyFallbackState>(

--- a/src/hooks/extensibility/sdk/runtime-state.ts
+++ b/src/hooks/extensibility/sdk/runtime-state.ts
@@ -54,7 +54,7 @@ async function readHudState(cwd: string, stateRoot?: string): Promise<HookPlugin
       const canonicalSessionDir = realpathSync.native(sessionDir);
       const canonicalHudStatePath = realpathSync.native(hudStatePath);
       if (!isContainedPath(canonicalSessionDir, canonicalStateRoot)
-        || !isContainedPath(canonicalHudStatePath, canonicalStateRoot)) return null;
+        || !isContainedPath(canonicalHudStatePath, canonicalSessionDir)) return null;
       return readOmxStateFile<HookPluginOmxHudState>(canonicalHudStatePath);
     } catch {
       return null;

--- a/src/hooks/extensibility/sdk/runtime-state.ts
+++ b/src/hooks/extensibility/sdk/runtime-state.ts
@@ -1,6 +1,6 @@
-import { existsSync } from 'fs';
+import { existsSync, realpathSync } from 'fs';
 import { readFile } from 'fs/promises';
-import { join } from 'path';
+import { isAbsolute, join, relative } from 'path';
 import type {
   HookPluginOmxHudState,
   HookPluginOmxNotifyFallbackState,
@@ -9,7 +9,7 @@ import type {
   HookPluginSdk,
 } from '../types.js';
 import { omxRootStateFilePath } from './paths.js';
-import { getReadScopedStateFilePaths } from '../../../mcp/state-paths.js';
+import { getReadScopedStateFilePaths, normalizeSessionId } from '../../../mcp/state-paths.js';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -30,21 +30,29 @@ async function readOmxStateFile<T extends Record<string, unknown>>(
 }
 
 function normalizeSessionState(value: Record<string, unknown>): HookPluginOmxSessionState | null {
-  return typeof value.session_id === 'string' && value.session_id.trim()
-    ? value as HookPluginOmxSessionState
-    : null;
+  const sessionId = normalizeSessionId(value.session_id);
+  return sessionId ? { ...value, session_id: sessionId } as HookPluginOmxSessionState : null;
+}
+
+function isContainedPath(path: string, root: string): boolean {
+  const rel = relative(root, path);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
 }
 
 async function readHudState(cwd: string, stateRoot?: string): Promise<HookPluginOmxHudState | null> {
   if (stateRoot) {
+    const canonicalStateRoot = realpathSync.native(stateRoot);
     const session = await readOmxStateFile<HookPluginOmxSessionState>(
-      join(stateRoot, 'session.json'),
+      join(canonicalStateRoot, 'session.json'),
       normalizeSessionState,
     );
     if (!session) return null;
-    return readOmxStateFile<HookPluginOmxHudState>(
-      join(stateRoot, 'sessions', session.session_id, 'hud-state.json'),
-    );
+    const sessionDir = join(canonicalStateRoot, 'sessions', session.session_id);
+    const hudStatePath = join(sessionDir, 'hud-state.json');
+    if (!existsSync(hudStatePath)) return null;
+    const canonicalSessionDir = realpathSync.native(sessionDir);
+    if (!isContainedPath(canonicalSessionDir, canonicalStateRoot)) return null;
+    return readOmxStateFile<HookPluginOmxHudState>(hudStatePath);
   }
   const [hudStatePath] = await getReadScopedStateFilePaths('hud-state.json', cwd, undefined, {
     rootFallback: false,

--- a/src/hooks/extensibility/sdk/runtime-state.ts
+++ b/src/hooks/extensibility/sdk/runtime-state.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
+import { join } from 'path';
 import type {
   HookPluginOmxHudState,
   HookPluginOmxNotifyFallbackState,
@@ -34,30 +35,42 @@ function normalizeSessionState(value: Record<string, unknown>): HookPluginOmxSes
     : null;
 }
 
-export function createHookPluginOmxApi(cwd: string): HookPluginSdk['omx'] {
+async function readHudState(cwd: string, stateRoot?: string): Promise<HookPluginOmxHudState | null> {
+  if (stateRoot) {
+    const session = await readOmxStateFile<HookPluginOmxSessionState>(
+      join(stateRoot, 'session.json'),
+      normalizeSessionState,
+    );
+    if (!session) return null;
+    return readOmxStateFile<HookPluginOmxHudState>(
+      join(stateRoot, 'sessions', session.session_id, 'hud-state.json'),
+    );
+  }
+  const [hudStatePath] = await getReadScopedStateFilePaths('hud-state.json', cwd, undefined, {
+    rootFallback: false,
+  });
+  return readOmxStateFile<HookPluginOmxHudState>(hudStatePath);
+}
+
+export function createHookPluginOmxApi(cwd: string, stateRoot?: string): HookPluginSdk['omx'] {
   return {
     session: {
       read: () => readOmxStateFile<HookPluginOmxSessionState>(
-        omxRootStateFilePath(cwd, 'session.json'),
+        omxRootStateFilePath(cwd, 'session.json', stateRoot),
         normalizeSessionState,
       ),
     },
     hud: {
-      read: async () => {
-        const [hudStatePath] = await getReadScopedStateFilePaths('hud-state.json', cwd, undefined, {
-          rootFallback: false,
-        });
-        return readOmxStateFile<HookPluginOmxHudState>(hudStatePath);
-      },
+      read: () => readHudState(cwd, stateRoot),
     },
     notifyFallback: {
       read: () => readOmxStateFile<HookPluginOmxNotifyFallbackState>(
-        omxRootStateFilePath(cwd, 'notify-fallback-state.json'),
+        omxRootStateFilePath(cwd, 'notify-fallback-state.json', stateRoot),
       ),
     },
     updateCheck: {
       read: () => readOmxStateFile<HookPluginOmxUpdateCheckState>(
-        omxRootStateFilePath(cwd, 'update-check.json'),
+        omxRootStateFilePath(cwd, 'update-check.json', stateRoot),
       ),
     },
   };

--- a/src/hooks/extensibility/sdk/runtime-state.ts
+++ b/src/hooks/extensibility/sdk/runtime-state.ts
@@ -45,11 +45,14 @@ async function readHudState(cwd: string, stateRoot?: string, requestedSessionId?
       const canonicalStateRoot = realpathSync.native(stateRoot);
       const metadata = await readSessionMetadataFromBaseStateDir(cwd, canonicalStateRoot);
       if (!metadata) return null;
-      const normalizedRequestedSessionId = normalizeSessionId(requestedSessionId);
+      const requestedSessionText = typeof requestedSessionId === 'string' ? requestedSessionId.trim() : '';
+      const normalizedRequestedSessionId = normalizeSessionId(requestedSessionText);
+      if (requestedSessionText && !normalizedRequestedSessionId) return null;
       const requestedIsBound = !normalizedRequestedSessionId
         || normalizedRequestedSessionId === metadata.sessionId
         || metadata.nativeSessionAliases.includes(normalizedRequestedSessionId)
-        || normalizedRequestedSessionId === metadata.ownerOmxSessionId;
+        || normalizedRequestedSessionId === metadata.ownerOmxSessionId
+        || normalizedRequestedSessionId === metadata.ownerCodexSessionId;
       if (!requestedIsBound) return null;
       const sessionDir = join(canonicalStateRoot, 'sessions', metadata.sessionId);
       const hudStatePath = join(sessionDir, 'hud-state.json');

--- a/src/hooks/extensibility/sdk/runtime-state.ts
+++ b/src/hooks/extensibility/sdk/runtime-state.ts
@@ -41,18 +41,24 @@ function isContainedPath(path: string, root: string): boolean {
 
 async function readHudState(cwd: string, stateRoot?: string): Promise<HookPluginOmxHudState | null> {
   if (stateRoot) {
-    const canonicalStateRoot = realpathSync.native(stateRoot);
-    const session = await readOmxStateFile<HookPluginOmxSessionState>(
-      join(canonicalStateRoot, 'session.json'),
-      normalizeSessionState,
-    );
-    if (!session) return null;
-    const sessionDir = join(canonicalStateRoot, 'sessions', session.session_id);
-    const hudStatePath = join(sessionDir, 'hud-state.json');
-    if (!existsSync(hudStatePath)) return null;
-    const canonicalSessionDir = realpathSync.native(sessionDir);
-    if (!isContainedPath(canonicalSessionDir, canonicalStateRoot)) return null;
-    return readOmxStateFile<HookPluginOmxHudState>(hudStatePath);
+    try {
+      const canonicalStateRoot = realpathSync.native(stateRoot);
+      const session = await readOmxStateFile<HookPluginOmxSessionState>(
+        join(canonicalStateRoot, 'session.json'),
+        normalizeSessionState,
+      );
+      if (!session) return null;
+      const sessionDir = join(canonicalStateRoot, 'sessions', session.session_id);
+      const hudStatePath = join(sessionDir, 'hud-state.json');
+      if (!existsSync(hudStatePath)) return null;
+      const canonicalSessionDir = realpathSync.native(sessionDir);
+      const canonicalHudStatePath = realpathSync.native(hudStatePath);
+      if (!isContainedPath(canonicalSessionDir, canonicalStateRoot)
+        || !isContainedPath(canonicalHudStatePath, canonicalStateRoot)) return null;
+      return readOmxStateFile<HookPluginOmxHudState>(canonicalHudStatePath);
+    } catch {
+      return null;
+    }
   }
   const [hudStatePath] = await getReadScopedStateFilePaths('hud-state.json', cwd, undefined, {
     rootFallback: false,

--- a/src/hooks/extensibility/types.ts
+++ b/src/hooks/extensibility/types.ts
@@ -203,6 +203,7 @@ export type HookDispatchSummary = HookDispatchResult;
 
 export interface HookDispatchOptions {
   cwd?: string;
+  stateRoot?: string;
   event?: HookEventEnvelope;
   env?: NodeJS.ProcessEnv;
   timeoutMs?: number;

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -45,6 +45,7 @@ export interface SessionState {
   codex_session_id?: string;
   started_at: string;
   cwd: string;
+  state_root?: string;
   pid: number;
   platform?: NodeJS.Platform;
   pid_start_ticks?: number;
@@ -637,6 +638,7 @@ export async function readUsableSessionState(
 
 function createSessionState(
   cwd: string,
+  stateRoot: string,
   sessionId: string,
   pid: number,
   platform: NodeJS.Platform,
@@ -667,6 +669,7 @@ function createSessionState(
     ...(ownerOmxSessionId ? { owner_omx_session_id: ownerOmxSessionId } : {}),
     started_at: options.startedAt ?? nowIso,
     cwd,
+    state_root: stateRoot,
     pid,
     platform,
     ...(linuxIdentity ? { pid_start_ticks: linuxIdentity.startTicks } : {}),
@@ -1374,7 +1377,7 @@ function startPointerTransition(
       }, error);
     }
 
-    return createSessionState(context.cwd, canonicalSessionId, pid, platform, sessionIdentityFor(pid, platform), {
+    return createSessionState(context.cwd, context.baseStateDir, canonicalSessionId, pid, platform, sessionIdentityFor(pid, platform), {
       nativeSessionId: options.nativeSessionId ?? existing?.native_session_id,
       previousNativeSessionId: options.previousNativeSessionId ?? existing?.previous_native_session_id,
       nativeSessionSwitchedAt: options.nativeSessionSwitchedAt ?? existing?.native_session_switched_at,
@@ -1434,7 +1437,7 @@ function reconcileNativeTransition(
       const ownerCandidate = verifiedOwnerCandidate(context, options);
       const ownerOmxSessionId = ownerCandidate;
       return {
-        state: createSessionState(context.cwd, nativeSessionId, pid, platform, linuxIdentity, {
+        state: createSessionState(context.cwd, context.baseStateDir, nativeSessionId, pid, platform, linuxIdentity, {
           nativeSessionId,
           ...(ownerOmxSessionId ? { ownerOmxSessionId } : {}),
         }),
@@ -1445,7 +1448,7 @@ function reconcileNativeTransition(
     if (existingNativeSessionId && existingNativeSessionId !== nativeSessionId) {
       const ownerOmxSessionId = getOmxLaunchSessionId(existing);
       return {
-        state: createSessionState(context.cwd, nativeSessionId, pid, platform, linuxIdentity, {
+        state: createSessionState(context.cwd, context.baseStateDir, nativeSessionId, pid, platform, linuxIdentity, {
           nativeSessionId,
           ...(ownerOmxSessionId ? {
             previousNativeSessionId: existingNativeSessionId,
@@ -1480,7 +1483,7 @@ function reconcileNativeTransition(
     }
 
     return {
-      state: createSessionState(context.cwd, existing.session_id, pid, platform, linuxIdentity, {
+      state: createSessionState(context.cwd, context.baseStateDir, existing.session_id, pid, platform, linuxIdentity, {
         nowIso,
         nativeSessionId,
         previousNativeSessionId: existing.previous_native_session_id,

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -1566,7 +1566,7 @@ describe('readAllState canonical skill precedence', () => {
       const sessionId = 'sess-team-root-session-json';
       const sessionDir = join(teamStateRoot, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(teamStateRoot, 'session.json'), JSON.stringify({ session_id: sessionId, cwd }));
+      await writeFile(join(teamStateRoot, 'session.json'), JSON.stringify({ session_id: sessionId, cwd, state_root: teamStateRoot }));
       await writeFile(join(sessionDir, 'skill-active-state.json'), JSON.stringify({
         active: true,
         skill: 'ralplan',

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -915,7 +915,10 @@ describe('readAllState canonical skill precedence', () => {
       });
 
       const state = await readAllState(cwd);
-      assert.deepEqual(state.ultragoal, {
+      const ultragoal = { ...(state.ultragoal as unknown as Record<string, unknown>) };
+      delete ultragoal.tmux_pane_id;
+      delete ultragoal.tmux_pane_set_at;
+      assert.deepEqual(ultragoal, {
         active: true,
         mode: 'ultragoal',
         current_phase: 'planning',

--- a/src/mcp/__tests__/server-lifecycle.test.ts
+++ b/src/mcp/__tests__/server-lifecycle.test.ts
@@ -7,8 +7,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 const STARTUP_SETTLE_MS = 150;
-const SPAWN_TIMEOUT_MS = 1_500;
-const EXIT_TIMEOUT_MS = 2_500;
+const SPAWN_TIMEOUT_MS = 3_000;
+const EXIT_TIMEOUT_MS = 5_000;
 const OUTPUT_LIMIT = 4_096;
 
 const IDLE_ENTRYPOINTS = [
@@ -260,7 +260,7 @@ describe('MCP stdio lifecycle runtime regression (built entrypoints)', () => {
 
       await waitForCondition(
         () => !isChildAlive(older),
-        4_000,
+        8_000,
         `older duplicate failed to self-exit: ${formatFailureContext(entrypoint, stderr, stdout)}`,
       );
 
@@ -382,7 +382,7 @@ describe('MCP stdio lifecycle runtime regression (built entrypoints)', () => {
 
       await waitForCondition(
         () => children.filter(isChildAlive).length <= 4,
-        4_000,
+        8_000,
         `pre-traffic hard cap did not bound duplicate children: ${formatFailureContext(entrypoint, stderr, stdout)}`,
       );
 

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -168,7 +168,7 @@ describe('state paths', () => {
     try {
       await mkdir(parentState, { recursive: true });
       await mkdir(nestedState, { recursive: true });
-      await writeFile(join(parentState, 'session.json'), JSON.stringify({ session_id: 'sess-parent', cwd: parent }));
+      await writeFile(join(parentState, 'session.json'), JSON.stringify({ session_id: 'sess-parent', cwd: parent, state_root: parentState }));
       await writeFile(join(nestedState, 'session.json'), JSON.stringify({ session_id: 'sess-nested', cwd: nested }));
       process.env.OMX_SESSION_ID = 'sess-parent';
 
@@ -176,6 +176,8 @@ describe('state paths', () => {
         baseStateDir: parentState,
         rootSource: 'session-authority',
       });
+      const writable = await resolveWritableStateScope(nested);
+      assert.equal(writable.stateDir, join(parentState, 'sessions', 'sess-parent'));
     } finally {
       await rm(parent, { recursive: true, force: true });
     }
@@ -197,6 +199,26 @@ describe('state paths', () => {
         () => getBaseStateDirWithSource(nested),
         new RegExp(`Conflicting authoritative state roots.*${parentState}.*${nestedState}|Conflicting authoritative state roots.*${nestedState}.*${parentState}`),
       );
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('does not discover ancestor authority outside OMX_MCP_WORKDIR_ROOTS', async () => {
+    const parent = await mkRealTemp('omx-state-authority-allowlist-');
+    const nested = join(parent, 'nested');
+    const parentState = join(parent, '.omx', 'state');
+    try {
+      await mkdir(parentState, { recursive: true });
+      await mkdir(nested, { recursive: true });
+      await writeFile(join(parentState, 'session.json'), JSON.stringify({ session_id: 'sess-outside', cwd: parent }));
+      process.env.OMX_SESSION_ID = 'sess-outside';
+      process.env.OMX_MCP_WORKDIR_ROOTS = nested;
+
+      assert.deepEqual(getBaseStateDirWithSource(nested), {
+        baseStateDir: join(nested, '.omx', 'state'),
+        rootSource: 'cwd-default',
+      });
     } finally {
       await rm(parent, { recursive: true, force: true });
     }

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -183,6 +183,25 @@ describe('state paths', () => {
     }
   });
 
+  it('uses a live legacy ancestor pointer when its inferred root matches exactly', async () => {
+    const parent = await mkRealTemp('omx-state-authority-legacy-');
+    const nested = join(parent, 'nested');
+    const parentState = join(parent, '.omx', 'state');
+    try {
+      await mkdir(parentState, { recursive: true });
+      await mkdir(nested, { recursive: true });
+      await writeFile(join(parentState, 'session.json'), JSON.stringify({ session_id: 'sess-legacy', cwd: parent }));
+      process.env.OMX_SESSION_ID = 'sess-legacy';
+
+      assert.deepEqual(getBaseStateDirWithSource(nested), {
+        baseStateDir: parentState,
+        rootSource: 'session-authority',
+      });
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
   it('fails explicitly when multiple ancestor pointers claim the same session authority', async () => {
     const parent = await mkRealTemp('omx-state-authority-conflict-');
     const nested = join(parent, 'nested');
@@ -214,7 +233,6 @@ describe('state paths', () => {
       await writeFile(join(parentState, 'session.json'), JSON.stringify({
         session_id: 'sess-dead',
         cwd: parent,
-        state_root: parentState,
         pid: 2_147_483_647,
       }));
       process.env.OMX_SESSION_ID = 'sess-dead';

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -14,6 +14,7 @@ import {
   getAllSessionScopedStatePaths,
   getReadScopedStateFilePaths,
   readCurrentSessionId,
+  readSessionMetadataFromBaseStateDir,
   resolveRuntimeStateScope,
   resolveStateScope,
   resolveWritableStateScope,
@@ -202,6 +203,26 @@ describe('state paths', () => {
     }
   });
 
+  it('rejects pointers whose persisted or inferred root does not own the selected base', async () => {
+    const cwd = await mkRealTemp('omx-state-pointer-root-owner-');
+    const selectedState = join(cwd, 'selected-state');
+    const claimedState = join(cwd, 'claimed-state');
+    try {
+      await mkdir(selectedState, { recursive: true });
+      await writeFile(join(selectedState, 'session.json'), JSON.stringify({
+        session_id: 'sess-mismatch',
+        cwd,
+        state_root: claimedState,
+      }));
+      assert.equal(await readSessionMetadataFromBaseStateDir(cwd, selectedState), undefined);
+
+      await writeFile(join(selectedState, 'session.json'), JSON.stringify({ session_id: 'sess-legacy-explicit', cwd }));
+      assert.equal(await readSessionMetadataFromBaseStateDir(cwd, selectedState), undefined);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('fails explicitly when multiple ancestor pointers claim the same session authority', async () => {
     const parent = await mkRealTemp('omx-state-authority-conflict-');
     const nested = join(parent, 'nested');
@@ -282,6 +303,26 @@ describe('state paths', () => {
         () => getBaseStateDirWithSource(nested),
         /State root .* is outside allowed roots \(OMX_MCP_WORKDIR_ROOTS\)/,
       );
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects OMX_ROOT and OMX_STATE_ROOT whose appended state directory escapes the allowlist', async () => {
+    const parent = await mkRealTemp('omx-state-override-symlink-');
+    const allowed = join(parent, 'allowed');
+    const outsideState = join(parent, 'outside-state');
+    try {
+      await mkdir(join(allowed, '.omx'), { recursive: true });
+      await mkdir(outsideState, { recursive: true });
+      await symlink(outsideState, join(allowed, '.omx', 'state'), process.platform === 'win32' ? 'junction' : 'dir');
+      process.env.OMX_MCP_WORKDIR_ROOTS = allowed;
+      process.env.OMX_ROOT = allowed;
+      assert.throws(() => getBaseStateDirWithSource(allowed), /State root .* is outside allowed roots/);
+
+      delete process.env.OMX_ROOT;
+      process.env.OMX_STATE_ROOT = allowed;
+      assert.throws(() => getBaseStateDirWithSource(allowed), /State root .* is outside allowed roots/);
     } finally {
       await rm(parent, { recursive: true, force: true });
     }
@@ -690,6 +731,7 @@ describe('state paths', () => {
       await writeFile(join(teamStateRoot, 'session.json'), JSON.stringify({
         session_id: 'sess-team-current',
         cwd: wd,
+        state_root: teamStateRoot,
       }));
       await mkdir(join(wd, '.omx', 'state'), { recursive: true });
       await writeFile(join(wd, '.omx', 'state', 'session.json'), JSON.stringify({

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -191,14 +191,38 @@ describe('state paths', () => {
     try {
       await mkdir(parentState, { recursive: true });
       await mkdir(nestedState, { recursive: true });
-      await writeFile(join(parentState, 'session.json'), JSON.stringify({ session_id: 'sess-conflict', cwd: parent }));
-      await writeFile(join(nestedState, 'session.json'), JSON.stringify({ session_id: 'sess-conflict', cwd: nested }));
+      await writeFile(join(parentState, 'session.json'), JSON.stringify({ session_id: 'sess-conflict', cwd: parent, state_root: parentState }));
+      await writeFile(join(nestedState, 'session.json'), JSON.stringify({ session_id: 'sess-conflict', cwd: nested, state_root: nestedState }));
       process.env.OMX_SESSION_ID = 'sess-conflict';
 
       assert.throws(
         () => getBaseStateDirWithSource(nested),
         new RegExp(`Conflicting authoritative state roots.*${parentState}.*${nestedState}|Conflicting authoritative state roots.*${nestedState}.*${parentState}`),
       );
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores a dead matching ancestor session pointer', async () => {
+    const parent = await mkRealTemp('omx-state-authority-dead-');
+    const nested = join(parent, 'nested');
+    const parentState = join(parent, '.omx', 'state');
+    try {
+      await mkdir(parentState, { recursive: true });
+      await mkdir(nested, { recursive: true });
+      await writeFile(join(parentState, 'session.json'), JSON.stringify({
+        session_id: 'sess-dead',
+        cwd: parent,
+        state_root: parentState,
+        pid: 2_147_483_647,
+      }));
+      process.env.OMX_SESSION_ID = 'sess-dead';
+
+      assert.deepEqual(getBaseStateDirWithSource(nested), {
+        baseStateDir: join(nested, '.omx', 'state'),
+        rootSource: 'cwd-default',
+      });
     } finally {
       await rm(parent, { recursive: true, force: true });
     }

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -160,6 +160,48 @@ describe('state paths', () => {
     }
   });
 
+  it('uses the ancestor session pointer matching OMX_SESSION_ID as the authoritative root', async () => {
+    const parent = await mkRealTemp('omx-state-authority-parent-');
+    const nested = join(parent, 'nested', 'project');
+    const parentState = join(parent, '.omx', 'state');
+    const nestedState = join(nested, '.omx', 'state');
+    try {
+      await mkdir(parentState, { recursive: true });
+      await mkdir(nestedState, { recursive: true });
+      await writeFile(join(parentState, 'session.json'), JSON.stringify({ session_id: 'sess-parent', cwd: parent }));
+      await writeFile(join(nestedState, 'session.json'), JSON.stringify({ session_id: 'sess-nested', cwd: nested }));
+      process.env.OMX_SESSION_ID = 'sess-parent';
+
+      assert.deepEqual(getBaseStateDirWithSource(nested), {
+        baseStateDir: parentState,
+        rootSource: 'session-authority',
+      });
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('fails explicitly when multiple ancestor pointers claim the same session authority', async () => {
+    const parent = await mkRealTemp('omx-state-authority-conflict-');
+    const nested = join(parent, 'nested');
+    const parentState = join(parent, '.omx', 'state');
+    const nestedState = join(nested, '.omx', 'state');
+    try {
+      await mkdir(parentState, { recursive: true });
+      await mkdir(nestedState, { recursive: true });
+      await writeFile(join(parentState, 'session.json'), JSON.stringify({ session_id: 'sess-conflict', cwd: parent }));
+      await writeFile(join(nestedState, 'session.json'), JSON.stringify({ session_id: 'sess-conflict', cwd: nested }));
+      process.env.OMX_SESSION_ID = 'sess-conflict';
+
+      assert.throws(
+        () => getBaseStateDirWithSource(nested),
+        new RegExp(`Conflicting authoritative state roots.*${parentState}.*${nestedState}|Conflicting authoritative state roots.*${nestedState}.*${parentState}`),
+      );
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
   it('fails closed when an explicit state root is outside the allowlist', async () => {
     const allowedRoot = await mkRealTemp('omx-state-root-allowed-');
     const disallowedRoot = await mkRealTemp('omx-state-root-disallowed-');

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -640,6 +640,7 @@ describe('state paths', () => {
         session_id: 'native-id',
         native_session_id: 'native-id',
         owner_omx_session_id: 'omx-owner-id',
+        owner_codex_session_id: 'codex-owner-id',
         cwd: wd,
       }));
       process.env.OMX_SESSION_ID = 'omx-owner-id';
@@ -654,6 +655,15 @@ describe('state paths', () => {
       assert.equal(runtimeScope.sessionId, 'native-id');
       assert.equal(runtimeScope.stateDir, join(stateDir, 'sessions', 'native-id'));
       assert.equal(runtimeScope.source, 'native-alias');
+
+      process.env.OMX_SESSION_ID = 'codex-owner-id';
+      assert.equal(await readCurrentSessionId(wd), 'native-id');
+      const codexScope = await resolveStateScope(wd);
+      assert.equal(codexScope.sessionId, 'native-id');
+      assert.equal(codexScope.stateDir, join(stateDir, 'sessions', 'native-id'));
+      const codexRuntimeScope = await resolveRuntimeStateScope(wd);
+      assert.equal(codexRuntimeScope.sessionId, 'native-id');
+      assert.equal(codexRuntimeScope.stateDir, join(stateDir, 'sessions', 'native-id'));
     } finally {
       if (typeof previousOmxSessionId === 'string') process.env.OMX_SESSION_ID = previousOmxSessionId;
       else delete process.env.OMX_SESSION_ID;
@@ -671,6 +681,7 @@ describe('state paths', () => {
         session_id: 'native-id',
         native_session_id: 'native-id',
         owner_omx_session_id: 'omx-owner-id',
+        owner_codex_session_id: 'codex-owner-id',
         cwd: wd,
       }));
 
@@ -678,6 +689,10 @@ describe('state paths', () => {
       assert.equal(scope.sessionId, 'native-id');
       assert.equal(scope.stateDir, join(stateDir, 'sessions', 'native-id'));
       assert.notEqual(scope.stateDir, join(stateDir, 'sessions', 'omx-owner-id'));
+
+      const codexScope = await resolveStateScope(wd, 'codex-owner-id');
+      assert.equal(codexScope.sessionId, 'native-id');
+      assert.equal(codexScope.stateDir, join(stateDir, 'sessions', 'native-id'));
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -859,10 +874,18 @@ describe('state paths', () => {
           session_id: 'sess-canonical',
           native_session_id: 'native-alias',
           owner_omx_session_id: 'omx-owner-alias',
+          owner_codex_session_id: 'codex-owner-alias',
           cwd: wd,
         }));
         process.env.OMX_SESSION_ID = 'omx-owner-alias';
 
+        assert.deepEqual(await resolveWritableStateScope(wd), {
+          source: 'session',
+          sessionId: 'sess-canonical',
+          stateDir: join(stateDir, 'sessions', 'sess-canonical'),
+        });
+
+        process.env.OMX_SESSION_ID = 'codex-owner-alias';
         assert.deepEqual(await resolveWritableStateScope(wd), {
           source: 'session',
           sessionId: 'sess-canonical',

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -224,6 +224,27 @@ describe('state paths', () => {
     }
   });
 
+  it('does not select an in-allowlist state symlink that escapes the allowed root', async () => {
+    const parent = await mkRealTemp('omx-state-authority-symlink-');
+    const nested = join(parent, 'nested');
+    const outsideState = join(parent, 'outside-state');
+    try {
+      await mkdir(join(nested, '.omx'), { recursive: true });
+      await mkdir(outsideState, { recursive: true });
+      await writeFile(join(outsideState, 'session.json'), JSON.stringify({ session_id: 'sess-symlink', cwd: nested }));
+      await symlink(outsideState, join(nested, '.omx', 'state'), process.platform === 'win32' ? 'junction' : 'dir');
+      process.env.OMX_SESSION_ID = 'sess-symlink';
+      process.env.OMX_MCP_WORKDIR_ROOTS = nested;
+
+      assert.throws(
+        () => getBaseStateDirWithSource(nested),
+        /State root .* is outside allowed roots \(OMX_MCP_WORKDIR_ROOTS\)/,
+      );
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
   it('fails closed when an explicit state root is outside the allowlist', async () => {
     const allowedRoot = await mkRealTemp('omx-state-root-allowed-');
     const disallowedRoot = await mkRealTemp('omx-state-root-disallowed-');

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -736,7 +736,7 @@ describe('state-server directory initialization', () => {
       const sessionId = 'sess-clear';
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: stateDir }, null, 2));
       await writeFile(
         join(stateDir, 'deep-interview-state.json'),
         JSON.stringify({ active: true, mode: 'deep-interview', current_phase: 'legacy-root' }, null, 2),

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -198,8 +198,8 @@ function canonicalizeExistingPath(path: string): string {
   return path;
 }
 
-function parseAllowedWorkingDirectoryRoots(): string[] {
-  const raw = process.env[WORKDIR_ALLOWLIST_ENV];
+function parseAllowedWorkingDirectoryRoots(env: NodeJS.ProcessEnv = process.env): string[] {
+  const raw = env[WORKDIR_ALLOWLIST_ENV];
   if (typeof raw !== 'string' || raw.trim() === '') return [];
 
   const roots = raw
@@ -250,13 +250,13 @@ function sessionPointerMatchesId(pointer: Record<string, unknown>, sessionId: st
   ].some((value) => normalizeSessionId(value) === sessionId);
 }
 
-function discoverSessionAuthorityBaseStateDir(workingDirectory?: string): string | undefined {
-  const sessionId = normalizeSessionId(process.env[OMX_SESSION_ID_ENV]);
+function discoverSessionAuthorityBaseStateDir(workingDirectory?: string, env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const sessionId = normalizeSessionId(env[OMX_SESSION_ID_ENV]);
   if (!sessionId) return undefined;
 
   let current = resolveWorkingDirectoryForState(workingDirectory);
   const observedCwd = canonicalizeExistingPath(current);
-  const allowedRoots = parseAllowedWorkingDirectoryRoots();
+  const allowedRoots = parseAllowedWorkingDirectoryRoots(env);
   const matches: string[] = [];
   while (true) {
     const canonicalCurrent = canonicalizeExistingPath(current);
@@ -310,39 +310,53 @@ function discoverSessionAuthorityBaseStateDir(workingDirectory?: string): string
   return uniqueMatches[0];
 }
 
-export function getBaseStateDirWithSource(workingDirectory?: string): { baseStateDir: string; rootSource: StateRootSource } {
-  const teamStateRootOverride = process.env[OMX_TEAM_STATE_ROOT_ENV]?.trim();
-  if (typeof teamStateRootOverride === 'string' && teamStateRootOverride !== '') {
-    return { baseStateDir: resolveWorkingDirectoryForState(teamStateRootOverride), rootSource: 'team-env' };
-  }
-
-  const omxRootOverride = process.env[OMX_ROOT_ENV]?.trim();
-  if (typeof omxRootOverride === 'string' && omxRootOverride !== '') {
-    return { baseStateDir: join(resolveWorkingDirectoryForState(omxRootOverride), '.omx', 'state'), rootSource: 'omx-root-env' };
-  }
-
-  const omxStateRootOverride = process.env[OMX_STATE_ROOT_ENV]?.trim();
-  if (typeof omxStateRootOverride === 'string' && omxStateRootOverride !== '') {
-    return { baseStateDir: join(resolveWorkingDirectoryForState(omxStateRootOverride), '.omx', 'state'), rootSource: 'omx-state-root-env' };
-  }
-
-  const sessionAuthority = discoverSessionAuthorityBaseStateDir(workingDirectory);
-  if (sessionAuthority) {
-    return { baseStateDir: sessionAuthority, rootSource: 'session-authority' };
-  }
-
-  const baseStateDir = join(resolveWorkingDirectoryForState(workingDirectory), '.omx', 'state');
-  const allowedRoots = parseAllowedWorkingDirectoryRoots();
+function validateResolvedBaseStateDir(
+  baseStateDir: string,
+  rootSource: StateRootSource,
+  env: NodeJS.ProcessEnv,
+): { baseStateDir: string; rootSource: StateRootSource } {
+  const allowedRoots = parseAllowedWorkingDirectoryRoots(env);
   if (allowedRoots.length > 0) {
     const canonicalBaseStateDir = canonicalizeExistingPath(baseStateDir);
     if (!allowedRoots.some((root) => isWithinRoot(canonicalBaseStateDir, root))) {
       throw new Error(`State root "${canonicalBaseStateDir}" is outside allowed roots (${WORKDIR_ALLOWLIST_ENV})`);
     }
   }
-  return { baseStateDir, rootSource: 'cwd-default' };
+  return { baseStateDir, rootSource };
 }
-export function getBaseStateDir(workingDirectory?: string): string {
-  return getBaseStateDirWithSource(workingDirectory).baseStateDir;
+
+export function getBaseStateDirWithSource(
+  workingDirectory?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): { baseStateDir: string; rootSource: StateRootSource } {
+  const teamStateRootOverride = env[OMX_TEAM_STATE_ROOT_ENV]?.trim();
+  if (typeof teamStateRootOverride === 'string' && teamStateRootOverride !== '') {
+    return validateResolvedBaseStateDir(resolveWorkingDirectoryForState(teamStateRootOverride), 'team-env', env);
+  }
+
+  const omxRootOverride = env[OMX_ROOT_ENV]?.trim();
+  if (typeof omxRootOverride === 'string' && omxRootOverride !== '') {
+    return validateResolvedBaseStateDir(join(resolveWorkingDirectoryForState(omxRootOverride), '.omx', 'state'), 'omx-root-env', env);
+  }
+
+  const omxStateRootOverride = env[OMX_STATE_ROOT_ENV]?.trim();
+  if (typeof omxStateRootOverride === 'string' && omxStateRootOverride !== '') {
+    return validateResolvedBaseStateDir(join(resolveWorkingDirectoryForState(omxStateRootOverride), '.omx', 'state'), 'omx-state-root-env', env);
+  }
+
+  const sessionAuthority = discoverSessionAuthorityBaseStateDir(workingDirectory, env);
+  if (sessionAuthority) {
+    return validateResolvedBaseStateDir(sessionAuthority, 'session-authority', env);
+  }
+
+  return validateResolvedBaseStateDir(
+    join(resolveWorkingDirectoryForState(workingDirectory), '.omx', 'state'),
+    'cwd-default',
+    env,
+  );
+}
+export function getBaseStateDir(workingDirectory?: string, env: NodeJS.ProcessEnv = process.env): string {
+  return getBaseStateDirWithSource(workingDirectory, env).baseStateDir;
 }
 
 export function getStateDir(workingDirectory?: string, sessionId?: string): string {
@@ -407,7 +421,8 @@ async function readUsableSessionStateFromBaseStateDir(
       && recordedStateRoot === canonicalBaseStateDir
       && isWithinRoot(canonicalObservedCwd, recordedCwd),
     );
-    return isSessionStateUsable(state, authorityOwnsObservedCwd ? recordedCwd : cwd) ? state : null;
+    if (!authorityOwnsObservedCwd) return null;
+    return isSessionStateUsable(state, recordedCwd) ? state : null;
   } catch {
     return null;
   }

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -281,7 +281,9 @@ function discoverSessionAuthorityBaseStateDir(workingDirectory?: string): string
             : '';
           const recordedStateRoot = typeof state.state_root === 'string'
             ? canonicalizeExistingPath(resolvePath(state.state_root))
-            : '';
+            : recordedCwd
+              ? canonicalizeExistingPath(join(recordedCwd, '.omx', 'state'))
+              : '';
           if (sessionPointerMatchesId(state as unknown as Record<string, unknown>, sessionId)
             && recordedCwd
             && recordedStateRoot === canonicalCandidate
@@ -395,7 +397,9 @@ async function readUsableSessionStateFromBaseStateDir(
     const recordedCwd = typeof state.cwd === 'string' ? canonicalizeExistingPath(resolvePath(state.cwd)) : '';
     const recordedStateRoot = typeof state.state_root === 'string'
       ? canonicalizeExistingPath(resolvePath(state.state_root))
-      : '';
+      : recordedCwd
+        ? canonicalizeExistingPath(join(recordedCwd, '.omx', 'state'))
+        : '';
     const canonicalBaseStateDir = canonicalizeExistingPath(baseStateDir);
     const canonicalObservedCwd = canonicalizeExistingPath(resolvePath(cwd));
     const authorityOwnsObservedCwd = Boolean(
@@ -450,7 +454,7 @@ function normalizeSessionMetadata(state: SessionState | null, sourcePath?: strin
 }
 
 
-async function readSessionMetadataFromBaseStateDir(
+export async function readSessionMetadataFromBaseStateDir(
   cwd: string,
   baseStateDir = getBaseStateDir(cwd),
 ): Promise<ResolvedSessionMetadata | undefined> {

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -399,7 +399,9 @@ function readSessionIdFromEnvironment(env: NodeJS.ProcessEnv = process.env): str
 function resolveCanonicalSessionId(candidate: string | undefined, metadata: ResolvedSessionMetadata | undefined): string | undefined {
   if (!candidate) return undefined;
   if (!metadata) return candidate;
-  return metadata.nativeSessionAliases.includes(candidate) || metadata.ownerOmxSessionId === candidate
+  return metadata.nativeSessionAliases.includes(candidate)
+      || metadata.ownerOmxSessionId === candidate
+      || metadata.ownerCodexSessionId === candidate
     ? metadata.sessionId
     : candidate;
 }

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -255,8 +255,12 @@ function discoverSessionAuthorityBaseStateDir(workingDirectory?: string): string
   if (!sessionId) return undefined;
 
   let current = resolveWorkingDirectoryForState(workingDirectory);
+  const allowedRoots = parseAllowedWorkingDirectoryRoots();
   const matches: string[] = [];
   while (true) {
+    const canonicalCurrent = canonicalizeExistingPath(current);
+    if (allowedRoots.length > 0 && !allowedRoots.some((root) => isWithinRoot(canonicalCurrent, root))) break;
+
     const candidate = join(current, '.omx', 'state');
     const pointerPath = join(candidate, 'session.json');
     if (existsSync(pointerPath)) {
@@ -360,7 +364,18 @@ async function readUsableSessionStateFromBaseStateDir(
   try {
     const content = await readFile(sessionPath, 'utf-8');
     const state = JSON.parse(content) as SessionState;
-    return isSessionStateUsable(state, cwd) ? state : null;
+    const recordedCwd = typeof state.cwd === 'string' ? canonicalizeExistingPath(resolvePath(state.cwd)) : '';
+    const recordedStateRoot = typeof state.state_root === 'string'
+      ? canonicalizeExistingPath(resolvePath(state.state_root))
+      : '';
+    const canonicalBaseStateDir = canonicalizeExistingPath(baseStateDir);
+    const canonicalObservedCwd = canonicalizeExistingPath(resolvePath(cwd));
+    const authorityOwnsObservedCwd = Boolean(
+      recordedCwd
+      && recordedStateRoot === canonicalBaseStateDir
+      && isWithinRoot(canonicalObservedCwd, recordedCwd),
+    );
+    return isSessionStateUsable(state, authorityOwnsObservedCwd ? recordedCwd : cwd) ? state : null;
   } catch {
     return null;
   }

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -1,5 +1,5 @@
 import { delimiter, isAbsolute, join, relative, resolve as resolvePath } from 'path';
-import { existsSync, realpathSync } from 'fs';
+import { existsSync, realpathSync, readFileSync } from 'fs';
 import { readFile, readdir } from 'fs/promises';
 import {
   isSessionStateUsable,
@@ -23,7 +23,7 @@ export const WRITABLE_STATE_SCOPE_ERRORS = {
 } as const;
 
 
-export type StateRootSource = 'team-env' | 'omx-root-env' | 'omx-state-root-env' | 'cwd-default';
+export type StateRootSource = 'team-env' | 'omx-root-env' | 'omx-state-root-env' | 'session-authority' | 'cwd-default';
 export type SessionScopeSource = 'explicit' | 'env' | 'session-json' | 'native-alias' | 'root';
 
 export interface ResolvedSessionMetadata {
@@ -240,6 +240,50 @@ function enforceWorkingDirectoryPolicy(resolvedWorkingDirectory: string): string
   return canonicalWorkingDirectory;
 }
 
+function sessionPointerMatchesId(pointer: Record<string, unknown>, sessionId: string): boolean {
+  return [
+    pointer.session_id,
+    pointer.native_session_id,
+    pointer.owner_omx_session_id,
+    pointer.owner_codex_session_id,
+    pointer.codex_session_id,
+  ].some((value) => normalizeSessionId(value) === sessionId);
+}
+
+function discoverSessionAuthorityBaseStateDir(workingDirectory?: string): string | undefined {
+  const sessionId = normalizeSessionId(process.env[OMX_SESSION_ID_ENV]);
+  if (!sessionId) return undefined;
+
+  let current = resolveWorkingDirectoryForState(workingDirectory);
+  const matches: string[] = [];
+  while (true) {
+    const candidate = join(current, '.omx', 'state');
+    const pointerPath = join(candidate, 'session.json');
+    if (existsSync(pointerPath)) {
+      try {
+        const parsed = JSON.parse(readFileSync(pointerPath, 'utf8')) as unknown;
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+          && sessionPointerMatchesId(parsed as Record<string, unknown>, sessionId)) {
+          matches.push(canonicalizeExistingPath(candidate));
+        }
+      } catch {
+        // Malformed pointers are classified by the normal state-scope resolver.
+      }
+    }
+    const parent = resolvePath(current, '..');
+    if (parent === current) break;
+    current = parent;
+  }
+
+  const uniqueMatches = [...new Set(matches)];
+  if (uniqueMatches.length > 1) {
+    throw new Error(
+      `Conflicting authoritative state roots for OMX_SESSION_ID ${sessionId}: ${uniqueMatches.join(', ')}`,
+    );
+  }
+  return uniqueMatches[0];
+}
+
 export function getBaseStateDirWithSource(workingDirectory?: string): { baseStateDir: string; rootSource: StateRootSource } {
   const teamStateRootOverride = process.env[OMX_TEAM_STATE_ROOT_ENV]?.trim();
   if (typeof teamStateRootOverride === 'string' && teamStateRootOverride !== '') {
@@ -254,6 +298,11 @@ export function getBaseStateDirWithSource(workingDirectory?: string): { baseStat
   const omxStateRootOverride = process.env[OMX_STATE_ROOT_ENV]?.trim();
   if (typeof omxStateRootOverride === 'string' && omxStateRootOverride !== '') {
     return { baseStateDir: join(resolveWorkingDirectoryForState(omxStateRootOverride), '.omx', 'state'), rootSource: 'omx-state-root-env' };
+  }
+
+  const sessionAuthority = discoverSessionAuthorityBaseStateDir(workingDirectory);
+  if (sessionAuthority) {
+    return { baseStateDir: sessionAuthority, rootSource: 'session-authority' };
   }
 
   return { baseStateDir: join(resolveWorkingDirectoryForState(workingDirectory), '.omx', 'state'), rootSource: 'cwd-default' };

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -255,6 +255,7 @@ function discoverSessionAuthorityBaseStateDir(workingDirectory?: string): string
   if (!sessionId) return undefined;
 
   let current = resolveWorkingDirectoryForState(workingDirectory);
+  const observedCwd = canonicalizeExistingPath(current);
   const allowedRoots = parseAllowedWorkingDirectoryRoots();
   const matches: string[] = [];
   while (true) {
@@ -273,9 +274,21 @@ function discoverSessionAuthorityBaseStateDir(workingDirectory?: string): string
     if (existsSync(pointerPath)) {
       try {
         const parsed = JSON.parse(readFileSync(pointerPath, 'utf8')) as unknown;
-        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-          && sessionPointerMatchesId(parsed as Record<string, unknown>, sessionId)) {
-          matches.push(canonicalCandidate);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          const state = parsed as SessionState;
+          const recordedCwd = typeof state.cwd === 'string'
+            ? canonicalizeExistingPath(resolvePath(state.cwd))
+            : '';
+          const recordedStateRoot = typeof state.state_root === 'string'
+            ? canonicalizeExistingPath(resolvePath(state.state_root))
+            : '';
+          if (sessionPointerMatchesId(state as unknown as Record<string, unknown>, sessionId)
+            && recordedCwd
+            && recordedStateRoot === canonicalCandidate
+            && isWithinRoot(observedCwd, recordedCwd)
+            && isSessionStateUsable(state, recordedCwd)) {
+            matches.push(canonicalCandidate);
+          }
         }
       } catch {
         // Malformed pointers are classified by the normal state-scope resolver.

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -141,14 +141,17 @@ function convertWslToWindowsPath(raw: string): string {
   return rest ? `${drive}:\\${rest}` : `${drive}:\\`;
 }
 
-export function resolveWorkingDirectoryForState(workingDirectory?: string): string {
+export function resolveWorkingDirectoryForState(
+  workingDirectory?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
   const raw = typeof workingDirectory === 'string' ? workingDirectory.trim() : '';
   if (raw.includes('\0')) {
     throw new Error('workingDirectory contains a NUL byte');
   }
   if (!raw) {
     const cwd = resolvePath(process.cwd());
-    return enforceWorkingDirectoryPolicy(cwd);
+    return enforceWorkingDirectoryPolicy(cwd, env);
   }
 
   let normalized = raw;
@@ -170,7 +173,7 @@ export function resolveWorkingDirectoryForState(workingDirectory?: string): stri
   }
 
   const resolved = resolvePath(normalized);
-  return enforceWorkingDirectoryPolicy(resolved);
+  return enforceWorkingDirectoryPolicy(resolved, env);
 }
 
 function canonicalizeExistingPath(path: string): string {
@@ -226,8 +229,11 @@ function isWithinRoot(path: string, root: string): boolean {
   return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
 }
 
-function enforceWorkingDirectoryPolicy(resolvedWorkingDirectory: string): string {
-  const roots = parseAllowedWorkingDirectoryRoots();
+function enforceWorkingDirectoryPolicy(
+  resolvedWorkingDirectory: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const roots = parseAllowedWorkingDirectoryRoots(env);
   if (roots.length === 0) return resolvedWorkingDirectory;
 
   const canonicalWorkingDirectory = canonicalizeExistingPath(resolvedWorkingDirectory);
@@ -254,7 +260,7 @@ function discoverSessionAuthorityBaseStateDir(workingDirectory?: string, env: No
   const sessionId = normalizeSessionId(env[OMX_SESSION_ID_ENV]);
   if (!sessionId) return undefined;
 
-  let current = resolveWorkingDirectoryForState(workingDirectory);
+  let current = resolveWorkingDirectoryForState(workingDirectory, env);
   const observedCwd = canonicalizeExistingPath(current);
   const allowedRoots = parseAllowedWorkingDirectoryRoots(env);
   const matches: string[] = [];
@@ -331,17 +337,17 @@ export function getBaseStateDirWithSource(
 ): { baseStateDir: string; rootSource: StateRootSource } {
   const teamStateRootOverride = env[OMX_TEAM_STATE_ROOT_ENV]?.trim();
   if (typeof teamStateRootOverride === 'string' && teamStateRootOverride !== '') {
-    return validateResolvedBaseStateDir(resolveWorkingDirectoryForState(teamStateRootOverride), 'team-env', env);
+    return validateResolvedBaseStateDir(resolveWorkingDirectoryForState(teamStateRootOverride, env), 'team-env', env);
   }
 
   const omxRootOverride = env[OMX_ROOT_ENV]?.trim();
   if (typeof omxRootOverride === 'string' && omxRootOverride !== '') {
-    return validateResolvedBaseStateDir(join(resolveWorkingDirectoryForState(omxRootOverride), '.omx', 'state'), 'omx-root-env', env);
+    return validateResolvedBaseStateDir(join(resolveWorkingDirectoryForState(omxRootOverride, env), '.omx', 'state'), 'omx-root-env', env);
   }
 
   const omxStateRootOverride = env[OMX_STATE_ROOT_ENV]?.trim();
   if (typeof omxStateRootOverride === 'string' && omxStateRootOverride !== '') {
-    return validateResolvedBaseStateDir(join(resolveWorkingDirectoryForState(omxStateRootOverride), '.omx', 'state'), 'omx-state-root-env', env);
+    return validateResolvedBaseStateDir(join(resolveWorkingDirectoryForState(omxStateRootOverride, env), '.omx', 'state'), 'omx-state-root-env', env);
   }
 
   const sessionAuthority = discoverSessionAuthorityBaseStateDir(workingDirectory, env);
@@ -350,7 +356,7 @@ export function getBaseStateDirWithSource(
   }
 
   return validateResolvedBaseStateDir(
-    join(resolveWorkingDirectoryForState(workingDirectory), '.omx', 'state'),
+    join(resolveWorkingDirectoryForState(workingDirectory, env), '.omx', 'state'),
     'cwd-default',
     env,
   );

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -262,13 +262,20 @@ function discoverSessionAuthorityBaseStateDir(workingDirectory?: string): string
     if (allowedRoots.length > 0 && !allowedRoots.some((root) => isWithinRoot(canonicalCurrent, root))) break;
 
     const candidate = join(current, '.omx', 'state');
-    const pointerPath = join(candidate, 'session.json');
+    const canonicalCandidate = canonicalizeExistingPath(candidate);
+    if (allowedRoots.length > 0 && !allowedRoots.some((root) => isWithinRoot(canonicalCandidate, root))) {
+      const parent = resolvePath(current, '..');
+      if (parent === current) break;
+      current = parent;
+      continue;
+    }
+    const pointerPath = join(canonicalCandidate, 'session.json');
     if (existsSync(pointerPath)) {
       try {
         const parsed = JSON.parse(readFileSync(pointerPath, 'utf8')) as unknown;
         if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)
           && sessionPointerMatchesId(parsed as Record<string, unknown>, sessionId)) {
-          matches.push(canonicalizeExistingPath(candidate));
+          matches.push(canonicalCandidate);
         }
       } catch {
         // Malformed pointers are classified by the normal state-scope resolver.
@@ -309,7 +316,15 @@ export function getBaseStateDirWithSource(workingDirectory?: string): { baseStat
     return { baseStateDir: sessionAuthority, rootSource: 'session-authority' };
   }
 
-  return { baseStateDir: join(resolveWorkingDirectoryForState(workingDirectory), '.omx', 'state'), rootSource: 'cwd-default' };
+  const baseStateDir = join(resolveWorkingDirectoryForState(workingDirectory), '.omx', 'state');
+  const allowedRoots = parseAllowedWorkingDirectoryRoots();
+  if (allowedRoots.length > 0) {
+    const canonicalBaseStateDir = canonicalizeExistingPath(baseStateDir);
+    if (!allowedRoots.some((root) => isWithinRoot(canonicalBaseStateDir, root))) {
+      throw new Error(`State root "${canonicalBaseStateDir}" is outside allowed roots (${WORKDIR_ALLOWLIST_ENV})`);
+    }
+  }
+  return { baseStateDir, rootSource: 'cwd-default' };
 }
 export function getBaseStateDir(workingDirectory?: string): string {
   return getBaseStateDirWithSource(workingDirectory).baseStateDir;

--- a/src/modes/__tests__/base-multi-state-compat.test.ts
+++ b/src/modes/__tests__/base-multi-state-compat.test.ts
@@ -13,7 +13,7 @@ describe('modes/base multi-state compatibility', () => {
       await startMode('team', 'coordinate execution', 5, wd);
       await writeFile(
         join(wd, '.omx', 'state', 'session.json'),
-        JSON.stringify({ session_id: 'sess-team-ralph' }),
+        JSON.stringify({ session_id: 'sess-team-ralph', cwd: wd, state_root: join(wd, '.omx', 'state') }),
       );
 
       await startMode('ralph', 'complete the approved plan', 5, wd);

--- a/src/modes/__tests__/base-session-scope.test.ts
+++ b/src/modes/__tests__/base-session-scope.test.ts
@@ -7,12 +7,22 @@ import { tmpdir } from 'node:os';
 import { assertModeStartAllowed, readModeState, startMode, updateModeState } from '../base.js';
 
 
+async function writeSessionPointer(wd: string, sessionId: string): Promise<void> {
+  const stateDir = join(wd, '.omx', 'state');
+  await mkdir(stateDir, { recursive: true });
+  await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+    session_id: sessionId,
+    cwd: wd,
+    state_root: stateDir,
+  }));
+}
+
 describe('modes/base session-scoped persistence', () => {
   it('writes mode state into the current session scope when session.json exists', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-mode-session-scope-'));
     try {
       await mkdir(join(wd, '.omx', 'state'), { recursive: true });
-      await writeFile(join(wd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: 'sess-base-write' }));
+      await writeSessionPointer(wd, 'sess-base-write');
 
       await startMode('ralplan', 'write in session scope', 5, wd);
 
@@ -35,7 +45,7 @@ describe('modes/base session-scoped persistence', () => {
       const sessionId = 'sess-base-canonical';
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(wd, sessionId);
 
       await startMode('ralplan', 'write canonical in session scope', 5, wd);
       await updateModeState('ralplan', { current_phase: 'planning', iteration: 1 }, wd);
@@ -59,7 +69,7 @@ describe('modes/base session-scoped persistence', () => {
       const sessionId = 'sess-ralph-owner';
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(wd, sessionId);
 
       await startMode('ralph', 'own this session', 5, wd);
 
@@ -78,7 +88,7 @@ describe('modes/base session-scoped persistence', () => {
       const sessionId = 'sess-base-read';
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(wd, sessionId);
       await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify({ active: true, current_phase: 'root-only', iteration: 9 }));
       await writeFile(join(sessionDir, 'ralplan-state.json'), JSON.stringify({ active: true, current_phase: 'draft', iteration: 1 }));
 
@@ -105,7 +115,7 @@ describe('modes/base session-scoped persistence', () => {
       const stateDir = join(wd, '.omx', 'state');
       const sessionId = 'sess-new-ralph';
       await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(wd, sessionId);
       await writeFile(join(stateDir, 'ralph-state.json'), JSON.stringify({
         active: true,
         mode: 'ralph',
@@ -137,7 +147,7 @@ describe('modes/base session-scoped persistence', () => {
       const sessionId = 'sess-ralph-restart';
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(wd, sessionId);
       await writeFile(join(sessionDir, 'ralph-state.json'), JSON.stringify({
         active: false,
         iteration: 7,

--- a/src/ralplan/__tests__/runtime.test.ts
+++ b/src/ralplan/__tests__/runtime.test.ts
@@ -14,6 +14,16 @@ function sessionStatePath(cwd: string, sessionId: string): string {
   return getStatePath('ralplan', cwd, sessionId);
 }
 
+async function writeSessionPointer(cwd: string, sessionId: string): Promise<void> {
+  const stateDir = join(cwd, '.omx', 'state');
+  await mkdir(stateDir, { recursive: true });
+  await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+    session_id: sessionId,
+    cwd,
+    state_root: stateDir,
+  }));
+}
+
 async function readScopedRalplanState(cwd: string, sessionId: string): Promise<Record<string, unknown>> {
   return JSON.parse(await readFile(sessionStatePath(cwd, sessionId), 'utf-8'));
 }
@@ -131,7 +141,7 @@ describe('ralplan runtime', () => {
     const sessionId = 'sess-ralplan-success';
     try {
       await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
-      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(cwd, sessionId);
 
       const seenPhases: string[] = [];
       const result = await runRalplanConsensus({
@@ -367,7 +377,7 @@ describe('ralplan runtime', () => {
     const sessionId = 'sess-ralplan-native-required-missing';
     try {
       await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
-      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(cwd, sessionId);
 
       const result = await runRalplanConsensus({
         async draft() {
@@ -407,7 +417,7 @@ describe('ralplan runtime', () => {
     const sessionId = 'sess-ralplan-planner-as-architect';
     try {
       await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
-      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(cwd, sessionId);
 
       const result = await runRalplanConsensus({
         async draft() {
@@ -452,7 +462,7 @@ describe('ralplan runtime', () => {
     const sessionId = 'sess-ralplan-native-missing-role';
     try {
       await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
-      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(cwd, sessionId);
       await writeNativeSubagentTracking(cwd, sessionId);
 
       const result = await runRalplanConsensus({
@@ -508,7 +518,7 @@ describe('ralplan runtime', () => {
     const criticCompletedAt = '2026-05-28T00:10:00.000Z';
     try {
       await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
-      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(cwd, sessionId);
       await writeNativeSubagentTracking(cwd, sessionId);
 
       const result = await runRalplanConsensus({
@@ -559,7 +569,7 @@ describe('ralplan runtime', () => {
     const sessionId = 'sess-ralplan-native-bookkeeping-only';
     try {
       await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
-      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(cwd, sessionId);
 
       const result = await runRalplanConsensus({
         async draft() {
@@ -624,7 +634,7 @@ describe('ralplan runtime', () => {
     const sessionId = 'sess-ralplan-native-required-ok';
     try {
       await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
-      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(cwd, sessionId);
       await writeNativeSubagentTracking(cwd, sessionId);
 
       const result = await runRalplanConsensus({
@@ -684,7 +694,7 @@ describe('ralplan runtime', () => {
     const sessionId = 'sess-ralplan-adapted-required-ok';
     try {
       await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
-      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(cwd, sessionId);
       await writeAdaptedSubagentTracking(cwd, sessionId);
 
       const result = await runRalplanConsensus({
@@ -741,7 +751,7 @@ describe('ralplan runtime', () => {
     const sessionId = 'sess-ralplan-native-same-thread';
     try {
       await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
-      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(cwd, sessionId);
       await writeNativeSubagentTracking(cwd, sessionId);
 
       const result = await runRalplanConsensus({
@@ -799,7 +809,7 @@ describe('ralplan runtime', () => {
     const sessionId = 'sess-ralplan-architect-reject';
     try {
       await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
-      await writeFile(join(cwd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(cwd, sessionId);
 
       let criticCalls = 0;
       const result = await runRalplanConsensus({
@@ -842,7 +852,7 @@ describe('ralplan runtime', () => {
     const sessionId = 'sess-ralplan-loop';
     try {
       await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
-      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(cwd, sessionId);
 
       const draftIterations: number[] = [];
       const criticVerdicts: string[] = [];
@@ -895,7 +905,7 @@ describe('ralplan runtime', () => {
     const sessionId = 'sess-ralplan-architect-reject';
     try {
       await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
-      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(cwd, sessionId);
       const plansDir = join(cwd, '.omx', 'plans');
       await mkdir(plansDir, { recursive: true });
       await writeFile(join(plansDir, 'prd-reject.md'), '# plan\n');
@@ -928,7 +938,7 @@ describe('ralplan runtime', () => {
     const sessionId = 'sess-ralplan-mismatched-artifacts';
     try {
       await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
-      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(cwd, sessionId);
 
       const result = await runRalplanConsensus({
         async draft() {
@@ -962,7 +972,7 @@ describe('ralplan runtime', () => {
     const sessionId = 'sess-ralplan-no-artifacts';
     try {
       await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
-      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(cwd, sessionId);
 
       const result = await runRalplanConsensus({
         async draft() {
@@ -996,7 +1006,7 @@ describe('ralplan runtime', () => {
     const sessionId = 'sess-ralplan-fail';
     try {
       await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
-      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(cwd, sessionId);
 
       const result = await runRalplanConsensus({
         async draft() {
@@ -1028,7 +1038,7 @@ describe('ralplan runtime', () => {
     const sessionId = 'sess-ralplan-cancel';
     try {
       await mkdir(join(sessionStatePath(cwd, sessionId), '..'), { recursive: true });
-      await writeFile(join(sessionStatePath(cwd, sessionId), '..', '..', '..', 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeSessionPointer(cwd, sessionId);
 
       await startMode('ralplan', 'cancel me', 2, cwd);
       await cancelRalplanConsensus(cwd);

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -866,7 +866,7 @@ describe('state operations directory initialization', () => {
       const sessionId = 'sess-clear';
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: stateDir }, null, 2));
       await writeFile(
         join(stateDir, 'deep-interview-state.json'),
         JSON.stringify({ active: true, mode: 'deep-interview', current_phase: 'legacy-root' }, null, 2),
@@ -992,7 +992,7 @@ describe('state operations directory initialization', () => {
       const sessionId = 'sess-terminal-implicit';
       const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(wd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(join(wd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: join(wd, '.omx', 'state') }, null, 2));
       await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
         active: true,
         current_phase: 'deep-interview',
@@ -5338,7 +5338,7 @@ describe('state operations directory initialization', () => {
       const sessionId = 'sess-resume-root-fallback';
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: stateDir }, null, 2));
       await writeFile(
         join(stateDir, 'ralph-state.json'),
         JSON.stringify({


### PR DESCRIPTION
## Summary

Issue #3139 exposed split-brain state-root selection: nested invocations could report no active mode while native hooks still enforced a parent session's state. This change establishes one persisted, authenticated, canonical-realpath state-root authority per run and makes mutation, status, cancellation, launch, hook, HUD/doctor, team/tmux, restart/resume, worktree, and migration surfaces resolve through it.

## Changes

- Add workspace-bound authority anchors, immutable generations, revisioned bindings, leases/fences, journaled transactions, authenticated child transport, and bounded migration/recovery.
- Make state writes, clears, status, cancellation, native hooks, HUD/doctor, team workers, tmux launches, hotswap, MCP, Ralph, and session lifecycle fail closed when authority proof is absent, stale, foreign, replaced, symlinked, or ambiguous.
- Keep raw transport bearers process-local; publish persistent launch effects only after journaled verification and use nonce-scoped, value-free tmux transport.
- Add compiler-assisted production callsite inventory, exact-head three-OS authority CI, state model documentation, and broad security/regression coverage.

## Validation

- [x] `npm run build`
- [ ] `npm test` — bounded exact-head run was stopped after exceeding the requested time bound; it reported no failures through 9,935 retained output lines, including the authority/native-hook surfaces reached before cancellation.
- [x] Conflict/rebase causal matrix: 8 affected compiled files, 1,036 tests passed, 0 failed.
- [x] Approved authority matrix: 628 tests passed before the sole inventory-drift assertion; the stale ranges/missing row were repaired, then the complete 19-test inventory file passed with zero production violations.
- [x] `npm run check:no-unused`
- [x] `npm run lint` — 738 files checked, no fixes.
- [x] `git diff --check`
- [x] `npm run smoke:packed-install`
- [x] PyYAML parse of `.github/workflows/authority-state-root.yml`
- [ ] `omx doctor` — setup/config behavior is not changed by this authority fix.

## Checklist

- [x] PR is focused on authoritative runtime state and its directly affected integrations.
- [x] `docs/STATE_MODEL.md` documents the new authority model.
- [x] Backward compatibility is bounded to authenticated deterministic migration; caller-selected mutation roots intentionally fail closed.

## Related

Addresses #3139.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
