### PR TITLE
fix(cli): preserve tmux-owned terminal environment

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3752,6 +3752,9 @@ describe("detached tmux new-session sequencing", () => {
       TERM: "xterm-256color",
       TERM_PROGRAM: "WarpTerminal",
       TERM_PROGRAM_VERSION: "1.0.0",
+      TERMINFO: "/tmp/outer-terminfo",
+      TERMINFO_DIRS: "/tmp/outer-terminfo-dirs",
+      TERMCAP: "outer-termcap",
       COLORTERM: "truecolor",
       TMUX: "/tmp/tmux/default,123,0",
       TMUX_PANE: "%9",
@@ -3761,10 +3764,14 @@ describe("detached tmux new-session sequencing", () => {
 
     assert.match(envScript, /export CUSTOM_LLM_API_KEY='fake-provider-key'/);
     assert.match(envScript, /export COLORTERM='truecolor'/);
+    assert.match(envScript, /^unset COLUMNS LINES TERMINFO TERMINFO_DIRS TERMCAP$/m);
     for (const key of [
       "TERM",
       "TERM_PROGRAM",
       "TERM_PROGRAM_VERSION",
+      "TERMINFO",
+      "TERMINFO_DIRS",
+      "TERMCAP",
       "TMUX",
       "TMUX_PANE",
       "COLUMNS",

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3746,6 +3746,34 @@ describe("detached tmux new-session sequencing", () => {
     assert.doesNotMatch(envScript, /not-a-shell-name/);
   });
 
+  it("does not replay tmux-owned terminal metadata into the detached session", () => {
+    const envScript = serializeDetachedSessionParentEnv({
+      CUSTOM_LLM_API_KEY: "fake-provider-key",
+      TERM: "xterm-256color",
+      TERM_PROGRAM: "WarpTerminal",
+      TERM_PROGRAM_VERSION: "1.0.0",
+      COLORTERM: "truecolor",
+      TMUX: "/tmp/tmux/default,123,0",
+      TMUX_PANE: "%9",
+      COLUMNS: "200",
+      LINES: "60",
+    });
+
+    assert.match(envScript, /export CUSTOM_LLM_API_KEY='fake-provider-key'/);
+    assert.match(envScript, /export COLORTERM='truecolor'/);
+    for (const key of [
+      "TERM",
+      "TERM_PROGRAM",
+      "TERM_PROGRAM_VERSION",
+      "TMUX",
+      "TMUX_PANE",
+      "COLUMNS",
+      "LINES",
+    ]) {
+      assert.doesNotMatch(envScript, new RegExp(`^export ${key}=`, "m"));
+    }
+  });
+
   it("creates a repo-local omx command shim for launched Codex sessions", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-runtime-command-shim-"));
     try {

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -940,8 +940,11 @@ exit 0
   printf 'colorterm=%s\n' "$COLORTERM"
   printf 'tmux=%s\n' "$TMUX"
   printf 'tmux_pane=%s\n' "$TMUX_PANE"
-  printf 'columns=%s\n' "$COLUMNS"
-  printf 'lines=%s\n' "$LINES"
+  printf 'columns=%s\n' "\${COLUMNS-unset}"
+  printf 'lines=%s\n' "\${LINES-unset}"
+  printf 'terminfo=%s\n' "\${TERMINFO-unset}"
+  printf 'terminfo_dirs=%s\n' "\${TERMINFO_DIRS-unset}"
+  printf 'termcap=%s\n' "\${TERMCAP-unset}"
 } > "${envLogPath}"
 exit 130
 `,
@@ -965,8 +968,11 @@ case "$1" in
       TERM_PROGRAM_VERSION=3.4 \
       TMUX=/tmp/tmux-test.sock,123,0 \
       TMUX_PANE=%12 \
-      COLUMNS=80 \
-      LINES=24 \
+      COLUMNS=211 \
+      LINES=77 \
+      TERMINFO=/tmp/server-terminfo \
+      TERMINFO_DIRS=/tmp/server-terminfo-dirs \
+      TERMCAP=server-termcap \
       sh -c "$last" >/dev/null 2>&1 || true
     printf 'leader-pane\\n'
     exit 0
@@ -1007,6 +1013,9 @@ exit 0
           TERM: 'xterm-256color',
           TERM_PROGRAM: 'WarpTerminal',
           TERM_PROGRAM_VERSION: 'outer-terminal-version',
+          TERMINFO: '/tmp/outer-terminfo',
+          TERMINFO_DIRS: '/tmp/outer-terminfo-dirs',
+          TERMCAP: 'outer-termcap',
           COLORTERM: 'truecolor',
           COLUMNS: '200',
           LINES: '60',
@@ -1031,8 +1040,11 @@ exit 0
           'colorterm=truecolor',
           'tmux=/tmp/tmux-test.sock,123,0',
           'tmux_pane=%12',
-          'columns=80',
-          'lines=24',
+          'columns=unset',
+          'lines=unset',
+          'terminfo=unset',
+          'terminfo_dirs=unset',
+          'termcap=unset',
           '',
         ].join('\n'),
       );

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -918,7 +918,7 @@ exit 0
     }
   });
 
-  it('preserves parent provider env for interactive OMX-created tmux without logging secret values', async () => {
+  it('preserves parent provider env without replaying terminal state over an OMX-created tmux pane', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-parent-env-'));
     try {
       const home = join(wd, 'home');
@@ -934,6 +934,14 @@ exit 0
 {
   printf 'custom=%s\n' "$CUSTOM_LLM_API_KEY"
   printf 'marker=%s\n' "$IS_GAJAE_SLOP_GENERATOR"
+  printf 'term=%s\n' "$TERM"
+  printf 'term_program=%s\n' "$TERM_PROGRAM"
+  printf 'term_program_version=%s\n' "$TERM_PROGRAM_VERSION"
+  printf 'colorterm=%s\n' "$COLORTERM"
+  printf 'tmux=%s\n' "$TMUX"
+  printf 'tmux_pane=%s\n' "$TMUX_PANE"
+  printf 'columns=%s\n' "$COLUMNS"
+  printf 'lines=%s\n' "$LINES"
 } > "${envLogPath}"
 exit 130
 `,
@@ -951,7 +959,15 @@ case "$1" in
   new-session)
     last=''
     for arg in "$@"; do last="$arg"; done
-    sh -c "$last" >/dev/null 2>&1 || true
+    env -u COLORTERM \
+      TERM=tmux-256color \
+      TERM_PROGRAM=tmux \
+      TERM_PROGRAM_VERSION=3.4 \
+      TMUX=/tmp/tmux-test.sock,123,0 \
+      TMUX_PANE=%12 \
+      COLUMNS=80 \
+      LINES=24 \
+      sh -c "$last" >/dev/null 2>&1 || true
     printf 'leader-pane\\n'
     exit 0
     ;;
@@ -988,6 +1004,12 @@ exit 0
           OMX_AUTO_UPDATE: '0',
           OMX_NOTIFY_FALLBACK: '0',
           OMX_HOOK_DERIVED_SIGNALS: '0',
+          TERM: 'xterm-256color',
+          TERM_PROGRAM: 'WarpTerminal',
+          TERM_PROGRAM_VERSION: 'outer-terminal-version',
+          COLORTERM: 'truecolor',
+          COLUMNS: '200',
+          LINES: '60',
           TMUX: '',
           TMUX_PANE: '',
           CUSTOM_LLM_API_KEY: 'fake-provider-key',
@@ -1000,7 +1022,19 @@ exit 0
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       assert.equal(
         await readFile(envLogPath, 'utf-8'),
-        'custom=fake-provider-key\nmarker=1\n',
+        [
+          'custom=fake-provider-key',
+          'marker=1',
+          'term=tmux-256color',
+          'term_program=tmux',
+          'term_program_version=3.4',
+          'colorterm=truecolor',
+          'tmux=/tmp/tmux-test.sock,123,0',
+          'tmux_pane=%12',
+          'columns=80',
+          'lines=24',
+          '',
+        ].join('\n'),
       );
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.doesNotMatch(tmuxLog, /fake-provider-key/);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4333,6 +4333,15 @@ function buildTmuxExtendedKeysReleaseShellSnippet(cwd: string): string {
 }
 
 const SHELL_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const DETACHED_SESSION_PANE_ENV_KEYS = new Set([
+  "TERM",
+  "TERM_PROGRAM",
+  "TERM_PROGRAM_VERSION",
+  "TMUX",
+  "TMUX_PANE",
+  "COLUMNS",
+  "LINES",
+]);
 
 export function serializeDetachedSessionParentEnv(
   env: NodeJS.ProcessEnv,
@@ -4340,6 +4349,7 @@ export function serializeDetachedSessionParentEnv(
   const lines: string[] = [];
   for (const key of Object.keys(env).sort()) {
     if (!SHELL_ENV_NAME_PATTERN.test(key)) continue;
+    if (DETACHED_SESSION_PANE_ENV_KEYS.has(key)) continue;
     const value = env[key];
     if (typeof value !== "string") continue;
     if (value.includes("\0")) continue;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4333,20 +4333,26 @@ function buildTmuxExtendedKeysReleaseShellSnippet(cwd: string): string {
 }
 
 const SHELL_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const DETACHED_SESSION_ENV_KEYS_TO_UNSET = [
+  "COLUMNS",
+  "LINES",
+  "TERMINFO",
+  "TERMINFO_DIRS",
+  "TERMCAP",
+] as const;
 const DETACHED_SESSION_PANE_ENV_KEYS = new Set([
   "TERM",
   "TERM_PROGRAM",
   "TERM_PROGRAM_VERSION",
   "TMUX",
   "TMUX_PANE",
-  "COLUMNS",
-  "LINES",
+  ...DETACHED_SESSION_ENV_KEYS_TO_UNSET,
 ]);
 
 export function serializeDetachedSessionParentEnv(
   env: NodeJS.ProcessEnv,
 ): string {
-  const lines: string[] = [];
+  const lines = [`unset ${DETACHED_SESSION_ENV_KEYS_TO_UNSET.join(" ")}`];
   for (const key of Object.keys(env).sort()) {
     if (!SHELL_ENV_NAME_PATTERN.test(key)) continue;
     if (DETACHED_SESSION_PANE_ENV_KEYS.has(key)) continue;


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Detached tmux launch sources a serialized copy of the parent environment after tmux has created the new pane. That currently replays terminal and pane metadata over the values established by tmux, so the launched process can observe a terminal type, tmux identity, or dimensions that do not describe its actual pane.

This change keeps the parent-environment transport for provider configuration while leaving tmux-owned terminal state authoritative.

## Changes

- Exclude `TERM`, `TERM_PROGRAM`, `TERM_PROGRAM_VERSION`, `TMUX`, `TMUX_PANE`, `COLUMNS`, and `LINES` from detached-session parent-environment serialization.
- Preserve provider variables and `COLORTERM`; do not hard-code a replacement `TERM`.
- Add serializer and detached-launch regression coverage for the environment boundary.

## Validation

- [x] `npm run build`
- [x] `npm test`
- [x] `omx doctor`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `npx tsc --noEmit`

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed (not needed for this internal environment-serialization boundary)
- [x] Backward-compatibility impact considered

## Related

Closes #3175
