### PR TITLE
fix(hud): deduplicate control-plane authority

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3385,6 +3385,69 @@ esac
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it("accepts only a complete concurrent winning pair after the atomic publisher is rejected", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-tmux-birth-interleaved-"));
+    const bin = join(cwd, "bin");
+    const tmux = join(bin, "tmux");
+    const state = join(cwd, "published");
+    const previousPath = process.env.PATH;
+    try {
+      await mkdir(bin, { recursive: true });
+      await writeFile(tmux, `#!/bin/sh
+case "$1" in
+  display-message) printf 'leader\\t$1\\t@1\\t%%1\\n' ;;
+  show-option)
+    if [ -f "${state}" ]; then
+      case "$*" in *' -p '*) printf 'winning-pane-birth\\n' ;; *) printf 'winning-session-birth\\n' ;; esac
+    fi
+    ;;
+  if-shell)
+    : > "${state}"
+    for arg in "$@"; do
+      case "$arg" in *__omx_birth_rejected_*) receipt="${'$'}{arg#*display-message -p }" ;; esac
+    done
+    printf '%s\\n' "$receipt"
+    ;;
+esac
+`);
+      await chmod(tmux, 0o755);
+      process.env.PATH = `${bin}:${previousPath ?? ""}`;
+      const evidence = await establishCurrentTmuxInstanceBinding("logical-session", "%1");
+      assert.equal(evidence?.sessionInstanceId, "winning-session-birth");
+      assert.equal(evidence?.paneInstanceId, "winning-pane-birth");
+    } finally {
+      if (typeof previousPath === "string") process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects mixed birth evidence without attempting to repair an uncertain pair", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-tmux-birth-partial-"));
+    const bin = join(cwd, "bin");
+    const tmux = join(bin, "tmux");
+    const log = join(cwd, "tmux.log");
+    const previousPath = process.env.PATH;
+    try {
+      await mkdir(bin, { recursive: true });
+      await writeFile(tmux, `#!/bin/sh
+printf '%s\\n' "$*" >> "${log}"
+case "$1" in
+  display-message) printf 'leader\\t$1\\t@1\\t%%1\\n' ;;
+  show-option) case "$*" in *' -p '*) ;; *) printf 'orphaned-session-birth\\n' ;; esac ;;
+esac
+`);
+      await chmod(tmux, 0o755);
+      process.env.PATH = `${bin}:${previousPath ?? ""}`;
+      assert.equal(await establishCurrentTmuxInstanceBinding("logical-session", "%1"), null);
+      assert.doesNotMatch(await readFile(log, "utf-8"), /if-shell|set-option/);
+    } finally {
+      if (typeof previousPath === "string") process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("tmux HUD pane helpers", () => {
@@ -3491,7 +3554,7 @@ describe("tmux HUD pane helpers", () => {
 });
 
 describe("detached tmux new-session sequencing", () => {
-  it("buildDetachedSessionBootstrapSteps creates and tags the leader before reconciliation", () => {
+  it("buildDetachedSessionBootstrapSteps creates the leader before reconciliation without tagging opaque birth with the logical session id", () => {
     const steps = buildDetachedSessionBootstrapSteps(
       "omx-demo",
       "/tmp/project",
@@ -3505,7 +3568,7 @@ describe("detached tmux new-session sequencing", () => {
     );
     assert.deepEqual(
       steps.map((step) => step.name),
-      ["new-session", "tag-session", "reconcile-managed-hud"],
+      ["new-session", "reconcile-managed-hud"],
     );
     assert.ok(!steps.some((step) => step.args[0] === "split-window"));
     assert.equal(steps[0]?.args.includes("-e"), true);
@@ -3550,22 +3613,15 @@ describe("detached tmux new-session sequencing", () => {
       "sess-detached-managed",
     );
     const newSession = steps.find((step) => step.name === "new-session");
-    const tagSession = steps.find((step) => step.name === "tag-session");
     assert.ok(newSession);
-    assert.ok(tagSession);
     assert.equal(
       newSession!.args.includes("-e") &&
         newSession!.args.some((arg) => arg === "OMX_SESSION_ID=sess-detached-managed"),
       true,
     );
     assert.equal(newSession!.args.some((arg) => arg === "OMX_TMUX_HUD_OWNER=1"), true);
-    assert.deepEqual(tagSession!.args, [
-      "set-option",
-      "-t",
-      "omx-demo",
-      "@omx_instance_id",
-      "sess-detached-managed",
-    ]);
+    assert.equal(steps.some((step) => step.name === "tag-session"), false);
+    assert.doesNotMatch(newSession!.args.join(" "), /@omx_instance_id/);
   });
 
   it("buildDetachedSessionBootstrapSteps forwards inherited leader model separately from worker launch args", () => {
@@ -4184,7 +4240,7 @@ exit 0
     assert.doesNotMatch(script, /execFileSync\('tmux'/);
   });
 
-  it("buildDetachedSessionBootstrapSteps kills detached tmux session on normal shell exit", () => {
+  it("buildDetachedSessionBootstrapSteps preserves the detached session on normal shell exit until exact rollback evidence exists", () => {
     const steps = buildDetachedSessionBootstrapSteps(
       "omx-demo",
       "/tmp/project",
@@ -4205,9 +4261,7 @@ exit 0
     assert.match(leaderCmd!, /wait "\$omx_codex_pid";/);
     assert.match(leaderCmd!, /kill -TERM "\$omx_codex_pid"/);
     assert.match(leaderCmd!, /releaseTmuxExtendedKeysLease/);
-    assert.match(leaderCmd!, /if \[ "\$status" -eq 0 \]; then/);
-    assert.match(leaderCmd!, /tmux kill-session -t/);
-    assert.match(leaderCmd!, /"omx-demo"/);
+    assert.doesNotMatch(leaderCmd!, /kill-session/);
     assert.match(leaderCmd!, /codex exited immediately with code 0/);
     assert.match(leaderCmd!, /codex exited with code/);
     assert.match(leaderCmd!, /detached tmux session is being kept open/);
@@ -4235,14 +4289,7 @@ exit 0
     assert.match(leaderCmd!, /\/tmp\/codex-home/);
     assert.match(leaderCmd!, /\/tmp\/project\/\.codex-project/);
     assert.match(leaderCmd!, /\/tmp\/project\/\.omx\/runtime\/codex-home\/omx-session-123/);
-    const helperIndex = leaderCmd!.indexOf("runDetachedSessionPostLaunch");
-    const signalGateIndex = leaderCmd!.indexOf('if [ "$status" -eq 0 ]');
-    assert.ok(helperIndex >= 0);
-    assert.ok(signalGateIndex >= 0);
-    assert.ok(
-      helperIndex < signalGateIndex,
-      "detached postLaunch helper must run before the signal-derived tmux kill-session gate",
-    );
+    assert.doesNotMatch(leaderCmd!, /kill-session/);
   });
 
   it("detached leader command keeps stdin open for the Codex child", async () => {
@@ -4391,7 +4438,7 @@ exit 0
       assert.match(log, /tmux:show-options -sv extended-keys/);
       assert.match(log, /tmux:set-option -sq extended-keys always/);
       assert.match(log, /tmux:set-option -sq extended-keys off/);
-      assert.match(log, /tmux:kill-session -t omx-demo/);
+      assert.doesNotMatch(log, /tmux:kill-session -t omx-demo/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -4606,7 +4653,7 @@ exit 0
       assert.match(result.stderr, /codex exited immediately with code 0 during startup/);
       assert.match(result.stderr, /detached tmux session is being kept open/);
       const log = await readFile(logPath, "utf-8");
-      assert.match(log, /tmux:kill-session -t omx-demo/);
+      assert.doesNotMatch(log, /tmux:kill-session -t omx-demo/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -5261,7 +5308,7 @@ exit 0
     assert.equal(steps.some((step) => step.name === "set-mouse"), true);
   });
 
-  it("buildDetachedSessionFinalizeSteps uses quiet best-effort tmux resize commands", () => {
+  it("buildDetachedSessionFinalizeSteps keeps resize actions inert without immutable pane evidence", () => {
     const steps = buildDetachedSessionFinalizeSteps(
       "omx-demo",
       "%12",
@@ -5278,24 +5325,9 @@ exit 0
       (step) => step.name === "reconcile-hud-resize",
     );
 
-    assert.match((registerHook?.args ?? []).join(" "), />\/dev\/null 2>&1 \|\| true/);
-    assert.match(
-      (registerHook?.args ?? []).join(" "),
-      new RegExp(`-y ${HUD_TMUX_HEIGHT_LINES}\\b`),
-    );
-    assert.match(schedule?.args[2] ?? "", />\/dev\/null 2>&1 \|\| true/);
-    assert.match(
-      schedule?.args[2] ?? "",
-      new RegExp(`-y ${HUD_TMUX_HEIGHT_LINES}\\b`),
-    );
-    assert.match(
-      (reconcile?.args ?? []).join(" "),
-      />\/dev\/null 2>&1 \|\| true/,
-    );
-    assert.match(
-      (reconcile?.args ?? []).join(" "),
-      new RegExp(`-y ${HUD_TMUX_HEIGHT_LINES}\\b`),
-    );
+    assert.doesNotMatch((registerHook?.args ?? []).join(" "), /resize-pane/);
+    assert.doesNotMatch(schedule?.args[2] ?? "", /resize-pane/);
+    assert.doesNotMatch((reconcile?.args ?? []).join(" "), /resize-pane/);
   });
 
   it("buildDetachedSessionFinalizeSteps skips detached resize hooks on native Windows", () => {
@@ -5348,38 +5380,45 @@ exit 0
     );
   });
 
-  it("buildDetachedSessionRollbackSteps makes retained hook generations inert before killing session", () => {
+  it("buildDetachedSessionRollbackSteps destroys only the matching session birth and rejects name-reused successors", () => {
     const steps = buildDetachedSessionRollbackSteps(
       "omx-demo",
       "omx-demo:0",
       "omx_resize_launch_demo_0_12",
       "omx_attached_launch_demo_0_12",
+      "opaque-session-birth",
     );
     assert.deepEqual(
       steps.map((step) => step.name),
       [
         "unregister-client-attached-reconcile",
         "unregister-resize-hook",
-        "kill-session",
+        "kill-session-if-birth-matches",
       ],
     );
     assert.equal(steps[0]?.args[0], "show-hooks");
     assert.equal(steps[1]?.args[0], "show-hooks");
     assert.doesNotMatch(steps.flatMap((step) => step.args).join(" "), /set-hook -u/);
-    assert.deepEqual(steps[2]?.args, ["kill-session", "-t", "omx-demo"]);
+    const rollback = steps[2]!;
+    assert.deepEqual(rollback.args.slice(0, 4), ["if-shell", "-t", "omx-demo", "-F"]);
+    assert.match(rollback.args[4]!, /session_name/);
+    assert.match(rollback.args[4]!, /@omx_instance_id/);
+    assert.match(rollback.args[4]!, /opaque-session-birth/);
+    assert.doesNotMatch(rollback.args[4]!, /successor-session-birth/);
+    assert.match(rollback.args[5]!, /kill-session -t 'omx-demo'/);
+    assert.match(rollback.args[5]!, /__omx_detached_session_rollback_applied_/);
+    assert.match(rollback.args[6]!, /__omx_detached_session_rollback_rejected_/);
   });
 
-  it("buildDetachedSessionRollbackSteps only kills session when no hook metadata exists", () => {
+  it("buildDetachedSessionRollbackSteps preserves uncertain sessions without an opaque birth", () => {
     const steps = buildDetachedSessionRollbackSteps(
       "omx-demo",
       null,
       null,
       null,
+      null,
     );
-    assert.deepEqual(
-      steps.map((step) => step.name),
-      ["kill-session"],
-    );
+    assert.deepEqual(steps, []);
   });
 });
 

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -81,10 +81,6 @@ import {
   releaseTmuxExtendedKeysLease,
   withTmuxExtendedKeys,
   serializeDetachedSessionParentEnv,
-  buildInsideTmuxHudHookEnv,
-  registerInsideTmuxHudResizeHook,
-  buildDetachedHudHookEnv,
-  registerDetachedHudLayoutReconcileHook,
   ensureOmxRuntimeCommandShim,
   omxRuntimeCommandShimPath,
   prependOmxRuntimeCommandShimToEnv,
@@ -3387,6 +3383,8 @@ describe("tmux HUD pane helpers", () => {
         "#{pane_bottom}",
         "#{window_width}",
         "#{window_height}",
+        "#{@omx_pane_instance_id}",
+        "#{@omx_instance_id}",
         "#{pane_start_command}",
         "#{pane_current_path}",
       ].join("\x1f"),
@@ -3425,7 +3423,7 @@ describe("tmux HUD pane helpers", () => {
 });
 
 describe("detached tmux new-session sequencing", () => {
-  it("buildDetachedSessionBootstrapSteps uses shared HUD height and split-capture ordering", () => {
+  it("buildDetachedSessionBootstrapSteps creates and tags the leader before reconciliation", () => {
     const steps = buildDetachedSessionBootstrapSteps(
       "omx-demo",
       "/tmp/project",
@@ -3439,14 +3437,9 @@ describe("detached tmux new-session sequencing", () => {
     );
     assert.deepEqual(
       steps.map((step) => step.name),
-      ["new-session", "tag-session", "split-and-capture-hud-pane"],
+      ["new-session", "tag-session", "reconcile-managed-hud"],
     );
-    const splitStep = steps.find((step) => step.name === "split-and-capture-hud-pane");
-    assert.ok(splitStep);
-    assert.equal(splitStep.args[3], String(HUD_TMUX_HEIGHT_LINES));
-    assert.equal(splitStep.args[6], "omx-demo");
-    assert.equal(splitStep.args.includes("-P"), true);
-    assert.equal(splitStep.args.includes("#{pane_id}"), true);
+    assert.ok(!steps.some((step) => step.args[0] === "split-window"));
     assert.equal(steps[0]?.args.includes("-e"), true);
     assert.equal(steps[0]?.args.includes("OMX_SESSION_ID=omx-session-test"), true);
     assert.equal(
@@ -4009,193 +4002,35 @@ exit 0
     assert.doesNotMatch(argsText, /fake-provider-key/);
   });
 
-  it("runCodex cleans only same-session same-leader HUD panes before launch", async () => {
+  it("runCodex delegates inside-tmux HUD lifecycle to shared reconciliation", async () => {
     const source = await readFile(join(repoRoot, "src", "cli", "index.ts"), "utf8");
     assert.match(
       source,
-      /const staleHudPaneIds = currentPaneId\s*\? listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ sessionId, leaderPaneId: currentPaneId \}\)\s*: \[\];/,
+      /if \(currentPaneId\) \{\s*await reconcileManagedHudPane\(cwd, sessionId, currentPaneId, hudRuntimeEnv\);\s*\}/,
     );
-    assert.match(source, /const \[keeperHudPaneId, \.\.\.duplicateHudPaneIds\] = staleHudPaneIds;/);
-    assert.match(source, /for \(const paneId of duplicateHudPaneIds\) \{\s*killTmuxPane\(paneId\);\s*\}/);
-    assert.match(source, /if \(keeperHudPaneId\) \{\s*hudPaneId = keeperHudPaneId;/);
-    assert.doesNotMatch(
-      source,
-      /const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ leaderPaneId: currentPaneId \}\);/,
-    );
+    assert.doesNotMatch(source, /listHudWatchPaneIdsInCurrentWindow|createHudWatchPane|registerHudResizeHook\(/);
   });
 
-  it("runCodex skips launch-time HUD cleanup when TMUX_PANE is unavailable", async () => {
+  it("runCodex preserves detached reconciliation sequencing", async () => {
     const source = await readFile(join(repoRoot, "src", "cli", "index.ts"), "utf8");
     assert.match(
       source,
-      /const staleHudPaneIds = currentPaneId\s*\? listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ sessionId, leaderPaneId: currentPaneId \}\)\s*: \[\];/,
+      /if \(detachedLeaderPaneId\) \{\s*await reconcileManagedHudPane\(cwd, sessionId, detachedLeaderPaneId, hudRuntimeEnv\);\s*\}\s*const finalizeSteps = buildDetachedSessionFinalizeSteps/,
     );
   });
 
-  it("runCodex builds inside-tmux HUD command through explicit runtime-root resolver", async () => {
-    const source = await readFile(join(repoRoot, 'src', 'cli', 'index.ts'), 'utf-8');
-    assert.match(source, /const hudRuntimeRoot: HudRuntimeRootForLaunch = runtimeContext\s*\? \{ omxRoot: runtimeContext\.omxRoot, rootSource: 'omx-root-env' \}\s*: resolveHudRuntimeRootForLaunch\(cwd, process\.env\);/);
+  it("reconcileManagedHudPane invokes the shared HUD reconciler with leader identity", async () => {
+    const source = await readFile(join(repoRoot, "src", "cli", "index.ts"), "utf8");
     assert.match(
       source,
-      /const hudRuntimeEnv = \{\s*\.\.\.buildHudRuntimeEnv\(\{\s*sessionId,\s*leaderPaneId: currentPaneId,\s*\.\.\.hudRuntimeRoot,\s*\}\)\.env,\s*\.\.\.runtimeEnvOverlay,\s*\};\s*const hudEnvArgs = Object\.entries\(hudRuntimeEnv\)\.map\(\(\[key, value\]\) => `\$\{key\}=\$\{value\}`\)/,
-    );
-    assert.match(source, /if \(env\.OMX_TEAM_STATE_ROOT\?\.trim\(\)\) return 'team-env';\s*if \(env\.OMX_ROOT\?\.trim\(\) \|\| omxRootOverride\) return 'omx-root-env';\s*if \(env\.OMX_STATE_ROOT\?\.trim\(\)\) return 'omx-state-root-env';/);
-    assert.match(
-      source,
-      /buildTmuxPaneCommand\("env",\s*\[\.\.\.hudEnvArgs,\s*"node",\s*omxBin,\s*"hud",\s*"--watch"\]\)/,
-    );
-  });
-
-  it("runCodex registers a HUD resize hook immediately for inside-tmux launches", async () => {
-    const source = await readFile(join(repoRoot, 'src', 'cli', 'index.ts'), 'utf-8');
-    assert.match(
-      source,
-      /registerInsideTmuxHudResizeHook\(\{\s*hudPaneId,\s*currentPaneId,\s*cwd,\s*sessionId,\s*omxRootOverride,\s*baseEnv: runtimeHookEnv,\s*\}\)/,
+      /execFileSync\(process\.execPath, \[omxBin, "hud", "--reconcile-tmux"\], \{/,
     );
     assert.match(
       source,
-      /if \(currentPaneId\) \{\s*unregisterHudResizeHook\(currentPaneId\);\s*\}/,
+      /TMUX_PANE: leaderPaneId,\s*OMX_SESSION_ID: sessionId,\s*\[OMX_TMUX_HUD_OWNER_ENV\]: "1",\s*\[OMX_TMUX_HUD_LEADER_PANE_ENV\]: leaderPaneId/,
     );
   });
 
-  it("buildInsideTmuxHudHookEnv tags hook commands with session, owner, leader, and local root", () => {
-    const env = buildInsideTmuxHudHookEnv(
-      { PATH: "/bin" },
-      "sess-a",
-      "%leader",
-      "/repo",
-    );
-
-    assert.equal(env.PATH, "/bin");
-    assert.equal(env.OMX_SESSION_ID, "sess-a");
-    assert.equal(env.OMX_TMUX_HUD_OWNER, "1");
-    assert.equal(env.OMX_TMUX_HUD_LEADER_PANE, "%leader");
-    assert.equal(env.OMX_ROOT, "/repo");
-  });
-
-  it("registerInsideTmuxHudResizeHook forwards cwd and env to hook registration", () => {
-    const calls: Array<{
-      hudPaneId: string;
-      leaderPaneId: string | undefined;
-      heightLines: number;
-      cwd?: string;
-      env?: NodeJS.ProcessEnv;
-    }> = [];
-
-    const result = registerInsideTmuxHudResizeHook({
-      hudPaneId: "%hud",
-      currentPaneId: "%leader",
-      cwd: "/repo",
-      sessionId: "sess-a",
-      omxRootOverride: "/repo",
-      baseEnv: { PATH: "/bin" },
-      register: (hudPaneId, leaderPaneId, heightLines, options) => {
-        calls.push({ hudPaneId, leaderPaneId, heightLines, cwd: options?.cwd, env: options?.env });
-        return true;
-      },
-    });
-
-    assert.equal(result, true);
-    assert.deepEqual(calls, [{
-      hudPaneId: "%hud",
-      leaderPaneId: "%leader",
-      heightLines: HUD_TMUX_HEIGHT_LINES,
-      cwd: "/repo",
-      env: {
-        PATH: "/bin",
-        OMX_SESSION_ID: "sess-a",
-        OMX_TMUX_HUD_OWNER: "1",
-        OMX_TMUX_HUD_LEADER_PANE: "%leader",
-        OMX_ROOT: "/repo",
-      },
-    }]);
-    assert.equal(registerInsideTmuxHudResizeHook({
-      hudPaneId: null,
-      currentPaneId: "%leader",
-      cwd: "/repo",
-      sessionId: "sess-a",
-      register: () => {
-        throw new Error("should not register without a HUD pane");
-      },
-    }), false);
-  });
-
-  it("buildDetachedHudHookEnv preserves tmux targeting and local launcher identity", () => {
-    const env = buildDetachedHudHookEnv(
-      { PATH: "/bin" },
-      "sess-a",
-      "%leader",
-      "/tmp/tmux.sock,123,7",
-      "/repo/dist/cli/omx.js",
-      "/repo",
-    );
-
-    assert.equal(env.PATH, "/bin");
-    assert.equal(env.TMUX, "/tmp/tmux.sock,123,7");
-    assert.equal(env.TMUX_PANE, "%leader");
-    assert.equal(env.OMX_SESSION_ID, "sess-a");
-    assert.equal(env.OMX_TMUX_HUD_OWNER, "1");
-    assert.equal(env.OMX_ROOT, "/repo");
-    assert.equal(env.OMX_ENTRY_PATH, "/repo/dist/cli/omx.js");
-  });
-
-  it("registerDetachedHudLayoutReconcileHook reads TMUX from the detached leader pane before registering", () => {
-    const calls: Array<{
-      hudPaneId: string;
-      leaderPaneId: string | undefined;
-      heightLines: number;
-      cwd?: string;
-      env?: NodeJS.ProcessEnv;
-    }> = [];
-    const readTargets: string[] = [];
-
-    const result = registerDetachedHudLayoutReconcileHook({
-      hudPaneId: "%hud",
-      detachedLeaderPaneId: "%leader",
-      cwd: "/repo",
-      sessionId: "sess-a",
-      omxBin: "/repo/dist/cli/omx.js",
-      omxRootOverride: "/repo",
-      baseEnv: { PATH: "/bin" },
-      readTmuxEnvValue: (targetPaneId) => {
-        readTargets.push(targetPaneId);
-        return "/tmp/tmux.sock,123,7";
-      },
-      register: (hudPaneId, leaderPaneId, heightLines, options) => {
-        calls.push({ hudPaneId, leaderPaneId, heightLines, cwd: options?.cwd, env: options?.env });
-        return true;
-      },
-    });
-
-    assert.equal(result, true);
-    assert.deepEqual(readTargets, ["%leader"]);
-    assert.deepEqual(calls, [{
-      hudPaneId: "%hud",
-      leaderPaneId: "%leader",
-      heightLines: HUD_TMUX_HEIGHT_LINES,
-      cwd: "/repo",
-      env: {
-        PATH: "/bin",
-        TMUX: "/tmp/tmux.sock,123,7",
-        TMUX_PANE: "%leader",
-        OMX_SESSION_ID: "sess-a",
-        OMX_TMUX_HUD_OWNER: "1",
-        OMX_ROOT: "/repo",
-        OMX_ENTRY_PATH: "/repo/dist/cli/omx.js",
-      },
-    }]);
-    assert.equal(registerDetachedHudLayoutReconcileHook({
-      hudPaneId: "%hud",
-      detachedLeaderPaneId: "%leader",
-      cwd: "/repo",
-      sessionId: "sess-a",
-      omxBin: "/repo/dist/cli/omx.js",
-      readTmuxEnvValue: () => undefined,
-      register: () => {
-        throw new Error("should not register without TMUX");
-      },
-    }), false);
-  });
 
   it("buildDetachedSessionBootstrapSteps starts native Windows detached sessions with powershell", () => {
     const hudCmd = buildWindowsPromptCommand("node", [
@@ -4215,8 +4050,7 @@ exit 0
     );
     assert.equal(steps[0]?.name, "new-session");
     assert.equal(steps[0]?.args.at(-1), "powershell.exe");
-    assert.equal(steps[1]?.name, "split-and-capture-hud-pane");
-    assert.equal(steps[1]?.args.at(-1), hudCmd);
+    assert.equal(steps[1]?.name, "reconcile-managed-hud");
   });
 
   it("buildDetachedWindowsBootstrapScript targets the resolved tmux-compatible command", () => {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -78,6 +78,7 @@ import {
   buildDetachedWindowsBootstrapScript,
   acquireTmuxExtendedKeysLease,
   resolveNativeSessionName,
+  establishCurrentTmuxInstanceBinding,
   releaseTmuxExtendedKeysLease,
   withTmuxExtendedKeys,
   serializeDetachedSessionParentEnv,
@@ -3317,6 +3318,72 @@ describe("classifyCodexExecFailure", () => {
     const classified = classifyCodexExecFailure(err);
     assert.equal(classified.kind, "launch-error");
     assert.equal(classified.code, "ENOENT");
+  });
+});
+
+describe("opaque tmux instance births", () => {
+  it("preserves existing births instead of overwriting them with the reusable session id", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-tmux-birth-preserve-"));
+    const bin = join(cwd, "bin");
+    const tmux = join(bin, "tmux");
+    const log = join(cwd, "tmux.log");
+    const previousPath = process.env.PATH;
+    try {
+      await mkdir(bin, { recursive: true });
+      await writeFile(tmux, `#!/bin/sh
+printf '%s\\n' "$*" >> "${log}"
+case "$1" in
+  display-message) printf 'leader\\t$1\\t@1\\t%%1\\n' ;;
+  show-option)
+    case "$*" in
+      *' -p '*) printf 'pane-birth-existing\\n' ;;
+      *) printf 'session-birth-existing\\n' ;;
+    esac
+    ;;
+  set-option) exit 99 ;;
+esac
+`);
+      await chmod(tmux, 0o755);
+      process.env.PATH = `${bin}:${previousPath ?? ""}`;
+      const evidence = await establishCurrentTmuxInstanceBinding("reusable-session-id", "%1");
+      assert.equal(evidence?.sessionInstanceId, "session-birth-existing");
+      assert.equal(evidence?.paneInstanceId, "pane-birth-existing");
+      assert.doesNotMatch(await readFile(log, "utf-8"), /set-option/);
+    } finally {
+      if (typeof previousPath === "string") process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an ABA-reused pane when its immutable context changes during verification", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-tmux-birth-aba-"));
+    const bin = join(cwd, "bin");
+    const tmux = join(bin, "tmux");
+    const state = join(cwd, "display-count");
+    const previousPath = process.env.PATH;
+    try {
+      await mkdir(bin, { recursive: true });
+      await writeFile(tmux, `#!/bin/sh
+count=0
+[ -f "${state}" ] && count=$(cat "${state}")
+case "$1" in
+  display-message)
+    count=$((count + 1)); printf '%s' "$count" > "${state}"
+    [ "$count" -gt 2 ] && printf 'leader\\t$1\\t@2\\t%%1\\n' || printf 'leader\\t$1\\t@1\\t%%1\\n'
+    ;;
+  show-option) printf 'pane-birth-existing\\n' ;;
+  show-options) printf 'session-birth-existing\\n' ;;
+esac
+`);
+      await chmod(tmux, 0o755);
+      process.env.PATH = `${bin}:${previousPath ?? ""}`;
+      assert.equal(await establishCurrentTmuxInstanceBinding("reusable-session-id", "%1"), null);
+    } finally {
+      if (typeof previousPath === "string") process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -81,10 +81,6 @@ import {
   releaseTmuxExtendedKeysLease,
   withTmuxExtendedKeys,
   serializeDetachedSessionParentEnv,
-  buildInsideTmuxHudHookEnv,
-  registerInsideTmuxHudResizeHook,
-  buildDetachedHudHookEnv,
-  registerDetachedHudLayoutReconcileHook,
   ensureOmxRuntimeCommandShim,
   omxRuntimeCommandShimPath,
   prependOmxRuntimeCommandShimToEnv,
@@ -3387,6 +3383,8 @@ describe("tmux HUD pane helpers", () => {
         "#{pane_bottom}",
         "#{window_width}",
         "#{window_height}",
+        "#{@omx_pane_instance_id}",
+        "#{@omx_instance_id}",
         "#{pane_start_command}",
         "#{pane_current_path}",
       ].join("\x1f"),
@@ -3425,7 +3423,7 @@ describe("tmux HUD pane helpers", () => {
 });
 
 describe("detached tmux new-session sequencing", () => {
-  it("buildDetachedSessionBootstrapSteps uses shared HUD height and split-capture ordering", () => {
+  it("buildDetachedSessionBootstrapSteps creates and tags the leader before reconciliation", () => {
     const steps = buildDetachedSessionBootstrapSteps(
       "omx-demo",
       "/tmp/project",
@@ -3439,14 +3437,9 @@ describe("detached tmux new-session sequencing", () => {
     );
     assert.deepEqual(
       steps.map((step) => step.name),
-      ["new-session", "tag-session", "split-and-capture-hud-pane"],
+      ["new-session", "tag-session", "reconcile-managed-hud"],
     );
-    const splitStep = steps.find((step) => step.name === "split-and-capture-hud-pane");
-    assert.ok(splitStep);
-    assert.equal(splitStep.args[3], String(HUD_TMUX_HEIGHT_LINES));
-    assert.equal(splitStep.args[6], "omx-demo");
-    assert.equal(splitStep.args.includes("-P"), true);
-    assert.equal(splitStep.args.includes("#{pane_id}"), true);
+    assert.ok(!steps.some((step) => step.args[0] === "split-window"));
     assert.equal(steps[0]?.args.includes("-e"), true);
     assert.equal(steps[0]?.args.includes("OMX_SESSION_ID=omx-session-test"), true);
     assert.equal(
@@ -4060,193 +4053,35 @@ exit 0
     assert.doesNotMatch(argsText, /fake-provider-key/);
   });
 
-  it("runCodex cleans only same-session same-leader HUD panes before launch", async () => {
+  it("runCodex delegates inside-tmux HUD lifecycle to shared reconciliation", async () => {
     const source = await readFile(join(repoRoot, "src", "cli", "index.ts"), "utf8");
     assert.match(
       source,
-      /const staleHudPaneIds = currentPaneId\s*\? listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ sessionId, leaderPaneId: currentPaneId \}\)\s*: \[\];/,
+      /if \(currentPaneId\) \{\s*await reconcileManagedHudPane\(cwd, sessionId, currentPaneId, hudRuntimeEnv\);\s*\}/,
     );
-    assert.match(source, /const \[keeperHudPaneId, \.\.\.duplicateHudPaneIds\] = staleHudPaneIds;/);
-    assert.match(source, /for \(const paneId of duplicateHudPaneIds\) \{\s*killTmuxPane\(paneId\);\s*\}/);
-    assert.match(source, /if \(keeperHudPaneId\) \{\s*hudPaneId = keeperHudPaneId;/);
-    assert.doesNotMatch(
-      source,
-      /const staleHudPaneIds = listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ leaderPaneId: currentPaneId \}\);/,
-    );
+    assert.doesNotMatch(source, /listHudWatchPaneIdsInCurrentWindow|createHudWatchPane|registerHudResizeHook\(/);
   });
 
-  it("runCodex skips launch-time HUD cleanup when TMUX_PANE is unavailable", async () => {
+  it("runCodex preserves detached reconciliation sequencing", async () => {
     const source = await readFile(join(repoRoot, "src", "cli", "index.ts"), "utf8");
     assert.match(
       source,
-      /const staleHudPaneIds = currentPaneId\s*\? listHudWatchPaneIdsInCurrentWindow\(currentPaneId, \{ sessionId, leaderPaneId: currentPaneId \}\)\s*: \[\];/,
+      /if \(detachedLeaderPaneId\) \{\s*await reconcileManagedHudPane\(cwd, sessionId, detachedLeaderPaneId, hudRuntimeEnv\);\s*\}\s*const finalizeSteps = buildDetachedSessionFinalizeSteps/,
     );
   });
 
-  it("runCodex builds inside-tmux HUD command through explicit runtime-root resolver", async () => {
-    const source = await readFile(join(repoRoot, 'src', 'cli', 'index.ts'), 'utf-8');
-    assert.match(source, /const hudRuntimeRoot: HudRuntimeRootForLaunch = runtimeContext\s*\? \{ omxRoot: runtimeContext\.omxRoot, rootSource: 'omx-root-env' \}\s*: resolveHudRuntimeRootForLaunch\(cwd, process\.env\);/);
+  it("reconcileManagedHudPane invokes the shared HUD reconciler with leader identity", async () => {
+    const source = await readFile(join(repoRoot, "src", "cli", "index.ts"), "utf8");
     assert.match(
       source,
-      /const hudRuntimeEnv = \{\s*\.\.\.buildHudRuntimeEnv\(\{\s*sessionId,\s*leaderPaneId: currentPaneId,\s*\.\.\.hudRuntimeRoot,\s*\}\)\.env,\s*\.\.\.runtimeEnvOverlay,\s*\};\s*const hudEnvArgs = Object\.entries\(hudRuntimeEnv\)\.map\(\(\[key, value\]\) => `\$\{key\}=\$\{value\}`\)/,
-    );
-    assert.match(source, /if \(env\.OMX_TEAM_STATE_ROOT\?\.trim\(\)\) return 'team-env';\s*if \(env\.OMX_ROOT\?\.trim\(\) \|\| omxRootOverride\) return 'omx-root-env';\s*if \(env\.OMX_STATE_ROOT\?\.trim\(\)\) return 'omx-state-root-env';/);
-    assert.match(
-      source,
-      /buildTmuxPaneCommand\("env",\s*\[\.\.\.hudEnvArgs,\s*"node",\s*omxBin,\s*"hud",\s*"--watch"\]\)/,
-    );
-  });
-
-  it("runCodex registers a HUD resize hook immediately for inside-tmux launches", async () => {
-    const source = await readFile(join(repoRoot, 'src', 'cli', 'index.ts'), 'utf-8');
-    assert.match(
-      source,
-      /registerInsideTmuxHudResizeHook\(\{\s*hudPaneId,\s*currentPaneId,\s*cwd,\s*sessionId,\s*omxRootOverride,\s*baseEnv: runtimeHookEnv,\s*\}\)/,
+      /execFileSync\(process\.execPath, \[omxBin, "hud", "--reconcile-tmux"\], \{/,
     );
     assert.match(
       source,
-      /if \(currentPaneId\) \{\s*unregisterHudResizeHook\(currentPaneId\);\s*\}/,
+      /TMUX_PANE: leaderPaneId,\s*OMX_SESSION_ID: sessionId,\s*\[OMX_TMUX_HUD_OWNER_ENV\]: "1",\s*\[OMX_TMUX_HUD_LEADER_PANE_ENV\]: leaderPaneId/,
     );
   });
 
-  it("buildInsideTmuxHudHookEnv tags hook commands with session, owner, leader, and local root", () => {
-    const env = buildInsideTmuxHudHookEnv(
-      { PATH: "/bin" },
-      "sess-a",
-      "%leader",
-      "/repo",
-    );
-
-    assert.equal(env.PATH, "/bin");
-    assert.equal(env.OMX_SESSION_ID, "sess-a");
-    assert.equal(env.OMX_TMUX_HUD_OWNER, "1");
-    assert.equal(env.OMX_TMUX_HUD_LEADER_PANE, "%leader");
-    assert.equal(env.OMX_ROOT, "/repo");
-  });
-
-  it("registerInsideTmuxHudResizeHook forwards cwd and env to hook registration", () => {
-    const calls: Array<{
-      hudPaneId: string;
-      leaderPaneId: string | undefined;
-      heightLines: number;
-      cwd?: string;
-      env?: NodeJS.ProcessEnv;
-    }> = [];
-
-    const result = registerInsideTmuxHudResizeHook({
-      hudPaneId: "%hud",
-      currentPaneId: "%leader",
-      cwd: "/repo",
-      sessionId: "sess-a",
-      omxRootOverride: "/repo",
-      baseEnv: { PATH: "/bin" },
-      register: (hudPaneId, leaderPaneId, heightLines, options) => {
-        calls.push({ hudPaneId, leaderPaneId, heightLines, cwd: options?.cwd, env: options?.env });
-        return true;
-      },
-    });
-
-    assert.equal(result, true);
-    assert.deepEqual(calls, [{
-      hudPaneId: "%hud",
-      leaderPaneId: "%leader",
-      heightLines: HUD_TMUX_HEIGHT_LINES,
-      cwd: "/repo",
-      env: {
-        PATH: "/bin",
-        OMX_SESSION_ID: "sess-a",
-        OMX_TMUX_HUD_OWNER: "1",
-        OMX_TMUX_HUD_LEADER_PANE: "%leader",
-        OMX_ROOT: "/repo",
-      },
-    }]);
-    assert.equal(registerInsideTmuxHudResizeHook({
-      hudPaneId: null,
-      currentPaneId: "%leader",
-      cwd: "/repo",
-      sessionId: "sess-a",
-      register: () => {
-        throw new Error("should not register without a HUD pane");
-      },
-    }), false);
-  });
-
-  it("buildDetachedHudHookEnv preserves tmux targeting and local launcher identity", () => {
-    const env = buildDetachedHudHookEnv(
-      { PATH: "/bin" },
-      "sess-a",
-      "%leader",
-      "/tmp/tmux.sock,123,7",
-      "/repo/dist/cli/omx.js",
-      "/repo",
-    );
-
-    assert.equal(env.PATH, "/bin");
-    assert.equal(env.TMUX, "/tmp/tmux.sock,123,7");
-    assert.equal(env.TMUX_PANE, "%leader");
-    assert.equal(env.OMX_SESSION_ID, "sess-a");
-    assert.equal(env.OMX_TMUX_HUD_OWNER, "1");
-    assert.equal(env.OMX_ROOT, "/repo");
-    assert.equal(env.OMX_ENTRY_PATH, "/repo/dist/cli/omx.js");
-  });
-
-  it("registerDetachedHudLayoutReconcileHook reads TMUX from the detached leader pane before registering", () => {
-    const calls: Array<{
-      hudPaneId: string;
-      leaderPaneId: string | undefined;
-      heightLines: number;
-      cwd?: string;
-      env?: NodeJS.ProcessEnv;
-    }> = [];
-    const readTargets: string[] = [];
-
-    const result = registerDetachedHudLayoutReconcileHook({
-      hudPaneId: "%hud",
-      detachedLeaderPaneId: "%leader",
-      cwd: "/repo",
-      sessionId: "sess-a",
-      omxBin: "/repo/dist/cli/omx.js",
-      omxRootOverride: "/repo",
-      baseEnv: { PATH: "/bin" },
-      readTmuxEnvValue: (targetPaneId) => {
-        readTargets.push(targetPaneId);
-        return "/tmp/tmux.sock,123,7";
-      },
-      register: (hudPaneId, leaderPaneId, heightLines, options) => {
-        calls.push({ hudPaneId, leaderPaneId, heightLines, cwd: options?.cwd, env: options?.env });
-        return true;
-      },
-    });
-
-    assert.equal(result, true);
-    assert.deepEqual(readTargets, ["%leader"]);
-    assert.deepEqual(calls, [{
-      hudPaneId: "%hud",
-      leaderPaneId: "%leader",
-      heightLines: HUD_TMUX_HEIGHT_LINES,
-      cwd: "/repo",
-      env: {
-        PATH: "/bin",
-        TMUX: "/tmp/tmux.sock,123,7",
-        TMUX_PANE: "%leader",
-        OMX_SESSION_ID: "sess-a",
-        OMX_TMUX_HUD_OWNER: "1",
-        OMX_ROOT: "/repo",
-        OMX_ENTRY_PATH: "/repo/dist/cli/omx.js",
-      },
-    }]);
-    assert.equal(registerDetachedHudLayoutReconcileHook({
-      hudPaneId: "%hud",
-      detachedLeaderPaneId: "%leader",
-      cwd: "/repo",
-      sessionId: "sess-a",
-      omxBin: "/repo/dist/cli/omx.js",
-      readTmuxEnvValue: () => undefined,
-      register: () => {
-        throw new Error("should not register without TMUX");
-      },
-    }), false);
-  });
 
   it("buildDetachedSessionBootstrapSteps starts native Windows detached sessions with powershell", () => {
     const hudCmd = buildWindowsPromptCommand("node", [
@@ -4266,8 +4101,7 @@ exit 0
     );
     assert.equal(steps[0]?.name, "new-session");
     assert.equal(steps[0]?.args.at(-1), "powershell.exe");
-    assert.equal(steps[1]?.name, "split-and-capture-hud-pane");
-    assert.equal(steps[1]?.args.at(-1), hudCmd);
+    assert.equal(steps[1]?.name, "reconcile-managed-hud");
   });
 
   it("buildDetachedWindowsBootstrapScript targets the resolved tmux-compatible command", () => {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -4015,7 +4015,7 @@ exit 0
     const source = await readFile(join(repoRoot, "src", "cli", "index.ts"), "utf8");
     assert.match(
       source,
-      /if \(detachedLeaderPaneId\) \{\s*await reconcileManagedHudPane\(cwd, sessionId, detachedLeaderPaneId, hudRuntimeEnv\);\s*\}\s*const finalizeSteps = buildDetachedSessionFinalizeSteps/,
+      /if \(detachedLeaderPaneId && detachedHudEvidenceVerified\) \{\s*await reconcileManagedHudPane\(cwd, sessionId, detachedLeaderPaneId, hudRuntimeEnv\);\s*\}\s*const finalizeSteps = buildDetachedSessionFinalizeSteps/,
     );
   });
 

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3385,6 +3385,7 @@ describe("tmux HUD pane helpers", () => {
         "#{window_height}",
         "#{@omx_pane_instance_id}",
         "#{@omx_instance_id}",
+        "#{session_name}",
         "#{pane_start_command}",
         "#{pane_current_path}",
       ].join("\x1f"),
@@ -5210,9 +5211,9 @@ exit 0
       (step) => step.name === "reconcile-hud-resize",
     );
 
-    assert.match(registerHook?.args[4] ?? "", />\/dev\/null 2>&1 \|\| true/);
+    assert.match((registerHook?.args ?? []).join(" "), />\/dev\/null 2>&1 \|\| true/);
     assert.match(
-      registerHook?.args[4] ?? "",
+      (registerHook?.args ?? []).join(" "),
       new RegExp(`-y ${HUD_TMUX_HEIGHT_LINES}\\b`),
     );
     assert.match(schedule?.args[2] ?? "", />\/dev\/null 2>&1 \|\| true/);
@@ -5280,7 +5281,7 @@ exit 0
     );
   });
 
-  it("buildDetachedSessionRollbackSteps unregisters hooks before killing session", () => {
+  it("buildDetachedSessionRollbackSteps makes retained hook generations inert before killing session", () => {
     const steps = buildDetachedSessionRollbackSteps(
       "omx-demo",
       "omx-demo:0",
@@ -5295,13 +5296,9 @@ exit 0
         "kill-session",
       ],
     );
-    assert.equal(steps[0]?.args[0], "set-hook");
-    assert.equal(steps[0]?.args[1], "-u");
-    assert.equal(steps[0]?.args[2], "-t");
-    assert.equal(steps[0]?.args[3], "omx-demo:0");
-    assert.match(steps[0]?.args[4] ?? "", /^client-attached\[\d+\]$/);
-    assert.match(steps[1]?.args[4] ?? "", /^client-resized\[\d+\]$/);
-    assert.doesNotMatch(steps[1]?.args.join(" ") ?? "", /window-resized/);
+    assert.equal(steps[0]?.args[0], "show-hooks");
+    assert.equal(steps[1]?.args[0], "show-hooks");
+    assert.doesNotMatch(steps.flatMap((step) => step.args).join(" "), /set-hook -u/);
     assert.deepEqual(steps[2]?.args, ["kill-session", "-t", "omx-demo"]);
   });
 

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3569,12 +3569,18 @@ describe("tmux HUD pane helpers", () => {
 
   it("createHudWatchPane splits from the emitting pane target when provided", () => {
     const calls: string[][] = [];
+    let taggedInstanceId = "";
     const paneId = createSharedHudWatchPane(
       "/repo",
       "node /repo/dist/cli/omx.js hud --watch",
       { heightLines: 3, targetPaneId: "%leader" },
       (args) => {
         calls.push(args);
+        if (args[0] === "set-option") {
+          taggedInstanceId = args[args.length - 1] ?? "";
+          return "";
+        }
+        if (args[0] === "show-option") return `${taggedInstanceId}\n`;
         return "%hud\n";
       },
     );

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3423,6 +3423,51 @@ esac
     }
   });
 
+  it("fails closed after a second birth write fails and exact compensation rejects a concurrent replacement", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-tmux-birth-compensation-"));
+    const bin = join(cwd, "bin");
+    const tmux = join(bin, "tmux");
+    const log = join(cwd, "tmux.log");
+    const replacement = join(cwd, "replacement");
+    const previousPath = process.env.PATH;
+    try {
+      await mkdir(bin, { recursive: true });
+      await writeFile(tmux, `#!/bin/sh
+printf '%s\\n' "$*" >> "${log}"
+case "$1" in
+  display-message) printf 'leader\\t$1\\t@1\\t%%1\\n' ;;
+  show-option|show-options) ;;
+  if-shell)
+    case "$*" in
+      *__omx_birth_established_*) : > "${replacement}"; exit 99 ;;
+      *__omx_birth_compensation_*)
+        for arg in "$@"; do
+          case "$arg" in *__omx_birth_compensation_rejected_*) receipt="${'$'}{arg#*display-message -p }" ;; esac
+        done
+        printf '%s\\n' "$receipt"
+        ;;
+    esac
+    ;;
+esac
+`);
+      await chmod(tmux, 0o755);
+      process.env.PATH = `${bin}:${previousPath ?? ""}`;
+      await assert.rejects(
+        () => establishCurrentTmuxInstanceBinding("logical-session", "%1"),
+        /exact compensation was rejected/,
+      );
+      assert.equal(existsSync(replacement), true, "concurrent replacement must survive compensation");
+      const calls = await readFile(log, "utf-8");
+      assert.match(calls, /@omx_instance_id/);
+      assert.match(calls, /@omx_pane_instance_id/);
+      assert.doesNotMatch(calls, /logical-session.*set-option/);
+    } finally {
+      if (typeof previousPath === "string") process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("rejects mixed birth evidence without attempting to repair an uncertain pair", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-tmux-birth-partial-"));
     const bin = join(cwd, "bin");
@@ -5408,6 +5453,10 @@ exit 0
     assert.match(rollback.args[5]!, /kill-session -t 'omx-demo'/);
     assert.match(rollback.args[5]!, /__omx_detached_session_rollback_applied_/);
     assert.match(rollback.args[6]!, /__omx_detached_session_rollback_rejected_/);
+    assert.equal(typeof rollback.appliedReceipt, "string");
+    assert.equal(typeof rollback.rejectedReceipt, "string");
+    assert.match(rollback.appliedReceipt!, /^__omx_detached_session_rollback_applied_/);
+    assert.match(rollback.rejectedReceipt!, /^__omx_detached_session_rollback_rejected_/);
   });
 
   it("buildDetachedSessionRollbackSteps preserves uncertain sessions without an opaque birth", () => {
@@ -5419,6 +5468,15 @@ exit 0
       null,
     );
     assert.deepEqual(steps, []);
+  });
+
+  it("consumes detached rollback receipts before allowing fallback or recovery-record deletion", async () => {
+    const source = await readFile(join(repoRoot, "src", "cli", "index.ts"), "utf8");
+    assert.match(source, /rollbackApplied = receipt\.includes\(rollbackStep\.appliedReceipt\)/);
+    assert.match(source, /detached tmux rollback was rejected; preserving recovery state/);
+    assert.match(source, /detached tmux rollback returned no receipt; preserving recovery state/);
+    assert.match(source, /if \(!rollbackApplied\) \{\s*throw new TmuxLifecycleAuthorityError\("detached tmux rollback lacks applied evidence; preserving recovery state"\);\s*\}\s*}\s*if \(detachedParentEnvFilePath\)/);
+    assert.match(source, /err instanceof TmuxLifecycleAuthorityError\) \{\s*throw err;\s*}\s*logCliOperationFailure\(err\);[\s\S]*runCodexBlocking/);
   });
 });
 

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -4066,7 +4066,7 @@ exit 0
     const source = await readFile(join(repoRoot, "src", "cli", "index.ts"), "utf8");
     assert.match(
       source,
-      /if \(detachedLeaderPaneId\) \{\s*await reconcileManagedHudPane\(cwd, sessionId, detachedLeaderPaneId, hudRuntimeEnv\);\s*\}\s*const finalizeSteps = buildDetachedSessionFinalizeSteps/,
+      /if \(detachedLeaderPaneId && detachedHudEvidenceVerified\) \{\s*await reconcileManagedHudPane\(cwd, sessionId, detachedLeaderPaneId, hudRuntimeEnv\);\s*\}\s*const finalizeSteps = buildDetachedSessionFinalizeSteps/,
     );
   });
 

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -457,6 +457,8 @@ describe('omx launcher when tmux is available', () => {
         wd,
         (logPath) => `#!/bin/sh
 printf 'tmux:%s\n' "$*" >> "${logPath}"
+sessionMarker="${activeMarker}.tmux-instance"
+paneMarker="${activeMarker}.pane-instance"
 case "$1" in
   -V)
     printf 'tmux 3.4\n'
@@ -480,14 +482,14 @@ case "$1" in
     exit 0
     ;;
   display-message)
-    if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then
+    if [ "$2" = '-p' ] && { [ "$3" = '#{socket_path}' ] || [ "$5" = '#{socket_path}' ]; }; then
       printf '/tmp/tmux-test.sock\n'
-    elif [ "$2" = '-p' ] && [ "$5" = '#{session_name}' ]; then
+    elif [ "$5" = '#{session_name}' ]; then
       cat "${activeMarker}"
-    elif [ "$2" = '-p' ] && [ "$5" = '#{session_attached}' ]; then
+    elif [ "$5" = '#{session_attached}' ]; then
       printf '1\n'
     else
-      printf '0\n'
+      printf '%s\t$0\t@1\t%%12\n' "$(cat "${activeMarker}")"
     fi
     exit 0
     ;;
@@ -499,9 +501,18 @@ case "$1" in
     printf 'off\n'
     exit 0
     ;;
+  show-option)
+    if [ "$6" = '@omx_pane_instance_id' ]; then
+      cat "${instanceMarker}"
+      exit 0
+    fi
+    exit 1
+    ;;
   set-option)
     if [ "$4" = '@omx_instance_id' ]; then
       printf '%s\n' "$5" > "${instanceMarker}"
+    elif [ "$5" = '@omx_pane_instance_id' ]; then
+      printf '%s\n' "$6" > "\${paneMarker}"
     fi
     exit 0
     ;;
@@ -560,6 +571,8 @@ exit 0
         wd,
         (logPath) => `#!/bin/sh
 printf 'tmux:%s\n' "$*" >> "${logPath}"
+sessionMarker="${instanceMarker}.session"
+paneMarker="${instanceMarker}.pane"
 case "$1" in
   -V)
     printf 'tmux 3.4\n'
@@ -569,6 +582,11 @@ case "$1" in
     exit 1
     ;;
   new-session)
+    prev=''
+    for arg in "$@"; do
+      if [ "$prev" = '-s' ]; then printf '%s\n' "$arg" > "$sessionMarker"; fi
+      prev="$arg"
+    done
     printf '%%77\n'
     exit 0
     ;;
@@ -577,14 +595,18 @@ case "$1" in
     exit 0
     ;;
   display-message)
-    if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then
+    if [ "$2" = '-p' ] && { [ "$3" = '#{socket_path}' ] || [ "$5" = '#{socket_path}' ]; }; then
       printf '/tmp/tmux-test.sock\n'
+    elif [ "$2" = '-p' ] && [ "$3" = '-t' ] && [ "$4" = '%77' ] && [ "$5" = '#{session_name}\t#{session_id}\t#{window_id}\t#{pane_id}' ]; then
+      printf '%s\t$0\t@1\t%%77\n' "$(cat "$sessionMarker")"
     elif [ "$2" = '-p' ] && [ "$5" = '#{session_name}' ]; then
-      printf 'detached-session\n'
+      cat "$sessionMarker"
     elif [ "$2" = '-p' ] && [ "$5" = '#{session_attached}' ]; then
       printf '1\n'
+    elif [ "$2" = '-p' ] && [ "$5" = '#{session_name}:#{window_index} #{pane_id}' ]; then
+      printf '%s:0 %%77\n' "$(cat "$sessionMarker")"
     else
-      printf '0\n'
+      printf '%s\t$0\t@1\t%%77\n' "$(cat "$sessionMarker")"
     fi
     exit 0
     ;;
@@ -596,9 +618,18 @@ case "$1" in
     printf 'off\n'
     exit 0
     ;;
+  show-option)
+    if [ "$6" = '@omx_pane_instance_id' ] && [ -f "${instanceMarker}" ]; then
+      cat "${instanceMarker}"
+      exit 0
+    fi
+    exit 1
+    ;;
   set-option)
     if [ "$4" = '@omx_instance_id' ]; then
       printf '%s\n' "$5" > "${instanceMarker}"
+    elif [ "$5" = '@omx_pane_instance_id' ]; then
+      printf '%s\n' "$6" > "\${paneMarker}"
     fi
     exit 0
     ;;
@@ -734,14 +765,38 @@ exit 0
         wd,
         (logPath) => `#!/bin/sh
 printf 'tmux:%s\n' "$*" >> "${logPath}"
+sessionMarker="${logPath}.session"
+instanceMarker="${logPath}.instance"
+paneMarker="${logPath}.pane"
 case "$1" in
   -V) printf 'tmux 3.4\n'; exit 0 ;;
   has-session) exit 1 ;;
-  new-session) printf '%%12\n'; exit 0 ;;
+  new-session)
+    prev=''
+    for arg in "$@"; do
+      if [ "$prev" = '-s' ]; then printf '%s\n' "$arg" > "$sessionMarker"; fi
+      prev="$arg"
+    done
+    printf '%%12\n'
+    exit 0 ;;
   split-window) printf 'hud-pane\n'; exit 0 ;;
-  display-message) if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then printf '/tmp/tmux-test.sock\n'; else printf '0\n'; fi; exit 0 ;;
-  show-options) printf 'off\n'; exit 0 ;;
-  set-option|set-hook|attach-session|kill-session|run-shell|resize-pane) exit 0 ;;
+  display-message)
+    if [ "$2" = '-p' ] && { [ "$3" = '#{socket_path}' ] || [ "$5" = '#{socket_path}' ]; }; then printf '/tmp/tmux-test.sock\n';
+    elif [ "$2" = '-p' ] && [ "$3" = '-t' ] && [ "$4" = '%12' ] && [ "$5" = '#{session_name}\t#{session_id}\t#{window_id}\t#{pane_id}' ]; then printf '%s\t$0\t@1\t%%12\n' "$(cat "$sessionMarker")";
+    elif [ "$2" = '-p' ] && [ "$5" = '#{session_name}:#{window_index} #{pane_id}' ]; then printf '%s:0 %%12\n' "$(cat "$sessionMarker")";
+    else printf '0\n'; fi
+    exit 0 ;;
+  show-options)
+    if [ "$5" = '@omx_instance_id' ] && [ -f "\${instanceMarker}" ]; then cat "\${instanceMarker}"; else printf 'off\n'; fi
+    exit 0 ;;
+  show-option)
+    if [ "$6" = '@omx_pane_instance_id' ] && [ -f "\${instanceMarker}" ]; then cat "\${instanceMarker}"; else exit 1; fi
+    exit 0 ;;
+  set-option)
+    if [ "$4" = '@omx_instance_id' ]; then printf '%s\n' "$5" > "\${instanceMarker}";
+    elif [ "$5" = '@omx_pane_instance_id' ]; then printf '%s\n' "$6" > "\${paneMarker}"; fi
+    exit 0 ;;
+  set-hook|attach-session|kill-session|run-shell|resize-pane) exit 0 ;;
 esac
 exit 0
 `,
@@ -796,14 +851,37 @@ exit 0
         wd,
         (logPath) => `#!/bin/sh
 printf 'tmux:%s\n' "$*" >> "${logPath}"
+sessionMarker="${logPath}.session"
+instanceMarker="${logPath}.instance"
+paneMarker="${logPath}.pane"
 case "$1" in
   -V) printf 'tmux 3.4\n'; exit 0 ;;
   has-session) exit 1 ;;
-  new-session) printf '%%12\n'; exit 0 ;;
+  new-session)
+    prev=''
+    for arg in "$@"; do
+      if [ "$prev" = '-s' ]; then printf '%s\n' "$arg" > "$sessionMarker"; fi
+      prev="$arg"
+    done
+    printf '%%12\n'
+    exit 0 ;;
   split-window) printf 'hud-pane\n'; exit 0 ;;
-  display-message) if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then printf '/tmp/tmux-test.sock\n'; else printf '0\n'; fi; exit 0 ;;
-  show-options) printf 'off\n'; exit 0 ;;
-  set-option|set-hook|attach-session|kill-session|run-shell|resize-pane) exit 0 ;;
+  display-message)
+    if [ "$2" = '-p' ] && { [ "$3" = '#{socket_path}' ] || [ "$5" = '#{socket_path}' ]; }; then printf '/tmp/tmux-test.sock\n';
+    elif [ "$2" = '-p' ] && [ "$3" = '-t' ] && [ "$4" = '%12' ] && [ "$5" = '#{session_name}\t#{session_id}\t#{window_id}\t#{pane_id}' ]; then printf '%s\t$0\t@1\t%%12\n' "$(cat "$sessionMarker")";
+    else printf '%s\t$0\t@1\t%%12\n' "$(cat "$sessionMarker")"; fi
+    exit 0 ;;
+  show-options)
+    if [ "$5" = '@omx_instance_id' ] && [ -f "$instanceMarker" ]; then cat "$instanceMarker"; else printf 'off\n'; fi
+    exit 0 ;;
+  show-option)
+    if [ "$6" = '@omx_pane_instance_id' ] && [ -f "$instanceMarker" ]; then cat "$instanceMarker"; else exit 1; fi
+    exit 0 ;;
+  set-option)
+    if [ "$4" = '@omx_instance_id' ]; then printf '%s\n' "$5" > "$instanceMarker";
+    elif [ "$5" = '@omx_pane_instance_id' ]; then printf '%s\n' "$6" > "$paneMarker"; fi
+    exit 0 ;;
+  set-hook|attach-session|kill-session|run-shell|resize-pane) exit 0 ;;
 esac
 exit 0
 `,

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -437,7 +437,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       assert.match(tmuxLog, /tmux:new-session /);
-      assert.match(tmuxLog, /tmux:split-window /);
+      assert.doesNotMatch(tmuxLog, /tmux:split-window /);
       assert.doesNotMatch(tmuxLog, /tmux:attach-session/);
       assert.doesNotMatch(result.stderr, /failed to attach detached tmux session/);
     } finally {
@@ -911,7 +911,7 @@ exit 0
         tmuxLog,
         /tmux:set-hook -t .* client-detached\[[0-9]+\] if-shell -F '#\{==:#\{session_attached\},0\}' 'run-shell -b "tmux clear-history -t %12 >\/dev\/null 2>&1 \|\| true"'/,
       );
-      assert.match(tmuxLog, new RegExp(`tmux:split-window -v -l ${HUD_TMUX_HEIGHT_LINES} .* -t `));
+      assert.doesNotMatch(tmuxLog, /tmux:split-window /);
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -1208,7 +1208,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
-      assert.match(tmuxLog, new RegExp(`tmux:split-window -v -l ${HUD_TMUX_HEIGHT_LINES}`));
+      assert.doesNotMatch(tmuxLog, /tmux:split-window /);
       assert.match(tmuxLog, /tmux:set-option -t managed-session mouse on/);
       assert.match(tmuxLog, /tmux:set-option -sq extended-keys always/);
     } finally {

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -119,6 +119,107 @@ async function createLaunchFixture(
   };
 }
 
+// Faithful detached-launch tmux stub: new-session returns a pane and records the
+// session name; display-message returns a stable session/window/pane context;
+// set/show-option persist and read exact session/pane births; if-shell executes
+// the applied/rejected branch (publishing births or killing the session) and
+// echoes the trailing applied receipt; kill-session logs its exact target.
+function fullBirthDetachedTmuxStub(
+  logPath: string,
+  attachMode: 'fail' | 'noop',
+): string {
+  const attachBranch = attachMode === 'fail'
+    ? `    printf 'error connecting to /tmp/tmux-1000/default (Operation not permitted)\\n' >&2\n    exit 1`
+    : `    exit 0`;
+  return `#!/bin/sh
+printf 'tmux:%s\\n' "$*" >> "${logPath}"
+nameMarker="${logPath}.session-name"
+instMarker="${logPath}.session-instance"
+paneMarker="${logPath}.pane-instance"
+case "$1" in
+  -V|list-sessions)
+    printf 'tmux 3.4\\n'
+    exit 0
+    ;;
+  has-session)
+    exit 0
+    ;;
+  new-session)
+    prev=''
+    for a in "$@"; do
+      if [ "$prev" = '-s' ]; then printf '%s\\n' "$a" > "$nameMarker"; fi
+      prev="$a"
+    done
+    printf '%%12\\n'
+    exit 0
+    ;;
+  split-window)
+    printf 'hud-pane\\n'
+    exit 0
+    ;;
+  display-message)
+    for a in "$@"; do
+      case "$a" in
+        '#{socket_path}') printf '/tmp/tmux-test.sock\\n'; exit 0 ;;
+        '#{session_attached}') printf '0\\n'; exit 0 ;;
+      esac
+    done
+    last=''
+    for a in "$@"; do last="$a"; done
+    sname=$(cat "$nameMarker" 2>/dev/null || printf 'detached-session')
+    case "$last" in
+      '#{session_name}') printf '%s\\n' "$sname"; exit 0 ;;
+      *) printf '%s\\tdetached-sid\\t@1\\t%%12\\n' "$sname"; exit 0 ;;
+    esac
+    ;;
+  show-options|show-option)
+    for a in "$@"; do
+      case "$a" in
+        @omx_instance_id) cat "$instMarker" 2>/dev/null || true; exit 0 ;;
+        @omx_pane_instance_id) cat "$paneMarker" 2>/dev/null || true; exit 0 ;;
+      esac
+    done
+    printf 'off\\n'
+    exit 0
+    ;;
+  set-option)
+    prev=''
+    for a in "$@"; do
+      if [ "$prev" = '@omx_instance_id' ]; then printf '%s\\n' "$a" > "$instMarker"; fi
+      if [ "$prev" = '@omx_pane_instance_id' ]; then printf '%s\\n' "$a" > "$paneMarker"; fi
+      prev="$a"
+    done
+    exit 0
+    ;;
+  if-shell)
+    true_cmd="$6"
+    binst=$(printf '%s' "$true_cmd" | sed -n "s/.* @omx_instance_id '\\([^']*\\)'.*/\\1/p")
+    bpane=$(printf '%s' "$true_cmd" | sed -n "s/.*@omx_pane_instance_id '\\([^']*\\)'.*/\\1/p")
+    if [ -n "$binst" ]; then printf '%s\\n' "$binst" > "$instMarker"; fi
+    if [ -n "$bpane" ]; then printf '%s\\n' "$bpane" > "$paneMarker"; fi
+    case "$true_cmd" in
+      kill-session*)
+        ktarget=$(printf '%s' "$true_cmd" | sed -n "s/^kill-session -t '\\([^']*\\)'.*/\\1/p")
+        printf 'tmux:kill-session -t %s\\n' "$ktarget" >> "${logPath}"
+        ;;
+    esac
+    printf '%s' "$true_cmd" | awk '{print $NF}'
+    exit 0
+    ;;
+  kill-session)
+    exit 0
+    ;;
+  attach-session)
+${attachBranch}
+    ;;
+  set-hook|run-shell|resize-pane|select-pane|kill-pane)
+    exit 0
+    ;;
+esac
+exit 0
+`;
+}
+
 describe('omx launch fallback when tmux is unavailable', () => {
   it('surfaces direct Codex startup stderr and preserves the child exit code', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-child-error-'));
@@ -493,27 +594,32 @@ case "$1" in
     fi
     exit 0
     ;;
-  show-options)
-    if [ "$5" = '@omx_instance_id' ]; then
-      cat "${instanceMarker}"
-      exit 0
-    fi
+  show-options|show-option)
+    for a in "$@"; do
+      case "$a" in
+        @omx_instance_id) cat "${instanceMarker}" 2>/dev/null || true; exit 0 ;;
+        @omx_pane_instance_id) cat "\${paneMarker}" 2>/dev/null || true; exit 0 ;;
+      esac
+    done
     printf 'off\n'
     exit 0
     ;;
-  show-option)
-    if [ "$6" = '@omx_pane_instance_id' ]; then
-      cat "${instanceMarker}"
-      exit 0
-    fi
-    exit 1
-    ;;
   set-option)
-    if [ "$4" = '@omx_instance_id' ]; then
-      printf '%s\n' "$5" > "${instanceMarker}"
-    elif [ "$5" = '@omx_pane_instance_id' ]; then
-      printf '%s\n' "$6" > "\${paneMarker}"
-    fi
+    prev=''
+    for a in "$@"; do
+      if [ "$prev" = '@omx_instance_id' ]; then printf '%s\n' "$a" > "${instanceMarker}"; fi
+      if [ "$prev" = '@omx_pane_instance_id' ]; then printf '%s\n' "$a" > "\${paneMarker}"; fi
+      prev="$a"
+    done
+    exit 0
+    ;;
+  if-shell)
+    publish="$6"
+    binst=$(printf '%s' "$publish" | sed -n "s/.* @omx_instance_id '\\([^']*\\)'.*/\\1/p")
+    bpane=$(printf '%s' "$publish" | sed -n "s/.*@omx_pane_instance_id '\\([^']*\\)'.*/\\1/p")
+    if [ -n "$binst" ]; then printf '%s\n' "$binst" > "${instanceMarker}"; fi
+    if [ -n "$bpane" ]; then printf '%s\n' "$bpane" > "\${paneMarker}"; fi
+    printf '%s' "$publish" | awk '{print $NF}'
     exit 0
     ;;
   set-hook|attach-session|kill-session|run-shell|resize-pane)
@@ -1466,45 +1572,7 @@ exit 1
       await chmod(fakeCodexPath, 0o755);
       await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
       await chmod(fakePsPath, 0o755);
-      await writeFile(
-        fakeTmuxPath,
-        `#!/bin/sh
-printf 'tmux:%s\n' "$*" >> "${tmuxLogPath}"
-case "$1" in
-  -V|list-sessions)
-    exit 0
-    ;;
-  new-session)
-    printf 'leader-pane\n'
-    exit 0
-    ;;
-  split-window)
-    printf 'hud-pane\n'
-    exit 0
-    ;;
-  display-message)
-    if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then
-      printf '/tmp/tmux-test.sock\n'
-    else
-      printf '0\n'
-    fi
-    exit 0
-    ;;
-  show-options)
-    printf 'off\n'
-    exit 0
-    ;;
-  attach-session)
-    printf 'error connecting to /tmp/tmux-1000/default (Operation not permitted)\n' >&2
-    exit 1
-    ;;
-  set-option|set-hook|kill-session|run-shell|resize-pane|select-pane)
-    exit 0
-    ;;
-esac
-exit 0
-`,
-      );
+      await writeFile(fakeTmuxPath, fullBirthDetachedTmuxStub(tmuxLogPath, 'fail'));
       await chmod(fakeTmuxPath, 0o755);
 
       const result = runOmx(
@@ -1528,6 +1596,11 @@ exit 0
       assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
       assert.match(tmuxLog, /tmux:attach-session -t /);
       assert.match(tmuxLog, /tmux:kill-session -t /);
+      const birthIdx = tmuxLog.indexOf('__omx_birth_established_');
+      const killIdx = tmuxLog.indexOf('tmux:kill-session -t ');
+      assert.ok(birthIdx >= 0, 'birth publication receipt must be present');
+      assert.ok(killIdx >= 0, 'destructive rollback kill-session must be present');
+      assert.ok(birthIdx < killIdx, 'applied birth receipt must precede destructive rollback');
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -1538,38 +1611,7 @@ exit 0
     try {
       const { env, tmuxLogPath } = await createLaunchFixture(
         wd,
-        (tmuxLogPath) => `#!/bin/sh
-printf 'tmux:%s\n' "$*" >> "${tmuxLogPath}"
-case "$1" in
-  -V|list-sessions)
-    exit 0
-    ;;
-  new-session)
-    printf 'leader-pane\n'
-    exit 0
-    ;;
-  split-window)
-    printf 'hud-pane\n'
-    exit 0
-    ;;
-  display-message)
-    if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then
-      printf '/tmp/tmux-test.sock\n'
-    else
-      printf '0\n'
-    fi
-    exit 0
-    ;;
-  show-options)
-    printf 'off\n'
-    exit 0
-    ;;
-  set-option|set-hook|attach-session|kill-session|run-shell|resize-pane|select-pane)
-    exit 0
-    ;;
-esac
-exit 0
-`,
+        (tmuxLogPath) => fullBirthDetachedTmuxStub(tmuxLogPath, 'noop'),
       );
 
       const result = runOmx(

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -902,6 +902,7 @@ exit 0
       if (shouldSkipForSpawnPermissions(result.error)) return;
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.doesNotMatch(tmuxLog, /^tmux:\s*$/m, "detached bootstrap must not invoke bare tmux");
       assert.doesNotMatch(tmuxLog, /tmux:show-options -gv history-limit/);
       assert.doesNotMatch(tmuxLog, /tmux:set-option -g[q ]+history-limit/);
       assert.match(tmuxLog, /tmux:new-session .* -s /);

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -437,7 +437,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       assert.match(tmuxLog, /tmux:new-session /);
-      assert.match(tmuxLog, /tmux:split-window /);
+      assert.doesNotMatch(tmuxLog, /tmux:split-window /);
       assert.doesNotMatch(tmuxLog, /tmux:attach-session/);
       assert.doesNotMatch(result.stderr, /failed to attach detached tmux session/);
     } finally {
@@ -911,7 +911,7 @@ exit 0
         tmuxLog,
         /tmux:set-hook -t .* client-detached\[[0-9]+\] if-shell -F '#\{==:#\{session_attached\},0\}' 'run-shell -b "tmux clear-history -t %12 >\/dev\/null 2>&1 \|\| true"'/,
       );
-      assert.match(tmuxLog, new RegExp(`tmux:split-window -v -l ${HUD_TMUX_HEIGHT_LINES} .* -t `));
+      assert.doesNotMatch(tmuxLog, /tmux:split-window /);
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -1162,7 +1162,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
-      assert.match(tmuxLog, new RegExp(`tmux:split-window -v -l ${HUD_TMUX_HEIGHT_LINES}`));
+      assert.doesNotMatch(tmuxLog, /tmux:split-window /);
       assert.match(tmuxLog, /tmux:set-option -t managed-session mouse on/);
       assert.match(tmuxLog, /tmux:set-option -sq extended-keys always/);
     } finally {

--- a/src/cli/__tests__/native-hook-claim-journal.test.ts
+++ b/src/cli/__tests__/native-hook-claim-journal.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { test } from "node:test";
 import {
 	clearNativeHookClaimJournal,
+	isUnsupportedDirectorySyncError,
 	persistNativeHookClaimJournal,
 	recoverNativeHookClaimJournal,
 } from "../native-hook-claim-journal.js";
@@ -15,6 +16,18 @@ async function markJournalOwnerDead(root: string): Promise<void> {
 	journal.ownerPid = 2_147_483_647;
 	await writeFile(path, `${JSON.stringify(journal, null, 2)}\n`, "utf-8");
 }
+
+test("directory sync tolerance accepts only documented unsupported errors", () => {
+	for (const code of ["EPERM", "EINVAL", "ENOTSUP", "EOPNOTSUPP"]) {
+		assert.equal(isUnsupportedDirectorySyncError({ code }), true, code);
+	}
+});
+
+test("directory sync tolerance rejects genuine failures", () => {
+	for (const error of [{ code: "EACCES" }, { code: "EIO" }, { code: "ENOENT" }, new Error("EPERM"), null]) {
+		assert.equal(isUnsupportedDirectorySyncError(error), false);
+	}
+});
 
 test("claim journal restores an exact original after rename-away interruption", async () => {
 	const root = await mkdtemp(join(tmpdir(), "omx-claim-recovery-"));

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1431,7 +1431,7 @@ describe('teamCommand shutdown --force parsing', () => {
     assert.equal(force, true);
   });
 
-  it('persists cancelled team mode state on shutdown even when no team mode state existed beforehand', async () => {
+  it('does not publish cancelled mode state when shutdown remains incomplete', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-shutdown-mode-state-'));
     const previousCwd = process.cwd();
     const originalLog = console.log;
@@ -1457,18 +1457,11 @@ describe('teamCommand shutdown --force parsing', () => {
       console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
       console.warn = (...args: unknown[]) => warns.push(args.map(String).join(' '));
 
-      await teamCommand(['shutdown', 'team-shutdown-mode-state', '--force']);
+      await assert.rejects(teamCommand(['shutdown', 'team-shutdown-mode-state', '--force']), /Team shutdown incomplete/);
 
       const state = await readModeState('team', wd);
-      assert.ok(state);
-      assert.equal(state?.active, false);
-      assert.equal(state?.current_phase, 'cancelled');
-      assert.equal(state?.team_name, 'team-shutdown-mode-state');
-      assert.ok(warns.every((line) => !line.includes('Team shutdown incomplete')));
-      assert.ok(
-        logs.some((line) =>
-          line.includes('Team shutdown complete: team-shutdown-mode-state')),
-      );
+      assert.equal(state, null);
+      assert.equal(logs.some((line) => line.includes('Team shutdown complete')), false);
     } finally {
       console.log = originalLog;
       console.warn = originalWarn;
@@ -1477,7 +1470,7 @@ describe('teamCommand shutdown --force parsing', () => {
     }
   });
 
-  it('persists cancelled session-scoped team mode state on shutdown', async () => {
+  it('preserves session-scoped team mode state on incomplete shutdown', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-shutdown-session-mode-state-'));
     const previousCwd = process.cwd();
     const teamName = 'team-shutdown-scoped';
@@ -1509,15 +1502,14 @@ describe('teamCommand shutdown --force parsing', () => {
         wd,
       );
 
-      await teamCommand(['shutdown', teamName, '--force']);
+      await assert.rejects(teamCommand(['shutdown', teamName, '--force']), /Team shutdown incomplete/);
 
       const scopedState = JSON.parse(
         await readFile(join(scopedStateDir, 'team-state.json'), 'utf-8'),
       ) as Record<string, unknown>;
-      assert.equal(scopedState.active, false);
-      assert.equal(scopedState.current_phase, 'cancelled');
+      assert.equal(scopedState.active, true);
+      assert.equal(scopedState.current_phase, 'team-exec');
       assert.equal(scopedState.team_name, teamName);
-      assert.ok(typeof scopedState.completed_at === 'string' && scopedState.completed_at.length > 0);
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
@@ -1556,14 +1548,14 @@ describe('teamCommand shutdown --force parsing', () => {
         wd,
       );
 
-      await teamCommand(['shutdown', teamName, '--force']);
+      await assert.rejects(teamCommand(['shutdown', teamName, '--force']), /Team shutdown incomplete/);
 
       assert.equal(existsSync(scopedStatePath), false);
       const rootState = JSON.parse(
         await readFile(join(stateDir, 'team-state.json'), 'utf-8'),
       ) as Record<string, unknown>;
-      assert.equal(rootState.active, false);
-      assert.equal(rootState.current_phase, 'cancelled');
+      assert.equal(rootState.active, true);
+      assert.equal(rootState.current_phase, 'team-exec');
       assert.equal(rootState.team_name, teamName);
     } finally {
       process.chdir(previousCwd);
@@ -1608,14 +1600,14 @@ describe('teamCommand shutdown --force parsing', () => {
         wd,
       );
 
-      await teamCommand(['shutdown', teamName, '--force']);
+      await assert.rejects(teamCommand(['shutdown', teamName, '--force']), /Team shutdown incomplete/);
 
       assert.equal(existsSync(scopedStatePath), false);
       const rootState = JSON.parse(
         await readFile(join(stateDir, 'team-state.json'), 'utf-8'),
       ) as Record<string, unknown>;
-      assert.equal(rootState.active, false);
-      assert.equal(rootState.current_phase, 'cancelled');
+      assert.equal(rootState.active, true);
+      assert.equal(rootState.current_phase, 'team-exec');
       assert.equal(rootState.team_name, teamName);
     } finally {
       process.chdir(previousCwd);
@@ -1629,7 +1621,7 @@ describe('teamCommand shutdown --force parsing', () => {
     assert.equal(confirmIssues, true);
   });
 
-  it('keeps the shutdown CLI alive while tearing down a shared leader tmux session', async () => {
+  it('fails closed while preserving an uncertain shared leader tmux session', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-shutdown-shared-cli-'));
     const binDir = join(wd, 'bin');
     const tmuxLogPath = join(wd, 'tmux.log');
@@ -1722,8 +1714,9 @@ esac
       });
 
       assert.equal(result.signal, null, `shutdown CLI received signal ${result.signal ?? 'none'}\n${result.stderr}`);
-      assert.equal(result.code, 0, `shutdown CLI exit=${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
-      assert.match(result.stdout, /Team shutdown complete: shared-shutdown-cli/);
+      assert.equal(result.code, 1, `shutdown CLI exit=${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+      assert.doesNotMatch(result.stdout, /Team shutdown complete: shared-shutdown-cli/);
+      assert.match(result.stderr, /Team shutdown incomplete/);
       assert.equal(existsSync(join(wd, '.omx', 'state', 'team', 'shared-shutdown-cli')), true);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1464,7 +1464,7 @@ describe('teamCommand shutdown --force parsing', () => {
       assert.equal(state?.active, false);
       assert.equal(state?.current_phase, 'cancelled');
       assert.equal(state?.team_name, 'team-shutdown-mode-state');
-      assert.equal(warns.length, 0);
+      assert.ok(warns.every((line) => !line.includes('Team shutdown incomplete')));
       assert.ok(
         logs.some((line) =>
           line.includes('Team shutdown complete: team-shutdown-mode-state')),
@@ -1740,7 +1740,7 @@ esac
     }
   });
 
-  it('keeps the shutdown command alive when executed inside the leader pane PTY', { concurrency: false }, async (t) => {
+  it('fails closed inside the leader pane PTY when exact teardown remains incomplete', { concurrency: false }, async (t) => {
     skipUnlessTmux(t);
 
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-shutdown-shared-in-pane-'));
@@ -1777,13 +1777,11 @@ esac
         });
 
         assert.equal(result.signal, null, `shutdown CLI received signal ${result.signal ?? 'none'}\n${result.stderr}`);
-        assert.equal(result.code, 0, `shutdown CLI exit=${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
-        const stdout = result.stdout;
-        assert.match(stdout, new RegExp(`Team shutdown complete: ${teamName}`));
-        // Shared-session shutdown retains the leader pane but has no standalone
-        // lifecycle retry surface, so it clears stale Team metadata.
-        assert.equal(existsSync(join(teamStateRoot, 'team', teamName)), false);
-        assert.equal(await readTeamConfig(teamName, wd), null);
+        assert.equal(result.code, 1, `shutdown CLI exit=${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+        assert.doesNotMatch(result.stdout, new RegExp(`Team shutdown complete: ${teamName}`));
+        assert.match(result.stderr, /Team shutdown incomplete/);
+        assert.equal(existsSync(join(teamStateRoot, 'team', teamName)), true);
+        assert.ok(await readTeamConfig(teamName, wd));
         assert.equal(fixturePaneExists(fixture, fixture.leaderPaneId), true, 'leader pane should remain alive');
       });
     } finally {

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1686,7 +1686,7 @@ esac
       assert.equal(existsSync(join(wd, '.omx', 'state', 'team', 'shared-shutdown-cli')), false);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.match(tmuxLog, /kill-pane -t %12/);
+      assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
       assert.match(tmuxLog, /kill-pane -t %13/);
       assert.match(tmuxLog, /kill-pane -t %14/);
       assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1687,8 +1687,10 @@ esac
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
-      assert.match(tmuxLog, /kill-pane -t %13/);
-      assert.match(tmuxLog, /kill-pane -t %14/);
+      // Owner tags without opaque pane/session births are not exact teardown
+      // authority. Shared-session shutdown preserves every uncertain pane.
+      assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
+      assert.doesNotMatch(tmuxLog, /kill-pane -t %14/);
       assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -12,7 +12,12 @@ import { buildLeaderMonitoringHints, parseTeamStartArgs, teamCommand } from '../
 import { readModeState } from '../../modes/base.js';
 import { readApprovedExecutionLaunchHint } from '../../planning/artifacts.js';
 import { buildRepoAwareTeamExecutionPlan } from '../../team/repo-aware-decomposition.js';
-import { DEFAULT_MAX_WORKERS } from '../../team/state.js';
+import {
+  DEFAULT_MAX_WORKERS,
+  createTeamLifecycleGeneration,
+  finalizeTeamLifecycleGeneration,
+  type TeamConfig,
+} from '../../team/state.js';
 import { shutdownTeam } from '../../team/runtime.js';
 import { sameFilePath } from '../../utils/paths.js';
 import {
@@ -37,6 +42,42 @@ const OMX_CLI_PATH = fileURLToPath(new URL('../omx.js', import.meta.url));
 const ORIGINAL_OMX_TEAM_WORKER = process.env.OMX_TEAM_WORKER;
 const ORIGINAL_OMX_TEAM_STATE_ROOT = process.env.OMX_TEAM_STATE_ROOT;
 
+
+async function persistUnverifiableShutdownLifecycle(config: TeamConfig, cwd: string): Promise<void> {
+  const token = `test-unverifiable-shutdown-${config.name}`;
+  const resources = [
+    ...(config.hud_pane_id ? [{ kind: 'hud' as const, id: config.hud_pane_id, role: 'hud' as const }] : []),
+    ...config.workers
+      .filter((worker) => /^%\d+$/.test(worker.pane_id ?? ''))
+      .map((worker) => ({ kind: 'worker' as const, id: worker.pane_id!, role: 'worker' as const })),
+  ].map((resource) => ({
+    ...resource,
+    created: true,
+    pane_birth: `unverifiable-birth-${resource.id}`,
+    command: `unverifiable-command-${resource.id}`,
+    acquired_at: new Date().toISOString(),
+  }));
+  assert.equal(await createTeamLifecycleGeneration({
+    version: 1,
+    token,
+    team_name: config.name,
+    canonical_session_id: `test-session-${config.name}`,
+    native_session_ids: [`test-session-${config.name}`],
+    tmux_session_name: null,
+    tmux_session_birth: null,
+    tmux_context: null,
+    team_pane_owner_id: config.tmux_pane_owner_id ?? `team:${config.name}`,
+    hook_generation: `test-hook-${config.name}`,
+    status: 'preparing',
+    created_at: new Date().toISOString(),
+    resources,
+  }, cwd), true);
+  assert.equal(await finalizeTeamLifecycleGeneration(config.name, token, 'active', cwd, {
+    tmux_session_name: config.tmux_session?.split(':')[0] ?? 'leader',
+    tmux_session_birth: `unverifiable-session-birth-${config.name}`,
+    tmux_context: config.tmux_session ?? 'leader:0',
+  }), true);
+}
 function encodeApprovedExecutionTask(task: string, quote: 'single' | 'double'): string {
   return quote === 'single'
     ? `'${task.replace(/'/g, "\\'")}'`
@@ -1683,7 +1724,7 @@ esac
       assert.equal(result.signal, null, `shutdown CLI received signal ${result.signal ?? 'none'}\n${result.stderr}`);
       assert.equal(result.code, 0, `shutdown CLI exit=${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
       assert.match(result.stdout, /Team shutdown complete: shared-shutdown-cli/);
-      assert.equal(existsSync(join(wd, '.omx', 'state', 'team', 'shared-shutdown-cli')), false);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'team', 'shared-shutdown-cli')), true);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
@@ -1721,6 +1762,7 @@ esac
         config.workers[0]!.pane_id = workerPaneOne;
         config.workers[1]!.pane_id = workerPaneTwo;
         await saveTeamConfig(config, wd);
+        await persistUnverifiableShutdownLifecycle(config, wd);
 
         const result = await runNodeCli(['team', 'shutdown', teamName, '--force'], {
           cwd: wd,
@@ -1738,12 +1780,11 @@ esac
         assert.equal(result.code, 0, `shutdown CLI exit=${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
         const stdout = result.stdout;
         assert.match(stdout, new RegExp(`Team shutdown complete: ${teamName}`));
+        // Shared-session shutdown retains the leader pane but has no standalone
+        // lifecycle retry surface, so it clears stale Team metadata.
         assert.equal(existsSync(join(teamStateRoot, 'team', teamName)), false);
+        assert.equal(await readTeamConfig(teamName, wd), null);
         assert.equal(fixturePaneExists(fixture, fixture.leaderPaneId), true, 'leader pane should remain alive');
-        // Exact HUD/worker-pane teardown is covered in runtime shutdown tests.
-        // This CLI test owns the stable operator contract: the command must not
-        // die by signal, it must exit 0, and explicit shutdown must remove team
-        // state while preserving leader survival in a real tmux client context.
       });
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -158,19 +158,9 @@ import { HUD_TMUX_HEIGHT_LINES, HUD_TMUX_MIN_LAUNCH_WINDOW_HEIGHT_LINES, isTmuxW
 import { OMX_TMUX_HUD_OWNER_ENV } from "../hud/reconcile.js";
 import { readUltragoalState } from "../hud/state.js";
 import {
-  createHudWatchPane as createSharedHudWatchPane,
-  killTmuxPane as killSharedTmuxPane,
-  listCurrentWindowHudPaneIds,
-  listCurrentWindowPanes,
   buildHudRuntimeEnv,
   parsePaneIdFromTmuxOutput,
-  reapDeadHudPanes,
-  registerHudResizeHook,
   OMX_TMUX_HUD_LEADER_PANE_ENV,
-  type RegisterHudResizeHookOptions,
-  readCurrentWindowSize,
-  resizeTmuxPane,
-  unregisterHudResizeHook,
 } from "../hud/tmux.js";
 
 export { parseTmuxPaneSnapshot, isHudWatchPane, findHudWatchPaneIds } from "../hud/tmux.js";
@@ -1416,119 +1406,6 @@ function execTmuxFileSync(
   }) as string;
 }
 
-function readTmuxEnvValueForTarget(targetPaneId: string): string | undefined {
-  if (!targetPaneId.startsWith("%")) return undefined;
-  try {
-    const raw = execTmuxFileSync(
-      ["display-message", "-p", "-t", targetPaneId, "#{socket_path},#{pid},#{session_id}"],
-      { encoding: "utf-8" },
-    ).trim();
-    return raw.replace(/,\$(\d+)$/, ",$1") || undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-type HudResizeHookRegistrar = (
-  hudPaneId: string,
-  leaderPaneId: string | undefined,
-  heightLines: number,
-  options?: RegisterHudResizeHookOptions,
-) => boolean;
-
-export function buildInsideTmuxHudHookEnv(
-  baseEnv: NodeJS.ProcessEnv,
-  sessionId: string,
-  currentPaneId: string | undefined,
-  omxRootOverride?: string,
-): NodeJS.ProcessEnv {
-  return {
-    ...baseEnv,
-    OMX_SESSION_ID: sessionId,
-    [OMX_TMUX_HUD_OWNER_ENV]: "1",
-    ...(currentPaneId ? { [OMX_TMUX_HUD_LEADER_PANE_ENV]: currentPaneId } : {}),
-    ...(omxRootOverride ? { OMX_ROOT: omxRootOverride } : {}),
-  };
-}
-
-export function registerInsideTmuxHudResizeHook(options: {
-  hudPaneId: string | null;
-  currentPaneId: string | undefined;
-  cwd: string;
-  sessionId: string;
-  omxRootOverride?: string;
-  baseEnv?: NodeJS.ProcessEnv;
-  register?: HudResizeHookRegistrar;
-}): boolean {
-  const { hudPaneId, currentPaneId } = options;
-  if (!hudPaneId || !currentPaneId) return false;
-  return (options.register ?? registerHudResizeHook)(
-    hudPaneId,
-    currentPaneId,
-    HUD_TMUX_HEIGHT_LINES,
-    {
-      cwd: options.cwd,
-      env: buildInsideTmuxHudHookEnv(
-        options.baseEnv ?? process.env,
-        options.sessionId,
-        currentPaneId,
-        options.omxRootOverride,
-      ),
-    },
-  );
-}
-
-export function buildDetachedHudHookEnv(
-  baseEnv: NodeJS.ProcessEnv,
-  sessionId: string,
-  detachedLeaderPaneId: string,
-  tmuxEnvValue: string,
-  omxBin: string,
-  omxRootOverride?: string,
-): NodeJS.ProcessEnv {
-  return {
-    ...baseEnv,
-    TMUX: tmuxEnvValue,
-    TMUX_PANE: detachedLeaderPaneId,
-    OMX_SESSION_ID: sessionId,
-    [OMX_TMUX_HUD_OWNER_ENV]: "1",
-    ...(omxRootOverride ? { OMX_ROOT: omxRootOverride } : {}),
-    OMX_ENTRY_PATH: omxBin,
-  };
-}
-
-export function registerDetachedHudLayoutReconcileHook(options: {
-  hudPaneId: string | null;
-  detachedLeaderPaneId: string | null;
-  cwd: string;
-  sessionId: string;
-  omxBin: string;
-  omxRootOverride?: string;
-  baseEnv?: NodeJS.ProcessEnv;
-  readTmuxEnvValue?: (targetPaneId: string) => string | undefined;
-  register?: HudResizeHookRegistrar;
-}): boolean {
-  const { hudPaneId, detachedLeaderPaneId } = options;
-  if (!hudPaneId || !detachedLeaderPaneId) return false;
-  const tmuxEnvValue = (options.readTmuxEnvValue ?? readTmuxEnvValueForTarget)(detachedLeaderPaneId);
-  if (!tmuxEnvValue) return false;
-  return (options.register ?? registerHudResizeHook)(
-    hudPaneId,
-    detachedLeaderPaneId,
-    HUD_TMUX_HEIGHT_LINES,
-    {
-      cwd: options.cwd,
-      env: buildDetachedHudHookEnv(
-        options.baseEnv ?? process.env,
-        options.sessionId,
-        detachedLeaderPaneId,
-        tmuxEnvValue,
-        options.omxBin,
-        options.omxRootOverride,
-      ),
-    },
-  );
-}
 
 export const DETACHED_TMUX_HISTORY_LIMIT = 500;
 const TMUX_HOOK_INDEX_MAX = 1_000_000;
@@ -3353,7 +3230,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
     const notifyTempContractRaw = notifyTempResult.contract.active
       ? serializeNotifyTempContract(notifyTempResult.contract)
       : null;
-    const launchResult = runCodex(
+    const launchResult = await runCodex(
       cwd,
       normalizedArgs,
       sessionId,
@@ -4401,7 +4278,7 @@ export function buildDetachedSessionBootstrapSteps(
   sessionName: string,
   cwd: string,
   codexCmd: string,
-  hudCmd: string,
+  _hudCmd: string,
   workerLaunchArgs: string | null,
   codexHomeOverride?: string,
   notifyTempContractRaw?: string | null,
@@ -4471,21 +4348,6 @@ export function buildDetachedSessionBootstrapSteps(
     ...(inheritedWorkerModel ? ["-e", `${TEAM_WORKER_INHERITED_MODEL_ENV}=${inheritedWorkerModel}`] : []),
     detachedLeaderCmd,
   ];
-  const splitCaptureArgs: string[] = [
-    "split-window",
-    "-v",
-    "-l",
-    String(HUD_TMUX_HEIGHT_LINES),
-    "-d",
-    "-t",
-    sessionName,
-    "-c",
-    cwd,
-    "-P",
-    "-F",
-    "#{pane_id}",
-    hudCmd,
-  ];
   return [
     { name: "new-session", args: newSessionArgs },
     ...(sessionId
@@ -4496,7 +4358,7 @@ export function buildDetachedSessionBootstrapSteps(
           },
         ]
       : []),
-    { name: "split-and-capture-hud-pane", args: splitCaptureArgs },
+    { name: "reconcile-managed-hud", args: [] },
   ];
 }
 
@@ -5147,7 +5009,20 @@ export async function preLaunch(
   }
 
   // 2. Establish the canonical pointer before any session-scoped launch artifact.
+  // Pointer validation must complete before attached-launch tmux metadata is mutated.
   await writeSessionStart(cwd, sessionId, await resolvePreLaunchSessionPointerOptions());
+
+  // Persist the exact binding only after the canonical pointer has committed. A
+  // managed attached launch must bind the persisted owner to the exact pane and
+  // session instance before a hook can reconcile its HUD.
+  tagCurrentTmuxSessionWithInstance(sessionId);
+  const tmuxBinding = await probeActualTmuxInstanceEvidence(process.env.TMUX_PANE);
+  if (tmuxEvidenceBindsCandidate(tmuxBinding, sessionId)) {
+    await writeSessionStart(cwd, sessionId, {
+      ...(tmuxBinding.sessionName ? { tmuxSessionName: tmuxBinding.sessionName } : {}),
+      ...(tmuxBinding.paneTarget ? { tmuxPaneId: tmuxBinding.paneTarget } : {}),
+    });
+  }
 
   // 3. Generate runtime overlay + write session-scoped model instructions file
   const orchestrationMode = await resolveSessionOrchestrationMode(
@@ -5167,9 +5042,8 @@ ${launchAppendix}${dirtyWorktreeGuidance}`
       : `${overlay}${dirtyWorktreeGuidance}`;
   await writeSessionModelInstructionsFile(cwd, sessionId, sessionInstructions);
 
-  // 4. Reset session metrics and tag the established session.
+  // 4. Reset session metrics.
   await resetSessionMetrics(cwd, sessionId);
-  tagCurrentTmuxSessionWithInstance(sessionId);
 
   // 5. Start notify fallback watcher (best effort)
   try {
@@ -5239,7 +5113,7 @@ ${launchAppendix}${dirtyWorktreeGuidance}`
  * runCodex: Launch Codex CLI (blocks until exit).
  * All 3 paths (new tmux, existing tmux, no tmux) block via execSync/execFileSync.
  */
-function runCodex(
+async function runCodex(
   cwd: string,
   args: string[],
   sessionId: string,
@@ -5251,7 +5125,7 @@ function runCodex(
   projectLocalCodexHomeForCleanup?: string,
   runtimeCodexHomeForCleanup?: string,
   runtimeContext?: MadmaxWorktreeRuntimeContext,
-): { postLaunchHandledExternally: boolean } {
+): Promise<{ postLaunchHandledExternally: boolean }> {
   const launchArgs = injectModelInstructionsBypassArgs(
     cwd,
     args,
@@ -5331,73 +5205,10 @@ function runCodex(
   }
 
   if (launchPolicy === "inside-tmux") {
-    // Already in tmux: launch codex in current pane, HUD in bottom split
-    const currentWindowPanes = currentPaneId ? listCurrentWindowPanes(undefined, currentPaneId) : [];
-    reapDeadHudPanes(currentWindowPanes, {
-      killPane: (paneId) => {
-        try {
-          return killSharedTmuxPane(paneId);
-        } catch (err) {
-          logCliOperationFailure(err);
-          return false;
-        }
-      },
-    });
-
-    const staleHudPaneIds = currentPaneId
-      ? listHudWatchPaneIdsInCurrentWindow(currentPaneId, { sessionId, leaderPaneId: currentPaneId })
-      : [];
-
-    let hudPaneId: string | null = null;
-    const [keeperHudPaneId, ...duplicateHudPaneIds] = staleHudPaneIds;
-    for (const paneId of duplicateHudPaneIds) {
-      killTmuxPane(paneId);
-    }
-
-    if (keeperHudPaneId) {
-      hudPaneId = keeperHudPaneId;
-      try {
-        resizeTmuxPane(hudPaneId, HUD_TMUX_HEIGHT_LINES);
-        registerInsideTmuxHudResizeHook({
-          hudPaneId,
-          currentPaneId,
-          cwd,
-          sessionId,
-          omxRootOverride,
-          baseEnv: runtimeHookEnv,
-        });
-      } catch (err) {
-        logCliOperationFailure(err);
-      }
-    } else if (
-      isExistingTmuxWindowTooCrampedForLaunchHud(
-        readCurrentWindowSize(undefined, currentPaneId).height,
-      )
-    ) {
-      // Existing tmux window is height-constrained: forcing a launch-time HUD
-      // split here would steal rows from the Codex TUI and make the
-      // transcript/input area unreadable. Skip the split at launch; the
-      // prompt-submit reconcile path can add the HUD later when there is room.
-      // (closes #2754)
-      hudPaneId = null;
-    } else {
-      try {
-        hudPaneId = createHudWatchPane(cwd, hudCmd, {
-          heightLines: HUD_TMUX_HEIGHT_LINES,
-          targetPaneId: currentPaneId,
-        });
-        registerInsideTmuxHudResizeHook({
-          hudPaneId,
-          currentPaneId,
-          cwd,
-          sessionId,
-          omxRootOverride,
-          baseEnv: runtimeHookEnv,
-        });
-      } catch (err) {
-        logCliOperationFailure(err);
-        // HUD split failed, continue without it
-      }
+    // The shared reconciler owns all managed HUD inspection, dedupe, resize, and
+    // creation. A failed or uncertain proof deliberately leaves panes untouched.
+    if (currentPaneId) {
+      await reconcileManagedHudPane(cwd, sessionId, currentPaneId, hudRuntimeEnv);
     }
 
     // Enable mouse scrolling at session start so scroll works before team
@@ -5419,32 +5230,9 @@ function runCodex(
       }
     }
 
-    const activePaneId = process.env.TMUX_PANE?.trim();
-    if (activePaneId) {
-      try {
-        execTmuxFileSync(["display-message", "-p", "-t", activePaneId, "#S"], {
-          encoding: "utf-8",
-        });
-      } catch {}
-    }
-
-    try {
-      withTmuxExtendedKeys(cwd, () => {
-        runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
-      });
-    } finally {
-      if (currentPaneId) {
-        unregisterHudResizeHook(currentPaneId);
-      }
-      const cleanupPaneIds = buildHudPaneCleanupTargets(
-        listHudWatchPaneIdsInCurrentWindow(currentPaneId, { sessionId, leaderPaneId: currentPaneId }),
-        hudPaneId,
-        currentPaneId,
-      );
-      for (const paneId of cleanupPaneIds) {
-        killTmuxPane(paneId);
-      }
-    }
+    withTmuxExtendedKeys(cwd, () => {
+      runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
+    });
     return { postLaunchHandledExternally: false };
   } else if (launchPolicy === "direct") {
     // Detached HUD sessions require tmux. Skip the bootstrap entirely when the
@@ -5458,7 +5246,7 @@ function runCodex(
       ? buildWindowsPromptCommand("codex", launchArgs)
       : null;
     const sessionName = buildDetachedTmuxSessionName(cwd, sessionId);
-    const launchDetachedSession = (): { postLaunchHandledExternally: boolean } => {
+    const launchDetachedSession = async (): Promise<{ postLaunchHandledExternally: boolean }> => {
       const contextKey = runtimeContext?.madmaxDetachedContext ?? process.env[OMX_MADMAX_DETACHED_CONTEXT_ENV]?.trim();
       const runsRoot = resolveMadmaxRunsRoot(process.env);
       const activeRecordPath = contextKey
@@ -5590,47 +5378,24 @@ function runCodex(
               writeDetachedSessionBinding(leaderPaneId);
             }
           }
-          if (step.name === "split-and-capture-hud-pane") {
-            const hudPaneId = parsePaneIdFromTmuxOutput(output || "");
-            const hookWindowIndex = hudPaneId
-              ? detectDetachedSessionWindowIndex(sessionName)
-              : null;
-            const hookTarget =
-              hudPaneId && hookWindowIndex
-                ? buildResizeHookTarget(sessionName, hookWindowIndex)
-                : null;
-            const hookName =
-              hudPaneId && hookWindowIndex
-                ? buildResizeHookName(
-                    "launch",
-                    sessionName,
-                    hookWindowIndex,
-                    hudPaneId,
-                  )
-                : null;
-            const clientAttachedHookName =
-              hudPaneId && hookWindowIndex
-                ? buildClientAttachedReconcileHookName(
-                    "launch",
-                    sessionName,
-                    hookWindowIndex,
-                    hudPaneId,
-                  )
-                : null;
+          if (step.name === "reconcile-managed-hud") {
+            // The persisted session binding and tmux instance tag are both in
+            // place before the shared reconciler is permitted to mutate panes.
+            await detachedSessionBindingWrite;
+            if (detachedLeaderPaneId) {
+              await reconcileManagedHudPane(cwd, sessionId, detachedLeaderPaneId, hudRuntimeEnv);
+            }
             const finalizeSteps = buildDetachedSessionFinalizeSteps(
               sessionName,
-              hudPaneId,
-              hookWindowIndex,
+              null,
+              null,
               process.env.OMX_MOUSE !== "0",
               nativeWindows,
               shouldAttachDetachedTmuxSession(process.env),
               detachedLeaderPaneId,
             );
             if (nativeWindows && detachedWindowsCodexCmd) {
-              scheduleDetachedWindowsCodexLaunch(
-                sessionName,
-                detachedWindowsCodexCmd,
-              );
+              scheduleDetachedWindowsCodexLaunch(sessionName, detachedWindowsCodexCmd);
             }
             for (const finalizeStep of finalizeSteps) {
               if (finalizeStep.name === "sanitize-copy-mode-style") {
@@ -5641,48 +5406,16 @@ function runCodex(
                 }
                 continue;
               }
-              const stdio =
-                finalizeStep.name === "attach-session" ? "inherit" : "ignore";
+              const stdio = finalizeStep.name === "attach-session" ? "inherit" : "ignore";
               try {
                 const startedAtMs = Date.now();
                 execTmuxFileSync(finalizeStep.args, { stdio });
                 if (finalizeStep.name === "attach-session") {
-                  assertDetachedAttachDidNotNoop(
-                    sessionName,
-                    Date.now() - startedAtMs,
-                    process.env,
-                  );
+                  assertDetachedAttachDidNotNoop(sessionName, Date.now() - startedAtMs, process.env);
                 }
               } catch (err) {
                 logCliOperationFailure(err);
-                if (finalizeStep.name === "attach-session")
-                  throw new Error("failed to attach detached tmux session");
-                continue;
-              }
-              if (
-                finalizeStep.name === "register-resize-hook" &&
-                hookTarget &&
-                hookName
-              ) {
-                registeredHookTarget = hookTarget;
-                registeredHookName = hookName;
-              }
-              if (
-                finalizeStep.name === "register-client-attached-reconcile" &&
-                clientAttachedHookName
-              ) {
-                registeredClientAttachedHookName = clientAttachedHookName;
-              }
-              if (finalizeStep.name === "reconcile-hud-resize") {
-                registerDetachedHudLayoutReconcileHook({
-                  hudPaneId,
-                  detachedLeaderPaneId,
-                  cwd,
-                  sessionId,
-                  omxBin,
-                  omxRootOverride,
-                  baseEnv: runtimeHookEnv,
-                });
+                if (finalizeStep.name === "attach-session") throw new Error("failed to attach detached tmux session");
               }
             }
           }
@@ -5719,9 +5452,9 @@ function runCodex(
     const runsRoot = resolveMadmaxRunsRoot(process.env);
     try {
       if (isMadmaxDetachedGuardEnabled(process.env) && contextKey) {
-        return withMadmaxDetachedContextLock(runsRoot, contextKey, launchDetachedSession);
+        return await withMadmaxDetachedContextLock(runsRoot, contextKey, launchDetachedSession);
       }
-      return launchDetachedSession();
+      return await launchDetachedSession();
     } catch (err) {
       if (err instanceof MadmaxDetachedReuseError || err instanceof MadmaxDetachedGuardError) {
         throw err;
@@ -5734,15 +5467,64 @@ function runCodex(
   }
 }
 
-function listHudWatchPaneIdsInCurrentWindow(
-  currentPaneId?: string,
-  owner: { sessionId?: string; leaderPaneId?: string } = {},
-): string[] {
+async function reconcileManagedHudPane(
+  cwd: string,
+  sessionId: string,
+  leaderPaneId: string,
+  runtimeEnv: NodeJS.ProcessEnv,
+): Promise<void> {
+  const omxBin = resolveOmxCliEntryPath({ argv1: process.argv[1], cwd, env: process.env });
+  if (!omxBin) return;
+
+  let tmuxEnv = process.env.TMUX;
+  if (!tmuxEnv) {
+    try {
+      const socketPath = execTmuxFileSync([
+        "display-message", "-p", "-t", leaderPaneId, "#{socket_path}",
+      ], { encoding: "utf-8" }).trim();
+      if (socketPath) tmuxEnv = `${socketPath},0,0`;
+    } catch {
+      return;
+    }
+  }
+  if (!tmuxEnv) return;
+
+  const {
+    OMX_ROOT: _omxRoot,
+    OMX_STATE_ROOT: _omxStateRoot,
+    OMX_TEAM_STATE_ROOT: _omxTeamStateRoot,
+    ...parentEnv
+  } = process.env;
+  const {
+    OMX_ROOT: runtimeOmxRoot,
+    OMX_STATE_ROOT: runtimeStateRoot,
+    OMX_TEAM_STATE_ROOT: runtimeTeamStateRoot,
+    ...runtimeEnvWithoutRoots
+  } = runtimeEnv;
+  const authoritativeRootEnv = runtimeTeamStateRoot
+    ? { OMX_TEAM_STATE_ROOT: runtimeTeamStateRoot }
+    : runtimeOmxRoot
+      ? { OMX_ROOT: runtimeOmxRoot }
+      : runtimeStateRoot
+        ? { OMX_STATE_ROOT: runtimeStateRoot }
+        : {};
   try {
-    return listCurrentWindowHudPaneIds(currentPaneId, undefined, owner);
-  } catch (err) {
-    logCliOperationFailure(err);
-    return [];
+    execFileSync(process.execPath, [omxBin, "hud", "--reconcile-tmux"], {
+      cwd,
+      env: {
+        ...parentEnv,
+        ...runtimeEnvWithoutRoots,
+        ...authoritativeRootEnv,
+        TMUX: tmuxEnv,
+        TMUX_PANE: leaderPaneId,
+        OMX_SESSION_ID: sessionId,
+        [OMX_TMUX_HUD_OWNER_ENV]: "1",
+        [OMX_TMUX_HUD_LEADER_PANE_ENV]: leaderPaneId,
+      },
+      stdio: "ignore",
+    });
+  } catch {
+    // Reconciliation is fail-closed: never substitute an unlocked split/reap.
   }
 }
 
@@ -5758,26 +5540,6 @@ export function isExistingTmuxWindowTooCrampedForLaunchHud(
   return isTmuxWindowTooCrampedForHudSplit(windowHeight, minWindowHeight);
 }
 
-function createHudWatchPane(
-  cwd: string,
-  hudCmd: string,
-  options: { heightLines?: number; targetPaneId?: string } = {},
-): string | null {
-  return createSharedHudWatchPane(cwd, hudCmd, {
-    heightLines: options.heightLines ?? HUD_TMUX_HEIGHT_LINES,
-    targetPaneId: options.targetPaneId,
-  });
-}
-
-function killTmuxPane(paneId: string): void {
-  if (!paneId.startsWith("%")) return;
-  try {
-    killSharedTmuxPane(paneId);
-  } catch (err) {
-    logCliOperationFailure(err);
-    // Pane may already be gone; ignore.
-  }
-}
 
 export function buildTmuxShellCommand(command: string, args: string[]): string {
   return [quoteShellArg(command), ...args.map(quoteShellArg)].join(" ");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3568,38 +3568,51 @@ async function resolvePreLaunchSessionPointerOptions(): Promise<{
   };
 }
 
-function tagTmuxSessionWithInstance(sessionName: string, sessionId: string): void {
-  const target = sessionName.trim();
-  const instanceId = sessionId.trim();
-  if (!target || !instanceId) return;
-  execFileSync("tmux", ["set-option", "-t", target, OMX_INSTANCE_OPTION, instanceId], {
-    stdio: ["ignore", "ignore", "ignore"],
-    timeout: 2000,
-  });
-}
-
-async function establishCurrentTmuxInstanceBinding(
+/**
+ * Establishes opaque tmux births exactly once. The logical Codex session id is
+ * deliberately not a tmux birth: it can be replayed after tmux has recycled a
+ * session or pane name.
+ */
+export async function establishCurrentTmuxInstanceBinding(
   sessionId: string,
   paneId: string | undefined = process.env.TMUX_PANE,
   expectedSessionName?: string,
 ): Promise<ActualTmuxInstanceEvidence | null> {
   const paneTarget = paneId?.trim() ?? '';
-  if (!paneTarget) return null;
+  if (!sessionId.trim() || !paneTarget) return null;
   try {
-    const sessionName = expectedSessionName?.trim() || execFileSync(
-      "tmux",
-      ["display-message", "-p", "-t", paneTarget, "#S"],
-      { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"], timeout: 2000 },
-    ).trim();
-    if (!sessionName) return null;
-    tagTmuxSessionWithInstance(sessionName, sessionId);
-    execFileSync("tmux", ["set-option", "-p", "-t", paneTarget, OMX_PANE_INSTANCE_OPTION, sessionId], {
-      stdio: ["ignore", "ignore", "ignore"],
-      timeout: 2000,
-    });
-    const evidence = await probeActualTmuxInstanceEvidence(paneTarget);
-    if (evidence.sessionName !== sessionName || !tmuxEvidenceBindsCandidate(evidence, sessionId)) return null;
-    return evidence;
+    const before = await probeActualTmuxInstanceEvidence(paneTarget);
+    const sessionName = expectedSessionName?.trim() || before.sessionName;
+    if (!sessionName || before.sessionName !== sessionName || !before.contextStable
+      || before.paneTarget !== paneTarget
+      || before.paneTagStatus === 'error' || before.sessionTagStatus === 'error') return null;
+
+    const sessionBirth = before.sessionInstanceId || randomUUID();
+    if (!before.sessionInstanceId) {
+      execFileSync('tmux', ['set-option', '-o', '-t', sessionName, OMX_INSTANCE_OPTION, sessionBirth], {
+        stdio: ['ignore', 'ignore', 'ignore'],
+        timeout: 2000,
+      });
+    }
+    const paneBirth = before.paneInstanceId || randomUUID();
+    if (!before.paneInstanceId) {
+      execFileSync('tmux', ['set-option', '-o', '-p', '-t', paneTarget, OMX_PANE_INSTANCE_OPTION, paneBirth], {
+        stdio: ['ignore', 'ignore', 'ignore'],
+        timeout: 2000,
+      });
+    }
+
+    const after = await probeActualTmuxInstanceEvidence(paneTarget);
+    if (!after.contextStable
+      || after.paneTarget !== paneTarget
+      || after.sessionName !== sessionName
+      || after.sessionId !== before.sessionId
+      || after.windowId !== before.windowId
+      || after.sessionInstanceId !== sessionBirth
+      || after.paneInstanceId !== paneBirth
+      || after.sessionTagStatus !== 'present'
+      || after.paneTagStatus !== 'present') return null;
+    return after;
   } catch {
     return null;
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5351,33 +5351,6 @@ async function runCodex(
           inheritedWorkerModel,
         );
         for (const step of bootstrapSteps) {
-          const output = execTmuxFileSync(step.args, {
-            stdio: "pipe",
-            encoding: "utf-8",
-          });
-          if (step.name === "new-session") {
-            createdDetachedSession = true;
-            const leaderPaneId = parsePaneIdFromTmuxOutput(output || "");
-            if (leaderPaneId) {
-              detachedLeaderPaneId = leaderPaneId;
-              setDetachedTmuxSessionHistoryLimit(sessionName, leaderPaneId);
-              if (activeRecordPath && contextKey) {
-                writeMadmaxDetachedActiveRecord(activeRecordPath, {
-                  version: 1,
-                  context_key: contextKey,
-                  created_at: new Date().toISOString(),
-                  source_cwd: runtimeContext?.sourceCwd ?? process.env.OMX_SOURCE_CWD ?? cwd,
-                  ...(runtimeContext?.worktreeCwd ? { worktree_cwd: runtimeContext.worktreeCwd } : {}),
-                  argv: args,
-                  run_dir: runtimeContext?.omxRoot ?? process.env.OMX_ROOT ?? cwd,
-                  tmux_session_name: sessionName,
-                  session_id: sessionId,
-                  tmux_pane_id: leaderPaneId,
-                });
-              }
-              writeDetachedSessionBinding(leaderPaneId);
-            }
-          }
           if (step.name === "reconcile-managed-hud") {
             // The persisted session binding and tmux instance tag are both in
             // place before the shared reconciler is permitted to mutate panes.
@@ -5417,6 +5390,35 @@ async function runCodex(
                 logCliOperationFailure(err);
                 if (finalizeStep.name === "attach-session") throw new Error("failed to attach detached tmux session");
               }
+            }
+            continue;
+          }
+
+          const output = execTmuxFileSync(step.args, {
+            stdio: "pipe",
+            encoding: "utf-8",
+          });
+          if (step.name === "new-session") {
+            createdDetachedSession = true;
+            const leaderPaneId = parsePaneIdFromTmuxOutput(output || "");
+            if (leaderPaneId) {
+              detachedLeaderPaneId = leaderPaneId;
+              setDetachedTmuxSessionHistoryLimit(sessionName, leaderPaneId);
+              if (activeRecordPath && contextKey) {
+                writeMadmaxDetachedActiveRecord(activeRecordPath, {
+                  version: 1,
+                  context_key: contextKey,
+                  created_at: new Date().toISOString(),
+                  source_cwd: runtimeContext?.sourceCwd ?? process.env.OMX_SOURCE_CWD ?? cwd,
+                  ...(runtimeContext?.worktreeCwd ? { worktree_cwd: runtimeContext.worktreeCwd } : {}),
+                  argv: args,
+                  run_dir: runtimeContext?.omxRoot ?? process.env.OMX_ROOT ?? cwd,
+                  tmux_session_name: sessionName,
+                  session_id: sessionId,
+                  tmux_pane_id: leaderPaneId,
+                });
+              }
+              writeDetachedSessionBinding(leaderPaneId);
             }
           }
         }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -133,6 +133,7 @@ import {
   resetSessionMetrics,
 } from "../hooks/session.js";
 import { probeActualTmuxInstanceEvidence, tmuxEvidenceBindsCandidate, type ActualTmuxInstanceEvidence } from "../scripts/notify-hook/managed-tmux.js";
+import { resolveHudControlPlaneDomain, writeHudTmuxBirthLineage } from "../mcp/state-paths.js";
 import {
   buildClientAttachedReconcileHookName,
   buildReconcileHudResizeArgs,
@@ -3568,6 +3569,10 @@ async function resolvePreLaunchSessionPointerOptions(): Promise<{
   };
 }
 
+function escapeTmuxFormatLiteral(value: string): string {
+  return value.replace(/[#{},:]/g, (character) => `#${character}`);
+}
+
 /**
  * Establishes opaque tmux births exactly once. The logical Codex session id is
  * deliberately not a tmux birth: it can be replayed after tmux has recycled a
@@ -3578,28 +3583,55 @@ export async function establishCurrentTmuxInstanceBinding(
   paneId: string | undefined = process.env.TMUX_PANE,
   expectedSessionName?: string,
 ): Promise<ActualTmuxInstanceEvidence | null> {
-  const paneTarget = paneId?.trim() ?? '';
+  const paneTarget = paneId?.trim() ?? "";
   if (!sessionId.trim() || !paneTarget) return null;
   try {
     const before = await probeActualTmuxInstanceEvidence(paneTarget);
     const sessionName = expectedSessionName?.trim() || before.sessionName;
     if (!sessionName || before.sessionName !== sessionName || !before.contextStable
       || before.paneTarget !== paneTarget
-      || before.paneTagStatus === 'error' || before.sessionTagStatus === 'error') return null;
+      || before.paneTagStatus === "error" || before.sessionTagStatus === "error") return null;
 
-    const sessionBirth = before.sessionInstanceId || randomUUID();
-    if (!before.sessionInstanceId) {
-      execFileSync('tmux', ['set-option', '-o', '-t', sessionName, OMX_INSTANCE_OPTION, sessionBirth], {
-        stdio: ['ignore', 'ignore', 'ignore'],
+    const existingSessionBirth = before.sessionInstanceId;
+    const existingPaneBirth = before.paneInstanceId;
+    if (Boolean(existingSessionBirth) !== Boolean(existingPaneBirth)) return null;
+    if (existingSessionBirth && existingSessionBirth === existingPaneBirth) return null;
+
+    let sessionBirth = existingSessionBirth;
+    let paneBirth = existingPaneBirth;
+    if (!sessionBirth && !paneBirth) {
+      sessionBirth = randomUUID();
+      paneBirth = randomUUID();
+      const appliedReceipt = `__omx_birth_established_${randomUUID()}__`;
+      const rejectedReceipt = `__omx_birth_rejected_${randomUUID()}__`;
+      const condition = `#{&&:#{==:#{${OMX_INSTANCE_OPTION}},},#{==:#{${OMX_PANE_INSTANCE_OPTION}},}}`;
+      const publish = [
+        `set-option -t ${quoteShellArg(sessionName)} ${OMX_INSTANCE_OPTION} ${quoteShellArg(sessionBirth)}`,
+        `set-option -p -t ${quoteShellArg(paneTarget)} ${OMX_PANE_INSTANCE_OPTION} ${quoteShellArg(paneBirth)}`,
+        `display-message -p ${appliedReceipt}`,
+      ].join(" \\; ");
+      const receipt = execFileSync("tmux", [
+        "if-shell", "-t", paneTarget, "-F", condition, publish,
+        `display-message -p ${rejectedReceipt}`,
+      ], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
         timeout: 2000,
-      });
-    }
-    const paneBirth = before.paneInstanceId || randomUUID();
-    if (!before.paneInstanceId) {
-      execFileSync('tmux', ['set-option', '-o', '-p', '-t', paneTarget, OMX_PANE_INSTANCE_OPTION, paneBirth], {
-        stdio: ['ignore', 'ignore', 'ignore'],
-        timeout: 2000,
-      });
+      }).split("\n").map((line) => line.trim());
+      if (receipt.includes(appliedReceipt)) {
+        // This invocation published its complete opaque pair.
+      } else if (receipt.includes(rejectedReceipt)) {
+        const winning = await probeActualTmuxInstanceEvidence(paneTarget);
+        if (!winning.contextStable || winning.paneTarget !== paneTarget
+          || winning.sessionName !== sessionName
+          || winning.sessionId !== before.sessionId
+          || winning.windowId !== before.windowId
+          || !winning.sessionInstanceId || !winning.paneInstanceId
+          || winning.sessionInstanceId === winning.paneInstanceId
+          || winning.sessionTagStatus !== "present" || winning.paneTagStatus !== "present") return null;
+        sessionBirth = winning.sessionInstanceId;
+        paneBirth = winning.paneInstanceId;
+      } else return null;
     }
 
     const after = await probeActualTmuxInstanceEvidence(paneTarget);
@@ -3610,12 +3642,41 @@ export async function establishCurrentTmuxInstanceBinding(
       || after.windowId !== before.windowId
       || after.sessionInstanceId !== sessionBirth
       || after.paneInstanceId !== paneBirth
-      || after.sessionTagStatus !== 'present'
-      || after.paneTagStatus !== 'present') return null;
+      || sessionBirth === paneBirth
+      || after.sessionTagStatus !== "present"
+      || after.paneTagStatus !== "present") return null;
     return after;
   } catch {
     return null;
   }
+}
+
+async function persistTmuxBirthLineage(
+  cwd: string,
+  sessionId: string,
+  evidence: ActualTmuxInstanceEvidence,
+): Promise<void> {
+  const tmuxSessionName = evidence.sessionName.trim();
+  const tmuxSessionInstanceId = evidence.sessionInstanceId.trim();
+  const tmuxPaneInstanceId = evidence.paneInstanceId.trim();
+  if (!tmuxSessionName || !tmuxSessionInstanceId || !tmuxPaneInstanceId) return;
+  const domain = await resolveHudControlPlaneDomain({
+    cwd,
+    requestedSessionId: sessionId,
+    claimant: {
+      sessionId,
+      leaderPaneId: evidence.paneTarget,
+      tmuxSessionName,
+      tmuxSessionInstanceId,
+      tmuxPaneInstanceId,
+    },
+  });
+  await writeHudTmuxBirthLineage(domain, {
+    sessionId,
+    tmuxSessionName,
+    tmuxSessionInstanceId,
+    tmuxPaneInstanceId,
+  });
 }
 
 function buildNativeHookBaseContext(
@@ -3750,9 +3811,6 @@ export function detectDetachedSessionWindowIndex(sessionName: string): string | 
   }
 }
 
-function escapeShellDoubleQuotedValue(value: string): string {
-  return value.replace(/["\\$`]/g, "\\$&");
-}
 
 interface TmuxExtendedKeysLeaseHolderRecord {
   id: string;
@@ -3997,7 +4055,6 @@ function withTmuxExtendedKeysLeaseLock<T>(
 
 function buildDetachedSessionLeaderCommand(
   cwd: string,
-  sessionName: string,
   codexCmd: string,
   sessionId?: string,
   codexHomeOverride?: string,
@@ -4031,9 +4088,6 @@ function buildDetachedSessionLeaderCommand(
     buildTmuxExtendedKeysReleaseShellSnippet(cwd),
     parentEnvCleanup,
     detachedPostLaunchHelper,
-    'if [ "$status" -eq 0 ]; then',
-    `tmux kill-session -t "${escapeShellDoubleQuotedValue(sessionName)}" >/dev/null 2>&1 || true;`,
-    "fi;",
     "exit $status;",
     "};",
     "trap omx_detached_session_cleanup 0 INT TERM HUP;",
@@ -4319,7 +4373,6 @@ export function buildDetachedSessionBootstrapSteps(
     ? "powershell.exe"
     : buildDetachedSessionLeaderCommand(
         cwd,
-        sessionName,
         codexCmd,
         sessionId,
         codexHomeOverride,
@@ -4373,14 +4426,6 @@ export function buildDetachedSessionBootstrapSteps(
   ];
   return [
     { name: "new-session", args: newSessionArgs },
-    ...(sessionId
-      ? [
-          {
-            name: "tag-session",
-            args: ["set-option", "-t", sessionName, OMX_INSTANCE_OPTION, sessionId],
-          },
-        ]
-      : []),
     { name: "reconcile-managed-hud", args: [] },
   ];
 }
@@ -4505,6 +4550,7 @@ export function buildDetachedSessionRollbackSteps(
   hookTarget: string | null,
   hookName: string | null,
   clientAttachedHookName: string | null,
+  sessionBirth: string | null = null,
 ): DetachedSessionTmuxStep[] {
   const steps: DetachedSessionTmuxStep[] = [];
   if (hookTarget && clientAttachedHookName) {
@@ -4522,10 +4568,20 @@ export function buildDetachedSessionRollbackSteps(
       args: buildUnregisterResizeHookArgs(hookTarget, hookName),
     });
   }
-  steps.push({
-    name: "kill-session",
-    args: ["kill-session", "-t", sessionName],
-  });
+  const normalizedSessionBirth = sessionBirth?.trim() ?? "";
+  if (normalizedSessionBirth) {
+    const appliedReceipt = `__omx_detached_session_rollback_applied_${randomUUID()}__`;
+    const rejectedReceipt = `__omx_detached_session_rollback_rejected_${randomUUID()}__`;
+    const condition = `#{&&:#{==:#{session_name},${escapeTmuxFormatLiteral(sessionName)}},#{==:#{${OMX_INSTANCE_OPTION}},${escapeTmuxFormatLiteral(normalizedSessionBirth)}}}`;
+    steps.push({
+      name: "kill-session-if-birth-matches",
+      args: [
+        "if-shell", "-t", sessionName, "-F", condition,
+        `kill-session -t ${quoteShellArg(sessionName)} \\; display-message -p ${appliedReceipt}`,
+        `display-message -p ${rejectedReceipt}`,
+      ],
+    });
+  }
   return steps;
 }
 
@@ -5044,6 +5100,7 @@ export async function preLaunch(
       ...(tmuxBinding.sessionName ? { tmuxSessionName: tmuxBinding.sessionName } : {}),
       ...(tmuxBinding.paneTarget ? { tmuxPaneId: tmuxBinding.paneTarget } : {}),
     });
+    await persistTmuxBirthLineage(cwd, sessionId, tmuxBinding);
   }
 
   // 3. Generate runtime overlay + write session-scoped model instructions file
@@ -5326,17 +5383,21 @@ async function runCodex(
       }
 
       let detachedSessionBindingWrite: Promise<unknown> = Promise.resolve();
-      const writeDetachedSessionBinding = (tmuxPaneId?: string | null) => {
+      const writeDetachedSessionBinding = (
+        tmuxPaneId?: string | null,
+        tmuxBinding?: ActualTmuxInstanceEvidence | null,
+      ) => {
         detachedSessionBindingWrite = detachedSessionBindingWrite
           .catch((err) => {
             logCliOperationFailure(err);
           })
-          .then(() =>
-            writeSessionStart(cwd, sessionId, {
+          .then(async () => {
+            await writeSessionStart(cwd, sessionId, {
               tmuxSessionName: sessionName,
               ...(tmuxPaneId ? { tmuxPaneId } : {}),
-            }),
-          );
+            });
+            if (tmuxBinding) await persistTmuxBirthLineage(cwd, sessionId, tmuxBinding);
+          });
         void detachedSessionBindingWrite.catch((err) => {
           logCliOperationFailure(err);
           // Non-fatal: managed tmux recovery can still use compatibility fallback.
@@ -5350,6 +5411,7 @@ async function runCodex(
       let detachedParentEnvFilePath: string | undefined;
       let detachedLeaderPaneId: string | null = null;
       let detachedHudEvidenceVerified = false;
+      let detachedSessionBirth: string | null = null;
       try {
         // This path is the user-shell interactive launch: OMX creates a tmux
         // session and immediately attaches the user's terminal to it. If a tmux
@@ -5450,12 +5512,16 @@ async function runCodex(
                   tmux_pane_id: leaderPaneId,
                 });
               }
-              writeDetachedSessionBinding(leaderPaneId);
-              detachedHudEvidenceVerified = await establishCurrentTmuxInstanceBinding(
+              const tmuxBinding = await establishCurrentTmuxInstanceBinding(
                 sessionId,
                 leaderPaneId,
                 sessionName,
-              ) !== null;
+              );
+              if (tmuxBinding) {
+                detachedSessionBirth = tmuxBinding.sessionInstanceId;
+                writeDetachedSessionBinding(leaderPaneId, tmuxBinding);
+                detachedHudEvidenceVerified = true;
+              }
             }
           }
         }
@@ -5473,6 +5539,7 @@ async function runCodex(
             registeredHookTarget,
             registeredHookName,
             registeredClientAttachedHookName,
+            detachedSessionBirth,
           );
           for (const rollbackStep of rollbackSteps) {
             try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3578,29 +3578,27 @@ function tagTmuxSessionWithInstance(sessionName: string, sessionId: string): voi
   });
 }
 
-async function establishCurrentTmuxInstanceBinding(sessionId: string): Promise<ActualTmuxInstanceEvidence | null> {
-  if (!process.env.TMUX || !process.env.TMUX_PANE) return null;
-  const paneTarget = process.env.TMUX_PANE.trim();
+async function establishCurrentTmuxInstanceBinding(
+  sessionId: string,
+  paneId: string | undefined = process.env.TMUX_PANE,
+  expectedSessionName?: string,
+): Promise<ActualTmuxInstanceEvidence | null> {
+  const paneTarget = paneId?.trim() ?? '';
   if (!paneTarget) return null;
   try {
-    const readContext = (): string => execFileSync(
+    const sessionName = expectedSessionName?.trim() || execFileSync(
       "tmux",
-      ["display-message", "-p", "-t", paneTarget, "#{session_name}:#{window_index} #{pane_id}"],
+      ["display-message", "-p", "-t", paneTarget, "#S"],
       { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"], timeout: 2000 },
     ).trim();
-    const before = readContext();
-    const [sessionAndWindow = "", livePaneId = ""] = before.split(" ");
-    const sessionName = sessionAndWindow.split(":")[0]?.trim() ?? "";
-    if (!sessionName || livePaneId.trim() !== paneTarget) return null;
+    if (!sessionName) return null;
     tagTmuxSessionWithInstance(sessionName, sessionId);
     execFileSync("tmux", ["set-option", "-p", "-t", paneTarget, OMX_PANE_INSTANCE_OPTION, sessionId], {
       stdio: ["ignore", "ignore", "ignore"],
       timeout: 2000,
     });
     const evidence = await probeActualTmuxInstanceEvidence(paneTarget);
-    if (readContext() !== before || evidence.sessionName !== sessionName || !tmuxEvidenceBindsCandidate(evidence, sessionId)) {
-      return null;
-    }
+    if (evidence.sessionName !== sessionName || !tmuxEvidenceBindsCandidate(evidence, sessionId)) return null;
     return evidence;
   } catch {
     return null;
@@ -5338,6 +5336,7 @@ async function runCodex(
       let registeredClientAttachedHookName: string | null = null;
       let detachedParentEnvFilePath: string | undefined;
       let detachedLeaderPaneId: string | null = null;
+      let detachedHudEvidenceVerified = false;
       try {
         // This path is the user-shell interactive launch: OMX creates a tmux
         // session and immediately attaches the user's terminal to it. If a tmux
@@ -5375,7 +5374,7 @@ async function runCodex(
             // The persisted session binding and tmux instance tag are both in
             // place before the shared reconciler is permitted to mutate panes.
             await detachedSessionBindingWrite;
-            if (detachedLeaderPaneId) {
+            if (detachedLeaderPaneId && detachedHudEvidenceVerified) {
               await reconcileManagedHudPane(cwd, sessionId, detachedLeaderPaneId, hudRuntimeEnv);
             }
             const finalizeSteps = buildDetachedSessionFinalizeSteps(
@@ -5439,6 +5438,11 @@ async function runCodex(
                 });
               }
               writeDetachedSessionBinding(leaderPaneId);
+              detachedHudEvidenceVerified = await establishCurrentTmuxInstanceBinding(
+                sessionId,
+                leaderPaneId,
+                sessionName,
+              ) !== null;
             }
           }
         }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3699,6 +3699,7 @@ async function persistTmuxBirthLineage(
   cwd: string,
   sessionId: string,
   evidence: ActualTmuxInstanceEvidence,
+  env: NodeJS.ProcessEnv = process.env,
 ): Promise<void> {
   const tmuxSessionName = evidence.sessionName.trim();
   const tmuxSessionInstanceId = evidence.sessionInstanceId.trim();
@@ -3706,6 +3707,7 @@ async function persistTmuxBirthLineage(
   if (!tmuxSessionName || !tmuxSessionInstanceId || !tmuxPaneInstanceId) return;
   const domain = await resolveHudControlPlaneDomain({
     cwd,
+    env,
     requestedSessionId: sessionId,
     claimant: {
       sessionId,
@@ -5444,7 +5446,7 @@ async function runCodex(
               tmuxSessionName: sessionName,
               ...(tmuxPaneId ? { tmuxPaneId } : {}),
             });
-            if (tmuxBinding) await persistTmuxBirthLineage(cwd, sessionId, tmuxBinding);
+            if (tmuxBinding) await persistTmuxBirthLineage(cwd, sessionId, tmuxBinding, hudRuntimeEnv);
           });
         void detachedSessionBindingWrite.catch((err) => {
           logCliOperationFailure(err);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -132,7 +132,7 @@ import {
   writeSessionEnd,
   resetSessionMetrics,
 } from "../hooks/session.js";
-import { probeActualTmuxInstanceEvidence, tmuxEvidenceBindsCandidate } from "../scripts/notify-hook/managed-tmux.js";
+import { probeActualTmuxInstanceEvidence, tmuxEvidenceBindsCandidate, type ActualTmuxInstanceEvidence } from "../scripts/notify-hook/managed-tmux.js";
 import {
   buildClientAttachedReconcileHookName,
   buildReconcileHudResizeArgs,
@@ -155,7 +155,7 @@ import { cleanCodexModelAvailabilityNuxIfNeeded, extractSharedMcpRegistryServers
 import type { UnifiedMcpRegistryServer } from "../config/mcp-registry.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { HUD_TMUX_HEIGHT_LINES, HUD_TMUX_MIN_LAUNCH_WINDOW_HEIGHT_LINES, isTmuxWindowTooCrampedForHudSplit } from "../hud/constants.js";
-import { OMX_TMUX_HUD_OWNER_ENV } from "../hud/reconcile.js";
+import { OMX_TMUX_HUD_OWNER_ENV, teardownManagedHudPane } from "../hud/reconcile.js";
 import { readUltragoalState } from "../hud/state.js";
 import {
   buildHudRuntimeEnv,
@@ -359,6 +359,7 @@ const TEAM_INHERIT_LEADER_FLAGS_ENV = "OMX_TEAM_INHERIT_LEADER_FLAGS";
 const OMX_BYPASS_DEFAULT_SYSTEM_PROMPT_ENV = "OMX_BYPASS_DEFAULT_SYSTEM_PROMPT";
 const OMX_MODEL_INSTRUCTIONS_FILE_ENV = "OMX_MODEL_INSTRUCTIONS_FILE";
 const OMX_INSTANCE_OPTION = "@omx_instance_id";
+const OMX_PANE_INSTANCE_OPTION = "@omx_pane_instance_id";
 const OMX_RALPH_APPEND_INSTRUCTIONS_FILE_ENV =
   "OMX_RALPH_APPEND_INSTRUCTIONS_FILE";
 const OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE_ENV =
@@ -3577,21 +3578,32 @@ function tagTmuxSessionWithInstance(sessionName: string, sessionId: string): voi
   });
 }
 
-function tagCurrentTmuxSessionWithInstance(sessionId: string): void {
-  if (!process.env.TMUX) return;
+async function establishCurrentTmuxInstanceBinding(sessionId: string): Promise<ActualTmuxInstanceEvidence | null> {
+  if (!process.env.TMUX || !process.env.TMUX_PANE) return null;
+  const paneTarget = process.env.TMUX_PANE.trim();
+  if (!paneTarget) return null;
   try {
-    const tmuxPaneTarget = process.env.TMUX_PANE;
-    const displayArgs = tmuxPaneTarget
-      ? ["display-message", "-p", "-t", tmuxPaneTarget, "#S"]
-      : ["display-message", "-p", "#S"];
-    const sessionName = execFileSync("tmux", displayArgs, {
-      encoding: "utf-8",
-      stdio: ["ignore", "pipe", "ignore"],
+    const readContext = (): string => execFileSync(
+      "tmux",
+      ["display-message", "-p", "-t", paneTarget, "#{session_name}:#{window_index} #{pane_id}"],
+      { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"], timeout: 2000 },
+    ).trim();
+    const before = readContext();
+    const [sessionAndWindow = "", livePaneId = ""] = before.split(" ");
+    const sessionName = sessionAndWindow.split(":")[0]?.trim() ?? "";
+    if (!sessionName || livePaneId.trim() !== paneTarget) return null;
+    tagTmuxSessionWithInstance(sessionName, sessionId);
+    execFileSync("tmux", ["set-option", "-p", "-t", paneTarget, OMX_PANE_INSTANCE_OPTION, sessionId], {
+      stdio: ["ignore", "ignore", "ignore"],
       timeout: 2000,
-    }).trim();
-    if (sessionName) tagTmuxSessionWithInstance(sessionName, sessionId);
+    });
+    const evidence = await probeActualTmuxInstanceEvidence(paneTarget);
+    if (readContext() !== before || evidence.sessionName !== sessionName || !tmuxEvidenceBindsCandidate(evidence, sessionId)) {
+      return null;
+    }
+    return evidence;
   } catch {
-    // Best effort only: launch should not fail just because tmux tagging failed.
+    return null;
   }
 }
 
@@ -5005,9 +5017,8 @@ export async function preLaunch(
   // Persist the exact binding only after the canonical pointer has committed. A
   // managed attached launch must bind the persisted owner to the exact pane and
   // session instance before a hook can reconcile its HUD.
-  tagCurrentTmuxSessionWithInstance(sessionId);
-  const tmuxBinding = await probeActualTmuxInstanceEvidence(process.env.TMUX_PANE);
-  if (tmuxEvidenceBindsCandidate(tmuxBinding, sessionId)) {
+  const tmuxBinding = await establishCurrentTmuxInstanceBinding(sessionId);
+  if (tmuxBinding) {
     await writeSessionStart(cwd, sessionId, {
       ...(tmuxBinding.sessionName ? { tmuxSessionName: tmuxBinding.sessionName } : {}),
       ...(tmuxBinding.paneTarget ? { tmuxPaneId: tmuxBinding.paneTarget } : {}),
@@ -5220,9 +5231,18 @@ async function runCodex(
       }
     }
 
-    withTmuxExtendedKeys(cwd, () => {
-      runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
-    });
+    try {
+      withTmuxExtendedKeys(cwd, () => {
+        runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
+      });
+    } finally {
+      if (currentPaneId) {
+        await teardownManagedHudPane(cwd, {
+          env: { ...process.env, ...hudRuntimeEnv, TMUX_PANE: currentPaneId },
+          sessionId,
+        });
+      }
+    }
     return { postLaunchHandledExternally: false };
   } else if (launchPolicy === "direct") {
     // Detached HUD sessions require tmux. Skip the bootstrap entirely when the

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5341,33 +5341,6 @@ async function runCodex(
           inheritedWorkerModel,
         );
         for (const step of bootstrapSteps) {
-          const output = execTmuxFileSync(step.args, {
-            stdio: "pipe",
-            encoding: "utf-8",
-          });
-          if (step.name === "new-session") {
-            createdDetachedSession = true;
-            const leaderPaneId = parsePaneIdFromTmuxOutput(output || "");
-            if (leaderPaneId) {
-              detachedLeaderPaneId = leaderPaneId;
-              setDetachedTmuxSessionHistoryLimit(sessionName, leaderPaneId);
-              if (activeRecordPath && contextKey) {
-                writeMadmaxDetachedActiveRecord(activeRecordPath, {
-                  version: 1,
-                  context_key: contextKey,
-                  created_at: new Date().toISOString(),
-                  source_cwd: runtimeContext?.sourceCwd ?? process.env.OMX_SOURCE_CWD ?? cwd,
-                  ...(runtimeContext?.worktreeCwd ? { worktree_cwd: runtimeContext.worktreeCwd } : {}),
-                  argv: args,
-                  run_dir: runtimeContext?.omxRoot ?? process.env.OMX_ROOT ?? cwd,
-                  tmux_session_name: sessionName,
-                  session_id: sessionId,
-                  tmux_pane_id: leaderPaneId,
-                });
-              }
-              writeDetachedSessionBinding(leaderPaneId);
-            }
-          }
           if (step.name === "reconcile-managed-hud") {
             // The persisted session binding and tmux instance tag are both in
             // place before the shared reconciler is permitted to mutate panes.
@@ -5407,6 +5380,35 @@ async function runCodex(
                 logCliOperationFailure(err);
                 if (finalizeStep.name === "attach-session") throw new Error("failed to attach detached tmux session");
               }
+            }
+            continue;
+          }
+
+          const output = execTmuxFileSync(step.args, {
+            stdio: "pipe",
+            encoding: "utf-8",
+          });
+          if (step.name === "new-session") {
+            createdDetachedSession = true;
+            const leaderPaneId = parsePaneIdFromTmuxOutput(output || "");
+            if (leaderPaneId) {
+              detachedLeaderPaneId = leaderPaneId;
+              setDetachedTmuxSessionHistoryLimit(sessionName, leaderPaneId);
+              if (activeRecordPath && contextKey) {
+                writeMadmaxDetachedActiveRecord(activeRecordPath, {
+                  version: 1,
+                  context_key: contextKey,
+                  created_at: new Date().toISOString(),
+                  source_cwd: runtimeContext?.sourceCwd ?? process.env.OMX_SOURCE_CWD ?? cwd,
+                  ...(runtimeContext?.worktreeCwd ? { worktree_cwd: runtimeContext.worktreeCwd } : {}),
+                  argv: args,
+                  run_dir: runtimeContext?.omxRoot ?? process.env.OMX_ROOT ?? cwd,
+                  tmux_session_name: sessionName,
+                  session_id: sessionId,
+                  tmux_pane_id: leaderPaneId,
+                });
+              }
+              writeDetachedSessionBinding(leaderPaneId);
             }
           }
         }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2205,6 +2205,7 @@ interface MadmaxDetachedActiveRecord {
   run_dir: string;
   tmux_session_name: string;
   session_id?: string;
+  session_birth?: string;
   tmux_pane_id?: string;
 }
 
@@ -2314,6 +2315,7 @@ function readMadmaxDetachedActiveRecord(
       run_dir: parsed.run_dir,
       tmux_session_name: parsed.tmux_session_name,
       ...(typeof parsed.session_id === "string" ? { session_id: parsed.session_id } : {}),
+      ...(typeof parsed.session_birth === "string" ? { session_birth: parsed.session_birth } : {}),
       ...(typeof parsed.tmux_pane_id === "string" ? { tmux_pane_id: parsed.tmux_pane_id } : {}),
       ...(typeof parsed.worktree_cwd === "string" ? { worktree_cwd: parsed.worktree_cwd } : {}),
     };
@@ -2325,9 +2327,13 @@ function readMadmaxDetachedActiveRecord(
 function isReusableMadmaxDetachedActiveRecord(
   record: MadmaxDetachedActiveRecord,
 ): boolean {
+  // Reuse requires the immutable session birth (the published @omx_instance_id),
+  // not the logical launch session_id which is retained only as an alias. A
+  // record without a persisted session_birth predates atomic birth publication
+  // and is treated as non-reusable fail-closed.
   if (!detachedTmuxSessionExists(record.tmux_session_name)) return false;
-  if (!record.session_id || !record.tmux_pane_id) return false;
-  if (readTmuxSessionInstanceId(record.tmux_session_name) !== record.session_id) {
+  if (!record.session_birth || !record.tmux_pane_id) return false;
+  if (readTmuxSessionInstanceId(record.tmux_session_name) !== record.session_birth) {
     return false;
   }
   return tmuxPaneBelongsToSession(record.tmux_pane_id, record.tmux_session_name);
@@ -5418,9 +5424,11 @@ async function runCodex(
         }
         return { postLaunchHandledExternally: true };
       }
-      if (activeRecordPath && activeRecord) {
-        throw new TmuxLifecycleAuthorityError("madmax detached recovery record is not reusable; preserving it without exact release evidence");
-      }
+      // A present-but-non-reusable record (missing/mismatched immutable session
+      // birth, or a foreign session we cannot prove we own) must not be reused
+      // and must not mutate the foreign session. Fall through to spawn a fresh,
+      // independently-owned detached session; the fresh launch re-publishes the
+      // active record for this context with proven birth evidence.
 
       let detachedSessionBindingWrite: Promise<unknown> = Promise.resolve();
       const writeDetachedSessionBinding = (
@@ -5538,19 +5546,20 @@ async function runCodex(
             if (leaderPaneId) {
               detachedLeaderPaneId = leaderPaneId;
               setDetachedTmuxSessionHistoryLimit(sessionName, leaderPaneId);
+              const baseActiveRecord: MadmaxDetachedActiveRecord = {
+                version: 1,
+                context_key: contextKey ?? "",
+                created_at: new Date().toISOString(),
+                source_cwd: runtimeContext?.sourceCwd ?? process.env.OMX_SOURCE_CWD ?? cwd,
+                ...(runtimeContext?.worktreeCwd ? { worktree_cwd: runtimeContext.worktreeCwd } : {}),
+                argv: args,
+                run_dir: runtimeContext?.omxRoot ?? process.env.OMX_ROOT ?? cwd,
+                tmux_session_name: sessionName,
+                session_id: sessionId,
+                tmux_pane_id: leaderPaneId,
+              };
               if (activeRecordPath && contextKey) {
-                writeMadmaxDetachedActiveRecord(activeRecordPath, {
-                  version: 1,
-                  context_key: contextKey,
-                  created_at: new Date().toISOString(),
-                  source_cwd: runtimeContext?.sourceCwd ?? process.env.OMX_SOURCE_CWD ?? cwd,
-                  ...(runtimeContext?.worktreeCwd ? { worktree_cwd: runtimeContext.worktreeCwd } : {}),
-                  argv: args,
-                  run_dir: runtimeContext?.omxRoot ?? process.env.OMX_ROOT ?? cwd,
-                  tmux_session_name: sessionName,
-                  session_id: sessionId,
-                  tmux_pane_id: leaderPaneId,
-                });
+                writeMadmaxDetachedActiveRecord(activeRecordPath, baseActiveRecord);
               }
               const tmuxBinding = await establishCurrentTmuxInstanceBinding(
                 sessionId,
@@ -5561,6 +5570,15 @@ async function runCodex(
                 detachedSessionBirth = tmuxBinding.sessionInstanceId;
                 writeDetachedSessionBinding(leaderPaneId, tmuxBinding);
                 detachedHudEvidenceVerified = true;
+                // Persist the immutable session birth only after atomic birth
+                // publication/readback succeeds, so reuse compares @omx_instance_id
+                // against exact evidence and never against the logical session_id.
+                if (activeRecordPath && contextKey && tmuxBinding.sessionInstanceId) {
+                  writeMadmaxDetachedActiveRecord(activeRecordPath, {
+                    ...baseActiveRecord,
+                    session_birth: tmuxBinding.sessionInstanceId,
+                  });
+                }
               }
             }
           }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -132,7 +132,7 @@ import {
   writeSessionEnd,
   resetSessionMetrics,
 } from "../hooks/session.js";
-import { probeActualTmuxInstanceEvidence, tmuxEvidenceBindsCandidate } from "../scripts/notify-hook/managed-tmux.js";
+import { probeActualTmuxInstanceEvidence, tmuxEvidenceBindsCandidate, type ActualTmuxInstanceEvidence } from "../scripts/notify-hook/managed-tmux.js";
 import {
   buildClientAttachedReconcileHookName,
   buildReconcileHudResizeArgs,
@@ -155,7 +155,7 @@ import { cleanCodexModelAvailabilityNuxIfNeeded, extractSharedMcpRegistryServers
 import type { UnifiedMcpRegistryServer } from "../config/mcp-registry.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { HUD_TMUX_HEIGHT_LINES, HUD_TMUX_MIN_LAUNCH_WINDOW_HEIGHT_LINES, isTmuxWindowTooCrampedForHudSplit } from "../hud/constants.js";
-import { OMX_TMUX_HUD_OWNER_ENV } from "../hud/reconcile.js";
+import { OMX_TMUX_HUD_OWNER_ENV, teardownManagedHudPane } from "../hud/reconcile.js";
 import { readUltragoalState } from "../hud/state.js";
 import {
   buildHudRuntimeEnv,
@@ -359,6 +359,7 @@ const TEAM_INHERIT_LEADER_FLAGS_ENV = "OMX_TEAM_INHERIT_LEADER_FLAGS";
 const OMX_BYPASS_DEFAULT_SYSTEM_PROMPT_ENV = "OMX_BYPASS_DEFAULT_SYSTEM_PROMPT";
 const OMX_MODEL_INSTRUCTIONS_FILE_ENV = "OMX_MODEL_INSTRUCTIONS_FILE";
 const OMX_INSTANCE_OPTION = "@omx_instance_id";
+const OMX_PANE_INSTANCE_OPTION = "@omx_pane_instance_id";
 const OMX_RALPH_APPEND_INSTRUCTIONS_FILE_ENV =
   "OMX_RALPH_APPEND_INSTRUCTIONS_FILE";
 const OMX_AUTORESEARCH_APPEND_INSTRUCTIONS_FILE_ENV =
@@ -3577,21 +3578,32 @@ function tagTmuxSessionWithInstance(sessionName: string, sessionId: string): voi
   });
 }
 
-function tagCurrentTmuxSessionWithInstance(sessionId: string): void {
-  if (!process.env.TMUX) return;
+async function establishCurrentTmuxInstanceBinding(sessionId: string): Promise<ActualTmuxInstanceEvidence | null> {
+  if (!process.env.TMUX || !process.env.TMUX_PANE) return null;
+  const paneTarget = process.env.TMUX_PANE.trim();
+  if (!paneTarget) return null;
   try {
-    const tmuxPaneTarget = process.env.TMUX_PANE;
-    const displayArgs = tmuxPaneTarget
-      ? ["display-message", "-p", "-t", tmuxPaneTarget, "#S"]
-      : ["display-message", "-p", "#S"];
-    const sessionName = execFileSync("tmux", displayArgs, {
-      encoding: "utf-8",
-      stdio: ["ignore", "pipe", "ignore"],
+    const readContext = (): string => execFileSync(
+      "tmux",
+      ["display-message", "-p", "-t", paneTarget, "#{session_name}:#{window_index} #{pane_id}"],
+      { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"], timeout: 2000 },
+    ).trim();
+    const before = readContext();
+    const [sessionAndWindow = "", livePaneId = ""] = before.split(" ");
+    const sessionName = sessionAndWindow.split(":")[0]?.trim() ?? "";
+    if (!sessionName || livePaneId.trim() !== paneTarget) return null;
+    tagTmuxSessionWithInstance(sessionName, sessionId);
+    execFileSync("tmux", ["set-option", "-p", "-t", paneTarget, OMX_PANE_INSTANCE_OPTION, sessionId], {
+      stdio: ["ignore", "ignore", "ignore"],
       timeout: 2000,
-    }).trim();
-    if (sessionName) tagTmuxSessionWithInstance(sessionName, sessionId);
+    });
+    const evidence = await probeActualTmuxInstanceEvidence(paneTarget);
+    if (readContext() !== before || evidence.sessionName !== sessionName || !tmuxEvidenceBindsCandidate(evidence, sessionId)) {
+      return null;
+    }
+    return evidence;
   } catch {
-    // Best effort only: launch should not fail just because tmux tagging failed.
+    return null;
   }
 }
 
@@ -5015,9 +5027,8 @@ export async function preLaunch(
   // Persist the exact binding only after the canonical pointer has committed. A
   // managed attached launch must bind the persisted owner to the exact pane and
   // session instance before a hook can reconcile its HUD.
-  tagCurrentTmuxSessionWithInstance(sessionId);
-  const tmuxBinding = await probeActualTmuxInstanceEvidence(process.env.TMUX_PANE);
-  if (tmuxEvidenceBindsCandidate(tmuxBinding, sessionId)) {
+  const tmuxBinding = await establishCurrentTmuxInstanceBinding(sessionId);
+  if (tmuxBinding) {
     await writeSessionStart(cwd, sessionId, {
       ...(tmuxBinding.sessionName ? { tmuxSessionName: tmuxBinding.sessionName } : {}),
       ...(tmuxBinding.paneTarget ? { tmuxPaneId: tmuxBinding.paneTarget } : {}),
@@ -5230,9 +5241,18 @@ async function runCodex(
       }
     }
 
-    withTmuxExtendedKeys(cwd, () => {
-      runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
-    });
+    try {
+      withTmuxExtendedKeys(cwd, () => {
+        runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
+      });
+    } finally {
+      if (currentPaneId) {
+        await teardownManagedHudPane(cwd, {
+          env: { ...process.env, ...hudRuntimeEnv, TMUX_PANE: currentPaneId },
+          sessionId,
+        });
+      }
+    }
     return { postLaunchHandledExternally: false };
   } else if (launchPolicy === "direct") {
     // Detached HUD sessions require tmux. Skip the bootstrap entirely when the

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1935,6 +1935,8 @@ export function prependOmxRuntimeCommandShimToEnv(
 export interface DetachedSessionTmuxStep {
   name: string;
   args: string[];
+  appliedReceipt?: string;
+  rejectedReceipt?: string;
 }
 
 export function buildHudPaneCleanupTargets(
@@ -3573,6 +3575,10 @@ function escapeTmuxFormatLiteral(value: string): string {
   return value.replace(/[#{},:]/g, (character) => `#${character}`);
 }
 
+class TmuxLifecycleAuthorityError extends Error {
+  readonly failClosed = true;
+}
+
 /**
  * Establishes opaque tmux births exactly once. The logical Codex session id is
  * deliberately not a tmux birth: it can be replayed after tmux has recycled a
@@ -3610,28 +3616,59 @@ export async function establishCurrentTmuxInstanceBinding(
         `set-option -p -t ${quoteShellArg(paneTarget)} ${OMX_PANE_INSTANCE_OPTION} ${quoteShellArg(paneBirth)}`,
         `display-message -p ${appliedReceipt}`,
       ].join(" \\; ");
-      const receipt = execFileSync("tmux", [
-        "if-shell", "-t", paneTarget, "-F", condition, publish,
-        `display-message -p ${rejectedReceipt}`,
-      ], {
-        encoding: "utf-8",
-        stdio: ["ignore", "pipe", "ignore"],
-        timeout: 2000,
-      }).split("\n").map((line) => line.trim());
-      if (receipt.includes(appliedReceipt)) {
-        // This invocation published its complete opaque pair.
-      } else if (receipt.includes(rejectedReceipt)) {
-        const winning = await probeActualTmuxInstanceEvidence(paneTarget);
-        if (!winning.contextStable || winning.paneTarget !== paneTarget
-          || winning.sessionName !== sessionName
-          || winning.sessionId !== before.sessionId
-          || winning.windowId !== before.windowId
-          || !winning.sessionInstanceId || !winning.paneInstanceId
-          || winning.sessionInstanceId === winning.paneInstanceId
-          || winning.sessionTagStatus !== "present" || winning.paneTagStatus !== "present") return null;
-        sessionBirth = winning.sessionInstanceId;
-        paneBirth = winning.paneInstanceId;
-      } else return null;
+      try {
+        const receipt = execFileSync("tmux", [
+          "if-shell", "-t", paneTarget, "-F", condition, publish,
+          `display-message -p ${rejectedReceipt}`,
+        ], {
+          encoding: "utf-8",
+          stdio: ["ignore", "pipe", "ignore"],
+          timeout: 2000,
+        }).split("\n").map((line) => line.trim());
+        if (receipt.includes(appliedReceipt)) {
+          // This invocation published its complete opaque pair.
+        } else if (receipt.includes(rejectedReceipt)) {
+          const winning = await probeActualTmuxInstanceEvidence(paneTarget);
+          if (!winning.contextStable || winning.paneTarget !== paneTarget
+            || winning.sessionName !== sessionName
+            || winning.sessionId !== before.sessionId
+            || winning.windowId !== before.windowId
+            || !winning.sessionInstanceId || !winning.paneInstanceId
+            || winning.sessionInstanceId === winning.paneInstanceId
+            || winning.sessionTagStatus !== "present" || winning.paneTagStatus !== "present") return null;
+          sessionBirth = winning.sessionInstanceId;
+          paneBirth = winning.paneInstanceId;
+        } else {
+          throw new TmuxLifecycleAuthorityError("tmux birth publication returned no receipt");
+        }
+      } catch (error) {
+        if (error instanceof TmuxLifecycleAuthorityError) throw error;
+        const compensationAppliedReceipt = `__omx_birth_compensation_applied_${randomUUID()}__`;
+        const compensationRejectedReceipt = `__omx_birth_compensation_rejected_${randomUUID()}__`;
+        const compensationCondition = `#{&&:#{==:#{session_name},${escapeTmuxFormatLiteral(sessionName)}},#{==:#{${OMX_INSTANCE_OPTION}},${escapeTmuxFormatLiteral(sessionBirth)}},#{==:#{${OMX_PANE_INSTANCE_OPTION}},}}`;
+        let compensationReceipt: string[];
+        try {
+          compensationReceipt = execFileSync("tmux", [
+            "if-shell", "-t", paneTarget, "-F", compensationCondition,
+            `set-option -u -t ${quoteShellArg(sessionName)} ${OMX_INSTANCE_OPTION} \\; display-message -p ${compensationAppliedReceipt}`,
+            `display-message -p ${compensationRejectedReceipt}`,
+          ], {
+            encoding: "utf-8",
+            stdio: ["ignore", "pipe", "ignore"],
+            timeout: 2000,
+          }).split("\n").map((line) => line.trim());
+        } catch {
+          throw new TmuxLifecycleAuthorityError("tmux birth publication failed and exact compensation is uncertain");
+        }
+        if (!compensationReceipt.includes(compensationAppliedReceipt)) {
+          throw new TmuxLifecycleAuthorityError(
+            compensationReceipt.includes(compensationRejectedReceipt)
+              ? "tmux birth publication failed and exact compensation was rejected"
+              : "tmux birth publication failed and compensation returned no receipt",
+          );
+        }
+        throw new TmuxLifecycleAuthorityError("tmux birth publication failed and was compensated");
+      }
     }
 
     const after = await probeActualTmuxInstanceEvidence(paneTarget);
@@ -3646,7 +3683,8 @@ export async function establishCurrentTmuxInstanceBinding(
       || after.sessionTagStatus !== "present"
       || after.paneTagStatus !== "present") return null;
     return after;
-  } catch {
+  } catch (error) {
+    if (error instanceof TmuxLifecycleAuthorityError) throw error;
     return null;
   }
 }
@@ -4580,6 +4618,8 @@ export function buildDetachedSessionRollbackSteps(
         `kill-session -t ${quoteShellArg(sessionName)} \\; display-message -p ${appliedReceipt}`,
         `display-message -p ${rejectedReceipt}`,
       ],
+      appliedReceipt,
+      rejectedReceipt,
     });
   }
   return steps;
@@ -5379,7 +5419,7 @@ async function runCodex(
         return { postLaunchHandledExternally: true };
       }
       if (activeRecordPath && activeRecord) {
-        rmSync(activeRecordPath, { force: true });
+        throw new TmuxLifecycleAuthorityError("madmax detached recovery record is not reusable; preserving it without exact release evidence");
       }
 
       let detachedSessionBindingWrite: Promise<unknown> = Promise.resolve();
@@ -5527,12 +5567,7 @@ async function runCodex(
         }
         return { postLaunchHandledExternally: !nativeWindows };
       } catch (err) {
-        if (detachedParentEnvFilePath) {
-          rmSync(detachedParentEnvFilePath, { force: true });
-        }
-        if (activeRecordPath) {
-          rmSync(activeRecordPath, { force: true });
-        }
+        let rollbackApplied = !createdDetachedSession;
         if (createdDetachedSession) {
           const rollbackSteps = buildDetachedSessionRollbackSteps(
             sessionName,
@@ -5543,12 +5578,36 @@ async function runCodex(
           );
           for (const rollbackStep of rollbackSteps) {
             try {
-              execTmuxFileSync(rollbackStep.args, { stdio: "ignore" });
+              const output = execTmuxFileSync(rollbackStep.args, {
+                stdio: rollbackStep.appliedReceipt ? "pipe" : "ignore",
+                encoding: rollbackStep.appliedReceipt ? "utf-8" : undefined,
+              });
+              if (rollbackStep.appliedReceipt) {
+                const receipt = (output || "").split("\n").map((line) => line.trim());
+                rollbackApplied = receipt.includes(rollbackStep.appliedReceipt);
+                if (!rollbackApplied) {
+                  throw new TmuxLifecycleAuthorityError(
+                    receipt.includes(rollbackStep.rejectedReceipt ?? "")
+                      ? "detached tmux rollback was rejected; preserving recovery state"
+                      : "detached tmux rollback returned no receipt; preserving recovery state",
+                  );
+                }
+              }
             } catch (rollbackErr) {
               logCliOperationFailure(rollbackErr);
-              // best-effort rollback only
+              if (rollbackErr instanceof TmuxLifecycleAuthorityError) throw rollbackErr;
+              throw new TmuxLifecycleAuthorityError("detached tmux rollback is uncertain; preserving recovery state");
             }
           }
+          if (!rollbackApplied) {
+            throw new TmuxLifecycleAuthorityError("detached tmux rollback lacks applied evidence; preserving recovery state");
+          }
+        }
+        if (detachedParentEnvFilePath) {
+          rmSync(detachedParentEnvFilePath, { force: true });
+        }
+        if (activeRecordPath) {
+          rmSync(activeRecordPath, { force: true });
         }
         throw err;
       }
@@ -5562,11 +5621,11 @@ async function runCodex(
       }
       return await launchDetachedSession();
     } catch (err) {
-      if (err instanceof MadmaxDetachedReuseError || err instanceof MadmaxDetachedGuardError) {
+      if (err instanceof MadmaxDetachedReuseError || err instanceof MadmaxDetachedGuardError || err instanceof TmuxLifecycleAuthorityError) {
         throw err;
       }
       logCliOperationFailure(err);
-      // tmux not available or failed, just run codex directly
+      // tmux not available or failed before creating a managed session, just run codex directly
       runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
       return { postLaunchHandledExternally: false };
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3578,29 +3578,27 @@ function tagTmuxSessionWithInstance(sessionName: string, sessionId: string): voi
   });
 }
 
-async function establishCurrentTmuxInstanceBinding(sessionId: string): Promise<ActualTmuxInstanceEvidence | null> {
-  if (!process.env.TMUX || !process.env.TMUX_PANE) return null;
-  const paneTarget = process.env.TMUX_PANE.trim();
+async function establishCurrentTmuxInstanceBinding(
+  sessionId: string,
+  paneId: string | undefined = process.env.TMUX_PANE,
+  expectedSessionName?: string,
+): Promise<ActualTmuxInstanceEvidence | null> {
+  const paneTarget = paneId?.trim() ?? '';
   if (!paneTarget) return null;
   try {
-    const readContext = (): string => execFileSync(
+    const sessionName = expectedSessionName?.trim() || execFileSync(
       "tmux",
-      ["display-message", "-p", "-t", paneTarget, "#{session_name}:#{window_index} #{pane_id}"],
+      ["display-message", "-p", "-t", paneTarget, "#S"],
       { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"], timeout: 2000 },
     ).trim();
-    const before = readContext();
-    const [sessionAndWindow = "", livePaneId = ""] = before.split(" ");
-    const sessionName = sessionAndWindow.split(":")[0]?.trim() ?? "";
-    if (!sessionName || livePaneId.trim() !== paneTarget) return null;
+    if (!sessionName) return null;
     tagTmuxSessionWithInstance(sessionName, sessionId);
     execFileSync("tmux", ["set-option", "-p", "-t", paneTarget, OMX_PANE_INSTANCE_OPTION, sessionId], {
       stdio: ["ignore", "ignore", "ignore"],
       timeout: 2000,
     });
     const evidence = await probeActualTmuxInstanceEvidence(paneTarget);
-    if (readContext() !== before || evidence.sessionName !== sessionName || !tmuxEvidenceBindsCandidate(evidence, sessionId)) {
-      return null;
-    }
+    if (evidence.sessionName !== sessionName || !tmuxEvidenceBindsCandidate(evidence, sessionId)) return null;
     return evidence;
   } catch {
     return null;
@@ -5328,6 +5326,7 @@ async function runCodex(
       let registeredClientAttachedHookName: string | null = null;
       let detachedParentEnvFilePath: string | undefined;
       let detachedLeaderPaneId: string | null = null;
+      let detachedHudEvidenceVerified = false;
       try {
         // This path is the user-shell interactive launch: OMX creates a tmux
         // session and immediately attaches the user's terminal to it. If a tmux
@@ -5365,7 +5364,7 @@ async function runCodex(
             // The persisted session binding and tmux instance tag are both in
             // place before the shared reconciler is permitted to mutate panes.
             await detachedSessionBindingWrite;
-            if (detachedLeaderPaneId) {
+            if (detachedLeaderPaneId && detachedHudEvidenceVerified) {
               await reconcileManagedHudPane(cwd, sessionId, detachedLeaderPaneId, hudRuntimeEnv);
             }
             const finalizeSteps = buildDetachedSessionFinalizeSteps(
@@ -5429,6 +5428,11 @@ async function runCodex(
                 });
               }
               writeDetachedSessionBinding(leaderPaneId);
+              detachedHudEvidenceVerified = await establishCurrentTmuxInstanceBinding(
+                sessionId,
+                leaderPaneId,
+                sessionName,
+              ) !== null;
             }
           }
         }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -158,19 +158,9 @@ import { HUD_TMUX_HEIGHT_LINES, HUD_TMUX_MIN_LAUNCH_WINDOW_HEIGHT_LINES, isTmuxW
 import { OMX_TMUX_HUD_OWNER_ENV } from "../hud/reconcile.js";
 import { readUltragoalState } from "../hud/state.js";
 import {
-  createHudWatchPane as createSharedHudWatchPane,
-  killTmuxPane as killSharedTmuxPane,
-  listCurrentWindowHudPaneIds,
-  listCurrentWindowPanes,
   buildHudRuntimeEnv,
   parsePaneIdFromTmuxOutput,
-  reapDeadHudPanes,
-  registerHudResizeHook,
   OMX_TMUX_HUD_LEADER_PANE_ENV,
-  type RegisterHudResizeHookOptions,
-  readCurrentWindowSize,
-  resizeTmuxPane,
-  unregisterHudResizeHook,
 } from "../hud/tmux.js";
 
 export { parseTmuxPaneSnapshot, isHudWatchPane, findHudWatchPaneIds } from "../hud/tmux.js";
@@ -1416,119 +1406,6 @@ function execTmuxFileSync(
   }) as string;
 }
 
-function readTmuxEnvValueForTarget(targetPaneId: string): string | undefined {
-  if (!targetPaneId.startsWith("%")) return undefined;
-  try {
-    const raw = execTmuxFileSync(
-      ["display-message", "-p", "-t", targetPaneId, "#{socket_path},#{pid},#{session_id}"],
-      { encoding: "utf-8" },
-    ).trim();
-    return raw.replace(/,\$(\d+)$/, ",$1") || undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-type HudResizeHookRegistrar = (
-  hudPaneId: string,
-  leaderPaneId: string | undefined,
-  heightLines: number,
-  options?: RegisterHudResizeHookOptions,
-) => boolean;
-
-export function buildInsideTmuxHudHookEnv(
-  baseEnv: NodeJS.ProcessEnv,
-  sessionId: string,
-  currentPaneId: string | undefined,
-  omxRootOverride?: string,
-): NodeJS.ProcessEnv {
-  return {
-    ...baseEnv,
-    OMX_SESSION_ID: sessionId,
-    [OMX_TMUX_HUD_OWNER_ENV]: "1",
-    ...(currentPaneId ? { [OMX_TMUX_HUD_LEADER_PANE_ENV]: currentPaneId } : {}),
-    ...(omxRootOverride ? { OMX_ROOT: omxRootOverride } : {}),
-  };
-}
-
-export function registerInsideTmuxHudResizeHook(options: {
-  hudPaneId: string | null;
-  currentPaneId: string | undefined;
-  cwd: string;
-  sessionId: string;
-  omxRootOverride?: string;
-  baseEnv?: NodeJS.ProcessEnv;
-  register?: HudResizeHookRegistrar;
-}): boolean {
-  const { hudPaneId, currentPaneId } = options;
-  if (!hudPaneId || !currentPaneId) return false;
-  return (options.register ?? registerHudResizeHook)(
-    hudPaneId,
-    currentPaneId,
-    HUD_TMUX_HEIGHT_LINES,
-    {
-      cwd: options.cwd,
-      env: buildInsideTmuxHudHookEnv(
-        options.baseEnv ?? process.env,
-        options.sessionId,
-        currentPaneId,
-        options.omxRootOverride,
-      ),
-    },
-  );
-}
-
-export function buildDetachedHudHookEnv(
-  baseEnv: NodeJS.ProcessEnv,
-  sessionId: string,
-  detachedLeaderPaneId: string,
-  tmuxEnvValue: string,
-  omxBin: string,
-  omxRootOverride?: string,
-): NodeJS.ProcessEnv {
-  return {
-    ...baseEnv,
-    TMUX: tmuxEnvValue,
-    TMUX_PANE: detachedLeaderPaneId,
-    OMX_SESSION_ID: sessionId,
-    [OMX_TMUX_HUD_OWNER_ENV]: "1",
-    ...(omxRootOverride ? { OMX_ROOT: omxRootOverride } : {}),
-    OMX_ENTRY_PATH: omxBin,
-  };
-}
-
-export function registerDetachedHudLayoutReconcileHook(options: {
-  hudPaneId: string | null;
-  detachedLeaderPaneId: string | null;
-  cwd: string;
-  sessionId: string;
-  omxBin: string;
-  omxRootOverride?: string;
-  baseEnv?: NodeJS.ProcessEnv;
-  readTmuxEnvValue?: (targetPaneId: string) => string | undefined;
-  register?: HudResizeHookRegistrar;
-}): boolean {
-  const { hudPaneId, detachedLeaderPaneId } = options;
-  if (!hudPaneId || !detachedLeaderPaneId) return false;
-  const tmuxEnvValue = (options.readTmuxEnvValue ?? readTmuxEnvValueForTarget)(detachedLeaderPaneId);
-  if (!tmuxEnvValue) return false;
-  return (options.register ?? registerHudResizeHook)(
-    hudPaneId,
-    detachedLeaderPaneId,
-    HUD_TMUX_HEIGHT_LINES,
-    {
-      cwd: options.cwd,
-      env: buildDetachedHudHookEnv(
-        options.baseEnv ?? process.env,
-        options.sessionId,
-        detachedLeaderPaneId,
-        tmuxEnvValue,
-        options.omxBin,
-        options.omxRootOverride,
-      ),
-    },
-  );
-}
 
 export const DETACHED_TMUX_HISTORY_LIMIT = 500;
 const TMUX_HOOK_INDEX_MAX = 1_000_000;
@@ -3353,7 +3230,7 @@ export async function launchWithHud(args: string[]): Promise<void> {
     const notifyTempContractRaw = notifyTempResult.contract.active
       ? serializeNotifyTempContract(notifyTempResult.contract)
       : null;
-    const launchResult = runCodex(
+    const launchResult = await runCodex(
       cwd,
       normalizedArgs,
       sessionId,
@@ -4391,7 +4268,7 @@ export function buildDetachedSessionBootstrapSteps(
   sessionName: string,
   cwd: string,
   codexCmd: string,
-  hudCmd: string,
+  _hudCmd: string,
   workerLaunchArgs: string | null,
   codexHomeOverride?: string,
   notifyTempContractRaw?: string | null,
@@ -4461,21 +4338,6 @@ export function buildDetachedSessionBootstrapSteps(
     ...(inheritedWorkerModel ? ["-e", `${TEAM_WORKER_INHERITED_MODEL_ENV}=${inheritedWorkerModel}`] : []),
     detachedLeaderCmd,
   ];
-  const splitCaptureArgs: string[] = [
-    "split-window",
-    "-v",
-    "-l",
-    String(HUD_TMUX_HEIGHT_LINES),
-    "-d",
-    "-t",
-    sessionName,
-    "-c",
-    cwd,
-    "-P",
-    "-F",
-    "#{pane_id}",
-    hudCmd,
-  ];
   return [
     { name: "new-session", args: newSessionArgs },
     ...(sessionId
@@ -4486,7 +4348,7 @@ export function buildDetachedSessionBootstrapSteps(
           },
         ]
       : []),
-    { name: "split-and-capture-hud-pane", args: splitCaptureArgs },
+    { name: "reconcile-managed-hud", args: [] },
   ];
 }
 
@@ -5137,7 +4999,20 @@ export async function preLaunch(
   }
 
   // 2. Establish the canonical pointer before any session-scoped launch artifact.
+  // Pointer validation must complete before attached-launch tmux metadata is mutated.
   await writeSessionStart(cwd, sessionId, await resolvePreLaunchSessionPointerOptions());
+
+  // Persist the exact binding only after the canonical pointer has committed. A
+  // managed attached launch must bind the persisted owner to the exact pane and
+  // session instance before a hook can reconcile its HUD.
+  tagCurrentTmuxSessionWithInstance(sessionId);
+  const tmuxBinding = await probeActualTmuxInstanceEvidence(process.env.TMUX_PANE);
+  if (tmuxEvidenceBindsCandidate(tmuxBinding, sessionId)) {
+    await writeSessionStart(cwd, sessionId, {
+      ...(tmuxBinding.sessionName ? { tmuxSessionName: tmuxBinding.sessionName } : {}),
+      ...(tmuxBinding.paneTarget ? { tmuxPaneId: tmuxBinding.paneTarget } : {}),
+    });
+  }
 
   // 3. Generate runtime overlay + write session-scoped model instructions file
   const orchestrationMode = await resolveSessionOrchestrationMode(
@@ -5157,9 +5032,8 @@ ${launchAppendix}${dirtyWorktreeGuidance}`
       : `${overlay}${dirtyWorktreeGuidance}`;
   await writeSessionModelInstructionsFile(cwd, sessionId, sessionInstructions);
 
-  // 4. Reset session metrics and tag the established session.
+  // 4. Reset session metrics.
   await resetSessionMetrics(cwd, sessionId);
-  tagCurrentTmuxSessionWithInstance(sessionId);
 
   // 5. Start notify fallback watcher (best effort)
   try {
@@ -5229,7 +5103,7 @@ ${launchAppendix}${dirtyWorktreeGuidance}`
  * runCodex: Launch Codex CLI (blocks until exit).
  * All 3 paths (new tmux, existing tmux, no tmux) block via execSync/execFileSync.
  */
-function runCodex(
+async function runCodex(
   cwd: string,
   args: string[],
   sessionId: string,
@@ -5241,7 +5115,7 @@ function runCodex(
   projectLocalCodexHomeForCleanup?: string,
   runtimeCodexHomeForCleanup?: string,
   runtimeContext?: MadmaxWorktreeRuntimeContext,
-): { postLaunchHandledExternally: boolean } {
+): Promise<{ postLaunchHandledExternally: boolean }> {
   const launchArgs = injectModelInstructionsBypassArgs(
     cwd,
     args,
@@ -5321,73 +5195,10 @@ function runCodex(
   }
 
   if (launchPolicy === "inside-tmux") {
-    // Already in tmux: launch codex in current pane, HUD in bottom split
-    const currentWindowPanes = currentPaneId ? listCurrentWindowPanes(undefined, currentPaneId) : [];
-    reapDeadHudPanes(currentWindowPanes, {
-      killPane: (paneId) => {
-        try {
-          return killSharedTmuxPane(paneId);
-        } catch (err) {
-          logCliOperationFailure(err);
-          return false;
-        }
-      },
-    });
-
-    const staleHudPaneIds = currentPaneId
-      ? listHudWatchPaneIdsInCurrentWindow(currentPaneId, { sessionId, leaderPaneId: currentPaneId })
-      : [];
-
-    let hudPaneId: string | null = null;
-    const [keeperHudPaneId, ...duplicateHudPaneIds] = staleHudPaneIds;
-    for (const paneId of duplicateHudPaneIds) {
-      killTmuxPane(paneId);
-    }
-
-    if (keeperHudPaneId) {
-      hudPaneId = keeperHudPaneId;
-      try {
-        resizeTmuxPane(hudPaneId, HUD_TMUX_HEIGHT_LINES);
-        registerInsideTmuxHudResizeHook({
-          hudPaneId,
-          currentPaneId,
-          cwd,
-          sessionId,
-          omxRootOverride,
-          baseEnv: runtimeHookEnv,
-        });
-      } catch (err) {
-        logCliOperationFailure(err);
-      }
-    } else if (
-      isExistingTmuxWindowTooCrampedForLaunchHud(
-        readCurrentWindowSize(undefined, currentPaneId).height,
-      )
-    ) {
-      // Existing tmux window is height-constrained: forcing a launch-time HUD
-      // split here would steal rows from the Codex TUI and make the
-      // transcript/input area unreadable. Skip the split at launch; the
-      // prompt-submit reconcile path can add the HUD later when there is room.
-      // (closes #2754)
-      hudPaneId = null;
-    } else {
-      try {
-        hudPaneId = createHudWatchPane(cwd, hudCmd, {
-          heightLines: HUD_TMUX_HEIGHT_LINES,
-          targetPaneId: currentPaneId,
-        });
-        registerInsideTmuxHudResizeHook({
-          hudPaneId,
-          currentPaneId,
-          cwd,
-          sessionId,
-          omxRootOverride,
-          baseEnv: runtimeHookEnv,
-        });
-      } catch (err) {
-        logCliOperationFailure(err);
-        // HUD split failed, continue without it
-      }
+    // The shared reconciler owns all managed HUD inspection, dedupe, resize, and
+    // creation. A failed or uncertain proof deliberately leaves panes untouched.
+    if (currentPaneId) {
+      await reconcileManagedHudPane(cwd, sessionId, currentPaneId, hudRuntimeEnv);
     }
 
     // Enable mouse scrolling at session start so scroll works before team
@@ -5409,32 +5220,9 @@ function runCodex(
       }
     }
 
-    const activePaneId = process.env.TMUX_PANE?.trim();
-    if (activePaneId) {
-      try {
-        execTmuxFileSync(["display-message", "-p", "-t", activePaneId, "#S"], {
-          encoding: "utf-8",
-        });
-      } catch {}
-    }
-
-    try {
-      withTmuxExtendedKeys(cwd, () => {
-        runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
-      });
-    } finally {
-      if (currentPaneId) {
-        unregisterHudResizeHook(currentPaneId);
-      }
-      const cleanupPaneIds = buildHudPaneCleanupTargets(
-        listHudWatchPaneIdsInCurrentWindow(currentPaneId, { sessionId, leaderPaneId: currentPaneId }),
-        hudPaneId,
-        currentPaneId,
-      );
-      for (const paneId of cleanupPaneIds) {
-        killTmuxPane(paneId);
-      }
-    }
+    withTmuxExtendedKeys(cwd, () => {
+      runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
+    });
     return { postLaunchHandledExternally: false };
   } else if (launchPolicy === "direct") {
     // Detached HUD sessions require tmux. Skip the bootstrap entirely when the
@@ -5448,7 +5236,7 @@ function runCodex(
       ? buildWindowsPromptCommand("codex", launchArgs)
       : null;
     const sessionName = buildDetachedTmuxSessionName(cwd, sessionId);
-    const launchDetachedSession = (): { postLaunchHandledExternally: boolean } => {
+    const launchDetachedSession = async (): Promise<{ postLaunchHandledExternally: boolean }> => {
       const contextKey = runtimeContext?.madmaxDetachedContext ?? process.env[OMX_MADMAX_DETACHED_CONTEXT_ENV]?.trim();
       const runsRoot = resolveMadmaxRunsRoot(process.env);
       const activeRecordPath = contextKey
@@ -5580,47 +5368,24 @@ function runCodex(
               writeDetachedSessionBinding(leaderPaneId);
             }
           }
-          if (step.name === "split-and-capture-hud-pane") {
-            const hudPaneId = parsePaneIdFromTmuxOutput(output || "");
-            const hookWindowIndex = hudPaneId
-              ? detectDetachedSessionWindowIndex(sessionName)
-              : null;
-            const hookTarget =
-              hudPaneId && hookWindowIndex
-                ? buildResizeHookTarget(sessionName, hookWindowIndex)
-                : null;
-            const hookName =
-              hudPaneId && hookWindowIndex
-                ? buildResizeHookName(
-                    "launch",
-                    sessionName,
-                    hookWindowIndex,
-                    hudPaneId,
-                  )
-                : null;
-            const clientAttachedHookName =
-              hudPaneId && hookWindowIndex
-                ? buildClientAttachedReconcileHookName(
-                    "launch",
-                    sessionName,
-                    hookWindowIndex,
-                    hudPaneId,
-                  )
-                : null;
+          if (step.name === "reconcile-managed-hud") {
+            // The persisted session binding and tmux instance tag are both in
+            // place before the shared reconciler is permitted to mutate panes.
+            await detachedSessionBindingWrite;
+            if (detachedLeaderPaneId) {
+              await reconcileManagedHudPane(cwd, sessionId, detachedLeaderPaneId, hudRuntimeEnv);
+            }
             const finalizeSteps = buildDetachedSessionFinalizeSteps(
               sessionName,
-              hudPaneId,
-              hookWindowIndex,
+              null,
+              null,
               process.env.OMX_MOUSE !== "0",
               nativeWindows,
               shouldAttachDetachedTmuxSession(process.env),
               detachedLeaderPaneId,
             );
             if (nativeWindows && detachedWindowsCodexCmd) {
-              scheduleDetachedWindowsCodexLaunch(
-                sessionName,
-                detachedWindowsCodexCmd,
-              );
+              scheduleDetachedWindowsCodexLaunch(sessionName, detachedWindowsCodexCmd);
             }
             for (const finalizeStep of finalizeSteps) {
               if (finalizeStep.name === "sanitize-copy-mode-style") {
@@ -5631,48 +5396,16 @@ function runCodex(
                 }
                 continue;
               }
-              const stdio =
-                finalizeStep.name === "attach-session" ? "inherit" : "ignore";
+              const stdio = finalizeStep.name === "attach-session" ? "inherit" : "ignore";
               try {
                 const startedAtMs = Date.now();
                 execTmuxFileSync(finalizeStep.args, { stdio });
                 if (finalizeStep.name === "attach-session") {
-                  assertDetachedAttachDidNotNoop(
-                    sessionName,
-                    Date.now() - startedAtMs,
-                    process.env,
-                  );
+                  assertDetachedAttachDidNotNoop(sessionName, Date.now() - startedAtMs, process.env);
                 }
               } catch (err) {
                 logCliOperationFailure(err);
-                if (finalizeStep.name === "attach-session")
-                  throw new Error("failed to attach detached tmux session");
-                continue;
-              }
-              if (
-                finalizeStep.name === "register-resize-hook" &&
-                hookTarget &&
-                hookName
-              ) {
-                registeredHookTarget = hookTarget;
-                registeredHookName = hookName;
-              }
-              if (
-                finalizeStep.name === "register-client-attached-reconcile" &&
-                clientAttachedHookName
-              ) {
-                registeredClientAttachedHookName = clientAttachedHookName;
-              }
-              if (finalizeStep.name === "reconcile-hud-resize") {
-                registerDetachedHudLayoutReconcileHook({
-                  hudPaneId,
-                  detachedLeaderPaneId,
-                  cwd,
-                  sessionId,
-                  omxBin,
-                  omxRootOverride,
-                  baseEnv: runtimeHookEnv,
-                });
+                if (finalizeStep.name === "attach-session") throw new Error("failed to attach detached tmux session");
               }
             }
           }
@@ -5709,9 +5442,9 @@ function runCodex(
     const runsRoot = resolveMadmaxRunsRoot(process.env);
     try {
       if (isMadmaxDetachedGuardEnabled(process.env) && contextKey) {
-        return withMadmaxDetachedContextLock(runsRoot, contextKey, launchDetachedSession);
+        return await withMadmaxDetachedContextLock(runsRoot, contextKey, launchDetachedSession);
       }
-      return launchDetachedSession();
+      return await launchDetachedSession();
     } catch (err) {
       if (err instanceof MadmaxDetachedReuseError || err instanceof MadmaxDetachedGuardError) {
         throw err;
@@ -5724,15 +5457,64 @@ function runCodex(
   }
 }
 
-function listHudWatchPaneIdsInCurrentWindow(
-  currentPaneId?: string,
-  owner: { sessionId?: string; leaderPaneId?: string } = {},
-): string[] {
+async function reconcileManagedHudPane(
+  cwd: string,
+  sessionId: string,
+  leaderPaneId: string,
+  runtimeEnv: NodeJS.ProcessEnv,
+): Promise<void> {
+  const omxBin = resolveOmxCliEntryPath({ argv1: process.argv[1], cwd, env: process.env });
+  if (!omxBin) return;
+
+  let tmuxEnv = process.env.TMUX;
+  if (!tmuxEnv) {
+    try {
+      const socketPath = execTmuxFileSync([
+        "display-message", "-p", "-t", leaderPaneId, "#{socket_path}",
+      ], { encoding: "utf-8" }).trim();
+      if (socketPath) tmuxEnv = `${socketPath},0,0`;
+    } catch {
+      return;
+    }
+  }
+  if (!tmuxEnv) return;
+
+  const {
+    OMX_ROOT: _omxRoot,
+    OMX_STATE_ROOT: _omxStateRoot,
+    OMX_TEAM_STATE_ROOT: _omxTeamStateRoot,
+    ...parentEnv
+  } = process.env;
+  const {
+    OMX_ROOT: runtimeOmxRoot,
+    OMX_STATE_ROOT: runtimeStateRoot,
+    OMX_TEAM_STATE_ROOT: runtimeTeamStateRoot,
+    ...runtimeEnvWithoutRoots
+  } = runtimeEnv;
+  const authoritativeRootEnv = runtimeTeamStateRoot
+    ? { OMX_TEAM_STATE_ROOT: runtimeTeamStateRoot }
+    : runtimeOmxRoot
+      ? { OMX_ROOT: runtimeOmxRoot }
+      : runtimeStateRoot
+        ? { OMX_STATE_ROOT: runtimeStateRoot }
+        : {};
   try {
-    return listCurrentWindowHudPaneIds(currentPaneId, undefined, owner);
-  } catch (err) {
-    logCliOperationFailure(err);
-    return [];
+    execFileSync(process.execPath, [omxBin, "hud", "--reconcile-tmux"], {
+      cwd,
+      env: {
+        ...parentEnv,
+        ...runtimeEnvWithoutRoots,
+        ...authoritativeRootEnv,
+        TMUX: tmuxEnv,
+        TMUX_PANE: leaderPaneId,
+        OMX_SESSION_ID: sessionId,
+        [OMX_TMUX_HUD_OWNER_ENV]: "1",
+        [OMX_TMUX_HUD_LEADER_PANE_ENV]: leaderPaneId,
+      },
+      stdio: "ignore",
+    });
+  } catch {
+    // Reconciliation is fail-closed: never substitute an unlocked split/reap.
   }
 }
 
@@ -5748,26 +5530,6 @@ export function isExistingTmuxWindowTooCrampedForLaunchHud(
   return isTmuxWindowTooCrampedForHudSplit(windowHeight, minWindowHeight);
 }
 
-function createHudWatchPane(
-  cwd: string,
-  hudCmd: string,
-  options: { heightLines?: number; targetPaneId?: string } = {},
-): string | null {
-  return createSharedHudWatchPane(cwd, hudCmd, {
-    heightLines: options.heightLines ?? HUD_TMUX_HEIGHT_LINES,
-    targetPaneId: options.targetPaneId,
-  });
-}
-
-function killTmuxPane(paneId: string): void {
-  if (!paneId.startsWith("%")) return;
-  try {
-    killSharedTmuxPane(paneId);
-  } catch (err) {
-    logCliOperationFailure(err);
-    // Pane may already be gone; ignore.
-  }
-}
 
 export function buildTmuxShellCommand(command: string, args: string[]): string {
   return [quoteShellArg(command), ...args.map(quoteShellArg)].join(" ");

--- a/src/cli/native-hook-claim-journal.ts
+++ b/src/cli/native-hook-claim-journal.ts
@@ -47,8 +47,22 @@ async function fsyncDirectory(path: string): Promise<void> {
 	}
 }
 
+export function isUnsupportedDirectorySyncError(error: unknown): boolean {
+	if (typeof error !== "object" || error === null || !("code" in error)) return false;
+	const code = (error as { code?: unknown }).code;
+	return code === "EPERM" || code === "EINVAL" || code === "ENOTSUP" || code === "EOPNOTSUPP";
+}
+
+async function fsyncDirectoryAfterRename(path: string): Promise<void> {
+	try {
+		await fsyncDirectory(path);
+	} catch (error) {
+		if (!isUnsupportedDirectorySyncError(error)) throw error;
+	}
+}
+
 export async function syncNativeHookClaimParent(path: string): Promise<void> {
-	await fsyncDirectory(dirname(path));
+	await fsyncDirectoryAfterRename(dirname(path));
 }
 
 export async function restoreNativeHookClaimNoClobber(

--- a/src/cli/native-hook-claim-journal.ts
+++ b/src/cli/native-hook-claim-journal.ts
@@ -93,7 +93,7 @@ export async function restoreNativeHookClaimNoClobber(
 	} finally {
 		await destinationHandle.close();
 	}
-	await fsyncDirectory(dirname(destinationPath));
+	await fsyncDirectoryAfterRename(dirname(destinationPath));
 	const [currentClaimStat, currentClaimBytes, destinationBytes, destinationStat] = await Promise.all([
 		lstat(claimPath),
 		readFile(claimPath),
@@ -110,7 +110,7 @@ export async function restoreNativeHookClaimNoClobber(
 		throw new Error(`Native hook claim changed during restore: ${claimPath}.`);
 	}
 	await rm(claimPath);
-	await fsyncDirectory(dirname(claimPath));
+	await fsyncDirectoryAfterRename(dirname(claimPath));
 }
 
 async function readRegularBytes(path: string): Promise<Buffer | null> {
@@ -152,7 +152,7 @@ export async function persistNativeHookClaimJournal(
 	if (directoryStat.isSymbolicLink() || !directoryStat.isDirectory()) {
 		throw new Error(`Native hook claim journal directory is unsafe: ${directory}`);
 	}
-	if (directoryCreated) await fsyncDirectory(dirname(directory));
+	if (directoryCreated) await fsyncDirectoryAfterRename(dirname(directory));
 	const path = journalPath(root);
 	const payload: ClaimJournalEntry = {
 		version: 1,
@@ -172,14 +172,14 @@ export async function persistNativeHookClaimJournal(
 		throw error;
 	}
 	await handle.close();
-	await fsyncDirectory(directory);
+	await fsyncDirectoryAfterRename(directory);
 }
 
 export async function clearNativeHookClaimJournal(root: string): Promise<void> {
 	const path = journalPath(root);
 	try {
 		await rm(path);
-		await fsyncDirectory(dirname(path));
+		await fsyncDirectoryAfterRename(dirname(path));
 	} catch (error) {
 		if (!isMissing(error)) throw error;
 	}
@@ -228,7 +228,7 @@ export async function recoverNativeHookClaimJournal(root: string): Promise<boole
 				throw new Error("Native hook claim journal cannot finalize a linked restore with changed bytes.");
 			}
 			await rm(parsed.claimPath);
-			await fsyncDirectory(dirname(parsed.claimPath));
+			await fsyncDirectoryAfterRename(dirname(parsed.claimPath));
 			await clearNativeHookClaimJournal(root);
 			return true;
 		}
@@ -264,7 +264,7 @@ export async function recoverNativeHookClaimJournal(root: string): Promise<boole
 	}
 	if (parsed.afterHash !== null && digest(canonical) === parsed.afterHash) {
 		await rm(parsed.claimPath);
-		await fsyncDirectory(dirname(parsed.claimPath));
+		await fsyncDirectoryAfterRename(dirname(parsed.claimPath));
 		await clearNativeHookClaimJournal(root);
 		return true;
 	}

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1703,6 +1703,9 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
     const resolvedName = resolveTeamNameForCurrentContext(name, cwd);
     const configBeforeShutdown = await readTeamConfig(resolvedName, cwd);
     const summary = await shutdownTeam(resolvedName, cwd, { force, confirmIssues });
+    if (!summary.complete) {
+      throw new Error(`Team shutdown incomplete: ${name}; resources and recovery metadata were preserved`);
+    }
     await persistTeamShutdownModeState(
       resolvedName,
       cwd,

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -9,6 +9,7 @@ import { randomUUID } from 'node:crypto';
 import { initTeamState, enqueueDispatchRequest, readDispatchRequest } from '../../team/state.js';
 import { buildTmuxSessionName, buildWindowsMsysBackgroundHelperBootstrapScript } from '../../cli/index.js';
 import { writeSessionStart } from '../session.js';
+import { resolveHudControlPlaneDomain } from '../../mcp/state-paths.js';
 
 const DEFAULT_AUTO_NUDGE_RESPONSE = 'continue with the current task only if it is already authorized';
 const INHERITED_OMX_ENV_KEYS = [
@@ -466,6 +467,38 @@ function buildCleanNotifyEnv(
     TMUX: '',
     TMUX_PANE: '',
     ...overrides,
+  };
+}
+
+async function buildAuthorityAdmissionEnv(cwd: string, overrides: Record<string, string> = {}): Promise<NodeJS.ProcessEnv> {
+  const env = buildCleanNotifyEnv(overrides);
+  const domain = await resolveHudControlPlaneDomain({ cwd, env });
+  const identity = 'authority-test-identity';
+  await mkdir(domain.baseStateDir, { recursive: true });
+  await writeFile(domain.authorityLeasePath, JSON.stringify({
+    version: 2,
+    domainKey: domain.domainKey,
+    baseStateDir: domain.baseStateDir,
+    rootSource: domain.rootSource,
+    pid: process.pid,
+    platform: process.platform,
+    processStartIdentity: identity,
+    claimant: JSON.stringify(domain.claimant),
+    token: 'authority-test-token',
+    generation: 'authority-test-generation',
+    heartbeatAt: new Date().toISOString(),
+  }));
+  return {
+    ...env,
+    OMX_HUD_AUTHORITY_DOMAIN_KEY: domain.domainKey,
+    OMX_HUD_AUTHORITY_BASE_STATE_DIR: domain.baseStateDir,
+    OMX_HUD_AUTHORITY_ROOT_SOURCE: domain.rootSource,
+    OMX_HUD_AUTHORITY_LEASE_PATH: domain.authorityLeasePath,
+    OMX_HUD_AUTHORITY_LEASE_TOKEN: 'authority-test-token',
+    OMX_HUD_AUTHORITY_LEASE_GENERATION: 'authority-test-generation',
+    OMX_HUD_AUTHORITY_OWNER_PID: String(process.pid),
+    OMX_HUD_AUTHORITY_OWNER_PLATFORM: process.platform,
+    OMX_HUD_AUTHORITY_OWNER_START_IDENTITY: identity,
   };
 }
 
@@ -955,7 +988,7 @@ describe('notify-fallback watcher', () => {
       const result = spawnSync(
         process.execPath,
         [watcherScript, '--once', '--authority-only', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
-        { encoding: 'utf-8', env: buildCleanNotifyEnv() },
+        { encoding: 'utf-8', env: await buildAuthorityAdmissionEnv(wd) },
       );
       assert.equal(result.status, 0, result.stderr || result.stdout);
 
@@ -971,6 +1004,25 @@ describe('notify-fallback watcher', () => {
       const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
       const logContent = await readFile(logPath, 'utf-8').catch(() => '');
       assert.equal(logContent.trim(), '');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed before registration when an authority-only child lacks an owner identity', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-authority-missing-identity-'));
+    try {
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const result = spawnSync(
+        process.execPath,
+        [watcherScript, '--once', '--authority-only', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+        { encoding: 'utf-8', env: buildCleanNotifyEnv() },
+      );
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.equal(await readFile(join(wd, '.omx', 'state', 'notify-fallback-state.json'), 'utf8').then(() => true).catch(() => false), false);
+      assert.equal(await readFile(join(wd, '.omx', 'state', 'notify-fallback.pid'), 'utf8').then(() => true).catch(() => false), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -1004,7 +1056,7 @@ describe('notify-fallback watcher', () => {
       const result = spawnSync(
         process.execPath,
         [watcherScript, '--once', '--authority-only', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
-        { encoding: 'utf-8', env: buildCleanNotifyEnv() },
+        { encoding: 'utf-8', env: await buildAuthorityAdmissionEnv(wd) },
       );
       assert.equal(result.status, 0, result.stderr || result.stdout);
 
@@ -1065,7 +1117,7 @@ describe('notify-fallback watcher', () => {
         [watcherScript, '--once', '--authority-only', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
         {
           encoding: 'utf-8',
-          env: buildCleanNotifyEnv({
+          env: await buildAuthorityAdmissionEnv(wd, {
             PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
             CODEX_HOME: codexHome,
             OMX_SESSION_ID: 'sess-managed-fallback',
@@ -1130,7 +1182,7 @@ describe('notify-fallback watcher', () => {
         [watcherScript, '--once', '--authority-only', '--cwd', aliasWd, '--notify-script', notifyHook, '--poll-ms', '50'],
         {
           encoding: 'utf-8',
-          env: buildCleanNotifyEnv({
+          env: await buildAuthorityAdmissionEnv(aliasWd, {
             PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
             OMX_SESSION_ID: 'sess-cwd-alias',
             TMUX: '1',
@@ -3692,7 +3744,7 @@ exit 0
         {
           cwd: wd,
           encoding: 'utf-8',
-          env: buildCleanNotifyEnv({ HOME: tempHome }),
+          env: await buildAuthorityAdmissionEnv(wd, { HOME: tempHome }),
         },
       );
 
@@ -4451,95 +4503,79 @@ exit 0
     }
   });
 
-  it('replaces a stale watcher from the per-cwd pid file', async () => {
-    const replacementTimeoutMs = 20000; // c8-instrumented Node20 full runs can delay watcher handoff well beyond 8s.
-    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-stale-pid-'));
-    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-stale-home-'));
+  it('replaces a proven dead watcher record from the per-cwd pid file', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-dead-pid-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-dead-home-'));
     const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
     const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
     const pidPath = join(wd, '.omx', 'state', 'notify-fallback.pid');
-    let first: ReturnType<typeof spawn> | undefined;
-    let second: ReturnType<typeof spawn> | undefined;
+    let child: ReturnType<typeof spawn> | undefined;
 
     try {
-      first = spawn(
-        process.execPath,
-        [
-          watcherScript,
-          '--cwd',
-          wd,
-          '--notify-script',
-          notifyHook,
-          '--poll-ms',
-          '50',
-          '--parent-pid',
-          String(process.pid),
-          '--max-lifetime-ms',
-          '5000',
-        ],
-        {
-          cwd: wd,
-          stdio: 'ignore',
-          env: buildCleanNotifyEnv({ HOME: tempHome }),
-        }
-      );
-      assert.ok(first.pid, 'expected first watcher pid');
+      const deadProcess = spawn(process.execPath, ['-e', 'process.exit(0)']);
+      const deadPid = deadProcess.pid;
+      await once(deadProcess, 'exit');
+      assert.ok(deadPid, 'expected a dead process pid');
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(pidPath, JSON.stringify({ pid: deadPid }));
+
+      child = spawn(process.execPath, [
+        watcherScript,
+        '--cwd', wd,
+        '--notify-script', notifyHook,
+        '--poll-ms', '50',
+        '--parent-pid', String(process.pid),
+        '--max-lifetime-ms', '5000',
+      ], { cwd: wd, stdio: 'ignore', env: buildCleanNotifyEnv({ HOME: tempHome }) });
+      assert.ok(child.pid, 'expected replacement watcher pid');
 
       await waitFor(async () => {
         try {
           const pidFile = JSON.parse(await readFile(pidPath, 'utf-8')) as { pid?: number; owner_token?: string };
-          assert.match(pidFile.owner_token ?? '', /^\d+-\d+-/, 'pid file should include an ownership token');
-          return pidFile.pid === first?.pid;
+          assert.match(pidFile.owner_token ?? '', /^\d+-\d+-/, 'replacement pid file should include ownership metadata');
+          return pidFile.pid === child?.pid;
         } catch {
           return false;
         }
-      }, replacementTimeoutMs, 50);
-
-      second = spawn(
-        process.execPath,
-        [
-          watcherScript,
-          '--cwd',
-          wd,
-          '--notify-script',
-          notifyHook,
-          '--poll-ms',
-          '50',
-          '--parent-pid',
-          String(process.pid),
-          '--max-lifetime-ms',
-          '5000',
-        ],
-        {
-          cwd: wd,
-          stdio: 'ignore',
-          env: buildCleanNotifyEnv({ HOME: tempHome }),
-        }
-      );
-      assert.ok(second.pid, 'expected second watcher pid');
-
-      await waitForExit(first, replacementTimeoutMs);
-      assert.equal(first.exitCode, 0);
-
-      await waitFor(async () => {
-        try {
-          const pidFile = JSON.parse(await readFile(pidPath, 'utf-8')) as { pid?: number; owner_token?: string };
-          assert.match(pidFile.owner_token ?? '', /^\d+-\d+-/, 'replacement pid file should keep ownership metadata');
-          return pidFile.pid === second?.pid;
-        } catch {
-          return false;
-        }
-      }, replacementTimeoutMs, 50);
-
-      assert.ok(isPidAlive(second.pid), 'expected replacement watcher to remain alive');
+      });
+      assert.ok(isPidAlive(child.pid), 'expected replacement watcher to remain alive');
     } finally {
-      if (second && isPidAlive(second.pid)) {
-        second.kill('SIGTERM');
-        await waitForExit(second, replacementTimeoutMs).catch(() => {});
+      if (child && isPidAlive(child.pid)) {
+        child.kill('SIGTERM');
+        await waitForExit(child).catch(() => {});
       }
-      if (first && isPidAlive(first.pid)) {
-        first.kill('SIGTERM');
-        await waitForExit(first, replacementTimeoutMs).catch(() => {});
+      await rm(wd, { recursive: true, force: true });
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed for a live legacy pid record without starting a watcher', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-live-legacy-pid-'));
+    const tempHome = await mkdtemp(join(tmpdir(), 'omx-fallback-live-legacy-home-'));
+    const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+    const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+    const pidPath = join(wd, '.omx', 'state', 'notify-fallback.pid');
+    let watcher: ReturnType<typeof spawn> | undefined;
+
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(pidPath, `${process.pid}\n`);
+
+      watcher = spawn(process.execPath, [
+        watcherScript,
+        '--cwd', wd,
+        '--notify-script', notifyHook,
+        '--poll-ms', '50',
+      ], { stdio: 'ignore', env: buildCleanNotifyEnv({ HOME: tempHome }) });
+      await waitForExit(watcher);
+      assert.equal(watcher.exitCode, 0);
+      assert.ok(isPidAlive(process.pid), 'live legacy pid must not be signaled');
+      assert.equal(await readFile(pidPath, 'utf-8'), `${process.pid}\n`, 'live legacy record must not be overwritten');
+      assert.equal(await readFile(join(wd, '.omx', 'state', 'notify-fallback-state.json'), 'utf-8').catch(() => ''), '');
+    } finally {
+      if (watcher && isPidAlive(watcher.pid)) {
+        watcher.kill('SIGTERM');
+        await waitForExit(watcher).catch(() => {});
       }
       await rm(wd, { recursive: true, force: true });
       await rm(tempHome, { recursive: true, force: true });

--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -499,6 +499,7 @@ async function buildAuthorityAdmissionEnv(cwd: string, overrides: Record<string,
     OMX_HUD_AUTHORITY_OWNER_PID: String(process.pid),
     OMX_HUD_AUTHORITY_OWNER_PLATFORM: process.platform,
     OMX_HUD_AUTHORITY_OWNER_START_IDENTITY: identity,
+    OMX_HUD_AUTHORITY_CLAIMANT: JSON.stringify(domain.claimant),
   };
 }
 
@@ -1009,6 +1010,25 @@ describe('notify-fallback watcher', () => {
     }
   });
 
+  it('fails closed on missing, stale, or mismatched serialized authority claimant evidence', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-authority-claimant-'));
+    try {
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const admitted = await buildAuthorityAdmissionEnv(wd);
+      for (const claimant of ['', '{"sessionId":"stale"}', '{"sessionId":"other","leaderPaneId":"%1","tmuxSessionName":"wrong","tmuxSessionInstanceId":"birth","tmuxPaneInstanceId":"birth"}']) {
+        const env = { ...admitted, OMX_HUD_AUTHORITY_CLAIMANT: claimant };
+        const result = spawnSync(process.execPath,
+          [watcherScript, '--once', '--authority-only', '--cwd', wd, '--notify-script', notifyHook, '--poll-ms', '50'],
+          { encoding: 'utf-8', env });
+        assert.equal(result.status, 0, result.stderr || result.stdout);
+        assert.equal(await readFile(join(wd, '.omx', 'state', 'notify-fallback-state.json'), 'utf8').then(() => true).catch(() => false), false);
+      }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('fails closed before registration when an authority-only child lacks an owner identity', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-authority-missing-identity-'));
     try {
@@ -1075,7 +1095,7 @@ describe('notify-fallback watcher', () => {
     }
   });
 
-  it('backs off authority-only nudge ticks when the primary watcher is healthy', async () => {
+  it('fails closed before authority backoff when managed claimant birth evidence is absent', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-authority-backed-off-'));
     const fakeBinDir = join(wd, 'fake-bin');
     const tmuxLogPath = join(wd, 'tmux.log');
@@ -1135,9 +1155,7 @@ describe('notify-fallback watcher', () => {
       const watcherState = JSON.parse(await readFile(join(wd, '.omx', 'state', 'notify-fallback-state.json'), 'utf-8'));
       assert.equal(watcherState.pid, process.pid, 'authority backoff should preserve the primary watcher state owner');
       assert.equal(watcherState.authority_only, false, 'authority backoff should not overwrite primary watcher ownership');
-      assert.equal(watcherState.authority_backoff?.active, true);
-      assert.equal(watcherState.authority_backoff?.reason, 'primary_watcher_healthy');
-      assert.equal(watcherState.authority_backoff?.primary_pid, process.pid);
+      assert.equal(watcherState.authority_backoff, undefined);
       assert.match(watcherState.dispatch_drain?.last_tick_at ?? '', /^\d{4}-\d{2}-\d{2}T/);
 
       const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
@@ -1150,7 +1168,7 @@ describe('notify-fallback watcher', () => {
 
 
 
-  it('treats symlinked cwd aliases as the same primary watcher during authority handoff', async () => {
+  it('fails closed on a symlinked managed cwd when claimant birth evidence is absent', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-cwd-alias-'));
     const aliasWd = `${wd}-alias`;
     const fakeBinDir = join(wd, 'fake-bin');
@@ -1193,9 +1211,7 @@ describe('notify-fallback watcher', () => {
       assert.equal(result.status, 0, result.stderr || result.stdout);
 
       const watcherState = JSON.parse(await readFile(join(wd, '.omx', 'state', 'notify-fallback-state.json'), 'utf-8'));
-      assert.equal(watcherState.authority_backoff?.active, true);
-      assert.equal(watcherState.authority_backoff?.reason, 'primary_watcher_healthy');
-      assert.equal(watcherState.authority_backoff?.primary_pid, process.pid);
+      assert.equal(watcherState.authority_backoff, undefined);
     } finally {
       await rm(aliasWd, { recursive: true, force: true });
       await rm(wd, { recursive: true, force: true });

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -361,6 +361,7 @@ describe('session lifecycle manager', () => {
       assert.equal(withoutPane.native_session_id, 'codex-native-1');
       assert.equal(withoutPane.tmux_session_name, 'omx-detached-demo');
       assert.equal(withoutPane.tmux_pane_id, '%42');
+      assert.equal(withPane.started_at, withoutPane.started_at);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -1351,6 +1351,7 @@ function startPointerTransition(
       previousNativeSessionId: options.previousNativeSessionId ?? existing?.previous_native_session_id,
       nativeSessionSwitchedAt: options.nativeSessionSwitchedAt ?? existing?.native_session_switched_at,
       ...(ownerOmxSessionId ? { ownerOmxSessionId } : {}),
+      startedAt: existing?.started_at,
       tmuxSessionName: options.tmuxSessionName ?? existing?.tmux_session_name,
       tmuxPaneId: options.tmuxPaneId ?? existing?.tmux_pane_id,
     });

--- a/src/hud/__tests__/authority.test.ts
+++ b/src/hud/__tests__/authority.test.ts
@@ -1,10 +1,31 @@
 import assert from 'node:assert/strict';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import { runHudAuthorityTick } from '../authority.js';
+import { resolveHudControlPlaneDomain, type ResolvedHudControlPlaneDomain } from '../../mcp/state-paths.js';
+
+function domain(baseStateDir: string, domainKey: string, cwd: string): ResolvedHudControlPlaneDomain {
+  return {
+    version: 1,
+    cwd,
+    baseStateDir,
+    rootSource: 'cwd-default',
+    domainKey,
+    authorityStatePath: join(baseStateDir, 'hud-authority-state.json'),
+    authorityLeasePath: join(baseStateDir, 'hud-authority-lease.json'),
+    authorityLockPath: join(baseStateDir, 'hud-authority.lock'),
+    reconcileLockPath: join(baseStateDir, 'hud-reconcile.lock'),
+    claimant: {},
+    managed: false,
+  };
+}
+
+async function resolvedDomain(cwd: string, env?: NodeJS.ProcessEnv): Promise<ResolvedHudControlPlaneDomain> {
+  return resolveHudControlPlaneDomain({ cwd, env: { ...process.env, ...env } });
+}
 
 describe('runHudAuthorityTick', () => {
   it('writes a live HUD authority owner lease before ticking', async () => {
@@ -15,13 +36,69 @@ describe('runHudAuthorityTick', () => {
         { runProcess: async () => {} },
       );
 
-      const lease = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'notify-fallback-authority-owner.json'), 'utf-8'));
-      assert.equal(lease.owner, 'hud');
+      const resolved = await resolvedDomain(cwd);
+      const lease = JSON.parse(await readFile(resolved.authorityLeasePath, 'utf-8'));
+      assert.equal(lease.version, 2);
+      assert.equal(lease.domainKey, resolved.domainKey);
+      assert.equal(lease.baseStateDir, resolved.baseStateDir);
+      assert.equal(lease.rootSource, resolved.rootSource);
       assert.equal(lease.pid, process.pid);
-      assert.equal(lease.cwd, cwd);
-      assert.ok(typeof lease.heartbeat_at === 'string' && lease.heartbeat_at.length > 0);
+      assert.equal(lease.platform, process.platform);
+      assert.ok(typeof lease.processStartIdentity === 'string' && lease.processStartIdentity.length > 0);
+      assert.ok(typeof lease.token === 'string' && lease.token.length > 0);
+      assert.ok(typeof lease.generation === 'string' && lease.generation.length > 0);
+      assert.ok(typeof lease.heartbeatAt === 'string' && lease.heartbeatAt.length > 0);
     } finally {
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed without a current process start identity', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-no-identity-'));
+    let calls = 0;
+    try {
+      await runHudAuthorityTick(
+        { cwd, nodePath: '/node', packageRoot: '/pkg' },
+        {
+          processStartIdentity: async () => undefined,
+          runProcess: async () => { calls += 1; },
+        },
+      );
+
+      assert.equal(calls, 0);
+      assert.equal(existsSync((await resolvedDomain(cwd)).authorityLeasePath), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('requires an exact current identity before renewing an owned lease', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-hud-authority-identity-renewal-'));
+    const shared = domain(join(root, 'state'), 'hud-control-plane:identity-renewal', '/claimant');
+    try {
+      await mkdir(shared.baseStateDir, { recursive: true });
+      await writeFile(shared.authorityLeasePath, JSON.stringify({
+        version: 2, domainKey: shared.domainKey, baseStateDir: shared.baseStateDir, rootSource: shared.rootSource,
+        pid: process.pid, platform: process.platform, processStartIdentity: 'previous-identity', claimant: '{}',
+        token: 'owner-token', generation: 'owner-generation', heartbeatAt: new Date(1_000).toISOString(),
+      }));
+
+      await runHudAuthorityTick(
+        { cwd: '/claimant', nodePath: '/node', packageRoot: '/pkg', minIntervalMs: 5_000, jitterMs: 0 },
+        {
+          nowMs: () => 2_000,
+          resolveDomain: async () => shared,
+          processStartIdentity: async () => 'current-identity',
+          probeLeaseProcess: async () => 'live',
+          runProcess: async () => assert.fail('mismatched owner identity must not renew or spawn'),
+        },
+      );
+
+      const preserved = JSON.parse(await readFile(shared.authorityLeasePath, 'utf8'));
+      assert.equal(preserved.token, 'owner-token');
+      assert.equal(preserved.processStartIdentity, 'previous-identity');
+    } finally {
+      await rm(root, { recursive: true, force: true });
     }
   });
 
@@ -63,8 +140,8 @@ describe('runHudAuthorityTick', () => {
       );
 
       assert.equal(invoked, true);
-      const lease = JSON.parse(readFileSync(join(liveMarkerCwd, '.omx', 'state', 'notify-fallback-authority-owner.json'), 'utf-8'));
-      assert.equal(lease.cwd, liveMarkerCwd);
+      const lease = JSON.parse(readFileSync((await resolvedDomain(liveMarkerCwd)).authorityLeasePath, 'utf-8'));
+      assert.equal(lease.domainKey, (await resolvedDomain(liveMarkerCwd)).domainKey);
     } finally {
       rmSync(parent, { recursive: true, force: true });
     }
@@ -113,11 +190,12 @@ describe('runHudAuthorityTick', () => {
       assert.equal(call.args[7], '--poll-ms');
       assert.equal(call.args[8], '75');
       assert.equal(call.options.cwd, cwd);
-      assert.equal(call.options.timeoutMs, 4321);
+      assert.equal(call.options.timeoutMs, 1_000);
       assert.equal(call.options.env.OMX_HUD_AUTHORITY, '1');
       assert.equal(call.options.env.OMX_HUD_AUTHORITY_MIN_INTERVAL_MS, '5000');
       assert.equal(call.options.env.OMX_HUD_AUTHORITY_JITTER_MS, '250');
       assert.equal(call.options.env.CUSTOM_ENV, '1');
+      assert.ok(typeof call.options.env.OMX_HUD_AUTHORITY_OWNER_START_IDENTITY === 'string' && call.options.env.OMX_HUD_AUTHORITY_OWNER_START_IDENTITY.length > 0);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -209,7 +287,7 @@ describe('runHudAuthorityTick', () => {
       );
 
       assert.equal(calls.length, 1, 'second HUD frame should not respawn an authority-only child');
-      const state = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'notify-fallback-authority-state.json'), 'utf-8'));
+      const state = JSON.parse(await readFile((await resolvedDomain(cwd)).authorityStatePath, 'utf-8'));
       assert.equal(state.last_status, 'skipped');
       assert.equal(state.last_reason, 'rate_limited');
       assert.equal(state.skip_count, 1);
@@ -244,7 +322,7 @@ describe('runHudAuthorityTick', () => {
       }
 
       assert.equal(calls, 2);
-      const state = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'notify-fallback-authority-state.json'), 'utf-8'));
+      const state = JSON.parse(await readFile((await resolvedDomain(cwd)).authorityStatePath, 'utf-8'));
       assert.equal(state.last_status, 'spawned');
       assert.equal(state.last_spawn_at, new Date(7_000).toISOString());
       assert.equal(state.next_allowed_at, new Date(12_000).toISOString());
@@ -255,7 +333,7 @@ describe('runHudAuthorityTick', () => {
 
   it('preserves cooldown when a contender observes the rate limit only after taking the lock', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-race-'));
-    const statePath = join(cwd, '.omx', 'state', 'notify-fallback-authority-state.json');
+    const statePath = (await resolvedDomain(cwd)).authorityStatePath;
     let calls = 0;
     try {
       await runHudAuthorityTick(
@@ -300,7 +378,7 @@ describe('runHudAuthorityTick', () => {
       assert.equal(calls, 1, 'contender should re-check cooldown after locking and skip spawning');
       const state = JSON.parse(await readFile(statePath, 'utf-8'));
       assert.equal(state.last_status, 'skipped');
-      assert.equal(state.last_reason, 'rate_limited_after_lock');
+      assert.equal(state.last_reason, 'rate_limited');
       assert.equal(state.next_allowed_at, new Date(6_000).toISOString());
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -309,10 +387,10 @@ describe('runHudAuthorityTick', () => {
 
   it('does not let a lock loser overwrite canonical cooldown diagnostics', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-lock-loser-'));
-    const stateDir = join(cwd, '.omx', 'state');
-    const statePath = join(stateDir, 'notify-fallback-authority-state.json');
-    const ownerPath = join(stateDir, 'notify-fallback-authority-owner.json');
-    const lockPath = join(stateDir, 'notify-fallback-authority.lock');
+    const resolved = await resolvedDomain(cwd);
+    const stateDir = resolved.baseStateDir;
+    const statePath = resolved.authorityStatePath;
+    const lockPath = resolved.authorityLockPath;
     const canonicalState = {
       owner: 'hud',
       pid: process.pid,
@@ -348,12 +426,8 @@ describe('runHudAuthorityTick', () => {
         },
       );
 
-      const state = JSON.parse(await readFile(statePath, 'utf-8'));
-      assert.equal(state.last_status, 'spawned');
-      assert.equal(state.next_allowed_at, canonicalState.next_allowed_at);
-      const owner = JSON.parse(await readFile(ownerPath, 'utf-8'));
-      assert.equal(owner.last_status, 'locked');
-      assert.equal(owner.last_reason, 'spawn_lock_active');
+      assert.deepEqual(JSON.parse(await readFile(statePath, 'utf-8')), canonicalState);
+      assert.equal(existsSync(resolved.authorityLeasePath), false, 'lock loser must not write a lease');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -361,7 +435,7 @@ describe('runHudAuthorityTick', () => {
 
   it('does not release a lock that was replaced by a newer owner', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-token-release-'));
-    const lockPath = join(cwd, '.omx', 'state', 'notify-fallback-authority.lock');
+    const lockPath = (await resolvedDomain(cwd)).authorityLockPath;
     let calls = 0;
     try {
       await runHudAuthorityTick(
@@ -397,13 +471,21 @@ describe('runHudAuthorityTick', () => {
 
   it('reaps a stale authority lock before acquiring a fresh lock', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-stale-lock-'));
-    const lockPath = join(cwd, '.omx', 'state', 'notify-fallback-authority.lock');
+    const resolved = await resolvedDomain(cwd);
+    const lockPath = resolved.authorityLockPath;
     let calls = 0;
     try {
       await mkdir(lockPath, { recursive: true });
-      await writeFile(join(lockPath, 'owner.json'), JSON.stringify({ token: 'stale-owner' }, null, 2));
-      const staleDate = new Date(1_000);
-      await utimes(lockPath, staleDate, staleDate);
+      await writeFile(join(lockPath, 'owner.json'), JSON.stringify({
+        version: 1,
+        token: 'stale-owner',
+        generation: 'stale-generation',
+        domainKey: resolved.domainKey,
+        pid: 999_999_999,
+        platform: process.platform,
+        processStartIdentity: 'stale-process',
+        acquiredAt: new Date(1_000).toISOString(),
+      }, null, 2));
 
       await runHudAuthorityTick(
         {
@@ -415,8 +497,12 @@ describe('runHudAuthorityTick', () => {
           timeoutMs: 1_000,
         },
         {
-          nowMs: () => 10_000,
+          nowMs: () => 11_000,
           random: () => 0,
+          lifecycleLockDeps: {
+            processStartIdentity: async () => 'current-process',
+            probeProcess: async () => 'dead',
+          },
           runProcess: async () => {
             calls += 1;
           },
@@ -425,15 +511,15 @@ describe('runHudAuthorityTick', () => {
 
       assert.equal(calls, 1);
       assert.equal(existsSync(lockPath), false, 'fresh authority lock should be released after successful spawn');
-      const state = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'notify-fallback-authority-state.json'), 'utf-8'));
+      const state = JSON.parse(await readFile(resolved.authorityStatePath, 'utf-8'));
       assert.equal(state.last_status, 'spawned');
-      assert.equal(state.next_allowed_at, new Date(15_000).toISOString());
+      assert.equal(state.next_allowed_at, new Date(16_000).toISOString());
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
-  it('fails closed before spawning when the rate-limit state cannot be persisted', async () => {
+  it('fails closed before spawning when authority persistence fails', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-persist-failure-'));
     let calls = 0;
     try {
@@ -449,16 +535,13 @@ describe('runHudAuthorityTick', () => {
           nowMs: () => 1_000,
           random: () => 0,
           onLockAcquired: async () => {
-            await rm(join(cwd, '.omx', 'state'), { recursive: true, force: true });
-            await writeFile(join(cwd, '.omx', 'state'), 'not a directory');
+            await rm((await resolvedDomain(cwd)).baseStateDir, { recursive: true, force: true });
+            await writeFile((await resolvedDomain(cwd)).baseStateDir, 'not a directory');
           },
           runProcess: async () => {
             calls += 1;
           },
         },
-      ).then(
-        () => assert.fail('expected persistence failure'),
-        (error) => assert.match(String(error), /failed to persist HUD authority rate-limit state/),
       );
 
       assert.equal(calls, 0, 'authority child should not spawn without durable rate-limit state');
@@ -469,8 +552,9 @@ describe('runHudAuthorityTick', () => {
 
   it('fails closed without spawning when the authority state is unreadable', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-invalid-state-'));
-    const stateDir = join(cwd, '.omx', 'state');
-    const statePath = join(stateDir, 'notify-fallback-authority-state.json');
+    const resolved = await resolvedDomain(cwd);
+    const stateDir = resolved.baseStateDir;
+    const statePath = resolved.authorityStatePath;
     let calls = 0;
     try {
       await mkdir(stateDir, { recursive: true });
@@ -529,8 +613,9 @@ describe('runHudAuthorityTick', () => {
 
   it('fails closed without spawning when the authority state has an invalid shape', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-authority-invalid-shape-'));
-    const stateDir = join(cwd, '.omx', 'state');
-    const statePath = join(stateDir, 'notify-fallback-authority-state.json');
+    const resolved = await resolvedDomain(cwd);
+    const stateDir = resolved.baseStateDir;
+    const statePath = resolved.authorityStatePath;
     let calls = 0;
     try {
       await mkdir(stateDir, { recursive: true });
@@ -629,6 +714,140 @@ describe('runHudAuthorityTick', () => {
       );
     } finally {
       rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+  it('permits only one concurrent claimant for a shared canonical domain without secondary writes', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-hud-authority-domain-'));
+    const shared = domain(join(root, 'state'), 'hud-control-plane:shared', '/claimant-a');
+    let calls = 0;
+    let releasePrimary: (() => void) | undefined;
+    const primaryStarted = new Promise<void>((resolve) => {
+      releasePrimary = resolve;
+    });
+    const first = runHudAuthorityTick(
+      { cwd: '/claimant-a', nodePath: '/node', packageRoot: '/pkg', minIntervalMs: 5_000, jitterMs: 0 },
+      {
+        nowMs: () => 1_000,
+        resolveDomain: async () => shared,
+        runProcess: async () => {
+          calls += 1;
+          await primaryStarted;
+        },
+      },
+    );
+    try {
+      while (calls === 0) await new Promise((resolve) => setTimeout(resolve, 0));
+      await runHudAuthorityTick(
+        { cwd: '/claimant-b', nodePath: '/node', packageRoot: '/pkg', minIntervalMs: 5_000, jitterMs: 0 },
+        {
+          nowMs: () => 1_000,
+          resolveDomain: async () => ({ ...shared, cwd: '/claimant-b', claimant: { leaderPaneId: '%2' } }),
+          runProcess: async () => assert.fail('secondary claimant must not spawn'),
+        },
+      );
+      assert.equal(calls, 1);
+      const state = JSON.parse(await readFile(shared.authorityStatePath, 'utf8'));
+      assert.equal(state.last_status, 'spawned');
+    } finally {
+      releasePrimary?.();
+      await first;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('takes over only a stale lease with proven reused process identity', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-hud-authority-stale-lease-'));
+    const shared = domain(join(root, 'state'), 'hud-control-plane:stale', '/claimant');
+    let calls = 0;
+    try {
+      await mkdir(shared.baseStateDir, { recursive: true });
+      await writeFile(shared.authorityLeasePath, JSON.stringify({
+        version: 2, domainKey: shared.domainKey, baseStateDir: shared.baseStateDir, rootSource: shared.rootSource,
+        pid: 4242, platform: process.platform, processStartIdentity: 'linux:old', claimant: '{}',
+        token: 'old-token', generation: 'old-generation', heartbeatAt: new Date(1_000).toISOString(),
+      }));
+      await runHudAuthorityTick(
+        { cwd: '/claimant', nodePath: '/node', packageRoot: '/pkg', minIntervalMs: 5_000, jitterMs: 0 },
+        { nowMs: () => 20_000, resolveDomain: async () => shared, processStartIdentity: async () => 'linux:current', probeLeaseProcess: async () => 'reused', runProcess: async () => { calls += 1; } },
+      );
+      assert.equal(calls, 1);
+      const replacement = JSON.parse(await readFile(shared.authorityLeasePath, 'utf8'));
+      assert.notEqual(replacement.token, 'old-token');
+      assert.notEqual(replacement.generation, 'old-generation');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('takes over a stale lease when its owner PID is proven dead', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-hud-authority-dead-lease-'));
+    const shared = domain(join(root, 'state'), 'hud-control-plane:dead', '/claimant');
+    let calls = 0;
+    try {
+      await mkdir(shared.baseStateDir, { recursive: true });
+      await writeFile(shared.authorityLeasePath, JSON.stringify({
+        version: 2, domainKey: shared.domainKey, baseStateDir: shared.baseStateDir, rootSource: shared.rootSource,
+        pid: 4242, platform: process.platform, processStartIdentity: 'dead-identity', claimant: '{}',
+        token: 'dead-token', generation: 'dead-generation', heartbeatAt: new Date(1_000).toISOString(),
+      }));
+
+      await runHudAuthorityTick(
+        { cwd: '/claimant', nodePath: '/node', packageRoot: '/pkg', minIntervalMs: 5_000, jitterMs: 0 },
+        {
+          nowMs: () => 20_000,
+          resolveDomain: async () => shared,
+          processStartIdentity: async () => 'current-identity',
+          probeLeaseProcess: async () => 'dead',
+          runProcess: async () => { calls += 1; },
+        },
+      );
+
+      assert.equal(calls, 1);
+      const replacement = JSON.parse(await readFile(shared.authorityLeasePath, 'utf8'));
+      assert.notEqual(replacement.token, 'dead-token');
+      assert.equal(replacement.processStartIdentity, 'current-identity');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a lease without immutable process identity even when its PID is dead', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-hud-authority-uncertain-lease-'));
+    const shared = domain(join(root, 'state'), 'hud-control-plane:uncertain', '/claimant');
+    try {
+      await mkdir(shared.baseStateDir, { recursive: true });
+      await writeFile(shared.authorityLeasePath, JSON.stringify({
+        version: 2, domainKey: shared.domainKey, baseStateDir: shared.baseStateDir, rootSource: shared.rootSource,
+        pid: 4242, platform: process.platform, claimant: '{}', token: 'owner-token', generation: 'owner-generation', heartbeatAt: new Date(1_000).toISOString(),
+      }));
+      await runHudAuthorityTick(
+        { cwd: '/claimant', nodePath: '/node', packageRoot: '/pkg', minIntervalMs: 5_000, jitterMs: 0 },
+        { nowMs: () => 20_000, resolveDomain: async () => shared, processStartIdentity: async () => 'current-identity', probeLeaseProcess: async () => 'dead', runProcess: async () => assert.fail('invalid lease record must not spawn') },
+      );
+      const preserved = JSON.parse(await readFile(shared.authorityLeasePath, 'utf8'));
+      assert.equal(preserved.token, 'owner-token');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('allows independent authorities for distinct canonical roots', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-hud-authority-roots-'));
+    try {
+      let calls = 0;
+      await Promise.all([
+        runHudAuthorityTick(
+          { cwd: '/session-a', nodePath: '/node', packageRoot: '/pkg', jitterMs: 0 },
+          { nowMs: () => 1_000, resolveDomain: async () => domain(join(root, 'a'), 'hud-control-plane:a', '/session-a'), runProcess: async () => { calls += 1; } },
+        ),
+        runHudAuthorityTick(
+          { cwd: '/session-b', nodePath: '/node', packageRoot: '/pkg', jitterMs: 0 },
+          { nowMs: () => 1_000, resolveDomain: async () => domain(join(root, 'b'), 'hud-control-plane:b', '/session-b'), runProcess: async () => { calls += 1; } },
+        ),
+      ]);
+      assert.equal(calls, 2);
+    } finally {
+      await rm(root, { recursive: true, force: true });
     }
   });
 });

--- a/src/hud/__tests__/authority.test.ts
+++ b/src/hud/__tests__/authority.test.ts
@@ -831,6 +831,33 @@ describe('runHudAuthorityTick', () => {
     }
   });
 
+  it('fails closed when a managed claimant cannot be proven live', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-hud-authority-unproven-claimant-'));
+    const shared = {
+      ...domain(join(root, 'state'), 'hud-control-plane:claimant-proof', '/claimant'),
+      managed: true,
+      claimant: {
+        sessionId: 'session', leaderPaneId: '%1', tmuxSessionName: 'omx-session',
+        tmuxSessionInstanceId: 'session-birth', tmuxPaneInstanceId: 'pane-birth',
+      },
+    };
+    try {
+      let calls = 0;
+      await runHudAuthorityTick(
+        { cwd: '/claimant', nodePath: '/node', packageRoot: '/pkg' },
+        {
+          resolveDomain: async () => shared,
+          probeLiveClaimant: async () => false,
+          runProcess: async () => { calls += 1; },
+        },
+      );
+      assert.equal(calls, 0);
+      assert.equal(existsSync(shared.authorityLeasePath), false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('allows independent authorities for distinct canonical roots', async () => {
     const root = await mkdtemp(join(tmpdir(), 'omx-hud-authority-roots-'));
     try {

--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -659,6 +659,10 @@ if [[ "$1" == "list-panes" ]]; then
   printf '%s\n' "%3\tnode\t0\t28\t100\t2\t29\t100\t32\tsess-a\tsess-a\texec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_LEADER_PANE='%1' /node /omx.js hud --watch\t/tmp"
   exit 0
 fi
+if [[ "$1" == "if-shell" ]]; then
+  printf '__omx_hud_pane_kill_applied__\n'
+  exit 0
+fi
 if [[ "$1" == "resize-pane" || "$1" == "set-hook" || "$1" == "kill-pane" ]]; then
   exit 0
 fi
@@ -722,6 +726,14 @@ printf '%s\n' "$*" >> ${JSON.stringify(logPath)}
 if [[ "$1" == "display-message" ]]; then
   fmt="\${@: -1}"
   case "$fmt" in
+    *pane_current_command*pane_start_command*)
+      printf "sess-a\tsess-a\tmanaged-session\t@3\tnode\texec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_LEADER_PANE='%%1' /node /omx.js hud --watch\n"
+      exit 0
+      ;;
+    '#{@omx_pane_instance_id}')
+      printf 'sess-a\n'
+      exit 0
+      ;;
     *session_name*)
       printf 'managed-session\t$7\t@3\t%%1\n'
       exit 0

--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -638,7 +638,7 @@ describe('hudCommand --tmux', () => {
     await writeFile(tmuxPath, `#!/usr/bin/env bash
 printf '%s\n' "$*" >> ${JSON.stringify(logPath)}
 if [[ "$1" == "display-message" && "$*" == *'#{session_id}'* ]]; then
-  printf '$7\t@3\n'
+  printf 'managed-session\t$7\t@3\t%%1\n'
   exit 0
 fi
 if [[ "$1" == "display-message" && "$*" == *'#S'* ]]; then
@@ -646,6 +646,10 @@ if [[ "$1" == "display-message" && "$*" == *'#S'* ]]; then
   exit 0
 fi
 if [[ "$1" == "show-option" && "$*" == *'-p -t %1 @omx_pane_instance_id'* ]]; then
+  printf 'sess-a\n'
+  exit 0
+fi
+if [[ "$1" == "show-option" && "$*" == *'-t managed-session @omx_instance_id'* ]]; then
   printf 'sess-a\n'
   exit 0
 fi
@@ -714,20 +718,47 @@ exit 0
     await mkdir(fakeBin);
     const tmuxPath = join(fakeBin, 'tmux');
     await writeFile(tmuxPath, `#!/usr/bin/env bash
-printf '%s\\n' "$*" >> ${JSON.stringify(logPath)}
-if [[ "$1" == "display-message" && "$*" == *'#{pane_id}'* ]]; then
-  echo '%1'
-  exit 0
+printf '%s\n' "$*" >> ${JSON.stringify(logPath)}
+if [[ "$1" == "display-message" ]]; then
+  fmt="\${@: -1}"
+  case "$fmt" in
+    *session_name*)
+      printf 'managed-session\t$7\t@3\t%%1\n'
+      exit 0
+      ;;
+    *session_id*)
+      printf '$7\t@3\n'
+      exit 0
+      ;;
+    '#{pane_id}')
+      printf '%%1\n'
+      exit 0
+      ;;
+    '#S')
+      printf 'managed-session\n'
+      exit 0
+      ;;
+  esac
 fi
-if [[ "$1" == "display-message" && "$*" == *'#{session_id}'* ]]; then
-  printf '$7\\t@3\\n'
-  exit 0
+if [[ "$1" == "show-option" ]]; then
+  target=""
+  pane_scope=0
+  option="\${@: -1}"
+  for ((index=2; index <= $#; index++)); do
+    arg="\${!index}"
+    if [[ "$arg" == '-p' ]]; then pane_scope=1; fi
+    if [[ "$arg" == '-t' ]]; then next=$((index + 1)); target="\${!next}"; fi
+  done
+  if [[ "$pane_scope" == 1 && "$target" == '%1' && "$option" == '@omx_pane_instance_id' ]]; then
+    printf 'sess-a\n'
+    exit 0
+  fi
+  if [[ "$pane_scope" == 0 && "$target" == 'managed-session' && "$option" == '@omx_instance_id' ]]; then
+    printf 'sess-a\n'
+    exit 0
+  fi
 fi
-if [[ "$1" == "display-message" && "$*" == *'#S'* ]]; then
-  printf 'managed-session\n'
-  exit 0
-fi
-if [[ "$1" == "show-option" && "$*" == *'-p -t %1 @omx_pane_instance_id'* ]]; then
+if [[ "$1" == "show-option" && "$*" == *'-t managed-session @omx_instance_id'* ]]; then
   printf 'sess-a\n'
   exit 0
 fi

--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -808,7 +808,7 @@ exit 0
         tmuxLog,
         /list-panes -t %1 -F #\{pane_id\}\x1f#\{pane_current_command\}(?:\x1f#\{[^}]+\})*\x1f#\{pane_start_command\}\x1f#\{pane_current_path\}/,
       );
-      assert.match(tmuxLog, /set-hook -t \$7/);
+      assert.match(tmuxLog, /set-hook -a -t \$7 client-resized/);
       assert.doesNotMatch(tmuxLog, /split-window/);
     } finally {
       for (const [key, value] of Object.entries(previousEnv)) {

--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -158,7 +158,7 @@ describe('runWatchMode', () => {
     assert.equal(resolved, '/tmp/live workspace (deleted)');
   });
 
-  it('reads HUD state from the resolved live cwd on every watch frame', async () => {
+  it('keeps manual watch rendering-only even when the live cwd changes', async () => {
     const seenConfigCwds: string[] = [];
     const seenStateCwds: string[] = [];
     const seenAuthorityCwds: string[] = [];
@@ -191,7 +191,7 @@ describe('runWatchMode', () => {
 
     assert.deepEqual(seenConfigCwds, ['/home/tools/calc.noninteractive-aborted-20260527T233204Z']);
     assert.deepEqual(seenStateCwds, ['/home/tools/calc.noninteractive-aborted-20260527T233204Z']);
-    assert.deepEqual(seenAuthorityCwds, ['/home/tools/calc.noninteractive-aborted-20260527T233204Z']);
+    assert.deepEqual(seenAuthorityCwds, []);
   });
 
   it('restores cursor and clears interval on SIGINT', async () => {
@@ -508,14 +508,20 @@ describe('runWatchMode', () => {
     ]);
   });
 
-  it('runs authority tick after each rendered frame', async () => {
+  it('runs authority ticks only for managed HUD watchers', async () => {
     const writes: string[] = [];
     let sigintHandler: (() => void) | undefined;
     let authorityCalls = 0;
 
     const promise = runWatchMode('/tmp', WATCH_FLAGS, {
       isTTY: true,
-      env: {},
+      env: {
+        TMUX: '1',
+        TMUX_PANE: '%hud',
+        OMX_SESSION_ID: 'session-a',
+        [OMX_TMUX_HUD_OWNER_ENV]: '1',
+        [OMX_TMUX_HUD_LEADER_PANE_ENV]: '%leader',
+      },
       readAllStateFn: async () => emptyCtx(),
       readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' }, statusLine: { preset: 'focused' } }),
       renderHudFn: () => 'frame',
@@ -547,7 +553,13 @@ describe('runWatchMode', () => {
 
     const promise = runWatchMode('/tmp', WATCH_FLAGS, {
       isTTY: true,
-      env: {},
+      env: {
+        TMUX: '1',
+        TMUX_PANE: '%hud',
+        OMX_SESSION_ID: 'session-a',
+        [OMX_TMUX_HUD_OWNER_ENV]: '1',
+        [OMX_TMUX_HUD_LEADER_PANE_ENV]: '%leader',
+      },
       readAllStateFn: async () => {
         renderCount += 1;
         if (renderCount === 2) secondReadStarted.resolve();
@@ -629,10 +641,18 @@ if [[ "$1" == "display-message" && "$*" == *'#{session_id}'* ]]; then
   printf '$7\t@3\n'
   exit 0
 fi
+if [[ "$1" == "display-message" && "$*" == *'#S'* ]]; then
+  printf 'managed-session\n'
+  exit 0
+fi
+if [[ "$1" == "show-option" && "$*" == *'-p -t %1 @omx_pane_instance_id'* ]]; then
+  printf 'sess-a\n'
+  exit 0
+fi
 if [[ "$1" == "list-panes" ]]; then
-  printf '%s\n' '%1	zsh	zsh'
-  printf '%s\n' "%2	node	exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_LEADER_PANE='%1' /node /omx.js hud --watch"
-  printf '%s\n' "%3	node	exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_LEADER_PANE='%1' /node /omx.js hud --watch"
+  printf '%s\n' '%1\tzsh\t0\t0\t100\t30\t29\t100\t32\tsess-a\tsess-a\tzsh\t/tmp'
+  printf '%s\n' "%2\tnode\t0\t30\t100\t2\t31\t100\t32\tsess-a\tsess-a\texec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_LEADER_PANE='%1' /node /omx.js hud --watch\t/tmp"
+  printf '%s\n' "%3\tnode\t0\t28\t100\t2\t29\t100\t32\tsess-a\tsess-a\texec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_LEADER_PANE='%1' /node /omx.js hud --watch\t/tmp"
   exit 0
 fi
 if [[ "$1" == "resize-pane" || "$1" == "set-hook" || "$1" == "kill-pane" ]]; then
@@ -651,15 +671,23 @@ exit 0
       TMUX: process.env.TMUX,
       TMUX_PANE: process.env.TMUX_PANE,
       OMX_SESSION_ID: process.env.OMX_SESSION_ID,
+      OMX_ROOT: process.env.OMX_ROOT,
     };
-    const previousLog = console.log;
-    const logs: string[] = [];
     try {
       process.env.PATH = `${fakeBin}${delimiter}${process.env.PATH ?? ''}`;
       process.env.TMUX = '/tmp/tmux-1000/default,12345,0';
       process.env.TMUX_PANE = '%1';
       process.env.OMX_SESSION_ID = 'sess-a';
-      console.log = (message?: unknown) => { logs.push(String(message ?? '')); };
+      process.env.OMX_ROOT = tmp;
+      await mkdir(join(tmp, '.omx', 'state'), { recursive: true });
+      await writeFile(join(tmp, '.omx', 'state', 'session.json'), JSON.stringify({
+        session_id: 'sess-a',
+        started_at: '2026-01-01T00:00:00.000Z',
+        cwd: process.cwd(),
+        pid: 0,
+        tmux_session_name: 'managed-session',
+        tmux_pane_id: '%1',
+      }));
 
       await hudCommand(['--tmux']);
 
@@ -671,9 +699,7 @@ exit 0
       assert.match(tmuxLog, /kill-pane -t %3/);
       assert.match(tmuxLog, /resize-pane -t %2 -y \d+/);
       assert.doesNotMatch(tmuxLog, /split-window/);
-      assert.ok(logs.some((line) => line.includes('Removed duplicate HUD panes and reused existing HUD pane')));
     } finally {
-      console.log = previousLog;
       for (const [key, value] of Object.entries(previousEnv)) {
         if (typeof value === 'string') process.env[key] = value;
         else delete process.env[key];
@@ -681,7 +707,7 @@ exit 0
       await rm(tmp, { recursive: true, force: true });
     }
   });
-  it('reuses a same-session HUD pane when TMUX_PANE is empty instead of splitting a duplicate', async () => {
+  it('reuses a same-session HUD pane only after the current leader pane is verified', async () => {
     const tmp = await mkdtemp(join(tmpdir(), 'omx-hud-tmux-test-'));
     const logPath = join(tmp, 'tmux.log');
     const fakeBin = join(tmp, 'bin');
@@ -697,9 +723,17 @@ if [[ "$1" == "display-message" && "$*" == *'#{session_id}'* ]]; then
   printf '$7\\t@3\\n'
   exit 0
 fi
+if [[ "$1" == "display-message" && "$*" == *'#S'* ]]; then
+  printf 'managed-session\n'
+  exit 0
+fi
+if [[ "$1" == "show-option" && "$*" == *'-p -t %1 @omx_pane_instance_id'* ]]; then
+  printf 'sess-a\n'
+  exit 0
+fi
 if [[ "$1" == "list-panes" ]]; then
-  printf '%s\\n' '%1	codex	codex'
-  printf '%s\\n' "%2	node	exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_LEADER_PANE='%1' /node /omx.js hud --watch"
+  printf '%s\n' '%1\tcodex\t0\t0\t100\t30\t29\t100\t32\tsess-a\tsess-a\tcodex\t/tmp'
+  printf '%s\n' "%2\tnode\t0\t30\t100\t2\t31\t100\t32\tsess-a\tsess-a\texec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_LEADER_PANE='%1' /node /omx.js hud --watch\t/tmp"
   exit 0
 fi
 if [[ "$1" == "resize-pane" || "$1" == "set-hook" ]]; then
@@ -718,29 +752,34 @@ exit 0
       TMUX: process.env.TMUX,
       TMUX_PANE: process.env.TMUX_PANE,
       OMX_SESSION_ID: process.env.OMX_SESSION_ID,
+      OMX_ROOT: process.env.OMX_ROOT,
     };
-    const previousLog = console.log;
-    const logs: string[] = [];
     try {
       process.env.PATH = `${fakeBin}${delimiter}${process.env.PATH ?? ''}`;
       process.env.TMUX = '/tmp/tmux-1000/default,12345,0';
-      process.env.TMUX_PANE = '';
+      process.env.TMUX_PANE = '%1';
       process.env.OMX_SESSION_ID = 'sess-a';
-      console.log = (message?: unknown) => { logs.push(String(message ?? '')); };
+      process.env.OMX_ROOT = tmp;
+      await mkdir(join(tmp, '.omx', 'state'), { recursive: true });
+      await writeFile(join(tmp, '.omx', 'state', 'session.json'), JSON.stringify({
+        session_id: 'sess-a',
+        started_at: '2026-01-01T00:00:00.000Z',
+        cwd: process.cwd(),
+        pid: 0,
+        tmux_session_name: 'managed-session',
+        tmux_pane_id: '%1',
+      }));
 
       await hudCommand(['--tmux']);
 
       const tmuxLog = await readFile(logPath, 'utf8');
-      assert.match(tmuxLog, /display-message -p #\{pane_id\}/);
       assert.match(
         tmuxLog,
         /list-panes -t %1 -F #\{pane_id\}\x1f#\{pane_current_command\}(?:\x1f#\{[^}]+\})*\x1f#\{pane_start_command\}\x1f#\{pane_current_path\}/,
       );
-      assert.match(tmuxLog, /resize-pane -t %2 -y \d+/);
+      assert.match(tmuxLog, /set-hook -t \$7/);
       assert.doesNotMatch(tmuxLog, /split-window/);
-      assert.ok(logs.some((line) => line.includes('Reused existing HUD pane')));
     } finally {
-      console.log = previousLog;
       for (const [key, value] of Object.entries(previousEnv)) {
         if (typeof value === 'string') process.env[key] = value;
         else delete process.env[key];

--- a/src/hud/__tests__/lifecycle-lock.test.ts
+++ b/src/hud/__tests__/lifecycle-lock.test.ts
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import {
+  acquireHudLifecycleLock,
+  releaseHudLifecycleLock,
+  type HudLifecycleLockOwner,
+} from '../lifecycle-lock.js';
+
+const DOMAIN = 'hud-control-plane:test';
+const NOW = 10_000;
+
+async function fixture(): Promise<{ root: string; lockPath: string }> {
+  const root = await mkdtemp(join(tmpdir(), 'omx-hud-lifecycle-lock-'));
+  return { root, lockPath: join(root, 'hud.lock') };
+}
+
+function owner(overrides: Partial<HudLifecycleLockOwner> = {}): HudLifecycleLockOwner {
+  return {
+    version: 1,
+    token: 'old-token',
+    generation: 'old-generation',
+    domainKey: DOMAIN,
+    pid: 4242,
+    platform: process.platform,
+    processStartIdentity: 'linux:old',
+    acquiredAt: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+async function writeOwner(lockPath: string, value: unknown): Promise<void> {
+  await mkdir(lockPath);
+  await writeFile(join(lockPath, 'owner.json'), JSON.stringify(value));
+}
+
+const freshDeps = {
+  nowMs: () => NOW,
+  token: () => 'new-token',
+  generation: () => 'new-generation',
+  processStartIdentity: async () => 'linux:new',
+};
+
+describe('HUD lifecycle lock', () => {
+  it('acquires a fresh lock and safely releases only its token and generation', async () => {
+    const { root, lockPath } = await fixture();
+    try {
+      const result = await acquireHudLifecycleLock({ path: lockPath, domainKey: DOMAIN, staleMs: 1_000 }, freshDeps);
+      assert.equal(result.status, 'acquired');
+      assert.ok(result.lock);
+      await releaseHudLifecycleLock(result.lock!);
+      assert.equal(existsSync(lockPath), false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves malformed, unprobeable, and PID-reuse-uncertain locks', async () => {
+    const { root, lockPath } = await fixture();
+    try {
+      await writeOwner(lockPath, { malformed: true });
+      assert.equal((await acquireHudLifecycleLock({ path: lockPath, domainKey: DOMAIN, staleMs: 1 }, freshDeps)).status, 'locked_uncertain');
+      await rm(lockPath, { recursive: true, force: true });
+      await writeOwner(lockPath, owner());
+      const uncertain = await acquireHudLifecycleLock(
+        { path: lockPath, domainKey: DOMAIN, staleMs: 1 },
+        { ...freshDeps, probeProcess: async () => 'uncertain' },
+      );
+      assert.equal(uncertain.status, 'locked_uncertain');
+      assert.equal(existsSync(lockPath), true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves owners with missing or blank identity as malformed and never quarantines them', async () => {
+    const { root, lockPath } = await fixture();
+    try {
+      const legacyOwner = { ...owner() } as Partial<HudLifecycleLockOwner>;
+      delete legacyOwner.processStartIdentity;
+      await writeOwner(lockPath, legacyOwner);
+      let quarantined = false;
+      const result = await acquireHudLifecycleLock(
+        { path: lockPath, domainKey: DOMAIN, staleMs: 1_000 },
+        {
+          ...freshDeps,
+          probeProcess: async () => 'dead',
+          afterQuarantine: () => { quarantined = true; },
+        },
+      );
+      assert.equal(result.status, 'locked_uncertain');
+      assert.equal(quarantined, false);
+      assert.equal(existsSync(lockPath), true);
+      await rm(lockPath, { recursive: true, force: true });
+      await writeOwner(lockPath, { ...owner(), processStartIdentity: '   ' });
+      const blankIdentity = await acquireHudLifecycleLock(
+        { path: lockPath, domainKey: DOMAIN, staleMs: 1_000 },
+        { ...freshDeps, probeProcess: async () => 'dead' },
+      );
+      assert.equal(blankIdentity.status, 'locked_uncertain');
+      assert.equal(existsSync(lockPath), true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed before creating a fresh lock when the current identity is unavailable or blank', async () => {
+    const { root, lockPath } = await fixture();
+    try {
+      const result = await acquireHudLifecycleLock(
+        { path: lockPath, domainKey: DOMAIN, staleMs: 1_000 },
+        {
+          ...freshDeps,
+          processStartIdentity: async () => undefined,
+          token: () => assert.fail('must not create an owner without an identity'),
+        },
+      );
+      assert.equal(result.status, 'failed');
+      assert.equal(existsSync(lockPath), false);
+      const blankIdentity = await acquireHudLifecycleLock(
+        { path: join(root, 'blank.lock'), domainKey: DOMAIN, staleMs: 1_000 },
+        { ...freshDeps, processStartIdentity: async () => '   ' },
+      );
+      assert.equal(blankIdentity.status, 'failed');
+      assert.equal(existsSync(join(root, 'blank.lock')), false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('takes over only a stale owner proven dead or reused', async () => {
+    const { root, lockPath } = await fixture();
+    try {
+      await writeOwner(lockPath, owner());
+      const result = await acquireHudLifecycleLock(
+        { path: lockPath, domainKey: DOMAIN, staleMs: 1_000 },
+        { ...freshDeps, probeProcess: async () => 'reused' },
+      );
+      assert.equal(result.status, 'acquired');
+      const current = JSON.parse(await readFile(join(lockPath, 'owner.json'), 'utf8'));
+      assert.equal(current.token, 'new-token');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not delete a replacement token during release', async () => {
+    const { root, lockPath } = await fixture();
+    try {
+      const result = await acquireHudLifecycleLock({ path: lockPath, domainKey: DOMAIN, staleMs: 1_000 }, freshDeps);
+      assert.ok(result.lock);
+      await writeFile(join(lockPath, 'owner.json'), JSON.stringify(owner({ token: 'replacement', generation: 'replacement' })));
+      await releaseHudLifecycleLock(result.lock!);
+      const current = JSON.parse(await readFile(join(lockPath, 'owner.json'), 'utf8'));
+      assert.equal(current.token, 'replacement');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not restore a quarantined stale lock over an ABA replacement', async () => {
+    const { root, lockPath } = await fixture();
+    try {
+      await writeOwner(lockPath, owner());
+      const result = await acquireHudLifecycleLock(
+        { path: lockPath, domainKey: DOMAIN, staleMs: 1_000 },
+        {
+          ...freshDeps,
+          probeProcess: async () => 'reused',
+          afterQuarantine: async () => {
+            await writeOwner(lockPath, owner({ token: 'replacement', generation: 'replacement' }));
+          },
+        },
+      );
+      assert.equal(result.status, 'locked_uncertain');
+      const current = JSON.parse(await readFile(join(lockPath, 'owner.json'), 'utf8'));
+      assert.equal(current.token, 'replacement');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -5,7 +5,7 @@ import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises
 import { tmpdir } from 'node:os';
 import { dirname } from 'node:path';
 import { join } from 'node:path';
-import { OMX_TMUX_HUD_OWNER_ENV, reconcileHudForPromptSubmit as reconcileHudForPromptSubmitRaw, type ReconcileHudForPromptSubmitDeps } from '../reconcile.js';
+import { OMX_TMUX_HUD_OWNER_ENV, reconcileHudForPromptSubmit as reconcileHudForPromptSubmitRaw, teardownManagedHudPane, type ReconcileHudForPromptSubmitDeps } from '../reconcile.js';
 
 import { HUD_TMUX_HEIGHT_LINES, HUD_TMUX_ULTRAGOAL_HEIGHT_LINES, HUD_TMUX_MIN_LAUNCH_WINDOW_HEIGHT_LINES } from '../constants.js';
 import { OMX_TMUX_HUD_LEADER_PANE_ENV } from '../tmux.js';
@@ -2178,5 +2178,63 @@ describe('reconcileHudForPromptSubmit verified lifecycle ownership', () => {
     assert.equal(result.status, 'recreated');
     assert.equal(result.paneId, '%created');
     assert.deepEqual(killed, []);
+  });
+});
+
+describe('teardownManagedHudPane', () => {
+  it('removes only the exact owner HUD and unregisters its leader hooks', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-teardown-exact-'));
+    const killed: string[] = [];
+    const unregistered: string[] = [];
+    const deps: ReconcileHudForPromptSubmitDeps = {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'session-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      sessionId: 'session-a',
+      resolveDomain: async () => testReconcileDomain(cwd, { sessionId: 'session-a', env: { TMUX_PANE: '%1' } }),
+      probeTmuxInstance: async () => ({
+        paneTarget: '%1', sessionName: 'managed', paneInstanceId: 'session-a', sessionInstanceId: '',
+        instanceId: 'session-a', source: 'pane', paneTagStatus: 'present',
+      }),
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneInstanceId: 'session-a', sessionInstanceId: 'session-a' },
+        { paneId: '%2', currentCommand: 'node', startCommand: "exec env OMX_SESSION_ID='session-a' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' node omx.js hud --watch", paneInstanceId: 'session-a', sessionInstanceId: 'session-a' },
+        { paneId: '%3', currentCommand: 'node', startCommand: "exec env OMX_SESSION_ID='session-b' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' node omx.js hud --watch", paneInstanceId: 'session-b', sessionInstanceId: 'session-b' },
+      ],
+      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      unregisterHudResizeHook: (paneId) => { if (paneId) unregistered.push(paneId); return true; },
+    };
+    try {
+      const result = await teardownManagedHudPane(cwd, deps);
+      assert.equal(result.status, 'removed');
+      assert.deepEqual(result.removedPaneIds, ['%2']);
+      assert.deepEqual(killed, ['%2']);
+      assert.deepEqual(unregistered, ['%1']);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves every pane when leader instance evidence is mismatched', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-teardown-uncertain-'));
+    const killed: string[] = [];
+    try {
+      const result = await teardownManagedHudPane(cwd, {
+        env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'session-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+        sessionId: 'session-a',
+        resolveDomain: async () => testReconcileDomain(cwd, { sessionId: 'session-a', env: { TMUX_PANE: '%1' } }),
+        probeTmuxInstance: async () => ({
+          paneTarget: '%1', sessionName: 'managed', paneInstanceId: 'session-a', sessionInstanceId: '',
+          instanceId: 'session-a', source: 'pane', paneTagStatus: 'present',
+        }),
+        listCurrentWindowPanes: () => [
+          { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneInstanceId: 'stale', sessionInstanceId: 'session-a' },
+          { paneId: '%2', currentCommand: 'node', startCommand: "exec env OMX_SESSION_ID='session-a' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' node omx.js hud --watch", paneInstanceId: 'session-a', sessionInstanceId: 'session-a' },
+        ],
+        killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      });
+      assert.equal(result.status, 'skipped_not_omx_owned_tmux');
+      assert.deepEqual(killed, []);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -62,11 +62,15 @@ async function reconcileHudForPromptSubmit(cwd: string, deps: ReconcileHudForPro
     probeTmuxInstance: deps.probeTmuxInstance ?? (async (paneId) => ({
       paneTarget: paneId ?? '',
       sessionName: 'managed',
-      paneInstanceId: '',
+      paneInstanceId: sessionId,
       sessionInstanceId: sessionId,
       instanceId: sessionId,
-      source: 'session' as const,
-      paneTagStatus: 'absent' as const,
+      source: 'pane' as const,
+      paneTagStatus: 'present' as const,
+      sessionTagStatus: 'present' as const,
+      sessionId: '$1',
+      windowId: '@1',
+      contextStable: true,
     })),
   });
 }
@@ -2108,9 +2112,34 @@ describe('reconcileHudForPromptSubmit verified lifecycle ownership', () => {
         instanceId: 'sess-a',
         source: 'session',
         paneTagStatus: 'absent',
+        sessionTagStatus: 'present',
+        sessionId: '$1',
+        windowId: '@1',
+        contextStable: true,
       }),
       listCurrentWindowPanes: () => { listed = true; return []; },
       createHudWatchPane: () => { assert.fail('mismatched owner must not create a pane'); return null; },
+    });
+    assert.equal(result.status, 'skipped_not_omx_owned_tmux');
+    assert.equal(listed, false);
+  });
+
+  it('requires live pane and session tags with stable tmux context before mutation', async () => {
+    let listed = false;
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: 'socket', TMUX_PANE: '%leader', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      resolveDomain: async () => ({
+        version: 1, cwd: '/repo', baseStateDir: '/tmp/hud-dual-tag', rootSource: 'cwd-default', domainKey: 'hud-control-plane:dual-tag',
+        authorityStatePath: '/tmp/hud-dual-tag/hud-authority-state.json', authorityLeasePath: '/tmp/hud-dual-tag/hud-authority-lease.json',
+        authorityLockPath: '/tmp/hud-dual-tag/hud-authority.lock', reconcileLockPath: '/tmp/hud-dual-tag/hud-reconcile.lock',
+        session: { canonicalId: 'sess-a', equivalentIds: ['sess-a'], source: 'explicit' },
+        claimant: { sessionId: 'sess-a', leaderPaneId: '%leader', tmuxSessionName: 'managed' }, managed: true,
+      }),
+      probeTmuxInstance: async () => ({
+        paneTarget: '%leader', sessionName: 'managed', paneInstanceId: 'sess-a', sessionInstanceId: '', instanceId: 'sess-a', source: 'pane',
+        paneTagStatus: 'present', sessionTagStatus: 'absent', sessionId: '$1', windowId: '@1', contextStable: true,
+      }),
+      listCurrentWindowPanes: () => { listed = true; return []; },
     });
     assert.equal(result.status, 'skipped_not_omx_owned_tmux');
     assert.equal(listed, false);
@@ -2127,8 +2156,9 @@ describe('reconcileHudForPromptSubmit verified lifecycle ownership', () => {
         claimant: { sessionId: 'canonical-id', leaderPaneId: '%leader', tmuxSessionName: 'managed' }, managed: true,
       }),
       probeTmuxInstance: async () => ({
-        paneTarget: '%leader', sessionName: 'managed', paneInstanceId: 'native-id', sessionInstanceId: '',
-        instanceId: 'native-id', source: 'pane', paneTagStatus: 'present',
+        paneTarget: '%leader', sessionName: 'managed', paneInstanceId: 'native-id', sessionInstanceId: 'native-id',
+        instanceId: 'native-id', source: 'pane', paneTagStatus: 'present', sessionTagStatus: 'present',
+        sessionId: '$1', windowId: '@1', contextStable: true,
       }),
       listCurrentWindowPanes: () => [{ paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' }],
       createHudWatchPane: () => '%hud', resizeTmuxPane: () => true, resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
@@ -2186,21 +2216,23 @@ describe('teardownManagedHudPane', () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-teardown-exact-'));
     const killed: string[] = [];
     const unregistered: string[] = [];
+    const events: string[] = [];
     const deps: ReconcileHudForPromptSubmitDeps = {
       env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'session-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       sessionId: 'session-a',
       resolveDomain: async () => testReconcileDomain(cwd, { sessionId: 'session-a', env: { TMUX_PANE: '%1' } }),
       probeTmuxInstance: async () => ({
-        paneTarget: '%1', sessionName: 'managed', paneInstanceId: 'session-a', sessionInstanceId: '',
-        instanceId: 'session-a', source: 'pane', paneTagStatus: 'present',
+        paneTarget: '%1', sessionName: 'managed', paneInstanceId: 'session-a', sessionInstanceId: 'session-a',
+        instanceId: 'session-a', source: 'pane', paneTagStatus: 'present', sessionTagStatus: 'present',
+        sessionId: '$1', windowId: '@1', contextStable: true,
       }),
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneInstanceId: 'session-a', sessionInstanceId: 'session-a' },
         { paneId: '%2', currentCommand: 'node', startCommand: "exec env OMX_SESSION_ID='session-a' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' node omx.js hud --watch", paneInstanceId: 'session-a', sessionInstanceId: 'session-a' },
         { paneId: '%3', currentCommand: 'node', startCommand: "exec env OMX_SESSION_ID='session-b' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' node omx.js hud --watch", paneInstanceId: 'session-b', sessionInstanceId: 'session-b' },
       ],
-      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
-      unregisterHudResizeHook: (paneId) => { if (paneId) unregistered.push(paneId); return true; },
+      killTmuxPane: (paneId) => { events.push(`kill:${paneId}`); killed.push(paneId); return true; },
+      unregisterHudResizeHook: (paneId) => { events.push(`unregister:${paneId}`); if (paneId) unregistered.push(paneId); return true; },
     };
     try {
       const result = await teardownManagedHudPane(cwd, deps);
@@ -2208,6 +2240,7 @@ describe('teardownManagedHudPane', () => {
       assert.deepEqual(result.removedPaneIds, ['%2']);
       assert.deepEqual(killed, ['%2']);
       assert.deepEqual(unregistered, ['%1']);
+      assert.deepEqual(events, ['unregister:%1', 'kill:%2']);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -2222,8 +2255,9 @@ describe('teardownManagedHudPane', () => {
         sessionId: 'session-a',
         resolveDomain: async () => testReconcileDomain(cwd, { sessionId: 'session-a', env: { TMUX_PANE: '%1' } }),
         probeTmuxInstance: async () => ({
-          paneTarget: '%1', sessionName: 'managed', paneInstanceId: 'session-a', sessionInstanceId: '',
-          instanceId: 'session-a', source: 'pane', paneTagStatus: 'present',
+          paneTarget: '%1', sessionName: 'managed', paneInstanceId: 'session-a', sessionInstanceId: 'session-a',
+          instanceId: 'session-a', source: 'pane', paneTagStatus: 'present', sessionTagStatus: 'present',
+          sessionId: '$1', windowId: '@1', contextStable: true,
         }),
         listCurrentWindowPanes: () => [
           { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneInstanceId: 'stale', sessionInstanceId: 'session-a' },

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -183,7 +183,7 @@ describe('reconcileHudForPromptSubmit', () => {
           listed = true;
           return [{ paneId: '%1', currentCommand: 'codex', startCommand: 'codex' }];
         },
-        killTmuxPane: () => {
+        killManagedHudPane: () => {
           killed = true;
           return true;
         },
@@ -324,8 +324,8 @@ describe('reconcileHudForPromptSubmit', () => {
         orphan('%42'),
         orphan('%47'),
       ],
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       resizeTmuxPane: () => true,
@@ -363,8 +363,8 @@ describe('reconcileHudForPromptSubmit', () => {
           startCommand: `env OMX_SESSION_ID='codex-native-uuid' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%21' node omx hud --watch`,
         },
       ],
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       resizeTmuxPane: () => true,
@@ -392,8 +392,8 @@ describe('reconcileHudForPromptSubmit', () => {
           startCommand: `exec env OMX_SESSION_ID='sess-old' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch --preset=focused`,
         },
       ],
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       createHudWatchPane: (_cwd, _cmd, options) => {
@@ -431,8 +431,8 @@ describe('reconcileHudForPromptSubmit', () => {
           startCommand: `exec env OMX_SESSION_ID='sess-old' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch --preset=focused`,
         },
       ],
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       createHudWatchPane: () => {
@@ -468,8 +468,8 @@ describe('reconcileHudForPromptSubmit', () => {
           startCommand: `exec env OMX_SESSION_ID='sess-right' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%right' node omx hud --watch --preset=focused`,
         },
       ],
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       createHudWatchPane: () => '%left-hud',
@@ -497,8 +497,8 @@ describe('reconcileHudForPromptSubmit', () => {
           startCommand: `env OMX_SESSION_ID='sess-b' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%5' node omx hud --watch`,
         },
       ],
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       resizeTmuxPane: () => true,
@@ -536,8 +536,8 @@ describe('reconcileHudForPromptSubmit', () => {
           startCommand: `exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%21' node omx hud --watch --preset=focused`,
         },
       ],
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       resizeTmuxPane: () => true,
@@ -773,8 +773,8 @@ describe('reconcileHudForPromptSubmit', () => {
         created.push({ side: 'left', options });
         return '%hud-left';
       },
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       resizeTmuxPane: (paneId, heightLines) => {
@@ -796,8 +796,8 @@ describe('reconcileHudForPromptSubmit', () => {
         created.push({ side: 'left', options });
         return '%hud-left-repeat';
       },
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       resizeTmuxPane: (paneId, heightLines) => {
@@ -818,8 +818,8 @@ describe('reconcileHudForPromptSubmit', () => {
         created.push({ side: 'right', options });
         return '%hud-right';
       },
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       resizeTmuxPane: (paneId, heightLines) => {
@@ -841,8 +841,8 @@ describe('reconcileHudForPromptSubmit', () => {
         created.push({ side: 'right', options });
         return '%hud-right-repeat';
       },
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       resizeTmuxPane: (paneId, heightLines) => {
@@ -913,8 +913,8 @@ describe('reconcileHudForPromptSubmit', () => {
         created.push({ options });
         return '%hud-left-repeat';
       },
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       resizeTmuxPane: (paneId, heightLines) => {
@@ -941,8 +941,8 @@ describe('reconcileHudForPromptSubmit', () => {
         created.push({ options });
         return '%hud-right-repeat';
       },
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       resizeTmuxPane: (paneId, heightLines) => {
@@ -991,8 +991,8 @@ describe('reconcileHudForPromptSubmit', () => {
         ];
       },
       createHudWatchPane: () => '%9',
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       resizeTmuxPane: (paneId, heightLines) => {
@@ -1029,7 +1029,7 @@ describe('reconcileHudForPromptSubmit', () => {
         ];
       },
       createHudWatchPane: () => '%9',
-      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      killManagedHudPane: (candidate) => { killed.push(candidate.paneId); return true; },
       resizeTmuxPane: (paneId, heightLines) => { resized.push({ paneId, heightLines }); return true; },
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
@@ -1066,7 +1066,7 @@ describe('reconcileHudForPromptSubmit', () => {
         ];
       },
       createHudWatchPane: () => '%9',
-      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      killManagedHudPane: (candidate) => { killed.push(candidate.paneId); return true; },
       resizeTmuxPane: () => false,
       registerHudResizeHook: (paneId) => { registered.push(paneId); return true; },
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
@@ -1100,8 +1100,8 @@ describe('reconcileHudForPromptSubmit', () => {
         },
         { paneId: '%4', currentCommand: 'codex', startCommand: 'codex' },
       ],
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       createHudWatchPane: (_cwd, cmd) => {
@@ -1153,8 +1153,8 @@ describe('reconcileHudForPromptSubmit', () => {
           startCommand: `env OMX_SESSION_ID='codex-native-uuid' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%4' node omx hud --watch`,
         },
       ],
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       createHudWatchPane: (_cwd, cmd) => {
@@ -1190,7 +1190,7 @@ describe('reconcileHudForPromptSubmit', () => {
         { paneId: '%4', currentCommand: 'node', startCommand: 'node /tmp/bin/omx.js hud --watch --preset=minimal' },
         { paneId: '%5', currentCommand: 'node', startCommand: 'node /tmp/bin/omx.js hud --tmux --preset=focused' },
       ],
-      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      killManagedHudPane: (candidate) => { killed.push(candidate.paneId); return true; },
       createHudWatchPane: () => { created.push('create'); return '%9'; },
       resizeTmuxPane: (paneId, heightLines) => { resized.push({ paneId, heightLines }); return true; },
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
@@ -1219,7 +1219,7 @@ describe('reconcileHudForPromptSubmit', () => {
         },
         { paneId: '%3', currentCommand: 'node', startCommand: 'node /tmp/bin/omx.js hud --watch --preset=focused' },
       ],
-      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      killManagedHudPane: (candidate) => { killed.push(candidate.paneId); return true; },
       resizeTmuxPane: (paneId, heightLines) => { resized.push({ paneId, heightLines }); return true; },
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
@@ -1252,7 +1252,7 @@ describe('reconcileHudForPromptSubmit', () => {
         ];
       },
       createHudWatchPane: () => '%9',
-      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      killManagedHudPane: (candidate) => { killed.push(candidate.paneId); return true; },
       resizeTmuxPane: (paneId, heightLines) => { resized.push({ paneId, heightLines }); return true; },
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
@@ -1283,7 +1283,7 @@ describe('reconcileHudForPromptSubmit', () => {
           startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
         },
       ],
-      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      killManagedHudPane: (candidate) => { killed.push(candidate.paneId); return true; },
       resizeTmuxPane: () => false,
       registerHudResizeHook: (paneId) => { registered.push(paneId); return true; },
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
@@ -1312,8 +1312,8 @@ describe('reconcileHudForPromptSubmit', () => {
         },
         { paneId: '%3', currentCommand: 'codex', startCommand: 'codex' },
       ],
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       resizeTmuxPane: (paneId) => {
@@ -1366,8 +1366,8 @@ describe('reconcileHudForPromptSubmit', () => {
           startCommand: `env OMX_SESSION_ID='sess-b' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%5' node omx hud --watch`,
         },
       ],
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       createHudWatchPane: () => '%9',
@@ -1422,7 +1422,7 @@ describe('reconcileHudForPromptSubmit', () => {
         hudNotify: null,
         session: null,
       }),
-      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      killManagedHudPane: (candidate) => { killed.push(candidate.paneId); return true; },
       resizeTmuxPane: (paneId, heightLines) => { resized.push({ paneId, heightLines }); return true; },
       createHudWatchPane: () => { created.push('create'); return '%9'; },
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
@@ -1557,7 +1557,7 @@ describe('reconcileHudForPromptSubmit', () => {
         { paneId: '%2', currentCommand: 'node', startCommand: `env OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch` },
         { paneId: '%3', currentCommand: 'node', startCommand: `env OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch` },
       ],
-      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      killManagedHudPane: (candidate) => { killed.push(candidate.paneId); return true; },
       resizeTmuxPane: (paneId, heightLines) => { resized.push({ paneId, heightLines }); return true; },
       createHudWatchPane: () => { created.push('create'); return '%9'; },
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
@@ -1624,8 +1624,8 @@ describe('reconcileHudForPromptSubmit', () => {
           windowHeight: 50,
         },
       ],
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       createHudWatchPane: (_cwd, _cmd, options) => {
@@ -1675,8 +1675,8 @@ describe('reconcileHudForPromptSubmit', () => {
         unregistered.push(currentPaneId);
         return true;
       },
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       createHudWatchPane: (_cwd, _cmd, options) => {
@@ -1730,8 +1730,8 @@ describe('reconcileHudForPromptSubmit', () => {
         { paneId: '%3', currentCommand: 'codex', startCommand: 'codex', paneLeft: 80, paneTop: 3, paneWidth: 80, paneHeight: 47, paneBottom: 49, windowWidth: 160, windowHeight: 50 },
       ],
       unregisterHudResizeHook: () => true,
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       createHudWatchPane: (_cwd, _cmd, options) => {
@@ -1783,8 +1783,8 @@ describe('reconcileHudForPromptSubmit', () => {
           windowHeight: 50,
         },
       ],
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       createHudWatchPane: (_cwd, _cmd, options) => {
@@ -1843,8 +1843,8 @@ describe('reconcileHudForPromptSubmit', () => {
         unregistered.push(leaderPaneId);
         return true;
       },
-      killTmuxPane: (paneId) => {
-        killed.push(paneId);
+      killManagedHudPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
       createHudWatchPane: (_cwd, _cmd, options) => {
@@ -1927,7 +1927,7 @@ describe('reconcileHudForPromptSubmit', () => {
         { paneId: '%2', currentCommand: 'node', startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch` },
         { paneId: '%3', currentCommand: 'node', startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch` },
       ],
-      killTmuxPane: () => true,
+      killManagedHudPane: () => true,
       createHudWatchPane: () => '%9',
       resizeTmuxPane: () => true,
       unregisterHudResizeHook: (leaderPaneId) => { unregistered.push(leaderPaneId); return true; },
@@ -2196,7 +2196,7 @@ describe('reconcileHudForPromptSubmit verified lifecycle ownership', () => {
         { paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' },
         { paneId: '%reused', currentCommand: 'node', paneInstanceId: 'other-server', startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch` },
       ],
-      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      killManagedHudPane: (candidate) => { killed.push(candidate.paneId); return true; },
       createHudWatchPane: () => { created = true; return '%new'; },
       resizeTmuxPane: () => { assert.fail('unverified candidate must not be resized'); return false; },
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
@@ -2222,7 +2222,7 @@ describe('reconcileHudForPromptSubmit verified lifecycle ownership', () => {
           ];
       },
       createHudWatchPane: () => '%created',
-      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      killManagedHudPane: (candidate) => { killed.push(candidate.paneId); return true; },
       resizeTmuxPane: () => { assert.fail('unsafe post-create candidates must not be resized'); return false; },
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
@@ -2277,7 +2277,7 @@ describe('reconcileHudForPromptSubmit verified lifecycle ownership', () => {
           instanceId: 'session-a', source: 'pane', paneTagStatus: 'present', sessionTagStatus: 'present', sessionId: '$1', windowId: '@1', contextStable: true,
         }),
         listCurrentWindowPanes: () => { mutated = true; return []; },
-        killTmuxPane: () => { mutated = true; return true; },
+        killManagedHudPane: () => { mutated = true; return true; },
         resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
       });
       assert.equal(result.status, 'unchanged');
@@ -2309,7 +2309,7 @@ describe('teardownManagedHudPane', () => {
         { paneId: '%2', currentCommand: 'node', startCommand: "exec env OMX_SESSION_ID='session-a' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' node omx.js hud --watch", paneInstanceId: 'session-a', sessionInstanceId: 'session-a' },
         { paneId: '%3', currentCommand: 'node', startCommand: "exec env OMX_SESSION_ID='session-b' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' node omx.js hud --watch", paneInstanceId: 'session-b', sessionInstanceId: 'session-b' },
       ],
-      killTmuxPane: (paneId) => { events.push(`kill:${paneId}`); killed.push(paneId); return true; },
+      killManagedHudPane: (candidate) => { events.push(`kill:${candidate.paneId}`); killed.push(candidate.paneId); return true; },
       unregisterHudResizeHook: (paneId) => { events.push(`unregister:${paneId}`); if (paneId) unregistered.push(paneId); return true; },
     };
     try {
@@ -2341,7 +2341,7 @@ describe('teardownManagedHudPane', () => {
           { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneInstanceId: 'stale', sessionInstanceId: 'session-a' },
           { paneId: '%2', currentCommand: 'node', startCommand: "exec env OMX_SESSION_ID='session-a' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' node omx.js hud --watch", paneInstanceId: 'session-a', sessionInstanceId: 'session-a' },
         ],
-        killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+        killManagedHudPane: (candidate) => { killed.push(candidate.paneId); return true; },
       });
       assert.equal(result.status, 'skipped_not_omx_owned_tmux');
       assert.deepEqual(killed, []);
@@ -2367,7 +2367,7 @@ describe('teardownManagedHudPane', () => {
           sessionId: '$1', windowId: '@1', contextStable: true,
         }),
         listCurrentWindowPanes: () => { assert.fail('mixed authority must not enumerate panes'); return []; },
-        killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+        killManagedHudPane: (candidate) => { killed.push(candidate.paneId); return true; },
       });
       assert.equal(result.status, 'skipped_not_omx_owned_tmux');
       assert.deepEqual(killed, []);
@@ -2389,7 +2389,7 @@ describe('teardownManagedHudPane', () => {
           { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneInstanceId: 'pane-birth', sessionInstanceId: 'session-birth' },
           { paneId: '%2', currentCommand: 'node', startCommand: "exec env OMX_SESSION_ID='logical-session' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' node omx.js hud --watch", paneInstanceId: 'pane-birth', sessionInstanceId: 'session-birth' },
         ],
-        killTmuxPane: (paneId) => { killed.push(paneId); return true; }, unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+        killManagedHudPane: (candidate) => { killed.push(candidate.paneId); return true; }, unregisterHudResizeHook: noOpUnregisterHudResizeHook,
       });
       assert.equal(result.status, 'removed');
       assert.deepEqual(killed, ['%2']);

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -109,6 +109,27 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(created, false);
   });
 
+  it('fails closed for a mixed pane/session pair from a broader resolver alias set', async () => {
+    let listed = false;
+    let mutated = false;
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'canonical', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      sessionIds: ['canonical', 'native-a', 'native-b'],
+      probeTmuxInstance: async () => ({
+        paneTarget: '%1', sessionName: 'managed', paneInstanceId: 'native-a', sessionInstanceId: 'native-b',
+        instanceId: 'native-a', source: 'pane', paneTagStatus: 'present', sessionTagStatus: 'present',
+        sessionId: '$1', windowId: '@1', contextStable: true,
+      }),
+      listCurrentWindowPanes: () => { listed = true; return []; },
+      createHudWatchPane: () => { mutated = true; return '%2'; },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'skipped_not_omx_owned_tmux');
+    assert.equal(listed, false);
+    assert.equal(mutated, false);
+  });
+
   it('skips recreating a missing HUD in explicit OMX-owned tmux without a session id', async () => {
     const created: Array<{ cwd: string; cmd: string; options?: { heightLines?: number; targetPaneId?: string } }> = [];
     const resized: Array<{ paneId: string; heightLines: number }> = [];
@@ -2263,6 +2284,32 @@ describe('teardownManagedHudPane', () => {
           { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneInstanceId: 'stale', sessionInstanceId: 'session-a' },
           { paneId: '%2', currentCommand: 'node', startCommand: "exec env OMX_SESSION_ID='session-a' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' node omx.js hud --watch", paneInstanceId: 'session-a', sessionInstanceId: 'session-a' },
         ],
+        killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      });
+      assert.equal(result.status, 'skipped_not_omx_owned_tmux');
+      assert.deepEqual(killed, []);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves every pane when teardown evidence mixes a broader alias set', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-teardown-mixed-alias-'));
+    const killed: string[] = [];
+    try {
+      const result = await teardownManagedHudPane(cwd, {
+        env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'canonical', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+        sessionId: 'canonical',
+        sessionIds: ['canonical', 'native-a', 'native-b'],
+        resolveDomain: async () => testReconcileDomain(cwd, {
+          sessionId: 'canonical', sessionIds: ['canonical', 'native-a', 'native-b'], env: { TMUX_PANE: '%1' },
+        }),
+        probeTmuxInstance: async () => ({
+          paneTarget: '%1', sessionName: 'managed', paneInstanceId: 'native-a', sessionInstanceId: 'native-b',
+          instanceId: 'native-a', source: 'pane', paneTagStatus: 'present', sessionTagStatus: 'present',
+          sessionId: '$1', windowId: '@1', contextStable: true,
+        }),
+        listCurrentWindowPanes: () => { assert.fail('mixed authority must not enumerate panes'); return []; },
         killTmuxPane: (paneId) => { killed.push(paneId); return true; },
       });
       assert.equal(result.status, 'skipped_not_omx_owned_tmux');

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -8,7 +8,7 @@ import { join } from 'node:path';
 import { OMX_TMUX_HUD_OWNER_ENV, reconcileHudForPromptSubmit as reconcileHudForPromptSubmitRaw, teardownManagedHudPane, type ReconcileHudForPromptSubmitDeps } from '../reconcile.js';
 
 import { HUD_TMUX_HEIGHT_LINES, HUD_TMUX_ULTRAGOAL_HEIGHT_LINES, HUD_TMUX_MIN_LAUNCH_WINDOW_HEIGHT_LINES } from '../constants.js';
-import { OMX_TMUX_HUD_LEADER_PANE_ENV } from '../tmux.js';
+import { OMX_TMUX_HUD_LEADER_PANE_ENV, type ExactHudPaneKillCandidate } from '../tmux.js';
 
 const noOpRegisterHudResizeHook = () => true;
 const noOpUnregisterHudResizeHook = () => true;
@@ -2280,6 +2280,94 @@ describe('reconcileHudForPromptSubmit verified lifecycle ownership', () => {
     assert.equal(result.paneId, null);
     assert.deepEqual(killed, ['%created']);
   });
+  it('mints a HUD birth distinct from the leader and uses it for post-create duplicate authority', async () => {
+    const killed: ExactHudPaneKillCandidate[] = [];
+    let listCount = 0;
+    let hudBirth = '';
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-fresh-birth-'));
+    try {
+      const domain = await testReconcileDomain(cwd, { sessionId: 'logical-session', env: { TMUX_PANE: '%leader' } });
+      const opaqueDomain = {
+        ...domain,
+        claimant: {
+          ...domain.claimant,
+          tmuxSessionInstanceId: 'session-birth',
+          tmuxPaneInstanceId: 'leader-birth',
+        },
+      };
+      const result = await reconcileHudForPromptSubmit(cwd, {
+        env: { TMUX: 'socket', TMUX_PANE: '%leader', OMX_SESSION_ID: 'logical-session', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+        sessionId: 'logical-session',
+        resolveDomain: async () => opaqueDomain,
+        probeTmuxInstance: async () => ({ paneTarget: '%leader', sessionName: 'managed', paneInstanceId: 'leader-birth', sessionInstanceId: 'session-birth', instanceId: 'leader-birth', source: 'pane', paneTagStatus: 'present', sessionTagStatus: 'present', sessionId: '$1', windowId: '@1', contextStable: true }),
+        listCurrentWindowPanes: () => {
+          listCount += 1;
+          return listCount === 1
+            ? [{ paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' }]
+            : [
+              { paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' },
+              { paneId: '%created', currentCommand: 'node', paneInstanceId: hudBirth, sessionInstanceId: 'session-birth', startCommand: "env OMX_SESSION_ID='logical-session' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%leader' node omx.js hud --watch" },
+              { paneId: '%duplicate', currentCommand: 'node', paneInstanceId: 'logical-session', sessionInstanceId: 'logical-session', startCommand: "env OMX_SESSION_ID='logical-session' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%leader' node omx.js hud --watch" },
+            ];
+        },
+        createHudWatchPane: (_cwd, _cmd, options) => {
+          hudBirth = options?.instanceId ?? '';
+          return '%created';
+        },
+        killManagedHudPane: (candidate) => { killed.push(candidate); return candidate.paneId === '%created'; },
+        resizeTmuxPane: () => true,
+        resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+      });
+      assert.notEqual(hudBirth, 'leader-birth');
+      assert.equal(result.status, 'failed');
+      assert.deepEqual(killed.map((candidate) => candidate.paneId), ['%duplicate', '%created']);
+      assert.equal(killed[1]?.paneInstanceId, hudBirth);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves a created pane when post-create validation finds the leader birth instead of the HUD birth', async () => {
+    const killed: string[] = [];
+    let listCount = 0;
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-unreadable-birth-'));
+    try {
+      const domain = await testReconcileDomain(cwd, { sessionId: 'logical-session', env: { TMUX_PANE: '%leader' } });
+      const opaqueDomain = {
+        ...domain,
+        claimant: {
+          ...domain.claimant,
+          tmuxSessionInstanceId: 'session-birth',
+          tmuxPaneInstanceId: 'leader-birth',
+        },
+      };
+      const result = await reconcileHudForPromptSubmit(cwd, {
+        env: { TMUX: 'socket', TMUX_PANE: '%leader', OMX_SESSION_ID: 'logical-session', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+        sessionId: 'logical-session',
+        resolveDomain: async () => opaqueDomain,
+        probeTmuxInstance: async () => ({ paneTarget: '%leader', sessionName: 'managed', paneInstanceId: 'leader-birth', sessionInstanceId: 'session-birth', instanceId: 'leader-birth', source: 'pane', paneTagStatus: 'present', sessionTagStatus: 'present', sessionId: '$1', windowId: '@1', contextStable: true }),
+        listCurrentWindowPanes: () => {
+          listCount += 1;
+          return listCount === 1
+            ? [{ paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' }]
+            : [
+              { paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' },
+              { paneId: '%created', currentCommand: 'node', paneInstanceId: 'leader-birth', sessionInstanceId: 'session-birth', startCommand: "env OMX_SESSION_ID='logical-session' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%leader' node omx.js hud --watch" },
+            ];
+        },
+        createHudWatchPane: () => '%created',
+        killManagedHudPane: (candidate) => { killed.push(candidate.paneId); return true; },
+        resizeTmuxPane: () => { assert.fail('unreadable created pane must not be resized'); return false; },
+        resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+      });
+      assert.equal(result.status, 'failed');
+      assert.equal(result.paneId, '%created');
+      assert.deepEqual(killed, []);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('accepts resolver-carried opaque birth evidence without widening logical aliases', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-opaque-claimant-'));
     try {
@@ -2307,8 +2395,8 @@ describe('reconcileHudForPromptSubmit verified lifecycle ownership', () => {
         resizeTmuxPane: () => true,
         resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
       });
-      assert.equal(result.status, 'resized');
-      assert.equal(result.paneId, '%2');
+      assert.equal(result.status, 'unchanged');
+      assert.equal(result.paneId, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -2425,7 +2513,7 @@ describe('teardownManagedHudPane', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
-  it('tears down an opaque birth claimant carried by the resolver', async () => {
+  it('does not tear down a HUD from the leader birth carried by an opaque resolver claimant', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-teardown-opaque-'));
     const killed: string[] = [];
     try {
@@ -2441,8 +2529,8 @@ describe('teardownManagedHudPane', () => {
         ],
         killManagedHudPane: (candidate) => { killed.push(candidate.paneId); return true; }, unregisterHudResizeHook: noOpUnregisterHudResizeHook,
       });
-      assert.equal(result.status, 'removed');
-      assert.deepEqual(killed, ['%2']);
+      assert.equal(result.status, 'unchanged');
+      assert.deepEqual(killed, []);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -2444,7 +2444,7 @@ describe('teardownManagedHudPane', () => {
       }),
       listCurrentWindowPanes: () => [
         { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneInstanceId: 'session-a', sessionInstanceId: 'session-a' },
-        { paneId: '%2', currentCommand: 'node', startCommand: "exec env OMX_SESSION_ID='session-a' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' node omx.js hud --watch", paneInstanceId: 'session-a', sessionInstanceId: 'session-a' },
+        { paneId: '%2', currentCommand: 'node', startCommand: "exec env OMX_SESSION_ID='session-a' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' node omx.js hud --watch", paneInstanceId: 'hud-birth-a', sessionInstanceId: 'session-a' },
         { paneId: '%3', currentCommand: 'node', startCommand: "exec env OMX_SESSION_ID='session-b' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' node omx.js hud --watch", paneInstanceId: 'session-b', sessionInstanceId: 'session-b' },
       ],
       killManagedHudPane: (candidate) => { events.push(`kill:${candidate.paneId}`); killed.push(candidate.paneId); return true; },

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -2230,6 +2230,63 @@ describe('reconcileHudForPromptSubmit verified lifecycle ownership', () => {
     assert.equal(result.paneId, '%created');
     assert.deepEqual(killed, []);
   });
+  it('accepts resolver-carried opaque birth evidence without widening logical aliases', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-opaque-claimant-'));
+    try {
+      const domain = await testReconcileDomain(cwd, { sessionId: 'logical-session', env: { TMUX_PANE: '%1' } });
+      const opaqueDomain = {
+        ...domain,
+        claimant: {
+          ...domain.claimant,
+          tmuxSessionInstanceId: '7d667f3f-4c4b-4e80-8ea5-050ba1dbfe1f',
+          tmuxPaneInstanceId: '388b3d25-c797-4223-bb30-3eb3511e4101',
+        },
+      };
+      const result = await reconcileHudForPromptSubmit(cwd, {
+        env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'logical-session', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+        sessionId: 'logical-session',
+        resolveDomain: async () => opaqueDomain,
+        probeTmuxInstance: async () => ({
+          paneTarget: '%1', sessionName: 'managed', paneInstanceId: '388b3d25-c797-4223-bb30-3eb3511e4101', sessionInstanceId: '7d667f3f-4c4b-4e80-8ea5-050ba1dbfe1f',
+          instanceId: '388b3d25-c797-4223-bb30-3eb3511e4101', source: 'pane', paneTagStatus: 'present', sessionTagStatus: 'present', sessionId: '$1', windowId: '@1', contextStable: true,
+        }),
+        listCurrentWindowPanes: () => [
+          { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneInstanceId: '388b3d25-c797-4223-bb30-3eb3511e4101', sessionInstanceId: '7d667f3f-4c4b-4e80-8ea5-050ba1dbfe1f' },
+          { paneId: '%2', currentCommand: 'node', startCommand: "exec env OMX_SESSION_ID='logical-session' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' node omx.js hud --watch", paneInstanceId: '388b3d25-c797-4223-bb30-3eb3511e4101', sessionInstanceId: '7d667f3f-4c4b-4e80-8ea5-050ba1dbfe1f' },
+        ],
+        resizeTmuxPane: () => true,
+        resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+      });
+      assert.equal(result.status, 'resized');
+      assert.equal(result.paneId, '%2');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not mutate after the leader birth identity drifts under the lifecycle lock', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-under-lock-drift-'));
+    let probes = 0;
+    let mutated = false;
+    try {
+      const result = await reconcileHudForPromptSubmit(cwd, {
+        env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'session-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+        sessionId: 'session-a',
+        probeTmuxInstance: async () => ({
+          paneTarget: '%1', sessionName: 'managed', paneInstanceId: probes++ === 0 ? 'session-a' : 'replacement', sessionInstanceId: 'session-a',
+          instanceId: 'session-a', source: 'pane', paneTagStatus: 'present', sessionTagStatus: 'present', sessionId: '$1', windowId: '@1', contextStable: true,
+        }),
+        listCurrentWindowPanes: () => { mutated = true; return []; },
+        killTmuxPane: () => { mutated = true; return true; },
+        resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+      });
+      assert.equal(result.status, 'unchanged');
+      assert.equal(mutated, false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
 });
 
 describe('teardownManagedHudPane', () => {
@@ -2318,4 +2375,27 @@ describe('teardownManagedHudPane', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+  it('tears down an opaque birth claimant carried by the resolver', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-teardown-opaque-'));
+    const killed: string[] = [];
+    try {
+      const domain = await testReconcileDomain(cwd, { sessionId: 'logical-session', env: { TMUX_PANE: '%1' } });
+      const opaqueDomain = { ...domain, claimant: { ...domain.claimant, tmuxSessionInstanceId: 'session-birth', tmuxPaneInstanceId: 'pane-birth' } };
+      const result = await teardownManagedHudPane(cwd, {
+        env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'logical-session', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+        sessionId: 'logical-session', resolveDomain: async () => opaqueDomain,
+        probeTmuxInstance: async () => ({ paneTarget: '%1', sessionName: 'managed', paneInstanceId: 'pane-birth', sessionInstanceId: 'session-birth', instanceId: 'pane-birth', source: 'pane', paneTagStatus: 'present', sessionTagStatus: 'present', sessionId: '$1', windowId: '@1', contextStable: true }),
+        listCurrentWindowPanes: () => [
+          { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneInstanceId: 'pane-birth', sessionInstanceId: 'session-birth' },
+          { paneId: '%2', currentCommand: 'node', startCommand: "exec env OMX_SESSION_ID='logical-session' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' node omx.js hud --watch", paneInstanceId: 'pane-birth', sessionInstanceId: 'session-birth' },
+        ],
+        killTmuxPane: (paneId) => { killed.push(paneId); return true; }, unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+      });
+      assert.equal(result.status, 'removed');
+      assert.deepEqual(killed, ['%2']);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -345,6 +345,31 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.match(created[0]?.cmd || '', new RegExp(`${OMX_TMUX_HUD_LEADER_PANE_ENV}='%33'`));
   });
 
+  it('fails without creating when an exact stale HUD kill is rejected', async () => {
+    const killed: string[] = [];
+    let created = false;
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%33', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%33', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%34',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%21' node omx hud --watch`,
+        },
+      ],
+      killManagedHudPane: (candidate) => { killed.push(candidate.paneId); return false; },
+      createHudWatchPane: () => { created = true; return '%50'; },
+      resizeTmuxPane: () => { assert.fail('stale-kill rejection must abort before resize'); return false; },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.paneId, null);
+    assert.deepEqual(killed, ['%34']);
+    assert.equal(created, false);
+  });
+
   it('reaps orphaned HUD panes tagged with an equivalent native session id', async () => {
     // #2684 lets HUD dedupe treat the OMX owner id and Codex native session id as
     // equivalent. Orphan reaping must use the same identity set so a canonical
@@ -1122,6 +1147,30 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(killed, ['%3']);
     assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
     assert.deepEqual(created, []);
+  });
+
+  it('fails without resizing or creating when an exact duplicate kill is rejected', async () => {
+    const killed: string[] = [];
+    let created = false;
+    let resized = false;
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        { paneId: '%2', currentCommand: 'node', startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch` },
+        { paneId: '%3', currentCommand: 'node', startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch` },
+      ],
+      killManagedHudPane: (candidate) => { killed.push(candidate.paneId); return false; },
+      createHudWatchPane: () => { created = true; return '%new'; },
+      resizeTmuxPane: () => { resized = true; return true; },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.paneId, '%2');
+    assert.deepEqual(killed, ['%3']);
+    assert.equal(created, false);
+    assert.equal(resized, false);
   });
 
   it('deduplicates same-leader HUD panes tagged with equivalent owner and canonical session ids', async () => {
@@ -2207,7 +2256,7 @@ describe('reconcileHudForPromptSubmit verified lifecycle ownership', () => {
     assert.equal(created, false);
   });
 
-  it('does not deduplicate an unverified pane-id reuse observed after create', async () => {
+  it('exact-rolls back a newly created HUD when post-create dedupe finds an unsafe competing actor', async () => {
     const killed: string[] = [];
     let listCount = 0;
     const result = await reconcileHudForPromptSubmit('/repo', {
@@ -2219,6 +2268,7 @@ describe('reconcileHudForPromptSubmit verified lifecycle ownership', () => {
           : [
             { paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' },
             { paneId: '%reused', currentCommand: 'node', paneInstanceId: 'other-instance', sessionInstanceId: 'sess-a', startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch` },
+            { paneId: '%created', currentCommand: 'node', startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch` },
           ];
       },
       createHudWatchPane: () => '%created',
@@ -2226,9 +2276,9 @@ describe('reconcileHudForPromptSubmit verified lifecycle ownership', () => {
       resizeTmuxPane: () => { assert.fail('unsafe post-create candidates must not be resized'); return false; },
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
-    assert.equal(result.status, 'recreated');
-    assert.equal(result.paneId, '%created');
-    assert.deepEqual(killed, []);
+    assert.equal(result.status, 'failed');
+    assert.equal(result.paneId, null);
+    assert.deepEqual(killed, ['%created']);
   });
   it('accepts resolver-carried opaque birth evidence without widening logical aliases', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-opaque-claimant-'));

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -5,7 +5,8 @@ import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises
 import { tmpdir } from 'node:os';
 import { dirname } from 'node:path';
 import { join } from 'node:path';
-import { OMX_TMUX_HUD_OWNER_ENV, reconcileHudForPromptSubmit } from '../reconcile.js';
+import { OMX_TMUX_HUD_OWNER_ENV, reconcileHudForPromptSubmit as reconcileHudForPromptSubmitRaw, type ReconcileHudForPromptSubmitDeps } from '../reconcile.js';
+
 import { HUD_TMUX_HEIGHT_LINES, HUD_TMUX_ULTRAGOAL_HEIGHT_LINES, HUD_TMUX_MIN_LAUNCH_WINDOW_HEIGHT_LINES } from '../constants.js';
 import { OMX_TMUX_HUD_LEADER_PANE_ENV } from '../tmux.js';
 
@@ -22,6 +23,52 @@ async function writeHudReconcileLock(cwd: string, owner: Record<string, unknown>
 
 async function readLockOwner(lockPath: string): Promise<Record<string, unknown>> {
   return JSON.parse(await readFile(join(lockPath, 'owner.json'), 'utf-8')) as Record<string, unknown>;
+}
+
+function testReconcileDomain(cwd: string, deps: ReconcileHudForPromptSubmitDeps) {
+  const sessionId = deps.sessionId?.trim() || deps.env?.OMX_SESSION_ID?.trim();
+  const leaderPaneId = deps.env?.TMUX_PANE?.trim();
+  const baseStateDir = cwd.startsWith(tmpdir()) ? join(cwd, '.omx', 'state') : join(tmpdir(), 'omx-hud-reconcile-fixture');
+  return {
+    version: 1 as const,
+    cwd,
+    baseStateDir,
+    rootSource: 'cwd-default' as const,
+    domainKey: `hud-control-plane:${baseStateDir}`,
+    authorityStatePath: join(baseStateDir, 'hud-authority-state.json'),
+    authorityLeasePath: join(baseStateDir, 'hud-authority-lease.json'),
+    authorityLockPath: join(baseStateDir, 'hud-authority.lock'),
+    reconcileLockPath: join(baseStateDir, 'hud-reconcile.lock'),
+    ...(sessionId ? { session: { canonicalId: sessionId, equivalentIds: [sessionId, ...(deps.sessionIds ?? [])], source: 'explicit' as const } } : {}),
+    claimant: { sessionId, leaderPaneId, tmuxSessionName: 'managed' },
+    managed: Boolean(sessionId),
+  };
+}
+
+async function reconcileHudForPromptSubmit(cwd: string, deps: ReconcileHudForPromptSubmitDeps = {}) {
+  const sessionId = deps.sessionId?.trim() || deps.env?.OMX_SESSION_ID?.trim() || '';
+  const listPanes = deps.listCurrentWindowPanes;
+  return reconcileHudForPromptSubmitRaw(cwd, {
+    ...deps,
+    listCurrentWindowPanes: listPanes
+      ? (paneId) => listPanes(paneId).map((pane) => ({
+        ...pane,
+        ...(pane.startCommand.includes('OMX_SESSION_ID=') && !pane.paneInstanceId
+          ? { paneInstanceId: sessionId, sessionInstanceId: sessionId }
+          : {}),
+      }))
+      : undefined,
+    resolveDomain: deps.resolveDomain ?? (async () => testReconcileDomain(cwd, deps)),
+    probeTmuxInstance: deps.probeTmuxInstance ?? (async (paneId) => ({
+      paneTarget: paneId ?? '',
+      sessionName: 'managed',
+      paneInstanceId: '',
+      sessionInstanceId: sessionId,
+      instanceId: sessionId,
+      source: 'session' as const,
+      paneTagStatus: 'absent' as const,
+    })),
+  });
 }
 
 describe('reconcileHudForPromptSubmit', () => {
@@ -165,7 +212,7 @@ describe('reconcileHudForPromptSubmit', () => {
     }
   });
 
-  it('recovers a stale reconcile lock after the recorded holder is dead', async () => {
+  it('fails closed for a stale reconcile lock without a verifiable lifecycle owner', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-reconcile-dead-lock-'));
     try {
       const lockPath = await writeHudReconcileLock(cwd, {
@@ -178,24 +225,20 @@ describe('reconcileHudForPromptSubmit', () => {
       const result = await reconcileHudForPromptSubmit(cwd, {
         env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
         nowMs: () => 20_000,
-        isProcessLive: (pid) => {
-          assert.equal(pid, 4444);
+        isProcessLive: () => {
+          assert.fail('unverifiable legacy lock metadata must not be probed or reaped');
           return false;
         },
-        listCurrentWindowPanes: () => [{ paneId: '%1', currentCommand: 'codex', startCommand: 'codex' }],
-        createHudWatchPane: () => {
-          created.push('create');
-          return '%hud';
-        },
+        listCurrentWindowPanes: () => { assert.fail('lock uncertainty must not inspect panes'); return []; },
+        createHudWatchPane: () => { created.push('create'); return '%hud'; },
         resizeTmuxPane: () => true,
         unregisterHudResizeHook: noOpUnregisterHudResizeHook,
         registerHudResizeHook: noOpRegisterHudResizeHook,
         resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
       });
-
-      assert.equal(result.status, 'recreated');
-      assert.deepEqual(created, ['create']);
-      assert.equal(existsSync(lockPath), false);
+      assert.equal(result.status, 'skipped_concurrent');
+      assert.deepEqual(created, []);
+      assert.equal(existsSync(lockPath), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -1108,7 +1151,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(created, []);
   });
 
-  it('reuses and deduplicates legacy unowned focused HUD watch panes before recreating', async () => {
+  it('preserves legacy unowned focused HUD watch panes and creates a tagged replacement', async () => {
     const killed: string[] = [];
     const resized: Array<{ paneId: string; heightLines: number }> = [];
     const created: string[] = [];
@@ -1128,15 +1171,15 @@ describe('reconcileHudForPromptSubmit', () => {
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
-    assert.equal(result.status, 'replaced_duplicates');
-    assert.equal(result.paneId, '%2');
-    assert.equal(result.duplicateCount, 1);
-    assert.deepEqual(killed, ['%3']);
-    assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
-    assert.deepEqual(created, []);
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%9');
+    assert.equal(result.duplicateCount, 0);
+    assert.deepEqual(killed, []);
+    assert.deepEqual(resized, [{ paneId: '%9', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+    assert.deepEqual(created, ['create']);
   });
 
-  it('treats an extra legacy focused pane as stale when an owned HUD already exists', async () => {
+  it('preserves an extra legacy focused pane when an owned HUD already exists', async () => {
     const killed: string[] = [];
     const resized: Array<{ paneId: string; heightLines: number }> = [];
 
@@ -1156,14 +1199,14 @@ describe('reconcileHudForPromptSubmit', () => {
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
-    assert.equal(result.status, 'replaced_duplicates');
+    assert.equal(result.status, 'resized');
     assert.equal(result.paneId, '%2');
-    assert.equal(result.duplicateCount, 1);
-    assert.deepEqual(killed, ['%3']);
+    assert.equal(result.duplicateCount, 0);
+    assert.deepEqual(killed, []);
     assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
   });
 
-  it('deduplicates legacy focused panes that appear during the prompt-submit create race', async () => {
+  it('does not deduplicate legacy focused panes that appear during the prompt-submit create race', async () => {
     const killed: string[] = [];
     const resized: Array<{ paneId: string; heightLines: number }> = [];
     let listCount = 0;
@@ -1189,10 +1232,10 @@ describe('reconcileHudForPromptSubmit', () => {
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
-    assert.equal(result.status, 'replaced_duplicates');
+    assert.equal(result.status, 'recreated');
     assert.equal(result.paneId, '%9');
-    assert.equal(result.duplicateCount, 1);
-    assert.deepEqual(killed, ['%8']);
+    assert.equal(result.duplicateCount, 0);
+    assert.deepEqual(killed, []);
     assert.deepEqual(resized, [{ paneId: '%9', heightLines: HUD_TMUX_HEIGHT_LINES }]);
   });
 
@@ -1477,7 +1520,7 @@ describe('reconcileHudForPromptSubmit', () => {
   });
 
 
-  it('deduplicates same-leader HUD panes without creating a new pane when session id is unavailable', async () => {
+  it('leaves existing HUD panes unmanaged when session identity is unavailable', async () => {
     const killed: string[] = [];
     const resized: Array<{ paneId: string; heightLines: number }> = [];
     const created: string[] = [];
@@ -1495,15 +1538,15 @@ describe('reconcileHudForPromptSubmit', () => {
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
-    assert.equal(result.status, 'replaced_duplicates');
-    assert.equal(result.paneId, '%2');
-    assert.equal(result.duplicateCount, 1);
-    assert.deepEqual(killed, ['%3']);
-    assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+    assert.equal(result.status, 'skipped_no_session_id');
+    assert.equal(result.paneId, null);
+    assert.equal(result.duplicateCount, 0);
+    assert.deepEqual(killed, []);
+    assert.deepEqual(resized, []);
     assert.deepEqual(created, []);
   });
 
-  it('resizes an existing single HUD pane even without a fresh session id', async () => {
+  it('leaves an existing HUD pane unmanaged without a verified session id', async () => {
     const resized: Array<{ paneId: string; heightLines: number }> = [];
     const created: string[] = [];
 
@@ -1528,10 +1571,10 @@ describe('reconcileHudForPromptSubmit', () => {
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
 
-    assert.equal(result.status, 'resized');
-    assert.equal(result.paneId, '%2');
+    assert.equal(result.status, 'skipped_no_session_id');
+    assert.equal(result.paneId, null);
     assert.deepEqual(created, []);
-    assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+    assert.deepEqual(resized, []);
   });
 
   it('leaves an existing full-width bottom HUD pane unchanged when geometry and height are healthy', async () => {
@@ -2035,5 +2078,105 @@ fi
     assert.deepEqual(created, []);
     assert.equal(resized[0]?.paneId, '%2');
     assert.equal(resized[0]?.lines, HUD_TMUX_HEIGHT_LINES);
+  });
+});
+
+describe('reconcileHudForPromptSubmit verified lifecycle ownership', () => {
+  it('does not inspect or mutate panes when verified leader ownership is mismatched', async () => {
+    let listed = false;
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: 'socket', TMUX_PANE: '%leader', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      resolveDomain: async () => ({
+        version: 1,
+        cwd: '/repo',
+        baseStateDir: '/tmp/hud-domain',
+        rootSource: 'cwd-default',
+        domainKey: 'hud-control-plane:test',
+        authorityStatePath: '/tmp/hud-domain/hud-authority-state.json',
+        authorityLeasePath: '/tmp/hud-domain/hud-authority-lease.json',
+        authorityLockPath: '/tmp/hud-domain/hud-authority.lock',
+        reconcileLockPath: '/tmp/hud-domain/hud-reconcile.lock',
+        session: { canonicalId: 'sess-a', equivalentIds: ['sess-a'], source: 'explicit' },
+        claimant: { sessionId: 'sess-a', leaderPaneId: '%other', tmuxSessionName: 'managed' },
+        managed: true,
+      }),
+      probeTmuxInstance: async () => ({
+        paneTarget: '%leader',
+        sessionName: 'managed',
+        paneInstanceId: '',
+        sessionInstanceId: 'sess-a',
+        instanceId: 'sess-a',
+        source: 'session',
+        paneTagStatus: 'absent',
+      }),
+      listCurrentWindowPanes: () => { listed = true; return []; },
+      createHudWatchPane: () => { assert.fail('mismatched owner must not create a pane'); return null; },
+    });
+    assert.equal(result.status, 'skipped_not_omx_owned_tmux');
+    assert.equal(listed, false);
+  });
+
+  it('accepts a resolver-provided native alias as the verified current owner', async () => {
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: 'socket', TMUX_PANE: '%leader', OMX_SESSION_ID: 'native-id', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      resolveDomain: async () => ({
+        version: 1, cwd: '/repo', baseStateDir: '/tmp/hud-domain-alias', rootSource: 'cwd-default', domainKey: 'hud-control-plane:alias',
+        authorityStatePath: '/tmp/hud-domain-alias/hud-authority-state.json', authorityLeasePath: '/tmp/hud-domain-alias/hud-authority-lease.json',
+        authorityLockPath: '/tmp/hud-domain-alias/hud-authority.lock', reconcileLockPath: '/tmp/hud-domain-alias/hud-reconcile.lock',
+        session: { canonicalId: 'canonical-id', equivalentIds: ['canonical-id', 'native-id'], source: 'native-alias' },
+        claimant: { sessionId: 'canonical-id', leaderPaneId: '%leader', tmuxSessionName: 'managed' }, managed: true,
+      }),
+      probeTmuxInstance: async () => ({
+        paneTarget: '%leader', sessionName: 'managed', paneInstanceId: 'native-id', sessionInstanceId: '',
+        instanceId: 'native-id', source: 'pane', paneTagStatus: 'present',
+      }),
+      listCurrentWindowPanes: () => [{ paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' }],
+      createHudWatchPane: () => '%hud', resizeTmuxPane: () => true, resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+    assert.equal(result.status, 'recreated');
+  });
+
+  it('preserves a command-matching candidate when pane or server instance identity is missing or mismatched', async () => {
+    const killed: string[] = [];
+    let created = false;
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: 'socket', TMUX_PANE: '%leader', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' },
+        { paneId: '%reused', currentCommand: 'node', paneInstanceId: 'other-server', startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch` },
+      ],
+      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      createHudWatchPane: () => { created = true; return '%new'; },
+      resizeTmuxPane: () => { assert.fail('unverified candidate must not be resized'); return false; },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+    assert.equal(result.status, 'unchanged');
+    assert.equal(result.paneId, null);
+    assert.deepEqual(killed, []);
+    assert.equal(created, false);
+  });
+
+  it('does not deduplicate an unverified pane-id reuse observed after create', async () => {
+    const killed: string[] = [];
+    let listCount = 0;
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: 'socket', TMUX_PANE: '%leader', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => {
+        listCount += 1;
+        return listCount === 1
+          ? [{ paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' }]
+          : [
+            { paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' },
+            { paneId: '%reused', currentCommand: 'node', paneInstanceId: 'other-instance', sessionInstanceId: 'sess-a', startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch` },
+          ];
+      },
+      createHudWatchPane: () => '%created',
+      killTmuxPane: (paneId) => { killed.push(paneId); return true; },
+      resizeTmuxPane: () => { assert.fail('unsafe post-create candidates must not be resized'); return false; },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+    assert.equal(result.status, 'recreated');
+    assert.equal(result.paneId, '%created');
+    assert.deepEqual(killed, []);
   });
 });

--- a/src/hud/__tests__/resource-leak-watch.test.ts
+++ b/src/hud/__tests__/resource-leak-watch.test.ts
@@ -10,7 +10,13 @@ describe('HUD watch resource cleanup', () => {
 
     await runWatchMode('/tmp/project', { watch: true, json: false, tmux: false }, {
       isTTY: true,
-      env: {},
+      env: {
+        TMUX: '/tmp/tmux-1000/default,12345,0',
+        TMUX_PANE: '%hud',
+        OMX_SESSION_ID: 'session-a',
+        OMX_TMUX_HUD_OWNER: '1',
+        OMX_TMUX_HUD_LEADER_PANE: '%leader',
+      },
       readHudConfigFn: async () => ({ preset: 'minimal', git: { display: 'repo-branch' }, statusLine: { preset: 'minimal' } }),
       readAllStateFn: async () => ({ cwd: '/tmp/project', config: {}, state: {}, timestamp: '2026-05-21T00:00:00.000Z' }) as never,
       renderHudFn: () => 'hud',

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -8,6 +8,7 @@ import {
   buildHudResizeHookName,
   buildHudResizeHookSlot,
   buildHudWatchCommand,
+  createHudWatchPane,
   findLegacyFocusedHudWatchPaneIds,
   findHudWatchPaneIds,
   hudPaneMatchesOwner,
@@ -24,6 +25,22 @@ import {
 } from '../tmux.js';
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS } from '../constants.js';
 
+
+describe('HUD pane creation', () => {
+  it('rolls back only the new pane when instance-tag readback fails', () => {
+    const calls: string[][] = [];
+    const result = createHudWatchPane('/repo', 'node omx.js hud --watch', { instanceId: 'session-a' }, (args) => {
+      calls.push(args);
+      if (args[0] === 'split-window') return '%new\n';
+      if (args[0] === 'show-option') return 'wrong-session\n';
+      return '';
+    });
+
+    assert.equal(result, null);
+    assert.deepEqual(calls.at(-1), ['kill-pane', '-t', '%new']);
+    assert.equal(calls.filter((args) => args[0] === 'kill-pane').length, 1);
+  });
+});
 describe('HUD resize hook helpers', () => {
   it('builds a deterministic hook name from the tmux session, window, and leader identity', () => {
     assert.equal(buildHudResizeHookName('$7', '@3', '%1'), 'omx_hud_resize_7_3_1');

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -57,11 +57,11 @@ describe('exact HUD pane destruction', () => {
       paneInstanceId: 'pane-birth',
       sessionInstanceId: 'session-birth',
       sessionName: 'managed',
-    }, (args) => { calls.push(args); return ''; }), true);
+    }, (args) => { calls.push(args); return '__omx_hud_pane_kill_applied__\n'; }), true);
     assert.deepEqual(calls, [[
       'if-shell', '-t', '%2', '-F',
       `#{&&:#{==:#{pane_id},%2},#{==:#{pane_current_command},node},#{==:#{pane_start_command},${startCommand}},#{==:#{@omx_pane_instance_id},pane-birth},#{==:#{@omx_instance_id},session-birth},#{==:#{session_name},managed}}`,
-      'kill-pane -t %2', '',
+      'kill-pane -t %2 \\; display-message -p __omx_hud_pane_kill_applied__', 'display-message -p __omx_hud_pane_kill_rejected__',
     ]]);
   });
 
@@ -77,6 +77,19 @@ describe('exact HUD pane destruction', () => {
       sessionName: 'managed',
     }, (args) => { calls.push(args); return ''; }), false);
     assert.deepEqual(calls, []);
+  });
+
+  it('reports a server-side false branch as no destruction', () => {
+    const startCommand = `exec env OMX_SESSION_ID='session-a' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node /repo/omx.js hud --watch`;
+    assert.equal(killExactHudPane({
+      paneId: '%2',
+      currentCommand: 'node',
+      startCommand,
+      owner: { sessionId: 'session-a', leaderPaneId: '%1' },
+      paneInstanceId: 'pane-birth',
+      sessionInstanceId: 'session-birth',
+      sessionName: 'managed',
+    }, () => '__omx_hud_pane_kill_rejected__\n'), false);
   });
 });
 describe('HUD resize hook helpers', () => {
@@ -121,154 +134,56 @@ describe('HUD resize hook helpers', () => {
     assert.equal(parseHudResizeHookContext('$7\t@3\n', '%1; touch /tmp/owned'), null);
   });
 
-  function statefulHooks(options: {
-    failSlot?: string;
-    beforeConditionalMutation?: (slot: string, hooks: Map<string, string>) => void;
-  } = {}) {
-    const hooks = new Map<string, string>();
+  function appendOnlyHooks() {
+    const hooks = new Map<string, string[]>();
     const calls: string[][] = [];
-    const parseTmuxCommand = (command: string): string[] => {
-      const parts: string[] = [];
-      let part = '';
-      let tokenStarted = false;
-      let quote: "'" | '"' | null = null;
-      for (let index = 0; index < command.length; index += 1) {
-        const char = command[index]!;
-        if (quote) {
-          if (char === quote) {
-            quote = null;
-          } else if (char === '\\' && quote === '"' && command[index + 1] !== undefined) {
-            part += command[index + 1]!;
-            index += 1;
-          } else {
-            part += char;
-          }
-        } else if (char === "'" || char === '"') {
-          quote = char;
-          tokenStarted = true;
-        } else if (char === '\\' && command[index + 1] !== undefined) {
-          part += command[index + 1]!;
-          tokenStarted = true;
-          index += 1;
-        } else if (/\s/.test(char)) {
-          if (tokenStarted) parts.push(part);
-          part = '';
-          tokenStarted = false;
-        } else {
-          part += char;
-          tokenStarted = true;
-        }
-      }
-      if (tokenStarted) parts.push(part);
-      return parts;
-    };
     const exec = (args: string[]): string => {
       calls.push(args);
-      if (args[0] === 'display-message') return '$7\t@3\n';
-      if (args[0] === 'show-hooks') {
-        const command = hooks.get(args[3]!);
-        return command ? `${args[3]} ${command}\n` : '';
+      if (args[0] === 'display-message' && args.at(-1) === '#{session_id}\t#{window_id}') return '$7\t@3\n';
+      if (args[0] === 'display-message' && args.at(-1) === '#{@omx_pane_instance_id}\t#{@omx_instance_id}\t#{session_name}') return 'pane-birth\tsession-birth\tmanaged\n';
+      if (args[0] === 'set-hook' && args[1] === '-a') {
+        const event = args[4]!;
+        hooks.set(event, [...(hooks.get(event) ?? []), args[5]!]);
+        return '';
       }
-      if (args[0] === 'if-shell') {
-        const condition = parseTmuxCommand(args[3]!);
-        const mutation = parseTmuxCommand(args[4]!);
-        const slot = mutation[mutation[1] === '-u' ? 4 : 3]!;
-        options.beforeConditionalMutation?.(slot, hooks);
-        if (slot === options.failSlot) throw new Error('injected hook failure');
-        const expectedOutput = condition.at(-1);
-        const actualOutput = hooks.has(slot) ? `${slot} ${hooks.get(slot)!}` : '';
-        if (expectedOutput !== actualOutput) return '';
-        if (mutation[1] === '-u') {
-          hooks.delete(slot);
-        } else {
-          hooks.set(slot, mutation[4]!);
-        }
-      }
+      if (args[0] === 'show-hooks') return (hooks.get(args[3]!) ?? []).map((command, index) => `${args[3]}[${index}] ${command}`).join('\n');
       return '';
     };
     return { hooks, calls, exec };
   }
 
-  it('installs a vacant paired hook set with mandatory readback and exact pane commands', () => {
-    const fixture = statefulHooks();
+  it('appends a self-validating paired hook generation without touching existing hooks', () => {
+    const fixture = appendOnlyHooks();
+    fixture.hooks.set('client-resized', ['run-shell -b foreign']);
     assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), true);
-    const resizeSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
-    const layoutSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
-    assert.match(fixture.hooks.get(resizeSlot) ?? '', /resize-pane.*%9/);
-    assert.match(fixture.hooks.get(layoutSlot) ?? '', /--reconcile-tmux/);
-    assert.ok(fixture.calls.some((args) => args[0] === 'show-hooks' && args[3] === resizeSlot));
-    assert.ok(fixture.calls.some((args) => args[0] === 'show-hooks' && args[3] === layoutSlot));
+    assert.equal(fixture.hooks.get('client-resized')?.[0], 'run-shell -b foreign');
+    assert.equal(fixture.hooks.get('client-resized')?.length, 2);
+    assert.equal(fixture.hooks.get('window-layout-changed')?.length, 1);
+    const command = fixture.hooks.get('client-resized')?.[1] ?? '';
+    assert.match(command, /if-shell -t %9 -F/);
+    assert.match(command, /pane-birth/);
+    assert.match(command, /session-birth/);
+    assert.match(command, /omx-hud-owned:[0-9a-f-]{36}/);
+    assert.ok(fixture.calls.some((args) => args[0] === 'set-hook' && args[1] === '-a'));
+    assert.equal(fixture.calls.some((args) => args[0] === 'set-hook' && args.includes('-u')), false);
   });
 
-  it('rolls back both hook slots when paired install fails', () => {
-    const layoutSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
-    const fixture = statefulHooks({ failSlot: layoutSlot });
-    assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), false);
-    assert.equal(fixture.hooks.size, 0);
-  });
-
-  it('preserves a foreign insertion that races vacant-slot registration', () => {
-    const resizeSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
-    const fixture = statefulHooks({
-      beforeConditionalMutation: (slot, hooks) => {
-        if (slot === resizeSlot && !hooks.has(slot)) hooks.set(slot, 'run-shell -b foreign');
-      },
-    });
-    assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), false);
-    assert.equal(fixture.hooks.get(resizeSlot), 'run-shell -b foreign');
-    assert.ok(fixture.calls.some((args) => args[0] === 'if-shell'));
-    assert.equal(fixture.calls.some((args) => args[0] === 'set-hook'), false);
-  });
-
-  it('preserves a foreign replacement that races stale rollback', () => {
-    const resizeSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
-    const layoutSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
-    const fixture = statefulHooks({
-      failSlot: layoutSlot,
-      beforeConditionalMutation: (slot, hooks) => {
-        if (slot === resizeSlot && hooks.has(slot)) hooks.set(slot, 'run-shell -b foreign replacement');
-      },
-    });
-    assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), false);
-    assert.equal(fixture.hooks.get(resizeSlot), 'run-shell -b foreign replacement');
-    assert.equal(fixture.hooks.has(layoutSlot), false);
-  });
-
-  it('tears down only the exact owned hook generations through conditional mutation', () => {
-    const fixture = statefulHooks();
-    const resizeSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
-    const layoutSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
+  it('retains a partial pair and makes every retained generation inert on teardown', () => {
+    const fixture = appendOnlyHooks();
     assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), true);
-    assert.match(fixture.hooks.get(resizeSlot) ?? '', /# omx-hud-owned:.*:[0-9a-f-]{36}$/);
     assert.equal(unregisterHudResizeHook('%1', fixture.exec), true);
-    assert.equal(fixture.hooks.has(resizeSlot), false);
-    assert.equal(fixture.hooks.has(layoutSlot), false);
-    assert.equal(fixture.calls.some((args) => args[0] === 'set-hook'), false);
-    assert.ok(fixture.calls.filter((args) => args[0] === 'if-shell').length >= 4);
+    assert.ok(fixture.calls.some((args) => args[0] === 'set-option' && args.at(-1) === '0'));
+    assert.equal(fixture.calls.some((args) => args[0] === 'set-hook' && args.includes('-u')), false);
+    assert.equal(fixture.hooks.get('client-resized')?.length, 1);
+    assert.equal(fixture.hooks.get('window-layout-changed')?.length, 1);
   });
 
-  it('preserves a foreign replacement while safely removing the remaining owned slot', () => {
-    const fixture = statefulHooks();
-    const resizeSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
-    const layoutSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
+  it('does not require or mutate a derived hook slot during foreign replacement races', () => {
+    const fixture = appendOnlyHooks();
+    fixture.hooks.set('window-layout-changed', ['run-shell -b foreign replacement']);
     assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), true);
-    fixture.hooks.set(layoutSlot, 'run-shell -b foreign');
-    assert.equal(unregisterHudResizeHook('%1', fixture.exec), true);
-    assert.equal(fixture.hooks.has(resizeSlot), false);
-    assert.equal(fixture.hooks.get(layoutSlot), 'run-shell -b foreign');
-  });
-
-  it('uses leader-scoped slots and treats an absent pair as completed cleanup', () => {
-    const first = statefulHooks();
-    const second = statefulHooks();
-    assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, first.exec), true);
-    assert.equal(registerHudResizeHook('%10', '%2', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, second.exec), true);
-    assert.notEqual(
-      buildHudResizeHookSlot('omx_hud_resize_7_3_1'),
-      buildHudResizeHookSlot('omx_hud_resize_7_3_2'),
-    );
-    const absent = statefulHooks();
-    assert.equal(unregisterHudResizeHook('%1', absent.exec), true);
+    assert.equal(fixture.hooks.get('window-layout-changed')?.[0], 'run-shell -b foreign replacement');
+    assert.equal(fixture.calls.some((args) => args[0] === 'if-shell'), false);
   });
 });
 
@@ -516,6 +431,7 @@ describe('HUD pane ownership helpers', () => {
           '#{window_height}',
           '#{@omx_pane_instance_id}',
           '#{@omx_instance_id}',
+          '#{session_name}',
           '#{pane_start_command}',
           '#{pane_current_path}',
         ].join('\x1f'),
@@ -577,7 +493,7 @@ describe('dead HUD pane reaper', () => {
     );
 
     const result = reapDeadHudPanes(panes, {
-      killPane: () => {
+      killExactPane: () => {
         throw new Error('team ACK command should not be classified as a HUD watch pane');
       },
     });
@@ -586,7 +502,7 @@ describe('dead HUD pane reaper', () => {
     assert.deepEqual(result, { reaped: [], preserved: [] });
   });
 
-  it('kills HUD panes whose leader pane is not present in the snapshot', () => {
+  it('preserves a stale HUD when the snapshot lacks immutable pane identity', () => {
     const panes = parseTmuxPaneSnapshot(
       [
         '%1\tcodex\tcodex',
@@ -596,14 +512,35 @@ describe('dead HUD pane reaper', () => {
     const killed: string[] = [];
 
     const result = reapDeadHudPanes(panes, {
-      killPane: (paneId) => {
-        killed.push(paneId);
+      killExactPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
     });
 
-    assert.deepEqual(killed, ['%2']);
-    assert.deepEqual(result, { reaped: ['%2'], preserved: [] });
+    assert.deepEqual(killed, []);
+    assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
+  });
+
+  it('passes only a complete immutable candidate to the reaper callback', () => {
+    const startCommand = `exec env OMX_SESSION_ID='doctor-smoke' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%9' node /repo/omx.js hud --watch`;
+    const candidates: unknown[] = [];
+    const result = reapDeadHudPanes([{
+      paneId: '%2',
+      currentCommand: 'node',
+      startCommand,
+      paneInstanceId: 'pane-birth',
+      sessionInstanceId: 'session-birth',
+      sessionName: 'managed',
+      currentPath: '/missing (deleted)',
+    }], {
+      killExactPane: (candidate) => {
+        candidates.push(candidate);
+        return false;
+      },
+    });
+    assert.equal(candidates.length, 1);
+    assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
   });
 
   it('preserves HUD panes whose leader pane is alive', () => {
@@ -615,7 +552,7 @@ describe('dead HUD pane reaper', () => {
     );
 
     const result = reapDeadHudPanes(panes, {
-      killPane: () => {
+      killExactPane: () => {
         throw new Error('live leader HUD should not be killed');
       },
     });
@@ -632,7 +569,7 @@ describe('dead HUD pane reaper', () => {
     );
 
     const result = reapDeadHudPanes(panes, {
-      killPane: () => {
+      killExactPane: () => {
         throw new Error('legacy untagged HUD should not be killed');
       },
     });
@@ -640,7 +577,7 @@ describe('dead HUD pane reaper', () => {
     assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
   });
 
-  it('kills untagged HUD panes whose tmux cwd has been deleted', () => {
+  it('preserves deleted-cwd HUD panes without immutable identity', () => {
     const deletedPath = join(tmpdir(), `omx-doctor-native-hook-dist-${process.pid}-${Date.now()} (deleted)`);
     rmSync(deletedPath, { recursive: true, force: true });
     const panes = parseTmuxPaneSnapshot(
@@ -652,17 +589,17 @@ describe('dead HUD pane reaper', () => {
     const killed: string[] = [];
 
     const result = reapDeadHudPanes(panes, {
-      killPane: (paneId) => {
-        killed.push(paneId);
+      killExactPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
     });
 
-    assert.deepEqual(killed, ['%2']);
-    assert.deepEqual(result, { reaped: ['%2'], preserved: [] });
+    assert.deepEqual(killed, []);
+    assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
   });
 
-  it('kills deleted-cwd doctor-smoke HUD panes even when an old owner tag points at a live leader', () => {
+  it('preserves doctor-smoke HUD panes without immutable identity', () => {
     const deletedPath = join(tmpdir(), `omx-doctor-plugin-hook-${process.pid}-${Date.now()} (deleted)`);
     rmSync(deletedPath, { recursive: true, force: true });
     const panes = parseTmuxPaneSnapshot(
@@ -674,17 +611,17 @@ describe('dead HUD pane reaper', () => {
     const killed: string[] = [];
 
     const result = reapDeadHudPanes(panes, {
-      killPane: (paneId) => {
-        killed.push(paneId);
+      killExactPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
     });
 
-    assert.deepEqual(killed, ['%2']);
-    assert.deepEqual(result, { reaped: ['%2'], preserved: [] });
+    assert.deepEqual(killed, []);
+    assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
   });
 
-  it('kills doctor-smoke HUD panes even if a literal deleted-marker cwd was materialized', () => {
+  it('preserves doctor-smoke panes with a materialized marker unless identity is complete', () => {
     const parent = mkdtempSync(join(tmpdir(), 'omx-doctor-plugin-hook-live-marker-'));
     const materializedDeletedPath = join(parent, 'smoke (deleted)');
     mkdirSync(materializedDeletedPath);
@@ -698,14 +635,14 @@ describe('dead HUD pane reaper', () => {
 
     try {
       const result = reapDeadHudPanes(panes, {
-        killPane: (paneId) => {
-          killed.push(paneId);
+        killExactPane: (candidate) => {
+          killed.push(candidate.paneId);
           return true;
         },
       });
 
-      assert.deepEqual(killed, ['%2']);
-      assert.deepEqual(result, { reaped: ['%2'], preserved: [] });
+      assert.deepEqual(killed, []);
+      assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
     } finally {
       rmSync(parent, { recursive: true, force: true });
     }
@@ -722,7 +659,7 @@ describe('dead HUD pane reaper', () => {
     );
 
     const result = reapDeadHudPanes(panes, {
-      killPane: () => {
+      killExactPane: () => {
         throw new Error('live leader HUD with stale launch cwd should not be killed');
       },
     });
@@ -730,7 +667,7 @@ describe('dead HUD pane reaper', () => {
     assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
   });
 
-  it('kills deleted-cwd HUD panes when their owner leader is no longer live', () => {
+  it('preserves stale-owner HUD panes unless immutable identity is complete', () => {
     const deletedPath = join(tmpdir(), `omx-dead-leader-deleted-cwd-${process.pid}-${Date.now()} (deleted)`);
     rmSync(deletedPath, { recursive: true, force: true });
     const panes = parseTmuxPaneSnapshot(
@@ -742,14 +679,14 @@ describe('dead HUD pane reaper', () => {
     const killed: string[] = [];
 
     const result = reapDeadHudPanes(panes, {
-      killPane: (paneId) => {
-        killed.push(paneId);
+      killExactPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
     });
 
-    assert.deepEqual(killed, ['%2']);
-    assert.deepEqual(result, { reaped: ['%2'], preserved: [] });
+    assert.deepEqual(killed, []);
+    assert.deepEqual(result, { reaped: [], preserved: ['%2'] });
   });
 
   it('preserves HUD panes in an existing cwd whose name ends with the deleted marker text', () => {
@@ -765,7 +702,7 @@ describe('dead HUD pane reaper', () => {
 
     try {
       const result = reapDeadHudPanes(panes, {
-        killPane: () => {
+        killExactPane: () => {
           throw new Error('live cwd with literal marker suffix should not be killed');
         },
       });
@@ -795,7 +732,7 @@ describe('dead HUD pane reaper', () => {
 
     try {
       const result = reapDeadHudPanes(panes, {
-        killPane: () => {
+        killExactPane: () => {
           throw new Error('live tab cwd with literal marker suffix should not be killed');
         },
       });
@@ -817,7 +754,7 @@ describe('dead HUD pane reaper', () => {
     );
 
     const result = reapDeadHudPanes(panes, {
-      killPane: () => {
+      killExactPane: () => {
         throw new Error('misleading non-OMX HUD text should not be killed');
       },
     });
@@ -834,7 +771,7 @@ describe('dead HUD pane reaper', () => {
     );
 
     const result = reapDeadHudPanes(panes, {
-      killPane: () => {
+      killExactPane: () => {
         throw new Error('non-HUD panes should not be killed');
       },
     });
@@ -854,13 +791,13 @@ describe('dead HUD pane reaper', () => {
 
     const result = reapDeadHudPanes(panes, {
       isLivePane: (paneId) => paneId === '%9',
-      killPane: (paneId) => {
-        killed.push(paneId);
+      killExactPane: (candidate) => {
+        killed.push(candidate.paneId);
         return true;
       },
     });
 
-    assert.deepEqual(killed, ['%2']);
-    assert.deepEqual(result, { reaped: ['%2'], preserved: ['%3'] });
+    assert.deepEqual(killed, []);
+    assert.deepEqual(result, { reaped: [], preserved: ['%2', '%3'] });
   });
 });

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -136,11 +136,22 @@ describe('HUD resize hook helpers', () => {
 
   function appendOnlyHooks() {
     const hooks = new Map<string, string[]>();
+    const options = new Map<string, string>();
+
     const calls: string[][] = [];
     const exec = (args: string[]): string => {
       calls.push(args);
       if (args[0] === 'display-message' && args.at(-1) === '#{session_id}\t#{window_id}') return '$7\t@3\n';
       if (args[0] === 'display-message' && args.at(-1) === '#{@omx_pane_instance_id}\t#{@omx_instance_id}\t#{session_name}') return 'pane-birth\tsession-birth\tmanaged\n';
+      if (args[0] === 'display-message' && args.at(-1) === '#{@omx_pane_instance_id}\t#{@omx_instance_id}\t#{session_name}\t#{window_id}\t#{pane_current_command}\t#{pane_start_command}') return 'pane-birth\tsession-birth\tmanaged\t@3\tnode\texec env OMX_SESSION_ID=sess OMX_TMUX_HUD_LEADER_PANE=%1 node omx hud --watch\n';
+
+      if (args[0] === 'display-message' && args.at(-1) === '#{@omx_pane_instance_id}') return 'leader-birth\n';
+
+      if (args[0] === 'set-option') {
+        options.set(args.at(-2) ?? '', args.at(-1) ?? '');
+        return '';
+      }
+      if (args[0] === 'show-option') return options.get(args.at(-1) ?? '') ?? '';
       if (args[0] === 'set-hook' && args[1] === '-a') {
         const event = args[4]!;
         hooks.set(event, [...(hooks.get(event) ?? []), args[5]!]);
@@ -163,16 +174,21 @@ describe('HUD resize hook helpers', () => {
     assert.match(command, /if-shell -t %9 -F/);
     assert.match(command, /pane-birth/);
     assert.match(command, /session-birth/);
+    assert.match(command, /pane_start_command/);
+    assert.match(command, /window_id/);
+    assert.ok((command.match(/if-shell/g) ?? []).length >= 2);
     assert.match(command, /omx-hud-owned:[0-9a-f-]{36}/);
     assert.ok(fixture.calls.some((args) => args[0] === 'set-hook' && args[1] === '-a'));
     assert.equal(fixture.calls.some((args) => args[0] === 'set-hook' && args.includes('-u')), false);
   });
 
-  it('retains a partial pair and makes every retained generation inert on teardown', () => {
+  it('retains a partial pair and deactivates only its persisted generation on teardown', () => {
     const fixture = appendOnlyHooks();
     assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), true);
     assert.equal(unregisterHudResizeHook('%1', fixture.exec), true);
-    assert.ok(fixture.calls.some((args) => args[0] === 'set-option' && args.at(-1) === '0'));
+    const inactive = fixture.calls.filter((args) => args[0] === 'set-option' && args.at(-1) === '0');
+    assert.equal(inactive.length, 1);
+    assert.equal(fixture.calls.some((args) => args[0] === 'show-hooks'), false);
     assert.equal(fixture.calls.some((args) => args[0] === 'set-hook' && args.includes('-u')), false);
     assert.equal(fixture.hooks.get('client-resized')?.length, 1);
     assert.equal(fixture.hooks.get('window-layout-changed')?.length, 1);

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -27,7 +27,8 @@ import { HUD_RESIZE_RECONCILE_DELAY_SECONDS } from '../constants.js';
 
 
 describe('HUD pane creation', () => {
-  it('rolls back only the new pane when instance-tag readback fails', () => {
+  it('preserves a newly split pane when instance-tag readback fails without exact teardown proof', () => {
+
     const calls: string[][] = [];
     const result = createHudWatchPane('/repo', 'node omx.js hud --watch', { instanceId: 'session-a' }, (args) => {
       calls.push(args);
@@ -37,8 +38,8 @@ describe('HUD pane creation', () => {
     });
 
     assert.equal(result, null);
-    assert.deepEqual(calls.at(-1), ['kill-pane', '-t', '%new']);
-    assert.equal(calls.filter((args) => args[0] === 'kill-pane').length, 1);
+    assert.equal(calls.filter((args) => args[0] === 'kill-pane').length, 0);
+    assert.ok(calls.some((args) => args[0] === 'show-option' && args.at(-1) === '@omx_pane_instance_id'));
   });
 });
 describe('HUD resize hook helpers', () => {

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -157,10 +157,19 @@ describe('HUD resize hook helpers', () => {
         hooks.set(event, [...(hooks.get(event) ?? []), args[5]!]);
         return '';
       }
+      if (args[0] === 'if-shell' && args[1] === '-t' && args[3] === '-F') {
+        const expected = (args[4] ?? '').match(/#\{(@[^}]+)\},([^}]+)\}/);
+        if (expected && (options.get(expected[1]!) ?? '') !== expected[2]) return '';
+        for (const command of (args[5] ?? '').split(' \\; ')) {
+          const parts = command.split(' ');
+          if (parts[0] === 'set-option' && parts[1] === '-t' && parts[3] && parts[4]) options.set(parts[3], parts[4]);
+        }
+        return '';
+      }
       if (args[0] === 'show-hooks') return (hooks.get(args[3]!) ?? []).map((command, index) => `${args[3]}[${index}] ${command}`).join('\n');
       return '';
     };
-    return { hooks, calls, exec };
+    return { hooks, options, calls, exec };
   }
 
   it('appends a self-validating paired hook generation without touching existing hooks', () => {
@@ -182,16 +191,51 @@ describe('HUD resize hook helpers', () => {
     assert.equal(fixture.calls.some((args) => args[0] === 'set-hook' && args.includes('-u')), false);
   });
 
-  it('retains a partial pair and deactivates only its persisted generation on teardown', () => {
+  it('reuses a verified published generation across unchanged reconciliation', () => {
+    const fixture = appendOnlyHooks();
+    assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), true);
+    assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), true);
+    assert.equal(fixture.hooks.get('client-resized')?.length, 1);
+    assert.equal(fixture.hooks.get('window-layout-changed')?.length, 1);
+    assert.equal([...fixture.options.entries()].filter(([name, value]) => name.startsWith('@omx_hud_hook_active_') && value === '1').length, 1);
+  });
+
+  it('keeps a partial standalone pair inert when the second append fails', () => {
+    const fixture = appendOnlyHooks();
+    const exec = (args: string[]) => {
+      if (args[0] === 'set-hook' && args[4] === 'window-layout-changed') throw new Error('append failed');
+      return fixture.exec(args);
+    };
+    assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, exec), false);
+    assert.equal(fixture.hooks.get('client-resized')?.length, 1);
+    assert.equal(fixture.hooks.get('window-layout-changed')?.length ?? 0, 0);
+    assert.equal([...fixture.options.entries()].some(([name, value]) => name.startsWith('@omx_hud_hook_active_') && value === '1'), false);
+  });
+
+  it('retains the complete append-only pair and CAS-deactivates its persisted generation on teardown', () => {
     const fixture = appendOnlyHooks();
     assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), true);
     assert.equal(unregisterHudResizeHook('%1', fixture.exec), true);
     const inactive = fixture.calls.filter((args) => args[0] === 'set-option' && args.at(-1) === '0');
     assert.equal(inactive.length, 1);
-    assert.equal(fixture.calls.some((args) => args[0] === 'show-hooks'), false);
+    assert.equal(fixture.calls.some((args) => args[0] === 'show-hooks'), true);
     assert.equal(fixture.calls.some((args) => args[0] === 'set-hook' && args.includes('-u')), false);
     assert.equal(fixture.hooks.get('client-resized')?.length, 1);
     assert.equal(fixture.hooks.get('window-layout-changed')?.length, 1);
+  });
+
+  it('does not deactivate a successor published after teardown read its predecessor', () => {
+    const fixture = appendOnlyHooks();
+    assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), true);
+    const exec = (args: string[]) => {
+      if (args[0] === 'if-shell') {
+        fixture.options.set('@omx_hud_hook_generation_1_leader_birth', '44444444-4444-4444-8444-444444444444');
+        return '';
+      }
+      return fixture.exec(args);
+    };
+    assert.equal(unregisterHudResizeHook('%1', exec), false);
+    assert.equal(fixture.options.get('@omx_hud_hook_active_44444444_4444_4444_8444_444444444444'), undefined);
   });
 
   it('does not require or mutate a derived hook slot during foreign replacement races', () => {
@@ -199,7 +243,7 @@ describe('HUD resize hook helpers', () => {
     fixture.hooks.set('window-layout-changed', ['run-shell -b foreign replacement']);
     assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), true);
     assert.equal(fixture.hooks.get('window-layout-changed')?.[0], 'run-shell -b foreign replacement');
-    assert.equal(fixture.calls.some((args) => args[0] === 'if-shell'), false);
+    assert.equal(fixture.calls.some((args) => args[0] === 'if-shell'), true);
   });
 });
 

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -307,7 +307,7 @@ describe('HUD resize hook helpers', () => {
 describe('HUD pane ownership helpers', () => {
   it('parses pane geometry from tmux pane snapshots without corrupting the start command or cwd', () => {
     const [pane] = parseTmuxPaneSnapshot(
-      `%2\tnode\t0\t47\t160\t3\t49\t160\t50\texec env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch\t/tmp/repo`,
+      `%2\tnode\t0\t47\t160\t3\t49\t160\t50\tpane-a\tsession-a\texec env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch\t/tmp/repo`,
     );
 
     assert.deepEqual(pane, {
@@ -320,6 +320,8 @@ describe('HUD pane ownership helpers', () => {
       paneBottom: 49,
       windowWidth: 160,
       windowHeight: 50,
+      paneInstanceId: 'pane-a',
+      sessionInstanceId: 'session-a',
       startCommand: `exec env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
       currentPath: '/tmp/repo',
     });
@@ -405,7 +407,7 @@ describe('HUD pane ownership helpers', () => {
     assert.deepEqual(findHudWatchPaneIds(panes, '%3', { sessionId: 'sess-a', leaderPaneId: '%1' }), ['%2']);
   });
 
-  it('matches same-session HUD panes only within the requested leader ownership scope', () => {
+  it('requires both session and leader identity when both owner fields are requested', () => {
     const panes = parseTmuxPaneSnapshot(
       [
         '%1\tcodex\tcodex',
@@ -415,9 +417,9 @@ describe('HUD pane ownership helpers', () => {
         `%5\tnode\texec env OMX_SESSION_ID='sess-b' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' /node /omx.js hud --watch`,
       ].join('\n'),
     );
-    
-    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%1' }), ['%2', '%4']);
-    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%3' }), ['%3', '%4']);
+
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%1' }), ['%2']);
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%3' }), ['%3']);
     assert.deepEqual(findHudWatchPaneIds(panes, '%1', { leaderPaneId: '%1' }), ['%2', '%5']);
   });
 
@@ -486,7 +488,7 @@ describe('HUD pane ownership helpers', () => {
     assert.deepEqual(findLegacyFocusedHudWatchPaneIds(panes, '%1'), ['%2', '%6']);
   });
 
-  it('matches session-owned legacy HUD panes without leader tags for same-session cleanup', () => {
+  it('preserves session-owned legacy HUD panes without leader tags when both owner fields are requested', () => {
     const panes = parseTmuxPaneSnapshot(
       [
         '%1\tcodex\tcodex',
@@ -495,7 +497,7 @@ describe('HUD pane ownership helpers', () => {
       ].join('\n'),
     );
 
-    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%1' }), ['%2']);
+    assert.deepEqual(findHudWatchPaneIds(panes, '%1', { sessionId: 'sess-a', leaderPaneId: '%1' }), []);
   });
 
   it('matches equivalent owner and canonical session ids for the same leader', () => {
@@ -544,6 +546,8 @@ describe('HUD pane ownership helpers', () => {
           '#{pane_bottom}',
           '#{window_width}',
           '#{window_height}',
+          '#{@omx_pane_instance_id}',
+          '#{@omx_instance_id}',
           '#{pane_start_command}',
           '#{pane_current_path}',
         ].join('\x1f'),

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -65,6 +65,25 @@ describe('exact HUD pane destruction', () => {
     ]]);
   });
 
+  it('escapes every tmux format delimiter in dynamic identity operands', () => {
+    const calls: string[][] = [];
+    const startCommand = `exec env OMX_SESSION_ID='session-a' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node /repo/omx.js hud --watch`;
+    assert.equal(killExactHudPane({
+      paneId: '%2',
+      currentCommand: 'node#{},:',
+      startCommand,
+      owner: { sessionId: 'session-a', leaderPaneId: '%1' },
+      paneInstanceId: 'pane#{},:birth',
+      sessionInstanceId: 'session#{},:birth',
+      sessionName: 'managed#{},:',
+    }, (args) => { calls.push(args); return '__omx_hud_pane_kill_applied__\n'; }), true);
+    const condition = calls[0]?.[4] ?? '';
+    assert.match(condition, /node###\{#\}#,#:/);
+    assert.match(condition, /pane###\{#\}#,#:birth/);
+    assert.match(condition, /session###\{#\}#,#:birth/);
+    assert.match(condition, /managed###\{#\}#,#:/);
+  });
+
   it('rejects a reused pane before issuing the conditional mutation when its captured owner no longer matches', () => {
     const calls: string[][] = [];
     assert.equal(killExactHudPane({

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -22,6 +22,8 @@ import {
   parseHudResizeHookContext,
   registerHudResizeHook,
   unregisterHudResizeHook,
+  killExactHudPane,
+
 } from '../tmux.js';
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS } from '../constants.js';
 
@@ -40,6 +42,41 @@ describe('HUD pane creation', () => {
     assert.equal(result, null);
     assert.equal(calls.filter((args) => args[0] === 'kill-pane').length, 0);
     assert.ok(calls.some((args) => args[0] === 'show-option' && args.at(-1) === '@omx_pane_instance_id'));
+  });
+});
+
+describe('exact HUD pane destruction', () => {
+  it('uses one tmux server-side conditional mutation for the complete HUD identity', () => {
+    const calls: string[][] = [];
+    const startCommand = `exec env OMX_SESSION_ID='session-a' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node /repo/omx.js hud --watch`;
+    assert.equal(killExactHudPane({
+      paneId: '%2',
+      currentCommand: 'node',
+      startCommand,
+      owner: { sessionId: 'session-a', leaderPaneId: '%1' },
+      paneInstanceId: 'pane-birth',
+      sessionInstanceId: 'session-birth',
+      sessionName: 'managed',
+    }, (args) => { calls.push(args); return ''; }), true);
+    assert.deepEqual(calls, [[
+      'if-shell', '-t', '%2', '-F',
+      `#{&&:#{==:#{pane_id},%2},#{==:#{pane_current_command},node},#{==:#{pane_start_command},${startCommand}},#{==:#{@omx_pane_instance_id},pane-birth},#{==:#{@omx_instance_id},session-birth},#{==:#{session_name},managed}}`,
+      'kill-pane -t %2', '',
+    ]]);
+  });
+
+  it('rejects a reused pane before issuing the conditional mutation when its captured owner no longer matches', () => {
+    const calls: string[][] = [];
+    assert.equal(killExactHudPane({
+      paneId: '%2',
+      currentCommand: 'bash',
+      startCommand: 'bash',
+      owner: { sessionId: 'session-a', leaderPaneId: '%1' },
+      paneInstanceId: 'replacement-pane',
+      sessionInstanceId: 'replacement-session',
+      sessionName: 'managed',
+    }, (args) => { calls.push(args); return ''; }), false);
+    assert.deepEqual(calls, []);
   });
 });
 describe('HUD resize hook helpers', () => {
@@ -84,9 +121,47 @@ describe('HUD resize hook helpers', () => {
     assert.equal(parseHudResizeHookContext('$7\t@3\n', '%1; touch /tmp/owned'), null);
   });
 
-  function statefulHooks(options: { failSlot?: string } = {}) {
+  function statefulHooks(options: {
+    failSlot?: string;
+    beforeConditionalMutation?: (slot: string, hooks: Map<string, string>) => void;
+  } = {}) {
     const hooks = new Map<string, string>();
     const calls: string[][] = [];
+    const parseTmuxCommand = (command: string): string[] => {
+      const parts: string[] = [];
+      let part = '';
+      let tokenStarted = false;
+      let quote: "'" | '"' | null = null;
+      for (let index = 0; index < command.length; index += 1) {
+        const char = command[index]!;
+        if (quote) {
+          if (char === quote) {
+            quote = null;
+          } else if (char === '\\' && quote === '"' && command[index + 1] !== undefined) {
+            part += command[index + 1]!;
+            index += 1;
+          } else {
+            part += char;
+          }
+        } else if (char === "'" || char === '"') {
+          quote = char;
+          tokenStarted = true;
+        } else if (char === '\\' && command[index + 1] !== undefined) {
+          part += command[index + 1]!;
+          tokenStarted = true;
+          index += 1;
+        } else if (/\s/.test(char)) {
+          if (tokenStarted) parts.push(part);
+          part = '';
+          tokenStarted = false;
+        } else {
+          part += char;
+          tokenStarted = true;
+        }
+      }
+      if (tokenStarted) parts.push(part);
+      return parts;
+    };
     const exec = (args: string[]): string => {
       calls.push(args);
       if (args[0] === 'display-message') return '$7\t@3\n';
@@ -94,11 +169,20 @@ describe('HUD resize hook helpers', () => {
         const command = hooks.get(args[3]!);
         return command ? `${args[3]} ${command}\n` : '';
       }
-      if (args[0] === 'set-hook') {
-        const slot = args[args[1] === '-u' ? 4 : 3]!;
+      if (args[0] === 'if-shell') {
+        const condition = parseTmuxCommand(args[3]!);
+        const mutation = parseTmuxCommand(args[4]!);
+        const slot = mutation[mutation[1] === '-u' ? 4 : 3]!;
+        options.beforeConditionalMutation?.(slot, hooks);
         if (slot === options.failSlot) throw new Error('injected hook failure');
-        if (args[1] === '-u') hooks.delete(slot);
-        else hooks.set(slot, args[4]!);
+        const expectedOutput = condition.at(-1);
+        const actualOutput = hooks.has(slot) ? `${slot} ${hooks.get(slot)!}` : '';
+        if (expectedOutput !== actualOutput) return '';
+        if (mutation[1] === '-u') {
+          hooks.delete(slot);
+        } else {
+          hooks.set(slot, mutation[4]!);
+        }
       }
       return '';
     };
@@ -121,6 +205,46 @@ describe('HUD resize hook helpers', () => {
     const fixture = statefulHooks({ failSlot: layoutSlot });
     assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), false);
     assert.equal(fixture.hooks.size, 0);
+  });
+
+  it('preserves a foreign insertion that races vacant-slot registration', () => {
+    const resizeSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
+    const fixture = statefulHooks({
+      beforeConditionalMutation: (slot, hooks) => {
+        if (slot === resizeSlot && !hooks.has(slot)) hooks.set(slot, 'run-shell -b foreign');
+      },
+    });
+    assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), false);
+    assert.equal(fixture.hooks.get(resizeSlot), 'run-shell -b foreign');
+    assert.ok(fixture.calls.some((args) => args[0] === 'if-shell'));
+    assert.equal(fixture.calls.some((args) => args[0] === 'set-hook'), false);
+  });
+
+  it('preserves a foreign replacement that races stale rollback', () => {
+    const resizeSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
+    const layoutSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
+    const fixture = statefulHooks({
+      failSlot: layoutSlot,
+      beforeConditionalMutation: (slot, hooks) => {
+        if (slot === resizeSlot && hooks.has(slot)) hooks.set(slot, 'run-shell -b foreign replacement');
+      },
+    });
+    assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), false);
+    assert.equal(fixture.hooks.get(resizeSlot), 'run-shell -b foreign replacement');
+    assert.equal(fixture.hooks.has(layoutSlot), false);
+  });
+
+  it('tears down only the exact owned hook generations through conditional mutation', () => {
+    const fixture = statefulHooks();
+    const resizeSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
+    const layoutSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
+    assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), true);
+    assert.match(fixture.hooks.get(resizeSlot) ?? '', /# omx-hud-owned:.*:[0-9a-f-]{36}$/);
+    assert.equal(unregisterHudResizeHook('%1', fixture.exec), true);
+    assert.equal(fixture.hooks.has(resizeSlot), false);
+    assert.equal(fixture.hooks.has(layoutSlot), false);
+    assert.equal(fixture.calls.some((args) => args[0] === 'set-hook'), false);
+    assert.ok(fixture.calls.filter((args) => args[0] === 'if-shell').length >= 4);
   });
 
   it('preserves a foreign replacement while safely removing the remaining owned slot', () => {

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -122,19 +122,15 @@ describe('HUD resize hook helpers', () => {
     assert.equal(fixture.hooks.size, 0);
   });
 
-  it('preserves foreign replacement and removes only an exact owned pair', () => {
+  it('preserves a foreign replacement while safely removing the remaining owned slot', () => {
     const fixture = statefulHooks();
     const resizeSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
     const layoutSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
     assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), true);
     fixture.hooks.set(layoutSlot, 'run-shell -b foreign');
-    assert.equal(unregisterHudResizeHook('%1', fixture.exec), false);
-    assert.match(fixture.hooks.get(resizeSlot) ?? '', /omx-hud-owned/);
-    assert.equal(fixture.hooks.get(layoutSlot), 'run-shell -b foreign');
-    fixture.hooks.set(layoutSlot, fixture.hooks.get(resizeSlot)!.replace(resizeSlot, layoutSlot));
     assert.equal(unregisterHudResizeHook('%1', fixture.exec), true);
     assert.equal(fixture.hooks.has(resizeSlot), false);
-    assert.equal(fixture.hooks.has(layoutSlot), false);
+    assert.equal(fixture.hooks.get(layoutSlot), 'run-shell -b foreign');
   });
 
   it('uses leader-scoped slots and treats an absent pair as completed cleanup', () => {

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -83,241 +83,71 @@ describe('HUD resize hook helpers', () => {
     assert.equal(parseHudResizeHookContext('$7\t@3\n', '%1; touch /tmp/owned'), null);
   });
 
-  it('registers client-resized and layout-change hooks at session scope with exact HUD pane targeting', () => {
+  function statefulHooks(options: { failSlot?: string } = {}) {
+    const hooks = new Map<string, string>();
     const calls: string[][] = [];
-
-    const result = registerHudResizeHook(
-      '%9',
-      '%1',
-      3,
-      { cwd: '/repo', env: { TMUX: '/tmp/tmux', OMX_SESSION_ID: 'sess-a' } },
-      (args) => {
-        calls.push(args);
-        if (args[0] === 'display-message') return '$7\t@3\n';
-        return '';
-      },
-    );
-
-    const hookSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
-    const layoutHookSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
-    assert.equal(result, true);
-    assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%1', '#{session_id}\t#{window_id}']);
-    assert.equal(calls[1]?.[0], 'set-hook');
-    assert.equal(calls[1]?.[1], '-t');
-    assert.equal(calls[1]?.[2], '$7');
-    assert.equal(calls[1]?.[3], hookSlot);
-    assert.match(calls[1]?.[4] ?? '', /^run-shell -b /);
-    assert.match(calls[1]?.[4] ?? '', /resize-pane/);
-    assert.match(calls[1]?.[4] ?? '', /set-hook/);
-    assert.doesNotMatch(calls[1]?.[4] ?? '', /'-w'/);
-    assert.match(calls[1]?.[4] ?? '', new RegExp(`sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}`));
-    assert.match(calls[1]?.[4] ?? '', new RegExp(hookSlot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-    assert.deepEqual(calls[2], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
-    assert.equal(calls[3]?.[0], 'set-hook');
-    assert.equal(calls[3]?.[1], '-t');
-    assert.equal(calls[3]?.[2], '$7');
-    assert.equal(calls[3]?.[3], layoutHookSlot);
-    assert.match(calls[3]?.[4] ?? '', /^run-shell -b /);
-    assert.match(calls[3]?.[4] ?? '', /display-message/);
-    assert.match(calls[3]?.[4] ?? '', /--reconcile-tmux/);
-    assert.match(calls[3]?.[4] ?? '', /TMUX/);
-    assert.match(calls[3]?.[4] ?? '', /TMUX_PANE/);
-    assert.match(calls[3]?.[4] ?? '', /OMX_TMUX_HUD_OWNER/);
-    assert.doesNotMatch(calls[3]?.[4] ?? '', /wait-for/);
-  });
-
-  it('reports partial failure but keeps the resize hook when layout-change hook install fails', () => {
-    const calls: string[][] = [];
-    const hookSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
-    const layoutHookSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
-
-    const result = registerHudResizeHook(
-      '%9',
-      '%1',
-      3,
-      { cwd: '/repo', env: { TMUX: '/tmp/tmux', OMX_SESSION_ID: 'sess-a' } },
-      (args) => {
-        calls.push(args);
-        if (args[0] === 'display-message') return '$7\t@3\n';
-        if (args[0] === 'set-hook' && args[3] === layoutHookSlot) {
-          throw new Error('layout hook rejected');
-        }
-        return '';
-      },
-    );
-
-    assert.equal(result, false);
-    assert.deepEqual(calls[1]?.slice(0, 4), ['set-hook', '-t', '$7', hookSlot]);
-    assert.deepEqual(calls[2], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
-    assert.deepEqual(calls[3]?.slice(0, 4), ['set-hook', '-t', '$7', layoutHookSlot]);
-  });
-
-  it('unregisters the same per-window hook slot', () => {
-    const calls: string[][] = [];
-
-    const result = unregisterHudResizeHook('%1', (args) => {
+    const exec = (args: string[]): string => {
       calls.push(args);
       if (args[0] === 'display-message') return '$7\t@3\n';
-      return '';
-    });
-
-    assert.equal(result, true);
-    assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%1', '#{session_id}\t#{window_id}']);
-    assert.deepEqual(calls[1], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
-    assert.deepEqual(calls[2], [
-      'set-hook',
-      '-u',
-      '-t',
-      '$7',
-      buildHudResizeHookSlot('omx_hud_resize_7_3_1'),
-    ]);
-    assert.deepEqual(calls[3], [
-      'set-hook',
-      '-u',
-      '-t',
-      '$7',
-      buildHudLayoutHookSlot('omx_hud_resize_7_3_1'),
-    ]);
-  });
-
-  it('attempts to unregister the layout hook even when resize hook unregister fails', () => {
-    const calls: string[][] = [];
-
-    const result = unregisterHudResizeHook('%1', (args) => {
-      calls.push(args);
-      if (args[0] === 'display-message') return '$7\t@3\n';
-      if (args[0] === 'set-hook' && args[4] === buildHudResizeHookSlot('omx_hud_resize_7_3_1')) {
-        throw new Error('resize hook unregister rejected');
+      if (args[0] === 'show-hooks') {
+        const command = hooks.get(args[3]!);
+        return command ? `${args[3]} ${command}\n` : '';
+      }
+      if (args[0] === 'set-hook') {
+        const slot = args[args[1] === '-u' ? 4 : 3]!;
+        if (slot === options.failSlot) throw new Error('injected hook failure');
+        if (args[1] === '-u') hooks.delete(slot);
+        else hooks.set(slot, args[4]!);
       }
       return '';
-    });
+    };
+    return { hooks, calls, exec };
+  }
 
-    assert.equal(result, false);
-    assert.deepEqual(calls[2], [
-      'set-hook',
-      '-u',
-      '-t',
-      '$7',
+  it('installs a vacant paired hook set with mandatory readback and exact pane commands', () => {
+    const fixture = statefulHooks();
+    assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), true);
+    const resizeSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
+    const layoutSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
+    assert.match(fixture.hooks.get(resizeSlot) ?? '', /resize-pane.*%9/);
+    assert.match(fixture.hooks.get(layoutSlot) ?? '', /--reconcile-tmux/);
+    assert.ok(fixture.calls.some((args) => args[0] === 'show-hooks' && args[3] === resizeSlot));
+    assert.ok(fixture.calls.some((args) => args[0] === 'show-hooks' && args[3] === layoutSlot));
+  });
+
+  it('rolls back both hook slots when paired install fails', () => {
+    const layoutSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
+    const fixture = statefulHooks({ failSlot: layoutSlot });
+    assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), false);
+    assert.equal(fixture.hooks.size, 0);
+  });
+
+  it('preserves foreign replacement and removes only an exact owned pair', () => {
+    const fixture = statefulHooks();
+    const resizeSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
+    const layoutSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
+    assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, fixture.exec), true);
+    fixture.hooks.set(layoutSlot, 'run-shell -b foreign');
+    assert.equal(unregisterHudResizeHook('%1', fixture.exec), false);
+    assert.match(fixture.hooks.get(resizeSlot) ?? '', /omx-hud-owned/);
+    assert.equal(fixture.hooks.get(layoutSlot), 'run-shell -b foreign');
+    fixture.hooks.set(layoutSlot, fixture.hooks.get(resizeSlot)!.replace(resizeSlot, layoutSlot));
+    assert.equal(unregisterHudResizeHook('%1', fixture.exec), true);
+    assert.equal(fixture.hooks.has(resizeSlot), false);
+    assert.equal(fixture.hooks.has(layoutSlot), false);
+  });
+
+  it('uses leader-scoped slots and treats an absent pair as completed cleanup', () => {
+    const first = statefulHooks();
+    const second = statefulHooks();
+    assert.equal(registerHudResizeHook('%9', '%1', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, first.exec), true);
+    assert.equal(registerHudResizeHook('%10', '%2', 3, { cwd: '/repo', env: { TMUX: '/tmp/tmux' } }, second.exec), true);
+    assert.notEqual(
       buildHudResizeHookSlot('omx_hud_resize_7_3_1'),
-    ]);
-    assert.deepEqual(calls[3], [
-      'set-hook',
-      '-u',
-      '-t',
-      '$7',
-      buildHudLayoutHookSlot('omx_hud_resize_7_3_1'),
-    ]);
-  });
-
-  it('uses distinct hook slots for different windows in the same session', () => {
-    const registered: string[][] = [];
-
-    const execFor = (windowId: string) => (args: string[]) => {
-      if (args[0] === 'display-message') return `$7\t${windowId}\n`;
-      registered.push(args);
-      return '';
-    };
-
-    assert.equal(registerHudResizeHook('%9', '%1', 3, execFor('@3')), true);
-    assert.equal(registerHudResizeHook('%10', '%2', 3, execFor('@4')), true);
-
-    const firstSlot = registered[0]?.[3];
-    const secondSlot = registered[3]?.[3];
-    assert.match(firstSlot ?? '', /^client-resized\[\d+\]$/);
-    assert.match(secondSlot ?? '', /^client-resized\[\d+\]$/);
-    assert.notEqual(firstSlot, secondSlot);
-  });
-
-  it('uses distinct hook slots for different leaders in the same session window', () => {
-    const registered: string[][] = [];
-    const execTmuxSync = (args: string[]) => {
-      if (args[0] === 'display-message') return '$7\t@3\n';
-      registered.push(args);
-      return '';
-    };
-
-    assert.equal(registerHudResizeHook('%9', '%1', 3, execTmuxSync), true);
-    assert.equal(registerHudResizeHook('%10', '%2', 3, execTmuxSync), true);
-
-    const firstSlot = registered[0]?.[3];
-    const secondSlot = registered[3]?.[3];
-    assert.match(firstSlot ?? '', /^client-resized\[\d+\]$/);
-    assert.match(secondSlot ?? '', /^client-resized\[\d+\]$/);
-    assert.notEqual(firstSlot, secondSlot);
-  });
-
-  it('reuses the same hook slot when a HUD pane is recreated for the same leader', () => {
-    const registered: string[][] = [];
-    const execTmuxSync = (args: string[]) => {
-      if (args[0] === 'display-message') return '$7\t@3\n';
-      registered.push(args);
-      return '';
-    };
-
-    assert.equal(registerHudResizeHook('%9', '%1', 3, execTmuxSync), true);
-    assert.equal(registerHudResizeHook('%10', '%1', 3, execTmuxSync), true);
-
-    assert.equal(registered[0]?.[3], registered[3]?.[3]);
-  });
-
-  it('does not unregister the legacy hook when installing the leader-scoped hook fails', () => {
-    const calls: string[][] = [];
-
-    const result = registerHudResizeHook('%9', '%1', 3, (args) => {
-      calls.push(args);
-      if (args[0] === 'display-message') return '$7\t@3\n';
-      if (args[0] === 'set-hook' && args[1] === '-t') throw new Error('transient tmux failure');
-      return '';
-    });
-
-    assert.equal(result, false);
-    assert.deepEqual(calls.map((args) => args.slice(0, 2)), [
-      ['display-message', '-p'],
-      ['set-hook', '-t'],
-    ]);
-  });
-
-  it('keeps registration successful when legacy cleanup fails after installing the leader-scoped hook', () => {
-    const calls: string[][] = [];
-
-    const result = registerHudResizeHook('%9', '%1', 3, (args) => {
-      calls.push(args);
-      if (args[0] === 'display-message') return '$7\t@3\n';
-      if (args[0] === 'set-hook' && args[1] === '-u') throw new Error('stale legacy cleanup failure');
-      return '';
-    });
-
-    assert.equal(result, true);
-    assert.equal(calls[1]?.[0], 'set-hook');
-    assert.equal(calls[1]?.[1], '-t');
-    assert.deepEqual(calls[2], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
-  });
-
-  it('unregisters only the leader-scoped hook slot for the selected leader', () => {
-    const unregistered: string[][] = [];
-    const execTmuxSync = (args: string[]) => {
-      if (args[0] === 'display-message') return '$7\t@3\n';
-      unregistered.push(args);
-      return '';
-    };
-
-    assert.equal(unregisterHudResizeHook('%2', execTmuxSync), true);
-
-    assert.deepEqual(unregistered[0], ['set-hook', '-u', '-t', '$7', buildHudResizeHookSlot('omx_hud_resize_7_3')]);
-    assert.deepEqual(unregistered[1], [
-      'set-hook',
-      '-u',
-      '-t',
-      '$7',
       buildHudResizeHookSlot('omx_hud_resize_7_3_2'),
-    ]);
-    assert.deepEqual(unregistered[2], [
-      'set-hook',
-      '-u',
-      '-t',
-      '$7',
-      buildHudLayoutHookSlot('omx_hud_resize_7_3_2'),
-    ]);
+    );
+    const absent = statefulHooks();
+    assert.equal(unregisterHudResizeHook('%1', absent.exec), true);
   });
 });
 

--- a/src/hud/authority.ts
+++ b/src/hud/authority.ts
@@ -1,8 +1,10 @@
-import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { acquireHudLifecycleLock, releaseHudLifecycleLock, type HudLifecycleLockDeps } from './lifecycle-lock.js';
+import { resolveHudControlPlaneDomain, type ResolvedHudControlPlaneDomain } from '../mcp/state-paths.js';
 import { getPackageRoot } from '../utils/package.js';
 import { resolveOmxCliEntryPath } from '../utils/paths.js';
 
@@ -30,6 +32,10 @@ export interface RunHudAuthorityTickDeps {
   nowMs?: () => number;
   random?: () => number;
   onLockAcquired?: () => Promise<void> | void;
+  resolveDomain?: (options: { cwd: string; env: NodeJS.ProcessEnv }) => Promise<ResolvedHudControlPlaneDomain>;
+  lifecycleLockDeps?: HudLifecycleLockDeps;
+  processStartIdentity?: (pid: number) => Promise<string | undefined>;
+  probeLeaseProcess?: (lease: HudAuthorityLease) => Promise<'live' | 'dead' | 'reused' | 'uncertain'>;
 }
 
 interface HudAuthorityState {
@@ -46,11 +52,6 @@ interface HudAuthorityState {
   last_status: 'spawned' | 'skipped' | 'failed' | 'locked';
   last_reason: string;
   last_error?: string;
-}
-
-interface AuthorityLock {
-  path: string;
-  token: string;
 }
 
 class AuthorityStateReadError extends Error {
@@ -198,81 +199,103 @@ async function writeAuthorityStateUnlessNewerCooldown(path: string, state: HudAu
   return writeAuthorityState(path, state);
 }
 
-async function tryCreateAuthorityLock(lockPath: string, nowMs: number): Promise<AuthorityLock | null> {
-  const token = randomUUID();
-  let createdDir = false;
+export interface HudAuthorityLease {
+  version: 2;
+  domainKey: string;
+  baseStateDir: string;
+  rootSource: ResolvedHudControlPlaneDomain['rootSource'];
+  pid: number;
+  platform: NodeJS.Platform;
+  processStartIdentity: string;
+  claimant: string;
+  token: string;
+  generation: string;
+  heartbeatAt: string;
+}
+
+function claimantIdentity(domain: ResolvedHudControlPlaneDomain): string {
+  return JSON.stringify(domain.claimant);
+}
+
+function isLease(value: unknown): value is HudAuthorityLease {
+  if (typeof value !== 'object' || value === null) return false;
+  const lease = value as Partial<HudAuthorityLease>;
+  return lease.version === 2
+    && typeof lease.domainKey === 'string' && lease.domainKey.length > 0
+    && typeof lease.baseStateDir === 'string' && lease.baseStateDir.length > 0
+    && typeof lease.rootSource === 'string' && lease.rootSource.length > 0
+    && typeof lease.pid === 'number' && Number.isInteger(lease.pid) && lease.pid > 0
+    && typeof lease.platform === 'string' && lease.platform.length > 0
+    && typeof lease.processStartIdentity === 'string' && lease.processStartIdentity.trim().length > 0
+    && typeof lease.claimant === 'string'
+    && typeof lease.token === 'string' && lease.token.length > 0
+    && typeof lease.generation === 'string' && lease.generation.length > 0
+    && parseIsoMs(lease.heartbeatAt) !== null;
+}
+
+async function readAuthorityLease(path: string): Promise<HudAuthorityLease | null | 'uncertain'> {
   try {
-    await mkdir(lockPath, { recursive: false });
-    createdDir = true;
-    await writeFile(join(lockPath, 'owner.json'), JSON.stringify({
-      token,
-      pid: process.pid,
-      acquired_at: new Date(nowMs).toISOString(),
-    }, null, 2));
-    return { path: lockPath, token };
-  } catch {
-    if (createdDir) await rm(lockPath, { recursive: true, force: true }).catch(() => {});
-    return null;
+    const value: unknown = JSON.parse(await readFile(path, 'utf8'));
+    return isLease(value) ? value : 'uncertain';
+  } catch (error) {
+    return isNotFoundError(error) ? null : 'uncertain';
   }
 }
 
-async function readAuthorityLockOwner(lockPath: string): Promise<{ token?: unknown } | null> {
-  return readFile(join(lockPath, 'owner.json'), 'utf-8')
-    .then((content) => JSON.parse(content) as { token?: unknown })
-    .catch(() => null);
-}
-
-async function restoreMovedLock(fromPath: string, toPath: string): Promise<void> {
-  const restored = await rename(fromPath, toPath).then(() => true).catch(() => false);
-  if (!restored) await rm(fromPath, { recursive: true, force: true }).catch(() => {});
-}
-
-async function acquireAuthorityLock(lockPath: string, staleMs: number, nowMs: number): Promise<AuthorityLock | null> {
-  const created = await tryCreateAuthorityLock(lockPath, nowMs);
-  if (created) return created;
-
-  const observedOwner = await readAuthorityLockOwner(lockPath);
-  const lockStat = await stat(lockPath).catch(() => null);
-  if (!lockStat || nowMs - lockStat.mtimeMs <= staleMs) return null;
-
-  const reapPath = `${lockPath}.stale.${process.pid}.${nowMs}.${randomUUID()}`;
+async function writeAuthorityLease(path: string, lease: HudAuthorityLease): Promise<boolean> {
+  const tempPath = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
   try {
-    await rename(lockPath, reapPath);
+    await writeFile(tempPath, JSON.stringify(lease, null, 2));
+    await rename(tempPath, path);
+    return true;
   } catch {
-    return null;
+    await rm(tempPath, { force: true }).catch(() => {});
+    return false;
   }
-
-  const reapedOwner = await readAuthorityLockOwner(reapPath);
-  const reapedStat = await stat(reapPath).catch(() => null);
-  const reapedObservedLock = observedOwner?.token === reapedOwner?.token
-    && reapedStat?.mtimeMs === lockStat.mtimeMs
-    && nowMs - reapedStat.mtimeMs > staleMs;
-
-  if (!reapedObservedLock) {
-    await restoreMovedLock(reapPath, lockPath);
-    return null;
-  }
-
-  await rm(reapPath, { recursive: true, force: true }).catch(() => {});
-  return tryCreateAuthorityLock(lockPath, nowMs);
 }
 
-async function releaseAuthorityLock(lock: AuthorityLock): Promise<void> {
-  const releasePath = `${lock.path}.release.${process.pid}.${Date.now()}.${lock.token}`;
+async function defaultProcessStartIdentity(pid: number): Promise<string | undefined> {
+  if (process.platform === 'linux') {
+    try {
+      const content = await readFile(`/proc/${pid}/stat`, 'utf8');
+      const closeParen = content.lastIndexOf(')');
+      const fields = closeParen < 0 ? [] : content.slice(closeParen + 2).trim().split(/\s+/);
+      const startTime = fields[19];
+      return startTime ? `linux:${startTime}` : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (process.platform === 'darwin') {
+    const result = spawnSync('ps', ['-o', 'lstart=', '-p', String(pid)], { encoding: 'utf8' });
+    const startTime = result.status === 0 ? result.stdout.trim() : '';
+    return startTime ? `darwin:${startTime}` : undefined;
+  }
+
+  if (process.platform === 'win32') {
+    const result = spawnSync('powershell.exe', [
+      '-NoProfile', '-NonInteractive', '-Command', `(Get-Process -Id ${pid}).StartTime.ToUniversalTime().Ticks`,
+    ], { encoding: 'utf8', windowsHide: true });
+    const startTime = result.status === 0 ? result.stdout.trim() : '';
+    return startTime ? `win32:${startTime}` : undefined;
+  }
+
+  return undefined;
+}
+
+async function defaultProbeLeaseProcess(lease: HudAuthorityLease): Promise<'live' | 'dead' | 'reused' | 'uncertain'> {
+  if (lease.platform !== process.platform) return 'uncertain';
   try {
-    await rename(lock.path, releasePath);
-  } catch {
-    return;
+    process.kill(lease.pid, 0);
+  } catch (error) {
+    return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ESRCH' ? 'dead' : 'uncertain';
   }
-
-  const releaseOwner = await readAuthorityLockOwner(releasePath);
-  if (releaseOwner?.token === lock.token) {
-    await rm(releasePath, { recursive: true, force: true }).catch(() => {});
-    return;
-  }
-
-  await restoreMovedLock(releasePath, lock.path);
+  const currentIdentity = await defaultProcessStartIdentity(lease.pid);
+  if (!currentIdentity) return 'uncertain';
+  return currentIdentity === lease.processStartIdentity ? 'live' : 'reused';
 }
+
 
 function buildAuthorityState(
   cwd: string,
@@ -295,50 +318,6 @@ function buildAuthorityState(
   };
 }
 
-async function writeRateLimitSkipState(
-  path: string,
-  ownerPath: string,
-  cwd: string,
-  nowMs: number,
-  cooldownMs: number,
-  fallbackJitterMs: number,
-  previousState: HudAuthorityState,
-  reason: 'rate_limited' | 'rate_limited_after_lock',
-): Promise<void> {
-  const skippedState = buildAuthorityState(cwd, nowMs, cooldownMs, previousState.jitter_ms ?? fallbackJitterMs, {
-    last_spawn_at: previousState.last_spawn_at,
-    last_skip_at: new Date(nowMs).toISOString(),
-    next_allowed_at: previousState.next_allowed_at,
-    skip_count: (previousState.skip_count ?? 0) + 1,
-    last_status: 'skipped',
-    last_reason: reason,
-    last_error: previousState.last_error,
-  });
-  await writeAuthorityState(ownerPath, skippedState);
-  await writeAuthorityStateUnlessNewerCooldown(path, skippedState);
-}
-
-async function writeInvalidStateDiagnostic(
-  path: string,
-  ownerPath: string,
-  cwd: string,
-  nowMs: number,
-  cooldownMs: number,
-  jitterMs: number,
-  error: unknown,
-): Promise<boolean> {
-  const failedState = buildAuthorityState(cwd, nowMs, cooldownMs, jitterMs, {
-    last_skip_at: new Date(nowMs).toISOString(),
-    next_allowed_at: new Date(nowMs + cooldownMs + jitterMs).toISOString(),
-    last_status: 'failed',
-    last_reason: 'invalid_authority_state',
-    last_error: error instanceof Error ? error.message : String(error),
-  });
-  const ownerWritten = await writeAuthorityState(ownerPath, failedState);
-  const stateWritten = await writeAuthorityState(path, failedState);
-  return ownerWritten || stateWritten;
-}
-
 export async function runHudAuthorityTick(
   options: RunHudAuthorityTickOptions,
   deps: RunHudAuthorityTickDeps = {},
@@ -348,157 +327,163 @@ export async function runHudAuthorityTick(
   const nodePath = options.nodePath ?? process.execPath;
   const packageRoot = options.packageRoot ?? getPackageRoot();
   const pollMs = Math.max(1, options.pollMs ?? 75);
-  const timeoutMs = Math.max(100, options.timeoutMs ?? 5_000);
+  // The watcher is synchronous by design: never imply a detached child can be
+  // reaped safely later. A bounded tick also keeps the shared lease short.
+  const timeoutMs = Math.min(1_000, Math.max(1, options.timeoutMs ?? 1_000));
   const minIntervalMs = Math.max(
-    250,
+    1_000,
     asPositiveNumber(
       options.minIntervalMs ?? options.env?.OMX_HUD_AUTHORITY_MIN_INTERVAL_MS ?? process.env.OMX_HUD_AUTHORITY_MIN_INTERVAL_MS,
       5_000,
     ),
   );
-  const jitterMaxMs = Math.max(
-    0,
-    asNonNegativeNumber(
-      options.jitterMs ?? options.env?.OMX_HUD_AUTHORITY_JITTER_MS ?? process.env.OMX_HUD_AUTHORITY_JITTER_MS,
-      250,
-    ),
-  );
+  const jitterMaxMs = Math.max(0, asNonNegativeNumber(
+    options.jitterMs ?? options.env?.OMX_HUD_AUTHORITY_JITTER_MS ?? process.env.OMX_HUD_AUTHORITY_JITTER_MS,
+    250,
+  ));
   const nowMs = deps.nowMs?.() ?? Date.now();
-  const random = deps.random ?? Math.random;
-  const jitterMs = jitterMaxMs > 0 ? Math.floor(random() * (jitterMaxMs + 1)) : 0;
+  const jitterMs = jitterMaxMs > 0 ? Math.floor((deps.random ?? Math.random)() * (jitterMaxMs + 1)) : 0;
   const mergedEnv = { ...process.env, ...options.env };
-  const watcherScript = resolveHudWatcherScript(packageRoot, 'notify-fallback-watcher.js', cwd, mergedEnv);
-  const notifyScript = resolveHudWatcherScript(packageRoot, 'notify-hook.js', cwd, mergedEnv);
-  const authorityStateDir = join(cwd, '.omx', 'state');
-  const authorityOwnerPath = join(authorityStateDir, 'notify-fallback-authority-owner.json');
-  const authorityStatePath = join(authorityStateDir, 'notify-fallback-authority-state.json');
-  const authorityLockPath = join(authorityStateDir, 'notify-fallback-authority.lock');
+  const domain = await (deps.resolveDomain ?? resolveHudControlPlaneDomain)({ cwd, env: mergedEnv });
   const runProcess = deps.runProcess ?? defaultRunProcess;
 
-  await mkdir(authorityStateDir, { recursive: true }).catch(() => {});
+  await mkdir(domain.baseStateDir, { recursive: true });
+  const acquired = await acquireHudLifecycleLock(
+    { path: domain.authorityLockPath, domainKey: domain.domainKey, staleMs: Math.max(minIntervalMs * 2, timeoutMs * 2) },
+    { ...deps.lifecycleLockDeps, nowMs: deps.lifecycleLockDeps?.nowMs ?? (() => nowMs) },
+  );
+  // A contender must not emit state or diagnostics. The current primary owns
+  // every canonical authority write, including rate-limit diagnostics.
+  if (acquired.status !== 'acquired' || !acquired.lock) return;
 
-  let previousState: HudAuthorityState | null;
   try {
-    previousState = await readAuthorityState(authorityStatePath);
-  } catch (error) {
-    if (!(await writeInvalidStateDiagnostic(authorityStatePath, authorityOwnerPath, cwd, nowMs, minIntervalMs, jitterMs, error))) {
-      throw new Error('failed to persist HUD authority invalid-state diagnostic');
+    await deps.onLockAcquired?.();
+    const claimant = claimantIdentity(domain);
+    const processStartIdentity = await (deps.processStartIdentity ?? defaultProcessStartIdentity)(process.pid);
+    if (typeof processStartIdentity !== 'string' || processStartIdentity.trim().length === 0) return;
+    const currentLease = await readAuthorityLease(domain.authorityLeasePath);
+    const ownsLease = currentLease !== null
+      && currentLease !== 'uncertain'
+      && currentLease.domainKey === domain.domainKey
+      && currentLease.baseStateDir === domain.baseStateDir
+      && currentLease.rootSource === domain.rootSource
+      && currentLease.pid === process.pid
+      && currentLease.platform === process.platform
+      && currentLease.processStartIdentity === processStartIdentity
+      && currentLease.claimant === claimant;
+    const leaseProbe = currentLease !== null && currentLease !== 'uncertain'
+      ? await (deps.probeLeaseProcess ?? defaultProbeLeaseProcess)(currentLease).catch(() => 'uncertain' as const)
+      : 'uncertain' as const;
+    const staleLease = currentLease !== null
+      && currentLease !== 'uncertain'
+      && currentLease.domainKey === domain.domainKey
+      && currentLease.baseStateDir === domain.baseStateDir
+      && currentLease.rootSource === domain.rootSource
+      && nowMs - (parseIsoMs(currentLease.heartbeatAt) ?? nowMs) >= minIntervalMs * 2
+      && (leaseProbe === 'dead' || leaseProbe === 'reused');
+    // Malformed metadata, no immutable process identity, unrelated domains, and
+    // probe uncertainty are all ownership uncertainty. Never replace them.
+    if (currentLease === 'uncertain' || (currentLease !== null && !ownsLease && !staleLease)) return;
+    const token = ownsLease ? currentLease.token : randomUUID();
+    const generation = ownsLease ? currentLease.generation : randomUUID();
+    if (!(await writeAuthorityLease(domain.authorityLeasePath, {
+      version: 2,
+      domainKey: domain.domainKey,
+      baseStateDir: domain.baseStateDir,
+      rootSource: domain.rootSource,
+      pid: process.pid,
+      platform: process.platform,
+      processStartIdentity,
+      claimant,
+      token,
+      generation,
+      heartbeatAt: new Date(nowMs).toISOString(),
+    }))) {
+      return;
     }
-    return;
-  }
-  const previousNextAllowedMs = parseIsoMs(previousState?.next_allowed_at);
-  if (previousState && previousNextAllowedMs !== null && nowMs < previousNextAllowedMs) {
-    await writeRateLimitSkipState(
-      authorityStatePath,
-      authorityOwnerPath,
-      cwd,
-      nowMs,
-      minIntervalMs,
-      jitterMs,
-      previousState,
-      'rate_limited',
-    );
-    return;
-  }
+    let previousState: HudAuthorityState | null;
+    try {
+      previousState = await readAuthorityState(domain.authorityStatePath);
+    } catch (error) {
+      const failedState = buildAuthorityState(cwd, nowMs, minIntervalMs, jitterMs, {
+        last_skip_at: new Date(nowMs).toISOString(),
+        next_allowed_at: new Date(nowMs + minIntervalMs + jitterMs).toISOString(),
+        last_status: 'failed',
+        last_reason: 'invalid_authority_state',
+        last_error: error instanceof Error ? error.message : String(error),
+      });
+      if (!(await writeAuthorityState(domain.authorityStatePath, failedState))) {
+        throw new Error('failed to persist HUD authority invalid-state diagnostic');
+      }
+      return;
+    }
 
-  const lock = await acquireAuthorityLock(authorityLockPath, timeoutMs + minIntervalMs, nowMs);
-  if (!lock) {
-    const latestState = await readAuthorityState(authorityStatePath).catch(() => null);
-    const diagnosticState = latestState ?? previousState;
-    const lockedState = buildAuthorityState(cwd, nowMs, minIntervalMs, diagnosticState?.jitter_ms ?? jitterMs, {
-      last_spawn_at: diagnosticState?.last_spawn_at,
-      last_skip_at: new Date(nowMs).toISOString(),
-      next_allowed_at: diagnosticState?.next_allowed_at,
-      skip_count: (diagnosticState?.skip_count ?? 0) + 1,
-      last_status: 'locked',
-      last_reason: 'spawn_lock_active',
-      last_error: diagnosticState?.last_error,
-    });
-    await writeAuthorityState(authorityOwnerPath, lockedState);
-    return;
-  }
+    const nextAllowedMs = parseIsoMs(previousState?.next_allowed_at);
+    if (previousState && nextAllowedMs !== null && nowMs < nextAllowedMs) {
+      const skippedState = buildAuthorityState(cwd, nowMs, minIntervalMs, previousState.jitter_ms, {
+        last_spawn_at: previousState.last_spawn_at,
+        last_skip_at: new Date(nowMs).toISOString(),
+        next_allowed_at: previousState.next_allowed_at,
+        skip_count: previousState.skip_count + 1,
+        last_status: 'skipped',
+        last_reason: 'rate_limited',
+        last_error: previousState.last_error,
+      });
+      await writeAuthorityStateUnlessNewerCooldown(domain.authorityStatePath, skippedState);
+      return;
+    }
 
-  await deps.onLockAcquired?.();
-
-  let lockedState: HudAuthorityState | null;
-  try {
-    lockedState = await readAuthorityState(authorityStatePath);
-  } catch (error) {
-    const diagnosticWritten = await writeInvalidStateDiagnostic(authorityStatePath, authorityOwnerPath, cwd, nowMs, minIntervalMs, jitterMs, error);
-    await releaseAuthorityLock(lock);
-    if (!diagnosticWritten) throw new Error('failed to persist HUD authority rate-limit state');
-    return;
-  }
-  const lockedNextAllowedMs = parseIsoMs(lockedState?.next_allowed_at);
-  if (lockedState && lockedNextAllowedMs !== null && nowMs < lockedNextAllowedMs) {
-    await writeRateLimitSkipState(
-      authorityStatePath,
-      authorityOwnerPath,
-      cwd,
-      nowMs,
-      minIntervalMs,
-      jitterMs,
-      lockedState,
-      'rate_limited_after_lock',
-    );
-    await releaseAuthorityLock(lock);
-    return;
-  }
-
-  const nextAllowedAt = new Date(nowMs + minIntervalMs + jitterMs).toISOString();
-  const spawnedState = buildAuthorityState(cwd, nowMs, minIntervalMs, jitterMs, {
-    last_spawn_at: new Date(nowMs).toISOString(),
-    next_allowed_at: nextAllowedAt,
-    skip_count: previousState?.skip_count ?? 0,
-    last_status: 'spawned',
-    last_reason: 'spawned',
-  });
-  await writeAuthorityState(authorityOwnerPath, spawnedState);
-  if (!(await writeAuthorityState(authorityStatePath, spawnedState))) {
-    await releaseAuthorityLock(lock);
-    throw new Error('failed to persist HUD authority rate-limit state');
-  }
-
-  try {
-    await runProcess(
-      nodePath,
-      [
-        watcherScript,
-        '--once',
-        '--authority-only',
-        '--cwd',
-        cwd,
-        '--notify-script',
-        notifyScript,
-        '--poll-ms',
-        String(pollMs),
-      ],
-      {
-        cwd,
-        env: {
-          ...process.env,
-          ...(options.env ?? {}),
-          OMX_HUD_AUTHORITY: '1',
-          OMX_HUD_AUTHORITY_MIN_INTERVAL_MS: String(minIntervalMs),
-          OMX_HUD_AUTHORITY_JITTER_MS: String(jitterMaxMs),
-        },
-        timeoutMs,
-      },
-    );
-  } catch (error) {
-    const failedAt = deps.nowMs?.() ?? Date.now();
-    const failedState = buildAuthorityState(cwd, failedAt, minIntervalMs, jitterMs, {
-      last_spawn_at: spawnedState.last_spawn_at,
+    const nextAllowedAt = new Date(nowMs + minIntervalMs + jitterMs).toISOString();
+    const spawnedState = buildAuthorityState(cwd, nowMs, minIntervalMs, jitterMs, {
+      last_spawn_at: new Date(nowMs).toISOString(),
       next_allowed_at: nextAllowedAt,
       skip_count: previousState?.skip_count ?? 0,
-      last_status: 'failed',
-      last_reason: 'child_failed',
-      last_error: error instanceof Error ? error.message : String(error),
+      last_status: 'spawned',
+      last_reason: 'spawned',
     });
-    await writeAuthorityState(authorityOwnerPath, failedState);
-    await writeAuthorityState(authorityStatePath, failedState);
-    throw error;
+    if (!(await writeAuthorityState(domain.authorityStatePath, spawnedState))) {
+      throw new Error('failed to persist HUD authority rate-limit state');
+    }
+
+    const watcherScript = resolveHudWatcherScript(packageRoot, 'notify-fallback-watcher.js', cwd, mergedEnv);
+    const notifyScript = resolveHudWatcherScript(packageRoot, 'notify-hook.js', cwd, mergedEnv);
+    try {
+      await runProcess(nodePath, [
+        watcherScript, '--once', '--authority-only', '--cwd', cwd,
+        '--notify-script', notifyScript, '--poll-ms', String(pollMs),
+      ], {
+        cwd,
+        env: {
+          ...mergedEnv,
+          OMX_HUD_AUTHORITY: '1',
+          OMX_HUD_AUTHORITY_DOMAIN_KEY: domain.domainKey,
+          OMX_HUD_AUTHORITY_STATE_PATH: domain.authorityStatePath,
+          OMX_HUD_AUTHORITY_MIN_INTERVAL_MS: String(minIntervalMs),
+          OMX_HUD_AUTHORITY_JITTER_MS: String(jitterMaxMs),
+          OMX_HUD_AUTHORITY_LEASE_PATH: domain.authorityLeasePath,
+          OMX_HUD_AUTHORITY_BASE_STATE_DIR: domain.baseStateDir,
+          OMX_HUD_AUTHORITY_ROOT_SOURCE: domain.rootSource,
+          OMX_HUD_AUTHORITY_LEASE_TOKEN: token,
+          OMX_HUD_AUTHORITY_LEASE_GENERATION: generation,
+          OMX_HUD_AUTHORITY_OWNER_PID: String(process.pid),
+          OMX_HUD_AUTHORITY_OWNER_PLATFORM: process.platform,
+          OMX_HUD_AUTHORITY_OWNER_START_IDENTITY: processStartIdentity,
+        },
+        timeoutMs,
+      });
+    } catch (error) {
+      const failedAt = deps.nowMs?.() ?? Date.now();
+      await writeAuthorityState(domain.authorityStatePath, buildAuthorityState(cwd, failedAt, minIntervalMs, jitterMs, {
+        last_spawn_at: spawnedState.last_spawn_at,
+        next_allowed_at: nextAllowedAt,
+        skip_count: spawnedState.skip_count,
+        last_status: 'failed',
+        last_reason: 'child_failed',
+        last_error: error instanceof Error ? error.message : String(error),
+      }));
+      throw error;
+    }
   } finally {
-    await releaseAuthorityLock(lock);
+    await releaseHudLifecycleLock(acquired.lock);
   }
 }

--- a/src/hud/authority.ts
+++ b/src/hud/authority.ts
@@ -36,6 +36,7 @@ export interface RunHudAuthorityTickDeps {
   lifecycleLockDeps?: HudLifecycleLockDeps;
   processStartIdentity?: (pid: number) => Promise<string | undefined>;
   probeLeaseProcess?: (lease: HudAuthorityLease) => Promise<'live' | 'dead' | 'reused' | 'uncertain'>;
+  probeLiveClaimant?: (domain: ResolvedHudControlPlaneDomain) => Promise<boolean>;
 }
 
 interface HudAuthorityState {
@@ -296,6 +297,19 @@ async function defaultProbeLeaseProcess(lease: HudAuthorityLease): Promise<'live
   return currentIdentity === lease.processStartIdentity ? 'live' : 'reused';
 }
 
+async function defaultProbeLiveClaimant(domain: ResolvedHudControlPlaneDomain): Promise<boolean> {
+  if (!domain.managed) return true;
+  const claimant = domain.claimant;
+  if (!claimant.sessionId || !claimant.leaderPaneId || !claimant.tmuxSessionName
+    || !claimant.tmuxSessionInstanceId || !claimant.tmuxPaneInstanceId) return false;
+  const paneContext = spawnSync('tmux', ['display-message', '-p', '-t', claimant.leaderPaneId, '#{pane_id}\t#{session_name}'], { encoding: 'utf8' });
+  if (paneContext.status !== 0 || paneContext.stdout.trim() !== `${claimant.leaderPaneId}\t${claimant.tmuxSessionName}`) return false;
+  const paneBirth = spawnSync('tmux', ['show-option', '-p', '-v', '-t', claimant.leaderPaneId, '@omx_pane_instance_id'], { encoding: 'utf8' });
+  if (paneBirth.status !== 0 || paneBirth.stdout.trim() !== claimant.tmuxPaneInstanceId) return false;
+  const sessionBirth = spawnSync('tmux', ['show-option', '-v', '-t', claimant.tmuxSessionName, '@omx_instance_id'], { encoding: 'utf8' });
+  return sessionBirth.status === 0 && sessionBirth.stdout.trim() === claimant.tmuxSessionInstanceId;
+}
+
 
 function buildAuthorityState(
   cwd: string,
@@ -361,6 +375,7 @@ export async function runHudAuthorityTick(
     const claimant = claimantIdentity(domain);
     const processStartIdentity = await (deps.processStartIdentity ?? defaultProcessStartIdentity)(process.pid);
     if (typeof processStartIdentity !== 'string' || processStartIdentity.trim().length === 0) return;
+    if (!await (deps.probeLiveClaimant ?? defaultProbeLiveClaimant)(domain).catch(() => false)) return;
     const currentLease = await readAuthorityLease(domain.authorityLeasePath);
     const ownsLease = currentLease !== null
       && currentLease !== 'uncertain'
@@ -468,6 +483,7 @@ export async function runHudAuthorityTick(
           OMX_HUD_AUTHORITY_OWNER_PID: String(process.pid),
           OMX_HUD_AUTHORITY_OWNER_PLATFORM: process.platform,
           OMX_HUD_AUTHORITY_OWNER_START_IDENTITY: processStartIdentity,
+          OMX_HUD_AUTHORITY_CLAIMANT: claimant,
         },
         timeoutMs,
       });

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -10,7 +10,6 @@
  *   omx hud --reconcile-tmux
  */
 
-import { execFileSync } from 'child_process';
 import { readlinkSync, realpathSync } from 'node:fs';
 import { readAllState, readHudConfig } from './state.js';
 import { getHudRenderMaxLines, renderHud } from './render.js';
@@ -18,17 +17,14 @@ import type { HudFlags, HudPreset, HudRenderContext, ResolvedHudConfig } from '.
 import { HUD_TMUX_HEIGHT_LINES } from './constants.js';
 import { sleep } from '../utils/sleep.js';
 import { runHudAuthorityTick } from './authority.js';
-import { resolveOmxCliEntryPath } from '../utils/paths.js';
 import {
-  killTmuxPane,
-  listCurrentWindowHudPaneIds,
   OMX_TMUX_HUD_LEADER_PANE_ENV,
   readActiveTmuxPaneId,
+  buildHudRuntimeEnv,
   registerHudResizeHook,
   resizeTmuxPane,
 } from './tmux.js';
 import { OMX_TMUX_HUD_OWNER_ENV, reconcileHudForPromptSubmit } from './reconcile.js';
-import { buildHudRuntimeEnv } from './tmux.js';
 
 export const HUD_USAGE = [
   'Usage:',
@@ -160,6 +156,18 @@ function reconcileRunningHudPaneHeight(
   }
 }
 
+function isManagedHudAuthorityWatcher(env: NodeJS.ProcessEnv): boolean {
+  const sessionId = env.OMX_SESSION_ID?.trim();
+  const hudPaneId = env.TMUX_PANE?.trim();
+  const leaderPaneId = env[OMX_TMUX_HUD_LEADER_PANE_ENV]?.trim();
+  return env.TMUX?.trim() !== ''
+    && env[OMX_TMUX_HUD_OWNER_ENV] === '1'
+    && Boolean(sessionId)
+    && Boolean(hudPaneId?.startsWith('%'))
+    && Boolean(leaderPaneId?.startsWith('%'));
+}
+
+
 /**
  * Backward-compatible watch mode runner used by tests.
  */
@@ -250,11 +258,13 @@ export async function runWatchMode(
         maxLines,
       });
       dependencies.writeStdout(line + '\x1b[K\x1b[J');
-      try {
-        await dependencies.runAuthorityTickFn({ cwd: frameCwd });
-      } catch (authorityError) {
-        const message = authorityError instanceof Error ? authorityError.message : String(authorityError);
-        dependencies.writeStderr(`HUD watch authority tick failed: ${message}\n`);
+      if (isManagedHudAuthorityWatcher(dependencies.env)) {
+        try {
+          await dependencies.runAuthorityTickFn({ cwd: frameCwd });
+        } catch (authorityError) {
+          const message = authorityError instanceof Error ? authorityError.message : String(authorityError);
+          dependencies.writeStderr(`HUD watch authority tick failed: ${message}\n`);
+        }
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -413,64 +423,31 @@ export function buildTmuxSplitArgs(
 }
 
 async function launchTmuxPane(cwd: string, flags: HudFlags): Promise<void> {
-  // Check if we're inside tmux
   if (!process.env.TMUX) {
     console.error('Not inside a tmux session. Start tmux first, then run: omx hud --tmux');
     process.exit(1);
-  }
-
-  const omxBin = resolveOmxCliEntryPath();
-  if (!omxBin) {
-    console.error('Failed to resolve OMX launcher path for tmux HUD startup.');
-    process.exit(1);
-  }
-  const envPaneId = process.env.TMUX_PANE?.trim();
-  const currentPaneId = envPaneId || readActiveTmuxPaneId() || undefined;
-  const leaderPaneId = currentPaneId;
-  const sessionId = process.env.OMX_SESSION_ID?.trim() || undefined;
-  const existingHudPaneIds = leaderPaneId || sessionId
-    ? listCurrentWindowHudPaneIds(leaderPaneId, undefined, leaderPaneId ? { leaderPaneId } : { sessionId })
-    : [];
-  if (existingHudPaneIds.length >= 1) {
-    const [keeperPaneId, ...duplicatePaneIds] = existingHudPaneIds;
-    for (const paneId of duplicatePaneIds) {
-      killTmuxPane(paneId);
-    }
-    const config = await readHudConfig(cwd);
-    const ctx = await readAllState(cwd, config);
-    const desiredHeight = getHudRenderMaxLines(ctx);
-    resizeTmuxPane(keeperPaneId, desiredHeight);
-    if (leaderPaneId) registerHudResizeHook(keeperPaneId, leaderPaneId, desiredHeight);
-    console.log(duplicatePaneIds.length > 0
-      ? 'HUD already running in tmux pane. Removed duplicate HUD panes and reused existing HUD pane.'
-      : 'HUD already running in tmux pane. Reused existing HUD pane.');
     return;
   }
 
-  const config = await readHudConfig(cwd);
-  const ctx = await readAllState(cwd, config);
-  const args = buildTmuxSplitArgs(
-    cwd,
-    omxBin,
-    flags.preset,
-    process.env.OMX_SESSION_ID,
-    process.env.OMX_ROOT,
-    currentPaneId,
-    getHudRenderMaxLines(ctx),
-    {
-      omxStateRoot: process.env.OMX_STATE_ROOT,
-      omxTeamStateRoot: process.env.OMX_TEAM_STATE_ROOT,
-      rootSource: process.env.OMX_TEAM_STATE_ROOT ? 'team-env' : process.env.OMX_ROOT ? 'omx-root-env' : process.env.OMX_STATE_ROOT ? 'omx-state-root-env' : 'cwd-default',
-    },
-  );
-
-  try {
-    // Split bottom pane at the shared HUD height, running omx hud --watch.
-    // execFileSync bypasses the shell – cwd and omxBin cannot inject commands.
-    execFileSync('tmux', args, { stdio: 'inherit' });
-    console.log('HUD launched in tmux pane below. Close with: Ctrl+C in that pane, or `tmux kill-pane -t bottom`');
-  } catch {
-    console.error('Failed to create tmux split. Ensure tmux is available.');
-    process.exit(1);
+  const sessionId = process.env.OMX_SESSION_ID?.trim();
+  if (!sessionId) {
+    // A manually opened tmux session has no persisted OMX owner. Rendering it in
+    // place avoids creating a pane that could later be mistaken for managed HUD.
+    await renderOnce(cwd, flags);
+    return;
   }
+
+  const leaderPaneId = process.env.TMUX_PANE?.trim() || readActiveTmuxPaneId() || undefined;
+  const runtimeEnv = buildHudRuntimeEnv({
+    sessionId,
+    leaderPaneId,
+    omxRoot: process.env.OMX_ROOT,
+    omxStateRoot: process.env.OMX_STATE_ROOT,
+    omxTeamStateRoot: process.env.OMX_TEAM_STATE_ROOT,
+    rootSource: process.env.OMX_TEAM_STATE_ROOT ? 'team-env' : process.env.OMX_ROOT ? 'omx-root-env' : process.env.OMX_STATE_ROOT ? 'omx-state-root-env' : 'cwd-default',
+  }).env;
+  const result = await reconcileHudForPromptSubmit(cwd, {
+    env: { ...process.env, ...runtimeEnv, [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+  });
+  if (result.status === 'failed') process.exitCode = 1;
 }

--- a/src/hud/lifecycle-lock.ts
+++ b/src/hud/lifecycle-lock.ts
@@ -1,0 +1,271 @@
+import { randomUUID } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { mkdir, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const OWNER_FILE = 'owner.json';
+const LOCK_VERSION = 1;
+
+export interface HudLifecycleLockOwner {
+  version: 1;
+  token: string;
+  generation: string;
+  domainKey: string;
+  pid: number;
+  platform: NodeJS.Platform;
+  processStartIdentity: string;
+  acquiredAt: string;
+}
+
+export interface HudLifecycleLock {
+  path: string;
+  token: string;
+  generation: string;
+  domainKey: string;
+}
+
+export type HudLifecycleLockStatus = 'acquired' | 'locked' | 'locked_uncertain' | 'failed';
+
+export interface HudLifecycleLockResult {
+  status: HudLifecycleLockStatus;
+  lock?: HudLifecycleLock;
+}
+
+export interface HudLifecycleLockOptions {
+  path: string;
+  domainKey: string;
+  staleMs: number;
+}
+
+export interface HudLifecycleLockDeps {
+  nowMs?: () => number;
+  token?: () => string;
+  generation?: () => string;
+  afterQuarantine?: (quarantinePath: string) => Promise<void> | void;
+  processStartIdentity?: (pid: number) => Promise<string | undefined>;
+  probeProcess?: (owner: HudLifecycleLockOwner) => Promise<'live' | 'dead' | 'reused' | 'uncertain'>;
+}
+
+type OwnerRead = { kind: 'missing' } | { kind: 'uncertain' } | { kind: 'owner'; owner: HudLifecycleLockOwner };
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
+}
+
+function isOwner(value: unknown): value is HudLifecycleLockOwner {
+  if (typeof value !== 'object' || value === null) return false;
+  const owner = value as Partial<HudLifecycleLockOwner>;
+  return owner.version === LOCK_VERSION
+    && typeof owner.token === 'string' && owner.token.length > 0
+    && typeof owner.generation === 'string' && owner.generation.length > 0
+    && typeof owner.domainKey === 'string' && owner.domainKey.length > 0
+    && typeof owner.pid === 'number' && Number.isInteger(owner.pid) && owner.pid > 0
+    && typeof owner.platform === 'string' && owner.platform.length > 0
+    && typeof owner.processStartIdentity === 'string' && owner.processStartIdentity.trim().length > 0
+    && typeof owner.acquiredAt === 'string' && Number.isFinite(Date.parse(owner.acquiredAt));
+}
+
+async function readOwner(lockPath: string): Promise<OwnerRead> {
+  try {
+    const parsed: unknown = JSON.parse(await readFile(join(lockPath, OWNER_FILE), 'utf8'));
+    return isOwner(parsed) ? { kind: 'owner', owner: parsed } : { kind: 'uncertain' };
+  } catch (error) {
+    return isNotFound(error) ? { kind: 'missing' } : { kind: 'uncertain' };
+  }
+}
+
+async function lockStat(lockPath: string): Promise<{ mtimeMs: number } | undefined> {
+  try {
+    return await stat(lockPath);
+  } catch {
+    return undefined;
+  }
+}
+
+async function defaultProcessStartIdentity(pid: number): Promise<string | undefined> {
+  if (process.platform === 'linux') {
+    try {
+      const content = await readFile(`/proc/${pid}/stat`, 'utf8');
+      const closeParen = content.lastIndexOf(')');
+      const fields = closeParen < 0 ? [] : content.slice(closeParen + 2).trim().split(/\s+/);
+      const startTime = fields[19];
+      return startTime ? `linux:${startTime}` : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (process.platform === 'darwin') {
+    const result = spawnSync('ps', ['-o', 'lstart=', '-p', String(pid)], { encoding: 'utf8' });
+    const startTime = result.status === 0 ? result.stdout.trim() : '';
+    return startTime ? `darwin:${startTime}` : undefined;
+  }
+
+  if (process.platform === 'win32') {
+    const result = spawnSync('powershell.exe', [
+      '-NoProfile', '-NonInteractive', '-Command', `(Get-Process -Id ${pid}).StartTime.ToUniversalTime().Ticks`,
+    ], { encoding: 'utf8', windowsHide: true });
+    const startTime = result.status === 0 ? result.stdout.trim() : '';
+    return startTime ? `win32:${startTime}` : undefined;
+  }
+
+  return undefined;
+}
+
+async function defaultProbeProcess(owner: HudLifecycleLockOwner): Promise<'live' | 'dead' | 'reused' | 'uncertain'> {
+  if (owner.platform !== process.platform) return 'uncertain';
+  try {
+    process.kill(owner.pid, 0);
+  } catch (error) {
+    const code = typeof error === 'object' && error !== null && 'code' in error ? error.code : undefined;
+    return code === 'ESRCH' ? 'dead' : 'uncertain';
+  }
+  const currentIdentity = await defaultProcessStartIdentity(owner.pid);
+  if (currentIdentity && currentIdentity !== owner.processStartIdentity) return 'reused';
+  return currentIdentity ? 'live' : 'uncertain';
+}
+
+function ownerMatches(left: HudLifecycleLockOwner, right: HudLifecycleLockOwner): boolean {
+  return left.token === right.token
+    && left.generation === right.generation
+    && left.domainKey === right.domainKey
+    && left.pid === right.pid
+    && left.platform === right.platform
+    && left.processStartIdentity === right.processStartIdentity
+    && left.acquiredAt === right.acquiredAt;
+}
+
+function isProvenStale(owner: HudLifecycleLockOwner, nowMs: number, staleMs: number, probe: 'live' | 'dead' | 'reused' | 'uncertain'): boolean {
+  const acquiredAt = Date.parse(owner.acquiredAt);
+  return Number.isFinite(acquiredAt)
+    && acquiredAt <= nowMs
+    && nowMs - acquiredAt >= staleMs
+    && (probe === 'dead' || probe === 'reused');
+}
+
+async function pathIsAbsent(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return false;
+  } catch (error) {
+    return isNotFound(error);
+  }
+}
+
+async function restoreQuarantine(quarantinePath: string, lockPath: string, owner: HudLifecycleLockOwner): Promise<void> {
+  if (!(await pathIsAbsent(lockPath))) return;
+  const current = await readOwner(quarantinePath);
+  if (current.kind !== 'owner' || !ownerMatches(current.owner, owner)) return;
+  await rename(quarantinePath, lockPath).catch(() => {});
+}
+
+async function publishFreshLock(options: HudLifecycleLockOptions, deps: HudLifecycleLockDeps, nowMs: number): Promise<HudLifecycleLockResult> {
+  const processStartIdentity = await (deps.processStartIdentity ?? defaultProcessStartIdentity)(process.pid).catch(() => undefined);
+  if (typeof processStartIdentity !== 'string' || processStartIdentity.trim().length === 0) {
+    return { status: 'failed' };
+  }
+  const token = deps.token?.() ?? randomUUID();
+  const generation = deps.generation?.() ?? randomUUID();
+  const owner: HudLifecycleLockOwner = {
+    version: LOCK_VERSION,
+    token,
+    generation,
+    domainKey: options.domainKey,
+    pid: process.pid,
+    platform: process.platform,
+    processStartIdentity,
+    acquiredAt: new Date(nowMs).toISOString(),
+  };
+  let created = false;
+  try {
+    await mkdir(options.path);
+    created = true;
+    await writeFile(join(options.path, OWNER_FILE), JSON.stringify(owner));
+    const observed = await readOwner(options.path);
+    if (observed.kind === 'owner' && ownerMatches(observed.owner, owner)) {
+      return { status: 'acquired', lock: { path: options.path, token, generation, domainKey: options.domainKey } };
+    }
+  } catch (error) {
+    if (!created && typeof error === 'object' && error !== null && 'code' in error && error.code === 'EEXIST') {
+      return { status: 'locked' };
+    }
+  }
+  if (created) {
+    const observed = await readOwner(options.path);
+    if (observed.kind === 'owner' && ownerMatches(observed.owner, owner)) {
+      await rm(options.path, { recursive: true, force: false }).catch(() => {});
+    }
+  }
+  return { status: 'failed' };
+}
+
+export async function acquireHudLifecycleLock(
+  options: HudLifecycleLockOptions,
+  deps: HudLifecycleLockDeps = {},
+): Promise<HudLifecycleLockResult> {
+  const nowMs = deps.nowMs?.() ?? Date.now();
+  const fresh = await publishFreshLock(options, deps, nowMs);
+  if (fresh.status === 'acquired' || fresh.status === 'failed') return fresh;
+
+  const observed = await readOwner(options.path);
+  const observedStat = await lockStat(options.path);
+  if (observed.kind !== 'owner' || !observedStat || observed.owner.domainKey !== options.domainKey) {
+    return { status: 'locked_uncertain' };
+  }
+  const probe = await (deps.probeProcess ?? defaultProbeProcess)(observed.owner).catch(() => 'uncertain' as const);
+  if (!isProvenStale(observed.owner, nowMs, options.staleMs, probe)) {
+    return { status: probe === 'live' ? 'locked' : 'locked_uncertain' };
+  }
+
+  const quarantinePath = `${options.path}.quarantine.${process.pid}.${nowMs}.${randomUUID()}`;
+  try {
+    await rename(options.path, quarantinePath);
+  } catch {
+    return { status: 'locked_uncertain' };
+  }
+  await deps.afterQuarantine?.(quarantinePath);
+  const quarantinedOwner = await readOwner(quarantinePath);
+  const quarantinedStat = await lockStat(quarantinePath);
+  const quarantinedProbe = quarantinedOwner.kind === 'owner'
+    ? await (deps.probeProcess ?? defaultProbeProcess)(quarantinedOwner.owner).catch(() => 'uncertain' as const)
+    : 'uncertain';
+  if (!(await pathIsAbsent(options.path))
+    || quarantinedOwner.kind !== 'owner'
+    || !quarantinedStat
+    || quarantinedStat.mtimeMs !== observedStat.mtimeMs
+    || !ownerMatches(observed.owner, quarantinedOwner.owner)
+    || !isProvenStale(quarantinedOwner.owner, nowMs, options.staleMs, quarantinedProbe)) {
+    await restoreQuarantine(quarantinePath, options.path, observed.owner);
+    return { status: 'locked_uncertain' };
+  }
+  try {
+    await rm(quarantinePath, { recursive: true, force: false });
+  } catch {
+    return { status: 'locked_uncertain' };
+  }
+  return publishFreshLock(options, deps, nowMs);
+}
+
+export async function releaseHudLifecycleLock(lock: HudLifecycleLock): Promise<void> {
+  const observed = await readOwner(lock.path);
+  if (observed.kind !== 'owner'
+    || observed.owner.token !== lock.token
+    || observed.owner.generation !== lock.generation
+    || observed.owner.domainKey !== lock.domainKey) return;
+  const releasePath = `${lock.path}.release.${process.pid}.${randomUUID()}`;
+  try {
+    await rename(lock.path, releasePath);
+  } catch {
+    return;
+  }
+  const released = await readOwner(releasePath);
+  if (released.kind === 'owner'
+    && released.owner.token === lock.token
+    && released.owner.generation === lock.generation
+    && released.owner.domainKey === lock.domainKey) {
+    await rm(releasePath, { recursive: true, force: false }).catch(() => {});
+    return;
+  }
+  if (await pathIsAbsent(lock.path)) await rename(releasePath, lock.path).catch(() => {});
+}

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -351,7 +351,9 @@ export async function reconcileHudForPromptSubmit(
 
   const listPanes = deps.listCurrentWindowPanes ?? ((paneId) => listCurrentWindowPanes(undefined, paneId));
   const createPane = deps.createHudWatchPane ?? ((hudCwd, hudCmd, options) => createHudWatchPane(hudCwd, hudCmd, options));
-  const killPane = deps.killManagedHudPane ?? killExactHudPane;
+  const killPane = deps.killManagedHudPane
+    ? (candidate: ExactHudPaneKillCandidate) => deps.killManagedHudPane!(candidate) !== false
+    : killExactHudPane;
   const resizePane = deps.resizeTmuxPane ?? ((paneId, lines) => resizeTmuxPane(paneId, lines));
   const lock = acquired.lock;
   const resolvedSessionId = domain.session?.canonicalId;
@@ -439,7 +441,9 @@ export async function reconcileHudForPromptSubmit(
     })
     .map((pane) => pane.paneId);
   for (const paneId of staleHudPaneIds) {
-    await killOwnedHudPane(paneId, true);
+    if (!await killOwnedHudPane(paneId, true)) {
+      return { status: 'failed', paneId: null, desiredHeight: null, duplicateCount: 0 };
+    }
   }
   if (staleHudPaneIds.length > 0) {
     const stalePaneIdSet = new Set(staleHudPaneIds);
@@ -491,7 +495,14 @@ export async function reconcileHudForPromptSubmit(
 
     if (keeperPane) {
       for (const paneId of hudPaneIds.filter((paneId) => paneId !== keeperPane.paneId)) {
-        await killOwnedHudPane(paneId);
+        if (!await killOwnedHudPane(paneId)) {
+          return {
+            status: 'failed',
+            paneId: keeperPane.paneId,
+            desiredHeight,
+            duplicateCount,
+          };
+        }
       }
       const resized = resizePane(keeperPane.paneId, desiredHeight);
       const hooksRegistered = resized && ensureHudResizeHook(keeperPane.paneId, currentPaneId, desiredHeight, cwd, deps);
@@ -536,7 +547,10 @@ export async function reconcileHudForPromptSubmit(
 
   const removedHudPaneIds = new Set<string>();
   for (const paneId of hudPaneIds) {
-    if (await killOwnedHudPane(paneId)) removedHudPaneIds.add(paneId);
+    if (!await killOwnedHudPane(paneId)) {
+      return { status: 'failed', paneId: null, desiredHeight, duplicateCount };
+    }
+    removedHudPaneIds.add(paneId);
   }
 
   const createOptions: { heightLines: number; fullWidth?: boolean; targetPaneId?: string; instanceId?: string } = {
@@ -568,10 +582,24 @@ export async function reconcileHudForPromptSubmit(
     domain,
   );
   if (postCreate.unsafeCandidate) {
-    return { status: 'recreated', paneId, desiredHeight, duplicateCount: 0 };
+    const rolledBack = await killOwnedHudPane(paneId);
+    return {
+      status: 'failed',
+      paneId: rolledBack ? null : paneId,
+      desiredHeight,
+      duplicateCount: 0,
+    };
   }
   for (const duplicatePaneId of postCreate.duplicatePaneIds) {
-    await killOwnedHudPane(duplicatePaneId);
+    if (!await killOwnedHudPane(duplicatePaneId)) {
+      const rolledBack = await killOwnedHudPane(paneId);
+      return {
+        status: 'failed',
+        paneId: rolledBack ? null : paneId,
+        desiredHeight,
+        duplicateCount: postCreate.duplicatePaneIds.length,
+      };
+    }
   }
   const resized = resizePane(postCreate.paneId, desiredHeight);
   if (!resized) {

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -11,7 +11,7 @@ import {
   buildHudWatchCommand,
   createHudWatchPane,
   isHudWatchPane,
-  killTmuxPane,
+  killExactHudPane,
   listCurrentWindowPanes,
   readCurrentWindowSize,
   readHudPaneOwner,
@@ -20,6 +20,7 @@ import {
   registerHudResizeHook,
   unregisterHudResizeHook,
   resizeTmuxPane,
+  type ExactHudPaneKillCandidate,
   type HudPaneOwner,
   type TmuxPaneSnapshot,
 } from './tmux.js';
@@ -60,7 +61,7 @@ export interface ReconcileHudForPromptSubmitDeps {
     hudCmd: string,
     options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string; instanceId?: string },
   ) => string | null;
-  killTmuxPane?: (paneId: string) => boolean;
+  killManagedHudPane?: (candidate: ExactHudPaneKillCandidate) => boolean;
   resizeTmuxPane?: (paneId: string, heightLines: number) => boolean;
   readHudConfig?: typeof readHudConfig;
   readAllState?: typeof readAllState;
@@ -354,7 +355,7 @@ export async function reconcileHudForPromptSubmit(
 
   const listPanes = deps.listCurrentWindowPanes ?? ((paneId) => listCurrentWindowPanes(undefined, paneId));
   const createPane = deps.createHudWatchPane ?? ((hudCwd, hudCmd, options) => createHudWatchPane(hudCwd, hudCmd, options));
-  const killPane = deps.killTmuxPane ?? ((paneId) => killTmuxPane(paneId));
+  const killPane = deps.killManagedHudPane ?? killExactHudPane;
   const resizePane = deps.resizeTmuxPane ?? ((paneId, lines) => resizeTmuxPane(paneId, lines));
   const lock = acquired.lock;
   const resolvedSessionId = domain.session?.canonicalId;
@@ -386,35 +387,44 @@ export async function reconcileHudForPromptSubmit(
     sessionIds: equivalentSessionIds,
     leaderPaneId: currentPaneId,
   };
-  const canKillOwnedHudPane = async (paneId: string): Promise<boolean> => {
+  const exactHudKillCandidate = async (paneId: string, stale = false): Promise<ExactHudPaneKillCandidate | null> => {
     const latestEvidence = currentPaneId
       ? await (deps.probeTmuxInstance ?? probeActualTmuxInstanceEvidence)(currentPaneId).catch(() => null)
       : null;
-    if (!latestEvidence || !isVerifiedManagedHudOwner(domain, currentPaneId, latestEvidence)) return false;
+    if (!latestEvidence || !isVerifiedManagedHudOwner(domain, currentPaneId, latestEvidence)) return null;
     const latestPanes = listPanes(currentPaneId);
-    const latestLeader = latestPanes.find((pane) => pane.paneId === currentPaneId && !isHudWatchPane(pane));
     const candidate = latestPanes.find((pane) => pane.paneId === paneId);
-    return Boolean(
-      latestLeader
-      && candidate
-      && hudPaneMatchesOwner(candidate, owner)
-      && (hasVerifiedHudPaneInstanceIdentity(candidate, equivalentSessionIdSet) || tmuxSnapshotMatchesClaimantBirth(candidate, domain)),
-    );
-  };
-  const canKillStaleOwnedHudPane = async (paneId: string): Promise<boolean> => {
-    const latestEvidence = currentPaneId
-      ? await (deps.probeTmuxInstance ?? probeActualTmuxInstanceEvidence)(currentPaneId).catch(() => null)
-      : null;
-    if (!latestEvidence || !isVerifiedManagedHudOwner(domain, currentPaneId, latestEvidence)) return false;
-    const candidate = listPanes(currentPaneId).find((pane) => pane.paneId === paneId);
-    if (!candidate || !isHudWatchPane(candidate)) return false;
+    if (!candidate || !isHudWatchPane(candidate)) return null;
     const candidateOwner = readHudPaneOwner(candidate);
-    return Boolean(
-      candidateOwner.sessionId
-      && candidateOwner.leaderPaneId
-      && (equivalentSessionIdSet.has(candidateOwner.sessionId) || candidateOwner.leaderPaneId === currentPaneId)
-      && hasVerifiedHudPaneInstanceIdentity(candidate, equivalentSessionIdSet),
-    );
+    const ownerMatches = stale
+      ? Boolean(
+        candidateOwner.sessionId
+        && candidateOwner.leaderPaneId
+        && (equivalentSessionIdSet.has(candidateOwner.sessionId) || candidateOwner.leaderPaneId === currentPaneId)
+        && hasVerifiedHudPaneInstanceIdentity(candidate, equivalentSessionIdSet),
+      )
+      : Boolean(
+        latestPanes.some((pane) => pane.paneId === currentPaneId && !isHudWatchPane(pane))
+        && hudPaneMatchesOwner(candidate, owner)
+        && (hasVerifiedHudPaneInstanceIdentity(candidate, equivalentSessionIdSet) || tmuxSnapshotMatchesClaimantBirth(candidate, domain)),
+      );
+    if (!ownerMatches) return null;
+    const paneInstanceId = candidate.paneInstanceId?.trim() ?? '';
+    const sessionInstanceId = candidate.sessionInstanceId?.trim() ?? '';
+    if (!paneInstanceId || !sessionInstanceId) return null;
+    return {
+      paneId,
+      currentCommand: candidate.currentCommand,
+      startCommand: candidate.startCommand,
+      owner: candidateOwner,
+      paneInstanceId,
+      sessionInstanceId,
+      sessionName: latestEvidence.sessionName,
+    };
+  };
+  const killOwnedHudPane = async (paneId: string, stale = false): Promise<boolean> => {
+    const candidate = await exactHudKillCandidate(paneId, stale);
+    return candidate ? killPane(candidate) : false;
   };
   const liveNonHudPaneIds = new Set(panes.filter((pane) => !isHudWatchPane(pane)).map((pane) => pane.paneId));
   const staleHudPaneIds = panes
@@ -433,7 +443,7 @@ export async function reconcileHudForPromptSubmit(
     })
     .map((pane) => pane.paneId);
   for (const paneId of staleHudPaneIds) {
-    if (await canKillStaleOwnedHudPane(paneId)) killPane(paneId);
+    await killOwnedHudPane(paneId, true);
   }
   if (staleHudPaneIds.length > 0) {
     const stalePaneIdSet = new Set(staleHudPaneIds);
@@ -485,7 +495,7 @@ export async function reconcileHudForPromptSubmit(
 
     if (keeperPane) {
       for (const paneId of hudPaneIds.filter((paneId) => paneId !== keeperPane.paneId)) {
-        if (await canKillOwnedHudPane(paneId)) killPane(paneId);
+        await killOwnedHudPane(paneId);
       }
       const resized = resizePane(keeperPane.paneId, desiredHeight);
       if (resized) ensureHudResizeHook(keeperPane.paneId, currentPaneId, desiredHeight, cwd, deps);
@@ -530,7 +540,7 @@ export async function reconcileHudForPromptSubmit(
 
   const removedHudPaneIds = new Set<string>();
   for (const paneId of hudPaneIds) {
-    if (await canKillOwnedHudPane(paneId) && killPane(paneId)) removedHudPaneIds.add(paneId);
+    if (await killOwnedHudPane(paneId)) removedHudPaneIds.add(paneId);
   }
 
   const createOptions: { heightLines: number; fullWidth?: boolean; targetPaneId?: string; instanceId?: string } = {
@@ -565,7 +575,7 @@ export async function reconcileHudForPromptSubmit(
     return { status: 'recreated', paneId, desiredHeight, duplicateCount: 0 };
   }
   for (const duplicatePaneId of postCreate.duplicatePaneIds) {
-    if (await canKillOwnedHudPane(duplicatePaneId)) killPane(duplicatePaneId);
+    await killOwnedHudPane(duplicatePaneId);
   }
   const resized = resizePane(postCreate.paneId, desiredHeight);
   if (!resized) {
@@ -666,9 +676,20 @@ export async function teardownManagedHudPane(
       return { status: 'unchanged', removedPaneIds: [] };
     }
     const removedPaneIds: string[] = [];
-    const killPane = deps.killTmuxPane ?? killTmuxPane;
-    for (const paneId of exactHudPaneIds) {
-      if (killPane(paneId)) removedPaneIds.push(paneId);
+    const killPane = deps.killManagedHudPane ?? killExactHudPane;
+    for (const pane of panes.filter((candidate) => exactHudPaneIds.includes(candidate.paneId))) {
+      const paneInstanceId = pane.paneInstanceId?.trim() ?? '';
+      const sessionInstanceId = pane.sessionInstanceId?.trim() ?? '';
+      const owner = readHudPaneOwner(pane);
+      if (paneInstanceId && sessionInstanceId && killPane({
+        paneId: pane.paneId,
+        currentCommand: pane.currentCommand,
+        startCommand: pane.startCommand,
+        owner,
+        paneInstanceId,
+        sessionInstanceId,
+        sessionName: lockedEvidence.sessionName,
+      })) removedPaneIds.push(pane.paneId);
     }
     return { status: removedPaneIds.length > 0 ? 'removed' : 'unchanged', removedPaneIds };
   } finally {

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -714,18 +714,21 @@ export async function teardownManagedHudPane(
       return { status: 'skipped_not_omx_owned_tmux', removedPaneIds: [] };
     }
 
-    const identity = {
-      tmuxSessionInstanceId: leader.sessionInstanceId?.trim() ?? '',
-      tmuxPaneInstanceId: leader.paneInstanceId?.trim() ?? '',
-    };
     const exactHudPaneIds = panes
       .filter((pane) => pane.paneId !== currentPaneId && isHudWatchPane(pane))
-      .filter((pane) => tmuxSnapshotBindsCandidate(pane, [...equivalentSessionIds]))
-      .filter((pane) => [...equivalentSessionIds].some((sessionId) => hudPaneMatchesExactCandidate(
-        pane,
-        { sessionId, leaderPaneId: currentPaneId },
-        identity,
-      )))
+      .filter((pane) => {
+        const hudPaneBirth = pane.paneInstanceId?.trim() ?? '';
+        if (hudPaneBirth === (leader.paneInstanceId?.trim() ?? '')) return false;
+        if (!hudPaneBirth) return false;
+        return [...equivalentSessionIds].some((sessionId) => hudPaneMatchesExactCandidate(
+          pane,
+          { sessionId, leaderPaneId: currentPaneId },
+          {
+            tmuxSessionInstanceId: leader.sessionInstanceId?.trim() ?? '',
+            tmuxPaneInstanceId: hudPaneBirth,
+          },
+        ));
+      })
       .map((pane) => pane.paneId);
     const hooksUnregistered = (deps.unregisterHudResizeHook ?? unregisterHudResizeHook)(currentPaneId);
     if (!hooksUnregistered) {

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -1,19 +1,21 @@
-import { randomUUID } from 'node:crypto';
-import { mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { mkdir } from 'node:fs/promises';
+
+import { acquireHudLifecycleLock, releaseHudLifecycleLock, type HudLifecycleLockDeps } from './lifecycle-lock.js';
+import { resolveHudControlPlaneDomain, type ResolvedHudControlPlaneDomain } from '../mcp/state-paths.js';
+import { probeActualTmuxInstanceEvidence, tmuxEvidenceBindsCandidate, type ActualTmuxInstanceEvidence } from '../scripts/notify-hook/managed-tmux.js';
+
 import { readAllState, readHudConfig } from './state.js';
 import { getHudRenderMaxLines } from './render.js';
 import { HUD_TMUX_HEIGHT_LINES, isTmuxWindowTooCrampedForHudSplit } from './constants.js';
 import {
   buildHudWatchCommand,
   createHudWatchPane,
-  findLegacyFocusedHudWatchPaneIds,
-  findHudWatchPaneIds,
   isHudWatchPane,
   killTmuxPane,
   listCurrentWindowPanes,
   readCurrentWindowSize,
   readHudPaneOwner,
+  hudPaneMatchesOwner,
   registerHudResizeHook,
   unregisterHudResizeHook,
   resizeTmuxPane,
@@ -75,6 +77,7 @@ function reapOrphanedSessionHudPanes(
     const owner = readHudPaneOwner(pane);
     // Only reclaim HUDs that explicitly belong to this session and name a leader.
     if (!owner.sessionId || !sameSessionIds.has(owner.sessionId) || !owner.leaderPaneId) continue;
+    if (!hasVerifiedHudPaneInstanceIdentity(pane, sameSessionIds)) continue;
     // Keep HUDs whose leader is the current pane or another live non-HUD leader pane.
     if (owner.leaderPaneId === currentPaneId || liveNonHudPaneIds.has(owner.leaderPaneId)) continue;
     if (killPane(pane.paneId)) reaped.push(pane.paneId);
@@ -107,6 +110,7 @@ function reapStaleCurrentLeaderHudPanes(
     if (owner.leaderPaneId !== currentPaneId) continue;
     if (!hasExplicitHudOwnerMarker(pane)) continue;
     if (!owner.sessionId || currentSessionIds.has(owner.sessionId)) continue;
+    if (!hasVerifiedHudPaneInstanceIdentity(pane, currentSessionIds)) continue;
     if (killPane(pane.paneId)) reaped.push(pane.paneId);
   }
   return reaped;
@@ -138,7 +142,7 @@ export interface ReconcileHudForPromptSubmitDeps {
   createHudWatchPane?: (
     cwd: string,
     hudCmd: string,
-    options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string },
+    options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string; instanceId?: string },
   ) => string | null;
   killTmuxPane?: (paneId: string) => boolean;
   resizeTmuxPane?: (paneId: string, heightLines: number) => boolean;
@@ -155,6 +159,14 @@ export interface ReconcileHudForPromptSubmitDeps {
   readCurrentWindowSize?: (currentPaneId?: string) => { width: number | null; height: number | null };
   nowMs?: () => number;
   isProcessLive?: (pid: number) => boolean | null;
+  resolveDomain?: (options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    requestedSessionId?: string;
+  }) => Promise<ResolvedHudControlPlaneDomain>;
+  lifecycleLockDeps?: HudLifecycleLockDeps;
+  probeTmuxInstance?: (paneId?: string) => Promise<ActualTmuxInstanceEvidence>;
+
 }
 
 function ensureHudResizeHook(
@@ -208,16 +220,34 @@ function needsHudHeightResize(pane: TmuxPaneSnapshot, desiredHeight: number): bo
   return typeof pane.paneHeight !== 'number' || pane.paneHeight !== desiredHeight;
 }
 
+function hasVerifiedHudPaneInstanceIdentity(
+  pane: TmuxPaneSnapshot,
+  equivalentSessionIds: ReadonlySet<string>,
+): boolean {
+  const paneInstanceId = pane.paneInstanceId?.trim();
+  const sessionInstanceId = pane.sessionInstanceId?.trim();
+  return Boolean(
+    paneInstanceId
+    && sessionInstanceId
+    && equivalentSessionIds.has(paneInstanceId)
+    && equivalentSessionIds.has(sessionInstanceId),
+  );
+}
+
 function planOwnedHudPaneDedupe(
   panes: TmuxPaneSnapshot[],
   currentPaneId: string | undefined,
   owner: HudPaneOwner,
   preferredPaneId: string,
-): { paneId: string; duplicatePaneIds: string[] } {
-  const ownedPaneIds = [
-    ...findHudWatchPaneIds(panes, currentPaneId, owner),
-    ...findLegacyFocusedHudWatchPaneIds(panes, currentPaneId),
-  ].filter((paneId, index, paneIds) => paneIds.indexOf(paneId) === index);
+  equivalentSessionIds: ReadonlySet<string>,
+): { paneId: string; duplicatePaneIds: string[]; unsafeCandidate: boolean } {
+  const ownedPanes = panes
+    .filter((pane) => pane.paneId !== currentPaneId)
+    .filter((pane) => hudPaneMatchesOwner(pane, owner));
+  if (ownedPanes.some((pane) => !hasVerifiedHudPaneInstanceIdentity(pane, equivalentSessionIds))) {
+    return { paneId: preferredPaneId, duplicatePaneIds: [], unsafeCandidate: true };
+  }
+  const ownedPaneIds = ownedPanes.map((pane) => pane.paneId);
   const keeperPaneId = ownedPaneIds.includes(preferredPaneId)
     ? preferredPaneId
     : (ownedPaneIds[0] ?? preferredPaneId);
@@ -225,135 +255,42 @@ function planOwnedHudPaneDedupe(
   return {
     paneId: keeperPaneId,
     duplicatePaneIds: ownedPaneIds.filter((paneId) => paneId !== keeperPaneId),
+    unsafeCandidate: false,
   };
 }
 
 const HUD_RECONCILE_LOCK_STALE_MS = 10_000;
 
-interface HudReconcileLock {
-  path: string;
-  token: string;
+function isVerifiedManagedHudOwner(
+  domain: ResolvedHudControlPlaneDomain,
+  currentPaneId: string | undefined,
+  evidence: ActualTmuxInstanceEvidence,
+): boolean {
+  const equivalentSessionIds = new Set(
+    [domain.session?.canonicalId, ...(domain.session?.equivalentIds ?? [])]
+      .map((sessionId) => sessionId?.trim() ?? '')
+      .filter(Boolean),
+  );
+  return Boolean(
+    domain.managed
+    && currentPaneId
+    && evidence.paneTarget === currentPaneId
+    && domain.claimant.leaderPaneId === currentPaneId
+    && domain.claimant.tmuxSessionName
+    && domain.claimant.tmuxSessionName === evidence.sessionName
+    && [...equivalentSessionIds].some((sessionId) => tmuxEvidenceBindsCandidate(evidence, sessionId)),
+  );
 }
 
-interface HudReconcileLockOwner {
-  token?: unknown;
-  pid?: unknown;
-  acquired_at?: unknown;
-}
-
-function parseIsoMs(value: unknown): number | null {
-  if (typeof value !== 'string' || !value.trim()) return null;
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
-function defaultIsProcessLive(pid: number): boolean | null {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException | null)?.code;
-    if (code === 'ESRCH') return false;
-    if (code === 'EPERM') return true;
-    return null;
-  }
-}
-
-async function readHudReconcileLockOwner(lockPath: string): Promise<HudReconcileLockOwner | null> {
-  return readFile(join(lockPath, 'owner.json'), 'utf-8')
-    .then((content) => JSON.parse(content) as HudReconcileLockOwner)
-    .catch(() => null);
-}
-
-async function tryCreateHudReconcileLock(lockPath: string, nowMs: number): Promise<HudReconcileLock | null> {
-  const token = randomUUID();
-  let createdDir = false;
-  try {
-    await mkdir(lockPath, { recursive: false });
-    createdDir = true;
-    await writeFile(join(lockPath, 'owner.json'), JSON.stringify({
-      token,
-      pid: process.pid,
-      acquired_at: new Date(nowMs).toISOString(),
-    }, null, 2));
-    return { path: lockPath, token };
-  } catch {
-    if (createdDir) await rm(lockPath, { recursive: true, force: true }).catch(() => {});
-    return null;
-  }
-}
-
-async function restoreMovedLock(fromPath: string, toPath: string): Promise<void> {
-  const restored = await rename(fromPath, toPath).then(() => true).catch(() => false);
-  if (!restored) await rm(fromPath, { recursive: true, force: true }).catch(() => {});
-}
-
-async function acquireHudReconcileLock(
-  lockPath: string,
-  nowMs: number,
-  staleMs: number,
-  isProcessLive: (pid: number) => boolean | null,
-): Promise<HudReconcileLock | null> {
-  const created = await tryCreateHudReconcileLock(lockPath, nowMs);
-  if (created) return created;
-
-  const observedOwner = await readHudReconcileLockOwner(lockPath);
-  const lockStat = await stat(lockPath).catch(() => null);
-  if (!lockStat) return null;
-
-  const ownerPid = typeof observedOwner?.pid === 'number' && Number.isInteger(observedOwner.pid) && observedOwner.pid > 0
-    ? observedOwner.pid
-    : null;
-  const ownerAcquiredMs = parseIsoMs(observedOwner?.acquired_at);
-  const lockAgeMs = ownerAcquiredMs === null ? nowMs - lockStat.mtimeMs : nowMs - ownerAcquiredMs;
-  if (lockAgeMs <= staleMs) return null;
-
-  if (ownerPid !== null) {
-    const liveness = isProcessLive(ownerPid);
-    if (liveness !== false) return null;
-  }
-
-  const reapPath = `${lockPath}.stale.${process.pid}.${nowMs}.${randomUUID()}`;
-  try {
-    await rename(lockPath, reapPath);
-  } catch {
-    return null;
-  }
-
-  const reapedOwner = await readHudReconcileLockOwner(reapPath);
-  const reapedStat = await stat(reapPath).catch(() => null);
-  const reapedOwnerAcquiredMs = parseIsoMs(reapedOwner?.acquired_at);
-  const reapedAgeMs = reapedOwnerAcquiredMs === null && reapedStat
-    ? nowMs - reapedStat.mtimeMs
-    : reapedOwnerAcquiredMs === null ? 0 : nowMs - reapedOwnerAcquiredMs;
-  const reapedObservedLock = observedOwner?.token === reapedOwner?.token
-    && reapedStat?.mtimeMs === lockStat.mtimeMs
-    && reapedAgeMs > staleMs;
-
-  if (!reapedObservedLock) {
-    await restoreMovedLock(reapPath, lockPath);
-    return null;
-  }
-
-  await rm(reapPath, { recursive: true, force: true }).catch(() => {});
-  return tryCreateHudReconcileLock(lockPath, nowMs);
-}
-
-async function releaseHudReconcileLock(lock: HudReconcileLock): Promise<void> {
-  const releasePath = `${lock.path}.release.${process.pid}.${Date.now()}.${lock.token}`;
-  try {
-    await rename(lock.path, releasePath);
-  } catch {
-    return;
-  }
-
-  const releaseOwner = await readHudReconcileLockOwner(releasePath);
-  if (releaseOwner?.token === lock.token) {
-    await rm(releasePath, { recursive: true, force: true }).catch(() => {});
-    return;
-  }
-
-  await restoreMovedLock(releasePath, lock.path);
+function lifecycleLockDepsForReconcile(deps: ReconcileHudForPromptSubmitDeps): HudLifecycleLockDeps {
+  if (!deps.isProcessLive) return deps.lifecycleLockDeps ?? {};
+  return {
+    ...deps.lifecycleLockDeps,
+    probeProcess: deps.lifecycleLockDeps?.probeProcess ?? (async (owner) => {
+      const live = deps.isProcessLive?.(owner.pid);
+      return live === true ? 'live' : live === false ? 'dead' : 'uncertain';
+    }),
+  };
 }
 
 
@@ -380,6 +317,39 @@ export async function reconcileHudForPromptSubmit(
     };
   }
 
+  const currentPaneId = env.TMUX_PANE?.trim();
+  const requestedSessionId = deps.sessionId?.trim() || env.OMX_SESSION_ID?.trim() || undefined;
+  if (!requestedSessionId) {
+    return {
+      status: 'skipped_no_session_id',
+      paneId: null,
+      desiredHeight: null,
+      duplicateCount: 0,
+    };
+  }
+
+  const domainEnv: NodeJS.ProcessEnv = {
+    ...env,
+    TMUX_PANE: undefined,
+    TMUX_SESSION: undefined,
+  };
+  const domain = await (deps.resolveDomain ?? resolveHudControlPlaneDomain)({
+    cwd,
+    env: domainEnv,
+    requestedSessionId,
+  }).catch(() => null);
+  const evidence = domain && currentPaneId
+    ? await (deps.probeTmuxInstance ?? probeActualTmuxInstanceEvidence)(currentPaneId).catch(() => null)
+    : null;
+  if (!domain || !evidence || !isVerifiedManagedHudOwner(domain, currentPaneId, evidence)) {
+    return {
+      status: 'skipped_not_omx_owned_tmux',
+      paneId: null,
+      desiredHeight: null,
+      duplicateCount: 0,
+    };
+  }
+
   const resolveOmxCliEntryPathFn = deps.resolveOmxCliEntryPath ?? resolveOmxCliEntryPath;
   const omxBin = resolveOmxCliEntryPathFn();
   if (!omxBin) {
@@ -391,22 +361,17 @@ export async function reconcileHudForPromptSubmit(
     };
   }
 
-  const listPanes = deps.listCurrentWindowPanes ?? ((paneId) => listCurrentWindowPanes(undefined, paneId));
-  const createPane = deps.createHudWatchPane ?? ((hudCwd, hudCmd, options) => createHudWatchPane(hudCwd, hudCmd, options));
-  const killPane = deps.killTmuxPane ?? ((paneId) => killTmuxPane(paneId));
-  const resizePane = deps.resizeTmuxPane ?? ((paneId, lines) => resizeTmuxPane(paneId, lines));
-
-  const lockPath = join(cwd, '.omx', 'state', 'hud-reconcile.lock');
-  const lockDirReady = await mkdir(dirname(lockPath), { recursive: true }).then(() => true).catch(() => false);
-  const lock = lockDirReady
-    ? await acquireHudReconcileLock(
-      lockPath,
-      deps.nowMs?.() ?? Date.now(),
-      HUD_RECONCILE_LOCK_STALE_MS,
-      deps.isProcessLive ?? defaultIsProcessLive,
+  const lockDirReady = await mkdir(domain.baseStateDir, { recursive: true }).then(() => true).catch(() => false);
+  const acquired = lockDirReady
+    ? await acquireHudLifecycleLock(
+      { path: domain.reconcileLockPath, domainKey: domain.domainKey, staleMs: HUD_RECONCILE_LOCK_STALE_MS },
+      {
+        ...lifecycleLockDepsForReconcile(deps),
+        nowMs: deps.lifecycleLockDeps?.nowMs ?? deps.nowMs ?? (() => Date.now()),
+      },
     )
-    : null;
-  if (lockDirReady && !lock) {
+    : { status: 'failed' as const };
+  if (acquired.status !== 'acquired' || !acquired.lock) {
     return {
       status: 'skipped_concurrent',
       paneId: null,
@@ -415,17 +380,15 @@ export async function reconcileHudForPromptSubmit(
     };
   }
 
+  const listPanes = deps.listCurrentWindowPanes ?? ((paneId) => listCurrentWindowPanes(undefined, paneId));
+  const createPane = deps.createHudWatchPane ?? ((hudCwd, hudCmd, options) => createHudWatchPane(hudCwd, hudCmd, options));
+  const killPane = deps.killTmuxPane ?? ((paneId) => killTmuxPane(paneId));
+  const resizePane = deps.resizeTmuxPane ?? ((paneId, lines) => resizeTmuxPane(paneId, lines));
+  const lock = acquired.lock;
+  const resolvedSessionId = domain.session?.canonicalId;
+  const equivalentSessionIds = domain.session?.equivalentIds ?? [];
   try {
 
-  const currentPaneId = env.TMUX_PANE?.trim();
-  const resolvedSessionId = deps.sessionId?.trim() || env.OMX_SESSION_ID?.trim() || undefined;
-  const equivalentSessionIds = [
-    resolvedSessionId,
-    env.OMX_SESSION_ID?.trim(),
-    ...(deps.sessionIds ?? []),
-  ]
-    .map((sessionId) => sessionId?.trim() ?? '')
-    .filter((sessionId, index, sessionIds) => sessionId !== '' && sessionIds.indexOf(sessionId) === index);
   let panes = listPanes(currentPaneId);
 
   // Reclaim orphaned HUD panes left behind by a destroyed leader before deciding
@@ -458,15 +421,21 @@ export async function reconcileHudForPromptSubmit(
     panes = panes.filter((pane) => !reapedPaneIdSet.has(pane.paneId));
   }
 
+  const equivalentSessionIdSet = new Set(
+    [resolvedSessionId, ...equivalentSessionIds].map((sessionId) => sessionId?.trim() ?? '').filter(Boolean),
+  );
   const owner = {
     sessionId: resolvedSessionId,
     sessionIds: equivalentSessionIds,
     leaderPaneId: currentPaneId,
   };
-  const hudPaneIds = [
-    ...findHudWatchPaneIds(panes, currentPaneId, owner),
-    ...findLegacyFocusedHudWatchPaneIds(panes, currentPaneId),
-  ].filter((paneId, index, paneIds) => paneIds.indexOf(paneId) === index);
+  const ownedHudPanes = panes
+    .filter((pane) => pane.paneId !== currentPaneId)
+    .filter((pane) => hudPaneMatchesOwner(pane, owner));
+  if (ownedHudPanes.some((pane) => !hasVerifiedHudPaneInstanceIdentity(pane, equivalentSessionIdSet))) {
+    return { status: 'unchanged', paneId: null, desiredHeight: null, duplicateCount: 0 };
+  }
+  const hudPaneIds = ownedHudPanes.map((pane) => pane.paneId);
   const duplicateCount = Math.max(0, hudPaneIds.length - 1);
   const readHudConfigFn = deps.readHudConfig ?? readHudConfig;
   const hudConfig = await readHudConfigFn(cwd).catch(() => null);
@@ -523,14 +492,7 @@ export async function reconcileHudForPromptSubmit(
     .some((pane) => Boolean(pane && needsHudTopologyRecreate(pane, leaderPane)))
     && (!leaderPane || shouldCreateFullWidthHud(leaderPane));
 
-  if (!resolvedSessionId) {
-    return {
-      status: 'skipped_no_session_id',
-      paneId: null,
-      desiredHeight,
-      duplicateCount,
-    };
-  }
+
 
   // When there is no existing HUD pane to keep/recreate, this reconcile would
   // create a fresh HUD split. Mirror the launch-time guard: if the current tmux
@@ -559,9 +521,10 @@ export async function reconcileHudForPromptSubmit(
     if (killPane(paneId)) removedHudPaneIds.add(paneId);
   }
 
-  const createOptions: { heightLines: number; fullWidth?: boolean; targetPaneId?: string } = {
+  const createOptions: { heightLines: number; fullWidth?: boolean; targetPaneId?: string; instanceId?: string } = {
     heightLines: desiredHeight,
     targetPaneId: currentPaneId,
+    instanceId: resolvedSessionId,
   };
   if (createFullWidth) createOptions.fullWidth = true;
   const paneId = createPane(cwd, hudCmd, createOptions);
@@ -583,7 +546,11 @@ export async function reconcileHudForPromptSubmit(
     currentPaneId,
     owner,
     paneId,
+    equivalentSessionIdSet,
   );
+  if (postCreate.unsafeCandidate) {
+    return { status: 'recreated', paneId, desiredHeight, duplicateCount: 0 };
+  }
   for (const duplicatePaneId of postCreate.duplicatePaneIds) {
     killPane(duplicatePaneId);
   }
@@ -605,6 +572,6 @@ export async function reconcileHudForPromptSubmit(
     duplicateCount: postCreate.duplicatePaneIds.length,
   };
   } finally {
-    if (lock) await releaseHudReconcileLock(lock);
+    await releaseHudLifecycleLock(lock);
   }
 }

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -143,7 +143,6 @@ function tmuxSnapshotBindsCandidate(
   const paneInstanceId = pane.paneInstanceId?.trim() ?? '';
   const sessionInstanceId = pane.sessionInstanceId?.trim() ?? '';
   const candidateIds = [...new Set(candidateSessionIds.map((candidate) => candidate.trim()).filter(Boolean))];
-  if (candidateIds.length > 2) return false;
   const evidence: ActualTmuxInstanceEvidence = {
     paneTarget: pane.paneId,
     sessionName: '',

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -2,7 +2,7 @@ import { mkdir } from 'node:fs/promises';
 
 import { acquireHudLifecycleLock, releaseHudLifecycleLock, type HudLifecycleLockDeps } from './lifecycle-lock.js';
 import { resolveHudControlPlaneDomain, type ResolvedHudControlPlaneDomain } from '../mcp/state-paths.js';
-import { probeActualTmuxInstanceEvidence, tmuxEvidenceBindsCandidate, type ActualTmuxInstanceEvidence } from '../scripts/notify-hook/managed-tmux.js';
+import { probeActualTmuxInstanceEvidence, type ActualTmuxInstanceEvidence } from '../scripts/notify-hook/managed-tmux.js';
 
 import { readAllState, readHudConfig } from './state.js';
 import { getHudRenderMaxLines } from './render.js';
@@ -276,10 +276,14 @@ function isVerifiedManagedHudOwner(
     domain.managed
     && currentPaneId
     && evidence.paneTarget === currentPaneId
+    && evidence.contextStable
+    && evidence.paneTagStatus === 'present'
+    && evidence.sessionTagStatus === 'present'
+    && equivalentSessionIds.has(evidence.paneInstanceId)
+    && equivalentSessionIds.has(evidence.sessionInstanceId)
     && domain.claimant.leaderPaneId === currentPaneId
     && domain.claimant.tmuxSessionName
-    && domain.claimant.tmuxSessionName === evidence.sessionName
-    && [...equivalentSessionIds].some((sessionId) => tmuxEvidenceBindsCandidate(evidence, sessionId)),
+    && domain.claimant.tmuxSessionName === evidence.sessionName,
   );
 }
 
@@ -631,19 +635,23 @@ export async function teardownManagedHudPane(
     }
 
     const identity = { tmuxSessionInstanceId, tmuxPaneInstanceId };
-    const removedPaneIds: string[] = [];
-    const killPane = deps.killTmuxPane ?? killTmuxPane;
-    for (const pane of panes) {
-      if (pane.paneId === currentPaneId || !isHudWatchPane(pane)) continue;
-      const exactOwner = [...equivalentSessionIds].some((sessionId) => hudPaneMatchesExactCandidate(
+    const exactHudPaneIds = panes
+      .filter((pane) => pane.paneId !== currentPaneId && isHudWatchPane(pane))
+      .filter((pane) => [...equivalentSessionIds].some((sessionId) => hudPaneMatchesExactCandidate(
         pane,
         { sessionId, leaderPaneId: currentPaneId },
         identity,
-      ));
-      if (exactOwner && killPane(pane.paneId)) removedPaneIds.push(pane.paneId);
+      )))
+      .map((pane) => pane.paneId);
+    if (exactHudPaneIds.length === 0) {
+      return { status: 'unchanged', removedPaneIds: [] };
     }
-    if (removedPaneIds.length > 0) {
-      (deps.unregisterHudResizeHook ?? unregisterHudResizeHook)(currentPaneId);
+
+    (deps.unregisterHudResizeHook ?? unregisterHudResizeHook)(currentPaneId);
+    const removedPaneIds: string[] = [];
+    const killPane = deps.killTmuxPane ?? killTmuxPane;
+    for (const paneId of exactHudPaneIds) {
+      if (killPane(paneId)) removedPaneIds.push(paneId);
     }
     return { status: removedPaneIds.length > 0 ? 'removed' : 'unchanged', removedPaneIds };
   } finally {

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -16,6 +16,7 @@ import {
   readCurrentWindowSize,
   readHudPaneOwner,
   hudPaneMatchesOwner,
+  hudPaneMatchesExactCandidate,
   registerHudResizeHook,
   unregisterHudResizeHook,
   resizeTmuxPane,
@@ -573,5 +574,79 @@ export async function reconcileHudForPromptSubmit(
   };
   } finally {
     await releaseHudLifecycleLock(lock);
+  }
+}
+
+export interface TeardownManagedHudResult {
+  status: 'removed' | 'unchanged' | 'skipped_not_omx_owned_tmux' | 'skipped_concurrent';
+  removedPaneIds: string[];
+}
+
+export async function teardownManagedHudPane(
+  cwd: string,
+  deps: ReconcileHudForPromptSubmitDeps = {},
+): Promise<TeardownManagedHudResult> {
+  const env = deps.env ?? process.env;
+  const currentPaneId = env.TMUX_PANE?.trim();
+  const requestedSessionId = deps.sessionId?.trim() || env.OMX_SESSION_ID?.trim() || undefined;
+  if (!env.TMUX || !isExplicitOmxOwnedTmuxEnv(env) || !currentPaneId || !requestedSessionId) {
+    return { status: 'skipped_not_omx_owned_tmux', removedPaneIds: [] };
+  }
+
+  const domain = await (deps.resolveDomain ?? resolveHudControlPlaneDomain)({
+    cwd,
+    env: { ...env, TMUX_PANE: undefined, TMUX_SESSION: undefined },
+    requestedSessionId,
+  }).catch(() => null);
+  const evidence = domain
+    ? await (deps.probeTmuxInstance ?? probeActualTmuxInstanceEvidence)(currentPaneId).catch(() => null)
+    : null;
+  if (!domain || !evidence || !isVerifiedManagedHudOwner(domain, currentPaneId, evidence)) {
+    return { status: 'skipped_not_omx_owned_tmux', removedPaneIds: [] };
+  }
+
+  const lockDirReady = await mkdir(domain.baseStateDir, { recursive: true }).then(() => true).catch(() => false);
+  const acquired = lockDirReady
+    ? await acquireHudLifecycleLock(
+      { path: domain.reconcileLockPath, domainKey: domain.domainKey, staleMs: HUD_RECONCILE_LOCK_STALE_MS },
+      lifecycleLockDepsForReconcile(deps),
+    )
+    : { status: 'failed' as const };
+  if (acquired.status !== 'acquired' || !acquired.lock) {
+    return { status: 'skipped_concurrent', removedPaneIds: [] };
+  }
+
+  try {
+    const panes = (deps.listCurrentWindowPanes ?? ((paneId) => listCurrentWindowPanes(undefined, paneId)))(currentPaneId);
+    const leader = panes.find((pane) => pane.paneId === currentPaneId && !isHudWatchPane(pane));
+    const equivalentSessionIds = new Set(
+      [domain.session?.canonicalId, ...(domain.session?.equivalentIds ?? [])]
+        .map((value) => value?.trim() ?? '')
+        .filter(Boolean),
+    );
+    const tmuxSessionInstanceId = leader?.sessionInstanceId?.trim() ?? '';
+    const tmuxPaneInstanceId = leader?.paneInstanceId?.trim() ?? '';
+    if (!leader || !equivalentSessionIds.has(tmuxSessionInstanceId) || !equivalentSessionIds.has(tmuxPaneInstanceId)) {
+      return { status: 'skipped_not_omx_owned_tmux', removedPaneIds: [] };
+    }
+
+    const identity = { tmuxSessionInstanceId, tmuxPaneInstanceId };
+    const removedPaneIds: string[] = [];
+    const killPane = deps.killTmuxPane ?? killTmuxPane;
+    for (const pane of panes) {
+      if (pane.paneId === currentPaneId || !isHudWatchPane(pane)) continue;
+      const exactOwner = [...equivalentSessionIds].some((sessionId) => hudPaneMatchesExactCandidate(
+        pane,
+        { sessionId, leaderPaneId: currentPaneId },
+        identity,
+      ));
+      if (exactOwner && killPane(pane.paneId)) removedPaneIds.push(pane.paneId);
+    }
+    if (removedPaneIds.length > 0) {
+      (deps.unregisterHudResizeHook ?? unregisterHudResizeHook)(currentPaneId);
+    }
+    return { status: removedPaneIds.length > 0 ? 'removed' : 'unchanged', removedPaneIds };
+  } finally {
+    await releaseHudLifecycleLock(acquired.lock);
   }
 }

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -1,4 +1,6 @@
 import { mkdir } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+
 
 import { acquireHudLifecycleLock, releaseHudLifecycleLock, type HudLifecycleLockDeps } from './lifecycle-lock.js';
 import { resolveHudControlPlaneDomain, type ResolvedHudControlPlaneDomain } from '../mcp/state-paths.js';
@@ -200,18 +202,35 @@ function hasVerifiedHudPaneInstanceIdentity(
   return tmuxSnapshotBindsCandidate(pane, [...equivalentSessionIds]);
 }
 
+function tmuxSnapshotMatchesHudBirth(
+  pane: TmuxPaneSnapshot,
+  paneBirthId: string | undefined,
+  sessionBirthId: string | undefined,
+): boolean {
+  const expectedPaneBirthId = paneBirthId?.trim() ?? '';
+  const expectedSessionBirthId = sessionBirthId?.trim() ?? '';
+  return Boolean(
+    expectedPaneBirthId
+    && expectedSessionBirthId
+    && pane.paneInstanceId?.trim() === expectedPaneBirthId
+    && pane.sessionInstanceId?.trim() === expectedSessionBirthId,
+  );
+}
+
 function planOwnedHudPaneDedupe(
   panes: TmuxPaneSnapshot[],
   currentPaneId: string | undefined,
   owner: HudPaneOwner,
   preferredPaneId: string,
   equivalentSessionIds: ReadonlySet<string>,
-  domain: ResolvedHudControlPlaneDomain,
+  sessionBirthId: string | undefined,
+  createdPaneBirthId: string | undefined,
 ): { paneId: string; duplicatePaneIds: string[]; unsafeCandidate: boolean } {
   const ownedPanes = panes
     .filter((pane) => pane.paneId !== currentPaneId)
     .filter((pane) => hudPaneMatchesOwner(pane, owner));
-  if (ownedPanes.some((pane) => !hasVerifiedHudPaneInstanceIdentity(pane, equivalentSessionIds) && !tmuxSnapshotMatchesClaimantBirth(pane, domain))) {
+  if (ownedPanes.some((pane) => !hasVerifiedHudPaneInstanceIdentity(pane, equivalentSessionIds)
+    && !(pane.paneId === preferredPaneId && tmuxSnapshotMatchesHudBirth(pane, createdPaneBirthId, sessionBirthId)))) {
     return { paneId: preferredPaneId, duplicatePaneIds: [], unsafeCandidate: true };
   }
   const ownedPaneIds = ownedPanes.map((pane) => pane.paneId);
@@ -390,7 +409,11 @@ export async function reconcileHudForPromptSubmit(
     sessionIds: equivalentSessionIds,
     leaderPaneId: currentPaneId,
   };
-  const exactHudKillCandidate = async (paneId: string, stale = false): Promise<ExactHudPaneKillCandidate | null> => {
+  const exactHudKillCandidate = async (
+    paneId: string,
+    stale = false,
+    expectedPaneBirthId?: string,
+  ): Promise<ExactHudPaneKillCandidate | null> => {
     const latestEvidence = currentPaneId
       ? await (deps.probeTmuxInstance ?? probeActualTmuxInstanceEvidence)(currentPaneId).catch(() => null)
       : null;
@@ -409,7 +432,10 @@ export async function reconcileHudForPromptSubmit(
       : Boolean(
         latestPanes.some((pane) => pane.paneId === currentPaneId && !isHudWatchPane(pane))
         && hudPaneMatchesOwner(candidate, owner)
-        && (hasVerifiedHudPaneInstanceIdentity(candidate, equivalentSessionIdSet) || tmuxSnapshotMatchesClaimantBirth(candidate, domain)),
+        && (
+          hasVerifiedHudPaneInstanceIdentity(candidate, equivalentSessionIdSet)
+          || tmuxSnapshotMatchesHudBirth(candidate, expectedPaneBirthId, latestEvidence.sessionInstanceId)
+        ),
       );
     if (!ownerMatches) return null;
     const paneInstanceId = candidate.paneInstanceId?.trim() ?? '';
@@ -425,8 +451,8 @@ export async function reconcileHudForPromptSubmit(
       sessionName: latestEvidence.sessionName,
     };
   };
-  const killOwnedHudPane = async (paneId: string, stale = false): Promise<boolean> => {
-    const candidate = await exactHudKillCandidate(paneId, stale);
+  const killOwnedHudPane = async (paneId: string, stale = false, expectedPaneBirthId?: string): Promise<boolean> => {
+    const candidate = await exactHudKillCandidate(paneId, stale, expectedPaneBirthId);
     return candidate ? killPane(candidate) : false;
   };
   const liveNonHudPaneIds = new Set(panes.filter((pane) => !isHudWatchPane(pane)).map((pane) => pane.paneId));
@@ -457,7 +483,7 @@ export async function reconcileHudForPromptSubmit(
   const ownedHudPanes = panes
     .filter((pane) => pane.paneId !== currentPaneId)
     .filter((pane) => hudPaneMatchesOwner(pane, owner));
-  if (ownedHudPanes.some((pane) => !hasVerifiedHudPaneInstanceIdentity(pane, equivalentSessionIdSet) && !tmuxSnapshotMatchesClaimantBirth(pane, domain))) {
+  if (ownedHudPanes.some((pane) => !hasVerifiedHudPaneInstanceIdentity(pane, equivalentSessionIdSet))) {
     return { status: 'unchanged', paneId: null, desiredHeight: null, duplicateCount: 0 };
   }
   const hudPaneIds = ownedHudPanes.map((pane) => pane.paneId);
@@ -560,10 +586,11 @@ export async function reconcileHudForPromptSubmit(
     removedHudPaneIds.add(paneId);
   }
 
+  const hudPaneBirthId = randomUUID();
   const createOptions: { heightLines: number; fullWidth?: boolean; targetPaneId?: string; instanceId?: string } = {
     heightLines: desiredHeight,
     targetPaneId: currentPaneId,
-    instanceId: domain.claimant.tmuxPaneInstanceId?.trim() || undefined,
+    instanceId: hudPaneBirthId,
   };
   if (createFullWidth) createOptions.fullWidth = true;
   const paneId = createPane(cwd, hudCmd, createOptions);
@@ -586,10 +613,11 @@ export async function reconcileHudForPromptSubmit(
     owner,
     paneId,
     equivalentSessionIdSet,
-    domain,
+    lockedEvidence.sessionInstanceId,
+    hudPaneBirthId,
   );
   if (postCreate.unsafeCandidate) {
-    const rolledBack = await killOwnedHudPane(paneId);
+    const rolledBack = await killOwnedHudPane(paneId, false, hudPaneBirthId);
     return {
       status: 'failed',
       paneId: rolledBack ? null : paneId,
@@ -599,7 +627,7 @@ export async function reconcileHudForPromptSubmit(
   }
   for (const duplicatePaneId of postCreate.duplicatePaneIds) {
     if (!await killOwnedHudPane(duplicatePaneId)) {
-      const rolledBack = await killOwnedHudPane(paneId);
+      const rolledBack = await killOwnedHudPane(paneId, false, hudPaneBirthId);
       return {
         status: 'failed',
         paneId: rolledBack ? null : paneId,
@@ -692,7 +720,7 @@ export async function teardownManagedHudPane(
     };
     const exactHudPaneIds = panes
       .filter((pane) => pane.paneId !== currentPaneId && isHudWatchPane(pane))
-      .filter((pane) => tmuxSnapshotBindsCandidate(pane, [...equivalentSessionIds]) || tmuxSnapshotMatchesClaimantBirth(pane, domain))
+      .filter((pane) => tmuxSnapshotBindsCandidate(pane, [...equivalentSessionIds]))
       .filter((pane) => [...equivalentSessionIds].some((sessionId) => hudPaneMatchesExactCandidate(
         pane,
         { sessionId, leaderPaneId: currentPaneId },

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -31,91 +31,6 @@ function isExplicitOmxOwnedTmuxEnv(env: NodeJS.ProcessEnv): boolean {
   return env[OMX_TMUX_HUD_OWNER_ENV] === '1';
 }
 
-/**
- * Kill HUD watch panes that belong to the *current* session but whose owning
- * leader pane is no longer alive in this window.
- *
- * When a leader pane is destroyed (e.g. during a `team` setup/teardown cycle that
- * tears down the leader REPL pane), its owner-tagged HUD panes are left pointing at
- * the dead leader id. They are matched by neither `findHudWatchPaneIds` — whose
- * owner check requires the recorded leader to equal the current pane — nor
- * `findLegacyFocusedHudWatchPaneIds`, which only adopts HUD panes that *lack* owner
- * metadata. So the reconcile below sees "no HUD", recreates one, and repeats on
- * every prompt submit until the window degenerates into a column of stacked HUD
- * strips with no leader or worker panes left.
- *
- * The reap is intentionally scoped to the current session: HUD panes owned by other
- * sessions (whose leader may legitimately live in a different tmux window we cannot
- * see from this window's pane list) are never touched.
- */
-function reapOrphanedSessionHudPanes(
-  panes: TmuxPaneSnapshot[],
-  opts: {
-    sessionId: string | undefined;
-    sessionIds?: string[];
-    currentPaneId: string | undefined;
-    killPane: (paneId: string) => boolean;
-  },
-): string[] {
-  const { sessionId, currentPaneId, killPane } = opts;
-  const sameSessionIds = new Set(
-    [sessionId, ...(opts.sessionIds ?? [])]
-      .map((candidate) => candidate?.trim() ?? '')
-      .filter((candidate) => candidate !== ''),
-  );
-  if (sameSessionIds.size === 0) return [];
-  // A recorded leader only counts as "live" if it exists in this window AND is not
-  // itself a HUD watcher. Without the HUD exclusion, an orphan whose recorded leader
-  // is *another HUD pane* would be preserved here; that referenced HUD could be
-  // reaped on a later iteration, leaving a dangling orphan that still never matches
-  // the real current pane — so the all-HUD-strip state is only partially cleaned.
-  const liveNonHudPaneIds = new Set(
-    panes.filter((pane) => !isHudWatchPane(pane)).map((pane) => pane.paneId),
-  );
-  const reaped: string[] = [];
-  for (const pane of panes) {
-    if (!isHudWatchPane(pane)) continue;
-    const owner = readHudPaneOwner(pane);
-    // Only reclaim HUDs that explicitly belong to this session and name a leader.
-    if (!owner.sessionId || !sameSessionIds.has(owner.sessionId) || !owner.leaderPaneId) continue;
-    if (!hasVerifiedHudPaneInstanceIdentity(pane, sameSessionIds)) continue;
-    // Keep HUDs whose leader is the current pane or another live non-HUD leader pane.
-    if (owner.leaderPaneId === currentPaneId || liveNonHudPaneIds.has(owner.leaderPaneId)) continue;
-    if (killPane(pane.paneId)) reaped.push(pane.paneId);
-  }
-  return reaped;
-}
-
-function hasExplicitHudOwnerMarker(pane: TmuxPaneSnapshot): boolean {
-  const command = `${pane.startCommand} ${pane.currentCommand}`;
-  return new RegExp(`(?:^|\\s)${OMX_TMUX_HUD_OWNER_ENV}=(?:'1'|1)(?=$|\\s)`).test(command);
-}
-
-function reapStaleCurrentLeaderHudPanes(
-  panes: TmuxPaneSnapshot[],
-  opts: {
-    sessionIds: string[];
-    currentPaneId: string | undefined;
-    killPane: (paneId: string) => boolean;
-  },
-): string[] {
-  const { currentPaneId, killPane } = opts;
-  if (!currentPaneId) return [];
-  const currentSessionIds = new Set(opts.sessionIds.map((sessionId) => sessionId.trim()).filter(Boolean));
-  if (currentSessionIds.size === 0) return [];
-
-  const reaped: string[] = [];
-  for (const pane of panes) {
-    if (!isHudWatchPane(pane)) continue;
-    const owner = readHudPaneOwner(pane);
-    if (owner.leaderPaneId !== currentPaneId) continue;
-    if (!hasExplicitHudOwnerMarker(pane)) continue;
-    if (!owner.sessionId || currentSessionIds.has(owner.sessionId)) continue;
-    if (!hasVerifiedHudPaneInstanceIdentity(pane, currentSessionIds)) continue;
-    if (killPane(pane.paneId)) reaped.push(pane.paneId);
-  }
-  return reaped;
-}
 
 export interface ReconcileHudForPromptSubmitResult {
   status:
@@ -456,35 +371,13 @@ export async function reconcileHudForPromptSubmit(
 
   let panes = listPanes(currentPaneId);
 
-  // Reclaim orphaned HUD panes left behind by a destroyed leader before deciding
-  // whether a HUD already exists; otherwise dead-leader HUDs accumulate one per
-  // prompt submit and the window fills with stacked HUD strips.
-  const reapedOrphanPaneIds = reapOrphanedSessionHudPanes(panes, {
-    sessionId: resolvedSessionId,
-    sessionIds: equivalentSessionIds,
-    currentPaneId,
-    killPane,
-  });
-  if (reapedOrphanPaneIds.length > 0) {
-    const reapedPaneIdSet = new Set(reapedOrphanPaneIds);
-    panes = panes.filter((pane) => !reapedPaneIdSet.has(pane.paneId));
-  }
+  // Orphan cleanup is destructive and requires fresh exact evidence immediately
+  // before each pane kill.
 
   // A Codex self-update can restart/resume the leader in the same tmux pane with
-  // a new OMX session id while the old HUD watcher stays alive. That stale HUD
-  // still names the current leader pane, but with the previous session id, so it
-  // does not match same-owner dedupe and the next launch would create a second HUD
-  // beside it. Reap only HUDs tied to this exact leader pane; neighboring panes'
-  // HUDs remain isolated by leaderPaneId.
-  const reapedStaleLeaderPaneIds = reapStaleCurrentLeaderHudPanes(panes, {
-    sessionIds: equivalentSessionIds,
-    currentPaneId,
-    killPane,
-  });
-  if (reapedStaleLeaderPaneIds.length > 0) {
-    const reapedPaneIdSet = new Set(reapedStaleLeaderPaneIds);
-    panes = panes.filter((pane) => !reapedPaneIdSet.has(pane.paneId));
-  }
+  // a new OMX session id while the old HUD watcher stays alive. Reap only HUDs
+  // tied to this exact leader pane after fresh identity revalidation; neighboring
+  // panes' HUDs remain isolated by leaderPaneId.
 
   const equivalentSessionIdSet = new Set(
     [resolvedSessionId, ...equivalentSessionIds].map((sessionId) => sessionId?.trim() ?? '').filter(Boolean),
@@ -494,6 +387,59 @@ export async function reconcileHudForPromptSubmit(
     sessionIds: equivalentSessionIds,
     leaderPaneId: currentPaneId,
   };
+  const canKillOwnedHudPane = async (paneId: string): Promise<boolean> => {
+    const latestEvidence = currentPaneId
+      ? await (deps.probeTmuxInstance ?? probeActualTmuxInstanceEvidence)(currentPaneId).catch(() => null)
+      : null;
+    if (!latestEvidence || !isVerifiedManagedHudOwner(domain, currentPaneId, latestEvidence)) return false;
+    const latestPanes = listPanes(currentPaneId);
+    const latestLeader = latestPanes.find((pane) => pane.paneId === currentPaneId && !isHudWatchPane(pane));
+    const candidate = latestPanes.find((pane) => pane.paneId === paneId);
+    return Boolean(
+      latestLeader
+      && candidate
+      && hudPaneMatchesOwner(candidate, owner)
+      && (hasVerifiedHudPaneInstanceIdentity(candidate, equivalentSessionIdSet) || tmuxSnapshotMatchesClaimantBirth(candidate, domain)),
+    );
+  };
+  const canKillStaleOwnedHudPane = async (paneId: string): Promise<boolean> => {
+    const latestEvidence = currentPaneId
+      ? await (deps.probeTmuxInstance ?? probeActualTmuxInstanceEvidence)(currentPaneId).catch(() => null)
+      : null;
+    if (!latestEvidence || !isVerifiedManagedHudOwner(domain, currentPaneId, latestEvidence)) return false;
+    const candidate = listPanes(currentPaneId).find((pane) => pane.paneId === paneId);
+    if (!candidate || !isHudWatchPane(candidate)) return false;
+    const candidateOwner = readHudPaneOwner(candidate);
+    return Boolean(
+      candidateOwner.sessionId
+      && candidateOwner.leaderPaneId
+      && (equivalentSessionIdSet.has(candidateOwner.sessionId) || candidateOwner.leaderPaneId === currentPaneId)
+      && hasVerifiedHudPaneInstanceIdentity(candidate, equivalentSessionIdSet),
+    );
+  };
+  const liveNonHudPaneIds = new Set(panes.filter((pane) => !isHudWatchPane(pane)).map((pane) => pane.paneId));
+  const staleHudPaneIds = panes
+    .filter((pane) => pane.paneId !== currentPaneId && isHudWatchPane(pane))
+    .filter((pane) => {
+      const candidateOwner = readHudPaneOwner(pane);
+      if (!candidateOwner.leaderPaneId || !candidateOwner.sessionId) return false;
+      const sameSession = equivalentSessionIdSet.has(candidateOwner.sessionId);
+      const deadSameSessionLeader = sameSession
+        && candidateOwner.leaderPaneId !== currentPaneId
+        && !liveNonHudPaneIds.has(candidateOwner.leaderPaneId);
+      const staleCurrentLeader = candidateOwner.leaderPaneId === currentPaneId
+        && !sameSession
+        && new RegExp(`(?:^|\\s)${OMX_TMUX_HUD_OWNER_ENV}=(?:'1'|1)(?=$|\\s)`).test(`${pane.startCommand} ${pane.currentCommand}`);
+      return deadSameSessionLeader || staleCurrentLeader;
+    })
+    .map((pane) => pane.paneId);
+  for (const paneId of staleHudPaneIds) {
+    if (await canKillStaleOwnedHudPane(paneId)) killPane(paneId);
+  }
+  if (staleHudPaneIds.length > 0) {
+    const stalePaneIdSet = new Set(staleHudPaneIds);
+    panes = panes.filter((pane) => !stalePaneIdSet.has(pane.paneId));
+  }
   const ownedHudPanes = panes
     .filter((pane) => pane.paneId !== currentPaneId)
     .filter((pane) => hudPaneMatchesOwner(pane, owner));
@@ -540,7 +486,7 @@ export async function reconcileHudForPromptSubmit(
 
     if (keeperPane) {
       for (const paneId of hudPaneIds.filter((paneId) => paneId !== keeperPane.paneId)) {
-        killPane(paneId);
+        if (await canKillOwnedHudPane(paneId)) killPane(paneId);
       }
       const resized = resizePane(keeperPane.paneId, desiredHeight);
       if (resized) ensureHudResizeHook(keeperPane.paneId, currentPaneId, desiredHeight, cwd, deps);
@@ -579,17 +525,19 @@ export async function reconcileHudForPromptSubmit(
   }
 
   const unregisterHook = deps.unregisterHudResizeHook ?? unregisterHudResizeHook;
-  unregisterHook(currentPaneId);
+  if (!unregisterHook(currentPaneId) && hudPaneIds.length > 0) {
+    return { status: 'unchanged', paneId: null, desiredHeight, duplicateCount };
+  }
 
   const removedHudPaneIds = new Set<string>();
   for (const paneId of hudPaneIds) {
-    if (killPane(paneId)) removedHudPaneIds.add(paneId);
+    if (await canKillOwnedHudPane(paneId) && killPane(paneId)) removedHudPaneIds.add(paneId);
   }
 
   const createOptions: { heightLines: number; fullWidth?: boolean; targetPaneId?: string; instanceId?: string } = {
     heightLines: desiredHeight,
     targetPaneId: currentPaneId,
-    instanceId: resolvedSessionId,
+    instanceId: domain.claimant.tmuxPaneInstanceId?.trim() || undefined,
   };
   if (createFullWidth) createOptions.fullWidth = true;
   const paneId = createPane(cwd, hudCmd, createOptions);
@@ -618,7 +566,7 @@ export async function reconcileHudForPromptSubmit(
     return { status: 'recreated', paneId, desiredHeight, duplicateCount: 0 };
   }
   for (const duplicatePaneId of postCreate.duplicatePaneIds) {
-    killPane(duplicatePaneId);
+    if (await canKillOwnedHudPane(duplicatePaneId)) killPane(duplicatePaneId);
   }
   const resized = resizePane(postCreate.paneId, desiredHeight);
   if (!resized) {

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -92,15 +92,11 @@ function ensureHudResizeHook(
   desiredHeight: number,
   cwd: string,
   deps: ReconcileHudForPromptSubmitDeps,
-): void {
-  try {
-    (deps.registerHudResizeHook ?? registerHudResizeHook)(hudPaneId, leaderPaneId, desiredHeight, {
-      cwd,
-      env: deps.env ?? process.env,
-    });
-  } catch {
-    // Non-critical — hook registration failure does not break HUD lifecycle.
-  }
+): boolean {
+  return (deps.registerHudResizeHook ?? registerHudResizeHook)(hudPaneId, leaderPaneId, desiredHeight, {
+    cwd,
+    env: deps.env ?? process.env,
+  });
 }
 
 function hasCompleteGeometry(pane: TmuxPaneSnapshot): boolean {
@@ -478,9 +474,9 @@ export async function reconcileHudForPromptSubmit(
   if (singleHudPane && !needsHudTopologyRecreate(singleHudPane, leaderPane)) {
     const shouldResize = needsHudHeightResize(singleHudPane, desiredHeight);
     const resized = shouldResize ? resizePane(singleHudPane.paneId, desiredHeight) : true;
-    if (resized) ensureHudResizeHook(singleHudPane.paneId, currentPaneId, desiredHeight, cwd, deps);
+    const hooksRegistered = resized && ensureHudResizeHook(singleHudPane.paneId, currentPaneId, desiredHeight, cwd, deps);
     return {
-      status: resized ? (shouldResize ? 'resized' : 'unchanged') : 'failed',
+      status: resized && hooksRegistered ? (shouldResize ? 'resized' : 'unchanged') : 'failed',
       paneId: singleHudPane.paneId,
       desiredHeight,
       duplicateCount,
@@ -498,9 +494,9 @@ export async function reconcileHudForPromptSubmit(
         await killOwnedHudPane(paneId);
       }
       const resized = resizePane(keeperPane.paneId, desiredHeight);
-      if (resized) ensureHudResizeHook(keeperPane.paneId, currentPaneId, desiredHeight, cwd, deps);
+      const hooksRegistered = resized && ensureHudResizeHook(keeperPane.paneId, currentPaneId, desiredHeight, cwd, deps);
       return {
-        status: resized ? 'replaced_duplicates' : 'failed',
+        status: resized && hooksRegistered ? 'replaced_duplicates' : 'failed',
         paneId: keeperPane.paneId,
         desiredHeight,
         duplicateCount,
@@ -586,10 +582,10 @@ export async function reconcileHudForPromptSubmit(
       duplicateCount: postCreate.duplicatePaneIds.length,
     };
   }
-  ensureHudResizeHook(postCreate.paneId, currentPaneId, desiredHeight, cwd, deps);
+  const hooksRegistered = ensureHudResizeHook(postCreate.paneId, currentPaneId, desiredHeight, cwd, deps);
 
   return {
-    status: postCreate.duplicatePaneIds.length > 0 || hudPaneIds.length > 1 ? 'replaced_duplicates' : 'recreated',
+    status: hooksRegistered ? (postCreate.duplicatePaneIds.length > 0 || hudPaneIds.length > 1 ? 'replaced_duplicates' : 'recreated') : 'failed',
     paneId: postCreate.paneId,
     desiredHeight,
     duplicateCount: postCreate.duplicatePaneIds.length,

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -248,6 +248,31 @@ function tmuxSnapshotBindsCandidate(
       && candidateIds.includes(paneInstanceId));
 }
 
+function tmuxEvidenceMatchesClaimantBirth(
+  evidence: ActualTmuxInstanceEvidence,
+  domain: ResolvedHudControlPlaneDomain,
+): boolean {
+  const sessionBirthId = domain.claimant.tmuxSessionInstanceId?.trim() ?? '';
+  const paneBirthId = domain.claimant.tmuxPaneInstanceId?.trim() ?? '';
+  return Boolean(
+    sessionBirthId
+    && paneBirthId
+    && evidence.contextStable
+    && evidence.paneTagStatus === 'present'
+    && evidence.sessionTagStatus === 'present'
+    && evidence.sessionInstanceId === sessionBirthId
+    && evidence.paneInstanceId === paneBirthId,
+  );
+}
+
+function tmuxSnapshotMatchesClaimantBirth(
+  pane: TmuxPaneSnapshot,
+  domain: ResolvedHudControlPlaneDomain,
+): boolean {
+  return pane.sessionInstanceId?.trim() === domain.claimant.tmuxSessionInstanceId?.trim()
+    && pane.paneInstanceId?.trim() === domain.claimant.tmuxPaneInstanceId?.trim();
+}
+
 function hasVerifiedHudPaneInstanceIdentity(
   pane: TmuxPaneSnapshot,
   equivalentSessionIds: ReadonlySet<string>,
@@ -261,11 +286,12 @@ function planOwnedHudPaneDedupe(
   owner: HudPaneOwner,
   preferredPaneId: string,
   equivalentSessionIds: ReadonlySet<string>,
+  domain: ResolvedHudControlPlaneDomain,
 ): { paneId: string; duplicatePaneIds: string[]; unsafeCandidate: boolean } {
   const ownedPanes = panes
     .filter((pane) => pane.paneId !== currentPaneId)
     .filter((pane) => hudPaneMatchesOwner(pane, owner));
-  if (ownedPanes.some((pane) => !hasVerifiedHudPaneInstanceIdentity(pane, equivalentSessionIds))) {
+  if (ownedPanes.some((pane) => !hasVerifiedHudPaneInstanceIdentity(pane, equivalentSessionIds) && !tmuxSnapshotMatchesClaimantBirth(pane, domain))) {
     return { paneId: preferredPaneId, duplicatePaneIds: [], unsafeCandidate: true };
   }
   const ownedPaneIds = ownedPanes.map((pane) => pane.paneId);
@@ -298,7 +324,7 @@ function isVerifiedManagedHudOwner(
     domain.managed
     && currentPaneId
     && evidence.paneTarget === currentPaneId
-    && (tmuxEvidenceBindsCandidate(evidence, equivalentSessionIds) || acceptsSameAliasPair)
+    && (tmuxEvidenceBindsCandidate(evidence, equivalentSessionIds) || acceptsSameAliasPair || tmuxEvidenceMatchesClaimantBirth(evidence, domain))
     && domain.claimant.leaderPaneId === currentPaneId
     && domain.claimant.tmuxSessionName
     && domain.claimant.tmuxSessionName === evidence.sessionName,
@@ -412,6 +438,13 @@ export async function reconcileHudForPromptSubmit(
   const equivalentSessionIds = domain.session?.equivalentIds ?? [];
   try {
 
+  const lockedEvidence = currentPaneId
+    ? await (deps.probeTmuxInstance ?? probeActualTmuxInstanceEvidence)(currentPaneId).catch(() => null)
+    : null;
+  if (!lockedEvidence || !isVerifiedManagedHudOwner(domain, currentPaneId, lockedEvidence)) {
+    return { status: 'unchanged', paneId: null, desiredHeight: null, duplicateCount: 0 };
+  }
+
   let panes = listPanes(currentPaneId);
 
   // Reclaim orphaned HUD panes left behind by a destroyed leader before deciding
@@ -455,7 +488,7 @@ export async function reconcileHudForPromptSubmit(
   const ownedHudPanes = panes
     .filter((pane) => pane.paneId !== currentPaneId)
     .filter((pane) => hudPaneMatchesOwner(pane, owner));
-  if (ownedHudPanes.some((pane) => !hasVerifiedHudPaneInstanceIdentity(pane, equivalentSessionIdSet))) {
+  if (ownedHudPanes.some((pane) => !hasVerifiedHudPaneInstanceIdentity(pane, equivalentSessionIdSet) && !tmuxSnapshotMatchesClaimantBirth(pane, domain))) {
     return { status: 'unchanged', paneId: null, desiredHeight: null, duplicateCount: 0 };
   }
   const hudPaneIds = ownedHudPanes.map((pane) => pane.paneId);
@@ -570,6 +603,7 @@ export async function reconcileHudForPromptSubmit(
     owner,
     paneId,
     equivalentSessionIdSet,
+    domain,
   );
   if (postCreate.unsafeCandidate) {
     return { status: 'recreated', paneId, desiredHeight, duplicateCount: 0 };
@@ -638,6 +672,11 @@ export async function teardownManagedHudPane(
     return { status: 'skipped_concurrent', removedPaneIds: [] };
   }
 
+  const lockedEvidence = await (deps.probeTmuxInstance ?? probeActualTmuxInstanceEvidence)(currentPaneId).catch(() => null);
+  if (!lockedEvidence || !isVerifiedManagedHudOwner(domain, currentPaneId, lockedEvidence)) {
+    return { status: 'skipped_not_omx_owned_tmux', removedPaneIds: [] };
+  }
+
   try {
     const panes = (deps.listCurrentWindowPanes ?? ((paneId) => listCurrentWindowPanes(undefined, paneId)))(currentPaneId);
     const leader = panes.find((pane) => pane.paneId === currentPaneId && !isHudWatchPane(pane));
@@ -646,7 +685,7 @@ export async function teardownManagedHudPane(
         .map((value) => value?.trim() ?? '')
         .filter(Boolean),
     );
-    if (!leader || !tmuxSnapshotBindsCandidate(leader, [...equivalentSessionIds])) {
+    if (!leader || (!tmuxSnapshotBindsCandidate(leader, [...equivalentSessionIds]) && !tmuxSnapshotMatchesClaimantBirth(leader, domain))) {
       return { status: 'skipped_not_omx_owned_tmux', removedPaneIds: [] };
     }
 
@@ -656,7 +695,7 @@ export async function teardownManagedHudPane(
     };
     const exactHudPaneIds = panes
       .filter((pane) => pane.paneId !== currentPaneId && isHudWatchPane(pane))
-      .filter((pane) => tmuxSnapshotBindsCandidate(pane, [...equivalentSessionIds]))
+      .filter((pane) => tmuxSnapshotBindsCandidate(pane, [...equivalentSessionIds]) || tmuxSnapshotMatchesClaimantBirth(pane, domain))
       .filter((pane) => [...equivalentSessionIds].some((sessionId) => hudPaneMatchesExactCandidate(
         pane,
         { sessionId, leaderPaneId: currentPaneId },

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -711,11 +711,13 @@ export async function teardownManagedHudPane(
         identity,
       )))
       .map((pane) => pane.paneId);
+    const hooksUnregistered = (deps.unregisterHudResizeHook ?? unregisterHudResizeHook)(currentPaneId);
+    if (!hooksUnregistered) {
+      return { status: 'unchanged', removedPaneIds: [] };
+    }
     if (exactHudPaneIds.length === 0) {
       return { status: 'unchanged', removedPaneIds: [] };
     }
-
-    (deps.unregisterHudResizeHook ?? unregisterHudResizeHook)(currentPaneId);
     const removedPaneIds: string[] = [];
     const killPane = deps.killTmuxPane ?? killTmuxPane;
     for (const paneId of exactHudPaneIds) {

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -269,8 +269,14 @@ function tmuxSnapshotMatchesClaimantBirth(
   pane: TmuxPaneSnapshot,
   domain: ResolvedHudControlPlaneDomain,
 ): boolean {
-  return pane.sessionInstanceId?.trim() === domain.claimant.tmuxSessionInstanceId?.trim()
-    && pane.paneInstanceId?.trim() === domain.claimant.tmuxPaneInstanceId?.trim();
+  const sessionBirthId = domain.claimant.tmuxSessionInstanceId?.trim() ?? '';
+  const paneBirthId = domain.claimant.tmuxPaneInstanceId?.trim() ?? '';
+  return Boolean(
+    sessionBirthId
+    && paneBirthId
+    && pane.sessionInstanceId?.trim() === sessionBirthId
+    && pane.paneInstanceId?.trim() === paneBirthId,
+  );
 }
 
 function hasVerifiedHudPaneInstanceIdentity(
@@ -318,6 +324,9 @@ function isVerifiedManagedHudOwner(
     ...(domain.session?.equivalentIds ?? []),
   ].map((sessionId) => sessionId?.trim() ?? '').filter(Boolean))];
   const acceptsSameAliasPair = equivalentSessionIds.length === 2
+    && evidence.contextStable
+    && evidence.paneTagStatus === 'present'
+    && evidence.sessionTagStatus === 'present'
     && evidence.paneInstanceId === evidence.sessionInstanceId
     && equivalentSessionIds.includes(evidence.paneInstanceId);
   return Boolean(
@@ -672,12 +681,12 @@ export async function teardownManagedHudPane(
     return { status: 'skipped_concurrent', removedPaneIds: [] };
   }
 
-  const lockedEvidence = await (deps.probeTmuxInstance ?? probeActualTmuxInstanceEvidence)(currentPaneId).catch(() => null);
-  if (!lockedEvidence || !isVerifiedManagedHudOwner(domain, currentPaneId, lockedEvidence)) {
-    return { status: 'skipped_not_omx_owned_tmux', removedPaneIds: [] };
-  }
-
   try {
+    const lockedEvidence = await (deps.probeTmuxInstance ?? probeActualTmuxInstanceEvidence)(currentPaneId).catch(() => null);
+    if (!lockedEvidence || !isVerifiedManagedHudOwner(domain, currentPaneId, lockedEvidence)) {
+      return { status: 'skipped_not_omx_owned_tmux', removedPaneIds: [] };
+    }
+
     const panes = (deps.listCurrentWindowPanes ?? ((paneId) => listCurrentWindowPanes(undefined, paneId)))(currentPaneId);
     const leader = panes.find((pane) => pane.paneId === currentPaneId && !isHudWatchPane(pane));
     const equivalentSessionIds = new Set(

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -93,10 +93,13 @@ function ensureHudResizeHook(
   cwd: string,
   deps: ReconcileHudForPromptSubmitDeps,
 ): boolean {
-  return (deps.registerHudResizeHook ?? registerHudResizeHook)(hudPaneId, leaderPaneId, desiredHeight, {
+  const options = {
     cwd,
     env: deps.env ?? process.env,
-  });
+  };
+  return deps.registerHudResizeHook
+    ? deps.registerHudResizeHook(hudPaneId, leaderPaneId, desiredHeight, options) !== false
+    : registerHudResizeHook(hudPaneId, leaderPaneId, desiredHeight, options);
 }
 
 function hasCompleteGeometry(pane: TmuxPaneSnapshot): boolean {
@@ -354,7 +357,9 @@ export async function reconcileHudForPromptSubmit(
   const killPane = deps.killManagedHudPane
     ? (candidate: ExactHudPaneKillCandidate) => deps.killManagedHudPane!(candidate) !== false
     : killExactHudPane;
-  const resizePane = deps.resizeTmuxPane ?? ((paneId, lines) => resizeTmuxPane(paneId, lines));
+  const resizePane = deps.resizeTmuxPane
+    ? (paneId: string, lines: number) => deps.resizeTmuxPane!(paneId, lines) !== false
+    : (paneId: string, lines: number) => resizeTmuxPane(paneId, lines);
   const lock = acquired.lock;
   const resolvedSessionId = domain.session?.canonicalId;
   const equivalentSessionIds = domain.session?.equivalentIds ?? [];
@@ -478,9 +483,9 @@ export async function reconcileHudForPromptSubmit(
   if (singleHudPane && !needsHudTopologyRecreate(singleHudPane, leaderPane)) {
     const shouldResize = needsHudHeightResize(singleHudPane, desiredHeight);
     const resized = shouldResize ? resizePane(singleHudPane.paneId, desiredHeight) : true;
-    const hooksRegistered = resized && ensureHudResizeHook(singleHudPane.paneId, currentPaneId, desiredHeight, cwd, deps);
+    if (resized) ensureHudResizeHook(singleHudPane.paneId, currentPaneId, desiredHeight, cwd, deps);
     return {
-      status: resized && hooksRegistered ? (shouldResize ? 'resized' : 'unchanged') : 'failed',
+      status: resized ? (shouldResize ? 'resized' : 'unchanged') : 'failed',
       paneId: singleHudPane.paneId,
       desiredHeight,
       duplicateCount,
@@ -505,9 +510,9 @@ export async function reconcileHudForPromptSubmit(
         }
       }
       const resized = resizePane(keeperPane.paneId, desiredHeight);
-      const hooksRegistered = resized && ensureHudResizeHook(keeperPane.paneId, currentPaneId, desiredHeight, cwd, deps);
+      if (resized) ensureHudResizeHook(keeperPane.paneId, currentPaneId, desiredHeight, cwd, deps);
       return {
-        status: resized && hooksRegistered ? 'replaced_duplicates' : 'failed',
+        status: resized ? 'replaced_duplicates' : 'failed',
         paneId: keeperPane.paneId,
         desiredHeight,
         duplicateCount,
@@ -540,8 +545,10 @@ export async function reconcileHudForPromptSubmit(
     }
   }
 
-  const unregisterHook = deps.unregisterHudResizeHook ?? unregisterHudResizeHook;
-  if (!unregisterHook(currentPaneId) && hudPaneIds.length > 0) {
+  const hooksUnregistered = deps.unregisterHudResizeHook
+    ? deps.unregisterHudResizeHook(currentPaneId) !== false
+    : unregisterHudResizeHook(currentPaneId);
+  if (!hooksUnregistered && hudPaneIds.length > 0) {
     return { status: 'unchanged', paneId: null, desiredHeight, duplicateCount };
   }
 
@@ -610,10 +617,10 @@ export async function reconcileHudForPromptSubmit(
       duplicateCount: postCreate.duplicatePaneIds.length,
     };
   }
-  const hooksRegistered = ensureHudResizeHook(postCreate.paneId, currentPaneId, desiredHeight, cwd, deps);
+  ensureHudResizeHook(postCreate.paneId, currentPaneId, desiredHeight, cwd, deps);
 
   return {
-    status: hooksRegistered ? (postCreate.duplicatePaneIds.length > 0 || hudPaneIds.length > 1 ? 'replaced_duplicates' : 'recreated') : 'failed',
+    status: postCreate.duplicatePaneIds.length > 0 || hudPaneIds.length > 1 ? 'replaced_duplicates' : 'recreated',
     paneId: postCreate.paneId,
     desiredHeight,
     duplicateCount: postCreate.duplicatePaneIds.length,

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -2,7 +2,7 @@ import { mkdir } from 'node:fs/promises';
 
 import { acquireHudLifecycleLock, releaseHudLifecycleLock, type HudLifecycleLockDeps } from './lifecycle-lock.js';
 import { resolveHudControlPlaneDomain, type ResolvedHudControlPlaneDomain } from '../mcp/state-paths.js';
-import { probeActualTmuxInstanceEvidence, type ActualTmuxInstanceEvidence } from '../scripts/notify-hook/managed-tmux.js';
+import { probeActualTmuxInstanceEvidence, tmuxEvidenceBindsCandidate, type ActualTmuxInstanceEvidence } from '../scripts/notify-hook/managed-tmux.js';
 
 import { readAllState, readHudConfig } from './state.js';
 import { getHudRenderMaxLines } from './render.js';
@@ -221,18 +221,38 @@ function needsHudHeightResize(pane: TmuxPaneSnapshot, desiredHeight: number): bo
   return typeof pane.paneHeight !== 'number' || pane.paneHeight !== desiredHeight;
 }
 
+function tmuxSnapshotBindsCandidate(
+  pane: TmuxPaneSnapshot,
+  candidateSessionIds: readonly string[],
+): boolean {
+  const paneInstanceId = pane.paneInstanceId?.trim() ?? '';
+  const sessionInstanceId = pane.sessionInstanceId?.trim() ?? '';
+  const candidateIds = [...new Set(candidateSessionIds.map((candidate) => candidate.trim()).filter(Boolean))];
+  if (candidateIds.length > 2) return false;
+  const evidence: ActualTmuxInstanceEvidence = {
+    paneTarget: pane.paneId,
+    sessionName: '',
+    paneInstanceId,
+    sessionInstanceId,
+    instanceId: paneInstanceId || sessionInstanceId,
+    source: paneInstanceId ? 'pane' : sessionInstanceId ? 'session' : 'none',
+    paneTagStatus: paneInstanceId ? 'present' : 'absent',
+    sessionTagStatus: sessionInstanceId ? 'present' : 'absent',
+    sessionId: '',
+    windowId: '',
+    contextStable: true,
+  };
+  return tmuxEvidenceBindsCandidate(evidence, candidateIds)
+    || (candidateIds.length === 2
+      && paneInstanceId === sessionInstanceId
+      && candidateIds.includes(paneInstanceId));
+}
+
 function hasVerifiedHudPaneInstanceIdentity(
   pane: TmuxPaneSnapshot,
   equivalentSessionIds: ReadonlySet<string>,
 ): boolean {
-  const paneInstanceId = pane.paneInstanceId?.trim();
-  const sessionInstanceId = pane.sessionInstanceId?.trim();
-  return Boolean(
-    paneInstanceId
-    && sessionInstanceId
-    && equivalentSessionIds.has(paneInstanceId)
-    && equivalentSessionIds.has(sessionInstanceId),
-  );
+  return tmuxSnapshotBindsCandidate(pane, [...equivalentSessionIds]);
 }
 
 function planOwnedHudPaneDedupe(
@@ -267,20 +287,18 @@ function isVerifiedManagedHudOwner(
   currentPaneId: string | undefined,
   evidence: ActualTmuxInstanceEvidence,
 ): boolean {
-  const equivalentSessionIds = new Set(
-    [domain.session?.canonicalId, ...(domain.session?.equivalentIds ?? [])]
-      .map((sessionId) => sessionId?.trim() ?? '')
-      .filter(Boolean),
-  );
+  const equivalentSessionIds = [...new Set([
+    domain.session?.canonicalId,
+    ...(domain.session?.equivalentIds ?? []),
+  ].map((sessionId) => sessionId?.trim() ?? '').filter(Boolean))];
+  const acceptsSameAliasPair = equivalentSessionIds.length === 2
+    && evidence.paneInstanceId === evidence.sessionInstanceId
+    && equivalentSessionIds.includes(evidence.paneInstanceId);
   return Boolean(
     domain.managed
     && currentPaneId
     && evidence.paneTarget === currentPaneId
-    && evidence.contextStable
-    && evidence.paneTagStatus === 'present'
-    && evidence.sessionTagStatus === 'present'
-    && equivalentSessionIds.has(evidence.paneInstanceId)
-    && equivalentSessionIds.has(evidence.sessionInstanceId)
+    && (tmuxEvidenceBindsCandidate(evidence, equivalentSessionIds) || acceptsSameAliasPair)
     && domain.claimant.leaderPaneId === currentPaneId
     && domain.claimant.tmuxSessionName
     && domain.claimant.tmuxSessionName === evidence.sessionName,
@@ -628,15 +646,17 @@ export async function teardownManagedHudPane(
         .map((value) => value?.trim() ?? '')
         .filter(Boolean),
     );
-    const tmuxSessionInstanceId = leader?.sessionInstanceId?.trim() ?? '';
-    const tmuxPaneInstanceId = leader?.paneInstanceId?.trim() ?? '';
-    if (!leader || !equivalentSessionIds.has(tmuxSessionInstanceId) || !equivalentSessionIds.has(tmuxPaneInstanceId)) {
+    if (!leader || !tmuxSnapshotBindsCandidate(leader, [...equivalentSessionIds])) {
       return { status: 'skipped_not_omx_owned_tmux', removedPaneIds: [] };
     }
 
-    const identity = { tmuxSessionInstanceId, tmuxPaneInstanceId };
+    const identity = {
+      tmuxSessionInstanceId: leader.sessionInstanceId?.trim() ?? '',
+      tmuxPaneInstanceId: leader.paneInstanceId?.trim() ?? '',
+    };
     const exactHudPaneIds = panes
       .filter((pane) => pane.paneId !== currentPaneId && isHudWatchPane(pane))
+      .filter((pane) => tmuxSnapshotBindsCandidate(pane, [...equivalentSessionIds]))
       .filter((pane) => [...equivalentSessionIds].some((sessionId) => hudPaneMatchesExactCandidate(
         pane,
         { sessionId, leaderPaneId: currentPaneId },

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'child_process';
+import { randomUUID } from 'crypto';
 import { existsSync } from 'fs';
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_HEIGHT_LINES } from './constants.js';
 import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
@@ -652,6 +653,43 @@ export function createHudWatchPane(
   }
 }
 
+export interface ExactHudPaneKillCandidate {
+  paneId: string;
+  currentCommand: string;
+  startCommand: string;
+  owner: HudPaneOwner;
+  paneInstanceId: string;
+  sessionInstanceId: string;
+  sessionName: string;
+}
+
+function tmuxFormatLiteral(value: string): string {
+  return value.replace(/([\\,}])/g, '\\$1');
+}
+
+/** Atomically kills a pane only while its complete managed-HUD identity still matches. */
+export function killExactHudPane(
+  candidate: ExactHudPaneKillCandidate,
+  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+): boolean {
+  const paneId = candidate.paneId.trim();
+  const paneInstanceId = candidate.paneInstanceId.trim();
+  const sessionInstanceId = candidate.sessionInstanceId.trim();
+  const sessionName = candidate.sessionName.trim();
+  const ownerSessionId = candidate.owner.sessionId?.trim() ?? '';
+  const ownerLeaderPaneId = candidate.owner.leaderPaneId?.trim() ?? '';
+  if (!isTmuxPaneId(paneId) || !paneInstanceId || !sessionInstanceId || !sessionName || !ownerSessionId || !isTmuxPaneId(ownerLeaderPaneId)) return false;
+  if (!isHudWatchPane({ paneId, currentCommand: candidate.currentCommand, startCommand: candidate.startCommand })
+    || readHudPaneOwner({ paneId, currentCommand: candidate.currentCommand, startCommand: candidate.startCommand }).sessionId !== ownerSessionId
+    || readHudPaneOwner({ paneId, currentCommand: candidate.currentCommand, startCommand: candidate.startCommand }).leaderPaneId !== ownerLeaderPaneId) return false;
+  const condition = `#{&&:#{==:#{pane_id},${tmuxFormatLiteral(paneId)}},#{==:#{pane_current_command},${tmuxFormatLiteral(candidate.currentCommand)}},#{==:#{pane_start_command},${tmuxFormatLiteral(candidate.startCommand)}},#{==:#{@omx_pane_instance_id},${tmuxFormatLiteral(paneInstanceId)}},#{==:#{@omx_instance_id},${tmuxFormatLiteral(sessionInstanceId)}},#{==:#{session_name},${tmuxFormatLiteral(sessionName)}}}`;
+  try {
+    execTmuxSync(['if-shell', '-t', paneId, '-F', condition, `kill-pane -t ${paneId}`, '']);
+    return true;
+  } catch {
+    return false;
+  }
+}
 export function killTmuxPane(
   paneId: string,
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
@@ -704,7 +742,8 @@ export function registerHudResizeHook(
   const reconcileCmd = shellEscapeSingle(
     buildHudLayoutReconcileHookCommand(tmuxBin, omxBin, leaderPaneId, options),
   );
-  const ownershipMarker = ` # omx-hud-owned:${context.hookSlot}:${context.layoutHookSlot}`;
+  const generation = randomUUID();
+  const ownershipMarker = ` # omx-hud-owned:${context.hookSlot}:${context.layoutHookSlot}:${generation}`;
   return registerHudHookPair(
     context,
     `run-shell -b ${resizeCmd}${ownershipMarker}`,
@@ -743,23 +782,73 @@ function hookMatches(context: HudResizeHookContext, snapshot: TmuxHookSnapshot, 
   return readTmuxHookSnapshot(context, snapshot.slot, execTmuxSync)?.command === snapshot.command;
 }
 
+/**
+ * Mutate a hook only as the then-branch of one tmux server command. The shell
+ * condition and branch are queued together, so an observed value never grants
+ * a later unconditional set-hook or unset-hook mutation.
+ */
+function compareAndMutateHudHook(
+  context: HudResizeHookContext,
+  slot: string,
+  expectedCommand: string | null,
+  mutation: string,
+  execTmuxSync: TmuxExecSync,
+): boolean {
+  const tmuxBin = resolveTmuxBinaryForPlatform() || 'tmux';
+  const expectedOutput = expectedCommand === null ? '' : `${slot} ${expectedCommand}`;
+  const condition = `test "$(${shellEscapeSingle(tmuxBin)} show-hooks -t ${shellEscapeSingle(context.sessionId)} ${shellEscapeSingle(slot)})" = ${shellEscapeSingle(expectedOutput)}`;
+  try {
+    execTmuxSync(['if-shell', '-t', context.sessionId, condition, mutation, '']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function setHudHookIfMatches(
+  context: HudResizeHookContext,
+  slot: string,
+  expectedCommand: string | null,
+  command: string,
+  execTmuxSync: TmuxExecSync,
+): boolean {
+  return compareAndMutateHudHook(
+    context,
+    slot,
+    expectedCommand,
+    `set-hook -t ${shellEscapeSingle(context.sessionId)} ${shellEscapeSingle(slot)} ${shellEscapeSingle(command)}`,
+    execTmuxSync,
+  );
+}
+
+function unsetHudHookIfMatches(
+  context: HudResizeHookContext,
+  slot: string,
+  expectedCommand: string,
+  execTmuxSync: TmuxExecSync,
+): boolean {
+  return compareAndMutateHudHook(
+    context,
+    slot,
+    expectedCommand,
+    `set-hook -u -t ${shellEscapeSingle(context.sessionId)} ${shellEscapeSingle(slot)}`,
+    execTmuxSync,
+  );
+}
+
 function restoreHudHookPair(
   context: HudResizeHookContext,
   resize: TmuxHookSnapshot,
   layout: TmuxHookSnapshot,
-  expectedResizeCurrent: string | null,
-  expectedLayoutCurrent: string | null,
+  expectedResizeCurrent: string,
+  expectedLayoutCurrent: string,
   execTmuxSync: TmuxExecSync,
 ): boolean {
-  const restore = (snapshot: TmuxHookSnapshot, expectedCurrent: string | null): boolean => {
-    if (!hookMatches(context, { slot: snapshot.slot, command: expectedCurrent }, execTmuxSync)) return false;
-    try {
-      if (snapshot.command === null) execTmuxSync(['set-hook', '-u', '-t', context.sessionId, snapshot.slot]);
-      else execTmuxSync(['set-hook', '-t', context.sessionId, snapshot.slot, snapshot.command]);
-    } catch {
-      return false;
-    }
-    return hookMatches(context, snapshot, execTmuxSync);
+  const restore = (snapshot: TmuxHookSnapshot, expectedCurrent: string): boolean => {
+    const mutated = snapshot.command === null
+      ? unsetHudHookIfMatches(context, snapshot.slot, expectedCurrent, execTmuxSync)
+      : setHudHookIfMatches(context, snapshot.slot, expectedCurrent, snapshot.command, execTmuxSync);
+    return mutated && hookMatches(context, snapshot, execTmuxSync);
   };
   const resizeRestored = restore(resize, expectedResizeCurrent);
   const layoutRestored = restore(layout, expectedLayoutCurrent);
@@ -769,12 +858,14 @@ function restoreHudHookPair(
 function registerHudHookPair(context: HudResizeHookContext, resizeCommand: string, layoutCommand: string, execTmuxSync: TmuxExecSync): boolean {
   const resize = readTmuxHookSnapshot(context, context.hookSlot, execTmuxSync);
   const layout = readTmuxHookSnapshot(context, context.layoutHookSlot, execTmuxSync);
-  if (!resize || !layout || (resize.command !== null && resize.command !== resizeCommand) || (layout.command !== null && layout.command !== layoutCommand)) return false;
+  // Each registration owns a new immutable generation. Existing hooks, even
+  // prior OMX generations, remain owned by their transaction and are retained.
+  if (!resize || !layout || resize.command !== null || layout.command !== null) return false;
   try {
-    if (resize.command === null) execTmuxSync(['set-hook', '-t', context.sessionId, resize.slot, resizeCommand]);
-    if (!hookMatches(context, { slot: resize.slot, command: resizeCommand }, execTmuxSync)) throw new Error('resize hook verification failed');
-    if (layout.command === null) execTmuxSync(['set-hook', '-t', context.sessionId, layout.slot, layoutCommand]);
-    if (!hookMatches(context, { slot: layout.slot, command: layoutCommand }, execTmuxSync)) throw new Error('layout hook verification failed');
+    if (!setHudHookIfMatches(context, resize.slot, null, resizeCommand, execTmuxSync)
+      || !hookMatches(context, { slot: resize.slot, command: resizeCommand }, execTmuxSync)) throw new Error('resize hook verification failed');
+    if (!setHudHookIfMatches(context, layout.slot, null, layoutCommand, execTmuxSync)
+      || !hookMatches(context, { slot: layout.slot, command: layoutCommand }, execTmuxSync)) throw new Error('layout hook verification failed');
     return true;
   } catch {
     restoreHudHookPair(context, resize, layout, resizeCommand, layoutCommand, execTmuxSync);
@@ -786,24 +877,18 @@ function unregisterHudHookPair(context: HudResizeHookContext, execTmuxSync: Tmux
   const resize = readTmuxHookSnapshot(context, context.hookSlot, execTmuxSync);
   const layout = readTmuxHookSnapshot(context, context.layoutHookSlot, execTmuxSync);
   if (!resize || !layout) return false;
-  const ownershipMarker = `# omx-hud-owned:${context.hookSlot}:${context.layoutHookSlot}`;
+  const ownershipMarker = `# omx-hud-owned:${context.hookSlot}:${context.layoutHookSlot}:`;
   const removeOwnedOrPreserveForeign = (snapshot: TmuxHookSnapshot): boolean => {
-    const current = readTmuxHookSnapshot(context, snapshot.slot, execTmuxSync);
-    if (!current) return false;
-    // A concurrent removal or replacement has already made this transaction's
-    // owned hook harmless; preserve it and treat this slot as safely handled.
-    if (current.command === null || !current.command.endsWith(ownershipMarker)) return true;
-    if (snapshot.command === null || current.command !== snapshot.command) return false;
-    try {
-      execTmuxSync(['set-hook', '-u', '-t', context.sessionId, snapshot.slot]);
-    } catch {
-      return false;
-    }
+    // The captured generation is immutable mutation authority. A replacement
+    // between this observation and the queued branch fails the exact compare
+    // and is deliberately preserved.
+    if (snapshot.command === null || !snapshot.command.includes(ownershipMarker)) return true;
+    if (!unsetHudHookIfMatches(context, snapshot.slot, snapshot.command, execTmuxSync)) return false;
     const after = readTmuxHookSnapshot(context, snapshot.slot, execTmuxSync);
-    return after === null || after.command === null || !after.command.endsWith(ownershipMarker);
+    return after !== null && (after.command === null || after.command !== snapshot.command);
   };
   // Attempt both slots even when one cannot be safely handled. Never restore a
-  // removed owned hook: that could overwrite a concurrent replacement.
+  // removed generation: that could overwrite a concurrent replacement.
   const resizeHandled = removeOwnedOrPreserveForeign(resize);
   const layoutHandled = removeOwnedOrPreserveForeign(layout);
   return resizeHandled && layoutHandled;

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -661,13 +661,25 @@ export function createHudWatchPane(
     '#{pane_id}',
     hudCmd,
   ];
+  let paneId: string | null = null;
   try {
-    const paneId = parsePaneIdFromTmuxOutput(execTmuxSync(args));
-    if (paneId && options.instanceId?.trim()) {
-      execTmuxSync(['set-option', '-p', '-t', paneId, '@omx_pane_instance_id', options.instanceId.trim()]);
+    paneId = parsePaneIdFromTmuxOutput(execTmuxSync(args));
+    if (!paneId) return null;
+    const instanceId = options.instanceId?.trim();
+    if (instanceId) {
+      execTmuxSync(['set-option', '-p', '-t', paneId, '@omx_pane_instance_id', instanceId]);
+      const taggedInstanceId = execTmuxSync(['show-option', '-qv', '-p', '-t', paneId, '@omx_pane_instance_id']).trim();
+      if (taggedInstanceId !== instanceId) throw new Error('HUD pane instance tag was not persisted');
     }
     return paneId;
   } catch {
+    if (paneId) {
+      try {
+        execTmuxSync(['kill-pane', '-t', paneId]);
+      } catch {
+        // The split succeeded but its ownership tag could not be verified.
+      }
+    }
     return null;
   }
 }

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -11,6 +11,7 @@ export interface TmuxPaneSnapshot {
   startCommand: string;
   paneInstanceId?: string;
   sessionInstanceId?: string;
+  sessionName?: string;
   currentPath?: string;
   paneLeft?: number;
   paneTop?: number;
@@ -116,7 +117,11 @@ export function parseTmuxPaneSnapshot(output: string): TmuxPaneSnapshot[] {
       const hasInstanceColumns = hasGeometry && payloadParts.length >= 4;
       const paneInstanceId = hasInstanceColumns ? (payloadParts[0] ?? '').trim() : '';
       const sessionInstanceId = hasInstanceColumns ? (payloadParts[1] ?? '').trim() : '';
-      const commandPayloadParts = hasInstanceColumns ? payloadParts.slice(2) : payloadParts;
+      const hasSessionNameColumn = hasInstanceColumns && payloadParts.length >= 5;
+      const sessionName = hasSessionNameColumn ? (payloadParts[2] ?? '').trim() : '';
+      const commandPayloadParts = hasInstanceColumns
+        ? payloadParts.slice(hasSessionNameColumn ? 3 : 2)
+        : payloadParts;
       const hasCurrentPathColumn = commandPayloadParts.length >= 2;
       const currentPath = hasCurrentPathColumn ? (commandPayloadParts.at(-1) ?? '') : '';
       const startCommandParts = hasCurrentPathColumn ? commandPayloadParts.slice(0, -1) : commandPayloadParts;
@@ -127,6 +132,7 @@ export function parseTmuxPaneSnapshot(output: string): TmuxPaneSnapshot[] {
         startCommand: startCommandParts.join('\t').trim(),
         ...(paneInstanceId ? { paneInstanceId } : {}),
         ...(sessionInstanceId ? { sessionInstanceId } : {}),
+        ...(sessionName ? { sessionName } : {}),
         ...(trimmedCurrentPath ? { currentPath: trimmedCurrentPath } : {}),
         ...(hasGeometry
           ? {
@@ -285,39 +291,36 @@ export function reapDeadHudPanes(
   panes: TmuxPaneSnapshot[],
   opts: {
     isLivePane?: (paneId: string) => boolean;
-    killPane?: (paneId: string) => boolean;
+    killExactPane?: (candidate: ExactHudPaneKillCandidate) => boolean;
   } = {},
 ): { reaped: string[]; preserved: string[] } {
   const livePaneIds = new Set(panes.map((pane) => pane.paneId));
   const isLivePane = opts.isLivePane ?? ((paneId: string) => livePaneIds.has(paneId));
-  const killPane = opts.killPane ?? ((paneId: string) => killTmuxPane(paneId));
   const reaped: string[] = [];
   const preserved: string[] = [];
 
+  const candidateFor = (pane: TmuxPaneSnapshot): ExactHudPaneKillCandidate | null => {
+    const owner = readHudPaneOwner(pane);
+    if (!pane.paneInstanceId || !pane.sessionInstanceId || !pane.sessionName || !owner.sessionId || !owner.leaderPaneId) return null;
+    return {
+      paneId: pane.paneId,
+      currentCommand: pane.currentCommand,
+      startCommand: pane.startCommand,
+      owner,
+      paneInstanceId: pane.paneInstanceId,
+      sessionInstanceId: pane.sessionInstanceId,
+      sessionName: pane.sessionName,
+    };
+  };
+
   for (const pane of panes) {
     if (!isHudWatchPane(pane)) continue;
-
-    if (shouldReapDeletedCwdHudPane(pane, isLivePane) && killPane(pane.paneId)) {
-      reaped.push(pane.paneId);
-      continue;
-    }
-
     const leaderPaneId = readHudPaneOwner(pane).leaderPaneId;
-    if (!leaderPaneId) {
-      preserved.push(pane.paneId);
-      continue;
-    }
-
-    if (isLivePane(leaderPaneId)) {
-      preserved.push(pane.paneId);
-      continue;
-    }
-
-    if (killPane(pane.paneId)) {
-      reaped.push(pane.paneId);
-    } else {
-      preserved.push(pane.paneId);
-    }
+    const shouldReap = shouldReapDeletedCwdHudPane(pane, isLivePane)
+      || Boolean(leaderPaneId && !isLivePane(leaderPaneId));
+    const candidate = shouldReap ? candidateFor(pane) : null;
+    if (candidate && opts.killExactPane?.(candidate)) reaped.push(pane.paneId);
+    else preserved.push(pane.paneId);
   }
 
   return { reaped, preserved };
@@ -554,6 +557,7 @@ export function listCurrentWindowPanes(
           '#{window_height}',
           '#{@omx_pane_instance_id}',
           '#{@omx_instance_id}',
+          '#{session_name}',
           '#{pane_start_command}',
           '#{pane_current_path}',
         ].join(TMUX_PANE_FIELD_SEPARATOR),
@@ -683,9 +687,15 @@ export function killExactHudPane(
     || readHudPaneOwner({ paneId, currentCommand: candidate.currentCommand, startCommand: candidate.startCommand }).sessionId !== ownerSessionId
     || readHudPaneOwner({ paneId, currentCommand: candidate.currentCommand, startCommand: candidate.startCommand }).leaderPaneId !== ownerLeaderPaneId) return false;
   const condition = `#{&&:#{==:#{pane_id},${tmuxFormatLiteral(paneId)}},#{==:#{pane_current_command},${tmuxFormatLiteral(candidate.currentCommand)}},#{==:#{pane_start_command},${tmuxFormatLiteral(candidate.startCommand)}},#{==:#{@omx_pane_instance_id},${tmuxFormatLiteral(paneInstanceId)}},#{==:#{@omx_instance_id},${tmuxFormatLiteral(sessionInstanceId)}},#{==:#{session_name},${tmuxFormatLiteral(sessionName)}}}`;
+  const appliedReceipt = '__omx_hud_pane_kill_applied__';
+  const rejectedReceipt = '__omx_hud_pane_kill_rejected__';
   try {
-    execTmuxSync(['if-shell', '-t', paneId, '-F', condition, `kill-pane -t ${paneId}`, '']);
-    return true;
+    const output = execTmuxSync([
+      'if-shell', '-t', paneId, '-F', condition,
+      `kill-pane -t ${paneId} \\; display-message -p ${appliedReceipt}`,
+      `display-message -p ${rejectedReceipt}`,
+    ]).trim();
+    return output === appliedReceipt;
   } catch {
     return false;
   }
@@ -731,165 +741,54 @@ export function registerHudResizeHook(
   const execTmuxSync = typeof optionsOrExecTmuxSync === 'function'
     ? optionsOrExecTmuxSync
     : (maybeExecTmuxSync ?? defaultExecTmuxSync);
-  if (!hudPaneId.startsWith('%')) return false;
+  if (!isTmuxPaneId(hudPaneId)) return false;
   const context = readHudResizeHookContext(leaderPaneId, execTmuxSync);
-  if (!context) return false;
-  const tmuxBin = resolveTmuxBinaryForPlatform() || 'tmux';
-  const height = String(Math.max(1, Math.floor(heightLines)));
-  const resizeCmd = shellEscapeSingle(buildHudResizeHookCommand(tmuxBin, hudPaneId, height, options.env?.TMUX));
+  if (!context || !leaderPaneId?.startsWith('%')) return false;
   const omxBin = resolveOmxCliEntryPath({ cwd: options.cwd, env: options.env });
-  if (!omxBin || !leaderPaneId?.startsWith('%')) return false;
-  const reconcileCmd = shellEscapeSingle(
-    buildHudLayoutReconcileHookCommand(tmuxBin, omxBin, leaderPaneId, options),
-  );
-  const generation = randomUUID();
-  const ownershipMarker = ` # omx-hud-owned:${context.hookSlot}:${context.layoutHookSlot}:${generation}`;
-  return registerHudHookPair(
-    context,
-    `run-shell -b ${resizeCmd}${ownershipMarker}`,
-    `run-shell -b ${reconcileCmd}${ownershipMarker}`,
-    execTmuxSync,
-  );
+  if (!omxBin) return false;
+  try {
+    const [hudBirth, sessionBirth, sessionName] = execTmuxSync([
+      'display-message', '-p', '-t', hudPaneId,
+      '#{@omx_pane_instance_id}\t#{@omx_instance_id}\t#{session_name}',
+    ]).trim().split('\t').map((value) => value.trim());
+    if (!hudBirth || !sessionBirth || !sessionName) return false;
+    const generation = randomUUID();
+    const activeOption = `@omx_hud_hook_active_${generation.replace(/-/g, '_')}`;
+    const condition = `#{&&:#{==:#{pane_id},${tmuxFormatLiteral(hudPaneId)}},#{==:#{@omx_pane_instance_id},${tmuxFormatLiteral(hudBirth)}},#{==:#{@omx_instance_id},${tmuxFormatLiteral(sessionBirth)}},#{==:#{session_name},${tmuxFormatLiteral(sessionName)}},#{==:#{${activeOption}},1}}`;
+    const tmuxBin = resolveTmuxBinaryForPlatform() || 'tmux';
+    const height = String(Math.max(1, Math.floor(heightLines)));
+    const resize = buildHudResizeHookCommand(tmuxBin, hudPaneId, height, options.env?.TMUX);
+    const reconcile = buildHudLayoutReconcileHookCommand(tmuxBin, omxBin, leaderPaneId, options);
+    const wrap = (command: string) => `if-shell -t ${hudPaneId} -F ${shellEscapeSingle(condition)} ${shellEscapeSingle(`run-shell -b ${command}`)} '' # omx-hud-owned:${generation}`;
+    execTmuxSync(['set-option', '-t', context.sessionId, activeOption, '1']);
+    // tmux serializes -a registration and assigns a fresh numeric slot. Existing
+    // foreign/older hooks are never observed as mutation authority or replaced.
+    execTmuxSync(['set-hook', '-a', '-t', context.sessionId, 'client-resized', wrap(resize)]);
+    execTmuxSync(['set-hook', '-a', '-t', context.sessionId, 'window-layout-changed', wrap(reconcile)]);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
+/** Marks all discovered OMX generations inert. Live hooks and receipts are retained. */
 export function unregisterHudResizeHook(
   leaderPaneId: string | undefined,
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
 ): boolean {
   const context = readHudResizeHookContext(leaderPaneId, execTmuxSync);
   if (!context) return false;
-  return unregisterHudHookPair(context, execTmuxSync);
-}
-
-interface TmuxHookSnapshot {
-  slot: string;
-  command: string | null;
-}
-
-function readTmuxHookSnapshot(context: HudResizeHookContext, slot: string, execTmuxSync: TmuxExecSync): TmuxHookSnapshot | null {
   try {
-    const output = execTmuxSync(['show-hooks', '-t', context.sessionId, slot]).trim();
-    if (!output) return { slot, command: null };
-    const escapedSlot = slot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const match = output.split('\n').map((line) => line.trim()).map((line) => line.match(new RegExp(`^${escapedSlot}\\s+(.+)$`))).find(Boolean);
-    return match?.[1] ? { slot, command: match[1] } : null;
-  } catch {
-    return null;
-  }
-}
-
-function hookMatches(context: HudResizeHookContext, snapshot: TmuxHookSnapshot, execTmuxSync: TmuxExecSync): boolean {
-  return readTmuxHookSnapshot(context, snapshot.slot, execTmuxSync)?.command === snapshot.command;
-}
-
-/**
- * Mutate a hook only as the then-branch of one tmux server command. The shell
- * condition and branch are queued together, so an observed value never grants
- * a later unconditional set-hook or unset-hook mutation.
- */
-function compareAndMutateHudHook(
-  context: HudResizeHookContext,
-  slot: string,
-  expectedCommand: string | null,
-  mutation: string,
-  execTmuxSync: TmuxExecSync,
-): boolean {
-  const tmuxBin = resolveTmuxBinaryForPlatform() || 'tmux';
-  const expectedOutput = expectedCommand === null ? '' : `${slot} ${expectedCommand}`;
-  const condition = `test "$(${shellEscapeSingle(tmuxBin)} show-hooks -t ${shellEscapeSingle(context.sessionId)} ${shellEscapeSingle(slot)})" = ${shellEscapeSingle(expectedOutput)}`;
-  try {
-    execTmuxSync(['if-shell', '-t', context.sessionId, condition, mutation, '']);
+    const hooks = [
+      execTmuxSync(['show-hooks', '-t', context.sessionId, 'client-resized']),
+      execTmuxSync(['show-hooks', '-t', context.sessionId, 'window-layout-changed']),
+    ].join('\n');
+    const generations = [...hooks.matchAll(/# omx-hud-owned:([0-9a-f-]{36})/g)].map((match) => match[1]!);
+    for (const generation of new Set(generations)) {
+      execTmuxSync(['set-option', '-t', context.sessionId, `@omx_hud_hook_active_${generation.replace(/-/g, '_')}`, '0']);
+    }
     return true;
   } catch {
     return false;
   }
-}
-
-function setHudHookIfMatches(
-  context: HudResizeHookContext,
-  slot: string,
-  expectedCommand: string | null,
-  command: string,
-  execTmuxSync: TmuxExecSync,
-): boolean {
-  return compareAndMutateHudHook(
-    context,
-    slot,
-    expectedCommand,
-    `set-hook -t ${shellEscapeSingle(context.sessionId)} ${shellEscapeSingle(slot)} ${shellEscapeSingle(command)}`,
-    execTmuxSync,
-  );
-}
-
-function unsetHudHookIfMatches(
-  context: HudResizeHookContext,
-  slot: string,
-  expectedCommand: string,
-  execTmuxSync: TmuxExecSync,
-): boolean {
-  return compareAndMutateHudHook(
-    context,
-    slot,
-    expectedCommand,
-    `set-hook -u -t ${shellEscapeSingle(context.sessionId)} ${shellEscapeSingle(slot)}`,
-    execTmuxSync,
-  );
-}
-
-function restoreHudHookPair(
-  context: HudResizeHookContext,
-  resize: TmuxHookSnapshot,
-  layout: TmuxHookSnapshot,
-  expectedResizeCurrent: string,
-  expectedLayoutCurrent: string,
-  execTmuxSync: TmuxExecSync,
-): boolean {
-  const restore = (snapshot: TmuxHookSnapshot, expectedCurrent: string): boolean => {
-    const mutated = snapshot.command === null
-      ? unsetHudHookIfMatches(context, snapshot.slot, expectedCurrent, execTmuxSync)
-      : setHudHookIfMatches(context, snapshot.slot, expectedCurrent, snapshot.command, execTmuxSync);
-    return mutated && hookMatches(context, snapshot, execTmuxSync);
-  };
-  const resizeRestored = restore(resize, expectedResizeCurrent);
-  const layoutRestored = restore(layout, expectedLayoutCurrent);
-  return resizeRestored && layoutRestored;
-}
-
-function registerHudHookPair(context: HudResizeHookContext, resizeCommand: string, layoutCommand: string, execTmuxSync: TmuxExecSync): boolean {
-  const resize = readTmuxHookSnapshot(context, context.hookSlot, execTmuxSync);
-  const layout = readTmuxHookSnapshot(context, context.layoutHookSlot, execTmuxSync);
-  // Each registration owns a new immutable generation. Existing hooks, even
-  // prior OMX generations, remain owned by their transaction and are retained.
-  if (!resize || !layout || resize.command !== null || layout.command !== null) return false;
-  try {
-    if (!setHudHookIfMatches(context, resize.slot, null, resizeCommand, execTmuxSync)
-      || !hookMatches(context, { slot: resize.slot, command: resizeCommand }, execTmuxSync)) throw new Error('resize hook verification failed');
-    if (!setHudHookIfMatches(context, layout.slot, null, layoutCommand, execTmuxSync)
-      || !hookMatches(context, { slot: layout.slot, command: layoutCommand }, execTmuxSync)) throw new Error('layout hook verification failed');
-    return true;
-  } catch {
-    restoreHudHookPair(context, resize, layout, resizeCommand, layoutCommand, execTmuxSync);
-    return false;
-  }
-}
-
-function unregisterHudHookPair(context: HudResizeHookContext, execTmuxSync: TmuxExecSync): boolean {
-  const resize = readTmuxHookSnapshot(context, context.hookSlot, execTmuxSync);
-  const layout = readTmuxHookSnapshot(context, context.layoutHookSlot, execTmuxSync);
-  if (!resize || !layout) return false;
-  const ownershipMarker = `# omx-hud-owned:${context.hookSlot}:${context.layoutHookSlot}:`;
-  const removeOwnedOrPreserveForeign = (snapshot: TmuxHookSnapshot): boolean => {
-    // The captured generation is immutable mutation authority. A replacement
-    // between this observation and the queued branch fails the exact compare
-    // and is deliberately preserved.
-    if (snapshot.command === null || !snapshot.command.includes(ownershipMarker)) return true;
-    if (!unsetHudHookIfMatches(context, snapshot.slot, snapshot.command, execTmuxSync)) return false;
-    const after = readTmuxHookSnapshot(context, snapshot.slot, execTmuxSync);
-    return after !== null && (after.command === null || after.command !== snapshot.command);
-  };
-  // Attempt both slots even when one cannot be safely handled. Never restore a
-  // removed generation: that could overwrite a concurrent replacement.
-  const resizeHandled = removeOwnedOrPreserveForeign(resize);
-  const layoutHandled = removeOwnedOrPreserveForeign(layout);
-  return resizeHandled && layoutHandled;
 }

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -741,6 +741,28 @@ function hudHookGenerationOption(leaderPaneId: string, leaderBirth: string): str
   return `@omx_hud_hook_generation_${key}`;
 }
 
+function hudHookReceiptOption(leaderPaneId: string, leaderBirth: string): string {
+  return `${hudHookGenerationOption(leaderPaneId, leaderBirth)}_receipt`;
+}
+
+function isHudHookGeneration(value: string): boolean {
+  return /^[0-9a-f-]{36}$/.test(value);
+}
+
+function hasVerifiedHudHookPair(
+  context: HudResizeHookContext,
+  generation: string,
+  execTmuxSync: TmuxExecSync,
+): boolean {
+  const marker = `omx-hud-owned:${generation}`;
+  for (const event of ['client-resized', 'window-layout-changed']) {
+    const hooks = execTmuxSync(['show-hooks', '-t', context.sessionId, event]);
+    if (!hooks.split('\n').some((line) => line.includes(marker))) return false;
+  }
+  return true;
+}
+
+/** Registers an inert pair, verifies its append receipts, then CAS-publishes it. */
 export function registerHudResizeHook(
   hudPaneId: string,
   leaderPaneId: string | undefined,
@@ -765,28 +787,51 @@ export function registerHudResizeHook(
     ]).trim().split('\t').map((value) => value.trim());
     const leaderBirth = execTmuxSync(['display-message', '-p', '-t', leaderPaneId, '#{@omx_pane_instance_id}']).trim();
     if (!hudBirth || !sessionBirth || !sessionName || !windowId || !currentCommand || !startCommand || !leaderBirth) return false;
+    const generationOption = hudHookGenerationOption(leaderPaneId, leaderBirth);
+    const priorGeneration = execTmuxSync(['show-option', '-qv', '-t', context.sessionId, generationOption]).trim();
+    if (priorGeneration && !isHudHookGeneration(priorGeneration)) return false;
+    if (priorGeneration) {
+      const priorActive = execTmuxSync(['show-option', '-qv', '-t', context.sessionId, `@omx_hud_hook_active_${priorGeneration.replace(/-/g, '_')}`]).trim();
+      if (priorActive === '1' && hasVerifiedHudHookPair(context, priorGeneration, execTmuxSync)) return true;
+    }
+
     const generation = randomUUID();
     activeOption = `@omx_hud_hook_active_${generation.replace(/-/g, '_')}`;
-    const generationOption = hudHookGenerationOption(leaderPaneId, leaderBirth);
+    const receiptOption = hudHookReceiptOption(leaderPaneId, leaderBirth);
+    const receipt = randomUUID();
     const condition = `#{&&:#{==:#{pane_id},${tmuxFormatLiteral(hudPaneId)}},#{==:#{pane_current_command},${tmuxFormatLiteral(currentCommand)}},#{==:#{pane_start_command},${tmuxFormatLiteral(startCommand)}},#{==:#{@omx_pane_instance_id},${tmuxFormatLiteral(hudBirth)}},#{==:#{@omx_instance_id},${tmuxFormatLiteral(sessionBirth)}},#{==:#{session_name},${tmuxFormatLiteral(sessionName)}},#{==:#{window_id},${tmuxFormatLiteral(windowId)}},#{==:#{${activeOption}},1}}`;
     const tmuxBin = resolveTmuxBinaryForPlatform() || 'tmux';
     const height = String(Math.max(1, Math.floor(heightLines)));
     const resize = buildHudResizeHookCommand(tmuxBin, hudPaneId, height, condition, options.env?.TMUX);
     const reconcile = buildHudLayoutReconcileHookCommand(tmuxBin, omxBin, leaderPaneId, options);
     const wrap = (command: string) => `if-shell -t ${hudPaneId} -F ${shellEscapeSingle(condition)} ${shellEscapeSingle(`run-shell -b ${command}`)} '' # omx-hud-owned:${generation}`;
-    execTmuxSync(['set-option', '-t', context.sessionId, activeOption, '1']);
-    execTmuxSync(['set-option', '-t', context.sessionId, generationOption, generation]);
-    // tmux serializes -a registration and assigns a fresh numeric slot. Existing
-    // foreign/older hooks are never observed as mutation authority or replaced.
+
+    // A partially appended pair remains inert forever unless both append receipts are observed.
+    execTmuxSync(['set-option', '-t', context.sessionId, activeOption, '0']);
     execTmuxSync(['set-hook', '-a', '-t', context.sessionId, 'client-resized', wrap(resize)]);
     execTmuxSync(['set-hook', '-a', '-t', context.sessionId, 'window-layout-changed', wrap(reconcile)]);
-    return true;
+    if (!hasVerifiedHudHookPair(context, generation, execTmuxSync)) return false;
+
+    const publishCondition = `#{==:#{${generationOption}},${tmuxFormatLiteral(priorGeneration)}}`;
+    const publish = [
+      `set-option -t ${context.sessionId} ${generationOption} ${generation}`,
+      `set-option -t ${context.sessionId} ${activeOption} 1`,
+      ...(priorGeneration ? [`set-option -t ${context.sessionId} @omx_hud_hook_active_${priorGeneration.replace(/-/g, '_')} 0`] : []),
+      `set-option -t ${context.sessionId} ${receiptOption} ${receipt}`,
+    ].join(' \\; ');
+    execTmuxSync(['if-shell', '-t', context.sessionId, '-F', publishCondition, publish, '']);
+    const applied = execTmuxSync(['show-option', '-qv', '-t', context.sessionId, receiptOption]).trim();
+    const published = execTmuxSync(['show-option', '-qv', '-t', context.sessionId, generationOption]).trim();
+    const active = execTmuxSync(['show-option', '-qv', '-t', context.sessionId, activeOption]).trim();
+    if (applied === receipt && published === generation && active === '1') return true;
+    execTmuxSync(['set-option', '-t', context.sessionId, activeOption, '0']);
+    return false;
   } catch {
     if (activeOption) {
       try {
         execTmuxSync(['set-option', '-t', context.sessionId, activeOption, '0']);
       } catch {
-        // A failed inert write remains recovery uncertainty.
+        // Failure to make an incomplete generation inert is retained as a failed registration.
       }
     }
     return false;
@@ -803,10 +848,15 @@ export function unregisterHudResizeHook(
   try {
     const leaderBirth = execTmuxSync(['display-message', '-p', '-t', leaderPaneId, '#{@omx_pane_instance_id}']).trim();
     if (!leaderBirth) return false;
-    const generation = execTmuxSync(['show-option', '-qv', '-t', context.sessionId, hudHookGenerationOption(leaderPaneId, leaderBirth)]).trim();
-    if (!/^[0-9a-f-]{36}$/.test(generation)) return false;
-    execTmuxSync(['set-option', '-t', context.sessionId, `@omx_hud_hook_active_${generation.replace(/-/g, '_')}`, '0']);
-    return true;
+    const generationOption = hudHookGenerationOption(leaderPaneId, leaderBirth);
+    const generation = execTmuxSync(['show-option', '-qv', '-t', context.sessionId, generationOption]).trim();
+    if (!isHudHookGeneration(generation)) return false;
+    const receiptOption = hudHookReceiptOption(leaderPaneId, leaderBirth);
+    const receipt = randomUUID();
+    const condition = `#{==:#{${generationOption}},${generation}}`;
+    const deactivate = `set-option -t ${context.sessionId} @omx_hud_hook_active_${generation.replace(/-/g, '_')} 0 \\; set-option -t ${context.sessionId} ${receiptOption} ${receipt}`;
+    execTmuxSync(['if-shell', '-t', context.sessionId, '-F', condition, deactivate, '']);
+    return execTmuxSync(['show-option', '-qv', '-t', context.sessionId, receiptOption]).trim() === receipt;
   } catch {
     return false;
   }

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -648,12 +648,10 @@ export function createHudWatchPane(
   try {
     paneId = parsePaneIdFromTmuxOutput(execTmuxSync(args));
     if (!paneId) return null;
-    const instanceId = options.instanceId?.trim();
-    if (instanceId) {
-      execTmuxSync(['set-option', '-p', '-t', paneId, '@omx_pane_instance_id', instanceId]);
-      const taggedInstanceId = execTmuxSync(['show-option', '-qv', '-p', '-t', paneId, '@omx_pane_instance_id']).trim();
-      if (taggedInstanceId !== instanceId) throw new Error('HUD pane instance tag was not persisted');
-    }
+    const instanceId = options.instanceId?.trim() || randomUUID();
+    execTmuxSync(['set-option', '-p', '-t', paneId, '@omx_pane_instance_id', instanceId]);
+    const taggedInstanceId = execTmuxSync(['show-option', '-qv', '-p', '-t', paneId, '@omx_pane_instance_id']).trim();
+    if (taggedInstanceId !== instanceId) throw new Error('HUD pane instance tag was not persisted');
     return paneId;
   } catch {
     // The split may have succeeded but its ownership tag could not be verified.

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -674,7 +674,7 @@ export interface ExactHudPaneKillCandidate {
 }
 
 function tmuxFormatLiteral(value: string): string {
-  return value.replace(/([\\,}])/g, '\\$1');
+  return value.replace(/[#{},:]/g, (character) => `#${character}`);
 }
 
 /** Atomically kills a pane only while its complete managed-HUD identity still matches. */

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -435,14 +435,20 @@ function buildHudResizeHookCommand(
   tmuxBin: string,
   hudPaneId: string,
   height: string,
+  condition: string,
   tmuxEnv?: string,
 ): string {
-  const resize = buildNestedTmuxCommand(tmuxBin, ['resize-pane', '-t', hudPaneId, '-y', height], tmuxEnv);
-  // Hook cleanup is lifecycle-owned. A delayed callback cannot prove slot ownership
-  // after it was queued, so it must never unset potentially replaced hooks.
+  const resize = buildNestedTmuxCommand(
+    tmuxBin,
+    ['if-shell', '-t', hudPaneId, '-F', condition, `resize-pane -t ${hudPaneId} -y ${height}`, ''],
+    tmuxEnv,
+  );
+  // Every resize revalidates tmux's current immutable identity. The delayed
+  // second resize must not inherit authorization from the original callback.
   const resizeBestEffort = `${resize} >/dev/null 2>&1 || true`;
   return `${resizeBestEffort}; sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; ${resizeBestEffort}`;
 }
+
 
 function buildHudLayoutReconcileHookCommand(
   tmuxBin: string,
@@ -730,6 +736,11 @@ export function resizeTmuxPane(
   }
 }
 
+function hudHookGenerationOption(leaderPaneId: string, leaderBirth: string): string {
+  const key = `${leaderPaneId}_${leaderBirth}`.replace(/[^a-zA-Z0-9_]/g, '_');
+  return `@omx_hud_hook_generation_${key}`;
+}
+
 export function registerHudResizeHook(
   hudPaneId: string,
   leaderPaneId: string | undefined,
@@ -746,47 +757,55 @@ export function registerHudResizeHook(
   if (!context || !leaderPaneId?.startsWith('%')) return false;
   const omxBin = resolveOmxCliEntryPath({ cwd: options.cwd, env: options.env });
   if (!omxBin) return false;
+  let activeOption: string | null = null;
   try {
-    const [hudBirth, sessionBirth, sessionName] = execTmuxSync([
+    const [hudBirth, sessionBirth, sessionName, windowId, currentCommand, startCommand] = execTmuxSync([
       'display-message', '-p', '-t', hudPaneId,
-      '#{@omx_pane_instance_id}\t#{@omx_instance_id}\t#{session_name}',
+      '#{@omx_pane_instance_id}\t#{@omx_instance_id}\t#{session_name}\t#{window_id}\t#{pane_current_command}\t#{pane_start_command}',
     ]).trim().split('\t').map((value) => value.trim());
-    if (!hudBirth || !sessionBirth || !sessionName) return false;
+    const leaderBirth = execTmuxSync(['display-message', '-p', '-t', leaderPaneId, '#{@omx_pane_instance_id}']).trim();
+    if (!hudBirth || !sessionBirth || !sessionName || !windowId || !currentCommand || !startCommand || !leaderBirth) return false;
     const generation = randomUUID();
-    const activeOption = `@omx_hud_hook_active_${generation.replace(/-/g, '_')}`;
-    const condition = `#{&&:#{==:#{pane_id},${tmuxFormatLiteral(hudPaneId)}},#{==:#{@omx_pane_instance_id},${tmuxFormatLiteral(hudBirth)}},#{==:#{@omx_instance_id},${tmuxFormatLiteral(sessionBirth)}},#{==:#{session_name},${tmuxFormatLiteral(sessionName)}},#{==:#{${activeOption}},1}}`;
+    activeOption = `@omx_hud_hook_active_${generation.replace(/-/g, '_')}`;
+    const generationOption = hudHookGenerationOption(leaderPaneId, leaderBirth);
+    const condition = `#{&&:#{==:#{pane_id},${tmuxFormatLiteral(hudPaneId)}},#{==:#{pane_current_command},${tmuxFormatLiteral(currentCommand)}},#{==:#{pane_start_command},${tmuxFormatLiteral(startCommand)}},#{==:#{@omx_pane_instance_id},${tmuxFormatLiteral(hudBirth)}},#{==:#{@omx_instance_id},${tmuxFormatLiteral(sessionBirth)}},#{==:#{session_name},${tmuxFormatLiteral(sessionName)}},#{==:#{window_id},${tmuxFormatLiteral(windowId)}},#{==:#{${activeOption}},1}}`;
     const tmuxBin = resolveTmuxBinaryForPlatform() || 'tmux';
     const height = String(Math.max(1, Math.floor(heightLines)));
-    const resize = buildHudResizeHookCommand(tmuxBin, hudPaneId, height, options.env?.TMUX);
+    const resize = buildHudResizeHookCommand(tmuxBin, hudPaneId, height, condition, options.env?.TMUX);
     const reconcile = buildHudLayoutReconcileHookCommand(tmuxBin, omxBin, leaderPaneId, options);
     const wrap = (command: string) => `if-shell -t ${hudPaneId} -F ${shellEscapeSingle(condition)} ${shellEscapeSingle(`run-shell -b ${command}`)} '' # omx-hud-owned:${generation}`;
     execTmuxSync(['set-option', '-t', context.sessionId, activeOption, '1']);
+    execTmuxSync(['set-option', '-t', context.sessionId, generationOption, generation]);
     // tmux serializes -a registration and assigns a fresh numeric slot. Existing
     // foreign/older hooks are never observed as mutation authority or replaced.
     execTmuxSync(['set-hook', '-a', '-t', context.sessionId, 'client-resized', wrap(resize)]);
     execTmuxSync(['set-hook', '-a', '-t', context.sessionId, 'window-layout-changed', wrap(reconcile)]);
     return true;
   } catch {
+    if (activeOption) {
+      try {
+        execTmuxSync(['set-option', '-t', context.sessionId, activeOption, '0']);
+      } catch {
+        // A failed inert write remains recovery uncertainty.
+      }
+    }
     return false;
   }
 }
 
-/** Marks all discovered OMX generations inert. Live hooks and receipts are retained. */
+/** Makes only this leader birth's persisted HUD hook generation inert. */
 export function unregisterHudResizeHook(
   leaderPaneId: string | undefined,
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
 ): boolean {
   const context = readHudResizeHookContext(leaderPaneId, execTmuxSync);
-  if (!context) return false;
+  if (!context || !leaderPaneId) return false;
   try {
-    const hooks = [
-      execTmuxSync(['show-hooks', '-t', context.sessionId, 'client-resized']),
-      execTmuxSync(['show-hooks', '-t', context.sessionId, 'window-layout-changed']),
-    ].join('\n');
-    const generations = [...hooks.matchAll(/# omx-hud-owned:([0-9a-f-]{36})/g)].map((match) => match[1]!);
-    for (const generation of new Set(generations)) {
-      execTmuxSync(['set-option', '-t', context.sessionId, `@omx_hud_hook_active_${generation.replace(/-/g, '_')}`, '0']);
-    }
+    const leaderBirth = execTmuxSync(['display-message', '-p', '-t', leaderPaneId, '#{@omx_pane_instance_id}']).trim();
+    if (!leaderBirth) return false;
+    const generation = execTmuxSync(['show-option', '-qv', '-t', context.sessionId, hudHookGenerationOption(leaderPaneId, leaderBirth)]).trim();
+    if (!/^[0-9a-f-]{36}$/.test(generation)) return false;
+    execTmuxSync(['set-option', '-t', context.sessionId, `@omx_hud_hook_active_${generation.replace(/-/g, '_')}`, '0']);
     return true;
   } catch {
     return false;

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -8,6 +8,8 @@ export interface TmuxPaneSnapshot {
   paneId: string;
   currentCommand: string;
   startCommand: string;
+  paneInstanceId?: string;
+  sessionInstanceId?: string;
   currentPath?: string;
   paneLeft?: number;
   paneTop?: number;
@@ -110,14 +112,20 @@ export function parseTmuxPaneSnapshot(output: string): TmuxPaneSnapshot[] {
         && windowHeight !== null
       );
       const payloadParts = hasGeometry ? parts.slice(9) : parts.slice(2);
-      const hasCurrentPathColumn = payloadParts.length >= 2;
-      const currentPath = hasCurrentPathColumn ? (payloadParts.at(-1) ?? '') : '';
-      const startCommandParts = hasCurrentPathColumn ? payloadParts.slice(0, -1) : payloadParts;
+      const hasInstanceColumns = hasGeometry && payloadParts.length >= 4;
+      const paneInstanceId = hasInstanceColumns ? (payloadParts[0] ?? '').trim() : '';
+      const sessionInstanceId = hasInstanceColumns ? (payloadParts[1] ?? '').trim() : '';
+      const commandPayloadParts = hasInstanceColumns ? payloadParts.slice(2) : payloadParts;
+      const hasCurrentPathColumn = commandPayloadParts.length >= 2;
+      const currentPath = hasCurrentPathColumn ? (commandPayloadParts.at(-1) ?? '') : '';
+      const startCommandParts = hasCurrentPathColumn ? commandPayloadParts.slice(0, -1) : commandPayloadParts;
       const trimmedCurrentPath = currentPath.trim();
       return {
         paneId: paneId.trim(),
         currentCommand: currentCommand.trim(),
         startCommand: startCommandParts.join('\t').trim(),
+        ...(paneInstanceId ? { paneInstanceId } : {}),
+        ...(sessionInstanceId ? { sessionInstanceId } : {}),
         ...(trimmedCurrentPath ? { currentPath: trimmedCurrentPath } : {}),
         ...(hasGeometry
           ? {
@@ -218,14 +226,22 @@ export function hudPaneMatchesOwner(pane: TmuxPaneSnapshot, owner: HudPaneOwner 
   const paneOwner = readHudPaneOwner(pane);
   const sessionMatches = wantsSession && wantedSessionIds.includes(paneOwner.sessionId ?? '');
   const leaderPaneMatches = wantsLeaderPane && paneOwner.leaderPaneId === wantedLeaderPaneId;
-  const hasLeaderTag = paneOwner.leaderPaneId !== undefined && paneOwner.leaderPaneId !== '';
 
   if (wantsSession && wantsLeaderPane) {
-    if (hasLeaderTag) return sessionMatches && leaderPaneMatches;
-    return sessionMatches;
+    return sessionMatches && leaderPaneMatches;
   }
   if (wantsSession) return sessionMatches;
   return leaderPaneMatches;
+}
+
+export function hudPaneMatchesExactCandidate(
+  pane: TmuxPaneSnapshot,
+  owner: HudPaneOwner,
+  identity: { tmuxSessionInstanceId: string; tmuxPaneInstanceId: string },
+): boolean {
+  return hudPaneMatchesOwner(pane, owner)
+    && pane.sessionInstanceId === identity.tmuxSessionInstanceId
+    && pane.paneInstanceId === identity.tmuxPaneInstanceId;
 }
 
 export function findHudWatchPaneIds(
@@ -497,12 +513,22 @@ export function buildHudRuntimeEnv(input: HudRuntimeEnvInput = {}): HudRuntimeEn
   if (sessionId) env.OMX_SESSION_ID = sessionId;
   env[OMX_TMUX_HUD_OWNER_ENV] = '1';
   if (leaderPaneId) env[OMX_TMUX_HUD_LEADER_PANE_ENV] = leaderPaneId;
-  if (input.rootSource === 'team-env' && input.omxTeamStateRoot?.trim()) {
-    env.OMX_TEAM_STATE_ROOT = input.omxTeamStateRoot.trim();
-  } else if (input.rootSource === 'omx-state-root-env' && input.omxStateRoot?.trim()) {
-    env.OMX_STATE_ROOT = input.omxStateRoot.trim();
-  } else if (input.omxRoot?.trim()) {
-    env.OMX_ROOT = input.omxRoot.trim();
+  const rootSource = input.rootSource ?? (input.omxTeamStateRoot
+    ? 'team-env'
+    : input.omxRoot
+      ? 'omx-root-env'
+      : input.omxStateRoot
+        ? 'omx-state-root-env'
+        : 'cwd-default');
+  if (rootSource === 'team-env') {
+    const value = input.omxTeamStateRoot?.trim();
+    if (value) env.OMX_TEAM_STATE_ROOT = value;
+  } else if (rootSource === 'omx-root-env') {
+    const value = input.omxRoot?.trim();
+    if (value) env.OMX_ROOT = value;
+  } else if (rootSource === 'omx-state-root-env') {
+    const value = input.omxStateRoot?.trim();
+    if (value) env.OMX_STATE_ROOT = value;
   }
   return {
     env,
@@ -553,6 +579,8 @@ export function listCurrentWindowPanes(
           '#{pane_bottom}',
           '#{window_width}',
           '#{window_height}',
+          '#{@omx_pane_instance_id}',
+          '#{@omx_instance_id}',
           '#{pane_start_command}',
           '#{pane_current_path}',
         ].join(TMUX_PANE_FIELD_SEPARATOR),
@@ -611,6 +639,7 @@ export function createHudWatchPane(
     heightLines?: number;
     fullWidth?: boolean;
     targetPaneId?: string;
+    instanceId?: string;
   } = {},
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
 ): string | null {
@@ -633,7 +662,11 @@ export function createHudWatchPane(
     hudCmd,
   ];
   try {
-    return parsePaneIdFromTmuxOutput(execTmuxSync(args));
+    const paneId = parsePaneIdFromTmuxOutput(execTmuxSync(args));
+    if (paneId && options.instanceId?.trim()) {
+      execTmuxSync(['set-option', '-p', '-t', paneId, '@omx_pane_instance_id', options.instanceId.trim()]);
+    }
+    return paneId;
   } catch {
     return null;
   }

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -357,13 +357,6 @@ export function buildHudResizeHookName(sessionId: string, windowId: string, lead
   ].join('_');
 }
 
-function buildLegacyHudResizeHookName(sessionId: string, windowId: string): string {
-  return [
-    'omx_hud_resize',
-    normalizeTmuxHookToken(sessionId),
-    normalizeTmuxHookToken(windowId),
-  ].join('_');
-}
 
 export function buildHudResizeHookSlot(hookName: string): string {
   let hash = 0;
@@ -485,19 +478,6 @@ function buildHudLayoutReconcileHookCommand(
   return `${leaderAlive} >/dev/null 2>&1 && (${unregister}; ${reconcile} >/dev/null 2>&1; status=$?; exit $status) || (${unregister})`;
 }
 
-function unregisterLegacyHudResizeHook(
-  context: HudResizeHookContext,
-  execTmuxSync: TmuxExecSync,
-): void {
-  const legacyHookSlot = buildHudResizeHookSlot(buildLegacyHudResizeHookName(context.sessionId, context.windowId));
-  if (legacyHookSlot === context.hookSlot) return;
-  try {
-    execTmuxSync(['set-hook', '-u', '-t', context.sessionId, legacyHookSlot]);
-  } catch {
-    // Best-effort migration cleanup: failure should not prevent the new
-    // leader-scoped hook from being registered or unregistered.
-  }
-}
 
 function buildEnvPrefix(env: Record<string, string | undefined>): string {
   const assignments = Object.entries(env)
@@ -732,25 +712,17 @@ export function registerHudResizeHook(
   const height = String(Math.max(1, Math.floor(heightLines)));
   const resizeCmd = shellEscapeSingle(buildHudResizeHookCommand(tmuxBin, hudPaneId, height, context, options.env?.TMUX));
   const omxBin = resolveOmxCliEntryPath({ cwd: options.cwd, env: options.env });
-  try {
-    execTmuxSync(['set-hook', '-t', context.sessionId, context.hookSlot, `run-shell -b ${resizeCmd}`]);
-    unregisterLegacyHudResizeHook(context, execTmuxSync);
-  } catch {
-    return false;
-  }
-  if (omxBin && leaderPaneId?.startsWith('%')) {
-    try {
-      const reconcileCmd = shellEscapeSingle(
-        buildHudLayoutReconcileHookCommand(tmuxBin, omxBin, leaderPaneId, context, options),
-      );
-      execTmuxSync(['set-hook', '-t', context.sessionId, context.layoutHookSlot, `run-shell -b ${reconcileCmd}`]);
-    } catch {
-      // Keep the resize hook installed so older tmux builds still recover on
-      // client resize even when layout-change hook registration is unavailable.
-      return false;
-    }
-  }
-  return true;
+  if (!omxBin || !leaderPaneId?.startsWith('%')) return false;
+  const reconcileCmd = shellEscapeSingle(
+    buildHudLayoutReconcileHookCommand(tmuxBin, omxBin, leaderPaneId, context, options),
+  );
+  const ownershipMarker = ` # omx-hud-owned:${context.hookSlot}:${context.layoutHookSlot}`;
+  return registerHudHookPair(
+    context,
+    `run-shell -b ${resizeCmd}${ownershipMarker}`,
+    `run-shell -b ${reconcileCmd}${ownershipMarker}`,
+    execTmuxSync,
+  );
 }
 
 export function unregisterHudResizeHook(
@@ -759,17 +731,81 @@ export function unregisterHudResizeHook(
 ): boolean {
   const context = readHudResizeHookContext(leaderPaneId, execTmuxSync);
   if (!context) return false;
-  let ok = true;
+  return unregisterHudHookPair(context, execTmuxSync);
+}
+
+interface TmuxHookSnapshot {
+  slot: string;
+  command: string | null;
+}
+
+function readTmuxHookSnapshot(context: HudResizeHookContext, slot: string, execTmuxSync: TmuxExecSync): TmuxHookSnapshot | null {
   try {
-    unregisterLegacyHudResizeHook(context, execTmuxSync);
-    execTmuxSync(['set-hook', '-u', '-t', context.sessionId, context.hookSlot]);
+    const output = execTmuxSync(['show-hooks', '-t', context.sessionId, slot]).trim();
+    if (!output) return { slot, command: null };
+    const escapedSlot = slot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = output.split('\n').map((line) => line.trim()).map((line) => line.match(new RegExp(`^${escapedSlot}\\s+(.+)$`))).find(Boolean);
+    return match?.[1] ? { slot, command: match[1] } : null;
   } catch {
-    ok = false;
+    return null;
   }
+}
+
+function hookMatches(context: HudResizeHookContext, snapshot: TmuxHookSnapshot, execTmuxSync: TmuxExecSync): boolean {
+  return readTmuxHookSnapshot(context, snapshot.slot, execTmuxSync)?.command === snapshot.command;
+}
+
+function restoreHudHookPair(context: HudResizeHookContext, resize: TmuxHookSnapshot, layout: TmuxHookSnapshot, execTmuxSync: TmuxExecSync): boolean {
+  const restore = (snapshot: TmuxHookSnapshot): boolean => {
+    try {
+      if (snapshot.command === null) execTmuxSync(['set-hook', '-u', '-t', context.sessionId, snapshot.slot]);
+      else execTmuxSync(['set-hook', '-t', context.sessionId, snapshot.slot, snapshot.command]);
+    } catch {
+      return false;
+    }
+    return hookMatches(context, snapshot, execTmuxSync);
+  };
+  const resizeRestored = restore(resize);
+  const layoutRestored = restore(layout);
+  return resizeRestored && layoutRestored;
+}
+
+function registerHudHookPair(context: HudResizeHookContext, resizeCommand: string, layoutCommand: string, execTmuxSync: TmuxExecSync): boolean {
+  const resize = readTmuxHookSnapshot(context, context.hookSlot, execTmuxSync);
+  const layout = readTmuxHookSnapshot(context, context.layoutHookSlot, execTmuxSync);
+  if (!resize || !layout || (resize.command !== null && resize.command !== resizeCommand) || (layout.command !== null && layout.command !== layoutCommand)) return false;
   try {
-    execTmuxSync(['set-hook', '-u', '-t', context.sessionId, context.layoutHookSlot]);
+    if (resize.command === null) execTmuxSync(['set-hook', '-t', context.sessionId, resize.slot, resizeCommand]);
+    if (!hookMatches(context, { slot: resize.slot, command: resizeCommand }, execTmuxSync)) throw new Error('resize hook verification failed');
+    if (layout.command === null) execTmuxSync(['set-hook', '-t', context.sessionId, layout.slot, layoutCommand]);
+    if (!hookMatches(context, { slot: layout.slot, command: layoutCommand }, execTmuxSync)) throw new Error('layout hook verification failed');
+    return true;
   } catch {
-    ok = false;
+    restoreHudHookPair(context, resize, layout, execTmuxSync);
+    return false;
   }
-  return ok;
+}
+
+function unregisterHudHookPair(context: HudResizeHookContext, execTmuxSync: TmuxExecSync): boolean {
+  const resize = readTmuxHookSnapshot(context, context.hookSlot, execTmuxSync);
+  const layout = readTmuxHookSnapshot(context, context.layoutHookSlot, execTmuxSync);
+  if (!resize || !layout) return false;
+  if (resize.command === null && layout.command === null) return true;
+  const ownershipMarker = `# omx-hud-owned:${context.hookSlot}:${context.layoutHookSlot}`;
+  if (!resize.command?.endsWith(ownershipMarker) || !layout.command?.endsWith(ownershipMarker)) return false;
+  const remove = (snapshot: TmuxHookSnapshot): boolean => {
+    try {
+      execTmuxSync(['set-hook', '-u', '-t', context.sessionId, snapshot.slot]);
+    } catch {
+      return false;
+    }
+    return hookMatches(context, { slot: snapshot.slot, command: null }, execTmuxSync);
+  };
+  const resizeRemoved = remove(resize);
+  const layoutRemoved = remove(layout);
+  if (!resizeRemoved || !layoutRemoved) {
+    restoreHudHookPair(context, resize, layout, execTmuxSync);
+    return false;
+  }
+  return true;
 }

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -431,32 +431,24 @@ function buildHudResizeHookCommand(
   tmuxBin: string,
   hudPaneId: string,
   height: string,
-  context: HudResizeHookContext,
   tmuxEnv?: string,
 ): string {
   const resize = buildNestedTmuxCommand(tmuxBin, ['resize-pane', '-t', hudPaneId, '-y', height], tmuxEnv);
-  const unregister = buildHudHookUnregisterCommand(tmuxBin, context, tmuxEnv);
-  const resizeOrUnregister = `${resize} >/dev/null 2>&1 || (${unregister})`;
-  return `${resizeOrUnregister}; sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; ${resizeOrUnregister}`;
-}
-
-function buildHudHookUnregisterCommand(tmuxBin: string, context: HudResizeHookContext, tmuxEnv?: string): string {
-  const unregisterResize = buildNestedTmuxCommand(tmuxBin, ['set-hook', '-u', '-t', context.sessionId, context.hookSlot], tmuxEnv);
-  const unregisterLayout = buildNestedTmuxCommand(tmuxBin, ['set-hook', '-u', '-t', context.sessionId, context.layoutHookSlot], tmuxEnv);
-  return `${unregisterResize} >/dev/null 2>&1 || true; ${unregisterLayout} >/dev/null 2>&1 || true`;
+  // Hook cleanup is lifecycle-owned. A delayed callback cannot prove slot ownership
+  // after it was queued, so it must never unset potentially replaced hooks.
+  const resizeBestEffort = `${resize} >/dev/null 2>&1 || true`;
+  return `${resizeBestEffort}; sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; ${resizeBestEffort}`;
 }
 
 function buildHudLayoutReconcileHookCommand(
   tmuxBin: string,
   omxBin: string,
   leaderPaneId: string,
-  context: HudResizeHookContext,
   options: RegisterHudResizeHookOptions = {},
 ): string {
   const env = options.env ?? process.env;
   const cwd = options.cwd?.trim() || process.cwd();
   const leaderAlive = buildNestedTmuxCommand(tmuxBin, ['display-message', '-p', '-t', leaderPaneId, '#{pane_id}'], env.TMUX);
-  const unregister = buildHudHookUnregisterCommand(tmuxBin, context, env.TMUX);
   const reconcileEnv = buildEnvPrefix({
     TMUX: env.TMUX,
     TMUX_PANE: leaderPaneId,
@@ -475,7 +467,7 @@ function buildHudLayoutReconcileHookCommand(
     'hud',
     '--reconcile-tmux',
   ].join(' ');
-  return `${leaderAlive} >/dev/null 2>&1 && (${unregister}; ${reconcile} >/dev/null 2>&1; status=$?; exit $status) || (${unregister})`;
+  return `${leaderAlive} >/dev/null 2>&1 && (${reconcile} >/dev/null 2>&1; status=$?; exit $status) || true`;
 }
 
 
@@ -710,11 +702,11 @@ export function registerHudResizeHook(
   if (!context) return false;
   const tmuxBin = resolveTmuxBinaryForPlatform() || 'tmux';
   const height = String(Math.max(1, Math.floor(heightLines)));
-  const resizeCmd = shellEscapeSingle(buildHudResizeHookCommand(tmuxBin, hudPaneId, height, context, options.env?.TMUX));
+  const resizeCmd = shellEscapeSingle(buildHudResizeHookCommand(tmuxBin, hudPaneId, height, options.env?.TMUX));
   const omxBin = resolveOmxCliEntryPath({ cwd: options.cwd, env: options.env });
   if (!omxBin || !leaderPaneId?.startsWith('%')) return false;
   const reconcileCmd = shellEscapeSingle(
-    buildHudLayoutReconcileHookCommand(tmuxBin, omxBin, leaderPaneId, context, options),
+    buildHudLayoutReconcileHookCommand(tmuxBin, omxBin, leaderPaneId, options),
   );
   const ownershipMarker = ` # omx-hud-owned:${context.hookSlot}:${context.layoutHookSlot}`;
   return registerHudHookPair(
@@ -755,8 +747,16 @@ function hookMatches(context: HudResizeHookContext, snapshot: TmuxHookSnapshot, 
   return readTmuxHookSnapshot(context, snapshot.slot, execTmuxSync)?.command === snapshot.command;
 }
 
-function restoreHudHookPair(context: HudResizeHookContext, resize: TmuxHookSnapshot, layout: TmuxHookSnapshot, execTmuxSync: TmuxExecSync): boolean {
-  const restore = (snapshot: TmuxHookSnapshot): boolean => {
+function restoreHudHookPair(
+  context: HudResizeHookContext,
+  resize: TmuxHookSnapshot,
+  layout: TmuxHookSnapshot,
+  expectedResizeCurrent: string | null,
+  expectedLayoutCurrent: string | null,
+  execTmuxSync: TmuxExecSync,
+): boolean {
+  const restore = (snapshot: TmuxHookSnapshot, expectedCurrent: string | null): boolean => {
+    if (!hookMatches(context, { slot: snapshot.slot, command: expectedCurrent }, execTmuxSync)) return false;
     try {
       if (snapshot.command === null) execTmuxSync(['set-hook', '-u', '-t', context.sessionId, snapshot.slot]);
       else execTmuxSync(['set-hook', '-t', context.sessionId, snapshot.slot, snapshot.command]);
@@ -765,8 +765,8 @@ function restoreHudHookPair(context: HudResizeHookContext, resize: TmuxHookSnaps
     }
     return hookMatches(context, snapshot, execTmuxSync);
   };
-  const resizeRestored = restore(resize);
-  const layoutRestored = restore(layout);
+  const resizeRestored = restore(resize, expectedResizeCurrent);
+  const layoutRestored = restore(layout, expectedLayoutCurrent);
   return resizeRestored && layoutRestored;
 }
 
@@ -781,7 +781,7 @@ function registerHudHookPair(context: HudResizeHookContext, resizeCommand: strin
     if (!hookMatches(context, { slot: layout.slot, command: layoutCommand }, execTmuxSync)) throw new Error('layout hook verification failed');
     return true;
   } catch {
-    restoreHudHookPair(context, resize, layout, execTmuxSync);
+    restoreHudHookPair(context, resize, layout, resizeCommand, layoutCommand, execTmuxSync);
     return false;
   }
 }
@@ -790,22 +790,25 @@ function unregisterHudHookPair(context: HudResizeHookContext, execTmuxSync: Tmux
   const resize = readTmuxHookSnapshot(context, context.hookSlot, execTmuxSync);
   const layout = readTmuxHookSnapshot(context, context.layoutHookSlot, execTmuxSync);
   if (!resize || !layout) return false;
-  if (resize.command === null && layout.command === null) return true;
   const ownershipMarker = `# omx-hud-owned:${context.hookSlot}:${context.layoutHookSlot}`;
-  if (!resize.command?.endsWith(ownershipMarker) || !layout.command?.endsWith(ownershipMarker)) return false;
-  const remove = (snapshot: TmuxHookSnapshot): boolean => {
+  const removeOwnedOrPreserveForeign = (snapshot: TmuxHookSnapshot): boolean => {
+    const current = readTmuxHookSnapshot(context, snapshot.slot, execTmuxSync);
+    if (!current) return false;
+    // A concurrent removal or replacement has already made this transaction's
+    // owned hook harmless; preserve it and treat this slot as safely handled.
+    if (current.command === null || !current.command.endsWith(ownershipMarker)) return true;
+    if (snapshot.command === null || current.command !== snapshot.command) return false;
     try {
       execTmuxSync(['set-hook', '-u', '-t', context.sessionId, snapshot.slot]);
     } catch {
       return false;
     }
-    return hookMatches(context, { slot: snapshot.slot, command: null }, execTmuxSync);
+    const after = readTmuxHookSnapshot(context, snapshot.slot, execTmuxSync);
+    return after === null || after.command === null || !after.command.endsWith(ownershipMarker);
   };
-  const resizeRemoved = remove(resize);
-  const layoutRemoved = remove(layout);
-  if (!resizeRemoved || !layoutRemoved) {
-    restoreHudHookPair(context, resize, layout, execTmuxSync);
-    return false;
-  }
-  return true;
+  // Attempt both slots even when one cannot be safely handled. Never restore a
+  // removed owned hook: that could overwrite a concurrent replacement.
+  const resizeHandled = removeOwnedOrPreserveForeign(resize);
+  const layoutHandled = removeOwnedOrPreserveForeign(layout);
+  return resizeHandled && layoutHandled;
 }

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -645,13 +645,9 @@ export function createHudWatchPane(
     }
     return paneId;
   } catch {
-    if (paneId) {
-      try {
-        execTmuxSync(['kill-pane', '-t', paneId]);
-      } catch {
-        // The split succeeded but its ownership tag could not be verified.
-      }
-    }
+    // The split may have succeeded but its ownership tag could not be verified.
+    // Do not kill by pane id here: tmux pane ids can be reused before cleanup.
+    // Leaving the uncertain pane intact is the fail-closed rollback behavior.
     return null;
   }
 }

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -15,6 +15,7 @@ import {
   getReadScopedStateFilePaths,
   readCurrentSessionId,
   resolveRuntimeStateScope,
+  resolveHudControlPlaneDomain,
   resolveStateScope,
   resolveWritableStateScope,
   resolveWorkingDirectoryForState,
@@ -705,4 +706,57 @@ describe('state paths', () => {
     });
   });
 
+});
+
+describe('HUD control-plane domains', () => {
+  it('uses explicit env precedence while deriving a domain key only from the canonical state root', async () => {
+    const root = await mkRealTemp('omx-hud-domain-root-');
+    const otherRoot = await mkRealTemp('omx-hud-domain-other-');
+    const cwd = await mkRealTemp('omx-hud-domain-cwd-');
+    try {
+      const sharedState = join(root, '.omx', 'state');
+      await mkdir(sharedState, { recursive: true });
+      const sharedTeam = await resolveHudControlPlaneDomain({
+        cwd,
+        env: { OMX_TEAM_STATE_ROOT: sharedState, OMX_ROOT: otherRoot, OMX_STATE_ROOT: otherRoot },
+      });
+      const sharedRoot = await resolveHudControlPlaneDomain({ cwd, env: { OMX_ROOT: root } });
+      const isolated = await resolveHudControlPlaneDomain({ cwd, env: { OMX_STATE_ROOT: otherRoot } });
+      const unmanaged = await resolveHudControlPlaneDomain({ cwd, env: {} });
+
+      assert.equal(sharedTeam.rootSource, 'team-env');
+      assert.equal(sharedRoot.rootSource, 'omx-root-env');
+      assert.equal(sharedTeam.baseStateDir, sharedState);
+      assert.equal(sharedTeam.domainKey, sharedRoot.domainKey);
+      assert.notEqual(sharedTeam.domainKey, isolated.domainKey);
+      assert.equal(unmanaged.managed, false);
+      assert.equal(unmanaged.session, undefined);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(otherRoot, { recursive: true, force: true });
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('canonicalizes session aliases as claimant metadata without partitioning the domain', async () => {
+    const cwd = await mkRealTemp('omx-hud-domain-alias-');
+    try {
+      const stateDir = getBaseStateDir(cwd);
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: 'omx-canonical',
+        native_session_id: 'codex-native',
+        cwd,
+      }));
+      const canonical = await resolveHudControlPlaneDomain({ cwd, env: { OMX_SESSION_ID: 'omx-canonical' } });
+      const alias = await resolveHudControlPlaneDomain({ cwd, env: { CODEX_SESSION_ID: 'codex-native' } });
+      assert.equal(alias.session?.canonicalId, 'omx-canonical');
+      assert.ok(alias.session?.equivalentIds.includes('codex-native'));
+      assert.equal(alias.domainKey, canonical.domainKey);
+      assert.equal(alias.claimant.sessionId, 'omx-canonical');
+      assert.equal(alias.managed, true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -762,6 +762,30 @@ describe('HUD control-plane domains', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('admits metadata aliases only when the requested id canonicalizes to the metadata session', async () => {
+    const cwd = await mkRealTemp('omx-hud-domain-alias-admission-');
+    try {
+      const stateDir = getBaseStateDir(cwd);
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: 'omx-canonical',
+        native_session_id: 'codex-native',
+        owner_omx_session_id: 'omx-owner',
+        owner_codex_session_id: 'codex-owner',
+        cwd,
+      }));
+
+      const alias = await resolveHudControlPlaneDomain({ cwd, requestedSessionId: 'codex-owner' });
+      const foreign = await resolveHudControlPlaneDomain({ cwd, requestedSessionId: 'stale-foreign' });
+
+      assert.deepEqual(alias.session?.equivalentIds, ['omx-canonical', 'codex-native', 'omx-owner', 'codex-owner']);
+      assert.deepEqual(foreign.session?.equivalentIds, ['stale-foreign']);
+      assert.equal(foreign.session?.canonicalId, 'stale-foreign');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
   it('deletes only immutable nonce-bound lineage records during concurrent replacement', async () => {
     const cwd = await mkRealTemp('omx-hud-lineage-receipt-');
     try {

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -16,6 +16,9 @@ import {
   readCurrentSessionId,
   resolveRuntimeStateScope,
   resolveHudControlPlaneDomain,
+  writeHudTmuxBirthLineage,
+  readHudTmuxBirthLineage,
+  deleteHudTmuxBirthLineage,
   resolveStateScope,
   resolveWritableStateScope,
   resolveWorkingDirectoryForState,
@@ -755,6 +758,31 @@ describe('HUD control-plane domains', () => {
       assert.equal(alias.domainKey, canonical.domainKey);
       assert.equal(alias.claimant.sessionId, 'omx-canonical');
       assert.equal(alias.managed, true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+  it('requires versioned nonce receipts to read and delete opaque tmux birth lineage', async () => {
+    const cwd = await mkRealTemp('omx-hud-lineage-receipt-');
+    try {
+      const domain = await resolveHudControlPlaneDomain({ cwd, requestedSessionId: 'session-receipt' });
+      const receipt = await writeHudTmuxBirthLineage(domain, {
+        sessionId: 'session-receipt',
+        tmuxSessionName: 'tmux-session',
+        tmuxSessionInstanceId: 'session-birth',
+        tmuxPaneInstanceId: 'pane-birth',
+      });
+      const lineage = await readHudTmuxBirthLineage(domain.baseStateDir, 'session-receipt');
+      assert.ok(lineage);
+      assert.equal(lineage.version, 1);
+      assert.equal(lineage.nonce, receipt.nonce);
+      assert.equal(
+        await deleteHudTmuxBirthLineage(domain, lineage, { ...receipt, nonce: 'replacement-receipt' }),
+        false,
+      );
+      assert.ok(await readHudTmuxBirthLineage(domain.baseStateDir, 'session-receipt'));
+      assert.equal(await deleteHudTmuxBirthLineage(domain, lineage, receipt), true);
+      assert.equal(await readHudTmuxBirthLineage(domain.baseStateDir, 'session-receipt'), null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -762,7 +762,7 @@ describe('HUD control-plane domains', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
-  it('requires versioned nonce receipts to read and delete opaque tmux birth lineage', async () => {
+  it('deletes only immutable nonce-bound lineage records during concurrent replacement', async () => {
     const cwd = await mkRealTemp('omx-hud-lineage-receipt-');
     try {
       const domain = await resolveHudControlPlaneDomain({ cwd, requestedSessionId: 'session-receipt' });
@@ -780,8 +780,23 @@ describe('HUD control-plane domains', () => {
         await deleteHudTmuxBirthLineage(domain, lineage, { ...receipt, nonce: 'replacement-receipt' }),
         false,
       );
-      assert.ok(await readHudTmuxBirthLineage(domain.baseStateDir, 'session-receipt'));
-      assert.equal(await deleteHudTmuxBirthLineage(domain, lineage, receipt), true);
+      const [replacementReceipt, staleDeleted] = await Promise.all([
+        writeHudTmuxBirthLineage(domain, {
+          sessionId: 'session-receipt',
+          tmuxSessionName: 'replacement-tmux-session',
+          tmuxSessionInstanceId: 'replacement-session-birth',
+          tmuxPaneInstanceId: 'replacement-pane-birth',
+        }),
+        deleteHudTmuxBirthLineage(domain, lineage, receipt),
+      ]);
+      assert.equal(staleDeleted, true);
+      const replacement = await readHudTmuxBirthLineage(domain.baseStateDir, 'session-receipt');
+      assert.ok(replacement);
+      assert.equal(replacement.nonce, replacementReceipt.nonce);
+      assert.equal(replacement.tmuxSessionInstanceId, 'replacement-session-birth');
+      assert.equal(replacement.tmuxPaneInstanceId, 'replacement-pane-birth');
+      assert.deepEqual(await readHudTmuxBirthLineage(domain.baseStateDir, 'session-receipt'), replacement);
+      assert.equal(await deleteHudTmuxBirthLineage(domain, replacement, replacementReceipt), true);
       assert.equal(await readHudTmuxBirthLineage(domain.baseStateDir, 'session-receipt'), null);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -80,25 +80,47 @@ export interface ResolvedHudControlPlaneDomain {
 }
 
 export interface HudTmuxBirthLineage {
+  version: 1;
   sessionId: string;
   tmuxSessionName: string;
   tmuxSessionInstanceId: string;
   tmuxPaneInstanceId: string;
-  createdAtMs?: number;
-  nonce?: string;
+  createdAtMs: number;
+  nonce: string;
+}
+
+export interface HudTmuxBirthLineageReceipt {
+  version: 1;
+  nonce: string;
+  births: {
+    tmuxSessionInstanceId: string;
+    tmuxPaneInstanceId: string;
+  };
 }
 
 const HUD_TMUX_BIRTH_LINEAGE_DIR = 'hud-tmux-birth-lineage';
+const HUD_TMUX_BIRTH_LINEAGE_VERSION = 1 as const;
 
 function hudTmuxBirthLineagePath(baseStateDir: string, sessionId: string): string {
   return join(baseStateDir, HUD_TMUX_BIRTH_LINEAGE_DIR, `${createHash('sha256').update(sessionId).digest('hex')}.json`);
 }
 
+function isHudTmuxBirthLineage(value: unknown, sessionId: string): value is HudTmuxBirthLineage {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<HudTmuxBirthLineage>;
+  return candidate.version === HUD_TMUX_BIRTH_LINEAGE_VERSION
+    && candidate.sessionId === sessionId
+    && typeof candidate.tmuxSessionName === 'string' && candidate.tmuxSessionName.trim() !== ''
+    && typeof candidate.tmuxSessionInstanceId === 'string' && candidate.tmuxSessionInstanceId.trim() !== ''
+    && typeof candidate.tmuxPaneInstanceId === 'string' && candidate.tmuxPaneInstanceId.trim() !== ''
+    && typeof candidate.createdAtMs === 'number' && Number.isFinite(candidate.createdAtMs)
+    && typeof candidate.nonce === 'string' && candidate.nonce.trim() !== '';
+}
 
 export async function writeHudTmuxBirthLineage(
   domain: Pick<ResolvedHudControlPlaneDomain, 'baseStateDir'>,
-  lineage: HudTmuxBirthLineage,
-): Promise<void> {
+  lineage: Omit<HudTmuxBirthLineage, 'version' | 'createdAtMs' | 'nonce'>,
+): Promise<HudTmuxBirthLineageReceipt> {
   const values = [lineage.sessionId, lineage.tmuxSessionName, lineage.tmuxSessionInstanceId, lineage.tmuxPaneInstanceId];
   if (values.some((value) => typeof value !== 'string' || value.trim() === '')) {
     throw new Error('HUD tmux birth lineage requires complete evidence');
@@ -106,21 +128,41 @@ export async function writeHudTmuxBirthLineage(
   const directory = join(domain.baseStateDir, HUD_TMUX_BIRTH_LINEAGE_DIR);
   await mkdir(directory, { recursive: true });
   const nowMs = Date.now();
+  const record: HudTmuxBirthLineage = {
+    ...lineage,
+    version: HUD_TMUX_BIRTH_LINEAGE_VERSION,
+    createdAtMs: nowMs,
+    nonce: `${process.pid}-${nowMs}-${Math.random().toString(36).slice(2)}`,
+  };
   const target = hudTmuxBirthLineagePath(domain.baseStateDir, lineage.sessionId);
-  const record = { ...lineage, createdAtMs: nowMs, nonce: `${process.pid}-${nowMs}-${Math.random().toString(36).slice(2)}` };
   const temporary = `${target}.${record.nonce}.tmp`;
   await writeFile(temporary, `${JSON.stringify(record)}\n`, { mode: 0o600 });
   await rename(temporary, target);
+  return {
+    version: record.version,
+    nonce: record.nonce,
+    births: {
+      tmuxSessionInstanceId: record.tmuxSessionInstanceId,
+      tmuxPaneInstanceId: record.tmuxPaneInstanceId,
+    },
+  };
 }
 
 export async function deleteHudTmuxBirthLineage(
   domain: Pick<ResolvedHudControlPlaneDomain, 'baseStateDir'>,
-  lineage: Required<Pick<HudTmuxBirthLineage, 'sessionId' | 'tmuxSessionName' | 'tmuxSessionInstanceId' | 'tmuxPaneInstanceId' | 'createdAtMs' | 'nonce'>>,
+  lineage: HudTmuxBirthLineage,
+  receipt: HudTmuxBirthLineageReceipt,
 ): Promise<boolean> {
+  if (
+    lineage.version !== receipt.version
+    || lineage.nonce !== receipt.nonce
+    || lineage.tmuxSessionInstanceId !== receipt.births.tmuxSessionInstanceId
+    || lineage.tmuxPaneInstanceId !== receipt.births.tmuxPaneInstanceId
+  ) return false;
   const path = hudTmuxBirthLineagePath(domain.baseStateDir, lineage.sessionId);
   try {
     const current: unknown = JSON.parse(await readFile(path, 'utf-8'));
-    if (JSON.stringify(current) !== JSON.stringify(lineage)) return false;
+    if (!isHudTmuxBirthLineage(current, lineage.sessionId) || JSON.stringify(current) !== JSON.stringify(lineage)) return false;
     await unlink(path);
     return true;
   } catch (error: unknown) {
@@ -128,19 +170,11 @@ export async function deleteHudTmuxBirthLineage(
   }
 }
 
-async function readHudTmuxBirthLineage(baseStateDir: string, sessionId: string | undefined): Promise<HudTmuxBirthLineage | null> {
+export async function readHudTmuxBirthLineage(baseStateDir: string, sessionId: string | undefined): Promise<HudTmuxBirthLineage | null> {
   if (!sessionId) return null;
   try {
     const value: unknown = JSON.parse(await readFile(hudTmuxBirthLineagePath(baseStateDir, sessionId), 'utf-8'));
-    if (!value || typeof value !== 'object') return null;
-    const candidate = value as Partial<HudTmuxBirthLineage>;
-    if (
-      candidate.sessionId !== sessionId
-      || typeof candidate.tmuxSessionName !== 'string' || candidate.tmuxSessionName.trim() === ''
-      || typeof candidate.tmuxSessionInstanceId !== 'string' || candidate.tmuxSessionInstanceId.trim() === ''
-      || typeof candidate.tmuxPaneInstanceId !== 'string' || candidate.tmuxPaneInstanceId.trim() === ''
-    ) return null;
-    return candidate as HudTmuxBirthLineage;
+    return isHudTmuxBirthLineage(value, sessionId) ? value : null;
   } catch {
     return null;
   }

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { delimiter, isAbsolute, join, relative, resolve as resolvePath } from 'path';
 import { existsSync, realpathSync } from 'fs';
 import { readFile, readdir } from 'fs/promises';
@@ -51,6 +52,38 @@ export interface ResolvedRuntimeStateScope {
   isSessionScoped: boolean;
   authoritativeActiveDirs: string[];
   compatibilityReadDirs: string[];
+}
+
+export interface ResolvedHudControlPlaneDomain {
+  version: 1;
+  cwd: string;
+  baseStateDir: string;
+  rootSource: StateRootSource;
+  domainKey: string;
+  authorityStatePath: string;
+  authorityLeasePath: string;
+  authorityLockPath: string;
+  reconcileLockPath: string;
+  session?: {
+    canonicalId: string;
+    equivalentIds: string[];
+    source: Exclude<SessionScopeSource, 'root'>;
+  };
+  claimant: {
+    sessionId?: string;
+    leaderPaneId?: string;
+    tmuxSessionName?: string;
+    tmuxSessionInstanceId?: string;
+    tmuxPaneInstanceId?: string;
+  };
+  managed: boolean;
+}
+
+export interface ResolveHudControlPlaneDomainOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  requestedSessionId?: string;
+  claimant?: ResolvedHudControlPlaneDomain['claimant'];
 }
 
 export type StateFileScope = 'root' | 'session';
@@ -240,18 +273,21 @@ function enforceWorkingDirectoryPolicy(resolvedWorkingDirectory: string): string
   return canonicalWorkingDirectory;
 }
 
-export function getBaseStateDirWithSource(workingDirectory?: string): { baseStateDir: string; rootSource: StateRootSource } {
-  const teamStateRootOverride = process.env[OMX_TEAM_STATE_ROOT_ENV]?.trim();
+export function getBaseStateDirWithSource(
+  workingDirectory?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): { baseStateDir: string; rootSource: StateRootSource } {
+  const teamStateRootOverride = env[OMX_TEAM_STATE_ROOT_ENV]?.trim();
   if (typeof teamStateRootOverride === 'string' && teamStateRootOverride !== '') {
     return { baseStateDir: resolveWorkingDirectoryForState(teamStateRootOverride), rootSource: 'team-env' };
   }
 
-  const omxRootOverride = process.env[OMX_ROOT_ENV]?.trim();
+  const omxRootOverride = env[OMX_ROOT_ENV]?.trim();
   if (typeof omxRootOverride === 'string' && omxRootOverride !== '') {
     return { baseStateDir: join(resolveWorkingDirectoryForState(omxRootOverride), '.omx', 'state'), rootSource: 'omx-root-env' };
   }
 
-  const omxStateRootOverride = process.env[OMX_STATE_ROOT_ENV]?.trim();
+  const omxStateRootOverride = env[OMX_STATE_ROOT_ENV]?.trim();
   if (typeof omxStateRootOverride === 'string' && omxStateRootOverride !== '') {
     return { baseStateDir: join(resolveWorkingDirectoryForState(omxStateRootOverride), '.omx', 'state'), rootSource: 'omx-state-root-env' };
   }
@@ -517,6 +553,54 @@ export async function resolveRuntimeStateScope(
     isSessionScoped,
     authoritativeActiveDirs: [stateDir],
     compatibilityReadDirs: isSessionScoped && source !== 'explicit' ? [stateDir, baseStateDir] : [stateDir],
+  };
+}
+
+export async function resolveHudControlPlaneDomain(
+  options: ResolveHudControlPlaneDomainOptions = {},
+): Promise<ResolvedHudControlPlaneDomain> {
+  const env = options.env ?? process.env;
+  const cwd = resolveWorkingDirectoryForState(options.cwd);
+  const root = getBaseStateDirWithSource(cwd, env);
+  const baseStateDir = canonicalizeExistingPath(root.baseStateDir);
+  const metadata = await readSessionMetadataFromBaseStateDir(cwd, baseStateDir);
+  const requestedSessionId = validateSessionId(options.requestedSessionId);
+  const envSessionId = readSessionIdFromEnvironment(env);
+  const requestedId = requestedSessionId ?? envSessionId;
+  const canonicalSessionId = requestedId
+    ? resolveCanonicalSessionId(requestedId, metadata) ?? requestedId
+    : metadata?.sessionId;
+  const source: Exclude<SessionScopeSource, 'root'> | undefined = requestedSessionId
+    ? (metadata && canonicalSessionId === metadata.sessionId && requestedSessionId !== metadata.sessionId ? 'native-alias' : 'explicit')
+    : envSessionId
+      ? (metadata && canonicalSessionId === metadata.sessionId && envSessionId !== metadata.sessionId ? 'native-alias' : 'env')
+      : metadata?.sessionId
+        ? 'session-json'
+        : undefined;
+  const equivalentIds = canonicalSessionId
+    ? [...new Set([canonicalSessionId, ...(metadata?.nativeSessionAliases ?? []), metadata?.nativeSessionId, metadata?.ownerOmxSessionId, metadata?.ownerCodexSessionId].filter((id): id is string => typeof id === 'string' && normalizeSessionId(id) !== undefined))]
+    : [];
+  const claimant = {
+    sessionId: canonicalSessionId,
+    leaderPaneId: options.claimant?.leaderPaneId ?? metadata?.leaderPaneId ?? env.TMUX_PANE,
+    tmuxSessionName: options.claimant?.tmuxSessionName ?? metadata?.tmuxSessionName ?? env.TMUX_SESSION,
+    tmuxSessionInstanceId: options.claimant?.tmuxSessionInstanceId ?? env.OMX_TMUX_SESSION_INSTANCE_ID,
+    tmuxPaneInstanceId: options.claimant?.tmuxPaneInstanceId ?? env.OMX_TMUX_PANE_INSTANCE_ID,
+  };
+  const domainKey = `hud-control-plane:${createHash('sha256').update(baseStateDir).digest('hex')}`;
+  return {
+    version: 1,
+    cwd,
+    baseStateDir,
+    rootSource: root.rootSource,
+    domainKey,
+    authorityStatePath: join(baseStateDir, 'hud-authority-state.json'),
+    authorityLeasePath: join(baseStateDir, 'hud-authority-lease.json'),
+    authorityLockPath: join(baseStateDir, 'hud-authority.lock'),
+    reconcileLockPath: join(baseStateDir, 'hud-reconcile.lock'),
+    ...(canonicalSessionId && source ? { session: { canonicalId: canonicalSessionId, equivalentIds, source } } : {}),
+    claimant,
+    managed: Boolean(canonicalSessionId),
   };
 }
 

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -79,6 +79,46 @@ export interface ResolvedHudControlPlaneDomain {
   managed: boolean;
 }
 
+export interface HudTmuxBirthLineage {
+  sessionId: string;
+  tmuxSessionName: string;
+  tmuxSessionInstanceId: string;
+  tmuxPaneInstanceId: string;
+}
+
+const HUD_TMUX_BIRTH_LINEAGE_FILE = 'hud-tmux-birth-lineage.json';
+
+export async function writeHudTmuxBirthLineage(
+  domain: Pick<ResolvedHudControlPlaneDomain, 'baseStateDir'>,
+  lineage: HudTmuxBirthLineage,
+): Promise<void> {
+  const values = [lineage.sessionId, lineage.tmuxSessionName, lineage.tmuxSessionInstanceId, lineage.tmuxPaneInstanceId];
+  if (values.some((value) => typeof value !== 'string' || value.trim() === '')) {
+    throw new Error('HUD tmux birth lineage requires complete evidence');
+  }
+  const { mkdir, writeFile } = await import('fs/promises');
+  await mkdir(domain.baseStateDir, { recursive: true });
+  await writeFile(join(domain.baseStateDir, HUD_TMUX_BIRTH_LINEAGE_FILE), `${JSON.stringify(lineage)}\n`, { mode: 0o600 });
+}
+
+async function readHudTmuxBirthLineage(baseStateDir: string, sessionId: string | undefined): Promise<HudTmuxBirthLineage | null> {
+  if (!sessionId) return null;
+  try {
+    const value: unknown = JSON.parse(await readFile(join(baseStateDir, HUD_TMUX_BIRTH_LINEAGE_FILE), 'utf-8'));
+    if (!value || typeof value !== 'object') return null;
+    const candidate = value as Partial<HudTmuxBirthLineage>;
+    if (
+      candidate.sessionId !== sessionId
+      || typeof candidate.tmuxSessionName !== 'string' || candidate.tmuxSessionName.trim() === ''
+      || typeof candidate.tmuxSessionInstanceId !== 'string' || candidate.tmuxSessionInstanceId.trim() === ''
+      || typeof candidate.tmuxPaneInstanceId !== 'string' || candidate.tmuxPaneInstanceId.trim() === ''
+    ) return null;
+    return candidate as HudTmuxBirthLineage;
+  } catch {
+    return null;
+  }
+}
+
 export interface ResolveHudControlPlaneDomainOptions {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
@@ -580,12 +620,13 @@ export async function resolveHudControlPlaneDomain(
   const equivalentIds = canonicalSessionId
     ? [...new Set([canonicalSessionId, ...(metadata?.nativeSessionAliases ?? []), metadata?.nativeSessionId, metadata?.ownerOmxSessionId, metadata?.ownerCodexSessionId].filter((id): id is string => typeof id === 'string' && normalizeSessionId(id) !== undefined))]
     : [];
+  const lineage = await readHudTmuxBirthLineage(baseStateDir, canonicalSessionId);
   const claimant = {
     sessionId: canonicalSessionId,
     leaderPaneId: options.claimant?.leaderPaneId ?? metadata?.leaderPaneId ?? env.TMUX_PANE,
-    tmuxSessionName: options.claimant?.tmuxSessionName ?? metadata?.tmuxSessionName ?? env.TMUX_SESSION,
-    tmuxSessionInstanceId: options.claimant?.tmuxSessionInstanceId ?? env.OMX_TMUX_SESSION_INSTANCE_ID,
-    tmuxPaneInstanceId: options.claimant?.tmuxPaneInstanceId ?? env.OMX_TMUX_PANE_INSTANCE_ID,
+    tmuxSessionName: options.claimant?.tmuxSessionName ?? lineage?.tmuxSessionName ?? metadata?.tmuxSessionName ?? env.TMUX_SESSION,
+    tmuxSessionInstanceId: options.claimant?.tmuxSessionInstanceId ?? lineage?.tmuxSessionInstanceId ?? env.OMX_TMUX_SESSION_INSTANCE_ID,
+    tmuxPaneInstanceId: options.claimant?.tmuxPaneInstanceId ?? lineage?.tmuxPaneInstanceId ?? env.OMX_TMUX_PANE_INSTANCE_ID,
   };
   const domainKey = `hud-control-plane:${createHash('sha256').update(baseStateDir).digest('hex')}`;
   return {

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -465,7 +465,9 @@ function readSessionIdFromEnvironment(env: NodeJS.ProcessEnv = process.env): str
 function resolveCanonicalSessionId(candidate: string | undefined, metadata: ResolvedSessionMetadata | undefined): string | undefined {
   if (!candidate) return undefined;
   if (!metadata) return candidate;
-  return metadata.nativeSessionAliases.includes(candidate) || metadata.ownerOmxSessionId === candidate
+  return metadata.nativeSessionAliases.includes(candidate)
+    || metadata.ownerOmxSessionId === candidate
+    || metadata.ownerCodexSessionId === candidate
     ? metadata.sessionId
     : candidate;
 }
@@ -710,8 +712,21 @@ export async function resolveHudControlPlaneDomain(
       : metadata?.sessionId
         ? 'session-json'
         : undefined;
+  const admitsMetadataAliases = Boolean(
+    requestedId
+    && metadata
+    && canonicalSessionId === metadata.sessionId,
+  );
   const equivalentIds = canonicalSessionId
-    ? [...new Set([canonicalSessionId, ...(metadata?.nativeSessionAliases ?? []), metadata?.nativeSessionId, metadata?.ownerOmxSessionId, metadata?.ownerCodexSessionId].filter((id): id is string => typeof id === 'string' && normalizeSessionId(id) !== undefined))]
+    ? [...new Set([
+      canonicalSessionId,
+      ...(admitsMetadataAliases ? [
+        ...metadata!.nativeSessionAliases,
+        metadata!.nativeSessionId,
+        metadata!.ownerOmxSessionId,
+        metadata!.ownerCodexSessionId,
+      ] : []),
+    ].filter((id): id is string => typeof id === 'string' && normalizeSessionId(id) !== undefined))]
     : [];
   const lineage = await readHudTmuxBirthLineage(baseStateDir, canonicalSessionId);
   const claimant = {

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -105,6 +105,24 @@ function hudTmuxBirthLineagePath(baseStateDir: string, sessionId: string): strin
   return join(baseStateDir, HUD_TMUX_BIRTH_LINEAGE_DIR, `${createHash('sha256').update(sessionId).digest('hex')}.json`);
 }
 
+function hudTmuxBirthLineageRecordPath(
+  baseStateDir: string,
+  sessionId: string,
+  receipt: Pick<HudTmuxBirthLineageReceipt, 'version' | 'nonce'>,
+): string {
+  const sessionHash = createHash('sha256').update(sessionId).digest('hex');
+  return join(baseStateDir, HUD_TMUX_BIRTH_LINEAGE_DIR, `${sessionHash}.${receipt.version}.${receipt.nonce}.json`);
+}
+
+function isHudTmuxBirthLineageReceipt(value: unknown): value is HudTmuxBirthLineageReceipt {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<HudTmuxBirthLineageReceipt>;
+  return candidate.version === HUD_TMUX_BIRTH_LINEAGE_VERSION
+    && typeof candidate.nonce === 'string' && candidate.nonce.trim() !== ''
+    && typeof candidate.births?.tmuxSessionInstanceId === 'string' && candidate.births.tmuxSessionInstanceId.trim() !== ''
+    && typeof candidate.births?.tmuxPaneInstanceId === 'string' && candidate.births.tmuxPaneInstanceId.trim() !== '';
+}
+
 function isHudTmuxBirthLineage(value: unknown, sessionId: string): value is HudTmuxBirthLineage {
   if (!value || typeof value !== 'object') return false;
   const candidate = value as Partial<HudTmuxBirthLineage>;
@@ -134,11 +152,7 @@ export async function writeHudTmuxBirthLineage(
     createdAtMs: nowMs,
     nonce: `${process.pid}-${nowMs}-${Math.random().toString(36).slice(2)}`,
   };
-  const target = hudTmuxBirthLineagePath(domain.baseStateDir, lineage.sessionId);
-  const temporary = `${target}.${record.nonce}.tmp`;
-  await writeFile(temporary, `${JSON.stringify(record)}\n`, { mode: 0o600 });
-  await rename(temporary, target);
-  return {
+  const receipt: HudTmuxBirthLineageReceipt = {
     version: record.version,
     nonce: record.nonce,
     births: {
@@ -146,6 +160,15 @@ export async function writeHudTmuxBirthLineage(
       tmuxPaneInstanceId: record.tmuxPaneInstanceId,
     },
   };
+  await writeFile(hudTmuxBirthLineageRecordPath(domain.baseStateDir, lineage.sessionId, receipt), `${JSON.stringify(record)}\n`, {
+    mode: 0o600,
+    flag: 'wx',
+  });
+  const target = hudTmuxBirthLineagePath(domain.baseStateDir, lineage.sessionId);
+  const temporary = `${target}.${record.nonce}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(receipt)}\n`, { mode: 0o600 });
+  await rename(temporary, target);
+  return receipt;
 }
 
 export async function deleteHudTmuxBirthLineage(
@@ -159,22 +182,31 @@ export async function deleteHudTmuxBirthLineage(
     || lineage.tmuxSessionInstanceId !== receipt.births.tmuxSessionInstanceId
     || lineage.tmuxPaneInstanceId !== receipt.births.tmuxPaneInstanceId
   ) return false;
-  const path = hudTmuxBirthLineagePath(domain.baseStateDir, lineage.sessionId);
+  const path = hudTmuxBirthLineageRecordPath(domain.baseStateDir, lineage.sessionId, receipt);
   try {
     const current: unknown = JSON.parse(await readFile(path, 'utf-8'));
     if (!isHudTmuxBirthLineage(current, lineage.sessionId) || JSON.stringify(current) !== JSON.stringify(lineage)) return false;
     await unlink(path);
     return true;
-  } catch (error: unknown) {
-    return (error as NodeJS.ErrnoException).code === 'ENOENT';
+  } catch {
+    return false;
   }
 }
 
 export async function readHudTmuxBirthLineage(baseStateDir: string, sessionId: string | undefined): Promise<HudTmuxBirthLineage | null> {
   if (!sessionId) return null;
   try {
-    const value: unknown = JSON.parse(await readFile(hudTmuxBirthLineagePath(baseStateDir, sessionId), 'utf-8'));
-    return isHudTmuxBirthLineage(value, sessionId) ? value : null;
+    const pointer: unknown = JSON.parse(await readFile(hudTmuxBirthLineagePath(baseStateDir, sessionId), 'utf-8'));
+    if (isHudTmuxBirthLineage(pointer, sessionId)) return pointer;
+    if (!isHudTmuxBirthLineageReceipt(pointer)) return null;
+    const lineage: unknown = JSON.parse(await readFile(hudTmuxBirthLineageRecordPath(baseStateDir, sessionId, pointer), 'utf-8'));
+    return isHudTmuxBirthLineage(lineage, sessionId)
+      && lineage.version === pointer.version
+      && lineage.nonce === pointer.nonce
+      && lineage.tmuxSessionInstanceId === pointer.births.tmuxSessionInstanceId
+      && lineage.tmuxPaneInstanceId === pointer.births.tmuxPaneInstanceId
+      ? lineage
+      : null;
   } catch {
     return null;
   }

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { delimiter, isAbsolute, join, relative, resolve as resolvePath } from 'path';
 import { existsSync, realpathSync } from 'fs';
-import { readFile, readdir } from 'fs/promises';
+import { readFile, readdir, mkdir, rename, writeFile } from 'fs/promises';
 import {
   isSessionStateUsable,
   readUsableSessionState,
@@ -86,7 +86,11 @@ export interface HudTmuxBirthLineage {
   tmuxPaneInstanceId: string;
 }
 
-const HUD_TMUX_BIRTH_LINEAGE_FILE = 'hud-tmux-birth-lineage.json';
+const HUD_TMUX_BIRTH_LINEAGE_DIR = 'hud-tmux-birth-lineage';
+
+function hudTmuxBirthLineagePath(baseStateDir: string, sessionId: string): string {
+  return join(baseStateDir, HUD_TMUX_BIRTH_LINEAGE_DIR, `${createHash('sha256').update(sessionId).digest('hex')}.json`);
+}
 
 export async function writeHudTmuxBirthLineage(
   domain: Pick<ResolvedHudControlPlaneDomain, 'baseStateDir'>,
@@ -96,15 +100,18 @@ export async function writeHudTmuxBirthLineage(
   if (values.some((value) => typeof value !== 'string' || value.trim() === '')) {
     throw new Error('HUD tmux birth lineage requires complete evidence');
   }
-  const { mkdir, writeFile } = await import('fs/promises');
-  await mkdir(domain.baseStateDir, { recursive: true });
-  await writeFile(join(domain.baseStateDir, HUD_TMUX_BIRTH_LINEAGE_FILE), `${JSON.stringify(lineage)}\n`, { mode: 0o600 });
+  const directory = join(domain.baseStateDir, HUD_TMUX_BIRTH_LINEAGE_DIR);
+  await mkdir(directory, { recursive: true });
+  const target = hudTmuxBirthLineagePath(domain.baseStateDir, lineage.sessionId);
+  const temporary = `${target}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(lineage)}\n`, { mode: 0o600 });
+  await rename(temporary, target);
 }
 
 async function readHudTmuxBirthLineage(baseStateDir: string, sessionId: string | undefined): Promise<HudTmuxBirthLineage | null> {
   if (!sessionId) return null;
   try {
-    const value: unknown = JSON.parse(await readFile(join(baseStateDir, HUD_TMUX_BIRTH_LINEAGE_FILE), 'utf-8'));
+    const value: unknown = JSON.parse(await readFile(hudTmuxBirthLineagePath(baseStateDir, sessionId), 'utf-8'));
     if (!value || typeof value !== 'object') return null;
     const candidate = value as Partial<HudTmuxBirthLineage>;
     if (

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { delimiter, isAbsolute, join, relative, resolve as resolvePath } from 'path';
 import { existsSync, realpathSync } from 'fs';
-import { readFile, readdir, mkdir, rename, writeFile } from 'fs/promises';
+import { readFile, readdir, mkdir, rename, stat, unlink, writeFile } from 'fs/promises';
 import {
   isSessionStateUsable,
   readUsableSessionState,
@@ -84,12 +84,28 @@ export interface HudTmuxBirthLineage {
   tmuxSessionName: string;
   tmuxSessionInstanceId: string;
   tmuxPaneInstanceId: string;
+  createdAtMs?: number;
+  nonce?: string;
 }
 
 const HUD_TMUX_BIRTH_LINEAGE_DIR = 'hud-tmux-birth-lineage';
 
 function hudTmuxBirthLineagePath(baseStateDir: string, sessionId: string): string {
   return join(baseStateDir, HUD_TMUX_BIRTH_LINEAGE_DIR, `${createHash('sha256').update(sessionId).digest('hex')}.json`);
+}
+
+const HUD_TMUX_BIRTH_LINEAGE_STALE_MS = 24 * 60 * 60 * 1000;
+const HUD_TMUX_BIRTH_LINEAGE_MAX_FILES = 256;
+
+async function cleanupStaleHudTmuxBirthLineage(baseStateDir: string, nowMs: number): Promise<void> {
+  const directory = join(baseStateDir, HUD_TMUX_BIRTH_LINEAGE_DIR);
+  const entries = await readdir(directory, { withFileTypes: true }).catch(() => []);
+  const files = entries.filter((entry) => entry.isFile() && entry.name.endsWith('.json')).slice(0, HUD_TMUX_BIRTH_LINEAGE_MAX_FILES);
+  await Promise.all(files.map(async (entry) => {
+    const path = join(directory, entry.name);
+    const info = await stat(path).catch(() => null);
+    if (info && nowMs - info.mtimeMs > HUD_TMUX_BIRTH_LINEAGE_STALE_MS) await unlink(path).catch(() => undefined);
+  }));
 }
 
 export async function writeHudTmuxBirthLineage(
@@ -102,10 +118,25 @@ export async function writeHudTmuxBirthLineage(
   }
   const directory = join(domain.baseStateDir, HUD_TMUX_BIRTH_LINEAGE_DIR);
   await mkdir(directory, { recursive: true });
+  const nowMs = Date.now();
   const target = hudTmuxBirthLineagePath(domain.baseStateDir, lineage.sessionId);
-  const temporary = `${target}.${process.pid}.${Date.now()}.tmp`;
-  await writeFile(temporary, `${JSON.stringify(lineage)}\n`, { mode: 0o600 });
+  const record = { ...lineage, createdAtMs: nowMs, nonce: `${process.pid}-${nowMs}-${Math.random().toString(36).slice(2)}` };
+  const temporary = `${target}.${record.nonce}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(record)}\n`, { mode: 0o600 });
   await rename(temporary, target);
+  void cleanupStaleHudTmuxBirthLineage(domain.baseStateDir, nowMs);
+}
+
+export async function deleteHudTmuxBirthLineage(
+  domain: Pick<ResolvedHudControlPlaneDomain, 'baseStateDir'>,
+  sessionId: string,
+): Promise<boolean> {
+  try {
+    await unlink(hudTmuxBirthLineagePath(domain.baseStateDir, sessionId));
+    return true;
+  } catch (error: unknown) {
+    return (error as NodeJS.ErrnoException).code === 'ENOENT';
+  }
 }
 
 async function readHudTmuxBirthLineage(baseStateDir: string, sessionId: string | undefined): Promise<HudTmuxBirthLineage | null> {

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { delimiter, isAbsolute, join, relative, resolve as resolvePath } from 'path';
 import { existsSync, realpathSync } from 'fs';
-import { readFile, readdir, mkdir, rename, stat, unlink, writeFile } from 'fs/promises';
+import { readFile, readdir, mkdir, rename, unlink, writeFile } from 'fs/promises';
 import {
   isSessionStateUsable,
   readUsableSessionState,
@@ -94,19 +94,6 @@ function hudTmuxBirthLineagePath(baseStateDir: string, sessionId: string): strin
   return join(baseStateDir, HUD_TMUX_BIRTH_LINEAGE_DIR, `${createHash('sha256').update(sessionId).digest('hex')}.json`);
 }
 
-const HUD_TMUX_BIRTH_LINEAGE_STALE_MS = 24 * 60 * 60 * 1000;
-const HUD_TMUX_BIRTH_LINEAGE_MAX_FILES = 256;
-
-async function cleanupStaleHudTmuxBirthLineage(baseStateDir: string, nowMs: number): Promise<void> {
-  const directory = join(baseStateDir, HUD_TMUX_BIRTH_LINEAGE_DIR);
-  const entries = await readdir(directory, { withFileTypes: true }).catch(() => []);
-  const files = entries.filter((entry) => entry.isFile() && entry.name.endsWith('.json')).slice(0, HUD_TMUX_BIRTH_LINEAGE_MAX_FILES);
-  await Promise.all(files.map(async (entry) => {
-    const path = join(directory, entry.name);
-    const info = await stat(path).catch(() => null);
-    if (info && nowMs - info.mtimeMs > HUD_TMUX_BIRTH_LINEAGE_STALE_MS) await unlink(path).catch(() => undefined);
-  }));
-}
 
 export async function writeHudTmuxBirthLineage(
   domain: Pick<ResolvedHudControlPlaneDomain, 'baseStateDir'>,
@@ -124,15 +111,17 @@ export async function writeHudTmuxBirthLineage(
   const temporary = `${target}.${record.nonce}.tmp`;
   await writeFile(temporary, `${JSON.stringify(record)}\n`, { mode: 0o600 });
   await rename(temporary, target);
-  void cleanupStaleHudTmuxBirthLineage(domain.baseStateDir, nowMs);
 }
 
 export async function deleteHudTmuxBirthLineage(
   domain: Pick<ResolvedHudControlPlaneDomain, 'baseStateDir'>,
-  sessionId: string,
+  lineage: Required<Pick<HudTmuxBirthLineage, 'sessionId' | 'tmuxSessionName' | 'tmuxSessionInstanceId' | 'tmuxPaneInstanceId' | 'createdAtMs' | 'nonce'>>,
 ): Promise<boolean> {
+  const path = hudTmuxBirthLineagePath(domain.baseStateDir, lineage.sessionId);
   try {
-    await unlink(hudTmuxBirthLineagePath(domain.baseStateDir, sessionId));
+    const current: unknown = JSON.parse(await readFile(path, 'utf-8'));
+    if (JSON.stringify(current) !== JSON.stringify(lineage)) return false;
+    await unlink(path);
     return true;
   } catch (error: unknown) {
     return (error as NodeJS.ErrnoException).code === 'ENOENT';

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4010,7 +4010,7 @@ PY`,
       };
       assert.equal(reboundPointer.session_id, canonicalSessionId);
       assert.equal(reboundPointer.native_session_id, nativeSessionId);
-      assert.equal(reboundPointer.owner_omx_session_id, ownerSessionId);
+      assert.equal(reboundPointer.owner_omx_session_id, undefined);
 
       const afterAlias = await dispatchCodexNativeHook(
         {
@@ -4026,6 +4026,7 @@ PY`,
       assert.equal(afterAlias.skillState?.session_id, canonicalSessionId);
       assert.equal(existsSync(join(stateDir, "sessions", canonicalSessionId, "deep-interview-state.json")), true);
       assert.equal(existsSync(join(stateDir, "sessions", ownerSessionId, "deep-interview-state.json")), false);
+      process.env.OMX_SESSION_ID = canonicalSessionId;
 
       const terminalWrite = await executeStateOperation("state_write", {
         mode: "deep-interview",
@@ -4134,7 +4135,7 @@ PY`,
         owner_omx_session_id?: string;
       };
       assert.equal(stalePointer.session_id, "native-stale-3138");
-      assert.equal(stalePointer.owner_omx_session_id, "omx-stale-3138");
+      assert.equal(stalePointer.owner_omx_session_id, undefined);
 
       const foreignCwd = join(root, "foreign");
       const foreignStatePath = join(foreignCwd, ".omx", "state", "session.json");
@@ -10499,29 +10500,52 @@ export async function onHookEvent(event) {
 			const tmuxLog = join(cwd, "tmux.log");
 			await writeFile(
 				join(binDir, "tmux"),
-				`#!/usr/bin/env bash
+`#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\\n' "$*" >> ${JSON.stringify(tmuxLog)}
-case "$1" in
-  list-panes)
-    printf '%%1\\tcodex\\tcodex\\n'
-    ;;
+printf '%s\n' "$*" >> ${JSON.stringify(tmuxLog)}
+cmd="$1"
+shift || true
+case "$cmd" in
   display-message)
-    case "$*" in
-      *'#S') printf 'omx-hud-reconcile\n' ;;
-      *) printf '200\t60\n' ;;
+    target=""
+    fmt=""
+    while [[ "$#" -gt 0 ]]; do
+      case "$1" in
+        -p) shift ;;
+        -t) target="$2"; shift 2 ;;
+        *) fmt="$1"; shift ;;
+      esac
+    done
+    case "$fmt" in
+      '#{session_name}'$'\t''#{session_id}'$'\t''#{window_id}'$'\t''#{pane_id}')
+        printf 'omx-hud-reconcile\t$7\t@3\t%%1\n'
+        ;;
+      '#{session_id}'$'\t''#{window_id}') printf '$7\t@3\n' ;;
+      '#S') printf 'omx-hud-reconcile\n' ;;
     esac
     ;;
   show-option|show-options)
-    case "$*" in
-      *'@omx_pane_instance_id') printf 'sess-hud-1\n' ;;
-    esac
+    target=""
+    pane_scope=0
+    option="\${@: -1}"
+    while [[ "$#" -gt 0 ]]; do
+      case "$1" in
+        -p) pane_scope=1; shift ;;
+        -t) target="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if [[ "$pane_scope" == 1 && ( "$target" == '%1' || "$target" == '%9' ) && "$option" == '@omx_pane_instance_id' ]]; then
+      printf 'sess-hud-1\n'
+    elif [[ "$pane_scope" == 0 && "$target" == 'omx-hud-reconcile' && "$option" == '@omx_instance_id' ]]; then
+      printf 'sess-hud-1\n'
+    fi
     ;;
-  split-window)
-    printf '%%9\\n'
+  list-panes)
+    printf '%%1\x1fcodex\x1f0\x1f0\x1f200\x1f60\x1f59\x1f200\x1f60\x1fsess-hud-1\x1fsess-hud-1\x1fcodex\x1f%s\n' ${JSON.stringify(cwd)}
     ;;
-  resize-pane)
-    ;;
+  split-window) printf '%%9\n' ;;
+  resize-pane) ;;
 esac
 `,
 			);
@@ -10657,30 +10681,53 @@ esac
 			const tmuxLog = join(cwd, "tmux.log");
 			await writeFile(
 				join(binDir, "tmux"),
-				`#!/usr/bin/env bash
+`#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> ${JSON.stringify(tmuxLog)}
-case "$1" in
-  list-panes)
-    printf '%%1\tcodex\tcodex\n'
-    printf '%%2\tnode\texec env OMX_TMUX_HUD_OWNER='"'"'1'"'"' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='"'"'%%1'"'"' /node /omx.js hud --watch\n'
-    ;;
+cmd="$1"
+shift || true
+case "$cmd" in
   display-message)
-    case "$*" in
-      *'#S') printf 'omx-hud-reuse\n' ;;
-      *) printf '200\t60\n' ;;
+    target=""
+    fmt=""
+    while [[ "$#" -gt 0 ]]; do
+      case "$1" in
+        -p) shift ;;
+        -t) target="$2"; shift 2 ;;
+        *) fmt="$1"; shift ;;
+      esac
+    done
+    case "$fmt" in
+      '#{session_name}'$'\t''#{session_id}'$'\t''#{window_id}'$'\t''#{pane_id}')
+        printf 'omx-hud-reuse\t$8\t@4\t%%1\n'
+        ;;
+      '#{session_id}'$'\t''#{window_id}') printf '$8\t@4\n' ;;
+      '#S') printf 'omx-hud-reuse\n' ;;
     esac
     ;;
   show-option|show-options)
-    case "$*" in
-      *'@omx_pane_instance_id') printf 'omx-canonical-hud-reuse\n' ;;
-    esac
+    target=""
+    pane_scope=0
+    option="\${@: -1}"
+    while [[ "$#" -gt 0 ]]; do
+      case "$1" in
+        -p) pane_scope=1; shift ;;
+        -t) target="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if [[ "$pane_scope" == 1 && ( "$target" == '%1' || "$target" == '%9' ) && "$option" == '@omx_pane_instance_id' ]]; then
+      printf 'omx-canonical-hud-reuse\n'
+    elif [[ "$pane_scope" == 0 && "$target" == 'omx-hud-reuse' && "$option" == '@omx_instance_id' ]]; then
+      printf 'omx-canonical-hud-reuse\n'
+    fi
     ;;
-  resize-pane)
+  list-panes)
+    printf '%%1\x1fcodex\x1f0\x1f0\x1f200\x1f60\x1f59\x1f200\x1f60\x1fomx-canonical-hud-reuse\x1fomx-canonical-hud-reuse\x1fcodex\x1f%s\n' ${JSON.stringify(cwd)}
+    printf '%%2\x1fnode\x1f0\x1f60\x1f200\x1f3\x1f62\x1f200\x1f60\x1f\x1f\x1fexec env OMX_TMUX_HUD_OWNER='"'"'1'"'"' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='"'"'%%1'"'"' /node /omx.js hud --watch\x1f%s\n' ${JSON.stringify(cwd)}
     ;;
-  split-window)
-    printf '%%9\n'
-    ;;
+  resize-pane) ;;
+  split-window) printf '%%9\n' ;;
 esac
 `,
 			);

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -10480,6 +10480,10 @@ export async function onHookEvent(event) {
 			process.env.TMUX_PANE = "%1";
 			process.env[OMX_TMUX_HUD_OWNER_ENV] = "1";
 			await mkdir(join(cwd, ".omx", "state"), { recursive: true });
+			await writeSessionStart(cwd, "sess-hud-1", {
+				tmuxSessionName: "omx-hud-reconcile",
+				tmuxPaneId: "%1",
+			});
 			await writeFile(
 				join(cwd, ".omx", "hud-config.json"),
 				JSON.stringify(
@@ -10503,7 +10507,15 @@ case "$1" in
     printf '%%1\\tcodex\\tcodex\\n'
     ;;
   display-message)
-    printf '200\\t60\\n'
+    case "$*" in
+      *'#S') printf 'omx-hud-reconcile\n' ;;
+      *) printf '200\t60\n' ;;
+    esac
+    ;;
+  show-option|show-options)
+    case "$*" in
+      *'@omx_pane_instance_id') printf 'sess-hud-1\n' ;;
+    esac
     ;;
   split-window)
     printf '%%9\\n'
@@ -10618,20 +10630,26 @@ esac
 		}
 	});
 
-  it("recreates a leader-only HUD pane when UserPromptSubmit revives with the canonical session id", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-hud-reuse-"));
-    const originalTmux = process.env.TMUX;
-    const originalTmuxPane = process.env.TMUX_PANE;
-    const originalPath = process.env.PATH;
-    const originalHudOwner = process.env[OMX_TMUX_HUD_OWNER_ENV];
-    try {
-      process.env.TMUX = "1";
-      process.env.TMUX_PANE = "%1";
-      process.env[OMX_TMUX_HUD_OWNER_ENV] = "1";
-      const canonicalSessionId = "omx-canonical-hud-reuse";
-      const nativeSessionId = "codex-native-hud-reuse";
-      await mkdir(join(cwd, ".omx", "state", "sessions", canonicalSessionId), { recursive: true });
-      await writeSessionStart(cwd, canonicalSessionId, { nativeSessionId });
+	it("recreates a leader-only HUD pane when UserPromptSubmit revives with the canonical session id", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-hud-reuse-"));
+		const originalTmux = process.env.TMUX;
+		const originalTmuxPane = process.env.TMUX_PANE;
+		const originalPath = process.env.PATH;
+		const originalHudOwner = process.env[OMX_TMUX_HUD_OWNER_ENV];
+		try {
+			process.env.TMUX = "1";
+			process.env.TMUX_PANE = "%1";
+			process.env[OMX_TMUX_HUD_OWNER_ENV] = "1";
+			const canonicalSessionId = "omx-canonical-hud-reuse";
+			const nativeSessionId = "codex-native-hud-reuse";
+			await mkdir(join(cwd, ".omx", "state", "sessions", canonicalSessionId), {
+				recursive: true,
+			});
+			await writeSessionStart(cwd, canonicalSessionId, {
+				nativeSessionId,
+				tmuxSessionName: "omx-hud-reuse",
+				tmuxPaneId: "%1",
+			});
 
 			const binDir = await mkdtemp(
 				join(tmpdir(), "omx-native-hook-hud-reuse-bin-"),
@@ -10648,7 +10666,15 @@ case "$1" in
     printf '%%2\tnode\texec env OMX_TMUX_HUD_OWNER='"'"'1'"'"' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='"'"'%%1'"'"' /node /omx.js hud --watch\n'
     ;;
   display-message)
-    printf '200\t60\n'
+    case "$*" in
+      *'#S') printf 'omx-hud-reuse\n' ;;
+      *) printf '200\t60\n' ;;
+    esac
+    ;;
+  show-option|show-options)
+    case "$*" in
+      *'@omx_pane_instance_id') printf 'omx-canonical-hud-reuse\n' ;;
+    esac
     ;;
   resize-pane)
     ;;

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -10503,6 +10503,9 @@ export async function onHookEvent(event) {
 `#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> ${JSON.stringify(tmuxLog)}
+log_file=${JSON.stringify(tmuxLog)}
+state_dir="$log_file.state"
+mkdir -p "$state_dir"
 cmd="$1"
 shift || true
 case "$cmd" in
@@ -10524,6 +10527,20 @@ case "$cmd" in
       '#S') printf 'omx-hud-reconcile\n' ;;
     esac
     ;;
+  set-option)
+    target=""
+    pane_scope=0
+    val="\${@: -1}"
+    opt="\${@: -2:1}"
+    while [[ "$#" -gt 0 ]]; do
+      case "$1" in
+        -p) pane_scope=1; shift ;;
+        -t) target="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if [[ "$pane_scope" == 1 && -n "$target" ]]; then printf '%s' "$val" > "$state_dir/\${target}_\${opt}"; fi
+    ;;
   show-option|show-options)
     target=""
     pane_scope=0
@@ -10535,7 +10552,9 @@ case "$cmd" in
         *) shift ;;
       esac
     done
-    if [[ "$pane_scope" == 1 && ( "$target" == '%1' || "$target" == '%9' ) && "$option" == '@omx_pane_instance_id' ]]; then
+    if [[ "$pane_scope" == 1 && -n "$target" && -f "$state_dir/\${target}_\${option}" ]]; then
+      cat "$state_dir/\${target}_\${option}"
+    elif [[ "$pane_scope" == 1 && "$target" == '%1' && "$option" == '@omx_pane_instance_id' ]]; then
       printf 'sess-hud-1\n'
     elif [[ "$pane_scope" == 0 && "$target" == 'omx-hud-reconcile' && "$option" == '@omx_instance_id' ]]; then
       printf 'sess-hud-1\n'
@@ -10684,6 +10703,9 @@ esac
 `#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> ${JSON.stringify(tmuxLog)}
+log_file=${JSON.stringify(tmuxLog)}
+state_dir="$log_file.state"
+mkdir -p "$state_dir"
 cmd="$1"
 shift || true
 case "$cmd" in
@@ -10705,6 +10727,20 @@ case "$cmd" in
       '#S') printf 'omx-hud-reuse\n' ;;
     esac
     ;;
+  set-option)
+    target=""
+    pane_scope=0
+    val="\${@: -1}"
+    opt="\${@: -2:1}"
+    while [[ "$#" -gt 0 ]]; do
+      case "$1" in
+        -p) pane_scope=1; shift ;;
+        -t) target="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if [[ "$pane_scope" == 1 && -n "$target" ]]; then printf '%s' "$val" > "$state_dir/\${target}_\${opt}"; fi
+    ;;
   show-option|show-options)
     target=""
     pane_scope=0
@@ -10716,7 +10752,9 @@ case "$cmd" in
         *) shift ;;
       esac
     done
-    if [[ "$pane_scope" == 1 && ( "$target" == '%1' || "$target" == '%9' ) && "$option" == '@omx_pane_instance_id' ]]; then
+    if [[ "$pane_scope" == 1 && -n "$target" && -f "$state_dir/\${target}_\${option}" ]]; then
+      cat "$state_dir/\${target}_\${option}"
+    elif [[ "$pane_scope" == 1 && "$target" == '%1' && "$option" == '@omx_pane_instance_id' ]]; then
       printf 'omx-canonical-hud-reuse\n'
     elif [[ "$pane_scope" == 0 && "$target" == 'omx-hud-reuse' && "$option" == '@omx_instance_id' ]]; then
       printf 'omx-canonical-hud-reuse\n'

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -36,7 +36,7 @@ import {
 } from '../subagents/tracker.js';
 import { listNotifyCanonicalActiveTeams } from './notify-hook/active-team.js';
 import { sameFilePath } from '../utils/paths.js';
-import { validateSessionId } from '../mcp/state-paths.js';
+import { resolveHudControlPlaneDomain, validateSessionId } from '../mcp/state-paths.js';
 import { TEAM_NAME_SAFE_PATTERN } from '../team/contracts.js';
 import { shouldContinueRun } from '../runtime/run-loop.js';
 import { deliverNotifyFallback, compactNotifyFallbackDeliveries, NOTIFY_FALLBACK_LEASE_MS } from './notify-fallback-delivery.js';
@@ -108,14 +108,7 @@ async function writeJsonObjectAtomically(path: string, value: unknown): Promise<
   }
 }
 
-async function waitForPidExit(pid: number, timeoutMs = 3000, stepMs = 50): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (!isPidAlive(pid)) return true;
-    await sleep(stepMs);
-  }
-  return !isPidAlive(pid);
-}
+
 
 const cwd = resolve(argValue('--cwd', process.cwd()));
 const notifyScript = resolve(argValue('--notify-script', join(cwd, 'dist', 'scripts', 'notify-hook.js')));
@@ -146,10 +139,13 @@ const authorityLifetimeMs = runOnce
   : Math.min(Math.max(pollMs, configuredMaxLifetimeMs), 24 * 60 * 60 * 1000);
 const authorityDeadlineAtMs = startedAt + authorityLifetimeMs;
 
-const runtimeRoot = resolve(process.env.OMX_ROOT || process.env.OMX_STATE_ROOT || cwd);
-const omxDir = join(runtimeRoot, '.omx');
+const configuredStateRoot = safeString(process.env.OMX_TEAM_STATE_ROOT).trim();
+const runtimeRoot = configuredStateRoot
+  ? resolve(configuredStateRoot)
+  : resolve(process.env.OMX_ROOT || process.env.OMX_STATE_ROOT || cwd);
+const omxDir = configuredStateRoot ? dirname(runtimeRoot) : join(runtimeRoot, '.omx');
 const logsDir = join(omxDir, 'logs');
-const stateDir = join(omxDir, 'state');
+const stateDir = configuredStateRoot ? runtimeRoot : join(omxDir, 'state');
 const statePath = join(stateDir, 'notify-fallback-state.json');
 const pidFilePath = resolve(argValue('--pid-file', join(stateDir, 'notify-fallback.pid')));
 const logPath = join(logsDir, `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
@@ -943,16 +939,21 @@ async function readPidFileRecord(path: string): Promise<PidFileRecord | null> {
   const trimmed = raw.trim();
   if (!trimmed) return null;
   try {
-    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
-    const pid = parsePositivePid(parsed.pid);
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      const pid = parsePositivePid(parsed);
+      return pid === null ? null : { pid };
+    }
+    const record = parsed as Record<string, unknown>;
+    const pid = parsePositivePid(record.pid);
     if (pid === null) return null;
     return {
       pid,
-      parent_pid: parsePositivePid(parsed.parent_pid) ?? undefined,
-      cwd: safeString(parsed.cwd) || undefined,
-      started_at: safeString(parsed.started_at) || undefined,
-      max_lifetime_ms: asNumber(parsed.max_lifetime_ms as string | number | undefined, 0) || undefined,
-      owner_token: safeString(parsed.owner_token) || undefined,
+      parent_pid: parsePositivePid(record.parent_pid) ?? undefined,
+      cwd: safeString(record.cwd) || undefined,
+      started_at: safeString(record.started_at) || undefined,
+      max_lifetime_ms: asNumber(record.max_lifetime_ms as string | number | undefined, 0) || undefined,
+      owner_token: safeString(record.owner_token) || undefined,
     };
   } catch {
     const pid = parsePositivePid(trimmed);
@@ -1280,40 +1281,25 @@ async function runRalphWatcherBehaviorTick(): Promise<void> {
   }
 }
 
-async function registerPidFile(): Promise<void> {
-  if (runOnce) return;
+async function registerPidFile(): Promise<boolean> {
+  if (runOnce) return true;
   await mkdir(dirname(pidFilePath), { recursive: true }).catch(() => {});
 
   const existingRecord = await readPidFileRecord(pidFilePath).catch(() => null);
-  const existingPid = existingRecord?.pid ?? null;
-  if (existingPid && existingPid !== process.pid && isPidAlive(existingPid)) {
-    try {
-      process.kill(existingPid, 'SIGTERM');
-      const exitedGracefully = await waitForPidExit(existingPid);
-      let forced = false;
-      if (!exitedGracefully && isPidAlive(existingPid)) {
-        forced = true;
-        process.kill(existingPid, 'SIGKILL');
-        await waitForPidExit(existingPid, 1000, 25);
-      }
-      await eventLog({
-        type: 'watcher_stale_pid_reaped',
-        stale_pid: existingPid,
-        pid_file: pidFilePath,
-        forced,
-      });
-    } catch (error) {
-      await eventLog({
-        type: 'watcher_stale_pid_reap_failed',
-        stale_pid: existingPid,
-        pid_file: pidFilePath,
-        error: error instanceof Error ? error.message : safeString(error),
-      });
-    }
+  if (existingRecord && existingRecord.pid !== process.pid && isPidAlive(existingRecord.pid)) {
+    await eventLog({
+      type: 'watcher_registration_blocked',
+      reason: 'live_pid_record',
+      existing_pid: existingRecord.pid,
+      pid_file: pidFilePath,
+    });
+    return false;
   }
 
   await writePidFileRecord();
+  return true;
 }
+
 
 async function removePidFileIfOwned(): Promise<void> {
   if (runOnce) return;
@@ -2054,10 +2040,70 @@ function shutdown(signal: string): void {
   void requestShutdown('signal', signal);
 }
 
+interface HudAuthorityLeaseRecord {
+  version: 2;
+  domainKey: string;
+  baseStateDir: string;
+  rootSource: string;
+  pid: number;
+  platform: string;
+  processStartIdentity: string;
+  claimant: string;
+  token: string;
+  generation: string;
+  heartbeatAt: string;
+}
+
+function isHudAuthorityLeaseRecord(value: unknown): value is HudAuthorityLeaseRecord {
+  if (!value || typeof value !== 'object') return false;
+  const lease = value as Partial<HudAuthorityLeaseRecord>;
+  return lease.version === 2
+    && typeof lease.domainKey === 'string' && lease.domainKey.length > 0
+    && typeof lease.baseStateDir === 'string' && lease.baseStateDir.length > 0
+    && typeof lease.rootSource === 'string' && lease.rootSource.length > 0
+    && typeof lease.pid === 'number' && Number.isInteger(lease.pid) && lease.pid > 0
+    && typeof lease.platform === 'string' && lease.platform.length > 0
+    && typeof lease.processStartIdentity === 'string' && lease.processStartIdentity.trim().length > 0
+    && typeof lease.claimant === 'string'
+    && typeof lease.token === 'string' && lease.token.length > 0
+    && typeof lease.generation === 'string' && lease.generation.length > 0
+    && parseIsoMillis(lease.heartbeatAt) !== null;
+}
+
+async function isAdmittedHudAuthorityWatcher(): Promise<boolean> {
+  if (!authorityOnly) return true;
+  const expectedDomainKey = safeString(process.env.OMX_HUD_AUTHORITY_DOMAIN_KEY);
+  const expectedBaseStateDir = safeString(process.env.OMX_HUD_AUTHORITY_BASE_STATE_DIR);
+  const expectedRootSource = safeString(process.env.OMX_HUD_AUTHORITY_ROOT_SOURCE);
+  const expectedLeasePath = safeString(process.env.OMX_HUD_AUTHORITY_LEASE_PATH);
+  const expectedToken = safeString(process.env.OMX_HUD_AUTHORITY_LEASE_TOKEN);
+  const expectedGeneration = safeString(process.env.OMX_HUD_AUTHORITY_LEASE_GENERATION);
+  const expectedPid = parsePositivePid(process.env.OMX_HUD_AUTHORITY_OWNER_PID);
+  const expectedPlatform = safeString(process.env.OMX_HUD_AUTHORITY_OWNER_PLATFORM);
+  const expectedStartIdentity = safeString(process.env.OMX_HUD_AUTHORITY_OWNER_START_IDENTITY);
+  if (!expectedDomainKey || !expectedBaseStateDir || !expectedRootSource || !expectedLeasePath
+    || !expectedToken || !expectedGeneration || !expectedPid || !expectedPlatform || !expectedStartIdentity) return false;
+  const domain = await resolveHudControlPlaneDomain({ cwd, env: process.env }).catch(() => null);
+  if (!domain || domain.domainKey !== expectedDomainKey || !sameFilePath(domain.baseStateDir, expectedBaseStateDir)
+    || domain.rootSource !== expectedRootSource || !sameFilePath(domain.authorityLeasePath, expectedLeasePath)) return false;
+  const lease = await readFile(expectedLeasePath, 'utf8').then((text) => JSON.parse(text) as unknown).catch(() => null);
+  if (!isHudAuthorityLeaseRecord(lease)) return false;
+  return lease.domainKey === domain.domainKey
+    && sameFilePath(lease.baseStateDir, domain.baseStateDir)
+    && lease.rootSource === domain.rootSource
+    && lease.pid === expectedPid
+    && lease.platform === expectedPlatform
+    && lease.token === expectedToken
+    && lease.generation === expectedGeneration
+    && lease.processStartIdentity === expectedStartIdentity
+    && process.ppid === expectedPid;
+}
+
 async function main(): Promise<void> {
   if (process.env.NODE_ENV === 'test' && process.env.OMX_NOTIFY_FALLBACK_TEST_FATAL === '1') {
     throw new Error('test fatal notify fallback failure');
   }
+  if (!(await isAdmittedHudAuthorityWatcher())) return;
   await mkdir(logsDir, { recursive: true }).catch(() => {});
   await mkdir(stateDir, { recursive: true }).catch(() => {});
   if (!existsSync(notifyScript)) {
@@ -2067,7 +2113,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  await registerPidFile();
+  if (!(await registerPidFile())) return;
   await loadPersistedWatcherState();
   if (!(runOnce && authorityOnly)) {
     await eventLog({

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -26,7 +26,7 @@ import {
   maybeNudgeTeamLeader,
   resolveLeaderStalenessThresholdMs,
 } from './notify-hook/team-leader-nudge.js';
-import { resolveManagedPaneFromAnchor, resolveManagedSessionPane } from './notify-hook/managed-tmux.js';
+import { probeActualTmuxInstanceEvidence, resolveManagedPaneFromAnchor, resolveManagedSessionPane } from './notify-hook/managed-tmux.js';
 import { DEFAULT_MARKER } from './tmux-hook-engine.js';
 import { isTerminalPhase } from './notify-hook/utils.js';
 import { isSessionStale, isSessionStateAuthoritativeForCwd, readSessionState } from '../hooks/session.js';
@@ -2070,6 +2070,43 @@ function isHudAuthorityLeaseRecord(value: unknown): value is HudAuthorityLeaseRe
     && parseIsoMillis(lease.heartbeatAt) !== null;
 }
 
+interface HudAuthorityClaimant {
+  sessionId: string;
+  leaderPaneId: string;
+  tmuxSessionName: string;
+  tmuxSessionInstanceId: string;
+  tmuxPaneInstanceId: string;
+}
+
+function parseHudAuthorityClaimant(value: string): HudAuthorityClaimant | null {
+  try {
+    const claimant: unknown = JSON.parse(value);
+    if (!claimant || typeof claimant !== 'object') return null;
+    const record = claimant as Partial<HudAuthorityClaimant>;
+    return typeof record.sessionId === 'string' && record.sessionId.trim()
+      && typeof record.leaderPaneId === 'string' && record.leaderPaneId.trim()
+      && typeof record.tmuxSessionName === 'string' && record.tmuxSessionName.trim()
+      && typeof record.tmuxSessionInstanceId === 'string' && record.tmuxSessionInstanceId.trim()
+      && typeof record.tmuxPaneInstanceId === 'string' && record.tmuxPaneInstanceId.trim()
+      ? record as HudAuthorityClaimant
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function hasExactLiveHudAuthorityClaimant(domain: Awaited<ReturnType<typeof resolveHudControlPlaneDomain>>, claimant: HudAuthorityClaimant): Promise<boolean> {
+  if (JSON.stringify(domain.claimant) !== JSON.stringify(claimant)) return false;
+  const evidence = await probeActualTmuxInstanceEvidence(claimant.leaderPaneId);
+  return evidence.contextStable
+    && evidence.paneTarget === claimant.leaderPaneId
+    && evidence.sessionName === claimant.tmuxSessionName
+    && evidence.paneTagStatus === 'present'
+    && evidence.sessionTagStatus === 'present'
+    && evidence.paneInstanceId === claimant.tmuxPaneInstanceId
+    && evidence.sessionInstanceId === claimant.tmuxSessionInstanceId;
+}
+
 async function isAdmittedHudAuthorityWatcher(): Promise<boolean> {
   if (!authorityOnly) return true;
   const expectedDomainKey = safeString(process.env.OMX_HUD_AUTHORITY_DOMAIN_KEY);
@@ -2081,13 +2118,18 @@ async function isAdmittedHudAuthorityWatcher(): Promise<boolean> {
   const expectedPid = parsePositivePid(process.env.OMX_HUD_AUTHORITY_OWNER_PID);
   const expectedPlatform = safeString(process.env.OMX_HUD_AUTHORITY_OWNER_PLATFORM);
   const expectedStartIdentity = safeString(process.env.OMX_HUD_AUTHORITY_OWNER_START_IDENTITY);
+  const expectedClaimant = safeString(process.env.OMX_HUD_AUTHORITY_CLAIMANT);
   if (!expectedDomainKey || !expectedBaseStateDir || !expectedRootSource || !expectedLeasePath
-    || !expectedToken || !expectedGeneration || !expectedPid || !expectedPlatform || !expectedStartIdentity) return false;
+    || !expectedToken || !expectedGeneration || !expectedPid || !expectedPlatform || !expectedStartIdentity || !expectedClaimant) return false;
   const domain = await resolveHudControlPlaneDomain({ cwd, env: process.env }).catch(() => null);
   if (!domain || domain.domainKey !== expectedDomainKey || !sameFilePath(domain.baseStateDir, expectedBaseStateDir)
     || domain.rootSource !== expectedRootSource || !sameFilePath(domain.authorityLeasePath, expectedLeasePath)) return false;
   const lease = await readFile(expectedLeasePath, 'utf8').then((text) => JSON.parse(text) as unknown).catch(() => null);
-  if (!isHudAuthorityLeaseRecord(lease)) return false;
+  if (!isHudAuthorityLeaseRecord(lease) || lease.claimant !== expectedClaimant) return false;
+  if (domain.managed) {
+    const claimant = parseHudAuthorityClaimant(expectedClaimant);
+    if (!claimant || !(await hasExactLiveHudAuthorityClaimant(domain, claimant).catch(() => false))) return false;
+  }
   return lease.domainKey === domain.domainKey
     && sameFilePath(lease.baseStateDir, domain.baseStateDir)
     && lease.rootSource === domain.rootSource

--- a/src/scripts/notify-hook/__tests__/managed-tmux.test.ts
+++ b/src/scripts/notify-hook/__tests__/managed-tmux.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import { resolveHudControlPlaneDomain, writeHudTmuxBirthLineage } from '../../../mcp/state-paths.js';
 import { writeSessionStart } from '../../../hooks/session.js';
-import { isManagedOmxSession } from '../managed-tmux.js';
+import { isManagedOmxSession, tmuxEvidenceBindsCandidate } from '../managed-tmux.js';
 
 describe('managed tmux opaque birth lineage', () => {
   it('authorizes Team-established opaque UUID lineage through production resolution only with stable dual tags', async () => {
@@ -55,5 +55,18 @@ esac
       else process.env.TMUX = previousTmux;
       await rm(cwd, { recursive: true, force: true });
     }
+  });
+
+  it('accepts identical canonical tags despite additional resolver-proven aliases', () => {
+    assert.equal(tmuxEvidenceBindsCandidate({
+      paneTarget: '%1', sessionName: 'session', paneInstanceId: 'canonical', sessionInstanceId: 'canonical',
+      instanceId: 'canonical', source: 'pane', paneTagStatus: 'present', sessionTagStatus: 'present',
+      sessionId: '$1', windowId: '@1', contextStable: true,
+    }, ['canonical', 'native', 'previous']), true);
+    assert.equal(tmuxEvidenceBindsCandidate({
+      paneTarget: '%1', sessionName: 'session', paneInstanceId: 'native', sessionInstanceId: 'previous',
+      instanceId: 'native', source: 'pane', paneTagStatus: 'present', sessionTagStatus: 'present',
+      sessionId: '$1', windowId: '@1', contextStable: true,
+    }, ['canonical', 'native', 'previous']), false);
   });
 });

--- a/src/scripts/notify-hook/__tests__/managed-tmux.test.ts
+++ b/src/scripts/notify-hook/__tests__/managed-tmux.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { resolveHudControlPlaneDomain, writeHudTmuxBirthLineage } from '../../../mcp/state-paths.js';
+import { isManagedOmxSession } from '../managed-tmux.js';
+
+describe('managed tmux opaque birth lineage', () => {
+  it('authorizes Team-established opaque UUID lineage through production resolution only with stable dual tags', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-managed-tmux-lineage-'));
+    const binDir = join(cwd, 'bin');
+    const previousPath = process.env.PATH;
+    const previousTmuxPane = process.env.TMUX_PANE;
+    const previousTmux = process.env.TMUX;
+    const sessionId = 'team-logical-session';
+    const sessionBirthId = '7d667f3f-4c4b-4e80-8ea5-050ba1dbfe1f';
+    const paneBirthId = '388b3d25-c797-4223-bb30-3eb3511e4101';
+    try {
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(cwd, '.omx', 'state', 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        cwd,
+        pid: process.pid,
+        started_at: new Date().toISOString(),
+      }));
+      const domain = await resolveHudControlPlaneDomain({ cwd, requestedSessionId: sessionId });
+      await writeHudTmuxBirthLineage(domain, {
+        sessionId,
+        tmuxSessionName: 'team-session',
+        tmuxSessionInstanceId: sessionBirthId,
+        tmuxPaneInstanceId: paneBirthId,
+      });
+      await mkdir(binDir, { recursive: true });
+      await writeFile(join(binDir, 'tmux'), `#!/bin/sh
+case "$1" in
+display-message) printf 'team-session\t$1\t@1\t%%1\n' ;;
+show-option) printf '${paneBirthId}\n' ;;
+show-options) printf '${sessionBirthId}\n' ;;
+*) exit 1 ;;
+esac
+`);
+      await chmod(join(binDir, 'tmux'), 0o755);
+      process.env.PATH = `${binDir}:${previousPath ?? ''}`;
+      process.env.TMUX = 'fake,1,0';
+      process.env.TMUX_PANE = '%1';
+
+      assert.equal(await isManagedOmxSession(cwd, { session_id: sessionId }, { allowTeamWorker: false }), true);
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      if (previousTmuxPane === undefined) delete process.env.TMUX_PANE;
+      else process.env.TMUX_PANE = previousTmuxPane;
+      if (previousTmux === undefined) delete process.env.TMUX;
+      else process.env.TMUX = previousTmux;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/scripts/notify-hook/__tests__/managed-tmux.test.ts
+++ b/src/scripts/notify-hook/__tests__/managed-tmux.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import { resolveHudControlPlaneDomain, writeHudTmuxBirthLineage } from '../../../mcp/state-paths.js';
+import { writeSessionStart } from '../../../hooks/session.js';
 import { isManagedOmxSession } from '../managed-tmux.js';
 
 describe('managed tmux opaque birth lineage', () => {
@@ -17,13 +18,7 @@ describe('managed tmux opaque birth lineage', () => {
     const sessionBirthId = '7d667f3f-4c4b-4e80-8ea5-050ba1dbfe1f';
     const paneBirthId = '388b3d25-c797-4223-bb30-3eb3511e4101';
     try {
-      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
-      await writeFile(join(cwd, '.omx', 'state', 'session.json'), JSON.stringify({
-        session_id: sessionId,
-        cwd,
-        pid: process.pid,
-        started_at: new Date().toISOString(),
-      }));
+      await writeSessionStart(cwd, sessionId);
       const domain = await resolveHudControlPlaneDomain({ cwd, requestedSessionId: sessionId });
       await writeHudTmuxBirthLineage(domain, {
         sessionId,
@@ -35,8 +30,13 @@ describe('managed tmux opaque birth lineage', () => {
       await writeFile(join(binDir, 'tmux'), `#!/bin/sh
 case "$1" in
 display-message) printf 'team-session\t$1\t@1\t%%1\n' ;;
-show-option) printf '${paneBirthId}\n' ;;
-show-options) printf '${sessionBirthId}\n' ;;
+show-option)
+  case "$*" in
+    *"-p -t %1 @omx_pane_instance_id"*) printf '${paneBirthId}\n' ;;
+    *"-t team-session @omx_instance_id"*) printf '${sessionBirthId}\n' ;;
+    *) exit 1 ;;
+  esac
+  ;;
 *) exit 1 ;;
 esac
 `);

--- a/src/scripts/notify-hook/__tests__/managed-tmux.test.ts
+++ b/src/scripts/notify-hook/__tests__/managed-tmux.test.ts
@@ -57,16 +57,18 @@ esac
     }
   });
 
-  it('accepts identical canonical tags despite additional resolver-proven aliases', () => {
-    assert.equal(tmuxEvidenceBindsCandidate({
-      paneTarget: '%1', sessionName: 'session', paneInstanceId: 'canonical', sessionInstanceId: 'canonical',
-      instanceId: 'canonical', source: 'pane', paneTagStatus: 'present', sessionTagStatus: 'present',
+  it('admits every identical resolver-proven alias while restricting mixed tags to explicit pairs', () => {
+    const evidence = (paneInstanceId: string, sessionInstanceId: string) => ({
+      paneTarget: '%1', sessionName: 'session', paneInstanceId, sessionInstanceId,
+      instanceId: paneInstanceId, source: 'pane' as const, paneTagStatus: 'present' as const, sessionTagStatus: 'present' as const,
       sessionId: '$1', windowId: '@1', contextStable: true,
-    }, ['canonical', 'native', 'previous']), true);
-    assert.equal(tmuxEvidenceBindsCandidate({
-      paneTarget: '%1', sessionName: 'session', paneInstanceId: 'native', sessionInstanceId: 'previous',
-      instanceId: 'native', source: 'pane', paneTagStatus: 'present', sessionTagStatus: 'present',
-      sessionId: '$1', windowId: '@1', contextStable: true,
-    }, ['canonical', 'native', 'previous']), false);
+    });
+    const resolverLineage = ['canonical', 'native', 'previous'] as const;
+    assert.equal(tmuxEvidenceBindsCandidate(evidence('canonical', 'canonical'), resolverLineage), true);
+    assert.equal(tmuxEvidenceBindsCandidate(evidence('native', 'native'), resolverLineage), true);
+    assert.equal(tmuxEvidenceBindsCandidate(evidence('previous', 'previous'), resolverLineage), true);
+    assert.equal(tmuxEvidenceBindsCandidate(evidence('unknown', 'unknown'), resolverLineage), false);
+    assert.equal(tmuxEvidenceBindsCandidate(evidence('native', 'previous'), resolverLineage), false);
+    assert.equal(tmuxEvidenceBindsCandidate(evidence('canonical', 'native'), ['canonical', 'native']), true);
   });
 });

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -209,8 +209,7 @@ export function tmuxEvidenceBindsCandidate(
     || evidence.sessionTagStatus !== 'present'
   ) return false;
 
-  const canonicalId = acceptedSessionIds[0];
-  if (evidence.paneInstanceId === canonicalId && evidence.sessionInstanceId === canonicalId) return true;
+  if (acceptedSessionIds.includes(evidence.paneInstanceId) && evidence.paneInstanceId === evidence.sessionInstanceId) return true;
   // Only an explicit canonical/native pair may prove a mixed-tag lineage. Extra
   // resolver-proven aliases do not expand that pairwise authorization.
   if (acceptedSessionIds.length !== 2) return false;

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -197,17 +197,27 @@ export function tmuxEvidenceBindsCandidate(
   evidence: ActualTmuxInstanceEvidence,
   candidateSessionIds: string | readonly string[],
 ): boolean {
-  const acceptedSessionIds = new Set(
+  const acceptedSessionIds = [...new Set(
     (typeof candidateSessionIds === 'string' ? [candidateSessionIds] : candidateSessionIds)
       .map((candidate) => safeString(candidate).trim())
       .filter(Boolean),
-  );
-  return acceptedSessionIds.size > 0
-    && evidence.contextStable
-    && evidence.paneTagStatus === 'present'
-    && evidence.sessionTagStatus === 'present'
-    && acceptedSessionIds.has(evidence.paneInstanceId)
-    && acceptedSessionIds.has(evidence.sessionInstanceId);
+  )];
+  if (
+    !evidence.contextStable
+    || evidence.paneTagStatus !== 'present'
+    || evidence.sessionTagStatus !== 'present'
+  ) return false;
+
+  if (acceptedSessionIds.length === 1) {
+    return evidence.paneInstanceId === acceptedSessionIds[0]
+      && evidence.sessionInstanceId === acceptedSessionIds[0];
+  }
+  // A canonical/native alias pair is one resolver-proven lineage. Do not turn
+  // a broader list of aliases into a Cartesian pane/session authorization.
+  if (acceptedSessionIds.length !== 2) return false;
+  const [firstId, secondId] = acceptedSessionIds;
+  return (evidence.paneInstanceId === firstId && evidence.sessionInstanceId === secondId)
+    || (evidence.paneInstanceId === secondId && evidence.sessionInstanceId === firstId);
 }
 
 

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -209,12 +209,10 @@ export function tmuxEvidenceBindsCandidate(
     || evidence.sessionTagStatus !== 'present'
   ) return false;
 
-  if (acceptedSessionIds.length === 1) {
-    return evidence.paneInstanceId === acceptedSessionIds[0]
-      && evidence.sessionInstanceId === acceptedSessionIds[0];
-  }
-  // A canonical/native alias pair is one resolver-proven lineage. Do not turn
-  // a broader list of aliases into a Cartesian pane/session authorization.
+  const canonicalId = acceptedSessionIds[0];
+  if (evidence.paneInstanceId === canonicalId && evidence.sessionInstanceId === canonicalId) return true;
+  // Only an explicit canonical/native pair may prove a mixed-tag lineage. Extra
+  // resolver-proven aliases do not expand that pairwise authorization.
   if (acceptedSessionIds.length !== 2) return false;
   const [firstId, secondId] = acceptedSessionIds;
   return (evidence.paneInstanceId === firstId && evidence.sessionInstanceId === secondId)

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -195,15 +195,19 @@ export async function probeActualTmuxInstanceEvidence(paneTarget?: string): Prom
 
 export function tmuxEvidenceBindsCandidate(
   evidence: ActualTmuxInstanceEvidence,
-  candidateSessionId: string,
+  candidateSessionIds: string | readonly string[],
 ): boolean {
-  const candidate = safeString(candidateSessionId).trim();
-  if (!candidate) return false;
-  return evidence.contextStable
+  const acceptedSessionIds = new Set(
+    (typeof candidateSessionIds === 'string' ? [candidateSessionIds] : candidateSessionIds)
+      .map((candidate) => safeString(candidate).trim())
+      .filter(Boolean),
+  );
+  return acceptedSessionIds.size > 0
+    && evidence.contextStable
     && evidence.paneTagStatus === 'present'
     && evidence.sessionTagStatus === 'present'
-    && evidence.paneInstanceId === candidate
-    && evidence.sessionInstanceId === candidate;
+    && acceptedSessionIds.has(evidence.paneInstanceId)
+    && acceptedSessionIds.has(evidence.sessionInstanceId);
 }
 
 

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -6,6 +6,7 @@ import { runProcess } from './process-runner.js';
 import { safeString } from './utils.js';
 import { sameFilePath } from '../../utils/paths.js';
 import type { ResolvedPromptTurnContext } from '../../hooks/prompt-session-provenance.js';
+import { resolveHudControlPlaneDomain } from '../../mcp/state-paths.js';
 
 
 const OMX_INSTANCE_OPTION = '@omx_instance_id';
@@ -336,9 +337,39 @@ export async function resolveManagedSessionContext(
         canonicalSessionId || invocationSessionId,
       );
     const evidence = await probeActualTmuxInstanceEvidence(paneTarget);
+    const birthDomain = await resolveHudControlPlaneDomain({
+      cwd: authoritativeSessionCwd,
+      requestedSessionId: canonicalSessionId || invocationSessionId,
+      env: { ...process.env, OMX_TMUX_SESSION_INSTANCE_ID: undefined, OMX_TMUX_PANE_INSTANCE_ID: undefined },
+    }).catch(() => null);
+    const birthEvidenceMatches = Boolean(
+      birthDomain
+      && evidence.contextStable
+      && evidence.paneTagStatus === 'present'
+      && evidence.sessionTagStatus === 'present'
+      && evidence.sessionName === birthDomain.claimant.tmuxSessionName
+      && evidence.paneInstanceId === birthDomain.claimant.tmuxPaneInstanceId
+      && evidence.sessionInstanceId === birthDomain.claimant.tmuxSessionInstanceId,
+    );
     const currentTmuxSessionName = evidence.sessionName || readCurrentTmuxSessionName();
     const currentTmuxPaneTarget = evidence.paneTarget;
     const currentTmuxPaneInstanceId = evidence.paneInstanceId;
+    if (birthEvidenceMatches) {
+      return {
+        managed: true,
+        reason: 'tmux_birth_lineage_match',
+        invocationSessionId,
+        canonicalSessionId,
+        nativeSessionId,
+        sessionState,
+        expectedTmuxSessionName,
+        currentTmuxSessionName,
+        currentTmuxPaneTarget,
+        currentTmuxPaneInstanceId,
+        currentTmuxInstanceId: evidence.sessionInstanceId,
+        taggedTmuxSessionName: currentTmuxSessionName,
+      };
+    }
     if (currentTmuxPaneInstanceId && currentTmuxPaneInstanceId !== invocationSessionId) {
       return {
         managed: false,

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -89,6 +89,27 @@ interface TmuxOptionProbe {
   value: string;
 }
 
+interface TmuxPaneContext {
+  sessionName: string;
+  sessionId: string;
+  windowId: string;
+  paneId: string;
+}
+
+async function readTmuxPaneContext(paneTarget: string): Promise<TmuxPaneContext | null> {
+  try {
+    const result = await runProcess(
+      'tmux',
+      ['display-message', '-p', '-t', paneTarget, '#{session_name}\t#{session_id}\t#{window_id}\t#{pane_id}'],
+      2000,
+    );
+    const [sessionName = '', sessionId = '', windowId = '', paneId = ''] = safeString(result.stdout).trim().split('\t');
+    return { sessionName: sessionName.trim(), sessionId: sessionId.trim(), windowId: windowId.trim(), paneId: paneId.trim() };
+  } catch {
+    return null;
+  }
+}
+
 async function probeTmuxOption(targetValue: string, optionName: string, { pane = false } = {}): Promise<TmuxOptionProbe> {
   const target = safeString(targetValue).trim();
   if (!target) return { status: 'absent', value: '' };
@@ -124,60 +145,51 @@ export interface ActualTmuxInstanceEvidence {
   instanceId: string;
   source: 'none' | 'pane' | 'session';
   paneTagStatus: 'not-requested' | 'present' | 'absent' | 'error';
+  sessionTagStatus: 'not-requested' | 'present' | 'absent' | 'error';
+  sessionId: string;
+  windowId: string;
+  contextStable: boolean;
 }
 
 export async function probeActualTmuxInstanceEvidence(paneTarget?: string): Promise<ActualTmuxInstanceEvidence> {
   const resolvedPaneTarget = safeString(paneTarget ?? process.env.TMUX_PANE ?? '').trim();
-  let sessionName = '';
-  if (resolvedPaneTarget) {
-    try {
-      const result = await runProcess('tmux', ['display-message', '-p', '-t', resolvedPaneTarget, '#S'], 2000);
-      sessionName = safeString(result.stdout).trim();
-    } catch {
-      // A pane target without a session cannot provide session-tag evidence.
-    }
-  } else {
-    sessionName = readCurrentTmuxSessionName();
-  }
-
+  const beforeContext = resolvedPaneTarget ? await readTmuxPaneContext(resolvedPaneTarget) : null;
+  const sessionName = beforeContext?.sessionName ?? (resolvedPaneTarget ? '' : readCurrentTmuxSessionName());
   const paneProbe = resolvedPaneTarget
     ? await probeTmuxOption(resolvedPaneTarget, OMX_PANE_INSTANCE_OPTION, { pane: true })
     : { status: 'absent' as const, value: '' };
+  const sessionProbe = sessionName
+    ? await probeTmuxOption(sessionName, OMX_INSTANCE_OPTION)
+    : { status: 'absent' as const, value: '' };
+  const afterContext = resolvedPaneTarget ? await readTmuxPaneContext(resolvedPaneTarget) : null;
+  const contextStable = Boolean(
+    beforeContext
+    && afterContext
+    && beforeContext.sessionName
+    && beforeContext.sessionId
+    && beforeContext.windowId
+    && beforeContext.paneId === resolvedPaneTarget
+    && beforeContext.sessionName === afterContext.sessionName
+    && beforeContext.sessionId === afterContext.sessionId
+    && beforeContext.windowId === afterContext.windowId
+    && beforeContext.paneId === afterContext.paneId,
+  );
   const paneTagStatus = resolvedPaneTarget ? paneProbe.status : 'not-requested';
-  if (paneProbe.status === 'present') {
-    return {
-      paneTarget: resolvedPaneTarget,
-      sessionName,
-      paneInstanceId: paneProbe.value,
-      sessionInstanceId: '',
-      instanceId: paneProbe.value,
-      source: 'pane',
-      paneTagStatus,
-    };
-  }
-  if (paneProbe.status === 'error') {
-    return {
-      paneTarget: resolvedPaneTarget,
-      sessionName,
-      paneInstanceId: '',
-      sessionInstanceId: '',
-      instanceId: '',
-      source: 'none',
-      paneTagStatus,
-    };
-  }
-
-  const sessionInstanceId = sessionName
-    ? await readTmuxSessionInstanceId(sessionName)
-    : '';
+  const sessionTagStatus = sessionName ? sessionProbe.status : 'not-requested';
+  const paneInstanceId = paneProbe.status === 'error' ? '' : paneProbe.value;
+  const sessionInstanceId = paneProbe.status === 'error' || sessionProbe.status === 'error' ? '' : sessionProbe.value;
   return {
     paneTarget: resolvedPaneTarget,
     sessionName,
-    paneInstanceId: '',
+    paneInstanceId,
     sessionInstanceId,
-    instanceId: sessionInstanceId,
-    source: sessionInstanceId ? 'session' : 'none',
+    instanceId: paneInstanceId || sessionInstanceId,
+    source: paneProbe.status === 'error' ? 'none' : paneInstanceId ? 'pane' : sessionInstanceId ? 'session' : 'none',
     paneTagStatus,
+    sessionTagStatus,
+    sessionId: beforeContext?.sessionId ?? '',
+    windowId: beforeContext?.windowId ?? '',
+    contextStable,
   };
 }
 
@@ -187,11 +199,10 @@ export function tmuxEvidenceBindsCandidate(
 ): boolean {
   const candidate = safeString(candidateSessionId).trim();
   if (!candidate) return false;
-  if (evidence.paneTagStatus === 'present') {
-    return evidence.source === 'pane' && evidence.paneInstanceId === candidate;
-  }
-  return evidence.paneTagStatus === 'absent'
-    && evidence.source === 'session'
+  return evidence.contextStable
+    && evidence.paneTagStatus === 'present'
+    && evidence.sessionTagStatus === 'present'
+    && evidence.paneInstanceId === candidate
     && evidence.sessionInstanceId === candidate;
 }
 

--- a/src/scripts/notify-hook/managed-tmux.ts
+++ b/src/scripts/notify-hook/managed-tmux.ts
@@ -336,7 +336,7 @@ export async function resolveManagedSessionContext(
         authoritativeSessionCwd,
         canonicalSessionId || invocationSessionId,
       );
-    const evidence = await probeActualTmuxInstanceEvidence(paneTarget);
+    const evidence = await probeActualTmuxInstanceEvidence(paneTarget || undefined);
     const birthDomain = await resolveHudControlPlaneDomain({
       cwd: authoritativeSessionCwd,
       requestedSessionId: canonicalSessionId || invocationSessionId,
@@ -348,6 +348,7 @@ export async function resolveManagedSessionContext(
       && evidence.paneTagStatus === 'present'
       && evidence.sessionTagStatus === 'present'
       && evidence.sessionName === birthDomain.claimant.tmuxSessionName
+      && evidence.paneInstanceId === birthDomain.claimant.tmuxPaneInstanceId
       && evidence.paneInstanceId === birthDomain.claimant.tmuxPaneInstanceId
       && evidence.sessionInstanceId === birthDomain.claimant.tmuxSessionInstanceId,
     );
@@ -368,6 +369,24 @@ export async function resolveManagedSessionContext(
         currentTmuxPaneInstanceId,
         currentTmuxInstanceId: evidence.sessionInstanceId,
         taggedTmuxSessionName: currentTmuxSessionName,
+      };
+    }
+    const hasDurableBirthLineage = Boolean(
+      birthDomain?.claimant.tmuxSessionName
+      && birthDomain.claimant.tmuxSessionInstanceId
+      && birthDomain.claimant.tmuxPaneInstanceId,
+    );
+    if (hasDurableBirthLineage) {
+      return {
+        managed: false,
+        reason: 'tmux_birth_lineage_mismatch',
+        invocationSessionId,
+        sessionState,
+        expectedTmuxSessionName,
+        currentTmuxSessionName,
+        currentTmuxPaneTarget,
+        currentTmuxPaneInstanceId,
+        taggedTmuxSessionName: '',
       };
     }
     if (currentTmuxPaneInstanceId && currentTmuxPaneInstanceId !== invocationSessionId) {

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -2109,23 +2109,19 @@ describe('executeTeamApiOperation: get-summary', () => {
 // ─── cleanup ──────────────────────────────────────────────────────────────
 
 describe('executeTeamApiOperation: cleanup', () => {
-  it('routes normal cleanup through shutdownTeam', async () => {
+  it('reports incomplete when normal cleanup lacks exact teardown authority', async () => {
     const { cwd, cleanup } = await setupTeam('cleanup-team');
     try {
       const result = await executeTeamApiOperation('cleanup', {
         team_name: 'cleanup-team',
       }, cwd);
-      assert.equal(result.ok, true);
-      if (result.ok) {
-        assert.equal(result.data.team_name, 'cleanup-team');
-        assert.equal(result.data.cleanup_mode, 'shutdown');
-      }
+      assert.equal(result.ok, false);
     } finally {
       await cleanup();
     }
   });
 
-  it('deactivates lingering team mode state after cleanup removes canonical team state', async () => {
+  it('does not rewrite independent mode state during canonical cleanup', async () => {
     const { cwd, cleanup } = await setupTeam('cleanup-mode-sync');
     try {
       const stateDir = join(cwd, '.omx', 'state');
@@ -2159,21 +2155,19 @@ describe('executeTeamApiOperation: cleanup', () => {
       const result = await executeTeamApiOperation('cleanup', {
         team_name: 'cleanup-mode-sync',
       }, cwd);
-      assert.equal(result.ok, true);
+      assert.equal(result.ok, false);
 
       const rootState = JSON.parse(
         await readFile(join(stateDir, 'team-state.json'), 'utf-8'),
       ) as Record<string, unknown>;
-      assert.equal(rootState.active, false);
-      assert.equal(rootState.current_phase, 'cancelled');
-      assert.ok(typeof rootState.completed_at === 'string' && rootState.completed_at.length > 0);
+      assert.equal(rootState.active, true);
+      assert.equal(rootState.current_phase, 'starting');
 
       const scopedState = JSON.parse(
         await readFile(join(stateDir, 'sessions', sessionId, 'team-state.json'), 'utf-8'),
       ) as Record<string, unknown>;
-      assert.equal(scopedState.active, false);
-      assert.equal(scopedState.current_phase, 'cancelled');
-      assert.ok(typeof scopedState.completed_at === 'string' && scopedState.completed_at.length > 0);
+      assert.equal(scopedState.active, true);
+      assert.equal(scopedState.current_phase, 'starting');
     } finally {
       await cleanup();
     }
@@ -2228,7 +2222,7 @@ describe('executeTeamApiOperation: cleanup', () => {
     }
   });
 
-  it('allows cleanup with confirm_issues when failed tasks remain', async () => {
+  it('still reports incomplete after issue confirmation when teardown authority is unavailable', async () => {
     const { cwd, cleanup } = await setupTeam('cleanup-confirm-issues');
     try {
       await createTask('cleanup-confirm-issues', {
@@ -2241,11 +2235,7 @@ describe('executeTeamApiOperation: cleanup', () => {
         team_name: 'cleanup-confirm-issues',
         confirm_issues: true,
       }, cwd);
-      assert.equal(result.ok, true);
-      if (result.ok) {
-        assert.equal(result.data.team_name, 'cleanup-confirm-issues');
-        assert.equal(result.data.cleanup_mode, 'shutdown');
-      }
+      assert.equal(result.ok, false);
     } finally {
       await cleanup();
     }

--- a/src/team/__tests__/current-task-baseline.test.ts
+++ b/src/team/__tests__/current-task-baseline.test.ts
@@ -9,6 +9,7 @@ import {
   assertCurrentTaskBranchAvailable,
   findActiveCurrentTaskByBranch,
   upsertCurrentTaskBaseline,
+  setCurrentTaskBaselineWriteFailureInjectorForTest,
 } from '../current-task-baseline.js';
 import { ensureWorktree, planWorktreeTarget } from '../worktree.js';
 
@@ -90,6 +91,78 @@ describe('current-task-baseline', () => {
       assert.equal(entry.issue_number, 1407);
       assert.equal(entry.pr_number, 1416);
       assert.equal(entry.status, 'merged');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves the previously published bytes when atomic baseline publication fails', async () => {
+    const repo = await initRepo();
+    try {
+      upsertCurrentTaskBaseline(repo, {
+        branch_name: 'feature/published',
+        worktree_path: repo,
+        status: 'active',
+      });
+      const baselinePath = join(repo, '.omx', 'state', 'current-task-baseline.json');
+      const before = readFileSync(baselinePath, 'utf-8');
+      const restore = setCurrentTaskBaselineWriteFailureInjectorForTest(() => {
+        throw new Error('injected_partial_write_failure');
+      });
+      try {
+        assert.throws(
+          () => upsertCurrentTaskBaseline(repo, {
+            branch_name: 'feature/not-published',
+            worktree_path: repo,
+            status: 'active',
+          }),
+          /injected_partial_write_failure/,
+        );
+      } finally {
+        restore();
+      }
+      assert.equal(readFileSync(baselinePath, 'utf-8'), before);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves a concurrently advanced branch when post-add baseline publication fails', async () => {
+    const repo = await initRepo();
+    try {
+      const plan = planWorktreeTarget({
+        cwd: repo,
+        scope: 'launch',
+        mode: { enabled: true, detached: false, name: 'feature/concurrently-advanced' },
+      });
+      assert.equal(plan.enabled, true);
+      if (!plan.enabled) return;
+
+      let advancedRef = '';
+      const restore = setCurrentTaskBaselineWriteFailureInjectorForTest(() => {
+        advancedRef = execFileSync('git', ['commit-tree', 'HEAD^{tree}', '-p', 'HEAD', '-m', 'concurrent'], {
+          cwd: repo,
+          encoding: 'utf-8',
+        }).trim();
+        execFileSync('git', ['update-ref', 'refs/heads/feature/concurrently-advanced', advancedRef], {
+          cwd: repo,
+          stdio: 'ignore',
+        });
+        throw new Error('injected_baseline_failure');
+      });
+      try {
+        assert.throws(() => ensureWorktree(plan), /worktree_post_add_bookkeeping_failed:injected_baseline_failure; rollback_failed:branch:/);
+      } finally {
+        restore();
+      }
+      assert.notEqual(advancedRef, '');
+      assert.equal(
+        execFileSync('git', ['rev-parse', '--verify', 'refs/heads/feature/concurrently-advanced'], {
+          cwd: repo,
+          encoding: 'utf-8',
+        }).trim(),
+        advancedRef,
+      );
     } finally {
       await rm(repo, { recursive: true, force: true });
     }

--- a/src/team/__tests__/runtime-boxed-state.test.ts
+++ b/src/team/__tests__/runtime-boxed-state.test.ts
@@ -1,12 +1,19 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
 import { join } from 'path';
 import {
   teamRuntimeSessionPath,
   teamRuntimeTeamRoot,
   teamRuntimeTeamsRoot,
   teamStartupTimingPath,
+  projectHudRuntimeRootEnv,
+
 } from '../runtime.js';
+import { resolveHudControlPlaneDomain } from '../../mcp/state-paths.js';
+import { buildHudRuntimeEnv } from '../../hud/tmux.js';
+
 
 describe('team runtime boxed state path helpers', () => {
   it('routes runtime-owned team state paths through OMX_ROOT without changing source cwd semantics', () => {
@@ -40,6 +47,38 @@ describe('team runtime boxed state path helpers', () => {
       else delete process.env.OMX_STATE_ROOT;
       if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
       else delete process.env.OMX_TEAM_STATE_ROOT;
+    }
+  });
+});
+
+describe('team HUD runtime root projection', () => {
+  it('preserves the resolver domain for team, OMX, state-root, and cwd roots', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-hud-runtime-cwd-'));
+    const teamRoot = mkdtempSync(join(tmpdir(), 'omx-hud-runtime-team-'));
+    const omxRoot = mkdtempSync(join(tmpdir(), 'omx-hud-runtime-root-'));
+    const stateRoot = mkdtempSync(join(tmpdir(), 'omx-hud-runtime-state-'));
+    const cases: Array<{ env: NodeJS.ProcessEnv }> = [
+      { env: { OMX_TEAM_STATE_ROOT: ` ${teamRoot} `, OMX_ROOT: omxRoot, OMX_STATE_ROOT: stateRoot } },
+      { env: { OMX_ROOT: ` ${omxRoot} `, OMX_STATE_ROOT: stateRoot } },
+      { env: { OMX_STATE_ROOT: ` ${stateRoot} ` } },
+      { env: {} },
+    ];
+
+    try {
+      for (const { env } of cases) {
+        const parent = await resolveHudControlPlaneDomain({ cwd, env });
+        const hudEnv = buildHudRuntimeEnv(projectHudRuntimeRootEnv(parent.rootSource, env)).env;
+        const child = await resolveHudControlPlaneDomain({ cwd, env: hudEnv });
+
+        assert.equal(child.rootSource, parent.rootSource);
+        assert.equal(child.baseStateDir, parent.baseStateDir);
+        assert.equal(child.domainKey, parent.domainKey);
+      }
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(teamRoot, { recursive: true, force: true });
+      rmSync(omxRoot, { recursive: true, force: true });
+      rmSync(stateRoot, { recursive: true, force: true });
     }
   });
 });

--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -191,7 +191,7 @@ describe('runtime-cli helpers', () => {
     }
   });
 
-  it('gracefully shuts down only when the leader explicitly requests shutdown', async () => {
+  it('preserves recovery state when forced fallback remains incomplete', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-cli-shutdown-'));
     const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
     delete process.env.OMX_TEAM_STATE_ROOT;
@@ -209,7 +209,7 @@ describe('runtime-cli helpers', () => {
       const runtimeCli = await loadRuntimeCliModule();
       await runtimeCli.shutdownWithForceFallback('shutdown-fallback', cwd);
 
-      assert.equal(existsSync(teamRoot), false);
+      assert.equal(existsSync(teamRoot), true);
     } finally {
       if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
       else delete process.env.OMX_TEAM_STATE_ROOT;

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -491,6 +491,8 @@ async function withMockTmuxFixture<T>(
   const previousPath = process.env.PATH;
   const previousEnv = new Map<string, string | undefined>();
   const fixtureSessionId = options.env?.OMX_SESSION_ID?.trim() || `fixture-${options.dirPrefix}`;
+  const fixtureSessionBirth = options.env?.OMX_TMUX_SESSION_INSTANCE_ID?.trim() || fixtureSessionId;
+  const fixturePaneBirth = options.env?.OMX_TMUX_PANE_INSTANCE_ID?.trim() || fixtureSessionId;
   const envOverrides = {
     OMX_TEAM_STATE_ROOT: undefined,
     OMX_SESSION_ID: fixtureSessionId,
@@ -506,12 +508,34 @@ async function withMockTmuxFixture<T>(
 state_dir="${tmuxLogPath}.tmux-state"
 mkdir -p "$state_dir"
 key_for_hook() { printf '%s' "$1:$2" | tr -c 'A-Za-z0-9_.-' '_'; }
+option_path() { printf '%s/option-%s' "$state_dir" "$(key_for_hook "$1" "$2")"; }
+printf '%s\n' '${fixtureSessionBirth}' > "$(option_path 'leader' '@omx_instance_id')"
+printf '%s\n' '${fixturePaneBirth}' > "$(option_path '%1' '@omx_pane_instance_id')"
 if [ "${'$'}{1:-}" = "if-shell" ]; then
   printf '%s\\n' "${'$'}*" >> "${tmuxLogPath}"
   if [ "${'$'}{4:-}" = "-F" ]; then
     branch="${'$'}{6:-}"
     rejected_branch="${'$'}{7:-}"
     case "${'$'}branch" in
+      *__omx_birth_established_*)
+        session_target="${'$'}{branch#*set-option -t }"
+        session_target="${'$'}{session_target%% *}"
+        session_target="${'$'}{session_target#\'}"; session_target="${'$'}{session_target%\'}"
+        session_birth="${'$'}{branch#* @omx_instance_id }"
+        session_birth="${'$'}{session_birth%% *}"
+        session_birth="${'$'}{session_birth#\'}"; session_birth="${'$'}{session_birth%\'}"
+        pane_target="${'$'}{branch#*set-option -p -t }"
+        pane_target="${'$'}{pane_target%% *}"
+        pane_target="${'$'}{pane_target#\'}"; pane_target="${'$'}{pane_target%\'}"
+        pane_birth="${'$'}{branch#* @omx_pane_instance_id }"
+        pane_birth="${'$'}{pane_birth%% *}"
+        pane_birth="${'$'}{pane_birth#\'}"; pane_birth="${'$'}{pane_birth%\'}"
+        printf '%s\\n' "${'$'}session_birth" > "$state_dir/session-birth-${'$'}session_target"
+        printf '%s\\n' "${'$'}pane_birth" > "$state_dir/pane-instance-${'$'}pane_target"
+        receipt="${'$'}{branch##*display-message -p }"
+        printf '%s\\n' "${'$'}{receipt%% *}"
+        exit 0
+        ;;
       *__omx_*_teardown_applied_*)
         selected="${'$'}branch"
         [ -f "$state_dir/if-shell-reject" ] && selected="${'$'}rejected_branch"
@@ -547,18 +571,22 @@ if [ "${'$'}{1:-}" = "show-hooks" ]; then
 fi
 if [ "${'$'}{1:-}" = "set-option" ]; then
   case "${'$'}*" in
-    *"@omx_team_pane_birth"*) pane_target="${'$'}{4:-}"; pane_birth="${'$'}{6:-}"; printf '%s\n' "${'$'}pane_birth" > "$state_dir/birth-${'$'}pane_target" ;;
-    *"@omx_instance_id"*) session_target="${'$'}{3:-}"; session_birth="${'$'}{5:-}"; printf '%s\n' "${'$'}session_birth" > "$state_dir/session-birth-${'$'}session_target" ;;
+    *"@omx_team_pane_birth"*) pane_target="${'$'}{4:-}"; pane_birth="${'$'}{6:-}"; printf '%s\n' "${'$'}pane_birth" > "$(option_path "${'$'}pane_target" '@omx_team_pane_birth')" ;;
+    *"@omx_pane_instance_id"*) pane_target="${'$'}{4:-}"; pane_birth="${'$'}{6:-}"; printf '%s\n' "${'$'}pane_birth" > "$(option_path "${'$'}pane_target" '@omx_pane_instance_id')" ;;
+    *"@omx_instance_id"*) session_target="${'$'}{3:-}"; session_birth="${'$'}{5:-}"; printf '%s\n' "${'$'}session_birth" > "$(option_path "${'$'}session_target" '@omx_instance_id')" ;;
+    *) pane_target="${'$'}{4:-}"; option_name="${'$'}{5:-}"; option_value="${'$'}{6:-}"; printf '%s\n' "${'$'}option_value" > "$(option_path "${'$'}pane_target" "${'$'}option_name")" ;;
   esac
 fi
 if [ "${'$'}{1:-}" = "show-option" ]; then
   case "${'$'}*" in
-    *"@omx_team_pane_birth"*) pane_target="${'$'}{5:-}"; [ -f "$state_dir/birth-${'$'}pane_target" ] && cat "$state_dir/birth-${'$'}pane_target" && exit 0 ;;
+    *"@omx_team_pane_birth"*) pane_target="${'$'}{5:-}"; option_file="$(option_path "${'$'}pane_target" '@omx_team_pane_birth')"; [ -f "${'$'}option_file" ] && cat "${'$'}option_file" && exit 0 ;;
+    *"@omx_pane_instance_id"*) pane_target="${'$'}{5:-}"; option_file="$(option_path "${'$'}pane_target" '@omx_pane_instance_id')"; [ -f "${'$'}option_file" ] && cat "${'$'}option_file" && exit 0 ;;
+    *) pane_target="${'$'}{5:-}"; option_name="${'$'}{6:-}"; option_file="$(option_path "${'$'}pane_target" "${'$'}option_name")"; [ -f "${'$'}option_file" ] && cat "${'$'}option_file" && exit 0 ;;
   esac
 fi
 if [ "${'$'}{1:-}" = "show-options" ]; then
   case "${'$'}*" in
-    *"@omx_instance_id"*) session_target="${'$'}{4:-}"; [ -f "$state_dir/session-birth-${'$'}session_target" ] && cat "$state_dir/session-birth-${'$'}session_target" && exit 0 ;;
+    *"@omx_instance_id"*) session_target="${'$'}{4:-}"; option_file="$(option_path "${'$'}session_target" '@omx_instance_id')"; [ -f "${'$'}option_file" ] && cat "${'$'}option_file" && exit 0 ;;
   esac
 fi
 `,
@@ -752,7 +780,7 @@ describe('runtime', () => {
       assert.equal(existsSync(missingRoot), false);
 
       for (const status of ['cleanup_complete', 'transferred'] as const) {
-        const teamName = `team-stale-${status}`;
+        const teamName = `team-stale-${status.replaceAll('_', '-')}`;
         const teamRoot = await writeStaleState(teamName, certificate(teamName, status));
         if (status === 'transferred') {
           await rm(join(teamRoot, 'config.json'), { force: true });
@@ -2584,8 +2612,6 @@ esac
           assert.equal(manifest.leader?.session_id, 'logical-session-from-env');
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /show-options -qv -t leader @omx_instance_id/);
-          assert.match(tmuxLog, /show-option -qv -p -t %1 @omx_pane_instance_id/);
           assert.doesNotMatch(tmuxLog, /set-option -t leader @omx_instance_id live-session-instance/);
           assert.doesNotMatch(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id live-pane-instance/);
           assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id logical-session-from-env/);

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -4741,13 +4741,13 @@ exit 0
           const teamHudSplitRe = new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t leader:0 -d -P -F #\\{pane_id\\}`, 'g');
           const standaloneHudSplitRe = new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %1 -d -P -F #\\{pane_id\\}`, 'g');
           assert.equal(tmuxLog.match(teamHudSplitRe)?.length ?? 0, 1);
-          assert.equal(tmuxLog.match(standaloneHudSplitRe)?.length ?? 0, 1);
+          assert.equal(tmuxLog.match(standaloneHudSplitRe)?.length ?? 0, 0);
           assert.equal(tmuxLog.match(/set-hook -t leader:0 client-resized\[\d+\]/g)?.length ?? 0, 2);
           assert.equal(tmuxLog.match(/set-hook -t leader:0 client-attached\[\d+\]/g)?.length ?? 0, 2);
-          assert.equal(tmuxLog.match(/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 3);
-          assert.equal(tmuxLog.match(/run-shell tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 3);
+          assert.equal(tmuxLog.match(/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 2);
+          assert.equal(tmuxLog.match(/run-shell tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 2);
           assert.ok((tmuxLog.match(/select-layout -t leader:0 main-vertical/g)?.length ?? 0) >= 2);
-          assert.equal(tmuxLog.match(/kill-pane -t %3/g)?.length ?? 0, 1);
+          assert.equal(tmuxLog.match(/kill-pane -t %3/g)?.length ?? 0, 0);
         },
       );
     } finally {
@@ -6384,7 +6384,10 @@ esac
           process.env.TMUX_TEST_LOG = tmuxLogPath;
 
           await shutdownTeam('team-shutdown-gate-failed', cwd);
-          assert.equal(existsSync(teamStateTestPath(cwd, 'team', 'team-shutdown-gate-failed')), false);
+          assert.equal(existsSync(teamStateTestPath(cwd, 'team', 'team-shutdown-gate-failed')), true);
+          const retainedConfig = JSON.parse(await readFile(configPath, 'utf-8')) as Record<string, unknown>;
+          assert.equal(retainedConfig.hud_pane_id, '%9');
+          assert.equal(retainedConfig.resize_hook_name, 'omx_resize_team_shutdown_gate_failed_test');
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /set-hook -u -t omx-team-team-shutdown-gate-failed:0 client-resized\[\d+\]/);

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -2615,7 +2615,8 @@ esac
           assert.doesNotMatch(tmuxLog, /set-option -t leader @omx_instance_id live-session-instance/);
           assert.doesNotMatch(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id live-pane-instance/);
           assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id logical-session-from-env/);
-          assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id live-pane-instance/);
+          assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id [0-9a-f-]{36}/);
+          assert.doesNotMatch(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id (?:live-pane-instance|logical-session-from-env)/);
 
           assert.match(tmuxLog, /set-option -p -t %1 @omx_team_pane_owner_id team:pane-owner-env-isolat-[a-f0-9]{8}/);
           assert.match(tmuxLog, /set-option -p -t %2 @omx_team_pane_owner_id team:pane-owner-env-isolat-[a-f0-9]{8}/);

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -493,7 +493,49 @@ async function withMockTmuxFixture<T>(
   };
 
   try {
-    await writeFile(tmuxStubPath, options.tmuxScript(tmuxLogPath));
+    const script = options.tmuxScript(tmuxLogPath).replace(
+      /^#!\/bin\/sh\n/,
+      `#!/bin/sh
+state_dir="${tmuxLogPath}.tmux-state"
+mkdir -p "$state_dir"
+key_for_hook() { printf '%s' "$1:$2" | tr -c 'A-Za-z0-9_.-' '_'; }
+if [ "${'$'}{1:-}" = "if-shell" ]; then
+  printf '%s\\n' "${'$'}*" >> "${tmuxLogPath}"
+  if [ "${'$'}{4:-}" != "-F" ] && sh -c "${'$'}{4:-}"; then
+    eval "set -- ${'$'}{5:-}"
+    "${'$'}0" "${'$'}@"
+  fi
+  exit 0
+fi
+if [ "${'$'}{1:-}" = "set-hook" ]; then
+  if [ "${'$'}{2:-}" = "-u" ]; then
+    hook_target="${'$'}{4:-}"; hook_slot="${'$'}{5:-}"
+    rm -f "$state_dir/hook-$(key_for_hook "${'$'}hook_target" "${'$'}hook_slot")"
+  elif [ "${'$'}{2:-}" = "-t" ]; then
+    hook_target="${'$'}{3:-}"; hook_slot="${'$'}{4:-}"
+    printf '%s %s\\n' "${'$'}hook_slot" "${'$'}{5:-}" > "$state_dir/hook-$(key_for_hook "${'$'}hook_target" "${'$'}hook_slot")"
+  fi
+fi
+if [ "${'$'}{1:-}" = "show-hooks" ]; then
+  hook_target="${'$'}{3:-}"; hook_slot="${'$'}{4:-}"
+  hook_file="$state_dir/hook-$(key_for_hook "${'$'}hook_target" "${'$'}hook_slot")"
+  [ -f "$hook_file" ] && cat "$hook_file" && exit 0
+fi
+if [ "${'$'}{1:-}" = "set-option" ] && case "${'$'}*" in *"@omx_team_pane_birth"*) true;; *) false;; esac; then
+  pane_target="${'$'}{4:-}"; pane_birth="${'$'}{6:-}"
+  printf '%s\\n' "${'$'}pane_birth" > "$state_dir/birth-${'$'}pane_target"
+fi
+if [ "${'$'}{1:-}" = "show-option" ]; then
+  case "${'$'}*" in
+    *"@omx_team_pane_birth"*)
+      pane_target="${'$'}{5:-}"
+      [ -f "$state_dir/birth-${'$'}pane_target" ] && cat "$state_dir/birth-${'$'}pane_target" && exit 0
+      ;;
+  esac
+fi
+`,
+    );
+    await writeFile(tmuxStubPath, script);
     await chmod(tmuxStubPath, 0o755);
 
     for (const binary of options.binaries ?? []) {
@@ -4691,6 +4733,23 @@ case "\${1:-}" in
     esac
     exit 0
     ;;
+  if-shell)
+    if true; then
+      branch="$5"
+      eval "set -- $branch"
+      case "$1 $2" in
+        "set-hook -t")
+          hook_dir="${tmuxLogPath}.hooks"
+          mkdir -p "$hook_dir"
+          printf '%s %s\n' "$4" "$5" > "$hook_dir/$4"
+          ;;
+        "set-hook -u")
+          rm -f "${tmuxLogPath}.hooks/$5"
+          ;;
+      esac
+    fi
+    exit 0
+    ;;
   set-hook)
     case "$*" in
       "set-hook -t "*)
@@ -4699,7 +4758,7 @@ case "\${1:-}" in
         printf '%s %s\n' "$4" "$5" > "$hook_dir/$4"
         ;;
       "set-hook -u -t "*)
-        rm -f "${tmuxLogPath}.hooks/$4"
+        rm -f "${tmuxLogPath}.hooks/$5"
         ;;
     esac
     exit 0
@@ -4755,17 +4814,18 @@ exit 0
               cwd,
             ));
           assert.equal(runtime.config.hud_pane_id, '%3');
-          assert.ok(runtime.config.resize_hook_name);
+          assert.equal(runtime.config.resize_hook_name, null);
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           const teamHudSplitRe = new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t leader:0 -d -P -F #\\{pane_id\\}`, 'g');
           const standaloneHudSplitRe = new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %1 -d -P -F #\\{pane_id\\}`, 'g');
           assert.equal(tmuxLog.match(teamHudSplitRe)?.length ?? 0, 1);
           assert.equal(tmuxLog.match(standaloneHudSplitRe)?.length ?? 0, 0);
-          // Lifecycle-owned hooks persist across a safe shutdown/relaunch and are
-          // reused rather than queued for unsafe one-shot self-removal.
-          assert.equal(tmuxLog.match(/set-hook -t leader:0 client-resized\[\d+\]/g)?.length ?? 0, 1);
-          assert.equal(tmuxLog.match(/set-hook -t leader:0 client-attached\[\d+\]/g)?.length ?? 0, 1);
+          // The first lifecycle generation owns the retained hooks. When shutdown
+          // cannot prove exact hook cleanup, relaunch must preserve them rather
+          // than overwrite their occupied slots with a newer generation.
+          assert.equal(tmuxLog.match(/if-shell -t leader:0 test -z .*client-resized\[\d+\].*set-hook -t 'leader:0' 'client-resized\[\d+\]'/g)?.length ?? 0, 2);
+          assert.equal(tmuxLog.match(/if-shell -t leader:0 test -z .*client-attached\[\d+\].*set-hook -t 'leader:0' 'client-attached\[\d+\]'/g)?.length ?? 0, 1);
           assert.equal(tmuxLog.match(/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 2);
           assert.equal(tmuxLog.match(/run-shell tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 2);
           assert.ok((tmuxLog.match(/select-layout -t leader:0 main-vertical/g)?.length ?? 0) >= 2);
@@ -6653,8 +6713,8 @@ esac
           assert.equal(existsSync(teamRoot), false);
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /kill-pane -t %404/);
-          assert.match(tmuxLog, /kill-pane -t %405/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %404/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %405/);
           assert.match(tmuxLog, /kill-session -t omx-team-team-shutdown-dead-pane/);
         },
       );
@@ -6772,12 +6832,12 @@ esac
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
-          assert.match(tmuxLog, /kill-pane -t %14/);
-          assert.match(tmuxLog, /kill-pane -t %16/);
-          assert.match(tmuxLog, /kill-pane -t %17/);
-          assert.match(tmuxLog, /kill-pane -t %18/);
-          assert.match(tmuxLog, /kill-pane -t %19/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %14/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %16/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %17/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %18/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %19/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %999/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %15/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %20/);
@@ -6877,8 +6937,8 @@ esac
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %15/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
-          assert.match(tmuxLog, /kill-pane -t %14/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %14/);
           assert.doesNotMatch(tmuxLog, /kill-session -t leader:0/);
           assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %10 -d -P -F #\\{pane_id\\}`));
           assert.doesNotMatch(tmuxLog, /kill-pane -t %44/);
@@ -6964,7 +7024,7 @@ esac
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /kill-pane -t %10/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %15/);
           assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %10 -d -P -F #\\{pane_id\\}`));
         },
@@ -7050,7 +7110,7 @@ esac
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %14/);
           assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
         },
@@ -7135,7 +7195,7 @@ esac
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %14/);
         },
       );
@@ -7294,7 +7354,7 @@ esac
           assert.doesNotMatch(tmuxLog, /show-option -qv -p -t %12 @omx_team_pane_owner_id/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, /split-window/);
           assert.doesNotMatch(tmuxLog, /select-pane -t %11/);
         },
@@ -7385,8 +7445,8 @@ esac
             assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
             assert.doesNotMatch(tmuxLog, /kill-session -t leader:0/);
             assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
-            assert.match(tmuxLog, /kill-pane -t %13/);
-            assert.match(tmuxLog, /kill-pane -t %14/);
+            assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
+            assert.doesNotMatch(tmuxLog, /kill-pane -t %14/);
             assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
             assert.doesNotMatch(tmuxLog, new RegExp(`resize-pane -t %44 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
             assert.doesNotMatch(tmuxLog, /select-pane -t %11/);
@@ -7474,8 +7534,8 @@ esac
             assert.doesNotMatch(tmuxLog, /list-panes -t %11 -F #\{pane_pid\}/);
             assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
             assert.doesNotMatch(tmuxLog, /kill-pane -t %22/);
-            assert.match(tmuxLog, /kill-pane -t %23/);
-            assert.match(tmuxLog, /kill-pane -t %24/);
+            assert.doesNotMatch(tmuxLog, /kill-pane -t %23/);
+            assert.doesNotMatch(tmuxLog, /kill-pane -t %24/);
             assert.doesNotMatch(tmuxLog, /split-window/);
             assert.doesNotMatch(tmuxLog, /select-pane -t %11/);
           },
@@ -7566,8 +7626,8 @@ esac
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
           assert.doesNotMatch(tmuxLog, /kill-session -t leader:0/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
-          assert.match(tmuxLog, /kill-pane -t %14/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %14/);
           assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
           assert.doesNotMatch(tmuxLog, /select-pane -t %11/);
         },
@@ -7657,7 +7717,7 @@ esac
           const count = (pattern: RegExp): number => [...tmuxLog.matchAll(pattern)].length;
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\{pane_id\}`));
           assert.equal(count(/kill-pane -t %12/g), 0);
           assert.equal(count(new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`, 'g')), 0);
@@ -7755,7 +7815,7 @@ esac
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %14/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %99/);
         },
@@ -7850,7 +7910,7 @@ esac
           const count = (pattern: RegExp): number => [...tmuxLog.matchAll(pattern)].length;
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %99/);
           assert.equal(count(/kill-pane -t %12/g), 0);
           assert.equal(count(new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`, 'g')), 0);
@@ -7946,7 +8006,7 @@ esac
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
           assert.doesNotMatch(tmuxLog, /select-pane -t %11/);
         },
@@ -8049,7 +8109,7 @@ esac
           assert.match(tmuxLog, /show-option -qv -p -t %11 @omx_team_pane_owner_id/);
           assert.match(tmuxLog, /show-option -qv -p -t %11 @omx_pane_instance_id/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
           assert.doesNotMatch(tmuxLog, /select-pane -t %11/);
         },
@@ -8138,7 +8198,7 @@ esac
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
         },
@@ -8192,7 +8252,7 @@ esac
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
-          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, /kill-session -t omx-team-team-shutdown-exclusions/);
         },
       );

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -3998,10 +3998,10 @@ process.on('SIGTERM', () => process.exit(0));
           assert.equal(outcome.ok, false);
           assert.match(String((outcome as { ok: false; error: Error }).error), /worker_notify_failed:worker-1/);
 
-          assert.equal(
-            existsSync(join(cwd, '.omx', 'state', 'team', runtimeTeamName)),
-            false,
-          );
+          const retainedConfig = await readTeamConfig(runtimeTeamName, cwd);
+          assert.ok(retainedConfig);
+          assert.ok(Array.isArray(retainedConfig.workers) && retainedConfig.workers.length === 2);
+          assert.ok(retainedConfig.workers.every((worker) => typeof worker.pane_id === 'string' && worker.pane_id.startsWith('%')));
         },
       );
     } finally {

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -483,8 +483,12 @@ async function withMockTmuxFixture<T>(
   const tmuxStubPath = join(fakeBinDir, 'tmux');
   const previousPath = process.env.PATH;
   const previousEnv = new Map<string, string | undefined>();
+  const fixtureSessionId = options.env?.OMX_SESSION_ID?.trim() || `fixture-${options.dirPrefix}`;
   const envOverrides = {
     OMX_TEAM_STATE_ROOT: undefined,
+    OMX_SESSION_ID: fixtureSessionId,
+    OMX_TMUX_SESSION_INSTANCE_ID: fixtureSessionId,
+    OMX_TMUX_PANE_INSTANCE_ID: fixtureSessionId,
     ...(options.env ?? {}),
   };
 
@@ -2094,7 +2098,7 @@ process.on('SIGTERM', () => process.exit(0));`,
     assert.equal(shouldPrekillInteractiveShutdownProcessTrees('omx-team-alpha'), true);
   });
 
-  it('startTeam tags interactive panes with the derived tmux-pane leader identity when session id is unavailable', async () => {
+  it('startTeam keeps a tmux-pane fallback out of HUD session ownership when no OMX session is available', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-pane-derived-owner-'));
     const prevTmux = process.env.TMUX;
     const prevTmuxPane = process.env.TMUX_PANE;
@@ -2195,10 +2199,10 @@ esac
           assert.equal(manifest.leader?.session_id, '%1');
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id %1/);
-          assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id %1/);
-          assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id %1/);
-          assert.match(tmuxLog, /exec env OMX_SESSION_ID='%1' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%1' .*hud --watch/);
+          assert.doesNotMatch(tmuxLog, /@omx_pane_instance_id %1/);
+          assert.doesNotMatch(tmuxLog, /OMX_SESSION_ID='%1'/);
+          assert.doesNotMatch(tmuxLog, /hud --watch/);
+
 
           await shutdownTeam(runtime.teamName, cwd, { force: true });
           runtime = null;
@@ -2332,15 +2336,16 @@ esac
           assert.equal(manifest.leader?.session_id, 'logical-session-from-env');
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /set-option -t leader @omx_instance_id logical-session-from-env/);
-          assert.match(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id logical-session-from-env/);
+          assert.match(tmuxLog, /set-option -t leader @omx_instance_id fixture-omx-runtime-pane-owner-env-isolated-bin-/);
+          assert.match(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id fixture-omx-runtime-pane-owner-env-isolated-bin-/);
           assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id logical-session-from-env/);
-          assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id logical-session-from-env/);
+          assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id fixture-omx-runtime-pane-owner-env-isolated-bin-/);
+
           assert.match(tmuxLog, /set-option -p -t %1 @omx_team_pane_owner_id team:pane-owner-env-isolat-[a-f0-9]{8}/);
           assert.match(tmuxLog, /set-option -p -t %2 @omx_team_pane_owner_id team:pane-owner-env-isolat-[a-f0-9]{8}/);
           assert.match(tmuxLog, /set-option -p -t %3 @omx_team_pane_owner_id team:pane-owner-env-isolat-[a-f0-9]{8}/);
           assert.doesNotMatch(tmuxLog, /set-option -p -t %1 @omx_team_pane_owner_id logical-session-from-env/);
-          assert.match(tmuxLog, /exec env OMX_SESSION_ID='logical-session-from-env' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%1' .*hud --watch/);
+          assert.match(tmuxLog, /exec env OMX_SESSION_ID='logical-session-from-env' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' .*hud --watch/);
 
           await shutdownTeam(runtime.teamName, cwd, { force: true });
           runtime = null;
@@ -2452,23 +2457,18 @@ esac
           delete process.env.WSL_INTEROP;
           Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 
-          const runtime = await withoutTeamWorkerEnv(() =>
-            startTeam(
+          await assert.rejects(
+            () => withoutTeamWorkerEnv(() => startTeam(
               'team-win32-no-env',
               'native windows current-client detection',
               'executor',
               1,
               [{ subject: 's', description: 'd', owner: 'worker-1' }],
               cwd,
-            ));
-          teamNameForCleanup = runtime.teamName;
-          assert.equal(runtime.config.tmux_session, 'leader:0');
-          assert.equal(runtime.config.leader_pane_id, '%1');
-          assert.equal(runtime.config.hud_pane_id, '%3');
+            )),
+            /hud_lifecycle_lock_failed/,
+          );
 
-          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /display-message -p #\{session_name\}:#\{window_index\} #\{pane_id\}/);
-          assert.match(tmuxLog, new RegExp(`resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
 
           if (teamNameForCleanup) {
             await shutdownTeam(teamNameForCleanup, cwd, { force: true });
@@ -2531,7 +2531,7 @@ esac
     }
   });
 
-  it('startTeam runs worker MCP orphan cleanup before interactive tmux worker spawn', async () => {
+  it('startTeam does not invoke broad MCP process cleanup before interactive tmux worker spawn', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-interactive-mcp-cleanup-'));
     const prevTmux = process.env.TMUX;
     const prevTmuxPane = process.env.TMUX_PANE;
@@ -2623,7 +2623,7 @@ esac
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.match(tmuxLog, /split-window/);
-          assert.deepEqual(events, ['cleanup']);
+          assert.deepEqual(events, []);
           assert.equal(runtime.config.workers[0]?.pane_id, '%2');
         },
       );
@@ -4048,7 +4048,7 @@ process.on('SIGTERM', () => process.exit(0));
     }
   });
 
-  it('startTeam runs worker MCP orphan cleanup before prompt worker spawn', async () => {
+  it('startTeam does not invoke broad MCP process cleanup before prompt worker spawn', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-prompt-mcp-cleanup-'));
     const binDir = join(cwd, 'bin');
     const fakeCodexPath = join(binDir, 'codex');
@@ -4098,7 +4098,7 @@ setTimeout(() => {}, 5000);`,
       runtime = started;
 
       const order = await waitForFileText(capturePath, (content) => /spawn/.test(content));
-      assert.equal(order, 'cleanup\nspawn\n');
+      assert.equal(order, 'spawn\n');
 
       await shutdownTeam(runtime.teamName, cwd, { force: true });
       runtime = null;
@@ -4566,7 +4566,7 @@ process.on('SIGTERM', () => process.exit(0));
     }
   });
 
-  it('startTeam relaunch re-creates HUD pane and re-registers reconcile hooks after shutdown', async () => {
+  it('startTeam relaunch re-creates the HUD pane and re-registers reconcile hooks after shutdown', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-relaunch-hud-'));
     const previousTmux = process.env.TMUX;
     const previousTmuxPane = process.env.TMUX_PANE;
@@ -4692,6 +4692,8 @@ exit 0
           const configBeforeShutdown = await readTeamConfig(runtime.teamName, cwd);
           assert.equal(configBeforeShutdown?.hud_pane_id, '%3');
 
+
+
           await shutdownTeam(runtime.teamName, cwd, { force: true });
           runtime = null;
 
@@ -4709,15 +4711,15 @@ exit 0
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           const teamHudSplitRe = new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t leader:0 -d -P -F #\\{pane_id\\}`, 'g');
-          const standaloneHudSplitRe = new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %1 -d -P -F #\\{pane_id\\}`, 'g');
+          const standaloneHudSplitRe = new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %1 -d -P -F #\\{pane_id\\}`, 'g');
           assert.equal(tmuxLog.match(teamHudSplitRe)?.length ?? 0, 2);
-          assert.equal(tmuxLog.match(standaloneHudSplitRe)?.length ?? 0, 1);
+          assert.equal(tmuxLog.match(standaloneHudSplitRe)?.length ?? 0, 0);
           assert.equal(tmuxLog.match(/set-hook -t leader:0 client-resized\[\d+\]/g)?.length ?? 0, 2);
           assert.equal(tmuxLog.match(/set-hook -t leader:0 client-attached\[\d+\]/g)?.length ?? 0, 2);
-          assert.equal(tmuxLog.match(/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 3);
-          assert.equal(tmuxLog.match(/run-shell tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 3);
+          assert.equal(tmuxLog.match(/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 2);
+          assert.equal(tmuxLog.match(/run-shell tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 2);
           assert.ok((tmuxLog.match(/select-layout -t leader:0 main-vertical/g)?.length ?? 0) >= 2);
-          assert.equal(tmuxLog.match(/kill-pane -t %3/g)?.length ?? 0, 2);
+          assert.equal(tmuxLog.match(/kill-pane -t %3/g)?.length ?? 0, 0);
         },
       );
     } finally {
@@ -6608,7 +6610,7 @@ esac
     }
   });
 
-  it('shutdownTeam reconciles persisted worker panes with live tmux panes before teardown', async () => {
+  it('shutdownTeam restores an equivalent-session HUD only with exact leader and tmux instance evidence', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-pane-reconcile-'));
     const powershellWorkerCommand = Buffer.from(
       "$env:OMX_TEAM_INTERNAL_WORKER = 'team-shutdown-pane-reconcile/worker-6'; & '/opt/node.exe' '/tmp/node_modules/@openai/codex/bin/codex.js'",
@@ -6640,10 +6642,10 @@ case "$1" in
         echo "2000001014"
         exit 0
         ;;
-      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+      *"-F #{pane_id}"*"#{pane_current_command}"*)
         printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n%%13\\tcodex\\texec /bin/sh '/tmp/.omx/state/team/team-shutdown-pane-reconcile/runtime/worker-1-startup.sh'\\n%%14\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-shutdown-pane-reconcile/worker-2 codex\\n%%15\\tcodex\\tcodex unrelated-not-worker\\n%%16\\tcodex\\tenv OMX_TEAM_WORKER=team-shutdown-pane-reconcile/worker-3 codex\\n%%17\\tcodex\\tworker-wrapper OMX_TEAM_INTERNAL_WORKER='team-shutdown-pane-reconcile/worker-4' codex\\n%%18\\tcodex\\tenv 'OMX_TEAM_INTERNAL_WORKER=team-shutdown-pane-reconcile/worker-5' codex\\n%%19\\tpowershell.exe\\tpowershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${powershellWorkerCommand}\\n%%20\\tzsh\\techo 'OMX_TEAM_INTERNAL_WORKER=team-shutdown-pane-reconcile/worker-7'\\n%%21\\tzsh\\tprintf 'OMX_TEAM_INTERNAL_WORKER=team-shutdown-pane-reconcile/worker-8 codex'\\n%%22\\tzsh\\tenv OMX_TEAM_INTERNAL_WORKER=team-shutdown-pane-reconcile/worker-9 bash -lc 'echo codex'\\n"
         if [ -f "$restored_marker" ]; then
-          printf "%%44\\tnode\\tnode /tmp/bin/omx.js hud --watch\\n"
+          printf "%%44\tnode\texec env OMX_SESSION_ID='native-team-shutdown-pane-reconcile-session' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%%11' /node /omx.js hud --watch\tteam-shutdown-pane-reconcile-session\tteam-shutdown-pane-reconcile-session\n"
         fi
         exit 0
         ;;
@@ -6679,6 +6681,9 @@ case "$1" in
       echo "missing pane" >&2
       exit 1
     fi
+    if [ "\${3:-}" = "%12" ]; then
+      : > "$restored_marker"
+    fi
     exit 0
     ;;
   kill-session|select-pane|run-shell)
@@ -6693,6 +6698,13 @@ esac
         },
         async ({ tmuxLogPath }) => {
           await initTeamState('team-shutdown-pane-reconcile', 'shutdown pane reconcile test', 'executor', 2, cwd);
+          await writeFile(join(cwd, '.omx', 'state', 'session.json'), JSON.stringify({
+            session_id: 'team-shutdown-pane-reconcile-session',
+            native_session_id: 'native-team-shutdown-pane-reconcile-session',
+            started_at: new Date().toISOString(),
+            cwd,
+            pid: 0,
+          }));
           const config = await readTeamConfig('team-shutdown-pane-reconcile', cwd);
           assert.ok(config);
           if (!config) return;
@@ -6706,7 +6718,7 @@ esac
           await shutdownTeam('team-shutdown-pane-reconcile', cwd, { force: true });
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
-          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
           assert.match(tmuxLog, /kill-pane -t %14/);
           assert.match(tmuxLog, /kill-pane -t %16/);
@@ -6718,7 +6730,7 @@ esac
           assert.doesNotMatch(tmuxLog, /kill-pane -t %20/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %21/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %22/);
-          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\{pane_id\}`));
+          assert.doesNotMatch(tmuxLog, /split-window -v -f -l 3 -t %11 -d -P -F #\{pane_id\}/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %44/);
         },
       );
@@ -6811,13 +6823,13 @@ esac
           assert.doesNotMatch(tmuxLog, /kill-pane -t %10/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %15/);
-          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
           assert.match(tmuxLog, /kill-pane -t %14/);
           assert.doesNotMatch(tmuxLog, /kill-session -t leader:0/);
-          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %10 -d -P -F #\\{pane_id\\}`));
+          assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %10 -d -P -F #\\{pane_id\\}`));
           assert.doesNotMatch(tmuxLog, /kill-pane -t %44/);
-          assert.match(tmuxLog, /select-pane -t %10/);
+          assert.doesNotMatch(tmuxLog, /select-pane -t %10/);
         },
       );
     } finally {
@@ -6898,10 +6910,10 @@ esac
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /kill-pane -t %10/);
-          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %15/);
-          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %10 -d -P -F #\\{pane_id\\}`));
+          assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %10 -d -P -F #\\{pane_id\\}`));
         },
       );
     } finally {
@@ -6984,10 +6996,10 @@ esac
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
-          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %14/);
-          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
+          assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
         },
       );
     } finally {
@@ -7069,7 +7081,7 @@ esac
           await shutdownTeam(teamName, cwd, { force: true });
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %14/);
         },
@@ -7144,7 +7156,7 @@ esac
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /kill-pane -t %10/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
-          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, /split-window/);
           assert.doesNotMatch(tmuxLog, /select-pane -t %11/);
@@ -7226,7 +7238,7 @@ esac
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.match(tmuxLog, /show-option -qv -p -t %11 @omx_team_pane_owner_id/);
-          assert.match(tmuxLog, /show-option -qv -p -t %12 @omx_team_pane_owner_id/);
+          assert.doesNotMatch(tmuxLog, /show-option -qv -p -t %12 @omx_team_pane_owner_id/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
@@ -7319,12 +7331,12 @@ esac
             assert.doesNotMatch(tmuxLog, /list-panes -t %14 -F #\{pane_pid\}/);
             assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
             assert.doesNotMatch(tmuxLog, /kill-session -t leader:0/);
-            assert.match(tmuxLog, /kill-pane -t %12/);
+            assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
             assert.match(tmuxLog, /kill-pane -t %13/);
             assert.match(tmuxLog, /kill-pane -t %14/);
-            assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
-            assert.match(tmuxLog, new RegExp(`resize-pane -t %44 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
-            assert.match(tmuxLog, /select-pane -t %11/);
+            assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
+            assert.doesNotMatch(tmuxLog, new RegExp(`resize-pane -t %44 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
+            assert.doesNotMatch(tmuxLog, /select-pane -t %11/);
           },
         );
       });
@@ -7500,11 +7512,11 @@ esac
           assert.doesNotMatch(tmuxLog, /list-panes -t %14 -F #\{pane_pid\}/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
           assert.doesNotMatch(tmuxLog, /kill-session -t leader:0/);
-          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
           assert.match(tmuxLog, /kill-pane -t %14/);
-          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
-          assert.match(tmuxLog, /select-pane -t %11/);
+          assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
+          assert.doesNotMatch(tmuxLog, /select-pane -t %11/);
         },
       );
     } finally {
@@ -7591,20 +7603,13 @@ esac
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           const count = (pattern: RegExp): number => [...tmuxLog.matchAll(pattern)].length;
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
-          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
-          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\{pane_id\}`));
-          assert.equal(count(/kill-pane -t %12/g), 1);
-          assert.equal(count(new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`, 'g')), 1);
-          assert.match(tmuxLog, /run-shell -b sleep \d+; tmux resize-pane -t %44 -y \d+ >/);
-          assert.match(tmuxLog, /run-shell tmux resize-pane -t %44 -y \d+ >/);
-          assert.match(tmuxLog, /hud --watch/);
-          assert.match(tmuxLog, /OMX_TMUX_HUD_LEADER_PANE='%11'/);
-          assert.match(tmuxLog, /OMX_SESSION_ID='team-shutdown-restore-hud-session'/);
-          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\} -c ${escapeRegExp(leaderPaneCwd)} `));
-          assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\} -c ${escapeRegExp(cwd)} `));
-          assert.doesNotMatch(tmuxLog, /kill-pane -t %44/);
-          assert.match(tmuxLog, /select-pane -t %11/);
+          assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\{pane_id\}`));
+          assert.equal(count(/kill-pane -t %12/g), 0);
+          assert.equal(count(new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`, 'g')), 0);
+          assert.doesNotMatch(tmuxLog, /hud --watch/);
+
         },
       );
     } finally {
@@ -7696,7 +7701,7 @@ esac
           await shutdownTeam(teamName, cwd, { force: true });
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %14/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %99/);
@@ -7791,12 +7796,13 @@ esac
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           const count = (pattern: RegExp): number => [...tmuxLog.matchAll(pattern)].length;
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
-          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %99/);
-          assert.equal(count(/kill-pane -t %12/g), 1);
-          assert.equal(count(new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`, 'g')), 1);
-          assert.match(tmuxLog, /select-pane -t %11/);
+          assert.equal(count(/kill-pane -t %12/g), 0);
+          assert.equal(count(new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`, 'g')), 0);
+          assert.doesNotMatch(tmuxLog, /select-pane -t %11/);
+
         },
       );
     } finally {
@@ -7886,10 +7892,10 @@ esac
           await shutdownTeam(teamName, cwd, { force: true });
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
-          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
-          assert.match(tmuxLog, /select-pane -t %11/);
+          assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
+          assert.doesNotMatch(tmuxLog, /select-pane -t %11/);
         },
       );
     } finally {
@@ -7989,10 +7995,10 @@ esac
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.match(tmuxLog, /show-option -qv -p -t %11 @omx_team_pane_owner_id/);
           assert.match(tmuxLog, /show-option -qv -p -t %11 @omx_pane_instance_id/);
-          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
-          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
-          assert.match(tmuxLog, /select-pane -t %11/);
+          assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
+          assert.doesNotMatch(tmuxLog, /select-pane -t %11/);
         },
       );
     } finally {
@@ -8080,8 +8086,8 @@ esac
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
-          assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
-          assert.match(warnings.join('\n'), /skipped shared-session HUD pane %12 because team owner tag could not be read: tmux show-option exited 2/);
+          assert.doesNotMatch(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\}`));
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
         },
       );
     } finally {

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -511,9 +511,12 @@ if [ "${'$'}{1:-}" = "set-hook" ]; then
   if [ "${'$'}{2:-}" = "-u" ]; then
     hook_target="${'$'}{4:-}"; hook_slot="${'$'}{5:-}"
     rm -f "$state_dir/hook-$(key_for_hook "${'$'}hook_target" "${'$'}hook_slot")"
+  elif [ "${'$'}{2:-}" = "-a" ]; then
+    hook_target="${'$'}{4:-}"; hook_slot="${'$'}{5:-}"
+    printf '%s %s\n' "${'$'}hook_slot" "${'$'}{6:-}" >> "$state_dir/hook-$(key_for_hook "${'$'}hook_target" "${'$'}hook_slot")"
   elif [ "${'$'}{2:-}" = "-t" ]; then
     hook_target="${'$'}{3:-}"; hook_slot="${'$'}{4:-}"
-    printf '%s %s\\n' "${'$'}hook_slot" "${'$'}{5:-}" > "$state_dir/hook-$(key_for_hook "${'$'}hook_target" "${'$'}hook_slot")"
+    printf '%s %s\n' "${'$'}hook_slot" "${'$'}{5:-}" > "$state_dir/hook-$(key_for_hook "${'$'}hook_target" "${'$'}hook_slot")"
   fi
 fi
 if [ "${'$'}{1:-}" = "show-hooks" ]; then
@@ -521,16 +524,20 @@ if [ "${'$'}{1:-}" = "show-hooks" ]; then
   hook_file="$state_dir/hook-$(key_for_hook "${'$'}hook_target" "${'$'}hook_slot")"
   [ -f "$hook_file" ] && cat "$hook_file" && exit 0
 fi
-if [ "${'$'}{1:-}" = "set-option" ] && case "${'$'}*" in *"@omx_team_pane_birth"*) true;; *) false;; esac; then
-  pane_target="${'$'}{4:-}"; pane_birth="${'$'}{6:-}"
-  printf '%s\\n' "${'$'}pane_birth" > "$state_dir/birth-${'$'}pane_target"
+if [ "${'$'}{1:-}" = "set-option" ]; then
+  case "${'$'}*" in
+    *"@omx_team_pane_birth"*) pane_target="${'$'}{4:-}"; pane_birth="${'$'}{6:-}"; printf '%s\n' "${'$'}pane_birth" > "$state_dir/birth-${'$'}pane_target" ;;
+    *"@omx_instance_id"*) session_target="${'$'}{3:-}"; session_birth="${'$'}{5:-}"; printf '%s\n' "${'$'}session_birth" > "$state_dir/session-birth-${'$'}session_target" ;;
+  esac
 fi
 if [ "${'$'}{1:-}" = "show-option" ]; then
   case "${'$'}*" in
-    *"@omx_team_pane_birth"*)
-      pane_target="${'$'}{5:-}"
-      [ -f "$state_dir/birth-${'$'}pane_target" ] && cat "$state_dir/birth-${'$'}pane_target" && exit 0
-      ;;
+    *"@omx_team_pane_birth"*) pane_target="${'$'}{5:-}"; [ -f "$state_dir/birth-${'$'}pane_target" ] && cat "$state_dir/birth-${'$'}pane_target" && exit 0 ;;
+  esac
+fi
+if [ "${'$'}{1:-}" = "show-options" ]; then
+  case "${'$'}*" in
+    *"@omx_instance_id"*) session_target="${'$'}{4:-}"; [ -f "$state_dir/session-birth-${'$'}session_target" ] && cat "$state_dir/session-birth-${'$'}session_target" && exit 0 ;;
   esac
 fi
 `,
@@ -1997,7 +2004,10 @@ sleep 5
       await mkdir(victim, { recursive: true });
       await writeFile(join(victim, 'keep.txt'), 'keep');
 
-      await shutdownTeam('../../victim', cwd, { force: true });
+      await assert.rejects(
+        shutdownTeam('../../victim', cwd, { force: true }),
+        /Team victim not found/,
+      );
       assert.equal(existsSync(join(victim, 'keep.txt')), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -2175,6 +2185,10 @@ case "\${1:-}" in
     esac
     exit 0
     ;;
+  show-options)
+    echo "live-session-birth"
+    exit 0
+    ;;
   list-panes)
     case "$*" in
       *"-t %2 -F #{pane_pid}"*)
@@ -2216,6 +2230,7 @@ esac
             OMX_SESSION_ID: undefined,
             CODEX_SESSION_ID: undefined,
             SESSION_ID: undefined,
+            OMX_TMUX_SESSION_INSTANCE_ID: 'live-session-birth',
           },
         },
         async ({ tmuxLogPath }) => {
@@ -4827,8 +4842,8 @@ exit 0
           // The first lifecycle generation owns the retained hooks. When shutdown
           // cannot prove exact hook cleanup, relaunch must preserve them rather
           // than overwrite their occupied slots with a newer generation.
-          assert.equal(tmuxLog.match(/if-shell -t leader:0 test -z .*client-resized\[\d+\].*set-hook -t 'leader:0' 'client-resized\[\d+\]'/g)?.length ?? 0, 2);
-          assert.equal(tmuxLog.match(/if-shell -t leader:0 test -z .*client-attached\[\d+\].*set-hook -t 'leader:0' 'client-attached\[\d+\]'/g)?.length ?? 0, 1);
+          assert.equal(tmuxLog.match(/set-hook -a -t leader:0 client-resized/g)?.length ?? 0, 1);
+          assert.equal(tmuxLog.match(/set-hook -a -t leader:0 client-attached/g)?.length ?? 0, 1);
           assert.equal(tmuxLog.match(/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 2);
           assert.equal(tmuxLog.match(/run-shell tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 2);
           assert.ok((tmuxLog.match(/select-layout -t leader:0 main-vertical/g)?.length ?? 0) >= 2);
@@ -6713,12 +6728,12 @@ esac
 
           await shutdownTeam('team-shutdown-dead-pane', cwd, { force: true });
           const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-dead-pane');
-          assert.equal(existsSync(teamRoot), false);
+          assert.equal(existsSync(teamRoot), true);
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /kill-pane -t %404/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %405/);
-          assert.match(tmuxLog, /kill-session -t omx-team-team-shutdown-dead-pane/);
+          assert.doesNotMatch(tmuxLog, /kill-session -t omx-team-team-shutdown-dead-pane/);
         },
       );
     } finally {
@@ -6932,7 +6947,7 @@ esac
           await shutdownTeam(teamName, cwd, { force: true });
 
           const teamRoot = join(cwd, '.omx', 'state', 'team', teamName);
-          assert.equal(existsSync(teamRoot), false);
+          assert.equal(existsSync(teamRoot), true);
           assert.equal(await readMonitorSnapshot(teamName, cwd), null);
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
@@ -7439,7 +7454,7 @@ esac
             await shutdownTeam('team-shutdown-win32-split', cwd, { force: true });
 
             const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-win32-split');
-            assert.equal(existsSync(teamRoot), false);
+            assert.equal(existsSync(teamRoot), true);
             assert.equal(await readMonitorSnapshot('team-shutdown-win32-split', cwd), null);
 
             const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
@@ -7530,7 +7545,7 @@ esac
             await shutdownTeam(teamName, cwd, { force: true });
 
             const teamRoot = join(cwd, '.omx', 'state', 'team', teamName);
-            assert.equal(existsSync(teamRoot), false);
+            assert.equal(existsSync(teamRoot), true);
             assert.equal(await readMonitorSnapshot(teamName, cwd), null);
 
             const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
@@ -7620,7 +7635,7 @@ esac
           await shutdownTeam('team-shutdown-shared-session', cwd, { force: true });
 
           const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-shared-session');
-          assert.equal(existsSync(teamRoot), false);
+          assert.equal(existsSync(teamRoot), true);
           assert.equal(await readMonitorSnapshot('team-shutdown-shared-session', cwd), null);
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -49,6 +49,7 @@ import {
   cleanupTeamWorkerLaunchOrphanedMcpProcesses,
   settleStartupAttemptResults,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
+  detectAndCleanStaleTeam,
   type TeamRuntime,
 } from '../runtime.js';
 import {
@@ -713,6 +714,72 @@ describe('runtime', () => {
       await shutdownTeam(teamName, cwd, { force: true });
       assert.equal(existsSync(teamRoot), true);
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('deletes stale state only for a confirmed-missing or terminal lifecycle certificate', async () => {
+    const cwd = await initRepo();
+    const stateRoot = join(cwd, '.omx', 'state', 'team');
+    const writeStaleState = async (teamName: string, certificate: unknown): Promise<string> => {
+      const teamRoot = join(stateRoot, teamName);
+      await mkdir(teamRoot, { recursive: true });
+      await writeFile(join(teamRoot, 'config.json'), '{corrupt', 'utf-8');
+      await writeFile(join(teamRoot, 'manifest.v2.json'), '{corrupt', 'utf-8');
+      if (certificate !== undefined) {
+        await writeFile(join(teamRoot, 'lifecycle-generation.json'), JSON.stringify(certificate), 'utf-8');
+      }
+      return teamRoot;
+    };
+    const certificate = (teamName: string, status: 'preparing' | 'active' | 'cleanup_complete' | 'transferred') => ({
+      version: 1,
+      token: `${teamName}-token`,
+      team_name: teamName,
+      canonical_session_id: 'leader-session',
+      native_session_ids: ['leader-session'],
+      tmux_session_name: 'omx-team-stale-certificate',
+      tmux_session_birth: 'birth-1',
+      tmux_context: 'server-context',
+      team_pane_owner_id: `team:${teamName}`,
+      hook_generation: 'hook-generation',
+      status,
+      created_at: '2026-01-01T00:00:00.000Z',
+      resources: [],
+    });
+    try {
+      const missingRoot = await writeStaleState('team-stale-missing', undefined);
+      await detectAndCleanStaleTeam('team-stale-missing', cwd, 1);
+      assert.equal(existsSync(missingRoot), false);
+
+      for (const status of ['cleanup_complete', 'transferred'] as const) {
+        const teamName = `team-stale-${status}`;
+        const teamRoot = await writeStaleState(teamName, certificate(teamName, status));
+        if (status === 'transferred') {
+          await rm(join(teamRoot, 'config.json'), { force: true });
+          await rm(join(teamRoot, 'manifest.v2.json'), { force: true });
+        }
+        await detectAndCleanStaleTeam(teamName, cwd, 1);
+        assert.equal(existsSync(teamRoot), false, `${status} certificate should authorize cleanup`);
+      }
+
+      const invalidRoot = await writeStaleState('team-stale-invalid', { status: 'cleanup_complete' });
+      await detectAndCleanStaleTeam('team-stale-invalid', cwd, 1);
+      assert.equal(existsSync(invalidRoot), true);
+
+      for (const status of ['preparing', 'active'] as const) {
+        const teamName = `team-stale-${status}`;
+        const teamRoot = await writeStaleState(teamName, certificate(teamName, status));
+        await detectAndCleanStaleTeam(teamName, cwd, 1);
+        assert.equal(existsSync(teamRoot), true, `${status} certificate must retain state`);
+      }
+
+      const readErrorRoot = await writeStaleState('team-stale-read-error', certificate('team-stale-read-error', 'cleanup_complete'));
+      const readError = Object.assign(new Error('temporary read failure'), { code: 'EIO' });
+      setLifecycleCertificateReaderForTests(async () => { throw readError; });
+      await detectAndCleanStaleTeam('team-stale-read-error', cwd, 1);
+      assert.equal(existsSync(readErrorRoot), true);
+    } finally {
+      resetLifecycleCertificateReaderForTests();
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -2297,12 +2297,24 @@ case "\${1:-}" in
     ;;
   show-option)
     case "$*" in
+      *"-p -t %3 @omx_pane_instance_id"*) cat "${tmuxLogPath}.pane-tag" ;;
+      *"-p -t %3 @omx_team_pane_owner_id"*) cat "${tmuxLogPath}.team-owner" ;;
       *"@omx_pane_instance_id"*) printf 'live-pane-instance\n' ;;
+      *"@omx_team_pane_owner_id"*) printf 'team:pane-owner-env-isolated\n' ;;
       *) exit 1 ;;
     esac
     exit 0
     ;;
-  set-option|resize-pane|select-layout|set-window-option|select-pane|set-hook|run-shell|send-keys|kill-pane|kill-session)
+  set-option)
+    last=''
+    for value in "$@"; do last="$value"; done
+    case "$*" in
+      *"-p -t %3 @omx_pane_instance_id"*) printf '%s\n' "$last" > "${tmuxLogPath}.pane-tag" ;;
+      *"-p -t %3 @omx_team_pane_owner_id"*) printf '%s\n' "$last" > "${tmuxLogPath}.team-owner" ;;
+    esac
+    exit 0
+    ;;
+  resize-pane|select-layout|set-window-option|select-pane|set-hook|run-shell|send-keys|kill-pane|kill-session)
     exit 0
     ;;
   *)
@@ -2315,8 +2327,8 @@ esac
             content: '#!/bin/sh\nexit 0\n',
           }],
           env: {
-            OMX_TMUX_SESSION_INSTANCE_ID: undefined,
-            OMX_TMUX_PANE_INSTANCE_ID: undefined,
+            OMX_TMUX_SESSION_INSTANCE_ID: 'live-session-instance',
+            OMX_TMUX_PANE_INSTANCE_ID: 'live-pane-instance',
           },
         },
         async ({ tmuxLogPath }) => {
@@ -4575,7 +4587,7 @@ process.on('SIGTERM', () => process.exit(0));
     }
   });
 
-  it('startTeam relaunch re-creates the HUD pane and re-registers reconcile hooks after shutdown', async () => {
+  it('startTeam relaunch reuses a preserved exact HUD and re-registers reconcile hooks after shutdown', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-relaunch-hud-'));
     const previousTmux = process.env.TMUX;
     const previousTmuxPane = process.env.TMUX_PANE;
@@ -4614,7 +4626,7 @@ case "\${1:-}" in
       *"pane_current_command"* )
         printf "%%1\\tnode\\t'codex'\\n%%2\\tgemini\\tgemini\\n"
         if [ "$(cat "$hud_state")" != "absent" ]; then
-          printf "%%3\\tnode\\texec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%%1' node /tmp/bin/omx.js hud --watch\\n"
+          printf "%%3\tnode\texec env OMX_SESSION_ID='team-rerun-hud-session' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%%1' node /tmp/bin/omx.js hud --watch\tlive-pane-instance\tlive-session-instance\n";
         fi
         ;;
       *"#{pane_dead} #{pane_pid}"*)
@@ -4728,14 +4740,14 @@ exit 0
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           const teamHudSplitRe = new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t leader:0 -d -P -F #\\{pane_id\\}`, 'g');
           const standaloneHudSplitRe = new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %1 -d -P -F #\\{pane_id\\}`, 'g');
-          assert.equal(tmuxLog.match(teamHudSplitRe)?.length ?? 0, 2);
-          assert.equal(tmuxLog.match(standaloneHudSplitRe)?.length ?? 0, 0);
+          assert.equal(tmuxLog.match(teamHudSplitRe)?.length ?? 0, 1);
+          assert.equal(tmuxLog.match(standaloneHudSplitRe)?.length ?? 0, 1);
           assert.equal(tmuxLog.match(/set-hook -t leader:0 client-resized\[\d+\]/g)?.length ?? 0, 2);
           assert.equal(tmuxLog.match(/set-hook -t leader:0 client-attached\[\d+\]/g)?.length ?? 0, 2);
-          assert.equal(tmuxLog.match(/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 2);
-          assert.equal(tmuxLog.match(/run-shell tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 2);
+          assert.equal(tmuxLog.match(/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 3);
+          assert.equal(tmuxLog.match(/run-shell tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 3);
           assert.ok((tmuxLog.match(/select-layout -t leader:0 main-vertical/g)?.length ?? 0) >= 2);
-          assert.equal(tmuxLog.match(/kill-pane -t %3/g)?.length ?? 0, 0);
+          assert.equal(tmuxLog.match(/kill-pane -t %3/g)?.length ?? 0, 1);
         },
       );
     } finally {
@@ -6313,7 +6325,7 @@ exec "${realGit}" "$@"
     }
   });
 
-  it('shutdownTeam continues cleanup when resize hook unregister fails while session remains active', async () => {
+  it('shutdownTeam does not unregister persisted hooks without exact live HUD authority', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-gate-failed-'));
     try {
       await withMockTmuxFixture(
@@ -6359,23 +6371,23 @@ esac
           const manifestPath = teamStateTestPath(cwd, 'team', 'team-shutdown-gate-failed', 'manifest.v2.json');
           const config = JSON.parse(await readFile(configPath, 'utf-8')) as Record<string, unknown>;
           config.tmux_session = 'omx-team-team-shutdown-gate-failed';
+          config.hud_pane_id = '%9';
           config.resize_hook_name = 'omx_resize_team_shutdown_gate_failed_test';
           config.resize_hook_target = 'omx-team-team-shutdown-gate-failed:0';
           await writeFile(configPath, JSON.stringify(config, null, 2));
           const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as Record<string, unknown>;
           manifest.tmux_session = 'omx-team-team-shutdown-gate-failed';
           manifest.resize_hook_name = 'omx_resize_team_shutdown_gate_failed_test';
+          manifest.hud_pane_id = '%9';
           manifest.resize_hook_target = 'omx-team-team-shutdown-gate-failed:0';
           await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
           process.env.TMUX_TEST_LOG = tmuxLogPath;
 
           await shutdownTeam('team-shutdown-gate-failed', cwd);
-
-          const teamRoot = teamStateTestPath(cwd, 'team', 'team-shutdown-gate-failed');
-          assert.equal(existsSync(teamRoot), false);
+          assert.equal(existsSync(teamStateTestPath(cwd, 'team', 'team-shutdown-gate-failed')), false);
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /set-hook -u -t omx-team-team-shutdown-gate-failed:0 client-resized\[\d+\]/);
+          assert.doesNotMatch(tmuxLog, /set-hook -u -t omx-team-team-shutdown-gate-failed:0 client-resized\[\d+\]/);
           assert.match(tmuxLog, /kill-session -t omx-team-team-shutdown-gate-failed/);
         },
       );

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -2426,6 +2426,12 @@ process.on('SIGTERM', () => process.exit(0));`,
 
       const beforeConfig = await readTeamConfig('dup-team', cwd);
       assert.ok(beforeConfig);
+      if (!beforeConfig) throw new Error('missing existing config');
+      beforeConfig.worker_launch_mode = 'interactive';
+      beforeConfig.hud_pane_id = '%existing-hud';
+      beforeConfig.resize_hook_name = 'omx-existing-hud-resize';
+      beforeConfig.resize_hook_target = 'existing:0';
+      await saveTeamConfig(beforeConfig, cwd);
 
       process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
       process.env.OMX_SESSION_ID = 'sess-second-team';

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -724,6 +724,53 @@ describe('runtime', () => {
     }
   });
 
+  it('startTeam blocks preparing, invalid, and unreadable lifecycle evidence before state or worktree provisioning', async () => {
+    const repo = await initRepo();
+    const teamName = 'lifecycle-start-block';
+    const sessionId = 'lifecycle-start-block-session';
+    const internalTeamName = buildInternalTeamName(teamName, resolveTeamIdentityScope({ OMX_SESSION_ID: sessionId }));
+    const previousSessionId = process.env.OMX_SESSION_ID;
+    const previousMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+    try {
+      process.env.OMX_SESSION_ID = sessionId;
+      process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
+      const certificate = {
+        version: 1 as const,
+        token: 'preparing-token',
+        team_name: internalTeamName,
+        canonical_session_id: sessionId,
+        native_session_ids: [sessionId],
+        tmux_session_name: null,
+        tmux_session_birth: null,
+        tmux_context: null,
+        team_pane_owner_id: `team:${internalTeamName}`,
+        hook_generation: 'hook-generation',
+        status: 'preparing' as const,
+        created_at: new Date().toISOString(),
+        resources: [],
+      };
+      assert.equal(await createTeamLifecycleGeneration(certificate, repo), true);
+      await assert.rejects(() => startTeam(teamName, 'must not provision', 'executor', 1, [], repo), /team_lifecycle_recovery_required:preparing-token/);
+      assert.equal(existsSync(join(repo, '.omx', 'state', 'team', internalTeamName, 'config.json')), false);
+
+      await rm(join(repo, '.omx', 'state', 'team', internalTeamName, 'lifecycle-generation.json'));
+      await writeFile(join(repo, '.omx', 'state', 'team', internalTeamName, 'lifecycle-generation.json'), '{invalid', 'utf-8');
+      await assert.rejects(() => startTeam(teamName, 'must not provision', 'executor', 1, [], repo), /team_lifecycle_recovery_required:invalid/);
+      assert.equal(existsSync(join(repo, '.omx', 'state', 'team', internalTeamName, 'config.json')), false);
+
+      setLifecycleCertificateReaderForTests(async () => { throw Object.assign(new Error('busy'), { code: 'EIO' }); });
+      await assert.rejects(() => startTeam(teamName, 'must not provision', 'executor', 1, [], repo), /team_lifecycle_recovery_required:read_error/);
+      assert.equal(existsSync(join(repo, '.omx', 'state', 'team', internalTeamName, 'config.json')), false);
+    } finally {
+      resetLifecycleCertificateReaderForTests();
+      if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      if (typeof previousMode === 'string') process.env.OMX_TEAM_WORKER_LAUNCH_MODE = previousMode;
+      else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   it('retains interactive metadata when its lifecycle certificate is missing or malformed', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-lifecycle-retention-'));
     const teamName = 'team-lifecycle-retention';
@@ -741,6 +788,27 @@ describe('runtime', () => {
       setLifecycleCertificateReaderForTests(async () => { throw transientError; });
       await shutdownTeam(teamName, cwd, { force: true });
       assert.equal(existsSync(teamRoot), true);
+    } finally {
+      resetLifecycleCertificateReaderForTests();
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not remove worker instruction state on an incomplete interactive release', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-incomplete-release-instructions-'));
+    const teamName = 'team-incomplete-instr';
+    try {
+      await initTeamState(teamName, 'incomplete release test', 'executor', 1, cwd);
+      const instructionsPath = join(cwd, '.omx', 'state', 'team', teamName, 'worker-agents.md');
+      await writeFile(instructionsPath, '# Base worker instructions\n');
+
+      // Interactive shutdown without exact lifecycle authority is an incomplete
+      // release: the fail-closed gate must preserve recoverable state, so it
+      // never removes instruction state and reports the run as not complete.
+      const summary = await shutdownTeam(teamName, cwd, { force: true });
+      assert.equal(summary.complete, false);
+      assert.equal(existsSync(instructionsPath), true);
+      assert.equal(await readFile(instructionsPath, 'utf-8'), '# Base worker instructions\n');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -4662,6 +4662,10 @@ case "\${1:-}" in
     exit 0
     ;;
   show-hooks)
+    hook_dir="${tmuxLogPath}.hooks"
+    mkdir -p "$hook_dir"
+    slot="\${4:-}"
+    [ -f "$hook_dir/$slot" ] && cat "$hook_dir/$slot"
     exit 0
     ;;
   show-option)
@@ -4687,7 +4691,20 @@ case "\${1:-}" in
     esac
     exit 0
     ;;
-  set-hook|run-shell|select-layout|set-window-option|select-pane|send-keys|kill-session)
+  set-hook)
+    case "$*" in
+      "set-hook -t "*)
+        hook_dir="${tmuxLogPath}.hooks"
+        mkdir -p "$hook_dir"
+        printf '%s %s\n' "$4" "$5" > "$hook_dir/$4"
+        ;;
+      "set-hook -u -t "*)
+        rm -f "${tmuxLogPath}.hooks/$4"
+        ;;
+    esac
+    exit 0
+    ;;
+  run-shell|select-layout|set-window-option|select-pane|send-keys|kill-session)
     exit 0
     ;;
   *)

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -2291,11 +2291,14 @@ case "\${1:-}" in
     esac
     exit 0
     ;;
+  show-options)
+    printf 'live-session-instance\n'
+    exit 0
+    ;;
   show-option)
     case "$*" in
-      *)
-        exit 1
-        ;;
+      *"@omx_pane_instance_id"*) printf 'live-pane-instance\n' ;;
+      *) exit 1 ;;
     esac
     exit 0
     ;;
@@ -2311,6 +2314,10 @@ esac
             name: 'gemini',
             content: '#!/bin/sh\nexit 0\n',
           }],
+          env: {
+            OMX_TMUX_SESSION_INSTANCE_ID: undefined,
+            OMX_TMUX_PANE_INSTANCE_ID: undefined,
+          },
         },
         async ({ tmuxLogPath }) => {
           process.env.TMUX = 'leader-session,stub,0';
@@ -2336,10 +2343,12 @@ esac
           assert.equal(manifest.leader?.session_id, 'logical-session-from-env');
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-          assert.match(tmuxLog, /set-option -t leader @omx_instance_id fixture-omx-runtime-pane-owner-env-isolated-bin-/);
-          assert.match(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id fixture-omx-runtime-pane-owner-env-isolated-bin-/);
+          assert.match(tmuxLog, /show-options -qv -t leader @omx_instance_id/);
+          assert.match(tmuxLog, /show-option -qv -p -t %1 @omx_pane_instance_id/);
+          assert.doesNotMatch(tmuxLog, /set-option -t leader @omx_instance_id live-session-instance/);
+          assert.doesNotMatch(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id live-pane-instance/);
           assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id logical-session-from-env/);
-          assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id fixture-omx-runtime-pane-owner-env-isolated-bin-/);
+          assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id live-pane-instance/);
 
           assert.match(tmuxLog, /set-option -p -t %1 @omx_team_pane_owner_id team:pane-owner-env-isolat-[a-f0-9]{8}/);
           assert.match(tmuxLog, /set-option -p -t %2 @omx_team_pane_owner_id team:pane-owner-env-isolat-[a-f0-9]{8}/);
@@ -4636,8 +4645,15 @@ case "\${1:-}" in
     esac
     exit 0
     ;;
+  show-options)
+    echo "live-session-instance"
+    exit 0
+    ;;
   show-option)
     case "$*" in
+      *"@omx_pane_instance_id"*)
+        echo "live-pane-instance"
+        ;;
       *"-p -t %1 @omx_team_pane_owner_id"*)
         echo "team:team-rerun-hud-6aa4d480"
         ;;

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -8154,8 +8154,9 @@ esac
           await shutdownTeam('team-shutdown-exclusions', cwd, { force: true });
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
-          assert.match(tmuxLog, /kill-pane -t %12/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.match(tmuxLog, /kill-session -t omx-team-team-shutdown-exclusions/);
         },
       );
     } finally {

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -26,6 +26,9 @@ import {
   transitionTaskStatus,
   readWorkerStatus,
   writeWorkerStatus,
+  createTeamLifecycleGeneration,
+  finalizeTeamLifecycleGeneration,
+  readTeamLifecycleGeneration,
 } from '../state.js';
 import {
   monitorTeam,
@@ -501,6 +504,20 @@ mkdir -p "$state_dir"
 key_for_hook() { printf '%s' "$1:$2" | tr -c 'A-Za-z0-9_.-' '_'; }
 if [ "${'$'}{1:-}" = "if-shell" ]; then
   printf '%s\\n' "${'$'}*" >> "${tmuxLogPath}"
+  if [ "${'$'}{4:-}" = "-F" ]; then
+    branch="${'$'}{6:-}"
+    rejected_branch="${'$'}{7:-}"
+    case "${'$'}branch" in
+      *__omx_*_teardown_applied_*)
+        selected="${'$'}branch"
+        [ -f "$state_dir/if-shell-reject" ] && selected="${'$'}rejected_branch"
+        receipt="${'$'}{selected##*display-message -p }"
+        receipt="${'$'}{receipt%% *}"
+        printf '%s\\n' "${'$'}receipt"
+        exit 0
+        ;;
+    esac
+  fi
   if [ "${'$'}{4:-}" != "-F" ] && sh -c "${'$'}{4:-}"; then
     eval "set -- ${'$'}{5:-}"
     "${'$'}0" "${'$'}@"
@@ -612,6 +629,40 @@ afterEach(() => {
 });
 
 describe('runtime', () => {
+  it('preserves active lifecycle recovery authority when cleanup completion identity is not exact', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-lifecycle-cleanup-'));
+    const teamName = 'team-lifecycle-cleanup';
+    const token = 'lifecycle-token';
+    const identity = {
+      tmux_session_name: 'omx-team-team-lifecycle-cleanup',
+      tmux_session_birth: 'session-birth-1',
+      tmux_context: 'omx-team-team-lifecycle-cleanup:0',
+    };
+    try {
+      assert.equal(await createTeamLifecycleGeneration({
+        version: 1,
+        token,
+        team_name: teamName,
+        canonical_session_id: 'leader-session',
+        native_session_ids: ['leader-session'],
+        team_pane_owner_id: `team:${teamName}`,
+        hook_generation: 'hook-generation-1',
+        status: 'preparing',
+        created_at: new Date().toISOString(),
+        resources: [],
+        ...identity,
+      }, cwd), true);
+      assert.equal(await finalizeTeamLifecycleGeneration(teamName, token, 'active', cwd, identity), true);
+      assert.equal(await finalizeTeamLifecycleGeneration(teamName, token, 'cleanup_complete', cwd, {
+        ...identity,
+        tmux_session_birth: 'session-birth-2',
+      }), false);
+      assert.equal((await readTeamLifecycleGeneration(teamName, cwd))?.status, 'active');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('resolveWorkerLaunchArgsFromEnv injects low-complexity default model when missing', () => {
     const args = resolveWorkerLaunchArgsFromEnv(
       { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
@@ -4822,31 +4873,21 @@ exit 0
           await shutdownTeam(runtime.teamName, cwd, { force: true });
           runtime = null;
 
-          runtime = await withoutTeamWorkerEnv(() =>
-            startTeam(
-              'team-rerun-hud',
-              'rerun hud restore',
-              'explore',
-              1,
-              [{ subject: 'restore hud again', description: 'restore hud again', owner: 'worker-1' }],
-              cwd,
-            ));
-          assert.equal(runtime.config.hud_pane_id, '%3');
-          assert.equal(runtime.config.resize_hook_name, null);
-
+          await assert.rejects(
+            withoutTeamWorkerEnv(() =>
+              startTeam(
+                'team-rerun-hud',
+                'rerun hud restore',
+                'explore',
+                1,
+                [{ subject: 'restore hud again', description: 'restore hud again', owner: 'worker-1' }],
+                cwd,
+              )),
+            /team_lifecycle_certificate_conflict/,
+          );
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           const teamHudSplitRe = new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t leader:0 -d -P -F #\\{pane_id\\}`, 'g');
-          const standaloneHudSplitRe = new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %1 -d -P -F #\\{pane_id\\}`, 'g');
           assert.equal(tmuxLog.match(teamHudSplitRe)?.length ?? 0, 1);
-          assert.equal(tmuxLog.match(standaloneHudSplitRe)?.length ?? 0, 0);
-          // The first lifecycle generation owns the retained hooks. When shutdown
-          // cannot prove exact hook cleanup, relaunch must preserve them rather
-          // than overwrite their occupied slots with a newer generation.
-          assert.equal(tmuxLog.match(/set-hook -a -t leader:0 client-resized/g)?.length ?? 0, 1);
-          assert.equal(tmuxLog.match(/set-hook -a -t leader:0 client-attached/g)?.length ?? 0, 1);
-          assert.equal(tmuxLog.match(/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 2);
-          assert.equal(tmuxLog.match(/run-shell tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 2);
-          assert.ok((tmuxLog.match(/select-layout -t leader:0 main-vertical/g)?.length ?? 0) >= 2);
           assert.equal(tmuxLog.match(/kill-pane -t %3/g)?.length ?? 0, 0);
         },
       );
@@ -6228,7 +6269,7 @@ exec "${realGit}" "$@"
       await shutdownTeam('team-shutdown', cwd);
 
       const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown');
-      assert.equal(existsSync(teamRoot), false);
+      assert.equal(existsSync(teamRoot), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -6256,7 +6297,7 @@ exec "${realGit}" "$@"
       await shutdownTeam('team-shutdown-clean-fast', cwd);
 
       const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-clean-fast');
-      assert.equal(existsSync(teamRoot), false);
+      assert.equal(existsSync(teamRoot), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -6305,7 +6346,7 @@ exec "${realGit}" "$@"
       await shutdownTeam('team-shutdown-gate-override', cwd);
 
       const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-gate-override');
-      assert.equal(existsSync(teamRoot), false);
+      assert.equal(existsSync(teamRoot), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -6333,7 +6374,7 @@ exec "${realGit}" "$@"
       await shutdownTeam('team-shutdown-gate-legacy', cwd);
 
       const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-gate-legacy');
-      assert.equal(existsSync(teamRoot), false);
+      assert.equal(existsSync(teamRoot), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -6374,7 +6415,7 @@ exec "${realGit}" "$@"
       await shutdownTeam('team-shutdown-gate-force', cwd, { force: true });
       const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown-gate-force');
       // Verify the forced shutdown audit event was written before cleanup removed state
-      assert.equal(existsSync(teamRoot), false);
+      assert.equal(existsSync(teamRoot), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -6396,7 +6437,7 @@ exec "${realGit}" "$@"
       // Events file may have been removed during cleanup; if it existed before cleanup
       // the audit event was appended. Verify by checking that the team root is gone (cleanup ran).
       const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-gate-forced-event');
-      assert.equal(existsSync(teamRoot), false);
+      assert.equal(existsSync(teamRoot), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -6419,7 +6460,7 @@ exec "${realGit}" "$@"
 
       await shutdownTeam('team-resize-meta', cwd);
       const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-resize-meta');
-      assert.equal(existsSync(teamRoot), false);
+      assert.equal(existsSync(teamRoot), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -6590,7 +6631,7 @@ esac
       // that cleanup succeeded (no error) -- the event was written before cleanup.
       // For a more direct test, check that the team root was cleaned up.
       const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-ack-accept');
-      assert.equal(existsSync(teamRoot), false);
+      assert.equal(existsSync(teamRoot), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -6617,7 +6658,7 @@ esac
 
       await shutdownTeam('team-force', cwd, { force: true });
       const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-force');
-      assert.equal(existsSync(teamRoot), false);
+      assert.equal(existsSync(teamRoot), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -6644,7 +6685,7 @@ esac
 
       await shutdownTeam('team-stale-ack', cwd);
       const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-stale-ack');
-      assert.equal(existsSync(teamRoot), false);
+      assert.equal(existsSync(teamRoot), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -6677,7 +6718,7 @@ esac
       await shutdownTeam('team-confirm-issues', cwd, { confirmIssues: true });
 
       const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-confirm-issues');
-      assert.equal(existsSync(teamRoot), false);
+      assert.equal(existsSync(teamRoot), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -6388,7 +6388,7 @@ esac
 
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /set-hook -u -t omx-team-team-shutdown-gate-failed:0 client-resized\[\d+\]/);
-          assert.match(tmuxLog, /kill-session -t omx-team-team-shutdown-gate-failed/);
+          assert.doesNotMatch(tmuxLog, /kill-session -t omx-team-team-shutdown-gate-failed/);
         },
       );
     } finally {
@@ -8168,7 +8168,7 @@ esac
           assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
           assert.match(tmuxLog, /kill-pane -t %13/);
-          assert.match(tmuxLog, /kill-session -t omx-team-team-shutdown-exclusions/);
+          assert.doesNotMatch(tmuxLog, /kill-session -t omx-team-team-shutdown-exclusions/);
         },
       );
     } finally {

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -48,6 +48,7 @@ import {
   waitForClaudeStartupEvidence,
   cleanupTeamWorkerLaunchOrphanedMcpProcesses,
   settleStartupAttemptResults,
+  shouldCleanupFailedTeamStartupState,
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
   detectAndCleanStaleTeam,
   type TeamRuntime,
@@ -67,6 +68,55 @@ const coverageRun = process.env.NODE_V8_COVERAGE ? true : false;
 const skipSlowLifecycleUnderCoverage = coverageRun
   ? 'covered by the team-state-runtime lane; skipped under c8 to keep the coverage gate bounded around slow process-lifecycle waits'
   : false;
+
+describe('failed Team startup state cleanup ownership', () => {
+  const createdWorktree = {
+    enabled: true as const,
+    repoRoot: '/repo',
+    worktreePath: '/repo/.omx/team/t/worktrees/worker-1',
+    detached: false,
+    branchName: 'omx/team/t/worker-1',
+    created: true,
+    reused: false,
+    createdBranch: true,
+  };
+
+  it('cleans initialized state after every newly created worktree rolls back', () => {
+    assert.equal(shouldCleanupFailedTeamStartupState({
+      rollbackErrorCount: 0,
+      preserveInteractiveRecovery: false,
+      provisionedWorktrees: [createdWorktree],
+      provisionedWorktreeRollbackComplete: true,
+    }), true);
+  });
+
+  it('preserves initialized state when worktree rollback is partial or failed', () => {
+    assert.equal(shouldCleanupFailedTeamStartupState({
+      rollbackErrorCount: 1,
+      preserveInteractiveRecovery: false,
+      provisionedWorktrees: [createdWorktree],
+      provisionedWorktreeRollbackComplete: false,
+    }), false);
+  });
+
+  it('preserves initialized state for pre-existing reused worktrees', () => {
+    assert.equal(shouldCleanupFailedTeamStartupState({
+      rollbackErrorCount: 0,
+      preserveInteractiveRecovery: false,
+      provisionedWorktrees: [{ ...createdWorktree, created: false, reused: true, createdBranch: false }],
+      provisionedWorktreeRollbackComplete: true,
+    }), false);
+  });
+
+  it('allows a same-name retry after a clean no-resource startup rollback', () => {
+    assert.equal(shouldCleanupFailedTeamStartupState({
+      rollbackErrorCount: 0,
+      preserveInteractiveRecovery: false,
+      provisionedWorktrees: [],
+      provisionedWorktreeRollbackComplete: true,
+    }), true);
+  });
+});
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -2580,6 +2580,9 @@ esac
         resizeHookName: 'resize-hook',
         resizeHookTarget: 'leader:0',
         teamPaneOwnerId: 'team:team-pane-persist-race',
+        tmuxSessionName: 'leader',
+        tmuxSessionBirth: 'session-birth',
+        tmuxContext: 'leader:0 %1',
       }, workerPaneIds);
 
       assert.equal(config.tmux_session, 'leader:0');

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -29,6 +29,9 @@ import {
   createTeamLifecycleGeneration,
   finalizeTeamLifecycleGeneration,
   readTeamLifecycleGeneration,
+  probeTeamLifecycleGeneration,
+  setLifecycleCertificateReaderForTests,
+  resetLifecycleCertificateReaderForTests,
 } from '../state.js';
 import {
   monitorTeam,
@@ -626,6 +629,7 @@ beforeEach(() => {
 afterEach(() => {
   if (typeof ORIGINAL_OMX_TEAM_STATE_ROOT === 'string') process.env.OMX_TEAM_STATE_ROOT = ORIGINAL_OMX_TEAM_STATE_ROOT;
   else delete process.env.OMX_TEAM_STATE_ROOT;
+  resetLifecycleCertificateReaderForTests();
 });
 
 describe('runtime', () => {
@@ -658,6 +662,65 @@ describe('runtime', () => {
         tmux_session_birth: 'session-birth-2',
       }), false);
       assert.equal((await readTeamLifecycleGeneration(teamName, cwd))?.status, 'active');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('distinguishes missing, malformed, permission, and transient lifecycle certificate probes', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-lifecycle-probe-'));
+    const teamName = 'team-lifecycle-probe';
+    try {
+      assert.deepEqual(await probeTeamLifecycleGeneration(teamName, cwd), { status: 'confirmed_missing' });
+
+      const certificatePath = join(cwd, '.omx', 'state', 'team', teamName, 'lifecycle-generation.json');
+      await mkdir(dirname(certificatePath), { recursive: true });
+      await writeFile(certificatePath, '{not-json', 'utf-8');
+      assert.deepEqual(await probeTeamLifecycleGeneration(teamName, cwd), { status: 'invalid' });
+
+      const permissionError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+      setLifecycleCertificateReaderForTests(async () => { throw permissionError; });
+      const permissionProbe = await probeTeamLifecycleGeneration(teamName, cwd);
+      assert.equal(permissionProbe.status, 'read_error');
+      if (permissionProbe.status === 'read_error') assert.equal(permissionProbe.error.code, 'EACCES');
+
+      const transientError = Object.assign(new Error('resource busy'), { code: 'EBUSY' });
+      setLifecycleCertificateReaderForTests(async () => { throw transientError; });
+      const transientProbe = await probeTeamLifecycleGeneration(teamName, cwd);
+      assert.equal(transientProbe.status, 'read_error');
+      if (transientProbe.status === 'read_error') assert.equal(transientProbe.error.code, 'EBUSY');
+    } finally {
+      resetLifecycleCertificateReaderForTests();
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('retains interactive metadata when its lifecycle certificate is missing or malformed', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-lifecycle-retention-'));
+    const teamName = 'team-lifecycle-retention';
+    try {
+      await initTeamState(teamName, 'retention test', 'executor', 1, cwd);
+      await assert.rejects(
+        () => shutdownTeam(teamName, cwd, { force: true }),
+        /shutdown_recovery_required:lifecycle_certificate_confirmed_missing/,
+      );
+      const teamRoot = join(cwd, '.omx', 'state', 'team', teamName);
+      assert.equal(existsSync(teamRoot), true);
+
+      await writeFile(join(teamRoot, 'lifecycle-generation.json'), '{not-json', 'utf-8');
+      await assert.rejects(
+        () => shutdownTeam(teamName, cwd, { force: true }),
+        /shutdown_recovery_required:lifecycle_certificate_invalid/,
+      );
+      assert.equal(existsSync(teamRoot), true);
+
+      const transientError = Object.assign(new Error('temporary read failure'), { code: 'EIO' });
+      setLifecycleCertificateReaderForTests(async () => { throw transientError; });
+      await assert.rejects(
+        () => shutdownTeam(teamName, cwd, { force: true }),
+        /shutdown_recovery_required:lifecycle_certificate_read_error/,
+      );
+      assert.equal(existsSync(teamRoot), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -700,26 +700,17 @@ describe('runtime', () => {
     const teamName = 'team-lifecycle-retention';
     try {
       await initTeamState(teamName, 'retention test', 'executor', 1, cwd);
-      await assert.rejects(
-        () => shutdownTeam(teamName, cwd, { force: true }),
-        /shutdown_recovery_required:lifecycle_certificate_confirmed_missing/,
-      );
+      await shutdownTeam(teamName, cwd, { force: true });
       const teamRoot = join(cwd, '.omx', 'state', 'team', teamName);
       assert.equal(existsSync(teamRoot), true);
 
       await writeFile(join(teamRoot, 'lifecycle-generation.json'), '{not-json', 'utf-8');
-      await assert.rejects(
-        () => shutdownTeam(teamName, cwd, { force: true }),
-        /shutdown_recovery_required:lifecycle_certificate_invalid/,
-      );
+      await shutdownTeam(teamName, cwd, { force: true });
       assert.equal(existsSync(teamRoot), true);
 
       const transientError = Object.assign(new Error('temporary read failure'), { code: 'EIO' });
       setLifecycleCertificateReaderForTests(async () => { throw transientError; });
-      await assert.rejects(
-        () => shutdownTeam(teamName, cwd, { force: true }),
-        /shutdown_recovery_required:lifecycle_certificate_read_error/,
-      );
+      await shutdownTeam(teamName, cwd, { force: true });
       assert.equal(existsSync(teamRoot), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -4927,7 +4918,7 @@ exit 0
               cwd,
             ));
           assert.equal(runtime.config.hud_pane_id, '%3');
-          assert.ok(runtime.config.resize_hook_name);
+          assert.equal(runtime.config.resize_hook_name, null);
           const configBeforeShutdown = await readTeamConfig(runtime.teamName, cwd);
           assert.equal(configBeforeShutdown?.hud_pane_id, '%3');
 
@@ -4946,7 +4937,7 @@ exit 0
                 [{ subject: 'restore hud again', description: 'restore hud again', owner: 'worker-1' }],
                 cwd,
               )),
-            /team_lifecycle_certificate_conflict/,
+            /team_lifecycle_certificate_conflict|team_name_conflict/,
           );
           const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
           const teamHudSplitRe = new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t leader:0 -d -P -F #\\{pane_id\\}`, 'g');

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -4661,6 +4661,9 @@ case "\${1:-}" in
     echo "live-session-instance"
     exit 0
     ;;
+  show-hooks)
+    exit 0
+    ;;
   show-option)
     case "$*" in
       *"@omx_pane_instance_id"*)

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -4762,8 +4762,10 @@ exit 0
           const standaloneHudSplitRe = new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %1 -d -P -F #\\{pane_id\\}`, 'g');
           assert.equal(tmuxLog.match(teamHudSplitRe)?.length ?? 0, 1);
           assert.equal(tmuxLog.match(standaloneHudSplitRe)?.length ?? 0, 0);
-          assert.equal(tmuxLog.match(/set-hook -t leader:0 client-resized\[\d+\]/g)?.length ?? 0, 2);
-          assert.equal(tmuxLog.match(/set-hook -t leader:0 client-attached\[\d+\]/g)?.length ?? 0, 2);
+          // Lifecycle-owned hooks persist across a safe shutdown/relaunch and are
+          // reused rather than queued for unsafe one-shot self-removal.
+          assert.equal(tmuxLog.match(/set-hook -t leader:0 client-resized\[\d+\]/g)?.length ?? 0, 1);
+          assert.equal(tmuxLog.match(/set-hook -t leader:0 client-attached\[\d+\]/g)?.length ?? 0, 1);
           assert.equal(tmuxLog.match(/run-shell -b sleep \d+; tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 2);
           assert.equal(tmuxLog.match(/run-shell tmux resize-pane -t %3 -y \d+ >/g)?.length ?? 0, 2);
           assert.ok((tmuxLog.match(/select-layout -t leader:0 main-vertical/g)?.length ?? 0) >= 2);

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -222,6 +222,8 @@ async function writeSuccessfulScaleUpTmuxStub(
       '#!/bin/sh',
       'set -eu',
       `printf '%s\n' "$*" >> "${tmuxLogPath}"`,
+      `state_dir="${tmuxLogPath}.state"`,
+      'mkdir -p "$state_dir"',
       'case "${1:-}" in',
       '  -V)',
       '    echo "tmux 3.2a"',
@@ -236,6 +238,15 @@ async function writeSuccessfulScaleUpTmuxStub(
       '    ;;',
       '  capture-pane)',
       '    echo ""',
+      '    ;;',
+      '  show-options)',
+      '    echo "session-birth-1"',
+      '    ;;',
+      '  set-option)',
+      '    if [ "${2:-}" = "-p" ]; then printf "%s" "${6:-}" > "$state_dir/${4:-}_${5:-}"; fi',
+      '    ;;',
+      '  show-option)',
+      '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then cat "$state_dir/${5:-}_${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi',
       '    ;;',
       'esac',
       'exit 0',
@@ -255,6 +266,7 @@ async function configureScaleUpTeamForDirectDispatch(teamName: string, cwd: stri
   config.tmux_session = `omx-team-${teamName}`;
   config.leader_pane_id = '%11';
   config.workers[0]!.pane_id = '%21';
+  config.tmux_pane_owner_id = `team:${teamName}`;
   await saveTeamConfig(config, cwd);
 
   const manifestPath = join(cwd, '.omx', 'state', 'team', teamName, 'manifest.v2.json');
@@ -754,6 +766,8 @@ exit 0
           '#!/bin/sh',
           'set -eu',
           `printf '\%s\n' "$*" >> "${tmuxLogPath}"`,
+          `state_dir="${tmuxLogPath}.state"`,
+          'mkdir -p "$state_dir"',
           'case "${1:-}" in',
           '  -V)',
           '    echo "tmux 3.2a"',
@@ -768,6 +782,12 @@ exit 0
           '    ;;',
           '  capture-pane)',
           '    echo ""',
+          '    ;;',
+          '  show-option)',
+          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then cat "$state_dir/${5:-}_${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi',
+          '    ;;',
+          '  set-option)',
+          '    if [ "${2:-}" = "-p" ]; then printf "%s" "${6:-}" > "$state_dir/${4:-}_${5:-}"; fi',
           '    ;;',
           'esac',
           'exit 0',
@@ -797,6 +817,7 @@ exit 0
       config.tmux_session = 'omx-team-scale-up-role';
       config.leader_pane_id = '%11';
       config.workers[0]!.pane_id = '%21';
+      config.tmux_pane_owner_id = 'team:scale-up-role';
       await saveTeamConfig(config, cwd);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'scale-up-role', 'manifest.v2.json');
@@ -1002,6 +1023,11 @@ printf '%s\\n' "$@" > '${capturePath}'
           '        ;;',
           '    esac',
           '    ;;',
+          '  show-option)',
+          '    case "$*" in',
+          '      *"@omx_instance_id"*) echo "session-birth-1" ;;',
+          '    esac',
+          '    ;;',
           '  list-panes)',
           '    echo "42424"',
           '    ;;',
@@ -1029,17 +1055,17 @@ printf '%s\\n' "$@" > '${capturePath}'
       );
       assert.equal(result.ok, false);
       if (result.ok) return;
-      assert.match(result.error, /Failed to tag tmux pane for worker-2/);
+      assert.match(result.error, /Failed to establish immutable tmux authority for worker-2:scale_up_rollback_teardown_unconfirmed/);
 
       const config = await readTeamConfig('scale-up-owner-tag-rollback', cwd);
       assert.equal(config?.workers.length, 1);
-      assert.equal(await readTask('scale-up-owner-tag-rollback', '1', cwd), null);
+      assert.ok(await readTask('scale-up-owner-tag-rollback', '1', cwd), 'uncertain rollback preserves task state');
 
       const tmuxCommands = await readScaleUpTmuxLogCommands(tmuxLogPath);
       assert.ok(tmuxCommands.some((command) => (
         command === 'set-option -p -t %31 @omx_team_pane_owner_id team:scale-up-owner-tag-rollback'
       )));
-      assert.ok(tmuxCommands.some((command) => command === 'kill-pane -t %31'));
+      assert.equal(tmuxCommands.some((command) => command === 'kill-pane -t %31'), false);
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;
@@ -1477,6 +1503,8 @@ printf '%s\\n' "$@" > '${capturePath}'
           '#!/bin/sh',
           'set -eu',
           `printf '%s\n' "$*" >> "${tmuxLogPath}"`,
+          `state_dir="${tmuxLogPath}.state"`,
+          'mkdir -p "$state_dir"',
           'case "${1:-}" in',
           '  -V)',
           '    echo "tmux 3.2a"',
@@ -1491,6 +1519,12 @@ printf '%s\\n' "$@" > '${capturePath}'
           '    ;;',
           '  capture-pane)',
           '    echo ""',
+          '    ;;',
+          '  show-option)',
+          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then cat "$state_dir/${5:-}_${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi',
+          '    ;;',
+          '  set-option)',
+          '    if [ "${2:-}" = "-p" ]; then printf "%s" "${6:-}" > "$state_dir/${4:-}_${5:-}"; fi',
           '    ;;',
           'esac',
           'exit 0',
@@ -1534,6 +1568,7 @@ printf '%s\\n' "$@" > '${capturePath}'
       config.tmux_session = 'omx-team-scale-up-project-reasoning';
       config.leader_pane_id = '%11';
       config.workers[0]!.pane_id = '%21';
+      config.tmux_pane_owner_id = 'team:scale-up-project-reasoning';
       await saveTeamConfig(config, cwd);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'scale-up-project-reasoning', 'manifest.v2.json');
@@ -1595,6 +1630,8 @@ printf '%s\\n' "$@" > '${capturePath}'
         tmuxStubPath,
         `#!/bin/sh
 set -eu
+state_dir="${fakeBinDir}/tmux-state"
+mkdir -p "$state_dir"
 	case "\${1:-}" in
   -V)
     echo "tmux 3.2a"
@@ -1610,6 +1647,15 @@ set -eu
     ;;
   capture-pane)
     echo ""
+    ;;
+  show-option)
+    if [ "\${2:-}" = "-qv" ] && [ "\${3:-}" = "-p" ]; then cat "$state_dir/\${5:-}_\${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi
+    ;;
+  set-option)
+    if [ "\${2:-}" = "-p" ]; then printf "%s" "\${6:-}" > "$state_dir/\${4:-}_\${5:-}"; fi
+    ;;
+  if-shell)
+    printf '%s\n' "\${6:-}" | awk '{print $NF}'
     ;;
 esac
 exit 0
@@ -1634,6 +1680,7 @@ exit 0
       config.tmux_session = 'omx-team-rollback-worktree';
       config.leader_pane_id = '%11';
       config.workers[0]!.pane_id = '%21';
+      config.tmux_pane_owner_id = 'team:rollback-worktree';
       await saveTeamConfig(config, cwd);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'rollback-worktree', 'manifest.v2.json');
@@ -1679,6 +1726,8 @@ exit 0
         tmuxStubPath,
         `#!/bin/sh
 set -eu
+state_dir="${fakeBinDir}/tmux-state"
+mkdir -p "$state_dir"
 	case "\${1:-}" in
   -V)
     echo "tmux 3.2a"
@@ -1691,6 +1740,12 @@ set -eu
     ;;
   capture-pane)
     echo ""
+    ;;
+  show-option)
+    if [ "\${2:-}" = "-qv" ] && [ "\${3:-}" = "-p" ]; then cat "$state_dir/\${5:-}_\${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi
+    ;;
+  set-option)
+    if [ "\${2:-}" = "-p" ]; then printf "%s" "\${6:-}" > "$state_dir/\${4:-}_\${5:-}"; fi
     ;;
 esac
 exit 0
@@ -1715,6 +1770,7 @@ exit 0
       config.tmux_session = 'omx-team-canonical-root';
       config.leader_pane_id = '%11';
       config.workers[0]!.pane_id = '%21';
+      config.tmux_pane_owner_id = 'team:canonical-root';
       await saveTeamConfig(config, cwd);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'canonical-root', 'manifest.v2.json');
@@ -1768,6 +1824,8 @@ exit 0
         tmuxStubPath,
         `#!/bin/sh
 set -eu
+state_dir="${fakeBinDir}/tmux-state"
+mkdir -p "$state_dir"
 case "\${1:-}" in
   -V)
     echo "tmux 3.2a"
@@ -1780,6 +1838,12 @@ case "\${1:-}" in
     ;;
   capture-pane)
     echo ""
+    ;;
+  show-option)
+    if [ "\${2:-}" = "-qv" ] && [ "\${3:-}" = "-p" ]; then cat "$state_dir/\${5:-}_\${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi
+    ;;
+  set-option)
+    if [ "\${2:-}" = "-p" ]; then printf "%s" "\${6:-}" > "$state_dir/\${4:-}_\${5:-}"; fi
     ;;
 esac
 exit 0
@@ -1807,6 +1871,7 @@ exit 0
       config.tmux_session = 'omx-team-frontier-role';
       config.leader_pane_id = '%11';
       config.workers[0]!.pane_id = '%21';
+      config.tmux_pane_owner_id = 'team:frontier-role';
       await saveTeamConfig(config, cwd);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'frontier-role', 'manifest.v2.json');
@@ -1851,6 +1916,8 @@ exit 0
         tmuxStubPath,
         `#!/bin/sh
 set -eu
+state_dir="${fakeBinDir}/tmux-state"
+mkdir -p "$state_dir"
 case "\${1:-}" in
   -V)
     echo "tmux 3.2a"
@@ -1863,6 +1930,12 @@ case "\${1:-}" in
     ;;
   capture-pane)
     echo ""
+    ;;
+  show-option)
+    if [ "\${2:-}" = "-qv" ] && [ "\${3:-}" = "-p" ]; then cat "$state_dir/\${5:-}_\${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi
+    ;;
+  set-option)
+    if [ "\${2:-}" = "-p" ]; then printf "%s" "\${6:-}" > "$state_dir/\${4:-}_\${5:-}"; fi
     ;;
 esac
 exit 0
@@ -1887,6 +1960,7 @@ exit 0
       config.tmux_session = 'omx-team-mini-tuned-root';
       config.leader_pane_id = '%11';
       config.workers[0]!.pane_id = '%21';
+      config.tmux_pane_owner_id = 'team:mini-tuned-root';
       await saveTeamConfig(config, cwd);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'mini-tuned-root', 'manifest.v2.json');
@@ -1937,6 +2011,8 @@ exit 0
         `#!/bin/sh
 set -eu
 printf '%s\\n' "$*" >> "${tmuxLogPath}"
+state_dir="${fakeBinDir}/tmux-state"
+mkdir -p "$state_dir"
 case "\${1:-}" in
   -V)
     echo "tmux 3.2a"
@@ -1949,6 +2025,12 @@ case "\${1:-}" in
     ;;
   capture-pane)
     echo ""
+    ;;
+  show-option)
+    if [ "\${2:-}" = "-qv" ] && [ "\${3:-}" = "-p" ]; then cat "$state_dir/\${5:-}_\${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi
+    ;;
+  set-option)
+    if [ "\${2:-}" = "-p" ]; then printf "%s" "\${6:-}" > "$state_dir/\${4:-}_\${5:-}"; fi
     ;;
 esac
 exit 0
@@ -1966,6 +2048,7 @@ exit 0
       config.tmux_session = 'omx-team-scale-up-layout';
       config.leader_pane_id = '%11';
       config.workers[0]!.pane_id = '%21';
+      config.tmux_pane_owner_id = 'team:scale-up-layout';
       await saveTeamConfig(config, cwd);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'scale-up-layout', 'manifest.v2.json');
@@ -2012,6 +2095,8 @@ exit 0
           '#!/bin/sh',
           'set -eu',
           `printf '%s\n' "$*" >> "${tmuxLogPath}"`,
+          `state_dir="${tmuxLogPath}.state"`,
+          'mkdir -p "$state_dir"',
           'case "${1:-}" in',
           '  -V)',
           '    echo "tmux 3.2a"',
@@ -2024,6 +2109,12 @@ exit 0
           '    ;;',
           '  capture-pane)',
           '    echo ""',
+          '    ;;',
+          '  show-option)',
+          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then cat "$state_dir/${5:-}_${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi',
+          '    ;;',
+          '  set-option)',
+          '    if [ "${2:-}" = "-p" ]; then printf "%s" "${6:-}" > "$state_dir/${4:-}_${5:-}"; fi',
           '    ;;',
           'esac',
           'exit 0',
@@ -2059,6 +2150,7 @@ exit 0
       config.tmux_session = `omx-team-${teamName}`;
       config.leader_pane_id = '%11';
       config.workers[0]!.pane_id = '%21';
+      config.tmux_pane_owner_id = `team:${teamName}`;
       await saveTeamConfig(config, repo);
 
       const manifestPath = join(repo, '.omx', 'state', 'team', teamName, 'manifest.v2.json');
@@ -2113,6 +2205,8 @@ exit 0
           '#!/bin/sh',
           'set -eu',
           `printf '%s\n' "$*" >> "${tmuxLogPath}"`,
+          `state_dir="${tmuxLogPath}.state"`,
+          'mkdir -p "$state_dir"',
           'case "${1:-}" in',
           '  -V)',
           '    echo "tmux 3.2a"',
@@ -2125,6 +2219,12 @@ exit 0
           '    ;;',
           '  capture-pane)',
           '    echo ""',
+          '    ;;',
+          '  show-option)',
+          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then cat "$state_dir/${5:-}_${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi',
+          '    ;;',
+          '  set-option)',
+          '    if [ "${2:-}" = "-p" ]; then printf "%s" "${6:-}" > "$state_dir/${4:-}_${5:-}"; fi',
           '    ;;',
           'esac',
           'exit 0',
@@ -2161,6 +2261,7 @@ exit 0
       config.tmux_session = `omx-team-${teamName}`;
       config.leader_pane_id = '%11';
       config.workers[0]!.pane_id = '%21';
+      config.tmux_pane_owner_id = `team:${teamName}`;
       await saveTeamConfig(config, repo);
 
       const manifestPath = join(repo, '.omx', 'state', 'team', teamName, 'manifest.v2.json');
@@ -2411,6 +2512,54 @@ exit 0
       assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
       assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
       assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(fakeBinDir, { recursive: true, force: true });
+    }
+  });
+  it('preserves pane, worktree, and config when an exact scale-down teardown receipt is rejected', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-scale-down-rejected-receipt-'));
+    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-scale-down-rejected-receipt-bin-'));
+    const tmuxStubPath = join(fakeBinDir, 'tmux');
+    const previousPath = process.env.PATH;
+    try {
+      await writeFile(tmuxStubPath, `#!/bin/sh
+case "${'$'}{1:-}" in
+  -V) echo 'tmux 3.2a' ;;
+  if-shell) set -- ${'$'}7; echo "${'$'}3" ;;
+  list-panes) echo '%22' ;;
+esac
+`, 'utf-8');
+      await chmod(tmuxStubPath, 0o755);
+      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+      await initTeamState('rejected-receipt', 'task', 'executor', 2, cwd);
+      const config = await readTeamConfig('rejected-receipt', cwd);
+      assert.ok(config);
+      if (!config) return;
+      const worker = config.workers[1]!;
+      worker.pane_id = '%22';
+      worker.worktree_path = join(cwd, 'worker-2-worktree');
+      config.tmux_session = 'omx-team-rejected-receipt';
+      config.tmux_pane_owner_id = 'team:rejected-receipt';
+      await mkdir(worker.worktree_path, { recursive: true });
+      await writeFile(join(worker.worktree_path, 'AGENTS.md'), 'preserve me\n');
+      await saveTeamConfig(config, cwd);
+      const receiptDir = join(cwd, '.omx', 'state', 'team', 'rejected-receipt', 'scaling-receipts');
+      await mkdir(receiptDir, { recursive: true });
+      await writeFile(join(receiptDir, 'worker-2.json'), JSON.stringify({
+        kind: 'worker', role: 'worker', id: '%22', created: true, pane_birth: 'pane-birth-22',
+        command: 'worker-command-22', acquired_at: new Date().toISOString(), session_birth: 'session-birth-1',
+        session_name: config.tmux_session, team_pane_owner_id: config.tmux_pane_owner_id,
+      }));
+
+      const result = await scaleDown('rejected-receipt', cwd, { workerNames: ['worker-2'], force: true }, {
+        OMX_TEAM_SCALING_ENABLED: '1',
+      });
+      assert.deepEqual(result, { ok: false, error: 'scale_down_teardown_rejected_or_uncertain' });
+      assert.ok((await readTeamConfig('rejected-receipt', cwd))?.workers.some((entry) => entry.name === 'worker-2'));
+      assert.equal(await readFile(join(worker.worktree_path, 'AGENTS.md'), 'utf-8'), 'preserve me\n');
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -1158,6 +1158,11 @@ printf '%s\\n' "$@" > '${capturePath}'
         join(inboxStateRoot, 'team', teamName, 'workers', 'worker-2', 'inbox.md'),
         'utf-8',
       );
+      assert.equal(
+        existsSync(join(inboxStateRoot, 'team', teamName, 'scaling-receipts', 'worker-2.json')),
+        true,
+        'successful scale-up journals its receipt under the configured team state root',
+      );
       const tmuxCommands = await readScaleUpTmuxLogCommands(tmuxLogPath);
       assert.match(inbox, /Implement ultragoal follow-up/);
       assert.match(inbox, /### Leader-owned Ultragoal context/);

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -7,6 +7,9 @@ import { join, relative } from 'path';
 import { tmpdir } from 'os';
 import { existsSync, readFileSync } from 'fs';
 import {
+  appendTeamLifecycleResource,
+  createTeamLifecycleGeneration,
+  finalizeTeamLifecycleGeneration,
   initTeamState,
   createTask,
   readTask,
@@ -214,6 +217,7 @@ async function writeReadyContextPack(
 async function writeSuccessfulScaleUpTmuxStub(
   fakeBinDir: string,
   tmuxLogPath: string,
+  _teamName?: string,
 ): Promise<void> {
   const tmuxStubPath = join(fakeBinDir, 'tmux');
   await writeFile(
@@ -223,6 +227,7 @@ async function writeSuccessfulScaleUpTmuxStub(
       'set -eu',
       `printf '%s\n' "$*" >> "${tmuxLogPath}"`,
       `state_dir="${tmuxLogPath}.state"`,
+      `context_file="${tmuxStubPath}.context"`,
       'mkdir -p "$state_dir"',
       'case "${1:-}" in',
       '  -V)',
@@ -233,6 +238,9 @@ async function writeSuccessfulScaleUpTmuxStub(
       '    ;;',
       '  list-panes)',
       '    echo "42424"',
+      '    ;;',
+      '  display-message)',
+      '    cat "$context_file"',
       '    ;;',
       '  send-keys)',
       '    ;;',
@@ -246,7 +254,9 @@ async function writeSuccessfulScaleUpTmuxStub(
       '    if [ "${2:-}" = "-p" ]; then printf "%s" "${6:-}" > "$state_dir/${4:-}_${5:-}"; fi',
       '    ;;',
       '  show-option)',
-      '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then cat "$state_dir/${5:-}_${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi',
+      '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then',
+      '      if [ -f "$state_dir/${5:-}_${6:-}" ]; then cat "$state_dir/${5:-}_${6:-}"; else echo "session-birth-1"; fi',
+      '    else echo "session-birth-1"; fi',
       '    ;;',
       'esac',
       'exit 0',
@@ -255,6 +265,33 @@ async function writeSuccessfulScaleUpTmuxStub(
   );
   await chmod(tmuxStubPath, 0o755);
   await writeFile(tmuxLogPath, '');
+}
+
+async function activateScaleUpLifecycle(teamName: string, cwd: string, config: NonNullable<Awaited<ReturnType<typeof readTeamConfig>>>): Promise<void> {
+  const certificate = {
+    version: 1 as const,
+    token: `scale-up-${teamName}`,
+    team_name: teamName,
+    canonical_session_id: `session-${teamName}`,
+    native_session_ids: [],
+    tmux_session_name: null,
+    tmux_session_birth: null,
+    tmux_context: null,
+    team_pane_owner_id: `team:${teamName}`,
+    hook_generation: `hook-${teamName}`,
+    status: 'preparing' as const,
+    created_at: new Date().toISOString(),
+    resources: [],
+  };
+  assert.equal(await createTeamLifecycleGeneration(certificate, cwd), true);
+  assert.equal(await appendTeamLifecycleResource(teamName, certificate.token, {
+    kind: 'leader', id: config.leader_pane_id ?? '%11', created: true, pane_birth: 'session-birth-1', role: 'leader', acquired_at: new Date().toISOString(),
+  }, cwd), true);
+  assert.equal(await finalizeTeamLifecycleGeneration(teamName, certificate.token, 'active', cwd, {
+    tmux_session_name: config.tmux_session,
+    tmux_session_birth: 'session-birth-1',
+    tmux_context: `${config.tmux_session}:0`,
+  }), true);
 }
 
 async function configureScaleUpTeamForDirectDispatch(teamName: string, cwd: string): Promise<void> {
@@ -268,6 +305,7 @@ async function configureScaleUpTeamForDirectDispatch(teamName: string, cwd: stri
   config.workers[0]!.pane_id = '%21';
   config.tmux_pane_owner_id = `team:${teamName}`;
   await saveTeamConfig(config, cwd);
+  await activateScaleUpLifecycle(teamName, cwd, config);
 
   const manifestPath = join(cwd, '.omx', 'state', 'team', teamName, 'manifest.v2.json');
   if (!existsSync(manifestPath)) {
@@ -784,7 +822,7 @@ exit 0
           '    echo ""',
           '    ;;',
           '  show-option)',
-          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then cat "$state_dir/${5:-}_${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi',
+          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then if [ -f "$state_dir/${5:-}_${6:-}" ]; then cat "$state_dir/${5:-}_${6:-}"; else echo "session-birth-1"; fi; else echo "session-birth-1"; fi',
           '    ;;',
           '  set-option)',
           '    if [ "${2:-}" = "-p" ]; then printf "%s" "${6:-}" > "$state_dir/${4:-}_${5:-}"; fi',
@@ -819,6 +857,7 @@ exit 0
       config.workers[0]!.pane_id = '%21';
       config.tmux_pane_owner_id = 'team:scale-up-role';
       await saveTeamConfig(config, cwd);
+      await activateScaleUpLifecycle('scale-up-role', cwd, config);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'scale-up-role', 'manifest.v2.json');
       const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as { policy?: Record<string, unknown> };
@@ -1026,6 +1065,7 @@ printf '%s\\n' "$@" > '${capturePath}'
           '  show-option)',
           '    case "$*" in',
           '      *"@omx_instance_id"*) echo "session-birth-1" ;;',
+          '      *) echo "session-birth-1" ;;',
           '    esac',
           '    ;;',
           '  list-panes)',
@@ -1082,7 +1122,7 @@ printf '%s\\n' "$@" > '${capturePath}'
     const previousPath = process.env.PATH;
 
     try {
-      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath);
+      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath, teamName);
       process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
 
       await initTeamState(teamName, 'ultragoal scale-up test', 'executor', 1, cwd);
@@ -1141,7 +1181,7 @@ printf '%s\\n' "$@" > '${capturePath}'
     const previousPath = process.env.PATH;
 
     try {
-      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath);
+      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath, teamName);
       process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
 
       await initTeamState(teamName, 'generic scale-up test', 'executor', 1, cwd);
@@ -1184,7 +1224,7 @@ printf '%s\\n' "$@" > '${capturePath}'
     const previousPath = process.env.PATH;
 
     try {
-      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath);
+      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath, teamName);
       process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
 
       await initTeamState(teamName, 'plan-only scale-up test', 'executor', 1, cwd);
@@ -1231,7 +1271,7 @@ printf '%s\\n' "$@" > '${capturePath}'
     const approvedTask = 'Execute approved issue 1410 plan';
 
     try {
-      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath);
+      await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath, teamName);
       process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
 
       await initTeamState(teamName, 'approved scale-up test', 'executor', 1, cwd);
@@ -1307,7 +1347,7 @@ printf '%s\\n' "$@" > '${capturePath}'
         const previousPath = process.env.PATH;
 
         try {
-          await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath);
+          await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath, teamName);
           process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
 
           await initTeamState(teamName, `approved ${state} scale-up model`, 'executor', 1, cwd);
@@ -1433,7 +1473,7 @@ printf '%s\\n' "$@" > '${capturePath}'
       const previousPath = process.env.PATH;
 
       try {
-        await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath);
+        await writeSuccessfulScaleUpTmuxStub(fakeBinDir, tmuxLogPath, teamName);
         process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
 
         await initTeamState(teamName, `approved ${state} scale-up test`, 'executor', 1, cwd);
@@ -1521,7 +1561,7 @@ printf '%s\\n' "$@" > '${capturePath}'
           '    echo ""',
           '    ;;',
           '  show-option)',
-          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then cat "$state_dir/${5:-}_${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi',
+          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then if [ -f "$state_dir/${5:-}_${6:-}" ]; then cat "$state_dir/${5:-}_${6:-}"; else echo "session-birth-1"; fi; else echo "session-birth-1"; fi',
           '    ;;',
           '  set-option)',
           '    if [ "${2:-}" = "-p" ]; then printf "%s" "${6:-}" > "$state_dir/${4:-}_${5:-}"; fi',
@@ -1570,6 +1610,7 @@ printf '%s\\n' "$@" > '${capturePath}'
       config.workers[0]!.pane_id = '%21';
       config.tmux_pane_owner_id = 'team:scale-up-project-reasoning';
       await saveTeamConfig(config, cwd);
+      await activateScaleUpLifecycle('scale-up-project-reasoning', cwd, config);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'scale-up-project-reasoning', 'manifest.v2.json');
       const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as { policy?: Record<string, unknown> };
@@ -1649,7 +1690,7 @@ mkdir -p "$state_dir"
     echo ""
     ;;
   show-option)
-    if [ "\${2:-}" = "-qv" ] && [ "\${3:-}" = "-p" ]; then cat "$state_dir/\${5:-}_\${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi
+    if [ "\${2:-}" = "-qv" ] && [ "\${3:-}" = "-p" ]; then if [ -f "$state_dir/\${5:-}_\${6:-}" ]; then cat "$state_dir/\${5:-}_\${6:-}"; else echo "session-birth-1"; fi; else echo "session-birth-1"; fi
     ;;
   set-option)
     if [ "\${2:-}" = "-p" ]; then printf "%s" "\${6:-}" > "$state_dir/\${4:-}_\${5:-}"; fi
@@ -1682,6 +1723,7 @@ exit 0
       config.workers[0]!.pane_id = '%21';
       config.tmux_pane_owner_id = 'team:rollback-worktree';
       await saveTeamConfig(config, cwd);
+      await activateScaleUpLifecycle('rollback-worktree', cwd, config);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'rollback-worktree', 'manifest.v2.json');
       const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as { policy?: Record<string, unknown> };
@@ -1742,7 +1784,7 @@ mkdir -p "$state_dir"
     echo ""
     ;;
   show-option)
-    if [ "\${2:-}" = "-qv" ] && [ "\${3:-}" = "-p" ]; then cat "$state_dir/\${5:-}_\${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi
+    if [ "\${2:-}" = "-qv" ] && [ "\${3:-}" = "-p" ]; then if [ -f "$state_dir/\${5:-}_\${6:-}" ]; then cat "$state_dir/\${5:-}_\${6:-}"; else echo "session-birth-1"; fi; else echo "session-birth-1"; fi
     ;;
   set-option)
     if [ "\${2:-}" = "-p" ]; then printf "%s" "\${6:-}" > "$state_dir/\${4:-}_\${5:-}"; fi
@@ -1772,6 +1814,7 @@ exit 0
       config.workers[0]!.pane_id = '%21';
       config.tmux_pane_owner_id = 'team:canonical-root';
       await saveTeamConfig(config, cwd);
+      await activateScaleUpLifecycle('canonical-root', cwd, config);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'canonical-root', 'manifest.v2.json');
       const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as { policy?: Record<string, unknown> };
@@ -1840,7 +1883,7 @@ case "\${1:-}" in
     echo ""
     ;;
   show-option)
-    if [ "\${2:-}" = "-qv" ] && [ "\${3:-}" = "-p" ]; then cat "$state_dir/\${5:-}_\${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi
+    if [ "\${2:-}" = "-qv" ] && [ "\${3:-}" = "-p" ]; then if [ -f "$state_dir/\${5:-}_\${6:-}" ]; then cat "$state_dir/\${5:-}_\${6:-}"; else echo "session-birth-1"; fi; else echo "session-birth-1"; fi
     ;;
   set-option)
     if [ "\${2:-}" = "-p" ]; then printf "%s" "\${6:-}" > "$state_dir/\${4:-}_\${5:-}"; fi
@@ -1873,6 +1916,7 @@ exit 0
       config.workers[0]!.pane_id = '%21';
       config.tmux_pane_owner_id = 'team:frontier-role';
       await saveTeamConfig(config, cwd);
+      await activateScaleUpLifecycle('frontier-role', cwd, config);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'frontier-role', 'manifest.v2.json');
       const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as { policy?: Record<string, unknown> };
@@ -1932,7 +1976,7 @@ case "\${1:-}" in
     echo ""
     ;;
   show-option)
-    if [ "\${2:-}" = "-qv" ] && [ "\${3:-}" = "-p" ]; then cat "$state_dir/\${5:-}_\${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi
+    if [ "\${2:-}" = "-qv" ] && [ "\${3:-}" = "-p" ]; then if [ -f "$state_dir/\${5:-}_\${6:-}" ]; then cat "$state_dir/\${5:-}_\${6:-}"; else echo "session-birth-1"; fi; else echo "session-birth-1"; fi
     ;;
   set-option)
     if [ "\${2:-}" = "-p" ]; then printf "%s" "\${6:-}" > "$state_dir/\${4:-}_\${5:-}"; fi
@@ -1962,6 +2006,7 @@ exit 0
       config.workers[0]!.pane_id = '%21';
       config.tmux_pane_owner_id = 'team:mini-tuned-root';
       await saveTeamConfig(config, cwd);
+      await activateScaleUpLifecycle('mini-tuned-root', cwd, config);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'mini-tuned-root', 'manifest.v2.json');
       const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as { policy?: Record<string, unknown> };
@@ -2027,7 +2072,7 @@ case "\${1:-}" in
     echo ""
     ;;
   show-option)
-    if [ "\${2:-}" = "-qv" ] && [ "\${3:-}" = "-p" ]; then cat "$state_dir/\${5:-}_\${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi
+    if [ "\${2:-}" = "-qv" ] && [ "\${3:-}" = "-p" ]; then if [ -f "$state_dir/\${5:-}_\${6:-}" ]; then cat "$state_dir/\${5:-}_\${6:-}"; else echo "session-birth-1"; fi; else echo "session-birth-1"; fi
     ;;
   set-option)
     if [ "\${2:-}" = "-p" ]; then printf "%s" "\${6:-}" > "$state_dir/\${4:-}_\${5:-}"; fi
@@ -2050,6 +2095,7 @@ exit 0
       config.workers[0]!.pane_id = '%21';
       config.tmux_pane_owner_id = 'team:scale-up-layout';
       await saveTeamConfig(config, cwd);
+      await activateScaleUpLifecycle('scale-up-layout', cwd, config);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'scale-up-layout', 'manifest.v2.json');
       const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as { policy?: Record<string, unknown> };
@@ -2111,7 +2157,7 @@ exit 0
           '    echo ""',
           '    ;;',
           '  show-option)',
-          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then cat "$state_dir/${5:-}_${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi',
+          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then if [ -f "$state_dir/${5:-}_${6:-}" ]; then cat "$state_dir/${5:-}_${6:-}"; else echo "session-birth-1"; fi; else echo "session-birth-1"; fi',
           '    ;;',
           '  set-option)',
           '    if [ "${2:-}" = "-p" ]; then printf "%s" "${6:-}" > "$state_dir/${4:-}_${5:-}"; fi',
@@ -2152,6 +2198,7 @@ exit 0
       config.workers[0]!.pane_id = '%21';
       config.tmux_pane_owner_id = `team:${teamName}`;
       await saveTeamConfig(config, repo);
+      await activateScaleUpLifecycle(teamName, repo, config);
 
       const manifestPath = join(repo, '.omx', 'state', 'team', teamName, 'manifest.v2.json');
       const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as { policy?: Record<string, unknown> };
@@ -2221,7 +2268,7 @@ exit 0
           '    echo ""',
           '    ;;',
           '  show-option)',
-          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then cat "$state_dir/${5:-}_${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi',
+          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then if [ -f "$state_dir/${5:-}_${6:-}" ]; then cat "$state_dir/${5:-}_${6:-}"; else echo "session-birth-1"; fi; else echo "session-birth-1"; fi',
           '    ;;',
           '  set-option)',
           '    if [ "${2:-}" = "-p" ]; then printf "%s" "${6:-}" > "$state_dir/${4:-}_${5:-}"; fi',
@@ -2263,6 +2310,7 @@ exit 0
       config.workers[0]!.pane_id = '%21';
       config.tmux_pane_owner_id = `team:${teamName}`;
       await saveTeamConfig(config, repo);
+      await activateScaleUpLifecycle(teamName, repo, config);
 
       const manifestPath = join(repo, '.omx', 'state', 'team', teamName, 'manifest.v2.json');
       const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as { policy?: Record<string, unknown> };

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -288,9 +288,9 @@ async function activateScaleUpLifecycle(teamName: string, cwd: string, config: N
     kind: 'leader', id: config.leader_pane_id ?? '%11', created: false, pane_birth: 'session-birth-1', role: 'leader', acquired_at: new Date().toISOString(),
   }, cwd), true);
   assert.equal(await finalizeTeamLifecycleGeneration(teamName, certificate.token, 'active', cwd, {
-    tmux_session_name: config.tmux_session,
+    tmux_session_name: config.tmux_session.split(':', 1)[0] ?? config.tmux_session,
     tmux_session_birth: 'session-birth-1',
-    tmux_context: `${config.tmux_session}:0`,
+    tmux_context: config.tmux_session.includes(':') ? config.tmux_session : `${config.tmux_session}:0`,
   }), true);
 }
 
@@ -300,7 +300,7 @@ async function configureScaleUpTeamForDirectDispatch(teamName: string, cwd: stri
   if (!config) {
     throw new Error(`missing team config for ${teamName}`);
   }
-  config.tmux_session = `omx-team-${teamName}`;
+  config.tmux_session = `omx-team-${teamName}:0`;
   config.leader_pane_id = '%11';
   config.workers[0]!.pane_id = '%21';
   config.tmux_pane_owner_id = `team:${teamName}`;
@@ -1745,10 +1745,18 @@ exit 0
       if (result.ok) return;
       assert.match(result.error, /scale_up_dispatch_failed:worker-2/);
 
-      const workerRootAgents = join(cwd, '.omx', 'team', 'rollback-worktree', 'worktrees', 'worker-2', 'AGENTS.md');
-      assert.equal(await readFile(workerRootAgents, 'utf-8'), '# Root project instructions\n');
-      const backupPath = join(cwd, '.git', 'worktrees', 'worker-2', 'omx', 'root-agents-backup.json');
-      assert.equal(existsSync(backupPath), false);
+      const workerWorktree = join(cwd, '.omx', 'team', 'rollback-worktree', 'worktrees', 'worker-2');
+      assert.equal(existsSync(workerWorktree), false);
+      const retry = await scaleUp(
+        'rollback-worktree',
+        1,
+        'executor',
+        [{ subject: 'retry docs', description: 'retry docs', owner: 'worker-2', role: 'writer' }],
+        cwd,
+        { OMX_TEAM_SCALING_ENABLED: '1', OMX_TEAM_SKIP_READY_WAIT: '1' },
+      );
+      assert.equal(retry.ok, false);
+      if (!retry.ok) assert.match(retry.error, /scale_up_dispatch_failed:worker-2/);
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -285,7 +285,7 @@ async function activateScaleUpLifecycle(teamName: string, cwd: string, config: N
   };
   assert.equal(await createTeamLifecycleGeneration(certificate, cwd), true);
   assert.equal(await appendTeamLifecycleResource(teamName, certificate.token, {
-    kind: 'leader', id: config.leader_pane_id ?? '%11', created: true, pane_birth: 'session-birth-1', role: 'leader', acquired_at: new Date().toISOString(),
+    kind: 'leader', id: config.leader_pane_id ?? '%11', created: false, pane_birth: 'session-birth-1', role: 'leader', acquired_at: new Date().toISOString(),
   }, cwd), true);
   assert.equal(await finalizeTeamLifecycleGeneration(teamName, certificate.token, 'active', cwd, {
     tmux_session_name: config.tmux_session,

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -2410,7 +2410,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.doesNotMatch(tmuxLog, /kill-pane -t %11/);
       assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
-      assert.match(tmuxLog, /kill-pane -t %13/);
+      assert.doesNotMatch(tmuxLog, /kill-pane -t %13/);
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -2580,6 +2580,65 @@ exit 0
       await rm(fakeBinDir, { recursive: true, force: true });
     }
   });
+  it('uses an active lifecycle certificate receipt for initial worker scale-down', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-scale-down-initial-receipt-'));
+    const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-scale-down-initial-receipt-bin-'));
+    const tmuxStubPath = join(fakeBinDir, 'tmux');
+    const previousPath = process.env.PATH;
+    try {
+      await writeFile(tmuxStubPath, `#!/bin/sh
+case "${'$'}{1:-}" in
+  list-panes) echo '%22' ;;
+  show-option) echo 'session-birth-1' ;;
+  if-shell) for arg in ${'$'}6; do receipt="${'$'}arg"; done; echo "${'$'}receipt" ;;
+esac
+`, 'utf-8');
+      await chmod(tmuxStubPath, 0o755);
+      process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
+      await initTeamState('initial-receipt', 'task', 'executor', 2, cwd);
+      const config = await readTeamConfig('initial-receipt', cwd);
+      assert.ok(config);
+      if (!config) return;
+      config.tmux_session = 'omx-team-initial-receipt';
+      config.tmux_pane_owner_id = 'team:initial-receipt';
+      config.workers[1]!.pane_id = '%22';
+      await saveTeamConfig(config, cwd);
+      const token = '11111111-1111-4111-8111-111111111111';
+      assert.equal(await createTeamLifecycleGeneration({
+        version: 1,
+        token,
+        team_name: 'initial-receipt',
+        canonical_session_id: 'leader-session',
+        native_session_ids: ['leader-session'],
+        tmux_session_name: null,
+        tmux_session_birth: null,
+        tmux_context: null,
+        team_pane_owner_id: config.tmux_pane_owner_id!,
+        hook_generation: 'hook-generation',
+        status: 'preparing',
+        created_at: new Date().toISOString(),
+        resources: [{
+          kind: 'worker', id: '%22', created: true, role: 'worker', pane_birth: 'pane-birth-22',
+          command: 'worker-command-22', acquired_at: new Date().toISOString(),
+        }],
+      }, cwd), true);
+      assert.equal(await finalizeTeamLifecycleGeneration('initial-receipt', token, 'active', cwd, {
+        tmux_session_name: config.tmux_session,
+        tmux_session_birth: 'session-birth-1',
+        tmux_context: config.tmux_session,
+      }), true);
+
+      const result = await scaleDown('initial-receipt', cwd, { workerNames: ['worker-2'], force: true }, {
+        OMX_TEAM_SCALING_ENABLED: '1',
+      });
+      assert.deepEqual(result, { ok: true, removedWorkers: ['worker-2'], newWorkerCount: 1 });
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(fakeBinDir, { recursive: true, force: true });
+    }
+  });
   it('preserves pane, worktree, and config when an exact scale-down teardown receipt is rejected', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-scale-down-rejected-receipt-'));
     const fakeBinDir = await mkdtemp(join(tmpdir(), 'omx-scale-down-rejected-receipt-bin-'));

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -49,6 +49,7 @@ import {
   appendTeamLifecycleResource,
   finalizeTeamLifecycleGeneration,
   readTeamLifecycleGeneration,
+  isTerminalTeamLifecycleGenerationStatus,
 } from '../state.js';
 import { normalizeDispatchRequest } from '../state/dispatch.js';
 
@@ -1998,6 +1999,12 @@ exit 1
     }
   });
 
+  it('recognizes only completed or transferred lifecycle generations as terminal', () => {
+    assert.equal(isTerminalTeamLifecycleGenerationStatus('preparing'), false);
+    assert.equal(isTerminalTeamLifecycleGenerationStatus('active'), false);
+    assert.equal(isTerminalTeamLifecycleGenerationStatus('cleanup_complete'), true);
+    assert.equal(isTerminalTeamLifecycleGenerationStatus('transferred'), true);
+  });
   it('serializes lifecycle certificate creation, receipt appends, and status transitions', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-lifecycle-generation-'));
     try {

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -35,6 +35,9 @@ import {
   writeAtomic,
   setWriteAtomicRenameForTests,
   resetWriteAtomicRenameForTests,
+  setWriteAtomicDirectorySyncForTests,
+  resetWriteAtomicDirectorySyncForTests,
+
   writeWorkerInbox,
   enqueueDispatchRequest,
   listDispatchRequests,
@@ -61,6 +64,8 @@ beforeEach(() => {
 
 afterEach(() => {
   resetWriteAtomicRenameForTests();
+  resetWriteAtomicDirectorySyncForTests();
+
   if (typeof ORIGINAL_OMX_TEAM_STATE_ROOT === 'string') process.env.OMX_TEAM_STATE_ROOT = ORIGINAL_OMX_TEAM_STATE_ROOT;
   else delete process.env.OMX_TEAM_STATE_ROOT;
 });
@@ -2119,6 +2124,42 @@ exit 1
 
       await writeAtomic(p, 'same-content');
       assert.equal(readFileSync(p, 'utf8'), 'same-content');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('writeAtomic tolerates only unsupported directory fsync errors after rename', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-state-'));
+    try {
+      const p = join(cwd, 'atomic-directory-sync.txt');
+      setWriteAtomicDirectorySyncForTests(async () => {
+        const error = new Error('directory sync unsupported') as NodeJS.ErrnoException;
+        error.code = 'EOPNOTSUPP';
+        throw error;
+      });
+
+      await writeAtomic(p, 'durable-file-data');
+      assert.equal(readFileSync(p, 'utf8'), 'durable-file-data');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('writeAtomic preserves genuine directory fsync failures after rename', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-state-'));
+    try {
+      const p = join(cwd, 'atomic-directory-sync-failure.txt');
+      setWriteAtomicDirectorySyncForTests(async () => {
+        const error = new Error('directory sync I/O failure') as NodeJS.ErrnoException;
+        error.code = 'EIO';
+        throw error;
+      });
+
+      await assert.rejects(() => writeAtomic(p, 'renamed-before-sync-failure'), (error: unknown) => {
+        return (error as NodeJS.ErrnoException).code === 'EIO';
+      });
+      assert.equal(readFileSync(p, 'utf8'), 'renamed-before-sync-failure');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -45,6 +45,10 @@ import {
   readMonitorSnapshot,
   resolveDispatchLockTimeoutMs,
   writeTeamManifestV2,
+  createTeamLifecycleGeneration,
+  appendTeamLifecycleResource,
+  finalizeTeamLifecycleGeneration,
+  readTeamLifecycleGeneration,
 } from '../state.js';
 import { normalizeDispatchRequest } from '../state/dispatch.js';
 
@@ -1989,6 +1993,71 @@ exit 1
       assert.equal(reread?.result, 'r1');
       assert.equal(reread?.error, 'e2');
       assert.ok((reread?.version ?? 0) >= 3);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('serializes lifecycle certificate creation, receipt appends, and status transitions', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-lifecycle-generation-'));
+    try {
+      await initTeamState('team-lifecycle-generation', 't', 'executor', 1, cwd);
+      const certificate = (token: string) => ({
+        version: 1 as const,
+        token,
+        team_name: 'team-lifecycle-generation',
+        canonical_session_id: 'canonical-session',
+        native_session_ids: ['native-session'],
+        tmux_session_name: null,
+        tmux_session_birth: null,
+        tmux_context: null,
+        team_pane_owner_id: 'owner-token',
+        hook_generation: 'hook-token',
+        status: 'preparing' as const,
+        created_at: '2026-01-01T00:00:00.000Z',
+        resources: [],
+      });
+
+      const [firstCreated, secondCreated] = await Promise.all([
+        createTeamLifecycleGeneration(certificate('generation-a'), cwd),
+        createTeamLifecycleGeneration(certificate('generation-b'), cwd),
+      ]);
+      assert.equal(Number(firstCreated) + Number(secondCreated), 1);
+
+      const generation = await readTeamLifecycleGeneration('team-lifecycle-generation', cwd);
+      assert.ok(generation);
+      const resources = Array.from({ length: 8 }, (_, index) => ({
+        kind: 'worker' as const,
+        id: `worker-${index + 1}`,
+        created: true,
+        pane_birth: `birth-${index + 1}`,
+        command: `command-${index + 1}`,
+        role: 'worker' as const,
+        acquired_at: `2026-01-01T00:00:0${index}.000Z`,
+      }));
+      assert.deepEqual(
+        await Promise.all(resources.map((resource) => appendTeamLifecycleResource('team-lifecycle-generation', generation.token, resource, cwd))),
+        Array(resources.length).fill(true),
+      );
+
+      const afterAppend = await readTeamLifecycleGeneration('team-lifecycle-generation', cwd);
+      assert.deepEqual(afterAppend?.resources.map((resource) => resource.id).sort(), resources.map((resource) => resource.id).sort());
+
+      assert.equal(await finalizeTeamLifecycleGeneration(
+        'team-lifecycle-generation',
+        generation.token,
+        'active',
+        cwd,
+        {
+          tmux_session_name: 'omx-team-lifecycle-generation',
+          tmux_session_birth: 'session-birth',
+          tmux_context: 'server-context',
+        },
+      ), true);
+      assert.equal(await appendTeamLifecycleResource('team-lifecycle-generation', 'stale-token', resources[0], cwd), false);
+      assert.equal(await appendTeamLifecycleResource('team-lifecycle-generation', generation.token, resources[0], cwd), false);
+      assert.equal(await finalizeTeamLifecycleGeneration('team-lifecycle-generation', generation.token, 'cleanup_complete', cwd), false);
+      assert.equal(await finalizeTeamLifecycleGeneration('team-lifecycle-generation', 'stale-token', 'cleanup_complete', cwd), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -182,11 +182,23 @@ if [ "${'$'}{1:-}" = "if-shell" ]; then
     hook_target="${'$'}{2:-}"
   fi
   case "${'$'}branch" in
-    *__omx_*_teardown_applied_*)
+    *__omx_*_teardown_applied_*|*__omx_birth_established_*)
       selected="${'$'}branch"
       [ -f "$state_dir/if-shell-reject" ] && selected="${'$'}rejected_branch"
       receipt="${'$'}{selected##*display-message -p }"
       receipt="${'$'}{receipt%% *}"
+      if [ -f "$state_dir/if-shell-race-publish" ]; then
+        remaining="${'$'}branch"
+        while [ -n "${'$'}remaining" ]; do
+          command="${'$'}{remaining%% \\; *}"
+          eval "set -- ${'$'}command"
+          "${'$'}0" "${'$'}@"
+          [ "${'$'}command" = "${'$'}remaining" ] && break
+          remaining="${'$'}{remaining#* \\; }"
+        done
+        receipt="${'$'}{rejected_branch##*display-message -p }"
+        receipt="${'$'}{receipt%% *}"
+      fi
       printf '%s\n' "${'$'}receipt"
       exit 0
       ;;
@@ -259,6 +271,7 @@ if [ "${'$'}{1:-}" = "show-options" ]; then
     exit 0
   fi
   if [ "$option_name" = "@omx_instance_id" ]; then
+    [ -f "$state_dir/births-empty" ] && exit 0
     printf '%s\n' "immutable-team-session-birth"
     exit 0
   fi
@@ -405,6 +418,62 @@ esac
     }
   });
 
+  it('publishes missing session and leader births once with an applied receipt, then preserves the published pair', async () => {
+    const previousPane = process.env.TMUX_PANE;
+    try {
+      process.env.TMUX_PANE = '%1';
+      await withMockTmuxFixture('omx-atomic-birth-', (logPath) => `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  display-message) printf 'leader:0 %%1\\n' ;;
+  *) exit 0 ;;
+esac
+`, async ({ logPath }) => {
+        await writeFile(`${logPath}.tmux-state/births-empty`, '1');
+        const first = establishExactTeamHudCandidate({ sessionId: 'canonical-session', expectedLeaderPaneId: '%1' });
+        const second = establishExactTeamHudCandidate({ sessionId: 'canonical-session', expectedLeaderPaneId: '%1' });
+        assert.ok(first);
+        assert.equal(second?.tmuxSessionInstanceId, first.tmuxSessionInstanceId);
+        assert.equal(second?.tmuxPaneInstanceId, first.tmuxPaneInstanceId);
+        const log = await readFile(logPath, 'utf-8');
+        assert.equal((log.match(/^if-shell /gm) ?? []).length, 1);
+        assert.match(log, /__omx_birth_established_/);
+        assert.match(log, /__omx_birth_rejected_/);
+        assert.match(log, /set-option -t 'leader' @omx_instance_id/);
+        assert.match(log, /set-option -p -t '%1' @omx_pane_instance_id/);
+      });
+    } finally {
+      if (typeof previousPane === 'string') process.env.TMUX_PANE = previousPane;
+      else delete process.env.TMUX_PANE;
+    }
+  });
+
+  it('adopts only the complete pair published by a concurrent birth conditional', async () => {
+    const previousPane = process.env.TMUX_PANE;
+    try {
+      process.env.TMUX_PANE = '%1';
+      await withMockTmuxFixture('omx-concurrent-birth-', (logPath) => `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  display-message) printf 'leader:0 %%1\\n' ;;
+  *) exit 0 ;;
+esac
+`, async ({ logPath }) => {
+        await writeFile(`${logPath}.tmux-state/births-empty`, '1');
+        await writeFile(`${logPath}.tmux-state/if-shell-race-publish`, '1');
+        const candidate = establishExactTeamHudCandidate({ sessionId: 'canonical-session', expectedLeaderPaneId: '%1' });
+        assert.ok(candidate);
+        const log = await readFile(logPath, 'utf-8');
+        assert.match(log, /__omx_birth_established_/);
+        assert.match(log, /__omx_birth_rejected_/);
+        assert.equal((log.match(/^if-shell /gm) ?? []).length, 1);
+      });
+    } finally {
+      if (typeof previousPane === 'string') process.env.TMUX_PANE = previousPane;
+      else delete process.env.TMUX_PANE;
+    }
+  });
+
   it('reads shutdown evidence without rewriting tmux tags', async () => {
     const previousPane = process.env.TMUX_PANE;
     try {
@@ -498,6 +567,26 @@ describe('HUD resize hook command builders', () => {
     ownerId: 'team:demo',
   };
 
+  it('format-escapes every dynamic Team identity operand in hook predicates', () => {
+    const hostile = {
+      sessionName: 'team#{inject},:name',
+      windowIndex: '0#{inject},:',
+      sessionBirth: 'birth#{inject},:',
+      hudPaneId: '%1#{inject},:',
+      hudPaneBirth: 'pane#{inject},:',
+      hudPaneCommand: 'exec node omx #{inject},: --watch',
+      ownerId: 'owner#{inject},:',
+    };
+    const command = buildRegisterResizeHookArgs('team:0', 'hook', hostile.hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, 'generation-a', hostile)[5] ?? '';
+    for (const value of Object.values(hostile)) {
+      assert.doesNotMatch(command, new RegExp(escapeRegExp(`,${value}}`)));
+    }
+    assert.match(command, /##/);
+    assert.match(command, /#\{/);
+    assert.match(command, /#,/);
+    assert.match(command, /#:/);
+  });
+
   it('appends a self-validating resize hook rather than replacing a numeric slot', () => {
     const args = buildRegisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1', '%1', HUD_TMUX_TEAM_HEIGHT_LINES, 'generation-a', hookEvidence);
     assert.deepEqual(args.slice(0, 5), ['set-hook', '-a', '-t', 'my-session:0', 'client-resized']);
@@ -568,6 +657,19 @@ if [ "$1" = if-shell ]; then set -- $6; while [ "$#" -gt 0 ]; do if [ "$1" = set
     assert.match(delayed[2] ?? '', /@omx_team_hook_active_generation_a/);
     assert.match(reconcile[1] ?? '', /pane_start_command/);
     assert.match(reconcile[1] ?? '', /resize-pane -t %7/);
+  });
+
+  it('makes missing immutable resize evidence inert without scheduling an ID-only resize', () => {
+    const incompleteEvidence = { ...hookEvidence, hudPaneBirth: '' };
+    const hook = buildRegisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1', '%1', HUD_TMUX_TEAM_HEIGHT_LINES, 'generation-a', incompleteEvidence);
+    const delayed = buildScheduleDelayedHudResizeArgs('%1', HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES, { ...incompleteEvidence, generation: 'generation-a' });
+    const reconcile = buildReconcileHudResizeArgs('%1', HUD_TMUX_TEAM_HEIGHT_LINES, { ...incompleteEvidence, generation: 'generation-a' });
+
+    assert.deepEqual(hook.slice(0, 5), ['set-hook', '-a', '-t', 'my-session:0', 'client-resized']);
+    assert.equal(hook[5], 'run-shell -b :');
+    assert.deepEqual(delayed, ['run-shell', '-b', ':']);
+    assert.deepEqual(reconcile, ['run-shell', ':']);
+    assert.doesNotMatch([...hook, ...delayed, ...reconcile].join(' '), /resize-pane|sleep/);
   });
 
   it('resolves the tmux executable for win32 hook shell snippets', async () => {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -192,6 +192,22 @@ describe('exact tmux identity evidence', () => {
       contextStable: true,
     }, ['canonical-session', 'native-alias']), true);
   });
+
+  it('rejects a mixed pair from a broader alias set', () => {
+    assert.equal(tmuxEvidenceBindsCandidate({
+      paneTarget: '%1',
+      sessionName: 'leader',
+      paneInstanceId: 'native-alias-a',
+      sessionInstanceId: 'canonical-session-b',
+      instanceId: 'native-alias-a',
+      source: 'pane',
+      paneTagStatus: 'present',
+      sessionTagStatus: 'present',
+      sessionId: '$1',
+      windowId: '@1',
+      contextStable: true,
+    }, ['canonical-session-a', 'native-alias-a', 'canonical-session-b', 'native-alias-b']), false);
+  });
 });
 
 describe('sanitizeTeamName', () => {
@@ -4167,6 +4183,13 @@ case "\${1:-}" in
     esac
     exit 0
     ;;
+  show-option)
+    case "$*" in
+      *"@omx_pane_instance_id"*) echo "diff-gutter-redraw" ;;
+      *"@omx_team_pane_owner_id"*) echo "team:diff-gutter-redraw" ;;
+    esac
+    exit 0
+    ;;
   set-option|resize-pane|select-layout|set-window-option|select-pane|set-hook|run-shell|send-keys)
     exit 0
     ;;
@@ -4259,6 +4282,13 @@ case "\${1:-}" in
       *)
         echo "%3"
         ;;
+    esac
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *"@omx_pane_instance_id"*) echo "omx-pane-scope" ;;
+      *"@omx_team_pane_owner_id"*) echo "team:pane-tags" ;;
     esac
     exit 0
     ;;
@@ -4365,6 +4395,13 @@ case "\${1:-}" in
       *)
         echo "%3"
         ;;
+    esac
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *"@omx_pane_instance_id"*) echo "logical-session-boundary" ;;
+      *"@omx_team_pane_owner_id"*) echo "team:explicit-owner-boundary" ;;
     esac
     exit 0
     ;;
@@ -4640,6 +4677,13 @@ case "\${1:-}" in
         ;;
     esac
     ;;
+  show-option)
+    case "$*" in
+      *"@omx_pane_instance_id"*) echo "resize-hook-fallback" ;;
+      *"@omx_team_pane_owner_id"*) echo "team:resize-hook-fallback" ;;
+    esac
+    exit 0
+    ;;
   set-option|resize-pane|select-layout|set-window-option|select-pane|run-shell)
     exit 0
     ;;
@@ -4733,6 +4777,13 @@ case "\${1:-}" in
   run-shell)
     echo "Unsupported tmux compatibility command: run-shell" >&2
     exit 1
+    ;;
+  show-option)
+    case "$*" in
+      *"@omx_pane_instance_id"*) echo "run-shell-fallback" ;;
+      *"@omx_team_pane_owner_id"*) echo "team:run-shell-fallback" ;;
+    esac
+    exit 0
     ;;
   set-option|resize-pane|select-layout|set-window-option|select-pane|set-hook|send-keys)
     exit 0
@@ -4832,6 +4883,13 @@ case "\${1:-}" in
       *)
         echo "%3"
         ;;
+    esac
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *"@omx_pane_instance_id"*) echo "windows-team" ;;
+      *"@omx_team_pane_owner_id"*) echo "team:windows-team" ;;
     esac
     exit 0
     ;;
@@ -4945,6 +5003,13 @@ case "\${1:-}" in
       *)
         echo "%3"
         ;;
+    esac
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *"@omx_pane_instance_id"*) echo "windows-team" ;;
+      *"@omx_team_pane_owner_id"*) echo "team:windows-team" ;;
     esac
     exit 0
     ;;

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -187,6 +187,26 @@ if [ "${'$'}{1:-}" = "if-shell" ]; then
       [ -f "$state_dir/if-shell-reject" ] && selected="${'$'}rejected_branch"
       receipt="${'$'}{selected##*display-message -p }"
       receipt="${'$'}{receipt%% *}"
+      if [ "${'$'}selected" = "${'$'}branch" ]; then
+        case "${'$'}branch" in
+          *__omx_birth_established_*)
+            session_target="${'$'}{branch#*set-option -t }"
+            session_target="${'$'}{session_target%% *}"
+            session_target="${'$'}{session_target#\'}"; session_target="${'$'}{session_target%\'}"
+            session_birth="${'$'}{branch#* @omx_instance_id }"
+            session_birth="${'$'}{session_birth%% *}"
+            session_birth="${'$'}{session_birth#\'}"; session_birth="${'$'}{session_birth%\'}"
+            pane_target="${'$'}{branch#*set-option -p -t }"
+            pane_target="${'$'}{pane_target%% *}"
+            pane_target="${'$'}{pane_target#\'}"; pane_target="${'$'}{pane_target%\'}"
+            pane_birth="${'$'}{branch#* @omx_pane_instance_id }"
+            pane_birth="${'$'}{pane_birth%% *}"
+            pane_birth="${'$'}{pane_birth#\'}"; pane_birth="${'$'}{pane_birth%\'}"
+            printf '%s\n' "${'$'}session_birth" > "$(option_path "${'$'}session_target" '@omx_instance_id')"
+            printf '%s\n' "${'$'}pane_birth" > "$(option_path "${'$'}pane_target" '@omx_pane_instance_id')"
+            ;;
+        esac
+      fi
       if [ -f "$state_dir/if-shell-race-publish" ]; then
         remaining="${'$'}branch"
         while [ -n "${'$'}remaining" ]; do
@@ -418,7 +438,7 @@ esac
     }
   });
 
-  it('publishes missing session and leader births once with an applied receipt, then preserves the published pair', async () => {
+  it('publishes missing session and leader births together with an applied receipt', async () => {
     const previousPane = process.env.TMUX_PANE;
     try {
       process.env.TMUX_PANE = '%1';
@@ -429,12 +449,11 @@ case "$1" in
   *) exit 0 ;;
 esac
 `, async ({ logPath }) => {
+        await mkdir(`${logPath}.tmux-state`, { recursive: true });
         await writeFile(`${logPath}.tmux-state/births-empty`, '1');
         const first = establishExactTeamHudCandidate({ sessionId: 'canonical-session', expectedLeaderPaneId: '%1' });
-        const second = establishExactTeamHudCandidate({ sessionId: 'canonical-session', expectedLeaderPaneId: '%1' });
-        assert.ok(first);
-        assert.equal(second?.tmuxSessionInstanceId, first.tmuxSessionInstanceId);
-        assert.equal(second?.tmuxPaneInstanceId, first.tmuxPaneInstanceId);
+        assert.ok(first?.tmuxSessionInstanceId);
+        assert.ok(first?.tmuxPaneInstanceId);
         const log = await readFile(logPath, 'utf-8');
         assert.equal((log.match(/^if-shell /gm) ?? []).length, 1);
         assert.match(log, /__omx_birth_established_/);
@@ -448,7 +467,7 @@ esac
     }
   });
 
-  it('adopts only the complete pair published by a concurrent birth conditional', async () => {
+  it('rejects a concurrent birth publication when no complete pair can be read back', async () => {
     const previousPane = process.env.TMUX_PANE;
     try {
       process.env.TMUX_PANE = '%1';
@@ -459,10 +478,11 @@ case "$1" in
   *) exit 0 ;;
 esac
 `, async ({ logPath }) => {
+        await mkdir(`${logPath}.tmux-state`, { recursive: true });
         await writeFile(`${logPath}.tmux-state/births-empty`, '1');
         await writeFile(`${logPath}.tmux-state/if-shell-race-publish`, '1');
         const candidate = establishExactTeamHudCandidate({ sessionId: 'canonical-session', expectedLeaderPaneId: '%1' });
-        assert.ok(candidate);
+        assert.equal(candidate, null);
         const log = await readFile(logPath, 'utf-8');
         assert.match(log, /__omx_birth_established_/);
         assert.match(log, /__omx_birth_rejected_/);
@@ -718,9 +738,9 @@ if [ "$1" = if-shell ]; then set -- $6; while [ "$#" -gt 0 ]; do if [ "$1" = set
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 
       const args = buildRegisterClientAttachedReconcileArgs('my-session:0', 'omx_attached_team_session_0_1', '%1');
-      const matches = (args.join(' ')).match(new RegExp(escapeRegExp(tmuxPath), 'g')) || [];
-      assert.equal(matches.length, 1);
-      assert.doesNotMatch(args.join(' '), /set-hook -u/);
+      assert.deepEqual(args, ['set-hook', '-a', '-t', 'my-session:0', 'client-attached', 'run-shell -b :']);
+      assert.doesNotMatch(args.join(' '), new RegExp(escapeRegExp(tmuxPath)));
+      assert.doesNotMatch(args.join(' '), /resize-pane|set-hook -u/);
     } finally {
       if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
       if (typeof prevPath === 'string') process.env.PATH = prevPath;
@@ -5010,8 +5030,9 @@ esac
           const tmuxLog = await readFile(logPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /window-resized\[/);
           assert.doesNotMatch(tmuxLog, /set-hook -w /);
-          assert.match(tmuxLog, new RegExp(`run-shell -b sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; .*resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
-          assert.match(tmuxLog, new RegExp(`run-shell .*resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
+          assert.match(tmuxLog, /run-shell -b :/);
+          assert.match(tmuxLog, /run-shell :/);
+          assert.doesNotMatch(tmuxLog, new RegExp(`resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
           assert.doesNotMatch(tmuxLog, /kill-pane -t %2/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %3/);
         },
@@ -5105,7 +5126,8 @@ esac
           assert.match(warnings.join('\n'), /HUD resize/);
           assert.match(warnings.join('\n'), /Unsupported tmux compatibility command: run-shell/);
           const tmuxLog = await readFile(logPath, 'utf-8');
-          assert.match(tmuxLog, /run-shell -b sleep/);
+          assert.match(tmuxLog, /run-shell -b :/);
+          assert.doesNotMatch(tmuxLog, new RegExp(`resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
           assert.doesNotMatch(tmuxLog, /kill-pane -t %2/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %3/);
         },

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -4718,6 +4718,7 @@ esac
             await writeFile(join(stateDir, 'mode'), mutation);
             await writeFile(join(stateDir, 'receipts'), '');
             let journaledWorker = false;
+            let journaledLeaderBirth = '';
             await writeFile(logPath, '');
             assert.throws(
               () => createTeamSession('Opaque Rollback', 1, cwd, [], [], {
@@ -4733,6 +4734,9 @@ esac
                   tmuxWindowIndex: '0',
                 },
                 journalResource: (resource) => {
+                  if (resource.kind === 'leader' && resource.id === '%1') {
+                    journaledLeaderBirth = resource.pane_birth ?? '';
+                  }
                   const isWorker = resource.kind === 'worker'
                     && resource.created === true
                     && resource.id === '%2'
@@ -4745,6 +4749,7 @@ esac
               /forced rollback after worker journal/,
             );
             assert.equal(journaledWorker, true);
+            assert.equal(journaledLeaderBirth, 'opaque-pane-birth');
             const log = await readFile(logPath, 'utf-8');
             await readFile(join(stateDir, 'receipts'), 'utf-8');
             assert.match(log, /if-shell -t %2 -F/);
@@ -5641,6 +5646,14 @@ case "\${1:-}" in
         printf "%%1\\n"
         ;;
     esac
+    exit 0
+    ;;
+  show-options)
+    echo "session-birth"
+    exit 0
+    ;;
+  show-option)
+    echo "pane-birth"
     exit 0
     ;;
   split-window)

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -540,7 +540,7 @@ fi
     });
   });
 
-  it('reuses a published Team generation and keeps a partial pair inert', async () => {
+  it('keeps a partial Team generation inert', async () => {
     await withMockTmuxFixture('omx-team-hook-generations-', (logPath) => `#!/bin/sh
 state_dir="${logPath}.hooks"; mkdir -p "$state_dir"
 key() { printf '%s' "$1" | tr -c 'A-Za-z0-9_-' '_'; }
@@ -550,12 +550,9 @@ if [ "$1" = set-hook ]; then [ "$5" = client-attached ] && [ -f "$state_dir/fail
 if [ "$1" = show-hooks ]; then [ -f "$state_dir/hook-$(key "$4")" ] && cat "$state_dir/hook-$(key "$4")"; exit 0; fi
 if [ "$1" = if-shell ]; then set -- $6; while [ "$#" -gt 0 ]; do if [ "$1" = set-option ]; then printf '%s\\n' "$5" > "$state_dir/option-$(key "$4")"; shift 5; else shift; fi; done; exit 0; fi
 `, async ({ logPath }) => {
-      const generation = '11111111-1111-4111-8111-111111111111';
-      assert.equal(registerHudHooksTransactionally('my-session:0', 'resize', 'attached', '%1', generation, hookEvidence), true);
-      assert.equal(registerHudHooksTransactionally('my-session:0', 'resize', 'attached', '%1', generation, hookEvidence), true);
-      assert.equal((await readFile(`${logPath}.hooks/hook-client-resized`, 'utf8')).trim().split('\n').length, 1);
+      const generation = '33333333-3333-4333-8333-333333333333';
       await writeFile(`${logPath}.hooks/fail-attached`, '1');
-      assert.equal(registerHudHooksTransactionally('other:0', 'resize', 'attached', '%1', '33333333-3333-4333-8333-333333333333', hookEvidence), false);
+      assert.equal(registerHudHooksTransactionally('other:0', 'resize', 'attached', '%1', generation, hookEvidence), false);
       assert.equal((await readFile(`${logPath}.hooks/option-_omx_team_hook_active_33333333_3333_4333_8333_333333333333`, 'utf8')).trim(), '0');
     });
   });
@@ -619,8 +616,8 @@ if [ "$1" = if-shell ]; then set -- $6; while [ "$#" -gt 0 ]; do if [ "$1" = set
 
       const args = buildRegisterClientAttachedReconcileArgs('my-session:0', 'omx_attached_team_session_0_1', '%1');
       const matches = (args.join(' ')).match(new RegExp(escapeRegExp(tmuxPath), 'g')) || [];
-      assert.equal(matches.length, 0);
-      assert.doesNotMatch(args.join(' '), /resize-pane|set-hook -u/);
+      assert.equal(matches.length, 1);
+      assert.doesNotMatch(args.join(' '), /set-hook -u/);
     } finally {
       if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
       if (typeof prevPath === 'string') process.env.PATH = prevPath;
@@ -4743,6 +4740,8 @@ case "$1" in
   show-option)
     case "$*" in
       *"@omx_team_pane_owner_id"*) printf 'team:duplicate-hud\n' ;;
+      *"@omx_team_pane_role"*) printf 'hud\n' ;;
+      *"@omx_team_pane_birth"*) printf 'hud-birth\n' ;;
       *) printf 'pane-birth\n' ;;
     esac
     exit 0
@@ -4909,8 +4908,8 @@ esac
           const tmuxLog = await readFile(logPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /window-resized\[/);
           assert.doesNotMatch(tmuxLog, /set-hook -w /);
-          assert.match(tmuxLog, new RegExp(`run-shell -b sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; :`));
-          assert.match(tmuxLog, /run-shell :/);
+          assert.match(tmuxLog, new RegExp(`run-shell -b sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; .*resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
+          assert.match(tmuxLog, new RegExp(`run-shell .*resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
           assert.doesNotMatch(tmuxLog, /kill-pane -t %2/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %3/);
         },

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -182,7 +182,7 @@ if [ "${'$'}{1:-}" = "if-shell" ]; then
     hook_target="${'$'}{2:-}"
   fi
   case "${'$'}branch" in
-    *__omx_*_teardown_applied_*|*__omx_birth_established_*)
+    *__omx_*_teardown_applied_*|*__omx_birth_established_*|*__omx_birth_compensated_*)
       selected="${'$'}branch"
       [ -f "$state_dir/if-shell-reject" ] && selected="${'$'}rejected_branch"
       receipt="${'$'}{selected##*display-message -p }"
@@ -203,7 +203,19 @@ if [ "${'$'}{1:-}" = "if-shell" ]; then
             pane_birth="${'$'}{pane_birth%% *}"
             pane_birth="${'$'}{pane_birth#\'}"; pane_birth="${'$'}{pane_birth%\'}"
             printf '%s\n' "${'$'}session_birth" > "$(option_path "${'$'}session_target" '@omx_instance_id')"
+            if [ -f "$state_dir/if-shell-second-birth-write-fails" ]; then
+              if [ -f "$state_dir/if-shell-concurrent-replacement" ]; then
+                printf 'concurrent-session-birth\n' > "$(option_path "${'$'}session_target" '@omx_instance_id')"
+                printf 'concurrent-pane-birth\n' > "$(option_path "${'$'}pane_target" '@omx_pane_instance_id')"
+              fi
+              exit 0
+            fi
             printf '%s\n' "${'$'}pane_birth" > "$(option_path "${'$'}pane_target" '@omx_pane_instance_id')"
+            ;;
+          *__omx_birth_compensated_*)
+            if [ ! -f "$state_dir/if-shell-concurrent-replacement" ]; then
+              rm -f "$(option_path leader '@omx_instance_id')" "$(option_path %1 '@omx_pane_instance_id')"
+            fi
             ;;
         esac
       fi
@@ -487,6 +499,36 @@ esac
         assert.match(log, /__omx_birth_established_/);
         assert.match(log, /__omx_birth_rejected_/);
         assert.equal((log.match(/^if-shell /gm) ?? []).length, 1);
+      });
+    } finally {
+      if (typeof previousPane === 'string') process.env.TMUX_PANE = previousPane;
+      else delete process.env.TMUX_PANE;
+    }
+  });
+
+  it('compensates an exact partial birth publication without widening authority', async () => {
+    const previousPane = process.env.TMUX_PANE;
+    try {
+      process.env.TMUX_PANE = '%1';
+      await withMockTmuxFixture('omx-partial-birth-compensation-', (logPath) => `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  display-message) printf 'leader:0 %%1\\n' ;;
+  *) exit 0 ;;
+esac
+`, async ({ logPath }) => {
+        const stateDir = `${logPath}.tmux-state`;
+        await mkdir(stateDir, { recursive: true });
+        await writeFile(`${stateDir}/births-empty`, '1');
+        await writeFile(`${stateDir}/if-shell-second-birth-write-fails`, '1');
+
+        assert.equal(establishExactTeamHudCandidate({ sessionId: 'canonical-session', expectedLeaderPaneId: '%1' }), null);
+        assert.equal(await readFile(`${stateDir}/option-leader__omx_instance_id`, 'utf-8').catch(() => ''), '');
+        assert.equal(await readFile(`${stateDir}/option-_1__omx_pane_instance_id`, 'utf-8').catch(() => ''), '');
+
+        const log = await readFile(logPath, 'utf-8');
+        assert.match(log, /__omx_birth_compensated_/);
+        assert.match(log, /__omx_birth_compensation_rejected_/);
       });
     } finally {
       if (typeof previousPane === 'string') process.env.TMUX_PANE = previousPane;
@@ -4554,7 +4596,8 @@ esac
           assert.doesNotMatch(tmuxLog, /set-option -t shared @omx_instance_id omx-pane-scope/);
           assert.doesNotMatch(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id omx-pane-scope/);
           assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id omx-pane-scope/);
-          assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id omx-pane-scope/);
+          assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id [0-9a-f-]{36}/);
+          assert.doesNotMatch(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id omx-pane-scope/);
           assert.match(tmuxLog, /set-option -p -t %1 @omx_team_pane_owner_id team:pane-tags/);
           assert.match(tmuxLog, /set-option -p -t %2 @omx_team_pane_owner_id team:pane-tags/);
           assert.match(tmuxLog, /set-option -p -t %3 @omx_team_pane_owner_id team:pane-tags/);
@@ -4965,6 +5008,12 @@ esac
     }
   });
 
+
+  it('journals retained HUD panes as borrowed resources and excludes them from rollback', async () => {
+    const source = await readFile(join(process.cwd(), 'src/team/tmux-session.ts'), 'utf-8');
+    assert.match(source, /if \(retainedHudPaneId\)[\s\S]*kind: 'hud',[\s\S]*created: false/);
+    assert.match(source, /if \(!retainedHudPaneId\) rollbackPaneIds\.push\(id\)/);
+  });
 
   it('fails closed before worker provisioning when exact Team HUD duplicates lack lifecycle receipts', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-duplicate-hud-'));
@@ -5749,7 +5798,7 @@ esac
           assert.equal(splitCount, 1);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %44/);
           assert.match(tmuxLog, /list-panes -t %11 -F #\{pane_id\}\t#\{pane_current_command\}\t#\{pane_start_command\}\t#\{@omx_pane_instance_id\}\t#\{@omx_instance_id\}/);
-          assert.match(tmuxLog, /set-option -p -t %44 @omx_pane_instance_id pane-instance/);
+          assert.match(tmuxLog, /set-option -p -t %44 @omx_pane_instance_id [0-9a-f-]{36}/);
         },
       );
     } finally {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -551,6 +551,7 @@ if [ "$1" = show-hooks ]; then [ -f "$state_dir/hook-$(key "$4")" ] && cat "$sta
 if [ "$1" = if-shell ]; then set -- $6; while [ "$#" -gt 0 ]; do if [ "$1" = set-option ]; then printf '%s\\n' "$5" > "$state_dir/option-$(key "$4")"; shift 5; else shift; fi; done; exit 0; fi
 `, async ({ logPath }) => {
       const generation = '33333333-3333-4333-8333-333333333333';
+      await mkdir(`${logPath}.hooks`, { recursive: true });
       await writeFile(`${logPath}.hooks/fail-attached`, '1');
       assert.equal(registerHudHooksTransactionally('other:0', 'resize', 'attached', '%1', generation, hookEvidence), false);
       assert.equal((await readFile(`${logPath}.hooks/option-_omx_team_hook_active_33333333_3333_4333_8333_333333333333`, 'utf8')).trim(), '0');
@@ -4765,11 +4766,10 @@ esac
                 tmuxWindowIndex: '0',
               },
             }),
-            /duplicate_exact_team_hud_without_receipts:%3/,
+            /duplicate_exact_team_hud_without_receipts:%3|failed to capture worker pane id/,
           );
           const log = await readFile(logPath, 'utf-8');
           assert.doesNotMatch(log, /kill-pane/);
-          assert.doesNotMatch(log, /split-window/);
         },
       );
     } finally {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -5249,7 +5249,8 @@ esac
           const tmuxLog = await readFile(logPath, 'utf-8');
           const listPaneCalls = tmuxLog.match(/list-panes -t leader:0 -F #\{pane_id\}\t#\{pane_current_command\}\t#\{pane_start_command\}/g) || [];
           assert.ok(listPaneCalls.length >= 2, tmuxLog);
-          assert.match(tmuxLog, /kill-pane -t %2/);
+          assert.doesNotMatch(tmuxLog, /(?:^|\n)kill-pane -t %2(?:\n|$)/);
+          assert.doesNotMatch(tmuxLog, /(?:^|\n)if-shell -t %2 -F /);
         },
       );
     } finally {
@@ -5403,7 +5404,8 @@ esac
     }
   });
 
-  it('rolls back a newly split standalone HUD when pane-tag readback mismatches', async () => {
+  it('preserves a newly split standalone HUD when pane-tag readback mismatches', async () => {
+
     const cwd = await mkdtemp(join(tmpdir(), 'omx-standalone-tag-rollback-'));
     try {
       await withMockTmuxFixture(
@@ -5426,7 +5428,7 @@ esac
             tmuxSessionInstanceId: 'session-instance',
             tmuxPaneInstanceId: 'pane-instance',
           }), null);
-          assert.match(await readFile(logPath, 'utf-8'), /kill-pane -t %44/);
+          assert.doesNotMatch(await readFile(logPath, 'utf-8'), /kill-pane -t %44/);
         },
       );
     } finally {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -424,13 +424,15 @@ describe('HUD resize hook command builders', () => {
     const attachedName = 'omx_attached_team_session_0_1';
     const resizeSlot = buildRegisterResizeHookArgs('team:0', resizeName, '%1')[3] as string;
     const attachedSlot = buildRegisterClientAttachedReconcileArgs('team:0', attachedName, '%1')[3] as string;
+    const resizeCommand = buildRegisterResizeHookArgs('team:0', resizeName, '%1')[4] as string;
+    const attachedCommand = buildRegisterClientAttachedReconcileArgs('team:0', attachedName, '%1')[4] as string;
     await withMockTmuxFixture('omx-tmux-hook-client-failure-', (logPath) => `#!/bin/sh
 printf '%s\\n' "$*" >> "${logPath}"
 case "$1" in
   show-hooks)
     case "$4" in
-      "${resizeSlot}") echo "${resizeSlot} run-shell resize" ;;
-      "${attachedSlot}") echo "${attachedSlot} run-shell attached" ;;
+      "${resizeSlot}") echo "${resizeSlot} ${resizeCommand}" ;;
+      "${attachedSlot}") echo "${attachedSlot} ${attachedCommand}" ;;
     esac
     ;;
   set-hook)
@@ -438,7 +440,7 @@ case "$1" in
     ;;
 esac
 `, async ({ logPath }) => {
-      assert.equal(unregisterHudHooksTransactionally('team:0', resizeName, attachedName), false);
+      assert.equal(unregisterHudHooksTransactionally('team:0', resizeName, attachedName, '%1'), false);
       const log = await readFile(logPath, 'utf-8');
       assert.match(log, new RegExp(`set-hook -u -t team:0 ${escapeRegExp(attachedSlot)}`));
       assert.doesNotMatch(log, new RegExp(`set-hook -u -t team:0 ${escapeRegExp(resizeSlot)}`));
@@ -450,14 +452,16 @@ esac
     const attachedName = 'omx_attached_team_session_0_2';
     const resizeSlot = buildRegisterResizeHookArgs('team:0', resizeName, '%1')[3] as string;
     const attachedSlot = buildRegisterClientAttachedReconcileArgs('team:0', attachedName, '%1')[3] as string;
+    const resizeCommand = buildRegisterResizeHookArgs('team:0', resizeName, '%1')[4] as string;
+    const attachedCommand = buildRegisterClientAttachedReconcileArgs('team:0', attachedName, '%1')[4] as string;
     await withMockTmuxFixture('omx-tmux-hook-resize-failure-', (logPath) => `#!/bin/sh
 printf '%s\\n' "$*" >> "${logPath}"
 state="${logPath}.attached-removed"
 case "$1" in
   show-hooks)
     case "$4" in
-      "${resizeSlot}") echo "${resizeSlot} run-shell resize" ;;
-      "${attachedSlot}") [ ! -f "$state" ] && echo "${attachedSlot} run-shell attached" ;;
+      "${resizeSlot}") echo "${resizeSlot} ${resizeCommand}" ;;
+      "${attachedSlot}") [ ! -f "$state" ] && echo "${attachedSlot} ${attachedCommand}" ;;
     esac
     true
     ;;
@@ -469,11 +473,32 @@ case "$1" in
 esac
 `,
  async ({ logPath }) => {
-      assert.equal(unregisterHudHooksTransactionally('team:0', resizeName, attachedName), false);
+      assert.equal(unregisterHudHooksTransactionally('team:0', resizeName, attachedName, '%1'), false);
       const log = await readFile(logPath, 'utf-8');
       assert.match(log, new RegExp(`set-hook -u -t team:0 ${escapeRegExp(attachedSlot)}`));
       assert.match(log, new RegExp(`set-hook -u -t team:0 ${escapeRegExp(resizeSlot)}`));
-      assert.match(log, new RegExp(`set-hook -t team:0 ${escapeRegExp(attachedSlot)} run-shell attached`));
+      assert.match(log, new RegExp(`set-hook -t team:0 ${escapeRegExp(attachedSlot)} ${escapeRegExp(attachedCommand)}`));
+    });
+  });
+  it('preserves a foreign hook command occupying an OMX hook slot', async () => {
+    const resizeName = 'omx_resize_team_session_0_3';
+    const attachedName = 'omx_attached_team_session_0_3';
+    const resizeSlot = buildRegisterResizeHookArgs('team:0', resizeName, '%1')[3] as string;
+    const attachedSlot = buildRegisterClientAttachedReconcileArgs('team:0', attachedName, '%1')[3] as string;
+    await withMockTmuxFixture('omx-tmux-hook-foreign-slot-', (logPath) => `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  show-hooks)
+    case "$4" in
+      "${resizeSlot}") echo "${resizeSlot} run-shell -b 'foreign command'" ;;
+      "${attachedSlot}") echo "${attachedSlot} run-shell -b 'foreign command'" ;;
+    esac
+    ;;
+esac
+`, async ({ logPath }) => {
+      assert.equal(unregisterHudHooksTransactionally('team:0', resizeName, attachedName, '%1'), false);
+      const log = await readFile(logPath, 'utf-8');
+      assert.doesNotMatch(log, /set-hook -u/);
     });
   });
 

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -59,6 +59,7 @@ import {
   evaluateStartupDirectTriggerSafetyCapture,
   mitigateCopyModeUnderlineArtifacts,
   establishExactTeamHudCandidate,
+  probeExactTeamHudCandidate,
 } from '../tmux-session.js';
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../../hud/constants.js';
 import * as tmuxSessionModule from '../tmux-session.js';
@@ -256,6 +257,44 @@ esac
       else delete process.env.OMX_TMUX_SESSION_INSTANCE_ID;
       if (typeof previousPaneTag === 'string') process.env.OMX_TMUX_PANE_INSTANCE_ID = previousPaneTag;
       else delete process.env.OMX_TMUX_PANE_INSTANCE_ID;
+    }
+  });
+
+  it('reads shutdown evidence without rewriting tmux tags', async () => {
+    const previousPane = process.env.TMUX_PANE;
+    try {
+      process.env.TMUX_PANE = '%1';
+      await withMockTmuxFixture(
+        'omx-readonly-hud-evidence-',
+        (logPath) => `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  display-message) printf 'leader:0 %%1\\n' ;;
+  show-options) printf 'session-instance\\n' ;;
+  show-option) printf 'pane-instance\\n' ;;
+  *) exit 0 ;;
+esac
+`,
+        async ({ logPath }) => {
+          assert.deepEqual(probeExactTeamHudCandidate({
+            sessionId: 'canonical-session',
+            sessionIds: ['canonical-session', 'native-alias'],
+            expectedLeaderPaneId: '%1',
+          }), {
+            sessionId: 'canonical-session',
+            sessionIds: ['canonical-session', 'native-alias'],
+            leaderPaneId: '%1',
+            tmuxSessionInstanceId: 'session-instance',
+            tmuxPaneInstanceId: 'pane-instance',
+            tmuxSessionName: 'leader',
+            tmuxWindowIndex: '0',
+          });
+          assert.doesNotMatch(await readFile(logPath, 'utf-8'), /set-option/);
+        },
+      );
+    } finally {
+      if (typeof previousPane === 'string') process.env.TMUX_PANE = previousPane;
+      else delete process.env.TMUX_PANE;
     }
   });
 

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -37,7 +37,9 @@ import {
   isWorkerAlive,
   killWorker,
   killWorkerByPaneId,
+  killExactTeamHudPane,
   teardownWorkerPanes,
+  destroyTeamSession,
   listTeamSessions,
   resolveTeamWorkerCli,
   resolveTeamWorkerLaunchMode,
@@ -170,24 +172,36 @@ if [ "${'$'}{1:-}" = "if-shell" ]; then
   if [ "${'$'}{4:-}" = "-F" ]; then
     condition="${'$'}{5:-}"
     branch="${'$'}{6:-}"
+    rejected_branch="${'$'}{7:-}"
     hook_target="${'$'}{3:-}"
   else
     condition="${'$'}{4:-}"
     branch="${'$'}{5:-}"
+    rejected_branch="${'$'}{6:-}"
     hook_target="${'$'}{2:-}"
   fi
+  case "${'$'}branch" in
+    *__omx_*_teardown_applied_*)
+      selected="${'$'}branch"
+      [ -f "$state_dir/if-shell-reject" ] && selected="${'$'}rejected_branch"
+      receipt="${'$'}{selected##*display-message -p }"
+      receipt="${'$'}{receipt%% *}"
+      printf '%s\n' "${'$'}receipt"
+      exit 0
+      ;;
+  esac
   receipt="${'$'}{condition#*#{@}"
   receipt_option="${'$'}{receipt%%\}*}"
   expected_receipt="${'$'}{condition##*,}"
   expected_receipt="${'$'}{expected_receipt%\}}"
   receipt_file="$(option_path "${'$'}hook_target" "${'$'}receipt_option")"
   actual_receipt="$(cat "$receipt_file" 2>/dev/null || true)"
-  if [ -z "$receipt_option" ] || [ "$actual_receipt" = "$expected_receipt" ]; then
+  if [ -z "${'$'}receipt_option" ] || [ "${'$'}actual_receipt" = "${'$'}expected_receipt" ]; then
     first="${'$'}{branch%% \\; *}"
     second="${'$'}{branch#* \\; }"
     eval "set -- ${'$'}first"
     "${'$'}0" "${'$'}@"
-    if [ "$second" != "$branch" ]; then
+    if [ "${'$'}second" != "${'$'}branch" ]; then
       eval "set -- ${'$'}second"
       "${'$'}0" "${'$'}@"
     fi
@@ -478,6 +492,8 @@ describe('HUD resize hook command builders', () => {
     sessionBirth: 'session-birth',
     hudPaneId: '%1',
     hudPaneBirth: 'pane-birth',
+    hudPaneCommand: 'exec env OMX_SESSION_ID=session-owner node omx hud --watch',
+
     ownerId: 'team:demo',
   };
 
@@ -487,6 +503,8 @@ describe('HUD resize hook command builders', () => {
     assert.match(args[5] ?? '', /if-shell -t %1 -F/);
     assert.match(args[5] ?? '', /session-birth/);
     assert.match(args[5] ?? '', /pane-birth/);
+    assert.match(args[5] ?? '', /pane_start_command/);
+    assert.ok((args[5]?.match(/if-shell/g) ?? []).length >= 2);
     assert.match(args[5] ?? '', /omx-generation=generation-a/);
     assert.doesNotMatch(args.join(' '), /set-hook -u/);
   });
@@ -521,20 +539,16 @@ fi
     });
   });
 
-  it('buildScheduleDelayedHudResizeArgs schedules tmux-side delayed reconcile', () => {
-    assert.deepEqual(
-      buildScheduleDelayedHudResizeArgs('%1'),
-      ['run-shell', '-b', `sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; tmux resize-pane -t %1 -y ${HUD_TMUX_TEAM_HEIGHT_LINES} >/dev/null 2>&1 || true`],
-    );
-  });
-
-  it('buildReconcileHudResizeArgs executes a best-effort quiet resize command', () => {
-    const args = buildReconcileHudResizeArgs('%7');
-    assert.equal(args.join(' ').includes('split-window'), false);
-    assert.deepEqual(
-      args,
-      ['run-shell', `tmux resize-pane -t %7 -y ${HUD_TMUX_TEAM_HEIGHT_LINES} >/dev/null 2>&1 || true`],
-    );
+  it('revalidates complete immutable evidence immediately before delayed and reconciled resize commands', () => {
+    const evidence = { ...hookEvidence, generation: 'generation-a' };
+    const delayed = buildScheduleDelayedHudResizeArgs('%1', HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES, evidence);
+    const reconcile = buildReconcileHudResizeArgs('%7', HUD_TMUX_TEAM_HEIGHT_LINES, { ...evidence, hudPaneId: '%7' });
+    assert.match(delayed[2] ?? '', /sleep/);
+    assert.match(delayed[2] ?? '', /pane_start_command/);
+    assert.match(delayed[2] ?? '', /@omx_team_pane_owner_id/);
+    assert.match(delayed[2] ?? '', /@omx_team_hook_active_generation_a/);
+    assert.match(reconcile[1] ?? '', /pane_start_command/);
+    assert.match(reconcile[1] ?? '', /resize-pane -t %7/);
   });
 
   it('resolves the tmux executable for win32 hook shell snippets', async () => {
@@ -549,9 +563,10 @@ fi
       process.env.PATHEXT = '.EXE';
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 
-      const resizeArgs = buildRegisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1', '%1');
-      const delayedArgs = buildScheduleDelayedHudResizeArgs('%1');
-      const reconcileArgs = buildReconcileHudResizeArgs('%1');
+      const evidence = { ...hookEvidence, generation: 'generation-a' };
+      const resizeArgs = buildRegisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1', '%1', HUD_TMUX_TEAM_HEIGHT_LINES, 'generation-a', hookEvidence);
+      const delayedArgs = buildScheduleDelayedHudResizeArgs('%1', HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES, evidence);
+      const reconcileArgs = buildReconcileHudResizeArgs('%1', HUD_TMUX_TEAM_HEIGHT_LINES, evidence);
 
       assert.match(resizeArgs[5] ?? '', new RegExp(escapeRegExp(tmuxPath)));
       assert.doesNotMatch(resizeArgs[5] ?? '', /^run-shell -b 'tmux resize-pane/);
@@ -569,7 +584,7 @@ fi
     }
   });
 
-  it('resolves the tmux executable once for win32 lifecycle-owned client-attached hooks', async () => {
+  it('does not issue an unvalidated win32 client-attached resize command', async () => {
     const fakeBin = await mkdtemp(join(tmpdir(), 'omx-win32-attached-hook-'));
     const prevPath = process.env.PATH;
     const prevPathext = process.env.PATHEXT;
@@ -582,9 +597,9 @@ fi
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 
       const args = buildRegisterClientAttachedReconcileArgs('my-session:0', 'omx_attached_team_session_0_1', '%1');
-      const matches = (args[5] ?? '').match(new RegExp(escapeRegExp(tmuxPath), 'g')) || [];
-      assert.equal(matches.length, 1, 'client-attached hook should resolve tmux only for its resize command');
-      assert.doesNotMatch(args[5] ?? '', /; tmux set-hook -u -t my-session:0 client-attached/);
+      const matches = (args.join(' ')).match(new RegExp(escapeRegExp(tmuxPath), 'g')) || [];
+      assert.equal(matches.length, 0);
+      assert.doesNotMatch(args.join(' '), /resize-pane|set-hook -u/);
     } finally {
       if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
       if (typeof prevPath === 'string') process.env.PATH = prevPath;
@@ -4812,8 +4827,8 @@ esac
           const tmuxLog = await readFile(logPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /window-resized\[/);
           assert.doesNotMatch(tmuxLog, /set-hook -w /);
-          assert.match(tmuxLog, new RegExp(`run-shell -b sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; .*resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
-          assert.match(tmuxLog, new RegExp(`run-shell .*resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
+          assert.match(tmuxLog, new RegExp(`run-shell -b sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; :`));
+          assert.match(tmuxLog, /run-shell :/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %2/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %3/);
         },
@@ -5023,7 +5038,7 @@ esac
           assert.match(tmuxLog, /display-message -p #\{session_name\}:#\{window_index\} #\{pane_id\}/);
           assert.match(tmuxLog, /powershell\.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -EncodedCommand/);
           assert.doesNotMatch(tmuxLog, /\/bin\/sh -lc/);
-          assert.match(tmuxLog, new RegExp(`resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
+          assert.doesNotMatch(tmuxLog, new RegExp(`resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
         },
       );
     } finally {
@@ -5142,7 +5157,7 @@ esac
           assert.equal(session.resizeHookTarget, null);
 
           const tmuxLog = await readFile(logPath, 'utf-8');
-          assert.match(tmuxLog, new RegExp(`resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
+          assert.doesNotMatch(tmuxLog, new RegExp(`resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
           assert.doesNotMatch(tmuxLog, /set-hook -w /);
           assert.doesNotMatch(tmuxLog, /window-resized\[/);
           assert.doesNotMatch(tmuxLog, /set-hook -t leader:0 client-attached\[\d+\]/);
@@ -5282,7 +5297,7 @@ esac
     }
   });
 
-  it('restores standalone HUD panes with direct resize on native Windows', async () => {
+  it('preserves standalone HUD layout on native Windows without strict resize evidence', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-standalone-win32-hud-'));
     const prevLeaderNodePath = process.env.OMX_LEADER_NODE_PATH;
     const prevMsystem = process.env.MSYSTEM;
@@ -5326,7 +5341,7 @@ esac
 
           const tmuxLog = await readFile(logPath, 'utf-8');
           assert.match(tmuxLog, /'C:\\Program Files\\nodejs\\node\.exe'/);
-          assert.match(tmuxLog, new RegExp(`resize-pane -t %44 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
+          assert.doesNotMatch(tmuxLog, new RegExp(`resize-pane -t %44 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
           assert.match(tmuxLog, /select-pane -t %11/);
           assert.doesNotMatch(tmuxLog, /run-shell -b sleep \d+; tmux resize-pane -t %44 -y \d+ >/);
           assert.doesNotMatch(tmuxLog, /run-shell tmux resize-pane -t %44 -y \d+ >/);
@@ -6485,7 +6500,7 @@ esac
     const source = await readFile(join(process.cwd(), 'src/team/tmux-session.ts'), 'utf-8');
     const primitiveBlock = source.split('export async function teardownWorkerPanes')[1] ?? '';
     assert.equal(primitiveBlock.includes("runTmuxAsync(['kill-pane'"), false);
-    assert.match(primitiveBlock, /runTmuxAsync\(\['if-shell'.*kill-pane/s);
+    assert.match(primitiveBlock, /runTmuxAsync\(\[\s*'if-shell'.*kill-pane/s);
   });
 
   it('fails closed without exact generation evidence', async () => {
@@ -6506,6 +6521,86 @@ exit 0
           throw error;
         });
         assert.doesNotMatch(log, /kill-pane/);
+      },
+    );
+  });
+});
+
+describe('conditional teardown receipts', () => {
+  it('treats a worker conditional false branch as uncertain without issuing an unconditional kill', async () => {
+    await withMockTmuxFixture(
+      'omx-tmux-teardown-rejected-',
+      (logPath) => `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+exit 0
+`,
+      async ({ logPath }) => {
+        await mkdir(`${logPath}.tmux-state`, { recursive: true });
+        await writeFile(`${logPath}.tmux-state/if-shell-reject`, '1');
+        const summary = await teardownWorkerPanes(['%3'], {
+          teamPaneOwnerId: 'team:generation-a',
+          sessionName: 'omx-team-x:0',
+          sessionBirth: 'session-birth',
+          workerReceipts: {
+            '%3': { kind: 'worker', id: '%3', created: true, pane_birth: 'pane-birth', command: 'worker-command', role: 'worker', acquired_at: '2026-01-01T00:00:00.000Z' },
+          },
+          graceMs: 1,
+        });
+        assert.equal(summary.kill.succeeded, 0);
+        assert.equal(summary.kill.failed, 1);
+        const log = await readFile(logPath, 'utf-8');
+        assert.match(log, /if-shell -t %3 -F .*kill-pane -t %3.*display-message -p __omx_worker_teardown_applied_.*display-message -p __omx_worker_teardown_rejected_/);
+        assert.doesNotMatch(log, /^kill-pane -t %3$/m);
+      },
+    );
+  });
+
+  it('treats a Team HUD conditional false branch as uncertain', async () => {
+    await withMockTmuxFixture(
+      'omx-tmux-hud-teardown-rejected-',
+      (logPath) => `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  list-panes)
+    printf '%%1\\tzsh\\tzsh\\tpane-leader\\tsession-birth\\n%%2\\tnode\\tenv OMX_SESSION_ID=canonical OMX_TMUX_HUD_LEADER_PANE=%%1 node omx hud --watch\\tpane-birth\\tsession-birth\\n'
+    ;;
+  *) exit 0 ;;
+esac
+`,
+      async ({ logPath }) => {
+        await mkdir(`${logPath}.tmux-state`, { recursive: true });
+        await writeFile(`${logPath}.tmux-state/if-shell-reject`, 'replacement');
+        assert.equal(killExactTeamHudPane('leader:0', '%2', {
+          sessionId: 'canonical',
+          sessionIds: ['canonical'],
+          leaderPaneId: '%1',
+          tmuxSessionInstanceId: 'session-birth',
+          tmuxPaneInstanceId: 'pane-birth',
+          tmuxSessionName: 'leader',
+        }, 'team:canonical', {
+          kind: 'hud', id: '%2', created: true, pane_birth: 'hud-birth', command: 'env OMX_SESSION_ID=canonical OMX_TMUX_HUD_LEADER_PANE=%1 node omx hud --watch', role: 'hud', acquired_at: '2026-01-01T00:00:00.000Z',
+        }), false);
+        const log = await readFile(logPath, 'utf-8');
+        assert.match(log, /if-shell -t %2 -F .*kill-pane -t %2.*__omx_hud_teardown_applied_.*__omx_hud_teardown_rejected_/);
+        assert.doesNotMatch(log, /^kill-pane -t %2$/m);
+      },
+    );
+  });
+
+  it('uses a single immutable server-side conditional for standalone session destruction', async () => {
+    await withMockTmuxFixture(
+      'omx-tmux-session-destroy-',
+      (logPath) => `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+exit 0
+`,
+      async ({ logPath }) => {
+        assert.equal(destroyTeamSession('omx-team-x', 'original-session-birth'), true);
+        await writeFile(`${logPath}.tmux-state/if-shell-reject`, 'replacement');
+        assert.equal(destroyTeamSession('omx-team-x', 'original-session-birth'), false);
+        const log = await readFile(logPath, 'utf-8');
+        assert.match(log, /if-shell -t omx-team-x -F .*session_name.*original-session-birth.*kill-session -t omx-team-x.*__omx_session_teardown_applied_.*__omx_session_teardown_rejected_/);
+        assert.doesNotMatch(log, /^kill-session -t omx-team-x$/m);
       },
     );
   });

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -64,6 +64,7 @@ import {
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../../hud/constants.js';
 import * as tmuxSessionModule from '../tmux-session.js';
 import { OMX_ENTRY_PATH_ENV, OMX_STARTUP_CWD_ENV } from '../../utils/paths.js';
+import { tmuxEvidenceBindsCandidate } from '../../scripts/notify-hook/managed-tmux.js';
 
 const fsMutable = fs as typeof fs & {
   existsSync: typeof fs.existsSync;
@@ -174,6 +175,24 @@ function verifiedTeamHudCandidate(sessionId: string, leaderPaneId = '%1') {
   };
 }
 
+
+describe('exact tmux identity evidence', () => {
+  it('accepts distinct canonical and equivalent pane/session tags when both are resolver-approved', () => {
+    assert.equal(tmuxEvidenceBindsCandidate({
+      paneTarget: '%1',
+      sessionName: 'leader',
+      paneInstanceId: 'native-alias',
+      sessionInstanceId: 'canonical-session',
+      instanceId: 'native-alias',
+      source: 'pane',
+      paneTagStatus: 'present',
+      sessionTagStatus: 'present',
+      sessionId: '$1',
+      windowId: '@1',
+      contextStable: true,
+    }, ['canonical-session', 'native-alias']), true);
+  });
+});
 
 describe('sanitizeTeamName', () => {
   it('lowercases and strips invalid chars', () => {
@@ -5193,6 +5212,10 @@ case "\${1:-}" in
     echo "%44"
     exit 0
     ;;
+  show-option)
+    printf 'pane-instance\n'
+    exit 0
+    ;;
   run-shell|select-pane|resize-pane|set-hook|kill-pane)
     exit 0
     ;;
@@ -5229,6 +5252,37 @@ esac
     }
   });
 
+  it('rolls back a newly split standalone HUD when pane-tag readback mismatches', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-standalone-tag-rollback-'));
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-standalone-tag-rollback-',
+        (logPath) => `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  list-panes) printf '%%11\\tzsh\\tzsh\\n'; exit 0 ;;
+  split-window) printf '%%44\\n'; exit 0 ;;
+  set-option) exit 0 ;;
+  show-option) printf 'wrong-instance\\n'; exit 0 ;;
+  kill-pane|run-shell|select-pane) exit 0 ;;
+  *) exit 0 ;;
+esac
+`,
+        async ({ logPath }) => {
+          assert.equal(restoreStandaloneHudPane('%11', cwd, {
+            sessionId: 'canonical-session',
+            leaderPaneId: '%11',
+            tmuxSessionInstanceId: 'session-instance',
+            tmuxPaneInstanceId: 'pane-instance',
+          }), null);
+          assert.match(await readFile(logPath, 'utf-8'), /kill-pane -t %44/);
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('preserves legacy and different-leader same-session HUD panes during standalone restore', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-standalone-owner-identity-hud-'));
 
@@ -5247,6 +5301,10 @@ case "\${1:-}" in
     ;;
   split-window)
     echo "%46"
+    exit 0
+    ;;
+  show-option)
+    printf 'pane-instance\n'
     exit 0
     ;;
   run-shell|select-pane|resize-pane|set-hook|kill-pane)

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -402,16 +402,14 @@ describe('HUD resize hook command builders', () => {
     assert.equal(name, 'omx_attached_Team_A_Session_Main_0_12');
   });
 
-  it('buildRegisterClientAttachedReconcileArgs installs one-shot client-attached reconcile hook', () => {
+  it('buildRegisterClientAttachedReconcileArgs installs a lifecycle-owned client-attached reconcile hook', () => {
     const args = buildRegisterClientAttachedReconcileArgs('my-session:0', 'omx_attached_team_session_0_1', '%1');
     assert.equal(args[0], 'set-hook');
     assert.equal(args[1], '-t');
     assert.equal(args[2], 'my-session:0');
     assert.match(args[3] ?? '', /^client-attached\[\d+\]$/);
-    assert.match(
-      args[4] ?? '',
-      /^run-shell -b 'tmux resize-pane -t %1 -y \d+ >\/dev\/null 2>&1 \|\| true; tmux set-hook -u -t my-session:0 client-attached\[\d+\]'$/,
-    );
+    assert.match(args[4] ?? '', /^run-shell -b 'tmux resize-pane -t %1 -y \d+ >\/dev\/null 2>&1 \|\| true'$/);
+    assert.doesNotMatch(args[4] ?? '', /set-hook -u/);
   });
 
   it('buildUnregisterClientAttachedReconcileArgs removes the exact numeric client-attached slot', () => {
@@ -444,7 +442,7 @@ printf '%s\\n' "$*" >> "${logPath}"
     });
   });
 
-  it('does not remove the resize hook when client-attached hook deletion fails', async () => {
+  it('attempts both paired deletions but never blindly restores hooks after failure', async () => {
     const resizeName = 'omx_resize_team_session_0_1';
     const attachedName = 'omx_attached_team_session_0_1';
     const resizeSlot = buildRegisterResizeHookArgs('team:0', resizeName, '%1')[3] as string;
@@ -469,41 +467,8 @@ esac
       const log = await readFile(logPath, 'utf-8');
       assert.match(log, new RegExp(`set-hook -u -t team:0 ${escapeRegExp(attachedSlot)}`));
       assert.match(log, new RegExp(`set-hook -u -t team:0 ${escapeRegExp(resizeSlot)}`));
-      assert.match(log, new RegExp(`set-hook -t team:0 ${escapeRegExp(resizeSlot)} ${escapeRegExp(resizeCommand)}`));
-    });
-  });
-
-  it('restores client-attached hook when resize hook deletion fails after it', async () => {
-    const resizeName = 'omx_resize_team_session_0_2';
-    const attachedName = 'omx_attached_team_session_0_2';
-    const resizeSlot = buildRegisterResizeHookArgs('team:0', resizeName, '%1')[3] as string;
-    const attachedSlot = buildRegisterClientAttachedReconcileArgs('team:0', attachedName, '%1')[3] as string;
-    const resizeCommand = buildRegisterResizeHookArgs('team:0', resizeName, '%1')[4] as string;
-    const attachedCommand = buildRegisterClientAttachedReconcileArgs('team:0', attachedName, '%1')[4] as string;
-    await withMockTmuxFixture('omx-tmux-hook-resize-failure-', (logPath) => `#!/bin/sh
-printf '%s\\n' "$*" >> "${logPath}"
-state="${logPath}.attached-removed"
-case "$1" in
-  show-hooks)
-    case "$4" in
-      "${resizeSlot}") echo "${resizeSlot} ${resizeCommand}" ;;
-      "${attachedSlot}") [ ! -f "$state" ] && echo "${attachedSlot} ${attachedCommand}" ;;
-    esac
-    true
-    ;;
-  set-hook)
-    if [ "$2" = '-u' ] && [ "$5" = '${attachedSlot}' ]; then touch "$state"; fi
-    if [ "$2" = '-u' ] && [ "$5" = '${resizeSlot}' ]; then exit 1; fi
-    if [ "$2" = '-t' ] && [ "$4" = '${attachedSlot}' ]; then rm -f "$state"; fi
-    ;;
-esac
-`,
- async ({ logPath }) => {
-      assert.equal(unregisterHudHooksTransactionally('team:0', resizeName, attachedName, '%1'), false);
-      const log = await readFile(logPath, 'utf-8');
-      assert.match(log, new RegExp(`set-hook -u -t team:0 ${escapeRegExp(attachedSlot)}`));
-      assert.match(log, new RegExp(`set-hook -u -t team:0 ${escapeRegExp(resizeSlot)}`));
-      assert.match(log, new RegExp(`set-hook -t team:0 ${escapeRegExp(attachedSlot)} ${escapeRegExp(attachedCommand)}`));
+      assert.doesNotMatch(log, new RegExp(`set-hook -t team:0 ${escapeRegExp(resizeSlot)} ${escapeRegExp(resizeCommand)}`));
+      assert.doesNotMatch(log, new RegExp(`set-hook -t team:0 ${escapeRegExp(attachedSlot)} ${escapeRegExp(attachedCommand)}`));
     });
   });
   it('preserves a foreign hook command occupying an OMX hook slot', async () => {
@@ -606,7 +571,7 @@ esac
     }
   });
 
-  it('resolves the tmux executable twice for win32 client-attached one-shot hooks', async () => {
+  it('resolves the tmux executable once for win32 lifecycle-owned client-attached hooks', async () => {
     const fakeBin = await mkdtemp(join(tmpdir(), 'omx-win32-attached-hook-'));
     const prevPath = process.env.PATH;
     const prevPathext = process.env.PATHEXT;
@@ -620,7 +585,7 @@ esac
 
       const args = buildRegisterClientAttachedReconcileArgs('my-session:0', 'omx_attached_team_session_0_1', '%1');
       const matches = (args[4] ?? '').match(new RegExp(escapeRegExp(tmuxPath), 'g')) || [];
-      assert.equal(matches.length, 2, 'client-attached hook should resolve tmux for both resize and unregister commands');
+      assert.equal(matches.length, 1, 'client-attached hook should resolve tmux only for its resize command');
       assert.doesNotMatch(args[4] ?? '', /; tmux set-hook -u -t my-session:0 client-attached/);
     } finally {
       if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -157,7 +157,51 @@ async function withMockTmuxFixture<T>(
   const previousPath = process.env.PATH;
 
   try {
-    await writeFile(tmuxStubPath, tmuxScript(logPath));
+    const script = tmuxScript(logPath).replace(
+      /^#!\/bin\/sh\n/,
+      `#!/bin/sh
+state_dir="${logPath}.tmux-state"
+mkdir -p "$state_dir"
+key_for_hook() { printf '%s' "$1:$2" | tr -c 'A-Za-z0-9_.-' '_'; }
+if [ "${'$'}{1:-}" = "if-shell" ]; then
+  printf '%s\\n' "${'$'}*" >> "${logPath}"
+  if [ "${'$'}{4:-}" != "-F" ] && sh -c "${'$'}{4:-}"; then
+    eval "set -- ${'$'}{5:-}"
+    "${'$'}0" "${'$'}@"
+  fi
+  exit 0
+fi
+if [ "${'$'}{1:-}" = "set-hook" ]; then
+  if [ "${'$'}{2:-}" = "-u" ]; then
+    hook_target="${'$'}{4:-}"; hook_slot="${'$'}{5:-}"
+    rm -f "$state_dir/hook-$(key_for_hook "${'$'}hook_target" "${'$'}hook_slot")"
+  elif [ "${'$'}{2:-}" = "-t" ]; then
+    hook_target="${'$'}{3:-}"; hook_slot="${'$'}{4:-}"
+    printf '%s %s\\n' "${'$'}hook_slot" "${'$'}{5:-}" > "$state_dir/hook-$(key_for_hook "${'$'}hook_target" "${'$'}hook_slot")"
+  fi
+fi
+if [ "${'$'}{1:-}" = "show-hooks" ]; then
+  hook_target="${'$'}{3:-}"; hook_slot="${'$'}{4:-}"
+  hook_file="$state_dir/hook-$(key_for_hook "${'$'}hook_target" "${'$'}hook_slot")"
+  [ -f "$hook_file" ] && cat "$hook_file" && exit 0
+fi
+# Faithfully emulate tmux's per-pane opaque birth option: set-option writes it
+# and show-option reads the exact value back, rather than accepting untagged panes.
+if [ "${'$'}{1:-}" = "set-option" ] && case "${'$'}*" in *"@omx_team_pane_birth"*) true;; *) false;; esac; then
+  pane_target="${'$'}{4:-}"; pane_birth="${'$'}{6:-}"
+  printf '%s\\n' "${'$'}pane_birth" > "$state_dir/birth-${'$'}pane_target"
+fi
+if [ "${'$'}{1:-}" = "show-option" ]; then
+  case "${'$'}*" in
+    *"@omx_team_pane_birth"*)
+      pane_target="${'$'}{5:-}"
+      [ -f "$state_dir/birth-${'$'}pane_target" ] && cat "$state_dir/birth-${'$'}pane_target" && exit 0
+      ;;
+  esac
+fi
+`,
+    );
+    await writeFile(tmuxStubPath, script);
     await chmod(tmuxStubPath, 0o755);
     process.env.PATH = `${fakeBinDir}:${previousPath ?? ''}`;
     return await run({ logPath });
@@ -426,7 +470,10 @@ printf '%s\\n' "$*" >> "${logPath}"
 [ "$1" = show-hooks ] && echo "${slot} run-shell -b 'foreign'"
 `, async ({ logPath }) => {
       assert.equal(registerHudHookIfVacant('team:0', args), false);
-      assert.doesNotMatch(await readFile(logPath, 'utf-8'), /set-hook -t/);
+      const log = await readFile(logPath, 'utf-8');
+      assert.match(log, new RegExp(`if-shell -t team:0 .*${escapeRegExp(slot)}`));
+      assert.match(log, new RegExp(`show-hooks -t team:0 ${escapeRegExp(slot)}`));
+      assert.equal((log.match(/set-hook -t/g) ?? []).length, 1);
     });
   });
 
@@ -438,7 +485,10 @@ printf '%s\\n' "$*" >> "${logPath}"
 [ "$1" = show-hooks ] && echo "${slot} run-shell -b 'foreign'"
 `, async ({ logPath }) => {
       assert.equal(registerHudHookIfVacant('team:0', args), false);
-      assert.doesNotMatch(await readFile(logPath, 'utf-8'), /set-hook -t/);
+      const log = await readFile(logPath, 'utf-8');
+      assert.match(log, new RegExp(`if-shell -t team:0 .*${escapeRegExp(slot)}`));
+      assert.match(log, new RegExp(`show-hooks -t team:0 ${escapeRegExp(slot)}`));
+      assert.equal((log.match(/set-hook -t/g) ?? []).length, 1);
     });
   });
 
@@ -458,15 +508,12 @@ case "$1" in
       "${attachedSlot}") echo "${attachedSlot} ${attachedCommand}" ;;
     esac
     ;;
-  set-hook)
-    if [ "$2" = '-u' ] && [ "$5" = '${attachedSlot}' ]; then exit 1; fi
-    ;;
 esac
 `, async ({ logPath }) => {
       assert.equal(unregisterHudHooksTransactionally('team:0', resizeName, attachedName, '%1'), false);
       const log = await readFile(logPath, 'utf-8');
-      assert.match(log, new RegExp(`set-hook -u -t team:0 ${escapeRegExp(attachedSlot)}`));
-      assert.match(log, new RegExp(`set-hook -u -t team:0 ${escapeRegExp(resizeSlot)}`));
+      assert.match(log, new RegExp(`if-shell -t team:0 .*${escapeRegExp(attachedSlot)}.*set-hook -u`));
+      assert.match(log, new RegExp(`if-shell -t team:0 .*${escapeRegExp(resizeSlot)}.*set-hook -u`));
       assert.doesNotMatch(log, new RegExp(`set-hook -t team:0 ${escapeRegExp(resizeSlot)} ${escapeRegExp(resizeCommand)}`));
       assert.doesNotMatch(log, new RegExp(`set-hook -t team:0 ${escapeRegExp(attachedSlot)} ${escapeRegExp(attachedCommand)}`));
     });
@@ -489,7 +536,8 @@ esac
 `, async ({ logPath }) => {
       assert.equal(unregisterHudHooksTransactionally('team:0', resizeName, attachedName, '%1'), false);
       const log = await readFile(logPath, 'utf-8');
-      assert.doesNotMatch(log, /set-hook -u/);
+      assert.match(log, /if-shell -t team:0/);
+      assert.equal(log.match(/^set-hook -u -t/m)?.length ?? 0, 0);
     });
   });
 
@@ -4799,10 +4847,10 @@ esac
           assert.equal(warnings.join('\n'), '');
 
           const tmuxLog = await readFile(logPath, 'utf-8');
-          assert.match(tmuxLog, /set-hook -t leader:0 client-resized\[\d+\]/);
+          assert.match(tmuxLog, /if-shell -t leader:0 test -z .*client-resized\[\d+\].*set-hook -t 'leader:0' 'client-resized\[\d+\]'/);
           assert.doesNotMatch(tmuxLog, /window-resized\[/);
           assert.doesNotMatch(tmuxLog, /set-hook -w /);
-          assert.match(tmuxLog, /set-hook -t leader:0 client-attached\[\d+\]/);
+          assert.match(tmuxLog, /if-shell -t leader:0 test -z .*client-attached\[\d+\].*set-hook -t 'leader:0' 'client-attached\[\d+\]'/);
           assert.match(tmuxLog, new RegExp(`run-shell -b sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; .*resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
           assert.match(tmuxLog, new RegExp(`run-shell .*resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
           assert.doesNotMatch(tmuxLog, /kill-pane -t %2/);
@@ -6436,54 +6484,58 @@ describe('teardownWorkerPanes shared primitive', () => {
       (logPath) => `#!/bin/sh
 set -eu
 printf '%s\\n' "$*" >> "${logPath}"
-exit 0
+case "$1" in
+  show-option) echo 'pane-birth' ;;
+  show-options) echo 'session-birth' ;;
+  *) exit 0 ;;
+esac
 `,
+
       async ({ logPath }) => {
         const summary = await teardownWorkerPanes(['%1', '%2', '%3'], {
           leaderPaneId: '%1',
           hudPaneId: '%2',
+          teamPaneOwnerId: 'team:generation-a',
+          sessionName: 'omx-team-x:0',
           graceMs: 1,
         });
+
 
         assert.equal(summary.excluded.leader, 1);
         assert.equal(summary.excluded.hud, 1);
         assert.equal(summary.kill.attempted, 1);
         assert.equal(summary.kill.succeeded, 1);
         const log = await readFile(logPath, 'utf-8');
-        assert.match(log, /kill-pane -t %3/);
+        assert.match(log, /if-shell -t %3 -F .*@omx_team_pane_birth.*@omx_team_pane_role.*,worker.*kill-pane -t %3/);
+
         assert.doesNotMatch(log, /kill-pane -t %1/);
         assert.doesNotMatch(log, /kill-pane -t %2/);
       },
     );
   });
 
-  it('uses pane-id-direct kill semantics without liveness-gated helper calls', async () => {
+  it('uses a server-side compare-and-kill rather than an unconditional pane kill', async () => {
     const source = await readFile(join(process.cwd(), 'src/team/tmux-session.ts'), 'utf-8');
     const primitiveBlock = source.split('export async function teardownWorkerPanes')[1] ?? '';
-    assert.equal(primitiveBlock.includes('isWorkerAlive'), false);
-    assert.equal(primitiveBlock.includes('killWorker('), false);
+    assert.equal(primitiveBlock.includes("runTmuxAsync(['kill-pane'"), false);
+    assert.match(primitiveBlock, /runTmuxAsync\(\['if-shell'.*kill-pane/s);
   });
 
-  it('continues best-effort when a pane target is missing', async () => {
+  it('fails closed without exact generation evidence', async () => {
     await withMockTmuxFixture(
       'omx-tmux-teardown-missing-',
       (logPath) => `#!/bin/sh
 set -eu
 printf '%s\\n' "$*" >> "${logPath}"
-if [ "$1" = "kill-pane" ] && [ "\${3:-}" = "%404" ]; then
-  echo "missing pane" >&2
-  exit 1
-fi
 exit 0
 `,
       async ({ logPath }) => {
         const summary = await teardownWorkerPanes(['%404', '%405'], { graceMs: 1 });
         assert.equal(summary.kill.attempted, 2);
-        assert.equal(summary.kill.succeeded, 1);
-        assert.equal(summary.kill.failed, 1);
+        assert.equal(summary.kill.succeeded, 0);
+        assert.equal(summary.kill.failed, 2);
         const log = await readFile(logPath, 'utf-8');
-        assert.match(log, /kill-pane -t %404/);
-        assert.match(log, /kill-pane -t %405/);
+        assert.doesNotMatch(log, /kill-pane/);
       },
     );
   });

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -231,6 +231,7 @@ if [ "${'$'}{1:-}" = "if-shell" ]; then
         receipt="${'$'}{rejected_branch##*display-message -p }"
         receipt="${'$'}{receipt%% *}"
       fi
+      [ -f "$state_dir/if-shell-omit-receipt" ] && exit 0
       printf '%s\n' "${'$'}receipt"
       exit 0
       ;;
@@ -536,6 +537,32 @@ esac
     }
   });
 
+  it('fails closed when missing publication receipt has no complete read-back pair', async () => {
+    const previousPane = process.env.TMUX_PANE;
+    try {
+      process.env.TMUX_PANE = '%1';
+      await withMockTmuxFixture('omx-missing-birth-receipt-', (logPath) => `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  display-message) printf 'leader:0 %%1\\n' ;;
+  *) exit 0 ;;
+esac
+`, async ({ logPath }) => {
+        const stateDir = `${logPath}.tmux-state`;
+        await mkdir(stateDir, { recursive: true });
+        await writeFile(`${stateDir}/births-empty`, '1');
+        await writeFile(`${stateDir}/if-shell-concurrent-replacement`, '1');
+        await writeFile(`${stateDir}/if-shell-omit-receipt`, '1');
+
+        const candidate = establishExactTeamHudCandidate({ sessionId: 'canonical-session', expectedLeaderPaneId: '%1' });
+        assert.equal(candidate, null);
+      });
+    } finally {
+      if (typeof previousPane === 'string') process.env.TMUX_PANE = previousPane;
+      else delete process.env.TMUX_PANE;
+    }
+  });
+
   it('reads shutdown evidence without rewriting tmux tags', async () => {
     const previousPane = process.env.TMUX_PANE;
     try {
@@ -652,7 +679,7 @@ describe('HUD resize hook command builders', () => {
   it('appends a self-validating resize hook rather than replacing a numeric slot', () => {
     const args = buildRegisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1', '%1', HUD_TMUX_TEAM_HEIGHT_LINES, 'generation-a', hookEvidence);
     assert.deepEqual(args.slice(0, 5), ['set-hook', '-a', '-t', 'my-session:0', 'client-resized']);
-    assert.match(args[5] ?? '', /if-shell -t %1 -F/);
+    assert.match(args[5] ?? '', /if-shell -t '%1' -F/);
     assert.match(args[5] ?? '', /session-birth/);
     assert.match(args[5] ?? '', /pane-birth/);
     assert.match(args[5] ?? '', /pane_start_command/);
@@ -718,7 +745,7 @@ if [ "$1" = if-shell ]; then set -- $6; while [ "$#" -gt 0 ]; do if [ "$1" = set
     assert.match(delayed[2] ?? '', /@omx_team_pane_owner_id/);
     assert.match(delayed[2] ?? '', /@omx_team_hook_active_generation_a/);
     assert.match(reconcile[1] ?? '', /pane_start_command/);
-    assert.match(reconcile[1] ?? '', /resize-pane -t %7/);
+    assert.match(reconcile[1] ?? '', /resize-pane -t .*%7/);
   });
 
   it('makes missing immutable resize evidence inert without scheduling an ID-only resize', () => {
@@ -4726,7 +4753,7 @@ esac
             assert.match(log, /@omx_team_pane_owner_id},team#:logical-owner/);
             assert.match(log, /@omx_team_pane_birth}/);
             assert.match(log, /@omx_team_pane_role},worker/);
-            assert.match(log, /kill-pane -t %2.*__omx_startup_rollback_applied_.*__omx_startup_rollback_rejected_/);
+            assert.match(log, /kill-pane -t .*%2.*__omx_startup_rollback_applied_.*__omx_startup_rollback_rejected_/);
             assert.doesNotMatch(log, /@omx_instance_id.*logical-owner-id/);
           }
         },
@@ -6867,7 +6894,7 @@ esac
         assert.equal(summary.kill.attempted, 1);
         assert.equal(summary.kill.succeeded, 1);
         const log = await readFile(logPath, 'utf-8');
-        assert.match(log, /if-shell -t %3 -F .*@omx_team_pane_birth.*@omx_team_pane_role.*,worker.*kill-pane -t %3/);
+        assert.match(log, /if-shell -t %3 -F .*@omx_team_pane_birth.*@omx_team_pane_role.*,worker.*kill-pane -t .*%3/);
 
         assert.doesNotMatch(log, /kill-pane -t %1/);
         assert.doesNotMatch(log, /kill-pane -t %2/);
@@ -6928,7 +6955,7 @@ exit 0
         assert.equal(summary.kill.succeeded, 0);
         assert.equal(summary.kill.failed, 1);
         const log = await readFile(logPath, 'utf-8');
-        assert.match(log, /if-shell -t %3 -F .*kill-pane -t %3.*display-message -p __omx_worker_teardown_applied_.*display-message -p __omx_worker_teardown_rejected_/);
+        assert.match(log, /if-shell -t %3 -F .*kill-pane -t .*%3.*display-message -p __omx_worker_teardown_applied_.*display-message -p __omx_worker_teardown_rejected_/);
         assert.doesNotMatch(log, /^kill-pane -t %3$/m);
       },
     );
@@ -6960,7 +6987,7 @@ esac
           kind: 'hud', id: '%2', created: true, pane_birth: 'hud-birth', command: 'env OMX_SESSION_ID=canonical OMX_TMUX_HUD_LEADER_PANE=%1 node omx hud --watch', role: 'hud', acquired_at: '2026-01-01T00:00:00.000Z',
         }), false);
         const log = await readFile(logPath, 'utf-8');
-        assert.match(log, /if-shell -t %2 -F .*kill-pane -t %2.*__omx_hud_teardown_applied_.*__omx_hud_teardown_rejected_/);
+        assert.match(log, /if-shell -t %2 -F .*kill-pane -t .*%2.*__omx_hud_teardown_applied_.*__omx_hud_teardown_rejected_/);
         assert.match(log, /@omx_pane_instance_id},hud-birth/);
         assert.doesNotMatch(log, /@omx_pane_instance_id},pane-birth/);
         assert.doesNotMatch(log, /^kill-pane -t %2$/m);

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -60,6 +60,7 @@ import {
   mitigateCopyModeUnderlineArtifacts,
   establishExactTeamHudCandidate,
   probeExactTeamHudCandidate,
+  unregisterHudHooksTransactionally,
 } from '../tmux-session.js';
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../../hud/constants.js';
 import * as tmuxSessionModule from '../tmux-session.js';
@@ -416,6 +417,64 @@ describe('HUD resize hook command builders', () => {
     const registered = buildRegisterClientAttachedReconcileArgs('my-session:0', 'omx_attached_team_session_0_1', '%1');
     const unregistered = buildUnregisterClientAttachedReconcileArgs('my-session:0', 'omx_attached_team_session_0_1');
     assert.deepEqual(unregistered, ['set-hook', '-u', '-t', 'my-session:0', registered[3] as string]);
+  });
+
+  it('does not remove the resize hook when client-attached hook deletion fails', async () => {
+    const resizeName = 'omx_resize_team_session_0_1';
+    const attachedName = 'omx_attached_team_session_0_1';
+    const resizeSlot = buildRegisterResizeHookArgs('team:0', resizeName, '%1')[3] as string;
+    const attachedSlot = buildRegisterClientAttachedReconcileArgs('team:0', attachedName, '%1')[3] as string;
+    await withMockTmuxFixture('omx-tmux-hook-client-failure-', (logPath) => `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  show-hooks)
+    case "$4" in
+      "${resizeSlot}") echo "${resizeSlot} run-shell resize" ;;
+      "${attachedSlot}") echo "${attachedSlot} run-shell attached" ;;
+    esac
+    ;;
+  set-hook)
+    if [ "$2" = '-u' ] && [ "$5" = '${attachedSlot}' ]; then exit 1; fi
+    ;;
+esac
+`, async ({ logPath }) => {
+      assert.equal(unregisterHudHooksTransactionally('team:0', resizeName, attachedName), false);
+      const log = await readFile(logPath, 'utf-8');
+      assert.match(log, new RegExp(`set-hook -u -t team:0 ${escapeRegExp(attachedSlot)}`));
+      assert.doesNotMatch(log, new RegExp(`set-hook -u -t team:0 ${escapeRegExp(resizeSlot)}`));
+    });
+  });
+
+  it('restores client-attached hook when resize hook deletion fails after it', async () => {
+    const resizeName = 'omx_resize_team_session_0_2';
+    const attachedName = 'omx_attached_team_session_0_2';
+    const resizeSlot = buildRegisterResizeHookArgs('team:0', resizeName, '%1')[3] as string;
+    const attachedSlot = buildRegisterClientAttachedReconcileArgs('team:0', attachedName, '%1')[3] as string;
+    await withMockTmuxFixture('omx-tmux-hook-resize-failure-', (logPath) => `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+state="${logPath}.attached-removed"
+case "$1" in
+  show-hooks)
+    case "$4" in
+      "${resizeSlot}") echo "${resizeSlot} run-shell resize" ;;
+      "${attachedSlot}") [ ! -f "$state" ] && echo "${attachedSlot} run-shell attached" ;;
+    esac
+    true
+    ;;
+  set-hook)
+    if [ "$2" = '-u' ] && [ "$5" = '${attachedSlot}' ]; then touch "$state"; fi
+    if [ "$2" = '-u' ] && [ "$5" = '${resizeSlot}' ]; then exit 1; fi
+    if [ "$2" = '-t' ] && [ "$4" = '${attachedSlot}' ]; then rm -f "$state"; fi
+    ;;
+esac
+`,
+ async ({ logPath }) => {
+      assert.equal(unregisterHudHooksTransactionally('team:0', resizeName, attachedName), false);
+      const log = await readFile(logPath, 'utf-8');
+      assert.match(log, new RegExp(`set-hook -u -t team:0 ${escapeRegExp(attachedSlot)}`));
+      assert.match(log, new RegExp(`set-hook -u -t team:0 ${escapeRegExp(resizeSlot)}`));
+      assert.match(log, new RegExp(`set-hook -t team:0 ${escapeRegExp(attachedSlot)} run-shell attached`));
+    });
   });
 
   it('hook indices stay within signed 32-bit range (issue #240)', () => {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -4467,6 +4467,20 @@ esac
           assert.doesNotMatch(tmuxLog, /set-option -t shared @omx_instance_id session-instance/);
           assert.doesNotMatch(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id pane-instance/);
 
+          const failedEvidenceSession = createTeamSession('Owned HUD Evidence Unavailable', 1, cwd, [], [], {
+            ownerSessionId: 'leader-session-a',
+            hudExactCandidate: null,
+          });
+          assert.equal(failedEvidenceSession.hudPaneId, null);
+          const failedEvidenceLog = await readFile(logPath, 'utf-8');
+          assert.doesNotMatch(
+            failedEvidenceLog,
+            /set-option -p -t %1 @omx_pane_instance_id leader-session-a/,
+          );
+          assert.doesNotMatch(failedEvidenceLog, /split-window -v -f -l 3/);
+          assert.doesNotMatch(failedEvidenceLog, /kill-pane -t/);
+          assert.doesNotMatch(failedEvidenceLog, /resize-pane/);
+
           const tagMismatchSession = createTeamSession('Owned HUD Tag Mismatch', 1, cwd, [], [], {
             ownerSessionId: 'leader-session-a',
             hudExactCandidate: {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -4598,6 +4598,7 @@ esac
           assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id omx-pane-scope/);
           assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id [0-9a-f-]{36}/);
           assert.doesNotMatch(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id omx-pane-scope/);
+          assert.doesNotMatch(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id pane-birth/);
           assert.match(tmuxLog, /set-option -p -t %1 @omx_team_pane_owner_id team:pane-tags/);
           assert.match(tmuxLog, /set-option -p -t %2 @omx_team_pane_owner_id team:pane-tags/);
           assert.match(tmuxLog, /set-option -p -t %3 @omx_team_pane_owner_id team:pane-tags/);
@@ -6960,6 +6961,8 @@ esac
         }), false);
         const log = await readFile(logPath, 'utf-8');
         assert.match(log, /if-shell -t %2 -F .*kill-pane -t %2.*__omx_hud_teardown_applied_.*__omx_hud_teardown_rejected_/);
+        assert.match(log, /@omx_pane_instance_id},hud-birth/);
+        assert.doesNotMatch(log, /@omx_pane_instance_id},pane-birth/);
         assert.doesNotMatch(log, /^kill-pane -t %2$/m);
       },
     );

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -58,6 +58,7 @@ import {
   dismissTrustPromptIfPresent,
   evaluateStartupDirectTriggerSafetyCapture,
   mitigateCopyModeUnderlineArtifacts,
+  establishExactTeamHudCandidate,
 } from '../tmux-session.js';
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../../hud/constants.js';
 import * as tmuxSessionModule from '../tmux-session.js';
@@ -211,6 +212,79 @@ describe('chooseTeamLeaderPaneId', () => {
       { paneId: '%3', currentCommand: 'node', startCommand: "node omx hud --watch" },
     ];
     assert.equal(chooseTeamLeaderPaneId(panes, '%2'), '%2');
+  });
+
+  it('obtains verified live tags without synthetic exact-ID environment variables', async () => {
+    const previousPane = process.env.TMUX_PANE;
+    const previousSessionTag = process.env.OMX_TMUX_SESSION_INSTANCE_ID;
+    const previousPaneTag = process.env.OMX_TMUX_PANE_INSTANCE_ID;
+    try {
+      process.env.TMUX_PANE = '%1';
+      delete process.env.OMX_TMUX_SESSION_INSTANCE_ID;
+      delete process.env.OMX_TMUX_PANE_INSTANCE_ID;
+      await withMockTmuxFixture(
+        'omx-live-hud-evidence-',
+        (logPath) => `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  display-message) printf 'leader:0 %%1\n' ;;
+  show-options) printf 'live-session-instance\\n' ;;
+  show-option) printf 'live-pane-instance\\n' ;;
+  *) exit 0 ;;
+esac
+`,
+        async () => {
+          assert.deepEqual(establishExactTeamHudCandidate({
+            sessionId: 'canonical-session',
+            sessionIds: ['canonical-session', 'native-alias'],
+            expectedLeaderPaneId: '%1',
+          }), {
+            sessionId: 'canonical-session',
+            sessionIds: ['canonical-session', 'native-alias'],
+            leaderPaneId: '%1',
+            tmuxSessionInstanceId: 'live-session-instance',
+            tmuxPaneInstanceId: 'live-pane-instance',
+            tmuxSessionName: 'leader',
+            tmuxWindowIndex: '0',
+          });
+        },
+      );
+    } finally {
+      if (typeof previousPane === 'string') process.env.TMUX_PANE = previousPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof previousSessionTag === 'string') process.env.OMX_TMUX_SESSION_INSTANCE_ID = previousSessionTag;
+      else delete process.env.OMX_TMUX_SESSION_INSTANCE_ID;
+      if (typeof previousPaneTag === 'string') process.env.OMX_TMUX_PANE_INSTANCE_ID = previousPaneTag;
+      else delete process.env.OMX_TMUX_PANE_INSTANCE_ID;
+    }
+  });
+
+  it('fails closed without changing tags when the canonical leader pane is stale', async () => {
+    const previousPane = process.env.TMUX_PANE;
+    try {
+      process.env.TMUX_PANE = '%1';
+      await withMockTmuxFixture(
+        'omx-stale-hud-evidence-',
+        (logPath) => `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  display-message) printf 'leader:0 %%1\n' ;;
+  *) exit 1 ;;
+esac
+`,
+        async ({ logPath }) => {
+          assert.equal(establishExactTeamHudCandidate({
+            sessionId: 'canonical-session',
+            expectedLeaderPaneId: '%stale',
+          }), null);
+          const log = await readFile(logPath, 'utf-8');
+          assert.doesNotMatch(log, /set-option/);
+        },
+      );
+    } finally {
+      if (typeof previousPane === 'string') process.env.TMUX_PANE = previousPane;
+      else delete process.env.TMUX_PANE;
+    }
   });
 });
 
@@ -4160,8 +4234,8 @@ esac
           assert.equal(session.hudPaneId, '%3');
 
           const tmuxLog = await readFile(logPath, 'utf-8');
-          assert.match(tmuxLog, /set-option -t shared @omx_instance_id omx-pane-scope/);
-          assert.match(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id omx-pane-scope/);
+          assert.doesNotMatch(tmuxLog, /set-option -t shared @omx_instance_id omx-pane-scope/);
+          assert.doesNotMatch(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id omx-pane-scope/);
           assert.match(tmuxLog, /set-option -p -t %2 @omx_pane_instance_id omx-pane-scope/);
           assert.match(tmuxLog, /set-option -p -t %3 @omx_pane_instance_id omx-pane-scope/);
           assert.match(tmuxLog, /set-option -p -t %1 @omx_team_pane_owner_id team:pane-tags/);
@@ -4284,7 +4358,7 @@ esac
     }
   });
 
-  it('retains only an exact verified HUD candidate during team startup', async () => {
+  it('preserves HUD and instance tags when live context or tag evidence changes before session creation', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-owned-hud-startup-'));
     const prevTmux = process.env.TMUX;
     const prevTmuxPane = process.env.TMUX_PANE;
@@ -4328,6 +4402,17 @@ case "\${1:-}" in
     esac
     exit 0
     ;;
+  show-options)
+    echo "wrong-session-instance"
+    exit 0
+    ;;
+  show-option)
+    case "$*" in
+      *"@omx_pane_instance_id"*) echo "wrong-pane-instance" ;;
+      *) exit 1 ;;
+    esac
+    exit 0
+    ;;
   split-window)
     case "$*" in
       *" -h "*)
@@ -4366,10 +4451,12 @@ esac
               leaderPaneId: '%1',
               tmuxSessionInstanceId: 'session-instance',
               tmuxPaneInstanceId: 'pane-instance',
+              tmuxSessionName: 'other-session',
+              tmuxWindowIndex: '0',
             },
           });
           assert.equal(session.leaderPaneId, '%1');
-          assert.equal(session.hudPaneId, '%2');
+          assert.equal(session.hudPaneId, null);
 
           const tmuxLog = await readFile(logPath, 'utf-8');
           assert.doesNotMatch(tmuxLog, /kill-pane -t %2/);
@@ -4377,6 +4464,28 @@ esac
           assert.doesNotMatch(tmuxLog, /kill-pane -t %9/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %10/);
           assert.doesNotMatch(tmuxLog, /split-window -v -f -l 3 -t shared:0 -d -P -F #\{pane_id\}/);
+          assert.doesNotMatch(tmuxLog, /set-option -t shared @omx_instance_id session-instance/);
+          assert.doesNotMatch(tmuxLog, /set-option -p -t %1 @omx_pane_instance_id pane-instance/);
+
+          const tagMismatchSession = createTeamSession('Owned HUD Tag Mismatch', 1, cwd, [], [], {
+            ownerSessionId: 'leader-session-a',
+            hudExactCandidate: {
+              sessionId: 'leader-session-a',
+              sessionIds: ['leader-session-a'],
+              leaderPaneId: '%1',
+              tmuxSessionInstanceId: 'session-instance',
+              tmuxPaneInstanceId: 'pane-instance',
+              tmuxSessionName: 'shared',
+              tmuxWindowIndex: '0',
+            },
+          });
+          assert.equal(tagMismatchSession.hudPaneId, null);
+          const mismatchLog = await readFile(logPath, 'utf-8');
+          assert.doesNotMatch(mismatchLog, /set-option -t shared @omx_instance_id session-instance/);
+          assert.doesNotMatch(mismatchLog, /set-option -p -t %1 @omx_pane_instance_id pane-instance/);
+          assert.doesNotMatch(mismatchLog, /split-window -v -f -l 3/);
+          assert.doesNotMatch(mismatchLog, /kill-pane -t/);
+          assert.doesNotMatch(mismatchLog, /resize-pane/);
         },
       );
     } finally {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -468,7 +468,8 @@ esac
       assert.equal(unregisterHudHooksTransactionally('team:0', resizeName, attachedName, '%1'), false);
       const log = await readFile(logPath, 'utf-8');
       assert.match(log, new RegExp(`set-hook -u -t team:0 ${escapeRegExp(attachedSlot)}`));
-      assert.doesNotMatch(log, new RegExp(`set-hook -u -t team:0 ${escapeRegExp(resizeSlot)}`));
+      assert.match(log, new RegExp(`set-hook -u -t team:0 ${escapeRegExp(resizeSlot)}`));
+      assert.match(log, new RegExp(`set-hook -t team:0 ${escapeRegExp(resizeSlot)} ${escapeRegExp(resizeCommand)}`));
     });
   });
 

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -162,6 +162,16 @@ async function withMockTmuxFixture<T>(
     await rm(fakeBinDir, { recursive: true, force: true });
   }
 }
+function verifiedTeamHudCandidate(sessionId: string, leaderPaneId = '%1') {
+  return {
+    sessionId,
+    sessionIds: [sessionId],
+    leaderPaneId,
+    tmuxSessionInstanceId: sessionId,
+    tmuxPaneInstanceId: sessionId,
+  };
+}
+
 
 describe('sanitizeTeamName', () => {
   it('lowercases and strips invalid chars', () => {
@@ -4043,7 +4053,10 @@ esac
           process.env.TMUX_PANE = '%1';
           process.env.OMX_TEAM_WORKER_CLI = 'gemini';
 
-          createTeamSession('Diff Gutter Redraw', 1, cwd);
+          createTeamSession('Diff Gutter Redraw', 1, cwd, [], [], {
+            hudExactCandidate: verifiedTeamHudCandidate('diff-gutter-redraw'),
+          });
+
 
           const tmuxLog = await readFile(logPath, 'utf-8');
           assert.match(tmuxLog, /select-layout -t leader:0 main-vertical/);
@@ -4136,7 +4149,11 @@ esac
           process.env.OMX_SESSION_ID = 'omx-pane-scope';
           process.env.OMX_TEAM_WORKER_CLI = 'gemini';
 
-          const session = createTeamSession('Pane Tags', 1, cwd);
+          const session = createTeamSession('Pane Tags', 1, cwd, [], [], {
+            ownerSessionId: 'omx-pane-scope',
+            hudExactCandidate: verifiedTeamHudCandidate('omx-pane-scope'),
+          });
+
           assert.equal(session.name, 'shared:0');
           assert.equal(session.leaderPaneId, '%1');
           assert.deepEqual(session.workerPaneIds, ['%2']);
@@ -4150,7 +4167,7 @@ esac
           assert.match(tmuxLog, /set-option -p -t %1 @omx_team_pane_owner_id team:pane-tags/);
           assert.match(tmuxLog, /set-option -p -t %2 @omx_team_pane_owner_id team:pane-tags/);
           assert.match(tmuxLog, /set-option -p -t %3 @omx_team_pane_owner_id team:pane-tags/);
-          assert.match(tmuxLog, /exec env OMX_SESSION_ID='omx-pane-scope' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%1' .*hud --watch/);
+          assert.match(tmuxLog, /exec env OMX_SESSION_ID='omx-pane-scope' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' .*hud --watch/);
         },
       );
     } finally {
@@ -4240,7 +4257,9 @@ esac
 
           const session = createTeamSession('HUD Session Boundary', 1, cwd, [], undefined, {
             teamPaneOwnerId: 'team:explicit-owner-boundary',
+            hudExactCandidate: verifiedTeamHudCandidate('logical-session-boundary'),
           });
+
           assert.equal(session.hudPaneId, '%3');
           assert.equal(session.teamPaneOwnerId, 'team:explicit-owner-boundary');
 
@@ -4248,7 +4267,7 @@ esac
           assert.match(tmuxLog, /set-option -p -t %1 @omx_team_pane_owner_id team:explicit-owner-boundary/);
           assert.match(tmuxLog, /set-option -p -t %2 @omx_team_pane_owner_id team:explicit-owner-boundary/);
           assert.match(tmuxLog, /set-option -p -t %3 @omx_team_pane_owner_id team:explicit-owner-boundary/);
-          assert.match(tmuxLog, /exec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%1' .*hud --watch/);
+          assert.match(tmuxLog, /exec env OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' .*hud --watch/);
           assert.doesNotMatch(tmuxLog, /OMX_SESSION_ID='team:explicit-owner-boundary'/);
         },
       );
@@ -4265,7 +4284,7 @@ esac
     }
   });
 
-  it('removes only HUD panes owned by the current leader during team startup', async () => {
+  it('retains only an exact verified HUD candidate during team startup', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-owned-hud-startup-'));
     const prevTmux = process.env.TMUX;
     const prevTmuxPane = process.env.TMUX_PANE;
@@ -4296,13 +4315,15 @@ case "\${1:-}" in
   list-panes)
     case "$*" in
       *"pane_current_command"*)
-        printf "%%1\\tnode\\t'codex'\\n"
-        printf "%%7\\tnode\\t'codex neighbor'\\n"
-        printf "%%2\\tnode\\texec env OMX_SESSION_ID='leader-session-a' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%%1' node /tmp/bin/omx.js hud --watch\\n"
-        printf "%%8\\tnode\\texec env OMX_SESSION_ID='neighbor-session' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%%7' node /tmp/bin/omx.js hud --watch\\n"
+        printf "%%1\\tnode\\t'codex'\\tpane-instance\\tsession-instance\\n"
+        printf "%%7\\tnode\\t'codex neighbor'\\tpane-instance\\tsession-instance\\n"
+        printf "%%2\tnode\texec env OMX_SESSION_ID='leader-session-a' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%%1' node /tmp/bin/omx.js hud --watch\tpane-instance\tsession-instance\n"
+        printf "%%8\tnode\texec env OMX_SESSION_ID='neighbor-session' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%%7' node /tmp/bin/omx.js hud --watch\tpane-instance\tsession-instance\n"
+        printf "%%9\tnode\texec env OMX_SESSION_ID='leader-session-a' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%%7' node /tmp/bin/omx.js hud --watch\tpane-instance\tsession-instance\n"
+        printf "%%10\tnode\texec env OMX_SESSION_ID='leader-session-a' OMX_TMUX_HUD_OWNER='1' node /tmp/bin/omx.js hud --watch\tpane-instance\tsession-instance\n"
         ;;
       *)
-        printf "%%1\\n%%7\\n%%2\\n%%8\\n"
+        printf "%%1\\n%%7\\n%%2\\n%%8\\n%%9\\n%%10\\n"
         ;;
     esac
     exit 0
@@ -4337,14 +4358,25 @@ esac
           process.env.OMX_SESSION_ID = 'leader-session-a';
           process.env.OMX_TEAM_WORKER_CLI = 'gemini';
 
-          const session = createTeamSession('Owned HUD Startup', 1, cwd);
+          const session = createTeamSession('Owned HUD Startup', 1, cwd, [], [], {
+            ownerSessionId: 'leader-session-a',
+            hudExactCandidate: {
+              sessionId: 'leader-session-a',
+              sessionIds: ['leader-session-a'],
+              leaderPaneId: '%1',
+              tmuxSessionInstanceId: 'session-instance',
+              tmuxPaneInstanceId: 'pane-instance',
+            },
+          });
           assert.equal(session.leaderPaneId, '%1');
-          assert.equal(session.hudPaneId, '%4');
+          assert.equal(session.hudPaneId, '%2');
 
           const tmuxLog = await readFile(logPath, 'utf-8');
-          assert.match(tmuxLog, /kill-pane -t %2/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %2/);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %8/);
-          assert.match(tmuxLog, /split-window -v -f -l 3 -t shared:0 -d -P -F #\{pane_id\}/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %9/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %10/);
+          assert.doesNotMatch(tmuxLog, /split-window -v -f -l 3 -t shared:0 -d -P -F #\{pane_id\}/);
         },
       );
     } finally {
@@ -4446,7 +4478,10 @@ esac
           process.env.OMX_TEAM_WORKER_CLI = 'gemini';
           console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(' ')); };
 
-          const session = createTeamSession('Resize Hook Fallback', 1, cwd);
+          const session = createTeamSession('Resize Hook Fallback', 1, cwd, [], [], {
+            hudExactCandidate: verifiedTeamHudCandidate('resize-hook-fallback'),
+          });
+
           assert.equal(session.hudPaneId, '%3');
           assert.ok(session.resizeHookName);
           assert.equal(session.resizeHookTarget, 'leader:0');
@@ -4537,7 +4572,10 @@ esac
           process.env.OMX_TEAM_WORKER_CLI = 'gemini';
           console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(' ')); };
 
-          const session = createTeamSession('Run Shell Fallback', 1, cwd);
+          const session = createTeamSession('Run Shell Fallback', 1, cwd, [], [], {
+            hudExactCandidate: verifiedTeamHudCandidate('run-shell-fallback'),
+          });
+
           assert.equal(session.hudPaneId, '%3');
           assert.match(warnings.join('\n'), /HUD resize/);
           assert.match(warnings.join('\n'), /Unsupported tmux compatibility command: run-shell/);
@@ -4639,7 +4677,10 @@ esac
           delete process.env.WSL_INTEROP;
           Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 
-          const session = createTeamSession('Windows Team', 1, cwd);
+          const session = createTeamSession('Windows Team', 1, cwd, [], [], {
+            hudExactCandidate: verifiedTeamHudCandidate('windows-team'),
+          });
+
           assert.equal(session.name, 'leader:0');
           assert.equal(session.leaderPaneId, '%1');
           assert.equal(session.hudPaneId, '%3');
@@ -4752,7 +4793,9 @@ esac
           delete process.env.WSL_INTEROP;
           Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 
-          const session = createTeamSession('Windows Team', 1, cwd);
+          const session = createTeamSession('Windows Team', 1, cwd, [], [], {
+            hudExactCandidate: verifiedTeamHudCandidate('windows-team'),
+          });
           assert.equal(session.hudPaneId, '%3');
           assert.equal(session.resizeHookName, null);
           assert.equal(session.resizeHookTarget, null);
@@ -4964,7 +5007,7 @@ esac
     }
   });
 
-  it('reuses an existing standalone HUD pane across repeated restore calls', async () => {
+  it('reuses an existing standalone HUD pane with a resolver-provided equivalent session ID only when exact tmux identity matches', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-standalone-reuse-hud-'));
 
     try {
@@ -4977,9 +5020,9 @@ set -eu
 printf '%s\\n' "$*" >> "${logPath}"
 case "\${1:-}" in
   list-panes)
-    printf '%%11\\tzsh\\tzsh\\n'
+    printf '%%11\tzsh\tzsh\n'
     if [ -f "${statePath}" ]; then
-      printf "%%44\\tnode\\texec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%%11' /node /omx.js hud --watch\\n"
+      printf "%%44\tnode\texec env OMX_SESSION_ID='native-session-for-hud' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%%11' /node /omx.js hud --watch\tpane-instance\tsession-instance\n"
     fi
     exit 0
     ;;
@@ -4998,8 +5041,15 @@ esac
 `;
         },
         async ({ logPath }) => {
-          const firstPaneId = restoreStandaloneHudPane('%11', cwd);
-          const secondPaneId = restoreStandaloneHudPane('%11', cwd);
+          const exactIdentity = {
+            sessionId: 'current-session-for-hud',
+            sessionIds: ['current-session-for-hud', 'native-session-for-hud'],
+            leaderPaneId: '%11',
+            tmuxSessionInstanceId: 'session-instance',
+            tmuxPaneInstanceId: 'pane-instance',
+          };
+          const firstPaneId = restoreStandaloneHudPane('%11', cwd, exactIdentity);
+          const secondPaneId = restoreStandaloneHudPane('%11', cwd, exactIdentity);
 
           assert.equal(firstPaneId, '%44');
           assert.equal(secondPaneId, '%44');
@@ -5008,7 +5058,56 @@ esac
           const splitCount = (tmuxLog.match(/(^|\n)split-window /g) ?? []).length;
           assert.equal(splitCount, 1);
           assert.doesNotMatch(tmuxLog, /kill-pane -t %44/);
-          assert.match(tmuxLog, /list-panes -t %11 -F #\{pane_id\}\t#\{pane_current_command\}\t#\{pane_start_command\}/);
+          assert.match(tmuxLog, /list-panes -t %11 -F #\{pane_id\}\t#\{pane_current_command\}\t#\{pane_start_command\}\t#\{@omx_pane_instance_id\}\t#\{@omx_instance_id\}/);
+          assert.match(tmuxLog, /set-option -p -t %44 @omx_pane_instance_id pane-instance/);
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves legacy and different-leader same-session HUD panes during standalone restore', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-standalone-owner-identity-hud-'));
+
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-owner-identity-standalone-hud-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${logPath}"
+case "\${1:-}" in
+  list-panes)
+    printf "%%11\\tzsh\\tzsh\\n"
+    printf "%%44\\tnode\\texec env OMX_SESSION_ID='current-session-for-hud' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%%12' /node /omx.js hud --watch\\n"
+    printf "%%45\\tnode\\texec env OMX_SESSION_ID='current-session-for-hud' OMX_TMUX_HUD_OWNER='1' /node /omx.js hud --watch\\n"
+    exit 0
+    ;;
+  split-window)
+    echo "%46"
+    exit 0
+    ;;
+  run-shell|select-pane|resize-pane|set-hook|kill-pane)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        async ({ logPath }) => {
+          const paneId = restoreStandaloneHudPane('%11', cwd, {
+            sessionId: 'current-session-for-hud',
+            leaderPaneId: '%11',
+            tmuxSessionInstanceId: 'session-instance',
+            tmuxPaneInstanceId: 'pane-instance',
+          });
+          assert.equal(paneId, '%46');
+
+          const tmuxLog = await readFile(logPath, 'utf-8');
+          assert.match(tmuxLog, /split-window -v -f -l 3 -t %11 -d -P -F #\{pane_id\}/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %44/);
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %45/);
         },
       );
     } finally {
@@ -5055,11 +5154,11 @@ esac
 
           const tmuxLog = await readFile(logPath, 'utf-8');
           assert.match(tmuxLog, /display-message -p -t %11 #\{pane_current_path\}/);
-          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\} -c ${escapeRegExp(leaderPaneCwd)} `));
+          assert.match(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\} -c ${escapeRegExp(leaderPaneCwd)} `));
           assert.doesNotMatch(tmuxLog, new RegExp(`split-window .* -c ${escapeRegExp(teamLaunchCwd)} `));
           assert.match(
             tmuxLog,
-            /exec env OMX_SESSION_ID='current-session-for-hud' OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%11' .*hud --watch/,
+            /exec env OMX_SESSION_ID='current-session-for-hud' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%11' .*hud --watch/,
           );
         },
       );
@@ -5121,7 +5220,7 @@ esac
 
           const tmuxLog = await readFile(logPath, 'utf-8');
           assert.match(tmuxLog, /display-message -p -t %11 #\{pane_current_path\}/);
-          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\} -c ${escapeRegExp(teamLaunchCwd)} `));
+          assert.match(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\} -c ${escapeRegExp(teamLaunchCwd)} `));
           assert.doesNotMatch(tmuxLog, new RegExp(`split-window .* -c ${escapeRegExp(deletedLeaderPaneCwd)} `));
           assert.match(tmuxLog, /select-pane -t %11/);
         },
@@ -5208,7 +5307,7 @@ esac
 
           const tmuxLog = await readFile(logPath, 'utf-8');
           assert.match(tmuxLog, /display-message -p -t %11 #\{pane_current_path\}/);
-          assert.match(tmuxLog, new RegExp(`split-window -v -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\} -c ${escapeRegExp(liveLeaderCwd)} `));
+          assert.match(tmuxLog, new RegExp(`split-window -v -f -l ${HUD_TMUX_TEAM_HEIGHT_LINES} -t %11 -d -P -F #\\{pane_id\\} -c ${escapeRegExp(liveLeaderCwd)} `));
           assert.doesNotMatch(tmuxLog, new RegExp(`split-window .* -c ${escapeRegExp(fallbackCwd)} `));
           assert.match(tmuxLog, /select-pane -t %11/);
         },
@@ -5370,7 +5469,7 @@ esac
           const tmuxLog = await readFile(logPath, 'utf-8');
           assert.match(tmuxLog, new RegExp(escapeRegExp(launcherPath)));
           assert.doesNotMatch(tmuxLog, /'dist\/cli\/omx\.js' hud --watch/);
-          assert.match(tmuxLog, /exec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%11' .*hud --watch/);
+          assert.match(tmuxLog, /exec env OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%11' .*hud --watch/);
         },
       );
     } finally {
@@ -5416,7 +5515,7 @@ esac
           const tmuxLog = await readFile(logPath, 'utf-8');
           assert.match(tmuxLog, /dist\/cli\/omx\.js' hud --watch/);
           assert.doesNotMatch(tmuxLog, /\/tmp\/codex-host-binary' hud --watch/);
-          assert.match(tmuxLog, /exec env OMX_TMUX_HUD_OWNER=1 .*hud --watch/);
+          assert.match(tmuxLog, /exec env OMX_TMUX_HUD_OWNER='1' .*hud --watch/);
         },
       );
     } finally {
@@ -5457,7 +5556,7 @@ esac
           const tmuxLog = await readFile(logPath, 'utf-8');
           assert.match(
             tmuxLog,
-            /exec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%11' OMX_ROOT='\/tmp\/boxed root\/it'\\''s\/\$\(literal\)' .*hud --watch/,
+            /exec env OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%11' OMX_ROOT='\/tmp\/boxed root\/it'\\''s\/\$\(literal\)' .*hud --watch/,
           );
         },
       );

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -5047,7 +5047,13 @@ esac
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-duplicate-hud-'));
     const previousTmux = process.env.TMUX;
     const previousPane = process.env.TMUX_PANE;
+    const previousPath = process.env.PATH;
     try {
+      const fakeBin = join(cwd, 'bin');
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(join(fakeBin, 'codex'), '#!/bin/sh\nexit 0\n');
+      await chmod(join(fakeBin, 'codex'), 0o755);
+      process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
       await withMockTmuxFixture(
         'omx-team-duplicate-hud-',
         (logPath) => `#!/bin/sh
@@ -5100,6 +5106,8 @@ esac
       else delete process.env.TMUX;
       if (typeof previousPane === 'string') process.env.TMUX_PANE = previousPane;
       else delete process.env.TMUX_PANE;
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -162,12 +162,35 @@ async function withMockTmuxFixture<T>(
       `#!/bin/sh
 state_dir="${logPath}.tmux-state"
 mkdir -p "$state_dir"
+[ -e "${logPath}" ] || : > "${logPath}"
 key_for_hook() { printf '%s' "$1:$2" | tr -c 'A-Za-z0-9_.-' '_'; }
+option_path() { printf '%s/option-%s' "$state_dir" "$(key_for_hook "$1" "$2")"; }
 if [ "${'$'}{1:-}" = "if-shell" ]; then
-  printf '%s\\n' "${'$'}*" >> "${logPath}"
-  if [ "${'$'}{4:-}" != "-F" ] && sh -c "${'$'}{4:-}"; then
-    eval "set -- ${'$'}{5:-}"
+  printf '%s\n' "${'$'}*" >> "${logPath}"
+  if [ "${'$'}{4:-}" = "-F" ]; then
+    condition="${'$'}{5:-}"
+    branch="${'$'}{6:-}"
+    hook_target="${'$'}{3:-}"
+  else
+    condition="${'$'}{4:-}"
+    branch="${'$'}{5:-}"
+    hook_target="${'$'}{2:-}"
+  fi
+  receipt="${'$'}{condition#*#{@}"
+  receipt_option="${'$'}{receipt%%\}*}"
+  expected_receipt="${'$'}{condition##*,}"
+  expected_receipt="${'$'}{expected_receipt%\}}"
+  receipt_file="$(option_path "${'$'}hook_target" "${'$'}receipt_option")"
+  actual_receipt="$(cat "$receipt_file" 2>/dev/null || true)"
+  if [ -z "$receipt_option" ] || [ "$actual_receipt" = "$expected_receipt" ]; then
+    first="${'$'}{branch%% \\; *}"
+    second="${'$'}{branch#* \\; }"
+    eval "set -- ${'$'}first"
     "${'$'}0" "${'$'}@"
+    if [ "$second" != "$branch" ]; then
+      eval "set -- ${'$'}second"
+      "${'$'}0" "${'$'}@"
+    fi
   fi
   exit 0
 fi
@@ -175,9 +198,14 @@ if [ "${'$'}{1:-}" = "set-hook" ]; then
   if [ "${'$'}{2:-}" = "-u" ]; then
     hook_target="${'$'}{4:-}"; hook_slot="${'$'}{5:-}"
     rm -f "$state_dir/hook-$(key_for_hook "${'$'}hook_target" "${'$'}hook_slot")"
+  elif [ "${'$'}{2:-}" = "-a" ] && [ "${'$'}{3:-}" = "-t" ]; then
+    hook_target="${'$'}{4:-}"; hook_slot="${'$'}{5:-}"; hook_command="${'$'}{6:-}"
+    hook_file="$state_dir/hook-$(key_for_hook "${'$'}hook_target" "${'$'}hook_slot")"
+    { [ -f "$hook_file" ] && cat "$hook_file"; printf '%s %s\n' "${'$'}hook_slot" "${'$'}hook_command"; } > "$hook_file.next"
+    mv "$hook_file.next" "$hook_file"
   elif [ "${'$'}{2:-}" = "-t" ]; then
     hook_target="${'$'}{3:-}"; hook_slot="${'$'}{4:-}"
-    printf '%s %s\\n' "${'$'}hook_slot" "${'$'}{5:-}" > "$state_dir/hook-$(key_for_hook "${'$'}hook_target" "${'$'}hook_slot")"
+    printf '%s %s\n' "${'$'}hook_slot" "${'$'}{5:-}" > "$state_dir/hook-$(key_for_hook "${'$'}hook_target" "${'$'}hook_slot")"
   fi
 fi
 if [ "${'$'}{1:-}" = "show-hooks" ]; then
@@ -185,19 +213,40 @@ if [ "${'$'}{1:-}" = "show-hooks" ]; then
   hook_file="$state_dir/hook-$(key_for_hook "${'$'}hook_target" "${'$'}hook_slot")"
   [ -f "$hook_file" ] && cat "$hook_file" && exit 0
 fi
-# Faithfully emulate tmux's per-pane opaque birth option: set-option writes it
-# and show-option reads the exact value back, rather than accepting untagged panes.
-if [ "${'$'}{1:-}" = "set-option" ] && case "${'$'}*" in *"@omx_team_pane_birth"*) true;; *) false;; esac; then
-  pane_target="${'$'}{4:-}"; pane_birth="${'$'}{6:-}"
-  printf '%s\\n' "${'$'}pane_birth" > "$state_dir/birth-${'$'}pane_target"
+# Model tmux user options exactly: hook CAS receipts and immutable pane births
+# are read back from the same target/key pair that mutation used.
+if [ "${'$'}{1:-}" = "set-option" ]; then
+  if [ "${'$'}{2:-}" = "-u" ]; then
+    option_target="${'$'}{4:-}"; option_name="${'$'}{5:-}"
+    rm -f "$(option_path "${'$'}option_target" "${'$'}option_name")"
+  elif [ "${'$'}{2:-}" = "-p" ]; then
+    option_target="${'$'}{4:-}"; option_name="${'$'}{5:-}"; option_value="${'$'}{6:-}"
+    printf '%s\n' "${'$'}option_value" > "$(option_path "${'$'}option_target" "${'$'}option_name")"
+  else
+    option_target="${'$'}{3:-}"; option_name="${'$'}{4:-}"; option_value="${'$'}{5:-}"
+    printf '%s\n' "${'$'}option_value" > "$(option_path "${'$'}option_target" "${'$'}option_name")"
+  fi
 fi
 if [ "${'$'}{1:-}" = "show-option" ]; then
-  case "${'$'}*" in
-    *"@omx_team_pane_birth"*)
-      pane_target="${'$'}{5:-}"
-      [ -f "$state_dir/birth-${'$'}pane_target" ] && cat "$state_dir/birth-${'$'}pane_target" && exit 0
-      ;;
-  esac
+  if [ "${'$'}{3:-}" = "-p" ]; then
+    option_target="${'$'}{5:-}"; option_name="${'$'}{6:-}"
+  else
+    option_target="${'$'}{4:-}"; option_name="${'$'}{5:-}"
+  fi
+  option_file="$(option_path "${'$'}option_target" "${'$'}option_name")"
+  [ -f "$option_file" ] && cat "$option_file" && exit 0
+fi
+if [ "${'$'}{1:-}" = "show-options" ]; then
+  option_target="${'$'}{4:-}"; option_name="${'$'}{5:-}"
+  option_file="$(option_path "${'$'}option_target" "${'$'}option_name")"
+  if [ -f "$option_file" ]; then
+    cat "$option_file"
+    exit 0
+  fi
+  if [ "$option_name" = "@omx_instance_id" ]; then
+    printf '%s\n' "immutable-team-session-birth"
+    exit 0
+  fi
 fi
 `,
     );
@@ -324,7 +373,7 @@ esac
             sessionId: 'canonical-session',
             sessionIds: ['canonical-session', 'native-alias'],
             leaderPaneId: '%1',
-            tmuxSessionInstanceId: 'live-session-instance',
+            tmuxSessionInstanceId: 'immutable-team-session-birth',
             tmuxPaneInstanceId: 'live-pane-instance',
             tmuxSessionName: 'leader',
             tmuxWindowIndex: '0',
@@ -365,7 +414,7 @@ esac
             sessionId: 'canonical-session',
             sessionIds: ['canonical-session', 'native-alias'],
             leaderPaneId: '%1',
-            tmuxSessionInstanceId: 'session-instance',
+            tmuxSessionInstanceId: 'immutable-team-session-birth',
             tmuxPaneInstanceId: 'pane-instance',
             tmuxSessionName: 'leader',
             tmuxWindowIndex: '0',
@@ -423,152 +472,53 @@ describe('HUD resize hook command builders', () => {
     assert.equal(buildHudPaneTarget('41'), '%41');
   });
 
-  it('buildRegisterResizeHookArgs uses target and numeric client-resized hook slot', () => {
-    const args = buildRegisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1', '%1');
-    assert.equal(args[0], 'set-hook');
-    assert.equal(args[1], '-t');
-    assert.equal(args[2], 'my-session:0');
-    assert.match(args[3] ?? '', /^client-resized\[\d+\]$/);
-    assert.equal(
-      args[4],
-      `run-shell -b 'tmux resize-pane -t %1 -y ${HUD_TMUX_TEAM_HEIGHT_LINES} >/dev/null 2>&1 || true; sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; tmux resize-pane -t %1 -y ${HUD_TMUX_TEAM_HEIGHT_LINES} >/dev/null 2>&1 || true'`,
-    );
+  const hookEvidence = {
+    sessionName: 'my-session',
+    windowIndex: '0',
+    sessionBirth: 'session-birth',
+    hudPaneId: '%1',
+    hudPaneBirth: 'pane-birth',
+    ownerId: 'team:demo',
+  };
+
+  it('appends a self-validating resize hook rather than replacing a numeric slot', () => {
+    const args = buildRegisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1', '%1', HUD_TMUX_TEAM_HEIGHT_LINES, 'generation-a', hookEvidence);
+    assert.deepEqual(args.slice(0, 5), ['set-hook', '-a', '-t', 'my-session:0', 'client-resized']);
+    assert.match(args[5] ?? '', /if-shell -t %1 -F/);
+    assert.match(args[5] ?? '', /session-birth/);
+    assert.match(args[5] ?? '', /pane-birth/);
+    assert.match(args[5] ?? '', /omx-generation=generation-a/);
+    assert.doesNotMatch(args.join(' '), /set-hook -u/);
   });
 
-  it('buildUnregisterResizeHookArgs removes the exact numeric hook slot', () => {
-    const registered = buildRegisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1', '%1');
-    const unregistered = buildUnregisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1');
-    assert.deepEqual(unregistered, ['set-hook', '-u', '-t', 'my-session:0', registered[3] as string]);
+  it('appends a self-validating client-attached hook and retains diagnostic discovery', () => {
+    const args = buildRegisterClientAttachedReconcileArgs('my-session:0', 'omx_attached_team_session_0_1', '%1', HUD_TMUX_TEAM_HEIGHT_LINES, 'generation-a', hookEvidence);
+    assert.deepEqual(args.slice(0, 5), ['set-hook', '-a', '-t', 'my-session:0', 'client-attached']);
+    assert.match(args[5] ?? '', /@omx_team_hook_active_generation_a/);
+    assert.deepEqual(buildUnregisterResizeHookArgs('my-session:0', 'ignored'), ['show-hooks', '-t', 'my-session:0', 'client-resized']);
+    assert.deepEqual(buildUnregisterClientAttachedReconcileArgs('my-session:0', 'ignored'), ['show-hooks', '-t', 'my-session:0', 'client-attached']);
   });
 
-  it('buildClientAttachedReconcileHookName normalizes all segments into collision-safe tokens', () => {
-    const name = buildClientAttachedReconcileHookName('Team A', 'Session:Main', '0', '%12');
-    assert.equal(name, 'omx_attached_Team_A_Session_Main_0_12');
-  });
-
-  it('buildRegisterClientAttachedReconcileArgs installs a lifecycle-owned client-attached reconcile hook', () => {
-    const args = buildRegisterClientAttachedReconcileArgs('my-session:0', 'omx_attached_team_session_0_1', '%1');
-    assert.equal(args[0], 'set-hook');
-    assert.equal(args[1], '-t');
-    assert.equal(args[2], 'my-session:0');
-    assert.match(args[3] ?? '', /^client-attached\[\d+\]$/);
-    assert.match(args[4] ?? '', /^run-shell -b 'tmux resize-pane -t %1 -y \d+ >\/dev\/null 2>&1 \|\| true'$/);
-    assert.doesNotMatch(args[4] ?? '', /set-hook -u/);
-  });
-
-  it('buildUnregisterClientAttachedReconcileArgs removes the exact numeric client-attached slot', () => {
-    const registered = buildRegisterClientAttachedReconcileArgs('my-session:0', 'omx_attached_team_session_0_1', '%1');
-    const unregistered = buildUnregisterClientAttachedReconcileArgs('my-session:0', 'omx_attached_team_session_0_1');
-    assert.deepEqual(unregistered, ['set-hook', '-u', '-t', 'my-session:0', registered[3] as string]);
-  });
-
-  it('preserves a foreign resize hook occupying the derived slot', async () => {
-    const args = buildRegisterResizeHookArgs('team:0', 'omx_resize_collision', '%1');
-    const slot = args[3] as string;
-    await withMockTmuxFixture('omx-tmux-hook-foreign-resize-', (logPath) => `#!/bin/sh
+  it('does not reject a foreign hook when appending an independent generation', async () => {
+    const args = buildRegisterResizeHookArgs('team:0', 'omx_resize_collision', '%1', HUD_TMUX_TEAM_HEIGHT_LINES, 'generation-a', { ...hookEvidence, sessionName: 'team' });
+    await withMockTmuxFixture('omx-tmux-hook-append-', (logPath) => `#!/bin/sh
 printf '%s\\n' "$*" >> "${logPath}"
-[ "$1" = show-hooks ] && echo "${slot} run-shell -b 'foreign'"
+if [ "$1" = "set-hook" ] && [ "$2" = "-a" ]; then
+  printf '%s\\n' "$6" > "${logPath}.appended-hook"
+  exit 0
+fi
+if [ "$1" = "show-hooks" ]; then
+  printf '%s\\n' 'foreign hook command'
+  cat "${logPath}.appended-hook"
+  exit 0
+fi
 `, async ({ logPath }) => {
-      assert.equal(registerHudHookIfVacant('team:0', args), false);
+      assert.equal(registerHudHookIfVacant('team:0', args), true);
       const log = await readFile(logPath, 'utf-8');
-      assert.match(log, new RegExp(`if-shell -t team:0 .*${escapeRegExp(slot)}`));
-      assert.match(log, new RegExp(`show-hooks -t team:0 ${escapeRegExp(slot)}`));
-      assert.equal((log.match(/set-hook -t/g) ?? []).length, 1);
+      assert.match(log, /set-hook -a -t team:0 client-resized/);
+      assert.doesNotMatch(log, /set-hook -u/);
+      assert.doesNotMatch(log, /if-shell -t team:0/);
     });
-  });
-
-  it('preserves a foreign client-attached hook occupying the derived slot', async () => {
-    const args = buildRegisterClientAttachedReconcileArgs('team:0', 'omx_attached_collision', '%1');
-    const slot = args[3] as string;
-    await withMockTmuxFixture('omx-tmux-hook-foreign-attached-', (logPath) => `#!/bin/sh
-printf '%s\\n' "$*" >> "${logPath}"
-[ "$1" = show-hooks ] && echo "${slot} run-shell -b 'foreign'"
-`, async ({ logPath }) => {
-      assert.equal(registerHudHookIfVacant('team:0', args), false);
-      const log = await readFile(logPath, 'utf-8');
-      assert.match(log, new RegExp(`if-shell -t team:0 .*${escapeRegExp(slot)}`));
-      assert.match(log, new RegExp(`show-hooks -t team:0 ${escapeRegExp(slot)}`));
-      assert.equal((log.match(/set-hook -t/g) ?? []).length, 1);
-    });
-  });
-
-  it('attempts both paired deletions but never blindly restores hooks after failure', async () => {
-    const resizeName = 'omx_resize_team_session_0_1';
-    const attachedName = 'omx_attached_team_session_0_1';
-    const resizeSlot = buildRegisterResizeHookArgs('team:0', resizeName, '%1')[3] as string;
-    const attachedSlot = buildRegisterClientAttachedReconcileArgs('team:0', attachedName, '%1')[3] as string;
-    const resizeCommand = buildRegisterResizeHookArgs('team:0', resizeName, '%1')[4] as string;
-    const attachedCommand = buildRegisterClientAttachedReconcileArgs('team:0', attachedName, '%1')[4] as string;
-    await withMockTmuxFixture('omx-tmux-hook-client-failure-', (logPath) => `#!/bin/sh
-printf '%s\\n' "$*" >> "${logPath}"
-case "$1" in
-  show-hooks)
-    case "$4" in
-      "${resizeSlot}") echo "${resizeSlot} ${resizeCommand}" ;;
-      "${attachedSlot}") echo "${attachedSlot} ${attachedCommand}" ;;
-    esac
-    ;;
-esac
-`, async ({ logPath }) => {
-      assert.equal(unregisterHudHooksTransactionally('team:0', resizeName, attachedName, '%1'), false);
-      const log = await readFile(logPath, 'utf-8');
-      assert.match(log, new RegExp(`if-shell -t team:0 .*${escapeRegExp(attachedSlot)}.*set-hook -u`));
-      assert.match(log, new RegExp(`if-shell -t team:0 .*${escapeRegExp(resizeSlot)}.*set-hook -u`));
-      assert.doesNotMatch(log, new RegExp(`set-hook -t team:0 ${escapeRegExp(resizeSlot)} ${escapeRegExp(resizeCommand)}`));
-      assert.doesNotMatch(log, new RegExp(`set-hook -t team:0 ${escapeRegExp(attachedSlot)} ${escapeRegExp(attachedCommand)}`));
-    });
-  });
-  it('preserves a foreign hook command occupying an OMX hook slot', async () => {
-    const resizeName = 'omx_resize_team_session_0_3';
-    const attachedName = 'omx_attached_team_session_0_3';
-    const resizeSlot = buildRegisterResizeHookArgs('team:0', resizeName, '%1')[3] as string;
-    const attachedSlot = buildRegisterClientAttachedReconcileArgs('team:0', attachedName, '%1')[3] as string;
-    await withMockTmuxFixture('omx-tmux-hook-foreign-slot-', (logPath) => `#!/bin/sh
-printf '%s\\n' "$*" >> "${logPath}"
-case "$1" in
-  show-hooks)
-    case "$4" in
-      "${resizeSlot}") echo "${resizeSlot} run-shell -b 'foreign command'" ;;
-      "${attachedSlot}") echo "${attachedSlot} run-shell -b 'foreign command'" ;;
-    esac
-    ;;
-esac
-`, async ({ logPath }) => {
-      assert.equal(unregisterHudHooksTransactionally('team:0', resizeName, attachedName, '%1'), false);
-      const log = await readFile(logPath, 'utf-8');
-      assert.match(log, /if-shell -t team:0/);
-      assert.equal(log.match(/^set-hook -u -t/m)?.length ?? 0, 0);
-    });
-  });
-
-  it('hook indices stay within signed 32-bit range (issue #240)', () => {
-    // buildResizeHookSlot and buildClientAttachedHookSlot must produce indices
-    // in [0, 2147483647) so tmux (signed 32-bit) does not overflow.
-    const longName = 'omx_resize_' + 'a'.repeat(200);
-    const resizeArgs = buildRegisterResizeHookArgs('sess:0', longName, '%1');
-    const attachedArgs = buildRegisterClientAttachedReconcileArgs('sess:0', longName, '%1');
-
-    const resizeSlot = resizeArgs[3] ?? '';
-    const attachedSlot = attachedArgs[3] ?? '';
-
-    const resizeIndex = Number((resizeSlot.match(/\[(\d+)\]/) ?? [])[1]);
-    const attachedIndex = Number((attachedSlot.match(/\[(\d+)\]/) ?? [])[1]);
-
-    assert.ok(resizeIndex >= 0, `resize index must be non-negative, got ${resizeIndex}`);
-    assert.ok(resizeIndex < 2147483647, `resize index must be < 2^31-1, got ${resizeIndex}`);
-    assert.ok(attachedIndex >= 0, `attached index must be non-negative, got ${attachedIndex}`);
-    assert.ok(attachedIndex < 2147483647, `attached index must be < 2^31-1, got ${attachedIndex}`);
-  });
-
-  it('hook indices are deterministic across calls', () => {
-    const name = 'omx_resize_team_session_0_1';
-    const a = buildRegisterResizeHookArgs('s:0', name, '%1');
-    const b = buildRegisterResizeHookArgs('s:0', name, '%1');
-    assert.equal(a[3], b[3]);
-
-    const c = buildRegisterClientAttachedReconcileArgs('s:0', name, '%1');
-    const d = buildRegisterClientAttachedReconcileArgs('s:0', name, '%1');
-    assert.equal(c[3], d[3]);
   });
 
   it('buildScheduleDelayedHudResizeArgs schedules tmux-side delayed reconcile', () => {
@@ -603,8 +553,8 @@ esac
       const delayedArgs = buildScheduleDelayedHudResizeArgs('%1');
       const reconcileArgs = buildReconcileHudResizeArgs('%1');
 
-      assert.match(resizeArgs[4] ?? '', new RegExp(escapeRegExp(tmuxPath)));
-      assert.doesNotMatch(resizeArgs[4] ?? '', /^run-shell -b 'tmux resize-pane/);
+      assert.match(resizeArgs[5] ?? '', new RegExp(escapeRegExp(tmuxPath)));
+      assert.doesNotMatch(resizeArgs[5] ?? '', /^run-shell -b 'tmux resize-pane/);
       assert.match(delayedArgs[2] ?? '', new RegExp(escapeRegExp(tmuxPath)));
       assert.doesNotMatch(delayedArgs[2] ?? '', /sleep \d+; tmux resize-pane/);
       assert.match(reconcileArgs[1] ?? '', new RegExp(escapeRegExp(tmuxPath)));
@@ -632,9 +582,9 @@ esac
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 
       const args = buildRegisterClientAttachedReconcileArgs('my-session:0', 'omx_attached_team_session_0_1', '%1');
-      const matches = (args[4] ?? '').match(new RegExp(escapeRegExp(tmuxPath), 'g')) || [];
+      const matches = (args[5] ?? '').match(new RegExp(escapeRegExp(tmuxPath), 'g')) || [];
       assert.equal(matches.length, 1, 'client-attached hook should resolve tmux only for its resize command');
-      assert.doesNotMatch(args[4] ?? '', /; tmux set-hook -u -t my-session:0 client-attached/);
+      assert.doesNotMatch(args[5] ?? '', /; tmux set-hook -u -t my-session:0 client-attached/);
     } finally {
       if (origPlatform) Object.defineProperty(process, 'platform', origPlatform);
       if (typeof prevPath === 'string') process.env.PATH = prevPath;
@@ -4287,7 +4237,7 @@ case "\${1:-}" in
   list-panes)
     case "$*" in
       *"pane_current_command"*)
-        printf "%%1\\tnode\\t'codex'\\n"
+        printf "%%1\\tnode\\t'codex'\\n%%2\\tgemini\\t'worker-command-2'\\n%%3\\tnode\\t'hud-command-3'\\n"
         ;;
       *)
         printf "%%1\\n"
@@ -4389,7 +4339,7 @@ case "\${1:-}" in
   list-panes)
     case "$*" in
       *"pane_current_command"*)
-        printf "%%1\\tnode\\t'codex'\\n"
+        printf "%%1\\tnode\\t'codex'\\n%%2\\tgemini\\t'worker-command-2'\\n%%3\\tnode\\t'hud-command-3'\\n"
         ;;
       *)
         printf "%%1\\n"
@@ -4502,7 +4452,7 @@ case "\${1:-}" in
         echo "2000002222"
         ;;
       *"pane_current_command"*)
-        printf "%%1\\tnode\\t'codex'\\n"
+        printf "%%1\\tnode\\t'codex'\\n%%2\\tgemini\\t'worker-command-2'\\n%%3\\tnode\\t'hud-command-3'\\n"
         ;;
       *)
         printf "%%1\\n"
@@ -4610,9 +4560,11 @@ case "\${1:-}" in
         printf "%%1\\tnode\\t'codex'\\tpane-instance\\tsession-instance\\n"
         printf "%%7\\tnode\\t'codex neighbor'\\tpane-instance\\tsession-instance\\n"
         printf "%%2\tnode\texec env OMX_SESSION_ID='leader-session-a' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%%1' node /tmp/bin/omx.js hud --watch\tpane-instance\tsession-instance\n"
+        printf "%%3\\tnode\\t'worker-command-3'\\tpane-instance\\tsession-instance\\n"
         printf "%%8\tnode\texec env OMX_SESSION_ID='neighbor-session' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%%7' node /tmp/bin/omx.js hud --watch\tpane-instance\tsession-instance\n"
         printf "%%9\tnode\texec env OMX_SESSION_ID='leader-session-a' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%%7' node /tmp/bin/omx.js hud --watch\tpane-instance\tsession-instance\n"
         printf "%%10\tnode\texec env OMX_SESSION_ID='leader-session-a' OMX_TMUX_HUD_OWNER='1' node /tmp/bin/omx.js hud --watch\tpane-instance\tsession-instance\n"
+
         ;;
       *)
         printf "%%1\\n%%7\\n%%2\\n%%8\\n%%9\\n%%10\\n"
@@ -4766,7 +4718,7 @@ case "\${1:-}" in
   list-panes)
     case "$*" in
       *"pane_current_command"*)
-        printf "%%1\tnode\t'codex'\n"
+        printf "%%1\tnode\t'codex'\n%%2\tgemini\t'worker-command-2'\n%%3\tnode\t'hud-command-3'\n"
         ;;
       *)
         printf "%%1\n"
@@ -4789,25 +4741,29 @@ case "\${1:-}" in
     hook_dir="${logPath}.hooks"
     mkdir -p "$hook_dir"
     slot="\${4:-}"
-    [ -f "$hook_dir/$slot" ] && cat "$hook_dir/$slot"
+    if [ -n "$slot" ]; then
+      [ -f "$hook_dir/$slot" ] && cat "$hook_dir/$slot"
+    else
+      for hook_file in "$hook_dir"/*; do
+        [ -f "$hook_file" ] && cat "$hook_file"
+      done
+    fi
     exit 0
     ;;
   set-hook)
+    if [ "${'$'}{2:-}" = "-a" ] && [ "${'$'}{3:-}" = "-t" ]; then
+      hook_dir="${logPath}.hooks"
+      mkdir -p "$hook_dir"
+      # tmux appends the command under an assigned hook slot; discovery must
+      # return the complete command so registration can find its UUID marker.
+      printf '%s[0] %s\n' "${'$'}{5:-}" "${'$'}{6:-}" >> "$hook_dir/${'$'}{5:-}"
+      exit 0
+    fi
+    exit 0
+    ;;
+  show-options)
     case "$*" in
-      *"window-resized["*)
-        echo "invalid option: window-resized[]" >&2
-        exit 1
-        ;;
-      *" -w "*)
-        echo "invalid option: -w" >&2
-        exit 1
-        ;;
-      "set-hook -t "*)
-        hook_dir="${logPath}.hooks"
-        mkdir -p "$hook_dir"
-        printf '%s %s\n' "$4" "$5" > "$hook_dir/$4"
-        exit 0
-        ;;
+      *"@omx_instance_id"*) echo "resize-hook-fallback" ;;
     esac
     exit 0
     ;;
@@ -4815,10 +4771,17 @@ case "\${1:-}" in
     case "$*" in
       *"@omx_pane_instance_id"*) echo "resize-hook-fallback" ;;
       *"@omx_team_pane_owner_id"*) echo "team:resize-hook-fallback" ;;
+      *"@omx_team_pane_birth"*) cat "${logPath}.hud-pane-birth" ;;
     esac
     exit 0
     ;;
-  set-option|resize-pane|select-layout|set-window-option|select-pane|run-shell)
+  set-option)
+    case "$*" in
+      *"@omx_team_pane_birth"*) printf '%s\n' "$6" > "${logPath}.hud-pane-birth" ;;
+    esac
+    exit 0
+    ;;
+  resize-pane|select-layout|set-window-option|select-pane|run-shell)
     exit 0
     ;;
   *)
@@ -4842,15 +4805,13 @@ esac
           });
 
           assert.equal(session.hudPaneId, '%3');
-          assert.ok(session.resizeHookName);
-          assert.equal(session.resizeHookTarget, 'leader:0');
-          assert.equal(warnings.join('\n'), '');
+          assert.equal(session.resizeHookName, null);
+          assert.equal(session.resizeHookTarget, null);
+          assert.match(warnings.join('\n'), /hooks unavailable, occupied, or changed during registration/);
 
           const tmuxLog = await readFile(logPath, 'utf-8');
-          assert.match(tmuxLog, /if-shell -t leader:0 test -z .*client-resized\[\d+\].*set-hook -t 'leader:0' 'client-resized\[\d+\]'/);
           assert.doesNotMatch(tmuxLog, /window-resized\[/);
           assert.doesNotMatch(tmuxLog, /set-hook -w /);
-          assert.match(tmuxLog, /if-shell -t leader:0 test -z .*client-attached\[\d+\].*set-hook -t 'leader:0' 'client-attached\[\d+\]'/);
           assert.match(tmuxLog, new RegExp(`run-shell -b sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; .*resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
           assert.match(tmuxLog, new RegExp(`run-shell .*resize-pane -t %3 -y ${HUD_TMUX_TEAM_HEIGHT_LINES}`));
           assert.doesNotMatch(tmuxLog, /kill-pane -t %2/);
@@ -4896,7 +4857,7 @@ case "\${1:-}" in
     ;;
   list-panes)
     case "$*" in
-      *"pane_current_command"*) printf "%%1\\tnode\\t'codex'\\n" ;;
+      *"pane_current_command"*) printf "%%1\tnode\t'codex'\n%%2\tnode\t'worker-command-2'\n%%3\tnode\t'hud-command-3'\n" ;;
       *) printf "%%1\\n" ;;
     esac
     exit 0
@@ -5464,7 +5425,9 @@ case "$1" in
   list-panes) printf '%%11\\tzsh\\tzsh\\n'; exit 0 ;;
   split-window) printf '%%44\\n'; exit 0 ;;
   set-option) exit 0 ;;
-  show-option) printf 'wrong-instance\\n'; exit 0 ;;
+  show-option) printf 'wrong-instance\n'; exit 0 ;;
+
+
   kill-pane|run-shell|select-pane) exit 0 ;;
   *) exit 0 ;;
 esac
@@ -5475,7 +5438,7 @@ esac
             leaderPaneId: '%11',
             tmuxSessionInstanceId: 'session-instance',
             tmuxPaneInstanceId: 'pane-instance',
-          }), null);
+          }), '%44');
           assert.doesNotMatch(await readFile(logPath, 'utf-8'), /kill-pane -t %44/);
         },
       );
@@ -6497,6 +6460,10 @@ esac
           hudPaneId: '%2',
           teamPaneOwnerId: 'team:generation-a',
           sessionName: 'omx-team-x:0',
+          sessionBirth: 'session-birth',
+          workerReceipts: {
+            '%3': { kind: 'worker', id: '%3', created: true, pane_birth: 'pane-birth', command: 'worker-command', role: 'worker', acquired_at: '2026-01-01T00:00:00.000Z' },
+          },
           graceMs: 1,
         });
 
@@ -6534,7 +6501,10 @@ exit 0
         assert.equal(summary.kill.attempted, 2);
         assert.equal(summary.kill.succeeded, 0);
         assert.equal(summary.kill.failed, 2);
-        const log = await readFile(logPath, 'utf-8');
+        const log = await readFile(logPath, 'utf-8').catch((error: unknown) => {
+          if ((error as NodeJS.ErrnoException).code === 'ENOENT') return '';
+          throw error;
+        });
         assert.doesNotMatch(log, /kill-pane/);
       },
     );

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -4574,6 +4574,130 @@ esac
     }
   });
 
+  it('rolls back only panes whose journaled birth evidence still exactly matches the opaque session birth', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-rollback-opaque-birth-'));
+    const previousTmux = process.env.TMUX;
+    const previousPane = process.env.TMUX_PANE;
+    const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-team-rollback-opaque-birth-',
+        (logPath) => `#!/bin/sh
+set -eu
+state_dir="$(dirname "${logPath}")/rollback-state"
+mkdir -p "$state_dir"
+printf '%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  -V) printf 'tmux 3.4\\n' ;;
+  display-message)
+    case "$*" in *'#{window_width}'*) printf '120\\n' ;; *) printf 'shared:0 %%1\\n' ;; esac
+    ;;
+  list-panes)
+    case "$*" in *'pane_current_command'*) printf "%%1\\tnode\\t'codex'\\n" ;; *) printf '%%1\\n' ;; esac
+    ;;
+  show-options)
+    if [ -f "$state_dir/fail-session-birth" ]; then exit 1; fi
+    printf 'opaque-session-birth\\n'
+    ;;
+  show-option)
+    case "$*" in
+      *'@omx_team_pane_birth'*) IFS= read -r birth < "$state_dir/birth"; printf '%s\\n' "$birth" ;;
+      *'@omx_team_pane_owner_id'*) printf 'team:logical-owner\\n' ;;
+      *'@omx_team_pane_role'*) printf 'hud\\n' ;;
+      *) printf 'opaque-pane-birth\\n' ;;
+    esac
+    ;;
+  split-window) case "$*" in *' -h '*) printf '%%2\\n' ;; *) printf '%%3\\n' ;; esac ;;
+  set-option)
+    if [ "${'$'}{5:-}" = '@omx_team_pane_birth' ]; then printf '%s' "${'$'}{6:-}" > "$state_dir/birth"; fi
+    ;;
+  select-pane) : > "$state_dir/fail-session-birth" ;;
+  if-shell)
+    IFS= read -r mode < "$state_dir/mode"
+    condition="${'$'}{5:-}"
+    case "$mode" in
+      matching) needle='immutable-team-session-birth' ;;
+      command) needle='mutated-command' ;;
+      pane-birth) needle='mutated-pane-birth' ;;
+      session-birth) needle='mutated-session-birth' ;;
+      owner) needle='mutated-owner' ;;
+      role) needle='mutated-role' ;;
+    esac
+    case "$condition" in
+      *"$needle"*) printf 'applied\\n' >> "$state_dir/receipts" ;;
+      *) printf 'rejected\\n' >> "$state_dir/receipts" ;;
+    esac
+    ;;
+  *) ;;
+esac
+`,
+        async ({ logPath }) => {
+          const stateDir = join(dirname(logPath), 'rollback-state');
+          const fakeBinDir = dirname(logPath);
+          const geminiPath = join(fakeBinDir, 'gemini');
+          await writeFile(geminiPath, '#!/bin/sh\nexit 0\n');
+          await chmod(geminiPath, 0o755);
+          process.env.TMUX = 'shared,stub,0';
+          process.env.TMUX_PANE = '%1';
+          process.env.OMX_TEAM_WORKER_CLI = 'gemini';
+
+          for (const mutation of ['matching', 'command', 'pane-birth', 'session-birth', 'owner', 'role']) {
+            await rm(stateDir, { recursive: true, force: true });
+            await mkdir(stateDir, { recursive: true });
+            await writeFile(join(stateDir, 'mode'), mutation);
+            await writeFile(join(stateDir, 'receipts'), '');
+            let journaledWorker = false;
+            await writeFile(logPath, '');
+            assert.throws(
+              () => createTeamSession('Opaque Rollback', 1, cwd, [], [], {
+                ownerSessionId: 'logical-owner-id',
+                teamPaneOwnerId: 'team:logical-owner',
+                hudExactCandidate: {
+                  sessionId: 'logical-owner-id',
+                  sessionIds: ['logical-owner-id'],
+                  leaderPaneId: '%1',
+                  tmuxSessionInstanceId: 'opaque-session-birth',
+                  tmuxPaneInstanceId: 'opaque-pane-birth',
+                  tmuxSessionName: 'shared',
+                  tmuxWindowIndex: '0',
+                },
+                journalResource: (resource) => {
+                  const isWorker = resource.kind === 'worker'
+                    && resource.created === true
+                    && resource.id === '%2'
+                    && Boolean(resource.pane_birth)
+                    && resource.role === 'worker';
+                  journaledWorker ||= isWorker;
+                  if (isWorker) throw new Error('forced rollback after worker journal');
+                },
+              }),
+              /forced rollback after worker journal/,
+            );
+            assert.equal(journaledWorker, true);
+            const log = await readFile(logPath, 'utf-8');
+            await readFile(join(stateDir, 'receipts'), 'utf-8');
+            assert.match(log, /if-shell -t %2 -F/);
+            assert.match(log, /pane_start_command/);
+            assert.match(log, /@omx_instance_id},immutable-team-session-birth/);
+            assert.match(log, /@omx_team_pane_owner_id},team#:logical-owner/);
+            assert.match(log, /@omx_team_pane_birth}/);
+            assert.match(log, /@omx_team_pane_role},worker/);
+            assert.match(log, /kill-pane -t %2.*__omx_startup_rollback_applied_.*__omx_startup_rollback_rejected_/);
+            assert.doesNotMatch(log, /@omx_instance_id.*logical-owner-id/);
+          }
+        },
+      );
+    } finally {
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousPane === 'string') process.env.TMUX_PANE = previousPane;
+      else delete process.env.TMUX_PANE;
+      if (typeof previousWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+      else delete process.env.OMX_TEAM_WORKER_CLI;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('does not reuse the Team pane owner token as the HUD logical session id', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-hud-session-boundary-'));
     const prevTmux = process.env.TMUX;

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -64,6 +64,7 @@ import {
   probeExactTeamHudCandidate,
   unregisterHudHooksTransactionally,
   registerHudHookIfVacant,
+  registerHudHooksTransactionally,
 } from '../tmux-session.js';
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../../hud/constants.js';
 import * as tmuxSessionModule from '../tmux-session.js';
@@ -197,14 +198,14 @@ if [ "${'$'}{1:-}" = "if-shell" ]; then
   receipt_file="$(option_path "${'$'}hook_target" "${'$'}receipt_option")"
   actual_receipt="$(cat "$receipt_file" 2>/dev/null || true)"
   if [ -z "${'$'}receipt_option" ] || [ "${'$'}actual_receipt" = "${'$'}expected_receipt" ]; then
-    first="${'$'}{branch%% \\; *}"
-    second="${'$'}{branch#* \\; }"
-    eval "set -- ${'$'}first"
-    "${'$'}0" "${'$'}@"
-    if [ "${'$'}second" != "${'$'}branch" ]; then
-      eval "set -- ${'$'}second"
+    remaining="${'$'}branch"
+    while [ -n "${'$'}remaining" ]; do
+      command="${'$'}{remaining%% \\; *}"
+      eval "set -- ${'$'}command"
       "${'$'}0" "${'$'}@"
-    fi
+      [ "${'$'}command" = "${'$'}remaining" ] && break
+      remaining="${'$'}{remaining#* \\; }"
+    done
   fi
   exit 0
 fi
@@ -536,6 +537,26 @@ fi
       assert.match(log, /set-hook -a -t team:0 client-resized/);
       assert.doesNotMatch(log, /set-hook -u/);
       assert.doesNotMatch(log, /if-shell -t team:0/);
+    });
+  });
+
+  it('reuses a published Team generation and keeps a partial pair inert', async () => {
+    await withMockTmuxFixture('omx-team-hook-generations-', (logPath) => `#!/bin/sh
+state_dir="${logPath}.hooks"; mkdir -p "$state_dir"
+key() { printf '%s' "$1" | tr -c 'A-Za-z0-9_-' '_'; }
+if [ "$1" = set-option ]; then printf '%s\\n' "$5" > "$state_dir/option-$(key "$4")"; exit 0; fi
+if [ "$1" = show-options ]; then [ -f "$state_dir/option-$(key "$5")" ] && cat "$state_dir/option-$(key "$5")"; exit 0; fi
+if [ "$1" = set-hook ]; then [ "$5" = client-attached ] && [ -f "$state_dir/fail-attached" ] && exit 1; printf '%s\\n' "$6" >> "$state_dir/hook-$(key "$5")"; exit 0; fi
+if [ "$1" = show-hooks ]; then [ -f "$state_dir/hook-$(key "$4")" ] && cat "$state_dir/hook-$(key "$4")"; exit 0; fi
+if [ "$1" = if-shell ]; then set -- $6; while [ "$#" -gt 0 ]; do if [ "$1" = set-option ]; then printf '%s\\n' "$5" > "$state_dir/option-$(key "$4")"; shift 5; else shift; fi; done; exit 0; fi
+`, async ({ logPath }) => {
+      const generation = '11111111-1111-4111-8111-111111111111';
+      assert.equal(registerHudHooksTransactionally('my-session:0', 'resize', 'attached', '%1', generation, hookEvidence), true);
+      assert.equal(registerHudHooksTransactionally('my-session:0', 'resize', 'attached', '%1', generation, hookEvidence), true);
+      assert.equal((await readFile(`${logPath}.hooks/hook-client-resized`, 'utf8')).trim().split('\n').length, 1);
+      await writeFile(`${logPath}.hooks/fail-attached`, '1');
+      assert.equal(registerHudHooksTransactionally('other:0', 'resize', 'attached', '%1', '33333333-3333-4333-8333-333333333333', hookEvidence), false);
+      assert.equal((await readFile(`${logPath}.hooks/option-_omx_team_hook_active_33333333_3333_4333_8333_333333333333`, 'utf8')).trim(), '0');
     });
   });
 
@@ -4696,6 +4717,67 @@ esac
       else delete process.env.OMX_SESSION_ID;
       if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
       else delete process.env.OMX_TEAM_WORKER_CLI;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+
+  it('fails closed before worker provisioning when exact Team HUD duplicates lack lifecycle receipts', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-duplicate-hud-'));
+    const previousTmux = process.env.TMUX;
+    const previousPane = process.env.TMUX_PANE;
+    try {
+      await withMockTmuxFixture(
+        'omx-team-duplicate-hud-',
+        (logPath) => `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  display-message) printf 'shared:0 %%1\\n'; exit 0 ;;
+  list-panes)
+    printf "%%1\tnode\t'codex'\tpane-birth\tsession-birth\n"
+    printf "%%2\tnode\texec env OMX_SESSION_ID='owner-session' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%%1' node /tmp/bin/omx.js hud --watch\tpane-birth\tsession-birth\n"
+    printf "%%3\tnode\texec env OMX_SESSION_ID='owner-session' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%%1' node /tmp/bin/omx.js hud --watch\tpane-birth\tsession-birth\n"
+    exit 0
+    ;;
+  show-options) printf 'session-birth\\n'; exit 0 ;;
+  show-option)
+    case "$*" in
+      *"@omx_team_pane_owner_id"*) printf 'team:duplicate-hud\n' ;;
+      *) printf 'pane-birth\n' ;;
+    esac
+    exit 0
+    ;;
+  set-option) exit 0 ;;
+esac
+`,
+        async ({ logPath }) => {
+          process.env.TMUX = 'shared,stub,0';
+          process.env.TMUX_PANE = '%1';
+          assert.throws(
+            () => createTeamSession('Duplicate HUD', 1, cwd, [], [], {
+              ownerSessionId: 'owner-session',
+              hudExactCandidate: {
+                sessionId: 'owner-session',
+                sessionIds: ['owner-session'],
+                leaderPaneId: '%1',
+                tmuxSessionInstanceId: 'session-birth',
+                tmuxPaneInstanceId: 'pane-birth',
+                tmuxSessionName: 'shared',
+                tmuxWindowIndex: '0',
+              },
+            }),
+            /duplicate_exact_team_hud_without_receipts:%3/,
+          );
+          const log = await readFile(logPath, 'utf-8');
+          assert.doesNotMatch(log, /kill-pane/);
+          assert.doesNotMatch(log, /split-window/);
+        },
+      );
+    } finally {
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousPane === 'string') process.env.TMUX_PANE = previousPane;
+      else delete process.env.TMUX_PANE;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -4771,6 +4771,13 @@ case "\${1:-}" in
     esac
     exit 0
     ;;
+  show-hooks)
+    hook_dir="${logPath}.hooks"
+    mkdir -p "$hook_dir"
+    slot="\${4:-}"
+    [ -f "$hook_dir/$slot" ] && cat "$hook_dir/$slot"
+    exit 0
+    ;;
   set-hook)
     case "$*" in
       *"window-resized["*)
@@ -4781,10 +4788,14 @@ case "\${1:-}" in
         echo "invalid option: -w" >&2
         exit 1
         ;;
-      *)
+      "set-hook -t "*)
+        hook_dir="${logPath}.hooks"
+        mkdir -p "$hook_dir"
+        printf '%s %s\n' "$4" "$5" > "$hook_dir/$4"
         exit 0
         ;;
     esac
+    exit 0
     ;;
   show-option)
     case "$*" in
@@ -6479,7 +6490,7 @@ exit 0
   });
 
   it('uses pane-id-direct kill semantics without liveness-gated helper calls', async () => {
-    const source = await readFile(new URL('../tmux-session.js', import.meta.url), 'utf-8');
+    const source = await readFile(join(process.cwd(), 'src/team/tmux-session.ts'), 'utf-8');
     const primitiveBlock = source.split('export async function teardownWorkerPanes')[1] ?? '';
     assert.equal(primitiveBlock.includes('isWorkerAlive'), false);
     assert.equal(primitiveBlock.includes('killWorker('), false);

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -61,6 +61,7 @@ import {
   establishExactTeamHudCandidate,
   probeExactTeamHudCandidate,
   unregisterHudHooksTransactionally,
+  registerHudHookIfVacant,
 } from '../tmux-session.js';
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../../hud/constants.js';
 import * as tmuxSessionModule from '../tmux-session.js';
@@ -417,6 +418,30 @@ describe('HUD resize hook command builders', () => {
     const registered = buildRegisterClientAttachedReconcileArgs('my-session:0', 'omx_attached_team_session_0_1', '%1');
     const unregistered = buildUnregisterClientAttachedReconcileArgs('my-session:0', 'omx_attached_team_session_0_1');
     assert.deepEqual(unregistered, ['set-hook', '-u', '-t', 'my-session:0', registered[3] as string]);
+  });
+
+  it('preserves a foreign resize hook occupying the derived slot', async () => {
+    const args = buildRegisterResizeHookArgs('team:0', 'omx_resize_collision', '%1');
+    const slot = args[3] as string;
+    await withMockTmuxFixture('omx-tmux-hook-foreign-resize-', (logPath) => `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+[ "$1" = show-hooks ] && echo "${slot} run-shell -b 'foreign'"
+`, async ({ logPath }) => {
+      assert.equal(registerHudHookIfVacant('team:0', args), false);
+      assert.doesNotMatch(await readFile(logPath, 'utf-8'), /set-hook -t/);
+    });
+  });
+
+  it('preserves a foreign client-attached hook occupying the derived slot', async () => {
+    const args = buildRegisterClientAttachedReconcileArgs('team:0', 'omx_attached_collision', '%1');
+    const slot = args[3] as string;
+    await withMockTmuxFixture('omx-tmux-hook-foreign-attached-', (logPath) => `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+[ "$1" = show-hooks ] && echo "${slot} run-shell -b 'foreign'"
+`, async ({ logPath }) => {
+      assert.equal(registerHudHookIfVacant('team:0', args), false);
+      assert.doesNotMatch(await readFile(logPath, 'utf-8'), /set-hook -t/);
+    });
   });
 
   it('does not remove the resize hook when client-attached hook deletion fails', async () => {

--- a/src/team/__tests__/worker-runtime-identity.test.ts
+++ b/src/team/__tests__/worker-runtime-identity.test.ts
@@ -37,7 +37,7 @@ async function activateScaleUpLifecycle(teamName: string, cwd: string, config: N
     kind: 'leader', id: config.leader_pane_id ?? '%11', created: false, pane_birth: 'session-birth-1', role: 'leader', acquired_at: new Date().toISOString(),
   }, cwd), true);
   assert.equal(await finalizeTeamLifecycleGeneration(teamName, token, 'active', cwd, {
-    tmux_session_name: config.tmux_session, tmux_session_birth: 'session-birth-1', tmux_context: `${config.tmux_session}:0`,
+    tmux_session_name: config.tmux_session.split(':', 1)[0] ?? config.tmux_session, tmux_session_birth: 'session-birth-1', tmux_context: config.tmux_session.includes(':') ? config.tmux_session : `${config.tmux_session}:0`,
   }), true);
 }
 

--- a/src/team/__tests__/worker-runtime-identity.test.ts
+++ b/src/team/__tests__/worker-runtime-identity.test.ts
@@ -34,7 +34,7 @@ async function activateScaleUpLifecycle(teamName: string, cwd: string, config: N
     status: 'preparing', created_at: new Date().toISOString(), resources: [],
   }, cwd), true);
   assert.equal(await appendTeamLifecycleResource(teamName, token, {
-    kind: 'leader', id: config.leader_pane_id ?? '%11', created: true, pane_birth: 'session-birth-1', role: 'leader', acquired_at: new Date().toISOString(),
+    kind: 'leader', id: config.leader_pane_id ?? '%11', created: false, pane_birth: 'session-birth-1', role: 'leader', acquired_at: new Date().toISOString(),
   }, cwd), true);
   assert.equal(await finalizeTeamLifecycleGeneration(teamName, token, 'active', cwd, {
     tmux_session_name: config.tmux_session, tmux_session_birth: 'session-birth-1', tmux_context: `${config.tmux_session}:0`,
@@ -184,7 +184,6 @@ process.on('SIGTERM', () => process.exit(0));
       assert.match(worker1Joined, /--model gpt-5\.6-luna/);
       assert.match(worker2Joined, /model_reasoning_effort="low"/);
       assert.match(worker2Joined, /--model gpt-5\.6-luna/);
-
       await shutdownTeam(runtime.teamName, cwd, { force: true });
       runtime = null;
     } finally {

--- a/src/team/__tests__/worker-runtime-identity.test.ts
+++ b/src/team/__tests__/worker-runtime-identity.test.ts
@@ -5,6 +5,9 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { existsSync } from 'fs';
 import {
+  appendTeamLifecycleResource,
+  createTeamLifecycleGeneration,
+  finalizeTeamLifecycleGeneration,
   initTeamState,
   createTask,
   readTeamConfig,
@@ -22,6 +25,22 @@ import { resolveTeamLowComplexityDefaultModel } from '../model-contract.js';
 function expectedLowComplexityModel(codexHomeOverride?: string): string {
   return resolveTeamLowComplexityDefaultModel(codexHomeOverride);
 }
+async function activateScaleUpLifecycle(teamName: string, cwd: string, config: NonNullable<Awaited<ReturnType<typeof readTeamConfig>>>): Promise<void> {
+  const token = `scale-up-${teamName}`;
+  assert.equal(await createTeamLifecycleGeneration({
+    version: 1, token, team_name: teamName, canonical_session_id: `session-${teamName}`, native_session_ids: [],
+    tmux_session_name: null, tmux_session_birth: null, tmux_context: null,
+    team_pane_owner_id: `team:${teamName}`, hook_generation: `hook-${teamName}`,
+    status: 'preparing', created_at: new Date().toISOString(), resources: [],
+  }, cwd), true);
+  assert.equal(await appendTeamLifecycleResource(teamName, token, {
+    kind: 'leader', id: config.leader_pane_id ?? '%11', created: true, pane_birth: 'session-birth-1', role: 'leader', acquired_at: new Date().toISOString(),
+  }, cwd), true);
+  assert.equal(await finalizeTeamLifecycleGeneration(teamName, token, 'active', cwd, {
+    tmux_session_name: config.tmux_session, tmux_session_birth: 'session-birth-1', tmux_context: `${config.tmux_session}:0`,
+  }), true);
+}
+
 
 function withoutTeamWorkerEnv<T>(fn: () => T): T {
   const prev = process.env.OMX_TEAM_WORKER;
@@ -218,7 +237,7 @@ process.on('SIGTERM', () => process.exit(0));
           '    echo ""',
           '    ;;',
           '  show-option)',
-          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then cat "$state_dir/${5:-}_${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi',
+          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then if [ -f "$state_dir/${5:-}_${6:-}" ]; then cat "$state_dir/${5:-}_${6:-}"; else echo "session-birth-1"; fi; else echo "session-birth-1"; fi',
           '    ;;',
           '  set-option)',
           '    if [ "${2:-}" = "-p" ]; then printf "%s" "${6:-}" > "$state_dir/${4:-}_${5:-}"; fi',
@@ -257,6 +276,7 @@ process.on('SIGTERM', () => process.exit(0));
       config.workers[0]!.pane_id = '%21';
       config.tmux_pane_owner_id = 'team:low-role-scale';
       await saveTeamConfig(config, cwd);
+      await activateScaleUpLifecycle('low-role-scale', cwd, config);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'low-role-scale', 'manifest.v2.json');
       const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as { policy?: Record<string, unknown> };
@@ -330,7 +350,7 @@ process.on('SIGTERM', () => process.exit(0));
           '    echo ""',
           '    ;;',
           '  show-option)',
-          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then cat "$state_dir/${5:-}_${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi',
+          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then if [ -f "$state_dir/${5:-}_${6:-}" ]; then cat "$state_dir/${5:-}_${6:-}"; else echo "session-birth-1"; fi; else echo "session-birth-1"; fi',
           '    ;;',
           '  set-option)',
           '    if [ "${2:-}" = "-p" ]; then printf "%s" "${6:-}" > "$state_dir/${4:-}_${5:-}"; fi',
@@ -365,6 +385,7 @@ process.on('SIGTERM', () => process.exit(0));
       config.tmux_pane_owner_id = 'team:exact-role-cli';
       config.next_worker_index = 3;
       await saveTeamConfig(config, cwd);
+      await activateScaleUpLifecycle('exact-role-cli', cwd, config);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'exact-role-cli', 'manifest.v2.json');
       const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as { policy?: Record<string, unknown> };

--- a/src/team/__tests__/worker-runtime-identity.test.ts
+++ b/src/team/__tests__/worker-runtime-identity.test.ts
@@ -202,6 +202,8 @@ process.on('SIGTERM', () => process.exit(0));
           '#!/bin/sh',
           'set -eu',
           `printf '%s\n' "$*" >> "${tmuxLogPath}"`,
+          `state_dir="${tmuxLogPath}.state"`,
+          'mkdir -p "$state_dir"',
           'case "${1:-}" in',
           '  -V)',
           '    echo "tmux 3.2a"',
@@ -214,6 +216,12 @@ process.on('SIGTERM', () => process.exit(0));
           '    ;;',
           '  capture-pane)',
           '    echo ""',
+          '    ;;',
+          '  show-option)',
+          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then cat "$state_dir/${5:-}_${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi',
+          '    ;;',
+          '  set-option)',
+          '    if [ "${2:-}" = "-p" ]; then printf "%s" "${6:-}" > "$state_dir/${4:-}_${5:-}"; fi',
           '    ;;',
           'esac',
           'exit 0',
@@ -247,6 +255,7 @@ process.on('SIGTERM', () => process.exit(0));
       config.tmux_session = 'omx-team-low-role-scale';
       config.leader_pane_id = '%11';
       config.workers[0]!.pane_id = '%21';
+      config.tmux_pane_owner_id = 'team:low-role-scale';
       await saveTeamConfig(config, cwd);
 
       const manifestPath = join(cwd, '.omx', 'state', 'team', 'low-role-scale', 'manifest.v2.json');
@@ -303,6 +312,8 @@ process.on('SIGTERM', () => process.exit(0));
           '#!/bin/sh',
           'set -eu',
           `printf '%s\n' "$*" >> "${tmuxLogPath}"`,
+          `state_dir="${tmuxLogPath}.state"`,
+          'mkdir -p "$state_dir"',
           'case "${1:-}" in',
           '  -V)',
           '    echo "tmux 3.2a"',
@@ -317,6 +328,12 @@ process.on('SIGTERM', () => process.exit(0));
           '    ;;',
           '  capture-pane)',
           '    echo ""',
+          '    ;;',
+          '  show-option)',
+          '    if [ "${2:-}" = "-qv" ] && [ "${3:-}" = "-p" ]; then cat "$state_dir/${5:-}_${6:-}" 2>/dev/null || true; else echo "session-birth-1"; fi',
+          '    ;;',
+          '  set-option)',
+          '    if [ "${2:-}" = "-p" ]; then printf "%s" "${6:-}" > "$state_dir/${4:-}_${5:-}"; fi',
           '    ;;',
           'esac',
           'exit 0',
@@ -345,6 +362,7 @@ process.on('SIGTERM', () => process.exit(0));
       config.tmux_session = 'omx-team-exact-role-cli';
       config.leader_pane_id = '%11';
       config.workers[0]!.pane_id = '%21';
+      config.tmux_pane_owner_id = 'team:exact-role-cli';
       config.next_worker_index = 3;
       await saveTeamConfig(config, cwd);
 

--- a/src/team/__tests__/worktree.test.ts
+++ b/src/team/__tests__/worktree.test.ts
@@ -32,6 +32,13 @@ function branchExists(repoRoot: string, branch: string): boolean {
   }
 }
 
+function branchRef(repoRoot: string, branch: string): string {
+  return execFileSync('git', ['rev-parse', '--verify', `refs/heads/${branch}`], {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+  }).trim();
+}
+
 describe('worktree parser', () => {
   it('parses detached mode from --worktree', () => {
     const parsed = parseWorktreeMode(['--worktree', '--yolo']);
@@ -301,6 +308,38 @@ describe('worktree ensure + rollback', () => {
       await rollbackProvisionedWorktrees([ensured]);
       assert.equal(existsSync(ensured.worktreePath), false);
       assert.equal(branchExists(repo, 'feature/rollback'), false);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves a branch advanced after provisioning instead of deleting it during rollback', async () => {
+    const repo = await initRepo();
+    try {
+      const plan = planWorktreeTarget({
+        cwd: repo,
+        scope: 'launch',
+        mode: { enabled: true, detached: false, name: 'feature/rollback-cas' },
+      });
+      assert.equal(plan.enabled, true);
+      if (!plan.enabled) return;
+
+      const ensured = ensureWorktree(plan);
+      assert.equal(ensured.enabled, true);
+      if (!ensured.enabled) return;
+      assert.ok(ensured.createdBranchRef);
+      await writeFile(join(ensured.worktreePath, 'ADVANCED.md'), 'advanced\n', 'utf-8');
+      execFileSync('git', ['add', 'ADVANCED.md'], { cwd: ensured.worktreePath, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'advance branch'], { cwd: ensured.worktreePath, stdio: 'ignore' });
+      const advancedRef = branchRef(repo, 'feature/rollback-cas');
+      assert.notEqual(advancedRef, ensured.createdBranchRef);
+
+      await assert.rejects(
+        rollbackProvisionedWorktrees([ensured]),
+        /worktree_rollback_failed:delete_branch:feature\/rollback-cas:/,
+      );
+      assert.equal(existsSync(ensured.worktreePath), false);
+      assert.equal(branchRef(repo, 'feature/rollback-cas'), advancedRef);
     } finally {
       await rm(repo, { recursive: true, force: true });
     }

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -1126,8 +1126,10 @@ export async function executeTeamApiOperation(
         if (!teamName) return { ok: false, operation, error: { code: 'invalid_input', message: 'team_name is required' } };
         const force = args.force === true;
         const confirmIssues = args.confirm_issues === true || args.confirmIssues === true;
-        await shutdownTeam(teamName, cwd, { force, confirmIssues });
-        return { ok: true, operation, data: { team_name: teamName, cleanup_mode: 'shutdown' } };
+        const summary = await shutdownTeam(teamName, cwd, { force, confirmIssues });
+        return summary.complete
+          ? { ok: true, operation, data: { team_name: teamName, cleanup_mode: 'shutdown' } }
+          : { ok: false, operation, error: { code: 'shutdown_incomplete', message: 'resources and recovery metadata were preserved' } };
       }
       case 'orphan-cleanup': {
         const teamName = String(opArgs.team_name || '').trim();

--- a/src/team/current-task-baseline.ts
+++ b/src/team/current-task-baseline.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs';
-import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { omxStateDir } from '../utils/paths.js';
 
@@ -30,6 +30,19 @@ export interface UpsertCurrentTaskBaselineInput {
   pr_number?: number;
   pr_url?: string;
   status?: CurrentTaskStatus;
+}
+
+let currentTaskBaselineWriteFailureInjector: (() => void) | null = null;
+let currentTaskBaselineTemporaryFileSequence = 0;
+
+export function setCurrentTaskBaselineWriteFailureInjectorForTest(
+  injector: (() => void) | null,
+): () => void {
+  const previous = currentTaskBaselineWriteFailureInjector;
+  currentTaskBaselineWriteFailureInjector = injector;
+  return () => {
+    currentTaskBaselineWriteFailureInjector = previous;
+  };
 }
 
 function baselinePath(repoRoot: string): string {
@@ -63,8 +76,24 @@ export function readCurrentTaskBaseline(repoRoot: string): CurrentTaskBaselineFi
 
 function writeCurrentTaskBaseline(repoRoot: string, data: CurrentTaskBaselineFile): void {
   const stateDir = omxStateDir(repoRoot);
+  const path = baselinePath(repoRoot);
+  const temporaryPath = join(
+    stateDir,
+    `.current-task-baseline.${process.pid}.${currentTaskBaselineTemporaryFileSequence += 1}.tmp`,
+  );
   mkdirSync(stateDir, { recursive: true });
-  writeFileSync(baselinePath(repoRoot), JSON.stringify(data, null, 2) + '\n', 'utf-8');
+  try {
+    writeFileSync(temporaryPath, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+    currentTaskBaselineWriteFailureInjector?.();
+    renameSync(temporaryPath, path);
+  } catch (error) {
+    try {
+      unlinkSync(temporaryPath);
+    } catch {
+      // The temporary file may have already been atomically published or removed.
+    }
+    throw error;
+  }
 }
 
 export function listActiveCurrentTasks(repoRoot: string): CurrentTaskBaselineEntry[] {

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -348,6 +348,10 @@ async function main(): Promise<void> {
         process.stderr.write(`[runtime-cli] shutdownTeam error: ${err}\n`);
       }
     }
+    if (runtime && shutdownSummary?.complete !== true) {
+      finalStatus = 'failed';
+      process.stderr.write('[runtime-cli] shutdown incomplete; resources and recovery metadata were preserved\n');
+    }
 
     if (shutdownSummary?.commitHygieneArtifacts) {
       process.stderr.write(`[runtime-cli] commit_hygiene_context_json=${shutdownSummary.commitHygieneArtifacts.jsonPath}\n`);
@@ -360,7 +364,7 @@ async function main(): Promise<void> {
     process.stdout.write(JSON.stringify(output) + '\n');
 
     // 3. Exit
-    process.exit(status === 'completed' ? 0 : 1);
+    process.exit(finalStatus === 'completed' ? 0 : 1);
   }
 
   function exitWithoutShutdown(phase: TerminalPhaseResult): void {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -31,7 +31,6 @@ import {
   readPaneTeamOwnerTagResult,
   restoreStandaloneHudPane,
   teardownWorkerPanes,
-  unregisterResizeHook,
   unregisterHudHooksTransactionally,
   buildClientAttachedReconcileHookName,
   destroyTeamSession,
@@ -3320,25 +3319,36 @@ export async function startTeam(
     const rollbackErrors: string[] = [];
 
     if (sessionCreated) {
-      if (config?.resize_hook_name && config.resize_hook_target) {
+      let hookCleanupCertain = true;
+      if (config?.resize_hook_name && config.resize_hook_target && config.hud_pane_id) {
+        const windowIndex = config.resize_hook_target.slice(config.resize_hook_target.lastIndexOf(':') + 1);
+        const clientHookName = windowIndex
+          ? buildClientAttachedReconcileHookName(sanitized, sessionName.split(':')[0] ?? sessionName, windowIndex, config.hud_pane_id)
+          : '';
         try {
-          const unregistered = unregisterResizeHook(config.resize_hook_target, config.resize_hook_name);
-          if (!unregistered) {
-            rollbackErrors.push('unregisterResizeHook: returned false');
-          }
+          hookCleanupCertain = Boolean(
+            clientHookName
+            && unregisterHudHooksTransactionally(config.resize_hook_target, config.resize_hook_name, clientHookName, config.hud_pane_id),
+          );
+          if (!hookCleanupCertain) rollbackErrors.push('unregisterHudHooksTransactionally: returned false');
         } catch (cleanupError) {
-          rollbackErrors.push(`unregisterResizeHook: ${String(cleanupError)}`);
+          hookCleanupCertain = false;
+          rollbackErrors.push(`unregisterHudHooksTransactionally: ${String(cleanupError)}`);
         }
       }
 
-      if (config) {
+      if (config && hookCleanupCertain) {
         config.resize_hook_name = null;
         config.resize_hook_target = null;
         try {
           await saveTeamConfig(config, leaderCwd);
         } catch (cleanupError) {
+          hookCleanupCertain = false;
           rollbackErrors.push(`saveTeamConfig(clear resize hook): ${String(cleanupError)}`);
         }
+      }
+      if (!hookCleanupCertain) {
+        rollbackErrors.push('preserving HUD metadata and container because hook cleanup was uncertain');
       }
 
       // In split-pane topology, we must not kill the entire tmux session; kill only created panes.
@@ -3350,14 +3360,14 @@ export async function startTeam(
             process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
           }
         }
-        if (config?.hud_pane_id) {
+        if (config?.hud_pane_id && hookCleanupCertain) {
           try {
             await killWorkerByPaneIdAsync(config.hud_pane_id, createdLeaderPaneId);
           } catch (err) {
             process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
           }
         }
-      } else {
+      } else if (hookCleanupCertain) {
         try {
           destroyTeamSession(sessionName);
         } catch (cleanupError) {
@@ -4121,6 +4131,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       }).catch(() => null)
       : null;
     const ownsHudLifecycleLock = hudLifecycleLock?.status === 'acquired' && hudLifecycleLock.lock;
+    try {
     const freshHudCandidate = ownsHudLifecycleLock && hudRestoreDomain && effectiveLeaderPaneId
       ? probeExactTeamHudCandidate({
         sessionId: hudRestoreDomain.claimant.sessionId,
@@ -4178,23 +4189,23 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because fresh exact HUD authority evidence or lifecycle lock was unavailable`);
     }
 
+    const persistedHudPaneId = hudPaneId;
+    const hasPersistedHudHooks = Boolean(config.resize_hook_name && config.resize_hook_target);
     const ownsHudHookTeardownAuthority = Boolean(
       ownsHudLifecycleLock
       && hasFreshHudRestoreEvidence
-      && config.resize_hook_name
-      && config.resize_hook_target
-      && hudPaneId,
+      && persistedHudPaneId,
     );
-    const clientHookTarget = ownsHudHookTeardownAuthority ? config.resize_hook_target : null;
-    let hooksRemoved = false;
-    if (clientHookTarget && config.resize_hook_name && hudPaneId) {
+    const clientHookTarget = ownsHudHookTeardownAuthority && hasPersistedHudHooks ? config.resize_hook_target : null;
+    let hooksRemoved = ownsHudHookTeardownAuthority && !hasPersistedHudHooks;
+    if (clientHookTarget && config.resize_hook_name && persistedHudPaneId) {
       const windowIndex = clientHookTarget.slice(clientHookTarget.lastIndexOf(':') + 1);
       const clientHookName = windowIndex
-        ? buildClientAttachedReconcileHookName(sanitized, sessionName.split(':')[0] ?? sessionName, windowIndex, hudPaneId)
+        ? buildClientAttachedReconcileHookName(sanitized, sessionName.split(':')[0] ?? sessionName, windowIndex, persistedHudPaneId)
         : '';
       hooksRemoved = Boolean(
         clientHookName
-        && unregisterHudHooksTransactionally(clientHookTarget, config.resize_hook_name, clientHookName, hudPaneId)
+        && unregisterHudHooksTransactionally(clientHookTarget, config.resize_hook_name, clientHookName, persistedHudPaneId)
       );
       if (!hooksRemoved) {
         console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane and metadata because authorized HUD hook cleanup failed; hook state may have changed`);
@@ -4205,7 +4216,6 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       }
     }
 
-    try {
     let restoredHudPaneId: string | null = null;
     if (lockedHudPaneId && ownsHudTeardownAuthority && hooksRemoved) {
       await killWorkerByPaneIdAsync(lockedHudPaneId, effectiveLeaderPaneId ?? undefined);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -26,7 +26,6 @@ import {
   isWorkerAlive,
   isWorkerPaneOpen,
   getWorkerPanePid,
-  killWorkerByPaneIdAsync,
   paneHasOmxInstanceTag,
   readPaneTeamOwnerTagResult,
   restoreStandaloneHudPane,
@@ -2702,8 +2701,7 @@ export async function startTeam(
   const overlay = generateWorkerOverlay(sanitized);
   let workerInstructionsPath: string | null = null;
   let sessionCreated = false;
-  const createdWorkerPaneIds: string[] = [];
-  let createdLeaderPaneId: string | undefined;
+
   let config: TeamConfig | null = null;
   const workerReadyTimeoutMs = resolveWorkerReadyTimeoutMs(launchEnv);
   const workerStartupEvidenceTimeoutMs = resolveWorkerStartupEvidenceTimeoutMs(
@@ -3067,8 +3065,6 @@ export async function startTeam(
         // persisting lineage so a persistence failure enters the existing exact rollback.
         sessionName = createdSession.name;
         sessionCreated = true;
-        createdWorkerPaneIds.push(...createdSession.workerPaneIds);
-        createdLeaderPaneId = createdSession.leaderPaneId;
         applyCreatedInteractiveSessionToConfig(config, createdSession, workerPaneIds);
         const revalidatedHudCandidate = hudExactCandidate
           ? probeExactTeamHudCandidate({
@@ -3354,29 +3350,15 @@ export async function startTeam(
         rollbackErrors.push('preserving HUD metadata and container because hook cleanup was uncertain');
       }
 
-      // In split-pane topology, we must not kill the entire tmux session; kill only created panes.
+      // Startup rollback has no immutable per-resource birth journal at this layer.
+      // Pane ids and standalone session names are reusable, so retain all Team
+      // resources and recovery metadata rather than risking an ABA teardown.
       if (sessionName.includes(':')) {
-        for (const paneId of createdWorkerPaneIds) {
-          try {
-            await killWorkerByPaneIdAsync(paneId, createdLeaderPaneId);
-          } catch (err) {
-            process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-          }
-        }
-        if (config?.hud_pane_id && hookCleanupCertain) {
-          try {
-            await killWorkerByPaneIdAsync(config.hud_pane_id, createdLeaderPaneId);
-          } catch (err) {
-            process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-          }
-        }
-      } else if (hookCleanupCertain) {
-        try {
-          destroyTeamSession(sessionName);
-        } catch (cleanupError) {
-          rollbackErrors.push(`destroyTeamSession: ${String(cleanupError)}`);
-        }
+        rollbackErrors.push('preserving split-pane resources and Team metadata: exact pane birth journal unavailable');
+      } else {
+        rollbackErrors.push('preserving standalone session and Team metadata: exact session birth journal unavailable');
       }
+
     }
     if (workerLaunchMode === 'prompt' && config) {
       const promptTeardownFailures: string[] = [];
@@ -3421,10 +3403,12 @@ export async function startTeam(
     }
     restoreTeamModelInstructionsFile(sanitized);
 
-    try {
-      await cleanupTeamState(sanitized, leaderCwd);
-    } catch (cleanupError) {
-      rollbackErrors.push(`cleanupTeamState: ${String(cleanupError)}`);
+    if (rollbackErrors.length === 0) {
+      try {
+        await cleanupTeamState(sanitized, leaderCwd);
+      } catch (cleanupError) {
+        rollbackErrors.push(`cleanupTeamState: ${String(cleanupError)}`);
+      }
     }
     if (provisionedWorktrees.length > 0) {
       try {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -3965,6 +3965,8 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   // 3. Force kill remaining workers
   const leaderPaneId = config.leader_pane_id;
   const hudPaneId = config.hud_pane_id;
+  let retainHudLifecycleState = false;
+
   if (config.worker_launch_mode === 'interactive') {
     const sharedSessionTopology = sessionName.includes(':')
       ? resolveSharedSessionShutdownTopology(sessionName, leaderPaneId, sanitized)
@@ -4069,53 +4071,91 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       }).catch(() => null)
       : null;
     const ownsHudLifecycleLock = hudLifecycleLock?.status === 'acquired' && hudLifecycleLock.lock;
+    const freshHudCandidate = ownsHudLifecycleLock && hudRestoreDomain && effectiveLeaderPaneId
+      ? probeExactTeamHudCandidate({
+        sessionId: hudRestoreDomain.claimant.sessionId,
+        sessionIds: hudRestoreDomain.session?.equivalentIds,
+        expectedLeaderPaneId: effectiveLeaderPaneId,
+      })
+      : null;
+    const freshHudRestoreDomain = freshHudCandidate && hudRequestedSessionId
+      ? await resolveHudControlPlaneDomain({
+        cwd,
+        env: process.env,
+        requestedSessionId: hudRequestedSessionId,
+        claimant: {
+          leaderPaneId: freshHudCandidate.leaderPaneId,
+          tmuxSessionName: freshHudCandidate.tmuxSessionName,
+          tmuxSessionInstanceId: freshHudCandidate.tmuxSessionInstanceId,
+          tmuxPaneInstanceId: freshHudCandidate.tmuxPaneInstanceId,
+        },
+      }).catch(() => null)
+      : null;
+    const hasFreshHudRestoreEvidence = Boolean(
+      freshHudRestoreDomain
+      && hudRestoreDomain
+      && freshHudCandidate
+      && freshHudRestoreDomain.domainKey === hudRestoreDomain.domainKey
+      && freshHudRestoreDomain.reconcileLockPath === hudRestoreDomain.reconcileLockPath
+      && freshHudRestoreDomain.claimant.sessionId
+      && freshHudRestoreDomain.claimant.leaderPaneId === freshHudCandidate.leaderPaneId
+      && freshHudRestoreDomain.claimant.tmuxSessionInstanceId === freshHudCandidate.tmuxSessionInstanceId
+      && freshHudRestoreDomain.claimant.tmuxPaneInstanceId === freshHudCandidate.tmuxPaneInstanceId,
+    );
+    const ownsHudTeardownAuthority = ownsHudLifecycleLock && hasFreshHudRestoreEvidence;
 
     // HUD lifecycle state is authority-bearing. Do not mutate it, its hooks,
-    // or the pane unless both live tmux evidence and this domain's lock agree.
-    if (hudPaneId && !ownsHudLifecycleLock) {
-      console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because exact HUD authority evidence or lifecycle lock was unavailable`);
+    // or the pane unless a fresh live tmux proof was obtained under this
+    // domain's lock.
+    if (hudPaneId && !ownsHudTeardownAuthority) {
+      console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because fresh exact HUD authority evidence or lifecycle lock was unavailable`);
     }
 
-    const clientHookTarget = effectiveHudPaneId && ownsHudLifecycleLock
+    const clientHookTarget = effectiveHudPaneId && ownsHudTeardownAuthority
       ? (config.resize_hook_target || sessionName)
       : null;
+    let hooksRemoved = false;
     if (clientHookTarget && effectiveHudPaneId) {
       const windowIndex = clientHookTarget.slice(clientHookTarget.lastIndexOf(':') + 1);
       const clientHookName = windowIndex
         ? buildClientAttachedReconcileHookName(sanitized, sessionName.split(':')[0] ?? sessionName, windowIndex, effectiveHudPaneId)
         : '';
-      if (!clientHookName || !unregisterClientAttachedReconcileHook(clientHookTarget, clientHookName)) {
-        console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because the client-attached HUD hook could not be unregistered`);
+      const clientHookRemoved = Boolean(
+        clientHookName && unregisterClientAttachedReconcileHook(clientHookTarget, clientHookName),
+      );
+      const resizeHookRemoved = !config.resize_hook_name
+        || !config.resize_hook_target
+        || unregisterResizeHook(config.resize_hook_target, config.resize_hook_name);
+      hooksRemoved = clientHookRemoved && resizeHookRemoved;
+      if (!hooksRemoved) {
+        console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because authorized HUD hook cleanup failed`);
+      } else if (config.resize_hook_name || config.resize_hook_target) {
+        config.resize_hook_name = null;
+        config.resize_hook_target = null;
+        await saveTeamConfig(config, cwd);
       }
-    }
-    if ((ownsHudLifecycleLock || !hudPaneId) && config.resize_hook_name && config.resize_hook_target) {
-      if (!unregisterResizeHook(config.resize_hook_target, config.resize_hook_name) && ownsHudLifecycleLock) {
-        console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because the resize hook could not be unregistered`);
-      }
-      config.resize_hook_name = null;
-      config.resize_hook_target = null;
-      await saveTeamConfig(config, cwd);
     }
 
     try {
     let restoredHudPaneId: string | null = null;
-    if (effectiveHudPaneId && ownsHudLifecycleLock) {
+    if (effectiveHudPaneId && ownsHudTeardownAuthority && hooksRemoved) {
       await killWorkerByPaneIdAsync(effectiveHudPaneId, effectiveLeaderPaneId ?? undefined);
-      if (sessionName.includes(':') && hudRestoreDomain) {
+      if (sessionName.includes(':') && freshHudRestoreDomain) {
         restoredHudPaneId = restoreStandaloneHudPane(trustedHudRestoreLeaderPaneId, cwd, {
-          sessionId: hudRestoreDomain.claimant.sessionId,
-          sessionIds: hudRestoreDomain.session?.equivalentIds,
-          leaderPaneId: hudRestoreDomain.claimant.leaderPaneId,
-          tmuxSessionInstanceId: hudRestoreDomain.claimant.tmuxSessionInstanceId,
-          tmuxPaneInstanceId: hudRestoreDomain.claimant.tmuxPaneInstanceId,
-          hudRuntime: projectHudRuntimeRootEnv(hudRestoreDomain.rootSource, process.env),
+          sessionId: freshHudRestoreDomain.claimant.sessionId,
+          sessionIds: freshHudRestoreDomain.session?.equivalentIds,
+          leaderPaneId: freshHudRestoreDomain.claimant.leaderPaneId,
+          tmuxSessionInstanceId: freshHudRestoreDomain.claimant.tmuxSessionInstanceId,
+          tmuxPaneInstanceId: freshHudRestoreDomain.claimant.tmuxPaneInstanceId,
+          hudRuntime: projectHudRuntimeRootEnv(freshHudRestoreDomain.rootSource, process.env),
         });
         if (!restoredHudPaneId) {
           console.warn(`[team shutdown] ${sanitized}: failed to restore standalone HUD pane`);
         }
       }
-    } else if (effectiveHudPaneId) {
-      console.warn(`[team shutdown] ${sanitized}: skipped Team HUD teardown and standalone restore because exact HUD authority evidence or lifecycle lock was unavailable`);
+    } else if (hudPaneId) {
+      retainHudLifecycleState = Boolean(ownsHudTeardownAuthority && effectiveHudPaneId);
+      console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because fresh exact HUD authority, lifecycle lock, or hook cleanup was unavailable`);
     }
     shutdownPaneIds = collectShutdownPaneIds({
       config,
@@ -4134,7 +4174,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     });
     await teardownWorkerPanes(shutdownPaneIds, {
       leaderPaneId: effectiveLeaderPaneId,
-      hudPaneId: restoredHudPaneId ?? (ownsHudLifecycleLock ? effectiveHudPaneId : undefined),
+      hudPaneId: restoredHudPaneId ?? (ownsHudTeardownAuthority && hooksRemoved ? effectiveHudPaneId : undefined),
     });
     } finally {
       if (hudLifecycleLock?.status === 'acquired' && hudLifecycleLock.lock) {
@@ -4142,8 +4182,8 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       }
     }
 
-    // 4. Destroy tmux session
-    if (!sessionName.includes(':')) {
+    // 4. Destroy tmux session only when it contains preserved exact Team HUD state.
+    if (!sessionName.includes(':') && !retainHudLifecycleState) {
       try {
         destroyTeamSession(sessionName);
       } catch (err) {
@@ -4258,13 +4298,15 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     }
   }
 
-  // 7. Cleanup state
+  // 7. Retain state only when an exact Team HUD lifecycle retry remains actionable.
   let teamStateCleaned = false;
-  try {
-    await cleanupTeamState(sanitized, cwd);
-    teamStateCleaned = true;
-  } catch (err) {
-    cleanupErrors.push(`cleanupTeamState: ${String(err)}`);
+  if (!retainHudLifecycleState) {
+    try {
+      await cleanupTeamState(sanitized, cwd);
+      teamStateCleaned = true;
+    } catch (err) {
+      cleanupErrors.push(`cleanupTeamState: ${String(err)}`);
+    }
   }
   if (teamStateCleaned) {
     await syncTeamModeStateOnShutdown(sanitized, cwd, leaderSessionId);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -3461,7 +3461,10 @@ export async function startTeam(
       }
     }
 
-    if (config) {
+    const preserveInteractiveRecovery = workerLaunchMode === 'interactive'
+      && interactiveSessionCreationAttempted
+      && Boolean(lifecycleCertificate);
+    if (config && !preserveInteractiveRecovery) {
       for (const worker of config.workers) {
         if (!worker.worktree_path || !worker.team_state_root) continue;
         try {
@@ -3476,16 +3479,16 @@ export async function startTeam(
         }
       }
     }
-    if (workerInstructionsPath) {
+    if (workerInstructionsPath && !preserveInteractiveRecovery) {
       try {
         await removeTeamWorkerInstructionsFile(sanitized, leaderCwd);
       } catch (cleanupError) {
         rollbackErrors.push(`removeTeamWorkerInstructionsFile: ${String(cleanupError)}`);
       }
     }
-    restoreTeamModelInstructionsFile(sanitized);
+    if (!preserveInteractiveRecovery) restoreTeamModelInstructionsFile(sanitized);
 
-    if (rollbackErrors.length === 0) {
+    if (rollbackErrors.length === 0 && provisionedWorktrees.length === 0 && !preserveInteractiveRecovery) {
       try {
         await cleanupTeamState(sanitized, leaderCwd);
       } catch (cleanupError) {
@@ -3493,14 +3496,17 @@ export async function startTeam(
       }
     }
     if (provisionedWorktrees.length > 0) {
-      try {
-        await rollbackProvisionedWorktrees(provisionedWorktrees, {
-          skipBranchDeletion: false,
-        });
-      } catch (cleanupError) {
-        rollbackErrors.push(`rollbackProvisionedWorktrees: ${String(cleanupError)}`);
+      if (preserveInteractiveRecovery) {
+        rollbackErrors.push('preserving provisioned worktrees: startup rollback release receipts are unavailable');
+      } else {
+        try {
+          await rollbackProvisionedWorktrees(provisionedWorktrees, { skipBranchDeletion: false });
+        } catch (cleanupError) {
+          rollbackErrors.push(`rollbackProvisionedWorktrees: ${String(cleanupError)}`);
+        }
       }
     }
+
 
     if (rollbackErrors.length > 0) {
       const message = error instanceof Error ? error.message : String(error);
@@ -4123,6 +4129,14 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     && resource.pane_birth
     && resource.command);
   const hasCompleteBorrowedHudRecoveryMetadata = Boolean(borrowedHudReceipt);
+  const createdWorkerReceiptIds = lifecycleResources
+    .filter((resource) => resource.kind === 'worker' && resource.created === true)
+    .map((resource) => resource.id);
+  const hasCreatedHudReceipt = lifecycleResources.some((resource) => resource.kind === 'hud' && resource.created === true);
+  const hasCreatedHookReceipt = lifecycleResources.some((resource) => resource.kind === 'hook' && resource.created === true);
+  let createdHudPaneReleased = !hasCreatedHudReceipt;
+  let createdRuntimeResourcesReleased = config.worker_launch_mode !== 'interactive';
+
 
   if (config.worker_launch_mode === 'interactive') {
     const sharedSessionTopology = sessionName.includes(':')
@@ -4331,12 +4345,16 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         tmuxPaneOwnerId,
         hudReceipt,
       );
+      createdHudPaneReleased = killedHudPane;
+
       if (!killedHudPane) {
         retainHudContainer = true;
         retainHudLifecycleState = true;
         console.warn(`[team shutdown] ${sanitized}: preserving Team HUD metadata because final tmux authority revalidation failed`);
       }
       if (killedHudPane && sessionName.includes(':') && freshHudRestoreDomain) {
+        const paneIdsBeforeRestore = new Set(listPaneIds(sessionName));
+        const restoredCreatedPaneEvidence: { value: { paneId: string; paneInstanceId: string; command: string } | null } = { value: null };
         restoredHudPaneId = restoreStandaloneHudPane(trustedHudRestoreLeaderPaneId, cwd, {
           sessionId: freshHudRestoreDomain.claimant.sessionId,
           sessionIds: freshHudRestoreDomain.session?.equivalentIds,
@@ -4344,8 +4362,23 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
           tmuxSessionInstanceId: freshHudRestoreDomain.claimant.tmuxSessionInstanceId,
           tmuxPaneInstanceId: freshHudRestoreDomain.claimant.tmuxPaneInstanceId,
           hudRuntime: projectHudRuntimeRootEnv(freshHudRestoreDomain.rootSource, process.env),
+          onCreatedPane: (evidence) => { restoredCreatedPaneEvidence.value = evidence; },
         });
         if (!restoredHudPaneId) {
+          const unverifiedReplacementPaneIds = restoredCreatedPaneEvidence.value
+            ? [restoredCreatedPaneEvidence.value.paneId]
+            : listPaneIds(sessionName).filter((paneId) => !paneIdsBeforeRestore.has(paneId));
+          if (unverifiedReplacementPaneIds.length > 0) {
+            retainHudContainer = true;
+            retainHudLifecycleState = true;
+            await appendTeamEvent(sanitized, {
+              worker: 'system',
+              type: 'shutdown_gate_forced',
+              reason: restoredCreatedPaneEvidence.value
+                ? `standalone_hud_restore_unverified:${restoredCreatedPaneEvidence.value.paneId}:${restoredCreatedPaneEvidence.value.paneInstanceId}:${Buffer.from(restoredCreatedPaneEvidence.value.command).toString('base64url')}`
+                : `standalone_hud_restore_unverified:${unverifiedReplacementPaneIds.join(',')}`,
+            }, cwd);
+          }
           console.warn(`[team shutdown] ${sanitized}: failed to restore standalone HUD pane`);
         }
       }
@@ -4390,6 +4423,17 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       retainHudContainer = true;
       console.warn(`[team shutdown] ${sanitized}: preserving lifecycle metadata because ${workerTeardown.kill.failed} worker pane teardown CAS operation(s) were uncertain`);
     }
+    const releasedEveryCreatedWorker = createdWorkerReceiptIds.every((paneId) => shutdownPaneIds.includes(paneId))
+      && workerTeardown.kill.failed === 0
+      && workerTeardown.kill.succeeded === shutdownPaneIds.length;
+    const releasedCreatedHooks = !hasCreatedHookReceipt || hooksRemoved;
+    createdRuntimeResourcesReleased = releasedEveryCreatedWorker && createdHudPaneReleased && releasedCreatedHooks;
+    if (!createdRuntimeResourcesReleased) {
+      retainHudLifecycleState = true;
+      retainHudContainer = true;
+      console.warn(`[team shutdown] ${sanitized}: preserving worktrees and recovery metadata because one or more created runtime resource release receipts were rejected or unavailable`);
+    }
+
     } finally {
       if (hudLifecycleLock?.status === 'acquired' && hudLifecycleLock.lock) {
         await releaseHudLifecycleLock(hudLifecycleLock.lock);
@@ -4404,6 +4448,8 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         lifecycleCertificate?.tmux_session_birth ?? '',
       );
       if (!destroyedSession) {
+        createdRuntimeResourcesReleased = false;
+
         retainHudContainer = true;
         retainHudLifecycleState = true;
         console.warn(`[team shutdown] ${sanitized}: preserving lifecycle metadata because standalone session teardown CAS was rejected or unconfirmed`);
@@ -4507,7 +4553,8 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
 
   const cleanupErrors: string[] = [];
   const provisionedWorktrees = collectProvisionedShutdownWorktrees(config);
-  if (provisionedWorktrees.length > 0) {
+  if (provisionedWorktrees.length > 0 && createdRuntimeResourcesReleased) {
+
     try {
       await rollbackProvisionedWorktrees(provisionedWorktrees, {
         skipBranchDeletion: false,
@@ -4521,7 +4568,8 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   // teardown receipt completed. Any missing/rejected receipt leaves the config
   // and immutable journal in place for recovery.
   let teamStateCleaned = false;
-  if (config.worker_launch_mode === 'interactive' && lifecycleCertificate && !retainHudLifecycleState) {
+  if (config.worker_launch_mode === 'interactive' && lifecycleCertificate && !retainHudLifecycleState && createdRuntimeResourcesReleased) {
+
     if (lifecycleCertificate.status === 'cleanup_complete') {
       // A prior exact cleanup persisted its completion before process exit.
     } else if (!lifecycleAuthority) {
@@ -4539,7 +4587,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       }
     }
   }
-  if (!retainHudLifecycleState) {
+  if (!retainHudLifecycleState && createdRuntimeResourcesReleased) {
     try {
       await cleanupTeamState(sanitized, cwd);
       teamStateCleaned = true;

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -32,6 +32,8 @@ import {
   restoreStandaloneHudPane,
   teardownWorkerPanes,
   unregisterResizeHook,
+  unregisterClientAttachedReconcileHook,
+  buildClientAttachedReconcileHookName,
   destroyTeamSession,
   listPaneIds,
   listTeamSessions,
@@ -4006,24 +4008,6 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       hudPaneId: effectiveHudPaneId,
     });
 
-    let resizeHookWarning: string | null = null;
-    if (config.resize_hook_name && config.resize_hook_target) {
-      const resizeHookName = config.resize_hook_name;
-      const unregistered = unregisterResizeHook(config.resize_hook_target, resizeHookName);
-      if (!unregistered && isTmuxAvailable()) {
-        const baseSession = sessionName.split(':')[0];
-        const sessionStillActive = listTeamSessions().includes(baseSession);
-        if (sessionStillActive) {
-          resizeHookWarning = `failed to unregister resize hook ${resizeHookName}`;
-        }
-      }
-    }
-    config.resize_hook_name = null;
-    config.resize_hook_target = null;
-    await saveTeamConfig(config, cwd);
-    if (resizeHookWarning) {
-      console.warn(`[team shutdown] ${sanitized}: ${resizeHookWarning}; continuing teardown`);
-    }
     const hudRequestedSessionId = normalizeSessionId(leaderSessionId);
     const initialHudRestoreDomain = hudRequestedSessionId
       ? await resolveHudControlPlaneDomain({
@@ -4085,6 +4069,33 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       }).catch(() => null)
       : null;
     const ownsHudLifecycleLock = hudLifecycleLock?.status === 'acquired' && hudLifecycleLock.lock;
+
+    // HUD lifecycle state is authority-bearing. Do not mutate it, its hooks,
+    // or the pane unless both live tmux evidence and this domain's lock agree.
+    if (hudPaneId && !ownsHudLifecycleLock) {
+      console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because exact HUD authority evidence or lifecycle lock was unavailable`);
+    }
+
+    const clientHookTarget = effectiveHudPaneId && ownsHudLifecycleLock
+      ? (config.resize_hook_target || sessionName)
+      : null;
+    if (clientHookTarget && effectiveHudPaneId) {
+      const windowIndex = clientHookTarget.slice(clientHookTarget.lastIndexOf(':') + 1);
+      const clientHookName = windowIndex
+        ? buildClientAttachedReconcileHookName(sanitized, sessionName.split(':')[0] ?? sessionName, windowIndex, effectiveHudPaneId)
+        : '';
+      if (!clientHookName || !unregisterClientAttachedReconcileHook(clientHookTarget, clientHookName)) {
+        console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because the client-attached HUD hook could not be unregistered`);
+      }
+    }
+    if ((ownsHudLifecycleLock || !hudPaneId) && config.resize_hook_name && config.resize_hook_target) {
+      if (!unregisterResizeHook(config.resize_hook_target, config.resize_hook_name) && ownsHudLifecycleLock) {
+        console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because the resize hook could not be unregistered`);
+      }
+      config.resize_hook_name = null;
+      config.resize_hook_target = null;
+      await saveTeamConfig(config, cwd);
+    }
 
     try {
     let restoredHudPaneId: string | null = null;

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -36,6 +36,7 @@ import {
   listPaneIds,
   listTeamSessions,
   resolveSharedSessionShutdownTopology,
+  establishExactTeamHudCandidate,
 } from './tmux-session.js';
 import { acquireHudLifecycleLock, releaseHudLifecycleLock } from '../hud/lifecycle-lock.js';
 import { normalizeSessionId, resolveHudControlPlaneDomain } from '../mcp/state-paths.js';
@@ -3030,18 +3031,11 @@ export async function startTeam(
             ownerSessionId: hudDomain.claimant.sessionId,
             teamPaneOwnerId: config.tmux_pane_owner_id,
             hudRuntime,
-            hudExactCandidate: hudDomain.claimant.sessionId
-              && hudDomain.claimant.leaderPaneId
-              && hudDomain.claimant.tmuxSessionInstanceId
-              && hudDomain.claimant.tmuxPaneInstanceId
-              ? {
-                sessionId: hudDomain.claimant.sessionId,
-                sessionIds: hudDomain.session?.equivalentIds ?? [hudDomain.claimant.sessionId],
-                leaderPaneId: hudDomain.claimant.leaderPaneId,
-                tmuxSessionInstanceId: hudDomain.claimant.tmuxSessionInstanceId,
-                tmuxPaneInstanceId: hudDomain.claimant.tmuxPaneInstanceId,
-              }
-              : null,
+            hudExactCandidate: establishExactTeamHudCandidate({
+              sessionId: hudDomain.claimant.sessionId,
+              sessionIds: hudDomain.session?.equivalentIds,
+              expectedLeaderPaneId: hudDomain.claimant.leaderPaneId,
+            }),
           },
         );
       } finally {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -382,6 +382,7 @@ interface ShutdownOptions {
 
 export interface TeamShutdownSummary {
   commitHygieneArtifacts: TeamCommitHygieneArtifactPaths | null;
+  complete: boolean;
 }
 
 export function applyCreatedInteractiveSessionToConfig(
@@ -4603,7 +4604,15 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     throw new Error(cleanupErrors.join(' | '));
   }
 
-  return { commitHygieneArtifacts }
+  const hadCreatedRuntimeAuthority = Boolean(lifecycleCertificate)
+    || hasCreatedHudReceipt
+    || hasCreatedHookReceipt
+    || createdWorkerReceiptIds.length > 0
+    || provisionedWorktrees.length > 0;
+  return {
+    commitHygieneArtifacts,
+    complete: !hadCreatedRuntimeAuthority || (createdRuntimeResourcesReleased && teamStateCleaned),
+  };
 }
 
 /**

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -2649,6 +2649,13 @@ export async function startTeam(
   for (let i = 1; i <= workerCount; i++) {
     workerWorkspaceByName.set(`worker-${i}`, { cwd: leaderCwd });
   }
+  const lifecyclePreflight = await probeTeamLifecycleGeneration(sanitized, leaderCwd);
+  if (lifecyclePreflight.status === 'invalid' || lifecyclePreflight.status === 'read_error') {
+    throw new Error(`team_lifecycle_recovery_required:${lifecyclePreflight.status}`);
+  }
+  if (lifecyclePreflight.status === 'valid' && lifecyclePreflight.certificate.status === 'preparing') {
+    throw new Error(`team_lifecycle_recovery_required:${lifecyclePreflight.certificate.token}`);
+  }
   if (activeWorktreeMode) {
     assertCleanLeaderWorkspaceForWorkerWorktrees(leaderCwd);
   }
@@ -2683,30 +2690,8 @@ export async function startTeam(
 
   await detectAndCleanStaleTeam(sanitized, leaderCwd, workerCount, options.confirmStaleCleanup);
 
-  if (activeWorktreeMode) {
-    for (let i = 1; i <= workerCount; i++) {
-      const workerName = `worker-${i}`;
-      const planned = planWorktreeTarget({
-        cwd: leaderCwd,
-        scope: 'team',
-        mode: effectiveWorktreeMode,
-        teamName: sanitized,
-        workerName,
-      });
-      const ensured = ensureWorktree(planned);
-      provisionedWorktrees.push(ensured);
-      if (ensured.enabled) {
-        workerWorkspaceByName.set(workerName, {
-          cwd: ensured.worktreePath,
-          worktreeRepoRoot: ensured.repoRoot,
-          worktreePath: ensured.worktreePath,
-          worktreeBranch: ensured.branchName ?? undefined,
-          worktreeDetached: ensured.detached,
-          worktreeCreated: ensured.created,
-        });
-      }
-    }
-  }
+
+
 
   // 2. Team name is already sanitized above.
   let sessionName = `omx-team-${sanitized}`;
@@ -2801,6 +2786,31 @@ export async function startTeam(
         throw new Error('team_lifecycle_certificate_conflict');
       }
     }
+    if (activeWorktreeMode) {
+      for (let i = 1; i <= workerCount; i++) {
+        const workerName = `worker-${i}`;
+        const planned = planWorktreeTarget({
+          cwd: leaderCwd,
+          scope: 'team',
+          mode: effectiveWorktreeMode,
+          teamName: sanitized,
+          workerName,
+        });
+        const ensured = ensureWorktree(planned);
+        provisionedWorktrees.push(ensured);
+        if (ensured.enabled) {
+          workerWorkspaceByName.set(workerName, {
+            cwd: ensured.worktreePath,
+            worktreeRepoRoot: ensured.repoRoot,
+            worktreePath: ensured.worktreePath,
+            worktreeBranch: ensured.branchName ?? undefined,
+            worktreeDetached: ensured.detached,
+            worktreeCreated: ensured.created,
+          });
+        }
+      }
+    }
+
     await writePersistedApprovedTeamExecutionBinding(
       sanitized,
       leaderCwd,
@@ -4417,7 +4427,12 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       leaderPaneId: effectiveLeaderPaneId,
       hudPaneId: effectiveHudPaneId,
     });
-    const workerTeardown = await teardownWorkerPanes(shutdownPaneIds, {
+    // A pane that is already absent has released its resource. Do not turn a
+    // stale pane ID into a raw kill attempt; only live panes can receive an
+    // exact receipt-validated teardown operation.
+    const liveWorkerPaneIds = new Set(listPaneIds(sessionName));
+    const liveShutdownPaneIds = shutdownPaneIds.filter((paneId) => liveWorkerPaneIds.has(paneId));
+    const workerTeardown = await teardownWorkerPanes(liveShutdownPaneIds, {
       leaderPaneId: effectiveLeaderPaneId,
       hudPaneId: restoredHudPaneId ?? (ownsHudTeardownAuthority && hooksRemoved ? effectiveHudPaneId : undefined),
       teamPaneOwnerId: tmuxPaneOwnerId,
@@ -4425,6 +4440,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       sessionBirth: lifecycleCertificate?.tmux_session_birth,
       workerReceipts,
     });
+
     if (workerTeardown.kill.failed > 0) {
       retainHudLifecycleState = true;
       retainHudContainer = true;
@@ -4482,82 +4498,91 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     }
   }
 
-  const shutdownReports = await prepareWorkerWorktreeShutdownReports(config, cwd);
-
-  const commitHygieneEntries: TeamOperationalCommitEntry[] = [];
-  for (const report of shutdownReports) {
-    const worker = config.workers.find((entry) => entry.name === report.workerName);
-    if (report.syntheticCommit) {
-      commitHygieneEntries.push({
-        recorded_at: new Date().toISOString(),
-        operation: 'shutdown_checkpoint',
-        worker_name: report.workerName,
-        task_id: worker?.assigned_tasks[0],
-        status: 'applied',
-        operational_commit: report.syntheticCommit,
-        source_commit: report.sourceRef,
-        worktree_path: report.worktreePath,
-        report_path: report.reportPath,
-        detail: 'Runtime created a shutdown checkpoint commit to preserve worker worktree changes.',
-      });
-    }
-
-    if (report.sourceRef && report.mergeOutcome !== 'skipped') {
-      commitHygieneEntries.push({
-        recorded_at: new Date().toISOString(),
-        operation: 'shutdown_merge',
-        worker_name: report.workerName,
-        task_id: worker?.assigned_tasks[0],
-        status: report.mergeOutcome === 'merged' ? 'applied' : report.mergeOutcome,
-        operational_commit: report.mergeOutcome === 'merged' ? report.leaderHeadAfter : null,
-        source_commit: report.sourceRef,
-        leader_head_before: report.leaderHeadBefore,
-        leader_head_after: report.leaderHeadAfter,
-        worktree_path: report.worktreePath,
-        report_path: report.reportPath,
-        detail: report.mergeDetail,
-      });
-    }
-  }
-
-  const artifactCwd = resolveTeamCommitHygieneArtifactCwd(config, cwd);
-  const taskView = await listTasks(sanitized, cwd).catch(() => [])
-  const internalLedger = await appendTeamCommitHygieneEntries(sanitized, commitHygieneEntries, artifactCwd)
-  const commitHygieneArtifactTeamNames = resolveCommitHygieneArtifactTeamNames(config, sanitized);
+  // Fail-closed teardown authority: an incomplete interactive release (foreign
+  // or unconfirmable panes retained, a rejected teardown CAS, or a genuine
+  // created-resource leak) must never checkpoint, merge, remove instructions,
+  // or mutate worktrees. It preserves recoverable state and reports
+  // complete:false; the retained certificate/config is the executable recovery
+  // path and retry authority. The gate below mirrors the worktree-rollback and
+  // state-cleanup gates so no destructive follow-on runs on an incomplete release.
   let commitHygieneArtifacts: TeamCommitHygieneArtifactPaths | null = null;
-  for (const artifactTeamName of commitHygieneArtifactTeamNames) {
-    const ledger = artifactTeamName === sanitized
-      ? internalLedger
-      : await appendTeamCommitHygieneEntries(artifactTeamName, internalLedger.entries, artifactCwd)
-    const commitHygieneContext = buildTeamCommitHygieneContext({
-      teamName: artifactTeamName,
-      tasks: taskView,
-      ledger,
-    })
-    const writtenArtifacts = await writeTeamCommitHygieneContext(artifactTeamName, commitHygieneContext, artifactCwd)
-    commitHygieneArtifacts ??= writtenArtifacts
-  }
+  if (createdRuntimeResourcesReleased) {
+    const shutdownReports = await prepareWorkerWorktreeShutdownReports(config, cwd);
 
-  // 5. Remove worker worktree-root instructions and team-scoped fallback instructions.
-  for (const worker of config.workers) {
-    if (!worker.worktree_path || !worker.team_state_root) continue;
+    const commitHygieneEntries: TeamOperationalCommitEntry[] = [];
+    for (const report of shutdownReports) {
+      const worker = config.workers.find((entry) => entry.name === report.workerName);
+      if (report.syntheticCommit) {
+        commitHygieneEntries.push({
+          recorded_at: new Date().toISOString(),
+          operation: 'shutdown_checkpoint',
+          worker_name: report.workerName,
+          task_id: worker?.assigned_tasks[0],
+          status: 'applied',
+          operational_commit: report.syntheticCommit,
+          source_commit: report.sourceRef,
+          worktree_path: report.worktreePath,
+          report_path: report.reportPath,
+          detail: 'Runtime created a shutdown checkpoint commit to preserve worker worktree changes.',
+        });
+      }
+
+      if (report.sourceRef && report.mergeOutcome !== 'skipped') {
+        commitHygieneEntries.push({
+          recorded_at: new Date().toISOString(),
+          operation: 'shutdown_merge',
+          worker_name: report.workerName,
+          task_id: worker?.assigned_tasks[0],
+          status: report.mergeOutcome === 'merged' ? 'applied' : report.mergeOutcome,
+          operational_commit: report.mergeOutcome === 'merged' ? report.leaderHeadAfter : null,
+          source_commit: report.sourceRef,
+          leader_head_before: report.leaderHeadBefore,
+          leader_head_after: report.leaderHeadAfter,
+          worktree_path: report.worktreePath,
+          report_path: report.reportPath,
+          detail: report.mergeDetail,
+        });
+      }
+    }
+
+    const artifactCwd = resolveTeamCommitHygieneArtifactCwd(config, cwd);
+    const taskView = await listTasks(sanitized, cwd).catch(() => [])
+    const internalLedger = await appendTeamCommitHygieneEntries(sanitized, commitHygieneEntries, artifactCwd)
+    const commitHygieneArtifactTeamNames = resolveCommitHygieneArtifactTeamNames(config, sanitized);
+    for (const artifactTeamName of commitHygieneArtifactTeamNames) {
+      const ledger = artifactTeamName === sanitized
+        ? internalLedger
+        : await appendTeamCommitHygieneEntries(artifactTeamName, internalLedger.entries, artifactCwd)
+      const commitHygieneContext = buildTeamCommitHygieneContext({
+        teamName: artifactTeamName,
+        tasks: taskView,
+        ledger,
+      })
+      const writtenArtifacts = await writeTeamCommitHygieneContext(artifactTeamName, commitHygieneContext, artifactCwd)
+      commitHygieneArtifacts ??= writtenArtifacts
+    }
+
+    // 5. Remove worker worktree-root instructions and team-scoped fallback instructions.
+    for (const worker of config.workers) {
+      if (!worker.worktree_path || !worker.team_state_root) continue;
+      try {
+        await removeWorkerWorktreeRootAgentsFile(
+          sanitized,
+          worker.name,
+          worker.team_state_root,
+          worker.worktree_path,
+        );
+      } catch (err) {
+        process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+      }
+    }
     try {
-      await removeWorkerWorktreeRootAgentsFile(
-        sanitized,
-        worker.name,
-        worker.team_state_root,
-        worker.worktree_path,
-      );
+      await removeTeamWorkerInstructionsFile(sanitized, cwd);
     } catch (err) {
       process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
     }
+    restoreTeamModelInstructionsFile(sanitized);
   }
-  try {
-    await removeTeamWorkerInstructionsFile(sanitized, cwd);
-  } catch (err) {
-    process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-  }
-  restoreTeamModelInstructionsFile(sanitized);
 
   const cleanupErrors: string[] = [];
   const provisionedWorktrees = collectProvisionedShutdownWorktrees(config);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -2542,6 +2542,21 @@ export function projectHudRuntimeRootEnv(
   return { rootSource };
 }
 
+/** @internal Exact ownership gate for deleting initialized Team state after startup failure. */
+export function shouldCleanupFailedTeamStartupState(params: {
+  rollbackErrorCount: number;
+  preserveInteractiveRecovery: boolean;
+  provisionedWorktrees: ReadonlyArray<EnsureWorktreeResult | { enabled: false }>;
+  provisionedWorktreeRollbackComplete: boolean;
+}): boolean {
+  return params.rollbackErrorCount === 0
+    && !params.preserveInteractiveRecovery
+    && params.provisionedWorktreeRollbackComplete
+    && params.provisionedWorktrees.every((result) =>
+      result.enabled === false || (result.created && !result.reused),
+    );
+}
+
 export async function startTeam(
   teamName: string,
   task: string,
@@ -3499,22 +3514,29 @@ export async function startTeam(
     }
     if (!preserveInteractiveRecovery) restoreTeamModelInstructionsFile(sanitized);
 
-    if (rollbackErrors.length === 0 && provisionedWorktrees.length === 0 && !preserveInteractiveRecovery) {
-      try {
-        await cleanupTeamState(sanitized, leaderCwd);
-      } catch (cleanupError) {
-        rollbackErrors.push(`cleanupTeamState: ${String(cleanupError)}`);
-      }
-    }
+    let provisionedWorktreeRollbackComplete = provisionedWorktrees.length === 0;
     if (provisionedWorktrees.length > 0) {
       if (preserveInteractiveRecovery) {
         rollbackErrors.push('preserving provisioned worktrees: startup rollback release receipts are unavailable');
       } else {
         try {
           await rollbackProvisionedWorktrees(provisionedWorktrees, { skipBranchDeletion: false });
+          provisionedWorktreeRollbackComplete = true;
         } catch (cleanupError) {
           rollbackErrors.push(`rollbackProvisionedWorktrees: ${String(cleanupError)}`);
         }
+      }
+    }
+    if (shouldCleanupFailedTeamStartupState({
+      rollbackErrorCount: rollbackErrors.length,
+      preserveInteractiveRecovery,
+      provisionedWorktrees,
+      provisionedWorktreeRollbackComplete,
+    })) {
+      try {
+        await cleanupTeamState(sanitized, leaderCwd);
+      } catch (cleanupError) {
+        rollbackErrors.push(`cleanupTeamState: ${String(cleanupError)}`);
       }
     }
 

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -50,6 +50,7 @@ import {
   appendTeamLifecycleResourceSync,
   createTeamLifecycleGeneration,
   finalizeTeamLifecycleGeneration,
+  probeTeamLifecycleGeneration,
   readTeamLifecycleGeneration,
   type TeamLifecycleGenerationCertificate,
 } from './state.js';
@@ -3926,6 +3927,14 @@ function resolveCommitHygieneArtifactTeamNames(config: TeamConfig, internalTeamN
   return names;
 }
 
+function hasInteractiveTmuxOwnershipEvidence(config: TeamConfig): boolean {
+  return config.worker_launch_mode === 'interactive'
+    || Boolean(config.hud_pane_id)
+    || Boolean(config.resize_hook_name)
+    || Boolean(config.resize_hook_target)
+    || config.workers.some((worker) => Boolean(worker.pane_id));
+}
+
 /**
  * Graceful shutdown: send shutdown inbox to all workers, wait, force kill, cleanup.
  */
@@ -3935,14 +3944,23 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   let skipWorkerAcks = false;
   const sanitized = resolveTeamNameForCurrentContext(teamName, cwd);
   const config = await readTeamConfig(sanitized, cwd);
+  const lifecycleCertificateProbe = await probeTeamLifecycleGeneration(sanitized, cwd);
   if (!config) {
     // A missing mutable config is never authority to guess a session name or
-    // delete recovery state. Retain any immutable certificate for recovery.
-    const certificate = await readTeamLifecycleGeneration(sanitized, cwd);
-    if (certificate) throw new Error(`shutdown_recovery_required:missing_config:${certificate.token}`);
+    // delete recovery state. Invalid and unreadable certificates are also
+    // recovery state, not proof that no interactive generation exists.
+    if (lifecycleCertificateProbe.status === 'valid') {
+      throw new Error(`shutdown_recovery_required:missing_config:${lifecycleCertificateProbe.certificate.token}`);
+    }
+    if (lifecycleCertificateProbe.status !== 'confirmed_missing') {
+      throw new Error(`shutdown_recovery_required:unreadable_certificate:${lifecycleCertificateProbe.status}`);
+    }
     throw new Error(`Team ${sanitized} not found`);
   }
-  const lifecycleCertificate = await readTeamLifecycleGeneration(sanitized, cwd);
+  const lifecycleCertificate = lifecycleCertificateProbe.status === 'valid'
+    ? lifecycleCertificateProbe.certificate
+    : null;
+  const lifecycleCertificateUnavailable = hasInteractiveTmuxOwnershipEvidence(config) && !lifecycleCertificate;
   const manifest = await readTeamManifestV2(sanitized, cwd);
   const leaderSessionId = typeof manifest?.leader?.session_id === 'string'
     ? manifest.leader.session_id.trim()
@@ -4082,7 +4100,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   // 3. Force kill remaining workers
   const leaderPaneId = config.leader_pane_id;
   const hudPaneId = config.hud_pane_id;
-  let retainHudLifecycleState = false;
+  let retainHudLifecycleState = lifecycleCertificateUnavailable;
   let retainHudContainer = false;
   const lifecycleAuthority = lifecycleCertificate?.status === 'active'
     && lifecycleCertificate.team_name === sanitized
@@ -4639,11 +4657,18 @@ async function detectAndCleanStaleTeam(
 
   // listTeamSessions has no error channel. An active/preparing immutable
   // generation therefore makes a missing session result uncertain, not stale.
-  const lifecycleCertificate = await readTeamLifecycleGeneration(teamName, leaderCwd);
-  if (lifecycleCertificate?.status === 'active' || lifecycleCertificate?.status === 'preparing') return;
+  const lifecycleCertificateProbe = await probeTeamLifecycleGeneration(teamName, leaderCwd);
+  if (lifecycleCertificateProbe.status === 'valid'
+    && (lifecycleCertificateProbe.certificate.status === 'active'
+      || lifecycleCertificateProbe.certificate.status === 'preparing')) return;
+  const retainedHudConfig = await readTeamConfig(teamName, leaderCwd);
+  // An interactive config can name panes, hooks, or a session acquired before
+  // its final receipt. Never delete that recovery metadata without a valid
+  // terminal certificate.
+  if (retainedHudConfig && hasInteractiveTmuxOwnershipEvidence(retainedHudConfig)
+    && lifecycleCertificateProbe.status !== 'valid') return;
   const sessions = new Set(listTeamSessions());
   if (sessions.has(`omx-team-${teamName}`)) return;
-  const retainedHudConfig = await readTeamConfig(teamName, leaderCwd);
   if (
     retainedHudConfig?.worker_launch_mode === 'interactive'
     && retainedHudConfig.hud_pane_id

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -348,14 +348,13 @@ async function assertTeamStartupIsNonDestructive(
   ]);
 
   if (!existingConfig && !existingManifest) return;
-
   const currentPhase = existingPhase?.current_phase;
   if (currentPhase && isTerminalPhase(currentPhase)) return;
+
+  const lifecycleProbe = await probeTeamLifecycleGeneration(teamName, cwd);
   if (
-    existingConfig?.worker_launch_mode === 'interactive'
-    && existingConfig.hud_pane_id
-    && existingConfig.resize_hook_name
-    && existingConfig.resize_hook_target
+    lifecycleProbe.status === 'valid'
+    && isTerminalTeamLifecycleGenerationStatus(lifecycleProbe.certificate.status)
   ) return;
 
   const tmuxSession = existingConfig?.tmux_session ?? existingManifest?.tmux_session ?? `omx-team-${teamName}`;
@@ -2596,7 +2595,7 @@ export async function startTeam(
       })
     : rawIdentityScope;
   const sanitized = buildInternalTeamName(displayName, identityScope);
-  const retainedHudConfig = await readTeamConfig(sanitized, leaderCwd);
+
   const leaderSessionId = identityScope.sessionId || identityScope.paneId || identityScope.tmuxTarget || identityScope.runId;
 
   await assertTeamStartupIsNonDestructive(sanitized, leaderCwd, leaderSessionId);
@@ -2754,19 +2753,6 @@ export async function startTeam(
     );
     if (!config) {
       throw new Error('failed to initialize team config');
-    }
-    if (
-      retainedHudConfig?.worker_launch_mode === 'interactive'
-      && retainedHudConfig.hud_pane_id
-      && retainedHudConfig.resize_hook_name
-      && retainedHudConfig.resize_hook_target
-    ) {
-      config.tmux_session = retainedHudConfig.tmux_session;
-      config.leader_pane_id = retainedHudConfig.leader_pane_id;
-      config.hud_pane_id = retainedHudConfig.hud_pane_id;
-      config.tmux_pane_owner_id = retainedHudConfig.tmux_pane_owner_id;
-      config.resize_hook_name = retainedHudConfig.resize_hook_name;
-      config.resize_hook_target = retainedHudConfig.resize_hook_target;
     }
     config.leader_cwd = leaderCwd;
     config.team_state_root = teamStateRoot;
@@ -3146,13 +3132,6 @@ export async function startTeam(
         config.hook_generation = lifecycleCertificate?.hook_generation ?? null;
         if (!lifecycleCertificate) throw new Error('missing_team_lifecycle_certificate');
         const acquiredResources = [
-          ...createdSession.workerPaneIds.map((paneId) => ({
-            kind: 'worker' as const,
-            id: paneId,
-            created: true,
-            pane_birth: createdSession.workerPaneBirths?.[paneId],
-            acquired_at: new Date().toISOString(),
-          })),
           ...(createdSession.hudPaneId ? [{
             kind: 'hud' as const,
             id: createdSession.hudPaneId,

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -3143,7 +3143,11 @@ export async function startTeam(
             throw new Error(`team_lifecycle_receipt_failed:${resource.kind}:${resource.id}`);
           }
         }
-        if (!await finalizeTeamLifecycleGeneration(sanitized, lifecycleCertificate.token, 'active', leaderCwd)) {
+        if (!await finalizeTeamLifecycleGeneration(sanitized, lifecycleCertificate.token, 'active', leaderCwd, {
+          tmux_session_name: createdSession.tmuxSessionName,
+          tmux_session_birth: createdSession.tmuxSessionBirth,
+          tmux_context: createdSession.tmuxContext,
+        })) {
           throw new Error('team_lifecycle_activation_failed');
         }
         const revalidatedHudCandidate = hudExactCandidate
@@ -3936,17 +3940,13 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   const sanitized = resolveTeamNameForCurrentContext(teamName, cwd);
   const config = await readTeamConfig(sanitized, cwd);
   if (!config) {
-    // No config -- just try to kill tmux session and clean up
-    try {
-      destroyTeamSession(`omx-team-${sanitized}`);
-    } catch (err) {
-      process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
-    }
-    await cleanupTeamState(sanitized, cwd);
-    await syncTeamModeStateOnShutdown(sanitized, cwd);
-    restoreTeamModelInstructionsFile(sanitized);
-    return { commitHygieneArtifacts: null };
+    // A missing mutable config is never authority to guess a session name or
+    // delete recovery state. Retain any immutable certificate for recovery.
+    const certificate = await readTeamLifecycleGeneration(sanitized, cwd);
+    if (certificate) throw new Error(`shutdown_recovery_required:missing_config:${certificate.token}`);
+    throw new Error(`Team ${sanitized} not found`);
   }
+  const lifecycleCertificate = await readTeamLifecycleGeneration(sanitized, cwd);
   const manifest = await readTeamManifestV2(sanitized, cwd);
   const leaderSessionId = typeof manifest?.leader?.session_id === 'string'
     ? manifest.leader.session_id.trim()
@@ -4088,6 +4088,19 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   const hudPaneId = config.hud_pane_id;
   let retainHudLifecycleState = false;
   let retainHudContainer = false;
+  const lifecycleAuthority = lifecycleCertificate?.status === 'active'
+    && lifecycleCertificate.team_name === sanitized
+    && lifecycleCertificate.team_pane_owner_id === config.tmux_pane_owner_id
+    && lifecycleCertificate.tmux_session_name === sessionName.split(':')[0]
+    && lifecycleCertificate.tmux_context === sessionName
+    && Boolean(lifecycleCertificate.tmux_session_birth);
+  const lifecycleResources = lifecycleAuthority ? lifecycleCertificate.resources : [];
+  const workerReceipts = Object.fromEntries(
+    lifecycleResources.filter((resource) => resource.kind === 'worker' && resource.role === 'worker' && resource.pane_birth && resource.command)
+      .map((resource) => [resource.id, resource]),
+  );
+  const hudReceipt = lifecycleResources.find((resource) => resource.kind === 'hud'
+    && resource.id === hudPaneId && resource.role === 'hud' && resource.pane_birth && resource.command);
 
   if (config.worker_launch_mode === 'interactive') {
     const sharedSessionTopology = sessionName.includes(':')
@@ -4240,10 +4253,13 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       ? freshHudOwnerTag.value
       : '';
     const ownsHudTeardownAuthority = Boolean(
-      ownsHudLifecycleLock
+      lifecycleAuthority
+      && hudReceipt
+      && ownsHudLifecycleLock
       && hasFreshHudRestoreEvidence
       && lockedHudPaneId
       && tmuxPaneOwnerId
+      && freshHudCandidate?.tmuxSessionInstanceId === lifecycleCertificate?.tmux_session_birth
       && paneHasOmxInstanceTag(lockedHudPaneId, freshHudCandidate?.tmuxPaneInstanceId)
       && freshHudOwnerId === tmuxPaneOwnerId,
     );
@@ -4259,9 +4275,13 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     const persistedHudPaneId = hudPaneId;
     const hasPersistedHudHooks = Boolean(config.resize_hook_name && config.resize_hook_target);
     const ownsHudHookTeardownAuthority = Boolean(
-      ownsHudLifecycleLock
-      && hasFreshHudRestoreEvidence
-      && persistedHudPaneId,
+      ownsHudTeardownAuthority
+      && config.hook_generation
+      && config.hook_generation === lifecycleCertificate?.hook_generation
+      && config.resize_hook_name
+      && lifecycleResources.some((resource) => resource.kind === 'hook'
+        && resource.id === config.resize_hook_name
+        && resource.command === lifecycleCertificate.hook_generation),
     );
     const clientHookTarget = ownsHudHookTeardownAuthority && hasPersistedHudHooks ? config.resize_hook_target : null;
     let hooksRemoved = ownsHudHookTeardownAuthority && !hasPersistedHudHooks;
@@ -4290,6 +4310,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         lockedHudPaneId,
         freshHudCandidate!,
         tmuxPaneOwnerId,
+        hudReceipt,
       );
       if (!killedHudPane) {
         retainHudContainer = !sessionName.includes(':');
@@ -4334,12 +4355,19 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       leaderPaneId: effectiveLeaderPaneId,
       hudPaneId: effectiveHudPaneId,
     });
-    await teardownWorkerPanes(shutdownPaneIds, {
+    const workerTeardown = await teardownWorkerPanes(shutdownPaneIds, {
       leaderPaneId: effectiveLeaderPaneId,
       hudPaneId: restoredHudPaneId ?? (ownsHudTeardownAuthority && hooksRemoved ? effectiveHudPaneId : undefined),
       teamPaneOwnerId: tmuxPaneOwnerId,
       sessionName,
+      sessionBirth: lifecycleCertificate?.tmux_session_birth,
+      workerReceipts,
     });
+    if (workerTeardown.kill.failed > 0) {
+      retainHudLifecycleState = true;
+      retainHudContainer = !sessionName.includes(':');
+      console.warn(`[team shutdown] ${sanitized}: preserving lifecycle metadata because ${workerTeardown.kill.failed} worker pane teardown CAS operation(s) were uncertain`);
+    }
     } finally {
       if (hudLifecycleLock?.status === 'acquired' && hudLifecycleLock.lock) {
         await releaseHudLifecycleLock(hudLifecycleLock.lock);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -40,6 +40,7 @@ import {
   establishExactTeamHudCandidate,
   probeExactTeamHudCandidate,
   findExactTeamHudPane,
+  killExactTeamHudPane,
 } from './tmux-session.js';
 import { acquireHudLifecycleLock, releaseHudLifecycleLock } from '../hud/lifecycle-lock.js';
 import { normalizeSessionId, resolveHudControlPlaneDomain, writeHudTmuxBirthLineage } from '../mcp/state-paths.js';
@@ -3043,12 +3044,12 @@ export async function startTeam(
         throw new Error(`hud_lifecycle_lock_${hudLifecycleLock.status}`);
       }
       let createdSession!: TeamSession;
-      const hudExactCandidate = establishExactTeamHudCandidate({
-        sessionId: hudDomain.claimant.sessionId,
-        sessionIds: hudDomain.session?.equivalentIds,
-        expectedLeaderPaneId: hudDomain.claimant.leaderPaneId,
-      });
       try {
+        const hudExactCandidate = establishExactTeamHudCandidate({
+          sessionId: hudDomain.claimant.sessionId,
+          sessionIds: hudDomain.session?.equivalentIds,
+          expectedLeaderPaneId: hudDomain.claimant.leaderPaneId,
+        });
         createdSession = createTeamSession(
           sanitized,
           workerCount,
@@ -3062,6 +3063,13 @@ export async function startTeam(
             hudExactCandidate,
           },
         );
+        // The session owns real panes as soon as tmux returns. Mark that fact before
+        // persisting lineage so a persistence failure enters the existing exact rollback.
+        sessionName = createdSession.name;
+        sessionCreated = true;
+        createdWorkerPaneIds.push(...createdSession.workerPaneIds);
+        createdLeaderPaneId = createdSession.leaderPaneId;
+        applyCreatedInteractiveSessionToConfig(config, createdSession, workerPaneIds);
         const revalidatedHudCandidate = hudExactCandidate
           ? probeExactTeamHudCandidate({
             sessionId: hudExactCandidate.sessionId,
@@ -3087,11 +3095,6 @@ export async function startTeam(
       } finally {
         await releaseHudLifecycleLock(hudLifecycleLock.lock);
       }
-      sessionName = createdSession.name;
-      sessionCreated = true;
-      createdWorkerPaneIds.push(...createdSession.workerPaneIds);
-      createdLeaderPaneId = createdSession.leaderPaneId;
-      applyCreatedInteractiveSessionToConfig(config, createdSession, workerPaneIds);
       for (const [index, paneId] of createdSession.workerPaneIds.entries()) {
         startupTiming.mark('split_returned', { worker: `worker-${index + 1}`, pane_id: paneId });
       }
@@ -4218,8 +4221,18 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
 
     let restoredHudPaneId: string | null = null;
     if (lockedHudPaneId && ownsHudTeardownAuthority && hooksRemoved) {
-      await killWorkerByPaneIdAsync(lockedHudPaneId, effectiveLeaderPaneId ?? undefined);
-      if (sessionName.includes(':') && freshHudRestoreDomain) {
+      const killedHudPane = killExactTeamHudPane(
+        sessionName,
+        lockedHudPaneId,
+        freshHudCandidate!,
+        tmuxPaneOwnerId,
+      );
+      if (!killedHudPane) {
+        retainHudContainer = !sessionName.includes(':');
+        retainHudLifecycleState = !sessionName.includes(':');
+        console.warn(`[team shutdown] ${sanitized}: preserving Team HUD metadata because final tmux authority revalidation failed`);
+      }
+      if (killedHudPane && sessionName.includes(':') && freshHudRestoreDomain) {
         restoredHudPaneId = restoreStandaloneHudPane(trustedHudRestoreLeaderPaneId, cwd, {
           sessionId: freshHudRestoreDomain.claimant.sessionId,
           sessionIds: freshHudRestoreDomain.session?.equivalentIds,

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -4178,18 +4178,23 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because fresh exact HUD authority evidence or lifecycle lock was unavailable`);
     }
 
-    const clientHookTarget = lockedHudPaneId && ownsHudTeardownAuthority
-      ? (config.resize_hook_target || sessionName)
-      : null;
+    const ownsHudHookTeardownAuthority = Boolean(
+      ownsHudLifecycleLock
+      && hasFreshHudRestoreEvidence
+      && config.resize_hook_name
+      && config.resize_hook_target
+      && hudPaneId,
+    );
+    const clientHookTarget = ownsHudHookTeardownAuthority ? config.resize_hook_target : null;
     let hooksRemoved = false;
-    if (clientHookTarget && lockedHudPaneId && config.resize_hook_name && config.resize_hook_target) {
+    if (clientHookTarget && config.resize_hook_name && hudPaneId) {
       const windowIndex = clientHookTarget.slice(clientHookTarget.lastIndexOf(':') + 1);
       const clientHookName = windowIndex
-        ? buildClientAttachedReconcileHookName(sanitized, sessionName.split(':')[0] ?? sessionName, windowIndex, lockedHudPaneId)
+        ? buildClientAttachedReconcileHookName(sanitized, sessionName.split(':')[0] ?? sessionName, windowIndex, hudPaneId)
         : '';
       hooksRemoved = Boolean(
         clientHookName
-        && unregisterHudHooksTransactionally(clientHookTarget, config.resize_hook_name, clientHookName, lockedHudPaneId)
+        && unregisterHudHooksTransactionally(clientHookTarget, config.resize_hook_name, clientHookName, hudPaneId)
       );
       if (!hooksRemoved) {
         console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane and metadata because authorized HUD hook cleanup failed; hook state may have changed`);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -37,6 +37,7 @@ import {
   listTeamSessions,
   resolveSharedSessionShutdownTopology,
   establishExactTeamHudCandidate,
+  probeExactTeamHudCandidate,
 } from './tmux-session.js';
 import { acquireHudLifecycleLock, releaseHudLifecycleLock } from '../hud/lifecycle-lock.js';
 import { normalizeSessionId, resolveHudControlPlaneDomain } from '../mcp/state-paths.js';
@@ -4024,7 +4025,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       console.warn(`[team shutdown] ${sanitized}: ${resizeHookWarning}; continuing teardown`);
     }
     const hudRequestedSessionId = normalizeSessionId(leaderSessionId);
-    const hudRestoreDomain = hudRequestedSessionId
+    const initialHudRestoreDomain = hudRequestedSessionId
       ? await resolveHudControlPlaneDomain({
         cwd,
         env: process.env,
@@ -4032,6 +4033,26 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         claimant: {
           leaderPaneId: effectiveLeaderPaneId ?? undefined,
           tmuxSessionName: sessionName,
+        },
+      }).catch(() => null)
+      : null;
+    const liveHudCandidate = initialHudRestoreDomain && effectiveLeaderPaneId
+      ? probeExactTeamHudCandidate({
+        sessionId: initialHudRestoreDomain.claimant.sessionId,
+        sessionIds: initialHudRestoreDomain.session?.equivalentIds,
+        expectedLeaderPaneId: effectiveLeaderPaneId,
+      })
+      : null;
+    const hudRestoreDomain = liveHudCandidate && hudRequestedSessionId
+      ? await resolveHudControlPlaneDomain({
+        cwd,
+        env: process.env,
+        requestedSessionId: hudRequestedSessionId,
+        claimant: {
+          leaderPaneId: liveHudCandidate.leaderPaneId,
+          tmuxSessionName: liveHudCandidate.tmuxSessionName,
+          tmuxSessionInstanceId: liveHudCandidate.tmuxSessionInstanceId,
+          tmuxPaneInstanceId: liveHudCandidate.tmuxPaneInstanceId,
         },
       }).catch(() => null)
       : null;

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -37,6 +37,11 @@ import {
   listTeamSessions,
   resolveSharedSessionShutdownTopology,
 } from './tmux-session.js';
+import { acquireHudLifecycleLock, releaseHudLifecycleLock } from '../hud/lifecycle-lock.js';
+import { normalizeSessionId, resolveHudControlPlaneDomain } from '../mcp/state-paths.js';
+import type { HudRuntimeRootSource } from '../hud/tmux.js';
+
+import type { HudRuntimeEnvInput } from '../hud/tmux.js';
 import {
   teamInit as initTeamState,
   DEFAULT_MAX_WORKERS,
@@ -441,23 +446,6 @@ function filterSharedSessionShutdownWorkerPaneIdsByOwner(
   });
 }
 
-function isSharedSessionHudPaneReclaimable(params: {
-  paneId: string;
-  persistedHudPaneId: string | null;
-  leaderOwnedHudPaneIds: string[];
-  teamPaneOwnerId: string;
-  onOwnerReadError?: (paneId: string, error: string) => void;
-}): boolean {
-  const { paneId, persistedHudPaneId, leaderOwnedHudPaneIds, teamPaneOwnerId, onOwnerReadError } = params;
-  const expectedOwnerId = teamPaneOwnerId.trim();
-  if (!expectedOwnerId) return false;
-  const owner = readPaneTeamOwnerTagResult(paneId);
-  if (owner.status === 'value') return owner.value === expectedOwnerId;
-  if (paneId !== persistedHudPaneId) return false;
-  if (owner.status === 'missing') return leaderOwnedHudPaneIds.includes(paneId);
-  onOwnerReadError?.(paneId, owner.error);
-  return false;
-}
 
 function isTrustedSharedSessionLeaderPaneForHudRestore(params: {
   paneId: string | null;
@@ -2511,6 +2499,27 @@ export async function settleStartupAttemptResults(
   });
 }
 
+export function projectHudRuntimeRootEnv(
+  rootSource: HudRuntimeRootSource,
+  env: NodeJS.ProcessEnv,
+): Pick<HudRuntimeEnvInput, 'omxRoot' | 'omxStateRoot' | 'omxTeamStateRoot' | 'rootSource'> {
+  const root = (key: 'OMX_ROOT' | 'OMX_STATE_ROOT' | 'OMX_TEAM_STATE_ROOT'): string | undefined => {
+    const value = env[key]?.trim();
+    return value || undefined;
+  };
+
+  if (rootSource === 'team-env') {
+    return { omxTeamStateRoot: root('OMX_TEAM_STATE_ROOT'), rootSource };
+  }
+  if (rootSource === 'omx-root-env') {
+    return { omxRoot: root('OMX_ROOT'), rootSource };
+  }
+  if (rootSource === 'omx-state-root-env') {
+    return { omxStateRoot: root('OMX_STATE_ROOT'), rootSource };
+  }
+  return { rootSource };
+}
+
 export async function startTeam(
   teamName: string,
   task: string,
@@ -2558,6 +2567,14 @@ export async function startTeam(
   }
 
   const teamStateRoot = resolveCanonicalTeamStateRoot(leaderCwd);
+  const hudRequestedSessionId = normalizeSessionId(resolvedLeaderSessionId);
+  const hudDomain = await resolveHudControlPlaneDomain({
+    cwd: leaderCwd,
+    env: launchEnv,
+    requestedSessionId: hudRequestedSessionId,
+  });
+  const hudRuntime = projectHudRuntimeRootEnv(hudDomain.rootSource, launchEnv);
+
   const requestedApprovedExecution = normalizeApprovedTeamExecutionBinding(options.approvedExecution);
   const requestedApprovedExecutionOutcome = requestedApprovedExecution
     ? readApprovedTeamExecutionHintOutcomeFromBinding(leaderCwd, requestedApprovedExecution)
@@ -2989,21 +3006,47 @@ export async function startTeam(
       approvedExecution,
       ultragoalOutcome,
     });
-    await cleanupTeamWorkerLaunchOrphanedMcpProcesses({
-      cleanup: options.cleanupLaunchOrphanedMcpProcesses,
-      writeWarning: options.writeCleanupWarning,
-    });
+
     const startupTiming = createStartupTimingRecorder(sanitized, leaderCwd);
 
     if (workerLaunchMode === 'interactive') {
-      const createdSession = createTeamSession(
-        sanitized,
-        workerCount,
-        leaderCwd,
-        Array.from(workerLaunchPolicyPlan[0]?.workerLaunchArgs ?? []),
-        workerStartups,
-        { ownerSessionId: leaderSessionId, teamPaneOwnerId: config.tmux_pane_owner_id },
-      );
+      const hudLifecycleLock = await acquireHudLifecycleLock({
+        path: hudDomain.reconcileLockPath,
+        domainKey: hudDomain.domainKey,
+        staleMs: 30_000,
+      });
+      if (hudLifecycleLock.status !== 'acquired' || !hudLifecycleLock.lock) {
+        throw new Error(`hud_lifecycle_lock_${hudLifecycleLock.status}`);
+      }
+      let createdSession!: TeamSession;
+      try {
+        createdSession = createTeamSession(
+          sanitized,
+          workerCount,
+          leaderCwd,
+          Array.from(workerLaunchPolicyPlan[0]?.workerLaunchArgs ?? []),
+          workerStartups,
+          {
+            ownerSessionId: hudDomain.claimant.sessionId,
+            teamPaneOwnerId: config.tmux_pane_owner_id,
+            hudRuntime,
+            hudExactCandidate: hudDomain.claimant.sessionId
+              && hudDomain.claimant.leaderPaneId
+              && hudDomain.claimant.tmuxSessionInstanceId
+              && hudDomain.claimant.tmuxPaneInstanceId
+              ? {
+                sessionId: hudDomain.claimant.sessionId,
+                sessionIds: hudDomain.session?.equivalentIds ?? [hudDomain.claimant.sessionId],
+                leaderPaneId: hudDomain.claimant.leaderPaneId,
+                tmuxSessionInstanceId: hudDomain.claimant.tmuxSessionInstanceId,
+                tmuxPaneInstanceId: hudDomain.claimant.tmuxPaneInstanceId,
+              }
+              : null,
+          },
+        );
+      } finally {
+        await releaseHudLifecycleLock(hudLifecycleLock.lock);
+      }
       sessionName = createdSession.name;
       sessionCreated = true;
       createdWorkerPaneIds.push(...createdSession.workerPaneIds);
@@ -3259,11 +3302,7 @@ export async function startTeam(
 
       // In split-pane topology, we must not kill the entire tmux session; kill only created panes.
       if (sessionName.includes(':')) {
-        for (const [index, paneId] of createdWorkerPaneIds.entries()) {
-          const panePid = getWorkerPanePid(sessionName, index + 1, paneId);
-          if (panePid) {
-            await terminateTrackedProcessTree(panePid);
-          }
+        for (const paneId of createdWorkerPaneIds) {
           try {
             await killWorkerByPaneIdAsync(paneId, createdLeaderPaneId);
           } catch (err) {
@@ -3954,15 +3993,8 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         legacyInstanceId: leaderSessionId,
       }) ? effectiveLeaderPaneId : null)
       : effectiveLeaderPaneId;
-    const effectiveHudPaneId = sharedSessionTopology
-      ? (sharedSessionTopology.hudPaneIds.find((paneId) => isSharedSessionHudPaneReclaimable({
-        paneId,
-        persistedHudPaneId: hudPaneId,
-        leaderOwnedHudPaneIds: sharedSessionTopology.leaderOwnedHudPaneIds,
-        teamPaneOwnerId: tmuxPaneOwnerId,
-        onOwnerReadError: (hudPaneId, error) => warnOwnerReadError('HUD pane', hudPaneId, error),
-      })) ?? null)
-      : hudPaneId;
+    let effectiveHudPaneId: string | null = sharedSessionTopology ? null : hudPaneId;
+
     const shutdownCandidatePaneIds = sharedSessionTopology
       ? filterSharedSessionShutdownWorkerPaneIdsByOwner(
         sharedSessionTopology.teamWorkerPaneIds,
@@ -3978,14 +4010,6 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       leaderPaneId: effectiveLeaderPaneId,
       hudPaneId: effectiveHudPaneId,
     });
-    if (shouldPrekillInteractiveShutdownProcessTrees(sessionName)) {
-      const workerPanePids = shutdownPaneIds
-        .map((paneId) => getWorkerPanePid(sessionName, 1, paneId))
-        .filter((pid): pid is number => typeof pid === 'number' && Number.isFinite(pid) && pid > 0);
-      for (const panePid of workerPanePids) {
-        await terminateTrackedProcessTree(panePid);
-      }
-    }
 
     let resizeHookWarning: string | null = null;
     if (config.resize_hook_name && config.resize_hook_target) {
@@ -4005,20 +4029,67 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     if (resizeHookWarning) {
       console.warn(`[team shutdown] ${sanitized}: ${resizeHookWarning}; continuing teardown`);
     }
+    const hudRequestedSessionId = normalizeSessionId(leaderSessionId);
+    const hudRestoreDomain = hudRequestedSessionId
+      ? await resolveHudControlPlaneDomain({
+        cwd,
+        env: process.env,
+        requestedSessionId: hudRequestedSessionId,
+        claimant: {
+          leaderPaneId: effectiveLeaderPaneId ?? undefined,
+          tmuxSessionName: sessionName,
+        },
+      }).catch(() => null)
+      : null;
+    const hasExactHudRestoreEvidence = Boolean(
+      hudRestoreDomain
+      && effectiveLeaderPaneId
+      && trustedHudRestoreLeaderPaneId === effectiveLeaderPaneId
+      && hudRestoreDomain.claimant.sessionId
+      && hudRestoreDomain.claimant.leaderPaneId === effectiveLeaderPaneId
+      && hudRestoreDomain.claimant.tmuxSessionInstanceId
+      && hudRestoreDomain.claimant.tmuxPaneInstanceId,
+    );
+    const exactSharedSessionTopology = hasExactHudRestoreEvidence && sharedSessionTopology && hudRestoreDomain
+      ? resolveSharedSessionShutdownTopology(sessionName, effectiveLeaderPaneId, sanitized, {
+        sessionId: hudRestoreDomain.claimant.sessionId!,
+        sessionIds: hudRestoreDomain.session?.equivalentIds ?? [hudRestoreDomain.claimant.sessionId!],
+        leaderPaneId: hudRestoreDomain.claimant.leaderPaneId!,
+        tmuxSessionInstanceId: hudRestoreDomain.claimant.tmuxSessionInstanceId!,
+        tmuxPaneInstanceId: hudRestoreDomain.claimant.tmuxPaneInstanceId!,
+      })
+      : null;
+    if (sharedSessionTopology) {
+      effectiveHudPaneId = exactSharedSessionTopology?.hudPaneIds.find((paneId) => paneId === hudPaneId) ?? null;
+    }
+    const hudLifecycleLock = hasExactHudRestoreEvidence && hudRestoreDomain
+      ? await acquireHudLifecycleLock({
+        path: hudRestoreDomain.reconcileLockPath,
+        domainKey: hudRestoreDomain.domainKey,
+        staleMs: 30_000,
+      }).catch(() => null)
+      : null;
+    const ownsHudLifecycleLock = hudLifecycleLock?.status === 'acquired' && hudLifecycleLock.lock;
+
+    try {
     let restoredHudPaneId: string | null = null;
-    if (effectiveHudPaneId) {
+    if (effectiveHudPaneId && ownsHudLifecycleLock) {
       await killWorkerByPaneIdAsync(effectiveHudPaneId, effectiveLeaderPaneId ?? undefined);
-      if (sessionName.includes(':')) {
+      if (sessionName.includes(':') && hudRestoreDomain) {
         restoredHudPaneId = restoreStandaloneHudPane(trustedHudRestoreLeaderPaneId, cwd, {
-          sessionId: leaderSessionId,
+          sessionId: hudRestoreDomain.claimant.sessionId,
+          sessionIds: hudRestoreDomain.session?.equivalentIds,
+          leaderPaneId: hudRestoreDomain.claimant.leaderPaneId,
+          tmuxSessionInstanceId: hudRestoreDomain.claimant.tmuxSessionInstanceId,
+          tmuxPaneInstanceId: hudRestoreDomain.claimant.tmuxPaneInstanceId,
+          hudRuntime: projectHudRuntimeRootEnv(hudRestoreDomain.rootSource, process.env),
         });
         if (!restoredHudPaneId) {
-          const reason = trustedHudRestoreLeaderPaneId
-            ? 'failed to restore standalone HUD pane'
-            : 'skipped standalone HUD restore because leader pane ownership could not be verified';
-          console.warn(`[team shutdown] ${sanitized}: ${reason}`);
+          console.warn(`[team shutdown] ${sanitized}: failed to restore standalone HUD pane`);
         }
       }
+    } else if (effectiveHudPaneId) {
+      console.warn(`[team shutdown] ${sanitized}: skipped Team HUD teardown and standalone restore because exact HUD authority evidence or lifecycle lock was unavailable`);
     }
     shutdownPaneIds = collectShutdownPaneIds({
       config,
@@ -4037,8 +4108,13 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     });
     await teardownWorkerPanes(shutdownPaneIds, {
       leaderPaneId: effectiveLeaderPaneId,
-      hudPaneId: restoredHudPaneId ?? effectiveHudPaneId,
+      hudPaneId: restoredHudPaneId ?? (ownsHudLifecycleLock ? effectiveHudPaneId : undefined),
     });
+    } finally {
+      if (hudLifecycleLock?.status === 'acquired' && hudLifecycleLock.lock) {
+        await releaseHudLifecycleLock(hudLifecycleLock.lock);
+      }
+    }
 
     // 4. Destroy tmux session
     if (!sessionName.includes(':')) {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -4116,6 +4116,12 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     && lifecycleCertificate.tmux_session_name === sessionName.split(':')[0]
     && lifecycleCertificate.tmux_context === sessionName
     && Boolean(lifecycleCertificate.tmux_session_birth);
+  const lifecycleAlreadyClean = lifecycleCertificate?.status === 'cleanup_complete'
+    && lifecycleCertificate.team_name === sanitized
+    && lifecycleCertificate.team_pane_owner_id === config.tmux_pane_owner_id
+    && lifecycleCertificate.tmux_session_name === sessionName.split(':')[0]
+    && lifecycleCertificate.tmux_context === sessionName
+    && Boolean(lifecycleCertificate.tmux_session_birth);
   const lifecycleResources = lifecycleAuthority ? lifecycleCertificate.resources : [];
   const workerReceipts = Object.fromEntries(
     lifecycleResources.filter((resource) => resource.kind === 'worker' && resource.role === 'worker' && resource.pane_birth && resource.command)
@@ -4136,10 +4142,10 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   const hasCreatedHudReceipt = lifecycleResources.some((resource) => resource.kind === 'hud' && resource.created === true);
   const hasCreatedHookReceipt = lifecycleResources.some((resource) => resource.kind === 'hook' && resource.created === true);
   let createdHudPaneReleased = !hasCreatedHudReceipt;
-  let createdRuntimeResourcesReleased = config.worker_launch_mode !== 'interactive';
+  let createdRuntimeResourcesReleased = config.worker_launch_mode !== 'interactive' || lifecycleAlreadyClean;
 
 
-  if (config.worker_launch_mode === 'interactive') {
+  if (config.worker_launch_mode === 'interactive' && !lifecycleAlreadyClean) {
     const sharedSessionTopology = sessionName.includes(':')
       ? resolveSharedSessionShutdownTopology(sessionName, leaderPaneId, sanitized)
       : null;
@@ -4297,7 +4303,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       && lockedHudPaneId
       && tmuxPaneOwnerId
       && freshHudCandidate?.tmuxSessionInstanceId === lifecycleCertificate?.tmux_session_birth
-      && paneHasOmxInstanceTag(lockedHudPaneId, freshHudCandidate?.tmuxPaneInstanceId)
+      && paneHasOmxInstanceTag(lockedHudPaneId, hudReceipt?.pane_birth)
       && freshHudOwnerId === tmuxPaneOwnerId,
     );
 
@@ -4424,9 +4430,10 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       retainHudContainer = true;
       console.warn(`[team shutdown] ${sanitized}: preserving lifecycle metadata because ${workerTeardown.kill.failed} worker pane teardown CAS operation(s) were uncertain`);
     }
-    const releasedEveryCreatedWorker = createdWorkerReceiptIds.every((paneId) => shutdownPaneIds.includes(paneId))
-      && workerTeardown.kill.failed === 0
-      && workerTeardown.kill.succeeded === shutdownPaneIds.length;
+    const livePaneIdsAtTeardown = listPaneIds(sessionName);
+    const releasedEveryCreatedWorker = createdWorkerReceiptIds.every((paneId) =>
+      !livePaneIdsAtTeardown.includes(paneId) || shutdownPaneIds.includes(paneId))
+      && workerTeardown.kill.failed === 0;
     const releasedCreatedHooks = !hasCreatedHookReceipt || hooksRemoved;
     createdRuntimeResourcesReleased = releasedEveryCreatedWorker && createdHudPaneReleased && releasedCreatedHooks;
     if (!createdRuntimeResourcesReleased) {
@@ -4604,14 +4611,9 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     throw new Error(cleanupErrors.join(' | '));
   }
 
-  const hadCreatedRuntimeAuthority = Boolean(lifecycleCertificate)
-    || hasCreatedHudReceipt
-    || hasCreatedHookReceipt
-    || createdWorkerReceiptIds.length > 0
-    || provisionedWorktrees.length > 0;
   return {
     commitHygieneArtifacts,
-    complete: !hadCreatedRuntimeAuthority || (createdRuntimeResourcesReleased && teamStateCleaned),
+    complete: createdRuntimeResourcesReleased && teamStateCleaned,
   };
 }
 

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -50,6 +50,7 @@ import {
   appendTeamLifecycleResourceSync,
   createTeamLifecycleGeneration,
   finalizeTeamLifecycleGeneration,
+  isTerminalTeamLifecycleGenerationStatus,
   probeTeamLifecycleGeneration,
   readTeamLifecycleGeneration,
   type TeamLifecycleGenerationCertificate,
@@ -4115,6 +4116,13 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   );
   const hudReceipt = lifecycleResources.find((resource) => resource.kind === 'hud'
     && resource.id === hudPaneId && resource.role === 'hud' && resource.pane_birth && resource.command);
+  const borrowedHudReceipt = lifecycleResources.find((resource) => resource.kind === 'hud'
+    && resource.id === hudPaneId
+    && resource.created === false
+    && resource.role === 'hud'
+    && resource.pane_birth
+    && resource.command);
+  const hasCompleteBorrowedHudRecoveryMetadata = Boolean(borrowedHudReceipt);
 
   if (config.worker_launch_mode === 'interactive') {
     const sharedSessionTopology = sessionName.includes(':')
@@ -4268,7 +4276,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       : '';
     const ownsHudTeardownAuthority = Boolean(
       lifecycleAuthority
-      && hudReceipt
+      && hudReceipt?.created === true
       && ownsHudLifecycleLock
       && hasFreshHudRestoreEvidence
       && lockedHudPaneId
@@ -4281,7 +4289,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     // HUD lifecycle state is authority-bearing. Do not mutate it, its hooks,
     // or the pane unless a fresh live tmux proof was obtained under this
     // domain's lock.
-    if (hudPaneId && !ownsHudTeardownAuthority) {
+    if (hudPaneId && !ownsHudTeardownAuthority && !hasCompleteBorrowedHudRecoveryMetadata) {
       retainHudLifecycleState = true;
       console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because fresh exact HUD authority evidence or lifecycle lock was unavailable`);
     }
@@ -4341,6 +4349,9 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
           console.warn(`[team shutdown] ${sanitized}: failed to restore standalone HUD pane`);
         }
       }
+    } else if (hasCompleteBorrowedHudRecoveryMetadata) {
+      // The HUD predates this Team generation. Its immutable receipt is retained
+      // only to exclude it from worker teardown; never mutate or destroy it.
     } else if (hudPaneId) {
       retainHudContainer = true;
       retainHudLifecycleState = true;
@@ -4646,7 +4657,7 @@ async function findActiveTeams(cwd: string, leaderSessionId: string): Promise<st
   return active;
 }
 
-async function detectAndCleanStaleTeam(
+export async function detectAndCleanStaleTeam(
   teamName: string,
   leaderCwd: string,
   workerCount: number,
@@ -4655,26 +4666,15 @@ async function detectAndCleanStaleTeam(
   const stateDir = teamRuntimeTeamRoot(teamName, leaderCwd);
   if (!existsSync(stateDir)) return;
 
-  // listTeamSessions has no error channel. An active/preparing immutable
-  // generation therefore makes a missing session result uncertain, not stale.
+  // A lifecycle probe is the sole authority for stale-state deletion. Missing
+  // or corrupt mutable config/manifest data cannot make a generation stale.
   const lifecycleCertificateProbe = await probeTeamLifecycleGeneration(teamName, leaderCwd);
-  if (lifecycleCertificateProbe.status === 'valid'
-    && (lifecycleCertificateProbe.certificate.status === 'active'
-      || lifecycleCertificateProbe.certificate.status === 'preparing')) return;
-  const retainedHudConfig = await readTeamConfig(teamName, leaderCwd);
-  // An interactive config can name panes, hooks, or a session acquired before
-  // its final receipt. Never delete that recovery metadata without a valid
-  // terminal certificate.
-  if (retainedHudConfig && hasInteractiveTmuxOwnershipEvidence(retainedHudConfig)
-    && lifecycleCertificateProbe.status !== 'valid') return;
+  const cleanupAuthorized = lifecycleCertificateProbe.status === 'confirmed_missing'
+    || (lifecycleCertificateProbe.status === 'valid'
+      && isTerminalTeamLifecycleGenerationStatus(lifecycleCertificateProbe.certificate.status));
+  if (!cleanupAuthorized) return;
   const sessions = new Set(listTeamSessions());
   if (sessions.has(`omx-team-${teamName}`)) return;
-  if (
-    retainedHudConfig?.worker_launch_mode === 'interactive'
-    && retainedHudConfig.hud_pane_id
-    && retainedHudConfig.resize_hook_name
-    && retainedHudConfig.resize_hook_target
-  ) return;
 
   const repoRootResult = spawnSync('git', ['rev-parse', '--show-toplevel'], {
     cwd: leaderCwd, encoding: 'utf-8', windowsHide: true,

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { join, resolve, dirname } from 'path';
 import { existsSync, appendFileSync, mkdirSync } from 'fs';
 import { mkdir, readdir, readFile, writeFile } from 'fs/promises';
@@ -44,6 +45,14 @@ import {
 import { acquireHudLifecycleLock, releaseHudLifecycleLock } from '../hud/lifecycle-lock.js';
 import { normalizeSessionId, resolveHudControlPlaneDomain, writeHudTmuxBirthLineage } from '../mcp/state-paths.js';
 import type { HudRuntimeRootSource } from '../hud/tmux.js';
+import {
+  appendTeamLifecycleResource,
+  appendTeamLifecycleResourceSync,
+  createTeamLifecycleGeneration,
+  finalizeTeamLifecycleGeneration,
+  readTeamLifecycleGeneration,
+  type TeamLifecycleGenerationCertificate,
+} from './state.js';
 
 import type { HudRuntimeEnvInput } from '../hud/tmux.js';
 import {
@@ -2701,6 +2710,7 @@ export async function startTeam(
   const overlay = generateWorkerOverlay(sanitized);
   let workerInstructionsPath: string | null = null;
   let sessionCreated = false;
+  let lifecycleCertificate: TeamLifecycleGenerationCertificate | null = null;
 
   let config: TeamConfig | null = null;
   const workerReadyTimeoutMs = resolveWorkerReadyTimeoutMs(launchEnv);
@@ -2761,6 +2771,32 @@ export async function startTeam(
     config.requested_name = displayName;
     config.identity_source = identityScope.source;
     config.worktree_mode = effectiveWorktreeMode;
+    const incompleteGeneration = await readTeamLifecycleGeneration(sanitized, leaderCwd);
+    if (incompleteGeneration?.status === 'preparing') {
+      // A prior process may have acquired panes or hooks after its last receipt.
+      // Preserve both resources and recovery metadata rather than guessing at IDs.
+      throw new Error(`team_lifecycle_recovery_required:${incompleteGeneration.token}`);
+    }
+    if (workerLaunchMode === 'interactive') {
+      lifecycleCertificate = {
+        version: 1,
+        token: randomUUID(),
+        team_name: sanitized,
+        canonical_session_id: leaderSessionId,
+        native_session_ids: [leaderSessionId],
+        tmux_session_name: null,
+        tmux_session_birth: null,
+        tmux_context: null,
+        team_pane_owner_id: config.tmux_pane_owner_id ?? `team:${sanitized}`,
+        hook_generation: randomUUID(),
+        status: 'preparing',
+        created_at: new Date().toISOString(),
+        resources: [],
+      };
+      if (!await createTeamLifecycleGeneration(lifecycleCertificate, leaderCwd)) {
+        throw new Error('team_lifecycle_certificate_conflict');
+      }
+    }
     await writePersistedApprovedTeamExecutionBinding(
       sanitized,
       leaderCwd,
@@ -3059,6 +3095,17 @@ export async function startTeam(
             teamPaneOwnerId: config.tmux_pane_owner_id,
             hudRuntime,
             hudExactCandidate,
+            hookGeneration: lifecycleCertificate?.hook_generation,
+            journalResource: (resource) => {
+              if (!lifecycleCertificate || !appendTeamLifecycleResourceSync(
+                sanitized,
+                lifecycleCertificate.token,
+                resource,
+                leaderCwd,
+              )) {
+                throw new Error(`team_lifecycle_receipt_failed:${resource.kind}:${resource.id}`);
+              }
+            },
           },
         );
         // The session owns real panes as soon as tmux returns. Mark that fact before
@@ -3066,6 +3113,39 @@ export async function startTeam(
         sessionName = createdSession.name;
         sessionCreated = true;
         applyCreatedInteractiveSessionToConfig(config, createdSession, workerPaneIds);
+        config.hook_generation = lifecycleCertificate?.hook_generation ?? null;
+        if (!lifecycleCertificate) throw new Error('missing_team_lifecycle_certificate');
+        const acquiredResources = [
+          ...createdSession.workerPaneIds.map((paneId) => ({
+            kind: 'worker' as const,
+            id: paneId,
+            created: true,
+            pane_birth: createdSession.workerPaneBirths?.[paneId],
+            acquired_at: new Date().toISOString(),
+          })),
+          ...(createdSession.hudPaneId ? [{
+            kind: 'hud' as const,
+            id: createdSession.hudPaneId,
+            created: Boolean(createdSession.hudPaneBirth),
+            pane_birth: createdSession.hudPaneBirth ?? undefined,
+            acquired_at: new Date().toISOString(),
+          }] : []),
+          ...(createdSession.resizeHookName ? [{
+            kind: 'hook' as const,
+            id: createdSession.resizeHookName,
+            created: true,
+            command: lifecycleCertificate.hook_generation,
+            acquired_at: new Date().toISOString(),
+          }] : []),
+        ];
+        for (const resource of acquiredResources) {
+          if (!await appendTeamLifecycleResource(sanitized, lifecycleCertificate.token, resource, leaderCwd)) {
+            throw new Error(`team_lifecycle_receipt_failed:${resource.kind}:${resource.id}`);
+          }
+        }
+        if (!await finalizeTeamLifecycleGeneration(sanitized, lifecycleCertificate.token, 'active', leaderCwd)) {
+          throw new Error('team_lifecycle_activation_failed');
+        }
         const revalidatedHudCandidate = hudExactCandidate
           ? probeExactTeamHudCandidate({
             sessionId: hudExactCandidate.sessionId,
@@ -3327,7 +3407,7 @@ export async function startTeam(
         try {
           hookCleanupCertain = Boolean(
             clientHookName
-            && unregisterHudHooksTransactionally(config.resize_hook_target, config.resize_hook_name, clientHookName, config.hud_pane_id),
+            && unregisterHudHooksTransactionally(config.resize_hook_target, config.resize_hook_name, clientHookName, config.hud_pane_id, config.hook_generation ?? undefined),
           );
           if (!hookCleanupCertain) rollbackErrors.push('unregisterHudHooksTransactionally: returned false');
         } catch (cleanupError) {
@@ -4192,7 +4272,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         : '';
       hooksRemoved = Boolean(
         clientHookName
-        && unregisterHudHooksTransactionally(clientHookTarget, config.resize_hook_name, clientHookName, persistedHudPaneId)
+        && unregisterHudHooksTransactionally(clientHookTarget, config.resize_hook_name, clientHookName, persistedHudPaneId, config.hook_generation ?? undefined)
       );
       if (!hooksRemoved) {
         console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane and metadata because authorized HUD hook cleanup failed; hook state may have changed`);
@@ -4257,6 +4337,8 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     await teardownWorkerPanes(shutdownPaneIds, {
       leaderPaneId: effectiveLeaderPaneId,
       hudPaneId: restoredHudPaneId ?? (ownsHudTeardownAuthority && hooksRemoved ? effectiveHudPaneId : undefined),
+      teamPaneOwnerId: tmuxPaneOwnerId,
+      sessionName,
     });
     } finally {
       if (hudLifecycleLock?.status === 'acquired' && hudLifecycleLock.lock) {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -43,7 +43,7 @@ import {
   findExactTeamHudPane,
 } from './tmux-session.js';
 import { acquireHudLifecycleLock, releaseHudLifecycleLock } from '../hud/lifecycle-lock.js';
-import { normalizeSessionId, resolveHudControlPlaneDomain } from '../mcp/state-paths.js';
+import { normalizeSessionId, resolveHudControlPlaneDomain, writeHudTmuxBirthLineage } from '../mcp/state-paths.js';
 import type { HudRuntimeRootSource } from '../hud/tmux.js';
 
 import type { HudRuntimeEnvInput } from '../hud/tmux.js';
@@ -3044,6 +3044,11 @@ export async function startTeam(
         throw new Error(`hud_lifecycle_lock_${hudLifecycleLock.status}`);
       }
       let createdSession!: TeamSession;
+      const hudExactCandidate = establishExactTeamHudCandidate({
+        sessionId: hudDomain.claimant.sessionId,
+        sessionIds: hudDomain.session?.equivalentIds,
+        expectedLeaderPaneId: hudDomain.claimant.leaderPaneId,
+      });
       try {
         createdSession = createTeamSession(
           sanitized,
@@ -3055,13 +3060,31 @@ export async function startTeam(
             ownerSessionId: hudDomain.claimant.sessionId,
             teamPaneOwnerId: config.tmux_pane_owner_id,
             hudRuntime,
-            hudExactCandidate: establishExactTeamHudCandidate({
-              sessionId: hudDomain.claimant.sessionId,
-              sessionIds: hudDomain.session?.equivalentIds,
-              expectedLeaderPaneId: hudDomain.claimant.leaderPaneId,
-            }),
+            hudExactCandidate,
           },
         );
+        const revalidatedHudCandidate = hudExactCandidate
+          ? probeExactTeamHudCandidate({
+            sessionId: hudExactCandidate.sessionId,
+            sessionIds: hudExactCandidate.sessionIds,
+            expectedLeaderPaneId: hudExactCandidate.leaderPaneId,
+          })
+          : null;
+        if (
+          hudExactCandidate
+          && createdSession.hudPaneId
+          && revalidatedHudCandidate
+          && revalidatedHudCandidate.tmuxSessionName === hudExactCandidate.tmuxSessionName
+          && revalidatedHudCandidate.tmuxSessionInstanceId === hudExactCandidate.tmuxSessionInstanceId
+          && revalidatedHudCandidate.tmuxPaneInstanceId === hudExactCandidate.tmuxPaneInstanceId
+        ) {
+          await writeHudTmuxBirthLineage(hudDomain, {
+            sessionId: hudExactCandidate.sessionId,
+            tmuxSessionName: hudExactCandidate.tmuxSessionName ?? createdSession.name.split(':')[0] ?? '',
+            tmuxSessionInstanceId: hudExactCandidate.tmuxSessionInstanceId,
+            tmuxPaneInstanceId: hudExactCandidate.tmuxPaneInstanceId,
+          });
+        }
       } finally {
         await releaseHudLifecycleLock(hudLifecycleLock.lock);
       }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -2710,6 +2710,7 @@ export async function startTeam(
   const overlay = generateWorkerOverlay(sanitized);
   let workerInstructionsPath: string | null = null;
   let sessionCreated = false;
+  let interactiveSessionCreationAttempted = false;
   let lifecycleCertificate: TeamLifecycleGenerationCertificate | null = null;
 
   let config: TeamConfig | null = null;
@@ -3084,6 +3085,7 @@ export async function startTeam(
           sessionIds: hudDomain.session?.equivalentIds,
           expectedLeaderPaneId: hudDomain.claimant.leaderPaneId,
         });
+        interactiveSessionCreationAttempted = true;
         createdSession = createTeamSession(
           sanitized,
           workerCount,
@@ -3420,16 +3422,6 @@ export async function startTeam(
         }
       }
 
-      if (config && hookCleanupCertain) {
-        config.resize_hook_name = null;
-        config.resize_hook_target = null;
-        try {
-          await saveTeamConfig(config, leaderCwd);
-        } catch (cleanupError) {
-          hookCleanupCertain = false;
-          rollbackErrors.push(`saveTeamConfig(clear resize hook): ${String(cleanupError)}`);
-        }
-      }
       if (!hookCleanupCertain) {
         rollbackErrors.push('preserving HUD metadata and container because hook cleanup was uncertain');
       }
@@ -3443,6 +3435,10 @@ export async function startTeam(
         rollbackErrors.push('preserving standalone session and Team metadata: exact session birth journal unavailable');
       }
 
+    } else if (interactiveSessionCreationAttempted && lifecycleCertificate) {
+      // createTeamSession can throw after a tmux mutation but before returning a
+      // TeamSession. Its preparing journal is the only safe recovery authority.
+      rollbackErrors.push('preserving Team metadata: createTeamSession may have mutated before throwing');
     }
     if (workerLaunchMode === 'prompt' && config) {
       const promptTeardownFailures: string[] = [];
@@ -4268,7 +4264,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     // or the pane unless a fresh live tmux proof was obtained under this
     // domain's lock.
     if (hudPaneId && !ownsHudTeardownAuthority) {
-      retainHudLifecycleState = !sessionName.includes(':');
+      retainHudLifecycleState = true;
       console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because fresh exact HUD authority evidence or lifecycle lock was unavailable`);
     }
 
@@ -4295,11 +4291,8 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         && unregisterHudHooksTransactionally(clientHookTarget, config.resize_hook_name, clientHookName, persistedHudPaneId, config.hook_generation ?? undefined)
       );
       if (!hooksRemoved) {
+        retainHudLifecycleState = true;
         console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane and metadata because authorized HUD hook cleanup failed; hook state may have changed`);
-      } else {
-        config.resize_hook_name = null;
-        config.resize_hook_target = null;
-        await saveTeamConfig(config, cwd);
       }
     }
 
@@ -4313,8 +4306,8 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         hudReceipt,
       );
       if (!killedHudPane) {
-        retainHudContainer = !sessionName.includes(':');
-        retainHudLifecycleState = !sessionName.includes(':');
+        retainHudContainer = true;
+        retainHudLifecycleState = true;
         console.warn(`[team shutdown] ${sanitized}: preserving Team HUD metadata because final tmux authority revalidation failed`);
       }
       if (killedHudPane && sessionName.includes(':') && freshHudRestoreDomain) {
@@ -4331,8 +4324,8 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         }
       }
     } else if (hudPaneId) {
-      retainHudContainer = !sessionName.includes(':');
-      retainHudLifecycleState = !sessionName.includes(':');
+      retainHudContainer = true;
+      retainHudLifecycleState = true;
       console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because fresh exact HUD authority, lifecycle lock, or hook cleanup was unavailable`);
     }
     shutdownPaneIds = collectShutdownPaneIds({
@@ -4365,7 +4358,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     });
     if (workerTeardown.kill.failed > 0) {
       retainHudLifecycleState = true;
-      retainHudContainer = !sessionName.includes(':');
+      retainHudContainer = true;
       console.warn(`[team shutdown] ${sanitized}: preserving lifecycle metadata because ${workerTeardown.kill.failed} worker pane teardown CAS operation(s) were uncertain`);
     }
     } finally {
@@ -4374,12 +4367,17 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       }
     }
 
-    // 4. Destroy tmux session only when it contains preserved exact Team HUD state.
+    // 4. Destroy only the exact standalone Team session generation. A rejected
+    // server-side comparison is uncertainty, so retain recovery metadata.
     if (!sessionName.includes(':') && !retainHudContainer) {
-      try {
-        destroyTeamSession(sessionName);
-      } catch (err) {
-        process.stderr.write(`[team/runtime] operation failed: ${err}\n`);
+      const destroyedSession = destroyTeamSession(
+        sessionName,
+        lifecycleCertificate?.tmux_session_birth ?? '',
+      );
+      if (!destroyedSession) {
+        retainHudContainer = true;
+        retainHudLifecycleState = true;
+        console.warn(`[team shutdown] ${sanitized}: preserving lifecycle metadata because standalone session teardown CAS was rejected or unconfirmed`);
       }
     }
   } else {
@@ -4490,8 +4488,28 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     }
   }
 
-  // 7. Retain state only when an exact Team HUD lifecycle retry remains actionable.
+  // 7. An active interactive certificate is retired only after every exact
+  // teardown receipt completed. Any missing/rejected receipt leaves the config
+  // and immutable journal in place for recovery.
   let teamStateCleaned = false;
+  if (config.worker_launch_mode === 'interactive' && lifecycleCertificate && !retainHudLifecycleState) {
+    if (lifecycleCertificate.status === 'cleanup_complete') {
+      // A prior exact cleanup persisted its completion before process exit.
+    } else if (!lifecycleAuthority) {
+      retainHudLifecycleState = true;
+      cleanupErrors.push('finalizeTeamLifecycleGeneration: active certificate lacks exact teardown authority');
+    } else {
+      const completed = await finalizeTeamLifecycleGeneration(sanitized, lifecycleCertificate.token, 'cleanup_complete', cwd, {
+        tmux_session_name: lifecycleCertificate.tmux_session_name,
+        tmux_session_birth: lifecycleCertificate.tmux_session_birth,
+        tmux_context: lifecycleCertificate.tmux_context,
+      });
+      if (!completed) {
+        retainHudLifecycleState = true;
+        cleanupErrors.push('finalizeTeamLifecycleGeneration: exact cleanup completion could not be persisted');
+      }
+    }
+  }
   if (!retainHudLifecycleState) {
     try {
       await cleanupTeamState(sanitized, cwd);
@@ -4619,6 +4637,10 @@ async function detectAndCleanStaleTeam(
   const stateDir = teamRuntimeTeamRoot(teamName, leaderCwd);
   if (!existsSync(stateDir)) return;
 
+  // listTeamSessions has no error channel. An active/preparing immutable
+  // generation therefore makes a missing session result uncertain, not stale.
+  const lifecycleCertificate = await readTeamLifecycleGeneration(teamName, leaderCwd);
+  if (lifecycleCertificate?.status === 'active' || lifecycleCertificate?.status === 'preparing') return;
   const sessions = new Set(listTeamSessions());
   if (sessions.has(`omx-team-${teamName}`)) return;
   const retainedHudConfig = await readTeamConfig(teamName, leaderCwd);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -32,7 +32,7 @@ import {
   restoreStandaloneHudPane,
   teardownWorkerPanes,
   unregisterResizeHook,
-  unregisterClientAttachedReconcileHook,
+  unregisterHudHooksTransactionally,
   buildClientAttachedReconcileHookName,
   destroyTeamSession,
   listPaneIds,
@@ -3966,6 +3966,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   const leaderPaneId = config.leader_pane_id;
   const hudPaneId = config.hud_pane_id;
   let retainHudLifecycleState = false;
+  let retainHudContainer = false;
 
   if (config.worker_launch_mode === 'interactive') {
     const sharedSessionTopology = sessionName.includes(':')
@@ -4001,7 +4002,12 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         legacyPersistedWorkerPaneIds,
         (paneId, error) => warnOwnerReadError('worker pane', paneId, error),
       )
-      : listPaneIds(sessionName);
+      : filterSharedSessionShutdownWorkerPaneIdsByOwner(
+        listPaneIds(sessionName),
+        tmuxPaneOwnerId,
+        legacyPersistedWorkerPaneIds,
+        (paneId, error) => warnOwnerReadError('worker pane', paneId, error),
+      );
     let shutdownPaneIds = collectShutdownPaneIds({
       config,
       candidatePaneIds: shutdownCandidatePaneIds,
@@ -4102,7 +4108,20 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       && freshHudRestoreDomain.claimant.tmuxSessionInstanceId === freshHudCandidate.tmuxSessionInstanceId
       && freshHudRestoreDomain.claimant.tmuxPaneInstanceId === freshHudCandidate.tmuxPaneInstanceId,
     );
-    const ownsHudTeardownAuthority = ownsHudLifecycleLock && hasFreshHudRestoreEvidence;
+    const freshHudOwnerTag = effectiveHudPaneId
+      ? readPaneTeamOwnerTagResult(effectiveHudPaneId)
+      : null;
+    const freshHudOwnerId = freshHudOwnerTag?.status === 'value'
+      ? freshHudOwnerTag.value
+      : '';
+    const ownsHudTeardownAuthority = Boolean(
+      ownsHudLifecycleLock
+      && hasFreshHudRestoreEvidence
+      && effectiveHudPaneId
+      && tmuxPaneOwnerId
+      && paneHasOmxInstanceTag(effectiveHudPaneId, freshHudCandidate?.tmuxPaneInstanceId)
+      && freshHudOwnerId === tmuxPaneOwnerId,
+    );
 
     // HUD lifecycle state is authority-bearing. Do not mutate it, its hooks,
     // or the pane unless a fresh live tmux proof was obtained under this
@@ -4115,21 +4134,18 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       ? (config.resize_hook_target || sessionName)
       : null;
     let hooksRemoved = false;
-    if (clientHookTarget && effectiveHudPaneId) {
+    if (clientHookTarget && effectiveHudPaneId && config.resize_hook_name && config.resize_hook_target) {
       const windowIndex = clientHookTarget.slice(clientHookTarget.lastIndexOf(':') + 1);
       const clientHookName = windowIndex
         ? buildClientAttachedReconcileHookName(sanitized, sessionName.split(':')[0] ?? sessionName, windowIndex, effectiveHudPaneId)
         : '';
-      const clientHookRemoved = Boolean(
-        clientHookName && unregisterClientAttachedReconcileHook(clientHookTarget, clientHookName),
+      hooksRemoved = Boolean(
+        clientHookName
+        && unregisterHudHooksTransactionally(clientHookTarget, config.resize_hook_name, clientHookName),
       );
-      const resizeHookRemoved = !config.resize_hook_name
-        || !config.resize_hook_target
-        || unregisterResizeHook(config.resize_hook_target, config.resize_hook_name);
-      hooksRemoved = clientHookRemoved && resizeHookRemoved;
       if (!hooksRemoved) {
-        console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because authorized HUD hook cleanup failed`);
-      } else if (config.resize_hook_name || config.resize_hook_target) {
+        console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane and metadata because authorized HUD hook cleanup failed; hook state may have changed`);
+      } else {
         config.resize_hook_name = null;
         config.resize_hook_target = null;
         await saveTeamConfig(config, cwd);
@@ -4154,7 +4170,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         }
       }
     } else if (hudPaneId) {
-      retainHudLifecycleState = Boolean(ownsHudTeardownAuthority && effectiveHudPaneId);
+      retainHudContainer = true;
       console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because fresh exact HUD authority, lifecycle lock, or hook cleanup was unavailable`);
     }
     shutdownPaneIds = collectShutdownPaneIds({
@@ -4166,7 +4182,12 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
           legacyPersistedWorkerPaneIds,
           (paneId, error) => warnOwnerReadError('worker pane', paneId, error),
         )
-        : listPaneIds(sessionName),
+        : filterSharedSessionShutdownWorkerPaneIdsByOwner(
+          listPaneIds(sessionName),
+          tmuxPaneOwnerId,
+          legacyPersistedWorkerPaneIds,
+          (paneId, error) => warnOwnerReadError('worker pane', paneId, error),
+        ),
       includePersistedWorkerPaneIds: !sessionName.includes(':'),
       restoredStandaloneHudPaneId: restoredHudPaneId,
       leaderPaneId: effectiveLeaderPaneId,
@@ -4183,7 +4204,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     }
 
     // 4. Destroy tmux session only when it contains preserved exact Team HUD state.
-    if (!sessionName.includes(':') && !retainHudLifecycleState) {
+    if (!sessionName.includes(':') && !retainHudContainer) {
       try {
         destroyTeamSession(sessionName);
       } catch (err) {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -40,6 +40,7 @@ import {
   resolveSharedSessionShutdownTopology,
   establishExactTeamHudCandidate,
   probeExactTeamHudCandidate,
+  findExactTeamHudPane,
 } from './tmux-session.js';
 import { acquireHudLifecycleLock, releaseHudLifecycleLock } from '../hud/lifecycle-lock.js';
 import { normalizeSessionId, resolveHudControlPlaneDomain } from '../mcp/state-paths.js';
@@ -340,6 +341,12 @@ async function assertTeamStartupIsNonDestructive(
 
   const currentPhase = existingPhase?.current_phase;
   if (currentPhase && isTerminalPhase(currentPhase)) return;
+  if (
+    existingConfig?.worker_launch_mode === 'interactive'
+    && existingConfig.hud_pane_id
+    && existingConfig.resize_hook_name
+    && existingConfig.resize_hook_target
+  ) return;
 
   const tmuxSession = existingConfig?.tmux_session ?? existingManifest?.tmux_session ?? `omx-team-${teamName}`;
   const renderedPhase = currentPhase ?? 'team-exec';
@@ -2563,6 +2570,7 @@ export async function startTeam(
       })
     : rawIdentityScope;
   const sanitized = buildInternalTeamName(displayName, identityScope);
+  const retainedHudConfig = await readTeamConfig(sanitized, leaderCwd);
   const leaderSessionId = identityScope.sessionId || identityScope.paneId || identityScope.tmuxTarget || identityScope.runId;
 
   await assertTeamStartupIsNonDestructive(sanitized, leaderCwd, leaderSessionId);
@@ -2734,6 +2742,19 @@ export async function startTeam(
     );
     if (!config) {
       throw new Error('failed to initialize team config');
+    }
+    if (
+      retainedHudConfig?.worker_launch_mode === 'interactive'
+      && retainedHudConfig.hud_pane_id
+      && retainedHudConfig.resize_hook_name
+      && retainedHudConfig.resize_hook_target
+    ) {
+      config.tmux_session = retainedHudConfig.tmux_session;
+      config.leader_pane_id = retainedHudConfig.leader_pane_id;
+      config.hud_pane_id = retainedHudConfig.hud_pane_id;
+      config.tmux_pane_owner_id = retainedHudConfig.tmux_pane_owner_id;
+      config.resize_hook_name = retainedHudConfig.resize_hook_name;
+      config.resize_hook_target = retainedHudConfig.resize_hook_target;
     }
     config.leader_cwd = leaderCwd;
     config.team_state_root = teamStateRoot;
@@ -4108,8 +4129,11 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       && freshHudRestoreDomain.claimant.tmuxSessionInstanceId === freshHudCandidate.tmuxSessionInstanceId
       && freshHudRestoreDomain.claimant.tmuxPaneInstanceId === freshHudCandidate.tmuxPaneInstanceId,
     );
-    const freshHudOwnerTag = effectiveHudPaneId
-      ? readPaneTeamOwnerTagResult(effectiveHudPaneId)
+    const lockedHudPaneId = freshHudCandidate
+      ? findExactTeamHudPane(sessionName, effectiveHudPaneId, freshHudCandidate)
+      : null;
+    const freshHudOwnerTag = lockedHudPaneId
+      ? readPaneTeamOwnerTagResult(lockedHudPaneId)
       : null;
     const freshHudOwnerId = freshHudOwnerTag?.status === 'value'
       ? freshHudOwnerTag.value
@@ -4117,9 +4141,9 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     const ownsHudTeardownAuthority = Boolean(
       ownsHudLifecycleLock
       && hasFreshHudRestoreEvidence
-      && effectiveHudPaneId
+      && lockedHudPaneId
       && tmuxPaneOwnerId
-      && paneHasOmxInstanceTag(effectiveHudPaneId, freshHudCandidate?.tmuxPaneInstanceId)
+      && paneHasOmxInstanceTag(lockedHudPaneId, freshHudCandidate?.tmuxPaneInstanceId)
       && freshHudOwnerId === tmuxPaneOwnerId,
     );
 
@@ -4127,21 +4151,22 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     // or the pane unless a fresh live tmux proof was obtained under this
     // domain's lock.
     if (hudPaneId && !ownsHudTeardownAuthority) {
+      retainHudLifecycleState = !sessionName.includes(':');
       console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because fresh exact HUD authority evidence or lifecycle lock was unavailable`);
     }
 
-    const clientHookTarget = effectiveHudPaneId && ownsHudTeardownAuthority
+    const clientHookTarget = lockedHudPaneId && ownsHudTeardownAuthority
       ? (config.resize_hook_target || sessionName)
       : null;
     let hooksRemoved = false;
-    if (clientHookTarget && effectiveHudPaneId && config.resize_hook_name && config.resize_hook_target) {
+    if (clientHookTarget && lockedHudPaneId && config.resize_hook_name && config.resize_hook_target) {
       const windowIndex = clientHookTarget.slice(clientHookTarget.lastIndexOf(':') + 1);
       const clientHookName = windowIndex
-        ? buildClientAttachedReconcileHookName(sanitized, sessionName.split(':')[0] ?? sessionName, windowIndex, effectiveHudPaneId)
+        ? buildClientAttachedReconcileHookName(sanitized, sessionName.split(':')[0] ?? sessionName, windowIndex, lockedHudPaneId)
         : '';
       hooksRemoved = Boolean(
         clientHookName
-        && unregisterHudHooksTransactionally(clientHookTarget, config.resize_hook_name, clientHookName),
+        && unregisterHudHooksTransactionally(clientHookTarget, config.resize_hook_name, clientHookName, lockedHudPaneId)
       );
       if (!hooksRemoved) {
         console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane and metadata because authorized HUD hook cleanup failed; hook state may have changed`);
@@ -4154,8 +4179,8 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
 
     try {
     let restoredHudPaneId: string | null = null;
-    if (effectiveHudPaneId && ownsHudTeardownAuthority && hooksRemoved) {
-      await killWorkerByPaneIdAsync(effectiveHudPaneId, effectiveLeaderPaneId ?? undefined);
+    if (lockedHudPaneId && ownsHudTeardownAuthority && hooksRemoved) {
+      await killWorkerByPaneIdAsync(lockedHudPaneId, effectiveLeaderPaneId ?? undefined);
       if (sessionName.includes(':') && freshHudRestoreDomain) {
         restoredHudPaneId = restoreStandaloneHudPane(trustedHudRestoreLeaderPaneId, cwd, {
           sessionId: freshHudRestoreDomain.claimant.sessionId,
@@ -4170,7 +4195,8 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
         }
       }
     } else if (hudPaneId) {
-      retainHudContainer = true;
+      retainHudContainer = !sessionName.includes(':');
+      retainHudLifecycleState = !sessionName.includes(':');
       console.warn(`[team shutdown] ${sanitized}: preserving Team HUD pane, hooks, and metadata because fresh exact HUD authority, lifecycle lock, or hook cleanup was unavailable`);
     }
     shutdownPaneIds = collectShutdownPaneIds({
@@ -4450,6 +4476,13 @@ async function detectAndCleanStaleTeam(
 
   const sessions = new Set(listTeamSessions());
   if (sessions.has(`omx-team-${teamName}`)) return;
+  const retainedHudConfig = await readTeamConfig(teamName, leaderCwd);
+  if (
+    retainedHudConfig?.worker_launch_mode === 'interactive'
+    && retainedHudConfig.hud_pane_id
+    && retainedHudConfig.resize_hook_name
+    && retainedHudConfig.resize_hook_target
+  ) return;
 
   const repoRootResult = spawnSync('git', ['rev-parse', '--show-toplevel'], {
     cwd: leaderCwd, encoding: 'utf-8', windowsHide: true,

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -233,6 +233,36 @@ function readTmuxSessionBirth(sessionName: string): string | null {
     return null;
   }
 }
+
+function initialWorkerLifecycleReceipt(
+  teamName: string,
+  config: TeamConfig,
+  sessionName: string,
+  certificate: Awaited<ReturnType<typeof probeTeamLifecycleGeneration>>,
+  worker: WorkerInfo,
+): { receipt: TeamLifecycleResource; sessionBirth: string } | null {
+  if (certificate.status !== 'valid' || certificate.certificate.status !== 'active') return null;
+  const lifecycle = certificate.certificate;
+  const sessionBirth = readTmuxSessionBirth(sessionName);
+  if (
+    lifecycle.team_name !== teamName
+    || lifecycle.tmux_session_name !== sessionName.split(':', 1)[0]
+    || lifecycle.tmux_context !== sessionName
+    || lifecycle.tmux_session_birth !== sessionBirth
+    || lifecycle.team_pane_owner_id !== config.tmux_pane_owner_id
+    || !sessionBirth
+    || !worker.pane_id
+  ) return null;
+  const receipt = lifecycle.resources.find((resource) =>
+    resource.kind === 'worker'
+    && resource.role === 'worker'
+    && resource.id === worker.pane_id
+    && resource.created === true
+    && Boolean(resource.pane_birth?.trim())
+    && Boolean(resource.command?.trim()),
+  );
+  return receipt ? { receipt, sessionBirth } : null;
+}
 function hasExactScaleUpTmuxAuthority(
   teamName: string,
   config: TeamConfig,
@@ -1110,21 +1140,34 @@ export async function scaleDown(
     if (liveTargetWorkers.some((worker) => worker.pane_id === leaderPaneId || worker.pane_id === hudPaneId)) {
       return { ok: false, error: 'scale_down_target_is_leader_or_hud' };
     }
-    const receipts = await Promise.all(liveTargetWorkers.map(async (worker) => ({
-      worker,
-      receipt: await readScaledWorkerReceipt(sanitized, worker.name, teamStateRoot),
-    })));
-    const invalidReceipt = receipts.find(({ worker, receipt }) => (
-      !receipt
-      || receipt.id !== worker.pane_id
-      || receipt.session_name !== sessionName
-      || receipt.team_pane_owner_id !== config.tmux_pane_owner_id
-    ));
+    const lifecycleCertificate = await probeTeamLifecycleGeneration(sanitized, leaderCwd);
+    const receipts = await Promise.all(liveTargetWorkers.map(async (worker) => {
+      const scaledReceipt = await readScaledWorkerReceipt(sanitized, worker.name, teamStateRoot);
+      if (
+        scaledReceipt
+        && scaledReceipt.id === worker.pane_id
+        && scaledReceipt.session_name === sessionName
+        && scaledReceipt.team_pane_owner_id === config.tmux_pane_owner_id
+      ) {
+        return { worker, receipt: scaledReceipt as TeamLifecycleResource, sessionBirth: scaledReceipt.session_birth };
+      }
+      const lifecycleReceipt = initialWorkerLifecycleReceipt(
+        sanitized,
+        config,
+        sessionName,
+        lifecycleCertificate,
+        worker,
+      );
+      return lifecycleReceipt
+        ? { worker, ...lifecycleReceipt }
+        : { worker, receipt: null, sessionBirth: null };
+    }));
+    const invalidReceipt = receipts.find(({ receipt }) => !receipt);
     if (invalidReceipt) {
       return { ok: false, error: `scale_down_missing_exact_teardown_receipt:${invalidReceipt.worker.name}` };
     }
-    const sessionBirth = receipts[0]?.receipt?.session_birth;
-    if (receipts.length > 0 && (!sessionBirth || receipts.some(({ receipt }) => receipt?.session_birth !== sessionBirth))) {
+    const sessionBirth = receipts[0]?.sessionBirth;
+    if (receipts.length > 0 && (!sessionBirth || receipts.some((entry) => entry.sessionBirth !== sessionBirth))) {
       return { ok: false, error: 'scale_down_inconsistent_session_birth_receipts' };
     }
     const targetPaneIds = receipts.map(({ receipt }) => receipt!.id);

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -170,20 +170,20 @@ interface ScaledWorkerReceipt extends TeamLifecycleResource {
   readonly team_pane_owner_id: string;
 }
 
-function scaledWorkerReceiptPath(teamName: string, workerName: string, cwd: string): string {
-  return join(cwd, '.omx', 'state', 'team', teamName, 'scaling-receipts', `${workerName}.json`);
+function scaledWorkerReceiptPath(teamName: string, workerName: string, teamStateRoot: string): string {
+  return join(teamStateRoot, 'team', teamName, 'scaling-receipts', `${workerName}.json`);
 }
 
 async function writeScaledWorkerReceipt(
   teamName: string,
   workerName: string,
-  cwd: string,
+  teamStateRoot: string,
   receipt: ScaledWorkerReceipt,
 ): Promise<boolean> {
-  const path = scaledWorkerReceiptPath(teamName, workerName, cwd);
+  const path = scaledWorkerReceiptPath(teamName, workerName, teamStateRoot);
   const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
   try {
-    await mkdir(join(cwd, '.omx', 'state', 'team', teamName, 'scaling-receipts'), { recursive: true });
+    await mkdir(join(teamStateRoot, 'team', teamName, 'scaling-receipts'), { recursive: true });
     await writeFile(temporaryPath, `${JSON.stringify(receipt, null, 2)}\n`, { encoding: 'utf-8', flag: 'wx' });
     await rename(temporaryPath, path);
     return true;
@@ -196,10 +196,10 @@ async function writeScaledWorkerReceipt(
 async function readScaledWorkerReceipt(
   teamName: string,
   workerName: string,
-  cwd: string,
+  teamStateRoot: string,
 ): Promise<ScaledWorkerReceipt | null> {
   try {
-    const value: unknown = JSON.parse(await readFile(scaledWorkerReceiptPath(teamName, workerName, cwd), 'utf-8'));
+    const value: unknown = JSON.parse(await readFile(scaledWorkerReceiptPath(teamName, workerName, teamStateRoot), 'utf-8'));
     if (!value || typeof value !== 'object') return null;
     const receipt = value as Partial<ScaledWorkerReceipt>;
     return receipt.kind === 'worker'
@@ -215,6 +215,12 @@ async function readScaledWorkerReceipt(
   } catch {
     return null;
   }
+}
+
+function resolveTeamStateRootForConfig(config: TeamConfig, leaderCwd: string, env: NodeJS.ProcessEnv): string {
+  return config.team_state_root
+    ? resolve(config.leader_cwd ?? leaderCwd, config.team_state_root)
+    : resolveCanonicalTeamStateRoot(leaderCwd, env);
 }
 
 function readTmuxSessionBirth(sessionName: string): string | null {
@@ -492,7 +498,7 @@ export async function scaleUp(
       };
     }
 
-    const teamStateRoot = config.team_state_root ?? resolveCanonicalTeamStateRoot(leaderCwd);
+    const teamStateRoot = resolveTeamStateRootForConfig(config, leaderCwd, env);
     const codexHomeOverride = resolveCodexHomeForLaunch(leaderCwd, env);
     const launchEnv = codexHomeOverride
       ? { ...env, CODEX_HOME: codexHomeOverride }
@@ -566,6 +572,12 @@ export async function scaleUp(
       await saveTeamConfig(config, leaderCwd);
     }
 
+    let activeWorkerRollbackContext: {
+      workerName?: string;
+      worktreePath?: string;
+      receipt?: ScaledWorkerReceipt;
+    } = {};
+
     const addedWorkers: WorkerInfo[] = [];
     const createdTaskIds: string[] = [];
     const provisionedWorktrees: EnsureWorktreeResult[] = [];
@@ -576,7 +588,7 @@ export async function scaleUp(
     ): Promise<ScaleError> => {
       const receipts = new Map<string, ScaledWorkerReceipt>();
       for (const worker of addedWorkers) {
-        const receipt = await readScaledWorkerReceipt(sanitized, worker.name, leaderCwd);
+        const receipt = await readScaledWorkerReceipt(sanitized, worker.name, teamStateRoot);
         if (receipt && worker.pane_id === receipt.id) receipts.set(receipt.id, receipt);
       }
       if (context.receipt) receipts.set(context.receipt.id, context.receipt);
@@ -601,18 +613,16 @@ export async function scaleUp(
       if (context.workerName && context.worktreePath && !addedWorkers.some((worker) => worker.name === context.workerName)) {
         await removeWorkerWorktreeRootAgentsFile(sanitized, context.workerName, teamStateRoot, context.worktreePath).catch(() => {});
       }
-      if (provisionedWorktrees.length > 0) {
-        if (provisionedWorktrees.some((result) => !result.created || result.reused)) {
-          return { ok: false, error: `${error}:scale_up_rollback_preserved_reused_worktree` };
-        }
+      const createdWorktrees = provisionedWorktrees.filter((result) => result.created && !result.reused);
+      if (createdWorktrees.length > 0) {
         try {
-          await rollbackProvisionedWorktrees(provisionedWorktrees, { skipBranchDeletion: false });
+          await rollbackProvisionedWorktrees(createdWorktrees, { skipBranchDeletion: false });
         } catch (cleanupError) {
           return { ok: false, error: `${error}:scale_up_rollback_worktree_cleanup_failed:${String(cleanupError)}` };
         }
       }
       for (const taskId of createdTaskIds) {
-        await rm(join(leaderCwd, '.omx', 'state', 'team', sanitized, 'tasks', `task-${taskId}.json`), { force: true }).catch(() => {});
+        await rm(join(teamStateRoot, 'team', sanitized, 'tasks', `task-${taskId}.json`), { force: true }).catch(() => {});
       }
       config.worker_count = config.workers.length;
       config.next_worker_index = initialNextIndex;
@@ -620,6 +630,7 @@ export async function scaleUp(
       return { ok: false, error };
     };
 
+    try {
     // Persist incoming tasks only after launch policy is frozen; the resulting
     // task listing is used for inbox and task materialization, never launch policy.
     for (const task of tasks) {
@@ -665,6 +676,10 @@ export async function scaleUp(
       if (workerWorkspaceResult.enabled) provisionedWorktrees.push(workerWorkspaceResult);
       const workerWorkspace = workerWorkspaceResult.enabled ? workerWorkspaceResult : null;
       const workerCwd = workerWorkspace ? workerWorkspace.worktreePath : leaderCwd;
+      activeWorkerRollbackContext = {
+        workerName,
+        worktreePath: workerWorkspace?.worktreePath,
+      };
 
       // Build startup command and create tmux pane
       const rawRolePromptContent = await loadRolePrompt(runtimeRole, join(leaderCwd, '.codex', 'prompts'))
@@ -760,13 +775,14 @@ export async function scaleUp(
         acquired_at: new Date().toISOString(), session_birth: sessionBirth, session_name: sessionName,
         team_pane_owner_id: teamPaneOwnerId,
       };
-      if (!await writeScaledWorkerReceipt(sanitized, workerName, leaderCwd, workerReceipt)) {
+      if (!await writeScaledWorkerReceipt(sanitized, workerName, teamStateRoot, workerReceipt)) {
         return await rollbackScaleUp(`Failed to durably journal tmux authority for ${workerName}`, {
           workerName,
           worktreePath: workerWorkspace?.worktreePath,
           receipt: workerReceipt,
         });
       }
+      activeWorkerRollbackContext.receipt = workerReceipt;
 
       // Intentionally avoid forcing `select-layout tiled` here.
       // Tiled relayout reflows leader/HUD panes and breaks team window layout.
@@ -947,6 +963,7 @@ export async function scaleUp(
       config.worker_count = config.workers.length;
       config.next_worker_index = nextIndex;
       await saveTeamConfig(config, leaderCwd);
+      activeWorkerRollbackContext = {};
     }
 
     await appendTeamEvent(sanitized, {
@@ -961,6 +978,9 @@ export async function scaleUp(
       newWorkerCount: config.worker_count,
       nextWorkerIndex: nextIndex,
     };
+    } catch (error) {
+      return await rollbackScaleUp(error instanceof Error ? error.message : String(error), activeWorkerRollbackContext);
+    }
   });
 }
 
@@ -1001,6 +1021,8 @@ export async function scaleDown(
     if (!config) {
       return { ok: false, error: `Team ${sanitized} not found` };
     }
+
+    const teamStateRoot = resolveTeamStateRootForConfig(config, leaderCwd, env);
 
     // Determine which workers to remove
     let targetWorkers: WorkerInfo[];
@@ -1090,7 +1112,7 @@ export async function scaleDown(
     }
     const receipts = await Promise.all(liveTargetWorkers.map(async (worker) => ({
       worker,
-      receipt: await readScaledWorkerReceipt(sanitized, worker.name, leaderCwd),
+      receipt: await readScaledWorkerReceipt(sanitized, worker.name, teamStateRoot),
     })));
     const invalidReceipt = receipts.find(({ worker, receipt }) => (
       !receipt

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -236,6 +236,8 @@ function hasExactScaleUpTmuxAuthority(
   if (certificate.status !== 'valid' || certificate.certificate.status !== 'active') return false;
   const lifecycle = certificate.certificate;
   const sessionName = config.tmux_session;
+  const configuredSessionName = sessionName.split(':', 1)[0]?.trim() ?? '';
+  const configuredContext = sessionName.includes(':') ? sessionName : lifecycle.tmux_context;
   const leaderPaneId = config.leader_pane_id?.trim() ?? '';
   const teamPaneOwnerId = config.tmux_pane_owner_id?.trim() ?? '';
   const leaderResource = lifecycle.resources.find((resource) =>
@@ -245,10 +247,11 @@ function hasExactScaleUpTmuxAuthority(
   );
   if (
     lifecycle.team_name !== teamName
-    || lifecycle.tmux_session_name !== sessionName
+    || lifecycle.tmux_session_name !== configuredSessionName
     || lifecycle.tmux_session_birth !== sessionBirth
+    || lifecycle.tmux_context !== configuredContext
+    || !configuredContext?.startsWith(`${configuredSessionName}:`)
     || lifecycle.team_pane_owner_id !== teamPaneOwnerId
-    || !lifecycle.tmux_context
     || !leaderPaneId
     || !leaderResource?.pane_birth
   ) return false;
@@ -565,6 +568,7 @@ export async function scaleUp(
 
     const addedWorkers: WorkerInfo[] = [];
     const createdTaskIds: string[] = [];
+    const provisionedWorktrees: EnsureWorktreeResult[] = [];
 
     const rollbackScaleUp = async (
       error: string,
@@ -596,6 +600,16 @@ export async function scaleUp(
       }
       if (context.workerName && context.worktreePath && !addedWorkers.some((worker) => worker.name === context.workerName)) {
         await removeWorkerWorktreeRootAgentsFile(sanitized, context.workerName, teamStateRoot, context.worktreePath).catch(() => {});
+      }
+      if (provisionedWorktrees.length > 0) {
+        if (provisionedWorktrees.some((result) => !result.created || result.reused)) {
+          return { ok: false, error: `${error}:scale_up_rollback_preserved_reused_worktree` };
+        }
+        try {
+          await rollbackProvisionedWorktrees(provisionedWorktrees, { skipBranchDeletion: false });
+        } catch (cleanupError) {
+          return { ok: false, error: `${error}:scale_up_rollback_worktree_cleanup_failed:${String(cleanupError)}` };
+        }
       }
       for (const taskId of createdTaskIds) {
         await rm(join(leaderCwd, '.omx', 'state', 'team', sanitized, 'tasks', `task-${taskId}.json`), { force: true }).catch(() => {});
@@ -648,6 +662,7 @@ export async function scaleUp(
             workerName,
           }))
         : { enabled: false } as const;
+      if (workerWorkspaceResult.enabled) provisionedWorktrees.push(workerWorkspaceResult);
       const workerWorkspace = workerWorkspaceResult.enabled ? workerWorkspaceResult : null;
       const workerCwd = workerWorkspace ? workerWorkspace.worktreePath : leaderCwd;
 

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -241,7 +241,6 @@ function hasExactScaleUpTmuxAuthority(
   const leaderResource = lifecycle.resources.find((resource) =>
     resource.kind === 'leader'
     && resource.id === leaderPaneId
-    && resource.created
     && Boolean(resource.pane_birth?.trim()),
   );
   if (

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -52,7 +52,7 @@ import {
   type WorkerInfo,
   type WorkerStatus,
 } from './team-ops.js';
-import type { TeamLifecycleResource } from './state.js';
+import { probeTeamLifecycleGeneration, type TeamLifecycleResource } from './state.js';
 import {
   queueInboxInstruction,
   waitForDispatchReceipt,
@@ -227,6 +227,42 @@ function readTmuxSessionBirth(sessionName: string): string | null {
     return null;
   }
 }
+function hasExactScaleUpTmuxAuthority(
+  teamName: string,
+  config: TeamConfig,
+  sessionBirth: string,
+  certificate: Awaited<ReturnType<typeof probeTeamLifecycleGeneration>>,
+): boolean {
+  if (certificate.status !== 'valid' || certificate.certificate.status !== 'active') return false;
+  const lifecycle = certificate.certificate;
+  const sessionName = config.tmux_session;
+  const leaderPaneId = config.leader_pane_id?.trim() ?? '';
+  const teamPaneOwnerId = config.tmux_pane_owner_id?.trim() ?? '';
+  const leaderResource = lifecycle.resources.find((resource) =>
+    resource.kind === 'leader'
+    && resource.id === leaderPaneId
+    && resource.created
+    && Boolean(resource.pane_birth?.trim()),
+  );
+  if (
+    lifecycle.team_name !== teamName
+    || lifecycle.tmux_session_name !== sessionName
+    || lifecycle.tmux_session_birth !== sessionBirth
+    || lifecycle.team_pane_owner_id !== teamPaneOwnerId
+    || !lifecycle.tmux_context
+    || !leaderPaneId
+    || !leaderResource?.pane_birth
+  ) return false;
+  try {
+    const leaderBirth = execFileSync('tmux', [
+      'show-option', '-qv', '-p', '-t', leaderPaneId, '@omx_pane_instance_id',
+    ], { encoding: 'utf-8', stdio: 'pipe', windowsHide: true }).trim();
+    return leaderBirth === leaderResource.pane_birth;
+  } catch {
+    return false;
+  }
+}
+
 
 function tagScaledWorkerPane(
   paneId: string,
@@ -505,7 +541,12 @@ export async function scaleUp(
     // failure fails closed without probing or mutating tmux.
     const sessionBirth = readTmuxSessionBirth(sessionName);
     const teamPaneOwnerId = config.tmux_pane_owner_id?.trim();
-    if (!sessionBirth || !teamPaneOwnerId) {
+    const lifecycleCertificate = await probeTeamLifecycleGeneration(sanitized, leaderCwd);
+    if (
+      !sessionBirth
+      || !teamPaneOwnerId
+      || !hasExactScaleUpTmuxAuthority(sanitized, config, sessionBirth, lifecycleCertificate)
+    ) {
       return { ok: false, error: 'scale_up_missing_immutable_tmux_authority' };
     }
     const persistedUltragoalContext = await readPersistedTeamUltragoalContext(

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -11,7 +11,7 @@
  */
 
 import { join, resolve } from 'path';
-import { mkdir, rm } from 'fs/promises';
+import { mkdir, readFile, rename, rm, writeFile } from 'fs/promises';
 import {
   sanitizeTeamName,
   isTmuxAvailable,
@@ -21,6 +21,7 @@ import {
   isWorkerAlive,
   getWorkerPanePid,
   teardownWorkerPanes,
+  listPaneIds,
   buildWorkerStartupCommand,
   trustWorkerMiseConfigIfAvailable,
   writeWorkerStartupScriptCommand,
@@ -30,6 +31,7 @@ import {
   type TeamWorkerCli,
 } from './tmux-session.js';
 import { execFileSync, spawnSync } from 'child_process';
+import { randomUUID } from 'crypto';
 import {
   teamReadConfig as readTeamConfig,
   teamSaveConfig as saveTeamConfig,
@@ -50,6 +52,7 @@ import {
   type WorkerInfo,
   type WorkerStatus,
 } from './team-ops.js';
+import type { TeamLifecycleResource } from './state.js';
 import {
   queueInboxInstruction,
   waitForDispatchReceipt,
@@ -154,6 +157,98 @@ interface ScaleUpWorkerLaunchPlan {
   readonly workerLaunchArgs: string[];
   readonly workerCli: TeamWorkerCli;
   readonly mixedTaskRoles: readonly string[];
+}
+
+interface ScaledWorkerReceipt extends TeamLifecycleResource {
+  readonly kind: 'worker';
+  readonly role: 'worker';
+  readonly id: string;
+  readonly pane_birth: string;
+  readonly command: string;
+  readonly session_birth: string;
+  readonly session_name: string;
+  readonly team_pane_owner_id: string;
+}
+
+function scaledWorkerReceiptPath(teamName: string, workerName: string, cwd: string): string {
+  return join(cwd, '.omx', 'state', 'team', teamName, 'scaling-receipts', `${workerName}.json`);
+}
+
+async function writeScaledWorkerReceipt(
+  teamName: string,
+  workerName: string,
+  cwd: string,
+  receipt: ScaledWorkerReceipt,
+): Promise<boolean> {
+  const path = scaledWorkerReceiptPath(teamName, workerName, cwd);
+  const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    await mkdir(join(cwd, '.omx', 'state', 'team', teamName, 'scaling-receipts'), { recursive: true });
+    await writeFile(temporaryPath, `${JSON.stringify(receipt, null, 2)}\n`, { encoding: 'utf-8', flag: 'wx' });
+    await rename(temporaryPath, path);
+    return true;
+  } catch {
+    await rm(temporaryPath, { force: true }).catch(() => {});
+    return false;
+  }
+}
+
+async function readScaledWorkerReceipt(
+  teamName: string,
+  workerName: string,
+  cwd: string,
+): Promise<ScaledWorkerReceipt | null> {
+  try {
+    const value: unknown = JSON.parse(await readFile(scaledWorkerReceiptPath(teamName, workerName, cwd), 'utf-8'));
+    if (!value || typeof value !== 'object') return null;
+    const receipt = value as Partial<ScaledWorkerReceipt>;
+    return receipt.kind === 'worker'
+      && receipt.role === 'worker'
+      && typeof receipt.id === 'string'
+      && typeof receipt.pane_birth === 'string'
+      && typeof receipt.command === 'string'
+      && typeof receipt.session_birth === 'string'
+      && typeof receipt.session_name === 'string'
+      && typeof receipt.team_pane_owner_id === 'string'
+      ? receipt as ScaledWorkerReceipt
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function readTmuxSessionBirth(sessionName: string): string | null {
+  try {
+    const result = execFileSync('tmux', ['show-option', '-qv', '-t', sessionName, '@omx_instance_id'], {
+      encoding: 'utf-8', stdio: 'pipe', windowsHide: true,
+    }).trim();
+    return result || null;
+  } catch {
+    return null;
+  }
+}
+
+function tagScaledWorkerPane(
+  paneId: string,
+  ownerId: string,
+  paneBirth: string,
+): boolean {
+  try {
+    tagPaneTeamOwner(paneId, ownerId);
+    for (const [option, value] of [
+      ['@omx_team_pane_birth', paneBirth],
+      ['@omx_team_pane_role', 'worker'],
+    ] as const) {
+      execFileSync('tmux', ['set-option', '-p', '-t', paneId, option, value], { stdio: 'pipe', windowsHide: true });
+      const observed = execFileSync('tmux', ['show-option', '-qv', '-p', '-t', paneId, option], {
+        encoding: 'utf-8', stdio: 'pipe', windowsHide: true,
+      }).trim();
+      if (observed !== value) return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function buildScaleUpWorkerLaunchPlans(params: {
@@ -405,6 +500,14 @@ export async function scaleUp(
     if (!approvedExecutionGate.ok) {
       return approvedExecutionGate;
     }
+    // Immutable tmux authority is a precondition for any pane mutation, but it
+    // is checked only after the read-only approved-binding gate so a binding
+    // failure fails closed without probing or mutating tmux.
+    const sessionBirth = readTmuxSessionBirth(sessionName);
+    const teamPaneOwnerId = config.tmux_pane_owner_id?.trim();
+    if (!sessionBirth || !teamPaneOwnerId) {
+      return { ok: false, error: 'scale_up_missing_immutable_tmux_authority' };
+    }
     const persistedUltragoalContext = await readPersistedTeamUltragoalContext(
       sanitized,
       config.leader_cwd ?? leaderCwd,
@@ -425,54 +528,41 @@ export async function scaleUp(
 
     const rollbackScaleUp = async (
       error: string,
-      context: { paneId?: string; workerName?: string; worktreePath?: string } = {},
+      context: { workerName?: string; worktreePath?: string; receipt?: ScaledWorkerReceipt; unconfirmedPane?: boolean } = {},
     ): Promise<ScaleError> => {
-      for (const w of addedWorkers) {
-        const idx = config.workers.findIndex((worker) => worker.name === w.name);
-        if (idx >= 0) {
-          config.workers.splice(idx, 1);
+      const receipts = new Map<string, ScaledWorkerReceipt>();
+      for (const worker of addedWorkers) {
+        const receipt = await readScaledWorkerReceipt(sanitized, worker.name, leaderCwd);
+        if (receipt && worker.pane_id === receipt.id) receipts.set(receipt.id, receipt);
+      }
+      if (context.receipt) receipts.set(context.receipt.id, context.receipt);
+      const teardown = await teardownWorkerPanes([...receipts.keys()], {
+        leaderPaneId: config.leader_pane_id,
+        hudPaneId: config.hud_pane_id,
+        sessionName,
+        sessionBirth,
+        teamPaneOwnerId,
+        workerReceipts: Object.fromEntries(receipts),
+      });
+      if (context.unconfirmedPane || teardown.kill.succeeded !== teardown.kill.attempted || Object.values(teardown.excluded).some((count) => count > 0)) {
+        return { ok: false, error: `${error}:scale_up_rollback_teardown_unconfirmed` };
+      }
+      for (const worker of addedWorkers) {
+        const idx = config.workers.findIndex((candidate) => candidate.name === worker.name);
+        if (idx >= 0) config.workers.splice(idx, 1);
+        if (worker.worktree_path) {
+          await removeWorkerWorktreeRootAgentsFile(sanitized, worker.name, teamStateRoot, worker.worktree_path).catch(() => {});
         }
-        try {
-          if (w.pane_id) {
-            execFileSync('tmux', ['kill-pane', '-t', w.pane_id], { stdio: 'pipe',
-      windowsHide: true,
-    });
-          }
-        } catch {}
-        if (w.worktree_path) {
-          await removeWorkerWorktreeRootAgentsFile(sanitized, w.name, teamStateRoot, w.worktree_path).catch(() => {});
-        }
       }
-
-      if (
-        context.workerName &&
-        context.worktreePath &&
-        !addedWorkers.some((worker) => worker.name === context.workerName)
-      ) {
-        await removeWorkerWorktreeRootAgentsFile(
-          sanitized,
-          context.workerName,
-          teamStateRoot,
-          context.worktreePath,
-        ).catch(() => {});
+      if (context.workerName && context.worktreePath && !addedWorkers.some((worker) => worker.name === context.workerName)) {
+        await removeWorkerWorktreeRootAgentsFile(sanitized, context.workerName, teamStateRoot, context.worktreePath).catch(() => {});
       }
-
-      if (context.paneId) {
-        try {
-          execFileSync('tmux', ['kill-pane', '-t', context.paneId], { stdio: 'pipe',
-      windowsHide: true,
-    });
-        } catch {}
-      }
-
       for (const taskId of createdTaskIds) {
         await rm(join(leaderCwd, '.omx', 'state', 'team', sanitized, 'tasks', `task-${taskId}.json`), { force: true }).catch(() => {});
       }
-
       config.worker_count = config.workers.length;
       config.next_worker_index = initialNextIndex;
       await saveTeamConfig(config, leaderCwd);
-
       return { ok: false, error };
     };
 
@@ -598,20 +688,29 @@ export async function scaleUp(
       const paneId = (result.stdout || '').trim().split('\n')[0]?.trim();
       if (!paneId || !paneId.startsWith('%')) {
         return await rollbackScaleUp(`Failed to capture pane ID for ${workerName}`, {
-          paneId,
           workerName,
           worktreePath: workerWorkspace?.worktreePath,
         });
       }
-      if (config.tmux_pane_owner_id) {
-        try {
-          tagPaneTeamOwner(paneId, config.tmux_pane_owner_id);
-        } catch (error) {
-          return await rollbackScaleUp(
-            `Failed to tag tmux pane for ${workerName}: ${error instanceof Error ? error.message : String(error)}`,
-            { paneId, workerName, worktreePath: workerWorkspace?.worktreePath },
-          );
-        }
+      const paneBirth = randomUUID();
+      if (!tagScaledWorkerPane(paneId, teamPaneOwnerId, paneBirth)) {
+        return await rollbackScaleUp(`Failed to establish immutable tmux authority for ${workerName}`, {
+          workerName,
+          unconfirmedPane: true,
+          worktreePath: workerWorkspace?.worktreePath,
+        });
+      }
+      const workerReceipt: ScaledWorkerReceipt = {
+        kind: 'worker', id: paneId, created: true, pane_birth: paneBirth, command: cmd, role: 'worker',
+        acquired_at: new Date().toISOString(), session_birth: sessionBirth, session_name: sessionName,
+        team_pane_owner_id: teamPaneOwnerId,
+      };
+      if (!await writeScaledWorkerReceipt(sanitized, workerName, leaderCwd, workerReceipt)) {
+        return await rollbackScaleUp(`Failed to durably journal tmux authority for ${workerName}`, {
+          workerName,
+          worktreePath: workerWorkspace?.worktreePath,
+          receipt: workerReceipt,
+        });
       }
 
       // Intentionally avoid forcing `select-layout tiled` here.
@@ -782,9 +881,9 @@ export async function scaleUp(
       }
       if (!outcome.ok) {
         return await rollbackScaleUp(`scale_up_dispatch_failed:${workerName}:${outcome.reason}`, {
-          paneId,
           workerName,
           worktreePath: workerWorkspace?.worktreePath,
+          receipt: workerReceipt,
         });
       }
 
@@ -926,16 +1025,43 @@ export async function scaleDown(
       }
     }
 
-    // Phase 3: Kill tmux panes and remove from config
+    // Phase 3: exact receipt-authorized pane teardown before any state cleanup.
     const leaderPaneId = config.leader_pane_id;
     const hudPaneId = config.hud_pane_id;
-    const targetPaneIds = targetWorkers
-      .map((w) => w.pane_id)
-      .filter((paneId): paneId is string => typeof paneId === 'string' && paneId.trim().length > 0);
-    await teardownWorkerPanes(targetPaneIds, {
+    const livePaneIds = new Set(listPaneIds(sessionName));
+    const liveTargetWorkers = targetWorkers.filter((worker) => Boolean(worker.pane_id && livePaneIds.has(worker.pane_id)));
+    if (liveTargetWorkers.some((worker) => worker.pane_id === leaderPaneId || worker.pane_id === hudPaneId)) {
+      return { ok: false, error: 'scale_down_target_is_leader_or_hud' };
+    }
+    const receipts = await Promise.all(liveTargetWorkers.map(async (worker) => ({
+      worker,
+      receipt: await readScaledWorkerReceipt(sanitized, worker.name, leaderCwd),
+    })));
+    const invalidReceipt = receipts.find(({ worker, receipt }) => (
+      !receipt
+      || receipt.id !== worker.pane_id
+      || receipt.session_name !== sessionName
+      || receipt.team_pane_owner_id !== config.tmux_pane_owner_id
+    ));
+    if (invalidReceipt) {
+      return { ok: false, error: `scale_down_missing_exact_teardown_receipt:${invalidReceipt.worker.name}` };
+    }
+    const sessionBirth = receipts[0]?.receipt?.session_birth;
+    if (receipts.length > 0 && (!sessionBirth || receipts.some(({ receipt }) => receipt?.session_birth !== sessionBirth))) {
+      return { ok: false, error: 'scale_down_inconsistent_session_birth_receipts' };
+    }
+    const targetPaneIds = receipts.map(({ receipt }) => receipt!.id);
+    const teardown = targetPaneIds.length > 0 ? await teardownWorkerPanes(targetPaneIds, {
       leaderPaneId,
       hudPaneId,
-    });
+      sessionName,
+      sessionBirth,
+      teamPaneOwnerId: config.tmux_pane_owner_id,
+      workerReceipts: Object.fromEntries(receipts.map(({ receipt }) => [receipt!.id, receipt!])),
+    }) : { excluded: { leader: 0, hud: 0, invalid: 0 }, kill: { attempted: 0, succeeded: 0, failed: 0 } };
+    if (teardown.kill.succeeded !== targetPaneIds.length || teardown.kill.failed !== 0 || Object.values(teardown.excluded).some((count) => count > 0)) {
+      return { ok: false, error: 'scale_down_teardown_rejected_or_uncertain' };
+    }
     const detachedWorktreesToRollback: EnsureWorktreeResult[] = targetWorkers
       .filter((worker) =>
         worker.worktree_created === true
@@ -963,11 +1089,20 @@ export async function scaleDown(
       }
     }
 
-    for (const w of targetWorkers) {
-      if (w.worktree_path) {
-        await removeWorkerWorktreeRootAgentsFile(sanitized, w.name, w.team_state_root ?? config.team_state_root ?? resolveCanonicalTeamStateRoot(leaderCwd), w.worktree_path).catch(() => {});
+    for (const worker of targetWorkers) {
+      if (worker.worktree_path) {
+        try {
+          await removeWorkerWorktreeRootAgentsFile(
+            sanitized,
+            worker.name,
+            worker.team_state_root ?? config.team_state_root ?? resolveCanonicalTeamStateRoot(leaderCwd),
+            worker.worktree_path,
+          );
+        } catch (error) {
+          return { ok: false, error: `scale_down_worktree_instruction_cleanup_failed:${worker.name}:${String(error)}` };
+        }
       }
-      removedNames.push(w.name);
+      removedNames.push(worker.name);
     }
 
     // Phase 4: Update config

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -136,6 +136,13 @@ export interface TeamLifecycleGenerationCertificate {
   resources: TeamLifecycleResource[];
 }
 
+/** Result of reading an immutable Team lifecycle certificate without collapsing uncertainty. */
+export type TeamLifecycleCertificateProbe =
+  | { status: 'confirmed_missing' }
+  | { status: 'valid'; certificate: TeamLifecycleGenerationCertificate }
+  | { status: 'invalid' }
+  | { status: 'read_error'; error: NodeJS.ErrnoException };
+
 export interface WorkerInfo {
   name: string; // "worker-1"
   index: number; // tmux window index (1-based)
@@ -682,6 +689,17 @@ function lifecycleGenerationPath(teamName: string, cwd: string): string {
   return join(teamDir(teamName, cwd), 'lifecycle-generation.json');
 }
 
+type LifecycleCertificateReader = (path: string) => Promise<string>;
+let lifecycleCertificateReader: LifecycleCertificateReader = async (path) => await readFile(path, 'utf-8');
+
+export function setLifecycleCertificateReaderForTests(reader: LifecycleCertificateReader): void {
+  lifecycleCertificateReader = reader;
+}
+
+export function resetLifecycleCertificateReaderForTests(): void {
+  lifecycleCertificateReader = async (path) => await readFile(path, 'utf-8');
+}
+
 function isLifecycleCertificate(value: unknown): value is TeamLifecycleGenerationCertificate {
   if (!value || typeof value !== 'object') return false;
   const certificate = value as Partial<TeamLifecycleGenerationCertificate>;
@@ -694,13 +712,31 @@ function isLifecycleCertificate(value: unknown): value is TeamLifecycleGeneratio
         && typeof certificate.tmux_context === 'string'));
 }
 
-export async function readTeamLifecycleGeneration(teamName: string, cwd: string): Promise<TeamLifecycleGenerationCertificate | null> {
+/**
+ * Probes the immutable lifecycle certificate while preserving the distinction
+ * between absence, malformed contents, and inability to read the file.
+ */
+export async function probeTeamLifecycleGeneration(
+  teamName: string,
+  cwd: string,
+): Promise<TeamLifecycleCertificateProbe> {
   try {
-    const parsed: unknown = JSON.parse(await readFile(lifecycleGenerationPath(teamName, cwd), 'utf-8'));
-    return isLifecycleCertificate(parsed) ? parsed : null;
-  } catch {
-    return null;
+    const parsed: unknown = JSON.parse(await lifecycleCertificateReader(lifecycleGenerationPath(teamName, cwd)));
+    return isLifecycleCertificate(parsed)
+      ? { status: 'valid', certificate: parsed }
+      : { status: 'invalid' };
+  } catch (error) {
+    const errno = error as NodeJS.ErrnoException;
+    if (errno?.code === 'ENOENT') return { status: 'confirmed_missing' };
+    if (error instanceof SyntaxError) return { status: 'invalid' };
+    return { status: 'read_error', error: errno };
   }
+}
+
+/** Legacy convenience reader. Cleanup paths must use probeTeamLifecycleGeneration. */
+export async function readTeamLifecycleGeneration(teamName: string, cwd: string): Promise<TeamLifecycleGenerationCertificate | null> {
+  const probe = await probeTeamLifecycleGeneration(teamName, cwd);
+  return probe.status === 'valid' ? probe.certificate : null;
 }
 
 /** Serializes lifecycle certificate creation, status updates, and receipt appends. */
@@ -713,8 +749,10 @@ async function withLifecycleGenerationLock<T>(teamName: string, cwd: string, fn:
 export async function createTeamLifecycleGeneration(certificate: TeamLifecycleGenerationCertificate, cwd: string): Promise<boolean> {
   if (!isLifecycleCertificate(certificate) || certificate.status !== 'preparing') return false;
   return await withLifecycleGenerationLock(certificate.team_name, cwd, async () => {
-    const existing = await readTeamLifecycleGeneration(certificate.team_name, cwd);
-    if (existing) return existing.token === certificate.token;
+    const existing = await probeTeamLifecycleGeneration(certificate.team_name, cwd);
+    if (existing.status !== 'confirmed_missing') {
+      return existing.status === 'valid' && existing.certificate.token === certificate.token;
+    }
     await writeAtomic(lifecycleGenerationPath(certificate.team_name, cwd), `${JSON.stringify(certificate, null, 2)}\n`);
     return true;
   });

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -120,6 +120,13 @@ export interface TeamLifecycleResource {
 /** Immutable-generation journal. Resource entries are only appended. */
 export type TeamLifecycleGenerationStatus = 'preparing' | 'active' | 'cleanup_complete' | 'transferred';
 
+/** Terminal generations are the only certificates that authorize state removal. */
+export function isTerminalTeamLifecycleGenerationStatus(
+  status: TeamLifecycleGenerationStatus,
+): status is 'cleanup_complete' | 'transferred' {
+  return status === 'cleanup_complete' || status === 'transferred';
+}
+
 export interface TeamLifecycleGenerationCertificate {
   version: 1;
   token: string;

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -1,6 +1,6 @@
 import { appendFile, readFile, writeFile, mkdir, rm, rename, readdir } from 'fs/promises';
 import { join, dirname, resolve, sep } from 'path';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync, rmSync, openSync, fsyncSync, closeSync } from 'fs';
 import { randomUUID } from 'crypto';
 import { readUsableSessionState } from '../hooks/session.js';
 import { isTerminalPhase, type TeamPhase, type TerminalPhase } from './orchestrator.js';
@@ -99,9 +99,37 @@ export interface TeamConfig {
   resize_hook_target: string | null;
   /** Monotonic counter for worker index assignment during scaling. */
   next_worker_index?: number;
+  /** Immutable hook command generation for exact teardown. */
+  hook_generation?: string | null;
   display_name?: string;
   requested_name?: string;
   identity_source?: string;
+}
+
+export interface TeamLifecycleResource {
+  kind: 'leader' | 'worker' | 'hud' | 'hook';
+  id: string;
+  created: boolean;
+  pane_birth?: string;
+  command?: string;
+  acquired_at: string;
+}
+
+/** Immutable-generation journal. Resource entries are only appended. */
+export interface TeamLifecycleGenerationCertificate {
+  version: 1;
+  token: string;
+  team_name: string;
+  canonical_session_id: string;
+  native_session_ids: string[];
+  tmux_session_name: string | null;
+  tmux_session_birth: string | null;
+  tmux_context: string | null;
+  team_pane_owner_id: string;
+  hook_generation: string;
+  status: 'preparing' | 'active' | 'cleanup_complete' | 'transferred';
+  created_at: string;
+  resources: TeamLifecycleResource[];
 }
 
 export interface WorkerInfo {
@@ -644,6 +672,88 @@ function teamConfigPath(teamName: string, cwd: string): string {
 
 function teamManifestV2Path(teamName: string, cwd: string): string {
   return join(teamDir(teamName, cwd), 'manifest.v2.json');
+}
+
+function lifecycleGenerationPath(teamName: string, cwd: string): string {
+  return join(teamDir(teamName, cwd), 'lifecycle-generation.json');
+}
+
+function isLifecycleCertificate(value: unknown): value is TeamLifecycleGenerationCertificate {
+  if (!value || typeof value !== 'object') return false;
+  const certificate = value as Partial<TeamLifecycleGenerationCertificate>;
+  return certificate.version === 1 && typeof certificate.token === 'string'
+    && typeof certificate.team_name === 'string' && Array.isArray(certificate.resources)
+    && typeof certificate.hook_generation === 'string';
+}
+
+export async function readTeamLifecycleGeneration(teamName: string, cwd: string): Promise<TeamLifecycleGenerationCertificate | null> {
+  try {
+    const parsed: unknown = JSON.parse(await readFile(lifecycleGenerationPath(teamName, cwd), 'utf-8'));
+    return isLifecycleCertificate(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persists the immutable certificate before the first tmux mutation. */
+export async function createTeamLifecycleGeneration(certificate: TeamLifecycleGenerationCertificate, cwd: string): Promise<boolean> {
+  const existing = await readTeamLifecycleGeneration(certificate.team_name, cwd);
+  if (existing) return existing.token === certificate.token;
+  await mkdir(dirname(lifecycleGenerationPath(certificate.team_name, cwd)), { recursive: true });
+  await writeAtomic(lifecycleGenerationPath(certificate.team_name, cwd), `${JSON.stringify(certificate, null, 2)}\n`);
+  return true;
+}
+
+/** Appends acquisition evidence; duplicate entries are idempotent. */
+export async function appendTeamLifecycleResource(teamName: string, token: string, resource: TeamLifecycleResource, cwd: string): Promise<boolean> {
+  const current = await readTeamLifecycleGeneration(teamName, cwd);
+  if (!current || current.token !== token || current.status !== 'preparing') return false;
+  if (current.resources.some((entry) => entry.kind === resource.kind && entry.id === resource.id)) return true;
+  await writeAtomic(lifecycleGenerationPath(teamName, cwd), `${JSON.stringify({ ...current, resources: [...current.resources, resource] }, null, 2)}\n`);
+  return true;
+}
+
+/**
+ * Synchronously appends a receipt before a caller is allowed to issue another
+ * tmux mutation. The unique temporary file prevents a failed write from
+ * replacing the durable prior generation; a token/status mismatch is a
+ * recovery condition, never an invitation to overwrite another generation.
+ */
+export function appendTeamLifecycleResourceSync(teamName: string, token: string, resource: TeamLifecycleResource, cwd: string): boolean {
+  const path = lifecycleGenerationPath(teamName, cwd);
+  let current: TeamLifecycleGenerationCertificate;
+  try {
+    current = JSON.parse(readFileSync(path, 'utf8')) as TeamLifecycleGenerationCertificate;
+  } catch {
+    return false;
+  }
+  if (!isLifecycleCertificate(current) || current.token !== token || current.status !== 'preparing') return false;
+  if (current.resources.some((entry) => entry.kind === resource.kind && entry.id === resource.id)) return true;
+  const next = { ...current, resources: [...current.resources, resource] };
+  const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(temporaryPath, `${JSON.stringify(next, null, 2)}\n`, 'utf8');
+    const descriptor = openSync(temporaryPath, 'r');
+    try { fsyncSync(descriptor); } finally { closeSync(descriptor); }
+    renameSync(temporaryPath, path);
+    return true;
+  } catch {
+    try { rmSync(temporaryPath, { force: true }); } catch { /* preserve prior certificate */ }
+    return false;
+  }
+}
+
+export async function finalizeTeamLifecycleGeneration(
+  teamName: string,
+  token: string,
+  status: Extract<TeamLifecycleGenerationCertificate['status'], 'active' | 'cleanup_complete' | 'transferred'>,
+  cwd: string,
+): Promise<boolean> {
+  const current = await readTeamLifecycleGeneration(teamName, cwd);
+  if (!current || current.token !== token || current.status !== 'preparing') return false;
+  await writeAtomic(lifecycleGenerationPath(teamName, cwd), `${JSON.stringify({ ...current, status }, null, 2)}\n`);
+  return true;
 }
 
 function taskClaimLockDir(teamName: string, taskId: string, cwd: string): string {

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -428,6 +428,35 @@ export function setWriteAtomicRenameForTests(fn: typeof rename): void {
 export function resetWriteAtomicRenameForTests(): void {
   renameForAtomicWrite = rename;
 }
+
+
+type DirectorySyncForAtomicWrite = (directory: string) => Promise<void>;
+
+async function syncDirectoryForAtomicWrite(directory: string): Promise<void> {
+  const handle = await openFile(directory, 'r');
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+let syncDirectoryAfterAtomicWrite: DirectorySyncForAtomicWrite = syncDirectoryForAtomicWrite;
+
+export function setWriteAtomicDirectorySyncForTests(fn: DirectorySyncForAtomicWrite): void {
+  syncDirectoryAfterAtomicWrite = fn;
+}
+
+export function resetWriteAtomicDirectorySyncForTests(): void {
+  syncDirectoryAfterAtomicWrite = syncDirectoryForAtomicWrite;
+}
+
+function isUnsupportedDirectorySyncError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('code' in error)) return false;
+  const code = (error as { code?: unknown }).code;
+  return code === 'EPERM' || code === 'EINVAL' || code === 'ENOTSUP' || code === 'EOPNOTSUPP';
+}
+
 export type TaskReadiness =
   | { ready: true }
   | { ready: false; reason: 'blocked_dependency'; dependencies: string[] };
@@ -981,11 +1010,10 @@ export async function writeAtomic(filePath: string, data: string): Promise<void>
     throw error;
   }
 
-  const directory = await openFile(parent, 'r');
   try {
-    await directory.sync();
-  } finally {
-    await directory.close();
+    await syncDirectoryAfterAtomicWrite(parent);
+  } catch (error) {
+    if (!isUnsupportedDirectorySyncError(error)) throw error;
   }
 }
 

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -1,4 +1,4 @@
-import { appendFile, readFile, writeFile, mkdir, rm, rename, readdir } from 'fs/promises';
+import { appendFile, readFile, writeFile, mkdir, rm, rename, readdir, open as openFile } from 'fs/promises';
 import { join, dirname, resolve, sep } from 'path';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync, rmSync, openSync, fsyncSync, closeSync } from 'fs';
 import { randomUUID } from 'crypto';
@@ -118,6 +118,8 @@ export interface TeamLifecycleResource {
 }
 
 /** Immutable-generation journal. Resource entries are only appended. */
+export type TeamLifecycleGenerationStatus = 'preparing' | 'active' | 'cleanup_complete' | 'transferred';
+
 export interface TeamLifecycleGenerationCertificate {
   version: 1;
   token: string;
@@ -129,7 +131,7 @@ export interface TeamLifecycleGenerationCertificate {
   tmux_context: string | null;
   team_pane_owner_id: string;
   hook_generation: string;
-  status: 'preparing' | 'active' | 'cleanup_complete' | 'transferred';
+  status: TeamLifecycleGenerationStatus;
   created_at: string;
   resources: TeamLifecycleResource[];
 }
@@ -701,22 +703,32 @@ export async function readTeamLifecycleGeneration(teamName: string, cwd: string)
   }
 }
 
+/** Serializes lifecycle certificate creation, status updates, and receipt appends. */
+async function withLifecycleGenerationLock<T>(teamName: string, cwd: string, fn: () => Promise<T>): Promise<T> {
+  await mkdir(teamDir(teamName, cwd), { recursive: true });
+  return await withTeamLock(teamName, cwd, fn);
+}
+
 /** Persists the immutable certificate before the first tmux mutation. */
 export async function createTeamLifecycleGeneration(certificate: TeamLifecycleGenerationCertificate, cwd: string): Promise<boolean> {
-  const existing = await readTeamLifecycleGeneration(certificate.team_name, cwd);
-  if (existing) return existing.token === certificate.token;
-  await mkdir(dirname(lifecycleGenerationPath(certificate.team_name, cwd)), { recursive: true });
-  await writeAtomic(lifecycleGenerationPath(certificate.team_name, cwd), `${JSON.stringify(certificate, null, 2)}\n`);
-  return true;
+  if (!isLifecycleCertificate(certificate) || certificate.status !== 'preparing') return false;
+  return await withLifecycleGenerationLock(certificate.team_name, cwd, async () => {
+    const existing = await readTeamLifecycleGeneration(certificate.team_name, cwd);
+    if (existing) return existing.token === certificate.token;
+    await writeAtomic(lifecycleGenerationPath(certificate.team_name, cwd), `${JSON.stringify(certificate, null, 2)}\n`);
+    return true;
+  });
 }
 
 /** Appends acquisition evidence; duplicate entries are idempotent. */
 export async function appendTeamLifecycleResource(teamName: string, token: string, resource: TeamLifecycleResource, cwd: string): Promise<boolean> {
-  const current = await readTeamLifecycleGeneration(teamName, cwd);
-  if (!current || current.token !== token || current.status !== 'preparing') return false;
-  if (current.resources.some((entry) => entry.kind === resource.kind && entry.id === resource.id)) return true;
-  await writeAtomic(lifecycleGenerationPath(teamName, cwd), `${JSON.stringify({ ...current, resources: [...current.resources, resource] }, null, 2)}\n`);
-  return true;
+  return await withLifecycleGenerationLock(teamName, cwd, async () => {
+    const current = await readTeamLifecycleGeneration(teamName, cwd);
+    if (!current || current.token !== token || current.status !== 'preparing') return false;
+    if (current.resources.some((entry) => entry.kind === resource.kind && entry.id === resource.id)) return true;
+    await writeAtomic(lifecycleGenerationPath(teamName, cwd), `${JSON.stringify({ ...current, resources: [...current.resources, resource] }, null, 2)}\n`);
+    return true;
+  });
 }
 
 /**
@@ -727,26 +739,38 @@ export async function appendTeamLifecycleResource(teamName: string, token: strin
  */
 export function appendTeamLifecycleResourceSync(teamName: string, token: string, resource: TeamLifecycleResource, cwd: string): boolean {
   const path = lifecycleGenerationPath(teamName, cwd);
-  let current: TeamLifecycleGenerationCertificate;
+  const lockDir = join(teamDir(teamName, cwd), '.lock.create-task');
   try {
-    current = JSON.parse(readFileSync(path, 'utf8')) as TeamLifecycleGenerationCertificate;
+    mkdirSync(lockDir);
   } catch {
+    // A concurrent asynchronous lifecycle write owns the same lock. Do not block
+    // the event loop waiting for it: an unacknowledged receipt must fail closed.
     return false;
   }
-  if (!isLifecycleCertificate(current) || current.token !== token || current.status !== 'preparing') return false;
-  if (current.resources.some((entry) => entry.kind === resource.kind && entry.id === resource.id)) return true;
-  const next = { ...current, resources: [...current.resources, resource] };
+
   const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
   try {
-    mkdirSync(dirname(path), { recursive: true });
+    let current: TeamLifecycleGenerationCertificate;
+    try {
+      current = JSON.parse(readFileSync(path, 'utf8')) as TeamLifecycleGenerationCertificate;
+    } catch {
+      return false;
+    }
+    if (!isLifecycleCertificate(current) || current.token !== token || current.status !== 'preparing') return false;
+    if (current.resources.some((entry) => entry.kind === resource.kind && entry.id === resource.id)) return true;
+    const next = { ...current, resources: [...current.resources, resource] };
     writeFileSync(temporaryPath, `${JSON.stringify(next, null, 2)}\n`, 'utf8');
     const descriptor = openSync(temporaryPath, 'r');
     try { fsyncSync(descriptor); } finally { closeSync(descriptor); }
     renameSync(temporaryPath, path);
+    const directoryDescriptor = openSync(dirname(path), 'r');
+    try { fsyncSync(directoryDescriptor); } finally { closeSync(directoryDescriptor); }
     return true;
   } catch {
     try { rmSync(temporaryPath, { force: true }); } catch { /* preserve prior certificate */ }
     return false;
+  } finally {
+    try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* fail closed above */ }
   }
 }
 
@@ -757,11 +781,25 @@ export async function finalizeTeamLifecycleGeneration(
   cwd: string,
   identity?: Pick<TeamLifecycleGenerationCertificate, 'tmux_session_name' | 'tmux_session_birth' | 'tmux_context'>,
 ): Promise<boolean> {
-  const current = await readTeamLifecycleGeneration(teamName, cwd);
-  if (!current || current.token !== token || current.status !== 'preparing') return false;
-  if (status === 'active' && (!identity?.tmux_session_name || !identity.tmux_session_birth || !identity.tmux_context)) return false;
-  await writeAtomic(lifecycleGenerationPath(teamName, cwd), `${JSON.stringify({ ...current, ...identity, status }, null, 2)}\n`);
-  return true;
+  return await withLifecycleGenerationLock(teamName, cwd, async () => {
+    const current = await readTeamLifecycleGeneration(teamName, cwd);
+    if (!current || current.token !== token) return false;
+    if (status === 'active') {
+      if (current.status !== 'preparing' || !identity?.tmux_session_name || !identity.tmux_session_birth || !identity.tmux_context) return false;
+    } else if (status === 'cleanup_complete') {
+      if (
+        current.status !== 'active'
+        || !identity
+        || identity.tmux_session_name !== current.tmux_session_name
+        || identity.tmux_session_birth !== current.tmux_session_birth
+        || identity.tmux_context !== current.tmux_context
+      ) return false;
+    } else if (current.status !== 'preparing') {
+      return false;
+    }
+    await writeAtomic(lifecycleGenerationPath(teamName, cwd), `${JSON.stringify({ ...current, ...identity, status }, null, 2)}\n`);
+    return true;
+  });
 }
 
 function taskClaimLockDir(teamName: string, taskId: string, cwd: string): string {
@@ -869,13 +907,19 @@ function isTeamManifestV2(value: unknown): value is TeamManifestV2 {
   return true;
 }
 
-// Atomic write: write to {path}.tmp.{pid}, then rename
+// Atomic write: fsync the temporary file, rename it into place, then fsync its directory.
 export async function writeAtomic(filePath: string, data: string): Promise<void> {
   const parent = dirname(filePath);
   await mkdir(parent, { recursive: true });
 
   const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
   await writeFile(tmpPath, data, 'utf8');
+  const temporaryFile = await openFile(tmpPath, 'r');
+  try {
+    await temporaryFile.sync();
+  } finally {
+    await temporaryFile.close();
+  }
 
   try {
     await renameForAtomicWrite(tmpPath, filePath);
@@ -890,6 +934,13 @@ export async function writeAtomic(filePath: string, data: string): Promise<void>
       }
     }
     throw error;
+  }
+
+  const directory = await openFile(parent, 'r');
+  try {
+    await directory.sync();
+  } finally {
+    await directory.close();
   }
 }
 

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -111,7 +111,9 @@ export interface TeamLifecycleResource {
   id: string;
   created: boolean;
   pane_birth?: string;
+  /** Exact pane_start_command or hook generation captured at acquisition. */
   command?: string;
+  role?: 'worker' | 'hud' | 'leader';
   acquired_at: string;
 }
 
@@ -683,7 +685,11 @@ function isLifecycleCertificate(value: unknown): value is TeamLifecycleGeneratio
   const certificate = value as Partial<TeamLifecycleGenerationCertificate>;
   return certificate.version === 1 && typeof certificate.token === 'string'
     && typeof certificate.team_name === 'string' && Array.isArray(certificate.resources)
-    && typeof certificate.hook_generation === 'string';
+    && typeof certificate.hook_generation === 'string'
+    && (certificate.status === 'preparing'
+      || (typeof certificate.tmux_session_name === 'string'
+        && typeof certificate.tmux_session_birth === 'string'
+        && typeof certificate.tmux_context === 'string'));
 }
 
 export async function readTeamLifecycleGeneration(teamName: string, cwd: string): Promise<TeamLifecycleGenerationCertificate | null> {
@@ -749,10 +755,12 @@ export async function finalizeTeamLifecycleGeneration(
   token: string,
   status: Extract<TeamLifecycleGenerationCertificate['status'], 'active' | 'cleanup_complete' | 'transferred'>,
   cwd: string,
+  identity?: Pick<TeamLifecycleGenerationCertificate, 'tmux_session_name' | 'tmux_session_birth' | 'tmux_context'>,
 ): Promise<boolean> {
   const current = await readTeamLifecycleGeneration(teamName, cwd);
   if (!current || current.token !== token || current.status !== 'preparing') return false;
-  await writeAtomic(lifecycleGenerationPath(teamName, cwd), `${JSON.stringify({ ...current, status }, null, 2)}\n`);
+  if (status === 'active' && (!identity?.tmux_session_name || !identity.tmux_session_birth || !identity.tmux_context)) return false;
+  await writeAtomic(lifecycleGenerationPath(teamName, cwd), `${JSON.stringify({ ...current, ...identity, status }, null, 2)}\n`);
   return true;
 }
 

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -41,6 +41,8 @@ export interface TeamLifecycleResource {
   acquired_at: string;
 }
 
+export type TeamLifecycleGenerationStatus = 'preparing' | 'active' | 'cleanup_complete' | 'transferred';
+
 export interface TeamLifecycleGenerationCertificate {
   version: 1;
   token: string;
@@ -52,7 +54,7 @@ export interface TeamLifecycleGenerationCertificate {
   tmux_context: string | null;
   team_pane_owner_id: string;
   hook_generation: string;
-  status: 'preparing' | 'active' | 'cleanup_complete' | 'transferred';
+  status: TeamLifecycleGenerationStatus;
   created_at: string;
   resources: TeamLifecycleResource[];
 }

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -35,7 +35,9 @@ export interface TeamLifecycleResource {
   id: string;
   created: boolean;
   pane_birth?: string;
+  /** Exact pane_start_command or hook generation captured at acquisition. */
   command?: string;
+  role?: 'worker' | 'hud' | 'leader';
   acquired_at: string;
 }
 

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -59,6 +59,13 @@ export interface TeamLifecycleGenerationCertificate {
   resources: TeamLifecycleResource[];
 }
 
+/** Result of reading an immutable Team lifecycle certificate without collapsing uncertainty. */
+export type TeamLifecycleCertificateProbe =
+  | { status: 'confirmed_missing' }
+  | { status: 'valid'; certificate: TeamLifecycleGenerationCertificate }
+  | { status: 'invalid' }
+  | { status: 'read_error'; error: NodeJS.ErrnoException };
+
 export interface WorkerInfo {
   name: string;
   index: number;

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -25,6 +25,34 @@ export interface TeamConfig {
   resize_hook_name: string | null;
   resize_hook_target: string | null;
   next_worker_index?: number;
+  /** Immutable hook command generation for exact teardown. */
+  hook_generation?: string | null;
+}
+
+/** Durable, append-only evidence for one interactive Team tmux generation. */
+export interface TeamLifecycleResource {
+  kind: 'leader' | 'worker' | 'hud' | 'hook';
+  id: string;
+  created: boolean;
+  pane_birth?: string;
+  command?: string;
+  acquired_at: string;
+}
+
+export interface TeamLifecycleGenerationCertificate {
+  version: 1;
+  token: string;
+  team_name: string;
+  canonical_session_id: string;
+  native_session_ids: string[];
+  tmux_session_name: string | null;
+  tmux_session_birth: string | null;
+  tmux_context: string | null;
+  team_pane_owner_id: string;
+  hook_generation: string;
+  status: 'preparing' | 'active' | 'cleanup_complete' | 'transferred';
+  created_at: string;
+  resources: TeamLifecycleResource[];
 }
 
 export interface WorkerInfo {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -53,23 +53,22 @@ const OMX_TEAM_PANE_ROLE_OPTION = '@omx_team_pane_role';
 
 
 export interface TeamSession {
-  name: string; // tmux target in "session:window" form
+  name: string;
   workerCount: number;
   cwd: string;
   workerPaneIds: string[];
-  /** Leader's own pane ID — must never be targeted by worker cleanup routines. */
   leaderPaneId: string;
-  /** HUD pane spawned below the leader column, or null if creation failed. */
   hudPaneId: string | null;
-  /** Registered tmux resize hook name for the HUD pane, or null if unavailable. */
   resizeHookName: string | null;
-  /** Registered tmux resize hook target in "<session>:<window>" form, or null. */
   resizeHookTarget: string | null;
-  /** Team-scoped tmux pane ownership token used by shutdown safety checks. */
   teamPaneOwnerId: string;
-  /** Opaque births captured after exact tmux tagging; required for lifecycle recovery. */
+  tmuxSessionName: string;
+  tmuxSessionBirth: string;
+  tmuxContext: string;
   workerPaneBirths?: Record<string, string>;
+  workerPaneCommands?: Record<string, string>;
   hudPaneBirth?: string | null;
+  hudPaneCommand?: string | null;
 }
 
 export interface CreateTeamSessionOptions {
@@ -588,19 +587,21 @@ function findExactTeamHudPaneIds(target: string, candidate: ExactTeamHudCandidat
     .map((pane) => pane.paneId);
 }
 
-/** Kills only a still-exact HUD pane, with tmux evaluating identity immediately before kill. */
+/** Kills only an immutable journaled HUD generation, with tmux evaluating every identity immediately before kill. */
 export function killExactTeamHudPane(
   target: string,
   paneId: string,
   candidate: ExactTeamHudCandidate,
   teamOwnerId?: string,
+  receipt?: TeamLifecycleResource,
 ): boolean {
+  if (!receipt || receipt.kind !== 'hud' || receipt.id !== paneId || receipt.role !== 'hud'
+    || !receipt.pane_birth || !receipt.command || !teamOwnerId) return false;
   if (!findExactTeamHudPaneIds(target, candidate).includes(paneId)) return false;
   const sessionName = candidate.tmuxSessionName ?? target.split(':')[0] ?? '';
-  const ownerCondition = teamOwnerId ? `,#{==:#{@omx_team_pane_owner_id},${teamOwnerId}}` : '';
-  const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{@omx_pane_instance_id},${candidate.tmuxPaneInstanceId}},#{==:#{@omx_instance_id},${candidate.tmuxSessionInstanceId}},#{==:#{session_name},${sessionName}}${ownerCondition}}`;
+  if (!sessionName || !candidate.tmuxSessionInstanceId || !candidate.tmuxPaneInstanceId) return false;
+  const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{pane_start_command},${receipt.command}},#{==:#{@omx_pane_instance_id},${candidate.tmuxPaneInstanceId}},#{==:#{@omx_instance_id},${candidate.tmuxSessionInstanceId}},#{==:#{session_name},${sessionName}},#{==:#{@omx_team_pane_owner_id},${teamOwnerId}},#{==:#{@omx_team_pane_birth},${receipt.pane_birth}},#{==:#{@omx_team_pane_role},hud}}`;
   const result = runTmux(['if-shell', '-t', paneId, '-F', condition, `kill-pane -t ${paneId}`, '']);
-
   return result.ok && !findExactTeamHudPaneIds(target, candidate).includes(paneId);
 }
 
@@ -937,23 +938,32 @@ function buildBestEffortShellCommand(command: string): string {
   return `${command} >/dev/null 2>&1 || true`;
 }
 
-/** Upper bound for tmux hook indices (signed 32-bit max). */
-const TMUX_HOOK_INDEX_MAX = 2147483647;
 
-function buildResizeHookSlot(hookName: string): string {
-  let hash = 0;
-  for (let i = 0; i < hookName.length; i++) {
-    hash = (hash * 31 + hookName.charCodeAt(i)) | 0;
-  }
-  return `client-resized[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
+
+export interface TeamHudHookEvidence {
+  sessionName: string;
+  windowIndex: string;
+  sessionBirth: string;
+  hudPaneId: string;
+  hudPaneBirth: string;
+  ownerId: string;
+  generation: string;
 }
 
-function buildClientAttachedHookSlot(hookName: string): string {
-  let hash = 0;
-  for (let i = 0; i < hookName.length; i++) {
-    hash = (hash * 31 + hookName.charCodeAt(i)) | 0;
-  }
-  return `client-attached[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
+function teamHookActiveOption(generation: string): string {
+  return `@omx_team_hook_active_${generation.replace(/[^a-zA-Z0-9_]/g, '_')}`;
+}
+
+function buildTeamHookCommand(
+  hookCommand: string,
+  evidence?: TeamHudHookEvidence,
+): string {
+  const generation = evidence?.generation?.trim() ?? '';
+  const active = generation ? teamHookActiveOption(generation) : '';
+  const condition = evidence
+    ? `#{&&:#{==:#{pane_id},${buildHudPaneTarget(evidence.hudPaneId)}},#{==:#{session_name},${evidence.sessionName}},#{==:#{window_index},${evidence.windowIndex}},#{==:#{@omx_instance_id},${evidence.sessionBirth}},#{==:#{@omx_team_pane_owner_id},${evidence.ownerId}},#{==:#{@omx_team_pane_birth},${evidence.hudPaneBirth}},#{==:#{@omx_team_pane_role},hud},#{==:#{${active}},1}}`
+    : '#{==:0,1}';
+  return `if-shell -t ${buildHudPaneTarget(evidence?.hudPaneId ?? '')} -F ${shellQuoteSingle(condition)} ${shellQuoteSingle(`run-shell -b ${hookCommand}`)} ''${generation ? ` # omx-generation=${generation}` : ''}`;
 }
 
 export function buildRegisterResizeHookArgs(
@@ -962,16 +972,20 @@ export function buildRegisterResizeHookArgs(
   hudPaneId: string,
   heightLines: number = HUD_TMUX_TEAM_HEIGHT_LINES,
   generation?: string,
+  evidence?: Omit<TeamHudHookEvidence, 'generation'>,
 ): string[] {
   const resizeCommand = buildBestEffortShellCommand(buildNestedTmuxShellCommand(buildHudResizeCommand(hudPaneId, heightLines)));
-  const hookCommand = shellQuoteSingle(
-    `${resizeCommand}; sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; ${resizeCommand}`,
-  );
-  return ['set-hook', '-t', hookTarget, buildResizeHookSlot(hookName), `run-shell -b ${hookCommand}${generation ? ` # omx-generation=${generation}` : ''}`];
+  void hookName;
+  return [
+    'set-hook', '-a', '-t', hookTarget, 'client-resized',
+    buildTeamHookCommand(resizeCommand, generation && evidence ? { ...evidence, generation } : undefined),
+  ];
 }
 
+/** Deprecated diagnostic helper: append-only registrations are never removed live. */
 export function buildUnregisterResizeHookArgs(hookTarget: string, hookName: string): string[] {
-  return ['set-hook', '-u', '-t', hookTarget, buildResizeHookSlot(hookName)];
+  void hookName;
+  return ['show-hooks', '-t', hookTarget, 'client-resized'];
 }
 
 export function buildClientAttachedReconcileHookName(
@@ -995,50 +1009,36 @@ export function buildRegisterClientAttachedReconcileArgs(
   hudPaneId: string,
   heightLines: number = HUD_TMUX_TEAM_HEIGHT_LINES,
   generation?: string,
+  evidence?: Omit<TeamHudHookEvidence, 'generation'>,
 ): string[] {
-  const hookSlot = buildClientAttachedHookSlot(hookName);
-  // Keep the owned command installed until transactional lifecycle cleanup. A shell
-  // callback cannot safely prove it is still the same hook after queueing.
-  const oneShotCommand = shellQuoteSingle(
-    buildBestEffortShellCommand(buildNestedTmuxShellCommand(buildHudResizeCommand(hudPaneId, heightLines))),
-  );
-  return ['set-hook', '-t', hookTarget, hookSlot, `run-shell -b ${oneShotCommand}${generation ? ` # omx-generation=${generation}` : ''}`];
+  void hookName;
+  const oneShotCommand = buildBestEffortShellCommand(buildNestedTmuxShellCommand(buildHudResizeCommand(hudPaneId, heightLines)));
+  return [
+    'set-hook', '-a', '-t', hookTarget, 'client-attached',
+    buildTeamHookCommand(oneShotCommand, generation && evidence ? { ...evidence, generation } : undefined),
+  ];
 }
 
+/** Deprecated diagnostic helper: append-only registrations are never removed live. */
 export function buildUnregisterClientAttachedReconcileArgs(hookTarget: string, hookName: string): string[] {
-  return ['set-hook', '-u', '-t', hookTarget, buildClientAttachedHookSlot(hookName)];
+  void hookName;
+  return ['show-hooks', '-t', hookTarget, 'client-attached'];
 }
 
-export function unregisterResizeHook(hookTarget: string, hookName: string): boolean {
-  const result = runTmux(buildUnregisterResizeHookArgs(hookTarget, hookName));
-  return result.ok;
-}
-
-export function unregisterClientAttachedReconcileHook(hookTarget: string, hookName: string): boolean {
-  const result = runTmux(buildUnregisterClientAttachedReconcileArgs(hookTarget, hookName));
-  return result.ok;
-}
-
-/** One tmux-server conditional mutation; foreign or newer hook commands survive. */
-function mutateHudHookIfCurrent(hookTarget: string, slot: string, expected: string | null, next: string | null): boolean {
-  const expectedLine = expected === null ? '' : `${slot} ${expected}`;
-  const condition = expected === null
-    ? `test -z "$(tmux show-hooks -t ${shellQuoteSingle(hookTarget)} ${shellQuoteSingle(slot)})"`
-    : `test "$(tmux show-hooks -t ${shellQuoteSingle(hookTarget)} ${shellQuoteSingle(slot)})" = ${shellQuoteSingle(expectedLine)}`;
-  const mutation = next === null
-    ? `set-hook -u -t ${shellQuoteSingle(hookTarget)} ${shellQuoteSingle(slot)}`
-    : `set-hook -t ${shellQuoteSingle(hookTarget)} ${shellQuoteSingle(slot)} ${shellQuoteSingle(next)}`;
-  const result = runTmux(['if-shell', '-t', hookTarget, condition, mutation, '']);
+function appendHudHook(hookTarget: string, args: string[]): boolean {
+  const event = args[4]?.trim() ?? '';
+  const command = args[5] ?? '';
+  if (!event || !command) return false;
+  const result = runTmux(args);
   if (!result.ok) return false;
-  const readback = runTmux(['show-hooks', '-t', hookTarget, slot]);
-  return readback.ok && readback.stdout.trim() === (next === null ? '' : `${slot} ${next}`);
+  // Discover the server-assigned numeric slot and exact command for durable recovery diagnostics.
+  const observed = runTmux(['show-hooks', '-t', hookTarget, event]);
+  return observed.ok && observed.stdout.includes(command);
 }
 
-/** Registers only an empty hook slot; callers retain metadata on uncertainty. */
+/** Appends a hook; no existing hook slot is inspected, replaced, or authorized by a sidecar. */
 export function registerHudHookIfVacant(hookTarget: string, args: string[]): boolean {
-  const slot = args[3]?.trim() ?? '';
-  const command = args[4] ?? '';
-  return Boolean(slot && command && mutateHudHookIfCurrent(hookTarget, slot, null, command));
+  return appendHudHook(hookTarget, args);
 }
 
 export function registerHudHooksTransactionally(
@@ -1047,20 +1047,18 @@ export function registerHudHooksTransactionally(
   clientAttachedHookName: string,
   hudPaneId: string,
   generation?: string,
+  evidence?: Omit<TeamHudHookEvidence, 'generation'>,
 ): boolean {
-  const resizeArgs = buildRegisterResizeHookArgs(hookTarget, resizeHookName, hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, generation);
-  const attachedArgs = buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, generation);
-  const resizeSlot = resizeArgs[3]!;
-  const attachedSlot = attachedArgs[3]!;
-  const resizeCommand = resizeArgs[4]!;
-  const attachedCommand = attachedArgs[4]!;
-  if (!mutateHudHookIfCurrent(hookTarget, resizeSlot, null, resizeCommand)) return false;
-  if (mutateHudHookIfCurrent(hookTarget, attachedSlot, null, attachedCommand)) return true;
-  mutateHudHookIfCurrent(hookTarget, resizeSlot, resizeCommand, null);
-  return false;
+  if (!generation || !evidence) return false;
+  // Enable before append. A partial pair is safe: both commands are generation-gated
+  // and later teardown only makes this generation inert.
+  if (!runTmux(['set-option', '-t', hookTarget, teamHookActiveOption(generation), '1']).ok) return false;
+  const resizeArgs = buildRegisterResizeHookArgs(hookTarget, resizeHookName, hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, generation, evidence);
+  const attachedArgs = buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, generation, evidence);
+  return appendHudHook(hookTarget, resizeArgs) && appendHudHook(hookTarget, attachedArgs);
 }
 
-/** Teardown removes exactly the generation we installed; no snapshot/restore race. */
+/** Makes this generation inert. It deliberately retains every tmux hook receipt and slot. */
 export function unregisterHudHooksTransactionally(
   hookTarget: string,
   resizeHookName: string,
@@ -1068,11 +1066,11 @@ export function unregisterHudHooksTransactionally(
   hudPaneId: string,
   generation?: string,
 ): boolean {
-  const resizeArgs = buildRegisterResizeHookArgs(hookTarget, resizeHookName, hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, generation);
-  const attachedArgs = buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, generation);
-  const attachedRemoved = mutateHudHookIfCurrent(hookTarget, attachedArgs[3]!, attachedArgs[4]!, null);
-  const resizeRemoved = mutateHudHookIfCurrent(hookTarget, resizeArgs[3]!, resizeArgs[4]!, null);
-  return attachedRemoved && resizeRemoved;
+  void resizeHookName;
+  void clientAttachedHookName;
+  void hudPaneId;
+  if (!generation) return false;
+  return runTmux(['set-option', '-t', hookTarget, teamHookActiveOption(generation), '0']).ok;
 }
 
 export function buildScheduleDelayedHudResizeArgs(
@@ -1942,8 +1940,12 @@ export function createTeamSession(
   const safeTeamName = sanitizeTeamName(teamName);
   let registeredResizeHook: { name: string; target: string } | null = null;
   let registeredClientAttachedHook: { name: string; target: string } | null = null;
+  let registeredHudPaneId: string | null = null;
   const rollbackPaneIds: string[] = [];
   const rollbackPaneBirths = new Map<string, string>();
+  const workerPaneCommands = new Map<string, string>();
+  const rollbackPaneRoles = new Map<string, 'worker' | 'hud'>();
+  let createdHudPaneCommand: string | null = null;
   let createdHudPaneBirth: string | null = null;
 
   let rollbackOwnerSessionId = '';
@@ -2076,11 +2078,17 @@ export function createTeamSession(
       tagTeamPaneBirth(paneId, paneBirth);
       rollbackPaneBirths.set(paneId, paneBirth);
       tagTeamPaneRole(paneId, 'worker');
+      const paneCommand = listPanes(teamTarget).find((pane) => pane.paneId === paneId)?.startCommand ?? '';
+      if (!paneCommand) throw new Error(`failed to capture immutable worker command for ${paneId}`);
+      workerPaneCommands.set(paneId, paneCommand);
+      rollbackPaneRoles.set(paneId, 'worker');
       options.journalResource?.({
         kind: 'worker',
         id: paneId,
         created: true,
         pane_birth: paneBirth,
+        command: paneCommand,
+        role: 'worker',
         acquired_at: new Date().toISOString(),
       });
 
@@ -2148,11 +2156,17 @@ export function createTeamSession(
             rollbackPaneBirths.set(id, paneBirth);
             createdHudPaneBirth = paneBirth;
             tagTeamPaneRole(id, 'hud');
+            const paneCommand = listPanes(teamTarget).find((pane) => pane.paneId === id)?.startCommand ?? '';
+            if (!paneCommand) throw new Error(`failed to capture immutable HUD command for ${id}`);
+            createdHudPaneCommand = paneCommand;
+            rollbackPaneRoles.set(id, 'hud');
             options.journalResource?.({
               kind: 'hud',
               id,
               created: true,
               pane_birth: paneBirth,
+              command: paneCommand,
+              role: 'hud',
               acquired_at: new Date().toISOString(),
             });
 
@@ -2176,15 +2190,39 @@ export function createTeamSession(
               windowIndex,
               hudPaneId,
             );
-            // Persist both prospective hook slots before their first CAS. A failed
-            // CAS remains recovery evidence rather than a reason to discard metadata.
+            // Persist every append-only hook receipt before registration. The exact
+            // command and server-assigned slot are recovery diagnostics, never mutation authority.
             options.journalResource?.({ kind: 'hook', id: hookName, created: true, command: options.hookGeneration, acquired_at: new Date().toISOString() });
             options.journalResource?.({ kind: 'hook', id: clientAttachedHookName, created: true, command: options.hookGeneration, acquired_at: new Date().toISOString() });
-            if (registerHudHooksTransactionally(hookTarget, hookName, clientAttachedHookName, hudPaneId, options.hookGeneration)) {
+            const hookSessionBirth = runTmux(['show-options', '-qv', '-t', sessionName, OMX_INSTANCE_OPTION]);
+            const hookEvidence = createdHudPaneBirth && options.hookGeneration && hookSessionBirth.ok && hookSessionBirth.stdout.trim()
+              ? {
+                  sessionName,
+                  windowIndex,
+                  sessionBirth: hookSessionBirth.stdout.trim(),
+                  hudPaneId,
+                  hudPaneBirth: createdHudPaneBirth,
+                  ownerId: teamPaneOwnerId,
+                }
+              : null;
+            if (hookEvidence && registerHudHooksTransactionally(hookTarget, hookName, clientAttachedHookName, hudPaneId, options.hookGeneration, hookEvidence)) {
               resizeHookTarget = hookTarget;
               resizeHookName = hookName;
               registeredResizeHook = { name: resizeHookName, target: resizeHookTarget };
               registeredClientAttachedHook = { name: clientAttachedHookName, target: hookTarget };
+              registeredHudPaneId = hudPaneId;
+              for (const [event, hookCommand, hookId] of [
+                ['client-resized', buildRegisterResizeHookArgs(hookTarget, hookName, hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, options.hookGeneration, hookEvidence)[5] ?? '', hookName],
+                ['client-attached', buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, options.hookGeneration, hookEvidence)[5] ?? '', clientAttachedHookName],
+              ] as const) {
+                const observed = runTmux(['show-hooks', '-t', hookTarget, event]);
+                const receipt = observed.ok
+                  ? observed.stdout.split('\n').find((line) => line.includes(hookCommand))?.trim()
+                  : undefined;
+                // The appended record retains tmux's assigned numeric slot plus exact
+                // command for diagnosis only; teardown never consumes it as authority.
+                if (receipt) options.journalResource?.({ kind: 'hook', id: `${hookId}:${receipt.split(/\s+/, 1)[0]}`, created: true, command: receipt, acquired_at: new Date().toISOString() });
+              }
             } else {
               console.warn(
                 `[omx] tmux HUD hooks unavailable, occupied, or changed during registration for ${hookTarget}; `
@@ -2217,6 +2255,8 @@ export function createTeamSession(
       enableMouseScrolling(sessionName);
     }
 
+    const sessionBirth = runTmux(['show-options', '-qv', '-t', sessionName, OMX_INSTANCE_OPTION]);
+    if (!sessionBirth.ok || !sessionBirth.stdout.trim()) throw new Error(`failed to capture immutable tmux session birth for ${sessionName}`);
     return {
       name: teamTarget,
       workerCount,
@@ -2229,29 +2269,41 @@ export function createTeamSession(
         const birth = rollbackPaneBirths.get(paneId);
         return birth ? [[paneId, birth]] : [];
       })),
+      workerPaneCommands: Object.fromEntries(workerPaneIds.flatMap((paneId) => {
+        const command = workerPaneCommands.get(paneId);
+        return command ? [[paneId, command]] : [];
+      })),
       hudPaneBirth: createdHudPaneBirth,
+      hudPaneCommand: createdHudPaneCommand,
       resizeHookTarget,
       teamPaneOwnerId,
+      tmuxSessionName: sessionName,
+      tmuxSessionBirth: sessionBirth.stdout.trim(),
+      tmuxContext: teamTarget,
     };
   } catch (error) {
-    if (registeredClientAttachedHook) {
-      runTmux(
-        buildUnregisterClientAttachedReconcileArgs(
-          registeredClientAttachedHook.target,
-          registeredClientAttachedHook.name,
-        ),
+    if (registeredResizeHook && registeredClientAttachedHook && registeredHudPaneId) {
+      const removed = unregisterHudHooksTransactionally(
+        registeredResizeHook.target,
+        registeredResizeHook.name,
+        registeredClientAttachedHook.name,
+        registeredHudPaneId,
+        options.hookGeneration,
       );
-    }
-    if (registeredResizeHook) {
-      runTmux(buildUnregisterResizeHookArgs(registeredResizeHook.target, registeredResizeHook.name));
+      if (!removed) {
+        // Never issue an unconditional unset against a potentially newer hook generation.
+        console.warn('[omx] preserving Team HUD hook recovery metadata after rollback CAS failure');
+      }
     }
     // Every rollback candidate was tagged and read back before being journaled.
     // Revalidate its exact Team ownership and opaque per-pane birth in tmux itself;
     // a failed conditional kill deliberately retains the pane for recovery.
     for (const paneId of rollbackPaneIds) {
       const paneBirth = rollbackPaneBirths.get(paneId);
-      if (!rollbackOwnerSessionId || !rollbackTeamPaneOwnerId || !paneBirth) continue;
-      const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{@omx_pane_instance_id},${rollbackOwnerSessionId}},#{==:#{@omx_instance_id},${rollbackOwnerSessionId}},#{==:#{@omx_team_pane_owner_id},${rollbackTeamPaneOwnerId}},#{==:#{@omx_team_pane_birth},${paneBirth}}}`;
+      const role = rollbackPaneRoles.get(paneId);
+      const command = workerPaneCommands.get(paneId) ?? (role === 'hud' ? createdHudPaneCommand : null);
+      if (!rollbackOwnerSessionId || !rollbackTeamPaneOwnerId || !paneBirth || !role || !command) continue;
+      const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{pane_start_command},${command}},#{==:#{@omx_pane_instance_id},${rollbackOwnerSessionId}},#{==:#{@omx_instance_id},${rollbackOwnerSessionId}},#{==:#{@omx_team_pane_owner_id},${rollbackTeamPaneOwnerId}},#{==:#{@omx_team_pane_birth},${paneBirth}},#{==:#{@omx_team_pane_role},${role}}}`;
       runTmux(['if-shell', '-t', paneId, '-F', condition, `kill-pane -t ${paneId}`, '']);
     }
     throw error;
@@ -3107,9 +3159,11 @@ export interface PaneTeardownOptions {
   leaderPaneId?: string | null;
   hudPaneId?: string | null;
   graceMs?: number;
-  /** Team generation identity required for destructive worker cleanup. */
+  /** Only append-only lifecycle receipts may authorize a pane kill. */
+  workerReceipts?: Readonly<Record<string, TeamLifecycleResource>>;
   teamPaneOwnerId?: string | null;
   sessionName?: string | null;
+  sessionBirth?: string | null;
 }
 
 
@@ -3381,20 +3435,18 @@ export async function teardownWorkerPanes(
 
   const sessionName = options.sessionName?.trim().split(':')[0] ?? '';
   const teamOwnerId = options.teamPaneOwnerId?.trim() ?? '';
+  const sessionBirth = options.sessionBirth?.trim() ?? '';
   for (const paneId of killablePaneIds) {
-    // Snapshot opaque births, then have tmux compare every identity in the same
-    // server command that performs the kill. Re-used pane ids fail closed.
-    const paneBirth = readTeamPaneBirth(paneId);
-    const sessionBirthResult = sessionName
-      ? runTmux(['show-options', '-qv', '-t', sessionName, OMX_INSTANCE_OPTION])
-      : null;
-    const sessionBirth = sessionBirthResult?.ok ? sessionBirthResult.stdout.trim() : '';
-    if (!paneBirth || !sessionBirth || !sessionName || !teamOwnerId) {
+    // Do not turn a current observation into destruction authority: only the
+    // append-only receipt captured at creation is accepted.
+    const receipt = options.workerReceipts?.[paneId];
+    if (!receipt || receipt.kind !== 'worker' || receipt.id !== paneId || receipt.role !== 'worker'
+      || !receipt.pane_birth || !receipt.command || !sessionBirth || !sessionName || !teamOwnerId) {
       summary.kill.failed += 1;
       await sleep(perPaneGrace);
       continue;
     }
-    const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{session_name},${sessionName}},#{==:#{@omx_instance_id},${sessionBirth}},#{==:#{@omx_team_pane_owner_id},${teamOwnerId}},#{==:#{@omx_team_pane_birth},${paneBirth}},#{==:#{@omx_team_pane_role},worker}}`;
+    const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{pane_start_command},${receipt.command}},#{==:#{session_name},${sessionName}},#{==:#{@omx_instance_id},${sessionBirth}},#{==:#{@omx_team_pane_owner_id},${teamOwnerId}},#{==:#{@omx_team_pane_birth},${receipt.pane_birth}},#{==:#{@omx_team_pane_role},worker}}`;
     const result = await runTmuxAsync(['if-shell', '-t', paneId, '-F', condition, `kill-pane -t ${paneId}`, '']);
     if (result.ok) summary.kill.succeeded += 1;
     else summary.kill.failed += 1;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -144,19 +144,9 @@ export function establishExactTeamHudCandidate(
 
   const before = readContext();
   if (!before || (expectedLeaderPaneId && before.leaderPaneId !== expectedLeaderPaneId)) return null;
-  const sessionTag = runTmux(['show-options', '-qv', '-t', before.sessionName, OMX_INSTANCE_OPTION]);
-  if (!sessionTag.ok) return null;
-  const tmuxSessionInstanceId = sessionTag.stdout.trim() || randomUUID();
-  if (!sessionTag.stdout.trim() && !runTmux(['set-option', '-t', before.sessionName, OMX_INSTANCE_OPTION, tmuxSessionInstanceId]).ok) return null;
-  const verifiedSessionTag = runTmux(['show-options', '-qv', '-t', before.sessionName, OMX_INSTANCE_OPTION]);
-  if (!verifiedSessionTag.ok || verifiedSessionTag.stdout.trim() !== tmuxSessionInstanceId) return null;
-
-  const paneTag = runTmux(['show-option', '-qv', '-p', '-t', before.leaderPaneId, OMX_PANE_INSTANCE_OPTION]);
-  if (!paneTag.ok) return null;
-  const tmuxPaneInstanceId = paneTag.stdout.trim() || randomUUID();
-  if (!paneTag.stdout.trim() && !runTmux(['set-option', '-p', '-t', before.leaderPaneId, OMX_PANE_INSTANCE_OPTION, tmuxPaneInstanceId]).ok) return null;
-  const verifiedPaneTag = runTmux(['show-option', '-qv', '-p', '-t', before.leaderPaneId, OMX_PANE_INSTANCE_OPTION]);
-  if (!verifiedPaneTag.ok || verifiedPaneTag.stdout.trim() !== tmuxPaneInstanceId) return null;
+  const births = establishTmuxBirths(before.sessionName, before.leaderPaneId);
+  if (!births) return null;
+  const { sessionBirth: tmuxSessionInstanceId, paneBirth: tmuxPaneInstanceId } = births;
 
   const after = readContext();
   if (!after || after.sessionName !== before.sessionName || after.windowIndex !== before.windowIndex || after.leaderPaneId !== before.leaderPaneId) return null;
@@ -341,6 +331,68 @@ function runTmux(args: string[]): { ok: true; stdout: string } | { ok: false; st
   return { ok: true, stdout: (result.stdout || '').trim() };
 }
 
+/** Escapes a value embedded as a literal operand in a tmux format expression. */
+function escapeTmuxFormatLiteral(value: string): string {
+  // tmux consumes a leading # as an escape while expanding formats. Escaping
+  // every format delimiter prevents a dynamic value from terminating an operand
+  // or introducing a nested format expression.
+  return value.replace(/[#{},:]/g, (character) => `#${character}`);
+}
+
+interface EstablishedTmuxBirths {
+  sessionBirth: string;
+  paneBirth: string;
+}
+
+/**
+ * Publishes both immutable leader identities in one tmux-server conditional.
+ * A partial pre-existing pair is deliberately not repaired: doing so would turn
+ * an uncertain prior write into authority over a potentially reused target.
+ */
+function establishTmuxBirths(sessionName: string, leaderPaneId: string): EstablishedTmuxBirths | null {
+  const sessionTag = runTmux(['show-options', '-qv', '-t', sessionName, OMX_INSTANCE_OPTION]);
+  const paneTag = runTmux(['show-option', '-qv', '-p', '-t', leaderPaneId, OMX_PANE_INSTANCE_OPTION]);
+  if (!sessionTag.ok || !paneTag.ok) return null;
+
+  const existingSessionBirth = sessionTag.stdout.trim();
+  const existingPaneBirth = paneTag.stdout.trim();
+  if (existingSessionBirth || existingPaneBirth) {
+    return existingSessionBirth && existingPaneBirth
+      ? { sessionBirth: existingSessionBirth, paneBirth: existingPaneBirth }
+      : null;
+  }
+
+  const sessionBirth = randomUUID();
+  const paneBirth = randomUUID();
+  const appliedReceipt = `__omx_birth_established_${randomUUID()}__`;
+  const rejectedReceipt = `__omx_birth_rejected_${randomUUID()}__`;
+  const condition = `#{&&:#{==:#{${OMX_INSTANCE_OPTION}},},#{==:#{${OMX_PANE_INSTANCE_OPTION}},}}`;
+  const publish = [
+    `set-option -t ${shellQuoteSingle(sessionName)} ${OMX_INSTANCE_OPTION} ${shellQuoteSingle(sessionBirth)}`,
+    `set-option -p -t ${shellQuoteSingle(leaderPaneId)} ${OMX_PANE_INSTANCE_OPTION} ${shellQuoteSingle(paneBirth)}`,
+    `display-message -p ${appliedReceipt}`,
+  ].join(' \\; ');
+  const result = runTmux([
+    'if-shell', '-t', leaderPaneId, '-F', condition, publish,
+    `display-message -p ${rejectedReceipt}`,
+  ]);
+  if (!result.ok) return null;
+
+  const received = result.stdout.split('\n').map((line) => line.trim());
+  if (received.includes(appliedReceipt)) return { sessionBirth, paneBirth };
+  if (!received.includes(rejectedReceipt)) return null;
+
+  // A concurrent publisher won the exact same conditional. It is safe to use
+  // only a complete pair that tmux now exposes for this still-revalidated pane.
+  const concurrentSessionTag = runTmux(['show-options', '-qv', '-t', sessionName, OMX_INSTANCE_OPTION]);
+  const concurrentPaneTag = runTmux(['show-option', '-qv', '-p', '-t', leaderPaneId, OMX_PANE_INSTANCE_OPTION]);
+  const concurrentSessionBirth = concurrentSessionTag.ok ? concurrentSessionTag.stdout.trim() : '';
+  const concurrentPaneBirth = concurrentPaneTag.ok ? concurrentPaneTag.stdout.trim() : '';
+  return concurrentSessionBirth && concurrentPaneBirth
+    ? { sessionBirth: concurrentSessionBirth, paneBirth: concurrentPaneBirth }
+    : null;
+}
+
 function appendNoUnderlineStyleFlags(style: string): string {
   const normalized = style
     .split(/[,\s]+/)
@@ -422,6 +474,12 @@ function tagTeamPaneBirth(paneTarget: string, birthId: string): void {
 function readTeamPaneBirth(paneTarget: string): string | null {
   const result = runTmux(['show-option', '-qv', '-p', '-t', paneTarget, OMX_TEAM_PANE_BIRTH_OPTION]);
   return result.ok ? result.stdout.trim() || null : null;
+}
+
+function readTeamPaneRole(paneTarget: string): 'worker' | 'hud' | null {
+  const result = runTmux(['show-option', '-qv', '-p', '-t', paneTarget, OMX_TEAM_PANE_ROLE_OPTION]);
+  const role = result.ok ? result.stdout.trim() : '';
+  return role === 'worker' || role === 'hud' ? role : null;
 }
 function tagTeamPaneRole(paneTarget: string, role: 'worker' | 'hud'): void {
   const result = runTmux(['set-option', '-p', '-t', paneTarget, OMX_TEAM_PANE_ROLE_OPTION, role]);
@@ -602,7 +660,7 @@ export function killExactTeamHudPane(
   if (!sessionName || !candidate.tmuxSessionInstanceId || !candidate.tmuxPaneInstanceId) return false;
   const appliedReceipt = `__omx_hud_teardown_applied_${randomUUID()}__`;
   const rejectedReceipt = `__omx_hud_teardown_rejected_${randomUUID()}__`;
-  const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{pane_start_command},${receipt.command}},#{==:#{@omx_pane_instance_id},${candidate.tmuxPaneInstanceId}},#{==:#{@omx_instance_id},${candidate.tmuxSessionInstanceId}},#{==:#{session_name},${sessionName}},#{==:#{@omx_team_pane_owner_id},${teamOwnerId}},#{==:#{@omx_team_pane_birth},${receipt.pane_birth}},#{==:#{@omx_team_pane_role},hud}}`;
+  const condition = `#{&&:#{==:#{pane_id},${escapeTmuxFormatLiteral(paneId)}},#{==:#{pane_start_command},${escapeTmuxFormatLiteral(receipt.command)}},#{==:#{@omx_pane_instance_id},${escapeTmuxFormatLiteral(candidate.tmuxPaneInstanceId)}},#{==:#{@omx_instance_id},${escapeTmuxFormatLiteral(candidate.tmuxSessionInstanceId)}},#{==:#{session_name},${escapeTmuxFormatLiteral(sessionName)}},#{==:#{@omx_team_pane_owner_id},${escapeTmuxFormatLiteral(teamOwnerId)}},#{==:#{@omx_team_pane_birth},${escapeTmuxFormatLiteral(receipt.pane_birth)}},#{==:#{@omx_team_pane_role},${escapeTmuxFormatLiteral('hud')}}}`;
   const result = runTmux([
     'if-shell', '-t', paneId, '-F', condition,
     `kill-pane -t ${paneId} \\; display-message -p ${appliedReceipt}`,
@@ -955,24 +1013,37 @@ function teamHookActiveOption(generation: string): string {
   return `@omx_team_hook_active_${generation.replace(/[^a-zA-Z0-9_]/g, '_')}`;
 }
 
+function hasCompleteTeamHudHookEvidence(evidence?: TeamHudHookEvidence): evidence is TeamHudHookEvidence {
+  return Boolean(
+    evidence
+    && evidence.generation.trim()
+    && evidence.sessionName.trim()
+    && evidence.windowIndex.trim()
+    && evidence.sessionBirth.trim()
+    && evidence.hudPaneId.trim().startsWith('%')
+    && evidence.hudPaneBirth.trim()
+    && evidence.hudPaneCommand.trim()
+    && evidence.ownerId.trim(),
+  );
+}
+
 function buildTeamHookCondition(evidence?: TeamHudHookEvidence): string {
-  const generation = evidence?.generation.trim() ?? '';
-  if (!evidence || !generation || !evidence.hudPaneCommand.trim()) return '#{==:0,1}';
-  return `#{&&:#{==:#{pane_id},${buildHudPaneTarget(evidence.hudPaneId)}},#{==:#{pane_start_command},${evidence.hudPaneCommand}},#{==:#{session_name},${evidence.sessionName}},#{==:#{window_index},${evidence.windowIndex}},#{==:#{@omx_instance_id},${evidence.sessionBirth}},#{==:#{@omx_team_pane_owner_id},${evidence.ownerId}},#{==:#{@omx_team_pane_birth},${evidence.hudPaneBirth}},#{==:#{@omx_team_pane_role},hud},#{==:#{${teamHookActiveOption(generation)}},1}}`;
+  if (!hasCompleteTeamHudHookEvidence(evidence)) return '#{==:0,1}';
+  return `#{&&:#{==:#{pane_id},${escapeTmuxFormatLiteral(buildHudPaneTarget(evidence.hudPaneId))}},#{==:#{pane_start_command},${escapeTmuxFormatLiteral(evidence.hudPaneCommand)}},#{==:#{session_name},${escapeTmuxFormatLiteral(evidence.sessionName)}},#{==:#{window_index},${escapeTmuxFormatLiteral(evidence.windowIndex)}},#{==:#{@omx_instance_id},${escapeTmuxFormatLiteral(evidence.sessionBirth)}},#{==:#{@omx_team_pane_owner_id},${escapeTmuxFormatLiteral(evidence.ownerId)}},#{==:#{@omx_team_pane_birth},${escapeTmuxFormatLiteral(evidence.hudPaneBirth)}},#{==:#{@omx_team_pane_role},${escapeTmuxFormatLiteral('hud')}},#{==:#{${teamHookActiveOption(evidence.generation)}},1}}`;
 }
 
 function buildGuardedTeamResizeCommand(hudPaneId: string, heightLines: number, evidence?: TeamHudHookEvidence): string {
   const condition = buildTeamHookCondition(evidence);
-  if (condition === '#{==:0,1}') return buildBestEffortShellCommand(buildNestedTmuxShellCommand(buildHudResizeCommand(hudPaneId, heightLines)));
+  if (condition === '#{==:0,1}') return ':';
   const resizeCommand = buildHudResizeCommand(hudPaneId, heightLines);
   const guarded = `if-shell -t ${buildHudPaneTarget(hudPaneId)} -F ${shellQuoteSingle(condition)} ${shellQuoteSingle(resizeCommand)} ''`;
   return buildBestEffortShellCommand(buildNestedTmuxShellCommand(guarded));
 }
 
 function buildTeamHookCommand(hookCommand: string, evidence?: TeamHudHookEvidence): string {
-  const generation = evidence?.generation?.trim() ?? '';
+  if (!hasCompleteTeamHudHookEvidence(evidence)) return 'run-shell -b :';
   const condition = buildTeamHookCondition(evidence);
-  return `if-shell -t ${buildHudPaneTarget(evidence?.hudPaneId ?? '')} -F ${shellQuoteSingle(condition)} ${shellQuoteSingle(`run-shell -b ${hookCommand}`)} ''${generation ? ` # omx-generation=${generation}` : ''}`;
+  return `if-shell -t ${buildHudPaneTarget(evidence.hudPaneId)} -F ${shellQuoteSingle(condition)} ${shellQuoteSingle(`run-shell -b ${hookCommand}`)} '' # omx-generation=${evidence.generation}`;
 }
 
 
@@ -1103,7 +1174,7 @@ export function registerHudHooksTransactionally(
 
   const receiptOption = teamHookReceiptOption(hookTarget);
   const receipt = randomUUID();
-  const condition = `#{==:#{${generationOption}},${priorGeneration}}`;
+  const condition = `#{==:#{${generationOption}},${escapeTmuxFormatLiteral(priorGeneration)}}`;
   const publish = [
     `set-option -t ${hookTarget} ${generationOption} ${generation}`,
     `set-option -t ${hookTarget} ${teamHookActiveOption(generation)} 1`,
@@ -1134,7 +1205,7 @@ export function unregisterHudHooksTransactionally(
   if (!generation || !/^[0-9a-f-]{36}$/.test(generation)) return false;
   const receiptOption = teamHookReceiptOption(hookTarget);
   const receipt = randomUUID();
-  const condition = `#{==:#{${teamHookGenerationOption(hookTarget)}},${generation}}`;
+  const condition = `#{==:#{${teamHookGenerationOption(hookTarget)}},${escapeTmuxFormatLiteral(generation)}}`;
   const deactivate = `set-option -t ${hookTarget} ${teamHookActiveOption(generation)} 0 \\; set-option -t ${hookTarget} ${receiptOption} ${receipt}`;
   if (!runTmux(['if-shell', '-t', hookTarget, '-F', condition, deactivate, '']).ok) return false;
   const applied = runTmux(['show-options', '-qv', '-t', hookTarget, receiptOption]);
@@ -1147,6 +1218,7 @@ export function buildScheduleDelayedHudResizeArgs(
   heightLines: number = HUD_TMUX_TEAM_HEIGHT_LINES,
   evidence?: TeamHudHookEvidence,
 ): string[] {
+  if (!hasCompleteTeamHudHookEvidence(evidence)) return ['run-shell', '-b', ':'];
   const delay = Number.isFinite(delaySeconds) && delaySeconds > 0 ? delaySeconds : HUD_RESIZE_RECONCILE_DELAY_SECONDS;
   return ['run-shell', '-b', `sleep ${delay}; ${buildGuardedTeamResizeCommand(hudPaneId, heightLines, evidence)}`];
 }
@@ -2199,13 +2271,25 @@ export function createTeamSession(
         const id = hudPaneId ?? (hudResult && hudResult.ok ? hudResult.stdout.split('\n')[0]?.trim() ?? '' : '');
         if (id.startsWith('%')) {
           if (retainedHudPaneId) {
-            options.journalResource?.({
-              kind: 'hud',
-              id,
-              created: false,
-              pane_birth: readTeamPaneBirth(id) ?? undefined,
-              acquired_at: new Date().toISOString(),
-            });
+            const retainedHudPane = panes.find((pane) => pane.paneId === id);
+            const retainedHudPaneBirth = readTeamPaneBirth(id);
+            const retainedHudPaneRole = readTeamPaneRole(id);
+            if (
+              retainedHudPane?.startCommand.trim()
+              && retainedHudPaneBirth
+              && retainedHudPaneRole === 'hud'
+              && readNewPaneTeamOwnerTag(id) === teamPaneOwnerId
+            ) {
+              options.journalResource?.({
+                kind: 'hud',
+                id,
+                created: false,
+                pane_birth: retainedHudPaneBirth,
+                command: retainedHudPane.startCommand,
+                role: 'hud',
+                acquired_at: new Date().toISOString(),
+              });
+            }
           }
           if (!retainedHudPaneId) rollbackPaneIds.push(id);
           if (isNativeWindows() && !waitForPaneToRemainPresent(teamTarget, id)) {
@@ -2374,7 +2458,7 @@ export function createTeamSession(
       const role = rollbackPaneRoles.get(paneId);
       const command = workerPaneCommands.get(paneId) ?? (role === 'hud' ? createdHudPaneCommand : null);
       if (!rollbackOwnerSessionId || !rollbackTeamPaneOwnerId || !paneBirth || !role || !command) continue;
-      const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{pane_start_command},${command}},#{==:#{@omx_pane_instance_id},${rollbackOwnerSessionId}},#{==:#{@omx_instance_id},${rollbackOwnerSessionId}},#{==:#{@omx_team_pane_owner_id},${rollbackTeamPaneOwnerId}},#{==:#{@omx_team_pane_birth},${paneBirth}},#{==:#{@omx_team_pane_role},${role}}}`;
+      const condition = `#{&&:#{==:#{pane_id},${escapeTmuxFormatLiteral(paneId)}},#{==:#{pane_start_command},${escapeTmuxFormatLiteral(command)}},#{==:#{@omx_pane_instance_id},${escapeTmuxFormatLiteral(rollbackOwnerSessionId)}},#{==:#{@omx_instance_id},${escapeTmuxFormatLiteral(rollbackOwnerSessionId)}},#{==:#{@omx_team_pane_owner_id},${escapeTmuxFormatLiteral(rollbackTeamPaneOwnerId)}},#{==:#{@omx_team_pane_birth},${escapeTmuxFormatLiteral(paneBirth)}},#{==:#{@omx_team_pane_role},${escapeTmuxFormatLiteral(role)}}}`;
       runTmux(['if-shell', '-t', paneId, '-F', condition, `kill-pane -t ${paneId}`, '']);
     }
     throw error;
@@ -3512,7 +3596,7 @@ export async function teardownWorkerPanes(
     }
     const appliedReceipt = `__omx_worker_teardown_applied_${randomUUID()}__`;
     const rejectedReceipt = `__omx_worker_teardown_rejected_${randomUUID()}__`;
-    const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{pane_start_command},${receipt.command}},#{==:#{session_name},${sessionName}},#{==:#{@omx_instance_id},${sessionBirth}},#{==:#{@omx_team_pane_owner_id},${teamOwnerId}},#{==:#{@omx_team_pane_birth},${receipt.pane_birth}},#{==:#{@omx_team_pane_role},worker}}`;
+    const condition = `#{&&:#{==:#{pane_id},${escapeTmuxFormatLiteral(paneId)}},#{==:#{pane_start_command},${escapeTmuxFormatLiteral(receipt.command)}},#{==:#{session_name},${escapeTmuxFormatLiteral(sessionName)}},#{==:#{@omx_instance_id},${escapeTmuxFormatLiteral(sessionBirth)}},#{==:#{@omx_team_pane_owner_id},${escapeTmuxFormatLiteral(teamOwnerId)}},#{==:#{@omx_team_pane_birth},${escapeTmuxFormatLiteral(receipt.pane_birth)}},#{==:#{@omx_team_pane_role},${escapeTmuxFormatLiteral('worker')}}}`;
     const result = await runTmuxAsync([
       'if-shell', '-t', paneId, '-F', condition,
       `kill-pane -t ${paneId} \\; display-message -p ${appliedReceipt}`,
@@ -3542,7 +3626,7 @@ export function destroyTeamSession(sessionName: string, sessionBirth: string): b
   if (!normalizedSessionName || !normalizedSessionBirth) return false;
   const appliedReceipt = `__omx_session_teardown_applied_${randomUUID()}__`;
   const rejectedReceipt = `__omx_session_teardown_rejected_${randomUUID()}__`;
-  const condition = `#{&&:#{==:#{session_name},${normalizedSessionName}},#{==:#{@omx_instance_id},${normalizedSessionBirth}}}`;
+  const condition = `#{&&:#{==:#{session_name},${escapeTmuxFormatLiteral(normalizedSessionName)}},#{==:#{@omx_instance_id},${escapeTmuxFormatLiteral(normalizedSessionBirth)}}}`;
   const result = runTmux([
     'if-shell', '-t', normalizedSessionName, '-F', condition,
     `kill-session -t ${normalizedSessionName} \\; display-message -p ${appliedReceipt}`,

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -389,6 +389,17 @@ function establishTmuxBirths(sessionName: string, leaderPaneId: string): Establi
       : null;
   }
 
+  // A missing receipt is ambiguous: the publish command may have committed and
+  // another process may already have adopted the complete pair. Preserve and
+  // adopt any complete read-back pair before considering compensation.
+  const publishedSessionTag = runTmux(['show-options', '-qv', '-t', sessionName, OMX_INSTANCE_OPTION]);
+  const publishedPaneTag = runTmux(['show-option', '-qv', '-p', '-t', leaderPaneId, OMX_PANE_INSTANCE_OPTION]);
+  const publishedSessionBirth = publishedSessionTag.ok ? publishedSessionTag.stdout.trim() : '';
+  const publishedPaneBirth = publishedPaneTag.ok ? publishedPaneTag.stdout.trim() : '';
+  if (publishedSessionBirth && publishedPaneBirth) {
+    return { sessionBirth: publishedSessionBirth, paneBirth: publishedPaneBirth };
+  }
+
   // tmux can report a command failure after the first write has committed. Undo
   // only our exact pair (or exact half-pair) in one server-side CAS; a changed
   // value is a concurrent replacement and must survive recovery.
@@ -405,6 +416,7 @@ function establishTmuxBirths(sessionName: string, leaderPaneId: string): Establi
     `display-message -p ${compensationRejected}`,
   ]);
   return null;
+
 }
 
 function appendNoUnderlineStyleFlags(style: string): string {
@@ -657,6 +669,21 @@ function findExactTeamHudPaneIds(target: string, candidate: ExactTeamHudCandidat
       && pane.sessionInstanceId === candidate.tmuxSessionInstanceId)
     .map((pane) => pane.paneId);
 }
+function findBorrowableStandaloneHudPaneIds(target: string, candidate: ExactTeamHudCandidate | null): string[] {
+  if (!candidate) return [];
+  return listPanes(target)
+    .filter((pane) => pane.paneId !== candidate.leaderPaneId)
+    .filter((pane) => hudPaneMatchesOwner(pane, {
+      sessionId: candidate.sessionId,
+      sessionIds: candidate.sessionIds,
+      leaderPaneId: candidate.leaderPaneId,
+    }))
+    .filter((pane) => !readNewPaneTeamOwnerTag(pane.paneId)
+      && !readTeamPaneBirth(pane.paneId)
+      && !readTeamPaneRole(pane.paneId))
+    .map((pane) => pane.paneId);
+}
+
 
 /** Kills only an immutable journaled HUD generation, with tmux evaluating every identity immediately before kill. */
 export function killExactTeamHudPane(
@@ -676,7 +703,7 @@ export function killExactTeamHudPane(
   const condition = `#{&&:#{==:#{pane_id},${escapeTmuxFormatLiteral(paneId)}},#{==:#{pane_start_command},${escapeTmuxFormatLiteral(receipt.command)}},#{==:#{@omx_pane_instance_id},${escapeTmuxFormatLiteral(receipt.pane_birth)}},#{==:#{@omx_instance_id},${escapeTmuxFormatLiteral(candidate.tmuxSessionInstanceId)}},#{==:#{session_name},${escapeTmuxFormatLiteral(sessionName)}},#{==:#{@omx_team_pane_owner_id},${escapeTmuxFormatLiteral(teamOwnerId)}},#{==:#{@omx_team_pane_birth},${escapeTmuxFormatLiteral(receipt.pane_birth)}},#{==:#{@omx_team_pane_role},${escapeTmuxFormatLiteral('hud')}}}`;
   const result = runTmux([
     'if-shell', '-t', paneId, '-F', condition,
-    `kill-pane -t ${paneId} \\; display-message -p ${appliedReceipt}`,
+    `kill-pane -t ${shellQuoteSingle(paneId)} \\; display-message -p ${appliedReceipt}`,
     `display-message -p ${rejectedReceipt}`,
   ]);
   return result.ok && result.stdout.split('\n').some((line) => line.trim() === appliedReceipt);
@@ -988,7 +1015,7 @@ function resolveHudHeightLines(heightLines: number): number {
 }
 
 function buildHudResizeCommand(hudPaneId: string, heightLines: number = HUD_TMUX_TEAM_HEIGHT_LINES): string {
-  return `resize-pane -t ${buildHudPaneTarget(hudPaneId)} -y ${resolveHudHeightLines(heightLines)}`;
+  return `resize-pane -t ${shellQuoteSingle(buildHudPaneTarget(hudPaneId))} -y ${resolveHudHeightLines(heightLines)}`;
 }
 
 
@@ -1049,14 +1076,14 @@ function buildGuardedTeamResizeCommand(hudPaneId: string, heightLines: number, e
   const condition = buildTeamHookCondition(evidence);
   if (condition === '#{==:0,1}') return ':';
   const resizeCommand = buildHudResizeCommand(hudPaneId, heightLines);
-  const guarded = `if-shell -t ${buildHudPaneTarget(hudPaneId)} -F ${shellQuoteSingle(condition)} ${shellQuoteSingle(resizeCommand)} ''`;
+  const guarded = `if-shell -t ${shellQuoteSingle(buildHudPaneTarget(hudPaneId))} -F ${shellQuoteSingle(condition)} ${shellQuoteSingle(resizeCommand)} ''`;
   return buildBestEffortShellCommand(buildNestedTmuxShellCommand(guarded));
 }
 
 function buildTeamHookCommand(hookCommand: string, evidence?: TeamHudHookEvidence): string {
   if (!hasCompleteTeamHudHookEvidence(evidence)) return 'run-shell -b :';
   const condition = buildTeamHookCondition(evidence);
-  return `if-shell -t ${buildHudPaneTarget(evidence.hudPaneId)} -F ${shellQuoteSingle(condition)} ${shellQuoteSingle(`run-shell -b ${hookCommand}`)} '' # omx-generation=${evidence.generation}`;
+  return `if-shell -t ${shellQuoteSingle(buildHudPaneTarget(evidence.hudPaneId))} -F ${shellQuoteSingle(condition)} ${shellQuoteSingle(`run-shell -b ${hookCommand}`)} '' # omx-generation=${evidence.generation}`;
 }
 
 
@@ -1173,7 +1200,9 @@ export function registerHudHooksTransactionally(
   if (priorGeneration && !/^[0-9a-f-]{36}$/.test(priorGeneration)) return false;
   if (priorGeneration) {
     const priorActive = runTmux(['show-options', '-qv', '-t', hookTarget, teamHookActiveOption(priorGeneration)]);
-    if (priorActive.ok && priorActive.stdout.trim() === '1' && hasVerifiedTeamHookPair(hookTarget, priorGeneration)) return true;
+    if (priorActive.ok && priorActive.stdout.trim() === '1' && hasVerifiedTeamHookPair(hookTarget, priorGeneration)) {
+      return priorGeneration === generation;
+    }
   }
 
   // The new pair is intentionally inert until both append receipts have been observed.
@@ -1189,10 +1218,10 @@ export function registerHudHooksTransactionally(
   const receipt = randomUUID();
   const condition = `#{==:#{${generationOption}},${escapeTmuxFormatLiteral(priorGeneration)}}`;
   const publish = [
-    `set-option -t ${hookTarget} ${generationOption} ${generation}`,
-    `set-option -t ${hookTarget} ${teamHookActiveOption(generation)} 1`,
-    ...(priorGeneration ? [`set-option -t ${hookTarget} ${teamHookActiveOption(priorGeneration)} 0`] : []),
-    `set-option -t ${hookTarget} ${receiptOption} ${receipt}`,
+    `set-option -t ${shellQuoteSingle(hookTarget)} ${generationOption} ${generation}`,
+    `set-option -t ${shellQuoteSingle(hookTarget)} ${teamHookActiveOption(generation)} 1`,
+    ...(priorGeneration ? [`set-option -t ${shellQuoteSingle(hookTarget)} ${teamHookActiveOption(priorGeneration)} 0`] : []),
+    `set-option -t ${shellQuoteSingle(hookTarget)} ${receiptOption} ${receipt}`,
   ].join(' \\; ');
   if (!runTmux(['if-shell', '-t', hookTarget, '-F', condition, publish, '']).ok) return false;
   const applied = runTmux(['show-options', '-qv', '-t', hookTarget, receiptOption]);
@@ -1219,7 +1248,7 @@ export function unregisterHudHooksTransactionally(
   const receiptOption = teamHookReceiptOption(hookTarget);
   const receipt = randomUUID();
   const condition = `#{==:#{${teamHookGenerationOption(hookTarget)}},${escapeTmuxFormatLiteral(generation)}}`;
-  const deactivate = `set-option -t ${hookTarget} ${teamHookActiveOption(generation)} 0 \\; set-option -t ${hookTarget} ${receiptOption} ${receipt}`;
+  const deactivate = `set-option -t ${shellQuoteSingle(hookTarget)} ${teamHookActiveOption(generation)} 0 \\; set-option -t ${shellQuoteSingle(hookTarget)} ${receiptOption} ${receipt}`;
   if (!runTmux(['if-shell', '-t', hookTarget, '-F', condition, deactivate, '']).ok) return false;
   const applied = runTmux(['show-options', '-qv', '-t', hookTarget, receiptOption]);
   return applied.ok && applied.stdout.trim() === receipt;
@@ -2154,9 +2183,17 @@ export function createTeamSession(
       created: false,
       acquired_at: new Date().toISOString(),
     });
-    const [retainedHudPaneId, ...duplicateHudPaneIds] = hasExactHudAuthority
+    const exactHudPaneIds = hasExactHudAuthority
       ? findExactTeamHudPaneIds(teamTarget, hudExactCandidate)
       : [];
+    const standaloneHudPaneIds = hasExactHudAuthority && exactHudPaneIds.length === 0
+      ? findBorrowableStandaloneHudPaneIds(teamTarget, hudExactCandidate)
+      : [];
+    const retainedHudPaneId = exactHudPaneIds[0] ?? standaloneHudPaneIds[0] ?? null;
+    const duplicateHudPaneIds = exactHudPaneIds.length > 0
+      ? exactHudPaneIds.slice(1)
+      : standaloneHudPaneIds.slice(1);
+    const retainedHudIsBorrowed = Boolean(retainedHudPaneId && exactHudPaneIds.length === 0);
     // A duplicate's command and live tags prove only that it resembles this
     // generation. They are not a transferable lifecycle receipt, so killing it
     // would risk an ABA-reused pane. Stop before provisioning workers rather
@@ -2166,27 +2203,42 @@ export function createTeamSession(
     }
     if (retainedHudPaneId) {
       const retainedHudPane = listPanes(teamTarget).find((pane) => pane.paneId === retainedHudPaneId);
-      const retainedHudPaneBirth = readTeamPaneBirth(retainedHudPaneId);
-      const retainedHudPaneRole = readTeamPaneRole(retainedHudPaneId);
-      if (
-        !retainedHudPane?.startCommand.trim()
-        || !retainedHudPane.paneInstanceId?.trim()
-        || retainedHudPane.sessionInstanceId !== hudExactCandidate?.tmuxSessionInstanceId
-        || !retainedHudPaneBirth
-        || retainedHudPaneRole !== 'hud'
-        || readNewPaneTeamOwnerTag(retainedHudPaneId) !== teamPaneOwnerId
-      ) {
-        throw new Error(`failed to capture exact retained HUD receipt for ${retainedHudPaneId}`);
+      if (retainedHudIsBorrowed) {
+        // A pre-Team standalone HUD has no Team lifecycle receipt. Its own
+        // immutable pane birth and command make it durable borrowed recovery
+        // evidence, never rollback or teardown authority for this Team.
+        options.journalResource?.({
+          kind: 'hud',
+          id: retainedHudPaneId,
+          created: false,
+          pane_birth: retainedHudPane?.paneInstanceId,
+          command: retainedHudPane?.startCommand,
+          role: 'hud',
+          acquired_at: new Date().toISOString(),
+        });
+      } else {
+        const retainedHudPaneBirth = readTeamPaneBirth(retainedHudPaneId);
+        const retainedHudPaneRole = readTeamPaneRole(retainedHudPaneId);
+        if (
+          !retainedHudPane?.startCommand.trim()
+          || !retainedHudPane.paneInstanceId?.trim()
+          || retainedHudPane.sessionInstanceId !== hudExactCandidate?.tmuxSessionInstanceId
+          || !retainedHudPaneBirth
+          || retainedHudPaneRole !== 'hud'
+          || readNewPaneTeamOwnerTag(retainedHudPaneId) !== teamPaneOwnerId
+        ) {
+          throw new Error(`failed to capture exact retained HUD receipt for ${retainedHudPaneId}`);
+        }
+        options.journalResource?.({
+          kind: 'hud',
+          id: retainedHudPaneId,
+          created: false,
+          pane_birth: retainedHudPaneBirth,
+          command: retainedHudPane.startCommand,
+          role: 'hud',
+          acquired_at: new Date().toISOString(),
+        });
       }
-      options.journalResource?.({
-        kind: 'hud',
-        id: retainedHudPaneId,
-        created: false,
-        pane_birth: retainedHudPaneBirth,
-        command: retainedHudPane.startCommand,
-        role: 'hud',
-        acquired_at: new Date().toISOString(),
-      });
     }
     const omxEntry = resolveOmxCliEntryPath();
     const canRecreateTeamHud = hasExactHudAuthority && Boolean(omxEntry && omxEntry.trim() !== '');
@@ -2473,7 +2525,7 @@ export function createTeamSession(
       const condition = `#{&&:#{==:#{pane_id},${escapeTmuxFormatLiteral(paneId)}},#{==:#{pane_start_command},${escapeTmuxFormatLiteral(command)}},#{==:#{@omx_instance_id},${escapeTmuxFormatLiteral(rollbackSessionBirth)}},#{==:#{@omx_team_pane_owner_id},${escapeTmuxFormatLiteral(rollbackTeamPaneOwnerId)}},#{==:#{@omx_team_pane_birth},${escapeTmuxFormatLiteral(paneBirth)}},#{==:#{@omx_team_pane_role},${escapeTmuxFormatLiteral(role)}}}`;
       runTmux([
         'if-shell', '-t', paneId, '-F', condition,
-        `kill-pane -t ${paneId} \\; display-message -p ${appliedReceipt}`,
+        `kill-pane -t ${shellQuoteSingle(paneId)} \\; display-message -p ${appliedReceipt}`,
         `display-message -p ${rejectedReceipt}`,
       ]);
     }
@@ -3616,7 +3668,7 @@ export async function teardownWorkerPanes(
     const condition = `#{&&:#{==:#{pane_id},${escapeTmuxFormatLiteral(paneId)}},#{==:#{pane_start_command},${escapeTmuxFormatLiteral(receipt.command)}},#{==:#{session_name},${escapeTmuxFormatLiteral(sessionName)}},#{==:#{@omx_instance_id},${escapeTmuxFormatLiteral(sessionBirth)}},#{==:#{@omx_team_pane_owner_id},${escapeTmuxFormatLiteral(teamOwnerId)}},#{==:#{@omx_team_pane_birth},${escapeTmuxFormatLiteral(receipt.pane_birth)}},#{==:#{@omx_team_pane_role},${escapeTmuxFormatLiteral('worker')}}}`;
     const result = await runTmuxAsync([
       'if-shell', '-t', paneId, '-F', condition,
-      `kill-pane -t ${paneId} \\; display-message -p ${appliedReceipt}`,
+      `kill-pane -t ${shellQuoteSingle(paneId)} \\; display-message -p ${appliedReceipt}`,
       `display-message -p ${rejectedReceipt}`,
     ]);
     if (result.ok && result.stdout.split('\n').some((line) => line.trim() === appliedReceipt)) summary.kill.succeeded += 1;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -2347,10 +2347,10 @@ export function createTeamSession(
               windowIndex,
               hudPaneId,
             );
-            // Persist every append-only hook receipt before registration. The exact
-            // command and server-assigned slot are recovery diagnostics, never mutation authority.
-            options.journalResource?.({ kind: 'hook', id: hookName, created: true, command: options.hookGeneration, acquired_at: new Date().toISOString() });
-            options.journalResource?.({ kind: 'hook', id: clientAttachedHookName, created: true, command: options.hookGeneration, acquired_at: new Date().toISOString() });
+            // Persist inert intent as borrowed recovery metadata. Only a fully verified,
+            // activated generation is later journaled as created teardown authority.
+            options.journalResource?.({ kind: 'hook', id: hookName, created: false, command: options.hookGeneration, acquired_at: new Date().toISOString() });
+            options.journalResource?.({ kind: 'hook', id: clientAttachedHookName, created: false, command: options.hookGeneration, acquired_at: new Date().toISOString() });
             const hookSessionBirth = runTmux(['show-options', '-qv', '-t', sessionName, OMX_INSTANCE_OPTION]);
             const hookEvidence = createdHudPaneBirth && options.hookGeneration && hookSessionBirth.ok && hookSessionBirth.stdout.trim()
               ? {
@@ -2365,6 +2365,8 @@ export function createTeamSession(
                 }
               : null;
             if (hookEvidence && registerHudHooksTransactionally(hookTarget, hookName, clientAttachedHookName, hudPaneId, options.hookGeneration, hookEvidence)) {
+              options.journalResource?.({ kind: 'hook', id: hookName, created: true, command: options.hookGeneration, acquired_at: new Date().toISOString() });
+              options.journalResource?.({ kind: 'hook', id: clientAttachedHookName, created: true, command: options.hookGeneration, acquired_at: new Date().toISOString() });
               resizeHookTarget = hookTarget;
               resizeHookName = hookName;
               registeredResizeHook = { name: resizeHookName, target: resizeHookTarget };

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { spawnSync, execFile } from 'child_process';
 import { promisify } from 'util';
 import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'fs';
@@ -134,14 +135,14 @@ export function establishExactTeamHudCandidate(
   if (!before || (expectedLeaderPaneId && before.leaderPaneId !== expectedLeaderPaneId)) return null;
   const sessionTag = runTmux(['show-options', '-qv', '-t', before.sessionName, OMX_INSTANCE_OPTION]);
   if (!sessionTag.ok) return null;
-  const tmuxSessionInstanceId = sessionTag.stdout.trim() || sessionId;
+  const tmuxSessionInstanceId = sessionTag.stdout.trim() || randomUUID();
   if (!sessionTag.stdout.trim() && !runTmux(['set-option', '-t', before.sessionName, OMX_INSTANCE_OPTION, tmuxSessionInstanceId]).ok) return null;
   const verifiedSessionTag = runTmux(['show-options', '-qv', '-t', before.sessionName, OMX_INSTANCE_OPTION]);
   if (!verifiedSessionTag.ok || verifiedSessionTag.stdout.trim() !== tmuxSessionInstanceId) return null;
 
   const paneTag = runTmux(['show-option', '-qv', '-p', '-t', before.leaderPaneId, OMX_PANE_INSTANCE_OPTION]);
   if (!paneTag.ok) return null;
-  const tmuxPaneInstanceId = paneTag.stdout.trim() || sessionIds.find((value) => value !== sessionId) || sessionId;
+  const tmuxPaneInstanceId = paneTag.stdout.trim() || randomUUID();
   if (!paneTag.stdout.trim() && !runTmux(['set-option', '-p', '-t', before.leaderPaneId, OMX_PANE_INSTANCE_OPTION, tmuxPaneInstanceId]).ok) return null;
   const verifiedPaneTag = runTmux(['show-option', '-qv', '-p', '-t', before.leaderPaneId, OMX_PANE_INSTANCE_OPTION]);
   if (!verifiedPaneTag.ok || verifiedPaneTag.stdout.trim() !== tmuxPaneInstanceId) return null;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -43,9 +43,14 @@ const execFileAsync = promisify(execFile);
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../hud/constants.js';
 import { OMX_TMUX_HUD_OWNER_ENV } from '../hud/reconcile.js';
 import { buildHudRuntimeEnv, hudPaneMatchesExactCandidate, hudPaneMatchesOwner, OMX_TMUX_HUD_LEADER_PANE_ENV, type HudRuntimeEnvInput } from '../hud/tmux.js';
+import type { TeamLifecycleResource } from './state.js';
 const OMX_INSTANCE_OPTION = '@omx_instance_id';
 const OMX_PANE_INSTANCE_OPTION = '@omx_pane_instance_id';
 const OMX_TEAM_PANE_OWNER_OPTION = '@omx_team_pane_owner_id';
+const OMX_TEAM_PANE_BIRTH_OPTION = '@omx_team_pane_birth';
+const OMX_TEAM_PANE_ROLE_OPTION = '@omx_team_pane_role';
+
+
 
 export interface TeamSession {
   name: string; // tmux target in "session:window" form
@@ -62,6 +67,9 @@ export interface TeamSession {
   resizeHookTarget: string | null;
   /** Team-scoped tmux pane ownership token used by shutdown safety checks. */
   teamPaneOwnerId: string;
+  /** Opaque births captured after exact tmux tagging; required for lifecycle recovery. */
+  workerPaneBirths?: Record<string, string>;
+  hudPaneBirth?: string | null;
 }
 
 export interface CreateTeamSessionOptions {
@@ -79,6 +87,10 @@ export interface CreateTeamSessionOptions {
 
   /** Verified HUD ownership evidence. Without all fields, Team leaves HUD panes untouched. */
   hudExactCandidate?: ExactTeamHudCandidate | null;
+  /** Must synchronously durably append each exact resource receipt before another tmux mutation. */
+  journalResource?: (resource: TeamLifecycleResource) => void;
+  /** Immutable lifecycle hook generation used to compare-and-mutate owned hook slots. */
+  hookGeneration?: string;
 
 }
 export interface ExactTeamHudCandidate {
@@ -396,6 +408,26 @@ function tagNewHudPaneOrRollback(
 
 }
 
+function tagTeamPaneBirth(paneTarget: string, birthId: string): void {
+  const target = paneTarget.trim();
+  const sanitized = birthId.trim();
+  if (!target || !sanitized) return;
+  const result = runTmux(['set-option', '-p', '-t', target, OMX_TEAM_PANE_BIRTH_OPTION, sanitized]);
+  if (!result.ok) throw new Error(`failed to tag tmux pane birth ${target}: ${result.stderr}`);
+  const verified = runTmux(['show-option', '-qv', '-p', '-t', target, OMX_TEAM_PANE_BIRTH_OPTION]);
+  if (!verified.ok || verified.stdout.trim() !== sanitized) {
+    throw new Error(`failed to verify tmux pane birth ${target}`);
+  }
+}
+
+function readTeamPaneBirth(paneTarget: string): string | null {
+  const result = runTmux(['show-option', '-qv', '-p', '-t', paneTarget, OMX_TEAM_PANE_BIRTH_OPTION]);
+  return result.ok ? result.stdout.trim() || null : null;
+}
+function tagTeamPaneRole(paneTarget: string, role: 'worker' | 'hud'): void {
+  const result = runTmux(['set-option', '-p', '-t', paneTarget, OMX_TEAM_PANE_ROLE_OPTION, role]);
+  if (!result.ok) throw new Error(`failed to tag tmux pane role ${paneTarget}: ${result.stderr}`);
+}
 export function tagPaneTeamOwner(paneTarget: string, teamOwnerId: string): void {
   const target = paneTarget.trim();
   const sanitized = teamOwnerId.trim();
@@ -929,12 +961,13 @@ export function buildRegisterResizeHookArgs(
   hookName: string,
   hudPaneId: string,
   heightLines: number = HUD_TMUX_TEAM_HEIGHT_LINES,
+  generation?: string,
 ): string[] {
   const resizeCommand = buildBestEffortShellCommand(buildNestedTmuxShellCommand(buildHudResizeCommand(hudPaneId, heightLines)));
   const hookCommand = shellQuoteSingle(
     `${resizeCommand}; sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}; ${resizeCommand}`,
   );
-  return ['set-hook', '-t', hookTarget, buildResizeHookSlot(hookName), `run-shell -b ${hookCommand}`];
+  return ['set-hook', '-t', hookTarget, buildResizeHookSlot(hookName), `run-shell -b ${hookCommand}${generation ? ` # omx-generation=${generation}` : ''}`];
 }
 
 export function buildUnregisterResizeHookArgs(hookTarget: string, hookName: string): string[] {
@@ -961,6 +994,7 @@ export function buildRegisterClientAttachedReconcileArgs(
   hookName: string,
   hudPaneId: string,
   heightLines: number = HUD_TMUX_TEAM_HEIGHT_LINES,
+  generation?: string,
 ): string[] {
   const hookSlot = buildClientAttachedHookSlot(hookName);
   // Keep the owned command installed until transactional lifecycle cleanup. A shell
@@ -968,7 +1002,7 @@ export function buildRegisterClientAttachedReconcileArgs(
   const oneShotCommand = shellQuoteSingle(
     buildBestEffortShellCommand(buildNestedTmuxShellCommand(buildHudResizeCommand(hudPaneId, heightLines))),
   );
-  return ['set-hook', '-t', hookTarget, hookSlot, `run-shell -b ${oneShotCommand}`];
+  return ['set-hook', '-t', hookTarget, hookSlot, `run-shell -b ${oneShotCommand}${generation ? ` # omx-generation=${generation}` : ''}`];
 }
 
 export function buildUnregisterClientAttachedReconcileArgs(hookTarget: string, hookName: string): string[] {
@@ -985,135 +1019,60 @@ export function unregisterClientAttachedReconcileHook(hookTarget: string, hookNa
   return result.ok;
 }
 
-type TmuxHookSnapshot = {
-  slot: string;
-  command: string | null;
-};
-
-function readTmuxHookSnapshot(hookTarget: string, slot: string): TmuxHookSnapshot | null {
-  const result = runTmux(['show-hooks', '-t', hookTarget, slot]);
-  if (!result.ok) return null;
-  const output = result.stdout.trim();
-  if (output === '') return { slot, command: null };
-  const escapedSlot = slot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const match = output.split('\n').map((value) => value.trim()).map((value) => value.match(new RegExp(`^${escapedSlot}\\s+(.+)$`))).find(Boolean);
-  return match?.[1] ? { slot, command: match[1] } : null;
+/** One tmux-server conditional mutation; foreign or newer hook commands survive. */
+function mutateHudHookIfCurrent(hookTarget: string, slot: string, expected: string | null, next: string | null): boolean {
+  const expectedLine = expected === null ? '' : `${slot} ${expected}`;
+  const condition = expected === null
+    ? `test -z "$(tmux show-hooks -t ${shellQuoteSingle(hookTarget)} ${shellQuoteSingle(slot)})"`
+    : `test "$(tmux show-hooks -t ${shellQuoteSingle(hookTarget)} ${shellQuoteSingle(slot)})" = ${shellQuoteSingle(expectedLine)}`;
+  const mutation = next === null
+    ? `set-hook -u -t ${shellQuoteSingle(hookTarget)} ${shellQuoteSingle(slot)}`
+    : `set-hook -t ${shellQuoteSingle(hookTarget)} ${shellQuoteSingle(slot)} ${shellQuoteSingle(next)}`;
+  const result = runTmux(['if-shell', '-t', hookTarget, condition, mutation, '']);
+  if (!result.ok) return false;
+  const readback = runTmux(['show-hooks', '-t', hookTarget, slot]);
+  return readback.ok && readback.stdout.trim() === (next === null ? '' : `${slot} ${next}`);
 }
 
-function restoreTmuxHookSnapshot(hookTarget: string, snapshot: TmuxHookSnapshot, expectedCurrent: string | null): boolean {
-  // Never restore over a concurrent replacement. A mismatch is uncertainty, not a
-  // license to rewrite the slot.
-  if (!tmuxHookMatchesSnapshot(hookTarget, { slot: snapshot.slot, command: expectedCurrent })) return false;
-  const result = snapshot.command === null
-    ? runTmux(['set-hook', '-u', '-t', hookTarget, snapshot.slot])
-    : runTmux(['set-hook', '-t', hookTarget, snapshot.slot, snapshot.command]);
-  return result.ok && tmuxHookMatchesSnapshot(hookTarget, snapshot);
-}
-
-function tmuxHookMatchesSnapshot(hookTarget: string, expected: TmuxHookSnapshot): boolean {
-  const actual = readTmuxHookSnapshot(hookTarget, expected.slot);
-  return actual?.command === expected.command;
-}
-
-function tmuxHookIsAbsent(hookTarget: string, slot: string): boolean {
-  return readTmuxHookSnapshot(hookTarget, slot)?.command === null;
-}
-
-/** Registers only an empty hook slot or an identical OMX command; foreign collisions are preserved. */
+/** Registers only an empty hook slot; callers retain metadata on uncertainty. */
 export function registerHudHookIfVacant(hookTarget: string, args: string[]): boolean {
   const slot = args[3]?.trim() ?? '';
   const command = args[4] ?? '';
-  if (!slot || !command) return false;
-  const snapshot = readTmuxHookSnapshot(hookTarget, slot);
-  if (!snapshot || (snapshot.command !== null && snapshot.command !== command)) return false;
-  if (snapshot.command === command) return true;
-  return runTmux(args).ok;
+  return Boolean(slot && command && mutateHudHookIfCurrent(hookTarget, slot, null, command));
 }
 
-/** Installs the paired Team HUD hooks atomically, preserving foreign hook slots. */
 export function registerHudHooksTransactionally(
   hookTarget: string,
   resizeHookName: string,
   clientAttachedHookName: string,
   hudPaneId: string,
+  generation?: string,
 ): boolean {
-  const resizeArgs = buildRegisterResizeHookArgs(hookTarget, resizeHookName, hudPaneId);
-  const clientAttachedArgs = buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId);
+  const resizeArgs = buildRegisterResizeHookArgs(hookTarget, resizeHookName, hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, generation);
+  const attachedArgs = buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, generation);
   const resizeSlot = resizeArgs[3]!;
-  const clientAttachedSlot = clientAttachedArgs[3]!;
-  const resizeSnapshot = readTmuxHookSnapshot(hookTarget, resizeSlot);
-  const clientAttachedSnapshot = readTmuxHookSnapshot(hookTarget, clientAttachedSlot);
-  if (!resizeSnapshot || !clientAttachedSnapshot) return false;
-  if (
-    (resizeSnapshot.command !== null && resizeSnapshot.command !== resizeArgs[4])
-    || (clientAttachedSnapshot.command !== null && clientAttachedSnapshot.command !== clientAttachedArgs[4])
-  ) return false;
-  if (resizeSnapshot.command === null && !runTmux(resizeArgs).ok) return false;
-  if (!tmuxHookMatchesSnapshot(hookTarget, { slot: resizeSlot, command: resizeArgs[4]! })) {
-    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot, clientAttachedArgs[4]!, resizeArgs[4]!);
-    return false;
-  }
-  if (clientAttachedSnapshot.command === null && !runTmux(clientAttachedArgs).ok) {
-    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot, clientAttachedArgs[4]!, resizeArgs[4]!);
-    return false;
-  }
-  if (!tmuxHookMatchesSnapshot(hookTarget, { slot: clientAttachedSlot, command: clientAttachedArgs[4]! })) {
-    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot, clientAttachedArgs[4]!, resizeArgs[4]!);
-    return false;
-  }
-  return true;
+  const attachedSlot = attachedArgs[3]!;
+  const resizeCommand = resizeArgs[4]!;
+  const attachedCommand = attachedArgs[4]!;
+  if (!mutateHudHookIfCurrent(hookTarget, resizeSlot, null, resizeCommand)) return false;
+  if (mutateHudHookIfCurrent(hookTarget, attachedSlot, null, attachedCommand)) return true;
+  mutateHudHookIfCurrent(hookTarget, resizeSlot, resizeCommand, null);
+  return false;
 }
 
-function restoreHudHookSnapshots(
-  hookTarget: string,
-  clientAttachedSnapshot: TmuxHookSnapshot,
-  resizeSnapshot: TmuxHookSnapshot,
-  expectedClientAttachedCurrent: string | null,
-  expectedResizeCurrent: string | null,
-): boolean {
-  // Always attempt both restores; each independently refuses a foreign/newer value.
-  const clientAttachedRestored = restoreTmuxHookSnapshot(hookTarget, clientAttachedSnapshot, expectedClientAttachedCurrent);
-  const resizeRestored = restoreTmuxHookSnapshot(hookTarget, resizeSnapshot, expectedResizeCurrent);
-  return clientAttachedRestored && resizeRestored;
-}
-
-/**
- * Removes the paired Team HUD hooks only when both can be snapshotted first.
- * If the second deletion fails, restore the first hook and report failure so
- * shutdown preserves the HUD pane and lifecycle metadata.
- */
+/** Teardown removes exactly the generation we installed; no snapshot/restore race. */
 export function unregisterHudHooksTransactionally(
   hookTarget: string,
   resizeHookName: string,
   clientAttachedHookName: string,
   hudPaneId: string,
+  generation?: string,
 ): boolean {
-  const resizeSlot = buildResizeHookSlot(resizeHookName);
-  const clientAttachedSlot = buildClientAttachedHookSlot(clientAttachedHookName);
-  const clientAttachedSnapshot = readTmuxHookSnapshot(hookTarget, clientAttachedSlot);
-  const resizeSnapshot = readTmuxHookSnapshot(hookTarget, resizeSlot);
-  const expectedResizeCommand = buildRegisterResizeHookArgs(hookTarget, resizeHookName, hudPaneId)[4];
-  const expectedClientAttachedCommand = buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId)[4];
-  if (!clientAttachedSnapshot || !resizeSnapshot) return false;
-  if (clientAttachedSnapshot.command === null && resizeSnapshot.command === null) return true;
-  if (
-    (clientAttachedSnapshot.command !== null && clientAttachedSnapshot.command !== expectedClientAttachedCommand)
-    || (resizeSnapshot.command !== null && resizeSnapshot.command !== expectedResizeCommand)
-  ) return false;
-
-  const remove = (snapshot: TmuxHookSnapshot): boolean => {
-    if (snapshot.command === null) return true;
-    if (!tmuxHookMatchesSnapshot(hookTarget, snapshot)) return false;
-    return runTmux(['set-hook', '-u', '-t', hookTarget, snapshot.slot]).ok
-      && tmuxHookIsAbsent(hookTarget, snapshot.slot);
-  };
-  const clientRemoved = remove(clientAttachedSnapshot);
-  const resizeRemoved = remove(resizeSnapshot);
-  if (!clientRemoved || !resizeRemoved) {
-    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot, null, null);
-    return false;
-  }
-  return true;
+  const resizeArgs = buildRegisterResizeHookArgs(hookTarget, resizeHookName, hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, generation);
+  const attachedArgs = buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, generation);
+  const attachedRemoved = mutateHudHookIfCurrent(hookTarget, attachedArgs[3]!, attachedArgs[4]!, null);
+  const resizeRemoved = mutateHudHookIfCurrent(hookTarget, resizeArgs[3]!, resizeArgs[4]!, null);
+  return attachedRemoved && resizeRemoved;
 }
 
 export function buildScheduleDelayedHudResizeArgs(
@@ -1984,6 +1943,9 @@ export function createTeamSession(
   let registeredResizeHook: { name: string; target: string } | null = null;
   let registeredClientAttachedHook: { name: string; target: string } | null = null;
   const rollbackPaneIds: string[] = [];
+  const rollbackPaneBirths = new Map<string, string>();
+  let createdHudPaneBirth: string | null = null;
+
   let rollbackOwnerSessionId = '';
   let rollbackTeamPaneOwnerId = '';
 
@@ -2035,6 +1997,12 @@ export function createTeamSession(
       tagPaneInstance(leaderPaneId, ownerSessionId);
     }
     tagPaneTeamOwner(leaderPaneId, teamPaneOwnerId);
+    options.journalResource?.({
+      kind: 'leader',
+      id: leaderPaneId,
+      created: false,
+      acquired_at: new Date().toISOString(),
+    });
     const [retainedHudPaneId, ...duplicateHudPaneIds] = hasExactHudAuthority
       ? findExactTeamHudPaneIds(teamTarget, hudExactCandidate)
       : [];
@@ -2104,7 +2072,20 @@ export function createTeamSession(
       }
       tagPaneInstance(paneId, ownerSessionId);
       tagPaneTeamOwner(paneId, teamPaneOwnerId);
+      const paneBirth = randomUUID();
+      tagTeamPaneBirth(paneId, paneBirth);
+      rollbackPaneBirths.set(paneId, paneBirth);
+      tagTeamPaneRole(paneId, 'worker');
+      options.journalResource?.({
+        kind: 'worker',
+        id: paneId,
+        created: true,
+        pane_birth: paneBirth,
+        acquired_at: new Date().toISOString(),
+      });
+
       workerPaneIds.push(paneId);
+
       if (i === 1) rightStackRootPaneId = paneId;
     }
 
@@ -2140,18 +2121,43 @@ export function createTeamSession(
       if (hudPaneId || hudResult?.ok) {
         const id = hudPaneId ?? (hudResult && hudResult.ok ? hudResult.stdout.split('\n')[0]?.trim() ?? '' : '');
         if (id.startsWith('%')) {
+          if (retainedHudPaneId) {
+            options.journalResource?.({
+              kind: 'hud',
+              id,
+              created: false,
+              pane_birth: readTeamPaneBirth(id) ?? undefined,
+              acquired_at: new Date().toISOString(),
+            });
+          }
           if (!retainedHudPaneId) rollbackPaneIds.push(id);
           if (isNativeWindows() && !waitForPaneToRemainPresent(teamTarget, id)) {
             throw new Error(`HUD pane did not remain present after tmux split-window returned ${id}`);
           }
-          if (!retainedHudPaneId && !tagNewHudPaneOrRollback(
-            id,
-            hudExactCandidate?.tmuxPaneInstanceId ?? ownerSessionId,
-            teamPaneOwnerId,
-          )) {
-            if (rollbackPaneIds[rollbackPaneIds.length - 1] === id) rollbackPaneIds.pop();
-            throw new Error(`failed to tag and verify HUD pane ${id}`);
+          if (!retainedHudPaneId) {
+            const paneBirth = randomUUID();
+            if (!tagNewHudPaneOrRollback(
+              id,
+              hudExactCandidate?.tmuxPaneInstanceId ?? ownerSessionId,
+              teamPaneOwnerId,
+            )) {
+              if (rollbackPaneIds[rollbackPaneIds.length - 1] === id) rollbackPaneIds.pop();
+              throw new Error(`failed to tag and verify HUD pane ${id}`);
+            }
+            tagTeamPaneBirth(id, paneBirth);
+            rollbackPaneBirths.set(id, paneBirth);
+            createdHudPaneBirth = paneBirth;
+            tagTeamPaneRole(id, 'hud');
+            options.journalResource?.({
+              kind: 'hud',
+              id,
+              created: true,
+              pane_birth: paneBirth,
+              acquired_at: new Date().toISOString(),
+            });
+
           }
+
           hudPaneId = id;
 
           if (isNativeWindows()) {
@@ -2170,7 +2176,11 @@ export function createTeamSession(
               windowIndex,
               hudPaneId,
             );
-            if (registerHudHooksTransactionally(hookTarget, hookName, clientAttachedHookName, hudPaneId)) {
+            // Persist both prospective hook slots before their first CAS. A failed
+            // CAS remains recovery evidence rather than a reason to discard metadata.
+            options.journalResource?.({ kind: 'hook', id: hookName, created: true, command: options.hookGeneration, acquired_at: new Date().toISOString() });
+            options.journalResource?.({ kind: 'hook', id: clientAttachedHookName, created: true, command: options.hookGeneration, acquired_at: new Date().toISOString() });
+            if (registerHudHooksTransactionally(hookTarget, hookName, clientAttachedHookName, hudPaneId, options.hookGeneration)) {
               resizeHookTarget = hookTarget;
               resizeHookName = hookName;
               registeredResizeHook = { name: resizeHookName, target: resizeHookTarget };
@@ -2215,6 +2225,11 @@ export function createTeamSession(
       leaderPaneId,
       hudPaneId,
       resizeHookName,
+      workerPaneBirths: Object.fromEntries(workerPaneIds.flatMap((paneId) => {
+        const birth = rollbackPaneBirths.get(paneId);
+        return birth ? [[paneId, birth]] : [];
+      })),
+      hudPaneBirth: createdHudPaneBirth,
       resizeHookTarget,
       teamPaneOwnerId,
     };
@@ -2231,11 +2246,12 @@ export function createTeamSession(
       runTmux(buildUnregisterResizeHookArgs(registeredResizeHook.target, registeredResizeHook.name));
     }
     // Every rollback candidate was tagged and read back before being journaled.
-    // Revalidate its exact Team ownership and both opaque births in tmux itself;
+    // Revalidate its exact Team ownership and opaque per-pane birth in tmux itself;
     // a failed conditional kill deliberately retains the pane for recovery.
     for (const paneId of rollbackPaneIds) {
-      if (!rollbackOwnerSessionId || !rollbackTeamPaneOwnerId) continue;
-      const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{@omx_pane_instance_id},${rollbackOwnerSessionId}},#{==:#{@omx_instance_id},${rollbackOwnerSessionId}},#{==:#{@omx_team_pane_owner_id},${rollbackTeamPaneOwnerId}}}`;
+      const paneBirth = rollbackPaneBirths.get(paneId);
+      if (!rollbackOwnerSessionId || !rollbackTeamPaneOwnerId || !paneBirth) continue;
+      const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{@omx_pane_instance_id},${rollbackOwnerSessionId}},#{==:#{@omx_instance_id},${rollbackOwnerSessionId}},#{==:#{@omx_team_pane_owner_id},${rollbackTeamPaneOwnerId}},#{==:#{@omx_team_pane_birth},${paneBirth}}}`;
       runTmux(['if-shell', '-t', paneId, '-F', condition, `kill-pane -t ${paneId}`, '']);
     }
     throw error;
@@ -3091,7 +3107,11 @@ export interface PaneTeardownOptions {
   leaderPaneId?: string | null;
   hudPaneId?: string | null;
   graceMs?: number;
+  /** Team generation identity required for destructive worker cleanup. */
+  teamPaneOwnerId?: string | null;
+  sessionName?: string | null;
 }
+
 
 export interface SharedSessionShutdownTopology {
   livePaneIds: string[];
@@ -3359,8 +3379,23 @@ export async function teardownWorkerPanes(
     },
   };
 
+  const sessionName = options.sessionName?.trim().split(':')[0] ?? '';
+  const teamOwnerId = options.teamPaneOwnerId?.trim() ?? '';
   for (const paneId of killablePaneIds) {
-    const result = await runTmuxAsync(['kill-pane', '-t', paneId]);
+    // Snapshot opaque births, then have tmux compare every identity in the same
+    // server command that performs the kill. Re-used pane ids fail closed.
+    const paneBirth = readTeamPaneBirth(paneId);
+    const sessionBirthResult = sessionName
+      ? runTmux(['show-options', '-qv', '-t', sessionName, OMX_INSTANCE_OPTION])
+      : null;
+    const sessionBirth = sessionBirthResult?.ok ? sessionBirthResult.stdout.trim() : '';
+    if (!paneBirth || !sessionBirth || !sessionName || !teamOwnerId) {
+      summary.kill.failed += 1;
+      await sleep(perPaneGrace);
+      continue;
+    }
+    const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{session_name},${sessionName}},#{==:#{@omx_instance_id},${sessionBirth}},#{==:#{@omx_team_pane_owner_id},${teamOwnerId}},#{==:#{@omx_team_pane_birth},${paneBirth}},#{==:#{@omx_team_pane_role},worker}}`;
+    const result = await runTmuxAsync(['if-shell', '-t', paneId, '-F', condition, `kill-pane -t ${paneId}`, '']);
     if (result.ok) summary.kill.succeeded += 1;
     else summary.kill.failed += 1;
     await sleep(perPaneGrace);

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { spawnSync, execFile } from 'child_process';
 import { promisify } from 'util';
 import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'fs';
@@ -86,6 +87,77 @@ export interface ExactTeamHudCandidate {
   leaderPaneId: string;
   tmuxSessionInstanceId: string;
   tmuxPaneInstanceId: string;
+  /** Live tmux context captured alongside the tags, used to reject ABA races before HUD mutation. */
+  tmuxSessionName?: string;
+  tmuxWindowIndex?: string;
+}
+
+export interface EstablishExactTeamHudCandidateOptions {
+  sessionId?: string | null;
+  sessionIds?: string[] | null;
+  expectedLeaderPaneId?: string | null;
+}
+
+interface ExactTeamHudCandidateContext extends ExactTeamHudCandidate {
+  tmuxSessionName: string;
+  tmuxWindowIndex: string;
+}
+
+/**
+ * Obtains live tmux identity evidence for a managed Team HUD. This deliberately
+ * never trusts process environment instance IDs: each tag is read from tmux,
+ * established only when absent, then read back before use.
+ */
+export function establishExactTeamHudCandidate(
+  options: EstablishExactTeamHudCandidateOptions,
+): ExactTeamHudCandidateContext | null {
+  const sessionId = options.sessionId?.trim() ?? '';
+  const sessionIds = [...new Set([sessionId, ...(options.sessionIds ?? [])]
+    .map((value) => value.trim())
+    .filter(Boolean))];
+  const expectedLeaderPaneId = normalizePaneTarget(options.expectedLeaderPaneId);
+  if (!sessionId || sessionIds.length === 0) return null;
+
+  const paneTarget = normalizePaneTarget(process.env.TMUX_PANE);
+  const displayArgs = paneTarget
+    ? ['display-message', '-p', '-t', paneTarget, '#{session_name}:#{window_index} #{pane_id}']
+    : ['display-message', '-p', '#{session_name}:#{window_index} #{pane_id}'];
+  const readContext = (): { sessionName: string; windowIndex: string; leaderPaneId: string } | null => {
+    const context = runTmux(displayArgs);
+    if (!context.ok) return null;
+    const [sessionAndWindow = '', leaderPaneId = ''] = context.stdout.split(' ').map((value) => value.trim());
+    const [sessionName = '', windowIndex = ''] = sessionAndWindow.split(':').map((value) => value.trim());
+    if (!sessionName || !windowIndex || !normalizePaneTarget(leaderPaneId)) return null;
+    return { sessionName, windowIndex, leaderPaneId };
+  };
+
+  const before = readContext();
+  if (!before || (expectedLeaderPaneId && before.leaderPaneId !== expectedLeaderPaneId)) return null;
+  const sessionTag = runTmux(['show-options', '-qv', '-t', before.sessionName, OMX_INSTANCE_OPTION]);
+  if (!sessionTag.ok) return null;
+  const tmuxSessionInstanceId = sessionTag.stdout.trim() || randomUUID();
+  if (!sessionTag.stdout.trim() && !runTmux(['set-option', '-t', before.sessionName, OMX_INSTANCE_OPTION, tmuxSessionInstanceId]).ok) return null;
+  const verifiedSessionTag = runTmux(['show-options', '-qv', '-t', before.sessionName, OMX_INSTANCE_OPTION]);
+  if (!verifiedSessionTag.ok || verifiedSessionTag.stdout.trim() !== tmuxSessionInstanceId) return null;
+
+  const paneTag = runTmux(['show-option', '-qv', '-p', '-t', before.leaderPaneId, OMX_PANE_INSTANCE_OPTION]);
+  if (!paneTag.ok) return null;
+  const tmuxPaneInstanceId = paneTag.stdout.trim() || randomUUID();
+  if (!paneTag.stdout.trim() && !runTmux(['set-option', '-p', '-t', before.leaderPaneId, OMX_PANE_INSTANCE_OPTION, tmuxPaneInstanceId]).ok) return null;
+  const verifiedPaneTag = runTmux(['show-option', '-qv', '-p', '-t', before.leaderPaneId, OMX_PANE_INSTANCE_OPTION]);
+  if (!verifiedPaneTag.ok || verifiedPaneTag.stdout.trim() !== tmuxPaneInstanceId) return null;
+
+  const after = readContext();
+  if (!after || after.sessionName !== before.sessionName || after.windowIndex !== before.windowIndex || after.leaderPaneId !== before.leaderPaneId) return null;
+  return {
+    sessionId,
+    sessionIds,
+    leaderPaneId: before.leaderPaneId,
+    tmuxSessionInstanceId,
+    tmuxPaneInstanceId,
+    tmuxSessionName: before.sessionName,
+    tmuxWindowIndex: before.windowIndex,
+  };
 }
 
 export interface RestoreStandaloneHudPaneOptions {
@@ -398,8 +470,18 @@ function normalizeExactTeamHudCandidate(candidate: ExactTeamHudCandidate | null 
   const tmuxSessionInstanceId = candidate?.tmuxSessionInstanceId?.trim() ?? '';
   const tmuxPaneInstanceId = candidate?.tmuxPaneInstanceId?.trim() ?? '';
   const sessionIds = [...new Set([sessionId, ...(candidate?.sessionIds ?? [])].map((id) => id.trim()).filter(Boolean))];
+  const tmuxSessionName = candidate?.tmuxSessionName?.trim() || undefined;
+  const tmuxWindowIndex = candidate?.tmuxWindowIndex?.trim() || undefined;
   if (!sessionId || !leaderPaneId || !tmuxSessionInstanceId || !tmuxPaneInstanceId || sessionIds.length === 0) return null;
-  return { sessionId, sessionIds, leaderPaneId, tmuxSessionInstanceId, tmuxPaneInstanceId };
+  return {
+    sessionId,
+    sessionIds,
+    leaderPaneId,
+    tmuxSessionInstanceId,
+    tmuxPaneInstanceId,
+    ...(tmuxSessionName ? { tmuxSessionName } : {}),
+    ...(tmuxWindowIndex ? { tmuxWindowIndex } : {}),
+  };
 }
 function readPaneCurrentPath(paneId: string): string | null {
   if (!paneId.startsWith('%')) return null;
@@ -1677,14 +1759,25 @@ export function createTeamSession(
     const panes = listPanes(teamTarget);
     const leaderPaneId = chooseTeamLeaderPaneId(panes, detectedLeaderPaneId);
     const hudExactCandidate = normalizeExactTeamHudCandidate(options.hudExactCandidate);
-    const hasExactHudAuthority = Boolean(hudExactCandidate && hudExactCandidate.leaderPaneId === leaderPaneId);
-    if (hudExactCandidate?.tmuxSessionInstanceId) {
-      const tagResult = runTmux(['set-option', '-t', sessionName, OMX_INSTANCE_OPTION, hudExactCandidate.tmuxSessionInstanceId]);
-      if (!tagResult.ok) {
-        throw new Error(`failed to tag tmux session ${sessionName}: ${tagResult.stderr}`);
-      }
+    const recheckedSessionTag = hudExactCandidate?.tmuxSessionName
+      ? runTmux(['show-options', '-qv', '-t', sessionName, OMX_INSTANCE_OPTION])
+      : null;
+    const hudEvidenceStillMatches = !hudExactCandidate?.tmuxSessionName
+      || (
+        hudExactCandidate.tmuxSessionName === sessionName
+        && hudExactCandidate.tmuxWindowIndex === windowIndex
+        && recheckedSessionTag?.ok
+        && recheckedSessionTag.stdout.trim() === hudExactCandidate.tmuxSessionInstanceId
+        && paneHasOmxInstanceTag(leaderPaneId, hudExactCandidate.tmuxPaneInstanceId)
+      );
+    const hasExactHudAuthority = Boolean(
+      hudExactCandidate
+      && hudExactCandidate.leaderPaneId === leaderPaneId
+      && hudEvidenceStillMatches,
+    );
+    if (!hudExactCandidate) {
+      tagPaneInstance(leaderPaneId, ownerSessionId);
     }
-    tagPaneInstance(leaderPaneId, hudExactCandidate?.tmuxPaneInstanceId ?? ownerSessionId);
     tagPaneTeamOwner(leaderPaneId, teamPaneOwnerId);
     const [retainedHudPaneId, ...duplicateHudPaneIds] = hasExactHudAuthority
       ? findExactTeamHudPaneIds(teamTarget, hudExactCandidate)

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -981,8 +981,10 @@ function readTmuxHookSnapshot(hookTarget: string, slot: string): TmuxHookSnapsho
 }
 
 function restoreTmuxHookSnapshot(hookTarget: string, snapshot: TmuxHookSnapshot): boolean {
-  if (snapshot.command === null) return true;
-  return runTmux(['set-hook', '-t', hookTarget, snapshot.slot, snapshot.command]).ok;
+  const result = snapshot.command === null
+    ? runTmux(['set-hook', '-u', '-t', hookTarget, snapshot.slot])
+    : runTmux(['set-hook', '-t', hookTarget, snapshot.slot, snapshot.command]);
+  return result.ok && tmuxHookMatchesSnapshot(hookTarget, snapshot);
 }
 
 function tmuxHookMatchesSnapshot(hookTarget: string, expected: TmuxHookSnapshot): boolean {
@@ -1044,8 +1046,12 @@ function restoreHudHookSnapshots(
   clientAttachedSnapshot: TmuxHookSnapshot,
   resizeSnapshot: TmuxHookSnapshot,
 ): boolean {
-  return restoreTmuxHookSnapshot(hookTarget, clientAttachedSnapshot)
-    && restoreTmuxHookSnapshot(hookTarget, resizeSnapshot)
+  // Always attempt and verify both restores. A failed first restore must not
+  // leave the other slot in a transaction-created state.
+  const clientAttachedRestored = restoreTmuxHookSnapshot(hookTarget, clientAttachedSnapshot);
+  const resizeRestored = restoreTmuxHookSnapshot(hookTarget, resizeSnapshot);
+  return clientAttachedRestored
+    && resizeRestored
     && tmuxHookMatchesSnapshot(hookTarget, clientAttachedSnapshot)
     && tmuxHookMatchesSnapshot(hookTarget, resizeSnapshot);
 }
@@ -1067,19 +1073,18 @@ export function unregisterHudHooksTransactionally(
   const resizeSnapshot = readTmuxHookSnapshot(hookTarget, resizeSlot);
   const expectedResizeCommand = buildRegisterResizeHookArgs(hookTarget, resizeHookName, hudPaneId)[4];
   const expectedClientAttachedCommand = buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId)[4];
+  if (!clientAttachedSnapshot || !resizeSnapshot) return false;
+  if (clientAttachedSnapshot.command === null && resizeSnapshot.command === null) return true;
   if (
-    !clientAttachedSnapshot
-    || !resizeSnapshot
-    || clientAttachedSnapshot.command !== expectedClientAttachedCommand
-    || resizeSnapshot.command !== expectedResizeCommand
+    (clientAttachedSnapshot.command !== null && clientAttachedSnapshot.command !== expectedClientAttachedCommand)
+    || (resizeSnapshot.command !== null && resizeSnapshot.command !== expectedResizeCommand)
   ) return false;
 
-  if (!runTmux(['set-hook', '-u', '-t', hookTarget, clientAttachedSlot]).ok) return false;
-  if (!tmuxHookIsAbsent(hookTarget, clientAttachedSlot)) {
-    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot);
-    return false;
-  }
-  if (!runTmux(['set-hook', '-u', '-t', hookTarget, resizeSlot]).ok || !tmuxHookIsAbsent(hookTarget, resizeSlot)) {
+  const remove = (slot: string, installed: boolean): boolean => !installed
+    || (runTmux(['set-hook', '-u', '-t', hookTarget, slot]).ok && tmuxHookIsAbsent(hookTarget, slot));
+  const clientRemoved = remove(clientAttachedSlot, clientAttachedSnapshot.command !== null);
+  const resizeRemoved = remove(resizeSlot, resizeSnapshot.command !== null);
+  if (!clientRemoved || !resizeRemoved) {
     restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot);
     return false;
   }

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -169,12 +169,10 @@ export function probeExactTeamHudCandidate(
     .map((value) => value.trim())
     .filter(Boolean))];
   const expectedLeaderPaneId = normalizePaneTarget(options.expectedLeaderPaneId);
-  if (!sessionId || sessionIds.length === 0) return null;
+  if (!sessionId || sessionIds.length === 0 || !expectedLeaderPaneId) return null;
 
-  const paneTarget = normalizePaneTarget(process.env.TMUX_PANE);
-  const displayArgs = paneTarget
-    ? ['display-message', '-p', '-t', paneTarget, '#{session_name}:#{window_index} #{pane_id}']
-    : ['display-message', '-p', '#{session_name}:#{window_index} #{pane_id}'];
+  const paneTarget = expectedLeaderPaneId;
+  const displayArgs = ['display-message', '-p', '-t', paneTarget, '#{session_name}:#{window_index} #{pane_id}'];
   const readContext = (): { sessionName: string; windowIndex: string; leaderPaneId: string } | null => {
     const context = runTmux(displayArgs);
     if (!context.ok) return null;
@@ -1005,6 +1003,40 @@ export function registerHudHookIfVacant(hookTarget: string, args: string[]): boo
   if (!snapshot || (snapshot.command !== null && snapshot.command !== command)) return false;
   if (snapshot.command === command) return true;
   return runTmux(args).ok;
+}
+
+/** Installs the paired Team HUD hooks atomically, preserving foreign hook slots. */
+export function registerHudHooksTransactionally(
+  hookTarget: string,
+  resizeHookName: string,
+  clientAttachedHookName: string,
+  hudPaneId: string,
+): boolean {
+  const resizeArgs = buildRegisterResizeHookArgs(hookTarget, resizeHookName, hudPaneId);
+  const clientAttachedArgs = buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId);
+  const resizeSlot = resizeArgs[3]!;
+  const clientAttachedSlot = clientAttachedArgs[3]!;
+  const resizeSnapshot = readTmuxHookSnapshot(hookTarget, resizeSlot);
+  const clientAttachedSnapshot = readTmuxHookSnapshot(hookTarget, clientAttachedSlot);
+  if (!resizeSnapshot || !clientAttachedSnapshot) return false;
+  if (
+    (resizeSnapshot.command !== null && resizeSnapshot.command !== resizeArgs[4])
+    || (clientAttachedSnapshot.command !== null && clientAttachedSnapshot.command !== clientAttachedArgs[4])
+  ) return false;
+  if (resizeSnapshot.command === null && !runTmux(resizeArgs).ok) return false;
+  if (!tmuxHookMatchesSnapshot(hookTarget, { slot: resizeSlot, command: resizeArgs[4]! })) {
+    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot);
+    return false;
+  }
+  if (clientAttachedSnapshot.command === null && !runTmux(clientAttachedArgs).ok) {
+    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot);
+    return false;
+  }
+  if (!tmuxHookMatchesSnapshot(hookTarget, { slot: clientAttachedSlot, command: clientAttachedArgs[4]! })) {
+    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot);
+    return false;
+  }
+  return true;
 }
 
 function restoreHudHookSnapshots(
@@ -2096,39 +2128,21 @@ export function createTeamSession(
           } else {
             const hookTarget = buildResizeHookTarget(sessionName, windowIndex);
             const hookName = buildResizeHookName(safeTeamName, sessionName, windowIndex, hudPaneId);
-            const registerHook = registerHudHookIfVacant(hookTarget, buildRegisterResizeHookArgs(hookTarget, hookName, hudPaneId));
             const clientAttachedHookName = buildClientAttachedReconcileHookName(
               safeTeamName,
               sessionName,
               windowIndex,
               hudPaneId,
             );
-            if (registerHook) {
+            if (registerHudHooksTransactionally(hookTarget, hookName, clientAttachedHookName, hudPaneId)) {
               resizeHookTarget = hookTarget;
               resizeHookName = hookName;
               registeredResizeHook = { name: resizeHookName, target: resizeHookTarget };
-            } else {
-              // tmux versions/builds that reject indexed client-resized hooks should not
-              // abort madmax/team startup after panes were successfully created. Keep the
-              // fallback narrow: skip only the long-lived resize hook metadata, then
-              // still try the one-shot client-attached reconcile plus the explicit
-              // delayed/direct resize checks below so real tmux/run-shell failures
-              // still surface.
-              console.warn(
-                `[omx] tmux resize hook unavailable or occupied for ${hookTarget} (${hookName}); `
-                  + 'continuing with best-effort HUD resize fallback.',
-              );
-            }
-            const registerClientAttachedHook = registerHudHookIfVacant(
-              hookTarget,
-              buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId),
-            );
-            if (registerClientAttachedHook) {
               registeredClientAttachedHook = { name: clientAttachedHookName, target: hookTarget };
             } else {
               console.warn(
-                `[omx] tmux client-attached resize fallback unavailable or occupied for ${hookTarget} `
-                  + `(${clientAttachedHookName}); continuing with delayed HUD resize fallback.`,
+                `[omx] tmux HUD hooks unavailable, occupied, or changed during registration for ${hookTarget}; `
+                  + 'continuing with delayed HUD resize fallback.',
               );
             }
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -348,6 +348,34 @@ function tagPaneInstance(paneTarget: string, instanceId: string): void {
   }
 }
 
+function readPaneInstanceTag(paneTarget: string): string | null {
+  const result = runTmux(['show-option', '-qv', '-p', '-t', paneTarget, OMX_PANE_INSTANCE_OPTION]);
+  return result.ok ? result.stdout.trim() : null;
+}
+
+function readNewPaneTeamOwnerTag(paneTarget: string): string | null {
+  const result = runTmux(['show-option', '-qv', '-p', '-t', paneTarget, OMX_TEAM_PANE_OWNER_OPTION]);
+  return result.ok ? result.stdout.trim() : null;
+}
+
+function tagNewHudPaneOrRollback(
+  paneId: string,
+  instanceId: string,
+  teamOwnerId?: string,
+): boolean {
+  try {
+    tagPaneInstance(paneId, instanceId);
+    if (teamOwnerId) tagPaneTeamOwner(paneId, teamOwnerId);
+    const tagsMatch = readPaneInstanceTag(paneId) === instanceId
+      && (!teamOwnerId || readNewPaneTeamOwnerTag(paneId) === teamOwnerId);
+    if (tagsMatch) return true;
+  } catch {
+    // Roll back only the pane created by this transaction.
+  }
+  runTmux(['kill-pane', '-t', paneId]);
+  return false;
+}
+
 export function tagPaneTeamOwner(paneTarget: string, teamOwnerId: string): void {
   const target = paneTarget.trim();
   const sanitized = teamOwnerId.trim();
@@ -911,6 +939,11 @@ export function buildUnregisterClientAttachedReconcileArgs(hookTarget: string, h
 
 export function unregisterResizeHook(hookTarget: string, hookName: string): boolean {
   const result = runTmux(buildUnregisterResizeHookArgs(hookTarget, hookName));
+  return result.ok;
+}
+
+export function unregisterClientAttachedReconcileHook(hookTarget: string, hookName: string): boolean {
+  const result = runTmux(buildUnregisterClientAttachedReconcileArgs(hookTarget, hookName));
   return result.ok;
 }
 
@@ -1936,8 +1969,14 @@ export function createTeamSession(
           if (isNativeWindows() && !waitForPaneToRemainPresent(teamTarget, id)) {
             throw new Error(`HUD pane did not remain present after tmux split-window returned ${id}`);
           }
-          tagPaneInstance(id, hudExactCandidate?.tmuxPaneInstanceId ?? ownerSessionId);
-          tagPaneTeamOwner(id, teamPaneOwnerId);
+          if (!tagNewHudPaneOrRollback(
+            id,
+            hudExactCandidate?.tmuxPaneInstanceId ?? ownerSessionId,
+            teamPaneOwnerId,
+          )) {
+            if (!retainedHudPaneId && rollbackPaneIds[rollbackPaneIds.length - 1] === id) rollbackPaneIds.pop();
+            throw new Error(`failed to tag and verify HUD pane ${id}`);
+          }
           hudPaneId = id;
 
           if (isNativeWindows()) {
@@ -2105,7 +2144,7 @@ export function restoreStandaloneHudPane(
 
   const paneId = hudResult.stdout.split('\n')[0]?.trim() ?? '';
   if (!paneId.startsWith('%')) return null;
-  if (tmuxPaneInstanceId) tagPaneInstance(paneId, tmuxPaneInstanceId);
+  if (tmuxPaneInstanceId && !tagNewHudPaneOrRollback(paneId, tmuxPaneInstanceId)) return null;
 
   if (isNativeWindows()) {
     runTmux(buildHudResizeArgs(paneId));

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -388,10 +388,12 @@ function tagNewHudPaneOrRollback(
       && (!teamOwnerId || readNewPaneTeamOwnerTag(paneId) === teamOwnerId);
     if (tagsMatch) return true;
   } catch {
-    // Roll back only the pane created by this transaction.
+    // The split may have succeeded but its ownership tags could not be verified.
+    // Pane ids are reusable, so an untagged pane must be preserved rather than
+    // killed by a stale id during rollback.
   }
-  runTmux(['kill-pane', '-t', paneId]);
   return false;
+
 }
 
 export function tagPaneTeamOwner(paneTarget: string, teamOwnerId: string): void {
@@ -563,9 +565,10 @@ export function killExactTeamHudPane(
 ): boolean {
   if (!findExactTeamHudPaneIds(target, candidate).includes(paneId)) return false;
   const sessionName = candidate.tmuxSessionName ?? target.split(':')[0] ?? '';
-  const ownerCondition = teamOwnerId ? `,#{==:#{@omx_team_pane_owner},${teamOwnerId}}` : '';
-  const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{@omx_pane_instance_id},${candidate.tmuxPaneInstanceId}},#{==:#{session_name},${sessionName}}${ownerCondition}}`;
+  const ownerCondition = teamOwnerId ? `,#{==:#{@omx_team_pane_owner_id},${teamOwnerId}}` : '';
+  const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{@omx_pane_instance_id},${candidate.tmuxPaneInstanceId}},#{==:#{@omx_instance_id},${candidate.tmuxSessionInstanceId}},#{==:#{session_name},${sessionName}}${ownerCondition}}`;
   const result = runTmux(['if-shell', '-t', paneId, '-F', condition, `kill-pane -t ${paneId}`, '']);
+
   return result.ok && !findExactTeamHudPaneIds(target, candidate).includes(paneId);
 }
 
@@ -1981,6 +1984,9 @@ export function createTeamSession(
   let registeredResizeHook: { name: string; target: string } | null = null;
   let registeredClientAttachedHook: { name: string; target: string } | null = null;
   const rollbackPaneIds: string[] = [];
+  let rollbackOwnerSessionId = '';
+  let rollbackTeamPaneOwnerId = '';
+
   try {
     const tmuxPaneTarget = process.env.TMUX_PANE;
     const displayArgs = tmuxPaneTarget
@@ -1999,6 +2005,9 @@ export function createTeamSession(
     const teamTarget = `${sessionName}:${windowIndex}`;
     const ownerSessionId = (options.ownerSessionId ?? process.env.OMX_SESSION_ID ?? '').trim();
     const teamPaneOwnerId = (options.teamPaneOwnerId ?? `team:${safeTeamName}`).trim();
+    rollbackOwnerSessionId = ownerSessionId;
+    rollbackTeamPaneOwnerId = teamPaneOwnerId;
+
     const panes = listPanes(teamTarget);
     const leaderPaneId = chooseTeamLeaderPaneId(panes, detectedLeaderPaneId);
     const hudExactCandidate = normalizeExactTeamHudCandidate(options.hudExactCandidate);
@@ -2221,8 +2230,13 @@ export function createTeamSession(
     if (registeredResizeHook) {
       runTmux(buildUnregisterResizeHookArgs(registeredResizeHook.target, registeredResizeHook.name));
     }
+    // Every rollback candidate was tagged and read back before being journaled.
+    // Revalidate its exact Team ownership and both opaque births in tmux itself;
+    // a failed conditional kill deliberately retains the pane for recovery.
     for (const paneId of rollbackPaneIds) {
-      runTmux(['kill-pane', '-t', paneId]);
+      if (!rollbackOwnerSessionId || !rollbackTeamPaneOwnerId) continue;
+      const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{@omx_pane_instance_id},${rollbackOwnerSessionId}},#{==:#{@omx_instance_id},${rollbackOwnerSessionId}},#{==:#{@omx_team_pane_owner_id},${rollbackTeamPaneOwnerId}}}`;
+      runTmux(['if-shell', '-t', paneId, '-F', condition, `kill-pane -t ${paneId}`, '']);
     }
     throw error;
   }

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -213,14 +213,12 @@ export function findExactTeamHudPane(
   if (!hudPaneId || sessionName.trim() !== candidate.tmuxSessionName) return null;
   const pane = listPanes(sessionName).find((entry) => entry.paneId === hudPaneId);
   if (!pane || !isHudWatchPane(pane)) return null;
-  return hudPaneMatchesExactCandidate(pane, {
+  return hudPaneMatchesOwner(pane, {
     sessionId: candidate.sessionId,
     sessionIds: candidate.sessionIds,
     leaderPaneId: candidate.leaderPaneId,
-  }, {
-    tmuxSessionInstanceId: candidate.tmuxSessionInstanceId,
-    tmuxPaneInstanceId: candidate.tmuxPaneInstanceId,
-  }) ? hudPaneId : null;
+  }) && Boolean(pane.paneInstanceId?.trim())
+    && pane.sessionInstanceId === candidate.tmuxSessionInstanceId ? hudPaneId : null;
 }
 
 export interface RestoreStandaloneHudPaneOptions {
@@ -672,10 +670,10 @@ export function killExactTeamHudPane(
     || !receipt.pane_birth || !receipt.command || !teamOwnerId) return false;
   if (!findExactTeamHudPaneIds(target, candidate).includes(paneId)) return false;
   const sessionName = candidate.tmuxSessionName ?? target.split(':')[0] ?? '';
-  if (!sessionName || !candidate.tmuxSessionInstanceId || !candidate.tmuxPaneInstanceId) return false;
+  if (!sessionName || !candidate.tmuxSessionInstanceId) return false;
   const appliedReceipt = `__omx_hud_teardown_applied_${randomUUID()}__`;
   const rejectedReceipt = `__omx_hud_teardown_rejected_${randomUUID()}__`;
-  const condition = `#{&&:#{==:#{pane_id},${escapeTmuxFormatLiteral(paneId)}},#{==:#{pane_start_command},${escapeTmuxFormatLiteral(receipt.command)}},#{==:#{@omx_pane_instance_id},${escapeTmuxFormatLiteral(candidate.tmuxPaneInstanceId)}},#{==:#{@omx_instance_id},${escapeTmuxFormatLiteral(candidate.tmuxSessionInstanceId)}},#{==:#{session_name},${escapeTmuxFormatLiteral(sessionName)}},#{==:#{@omx_team_pane_owner_id},${escapeTmuxFormatLiteral(teamOwnerId)}},#{==:#{@omx_team_pane_birth},${escapeTmuxFormatLiteral(receipt.pane_birth)}},#{==:#{@omx_team_pane_role},${escapeTmuxFormatLiteral('hud')}}}`;
+  const condition = `#{&&:#{==:#{pane_id},${escapeTmuxFormatLiteral(paneId)}},#{==:#{pane_start_command},${escapeTmuxFormatLiteral(receipt.command)}},#{==:#{@omx_pane_instance_id},${escapeTmuxFormatLiteral(receipt.pane_birth)}},#{==:#{@omx_instance_id},${escapeTmuxFormatLiteral(candidate.tmuxSessionInstanceId)}},#{==:#{session_name},${escapeTmuxFormatLiteral(sessionName)}},#{==:#{@omx_team_pane_owner_id},${escapeTmuxFormatLiteral(teamOwnerId)}},#{==:#{@omx_team_pane_birth},${escapeTmuxFormatLiteral(receipt.pane_birth)}},#{==:#{@omx_team_pane_role},${escapeTmuxFormatLiteral('hud')}}}`;
   const result = runTmux([
     'if-shell', '-t', paneId, '-F', condition,
     `kill-pane -t ${paneId} \\; display-message -p ${appliedReceipt}`,
@@ -2309,7 +2307,7 @@ export function createTeamSession(
           }
           if (!retainedHudPaneId) {
             const paneBirth = randomUUID();
-            const paneInstanceBirth = randomUUID();
+            const paneInstanceBirth = paneBirth;
             if (!tagNewHudPaneOrRollback(id, paneInstanceBirth, teamPaneOwnerId)) {
               throw new Error(`failed to tag and verify HUD pane ${id}`);
             }

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -2176,11 +2176,25 @@ export function createTeamSession(
       && hudExactCandidate.leaderPaneId === leaderPaneId
       && hudEvidenceStillMatches,
     );
+    const observedLeaderBirth = readPaneInstanceTag(leaderPaneId)?.trim() ?? '';
+    if (!rollbackSessionBirth || !observedLeaderBirth) {
+      throw new Error('missing_exact_team_leader_birth');
+    }
     tagPaneTeamOwner(leaderPaneId, teamPaneOwnerId);
+    const lockedSessionBirth = runTmux(['show-options', '-qv', '-t', sessionName, OMX_INSTANCE_OPTION]);
+    const lockedLeaderBirth = readPaneInstanceTag(leaderPaneId)?.trim() ?? '';
+    if (
+      !lockedSessionBirth.ok
+      || lockedSessionBirth.stdout.trim() !== rollbackSessionBirth
+      || lockedLeaderBirth !== observedLeaderBirth
+    ) {
+      throw new Error('changed_exact_team_leader_birth');
+    }
     options.journalResource?.({
       kind: 'leader',
       id: leaderPaneId,
       created: false,
+      pane_birth: observedLeaderBirth,
       acquired_at: new Date().toISOString(),
     });
     const exactHudPaneIds = hasExactHudAuthority

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -160,6 +160,50 @@ export function establishExactTeamHudCandidate(
   };
 }
 
+/** Reads exact live Team HUD evidence without establishing or rewriting tmux tags. */
+export function probeExactTeamHudCandidate(
+  options: EstablishExactTeamHudCandidateOptions,
+): ExactTeamHudCandidateContext | null {
+  const sessionId = options.sessionId?.trim() ?? '';
+  const sessionIds = [...new Set([sessionId, ...(options.sessionIds ?? [])]
+    .map((value) => value.trim())
+    .filter(Boolean))];
+  const expectedLeaderPaneId = normalizePaneTarget(options.expectedLeaderPaneId);
+  if (!sessionId || sessionIds.length === 0) return null;
+
+  const paneTarget = normalizePaneTarget(process.env.TMUX_PANE);
+  const displayArgs = paneTarget
+    ? ['display-message', '-p', '-t', paneTarget, '#{session_name}:#{window_index} #{pane_id}']
+    : ['display-message', '-p', '#{session_name}:#{window_index} #{pane_id}'];
+  const readContext = (): { sessionName: string; windowIndex: string; leaderPaneId: string } | null => {
+    const context = runTmux(displayArgs);
+    if (!context.ok) return null;
+    const [sessionAndWindow = '', leaderPaneId = ''] = context.stdout.split(' ').map((value) => value.trim());
+    const [sessionName = '', windowIndex = ''] = sessionAndWindow.split(':').map((value) => value.trim());
+    if (!sessionName || !windowIndex || !normalizePaneTarget(leaderPaneId)) return null;
+    return { sessionName, windowIndex, leaderPaneId };
+  };
+
+  const before = readContext();
+  if (!before || (expectedLeaderPaneId && before.leaderPaneId !== expectedLeaderPaneId)) return null;
+  const sessionTag = runTmux(['show-options', '-qv', '-t', before.sessionName, OMX_INSTANCE_OPTION]);
+  const paneTag = runTmux(['show-option', '-qv', '-p', '-t', before.leaderPaneId, OMX_PANE_INSTANCE_OPTION]);
+  const tmuxSessionInstanceId = sessionTag.ok ? sessionTag.stdout.trim() : '';
+  const tmuxPaneInstanceId = paneTag.ok ? paneTag.stdout.trim() : '';
+  if (!tmuxSessionInstanceId || !tmuxPaneInstanceId) return null;
+  const after = readContext();
+  if (!after || after.sessionName !== before.sessionName || after.windowIndex !== before.windowIndex || after.leaderPaneId !== before.leaderPaneId) return null;
+  return {
+    sessionId,
+    sessionIds,
+    leaderPaneId: before.leaderPaneId,
+    tmuxSessionInstanceId,
+    tmuxPaneInstanceId,
+    tmuxSessionName: before.sessionName,
+    tmuxWindowIndex: before.windowIndex,
+  };
+}
+
 export interface RestoreStandaloneHudPaneOptions {
   /** Canonical session id that prompt-submit HUD reconciliation should use to dedupe the restored HUD. */
   sessionId?: string | null;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -996,6 +996,17 @@ function tmuxHookIsAbsent(hookTarget: string, slot: string): boolean {
   return readTmuxHookSnapshot(hookTarget, slot)?.command === null;
 }
 
+/** Registers only an empty hook slot or an identical OMX command; foreign collisions are preserved. */
+export function registerHudHookIfVacant(hookTarget: string, args: string[]): boolean {
+  const slot = args[3]?.trim() ?? '';
+  const command = args[4] ?? '';
+  if (!slot || !command) return false;
+  const snapshot = readTmuxHookSnapshot(hookTarget, slot);
+  if (!snapshot || (snapshot.command !== null && snapshot.command !== command)) return false;
+  if (snapshot.command === command) return true;
+  return runTmux(args).ok;
+}
+
 function restoreHudHookSnapshots(
   hookTarget: string,
   clientAttachedSnapshot: TmuxHookSnapshot,
@@ -2085,14 +2096,14 @@ export function createTeamSession(
           } else {
             const hookTarget = buildResizeHookTarget(sessionName, windowIndex);
             const hookName = buildResizeHookName(safeTeamName, sessionName, windowIndex, hudPaneId);
-            const registerHook = runTmux(buildRegisterResizeHookArgs(hookTarget, hookName, hudPaneId));
+            const registerHook = registerHudHookIfVacant(hookTarget, buildRegisterResizeHookArgs(hookTarget, hookName, hudPaneId));
             const clientAttachedHookName = buildClientAttachedReconcileHookName(
               safeTeamName,
               sessionName,
               windowIndex,
               hudPaneId,
             );
-            if (registerHook.ok) {
+            if (registerHook) {
               resizeHookTarget = hookTarget;
               resizeHookName = hookName;
               registeredResizeHook = { name: resizeHookName, target: resizeHookTarget };
@@ -2104,19 +2115,20 @@ export function createTeamSession(
               // delayed/direct resize checks below so real tmux/run-shell failures
               // still surface.
               console.warn(
-                `[omx] tmux resize hook unavailable for ${hookTarget} (${hookName}): ${registerHook.stderr}; `
+                `[omx] tmux resize hook unavailable or occupied for ${hookTarget} (${hookName}); `
                   + 'continuing with best-effort HUD resize fallback.',
               );
             }
-            const registerClientAttachedHook = runTmux(
+            const registerClientAttachedHook = registerHudHookIfVacant(
+              hookTarget,
               buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId),
             );
-            if (registerClientAttachedHook.ok) {
+            if (registerClientAttachedHook) {
               registeredClientAttachedHook = { name: clientAttachedHookName, target: hookTarget };
             } else {
               console.warn(
-                `[omx] tmux client-attached resize fallback unavailable for ${hookTarget} `
-                  + `(${clientAttachedHookName}): ${registerClientAttachedHook.stderr}; continuing with delayed HUD resize fallback.`,
+                `[omx] tmux client-attached resize fallback unavailable or occupied for ${hookTarget} `
+                  + `(${clientAttachedHookName}); continuing with delayed HUD resize fallback.`,
               );
             }
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -41,8 +41,7 @@ import { resolveOmxCliEntryPath } from '../utils/paths.js';
 const execFileAsync = promisify(execFile);
 import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES } from '../hud/constants.js';
 import { OMX_TMUX_HUD_OWNER_ENV } from '../hud/reconcile.js';
-import { findHudWatchPaneIds, hudPaneMatchesOwner, OMX_TMUX_HUD_LEADER_PANE_ENV } from '../hud/tmux.js';
-
+import { buildHudRuntimeEnv, hudPaneMatchesExactCandidate, hudPaneMatchesOwner, OMX_TMUX_HUD_LEADER_PANE_ENV, type HudRuntimeEnvInput } from '../hud/tmux.js';
 const OMX_INSTANCE_OPTION = '@omx_instance_id';
 const OMX_PANE_INSTANCE_OPTION = '@omx_pane_instance_id';
 const OMX_TEAM_PANE_OWNER_OPTION = '@omx_team_pane_owner_id';
@@ -74,13 +73,34 @@ export interface CreateTeamSessionOptions {
   ownerSessionId?: string | null;
   /** Team-scoped pane owner token used only for Team shutdown/teardown. */
   teamPaneOwnerId?: string | null;
+  /** Canonical state-root metadata resolved by the HUD control-plane resolver. */
+  hudRuntime?: Pick<HudRuntimeEnvInput, 'omxRoot' | 'omxStateRoot' | 'omxTeamStateRoot' | 'rootSource'>;
+
+  /** Verified HUD ownership evidence. Without all fields, Team leaves HUD panes untouched. */
+  hudExactCandidate?: ExactTeamHudCandidate | null;
+
+}
+export interface ExactTeamHudCandidate {
+  sessionId: string;
+  sessionIds: string[];
+  leaderPaneId: string;
+  tmuxSessionInstanceId: string;
+  tmuxPaneInstanceId: string;
 }
 
 export interface RestoreStandaloneHudPaneOptions {
-  /** Session id that prompt-submit HUD reconciliation should use to dedupe the restored HUD. */
+  /** Canonical session id that prompt-submit HUD reconciliation should use to dedupe the restored HUD. */
   sessionId?: string | null;
+  /** Resolver-provided canonical and native-equivalent session IDs accepted for exact HUD ownership. */
+  sessionIds?: string[] | null;
+  /** Exact tmux leader/session identity required to reclaim a prior standalone HUD. */
+  leaderPaneId?: string | null;
+  tmuxSessionInstanceId?: string | null;
+  tmuxPaneInstanceId?: string | null;
   /** Explicit HUD cwd override. When omitted, the live leader pane cwd is preferred over team launch cwd. */
   cwd?: string | null;
+  /** Canonical state-root metadata resolved by the HUD control-plane resolver. */
+  hudRuntime?: Pick<HudRuntimeEnvInput, 'omxRoot' | 'omxStateRoot' | 'omxTeamStateRoot' | 'rootSource'>;
 }
 
 const INJECTION_MARKER = '[OMX_TMUX_INJECT]';
@@ -159,6 +179,8 @@ interface TmuxPaneInfo {
   paneId: string;
   currentCommand: string;
   startCommand: string;
+  paneInstanceId?: string;
+  sessionInstanceId?: string;
 }
 
 type SpawnSyncLike = typeof spawnSync;
@@ -286,15 +308,21 @@ function baseSessionName(target: string): string {
 }
 
 function listPanes(target: string): TmuxPaneInfo[] {
-  const result = runTmux(['list-panes', '-t', target, '-F', '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}']);
+  const result = runTmux(['list-panes', '-t', target, '-F', '#{pane_id}\t#{pane_current_command}\t#{pane_start_command}\t#{@omx_pane_instance_id}\t#{@omx_instance_id}']);
   if (!result.ok) return [];
   return result.stdout
     .split('\n')
     .map((line) => line.trim())
     .filter((line) => line.length > 0)
     .map((line) => {
-      const [paneId = '', currentCommand = '', startCommand = ''] = line.split('\t');
-      return { paneId, currentCommand, startCommand };
+      const [paneId = '', currentCommand = '', startCommand = '', paneInstanceId = '', sessionInstanceId = ''] = line.split('\t');
+      return {
+        paneId,
+        currentCommand,
+        startCommand,
+        ...(paneInstanceId.trim() ? { paneInstanceId: paneInstanceId.trim() } : {}),
+        ...(sessionInstanceId.trim() ? { sessionInstanceId: sessionInstanceId.trim() } : {}),
+      };
     })
     .filter((pane) => pane.paneId.startsWith('%'));
 }
@@ -336,8 +364,7 @@ function waitForPaneToRemainPresent(
 }
 
 function isHudWatchPane(pane: TmuxPaneInfo): boolean {
-  const start = pane.startCommand || '';
-  return /\bomx\b.*\bhud\b.*--watch/i.test(start);
+  return hudPaneMatchesOwner(pane);
 }
 
 export function chooseTeamLeaderPaneId(panes: TmuxPaneInfo[], preferredPaneId: string): string {
@@ -350,14 +377,30 @@ export function chooseTeamLeaderPaneId(panes: TmuxPaneInfo[], preferredPaneId: s
   return preferredPaneId;
 }
 
-function findHudPaneIds(target: string, leaderPaneId: string): string[] {
-  return findHudWatchPaneIds(listPanes(target), leaderPaneId, { leaderPaneId });
+function findExactTeamHudPaneIds(target: string, candidate: ExactTeamHudCandidate | null): string[] {
+  if (!candidate) return [];
+  return listPanes(target)
+    .filter((pane) => pane.paneId !== candidate.leaderPaneId)
+    .filter((pane) => hudPaneMatchesExactCandidate(pane, {
+      sessionId: candidate.sessionId,
+      sessionIds: candidate.sessionIds,
+      leaderPaneId: candidate.leaderPaneId,
+    }, {
+      tmuxSessionInstanceId: candidate.tmuxSessionInstanceId,
+      tmuxPaneInstanceId: candidate.tmuxPaneInstanceId,
+    }))
+    .map((pane) => pane.paneId);
 }
 
-function findOwnedHudPaneIds(target: string, leaderPaneId: string): string[] {
-  return findHudWatchPaneIds(listPanes(target), leaderPaneId, { leaderPaneId });
+function normalizeExactTeamHudCandidate(candidate: ExactTeamHudCandidate | null | undefined): ExactTeamHudCandidate | null {
+  const sessionId = candidate?.sessionId?.trim() ?? '';
+  const leaderPaneId = normalizePaneTarget(candidate?.leaderPaneId);
+  const tmuxSessionInstanceId = candidate?.tmuxSessionInstanceId?.trim() ?? '';
+  const tmuxPaneInstanceId = candidate?.tmuxPaneInstanceId?.trim() ?? '';
+  const sessionIds = [...new Set([sessionId, ...(candidate?.sessionIds ?? [])].map((id) => id.trim()).filter(Boolean))];
+  if (!sessionId || !leaderPaneId || !tmuxSessionInstanceId || !tmuxPaneInstanceId || sessionIds.length === 0) return null;
+  return { sessionId, sessionIds, leaderPaneId, tmuxSessionInstanceId, tmuxPaneInstanceId };
 }
-
 function readPaneCurrentPath(paneId: string): string | null {
   if (!paneId.startsWith('%')) return null;
   const result = runTmux(['display-message', '-p', '-t', paneId, '#{pane_current_path}']);
@@ -556,18 +599,19 @@ function shellQuoteSingle(value: string): string {
 function formatHudEnvAssignments(
   env: NodeJS.ProcessEnv = process.env,
   owner: { sessionId?: string | null; leaderPaneId?: string | null } = {},
+  hudRuntime: Pick<HudRuntimeEnvInput, 'omxRoot' | 'omxStateRoot' | 'omxTeamStateRoot' | 'rootSource'> = {},
 ): string {
-  const sessionId = (owner.sessionId ?? '').trim();
-  const leaderPaneId = (owner.leaderPaneId ?? '').trim();
-  const assignments = [
-    sessionId ? `OMX_SESSION_ID=${shellQuoteSingle(sessionId)}` : '',
-    `${OMX_TMUX_HUD_OWNER_ENV}=1`,
-    leaderPaneId ? `${OMX_TMUX_HUD_LEADER_PANE_ENV}=${shellQuoteSingle(leaderPaneId)}` : '',
-    ...(typeof env.OMX_ROOT === 'string' && env.OMX_ROOT.trim() !== ''
-      ? [`OMX_ROOT=${shellQuoteSingle(env.OMX_ROOT)}`]
-      : []),
-  ].filter(Boolean);
-  return assignments.join(' ');
+  const runtimeEnv = buildHudRuntimeEnv({
+    sessionId: owner.sessionId ?? undefined,
+    leaderPaneId: owner.leaderPaneId ?? undefined,
+    omxRoot: hudRuntime.omxRoot ?? env.OMX_ROOT,
+    omxStateRoot: hudRuntime.omxStateRoot,
+    omxTeamStateRoot: hudRuntime.omxTeamStateRoot,
+    rootSource: hudRuntime.rootSource,
+  }).env;
+  return Object.entries(runtimeEnv)
+    .map(([key, value]) => `${key}=${shellQuoteSingle(value)}`)
+    .join(' ');
 }
 
 function quotePowerShellArg(value: string): string {
@@ -1630,28 +1674,30 @@ export function createTeamSession(
     const teamTarget = `${sessionName}:${windowIndex}`;
     const ownerSessionId = (options.ownerSessionId ?? process.env.OMX_SESSION_ID ?? '').trim();
     const teamPaneOwnerId = (options.teamPaneOwnerId ?? `team:${safeTeamName}`).trim();
-    if (ownerSessionId) {
-      const tagResult = runTmux(['set-option', '-t', sessionName, OMX_INSTANCE_OPTION, ownerSessionId]);
+    const panes = listPanes(teamTarget);
+    const leaderPaneId = chooseTeamLeaderPaneId(panes, detectedLeaderPaneId);
+    const hudExactCandidate = normalizeExactTeamHudCandidate(options.hudExactCandidate);
+    const hasExactHudAuthority = Boolean(hudExactCandidate && hudExactCandidate.leaderPaneId === leaderPaneId);
+    if (hudExactCandidate?.tmuxSessionInstanceId) {
+      const tagResult = runTmux(['set-option', '-t', sessionName, OMX_INSTANCE_OPTION, hudExactCandidate.tmuxSessionInstanceId]);
       if (!tagResult.ok) {
         throw new Error(`failed to tag tmux session ${sessionName}: ${tagResult.stderr}`);
       }
     }
-    const panes = listPanes(teamTarget);
-    const leaderPaneId = chooseTeamLeaderPaneId(panes, detectedLeaderPaneId);
-    tagPaneInstance(leaderPaneId, ownerSessionId);
+    tagPaneInstance(leaderPaneId, hudExactCandidate?.tmuxPaneInstanceId ?? ownerSessionId);
     tagPaneTeamOwner(leaderPaneId, teamPaneOwnerId);
-    const initialHudPaneIds = findHudPaneIds(teamTarget, leaderPaneId);
+    const [retainedHudPaneId, ...duplicateHudPaneIds] = hasExactHudAuthority
+      ? findExactTeamHudPaneIds(teamTarget, hudExactCandidate)
+      : [];
     const omxEntry = resolveOmxCliEntryPath();
-    const canRecreateTeamHud = Boolean(omxEntry && omxEntry.trim() !== '');
-    // Team mode prioritizes leader + worker visibility. Remove HUD panes only
-    // when we can recreate the team HUD. Otherwise keep the existing HUD alive
-    // instead of making it disappear on team startup failures or broken installs.
+    const canRecreateTeamHud = hasExactHudAuthority && Boolean(omxEntry && omxEntry.trim() !== '');
+    // Reclaim only exact, resolver-verified duplicate candidates. Legacy or
+    // unverified panes are preserved rather than inferred from their command.
     if (canRecreateTeamHud) {
-      for (const hudPaneId of initialHudPaneIds) {
+      for (const hudPaneId of duplicateHudPaneIds) {
         runTmux(['kill-pane', '-t', hudPaneId]);
       }
     }
-
     const workerPaneIds: string[] = [];
     let rightStackRootPaneId: string | null = null;
     for (let i = 1; i <= workerCount; i++) {
@@ -1731,23 +1777,25 @@ export function createTeamSession(
     // leader + worker columns. Keep this after layout sizing so the main
     // leader/worker topology stays readable and the HUD remains compact.
     // Capture the HUD pane ID so it can be tracked and excluded from worker cleanup.
-    let hudPaneId: string | null = null;
+    let hudPaneId: string | null = retainedHudPaneId ?? null;
     let resizeHookName: string | null = null;
     let resizeHookTarget: string | null = null;
     if (canRecreateTeamHud && omxEntry) {
-      const hudCmd = `exec env ${formatHudEnvAssignments(process.env, { sessionId: ownerSessionId, leaderPaneId })} node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
+      const hudCmd = `exec env ${formatHudEnvAssignments(process.env, { sessionId: ownerSessionId, leaderPaneId }, options.hudRuntime)} node ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
       const hudCwd = translatePathForMsys(cwd);
-      const hudResult = runTmux([
-        'split-window', '-v', '-f', '-l', String(HUD_TMUX_TEAM_HEIGHT_LINES), '-t', teamTarget, '-d', '-P', '-F', '#{pane_id}', '-c', hudCwd, hudCmd,
-      ]);
-      if (hudResult.ok) {
-        const id = hudResult.stdout.split('\n')[0]?.trim() ?? '';
+      const hudResult = hudPaneId
+        ? null
+        : runTmux([
+          'split-window', '-v', '-f', '-l', String(HUD_TMUX_TEAM_HEIGHT_LINES), '-t', teamTarget, '-d', '-P', '-F', '#{pane_id}', '-c', hudCwd, hudCmd,
+        ]);
+      if (hudPaneId || hudResult?.ok) {
+        const id = hudPaneId ?? (hudResult && hudResult.ok ? hudResult.stdout.split('\n')[0]?.trim() ?? '' : '');
         if (id.startsWith('%')) {
-          rollbackPaneIds.push(id);
+          if (!retainedHudPaneId) rollbackPaneIds.push(id);
           if (isNativeWindows() && !waitForPaneToRemainPresent(teamTarget, id)) {
             throw new Error(`HUD pane did not remain present after tmux split-window returned ${id}`);
           }
-          tagPaneInstance(id, ownerSessionId);
+          tagPaneInstance(id, hudExactCandidate?.tmuxPaneInstanceId ?? ownerSessionId);
           tagPaneTeamOwner(id, teamPaneOwnerId);
           hudPaneId = id;
 
@@ -1857,18 +1905,22 @@ export function restoreStandaloneHudPane(
   options: RestoreStandaloneHudPaneOptions = {},
 ): string | null {
   const normalizedLeaderPaneId = normalizePaneTarget(leaderPaneId);
+  const tmuxPaneInstanceId = options.tmuxPaneInstanceId?.trim();
   if (!normalizedLeaderPaneId) return null;
 
   const omxEntry = resolveOmxCliEntryPath();
   if (!omxEntry || omxEntry.trim() === '') return null;
 
-  const [existingHudPaneId, ...duplicateHudPaneIds] = findOwnedHudPaneIds(
+  const [existingHudPaneId] = findExactTeamHudPaneIds(
     normalizedLeaderPaneId,
-    normalizedLeaderPaneId,
+    normalizeExactTeamHudCandidate({
+      sessionId: options.sessionId ?? '',
+      sessionIds: options.sessionIds ?? [],
+      leaderPaneId: options.leaderPaneId ?? '',
+      tmuxSessionInstanceId: options.tmuxSessionInstanceId ?? '',
+      tmuxPaneInstanceId: options.tmuxPaneInstanceId ?? '',
+    }),
   );
-  for (const paneId of duplicateHudPaneIds) {
-    runTmux(['kill-pane', '-t', paneId]);
-  }
   if (existingHudPaneId) {
     if (isNativeWindows()) {
       runTmux(buildHudResizeArgs(existingHudPaneId));
@@ -1880,7 +1932,7 @@ export function restoreStandaloneHudPane(
     return existingHudPaneId;
   }
 
-  const hudCmd = `exec env ${formatHudEnvAssignments(process.env, { sessionId: options.sessionId, leaderPaneId: normalizedLeaderPaneId })} ${shellQuoteSingle(translatePathForMsys(resolveLeaderNodePath()))} ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
+  const hudCmd = `exec env ${formatHudEnvAssignments(process.env, { sessionId: options.sessionId, leaderPaneId: normalizedLeaderPaneId }, options.hudRuntime)} ${shellQuoteSingle(translatePathForMsys(resolveLeaderNodePath()))} ${shellQuoteSingle(translatePathForMsys(omxEntry))} hud --watch`;
   let hudResult: ReturnType<typeof runTmux> | null = null;
   for (const restoreCwd of resolveStandaloneHudRestoreCwdCandidates(
     normalizedLeaderPaneId,
@@ -1890,6 +1942,7 @@ export function restoreStandaloneHudPane(
     const candidateResult = runTmux([
       'split-window',
       '-v',
+      '-f',
       '-l',
       String(HUD_TMUX_TEAM_HEIGHT_LINES),
       '-t',
@@ -1911,6 +1964,7 @@ export function restoreStandaloneHudPane(
 
   const paneId = hudResult.stdout.split('\n')[0]?.trim() ?? '';
   if (!paneId.startsWith('%')) return null;
+  if (tmuxPaneInstanceId) tagPaneInstance(paneId, tmuxPaneInstanceId);
 
   if (isNativeWindows()) {
     runTmux(buildHudResizeArgs(paneId));
@@ -2700,9 +2754,10 @@ export interface SharedSessionShutdownTopology {
   livePaneIds: string[];
   teamWorkerPaneIds: string[];
   leaderPaneId: string | null;
+  /** Only resolver-verified exact HUD candidates; unverified HUD panes are preserved. */
   hudPaneIds: string[];
-  leaderOwnedHudPaneIds: string[];
 }
+
 
 function normalizePaneTarget(value: string | null | undefined): string | null {
   if (typeof value !== 'string') return null;
@@ -2747,7 +2802,9 @@ export function resolveSharedSessionShutdownTopology(
   sessionName: string,
   preferredLeaderPaneId?: string | null,
   teamName?: string | null,
+  hudExactCandidate?: ExactTeamHudCandidate | null,
 ): SharedSessionShutdownTopology {
+
   const panes = listPanes(sessionName);
   const livePaneIds = panes
     .map((pane) => normalizePaneTarget(pane.paneId))
@@ -2759,9 +2816,9 @@ export function resolveSharedSessionShutdownTopology(
       teamWorkerPaneIds: [],
       leaderPaneId: fallbackLeaderPaneId,
       hudPaneIds: [],
-      leaderOwnedHudPaneIds: [],
     };
   }
+
 
   const normalizedTeamName = typeof teamName === 'string' ? teamName.trim() : '';
   const normalizedTeamWorkerPaneIds = normalizedTeamName
@@ -2777,25 +2834,28 @@ export function resolveSharedSessionShutdownTopology(
     fallbackLeaderPaneId,
     workerPaneIdSet,
   );
-  const hudPaneIds = panes
-    .filter((pane) => pane.paneId !== resolvedLeaderPaneId)
-    .filter((pane) => isHudWatchPane(pane))
-    .map((pane) => pane.paneId)
-    .filter((paneId) => paneId.startsWith('%'));
-  const leaderOwnedHudPaneIds = resolvedLeaderPaneId
+  const exactHudCandidate = normalizeExactTeamHudCandidate(hudExactCandidate);
+  const hudPaneIds = exactHudCandidate && exactHudCandidate.leaderPaneId === resolvedLeaderPaneId
     ? panes
       .filter((pane) => pane.paneId !== resolvedLeaderPaneId)
-      .filter((pane) => hudPaneMatchesOwner(pane, { leaderPaneId: resolvedLeaderPaneId }))
+      .filter((pane) => hudPaneMatchesExactCandidate(pane, {
+        sessionId: exactHudCandidate.sessionId,
+        sessionIds: exactHudCandidate.sessionIds,
+        leaderPaneId: exactHudCandidate.leaderPaneId,
+      }, {
+        tmuxSessionInstanceId: exactHudCandidate.tmuxSessionInstanceId,
+        tmuxPaneInstanceId: exactHudCandidate.tmuxPaneInstanceId,
+      }))
       .map((pane) => pane.paneId)
       .filter((paneId) => paneId.startsWith('%'))
     : [];
+
 
   return {
     livePaneIds,
     teamWorkerPaneIds: normalizedTeamWorkerPaneIds,
     leaderPaneId: resolvedLeaderPaneId,
     hudPaneIds,
-    leaderOwnedHudPaneIds,
   };
 }
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -554,6 +554,21 @@ function findExactTeamHudPaneIds(target: string, candidate: ExactTeamHudCandidat
     .map((pane) => pane.paneId);
 }
 
+/** Kills only a still-exact HUD pane, with tmux evaluating identity immediately before kill. */
+export function killExactTeamHudPane(
+  target: string,
+  paneId: string,
+  candidate: ExactTeamHudCandidate,
+  teamOwnerId?: string,
+): boolean {
+  if (!findExactTeamHudPaneIds(target, candidate).includes(paneId)) return false;
+  const sessionName = candidate.tmuxSessionName ?? target.split(':')[0] ?? '';
+  const ownerCondition = teamOwnerId ? `,#{==:#{@omx_team_pane_owner},${teamOwnerId}}` : '';
+  const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{@omx_pane_instance_id},${candidate.tmuxPaneInstanceId}},#{==:#{session_name},${sessionName}}${ownerCondition}}`;
+  const result = runTmux(['if-shell', '-t', paneId, '-F', condition, `kill-pane -t ${paneId}`, '']);
+  return result.ok && !findExactTeamHudPaneIds(target, candidate).includes(paneId);
+}
+
 function normalizeExactTeamHudCandidate(candidate: ExactTeamHudCandidate | null | undefined): ExactTeamHudCandidate | null {
   const sessionId = candidate?.sessionId?.trim() ?? '';
   const leaderPaneId = normalizePaneTarget(candidate?.leaderPaneId);
@@ -945,8 +960,10 @@ export function buildRegisterClientAttachedReconcileArgs(
   heightLines: number = HUD_TMUX_TEAM_HEIGHT_LINES,
 ): string[] {
   const hookSlot = buildClientAttachedHookSlot(hookName);
+  // Keep the owned command installed until transactional lifecycle cleanup. A shell
+  // callback cannot safely prove it is still the same hook after queueing.
   const oneShotCommand = shellQuoteSingle(
-    `${buildBestEffortShellCommand(buildNestedTmuxShellCommand(buildHudResizeCommand(hudPaneId, heightLines)))}; ${buildNestedTmuxShellCommand(`set-hook -u -t ${hookTarget} ${hookSlot}`)}`,
+    buildBestEffortShellCommand(buildNestedTmuxShellCommand(buildHudResizeCommand(hudPaneId, heightLines))),
   );
   return ['set-hook', '-t', hookTarget, hookSlot, `run-shell -b ${oneShotCommand}`];
 }
@@ -980,7 +997,10 @@ function readTmuxHookSnapshot(hookTarget: string, slot: string): TmuxHookSnapsho
   return match?.[1] ? { slot, command: match[1] } : null;
 }
 
-function restoreTmuxHookSnapshot(hookTarget: string, snapshot: TmuxHookSnapshot): boolean {
+function restoreTmuxHookSnapshot(hookTarget: string, snapshot: TmuxHookSnapshot, expectedCurrent: string | null): boolean {
+  // Never restore over a concurrent replacement. A mismatch is uncertainty, not a
+  // license to rewrite the slot.
+  if (!tmuxHookMatchesSnapshot(hookTarget, { slot: snapshot.slot, command: expectedCurrent })) return false;
   const result = snapshot.command === null
     ? runTmux(['set-hook', '-u', '-t', hookTarget, snapshot.slot])
     : runTmux(['set-hook', '-t', hookTarget, snapshot.slot, snapshot.command]);
@@ -1027,15 +1047,15 @@ export function registerHudHooksTransactionally(
   ) return false;
   if (resizeSnapshot.command === null && !runTmux(resizeArgs).ok) return false;
   if (!tmuxHookMatchesSnapshot(hookTarget, { slot: resizeSlot, command: resizeArgs[4]! })) {
-    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot);
+    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot, clientAttachedArgs[4]!, resizeArgs[4]!);
     return false;
   }
   if (clientAttachedSnapshot.command === null && !runTmux(clientAttachedArgs).ok) {
-    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot);
+    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot, clientAttachedArgs[4]!, resizeArgs[4]!);
     return false;
   }
   if (!tmuxHookMatchesSnapshot(hookTarget, { slot: clientAttachedSlot, command: clientAttachedArgs[4]! })) {
-    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot);
+    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot, clientAttachedArgs[4]!, resizeArgs[4]!);
     return false;
   }
   return true;
@@ -1045,15 +1065,13 @@ function restoreHudHookSnapshots(
   hookTarget: string,
   clientAttachedSnapshot: TmuxHookSnapshot,
   resizeSnapshot: TmuxHookSnapshot,
+  expectedClientAttachedCurrent: string | null,
+  expectedResizeCurrent: string | null,
 ): boolean {
-  // Always attempt and verify both restores. A failed first restore must not
-  // leave the other slot in a transaction-created state.
-  const clientAttachedRestored = restoreTmuxHookSnapshot(hookTarget, clientAttachedSnapshot);
-  const resizeRestored = restoreTmuxHookSnapshot(hookTarget, resizeSnapshot);
-  return clientAttachedRestored
-    && resizeRestored
-    && tmuxHookMatchesSnapshot(hookTarget, clientAttachedSnapshot)
-    && tmuxHookMatchesSnapshot(hookTarget, resizeSnapshot);
+  // Always attempt both restores; each independently refuses a foreign/newer value.
+  const clientAttachedRestored = restoreTmuxHookSnapshot(hookTarget, clientAttachedSnapshot, expectedClientAttachedCurrent);
+  const resizeRestored = restoreTmuxHookSnapshot(hookTarget, resizeSnapshot, expectedResizeCurrent);
+  return clientAttachedRestored && resizeRestored;
 }
 
 /**
@@ -1080,12 +1098,16 @@ export function unregisterHudHooksTransactionally(
     || (resizeSnapshot.command !== null && resizeSnapshot.command !== expectedResizeCommand)
   ) return false;
 
-  const remove = (slot: string, installed: boolean): boolean => !installed
-    || (runTmux(['set-hook', '-u', '-t', hookTarget, slot]).ok && tmuxHookIsAbsent(hookTarget, slot));
-  const clientRemoved = remove(clientAttachedSlot, clientAttachedSnapshot.command !== null);
-  const resizeRemoved = remove(resizeSlot, resizeSnapshot.command !== null);
+  const remove = (snapshot: TmuxHookSnapshot): boolean => {
+    if (snapshot.command === null) return true;
+    if (!tmuxHookMatchesSnapshot(hookTarget, snapshot)) return false;
+    return runTmux(['set-hook', '-u', '-t', hookTarget, snapshot.slot]).ok
+      && tmuxHookIsAbsent(hookTarget, snapshot.slot);
+  };
+  const clientRemoved = remove(clientAttachedSnapshot);
+  const resizeRemoved = remove(resizeSnapshot);
   if (!clientRemoved || !resizeRemoved) {
-    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot);
+    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot, null, null);
     return false;
   }
   return true;
@@ -2013,7 +2035,7 @@ export function createTeamSession(
     // unverified panes are preserved rather than inferred from their command.
     if (canRecreateTeamHud) {
       for (const hudPaneId of duplicateHudPaneIds) {
-        runTmux(['kill-pane', '-t', hudPaneId]);
+        killExactTeamHudPane(teamTarget, hudPaneId, hudExactCandidate!, teamPaneOwnerId);
       }
     }
     const workerPaneIds: string[] = [];

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'crypto';
 import { spawnSync, execFile } from 'child_process';
 import { promisify } from 'util';
 import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'fs';
@@ -135,14 +134,14 @@ export function establishExactTeamHudCandidate(
   if (!before || (expectedLeaderPaneId && before.leaderPaneId !== expectedLeaderPaneId)) return null;
   const sessionTag = runTmux(['show-options', '-qv', '-t', before.sessionName, OMX_INSTANCE_OPTION]);
   if (!sessionTag.ok) return null;
-  const tmuxSessionInstanceId = sessionTag.stdout.trim() || randomUUID();
+  const tmuxSessionInstanceId = sessionTag.stdout.trim() || sessionId;
   if (!sessionTag.stdout.trim() && !runTmux(['set-option', '-t', before.sessionName, OMX_INSTANCE_OPTION, tmuxSessionInstanceId]).ok) return null;
   const verifiedSessionTag = runTmux(['show-options', '-qv', '-t', before.sessionName, OMX_INSTANCE_OPTION]);
   if (!verifiedSessionTag.ok || verifiedSessionTag.stdout.trim() !== tmuxSessionInstanceId) return null;
 
   const paneTag = runTmux(['show-option', '-qv', '-p', '-t', before.leaderPaneId, OMX_PANE_INSTANCE_OPTION]);
   if (!paneTag.ok) return null;
-  const tmuxPaneInstanceId = paneTag.stdout.trim() || randomUUID();
+  const tmuxPaneInstanceId = paneTag.stdout.trim() || sessionIds.find((value) => value !== sessionId) || sessionId;
   if (!paneTag.stdout.trim() && !runTmux(['set-option', '-p', '-t', before.leaderPaneId, OMX_PANE_INSTANCE_OPTION, tmuxPaneInstanceId]).ok) return null;
   const verifiedPaneTag = runTmux(['show-option', '-qv', '-p', '-t', before.leaderPaneId, OMX_PANE_INSTANCE_OPTION]);
   if (!verifiedPaneTag.ok || verifiedPaneTag.stdout.trim() !== tmuxPaneInstanceId) return null;
@@ -1969,12 +1968,12 @@ export function createTeamSession(
           if (isNativeWindows() && !waitForPaneToRemainPresent(teamTarget, id)) {
             throw new Error(`HUD pane did not remain present after tmux split-window returned ${id}`);
           }
-          if (!tagNewHudPaneOrRollback(
+          if (!retainedHudPaneId && !tagNewHudPaneOrRollback(
             id,
             hudExactCandidate?.tmuxPaneInstanceId ?? ownerSessionId,
             teamPaneOwnerId,
           )) {
-            if (!retainedHudPaneId && rollbackPaneIds[rollbackPaneIds.length - 1] === id) rollbackPaneIds.pop();
+            if (rollbackPaneIds[rollbackPaneIds.length - 1] === id) rollbackPaneIds.pop();
             throw new Error(`failed to tag and verify HUD pane ${id}`);
           }
           hudPaneId = id;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -600,9 +600,15 @@ export function killExactTeamHudPane(
   if (!findExactTeamHudPaneIds(target, candidate).includes(paneId)) return false;
   const sessionName = candidate.tmuxSessionName ?? target.split(':')[0] ?? '';
   if (!sessionName || !candidate.tmuxSessionInstanceId || !candidate.tmuxPaneInstanceId) return false;
+  const appliedReceipt = `__omx_hud_teardown_applied_${randomUUID()}__`;
+  const rejectedReceipt = `__omx_hud_teardown_rejected_${randomUUID()}__`;
   const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{pane_start_command},${receipt.command}},#{==:#{@omx_pane_instance_id},${candidate.tmuxPaneInstanceId}},#{==:#{@omx_instance_id},${candidate.tmuxSessionInstanceId}},#{==:#{session_name},${sessionName}},#{==:#{@omx_team_pane_owner_id},${teamOwnerId}},#{==:#{@omx_team_pane_birth},${receipt.pane_birth}},#{==:#{@omx_team_pane_role},hud}}`;
-  const result = runTmux(['if-shell', '-t', paneId, '-F', condition, `kill-pane -t ${paneId}`, '']);
-  return result.ok && !findExactTeamHudPaneIds(target, candidate).includes(paneId);
+  const result = runTmux([
+    'if-shell', '-t', paneId, '-F', condition,
+    `kill-pane -t ${paneId} \\; display-message -p ${appliedReceipt}`,
+    `display-message -p ${rejectedReceipt}`,
+  ]);
+  return result.ok && result.stdout.split('\n').some((line) => line.trim() === appliedReceipt);
 }
 
 function normalizeExactTeamHudCandidate(candidate: ExactTeamHudCandidate | null | undefined): ExactTeamHudCandidate | null {
@@ -914,12 +920,6 @@ function buildHudResizeCommand(hudPaneId: string, heightLines: number = HUD_TMUX
   return `resize-pane -t ${buildHudPaneTarget(hudPaneId)} -y ${resolveHudHeightLines(heightLines)}`;
 }
 
-function buildHudResizeArgs(
-  hudPaneId: string,
-  heightLines: number = HUD_TMUX_TEAM_HEIGHT_LINES,
-): string[] {
-  return ['resize-pane', '-t', buildHudPaneTarget(hudPaneId), '-y', String(resolveHudHeightLines(heightLines))];
-}
 
 function buildNestedTmuxShellCommand(command: string): string {
   if (process.platform !== 'win32') {
@@ -946,6 +946,7 @@ export interface TeamHudHookEvidence {
   sessionBirth: string;
   hudPaneId: string;
   hudPaneBirth: string;
+  hudPaneCommand: string;
   ownerId: string;
   generation: string;
 }
@@ -954,17 +955,26 @@ function teamHookActiveOption(generation: string): string {
   return `@omx_team_hook_active_${generation.replace(/[^a-zA-Z0-9_]/g, '_')}`;
 }
 
-function buildTeamHookCommand(
-  hookCommand: string,
-  evidence?: TeamHudHookEvidence,
-): string {
+function buildTeamHookCondition(evidence?: TeamHudHookEvidence): string {
+  const generation = evidence?.generation.trim() ?? '';
+  if (!evidence || !generation || !evidence.hudPaneCommand.trim()) return '#{==:0,1}';
+  return `#{&&:#{==:#{pane_id},${buildHudPaneTarget(evidence.hudPaneId)}},#{==:#{pane_start_command},${evidence.hudPaneCommand}},#{==:#{session_name},${evidence.sessionName}},#{==:#{window_index},${evidence.windowIndex}},#{==:#{@omx_instance_id},${evidence.sessionBirth}},#{==:#{@omx_team_pane_owner_id},${evidence.ownerId}},#{==:#{@omx_team_pane_birth},${evidence.hudPaneBirth}},#{==:#{@omx_team_pane_role},hud},#{==:#{${teamHookActiveOption(generation)}},1}}`;
+}
+
+function buildGuardedTeamResizeCommand(hudPaneId: string, heightLines: number, evidence?: TeamHudHookEvidence): string {
+  const condition = buildTeamHookCondition(evidence);
+  if (condition === '#{==:0,1}') return ':';
+  const resizeCommand = buildHudResizeCommand(hudPaneId, heightLines);
+  const guarded = `if-shell -t ${buildHudPaneTarget(hudPaneId)} -F ${shellQuoteSingle(condition)} ${shellQuoteSingle(resizeCommand)} ''`;
+  return buildBestEffortShellCommand(buildNestedTmuxShellCommand(guarded));
+}
+
+function buildTeamHookCommand(hookCommand: string, evidence?: TeamHudHookEvidence): string {
   const generation = evidence?.generation?.trim() ?? '';
-  const active = generation ? teamHookActiveOption(generation) : '';
-  const condition = evidence
-    ? `#{&&:#{==:#{pane_id},${buildHudPaneTarget(evidence.hudPaneId)}},#{==:#{session_name},${evidence.sessionName}},#{==:#{window_index},${evidence.windowIndex}},#{==:#{@omx_instance_id},${evidence.sessionBirth}},#{==:#{@omx_team_pane_owner_id},${evidence.ownerId}},#{==:#{@omx_team_pane_birth},${evidence.hudPaneBirth}},#{==:#{@omx_team_pane_role},hud},#{==:#{${active}},1}}`
-    : '#{==:0,1}';
+  const condition = buildTeamHookCondition(evidence);
   return `if-shell -t ${buildHudPaneTarget(evidence?.hudPaneId ?? '')} -F ${shellQuoteSingle(condition)} ${shellQuoteSingle(`run-shell -b ${hookCommand}`)} ''${generation ? ` # omx-generation=${generation}` : ''}`;
 }
+
 
 export function buildRegisterResizeHookArgs(
   hookTarget: string,
@@ -974,12 +984,14 @@ export function buildRegisterResizeHookArgs(
   generation?: string,
   evidence?: Omit<TeamHudHookEvidence, 'generation'>,
 ): string[] {
-  const resizeCommand = buildBestEffortShellCommand(buildNestedTmuxShellCommand(buildHudResizeCommand(hudPaneId, heightLines)));
+  const hookEvidence = generation && evidence ? { ...evidence, generation } : undefined;
+  const resizeCommand = buildGuardedTeamResizeCommand(hudPaneId, heightLines, hookEvidence);
   void hookName;
   return [
     'set-hook', '-a', '-t', hookTarget, 'client-resized',
-    buildTeamHookCommand(resizeCommand, generation && evidence ? { ...evidence, generation } : undefined),
+    buildTeamHookCommand(resizeCommand, hookEvidence),
   ];
+
 }
 
 /** Deprecated diagnostic helper: append-only registrations are never removed live. */
@@ -1012,11 +1024,13 @@ export function buildRegisterClientAttachedReconcileArgs(
   evidence?: Omit<TeamHudHookEvidence, 'generation'>,
 ): string[] {
   void hookName;
-  const oneShotCommand = buildBestEffortShellCommand(buildNestedTmuxShellCommand(buildHudResizeCommand(hudPaneId, heightLines)));
+  const hookEvidence = generation && evidence ? { ...evidence, generation } : undefined;
+  const oneShotCommand = buildGuardedTeamResizeCommand(hudPaneId, heightLines, hookEvidence);
   return [
     'set-hook', '-a', '-t', hookTarget, 'client-attached',
-    buildTeamHookCommand(oneShotCommand, generation && evidence ? { ...evidence, generation } : undefined),
+    buildTeamHookCommand(oneShotCommand, hookEvidence),
   ];
+
 }
 
 /** Deprecated diagnostic helper: append-only registrations are never removed live. */
@@ -1050,12 +1064,15 @@ export function registerHudHooksTransactionally(
   evidence?: Omit<TeamHudHookEvidence, 'generation'>,
 ): boolean {
   if (!generation || !evidence) return false;
-  // Enable before append. A partial pair is safe: both commands are generation-gated
-  // and later teardown only makes this generation inert.
+  // Enable before append. A partial pair is safe only after a failed registration
+  // makes its unique generation inert; retained append-only commands then cannot resize.
   if (!runTmux(['set-option', '-t', hookTarget, teamHookActiveOption(generation), '1']).ok) return false;
   const resizeArgs = buildRegisterResizeHookArgs(hookTarget, resizeHookName, hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, generation, evidence);
   const attachedArgs = buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, generation, evidence);
-  return appendHudHook(hookTarget, resizeArgs) && appendHudHook(hookTarget, attachedArgs);
+  if (appendHudHook(hookTarget, resizeArgs) && appendHudHook(hookTarget, attachedArgs)) return true;
+  runTmux(['set-option', '-t', hookTarget, teamHookActiveOption(generation), '0']);
+  return false;
+
 }
 
 /** Makes this generation inert. It deliberately retains every tmux hook receipt and slot. */
@@ -1077,16 +1094,18 @@ export function buildScheduleDelayedHudResizeArgs(
   hudPaneId: string,
   delaySeconds: number = HUD_RESIZE_RECONCILE_DELAY_SECONDS,
   heightLines: number = HUD_TMUX_TEAM_HEIGHT_LINES,
+  evidence?: TeamHudHookEvidence,
 ): string[] {
   const delay = Number.isFinite(delaySeconds) && delaySeconds > 0 ? delaySeconds : HUD_RESIZE_RECONCILE_DELAY_SECONDS;
-  return ['run-shell', '-b', `sleep ${delay}; ${buildBestEffortShellCommand(buildNestedTmuxShellCommand(buildHudResizeCommand(hudPaneId, heightLines)))}`];
+  return ['run-shell', '-b', `sleep ${delay}; ${buildGuardedTeamResizeCommand(hudPaneId, heightLines, evidence)}`];
 }
 
 export function buildReconcileHudResizeArgs(
   hudPaneId: string,
   heightLines: number = HUD_TMUX_TEAM_HEIGHT_LINES,
+  evidence?: TeamHudHookEvidence,
 ): string[] {
-  return ['run-shell', buildBestEffortShellCommand(buildNestedTmuxShellCommand(buildHudResizeCommand(hudPaneId, heightLines)))];
+  return ['run-shell', buildGuardedTeamResizeCommand(hudPaneId, heightLines, evidence)];
 }
 
 function redrawLeaderPaneAfterTeamLayout(leaderPaneId: string): void {
@@ -2173,13 +2192,12 @@ export function createTeamSession(
           hudPaneId = id;
 
           if (isNativeWindows()) {
-            // Native Windows tmux support may flow through psmux; issuing a
-            // direct control-plane resize avoids nested run-shell PATH drift.
-            const reconcile = runTmux(buildHudResizeArgs(hudPaneId));
-            if (!reconcile.ok) {
-              throw new Error(`failed to reconcile HUD resize: ${reconcile.stderr}`);
-            }
+            // The direct control-plane path cannot revalidate a deferred resize.
+            // Retain the pane rather than risking a reused pane ID.
+            console.warn(`[omx] strict HUD resize validation is unavailable for ${hudPaneId} on native Windows; retaining layout.`);
           } else {
+
+
             const hookTarget = buildResizeHookTarget(sessionName, windowIndex);
             const hookName = buildResizeHookName(safeTeamName, sessionName, windowIndex, hudPaneId);
             const clientAttachedHookName = buildClientAttachedReconcileHookName(
@@ -2200,6 +2218,8 @@ export function createTeamSession(
                   sessionBirth: hookSessionBirth.stdout.trim(),
                   hudPaneId,
                   hudPaneBirth: createdHudPaneBirth,
+                  hudPaneCommand: createdHudPaneCommand ?? '',
+
                   ownerId: teamPaneOwnerId,
                 }
               : null;
@@ -2228,11 +2248,13 @@ export function createTeamSession(
               );
             }
 
-            const delayed = runTmux(buildScheduleDelayedHudResizeArgs(hudPaneId));
+            const resizeEvidence = hookEvidence && options.hookGeneration ? { ...hookEvidence, generation: options.hookGeneration } : undefined;
+            const delayed = runTmux(buildScheduleDelayedHudResizeArgs(hudPaneId, HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_TEAM_HEIGHT_LINES, resizeEvidence));
+
             if (!delayed.ok) {
               console.warn(`[omx] tmux delayed HUD resize unavailable for ${hudPaneId}: ${delayed.stderr}; continuing.`);
             }
-            const reconcile = runTmux(buildReconcileHudResizeArgs(hudPaneId));
+            const reconcile = runTmux(buildReconcileHudResizeArgs(hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, resizeEvidence));
             if (!reconcile.ok) {
               console.warn(`[omx] tmux HUD resize reconcile unavailable for ${hudPaneId}: ${reconcile.stderr}; continuing.`);
             }
@@ -2331,12 +2353,9 @@ export function restoreStandaloneHudPane(
     }),
   );
   if (existingHudPaneId) {
-    if (isNativeWindows()) {
-      runTmux(buildHudResizeArgs(existingHudPaneId));
-    } else {
-      runTmux(buildScheduleDelayedHudResizeArgs(existingHudPaneId));
-      runTmux(buildReconcileHudResizeArgs(existingHudPaneId));
-    }
+    // No standalone generation carries complete immutable resize evidence.
+    // Retain the existing layout rather than resizing a potentially reused pane ID.
+
     runTmux(['select-pane', '-t', normalizedLeaderPaneId]);
     return existingHudPaneId;
   }
@@ -2375,12 +2394,8 @@ export function restoreStandaloneHudPane(
   if (!paneId.startsWith('%')) return null;
   if (tmuxPaneInstanceId && !tagNewHudPaneOrRollback(paneId, tmuxPaneInstanceId)) return null;
 
-  if (isNativeWindows()) {
-    runTmux(buildHudResizeArgs(paneId));
-  } else {
-    runTmux(buildScheduleDelayedHudResizeArgs(paneId));
-    runTmux(buildReconcileHudResizeArgs(paneId));
-  }
+  // A restored standalone pane is not resize-authorized until a complete
+  // immutable hook generation exists.
   runTmux(['select-pane', '-t', normalizedLeaderPaneId]);
   return paneId;
 }
@@ -3444,9 +3459,15 @@ export async function teardownWorkerPanes(
       await sleep(perPaneGrace);
       continue;
     }
+    const appliedReceipt = `__omx_worker_teardown_applied_${randomUUID()}__`;
+    const rejectedReceipt = `__omx_worker_teardown_rejected_${randomUUID()}__`;
     const condition = `#{&&:#{==:#{pane_id},${paneId}},#{==:#{pane_start_command},${receipt.command}},#{==:#{session_name},${sessionName}},#{==:#{@omx_instance_id},${sessionBirth}},#{==:#{@omx_team_pane_owner_id},${teamOwnerId}},#{==:#{@omx_team_pane_birth},${receipt.pane_birth}},#{==:#{@omx_team_pane_role},worker}}`;
-    const result = await runTmuxAsync(['if-shell', '-t', paneId, '-F', condition, `kill-pane -t ${paneId}`, '']);
-    if (result.ok) summary.kill.succeeded += 1;
+    const result = await runTmuxAsync([
+      'if-shell', '-t', paneId, '-F', condition,
+      `kill-pane -t ${paneId} \\; display-message -p ${appliedReceipt}`,
+      `display-message -p ${rejectedReceipt}`,
+    ]);
+    if (result.ok && result.stdout.split('\n').some((line) => line.trim() === appliedReceipt)) summary.kill.succeeded += 1;
     else summary.kill.failed += 1;
     await sleep(perPaneGrace);
   }
@@ -3463,13 +3484,20 @@ export async function killWorkerPanes(
   return teardownWorkerPanes(paneIds, { leaderPaneId, hudPaneId: hudPaneId ?? null, graceMs });
 }
 
-// Kill entire tmux session. Tolerates already-dead sessions.
-export function destroyTeamSession(sessionName: string): void {
-  try {
-    runTmux(['kill-session', '-t', sessionName]);
-  } catch {
-    // tolerate
-  }
+/** Destroys only the immutable standalone Team session generation and returns its same-command receipt. */
+export function destroyTeamSession(sessionName: string, sessionBirth: string): boolean {
+  const normalizedSessionName = sessionName.trim();
+  const normalizedSessionBirth = sessionBirth.trim();
+  if (!normalizedSessionName || !normalizedSessionBirth) return false;
+  const appliedReceipt = `__omx_session_teardown_applied_${randomUUID()}__`;
+  const rejectedReceipt = `__omx_session_teardown_rejected_${randomUUID()}__`;
+  const condition = `#{&&:#{==:#{session_name},${normalizedSessionName}},#{==:#{@omx_instance_id},${normalizedSessionBirth}}}`;
+  const result = runTmux([
+    'if-shell', '-t', normalizedSessionName, '-F', condition,
+    `kill-session -t ${normalizedSessionName} \\; display-message -p ${appliedReceipt}`,
+    `display-message -p ${rejectedReceipt}`,
+  ]);
+  return result.ok && result.stdout.split('\n').some((line) => line.trim() === appliedReceipt);
 }
 
 // List all tmux sessions matching omx-team-* pattern

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -963,7 +963,7 @@ function buildTeamHookCondition(evidence?: TeamHudHookEvidence): string {
 
 function buildGuardedTeamResizeCommand(hudPaneId: string, heightLines: number, evidence?: TeamHudHookEvidence): string {
   const condition = buildTeamHookCondition(evidence);
-  if (condition === '#{==:0,1}') return ':';
+  if (condition === '#{==:0,1}') return buildBestEffortShellCommand(buildNestedTmuxShellCommand(buildHudResizeCommand(hudPaneId, heightLines)));
   const resizeCommand = buildHudResizeCommand(hudPaneId, heightLines);
   const guarded = `if-shell -t ${buildHudPaneTarget(hudPaneId)} -F ${shellQuoteSingle(condition)} ${shellQuoteSingle(resizeCommand)} ''`;
   return buildBestEffortShellCommand(buildNestedTmuxShellCommand(guarded));
@@ -1055,6 +1055,24 @@ export function registerHudHookIfVacant(hookTarget: string, args: string[]): boo
   return appendHudHook(hookTarget, args);
 }
 
+function teamHookGenerationOption(hookTarget: string): string {
+  return `@omx_team_hook_generation_${normalizeTmuxHookToken(hookTarget)}`;
+}
+
+function teamHookReceiptOption(hookTarget: string): string {
+  return `@omx_team_hook_receipt_${normalizeTmuxHookToken(hookTarget)}`;
+}
+
+function hasVerifiedTeamHookPair(hookTarget: string, generation: string): boolean {
+  const marker = `omx-generation=${generation}`;
+  for (const event of ['client-resized', 'client-attached']) {
+    const observed = runTmux(['show-hooks', '-t', hookTarget, event]);
+    if (!observed.ok || !observed.stdout.split('\n').some((line) => line.includes(marker))) return false;
+  }
+  return true;
+}
+
+/** Appends an inert pair, verifies receipts, then publishes it with an expected-generation CAS. */
 export function registerHudHooksTransactionally(
   hookTarget: string,
   resizeHookName: string,
@@ -1063,13 +1081,40 @@ export function registerHudHooksTransactionally(
   generation?: string,
   evidence?: Omit<TeamHudHookEvidence, 'generation'>,
 ): boolean {
-  if (!generation || !evidence) return false;
-  // Enable before append. A partial pair is safe only after a failed registration
-  // makes its unique generation inert; retained append-only commands then cannot resize.
-  if (!runTmux(['set-option', '-t', hookTarget, teamHookActiveOption(generation), '1']).ok) return false;
+  if (!generation || !evidence || !/^[0-9a-f-]{36}$/.test(generation)) return false;
+  const generationOption = teamHookGenerationOption(hookTarget);
+  const prior = runTmux(['show-options', '-qv', '-t', hookTarget, generationOption]);
+  if (!prior.ok) return false;
+  const priorGeneration = prior.stdout.trim();
+  if (priorGeneration && !/^[0-9a-f-]{36}$/.test(priorGeneration)) return false;
+  if (priorGeneration) {
+    const priorActive = runTmux(['show-options', '-qv', '-t', hookTarget, teamHookActiveOption(priorGeneration)]);
+    if (priorActive.ok && priorActive.stdout.trim() === '1' && hasVerifiedTeamHookPair(hookTarget, priorGeneration)) return true;
+  }
+
+  // The new pair is intentionally inert until both append receipts have been observed.
+  if (!runTmux(['set-option', '-t', hookTarget, teamHookActiveOption(generation), '0']).ok) return false;
   const resizeArgs = buildRegisterResizeHookArgs(hookTarget, resizeHookName, hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, generation, evidence);
   const attachedArgs = buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId, HUD_TMUX_TEAM_HEIGHT_LINES, generation, evidence);
-  if (appendHudHook(hookTarget, resizeArgs) && appendHudHook(hookTarget, attachedArgs)) return true;
+  if (!appendHudHook(hookTarget, resizeArgs) || !appendHudHook(hookTarget, attachedArgs) || !hasVerifiedTeamHookPair(hookTarget, generation)) {
+    runTmux(['set-option', '-t', hookTarget, teamHookActiveOption(generation), '0']);
+    return false;
+  }
+
+  const receiptOption = teamHookReceiptOption(hookTarget);
+  const receipt = randomUUID();
+  const condition = `#{==:#{${generationOption}},${priorGeneration}}`;
+  const publish = [
+    `set-option -t ${hookTarget} ${generationOption} ${generation}`,
+    `set-option -t ${hookTarget} ${teamHookActiveOption(generation)} 1`,
+    ...(priorGeneration ? [`set-option -t ${hookTarget} ${teamHookActiveOption(priorGeneration)} 0`] : []),
+    `set-option -t ${hookTarget} ${receiptOption} ${receipt}`,
+  ].join(' \\; ');
+  if (!runTmux(['if-shell', '-t', hookTarget, '-F', condition, publish, '']).ok) return false;
+  const applied = runTmux(['show-options', '-qv', '-t', hookTarget, receiptOption]);
+  const published = runTmux(['show-options', '-qv', '-t', hookTarget, generationOption]);
+  const active = runTmux(['show-options', '-qv', '-t', hookTarget, teamHookActiveOption(generation)]);
+  if (applied.ok && published.ok && active.ok && applied.stdout.trim() === receipt && published.stdout.trim() === generation && active.stdout.trim() === '1') return true;
   runTmux(['set-option', '-t', hookTarget, teamHookActiveOption(generation), '0']);
   return false;
 
@@ -1086,8 +1131,14 @@ export function unregisterHudHooksTransactionally(
   void resizeHookName;
   void clientAttachedHookName;
   void hudPaneId;
-  if (!generation) return false;
-  return runTmux(['set-option', '-t', hookTarget, teamHookActiveOption(generation), '0']).ok;
+  if (!generation || !/^[0-9a-f-]{36}$/.test(generation)) return false;
+  const receiptOption = teamHookReceiptOption(hookTarget);
+  const receipt = randomUUID();
+  const condition = `#{==:#{${teamHookGenerationOption(hookTarget)}},${generation}}`;
+  const deactivate = `set-option -t ${hookTarget} ${teamHookActiveOption(generation)} 0 \\; set-option -t ${hookTarget} ${receiptOption} ${receipt}`;
+  if (!runTmux(['if-shell', '-t', hookTarget, '-F', condition, deactivate, '']).ok) return false;
+  const applied = runTmux(['show-options', '-qv', '-t', hookTarget, receiptOption]);
+  return applied.ok && applied.stdout.trim() === receipt;
 }
 
 export function buildScheduleDelayedHudResizeArgs(
@@ -2027,15 +2078,15 @@ export function createTeamSession(
     const [retainedHudPaneId, ...duplicateHudPaneIds] = hasExactHudAuthority
       ? findExactTeamHudPaneIds(teamTarget, hudExactCandidate)
       : [];
+    // A duplicate's command and live tags prove only that it resembles this
+    // generation. They are not a transferable lifecycle receipt, so killing it
+    // would risk an ABA-reused pane. Stop before provisioning workers rather
+    // than silently running multiple HUD actors.
+    if (duplicateHudPaneIds.length > 0) {
+      throw new Error(`duplicate_exact_team_hud_without_receipts:${duplicateHudPaneIds.join(',')}`);
+    }
     const omxEntry = resolveOmxCliEntryPath();
     const canRecreateTeamHud = hasExactHudAuthority && Boolean(omxEntry && omxEntry.trim() !== '');
-    // Reclaim only exact, resolver-verified duplicate candidates. Legacy or
-    // unverified panes are preserved rather than inferred from their command.
-    if (canRecreateTeamHud) {
-      for (const hudPaneId of duplicateHudPaneIds) {
-        killExactTeamHudPane(teamTarget, hudPaneId, hudExactCandidate!, teamPaneOwnerId);
-      }
-    }
     const workerPaneIds: string[] = [];
     let rightStackRootPaneId: string | null = null;
     for (let i = 1; i <= workerCount; i++) {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1759,6 +1759,10 @@ export function createTeamSession(
     const panes = listPanes(teamTarget);
     const leaderPaneId = chooseTeamLeaderPaneId(panes, detectedLeaderPaneId);
     const hudExactCandidate = normalizeExactTeamHudCandidate(options.hudExactCandidate);
+    const hudExactCandidateWasProvided = Object.prototype.hasOwnProperty.call(
+      options,
+      'hudExactCandidate',
+    );
     const recheckedSessionTag = hudExactCandidate?.tmuxSessionName
       ? runTmux(['show-options', '-qv', '-t', sessionName, OMX_INSTANCE_OPTION])
       : null;
@@ -1775,7 +1779,7 @@ export function createTeamSession(
       && hudExactCandidate.leaderPaneId === leaderPaneId
       && hudEvidenceStillMatches,
     );
-    if (!hudExactCandidate) {
+    if (!hudExactCandidate && !hudExactCandidateWasProvided) {
       tagPaneInstance(leaderPaneId, ownerSessionId);
     }
     tagPaneTeamOwner(leaderPaneId, teamPaneOwnerId);

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -204,6 +204,26 @@ export function probeExactTeamHudCandidate(
   };
 }
 
+/** Returns the exact live HUD pane only when its command, logical claimant, and opaque tmux birth tags all match. */
+export function findExactTeamHudPane(
+  sessionName: string,
+  expectedHudPaneId: string | null | undefined,
+  candidate: ExactTeamHudCandidate & { tmuxSessionName: string },
+): string | null {
+  const hudPaneId = normalizePaneTarget(expectedHudPaneId);
+  if (!hudPaneId || sessionName.trim() !== candidate.tmuxSessionName) return null;
+  const pane = listPanes(sessionName).find((entry) => entry.paneId === hudPaneId);
+  if (!pane || !isHudWatchPane(pane)) return null;
+  return hudPaneMatchesExactCandidate(pane, {
+    sessionId: candidate.sessionId,
+    sessionIds: candidate.sessionIds,
+    leaderPaneId: candidate.leaderPaneId,
+  }, {
+    tmuxSessionInstanceId: candidate.tmuxSessionInstanceId,
+    tmuxPaneInstanceId: candidate.tmuxPaneInstanceId,
+  }) ? hudPaneId : null;
+}
+
 export interface RestoreStandaloneHudPaneOptions {
   /** Canonical session id that prompt-submit HUD reconciliation should use to dedupe the restored HUD. */
   sessionId?: string | null;
@@ -957,8 +977,9 @@ function readTmuxHookSnapshot(hookTarget: string, slot: string): TmuxHookSnapsho
   if (!result.ok) return null;
   const output = result.stdout.trim();
   if (output === '') return { slot, command: null };
-  const prefix = `${slot} `;
-  return output.startsWith(prefix) ? { slot, command: output.slice(prefix.length) } : null;
+  const escapedSlot = slot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = output.split('\n').map((value) => value.trim()).map((value) => value.match(new RegExp(`^${escapedSlot}\\s+(.+)$`))).find(Boolean);
+  return match?.[1] ? { slot, command: match[1] } : null;
 }
 
 function restoreTmuxHookSnapshot(hookTarget: string, snapshot: TmuxHookSnapshot): boolean {
@@ -995,12 +1016,20 @@ export function unregisterHudHooksTransactionally(
   hookTarget: string,
   resizeHookName: string,
   clientAttachedHookName: string,
+  hudPaneId: string,
 ): boolean {
   const resizeSlot = buildResizeHookSlot(resizeHookName);
   const clientAttachedSlot = buildClientAttachedHookSlot(clientAttachedHookName);
   const clientAttachedSnapshot = readTmuxHookSnapshot(hookTarget, clientAttachedSlot);
   const resizeSnapshot = readTmuxHookSnapshot(hookTarget, resizeSlot);
-  if (!clientAttachedSnapshot || !resizeSnapshot) return false;
+  const expectedResizeCommand = buildRegisterResizeHookArgs(hookTarget, resizeHookName, hudPaneId)[4];
+  const expectedClientAttachedCommand = buildRegisterClientAttachedReconcileArgs(hookTarget, clientAttachedHookName, hudPaneId)[4];
+  if (
+    !clientAttachedSnapshot
+    || !resizeSnapshot
+    || clientAttachedSnapshot.command !== expectedClientAttachedCommand
+    || resizeSnapshot.command !== expectedResizeCommand
+  ) return false;
 
   if (!runTmux(['set-hook', '-u', '-t', hookTarget, clientAttachedSlot]).ok) return false;
   if (!tmuxHookIsAbsent(hookTarget, clientAttachedSlot)) {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -2090,7 +2090,7 @@ export function createTeamSession(
   let createdHudPaneCommand: string | null = null;
   let createdHudPaneBirth: string | null = null;
 
-  let rollbackOwnerSessionId = '';
+  let rollbackSessionBirth = '';
   let rollbackTeamPaneOwnerId = '';
 
   try {
@@ -2111,7 +2111,6 @@ export function createTeamSession(
     const teamTarget = `${sessionName}:${windowIndex}`;
     const ownerSessionId = (options.ownerSessionId ?? process.env.OMX_SESSION_ID ?? '').trim();
     const teamPaneOwnerId = (options.teamPaneOwnerId ?? `team:${safeTeamName}`).trim();
-    rollbackOwnerSessionId = ownerSessionId;
     rollbackTeamPaneOwnerId = teamPaneOwnerId;
 
     const panes = listPanes(teamTarget);
@@ -2121,15 +2120,17 @@ export function createTeamSession(
       options,
       'hudExactCandidate',
     );
-    const recheckedSessionTag = hudExactCandidate?.tmuxSessionName
-      ? runTmux(['show-options', '-qv', '-t', sessionName, OMX_INSTANCE_OPTION])
-      : null;
+    // Capture the session's persisted opaque birth before creating any rollback
+    // candidates. The logical owner/session id is only an alias and must never
+    // authorize destruction of panes in a later session generation.
+    const observedSessionBirth = runTmux(['show-options', '-qv', '-t', sessionName, OMX_INSTANCE_OPTION]);
+    rollbackSessionBirth = observedSessionBirth.ok ? observedSessionBirth.stdout.trim() : '';
     const hudEvidenceStillMatches = !hudExactCandidate?.tmuxSessionName
       || (
         hudExactCandidate.tmuxSessionName === sessionName
         && hudExactCandidate.tmuxWindowIndex === windowIndex
-        && recheckedSessionTag?.ok
-        && recheckedSessionTag.stdout.trim() === hudExactCandidate.tmuxSessionInstanceId
+        && observedSessionBirth.ok
+        && observedSessionBirth.stdout.trim() === hudExactCandidate.tmuxSessionInstanceId
         && paneHasOmxInstanceTag(leaderPaneId, hudExactCandidate.tmuxPaneInstanceId)
       );
     const hasExactHudAuthority = Boolean(
@@ -2451,15 +2452,23 @@ export function createTeamSession(
       }
     }
     // Every rollback candidate was tagged and read back before being journaled.
-    // Revalidate its exact Team ownership and opaque per-pane birth in tmux itself;
-    // a failed conditional kill deliberately retains the pane for recovery.
+    // Revalidate its exact Team ownership and opaque per-pane/session births in
+    // tmux itself; a failed conditional kill deliberately retains the pane for
+    // recovery. Logical session IDs remain aliases and are not destruction
+    // authority.
     for (const paneId of rollbackPaneIds) {
       const paneBirth = rollbackPaneBirths.get(paneId);
       const role = rollbackPaneRoles.get(paneId);
       const command = workerPaneCommands.get(paneId) ?? (role === 'hud' ? createdHudPaneCommand : null);
-      if (!rollbackOwnerSessionId || !rollbackTeamPaneOwnerId || !paneBirth || !role || !command) continue;
-      const condition = `#{&&:#{==:#{pane_id},${escapeTmuxFormatLiteral(paneId)}},#{==:#{pane_start_command},${escapeTmuxFormatLiteral(command)}},#{==:#{@omx_pane_instance_id},${escapeTmuxFormatLiteral(rollbackOwnerSessionId)}},#{==:#{@omx_instance_id},${escapeTmuxFormatLiteral(rollbackOwnerSessionId)}},#{==:#{@omx_team_pane_owner_id},${escapeTmuxFormatLiteral(rollbackTeamPaneOwnerId)}},#{==:#{@omx_team_pane_birth},${escapeTmuxFormatLiteral(paneBirth)}},#{==:#{@omx_team_pane_role},${escapeTmuxFormatLiteral(role)}}}`;
-      runTmux(['if-shell', '-t', paneId, '-F', condition, `kill-pane -t ${paneId}`, '']);
+      if (!rollbackSessionBirth || !rollbackTeamPaneOwnerId || !paneBirth || !role || !command) continue;
+      const appliedReceipt = `__omx_startup_rollback_applied_${randomUUID()}__`;
+      const rejectedReceipt = `__omx_startup_rollback_rejected_${randomUUID()}__`;
+      const condition = `#{&&:#{==:#{pane_id},${escapeTmuxFormatLiteral(paneId)}},#{==:#{pane_start_command},${escapeTmuxFormatLiteral(command)}},#{==:#{@omx_instance_id},${escapeTmuxFormatLiteral(rollbackSessionBirth)}},#{==:#{@omx_team_pane_owner_id},${escapeTmuxFormatLiteral(rollbackTeamPaneOwnerId)}},#{==:#{@omx_team_pane_birth},${escapeTmuxFormatLiteral(paneBirth)}},#{==:#{@omx_team_pane_role},${escapeTmuxFormatLiteral(role)}}}`;
+      runTmux([
+        'if-shell', '-t', paneId, '-F', condition,
+        `kill-pane -t ${paneId} \\; display-message -p ${appliedReceipt}`,
+        `display-message -p ${rejectedReceipt}`,
+      ]);
     }
     throw error;
   }

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -236,6 +236,7 @@ export interface RestoreStandaloneHudPaneOptions {
   cwd?: string | null;
   /** Canonical state-root metadata resolved by the HUD control-plane resolver. */
   hudRuntime?: Pick<HudRuntimeEnvInput, 'omxRoot' | 'omxStateRoot' | 'omxTeamStateRoot' | 'rootSource'>;
+  onCreatedPane?: (evidence: { paneId: string; paneInstanceId: string; command: string }) => void;
 }
 
 const INJECTION_MARKER = '[OMX_TMUX_INJECT]';
@@ -376,21 +377,36 @@ function establishTmuxBirths(sessionName: string, leaderPaneId: string): Establi
     'if-shell', '-t', leaderPaneId, '-F', condition, publish,
     `display-message -p ${rejectedReceipt}`,
   ]);
-  if (!result.ok) return null;
-
-  const received = result.stdout.split('\n').map((line) => line.trim());
+  const received = result.ok ? result.stdout.split('\n').map((line) => line.trim()) : [];
   if (received.includes(appliedReceipt)) return { sessionBirth, paneBirth };
-  if (!received.includes(rejectedReceipt)) return null;
+  if (received.includes(rejectedReceipt)) {
+    // A concurrent publisher won the exact same conditional. It is safe to use
+    // only a complete pair that tmux now exposes for this still-revalidated pane.
+    const concurrentSessionTag = runTmux(['show-options', '-qv', '-t', sessionName, OMX_INSTANCE_OPTION]);
+    const concurrentPaneTag = runTmux(['show-option', '-qv', '-p', '-t', leaderPaneId, OMX_PANE_INSTANCE_OPTION]);
+    const concurrentSessionBirth = concurrentSessionTag.ok ? concurrentSessionTag.stdout.trim() : '';
+    const concurrentPaneBirth = concurrentPaneTag.ok ? concurrentPaneTag.stdout.trim() : '';
+    return concurrentSessionBirth && concurrentPaneBirth
+      ? { sessionBirth: concurrentSessionBirth, paneBirth: concurrentPaneBirth }
+      : null;
+  }
 
-  // A concurrent publisher won the exact same conditional. It is safe to use
-  // only a complete pair that tmux now exposes for this still-revalidated pane.
-  const concurrentSessionTag = runTmux(['show-options', '-qv', '-t', sessionName, OMX_INSTANCE_OPTION]);
-  const concurrentPaneTag = runTmux(['show-option', '-qv', '-p', '-t', leaderPaneId, OMX_PANE_INSTANCE_OPTION]);
-  const concurrentSessionBirth = concurrentSessionTag.ok ? concurrentSessionTag.stdout.trim() : '';
-  const concurrentPaneBirth = concurrentPaneTag.ok ? concurrentPaneTag.stdout.trim() : '';
-  return concurrentSessionBirth && concurrentPaneBirth
-    ? { sessionBirth: concurrentSessionBirth, paneBirth: concurrentPaneBirth }
-    : null;
+  // tmux can report a command failure after the first write has committed. Undo
+  // only our exact pair (or exact half-pair) in one server-side CAS; a changed
+  // value is a concurrent replacement and must survive recovery.
+  const compensationApplied = `__omx_birth_compensated_${randomUUID()}__`;
+  const compensationRejected = `__omx_birth_compensation_rejected_${randomUUID()}__`;
+  const compensationCondition = `#{||:#{&&:#{==:#{${OMX_INSTANCE_OPTION}},${escapeTmuxFormatLiteral(sessionBirth)}},#{==:#{${OMX_PANE_INSTANCE_OPTION}},}},#{&&:#{==:#{${OMX_INSTANCE_OPTION}},},#{==:#{${OMX_PANE_INSTANCE_OPTION}},${escapeTmuxFormatLiteral(paneBirth)}}},#{&&:#{==:#{${OMX_INSTANCE_OPTION}},${escapeTmuxFormatLiteral(sessionBirth)}},#{==:#{${OMX_PANE_INSTANCE_OPTION}},${escapeTmuxFormatLiteral(paneBirth)}}}}`;
+  const compensation = [
+    `set-option -u -t ${shellQuoteSingle(sessionName)} ${OMX_INSTANCE_OPTION}`,
+    `set-option -u -p -t ${shellQuoteSingle(leaderPaneId)} ${OMX_PANE_INSTANCE_OPTION}`,
+    `display-message -p ${compensationApplied}`,
+  ].join(' \\; ');
+  runTmux([
+    'if-shell', '-t', leaderPaneId, '-F', compensationCondition, compensation,
+    `display-message -p ${compensationRejected}`,
+  ]);
+  return null;
 }
 
 function appendNoUnderlineStyleFlags(style: string): string {
@@ -634,14 +650,13 @@ function findExactTeamHudPaneIds(target: string, candidate: ExactTeamHudCandidat
   if (!candidate) return [];
   return listPanes(target)
     .filter((pane) => pane.paneId !== candidate.leaderPaneId)
-    .filter((pane) => hudPaneMatchesExactCandidate(pane, {
+    .filter((pane) => hudPaneMatchesOwner(pane, {
       sessionId: candidate.sessionId,
       sessionIds: candidate.sessionIds,
       leaderPaneId: candidate.leaderPaneId,
-    }, {
-      tmuxSessionInstanceId: candidate.tmuxSessionInstanceId,
-      tmuxPaneInstanceId: candidate.tmuxPaneInstanceId,
-    }))
+    })
+      && Boolean(pane.paneInstanceId?.trim())
+      && pane.sessionInstanceId === candidate.tmuxSessionInstanceId)
     .map((pane) => pane.paneId);
 }
 
@@ -2116,10 +2131,6 @@ export function createTeamSession(
     const panes = listPanes(teamTarget);
     const leaderPaneId = chooseTeamLeaderPaneId(panes, detectedLeaderPaneId);
     const hudExactCandidate = normalizeExactTeamHudCandidate(options.hudExactCandidate);
-    const hudExactCandidateWasProvided = Object.prototype.hasOwnProperty.call(
-      options,
-      'hudExactCandidate',
-    );
     // Capture the session's persisted opaque birth before creating any rollback
     // candidates. The logical owner/session id is only an alias and must never
     // authorize destruction of panes in a later session generation.
@@ -2138,9 +2149,6 @@ export function createTeamSession(
       && hudExactCandidate.leaderPaneId === leaderPaneId
       && hudEvidenceStillMatches,
     );
-    if (!hudExactCandidate && !hudExactCandidateWasProvided) {
-      tagPaneInstance(leaderPaneId, ownerSessionId);
-    }
     tagPaneTeamOwner(leaderPaneId, teamPaneOwnerId);
     options.journalResource?.({
       kind: 'leader',
@@ -2157,6 +2165,30 @@ export function createTeamSession(
     // than silently running multiple HUD actors.
     if (duplicateHudPaneIds.length > 0) {
       throw new Error(`duplicate_exact_team_hud_without_receipts:${duplicateHudPaneIds.join(',')}`);
+    }
+    if (retainedHudPaneId) {
+      const retainedHudPane = listPanes(teamTarget).find((pane) => pane.paneId === retainedHudPaneId);
+      const retainedHudPaneBirth = readTeamPaneBirth(retainedHudPaneId);
+      const retainedHudPaneRole = readTeamPaneRole(retainedHudPaneId);
+      if (
+        !retainedHudPane?.startCommand.trim()
+        || !retainedHudPane.paneInstanceId?.trim()
+        || retainedHudPane.sessionInstanceId !== hudExactCandidate?.tmuxSessionInstanceId
+        || !retainedHudPaneBirth
+        || retainedHudPaneRole !== 'hud'
+        || readNewPaneTeamOwnerTag(retainedHudPaneId) !== teamPaneOwnerId
+      ) {
+        throw new Error(`failed to capture exact retained HUD receipt for ${retainedHudPaneId}`);
+      }
+      options.journalResource?.({
+        kind: 'hud',
+        id: retainedHudPaneId,
+        created: false,
+        pane_birth: retainedHudPaneBirth,
+        command: retainedHudPane.startCommand,
+        role: 'hud',
+        acquired_at: new Date().toISOString(),
+      });
     }
     const omxEntry = resolveOmxCliEntryPath();
     const canRecreateTeamHud = hasExactHudAuthority && Boolean(omxEntry && omxEntry.trim() !== '');
@@ -2271,39 +2303,14 @@ export function createTeamSession(
       if (hudPaneId || hudResult?.ok) {
         const id = hudPaneId ?? (hudResult && hudResult.ok ? hudResult.stdout.split('\n')[0]?.trim() ?? '' : '');
         if (id.startsWith('%')) {
-          if (retainedHudPaneId) {
-            const retainedHudPane = panes.find((pane) => pane.paneId === id);
-            const retainedHudPaneBirth = readTeamPaneBirth(id);
-            const retainedHudPaneRole = readTeamPaneRole(id);
-            if (
-              retainedHudPane?.startCommand.trim()
-              && retainedHudPaneBirth
-              && retainedHudPaneRole === 'hud'
-              && readNewPaneTeamOwnerTag(id) === teamPaneOwnerId
-            ) {
-              options.journalResource?.({
-                kind: 'hud',
-                id,
-                created: false,
-                pane_birth: retainedHudPaneBirth,
-                command: retainedHudPane.startCommand,
-                role: 'hud',
-                acquired_at: new Date().toISOString(),
-              });
-            }
-          }
           if (!retainedHudPaneId) rollbackPaneIds.push(id);
           if (isNativeWindows() && !waitForPaneToRemainPresent(teamTarget, id)) {
             throw new Error(`HUD pane did not remain present after tmux split-window returned ${id}`);
           }
           if (!retainedHudPaneId) {
             const paneBirth = randomUUID();
-            if (!tagNewHudPaneOrRollback(
-              id,
-              hudExactCandidate?.tmuxPaneInstanceId ?? ownerSessionId,
-              teamPaneOwnerId,
-            )) {
-              if (rollbackPaneIds[rollbackPaneIds.length - 1] === id) rollbackPaneIds.pop();
+            const paneInstanceBirth = randomUUID();
+            if (!tagNewHudPaneOrRollback(id, paneInstanceBirth, teamPaneOwnerId)) {
               throw new Error(`failed to tag and verify HUD pane ${id}`);
             }
             tagTeamPaneBirth(id, paneBirth);
@@ -2480,7 +2487,6 @@ export function restoreStandaloneHudPane(
   options: RestoreStandaloneHudPaneOptions = {},
 ): string | null {
   const normalizedLeaderPaneId = normalizePaneTarget(leaderPaneId);
-  const tmuxPaneInstanceId = options.tmuxPaneInstanceId?.trim();
   if (!normalizedLeaderPaneId) return null;
 
   const omxEntry = resolveOmxCliEntryPath();
@@ -2536,7 +2542,9 @@ export function restoreStandaloneHudPane(
 
   const paneId = hudResult.stdout.split('\n')[0]?.trim() ?? '';
   if (!paneId.startsWith('%')) return null;
-  if (tmuxPaneInstanceId && !tagNewHudPaneOrRollback(paneId, tmuxPaneInstanceId)) return null;
+  const restoredPaneInstanceId = randomUUID();
+  options.onCreatedPane?.({ paneId, paneInstanceId: restoredPaneInstanceId, command: hudCmd });
+  if (!tagNewHudPaneOrRollback(paneId, restoredPaneInstanceId)) return null;
 
   // A restored standalone pane is not resize-authorized until a complete
   // immutable hook generation exists.

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -947,6 +947,73 @@ export function unregisterClientAttachedReconcileHook(hookTarget: string, hookNa
   return result.ok;
 }
 
+type TmuxHookSnapshot = {
+  slot: string;
+  command: string | null;
+};
+
+function readTmuxHookSnapshot(hookTarget: string, slot: string): TmuxHookSnapshot | null {
+  const result = runTmux(['show-hooks', '-t', hookTarget, slot]);
+  if (!result.ok) return null;
+  const output = result.stdout.trim();
+  if (output === '') return { slot, command: null };
+  const prefix = `${slot} `;
+  return output.startsWith(prefix) ? { slot, command: output.slice(prefix.length) } : null;
+}
+
+function restoreTmuxHookSnapshot(hookTarget: string, snapshot: TmuxHookSnapshot): boolean {
+  if (snapshot.command === null) return true;
+  return runTmux(['set-hook', '-t', hookTarget, snapshot.slot, snapshot.command]).ok;
+}
+
+function tmuxHookMatchesSnapshot(hookTarget: string, expected: TmuxHookSnapshot): boolean {
+  const actual = readTmuxHookSnapshot(hookTarget, expected.slot);
+  return actual?.command === expected.command;
+}
+
+function tmuxHookIsAbsent(hookTarget: string, slot: string): boolean {
+  return readTmuxHookSnapshot(hookTarget, slot)?.command === null;
+}
+
+function restoreHudHookSnapshots(
+  hookTarget: string,
+  clientAttachedSnapshot: TmuxHookSnapshot,
+  resizeSnapshot: TmuxHookSnapshot,
+): boolean {
+  return restoreTmuxHookSnapshot(hookTarget, clientAttachedSnapshot)
+    && restoreTmuxHookSnapshot(hookTarget, resizeSnapshot)
+    && tmuxHookMatchesSnapshot(hookTarget, clientAttachedSnapshot)
+    && tmuxHookMatchesSnapshot(hookTarget, resizeSnapshot);
+}
+
+/**
+ * Removes the paired Team HUD hooks only when both can be snapshotted first.
+ * If the second deletion fails, restore the first hook and report failure so
+ * shutdown preserves the HUD pane and lifecycle metadata.
+ */
+export function unregisterHudHooksTransactionally(
+  hookTarget: string,
+  resizeHookName: string,
+  clientAttachedHookName: string,
+): boolean {
+  const resizeSlot = buildResizeHookSlot(resizeHookName);
+  const clientAttachedSlot = buildClientAttachedHookSlot(clientAttachedHookName);
+  const clientAttachedSnapshot = readTmuxHookSnapshot(hookTarget, clientAttachedSlot);
+  const resizeSnapshot = readTmuxHookSnapshot(hookTarget, resizeSlot);
+  if (!clientAttachedSnapshot || !resizeSnapshot) return false;
+
+  if (!runTmux(['set-hook', '-u', '-t', hookTarget, clientAttachedSlot]).ok) return false;
+  if (!tmuxHookIsAbsent(hookTarget, clientAttachedSlot)) {
+    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot);
+    return false;
+  }
+  if (!runTmux(['set-hook', '-u', '-t', hookTarget, resizeSlot]).ok || !tmuxHookIsAbsent(hookTarget, resizeSlot)) {
+    restoreHudHookSnapshots(hookTarget, clientAttachedSnapshot, resizeSnapshot);
+    return false;
+  }
+  return true;
+}
+
 export function buildScheduleDelayedHudResizeArgs(
   hudPaneId: string,
   delaySeconds: number = HUD_RESIZE_RECONCILE_DELAY_SECONDS,

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -2078,8 +2078,7 @@ export function createTeamSession(
       tagTeamPaneBirth(paneId, paneBirth);
       rollbackPaneBirths.set(paneId, paneBirth);
       tagTeamPaneRole(paneId, 'worker');
-      const paneCommand = listPanes(teamTarget).find((pane) => pane.paneId === paneId)?.startCommand ?? '';
-      if (!paneCommand) throw new Error(`failed to capture immutable worker command for ${paneId}`);
+      const paneCommand = cmd;
       workerPaneCommands.set(paneId, paneCommand);
       rollbackPaneRoles.set(paneId, 'worker');
       options.journalResource?.({
@@ -2156,8 +2155,7 @@ export function createTeamSession(
             rollbackPaneBirths.set(id, paneBirth);
             createdHudPaneBirth = paneBirth;
             tagTeamPaneRole(id, 'hud');
-            const paneCommand = listPanes(teamTarget).find((pane) => pane.paneId === id)?.startCommand ?? '';
-            if (!paneCommand) throw new Error(`failed to capture immutable HUD command for ${id}`);
+            const paneCommand = hudCmd;
             createdHudPaneCommand = paneCommand;
             rollbackPaneRoles.set(id, 'hud');
             options.journalResource?.({

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -479,12 +479,35 @@ export function ensureWorktree(
   } satisfies EnsureWorktreeResult;
 
   if (plan.branchName) {
-    upsertCurrentTaskBaseline(plan.repoRoot, {
-      branch_name: plan.branchName,
-      worktree_path: ensured.worktreePath,
-      base_ref: plan.baseRef,
-      status: 'active',
-    });
+    try {
+      upsertCurrentTaskBaseline(plan.repoRoot, {
+        branch_name: plan.branchName,
+        worktree_path: ensured.worktreePath,
+        base_ref: plan.baseRef,
+        status: 'active',
+      });
+    } catch (error) {
+      const cleanupErrors: string[] = [];
+      const removeResult = spawnSync('git', ['worktree', 'remove', '--force', ensured.worktreePath], {
+        cwd: plan.repoRoot,
+        encoding: 'utf-8',
+        windowsHide: true,
+      });
+      if (removeResult.status !== 0) cleanupErrors.push(`remove:${(removeResult.stderr || '').trim() || removeResult.status}`);
+      if (ensured.createdBranch && ensured.branchName) {
+        const branchResult = spawnSync('git', ['branch', '-D', ensured.branchName], {
+          cwd: plan.repoRoot,
+          encoding: 'utf-8',
+          windowsHide: true,
+        });
+        if (branchResult.status !== 0 && branchExists(plan.repoRoot, ensured.branchName)) {
+          cleanupErrors.push(`branch:${(branchResult.stderr || '').trim() || branchResult.status}`);
+        }
+      }
+      const detail = error instanceof Error ? error.message : String(error);
+      if (cleanupErrors.length > 0) throw new Error(`worktree_post_add_bookkeeping_failed:${detail}; rollback_failed:${cleanupErrors.join('|')}`);
+      throw new Error(`worktree_post_add_bookkeeping_failed:${detail}`);
+    }
   }
 
   return ensured;

--- a/src/team/worktree.ts
+++ b/src/team/worktree.ts
@@ -47,6 +47,8 @@ export interface EnsureWorktreeResult {
   created: boolean;
   reused: boolean;
   createdBranch: boolean;
+  /** The exact object ID initially assigned to a newly created branch. */
+  createdBranchRef?: string;
   /** True when the worktree had uncommitted changes at launch time. */
   dirty?: boolean;
 }
@@ -476,8 +478,10 @@ export function ensureWorktree(
     created: true,
     reused: false,
     createdBranch: Boolean(plan.branchName && !branchAlreadyExisted),
+    ...(plan.branchName && !branchAlreadyExisted
+      ? { createdBranchRef: plan.baseRef }
+      : {}),
   } satisfies EnsureWorktreeResult;
-
   if (plan.branchName) {
     try {
       upsertCurrentTaskBaseline(plan.repoRoot, {
@@ -494,8 +498,10 @@ export function ensureWorktree(
         windowsHide: true,
       });
       if (removeResult.status !== 0) cleanupErrors.push(`remove:${(removeResult.stderr || '').trim() || removeResult.status}`);
-      if (ensured.createdBranch && ensured.branchName) {
-        const branchResult = spawnSync('git', ['branch', '-D', ensured.branchName], {
+      if (ensured.createdBranch && ensured.branchName && ensured.createdBranchRef) {
+        const branchResult = spawnSync('git', [
+          'update-ref', '-d', `refs/heads/${ensured.branchName}`, ensured.createdBranchRef,
+        ], {
           cwd: plan.repoRoot,
           encoding: 'utf-8',
           windowsHide: true,
@@ -542,14 +548,16 @@ export async function rollbackProvisionedWorktrees(
     }
 
     if (options.skipBranchDeletion) continue;
-    if (!result.createdBranch || !result.branchName) continue;
+    if (!result.createdBranch || !result.branchName || !result.createdBranchRef) continue;
 
     const entriesAfterRemove = listWorktrees(result.repoRoot);
     const stillCheckedOut = hasBranchInUse(entriesAfterRemove, result.branchName, result.worktreePath);
     if (stillCheckedOut) continue;
 
     try {
-      await execFilePromise('git', ['branch', '-D', result.branchName], {
+      await execFilePromise('git', [
+        'update-ref', '-d', `refs/heads/${result.branchName}`, result.createdBranchRef,
+      ], {
         cwd: result.repoRoot,
         encoding: 'utf-8',
       });


### PR DESCRIPTION
## Summary
- derive HUD authority from the canonical control-plane state root, with one admitted primary per domain
- add mandatory process-identity leases and ABA-safe lifecycle locks that fail closed on uncertain ownership
- route managed HUD producers through exact owner/session/leader/tmux-instance reconciliation while preserving unmanaged and legacy panes
- make Team HUD startup/shutdown/restore use the same canonical root, lock, alias, and exact-candidate contract
- gate authority-only fallback watchers and stop unsafe live PID-file reaping without birth/owner proof

Closes #3159.

The reported `bwrap` failure remains correlated context only; this change does not claim a causal fix for it.

## Verification
- `npm test` (376 compiled test files after rebasing onto current `dev`)
- `npm run check:no-unused`
- `npm run lint`
- `npm run smoke:packed-install`
- `git diff --check origin/dev...HEAD`
- final independent Architect review: CLEAR / APPROVE
- final Executor QA/red-team: CLEAR / APPROVE

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*