### PR TITLE
fix(hooks): allow stateless unmatched root Stops to exit

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4334,13 +4334,19 @@ PY`,
       assert.equal(foreignStop.outputJson?.stopReason, "session_pointer_unusable");
       assert.equal(existsSync(join(foreignCwd, ".omx", "state", "native-stop-state.json")), false);
 
+      const conflictingPointerPath = join(conflictingCwd, ".omx", "state", "session.json");
+      const conflictingPointerBeforeStop = await readFile(conflictingPointerPath, "utf-8");
       const unmatchedStop = await dispatchCodexNativeHook({
         hook_event_name: "Stop",
         cwd: conflictingCwd,
         session_id: "native-unmatched-stop-3138",
       }, { cwd: conflictingCwd });
-      assert.equal(unmatchedStop.outputJson?.decision, "block");
-      assert.equal(unmatchedStop.outputJson?.stopReason, "session_scope_unmatched");
+      assert.equal(unmatchedStop.outputJson, null);
+      assert.equal(await readFile(conflictingPointerPath, "utf-8"), conflictingPointerBeforeStop);
+      assert.equal(
+        existsSync(join(conflictingCwd, ".omx", "state", "sessions", "native-unmatched-stop-3138")),
+        false,
+      );
       assert.equal(existsSync(join(conflictingCwd, ".omx", "state", "native-stop-state.json")), false);
     } finally {
       if (typeof previousSessionId === "string") process.env.OMX_SESSION_ID = previousSessionId;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -19717,6 +19717,7 @@ export async function dispatchCodexNativeHook(
       stopReason: "session_pointer_unusable",
       reason: `OMX cannot authorize Stop while the selected session pointer is ${pointer.status}; repair the pointer evidence before continuing.`,
     };
+  let allowUnmatchedStopExit = false;
   let canonicalSessionId = safeString(currentSessionState?.session_id).trim();
   if (promptTurnContext?.status === "authorized") {
     canonicalSessionId = promptTurnContext.authorization.targetSessionId;
@@ -19837,6 +19838,8 @@ export async function dispatchCodexNativeHook(
           reason: `OMX cannot authorize Stop for unmatched session id ${stopPayloadSessionId}; the selected session pointer remains authoritative.`,
         };
       }
+      allowUnmatchedStopExit = stopAuthorizationFailure.stopReason === "session_scope_unmatched"
+        && !existsSync(join(stateDir, "sessions", stopPayloadSessionId));
     } else if (stopCanonicalSessionId) {
       canonicalSessionId = stopCanonicalSessionId;
     }
@@ -20303,6 +20306,8 @@ export async function dispatchCodexNativeHook(
         skipRalphStopBlock: isSubagentStop,
         skipAutoNudge: isSubagentStop,
       }) ?? await buildCompletedGoalCleanupStopOutput(payload, cwd);
+    } else if (allowUnmatchedStopExit) {
+      outputJson = null;
     } else {
       const failure = stopAuthorizationFailure ?? {
         stopReason: "session_pointer_unusable",


### PR DESCRIPTION
## Summary

- return no Stop output when an unmatched root session has no session-scoped OMX state
- keep unusable pointers and unmatched sessions with scoped Team or Ralph state fail-closed
- verify the authoritative pointer remains byte-identical and no native Stop state is created

## Test Plan

- [x] `npm run build`
- [x] issue #3138 focused regression — 1/1
- [x] scoped Team/Ralph mismatch regressions — 2/2
- [x] native-hook suite — 557/558; the sole unrelated Conductor PATH parsing failure reproduces unchanged on a clean `origin/dev` snapshot at `0e67d48d`