### PR TITLE
fix(session): recover dead pointer locks safely

### DIFF
--- a/src/cli/__tests__/session-lock.test.ts
+++ b/src/cli/__tests__/session-lock.test.ts
@@ -1,0 +1,133 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const DEAD_PID = 2_147_483_647;
+const TOKEN = 'dead_lock_token_123456789';
+
+function runOmx(cwd: string, argv: string[]) {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(testDir, '..', '..', '..');
+  return spawnSync(process.execPath, [join(repoRoot, 'dist', 'cli', 'omx.js'), ...argv], {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      OMX_ROOT: '',
+      OMX_STATE_ROOT: '',
+      OMX_TEAM_STATE_ROOT: '',
+    },
+  });
+}
+
+function validOwner(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    version: 1,
+    token: TOKEN,
+    pid: DEAD_PID,
+    platform: process.platform,
+    created_at: '2026-07-19T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+async function prepareState(cwd: string): Promise<{ pointerPath: string; lockPath: string; pointerRaw: string }> {
+  const stateDir = join(cwd, '.omx', 'state');
+  const pointerPath = join(stateDir, 'session.json');
+  const lockPath = `${pointerPath}.lock`;
+  const pointerRaw = '{"session_id":"preserved-session"}\n';
+  await mkdir(lockPath, { recursive: true });
+  await writeFile(pointerPath, pointerRaw, 'utf8');
+  return { pointerPath, lockPath, pointerRaw };
+}
+
+describe('omx session lock CLI', () => {
+  it('keeps top-level and lock help reachable while an ambiguous lock blocks launch', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-help-'));
+    try {
+      await prepareState(cwd);
+      for (const argv of [['--help'], ['session', 'lock', '--help'], ['session', 'lock', 'inspect', '--help']]) {
+        const result = runOmx(cwd, argv);
+        assert.equal(result.status, 0, result.stderr || result.stdout);
+      }
+      assert.match(runOmx(cwd, ['session', 'lock', '--help']).stdout, /There is no force mode/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('inspects and idempotently recovers a definitely dead token-consistent temporary owner', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recover-'));
+    try {
+      const fixture = await prepareState(cwd);
+      await writeFile(join(fixture.lockPath, `owner.${TOKEN}.tmp`), JSON.stringify(validOwner()), 'utf8');
+
+      const inspected = runOmx(cwd, ['session', 'lock', 'inspect', '--json']);
+      assert.equal(inspected.status, 0, inspected.stderr || inspected.stdout);
+      const inspection = JSON.parse(inspected.stdout) as Record<string, unknown>;
+      assert.equal(inspection.status, 'dead');
+      assert.equal(inspection.evidenceSource, 'temporary');
+      assert.equal(inspection.safeToRecover, true);
+
+      const recovered = runOmx(cwd, ['session', 'lock', 'recover', '--json']);
+      assert.equal(recovered.status, 0, recovered.stderr || recovered.stdout);
+      const recovery = JSON.parse(recovered.stdout) as Record<string, unknown>;
+      assert.equal(recovery.action, 'quarantined');
+      assert.equal(recovery.recovered, true);
+      assert.equal(existsSync(fixture.lockPath), false);
+      const quarantinePath = String(recovery.quarantinePath);
+      assert.equal(existsSync(quarantinePath), true);
+      assert.deepEqual(await readdir(quarantinePath), [`owner.${TOKEN}.tmp`]);
+      assert.equal(await readFile(fixture.pointerPath, 'utf8'), fixture.pointerRaw);
+
+      const repeated = runOmx(cwd, ['session', 'lock', 'recover', '--json']);
+      assert.equal(repeated.status, 0, repeated.stderr || repeated.stdout);
+      const repeatResult = JSON.parse(repeated.stdout) as Record<string, unknown>;
+      assert.equal(repeatResult.action, 'absent');
+      assert.equal(repeatResult.recovered, false);
+      assert.equal(await readFile(fixture.pointerPath, 'utf8'), fixture.pointerRaw);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('reports ambiguous evidence without mutating the lock or session pointer', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-ambiguous-'));
+    try {
+      const fixture = await prepareState(cwd);
+      await writeFile(join(fixture.lockPath, 'unexpected.txt'), 'preserve me', 'utf8');
+      const beforeEntries = await readdir(fixture.lockPath);
+
+      const inspected = runOmx(cwd, ['session', 'lock', 'inspect', '--cwd', cwd, '--json']);
+      assert.equal(inspected.status, 0, inspected.stderr || inspected.stdout);
+      assert.equal((JSON.parse(inspected.stdout) as { status: string }).status, 'ambiguous');
+
+      const recovered = runOmx(cwd, ['session', 'lock', 'recover', `--cwd=${cwd}`, '--json']);
+      assert.equal(recovered.status, 2, recovered.stderr || recovered.stdout);
+      const recovery = JSON.parse(recovered.stdout) as Record<string, unknown>;
+      assert.equal(recovery.action, 'blocked');
+      assert.equal(recovery.recovered, false);
+      assert.equal(recovery.reasonCode, 'lock_not_definitely_dead');
+      assert.match(String(recovery.reason), /safe recovery requires a definitely dead owner/);
+      assert.match(JSON.stringify(recovery.nextSteps), /Evidence was preserved/);
+      assert.match(JSON.stringify(recovery.nextSteps), /No force recovery is available/);
+      assert.match(JSON.stringify(recovery.nextSteps), /session lock inspect/);
+
+      const human = runOmx(cwd, ['session', 'lock', 'recover', '--cwd', cwd]);
+      assert.equal(human.status, 2, human.stderr || human.stdout);
+      assert.match(human.stdout, /reason: Lock evidence is ambiguous/);
+      assert.match(human.stdout, /next: Inspect the resolved lock path/);
+      assert.match(human.stdout, /Evidence was preserved\. No force recovery is available/);
+      assert.deepEqual(await readdir(fixture.lockPath), beforeEntries);
+      assert.equal(await readFile(join(fixture.lockPath, 'unexpected.txt'), 'utf8'), 'preserve me');
+      assert.equal(await readFile(fixture.pointerPath, 'utf8'), fixture.pointerRaw);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/__tests__/session-search-help.test.ts
+++ b/src/cli/__tests__/session-search-help.test.ts
@@ -25,12 +25,13 @@ describe('omx session help', () => {
       assert.equal(mainHelp.status, 0, mainHelp.stderr || mainHelp.stdout);
       assert.match(mainHelp.stdout, /omx resume\s+Resume Codex sessions \(supports --project and --codex-home <path>\)/i);
       assert.match(mainHelp.stdout, /omx autoresearch\s+\[DEPRECATED\] Use \$autoresearch; direct CLI launch removed/i);
-      assert.match(mainHelp.stdout, /omx session\s+Search and summarize local session history \(--codex-home <path> escape hatch\)/i);
+      assert.match(mainHelp.stdout, /omx session\s+Search history or inspect\/recover the session-pointer lock/i);
 
       const sessionHelp = runOmx(cwd, ['session', '--help']);
       assert.equal(sessionHelp.status, 0, sessionHelp.stderr || sessionHelp.stdout);
       assert.match(sessionHelp.stdout, /omx session search <query>/i);
       assert.match(sessionHelp.stdout, /omx session friction \[options\]/i);
+      assert.match(sessionHelp.stdout, /omx session lock inspect \[--cwd <path>\] \[--json\]/i);
       assert.match(sessionHelp.stdout, /Options for friction:/i);
       assert.match(sessionHelp.stdout, /--since <spec>/i);
       assert.match(sessionHelp.stdout, /--codex-home <path>/i);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -258,7 +258,7 @@ Usage:
   omx resume    Resume Codex sessions (supports --project and --codex-home <path>)
   omx explore   DEPRECATED compatibility command; use normal repo inspection or omx sparkshell
   omx api       Run native omx-api localhost gateway commands (serve|status|stop|generate)
-  omx session   Search and summarize local session history (--codex-home <path> escape hatch)
+  omx session   Search history or inspect/recover the session-pointer lock
   omx url       Passive URL reader (read <url> --json)
   omx capabilities
                 Lock/check deterministic configured tool, skill, agent, and observation surfaces

--- a/src/cli/session-search.ts
+++ b/src/cli/session-search.ts
@@ -1,11 +1,14 @@
 import { buildSessionFrictionReport, type SessionFrictionReport, type SessionFrictionOptions } from '../session-history/friction.js';
 import { searchSessionHistory, type SessionSearchReport, type SessionSearchOptions } from '../session-history/search.js';
+import { inspectSessionPointerLock, recoverSessionPointerLock } from '../hooks/session.js';
 
 const HELP = `omx session - Search and summarize local session history
 
 Usage:
   omx session search <query> [options]
   omx session friction [options]
+  omx session lock inspect [--cwd <path>] [--json]
+  omx session lock recover [--cwd <path>] [--json]
 
 Options for search:
   --limit <n>          Maximum results to return (default: 10)
@@ -35,6 +38,20 @@ Examples:
 
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 
+const LOCK_HELP = `omx session lock - Inspect or safely recover the selected session-pointer lock
+
+Usage:
+  omx session lock inspect [--cwd <path>] [--json]
+  omx session lock recover [--cwd <path>] [--json]
+
+Options:
+  --cwd <path>  Resolve the session pointer for this working directory
+  --json        Emit structured JSON
+  -h, --help    Show this help
+
+Recovery quarantines only canonical or token-consistent temporary owner evidence
+whose process is definitely dead. There is no force mode.`;
+
 export interface ParsedSessionSearchArgs {
   options: SessionSearchOptions;
   json: boolean;
@@ -43,6 +60,38 @@ export interface ParsedSessionSearchArgs {
 export interface ParsedSessionFrictionArgs {
   options: SessionFrictionOptions;
   json: boolean;
+}
+
+export interface ParsedSessionLockArgs {
+  cwd: string;
+  json: boolean;
+}
+
+export function parseSessionLockArgs(args: string[], defaultCwd = process.cwd()): ParsedSessionLockArgs {
+  let cwd = defaultCwd;
+  let json = false;
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '--json') {
+      json = true;
+      continue;
+    }
+    if (token === '--cwd') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) throw new Error('Missing value after --cwd.');
+      cwd = next;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith('--cwd=')) {
+      const value = token.slice('--cwd='.length);
+      if (!value) throw new Error('Missing value after --cwd=.');
+      cwd = value;
+      continue;
+    }
+    throw new Error(`Unknown session lock option: ${token}`);
+  }
+  return { cwd, json };
 }
 
 function parsePositiveInteger(value: string, flag: string): number {
@@ -174,7 +223,6 @@ export function parseSessionFrictionArgs(args: string[]): ParsedSessionFrictionA
   return { options, json };
 }
 
-
 function formatReport(report: SessionSearchReport): string {
   if (report.results.length === 0) {
     return `No session history matches for "${report.query}". Searched ${report.searched_files} transcript(s).`;
@@ -225,7 +273,6 @@ function formatFrictionReport(report: SessionFrictionReport): string {
   return lines.join('\n');
 }
 
-
 export async function sessionCommand(args: string[]): Promise<void> {
   const subcommand = args[0];
   if (!subcommand || HELP_TOKENS.has(subcommand)) {
@@ -233,12 +280,39 @@ export async function sessionCommand(args: string[]): Promise<void> {
     return;
   }
 
-  if (subcommand !== 'search' && subcommand !== 'friction') {
+  if (subcommand !== 'search' && subcommand !== 'friction' && subcommand !== 'lock') {
     throw new Error(`Unknown session subcommand: ${subcommand}\n${HELP}`);
   }
 
   if (args.slice(1).some((token) => HELP_TOKENS.has(token))) {
-    console.log(HELP.trim());
+    console.log(subcommand === 'lock' ? LOCK_HELP : HELP.trim());
+    return;
+  }
+
+  if (subcommand === 'lock') {
+    const operation = args[1];
+    if (operation !== 'inspect' && operation !== 'recover') {
+      throw new Error(`${operation ? `Unknown session lock operation: ${operation}` : 'Missing session lock operation.'}\n${LOCK_HELP}`);
+    }
+    const parsed = parseSessionLockArgs(args.slice(2));
+    const result = operation === 'inspect'
+      ? await inspectSessionPointerLock(parsed.cwd)
+      : await recoverSessionPointerLock(parsed.cwd);
+    if (parsed.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(`Session pointer lock: ${result.status}`);
+      console.log(`path: ${result.lockPath}`);
+      console.log(`evidence: ${result.evidenceSource}`);
+      console.log(`safe to recover: ${result.safeToRecover ? 'yes' : 'no'}`);
+      if ('action' in result) console.log(`action: ${result.action}`);
+      if ('reason' in result && result.reason) console.log(`reason: ${result.reason}`);
+      if ('nextSteps' in result && Array.isArray(result.nextSteps)) {
+        for (const step of result.nextSteps) console.log(`next: ${step}`);
+      }
+      if ('quarantinePath' in result && result.quarantinePath) console.log(`quarantine: ${result.quarantinePath}`);
+    }
+    if (operation === 'recover' && 'action' in result && result.action === 'blocked') process.exitCode = 2;
     return;
   }
 

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, readdir, rename, rm, symlink, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, rename, rm, rmdir, symlink, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -14,6 +14,8 @@ import {
   readSessionPointer,
   readSessionState,
   readUsableSessionState,
+  inspectSessionPointerLock,
+  recoverSessionPointerLock,
   reconcileNativeSessionStart,
   resetSessionMetrics,
   resolveSessionPointerContext,
@@ -48,6 +50,7 @@ function makeState(overrides: Partial<SessionState> = {}): SessionState {
 const TEST_TOKEN = 'transaction_token_123456';
 const FOREIGN_TOKEN = 'foreign_token_123456789';
 const SUCCESSOR_TOKEN = 'successor_token_123456789';
+const DEAD_PID = 2_147_483_647;
 
 function codedError(code: string): Error & { code: string } {
   return Object.assign(new Error(code), { code });
@@ -86,6 +89,19 @@ async function writeLockOwner(cwd: string, owner: Record<string, unknown>): Prom
   await mkdir(context.lockPath, { recursive: true });
   await writeFile(join(context.lockPath, 'owner.json'), JSON.stringify(owner), 'utf-8');
   return context.lockPath;
+}
+
+async function writeTemporaryLockOwner(cwd: string, owner: Record<string, unknown>): Promise<string> {
+  const context = resolveSessionPointerContext(cwd);
+  await mkdir(context.lockPath, { recursive: true });
+  await writeFile(join(context.lockPath, `owner.${String(owner.token)}.tmp`), JSON.stringify(owner), 'utf-8');
+  return context.lockPath;
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
 }
 
 function validLockOwner(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -794,7 +810,7 @@ describe('session pointer transaction', () => {
     assert.equal(primitive(1), 'indeterminate');
   });
 
-  it('never reaps dead, reused, indeterminate, missing, or malformed lock evidence', async () => {
+  it('never reaps reused, indeterminate, missing, or malformed lock evidence', async () => {
     const cases: Array<{
       name: string;
       owner?: Record<string, unknown>;
@@ -806,7 +822,6 @@ describe('session pointer transaction', () => {
       };
       expected: string;
     }> = [
-      { name: 'dead', owner: validLockOwner(), probePid: 'dead', expected: 'dead' },
       { name: 'reused', owner: validLockOwner(), probePid: 'alive', identity: { status: 'reused', startTicks: 2 }, expected: 'reused' },
       { name: 'indeterminate-probe', owner: validLockOwner(), probePid: 'indeterminate', expected: 'identity-indeterminate' },
       { name: 'indeterminate-identity', owner: validLockOwner(), probePid: 'alive', identity: { status: 'indeterminate' }, expected: 'identity-indeterminate' },
@@ -841,6 +856,372 @@ describe('session pointer transaction', () => {
       } finally {
         await rm(cwd, { recursive: true, force: true });
       }
+    }
+  });
+
+  it('recovers a definitely dead canonical owner and publishes the successor pointer', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-dead-canonical-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      await writeLockOwner(cwd, validLockOwner({ pid: DEAD_PID }));
+
+      await withPointerDependencies({
+        token: () => SUCCESSOR_TOKEN,
+        probePid: () => 'dead',
+      }, async () => {
+        const state = await writeSessionStart(cwd, 'sess-dead-canonical-successor', { platform: 'win32' });
+        assert.equal(state.session_id, 'sess-dead-canonical-successor');
+      });
+
+      assert.equal(existsSync(context.lockPath), false);
+      assert.equal(JSON.parse(await readFile(context.sessionPath, 'utf8')).session_id, 'sess-dead-canonical-successor');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('recovers exactly one token-consistent temporary owner only when its process is definitely dead', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-dead-temporary-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      await writeTemporaryLockOwner(cwd, validLockOwner({ pid: DEAD_PID }));
+
+      await withPointerDependencies({
+        token: () => SUCCESSOR_TOKEN,
+        probePid: () => 'dead',
+      }, async () => {
+        const state = await writeSessionStart(cwd, 'sess-dead-temporary-successor', { platform: 'win32' });
+        assert.equal(state.session_id, 'sess-dead-temporary-successor');
+      });
+
+      assert.equal(existsSync(context.lockPath), false);
+      assert.equal(JSON.parse(await readFile(context.sessionPath, 'utf8')).session_id, 'sess-dead-temporary-successor');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed on canonical or temporary owners with unexpected siblings and preserves every byte', async () => {
+    for (const source of ['canonical', 'temporary'] as const) {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-session-lock-dead-${source}-siblings-`));
+      try {
+        const context = resolveSessionPointerContext(cwd);
+        if (source === 'canonical') await writeLockOwner(cwd, validLockOwner({ pid: DEAD_PID }));
+        else await writeTemporaryLockOwner(cwd, validLockOwner({ pid: DEAD_PID }));
+        const siblingPath = join(context.lockPath, 'diagnostic.txt');
+        await writeFile(siblingPath, 'retain me', 'utf8');
+        const entriesBefore = await readdir(context.lockPath);
+        const bytesBefore = await Promise.all(entriesBefore.map((entry) => readFile(join(context.lockPath, entry))));
+
+        await withPointerDependencies({ probePid: () => 'dead' }, async () => {
+          const inspection = await inspectSessionPointerLock(cwd);
+          assert.equal(inspection.status, 'ambiguous');
+          const result = await recoverSessionPointerLock(cwd);
+          assert.equal(result.action, 'blocked');
+          assert.equal(result.reasonCode, 'lock_not_definitely_dead');
+        });
+
+        assert.deepEqual(await readdir(context.lockPath), entriesBefore);
+        const bytesAfter = await Promise.all(entriesBefore.map((entry) => readFile(join(context.lockPath, entry))));
+        assert.deepEqual(bytesAfter, bytesBefore);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('preserves a live owner paused after temporary publication and never lets a second acquirer publish', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-live-publication-'));
+    const context = resolveSessionPointerContext(cwd);
+    const firstAtPublish = deferred();
+    const releaseFirstPublish = deferred();
+    const secondObservedContention = deferred();
+    let tokenCalls = 0;
+    let secondSettled = false;
+    try {
+      await withPointerDependencies({
+        token: () => (++tokenCalls === 1 ? TEST_TOKEN : SUCCESSOR_TOKEN),
+        probePid: () => 'alive',
+        readProcessIdentity: () => matchingProcessIdentity(),
+        sleep: async () => { secondObservedContention.resolve(); },
+        fs: {
+          writeFile: async (path, data, options) => {
+            if (path === join(context.lockPath, `owner.${TEST_TOKEN}.tmp`)) {
+              const owner = JSON.parse(String(data)) as Record<string, unknown>;
+              data = JSON.stringify({ ...owner, platform: 'linux', pid_start_ticks: 1 });
+            }
+            await writeFile(path, data, options);
+          },
+          rename: async (from, to) => {
+            if (from === join(context.lockPath, `owner.${TEST_TOKEN}.tmp`) && to === join(context.lockPath, 'owner.json')) {
+              firstAtPublish.resolve();
+              await releaseFirstPublish.promise;
+            }
+            await rename(from, to);
+          },
+        },
+      }, async () => {
+        const first = writeSessionStart(cwd, 'sess-first-publisher', { platform: 'win32' });
+        await firstAtPublish.promise;
+        assert.deepEqual(await readdir(context.lockPath), [`owner.${TEST_TOKEN}.tmp`]);
+
+        const second = writeSessionStart(cwd, 'sess-second-publisher', { platform: 'win32' });
+        void second.finally(() => { secondSettled = true; }).catch(() => {});
+        await Promise.race([
+          secondObservedContention.promise,
+          second.then(() => {}, () => {}),
+        ]);
+
+        const settledBeforeRelease = secondSettled;
+        assert.deepEqual(await readdir(context.lockPath), [`owner.${TEST_TOKEN}.tmp`]);
+
+        releaseFirstPublish.resolve();
+        const results = await Promise.allSettled([first, second]);
+        assert.equal(settledBeforeRelease, false, 'the contender must wait for a live temporary owner');
+        assert.equal(results[0].status, 'fulfilled');
+        assert.equal(results[1].status, 'rejected');
+        assert.ok(
+          results[1].status === 'rejected'
+            && isSessionPointerLaunchAbort(results[1].reason)
+            && results[1].reason.code === 'session_pointer_owner_conflict',
+          'the contender must not publish a conflicting session after the live owner releases',
+        );
+      });
+
+      assert.equal(tokenCalls, 2);
+      assert.equal(existsSync(context.lockPath), false);
+    } finally {
+      releaseFirstPublish.resolve();
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed on an empty lock directory while the first acquirer is paused before owner creation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-empty-publication-'));
+    const context = resolveSessionPointerContext(cwd);
+    const firstAfterMkdir = deferred();
+    const releaseFirstMkdir = deferred();
+    let lockMkdirCalls = 0;
+    let tokenCalls = 0;
+    try {
+      await withPointerDependencies({
+        token: () => (++tokenCalls === 1 ? TEST_TOKEN : SUCCESSOR_TOKEN),
+        fs: {
+          mkdir: async (path, options) => {
+            await mkdir(path, options);
+            if (path === context.lockPath && ++lockMkdirCalls === 1) {
+              firstAfterMkdir.resolve();
+              await releaseFirstMkdir.promise;
+            }
+          },
+        },
+      }, async () => {
+        const first = writeSessionStart(cwd, 'sess-empty-first', { platform: 'win32' });
+        await firstAfterMkdir.promise;
+
+        await assert.rejects(
+          writeSessionStart(cwd, 'sess-empty-contender', { platform: 'win32' }),
+          (error: unknown) => isSessionPointerLaunchAbort(error)
+            && error.code === 'session_pointer_lock_recovery_required'
+            && ['missing', 'ambiguous'].includes(String(error.lockOwnerStatus)),
+        );
+        assert.deepEqual(await readdir(context.lockPath), []);
+        releaseFirstMkdir.resolve();
+        await first;
+      });
+
+      assert.equal(tokenCalls, 1, 'the contender must not advance far enough to allocate an owner token');
+    } finally {
+      releaseFirstMkdir.resolve();
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('serializes two acquirers racing to recover the same definitely dead temporary owner', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-dead-racers-'));
+    const context = resolveSessionPointerContext(cwd);
+    let tokenCalls = 0;
+    let activeCanonicalOwners = 0;
+    let maximumCanonicalOwners = 0;
+    try {
+      await writeTemporaryLockOwner(cwd, validLockOwner({ pid: DEAD_PID }));
+      await withPointerDependencies({
+        token: () => `race_token_${String(++tokenCalls).padStart(8, '0')}`,
+        probePid: (pid) => pid === DEAD_PID ? 'dead' : 'alive',
+        readProcessIdentity: () => matchingProcessIdentity(),
+        fs: {
+          writeFile: async (path, data, options) => {
+            if (path.startsWith(context.lockPath) && path.endsWith('.tmp')) {
+              const owner = JSON.parse(String(data)) as Record<string, unknown>;
+              data = JSON.stringify({ ...owner, platform: 'linux', pid_start_ticks: 1 });
+            }
+            await writeFile(path, data, options);
+          },
+          rename: async (from, to) => {
+            await rename(from, to);
+            if (to === join(context.lockPath, 'owner.json')) {
+              activeCanonicalOwners += 1;
+              maximumCanonicalOwners = Math.max(maximumCanonicalOwners, activeCanonicalOwners);
+            } else if (from === context.lockPath && activeCanonicalOwners > 0) {
+              activeCanonicalOwners -= 1;
+            }
+          },
+        },
+      }, async () => {
+        const results = await Promise.all([
+          writeSessionStart(cwd, 'sess-dead-racer', { platform: 'win32' }),
+          writeSessionStart(cwd, 'sess-dead-racer', { platform: 'win32' }),
+        ]);
+        assert.deepEqual(new Set(results.map((state) => state.session_id)), new Set(['sess-dead-racer']));
+      });
+
+      assert.equal(maximumCanonicalOwners, 1);
+      assert.equal(activeCanonicalOwners, 0);
+      assert.ok(tokenCalls >= 2, 'both successful acquirers must allocate owner tokens');
+      assert.equal(existsSync(context.lockPath), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('uses one retained deterministic quarantine so a stale recovery cannot rename a successor live lock', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-aba-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      await writeTemporaryLockOwner(cwd, validLockOwner({ pid: DEAD_PID }));
+      const secondReachedRename = deferred();
+      const releaseSecondRename = deferred();
+      let recoveryRenames = 0;
+      await withPointerDependencies({
+        probePid: (pid) => pid === DEAD_PID ? 'dead' : 'alive',
+        readProcessIdentity: () => matchingProcessIdentity(),
+        fs: {
+          rename: async (from, to) => {
+            if (from === context.lockPath && ++recoveryRenames === 1) {
+              secondReachedRename.resolve();
+              await releaseSecondRename.promise;
+            }
+            await rename(from, to);
+          },
+        },
+      }, async () => {
+        const secondRecovery = recoverSessionPointerLock(cwd);
+        await secondReachedRename.promise;
+
+        const first = await recoverSessionPointerLock(cwd);
+        assert.equal(first.action, 'quarantined');
+        assert.equal(existsSync(first.quarantinePath ?? ''), true);
+
+        await writeLockOwner(cwd, validLockOwner());
+        const successorRaw = await readFile(join(context.lockPath, 'owner.json'), 'utf8');
+
+        releaseSecondRename.resolve();
+        const second = await secondRecovery;
+        assert.equal(second.action, 'raced');
+        assert.equal(second.status, 'live');
+        assert.equal(await readFile(join(context.lockPath, 'owner.json'), 'utf8'), successorRaw);
+        assert.equal(recoveryRenames, 2);
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('recognizes a retained non-empty quarantine destination across platform-specific rename errors', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-quarantine-conflict-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      await writeLockOwner(cwd, validLockOwner({ pid: DEAD_PID }));
+      const quarantinePath = `${context.lockPath}.recovery-${TEST_TOKEN}`;
+      await mkdir(quarantinePath);
+      await writeFile(join(quarantinePath, 'owner.json'), JSON.stringify(validLockOwner({ pid: DEAD_PID })), 'utf8');
+
+      await withPointerDependencies({
+        probePid: () => 'dead',
+        fs: { rename: async () => { throw codedError('EPERM'); } },
+      }, async () => {
+        const result = await recoverSessionPointerLock(cwd);
+        assert.equal(result.action, 'blocked');
+        assert.equal(result.reasonCode, 'quarantine_destination_exists');
+        assert.equal(result.quarantinePath, quarantinePath);
+        assert.equal(existsSync(context.lockPath), true);
+        assert.equal(existsSync(quarantinePath), true);
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects canonical-lock and owner-evidence symlinks without mutating external targets', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-symlink-'));
+    const external = await mkdtemp(join(tmpdir(), 'omx-session-lock-external-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      await mkdir(context.baseStateDir, { recursive: true });
+      const externalOwnerPath = join(external, 'external-owner.json');
+      const externalRaw = JSON.stringify(validLockOwner({ pid: DEAD_PID }));
+      await writeFile(externalOwnerPath, externalRaw, 'utf8');
+
+      const externalLockDir = join(external, 'lock-target');
+      await mkdir(externalLockDir);
+      await writeFile(join(externalLockDir, 'owner.json'), externalRaw, 'utf8');
+      await symlink(externalLockDir, context.lockPath, 'dir');
+      assert.equal((await inspectSessionPointerLock(cwd)).status, 'ambiguous');
+      assert.equal((await recoverSessionPointerLock(cwd)).action, 'blocked');
+      assert.equal(await readFile(join(externalLockDir, 'owner.json'), 'utf8'), externalRaw);
+
+      await rm(context.lockPath);
+      await mkdir(context.lockPath);
+      await symlink(externalOwnerPath, join(context.lockPath, `owner.${TEST_TOKEN}.tmp`));
+      assert.equal((await inspectSessionPointerLock(cwd)).status, 'ambiguous');
+      assert.equal((await recoverSessionPointerLock(cwd)).action, 'blocked');
+      assert.equal(await readFile(externalOwnerPath, 'utf8'), externalRaw);
+
+      await rm(context.lockPath, { recursive: true });
+      await mkdir(context.lockPath);
+      await symlink(externalOwnerPath, join(context.lockPath, 'owner.json'));
+      assert.equal((await inspectSessionPointerLock(cwd)).status, 'ambiguous');
+      assert.equal((await recoverSessionPointerLock(cwd)).action, 'blocked');
+      assert.equal(await readFile(externalOwnerPath, 'utf8'), externalRaw);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(external, { recursive: true, force: true });
+    }
+  });
+
+  it('performs no quarantine cleanup when the retained destination path is swapped to a symlink', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-quarantine-symlink-'));
+    const external = await mkdtemp(join(tmpdir(), 'omx-session-lock-quarantine-external-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      const externalPath = join(external, 'marker.txt');
+      const externalRaw = 'external evidence must survive';
+      await writeFile(externalPath, externalRaw, 'utf8');
+      await writeLockOwner(cwd, validLockOwner({ pid: DEAD_PID }));
+      let retainedPath = '';
+
+      await withPointerDependencies({
+        probePid: () => 'dead',
+        fs: {
+          rename: async (from, to) => {
+            await rename(from, to);
+            if (from === context.lockPath) {
+              retainedPath = `${to}.retained`;
+              await rename(to, retainedPath);
+              await symlink(external, to, 'dir');
+            }
+          },
+        },
+      }, async () => {
+        const result = await recoverSessionPointerLock(cwd);
+        assert.equal(result.action, 'quarantined');
+        assert.equal(await readFile(externalPath, 'utf8'), externalRaw);
+        assert.equal(existsSync(result.quarantinePath ?? ''), true);
+        assert.equal(existsSync(join(retainedPath, 'owner.json')), true);
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(external, { recursive: true, force: true });
     }
   });
 
@@ -903,7 +1284,7 @@ describe('session pointer transaction', () => {
           },
           rmdir: async (path) => {
             if (path === context.lockPath) throw new Error('keep lock evidence');
-            await rm(path, { recursive: false });
+            await rmdir(path);
           },
         },
       }, async () => {
@@ -1134,7 +1515,7 @@ describe('session pointer transaction', () => {
           },
           rmdir: async (path) => {
             if (path.endsWith(`.release-${TEST_TOKEN}`)) throw new Error('release cleanup failure');
-            await rm(path, { recursive: false });
+            await rmdir(path);
           },
         },
       }, async () => {

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -7,6 +7,7 @@
  */
 import {
   appendFile,
+  lstat as nodeLstat,
   mkdir as nodeMkdir,
   open,
   readFile as nodeReadFile,
@@ -141,7 +142,7 @@ export interface ResolvedSessionPointerAbort extends SessionPointerAbortBase {
   lockPath?: string;
   rootSource: StateRootSource;
   pointerStatus?: UnusableSessionPointerStatus;
-  lockOwnerStatus?: 'live' | 'dead' | 'reused' | 'identity-indeterminate' | 'missing' | 'malformed';
+  lockOwnerStatus?: 'live' | 'dead' | 'reused' | 'identity-indeterminate' | 'missing' | 'malformed' | 'ambiguous';
   primaryOperation?: Exclude<
     SessionPointerTransactionOperation,
     'pointer-context-resolve' | 'precommit-cleanup' | 'lock-release'
@@ -307,6 +308,7 @@ export interface SessionPointerFsDependencies {
   mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
   readdir(path: string): Promise<string[]>;
   readFile(path: string, encoding: 'utf8'): Promise<string>;
+  lstat(path: string): Promise<{ isDirectory(): boolean; isFile(): boolean; isSymbolicLink(): boolean }>;
   writeFile(path: string, data: string, options?: { mode?: number; flag?: string }): Promise<void>;
   openAndSync(
     path: string,
@@ -338,6 +340,7 @@ const defaultFsDependencies: SessionPointerFsDependencies = {
   },
   readdir: async (path) => await nodeReaddir(path),
   readFile: async (path, encoding) => await nodeReadFile(path, encoding),
+  lstat: async (path) => await nodeLstat(path),
   writeFile: async (path, data, options) => {
     await nodeWriteFile(path, data, options);
   },
@@ -738,7 +741,34 @@ interface SessionPointerLockOwnerV1 {
   created_at: string;
 }
 
-type LockOwnerStatus = 'live' | 'dead' | 'reused' | 'identity-indeterminate' | 'missing' | 'malformed';
+type LockOwnerStatus = 'live' | 'dead' | 'reused' | 'identity-indeterminate' | 'missing' | 'malformed' | 'ambiguous';
+
+interface LockOwnerInspection {
+  status: LockOwnerStatus | 'absent';
+  owner?: SessionPointerLockOwnerV1;
+  source: 'canonical' | 'temporary' | 'directory' | 'none';
+  entries: string[];
+}
+
+export interface SessionPointerLockInspection {
+  cwd: string;
+  pointerPath: string;
+  lockPath: string;
+  status: LockOwnerStatus | 'absent';
+  evidenceSource: LockOwnerInspection['source'];
+  safeToRecover: boolean;
+  entries: string[];
+  owner?: Pick<SessionPointerLockOwnerV1, 'pid' | 'platform' | 'created_at'>;
+}
+
+export interface SessionPointerLockRecoveryResult extends SessionPointerLockInspection {
+  action: 'absent' | 'blocked' | 'quarantined' | 'raced';
+  recovered: boolean;
+  quarantinePath?: string;
+  reasonCode?: 'lock_not_definitely_dead' | 'quarantine_destination_exists';
+  reason?: string;
+  nextSteps?: string[];
+}
 
 function parseLockOwner(raw: string): SessionPointerLockOwnerV1 | null {
   try {
@@ -763,20 +793,10 @@ function isValidToken(value: unknown): value is string {
   return typeof value === 'string' && SESSION_POINTER_TOKEN_PATTERN.test(value);
 }
 
-async function inspectLockOwner(lockPath: string): Promise<{
+function classifyLockOwner(owner: SessionPointerLockOwnerV1): {
   status: LockOwnerStatus;
-  owner?: SessionPointerLockOwnerV1;
-}> {
-  let raw: string;
-  try {
-    raw = await transactionDependencies.fs.readFile(join(lockPath, 'owner.json'), 'utf8');
-  } catch (error) {
-    return isNotFound(error) ? { status: 'missing' } : { status: 'identity-indeterminate' };
-  }
-
-  const owner = parseLockOwner(raw);
-  if (!owner) return { status: 'malformed' };
-
+  owner: SessionPointerLockOwnerV1;
+} {
   let pidStatus: PidProbeResult;
   try {
     pidStatus = transactionDependencies.probePid(owner.pid);
@@ -807,6 +827,188 @@ async function inspectLockOwner(lockPath: string): Promise<{
     return { status: 'identity-indeterminate', owner };
   }
   return { status: 'live', owner };
+}
+
+async function inspectLockOwner(lockPath: string): Promise<LockOwnerInspection> {
+  let lockStat: Awaited<ReturnType<SessionPointerFsDependencies['lstat']>>;
+  try {
+    lockStat = await transactionDependencies.fs.lstat(lockPath);
+  } catch (error) {
+    return isNotFound(error)
+      ? { status: 'absent', source: 'none', entries: [] }
+      : { status: 'identity-indeterminate', source: 'directory', entries: [] };
+  }
+  if (lockStat.isSymbolicLink() || !lockStat.isDirectory()) {
+    return { status: 'ambiguous', source: 'directory', entries: [] };
+  }
+
+  let entries: string[];
+  try {
+    entries = await transactionDependencies.fs.readdir(lockPath);
+  } catch (error) {
+    return isNotFound(error)
+      ? { status: 'absent', source: 'none', entries: [] }
+      : { status: 'identity-indeterminate', source: 'directory', entries: [] };
+  }
+
+  if (entries.includes('owner.json')) {
+    if (entries.length !== 1) return { status: 'ambiguous', source: 'directory', entries };
+    const ownerPath = join(lockPath, 'owner.json');
+    let ownerStat: Awaited<ReturnType<SessionPointerFsDependencies['lstat']>>;
+    try {
+      ownerStat = await transactionDependencies.fs.lstat(ownerPath);
+    } catch (error) {
+      return isNotFound(error)
+        ? { status: 'absent', source: 'none', entries }
+        : { status: 'identity-indeterminate', source: 'canonical', entries };
+    }
+    if (ownerStat.isSymbolicLink() || !ownerStat.isFile()) {
+      return { status: 'ambiguous', source: 'canonical', entries };
+    }
+    let canonicalRaw: string;
+    try {
+      canonicalRaw = await transactionDependencies.fs.readFile(ownerPath, 'utf8');
+    } catch (error) {
+      return isNotFound(error)
+        ? { status: 'absent', source: 'none', entries }
+        : { status: 'identity-indeterminate', source: 'canonical', entries };
+    }
+    const owner = parseLockOwner(canonicalRaw);
+    if (!owner) return { status: 'malformed', source: 'canonical', entries };
+    return { ...classifyLockOwner(owner), source: 'canonical', entries };
+  }
+
+  if (entries.length === 0) return { status: 'missing', source: 'directory', entries };
+  if (entries.length !== 1) return { status: 'ambiguous', source: 'directory', entries };
+
+  const evidenceFileName = entries[0];
+  const match = /^owner\.([A-Za-z0-9_-]{16,128})\.tmp$/.exec(evidenceFileName);
+  if (!match) return { status: 'ambiguous', source: 'directory', entries };
+
+  const temporaryPath = join(lockPath, evidenceFileName);
+  let temporaryStat: Awaited<ReturnType<SessionPointerFsDependencies['lstat']>>;
+  try {
+    temporaryStat = await transactionDependencies.fs.lstat(temporaryPath);
+  } catch (error) {
+    return isNotFound(error)
+      ? { status: 'absent', source: 'none', entries }
+      : { status: 'identity-indeterminate', source: 'temporary', entries };
+  }
+  if (temporaryStat.isSymbolicLink() || !temporaryStat.isFile()) {
+    return { status: 'ambiguous', source: 'temporary', entries };
+  }
+
+  let temporaryRaw: string;
+  try {
+    temporaryRaw = await transactionDependencies.fs.readFile(temporaryPath, 'utf8');
+  } catch (error) {
+    // The publisher may have atomically promoted the temporary evidence after
+    // readdir. Re-enter acquisition so the canonical state is inspected afresh.
+    return isNotFound(error)
+      ? { status: 'absent', source: 'none', entries }
+      : { status: 'identity-indeterminate', source: 'temporary', entries };
+  }
+  const owner = parseLockOwner(temporaryRaw);
+  if (!owner || owner.token !== match[1]) return { status: 'malformed', source: 'temporary', entries };
+  return { ...classifyLockOwner(owner), source: 'temporary', entries };
+}
+
+interface DeadLockQuarantineResult {
+  outcome: 'quarantined' | 'raced' | 'destination-exists';
+  quarantinePath: string;
+}
+
+async function quarantineDeadLock(lockPath: string, owner: SessionPointerLockOwnerV1): Promise<DeadLockQuarantineResult> {
+  // Every recovery of the same immutable owner targets the same retained,
+  // non-empty directory. Once one rename succeeds, a stale contender cannot
+  // rename a successor lock over that destination on supported filesystems.
+  const quarantinePath = `${lockPath}.recovery-${owner.token}`;
+  try {
+    await transactionDependencies.fs.rename(lockPath, quarantinePath);
+    return { outcome: 'quarantined', quarantinePath };
+  } catch (error) {
+    if (isNotFound(error)) return { outcome: 'raced', quarantinePath };
+    if (isAlreadyExists(error) || errorCode(error) === 'ENOTEMPTY') {
+      return { outcome: 'destination-exists', quarantinePath };
+    }
+    try {
+      const destinationStat = await transactionDependencies.fs.lstat(quarantinePath);
+      if (!destinationStat.isSymbolicLink() && destinationStat.isDirectory()) {
+        const retainedEntries = await transactionDependencies.fs.readdir(quarantinePath);
+        if (retainedEntries.length > 0) return { outcome: 'destination-exists', quarantinePath };
+      }
+    } catch {
+      // Preserve the original rename failure when the destination cannot be
+      // positively identified as retained, non-empty quarantine evidence.
+    }
+    throw error;
+  }
+}
+
+function publicLockInspection(
+  context: SessionPointerContext,
+  inspection: LockOwnerInspection,
+): SessionPointerLockInspection {
+  return {
+    cwd: context.cwd,
+    pointerPath: context.sessionPath,
+    lockPath: context.lockPath,
+    status: inspection.status,
+    evidenceSource: inspection.source,
+    safeToRecover: inspection.status === 'dead' && Boolean(inspection.owner),
+    entries: inspection.entries,
+    ...(inspection.owner
+      ? { owner: { pid: inspection.owner.pid, platform: inspection.owner.platform, created_at: inspection.owner.created_at } }
+      : {}),
+  };
+}
+
+/** Inspect only the selected session-pointer lock; never mutates lock or pointer state. */
+export async function inspectSessionPointerLock(cwd: string): Promise<SessionPointerLockInspection> {
+  const context = resolveSessionPointerContext(cwd);
+  return publicLockInspection(context, await inspectLockOwner(context.lockPath));
+}
+
+/** Safely quarantine only a lock whose canonical or temporary owner is definitely dead. */
+export async function recoverSessionPointerLock(cwd: string): Promise<SessionPointerLockRecoveryResult> {
+  const context = resolveSessionPointerContext(cwd);
+  const inspection = await inspectLockOwner(context.lockPath);
+  const result = publicLockInspection(context, inspection);
+  if (inspection.status === 'absent') return { ...result, action: 'absent', recovered: false };
+  if (inspection.status !== 'dead' || !inspection.owner) {
+    return {
+      ...result,
+      action: 'blocked',
+      recovered: false,
+      reasonCode: 'lock_not_definitely_dead',
+      reason: `Lock evidence is ${inspection.status}; safe recovery requires a definitely dead owner.`,
+      nextSteps: [
+        `Inspect the resolved lock path with: omx session lock inspect --cwd ${JSON.stringify(context.cwd)} --json`,
+        'Evidence was preserved. No force recovery is available.',
+      ],
+    };
+  }
+  const quarantine = await quarantineDeadLock(context.lockPath, inspection.owner);
+  if (quarantine.outcome === 'raced') return { ...result, action: 'raced', recovered: false };
+  if (quarantine.outcome === 'destination-exists') {
+    const current = await inspectLockOwner(context.lockPath);
+    if (current.status !== 'dead' || current.owner?.token !== inspection.owner.token) {
+      return { ...publicLockInspection(context, current), action: 'raced', recovered: false, quarantinePath: quarantine.quarantinePath };
+    }
+    return {
+      ...result,
+      action: 'blocked',
+      recovered: false,
+      quarantinePath: quarantine.quarantinePath,
+      reasonCode: 'quarantine_destination_exists',
+      reason: 'The deterministic quarantine destination already exists while the same dead lock remains canonical.',
+      nextSteps: [
+        `Inspect the resolved lock path with: omx session lock inspect --cwd ${JSON.stringify(context.cwd)} --json`,
+        'Existing lock and quarantine evidence were preserved. No force recovery is available.',
+      ],
+    };
+  }
+  return { ...result, action: 'quarantined', recovered: true, quarantinePath: quarantine.quarantinePath };
 }
 
 interface HeldPointerLock {
@@ -949,6 +1151,33 @@ async function acquirePointerLock(
       }
 
       const owner = await inspectLockOwner(context.lockPath);
+      if (owner.status === 'absent') continue;
+      if (owner.status === 'dead' && owner.owner) {
+        try {
+          const recovery = await quarantineDeadLock(context.lockPath, owner.owner);
+          if (recovery.outcome === 'quarantined' || recovery.outcome === 'raced') continue;
+          const current = await inspectLockOwner(context.lockPath);
+          if (current.status !== 'dead' || current.owner?.token !== owner.owner.token) continue;
+          throw resolvedAbort(context, {
+            code: 'session_pointer_lock_recovery_required',
+            operation: 'lock-acquire',
+            ...(candidateSessionId ? { candidateSessionId } : {}),
+            lockPath: context.lockPath,
+            lockOwnerStatus: 'dead',
+            reason: `Session pointer lock recovery is blocked by retained quarantine evidence: ${recovery.quarantinePath}`,
+          });
+        } catch (recoveryError) {
+          if (isSessionPointerLaunchAbort(recoveryError)) throw recoveryError;
+          throw resolvedAbort(context, {
+            code: 'session_pointer_io_failure',
+            operation: 'lock-acquire',
+            ...(candidateSessionId ? { candidateSessionId } : {}),
+            lockPath: context.lockPath,
+            reason: `Unable to quarantine definitely dead session pointer lock: ${errorMessage(recoveryError)}`,
+            cause: recoveryError,
+          });
+        }
+      }
       if (owner.status !== 'live') {
         throw resolvedAbort(context, {
           code: 'session_pointer_lock_recovery_required',


### PR DESCRIPTION
## Summary

- classify canonical and temporary session-pointer owner evidence with one strict, no-follow path
- recover only positively proven dead owners; missing, malformed, reused, indeterminate, symlinked, or unexpected evidence remains fail-closed
- quarantine dead locks to a deterministic owner-token path and retain the non-empty evidence, preventing stale-recovery ABA without unsafe cleanup
- add always-reachable `omx session lock inspect|recover` commands that never mutate `session.json`

## Safety properties

- no recovery based on absence or age alone
- token-consistent temporary evidence is required
- a stale recovery cannot rename a successor live lock over the retained deterministic quarantine
- quarantine performs no recursive or synchronous content deletion
- inspect is read-only; recover has no force mode and preserves ambiguous evidence

## Validation

- `npm run lint`
- `npm run check:no-unused`
- `npm run build`
- targeted compiled session/CLI/index suite: **360 passed, 0 failed**
- `git diff --check`
- independent code review: **APPROVE**
- independent architecture review: **CLEAR**

`npm test` was also exercised locally across all 385 compiled test files. In the active Node 25/macOS OMX runtime, 33 unrelated files fail in existing CLI setup, tmux/hook, uninstall, proxy/notification, MCP, native-asset, and team-runtime areas; none are among the six changed files, while all issue-scoped session and executable CLI tests pass. Supported Node 20/22 CI remains the authoritative cross-platform gate.

Fixes #3203
