### PR TITLE
fix(#3181): attest SessionStart-reconciled leader in PreToolUse

### DIFF
--- a/src/scripts/__tests__/role-intent-bootstrap-e2e-3181.test.ts
+++ b/src/scripts/__tests__/role-intent-bootstrap-e2e-3181.test.ts
@@ -1,11 +1,14 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 
 import { ralplanCommand } from '../../cli/ralplan.js';
 import { readSubagentTrackingState, recordSubagentTurnForSession } from '../../subagents/tracker.js';
+import { parseRoleIntentCorrelationToken } from '../../leader/contract.js';
 import { dispatchCodexNativeHook } from '../codex-native-hook.js';
 
 async function invokeRoleIntent(cwd: string, args: string[]) {
@@ -19,6 +22,31 @@ async function invokeRoleIntent(cwd: string, args: string[]) {
   } finally {
     process.exitCode = previous;
   }
+}
+
+function compiledPath(...segments: string[]): string {
+  return resolve(process.cwd(), 'dist', ...segments);
+}
+
+function buildHermeticChildEnvironment(home: string, codexHome: string): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = { ...process.env, HOME: home, CODEX_HOME: codexHome };
+  for (const key of [
+    'OMX_ROOT', 'OMX_STATE_ROOT', 'OMX_TEAM_STATE_ROOT', 'OMX_SESSION_ID', 'OMX_RUN_ID',
+    'OMX_ACTIVE_SESSION_PID', 'OMX_SOURCE_CWD', 'OMX_STARTUP_CWD', 'OMX_TEAM_WORKER',
+    'OMX_TEAM_INTERNAL_WORKER', 'OMX_TEAM_LEADER_CWD', 'OMX_TEAM_MODE',
+    'OMX_QUESTION_RETURN_PANE', 'OMX_LEADER_PANE_ID', 'OMX_TMUX_HUD_OWNER',
+    'CODEX_SESSION_ID', 'CODEX_THREAD_ID', 'CODEX_TURN_ID', 'SESSION_ID', 'TMUX', 'TMUX_PANE',
+  ]) delete environment[key];
+  return environment;
+}
+
+function runCompiled(cwd: string, environment: NodeJS.ProcessEnv, script: string, args: string[], input?: Record<string, unknown>) {
+  return spawnSync(process.execPath, [compiledPath(script), ...args], {
+    cwd,
+    env: environment,
+    input: input ? JSON.stringify(input) : undefined,
+    encoding: 'utf8',
+  });
 }
 
 describe('#3181 end-to-end fresh App turn bootstrap', () => {
@@ -104,6 +132,110 @@ describe('#3181 end-to-end fresh App turn bootstrap', () => {
     }
   });
 
+  it('compiled SessionStart then PreToolUse attests the same native leader before the actual role-intent CLI dispatch', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-3181-e2e-compiled-'));
+    const home = await mkdtemp(join(tmpdir(), 'omx-3181-home-'));
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-3181-codex-home-'));
+    const environment = buildHermeticChildEnvironment(home, codexHome);
+    const nativeSessionId = 'codex-native-compiled-leader';
+    try {
+      assert.equal(existsSync(join(cwd, '.omx', 'state', 'session.json')), false, 'compiled fixture must start without a canonical pointer');
+      assert.equal(existsSync(join(cwd, '.omx', 'state', 'subagent-tracking.json')), false, 'compiled fixture must start without a tracker');
+      const sessionStart = runCompiled(cwd, environment, 'scripts/codex-native-hook.js', [], {
+        hook_event_name: 'SessionStart', cwd, session_id: nativeSessionId,
+      });
+      assert.equal(sessionStart.status, 0, String(sessionStart.stderr));
+      assert.equal((await readSubagentTrackingState(cwd)).sessions[nativeSessionId]?.leader_attested_at, undefined);
+      const unattestedCli = runCompiled(cwd, environment, 'cli/omx.js', [
+        'ralplan', 'role-intent', 'write', '--role', 'architect', '--parent-thread', nativeSessionId, '--json',
+      ]);
+      assert.notEqual(unattestedCli.status, 0, 'SessionStart-only state must not authorize the actual CLI');
+      assert.deepEqual(JSON.parse(String(unattestedCli.stdout)), { ok: false, reason: 'parent_not_active_leader' });
+
+      const preToolUse = runCompiled(cwd, environment, 'scripts/codex-native-hook.js', [], {
+        hook_event_name: 'PreToolUse',
+        cwd,
+        session_id: nativeSessionId,
+        thread_id: nativeSessionId,
+        tool_name: 'Bash',
+        tool_use_id: 'tool-compiled-leader',
+        tool_input: { command: 'omx ralplan role-intent write --role architect --parent-thread "$CODEX_THREAD_ID" --json' },
+      });
+      assert.equal(preToolUse.status, 0, String(preToolUse.stderr));
+      const attested = (await readSubagentTrackingState(cwd)).sessions[nativeSessionId];
+      assert.equal(attested?.leader_thread_id, nativeSessionId);
+      assert.equal(attested?.leader_attest_source, 'native-pretooluse');
+
+      const cli = runCompiled(cwd, environment, 'cli/omx.js', [
+        'ralplan', 'role-intent', 'write', '--role', 'architect', '--parent-thread', nativeSessionId, '--json',
+      ]);
+      assert.equal(cli.status, 0, String(cli.stderr));
+      const receipt = JSON.parse(String(cli.stdout)) as {
+        ok: boolean;
+        intent: { role: string; session_id: string; parent_thread_id: string; correlation_token: string };
+        spawn_task_name: string;
+      };
+      assert.equal(receipt.ok, true);
+      assert.equal(receipt.intent.role, 'architect');
+      assert.equal(receipt.intent.parent_thread_id, nativeSessionId);
+      assert.ok(receipt.intent.session_id);
+      assert.match(receipt.spawn_task_name, /^omx_role_intent_[a-z0-9_]+$/);
+      assert.equal(parseRoleIntentCorrelationToken(receipt.spawn_task_name), receipt.intent.correlation_token);
+      const tracking = await readSubagentTrackingState(cwd);
+      assert.equal(tracking.sessions[receipt.intent.session_id]?.leader_thread_id, nativeSessionId);
+      assert.equal(tracking.pending_role_intents.length, 1);
+      assert.equal(tracking.pending_role_intents[0]?.correlation_token, receipt.intent.correlation_token);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(home, { recursive: true, force: true });
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  it('compiled foreign canonical pointer refuses PreToolUse without mutation, attestation, or role-intent authorization', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-3181-e2e-foreign-'));
+    const home = await mkdtemp(join(tmpdir(), 'omx-3181-home-foreign-'));
+    const codexHome = await mkdtemp(join(tmpdir(), 'omx-3181-codex-home-foreign-'));
+    const environment = buildHermeticChildEnvironment(home, codexHome);
+    const canonicalNativeSessionId = 'codex-native-canonical-a';
+    const foreignNativeSessionId = 'codex-native-foreign-b';
+    try {
+      assert.equal(runCompiled(cwd, environment, 'scripts/codex-native-hook.js', [], {
+        hook_event_name: 'SessionStart', cwd, session_id: canonicalNativeSessionId,
+      }).status, 0);
+      const pointerPath = join(cwd, '.omx', 'state', 'session.json');
+      const pointerBefore = await readFile(pointerPath);
+      const trackerBefore = await readSubagentTrackingState(cwd);
+
+      const preToolUse = runCompiled(cwd, environment, 'scripts/codex-native-hook.js', [], {
+        hook_event_name: 'PreToolUse',
+        cwd,
+        session_id: foreignNativeSessionId,
+        thread_id: foreignNativeSessionId,
+        tool_name: 'Bash',
+        tool_use_id: 'tool-foreign-leader',
+        tool_input: { command: 'omx ralplan role-intent write --role architect --parent-thread "$CODEX_THREAD_ID" --json' },
+      });
+      assert.equal(preToolUse.status, 0, String(preToolUse.stderr));
+      assert.deepEqual(await readFile(pointerPath), pointerBefore, 'foreign PreToolUse must not replace or mutate the canonical pointer');
+      const state = await readSubagentTrackingState(cwd);
+      assert.equal(state.sessions[foreignNativeSessionId]?.leader_attested_at, undefined);
+      assert.deepEqual(state.pending_role_intents, []);
+      assert.deepEqual(state, trackerBefore, 'foreign PreToolUse must not add an A or B attestation or role intent');
+
+      const cli = runCompiled(cwd, environment, 'cli/omx.js', [
+        'ralplan', 'role-intent', 'write', '--role', 'architect', '--parent-thread', foreignNativeSessionId, '--json',
+      ]);
+      assert.notEqual(cli.status, 0, 'foreign native thread must not authorize the actual CLI');
+      assert.deepEqual(JSON.parse(String(cli.stdout)), { ok: false, reason: 'parent_not_active_leader' });
+      assert.deepEqual(await readSubagentTrackingState(cwd), trackerBefore, 'foreign CLI denial must preserve both-session tracker state');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(home, { recursive: true, force: true });
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
   it('never attests a thread durably tracked as a subagent, even via a source-less leader-shaped PreToolUse', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-3181-e2e-child-'));
     const priorEnv = { OMX_SESSION_ID: process.env.OMX_SESSION_ID, CODEX_SESSION_ID: process.env.CODEX_SESSION_ID, SESSION_ID: process.env.SESSION_ID };
@@ -154,24 +286,31 @@ describe('#3181 end-to-end fresh App turn bootstrap', () => {
       delete process.env.OMX_SESSION_ID;
       delete process.env.CODEX_SESSION_ID;
       delete process.env.SESSION_ID;
-      const childThreadId = 'codex-native-malformed-spawn';
-      // Present-but-malformed thread_spawn carrier (blank parent id) is still child
-      // provenance and must veto leader bootstrap: no pointer, no attestation.
-      await dispatchCodexNativeHook(
-        {
-          hook_event_name: 'PreToolUse',
-          cwd,
-          session_id: childThreadId,
-          thread_id: childThreadId,
-          tool_name: 'Bash',
-          tool_use_id: 'tool-malformed-spawn',
-          source: { subagent: { thread_spawn: { parent_thread_id: '' } } },
-          tool_input: { command: 'omx ralplan role-intent write --role architect --parent-thread "$CODEX_THREAD_ID" --json' },
-        },
-        { cwd, sessionOwnerPid: process.pid },
-      );
-      const state = await readSubagentTrackingState(cwd);
-      assert.equal(state.sessions[childThreadId]?.leader_attested_at, undefined, 'malformed thread_spawn must not attest as leader');
+      for (const [index, threadSpawn] of [
+        { parent_thread_id: '' },
+        { parent_thread_id: null },
+        null,
+        '',
+        { parent_thread_id: { malformed: true } },
+      ].entries()) {
+        const childThreadId = `codex-native-malformed-spawn-${index}`;
+        await dispatchCodexNativeHook(
+          {
+            hook_event_name: 'PreToolUse',
+            cwd,
+            session_id: childThreadId,
+            thread_id: childThreadId,
+            tool_name: 'Bash',
+            tool_use_id: `tool-malformed-spawn-${index}`,
+            source: { subagent: { thread_spawn: threadSpawn } },
+            tool_input: { command: 'omx ralplan role-intent write --role architect --parent-thread "$CODEX_THREAD_ID" --json' },
+          },
+          { cwd, sessionOwnerPid: process.pid },
+        );
+        const state = await readSubagentTrackingState(cwd);
+        assert.equal(state.sessions[childThreadId]?.leader_attested_at, undefined, `thread_spawn variant ${index} must not attest as leader`);
+        assert.equal(existsSync(join(cwd, '.omx', 'state', 'session.json')), false, `thread_spawn variant ${index} must not bootstrap a pointer`);
+      }
     } finally {
       if (priorEnv.OMX_SESSION_ID !== undefined) process.env.OMX_SESSION_ID = priorEnv.OMX_SESSION_ID;
       if (priorEnv.CODEX_SESSION_ID !== undefined) process.env.CODEX_SESSION_ID = priorEnv.CODEX_SESSION_ID;
@@ -210,6 +349,81 @@ describe('#3181 end-to-end fresh App turn bootstrap', () => {
       if (priorEnv.CODEX_SESSION_ID !== undefined) process.env.CODEX_SESSION_ID = priorEnv.CODEX_SESSION_ID;
       if (priorEnv.SESSION_ID !== undefined) process.env.SESSION_ID = priorEnv.SESSION_ID;
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+  it('rejects conflicting thread carriers and every nonempty direct or nested role alias at the leader-attestation boundary', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-3181-e2e-conflicting-carriers-'));
+    const priorEnv = { OMX_SESSION_ID: process.env.OMX_SESSION_ID, CODEX_SESSION_ID: process.env.CODEX_SESSION_ID, SESSION_ID: process.env.SESSION_ID };
+    try {
+      delete process.env.OMX_SESSION_ID;
+      delete process.env.CODEX_SESSION_ID;
+      delete process.env.SESSION_ID;
+      const malformedRoleCarrierValues: unknown[] = [{ malformed: true }, [], 1, true, null];
+      const variants: Record<string, unknown>[] = [
+        { threadId: 'conflicting-thread' },
+        { owner_codex_thread_id: 'conflicting-owner' },
+        { agent_role: 'architect' },
+        { agentRole: 'architect' },
+        { agent_type: 'architect' },
+        { agentType: 'architect' },
+        { source: { subagent: { agentRole: 'architect' } } },
+        { source: { subagent: { thread_spawn: { agentType: 'architect' } } } },
+        ...malformedRoleCarrierValues.flatMap((agent_role) => [
+          { agent_role },
+          { source: { subagent: { agent_role } } },
+          { source: { subagent: { thread_spawn: { agent_role } } } },
+        ]),
+      ];
+      for (const [index, variant] of variants.entries()) {
+        const nativeSessionId = `codex-native-conflicting-${index}`;
+        await dispatchCodexNativeHook({
+          hook_event_name: 'PreToolUse', cwd, session_id: nativeSessionId, thread_id: nativeSessionId,
+          tool_name: 'Bash', tool_use_id: `tool-conflicting-${index}`,
+          tool_input: { command: 'omx ralplan role-intent write --role architect --parent-thread "$CODEX_THREAD_ID" --json' },
+          ...variant,
+        }, { cwd, sessionOwnerPid: process.pid });
+        const state = await readSubagentTrackingState(cwd);
+        assert.equal(state.sessions[nativeSessionId]?.leader_attested_at, undefined, `carrier variant ${index} must not attest`);
+        assert.deepEqual(state.pending_role_intents, [], `carrier variant ${index} must not bootstrap a role intent`);
+        assert.equal(existsSync(join(cwd, '.omx', 'state', 'session.json')), false, `carrier variant ${index} must not bootstrap a pointer`);
+      }
+    } finally {
+      if (priorEnv.OMX_SESSION_ID !== undefined) process.env.OMX_SESSION_ID = priorEnv.OMX_SESSION_ID;
+      if (priorEnv.CODEX_SESSION_ID !== undefined) process.env.CODEX_SESSION_ID = priorEnv.CODEX_SESSION_ID;
+      if (priorEnv.SESSION_ID !== undefined) process.env.SESSION_ID = priorEnv.SESSION_ID;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+  it('preserves canonical-pointer bytes when its native binding is missing, blank, or malformed', async () => {
+    const priorEnv = { OMX_SESSION_ID: process.env.OMX_SESSION_ID, CODEX_SESSION_ID: process.env.CODEX_SESSION_ID, SESSION_ID: process.env.SESSION_ID };
+    const root = await mkdtemp(join(tmpdir(), 'omx-3181-e2e-invalid-binding-'));
+    try {
+      delete process.env.OMX_SESSION_ID;
+      delete process.env.CODEX_SESSION_ID;
+      delete process.env.SESSION_ID;
+      for (const [index, nativeBinding] of [undefined, '', { malformed: true }].entries()) {
+        const cwd = join(root, String(index));
+        const nativeSessionId = `codex-native-invalid-binding-${index}`;
+        await dispatchCodexNativeHook({ hook_event_name: 'SessionStart', cwd, session_id: nativeSessionId }, { cwd, sessionOwnerPid: process.pid });
+        const pointerPath = join(cwd, '.omx', 'state', 'session.json');
+        const pointer = JSON.parse(String(await readFile(pointerPath))) as Record<string, unknown>;
+        if (nativeBinding === undefined) delete pointer.native_session_id;
+        else pointer.native_session_id = nativeBinding;
+        const invalidBytes = Buffer.from(`${JSON.stringify(pointer)}\n`);
+        await writeFile(pointerPath, invalidBytes);
+        await dispatchCodexNativeHook({
+          hook_event_name: 'PreToolUse', cwd, session_id: nativeSessionId, thread_id: nativeSessionId,
+          tool_name: 'Bash', tool_use_id: `tool-invalid-binding-${index}`,
+          tool_input: { command: 'omx ralplan role-intent write --role architect --parent-thread "$CODEX_THREAD_ID" --json' },
+        }, { cwd, sessionOwnerPid: process.pid });
+        assert.deepEqual(await readFile(pointerPath), invalidBytes, `invalid native binding variant ${index} must be byte-preserved`);
+        assert.equal((await readSubagentTrackingState(cwd)).sessions[nativeSessionId]?.leader_attested_at, undefined);
+      }
+    } finally {
+      if (priorEnv.OMX_SESSION_ID !== undefined) process.env.OMX_SESSION_ID = priorEnv.OMX_SESSION_ID;
+      if (priorEnv.CODEX_SESSION_ID !== undefined) process.env.CODEX_SESSION_ID = priorEnv.CODEX_SESSION_ID;
+      if (priorEnv.SESSION_ID !== undefined) process.env.SESSION_ID = priorEnv.SESSION_ID;
+      await rm(root, { recursive: true, force: true });
     }
   });
 });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3304,6 +3304,32 @@ function readPayloadThreadId(payload: CodexHookPayload): string {
   return safeString(payload.owner_codex_thread_id ?? payload.thread_id ?? payload.threadId).trim();
 }
 
+// #3181 leader bootstrap accepts only a single, self-consistent native thread binding.
+// `readPayloadThreadId` remains precedence-based for compatibility at ordinary call sites;
+// this stricter predicate is intentionally limited to the attestation boundary.
+function hasUnambiguousNativeLeaderThreadBinding(payload: CodexHookPayload, nativeSessionId: string): boolean {
+  const expected = nativeSessionId.trim();
+  if (!expected) return false;
+  const directThreadIds = ["thread_id", "threadId"] as const;
+  if (!directThreadIds.some((key) => safeString(payload[key]).trim() === expected)) return false;
+  return (["owner_codex_thread_id", ...directThreadIds] as const)
+    .every((key) => !Object.prototype.hasOwnProperty.call(payload, key) || safeString(payload[key]).trim() === expected);
+}
+
+function hasOnlyEmptyLeaderRoleCarriers(payload: CodexHookPayload): boolean {
+  const aliases = (carrier: Record<string, unknown>): boolean => [
+    "agent_role",
+    "agentRole",
+    "agent_type",
+    "agentType",
+  ].every((key) => !Object.prototype.hasOwnProperty.call(carrier, key)
+    || (typeof carrier[key] === "string" && carrier[key].trim() === ""));
+  const source = safeObject(payload.source);
+  const subagent = safeObject(source.subagent);
+  const threadSpawn = safeObject(subagent.thread_spawn);
+  return aliases(payload) && aliases(subagent) && aliases(threadSpawn);
+}
+
 function readPayloadAgentRole(payload: CodexHookPayload): string {
   const directRole = safeString(
     payload.agent_role
@@ -10576,46 +10602,55 @@ export async function dispatchCodexNativeHook(
     }
   } else if (hookEventName === "PreToolUse") {
     // #3181 Phase-1 (PreToolUse): this hook fires before the shell tool call that runs
-    // the first in-turn `omx ralplan role-intent write`. On a fresh App/outside-tmux
-    // turn where SessionStart did not establish the pointer, reconcile the canonical
-    // pointer and attest the leader here so the first command can bootstrap. Strictly
-    // gated to a fresh (absent-pointer) LEADER turn: no canonical session yet, a present
-    // native session id, a leader-shaped thread (absent or equal to the native session
-    // id), and no subagent/typed-role provenance. Best-effort; never blocks PreToolUse.
-    if (
-      allowImplicitSessionSideEffects
-      && !canonicalSessionId
+    // the first in-turn `omx ralplan role-intent write`. A positively-provenanced
+    // leader-shaped turn may bootstrap an absent canonical pointer, or attest the
+    // already SessionStart-reconciled canonical session. Never reconcile, replace, or
+    // attest a usable pointer whose captured native binding does not exactly match.
+    const canonicalNativeSessionId = currentSessionState
+      ? normalizeSessionId(currentSessionState.native_session_id)
+      : null;
+    const hasPositiveLeaderProvenance = allowImplicitSessionSideEffects
       && nativeSessionId
-      && readPayloadAgentRole(payload) === ""
+      && hasUnambiguousNativeLeaderThreadBinding(payload, nativeSessionId)
+      && hasOnlyEmptyLeaderRoleCarriers(payload)
       && !hasSubagentThreadSpawnProvenance(payload)
-    ) {
-      const preToolUseLeaderThreadId = readPayloadThreadId(payload);
-      if (
-        preToolUseLeaderThreadId
-        && preToolUseLeaderThreadId === nativeSessionId
-        && !(await isThreadTrackedAsSubagent(cwd, nativeSessionId))
-      ) {
-        try {
-          const ownerOmxSessionId = await resolveVerifiedOwnerOmxSessionId();
-          const sessionState = await reconcileNativeSessionStart(cwd, nativeSessionId, {
-            context: pointerContext,
-            pid: options.sessionOwnerPid ?? resolveSessionOwnerPid(payload),
-            ...(ownerOmxSessionId ? { ownerOmxSessionId, ownerAliasVerified: true } : {}),
+      && !(await isThreadTrackedAsSubagent(cwd, nativeSessionId));
+    if (hasPositiveLeaderProvenance && pointer.status === "absent") {
+      try {
+        const ownerOmxSessionId = await resolveVerifiedOwnerOmxSessionId();
+        const sessionState = await reconcileNativeSessionStart(cwd, nativeSessionId, {
+          context: pointerContext,
+          pid: options.sessionOwnerPid ?? resolveSessionOwnerPid(payload),
+          ...(ownerOmxSessionId ? { ownerOmxSessionId, ownerAliasVerified: true } : {}),
+        });
+        const bootstrapSessionId = safeString(sessionState.session_id).trim();
+        const bootstrapLeaderThreadId = safeString(sessionState.native_session_id).trim() || nativeSessionId;
+        if (bootstrapSessionId && bootstrapLeaderThreadId) {
+          canonicalSessionId = bootstrapSessionId;
+          attestLeaderThread(cwd, {
+            sessionId: bootstrapSessionId,
+            leaderThreadId: bootstrapLeaderThreadId,
+            source: 'native-pretooluse',
           });
-          const bootstrapSessionId = safeString(sessionState.session_id).trim();
-          const bootstrapLeaderThreadId = safeString(sessionState.native_session_id).trim() || nativeSessionId;
-          if (bootstrapSessionId && bootstrapLeaderThreadId) {
-            canonicalSessionId = bootstrapSessionId;
-            attestLeaderThread(cwd, {
-              sessionId: bootstrapSessionId,
-              leaderThreadId: bootstrapLeaderThreadId,
-              source: 'native-pretooluse',
-            });
-          }
-        } catch {
-          // Best-effort bootstrap; PreToolUse must never fail on this.
         }
+      } catch {
+        // Best-effort bootstrap; PreToolUse must never fail on this.
       }
+    } else if (
+      hasPositiveLeaderProvenance
+      && pointer.status === "usable"
+      && currentSessionState
+      && canonicalNativeSessionId === nativeSessionId
+      && canonicalSessionId
+    ) {
+      // SessionStart established this native binding but intentionally did not attest.
+      // Attest only the existing canonical session; reconciliation here could replace a
+      // foreign/stale pointer before the mismatch checks above reject it.
+      attestLeaderThread(cwd, {
+        sessionId: canonicalSessionId,
+        leaderThreadId: nativeSessionId,
+        source: 'native-pretooluse',
+      });
     }
     const payloadSessionId = readPayloadSessionId(payload);
     const rootPointerConflict = await readLiveRootSessionPointerConflict(stateDir, payloadSessionId);

--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -1461,6 +1461,88 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
       validateHookStdout(eventName, result.stdout as string);
     }
 
+    // #3181: exercise the installed hook and installed CLI as separate processes. This
+    // stays hermetic and bounded: no model, app-server, or network surface is involved.
+    const roleIntentCwd = join(smokeCwd, 'issue-3181-role-intent');
+    const roleIntentHome = join(roleIntentCwd, 'home');
+    const roleIntentCodexHome = join(roleIntentCwd, 'codex-home');
+    const roleIntentNativeSessionId = 'packed-issue-3181-native-leader';
+    mkdirSync(roleIntentHome, { recursive: true });
+    mkdirSync(roleIntentCodexHome, { recursive: true });
+    const roleIntentEnvironment = {
+      ...buildPackedRegressionEnvironment({ name: 'issue-3181-role-intent' }),
+      HOME: roleIntentHome,
+      CODEX_HOME: roleIntentCodexHome,
+    };
+    const sessionStartResult = run(process.execPath, [realpathSync(hookScript)], {
+      cwd: roleIntentCwd,
+      env: roleIntentEnvironment,
+      input: JSON.stringify({ hook_event_name: 'SessionStart', cwd: roleIntentCwd, session_id: roleIntentNativeSessionId }),
+    });
+    validateHookStdout('SessionStart', String(sessionStartResult.stdout || ''));
+    const sessionStartTracking: { sessions?: Record<string, { leader_attested_at?: string }> } = existsSync(join(roleIntentCwd, '.omx', 'state', 'subagent-tracking.json'))
+      ? JSON.parse(readFileSync(join(roleIntentCwd, '.omx', 'state', 'subagent-tracking.json'), 'utf-8')) as {
+        sessions?: Record<string, { leader_attested_at?: string }>;
+      }
+      : {};
+    if (sessionStartTracking.sessions?.[roleIntentNativeSessionId]?.leader_attested_at) {
+      throw new Error('installed #3181 SessionStart must not attest a leader');
+    }
+    const preToolUseResult = run(process.execPath, [realpathSync(hookScript)], {
+      cwd: roleIntentCwd,
+      env: roleIntentEnvironment,
+      input: JSON.stringify({
+        hook_event_name: 'PreToolUse',
+        cwd: roleIntentCwd,
+        session_id: roleIntentNativeSessionId,
+        thread_id: roleIntentNativeSessionId,
+        tool_name: 'Bash',
+        tool_use_id: 'packed-issue-3181-pretooluse',
+        tool_input: { command: 'omx ralplan role-intent write --role architect --parent-thread "$CODEX_THREAD_ID" --json' },
+      }),
+    });
+    validateHookStdout('PreToolUse', String(preToolUseResult.stdout || ''));
+    const roleIntentTracking = JSON.parse(readFileSync(join(roleIntentCwd, '.omx', 'state', 'subagent-tracking.json'), 'utf-8')) as {
+      sessions?: Record<string, { leader_thread_id?: string; leader_attested_at?: string; leader_attest_source?: string }>;
+      pending_role_intents?: Array<{ role?: string; correlation_token?: string }>;
+    };
+    const roleIntentLeader = roleIntentTracking.sessions?.[roleIntentNativeSessionId];
+    if (
+      roleIntentLeader?.leader_thread_id !== roleIntentNativeSessionId
+      || !roleIntentLeader.leader_attested_at
+      || roleIntentLeader.leader_attest_source !== 'native-pretooluse'
+    ) {
+      throw new Error('installed #3181 PreToolUse did not attest the canonical native leader with native-pretooluse provenance');
+    }
+    const roleIntentCliResult = run(process.execPath, [realpathSync(join(packageRoot, 'dist', 'cli', 'omx.js')), 'ralplan', 'role-intent', 'write', '--role', 'architect', '--parent-thread', roleIntentNativeSessionId, '--json'], {
+      cwd: roleIntentCwd,
+      env: roleIntentEnvironment,
+    });
+    if (roleIntentCliResult.status !== 0) throw new Error(`installed #3181 role-intent CLI failed: ${String(roleIntentCliResult.stderr || '')}`);
+    const roleIntentReceipt = JSON.parse(String(roleIntentCliResult.stdout || '{}')) as {
+      ok?: boolean;
+      intent?: { role?: string; correlation_token?: string };
+      spawn_task_name?: string;
+    };
+    const finalRoleIntentTracking = JSON.parse(readFileSync(join(roleIntentCwd, '.omx', 'state', 'subagent-tracking.json'), 'utf-8')) as {
+      pending_role_intents?: Array<{ role?: string; correlation_token?: string }>;
+    };
+    if (!roleIntentReceipt.ok || roleIntentReceipt.intent?.role !== 'architect' || !roleIntentReceipt.intent.correlation_token) {
+      throw new Error('installed #3181 role-intent CLI did not authorize an Architect receipt');
+    }
+    const spawnTaskName = roleIntentReceipt.spawn_task_name || '';
+    if (!/^omx_role_intent_[a-z0-9_]+$/.test(spawnTaskName)) {
+      throw new Error('installed #3181 role-intent CLI returned an invalid App-compatible spawn_task_name');
+    }
+    if (
+      finalRoleIntentTracking.pending_role_intents?.length !== 1
+      || finalRoleIntentTracking.pending_role_intents[0]?.role !== 'architect'
+      || finalRoleIntentTracking.pending_role_intents[0]?.correlation_token !== roleIntentReceipt.intent.correlation_token
+      || !spawnTaskName.endsWith(roleIntentReceipt.intent.correlation_token)
+    ) {
+      throw new Error('installed #3181 must leave exactly one correlated Architect pending intent/receipt');
+    }
+
     for (const [caseIndex, testCase] of PACKED_INSTALL_NATIVE_HOOK_REGRESSION_PROMPTS.entries()) {
       const caseCwd = join(smokeCwd, testCase.name);
       const sessionId = `packed-regression-${caseIndex}`;


### PR DESCRIPTION
Closes #3181

## Root cause
A fresh outside-tmux turn can deliver `SessionStart` before `PreToolUse`. `SessionStart` safely reconciles the canonical pointer but never attests; the old PreToolUse gate only bootstrapped when no pointer existed, so the first role-intent CLI call failed `parent_not_active_leader`.

## Fix
- Keep SessionStart reconciliation-only.
- Split the strictly-provenanced PreToolUse path:
  - absent pointer: existing reconcile-then-attest bootstrap;
  - usable pointer: attest only the already-reconciled canonical session when its captured native binding exactly matches the event.
- Reject conflicting/malformed thread and role carriers, structural `thread_spawn`, durable subagents, foreign/malformed pointers, and corrupt authority evidence without mutation.
- No CLI/tracker self-heal authority path.

## Deterministic regression
The primary CI test executes compiled `dist/scripts/codex-native-hook.js` for SessionStart and PreToolUse, inspects durable attestation before dispatch, then invokes the actual compiled `dist/cli/omx.js ralplan role-intent write` CLI. It also proves SessionStart-only denial and byte-preserving foreign/malformed negatives.

Red-before/green-after:
- exact pre-fix `f5e4753135ebc86342e7353300ac3ec5d9ae3d8d`: new compiled SessionStart→PreToolUse test fails with missing leader attestation;
- exact candidate `3ce88fb50df1ac7241d8d1621d09b3fda00baeee`: focused 38-test matrix passes.

## Verification
- `npm ci`
- `npm run build`
- focused #3181 compiled/CLI/tracker/recovery matrix: 38 passed
- `npm run lint`
- `npm run check:no-unused`
- `npm run build:full`
- `git diff --check origin/dev...HEAD`
- hostile exact-head review: `MERGE_READY`, `CLEAR`, no P0/P1

`npm test` and `npm run smoke:packed-install` reach an existing environment precondition failure because this host has Codex CLI `0.144.4` while the smoke contract is pinned to `0.142.5`; the #3181 packed scenario is therefore not claimed as passed. The installed-package scenario is included as supplementary evidence, while the deterministic compiled hook→actual CLI test is the required gate.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*