### PR TITLE
fix(state): ignore foreign stale transition mirrors

### DIFF
--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -1767,6 +1767,58 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('activates deep-interview when terminal Team detail outranks foreign legacy mirrors', async () => {
+    await withStateRootEnv({}, async () => {
+      const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-stale-team-transition-'));
+      try {
+        const stateDir = join(wd, '.omx', 'state');
+        await mkdir(stateDir, { recursive: true });
+        const teamState = { active: false, mode: 'team', current_phase: 'cancelled', run_outcome: 'continue' };
+        const foreignSkillState = {
+          version: 1,
+          active: true,
+          skill: 'team',
+          phase: 'team-exec',
+          current_phase: 'cancelled',
+          session_id: 'foreign-team-session',
+          active_skills: [{ skill: 'team', phase: 'team-exec', active: true }],
+        };
+        const runState = { version: 1, mode: 'team', active: true, outcome: 'continue', current_phase: 'team-exec' };
+        await writeFile(join(stateDir, 'team-state.json'), JSON.stringify(teamState, null, 2));
+        await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify(foreignSkillState, null, 2));
+        await writeFile(join(stateDir, 'run-state.json'), JSON.stringify(runState, null, 2));
+
+        const beforeList = await executeStateOperation('state_list_active', { workingDirectory: wd });
+        const beforeTeam = await executeStateOperation('state_read', { workingDirectory: wd, mode: 'team' });
+        assert.deepEqual(beforeList.payload, { active_modes: ['run'] });
+        assert.deepEqual(beforeTeam.payload, teamState);
+
+        const response = await executeStateOperation('state_write', {
+          workingDirectory: wd,
+          mode: 'deep-interview',
+          active: true,
+          current_phase: 'deep-interview',
+          state: { interview_id: 'fixture', profile: 'quick', type: 'brownfield' },
+        });
+
+        const payload = responsePayload<{ success: boolean; path: string }>(response);
+        assert.equal(payload.success, true);
+        assert.equal(payload.path, join(stateDir, 'deep-interview-state.json'));
+        assert.deepEqual(JSON.parse(await readFile(join(stateDir, 'team-state.json'), 'utf-8')), teamState);
+        assert.deepEqual(JSON.parse(await readFile(join(stateDir, 'run-state.json'), 'utf-8')), runState);
+        assert.equal(existsSync(join(stateDir, 'sessions', 'foreign-team-session', 'deep-interview-state.json')), false);
+
+        assert.deepEqual(
+          JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')),
+          foreignSkillState,
+        );
+        const afterList = await executeStateOperation('state_list_active', { workingDirectory: wd });
+        assert.deepEqual(afterList.payload, { active_modes: ['deep-interview', 'run'] });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
+  });
   it('fails closed without mutating root state when ralplan terminalization sees a foreign session pointer', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-ralplan-stale-session-'));
     try {

--- a/src/state/__tests__/skill-active.test.ts
+++ b/src/state/__tests__/skill-active.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   listActiveSkills,
+  listTransitionActiveSkills,
   readVisibleSkillActiveState,
   syncCanonicalSkillStateForMode,
   writeSkillActiveStateCopies,
@@ -282,6 +283,34 @@ describe('skill-active state helpers', () => {
     });
   });
 
+  it('requires nested transition entries to match canonical session ownership', () => {
+    const entries = [
+      { skill: 'team', phase: 'team-exec', active: true },
+      { skill: 'ralph', phase: 'executing', active: true, session_id: 'foreign-session' },
+      { skill: 'ultrawork', phase: 'executing', active: true, session_id: 'current-session' },
+    ];
+    const compact = (state: unknown, sessionId?: string) => listTransitionActiveSkills(state, sessionId)
+      .map(({ skill, phase, session_id }) => ({ skill, phase, session_id }));
+
+    assert.deepEqual(compact({
+      active: true,
+      skill: 'team',
+      session_id: 'foreign-outer',
+      active_skills: entries,
+    }), []);
+    assert.deepEqual(
+      compact({ active: true, skill: 'team', active_skills: entries }),
+      [{ skill: 'team', phase: 'team-exec', session_id: undefined }],
+    );
+    assert.deepEqual(
+      compact({ active: true, skill: 'team', active_skills: [...entries].reverse() }, 'current-session'),
+      [{ skill: 'ultrawork', phase: 'executing', session_id: 'current-session' }],
+    );
+    assert.deepEqual(
+      compact({ active: true, skill: 'team', active_skills: entries }, 'foreign-session'),
+      [{ skill: 'ralph', phase: 'executing', session_id: 'foreign-session' }],
+    );
+  });
   it('does not treat active_skills as active when the canonical state is terminal', async () => {
     await withTempRepo('omx-skill-active-terminal-overrides-entries-', async (cwd) => {
       await mkdir(join(cwd, '.omx', 'state', 'sessions', 'sess-terminal'), { recursive: true });

--- a/src/state/__tests__/workflow-transition.test.ts
+++ b/src/state/__tests__/workflow-transition.test.ts
@@ -234,6 +234,72 @@ describe('workflow transition rules', () => {
     });
   });
 
+  it('lets terminal Team detail outrank a foreign compatibility mirror without touching foreign state', async () => {
+    await withIsolatedStateEnv(async () => {
+      const wd = await mkdtemp(join(tmpdir(), 'omx-workflow-foreign-team-terminal-'));
+      try {
+        const stateDir = join(wd, '.omx', 'state');
+        await mkdir(stateDir, { recursive: true });
+        const teamState = { active: false, mode: 'team', current_phase: 'cancelled', run_outcome: 'continue' };
+        const skillState = {
+          version: 1,
+          active: true,
+          skill: 'team',
+          phase: 'team-exec',
+          current_phase: 'cancelled',
+          session_id: 'foreign-team-session',
+          active_skills: [{ skill: 'team', phase: 'team-exec', active: true }],
+        };
+        const runState = { version: 1, mode: 'team', active: true, outcome: 'continue', current_phase: 'team-exec' };
+        await writeFile(join(stateDir, 'team-state.json'), JSON.stringify(teamState, null, 2));
+        await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify(skillState, null, 2));
+        await writeFile(join(stateDir, 'run-state.json'), JSON.stringify(runState, null, 2));
+
+        const transition = await reconcileWorkflowTransition(wd, 'deep-interview', {
+          action: 'write',
+          source: 'test',
+        });
+
+        assert.equal(transition.decision.allowed, true);
+        assert.deepEqual(transition.decision.currentModes, []);
+        assert.deepEqual(transition.completedPaths, []);
+        assert.deepEqual(JSON.parse(await readFile(join(stateDir, 'team-state.json'), 'utf-8')), teamState);
+        assert.deepEqual(JSON.parse(await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8')), skillState);
+        assert.deepEqual(JSON.parse(await readFile(join(stateDir, 'run-state.json'), 'utf-8')), runState);
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it('still rejects planning rollback when root Team detail is genuinely active', async () => {
+    await withIsolatedStateEnv(async () => {
+      const wd = await mkdtemp(join(tmpdir(), 'omx-workflow-foreign-team-active-'));
+      try {
+        const stateDir = join(wd, '.omx', 'state');
+        await mkdir(stateDir, { recursive: true });
+        await writeFile(join(stateDir, 'team-state.json'), JSON.stringify({
+          active: true,
+          mode: 'team',
+          current_phase: 'team-exec',
+        }, null, 2));
+        await writeFile(join(stateDir, 'skill-active-state.json'), JSON.stringify({
+          version: 1,
+          active: true,
+          skill: 'team',
+          session_id: 'foreign-team-session',
+          active_skills: [{ skill: 'team', phase: 'team-exec', active: true }],
+        }, null, 2));
+
+        await assert.rejects(
+          reconcileWorkflowTransition(wd, 'deep-interview', { action: 'write', source: 'test' }),
+          /team is already active/,
+        );
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
+  });
   it('co-locates auto-completed mode detail and canonical skill state under an explicit base state dir', async () => {
     const root = await mkdtemp(join(tmpdir(), 'omx-workflow-reconcile-base-dir-'));
     try {

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -35,7 +35,9 @@ import {
   clearTerminalSkillActiveMarkers,
   getSkillActiveStatePathsForStateDir,
   isTerminalSkillActiveState,
+  isTransitionCanonicalStateOwned,
   listActiveSkills,
+  listTransitionActiveSkills,
   readSkillActiveState,
   readVisibleSkillActiveStateForStateDir,
   syncCanonicalSkillStateForMode,
@@ -663,14 +665,9 @@ export async function listActiveStateModes(
   });
   const canonicalState = await readVisibleSkillActiveStateForStateDir(getBaseStateDir(cwd), sessionId);
   const canonicalActiveModes = new Set(
-    listActiveSkills(canonicalState ?? {})
-      .filter((entry) => {
-        const entrySessionId = typeof entry.session_id === 'string' ? entry.session_id.trim() : '';
-        return sessionId ? entrySessionId === sessionId : entrySessionId.length === 0;
-      })
-      .map((entry) => entry.skill),
+    listTransitionActiveSkills(canonicalState ?? {}, sessionId).map((entry) => entry.skill),
   );
-  const hasCanonicalVisibility = canonicalState !== null;
+  const hasCanonicalVisibility = isTransitionCanonicalStateOwned(canonicalState, sessionId);
 
   return Object.entries(statuses)
     .filter(([mode, status]) => {
@@ -687,13 +684,8 @@ async function readCanonicalActiveWorkflowModes(
   baseStateDir: string,
   sessionId?: string,
 ): Promise<TrackedWorkflowMode[]> {
-  const normalizedSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
   const canonicalState = await readVisibleSkillActiveStateForStateDir(baseStateDir, sessionId);
-  const activeModes = listActiveSkills(canonicalState ?? {})
-    .filter((entry) => {
-      const entrySessionId = typeof entry.session_id === 'string' ? entry.session_id.trim() : '';
-      return normalizedSessionId ? entrySessionId === normalizedSessionId : entrySessionId.length === 0;
-    })
+  const activeModes = listTransitionActiveSkills(canonicalState ?? {}, sessionId)
     .map((entry) => entry.skill)
     .filter(isTrackedWorkflowMode);
   return [...new Set(activeModes)];

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -235,6 +235,28 @@ export function listActiveSkills(raw: unknown): SkillActiveEntry[] {
   return [...deduped.values()];
 }
 
+/**
+ * Returns whether a canonical compatibility record may speak for the requested
+ * transition scope. A foreign outer session never authenticates unowned legacy
+ * child entries for a root or different-session caller.
+ */
+export function isTransitionCanonicalStateOwned(raw: unknown, sessionId?: string): boolean {
+  if (!raw || typeof raw !== 'object') return false;
+  const outerSessionId = safeString((raw as SkillActiveStateLike).session_id).trim();
+  const normalizedSessionId = safeString(sessionId).trim();
+  return normalizedSessionId ? !outerSessionId || outerSessionId === normalizedSessionId : !outerSessionId;
+}
+
+export function listTransitionActiveSkills(raw: unknown, sessionId?: string): SkillActiveEntry[] {
+  if (!isTransitionCanonicalStateOwned(raw, sessionId)) return [];
+  const entries = listActiveSkills(raw);
+  const normalizedSessionId = safeString(sessionId).trim();
+  if (normalizedSessionId) {
+    return entries.filter((entry) => safeString(entry.session_id).trim() === normalizedSessionId);
+  }
+  return entries.filter((entry) => safeString(entry.session_id).trim().length === 0);
+}
+
 /** Owner metadata for read-only provenance preflight; never infers ownership from storage. */
 export function listSkillActiveOwnerCodexSessionIds(raw: unknown): string[] {
   if (!raw || typeof raw !== 'object') return [];
@@ -409,9 +431,7 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
       ))
     ))
     : [];
-  const visibleEntries = normalizedSessionId
-    ? [...rootEntries, ...sessionOnlyEntries]
-    : rootEntries.filter((entry) => safeString(entry.session_id).trim().length === 0);
+  const visibleEntries = listTransitionActiveSkills(existingSession ?? existingRoot ?? {}, sessionId);
 
   if (active && isTrackedWorkflowMode(mode)) {
     const currentWorkflowModes = visibleEntries
@@ -419,6 +439,8 @@ export async function syncCanonicalSkillStateForMode(options: SyncCanonicalSkill
       .filter(isTrackedWorkflowMode);
     assertWorkflowTransitionAllowed(currentWorkflowModes, mode, 'write');
   }
+
+  if (!normalizedSessionId && existingRoot && !isTransitionCanonicalStateOwned(existingRoot)) return;
 
   const applyEntriesToState = (
     base: SkillActiveStateLike | null,

--- a/src/state/workflow-transition-reconcile.ts
+++ b/src/state/workflow-transition-reconcile.ts
@@ -12,7 +12,7 @@ import {
   type WorkflowTransitionDecision,
 } from './workflow-transition.js';
 import {
-  listActiveSkills,
+  listTransitionActiveSkills,
   readVisibleSkillActiveState,
   readVisibleSkillActiveStateForStateDir,
   syncCanonicalSkillStateForMode,
@@ -86,6 +86,12 @@ async function assertAuthoritativeWorkflowStateReadable(
   }
 }
 
+function isActiveWorkflowDetail(state: TransitionStateLike | null): boolean {
+  if (!state || state.active !== true) return false;
+  const phase = safeString(state.current_phase).trim().toLowerCase();
+  return !['complete', 'completed', 'cancelled', 'canceled', 'failed', 'cleared'].includes(phase);
+}
+
 async function visibleTrackedModes(
   cwd: string,
   sessionId?: string,
@@ -94,12 +100,22 @@ async function visibleTrackedModes(
   const canonical = baseStateDir
     ? await readVisibleSkillActiveStateForStateDir(baseStateDir, sessionId)
     : await readVisibleSkillActiveState(cwd, sessionId);
-  const canonicalModes = listActiveSkills(canonical ?? {})
-    .filter((entry) => sessionId || safeString(entry.session_id).trim().length === 0)
+  const canonicalModes = listTransitionActiveSkills(canonical ?? {}, sessionId)
     .map((entry) => entry.skill)
     .filter(isTrackedWorkflowMode);
 
-  return [...new Set(canonicalModes)];
+  if (sessionId) return [...new Set(canonicalModes)];
+
+  const activeDetailModes: TrackedWorkflowMode[] = [];
+  for (const mode of TRACKED_WORKFLOW_MODES) {
+    const state = await readJsonIfExists(modeStatePathForRoot(mode, cwd, undefined, baseStateDir), {
+      mode,
+      throwOnParseError: true,
+    });
+    if (isActiveWorkflowDetail(state)) activeDetailModes.push(mode);
+  }
+
+  return [...new Set([...canonicalModes, ...activeDetailModes])];
 }
 
 async function completeSourceModeState(


### PR DESCRIPTION
## Summary
- make transition activity require canonical `skill-active` ownership for the requested root/session scope
- let genuinely active root workflow detail remain fail-closed while terminal Team detail outranks foreign stale compatibility mirrors
- preserve foreign Team detail, run-state, and skill-active bytes during a new root Deep Interview write

## Reproduction and fix evidence
Current `dev` (`e8e94678`) reproduced the contradiction exactly:
- `state list-active`: `{"active_modes":["run"]}`
- `state read --mode team`: terminal/inactive Team
- Deep Interview write: rejected with `team is already active`

At this PR head (`50d4c5e6`), the same disposable matrix reports:
- before: `{"active_modes":["run"]}`
- Team read remains terminal/inactive
- Deep Interview write succeeds at root scope
- after: `{"active_modes":["deep-interview","run"]}`
- foreign `skill-active-state.json` remains byte-for-byte unchanged

The discriminating controls cover missing, foreign, and current nested session IDs, array order, active versus terminal Team detail, stale run-state alone, and no foreign writes.

## #3160 overlap
PR #3160 is the broad authority-root change for #3139. Its exact head does not directly close this same-root defect: the raw #3171 fixture is rejected earlier because #3160 requires a committed authenticated authority. This fix stays in the dedicated same-root transition lane rather than being silently bundled into #3160.

## Validation
- `npm run build`
- focused state suites: 131 passed, 0 failed
- `npm run check:no-unused`
- `npm run lint` — 740 files, no fixes
- `git diff --check`
- `npm test` — passed, including catalog check

Fixes #3171

—

_[repo owner's gaebal-gajae (clawdbot) 🦞]_