### PR TITLE
fix(cli): support isolated standard conversations

### DIFF
--- a/.github/scripts/dev-merge-issue-close.cjs
+++ b/.github/scripts/dev-merge-issue-close.cjs
@@ -93,6 +93,9 @@ function buildMaintainerCloseComment({ prNumber }) {
     `Closing automatically because PR #${prNumber} was merged into \`dev\` and explicitly referenced this issue in the PR title or body.`,
     '',
     'A hot-fix build is available now. Try it with `omx update --dev` and let us know whether it resolves the issue.',
+    '',
+    '—',
+    "*[repo owner's gaebal-gajae (clawdbot) 🦞]*",
   ].join('\n');
 }
 
@@ -105,6 +108,9 @@ function buildMaintainerPrComment({ issueNumbers }) {
     `Closed explicitly linked issue${issueNumbers.length === 1 ? '' : 's'} after this PR was merged into \`dev\`: ${formatIssueList(issueNumbers)}.`,
     '',
     'A hot-fix build is available now. Issue creators can try it with `omx update --dev` and let us know whether it resolves the issue.',
+    '',
+    '—',
+    "*[repo owner's gaebal-gajae (clawdbot) 🦞]*",
   ].join('\n');
 }
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,32 @@ created and recovered. `--worktree` also moves the launch into a separate git
 checkout, which is the safer default when using `--madmax`. Replace
 `feat/task` with a branch-like name for the task.
 
+### Concurrent standard conversations
+
+A standard launch owns one writable session pointer under its selected `OMX_ROOT`. A second ordinary `omx` launch from the same checkout therefore fails closed instead of sharing or silently changing that root. Give each additional conversation an explicit, distinct root:
+
+```bash
+omx
+OMX_ROOT="$HOME/.omx/instances/second-conversation" omx
+OMX_ROOT="$HOME/.omx/instances/third-conversation" omx
+```
+
+PowerShell:
+
+```powershell
+$env:OMX_ROOT = "$HOME/.omx/instances/second-conversation"
+omx
+```
+
+Command Prompt:
+
+```bat
+set "OMX_ROOT=%USERPROFILE%\.omx\instances\second-conversation"
+omx
+```
+
+User-specified roots are literal: launching twice with the same explicit `OMX_ROOT` remains a fatal owner conflict. Separate checkouts have separate default roots, while `--worktree` and `--madmax` keep their existing isolation behavior.
+
 ### Madmax and worktree launch safety
 
 `--madmax` is OMX shorthand for Codex

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -2,12 +2,13 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
 import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { HUD_TMUX_HEIGHT_LINES } from '../../hud/constants.js';
 import { DETACHED_TMUX_HISTORY_LIMIT } from '../index.js';
+import { writeSessionEnd, writeSessionStart } from '../../hooks/session.js';
 
 const CLI_SPAWN_TIMEOUT_MS = 60_000;
 
@@ -119,6 +120,75 @@ async function createLaunchFixture(
   };
 }
 
+function startHeldOmx(
+  cwd: string,
+  envOverrides: Record<string, string>,
+): ReturnType<typeof spawn> {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, '..', '..', '..');
+  return spawn(process.execPath, [join(repoRoot, 'dist', 'cli', 'omx.js'), '--direct', '--version'], {
+    cwd,
+    env: buildRunOmxEnv(envOverrides),
+    stdio: 'inherit',
+  });
+}
+
+async function waitForPath(path: string, expectedLines: number = 1): Promise<void> {
+  for (let attempt = 0; attempt < 300; attempt += 1) {
+    if (existsSync(path)) {
+      const contents = await readFile(path, 'utf-8').catch(() => '');
+      if (contents.trim().split('\n').filter(Boolean).length >= expectedLines) return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`timed out waiting for ${path}`);
+}
+
+async function stopHeldOmx(child: ReturnType<typeof spawn>, releasePath: string): Promise<void> {
+  await rm(releasePath, { force: true });
+  await new Promise<void>((resolve, reject) => {
+    child.once('error', reject);
+    child.once('exit', () => resolve());
+  });
+}
+
+async function createHeldCodexFixture(wd: string): Promise<{
+  env: Record<string, string>;
+  releasePath: string;
+  rootsPath: string;
+}> {
+  const home = join(wd, 'home');
+  const fakeBin = join(wd, 'bin');
+  const releasePath = join(wd, 'hold');
+  const rootsPath = join(wd, 'roots.log');
+  await mkdir(home, { recursive: true });
+  await mkdir(fakeBin, { recursive: true });
+  await writeFile(releasePath, 'hold\n');
+  await writeExecutable(
+    join(fakeBin, 'codex'),
+    `#!/bin/sh
+printf '%s\\n' "$OMX_ROOT" >> "${rootsPath}"
+while [ -f "${releasePath}" ]; do sleep 1; done
+`,
+  );
+  await writeExecutable(join(fakeBin, 'ps'), '#!/bin/sh\nexit 0\n');
+  return {
+    releasePath,
+    rootsPath,
+    env: {
+      HOME: home,
+      PATH: `${fakeBin}:/usr/bin:/bin`,
+      OMX_AUTO_UPDATE: '0',
+      OMX_NOTIFY_FALLBACK: '0',
+      OMX_HOOK_DERIVED_SIGNALS: '0',
+      OMX_ROOT: '',
+      OMX_STATE_ROOT: '',
+      TMUX: '',
+      TMUX_PANE: '',
+    },
+  };
+}
+
 describe('omx launch fallback when tmux is unavailable', () => {
   it('surfaces direct Codex startup stderr and preserves the child exit code', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-child-error-'));
@@ -223,6 +293,105 @@ exit 42
       assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
       assert.match(result.stdout, /fake-codex:.*model_reasoning_effort="xhigh"/);
       assert.doesNotMatch(result.stderr, /spawnSync tmux ENOENT/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('ordinary launch root collision guidance', () => {
+  it('keeps the cwd default for the first launch and fails the second and third launches closed with explicit-root guidance', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-root-conflict-'));
+    try {
+      execFileSync('git', ['init'], { cwd: wd, stdio: 'ignore' });
+      const fixture = await createHeldCodexFixture(wd);
+      await writeSessionStart(wd, 'first-standard-launch', { pid: process.pid });
+
+      const second = runOmx(wd, ['--direct', '--version'], fixture.env);
+      const third = runOmx(wd, ['--direct', '--version'], fixture.env);
+      if (shouldSkipForSpawnPermissions(second.error) || shouldSkipForSpawnPermissions(third.error)) return;
+      for (const result of [second, third]) {
+        assert.notEqual(result.status, 0, result.stderr || result.stdout);
+        assert.match(result.stderr, /session_pointer_owner_conflict/);
+        assert.match(result.stderr, /concurrent conversations in this checkout require distinct user-specified OMX_ROOT values/);
+        assert.match(result.stderr, /POSIX: OMX_ROOT="\$HOME\/\.omx\/instances\/second-conversation" omx/);
+        assert.match(result.stderr, /PowerShell: \$env:OMX_ROOT = "\$HOME\/\.omx\/instances\/second-conversation"; omx/);
+        assert.match(result.stderr, /cmd\.exe: set "OMX_ROOT=%USERPROFILE%\\\.omx\\instances\\second-conversation" && omx/);
+        assert.match(result.stderr, /OMX does not reroute or allocate one automatically/);
+      }
+      const resume = runOmx(wd, ['--direct', 'resume'], fixture.env);
+      if (!shouldSkipForSpawnPermissions(resume.error)) {
+        assert.notEqual(resume.status, 0, resume.stderr || resume.stdout);
+        assert.match(resume.stderr, /session_pointer_owner_conflict/);
+        assert.doesNotMatch(resume.stderr, /concurrent conversations in this checkout require distinct user-specified OMX_ROOT values/);
+      }
+      await writeSessionEnd(wd, 'first-standard-launch');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps explicit roots literal: distinct roots launch independently while a shared root remains fatal without reroute guidance', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-explicit-roots-'));
+    execFileSync('git', ['init'], { cwd: wd, stdio: 'ignore' });
+    let first: ReturnType<typeof spawn> | undefined;
+    let second: ReturnType<typeof spawn> | undefined;
+    try {
+      const fixture = await createHeldCodexFixture(wd);
+      const firstRoot = join(wd, 'first-root');
+      const secondRoot = join(wd, 'second-root');
+      first = startHeldOmx(wd, { ...fixture.env, OMX_ROOT: firstRoot });
+      second = startHeldOmx(wd, { ...fixture.env, OMX_ROOT: secondRoot });
+      await waitForPath(fixture.rootsPath, 2);
+      assert.deepEqual(
+        new Set((await readFile(fixture.rootsPath, 'utf-8')).trim().split('\n')),
+        new Set([firstRoot, secondRoot]),
+      );
+
+      const collision = runOmx(wd, ['--direct', '--version'], { ...fixture.env, OMX_ROOT: firstRoot });
+      if (shouldSkipForSpawnPermissions(collision.error)) return;
+      assert.notEqual(collision.status, 0, collision.stderr || collision.stdout);
+      assert.match(collision.stderr, /session_pointer_owner_conflict/);
+      assert.doesNotMatch(collision.stderr, /concurrent conversations in this checkout require distinct user-specified OMX_ROOT values/);
+      assert.doesNotMatch(collision.stderr, /reroute or allocate one automatically/);
+
+      await stopHeldOmx(first, fixture.releasePath);
+      first = undefined;
+      if (second.exitCode === null) {
+        await new Promise<void>((resolve) => second!.once('exit', () => resolve()));
+      }
+      second = undefined;
+    } finally {
+      if (first) first.kill('SIGKILL');
+      if (second) second.kill('SIGKILL');
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps different checkout defaults independent and relaunches through stale default-pointer evidence', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-root-stale-'));
+    try {
+      const firstCheckout = join(wd, 'first-checkout');
+      const secondCheckout = join(wd, 'second-checkout');
+      await mkdir(firstCheckout, { recursive: true });
+      await mkdir(secondCheckout, { recursive: true });
+      execFileSync('git', ['init'], { cwd: firstCheckout, stdio: 'ignore' });
+      execFileSync('git', ['init'], { cwd: secondCheckout, stdio: 'ignore' });
+
+      await writeSessionStart(firstCheckout, 'first-checkout-owner', { pid: process.pid });
+      await writeSessionStart(secondCheckout, 'second-checkout-owner', { pid: process.pid });
+      assert.match(await readFile(join(firstCheckout, '.omx', 'state', 'session.json'), 'utf-8'), /first-checkout-owner/);
+      assert.match(await readFile(join(secondCheckout, '.omx', 'state', 'session.json'), 'utf-8'), /second-checkout-owner/);
+      await writeSessionEnd(firstCheckout, 'first-checkout-owner');
+      await writeSessionEnd(secondCheckout, 'second-checkout-owner');
+
+      await writeSessionStart(firstCheckout, 'stale-owner', { pid: 2_147_483_647 });
+      const fixture = await createHeldCodexFixture(wd);
+      await rm(fixture.releasePath, { force: true });
+      const relaunch = runOmx(firstCheckout, ['--direct', '--version'], fixture.env);
+      if (shouldSkipForSpawnPermissions(relaunch.error)) return;
+      assert.equal(relaunch.status, 0, relaunch.error || relaunch.stderr || relaunch.stdout);
+      assert.doesNotMatch(relaunch.stderr, /concurrent conversations in this checkout require distinct user-specified OMX_ROOT values/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -68,6 +68,7 @@ import {
 } from "./constants.js";
 import {
   getBaseStateDir,
+  getBaseStateDirWithSource,
   getStateDir,
   listModeStateFilesWithScopePreference,
   resolveWritableStateScope,
@@ -1635,6 +1636,25 @@ function hasErrnoCode(error: unknown, code: string): boolean {
 
 function isMissingTmuxLaunchNoise(error: unknown): boolean {
   return error instanceof Error && /spawnSync tmux ENOENT/i.test(error.message);
+}
+
+function reportOrdinaryLaunchRootConflict(
+  error: unknown,
+  cwd: string,
+  ordinaryLaunch: boolean,
+): void {
+  if (!ordinaryLaunch || !isSessionPointerLaunchAbort(error)
+    || error.code !== "session_pointer_owner_conflict"
+    || getBaseStateDirWithSource(cwd).rootSource !== "cwd-default") return;
+
+  console.error(
+    "[omx] concurrent conversations in this checkout require distinct user-specified OMX_ROOT values.\n" +
+      "[omx] Choose a distinct directory and set OMX_ROOT before launching the additional conversation.\n" +
+      "[omx] POSIX: OMX_ROOT=\"$HOME/.omx/instances/second-conversation\" omx\n" +
+      "[omx] PowerShell: $env:OMX_ROOT = \"$HOME/.omx/instances/second-conversation\"; omx\n" +
+      "[omx] cmd.exe: set \"OMX_ROOT=%USERPROFILE%\\.omx\\instances\\second-conversation\" && omx\n" +
+      "[omx] The selected OMX_ROOT is used literally; OMX does not reroute or allocate one automatically.",
+  );
 }
 
 function logCliOperationFailure(error: unknown): void {
@@ -3331,6 +3351,11 @@ export async function launchWithHud(args: string[]): Promise<void> {
   } catch (err) {
     if (isSessionPointerLaunchAbort(err)) {
       console.error(`[omx] session pointer launch aborted: ${err.code}`);
+      reportOrdinaryLaunchRootConflict(
+        err,
+        cwd,
+        cwd === launchCwd && !parsedWorktree.mode.enabled && !isResumeCodexLaunch(normalizedArgs),
+      );
       await cleanupRuntimeCodexHome(
         preparedCodexHome.runtimeCodexHomeForCleanup,
         projectLocalCodexHomeForCleanup,

--- a/src/verification/__tests__/dev-merge-issue-close-workflow.test.ts
+++ b/src/verification/__tests__/dev-merge-issue-close-workflow.test.ts
@@ -107,6 +107,7 @@ describe('dev merge issue close workflow', () => {
     assert.match(comment, /A hot-fix build is available now\./);
     assert.match(comment, /`omx update --dev`/);
     assert.match(comment, /let us know whether it resolves the issue/);
+    assert.match(comment, /\n\n—\n\*\[repo owner's gaebal-gajae \(clawdbot\) 🦞\]\*$/);
   });
 
   it('provides a matching PR summary comment after linked issues close', () => {
@@ -118,6 +119,7 @@ describe('dev merge issue close workflow', () => {
     assert.match(comment, /A hot-fix build is available now\./);
     assert.match(comment, /Issue creators can try it with `omx update --dev`/);
     assert.match(comment, /let us know whether it resolves the issue/);
+    assert.match(comment, /\n\n—\n\*\[repo owner's gaebal-gajae \(clawdbot\) 🦞\]\*$/);
   });
   it('posts the PR follow-up comment on the success path', async () => {
     const calls: Array<Record<string, unknown>> = [];
@@ -149,6 +151,7 @@ describe('dev merge issue close workflow', () => {
     assert.equal(calls[0].repo, 'oh-my-codex');
     assert.equal(calls[0].issue_number, 2825);
     assert.match(String(calls[0].body), /Closed explicitly linked issue after this PR was merged into `dev`: #2824\./);
+    assert.match(String(calls[0].body), /\n\n—\n\*\[repo owner's gaebal-gajae \(clawdbot\) 🦞\]\*$/);
     assert.deepEqual(warnings, []);
   });
 


### PR DESCRIPTION
## Summary
- keep same-root session pointer collisions fail-closed
- give ordinary same-checkout launches deterministic guidance for distinct literal `OMX_ROOT` values
- add process-level regression coverage for second/third launches, explicit distinct/shared roots, separate checkouts, stale recovery, resume suppression, Madmax/worktree behavior
- sign dev-merge issue/PR automation comments

## Verification
- `npm run build`
- focused launch/workflow suites
- full launch-fallback, index/session, resume/session-search suites
- `npm run lint`
- `npm run check:no-unused`
- `npx tsc --noEmit`
- `npm test` (one unrelated MCP lifecycle timing file flaked in the aggregate run and passed immediately in isolation)
- packed-install smoke attempted; locally blocked because installed Codex 0.144.4 exceeds the script's 0.142.5 boundary

Fixes #3190

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*