### PR TITLE
fix(cli): accept BOM-prefixed state input files

### DIFF
--- a/src/cli/__tests__/state.test.ts
+++ b/src/cli/__tests__/state.test.ts
@@ -137,6 +137,46 @@ describe('stateCommand', () => {
     }
   });
 
+  it('reads UTF-8 BOM-prefixed structured input from --input-file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omx-state-input-file-bom-'));
+    const file = join(dir, 'payload.json');
+    await writeFile(file, `\uFEFF${JSON.stringify({ mode: 'ralph', all_sessions: true })}`, 'utf-8');
+    try {
+      let capturedOperation: string | undefined;
+      let capturedInput: Record<string, unknown> | undefined;
+      await stateCommand(['clear', '--input-file', file, '--json'], {
+        stdout: () => undefined,
+        stderr: () => undefined,
+        execute: async (operation, input) => {
+          capturedOperation = operation;
+          capturedInput = input;
+          return { payload: { cleared: true } };
+        },
+      });
+      assert.equal(capturedOperation, 'state_clear');
+      assert.deepEqual(capturedInput, { mode: 'ralph', all_sessions: true });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('strips only one leading BOM from --input-file JSON', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omx-state-input-file-double-bom-'));
+    const file = join(dir, 'payload.json');
+    await writeFile(file, '\uFEFF\uFEFF{"mode":"ralph"}', 'utf-8');
+    try {
+      await assert.rejects(
+        stateCommand(['read', '--input-file', file], {
+          stdout: () => undefined,
+          stderr: () => undefined,
+        }),
+        /valid JSON/i,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('rejects an unreadable --input-file path', async () => {
     await assert.rejects(
       stateCommand(['read', '--input-file', join(tmpdir(), 'omx-state-missing-does-not-exist.json')], {

--- a/src/cli/state.ts
+++ b/src/cli/state.ts
@@ -47,9 +47,10 @@ function parseStateInputJson(
   raw: string,
   source: '--input' | '--input-file',
 ): Record<string, unknown> {
+  const json = source === '--input-file' && raw.startsWith('\uFEFF') ? raw.slice(1) : raw;
   let parsed: unknown;
   try {
-    parsed = JSON.parse(raw);
+    parsed = JSON.parse(json);
   } catch (error) {
     let message = `${source} must be valid JSON: ${(error as Error).message}`;
     if (source === '--input' && looksLikeQuoteStrippedJson(raw)) {


### PR DESCRIPTION
## Summary

- accept one leading UTF-8 byte-order mark in JSON read through `omx state --input-file`
- keep inline `--input` parsing unchanged
- retain fail-closed behavior for malformed files, including multiple leading BOMs

## Root cause

Windows tools commonly emit UTF-8 text files with a leading BOM. Node preserves that marker as `U+FEFF` when the file is read as UTF-8, while `JSON.parse` rejects it before the opening JSON token. That made the documented file-based state recovery path fail for otherwise valid payloads.

## Impact

State read, write, and recovery commands can consume JSON payload files produced by Windows PowerShell and other BOM-emitting editors without weakening validation for inline JSON or malformed files.

## Validation

- `npm run build`
- `node --test dist/cli/__tests__/state.test.js` — 15/15 passed
- `npm run lint` — 740 files checked
- `npm run check:no-unused`
- `git diff --check`
