### PR TITLE
fix: allow deep-interview terminal state closeout

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -190,6 +190,12 @@ For `ralplan`, native `PreToolUse` allows only a standalone terminal
 authority for consensus validation and root/session terminalization, so compound
 Bash commands that add any suffix after the closeout command stay blocked.
 
+`deep-interview` uses the same narrow closeout boundary: only a standalone,
+same-session write with `mode:"deep-interview"`, `active:false`, and
+`current_phase:"complete"` is allowed. Partial deactivation, mismatched-session
+payloads, nested transports, state clears, and commands with suffixes remain
+blocked by the planning guard.
+
 There is still no distinct native Codex `ask-user-question` hook today. That means `askuserQuestion` classification remains a runtime/fallback responsibility unless a future native hook surface exposes first-class question-stop metadata.
 
 ## Combined workflow note

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -13879,6 +13879,99 @@ exit 0
 		}
 	});
 
+	it("allows complete deep-interview terminal state writes while preserving the planning boundary", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-native-hook-pretool-deep-interview-terminal-"),
+		);
+		try {
+			const stateDir = join(cwd, ".omx", "state");
+			const sessionId = "sess-deep-interview-terminal";
+			const sessionDir = join(stateDir, "sessions", sessionId);
+			await mkdir(sessionDir, { recursive: true });
+			await writeJson(join(stateDir, "session.json"), {
+				session_id: sessionId,
+				cwd,
+			});
+			await writeJson(join(sessionDir, "skill-active-state.json"), {
+				version: 1,
+				active: true,
+				skill: "deep-interview",
+				phase: "interviewing",
+				session_id: sessionId,
+				active_skills: [
+					{
+						skill: "deep-interview",
+						phase: "interviewing",
+						active: true,
+						session_id: sessionId,
+					},
+				],
+			});
+			await writeJson(join(sessionDir, "deep-interview-state.json"), {
+				active: true,
+				mode: "deep-interview",
+				current_phase: "interviewing",
+				session_id: sessionId,
+			});
+
+			const dispatchBash = async (toolUseId: string, command: string) =>
+				dispatchCodexNativeHook(
+					{
+						hook_event_name: "PreToolUse",
+						cwd,
+						session_id: sessionId,
+						tool_name: "Bash",
+						tool_use_id: toolUseId,
+						tool_input: { command },
+					},
+					{ cwd },
+				);
+
+			const allowedTerminal = await dispatchBash(
+				"tool-deep-interview-terminal-allowed",
+				"omx state write --input '{\"mode\":\"deep-interview\",\"active\":false,\"current_phase\":\"complete\",\"state\":{\"artifact\":\".omx/interviews/final.md\"}}' --json",
+			);
+			assert.equal(allowedTerminal.outputJson, null);
+
+			const blockedPartial = await dispatchBash(
+				"tool-deep-interview-terminal-partial",
+				"omx state write --input '{\"mode\":\"deep-interview\",\"active\":false}' --json",
+			);
+			assert.equal(
+				(blockedPartial.outputJson as { decision?: string } | null)?.decision,
+				"block",
+			);
+
+			const blockedMismatchedSession = await dispatchBash(
+				"tool-deep-interview-terminal-mismatched-session",
+				"omx state write --input '{\"mode\":\"deep-interview\",\"active\":false,\"current_phase\":\"complete\",\"session_id\":\"other-session\"}' --json",
+			);
+			assert.equal(
+				(
+					blockedMismatchedSession.outputJson as {
+						decision?: string;
+					} | null
+				)?.decision,
+				"block",
+			);
+
+			const blockedTerminalThenImplementation = await dispatchBash(
+				"tool-deep-interview-terminal-then-implementation",
+				"omx state write --input '{\"mode\":\"deep-interview\",\"active\":false,\"current_phase\":\"complete\"}' --json && printf bad > src/leak.ts",
+			);
+			assert.equal(
+				(
+					blockedTerminalThenImplementation.outputJson as {
+						decision?: string;
+					} | null
+				)?.decision,
+				"block",
+			);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
 	it("allows complete ralplan terminal state writes while blocking partial deactivation writes", async () => {
 		const cwd = await mkdtemp(
 			join(tmpdir(), "omx-native-hook-pretool-ralplan-state-input-file-"),

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -7037,6 +7037,53 @@ function isAllowedRalplanTerminalStateWriteCommand(
   return payload ? isCompleteRalplanTerminalWritePayload(payload, activeState, sessionId) : false;
 }
 
+function isCompleteDeepInterviewTerminalWritePayload(
+  payload: Record<string, unknown>,
+  activeState: Record<string, unknown>,
+  sessionId: string,
+): boolean {
+  if (!sessionId) return false;
+  const mode = safeString(payload.mode).trim().toLowerCase();
+  if (mode !== "deep-interview") return false;
+  const phase = safeString(payload.current_phase ?? payload.currentPhase).trim().toLowerCase();
+  if (payload.active !== false || phase !== "complete") return false;
+
+  const payloadSessionId = safeString(payload.session_id).trim();
+  const activeSessionId = safeString(
+    activeState.session_id
+      ?? activeState.owner_omx_session_id
+      ?? activeState.codex_session_id
+      ?? activeState.owner_codex_session_id,
+  ).trim();
+  if (payloadSessionId && payloadSessionId !== sessionId) return false;
+  if (payloadSessionId && activeSessionId && payloadSessionId !== activeSessionId) return false;
+  return true;
+}
+
+function isAllowedDeepInterviewTerminalStateWriteCommand(
+  cwd: string,
+  command: string,
+  activeState: Record<string, unknown>,
+  sessionId: string,
+): boolean {
+  const canonicalCommand = canonicalizeOmxStateTransportCommand(command);
+  if (hasUnsafeUnquotedHeredocExpansion(canonicalCommand)) return false;
+  if (hasUnquotedShellSubstitution(canonicalCommand)) return false;
+  if (splitStateScanSegments(canonicalCommand).length !== 1) return false;
+  if (sourcesFileWrittenEarlierInSameCommand(cwd, canonicalCommand)) return false;
+  if (findUnquotedOmxStateCommandIndexes(canonicalCommand, "clear").length > 0) return false;
+  if (hasDynamicNestedShellExecution(canonicalCommand)) return false;
+  if (commandHasDeepInterviewWriteIntent(canonicalCommand)) return false;
+
+  const operations = collectOmxStateCommandOperations(canonicalCommand, "write");
+  if (operations.length !== 1) return false;
+  const operation = operations[0];
+  if (!operation || operation.nested || hasPriorExecutableCommand(operation.prefix)) return false;
+
+  const payload = readStateWriteInputPayload(cwd, canonicalCommand, command);
+  return payload ? isCompleteDeepInterviewTerminalWritePayload(payload, activeState, sessionId) : false;
+}
+
 function commandEndsPlanningPhase(cwd: string, command: string): boolean {
   if (findUnquotedOmxStateCommandIndexes(command, "clear").length > 0) return true;
   const canonicalCommand = canonicalizeOmxStateTransportCommand(command);
@@ -7051,10 +7098,19 @@ function commandEndsPlanningPhase(cwd: string, command: string): boolean {
   return payload ? isPlanningPhaseDeactivationPayload(payload) : true;
 }
 
-function isAllowedDeepInterviewBashWrite(cwd: string, command: string): boolean {
+function isAllowedDeepInterviewBashWrite(
+  cwd: string,
+  command: string,
+  activeState?: Record<string, unknown>,
+  sessionId = "",
+): boolean {
   if (isAllowedDeepInterviewRalplanHandoffCommand(cwd, command)) return true;
   if (hasDeepInterviewRalplanHandoffStateMutation(cwd, command)) return false;
-  if (commandEndsPlanningPhase(cwd, command)) return false;
+  if (commandEndsPlanningPhase(cwd, command)) {
+    return activeState
+      ? isAllowedDeepInterviewTerminalStateWriteCommand(cwd, command, activeState, sessionId)
+      : false;
+  }
   if (commandHasUntargetedPlanningForbiddenIntent(command)) return false;
   if (firstPlanningTmpScriptExecutionTarget(cwd, command)) return false;
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
@@ -7326,7 +7382,7 @@ async function buildDeepInterviewPreToolUseBoundaryOutput(
   let blockedDetail = "implementation/write tools are blocked until an explicit handoff workflow is activated";
 
   if (toolName === "Bash") {
-    blocked = !isAllowedDeepInterviewBashWrite(cwd, command);
+    blocked = !isAllowedDeepInterviewBashWrite(cwd, command, activeState, sessionId);
     if (blocked) {
       blockedDetail = buildDeepInterviewBashBlockedDetail(cwd, command);
     }


### PR DESCRIPTION
## Summary

- Allow `deep-interview` to write its own complete terminal state instead of blocking the closeout command.
- Keep the planning boundary fail-closed for partial deactivation, mismatched sessions, nested transports, state clears, substitutions, and compound commands.
- Add regression coverage and document the narrow closeout exception.

## Changes

- Validate a same-session payload with `mode: "deep-interview"`, `active: false`, and `current_phase: "complete"`.
- Permit exactly one standalone `omx state write` operation when the deep-interview guard is active.
- Preserve existing handoff and implementation-write protections.

## Validation

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `npx tsc --noEmit`
- [x] Native hook test file: 540 passed, 0 failed
- [ ] `npm test` — attempted; the full repository suite reached unrelated environment/timing-sensitive failures in doctor, resume, setup-hook trust, and packed-lifecycle tests. The modified native-hook suite passed completely.

## Checklist

- [x] Change is focused and backwards-compatible outside the terminal closeout case.
- [x] Regression tests cover allowed and blocked payloads.
- [x] Native hook documentation is updated.

Closes #3177
