### PR TITLE
fix(config): reconcile duplicate project trust tables

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -2756,6 +2756,10 @@ describe("project launch scope helpers", () => {
           'trusted_hash = "sha256:setup-owned"',
           "# End OMX-owned Codex hook trust state",
           "",
+          "# User-owned project trust source must remain external during launch repair.",
+          `[projects."${wd}"] # retained external ownership`,
+          'trust_level = "trusted"',
+          "",
           "# OMX-synced Codex project trust state (from runtime CODEX_HOME)",
           `[projects."${wd}"]`,
           'trust_level = "trusted"',
@@ -2793,6 +2797,13 @@ describe("project launch scope helpers", () => {
       );
       assert.ok(runtimeConfig.includes(`[projects."${wd}"]`));
       assert.ok(repairedProjectConfig.includes(`[projects."${wd}"]`));
+      assert.match(repairedProjectConfig, /User-owned project trust source must remain external/);
+      assert.match(repairedProjectConfig, new RegExp(`^${escapeRegExp(`[projects."${wd}"]`)} # retained external ownership$`, "m"));
+      assert.equal(
+        countMatches(repairedProjectConfig, new RegExp(`^${escapeRegExp(`[projects."${wd}"]`)}(?:\\s|$)`, "gm")),
+        1,
+        "launch repair must remove only the marker-owned duplicate before the runtime mirror is written",
+      );
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -15,9 +15,11 @@ import {
   hasExactOmxSeededBehavioralDefaultsPair,
   mergeConfig,
   repairConfigIfNeeded,
+  repairProjectScopeTrustStateForLaunch,
   stripExistingOmxBlocks,
   stripManagedCodexHookTrustState,
   stripOmxFeatureFlags,
+  syncProjectScopeTrustStateFromRuntime,
   upsertManagedCodexHookTrustState,
   stripOmxSeededBehavioralDefaults,
 } from "../generator.js";
@@ -32,6 +34,10 @@ import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../omx-first-party-mcp.js";
 /** Count occurrences of a pattern in text */
 function count(text: string, pattern: RegExp): number {
   return (text.match(pattern) ?? []).length;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 async function writeSetupGeneratedHookTrustFixture(wd: string): Promise<{
@@ -2702,6 +2708,367 @@ describe("config generator idempotency (#384)", () => {
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
+  });
+
+});
+
+describe("project trust sync ownership reconciliation (#3199)", () => {
+  const markerStart = "# OMX-synced Codex project trust state (from runtime CODEX_HOME)";
+  const markerEnd = "# End OMX-synced Codex project trust state";
+
+  it("retains an equal external project family byte-for-byte and removes only its fenced duplicate", () => {
+    const key = "/tmp/외부.project";
+    const external = `[projects."${key}"] # retain this spelling\ntrust_level = "trusted"\n\n[projects."${key}".child]\nanswer = 42\n`;
+    const durable = `${external}\n${markerStart}\n[projects."${key}"]\ntrust_level = "trusted"\n\n[projects."${key}".child]\nanswer = 42\n${markerEnd}\n`;
+    const runtime = `[projects."${key}"]\ntrust_level = "trusted"\n\n[projects."${key}".child]\nanswer = 42\n`;
+
+    const synced = syncProjectScopeTrustStateFromRuntime(durable, runtime, "/tmp/hooks.json");
+    assert.equal(synced, external);
+    assert.deepEqual(TOML.parse(synced), TOML.parse(external));
+    assert.equal(syncProjectScopeTrustStateFromRuntime(synced, runtime, "/tmp/hooks.json"), synced);
+    assert.equal(syncProjectScopeTrustStateFromRuntime(synced, runtime, "/tmp/hooks.json"), synced);
+  });
+
+  it("fails closed atomically for mismatched, nested, and ambiguous project source", () => {
+    const runtime = '[projects."/tmp/a"]\ntrust_level = "trusted"\n\n[projects."/tmp/b"]\ntrust_level = "trusted"\n';
+    const mismatch = '[projects."/tmp/a"]\ntrust_level = "untrusted"\n';
+    assert.equal(syncProjectScopeTrustStateFromRuntime(mismatch, runtime, "/tmp/hooks.json"), mismatch);
+    const nested = '[projects."/tmp/a"]\n[projects."/tmp/a".child]\nvalue = "x"\n';
+    assert.equal(syncProjectScopeTrustStateFromRuntime("", nested, "/tmp/hooks.json"), "");
+    const duplicateMarker = `${markerStart}\n${markerEnd}\n${markerStart}\n${markerEnd}\n`;
+    assert.equal(syncProjectScopeTrustStateFromRuntime(duplicateMarker, runtime, "/tmp/hooks.json"), duplicateMarker);
+  });
+
+  it("preserves BOM and hook-only marker state through launch repair", () => {
+    const hook = "/tmp/hooks.json:pre_tool_use:0:0";
+    const runtime = `[hooks.state."${hook}"]\ntrusted_hash = "sha256:ok"\n`;
+    const bom = `\uFEFF# non-ascii: 외부\r\n`;
+    const synced = syncProjectScopeTrustStateFromRuntime(bom, runtime, "/tmp/hooks.json");
+    assert.ok(synced.startsWith("\uFEFF# non-ascii: 외부\r\n"));
+    assert.ok(synced.includes(`${markerStart}\r\n`));
+    assert.doesNotThrow(() => TOML.parse(synced.slice(1)));
+    assert.equal(repairProjectScopeTrustStateForLaunch(synced, "/tmp/hooks.json"), synced);
+  });
+
+  it("preserves unrelated external tables and distinguishes quoted dotted keys from dotted paths", () => {
+    const target = "org.example/project";
+    const external = [
+      "# user-owned leading comment",
+      `[projects.'${target}']`,
+      'trust_level = "trusted" # user-owned trailing comment',
+      "",
+      '[projects."other.key"]',
+      'trust_level = "untrusted"',
+      "",
+      "[user.section]",
+      'note = "keep"',
+      "",
+    ].join("\n");
+    const runtime = `[projects."${target}"]\ntrust_level = "trusted"\n`;
+    const synced = syncProjectScopeTrustStateFromRuntime(external, runtime, "/tmp/hooks.json");
+    assert.equal(synced, external);
+    assert.equal((TOML.parse(synced) as { projects: Record<string, unknown> }).projects["other.key"] !== undefined, true);
+  });
+
+  it("normal sync removes semantically empty markers while launch repair leaves them untouched", () => {
+    const empty = `${markerStart}\n${markerEnd}\n`;
+    assert.equal(syncProjectScopeTrustStateFromRuntime(empty, "", "/tmp/hooks.json"), "\n");
+    const comments = `${markerStart}\n# OMX payload comment\n\n${markerEnd}\n`;
+    assert.equal(syncProjectScopeTrustStateFromRuntime(comments, "", "/tmp/hooks.json"), "\n");
+    assert.equal(repairProjectScopeTrustStateForLaunch(comments, "/tmp/hooks.json"), comments);
+    const hook = "/tmp/hooks.json:post_tool_use:0:0";
+    const runtime = `[hooks.state."${hook}"]\ntrusted_hash = "sha256:hook"\n`;
+    const hookOnly = syncProjectScopeTrustStateFromRuntime(comments, runtime, "/tmp/hooks.json");
+    assert.ok(hookOnly.includes(markerStart));
+    assert.match(hookOnly, new RegExp(`^\\[hooks\\.state\\."${escapeRegExp(hook)}"\\]$`, "m"));
+    assert.equal(syncProjectScopeTrustStateFromRuntime(hookOnly, runtime, "/tmp/hooks.json"), hookOnly);
+  });
+
+  it("keeps project and hook mutation atomic across runtime shape and multi-key failures", () => {
+    const hook = "/tmp/hooks.json:pre_tool_use:0:0";
+    const hookRuntime = `[hooks.state."${hook}"]\ntrusted_hash = "sha256:hook"\n`;
+    const nonRecord = `projects = "invalid"\n\n${hookRuntime}`;
+    assert.equal(syncProjectScopeTrustStateFromRuntime("# durable\n", nonRecord, "/tmp/hooks.json"), "# durable\n");
+    const mixed = `${hookRuntime}\n[projects."/safe"]\ntrust_level = "trusted"\n\n[projects."/unsafe"]\n[projects."/unsafe".child]\nvalue = "nested"\n`;
+    const durable = '[projects."/unsafe"]\ntrust_level = "untrusted"\n';
+    assert.equal(syncProjectScopeTrustStateFromRuntime(durable, mixed, "/tmp/hooks.json"), durable);
+    const absentProjects = syncProjectScopeTrustStateFromRuntime("", hookRuntime, "/tmp/hooks.json");
+    assert.match(absentProjects, /hooks\.state/);
+    const emptyProjects = syncProjectScopeTrustStateFromRuntime("", `projects = {}\n\n${hookRuntime}`, "/tmp/hooks.json");
+    assert.match(emptyProjects, /hooks\.state/);
+  });
+
+  it("accepts nested external retention but refuses nested rendering and malformed project forms", () => {
+    const nested = '[projects."/nested"]\ntrust_level = "trusted"\n\n[projects."/nested".child]\nvalue = "x"\n';
+    assert.equal(syncProjectScopeTrustStateFromRuntime(nested, nested, "/tmp/hooks.json"), nested);
+    assert.equal(syncProjectScopeTrustStateFromRuntime("", nested, "/tmp/hooks.json"), "");
+    for (const unsafe of [
+      'projects = { "/inline" = { trust_level = "trusted" } }\n',
+      '[projects]\n"/dotted".trust_level = "trusted"\n',
+      '[[projects."/array"]]\ntrust_level = "trusted"\n',
+      '[projects."/bad"\ntrust_level = "trusted"\n',
+    ]) {
+      assert.equal(syncProjectScopeTrustStateFromRuntime(unsafe, '[projects."/bad"]\ntrust_level = "trusted"\n', "/tmp/hooks.json"), unsafe);
+    }
+  });
+
+  it("fails closed for equal external state with parent-only dotted or inline nested marker bodies", () => {
+    const external = '[projects."/nested"]\nchild.value = "x"\n';
+    const runtime = '[projects."/nested"]\n[projects."/nested".child]\nvalue = "x"\n';
+    const inlineExternal = '[projects."/nested"]\nchild = { value = "x" }\n';
+    const inlineRuntime = '[projects."/nested"]\n[projects."/nested".child]\nvalue = "x"\n';
+    for (const [outside, source] of [
+      [external, external],
+      [inlineExternal, inlineExternal],
+    ]) {
+      const durable = `${outside}\n${markerStart}\n${source}${markerEnd}\n`;
+      assert.equal(
+        syncProjectScopeTrustStateFromRuntime(durable, source === external ? runtime : inlineRuntime, "/tmp/hooks.json"),
+        durable,
+      );
+      assert.equal(repairProjectScopeTrustStateForLaunch(durable, "/tmp/hooks.json"), durable);
+    }
+  });
+
+  it("fails closed for implicit nested runtime and external sources before any hook mutation", () => {
+    const hook = "/tmp/hooks.json:post_tool_use:0:0";
+    const hookRuntime = `[hooks.state."${hook}"]\ntrusted_hash = "sha256:hook"\n`;
+    const durable = '# durable bytes\n';
+    for (const runtime of [
+      '[projects."/dotted"]\nchild.value = "x"\n',
+      '[projects."/inline"]\nchild = { value = "x" }\n',
+    ]) {
+      assert.equal(
+        syncProjectScopeTrustStateFromRuntime(durable, `${runtime}\n${hookRuntime}`, "/tmp/hooks.json"),
+        durable,
+      );
+    }
+
+    for (const external of [
+      '[projects."/dotted"]\nchild.value = "x"\n',
+      '[projects."/inline"]\nchild = { value = "x" }\n',
+    ]) {
+      assert.equal(
+        syncProjectScopeTrustStateFromRuntime(external, `${external}\n${hookRuntime}`, "/tmp/hooks.json"),
+        external,
+      );
+    }
+  });
+
+  it("preserves managed marker headers and assignments with inline comments exactly", () => {
+    const hook = "/tmp/hooks.json:pre_tool_use:0:0";
+    const runtime = `[projects."/commented"]\ntrust_level = "trusted"\n\n[hooks.state."${hook}"]\ntrusted_hash = "sha256:hook"\n`;
+    for (const managedLine of [
+      '[projects."/commented"] # user-owned header comment',
+      'trust_level = "trusted" # user-owned assignment comment',
+    ]) {
+      const durable = `${markerStart}\n${managedLine}\n${managedLine.startsWith("[") ? 'trust_level = "trusted"' : '[projects."/commented"]'}\n${markerEnd}\n`;
+      assert.equal(syncProjectScopeTrustStateFromRuntime(durable, runtime, "/tmp/hooks.json"), durable);
+      assert.equal(repairProjectScopeTrustStateForLaunch(durable, "/tmp/hooks.json"), durable);
+    }
+    const inlineMarker = `${markerStart} # user-owned marker comment\n${markerEnd}\n`;
+    assert.equal(syncProjectScopeTrustStateFromRuntime(inlineMarker, runtime, "/tmp/hooks.json"), inlineMarker);
+  });
+
+  it("fails closed rather than moving comments before or between table assignments", () => {
+    const durable = [
+      markerStart,
+      '[projects."/commented"]',
+      "# before trust level",
+      'trust_level = "trusted"',
+      "# between assignments",
+      'approval = "trusted"',
+      markerEnd,
+      "",
+    ].join("\n");
+    const runtime = '[projects."/commented"]\ntrust_level = "trusted"\napproval = "trusted"\n';
+
+    assert.equal(syncProjectScopeTrustStateFromRuntime(durable, runtime, "/tmp/hooks.json"), durable);
+    assert.equal(repairProjectScopeTrustStateForLaunch(durable, "/tmp/hooks.json"), durable);
+  });
+
+  it("fails closed for noncanonical runtime and marker project source forms", () => {
+    const canonical = '[projects."/safe"]\ntrust_level = "trusted"\n';
+    const runtimeForms = [
+      'projects = { "/inline" = { trust_level = "trusted" } }\n',
+      '[projects]\n"/dotted".trust_level = "trusted"\n',
+      '[projects]\n"/implicit" = { trust_level = "trusted" }\n',
+    ];
+    for (const runtime of runtimeForms) {
+      assert.equal(syncProjectScopeTrustStateFromRuntime("# durable\n", runtime, "/tmp/hooks.json"), "# durable\n");
+    }
+    for (const payload of runtimeForms) {
+      const durable = `${markerStart}\n${payload}${markerEnd}\n`;
+      assert.equal(syncProjectScopeTrustStateFromRuntime(durable, canonical, "/tmp/hooks.json"), durable);
+    }
+    const malformed = `${markerStart}\n[projects."/bad"\ntrust_level = "trusted"\n${markerEnd}\n`;
+    const noncontiguous = '[projects."/safe"]\ntrust_level = "trusted"\n\n[user]\nkeep = true\n\n[projects."/safe".child]\nvalue = "x"\n';
+    const multiline = 'note = """\n[projects."/not-a-header"]\n"""\n';
+    assert.equal(syncProjectScopeTrustStateFromRuntime(malformed, canonical, "/tmp/hooks.json"), malformed);
+    assert.equal(syncProjectScopeTrustStateFromRuntime(noncontiguous, noncontiguous, "/tmp/hooks.json"), noncontiguous);
+    const multilineSynced = syncProjectScopeTrustStateFromRuntime(multiline, canonical, "/tmp/hooks.json");
+    assert.match(multilineSynced, /^note = """\n\[projects\."\/not-a-header"\]\n"""$/m);
+    assert.equal(syncProjectScopeTrustStateFromRuntime(multilineSynced, canonical, "/tmp/hooks.json"), multilineSynced);
+  });
+
+  it("preserves zero and multiple durable trailing newlines without accumulating separators", () => {
+    const runtime = '[projects."/eol"]\ntrust_level = "trusted"\n';
+    for (const trailingEols of ["", "\n\n\n", "\r\n\n\r\n"]) {
+      const durable = `# external${trailingEols}`;
+      const synced = syncProjectScopeTrustStateFromRuntime(durable, runtime, "/tmp/hooks.json");
+      const replaced = syncProjectScopeTrustStateFromRuntime(synced, runtime, "/tmp/hooks.json");
+      const removed = syncProjectScopeTrustStateFromRuntime(replaced, "", "/tmp/hooks.json");
+      assert.equal(synced.match(/(?:\r\n|\n)*$/)?.[0], trailingEols);
+      assert.equal(replaced, synced);
+      assert.equal(removed, durable);
+    }
+  });
+
+  it("repairs an equal external-and-fenced project duplicate without moving external bytes", () => {
+    const external = '# before external\n[projects."/repair"]\ntrust_level = "trusted"\n';
+    const durable = `${external}\n${markerStart}\n[projects."/repair"]\ntrust_level = "trusted"\n${markerEnd}\n`;
+    const repaired = repairProjectScopeTrustStateForLaunch(durable, "/tmp/hooks.json");
+    assert.equal(repaired, external);
+    assert.doesNotThrow(() => TOML.parse(repaired));
+  });
+
+  it("preserves BOM and escaped project keys through second and third sync", () => {
+    const key = '__omx_project_sync_probe__\\"quoted';
+    const runtime = `[projects."${key.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"]\ntrust_level = "trusted"\n`;
+    const first = syncProjectScopeTrustStateFromRuntime("\uFEFF# é\n", runtime, "/tmp/hooks.json");
+    const second = syncProjectScopeTrustStateFromRuntime(first, runtime, "/tmp/hooks.json");
+    const third = syncProjectScopeTrustStateFromRuntime(second, runtime, "/tmp/hooks.json");
+    const projects = (TOML.parse(third.slice(1)) as { projects: Record<string, unknown> }).projects;
+    assert.equal(second, first);
+    assert.equal(third, first);
+    assert.deepEqual(Object.keys(projects), [key]);
+    assert.equal(syncProjectScopeTrustStateFromRuntime("# x\uFEFF\n", runtime, "/tmp/hooks.json"), "# x\uFEFF\n");
+    assert.equal(syncProjectScopeTrustStateFromRuntime("\uFEFF\uFEFF# x\n", runtime, "/tmp/hooks.json"), "\uFEFF\uFEFF# x\n");
+  });
+  it("fails closed for unsupported marker tables and assignments", () => {
+    const runtime = '[projects."/safe"]\ntrust_level = "trusted"\n';
+    for (const unsupported of [
+      '[omx_unknown]\nvalue = true\n',
+      'unknown_managed_assignment = true\n',
+    ]) {
+      const durable = `${markerStart}\n${unsupported}${markerEnd}\n`;
+      assert.equal(syncProjectScopeTrustStateFromRuntime(durable, runtime, "/tmp/hooks.json"), durable);
+      assert.equal(repairProjectScopeTrustStateForLaunch(durable, "/tmp/hooks.json"), durable);
+    }
+  });
+
+  it("fails closed for descendant-only and hook-interleaved marker project families", () => {
+    const hook = "/tmp/hooks.json:post_tool_use:0:0";
+    const external = [
+      '[projects."/safe"]',
+      'trust_level = "trusted"',
+      "",
+      '[projects."/safe".child]',
+      'value = "nested"',
+      "",
+    ].join("\n");
+    const runtime = `${external}[hooks.state."${hook}"]\ntrusted_hash = "sha256:hook"\n`;
+    const descendantOnly = `${external}${markerStart}\n[projects."/safe".child]\nvalue = "nested"\n${markerEnd}\n`;
+    const hookInterleaved = `${external}${markerStart}\n[projects."/safe"]\ntrust_level = "trusted"\n\n[hooks.state."${hook}"]\ntrusted_hash = "sha256:hook"\n\n[projects."/safe".child]\nvalue = "nested"\n${markerEnd}\n`;
+
+    for (const durable of [descendantOnly, hookInterleaved]) {
+      assert.equal(syncProjectScopeTrustStateFromRuntime(durable, runtime, "/tmp/hooks.json"), durable);
+      assert.equal(repairProjectScopeTrustStateForLaunch(durable, "/tmp/hooks.json"), durable);
+    }
+  });
+
+  it("inserts new runtime project and hook tables before the trailing owned payload gap", () => {
+    const hook = "/tmp/hooks.json:post_tool_use:0:0";
+    const durable = [
+      markerStart,
+      '[projects."/existing"]',
+      'trust_level = "trusted"',
+      "# trailing owned gap",
+      "",
+      markerEnd,
+      "",
+    ].join("\n");
+    const runtime = [
+      '[projects."/existing"]',
+      'trust_level = "trusted"',
+      "",
+      '[projects."/new"]',
+      'trust_level = "trusted"',
+      "",
+      `[hooks.state."${hook}"]`,
+      'trusted_hash = "sha256:hook"',
+      "",
+    ].join("\n");
+    const expected = [
+      markerStart,
+      '[projects."/existing"]',
+      'trust_level = "trusted"',
+      '[projects."/new"]',
+      'trust_level = "trusted"',
+      `[hooks.state."${hook}"]`,
+      'trusted_hash = "sha256:hook"',
+      "# trailing owned gap",
+      "",
+      markerEnd,
+      "",
+    ].join("\n");
+
+    const synced = syncProjectScopeTrustStateFromRuntime(durable, runtime, "/tmp/hooks.json");
+    assert.equal(synced, expected);
+    assert.equal(syncProjectScopeTrustStateFromRuntime(synced, runtime, "/tmp/hooks.json"), synced);
+  });
+
+  it("preserves owned payload gaps while removing first, middle, and last project duplicates", () => {
+    const hook = "/tmp/hooks.json:post_tool_use:0:0";
+    const external = [
+      '[projects."/first"]',
+      'trust_level = "trusted"',
+      "",
+      '[projects."/middle"]',
+      'trust_level = "trusted"',
+      "",
+      '[projects."/last"]',
+      'trust_level = "trusted"',
+      "",
+    ].join("\n");
+    const runtime = `${external}[hooks.state."${hook}"]\ntrusted_hash = "sha256:hook"\n`;
+    const durable = [
+      external,
+      markerStart,
+      "# before first",
+      '[projects."/first"]',
+      'trust_level = "trusted"',
+      "# between first and middle",
+      '[projects."/middle"]',
+      'trust_level = "trusted"',
+      "# between middle and hook",
+      `[hooks.state."${hook}"]`,
+      'trusted_hash = "sha256:hook"',
+      "# between hook and last",
+      '[projects."/last"]',
+      'trust_level = "trusted"',
+      "# after last",
+      markerEnd,
+      "",
+    ].join("\n");
+    const expected = [
+      external,
+      markerStart,
+      "# before first",
+      "# between first and middle",
+      "# between middle and hook",
+      `[hooks.state."${hook}"]`,
+      'trusted_hash = "sha256:hook"',
+      "# between hook and last",
+      "# after last",
+      markerEnd,
+      "",
+    ].join("\n");
+
+    const synced = syncProjectScopeTrustStateFromRuntime(durable, runtime, "/tmp/hooks.json");
+    assert.equal(synced, expected);
+    assert.equal(syncProjectScopeTrustStateFromRuntime(synced, runtime, "/tmp/hooks.json"), synced);
+    assert.doesNotThrow(() => TOML.parse(synced));
   });
 
 });

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -939,69 +939,8 @@ const OMX_PROJECT_TRUST_START_MARKER =
 const OMX_PROJECT_TRUST_END_MARKER =
   "# End OMX-synced Codex project trust state";
 
-function extractMarkerBlockContent(
-  config: string,
-  startMarker: string,
-  endMarker: string,
-): string | undefined {
-  const lines = config.split(/\r?\n/);
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].trim() !== startMarker) continue;
-
-    const nextEndIdx = lines.findIndex(
-      (line, index) => index > i && line.trim() === endMarker,
-    );
-    const nextStartIdx = lines.findIndex(
-      (line, index) => index > i && line.trim() === startMarker,
-    );
-    if (nextEndIdx === -1 || (nextStartIdx !== -1 && nextStartIdx < nextEndIdx)) {
-      return undefined;
-    }
-
-    return lines.slice(i + 1, nextEndIdx).join("\n").trim();
-  }
-  return undefined;
-}
-
-function stripMarkerBlock(
-  config: string,
-  startMarker: string,
-  endMarker: string,
-): string {
-  const lines = config.split(/\r?\n/);
-  const kept: string[] = [];
-
-  for (let i = 0; i < lines.length;) {
-    if (lines[i].trim() !== startMarker) {
-      kept.push(lines[i]);
-      i += 1;
-      continue;
-    }
-
-    const nextEndIdx = lines.findIndex(
-      (line, index) => index > i && line.trim() === endMarker,
-    );
-    const nextStartIdx = lines.findIndex(
-      (line, index) => index > i && line.trim() === startMarker,
-    );
-    if (nextEndIdx === -1 || (nextStartIdx !== -1 && nextStartIdx < nextEndIdx)) {
-      kept.push(lines[i]);
-      i += 1;
-      continue;
-    }
-    i = nextEndIdx + 1;
-  }
-
-  return kept.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd();
-}
-
 function isPlainTomlRecord(value: unknown): value is Record<string, unknown> {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    !Array.isArray(value) &&
-    Object.getPrototypeOf(value) === Object.prototype
-  );
+  return typeof value === "object" && value !== null && !Array.isArray(value) && Object.getPrototypeOf(value) === Object.prototype;
 }
 
 function safeParseToml(content: string): Record<string, unknown> | undefined {
@@ -1013,126 +952,550 @@ function safeParseToml(content: string): Record<string, unknown> | undefined {
   }
 }
 
-function collectProjectHookTrustStateKeys(config: string): Set<string> {
-  const keys = new Set<string>();
-  const parsed = safeParseToml(config);
-  const hooksTable = isPlainTomlRecord(parsed) ? parsed.hooks : undefined;
-  const hooksState = isPlainTomlRecord(hooksTable) ? hooksTable.state : undefined;
-  if (!isPlainTomlRecord(hooksState)) return keys;
-  for (const [key, entry] of Object.entries(hooksState)) {
-    if (!isPlainTomlRecord(entry)) continue;
-    keys.add(key);
+function projectHookTrustState(config: string): Record<string, unknown> | undefined {
+  const hooks = safeParseToml(config)?.hooks;
+  const state = isPlainTomlRecord(hooks) ? hooks.state : undefined;
+  return isPlainTomlRecord(state) ? state : undefined;
+}
+
+
+function projectTrustSemanticView(config: string): { source: string; prefix: string } | undefined {
+  const hasLeadingBom = config.startsWith("\uFEFF");
+  const source = hasLeadingBom ? config.slice(1) : config;
+  if (source.includes("\uFEFF")) return undefined;
+  return { source, prefix: hasLeadingBom ? "\uFEFF" : "" };
+}
+
+interface ProjectTrustMarkerRange extends SourceSpan {
+  payloadStart: number;
+  payloadEnd: number;
+}
+
+function projectTrustMarkerRange(config: string): ProjectTrustMarkerRange | undefined {
+  const lexical = analyzeTomlSource(config);
+  if (!lexical.isUnambiguous) return undefined;
+  const lines = sourceLines(config);
+  const starts = lines.filter((line, index) =>
+    lexical.lineStartsOutsideMultiline[index] && line.content.trim() === OMX_PROJECT_TRUST_START_MARKER
+  );
+  const ends = lines.filter((line, index) =>
+    lexical.lineStartsOutsideMultiline[index] && line.content.trim() === OMX_PROJECT_TRUST_END_MARKER
+  );
+  if (starts.length === 0 && ends.length === 0) return { start: config.length, end: config.length, payloadStart: config.length, payloadEnd: config.length };
+  if (starts.length !== 1 || ends.length !== 1 || starts[0]!.start >= ends[0]!.start) return undefined;
+  const start = starts[0]!;
+  const end = ends[0]!;
+  return { start: start.start, end: end.end, payloadStart: start.end, payloadEnd: end.start };
+}
+
+function hasInlineProjectTrustMarkerComment(config: string): boolean {
+  const lexical = analyzeTomlSource(config);
+  return sourceLines(config).some((line, index) => {
+    if (!lexical.lineStartsOutsideMultiline[index]) return false;
+    const trimmed = line.content.trim();
+    return (trimmed.startsWith(OMX_PROJECT_TRUST_START_MARKER) && trimmed !== OMX_PROJECT_TRUST_START_MARKER) ||
+      (trimmed.startsWith(OMX_PROJECT_TRUST_END_MARKER) && trimmed !== OMX_PROJECT_TRUST_END_MARKER);
+  });
+}
+
+function projectTrustHeaderPath(line: string): string[] | undefined {
+  if (/^\s*\[\[/.test(line)) return undefined;
+  const header = parseTomlSourceTableHeader(line);
+  if (!header?.parsed) return undefined;
+  const path: string[] = [];
+  let cursor: unknown = header.parsed;
+  while (isPlainTomlRecord(cursor)) {
+    const keys = Object.keys(cursor);
+    if (keys.length === 0) return path;
+    if (keys.length !== 1) return undefined;
+    const key = keys[0]!;
+    path.push(key);
+    cursor = cursor[key];
   }
-  return keys;
+  return path;
+}
+
+function dominantProjectTrustEol(source: string): string {
+  const crlfCount = (source.match(/\r\n/g) ?? []).length;
+  const lfCount = (source.match(/(?<!\r)\n/g) ?? []).length;
+  return crlfCount > lfCount ? "\r\n" : "\n";
+}
+
+function projectTrustPayloadIsSemanticallyEmpty(payload: string): boolean {
+  const parsed = safeParseToml(payload);
+  return parsed !== undefined && Object.keys(parsed).length === 0;
+}
+
+interface ProjectTrustPayloadHeader extends ProjectTrustHeader {
+  kind: "project" | "hook";
+}
+
+function projectTrustValueAtPath(
+  source: Record<string, unknown>,
+  path: readonly string[],
+): unknown {
+  let value: unknown = source;
+  for (const key of path) {
+    if (!isPlainTomlRecord(value)) return undefined;
+    value = value[key];
+  }
+  return value;
 }
 
 /**
- * Repairs project configs from the 0.18.3 relaunch regression where a
- * project-synced trust block could duplicate setup-owned hook trust tables and
- * make the next runtime CODEX_HOME config.toml invalid before Codex started.
+ * Marker contents are an ownership boundary, not general TOML. Reject every
+ * source form that OMX did not emit rather than rebuilding it and losing data.
  */
-export function repairProjectScopeTrustStateForLaunch(
-  projectConfig: string,
+function inventoryProjectTrustPayload(
+  payload: string,
   projectHooksPath: string,
-): string {
-  const syncedTrustBlock = extractMarkerBlockContent(
-    projectConfig,
-    OMX_PROJECT_TRUST_START_MARKER,
-    OMX_PROJECT_TRUST_END_MARKER,
-  );
-  if (!syncedTrustBlock) return projectConfig;
+): { parsed: Record<string, unknown>; headers: ProjectTrustPayloadHeader[] } | undefined {
+  const parsed = safeParseToml(payload);
+  const lexical = analyzeTomlSource(payload);
+  const headers = projectTrustHeaders(payload, { start: 0, end: payload.length });
+  if (!parsed || !lexical.isUnambiguous || !headers) return undefined;
+  if (Object.keys(parsed).some((key) => key !== "projects" && key !== "hooks")) return undefined;
 
-  const stripped = stripMarkerBlock(
-    projectConfig,
-    OMX_PROJECT_TRUST_START_MARKER,
-    OMX_PROJECT_TRUST_END_MARKER,
-  );
-  const repaired = syncProjectScopeTrustStateFromRuntime(
-    stripped,
-    syncedTrustBlock,
-    projectHooksPath,
-  );
-  return repaired === stripped ? projectConfig : repaired;
+  const lines = sourceLines(payload);
+  const headerStarts = new Set(headers.map((header) => header.start));
+  for (const [index, line] of lines.entries()) {
+    if (!lexical.lineStartsOutsideMultiline[index]) return undefined;
+    const isHeader = headerStarts.has(line.start);
+    const isBlankOrComment = line.content.trim() === "" || /^\s*#/.test(line.content);
+    if (isHeader || isBlankOrComment) {
+      if (isHeader && lexical.lineHasTomlComment[index]) return undefined;
+      continue;
+    }
+    if (lexical.lineHasTomlComment[index]) return undefined;
+    const priorHeader = headers.some((header) => header.start < line.start);
+    if (!priorHeader) return undefined;
+  }
+
+  const managedHeaders: ProjectTrustPayloadHeader[] = [];
+  for (const header of headers) {
+    if (header.path[0] === "projects" && header.path.length >= 2) {
+      if (!isPlainTomlRecord(projectTrustValueAtPath(parsed, header.path))) return undefined;
+      managedHeaders.push({ ...header, kind: "project" });
+      continue;
+    }
+    if (
+      header.path[0] === "hooks" &&
+      header.path[1] === "state" &&
+      header.path.length === 3 &&
+      header.path[2]!.startsWith(`${projectHooksPath}:`)
+    ) {
+      const value = projectTrustValueAtPath(parsed, header.path);
+      if (!isPlainTomlRecord(value) || typeof value.trusted_hash !== "string" || value.trusted_hash.length === 0 || Object.keys(value).some((key) => key !== "trusted_hash")) return undefined;
+      managedHeaders.push({ ...header, kind: "hook" });
+      continue;
+    }
+    return undefined;
+  }
+  if (!projectTrustPayloadProjectFamiliesAreValid(managedHeaders)) return undefined;
+  if (!projectTrustPayloadNestedStructuresAreExplicit(parsed, managedHeaders)) return undefined;
+  return { parsed, headers: managedHeaders };
 }
 
-/**
- * Project-scope launches mirror the durable project config.toml into an
- * ephemeral runtime CODEX_HOME. Codex writes its workspace-trust ledger and
- * hook trust ledger into the runtime config.toml during the session. Without
- * persistence, those entries die with the runtime, so Codex prompts to trust
- * the workspace and hooks on every launch (issue #2470).
- *
- * This function extracts only trust-state tables (`[projects."<cwd>"]` and
- * `[hooks.state."<projectHooksPath>:..."]`) from the runtime config.toml and
- * upserts them into the durable project config.toml inside a marker-fenced
- * block, preserving any surrounding user-managed content and comments and
- * ignoring Codex's NUX counters or other ephemeral runtime-only writes.
- */
+function projectTrustSourceNestedStructuresAreExplicit(
+  parsed: Record<string, unknown>,
+  headers: readonly ProjectTrustHeader[],
+): boolean {
+  const projects = parsed.projects;
+  if (projects === undefined) return true;
+  if (!isPlainTomlRecord(projects)) return false;
+
+  const hasHeader = (path: readonly string[]): boolean =>
+    headers.some((header) => projectTrustEqual(header.path, path));
+  const visit = (value: Record<string, unknown>, path: readonly string[]): boolean => {
+    for (const [key, child] of Object.entries(value)) {
+      if (!isPlainTomlRecord(child)) continue;
+      const childPath = [...path, key];
+      if (!hasHeader(childPath) || !visit(child, childPath)) return false;
+    }
+    return true;
+  };
+
+  return Object.entries(projects).every(([key, value]) =>
+    isPlainTomlRecord(value) && hasHeader(["projects", key]) && visit(value, ["projects", key])
+  );
+}
+
+function projectTrustPayloadNestedStructuresAreExplicit(
+  parsed: Record<string, unknown>,
+  headers: readonly ProjectTrustPayloadHeader[],
+): boolean {
+  const hasHeader = (path: readonly string[]): boolean =>
+    headers.some((header) => header.kind === "project" && projectTrustEqual(header.path, path));
+  const visit = (value: Record<string, unknown>, path: readonly string[]): boolean => {
+    for (const [key, child] of Object.entries(value)) {
+      if (!isPlainTomlRecord(child)) continue;
+      const childPath = [...path, key];
+      if (!hasHeader(childPath) || !visit(child, childPath)) return false;
+    }
+    return true;
+  };
+
+  return headers
+    .filter((header) => header.kind === "project" && header.path.length === 2)
+    .every((header) => {
+      const value = projectTrustValueAtPath(parsed, header.path);
+      return isPlainTomlRecord(value) && visit(value, header.path);
+    });
+}
+
+interface ProjectTrustPayloadTableSpan {
+  source: string;
+  gap: string;
+}
+
+function projectTrustPayloadTableSpan(source: string): ProjectTrustPayloadTableSpan {
+  const lines = sourceLines(source);
+  const lastBodyLine = lines
+    .slice(1)
+    .reverse()
+    .find((line) => line.content.trim() !== "" && !/^\s*#/.test(line.content));
+  if (!lastBodyLine) return { source, gap: "" };
+  const bodyEnd = lastBodyLine.end;
+  return { source: source.slice(0, bodyEnd), gap: source.slice(bodyEnd) };
+}
+
+function projectTrustPayloadTableBodyHasCommentsOrBlanks(source: string): boolean {
+  return sourceLines(source).some(
+    (line) => line.content.trim() === "" || /^\s*#/.test(line.content),
+  );
+}
+function reconcileProjectTrustPayload(
+  payload: string,
+  payloadInventory: { parsed: Record<string, unknown>; headers: ProjectTrustPayloadHeader[] },
+  externalProjects: Record<string, unknown>,
+  runtimeProjects: Record<string, unknown>,
+  runtimeHooksState: Record<string, unknown> | undefined,
+  externalHookTrustState: Record<string, unknown> | undefined,
+  projectHooksPath: string,
+  eol: string,
+): string | undefined {
+  const { headers } = payloadInventory;
+  const payloadProjectKeys = new Set(headers.filter((header) => header.kind === "project").map((header) => header.path[1]!));
+  const replacementByHeader = new Map<number, string | undefined>();
+
+  for (const key of payloadProjectKeys) {
+    const projectHeaders = headers.filter((header) => header.kind === "project" && header.path[1] === key);
+    const parent = projectHeaders.find((header) => header.path.length === 2);
+    const payloadValue = projectTrustValueAtPath(payloadInventory.parsed, ["projects", key]);
+    const externalValue = externalProjects[key];
+    const runtimeValue = runtimeProjects[key];
+    if (externalValue !== undefined) {
+      if (!projectTrustEqual(payloadValue, externalValue) || (runtimeValue !== undefined && !projectTrustEqual(runtimeValue, externalValue))) return undefined;
+      for (const header of projectHeaders) replacementByHeader.set(header.start, undefined);
+      continue;
+    }
+    if (runtimeValue === undefined) {
+      for (const header of projectHeaders) replacementByHeader.set(header.start, undefined);
+      continue;
+    }
+    if (!parent || projectHeaders.length !== 1 || !isPlainTomlRecord(runtimeValue)) return undefined;
+    const rendered = renderProjectTrust(key, runtimeValue);
+    if (!rendered) return undefined;
+    replacementByHeader.set(parent.start, rendered.replaceAll("\n", eol));
+  }
+
+  for (const header of headers.filter((candidate) => candidate.kind === "hook")) {
+    const key = header.path[2]!;
+    const payloadValue = projectTrustValueAtPath(payloadInventory.parsed, header.path);
+    const runtimeValue = runtimeHooksState?.[key];
+    const externalValue = externalHookTrustState?.[key];
+    if (externalValue !== undefined) {
+      if (!projectTrustEqual(payloadValue, externalValue)) return undefined;
+      replacementByHeader.set(header.start, undefined);
+      continue;
+    }
+
+    if (!isPlainTomlRecord(runtimeValue) || typeof runtimeValue.trusted_hash !== "string" || runtimeValue.trusted_hash.length === 0) {
+      replacementByHeader.set(header.start, undefined);
+      continue;
+    }
+    replacementByHeader.set(header.start, `[hooks.state."${escapeTomlBasicString(key)}"]${eol}trusted_hash = "${escapeTomlBasicString(runtimeValue.trusted_hash)}"`);
+  }
+
+  const leadingGap = payload.slice(0, headers[0]?.start ?? payload.length);
+  const parts: string[] = headers.length === 0 ? [] : [leadingGap];
+  let trailingGap = headers.length === 0 ? leadingGap : "";
+  const appendPart = (part: string): void => {
+    if (!part) return;
+    const previous = parts.at(-1);
+    if (previous && !/(?:\r\n|\n)$/.test(previous) && !/^(?:\r\n|\n)/.test(part)) parts.push(eol);
+    parts.push(part);
+  };
+  for (const [index, header] of headers.entries()) {
+    const next = headers[index + 1];
+    const segmentEnd = next?.start ?? payload.length;
+    const replacement = replacementByHeader.get(header.start);
+    const span = projectTrustPayloadTableSpan(payload.slice(header.start, segmentEnd));
+    const tableBody = span.source.slice(header.end - header.start);
+    if (
+      replacement !== undefined &&
+      replacement !== span.source &&
+      projectTrustPayloadTableBodyHasCommentsOrBlanks(tableBody)
+    ) {
+      return undefined;
+    }
+    if (!next) {
+      trailingGap = span.gap;
+      if (replacement !== undefined) appendPart(replacement);
+      continue;
+    }
+    if (replacement !== undefined) appendPart(replacement);
+    if (span.gap) appendPart(span.gap);
+  }
+  const additions: string[] = [];
+  for (const [key, value] of Object.entries(runtimeProjects).sort(([left], [right]) => left.localeCompare(right))) {
+    if (externalProjects[key] !== undefined || payloadProjectKeys.has(key)) continue;
+    if (!isPlainTomlRecord(value)) return undefined;
+    const rendered = renderProjectTrust(key, value);
+    if (!rendered) return undefined;
+    additions.push(`${rendered.replaceAll("\n", eol)}${eol}`);
+  }
+  for (const [key, value] of Object.entries(runtimeHooksState ?? {}).sort(([left], [right]) => left.localeCompare(right))) {
+    if (!key.startsWith(`${projectHooksPath}:`) || externalHookTrustState?.[key] !== undefined || headers.some((header) => header.kind === "hook" && header.path[2] === key)) continue;
+
+    if (!isPlainTomlRecord(value) || typeof value.trusted_hash !== "string" || value.trusted_hash.length === 0) continue;
+    additions.push(`[hooks.state."${escapeTomlBasicString(key)}"]${eol}trusted_hash = "${escapeTomlBasicString(value.trusted_hash)}"${eol}`);
+  }
+  let reconciled = parts.join("");
+  if (additions.length > 0 && reconciled && !/(?:\r\n|\n)$/.test(reconciled)) reconciled += eol;
+  reconciled += additions.join("");
+  if (trailingGap && reconciled && !/(?:\r\n|\n)$/.test(reconciled) && !/^(?:\r\n|\n)/.test(trailingGap)) reconciled += eol;
+  reconciled += trailingGap;
+  reconciled = reconciled.replace(/(?:\r\n|\n)$/, "");
+  return Object.keys(safeParseToml(reconciled) ?? {}).length === 0 ? "" : reconciled;
+}
+
+interface ProjectTrustHeader extends SourceSpan {
+  path: string[];
+}
+
+function projectTrustHeaders(config: string, region: SourceSpan): ProjectTrustHeader[] | undefined {
+  const lexical = analyzeTomlSource(config);
+  if (!lexical.isUnambiguous) return undefined;
+  const lines = sourceLines(config);
+  const headers: ProjectTrustHeader[] = [];
+  for (const [index, line] of lines.entries()) {
+    if (line.start < region.start || line.start >= region.end || !lexical.lineStartsOutsideMultiline[index]) continue;
+    if (!/^\s*\[/.test(line.content)) continue;
+    const path = projectTrustHeaderPath(line.content);
+    if (!path) {
+      if (/^\s*\[\[?\s*(?:projects|"projects"|'projects')/.test(line.content)) return undefined;
+      continue;
+    }
+    headers.push({ start: line.start, end: line.end, path });
+  }
+  return headers;
+}
+
+interface ProjectTrustSourceInventory {
+  projects: Record<string, unknown>;
+  headers: ProjectTrustHeader[];
+}
+
+function inventoryProjectTrustSource(config: string): ProjectTrustSourceInventory | undefined {
+  const parsed = safeParseToml(config);
+  if (!parsed) return undefined;
+  const projects = parsed.projects;
+  if (projects !== undefined && !isPlainTomlRecord(projects)) return undefined;
+  const headers = projectTrustHeaders(config, { start: 0, end: config.length });
+  if (!headers) return undefined;
+  const projectHeaders = headers.filter((header) => header.path[0] === "projects");
+  if (projectHeaders.some((header) => header.path.length < 2)) return undefined;
+  for (const key of Object.keys(projects ?? {})) {
+    if (projectHeaders.filter((header) => header.path.length === 2 && header.path[1] === key).length !== 1) {
+      return undefined;
+    }
+  }
+  if (!projectTrustSourceNestedStructuresAreExplicit(parsed, projectHeaders)) return undefined;
+  return { projects: projects ?? {}, headers };
+}
+
+function projectTrustCandidateIsSafe(
+  candidate: string,
+  external: string,
+  runtimeProjects: Record<string, unknown>,
+): boolean {
+  const marker = projectTrustMarkerRange(candidate);
+  const inventory = inventoryProjectTrustSource(candidate);
+  const externalInventory = inventoryProjectTrustSource(external);
+  if (!inventory || !externalInventory) return false;
+  const hasMarker = marker !== undefined && marker.start !== marker.end;
+  const hasEquivalentExternalBytes = (actual: string): boolean => {
+    if (actual === external) return true;
+    return splitProjectTrustTrailingEols(actual).body === splitProjectTrustTrailingEols(external).body;
+  };
+  if (hasMarker) {
+    const candidateExternal = `${candidate.slice(0, marker.start)}${candidate.slice(marker.end)}`;
+    if (!hasEquivalentExternalBytes(candidateExternal) && !(candidate.startsWith(external) && candidate.slice(marker.end).length === 0 && /^(?:\r\n|\n)+$/.test(candidate.slice(external.length, marker.start)))) return false;
+  } else if (!hasEquivalentExternalBytes(candidate)) {
+    return false;
+  }
+  const expectedProjects = { ...externalInventory.projects, ...runtimeProjects };
+  if (!projectTrustEqual(inventory.projects, expectedProjects)) return false;
+  for (const [key, value] of Object.entries(expectedProjects)) {
+    if (!projectTrustEqual(inventory.projects[key], value)) return false;
+    if (inventory.headers.filter((header) => header.path[0] === "projects" && header.path.length === 2 && header.path[1] === key).length !== 1) return false;
+  }
+  return true;
+}
+
+function projectTrustPayloadProjectFamiliesAreValid(
+  headers: readonly ProjectTrustPayloadHeader[],
+): boolean {
+  const projectKeys = new Set(
+    headers.filter((header) => header.kind === "project").map((header) => header.path[1]!),
+  );
+  for (const key of projectKeys) {
+    const family = headers.filter((header) => header.kind === "project" && header.path[1] === key);
+    const parents = family.filter((header) => header.path.length === 2);
+    if (parents.length !== 1 || !projectTrustFamilyIsContiguous(headers, parents[0]!)) return false;
+  }
+  return true;
+}
+function projectTrustFamilyIsContiguous(headers: readonly ProjectTrustHeader[], parent: ProjectTrustHeader): boolean {
+  const first = headers.indexOf(parent);
+  let ended = false;
+  for (let index = first + 1; index < headers.length; index += 1) {
+    const path = headers[index]!.path;
+    const belongsToFamily = path[0] === "projects" && path[1] === parent.path[1];
+    if (!belongsToFamily) {
+      ended = true;
+      continue;
+    }
+    if (ended || path.length < 3) return false;
+  }
+  return true;
+}
+
+function projectTrustEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (left instanceof Date || right instanceof Date) {
+    return left instanceof Date && right instanceof Date && left.constructor === right.constructor && String(left) === String(right);
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return Array.isArray(left) && Array.isArray(right) && left.length === right.length && left.every((value, index) => projectTrustEqual(value, right[index]));
+  }
+  if (!isPlainTomlRecord(left) || !isPlainTomlRecord(right)) return false;
+  const leftKeys = Object.keys(left).sort();
+  const rightKeys = Object.keys(right).sort();
+  return leftKeys.length === rightKeys.length && leftKeys.every((key, index) => key === rightKeys[index] && projectTrustEqual(left[key], right[key]));
+}
+
+function canRenderFlatProjectTrust(entry: Record<string, unknown>): boolean {
+  const isValue = (value: unknown): boolean => {
+    if (Array.isArray(value)) return value.every(isValue);
+    return !isPlainTomlRecord(value);
+  };
+  return Object.values(entry).every(isValue);
+}
+
+function renderProjectTrust(projectKey: string, entry: Record<string, unknown>): string | undefined {
+  if (!canRenderFlatProjectTrust(entry)) return undefined;
+  const serialized = TOML.stringify({ [projectKey]: entry } as TOML.JsonMap);
+  const body = serialized.split(/\r?\n/).filter((line) => !/^\s*\[/.test(line) && line.trim() !== "").join("\n");
+  return body ? `[projects."${escapeTomlBasicString(projectKey)}"]\n${body}` : undefined;
+}
+
+function splitProjectTrustTrailingEols(source: string): { body: string; trailingEols: string } {
+  const match = source.match(/(?:(?:\r\n|\n))*$/);
+  const trailingEols = match?.[0] ?? "";
+  return { body: source.slice(0, source.length - trailingEols.length), trailingEols };
+}
+
+function appendProjectTrustMarker(base: string, payload: string, eol: string, trailingEols: string): string {
+  if (!payload) return `${splitProjectTrustTrailingEols(base).body}${trailingEols}`;
+  const { body } = splitProjectTrustTrailingEols(base);
+  const separator = body ? `${eol}${eol}` : "";
+  const block = `${OMX_PROJECT_TRUST_START_MARKER}${eol}${payload}${eol}${OMX_PROJECT_TRUST_END_MARKER}`;
+  return `${body}${separator}${block}${trailingEols}`;
+}
+
+function reconcileProjectScopeTrustState(
+  projectConfig: string,
+  runtimeConfig: string,
+  projectHooksPath: string,
+  requireExistingPayload: boolean,
+): string {
+  const durable = projectTrustSemanticView(projectConfig);
+  const runtime = projectTrustSemanticView(runtimeConfig);
+  if (!durable || !runtime) return projectConfig;
+  if (hasInlineProjectTrustMarkerComment(durable.source) || hasInlineProjectTrustMarkerComment(runtime.source)) return projectConfig;
+  const parsedRuntime = safeParseToml(runtime.source);
+  const runtimeInventory = inventoryProjectTrustSource(runtime.source);
+  if (!parsedRuntime || !runtimeInventory) return projectConfig;
+  const marker = projectTrustMarkerRange(durable.source);
+  if (!marker) return projectConfig;
+  const hasMarker = marker.start !== marker.end;
+  const payload = durable.source.slice(marker.payloadStart, marker.payloadEnd);
+  const payloadIsEmpty = projectTrustPayloadIsSemanticallyEmpty(payload);
+  const payloadInventory = hasMarker
+    ? inventoryProjectTrustPayload(payload, projectHooksPath)
+    : { parsed: {} as Record<string, unknown>, headers: [] as ProjectTrustPayloadHeader[] };
+  if (!payloadInventory) return projectConfig;
+  if (requireExistingPayload && (!hasMarker || payloadIsEmpty)) return projectConfig;
+
+  const external = hasMarker
+    ? `${durable.source.slice(0, marker.start)}${durable.source.slice(marker.end)}`
+    : durable.source;
+  const trailingEols = splitProjectTrustTrailingEols(durable.source).trailingEols;
+  const externalInventory = inventoryProjectTrustSource(external);
+  if (!externalInventory) return projectConfig;
+  const projects = runtimeInventory.projects;
+  const externalProjects = externalInventory.projects;
+  const headersBeforeMarker = projectTrustHeaders(durable.source, { start: 0, end: marker.start });
+  const headersAfterMarker = projectTrustHeaders(durable.source, { start: marker.end, end: durable.source.length });
+  if (!headersBeforeMarker || !headersAfterMarker) return projectConfig;
+  const headers = [...headersBeforeMarker, ...headersAfterMarker];
+  for (const key of Object.keys(externalProjects)) {
+    const family = headers.filter((header) => header.path[0] === "projects" && header.path[1] === key);
+    const parents = family.filter((header) => header.path.length === 2);
+    if (parents.length !== 1) return projectConfig;
+    const parentIsBeforeMarker = parents[0]!.start < marker.start;
+    if (family.some((header) => (header.start < marker.start) !== parentIsBeforeMarker)) return projectConfig;
+    if (!projectTrustFamilyIsContiguous(headers, parents[0]!)) return projectConfig;
+  }
+  const eol = dominantProjectTrustEol(durable.source);
+  const hooks = parsedRuntime.hooks;
+  const hooksState = isPlainTomlRecord(hooks) && isPlainTomlRecord(hooks.state) ? hooks.state : undefined;
+  const nextPayload = reconcileProjectTrustPayload(
+    payload,
+    payloadInventory,
+    externalProjects,
+    projects,
+    hooksState,
+    projectHookTrustState(external),
+    projectHooksPath,
+    eol,
+  );
+  if (nextPayload === undefined) return projectConfig;
+  if (!inventoryProjectTrustPayload(nextPayload, projectHooksPath)) return projectConfig;
+  const candidate = appendProjectTrustMarker(external, nextPayload, eol, trailingEols);
+  if (!projectTrustCandidateIsSafe(candidate, external, projects)) return projectConfig;
+  return `${durable.prefix}${candidate}`;
+}
+
+/** Repairs only a uniquely parseable, nonempty project-sync payload before mirror creation. */
+export function repairProjectScopeTrustStateForLaunch(projectConfig: string, projectHooksPath: string): string {
+  const durable = projectTrustSemanticView(projectConfig);
+  if (!durable) return projectConfig;
+  const marker = projectTrustMarkerRange(durable.source);
+  if (!marker || marker.start === marker.end) return projectConfig;
+  const payload = durable.source.slice(marker.payloadStart, marker.payloadEnd);
+  return reconcileProjectScopeTrustState(projectConfig, payload, projectHooksPath, true);
+}
+
+/** Conservatively persists runtime project and hook trust without rewriting external TOML. */
 export function syncProjectScopeTrustStateFromRuntime(
   projectConfig: string,
   runtimeConfig: string,
   projectHooksPath: string,
 ): string {
-  const parsed = safeParseToml(runtimeConfig);
-  if (!parsed) return projectConfig;
-
-  const stripped = stripMarkerBlock(
-    projectConfig,
-    OMX_PROJECT_TRUST_START_MARKER,
-    OMX_PROJECT_TRUST_END_MARKER,
-  );
-  const existingHookTrustStateKeys = collectProjectHookTrustStateKeys(stripped);
-  const trustBlockLines: string[] = [];
-
-  const projectsTable = parsed.projects;
-  if (isPlainTomlRecord(projectsTable)) {
-    for (const [projectKey, entry] of Object.entries(projectsTable).sort(
-      ([a], [b]) => a.localeCompare(b),
-    )) {
-      if (!isPlainTomlRecord(entry)) continue;
-      const serialized = TOML.stringify({ [projectKey]: entry } as TOML.JsonMap);
-      const renderedHeader = `[projects."${escapeTomlBasicString(projectKey)}"]`;
-      const body = serialized
-        .split(/\r?\n/)
-        .filter((line) => !/^\s*\[/.test(line) && line.trim() !== "")
-        .join("\n");
-      if (body.length === 0) continue;
-      trustBlockLines.push(renderedHeader, body, "");
-    }
-  }
-
-  const hooksTable = parsed.hooks;
-  const hooksState = isPlainTomlRecord(hooksTable) ? hooksTable.state : undefined;
-  if (isPlainTomlRecord(hooksState)) {
-    for (const [stateKey, entry] of Object.entries(hooksState).sort(
-      ([a], [b]) => a.localeCompare(b),
-    )) {
-      if (!isPlainTomlRecord(entry)) continue;
-      if (!stateKey.startsWith(`${projectHooksPath}:`)) continue;
-      if (existingHookTrustStateKeys.has(stateKey)) continue;
-      const trusted = entry.trusted_hash;
-      if (typeof trusted !== "string" || trusted.length === 0) continue;
-      trustBlockLines.push(
-        `[hooks.state."${escapeTomlBasicString(stateKey)}"]`,
-        `trusted_hash = "${escapeTomlBasicString(trusted)}"`,
-        "",
-      );
-    }
-  }
-
-  if (trustBlockLines.length === 0) {
-    return stripped.length === 0 ? "" : `${stripped}\n`;
-  }
-
-  const block = [
-    OMX_PROJECT_TRUST_START_MARKER,
-    ...trustBlockLines,
-    OMX_PROJECT_TRUST_END_MARKER,
-    "",
-  ].join("\n");
-
-  if (stripped.length === 0) return block;
-  return `${stripped}\n\n${block}`;
+  return reconcileProjectScopeTrustState(projectConfig, runtimeConfig, projectHooksPath, false);
 }
 
 type ManagedCodexHookTrustStateMap = Record<string, ManagedCodexHookTrustState>;


### PR DESCRIPTION
## Summary
- reconcile equivalent external and managed project trust tables without deleting user-owned TOML
- preserve comments, payload gaps, BOM/EOL/trailing bytes, and unrelated project tables
- fail closed for malformed, ambiguous, unsupported, implicit nested, or comment-sensitive forms
- cover repeated sync, launch repair, hook-only state, and package parity

## Verification
- focused compiled config/CLI suites: 394/394 passed
- lint, typecheck, no-unused: passed
- packed tarball consumer replay: passed
- hostile exact-head Architect: CLEAR / APPROVE
- exact-head QA/red-team: passed

Fixes #3199