### PR TITLE
Make agent assurance proportional to task risk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,44 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 - Reuse existing utils and patterns before introducing new abstractions.
 - No new dependencies without explicit request.
 - Keep diffs small, reviewable, and reversible.
-- Run lint, typecheck, tests, and static analysis after changes.
+- Run relevant lint, typecheck, tests, and static analysis for the changed surface; documentation-only and exploratory artifact work uses its applicable render, parse, link, or provenance checks instead of unrelated engineering suites.
 - Final reports must include changed files, simplifications made, and remaining risks.
+
+## AI-assisted engineering defaults
+- Start from existing context before designing: read the relevant repo docs, AGENTS/CONTEXT files, ADRs, and wiki indexes before changing behavior.
+- Name the public interface and the user/caller-visible behavior before writing tests or implementation.
+- Use modular tracer bullets: before substantive implementation, name the modules crossed and freeze each changed module's responsibility, public contract, invariants, allowed dependencies, and focused tests.
+- Prefer tracer-bullet vertical slices over layer-only delivery. A slice should prove one narrow path through the real architecture and be demoable or verifiable on its own.
+- Use TDD one behavior at a time: write one RED test, confirm it fails for a behavioral reason, write the minimum GREEN implementation, then refactor only while tests stay green.
+- Test through public interfaces and owned seams. Mock only at system boundaries when the feedback loop is affordable.
+- Verify from narrow to broad: changed-module tests -> boundary contract/integration tests -> tracer acceptance -> broad regression/CI. Stop at the first failing layer.
+- For substantive AI-authored tests, separate test-author, implementer, and verifier authority where practical; implementers must not weaken acceptance tests without explicit controller review.
+- Update glossary, wiki, CONTEXT files, or ADRs when a domain term or hard-to-reverse trade-off is settled.
+- Before changing agent or skill guidance, audit recent session calls and trace active surfaces to their owned source/template; do not treat generated plugin caches as durable sources.
+- Route these workflow entry points through the user-owned unprefixed workflow overlays: `writing-plans`, `test-driven-development`, and `subagent-driven-development`; use `executing-plans`, `dispatching-parallel-agents`, and `verification-before-completion` for their execution phases.
+- `writing-plans` and `dispatching-parallel-agents` load their matching namespaced Superpowers skills for upstream process details.
+- `test-driven-development`, `subagent-driven-development`, `executing-plans`, and `verification-before-completion` are standalone owned policy; do not recursively enter their cached namespaced workflows when the owned overlay is active.
+
+### Lean execution default
+- Route bounded coding to one capable owner.
+- Before broad exploration, estimate task shape as `local | cross-file | repository`, risk, and confidence using at most one cheap probe; execute the smallest reliable path; expand one boundary at a time only when focused verification fails or confidence drops, reusing evidence already collected.
+- Before substantive edits, name caller-visible behaviour, owning module/public interface, invalidating assumptions and cheap probes, acceptance command, and one thin tracer.
+- Escalate only for independent lanes, security/auth/data/destructive/shared-contract risk, weak machine oracles, unexpected scope expansion, or failed grounded acceptance.
+- Re-localise when the same failure repeats twice, a second patch relies on the same unverified premise, or about five recovery actions fail to reduce uncertainty.
+
+### Proportional assurance and execution shape
+- Assurance level and execution shape are separate decisions: choose direct artifact, bounded change, standard behaviour, or full assurance from risk and oracle strength; choose solo, serial, or independent parallel execution from dependency shape and concrete benefit.
+- Use the direct artifact route for bounded article copy, wiki notes, exploratory mockups, slides, and similar non-runtime work: edit the owned artifact, inspect the actual rendered or previewed result, and stop when the requested surface is verified.
+- `superpowers:brainstorming` applies when product or design intent is materially unresolved, or when the user asks to explore alternatives before creating behaviour. It does not apply to a bounded direct artifact request when the target, requested adjustment, constraints, and acceptance surface are already specified; an explicit user request for brainstorming remains authoritative.
+- For a text-only visual-artifact edit that cannot affect layout or behaviour, a focused source or DOM assertion is sufficient unless the user asks to inspect rendered output. “Show the changed surface” does not by itself request rendered output: quote or link the changed source/DOM unless the user explicitly asks for a screenshot, preview, browser, rendered, or visual result, or the edit can affect appearance. When rendered acceptance applies and the primary renderer is unavailable, try one bounded fallback; if that also fails, report the visual-verification gap and stop. Do not cascade across Playwright, Browser, and Computer Use merely because a renderer is unavailable.
+- Add only relevant artifact controls: provenance for consequential factual claims; parse/build/link checks for structured content; reference comparison for fidelity work; accessibility/privacy/brand checks when required; native structure/editability checks for documents and decks; and explicit authority before publication or external writes.
+- File count is not a router. Multiple simple artifacts can remain direct; a one-file migration, auth change, destructive action, secrets/personal-data path, hardware-dependent behaviour, compatibility-sensitive contract, or weak oracle can require full assurance.
+- Local observable behaviour changes retain one right-reason RED/GREEN cycle or an existing right-reason failing reproduction. Discovering a hard-risk boundary jumps directly to the required assurance level; exploration scope may still expand one boundary at a time.
+
+### Child context and independent authority
+- Give child agents a compact task packet: objective, behaviour, constraints/non-goals, owned paths, evidence/unknowns, acceptance command, and return shape.
+- Do not use an all-turn fork from a mature task by default; use no inherited turns or a small recent-turn bound when supported.
+- For substantive AI-authored behaviour, keep RED author, implementer, and verifier in separate contexts; give the RED author and verifier fresh context. Freeze the right-reason RED oracle; the implementer must not weaken it.
 
 ---
 
@@ -135,7 +171,7 @@ The `deep-interview` skill is the Socratic deep interview workflow and includes 
 | Keyword(s) | Skill | Action |
 |-------------|-------|--------|
 | "ralph", "don't stop", "must complete", "keep going" | `$ralph` | Read `./.codex/skills/ralph/SKILL.md`, execute persistence loop |
-| "autopilot", "build me", "I want a" | `$autopilot` | Read `./.codex/skills/autopilot/SKILL.md`, execute autonomous pipeline |
+| "autopilot", "build me" | `$autopilot` | Read `./.codex/skills/autopilot/SKILL.md`, execute autonomous pipeline |
 | "ultrawork", "ulw", "parallel" | `$ultrawork` | Read `./.codex/skills/ultrawork/SKILL.md`, execute parallel agents |
 | "ultraqa" | `$ultraqa` | Read `./.codex/skills/ultraqa/SKILL.md`, run QA cycling workflow |
 | "analyze", "investigate" | `$analyze` | Read `./.codex/skills/analyze/SKILL.md`, run deep analysis |
@@ -153,6 +189,7 @@ The `deep-interview` skill is the Socratic deep interview workflow and includes 
 
 Detection rules:
 - Keywords are case-insensitive and match anywhere in the user message.
+- Implicit keyword matches require affirmative invocation intent; negated or mention-only occurrences do not activate a mode. Explicit `$name` invocations remain authoritative.
 - Explicit `$name` invocations run left-to-right and override non-explicit keyword resolution.
 - If multiple non-explicit keywords match, use the most specific match.
 - If the user explicitly invokes `$name`, run those explicit invocations left-to-right before considering non-explicit keyword routing.
@@ -269,17 +306,18 @@ Parallelization:
 - If correctness depends on retrieval, diagnostics, tests, or other tools, continue using them until the task is grounded and verified.
 
 Anti-slop workflow:
-- Cleanup/refactor/deslop work still follows the same `$deep-interview` -> `$ralplan` -> `$team`/`$ralph` path; use `$ai-slop-cleaner` as a bounded helper inside the chosen execution lane, not as a competing top-level workflow.
+- Route cleanup/refactor/deslop work proportionally: use the active solo, serial, or parallel execution lane that the task already earns, and use `$ai-slop-cleaner` as a bounded helper rather than forcing interview, consensus planning, Team, or Ralph for every cleanup.
 - Lock behavior with tests first, then make one smell-focused pass at a time.
 - Prefer deletion, reuse, and boundary repair over new layers.
 - Keep writer/reviewer pass separation for cleanup plans and approvals.
 
 Visual iteration gate:
-- For visual tasks, run `$visual-verdict` every iteration before the next edit.
-- Persist verdict JSON in `.omx/state/{scope}/ralph-progress.json`.
+- Run `$visual-verdict` before the next edit only for visual fidelity work that has both a generated screenshot and at least one reference image.
+- For exploratory mockups without a reference, inspect and show the rendered artifact directly; do not manufacture a numeric fidelity gate.
+- When `$visual-verdict` applies, persist verdict JSON in `.omx/state/{scope}/ralph-progress.json`.
 
 Continuation:
-Before concluding, confirm: no pending work, features working, tests passing, zero known errors, verification evidence collected. If not, continue.
+Before concluding, confirm: no pending in-scope work, the requested surface works, tests pass where tests apply, no known attributable errors remain, and fresh applicable verification evidence was collected. If not, continue.
 
 Ralph planning gate:
 If ralph is active, verify PRD + test spec artifacts exist before implementation work.

--- a/prompts/executor.md
+++ b/prompts/executor.md
@@ -49,6 +49,13 @@ Treat implementation, fix, and investigation requests as action requests by defa
 If the user asks a pure explanation question and explicitly says not to change anything, explain only. Otherwise, keep moving toward a finished result.
 </intent>
 
+<modular_tracer_contract>
+- For substantive work, identify the observable tracer behavior and modules crossed before editing.
+- Preserve the plan's frozen module contracts: responsibility, public inputs/outputs/errors, invariants, and allowed dependencies. Escalate contract changes instead of silently widening them.
+- Implement one thin end-to-end tracer before layer-only fan-out, and keep each RED -> GREEN cycle scoped to one behavior through a public interface.
+- Verify in this order: changed-module tests -> boundary contract/integration tests -> tracer acceptance -> broad regression/CI. Stop and repair at the first failing layer.
+</modular_tracer_contract>
+
 <execution_loop>
 1. Explore the relevant files, patterns, and tests.
 2. Make a concrete file-level plan.
@@ -73,6 +80,7 @@ After implementation:
 2. Run related tests, or state none exist.
 3. Run typecheck/build when applicable.
 4. Check changed files for accidental debug leftovers.
+5. Confirm no frozen module contract or allowed-dependency boundary drifted.
 
 No evidence = not complete.
 </verification_loop>

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -33,6 +33,13 @@ You are Planner (Prometheus). Turn requests into actionable work plans. You plan
 Interpret implementation requests as planning requests only when this role is explicitly invoked. Your job is to leave execution with a plan that can be acted on immediately.
 </intent>
 
+<modular_tracer_contract>
+- For substantive behavior changes, define one observable tracer behavior and the modules crossed before decomposing implementation work.
+- Give every changed module a module contract card: responsibility, public inputs/outputs/errors, invariants, allowed dependencies, focused tests, and contracts that must remain frozen.
+- Keep the tracer thin: one demonstrable path through the real architecture, with non-goals and forbidden scope stated explicitly.
+- Specify verification in this order: changed-module tests -> boundary contract/integration tests -> tracer acceptance -> broad regression/CI.
+</modular_tracer_contract>
+
 <explore>
 1. Inspect the repository before asking the user about code facts.
 2. Classify the task: simple, refactor, new feature, or broad initiative.
@@ -51,6 +58,7 @@ Interpret implementation requests as planning requests only when this role is ex
 <success_criteria>
 - The plan has an adaptive number of actionable steps that matches the task scope (for example, fewer for a tight fix and more for broader work) without defaulting to five.
 - Acceptance criteria are specific and testable.
+- Substantive plans include the modular tracer contract and narrow-to-broad verification ladder.
 - Codebase facts come from repository inspection, not user guesses.
 - The plan is saved to `.omx/plans/{name}.md`.
 - User confirmation is obtained before handoff.

--- a/prompts/test-engineer.md
+++ b/prompts/test-engineer.md
@@ -34,6 +34,13 @@ Tests are executable documentation of expected behavior. These rules exist becau
 5) Run all tests after changes to verify no regressions.
 </explore>
 
+<modular_tracer_contract>
+- Test public module contracts deeply: responsibility, inputs/outputs/errors, invariants, and dependency boundaries. Avoid coupling focused tests to private helpers.
+- Keep end-to-end coverage to a thin tracer that proves the changed modules compose; do not duplicate every module edge case at the tracer layer.
+- Build and report the ladder explicitly: changed-module tests -> boundary contract/integration tests -> tracer acceptance -> broad regression/CI.
+- In TDD, freeze each right-reason RED oracle before implementation and reject downstream weakening without controller review.
+</modular_tracer_contract>
+
 <execution_loop>
 <success_criteria>
 - Tests follow the testing pyramid: 70% unit, 20% integration, 10% e2e
@@ -42,6 +49,7 @@ Tests are executable documentation of expected behavior. These rules exist becau
 - Coverage gaps identified with risk levels
 - Flaky tests diagnosed with root cause and fix applied
 - TDD cycle followed: RED (failing test) -> GREEN (minimal code) -> REFACTOR (clean up)
+- The focused module, boundary, tracer, and regression layers are proportionate to the change risk.
 </success_criteria>
 
 <verification_loop>

--- a/prompts/verifier.md
+++ b/prompts/verifier.md
@@ -29,11 +29,17 @@ You are Verifier. Your job is to prove or disprove completion with concrete evid
 3. Run or review the commands that prove the claim.
 4. Report verdict, evidence, gaps, and risk.
 
+For substantive modular tracer work:
+5. Compare the diff with each frozen module contract and reject unexplained module-contract drift, forbidden dependencies, or widened public interfaces.
+6. Require fresh evidence in this order: changed-module tests -> boundary contract/integration tests -> tracer acceptance -> broad regression/CI.
+7. Confirm the tracer proves one real composed behavior and that focused tests carry module edge cases.
+
 <success_criteria>
 - The verdict is grounded in commands, code, or artifacts.
 - Acceptance criteria are checked directly.
 - Missing proof is called out explicitly.
 - The final verdict is grounded and actionable.
+- Each required verification layer is present or explicitly marked not applicable with evidence.
 </success_criteria>
 
 <verification_loop>

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -4,12 +4,12 @@ description: Full autonomous execution from idea to working code
 ---
 
 <Purpose>
-Autopilot takes a brief product idea and autonomously handles the full lifecycle: requirements analysis, technical design, planning, parallel implementation, QA cycling, and multi-perspective validation. It produces working, verified code from a 2-3 line description.
+Autopilot takes a product idea or approved artifact and autonomously carries it to working, verified code. It adapts requirements, planning, execution, QA, and validation effort to the task instead of requiring parallel implementation and every reviewer on every run.
 </Purpose>
 
 <Use_When>
 - User wants end-to-end autonomous execution from an idea to working code
-- User says "autopilot", "auto pilot", "autonomous", "build me", "create me", "make me", "full auto", "handle it all", or "I want a/an..."
+- User says "autopilot", "auto pilot", "autonomous", "build me", "create me", "make me", "full auto", or "handle it all"
 - Task requires multiple phases: planning, coding, testing, and validation
 - User wants hands-off execution and is willing to let the system run to completion
 </Use_When>
@@ -23,14 +23,17 @@ Autopilot takes a brief product idea and autonomously handles the full lifecycle
 </Do_Not_Use_When>
 
 <Why_This_Exists>
-Most non-trivial software tasks require coordinated phases: understanding requirements, designing a solution, implementing in parallel, testing, and validating quality. Autopilot orchestrates all of these phases automatically so the user can describe what they want and receive working code without managing each step.
+Most non-trivial software tasks require coordinated phases: understanding requirements, designing a solution, implementing the smallest owned execution shape, testing, and validating quality. Autopilot orchestrates these phases automatically while reusing approved artifacts and adding parallel lanes or reviewers only when task shape and risk justify them.
 </Why_This_Exists>
 
 <Execution_Policy>
 - Each phase must complete before the next begins
-- Parallel execution is used within phases where possible (Phase 2 and Phase 4)
+- Reuse an approved spec or implementation plan instead of regenerating equivalent artifacts
+- Use one planning owner by default; add a critic or specialist only when ambiguity, reversibility, or risk requires independent challenge
+- Execute solo for one owned lane; parallelize only independent lanes with explicit ownership and merge boundaries
+- Select a risk-matched reviewer set from the surfaces changed; reviewer count is not a completion metric
 - QA cycles repeat up to 5 times; if the same error persists 3 times, stop and report the fundamental issue
-- Validation requires approval from all reviewers; rejected items get fixed and re-validated
+- Validation requires approval from all selected risk-matched reviewers; rejected items get fixed and re-validated
 - Cancel with `/cancel` at any time; progress is preserved for resume
 - If a deep-interview spec exists, use it as high-clarity phase input instead of re-expanding from scratch
 - If input is too vague for reliable expansion, offer/trigger `$deep-interview` first
@@ -56,33 +59,34 @@ Most non-trivial software tasks require coordinated phases: understanding requir
    - Carry the snapshot path into autopilot artifacts/state so all phases share grounded context.
 
 1. **Phase 0 - Expansion**: Turn the user's idea into a detailed spec
-   - If `.omx/specs/deep-interview-*.md` exists for this task: reuse it and skip redundant expansion work
+   - If an approved spec or `.omx/specs/deep-interview-*.md` exists for this task: reuse the approved spec and skip redundant expansion work
    - If prompt is highly vague: route to `$deep-interview` for Socratic ambiguity-gated clarification
-   - Analyst (THOROUGH tier): Extract requirements
-   - Architect (THOROUGH tier): Create technical specification
+   - If no approved artifact exists, assign one planning owner to extract requirements and create the technical specification
    - Output: `.omx/plans/autopilot-spec.md`
 
 2. **Phase 1 - Planning**: Create an implementation plan from the spec
-   - Architect (THOROUGH tier): Create plan (direct mode, no interview)
-   - Critic (THOROUGH tier): Validate plan
+   - Keep one planning owner for a clear, reversible task
+   - Add a critic or specialist only for consequential ambiguity, broad contracts, security, or hard-to-reverse decisions
    - Output: `.omx/plans/autopilot-impl.md`
 
-3. **Phase 2 - Execution**: Implement the plan using Ralph + Ultrawork
+3. **Phase 2 - Execution**: Implement the plan using Ralph, adding Ultrawork only when justified
+   - Execute solo for one owned lane
    - LOW-tier executor/search roles: Simple tasks
    - STANDARD-tier executor roles: Standard tasks
    - THOROUGH-tier executor/architect roles: Complex tasks
-   - Run independent tasks in parallel
+   - Run independent tasks in parallel only when ownership and integration boundaries are explicit
 
 4. **Phase 3 - QA**: Cycle until all tests pass (UltraQA mode)
    - Build, lint, test, fix failures
    - Repeat up to 5 cycles
    - Stop early if the same error repeats 3 times (indicates a fundamental issue)
 
-5. **Phase 4 - Validation**: Multi-perspective review in parallel
-   - Architect: Functional completeness
-   - Security-reviewer: Vulnerability check
-   - Code-reviewer: Quality review
-   - All must approve; fix and re-validate on rejection
+5. **Phase 4 - Validation**: Risk-matched review
+   - Always verify functional completeness with fresh executable evidence
+   - Add an architect for architectural or shared public contract risk
+   - Add a security-reviewer for trust-boundary, auth, secret, or input-handling risk
+   - Add a code-reviewer when change breadth or weak executable oracles warrant an independent quality review
+   - Selected reviewers must approve; fix and re-validate on rejection
 
 6. **Phase 5 - Cleanup**: Clear all mode state via OMX MCP tools on successful completion
    - `state_clear({mode: "autopilot"})`
@@ -94,9 +98,7 @@ Most non-trivial software tasks require coordinated phases: understanding requir
 
 <Tool_Usage>
 - Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools
-- Use `ask_codex` with `agent_role: "architect"` for Phase 4 architecture validation
-- Use `ask_codex` with `agent_role: "security-reviewer"` for Phase 4 security review
-- Use `ask_codex` with `agent_role: "code-reviewer"` for Phase 4 quality review
+- Use `ask_codex` with the selected risk-matched reviewer role when Phase 4 needs independent validation
 - Agents form their own analysis first, then consult Codex for cross-validation
 - If ToolSearch finds no MCP tools or Codex is unavailable, proceed without it -- never block on external tools
 </Tool_Usage>
@@ -156,8 +158,8 @@ Why bad: This is an exploration/brainstorming request. Respond conversationally 
 </Escalation_And_Stop_Conditions>
 
 <Final_Checklist>
-- [ ] All 5 phases completed (Expansion, Planning, Execution, QA, Validation)
-- [ ] All validators approved in Phase 4
+- [ ] Expansion and planning completed or satisfied by reused approved artifacts; execution, QA, and validation completed
+- [ ] All selected risk-matched reviewers approved in Phase 4
 - [ ] Tests pass (verified with fresh test run output)
 - [ ] Build succeeds (verified with fresh build output)
 - [ ] State files cleaned up
@@ -206,10 +208,12 @@ deep-interview -> ralplan -> autopilot
 ## Pipeline Orchestrator (v0.8+)
 
 Autopilot can be driven by the configurable pipeline orchestrator (`src/pipeline/`), which
-sequences stages through a uniform `PipelineStage` interface:
+sequences the smallest justified stage set through a uniform `PipelineStage` interface:
 
 ```
-RALPLAN (consensus planning) -> team-exec (Codex CLI workers) -> ralph-verify (architect verification)
+approved spec/plan reuse -> solo execution -> fresh executable verification
+                         -> Team/Ultrawork only for independent lanes
+                         -> architect review only when risk triggers it
 ```
 
 Pipeline configuration options:

--- a/skills/ecomode/SKILL.md
+++ b/skills/ecomode/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: ecomode
-description: Token-efficient model routing modifier
+description: Resource-efficient context, stage, fan-out, and model routing modifier
 ---
 
 # Ecomode Skill
 
-Token-efficient model routing. This is a **MODIFIER**, not a standalone execution mode.
+Resource-efficient execution. This is a **MODIFIER**, not a standalone execution mode.
 
 ## What Ecomode Does
 
-Overrides default model selection to prefer cheaper tiers:
+Ecomode reduces total interaction cost and rework, not merely model price:
+
+- Carry compact context packets containing only the task, owned surfaces, constraints, and current evidence
+- Reuse approved artifacts instead of regenerating specs, plans, or repository summaries
+- Use minimal fan-out: start with one capable owner and add agents only for independent work or a demonstrated authority need
+- Collapse redundant stages when an approved artifact already satisfies their output contract
+- Reduce interaction count by batching related checks and handing off grounded evidence once
+- Stop and re-localise repeated failures before they create more rework
+
+It also overrides default model selection to prefer cheaper tiers:
 
 | Default Tier | Ecomode Override |
 |--------------|------------------|
@@ -21,7 +30,7 @@ Overrides default model selection to prefer cheaper tiers:
 
 - **Persistence**: Use `ralph` for "don't stop until done"
 - **Parallel Execution**: Use `ultrawork` for parallel agents
-- **Delegation Enforcement**: Always active via core orchestration
+- **Orchestration Policy**: Core ownership and safety rules remain active, but delegation is conditional on independent work or a demonstrated authority need
 
 ## Combining Ecomode with Other Modes
 
@@ -30,12 +39,14 @@ Ecomode is a modifier that combines with execution modes:
 | Combination | Effect |
 |-------------|--------|
 | `eco ralph` | Ralph loop with cheaper agents |
-| `eco ultrawork` | Parallel execution with cheaper agents |
-| `eco autopilot` | Full autonomous with cost optimization |
+| `eco ultrawork` | Independent parallel lanes with compact context packets |
+| `eco autopilot` | Adaptive autonomous execution with artifact and stage reuse |
 
 ## Ecomode Routing Rules
 
 **ALWAYS prefer lower tiers. Only escalate when task genuinely requires it.**
+
+Model tier is the final routing decision, after reducing context size, stage count, interaction count, and unnecessary fan-out.
 
 | Decision | Rule |
 |----------|------|
@@ -67,11 +78,11 @@ delegate(role="architect", tier="STANDARD", task="...")
 delegate(role="planner", tier="THOROUGH", task="...")
 ```
 
-## Delegation Enforcement
+## Conditional Delegation
 
-Ecomode maintains all delegation rules from core protocol with cost-optimized routing:
+When delegation is warranted, Ecomode maintains core ownership rules with cost-optimized routing:
 
-| Action | Delegate To | Model |
+| Delegated action | Route To | Model |
 |--------|-------------|-------|
 | Code changes | executor | LOW / STANDARD |
 | Analysis | architect | LOW |
@@ -83,11 +94,13 @@ Long-running commands (install, build, test) run in background. Maximum 20 concu
 
 ## Token Savings Tips
 
-1. **Batch similar tasks** to one agent instead of spawning many
-2. **Use explore (LOW tier)** for file discovery, not architect
-3. **Prefer LOW-tier executor routing** for simple changes - only upgrade if it fails
-4. **Use writer (LOW tier)** for all documentation tasks
-5. **Avoid THOROUGH-tier agents** unless the task genuinely requires deep reasoning
+1. **Reuse approved artifacts** so phases do not rediscover settled context
+2. **Send compact context** rather than full conversation history when a bounded packet is enough
+3. **Batch similar checks** to reduce interaction count without hiding distinct failures
+4. **Use minimal fan-out** and add a second owner only for an independent lane or fresh authority requirement
+5. **Use explore (LOW tier)** for file discovery, not architect
+6. **Prefer LOW-tier executor routing** for simple changes - only upgrade if it fails or risk requires it
+7. **Avoid THOROUGH-tier agents** unless the task genuinely requires deep reasoning
 
 ## Disabling Ecomode
 

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -11,7 +11,7 @@ description: Guide on using oh-my-codex plugin
 
 | When You... | I Automatically... |
 |-------------|-------------------|
-| Give me a complex task | Parallelize and delegate to specialist agents |
+| Give me a complex task | Start with one capable owner and adapt to the task shape |
 | Ask me to plan something | Start a planning interview |
 | Need something done completely | Persist until verified complete |
 | Work on UI/frontend | Activate design sensibility |
@@ -26,9 +26,11 @@ You can include these words naturally in your request for explicit control:
 | **ralph** | Persistence mode | "ralph: fix all the bugs" |
 | **ralplan** | Iterative planning | "ralplan this feature" |
 | **ulw** | Max parallelism | "ulw refactor the API" |
+| **team** | Coordinated independent lanes | "team: implement the approved plan" |
+| **eco** | Reduce context, stages, fan-out, and model cost | "eco: fix the routine lint errors" |
 | **plan** | Planning interview | "plan the new endpoints" |
 
-**ralph includes ultrawork:** When you activate ralph mode, it automatically includes ultrawork's parallel execution. No need to combine keywords.
+Ralph starts with one owner for persistence. Use Ultrawork or Team explicitly when the work has independent lanes that benefit from coordination.
 
 ## Stopping Things
 
@@ -76,8 +78,8 @@ Analyze your oh-my-codex usage and get tailored recommendations to improve your 
 1. Reads token tracking from `~/.omx/state/token-tracking.jsonl`
 2. Reads session history from `.omx/state/session-history.json`
 3. Analyzes agent usage patterns
-4. Identifies underutilized features
-5. Recommends configuration changes
+4. Correlates observed task shape with execution mode, reviewer yield, retries, and outcomes
+5. Recommends changes only when task-shape and outcome evidence supports them
 
 ### Step 1: Gather Data
 
@@ -119,38 +121,88 @@ fi
 ```bash
 if [[ "$HAS_TOKENS" == "true" ]]; then
   echo ""
+  echo "TOKEN USAGE BY BILLING CATEGORY:"
+  jq -rs '
+    def stream_key:
+      if .session_id != null then ["session", .session_id] | @json
+      elif .thread_id != null then ["thread", .thread_id] | @json
+      else ["legacy", (.project // "unknown")] | @json
+      end;
+    def total($field):
+      reduce .[] as $record ({};
+        ($record | stream_key) as $stream
+        | if $record[$field] == null then .
+          elif ($record[$field + "_cumulative"] // false) then
+            .[$stream] = $record[$field]
+          else
+            .[$stream] = ((.[$stream] // 0) + $record[$field])
+          end
+      )
+      | ([.[]] | add // 0);
+    {
+      input_tokens: total("input_tokens"),
+      cached_input_tokens: total("cached_input_tokens"),
+      uncached_input_tokens: total("uncached_input_tokens"),
+      output_tokens: total("output_tokens"),
+      reasoning_output_tokens: total("reasoning_output_tokens")
+    }
+    | to_entries[]
+    | "\(.key): \(.value)"
+  ' "$TOKEN_FILE"
+
+  echo ""
   echo "TOP AGENTS BY USAGE:"
-  cat "$TOKEN_FILE" | jq -r '.agentName // "main"' | sort | uniq -c | sort -rn | head -10
+  jq -r '.agent // "main"' "$TOKEN_FILE" | sort | uniq -c | sort -rn | head -10
 
   echo ""
   echo "MODEL DISTRIBUTION:"
-  cat "$TOKEN_FILE" | jq -r '.modelName' | sort | uniq -c | sort -rn
+  jq -r '.model // "unknown"' "$TOKEN_FILE" | sort | uniq -c | sort -rn
 fi
 ```
 
+Each new ledger record carries a cumulative/delta flag for every token field.
+Step 2 replaces cumulative snapshots within each session and adds delta values;
+use the exact fallback order: `session_id` → `thread_id` → project. Records
+written before these flags existed cannot be disambiguated after the fact, so
+missing flags retain the legacy additive interpretation. Old cumulative
+snapshots may therefore remain overcounted; use a post-upgrade ledger segment
+when exact historical totals are required.
+
+Keep these five ledger fields separate in the report. `input_tokens` is the
+overall input count; `cached_input_tokens` and `uncached_input_tokens` explain
+its cache split and must not be added to it as extra input. Keep
+`reasoning_output_tokens` distinct from ordinary `output_tokens` so billing
+weights can be applied without hiding the source categories.
+
 ### Step 3: Generate Recommendations
 
-Based on patterns found, output recommendations:
+Base recommendations on observed task shape and outcome evidence, not zero-usage counts alone:
 
-**If high Opus usage (>40%) and no ecomode:**
-- "Consider using ecomode for routine tasks to save tokens"
+- Recommend Team only when repeated tasks show two or more independent owned lanes.
+- Recommend a reviewer when risk-matched findings changed outcomes, not merely when reviewer usage is zero.
+- Prefer the model with the best accepted outcome per billable-equivalent token; cheap per-call price is not sufficient.
 
-**If no team usage:**
-- "Try /team for coordinated review workflows"
+**If routine, bounded tasks repeatedly use high-cost models without better outcomes:**
+- "Consider ecomode for this recurring task shape; its successful runs have not needed broad context or high-tier review"
 
-**If no security-reviewer usage:**
-- "Use security-reviewer after auth/API changes"
+**If independent lanes repeatedly serialize and increase elapsed time:**
+- "Consider Team for this task shape because the history shows independent lanes with clear ownership"
+
+**If security-sensitive changes show review findings or weak verification:**
+- "Add a security reviewer for this risk surface because prior outcome evidence shows reviewer yield"
 
 **If defaultExecutionMode not set:**
 - "Set defaultExecutionMode in /omx-setup for consistent behavior"
 
+Do not recommend Team or any reviewer merely because its usage count is zero. Absence of usage is not evidence that another stage will improve outcomes.
+
 ### Step 4: Output Report
 
 Format a summary with:
-- Token summary (total, by model)
+- Token summary with separate input, cached input, uncached input, output, and reasoning output totals
 - Top agents used
-- Underutilized features
-- Personalized recommendations
+- Task shapes and observed outcomes
+- Evidence-backed recommendations
 
 ### Example Output
 
@@ -159,6 +211,11 @@ Format a summary with:
 
 TOKEN SUMMARY:
 - Total records: 1,234
+- input_tokens: 8,420,000
+- cached_input_tokens: 6,310,000
+- uncached_input_tokens: 2,110,000
+- output_tokens: 740,000
+- reasoning_output_tokens: 185,000
 - By Reasoning Effort: high 45%, medium 40%, low 15%
 
 TOP AGENTS:
@@ -166,14 +223,15 @@ TOP AGENTS:
 2. architect (89 uses)
 3. explore (67 uses)
 
-UNDERUTILIZED FEATURES:
-- ecomode: 0 uses (could save ~30% on routine tasks)
-- team: 0 uses (great for coordinated workflows)
+TASK-SHAPE EVIDENCE:
+- 18 bounded maintenance runs completed with one owner
+- 4 multi-module runs had independent lanes but executed sequentially
+- Security review found actionable issues on 3 of 5 auth-boundary changes
 
 RECOMMENDATIONS:
-1. Set defaultExecutionMode: "ecomode" to save tokens
-2. Try /team for PR review workflows
-3. Use explore agent before architect to save context
+1. Use ecomode for bounded maintenance runs to reduce context and stage count
+2. Use Team for the recurring independent multi-module lanes
+3. Keep security review scoped to auth-boundary changes, where it has demonstrated yield
 ```
 
 ### Graceful Degradation

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -39,6 +39,9 @@ Jumping into code without understanding requirements leads to rework, scope cree
 - Treat newer user task updates as local overrides for the active workflow branch while preserving earlier non-conflicting constraints
 - If correctness depends on additional inspection, retrieval, execution, or verification, keep using the relevant tools until the plan is grounded
 - Continue through clear, low-risk, reversible next steps automatically; ask only when the next step is materially branching, destructive, or preference-dependent
+- For substantive behavior changes, every plan names one observable tracer and the modules crossed before implementation is decomposed.
+- Every changed module gets a module contract card covering responsibility, public inputs/outputs/errors, invariants, allowed dependencies, focused tests, and frozen contracts.
+- Plans verify from narrow to broad: changed-module tests -> boundary contract/integration tests -> tracer acceptance -> broad regression/CI.
 </Execution_Policy>
 
 <Steps>
@@ -124,6 +127,7 @@ Jumping into code without understanding requirements leads to rework, scope cree
 Every plan includes:
 - Requirements Summary
 - Acceptance Criteria (testable)
+- Modular Tracer Contract (observable behavior, modules crossed, module contract cards, frozen scope, and non-goals) when the work changes behavior
 - Implementation Steps (with file references)
 - Adaptive step count sized to the actual scope (not a fixed five-step template)
 - Risks and Mitigations

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -1,40 +1,42 @@
 ---
 name: ralph
-description: Self-referential loop until task completion with architect verification
+description: Persistent single-owner loop until task completion with risk-adaptive verification
 ---
 
-[RALPH + ULTRAWORK - ITERATION {{ITERATION}}/{{MAX}}]
+[RALPH - ITERATION {{ITERATION}}/{{MAX}}]
 
 Your previous attempt did not output the completion promise. Continue working on the task.
 
 <Purpose>
-Ralph is a persistence loop that keeps working on a task until it is fully complete and architect-verified. It wraps ultrawork's parallel execution with session persistence, automatic retry on failure, and mandatory verification before completion.
+Ralph is a persistence loop that keeps one owner working until a task is fully complete. It combines automatic retry with fresh executable evidence, adding parallel execution or specialist review only when the task's shape and risk justify them.
 </Purpose>
 
 <Use_When>
 - Task requires guaranteed completion with verification (not just "do your best")
 - User says "ralph", "don't stop", "must complete", "finish this", or "keep going until done"
 - Work may span multiple iterations and needs persistence across retries
-- Task benefits from parallel execution with architect sign-off at the end
+- Work may need risk-matched review or independent parallel lanes
 </Use_When>
 
 <Do_Not_Use_When>
 - User wants a full autonomous pipeline from idea to code -- use `autopilot` instead
 - User wants to explore or plan before committing -- use `plan` skill instead
 - User wants a quick one-shot fix -- delegate directly to an executor agent
-- User wants manual control over completion -- use `ultrawork` directly
+- User wants parallel execution without a persistence loop -- use `ultrawork` directly
 </Do_Not_Use_When>
 
 <Why_This_Exists>
-Complex tasks often fail silently: partial implementations get declared "done", tests get skipped, edge cases get forgotten. Ralph prevents this by looping until work is genuinely complete, requiring fresh verification evidence before allowing completion, and using tiered architect review to confirm quality.
+Complex tasks often fail silently: partial implementations get declared "done", tests get skipped, and edge cases get forgotten. Ralph prevents this by looping until work is genuinely complete and requiring fresh executable evidence before allowing completion. Extra agents and reviews are selected from demonstrated need instead of being automatic ceremony.
 </Why_This_Exists>
 
 <Execution_Policy>
-- Fire independent agent calls simultaneously -- never wait sequentially for independent work
+- Start with one owner for planning, execution, and the completion loop
+- Use Ultrawork only for independent lanes with clear ownership and merge boundaries
+- Fire agent calls simultaneously only after independence has been established
 - Use `run_in_background: true` for long operations (installs, builds, test suites)
-- Always pass the `model` parameter explicitly when delegating to agents
-- Read `docs/shared/agent-tiers.md` before first delegation to select correct agent tiers
 - Deliver the full implementation: no scope reduction, no partial completion, no deleting tests to make them pass
+- For substantive AI-authored behaviour, keep fresh authority separation: a RED author, an implementer, and a verifier work from fresh context; the implementer must not weaken frozen acceptance tests
+- Re-localise the fault when the same failure repeats twice instead of adding more retries or reviewers to an ungrounded diagnosis
 - Default to concise, evidence-dense progress and completion reporting unless the user or risk level requires more detail
 - Treat newer user task updates as local overrides for the active workflow branch while preserving earlier non-conflicting constraints
 - If correctness depends on additional inspection, retrieval, execution, or verification, keep using the relevant tools until the execution loop is grounded
@@ -56,11 +58,12 @@ Complex tasks often fail silently: partial implementations get declared "done", 
    - Do not begin Ralph execution work (delegation, implementation, or verification loops) until snapshot grounding exists. If forced to proceed quickly, note explicit risk tradeoffs.
 1. **Review progress**: Check TODO list and any prior iteration state
 2. **Continue from where you left off**: Pick up incomplete tasks
-3. **Delegate in parallel**: Route tasks to specialist agents at appropriate tiers
+3. **Choose the execution shape**: Keep one owner by default; delegate only bounded independent work
    - Simple lookups: LOW tier -- "What does this function return?"
    - Standard work: STANDARD tier -- "Add error handling to this module"
    - Complex analysis: THOROUGH tier -- "Debug this race condition"
-   - When Ralph is entered as a ralplan follow-up, start from the approved **available-agent-types roster** and make the delegation plan explicit: implementation lane, evidence/regression lane, and final sign-off lane using only known agent types
+   - Use Ultrawork only when two or more lanes can proceed independently without shared-file conflicts or sequential dependencies
+   - When Ralph is entered as a ralplan follow-up, reuse the approved plan and available-agent-types roster; do not recreate planning or invent lanes solely to create fan-out
 4. **Run long operations in background**: Builds, installs, test suites use `run_in_background: true`
 5. **Visual task gate (when screenshot/reference images are present)**:
    - Run `$visual-verdict` **before every next edit**.
@@ -73,20 +76,15 @@ Complex tasks often fail silently: partial implementations get declared "done", 
    b. Run verification (test, build, lint)
    c. Read the output -- confirm it actually passed
    d. Check: zero pending/in_progress TODO items
-7. **Architect verification** (tiered):
-   - <5 files, <100 lines with full tests: STANDARD tier minimum (architect role)
-   - Standard changes: STANDARD tier (architect role)
-   - >20 files or security/architectural changes: THOROUGH tier (architect role)
-   - Ralph floor: always at least STANDARD, even for small changes
-7.5 **Mandatory Deslop Pass**:
-   - After Step 7 passes, run `oh-my-codex:ai-slop-cleaner` on **all files changed during the Ralph session**.
-   - Scope the cleaner to **changed files only**; do not widen the pass beyond Ralph-owned edits.
-   - Run the cleaner in **standard mode** (not `--review`).
-   - If the prompt contains `--no-deslop`, skip Step 7.5 entirely and proceed with the most recent successful verification evidence.
-7.6 **Regression Re-verification**:
-   - After the deslop pass, re-run all tests/build/lint and read the output to confirm they still pass.
-   - If post-deslop regression fails, roll back cleaner changes or fix and retry. Then rerun Step 7.5 and Step 7.6 until the regression is green.
-   - Do not proceed to completion until post-deslop regression is green (unless `--no-deslop` explicitly skipped the deslop pass).
+7. **Risk-triggered review and authority check**:
+   - Architect review is required for security-sensitive changes, shared public contracts, architectural boundaries, weak oracles, or other high-risk surfaces; otherwise fresh executable evidence may be sufficient
+   - For substantive AI-authored behaviour, confirm the RED author, implementer, and verifier had fresh authority separation and that frozen acceptance tests were not weakened
+7.5 **Conditional cleanup**:
+   - The `ai-slop-cleaner` pass is conditional, not a completion requirement for every Ralph run
+   - Run it only for explicit cleanup intent or evidence of changed-code cleanup value; scope it to Ralph-owned changed files
+   - If `--no-deslop` is present, skip the deslop pass even when cleanup would otherwise be conditionally justified
+   - If cleanup runs, re-run the affected tests, build, and lint checks and read the fresh output before completion
+   - If cleanup breaks affected verification, roll back the cleanup or fix it, then rerun the affected checks
 8. **On approval**: Run `/cancel` to cleanly exit and clean up all state files
 9. **On rejection**: Fix the issues raised, then re-verify at the same tier
 </Steps>
@@ -95,7 +93,7 @@ Complex tasks often fail silently: partial implementations get declared "done", 
 - Before first MCP tool use, call `ToolSearch("mcp")` to discover deferred MCP tools
 - Use `ask_codex` with `agent_role: "architect"` for verification cross-checks when changes are security-sensitive, architectural, or involve complex multi-system integration
 - Skip Codex consultation for simple feature additions, well-tested changes, or time-critical verification
-- If ToolSearch finds no MCP tools or Codex is unavailable, proceed with architect agent verification alone -- never block on external tools
+- If ToolSearch finds no MCP tools or Codex is unavailable, proceed with local executable evidence plus any risk-triggered architect agent review -- never block on external tools
 - Use `state_write` / `state_read` for ralph mode state persistence between iterations
 - Persist context snapshot path in Ralph mode state so later phases and agents share the same grounding context
 </Tool_Usage>
@@ -122,17 +120,19 @@ Use the `omx_state` MCP server tools (`state_write`, `state_read`, `state_clear`
 
 **Good:** The user changes only the output shape or downstream delivery step (for example `make a PR`). Preserve earlier non-conflicting workflow constraints and apply the update locally.
 
+**Good:** A one-lane change stays with one owner; Ralph adds an architect only after identifying a security boundary or weak executable oracle.
+
 **Bad:** The user says `continue`, and the workflow restarts discovery or stops before the missing verification/evidence is gathered.
 
 <Examples>
 <Good>
-Correct parallel delegation:
+Conditional parallel delegation:
 ```
 delegate(role="executor", tier="LOW", task="Add type export for UserConfig")
 delegate(role="executor", tier="STANDARD", task="Implement the caching layer for API responses")
 delegate(role="executor", tier="THOROUGH", task="Refactor auth module to support OAuth2 flow")
 ```
-Why good: Three independent tasks fired simultaneously at appropriate tiers.
+Why good: The tasks have independent ownership and can be merged without shared-file contention.
 </Good>
 
 <Good>
@@ -141,16 +141,16 @@ Correct verification before completion:
 1. Run: npm test           → Output: "42 passed, 0 failed"
 2. Run: npm run build      → Output: "Build succeeded"
 3. Run: lsp_diagnostics    → Output: 0 errors
-4. Delegate to architect at STANDARD tier  → Verdict: "APPROVED"
+4. Check whether the changed surface triggers specialist review
 5. Run /cancel
 ```
-Why good: Fresh evidence at each step, architect verification, then clean exit.
+Why good: Fresh evidence is mandatory; extra review is based on the changed surface's risk.
 </Good>
 
 <Bad>
 Claiming completion without verification:
 "All the changes look good, the implementation should work correctly. Task complete."
-Why bad: Uses "should" and "look good" -- no fresh test/build output, no architect verification.
+Why bad: Uses "should" and "look good" -- there is no fresh executable evidence and no risk-triggered review when applicable.
 </Bad>
 
 <Bad>
@@ -168,19 +168,20 @@ Why bad: These are independent tasks that should run in parallel, not sequential
 - Stop and report when a fundamental blocker requires user input (missing credentials, unclear requirements, external service down)
 - Stop when the user says "stop", "cancel", or "abort" -- run `/cancel`
 - Continue working when the hook system sends "The boulder never stops" -- this means the iteration continues
-- If architect rejects verification, fix the issues and re-verify (do not stop)
-- If the same issue recurs across 3+ iterations, report it as a potential fundamental problem
+- If a risk-triggered reviewer rejects verification, fix the issues and re-verify (do not stop)
+- If the same failure repeats twice, re-localise from the last grounded acceptance boundary before retrying
 </Escalation_And_Stop_Conditions>
 
 <Final_Checklist>
+Final checklist cleanup is conditional: include cleanup evidence only when cleanup ran.
+
 - [ ] All requirements from the original task are met (no scope reduction)
 - [ ] Zero pending or in_progress TODO items
 - [ ] Fresh test run output shows all tests pass
 - [ ] Fresh build output shows success
 - [ ] lsp_diagnostics shows 0 errors on affected files
-- [ ] Architect verification passed (STANDARD tier minimum)
-- [ ] ai-slop-cleaner pass completed on changed files (or --no-deslop specified)
-- [ ] Post-deslop regression tests pass
+- [ ] Any risk-triggered specialist review passed
+- [ ] If cleanup ran, affected tests, build, and lint were rerun successfully
 - [ ] `/cancel` run for clean state cleanup
 </Final_Checklist>
 
@@ -192,9 +193,8 @@ When the user provides the `--prd` flag, initialize a Product Requirements Docum
 ### Detecting PRD Mode
 Check if `{{PROMPT}}` contains `--prd` or `--PRD`.
 
-### Detecting `--no-deslop`
-Check if `{{PROMPT}}` contains `--no-deslop`.
-If `--no-deslop` is present, skip the deslop pass entirely after Step 7 and continue using the latest successful pre-deslop verification evidence.
+### Cleanup Opt-out in PRD Mode
+Cleanup remains conditional by default. If `{{PROMPT}}` contains `--no-deslop`, skip the deslop pass completely, including any conditionally justified cleanup, in PRD mode as well as standard Ralph mode.
 
 ### Visual Reference Flags (Optional)
 Ralph execution supports visual reference flags for screenshot tasks:

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -33,6 +33,9 @@ $ralplan --interactive "task description"
 - If correctness depends on additional inspection, retrieval, execution, or verification, keep using the relevant tools until the consensus-planning flow is grounded.
 - Right-size implementation steps and PRD story counts to the actual scope; do not default to exactly five steps when the task is clearly smaller or larger.
 - Continue through clear, low-risk, reversible next steps automatically; ask only when the next step is materially branching, destructive, or preference-dependent.
+- For substantive behavior changes, require one observable tracer and the modules crossed before implementation is decomposed.
+- Give each changed module a module contract card covering responsibility, public inputs/outputs/errors, invariants, allowed dependencies, focused tests, and frozen contracts.
+- Require the verification ladder: changed-module tests -> boundary contract/integration tests -> tracer acceptance -> broad regression/CI.
 
 This skill invokes the Plan skill in consensus mode:
 
@@ -43,6 +46,7 @@ $plan --consensus --interactive <arguments>
 
 The consensus workflow:
 1. **Planner** creates initial plan and a compact **RALPLAN-DR summary** before review:
+   - Modular Tracer Contract for behavior changes: observable behavior, modules crossed, module contract cards, frozen scope, and verification ladder
    - Principles (3-5)
    - Decision Drivers (top 3)
    - Viable Options (>=2) with bounded pros/cons

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -55,7 +55,10 @@ Team mode should carry its own parallel delivery + verification lanes without
 requiring a separate linked Ralph launch up front.
 
 - **Canonical launch:** use plain `omx team ...` / `$team ...` for coordinated workers.
+- **Module ownership:** dispatch parallel lanes only after stable module contracts name responsibility, public interfaces, invariants, allowed dependencies, and focused tests.
+- **Shared hotspots:** keep shared contracts and schemas serialized under one writer; parallel workers consume them but do not redefine them independently.
 - **Verification ownership:** keep one lane focused on tests, regression coverage, and evidence before shutdown.
+- **Verification order:** changed-module tests -> boundary contract/integration tests -> tracer acceptance -> broad regression/CI.
 - **Escalation:** start a separate `omx ralph ...` / `$ralph ...` only when a later manual follow-up still needs a persistent single-owner fix/verification loop.
 - **Deprecation:** `omx team ralph ...` has been removed. Use plain `omx team ...` for team execution or run `omx ralph ...` separately when you explicitly want a later Ralph loop.
 
@@ -121,6 +124,7 @@ When `$team` is used as a follow-up mode from ralplan, carry forward the approve
 - state the recommended headcount and role counts
 - state the suggested reasoning level for each lane when available
 - explain why each lane exists (delivery, verification, specialist support)
+- carry the plan's module contract card, frozen scope, and tracer acceptance into every worker task packet
 - include an explicit launch hint (`omx team N "<task>"` / `$team N "<task>"`) for the coordinated team run; mention a later separate Ralph follow-up only when genuinely needed
 - if the ideal role is unavailable, choose the closest role from the roster and say so
 

--- a/src/hooks/__tests__/anti-slop-workflow.test.ts
+++ b/src/hooks/__tests__/anti-slop-workflow.test.ts
@@ -20,7 +20,7 @@ describe('anti-slop workflow surfaces', () => {
       assert.match(content, /Lock existing behavior with regression tests/i);
       assert.match(content, /Prefer deletion over addition/i);
       assert.match(content, /No new dependencies without explicit request/i);
-      assert.match(content, /Run lint, typecheck, tests, and static analysis/i);
+      assert.match(content, /Run relevant lint, typecheck, tests, and static analysis for the changed surface/i);
       assert.match(content, /\$ai-slop-cleaner/);
       assert.match(content, /writer\/reviewer pass separation/i);
     }

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -205,6 +205,45 @@ describe('keyword registry coverage', () => {
     assert.ok(registryKeywords.has("don't assume"));
     assert.ok(registryKeywords.has('interview me'));
   });
+
+  it('does not treat ordinary desire phrasing as an autopilot command', () => {
+    const registryKeywords = new Set(KEYWORD_TRIGGER_DEFINITIONS.map((v) => v.keyword.toLowerCase()));
+    assert.equal(registryKeywords.has('i want a'), false);
+  });
+});
+
+describe('proportional implicit keyword routing', () => {
+  it('keeps an ordinary article adjustment out of autopilot', () => {
+    assert.equal(detectPrimaryKeyword('I want a paragraph shortened in this article'), null);
+  });
+
+  it('preserves explicit and unmistakable autopilot intent', () => {
+    assert.equal(detectPrimaryKeyword('$autopilot build the approved application')?.skill, 'autopilot');
+    assert.equal(detectPrimaryKeyword('build me a CLI tool for release notes')?.skill, 'autopilot');
+  });
+
+  it('does not activate parallel execution from negation or mention-only prose', () => {
+    assert.equal(detectPrimaryKeyword('Do not run these edits in parallel'), null);
+    assert.equal(detectPrimaryKeyword('The plan discusses parallel execution as a rejected option'), null);
+  });
+
+  it('still activates parallel execution from a direct request', () => {
+    assert.equal(detectPrimaryKeyword('Run these independent tasks in parallel')?.skill, 'ultrawork');
+  });
+
+  it('does not activate team mode when the request explicitly rejects it', () => {
+    assert.equal(detectPrimaryKeyword('Do not use team mode for this task'), null);
+  });
+
+  it('distinguishes a stop condition from a cancellation request', () => {
+    assert.equal(detectPrimaryKeyword('The workflow has a stop condition after three failures'), null);
+    assert.equal(detectPrimaryKeyword('Please stop now')?.skill, 'cancel');
+  });
+
+  it('distinguishes mention-only analysis language from an analysis request', () => {
+    assert.equal(detectPrimaryKeyword('The word analyze appears in the routing table'), null);
+    assert.equal(detectPrimaryKeyword('Please analyze this workflow')?.skill, 'analyze');
+  });
 });
 
 describe('keyword detector skill-active-state lifecycle', () => {
@@ -436,7 +475,7 @@ describe('keyword detector skill-active-state lifecycle', () => {
 
       const result = await recordSkillActivation({
         stateDir,
-        text: 'I want a starter API',
+        text: 'build me a starter API',
         nowIso: '2026-02-26T00:00:00.000Z',
       });
 

--- a/src/hooks/__tests__/lean-harness-guidance-contract.test.ts
+++ b/src/hooks/__tests__/lean-harness-guidance-contract.test.ts
@@ -1,0 +1,28 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const surfaces = ['templates/AGENTS.md', 'AGENTS.md'];
+
+describe('lean global harness guidance', () => {
+  for (const path of surfaces) {
+    it(`${path} preserves the lean route and independent authority`, async () => {
+      const text = await readFile(path, 'utf8');
+      assert.match(text, /one capable owner|solo execute/i);
+      assert.match(text, /compact task packet/i);
+      assert.match(text, /do not.*all-turn|never.*full.*mature.*conversation/i);
+      assert.match(text, /premise.*gate|caller-visible behaviour.*assumptions/i);
+      assert.match(text, /same failure.*twice|re-localise/i);
+      assert.match(text, /RED author.*fresh context/i);
+      assert.match(text, /implementer.*(must not|no authority).*weaken/i);
+      assert.match(text, /verifier.*fresh context/i);
+      assert.match(text, /local\s*\|\s*cross-file\s*\|\s*repository/i);
+      assert.match(text, /risk.*confidence/i);
+      assert.match(text, /at most one cheap probe/i);
+      assert.match(text, /smallest reliable path/i);
+      assert.match(text, /expand one boundary at a time/i);
+      assert.match(text, /focused verification fails.*confidence drops/i);
+      assert.match(text, /reus(?:e|ing).*evidence/i);
+    });
+  }
+});

--- a/src/hooks/__tests__/lean-mode-guidance-contract.test.ts
+++ b/src/hooks/__tests__/lean-mode-guidance-contract.test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+describe('lean mode guidance', () => {
+  it('keeps Ralph persistent without mandatory fan-out or cleanup', async () => {
+    const text = await readFile('skills/ralph/SKILL.md', 'utf8');
+    assert.match(text, /start with one owner/i);
+    assert.match(text, /ultrawork.*only.*independent/i);
+    assert.match(text, /architect.*(security|shared public|weak oracle|risk)/i);
+    assert.match(text, /ai-slop-cleaner.*conditional/i);
+    assert.match(text, /same failure.*twice|re-localise/i);
+  });
+
+  it('does not reject low-risk Ralph completion solely for no architect verification', async () => {
+    const text = await readFile('skills/ralph/SKILL.md', 'utf8');
+    assert.doesNotMatch(text, /no architect verification/i);
+  });
+
+  it('makes Autopilot phase compute adaptive', async () => {
+    const text = await readFile('skills/autopilot/SKILL.md', 'utf8');
+    assert.match(text, /reuse.*approved spec/i);
+    assert.match(text, /one planning owner/i);
+    assert.match(text, /execute solo.*one owned lane/i);
+    assert.match(text, /reviewer.*risk|risk-matched reviewer/i);
+  });
+
+  it('does not make parallel implementation or an architect pipeline inherent to Autopilot', async () => {
+    const text = await readFile('skills/autopilot/SKILL.md', 'utf8');
+    const legacyClaims = [
+      /implementing in parallel/i,
+      /RALPLAN.*team-exec.*ralph-verify.*architect verification/i,
+    ];
+    const contradictions = legacyClaims.filter((pattern) => pattern.test(text)).map((pattern) => pattern.source);
+    assert.deepEqual(contradictions, []);
+  });
+
+  it('makes Ecomode reduce context and stage count, not just model price', async () => {
+    const text = await readFile('skills/ecomode/SKILL.md', 'utf8');
+    assert.match(text, /compact context/i);
+    assert.match(text, /minimal fan-out/i);
+    assert.match(text, /interaction count|rework/i);
+  });
+
+  it('keeps delegation conditional in Ecomode', async () => {
+    const text = await readFile('skills/ecomode/SKILL.md', 'utf8');
+    assert.doesNotMatch(text, /Delegation Enforcement[^A-Za-z0-9]*Always active via core orchestration/i);
+  });
+
+  it('grounds Help usage advice in real ledger fields and outcome evidence', async () => {
+    const text = await readFile('skills/help/SKILL.md', 'utf8');
+    assert.match(text, /~\/\.omx\/state\/token-tracking\.jsonl/);
+
+    const requiredGuidance = [
+      {
+        contract: 'separate input, cached, uncached, output, and reasoning reporting',
+        pattern: /input_tokens[\s\S]*cached_input_tokens[\s\S]*uncached_input_tokens[\s\S]*output_tokens[\s\S]*reasoning_output_tokens/i,
+      },
+      {
+        contract: 'Team requires repeated tasks with two or more independent owned lanes',
+        pattern: /Recommend Team only when repeated tasks show two or more independent owned lanes\./i,
+      },
+      {
+        contract: 'reviewers require risk-matched findings that changed outcomes',
+        pattern: /Recommend a reviewer when risk-matched findings changed outcomes, not merely when reviewer usage is zero\./i,
+      },
+      {
+        contract: 'model choice uses accepted outcomes per billable-equivalent token',
+        pattern: /Prefer the model with the best accepted outcome per billable-equivalent token; cheap per-call price is not sufficient\./i,
+      },
+    ];
+    const missing = requiredGuidance
+      .filter(({ pattern }) => !pattern.test(text))
+      .map(({ contract }) => contract);
+
+    assert.deepEqual(missing, []);
+  });
+});

--- a/src/hooks/__tests__/proportional-harness-routing.test.ts
+++ b/src/hooks/__tests__/proportional-harness-routing.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '../../../');
+
+function read(path: string): string {
+  return readFileSync(join(repoRoot, path), 'utf-8');
+}
+
+const guidanceSurfaces = ['AGENTS.md', 'templates/AGENTS.md'];
+
+describe('proportional harness guidance', () => {
+  for (const path of guidanceSurfaces) {
+    it(`${path} keeps artifact work direct and assurance separate from execution shape`, () => {
+      const content = read(path);
+      assert.match(content, /direct artifact|artifact-only/i);
+      assert.match(content, /article|wiki|mockup/i);
+      assert.match(content, /rendered|previewed/i);
+      assert.match(content, /assurance.*execution shape|execution shape.*assurance/i);
+      assert.match(content, /file count.*not.*router|not.*file count/i);
+    });
+
+    it(`${path} limits brainstorming to materially unresolved intent`, () => {
+      const content = read(path);
+      assert.match(content, /brainstorming.*materially unresolved|materially unresolved.*brainstorming/i);
+      assert.match(content, /does not apply.*bounded direct artifact|bounded direct artifact.*does not apply/i);
+      assert.match(content, /target.*adjustment.*constraints.*acceptance surface/i);
+    });
+
+    it(`${path} makes visual and engineering gates applicability-aware`, () => {
+      const content = read(path);
+      assert.match(content, /generated screenshot.*reference image|reference image.*generated screenshot/i);
+      assert.match(content, /visual fidelity/i);
+      assert.match(content, /text-only.*source.*DOM|source.*DOM.*text-only/i);
+      assert.match(content, /show the changed surface.*does not.*rendered output|rendered output.*does not.*show the changed surface/i);
+      assert.match(content, /one bounded fallback/i);
+      assert.match(content, /do not cascade.*Playwright.*Computer Use|Playwright.*Computer Use.*do not cascade/i);
+      assert.match(content, /relevant.*changed surface|changed surface.*relevant/i);
+      assert.match(content, /tests pass.*where tests apply|where tests apply.*tests pass/i);
+    });
+
+    it(`${path} routes cleanup proportionally`, () => {
+      const content = read(path);
+      assert.match(content, /cleanup.*proportional|proportional.*cleanup/i);
+      assert.doesNotMatch(content, /Cleanup\/refactor\/deslop work still follows the same `\$deep-interview` -> `\$ralplan` -> `\$team`\/`\$ralph` path/i);
+    });
+
+    it(`${path} no longer advertises ordinary desire phrasing as autopilot`, () => {
+      const content = read(path);
+      assert.doesNotMatch(content, /"I want a".*\| `\$autopilot`/i);
+    });
+
+    it(`${path} makes upstream workflow imports explicit per owned overlay`, () => {
+      const content = read(path);
+      assert.match(content, /writing-plans.*dispatching-parallel-agents.*load their matching namespaced Superpowers skills/is);
+      assert.match(
+        content,
+        /test-driven-development.*subagent-driven-development.*executing-plans.*verification-before-completion.*standalone owned policy/is,
+      );
+      assert.doesNotMatch(content, /each overlay must load its matching namespaced Superpowers skill/i);
+    });
+  }
+
+  it('keeps visual-verdict scoped to reference comparison', () => {
+    const content = read('skills/visual-verdict/SKILL.md');
+    assert.match(content, /generated screenshot/i);
+    assert.match(content, /at least one reference image/i);
+  });
+
+  it('requires unmistakable hands-off intent for autopilot', () => {
+    const content = read('skills/autopilot/SKILL.md');
+    assert.doesNotMatch(content, /I want a\/an/i);
+    assert.match(content, /end-to-end autonomous|hands-off/i);
+  });
+});

--- a/src/hooks/__tests__/skill-guidance-contract.test.ts
+++ b/src/hooks/__tests__/skill-guidance-contract.test.ts
@@ -1,9 +1,17 @@
 import { describe, it } from 'node:test';
-import { SKILL_CONTRACTS } from '../prompt-guidance-contract.js';
+import {
+  LEAN_MODE_SKILL_CONTRACTS,
+  MODULAR_TRACER_SKILL_CONTRACTS,
+  SKILL_CONTRACTS,
+} from '../prompt-guidance-contract.js';
 import { assertContractSurface } from './prompt-guidance-test-helpers.js';
 
 describe('execution-heavy skill guidance contract', () => {
-  for (const contract of SKILL_CONTRACTS) {
+  for (const contract of [
+    ...SKILL_CONTRACTS,
+    ...MODULAR_TRACER_SKILL_CONTRACTS,
+    ...LEAN_MODE_SKILL_CONTRACTS,
+  ]) {
     it(`${contract.id} satisfies the execution-heavy skill guidance contract`, () => {
       assertContractSurface(contract);
     });

--- a/src/hooks/__tests__/task-size-detector.test.ts
+++ b/src/hooks/__tests__/task-size-detector.test.ts
@@ -223,6 +223,17 @@ describe('task-size-detector', () => {
     });
 
     describe('small task classification', () => {
+      const localParaphrases = [
+        'Adjust the label returned by renderBadge; its public contract and callers stay unchanged.',
+        'Correct the delimiter chosen by parseHeader without touching its callers.',
+      ];
+
+      for (const text of localParaphrases) {
+        it(`classifies paraphrased local scope as small: ${text}`, () => {
+          assert.equal(classifyTaskSize(text).size, 'small');
+        });
+      }
+
       it('classifies short prompt as small', () => {
         const result = classifyTaskSize('Fix the typo in the README.');
         assert.equal(result.size, 'small');
@@ -255,6 +266,17 @@ describe('task-size-detector', () => {
     });
 
     describe('large task classification', () => {
+      const hiddenCouplingParaphrases = [
+        'Change the shared identity representation while keeping consumers, stored records, and compatibility boundaries aligned.',
+        'A status value flows through callers, persisted records, and compatibility boundaries that must continue to agree.',
+      ];
+
+      for (const text of hiddenCouplingParaphrases) {
+        it(`classifies paraphrased hidden coupling as large: ${text}`, () => {
+          assert.equal(classifyTaskSize(text).size, 'large');
+        });
+      }
+
       it('classifies prompt with large signals as large', () => {
         const result = classifyTaskSize(
           'Refactor the authentication module to support OAuth2 and clean up the token management'

--- a/src/hooks/keyword-detector.ts
+++ b/src/hooks/keyword-detector.ts
@@ -188,9 +188,18 @@ const KEYWORD_MAP: Array<{ pattern: RegExp; skill: string; priority: number }> =
   priority: entry.priority,
 }));
 
-const KEYWORDS_REQUIRING_INTENT = new Set(['team', 'swarm']);
+const KEYWORDS_REQUIRING_INTENT = new Set([
+  'team',
+  'swarm',
+  'parallel',
+  'analyze',
+  'investigate',
+  'cancel',
+  'stop',
+  'abort',
+]);
 
-const TEAM_SWARM_INTENT_PATTERNS: Record<'team' | 'swarm', RegExp[]> = {
+const IMPLICIT_INTENT_PATTERNS: Record<string, RegExp[]> = {
   team: [
     /(?:^|[^\w])\$(?:team)\b/i,
     /\/prompts:team\b/i,
@@ -203,7 +212,45 @@ const TEAM_SWARM_INTENT_PATTERNS: Record<'team' | 'swarm', RegExp[]> = {
     /\b(?:use|run|start|enable|launch|invoke|activate|orchestrate|coordinate)\s+(?:a\s+|an\s+|the\s+)?swarm\b/i,
     /\bswarm\s+(?:mode|orchestration|workflow|agents?)\b/i,
   ],
+  parallel: [
+    /(?:^|[.!?]\s*)(?:please\s+)?(?:run|execute|work|do|handle|process)\b[^.!?\n]{0,80}\bin parallel\b/i,
+    /\b(?:use|enable|start|launch|invoke|activate)\s+(?:a\s+|an\s+|the\s+)?parallel(?:\s+(?:mode|workflow|execution|agents?))?\b/i,
+    /(?:^|[.!?]\s*)parallel\s+(?:mode|workflow|execution|agents?)\b/i,
+  ],
+  analyze: [
+    /(?:^|[.!?]\s*)(?:please\s+)?analyze\b/i,
+    /\b(?:please|kindly)\s+analyze\b/i,
+    /\b(?:can|could|would|will)\s+you\s+(?:please\s+)?analyze\b/i,
+  ],
+  investigate: [
+    /(?:^|[.!?]\s*)(?:please\s+)?investigate\b/i,
+    /\b(?:please|kindly)\s+investigate\b/i,
+    /\b(?:can|could|would|will)\s+you\s+(?:please\s+)?investigate\b/i,
+  ],
+  cancel: [
+    /(?:^|[.!?]\s*)(?:please\s+)?cancel\b/i,
+    /\b(?:please|kindly)\s+cancel\b/i,
+    /\b(?:can|could|would|will)\s+you\s+(?:please\s+)?cancel\b/i,
+  ],
+  stop: [
+    /(?:^|[.!?]\s*)(?:please\s+)?stop\b/i,
+    /\b(?:please|kindly)\s+stop\b/i,
+    /\b(?:can|could|would|will)\s+you\s+(?:please\s+)?stop\b/i,
+  ],
+  abort: [
+    /(?:^|[.!?]\s*)(?:please\s+)?abort\b/i,
+    /\b(?:please|kindly)\s+abort\b/i,
+    /\b(?:can|could|would|will)\s+you\s+(?:please\s+)?abort\b/i,
+  ],
 };
+
+function hasNegatedIntent(text: string, keyword: string): boolean {
+  const escaped = escapeRegex(keyword);
+  return new RegExp(
+    `\\b(?:do\\s+not|don't|dont|never|without|avoid)\\b[^.!?\\n]{0,80}\\b${escaped}\\b`,
+    'i',
+  ).test(text);
+}
 
 function hasExplicitPromptsInvocation(text: string): boolean {
   return /(?:^|\s)\/prompts:[\w.-]+(?=[\s.,!?;:]|$)/i.test(text);
@@ -246,9 +293,10 @@ function extractExplicitSkillInvocations(text: string): KeywordMatch[] {
 }
 
 function hasIntentContextForKeyword(text: string, keyword: string): boolean {
-  if (!KEYWORDS_REQUIRING_INTENT.has(keyword.toLowerCase())) return true;
-  const k = keyword.toLowerCase() as 'team' | 'swarm';
-  return TEAM_SWARM_INTENT_PATTERNS[k].some((pattern) => pattern.test(text));
+  const normalized = keyword.toLowerCase();
+  if (!KEYWORDS_REQUIRING_INTENT.has(normalized)) return true;
+  if (hasNegatedIntent(text, normalized)) return false;
+  return (IMPLICIT_INTENT_PATTERNS[normalized] ?? []).some((pattern) => pattern.test(text));
 }
 
 /**

--- a/src/hooks/keyword-registry.ts
+++ b/src/hooks/keyword-registry.ts
@@ -13,7 +13,6 @@ export const KEYWORD_TRIGGER_DEFINITIONS: readonly KeywordTriggerDefinition[] = 
 
   { keyword: 'autopilot', skill: 'autopilot', priority: 10, guidance: 'Activate autopilot skill for autonomous execution' },
   { keyword: 'build me', skill: 'autopilot', priority: 10, guidance: 'Activate autopilot skill for autonomous execution' },
-  { keyword: 'I want a', skill: 'autopilot', priority: 10, guidance: 'Activate autopilot skill for autonomous execution' },
 
   { keyword: 'ultrawork', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },
   { keyword: 'ulw', skill: 'ultrawork', priority: 10, guidance: 'Activate ultrawork parallel execution mode' },

--- a/src/hooks/prompt-guidance-contract.ts
+++ b/src/hooks/prompt-guidance-contract.ts
@@ -22,6 +22,39 @@ const ROOT_TEMPLATE_PATTERNS = [
   rx('Default update/final shape'),
   rx('do not skip prerequisites|task is grounded and verified'),
   rx('concise evidence summaries'),
+  rx('modular tracer bullets'),
+  rx('public contract.*allowed dependencies'),
+  rx('changed-module tests.*boundary contract.*tracer acceptance.*broad regression'),
+  rx('audit recent session calls.*plugin caches'),
+  rx('user-owned unprefixed workflow overlays'),
+  rx('writing-plans.*test-driven-development.*subagent-driven-development'),
+  rx('executing-plans.*dispatching-parallel-agents.*verification-before-completion'),
+  rx('writing-plans.*dispatching-parallel-agents.*load their matching namespaced Superpowers skills'),
+  rx('test-driven-development.*subagent-driven-development.*executing-plans.*verification-before-completion.*standalone owned policy'),
+  rx('one capable owner'),
+  rx('caller-visible behaviour.*invalidating assumptions'),
+  rx('Escalate only for independent lanes.*failed grounded acceptance'),
+  rx('Re-localise.*same failure repeats twice'),
+  rx('compact task packet'),
+  rx('Do not use an all-turn fork.*mature task'),
+  rx('RED author.*fresh context'),
+  rx('implementer must not weaken'),
+  rx('verifier.*fresh context'),
+  rx('Proportional assurance and execution shape'),
+  rx('direct artifact route.*article copy.*wiki notes.*exploratory mockups'),
+  rx('brainstorming.*materially unresolved'),
+  rx('does not apply.*bounded direct artifact'),
+  rx('target.*adjustment.*constraints.*acceptance surface'),
+  rx('File count is not a router'),
+  rx('Local observable behaviour changes retain one right-reason RED/GREEN'),
+  rx('generated screenshot.*at least one reference image'),
+  rx('text-only.*source.*DOM'),
+  rx('show the changed surface.*does not.*rendered output'),
+  rx('one bounded fallback'),
+  rx('do not cascade.*Playwright.*Computer Use'),
+  rx('tests pass where tests apply'),
+  rx('Route cleanup/refactor/deslop work proportionally'),
+  rx('Implicit keyword matches require affirmative invocation intent'),
 ];
 
 const CORE_ROLE_PATTERNS = {
@@ -29,16 +62,28 @@ const CORE_ROLE_PATTERNS = {
     rx('compact, information-dense outputs'),
     rx('local overrides?.*non-conflicting constraints'),
     rx('task is grounded and verified'),
+    rx('preserve.*module contracts'),
+    rx('changed-module tests.*boundary contract.*tracer acceptance.*broad regression'),
   ],
   planner: [
     rx('compact, information-dense plan summaries'),
     rx('local overrides?.*non-conflicting constraints'),
     rx('plan is grounded in evidence'),
+    rx('observable tracer.*modules crossed'),
+    rx('module contract card'),
+    rx('changed-module tests.*boundary contract.*tracer acceptance.*broad regression'),
+  ],
+  testEngineer: [
+    rx('public module contracts'),
+    rx('thin tracer'),
+    rx('changed-module tests.*boundary contract.*tracer acceptance.*broad regression'),
   ],
   verifier: [
     rx('concise, evidence-dense summaries'),
     rx('verdict is grounded'),
     rx('non-conflicting acceptance criteria'),
+    rx('module-contract drift'),
+    rx('changed-module tests.*boundary contract.*tracer acceptance.*broad regression'),
   ],
 };
 
@@ -68,6 +113,7 @@ export const ROOT_TEMPLATE_CONTRACTS: GuidanceSurfaceContract[] = [
 export const CORE_ROLE_CONTRACTS: GuidanceSurfaceContract[] = [
   { id: 'executor', path: 'prompts/executor.md', requiredPatterns: CORE_ROLE_PATTERNS.executor },
   { id: 'planner', path: 'prompts/planner.md', requiredPatterns: CORE_ROLE_PATTERNS.planner },
+  { id: 'test-engineer-modular-tracer', path: 'prompts/test-engineer.md', requiredPatterns: CORE_ROLE_PATTERNS.testEngineer },
   { id: 'verifier', path: 'prompts/verifier.md', requiredPatterns: CORE_ROLE_PATTERNS.verifier },
 ];
 
@@ -184,3 +230,83 @@ export const SKILL_CONTRACTS: GuidanceSurfaceContract[] = [
   path: `skills/${name}/SKILL.md`,
   requiredPatterns: SKILL_PATTERNS,
 }));
+
+export const MODULAR_TRACER_SKILL_CONTRACTS: GuidanceSurfaceContract[] = [
+  {
+    id: 'plan-modular-tracer',
+    path: 'skills/plan/SKILL.md',
+    requiredPatterns: [
+      rx('observable tracer.*modules crossed'),
+      rx('module contract card'),
+      rx('changed-module tests.*boundary contract.*tracer acceptance.*broad regression'),
+    ],
+  },
+  {
+    id: 'ralplan-modular-tracer',
+    path: 'skills/ralplan/SKILL.md',
+    requiredPatterns: [
+      rx('observable tracer.*modules crossed'),
+      rx('module contract card'),
+      rx('changed-module tests.*boundary contract.*tracer acceptance.*broad regression'),
+    ],
+  },
+  {
+    id: 'team-modular-tracer',
+    path: 'skills/team/SKILL.md',
+    requiredPatterns: [
+      rx('stable module contracts'),
+      rx('shared contracts.*serialized'),
+      rx('changed-module tests.*boundary contract.*tracer acceptance.*broad regression'),
+    ],
+  },
+];
+
+export const LEAN_MODE_SKILL_CONTRACTS: GuidanceSurfaceContract[] = [
+  {
+    id: 'ralph-lean-mode',
+    path: 'skills/ralph/SKILL.md',
+    requiredPatterns: [
+      rx('start with one owner'),
+      rx('ultrawork.*only.*independent'),
+      rx('architect.*(security|shared public|weak oracle|risk)'),
+      rx('ai-slop-cleaner.*conditional'),
+      rx('same failure.*twice|re-localise'),
+      rx('fresh authority separation'),
+      rx('if cleanup runs.*re-run.*affected tests.*build.*lint'),
+    ],
+  },
+  {
+    id: 'autopilot-lean-mode',
+    path: 'skills/autopilot/SKILL.md',
+    requiredPatterns: [
+      rx('reuse.*approved spec'),
+      rx('one planning owner'),
+      rx('execute solo.*one owned lane'),
+      rx('reviewer.*risk|risk-matched reviewer'),
+    ],
+  },
+  {
+    id: 'ecomode-lean-mode',
+    path: 'skills/ecomode/SKILL.md',
+    requiredPatterns: [
+      rx('compact context'),
+      rx('minimal fan-out'),
+      rx('interaction count|rework'),
+      rx('reuse approved artifacts'),
+    ],
+  },
+  {
+    id: 'help-evidence-aware-recommendations',
+    path: 'skills/help/SKILL.md',
+    requiredPatterns: [
+      rx('~/.omx/state/token-tracking.jsonl'),
+      rx('input_tokens[\\s\\S]*cached_input_tokens[\\s\\S]*uncached_input_tokens[\\s\\S]*output_tokens[\\s\\S]*reasoning_output_tokens'),
+      rx('observed task shape.*outcome evidence'),
+      rx('reviewer yield'),
+      rx('do not recommend Team or any reviewer merely because its usage count is zero'),
+      rx('Recommend Team only when repeated tasks show two or more independent owned lanes'),
+      rx('Recommend a reviewer when risk-matched findings changed outcomes, not merely when reviewer usage is zero'),
+      rx('Prefer the model with the best accepted outcome per billable-equivalent token; cheap per-call price is not sufficient'),
+    ],
+  },
+];

--- a/src/hooks/task-size-detector.ts
+++ b/src/hooks/task-size-detector.ts
@@ -100,6 +100,7 @@ const LARGE_TASK_SIGNALS = [
   /\boverhaul\b/i,
   /\bcomprehensive\b/i,
   /\bextensive\b/i,
+  /(?=.*\b(?:callers?|consumers?)\b)(?=.*\b(?:persisted|stored)\b)(?=.*\bcompatibility\s+boundar(?:y|ies)\b)/i,
   /\bimplement\s+(a\s+)?(new\s+)?system\b/i,
   /\bbuild\s+(a\s+)?(complete|full|new)\b/i,
 ];

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -50,8 +50,44 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 - Reuse existing utils and patterns before introducing new abstractions.
 - No new dependencies without explicit request.
 - Keep diffs small, reviewable, and reversible.
-- Run lint, typecheck, tests, and static analysis after changes.
+- Run relevant lint, typecheck, tests, and static analysis for the changed surface; documentation-only and exploratory artifact work uses its applicable render, parse, link, or provenance checks instead of unrelated engineering suites.
 - Final reports must include changed files, simplifications made, and remaining risks.
+
+## AI-assisted engineering defaults
+- Start from existing context before designing: read the relevant repo docs, AGENTS/CONTEXT files, ADRs, and wiki indexes before changing behavior.
+- Name the public interface and the user/caller-visible behavior before writing tests or implementation.
+- Use modular tracer bullets: before substantive implementation, name the modules crossed and freeze each changed module's responsibility, public contract, invariants, allowed dependencies, and focused tests.
+- Prefer tracer-bullet vertical slices over layer-only delivery. A slice should prove one narrow path through the real architecture and be demoable or verifiable on its own.
+- Use TDD one behavior at a time: write one RED test, confirm it fails for a behavioral reason, write the minimum GREEN implementation, then refactor only while tests stay green.
+- Test through public interfaces and owned seams. Mock only at system boundaries when the feedback loop is affordable.
+- Verify from narrow to broad: changed-module tests -> boundary contract/integration tests -> tracer acceptance -> broad regression/CI. Stop at the first failing layer.
+- For substantive AI-authored tests, separate test-author, implementer, and verifier authority where practical; implementers must not weaken acceptance tests without explicit controller review.
+- Update glossary, wiki, CONTEXT files, or ADRs when a domain term or hard-to-reverse trade-off is settled.
+- Before changing agent or skill guidance, audit recent session calls and trace active surfaces to their owned source/template; do not treat generated plugin caches as durable sources.
+- Route these workflow entry points through the user-owned unprefixed workflow overlays: `writing-plans`, `test-driven-development`, and `subagent-driven-development`; use `executing-plans`, `dispatching-parallel-agents`, and `verification-before-completion` for their execution phases.
+- `writing-plans` and `dispatching-parallel-agents` load their matching namespaced Superpowers skills for upstream process details.
+- `test-driven-development`, `subagent-driven-development`, `executing-plans`, and `verification-before-completion` are standalone owned policy; do not recursively enter their cached namespaced workflows when the owned overlay is active.
+
+### Lean execution default
+- Route bounded coding to one capable owner.
+- Before broad exploration, estimate task shape as `local | cross-file | repository`, risk, and confidence using at most one cheap probe; execute the smallest reliable path; expand one boundary at a time only when focused verification fails or confidence drops, reusing evidence already collected.
+- Before substantive edits, name caller-visible behaviour, owning module/public interface, invalidating assumptions and cheap probes, acceptance command, and one thin tracer.
+- Escalate only for independent lanes, security/auth/data/destructive/shared-contract risk, weak machine oracles, unexpected scope expansion, or failed grounded acceptance.
+- Re-localise when the same failure repeats twice, a second patch relies on the same unverified premise, or about five recovery actions fail to reduce uncertainty.
+
+### Proportional assurance and execution shape
+- Assurance level and execution shape are separate decisions: choose direct artifact, bounded change, standard behaviour, or full assurance from risk and oracle strength; choose solo, serial, or independent parallel execution from dependency shape and concrete benefit.
+- Use the direct artifact route for bounded article copy, wiki notes, exploratory mockups, slides, and similar non-runtime work: edit the owned artifact, inspect the actual rendered or previewed result, and stop when the requested surface is verified.
+- `superpowers:brainstorming` applies when product or design intent is materially unresolved, or when the user asks to explore alternatives before creating behaviour. It does not apply to a bounded direct artifact request when the target, requested adjustment, constraints, and acceptance surface are already specified; an explicit user request for brainstorming remains authoritative.
+- For a text-only visual-artifact edit that cannot affect layout or behaviour, a focused source or DOM assertion is sufficient unless the user asks to inspect rendered output. “Show the changed surface” does not by itself request rendered output: quote or link the changed source/DOM unless the user explicitly asks for a screenshot, preview, browser, rendered, or visual result, or the edit can affect appearance. When rendered acceptance applies and the primary renderer is unavailable, try one bounded fallback; if that also fails, report the visual-verification gap and stop. Do not cascade across Playwright, Browser, and Computer Use merely because a renderer is unavailable.
+- Add only relevant artifact controls: provenance for consequential factual claims; parse/build/link checks for structured content; reference comparison for fidelity work; accessibility/privacy/brand checks when required; native structure/editability checks for documents and decks; and explicit authority before publication or external writes.
+- File count is not a router. Multiple simple artifacts can remain direct; a one-file migration, auth change, destructive action, secrets/personal-data path, hardware-dependent behaviour, compatibility-sensitive contract, or weak oracle can require full assurance.
+- Local observable behaviour changes retain one right-reason RED/GREEN cycle or an existing right-reason failing reproduction. Discovering a hard-risk boundary jumps directly to the required assurance level; exploration scope may still expand one boundary at a time.
+
+### Child context and independent authority
+- Give child agents a compact task packet: objective, behaviour, constraints/non-goals, owned paths, evidence/unknowns, acceptance command, and return shape.
+- Do not use an all-turn fork from a mature task by default; use no inherited turns or a small recent-turn bound when supported.
+- For substantive AI-authored behaviour, keep RED author, implementer, and verifier in separate contexts; give the RED author and verifier fresh context. Freeze the right-reason RED oracle; the implementer must not weaken it.
 
 <lore_commit_protocol>
 ## Lore Commit Protocol
@@ -204,7 +240,7 @@ The `deep-interview` skill is the Socratic deep interview workflow and includes 
 | Keyword(s) | Skill | Action |
 |-------------|-------|--------|
 | "ralph", "don't stop", "must complete", "keep going" | `$ralph` | Read `~/.codex/skills/ralph/SKILL.md`, execute persistence loop |
-| "autopilot", "build me", "I want a" | `$autopilot` | Read `~/.codex/skills/autopilot/SKILL.md`, execute autonomous pipeline |
+| "autopilot", "build me" | `$autopilot` | Read `~/.codex/skills/autopilot/SKILL.md`, execute autonomous pipeline |
 | "ultrawork", "ulw", "parallel" | `$ultrawork` | Read `~/.codex/skills/ultrawork/SKILL.md`, execute parallel agents |
 | "ultraqa" | `$ultraqa` | Read `~/.codex/skills/ultraqa/SKILL.md`, run QA cycling workflow |
 | "analyze", "investigate" | `$analyze` | Read `~/.codex/skills/analyze/SKILL.md`, run deep analysis |
@@ -222,6 +258,7 @@ The `deep-interview` skill is the Socratic deep interview workflow and includes 
 
 Detection rules:
 - Keywords are case-insensitive and match anywhere in the user message.
+- Implicit keyword matches require affirmative invocation intent; negated or mention-only occurrences do not activate a mode. Explicit `$name` invocations remain authoritative.
 - Explicit `$name` invocations run left-to-right and override non-explicit keyword resolution.
 - If multiple non-explicit keywords match, use the most specific match.
 - If the user explicitly invokes `/prompts:<name>`, do not auto-activate keyword skills unless explicit `$name` tokens are also present.
@@ -338,17 +375,18 @@ Parallelization:
 - If correctness depends on retrieval, diagnostics, tests, or other tools, continue using them until the task is grounded and verified.
 
 Anti-slop workflow:
-- Cleanup/refactor/deslop work still follows the same `$deep-interview` -> `$ralplan` -> `$team`/`$ralph` path; use `$ai-slop-cleaner` as a bounded helper inside the chosen execution lane, not as a competing top-level workflow.
+- Route cleanup/refactor/deslop work proportionally: use the active solo, serial, or parallel execution lane that the task already earns, and use `$ai-slop-cleaner` as a bounded helper rather than forcing interview, consensus planning, Team, or Ralph for every cleanup.
 - Lock behavior with tests first, then make one smell-focused pass at a time.
 - Prefer deletion, reuse, and boundary repair over new layers.
 - Keep writer/reviewer pass separation for cleanup plans and approvals.
 
 Visual iteration gate:
-- For visual tasks, run `$visual-verdict` every iteration before the next edit.
-- Persist verdict JSON in `.omx/state/{scope}/ralph-progress.json`.
+- Run `$visual-verdict` before the next edit only for visual fidelity work that has both a generated screenshot and at least one reference image.
+- For exploratory mockups without a reference, inspect and show the rendered artifact directly; do not manufacture a numeric fidelity gate.
+- When `$visual-verdict` applies, persist verdict JSON in `.omx/state/{scope}/ralph-progress.json`.
 
 Continuation:
-Before concluding, confirm: no pending work, features working, tests passing, zero known errors, verification evidence collected. If not, continue.
+Before concluding, confirm: no pending in-scope work, the requested surface works, tests pass where tests apply, no known attributable errors remain, and fresh applicable verification evidence was collected. If not, continue.
 
 Ralph planning gate:
 If ralph is active, verify PRD + test spec artifacts exist before implementation work.


### PR DESCRIPTION
## What changed

- separates assurance level from solo, serial, or parallel execution shape;
- adds a direct-artifact route for bounded prose, wiki, mockup, and visual work;
- makes brainstorming, cleanup, verification, and visual comparison applicability-aware;
- prevents mention-only, negated, or ordinary desire phrasing from activating heavy modes;
- makes Ralph, Autopilot, Ecomode, and Help guidance proportional to risk and evidence;
- records explicit composition rules for user-owned workflow overlays;
- adds contract tests for routing, task-size boundaries, lean modes, and guidance surfaces.

## Why

Small, well-specified changes were inheriting planning, fan-out, and broad verification designed for ambiguous or high-risk work. This keeps full assurance for hard-risk boundaries and weak oracles while restoring a fast path for bounded work with a strong focused acceptance surface.

## Validation

- TypeScript build passed on the exact isolated commit.
- 214 focused routing, guidance, mode, keyword, and task-size tests passed.
- `git diff --check` passed.

## Scope

This PR intentionally excludes unrelated notification, catalog, explore/Rust, session-history, HUD, and research-provenance work that remains local in the source checkout.
