### PR TITLE
fix(deep-interview): allow authenticated terminal state write

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -10167,6 +10167,175 @@ exit 0
 		}
 	});
 
+	it("allows only the authenticated standalone deep-interview complete terminal state write", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-deep-interview-terminal-write-"));
+		try {
+			const stateDir = join(cwd, ".omx", "state");
+			const sessionId = "sess-di-terminal-write";
+			const threadId = "thread-di-terminal-write";
+			const sessionDir = join(stateDir, "sessions", sessionId);
+			await mkdir(sessionDir, { recursive: true });
+			await writeJson(join(stateDir, "session.json"), { session_id: sessionId, cwd });
+			await writeJson(join(sessionDir, "skill-active-state.json"), {
+				active: true,
+				skill: "deep-interview",
+				phase: "planning",
+				session_id: sessionId,
+				thread_id: threadId,
+				active_skills: [{
+					skill: "deep-interview",
+					phase: "planning",
+					active: true,
+					session_id: sessionId,
+					thread_id: threadId,
+				}],
+			});
+			const activeWrite = await executeStateOperation("state_write", {
+				mode: "deep-interview",
+				active: true,
+				current_phase: "intent-first",
+				session_id: sessionId,
+				thread_id: threadId,
+				workingDirectory: cwd,
+			});
+			assert.notEqual(activeWrite.isError, true);
+			const persistedActiveState = JSON.parse(
+				await readFile(join(sessionDir, "deep-interview-state.json"), "utf-8"),
+			) as { mode?: string; session_id?: string };
+			assert.equal(persistedActiveState.mode, undefined);
+			assert.equal(persistedActiveState.session_id, undefined);
+
+			const preToolUse = (command: string) => dispatchCodexNativeHook({
+				hook_event_name: "PreToolUse",
+				cwd,
+				session_id: sessionId,
+				thread_id: threadId,
+				tool_name: "Bash",
+				tool_input: { command },
+			}, { cwd });
+			const validPayload = JSON.stringify({
+				mode: "deep-interview",
+				active: false,
+				current_phase: "complete",
+				session_id: sessionId,
+				state: { spec_path: ".omx/interviews/final.md" },
+			});
+			const validCommand = `omx state write --input '${validPayload}' --json`;
+			assert.equal((await preToolUse(validCommand)).outputJson, null);
+			const terminalInputFile = join(cwd, "terminal-input.json");
+			await writeFile(terminalInputFile, validPayload);
+			const foreignInputFile = join(cwd, "foreign-input.json");
+			await writeFile(foreignInputFile, JSON.stringify({
+				mode: "team",
+				active: false,
+				current_phase: "complete",
+				session_id: sessionId,
+			}));
+			const activePayload = JSON.stringify({
+				mode: "deep-interview",
+				active: true,
+				current_phase: "intent-first",
+				session_id: sessionId,
+			});
+			for (const command of [
+				`env bun --preload ./preload.ts dist/cli/omx.js state write --input '${activePayload}' --json`,
+				`command tsx --tsconfig tsconfig.json dist/cli/omx.js state write --input '${activePayload}' --json`,
+				`time nodejs --require ./preload.js dist/cli/omx.js state write --input '${activePayload}' --json`,
+			]) {
+				assert.equal((await preToolUse(command)).outputJson, null, command);
+			}
+
+			const rejectedCommands = [
+				["wrong mode", `omx state write --input '${JSON.stringify({ mode: "ralplan", active: false, current_phase: "complete", session_id: sessionId })}' --json`],
+				["wrong session", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, current_phase: "complete", session_id: "sess-other" })}' --json`],
+				["missing session", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, current_phase: "complete" })}' --json`],
+				["missing inactive flag", `omx state write --input '${JSON.stringify({ mode: "deep-interview", current_phase: "complete", session_id: sessionId })}' --json`],
+				["missing complete phase", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, session_id: sessionId })}' --json`],
+				["cancelled deactivation", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, current_phase: "cancelled", session_id: sessionId })}' --json`],
+				["cleared deactivation", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, current_phase: "cleared", session_id: sessionId })}' --json`],
+				["contradictory run outcome", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, current_phase: "complete", session_id: sessionId, run_outcome: "cancelled" })}' --json`],
+				["contradictory lifecycle outcome", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, current_phase: "complete", session_id: sessionId, lifecycle_outcome: "askuserQuestion" })}' --json`],
+				["nested mode conflict", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, current_phase: "complete", session_id: sessionId, state: { mode: "ralplan" } })}' --json`],
+				["nested session conflict", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, current_phase: "complete", session_id: sessionId, state: { session_id: "sess-other" } })}' --json`],
+				["paired run outcome conflict", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, current_phase: "complete", session_id: sessionId, lifecycle_outcome: "finished", run_outcome: "cancelled" })}' --json`],
+				["paired terminal outcome conflict", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, current_phase: "complete", session_id: sessionId, lifecycle_outcome: "finished", terminal_outcome: "cancelled" })}' --json`],
+				["shadowed run outcome conflict", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, current_phase: "complete", session_id: sessionId, run_outcome: "cancelled", state: { run_outcome: "finish" } })}' --json`],
+				["shadowed lifecycle outcome conflict", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, current_phase: "complete", session_id: sessionId, lifecycle_outcome: "askuserQuestion", state: { lifecycle_outcome: "finished" } })}' --json`],
+				["shadowed terminal outcome conflict", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, current_phase: "complete", session_id: sessionId, terminal_outcome: "cancelled", state: { terminal_outcome: "finished" } })}' --json`],
+				["foreign working directory", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, current_phase: "complete", session_id: sessionId, workingDirectory: join(cwd, "other") })}' --json`],
+				["top-level owner session conflict", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, current_phase: "complete", session_id: sessionId, owner_omx_session_id: "sess-other" })}' --json`],
+				["top-level codex session conflict", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, current_phase: "complete", session_id: sessionId, codex_session_id: "sess-other" })}' --json`],
+				["nested owner session conflict", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: false, current_phase: "complete", session_id: sessionId, state: { owner_codex_session_id: "sess-other" } })}' --json`],
+				["nested active override", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: true, current_phase: "intent-first", session_id: sessionId, state: { active: false, current_phase: "complete" } })}' --json`],
+				["nested camel phase override", `omx state write --input '${JSON.stringify({ mode: "deep-interview", active: true, current_phase: "intent-first", session_id: sessionId, state: { active: false, currentPhase: "complete" } })}' --json`],
+				["state clear", "omx state clear --mode deep-interview --json"],
+				["direct input file", `omx state write --input-file ${terminalInputFile} --json`],
+				["prefix chain", `printf ready && ${validCommand}`],
+				["suffix chain", `${validCommand} && printf done`],
+				["pipeline", `${validCommand} | tee terminal.json`],
+				["command substitution", `printf '%s' \"$(${validCommand})\"`],
+				["nested shell", `bash -c 'omx state write --input-file ${terminalInputFile} --json'`],
+				["subshell grouping", `( ${validCommand} )`],
+				["background execution", `${validCommand} &`],
+				["wrapper dispatch", `env ${validCommand}`],
+				["node runtime wrapper", `node --require ./preload.js dist/cli/omx.js state write --input '${validPayload}' --json`],
+				["bun runtime wrapper", `bun --preload ./preload.ts dist/cli/omx.js state write --input '${validPayload}' --json`],
+				["tsx runtime wrapper", `tsx --require ./preload.ts dist/cli/omx.js state write --input '${validPayload}' --json`],
+				["path-qualified omx", `./attacker/omx state write --input '${validPayload}' --json`],
+				["env bun preload wrapper", `env bun --preload ./preload.ts dist/cli/omx.js state write --input '${validPayload}' --json`],
+				["command tsx config wrapper", `command tsx --tsconfig tsconfig.json dist/cli/omx.js state write --input '${validPayload}' --json`],
+				["time node preload wrapper", `time node --require ./preload.js dist/cli/omx.js state write --input '${validPayload}' --json`],
+				["nodejs runtime wrapper", `nodejs --require ./preload.js dist/cli/omx.js state write --input '${validPayload}' --json`],
+				["path-qualified nodejs wrapper", `/usr/bin/nodejs --require ./preload.js dist/cli/omx.js state write --input '${validPayload}' --json`],
+				["nested terminal payload wrapper", `env bun --preload ./preload.ts dist/cli/omx.js state write --input '${JSON.stringify({ mode: "deep-interview", session_id: sessionId, state: { active: false, current_phase: "complete" } })}' --json`],
+				["foreign completed payload wrapper", `command tsx --tsconfig tsconfig.json dist/cli/omx.js state write --input '${JSON.stringify({ mode: "ralph", active: false, current_phase: "complete", session_id: sessionId })}' --json`],
+				["nodejs terminal input file wrapper", `nodejs dist/cli/omx.js state write --input-file ${terminalInputFile} --json`],
+				["path-qualified nodejs foreign input file wrapper", `/usr/bin/nodejs dist/cli/omx.js state write --input-file ${foreignInputFile} --json`],
+				["split-string nodejs terminal input file wrapper", `env -S "nodejs dist/cli/omx.js state write --input-file ${terminalInputFile} --json"`],
+				["long split-string nodejs foreign input file wrapper", `env --split-string "nodejs dist/cli/omx.js state write --input-file ${foreignInputFile} --json"`],
+				["split-string bun terminal wrapper", `env -S "bun --preload ./preload.ts dist/cli/omx.js state write --input '${validPayload}' --json"`],
+				["split-string tsx foreign wrapper", `env --split-string "tsx --tsconfig tsconfig.json dist/cli/omx.js state write --input '${JSON.stringify({ mode: "team", active: true, current_phase: "running", session_id: sessionId })}' --json"`],
+				["stdout redirect", `${validCommand} > terminal.json`],
+				["null redirect", `${validCommand} > /dev/null`],
+				["stderr redirect", `${validCommand} 2> terminal.err`],
+				["stdin redirect", `${validCommand} < ${terminalInputFile}`],
+				["arbitrary state mutation", `omx state write --input '${JSON.stringify({ mode: "team", active: false, current_phase: "complete", session_id: sessionId, state: { arbitrary: true } })}' --json`],
+			] as const;
+			for (const [name, command] of rejectedCommands) {
+				const result = await preToolUse(command);
+				assert.equal(
+					(result.outputJson as { decision?: string } | null)?.decision,
+					"block",
+					name,
+				);
+			}
+			for (const conflictingState of [
+				{ active: true, mode: "ralplan", current_phase: "intent-first" },
+				{ active: true, current_phase: "intent-first", session_id: "sess-other" },
+			]) {
+				await writeJson(join(sessionDir, "deep-interview-state.json"), conflictingState);
+				assert.equal(
+					((await preToolUse(validCommand)).outputJson as { decision?: string } | null)?.decision,
+					"block",
+				);
+				const implementationWrite = await dispatchCodexNativeHook({
+					hook_event_name: "PreToolUse",
+					cwd,
+					session_id: sessionId,
+					thread_id: threadId,
+					tool_name: "Edit",
+					tool_input: { file_path: "src/runtime.ts" },
+				}, { cwd });
+				assert.equal(
+					(implementationWrite.outputJson as { decision?: string } | null)?.decision,
+					"block",
+				);
+			}
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
 	it("allows deep-interview artifact and state writes while blocking implementation Bash writes", async () => {
 		const cwd = await mkdtemp(
 			join(tmpdir(), "omx-native-hook-pretool-deep-interview-artifact-"),
@@ -11094,7 +11263,7 @@ exit 0
 				);
 			}
 
-			const allowedQuotedModeMentionInPayload = await preToolUse(
+			const blockedForeignModeMutationWithQuotedMention = await preToolUse(
 				{
 					hook_event_name: "PreToolUse",
 					cwd,
@@ -11108,7 +11277,10 @@ exit 0
 				},
 				{ cwd },
 			);
-			assert.equal(allowedQuotedModeMentionInPayload.outputJson, null);
+			assert.equal(
+				(blockedForeignModeMutationWithQuotedMention.outputJson as { decision?: string } | null)?.decision,
+				"block",
+			);
 
 			const allowedStateInputFile = join(cwd, "allowed-state-input.json");
 			await writeJson(allowedStateInputFile, {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3718,14 +3718,6 @@ const RALPLAN_EXECUTION_HANDOFF_SKILLS = new Set([
   "ultraqa",
 ]);
 
-function isActiveDeepInterviewPhase(state: Record<string, unknown> | null): boolean {
-  if (!state || state.active !== true) return false;
-  const mode = safeString(state.mode).trim();
-  if (mode && mode !== "deep-interview") return false;
-  const phase = safeString(state.current_phase ?? state.currentPhase).trim().toLowerCase();
-  if (phase && (TERMINAL_MODE_PHASES.has(phase) || phase === "completing")) return false;
-  return true;
-}
 
 function isInactiveCompletedDeepInterviewPhase(state: Record<string, unknown> | null): boolean {
   if (!state || state.active !== false) return false;
@@ -7013,6 +7005,128 @@ function isCompleteRalplanTerminalWritePayload(
   return true;
 }
 
+function hasUnquotedShellControlOrRedirection(command: string): boolean {
+  let quote: "'" | '"' | null = null;
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index] ?? "";
+    if (char === "\\" && quote !== "'") {
+      index += 1;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = quote === char ? null : quote ?? char;
+      continue;
+    }
+    if (!quote && ";&|()<>\n\r".includes(char)) return true;
+  }
+  return false;
+}
+
+function suppliedSessionAliasesMatch(payload: Record<string, unknown>, sessionId: string): boolean {
+  return [
+    payload.session_id,
+    payload.owner_omx_session_id,
+    payload.codex_session_id,
+    payload.owner_codex_session_id,
+  ].filter((value) => value !== undefined)
+    .every((value) => safeString(value).trim() === sessionId);
+}
+
+function hasOnlyFinishedExplicitOutcomes(payload: Record<string, unknown>): boolean {
+  const values = [
+    payload.lifecycle_outcome,
+    payload.lifecycleOutcome,
+    payload.terminal_outcome,
+    payload.terminalOutcome,
+    payload.run_outcome,
+    payload.runOutcome,
+  ].filter((value) => value !== undefined);
+  return values.every((value) => inferTerminalLifecycleOutcome(
+    { lifecycle_outcome: value },
+    { includeQuestionEnforcement: false },
+  ) === "finished");
+}
+
+function isCompleteDeepInterviewTerminalWritePayload(
+  payload: Record<string, unknown>,
+  activeState: Record<string, unknown>,
+  sessionId: string,
+): boolean {
+  if (!sessionId) return false;
+  const activeMode = safeString(activeState.mode).trim().toLowerCase();
+  if (activeMode && activeMode !== "deep-interview") return false;
+  const activeSessionId = safeString(
+    activeState.session_id
+      ?? activeState.owner_omx_session_id
+      ?? activeState.codex_session_id
+      ?? activeState.owner_codex_session_id,
+  ).trim();
+  if (activeSessionId && activeSessionId !== sessionId) return false;
+
+  const mode = safeString(payload.mode).trim().toLowerCase();
+  const phase = safeString(payload.current_phase ?? payload.currentPhase).trim().toLowerCase();
+  const payloadSessionId = safeString(payload.session_id).trim();
+  if (!hasOnlyFinishedExplicitOutcomes(payload)) return false;
+  return mode === "deep-interview"
+    && payload.active === false
+    && phase === "complete"
+    && payloadSessionId === sessionId
+    && inferTerminalLifecycleOutcome(payload, { includeQuestionEnforcement: false }) === "finished";
+}
+
+function isAllowedDeepInterviewTerminalStateWriteCommand(
+  cwd: string,
+  command: string,
+  activeState: Record<string, unknown>,
+  sessionId: string,
+): boolean {
+  const rawWords = tokenizeShellWords(normalizeShellLineContinuations(command).trim());
+  if (rawWords[0] !== "omx") return false;
+  const canonicalCommand = canonicalizeOmxStateTransportCommand(command);
+  if (hasUnquotedShellControlOrRedirection(command)) return false;
+  if (hasUnsafeUnquotedHeredocExpansion(canonicalCommand)) return false;
+  if (hasUnquotedShellSubstitution(canonicalCommand)) return false;
+  if (splitStateScanSegments(canonicalCommand).length !== 1) return false;
+  if (sourcesFileWrittenEarlierInSameCommand(cwd, canonicalCommand)) return false;
+  if (findUnquotedOmxStateCommandIndexes(canonicalCommand, "clear").length > 0) return false;
+  if (hasDynamicNestedShellExecution(canonicalCommand)) return false;
+  if (extractDeepInterviewCommandWriteTargets(command).length > 0) return false;
+
+  const operations = collectOmxStateCommandOperations(command, "write");
+  if (operations.length !== 1) return false;
+  const operation = operations[0];
+  if (!operation || operation.nested || operation.commandPrefix.trim() || hasPriorExecutableCommand(operation.prefix)) return false;
+  const inlineInputCount = operation.args.filter((arg) => arg === "--input" || arg.startsWith("--input=")).length;
+  if (inlineInputCount !== 1 || operation.args.some((arg) => arg === "--input-file" || arg.startsWith("--input-file="))) return false;
+  const inlineInput = readStateWriteFlagValue(operation.args, "--input");
+  let rawPayload: Record<string, unknown> | null = null;
+  try {
+    rawPayload = inlineInput ? safeObject(JSON.parse(inlineInput)) : null;
+  } catch {
+    rawPayload = null;
+  }
+  const nestedState = safeObject(rawPayload?.state);
+  if (
+    !rawPayload
+    || "workingDirectory" in rawPayload
+    || !suppliedSessionAliasesMatch(rawPayload, sessionId)
+    || !hasOnlyFinishedExplicitOutcomes(rawPayload)
+    || (nestedState && (
+      "mode" in nestedState
+      || "session_id" in nestedState
+      || "workingDirectory" in nestedState
+      || "active" in nestedState
+      || "current_phase" in nestedState
+      || "currentPhase" in nestedState
+      || !suppliedSessionAliasesMatch(nestedState, sessionId)
+      || !hasOnlyFinishedExplicitOutcomes(nestedState)
+    ))
+  ) return false;
+
+  const payload = readStateWriteInputPayload(cwd, canonicalCommand, command);
+  return payload ? isCompleteDeepInterviewTerminalWritePayload(payload, activeState, sessionId) : false;
+}
+
 function isAllowedRalplanTerminalStateWriteCommand(
   cwd: string,
   command: string,
@@ -7051,10 +7165,56 @@ function commandEndsPlanningPhase(cwd: string, command: string): boolean {
   return payload ? isPlanningPhaseDeactivationPayload(payload) : true;
 }
 
-function isAllowedDeepInterviewBashWrite(cwd: string, command: string): boolean {
+function isAllowedDeepInterviewBashWrite(
+  cwd: string,
+  command: string,
+  activeState?: Record<string, unknown>,
+  sessionId = "",
+): boolean {
+  const stateWriteOperations = collectOmxStateCommandOperations(command, "write");
+  const hasUnsafeRuntimeStateWrite = (words: string[]): boolean => {
+    const stateWordIndex = words.indexOf("state");
+    const writeWordIndex = stateWordIndex >= 0 ? words.indexOf("write", stateWordIndex + 1) : -1;
+    if (writeWordIndex <= stateWordIndex) return false;
+    const hasRuntimeBeforeState = words.slice(0, stateWordIndex).some((word) => {
+      const base = shellWordBaseName(word);
+      return isNodeInterpreterCommandWord(base) || base === "bun" || base === "tsx";
+    });
+    if (!hasRuntimeBeforeState) return false;
+
+    const inlineInput = readStateWriteFlagValue(words, "--input");
+    let payload: Record<string, unknown> | null = null;
+    try {
+      const parsed = inlineInput ? safeObject(JSON.parse(inlineInput)) : null;
+      const modeOverride = readStateWriteFlagValue(words, "--mode");
+      payload = parsed
+        ? normalizeStateWriteClassificationPayload(modeOverride ? { ...parsed, mode: modeOverride } : parsed)
+        : null;
+    } catch {
+      payload = null;
+    }
+    return (!payload && stateWriteOperations.length === 0)
+      || Boolean(payload && (
+        safeString(payload.mode).trim().toLowerCase() !== "deep-interview"
+        || isPlanningPhaseDeactivationPayload(payload)
+      ));
+  };
+  const rawCommand = normalizeShellLineContinuations(command).trim();
+  if ([rawCommand, canonicalizeOmxStateTransportCommand(rawCommand)]
+    .some((candidate) => hasUnsafeRuntimeStateWrite(tokenizeShellWords(candidate)))) return false;
+  if (stateWriteOperations.some((operation) => operation.nested)) return false;
   if (isAllowedDeepInterviewRalplanHandoffCommand(cwd, command)) return true;
   if (hasDeepInterviewRalplanHandoffStateMutation(cwd, command)) return false;
-  if (commandEndsPlanningPhase(cwd, command)) return false;
+  if (commandEndsPlanningPhase(cwd, command)) {
+    return activeState
+      ? isAllowedDeepInterviewTerminalStateWriteCommand(cwd, command, activeState, sessionId)
+      : false;
+  }
+  if (stateWriteOperations.length > 0) {
+    const canonicalCommand = canonicalizeOmxStateTransportCommand(command);
+    const payload = readStateWriteInputPayload(cwd, canonicalCommand, command);
+    if (!payload || safeString(payload.mode).trim().toLowerCase() !== "deep-interview") return false;
+  }
   if (commandHasUntargetedPlanningForbiddenIntent(command)) return false;
   if (firstPlanningTmpScriptExecutionTarget(cwd, command)) return false;
   if (!commandHasDeepInterviewWriteIntent(command)) return true;
@@ -7079,13 +7239,11 @@ async function readActiveDeepInterviewStateForPreToolUse(
   const modeState = sessionId
     ? await readStopSessionPinnedState("deep-interview-state.json", cwd, sessionId, stateDir)
     : await readJsonIfExists(join(stateDir, "deep-interview-state.json"));
-  if (isActiveDeepInterviewPhase(modeState) && modeState && modeStateMatchesSkillStopContext(modeState, cwd, sessionId)) {
-    const hasActiveDeepInterviewSkill = listActiveSkills(canonicalState).some((entry) => (
-      entry.skill === "deep-interview"
-      && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
-    ));
-    if (hasActiveDeepInterviewSkill) return modeState;
-  }
+  const hasActiveDeepInterviewSkill = listActiveSkills(canonicalState).some((entry) => (
+    entry.skill === "deep-interview"
+    && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
+  ));
+  if (hasActiveDeepInterviewSkill && modeState?.active === true) return modeState;
   if (isInactiveCompletedDeepInterviewPhase(modeState)) return null;
 
   const autopilotState = sessionId
@@ -7326,7 +7484,7 @@ async function buildDeepInterviewPreToolUseBoundaryOutput(
   let blockedDetail = "implementation/write tools are blocked until an explicit handoff workflow is activated";
 
   if (toolName === "Bash") {
-    blocked = !isAllowedDeepInterviewBashWrite(cwd, command);
+    blocked = !isAllowedDeepInterviewBashWrite(cwd, command, activeState, sessionId);
     if (blocked) {
       blockedDetail = buildDeepInterviewBashBlockedDetail(cwd, command);
     }


### PR DESCRIPTION
## Summary
- allow only a standalone, non-nested `omx state write` that authenticates the active deep-interview session and sets `active:false` with `current_phase:complete`
- keep wrong mode/session, partial terminal payloads, clear/cancel variants, chains, substitutions, redirects, nested shells, and foreign state mutations fail-closed
- preserve existing deep-interview artifact/state writes and Ralplan terminal behavior

## Verification
- independently reproduced on `origin/dev` (`8a997dc0`) with the focused regression failing at the expected terminal write
- focused negative matrix: pass
- native hook suite: 540/540 pass
- build/typecheck/no-unused/lint: pass
- full `npm test`: all product tests passed except environment-gated `setup-hooks-trust-e2e` because installed Codex is 0.144.4 instead of pinned 0.142.5
- packed-install smoke: same installed-Codex 0.142.5 boundary blocker

Closes #3177

— GJC