### PR TITLE
fix(ralplan): require strict direct review order

### DIFF
--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -5661,8 +5661,8 @@ describe('applyRalplanGate', () => {
         ralplan_consensus_gate: {
           complete: true,
           sequence: ['architect-review', 'critic-review'],
-          ralplan_architect_review: { agent_role: 'architect', verdict: 'approve', iteration: 1 },
-          ralplan_critic_review: { agent_role: 'critic', verdict: 'approve', iteration: 1 },
+          ralplan_architect_review: { agent_role: 'architect', verdict: 'approve', iteration: 1, sequence_index: 1 },
+          ralplan_critic_review: { agent_role: 'critic', verdict: 'approve', iteration: 1, sequence_index: 2 },
         },
       }));
 
@@ -5733,8 +5733,8 @@ describe('applyRalplanGate', () => {
         ralplan_consensus_gate: {
           complete: true,
           sequence: ['architect-review', 'critic-review'],
-          ralplan_architect_review: { agent_role: 'architect', verdict: 'approve', iteration: 1 },
-          ralplan_critic_review: { agent_role: 'critic', verdict: 'approve', iteration: 1 },
+          ralplan_architect_review: { agent_role: 'architect', verdict: 'approve', iteration: 1, sequence_index: 1 },
+          ralplan_critic_review: { agent_role: 'critic', verdict: 'approve', iteration: 1, sequence_index: 2 },
         },
       }));
 

--- a/src/pipeline/__tests__/orchestrator.test.ts
+++ b/src/pipeline/__tests__/orchestrator.test.ts
@@ -577,8 +577,8 @@ describe('Pipeline Orchestrator', () => {
         planning_complete: true,
         ralplan_consensus_gate: {
           complete: true,
-          ralplan_architect_review: { agent_role: 'architect', verdict: 'approve', summary: 'architect ok' },
-          ralplan_critic_review: { agent_role: 'critic', verdict: 'approve', summary: 'critic ok' },
+          ralplan_architect_review: { agent_role: 'architect', verdict: 'approve', sequence_index: 1, summary: 'architect ok' },
+          ralplan_critic_review: { agent_role: 'critic', verdict: 'approve', sequence_index: 2, summary: 'critic ok' },
         },
       }));
 
@@ -598,8 +598,8 @@ describe('Pipeline Orchestrator', () => {
       assert.deepEqual(handoffs.ralplan_consensus_gate, {
         complete: true,
         sequence: ['architect-review', 'critic-review'],
-        ralplan_architect_review: { agent_role: 'architect', verdict: 'approve', summary: 'architect ok' },
-        ralplan_critic_review: { agent_role: 'critic', verdict: 'approve', summary: 'critic ok' },
+        ralplan_architect_review: { agent_role: 'architect', verdict: 'approve', sequence_index: 1, summary: 'architect ok' },
+        ralplan_critic_review: { agent_role: 'critic', verdict: 'approve', sequence_index: 2, summary: 'critic ok' },
         source: join(tempDir, '.omx', 'state', 'ralplan-state.json'),
         blockedReason: null,
       });

--- a/src/pipeline/__tests__/stages.test.ts
+++ b/src/pipeline/__tests__/stages.test.ts
@@ -195,8 +195,8 @@ describe('RALPLAN Stage', () => {
           ralplanConsensusGate: {
             complete: true,
             sequence: ['architect-review', 'critic-review'],
-            ralplan_architect_review: { agent_role: 'architect', verdict: 'approve' },
-            ralplan_critic_review: { agent_role: 'critic', verdict: 'approve' },
+            ralplan_architect_review: { agent_role: 'architect', verdict: 'approve', sequence_index: 1 },
+            ralplan_critic_review: { agent_role: 'critic', verdict: 'approve', sequence_index: 2 },
           },
         },
       },
@@ -219,8 +219,8 @@ describe('RALPLAN Stage', () => {
         ralplan: {
           ralplanConsensusGate: {
             complete: true,
-            ralplan_architect_review: { agent_role: 'architect', verdict: 'approve', summary: 'architect approved' },
-            ralplan_critic_review: { agent_role: 'critic', verdict: 'approve', summary: 'critic approved after architect' },
+            ralplan_architect_review: { agent_role: 'architect', verdict: 'approve', sequence_index: 1, summary: 'architect approved' },
+            ralplan_critic_review: { agent_role: 'critic', verdict: 'approve', sequence_index: 2, summary: 'critic approved after architect' },
           },
         },
       },
@@ -362,8 +362,8 @@ describe('RALPLAN Stage', () => {
     await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({
       state: {
         handoff_artifacts: {
-          ralplan_architect_review: { agent_role: 'architect', verdict: 'approve' },
-          ralplan_critic_review: { agent_role: 'critic', verdict: 'approve' },
+          ralplan_architect_review: { agent_role: 'architect', verdict: 'approve', sequence_index: 1 },
+          ralplan_critic_review: { agent_role: 'critic', verdict: 'approve', sequence_index: 2 },
         },
       },
     }));
@@ -840,8 +840,8 @@ describe('RALPLAN Stage', () => {
     assert.deepEqual(artifacts.ralplanConsensusGate, {
       complete: true,
       sequence: ['architect-review', 'critic-review'],
-      ralplan_architect_review: { agent_role: 'architect', iteration: 1, verdict: 'approve', summary: 'architect ok' },
-      ralplan_critic_review: { agent_role: 'critic', iteration: 1, verdict: 'approve', summary: 'critic ok' },
+      ralplan_architect_review: { agent_role: 'architect', iteration: 1, sequence_index: 1, verdict: 'approve', summary: 'architect ok' },
+      ralplan_critic_review: { agent_role: 'critic', iteration: 1, sequence_index: 2, verdict: 'approve', summary: 'critic ok' },
       source: 'runtime-result',
       blockedReason: null,
     });

--- a/src/ralplan/__tests__/consensus-gate.test.ts
+++ b/src/ralplan/__tests__/consensus-gate.test.ts
@@ -204,6 +204,147 @@ describe('ralplan consensus gate state roots', () => {
   });
 
 
+  it('requires strict direct Architect-before-Critic order evidence', () => {
+    const buildGate = (
+      form: 'explicit' | 'fallback',
+      architectOrder?: string,
+      criticOrder?: string,
+    ) => {
+      const architectReview = {
+        agent_role: 'architect',
+        verdict: 'approve',
+        ...(architectOrder ? { completed_at: architectOrder } : {}),
+      };
+      const criticReview = {
+        agent_role: 'critic',
+        verdict: 'approve',
+        ...(criticOrder ? { completed_at: criticOrder } : {}),
+      };
+      return buildRalplanConsensusGateFromSources([{
+        source: `direct-order-${form}`,
+        value: form === 'explicit'
+          ? {
+            ralplan_consensus_gate: {
+              complete: true,
+              sequence: ['architect-review', 'critic-review'],
+              ralplan_architect_review: architectReview,
+              ralplan_critic_review: criticReview,
+            },
+          }
+          : {
+            sequence: ['architect-review', 'critic-review'],
+            ralplan_architect_review: architectReview,
+            ralplan_critic_review: criticReview,
+          },
+      }]);
+    };
+
+    for (const form of ['explicit', 'fallback'] as const) {
+      const valid = buildGate(form, '2026-06-12T10:00:00.000Z', '2026-06-12T10:05:00.000Z');
+      assert.equal(valid.complete, true);
+
+      for (const gate of [
+        buildGate(form, '2026-06-12T10:00:00.000Z', '2026-06-12T10:00:00.000Z'),
+        buildGate(form, '2026-06-12T10:05:00.000Z', '2026-06-12T10:00:00.000Z'),
+        buildGate(form, undefined, '2026-06-12T10:05:00.000Z'),
+        buildGate(form, '2026-06-12T10:00:00.000Z', undefined),
+      ]) {
+        assert.equal(gate.complete, false);
+        assert.equal(
+          gate.blockedReason,
+          form === 'explicit'
+            ? 'non_approving_ralplan_consensus_review'
+            : 'missing_sequential_architect_then_critic_approval',
+        );
+        if (form === 'explicit') {
+          assert.match(gate.blockedDetails?.join(' ') ?? '', /direct review order is not proven strictly architect-before-critic/i);
+        }
+      }
+    }
+  });
+
+  it('uses sequence order authoritatively and rejects contradictory timestamps', () => {
+    const buildGate = (
+      architectSequence: number | undefined,
+      criticSequence: number | undefined,
+      architectCompletedAt?: string,
+      criticCompletedAt?: string,
+    ) => buildRalplanConsensusGateFromSources([{
+      source: 'sequence-order',
+      value: {
+        ralplan_consensus_gate: {
+          complete: true,
+          sequence: ['architect-review', 'critic-review'],
+          ralplan_architect_review: {
+            agent_role: 'architect',
+            verdict: 'approve',
+            ...(architectSequence === undefined ? {} : { sequence_index: architectSequence }),
+            ...(architectCompletedAt ? { completed_at: architectCompletedAt } : {}),
+          },
+          ralplan_critic_review: {
+            agent_role: 'critic',
+            verdict: 'approve',
+            ...(criticSequence === undefined ? {} : { sequence_index: criticSequence }),
+            ...(criticCompletedAt ? { completed_at: criticCompletedAt } : {}),
+          },
+        },
+      },
+    }]);
+
+    assert.equal(buildGate(1, 2).complete, true);
+    assert.equal(buildGate(2, 1).complete, false);
+    assert.equal(buildGate(1, 1).complete, false);
+    assert.equal(buildGate(1, undefined).complete, false);
+    assert.equal(buildGate(undefined, 2).complete, false);
+    assert.equal(
+      buildGate(1, 2, '2026-06-12T10:05:00.000Z', '2026-06-12T10:00:00.000Z').complete,
+      false,
+    );
+    assert.equal(
+      buildGate(2, 1, '2026-06-12T10:00:00.000Z', '2026-06-12T10:05:00.000Z').complete,
+      false,
+    );
+  });
+
+  it('does not compare timestamp and sequence freshness domains', () => {
+    const timestampConsensus = {
+      ralplan_consensus_gate: {
+        complete: true,
+        sequence: ['architect-review', 'critic-review'],
+        ralplan_architect_review: {
+          agent_role: 'architect',
+          verdict: 'approve',
+          completed_at: '2026-06-12T10:00:00.000Z',
+        },
+        ralplan_critic_review: {
+          agent_role: 'critic',
+          verdict: 'approve',
+          completed_at: '2026-06-12T10:05:00.000Z',
+        },
+      },
+    };
+    const sequenceConsensus = {
+      ralplan_consensus_gate: {
+        complete: true,
+        sequence: ['architect-review', 'critic-review'],
+        ralplan_architect_review: { agent_role: 'architect', verdict: 'approve', sequence_index: 3 },
+        ralplan_critic_review: { agent_role: 'critic', verdict: 'approve', sequence_index: 4 },
+      },
+    };
+
+    const timestampFirst = buildRalplanConsensusGateFromSources([
+      { source: 'timestamp-first', value: timestampConsensus },
+      { source: 'sequence-second', value: sequenceConsensus },
+    ]);
+    assert.equal(timestampFirst.source, 'timestamp-first');
+
+    const sequenceFirst = buildRalplanConsensusGateFromSources([
+      { source: 'sequence-first', value: sequenceConsensus },
+      { source: 'timestamp-second', value: timestampConsensus },
+    ]);
+    assert.equal(sequenceFirst.source, 'sequence-first');
+  });
+
   it('rejects malformed complete consensus even when it appears after a valid source', () => {
     const validConsensus = {
       ralplan_consensus_gate: {
@@ -1096,9 +1237,13 @@ describe('ralplan consensus gate state roots', () => {
     const sessionId = 'sess-native-consensus-ok';
     try {
       await writeNativeSubagentTracking(cwd, sessionId);
+      const consensus = nativeConsensus(sessionId);
+      const reviews = consensus.ralplan_consensus_gate as Record<string, Record<string, unknown>>;
+      delete reviews.ralplan_architect_review!.completed_at;
+      delete reviews.ralplan_critic_review!.completed_at;
       const gate = buildRalplanConsensusGateFromSources([{
         source: 'native-consensus',
-        value: nativeConsensus(sessionId),
+        value: consensus,
       }], { cwd, sessionId });
 
       assert.equal(gate.complete, true);
@@ -1263,9 +1408,13 @@ describe('ralplan consensus gate state roots', () => {
     const sessionId = 'sess-adapted-consensus-ok';
     try {
       await writeAdaptedSubagentTracking(cwd, sessionId);
+      const consensus = adaptedConsensus(sessionId);
+      const reviews = consensus.ralplan_consensus_gate as Record<string, Record<string, unknown>>;
+      delete reviews.ralplan_architect_review!.completed_at;
+      delete reviews.ralplan_critic_review!.completed_at;
       const gate = buildRalplanConsensusGateFromSources([{
         source: 'adapted-consensus',
-        value: adaptedConsensus(sessionId),
+        value: consensus,
       }], { cwd, sessionId });
 
       assert.equal(gate.complete, true);

--- a/src/ralplan/__tests__/runtime.test.ts
+++ b/src/ralplan/__tests__/runtime.test.ts
@@ -189,6 +189,7 @@ describe('ralplan runtime', () => {
         ralplan_architect_review: {
           agent_role: 'architect',
           iteration: 1,
+          sequence_index: 1,
           verdict: 'approve',
           summary: 'architect-ok',
           artifacts: { architected: true },
@@ -196,6 +197,7 @@ describe('ralplan runtime', () => {
         ralplan_critic_review: {
           agent_role: 'critic',
           iteration: 1,
+          sequence_index: 2,
           verdict: 'approve',
           summary: 'critic-ok',
           artifacts: { critiqued: true },
@@ -203,6 +205,7 @@ describe('ralplan runtime', () => {
         architect_review: {
           agent_role: 'architect',
           iteration: 1,
+          sequence_index: 1,
           verdict: 'approve',
           summary: 'architect-ok',
           artifacts: { architected: true },
@@ -210,6 +213,7 @@ describe('ralplan runtime', () => {
         critic_review: {
           agent_role: 'critic',
           iteration: 1,
+          sequence_index: 2,
           verdict: 'approve',
           summary: 'critic-ok',
           artifacts: { critiqued: true },

--- a/src/ralplan/consensus-gate.ts
+++ b/src/ralplan/consensus-gate.ts
@@ -407,7 +407,7 @@ function resolveDirectGate(record: Record<string, unknown>): ConsensusResolution
         blockedDetails.push('consensus review sequence is not architect-review then critic-review');
       }
       if (!isCriticNotBeforeArchitect(architectReview, criticReview)) {
-        blockedDetails.push('critic review is ordered before architect review');
+        blockedDetails.push('direct review order is not proven strictly architect-before-critic');
       }
       if (blockedDetails.length > 0) {
         return {
@@ -483,7 +483,8 @@ function isConsensusEvidenceNewerThanSelected(
   if (evidenceOrder !== null || selectedOrder !== null) {
     if (selectedOrder === null) return true;
     if (evidenceOrder === null) return false;
-    if (evidenceOrder !== selectedOrder) return evidenceOrder > selectedOrder;
+    if (evidenceOrder.domain !== selectedOrder.domain) return false;
+    if (evidenceOrder.value !== selectedOrder.value) return evidenceOrder.value > selectedOrder.value;
   }
 
   return false;
@@ -496,11 +497,13 @@ function consensusEvidenceReviewCycle(evidence: ConsensusResolution): number | n
   );
 }
 
-function consensusEvidenceOrder(evidence: ConsensusResolution): number | null {
-  return maxKnownNumber(
-    reviewOrderValue(evidence.ralplan_architect_review ?? {}),
-    reviewOrderValue(evidence.ralplan_critic_review ?? {}),
-  );
+function consensusEvidenceOrder(evidence: ConsensusResolution): ReviewOrder | null {
+  const architectOrder = reviewOrderValue(evidence.ralplan_architect_review ?? {});
+  const criticOrder = reviewOrderValue(evidence.ralplan_critic_review ?? {});
+  if (architectOrder === null) return criticOrder;
+  if (criticOrder === null) return architectOrder;
+  if (architectOrder.domain !== criticOrder.domain) return null;
+  return architectOrder.value >= criticOrder.value ? architectOrder : criticOrder;
 }
 
 function maxKnownNumber(left: number | null, right: number | null): number | null {
@@ -588,26 +591,57 @@ function hasArchitectThenCriticSequence(value: Record<string, unknown>): boolean
   return value.sequence[0] === 'architect-review' && value.sequence[1] === 'critic-review';
 }
 
+interface ReviewOrder {
+  domain: 'sequence' | 'timestamp';
+  value: number;
+}
+
 function isCriticNotBeforeArchitect(
   architectReview: Record<string, unknown> | null,
   criticReview: Record<string, unknown> | null,
 ): boolean {
   if (!architectReview || !criticReview) return false;
-  const architectOrder = reviewOrderValue(architectReview);
-  const criticOrder = reviewOrderValue(criticReview);
-  return architectOrder === null || criticOrder === null || criticOrder >= architectOrder;
+  if (isTrackerBackedReview(architectReview) || isTrackerBackedReview(criticReview)) return true;
+
+  const architectSequence = reviewSequenceValue(architectReview);
+  const criticSequence = reviewSequenceValue(criticReview);
+  if (architectSequence !== null || criticSequence !== null) {
+    if (architectSequence === null || criticSequence === null || criticSequence <= architectSequence) return false;
+    const architectTimestamp = reviewTimestampValue(architectReview);
+    const criticTimestamp = reviewTimestampValue(criticReview);
+    return architectTimestamp === null || criticTimestamp === null || criticTimestamp > architectTimestamp;
+  }
+
+  const architectTimestamp = reviewTimestampValue(architectReview);
+  const criticTimestamp = reviewTimestampValue(criticReview);
+  return architectTimestamp !== null && criticTimestamp !== null && criticTimestamp > architectTimestamp;
 }
 
-function reviewOrderValue(review: Record<string, unknown>): number | null {
+function isTrackerBackedReview(review: Record<string, unknown>): boolean {
+  return review.provenance_kind === 'native_subagent' || review.provenance_kind === 'omx_adapted';
+}
+
+function reviewOrderValue(review: Record<string, unknown>): ReviewOrder | null {
+  const sequence = reviewSequenceValue(review);
+  if (sequence !== null) return { domain: 'sequence', value: sequence };
+  const timestamp = reviewTimestampValue(review);
+  return timestamp === null ? null : { domain: 'timestamp', value: timestamp };
+}
+
+function reviewSequenceValue(review: Record<string, unknown>): number | null {
+  for (const key of ['sequence_index', 'order', 'review_order']) {
+    const raw = review[key];
+    const parsed = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : Number.NaN;
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function reviewTimestampValue(review: Record<string, unknown>): number | null {
   for (const key of ['completed_at', 'created_at', 'updated_at', 'timestamp', 'ts']) {
     const raw = review[key];
     if (typeof raw !== 'string') continue;
     const parsed = Date.parse(raw);
-    if (Number.isFinite(parsed)) return parsed;
-  }
-  for (const key of ['sequence_index', 'order', 'review_order', 'iteration']) {
-    const raw = review[key];
-    const parsed = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : Number.NaN;
     if (Number.isFinite(parsed)) return parsed;
   }
   return null;

--- a/src/ralplan/runtime.ts
+++ b/src/ralplan/runtime.ts
@@ -51,6 +51,7 @@ export interface RalplanReviewResult {
   lane_id?: string;
   tracker_path?: string;
   new_lane_reason?: string;
+  sequence_index?: number;
 }
 
 export interface RalplanConsensusGate {
@@ -220,14 +221,13 @@ function buildRalplanConsensusGate(
       critic_review: ralplanCriticReview,
       blocked_reason: null,
     };
-    if (!options.requireNativeSubagents) return gate;
     const evidenceGate = buildRalplanConsensusGateFromSources([{
       source: 'runtime-result',
       value: { ralplan_consensus_gate: gate },
     }], {
       cwd: options.cwd,
       sessionId: options.sessionId,
-      requireNativeSubagents: true,
+      requireNativeSubagents: options.requireNativeSubagents,
     });
     return {
       ...gate,
@@ -275,6 +275,7 @@ function normalizeReviewForLane(
   review: RalplanReviewResult,
   laneRole: 'architect' | 'critic',
   options: { requireNativeSubagents?: boolean },
+  sequenceIndex: number,
 ): RalplanReviewResult {
   if (review.agent_role !== undefined && review.agent_role !== laneRole) {
     throw new Error(`ralplan_${laneRole}_review_role_mismatch: expected agent_role=${laneRole}, received ${String(review.agent_role)}`);
@@ -282,7 +283,13 @@ function normalizeReviewForLane(
   if (review.agent_role === undefined && (options.requireNativeSubagents || hasNativeOrThreadEvidence(review))) {
     throw new Error(`ralplan_${laneRole}_review_role_missing: native or thread-backed ${laneRole} review must declare agent_role=${laneRole}`);
   }
-  return { ...review, agent_role: laneRole };
+  return {
+    ...review,
+    agent_role: laneRole,
+    ...(review.provenance_kind === 'native_subagent' || review.provenance_kind === 'omx_adapted'
+      ? {}
+      : { sequence_index: sequenceIndex }),
+  };
 }
 
 function nonEmptyString(value: unknown): string | undefined {
@@ -442,7 +449,7 @@ export async function runRalplanConsensus(
       const architectReview = normalizeReviewForLane(await executor.architectReview({
         ...iterationContext,
         draft,
-      }), 'architect', gateOptions);
+      }), 'architect', gateOptions, (iteration * 2) - 1);
       assertRoleLaneReuse(reusableRoleLanes.architect, architectReview, 'architect');
       architectReviews.push(architectReview);
       if (architectReview.artifacts) Object.assign(aggregatedArtifacts, architectReview.artifacts);
@@ -513,7 +520,7 @@ export async function runRalplanConsensus(
         ...iterationContext,
         draft,
         architectReview,
-      }), 'critic', gateOptions);
+      }), 'critic', gateOptions, iteration * 2);
       assertRoleLaneReuse(reusableRoleLanes.critic, criticReview, 'critic');
       criticReviews.push(criticReview);
       if (criticReview.artifacts) Object.assign(aggregatedArtifacts, criticReview.artifacts);

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -153,6 +153,7 @@ function ralplanConsensusGate(
     ralplan_architect_review: {
       agent_role: 'architect',
       verdict: 'approve',
+      sequence_index: 1,
       provenance_kind: provenanceKind,
       session_id: sessionId,
       thread_id: architectThread,
@@ -162,6 +163,7 @@ function ralplanConsensusGate(
     ralplan_critic_review: {
       agent_role: 'critic',
       verdict: 'approve',
+      sequence_index: 2,
       provenance_kind: provenanceKind,
       session_id: sessionId,
       thread_id: criticThread,


### PR DESCRIPTION
## Summary

- require direct non-tracker Ralplan consensus reviews to provide strict Architect-before-Critic ordering evidence
- assign monotonic `sequence_index` values to runtime-produced direct Architect and Critic reviews
- reject contradictory direct sequence/timestamp evidence and keep incomparable freshness domains from numerically competing
- preserve tracker-ledger ordering authority for native and OMX-adapted reviews
- update downstream fixtures and add adversarial ordering/freshness regressions

## Verification

- `npm test` — passed all 383 test files; catalog check passed
- focused affected suites — 6 files passed, 491 tests passed
- final Ralplan suites after diagnostic cleanup — 54 tests passed
- `git diff --check`
- exact head: `0dcceac0c`

## Scope

Refs #3132.

#3138 is explicitly excluded.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*