### PR TITLE
fix(cli): scope cancellation to proven session

### DIFF
--- a/plugins/oh-my-codex/skills/cancel/SKILL.md
+++ b/plugins/oh-my-codex/skills/cancel/SKILL.md
@@ -75,78 +75,27 @@ When cancellation targets Ralph state in a scope, completion requires all of the
 2. Linked Ultrawork/Ecomode in the same scope is also terminal/non-active.
 4. Unrelated sessions are untouched.
 
-## Force Clear All
+## Exact-scope force compatibility
 
-Use `--force` or `--all` when you need to erase every session plus legacy artifacts, e.g., to reset the workspace entirely.
+`--force` is a compatibility flag for the same proven current scope as bare cancellation. It does not widen cancellation to other sessions, legacy roots, Team runtimes, or workspace artifacts. Its only additional behavior is exact-session native-stop cleanup after the same ownership checks.
 
-```
+`--all` is intentionally unsupported. Workspace-wide destructive cancellation requires a separately reviewed command and authority contract. Unknown flags and mixed flag combinations fail before mutation.
+
+```text
+/cancel
 /cancel --force
 ```
 
-```
-/cancel --all
-```
+### Argument contract
 
-Steps under the hood:
-1. `state_list_active` enumerates `.omx/state/sessions/{sessionId}/…` to find every known session.
-2. `state_clear` runs once per session to drop that session’s files.
-3. A global `state_clear` without `session_id` removes legacy files under `.omx/state/*.json`, `.omx/state/swarm*.db`, and compatibility artifacts (see list).
-4. Team artifacts (`.omx/state/team/*/`, tmux sessions matching `omx-team-*`) are best-effort cleared as part of the legacy fallback.
+- no arguments: cancel only the provably current session/root scope;
+- `--force`: same scope, plus exact-session native-stop cleanup;
+- `--all`: reject without mutation;
+- unknown or multiple flags: reject without mutation.
 
-Every `state_clear` command honors the `session_id` argument, so even force mode still uses the session-aware paths first before deleting legacy files.
+### State discovery
 
-Legacy compatibility list (removed only under `--force`/`--all`):
-- `.omx/state/autopilot-state.json`
-- `.omx/state/ralph-state.json`
-- `.omx/state/ralph-plan-state.json`
-- `.omx/state/ralph-verification.json`
-- `.omx/state/ultrawork-state.json`
-- `.omx/state/ecomode-state.json`
-- `.omx/state/ultraqa-state.json`
-- `.omx/state/swarm.db`
-- `.omx/state/swarm.db-wal`
-- `.omx/state/swarm.db-shm`
-- `.omx/state/swarm-active.marker`
-- `.omx/state/swarm-tasks.db`
-- `.omx/state/ultrapilot-state.json`
-- `.omx/state/ultrapilot-ownership.json`
-- `.omx/state/pipeline-state.json`
-- `.omx/state/plan-consensus.json`
-- `.omx/state/ralplan-state.json`
-- `.omx/state/boulder.json`
-- `.omx/state/hud-state.json`
-- `.omx/state/subagent-tracking.json`
-- `.omx/state/subagent-tracker.lock`
-- `.omx/state/rate-limit-daemon.pid`
-- `.omx/state/rate-limit-daemon.log`
-- `.omx/state/checkpoints/` (directory)
-- `.omx/state/sessions/` (empty directory cleanup after clearing sessions)
-
-## Implementation Steps
-
-When you invoke this skill:
-
-### 1. Parse Arguments
-
-```bash
-# Check for --force or --all flags
-FORCE_MODE=false
-if [[ "$*" == *"--force"* ]] || [[ "$*" == *"--all"* ]]; then
-  FORCE_MODE=true
-fi
-```
-
-### 2. Detect Active Modes
-
-The skill now relies on the session-aware state contract rather than hard-coded file paths:
-1. Call `state_list_active` to enumerate `.omx/state/sessions/{sessionId}/…` and discover every active session.
-2. For each session id, call `state_get_status` to learn which mode is running (`autopilot`, `ralph`, `ultrawork`, etc.) and whether dependent modes exist.
-3. If a `session_id` was supplied to `/cancel`, skip legacy fallback entirely and operate solely within that session path; otherwise, consult legacy files in `.omx/state/*.json` only if the state tools report no active session. Swarm remains a shared SQLite/marker mode outside session scoping.
-4. Any cancellation logic in this doc mirrors the dependency order discovered via state tools (autopilot → ralph → …).
-
-### 3A. Force Mode (if --force or --all)
-
-Use force mode to clear every session plus legacy artifacts via `state_clear`. Direct file removal is reserved for legacy cleanup when the state tools report no active sessions.
+Cancellation derives writable targets from the already-proven writable scope. Compatibility discovery may inform status, but never grants write authority. Unrelated session, legacy-root, Team, and run-dir state remains untouched unless it is independently proven as the exact cancellation target.
 
 ### 3B. Smart Cancellation (default)
 
@@ -327,21 +276,20 @@ echo "  - Ralph (.omx/state/ralph-state.json)"
 echo "  - Ultrawork (.omx/state/ultrawork-state.json)"
 echo "  - UltraQA (.omx/state/ultraqa-state.json)"
 echo ""
-echo "Use --force to clear all state files anyway."
+echo "Use --force for exact-session native-stop cleanup without widening scope."
+
 ```
 
 ## Implementation Notes
 
 The cancel skill runs as follows:
-1. Parse the `--force` / `--all` flags, tracking whether cleanup should span every session or stay scoped to the current session id.
-2. Use `state_list_active` to enumerate known session ids and `state_get_status` to learn the active mode (`autopilot`, `ralph`, `ultrawork`, etc.) for each session.
-3. When operating in default mode, call `state_clear` with that session_id to remove only the session’s files, then run mode-specific cleanup (autopilot → ralph → …) based on the state tool signals.
-4. In force mode, iterate every active session, call `state_clear` per session, then run a global `state_clear` without `session_id` to drop legacy files (`.omx/state/*.json`, compatibility artifacts) and report success. Swarm remains a shared SQLite/marker mode outside session scoping.
-5. Team artifacts (`.omx/state/team/*/`, tmux sessions matching `omx-team-*`) remain best-effort cleanup items invoked during the legacy/global pass.
+1. Parse arguments strictly. Bare cancellation and a single `--force` are accepted; `--all`, unknown flags, and multiple flags fail before mutation.
+2. Resolve one writable scope and treat compatibility discovery as read-only.
+3. Cancel only active state files whose exact scope, ownership fields, and frozen file identity are proven.
+4. With `--force`, remove only the selected session's native-stop entry after the same proof and revalidation.
+5. Leave unrelated sessions, legacy compatibility roots, Team artifacts, and tmux sessions untouched.
 
-State tools always honor the `session_id` argument, so even force mode still clears the session-scoped paths before deleting compatibility-only legacy state.
-
-Mode-specific subsections below describe what extra cleanup each handler performs after the state-wide operations finish.
+Mode-specific subsections below describe same-scope dependency ordering only.
 ## Messages Reference
 
 | Mode | Success Message |

--- a/plugins/oh-my-codex/skills/cancel/SKILL.md
+++ b/plugins/oh-my-codex/skills/cancel/SKILL.md
@@ -327,21 +327,10 @@ Mode-specific subsections below describe same-scope dependency ordering only.
 - **Safe**: Only clears linked Ultrawork, preserves standalone Ultrawork
 - **Local-only**: Clears state files in `.omx/state/` directory
 - **Resume-friendly**: Autopilot state is preserved for seamless resume
-- **Team-aware**: Detects tmux-based teams and performs graceful shutdown with force-kill fallback
+- **Team-aware**: Team cancellation is permitted only when the selected state carries exact same-scope Team authority; unrelated Team artifacts and tmux sessions remain untouched.
 
 ## Tmux Team Cleanup
 
-When cancelling team mode, the cancel skill should:
+Cancellation MUST NOT enumerate or kill every `omx-team-*` session and MUST NOT recursively delete `.omx/state/team/`. Team shutdown requires the exact frozen Team root, internal name, session, leader pane, and runtime identity selected by the authorized state transition. When that proof is unavailable or changes, cancellation fails closed without signals, pane actions, overlay edits, or Team-state deletion.
 
-1. **Kill all team tmux sessions**: `tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^omx-team-'` and kill each
-2. **Remove team state directories**: `rm -rf .omx/state/team/*/`
-3. **Strip AGENTS.md overlay**: Remove content between `<!-- OMX:TEAM:WORKER:START -->` and `<!-- OMX:TEAM:WORKER:END -->`
-
-### Force Clear Addition
-
-When `--force` is used, also clean up:
-```bash
-rm -rf .omx/state/team/                  # All team state
-# Kill all omx-team-* tmux sessions
-tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^omx-team-' | while read s; do tmux kill-session -t "$s" 2>/dev/null; done
-```
+`--force` does not widen Team scope. It only enables exact-session native-stop cleanup after the same authority checks.

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -75,78 +75,27 @@ When cancellation targets Ralph state in a scope, completion requires all of the
 2. Linked Ultrawork/Ecomode in the same scope is also terminal/non-active.
 4. Unrelated sessions are untouched.
 
-## Force Clear All
+## Exact-scope force compatibility
 
-Use `--force` or `--all` when you need to erase every session plus legacy artifacts, e.g., to reset the workspace entirely.
+`--force` is a compatibility flag for the same proven current scope as bare cancellation. It does not widen cancellation to other sessions, legacy roots, Team runtimes, or workspace artifacts. Its only additional behavior is exact-session native-stop cleanup after the same ownership checks.
 
-```
+`--all` is intentionally unsupported. Workspace-wide destructive cancellation requires a separately reviewed command and authority contract. Unknown flags and mixed flag combinations fail before mutation.
+
+```text
+/cancel
 /cancel --force
 ```
 
-```
-/cancel --all
-```
+### Argument contract
 
-Steps under the hood:
-1. `state_list_active` enumerates `.omx/state/sessions/{sessionId}/…` to find every known session.
-2. `state_clear` runs once per session to drop that session’s files.
-3. A global `state_clear` without `session_id` removes legacy files under `.omx/state/*.json`, `.omx/state/swarm*.db`, and compatibility artifacts (see list).
-4. Team artifacts (`.omx/state/team/*/`, tmux sessions matching `omx-team-*`) are best-effort cleared as part of the legacy fallback.
+- no arguments: cancel only the provably current session/root scope;
+- `--force`: same scope, plus exact-session native-stop cleanup;
+- `--all`: reject without mutation;
+- unknown or multiple flags: reject without mutation.
 
-Every `state_clear` command honors the `session_id` argument, so even force mode still uses the session-aware paths first before deleting legacy files.
+### State discovery
 
-Legacy compatibility list (removed only under `--force`/`--all`):
-- `.omx/state/autopilot-state.json`
-- `.omx/state/ralph-state.json`
-- `.omx/state/ralph-plan-state.json`
-- `.omx/state/ralph-verification.json`
-- `.omx/state/ultrawork-state.json`
-- `.omx/state/ecomode-state.json`
-- `.omx/state/ultraqa-state.json`
-- `.omx/state/swarm.db`
-- `.omx/state/swarm.db-wal`
-- `.omx/state/swarm.db-shm`
-- `.omx/state/swarm-active.marker`
-- `.omx/state/swarm-tasks.db`
-- `.omx/state/ultrapilot-state.json`
-- `.omx/state/ultrapilot-ownership.json`
-- `.omx/state/pipeline-state.json`
-- `.omx/state/plan-consensus.json`
-- `.omx/state/ralplan-state.json`
-- `.omx/state/boulder.json`
-- `.omx/state/hud-state.json`
-- `.omx/state/subagent-tracking.json`
-- `.omx/state/subagent-tracker.lock`
-- `.omx/state/rate-limit-daemon.pid`
-- `.omx/state/rate-limit-daemon.log`
-- `.omx/state/checkpoints/` (directory)
-- `.omx/state/sessions/` (empty directory cleanup after clearing sessions)
-
-## Implementation Steps
-
-When you invoke this skill:
-
-### 1. Parse Arguments
-
-```bash
-# Check for --force or --all flags
-FORCE_MODE=false
-if [[ "$*" == *"--force"* ]] || [[ "$*" == *"--all"* ]]; then
-  FORCE_MODE=true
-fi
-```
-
-### 2. Detect Active Modes
-
-The skill now relies on the session-aware state contract rather than hard-coded file paths:
-1. Call `state_list_active` to enumerate `.omx/state/sessions/{sessionId}/…` and discover every active session.
-2. For each session id, call `state_get_status` to learn which mode is running (`autopilot`, `ralph`, `ultrawork`, etc.) and whether dependent modes exist.
-3. If a `session_id` was supplied to `/cancel`, skip legacy fallback entirely and operate solely within that session path; otherwise, consult legacy files in `.omx/state/*.json` only if the state tools report no active session. Swarm remains a shared SQLite/marker mode outside session scoping.
-4. Any cancellation logic in this doc mirrors the dependency order discovered via state tools (autopilot → ralph → …).
-
-### 3A. Force Mode (if --force or --all)
-
-Use force mode to clear every session plus legacy artifacts via `state_clear`. Direct file removal is reserved for legacy cleanup when the state tools report no active sessions.
+Cancellation derives writable targets from the already-proven writable scope. Compatibility discovery may inform status, but never grants write authority. Unrelated session, legacy-root, Team, and run-dir state remains untouched unless it is independently proven as the exact cancellation target.
 
 ### 3B. Smart Cancellation (default)
 
@@ -327,21 +276,20 @@ echo "  - Ralph (.omx/state/ralph-state.json)"
 echo "  - Ultrawork (.omx/state/ultrawork-state.json)"
 echo "  - UltraQA (.omx/state/ultraqa-state.json)"
 echo ""
-echo "Use --force to clear all state files anyway."
+echo "Use --force for exact-session native-stop cleanup without widening scope."
+
 ```
 
 ## Implementation Notes
 
 The cancel skill runs as follows:
-1. Parse the `--force` / `--all` flags, tracking whether cleanup should span every session or stay scoped to the current session id.
-2. Use `state_list_active` to enumerate known session ids and `state_get_status` to learn the active mode (`autopilot`, `ralph`, `ultrawork`, etc.) for each session.
-3. When operating in default mode, call `state_clear` with that session_id to remove only the session’s files, then run mode-specific cleanup (autopilot → ralph → …) based on the state tool signals.
-4. In force mode, iterate every active session, call `state_clear` per session, then run a global `state_clear` without `session_id` to drop legacy files (`.omx/state/*.json`, compatibility artifacts) and report success. Swarm remains a shared SQLite/marker mode outside session scoping.
-5. Team artifacts (`.omx/state/team/*/`, tmux sessions matching `omx-team-*`) remain best-effort cleanup items invoked during the legacy/global pass.
+1. Parse arguments strictly. Bare cancellation and a single `--force` are accepted; `--all`, unknown flags, and multiple flags fail before mutation.
+2. Resolve one writable scope and treat compatibility discovery as read-only.
+3. Cancel only active state files whose exact scope, ownership fields, and frozen file identity are proven.
+4. With `--force`, remove only the selected session's native-stop entry after the same proof and revalidation.
+5. Leave unrelated sessions, legacy compatibility roots, Team artifacts, and tmux sessions untouched.
 
-State tools always honor the `session_id` argument, so even force mode still clears the session-scoped paths before deleting compatibility-only legacy state.
-
-Mode-specific subsections below describe what extra cleanup each handler performs after the state-wide operations finish.
+Mode-specific subsections below describe same-scope dependency ordering only.
 ## Messages Reference
 
 | Mode | Success Message |

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -327,21 +327,10 @@ Mode-specific subsections below describe same-scope dependency ordering only.
 - **Safe**: Only clears linked Ultrawork, preserves standalone Ultrawork
 - **Local-only**: Clears state files in `.omx/state/` directory
 - **Resume-friendly**: Autopilot state is preserved for seamless resume
-- **Team-aware**: Detects tmux-based teams and performs graceful shutdown with force-kill fallback
+- **Team-aware**: Team cancellation is permitted only when the selected state carries exact same-scope Team authority; unrelated Team artifacts and tmux sessions remain untouched.
 
 ## Tmux Team Cleanup
 
-When cancelling team mode, the cancel skill should:
+Cancellation MUST NOT enumerate or kill every `omx-team-*` session and MUST NOT recursively delete `.omx/state/team/`. Team shutdown requires the exact frozen Team root, internal name, session, leader pane, and runtime identity selected by the authorized state transition. When that proof is unavailable or changes, cancellation fails closed without signals, pane actions, overlay edits, or Team-state deletion.
 
-1. **Kill all team tmux sessions**: `tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^omx-team-'` and kill each
-2. **Remove team state directories**: `rm -rf .omx/state/team/*/`
-3. **Strip AGENTS.md overlay**: Remove content between `<!-- OMX:TEAM:WORKER:START -->` and `<!-- OMX:TEAM:WORKER:END -->`
-
-### Force Clear Addition
-
-When `--force` is used, also clean up:
-```bash
-rm -rf .omx/state/team/                  # All team state
-# Kill all omx-team-* tmux sessions
-tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^omx-team-' | while read s; do tmux kill-session -t "$s" 2>/dev/null; done
-```
+`--force` does not widen Team scope. It only enables exact-session native-stop cleanup after the same authority checks.

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -801,6 +801,12 @@ case "$1" in
     printf 'hud-pane\n'
     exit 0
     ;;
+  list-panes)
+    session=$(cat "${activeMarker}")
+    instance=$(cat "${instanceMarker}")
+    printf '%%12\t0\t4242\t%s\t$1\t100\t%s\n' "$session" "$instance"
+    exit 0
+    ;;
   display-message)
     if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then
       printf '/tmp/tmux-test.sock\n'
@@ -858,7 +864,8 @@ exit 0
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal((tmuxLog.match(/tmux:new-session/g) || []).length, 1);
-      assert.equal((tmuxLog.match(/tmux:has-session/g) || []).length, 1);
+      assert.equal((tmuxLog.match(/tmux:has-session/g) || []).length, 0);
+      assert.ok((tmuxLog.match(/tmux:list-panes/g) || []).length >= 2);
       assert.equal((tmuxLog.match(/tmux:attach-session/g) || []).length, 2);
       const activeRecords = await readFile(
         join(runs, 'active-detached', 'boxed-context-under-test.json'),
@@ -878,6 +885,8 @@ exit 0
       const repo = await createGitRepo(wd);
       const runs = join(wd, 'runs');
       const instanceMarker = join(wd, 'active-instance');
+      const sessionMarker = join(wd, 'active-session-name');
+
       const { env, tmuxLogPath } = await createLaunchFixture(
         wd,
         (logPath) => `#!/bin/sh
@@ -891,13 +900,25 @@ case "$1" in
     exit 1
     ;;
   new-session)
+    prev=''
+    for arg in "$@"; do
+      if [ "$prev" = '-s' ]; then printf '%s' "$arg" > "${sessionMarker}"; fi
+      prev="$arg"
+    done
     printf '%%77\n'
     exit 0
     ;;
+
   split-window)
     printf '%%78\n'
     exit 0
     ;;
+  list-panes)
+    instance=$(cat "${instanceMarker}")
+    printf '%%77\t0\t4242\t%s\t$1\t100\t%s\n' "$(cat "${sessionMarker}")" "$instance"
+    exit 0
+    ;;
+
   display-message)
     if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then
       printf '/tmp/tmux-test.sock\n'
@@ -1052,6 +1073,9 @@ exit 0
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-madmax-independent-high-'));
     try {
       const runs = join(wd, 'runs');
+      const sessionMarker = join(wd, 'independent-session');
+      const instanceMarker = join(wd, 'independent-instance');
+
       const { env, tmuxLogPath } = await createLaunchFixture(
         wd,
         (logPath) => `#!/bin/sh
@@ -1059,11 +1083,14 @@ printf 'tmux:%s\n' "$*" >> "${logPath}"
 case "$1" in
   -V) printf 'tmux 3.4\n'; exit 0 ;;
   has-session) exit 1 ;;
-  new-session) printf '%%12\n'; exit 0 ;;
+  new-session) prev=''; for arg in "$@"; do if [ "$prev" = '-s' ]; then printf '%s' "$arg" > "${sessionMarker}"; fi; prev="$arg"; done; printf '%%12\n'; exit 0 ;;
+
   split-window) printf 'hud-pane\n'; exit 0 ;;
   display-message) if [ "$2" = '-p' ] && [ "$3" = '#{socket_path}' ]; then printf '/tmp/tmux-test.sock\n'; else printf '0\n'; fi; exit 0 ;;
+  list-panes) printf '%%12\t0\t4242\t%s\t$1\t100\t%s\n' "$(cat "${sessionMarker}")" "$(cat "${instanceMarker}")"; exit 0 ;;
   show-options) printf 'off\n'; exit 0 ;;
-  set-option|set-hook|attach-session|kill-session|run-shell|resize-pane) exit 0 ;;
+  set-option) if [ "$4" = '@omx_instance_id' ]; then printf '%s' "$5" > "${instanceMarker}"; fi; exit 0 ;;
+  set-hook|attach-session|kill-session|run-shell|resize-pane) exit 0 ;;
 esac
 exit 0
 `,

--- a/src/cli/__tests__/ralplan.test.ts
+++ b/src/cli/__tests__/ralplan.test.ts
@@ -17,16 +17,13 @@ async function invoke(args: string[], deps: RalplanCommandDependencies = {}) {
 }
 
 describe('#3194 ralplan CLI unsupported-only surface', () => {
-  it('fails the explicit adapted-surface preflight and neutralizes routing-only Ralplan state', async () => {
+  it('fails the explicit adapted-surface preflight without mutating Ralplan state', async () => {
     let resolved = false;
-    let cancelled = false;
     const result = await invoke(['preflight', '--json'], {
       resolveInstalledRoleName: () => { resolved = true; return 'architect'; },
-      cancelRalplan: async () => { cancelled = true; },
     });
     assert.equal(result.exitCode, 1);
     assert.equal(resolved, false);
-    assert.equal(cancelled, true);
     assert.deepEqual(result.stderr, []);
     assert.deepEqual(JSON.parse(result.stdout.join('\n')), { ok: false, reason: 'unsupported_documented_leader_proof' });
   });

--- a/src/cli/__tests__/ralplan.test.ts
+++ b/src/cli/__tests__/ralplan.test.ts
@@ -17,14 +17,27 @@ async function invoke(args: string[], deps: RalplanCommandDependencies = {}) {
 }
 
 describe('#3194 ralplan CLI unsupported-only surface', () => {
-  it('fails the explicit adapted-surface preflight without mutating Ralplan state', async () => {
+  it('fails the explicit adapted-surface preflight without unproven mutation', async () => {
     let resolved = false;
+    let neutralized = false;
     const result = await invoke(['preflight', '--json'], {
       resolveInstalledRoleName: () => { resolved = true; return 'architect'; },
+      neutralizeOwnedRoutingRalplan: async () => { neutralized = false; return false; },
     });
     assert.equal(result.exitCode, 1);
     assert.equal(resolved, false);
+    assert.equal(neutralized, false);
     assert.deepEqual(result.stderr, []);
+    assert.deepEqual(JSON.parse(result.stdout.join('\n')), { ok: false, reason: 'unsupported_documented_leader_proof' });
+  });
+
+  it('neutralizes proven-owner routing state before returning the same denial', async () => {
+    let neutralized = false;
+    const result = await invoke(['preflight', '--json'], {
+      neutralizeOwnedRoutingRalplan: async () => { neutralized = true; return true; },
+    });
+    assert.equal(result.exitCode, 1);
+    assert.equal(neutralized, true);
     assert.deepEqual(JSON.parse(result.stdout.join('\n')), { ok: false, reason: 'unsupported_documented_leader_proof' });
   });
   it('validates malformed arguments before resolving a role', async () => {

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile, readFile } from 'fs/promises';
+import { chmod, mkdir, mkdtemp, rm, symlink, writeFile, readFile } from 'fs/promises';
+
 import { existsSync } from 'fs';
 import { dirname, join } from 'path';
 import { tmpdir } from 'os';
@@ -42,6 +43,46 @@ function runOmxWithEnv(cwd: string, env: NodeJS.ProcessEnv, ...args: string[]) {
     env: cleanOmxEnv(env),
   });
 }
+
+async function createFakeTmuxBin(root: string): Promise<string> {
+  const binDir = join(root, 'bin');
+  const tmuxPath = join(binDir, 'tmux');
+  await mkdir(binDir, { recursive: true });
+  await writeFile(tmuxPath, `#!/bin/sh
+case "$1" in
+  has-session) exit 0 ;;
+  show-options) printf '%s\\n' "$FAKE_OMX_SESSION_ID" ;;
+  display-message) printf '%s\\n' "$FAKE_TMUX_SESSION_NAME" ;;
+  *) exit 1 ;;
+esac
+`);
+  await chmod(tmuxPath, 0o755);
+  return binDir;
+}
+
+async function writeActiveRunRecord(options: {
+  runsRoot: string;
+  contextKey: string;
+  sourceCwd: string;
+  runDir: string;
+  sessionId: string;
+  tmuxSessionName: string;
+}): Promise<void> {
+  const activeDir = join(options.runsRoot, 'active-detached');
+  await mkdir(activeDir, { recursive: true });
+  await writeFile(join(activeDir, `${options.contextKey}.json`), JSON.stringify({
+    version: 1,
+    context_key: options.contextKey,
+    created_at: '2026-07-19T00:00:00.000Z',
+    source_cwd: options.sourceCwd,
+    argv: ['--madmax'],
+    run_dir: options.runDir,
+    tmux_session_name: options.tmuxSessionName,
+    session_id: options.sessionId,
+    tmux_pane_id: '%42',
+  }, null, 2));
+}
+
 
 describe('CLI session-scoped state parity', () => {
   it('status and cancel include session-scoped states', async () => {
@@ -359,17 +400,143 @@ describe('CLI session-scoped state parity', () => {
     }
   });
 
+  it('keeps stale registry-only run state read-only during root cancellation', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-stale-registry-'));
+    const runsRoot = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-stale-runs-'));
+    try {
+      const sessionId = 'sess-stale-registry';
+      const runDir = join(runsRoot, 'run-stale-registry');
+      const runStateDir = join(runDir, '.omx', 'state');
+      const statePath = join(runStateDir, 'sessions', sessionId, 'autopilot-state.json');
+      const state = JSON.stringify({ active: true, mode: 'autopilot', current_phase: 'deep-interview' }, null, 2);
+      await mkdir(dirname(statePath), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(runStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(statePath, state);
+      await writeFile(join(runsRoot, 'registry.jsonl'), `${JSON.stringify({ source_cwd: wd, run_dir: runDir })}\n`);
+
+      const cancelResult = runOmxWithEnv(wd, { OMX_RUNS_DIR: runsRoot }, 'cancel');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /No active modes to cancel\./);
+      assert.equal(await readFile(statePath, 'utf-8'), state);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(runsRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a live run record whose run directory escapes through a symlink', async () => {
+    if (process.platform === 'win32') return;
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-symlink-owner-'));
+    const runsRoot = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-symlink-runs-'));
+    const outsideRoot = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-symlink-outside-'));
+    try {
+      const sessionId = 'sess-symlink-escape';
+      const tmuxSessionName = 'omx-symlink-run';
+      const linkRunDir = join(runsRoot, 'linked-run');
+      const outsideStateDir = join(outsideRoot, '.omx', 'state');
+      const statePath = join(outsideStateDir, 'sessions', sessionId, 'autopilot-state.json');
+      const state = JSON.stringify({ active: true, mode: 'autopilot', current_phase: 'deep-interview' }, null, 2);
+      const fakeBin = await createFakeTmuxBin(wd);
+      await mkdir(dirname(statePath), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(outsideStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(statePath, state);
+      await symlink(outsideRoot, linkRunDir, 'dir');
+      await writeActiveRunRecord({
+        runsRoot,
+        contextKey: 'symlink-run-context',
+        sourceCwd: wd,
+        runDir: linkRunDir,
+        sessionId,
+        tmuxSessionName,
+      });
+
+      const cancelResult = runOmxWithEnv(wd, {
+        OMX_RUNS_DIR: runsRoot,
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+        FAKE_OMX_SESSION_ID: sessionId,
+        FAKE_TMUX_SESSION_NAME: tmuxSessionName,
+      }, 'cancel');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /No active modes to cancel\./);
+      assert.equal(await readFile(statePath, 'utf-8'), state);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(runsRoot, { recursive: true, force: true });
+      await rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when multiple live run records match the same root', async () => {
+    if (process.platform === 'win32') return;
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-duplicate-owner-'));
+    const runsRoot = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-duplicate-runs-'));
+    try {
+      const sessionId = 'sess-duplicate-live';
+      const tmuxSessionName = 'omx-duplicate-run';
+      const fakeBin = await createFakeTmuxBin(wd);
+      const states: Array<{ path: string; content: string }> = [];
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      for (const [index, mode] of ['autopilot', 'ralplan'].entries()) {
+        const runDir = join(runsRoot, `run-duplicate-${index}`);
+        const runStateDir = join(runDir, '.omx', 'state');
+        const statePath = join(runStateDir, 'sessions', sessionId, `${mode}-state.json`);
+        const content = JSON.stringify({ active: true, mode, current_phase: 'executing' }, null, 2);
+        await mkdir(dirname(statePath), { recursive: true });
+        await writeFile(join(runStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+        await writeFile(statePath, content);
+        await writeActiveRunRecord({
+          runsRoot,
+          contextKey: `duplicate-run-context-${index}`,
+          sourceCwd: wd,
+          runDir,
+          sessionId,
+          tmuxSessionName,
+        });
+        states.push({ path: statePath, content });
+      }
+
+      const cancelResult = runOmxWithEnv(wd, {
+        OMX_RUNS_DIR: runsRoot,
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+        FAKE_OMX_SESSION_ID: sessionId,
+        FAKE_TMUX_SESSION_NAME: tmuxSessionName,
+      }, 'cancel');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /No active modes to cancel\./);
+      for (const state of states) {
+        assert.equal(await readFile(state.path, 'utf-8'), state.content);
+      }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(runsRoot, { recursive: true, force: true });
+    }
+  });
+
   it('cancels hook-visible run-dir session state when worktree state list-active is empty', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-cancel-worktree-'));
     const runsRoot = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-cancel-runs-'));
     try {
+      if (process.platform === 'win32') return;
       const sessionId = 'sess-run-dir-cancel';
+      const tmuxSessionName = 'omx-live-run';
       const runDir = join(runsRoot, 'run-20260610121751-b6c4');
       const runStateDir = join(runDir, '.omx', 'state');
       const runSessionDir = join(runStateDir, 'sessions', sessionId);
+      const fakeBin = await createFakeTmuxBin(wd);
+      const rootAutopilotPath = join(runStateDir, 'autopilot-state.json');
+      const rootAutopilotState = JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'stale-root-copy',
+      }, null, 2);
+
       await mkdir(runSessionDir, { recursive: true });
       await mkdir(join(wd, '.omx', 'state'), { recursive: true });
       await writeFile(join(runStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(rootAutopilotPath, rootAutopilotState);
+
       await writeFile(join(runSessionDir, 'autopilot-state.json'), JSON.stringify({
         active: true,
         mode: 'autopilot',
@@ -383,20 +550,26 @@ describe('CLI session-scoped state parity', () => {
         session_id: sessionId,
         active_skills: [{ skill: 'autopilot', phase: 'deep-interview', active: true, session_id: sessionId }],
       }, null, 2));
-      await writeFile(join(runsRoot, 'registry.jsonl'), `${JSON.stringify({
-        launcher: 'omx --madmax',
-        created_at: '2026-06-10T12:17:51.000Z',
-        cwd: runDir,
-        source_cwd: wd,
-        argv: ['codex'],
-        run_dir: runDir,
-      })}\n`);
+      await writeActiveRunRecord({
+        runsRoot,
+        contextKey: 'live-run-context',
+        sourceCwd: wd,
+        runDir,
+        sessionId,
+        tmuxSessionName,
+      });
+
 
       const listResult = runOmx(wd, 'state', 'list-active', '--json');
       assert.equal(listResult.status, 0, listResult.stderr || listResult.stdout);
       assert.deepEqual(JSON.parse(listResult.stdout), { active_modes: [] });
 
-      const cancelResult = runOmxWithEnv(wd, { OMX_RUNS_DIR: runsRoot }, 'cancel');
+      const cancelResult = runOmxWithEnv(wd, {
+        OMX_RUNS_DIR: runsRoot,
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+        FAKE_OMX_SESSION_ID: sessionId,
+        FAKE_TMUX_SESSION_NAME: tmuxSessionName,
+      }, 'cancel');
       assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
       assert.match(cancelResult.stdout, /Cancelled: autopilot/);
       assert.doesNotMatch(cancelResult.stdout, /No active modes to cancel/);
@@ -405,6 +578,7 @@ describe('CLI session-scoped state parity', () => {
       assert.equal(autopilot.active, false);
       assert.equal(autopilot.current_phase, 'cancelled');
       assert.ok(typeof autopilot.completed_at === 'string' && autopilot.completed_at.length > 0);
+      assert.equal(await readFile(rootAutopilotPath, 'utf-8'), rootAutopilotState);
 
       const skillActive = JSON.parse(await readFile(join(runSessionDir, 'skill-active-state.json'), 'utf-8'));
       assert.equal(skillActive.active, false);
@@ -467,10 +641,14 @@ describe('CLI session-scoped state parity', () => {
     const worktree = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-worktree-alias-wt-'));
     const runsRoot = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-worktree-alias-runs-'));
     try {
+      if (process.platform === 'win32') return;
+
       const sessionId = 'sess-run-dir-worktree-alias';
       const runDir = join(runsRoot, 'run-20260610121751-a11a');
       const runStateDir = join(runDir, '.omx', 'state');
       const runSessionDir = join(runStateDir, 'sessions', sessionId);
+      const fakeBin = await createFakeTmuxBin(worktree);
+
       await mkdir(runSessionDir, { recursive: true });
       await mkdir(join(worktree, '.omx', 'state'), { recursive: true });
       await mkdir(join(runsRoot, 'active-detached'), { recursive: true });
@@ -497,7 +675,12 @@ describe('CLI session-scoped state parity', () => {
       assert.equal(statusResult.status, 0, statusResult.stderr || statusResult.stdout);
       assert.match(statusResult.stdout, /autopilot: ACTIVE \(phase: deep-interview\)/);
 
-      const cancelResult = runOmxWithEnv(worktree, { OMX_RUNS_DIR: runsRoot }, 'cancel');
+      const cancelResult = runOmxWithEnv(worktree, {
+        OMX_RUNS_DIR: runsRoot,
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+        FAKE_OMX_SESSION_ID: sessionId,
+        FAKE_TMUX_SESSION_NAME: 'omx-detached',
+      }, 'cancel');
       assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
       assert.match(cancelResult.stdout, /Cancelled: autopilot/);
 

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -295,6 +295,43 @@ describe('CLI session-scoped state parity', () => {
     }
   });
 
+  it('does not cancel a foreign hook-visible run-dir from session-owned scope', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-cancel-foreign-owner-'));
+    const runsRoot = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-cancel-foreign-runs-'));
+    try {
+      const ownerSessionId = 'sess-canonical-owner';
+      const foreignSessionId = 'sess-foreign-run';
+      const stateDir = join(wd, '.omx', 'state');
+      const runDir = join(runsRoot, 'run-foreign-session');
+      const runStateDir = join(runDir, '.omx', 'state');
+      const foreignSessionDir = join(runStateDir, 'sessions', foreignSessionId);
+      const foreignStatePath = join(foreignSessionDir, 'autopilot-state.json');
+      const foreignState = JSON.stringify({
+        active: true,
+        mode: 'autopilot',
+        current_phase: 'deep-interview',
+      }, null, 2);
+      await mkdir(join(stateDir, 'sessions', ownerSessionId), { recursive: true });
+      await mkdir(foreignSessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: ownerSessionId }));
+      await writeFile(join(runStateDir, 'session.json'), JSON.stringify({ session_id: foreignSessionId }));
+      await writeFile(foreignStatePath, foreignState);
+      await writeFile(join(runsRoot, 'registry.jsonl'), `${JSON.stringify({
+        source_cwd: wd,
+        run_dir: runDir,
+      })}\n`);
+
+      const cancelResult = runOmxWithEnv(wd, { OMX_RUNS_DIR: runsRoot }, 'cancel');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /No active modes to cancel\./);
+      assert.doesNotMatch(cancelResult.stdout, /Cancelled: autopilot/);
+      assert.equal(await readFile(foreignStatePath, 'utf-8'), foreignState);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(runsRoot, { recursive: true, force: true });
+    }
+  });
+
   it('cancels hook-visible run-dir session state when worktree state list-active is empty', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-cancel-worktree-'));
     const runsRoot = await mkdtemp(join(tmpdir(), 'omx-cli-run-dir-cancel-runs-'));

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -95,6 +95,94 @@ describe('CLI session-scoped state parity', () => {
     }
   });
 
+  it('keeps root Team compatibility state read-only when current-session Ralplan owns cancellation', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-cancel-cross-mode-scope-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-ralplan-owner';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      const ralplanPath = join(sessionDir, 'ralplan-state.json');
+      const teamPath = join(stateDir, 'team-state.json');
+      const skillActivePath = join(stateDir, 'skill-active-state.json');
+      const nativeStopPath = join(stateDir, 'native-stop-state.json');
+      const ralplanState = JSON.stringify({
+        active: true,
+        mode: 'ralplan',
+        current_phase: 'executing',
+      }, null, 2);
+      const rootTeamState = JSON.stringify({
+        active: true,
+        mode: 'team',
+        current_phase: 'team-exec',
+      }, null, 2);
+      const rootSkillActiveState = JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'team',
+        phase: 'team-exec',
+        active_skills: [{ skill: 'team', phase: 'team-exec', active: true }],
+      }, null, 2);
+      const rootNativeStopState = JSON.stringify({
+        sessions: { [sessionId]: { last_signature: 'team-stop|pending' } },
+      }, null, 2);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(ralplanPath, ralplanState);
+      await writeFile(teamPath, rootTeamState);
+      await writeFile(skillActivePath, rootSkillActiveState);
+      await writeFile(nativeStopPath, rootNativeStopState);
+
+      const cancelResult = runOmx(wd, 'cancel');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /Cancelled: ralplan/);
+      assert.doesNotMatch(cancelResult.stdout, /Cancelled: team/);
+      assert.equal(JSON.parse(await readFile(ralplanPath, 'utf-8')).active, false);
+      assert.equal(await readFile(teamPath, 'utf-8'), rootTeamState);
+      assert.equal(await readFile(skillActivePath, 'utf-8'), rootSkillActiveState);
+      assert.equal(await readFile(nativeStopPath, 'utf-8'), rootNativeStopState);
+
+      await writeFile(ralplanPath, ralplanState);
+      const forceResult = runOmx(wd, 'cancel', '--force');
+      assert.equal(forceResult.status, 0, forceResult.stderr || forceResult.stdout);
+      assert.match(forceResult.stdout, /Cancelled: ralplan/);
+      assert.doesNotMatch(forceResult.stdout, /Cancelled: team/);
+      assert.equal(JSON.parse(await readFile(ralplanPath, 'utf-8')).active, false);
+      assert.equal(await readFile(teamPath, 'utf-8'), rootTeamState);
+      assert.equal(await readFile(skillActivePath, 'utf-8'), rootSkillActiveState);
+      assert.equal(await readFile(nativeStopPath, 'utf-8'), rootNativeStopState);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails Ralplan preflight without mutating unproven session state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-ralplan-preflight-scope-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-unproven-owner';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      const ralplanPath = join(sessionDir, 'ralplan-state.json');
+      const ralplanState = JSON.stringify({
+        active: true,
+        mode: 'ralplan',
+        current_phase: 'starting',
+      }, null, 2);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(ralplanPath, ralplanState);
+
+      const preflightResult = runOmx(wd, 'ralplan', 'preflight', '--json');
+      assert.equal(preflightResult.status, 1, preflightResult.stderr || preflightResult.stdout);
+      assert.deepEqual(JSON.parse(preflightResult.stdout), {
+        ok: false,
+        reason: 'unsupported_documented_leader_proof',
+      });
+      assert.equal(await readFile(ralplanPath, 'utf-8'), ralplanState);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('status does not report a root fallback mode as active after current-session clear', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-session-clear-fallback-'));
     try {

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -187,7 +187,8 @@ describe('CLI session-scoped state parity', () => {
       const foreignState = JSON.stringify({ active: true, mode: 'team', current_phase: 'team-exec' }, null, 2);
       await mkdir(dirname(ownerPath), { recursive: true });
       await mkdir(dirname(foreignPath), { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: ownerSession }));
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: ownerSession, cwd: wd, state_root: stateDir }));
+
       await writeFile(ownerPath, ownerState);
       await writeFile(foreignPath, foreignState);
 
@@ -243,7 +244,8 @@ describe('CLI session-scoped state parity', () => {
       const malformedState = '{"active":true';
       const rootTeamState = JSON.stringify({ active: true, mode: 'team', current_phase: 'team-exec' }, null, 2);
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: stateDir }));
+
       await writeFile(malformedPath, malformedState);
       await writeFile(teamPath, rootTeamState);
 
@@ -289,7 +291,8 @@ describe('CLI session-scoped state parity', () => {
         sessions: { [sessionId]: { last_signature: 'team-stop|pending' } },
       }, null, 2);
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: stateDir }));
+
       await writeFile(ralplanPath, ralplanState);
       await writeFile(teamPath, rootTeamState);
       await writeFile(skillActivePath, rootSkillActiveState);
@@ -331,7 +334,8 @@ describe('CLI session-scoped state parity', () => {
         current_phase: 'starting',
       }, null, 2);
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: stateDir }));
+
       await writeFile(ralplanPath, ralplanState);
 
       const preflightResult = runOmx(wd, 'ralplan', 'preflight', '--json');
@@ -354,7 +358,7 @@ describe('CLI session-scoped state parity', () => {
       const sessionDir = join(stateDir, 'sessions', sessionId);
       const ralplanPath = join(sessionDir, 'ralplan-state.json');
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: stateDir }));
       await writeFile(ralplanPath, JSON.stringify({
         active: true,
         mode: 'ralplan',

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -11,10 +11,27 @@ const testDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(testDir, '..', '..', '..');
 const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
 
+function cleanOmxEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const name of [
+    'OMX_ROOT',
+    'OMX_STATE_ROOT',
+    'OMX_TEAM_STATE_ROOT',
+    'OMX_SESSION_ID',
+    'CODEX_SESSION_ID',
+    'SESSION_ID',
+    'OMX_RUNS_DIR',
+  ]) {
+    delete env[name];
+  }
+  return { ...env, ...overrides };
+}
+
 function runOmx(cwd: string, ...args: string[]) {
   return spawnSync(process.execPath, [omxBin, ...args], {
     cwd,
     encoding: 'utf-8',
+    env: cleanOmxEnv(),
   });
 }
 
@@ -22,7 +39,7 @@ function runOmxWithEnv(cwd: string, env: NodeJS.ProcessEnv, ...args: string[]) {
   return spawnSync(process.execPath, [omxBin, ...args], {
     cwd,
     encoding: 'utf-8',
-    env: { ...process.env, ...env },
+    env: cleanOmxEnv(env),
   });
 }
 
@@ -90,6 +107,62 @@ describe('CLI session-scoped state parity', () => {
         JSON.parse(await readFile(nativeStopPath, 'utf-8')),
         { sessions: { [sessionId]: { last_signature: 'ralph-stop|pending' } } },
       );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores ambient Codex session aliases that do not own writable cancellation', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-cancel-codex-session-mismatch-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const ownerSession = 'owner-session';
+      const foreignSession = 'foreign-codex-session';
+      const ownerPath = join(stateDir, 'sessions', ownerSession, 'ralplan-state.json');
+      const foreignPath = join(stateDir, 'sessions', foreignSession, 'team-state.json');
+      const ownerState = JSON.stringify({ active: true, mode: 'ralplan', current_phase: 'executing' }, null, 2);
+      const foreignState = JSON.stringify({ active: true, mode: 'team', current_phase: 'team-exec' }, null, 2);
+      await mkdir(dirname(ownerPath), { recursive: true });
+      await mkdir(dirname(foreignPath), { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: ownerSession }));
+      await writeFile(ownerPath, ownerState);
+      await writeFile(foreignPath, foreignState);
+
+      for (const environmentName of ['CODEX_SESSION_ID', 'SESSION_ID']) {
+        await writeFile(ownerPath, ownerState);
+        const cancelResult = runOmxWithEnv(wd, { [environmentName]: foreignSession }, 'cancel');
+        assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+        assert.match(cancelResult.stdout, /Cancelled: ralplan/);
+        assert.doesNotMatch(cancelResult.stdout, /Cancelled: team/);
+        assert.equal(JSON.parse(await readFile(ownerPath, 'utf-8')).active, false);
+        assert.equal(await readFile(foreignPath, 'utf-8'), foreignState);
+      }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when owned session state is malformed', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-cancel-malformed-owner-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'malformed-owner';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      const malformedPath = join(sessionDir, 'ralplan-state.json');
+      const teamPath = join(stateDir, 'team-state.json');
+      const malformedState = '{"active":true';
+      const rootTeamState = JSON.stringify({ active: true, mode: 'team', current_phase: 'team-exec' }, null, 2);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(malformedPath, malformedState);
+      await writeFile(teamPath, rootTeamState);
+
+      const cancelResult = runOmx(wd, 'cancel');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /No active modes to cancel\./);
+      assert.doesNotMatch(cancelResult.stdout, /Cancelled: team/);
+      assert.equal(await readFile(malformedPath, 'utf-8'), malformedState);
+      assert.equal(await readFile(teamPath, 'utf-8'), rootTeamState);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -159,9 +159,8 @@ describe('CLI session-scoped state parity', () => {
         '--force',
       );
 
-      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.notEqual(cancelResult.status, 0);
       assert.match(cancelResult.stderr, /OMX_SESSION_ID is not bound to session\.json/);
-      assert.match(cancelResult.stdout, /No active modes to cancel\./);
       assert.deepEqual(
         JSON.parse(await readFile(ralphPath, 'utf-8')),
         { active: true, current_phase: 'executing' },
@@ -263,8 +262,31 @@ describe('CLI session-scoped state parity', () => {
       await writeFile(outsidePath, state);
       await symlink(outsidePath, join(stateDir, 'team-state.json'));
       const result = runOmx(wd, 'cancel');
-      assert.equal(result.status, 0, result.stderr || result.stdout);
-      assert.match(result.stdout, /No active modes to cancel\./);
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /non-regular state target/);
+      assert.equal(await readFile(outsidePath, 'utf-8'), state);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects symlinked session authority directories', async () => {
+    if (process.platform === 'win32') return;
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-cancel-session-root-symlink-'));
+    const outside = await mkdtemp(join(tmpdir(), 'omx-cli-cancel-session-root-outside-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'session-root-link';
+      const outsidePath = join(outside, 'ralplan-state.json');
+      const state = JSON.stringify({ active: true, mode: 'ralplan', session_id: sessionId, current_phase: 'executing' }, null, 2);
+      await mkdir(join(stateDir, 'sessions'), { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: stateDir }));
+      await writeFile(outsidePath, state);
+      await symlink(outside, join(stateDir, 'sessions', sessionId), 'dir');
+      const result = runOmx(wd, 'cancel');
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /symlinked authority component|unusable/);
       assert.equal(await readFile(outsidePath, 'utf-8'), state);
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -287,8 +309,8 @@ describe('CLI session-scoped state parity', () => {
       await writeFile(contradictoryPath, contradictory);
       await writeFile(validPath, valid);
       const result = runOmx(wd, 'cancel');
-      assert.equal(result.status, 0, result.stderr || result.stdout);
-      assert.match(result.stdout, /No active modes to cancel\./);
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /contradictory mode state/);
       assert.equal(await readFile(contradictoryPath, 'utf-8'), contradictory);
       assert.equal(await readFile(validPath, 'utf-8'), valid);
     } finally {
@@ -313,11 +335,35 @@ describe('CLI session-scoped state parity', () => {
       await writeFile(teamPath, rootTeamState);
 
       const cancelResult = runOmx(wd, 'cancel');
-      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
-      assert.match(cancelResult.stdout, /No active modes to cancel\./);
+      assert.notEqual(cancelResult.status, 0);
+      assert.match(cancelResult.stderr, /Refusing partial cancellation/);
       assert.doesNotMatch(cancelResult.stdout, /Cancelled: team/);
       assert.equal(await readFile(malformedPath, 'utf-8'), malformedState);
       assert.equal(await readFile(teamPath, 'utf-8'), rootTeamState);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies wrong-typed and nested ownership contradictions transaction-wide', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-cancel-owner-evidence-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'owner-evidence-session';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      const skillPath = join(sessionDir, 'skill-active-state.json');
+      const modePath = join(sessionDir, 'autopilot-state.json');
+      const skillState = JSON.stringify({ active: true, skill: 'autopilot', owner_codex_session_id: 42, active_skills: [{ skill: 'autopilot', active: true, owner_codex_session_id: 'foreign-owner' }] }, null, 2);
+      const modeState = JSON.stringify({ active: true, mode: 'autopilot', session_id: sessionId }, null, 2);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: stateDir }));
+      await writeFile(skillPath, skillState);
+      await writeFile(modePath, modeState);
+      const result = runOmx(wd, 'cancel');
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /contradictory owner_codex_session_id/);
+      assert.equal(await readFile(skillPath, 'utf-8'), skillState);
+      assert.equal(await readFile(modePath, 'utf-8'), modeState);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -523,8 +569,8 @@ describe('CLI session-scoped state parity', () => {
       })}\n`);
 
       const cancelResult = runOmxWithEnv(wd, { OMX_RUNS_DIR: runsRoot }, 'cancel');
-      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
-      assert.match(cancelResult.stdout, /No active modes to cancel\./);
+      assert.notEqual(cancelResult.status, 0);
+      assert.match(cancelResult.stderr, /session\.json is present but unusable/);
       assert.doesNotMatch(cancelResult.stdout, /Cancelled: autopilot/);
       assert.equal(await readFile(foreignStatePath, 'utf-8'), foreignState);
     } finally {
@@ -591,8 +637,8 @@ describe('CLI session-scoped state parity', () => {
         FAKE_OMX_SESSION_ID: sessionId,
         FAKE_TMUX_SESSION_NAME: tmuxSessionName,
       }, 'cancel');
-      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
-      assert.match(cancelResult.stdout, /No active modes to cancel\./);
+      assert.notEqual(cancelResult.status, 0);
+      assert.match(cancelResult.stderr, /detached run authority is invalid/);
       assert.equal(await readFile(statePath, 'utf-8'), state);
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -634,8 +680,8 @@ describe('CLI session-scoped state parity', () => {
           FAKE_OMX_SESSION_ID: sessionId,
           FAKE_TMUX_SESSION_NAME: tmuxSessionName,
         }, 'cancel');
-        assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
-        assert.match(cancelResult.stdout, /No active modes to cancel\./);
+        assert.notEqual(cancelResult.status, 0);
+        assert.match(cancelResult.stderr, /detached run (?:state )?authority is invalid/);
         assert.equal(await readFile(outsideStatePath, 'utf-8'), state);
       } finally {
         await rm(wd, { recursive: true, force: true });
@@ -672,8 +718,8 @@ describe('CLI session-scoped state parity', () => {
         FAKE_TMUX_COUNTER_FILE: counterPath,
         FAKE_TMUX_REPLACE_AFTER_FIRST: '1',
       }, 'cancel');
-      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
-      assert.match(cancelResult.stdout, /No active modes to cancel\./);
+      assert.notEqual(cancelResult.status, 0);
+      assert.match(cancelResult.stderr, /detached run authority changed/);
       assert.equal(await readFile(statePath, 'utf-8'), state);
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -709,8 +755,8 @@ describe('CLI session-scoped state parity', () => {
         FAKE_OMX_SESSION_ID: sessionId,
         FAKE_TMUX_SESSION_NAME: tmuxSessionName,
       }, 'cancel');
-      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
-      assert.match(cancelResult.stdout, /No active modes to cancel\./);
+      assert.notEqual(cancelResult.status, 0);
+      assert.match(cancelResult.stderr, /Refusing partial cancellation/);
       assert.equal(await readFile(validPath, 'utf-8'), validState);
       assert.equal(await readFile(malformedPath, 'utf-8'), malformedState);
     } finally {
@@ -790,8 +836,8 @@ describe('CLI session-scoped state parity', () => {
         FAKE_OMX_SESSION_ID: sessionId,
         FAKE_TMUX_SESSION_NAME: tmuxSessionName,
       }, 'cancel');
-      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
-      assert.match(cancelResult.stdout, /No active modes to cancel\./);
+      assert.notEqual(cancelResult.status, 0);
+      assert.match(cancelResult.stderr, /No active modes|multiple|authority/i);
       for (const state of states) {
         assert.equal(await readFile(state.path, 'utf-8'), state.content);
       }
@@ -1198,6 +1244,27 @@ describe('CLI session-scoped state parity', () => {
     }
   });
 
+  it('cancels linked ecomode before Ralph', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-ralph-ecomode-link-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-ecomode-link';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: stateDir }));
+      await writeFile(join(sessionDir, 'ralph-state.json'), JSON.stringify({ active: true, mode: 'ralph', session_id: sessionId, current_phase: 'executing', linked_ecomode: true }));
+      await writeFile(join(sessionDir, 'ecomode-state.json'), JSON.stringify({ active: true, mode: 'ecomode', session_id: sessionId, current_phase: 'executing' }));
+      const result = runOmx(wd, 'cancel');
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /Cancelled: ecomode/);
+      assert.match(result.stdout, /Cancelled: ralph/);
+      assert.equal(JSON.parse(await readFile(join(sessionDir, 'ecomode-state.json'), 'utf-8')).active, false);
+      assert.equal(JSON.parse(await readFile(join(sessionDir, 'ralph-state.json'), 'utf-8')).active, false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('does not mutate unrelated sessions when cancelling current session mode', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-cross-session-'));
     try {
@@ -1240,7 +1307,7 @@ describe('CLI session-scoped state parity', () => {
       const sessionId = 'sess-stale-autopilot-mirror';
       const sessionDir = join(stateDir, 'sessions', sessionId);
       await mkdir(sessionDir, { recursive: true });
-      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: stateDir }, null, 2));
       await writeFile(join(stateDir, 'autopilot-state.json'), JSON.stringify({
         active: false,
         mode: 'autopilot',

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -142,6 +142,33 @@ describe('CLI session-scoped state parity', () => {
     }
   });
 
+  it('keeps root cancellation authoritative despite ambient session aliases', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-cancel-root-ambient-session-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const foreignSession = 'foreign-ambient-session';
+      const rootPath = join(stateDir, 'team-state.json');
+      const foreignPath = join(stateDir, 'sessions', foreignSession, 'ralplan-state.json');
+      const rootState = JSON.stringify({ active: true, mode: 'team', current_phase: 'team-exec' }, null, 2);
+      const foreignState = JSON.stringify({ active: true, mode: 'ralplan', current_phase: 'executing' }, null, 2);
+      await mkdir(dirname(foreignPath), { recursive: true });
+      await writeFile(rootPath, rootState);
+      await writeFile(foreignPath, foreignState);
+
+      for (const environmentName of ['CODEX_SESSION_ID', 'SESSION_ID']) {
+        await writeFile(rootPath, rootState);
+        const cancelResult = runOmxWithEnv(wd, { [environmentName]: foreignSession }, 'cancel');
+        assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+        assert.match(cancelResult.stdout, /Cancelled: team/);
+        assert.doesNotMatch(cancelResult.stdout, /Cancelled: ralplan/);
+        assert.equal(JSON.parse(await readFile(rootPath, 'utf-8')).active, false);
+        assert.equal(await readFile(foreignPath, 'utf-8'), foreignState);
+      }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('fails closed when owned session state is malformed', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-cancel-malformed-owner-'));
     try {

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -233,6 +233,69 @@ describe('CLI session-scoped state parity', () => {
     }
   });
 
+  it('rejects unsupported cancellation flags before mutation', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-cancel-flags-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const statePath = join(stateDir, 'team-state.json');
+      const state = JSON.stringify({ active: true, mode: 'team', current_phase: 'team-exec' }, null, 2);
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(statePath, state);
+      for (const args of [['--all'], ['--unknown'], ['--force', '--all']]) {
+        const result = runOmx(wd, 'cancel', ...args);
+        assert.notEqual(result.status, 0);
+        assert.equal(await readFile(statePath, 'utf-8'), state);
+      }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects symlinked ordinary-scope state targets', async () => {
+    if (process.platform === 'win32') return;
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-cancel-root-symlink-'));
+    const outside = await mkdtemp(join(tmpdir(), 'omx-cli-cancel-root-symlink-outside-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const outsidePath = join(outside, 'team-state.json');
+      const state = JSON.stringify({ active: true, mode: 'team', current_phase: 'team-exec' }, null, 2);
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(outsidePath, state);
+      await symlink(outsidePath, join(stateDir, 'team-state.json'));
+      const result = runOmx(wd, 'cancel');
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /No active modes to cancel\./);
+      assert.equal(await readFile(outsidePath, 'utf-8'), state);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('denies contradictory selected session state transaction-wide', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-cancel-contradictory-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-contradictory';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      const contradictoryPath = join(sessionDir, 'ralplan-state.json');
+      const validPath = join(sessionDir, 'autopilot-state.json');
+      const contradictory = JSON.stringify({ active: true, mode: 'team', session_id: 'foreign', current_phase: 'team-exec' }, null, 2);
+      const valid = JSON.stringify({ active: true, mode: 'autopilot', session_id: sessionId, current_phase: 'executing' }, null, 2);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: stateDir }));
+      await writeFile(contradictoryPath, contradictory);
+      await writeFile(validPath, valid);
+      const result = runOmx(wd, 'cancel');
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /No active modes to cancel\./);
+      assert.equal(await readFile(contradictoryPath, 'utf-8'), contradictory);
+      assert.equal(await readFile(validPath, 'utf-8'), valid);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('fails closed when owned session state is malformed', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-cancel-malformed-owner-'));
     try {
@@ -357,6 +420,13 @@ describe('CLI session-scoped state parity', () => {
       const sessionId = 'sess-proven-owner';
       const sessionDir = join(stateDir, 'sessions', sessionId);
       const ralplanPath = join(sessionDir, 'ralplan-state.json');
+      const rootTeamPath = join(stateDir, 'team-state.json');
+      const rootSkillPath = join(stateDir, 'skill-active-state.json');
+      const rootStopPath = join(stateDir, 'native-stop-state.json');
+      const rootTeam = JSON.stringify({ active: true, mode: 'team', current_phase: 'team-exec' }, null, 2);
+      const rootSkill = JSON.stringify({ active: true, skill: 'team', phase: 'team-exec' }, null, 2);
+      const rootStop = JSON.stringify({ sessions: { foreign: { pending: true } } }, null, 2);
+
       await mkdir(sessionDir, { recursive: true });
       await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd, state_root: stateDir }));
       await writeFile(ralplanPath, JSON.stringify({
@@ -365,6 +435,10 @@ describe('CLI session-scoped state parity', () => {
         session_id: sessionId,
         current_phase: 'planning',
       }, null, 2));
+      await writeFile(rootTeamPath, rootTeam);
+      await writeFile(rootSkillPath, rootSkill);
+      await writeFile(rootStopPath, rootStop);
+
 
       const preflightResult = runOmxWithEnv(wd, { OMX_SESSION_ID: sessionId }, 'ralplan', 'preflight', '--json');
       assert.equal(preflightResult.status, 1, preflightResult.stderr || preflightResult.stdout);
@@ -375,6 +449,9 @@ describe('CLI session-scoped state parity', () => {
       const state = JSON.parse(await readFile(ralplanPath, 'utf-8'));
       assert.equal(state.active, false);
       assert.equal(state.current_phase, 'cancelled');
+      assert.equal(await readFile(rootTeamPath, 'utf-8'), rootTeam);
+      assert.equal(await readFile(rootSkillPath, 'utf-8'), rootSkill);
+      assert.equal(await readFile(rootStopPath, 'utf-8'), rootStop);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -25,7 +25,15 @@ function cleanOmxEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   ]) {
     delete env[name];
   }
-  return { ...env, ...overrides };
+  return {
+    ...env,
+    ...(overrides.FAKE_TMUX_SESSION_NAME ? {
+      FAKE_TMUX_PANE_PID: '4242',
+      FAKE_TMUX_INTERNAL_SESSION_ID: '$1',
+      FAKE_TMUX_SESSION_CREATED: '100',
+    } : {}),
+    ...overrides,
+  };
 }
 
 function runOmx(cwd: string, ...args: string[]) {
@@ -50,12 +58,19 @@ async function createFakeTmuxBin(root: string): Promise<string> {
   await mkdir(binDir, { recursive: true });
   await writeFile(tmuxPath, `#!/bin/sh
 case "$1" in
-  has-session) exit 0 ;;
-  show-options) printf '%s\\n' "$FAKE_OMX_SESSION_ID" ;;
-  display-message) printf '%s\\n' "$FAKE_TMUX_SESSION_NAME" ;;
+  list-panes)
+    count=0
+    if [ -n "$FAKE_TMUX_COUNTER_FILE" ] && [ -f "$FAKE_TMUX_COUNTER_FILE" ]; then count=$(cat "$FAKE_TMUX_COUNTER_FILE"); fi
+    count=$((count + 1))
+    if [ -n "$FAKE_TMUX_COUNTER_FILE" ]; then printf '%s' "$count" > "$FAKE_TMUX_COUNTER_FILE"; fi
+    created="$FAKE_TMUX_SESSION_CREATED"
+    if [ "$FAKE_TMUX_REPLACE_AFTER_FIRST" = "1" ] && [ "$count" -gt 1 ]; then created=$((created + 1)); fi
+    printf '%%42\\t0\\t%s\\t%s\\t%s\\t%s\\t%s\\n' "$FAKE_TMUX_PANE_PID" "$FAKE_TMUX_SESSION_NAME" "$FAKE_TMUX_INTERNAL_SESSION_ID" "$created" "$FAKE_OMX_SESSION_ID"
+    ;;
   *) exit 1 ;;
 esac
 `);
+
   await chmod(tmuxPath, 0o755);
   return binDir;
 }
@@ -67,6 +82,8 @@ async function writeActiveRunRecord(options: {
   runDir: string;
   sessionId: string;
   tmuxSessionName: string;
+  worktreeCwd?: string;
+
 }): Promise<void> {
   const activeDir = join(options.runsRoot, 'active-detached');
   await mkdir(activeDir, { recursive: true });
@@ -75,11 +92,16 @@ async function writeActiveRunRecord(options: {
     context_key: options.contextKey,
     created_at: '2026-07-19T00:00:00.000Z',
     source_cwd: options.sourceCwd,
+    ...(options.worktreeCwd ? { worktree_cwd: options.worktreeCwd } : {}),
+
     argv: ['--madmax'],
     run_dir: options.runDir,
     tmux_session_name: options.tmuxSessionName,
     session_id: options.sessionId,
     tmux_pane_id: '%42',
+    tmux_internal_session_id: '$1',
+    tmux_session_created: '100',
+    tmux_pane_pid: 4242,
   }, null, 2));
 }
 
@@ -324,6 +346,36 @@ describe('CLI session-scoped state parity', () => {
     }
   });
 
+  it('neutralizes exact-owner routing-only Ralplan before preflight denial', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-ralplan-preflight-owner-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-proven-owner';
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      const ralplanPath = join(sessionDir, 'ralplan-state.json');
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(ralplanPath, JSON.stringify({
+        active: true,
+        mode: 'ralplan',
+        session_id: sessionId,
+        current_phase: 'planning',
+      }, null, 2));
+
+      const preflightResult = runOmxWithEnv(wd, { OMX_SESSION_ID: sessionId }, 'ralplan', 'preflight', '--json');
+      assert.equal(preflightResult.status, 1, preflightResult.stderr || preflightResult.stdout);
+      assert.deepEqual(JSON.parse(preflightResult.stdout), {
+        ok: false,
+        reason: 'unsupported_documented_leader_proof',
+      });
+      const state = JSON.parse(await readFile(ralplanPath, 'utf-8'));
+      assert.equal(state.active, false);
+      assert.equal(state.current_phase, 'cancelled');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('status does not report a root fallback mode as active after current-session clear', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-session-clear-fallback-'));
     try {
@@ -465,6 +517,160 @@ describe('CLI session-scoped state parity', () => {
       await rm(wd, { recursive: true, force: true });
       await rm(runsRoot, { recursive: true, force: true });
       await rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects nested session-directory and state-file symlink escapes', async () => {
+    if (process.platform === 'win32') return;
+    for (const kind of ['session-dir', 'state-file'] as const) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-cli-nested-${kind}-owner-`));
+      const runsRoot = await mkdtemp(join(tmpdir(), `omx-cli-nested-${kind}-runs-`));
+      const outsideRoot = await mkdtemp(join(tmpdir(), `omx-cli-nested-${kind}-outside-`));
+      try {
+        const sessionId = `sess-nested-${kind}`;
+        const tmuxSessionName = `omx-nested-${kind}`;
+        const runDir = join(runsRoot, `run-nested-${kind}`);
+        const stateDir = join(runDir, '.omx', 'state');
+        const sessionDir = join(stateDir, 'sessions', sessionId);
+        const outsideStatePath = join(outsideRoot, 'autopilot-state.json');
+        const state = JSON.stringify({ active: true, mode: 'autopilot', current_phase: 'executing' }, null, 2);
+        const fakeBin = await createFakeTmuxBin(wd);
+        await mkdir(join(stateDir, 'sessions'), { recursive: true });
+        await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+        await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+        await writeFile(outsideStatePath, state);
+        if (kind === 'session-dir') {
+          await symlink(outsideRoot, sessionDir, 'dir');
+        } else {
+          await mkdir(sessionDir, { recursive: true });
+          await symlink(outsideStatePath, join(sessionDir, 'autopilot-state.json'));
+        }
+        await writeActiveRunRecord({ runsRoot, contextKey: `nested-${kind}`, sourceCwd: wd, runDir, sessionId, tmuxSessionName });
+
+        const cancelResult = runOmxWithEnv(wd, {
+          OMX_RUNS_DIR: runsRoot,
+          PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+          FAKE_OMX_SESSION_ID: sessionId,
+          FAKE_TMUX_SESSION_NAME: tmuxSessionName,
+        }, 'cancel');
+        assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+        assert.match(cancelResult.stdout, /No active modes to cancel\./);
+        assert.equal(await readFile(outsideStatePath, 'utf-8'), state);
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+        await rm(runsRoot, { recursive: true, force: true });
+        await rm(outsideRoot, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('revalidates frozen tmux incarnation immediately before mutation', async () => {
+    if (process.platform === 'win32') return;
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-run-toctou-owner-'));
+    const runsRoot = await mkdtemp(join(tmpdir(), 'omx-cli-run-toctou-runs-'));
+    try {
+      const sessionId = 'sess-run-toctou';
+      const tmuxSessionName = 'omx-run-toctou';
+      const runDir = join(runsRoot, 'run-toctou');
+      const stateDir = join(runDir, '.omx', 'state');
+      const statePath = join(stateDir, 'sessions', sessionId, 'autopilot-state.json');
+      const state = JSON.stringify({ active: true, mode: 'autopilot', current_phase: 'executing' }, null, 2);
+      const counterPath = join(wd, 'tmux-count');
+      const fakeBin = await createFakeTmuxBin(wd);
+      await mkdir(dirname(statePath), { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(statePath, state);
+      await writeActiveRunRecord({ runsRoot, contextKey: 'toctou-run', sourceCwd: wd, runDir, sessionId, tmuxSessionName });
+
+      const cancelResult = runOmxWithEnv(wd, {
+        OMX_RUNS_DIR: runsRoot,
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+        FAKE_OMX_SESSION_ID: sessionId,
+        FAKE_TMUX_SESSION_NAME: tmuxSessionName,
+        FAKE_TMUX_COUNTER_FILE: counterPath,
+        FAKE_TMUX_REPLACE_AFTER_FIRST: '1',
+      }, 'cancel');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /No active modes to cancel\./);
+      assert.equal(await readFile(statePath, 'utf-8'), state);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(runsRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('denies the entire run transaction when one candidate state is malformed', async () => {
+    if (process.platform === 'win32') return;
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-run-malformed-owner-'));
+    const runsRoot = await mkdtemp(join(tmpdir(), 'omx-cli-run-malformed-runs-'));
+    try {
+      const sessionId = 'sess-run-malformed';
+      const tmuxSessionName = 'omx-run-malformed';
+      const runDir = join(runsRoot, 'run-malformed');
+      const stateDir = join(runDir, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      const validPath = join(sessionDir, 'ralplan-state.json');
+      const malformedPath = join(sessionDir, 'autopilot-state.json');
+      const validState = JSON.stringify({ active: true, mode: 'ralplan', current_phase: 'executing' }, null, 2);
+      const malformedState = '{"active":true';
+      const fakeBin = await createFakeTmuxBin(wd);
+      await mkdir(sessionDir, { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(validPath, validState);
+      await writeFile(malformedPath, malformedState);
+      await writeActiveRunRecord({ runsRoot, contextKey: 'malformed-run', sourceCwd: wd, runDir, sessionId, tmuxSessionName });
+
+      const cancelResult = runOmxWithEnv(wd, {
+        OMX_RUNS_DIR: runsRoot,
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+        FAKE_OMX_SESSION_ID: sessionId,
+        FAKE_TMUX_SESSION_NAME: tmuxSessionName,
+      }, 'cancel');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /No active modes to cancel\./);
+      assert.equal(await readFile(validPath, 'utf-8'), validState);
+      assert.equal(await readFile(malformedPath, 'utf-8'), malformedState);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(runsRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the authorized run session for force native-stop cleanup', async () => {
+    if (process.platform === 'win32') return;
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-run-force-owner-'));
+    const runsRoot = await mkdtemp(join(tmpdir(), 'omx-cli-run-force-runs-'));
+    try {
+      const sessionId = 'sess-run-force';
+      const tmuxSessionName = 'omx-run-force';
+      const runDir = join(runsRoot, 'run-force');
+      const stateDir = join(runDir, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      const modePath = join(sessionDir, 'autopilot-state.json');
+      const stopPath = join(sessionDir, 'native-stop-state.json');
+      const fakeBin = await createFakeTmuxBin(wd);
+      await mkdir(sessionDir, { recursive: true });
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId }));
+      await writeFile(modePath, JSON.stringify({ active: true, mode: 'autopilot', current_phase: 'executing' }));
+      await writeFile(stopPath, JSON.stringify({ sessions: { [sessionId]: { pending: true }, foreign: { pending: true } } }, null, 2));
+      await writeActiveRunRecord({ runsRoot, contextKey: 'force-run', sourceCwd: wd, runDir, sessionId, tmuxSessionName });
+
+      const cancelResult = runOmxWithEnv(wd, {
+        OMX_RUNS_DIR: runsRoot,
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+        FAKE_OMX_SESSION_ID: sessionId,
+        FAKE_TMUX_SESSION_NAME: tmuxSessionName,
+      }, 'cancel', '--force');
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /Cancelled: autopilot/);
+      const stopState = JSON.parse(await readFile(stopPath, 'utf-8'));
+      assert.deepEqual(stopState.sessions, { foreign: { pending: true } });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(runsRoot, { recursive: true, force: true });
     }
   });
 
@@ -651,25 +857,22 @@ describe('CLI session-scoped state parity', () => {
 
       await mkdir(runSessionDir, { recursive: true });
       await mkdir(join(worktree, '.omx', 'state'), { recursive: true });
-      await mkdir(join(runsRoot, 'active-detached'), { recursive: true });
+
       await writeFile(join(runStateDir, 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
       await writeFile(join(runSessionDir, 'autopilot-state.json'), JSON.stringify({
         active: true,
         mode: 'autopilot',
         current_phase: 'deep-interview',
       }, null, 2));
-      await writeFile(join(runsRoot, 'active-detached', 'ctx-worktree-alias.json'), `${JSON.stringify({
-        version: 1,
-        context_key: 'ctx-worktree-alias',
-        created_at: '2026-06-10T12:17:51.000Z',
-        source_cwd: wd,
-        worktree_cwd: worktree,
-        argv: ['--madmax', '--worktree', '--tmux'],
-        run_dir: runDir,
-        tmux_session_name: 'omx-detached',
-        session_id: sessionId,
-        tmux_pane_id: '%42',
-      })}\n`);
+      await writeActiveRunRecord({
+        runsRoot,
+        contextKey: 'ctx-worktree-alias',
+        sourceCwd: wd,
+        worktreeCwd: worktree,
+        runDir,
+        sessionId,
+        tmuxSessionName: 'omx-detached',
+      });
 
       const statusResult = runOmxWithEnv(worktree, { OMX_RUNS_DIR: runsRoot }, 'status');
       assert.equal(statusResult.status, 0, statusResult.stderr || statusResult.stdout);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6868,7 +6868,15 @@ async function cancelModes(args: string[] = []): Promise<void> {
       return loaded;
     };
 
-    const preferredRefs = await listModeStateFilesWithScopePreference(cwd, writableScope.sessionId);
+    const preferredRefs: ModeStateFileRef[] = writableScope.source === "root"
+      ? (await readdir(writableScope.stateDir).catch(() => [] as string[]))
+        .filter((file) => file.endsWith("-state.json") && file !== "session.json")
+        .map((file) => ({
+          mode: file.slice(0, -"-state.json".length),
+          path: join(writableScope.stateDir, file),
+          scope: "root" as const,
+        }))
+      : await listModeStateFilesWithScopePreference(cwd, writableScope.sessionId);
     const hasPreferredSessionStateFiles = preferredRefs.some((ref) => ref.scope === "session");
     let states = await loadStates(preferredRefs);
     // Once writable ownership resolves to a session, cancellation may only write

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6882,7 +6882,11 @@ async function cancelModes(args: string[] = []): Promise<void> {
       [...entries.entries()].some(
         ([mode, entry]) => mode !== SKILL_ACTIVE_STATE_MODE && entry.state.active === true,
       );
-    if (!hasActiveWorkflowMode(states) && !hasPreferredSessionStateFiles) {
+    if (
+      writableScope.source === "root"
+      && !hasActiveWorkflowMode(states)
+      && !hasPreferredSessionStateFiles
+    ) {
       const runDirStates = await loadStates(await listHookVisibleRunDirStateRefs(cwd));
       if (hasActiveWorkflowMode(runDirStates)) states = runDirStates;
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,8 +6,9 @@
 import { execFileSync, spawn } from "child_process";
 import { basename, dirname, isAbsolute, join, posix, relative, resolve, win32 } from "path";
 
-import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "fs";
-import { copyFile, cp, lstat, mkdir, readFile, readdir, rm, stat, symlink, utimes, writeFile } from "fs/promises";
+import { chmodSync, constants as fsConstants, existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "fs";
+
+import { copyFile, cp, lstat, mkdir, open, readFile, readdir, rm, stat, symlink, utimes, writeFile } from "fs/promises";
 import { constants as osConstants, homedir } from "os";
 import { createHash, randomUUID } from "crypto";
 import {
@@ -6865,6 +6866,8 @@ async function listHookVisibleRunDirStateRefs(cwd: string): Promise<ModeStateFil
 interface AuthorizedRunStateSelection {
   refs: ModeStateFileRef[];
   sessionId: string;
+  sessionDir: string;
+
   record: MadmaxDetachedActiveRecord;
 }
 
@@ -6935,40 +6938,78 @@ async function selectAuthorizedHookVisibleRunDirState(cwd: string): Promise<Auth
       return null;
     }
   }
-  return { refs: refs.sort((a, b) => a.mode.localeCompare(b.mode)), sessionId, record };
+  return { refs: refs.sort((a, b) => a.mode.localeCompare(b.mode)), sessionId, sessionDir, record };
 }
 
 async function cancelModes(args: string[] = []): Promise<void> {
-  const { writeFile, readFile } = await import("fs/promises");
+
   const cwd = process.cwd();
   const nowIso = new Date().toISOString();
-  const force = args.includes("--force");
+  if (args.length > 1 || args.some((arg) => arg !== "--force")) {
+    const unsupported = args.find((arg) => arg !== "--force") ?? args[1] ?? "";
+    throw new Error(unsupported === "--all"
+      ? "omx cancel --all is not supported; broad workspace cancellation requires a separate command."
+      : `Unknown cancel argument: ${unsupported}`);
+  }
+  const force = args.length === 1;
   try {
     const writableScope = await resolveWritableStateScope(cwd);
-    const loadStates = async (refs: ModeStateFileRef[]) => {
+    const loadStates = async (
+      refs: ModeStateFileRef[],
+      authorityRoot: string,
+      expectedSessionId?: string,
+    ) => {
       const loaded = new Map<
-      string,
-      {
-        path: string;
-        scope: "root" | "session";
-        state: Record<string, unknown>;
-      }
-    >();
-
+        string,
+        {
+          path: string;
+          scope: "root" | "session";
+          state: Record<string, unknown>;
+          originalContent: string;
+          dev: number;
+          ino: number;
+        }
+      >();
+      const canonicalAuthorityRoot = realpathSync(authorityRoot);
       for (const ref of refs) {
-        const content = await readFile(ref.path, "utf-8");
+        const fileStat = lstatSync(ref.path);
+        if (!fileStat.isFile() || fileStat.isSymbolicLink()) {
+          throw new Error(`Refusing cancellation through non-regular state target ${ref.path}.`);
+        }
+        const canonicalPath = realpathSync(ref.path);
+        const canonicalParent = realpathSync(dirname(ref.path));
+        if (!isCanonicalPathWithin(canonicalAuthorityRoot, canonicalParent, true)
+          || !isCanonicalPathWithin(canonicalAuthorityRoot, canonicalPath)) {
+          throw new Error(`Refusing cancellation outside authorized state root: ${ref.path}.`);
+        }
+        const content = await readFile(canonicalPath, "utf-8");
         let parsedState: Record<string, unknown>;
         try {
-          parsedState = JSON.parse(content) as Record<string, unknown>;
+          const parsed = JSON.parse(content) as unknown;
+          if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+            throw new Error("state must be a JSON object");
+          }
+          parsedState = parsed as Record<string, unknown>;
         } catch (err) {
           logCliOperationFailure(err);
           throw new Error(`Refusing partial cancellation because ${ref.path} is malformed.`, { cause: err });
         }
-
+        if (typeof parsedState.mode === "string" && parsedState.mode !== ref.mode) {
+          throw new Error(`Refusing contradictory mode state in ${ref.path}.`);
+        }
+        for (const ownerField of ["session_id", "owner_omx_session_id"] as const) {
+          const owner = parsedState[ownerField];
+          if (typeof owner === "string" && owner !== expectedSessionId) {
+            throw new Error(`Refusing contradictory ${ownerField} in ${ref.path}.`);
+          }
+        }
         loaded.set(ref.mode, {
-          path: ref.path,
+          path: canonicalPath,
           scope: ref.scope,
           state: parsedState,
+          originalContent: content,
+          dev: fileStat.dev,
+          ino: fileStat.ino,
         });
       }
       return loaded;
@@ -6984,15 +7025,14 @@ async function cancelModes(args: string[] = []): Promise<void> {
         }))
       : await listModeStateFilesWithScopePreference(cwd, writableScope.sessionId);
     const hasPreferredSessionStateFiles = preferredRefs.some((ref) => ref.scope === "session");
+    const targetRefs = writableScope.source === "session"
+      ? preferredRefs.filter((ref) => ref.scope === "session")
+      : preferredRefs;
+
     let runSelection: AuthorizedRunStateSelection | null = null;
 
-    let states = await loadStates(preferredRefs);
-    // Once writable ownership resolves to a session, cancellation may only write
-    // that exact session directory. Root entries remain compatibility reads and
-    // malformed session state must never authorize broader mutation.
-    if (writableScope.source === "session") {
-      states = new Map([...states.entries()].filter(([, entry]) => entry.scope === "session"));
-    }
+    let states = await loadStates(targetRefs, writableScope.stateDir, writableScope.sessionId);
+
 
     const hasActiveWorkflowMode = (entries: typeof states): boolean =>
       [...entries.entries()].some(
@@ -7005,7 +7045,7 @@ async function cancelModes(args: string[] = []): Promise<void> {
     ) {
       runSelection = await selectAuthorizedHookVisibleRunDirState(cwd);
       if (runSelection) {
-        const runDirStates = await loadStates(runSelection.refs);
+        const runDirStates = await loadStates(runSelection.refs, runSelection.sessionDir, runSelection.sessionId);
         if (hasActiveWorkflowMode(runDirStates)) states = runDirStates;
         else runSelection = null;
       }
@@ -7073,11 +7113,34 @@ async function cancelModes(args: string[] = []): Promise<void> {
       }
     };
 
+    const writeFrozenEntry = async (entry: (typeof states extends Map<string, infer T> ? T : never)): Promise<void> => {
+      const handle = await open(entry.path, fsConstants.O_RDWR | fsConstants.O_NOFOLLOW);
+      try {
+        const currentStat = await handle.stat();
+        if (!currentStat.isFile() || currentStat.dev !== entry.dev || currentStat.ino !== entry.ino) {
+          throw new Error(`Refusing cancellation because state identity changed: ${entry.path}.`);
+        }
+        const currentContent = await handle.readFile({ encoding: "utf-8" });
+        if (currentContent !== entry.originalContent) {
+          throw new Error(`Refusing cancellation because state content changed: ${entry.path}.`);
+        }
+        const nextContent = JSON.stringify(entry.state, null, 2);
+        await handle.truncate(0);
+        await handle.write(nextContent, 0, "utf-8");
+        await handle.sync();
+        entry.originalContent = nextContent;
+      } finally {
+        await handle.close();
+      }
+    };
+
+
     for (const [mode, entry] of states.entries()) {
       if (!changed.has(mode)) continue;
       assertRunAuthority();
 
-      await writeFile(entry.path, JSON.stringify(entry.state, null, 2));
+      await writeFrozenEntry(entry);
+
     }
     if (force && currentSessionId) {
       assertRunAuthority();
@@ -7089,7 +7152,7 @@ async function cancelModes(args: string[] = []): Promise<void> {
         if (!sessions || !Object.prototype.hasOwnProperty.call(sessions, currentSessionId)) continue;
         delete sessions[currentSessionId];
         entry.state.sessions = sessions;
-        await writeFile(entry.path, JSON.stringify(entry.state, null, 2));
+        await writeFrozenEntry(entry);
         changed.add("native-stop");
       }
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1630,34 +1630,7 @@ function clearDetachedTmuxSessionHistoryIfUnattached(
   }
 }
 
-function readTmuxSessionInstanceId(sessionName: string): string | null {
-  try {
-    return execTmuxFileSync(
-      ["show-options", "-qv", "-t", sessionName, OMX_INSTANCE_OPTION],
-      {
-        stdio: ["ignore", "pipe", "ignore"],
-        encoding: "utf-8",
-      },
-    ).trim();
-  } catch {
-    return null;
-  }
-}
 
-function tmuxPaneBelongsToSession(paneId: string, sessionName: string): boolean {
-  try {
-    const paneSessionName = execTmuxFileSync(
-      ["display-message", "-p", "-t", paneId, "#{session_name}"],
-      {
-        stdio: ["ignore", "pipe", "ignore"],
-        encoding: "utf-8",
-      },
-    ).trim();
-    return paneSessionName === sessionName;
-  } catch {
-    return false;
-  }
-}
 
 function buildDetachedHistoryPruneHookCommand(leaderPaneId: string): string {
   // The leader pane can be gone by the time the hook fires (e.g. crashed
@@ -2410,6 +2383,10 @@ interface MadmaxDetachedActiveRecord {
   tmux_session_name: string;
   session_id?: string;
   tmux_pane_id?: string;
+  tmux_internal_session_id?: string;
+  tmux_session_created?: string;
+  tmux_pane_pid?: number;
+
 }
 
 function resolveMadmaxRunsRoot(env: NodeJS.ProcessEnv = process.env): string {
@@ -2519,6 +2496,10 @@ function readMadmaxDetachedActiveRecord(
       tmux_session_name: parsed.tmux_session_name,
       ...(typeof parsed.session_id === "string" ? { session_id: parsed.session_id } : {}),
       ...(typeof parsed.tmux_pane_id === "string" ? { tmux_pane_id: parsed.tmux_pane_id } : {}),
+      ...(typeof parsed.tmux_internal_session_id === "string" ? { tmux_internal_session_id: parsed.tmux_internal_session_id } : {}),
+      ...(typeof parsed.tmux_session_created === "string" ? { tmux_session_created: parsed.tmux_session_created } : {}),
+      ...(typeof parsed.tmux_pane_pid === "number" ? { tmux_pane_pid: parsed.tmux_pane_pid } : {}),
+
       ...(typeof parsed.worktree_cwd === "string" ? { worktree_cwd: parsed.worktree_cwd } : {}),
     };
   } catch {
@@ -2526,25 +2507,51 @@ function readMadmaxDetachedActiveRecord(
   }
 }
 
-function isReusableMadmaxDetachedActiveRecord(
-  record: MadmaxDetachedActiveRecord,
-): boolean {
-  if (!detachedTmuxSessionExists(record.tmux_session_name)) return false;
-  if (!record.session_id || !record.tmux_pane_id) return false;
-  if (readTmuxSessionInstanceId(record.tmux_session_name) !== record.session_id) {
-    return false;
-  }
-  return tmuxPaneBelongsToSession(record.tmux_pane_id, record.tmux_session_name);
+interface MadmaxDetachedRuntimeBinding {
+  paneId: string;
+  panePid: number;
+  sessionName: string;
+  internalSessionId: string;
+  sessionCreated: string;
+  omxInstanceId: string;
 }
 
-function detachedTmuxSessionExists(sessionName: string): boolean {
+function queryMadmaxDetachedRuntimeBinding(record: MadmaxDetachedActiveRecord): MadmaxDetachedRuntimeBinding | null {
+  if (!record.tmux_pane_id || !record.session_id) return null;
   try {
-    execTmuxFileSync(["has-session", "-t", sessionName], { stdio: "ignore" });
-    return true;
+    const output = execTmuxFileSync([
+      "list-panes", "-a", "-F",
+      "#{pane_id}\t#{pane_dead}\t#{pane_pid}\t#{session_name}\t#{session_id}\t#{session_created}\t#{@omx_instance_id}",
+    ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] });
+    let binding: MadmaxDetachedRuntimeBinding | null = null;
+    const seen = new Set<string>();
+    for (const line of output.split("\n").filter(Boolean)) {
+      const fields = line.split("\t");
+      if (fields.length !== 7) return null;
+      const [paneId, dead, panePidRaw, sessionName, internalSessionId, sessionCreated, omxInstanceId] = fields;
+      const panePid = Number(panePidRaw);
+      if (!/^%[0-9]+$/.test(paneId) || seen.has(paneId) || (dead !== "0" && dead !== "1")
+        || !Number.isSafeInteger(panePid) || panePid <= 0 || !sessionName
+        || !/^\$[0-9]+$/.test(internalSessionId) || !/^[0-9]+$/.test(sessionCreated)) return null;
+      seen.add(paneId);
+      if (paneId !== record.tmux_pane_id) continue;
+      if (dead !== "0" || sessionName !== record.tmux_session_name || omxInstanceId !== record.session_id) return null;
+      binding = { paneId, panePid, sessionName, internalSessionId, sessionCreated, omxInstanceId };
+    }
+    return binding;
   } catch {
-    return false;
+    return null;
   }
 }
+
+function isReusableMadmaxDetachedActiveRecord(record: MadmaxDetachedActiveRecord): boolean {
+  const binding = queryMadmaxDetachedRuntimeBinding(record);
+  return !!binding
+    && binding.panePid === record.tmux_pane_pid
+    && binding.internalSessionId === record.tmux_internal_session_id
+    && binding.sessionCreated === record.tmux_session_created;
+}
+
 
 function readMadmaxDetachedLockOwner(lockPath: string): MadmaxDetachedLockOwner | null {
   try {
@@ -5683,21 +5690,31 @@ function runCodex(
             if (leaderPaneId) {
               detachedLeaderPaneId = leaderPaneId;
               setDetachedTmuxSessionHistoryLimit(sessionName, leaderPaneId);
-              if (activeRecordPath && contextKey) {
-                writeMadmaxDetachedActiveRecord(activeRecordPath, {
-                  version: 1,
-                  context_key: contextKey,
-                  created_at: new Date().toISOString(),
-                  source_cwd: runtimeContext?.sourceCwd ?? process.env.OMX_SOURCE_CWD ?? cwd,
-                  ...(runtimeContext?.worktreeCwd ? { worktree_cwd: runtimeContext.worktreeCwd } : {}),
-                  argv: args,
-                  run_dir: runtimeContext?.omxRoot ?? process.env.OMX_ROOT ?? cwd,
-                  tmux_session_name: sessionName,
-                  session_id: sessionId,
-                  tmux_pane_id: leaderPaneId,
-                });
-              }
+
               writeDetachedSessionBinding(leaderPaneId);
+            }
+          }
+          if (step.name === "tag-session" && detachedLeaderPaneId && activeRecordPath && contextKey) {
+            const record: MadmaxDetachedActiveRecord = {
+              version: 1,
+              context_key: contextKey,
+              created_at: new Date().toISOString(),
+              source_cwd: runtimeContext?.sourceCwd ?? process.env.OMX_SOURCE_CWD ?? cwd,
+              ...(runtimeContext?.worktreeCwd ? { worktree_cwd: runtimeContext.worktreeCwd } : {}),
+              argv: args,
+              run_dir: runtimeContext?.omxRoot ?? process.env.OMX_ROOT ?? cwd,
+              tmux_session_name: sessionName,
+              session_id: sessionId,
+              tmux_pane_id: detachedLeaderPaneId,
+            };
+            const binding = queryMadmaxDetachedRuntimeBinding(record);
+            if (binding) {
+              writeMadmaxDetachedActiveRecord(activeRecordPath, {
+                ...record,
+                tmux_internal_session_id: binding.internalSessionId,
+                tmux_session_created: binding.sessionCreated,
+                tmux_pane_pid: binding.panePid,
+              });
             }
           }
           if (step.name === "split-and-capture-hud-pane") {
@@ -6845,7 +6862,19 @@ async function listHookVisibleRunDirStateRefs(cwd: string): Promise<ModeStateFil
   return refs.sort((a, b) => a.mode.localeCompare(b.mode));
 }
 
-async function listAuthorizedHookVisibleRunDirStateRefs(cwd: string): Promise<ModeStateFileRef[]> {
+interface AuthorizedRunStateSelection {
+  refs: ModeStateFileRef[];
+  sessionId: string;
+  record: MadmaxDetachedActiveRecord;
+}
+
+function isCanonicalPathWithin(parent: string, child: string, allowEqual = false): boolean {
+  const rel = relative(parent, child);
+  if (rel === "") return allowEqual;
+  return rel !== ".." && !rel.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) && !isAbsolute(rel);
+}
+
+async function selectAuthorizedHookVisibleRunDirState(cwd: string): Promise<AuthorizedRunStateSelection | null> {
   const runsRoot = resolveMadmaxRunsRoot(process.env);
   const activeDir = join(runsRoot, MADMAX_DETACHED_ACTIVE_DIR);
   const canonicalCwd = canonicalizePathForRunDirMatch(cwd);
@@ -6853,55 +6882,60 @@ async function listAuthorizedHookVisibleRunDirStateRefs(cwd: string): Promise<Mo
   try {
     canonicalRunsRoot = realpathSync(resolve(runsRoot));
   } catch {
-    return [];
+    return null;
   }
 
-  const candidates: Array<{ runDir: string; sessionId: string }> = [];
+  const candidates: Array<{ sessionDir: string; sessionId: string; record: MadmaxDetachedActiveRecord }> = [];
+
   const files = await readdir(activeDir).catch(() => [] as string[]);
   for (const file of files) {
     if (!file.endsWith(".json")) continue;
     const record = readMadmaxDetachedActiveRecord(join(activeDir, file));
     if (!record || file !== `${record.context_key}.json`) continue;
+    if (!record.session_id || normalizeSessionId(record.session_id) !== record.session_id) continue;
     if (!isReusableMadmaxDetachedActiveRecord(record)) continue;
     if (
       canonicalizePathForRunDirMatch(record.source_cwd) !== canonicalCwd
       && (!record.worktree_cwd || canonicalizePathForRunDirMatch(record.worktree_cwd) !== canonicalCwd)
     ) continue;
-    if (!record.session_id) continue;
 
-    let canonicalRunDir: string;
     try {
-      canonicalRunDir = realpathSync(resolve(record.run_dir));
-    } catch {
-      continue;
-    }
-    const runRelative = relative(canonicalRunsRoot, canonicalRunDir);
-    if (runRelative === ".." || runRelative.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute(runRelative)) {
-      continue;
-    }
-
-    const stateDir = join(canonicalRunDir, ".omx", "state");
-    try {
+      const canonicalRunDir = realpathSync(resolve(record.run_dir));
+      if (!isCanonicalPathWithin(canonicalRunsRoot, canonicalRunDir)) continue;
+      const stateDir = realpathSync(join(canonicalRunDir, ".omx", "state"));
+      if (!isCanonicalPathWithin(canonicalRunDir, stateDir)) continue;
       const session = JSON.parse(await readFile(join(stateDir, "session.json"), "utf-8")) as Record<string, unknown>;
       if (session.session_id !== record.session_id) continue;
+      const sessionDir = realpathSync(join(stateDir, "sessions", record.session_id));
+      if (!isCanonicalPathWithin(stateDir, sessionDir)) continue;
+      candidates.push({ sessionDir, sessionId: record.session_id, record });
     } catch {
       continue;
     }
-    candidates.push({ runDir: canonicalRunDir, sessionId: record.session_id });
   }
 
-  if (candidates.length !== 1) return [];
-  const [{ runDir, sessionId }] = candidates;
-  const sessionDir = join(runDir, ".omx", "state", "sessions", sessionId);
+  if (candidates.length !== 1) return null;
+  const [{ sessionDir, sessionId, record }] = candidates;
+  const refs: ModeStateFileRef[] = [];
   const stateFiles = await readdir(sessionDir).catch(() => [] as string[]);
-  return stateFiles
-    .filter((file) => file.endsWith("-state.json") && file !== "session.json")
-    .map((file) => ({
-      mode: file.slice(0, -"-state.json".length),
-      path: join(sessionDir, file),
-      scope: "session" as const,
-    }))
-    .sort((a, b) => a.mode.localeCompare(b.mode));
+  for (const file of stateFiles) {
+    if (!file.endsWith("-state.json") || file === "session.json") continue;
+    const path = join(sessionDir, file);
+    try {
+      const fileStat = lstatSync(path);
+      if (!fileStat.isFile() || fileStat.isSymbolicLink()) return null;
+      const canonicalFile = realpathSync(path);
+      if (!isCanonicalPathWithin(sessionDir, canonicalFile)) return null;
+      refs.push({
+        mode: file.slice(0, -"-state.json".length),
+        path: canonicalFile,
+        scope: "session",
+      });
+    } catch {
+      return null;
+    }
+  }
+  return { refs: refs.sort((a, b) => a.mode.localeCompare(b.mode)), sessionId, record };
 }
 
 async function cancelModes(args: string[] = []): Promise<void> {
@@ -6928,8 +6962,9 @@ async function cancelModes(args: string[] = []): Promise<void> {
           parsedState = JSON.parse(content) as Record<string, unknown>;
         } catch (err) {
           logCliOperationFailure(err);
-          continue;
+          throw new Error(`Refusing partial cancellation because ${ref.path} is malformed.`, { cause: err });
         }
+
         loaded.set(ref.mode, {
           path: ref.path,
           scope: ref.scope,
@@ -6949,6 +6984,8 @@ async function cancelModes(args: string[] = []): Promise<void> {
         }))
       : await listModeStateFilesWithScopePreference(cwd, writableScope.sessionId);
     const hasPreferredSessionStateFiles = preferredRefs.some((ref) => ref.scope === "session");
+    let runSelection: AuthorizedRunStateSelection | null = null;
+
     let states = await loadStates(preferredRefs);
     // Once writable ownership resolves to a session, cancellation may only write
     // that exact session directory. Root entries remain compatibility reads and
@@ -6966,11 +7003,17 @@ async function cancelModes(args: string[] = []): Promise<void> {
       && !hasActiveWorkflowMode(states)
       && !hasPreferredSessionStateFiles
     ) {
-      const runDirStates = await loadStates(await listAuthorizedHookVisibleRunDirStateRefs(cwd));
-      if (hasActiveWorkflowMode(runDirStates)) states = runDirStates;
+      runSelection = await selectAuthorizedHookVisibleRunDirState(cwd);
+      if (runSelection) {
+        const runDirStates = await loadStates(runSelection.refs);
+        if (hasActiveWorkflowMode(runDirStates)) states = runDirStates;
+        else runSelection = null;
+      }
     }
 
-    const currentSessionId = writableScope.sessionId ?? "";
+
+    const currentSessionId = writableScope.sessionId ?? runSelection?.sessionId ?? "";
+
     const changed = new Set<string>();
     const reported = new Set<string>();
 
@@ -7024,11 +7067,20 @@ async function cancelModes(args: string[] = []): Promise<void> {
       }
     }
 
+    const assertRunAuthority = (): void => {
+      if (runSelection && !isReusableMadmaxDetachedActiveRecord(runSelection.record)) {
+        throw new Error("Refusing cancellation because detached run authority changed.");
+      }
+    };
+
     for (const [mode, entry] of states.entries()) {
       if (!changed.has(mode)) continue;
+      assertRunAuthority();
+
       await writeFile(entry.path, JSON.stringify(entry.state, null, 2));
     }
     if (force && currentSessionId) {
+      assertRunAuthority();
       const stopStateEntries = [...states.entries()].filter(([mode]) => mode === "native-stop");
       for (const [, entry] of stopStateEntries) {
         const sessions = entry.state.sessions && typeof entry.state.sessions === "object" && !Array.isArray(entry.state.sessions)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6868,24 +6868,21 @@ async function cancelModes(args: string[] = []): Promise<void> {
       return loaded;
     };
 
-    let states = await loadStates(await listModeStateFilesWithScopePreference(cwd));
-    // A current session owns cancellation once it has an active workflow mode.
-    // Root entries may still be compatibility reads, but must not be cancelled
-    // alongside a distinct active session workflow.
-    const hasActiveSessionWorkflowMode = writableScope.source === "session"
-      && [...states.entries()].some(
-        ([mode, entry]) => mode !== SKILL_ACTIVE_STATE_MODE
-          && entry.scope === "session"
-          && entry.state.active === true,
-      );
-    if (hasActiveSessionWorkflowMode) {
+    const preferredRefs = await listModeStateFilesWithScopePreference(cwd, writableScope.sessionId);
+    const hasPreferredSessionStateFiles = preferredRefs.some((ref) => ref.scope === "session");
+    let states = await loadStates(preferredRefs);
+    // Once writable ownership resolves to a session, cancellation may only write
+    // that exact session directory. Root entries remain compatibility reads and
+    // malformed session state must never authorize broader mutation.
+    if (writableScope.source === "session") {
       states = new Map([...states.entries()].filter(([, entry]) => entry.scope === "session"));
     }
+
     const hasActiveWorkflowMode = (entries: typeof states): boolean =>
       [...entries.entries()].some(
         ([mode, entry]) => mode !== SKILL_ACTIVE_STATE_MODE && entry.state.active === true,
       );
-    if (!hasActiveWorkflowMode(states)) {
+    if (!hasActiveWorkflowMode(states) && !hasPreferredSessionStateFiles) {
       const runDirStates = await loadStates(await listHookVisibleRunDirStateRefs(cwd));
       if (hasActiveWorkflowMode(runDirStates)) states = runDirStates;
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6904,20 +6904,27 @@ async function selectAuthorizedHookVisibleRunDirState(cwd: string): Promise<Auth
 
     try {
       const canonicalRunDir = realpathSync(resolve(record.run_dir));
-      if (!isCanonicalPathWithin(canonicalRunsRoot, canonicalRunDir)) continue;
+      if (!isCanonicalPathWithin(canonicalRunsRoot, canonicalRunDir)) {
+        throw new Error("run directory escapes the authorized runs root");
+      }
       const stateDir = realpathSync(join(canonicalRunDir, ".omx", "state"));
-      if (!isCanonicalPathWithin(canonicalRunDir, stateDir)) continue;
+      if (!isCanonicalPathWithin(canonicalRunDir, stateDir)) {
+        throw new Error("state directory escapes the authorized run directory");
+      }
       const session = JSON.parse(await readFile(join(stateDir, "session.json"), "utf-8")) as Record<string, unknown>;
-      if (session.session_id !== record.session_id) continue;
+      if (session.session_id !== record.session_id) throw new Error("run session pointer changed");
       const sessionDir = realpathSync(join(stateDir, "sessions", record.session_id));
-      if (!isCanonicalPathWithin(stateDir, sessionDir)) continue;
+      if (!isCanonicalPathWithin(stateDir, sessionDir)) {
+        throw new Error("session directory escapes the authorized state directory");
+      }
       candidates.push({ sessionDir, sessionId: record.session_id, record });
-    } catch {
-      continue;
+    } catch (err) {
+      throw new Error(`Refusing cancellation because detached run authority is invalid: ${record.run_dir}.`, { cause: err });
     }
   }
 
-  if (candidates.length !== 1) return null;
+  if (candidates.length > 1) throw new Error("Refusing cancellation because multiple detached run authorities match.");
+  if (candidates.length === 0) return null;
   const [{ sessionDir, sessionId, record }] = candidates;
   const refs: ModeStateFileRef[] = [];
   const stateFiles = await readdir(sessionDir).catch(() => [] as string[]);
@@ -6926,19 +6933,78 @@ async function selectAuthorizedHookVisibleRunDirState(cwd: string): Promise<Auth
     const path = join(sessionDir, file);
     try {
       const fileStat = lstatSync(path);
-      if (!fileStat.isFile() || fileStat.isSymbolicLink()) return null;
+      if (!fileStat.isFile() || fileStat.isSymbolicLink()) {
+        throw new Error(`Refusing cancellation through non-regular run state target: ${path}.`);
+      }
       const canonicalFile = realpathSync(path);
-      if (!isCanonicalPathWithin(sessionDir, canonicalFile)) return null;
+      if (!isCanonicalPathWithin(sessionDir, canonicalFile)) {
+        throw new Error(`Refusing cancellation outside authorized run session: ${path}.`);
+      }
       refs.push({
         mode: file.slice(0, -"-state.json".length),
         path: canonicalFile,
         scope: "session",
       });
-    } catch {
-      return null;
+    } catch (err) {
+      throw new Error(`Refusing cancellation because detached run state authority is invalid: ${path}.`, { cause: err });
     }
   }
   return { refs: refs.sort((a, b) => a.mode.localeCompare(b.mode)), sessionId, sessionDir, record };
+}
+
+function assertCancellationAuthorityPath(baseStateDir: string, authorityRoot: string): string {
+  const resolvedBase = resolve(baseStateDir);
+  const resolvedAuthority = resolve(authorityRoot);
+  const baseStat = lstatSync(resolvedBase);
+  if (!baseStat.isDirectory() || baseStat.isSymbolicLink() || realpathSync(resolvedBase) !== resolvedBase) {
+    throw new Error(`Refusing cancellation through symlinked state authority root: ${baseStateDir}.`);
+  }
+  if (!isCanonicalPathWithin(resolvedBase, resolvedAuthority, true)) {
+    throw new Error(`Refusing cancellation outside base state authority: ${authorityRoot}.`);
+  }
+  let current = resolvedBase;
+  const rel = relative(resolvedBase, resolvedAuthority);
+  for (const component of rel ? rel.split(/[\\/]+/) : []) {
+    current = join(current, component);
+    const componentStat = lstatSync(current);
+    if (!componentStat.isDirectory() || componentStat.isSymbolicLink() || realpathSync(current) !== current) {
+      throw new Error(`Refusing cancellation through symlinked authority component: ${current}.`);
+    }
+  }
+  return resolvedAuthority;
+}
+
+function collectCancellationOwnerIds(baseStateDir: string, sessionId?: string): Set<string> {
+  const ownerIds = new Set<string>();
+  if (sessionId) ownerIds.add(sessionId);
+  try {
+    const pointer = JSON.parse(readFileSync(join(baseStateDir, "session.json"), "utf-8")) as Record<string, unknown>;
+    for (const field of [
+      "session_id",
+      "native_session_id",
+      "codex_session_id",
+      "owner_omx_session_id",
+      "owner_codex_session_id",
+    ]) {
+      const normalized = normalizeSessionId(pointer[field]);
+      if (normalized) ownerIds.add(normalized);
+    }
+  } catch {}
+  return ownerIds;
+}
+
+function assertCancellationOwnerMetadata(
+  value: Record<string, unknown>,
+  ownerIds: Set<string>,
+  path: string,
+): void {
+  for (const ownerField of ["session_id", "owner_omx_session_id", "owner_codex_session_id"] as const) {
+    if (!Object.prototype.hasOwnProperty.call(value, ownerField)) continue;
+    const owner = normalizeSessionId(value[ownerField]);
+    if (!owner || !ownerIds.has(owner)) {
+      throw new Error(`Refusing contradictory ${ownerField} in ${path}.`);
+    }
+  }
 }
 
 async function cancelModes(args: string[] = []): Promise<void> {
@@ -6954,10 +7020,12 @@ async function cancelModes(args: string[] = []): Promise<void> {
   const force = args.length === 1;
   try {
     const writableScope = await resolveWritableStateScope(cwd);
+    const baseStateDir = getBaseStateDir(cwd);
+    const expectedOwnerIds = collectCancellationOwnerIds(baseStateDir, writableScope.sessionId);
     const loadStates = async (
       refs: ModeStateFileRef[],
       authorityRoot: string,
-      expectedSessionId?: string,
+      ownerIds: Set<string> = expectedOwnerIds,
     ) => {
       const loaded = new Map<
         string,
@@ -6970,7 +7038,11 @@ async function cancelModes(args: string[] = []): Promise<void> {
           ino: number;
         }
       >();
-      const canonicalAuthorityRoot = realpathSync(authorityRoot);
+      if (refs.length === 0) return loaded;
+      const canonicalAuthorityRoot = assertCancellationAuthorityPath(
+        authorityRoot === writableScope.stateDir ? baseStateDir : authorityRoot,
+        authorityRoot,
+      );
       for (const ref of refs) {
         const fileStat = lstatSync(ref.path);
         if (!fileStat.isFile() || fileStat.isSymbolicLink()) {
@@ -6997,10 +7069,12 @@ async function cancelModes(args: string[] = []): Promise<void> {
         if (typeof parsedState.mode === "string" && parsedState.mode !== ref.mode) {
           throw new Error(`Refusing contradictory mode state in ${ref.path}.`);
         }
-        for (const ownerField of ["session_id", "owner_omx_session_id"] as const) {
-          const owner = parsedState[ownerField];
-          if (typeof owner === "string" && owner !== expectedSessionId) {
-            throw new Error(`Refusing contradictory ${ownerField} in ${ref.path}.`);
+        assertCancellationOwnerMetadata(parsedState, ownerIds, ref.path);
+        if (Array.isArray(parsedState.active_skills)) {
+          for (const skill of parsedState.active_skills) {
+            if (skill && typeof skill === "object" && !Array.isArray(skill)) {
+              assertCancellationOwnerMetadata(skill as Record<string, unknown>, ownerIds, `${ref.path} active_skills`);
+            }
           }
         }
         loaded.set(ref.mode, {
@@ -7031,7 +7105,7 @@ async function cancelModes(args: string[] = []): Promise<void> {
 
     let runSelection: AuthorizedRunStateSelection | null = null;
 
-    let states = await loadStates(targetRefs, writableScope.stateDir, writableScope.sessionId);
+    let states = await loadStates(targetRefs, writableScope.stateDir, expectedOwnerIds);
 
 
     const hasActiveWorkflowMode = (entries: typeof states): boolean =>
@@ -7045,7 +7119,8 @@ async function cancelModes(args: string[] = []): Promise<void> {
     ) {
       runSelection = await selectAuthorizedHookVisibleRunDirState(cwd);
       if (runSelection) {
-        const runDirStates = await loadStates(runSelection.refs, runSelection.sessionDir, runSelection.sessionId);
+        const runOwnerIds = new Set([runSelection.sessionId]);
+        const runDirStates = await loadStates(runSelection.refs, runSelection.sessionDir, runOwnerIds);
         if (hasActiveWorkflowMode(runDirStates)) states = runDirStates;
         else runSelection = null;
       }
@@ -7090,15 +7165,18 @@ async function cancelModes(args: string[] = []): Promise<void> {
       if (reportIfWasActive && wasActive && mode !== SKILL_ACTIVE_STATE_MODE) reported.add(mode);
     };
 
-    const ralphLinksUltrawork = (state: Record<string, unknown>): boolean =>
-      state.linked_ultrawork === true || state.linked_mode === "ultrawork";
+    const linkedRalphMode = (state: Record<string, unknown>): "ultrawork" | "ecomode" | undefined => {
+      if (state.linked_ultrawork === true || state.linked_mode === "ultrawork") return "ultrawork";
+      if (state.linked_ecomode === true || state.linked_mode === "ecomode") return "ecomode";
+      return undefined;
+    };
 
     const ralph = states.get("ralph");
     const hadActiveRalph = !!(ralph && ralph.state.active === true);
     if (ralph && ralph.state.active === true) {
+      const linkedMode = linkedRalphMode(ralph.state);
+      if (linkedMode) cancelMode(linkedMode, "cancelled", true);
       cancelMode("ralph", "cancelled", true);
-      if (ralphLinksUltrawork(ralph.state))
-        cancelMode("ultrawork", "cancelled", true);
     }
 
     if (!hadActiveRalph) {
@@ -7113,37 +7191,7 @@ async function cancelModes(args: string[] = []): Promise<void> {
       }
     };
 
-    const writeFrozenEntry = async (entry: (typeof states extends Map<string, infer T> ? T : never)): Promise<void> => {
-      const handle = await open(entry.path, fsConstants.O_RDWR | fsConstants.O_NOFOLLOW);
-      try {
-        const currentStat = await handle.stat();
-        if (!currentStat.isFile() || currentStat.dev !== entry.dev || currentStat.ino !== entry.ino) {
-          throw new Error(`Refusing cancellation because state identity changed: ${entry.path}.`);
-        }
-        const currentContent = await handle.readFile({ encoding: "utf-8" });
-        if (currentContent !== entry.originalContent) {
-          throw new Error(`Refusing cancellation because state content changed: ${entry.path}.`);
-        }
-        const nextContent = JSON.stringify(entry.state, null, 2);
-        await handle.truncate(0);
-        await handle.write(nextContent, 0, "utf-8");
-        await handle.sync();
-        entry.originalContent = nextContent;
-      } finally {
-        await handle.close();
-      }
-    };
-
-
-    for (const [mode, entry] of states.entries()) {
-      if (!changed.has(mode)) continue;
-      assertRunAuthority();
-
-      await writeFrozenEntry(entry);
-
-    }
     if (force && currentSessionId) {
-      assertRunAuthority();
       const stopStateEntries = [...states.entries()].filter(([mode]) => mode === "native-stop");
       for (const [, entry] of stopStateEntries) {
         const sessions = entry.state.sessions && typeof entry.state.sessions === "object" && !Array.isArray(entry.state.sessions)
@@ -7152,9 +7200,60 @@ async function cancelModes(args: string[] = []): Promise<void> {
         if (!sessions || !Object.prototype.hasOwnProperty.call(sessions, currentSessionId)) continue;
         delete sessions[currentSessionId];
         entry.state.sessions = sessions;
-        await writeFrozenEntry(entry);
         changed.add("native-stop");
       }
+    }
+
+    const orderedChanges = [...changed]
+      .sort((left, right) => {
+        if (left === "ralph") return 1;
+        if (right === "ralph") return -1;
+        return left.localeCompare(right);
+      })
+      .map((mode) => {
+        const entry = states.get(mode);
+        if (!entry) throw new Error(`Missing frozen cancellation entry for ${mode}.`);
+        return { mode, entry, nextContent: JSON.stringify(entry.state, null, 2) };
+      });
+    const opened: Array<{ mode: string; entry: (typeof states extends Map<string, infer T> ? T : never); nextContent: string; handle: Awaited<ReturnType<typeof open>> }> = [];
+    try {
+      for (const change of orderedChanges) {
+        assertRunAuthority();
+        const handle = await open(change.entry.path, fsConstants.O_RDWR | fsConstants.O_NOFOLLOW);
+        const currentStat = await handle.stat();
+        const currentContent = await handle.readFile({ encoding: "utf-8" });
+        if (!currentStat.isFile() || currentStat.dev !== change.entry.dev || currentStat.ino !== change.entry.ino) {
+          await handle.close();
+          throw new Error(`Refusing cancellation because state identity changed: ${change.entry.path}.`);
+        }
+        if (currentContent !== change.entry.originalContent) {
+          await handle.close();
+          throw new Error(`Refusing cancellation because state content changed: ${change.entry.path}.`);
+        }
+        opened.push({ ...change, handle });
+      }
+
+      const committed: typeof opened = [];
+      try {
+        for (const openedEntry of opened) {
+          assertRunAuthority();
+          committed.push(openedEntry);
+          await openedEntry.handle.truncate(0);
+          await openedEntry.handle.write(openedEntry.nextContent, 0, "utf-8");
+          await openedEntry.handle.sync();
+        }
+      } catch (writeError) {
+        for (const committedEntry of committed.reverse()) {
+          try {
+            await committedEntry.handle.truncate(0);
+            await committedEntry.handle.write(committedEntry.entry.originalContent, 0, "utf-8");
+            await committedEntry.handle.sync();
+          } catch {}
+        }
+        throw writeError;
+      }
+    } finally {
+      await Promise.all(opened.map(({ handle }) => handle.close().catch(() => undefined)));
     }
 
     for (const mode of reported) {
@@ -7166,6 +7265,6 @@ async function cancelModes(args: string[] = []): Promise<void> {
     }
   } catch (err) {
     logCliOperationFailure(err);
-    console.log("No active modes to cancel.");
+    process.exitCode = 1;
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6869,6 +6869,18 @@ async function cancelModes(args: string[] = []): Promise<void> {
     };
 
     let states = await loadStates(await listModeStateFilesWithScopePreference(cwd));
+    // A current session owns cancellation once it has an active workflow mode.
+    // Root entries may still be compatibility reads, but must not be cancelled
+    // alongside a distinct active session workflow.
+    const hasActiveSessionWorkflowMode = writableScope.source === "session"
+      && [...states.entries()].some(
+        ([mode, entry]) => mode !== SKILL_ACTIVE_STATE_MODE
+          && entry.scope === "session"
+          && entry.state.active === true,
+      );
+    if (hasActiveSessionWorkflowMode) {
+      states = new Map([...states.entries()].filter(([, entry]) => entry.scope === "session"));
+    }
     const hasActiveWorkflowMode = (entries: typeof states): boolean =>
       [...entries.entries()].some(
         ([mode, entry]) => mode !== SKILL_ACTIVE_STATE_MODE && entry.state.active === true,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,7 +4,8 @@
  */
 
 import { execFileSync, spawn } from "child_process";
-import { basename, dirname, join, posix, resolve, win32 } from "path";
+import { basename, dirname, isAbsolute, join, posix, relative, resolve, win32 } from "path";
+
 import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "fs";
 import { copyFile, cp, lstat, mkdir, readFile, readdir, rm, stat, symlink, utimes, writeFile } from "fs/promises";
 import { constants as osConstants, homedir } from "os";
@@ -6750,6 +6751,7 @@ function canonicalizePathForRunDirMatch(p: string): string {
   }
 }
 
+
 async function listHookVisibleRunDirStateRefs(cwd: string): Promise<ModeStateFileRef[]> {
   const runsRoot = resolveMadmaxRunsRoot(process.env);
   const registryPath = join(runsRoot, "registry.jsonl");
@@ -6771,16 +6773,14 @@ async function listHookVisibleRunDirStateRefs(cwd: string): Promise<ModeStateFil
 
     try {
       if (
-        canonicalizePathForRunDirMatch(sourceCwd) !== canonicalCwd &&
-        (!worktreeCwd || canonicalizePathForRunDirMatch(worktreeCwd) !== canonicalCwd)
+        canonicalizePathForRunDirMatch(sourceCwd) !== canonicalCwd
+        && (!worktreeCwd || canonicalizePathForRunDirMatch(worktreeCwd) !== canonicalCwd)
       ) return;
       const resolvedRunDir = resolve(runDir);
       if (
         resolvedRunDir !== canonicalRunsRoot
         && !resolvedRunDir.startsWith(`${canonicalRunsRoot}/`)
-      ) {
-        return;
-      }
+      ) return;
       runDirs.add(resolvedRunDir);
     } catch {
       return;
@@ -6845,6 +6845,65 @@ async function listHookVisibleRunDirStateRefs(cwd: string): Promise<ModeStateFil
   return refs.sort((a, b) => a.mode.localeCompare(b.mode));
 }
 
+async function listAuthorizedHookVisibleRunDirStateRefs(cwd: string): Promise<ModeStateFileRef[]> {
+  const runsRoot = resolveMadmaxRunsRoot(process.env);
+  const activeDir = join(runsRoot, MADMAX_DETACHED_ACTIVE_DIR);
+  const canonicalCwd = canonicalizePathForRunDirMatch(cwd);
+  let canonicalRunsRoot: string;
+  try {
+    canonicalRunsRoot = realpathSync(resolve(runsRoot));
+  } catch {
+    return [];
+  }
+
+  const candidates: Array<{ runDir: string; sessionId: string }> = [];
+  const files = await readdir(activeDir).catch(() => [] as string[]);
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    const record = readMadmaxDetachedActiveRecord(join(activeDir, file));
+    if (!record || file !== `${record.context_key}.json`) continue;
+    if (!isReusableMadmaxDetachedActiveRecord(record)) continue;
+    if (
+      canonicalizePathForRunDirMatch(record.source_cwd) !== canonicalCwd
+      && (!record.worktree_cwd || canonicalizePathForRunDirMatch(record.worktree_cwd) !== canonicalCwd)
+    ) continue;
+    if (!record.session_id) continue;
+
+    let canonicalRunDir: string;
+    try {
+      canonicalRunDir = realpathSync(resolve(record.run_dir));
+    } catch {
+      continue;
+    }
+    const runRelative = relative(canonicalRunsRoot, canonicalRunDir);
+    if (runRelative === ".." || runRelative.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute(runRelative)) {
+      continue;
+    }
+
+    const stateDir = join(canonicalRunDir, ".omx", "state");
+    try {
+      const session = JSON.parse(await readFile(join(stateDir, "session.json"), "utf-8")) as Record<string, unknown>;
+      if (session.session_id !== record.session_id) continue;
+    } catch {
+      continue;
+    }
+    candidates.push({ runDir: canonicalRunDir, sessionId: record.session_id });
+  }
+
+  if (candidates.length !== 1) return [];
+  const [{ runDir, sessionId }] = candidates;
+  const sessionDir = join(runDir, ".omx", "state", "sessions", sessionId);
+  const stateFiles = await readdir(sessionDir).catch(() => [] as string[]);
+  return stateFiles
+    .filter((file) => file.endsWith("-state.json") && file !== "session.json")
+    .map((file) => ({
+      mode: file.slice(0, -"-state.json".length),
+      path: join(sessionDir, file),
+      scope: "session" as const,
+    }))
+    .sort((a, b) => a.mode.localeCompare(b.mode));
+}
+
 async function cancelModes(args: string[] = []): Promise<void> {
   const { writeFile, readFile } = await import("fs/promises");
   const cwd = process.cwd();
@@ -6907,7 +6966,7 @@ async function cancelModes(args: string[] = []): Promise<void> {
       && !hasActiveWorkflowMode(states)
       && !hasPreferredSessionStateFiles
     ) {
-      const runDirStates = await loadStates(await listHookVisibleRunDirStateRefs(cwd));
+      const runDirStates = await loadStates(await listAuthorizedHookVisibleRunDirStateRefs(cwd));
       if (hasActiveWorkflowMode(runDirStates)) states = runDirStates;
     }
 

--- a/src/cli/ralplan.ts
+++ b/src/cli/ralplan.ts
@@ -1,5 +1,5 @@
 import { resolveInstalledRoleName } from '../subagents/tracker.js';
-import { cancelMode } from '../modes/base.js';
+
 
 export const RALPLAN_HELP = `omx ralplan - RALPLAN consensus support commands
 
@@ -24,7 +24,7 @@ export interface RalplanCommandDependencies {
   stdout?: (line: string) => void;
   stderr?: (line: string) => void;
   resolveInstalledRoleName?: typeof resolveInstalledRoleName;
-  cancelRalplan?: (cwd?: string) => Promise<void>;
+
 }
 
 export async function ralplanCommand(
@@ -40,7 +40,6 @@ export async function ralplanCommand(
   if (args[0] === 'preflight') {
     const json = args.length === 2 && args[1] === '--json';
     if ((args.length !== 1 && !json)) throw new Error(`Unknown ralplan preflight argument: ${args.slice(1).join(' ')}`);
-    await (deps.cancelRalplan ?? ((cwd?: string) => cancelMode('ralplan', cwd)))(process.cwd());
     const failure = { ok: false, reason: 'unsupported_documented_leader_proof' as const };
     if (json) stdout(JSON.stringify(failure));
     else stderr('ralplan preflight failed: unsupported_documented_leader_proof');

--- a/src/cli/ralplan.ts
+++ b/src/cli/ralplan.ts
@@ -1,9 +1,10 @@
 import { resolveInstalledRoleName } from '../subagents/tracker.js';
 import { lstat, open, readFile } from 'fs/promises';
-import { constants as fsConstants } from 'fs';
+import { constants as fsConstants, lstatSync, readFileSync, realpathSync } from 'fs';
+import { join } from 'path';
 
 
-import { getStatePath, normalizeSessionId, resolveWritableStateScope } from '../mcp/state-paths.js';
+import { getBaseStateDir, getStatePath, normalizeSessionId, resolveWritableStateScope } from '../mcp/state-paths.js';
 
 
 
@@ -71,21 +72,53 @@ export async function ralplanCommand(
   );
 }
 
+function collectRoutingOwnerIds(baseStateDir: string, canonicalSessionId: string): Set<string> {
+  const ownerIds = new Set([canonicalSessionId]);
+  try {
+    const pointerPath = join(baseStateDir, 'session.json');
+    if (realpathSync(pointerPath) !== pointerPath || !lstatSync(pointerPath).isFile()) return ownerIds;
+    const pointer = JSON.parse(readFileSync(pointerPath, 'utf-8')) as Record<string, unknown>;
+    for (const field of ['session_id', 'native_session_id', 'codex_session_id', 'owner_omx_session_id', 'owner_codex_session_id']) {
+      const ownerId = normalizeSessionId(pointer[field]);
+      if (ownerId) ownerIds.add(ownerId);
+    }
+  } catch {}
+  return ownerIds;
+}
+
+
+function hasContradictoryRoutingOwner(state: Record<string, unknown>, ownerIds: Set<string>): boolean {
+  for (const field of ['session_id', 'owner_omx_session_id', 'owner_codex_session_id']) {
+    if (!Object.prototype.hasOwnProperty.call(state, field)) continue;
+    const ownerId = normalizeSessionId(state[field]);
+    if (!ownerId || !ownerIds.has(ownerId)) return true;
+  }
+  return false;
+}
+
 async function neutralizeOwnedRoutingRalplan(cwd: string): Promise<boolean> {
   const ownerSessionId = normalizeSessionId(process.env.OMX_SESSION_ID);
   if (!ownerSessionId) return false;
   try {
     const scope = await resolveWritableStateScope(cwd);
-    if (scope.source !== 'session' || scope.sessionId !== ownerSessionId) return false;
-    const path = getStatePath('ralplan', cwd, ownerSessionId);
+    if (scope.source !== 'session' || !scope.sessionId) return false;
+    const baseStateDir = getBaseStateDir(cwd);
+    if (realpathSync(baseStateDir) !== baseStateDir) return false;
+    const sessionsDir = join(baseStateDir, 'sessions');
+    if (realpathSync(sessionsDir) !== sessionsDir || lstatSync(sessionsDir).isSymbolicLink()) return false;
+    const authorityDir = join(sessionsDir, scope.sessionId);
+    if (realpathSync(authorityDir) !== authorityDir || lstatSync(authorityDir).isSymbolicLink()) return false;
+    const ownerIds = collectRoutingOwnerIds(baseStateDir, scope.sessionId);
+    const path = getStatePath('ralplan', cwd, scope.sessionId);
     const fileStat = await lstat(path);
     if (!fileStat.isFile() || fileStat.isSymbolicLink()) return false;
     const originalContent = await readFile(path, 'utf-8');
     const state = JSON.parse(originalContent) as Record<string, unknown>;
+    if (hasContradictoryRoutingOwner(state, ownerIds)) return false;
     if (
       state.active !== true
       || state.mode !== 'ralplan'
-      || state.session_id !== ownerSessionId
+      || (state.session_id !== undefined && !ownerIds.has(normalizeSessionId(state.session_id) ?? ''))
       || state.current_phase !== 'planning'
       || state.planning_complete === true
       || state.ralplan_consensus_gate !== undefined

--- a/src/cli/ralplan.ts
+++ b/src/cli/ralplan.ts
@@ -1,4 +1,8 @@
 import { resolveInstalledRoleName } from '../subagents/tracker.js';
+import { readFile } from 'fs/promises';
+import { cancelMode } from '../modes/base.js';
+import { getStatePath, normalizeSessionId, resolveWritableStateScope } from '../mcp/state-paths.js';
+
 
 
 export const RALPLAN_HELP = `omx ralplan - RALPLAN consensus support commands
@@ -24,6 +28,8 @@ export interface RalplanCommandDependencies {
   stdout?: (line: string) => void;
   stderr?: (line: string) => void;
   resolveInstalledRoleName?: typeof resolveInstalledRoleName;
+  neutralizeOwnedRoutingRalplan?: (cwd: string) => Promise<boolean>;
+
 
 }
 
@@ -40,6 +46,8 @@ export async function ralplanCommand(
   if (args[0] === 'preflight') {
     const json = args.length === 2 && args[1] === '--json';
     if ((args.length !== 1 && !json)) throw new Error(`Unknown ralplan preflight argument: ${args.slice(1).join(' ')}`);
+    await (deps.neutralizeOwnedRoutingRalplan ?? neutralizeOwnedRoutingRalplan)(process.cwd());
+
     const failure = { ok: false, reason: 'unsupported_documented_leader_proof' as const };
     if (json) stdout(JSON.stringify(failure));
     else stderr('ralplan preflight failed: unsupported_documented_leader_proof');
@@ -59,6 +67,29 @@ export async function ralplanCommand(
     stdout,
     stderr,
   );
+}
+
+async function neutralizeOwnedRoutingRalplan(cwd: string): Promise<boolean> {
+  const ownerSessionId = normalizeSessionId(process.env.OMX_SESSION_ID);
+  if (!ownerSessionId) return false;
+  try {
+    const scope = await resolveWritableStateScope(cwd);
+    if (scope.source !== 'session' || scope.sessionId !== ownerSessionId) return false;
+    const state = JSON.parse(await readFile(getStatePath('ralplan', cwd, ownerSessionId), 'utf-8')) as Record<string, unknown>;
+    if (
+      state.active !== true
+      || state.mode !== 'ralplan'
+      || state.session_id !== ownerSessionId
+      || state.current_phase !== 'planning'
+      || state.planning_complete === true
+      || state.ralplan_consensus_gate !== undefined
+      || (typeof state.iteration === 'number' && state.iteration > 0)
+    ) return false;
+    await cancelMode('ralplan', cwd);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function parseRoleIntentWriteArgs(args: string[]): ParsedRoleIntentWriteArgs {

--- a/src/cli/ralplan.ts
+++ b/src/cli/ralplan.ts
@@ -1,6 +1,8 @@
 import { resolveInstalledRoleName } from '../subagents/tracker.js';
-import { readFile } from 'fs/promises';
-import { cancelMode } from '../modes/base.js';
+import { lstat, open, readFile } from 'fs/promises';
+import { constants as fsConstants } from 'fs';
+
+
 import { getStatePath, normalizeSessionId, resolveWritableStateScope } from '../mcp/state-paths.js';
 
 
@@ -75,7 +77,11 @@ async function neutralizeOwnedRoutingRalplan(cwd: string): Promise<boolean> {
   try {
     const scope = await resolveWritableStateScope(cwd);
     if (scope.source !== 'session' || scope.sessionId !== ownerSessionId) return false;
-    const state = JSON.parse(await readFile(getStatePath('ralplan', cwd, ownerSessionId), 'utf-8')) as Record<string, unknown>;
+    const path = getStatePath('ralplan', cwd, ownerSessionId);
+    const fileStat = await lstat(path);
+    if (!fileStat.isFile() || fileStat.isSymbolicLink()) return false;
+    const originalContent = await readFile(path, 'utf-8');
+    const state = JSON.parse(originalContent) as Record<string, unknown>;
     if (
       state.active !== true
       || state.mode !== 'ralplan'
@@ -85,8 +91,26 @@ async function neutralizeOwnedRoutingRalplan(cwd: string): Promise<boolean> {
       || state.ralplan_consensus_gate !== undefined
       || (typeof state.iteration === 'number' && state.iteration > 0)
     ) return false;
-    await cancelMode('ralplan', cwd);
-    return true;
+    const handle = await open(path, fsConstants.O_RDWR | fsConstants.O_NOFOLLOW);
+    try {
+      const currentStat = await handle.stat();
+      if (currentStat.dev !== fileStat.dev || currentStat.ino !== fileStat.ino) return false;
+      if (await handle.readFile({ encoding: 'utf-8' }) !== originalContent) return false;
+      const now = new Date().toISOString();
+      const neutralized = {
+        ...state,
+        active: false,
+        current_phase: 'cancelled',
+        completed_at: now,
+        last_turn_at: now,
+      };
+      await handle.truncate(0);
+      await handle.write(JSON.stringify(neutralized, null, 2), 0, 'utf-8');
+      await handle.sync();
+      return true;
+    } finally {
+      await handle.close();
+    }
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- restrict bare and `--force` cancellation to active state in the resolved writable session when session ownership is available
- preserve unrelated root Team compatibility state, skill mirrors, and native-stop state
- keep unsupported Ralplan preflight fail-closed without terminalizing unproven session state

## Reproduction
Fresh `origin/dev` baseline `6f969fc6` independently reproduced both failures:
- bare `omx cancel`: emitted `Cancelled: ralplan` and `Cancelled: team`, mutating both states
- `omx ralplan preflight --json`: exited 1 with `unsupported_documented_leader_proof` but changed Ralplan from active/starting to inactive/cancelled

## Verification
- `npm run build`
- `node --test dist/cli/__tests__/ralplan.test.js`
- `node --test dist/cli/__tests__/session-scoped-runtime.test.js`
- `npm run check:no-unused`
- `npm run lint`
- `npm test`
- `npm run build:full`

Closes #3134

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*