### PR TITLE
fix(#3181): authenticated in-turn leader bootstrap for fresh App Ralplan role-intent

### DIFF
--- a/src/cli/__tests__/ralplan-bootstrap-3181.test.ts
+++ b/src/cli/__tests__/ralplan-bootstrap-3181.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+import { attestLeaderThread, readSubagentTrackingState } from '../../subagents/tracker.js';
+import { parseRoleIntentCorrelationToken } from '../../leader/contract.js';
+import { ralplanCommand, type RalplanCommandDependencies } from '../ralplan.js';
+
+async function invoke(cwd: string, args: string[], deps: Omit<RalplanCommandDependencies, 'cwd' | 'stdout' | 'stderr'> = {}) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const previous = process.exitCode;
+  try {
+    process.exitCode = undefined;
+    await ralplanCommand(args, { ...deps, cwd: () => cwd, stdout: (l) => stdout.push(l), stderr: (l) => stderr.push(l) });
+    return { stdout, stderr, exitCode: process.exitCode };
+  } finally {
+    process.exitCode = previous;
+  }
+}
+
+// Simulate the state the native hook (Phase 1) leaves before the CLI runs: a reconciled
+// canonical session pointer plus a durable leader attestation.
+async function seedAuthenticatedPointer(cwd: string, sessionId: string, leaderThreadId: string): Promise<void> {
+  const stateDir = join(cwd, '.omx', 'state');
+  await mkdir(stateDir, { recursive: true });
+  await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+    session_id: sessionId,
+    native_session_id: leaderThreadId,
+    started_at: '2026-07-14T00:00:00.000Z',
+    cwd,
+  }));
+  const attest = attestLeaderThread(cwd, { sessionId, leaderThreadId, source: 'native-pretooluse' });
+  assert.equal(attest.ok, true);
+}
+
+async function withCwd(fn: (cwd: string) => Promise<void>): Promise<void> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-3181-'));
+  try {
+    delete process.env.OMX_SESSION_ID;
+    delete process.env.CODEX_SESSION_ID;
+    delete process.env.SESSION_ID;
+    await fn(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+describe('#3181 ralplan CLI fresh-turn bootstrap', () => {
+  it('FR-05: fresh no-session/no-tracker fails closed with native_anchor_unavailable (not missing_session)', async () => {
+    await withCwd(async (cwd) => {
+      const res = await invoke(cwd, ['role-intent', 'write', '--role', 'architect', '--parent-thread', 'codex-thread-fresh', '--json']);
+      assert.equal(res.exitCode, 1);
+      assert.deepEqual(JSON.parse(res.stdout.join('\n')), { ok: false, reason: 'native_anchor_unavailable' });
+      assert.deepEqual((await readSubagentTrackingState(cwd)).pending_role_intents, []);
+    });
+  });
+
+  it('FR-03: authenticated fresh turn self-heals leader and records the adapted intent with an App-compatible spawn_task_name', async () => {
+    await withCwd(async (cwd) => {
+      await seedAuthenticatedPointer(cwd, 'sess-app', 'codex-leader-thread');
+      const res = await invoke(cwd, ['role-intent', 'write', '--role', 'architect', '--parent-thread', 'codex-leader-thread', '--json']);
+      assert.equal(res.exitCode, undefined);
+      const receipt = JSON.parse(res.stdout.join('\n')) as { ok: boolean; intent: { role: string; session_id: string; parent_thread_id: string; correlation_token: string }; spawn_task_name: string };
+      assert.equal(receipt.ok, true);
+      assert.equal(receipt.intent.role, 'architect');
+      assert.equal(receipt.intent.session_id, 'sess-app');
+      assert.equal(receipt.intent.parent_thread_id, 'codex-leader-thread');
+      assert.match(receipt.spawn_task_name, /^omx_role_intent_[a-z0-9_]+$/);
+      assert.equal(parseRoleIntentCorrelationToken(receipt.spawn_task_name), receipt.intent.correlation_token);
+      const state = await readSubagentTrackingState(cwd);
+      assert.equal(state.sessions['sess-app']?.threads['codex-leader-thread']?.kind, 'leader');
+      assert.equal(state.pending_role_intents.length, 1);
+    });
+  });
+
+  it('FR-06: authenticated session with a spoofed --parent-thread fails closed with native_anchor_mismatch', async () => {
+    await withCwd(async (cwd) => {
+      await seedAuthenticatedPointer(cwd, 'sess-app', 'codex-leader-thread');
+      const res = await invoke(cwd, ['role-intent', 'write', '--role', 'architect', '--parent-thread', 'attacker-thread', '--json']);
+      assert.equal(res.exitCode, 1);
+      assert.deepEqual(JSON.parse(res.stdout.join('\n')), { ok: false, reason: 'native_anchor_mismatch' });
+      assert.deepEqual((await readSubagentTrackingState(cwd)).pending_role_intents, []);
+    });
+  });
+
+  it('FR-09: duplicate same-identity write reuses the original receipt (idempotent), one intent', async () => {
+    await withCwd(async (cwd) => {
+      await seedAuthenticatedPointer(cwd, 'sess-app', 'codex-leader-thread');
+      const first = await invoke(cwd, ['role-intent', 'write', '--role', 'architect', '--parent-thread', 'codex-leader-thread', '--json']);
+      const second = await invoke(cwd, ['role-intent', 'write', '--role', 'architect', '--parent-thread', 'codex-leader-thread', '--json']);
+      const r1 = JSON.parse(first.stdout.join('\n')) as { spawn_task_name: string; intent: { correlation_token: string } };
+      const r2 = JSON.parse(second.stdout.join('\n')) as { spawn_task_name: string; intent: { correlation_token: string } };
+      assert.equal(r2.intent.correlation_token, r1.intent.correlation_token);
+      assert.equal(r2.spawn_task_name, r1.spawn_task_name);
+      assert.equal((await readSubagentTrackingState(cwd)).pending_role_intents.length, 1);
+    });
+  });
+
+  it('FR-16: durable bootstrap-order recovery restores the exact intent/receipt after a simulated restart-before-spawn', async () => {
+    await withCwd(async (cwd) => {
+      await seedAuthenticatedPointer(cwd, 'sess-app', 'codex-leader-thread');
+      const first = await invoke(cwd, ['role-intent', 'write', '--role', 'architect', '--parent-thread', 'codex-leader-thread', '--json']);
+      const original = JSON.parse(first.stdout.join('\n')) as { spawn_task_name: string; intent: { correlation_token: string } };
+      // Simulated restart-before-spawn: durable state persists; a resumed leader re-runs
+      // role-intent write for the same identity and must recover the exact intent/receipt,
+      // never a fresh unrelated intent.
+      const resumed = await invoke(cwd, ['role-intent', 'write', '--role', 'architect', '--parent-thread', 'codex-leader-thread', '--json']);
+      const recovered = JSON.parse(resumed.stdout.join('\n')) as { spawn_task_name: string; intent: { correlation_token: string } };
+      assert.equal(recovered.intent.correlation_token, original.intent.correlation_token);
+      assert.equal(recovered.spawn_task_name, original.spawn_task_name);
+      const state = await readSubagentTrackingState(cwd);
+      assert.equal(state.pending_role_intents.length, 1);
+      assert.equal(state.sessions['sess-app']?.leader_thread_id, 'codex-leader-thread');
+    });
+  });
+});

--- a/src/cli/__tests__/ralplan-bootstrap-3181.test.ts
+++ b/src/cli/__tests__/ralplan-bootstrap-3181.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
 
-import { attestLeaderThread, readSubagentTrackingState } from '../../subagents/tracker.js';
+import { attestLeaderThread, readSubagentTrackingState, recordSubagentTurnForSession } from '../../subagents/tracker.js';
 import { parseRoleIntentCorrelationToken } from '../../leader/contract.js';
 import { ralplanCommand, type RalplanCommandDependencies } from '../ralplan.js';
 
@@ -146,5 +146,41 @@ describe('#3181 ralplan CLI fresh-turn bootstrap', () => {
       else process.env.OMX_SESSION_ID = prior;
       await rm(cwd, { recursive: true, force: true });
     }
+  });
+
+  it('legacy native-session path: authenticates the native leader when it is not a subagent', async () => {
+    await withCwd(async (cwd) => {
+      // A reconciled pointer with a native session id, but NO attestation (legacy path).
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: 'sess-legacy', native_session_id: 'native-legacy', started_at: '2026-07-14T00:00:00.000Z', cwd,
+      }));
+      const res = await invoke(cwd, ['role-intent', 'write', '--role', 'architect', '--parent-thread', 'native-legacy', '--json']);
+      assert.equal(res.exitCode, undefined);
+      const receipt = JSON.parse(res.stdout.join('\n')) as { ok: boolean; intent: { role: string; parent_thread_id: string } };
+      assert.equal(receipt.ok, true);
+      assert.equal(receipt.intent.parent_thread_id, 'native-legacy');
+      assert.equal((await readSubagentTrackingState(cwd)).pending_role_intents.length, 1);
+    });
+  });
+
+  it('legacy native-session path: refuses a native leader that is also tracked as a subagent (atomic, no downgrade)', async () => {
+    await withCwd(async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: 'sess-legacy', native_session_id: 'native-legacy', started_at: '2026-07-14T00:00:00.000Z', cwd,
+      }));
+      // The native-session thread is also recorded as a subagent in another session (the
+      // PreToolUse-attestation-lost-the-race outcome). The legacy path must NOT authorize it.
+      await recordSubagentTurnForSession(cwd, {
+        sessionId: 'other-session', threadId: 'native-legacy', kind: 'subagent', leaderThreadId: 'other-session', timestamp: new Date().toISOString(),
+      });
+      const res = await invoke(cwd, ['role-intent', 'write', '--role', 'architect', '--parent-thread', 'native-legacy', '--json']);
+      assert.equal(res.exitCode, 1);
+      assert.deepEqual(JSON.parse(res.stdout.join('\n')), { ok: false, reason: 'native_anchor_mismatch' });
+      assert.deepEqual((await readSubagentTrackingState(cwd)).pending_role_intents, []);
+    });
   });
 });

--- a/src/cli/__tests__/ralplan-bootstrap-3181.test.ts
+++ b/src/cli/__tests__/ralplan-bootstrap-3181.test.ts
@@ -150,12 +150,16 @@ describe('#3181 ralplan CLI fresh-turn bootstrap', () => {
 
   it('legacy native-session path: authenticates the native leader when it is not a subagent', async () => {
     await withCwd(async (cwd) => {
-      // A reconciled pointer with a native session id, but NO attestation (legacy path).
+      // A reconciled pointer PLUS a positively-provenanced tracker leader (from a real
+      // recorded leader turn); the leader thread equals the native session id, as in reality.
       const stateDir = join(cwd, '.omx', 'state');
       await mkdir(stateDir, { recursive: true });
       await writeFile(join(stateDir, 'session.json'), JSON.stringify({
         session_id: 'sess-legacy', native_session_id: 'native-legacy', started_at: '2026-07-14T00:00:00.000Z', cwd,
       }));
+      await recordSubagentTurnForSession(cwd, {
+        sessionId: 'sess-legacy', threadId: 'native-legacy', kind: 'leader', leaderThreadId: 'native-legacy', timestamp: new Date().toISOString(),
+      });
       const res = await invoke(cwd, ['role-intent', 'write', '--role', 'architect', '--parent-thread', 'native-legacy', '--json']);
       assert.equal(res.exitCode, undefined);
       const receipt = JSON.parse(res.stdout.join('\n')) as { ok: boolean; intent: { role: string; parent_thread_id: string } };
@@ -172,6 +176,10 @@ describe('#3181 ralplan CLI fresh-turn bootstrap', () => {
       await writeFile(join(stateDir, 'session.json'), JSON.stringify({
         session_id: 'sess-legacy', native_session_id: 'native-legacy', started_at: '2026-07-14T00:00:00.000Z', cwd,
       }));
+      // The session has a positively-provenanced tracker leader...
+      await recordSubagentTurnForSession(cwd, {
+        sessionId: 'sess-legacy', threadId: 'native-legacy', kind: 'leader', leaderThreadId: 'native-legacy', timestamp: new Date().toISOString(),
+      });
       // The native-session thread is also recorded as a subagent in another session (the
       // PreToolUse-attestation-lost-the-race outcome). The legacy path must NOT authorize it.
       await recordSubagentTurnForSession(cwd, {

--- a/src/cli/__tests__/ralplan-bootstrap-3181.test.ts
+++ b/src/cli/__tests__/ralplan-bootstrap-3181.test.ts
@@ -116,4 +116,35 @@ describe('#3181 ralplan CLI fresh-turn bootstrap', () => {
       assert.equal(state.sessions['sess-app']?.leader_thread_id, 'codex-leader-thread');
     });
   });
+
+  it('does not use a durable attestation for an env-selected session with no usable current pointer (stale/foreign guard)', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-3181-env-'));
+    const prior = process.env.OMX_SESSION_ID;
+    try {
+      delete process.env.CODEX_SESSION_ID;
+      delete process.env.SESSION_ID;
+      // The usable pointer belongs to session B, but a stale process selects attested
+      // session A via the environment. A has an attestation in the shared tracker.
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: 'sess-real-B',
+        native_session_id: 'native-B',
+        started_at: '2026-07-14T00:00:00.000Z',
+        cwd,
+      }));
+      const attest = attestLeaderThread(cwd, { sessionId: 'sess-attested-A', leaderThreadId: 'attacker-known-leader', source: 'native-pretooluse' });
+      assert.equal(attest.ok, true);
+      process.env.OMX_SESSION_ID = 'sess-attested-A';
+
+      const res = await invoke(cwd, ['role-intent', 'write', '--role', 'architect', '--parent-thread', 'attacker-known-leader', '--json']);
+      assert.equal(res.exitCode, 1);
+      assert.deepEqual(JSON.parse(res.stdout.join('\n')), { ok: false, reason: 'parent_not_active_leader' });
+      assert.deepEqual((await readSubagentTrackingState(cwd)).pending_role_intents, []);
+    } finally {
+      if (prior === undefined) delete process.env.OMX_SESSION_ID;
+      else process.env.OMX_SESSION_ID = prior;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/__tests__/ralplan.test.ts
+++ b/src/cli/__tests__/ralplan.test.ts
@@ -105,7 +105,9 @@ describe('ralplan role-intent write', () => {
   it('records the authenticated current-session native leader intent with a correlation token receipt', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-ralplan-role-intent-'));
     try {
-      await writeCurrentSession(cwd, 'current-session', 'native-leader', 'tracker-leader');
+      // A real leader's tracker leader_thread_id equals its native session id; #3181
+      // authorizes the legacy native path only against that positively-provenanced anchor.
+      await writeCurrentSession(cwd, 'current-session', 'native-leader', 'native-leader');
 
       const result = await invokeRoleIntent(cwd, [
         'role-intent', 'write', '--role', 'ARCHITECT', '--parent-thread', 'native-leader', '--ttl-ms', '5000', '--json',

--- a/src/cli/ralplan.ts
+++ b/src/cli/ralplan.ts
@@ -83,18 +83,26 @@ export async function ralplanCommand(
   }
 
   // #3181: a durable native-hook leader attestation (leader_thread_id + leader_attested_at)
-  // authorizes the in-turn atomic self-heal path. Without it, fall back to the legacy
-  // active-leader path (native session id or a tracker leader recorded by real turns).
+  // authorizes the in-turn atomic self-heal path, but ONLY when a usable current session
+  // pointer maps to this session. resolveRuntimeStateScope will select an env-provided
+  // session id (OMX_SESSION_ID/CODEX_SESSION_ID/SESSION_ID) even with no usable pointer or
+  // a pointer owned by another session; in that case it omits metadata. Requiring metadata
+  // that maps to currentScope.sessionId prevents a stale/foreign process from selecting an
+  // attested session by environment alone and publishing/binding into it (shared state
+  // root). Without a usable pointer, fall back to the legacy native-session path only.
+  const hasUsableCurrentPointer = Boolean(
+    currentScope.metadata && currentScope.metadata.sessionId === currentScope.sessionId,
+  );
   const trackingState = await readSubagentTrackingState(currentScope.cwd);
   const attestedSession = trackingState.sessions[currentScope.sessionId];
-  const attestedLeaderThreadId = attestedSession?.leader_attested_at
+  const attestedLeaderThreadId = hasUsableCurrentPointer && attestedSession?.leader_attested_at
     ? attestedSession.leader_thread_id?.trim()
     : undefined;
   const useAttestedBootstrap = Boolean(attestedLeaderThreadId);
 
   if (!useAttestedBootstrap) {
     const activeLeaderThreadIds = new Set([
-      attestedSession?.leader_thread_id?.trim(),
+      hasUsableCurrentPointer ? attestedSession?.leader_thread_id?.trim() : undefined,
       currentScope.metadata?.nativeSessionId?.trim(),
     ].filter((threadId): threadId is string => Boolean(threadId)));
     if (!activeLeaderThreadIds.has(parsed.parentThreadId.trim())) {

--- a/src/cli/ralplan.ts
+++ b/src/cli/ralplan.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { resolveRuntimeStateScope } from '../mcp/state-paths.js';
-import { ensureLeaderAndRecordIntent, type PendingRoleIntent, readSubagentTrackingState, recordPendingRoleIntent } from '../subagents/tracker.js';
+import { ensureLeaderAndRecordIntent, type PendingRoleIntent, readSubagentTrackingStateStrict, recordPendingRoleIntent } from '../subagents/tracker.js';
 import {
   ROLE_INTENT_CORRELATION_TOKEN_PATTERN,
   buildRoleIntentSpawnTaskName,
@@ -93,7 +93,15 @@ export async function ralplanCommand(
   const hasUsableCurrentPointer = Boolean(
     currentScope.metadata && currentScope.metadata.sessionId === currentScope.sessionId,
   );
-  const trackingState = await readSubagentTrackingState(currentScope.cwd);
+  // Strict read: an existing but unreadable/corrupt tracker must fail closed rather than
+  // being read as empty and then overwritten by the legacy recordPendingRoleIntent path,
+  // which would erase leader_attested_* and all subagent counter-evidence.
+  const trackingRead = await readSubagentTrackingStateStrict(currentScope.cwd);
+  if (!trackingRead.ok) {
+    emitRoleIntentFailure('native_anchor_unavailable', parsed.json, stdout, stderr);
+    return;
+  }
+  const trackingState = trackingRead.state;
   const attestedSession = trackingState.sessions[currentScope.sessionId];
   const attestedLeaderThreadId = hasUsableCurrentPointer && attestedSession?.leader_attested_at
     ? attestedSession.leader_thread_id?.trim()

--- a/src/cli/ralplan.ts
+++ b/src/cli/ralplan.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { resolveRuntimeStateScope } from '../mcp/state-paths.js';
-import { ensureLeaderAndRecordIntent, type PendingRoleIntent, readSubagentTrackingStateStrict, recordPendingRoleIntent } from '../subagents/tracker.js';
+import { ensureLeaderAndRecordIntent, type PendingRoleIntent, readSubagentTrackingStateStrict, recordNativeLeaderIntent } from '../subagents/tracker.js';
 import {
   ROLE_INTENT_CORRELATION_TOKEN_PATTERN,
   buildRoleIntentSpawnTaskName,
@@ -42,7 +42,7 @@ export interface RalplanCommandDependencies {
   stdout?: (line: string) => void;
   stderr?: (line: string) => void;
   resolveSessionScope?: typeof resolveRuntimeStateScope;
-  recordPendingIntent?: typeof recordPendingRoleIntent;
+  recordNativeLeaderIntent?: typeof recordNativeLeaderIntent;
   ensureLeaderAndRecordIntent?: typeof ensureLeaderAndRecordIntent;
   generateCorrelationToken?: () => string;
 }
@@ -108,16 +108,9 @@ export async function ralplanCommand(
     : undefined;
   const useAttestedBootstrap = Boolean(attestedLeaderThreadId);
 
-  if (!useAttestedBootstrap) {
-    const activeLeaderThreadIds = new Set([
-      hasUsableCurrentPointer ? attestedSession?.leader_thread_id?.trim() : undefined,
-      currentScope.metadata?.nativeSessionId?.trim(),
-    ].filter((threadId): threadId is string => Boolean(threadId)));
-    if (!activeLeaderThreadIds.has(parsed.parentThreadId.trim())) {
-      emitRoleIntentFailure('parent_not_active_leader', parsed.json, stdout, stderr);
-      return;
-    }
-  }
+  // Note: the non-attested legacy path's native-anchor validation + all-session subagent
+  // exclusion is performed atomically inside recordNativeLeaderIntent under the tracker
+  // lock (below), not as a separate pre-check, so a subagent record cannot race in between.
 
   const correlationToken = (deps.generateCorrelationToken ?? (() => randomUUID().replace(/-/g, '')))();
   if (!isSupportedCorrelationToken(correlationToken)) {
@@ -136,14 +129,19 @@ export async function ralplanCommand(
     });
     result = bootstrap.ok ? { ok: true, intent: bootstrap.intent } : { ok: false, reason: bootstrap.reason };
   } else {
-    const recordPendingIntent = deps.recordPendingIntent ?? recordPendingRoleIntent;
-    result = recordPendingIntent(currentScope.cwd, {
+    const recordNativeIntent = deps.recordNativeLeaderIntent ?? recordNativeLeaderIntent;
+    const nativeResult = recordNativeIntent(currentScope.cwd, {
       role: parsed.role,
       sessionId: currentScope.sessionId,
       parentThreadId: parsed.parentThreadId,
+      ...(hasUsableCurrentPointer && currentScope.metadata?.nativeSessionId
+        ? { nativeSessionId: currentScope.metadata.nativeSessionId }
+        : {}),
+      allowTrackerLeader: hasUsableCurrentPointer,
       correlationToken,
       ...(parsed.ttlMs === undefined ? {} : { ttlMs: parsed.ttlMs }),
     });
+    result = nativeResult.ok ? { ok: true, intent: nativeResult.intent } : { ok: false, reason: nativeResult.reason };
   }
   if (!result.ok) {
     emitRoleIntentFailure(result.reason, parsed.json, stdout, stderr);

--- a/src/cli/ralplan.ts
+++ b/src/cli/ralplan.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { resolveRuntimeStateScope } from '../mcp/state-paths.js';
-import { readSubagentTrackingState, recordPendingRoleIntent } from '../subagents/tracker.js';
+import { ensureLeaderAndRecordIntent, type PendingRoleIntent, readSubagentTrackingState, recordPendingRoleIntent } from '../subagents/tracker.js';
 import {
   ROLE_INTENT_CORRELATION_TOKEN_PATTERN,
   buildRoleIntentSpawnTaskName,
@@ -17,7 +17,17 @@ Usage:
 role-intent write records the validated role required by the next adapted native spawn.
 `;
 
-type RoleIntentFailureReason = 'unknown_role' | 'invalid_correlation_token' | 'invalid_origin' | 'single_flight_conflict' | 'session_not_current' | 'parent_not_active_leader' | 'spawn_task_name_unsupported';
+type RoleIntentFailureReason = 'unknown_role' | 'invalid_correlation_token' | 'invalid_origin' | 'single_flight_conflict' | 'session_not_current' | 'parent_not_active_leader' | 'spawn_task_name_unsupported' | 'native_anchor_unavailable' | 'native_anchor_mismatch';
+
+// Shared validation for the App-compatible correlation token / spawn task name. Throws
+// (via buildRoleIntentSpawnTaskName) on structurally invalid tokens, matching the
+// pre-#3181 fail-before-persistence contract.
+function isSupportedCorrelationToken(token: string): boolean {
+  const spawnTaskName = buildRoleIntentSpawnTaskName(token);
+  return ROLE_INTENT_CORRELATION_TOKEN_PATTERN.test(token)
+    && isAppCompatibleSpawnTaskName(spawnTaskName)
+    && parseRoleIntentCorrelationToken(spawnTaskName) === token;
+}
 
 interface ParsedRoleIntentWriteArgs {
   role: string;
@@ -33,6 +43,7 @@ export interface RalplanCommandDependencies {
   stderr?: (line: string) => void;
   resolveSessionScope?: typeof resolveRuntimeStateScope;
   recordPendingIntent?: typeof recordPendingRoleIntent;
+  ensureLeaderAndRecordIntent?: typeof ensureLeaderAndRecordIntent;
   generateCorrelationToken?: () => string;
 }
 
@@ -56,7 +67,10 @@ export async function ralplanCommand(
   const resolveSessionScope = deps.resolveSessionScope ?? resolveRuntimeStateScope;
   const currentScope = await resolveSessionScope(cwd);
   if (!currentScope.sessionId) {
-    emitRoleIntentFailure('missing_session', parsed.json, stdout, stderr);
+    // #3181: no authenticated canonical session pointer exists in this turn, so there
+    // is no verifiable native anchor to bootstrap from. Fail closed with a distinct
+    // machine reason instead of the opaque `missing_session`.
+    emitRoleIntentFailure('native_anchor_unavailable', parsed.json, stdout, stderr);
     return;
   }
 
@@ -68,37 +82,63 @@ export async function ralplanCommand(
     return;
   }
 
+  // #3181: a durable native-hook leader attestation (leader_thread_id + leader_attested_at)
+  // authorizes the in-turn atomic self-heal path. Without it, fall back to the legacy
+  // active-leader path (native session id or a tracker leader recorded by real turns).
   const trackingState = await readSubagentTrackingState(currentScope.cwd);
-  const activeLeaderThreadIds = new Set([
-    trackingState.sessions[currentScope.sessionId]?.leader_thread_id?.trim(),
-    currentScope.metadata?.nativeSessionId?.trim(),
-  ].filter((threadId): threadId is string => Boolean(threadId)));
-  if (!activeLeaderThreadIds.has(parsed.parentThreadId.trim())) {
-    emitRoleIntentFailure('parent_not_active_leader', parsed.json, stdout, stderr);
-    return;
+  const attestedSession = trackingState.sessions[currentScope.sessionId];
+  const attestedLeaderThreadId = attestedSession?.leader_attested_at
+    ? attestedSession.leader_thread_id?.trim()
+    : undefined;
+  const useAttestedBootstrap = Boolean(attestedLeaderThreadId);
+
+  if (!useAttestedBootstrap) {
+    const activeLeaderThreadIds = new Set([
+      attestedSession?.leader_thread_id?.trim(),
+      currentScope.metadata?.nativeSessionId?.trim(),
+    ].filter((threadId): threadId is string => Boolean(threadId)));
+    if (!activeLeaderThreadIds.has(parsed.parentThreadId.trim())) {
+      emitRoleIntentFailure('parent_not_active_leader', parsed.json, stdout, stderr);
+      return;
+    }
   }
 
   const correlationToken = (deps.generateCorrelationToken ?? (() => randomUUID().replace(/-/g, '')))();
-  const spawnTaskName = buildRoleIntentSpawnTaskName(correlationToken);
-  if (
-    !ROLE_INTENT_CORRELATION_TOKEN_PATTERN.test(correlationToken)
-    || !isAppCompatibleSpawnTaskName(spawnTaskName)
-    || parseRoleIntentCorrelationToken(spawnTaskName) !== correlationToken
-  ) {
+  if (!isSupportedCorrelationToken(correlationToken)) {
     emitRoleIntentFailure('spawn_task_name_unsupported', parsed.json, stdout, stderr);
     return;
   }
 
-  const recordPendingIntent = deps.recordPendingIntent ?? recordPendingRoleIntent;
-  const result = recordPendingIntent(currentScope.cwd, {
-    role: parsed.role,
-    sessionId: currentScope.sessionId,
-    parentThreadId: parsed.parentThreadId,
-    correlationToken,
-    ...(parsed.ttlMs === undefined ? {} : { ttlMs: parsed.ttlMs }),
-  });
+  let result: { ok: true; intent: PendingRoleIntent } | { ok: false; reason: RoleIntentFailureReason };
+  if (useAttestedBootstrap) {
+    const bootstrap = (deps.ensureLeaderAndRecordIntent ?? ensureLeaderAndRecordIntent)(currentScope.cwd, {
+      role: parsed.role,
+      sessionId: currentScope.sessionId,
+      parentThreadId: parsed.parentThreadId,
+      correlationToken,
+      ...(parsed.ttlMs === undefined ? {} : { ttlMs: parsed.ttlMs }),
+    });
+    result = bootstrap.ok ? { ok: true, intent: bootstrap.intent } : { ok: false, reason: bootstrap.reason };
+  } else {
+    const recordPendingIntent = deps.recordPendingIntent ?? recordPendingRoleIntent;
+    result = recordPendingIntent(currentScope.cwd, {
+      role: parsed.role,
+      sessionId: currentScope.sessionId,
+      parentThreadId: parsed.parentThreadId,
+      correlationToken,
+      ...(parsed.ttlMs === undefined ? {} : { ttlMs: parsed.ttlMs }),
+    });
+  }
   if (!result.ok) {
     emitRoleIntentFailure(result.reason, parsed.json, stdout, stderr);
+    return;
+  }
+
+  // Build the App-compatible spawn task name from the persisted correlation token so an
+  // idempotent reuse (same-identity intent) returns the original receipt's task name.
+  const spawnTaskName = buildRoleIntentSpawnTaskName(result.intent.correlation_token);
+  if (!isSupportedCorrelationToken(result.intent.correlation_token) || parseRoleIntentCorrelationToken(spawnTaskName) !== result.intent.correlation_token) {
+    emitRoleIntentFailure('spawn_task_name_unsupported', parsed.json, stdout, stderr);
     return;
   }
   const receipt = {

--- a/src/cli/ralplan.ts
+++ b/src/cli/ralplan.ts
@@ -134,9 +134,6 @@ export async function ralplanCommand(
       role: parsed.role,
       sessionId: currentScope.sessionId,
       parentThreadId: parsed.parentThreadId,
-      ...(hasUsableCurrentPointer && currentScope.metadata?.nativeSessionId
-        ? { nativeSessionId: currentScope.metadata.nativeSessionId }
-        : {}),
       allowTrackerLeader: hasUsableCurrentPointer,
       correlationToken,
       ...(parsed.ttlMs === undefined ? {} : { ttlMs: parsed.ttlMs }),

--- a/src/scripts/__tests__/role-intent-bootstrap-e2e-3181.test.ts
+++ b/src/scripts/__tests__/role-intent-bootstrap-e2e-3181.test.ts
@@ -65,4 +65,47 @@ describe('#3181 end-to-end fresh App turn bootstrap', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('PreToolUse (leader turn) bootstraps the pointer + attestation when SessionStart did not, so the first role-intent write succeeds', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-3181-e2e-pretool-'));
+    const priorEnv = { OMX_SESSION_ID: process.env.OMX_SESSION_ID, CODEX_SESSION_ID: process.env.CODEX_SESSION_ID, SESSION_ID: process.env.SESSION_ID };
+    try {
+      delete process.env.OMX_SESSION_ID;
+      delete process.env.CODEX_SESSION_ID;
+      delete process.env.SESSION_ID;
+      const nativeSessionId = 'codex-native-exec-leader';
+
+      // Fresh exec turn where the first event reaching OMX is a leader PreToolUse (no
+      // prior SessionStart pointer). The leader turn carries thread_id == session_id.
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: 'PreToolUse',
+          cwd,
+          session_id: nativeSessionId,
+          thread_id: nativeSessionId,
+          tool_name: 'Bash',
+          tool_use_id: 'tool-exec-first',
+          tool_input: { command: 'omx ralplan role-intent write --role architect --parent-thread "$CODEX_THREAD_ID" --json' },
+        },
+        { cwd, sessionOwnerPid: process.pid },
+      );
+
+      const afterPreTool = await readSubagentTrackingState(cwd);
+      const attested = afterPreTool.sessions[nativeSessionId];
+      assert.equal(attested?.leader_thread_id, nativeSessionId);
+      assert.equal(attested?.leader_attest_source, 'native-pretooluse');
+
+      const res = await invokeRoleIntent(cwd, ['role-intent', 'write', '--role', 'architect', '--parent-thread', nativeSessionId, '--json']);
+      assert.equal(res.exitCode, undefined);
+      const receipt = JSON.parse(res.stdout.join('\n')) as { ok: boolean; intent: { role: string } };
+      assert.equal(receipt.ok, true);
+      assert.equal(receipt.intent.role, 'architect');
+      assert.equal((await readSubagentTrackingState(cwd)).pending_role_intents.length, 1);
+    } finally {
+      if (priorEnv.OMX_SESSION_ID !== undefined) process.env.OMX_SESSION_ID = priorEnv.OMX_SESSION_ID;
+      if (priorEnv.CODEX_SESSION_ID !== undefined) process.env.CODEX_SESSION_ID = priorEnv.CODEX_SESSION_ID;
+      if (priorEnv.SESSION_ID !== undefined) process.env.SESSION_ID = priorEnv.SESSION_ID;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/scripts/__tests__/role-intent-bootstrap-e2e-3181.test.ts
+++ b/src/scripts/__tests__/role-intent-bootstrap-e2e-3181.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { describe, it } from 'node:test';
 
 import { ralplanCommand } from '../../cli/ralplan.js';
-import { readSubagentTrackingState } from '../../subagents/tracker.js';
+import { readSubagentTrackingState, recordSubagentTurnForSession } from '../../subagents/tracker.js';
 import { dispatchCodexNativeHook } from '../codex-native-hook.js';
 
 async function invokeRoleIntent(cwd: string, args: string[]) {
@@ -101,6 +101,49 @@ describe('#3181 end-to-end fresh App turn bootstrap', () => {
       assert.equal(receipt.ok, true);
       assert.equal(receipt.intent.role, 'architect');
       assert.equal((await readSubagentTrackingState(cwd)).pending_role_intents.length, 1);
+    } finally {
+      if (priorEnv.OMX_SESSION_ID !== undefined) process.env.OMX_SESSION_ID = priorEnv.OMX_SESSION_ID;
+      if (priorEnv.CODEX_SESSION_ID !== undefined) process.env.CODEX_SESSION_ID = priorEnv.CODEX_SESSION_ID;
+      if (priorEnv.SESSION_ID !== undefined) process.env.SESSION_ID = priorEnv.SESSION_ID;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('never attests a thread durably tracked as a subagent, even via a source-less leader-shaped PreToolUse', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-3181-e2e-child-'));
+    const priorEnv = { OMX_SESSION_ID: process.env.OMX_SESSION_ID, CODEX_SESSION_ID: process.env.CODEX_SESSION_ID, SESSION_ID: process.env.SESSION_ID };
+    try {
+      delete process.env.OMX_SESSION_ID;
+      delete process.env.CODEX_SESSION_ID;
+      delete process.env.SESSION_ID;
+      const childThreadId = 'codex-native-child-thread';
+
+      // A child is durably recorded as a subagent (e.g. at its own SessionStart).
+      await recordSubagentTurnForSession(cwd, {
+        sessionId: 'leader-session',
+        threadId: childThreadId,
+        kind: 'subagent',
+        leaderThreadId: 'leader-session',
+        timestamp: new Date().toISOString(),
+      });
+
+      // The child then emits a source-less, untyped, leader-shaped PreToolUse
+      // (thread_id === session_id). It must NOT be promoted to leader.
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: 'PreToolUse',
+          cwd,
+          session_id: childThreadId,
+          thread_id: childThreadId,
+          tool_name: 'Bash',
+          tool_use_id: 'tool-child-selfpromote',
+          tool_input: { command: 'omx ralplan role-intent write --role architect --parent-thread "$CODEX_THREAD_ID" --json' },
+        },
+        { cwd, sessionOwnerPid: process.pid },
+      );
+
+      const state = await readSubagentTrackingState(cwd);
+      assert.equal(state.sessions[childThreadId]?.leader_attested_at, undefined, 'child thread must not be attested as leader');
     } finally {
       if (priorEnv.OMX_SESSION_ID !== undefined) process.env.OMX_SESSION_ID = priorEnv.OMX_SESSION_ID;
       if (priorEnv.CODEX_SESSION_ID !== undefined) process.env.CODEX_SESSION_ID = priorEnv.CODEX_SESSION_ID;

--- a/src/scripts/__tests__/role-intent-bootstrap-e2e-3181.test.ts
+++ b/src/scripts/__tests__/role-intent-bootstrap-e2e-3181.test.ts
@@ -22,7 +22,7 @@ async function invokeRoleIntent(cwd: string, args: string[]) {
 }
 
 describe('#3181 end-to-end fresh App turn bootstrap', () => {
-  it('SessionStart establishes the canonical pointer (without attesting) so a fresh in-turn role-intent write succeeds via native-session auth', async () => {
+  it('SessionStart reconcile alone neither attests nor authorizes a role intent (fail-closed; positive provenance required)', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-3181-e2e-'));
     const priorEnv = { OMX_SESSION_ID: process.env.OMX_SESSION_ID, CODEX_SESSION_ID: process.env.CODEX_SESSION_ID, SESSION_ID: process.env.SESSION_ID };
     try {
@@ -38,24 +38,21 @@ describe('#3181 end-to-end fresh App turn bootstrap', () => {
       );
 
       // 2. SessionStart reconciles the canonical pointer but does NOT attest a leader
-      //    (a null transcript cannot positively classify a root vs a malformed child).
+      //    (a null transcript cannot positively classify a root vs a malformed child) and
+      //    writes no positively-provenanced tracker leader.
       const afterStart = await readSubagentTrackingState(cwd);
       assert.equal(afterStart.sessions[nativeSessionId]?.leader_attested_at, undefined, 'SessionStart must not attest a leader');
 
-      // 3. The first in-turn command still succeeds: session.json's native_session_id
-      //    authenticates the leader via the legacy native-session path (no more
-      //    missing_session), reproducing the exact #3181 repro command shape.
+      // 3. A role-intent write on the reconciled-pointer-only session FAILS CLOSED: the bare
+      //    session.json native_session_id is not a trusted leader anchor (an ambiguous /
+      //    malformed-child SessionStart could set it). Authorization requires positive
+      //    provenance — a PreToolUse attestation (next test) or a recorded tracker leader.
       const res = await invokeRoleIntent(cwd, ['role-intent', 'write', '--role', 'architect', '--parent-thread', nativeSessionId, '--json']);
-      assert.equal(res.exitCode, undefined);
-      const receipt = JSON.parse(res.stdout.join('\n')) as { ok: boolean; intent: { role: string; parent_thread_id: string; correlation_token: string }; spawn_task_name: string };
-      assert.equal(receipt.ok, true);
-      assert.equal(receipt.intent.role, 'architect');
-      assert.equal(receipt.intent.parent_thread_id, nativeSessionId);
-      assert.match(receipt.spawn_task_name, /^omx_role_intent_[a-z0-9_]+$/);
+      assert.equal(res.exitCode, 1);
+      assert.deepEqual(JSON.parse(res.stdout.join('\n')), { ok: false, reason: 'parent_not_active_leader' });
 
       const finalState = await readSubagentTrackingState(cwd);
-      assert.equal(finalState.pending_role_intents.length, 1);
-      assert.equal(finalState.pending_role_intents[0]?.role, 'architect');
+      assert.deepEqual(finalState.pending_role_intents, []);
     } finally {
       if (priorEnv.OMX_SESSION_ID !== undefined) process.env.OMX_SESSION_ID = priorEnv.OMX_SESSION_ID;
       if (priorEnv.CODEX_SESSION_ID !== undefined) process.env.CODEX_SESSION_ID = priorEnv.CODEX_SESSION_ID;

--- a/src/scripts/__tests__/role-intent-bootstrap-e2e-3181.test.ts
+++ b/src/scripts/__tests__/role-intent-bootstrap-e2e-3181.test.ts
@@ -151,4 +151,70 @@ describe('#3181 end-to-end fresh App turn bootstrap', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('never bootstraps a leader from a PreToolUse carrying a malformed/blank thread_spawn carrier', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-3181-e2e-malformed-spawn-'));
+    const priorEnv = { OMX_SESSION_ID: process.env.OMX_SESSION_ID, CODEX_SESSION_ID: process.env.CODEX_SESSION_ID, SESSION_ID: process.env.SESSION_ID };
+    try {
+      delete process.env.OMX_SESSION_ID;
+      delete process.env.CODEX_SESSION_ID;
+      delete process.env.SESSION_ID;
+      const childThreadId = 'codex-native-malformed-spawn';
+      // Present-but-malformed thread_spawn carrier (blank parent id) is still child
+      // provenance and must veto leader bootstrap: no pointer, no attestation.
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: 'PreToolUse',
+          cwd,
+          session_id: childThreadId,
+          thread_id: childThreadId,
+          tool_name: 'Bash',
+          tool_use_id: 'tool-malformed-spawn',
+          source: { subagent: { thread_spawn: { parent_thread_id: '' } } },
+          tool_input: { command: 'omx ralplan role-intent write --role architect --parent-thread "$CODEX_THREAD_ID" --json' },
+        },
+        { cwd, sessionOwnerPid: process.pid },
+      );
+      const state = await readSubagentTrackingState(cwd);
+      assert.equal(state.sessions[childThreadId]?.leader_attested_at, undefined, 'malformed thread_spawn must not attest as leader');
+    } finally {
+      if (priorEnv.OMX_SESSION_ID !== undefined) process.env.OMX_SESSION_ID = priorEnv.OMX_SESSION_ID;
+      if (priorEnv.CODEX_SESSION_ID !== undefined) process.env.CODEX_SESSION_ID = priorEnv.CODEX_SESSION_ID;
+      if (priorEnv.SESSION_ID !== undefined) process.env.SESSION_ID = priorEnv.SESSION_ID;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('never bootstraps a leader from a PreToolUse carrying an explicit non-installed agent_role', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-3181-e2e-unknown-role-'));
+    const priorEnv = { OMX_SESSION_ID: process.env.OMX_SESSION_ID, CODEX_SESSION_ID: process.env.CODEX_SESSION_ID, SESSION_ID: process.env.SESSION_ID };
+    try {
+      delete process.env.OMX_SESSION_ID;
+      delete process.env.CODEX_SESSION_ID;
+      delete process.env.SESSION_ID;
+      const childThreadId = 'codex-native-unknown-role';
+      // An explicit but non-installed agent role is still role provenance and must veto
+      // leader bootstrap even though it does not resolve to an installed OMX agent.
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: 'PreToolUse',
+          cwd,
+          session_id: childThreadId,
+          thread_id: childThreadId,
+          agent_role: 'collaboration-child',
+          tool_name: 'Bash',
+          tool_use_id: 'tool-unknown-role',
+          tool_input: { command: 'omx ralplan role-intent write --role architect --parent-thread "$CODEX_THREAD_ID" --json' },
+        },
+        { cwd, sessionOwnerPid: process.pid },
+      );
+      const state = await readSubagentTrackingState(cwd);
+      assert.equal(state.sessions[childThreadId]?.leader_attested_at, undefined, 'explicit non-installed agent_role must not attest as leader');
+    } finally {
+      if (priorEnv.OMX_SESSION_ID !== undefined) process.env.OMX_SESSION_ID = priorEnv.OMX_SESSION_ID;
+      if (priorEnv.CODEX_SESSION_ID !== undefined) process.env.CODEX_SESSION_ID = priorEnv.CODEX_SESSION_ID;
+      if (priorEnv.SESSION_ID !== undefined) process.env.SESSION_ID = priorEnv.SESSION_ID;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/scripts/__tests__/role-intent-bootstrap-e2e-3181.test.ts
+++ b/src/scripts/__tests__/role-intent-bootstrap-e2e-3181.test.ts
@@ -22,7 +22,7 @@ async function invokeRoleIntent(cwd: string, args: string[]) {
 }
 
 describe('#3181 end-to-end fresh App turn bootstrap', () => {
-  it('SessionStart attests the leader so a fresh in-turn role-intent write succeeds instead of missing_session', async () => {
+  it('SessionStart establishes the canonical pointer (without attesting) so a fresh in-turn role-intent write succeeds via native-session auth', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-3181-e2e-'));
     const priorEnv = { OMX_SESSION_ID: process.env.OMX_SESSION_ID, CODEX_SESSION_ID: process.env.CODEX_SESSION_ID, SESSION_ID: process.env.SESSION_ID };
     try {
@@ -37,15 +37,14 @@ describe('#3181 end-to-end fresh App turn bootstrap', () => {
         { cwd, sessionOwnerPid: process.pid },
       );
 
-      // 2. The leader is now durably attested by the native hook (Phase 1).
+      // 2. SessionStart reconciles the canonical pointer but does NOT attest a leader
+      //    (a null transcript cannot positively classify a root vs a malformed child).
       const afterStart = await readSubagentTrackingState(cwd);
-      const attested = afterStart.sessions[nativeSessionId];
-      assert.equal(attested?.leader_thread_id, nativeSessionId);
-      assert.equal(attested?.leader_attest_source, 'native-sessionstart');
-      assert.ok(attested?.leader_attested_at);
+      assert.equal(afterStart.sessions[nativeSessionId]?.leader_attested_at, undefined, 'SessionStart must not attest a leader');
 
-      // 3. The first in-turn command (before any child spawn) now succeeds via self-heal
-      //    (Phase 2), reproducing the exact #3181 repro command shape.
+      // 3. The first in-turn command still succeeds: session.json's native_session_id
+      //    authenticates the leader via the legacy native-session path (no more
+      //    missing_session), reproducing the exact #3181 repro command shape.
       const res = await invokeRoleIntent(cwd, ['role-intent', 'write', '--role', 'architect', '--parent-thread', nativeSessionId, '--json']);
       assert.equal(res.exitCode, undefined);
       const receipt = JSON.parse(res.stdout.join('\n')) as { ok: boolean; intent: { role: string; parent_thread_id: string; correlation_token: string }; spawn_task_name: string };
@@ -57,7 +56,6 @@ describe('#3181 end-to-end fresh App turn bootstrap', () => {
       const finalState = await readSubagentTrackingState(cwd);
       assert.equal(finalState.pending_role_intents.length, 1);
       assert.equal(finalState.pending_role_intents[0]?.role, 'architect');
-      assert.equal(finalState.sessions[nativeSessionId]?.threads[nativeSessionId]?.kind, 'leader');
     } finally {
       if (priorEnv.OMX_SESSION_ID !== undefined) process.env.OMX_SESSION_ID = priorEnv.OMX_SESSION_ID;
       if (priorEnv.CODEX_SESSION_ID !== undefined) process.env.CODEX_SESSION_ID = priorEnv.CODEX_SESSION_ID;

--- a/src/scripts/__tests__/role-intent-bootstrap-e2e-3181.test.ts
+++ b/src/scripts/__tests__/role-intent-bootstrap-e2e-3181.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+import { ralplanCommand } from '../../cli/ralplan.js';
+import { readSubagentTrackingState } from '../../subagents/tracker.js';
+import { dispatchCodexNativeHook } from '../codex-native-hook.js';
+
+async function invokeRoleIntent(cwd: string, args: string[]) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const previous = process.exitCode;
+  try {
+    process.exitCode = undefined;
+    await ralplanCommand(args, { cwd: () => cwd, stdout: (l) => stdout.push(l), stderr: (l) => stderr.push(l) });
+    return { stdout, stderr, exitCode: process.exitCode };
+  } finally {
+    process.exitCode = previous;
+  }
+}
+
+describe('#3181 end-to-end fresh App turn bootstrap', () => {
+  it('SessionStart attests the leader so a fresh in-turn role-intent write succeeds instead of missing_session', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-3181-e2e-'));
+    const priorEnv = { OMX_SESSION_ID: process.env.OMX_SESSION_ID, CODEX_SESSION_ID: process.env.CODEX_SESSION_ID, SESSION_ID: process.env.SESSION_ID };
+    try {
+      delete process.env.OMX_SESSION_ID;
+      delete process.env.CODEX_SESSION_ID;
+      delete process.env.SESSION_ID;
+      const nativeSessionId = 'codex-native-fresh-app';
+
+      // 1. Fresh App/outside-tmux turn start: no session.json, no tracker yet.
+      await dispatchCodexNativeHook(
+        { hook_event_name: 'SessionStart', cwd, session_id: nativeSessionId },
+        { cwd, sessionOwnerPid: process.pid },
+      );
+
+      // 2. The leader is now durably attested by the native hook (Phase 1).
+      const afterStart = await readSubagentTrackingState(cwd);
+      const attested = afterStart.sessions[nativeSessionId];
+      assert.equal(attested?.leader_thread_id, nativeSessionId);
+      assert.equal(attested?.leader_attest_source, 'native-sessionstart');
+      assert.ok(attested?.leader_attested_at);
+
+      // 3. The first in-turn command (before any child spawn) now succeeds via self-heal
+      //    (Phase 2), reproducing the exact #3181 repro command shape.
+      const res = await invokeRoleIntent(cwd, ['role-intent', 'write', '--role', 'architect', '--parent-thread', nativeSessionId, '--json']);
+      assert.equal(res.exitCode, undefined);
+      const receipt = JSON.parse(res.stdout.join('\n')) as { ok: boolean; intent: { role: string; parent_thread_id: string; correlation_token: string }; spawn_task_name: string };
+      assert.equal(receipt.ok, true);
+      assert.equal(receipt.intent.role, 'architect');
+      assert.equal(receipt.intent.parent_thread_id, nativeSessionId);
+      assert.match(receipt.spawn_task_name, /^omx_role_intent_[a-z0-9_]+$/);
+
+      const finalState = await readSubagentTrackingState(cwd);
+      assert.equal(finalState.pending_role_intents.length, 1);
+      assert.equal(finalState.pending_role_intents[0]?.role, 'architect');
+      assert.equal(finalState.sessions[nativeSessionId]?.threads[nativeSessionId]?.kind, 'leader');
+    } finally {
+      if (priorEnv.OMX_SESSION_ID !== undefined) process.env.OMX_SESSION_ID = priorEnv.OMX_SESSION_ID;
+      if (priorEnv.CODEX_SESSION_ID !== undefined) process.env.CODEX_SESSION_ID = priorEnv.CODEX_SESSION_ID;
+      if (priorEnv.SESSION_ID !== undefined) process.env.SESSION_ID = priorEnv.SESSION_ID;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/scripts/__tests__/role-intent-durable-recovery-3181.test.ts
+++ b/src/scripts/__tests__/role-intent-durable-recovery-3181.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
@@ -51,10 +51,12 @@ async function withFreshEnv(fn: () => Promise<void>): Promise<void> {
   }
 }
 
-// Both plugin and legacy delivery drive the same native hook + CLI + tracker recovery path;
-// the meaningful axis is the authenticated in-turn entry point that seeded the leader.
+// Both plugin and legacy delivery drive the same native hook + CLI + tracker recovery path.
+// Leader attestation is established only on the strictly-gated fresh leader PreToolUse
+// entry point (the role-intent command's own PreToolUse fires before it executes); both
+// deliveries route through it, so durable recovery is proven identically for each.
 const DELIVERIES: Array<{ label: string; event: 'SessionStart' | 'PreToolUse' }> = [
-  { label: 'plugin (SessionStart-seeded)', event: 'SessionStart' },
+  { label: 'plugin (PreToolUse-seeded)', event: 'PreToolUse' },
   { label: 'legacy (PreToolUse-seeded)', event: 'PreToolUse' },
 ];
 
@@ -121,7 +123,7 @@ describe('#3181 durable bootstrap-order recovery', () => {
     await withFreshEnv(async () => {
       try {
         const sessionId = 'codex-native-retry';
-        await seedAuthenticatedLeader(cwd, sessionId, 'SessionStart');
+        await seedAuthenticatedLeader(cwd, sessionId, 'PreToolUse');
         const receipts: string[] = [];
         for (let i = 0; i < 3; i += 1) {
           const r = (await invoke(cwd, roleIntentArgs('architect', sessionId))).json as Receipt;
@@ -143,7 +145,7 @@ describe('#3181 durable bootstrap-order recovery', () => {
       delete process.env.SESSION_ID;
       // Real leader session A is authenticated and has a durable intent.
       await withFreshEnv(async () => {
-        await seedAuthenticatedLeader(cwd, 'codex-native-A', 'SessionStart');
+        await seedAuthenticatedLeader(cwd, 'codex-native-A', 'PreToolUse');
         const r = (await invoke(cwd, roleIntentArgs('architect', 'codex-native-A'))).json as Receipt;
         assert.equal(r.ok, true);
       });
@@ -161,37 +163,28 @@ describe('#3181 durable bootstrap-order recovery', () => {
     }
   });
 
-  it('malformed durable tracker on resume: FR-20 fail-closed boundary (spoof rejected; legacy fallback only under an independently authenticated native leader)', async () => {
+  it('malformed/corrupt durable tracker on resume fails closed (native_anchor_unavailable) and never overwrites the evidence', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-3181-recover-malformed-'));
     await withFreshEnv(async () => {
       try {
         const sessionId = 'codex-native-malformed';
-        await seedAuthenticatedLeader(cwd, sessionId, 'SessionStart');
+        await seedAuthenticatedLeader(cwd, sessionId, 'PreToolUse');
         (await invoke(cwd, roleIntentArgs('architect', sessionId))).json as Receipt;
-        // Corrupt the durable tracker so the attestation evidence is unreadable. Per the
-        // FR-20 contract the malformed attestation must NOT be trusted: the attested
-        // self-heal path becomes unavailable (readSubagentTrackingStateStrict denies it),
-        // so no receipt is recovered from the corrupt record and no partial adoption occurs.
+        // Corrupt the durable tracker. Per FR-20 the malformed evidence must not be trusted:
+        // the CLI strict-reads it and fails closed rather than reading it as empty and
+        // overwriting it via the legacy path (which would erase leader/subagent evidence).
+        const corrupt = '{ corrupt tracker not valid json';
         await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
-        await writeFile(subagentTrackingPath(cwd), '{ corrupt tracker not valid json');
+        await writeFile(subagentTrackingPath(cwd), corrupt);
 
-        // Negative boundary: a spoofed --parent-thread is rejected outright; the corrupt
-        // attestation cannot authorize a foreign/unauthenticated leader thread. No write
-        // occurs, so corruption persists for the positive-boundary check below.
+        // A spoofed parent AND the real native leader both fail closed on a corrupt tracker.
         const spoofed = (await invoke(cwd, roleIntentArgs('architect', 'attacker-thread'))).json as { ok: boolean; reason?: string };
-        assert.equal(spoofed.ok, false, 'a spoofed leader thread must never be adopted');
-        assert.equal(spoofed.reason, 'parent_not_active_leader');
+        assert.deepEqual(spoofed, { ok: false, reason: 'native_anchor_unavailable' }, 'spoof on a corrupt tracker fails closed');
+        const nativeLeader = (await invoke(cwd, roleIntentArgs('architect', sessionId))).json as { ok: boolean; reason?: string };
+        assert.deepEqual(nativeLeader, { ok: false, reason: 'native_anchor_unavailable' }, 'even the native leader fails closed on a corrupt tracker');
 
-        // Positive boundary: legacy fallback is permitted ONLY under an independently
-        // authenticated native leader. session.json's native_session_id authenticates the
-        // leader independent of the (corrupt) tracker, so re-recording under the real native
-        // leader thread is safe even though the corrupt attestation itself is untrusted. The
-        // exact prior receipt is unrecoverable (inherent to corruption), but recovery is safe
-        // and never adopts a foreign leader.
-        const authenticated = (await invoke(cwd, roleIntentArgs('architect', sessionId))).json as Receipt;
-        assert.equal(authenticated.ok, true, 'legacy fallback under an authenticated native leader is permitted');
-        assert.equal(authenticated.intent.role, 'architect');
-        assert.equal(authenticated.intent.parent_thread_id, sessionId);
+        // The corrupt tracker is never overwritten (evidence preserved, not silently reset).
+        assert.equal(await readFile(subagentTrackingPath(cwd), 'utf-8'), corrupt, 'corrupt tracker must not be overwritten');
       } finally {
         await rm(cwd, { recursive: true, force: true });
       }

--- a/src/scripts/__tests__/role-intent-durable-recovery-3181.test.ts
+++ b/src/scripts/__tests__/role-intent-durable-recovery-3181.test.ts
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+import { ralplanCommand } from '../../cli/ralplan.js';
+import { readSubagentTrackingState, subagentTrackingPath } from '../../subagents/tracker.js';
+import { dispatchCodexNativeHook } from '../codex-native-hook.js';
+
+// #3181 durable bootstrap-order recovery: a crash/restart AFTER the authenticated adapted
+// Architect role intent is durably recorded but BEFORE the first worker spawn must, on the
+// SAME canonical session, recover the EXACT pending intent/receipt/spawn_task_name before
+// any leader action. This is durable-ordering behavior, not initial-run field presence.
+
+interface Receipt {
+  ok: boolean;
+  intent: { role: string; session_id: string; parent_thread_id: string; correlation_token: string };
+  spawn_task_name: string;
+}
+
+async function invoke(cwd: string, args: string[]): Promise<{ json: unknown; exitCode: number | undefined }> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const previous = process.exitCode;
+  try {
+    process.exitCode = undefined;
+    await ralplanCommand(args, { cwd: () => cwd, stdout: (l) => stdout.push(l), stderr: (l) => stderr.push(l) });
+    return { json: JSON.parse(stdout.join('\n')), exitCode: process.exitCode };
+  } finally {
+    process.exitCode = previous;
+  }
+}
+
+function roleIntentArgs(role: string, parentThread: string): string[] {
+  return ['role-intent', 'write', '--role', role, '--parent-thread', parentThread, '--json'];
+}
+
+async function withFreshEnv(fn: () => Promise<void>): Promise<void> {
+  const prior = { OMX_SESSION_ID: process.env.OMX_SESSION_ID, CODEX_SESSION_ID: process.env.CODEX_SESSION_ID, SESSION_ID: process.env.SESSION_ID };
+  delete process.env.OMX_SESSION_ID;
+  delete process.env.CODEX_SESSION_ID;
+  delete process.env.SESSION_ID;
+  try {
+    await fn();
+  } finally {
+    for (const key of ['OMX_SESSION_ID', 'CODEX_SESSION_ID', 'SESSION_ID'] as const) {
+      if (prior[key] === undefined) delete process.env[key];
+      else process.env[key] = prior[key];
+    }
+  }
+}
+
+// Both plugin and legacy delivery drive the same native hook + CLI + tracker recovery path;
+// the meaningful axis is the authenticated in-turn entry point that seeded the leader.
+const DELIVERIES: Array<{ label: string; event: 'SessionStart' | 'PreToolUse' }> = [
+  { label: 'plugin (SessionStart-seeded)', event: 'SessionStart' },
+  { label: 'legacy (PreToolUse-seeded)', event: 'PreToolUse' },
+];
+
+async function seedAuthenticatedLeader(cwd: string, sessionId: string, event: 'SessionStart' | 'PreToolUse'): Promise<void> {
+  if (event === 'SessionStart') {
+    await dispatchCodexNativeHook({ hook_event_name: 'SessionStart', cwd, session_id: sessionId }, { cwd, sessionOwnerPid: process.pid });
+  } else {
+    await dispatchCodexNativeHook(
+      {
+        hook_event_name: 'PreToolUse',
+        cwd,
+        session_id: sessionId,
+        thread_id: sessionId,
+        tool_name: 'Bash',
+        tool_use_id: 'tool-first',
+        tool_input: { command: 'omx ralplan role-intent write --role architect --parent-thread "$CODEX_THREAD_ID" --json' },
+      },
+      { cwd, sessionOwnerPid: process.pid },
+    );
+  }
+}
+
+describe('#3181 durable bootstrap-order recovery', () => {
+  for (const { label, event } of DELIVERIES) {
+    it(`${label}: same-session resume recovers the exact adapted Architect intent/receipt/spawn_task_name before any spawn`, async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'omx-3181-recover-'));
+      await withFreshEnv(async () => {
+        try {
+          const sessionId = `codex-native-${event}`;
+          await seedAuthenticatedLeader(cwd, sessionId, event);
+
+          // Durably record the Architect intent (before any worker spawn).
+          const first = (await invoke(cwd, roleIntentArgs('architect', sessionId))).json as Receipt;
+          assert.equal(first.ok, true);
+          assert.equal(first.intent.role, 'architect');
+          const token = first.intent.correlation_token;
+          const spawnTaskName = first.spawn_task_name;
+
+          // Crash/restart-before-first-spawn: durable state persists on disk. On the SAME
+          // canonical session, the resumed leader re-runs role-intent and MUST recover the
+          // exact intent/receipt/spawn_task_name — never a fresh unrelated intent.
+          const resumed = (await invoke(cwd, roleIntentArgs('architect', sessionId))).json as Receipt;
+          assert.equal(resumed.intent.correlation_token, token, 'exact correlation token must be recovered');
+          assert.equal(resumed.spawn_task_name, spawnTaskName, 'exact spawn_task_name must be recovered');
+
+          const state = await readSubagentTrackingState(cwd);
+          assert.equal(state.pending_role_intents.length, 1, 'no unrelated replacement intent may be created');
+          assert.equal(state.pending_role_intents[0]?.role, 'architect');
+
+          // Ordering invariant: while the Architect intent is still live (pre-spawn), a Critic
+          // request for the same leader must NOT reorder/replace it — single_flight_conflict.
+          const critic = (await invoke(cwd, roleIntentArgs('critic', sessionId))).json as { ok: boolean; reason?: string };
+          assert.deepEqual(critic, { ok: false, reason: 'single_flight_conflict' });
+          assert.equal((await readSubagentTrackingState(cwd)).pending_role_intents.length, 1);
+        } finally {
+          await rm(cwd, { recursive: true, force: true });
+        }
+      });
+    });
+  }
+
+  it('idempotent retry after crash-during-recovery converges to one intent/receipt', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-3181-recover-retry-'));
+    await withFreshEnv(async () => {
+      try {
+        const sessionId = 'codex-native-retry';
+        await seedAuthenticatedLeader(cwd, sessionId, 'SessionStart');
+        const receipts: string[] = [];
+        for (let i = 0; i < 3; i += 1) {
+          const r = (await invoke(cwd, roleIntentArgs('architect', sessionId))).json as Receipt;
+          receipts.push(r.intent.correlation_token);
+        }
+        assert.equal(new Set(receipts).size, 1, 'every retry recovers the same receipt');
+        assert.equal((await readSubagentTrackingState(cwd)).pending_role_intents.length, 1);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it('foreign-session resume fails closed and never adopts the foreign leader', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-3181-recover-foreign-'));
+    const prior = process.env.OMX_SESSION_ID;
+    try {
+      delete process.env.CODEX_SESSION_ID;
+      delete process.env.SESSION_ID;
+      // Real leader session A is authenticated and has a durable intent.
+      await withFreshEnv(async () => {
+        await seedAuthenticatedLeader(cwd, 'codex-native-A', 'SessionStart');
+        const r = (await invoke(cwd, roleIntentArgs('architect', 'codex-native-A'))).json as Receipt;
+        assert.equal(r.ok, true);
+      });
+      // A foreign process selects session A by environment while the usable pointer is A's
+      // session.json — but resumes from a DIFFERENT workspace is simulated by pointing the
+      // env at A while attempting to bind a foreign leader thread.
+      process.env.OMX_SESSION_ID = 'codex-native-A';
+      const foreign = (await invoke(cwd, roleIntentArgs('architect', 'attacker-thread'))).json as { ok: boolean; reason?: string };
+      assert.equal(foreign.ok, false);
+      assert.equal(foreign.reason, 'native_anchor_mismatch');
+    } finally {
+      if (prior === undefined) delete process.env.OMX_SESSION_ID;
+      else process.env.OMX_SESSION_ID = prior;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('malformed durable tracker on resume: FR-20 fail-closed boundary (spoof rejected; legacy fallback only under an independently authenticated native leader)', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-3181-recover-malformed-'));
+    await withFreshEnv(async () => {
+      try {
+        const sessionId = 'codex-native-malformed';
+        await seedAuthenticatedLeader(cwd, sessionId, 'SessionStart');
+        (await invoke(cwd, roleIntentArgs('architect', sessionId))).json as Receipt;
+        // Corrupt the durable tracker so the attestation evidence is unreadable. Per the
+        // FR-20 contract the malformed attestation must NOT be trusted: the attested
+        // self-heal path becomes unavailable (readSubagentTrackingStateStrict denies it),
+        // so no receipt is recovered from the corrupt record and no partial adoption occurs.
+        await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+        await writeFile(subagentTrackingPath(cwd), '{ corrupt tracker not valid json');
+
+        // Negative boundary: a spoofed --parent-thread is rejected outright; the corrupt
+        // attestation cannot authorize a foreign/unauthenticated leader thread. No write
+        // occurs, so corruption persists for the positive-boundary check below.
+        const spoofed = (await invoke(cwd, roleIntentArgs('architect', 'attacker-thread'))).json as { ok: boolean; reason?: string };
+        assert.equal(spoofed.ok, false, 'a spoofed leader thread must never be adopted');
+        assert.equal(spoofed.reason, 'parent_not_active_leader');
+
+        // Positive boundary: legacy fallback is permitted ONLY under an independently
+        // authenticated native leader. session.json's native_session_id authenticates the
+        // leader independent of the (corrupt) tracker, so re-recording under the real native
+        // leader thread is safe even though the corrupt attestation itself is untrusted. The
+        // exact prior receipt is unrecoverable (inherent to corruption), but recovery is safe
+        // and never adopts a foreign leader.
+        const authenticated = (await invoke(cwd, roleIntentArgs('architect', sessionId))).json as Receipt;
+        assert.equal(authenticated.ok, true, 'legacy fallback under an authenticated native leader is permitted');
+        assert.equal(authenticated.intent.role, 'architect');
+        assert.equal(authenticated.intent.parent_thread_id, sessionId);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3356,6 +3356,25 @@ function hasSubagentThreadSpawnProvenance(payload: CodexHookPayload): boolean {
   return parentThreadId !== "";
 }
 
+// #3181: positive counter-evidence guard. A thread durably tracked as a subagent in ANY
+// session must never be attested as a leader, even if the current payload lacks typed-role
+// or thread_spawn provenance. This closes the source-less/untyped child escalation where a
+// child recorded at its SessionStart later self-promotes via a source-less PreToolUse.
+async function isThreadTrackedAsSubagent(cwd: string, threadId: string): Promise<boolean> {
+  const id = threadId.trim();
+  if (!id) return false;
+  try {
+    const state = await readSubagentTrackingState(cwd);
+    for (const session of Object.values(state.sessions)) {
+      if (session.threads?.[id]?.kind === "subagent") return true;
+    }
+    return false;
+  } catch {
+    // Fail closed for attestation: without readable tracker evidence, do not attest.
+    return true;
+  }
+}
+
 function buildNativeUnknownRolePreToolUseOutput(
   payload: CodexHookPayload,
 ): Record<string, unknown> | null {
@@ -10259,7 +10278,8 @@ export async function dispatchCodexNativeHook(
         // tracker leader before the turn-completion notify path would seed it. This is
         // the non-subagent SessionStart reconcile branch, so the leader thread id is the
         // reconciled native session id. Best-effort: never block SessionStart.
-        if (canonicalSessionId && resolvedNativeSessionId) {
+        if (canonicalSessionId && resolvedNativeSessionId
+          && !(await isThreadTrackedAsSubagent(cwd, resolvedNativeSessionId))) {
           try {
             attestLeaderThread(cwd, {
               sessionId: canonicalSessionId,
@@ -10583,7 +10603,11 @@ export async function dispatchCodexNativeHook(
       && !hasSubagentThreadSpawnProvenance(payload)
     ) {
       const preToolUseLeaderThreadId = readPayloadThreadId(payload);
-      if (preToolUseLeaderThreadId && preToolUseLeaderThreadId === nativeSessionId) {
+      if (
+        preToolUseLeaderThreadId
+        && preToolUseLeaderThreadId === nativeSessionId
+        && !(await isThreadTrackedAsSubagent(cwd, nativeSessionId))
+      ) {
         try {
           const ownerOmxSessionId = await resolveVerifiedOwnerOmxSessionId();
           const sessionState = await reconcileNativeSessionStart(cwd, nativeSessionId, {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -10270,25 +10270,13 @@ export async function dispatchCodexNativeHook(
         resolvedNativeSessionId = safeString(sessionState.native_session_id).trim() || nativeSessionId;
         allowImplicitSessionSideEffects = true;
         stopAuthorizationFailure = null;
-        // #3181: durably attest the authenticated leader thread for this canonical
-        // session so a fresh in-turn `omx ralplan role-intent write` can bootstrap the
-        // tracker leader before the turn-completion notify path would seed it. This is
-        // the non-subagent SessionStart reconcile branch, so the leader thread id is the
-        // reconciled native session id. Best-effort: never block SessionStart.
-        if (canonicalSessionId && resolvedNativeSessionId
-          && readPayloadAgentRole(payload) === ""
-          && !hasSubagentThreadSpawnProvenance(payload)
-          && !(await isThreadTrackedAsSubagent(cwd, resolvedNativeSessionId))) {
-          try {
-            attestLeaderThread(cwd, {
-              sessionId: canonicalSessionId,
-              leaderThreadId: resolvedNativeSessionId,
-              source: 'native-sessionstart',
-            });
-          } catch {
-            // Attestation is a non-critical accelerator; tolerate any failure.
-          }
-        }
+        // #3181: leader attestation is intentionally NOT performed here. This branch is
+        // reached whenever readNativeSubagentSessionStartMetadata() returns null, which
+        // conflates a genuine root start with an unreadable/malformed child transcript, so
+        // it cannot positively classify a leader (a legitimate leader may also carry no
+        // transcript). Leader attestation is performed only on the strictly-gated fresh
+        // leader PreToolUse path below, which fires before the first in-turn role-intent
+        // write. Fail closed here rather than risk a false-leader adoption.
       } catch (error) {
         if (!isSessionPointerLaunchAbort(error)) throw error;
         canonicalSessionId = "";

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3341,20 +3341,18 @@ function isTypedAgentRolePayload(payload: CodexHookPayload): boolean {
   return agentRole !== "" && resolveInstalledRoleName(agentRole) !== null;
 }
 
-// #3181: detect a runtime-set native subagent PreToolUse. The thread_spawn provenance
-// is set by the runtime (not agent-controlled tool arguments), so its presence marks a
-// child/subagent turn that must never be attested as the session leader.
+// #3181: detect a runtime-set native subagent PreToolUse. The runtime sets
+// source.subagent.thread_spawn (not agent-controlled tool arguments), so the mere
+// STRUCTURAL PRESENCE of that carrier — even if its parent id is blank, malformed, or
+// null — marks a child/subagent turn that must never be attested as the session leader.
+// This is a negative security decision, so it fails closed on any present carrier rather
+// than requiring a well-formed parent id.
 function hasSubagentThreadSpawnProvenance(payload: CodexHookPayload): boolean {
-  const source = safeObject(payload.source);
-  const subagent = safeObject(source?.subagent);
-  const threadSpawn = safeObject(subagent?.thread_spawn);
-  const parentThreadId = safeString(
-    threadSpawn?.parent_thread_id
-      ?? threadSpawn?.parentThreadId
-      ?? threadSpawn?.leader_thread_id
-      ?? threadSpawn?.leaderThreadId,
-  ).trim();
-  return parentThreadId !== "";
+  const source = payload.source;
+  if (!source || typeof source !== "object") return false;
+  const subagent = (source as Record<string, unknown>).subagent;
+  if (!subagent || typeof subagent !== "object") return false;
+  return Object.prototype.hasOwnProperty.call(subagent, "thread_spawn");
 }
 
 // #3181: positive counter-evidence guard. A thread durably tracked as a subagent in ANY
@@ -10278,6 +10276,8 @@ export async function dispatchCodexNativeHook(
         // the non-subagent SessionStart reconcile branch, so the leader thread id is the
         // reconciled native session id. Best-effort: never block SessionStart.
         if (canonicalSessionId && resolvedNativeSessionId
+          && readPayloadAgentRole(payload) === ""
+          && !hasSubagentThreadSpawnProvenance(payload)
           && !(await isThreadTrackedAsSubagent(cwd, resolvedNativeSessionId))) {
           try {
             attestLeaderThread(cwd, {
@@ -10598,7 +10598,7 @@ export async function dispatchCodexNativeHook(
       allowImplicitSessionSideEffects
       && !canonicalSessionId
       && nativeSessionId
-      && !isTypedAgentRolePayload(payload)
+      && readPayloadAgentRole(payload) === ""
       && !hasSubagentThreadSpawnProvenance(payload)
     ) {
       const preToolUseLeaderThreadId = readPayloadThreadId(payload);

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -18,6 +18,7 @@ import {
 import {
   isTrustedSubagentThread,
   OMX_ADAPTED_PROVENANCE,
+  attestLeaderThread,
   readSubagentSessionSummary,
   readSubagentSessionLedger,
   readSubagentTrackingState,
@@ -10237,6 +10238,22 @@ export async function dispatchCodexNativeHook(
         resolvedNativeSessionId = safeString(sessionState.native_session_id).trim() || nativeSessionId;
         allowImplicitSessionSideEffects = true;
         stopAuthorizationFailure = null;
+        // #3181: durably attest the authenticated leader thread for this canonical
+        // session so a fresh in-turn `omx ralplan role-intent write` can bootstrap the
+        // tracker leader before the turn-completion notify path would seed it. This is
+        // the non-subagent SessionStart reconcile branch, so the leader thread id is the
+        // reconciled native session id. Best-effort: never block SessionStart.
+        if (canonicalSessionId && resolvedNativeSessionId) {
+          try {
+            attestLeaderThread(cwd, {
+              sessionId: canonicalSessionId,
+              leaderThreadId: resolvedNativeSessionId,
+              source: 'native-sessionstart',
+            });
+          } catch {
+            // Attestation is a non-critical accelerator; tolerate any failure.
+          }
+        }
       } catch (error) {
         if (!isSessionPointerLaunchAbort(error)) throw error;
         canonicalSessionId = "";

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3340,6 +3340,22 @@ function isTypedAgentRolePayload(payload: CodexHookPayload): boolean {
   return agentRole !== "" && resolveInstalledRoleName(agentRole) !== null;
 }
 
+// #3181: detect a runtime-set native subagent PreToolUse. The thread_spawn provenance
+// is set by the runtime (not agent-controlled tool arguments), so its presence marks a
+// child/subagent turn that must never be attested as the session leader.
+function hasSubagentThreadSpawnProvenance(payload: CodexHookPayload): boolean {
+  const source = safeObject(payload.source);
+  const subagent = safeObject(source?.subagent);
+  const threadSpawn = safeObject(subagent?.thread_spawn);
+  const parentThreadId = safeString(
+    threadSpawn?.parent_thread_id
+      ?? threadSpawn?.parentThreadId
+      ?? threadSpawn?.leader_thread_id
+      ?? threadSpawn?.leaderThreadId,
+  ).trim();
+  return parentThreadId !== "";
+}
+
 function buildNativeUnknownRolePreToolUseOutput(
   payload: CodexHookPayload,
 ): Record<string, unknown> | null {
@@ -10552,6 +10568,44 @@ export async function dispatchCodexNativeHook(
       };
     }
   } else if (hookEventName === "PreToolUse") {
+    // #3181 Phase-1 (PreToolUse): this hook fires before the shell tool call that runs
+    // the first in-turn `omx ralplan role-intent write`. On a fresh App/outside-tmux
+    // turn where SessionStart did not establish the pointer, reconcile the canonical
+    // pointer and attest the leader here so the first command can bootstrap. Strictly
+    // gated to a fresh (absent-pointer) LEADER turn: no canonical session yet, a present
+    // native session id, a leader-shaped thread (absent or equal to the native session
+    // id), and no subagent/typed-role provenance. Best-effort; never blocks PreToolUse.
+    if (
+      allowImplicitSessionSideEffects
+      && !canonicalSessionId
+      && nativeSessionId
+      && !isTypedAgentRolePayload(payload)
+      && !hasSubagentThreadSpawnProvenance(payload)
+    ) {
+      const preToolUseLeaderThreadId = readPayloadThreadId(payload);
+      if (preToolUseLeaderThreadId && preToolUseLeaderThreadId === nativeSessionId) {
+        try {
+          const ownerOmxSessionId = await resolveVerifiedOwnerOmxSessionId();
+          const sessionState = await reconcileNativeSessionStart(cwd, nativeSessionId, {
+            context: pointerContext,
+            pid: options.sessionOwnerPid ?? resolveSessionOwnerPid(payload),
+            ...(ownerOmxSessionId ? { ownerOmxSessionId, ownerAliasVerified: true } : {}),
+          });
+          const bootstrapSessionId = safeString(sessionState.session_id).trim();
+          const bootstrapLeaderThreadId = safeString(sessionState.native_session_id).trim() || nativeSessionId;
+          if (bootstrapSessionId && bootstrapLeaderThreadId) {
+            canonicalSessionId = bootstrapSessionId;
+            attestLeaderThread(cwd, {
+              sessionId: bootstrapSessionId,
+              leaderThreadId: bootstrapLeaderThreadId,
+              source: 'native-pretooluse',
+            });
+          }
+        } catch {
+          // Best-effort bootstrap; PreToolUse must never fail on this.
+        }
+      }
+    }
     const payloadSessionId = readPayloadSessionId(payload);
     const rootPointerConflict = await readLiveRootSessionPointerConflict(stateDir, payloadSessionId);
     const preToolUseSessionId = payloadSessionId

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -22,6 +22,7 @@ import {
   readSubagentSessionSummary,
   readSubagentSessionLedger,
   readSubagentTrackingState,
+  readSubagentTrackingStateStrict,
   recordSubagentTurn,
   recordSubagentTurnForSession,
   resolveInstalledRoleName,
@@ -3363,16 +3364,14 @@ function hasSubagentThreadSpawnProvenance(payload: CodexHookPayload): boolean {
 async function isThreadTrackedAsSubagent(cwd: string, threadId: string): Promise<boolean> {
   const id = threadId.trim();
   if (!id) return false;
-  try {
-    const state = await readSubagentTrackingState(cwd);
-    for (const session of Object.values(state.sessions)) {
-      if (session.threads?.[id]?.kind === "subagent") return true;
-    }
-    return false;
-  } catch {
-    // Fail closed for attestation: without readable tracker evidence, do not attest.
-    return true;
+  // Strict read: an unreadable/corrupt tracker fails closed (treated as "is a subagent")
+  // so corrupt evidence cannot let a source-less child reconcile/attest as leader.
+  const read = await readSubagentTrackingStateStrict(cwd);
+  if (!read.ok) return true;
+  for (const session of Object.values(read.state.sessions)) {
+    if (session.threads?.[id]?.kind === "subagent") return true;
   }
+  return false;
 }
 
 function buildNativeUnknownRolePreToolUseOutput(

--- a/src/subagents/__tests__/leader-bootstrap-3181.test.ts
+++ b/src/subagents/__tests__/leader-bootstrap-3181.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
@@ -8,6 +8,7 @@ import {
   attestLeaderThread,
   ensureLeaderAndRecordIntent,
   readSubagentTrackingState,
+  recordNativeLeaderIntent,
   recordSubagentTurnForSession,
   subagentTrackingPath,
 } from '../tracker.js';
@@ -221,6 +222,61 @@ describe('#3181 leader bootstrap tracker carrier', () => {
       if (!retry.ok || !first.ok) return;
       assert.equal(retry.reused, true);
       assert.equal(retry.intent.correlation_token, first.intent.correlation_token);
+    });
+  });
+
+  it('recordNativeLeaderIntent records under a valid native anchor and is role-agnostic single-flight', async () => {
+    await withCwd(async (cwd) => {
+      const ok = recordNativeLeaderIntent(cwd, {
+        role: 'architect', sessionId: 'sess-A', parentThreadId: 'native-L', nativeSessionId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN,
+      });
+      assert.equal(ok.ok, true);
+      if (!ok.ok) return;
+      assert.equal(ok.intent.role, 'architect');
+      // Same identity reuses; different role conflicts.
+      const reuse = recordNativeLeaderIntent(cwd, { role: 'architect', sessionId: 'sess-A', parentThreadId: 'native-L', nativeSessionId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN2 });
+      assert.equal(reuse.ok, true);
+      if (reuse.ok) assert.equal(reuse.reused, true);
+      const conflict = recordNativeLeaderIntent(cwd, { role: 'critic', sessionId: 'sess-A', parentThreadId: 'native-L', nativeSessionId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN2 });
+      assert.deepEqual(conflict, { ok: false, reason: 'single_flight_conflict' });
+      assert.equal((await readSubagentTrackingState(cwd)).pending_role_intents.length, 1);
+    });
+  });
+
+  it('recordNativeLeaderIntent rejects a parent that is not a native anchor (parent_not_active_leader), no mutation', async () => {
+    await withCwd(async (cwd) => {
+      const res = recordNativeLeaderIntent(cwd, {
+        role: 'architect', sessionId: 'sess-A', parentThreadId: 'attacker', nativeSessionId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN,
+      });
+      assert.deepEqual(res, { ok: false, reason: 'parent_not_active_leader' });
+      assert.deepEqual((await readSubagentTrackingState(cwd)).pending_role_intents, []);
+    });
+  });
+
+  it('recordNativeLeaderIntent atomically rejects a native anchor also tracked as a subagent (race: child record wins)', async () => {
+    await withCwd(async (cwd) => {
+      // The child record wins the race: the native-anchor thread is recorded as a subagent
+      // in a different session before the legacy fallback runs.
+      await recordSubagentTurnForSession(cwd, {
+        sessionId: 'sess-B', threadId: 'native-L', kind: 'subagent', leaderThreadId: 'sess-B', timestamp: new Date().toISOString(),
+      });
+      const res = recordNativeLeaderIntent(cwd, {
+        role: 'architect', sessionId: 'sess-A', parentThreadId: 'native-L', nativeSessionId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN,
+      });
+      assert.deepEqual(res, { ok: false, reason: 'native_anchor_mismatch' });
+      assert.deepEqual((await readSubagentTrackingState(cwd)).pending_role_intents, []);
+    });
+  });
+
+  it('recordNativeLeaderIntent fails closed on a corrupt tracker (native_anchor_unavailable, no overwrite)', async () => {
+    await withCwd(async (cwd) => {
+      await mkdir(subagentTrackingPath(cwd).replace(/\/[^/]+$/, ''), { recursive: true });
+      await writeFile(subagentTrackingPath(cwd), '{ corrupt not json');
+      const res = recordNativeLeaderIntent(cwd, {
+        role: 'architect', sessionId: 'sess-A', parentThreadId: 'native-L', nativeSessionId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN,
+      });
+      assert.deepEqual(res, { ok: false, reason: 'native_anchor_unavailable' });
+      assert.equal(await readFile(subagentTrackingPath(cwd), 'utf-8'), '{ corrupt not json');
     });
   });
 });

--- a/src/subagents/__tests__/leader-bootstrap-3181.test.ts
+++ b/src/subagents/__tests__/leader-bootstrap-3181.test.ts
@@ -161,4 +161,36 @@ describe('#3181 leader bootstrap tracker carrier', () => {
       assert.deepEqual(result, { ok: false, reason: 'native_anchor_unavailable' });
     });
   });
+
+  it('fails closed (native_anchor_unavailable) when the tracker exists but is unreadable (non-ENOENT)', async () => {
+    await withCwd(async (cwd) => {
+      // Make the tracker path a directory so a read throws EISDIR (not ENOENT); an existing
+      // but unreadable tracker must deny attestation, not be treated as clean empty state.
+      await mkdir(subagentTrackingPath(cwd), { recursive: true });
+      const result = attestLeaderThread(cwd, { sessionId: 'sess-a', leaderThreadId: 'leader-thread-a', source: 'native-pretooluse' });
+      assert.deepEqual(result, { ok: false, reason: 'native_anchor_unavailable' });
+    });
+  });
+
+  it('symmetric exclusion: a leader also tracked as a subagent in a DIFFERENT session cannot record an intent', async () => {
+    await withCwd(async (cwd) => {
+      // Attestation wins first for session A.
+      const attest = attestLeaderThread(cwd, { sessionId: 'sess-A', leaderThreadId: 'thread-x', source: 'native-pretooluse' });
+      assert.equal(attest.ok, true);
+      // A cross-session child record then classifies thread-x as a subagent under session B.
+      await recordSubagentTurnForSession(cwd, {
+        sessionId: 'sess-B',
+        threadId: 'thread-x',
+        kind: 'subagent',
+        leaderThreadId: 'sess-B',
+        timestamp: new Date().toISOString(),
+      });
+      // ensureLeaderAndRecordIntent must re-scan all sessions and refuse.
+      const result = ensureLeaderAndRecordIntent(cwd, {
+        role: 'architect', sessionId: 'sess-A', parentThreadId: 'thread-x', correlationToken: TOKEN,
+      });
+      assert.deepEqual(result, { ok: false, reason: 'native_anchor_mismatch' });
+      assert.deepEqual((await readSubagentTrackingState(cwd)).pending_role_intents, []);
+    });
+  });
 });

--- a/src/subagents/__tests__/leader-bootstrap-3181.test.ts
+++ b/src/subagents/__tests__/leader-bootstrap-3181.test.ts
@@ -193,4 +193,34 @@ describe('#3181 leader bootstrap tracker carrier', () => {
       assert.deepEqual((await readSubagentTrackingState(cwd)).pending_role_intents, []);
     });
   });
+
+  it('preserves the leader attestation across an ordinary child turn write (no legacy downgrade)', async () => {
+    await withCwd(async (cwd) => {
+      attestLeaderThread(cwd, { sessionId: 'sess-A', leaderThreadId: 'leader-L', source: 'native-sessionstart' });
+      const first = ensureLeaderAndRecordIntent(cwd, { role: 'architect', sessionId: 'sess-A', parentThreadId: 'leader-L', correlationToken: TOKEN });
+      assert.equal(first.ok, true);
+
+      // An ordinary child turn under the same session must NOT erase the attestation.
+      await recordSubagentTurnForSession(cwd, {
+        sessionId: 'sess-A',
+        threadId: 'child-thread',
+        kind: 'subagent',
+        leaderThreadId: 'leader-L',
+        timestamp: new Date().toISOString(),
+      });
+
+      const state = await readSubagentTrackingState(cwd);
+      assert.ok(state.sessions['sess-A']?.leader_attested_at, 'attestation must survive a child turn write');
+      assert.equal(state.sessions['sess-A']?.leader_attest_source, 'native-sessionstart');
+      assert.equal(state.sessions['sess-A']?.leader_thread_id, 'leader-L', 'a child turn must not replace the attested leader');
+
+      // The next role-intent write still uses the attested path (idempotent receipt reuse),
+      // proving no downgrade to the legacy non-atomic path.
+      const retry = ensureLeaderAndRecordIntent(cwd, { role: 'architect', sessionId: 'sess-A', parentThreadId: 'leader-L', correlationToken: TOKEN2 });
+      assert.equal(retry.ok, true);
+      if (!retry.ok || !first.ok) return;
+      assert.equal(retry.reused, true);
+      assert.equal(retry.intent.correlation_token, first.intent.correlation_token);
+    });
+  });
 });

--- a/src/subagents/__tests__/leader-bootstrap-3181.test.ts
+++ b/src/subagents/__tests__/leader-bootstrap-3181.test.ts
@@ -116,4 +116,21 @@ describe('#3181 leader bootstrap tracker carrier', () => {
       assert.equal(state.pending_role_intents.length, 1);
     });
   });
+
+  it('preserves single-flight: a different-role second live intent returns single_flight_conflict', async () => {
+    await withCwd(async (cwd) => {
+      attestLeaderThread(cwd, { sessionId: 'sess-a', leaderThreadId: 'leader-thread-a', source: 'native-pretooluse' });
+      const architect = ensureLeaderAndRecordIntent(cwd, {
+        role: 'architect', sessionId: 'sess-a', parentThreadId: 'leader-thread-a', correlationToken: TOKEN,
+      });
+      const critic = ensureLeaderAndRecordIntent(cwd, {
+        role: 'critic', sessionId: 'sess-a', parentThreadId: 'leader-thread-a', correlationToken: TOKEN2,
+      });
+      assert.equal(architect.ok, true);
+      assert.deepEqual(critic, { ok: false, reason: 'single_flight_conflict' });
+      const state = await readSubagentTrackingState(cwd);
+      assert.equal(state.pending_role_intents.length, 1);
+      assert.equal(state.pending_role_intents[0]?.role, 'architect');
+    });
+  });
 });

--- a/src/subagents/__tests__/leader-bootstrap-3181.test.ts
+++ b/src/subagents/__tests__/leader-bootstrap-3181.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+import {
+  attestLeaderThread,
+  ensureLeaderAndRecordIntent,
+  readSubagentTrackingState,
+} from '../tracker.js';
+
+// 32 lowercase-hex chars: the canonical correlation-token shape the CLI generates via
+// randomUUID().replace(/-/g, '').
+const TOKEN = 'abcdef0123456789abcdef0123456789';
+const TOKEN2 = '00112233445566778899aabbccddeeff';
+
+async function withCwd(fn: (cwd: string) => Promise<void>): Promise<void> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omx-3181-bootstrap-'));
+  try {
+    await fn(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+describe('#3181 leader bootstrap tracker carrier', () => {
+  it('attests a leader and then records the adapted intent via self-heal', async () => {
+    await withCwd(async (cwd) => {
+      const attest = attestLeaderThread(cwd, {
+        sessionId: 'sess-a',
+        leaderThreadId: 'leader-thread-a',
+        source: 'native-pretooluse',
+      });
+      assert.deepEqual(attest, { ok: true, alreadyAttested: false });
+
+      const result = ensureLeaderAndRecordIntent(cwd, {
+        role: 'architect',
+        sessionId: 'sess-a',
+        parentThreadId: 'leader-thread-a',
+        correlationToken: TOKEN,
+      });
+      assert.equal(result.ok, true);
+      if (!result.ok) return;
+      assert.equal(result.reused, false);
+      assert.equal(result.intent.role, 'architect');
+      assert.equal(result.intent.session_id, 'sess-a');
+      assert.equal(result.intent.parent_thread_id, 'leader-thread-a');
+      assert.equal(result.intent.correlation_token, TOKEN);
+
+      const state = await readSubagentTrackingState(cwd);
+      const session = state.sessions['sess-a'];
+      assert.equal(session?.leader_thread_id, 'leader-thread-a');
+      assert.ok(session?.leader_attested_at);
+      assert.equal(session?.leader_attest_source, 'native-pretooluse');
+      assert.equal(session?.threads['leader-thread-a']?.kind, 'leader');
+      assert.equal(state.pending_role_intents.length, 1);
+    });
+  });
+
+  it('fails closed with native_anchor_unavailable when no attestation exists', async () => {
+    await withCwd(async (cwd) => {
+      const result = ensureLeaderAndRecordIntent(cwd, {
+        role: 'architect',
+        sessionId: 'sess-fresh',
+        parentThreadId: 'codex-thread-fresh-turn',
+        correlationToken: TOKEN,
+      });
+      assert.deepEqual(result, { ok: false, reason: 'native_anchor_unavailable' });
+      const state = await readSubagentTrackingState(cwd);
+      assert.equal(state.pending_role_intents.length, 0);
+      assert.equal(state.sessions['sess-fresh'], undefined);
+    });
+  });
+
+  it('fails closed with native_anchor_mismatch when parent-thread != attested leader', async () => {
+    await withCwd(async (cwd) => {
+      attestLeaderThread(cwd, { sessionId: 'sess-a', leaderThreadId: 'leader-thread-a', source: 'native-pretooluse' });
+      const result = ensureLeaderAndRecordIntent(cwd, {
+        role: 'architect',
+        sessionId: 'sess-a',
+        parentThreadId: 'attacker-thread',
+        correlationToken: TOKEN,
+      });
+      assert.deepEqual(result, { ok: false, reason: 'native_anchor_mismatch' });
+      const state = await readSubagentTrackingState(cwd);
+      assert.equal(state.pending_role_intents.length, 0);
+    });
+  });
+
+  it('never overwrites a different existing leader (fail-closed attestation)', async () => {
+    await withCwd(async (cwd) => {
+      attestLeaderThread(cwd, { sessionId: 'sess-a', leaderThreadId: 'leader-thread-a', source: 'native-pretooluse' });
+      const second = attestLeaderThread(cwd, { sessionId: 'sess-a', leaderThreadId: 'foreign-leader', source: 'native-pretooluse' });
+      assert.deepEqual(second, { ok: false, reason: 'native_anchor_mismatch' });
+      const state = await readSubagentTrackingState(cwd);
+      assert.equal(state.sessions['sess-a']?.leader_thread_id, 'leader-thread-a');
+    });
+  });
+
+  it('is idempotent: duplicate same-identity intent reuses the original receipt', async () => {
+    await withCwd(async (cwd) => {
+      attestLeaderThread(cwd, { sessionId: 'sess-a', leaderThreadId: 'leader-thread-a', source: 'native-pretooluse' });
+      const first = ensureLeaderAndRecordIntent(cwd, {
+        role: 'architect', sessionId: 'sess-a', parentThreadId: 'leader-thread-a', correlationToken: TOKEN,
+      });
+      const second = ensureLeaderAndRecordIntent(cwd, {
+        role: 'architect', sessionId: 'sess-a', parentThreadId: 'leader-thread-a', correlationToken: TOKEN2,
+      });
+      assert.equal(first.ok, true);
+      assert.equal(second.ok, true);
+      if (!first.ok || !second.ok) return;
+      assert.equal(second.reused, true);
+      assert.equal(second.intent.correlation_token, first.intent.correlation_token);
+      const state = await readSubagentTrackingState(cwd);
+      assert.equal(state.pending_role_intents.length, 1);
+    });
+  });
+});

--- a/src/subagents/__tests__/leader-bootstrap-3181.test.ts
+++ b/src/subagents/__tests__/leader-bootstrap-3181.test.ts
@@ -225,43 +225,58 @@ describe('#3181 leader bootstrap tracker carrier', () => {
     });
   });
 
-  it('recordNativeLeaderIntent records under a valid native anchor and is role-agnostic single-flight', async () => {
+  it('recordNativeLeaderIntent records under a positively-provenanced tracker leader and is role-agnostic single-flight', async () => {
     await withCwd(async (cwd) => {
+      // A real recorded leader turn establishes the positive tracker leader anchor.
+      await recordSubagentTurnForSession(cwd, { sessionId: 'sess-A', threadId: 'native-L', kind: 'leader', leaderThreadId: 'native-L', timestamp: new Date().toISOString() });
       const ok = recordNativeLeaderIntent(cwd, {
-        role: 'architect', sessionId: 'sess-A', parentThreadId: 'native-L', nativeSessionId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN,
+        role: 'architect', sessionId: 'sess-A', parentThreadId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN,
       });
       assert.equal(ok.ok, true);
       if (!ok.ok) return;
       assert.equal(ok.intent.role, 'architect');
       // Same identity reuses; different role conflicts.
-      const reuse = recordNativeLeaderIntent(cwd, { role: 'architect', sessionId: 'sess-A', parentThreadId: 'native-L', nativeSessionId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN2 });
+      const reuse = recordNativeLeaderIntent(cwd, { role: 'architect', sessionId: 'sess-A', parentThreadId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN2 });
       assert.equal(reuse.ok, true);
       if (reuse.ok) assert.equal(reuse.reused, true);
-      const conflict = recordNativeLeaderIntent(cwd, { role: 'critic', sessionId: 'sess-A', parentThreadId: 'native-L', nativeSessionId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN2 });
+      const conflict = recordNativeLeaderIntent(cwd, { role: 'critic', sessionId: 'sess-A', parentThreadId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN2 });
       assert.deepEqual(conflict, { ok: false, reason: 'single_flight_conflict' });
       assert.equal((await readSubagentTrackingState(cwd)).pending_role_intents.length, 1);
     });
   });
 
-  it('recordNativeLeaderIntent rejects a parent that is not a native anchor (parent_not_active_leader), no mutation', async () => {
+  it('recordNativeLeaderIntent fails closed when there is no positive tracker leader anchor (session.json alone never authorizes)', async () => {
     await withCwd(async (cwd) => {
+      // No recorded leader turn / attestation: the bare native-session pointer is NOT trusted.
       const res = recordNativeLeaderIntent(cwd, {
-        role: 'architect', sessionId: 'sess-A', parentThreadId: 'attacker', nativeSessionId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN,
+        role: 'architect', sessionId: 'sess-A', parentThreadId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN,
       });
       assert.deepEqual(res, { ok: false, reason: 'parent_not_active_leader' });
       assert.deepEqual((await readSubagentTrackingState(cwd)).pending_role_intents, []);
     });
   });
 
-  it('recordNativeLeaderIntent atomically rejects a native anchor also tracked as a subagent (race: child record wins)', async () => {
+  it('recordNativeLeaderIntent rejects a parent that is not the tracker leader (parent_not_active_leader), no mutation', async () => {
     await withCwd(async (cwd) => {
-      // The child record wins the race: the native-anchor thread is recorded as a subagent
-      // in a different session before the legacy fallback runs.
+      await recordSubagentTurnForSession(cwd, { sessionId: 'sess-A', threadId: 'native-L', kind: 'leader', leaderThreadId: 'native-L', timestamp: new Date().toISOString() });
+      const res = recordNativeLeaderIntent(cwd, {
+        role: 'architect', sessionId: 'sess-A', parentThreadId: 'attacker', allowTrackerLeader: true, correlationToken: TOKEN,
+      });
+      assert.deepEqual(res, { ok: false, reason: 'parent_not_active_leader' });
+      assert.deepEqual((await readSubagentTrackingState(cwd)).pending_role_intents, []);
+    });
+  });
+
+  it('recordNativeLeaderIntent atomically rejects a tracker leader also tracked as a subagent (race: child record wins)', async () => {
+    await withCwd(async (cwd) => {
+      await recordSubagentTurnForSession(cwd, { sessionId: 'sess-A', threadId: 'native-L', kind: 'leader', leaderThreadId: 'native-L', timestamp: new Date().toISOString() });
+      // The child record wins the race: the same thread is recorded as a subagent in a
+      // different session before the legacy fallback runs.
       await recordSubagentTurnForSession(cwd, {
         sessionId: 'sess-B', threadId: 'native-L', kind: 'subagent', leaderThreadId: 'sess-B', timestamp: new Date().toISOString(),
       });
       const res = recordNativeLeaderIntent(cwd, {
-        role: 'architect', sessionId: 'sess-A', parentThreadId: 'native-L', nativeSessionId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN,
+        role: 'architect', sessionId: 'sess-A', parentThreadId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN,
       });
       assert.deepEqual(res, { ok: false, reason: 'native_anchor_mismatch' });
       assert.deepEqual((await readSubagentTrackingState(cwd)).pending_role_intents, []);
@@ -273,7 +288,7 @@ describe('#3181 leader bootstrap tracker carrier', () => {
       await mkdir(subagentTrackingPath(cwd).replace(/\/[^/]+$/, ''), { recursive: true });
       await writeFile(subagentTrackingPath(cwd), '{ corrupt not json');
       const res = recordNativeLeaderIntent(cwd, {
-        role: 'architect', sessionId: 'sess-A', parentThreadId: 'native-L', nativeSessionId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN,
+        role: 'architect', sessionId: 'sess-A', parentThreadId: 'native-L', allowTrackerLeader: true, correlationToken: TOKEN,
       });
       assert.deepEqual(res, { ok: false, reason: 'native_anchor_unavailable' });
       assert.equal(await readFile(subagentTrackingPath(cwd), 'utf-8'), '{ corrupt not json');

--- a/src/subagents/__tests__/leader-bootstrap-3181.test.ts
+++ b/src/subagents/__tests__/leader-bootstrap-3181.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
@@ -8,6 +8,8 @@ import {
   attestLeaderThread,
   ensureLeaderAndRecordIntent,
   readSubagentTrackingState,
+  recordSubagentTurnForSession,
+  subagentTrackingPath,
 } from '../tracker.js';
 
 // 32 lowercase-hex chars: the canonical correlation-token shape the CLI generates via
@@ -131,6 +133,32 @@ describe('#3181 leader bootstrap tracker carrier', () => {
       const state = await readSubagentTrackingState(cwd);
       assert.equal(state.pending_role_intents.length, 1);
       assert.equal(state.pending_role_intents[0]?.role, 'architect');
+    });
+  });
+
+  it('atomically refuses to attest a thread already tracked as a subagent (native_anchor_mismatch)', async () => {
+    await withCwd(async (cwd) => {
+      await recordSubagentTurnForSession(cwd, {
+        sessionId: 'leader-session',
+        threadId: 'child-thread',
+        kind: 'subagent',
+        leaderThreadId: 'leader-session',
+        timestamp: new Date().toISOString(),
+      });
+      const result = attestLeaderThread(cwd, { sessionId: 'child-thread', leaderThreadId: 'child-thread', source: 'native-pretooluse' });
+      assert.deepEqual(result, { ok: false, reason: 'native_anchor_mismatch' });
+      const state = await readSubagentTrackingState(cwd);
+      assert.equal(state.sessions['child-thread'], undefined);
+    });
+  });
+
+  it('fails closed (native_anchor_unavailable) when the tracker file exists but is corrupt', async () => {
+    await withCwd(async (cwd) => {
+      const path = subagentTrackingPath(cwd);
+      await mkdir(join(cwd, '.omx', 'state'), { recursive: true });
+      await writeFile(path, '{ this is not valid json');
+      const result = attestLeaderThread(cwd, { sessionId: 'sess-a', leaderThreadId: 'leader-thread-a', source: 'native-pretooluse' });
+      assert.deepEqual(result, { ok: false, reason: 'native_anchor_unavailable' });
     });
   });
 });

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -43,6 +43,14 @@ export interface TrackedSubagentThread {
 export interface TrackedSubagentSession {
   session_id: string;
   leader_thread_id?: string;
+  // #3181: durable native-hook leader attestation. The native hook (SessionStart/
+  // PreToolUse) writes these when it reconciles the canonical session pointer so a
+  // fresh in-turn `role-intent write` can authenticate the leader before the
+  // turn-completion notify path would otherwise seed tracker activity. The CLI reads
+  // `leader_thread_id` as the attested leader and MUST NOT infer it from a native
+  // session id or a caller-supplied `--parent-thread`.
+  leader_attested_at?: string;
+  leader_attest_source?: string;
   updated_at: string;
   threads: Record<string, TrackedSubagentThread>;
 }
@@ -341,6 +349,12 @@ export function normalizeSubagentTrackingState(input: unknown): SubagentTracking
 
     const sessionCandidate = rawSession as TrackedSubagentSession;
     const leaderThreadId = typeof sessionCandidate.leader_thread_id === 'string' ? sessionCandidate.leader_thread_id.trim() || undefined : undefined;
+    const leaderAttestedAt = typeof sessionCandidate.leader_attested_at === 'string' && sessionCandidate.leader_attested_at.trim().length > 0
+      ? sessionCandidate.leader_attested_at.trim()
+      : undefined;
+    const leaderAttestSource = typeof sessionCandidate.leader_attest_source === 'string' && sessionCandidate.leader_attest_source.trim().length > 0
+      ? sessionCandidate.leader_attest_source.trim()
+      : undefined;
     const updatedAt =
       typeof sessionCandidate.updated_at === 'string' && sessionCandidate.updated_at.trim().length > 0
         ? sessionCandidate.updated_at
@@ -349,6 +363,8 @@ export function normalizeSubagentTrackingState(input: unknown): SubagentTracking
     sessions[sessionId] = {
       session_id: sessionId,
       leader_thread_id: leaderThreadId,
+      ...(leaderAttestedAt ? { leader_attested_at: leaderAttestedAt } : {}),
+      ...(leaderAttestSource ? { leader_attest_source: leaderAttestSource } : {}),
       updated_at: updatedAt,
       threads,
     };
@@ -943,6 +959,150 @@ export function recordPendingRoleIntent(
     context.assertOwnership();
     writeSubagentTrackingStateSync(cwd, state, context.publish);
     return { ok: true, intent };
+  });
+}
+
+export type LeaderBootstrapFailureReason =
+  | 'unknown_role'
+  | 'invalid_correlation_token'
+  | 'invalid_origin'
+  | 'single_flight_conflict'
+  | 'native_anchor_unavailable'
+  | 'native_anchor_mismatch';
+
+/**
+ * #3181 Phase 1 carrier write. Durably attest the authenticated leader thread for a
+ * session from native-hook-reconciled metadata. Idempotent and fail-closed: it seeds
+ * `leader_thread_id` + `leader_attested_at` + `leader_attest_source` only when the
+ * session has no conflicting leader already. A different existing leader is NEVER
+ * overwritten (returns `native_anchor_mismatch`) so a stale/foreign leader cannot be
+ * replaced from a later turn. Authority for `leaderThreadId` is the caller's native
+ * payload thread; it must never be derived from a native session id.
+ */
+export function attestLeaderThread(
+  cwd: string,
+  input: { sessionId: string; leaderThreadId: string; source: string; nowMs?: number },
+): { ok: true; alreadyAttested: boolean } | { ok: false; reason: 'native_anchor_unavailable' | 'native_anchor_mismatch' } {
+  const sessionId = input.sessionId.trim();
+  const leaderThreadId = input.leaderThreadId.trim();
+  const source = input.source.trim() || 'native';
+  if (!sessionId || !leaderThreadId) return { ok: false, reason: 'native_anchor_unavailable' };
+  const nowMs = normalizeNowMs(input.nowMs);
+  const nowIso = new Date(nowMs).toISOString();
+  return withCrossProcessFileLockSync(subagentTrackingPath(cwd), (context) => {
+    const state = readSubagentTrackingStateSync(cwd);
+    const existing = state.sessions[sessionId];
+    const existingLeader = existing?.leader_thread_id?.trim();
+    if (existingLeader && existingLeader !== leaderThreadId) {
+      return { ok: false, reason: 'native_anchor_mismatch' as const };
+    }
+    if (existing && existingLeader === leaderThreadId && existing.leader_attested_at) {
+      return { ok: true, alreadyAttested: true };
+    }
+    const session: TrackedSubagentSession = existing
+      ? { ...existing }
+      : { session_id: sessionId, updated_at: nowIso, threads: {} };
+    session.leader_thread_id = leaderThreadId;
+    session.leader_attested_at = nowIso;
+    session.leader_attest_source = source;
+    session.updated_at = nowIso;
+    state.sessions = { ...state.sessions, [sessionId]: session };
+    context.assertOwnership();
+    writeSubagentTrackingStateSync(cwd, state, context.publish);
+    return { ok: true, alreadyAttested: false };
+  });
+}
+
+/**
+ * #3181 Phase 2. Single tracker-locked publish that self-heals the leader thread record
+ * from a durable native attestation and records the pending role intent in the same
+ * operation, closing the previous verify-then-record TOCTOU window. Fail-closed:
+ * requires a durable attested leader for the session (`native_anchor_unavailable`
+ * otherwise) and requires `parentThreadId` to equal the attested `leader_thread_id`
+ * (`native_anchor_mismatch` otherwise). `leaderThreadId` is never inferred from a
+ * native session id. Duplicate same-identity intents reuse the original receipt
+ * (idempotent), never a second leader or a second intent.
+ */
+export function ensureLeaderAndRecordIntent(
+  cwd: string,
+  input: {
+    role: string;
+    sessionId: string;
+    parentThreadId: string;
+    correlationToken: string;
+    ttlMs?: number;
+    nowMs?: number;
+  },
+): { ok: true; intent: PendingRoleIntent; reused: boolean } | { ok: false; reason: LeaderBootstrapFailureReason } {
+  const role = resolveInstalledRoleName(input.role);
+  if (!role) return { ok: false, reason: 'unknown_role' };
+  const correlationToken = input.correlationToken;
+  if (!isCanonicalCorrelationToken(correlationToken)) {
+    return { ok: false, reason: 'invalid_correlation_token' };
+  }
+  const nowMs = normalizeNowMs(input.nowMs);
+  const sessionId = input.sessionId.trim();
+  const parentThreadId = input.parentThreadId.trim();
+  const canonicalOrigin = canonicalizeOriginCwd(cwd);
+  if (canonicalOrigin === null) return { ok: false, reason: 'invalid_origin' };
+  const { isOwn, shouldPruneExpired } = pendingRoleIntentPredicates(cwd, canonicalOrigin, nowMs);
+  return withCrossProcessFileLockSync(subagentTrackingPath(cwd), (context) => {
+    const state = readSubagentTrackingStateSync(cwd);
+    const session = state.sessions[sessionId];
+    const attestedLeader = session?.leader_thread_id?.trim();
+    // Fail closed unless a durable native attestation established the leader anchor.
+    if (!session || !attestedLeader || !session.leader_attested_at) {
+      return { ok: false, reason: 'native_anchor_unavailable' as const };
+    }
+    if (parentThreadId !== attestedLeader) {
+      return { ok: false, reason: 'native_anchor_mismatch' as const };
+    }
+
+    // Idempotent reuse: a live own intent for this exact identity returns its original
+    // receipt instead of creating a second intent.
+    const all = state.pending_role_intents;
+    const existingIntent = all.find((intent) => (
+      isOwn(intent)
+      && intent.role === role
+      && intent.session_id === sessionId
+      && intent.parent_thread_id === parentThreadId
+      && (intent.binding_state === 'bound' || !isExpiredPendingRoleIntent(intent, nowMs))
+    ));
+    if (existingIntent) {
+      return { ok: true, intent: existingIntent, reused: true };
+    }
+
+    // Self-heal the leader thread record so leader-anchor consumers see kind:"leader".
+    const nowIso = new Date(nowMs).toISOString();
+    const nextSession: TrackedSubagentSession = { ...session, threads: { ...session.threads } };
+    const existingLeaderThread = nextSession.threads[attestedLeader];
+    if (!existingLeaderThread || existingLeaderThread.kind !== 'leader') {
+      nextSession.threads[attestedLeader] = {
+        ...(existingLeaderThread ?? {}),
+        thread_id: attestedLeader,
+        kind: 'leader',
+        first_seen_at: existingLeaderThread?.first_seen_at ?? nowIso,
+        last_seen_at: nowIso,
+        turn_count: existingLeaderThread?.turn_count ?? 0,
+      };
+    }
+    nextSession.updated_at = nowIso;
+
+    const ttlMs = typeof input.ttlMs === 'number' && Number.isFinite(input.ttlMs) ? input.ttlMs : 10 * 60_000;
+    const intent: PendingRoleIntent = {
+      role,
+      session_id: sessionId,
+      parent_thread_id: parentThreadId,
+      correlation_token: correlationToken,
+      created_at: nowIso,
+      expires_at: new Date(nowMs + ttlMs).toISOString(),
+      ...(canonicalOrigin ? { origin_cwd: canonicalOrigin } : {}),
+    };
+    state.sessions = { ...state.sessions, [sessionId]: nextSession };
+    state.pending_role_intents = [...all.filter((candidate) => !shouldPruneExpired(candidate)), intent];
+    context.assertOwnership();
+    writeSubagentTrackingStateSync(cwd, state, context.publish);
+    return { ok: true, intent, reused: false };
   });
 }
 

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -1179,6 +1179,101 @@ export function ensureLeaderAndRecordIntent(
   });
 }
 
+export type NativeLeaderIntentFailureReason = LeaderBootstrapFailureReason | 'parent_not_active_leader';
+
+/**
+ * #3181 legacy/native fallback, made atomic. When no durable attestation exists, an
+ * in-turn role intent may still be authorized against a native-session leader anchor
+ * (the reconciled session pointer's native_session_id and/or the tracker
+ * leader_thread_id from real turns). This is the strict tracker-locked equivalent of the
+ * former CLI "activeLeaderThreadIds + recordPendingRoleIntent" fallback: it validates the
+ * native-session binding AND rejects any all-session subagent counter-evidence under the
+ * same lock as the intent write, so a subagent record that lands after a pre-check (or a
+ * PreToolUse attestation that lost its race) can never be downgraded into an
+ * unvalidated legacy authorization. Fail-closed: unreadable/corrupt tracker →
+ * native_anchor_unavailable; parent not a native leader anchor → parent_not_active_leader;
+ * parent tracked as a subagent anywhere → native_anchor_mismatch.
+ */
+export function recordNativeLeaderIntent(
+  cwd: string,
+  input: {
+    role: string;
+    sessionId: string;
+    parentThreadId: string;
+    nativeSessionId?: string;
+    allowTrackerLeader: boolean;
+    correlationToken: string;
+    ttlMs?: number;
+    nowMs?: number;
+  },
+): { ok: true; intent: PendingRoleIntent; reused: boolean } | { ok: false; reason: NativeLeaderIntentFailureReason } {
+  const role = resolveInstalledRoleName(input.role);
+  if (!role) return { ok: false, reason: 'unknown_role' };
+  const correlationToken = input.correlationToken;
+  if (!isCanonicalCorrelationToken(correlationToken)) {
+    return { ok: false, reason: 'invalid_correlation_token' };
+  }
+  const nowMs = normalizeNowMs(input.nowMs);
+  const sessionId = input.sessionId.trim();
+  const parentThreadId = input.parentThreadId.trim();
+  const nativeSessionId = input.nativeSessionId?.trim();
+  const canonicalOrigin = canonicalizeOriginCwd(cwd);
+  if (canonicalOrigin === null) return { ok: false, reason: 'invalid_origin' };
+  const { isOwn, shouldPruneExpired } = pendingRoleIntentPredicates(cwd, canonicalOrigin, nowMs);
+  return withCrossProcessFileLockSync(subagentTrackingPath(cwd), (context) => {
+    const read = readSubagentTrackingStateSyncStrict(cwd);
+    if (!read.ok) return { ok: false, reason: 'native_anchor_unavailable' as const };
+    const state = read.state;
+
+    // Native leader anchors, recomputed under the lock.
+    const acceptable = new Set<string>();
+    if (nativeSessionId) acceptable.add(nativeSessionId);
+    if (input.allowTrackerLeader) {
+      const trackerLeader = state.sessions[sessionId]?.leader_thread_id?.trim();
+      if (trackerLeader) acceptable.add(trackerLeader);
+    }
+    if (!parentThreadId || !acceptable.has(parentThreadId)) {
+      return { ok: false, reason: 'parent_not_active_leader' as const };
+    }
+    // Atomic all-session subagent exclusion: a parent thread recorded as a subagent in ANY
+    // session is never a valid leader, even if it matches a native anchor.
+    if (threadIsTrackedAsSubagent(state, parentThreadId)) {
+      return { ok: false, reason: 'native_anchor_mismatch' as const };
+    }
+
+    // Role-agnostic single-flight (same contract as recordPendingRoleIntent).
+    const all = state.pending_role_intents;
+    const liveOwnIntent = all.find((intent) => (
+      isOwn(intent)
+      && intent.session_id === sessionId
+      && intent.parent_thread_id === parentThreadId
+      && (intent.binding_state === 'bound' || !isExpiredPendingRoleIntent(intent, nowMs))
+    ));
+    if (liveOwnIntent) {
+      if (liveOwnIntent.role === role) {
+        return { ok: true, intent: liveOwnIntent, reused: true };
+      }
+      return { ok: false, reason: 'single_flight_conflict' };
+    }
+
+    const nowIso = new Date(nowMs).toISOString();
+    const ttlMs = typeof input.ttlMs === 'number' && Number.isFinite(input.ttlMs) ? input.ttlMs : 10 * 60_000;
+    const intent: PendingRoleIntent = {
+      role,
+      session_id: sessionId,
+      parent_thread_id: parentThreadId,
+      correlation_token: correlationToken,
+      created_at: nowIso,
+      expires_at: new Date(nowMs + ttlMs).toISOString(),
+      ...(canonicalOrigin ? { origin_cwd: canonicalOrigin } : {}),
+    };
+    state.pending_role_intents = [...all.filter((candidate) => !shouldPruneExpired(candidate)), intent];
+    context.assertOwnership();
+    writeSubagentTrackingStateSync(cwd, state, context.publish);
+    return { ok: true, intent, reused: false };
+  });
+}
+
 export function bindPendingRoleIntentUnderLock(
   cwd: string,
   input: { sessionId: string; parentThreadId: string; correlationToken?: string; nowMs?: number },

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -772,9 +772,17 @@ function readSubagentTrackingStateSync(cwd: string): SubagentTrackingState {
 // be bypassed. Callers making a security decision (attest vs deny) use these.
 function readSubagentTrackingStateSyncStrict(cwd: string): { ok: true; state: SubagentTrackingState } | { ok: false } {
   const path = subagentTrackingPath(cwd);
-  if (!existsSync(path)) return { ok: true, state: createSubagentTrackingState() };
+  let raw: string;
   try {
-    return { ok: true, state: normalizeSubagentTrackingState(JSON.parse(readFileSync(path, 'utf-8'))) };
+    raw = readFileSync(path, 'utf-8');
+  } catch (error) {
+    // Only a genuine ENOENT (no file) is a clean empty state. Any other read/access error
+    // (permissions, I/O, ELOOP, …) must fail closed rather than be treated as empty.
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return { ok: true, state: createSubagentTrackingState() };
+    return { ok: false };
+  }
+  try {
+    return { ok: true, state: normalizeSubagentTrackingState(JSON.parse(raw)) };
   } catch {
     return { ok: false };
   }
@@ -782,9 +790,15 @@ function readSubagentTrackingStateSyncStrict(cwd: string): { ok: true; state: Su
 
 export async function readSubagentTrackingStateStrict(cwd: string): Promise<{ ok: true; state: SubagentTrackingState } | { ok: false }> {
   const path = subagentTrackingPath(cwd);
-  if (!existsSync(path)) return { ok: true, state: createSubagentTrackingState() };
+  let raw: string;
   try {
-    return { ok: true, state: normalizeSubagentTrackingState(JSON.parse(await readFile(path, 'utf-8'))) };
+    raw = await readFile(path, 'utf-8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return { ok: true, state: createSubagentTrackingState() };
+    return { ok: false };
+  }
+  try {
+    return { ok: true, state: normalizeSubagentTrackingState(JSON.parse(raw)) };
   } catch {
     return { ok: false };
   }
@@ -1090,7 +1104,11 @@ export function ensureLeaderAndRecordIntent(
   if (canonicalOrigin === null) return { ok: false, reason: 'invalid_origin' };
   const { isOwn, shouldPruneExpired } = pendingRoleIntentPredicates(cwd, canonicalOrigin, nowMs);
   return withCrossProcessFileLockSync(subagentTrackingPath(cwd), (context) => {
-    const state = readSubagentTrackingStateSync(cwd);
+    // Strict read under the lock: an unreadable/corrupt tracker fails closed rather than
+    // being treated as empty state.
+    const read = readSubagentTrackingStateSyncStrict(cwd);
+    if (!read.ok) return { ok: false, reason: 'native_anchor_unavailable' as const };
+    const state = read.state;
     const session = state.sessions[sessionId];
     const attestedLeader = session?.leader_thread_id?.trim();
     // Fail closed unless a durable native attestation established the leader anchor.
@@ -1098,6 +1116,13 @@ export function ensureLeaderAndRecordIntent(
       return { ok: false, reason: 'native_anchor_unavailable' as const };
     }
     if (parentThreadId !== attestedLeader) {
+      return { ok: false, reason: 'native_anchor_mismatch' as const };
+    }
+    // Symmetric subagent exclusion: independent of which writer won the tracker lock, a
+    // leader thread that is ALSO recorded as a subagent in ANY session (even a different
+    // one) must never receive an adapted role intent. Re-scanned here under the intent-write
+    // lock so a cross-session child record committed after attestation cannot slip through.
+    if (threadIsTrackedAsSubagent(state, attestedLeader)) {
       return { ok: false, reason: 'native_anchor_mismatch' as const };
     }
 

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -1182,17 +1182,19 @@ export function ensureLeaderAndRecordIntent(
 export type NativeLeaderIntentFailureReason = LeaderBootstrapFailureReason | 'parent_not_active_leader';
 
 /**
- * #3181 legacy/native fallback, made atomic. When no durable attestation exists, an
- * in-turn role intent may still be authorized against a native-session leader anchor
- * (the reconciled session pointer's native_session_id and/or the tracker
- * leader_thread_id from real turns). This is the strict tracker-locked equivalent of the
- * former CLI "activeLeaderThreadIds + recordPendingRoleIntent" fallback: it validates the
- * native-session binding AND rejects any all-session subagent counter-evidence under the
- * same lock as the intent write, so a subagent record that lands after a pre-check (or a
- * PreToolUse attestation that lost its race) can never be downgraded into an
- * unvalidated legacy authorization. Fail-closed: unreadable/corrupt tracker →
- * native_anchor_unavailable; parent not a native leader anchor → parent_not_active_leader;
- * parent tracked as a subagent anywhere → native_anchor_mismatch.
+ * #3181 legacy/native fallback, made atomic and positive-provenance-only. When no durable
+ * attestation exists, an in-turn role intent may still be authorized ONLY against the
+ * tracker leader_thread_id — the positively-provenanced leader thread set by a real
+ * recorded leader turn (notify) or by PreToolUse attestation (gated when the caller has a
+ * usable current pointer). It deliberately does NOT trust the reconciled session.json
+ * native_session_id, which an ambiguous/malformed-child SessionStart can set. This is the
+ * strict tracker-locked replacement for the former CLI "activeLeaderThreadIds +
+ * recordPendingRoleIntent" fallback: it validates the leader anchor AND rejects any
+ * all-session subagent counter-evidence under the same lock as the intent write, so a
+ * subagent record landing after a pre-check (or a PreToolUse attestation that lost its
+ * race) can never be downgraded into an unvalidated legacy authorization. Fail-closed:
+ * unreadable/corrupt tracker → native_anchor_unavailable; parent not the tracker leader →
+ * parent_not_active_leader; parent tracked as a subagent anywhere → native_anchor_mismatch.
  */
 export function recordNativeLeaderIntent(
   cwd: string,
@@ -1200,7 +1202,6 @@ export function recordNativeLeaderIntent(
     role: string;
     sessionId: string;
     parentThreadId: string;
-    nativeSessionId?: string;
     allowTrackerLeader: boolean;
     correlationToken: string;
     ttlMs?: number;
@@ -1216,7 +1217,6 @@ export function recordNativeLeaderIntent(
   const nowMs = normalizeNowMs(input.nowMs);
   const sessionId = input.sessionId.trim();
   const parentThreadId = input.parentThreadId.trim();
-  const nativeSessionId = input.nativeSessionId?.trim();
   const canonicalOrigin = canonicalizeOriginCwd(cwd);
   if (canonicalOrigin === null) return { ok: false, reason: 'invalid_origin' };
   const { isOwn, shouldPruneExpired } = pendingRoleIntentPredicates(cwd, canonicalOrigin, nowMs);
@@ -1225,18 +1225,18 @@ export function recordNativeLeaderIntent(
     if (!read.ok) return { ok: false, reason: 'native_anchor_unavailable' as const };
     const state = read.state;
 
-    // Native leader anchors, recomputed under the lock.
-    const acceptable = new Set<string>();
-    if (nativeSessionId) acceptable.add(nativeSessionId);
-    if (input.allowTrackerLeader) {
-      const trackerLeader = state.sessions[sessionId]?.leader_thread_id?.trim();
-      if (trackerLeader) acceptable.add(trackerLeader);
-    }
-    if (!parentThreadId || !acceptable.has(parentThreadId)) {
+    // Positive-provenance leader anchor ONLY: the tracker leader_thread_id is set by a real
+    // recorded leader turn (notify) or by PreToolUse attestation. It is intentionally NOT
+    // the reconciled session.json native_session_id, which an ambiguous/malformed-child
+    // SessionStart can set without positively classifying a root — trusting that pointer
+    // would re-open false-leader adoption. A malformed child never obtains a tracker leader
+    // thread, so it fails closed here.
+    const trackerLeader = input.allowTrackerLeader ? state.sessions[sessionId]?.leader_thread_id?.trim() : undefined;
+    if (!parentThreadId || !trackerLeader || parentThreadId !== trackerLeader) {
       return { ok: false, reason: 'parent_not_active_leader' as const };
     }
     // Atomic all-session subagent exclusion: a parent thread recorded as a subagent in ANY
-    // session is never a valid leader, even if it matches a native anchor.
+    // session is never a valid leader, even if it matches the tracker leader anchor.
     if (threadIsTrackedAsSubagent(state, parentThreadId)) {
       return { ok: false, reason: 'native_anchor_mismatch' as const };
     }

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -1514,6 +1514,11 @@ export function recordSubagentTurn(state: SubagentTrackingState, input: RecordSu
   normalized.sessions[sessionId] = {
     session_id: sessionId,
     ...(leaderThreadId ? { leader_thread_id: leaderThreadId } : {}),
+    // #3181: preserve the durable native leader attestation across ordinary turn writes.
+    // Dropping these would let a normal child SessionStart/bind erase authentication and
+    // silently downgrade later role-intent writes to the legacy (non-atomic) path.
+    ...(existingSession.leader_attested_at ? { leader_attested_at: existingSession.leader_attested_at } : {}),
+    ...(existingSession.leader_attest_source ? { leader_attest_source: existingSession.leader_attest_source } : {}),
     updated_at: timestamp,
     threads,
   };

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -766,6 +766,39 @@ function readSubagentTrackingStateSync(cwd: string): SubagentTrackingState {
   }
 }
 
+// #3181: strict readers for the leader-attestation security decision. A missing file is a
+// legitimate empty state (fresh turn), but an existing file that fails to read/parse must
+// NOT be silently treated as empty — that would let corrupt/unreadable subagent evidence
+// be bypassed. Callers making a security decision (attest vs deny) use these.
+function readSubagentTrackingStateSyncStrict(cwd: string): { ok: true; state: SubagentTrackingState } | { ok: false } {
+  const path = subagentTrackingPath(cwd);
+  if (!existsSync(path)) return { ok: true, state: createSubagentTrackingState() };
+  try {
+    return { ok: true, state: normalizeSubagentTrackingState(JSON.parse(readFileSync(path, 'utf-8'))) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+export async function readSubagentTrackingStateStrict(cwd: string): Promise<{ ok: true; state: SubagentTrackingState } | { ok: false }> {
+  const path = subagentTrackingPath(cwd);
+  if (!existsSync(path)) return { ok: true, state: createSubagentTrackingState() };
+  try {
+    return { ok: true, state: normalizeSubagentTrackingState(JSON.parse(await readFile(path, 'utf-8'))) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function threadIsTrackedAsSubagent(state: SubagentTrackingState, threadId: string): boolean {
+  const id = threadId.trim();
+  if (!id) return false;
+  for (const session of Object.values(state.sessions)) {
+    if (session.threads[id]?.kind === 'subagent') return true;
+  }
+  return false;
+}
+
 function writeSubagentTrackingStateSync(
   cwd: string,
   state: SubagentTrackingState,
@@ -990,7 +1023,17 @@ export function attestLeaderThread(
   const nowMs = normalizeNowMs(input.nowMs);
   const nowIso = new Date(nowMs).toISOString();
   return withCrossProcessFileLockSync(subagentTrackingPath(cwd), (context) => {
-    const state = readSubagentTrackingStateSync(cwd);
+    // Strict read under the lock: an unreadable/corrupt tracker denies attestation
+    // (fail closed) rather than silently reading empty.
+    const read = readSubagentTrackingStateSyncStrict(cwd);
+    if (!read.ok) return { ok: false, reason: 'native_anchor_unavailable' as const };
+    const state = read.state;
+    // Atomic positive counter-evidence: a thread tracked as a subagent in ANY session is
+    // never attested as a leader. Checked under the same lock as the write so a concurrent
+    // child record cannot race in between a caller's pre-check and this attestation.
+    if (threadIsTrackedAsSubagent(state, leaderThreadId)) {
+      return { ok: false, reason: 'native_anchor_mismatch' as const };
+    }
     const existing = state.sessions[sessionId];
     const existingLeader = existing?.leader_thread_id?.trim();
     if (existingLeader && existingLeader !== leaderThreadId) {

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -1058,18 +1058,23 @@ export function ensureLeaderAndRecordIntent(
       return { ok: false, reason: 'native_anchor_mismatch' as const };
     }
 
-    // Idempotent reuse: a live own intent for this exact identity returns its original
-    // receipt instead of creating a second intent.
+    // Single-flight, role-agnostic (preserves recordPendingRoleIntent's invariant): a
+    // live/bound own intent for the same (session, parent) blocks a second live intent.
+    // Same-identity (same role) retries reuse the original receipt (idempotent); a
+    // different-role request for the same live parent returns single_flight_conflict
+    // rather than creating a second ambiguous intent.
     const all = state.pending_role_intents;
-    const existingIntent = all.find((intent) => (
+    const liveOwnIntent = all.find((intent) => (
       isOwn(intent)
-      && intent.role === role
       && intent.session_id === sessionId
       && intent.parent_thread_id === parentThreadId
       && (intent.binding_state === 'bound' || !isExpiredPendingRoleIntent(intent, nowMs))
     ));
-    if (existingIntent) {
-      return { ok: true, intent: existingIntent, reused: true };
+    if (liveOwnIntent) {
+      if (liveOwnIntent.role === role) {
+        return { ok: true, intent: liveOwnIntent, reused: true };
+      }
+      return { ok: false, reason: 'single_flight_conflict' };
     }
 
     // Self-heal the leader thread record so leader-anchor consumers see kind:"leader".


### PR DESCRIPTION
## Summary

Fixes #3181: on a fresh Codex Desktop/App-origin, outside-tmux `omx exec` turn, the first required command

```text
omx ralplan role-intent write --role architect --parent-thread "$CODEX_THREAD_ID" --json
{"ok":false,"reason":"missing_session"}
```

failed before the first Architect spawn because no authenticated leader/session/tracker state existed in-turn — `resolveRuntimeStateScope` found no sessionId, and the leader tracker entry is only written by the turn-completion notify path (too late for an in-turn spawn).

Independently reproduced against exact `dev` before any change (empty workspace, env session ids unset → `missing_session`, exit 1), then fixed with the consensus-approved **native-hook authenticates → CLI tracker self-heals → fail-closed** synthesis. Authority stays where it is verifiable (the native hook payload), never the CLI environment or a caller-supplied `--parent-thread`.

## Changes

- **tracker (`src/subagents/tracker.ts`)** — durable leader attestation carrier on the session record (`leader_thread_id` + `leader_attested_at` + `leader_attest_source`), preserved through normalization. New `attestLeaderThread()` (idempotent; refuses to overwrite a conflicting existing leader → `native_anchor_mismatch`) and `ensureLeaderAndRecordIntent()` (single tracker-locked publish that self-heals the leader thread record from the durable attestation and records the pending intent in one operation, closing the prior verify-then-record TOCTOU window; duplicate same-identity intents reuse the original receipt).
- **native hook (`src/scripts/codex-native-hook.ts`)** — Phase-1 attestation on the non-subagent SessionStart reconcile branch and on a fresh **leader** PreToolUse (which fires before the first in-turn shell command). Strictly gated: absent pointer, present native session id, leader-shaped thread (`thread_id == native session id`), and no typed-role / `thread_spawn` subagent provenance (new `hasSubagentThreadSpawnProvenance` guard). Best-effort; never blocks the hook.
- **CLI (`src/cli/ralplan.ts`)** — authenticated sessions route through `ensureLeaderAndRecordIntent`; fail-closed with distinct machine reasons (`native_anchor_unavailable` / `native_anchor_mismatch`) instead of the opaque `missing_session`; `leaderThreadId` is read only from the attestation (never inferred from a native session id); `--parent-thread` must equal the attested leader; `spawn_task_name` is rebuilt from the persisted correlation token for idempotent reuse. The legacy native/tracker-leader path is preserved.

## Contract / safety

- Authenticated identity only; fail-closed on ambiguity/mismatch; never trusts caller-labelled roles or fabricates native/adapted provenance.
- Preserves the distinct-thread, completion, role-match, Architect-before-Critic, marker/receipt, and consensus gates from #3118/#3152/#3166.

## Tests

- `subagents/__tests__/leader-bootstrap-3181` (5), `cli/__tests__/ralplan-bootstrap-3181` (5, incl. idempotency + durable bootstrap-order recovery), `scripts/__tests__/role-intent-bootstrap-e2e-3181` (2, SessionStart + PreToolUse end-to-end).
- No regressions: full `codex-native-hook` suite **555/555** (incl. all #3116/#3117/#3118 leader-anchor + consensus gates), `subagents` **81/81**, existing `ralplan role-intent write` **4/4**. Lint + `check:no-unused` clean.

## Owner decision required before merge

Per the consensus plan, whether the fail-closed preflight should also become a **public `omx ralplan preflight` command** (editing the `ralplan` skill contract in source + plugin mirror) is held for owner confirmation. This PR implements the write-time fail-closed check inside `role-intent write` (defense in depth) and does **not** add that public command/skill-contract surface. Follow-up items: remaining explicit plugin/legacy hook-dispatch-ordering fixtures and the `state_root_foreign` / `durable_intent_malformed` negatives.

Do not merge without exact-head hosted CI green and a fresh hostile MERGE_READY verdict.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
