### PR TITLE
fix(hud): verify reconciliation convergence

### DIFF
--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -45,19 +45,67 @@ function testReconcileDomain(cwd: string, deps: ReconcileHudForPromptSubmitDeps)
   };
 }
 
-async function reconcileHudForPromptSubmit(cwd: string, deps: ReconcileHudForPromptSubmitDeps = {}) {
+type ReconcileTestDeps = ReconcileHudForPromptSubmitDeps & {
+  exposeCreatedPaneAfterCreate?: boolean;
+  exposeKilledPaneAfterKill?: boolean;
+};
+
+async function reconcileHudForPromptSubmit(cwd: string, deps: ReconcileTestDeps = {}) {
   const sessionId = deps.sessionId?.trim() || deps.env?.OMX_SESSION_ID?.trim() || '';
+  const leaderPaneId = deps.env?.TMUX_PANE?.trim() || '';
   const listPanes = deps.listCurrentWindowPanes;
+  const createPane = deps.createHudWatchPane;
+  const killPane = deps.killTmuxPane;
+  let createdPaneId: string | null = null;
+  const successfullyKilledPaneIds = new Set<string>();
+  const {
+    exposeCreatedPaneAfterCreate: _exposeCreatedPaneAfterCreate,
+    exposeKilledPaneAfterKill: _exposeKilledPaneAfterKill,
+    ...rawDeps
+  } = deps;
   return reconcileHudForPromptSubmitRaw(cwd, {
-    ...deps,
+    ...rawDeps,
     listCurrentWindowPanes: listPanes
-      ? (paneId) => listPanes(paneId).map((pane) => ({
-        ...pane,
-        ...(pane.startCommand.includes('OMX_SESSION_ID=') && !pane.paneInstanceId
-          ? { paneInstanceId: sessionId, sessionInstanceId: sessionId }
-          : {}),
-      }))
+      ? (paneId) => {
+        const panes = listPanes(paneId)
+          .filter((pane) => deps.exposeKilledPaneAfterKill === true || !successfullyKilledPaneIds.has(pane.paneId))
+          .map((pane) => ({
+            ...pane,
+            ...(pane.startCommand.includes('OMX_SESSION_ID=') && !pane.paneInstanceId
+              ? { paneInstanceId: sessionId, sessionInstanceId: sessionId }
+              : {}),
+          }));
+        if (
+          createdPaneId
+          && deps.exposeCreatedPaneAfterCreate !== false
+          && !panes.some((pane) => pane.paneId === createdPaneId)
+        ) {
+          panes.push({
+            paneId: createdPaneId,
+            currentCommand: 'node',
+            startCommand: `exec env OMX_SESSION_ID='${sessionId}' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='${leaderPaneId}' node omx hud --watch`,
+            paneInstanceId: sessionId,
+            sessionInstanceId: sessionId,
+          });
+        }
+        return panes;
+      }
       : undefined,
+    createHudWatchPane: createPane
+      ? (hudCwd, hudCmd, options) => {
+        createdPaneId = createPane(hudCwd, hudCmd, options);
+        return createdPaneId;
+      }
+      : undefined,
+    killTmuxPane: killPane
+      ? (paneId) => {
+        const killed = killPane(paneId);
+        if (killed) successfullyKilledPaneIds.add(paneId);
+        return killed;
+      }
+      : undefined,
+    registerHudResizeHook: deps.registerHudResizeHook ?? noOpRegisterHudResizeHook,
+    unregisterHudResizeHook: deps.unregisterHudResizeHook ?? noOpUnregisterHudResizeHook,
     resolveDomain: deps.resolveDomain ?? (async () => testReconcileDomain(cwd, deps)),
     probeTmuxInstance: deps.probeTmuxInstance ?? (async (paneId) => ({
       paneTarget: paneId ?? '',
@@ -248,6 +296,44 @@ describe('reconcileHudForPromptSubmit', () => {
     }
   });
 
+  it('reports lifecycle lock setup errors as failures instead of healthy contention', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-reconcile-lock-error-'));
+    const blockedStateDir = join(cwd, 'blocked-state-dir');
+    await writeFile(blockedStateDir, 'not a directory');
+    try {
+      const baseDomain = testReconcileDomain(cwd, {
+        sessionId: 'sess-a',
+        env: { TMUX_PANE: '%1' },
+      });
+      const result = await reconcileHudForPromptSubmit(cwd, {
+        env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+        resolveDomain: async () => ({
+          ...baseDomain,
+          baseStateDir: blockedStateDir,
+          reconcileLockPath: join(blockedStateDir, 'hud-reconcile.lock'),
+        }),
+        listCurrentWindowPanes: () => { assert.fail('lock setup failure must stop before scanning panes'); return []; },
+        resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+      });
+
+      assert.equal(result.status, 'failed');
+      assert.equal(result.paneId, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when the initial tmux pane scan fails', async () => {
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => { throw new Error('tmux list-panes failed'); },
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    }).catch(() => null);
+
+    assert.equal(result?.status, 'failed');
+    assert.equal(result?.paneId, null);
+  });
+
   it('recreates a missing HUD in explicit OMX-owned tmux with a session id', async () => {
     const created: Array<{ cwd: string; cmd: string; options?: { heightLines?: number; targetPaneId?: string } }> = [];
     const resized: Array<{ paneId: string; heightLines: number }> = [];
@@ -324,6 +410,31 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.match(created[0]?.cmd || '', new RegExp(`${OMX_TMUX_HUD_LEADER_PANE_ENV}='%33'`));
   });
 
+  it('fails without creating a HUD when a same-session orphan cannot be reaped', async () => {
+    let created = false;
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%33', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%33', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%34',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%21' node omx hud --watch`,
+        },
+      ],
+      killTmuxPane: () => false,
+      createHudWatchPane: () => { created = true; return '%50'; },
+      resizeTmuxPane: () => true,
+      registerHudResizeHook: noOpRegisterHudResizeHook,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.paneId, null);
+    assert.equal(created, false);
+  });
+
   it('reaps orphaned HUD panes tagged with an equivalent native session id', async () => {
     // #2684 lets HUD dedupe treat the OMX owner id and Codex native session id as
     // equivalent. Orphan reaping must use the same identity set so a canonical
@@ -388,6 +499,31 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(result.paneId, '%new-hud');
     assert.equal(created.length, 1);
     assert.equal(created[0]?.options?.targetPaneId, '%leader');
+  });
+
+  it('fails without creating a HUD when a stale same-leader pane cannot be reaped', async () => {
+    let created = false;
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%leader', OMX_SESSION_ID: 'sess-new', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%leader', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%stale-hud',
+          currentCommand: 'node',
+          startCommand: `exec env OMX_SESSION_ID='sess-old' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%leader' node omx hud --watch`,
+        },
+      ],
+      killTmuxPane: () => false,
+      createHudWatchPane: () => { created = true; return '%new-hud'; },
+      resizeTmuxPane: () => true,
+      registerHudResizeHook: noOpRegisterHudResizeHook,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.paneId, null);
+    assert.equal(created, false);
   });
 
   it('reaps a stale same-leader HUD even when a current-session HUD already exists', async () => {
@@ -698,7 +834,7 @@ describe('reconcileHudForPromptSubmit', () => {
     });
 
     assert.equal(result.status, 'recreated');
-    assert.deepEqual(listArgs, ['%leader', '%leader']);
+    assert.deepEqual(listArgs, ['%leader', '%leader', '%leader']);
     assert.equal(created[0]?.options?.targetPaneId, '%leader');
   });
 
@@ -994,6 +1130,7 @@ describe('reconcileHudForPromptSubmit', () => {
     let listCount = 0;
 
     const result = await reconcileHudForPromptSubmit('/repo', {
+      exposeCreatedPaneAfterCreate: false,
       env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-race', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: () => {
         listCount += 1;
@@ -1018,6 +1155,27 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(result.duplicateCount, 0);
     assert.deepEqual(killed, []);
     assert.deepEqual(resized, [{ paneId: '%8', heightLines: HUD_TMUX_HEIGHT_LINES }]);
+  });
+
+  it('fails when the created HUD is absent from a successful post-create owner scan', async () => {
+    let resized = false;
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      exposeCreatedPaneAfterCreate: false,
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-race', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+      ],
+      createHudWatchPane: () => '%9',
+      resizeTmuxPane: () => { resized = true; return true; },
+      registerHudResizeHook: noOpRegisterHudResizeHook,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.paneId, null);
+    assert.equal(result.duplicateCount, 0);
+    assert.equal(resized, false);
   });
 
   it('kills post-create duplicate HUD panes even when the keeper cannot be resized', async () => {
@@ -1056,6 +1214,78 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(result.duplicateCount, 1);
     assert.deepEqual(killed, ['%8']);
     assert.deepEqual(registered, []);
+  });
+
+  it('fails when a duplicate discovered after create cannot be killed', async () => {
+    let listCount = 0;
+    let resized = false;
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-race', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => {
+        listCount += 1;
+        if (listCount === 1) return [{ paneId: '%1', currentCommand: 'codex', startCommand: 'codex' }];
+        return [
+          { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+          {
+            paneId: '%8',
+            currentCommand: 'node',
+            startCommand: `exec env OMX_SESSION_ID='sess-race' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+          },
+          {
+            paneId: '%9',
+            currentCommand: 'node',
+            startCommand: `exec env OMX_SESSION_ID='sess-race' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+          },
+        ];
+      },
+      createHudWatchPane: () => '%9',
+      killTmuxPane: () => false,
+      resizeTmuxPane: () => { resized = true; return true; },
+      registerHudResizeHook: noOpRegisterHudResizeHook,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.paneId, '%9');
+    assert.equal(result.duplicateCount, 1);
+    assert.equal(resized, false);
+  });
+
+  it('fails when the final owner scan still observes a post-create duplicate', async () => {
+    let listCount = 0;
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      exposeKilledPaneAfterKill: true,
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-race', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => {
+        listCount += 1;
+        if (listCount === 1) return [{ paneId: '%1', currentCommand: 'codex', startCommand: 'codex' }];
+        return [
+          { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+          {
+            paneId: '%8',
+            currentCommand: 'node',
+            startCommand: `exec env OMX_SESSION_ID='sess-race' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+          },
+          {
+            paneId: '%9',
+            currentCommand: 'node',
+            startCommand: `exec env OMX_SESSION_ID='sess-race' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+          },
+        ];
+      },
+      createHudWatchPane: () => '%9',
+      killTmuxPane: () => true,
+      resizeTmuxPane: () => true,
+      registerHudResizeHook: noOpRegisterHudResizeHook,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.paneId, '%9');
+    assert.equal(result.duplicateCount, 1);
+    assert.ok(listCount >= 3);
   });
 
   it('kills duplicate HUD panes and reuses one existing pane', async () => {
@@ -1101,6 +1331,36 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(killed, ['%3']);
     assert.deepEqual(resized, [{ paneId: '%2', heightLines: HUD_TMUX_HEIGHT_LINES }]);
     assert.deepEqual(created, []);
+  });
+
+  it('fails reconciliation when an existing duplicate HUD pane cannot be killed', async () => {
+    const resized: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+        },
+        {
+          paneId: '%3',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+        },
+      ],
+      killTmuxPane: (paneId) => paneId !== '%3',
+      resizeTmuxPane: (paneId) => { resized.push(paneId); return true; },
+      registerHudResizeHook: noOpRegisterHudResizeHook,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.paneId, '%2');
+    assert.equal(result.duplicateCount, 1);
+    assert.deepEqual(resized, []);
   });
 
   it('deduplicates same-leader HUD panes tagged with equivalent owner and canonical session ids', async () => {
@@ -1686,6 +1946,47 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(registered, [{ hudPaneId: '%9', currentPaneId: '%1', heightLines: HUD_TMUX_HEIGHT_LINES }]);
   });
 
+  it('does not create a replacement when a malformed HUD pane cannot be killed', async () => {
+    const killed: string[] = [];
+    const created: string[] = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneLeft: 0, paneTop: 0, paneWidth: 80, paneHeight: 50, paneBottom: 49, windowWidth: 160, windowHeight: 50 },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+          paneLeft: 80,
+          paneTop: 0,
+          paneWidth: 80,
+          paneHeight: 50,
+          paneBottom: 49,
+          windowWidth: 160,
+          windowHeight: 50,
+        },
+      ],
+      unregisterHudResizeHook: () => true,
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return false;
+      },
+      createHudWatchPane: () => {
+        created.push('%9');
+        return '%9';
+      },
+      resizeTmuxPane: () => true,
+      registerHudResizeHook: () => true,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.paneId, '%2');
+    assert.deepEqual(killed, ['%2']);
+    assert.deepEqual(created, []);
+  });
+
   it('recreates a single owned HUD pane when tmux layout moves it away from the bottom', async () => {
     const killed: string[] = [];
     const created: Array<{ options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
@@ -1893,6 +2194,23 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(registered[0]?.hudPaneId, '%9');
     assert.equal(registered[0]?.leaderPaneId, '%1');
     assert.equal(registered[0]?.heightLines, HUD_TMUX_HEIGHT_LINES);
+  });
+
+  it('fails when the resize hook cannot be registered for a created HUD pane', async () => {
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+      ],
+      createHudWatchPane: () => '%9',
+      resizeTmuxPane: () => true,
+      unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+      registerHudResizeHook: () => false,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.paneId, '%9');
   });
 
   it('keeps the resize hook on the reused duplicate keeper pane', async () => {
@@ -2186,10 +2504,11 @@ describe('reconcileHudForPromptSubmit verified lifecycle ownership', () => {
     assert.equal(created, false);
   });
 
-  it('does not deduplicate an unverified pane-id reuse observed after create', async () => {
+  it('fails closed for an unverified pane-id reuse observed after create', async () => {
     const killed: string[] = [];
     let listCount = 0;
     const result = await reconcileHudForPromptSubmit('/repo', {
+      exposeCreatedPaneAfterCreate: false,
       env: { TMUX: 'socket', TMUX_PANE: '%leader', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: () => {
         listCount += 1;
@@ -2205,8 +2524,8 @@ describe('reconcileHudForPromptSubmit verified lifecycle ownership', () => {
       resizeTmuxPane: () => { assert.fail('unsafe post-create candidates must not be resized'); return false; },
       resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
     });
-    assert.equal(result.status, 'recreated');
-    assert.equal(result.paneId, '%created');
+    assert.equal(result.status, 'failed');
+    assert.equal(result.paneId, null);
     assert.deepEqual(killed, []);
   });
 });

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -12,6 +12,7 @@ import {
   findLegacyFocusedHudWatchPaneIds,
   findHudWatchPaneIds,
   hudPaneMatchesOwner,
+  listCurrentWindowPanes,
   listCurrentWindowHudPaneIds,
   OMX_TMUX_HUD_LEADER_PANE_ENV,
   TMUX_PANE_FIELD_SEPARATOR_OCTAL_ESCAPE,
@@ -39,6 +40,23 @@ describe('HUD pane creation', () => {
     assert.equal(result, null);
     assert.deepEqual(calls.at(-1), ['kill-pane', '-t', '%new']);
     assert.equal(calls.filter((args) => args[0] === 'kill-pane').length, 1);
+  });
+});
+
+describe('HUD pane scanning', () => {
+  it('can preserve tmux scan failures for callers that must fail closed', () => {
+    const failingScan = () => { throw new Error('tmux list-panes failed'); };
+    assert.deepEqual(listCurrentWindowPanes(failingScan), []);
+
+    const strictList = listCurrentWindowPanes as unknown as (
+      execTmuxSync: (args: string[]) => string,
+      currentPaneId: string | undefined,
+      options: { throwOnError: boolean },
+    ) => unknown;
+    assert.throws(
+      () => strictList(failingScan, '%1', { throwOnError: true }),
+      /tmux list-panes failed/,
+    );
   });
 });
 describe('HUD resize hook helpers', () => {

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -56,14 +56,14 @@ function reapOrphanedSessionHudPanes(
     currentPaneId: string | undefined;
     killPane: (paneId: string) => boolean;
   },
-): string[] {
+): { reapedPaneIds: string[]; failed: boolean } {
   const { sessionId, currentPaneId, killPane } = opts;
   const sameSessionIds = new Set(
     [sessionId, ...(opts.sessionIds ?? [])]
       .map((candidate) => candidate?.trim() ?? '')
       .filter((candidate) => candidate !== ''),
   );
-  if (sameSessionIds.size === 0) return [];
+  if (sameSessionIds.size === 0) return { reapedPaneIds: [], failed: false };
   // A recorded leader only counts as "live" if it exists in this window AND is not
   // itself a HUD watcher. Without the HUD exclusion, an orphan whose recorded leader
   // is *another HUD pane* would be preserved here; that referenced HUD could be
@@ -73,6 +73,7 @@ function reapOrphanedSessionHudPanes(
     panes.filter((pane) => !isHudWatchPane(pane)).map((pane) => pane.paneId),
   );
   const reaped: string[] = [];
+  let failed = false;
   for (const pane of panes) {
     if (!isHudWatchPane(pane)) continue;
     const owner = readHudPaneOwner(pane);
@@ -82,8 +83,9 @@ function reapOrphanedSessionHudPanes(
     // Keep HUDs whose leader is the current pane or another live non-HUD leader pane.
     if (owner.leaderPaneId === currentPaneId || liveNonHudPaneIds.has(owner.leaderPaneId)) continue;
     if (killPane(pane.paneId)) reaped.push(pane.paneId);
+    else failed = true;
   }
-  return reaped;
+  return { reapedPaneIds: reaped, failed };
 }
 
 function hasExplicitHudOwnerMarker(pane: TmuxPaneSnapshot): boolean {
@@ -98,13 +100,14 @@ function reapStaleCurrentLeaderHudPanes(
     currentPaneId: string | undefined;
     killPane: (paneId: string) => boolean;
   },
-): string[] {
+): { reapedPaneIds: string[]; failed: boolean } {
   const { currentPaneId, killPane } = opts;
-  if (!currentPaneId) return [];
+  if (!currentPaneId) return { reapedPaneIds: [], failed: false };
   const currentSessionIds = new Set(opts.sessionIds.map((sessionId) => sessionId.trim()).filter(Boolean));
-  if (currentSessionIds.size === 0) return [];
+  if (currentSessionIds.size === 0) return { reapedPaneIds: [], failed: false };
 
   const reaped: string[] = [];
+  let failed = false;
   for (const pane of panes) {
     if (!isHudWatchPane(pane)) continue;
     const owner = readHudPaneOwner(pane);
@@ -113,8 +116,9 @@ function reapStaleCurrentLeaderHudPanes(
     if (!owner.sessionId || currentSessionIds.has(owner.sessionId)) continue;
     if (!hasVerifiedHudPaneInstanceIdentity(pane, currentSessionIds)) continue;
     if (killPane(pane.paneId)) reaped.push(pane.paneId);
+    else failed = true;
   }
-  return reaped;
+  return { reapedPaneIds: reaped, failed };
 }
 
 export interface ReconcileHudForPromptSubmitResult {
@@ -176,14 +180,14 @@ function ensureHudResizeHook(
   desiredHeight: number,
   cwd: string,
   deps: ReconcileHudForPromptSubmitDeps,
-): void {
+): boolean {
   try {
-    (deps.registerHudResizeHook ?? registerHudResizeHook)(hudPaneId, leaderPaneId, desiredHeight, {
+    return (deps.registerHudResizeHook ?? registerHudResizeHook)(hudPaneId, leaderPaneId, desiredHeight, {
       cwd,
       env: deps.env ?? process.env,
     });
   } catch {
-    // Non-critical — hook registration failure does not break HUD lifecycle.
+    return false;
   }
 }
 
@@ -241,7 +245,7 @@ function planOwnedHudPaneDedupe(
   owner: HudPaneOwner,
   preferredPaneId: string,
   equivalentSessionIds: ReadonlySet<string>,
-): { paneId: string; duplicatePaneIds: string[]; unsafeCandidate: boolean } {
+): { paneId: string | null; duplicatePaneIds: string[]; unsafeCandidate: boolean } {
   const ownedPanes = panes
     .filter((pane) => pane.paneId !== currentPaneId)
     .filter((pane) => hudPaneMatchesOwner(pane, owner));
@@ -251,13 +255,28 @@ function planOwnedHudPaneDedupe(
   const ownedPaneIds = ownedPanes.map((pane) => pane.paneId);
   const keeperPaneId = ownedPaneIds.includes(preferredPaneId)
     ? preferredPaneId
-    : (ownedPaneIds[0] ?? preferredPaneId);
+    : (ownedPaneIds[0] ?? null);
 
   return {
     paneId: keeperPaneId,
     duplicatePaneIds: ownedPaneIds.filter((paneId) => paneId !== keeperPaneId),
     unsafeCandidate: false,
   };
+}
+
+function hasConvergedOwnedHudPane(
+  panes: TmuxPaneSnapshot[],
+  currentPaneId: string | undefined,
+  owner: HudPaneOwner,
+  expectedPaneId: string,
+  equivalentSessionIds: ReadonlySet<string>,
+): boolean {
+  const ownedPanes = panes
+    .filter((pane) => pane.paneId !== currentPaneId)
+    .filter((pane) => hudPaneMatchesOwner(pane, owner));
+  return ownedPanes.length === 1
+    && ownedPanes[0]?.paneId === expectedPaneId
+    && hasVerifiedHudPaneInstanceIdentity(ownedPanes[0], equivalentSessionIds);
 }
 
 const HUD_RECONCILE_LOCK_STALE_MS = 10_000;
@@ -376,6 +395,14 @@ export async function reconcileHudForPromptSubmit(
       },
     )
     : { status: 'failed' as const };
+  if (acquired.status === 'failed') {
+    return {
+      status: 'failed',
+      paneId: null,
+      desiredHeight: null,
+      duplicateCount: 0,
+    };
+  }
   if (acquired.status !== 'acquired' || !acquired.lock) {
     return {
       status: 'skipped_concurrent',
@@ -385,7 +412,15 @@ export async function reconcileHudForPromptSubmit(
     };
   }
 
-  const listPanes = deps.listCurrentWindowPanes ?? ((paneId) => listCurrentWindowPanes(undefined, paneId));
+  const listPanes = deps.listCurrentWindowPanes
+    ?? ((paneId) => listCurrentWindowPanes(undefined, paneId, { throwOnError: true }));
+  const scanPanes = (): TmuxPaneSnapshot[] | null => {
+    try {
+      return listPanes(currentPaneId);
+    } catch {
+      return null;
+    }
+  };
   const createPane = deps.createHudWatchPane ?? ((hudCwd, hudCmd, options) => createHudWatchPane(hudCwd, hudCmd, options));
   const killPane = deps.killTmuxPane ?? ((paneId) => killTmuxPane(paneId));
   const resizePane = deps.resizeTmuxPane ?? ((paneId, lines) => resizeTmuxPane(paneId, lines));
@@ -394,17 +429,24 @@ export async function reconcileHudForPromptSubmit(
   const equivalentSessionIds = domain.session?.equivalentIds ?? [];
   try {
 
-  let panes = listPanes(currentPaneId);
+  let panes = scanPanes();
+  if (!panes) {
+    return { status: 'failed', paneId: null, desiredHeight: null, duplicateCount: 0 };
+  }
 
   // Reclaim orphaned HUD panes left behind by a destroyed leader before deciding
   // whether a HUD already exists; otherwise dead-leader HUDs accumulate one per
   // prompt submit and the window fills with stacked HUD strips.
-  const reapedOrphanPaneIds = reapOrphanedSessionHudPanes(panes, {
+  const orphanReap = reapOrphanedSessionHudPanes(panes, {
     sessionId: resolvedSessionId,
     sessionIds: equivalentSessionIds,
     currentPaneId,
     killPane,
   });
+  if (orphanReap.failed) {
+    return { status: 'failed', paneId: null, desiredHeight: null, duplicateCount: 0 };
+  }
+  const reapedOrphanPaneIds = orphanReap.reapedPaneIds;
   if (reapedOrphanPaneIds.length > 0) {
     const reapedPaneIdSet = new Set(reapedOrphanPaneIds);
     panes = panes.filter((pane) => !reapedPaneIdSet.has(pane.paneId));
@@ -416,11 +458,15 @@ export async function reconcileHudForPromptSubmit(
   // does not match same-owner dedupe and the next launch would create a second HUD
   // beside it. Reap only HUDs tied to this exact leader pane; neighboring panes'
   // HUDs remain isolated by leaderPaneId.
-  const reapedStaleLeaderPaneIds = reapStaleCurrentLeaderHudPanes(panes, {
+  const staleLeaderReap = reapStaleCurrentLeaderHudPanes(panes, {
     sessionIds: equivalentSessionIds,
     currentPaneId,
     killPane,
   });
+  if (staleLeaderReap.failed) {
+    return { status: 'failed', paneId: null, desiredHeight: null, duplicateCount: 0 };
+  }
+  const reapedStaleLeaderPaneIds = staleLeaderReap.reapedPaneIds;
   if (reapedStaleLeaderPaneIds.length > 0) {
     const reapedPaneIdSet = new Set(reapedStaleLeaderPaneIds);
     panes = panes.filter((pane) => !reapedPaneIdSet.has(pane.paneId));
@@ -463,9 +509,10 @@ export async function reconcileHudForPromptSubmit(
   if (singleHudPane && !needsHudTopologyRecreate(singleHudPane, leaderPane)) {
     const shouldResize = needsHudHeightResize(singleHudPane, desiredHeight);
     const resized = shouldResize ? resizePane(singleHudPane.paneId, desiredHeight) : true;
-    if (resized) ensureHudResizeHook(singleHudPane.paneId, currentPaneId, desiredHeight, cwd, deps);
+    const hookRegistered = resized
+      && ensureHudResizeHook(singleHudPane.paneId, currentPaneId, desiredHeight, cwd, deps);
     return {
-      status: resized ? (shouldResize ? 'resized' : 'unchanged') : 'failed',
+      status: hookRegistered ? (shouldResize ? 'resized' : 'unchanged') : 'failed',
       paneId: singleHudPane.paneId,
       desiredHeight,
       duplicateCount,
@@ -479,13 +526,31 @@ export async function reconcileHudForPromptSubmit(
     const keeperPane = hudPanes.find((pane) => !needsHudTopologyRecreate(pane, leaderPane));
 
     if (keeperPane) {
+      let killedEveryDuplicate = true;
       for (const paneId of hudPaneIds.filter((paneId) => paneId !== keeperPane.paneId)) {
-        killPane(paneId);
+        if (!killPane(paneId)) killedEveryDuplicate = false;
+      }
+      if (!killedEveryDuplicate) {
+        return {
+          status: 'failed',
+          paneId: keeperPane.paneId,
+          desiredHeight,
+          duplicateCount,
+        };
       }
       const resized = resizePane(keeperPane.paneId, desiredHeight);
-      if (resized) ensureHudResizeHook(keeperPane.paneId, currentPaneId, desiredHeight, cwd, deps);
+      const hookRegistered = resized
+        && ensureHudResizeHook(keeperPane.paneId, currentPaneId, desiredHeight, cwd, deps);
+      const finalPanes = resized ? scanPanes() : null;
+      const converged = hookRegistered && finalPanes !== null && hasConvergedOwnedHudPane(
+        finalPanes,
+        currentPaneId,
+        owner,
+        keeperPane.paneId,
+        equivalentSessionIdSet,
+      );
       return {
-        status: resized ? 'replaced_duplicates' : 'failed',
+        status: converged ? 'replaced_duplicates' : 'failed',
         paneId: keeperPane.paneId,
         desiredHeight,
         duplicateCount,
@@ -523,7 +588,15 @@ export async function reconcileHudForPromptSubmit(
 
   const removedHudPaneIds = new Set<string>();
   for (const paneId of hudPaneIds) {
-    if (killPane(paneId)) removedHudPaneIds.add(paneId);
+    if (!killPane(paneId)) {
+      return {
+        status: 'failed',
+        paneId,
+        desiredHeight,
+        duplicateCount,
+      };
+    }
+    removedHudPaneIds.add(paneId);
   }
 
   const createOptions: { heightLines: number; fullWidth?: boolean; targetPaneId?: string; instanceId?: string } = {
@@ -546,18 +619,34 @@ export async function reconcileHudForPromptSubmit(
   // "no HUD" before either split-window has materialized. Re-scan after create
   // and collapse same-owner panes so the second creator cleans up the race
   // instead of leaving a duplicate HUD in the user window.
+  const postCreatePanes = scanPanes();
+  if (!postCreatePanes) {
+    return { status: 'failed', paneId: null, desiredHeight, duplicateCount };
+  }
   const postCreate = planOwnedHudPaneDedupe(
-    listPanes(currentPaneId).filter((pane) => !removedHudPaneIds.has(pane.paneId)),
+    postCreatePanes.filter((pane) => !removedHudPaneIds.has(pane.paneId)),
     currentPaneId,
     owner,
     paneId,
     equivalentSessionIdSet,
   );
   if (postCreate.unsafeCandidate) {
-    return { status: 'recreated', paneId, desiredHeight, duplicateCount: 0 };
+    return { status: 'failed', paneId: null, desiredHeight, duplicateCount: 0 };
   }
+  if (!postCreate.paneId) {
+    return { status: 'failed', paneId: null, desiredHeight, duplicateCount: 0 };
+  }
+  let killedEveryPostCreateDuplicate = true;
   for (const duplicatePaneId of postCreate.duplicatePaneIds) {
-    killPane(duplicatePaneId);
+    if (!killPane(duplicatePaneId)) killedEveryPostCreateDuplicate = false;
+  }
+  if (!killedEveryPostCreateDuplicate) {
+    return {
+      status: 'failed',
+      paneId: postCreate.paneId,
+      desiredHeight,
+      duplicateCount: postCreate.duplicatePaneIds.length,
+    };
   }
   const resized = resizePane(postCreate.paneId, desiredHeight);
   if (!resized) {
@@ -568,7 +657,22 @@ export async function reconcileHudForPromptSubmit(
       duplicateCount: postCreate.duplicatePaneIds.length,
     };
   }
-  ensureHudResizeHook(postCreate.paneId, currentPaneId, desiredHeight, cwd, deps);
+  const hookRegistered = ensureHudResizeHook(postCreate.paneId, currentPaneId, desiredHeight, cwd, deps);
+  const finalPanes = scanPanes();
+  if (!hookRegistered || !finalPanes || !hasConvergedOwnedHudPane(
+    finalPanes,
+    currentPaneId,
+    owner,
+    postCreate.paneId,
+    equivalentSessionIdSet,
+  )) {
+    return {
+      status: 'failed',
+      paneId: postCreate.paneId,
+      desiredHeight,
+      duplicateCount: postCreate.duplicatePaneIds.length,
+    };
+  }
 
   return {
     status: postCreate.duplicatePaneIds.length > 0 || hudPaneIds.length > 1 ? 'replaced_duplicates' : 'recreated',

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -562,6 +562,7 @@ export function buildHudWatchCommand(
 export function listCurrentWindowPanes(
   execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
   currentPaneId?: string,
+  options: { throwOnError?: boolean } = {},
 ): TmuxPaneSnapshot[] {
   try {
     return parseTmuxPaneSnapshot(
@@ -586,7 +587,8 @@ export function listCurrentWindowPanes(
         ].join(TMUX_PANE_FIELD_SEPARATOR),
       ]),
     );
-  } catch {
+  } catch (error) {
+    if (options.throwOnError) throw error;
     return [];
   }
 }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -9189,8 +9189,14 @@ case "$cmd" in
     ;;
   list-panes)
     printf '%%1\x1fcodex\x1f0\x1f0\x1f200\x1f60\x1f59\x1f200\x1f60\x1fsess-hud-1\x1fsess-hud-1\x1fcodex\x1f%s\n' ${JSON.stringify(cwd)}
+    if [[ -f ${JSON.stringify(join(cwd, "hud-pane-created"))} ]]; then
+      printf '%%9\x1fnode\x1f0\x1f58\x1f200\x1f2\x1f59\x1f200\x1f60\x1fsess-hud-1\x1fsess-hud-1\x1fexec env OMX_SESSION_ID='"'"'sess-hud-1'"'"' OMX_TMUX_HUD_OWNER='"'"'1'"'"' OMX_TMUX_HUD_LEADER_PANE='"'"'%%1'"'"' /node /omx.js hud --watch --preset=focused\x1f%s\n' ${JSON.stringify(cwd)}
+    fi
     ;;
-  split-window) printf '%%9\n' ;;
+  split-window)
+    : > ${JSON.stringify(join(cwd, "hud-pane-created"))}
+    printf '%%9\n'
+    ;;
   resize-pane) ;;
 esac
 `,
@@ -9371,9 +9377,15 @@ case "$cmd" in
   list-panes)
     printf '%%1\x1fcodex\x1f0\x1f0\x1f200\x1f60\x1f59\x1f200\x1f60\x1fomx-canonical-hud-reuse\x1fomx-canonical-hud-reuse\x1fcodex\x1f%s\n' ${JSON.stringify(cwd)}
     printf '%%2\x1fnode\x1f0\x1f60\x1f200\x1f3\x1f62\x1f200\x1f60\x1f\x1f\x1fexec env OMX_TMUX_HUD_OWNER='"'"'1'"'"' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='"'"'%%1'"'"' /node /omx.js hud --watch\x1f%s\n' ${JSON.stringify(cwd)}
+    if [[ -f ${JSON.stringify(join(cwd, "hud-pane-created"))} ]]; then
+      printf '%%9\x1fnode\x1f0\x1f58\x1f200\x1f2\x1f59\x1f200\x1f60\x1fomx-canonical-hud-reuse\x1fomx-canonical-hud-reuse\x1fexec env OMX_SESSION_ID='"'"'omx-canonical-hud-reuse'"'"' OMX_TMUX_HUD_OWNER='"'"'1'"'"' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='"'"'%%1'"'"' /node /omx.js hud --watch\x1f%s\n' ${JSON.stringify(cwd)}
+    fi
     ;;
   resize-pane) ;;
-  split-window) printf '%%9\n' ;;
+  split-window)
+    : > ${JSON.stringify(join(cwd, "hud-pane-created"))}
+    printf '%%9\n'
+    ;;
 esac
 `,
 			);


### PR DESCRIPTION
## Summary

- fail closed when tmux scans, stale/orphan cleanup, lifecycle-lock setup, pane deletion, or resize-hook registration cannot be verified
- require post-create and final scans to prove exactly one owner-matching HUD pane instead of trusting an unobserved split pane id
- stop before creating a replacement when an existing malformed HUD pane cannot be killed
- add regression coverage for scan failures, duplicate races, pane-id reuse, hook failures, and reconciliation convergence

## Context

This is a focused supplement to #3167. It targets that PR's feature branch so the owner-authority fix and these convergence guarantees can land together without opening a competing implementation against `dev`.

## Validation

- `npm run build`
- HUD tests: 372 passed, 0 failed
- native-hook integration tests: 536 passed, 0 failed
- `npm run lint`
- `npm run check:no-unused`
- `npx tsc --noEmit`
- `git diff --check`

The full 377-file local run also exercised the broader suite. On macOS, six existing platform-sensitive files remain red because of GNU `stat -c` and `/var` versus `/private/var` path assumptions; none are touched by this diff. The focused suites above are green, and Linux CI remains the authoritative full-suite gate.

## Related

Supplements #3167.

Closes #3159 when merged through #3167.
