### PR TITLE
fix(hooks): isolate unmatched Stop session state

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -69,6 +69,28 @@ Setup-owned trust state is limited to those generated wrapper identities; user h
 | wiki session capture | none | `session-end` | runtime-fallback | Wiki session-log capture runs from the existing runtime session-end cleanup path, not from a native Codex hook |
 | `session-idle` | none | `session-idle` | runtime-fallback | Still emitted from runtime/notify path, not native Codex hooks |
 
+## Stop: unmatched root-session read-only boundary
+
+A native root `Stop` with a valid payload session ID that does not match a
+usable selected `session.json` pointer evaluates blockers only from
+`.omx/state/sessions/<payload-session-id>/`. The approved blockers are
+autopilot, ultrawork, ultraqa, Team, a pending deep-interview question, and
+ralplan. An exact-session terminal `run-state.json` may suppress stale blocker
+state; if no blocker remains, the turn may stop. Payload prose, transcripts,
+and side-conversation heuristics cannot bypass this evaluation.
+
+The unmatched path does not promote the payload ID to global or selected
+authority. It has no root workflow fallback, canonical Team-phase lookup,
+reconciliation, Stop signatures, locks, HUD or mode mutation, plugin dispatch,
+completed-goal cleanup, or pointer write, delete, or repair. Invalid IDs and
+unusable selected pointers remain fail-closed, and Ralph is excluded.
+
+The one root-read exception is classification-only:
+`.omx/state/subagent-tracking.json` may be read to recognize a known native
+child and preserve its existing Stop path. Tracker data is never blocker,
+ownership, pointer, cleanup, or lifecycle authority, and this path creates no
+marker or sidecar. Issue #3202 stale-dead cleanup remains separate.
+
 
 ## PreToolUse: conductor and native-child write boundary
 

--- a/docs/superpowers/plans/2026-07-18-unmatched-stop-session-readonly.md
+++ b/docs/superpowers/plans/2026-07-18-unmatched-stop-session-readonly.md
@@ -1,0 +1,882 @@
+# Unmatched Stop Session-Readonly Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an unmatched native Codex root session finish a turn by evaluating only its own session-scoped Stop blockers, without creating ownership state or mutating the selected pointer and root state.
+
+**Architecture:** Keep the existing full Stop pipeline for payloads that match the usable selected pointer. Route a valid unmatched payload session through a `sessionScopedOnly` branch that reuses the existing autopilot, ultrawork, ultraqa, team, deep-interview, and ralplan blocker builders with every root fallback and mutation disabled. Leave stale-dead pointer cleanup, lock recovery, SessionStart, subagent handling, and issue #3202 unchanged.
+
+**Tech Stack:** TypeScript, Node.js built-in test runner, existing OMX session/mode state helpers, Biome, npm.
+
+---
+
+## File Map
+
+- Modify `src/scripts/__tests__/codex-native-hook.test.ts`: add the unmatched-root regressions, side-effect snapshots, named blocker matrix, and update three old fail-closed expectations.
+- Modify `src/scripts/codex-native-hook.ts`: add the strict session-only read option and route only valid unmatched usable-pointer Stop events through it.
+- Modify `docs/codex-native-hooks.md`: document the unmatched Stop read-only boundary.
+- Preserve `src/hooks/session.ts`: no pointer, lock, owner, archive, or stale-dead changes.
+- Preserve dependencies and package metadata: no new package or persisted artifact.
+
+### Task 0: Pin the execution baseline and dependency tree
+
+**Files:**
+- Verify: `package-lock.json`
+- Verify: `docs/superpowers/specs/2026-07-18-unmatched-stop-session-readonly-design.md`
+- Verify: `src/scripts/__tests__/codex-native-hook.test.ts`
+
+- [ ] **Step 1: Verify the task branch is based on current `origin/dev`**
+
+Run:
+
+```bash
+git fetch origin dev
+git rev-list --left-right --count origin/dev...HEAD
+git status --short --branch
+```
+
+Expected: the left count is `0`, the branch contains only the approved design/plan commits ahead of `origin/dev`, and the worktree is clean. If the left count is non-zero, run `git rebase origin/dev` in this task worktree, resolve only conflicts in task-owned files, then repeat this step before continuing.
+
+- [ ] **Step 2: Install exactly the reviewed dependency tree**
+
+Run:
+
+```bash
+sha256sum package-lock.json
+npm ci
+sha256sum package-lock.json
+```
+
+Expected: `npm ci` succeeds and both lockfile hashes are identical.
+
+- [ ] **Step 3: Build and run the pre-change ownership baseline**
+
+Run:
+
+```bash
+npm run build
+node --test \
+  --test-name-pattern='issue #3138|session-scoped (team|Ralph) id' \
+  dist/scripts/__tests__/codex-native-hook.test.js
+```
+
+Expected: build succeeds and the three existing tests pass on the unmodified runtime.
+
+### Task 1: Lock the unmatched Stop contract with failing tests
+
+**Files:**
+- Modify: `src/scripts/__tests__/codex-native-hook.test.ts:133-136`
+- Modify: `src/scripts/__tests__/codex-native-hook.test.ts:4108-4355`
+- Modify: `src/scripts/__tests__/codex-native-hook.test.ts:24292-24328`
+- Modify: `src/scripts/__tests__/codex-native-hook.test.ts:26222-26250`
+
+- [ ] **Step 1: Add one fixture that proves the entire state tree stays read-only**
+
+Insert after `writeJson()`:
+
+```ts
+interface IndependentStopFixture {
+  cwd: string;
+  stateDir: string;
+  sessionId: string;
+  threadId: string;
+}
+
+async function withIndependentStopFixture(
+  suffix: string,
+  arrange: (fixture: IndependentStopFixture) => Promise<string[]>,
+  verify: (
+    result: Awaited<ReturnType<typeof dispatchCodexNativeHook>>,
+  ) => void | Promise<void>,
+): Promise<void> {
+  const cwd = await mkdtemp(join(tmpdir(), `omx-native-hook-independent-stop-${suffix}-`));
+  try {
+    const stateDir = join(cwd, ".omx", "state");
+    const selectedSessionId = `selected-${suffix}`;
+    const sessionId = `independent-${suffix}`;
+    const threadId = `thread-${suffix}`;
+
+    await writeSessionStart(cwd, selectedSessionId, {
+      nativeSessionId: selectedSessionId,
+      pid: process.pid,
+    });
+
+    const rootSkillPath = join(stateDir, "skill-active-state.json");
+    const rootModePath = join(stateDir, "autopilot-state.json");
+    const nativeStopPath = join(stateDir, "native-stop-state.json");
+    await writeJson(rootSkillPath, {
+      active: true,
+      skill: "autopilot",
+      phase: "executing",
+      session_id: selectedSessionId,
+      active_skills: [{
+        active: true,
+        skill: "autopilot",
+        phase: "executing",
+        session_id: selectedSessionId,
+      }],
+    });
+    await writeJson(rootModePath, {
+      active: true,
+      mode: "autopilot",
+      current_phase: "executing",
+      session_id: selectedSessionId,
+      workingDirectory: cwd,
+    });
+    await writeJson(nativeStopPath, {
+      sessions: {
+        [selectedSessionId]: {
+          signature: "selected-session-sentinel",
+        },
+      },
+    });
+
+    const arrangedPaths = await arrange({ cwd, stateDir, sessionId, threadId });
+    const watchedPaths = [
+      join(stateDir, "session.json"),
+      rootSkillPath,
+      rootModePath,
+      nativeStopPath,
+      ...arrangedPaths,
+    ];
+    const contentsBefore = await Promise.all(
+      watchedPaths.map((path) => readFile(path, "utf-8")),
+    );
+    const treeBefore = (await readdir(stateDir, { recursive: true }))
+      .map(String)
+      .sort();
+
+    const result = await dispatchCodexNativeHook(
+      {
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        thread_id: threadId,
+      },
+      { cwd },
+    );
+
+    await verify(result);
+    assert.deepEqual(
+      (await readdir(stateDir, { recursive: true })).map(String).sort(),
+      treeBefore,
+    );
+    for (const [index, path] of watchedPaths.entries()) {
+      assert.equal(await readFile(path, "utf-8"), contentsBefore[index]);
+    }
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+```
+
+- [ ] **Step 2: Add the no-blocker, invalid-ID, and blocker-matrix regressions**
+
+Add near the existing issue #3138 Stop assertions:
+
+```ts
+it("allows an unmatched root Stop without reading or mutating selected root state", async () => {
+  await withIndependentStopFixture(
+    "ordinary",
+    async () => [],
+    (result) => {
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+    },
+  );
+});
+
+it("keeps invalid unmatched Stop session ids fail-closed", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-invalid-unmatched-stop-"));
+  try {
+    await writeSessionStart(cwd, "selected-valid-stop", {
+      nativeSessionId: "selected-valid-stop",
+      pid: process.pid,
+    });
+
+    const result = await dispatchCodexNativeHook(
+      {
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "../foreign",
+      },
+      { cwd },
+    );
+
+    assert.equal(result.outputJson?.decision, "block");
+    assert.equal(result.outputJson?.stopReason, "session_scope_unmatched");
+    assert.equal(
+      existsSync(join(cwd, ".omx", "state", "sessions", "foreign")),
+      false,
+    );
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+const independentStopBlockers: Array<{
+  name: string;
+  expectedStopReason: string | RegExp;
+  arrange: (fixture: IndependentStopFixture) => Promise<string[]>;
+}> = [
+  ...(["autopilot", "ultrawork", "ultraqa"] as const).map((mode) => ({
+    name: mode,
+    expectedStopReason: new RegExp(`^${mode}_`),
+    arrange: async ({ cwd, stateDir, sessionId }: IndependentStopFixture) => {
+      const path = join(stateDir, "sessions", sessionId, `${mode}-state.json`);
+      await writeJson(path, {
+        active: true,
+        mode,
+        current_phase: "executing",
+        session_id: sessionId,
+        workingDirectory: cwd,
+      });
+      return [path];
+    },
+  })),
+  {
+    name: "team",
+    expectedStopReason: "team_team-exec",
+    arrange: async ({ stateDir, sessionId, threadId }) => {
+      const path = join(stateDir, "sessions", sessionId, "team-state.json");
+      await writeJson(path, {
+        active: true,
+        mode: "team",
+        team_name: "independent-team",
+        current_phase: "team-exec",
+        session_id: sessionId,
+        owner_codex_thread_id: threadId,
+      });
+      return [path];
+    },
+  },
+  {
+    name: "deep-interview",
+    expectedStopReason: "deep_interview_question_required",
+    arrange: async ({ stateDir, sessionId, threadId }) => {
+      const skillPath = join(
+        stateDir,
+        "sessions",
+        sessionId,
+        "skill-active-state.json",
+      );
+      const modePath = join(
+        stateDir,
+        "sessions",
+        sessionId,
+        "deep-interview-state.json",
+      );
+      await writeJson(skillPath, {
+        active: true,
+        skill: "deep-interview",
+        phase: "intent-first",
+        session_id: sessionId,
+        thread_id: threadId,
+      });
+      await writeJson(modePath, {
+        active: true,
+        mode: "deep-interview",
+        current_phase: "intent-first",
+        session_id: sessionId,
+        thread_id: threadId,
+        question_enforcement: {
+          obligation_id: "independent-question",
+          source: "omx-question",
+          status: "pending",
+          requested_at: "2026-07-18T00:00:00.000Z",
+        },
+      });
+      return [skillPath, modePath];
+    },
+  },
+  {
+    name: "ralplan",
+    expectedStopReason: "skill_ralplan_planning_continue_artifact",
+    arrange: async ({ stateDir, sessionId, threadId }) => {
+      const skillPath = join(
+        stateDir,
+        "sessions",
+        sessionId,
+        "skill-active-state.json",
+      );
+      const modePath = join(
+        stateDir,
+        "sessions",
+        sessionId,
+        "ralplan-state.json",
+      );
+      await writeJson(skillPath, {
+        active: true,
+        skill: "ralplan",
+        phase: "planning",
+        session_id: sessionId,
+        thread_id: threadId,
+      });
+      await writeJson(modePath, {
+        active: true,
+        mode: "ralplan",
+        current_phase: "planning",
+        session_id: sessionId,
+        thread_id: threadId,
+      });
+      return [skillPath, modePath];
+    },
+  },
+];
+
+for (const blocker of independentStopBlockers) {
+  it(`uses only the unmatched session ${blocker.name} Stop blocker`, async () => {
+    await withIndependentStopFixture(
+      blocker.name,
+      blocker.arrange,
+      (result) => {
+        assert.equal(result.outputJson?.decision, "block");
+        const stopReason = String(result.outputJson?.stopReason ?? "");
+        if (blocker.expectedStopReason instanceof RegExp) {
+          assert.match(stopReason, blocker.expectedStopReason);
+        } else {
+          assert.equal(stopReason, blocker.expectedStopReason);
+        }
+      },
+    );
+  });
+}
+```
+
+- [ ] **Step 3: Update the three existing expectations that encode the old singleton rule**
+
+Apply these exact changes without altering the surrounding fixtures:
+
+```ts
+// Replace the two output assertions for `unmatchedStop` in the issue #3138 case:
+assert.equal(unmatchedStop.outputJson, null);
+assert.equal(
+  existsSync(join(conflictingCwd, ".omx", "state", "native-stop-state.json")),
+  false,
+);
+
+// Rename:
+"fails closed on Stop when a session-scoped team id is not bound to session.json"
+// To:
+"uses a session-scoped team blocker when its id is not bound to session.json"
+// Replace the reason assertion block with:
+assert.equal(result.outputJson?.decision, "block");
+assert.equal(result.outputJson?.stopReason, "team_team-exec");
+
+// Rename:
+"fails closed on Stop when a session-scoped Ralph id is not bound to session.json"
+// To:
+"does not import unsupported Ralph blockers into unmatched Stop"
+// Replace its three output assertions with:
+assert.equal(result.omxEventName, "stop");
+assert.equal(result.outputJson, null);
+```
+
+Remove the superseded `session_scope_unmatched` reason assertions from those three cases. Do not remove the foreign-cwd or invalid-ID fail-closed assertions.
+
+- [ ] **Step 4: Build and run the new tests to verify RED**
+
+Run:
+
+```bash
+npm run build
+node --test \
+  --test-name-pattern='unmatched root Stop|invalid unmatched Stop|unmatched session .* Stop blocker|session-scoped team blocker|unsupported Ralph blockers|issue #3138' \
+  dist/scripts/__tests__/codex-native-hook.test.js
+```
+
+Expected: the invalid-ID and foreign-pointer boundaries remain green; the new ordinary and named-blocker expectations fail because the runtime still returns `session_scope_unmatched`.
+
+- [ ] **Step 5: Commit the regression contract**
+
+```bash
+git add src/scripts/__tests__/codex-native-hook.test.ts
+git commit \
+  -m "Lock unmatched Stop to a read-only session contract" \
+  -m "Record the ordinary, workflow-blocked, invalid-id, and byte-identical state expectations before changing native Stop routing." \
+  -m $'Constraint: Tests must fail on the old session_scope_unmatched boundary before runtime changes.\nConfidence: high\nScope-risk: narrow\nReversibility: clean\nDirective: Keep the fixture independent from owner sidecars and pointer cleanup.\nTested: Focused unmatched Stop tests fail on the expected old boundary.\nNot-tested: Runtime implementation remains intentionally absent in this commit.'
+```
+
+### Task 2: Implement the strict session-only Stop path
+
+**Files:**
+- Modify: `src/scripts/codex-native-hook.ts:2802-2914`
+- Modify: `src/scripts/codex-native-hook.ts:3193-3241`
+- Modify: `src/scripts/codex-native-hook.ts:18394-18462`
+- Modify: `src/scripts/codex-native-hook.ts:18754-18805`
+- Modify: `src/scripts/codex-native-hook.ts:19147-19179`
+- Modify: `src/scripts/codex-native-hook.ts:19286-19504`
+- Modify: `src/scripts/codex-native-hook.ts:19713-20317`
+
+- [ ] **Step 1: Make autopilot, ultrawork, and ultraqa read the exact session file**
+
+Change `readModeStateWithStopSource()` to:
+
+```ts
+async function readModeStateWithStopSource(
+  mode: "autopilot" | "ultrawork" | "ultraqa",
+  cwd: string,
+  sessionId?: string,
+  options: { sessionScopedOnly?: boolean } = {},
+): Promise<{ state: Record<string, unknown>; path: string } | null> {
+  if (options.sessionScopedOnly) {
+    const normalizedSessionId = safeString(sessionId).trim();
+    if (!normalizedSessionId) return null;
+    const path = getStateFilePath(`${mode}-state.json`, cwd, normalizedSessionId);
+    const state = await readJsonIfExists(path);
+    return state ? { state, path } : null;
+  }
+  const paths = await getAuthoritativeActiveStatePaths(
+    mode,
+    cwd,
+    sessionId?.trim() || undefined,
+  ).catch(() => [] as string[]);
+  const path = paths[0];
+  if (!path) return null;
+  const state = await readJsonIfExists(path);
+  return state ? { state, path } : null;
+}
+```
+
+Make these three exact substitutions in `buildModeBasedStopOutput()`:
+
+```ts
+// 1. Replace the signature with:
+async function buildModeBasedStopOutput(
+  mode: "autopilot" | "ultrawork" | "ultraqa",
+  cwd: string,
+  sessionId?: string,
+  options: { sessionScopedOnly?: boolean } = {},
+): Promise<Record<string, unknown> | null> {
+}
+
+// 2. Replace the sourced-state call with:
+const sourcedState = await readModeStateWithStopSource(
+  mode,
+  cwd,
+  sessionId,
+  options,
+);
+
+// 3. Replace the root canonical-state assignment with:
+const rootCanonicalState = options.sessionScopedOnly
+  ? null
+  : await readRawSkillActiveState(
+    getSkillActiveStatePathsForStateDir(getBaseStateDir(cwd)).rootPath,
+  );
+```
+
+Do not change the terminal-run check, autopilot question-wait check, continuation
+test, or output construction around these substitutions.
+
+- [ ] **Step 2: Make Team use only session `team-state.json` and its coarse phase**
+
+Add `options: { sessionScopedOnly?: boolean } = {}` to
+`readTeamModeStateForStop()`. Immediately after the scoped-state branch, add:
+
+```ts
+if (options.sessionScopedOnly) return null;
+```
+
+Make these exact changes in `buildTeamStopOutput()`:
+
+```ts
+// 1. Replace the signature with:
+async function buildTeamStopOutput(
+  cwd: string,
+  sessionId?: string,
+  threadId?: string,
+  options: { sessionScopedOnly?: boolean } = {},
+): Promise<Record<string, unknown> | null> {
+}
+
+// 2. Replace the readTeamModeStateForStop call with:
+const teamStateForStop = await readTeamModeStateForStop(
+  cwd,
+  getBaseStateDir(cwd),
+  sessionId,
+  threadId,
+  options,
+);
+
+// 3. Immediately after the existing `teamName` assignment, insert:
+const coarsePhase = teamState.current_phase;
+if (options.sessionScopedOnly) {
+  return isNonTerminalPhase(coarsePhase)
+    ? buildTeamStopOutputForPhase(teamName, formatPhase(coarsePhase))
+    : null;
+}
+```
+
+Remove the later duplicate `const coarsePhase = teamState.current_phase;`.
+Leave the terminal-run check and the matched-session canonical team-directory
+and phase handling unchanged.
+
+- [ ] **Step 3: Make deep-interview and ralplan read-only**
+
+Add `options: { sessionScopedOnly?: boolean } = {}` to
+`buildDeepInterviewQuestionStopOutput()` and guard its reconciliation write:
+
+```ts
+if (!options.sessionScopedOnly) {
+  await reconcileDeepInterviewQuestionEnforcementFromAnsweredRecords(
+    cwd,
+    sessionId,
+  );
+}
+```
+
+Add the same option to `readBlockingSkillForStop()` and guard the root
+inactive-state comparison:
+
+```ts
+if (
+  !options.sessionScopedOnly
+  && await shouldIgnoreSessionSkillBlockerForCanonicalInactiveRoot(
+    cwd,
+    stateDir,
+    skill,
+    sessionId,
+    threadId,
+  )
+) continue;
+```
+
+Add the option to `buildSkillStopOutput()`, forward it to
+`readBlockingSkillForStop()`, and avoid root subagent-tracker reads:
+
+```ts
+const blocker = await readBlockingSkillForStop(
+  cwd,
+  stateDir,
+  sessionId,
+  threadId,
+  undefined,
+  options,
+);
+if (!blocker) return null;
+
+const subagentSummary = options.sessionScopedOnly
+  ? null
+  : await readSubagentSessionSummary(cwd, sessionId).catch(() => null);
+```
+
+Keep the existing ralplan status/message builder unchanged.
+
+- [ ] **Step 4: Compose only the six approved blockers**
+
+Extend `buildStopHookOutput()` options:
+
+```ts
+options: {
+  skipAutoNudge?: boolean;
+  skipRalphStopBlock?: boolean;
+  canonicalSessionId?: string;
+  sessionScopedOnly?: boolean;
+} = {},
+```
+
+Immediately after computing `canonicalSessionId`, `threadId`, and
+`suppressParentWorkflowStop`, add:
+
+```ts
+if (options.sessionScopedOnly) {
+  if (!canonicalSessionId || suppressParentWorkflowStop) return null;
+
+  for (const mode of ["autopilot", "ultrawork", "ultraqa"] as const) {
+    const modeOutput = await buildModeBasedStopOutput(
+      mode,
+      cwd,
+      canonicalSessionId,
+      { sessionScopedOnly: true },
+    );
+    if (modeOutput) return modeOutput;
+  }
+
+  const teamOutput = await buildTeamStopOutput(
+    cwd,
+    canonicalSessionId,
+    threadId,
+    { sessionScopedOnly: true },
+  );
+  if (teamOutput) return teamOutput;
+
+  const deepInterviewQuestionOutput =
+    await buildDeepInterviewQuestionStopOutput(
+      cwd,
+      stateDir,
+      canonicalSessionId,
+      threadId,
+      { sessionScopedOnly: true },
+    );
+  if (deepInterviewQuestionOutput) {
+    return deepInterviewQuestionOutput.output;
+  }
+
+  return await buildSkillStopOutput(
+    cwd,
+    stateDir,
+    canonicalSessionId,
+    threadId,
+    { sessionScopedOnly: true },
+  );
+}
+```
+
+This return must stay before root reconciliation, exec follow-up, Ralph,
+autoresearch, Team worker, release-readiness, persistent signatures,
+auto-nudge, goal cleanup, and plugin side effects.
+
+- [ ] **Step 5: Route only valid unmatched usable-pointer root Stops into the strict branch**
+
+Near `allowImplicitSessionSideEffects`, add:
+
+```ts
+let sessionScopedStopOnly = false;
+```
+
+Replace the unmatched part of the native Stop session resolution with:
+
+```ts
+if (hookEventName === "Stop") {
+  const stopPayloadSessionId = readPayloadSessionId(payload);
+  const stopCanonicalSessionId = await resolveInternalSessionIdForPayload(
+    cwd,
+    stopPayloadSessionId,
+    undefined,
+    currentSessionState,
+    pointer.status === "absent",
+  );
+  if (stopPayloadSessionId && !stopCanonicalSessionId) {
+    const scopedStopSessionId = normalizeSessionId(stopPayloadSessionId);
+    if (
+      pointer.status === "usable"
+      && scopedStopSessionId
+      && !stopAuthorizationFailure
+    ) {
+      canonicalSessionId = scopedStopSessionId;
+      allowImplicitSessionSideEffects = false;
+      sessionScopedStopOnly = true;
+    } else {
+      canonicalSessionId = "";
+      allowImplicitSessionSideEffects = false;
+      if (!stopAuthorizationFailure) {
+        stopAuthorizationFailure = {
+          stopReason: "session_scope_unmatched",
+          reason:
+            `OMX cannot authorize Stop for unmatched session id ${stopPayloadSessionId}; the selected session pointer remains authoritative.`,
+        };
+      }
+    }
+  } else if (stopCanonicalSessionId) {
+    canonicalSessionId = stopCanonicalSessionId;
+  }
+  if (
+    canonicalSessionId
+    && safeString(currentSessionState?.session_id).trim() === canonicalSessionId
+  ) {
+    resolvedNativeSessionId =
+      safeString(currentSessionState?.native_session_id).trim()
+      || resolvedNativeSessionId;
+  }
+}
+```
+
+Preserve native subagent behavior by widening the existing recovery condition
+and clearing the strict-root flag:
+
+```ts
+if (
+  isSubagentStop
+  && (
+    sessionScopedStopOnly
+    || stopAuthorizationFailure?.stopReason === "session_scope_unmatched"
+  )
+) {
+  sessionScopedStopOnly = false;
+  canonicalSessionId = normalizeSessionId(readPayloadSessionId(payload)) ?? "";
+  allowImplicitSessionSideEffects = true;
+  stopAuthorizationFailure = null;
+  eventSessionId = canonicalSessionId || nativeSessionId || undefined;
+  sessionIdForState = canonicalSessionId || null;
+}
+```
+
+Finally, replace the Stop output branch with:
+
+```ts
+} else if (hookEventName === "Stop") {
+  if (sessionScopedStopOnly) {
+    outputJson = await buildStopHookOutput(payload, cwd, stateDir, {
+      canonicalSessionId: canonicalSessionId || undefined,
+      sessionScopedOnly: true,
+    });
+  } else if (allowImplicitSessionSideEffects) {
+    outputJson = await buildStopHookOutput(payload, cwd, stateDir, {
+      canonicalSessionId: canonicalSessionId || undefined,
+      skipRalphStopBlock: isSubagentStop,
+      skipAutoNudge: isSubagentStop,
+    }) ?? await buildCompletedGoalCleanupStopOutput(payload, cwd);
+  } else {
+    const failure = stopAuthorizationFailure ?? {
+      stopReason: "session_pointer_unusable",
+      reason: "OMX cannot authorize Stop without a writable session authority.",
+    };
+    outputJson = {
+      decision: "block",
+      stopReason: failure.stopReason,
+      reason: failure.reason,
+      systemMessage: failure.reason,
+    };
+  }
+}
+```
+
+Do not change `allowPromptGlobalSideEffects`, SessionStart reconciliation,
+pointer helpers, or state schemas.
+
+- [ ] **Step 6: Build and run the focused tests to verify GREEN**
+
+Run:
+
+```bash
+npm run build
+node --test \
+  --test-name-pattern='unmatched root Stop|invalid unmatched Stop|unmatched session .* Stop blocker|session-scoped team blocker|unsupported Ralph blockers|issue #3138' \
+  dist/scripts/__tests__/codex-native-hook.test.js
+```
+
+Expected: all selected tests pass; the no-blocker case returns no output, the
+six named blockers return their workflow output, invalid IDs remain blocked,
+and every state snapshot is unchanged.
+
+- [ ] **Step 7: Run the complete native-hook test file**
+
+Run:
+
+```bash
+node --test dist/scripts/__tests__/codex-native-hook.test.js
+```
+
+Expected: all tests in the file pass with zero failures.
+
+- [ ] **Step 8: Commit the runtime change**
+
+```bash
+git add src/scripts/codex-native-hook.ts
+git commit \
+  -m "Let unmatched native sessions stop without pointer ownership" \
+  -m "Use the explicit payload session only as an exact read scope, while retaining the full pipeline for selected sessions and the existing fail-closed pointer boundaries." \
+  -m $'Constraint: The unmatched branch may read only exact session state and must perform no root, pointer, lock, plugin, or lifecycle mutation.\nRejected: Owner sidecars | no persisted identity is required for a read-only caller-local decision.\nConfidence: high\nScope-risk: narrow\nReversibility: clean\nDirective: Do not add root fallback or completed-goal cleanup to sessionScopedOnly Stop.\nTested: Focused unmatched Stop regressions and complete codex-native-hook test file.\nNot-tested: Full repository suite remains for final verification.'
+```
+
+### Task 3: Document the operator-visible boundary
+
+**Files:**
+- Modify: `docs/codex-native-hooks.md:53-71`
+
+- [ ] **Step 1: Add the unmatched Stop section after the native hook mapping table**
+
+Insert:
+
+```markdown
+## Stop: unmatched root-session read-only boundary
+
+A native root `Stop` whose valid payload session ID does not match the usable
+selected `session.json` pointer is evaluated only against
+`.omx/state/sessions/<payload-session-id>/`. This narrow path may return
+session-pinned autopilot, ultrawork, ultraqa, Team, pending deep-interview
+question, or ralplan continuation output. If none applies, the turn may stop.
+
+The unmatched path does not promote the payload ID to selected or global
+authority. It does not dispatch hook plugins, read root workflow fallback,
+persist Stop signatures, reconcile state, mutate HUD or modes, acquire locks,
+or write/delete/repair the selected pointer. Invalid payload IDs and unusable
+selected pointers remain fail-closed. Native subagent Stop handling retains
+its existing path.
+
+This rule does not change wrapper-owned stale-dead pointer archive/cleanup;
+that lifecycle remains tracked separately by issue #3202.
+```
+
+- [ ] **Step 2: Verify the documentation-only diff**
+
+Run:
+
+```bash
+git diff --check
+git diff -- docs/codex-native-hooks.md
+```
+
+Expected: no whitespace errors and only the approved Stop boundary is added.
+
+- [ ] **Step 3: Commit the documentation**
+
+```bash
+git add docs/codex-native-hooks.md
+git commit \
+  -m "Explain why unmatched Stop needs no pointer ownership" \
+  -m "Document the exact session-only read boundary, preserved fail-closed cases, and separation from issue #3202." \
+  -m $'Constraint: Operator documentation must not imply pointer repair, ownership transfer, or stale-dead cleanup.\nConfidence: high\nScope-risk: narrow\nReversibility: clean\nDirective: Keep #3202 lifecycle cleanup separate from unmatched Stop decisions.\nTested: git diff --check and targeted documentation diff review.\nNot-tested: No runtime behavior changed in this commit.'
+```
+
+### Task 4: Run final verification and prepare review evidence
+
+**Files:**
+- Verify: `src/scripts/codex-native-hook.ts`
+- Verify: `src/scripts/__tests__/codex-native-hook.test.ts`
+- Verify: `docs/codex-native-hooks.md`
+- Verify: `docs/superpowers/specs/2026-07-18-unmatched-stop-session-readonly-design.md`
+- Verify: `docs/superpowers/plans/2026-07-18-unmatched-stop-session-readonly.md`
+
+- [ ] **Step 1: Run fresh static checks**
+
+Run:
+
+```bash
+npm run build
+npm run lint
+npm run check:no-unused
+node dist/scripts/generate-catalog-docs.js --check
+git diff --check origin/dev...HEAD
+```
+
+Expected: every command exits zero.
+
+- [ ] **Step 2: Run focused and full tests**
+
+Run:
+
+```bash
+node --test dist/scripts/__tests__/codex-native-hook.test.js
+npm test
+```
+
+Expected: both commands exit zero. If `npm test` fails outside the changed
+native-hook surface, reproduce the exact failure on a clean `origin/dev`
+worktree with the same `npm ci` dependency tree and report both results; do not
+modify unrelated code to hide a baseline failure.
+
+- [ ] **Step 3: Verify the final scope and commit provenance**
+
+Run:
+
+```bash
+git status --short --branch
+git diff --name-only origin/dev...HEAD
+git log --format=fuller --decorate origin/dev..HEAD
+git rev-list --left-right --count origin/dev...HEAD
+```
+
+Expected:
+
+- the worktree is clean;
+- the changed paths are limited to the five files listed in this task;
+- every commit has contiguous Lore trailers;
+- the branch is not behind `origin/dev`.
+
+- [ ] **Step 4: Stop before external publication**
+
+Do not push, open a replacement PR, install globally, or deploy from this
+plan. Present the final diff, test evidence, current `origin/dev` base SHA, and
+the #3202 non-overlap statement for user review before any external write.

--- a/docs/superpowers/plans/2026-07-18-unmatched-stop-session-readonly.md
+++ b/docs/superpowers/plans/2026-07-18-unmatched-stop-session-readonly.md
@@ -4,7 +4,18 @@
 
 **Goal:** Let an unmatched native Codex root session finish a turn by evaluating only its own session-scoped Stop blockers, without creating ownership state or mutating the selected pointer and root state.
 
-**Architecture:** Keep the existing full Stop pipeline for payloads that match the usable selected pointer. Route a valid unmatched payload session through a `sessionScopedOnly` branch that reuses the existing autopilot, ultrawork, ultraqa, team, deep-interview, and ralplan blocker builders with every root fallback and mutation disabled. Leave stale-dead pointer cleanup, lock recovery, SessionStart, subagent handling, and issue #3202 unchanged.
+**Architecture:** Keep the existing full Stop pipeline for payloads that match the usable selected pointer. Route a valid unmatched payload session through a `sessionScopedOnly` branch that reuses the existing autopilot, ultrawork, ultraqa, team, deep-interview, and ralplan blocker builders with every root workflow fallback and mutation disabled. The dispatcher may read root subagent tracking only to classify a known native child and preserve its existing Stop path. Leave stale-dead pointer cleanup, lock recovery, SessionStart, and issue #3202 unchanged.
+
+### Approved implementation clarification (2026-07-18)
+
+- Builder-level tracker reads remain forbidden in `sessionScopedOnly`; the
+  dispatcher may read root `subagent-tracking.json` only for native-child
+  classification. Tracker data is never blocker, ownership, pointer, cleanup,
+  or lifecycle authority, and no marker or sidecar is added.
+- Terminal suppression reads `run-state.json` directly from the exact payload
+  session directory, with no root fallback.
+- Payload prose, transcript text, and side-conversation heuristics cannot
+  bypass unmatched root blocker evaluation.
 
 **Tech Stack:** TypeScript, Node.js built-in test runner, existing OMX session/mode state helpers, Biome, npm.
 
@@ -175,7 +186,7 @@ async function withIndependentStopFixture(
 Add near the existing issue #3138 Stop assertions:
 
 ```ts
-it("allows an unmatched root Stop without reading or mutating selected root state", async () => {
+it("allows an unmatched root Stop without importing or mutating selected root workflow state", async () => {
   await withIndependentStopFixture(
     "ordinary",
     async () => [],
@@ -466,8 +477,11 @@ const rootCanonicalState = options.sessionScopedOnly
   );
 ```
 
-Do not change the terminal-run check, autopilot question-wait check, continuation
-test, or output construction around these substitutions.
+Preserve the terminal-run semantics, but in `sessionScopedOnly` read
+`run-state.json` directly through
+`getStateFilePath("run-state.json", cwd, normalizedSessionId)` instead of the
+root-aware reader. Do not change the autopilot question-wait check,
+continuation test, or output construction around these substitutions.
 
 - [ ] **Step 2: Make Team use only session `team-state.json` and its coarse phase**
 
@@ -509,8 +523,8 @@ if (options.sessionScopedOnly) {
 ```
 
 Remove the later duplicate `const coarsePhase = teamState.current_phase;`.
-Leave the terminal-run check and the matched-session canonical team-directory
-and phase handling unchanged.
+Use the same direct exact-session terminal-run read described above. Leave the
+matched-session canonical team-directory and phase handling unchanged.
 
 - [ ] **Step 3: Make deep-interview and ralplan read-only**
 
@@ -543,7 +557,9 @@ if (
 ```
 
 Add the option to `buildSkillStopOutput()`, forward it to
-`readBlockingSkillForStop()`, and avoid root subagent-tracker reads:
+`readBlockingSkillForStop()`, and keep builder-level root tracker reads
+disabled. Dispatcher-level read-only native-child classification remains the
+sole exception:
 
 ```ts
 const blocker = await readBlockingSkillForStop(
@@ -581,7 +597,7 @@ Immediately after computing `canonicalSessionId`, `threadId`, and
 
 ```ts
 if (options.sessionScopedOnly) {
-  if (!canonicalSessionId || suppressParentWorkflowStop) return null;
+  if (!canonicalSessionId) return null;
 
   for (const mode of ["autopilot", "ultrawork", "ultraqa"] as const) {
     const modeOutput = await buildModeBasedStopOutput(
@@ -767,7 +783,7 @@ git add src/scripts/codex-native-hook.ts
 git commit \
   -m "Let unmatched native sessions stop without pointer ownership" \
   -m "Use the explicit payload session only as an exact read scope, while retaining the full pipeline for selected sessions and the existing fail-closed pointer boundaries." \
-  -m $'Constraint: The unmatched branch may read only exact session state and must perform no root, pointer, lock, plugin, or lifecycle mutation.\nRejected: Owner sidecars | no persisted identity is required for a read-only caller-local decision.\nConfidence: high\nScope-risk: narrow\nReversibility: clean\nDirective: Do not add root fallback or completed-goal cleanup to sessionScopedOnly Stop.\nTested: Focused unmatched Stop regressions and complete codex-native-hook test file.\nNot-tested: Full repository suite remains for final verification.'
+  -m $'Constraint: Unmatched blocker evaluation may read exact session state only; the root subagent tracker is allowed solely for read-only native-child classification.\nRejected: Owner sidecars | no persisted identity is required for a read-only caller-local decision.\nConfidence: high\nScope-risk: narrow\nReversibility: clean\nDirective: Do not use root tracker data for blocker, ownership, pointer, cleanup, or lifecycle decisions.\nTested: Focused unmatched Stop regressions and complete codex-native-hook test file.\nNot-tested: Full repository suite remains for final verification.'
 ```
 
 ### Task 3: Document the operator-visible boundary
@@ -786,14 +802,22 @@ A native root `Stop` whose valid payload session ID does not match the usable
 selected `session.json` pointer is evaluated only against
 `.omx/state/sessions/<payload-session-id>/`. This narrow path may return
 session-pinned autopilot, ultrawork, ultraqa, Team, pending deep-interview
-question, or ralplan continuation output. If none applies, the turn may stop.
+question, or ralplan continuation output. Exact-session terminal
+`run-state.json` may suppress stale blockers; if none applies, the turn may
+stop. Payload prose, transcript text, and side-conversation heuristics cannot
+bypass this evaluation.
 
 The unmatched path does not promote the payload ID to selected or global
 authority. It does not dispatch hook plugins, read root workflow fallback,
-persist Stop signatures, reconcile state, mutate HUD or modes, acquire locks,
-or write/delete/repair the selected pointer. Invalid payload IDs and unusable
-selected pointers remain fail-closed. Native subagent Stop handling retains
-its existing path.
+use canonical Team phase, persist Stop signatures, reconcile state, mutate HUD
+or modes, acquire locks, run completed-goal cleanup, or write/delete/repair the
+selected pointer. Invalid payload IDs and unusable selected pointers remain
+fail-closed, and Ralph is excluded.
+
+The dispatcher may read root `subagent-tracking.json` only to classify a known
+native child and preserve its existing Stop path. Tracker data is never
+blocker, ownership, pointer, cleanup, or lifecycle authority, and no marker or
+sidecar is added.
 
 This rule does not change wrapper-owned stale-dead pointer archive/cleanup;
 that lifecycle remains tracked separately by issue #3202.

--- a/docs/superpowers/specs/2026-07-18-unmatched-stop-session-readonly-design.md
+++ b/docs/superpowers/specs/2026-07-18-unmatched-stop-session-readonly-design.md
@@ -1,0 +1,154 @@
+# Unmatched Stop Session-Readonly Design
+
+**Status:** Approved direction
+
+**Base:** `origin/dev` at `0e67d48d63decdb3234562ac9626a122221e02a0`
+
+**Scope:** Native Codex `Stop` handling only
+
+## Problem
+
+One checkout has one selected pointer at `.omx/state/session.json`. When two
+root Codex sessions are live in that checkout, the pointer can describe only
+one of them. A `Stop` event from the other session is rejected:
+
+```text
+OMX cannot authorize Stop for unmatched session id <id>; the selected session pointer remains authoritative.
+```
+
+This is a turn-ending decision, not a process shutdown or pointer ownership
+transfer. Requiring singleton pointer ownership for this read-mostly decision
+causes a live independent session to be blocked by another live session.
+
+Issue #3202 is separate: it concerns wrapper-owned cleanup of a stale-dead
+pointer after `omx exec` exits. This design does not alter pointer cleanup,
+archival, locking, or stale evidence.
+
+## Decision
+
+Treat an unmatched native `Stop` as a strictly session-scoped, read-only
+decision.
+
+The payload session ID is only a lookup scope for:
+
+```text
+.omx/state/sessions/<payload-session-id>/
+```
+
+It does not become selected-pointer authority, root-state authority, or
+permission to mutate lifecycle state.
+
+## Behavior
+
+### Existing selected session
+
+When the payload session matches the usable selected pointer through its
+canonical, native, or verified owner alias, keep the existing full `Stop`
+pipeline unchanged.
+
+### Unmatched session
+
+When a usable selected pointer exists but does not match the payload session:
+
+1. Validate the payload session ID with the existing session-ID validator.
+2. Use it only as the exact session directory lookup key.
+3. Evaluate existing session-pinned blockers without root fallback.
+4. Return the first applicable blocker.
+5. If no session-pinned blocker applies, allow `Stop`.
+
+The first implementation is limited to these currently proven session-safe
+blockers:
+
+- `autopilot`
+- `ultrawork`
+- `ultraqa`
+- `team`
+- pending `deep-interview` question obligations
+- `ralplan`
+
+It should reuse the existing blocker builders with a `sessionScopedOnly`
+option instead of adding a second workflow engine.
+
+Other blocker families remain on the matched selected-session path until they
+are separately proven read-only and session-local.
+
+### Fail-closed boundaries
+
+Keep the existing failure behavior for:
+
+- missing or invalid payload session IDs;
+- malformed, foreign-cwd, or identity-indeterminate selected pointers;
+- stale-dead selected pointers, which remain part of #3202;
+- native subagent lifecycle cases already handled by the subagent guard.
+
+## Mandatory side-effect boundary
+
+The unmatched branch must not:
+
+- write, replace, delete, or repair `session.json`;
+- acquire or recover the selected-pointer lock;
+- create owner sidecars, tokens, leases, or a session registry;
+- read root workflow state as fallback;
+- reconcile or clear root workflow state;
+- persist root `native-stop-state.json` signatures;
+- update HUD, mode, team, release-readiness, or lifecycle state;
+- inspect or promote neighboring session directories.
+
+The selected pointer and all root-scoped files must remain byte-identical.
+
+## Security model
+
+The native payload session ID is not promoted to global ownership. Even if a
+caller supplies another valid session ID, the unmatched branch can only read
+that exact session directory and return a decision to the caller. It cannot
+change the selected session, the referenced session, or any global state.
+
+The existing session-ID validator prevents path traversal. Removing all writes
+from this branch keeps the authority granted to the payload narrower than the
+authority already granted to a matched selected session.
+
+## Implementation surface
+
+The expected implementation is limited to:
+
+- `src/scripts/codex-native-hook.ts`
+- `src/scripts/__tests__/codex-native-hook.test.ts`
+- `docs/codex-native-hooks.md`
+
+`src/hooks/session.ts` must not change. The design adds no dependency and no
+new persisted artifact.
+
+## Verification
+
+Regression coverage must prove:
+
+1. An unmatched root session with no scoped blocker may stop.
+2. Each named session-pinned workflow still blocks its own unmatched session.
+3. A blocker belonging to the selected or another session is ignored.
+4. `session.json` and representative root state files remain byte-identical.
+5. No new root or session files are created by unmatched `Stop`.
+6. Invalid session IDs and unusable selected pointers remain blocked.
+7. Matched selected-session and native-subagent behavior remains unchanged.
+
+Use a table-driven test for the named workflow blockers and one focused
+side-effect assertion shared by those cases.
+
+## Rejected alternatives
+
+### Per-session owner sidecar
+
+Rejected because it adds identity persistence, locking, replacement, stale
+owner, and recovery rules to a branch that does not need mutation authority.
+PR #3207 demonstrated that this turns a narrow `Stop` problem into a broader
+ownership redesign.
+
+### Multi-session pointer registry
+
+Rejected because replacing the singleton pointer affects launch, archive,
+cancel, HUD, notify, and compatibility paths. The unmatched `Stop` decision
+does not require that migration.
+
+### Solving #3202 in the same change
+
+Rejected because stale-dead wrapper cleanup has different ownership and
+mutation requirements. It remains under the owner-controlled #3202 work.

--- a/docs/superpowers/specs/2026-07-18-unmatched-stop-session-readonly-design.md
+++ b/docs/superpowers/specs/2026-07-18-unmatched-stop-session-readonly-design.md
@@ -26,17 +26,21 @@ archival, locking, or stale evidence.
 
 ## Decision
 
-Treat an unmatched native `Stop` as a strictly session-scoped, read-only
-decision.
+Treat an unmatched native root `Stop` as a strictly session-scoped, read-only
+decision after native-child classification.
 
-The payload session ID is only a lookup scope for:
+For blocker evaluation, the payload session ID is only a lookup scope for:
 
 ```text
 .omx/state/sessions/<payload-session-id>/
 ```
 
 It does not become selected-pointer authority, root-state authority, or
-permission to mutate lifecycle state.
+permission to mutate lifecycle state. The dispatcher may additionally read
+root `subagent-tracking.json` only to recognize a known native child and
+preserve its existing Stop path. That tracker is not blocker, ownership,
+pointer, cleanup, or lifecycle authority and does not create a marker or
+sidecar.
 
 ## Behavior
 
@@ -51,10 +55,15 @@ pipeline unchanged.
 When a usable selected pointer exists but does not match the payload session:
 
 1. Validate the payload session ID with the existing session-ID validator.
-2. Use it only as the exact session directory lookup key.
-3. Evaluate existing session-pinned blockers without root fallback.
-4. Return the first applicable blocker.
-5. If no session-pinned blocker applies, allow `Stop`.
+2. Read root `subagent-tracking.json` only to classify a known native child;
+   if matched, preserve the existing native-child Stop path.
+3. Otherwise use the ID only as the exact session directory lookup key.
+4. Read terminal `run-state.json` directly from that exact session so terminal
+   truth can suppress stale blocker state.
+5. Evaluate existing session-pinned blockers without root fallback. Payload
+   prose, transcript text, and side-conversation heuristics cannot bypass this
+   root blocker evaluation.
+6. Return the first applicable blocker, or allow `Stop` when none applies.
 
 The first implementation is limited to these currently proven session-safe
 blockers:
@@ -93,15 +102,19 @@ The unmatched branch must not:
 - persist root `native-stop-state.json` signatures;
 - update HUD, mode, team, release-readiness, or lifecycle state;
 - inspect or promote neighboring session directories.
+- use root `subagent-tracking.json` for anything except read-only native-child
+  classification.
 
 The selected pointer and all root-scoped files must remain byte-identical.
 
 ## Security model
 
 The native payload session ID is not promoted to global ownership. Even if a
-caller supplies another valid session ID, the unmatched branch can only read
-that exact session directory and return a decision to the caller. It cannot
-change the selected session, the referenced session, or any global state.
+caller supplies another valid session ID, blocker evaluation can only read
+that exact session directory and return a decision to the caller. The
+dispatcher-only tracker classification exception cannot supply blocker or
+ownership authority. Neither path can change the selected session, the
+referenced session, or any global state.
 
 The existing session-ID validator prevents path traversal. Removing all writes
 from this branch keeps the authority granted to the payload narrower than the
@@ -125,10 +138,13 @@ Regression coverage must prove:
 1. An unmatched root session with no scoped blocker may stop.
 2. Each named session-pinned workflow still blocks its own unmatched session.
 3. A blocker belonging to the selected or another session is ignored.
-4. `session.json` and representative root state files remain byte-identical.
-5. No new root or session files are created by unmatched `Stop`.
-6. Invalid session IDs and unusable selected pointers remain blocked.
-7. Matched selected-session and native-subagent behavior remains unchanged.
+4. Exact-session terminal `run-state.json` suppresses stale blocker state.
+5. Payload text and side-conversation heuristics do not bypass blockers.
+6. Root tracker reads only preserve an already-known native child's Stop path.
+7. `session.json` and representative root state files remain byte-identical.
+8. No new root or session files, markers, or sidecars are created.
+9. Invalid session IDs and unusable selected pointers remain blocked.
+10. Matched selected-session and native-subagent behavior remains unchanged.
 
 Use a table-driven test for the named workflow blockers and one focused
 side-effect assertion shared by those cases.

--- a/src/autopilot/__tests__/ralplan-gate.test.ts
+++ b/src/autopilot/__tests__/ralplan-gate.test.ts
@@ -1122,7 +1122,7 @@ describe('autopilot ralplan gate', () => {
       assert.match(error, /current_session_id: sess-autopilot-diagnostic-missing-session/);
       assert.match(error, /architect thread_id: thread-architect found: no kind=missing completed=no/);
       assert.match(error, /session_id: sess-autopilot-diagnostic-missing-session session_found=no/);
-      assert.match(error, /Re-run native ralplan Architect\/Critic reviews/);
+      assert.match(error, /Re-run typed native ralplan Architect\/Critic reviews/);
       assert.match(error, /docs\/contracts\/ralplan-consensus-gate\.md/);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -135,6 +135,245 @@ async function writeJson(path: string, value: unknown): Promise<void> {
 	await writeFile(path, JSON.stringify(value, null, 2));
 }
 
+interface IndependentStopFixture {
+	cwd: string;
+	stateDir: string;
+	sessionId: string;
+	threadId: string;
+}
+
+async function withIndependentStopFixture(
+	suffix: string,
+	arrange: (fixture: IndependentStopFixture) => Promise<string[]>,
+	verify: (
+		result: Awaited<ReturnType<typeof dispatchCodexNativeHook>>,
+	) => Promise<void> | void,
+): Promise<void> {
+	const cwd = await mkdtemp(
+		join(tmpdir(), `omx-native-hook-independent-stop-${suffix}-`),
+	);
+	const stateDir = join(cwd, ".omx", "state");
+	const selectedSessionId = `selected-${suffix}`;
+	const neighborSessionId = `neighbor-${suffix}`;
+	const sessionId = `independent-${suffix}`;
+	const threadId = `thread-${suffix}`;
+	const snapshotTree = async (
+		directory: string,
+		prefix = "",
+	): Promise<string[]> => {
+		const snapshot: string[] = [];
+		for (const entry of await readdir(directory, { withFileTypes: true })) {
+			const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+			snapshot.push(`${entry.isDirectory() ? "directory" : "file"}:${relativePath}`);
+			if (entry.isDirectory()) {
+				snapshot.push(
+					...(await snapshotTree(join(directory, entry.name), relativePath)),
+				);
+			}
+		}
+		return snapshot.sort();
+	};
+
+	try {
+		await writeSessionStart(cwd, selectedSessionId, {
+			nativeSessionId: selectedSessionId,
+			pid: process.pid,
+		});
+		const rootSkillPath = join(stateDir, "skill-active-state.json");
+		const rootAutopilotPath = join(stateDir, "autopilot-state.json");
+		const rootStopPath = join(stateDir, "native-stop-state.json");
+		const neighborModePath = join(
+			stateDir,
+			"sessions",
+			neighborSessionId,
+			"autopilot-state.json",
+		);
+		await writeJson(rootSkillPath, {
+			active: true,
+			skill: "autopilot",
+			phase: "executing",
+			session_id: selectedSessionId,
+			active_skills: [
+				{
+					active: true,
+					skill: "autopilot",
+					phase: "executing",
+					session_id: selectedSessionId,
+				},
+			],
+		});
+		await writeJson(rootAutopilotPath, {
+			active: true,
+			mode: "autopilot",
+			current_phase: "executing",
+			session_id: selectedSessionId,
+			workingDirectory: cwd,
+		});
+		await writeJson(rootStopPath, {
+			sessions: {
+				[selectedSessionId]: {
+					signature: "selected-session-sentinel",
+				},
+			},
+		});
+		await writeJson(neighborModePath, {
+			active: true,
+			mode: "autopilot",
+			current_phase: "executing",
+			session_id: neighborSessionId,
+			workingDirectory: cwd,
+		});
+
+		const arrangedPaths = await arrange({ cwd, stateDir, sessionId, threadId });
+		const watchedPaths = [
+			join(stateDir, "session.json"),
+			rootSkillPath,
+			rootAutopilotPath,
+			rootStopPath,
+			neighborModePath,
+			...arrangedPaths,
+		];
+		const watchedBytes = new Map(
+			await Promise.all(
+				watchedPaths.map(async (path) => [path, await readFile(path)] as const),
+			),
+		);
+		const treeBefore = await snapshotTree(stateDir);
+
+		const result = await dispatchCodexNativeHook(
+			{
+				hook_event_name: "Stop",
+				cwd,
+				session_id: sessionId,
+				thread_id: threadId,
+			},
+			{ cwd },
+		);
+
+		await verify(result);
+		assert.deepEqual(await snapshotTree(stateDir), treeBefore);
+		for (const [path, bytes] of watchedBytes) {
+			assert.deepEqual(await readFile(path), bytes, path);
+		}
+	} finally {
+		await rm(cwd, { recursive: true, force: true });
+	}
+}
+
+interface IndependentStopBlocker {
+	name: string;
+	expectedStopReason: string;
+	arrange: (fixture: IndependentStopFixture) => Promise<string[]>;
+}
+
+const independentStopBlockers: IndependentStopBlocker[] = [
+	...(["autopilot", "ultrawork", "ultraqa"] as const).map(
+		(mode): IndependentStopBlocker => ({
+			name: mode,
+			expectedStopReason: `${mode}_executing`,
+			arrange: async ({ cwd, stateDir, sessionId }) => {
+				const path = join(stateDir, "sessions", sessionId, `${mode}-state.json`);
+				await writeJson(path, {
+					active: true,
+					mode,
+					current_phase: "executing",
+					session_id: sessionId,
+					workingDirectory: cwd,
+				});
+				return [path];
+			},
+		}),
+	),
+	{
+		name: "team",
+		expectedStopReason: "team_team-exec",
+		arrange: async ({ stateDir, sessionId, threadId }) => {
+			const path = join(stateDir, "sessions", sessionId, "team-state.json");
+			await writeJson(path, {
+				active: true,
+				mode: "team",
+				team_name: "independent-team",
+				current_phase: "team-exec",
+				session_id: sessionId,
+				owner_codex_thread_id: threadId,
+			});
+			return [path];
+		},
+	},
+	{
+		name: "deep-interview",
+		expectedStopReason: "deep_interview_question_required",
+		arrange: async ({ stateDir, sessionId, threadId }) => {
+			const skillPath = join(
+				stateDir,
+				"sessions",
+				sessionId,
+				"skill-active-state.json",
+			);
+			const detailPath = join(
+				stateDir,
+				"sessions",
+				sessionId,
+				"deep-interview-state.json",
+			);
+			await writeJson(skillPath, {
+				active: true,
+				skill: "deep-interview",
+				phase: "intent-first",
+				session_id: sessionId,
+				thread_id: threadId,
+			});
+			await writeJson(detailPath, {
+				active: true,
+				mode: "deep-interview",
+				phase: "intent-first",
+				session_id: sessionId,
+				thread_id: threadId,
+				question_enforcement: {
+					obligation_id: "independent-question",
+					source: "omx-question",
+					status: "pending",
+					requested_at: "2026-07-18T00:00:00.000Z",
+				},
+			});
+			return [skillPath, detailPath];
+		},
+	},
+	{
+		name: "ralplan",
+		expectedStopReason: "skill_ralplan_planning_continue_artifact",
+		arrange: async ({ stateDir, sessionId, threadId }) => {
+			const skillPath = join(
+				stateDir,
+				"sessions",
+				sessionId,
+				"skill-active-state.json",
+			);
+			const detailPath = join(
+				stateDir,
+				"sessions",
+				sessionId,
+				"ralplan-state.json",
+			);
+			await writeJson(skillPath, {
+				active: true,
+				skill: "ralplan",
+				phase: "planning",
+				session_id: sessionId,
+				thread_id: threadId,
+			});
+			await writeJson(detailPath, {
+				active: true,
+				mode: "ralplan",
+				current_phase: "planning",
+				session_id: sessionId,
+				thread_id: threadId,
+			});
+			return [skillPath, detailPath];
+		},
+	},
+];
+
 async function writeCanonicalLeaderFixture(
 	stateDir: string,
 	sessionId: string,
@@ -4105,6 +4344,62 @@ PY`,
     }
   });
 
+  it("allows an unmatched root Stop without reading or mutating selected root state", async () => {
+    await withIndependentStopFixture(
+      "ordinary",
+      async () => [],
+      (result) => {
+        assert.equal(result.omxEventName, "stop");
+        assert.equal(result.outputJson, null);
+      },
+    );
+  });
+
+  it("keeps invalid unmatched Stop session ids fail-closed", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-invalid-unmatched-stop-"));
+    try {
+      await writeSessionStart(cwd, "selected-valid-stop", {
+        nativeSessionId: "selected-valid-stop",
+        pid: process.pid,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "../foreign",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson?.decision, "block");
+      assert.equal(result.outputJson?.stopReason, "session_scope_unmatched");
+      assert.equal(
+        existsSync(join(cwd, ".omx", "state", "foreign")),
+        false,
+      );
+      assert.equal(
+        existsSync(join(cwd, ".omx", "state", "sessions", "foreign")),
+        false,
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  for (const blocker of independentStopBlockers) {
+    it(`uses only the unmatched session ${blocker.name} Stop blocker`, async () => {
+      await withIndependentStopFixture(
+        blocker.name,
+        blocker.arrange,
+        (result) => {
+          assert.equal(result.outputJson?.decision, "block");
+          assert.equal(result.outputJson?.stopReason, blocker.expectedStopReason);
+        },
+      );
+    });
+  }
+
   it("issue #3138 converges owner-env terminal write and native Stop on one canonical scope", async () => {
     const root = await mkdtemp(join(tmpdir(), "omx-native-hook-3138-"));
     const fakeBinDir = join(root, "fake-bin");
@@ -4339,8 +4634,7 @@ PY`,
         cwd: conflictingCwd,
         session_id: "native-unmatched-stop-3138",
       }, { cwd: conflictingCwd });
-      assert.equal(unmatchedStop.outputJson?.decision, "block");
-      assert.equal(unmatchedStop.outputJson?.stopReason, "session_scope_unmatched");
+      assert.equal(unmatchedStop.outputJson, null);
       assert.equal(existsSync(join(conflictingCwd, ".omx", "state", "native-stop-state.json")), false);
     } finally {
       if (typeof previousSessionId === "string") process.env.OMX_SESSION_ID = previousSessionId;
@@ -24289,7 +24583,7 @@ PY`,
     }
   });
 
-  it("fails closed on Stop when a session-scoped team id is not bound to session.json", async () => {
+  it("uses a session-scoped team blocker when its id is not bound to session.json", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-team-session-mismatch-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -24320,8 +24614,7 @@ PY`,
 
       assert.equal(result.omxEventName, "stop");
       assert.equal(result.outputJson?.decision, "block");
-      assert.equal(result.outputJson?.stopReason, "session_scope_unmatched");
-      assert.match(String(result.outputJson?.reason ?? ""), /sess-live-team/);
+      assert.equal(result.outputJson?.stopReason, "team_team-exec");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -26219,7 +26512,7 @@ PY`,
     }
   });
 
-  it("fails closed on Stop when a session-scoped Ralph id is not bound to session.json", async () => {
+  it("does not import unsupported Ralph blockers into unmatched Stop", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-ralph-session-mismatch-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -26241,9 +26534,7 @@ PY`,
       );
 
       assert.equal(result.omxEventName, "stop");
-      assert.equal(result.outputJson?.decision, "block");
-      assert.equal(result.outputJson?.stopReason, "session_scope_unmatched");
-      assert.match(String(result.outputJson?.reason ?? ""), /sess-live-ralph/);
+      assert.equal(result.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4356,6 +4356,48 @@ PY`,
     );
   });
 
+  it("lets exact-session terminal run-state shadow stale unmatched mode state", async () => {
+    await withIndependentStopFixture(
+      "terminal-run-state",
+      async ({ cwd, stateDir, sessionId }) => {
+        const modePath = join(
+          stateDir,
+          "sessions",
+          sessionId,
+          "autopilot-state.json",
+        );
+        const runPath = join(
+          stateDir,
+          "sessions",
+          sessionId,
+          "run-state.json",
+        );
+        await writeJson(modePath, {
+          active: true,
+          mode: "autopilot",
+          current_phase: "executing",
+          session_id: sessionId,
+          workingDirectory: cwd,
+        });
+        await writeJson(runPath, {
+          version: 1,
+          active: false,
+          mode: "autopilot",
+          outcome: "finish",
+          lifecycle_outcome: "finished",
+          current_phase: "complete",
+          completed_at: "2026-07-18T00:00:00.000Z",
+          updated_at: "2026-07-18T00:00:00.000Z",
+        });
+        return [modePath, runPath];
+      },
+      (result) => {
+        assert.equal(result.omxEventName, "stop");
+        assert.equal(result.outputJson, null);
+      },
+    );
+  });
+
   it("keeps invalid unmatched Stop session ids fail-closed", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-invalid-unmatched-stop-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -32581,7 +32581,9 @@ PY`,
 
   it("blocks non-shell direct writes in Main-root conductor states", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-conductor-bash-mutations-"));
+    const previousPath = process.env.PATH;
     try {
+      process.env.PATH = `${dirname(process.execPath)}:/usr/bin:/bin`;
       const stateDir = join(cwd, ".omx", "state");
       const sessionId = "sess-conductor-bash-mutations";
       await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
@@ -32672,6 +32674,8 @@ PY`,
         assert.equal(result.outputJson, null, command);
       }
     } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -246,6 +246,7 @@ async function withIndependentStopFixture(
 				cwd,
 				session_id: sessionId,
 				thread_id: threadId,
+				last_assistant_message: "Reference context only.",
 			},
 			{ cwd },
 		);

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1234,9 +1234,13 @@ async function readCanonicalTerminalRunStateForStop(
   cwd: string,
   sessionId: string | undefined,
   mode: string,
+  options: { sessionScopedOnly?: boolean } = {},
 ): Promise<Record<string, unknown> | null> {
-  if (!safeString(sessionId).trim()) return null;
-  const runState = await readRunState(cwd, sessionId).catch(() => null);
+  const normalizedSessionId = safeString(sessionId).trim();
+  if (!normalizedSessionId) return null;
+  const runState = options.sessionScopedOnly
+    ? await readJsonIfExists(getStateFilePath("run-state.json", cwd, normalizedSessionId))
+    : await readRunState(cwd, normalizedSessionId).catch(() => null);
   const runRecord = runState as unknown as Record<string, unknown> | null;
   return shouldHonorCanonicalTerminalRunState(runRecord, mode) ? runRecord : null;
 }
@@ -2803,7 +2807,15 @@ async function readModeStateWithStopSource(
   mode: "autopilot" | "ultrawork" | "ultraqa",
   cwd: string,
   sessionId?: string,
+  options: { sessionScopedOnly?: boolean } = {},
 ): Promise<{ state: Record<string, unknown>; path: string } | null> {
+  if (options.sessionScopedOnly) {
+    const normalizedSessionId = safeString(sessionId).trim();
+    if (!normalizedSessionId) return null;
+    const path = getStateFilePath(`${mode}-state.json`, cwd, normalizedSessionId);
+    const state = await readJsonIfExists(path);
+    return state ? { state, path } : null;
+  }
   const paths = await getAuthoritativeActiveStatePaths(mode, cwd, sessionId?.trim() || undefined).catch(() => [] as string[]);
   const path = paths[0];
   if (!path) return null;
@@ -2873,17 +2885,20 @@ async function buildModeBasedStopOutput(
   mode: "autopilot" | "ultrawork" | "ultraqa",
   cwd: string,
   sessionId?: string,
+  options: { sessionScopedOnly?: boolean } = {},
 ): Promise<Record<string, unknown> | null> {
-  if (await readCanonicalTerminalRunStateForStop(cwd, sessionId, mode)) {
+  if (await readCanonicalTerminalRunStateForStop(cwd, sessionId, mode, options)) {
     return null;
   }
   if (mode === "autopilot" && await readAutopilotDeepInterviewQuestionWaitState(cwd, sessionId)) {
     return null;
   }
-  const sourcedState = await readModeStateWithStopSource(mode, cwd, sessionId);
+  const sourcedState = await readModeStateWithStopSource(mode, cwd, sessionId, options);
   const state = sourcedState?.state ?? null;
   if (!state || !shouldContinueRun(state)) return null;
-  const rootCanonicalState = await readRawSkillActiveState(getSkillActiveStatePathsForStateDir(getBaseStateDir(cwd)).rootPath);
+  const rootCanonicalState = options.sessionScopedOnly
+    ? null
+    : await readRawSkillActiveState(getSkillActiveStatePathsForStateDir(getBaseStateDir(cwd)).rootPath);
   const canonicalDisagreement = rootCanonicalState
     ? canonicalStopDisagreement(state, rootCanonicalState, mode, sessionId)
     : "canonical_state_missing";
@@ -3195,6 +3210,7 @@ async function readTeamModeStateForStop(
   stateDir: string,
   sessionId?: string,
   threadId?: string,
+  options: { sessionScopedOnly?: boolean } = {},
 ): Promise<TeamModeStateForStop | null> {
   const normalizedSessionId = safeString(sessionId).trim();
   if (!normalizedSessionId) return null;
@@ -3205,6 +3221,7 @@ async function readTeamModeStateForStop(
       ? { state: scopedState, scope: "session" }
       : null;
   }
+  if (options.sessionScopedOnly) return null;
 
   const rootState = await readJsonIfExists(join(stateDir, "team-state.json"));
   if (rootState?.active !== true) return null;
@@ -3219,21 +3236,31 @@ async function readTeamModeStateForStop(
   return { state: rootState, scope: "root" };
 }
 
-async function buildTeamStopOutput(cwd: string, sessionId?: string, threadId?: string): Promise<Record<string, unknown> | null> {
-  if (await readCanonicalTerminalRunStateForStop(cwd, sessionId, "team")) {
+async function buildTeamStopOutput(
+  cwd: string,
+  sessionId?: string,
+  threadId?: string,
+  options: { sessionScopedOnly?: boolean } = {},
+): Promise<Record<string, unknown> | null> {
+  if (await readCanonicalTerminalRunStateForStop(cwd, sessionId, "team", options)) {
     return null;
   }
-  const teamStateForStop = await readTeamModeStateForStop(cwd, getBaseStateDir(cwd), sessionId, threadId);
+  const teamStateForStop = await readTeamModeStateForStop(cwd, getBaseStateDir(cwd), sessionId, threadId, options);
   if (!teamStateForStop || teamStateForStop.state.active !== true) return null;
   const teamState = teamStateForStop.state;
   const teamName = safeString(teamState.team_name).trim();
+  const coarsePhase = teamState.current_phase;
+  if (options.sessionScopedOnly) {
+    return isNonTerminalPhase(coarsePhase)
+      ? buildTeamStopOutputForPhase(teamName, formatPhase(coarsePhase))
+      : null;
+  }
   if (teamName) {
     const canonicalTeamDir = join(resolveCanonicalTeamStateRoot(cwd), "team", teamName);
     if (!existsSync(canonicalTeamDir)) {
       return null;
     }
   }
-  const coarsePhase = teamState.current_phase;
   const canonicalPhaseState = teamName ? await readTeamPhase(teamName, cwd) : null;
   if (teamStateForStop.scope === "root" && !canonicalPhaseState) return null;
   const canonicalPhase = canonicalPhaseState?.current_phase ?? coarsePhase;
@@ -18397,6 +18424,7 @@ async function readBlockingSkillForStop(
   sessionId: string,
   threadId: string,
   requiredSkill?: string,
+  options: { sessionScopedOnly?: boolean } = {},
 ): Promise<{ skill: string; phase: string; latestPlanPath?: string; planningComplete?: boolean; runOutcome?: string } | null> {
   const canonicalState = await readVisibleSkillActiveStateForStateDir(stateDir, sessionId);
   const visibleEntries = canonicalState ? listActiveSkills(canonicalState) : [];
@@ -18405,7 +18433,7 @@ async function readBlockingSkillForStop(
     : [...SKILL_STOP_BLOCKERS];
 
   for (const skill of candidateSkills) {
-    const terminalRunState = await readCanonicalTerminalRunStateForStop(cwd, sessionId, skill);
+    const terminalRunState = await readCanonicalTerminalRunStateForStop(cwd, sessionId, skill, options);
     if (terminalRunState) continue;
 
     const modeState = await readStopSessionPinnedState(`${skill}-state.json`, cwd, sessionId, stateDir);
@@ -18415,7 +18443,7 @@ async function readBlockingSkillForStop(
     const modeSnapshot = getRunContinuationSnapshot(modeState);
     if (modeSnapshot?.terminal === true) continue;
 
-    if (await shouldIgnoreSessionSkillBlockerForCanonicalInactiveRoot(
+    if (!options.sessionScopedOnly && await shouldIgnoreSessionSkillBlockerForCanonicalInactiveRoot(
       cwd,
       stateDir,
       skill,
@@ -18756,8 +18784,11 @@ async function buildDeepInterviewQuestionStopOutput(
   stateDir: string,
   sessionId: string,
   threadId: string,
+  options: { sessionScopedOnly?: boolean } = {},
 ): Promise<{ output: Record<string, unknown>; obligationId: string } | null> {
-  await reconcileDeepInterviewQuestionEnforcementFromAnsweredRecords(cwd, sessionId);
+  if (!options.sessionScopedOnly) {
+    await reconcileDeepInterviewQuestionEnforcementFromAnsweredRecords(cwd, sessionId);
+  }
   if (await readAutopilotDeepInterviewQuestionWaitState(cwd, sessionId)) {
     return null;
   }
@@ -19149,11 +19180,14 @@ async function buildSkillStopOutput(
   stateDir: string,
   sessionId: string,
   threadId: string,
+  options: { sessionScopedOnly?: boolean } = {},
 ): Promise<Record<string, unknown> | null> {
-  const blocker = await readBlockingSkillForStop(cwd, stateDir, sessionId, threadId);
+  const blocker = await readBlockingSkillForStop(cwd, stateDir, sessionId, threadId, undefined, options);
   if (!blocker) return null;
 
-  const subagentSummary = await readSubagentSessionSummary(cwd, sessionId).catch(() => null);
+  const subagentSummary = options.sessionScopedOnly
+    ? null
+    : await readSubagentSessionSummary(cwd, sessionId).catch(() => null);
   const activeSubagentCount = subagentSummary?.activeSubagentThreadIds.length ?? 0;
 
   if (blocker.skill === "ralplan") {
@@ -19287,7 +19321,12 @@ async function buildStopHookOutput(
   payload: CodexHookPayload,
   cwd: string,
   stateDir: string,
-  options: { skipAutoNudge?: boolean; skipRalphStopBlock?: boolean; canonicalSessionId?: string } = {},
+  options: {
+    skipAutoNudge?: boolean;
+    skipRalphStopBlock?: boolean;
+    canonicalSessionId?: string;
+    sessionScopedOnly?: boolean;
+  } = {},
 ): Promise<Record<string, unknown> | null> {
   if (isStopExempt(payload)) {
     return null;
@@ -19298,6 +19337,40 @@ async function buildStopHookOutput(
     ?? await resolveInternalSessionIdForPayload(cwd, sessionId);
   const threadId = readPayloadThreadId(payload);
   const suppressParentWorkflowStop = shouldSuppressParentWorkflowStopForSideConversation(payload);
+  if (options.sessionScopedOnly) {
+    if (!canonicalSessionId || suppressParentWorkflowStop) return null;
+    for (const mode of ["autopilot", "ultrawork", "ultraqa"] as const) {
+      const modeOutput = await buildModeBasedStopOutput(
+        mode,
+        cwd,
+        canonicalSessionId,
+        { sessionScopedOnly: true },
+      );
+      if (modeOutput) return modeOutput;
+    }
+    const teamOutput = await buildTeamStopOutput(
+      cwd,
+      canonicalSessionId,
+      threadId,
+      { sessionScopedOnly: true },
+    );
+    if (teamOutput) return teamOutput;
+    const deepInterviewQuestionOutput = await buildDeepInterviewQuestionStopOutput(
+      cwd,
+      stateDir,
+      canonicalSessionId,
+      threadId,
+      { sessionScopedOnly: true },
+    );
+    if (deepInterviewQuestionOutput) return deepInterviewQuestionOutput.output;
+    return buildSkillStopOutput(
+      cwd,
+      stateDir,
+      canonicalSessionId,
+      threadId,
+      { sessionScopedOnly: true },
+    );
+  }
   if (canonicalSessionId) {
     await reconcileStaleRootSkillActiveStateForStop(cwd, stateDir, canonicalSessionId);
     if (await hasAuthoritativeInactiveSkillStopState(cwd, stateDir, "ralplan", canonicalSessionId, threadId)) {
@@ -19711,6 +19784,7 @@ export async function dispatchCodexNativeHook(
     await mkdir(stateDir, { recursive: true });
   }
   let allowImplicitSessionSideEffects = pointer.status === "usable" || pointer.status === "absent" || promptTurnContext?.status === "authorized";
+  let sessionScopedStopOnly = false;
   let stopAuthorizationFailure: { stopReason: string; reason: string } | null = allowImplicitSessionSideEffects
     ? null
     : {
@@ -19829,13 +19903,20 @@ export async function dispatchCodexNativeHook(
       pointer.status === "absent",
     );
     if (stopPayloadSessionId && !stopCanonicalSessionId) {
-      canonicalSessionId = "";
-      allowImplicitSessionSideEffects = false;
-      if (!stopAuthorizationFailure) {
-        stopAuthorizationFailure = {
-          stopReason: "session_scope_unmatched",
-          reason: `OMX cannot authorize Stop for unmatched session id ${stopPayloadSessionId}; the selected session pointer remains authoritative.`,
-        };
+      const normalizedStopPayloadSessionId = normalizeSessionId(stopPayloadSessionId);
+      if (pointer.status === "usable" && normalizedStopPayloadSessionId && !stopAuthorizationFailure) {
+        canonicalSessionId = normalizedStopPayloadSessionId;
+        allowImplicitSessionSideEffects = false;
+        sessionScopedStopOnly = true;
+      } else {
+        canonicalSessionId = "";
+        allowImplicitSessionSideEffects = false;
+        if (!stopAuthorizationFailure) {
+          stopAuthorizationFailure = {
+            stopReason: "session_scope_unmatched",
+            reason: `OMX cannot authorize Stop for unmatched session id ${stopPayloadSessionId}; the selected session pointer remains authoritative.`,
+          };
+        }
       }
     } else if (stopCanonicalSessionId) {
       canonicalSessionId = stopCanonicalSessionId;
@@ -19876,7 +19957,11 @@ export async function dispatchCodexNativeHook(
         )),
     )).some(Boolean)
     : false;
-  if (isSubagentStop && stopAuthorizationFailure?.stopReason === "session_scope_unmatched") {
+  if (
+    isSubagentStop
+    && (sessionScopedStopOnly || stopAuthorizationFailure?.stopReason === "session_scope_unmatched")
+  ) {
+    sessionScopedStopOnly = false;
     canonicalSessionId = normalizeSessionId(readPayloadSessionId(payload)) ?? "";
     allowImplicitSessionSideEffects = true;
     stopAuthorizationFailure = null;
@@ -20297,7 +20382,12 @@ export async function dispatchCodexNativeHook(
     }
     outputJson = buildNativePostToolUseOutput(payload);
   } else if (hookEventName === "Stop") {
-    if (allowImplicitSessionSideEffects) {
+    if (sessionScopedStopOnly) {
+      outputJson = await buildStopHookOutput(payload, cwd, stateDir, {
+        canonicalSessionId,
+        sessionScopedOnly: true,
+      });
+    } else if (allowImplicitSessionSideEffects) {
       outputJson = await buildStopHookOutput(payload, cwd, stateDir, {
         canonicalSessionId: canonicalSessionId || undefined,
         skipRalphStopBlock: isSubagentStop,

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -19338,7 +19338,7 @@ async function buildStopHookOutput(
   const threadId = readPayloadThreadId(payload);
   const suppressParentWorkflowStop = shouldSuppressParentWorkflowStopForSideConversation(payload);
   if (options.sessionScopedOnly) {
-    if (!canonicalSessionId || suppressParentWorkflowStop) return null;
+    if (!canonicalSessionId) return null;
     for (const mode of ["autopilot", "ultrawork", "ultraqa"] as const) {
       const modeOutput = await buildModeBasedStopOutput(
         mode,


### PR DESCRIPTION
## Summary

- evaluate valid unmatched native `Stop` payloads from the exact payload session directory without promoting that session to selected/root authority
- preserve fail-closed invalid-ID handling and the unmatched session's own Autopilot, Ultrawork, UltraQA, Team, deep-interview, and Ralplan blockers
- keep tracker access classification-only, document the boundary, and add byte-stability plus terminal `run-state.json` regressions
- stabilize two pre-existing baseline tests without changing production trust behavior

## Test plan

- `npm test` — all 384 test files pass; catalog check passes
- `npm run lint` — 752 files checked
- native hook suite — 567/567 pass
- Ralplan gate suite — 25/25 pass
- focused unmatched Stop regressions — 11/11 pass
- `git diff --check`

Related to #3138.
