### PR TITLE
fix(hooks): let native subagents stop without auto-nudge

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -25951,6 +25951,58 @@ PY`,
     }
   });
 
+  it("allows a native subagent Stop instead of auto-nudging it into another turn", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-auto-nudge-subagent-stop-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await mkdir(stateDir, { recursive: true });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          "sess-stop-auto-child": {
+            session_id: "sess-stop-auto-child",
+            leader_thread_id: "thread-leader",
+            updated_at: new Date().toISOString(),
+            threads: {
+              "thread-leader": {
+                thread_id: "thread-leader",
+                kind: "leader",
+                first_seen_at: new Date().toISOString(),
+                last_seen_at: new Date().toISOString(),
+                turn_count: 1,
+              },
+              "thread-child": {
+                thread_id: "thread-child",
+                kind: "subagent",
+                first_seen_at: new Date().toISOString(),
+                last_seen_at: new Date().toISOString(),
+                turn_count: 1,
+                mode: "executor",
+              },
+            },
+          },
+        },
+        pending_role_intents: [],
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "sess-stop-auto-child",
+          thread_id: "thread-child",
+          last_assistant_message: "Keep going and finish the cleanup.",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("bounds repeated ordinary working Stop loops with a diagnostic summary", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-working-loop-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -9739,7 +9739,7 @@ async function buildStopHookOutput(
   payload: CodexHookPayload,
   cwd: string,
   stateDir: string,
-  options: { skipRalphStopBlock?: boolean; canonicalSessionId?: string } = {},
+  options: { skipAutoNudge?: boolean; skipRalphStopBlock?: boolean; canonicalSessionId?: string } = {},
 ): Promise<Record<string, unknown> | null> {
   if (isStopExempt(payload)) {
     return null;
@@ -9982,7 +9982,8 @@ async function buildStopHookOutput(
     const autoNudgePhase = await readStopAutoNudgePhase(cwd, stateDir, canonicalSessionId, threadId);
 
     if (
-      autoNudgeConfig.enabled
+      options.skipAutoNudge !== true
+      && autoNudgeConfig.enabled
       && detectNativeStopStallPattern(lastAssistantMessage, autoNudgeConfig.patterns, autoNudgePhase)
     ) {
       const effectiveResponse = resolveEffectiveAutoNudgeResponse(autoNudgeConfig.response);
@@ -10562,6 +10563,7 @@ export async function dispatchCodexNativeHook(
       outputJson = await buildStopHookOutput(payload, cwd, stateDir, {
         canonicalSessionId: canonicalSessionId || undefined,
         skipRalphStopBlock: isSubagentStop,
+        skipAutoNudge: isSubagentStop,
       }) ?? await buildCompletedGoalCleanupStopOutput(payload, cwd);
     } else {
       const failure = stopAuthorizationFailure ?? {


### PR DESCRIPTION
## Summary

- prevent the generic native Stop auto-nudge from forcing a recognized native subagent into another model turn
- preserve leader/root auto-nudge behavior and all earlier Stop guards
- add a regression fixture for tracked native child completion

This is a narrow OMX-owned amplification fix for #3149. It does **not** claim to control Codex context inheritance, per-child request/token budgets, compaction, total fan-out, model-runtime honoring, or total cost.

## Verification

- focused hook + native-agent suites: 555 passed
- adversarial frozen-diff QA: tracked child completion, leader control, malformed tracker, stale foreign tracker collision, Ralph/guard ordering all passed
- `npm run check:no-unused`: passed
- `npm run lint`: passed
- LSP diagnostics: clean
- `npm test`: all applicable tests passed except the existing installed-Codex boundary E2E, which rejects local Codex 0.144.4 because that fixture requires the pinned 0.142.5 boundary; unrelated to this diff
- independent architecture/product/code review: CLEAR / APPROVE
- commit `fde27412522311bd1c62a5f3428894eded853ff6` contains an SSH signature block

Closes #3149

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*