### PR TITLE
fix(ultragoal): complete runtime with durable plan

### DIFF
--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -14,6 +14,7 @@ import {
   NATIVE_SUBAGENT_ROLE_ROUTING_MARKER_FILE,
   writeRoleRoutingMarker,
 } from '../../subagents/role-routing-marker.js';
+import { readModeState, startMode } from '../../modes/base.js';
 import { ultragoalCommand, ULTRAGOAL_HELP } from '../ultragoal.js';
 
 async function withCwd<T>(run: (cwd: string) => Promise<T>): Promise<T> {
@@ -259,6 +260,7 @@ describe('cli/ultragoal', () => {
 
   it('prints explicit terminal cleanup after final checkpoint without claiming hidden clear', async () => {
     await withCwd(async (cwd) => {
+      await startMode('ultragoal', 'Complete the final milestone.', 1, cwd);
       await capture(() => ultragoalCommand(['create-goals', '--brief', '- Final milestone']));
       await capture(() => ultragoalCommand(['complete-goals']));
       const goals = JSON.parse(await readFile(join(cwd, '.omx/ultragoal/goals.json'), 'utf-8')) as { codexObjective: string };
@@ -277,6 +279,53 @@ describe('cli/ultragoal', () => {
       assert.match(output, /Terminal next step for another goal in this same Codex thread\/session: run \/goal clear/);
       assert.match(output, /OMX shell commands and hooks do not call \/goal clear or hidden thread\/goal\/clear routes/);
       assert.doesNotMatch(output, /cleared Codex goal state/i);
+
+      const runtime = await readModeState('ultragoal', cwd);
+      assert.equal(runtime?.active, false);
+      assert.equal(runtime?.current_phase, 'complete');
+      assert.ok(typeof runtime?.completed_at === 'string');
+
+      const skillActive = JSON.parse(
+        await readFile(join(cwd, '.omx/state/skill-active-state.json'), 'utf-8'),
+      ) as { active?: boolean; active_skills?: unknown[] };
+      assert.equal(skillActive.active, false);
+      assert.deepEqual(skillActive.active_skills, []);
+    });
+  });
+
+  it('keeps the runtime active after a non-terminal intermediate checkpoint', async () => {
+    await withCwd(async (cwd) => {
+      const taskObjective = 'Complete two durable Ultragoal stories.';
+      await startMode('ultragoal', taskObjective, 2, cwd);
+      await capture(() => ultragoalCommand([
+        'create-goals',
+        '--brief', taskObjective,
+        '--goal', 'First::Complete the first durable story.',
+        '--goal', 'Second::Complete the second durable story.',
+      ]));
+      await capture(() => ultragoalCommand(['complete-goals']));
+      const goals = JSON.parse(
+        await readFile(join(cwd, '.omx/ultragoal/goals.json'), 'utf-8'),
+      ) as { codexObjective: string };
+
+      const checkpoint = await capture(() => ultragoalCommand([
+        'checkpoint',
+        '--goal-id', 'G001-first',
+        '--status', 'complete',
+        '--evidence', 'The first durable story is complete.',
+        '--codex-goal-json', JSON.stringify({ goal: { objective: goals.codexObjective, status: 'active' } }),
+        '--json',
+      ]));
+      assert.equal(checkpoint.exitCode, undefined);
+      const parsed = JSON.parse(checkpoint.stdout.join('\n')) as {
+        summary: { aggregateComplete: boolean; artifactComplete: boolean };
+      };
+      assert.equal(parsed.summary.aggregateComplete, false);
+      assert.equal(parsed.summary.artifactComplete, false);
+
+      const runtime = await readModeState('ultragoal', cwd);
+      assert.equal(runtime?.active, true);
+      assert.notEqual(runtime?.current_phase, 'complete');
     });
   });
 

--- a/src/cli/ultragoal.ts
+++ b/src/cli/ultragoal.ts
@@ -11,6 +11,7 @@ import {
   NATIVE_SUBAGENT_SUPPORT_BLOCKER_FILE,
   resolveNativeSubagentSupportStatus,
 } from '../leader/contract.js';
+import { readModeState, updateModeState } from '../modes/base.js';
 import { resolveRuntimeStateScope } from '../mcp/state-paths.js';
 import { readRoleRoutingMarker } from '../subagents/role-routing-marker.js';
 import {
@@ -128,6 +129,17 @@ function positionalText(args: readonly string[]): string {
 
 function printJson(value: unknown): void {
   console.log(JSON.stringify(value, null, 2));
+}
+
+async function completeActiveUltragoalRuntime(cwd: string): Promise<void> {
+  const state = await readModeState('ultragoal', cwd);
+  if (state?.active !== true) return;
+
+  await updateModeState('ultragoal', {
+    active: false,
+    current_phase: 'complete',
+    completed_at: new Date().toISOString(),
+  }, cwd);
 }
 
 function normalizeCodexGoalMode(raw: string | undefined): 'aggregate' | 'per_story' | undefined {
@@ -523,12 +535,15 @@ export async function ultragoalCommand(args: string[], deps: UltragoalCommandDep
       const codexGoal = await parseCodexGoalJson(readValue(rest, '--codex-goal-json'));
       const qualityGate = await readJsonInput(readValue(rest, '--quality-gate-json'));
       const plan = await checkpointUltragoal(cwd, { goalId, status, evidence, codexGoal, qualityGate });
-      if (json) printJson({ ok: true, plan, summary: summarizeUltragoalPlan(plan) });
+      const summary = summarizeUltragoalPlan(plan);
+      if (status === 'complete' && summary.artifactComplete) {
+        await completeActiveUltragoalRuntime(cwd);
+      }
+      if (json) printJson({ ok: true, plan, summary });
       else {
         const goal = plan.goals.find((candidate: UltragoalItem) => candidate.id === goalId);
         console.log(`ultragoal checkpoint: ${goalId} -> ${goal?.status ?? status}`);
         printStatus(plan);
-        const summary = summarizeUltragoalPlan(plan);
         if (status === 'complete' && (summary.aggregateComplete || summary.artifactComplete)) {
           console.log(buildCodexGoalTerminalCleanupNotice('Ultragoal completion'));
         }


### PR DESCRIPTION
## Summary
- terminalize active Ultragoal mode state after a durable plan completes
- synchronize canonical skill-active state through the existing mode lifecycle
- retain active runtime state for non-terminal checkpoints

## Validation
- npm run lint
- npm run check:no-unused
- npm run build
- node dist/scripts/run-test-files.js dist/cli/__tests__/ultragoal.test.js
- npm test

Fixes stale `omx status`/skill-active runtime state after `omx ultragoal checkpoint` records durable completion without modifying Ultragoal plan or ledger artifacts.