### PR TITLE
fix(plugin): return structured oversized tool-hook responses

### DIFF
--- a/plugins/oh-my-codex/hooks/codex-native-hook.mjs
+++ b/plugins/oh-my-codex/hooks/codex-native-hook.mjs
@@ -241,6 +241,25 @@ function writeOversizedStopNoop() {
   process.exitCode = 0;
 }
 
+function writeOversizedToolHookOutput(eventName) {
+  const systemMessage = 'OMX native hook rejected oversized stdin JSON before parsing; maxBytes=1048576.';
+  const output = eventName === 'PreToolUse'
+    ? {
+      systemMessage,
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: systemMessage,
+      },
+    }
+    : {
+      continue: false,
+      stopReason: 'native_hook_stdin_oversized',
+      systemMessage,
+    };
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+  process.exitCode = 0;
+}
 function writeCompactFallback() {
   process.exitCode = 0;
 }
@@ -438,6 +457,11 @@ async function main() {
         return;
       }
       writeOversizedStopNoop();
+      return;
+    }
+    const eventName = extractTopLevelHookEventName(input.toString('utf8'));
+    if (eventName === 'PreToolUse' || eventName === 'PostToolUse') {
+      writeOversizedToolHookOutput(eventName);
       return;
     }
     console.error(`[oh-my-codex] ${message}`);

--- a/src/cli/__tests__/codex-plugin-layout.test.ts
+++ b/src/cli/__tests__/codex-plugin-layout.test.ts
@@ -344,6 +344,23 @@ function parseSingleJsonStdout(stdout: string): Record<string, unknown> {
   return JSON.parse(trimmed) as Record<string, unknown>;
 }
 
+const OVERSIZED_STDIN_SYSTEM_MESSAGE = 'OMX native hook rejected oversized stdin JSON before parsing; maxBytes=1048576.';
+
+function buildExactBytePluginHookPayload(eventName: 'PreToolUse' | 'PostToolUse', sessionId: string, byteLength: number): string {
+  const base = JSON.stringify({ hook_event_name: eventName, session_id: sessionId, unicode: '😀é', padding: '' });
+  const paddingBytes = byteLength - Buffer.byteLength(base, 'utf8');
+  assert.ok(paddingBytes >= 0);
+  const payload = JSON.stringify({ hook_event_name: eventName, session_id: sessionId, unicode: '😀é', padding: 'x'.repeat(paddingBytes) });
+  assert.equal(Buffer.byteLength(payload, 'utf8'), byteLength);
+  assert.notEqual(payload.length, Buffer.byteLength(payload, 'utf8'));
+  return payload;
+}
+
+function oversizedToolHookOutput(eventName: 'PreToolUse' | 'PostToolUse'): Record<string, unknown> {
+  return eventName === 'PreToolUse'
+    ? { systemMessage: OVERSIZED_STDIN_SYSTEM_MESSAGE, hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'deny', permissionDecisionReason: OVERSIZED_STDIN_SYSTEM_MESSAGE } }
+    : { continue: false, stopReason: 'native_hook_stdin_oversized', systemMessage: OVERSIZED_STDIN_SYSTEM_MESSAGE };
+}
 async function withPluginCacheCopy<T>(run: (cachePluginRoot: string, cacheRoot: string) => Promise<T>): Promise<T> {
   const cacheRoot = await mkdtemp(join(tmpdir(), 'omx-plugin-hook-cache-'));
   const cachePluginRoot = join(cacheRoot, pluginName, 'local');
@@ -533,6 +550,17 @@ describe('official Codex plugin layout', () => {
       assert.equal(oversizedUserPrompt.status, 0, oversizedUserPrompt.stderr || oversizedUserPrompt.stdout);
       assert.equal(oversizedUserPrompt.stdout, '');
       await assert.rejects(readFile(calledPath, 'utf-8'), { code: 'ENOENT' });
+      for (const eventName of ['PreToolUse', 'PostToolUse'] as const) {
+        const result = runPluginNativeHook(
+          cachePluginRoot,
+          buildExactBytePluginHookPayload(eventName, `plain-${eventName}`, 1024 * 1024 + 1),
+          { OMX_ENTRY_PATH: '', OMX_CODEX_LAUNCH_ID: '', OMX_NATIVE_HOOK_COMMAND: commandPath },
+        );
+        assert.equal(result.status, 0, result.stderr || result.stdout);
+        assert.equal(result.stdout, '');
+        await assert.rejects(readFile(calledPath, 'utf-8'), { code: 'ENOENT' });
+      }
+
 
       const oversizedStop = runPluginNativeHook(
         cachePluginRoot,
@@ -601,6 +629,16 @@ describe('official Codex plugin layout', () => {
       assert.equal(nestedPlainCodex.status, 0, nestedPlainCodex.stderr || nestedPlainCodex.stdout);
       assert.equal(nestedPlainCodex.stdout, '');
       await assert.rejects(readFile(calledPath, 'utf-8'), { code: 'ENOENT' });
+      for (const eventName of ['PreToolUse', 'PostToolUse'] as const) {
+        const result = runPluginNativeHook(
+          cachePluginRoot,
+          buildExactBytePluginHookPayload(eventName, `nested-${eventName}`, 1024 * 1024 + 1),
+          inheritedEnv,
+        );
+        assert.equal(result.status, 0, result.stderr || result.stdout);
+        assert.equal(result.stdout, '');
+        await assert.rejects(readFile(calledPath, 'utf-8'), { code: 'ENOENT' });
+      }
     });
   });
 
@@ -1211,6 +1249,59 @@ head -c 1100000 /dev/zero | tr '\0' x
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
       assert.deepEqual(parseSingleJsonStdout(result.stdout), {});
+    });
+  });
+
+  it('delegates exact UTF-8 under-limit plugin tool-hook input and locally rejects only oversized owned input', async () => {
+    await withPluginCacheCopy(async (cachePluginRoot, cacheRoot) => {
+      const capturePath = join(cacheRoot, 'captured-stdin.json');
+      const sentinelPath = join(cacheRoot, 'delegated.txt');
+      const commandPath = join(cacheRoot, 'capture-tool-hook.mjs');
+      const launcherPath = join(cacheRoot, process.platform === 'win32' ? 'capture-tool-hook.cmd' : 'capture-tool-hook.sh');
+      await writeFile(commandPath, `import { writeFileSync } from 'node:fs';
+const chunks = [];
+process.stdin.on('data', (chunk) => chunks.push(chunk));
+process.stdin.on('end', () => {
+  writeFileSync(process.env.CAPTURE_PATH, Buffer.concat(chunks));
+  writeFileSync(process.env.SENTINEL_PATH, 'delegated');
+  process.stdout.write('{}\\n');
+});
+`, 'utf-8');
+      if (process.platform === 'win32') {
+        await writeFile(launcherPath, `@echo off\r\n"${process.execPath}" "${commandPath}" %*\r\n`, 'utf-8');
+      } else {
+        await writeFile(launcherPath, `#!/bin/sh\nexec "${process.execPath}" "${commandPath}" "$@"\n`, 'utf-8');
+        await chmod(launcherPath, 0o755);
+      }
+      for (const eventName of ['PreToolUse', 'PostToolUse'] as const) {
+        const sessionId = `owned-${eventName.toLowerCase()}-😀é`;
+        for (const byteLength of [1024 * 1024 - 1, 1024 * 1024]) {
+          const input = buildExactBytePluginHookPayload(eventName, sessionId, byteLength);
+          const result = runPluginNativeHook(cachePluginRoot, input, {
+            OMX_CODEX_LAUNCH_ID: `owned-${eventName}-${byteLength}`,
+            OMX_NATIVE_HOOK_COMMAND: launcherPath,
+            CAPTURE_PATH: capturePath,
+            SENTINEL_PATH: sentinelPath,
+          });
+          assert.equal(result.status, 0, result.stderr || result.stdout);
+          assert.equal(result.stdout, '{}\n');
+          assert.deepEqual(await readFile(capturePath), Buffer.from(input));
+          await rm(capturePath, { force: true });
+          await rm(sentinelPath, { force: true });
+        }
+        const input = buildExactBytePluginHookPayload(eventName, sessionId, 1024 * 1024 + 1);
+        const result = runPluginNativeHook(cachePluginRoot, input, {
+          OMX_CODEX_LAUNCH_ID: `owned-oversized-${eventName}`,
+          OMX_NATIVE_HOOK_COMMAND: launcherPath,
+          CAPTURE_PATH: capturePath,
+          SENTINEL_PATH: sentinelPath,
+        });
+        assert.equal(result.status, 0, result.stderr || result.stdout);
+        assert.equal(result.stderr, '');
+        assert.deepEqual(parseSingleJsonStdout(result.stdout), oversizedToolHookOutput(eventName));
+        await assert.rejects(readFile(sentinelPath, 'utf-8'), { code: 'ENOENT' });
+        await assert.rejects(readFile(capturePath), { code: 'ENOENT' });
+      }
     });
   });
 

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -130,6 +130,25 @@ function runNativeHookCliResult(
 	});
 }
 
+const OVERSIZED_STDIN_SYSTEM_MESSAGE = "OMX native hook rejected oversized stdin JSON before parsing; maxBytes=1048576.";
+
+function buildExactByteHookPayload(eventName: "PreToolUse" | "PostToolUse", byteLength: number): string {
+	const base = JSON.stringify({
+		hook_event_name: eventName,
+		session_id: `native-${eventName.toLowerCase()}-😀é`,
+		padding: "",
+	});
+	const paddingBytes = byteLength - Buffer.byteLength(base, "utf8");
+	assert.ok(paddingBytes >= 0);
+	const payload = JSON.stringify({
+		hook_event_name: eventName,
+		session_id: `native-${eventName.toLowerCase()}-😀é`,
+		padding: "x".repeat(paddingBytes),
+	});
+	assert.equal(Buffer.byteLength(payload, "utf8"), byteLength);
+	assert.notEqual(payload.length, Buffer.byteLength(payload, "utf8"));
+	return payload;
+}
 async function writeJson(path: string, value: unknown): Promise<void> {
 	await mkdir(dirname(path), { recursive: true }).catch(() => {});
 	await writeFile(path, JSON.stringify(value, null, 2));
@@ -2101,6 +2120,34 @@ PY`,
 			assert.equal(existsSync(join(cwd, ".omx", "logs")), false);
 		} finally {
 			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("accepts exact UTF-8 byte-limit PreToolUse and PostToolUse payloads and rejects only larger input", () => {
+		for (const eventName of ["PreToolUse", "PostToolUse"] as const) {
+			for (const byteLength of [MAX_NATIVE_STDIN_JSON_BYTES - 1, MAX_NATIVE_STDIN_JSON_BYTES]) {
+				const result = runNativeHookCliResult(buildExactByteHookPayload(eventName, byteLength));
+				assert.equal(result.status, 0, result.stderr || result.stdout);
+				assert.doesNotMatch(result.stdout, /native_hook_stdin_oversized/);
+			}
+			const result = runNativeHookCliResult(buildExactByteHookPayload(eventName, MAX_NATIVE_STDIN_JSON_BYTES + 1));
+			assert.equal(result.status, 0, result.stderr || result.stdout);
+			assert.equal(result.stderr, "");
+			const expected = eventName === "PreToolUse"
+				? {
+					systemMessage: OVERSIZED_STDIN_SYSTEM_MESSAGE,
+					hookSpecificOutput: {
+						hookEventName: "PreToolUse",
+						permissionDecision: "deny",
+						permissionDecisionReason: OVERSIZED_STDIN_SYSTEM_MESSAGE,
+					},
+				}
+				: {
+					continue: false,
+					stopReason: "native_hook_stdin_oversized",
+					systemMessage: OVERSIZED_STDIN_SYSTEM_MESSAGE,
+				};
+			assert.deepEqual(parseSingleJsonStdout(result.stdout), expected);
 		}
 	});
 

--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -1508,6 +1508,43 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
       });
       validateHookStdout(eventName, result.stdout as string);
     }
+    const pluginHookScript = join(packageRoot, 'plugins', 'oh-my-codex', 'hooks', 'codex-native-hook.mjs');
+    const pluginChildScript = join(smokeCwd, 'packed-plugin-oversized-child.mjs');
+    const pluginLauncher = join(smokeCwd, process.platform === 'win32' ? 'packed-plugin-oversized.cmd' : 'packed-plugin-oversized.sh');
+    writeFileSync(pluginChildScript, `import { writeFileSync } from 'node:fs';\nwriteFileSync(process.env.OMX_PLUGIN_SENTINEL, 'delegated');\nprocess.stdout.write('{}\\n');\n`);
+    if (process.platform === 'win32') {
+      writeFileSync(pluginLauncher, `@echo off\r\n"${process.execPath}" "${pluginChildScript}" %*\r\n`);
+    } else {
+      writeFileSync(pluginLauncher, `#!/bin/sh\nexec "${process.execPath}" "${pluginChildScript}" "$@"\n`, { mode: 0o755 });
+    }
+    for (const eventName of ['PreToolUse', 'PostToolUse'] as const) {
+      const launchId = eventName === 'PreToolUse' ? 'packed-plugin-oversized-pre' : 'packed-plugin-oversized-post';
+      const sessionId = `${launchId}-session`;
+      const sentinel = join(smokeCwd, `${launchId}.sentinel`);
+      const base = JSON.stringify({ hook_event_name: eventName, session_id: sessionId, unicode: '😀é', padding: '' });
+      const input = JSON.stringify({ hook_event_name: eventName, session_id: sessionId, unicode: '😀é', padding: 'x'.repeat(1_048_577 - Buffer.byteLength(base, 'utf8')) });
+      if (Buffer.byteLength(input, 'utf8') !== 1_048_577 || input.length === Buffer.byteLength(input, 'utf8')) {
+        throw new Error(`packed plugin ${eventName} oversized fixture did not prove UTF-8 byte sizing`);
+      }
+      const result = run(process.execPath, [realpathSync(pluginHookScript)], {
+        cwd: smokeCwd,
+        env: {
+          ...process.env,
+          OMX_ENTRY_PATH: join(packageRoot, 'dist', 'cli', 'omx.js'),
+          OMX_CODEX_LAUNCH_ID: launchId,
+          OMX_NATIVE_HOOK_COMMAND: pluginLauncher,
+          OMX_PLUGIN_SENTINEL: sentinel,
+        },
+        input,
+      });
+      const systemMessage = 'OMX native hook rejected oversized stdin JSON before parsing; maxBytes=1048576.';
+      const expected = eventName === 'PreToolUse'
+        ? { systemMessage, hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'deny', permissionDecisionReason: systemMessage } }
+        : { continue: false, stopReason: 'native_hook_stdin_oversized', systemMessage };
+      if (result.status !== 0 || String(result.stderr) !== '' || String(result.stdout) !== `${JSON.stringify(expected)}\n` || existsSync(sentinel)) {
+        throw new Error(`packed plugin ${eventName} oversized stdin did not return the native-equivalent local response without delegation`);
+      }
+    }
     for (const input of [
       '{"hook_event_name":"PreToolUse",',
       `{"hook_event_name":"PreToolUse","transcript":"${'x'.repeat(1_048_577)}"}`,


### PR DESCRIPTION
## Summary
- return native-equivalent structured responses for verified-owned oversized plugin `PreToolUse` and `PostToolUse` payloads
- preserve the 1 MiB byte bound, bounded-prefix ownership parsing, no-delegation behavior, unrelated event handling, and all `Stop` semantics
- add exact UTF-8 below/equal/above boundary coverage across native, plugin-cache, and installed-package surfaces

## Validation
- `npm run build`
- `node --test --test-concurrency=1 dist/scripts/__tests__/codex-native-hook.test.js`
- `node --test --test-concurrency=1 dist/cli/__tests__/codex-plugin-layout.test.js`
- `npm run verify:plugin-bundle`
- `node --test --test-concurrency=1 dist/scripts/__tests__/smoke-packed-install.test.js`
- isolated `npm pack` + installed-package consumer probes for oversized PreToolUse/PostToolUse
- `npm run check:no-unused`
- `npm run lint`
- `npm run test:plugin-boundaries:compiled`
- `npm run test:recent-bug-regressions:compiled`
- `git diff --check`

## Broader-suite notes
- `npm test` has one deterministic unrelated baseline failure in `dist/autopilot/__tests__/ralplan-gate.test.js`: expected wording `Re-run native ralplan Architect/Critic reviews` differs from current `Re-run typed native ralplan Architect/Critic reviews`.
- `npm run smoke:packed-install` reaches an environment-only pinned lifecycle gate because the installed Codex is `0.144.4` while that lifecycle requires `0.142.5`; the changed installed plugin asset was separately proven through a real packed-package consumer run.

No merge is requested or performed.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*