### PR TITLE
fix: tolerate Windows regular-file fsync EPERM

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -30,7 +30,14 @@ import {
 	checkNativePostCompactHookRuntime,
 	checkNativeHooks,
 	classifyPostCompactHookStdout,
+	doctor,
+	setDoctorClaimJournalDurabilityForTest,
 } from "../doctor.js";
+import {
+	createNativeHookClaimJournalDurability,
+	persistNativeHookClaimJournal,
+} from "../native-hook-claim-journal.js";
+import { syncRegularFile } from "../../utils/file-durability.js";
 import {
 	buildManagedCodexNativeHookCommand,
 	buildManagedCodexNativeHookWindowsShimContent,
@@ -172,6 +179,44 @@ function buildHooksJsonWithPostCompactCommand(
 			]),
 		),
 	}, null, 2)}\n`;
+}
+
+async function withRecoverableDoctorClaimJournal<T>(
+	run: (codexHomeDir: string) => Promise<T>,
+): Promise<T> {
+	const wd = await mkdtemp(join(tmpdir(), "omx-doctor-claim-recovery-"));
+	const codexHomeDir = join(wd, ".codex");
+	const hooksPath = join(codexHomeDir, "hooks.json");
+	const claimPath = join(codexHomeDir, ".hooks.json.omx-claim-test.tmp");
+	const previousCwd = process.cwd();
+	const previousCodexHome = process.env.CODEX_HOME;
+	try {
+		await mkdir(codexHomeDir, { recursive: true });
+		await writeFile(hooksPath, "{\"hooks\":{}}\n");
+		await persistNativeHookClaimJournal(
+			codexHomeDir,
+			{
+				canonicalPath: hooksPath,
+				claimPath,
+				before: Buffer.from("{\"hooks\":{}}\n"),
+				after: null,
+			},
+			createNativeHookClaimJournalDurability(),
+		);
+		await rename(hooksPath, claimPath);
+		const journalPath = join(codexHomeDir, ".omx", "native-hook-claim-journal.json");
+		const journal = JSON.parse(await readFile(journalPath, "utf-8")) as { ownerPid: number };
+		journal.ownerPid = 2_147_483_647;
+		await writeFile(journalPath, `${JSON.stringify(journal, null, 2)}\n`, "utf-8");
+		process.env.CODEX_HOME = codexHomeDir;
+		process.chdir(wd);
+		return await run(codexHomeDir);
+	} finally {
+		process.chdir(previousCwd);
+		if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+		else process.env.CODEX_HOME = previousCodexHome;
+		await rm(wd, { recursive: true, force: true });
+	}
 }
 
 describe("omx doctor onboarding warning copy", () => {
@@ -2780,5 +2825,73 @@ command = "node"
 		} finally {
 			await rm(wd, { recursive: true, force: true });
 		}
+	});
+
+	it("recovers a claim journal after Windows regular-file EPERM with one degraded-durability warning", async () => {
+		const originalStderrWrite = process.stderr.write;
+		const stderr: string[] = [];
+		try {
+			await withRecoverableDoctorClaimJournal(async (codexHomeDir) => {
+				const restoreDurability = setDoctorClaimJournalDurabilityForTest({
+					platform: "win32",
+					syncRegularFile: async () => syncRegularFile({
+						sync: async () => {
+							throw Object.assign(new Error("injected Windows EPERM"), { code: "EPERM" });
+						},
+					}, "win32"),
+					syncDirectory: async () => undefined,
+				});
+				process.stderr.write = ((chunk: string | Uint8Array) => {
+					stderr.push(String(chunk));
+					return true;
+				}) as typeof process.stderr.write;
+				try {
+					await doctor();
+					assert.equal(await readFile(join(codexHomeDir, "hooks.json"), "utf-8"), "{\"hooks\":{}}\n");
+					await assert.rejects(
+						readFile(join(codexHomeDir, ".omx", "native-hook-claim-journal.json")),
+						/ENOENT/,
+					);
+				} finally {
+					restoreDurability();
+				}
+			});
+			assert.equal(stderr.length, 1);
+			assert.match(stderr[0]!, /Windows EPERM/);
+			assert.match(stderr[0]!, /native-hook claim-journal recovery/);
+			assert.match(stderr[0]!, /degraded durability/);
+		} finally {
+			process.stderr.write = originalStderrWrite;
+		}
+	});
+
+	it("keeps non-EPERM regular-file and directory claim-journal sync failures fatal", async () => {
+		const regularError = Object.assign(new Error("injected regular-file EIO"), { code: "EIO" });
+		await withRecoverableDoctorClaimJournal(async () => {
+			const restoreDurability = setDoctorClaimJournalDurabilityForTest({
+				platform: "win32",
+				syncRegularFile: async () => { throw regularError; },
+				syncDirectory: async () => undefined,
+			});
+			try {
+				await assert.rejects(doctor(), (error) => error === regularError);
+			} finally {
+				restoreDurability();
+			}
+		});
+
+		const directoryError = Object.assign(new Error("injected directory EPERM"), { code: "EPERM" });
+		await withRecoverableDoctorClaimJournal(async () => {
+			const restoreDurability = setDoctorClaimJournalDurabilityForTest({
+				platform: "win32",
+				syncRegularFile: async () => "synced",
+				syncDirectory: async () => { throw directoryError; },
+			});
+			try {
+				await assert.rejects(doctor(), (error) => error === directoryError);
+			} finally {
+				restoreDurability();
+			}
+		});
 	});
 });

--- a/src/cli/__tests__/native-hook-claim-journal.test.ts
+++ b/src/cli/__tests__/native-hook-claim-journal.test.ts
@@ -4,10 +4,22 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import {
-	clearNativeHookClaimJournal,
-	persistNativeHookClaimJournal,
-	recoverNativeHookClaimJournal,
+	clearNativeHookClaimJournal as clearNativeHookClaimJournalWithDurability,
+	createNativeHookClaimJournalDurability,
+	persistNativeHookClaimJournal as persistNativeHookClaimJournalWithDurability,
+	recoverNativeHookClaimJournal as recoverNativeHookClaimJournalWithDurability,
 } from "../native-hook-claim-journal.js";
+
+const durability = createNativeHookClaimJournalDurability();
+
+const clearNativeHookClaimJournal = (root: string) =>
+	clearNativeHookClaimJournalWithDurability(root, durability);
+const persistNativeHookClaimJournal = (
+	root: string,
+	entry: Parameters<typeof persistNativeHookClaimJournalWithDurability>[1],
+) => persistNativeHookClaimJournalWithDurability(root, entry, durability);
+const recoverNativeHookClaimJournal = (root: string) =>
+	recoverNativeHookClaimJournalWithDurability(root, durability);
 
 async function markJournalOwnerDead(root: string): Promise<void> {
 	const path = join(root, ".omx", "native-hook-claim-journal.json");
@@ -32,9 +44,9 @@ test("claim journal restores an exact original after rename-away interruption", 
 		await rename(canonicalPath, claimPath);
 		await markJournalOwnerDead(root);
 
-		assert.equal(await recoverNativeHookClaimJournal(root), true);
+		assert.equal((await recoverNativeHookClaimJournal(root)).recovered, true);
 		assert.deepEqual(await readFile(canonicalPath), before);
-		assert.equal(await recoverNativeHookClaimJournal(root), false);
+		assert.equal((await recoverNativeHookClaimJournal(root)).recovered, false);
 	} finally {
 		await rm(root, { recursive: true, force: true });
 	}
@@ -57,7 +69,7 @@ test("claim journal finalizes an exact installed successor and removes the parke
 		});
 		await markJournalOwnerDead(root);
 
-		assert.equal(await recoverNativeHookClaimJournal(root), true);
+		assert.equal((await recoverNativeHookClaimJournal(root)).recovered, true);
 		assert.deepEqual(await readFile(canonicalPath), after);
 		await assert.rejects(readFile(claimPath), /ENOENT/);
 	} finally {
@@ -134,8 +146,91 @@ test("claim journal finalizes a completed deletion after claim removal", async (
 		});
 		await markJournalOwnerDead(root);
 
-		assert.equal(await recoverNativeHookClaimJournal(root), true);
-		assert.equal(await recoverNativeHookClaimJournal(root), false);
+		assert.equal((await recoverNativeHookClaimJournal(root)).recovered, true);
+		assert.equal((await recoverNativeHookClaimJournal(root)).recovered, false);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim journal treats only injected Windows regular-file EPERM as degraded", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-durability-"));
+	try {
+		const canonicalPath = join(root, "hooks.json");
+		const claimPath = join(root, ".hooks.json.claim");
+		const order: string[] = [];
+		const outcome = await persistNativeHookClaimJournalWithDurability(root, {
+			canonicalPath,
+			claimPath,
+			before: Buffer.from("before\n"),
+			after: null,
+		}, {
+			platform: "win32",
+			syncRegularFile: async () => {
+				order.push("regular");
+				return "unsupported-windows-eperm";
+			},
+			syncDirectory: async () => { order.push("directory"); },
+		});
+		assert.equal(outcome, "unsupported-windows-eperm");
+		assert.deepEqual(order, ["directory", "regular", "directory"]);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim journal keeps POSIX regular-file and directory EPERM fatal", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-durability-fatal-"));
+	try {
+		const entry = {
+			canonicalPath: join(root, "hooks.json"),
+			claimPath: join(root, ".hooks.json.claim"),
+			before: Buffer.from("before\n"),
+			after: null,
+		};
+		const regularError = Object.assign(new Error("EPERM"), { code: "EPERM" });
+		await assert.rejects(
+			persistNativeHookClaimJournalWithDurability(root, entry, {
+				platform: "linux",
+				syncRegularFile: async () => { throw regularError; },
+				syncDirectory: async () => undefined,
+			}),
+			(error) => error === regularError,
+		);
+		const directoryError = Object.assign(new Error("EPERM"), { code: "EPERM" });
+		await assert.rejects(
+			persistNativeHookClaimJournalWithDurability(root, entry, {
+				platform: "win32",
+				syncRegularFile: async () => "synced",
+				syncDirectory: async () => { throw directoryError; },
+			}),
+			(error) => error === directoryError,
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim journal recovery returns independent recovered and no-op outcomes", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-recovery-outcome-"));
+	try {
+		const canonicalPath = join(root, "hooks.json");
+		const claimPath = join(root, ".hooks.json.claim");
+		const before = Buffer.from("before\n");
+		await persistNativeHookClaimJournal(root, { canonicalPath, claimPath, before, after: null });
+		await rename(canonicalPath, claimPath).catch(() => undefined);
+		await writeFile(claimPath, before);
+		await markJournalOwnerDead(root);
+		const recovered = await recoverNativeHookClaimJournalWithDurability(root, {
+			platform: "win32",
+			syncRegularFile: async () => "unsupported-windows-eperm",
+			syncDirectory: async () => undefined,
+		});
+		assert.deepEqual(recovered, { recovered: true, outcome: "unsupported-windows-eperm" });
+		assert.deepEqual(
+			await recoverNativeHookClaimJournalWithDurability(root, durability),
+			{ recovered: false, outcome: "synced" },
+		);
 	} finally {
 		await rm(root, { recursive: true, force: true });
 	}

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -22,6 +22,7 @@ import {
 	setNativeHookTransactionFailureInjectorForTest,
 	setSetupLatePhaseFailureInjectorForTest,
 	setNativeHookTransactionPlatformForTest,
+	setNativeHookTransactionRegularFileSyncForTest,
 	setNativeHookTransactionTemporaryPathForTest,
 	setup,
 } from "../setup.js";
@@ -3186,6 +3187,46 @@ describe("omx setup install mode behavior", () => {
 				});
 			});
 		} finally {
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+	it("completes Windows native-hook transactions when regular-file fsync reports EPERM", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-fsync-eperm-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		let syncCalls = 0;
+		const stderr: string[] = [];
+		const originalStderrWrite = process.stderr.write;
+		process.stderr.write = ((chunk: string | Uint8Array) => {
+			stderr.push(String(chunk));
+			return true;
+		}) as typeof process.stderr.write;
+		const resetSync = setNativeHookTransactionRegularFileSyncForTest(async (platform) => {
+			assert.equal(platform, "win32");
+			syncCalls += 1;
+			throw Object.assign(new Error("EPERM: fsync"), { code: "EPERM" });
+		});
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({
+						scope: "user",
+						installMode: "legacy",
+						skipNativeAgentRefresh: true,
+					});
+					assert.ok(syncCalls > 0);
+					assert.equal(existsSync(join(codexHomeDir, "hooks.json")), true);
+					assert.equal(existsSync(buildManagedCodexNativeHookWindowsShimPath(codexHomeDir)), true);
+					assert.equal(existsSync(join(codexHomeDir, "config.toml")), true);
+				});
+				assert.equal(
+					stderr.filter((line) => line.includes("native-hook setup")).length,
+					1,
+				);
+			});
+		} finally {
+			process.stderr.write = originalStderrWrite;
+			resetSync();
 			resetPlatform();
 			await rm(wd, { recursive: true, force: true });
 		}

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -3118,6 +3118,54 @@ describe('omx uninstall', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+  it('warns once after a successful Windows EPERM-degraded uninstall transaction', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-durability-'));
+    const originalStderrWrite = process.stderr.write;
+    const stderr: string[] = [];
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+        await mkdir(codexDir, { recursive: true });
+        await mkdir(dirname(shimPath), { recursive: true });
+        await writeFile(configPath, buildOmxConfig());
+        await writeFile(
+          hooksPath,
+          `${JSON.stringify(buildManagedCodexHooksConfig(packageRoot(), {
+            platform: 'win32',
+            codexHomeDir: codexDir,
+          }), null, 2)}\n`,
+        );
+        await writeFile(shimPath, buildManagedCodexNativeHookWindowsShimContent(packageRoot()));
+        const syncSites: string[] = [];
+        process.stderr.write = ((chunk: string | Uint8Array) => {
+          stderr.push(String(chunk));
+          return true;
+        }) as typeof process.stderr.write;
+        await uninstall({
+          scope: 'project',
+          transactionPlatform: 'win32',
+          regularFileSyncForTest: async (site, _handle, platform) => {
+            assert.equal(platform, 'win32');
+            syncSites.push(site);
+            return 'unsupported-windows-eperm';
+          },
+        });
+        assert.deepEqual([...new Set(syncSites)].sort(), [
+          'installed-destination',
+          'replacement-temporary',
+          'staged-deletion',
+        ]);
+        assert.equal(stderr.filter((line) => line.includes('Windows EPERM')).length, 1);
+        assert.match(stderr[0]!, /native-hook uninstall.*degraded durability/);
+      });
+    } finally {
+      process.stderr.write = originalStderrWrite;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('stripOmxFeatureFlags', () => {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2,7 +2,16 @@
  * omx doctor - Validate oh-my-codex installation
  */
 
-import { recoverNativeHookClaimJournal } from "./native-hook-claim-journal.js";
+import {
+	createNativeHookClaimJournalDurability,
+	recoverNativeHookClaimJournal,
+	type NativeHookClaimJournalDurability,
+} from "./native-hook-claim-journal.js";
+import {
+	emitDegradedDurabilityWarning,
+	recordRegularFileSyncOutcome,
+	type RegularFileDurabilityTracker,
+} from "../utils/file-durability.js";
 import { constants, existsSync, readFileSync, type Stats } from "fs";
 import { access, chown, lstat, mkdtemp, readdir, readFile, rmdir, rm } from "fs/promises";
 import { spawnSync } from "child_process";
@@ -91,6 +100,19 @@ import {
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { getInstallableNativeAgentNames } from "../agents/policy.js";
 import { readCatalogManifest } from "../catalog/reader.js";
+
+let doctorClaimJournalDurabilityOverride: NativeHookClaimJournalDurability | undefined;
+
+/** @internal Test seam for deterministic claim-journal durability coverage. */
+export function setDoctorClaimJournalDurabilityForTest(
+	durability: NativeHookClaimJournalDurability | undefined,
+): () => void {
+	const previous = doctorClaimJournalDurabilityOverride;
+	doctorClaimJournalDurabilityOverride = durability;
+	return () => {
+		doctorClaimJournalDurabilityOverride = previous;
+	};
+}
 
 interface DoctorOptions {
 	verbose?: boolean;
@@ -266,7 +288,13 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 	const cwd = process.cwd();
 	const scopeResolution = await resolveDoctorScope(cwd);
 	const paths = resolveDoctorPaths(cwd, scopeResolution.scope);
-	await recoverNativeHookClaimJournal(paths.codexHomeDir);
+	const recoveryTracker: RegularFileDurabilityTracker = { degraded: false };
+	const recovery = await recoverNativeHookClaimJournal(
+		paths.codexHomeDir,
+		doctorClaimJournalDurabilityOverride ?? createNativeHookClaimJournalDurability(),
+	);
+	recordRegularFileSyncOutcome(recoveryTracker, recovery.outcome);
+	emitDegradedDurabilityWarning("native-hook claim-journal recovery", recoveryTracker);
 	const scopeSourceMessage =
 		scopeResolution.source === "persisted"
 			? " (from .omx/setup-scope.json)"

--- a/src/cli/native-hook-claim-journal.ts
+++ b/src/cli/native-hook-claim-journal.ts
@@ -1,7 +1,17 @@
 import { createHash } from "crypto";
 import { constants } from "fs";
-import { copyFile, link, open, lstat, mkdir, readFile, rm } from "fs/promises";
+import { copyFile, link, open, lstat, mkdir, readFile, rm, type FileHandle } from "fs/promises";
 import { dirname, isAbsolute, join, relative, sep } from "path";
+import {
+	syncRegularFile,
+	type RegularFileSyncOutcome,
+} from "../utils/file-durability.js";
+
+export interface NativeHookClaimJournalDurability {
+	platform: NodeJS.Platform;
+	syncRegularFile(handle: Pick<FileHandle, "sync">): Promise<RegularFileSyncOutcome>;
+	syncDirectory(path: string): Promise<void>;
+}
 
 interface ClaimJournalEntry {
 	version: 1;
@@ -47,14 +57,28 @@ async function fsyncDirectory(path: string): Promise<void> {
 	}
 }
 
-export async function syncNativeHookClaimParent(path: string): Promise<void> {
-	await fsyncDirectory(dirname(path));
+export function createNativeHookClaimJournalDurability(
+	platform: NodeJS.Platform = process.platform,
+): NativeHookClaimJournalDurability {
+	return {
+		platform,
+		syncRegularFile: (handle) => syncRegularFile(handle, platform),
+		syncDirectory: fsyncDirectory,
+	};
+}
+
+export async function syncNativeHookClaimParent(
+	path: string,
+	durability: NativeHookClaimJournalDurability,
+): Promise<void> {
+	await durability.syncDirectory(dirname(path));
 }
 
 export async function restoreNativeHookClaimNoClobber(
 	claimPath: string,
 	destinationPath: string,
-): Promise<void> {
+	durability: NativeHookClaimJournalDurability,
+): Promise<RegularFileSyncOutcome> {
 	const claimStat = await lstat(claimPath);
 	if (claimStat.isSymbolicLink() || !claimStat.isFile() || claimStat.nlink !== 1) {
 		throw new Error(`Native hook claim restore refuses unsafe claim ${claimPath}.`);
@@ -74,12 +98,13 @@ export async function restoreNativeHookClaimNoClobber(
 		await copyFile(claimPath, destinationPath, constants.COPYFILE_EXCL);
 	}
 	const destinationHandle = await open(destinationPath, "r");
+	let outcome: RegularFileSyncOutcome;
 	try {
-		await destinationHandle.sync();
+		outcome = await durability.syncRegularFile(destinationHandle);
 	} finally {
 		await destinationHandle.close();
 	}
-	await fsyncDirectory(dirname(destinationPath));
+	await durability.syncDirectory(dirname(destinationPath));
 	const [currentClaimStat, currentClaimBytes, destinationBytes, destinationStat] = await Promise.all([
 		lstat(claimPath),
 		readFile(claimPath),
@@ -96,7 +121,8 @@ export async function restoreNativeHookClaimNoClobber(
 		throw new Error(`Native hook claim changed during restore: ${claimPath}.`);
 	}
 	await rm(claimPath);
-	await fsyncDirectory(dirname(claimPath));
+	await durability.syncDirectory(dirname(claimPath));
+	return outcome;
 }
 
 async function readRegularBytes(path: string): Promise<Buffer | null> {
@@ -122,7 +148,8 @@ export async function persistNativeHookClaimJournal(
 		before: Buffer;
 		after: Buffer | null;
 	},
-): Promise<void> {
+	durability: NativeHookClaimJournalDurability,
+): Promise<RegularFileSyncOutcome> {
 	assertControlledPath(root, entry.canonicalPath);
 	assertControlledPath(root, entry.claimPath);
 	const directory = dirname(journalPath(root));
@@ -138,7 +165,7 @@ export async function persistNativeHookClaimJournal(
 	if (directoryStat.isSymbolicLink() || !directoryStat.isDirectory()) {
 		throw new Error(`Native hook claim journal directory is unsafe: ${directory}`);
 	}
-	if (directoryCreated) await fsyncDirectory(dirname(directory));
+	if (directoryCreated) await durability.syncDirectory(dirname(directory));
 	const path = journalPath(root);
 	const payload: ClaimJournalEntry = {
 		version: 1,
@@ -149,29 +176,37 @@ export async function persistNativeHookClaimJournal(
 		afterHash: entry.after === null ? null : digest(entry.after),
 	};
 	const handle = await open(path, "wx", 0o600);
+	let outcome: RegularFileSyncOutcome;
 	try {
 		await handle.writeFile(`${JSON.stringify(payload, null, 2)}\n`, "utf-8");
-		await handle.sync();
+		outcome = await durability.syncRegularFile(handle);
 	} catch (error) {
 		await handle.close();
 		await rm(path, { force: true });
 		throw error;
 	}
 	await handle.close();
-	await fsyncDirectory(directory);
+	await durability.syncDirectory(directory);
+	return outcome;
 }
 
-export async function clearNativeHookClaimJournal(root: string): Promise<void> {
+export async function clearNativeHookClaimJournal(
+	root: string,
+	durability: NativeHookClaimJournalDurability,
+): Promise<void> {
 	const path = journalPath(root);
 	try {
 		await rm(path);
-		await fsyncDirectory(dirname(path));
+		await durability.syncDirectory(dirname(path));
 	} catch (error) {
 		if (!isMissing(error)) throw error;
 	}
 }
 
-export async function recoverNativeHookClaimJournal(root: string): Promise<boolean> {
+export async function recoverNativeHookClaimJournal(
+	root: string,
+	durability: NativeHookClaimJournalDurability,
+): Promise<{ recovered: boolean; outcome: RegularFileSyncOutcome }> {
 	const path = journalPath(root);
 	let parsed: ClaimJournalEntry;
 	try {
@@ -181,7 +216,7 @@ export async function recoverNativeHookClaimJournal(root: string): Promise<boole
 		}
 		parsed = JSON.parse(await readFile(path, "utf-8")) as ClaimJournalEntry;
 	} catch (error) {
-		if (isMissing(error)) return false;
+		if (isMissing(error)) return { recovered: false, outcome: "synced" };
 		throw error;
 	}
 	if (
@@ -199,6 +234,7 @@ export async function recoverNativeHookClaimJournal(root: string): Promise<boole
 	if (processIsAlive(parsed.ownerPid)) {
 		throw new Error("Native hook claim journal belongs to a live mutation; recovery refused to mutate it.");
 	}
+	let outcome: RegularFileSyncOutcome = "synced";
 	try {
 		const [canonicalStat, claimStat] = await Promise.all([
 			lstat(parsed.canonicalPath),
@@ -214,9 +250,9 @@ export async function recoverNativeHookClaimJournal(root: string): Promise<boole
 				throw new Error("Native hook claim journal cannot finalize a linked restore with changed bytes.");
 			}
 			await rm(parsed.claimPath);
-			await fsyncDirectory(dirname(parsed.claimPath));
-			await clearNativeHookClaimJournal(root);
-			return true;
+			await durability.syncDirectory(dirname(parsed.claimPath));
+			await clearNativeHookClaimJournal(root, durability);
+			return { recovered: true, outcome };
 		}
 	} catch (error) {
 		if (!isMissing(error)) throw error;
@@ -227,16 +263,16 @@ export async function recoverNativeHookClaimJournal(root: string): Promise<boole
 	]);
 	if (claim === null) {
 		if (canonical === null && parsed.afterHash === null) {
-			await clearNativeHookClaimJournal(root);
-			return true;
+			await clearNativeHookClaimJournal(root, durability);
+			return { recovered: true, outcome };
 		}
 		if (canonical !== null && parsed.afterHash !== null && digest(canonical) === parsed.afterHash) {
-			await clearNativeHookClaimJournal(root);
-			return true;
+			await clearNativeHookClaimJournal(root, durability);
+			return { recovered: true, outcome };
 		}
 		if (canonical !== null && digest(canonical) === parsed.beforeHash) {
-			await clearNativeHookClaimJournal(root);
-			return true;
+			await clearNativeHookClaimJournal(root, durability);
+			return { recovered: true, outcome };
 		}
 		throw new Error("Native hook claim journal cannot recover: claim is missing and canonical bytes are not the recorded original.");
 	}
@@ -244,15 +280,15 @@ export async function recoverNativeHookClaimJournal(root: string): Promise<boole
 		throw new Error("Native hook claim journal cannot recover: claim bytes do not match recorded ownership.");
 	}
 	if (canonical === null) {
-		await restoreNativeHookClaimNoClobber(parsed.claimPath, parsed.canonicalPath);
-		await clearNativeHookClaimJournal(root);
-		return true;
+		outcome = await restoreNativeHookClaimNoClobber(parsed.claimPath, parsed.canonicalPath, durability);
+		await clearNativeHookClaimJournal(root, durability);
+		return { recovered: true, outcome };
 	}
 	if (parsed.afterHash !== null && digest(canonical) === parsed.afterHash) {
 		await rm(parsed.claimPath);
-		await fsyncDirectory(dirname(parsed.claimPath));
-		await clearNativeHookClaimJournal(root);
-		return true;
+		await durability.syncDirectory(dirname(parsed.claimPath));
+		await clearNativeHookClaimJournal(root, durability);
+		return { recovered: true, outcome };
 	}
 	throw new Error("Native hook claim journal cannot recover without overwriting unrecognized canonical content.");
 }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -27,11 +27,13 @@ import { homedir } from "os";
 import TOML from "@iarna/toml";
 import { createHash } from "crypto";
 import {
-	clearNativeHookClaimJournal,
-	persistNativeHookClaimJournal,
+	clearNativeHookClaimJournal as clearNativeHookClaimJournalWithDurability,
+	createNativeHookClaimJournalDurability,
+	persistNativeHookClaimJournal as persistNativeHookClaimJournalWithDurability,
 	recoverNativeHookClaimJournal,
-	syncNativeHookClaimParent,
-	restoreNativeHookClaimNoClobber,
+	syncNativeHookClaimParent as syncNativeHookClaimParentWithDurability,
+	restoreNativeHookClaimNoClobber as restoreNativeHookClaimNoClobberWithDurability,
+	type NativeHookClaimJournalDurability,
 } from "./native-hook-claim-journal.js";
 import {
 	codexHome,
@@ -44,6 +46,13 @@ import {
 	omxPlansDir,
 	omxLogsDir,
 } from "../utils/paths.js";
+import {
+	emitDegradedDurabilityWarning,
+	recordRegularFileSyncOutcome,
+	syncRegularFile,
+	type RegularFileDurabilityTracker,
+	type RegularFileSyncOutcome,
+} from "../utils/file-durability.js";
 import {
 	buildMergedConfig,
 	getRootModelName,
@@ -537,6 +546,10 @@ let nativeHookTransactionTemporaryPathOverride:
 	| ((path: string, purpose: "write" | "delete") => string)
 	| undefined;
 let setupLatePhaseFailureInjector: (() => void) | undefined;
+let nativeHookTransactionRegularFileSyncOverride:
+	| ((platform: NodeJS.Platform) => Promise<void>)
+	| undefined;
+let nativeHookClaimJournalDurabilityOverride: NativeHookClaimJournalDurability | undefined;
 
 
 
@@ -593,8 +606,74 @@ export function setNativeHookTransactionTemporaryPathForTest(
 	};
 }
 
+/** @internal Test seam for deterministic regular-file fsync coverage. */
+export function setNativeHookTransactionRegularFileSyncForTest(
+	sync: ((platform: NodeJS.Platform) => Promise<void>) | undefined,
+): () => void {
+	const previous = nativeHookTransactionRegularFileSyncOverride;
+	nativeHookTransactionRegularFileSyncOverride = sync;
+	return () => {
+		nativeHookTransactionRegularFileSyncOverride = previous;
+	};
+}
+
+/** @internal Test seam for deterministic claim-journal durability coverage. */
+export function setNativeHookClaimJournalDurabilityForTest(
+	durability: NativeHookClaimJournalDurability | undefined,
+): () => void {
+	const previous = nativeHookClaimJournalDurabilityOverride;
+	nativeHookClaimJournalDurabilityOverride = durability;
+	return () => {
+		nativeHookClaimJournalDurabilityOverride = previous;
+	};
+}
+
 function nativeHookPlatform(): NodeJS.Platform {
 	return nativeHookTransactionPlatformOverride ?? process.platform;
+}
+
+
+function nativeHookClaimJournalDurability() {
+	return nativeHookClaimJournalDurabilityOverride
+		?? createNativeHookClaimJournalDurability(nativeHookPlatform());
+}
+
+async function clearNativeHookClaimJournal(root: string): Promise<void> {
+	return clearNativeHookClaimJournalWithDurability(root, nativeHookClaimJournalDurability());
+}
+
+async function persistNativeHookClaimJournal(
+	root: string,
+	entry: Parameters<typeof persistNativeHookClaimJournalWithDurability>[1],
+): Promise<RegularFileSyncOutcome> {
+	return persistNativeHookClaimJournalWithDurability(root, entry, nativeHookClaimJournalDurability());
+}
+
+async function restoreNativeHookClaimNoClobber(
+	claimPath: string,
+	destinationPath: string,
+): Promise<RegularFileSyncOutcome> {
+	return restoreNativeHookClaimNoClobberWithDurability(
+		claimPath,
+		destinationPath,
+		nativeHookClaimJournalDurability(),
+	);
+}
+
+async function syncNativeHookClaimParent(path: string): Promise<void> {
+	return syncNativeHookClaimParentWithDurability(path, nativeHookClaimJournalDurability());
+}
+async function syncNativeHookRegularFile(
+	handle: Awaited<ReturnType<typeof open>>,
+): Promise<RegularFileSyncOutcome> {
+	const platform = nativeHookPlatform();
+	if (nativeHookTransactionRegularFileSyncOverride) {
+		return syncRegularFile(
+			{ sync: () => nativeHookTransactionRegularFileSyncOverride!(platform) },
+			platform,
+		);
+	}
+	return syncRegularFile(handle, platform);
 }
 
 function hookTransactionBytesEqual(
@@ -1084,8 +1163,15 @@ function nativeHookTransactionClaimPath(path: string): string {
 	);
 }
 
-async function restoreNativeHookClaim(claimPath: string, destinationPath: string): Promise<void> {
-	await restoreNativeHookClaimNoClobber(claimPath, destinationPath);
+async function restoreNativeHookClaim(
+	claimPath: string,
+	destinationPath: string,
+	tracker: RegularFileDurabilityTracker,
+): Promise<void> {
+	recordRegularFileSyncOutcome(
+		tracker,
+		await restoreNativeHookClaimNoClobber(claimPath, destinationPath),
+	);
 }
 
 
@@ -1095,6 +1181,7 @@ async function atomicWriteNativeHookTransactionArtifact(
 	stage: "write" | "rollback",
 	expectedCurrent: NativeHookTransactionArtifactSnapshot,
 	ancestorPrecondition: NativeHookTransactionAncestorPrecondition,
+	tracker: RegularFileDurabilityTracker,
 	onWriteApplied?: (snapshot: NativeHookTransactionArtifactSnapshot) => void,
 	onWriteStabilized?: (snapshot: NativeHookTransactionArtifactSnapshot) => void,
 	assertApplied?: () => Promise<void>,
@@ -1139,7 +1226,7 @@ async function atomicWriteNativeHookTransactionArtifact(
 		temporaryCreated = true;
 		try {
 			await handle.writeFile(content);
-			await handle.sync();
+			recordRegularFileSyncOutcome(tracker, await syncNativeHookRegularFile(handle));
 		} finally {
 			await handle.close();
 		}
@@ -1188,12 +1275,15 @@ async function atomicWriteNativeHookTransactionArtifact(
 			!claimRelativePath.startsWith(`..${sep}`);
 		if (expectedCurrent.bytes !== null) {
 			if (canJournalClaim) {
-				await persistNativeHookClaimJournal(ancestorPrecondition.controlledRoot, {
-					canonicalPath: artifact.path,
-					claimPath,
-					before: expectedCurrent.bytes,
-					after: content,
-				});
+				recordRegularFileSyncOutcome(
+					tracker,
+					await persistNativeHookClaimJournal(ancestorPrecondition.controlledRoot, {
+						canonicalPath: artifact.path,
+						claimPath,
+						before: expectedCurrent.bytes,
+						after: content,
+					}),
+				);
 				await refreshNativeHookTransactionAncestorPrecondition(
 					ancestorPrecondition,
 					join(ancestorPrecondition.controlledRoot, ".omx", "native-hook-claim-journal.json"),
@@ -1216,7 +1306,7 @@ async function atomicWriteNativeHookTransactionArtifact(
 		}
 		const installedHandle = await open(artifact.path, "r");
 		try {
-			await installedHandle.sync();
+			recordRegularFileSyncOutcome(tracker, await syncNativeHookRegularFile(installedHandle));
 		} finally {
 			await installedHandle.close();
 		}
@@ -1253,7 +1343,7 @@ async function atomicWriteNativeHookTransactionArtifact(
 	} catch (error) {
 		if (claimCreated && claimPath) {
 			try {
-				await restoreNativeHookClaim(claimPath, artifact.path);
+				await restoreNativeHookClaim(claimPath, artifact.path, tracker);
 				await syncNativeHookClaimParent(artifact.path);
 				claimCreated = false;
 				if (journaledClaim) {
@@ -1396,6 +1486,7 @@ async function assertNativeHookTransactionRollbackState(
 async function applyNativeHookTransactionArtifact(
 	artifact: NativeHookTransactionArtifact,
 	ancestorPrecondition: NativeHookTransactionAncestorPrecondition,
+	tracker: RegularFileDurabilityTracker,
 	applied: AppliedNativeHookTransactionArtifact[],
 ): Promise<AppliedNativeHookTransactionArtifact> {
 	await assertNativeHookTransactionArtifactSnapshot(
@@ -1414,6 +1505,7 @@ async function applyNativeHookTransactionArtifact(
 			"write",
 			artifact.before,
 			ancestorPrecondition,
+			tracker,
 			(appliedSnapshot) => {
 				entry = { artifact, appliedSnapshot };
 				applied.push(entry);
@@ -1457,7 +1549,7 @@ async function applyNativeHookTransactionArtifact(
 		stagedDeletionCreated = true;
 		try {
 			await handle.writeFile(artifact.before.bytes!);
-			await handle.sync();
+			recordRegularFileSyncOutcome(tracker, await syncNativeHookRegularFile(handle));
 		} finally {
 			await handle.close();
 		}
@@ -1501,12 +1593,15 @@ async function applyNativeHookTransactionArtifact(
 			claimRelativePath !== ".." &&
 			!claimRelativePath.startsWith(`..${sep}`);
 		if (journaledClaim) {
-			await persistNativeHookClaimJournal(ancestorPrecondition.controlledRoot, {
-				canonicalPath: artifact.path,
-				claimPath,
-				before: artifact.before.bytes!,
-				after: null,
-			});
+			recordRegularFileSyncOutcome(
+				tracker,
+				await persistNativeHookClaimJournal(ancestorPrecondition.controlledRoot, {
+					canonicalPath: artifact.path,
+					claimPath,
+					before: artifact.before.bytes!,
+					after: null,
+				}),
+			);
 		}
 		await rename(artifact.path, claimPath);
 		if (journaledClaim) await syncNativeHookClaimParent(claimPath);
@@ -1535,7 +1630,7 @@ async function applyNativeHookTransactionArtifact(
 					claimPath,
 					`${artifact.label} removal claim`,
 				);
-				await restoreNativeHookClaim(claimPath, artifact.path);
+				await restoreNativeHookClaim(claimPath, artifact.path, tracker);
 				if (journaledClaim) await syncNativeHookClaimParent(artifact.path);
 				if (journaledClaim) {
 					await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot);
@@ -1589,7 +1684,7 @@ async function applyNativeHookTransactionArtifact(
 					);
 				} catch (claimError) {
 					try {
-						await restoreNativeHookClaim(claimPath, stagedDeletionPath);
+						await restoreNativeHookClaim(claimPath, stagedDeletionPath, tracker);
 					} catch (recoveryError) {
 						throw new Error(
 							`Native hook transaction staged deletion cleanup claim failed (${claimError instanceof Error ? claimError.message : String(claimError)}) and preserved ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
@@ -1638,6 +1733,7 @@ async function verifyNativeHookTransactionArtifact(
 async function restoreNativeHookTransactionArtifact(
 	applied: AppliedNativeHookTransactionArtifact,
 	ancestorPrecondition: NativeHookTransactionAncestorPrecondition,
+	tracker: RegularFileDurabilityTracker,
 	assertRollbackState: () => Promise<void>,
 ): Promise<void> {
 	const { artifact } = applied;
@@ -1678,7 +1774,7 @@ async function restoreNativeHookTransactionArtifact(
 					claimPath,
 					`${artifact.label} rollback removal claim`,
 				);
-				await restoreNativeHookClaim(claimPath, artifact.path);
+				await restoreNativeHookClaim(claimPath, artifact.path, tracker);
 				await assertNativeHookTransactionArtifactSnapshot(
 					artifact.path,
 					artifact.label,
@@ -1705,6 +1801,7 @@ async function restoreNativeHookTransactionArtifact(
 			"rollback",
 			applied.appliedSnapshot,
 			ancestorPrecondition,
+			tracker,
 			(restoredSnapshot) => {
 				applied.appliedSnapshot = restoredSnapshot;
 			},
@@ -1735,6 +1832,7 @@ async function restoreNativeHookTransactionArtifact(
 async function cleanupNativeHookTransactionStagedDeletions(
 	applied: readonly AppliedNativeHookTransactionArtifact[],
 	ancestorPrecondition: NativeHookTransactionAncestorPrecondition,
+	tracker: RegularFileDurabilityTracker,
 	preconditions?: readonly NativeHookTransactionPrecondition[],
 	rollbackApplied?: readonly AppliedNativeHookTransactionArtifact[],
 ): Promise<void> {
@@ -1778,7 +1876,7 @@ async function cleanupNativeHookTransactionStagedDeletions(
 			);
 		} catch (error) {
 			try {
-				await restoreNativeHookClaim(claimPath, stagedDeletionPath);
+				await restoreNativeHookClaim(claimPath, stagedDeletionPath, tracker);
 			} catch (recoveryError) {
 				throw new Error(
 					`Native hook transaction staged deletion cleanup claim failed (${error instanceof Error ? error.message : String(error)}) and preserved ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
@@ -1810,6 +1908,7 @@ async function ensureSnapshotBackup(
 	artifact: NativeHookTransactionArtifact,
 	backupContext: SetupBackupContext,
 	options: Pick<SetupOptions, "dryRun" | "verbose">,
+	tracker: RegularFileDurabilityTracker,
 ): Promise<boolean> {
 	const bytes = artifact.before.bytes;
 	if (bytes === null) return false;
@@ -1843,7 +1942,7 @@ async function ensureSnapshotBackup(
 		const handle = await open(backupPath, "wx", 0o600);
 		try {
 			await handle.writeFile(bytes);
-			await handle.sync();
+			recordRegularFileSyncOutcome(tracker, await syncNativeHookRegularFile(handle));
 		} finally {
 			await handle.close();
 		}
@@ -1867,6 +1966,7 @@ async function commitNativeHookTransaction(
 	preconditions: readonly NativeHookTransactionPrecondition[],
 	ancestorPrecondition: NativeHookTransactionAncestorPrecondition,
 	backupContext: SetupBackupContext,
+	tracker: RegularFileDurabilityTracker,
 	summary: SetupCategorySummary,
 	options: Pick<SetupOptions, "dryRun" | "verbose">,
 ): Promise<void> {
@@ -1881,7 +1981,7 @@ async function commitNativeHookTransaction(
 	if (artifacts.length === 0) return;
 	for (const artifact of artifacts) {
 		injectNativeHookTransactionFailure("before_backup", artifact);
-		if (await ensureSnapshotBackup(artifact, backupContext, options)) {
+		if (await ensureSnapshotBackup(artifact, backupContext, options, tracker)) {
 			summary.backedUp += 1;
 		}
 	}
@@ -1901,6 +2001,7 @@ async function commitNativeHookTransaction(
 			const entry = await applyNativeHookTransactionArtifact(
 				artifact,
 				ancestorPrecondition,
+				tracker,
 				applied,
 			);
 			await verifyNativeHookTransactionArtifact(entry);
@@ -1916,6 +2017,7 @@ async function commitNativeHookTransaction(
 		await cleanupNativeHookTransactionStagedDeletions(
 			applied,
 			ancestorPrecondition,
+			tracker,
 			preconditions,
 		);
 		injectNativeHookTransactionFailure(
@@ -1950,6 +2052,7 @@ async function commitNativeHookTransaction(
 					await restoreNativeHookTransactionArtifact(
 						entry,
 						ancestorPrecondition,
+						tracker,
 						() => assertNativeHookTransactionRollbackState(applied),
 					);
 					restored.push(entry);
@@ -1967,6 +2070,7 @@ async function commitNativeHookTransaction(
 				await cleanupNativeHookTransactionStagedDeletions(
 					restored,
 					ancestorPrecondition,
+					tracker,
 					undefined,
 					applied,
 				);
@@ -3824,7 +3928,15 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		process.env[SKIP_NATIVE_AGENT_REFRESH_ENV] === "1";
 	const scopeDirs = resolveScopeDirectories(resolvedScope.scope, projectRoot);
 	if (!dryRun) {
-		await recoverNativeHookClaimJournal(scopeDirs.codexHomeDir);
+		const recoveryTracker: RegularFileDurabilityTracker = { degraded: false };
+		const recovery = await recoverNativeHookClaimJournal(
+			scopeDirs.codexHomeDir,
+			nativeHookClaimJournalDurability(),
+		);
+		recordRegularFileSyncOutcome(recoveryTracker, recovery.outcome);
+		if (recovery.recovered) {
+			emitDegradedDurabilityWarning("native-hook claim-journal recovery", recoveryTracker);
+		}
 	}
 	const nativeHookTransactionPlatform = nativeHookPlatform();
 	let nativeHookTransactionAncestorPrecondition =
@@ -4789,14 +4901,17 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			scopeDirs.codexHomeDir,
 			nativeHookSetupTransaction.artifacts.map((artifact) => artifact.path),
 		);
+	const nativeHookSetupDurabilityTracker: RegularFileDurabilityTracker = { degraded: false };
 	await commitNativeHookTransaction(
 		nativeHookSetupTransaction.artifacts,
 		nativeHookSetupTransaction.preconditions,
 		nativeHookTransactionAncestorPrecondition,
 		backupContext,
+		nativeHookSetupDurabilityTracker,
 		summary.config,
 		{ dryRun, verbose },
 	);
+	emitDegradedDurabilityWarning("native-hook setup", nativeHookSetupDurabilityTracker);
 
 	console.log('Setup complete! Run "omx doctor" to verify installation.');
 	console.log("\nNext steps:");

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -2,17 +2,19 @@
  * omx uninstall - Remove oh-my-codex configuration and installed artifacts
  */
 
-import { chmod, copyFile, lstat, open, readFile, readdir, rename, rm, writeFile } from "fs/promises";
+import { chmod, copyFile, lstat, open, readFile, readdir, rename, rm, writeFile, type FileHandle } from "fs/promises";
 
 import { constants, existsSync } from "fs";
 import { join, basename, dirname, isAbsolute, relative } from "path";
 import { randomUUID } from "crypto";
 import {
-  clearNativeHookClaimJournal,
-  persistNativeHookClaimJournal,
+  clearNativeHookClaimJournal as clearNativeHookClaimJournalWithDurability,
+  createNativeHookClaimJournalDurability,
+  persistNativeHookClaimJournal as persistNativeHookClaimJournalWithDurability,
   recoverNativeHookClaimJournal,
-  syncNativeHookClaimParent,
-  restoreNativeHookClaimNoClobber,
+  syncNativeHookClaimParent as syncNativeHookClaimParentWithDurability,
+  restoreNativeHookClaimNoClobber as restoreNativeHookClaimNoClobberWithDurability,
+  type NativeHookClaimJournalDurability,
 } from "./native-hook-claim-journal.js";
 import {
   formatTomlStringArray,
@@ -54,6 +56,13 @@ import {
 } from "../utils/agents-md.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import TOML from "@iarna/toml";
+import {
+  emitDegradedDurabilityWarning,
+  recordRegularFileSyncOutcome,
+  syncRegularFile,
+  type RegularFileSyncOutcome,
+  type RegularFileDurabilityTracker,
+} from "../utils/file-durability.js";
 
 /** @internal Deterministic file-operation seam for uninstall transaction tests. */
 export type UninstallTransactionFailureStage =
@@ -75,6 +84,25 @@ export type UninstallTransactionFailureStage =
   | "after-staged-cleanup"
   | "after-config-commit";
 
+/** @internal Distinguishes each direct regular-file durability boundary. */
+export type UninstallRegularFileSyncSite =
+  | "replacement-temporary"
+  | "installed-destination"
+  | "staged-deletion";
+
+let uninstallClaimJournalDurabilityOverride: NativeHookClaimJournalDurability | undefined;
+
+/** @internal Test seam for deterministic claim-journal durability coverage. */
+export function setUninstallClaimJournalDurabilityForTest(
+  durability: NativeHookClaimJournalDurability | undefined,
+): () => void {
+  const previous = uninstallClaimJournalDurabilityOverride;
+  uninstallClaimJournalDurabilityOverride = durability;
+  return () => {
+    uninstallClaimJournalDurabilityOverride = previous;
+  };
+}
+
 
 export interface UninstallOptions {
   codexFeaturesProbe?: () => string | null;
@@ -95,6 +123,12 @@ export interface UninstallOptions {
     path: string,
     purpose: "write" | "delete",
   ) => string;
+  /** @internal */
+  regularFileSyncForTest?: (
+    site: UninstallRegularFileSyncSite,
+    handle: Pick<FileHandle, "sync">,
+    platform: NodeJS.Platform,
+  ) => Promise<RegularFileSyncOutcome>;
 
 
 }
@@ -864,6 +898,37 @@ function transactionTemporaryPath(
   );
 }
 
+function uninstallClaimJournalDurability() {
+  return uninstallClaimJournalDurabilityOverride
+    ?? createNativeHookClaimJournalDurability();
+}
+
+async function clearNativeHookClaimJournal(root: string): Promise<void> {
+  return clearNativeHookClaimJournalWithDurability(root, uninstallClaimJournalDurability());
+}
+
+async function persistNativeHookClaimJournal(
+  root: string,
+  entry: Parameters<typeof persistNativeHookClaimJournalWithDurability>[1],
+): Promise<RegularFileSyncOutcome> {
+  return persistNativeHookClaimJournalWithDurability(root, entry, uninstallClaimJournalDurability());
+}
+
+async function restoreNativeHookClaimNoClobber(
+  claimPath: string,
+  destinationPath: string,
+): Promise<RegularFileSyncOutcome> {
+  return restoreNativeHookClaimNoClobberWithDurability(
+    claimPath,
+    destinationPath,
+    uninstallClaimJournalDurability(),
+  );
+}
+
+async function syncNativeHookClaimParent(path: string): Promise<void> {
+  return syncNativeHookClaimParentWithDurability(path, uninstallClaimJournalDurability());
+}
+
 function transactionClaimPath(path: string): string {
   return join(
     dirname(path),
@@ -871,8 +936,15 @@ function transactionClaimPath(path: string): string {
   );
 }
 
-async function restoreUninstallClaim(claimPath: string, destinationPath: string): Promise<void> {
-  await restoreNativeHookClaimNoClobber(claimPath, destinationPath);
+async function restoreUninstallClaim(
+  claimPath: string,
+  destinationPath: string,
+  tracker: RegularFileDurabilityTracker,
+): Promise<void> {
+  recordRegularFileSyncOutcome(
+    tracker,
+    await restoreNativeHookClaimNoClobber(claimPath, destinationPath),
+  );
 }
 
 
@@ -995,6 +1067,7 @@ async function removeOwnedTemporary(
   snapshot: FileSnapshot | undefined,
   originalError: unknown,
   description: "temporary" | "staged deletion",
+  tracker: RegularFileDurabilityTracker,
 ): Promise<void> {
 
   try {
@@ -1009,7 +1082,7 @@ async function removeOwnedTemporary(
       await assertSnapshotAtPath(claimPath, snapshot, `${description} cleanup claim`);
     } catch (error) {
       try {
-        await restoreUninstallClaim(claimPath, path);
+        await restoreUninstallClaim(claimPath, path, tracker);
       } catch (recoveryError) {
         throw new Error(
           `${error instanceof Error ? error.message : String(error)}; preserved claim ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
@@ -1029,11 +1102,30 @@ async function removeOwnedTemporary(
 }
 
 
+type UninstallDurabilityOptions = Pick<
+  UninstallOptions,
+  "regularFileSyncForTest" | "transactionPlatform"
+> & {
+  durabilityTracker: RegularFileDurabilityTracker;
+};
+
+async function syncUninstallRegularFile(
+  site: UninstallRegularFileSyncSite,
+  handle: Pick<FileHandle, "sync">,
+  options: UninstallDurabilityOptions,
+): Promise<void> {
+  const platform = options.transactionPlatform ?? process.platform;
+  const outcome = options.regularFileSyncForTest
+    ? await options.regularFileSyncForTest(site, handle, platform)
+    : await syncRegularFile(handle, platform);
+  recordRegularFileSyncOutcome(options.durabilityTracker, outcome);
+}
+
 async function atomicReplaceFile(
   mutation: PlannedFileMutation,
   expectedCurrent: FileSnapshot,
   content: Buffer,
-  options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath">,
+  options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath"> & UninstallDurabilityOptions,
   stage: "write" | "rollback",
   onRename: (ownership: RenamedDestinationOwnership) => void,
 
@@ -1059,7 +1151,7 @@ async function atomicReplaceFile(
     temporaryCreated = true;
     await handle.writeFile(content);
     await chmod(temporaryPath, mutation.snapshot.mode);
-    await handle.sync();
+    await syncUninstallRegularFile("replacement-temporary", handle, options);
     await handle.close();
     handle = undefined;
     temporarySnapshot = await readFileSnapshot(
@@ -1091,12 +1183,15 @@ async function atomicReplaceFile(
     claimPath = transactionClaimPath(mutation.snapshot.path);
     const controlledRoot = mutation.snapshot.topology?.root;
     if (expectedCurrent.bytes !== null && controlledRoot) {
-      await persistNativeHookClaimJournal(controlledRoot, {
-        canonicalPath: mutation.snapshot.path,
-        claimPath,
-        before: expectedCurrent.bytes,
-        after: content,
-      });
+      recordRegularFileSyncOutcome(
+        options.durabilityTracker,
+        await persistNativeHookClaimJournal(controlledRoot, {
+          canonicalPath: mutation.snapshot.path,
+          claimPath,
+          before: expectedCurrent.bytes,
+          after: content,
+        }),
+      );
       journaledClaim = true;
       await rename(mutation.snapshot.path, claimPath);
       claimCreated = true;
@@ -1107,7 +1202,7 @@ async function atomicReplaceFile(
     await chmod(mutation.snapshot.path, mutation.snapshot.mode);
     const installedHandle = await open(mutation.snapshot.path, "r");
     try {
-      await installedHandle.sync();
+      await syncUninstallRegularFile("installed-destination", installedHandle, options);
     } finally {
       await installedHandle.close();
     }
@@ -1147,7 +1242,7 @@ async function atomicReplaceFile(
     await handle?.close().catch(() => undefined);
     if (claimCreated && claimPath) {
       try {
-        await restoreUninstallClaim(claimPath, mutation.snapshot.path);
+        await restoreUninstallClaim(claimPath, mutation.snapshot.path, options.durabilityTracker);
         await syncNativeHookClaimParent(mutation.snapshot.path);
         claimCreated = false;
         const controlledRoot = mutation.snapshot.topology?.root;
@@ -1167,6 +1262,7 @@ async function atomicReplaceFile(
         temporarySnapshot,
         error,
         "temporary",
+        options.durabilityTracker,
       );
 
     }
@@ -1178,7 +1274,7 @@ async function atomicReplaceFile(
 async function stageAndRemoveFile(
   mutation: PlannedFileMutation,
   execution: MutationExecution,
-  options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath">,
+  options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath"> & UninstallDurabilityOptions,
   assertApplied: () => Promise<void>,
 ): Promise<void> {
   if (mutation.snapshot.bytes === null || mutation.snapshot.mode === null) {
@@ -1195,7 +1291,7 @@ async function stageAndRemoveFile(
     stagedCreated = true;
     await handle.writeFile(mutation.snapshot.bytes);
     await chmod(stagedPath, mutation.snapshot.mode);
-    await handle.sync();
+    await syncUninstallRegularFile("staged-deletion", handle, options);
     await handle.close();
     handle = undefined;
     const stagedDeletion = await readFileSnapshot(
@@ -1221,12 +1317,15 @@ async function stageAndRemoveFile(
 
     const controlledRoot = mutation.snapshot.topology?.root;
     if (controlledRoot && mutation.snapshot.bytes !== null) {
-      await persistNativeHookClaimJournal(controlledRoot, {
-        canonicalPath: mutation.snapshot.path,
-        claimPath,
-        before: mutation.snapshot.bytes,
-        after: null,
-      });
+      recordRegularFileSyncOutcome(
+        options.durabilityTracker,
+        await persistNativeHookClaimJournal(controlledRoot, {
+          canonicalPath: mutation.snapshot.path,
+          claimPath,
+          before: mutation.snapshot.bytes,
+          after: null,
+        }),
+      );
     }
     await rename(mutation.snapshot.path, claimPath);
     if (controlledRoot) await syncNativeHookClaimParent(claimPath);
@@ -1245,7 +1344,7 @@ async function stageAndRemoveFile(
       await assertSnapshotAtPath(claimPath, mutation.snapshot, "removal claim");
     } catch (error) {
       try {
-        await restoreUninstallClaim(claimPath, mutation.snapshot.path);
+        await restoreUninstallClaim(claimPath, mutation.snapshot.path, options.durabilityTracker);
         if (controlledRoot) await syncNativeHookClaimParent(mutation.snapshot.path);
         if (controlledRoot) await clearNativeHookClaimJournal(controlledRoot);
         execution.appliedSnapshot = undefined;
@@ -1275,6 +1374,7 @@ async function stageAndRemoveFile(
         execution.stagedDeletion,
         error,
         "staged deletion",
+        options.durabilityTracker,
       );
     }
     throw error;
@@ -1284,7 +1384,7 @@ async function stageAndRemoveFile(
 async function applyFileMutation(
   execution: MutationExecution,
   executions: readonly MutationExecution[],
-  options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath">,
+  options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath"> & UninstallDurabilityOptions,
 ): Promise<void> {
   const { mutation } = execution;
   if (mutation.finalContent === null) {
@@ -1339,7 +1439,7 @@ async function captureRollbackOwnedSnapshot(
 
 async function restoreFileSnapshot(
   execution: MutationExecution,
-  options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath">,
+  options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath"> & UninstallDurabilityOptions,
   assertRollbackState: () => Promise<void>,
 ): Promise<void> {
   const { mutation } = execution;
@@ -1372,7 +1472,7 @@ async function restoreFileSnapshot(
       await assertSnapshotAtPath(claimPath, appliedSnapshot, "rollback removal claim");
     } catch (error) {
       try {
-        await restoreUninstallClaim(claimPath, mutation.snapshot.path);
+        await restoreUninstallClaim(claimPath, mutation.snapshot.path, options.durabilityTracker);
       } catch (recoveryError) {
         throw new Error(
           `Uninstall rollback removal claim failed (${error instanceof Error ? error.message : String(error)}) and preserved ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
@@ -1406,7 +1506,7 @@ async function restoreFileSnapshot(
 
 async function cleanupStagedDeletions(
   executions: readonly MutationExecution[],
-  options: Pick<UninstallOptions, "transactionFailureInjector">,
+  options: Pick<UninstallOptions, "transactionFailureInjector"> & UninstallDurabilityOptions,
   stage: "commit" | "rollback",
   transaction?: UninstallArtifactTransaction,
   assertRollbackState?: () => Promise<void>,
@@ -1431,7 +1531,7 @@ async function cleanupStagedDeletions(
       await assertSnapshotAtPath(claimPath, stagedDeletion, "staged deletion cleanup claim");
     } catch (error) {
       try {
-        await restoreUninstallClaim(claimPath, stagedDeletion.path);
+        await restoreUninstallClaim(claimPath, stagedDeletion.path, options.durabilityTracker);
       } catch (recoveryError) {
         throw new Error(
           `Uninstall staged deletion cleanup claim failed (${error instanceof Error ? error.message : String(error)}) and preserved ${claimPath} for manual recovery: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
@@ -1459,7 +1559,7 @@ async function assertRollbackTransactionState(
 
 async function rollbackArtifactMutations(
   executions: readonly MutationExecution[],
-  options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath">,
+  options: Pick<UninstallOptions, "transactionFailureInjector" | "transactionTemporaryPath"> & UninstallDurabilityOptions,
 ): Promise<void> {
   const failures: string[] = [];
   const restored: MutationExecution[] = [];
@@ -1539,7 +1639,7 @@ async function commitUninstallArtifactTransaction(
   options: Pick<
     UninstallOptions,
     "transactionFailureInjector" | "transactionTemporaryPath"
-  >,
+  > & UninstallDurabilityOptions,
 ): Promise<void> {
   const mutations = [transaction.hooks, transaction.shim, transaction.config]
     .filter((mutation): mutation is PlannedFileMutation => mutation !== undefined);
@@ -1723,7 +1823,14 @@ export async function uninstall(options: UninstallOptions = {}): Promise<void> {
   const scope = options.scope ?? readPersistedSetupScope(projectRoot) ?? "user";
   const scopeDirs = resolveScopeDirectories(scope, projectRoot);
   if (!dryRun) {
-    await recoverNativeHookClaimJournal(scopeDirs.codexHomeDir);
+    const recoveryTracker: RegularFileDurabilityTracker = { degraded: false };
+    const recovery = await recoverNativeHookClaimJournal(
+      scopeDirs.codexHomeDir,
+      uninstallClaimJournalDurabilityOverride
+        ?? createNativeHookClaimJournalDurability(options.transactionPlatform ?? process.platform),
+    );
+    recordRegularFileSyncOutcome(recoveryTracker, recovery.outcome);
+    emitDegradedDurabilityWarning("native-hook claim-journal recovery", recoveryTracker);
   }
   const transactionPlatform = options.transactionPlatform ?? process.platform;
 
@@ -1832,10 +1939,15 @@ export async function uninstall(options: UninstallOptions = {}): Promise<void> {
   console.log("[1/6] Removing native hooks artifact...");
   if (!keepConfig) console.log("[2/6] Cleaning config.toml...");
   if (!dryRun) {
+    const mutationTracker: RegularFileDurabilityTracker = { degraded: false };
     await commitUninstallArtifactTransaction(artifactTransaction, {
       transactionFailureInjector: options.transactionFailureInjector,
       transactionTemporaryPath: options.transactionTemporaryPath,
+      transactionPlatform,
+      regularFileSyncForTest: options.regularFileSyncForTest,
+      durabilityTracker: mutationTracker,
     });
+    emitDegradedDurabilityWarning("native-hook uninstall", mutationTracker);
   }
   if (verbose) {
     if (artifactTransaction.hooks) {

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -209,6 +209,55 @@ describe('session lifecycle manager', () => {
     }
   });
 
+  it('emits the session-end warning only after successful end finalization', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-end-durability-'));
+    const originalWrite = process.stderr.write;
+    const warnings: string[] = [];
+    process.stderr.write = ((value: string) => {
+      warnings.push(value);
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      await writeSessionEnd(cwd, 'sess-end-durability', {
+        platform: 'win32',
+        regularFileSync: async () => { throw codedError('EPERM'); },
+      });
+      assert.deepEqual(warnings, [
+        '[omx] warning: Windows EPERM regular-file fsync unsupported in session pointer end; operation succeeded with degraded durability.\n',
+      ]);
+    } finally {
+      process.stderr.write = originalWrite;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps session-end durability warnings silent when finalization or release fails', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-end-durability-failure-'));
+    const originalWrite = process.stderr.write;
+    const warnings: string[] = [];
+    process.stderr.write = ((value: string) => {
+      warnings.push(value);
+      return true;
+    }) as typeof process.stderr.write;
+    const regularFileSync = async () => { throw codedError('EPERM'); };
+    try {
+      await withPointerDependencies({
+        fs: {
+          rmdir: async () => { throw new Error('release failure'); },
+        },
+      }, async () => {
+        await assert.rejects(writeSessionEnd(cwd, 'sess-end-release-failure', {
+          platform: 'win32',
+          regularFileSync,
+        }));
+      });
+      assert.deepEqual(warnings, []);
+    } finally {
+      process.stderr.write = originalWrite;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('does not delete the current session pointer when ending a different session', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-end-owner-'));
     try {
@@ -872,6 +921,65 @@ describe('session pointer transaction', () => {
     }
   });
 
+  it('publishes the owner and pointer on Windows when regular-file fsync reports EPERM', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-windows-eperm-'));
+    let syncCalls = 0;
+    const regularFileSync = async (platform: NodeJS.Platform) => {
+      assert.equal(platform, 'win32');
+      syncCalls += 1;
+      throw codedError('EPERM');
+    };
+    try {
+      const state = await writeSessionStart(cwd, 'sess-windows-eperm', {
+        platform: 'win32',
+        regularFileSync,
+      });
+      const context = resolveSessionPointerContext(cwd);
+      assert.equal(state.session_id, 'sess-windows-eperm');
+      assert.equal(syncCalls, 2, 'owner publication and pointer publication must both attempt fsync');
+      assert.equal(existsSync(join(context.lockPath, 'owner.json')), false, 'lock owner is removed after commit');
+      assert.equal(JSON.parse(await readFile(context.sessionPath, 'utf8')).session_id, 'sess-windows-eperm');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('emits one post-release warning for a degraded session start and stays silent for synced or failed transactions', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-durability-warning-'));
+    const originalWrite = process.stderr.write;
+    const warnings: Array<{ value: string; lockExists: boolean }> = [];
+    process.stderr.write = ((value: string) => {
+      warnings.push({ value, lockExists: existsSync(resolveSessionPointerContext(cwd).lockPath) });
+      return true;
+    }) as typeof process.stderr.write;
+    const regularFileSync = async () => { throw codedError('EPERM'); };
+    try {
+      await writeSessionStart(cwd, 'sess-degraded-start', { platform: 'win32', regularFileSync });
+      assert.deepEqual(warnings, [{
+        value: '[omx] warning: Windows EPERM regular-file fsync unsupported in session pointer start/reconcile; operation succeeded with degraded durability.\n',
+        lockExists: false,
+      }]);
+
+      warnings.length = 0;
+      await writeSessionStart(cwd, 'sess-degraded-start', { platform: 'win32' });
+      assert.deepEqual(warnings, []);
+
+      await withPointerDependencies({
+        fs: {
+          rename: async (from, to) => {
+            if (to === resolveSessionPointerContext(cwd).sessionPath) throw new Error('rename failure');
+            await rename(from, to);
+          },
+        },
+      }, async () => {
+        await assert.rejects(writeSessionStart(cwd, 'sess-degraded-start', { platform: 'win32', regularFileSync }));
+      });
+      assert.deepEqual(warnings, []);
+    } finally {
+      process.stderr.write = originalWrite;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
   it('types state-directory, pointer-read, owner-sync, owner-rename, and invalid-token failures before commit', async () => {
     const failures = [
       {
@@ -907,6 +1015,7 @@ describe('session pointer transaction', () => {
           fs: {
             openAndSync: async (path: string) => {
               if (path === join(context.lockPath, `owner.${TEST_TOKEN}.tmp`)) throw new Error('owner sync failure');
+              return 'synced' as const;
             },
           },
         }),
@@ -982,6 +1091,7 @@ describe('session pointer transaction', () => {
             },
             openAndSync: async (path) => {
               if (phase.fail === 'sync' && path === tempPath) throw new Error('pointer sync failure');
+              return 'synced' as const;
             },
             rename: async (from, to) => {
               if (phase.fail === 'rename' && from === tempPath && to === context.sessionPath) {

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -27,6 +27,13 @@ import {
   type StateRootSource,
 } from '../mcp/state-paths.js';
 import type { PromptDiagnosticDescriptor } from './prompt-session-provenance.js';
+import {
+  emitDegradedDurabilityWarning,
+  recordRegularFileSyncOutcome,
+  syncRegularFile,
+  type RegularFileDurabilityTracker,
+  type RegularFileSyncOutcome,
+} from '../utils/file-durability.js';
 
 export interface SessionState {
   session_id: string;
@@ -275,6 +282,8 @@ export interface SessionStaleCheckOptions {
 export interface SessionStartOptions {
   pid?: number;
   platform?: NodeJS.Platform;
+  /** @internal Scoped deterministic regular-file fsync seam. */
+  regularFileSync?: (platform: NodeJS.Platform) => Promise<void>;
   nativeSessionId?: string;
   previousNativeSessionId?: string;
   nativeSessionSwitchedAt?: string;
@@ -299,7 +308,11 @@ export interface SessionPointerFsDependencies {
   readdir(path: string): Promise<string[]>;
   readFile(path: string, encoding: 'utf8'): Promise<string>;
   writeFile(path: string, data: string, options?: { mode?: number; flag?: string }): Promise<void>;
-  openAndSync(path: string): Promise<void>;
+  openAndSync(
+    path: string,
+    platform: NodeJS.Platform,
+    regularFileSync?: SessionStartOptions['regularFileSync'],
+  ): Promise<RegularFileSyncOutcome>;
   rename(from: string, to: string): Promise<void>;
   unlink(path: string): Promise<void>;
   rmdir(path: string): Promise<void>;
@@ -328,10 +341,13 @@ const defaultFsDependencies: SessionPointerFsDependencies = {
   writeFile: async (path, data, options) => {
     await nodeWriteFile(path, data, options);
   },
-  openAndSync: async (path) => {
+  openAndSync: async (path, platform, regularFileSync) => {
     const handle = await open(path, 'r');
     try {
-      await handle.sync();
+      return await syncRegularFile(
+        regularFileSync ? { sync: () => regularFileSync(platform) } : handle,
+        platform,
+      );
     } finally {
       await handle.close();
     }
@@ -909,6 +925,9 @@ async function acquirePointerLock(
   context: SessionPointerContext,
   candidateSessionId: string | undefined,
   timeoutMs: number,
+  platform: NodeJS.Platform,
+  tracker: RegularFileDurabilityTracker,
+  regularFileSync?: SessionStartOptions['regularFileSync'],
 ): Promise<HeldPointerLock> {
   const deadline = transactionDependencies.nowMs() + timeoutMs;
   let attempt = 0;
@@ -1005,7 +1024,7 @@ async function acquirePointerLock(
   const ownerPath = join(context.lockPath, 'owner.json');
   try {
     await transactionDependencies.fs.writeFile(ownerTempPath, JSON.stringify(buildLockOwner(token)), { mode: 0o600 });
-    await transactionDependencies.fs.openAndSync(ownerTempPath);
+    recordRegularFileSyncOutcome(tracker, await transactionDependencies.fs.openAndSync(ownerTempPath, platform, regularFileSync));
     await transactionDependencies.fs.rename(ownerTempPath, ownerPath);
   } catch (error) {
     const primary = resolvedAbort(context, {
@@ -1178,7 +1197,7 @@ interface PointerTransactionResult<T> {
 async function writePointerTransaction<T>(
   cwd: string,
   candidateSessionId: string | undefined,
-  options: Pick<SessionStartOptions, 'context'>,
+  options: Pick<SessionStartOptions, 'context' | 'platform' | 'regularFileSync'>,
   timeoutMs: number,
   transition: (pointer: SessionPointerReadResult, context: SessionPointerContext) => T,
   pointerState: (value: T) => SessionState,
@@ -1214,10 +1233,15 @@ async function writePointerTransaction<T>(
     });
   }
 
+  const platform = options.platform ?? process.platform;
+  const tracker: RegularFileDurabilityTracker = { degraded: false };
   const lock = await acquirePointerLock(
     context,
     candidateSessionId,
     timeoutMs,
+    platform,
+    tracker,
+    options.regularFileSync,
   );
   const pointerTempPath = `${context.sessionPath}.tmp-${lock.token}`;
   let pointerCommitted = false;
@@ -1265,7 +1289,10 @@ async function writePointerTransaction<T>(
       });
     }
     try {
-      await transactionDependencies.fs.openAndSync(pointerTempPath);
+      recordRegularFileSyncOutcome(
+        tracker,
+        await transactionDependencies.fs.openAndSync(pointerTempPath, platform, options.regularFileSync),
+      );
     } catch (error) {
       throw resolvedAbort(context, {
         code: 'session_pointer_io_failure',
@@ -1292,6 +1319,7 @@ async function writePointerTransaction<T>(
 
     const releaseFailures = await releasePointerLock(lock);
     if (releaseFailures.length > 0) throw releaseFailureError(releaseFailures);
+    emitDegradedDurabilityWarning('session pointer start/reconcile', tracker);
     return { context, value: next };
   } catch (error) {
     if (pointerCommitted) throw error;
@@ -1531,7 +1559,7 @@ async function removeDeadSessionHudState(
 export async function writeSessionEnd(
   cwd: string,
   sessionId: string,
-  options: Pick<SessionStartOptions, 'context'> = {},
+  options: Pick<SessionStartOptions, 'context' | 'platform' | 'regularFileSync'> = {},
 ): Promise<void> {
   const candidateSessionId = normalizeSessionId(sessionId);
   let context: SessionPointerContext;
@@ -1564,10 +1592,15 @@ export async function writeSessionEnd(
     });
   }
 
+  const platform = options.platform ?? process.platform;
+  const tracker: RegularFileDurabilityTracker = { degraded: false };
   const lock = await acquirePointerLock(
     context,
     candidateSessionId,
     DEFAULT_POINTER_TIMEOUT_MS,
+    platform,
+    tracker,
+    options.regularFileSync,
   );
   let primary: unknown;
   try {
@@ -1642,6 +1675,7 @@ export async function writeSessionEnd(
     throw primary;
   }
   if (releaseFailures.length > 0) throw releaseFailureError(releaseFailures);
+  emitDegradedDurabilityWarning('session pointer end', tracker);
 }
 
 /** Reset session-scoped HUD/metrics files at launch. */

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3705,6 +3705,34 @@ PY`,
     }
   });
 
+  it("reconciles native SessionStart on Windows EPERM with one degraded-durability warning", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-session-start-windows-eperm-"));
+    const originalWrite = process.stderr.write;
+    const warnings: string[] = [];
+    process.stderr.write = ((value: string) => {
+      warnings.push(value);
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      await dispatchCodexNativeHook(
+        { hook_event_name: "SessionStart", cwd, session_id: "sess-start-windows-eperm" },
+        {
+          cwd,
+          sessionStartOptions: {
+            platform: "win32",
+            regularFileSync: async () => { throw Object.assign(new Error("EPERM"), { code: "EPERM" }); },
+          },
+        },
+      );
+      assert.deepEqual(warnings, [
+        "[omx] warning: Windows EPERM regular-file fsync unsupported in session pointer start/reconcile; operation succeeded with degraded durability.\n",
+      ]);
+    } finally {
+      process.stderr.write = originalWrite;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("adds resume-by-id instructions for persisted subagents on SessionStart resume", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-subagent-reopen-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -47,6 +47,7 @@ import {
   readUsableSessionState,
   reconcileNativeSessionStart,
   resolveSessionPointerContext,
+  type SessionStartOptions,
   type SessionState,
 } from "../hooks/session.js";
 import {
@@ -187,6 +188,8 @@ type CodexHookPayload = Record<string, unknown>;
 interface NativeHookDispatchOptions {
   cwd?: string;
   sessionOwnerPid?: number;
+  /** @internal Scoped deterministic SessionStart durability seam for native-hook tests. */
+  sessionStartOptions?: Pick<SessionStartOptions, 'platform' | 'regularFileSync'>;
   reconcileHudForPromptSubmitFn?: typeof reconcileHudForPromptSubmit;
 }
 
@@ -10288,6 +10291,7 @@ export async function dispatchCodexNativeHook(
         const sessionState = await reconcileNativeSessionStart(cwd, nativeSessionId, {
           context: pointerContext,
           pid: options.sessionOwnerPid ?? resolveSessionOwnerPid(payload),
+          ...options.sessionStartOptions,
           ...(ownerOmxSessionId
             ? { ownerOmxSessionId, ownerAliasVerified: true }
             : {}),
@@ -10621,6 +10625,7 @@ export async function dispatchCodexNativeHook(
         const sessionState = await reconcileNativeSessionStart(cwd, nativeSessionId, {
           context: pointerContext,
           pid: options.sessionOwnerPid ?? resolveSessionOwnerPid(payload),
+          ...options.sessionStartOptions,
           ...(ownerOmxSessionId ? { ownerOmxSessionId, ownerAliasVerified: true } : {}),
         });
         const bootstrapSessionId = safeString(sessionState.session_id).trim();

--- a/src/utils/__tests__/file-durability.test.ts
+++ b/src/utils/__tests__/file-durability.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+	emitDegradedDurabilityWarning,
+	recordRegularFileSyncOutcome,
+	syncRegularFile,
+	type RegularFileDurabilityTracker,
+} from "../file-durability.js";
+
+function errno(code: unknown): Error & { code: unknown } {
+	return Object.assign(new Error(`${String(code)}: fsync`), { code });
+}
+
+test("regular-file sync returns the Windows EPERM durability outcome", async () => {
+	const outcome = await syncRegularFile(
+		{ sync: async () => { throw errno("EPERM"); } },
+		"win32",
+	);
+	assert.equal(outcome, "unsupported-windows-eperm");
+});
+
+test("regular-file sync returns synced after a successful sync", async () => {
+	assert.equal(await syncRegularFile({ sync: async () => {} }, "win32"), "synced");
+});
+
+for (const { description, platform, failure } of [
+	{ description: "Linux string EPERM", platform: "linux", failure: errno("EPERM") },
+	{ description: "Windows EACCES", platform: "win32", failure: errno("EACCES") },
+	{ description: "Windows non-string code", platform: "win32", failure: errno(1) },
+	{ description: "Windows message-only EPERM", platform: "win32", failure: new Error("EPERM") },
+] as const) {
+	test(`regular-file sync preserves fatal error identity for ${description}`, async () => {
+		await assert.rejects(
+			syncRegularFile({ sync: async () => { throw failure; } }, platform),
+			(error: unknown) => error === failure,
+		);
+	});
+}
+
+test("durability tracker aggregates outcomes and emits one exact best-effort warning", () => {
+	const tracker: RegularFileDurabilityTracker = { degraded: false };
+	recordRegularFileSyncOutcome(tracker, "synced");
+	recordRegularFileSyncOutcome(tracker, "unsupported-windows-eperm");
+	recordRegularFileSyncOutcome(tracker, "unsupported-windows-eperm");
+	const originalWrite = process.stderr.write;
+	const warnings: string[] = [];
+	process.stderr.write = ((value: string) => {
+		warnings.push(value);
+		return true;
+	}) as typeof process.stderr.write;
+	try {
+		emitDegradedDurabilityWarning("session pointer start/reconcile", tracker);
+	} finally {
+		process.stderr.write = originalWrite;
+	}
+	assert.deepEqual(warnings, [
+		"[omx] warning: Windows EPERM regular-file fsync unsupported in session pointer start/reconcile; operation succeeded with degraded durability.\n",
+	]);
+});
+
+test("a throwing stderr sink cannot fail an already successful transaction", () => {
+	const originalWrite = process.stderr.write;
+	const tracker: RegularFileDurabilityTracker = { degraded: false };
+	recordRegularFileSyncOutcome(tracker, "unsupported-windows-eperm");
+	process.stderr.write = (() => { throw new Error("stderr unavailable"); }) as typeof process.stderr.write;
+	try {
+		assert.doesNotThrow(() => emitDegradedDurabilityWarning("session pointer end", tracker));
+	} finally {
+		process.stderr.write = originalWrite;
+	}
+});

--- a/src/utils/file-durability.ts
+++ b/src/utils/file-durability.ts
@@ -1,0 +1,65 @@
+import type { FileHandle } from "fs/promises";
+
+export type RegularFileSyncOutcome = "synced" | "unsupported-windows-eperm";
+
+export type DurabilityWarningSubsystem =
+	| "session pointer start/reconcile"
+	| "session pointer end"
+	| "native-hook setup"
+	| "native-hook uninstall"
+	| "native-hook claim-journal recovery";
+
+export interface RegularFileDurabilityTracker {
+	degraded: boolean;
+}
+
+function isUnsupportedWindowsRegularFileSync(
+	error: unknown,
+	platform: NodeJS.Platform,
+): boolean {
+	return platform === "win32"
+		&& typeof error === "object"
+		&& error !== null
+		&& "code" in error
+		&& (error as { code?: unknown }).code === "EPERM";
+}
+
+/**
+ * Windows can report EPERM when fsync is unsupported for an otherwise valid
+ * regular-file handle. Only that platform/error pair is a durability
+ * capability limitation; every other failure remains fatal.
+ */
+
+export async function syncRegularFile(
+	handle: Pick<FileHandle, "sync">,
+	platform: NodeJS.Platform = process.platform,
+): Promise<RegularFileSyncOutcome> {
+	try {
+		await handle.sync();
+		return "synced";
+	} catch (error) {
+		if (!isUnsupportedWindowsRegularFileSync(error, platform)) throw error;
+		return "unsupported-windows-eperm";
+	}
+}
+
+export function recordRegularFileSyncOutcome(
+	tracker: RegularFileDurabilityTracker,
+	outcome: RegularFileSyncOutcome,
+): void {
+	tracker.degraded ||= outcome === "unsupported-windows-eperm";
+}
+
+export function emitDegradedDurabilityWarning(
+	subsystem: DurabilityWarningSubsystem,
+	tracker: RegularFileDurabilityTracker,
+): void {
+	if (!tracker.degraded) return;
+	try {
+		process.stderr.write(
+			`[omx] warning: Windows EPERM regular-file fsync unsupported in ${subsystem}; operation succeeded with degraded durability.\n`,
+		);
+	} catch {
+		// Diagnostics must not fail an already committed transaction.
+	}
+}


### PR DESCRIPTION
## Summary
- tolerate only native Windows regular-file `fsync` failures whose structured code is exactly `EPERM`
- preserve all POSIX, non-`EPERM`, directory-sync, write, close, rename, rollback, claim-journal, and recovery failures
- aggregate degraded durability per transaction and emit exactly one post-commit stderr warning naming Windows EPERM, subsystem, and degraded durability
- cover session start/reconcile/end, setup, uninstall, doctor recovery, and claim-journal paths with scoped deterministic seams

## Verification
- `npx tsc --noEmit`
- `npm run check:no-unused`
- `npm run lint`
- `npm run build`
- focused 7-file regression suite: utility, session, claim journal, setup, uninstall, doctor, native SessionStart
- `npm run test:ci:compiled`

Fixes #3189

—

_[repo owner's gaebal-gajae (clawdbot) 🦞]_