### PR TITLE
fix(session): add exact pointer lock recovery

### DIFF
--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -662,32 +662,33 @@ fi | sort
     }
   });
 
-  it('passes resume --help through to codex instead of printing top-level omx help', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-cli-'));
+  it('prints read-only resume help without launching through a hostile incomplete pointer lock', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-help-'));
     try {
       const home = join(wd, 'home');
       const fakeBin = join(wd, 'bin');
       const fakeCodexPath = join(fakeBin, 'codex');
-      const fakePsPath = join(fakeBin, 'ps');
+      const codexLog = join(wd, 'codex.log');
+      const lockPath = join(wd, '.omx', 'state', 'session.json.lock');
 
       await mkdir(home, { recursive: true });
       await mkdir(fakeBin, { recursive: true });
-      await writeFile(fakeCodexPath, '#!/bin/sh\nprintf \'fake-codex:%s\\n\' \"$*\"\n');
+      await mkdir(lockPath, { recursive: true });
+      await writeFile(join(lockPath, 'owner.incomplete.tmp'), '{"incomplete":true}\n');
+      await writeFile(fakeCodexPath, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(codexLog)}\n`);
       await chmod(fakeCodexPath, 0o755);
-      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
-      await chmod(fakePsPath, 0o755);
 
       const result = runOmx(wd, ['resume', '--help'], {
         HOME: home,
         PATH: `${fakeBin}:/usr/bin:/bin`,
         OMX_AUTO_UPDATE: '0',
-        OMX_NOTIFY_FALLBACK: '0',
-        OMX_HOOK_DERIVED_SIGNALS: '0',
       });
 
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
-      assert.match(result.stdout, /fake-codex:resume --help\b/);
-      assert.doesNotMatch(result.stdout, /Unknown command: resume/);
+      assert.match(result.stdout, /Usage: omx resume/);
+      assert.match(result.stdout, /Read-only help does not prepare or launch/i);
+      await assert.rejects(readFile(codexLog, 'utf-8'), { code: 'ENOENT' });
+      assert.equal((await readdir(lockPath)).join(','), 'owner.incomplete.tmp');
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/session-search-help.test.ts
+++ b/src/cli/__tests__/session-search-help.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
@@ -21,6 +21,15 @@ describe('omx session help', () => {
   it('documents the session search command in help output', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-help-'));
     try {
+      const lockRoot = join(cwd, '.omx', 'state');
+      const lockPath = join(lockRoot, 'session.json.lock');
+      const pointerPath = join(lockRoot, 'session.json');
+      await mkdir(lockPath, { recursive: true });
+      await writeFile(pointerPath, '{"session":"pointer-evidence"}\n', 'utf-8');
+      await writeFile(join(lockPath, 'owner.json.tmp-stalled'), '{"incomplete":true}\n', 'utf-8');
+      const pointerBefore = await readFile(pointerPath, 'utf-8');
+      const lockBefore = await readFile(join(lockPath, 'owner.json.tmp-stalled'), 'utf-8');
+
       const mainHelp = runOmx(cwd, ['--help']);
       assert.equal(mainHelp.status, 0, mainHelp.stderr || mainHelp.stdout);
       assert.match(mainHelp.stdout, /omx resume\s+Resume Codex sessions \(supports --project and --codex-home <path>\)/i);
@@ -34,6 +43,26 @@ describe('omx session help', () => {
       assert.match(sessionHelp.stdout, /Options for friction:/i);
       assert.match(sessionHelp.stdout, /--since <spec>/i);
       assert.match(sessionHelp.stdout, /--codex-home <path>/i);
+
+
+      const lockHelp = runOmx(cwd, ['session', 'lock', '--help']);
+      assert.equal(lockHelp.status, 0, lockHelp.stderr || lockHelp.stdout);
+      assert.match(lockHelp.stdout, /omx session lock <inspect\|recover>/i);
+
+      const inspection = runOmx(cwd, ['session', 'lock', 'inspect', '--cwd', cwd, '--json']);
+      assert.equal(inspection.status, 0, inspection.stderr || inspection.stdout);
+      const inspected = JSON.parse(inspection.stdout) as { lockPath: string; safeToRecover: boolean };
+      assert.equal(inspected.lockPath, lockPath);
+      assert.equal(typeof inspected.safeToRecover, 'boolean');
+      assert.equal(await readFile(pointerPath, 'utf-8'), pointerBefore);
+      assert.equal(await readFile(join(lockPath, 'owner.json.tmp-stalled'), 'utf-8'), lockBefore);
+
+      const blockedRecovery = runOmx(cwd, ['session', 'lock', 'recover', '--cwd', cwd, '--json']);
+      assert.equal(blockedRecovery.status, 1, blockedRecovery.stderr || blockedRecovery.stdout);
+      const recovery = JSON.parse(blockedRecovery.stdout) as { action: string; recovered: boolean; reason: string };
+      assert.equal(recovery.action, 'none');
+      assert.equal(recovery.recovered, false);
+      assert.match(recovery.reason, /not safe to recover/i);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -263,6 +263,7 @@ Usage:
   omx explore   DEPRECATED compatibility command; use normal repo inspection or omx sparkshell
   omx api       Run native omx-api localhost gateway commands (serve|status|stop|generate)
   omx session   Search and summarize local session history (--codex-home <path> escape hatch)
+                Includes session lock inspect/recover diagnostics
   omx url       Passive URL reader (read <url> --json)
   omx capabilities
                 Lock/check deterministic configured tool, skill, agent, and observation surfaces
@@ -460,6 +461,10 @@ type CliCommand =
   | "reasoning"
   | "codex-native-hook"
   | string;
+
+const RESUME_HELP = `Usage: omx resume [--project] [--codex-home <path>] [codex resume options]
+
+Read-only help does not prepare or launch a Codex session.`;
 
 const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "ask",
@@ -2829,9 +2834,19 @@ export async function main(args: string[]): Promise<void> {
     return;
   }
 
-  activateMadmaxIsolationIfNeeded(command, launchArgs, process.cwd(), process.env);
-
   try {
+    if (command === "session") {
+      await sessionCommand(args.slice(1));
+      return;
+    }
+
+    if (command === "resume" && launchArgs.some((arg) => arg === "--help" || arg === "-h")) {
+      console.log(RESUME_HELP);
+      return;
+    }
+
+    activateMadmaxIsolationIfNeeded(command, launchArgs, process.cwd(), process.env);
+
     switch (command) {
       case "launch":
         if (launchArgsRequestAuthHotswap(launchArgs)) {
@@ -2942,9 +2957,6 @@ export async function main(args: string[]): Promise<void> {
         break;
       case "team":
         await teamCommand(args.slice(1), options);
-        break;
-      case "session":
-        await sessionCommand(args.slice(1));
         break;
       case "url":
         await urlCommand(args.slice(1));

--- a/src/cli/session-search.ts
+++ b/src/cli/session-search.ts
@@ -1,3 +1,4 @@
+import { inspectSessionPointerLock, recoverSessionPointerLock } from '../hooks/session.js';
 import { buildSessionFrictionReport, type SessionFrictionReport, type SessionFrictionOptions } from '../session-history/friction.js';
 import { searchSessionHistory, type SessionSearchReport, type SessionSearchOptions } from '../session-history/search.js';
 
@@ -6,6 +7,7 @@ const HELP = `omx session - Search and summarize local session history
 Usage:
   omx session search <query> [options]
   omx session friction [options]
+  omx session lock <inspect|recover> [--cwd <path>] [--json]
 
 Options for search:
   --limit <n>          Maximum results to return (default: 10)
@@ -26,11 +28,18 @@ Options for friction:
   --codex-home <path>  Inspect only the supplied Codex home (escape hatch)
   --json               Emit structured JSON
 
+Options for lock:
+  --cwd <path>         Inspect or recover the session pointer lock for this directory
+  --json               Emit structured JSON
+  -h, --help           Show this help
+
 Examples:
   omx session search "worker inbox path"
   omx session search all_workers_idle --since 7d --limit 5
   omx session friction --project current
   omx session friction --session <id> --json
+  omx session lock inspect --json
+  omx session lock recover --cwd /path/to/project
 `;
 
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
@@ -45,12 +54,53 @@ export interface ParsedSessionFrictionArgs {
   json: boolean;
 }
 
+export interface ParsedSessionLockArgs {
+  cwd: string;
+  json: boolean;
+}
+
 function parsePositiveInteger(value: string, flag: string): number {
   const parsed = Number.parseInt(value, 10);
   if (!Number.isInteger(parsed) || parsed < 0) {
     throw new Error(`Invalid ${flag} value "${value}". Expected a non-negative integer.`);
   }
   return parsed;
+}
+
+export function parseSessionLockArgs(args: string[]): ParsedSessionLockArgs {
+  let cwd = process.cwd();
+  let json = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '--json') {
+      json = true;
+      continue;
+    }
+    if (token === '--cwd') {
+      const next = args[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('Missing value after --cwd.');
+      }
+      cwd = next;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith('--cwd=')) {
+      const value = token.slice('--cwd='.length);
+      if (!value) {
+        throw new Error('Missing value after --cwd.');
+      }
+      cwd = value;
+      continue;
+    }
+    if (token.startsWith('-')) {
+      throw new Error(`Unknown option: ${token}`);
+    }
+    throw new Error(`Unexpected positional argument for lock: ${token}`);
+  }
+
+  return { cwd, json };
 }
 
 export function parseSessionSearchArgs(args: string[]): ParsedSessionSearchArgs {
@@ -226,10 +276,65 @@ function formatFrictionReport(report: SessionFrictionReport): string {
 }
 
 
+function formatLockResult(result: {
+  status: string;
+  lockPath: string;
+  evidenceSource: string;
+  safeToRecover: boolean;
+  evidencePath?: string;
+  action?: string;
+  recovered?: boolean;
+  reason?: string;
+  quarantinePath?: string;
+}): string {
+  const lines = [
+    `status: ${result.status}`,
+    `lock: ${result.lockPath}`,
+    `evidence: ${result.evidenceSource}`,
+    `safe to recover: ${result.safeToRecover ? 'yes' : 'no'}`,
+  ];
+  if (result.action) lines.push(`action: ${result.action}`);
+  if (result.recovered !== undefined) lines.push(`recovered: ${result.recovered ? 'yes' : 'no'}`);
+  if (result.reason) lines.push(`reason: ${result.reason}`);
+  if (result.evidencePath) lines.push(`evidence path: ${result.evidencePath}`);
+  if (result.quarantinePath) lines.push(`quarantine: ${result.quarantinePath}`);
+  return lines.join('\n');
+}
+
+async function sessionLockCommand(args: string[]): Promise<void> {
+  const operation = args[0];
+  if (!operation || HELP_TOKENS.has(operation)) {
+    console.log(`Usage: omx session lock <inspect|recover> [--cwd <path>] [--json]`);
+    return;
+  }
+  if (operation !== 'inspect' && operation !== 'recover') {
+    throw new Error(`Unknown session lock operation: ${operation}`);
+  }
+  if (args.slice(1).some((token) => HELP_TOKENS.has(token))) {
+    console.log(`Usage: omx session lock ${operation} [--cwd <path>] [--json]`);
+    return;
+  }
+
+  const parsed = parseSessionLockArgs(args.slice(1));
+  const result = operation === 'inspect'
+    ? await inspectSessionPointerLock(parsed.cwd)
+    : await recoverSessionPointerLock(parsed.cwd);
+  console.log(parsed.json ? JSON.stringify(result, null, 2) : formatLockResult(result));
+
+  if (operation === 'recover' && result.status !== 'absent' && (!('recovered' in result) || result.recovered !== true)) {
+    process.exitCode = 1;
+  }
+}
+
 export async function sessionCommand(args: string[]): Promise<void> {
   const subcommand = args[0];
   if (!subcommand || HELP_TOKENS.has(subcommand)) {
     console.log(HELP.trim());
+    return;
+  }
+
+  if (subcommand === 'lock') {
+    await sessionLockCommand(args.slice(1));
     return;
   }
 

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -1,7 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, readdir, rename, rm, symlink, writeFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
 import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, readdir, rename, rm, rmdir, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -9,12 +11,14 @@ import {
   appendPromptSessionProvenanceRejection,
   __resetSessionPointerTransactionDependenciesForTests,
   __setSessionPointerTransactionDependenciesForTests,
+  inspectSessionPointerLock,
   isSessionPointerLaunchAbort,
   isSessionStale,
   readSessionPointer,
   readSessionState,
   readUsableSessionState,
   reconcileNativeSessionStart,
+  recoverSessionPointerLock,
   resetSessionMetrics,
   resolveSessionPointerContext,
   writeSessionEnd,
@@ -98,6 +102,16 @@ function validLockOwner(overrides: Record<string, unknown> = {}): Record<string,
     created_at: '2026-07-14T00:00:00.000Z',
     ...overrides,
   };
+}
+
+async function linuxProcessStartTicks(pid: number): Promise<number> {
+  const stat = await readFile(`/proc/${pid}/stat`, 'utf-8');
+  const closingParen = stat.lastIndexOf(')');
+  assert.notEqual(closingParen, -1);
+  const fieldsAfterCommand = stat.slice(closingParen + 2).trim().split(/\s+/);
+  const startTicks = Number.parseInt(fieldsAfterCommand[19] ?? '', 10);
+  assert.equal(Number.isInteger(startTicks), true);
+  return startTicks;
 }
 
 describe('session lifecycle manager', () => {
@@ -841,6 +855,233 @@ describe('session pointer transaction', () => {
       } finally {
         await rm(cwd, { recursive: true, force: true });
       }
+    }
+  });
+
+  it('atomically quarantines dead pre-rename temporary owner evidence and stays idempotent', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-dead-temp-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      await mkdir(context.lockPath, { recursive: true });
+      await writeFile(join(context.lockPath, `owner.${TEST_TOKEN}.tmp`), JSON.stringify(validLockOwner()), 'utf-8');
+      await withPointerDependencies({ token: () => SUCCESSOR_TOKEN, probePid: () => 'dead' }, async () => {
+        const inspected = await inspectSessionPointerLock(cwd);
+        assert.equal(inspected.status, 'dead');
+        assert.equal(inspected.evidenceSource, 'owner-temp');
+        assert.equal(inspected.safeToRecover, true);
+        const recovered = await recoverSessionPointerLock(cwd);
+        assert.equal(recovered.recovered, true);
+        assert.equal(recovered.action, 'quarantined');
+        assert.equal(existsSync(context.lockPath), false);
+        assert.equal(existsSync(recovered.quarantinePath!), true);
+        const repeated = await recoverSessionPointerLock(cwd);
+        assert.equal(repeated.recovered, false);
+        assert.equal(repeated.action, 'none');
+        assert.equal(repeated.status, 'absent');
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not recover a dead canonical owner because owner.json is not an exact acquisition claim', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-dead-canonical-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      await writeLockOwner(cwd, validLockOwner());
+      await withPointerDependencies({ token: () => SUCCESSOR_TOKEN, probePid: () => 'dead' }, async () => {
+        const recovered = await recoverSessionPointerLock(cwd);
+        assert.equal(recovered.status, 'dead');
+        assert.equal(recovered.evidenceSource, 'owner.json');
+        assert.equal(recovered.safeToRecover, false);
+        assert.equal(recovered.recovered, false);
+        assert.equal(recovered.action, 'none');
+        assert.equal(existsSync(context.lockPath), true);
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('distinguishes a paused live pre-rename owner from the same owner after SIGKILL', async (t) => {
+    if (process.platform !== 'linux') {
+      t.skip('Linux process start identity is required for deterministic PID reuse protection.');
+      return;
+    }
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-sigkill-'));
+    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1_000)'], { stdio: 'ignore' });
+    try {
+      assert.ok(child.pid);
+      await once(child, 'spawn');
+      const context = resolveSessionPointerContext(cwd);
+      await mkdir(context.lockPath, { recursive: true });
+      await writeFile(join(context.lockPath, `owner.${TEST_TOKEN}.tmp`), JSON.stringify(validLockOwner({
+        pid: child.pid,
+        pid_start_ticks: await linuxProcessStartTicks(child.pid),
+      })), 'utf-8');
+
+      const paused = await recoverSessionPointerLock(cwd);
+      assert.equal(paused.status, 'live');
+      assert.equal(paused.recovered, false);
+      assert.equal(paused.action, 'none');
+      assert.equal(existsSync(context.lockPath), true);
+
+      child.kill('SIGKILL');
+      const [exitCode, signal] = await once(child, 'exit') as [number | null, NodeJS.Signals | null];
+      assert.equal(exitCode, null);
+      assert.equal(signal, 'SIGKILL');
+
+      const orphaned = await recoverSessionPointerLock(cwd);
+      assert.equal(orphaned.status, 'dead');
+      assert.equal(orphaned.recovered, true);
+      assert.equal(orphaned.action, 'quarantined');
+      assert.equal(existsSync(context.lockPath), false);
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed for live pre-rename, PID reuse, malformed, and ambiguous lock evidence', async () => {
+    const cases: Array<{ name: string; files: Array<[string, string]>; probePid: 'alive' | 'dead'; identity?: ReturnType<typeof matchingProcessIdentity> }> = [
+      { name: 'live-temp', files: [[`owner.${TEST_TOKEN}.tmp`, JSON.stringify(validLockOwner())]], probePid: 'alive', identity: matchingProcessIdentity() },
+      { name: 'reused', files: [['owner.json', JSON.stringify(validLockOwner())]], probePid: 'alive', identity: { status: 'matching', startTicks: 2 } },
+      { name: 'malformed', files: [['owner.json', '{']], probePid: 'dead' },
+      { name: 'ambiguous', files: [['owner.json', JSON.stringify(validLockOwner())], [`owner.${SUCCESSOR_TOKEN}.tmp`, JSON.stringify(validLockOwner({ token: SUCCESSOR_TOKEN }))]], probePid: 'dead' },
+    ];
+    for (const testCase of cases) {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-session-lock-recovery-${testCase.name}-`));
+      try {
+        const context = resolveSessionPointerContext(cwd);
+        await mkdir(context.lockPath, { recursive: true });
+        await Promise.all(testCase.files.map(async ([name, contents]) => await writeFile(join(context.lockPath, name), contents, 'utf-8')));
+        await withPointerDependencies({
+          token: () => SUCCESSOR_TOKEN,
+          probePid: () => testCase.probePid,
+          readProcessIdentity: () => testCase.identity ?? matchingProcessIdentity(),
+        }, async () => {
+          const before = await readdir(context.lockPath);
+          const recovered = await recoverSessionPointerLock(cwd);
+          assert.equal(recovered.recovered, false);
+          assert.equal(recovered.action, 'none');
+          assert.equal(recovered.safeToRecover, false);
+          assert.deepEqual(await readdir(context.lockPath), before);
+        });
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('claims stale evidence before quarantine so a successor cannot be mistaken for it', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-race-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      await mkdir(context.lockPath, { recursive: true });
+      await writeFile(join(context.lockPath, `owner.${TEST_TOKEN}.tmp`), JSON.stringify(validLockOwner()), 'utf-8');
+      const renames: Array<[string, string]> = [];
+      let successorBlocked = false;
+      await withPointerDependencies({
+        token: () => SUCCESSOR_TOKEN,
+        probePid: () => 'dead',
+        fs: {
+          rename: async (from, to) => {
+            renames.push([from, to]);
+            await rename(from, to);
+            if (from.endsWith(`owner.${TEST_TOKEN}.tmp`)) {
+              await assert.rejects(mkdir(context.lockPath), { code: 'EEXIST' });
+              successorBlocked = true;
+            }
+          },
+        },
+      }, async () => {
+        const recovered = await recoverSessionPointerLock(cwd);
+        assert.equal(recovered.recovered, true);
+      });
+      assert.equal(successorBlocked, true);
+      assert.match(renames[0]![0], /owner\.transaction_token_123456\.tmp$/);
+      assert.match(renames[0]![1], new RegExp(`owner\\.${TEST_TOKEN}\\.${SUCCESSOR_TOKEN}\\.recovery$`));
+      assert.match(renames[1]![0], new RegExp(`owner\\.${TEST_TOKEN}\\.${SUCCESSOR_TOKEN}\\.recovery$`));
+      assert.equal(renames[1]![1].includes('.quarantine.'), true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not claim a successor lock when the inspected orphan is displaced before the exact temp rename', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-successor-race-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      const staleTemp = join(context.lockPath, `owner.${TEST_TOKEN}.tmp`);
+      const successorTemp = join(context.lockPath, `owner.${SUCCESSOR_TOKEN}.tmp`);
+      const displacedPath = `${context.lockPath}.displaced`;
+      await mkdir(context.lockPath, { recursive: true });
+      await writeFile(staleTemp, JSON.stringify(validLockOwner()), 'utf-8');
+      let displaced = false;
+      await withPointerDependencies({
+        token: () => SUCCESSOR_TOKEN,
+        probePid: () => 'dead',
+        fs: {
+          rename: async (from, to) => {
+            if (!displaced && from === staleTemp) {
+              displaced = true;
+              await rename(context.lockPath, displacedPath);
+              await mkdir(context.lockPath);
+              await writeFile(successorTemp, JSON.stringify(validLockOwner({ token: SUCCESSOR_TOKEN })), 'utf-8');
+            }
+            await rename(from, to);
+          },
+        },
+      }, async () => {
+        const recovered = await recoverSessionPointerLock(cwd);
+        assert.equal(recovered.recovered, false);
+        assert.equal(recovered.action, 'none');
+        assert.match(recovered.reason, /changed before recovery claim/i);
+      });
+      assert.equal(displaced, true);
+      assert.deepEqual(await readdir(context.lockPath), [`owner.${SUCCESSOR_TOKEN}.tmp`]);
+      assert.equal(await readFile(successorTemp, 'utf-8'), JSON.stringify(validLockOwner({ token: SUCCESSOR_TOKEN })));
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not quarantine a successor live lock displaced into the canonical path after claim revalidation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-post-claim-race-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      const staleTemp = join(context.lockPath, `owner.${TEST_TOKEN}.tmp`);
+      const successorTemp = join(context.lockPath, `owner.${SUCCESSOR_TOKEN}.tmp`);
+      const displacedPath = `${context.lockPath}.claimed-displaced`;
+      await mkdir(context.lockPath, { recursive: true });
+      await writeFile(staleTemp, JSON.stringify(validLockOwner()), 'utf-8');
+      let displaced = false;
+      await withPointerDependencies({
+        token: () => SUCCESSOR_TOKEN,
+        probePid: () => 'dead',
+        fs: {
+          rmdir: async (path) => {
+            if (!displaced && path === context.lockPath) {
+              displaced = true;
+              await rename(context.lockPath, displacedPath);
+              await mkdir(context.lockPath);
+              await writeFile(successorTemp, JSON.stringify(validLockOwner({ token: SUCCESSOR_TOKEN })), 'utf-8');
+            }
+            await rmdir(path);
+          },
+        },
+      }, async () => {
+        const recovered = await recoverSessionPointerLock(cwd);
+        assert.equal(recovered.recovered, false);
+        assert.equal(recovered.action, 'none');
+        assert.match(recovered.reason, /canonical lock directory was not empty/i);
+        assert.ok(recovered.quarantinePath);
+      });
+      assert.equal(displaced, true);
+      assert.deepEqual(await readdir(context.lockPath), [`owner.${SUCCESSOR_TOKEN}.tmp`]);
+      assert.equal(await readFile(successorTemp, 'utf-8'), JSON.stringify(validLockOwner({ token: SUCCESSOR_TOKEN })));
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
     }
   });
 

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -7,6 +7,7 @@
  */
 import {
   appendFile,
+  lstat as nodeLstat,
   mkdir as nodeMkdir,
   open,
   readFile as nodeReadFile,
@@ -306,6 +307,11 @@ export type PidProbeResult = 'alive' | 'dead' | 'indeterminate';
 export interface SessionPointerFsDependencies {
   mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
   readdir(path: string): Promise<string[]>;
+  lstat(path: string): Promise<{
+    isDirectory(): boolean;
+    isFile(): boolean;
+    isSymbolicLink(): boolean;
+  }>;
   readFile(path: string, encoding: 'utf8'): Promise<string>;
   writeFile(path: string, data: string, options?: { mode?: number; flag?: string }): Promise<void>;
   openAndSync(
@@ -316,6 +322,21 @@ export interface SessionPointerFsDependencies {
   rename(from: string, to: string): Promise<void>;
   unlink(path: string): Promise<void>;
   rmdir(path: string): Promise<void>;
+}
+
+
+export interface SessionPointerLockInspection {
+  status: 'absent' | 'live' | 'dead' | 'reused' | 'identity-indeterminate' | 'missing-owner' | 'malformed' | 'ambiguous' | 'unexpected' | 'symlink' | 'io-error';
+  lockPath: string;
+  evidenceSource: 'none' | 'owner.json' | 'owner-temp';
+  safeToRecover: boolean;
+}
+
+export interface SessionPointerLockRecovery extends SessionPointerLockInspection {
+  action: 'none' | 'quarantined';
+  recovered: boolean;
+  reason: string;
+  quarantinePath?: string;
 }
 
 /** @internal Test-only deterministic transaction seam; do not use outside session tests. */
@@ -338,6 +359,7 @@ const defaultFsDependencies: SessionPointerFsDependencies = {
   },
   readdir: async (path) => await nodeReaddir(path),
   readFile: async (path, encoding) => await nodeReadFile(path, encoding),
+  lstat: async (path) => await nodeLstat(path),
   writeFile: async (path, data, options) => {
     await nodeWriteFile(path, data, options);
   },
@@ -763,15 +785,15 @@ function isValidToken(value: unknown): value is string {
   return typeof value === 'string' && SESSION_POINTER_TOKEN_PATTERN.test(value);
 }
 
-async function inspectLockOwner(lockPath: string): Promise<{
+async function inspectLockOwnerFile(ownerPath: string, missingStatus: LockOwnerStatus = 'missing'): Promise<{
   status: LockOwnerStatus;
   owner?: SessionPointerLockOwnerV1;
 }> {
   let raw: string;
   try {
-    raw = await transactionDependencies.fs.readFile(join(lockPath, 'owner.json'), 'utf8');
+    raw = await transactionDependencies.fs.readFile(ownerPath, 'utf8');
   } catch (error) {
-    return isNotFound(error) ? { status: 'missing' } : { status: 'identity-indeterminate' };
+    return isNotFound(error) ? { status: missingStatus } : { status: 'identity-indeterminate' };
   }
 
   const owner = parseLockOwner(raw);
@@ -786,8 +808,6 @@ async function inspectLockOwner(lockPath: string): Promise<{
   if (pidStatus === 'dead') return { status: 'dead', owner };
   if (pidStatus !== 'alive') return { status: 'identity-indeterminate', owner };
 
-  // Without Linux immutable start metadata, a live PID cannot be proved to be
-  // the same process. Preserve the lock instead of guessing.
   if (owner.platform !== 'linux' || !isValidStartTicks(owner.pid_start_ticks)) {
     return { status: 'identity-indeterminate', owner };
   }
@@ -807,6 +827,151 @@ async function inspectLockOwner(lockPath: string): Promise<{
     return { status: 'identity-indeterminate', owner };
   }
   return { status: 'live', owner };
+}
+
+async function inspectLockOwner(lockPath: string): Promise<{
+  status: LockOwnerStatus;
+  owner?: SessionPointerLockOwnerV1;
+}> {
+  return await inspectLockOwnerFile(join(lockPath, 'owner.json'));
+}
+
+async function inspectSessionPointerLockAtContext(context: SessionPointerContext): Promise<SessionPointerLockInspection> {
+  const absent = (): SessionPointerLockInspection => ({ status: 'absent', lockPath: context.lockPath, evidenceSource: 'none', safeToRecover: false });
+  let lockStat: Awaited<ReturnType<SessionPointerFsDependencies['lstat']>>;
+  try {
+    lockStat = await transactionDependencies.fs.lstat(context.lockPath);
+  } catch (error) {
+    return isNotFound(error) ? absent() : { status: 'io-error', lockPath: context.lockPath, evidenceSource: 'none', safeToRecover: false };
+  }
+  if (lockStat.isSymbolicLink()) return { status: 'symlink', lockPath: context.lockPath, evidenceSource: 'none', safeToRecover: false };
+  if (!lockStat.isDirectory()) return { status: 'unexpected', lockPath: context.lockPath, evidenceSource: 'none', safeToRecover: false };
+
+  let entries: string[];
+  try {
+    entries = await transactionDependencies.fs.readdir(context.lockPath);
+  } catch {
+    return { status: 'io-error', lockPath: context.lockPath, evidenceSource: 'none', safeToRecover: false };
+  }
+  const tempEntries = entries.filter((entry) => /^owner\.([A-Za-z0-9_-]{16,128})\.tmp$/.test(entry));
+  const hasCanonical = entries.includes('owner.json');
+  if (entries.length === 0) return { status: 'missing-owner', lockPath: context.lockPath, evidenceSource: 'none', safeToRecover: false };
+  if ((hasCanonical && entries.length !== 1) || (!hasCanonical && tempEntries.length !== 1) || entries.length !== 1) {
+    return { status: entries.length > 1 && (hasCanonical || tempEntries.length > 0) ? 'ambiguous' : 'unexpected', lockPath: context.lockPath, evidenceSource: 'none', safeToRecover: false };
+  }
+
+  const evidenceName = hasCanonical ? 'owner.json' : tempEntries[0];
+  const evidenceSource = hasCanonical ? 'owner.json' as const : 'owner-temp' as const;
+  const evidencePath = join(context.lockPath, evidenceName);
+  let evidenceStat: Awaited<ReturnType<SessionPointerFsDependencies['lstat']>>;
+  try {
+    evidenceStat = await transactionDependencies.fs.lstat(evidencePath);
+  } catch {
+    return { status: 'io-error', lockPath: context.lockPath, evidenceSource, safeToRecover: false };
+  }
+  if (evidenceStat.isSymbolicLink()) return { status: 'symlink', lockPath: context.lockPath, evidenceSource, safeToRecover: false };
+  if (!evidenceStat.isFile()) return { status: 'unexpected', lockPath: context.lockPath, evidenceSource, safeToRecover: false };
+
+  const owner = await inspectLockOwnerFile(evidencePath, 'missing');
+  if (evidenceSource === 'owner-temp' && owner.owner?.token !== /^owner\.([A-Za-z0-9_-]{16,128})\.tmp$/.exec(evidenceName)?.[1]) {
+    return { status: 'malformed', lockPath: context.lockPath, evidenceSource, safeToRecover: false };
+  }
+  const status = owner.status === 'missing' ? 'io-error' : owner.status;
+  return {
+    status,
+    lockPath: context.lockPath,
+    evidenceSource,
+    safeToRecover: status === 'dead' && evidenceSource === 'owner-temp',
+  };
+}
+
+/** Inspect only exact, regular owner evidence in the selected pointer lock. */
+export async function inspectSessionPointerLock(cwd: string): Promise<SessionPointerLockInspection> {
+  return await inspectSessionPointerLockAtContext(resolveSessionPointerContext(cwd));
+}
+
+/** Explicitly quarantine only a dead, atomically claimed pointer lock; never force recovery. */
+export async function recoverSessionPointerLock(cwd: string): Promise<SessionPointerLockRecovery> {
+  const context = resolveSessionPointerContext(cwd);
+  const inspection = await inspectSessionPointerLockAtContext(context);
+  if (!inspection.safeToRecover) {
+    return { ...inspection, action: 'none', recovered: false, reason: inspection.status === 'absent' ? 'No session pointer lock exists.' : `Session pointer lock is not safe to recover (${inspection.status}).` };
+  }
+
+  let entries: string[];
+  try {
+    entries = await transactionDependencies.fs.readdir(context.lockPath);
+  } catch {
+    return { ...inspection, action: 'none', recovered: false, reason: 'Unable to re-read session pointer lock evidence.' };
+  }
+  const evidenceName = inspection.evidenceSource === 'owner.json' ? 'owner.json' : entries.find((entry) => /^owner\.([A-Za-z0-9_-]{16,128})\.tmp$/.test(entry));
+  if (!evidenceName || entries.length !== 1) {
+    return { ...inspection, action: 'none', recovered: false, reason: 'Session pointer lock evidence changed before recovery claim.' };
+  }
+  const owner = await inspectLockOwnerFile(join(context.lockPath, evidenceName));
+  if (owner.status !== 'dead' || !owner.owner) {
+    return { ...inspection, action: 'none', recovered: false, reason: 'Session pointer lock evidence changed before recovery claim.' };
+  }
+
+  let claimToken: string;
+  try {
+    claimToken = transactionDependencies.token();
+  } catch {
+    return { ...inspection, action: 'none', recovered: false, reason: 'Unable to create recovery claim token.' };
+  }
+  if (!isValidToken(claimToken)) return { ...inspection, action: 'none', recovered: false, reason: 'Recovery claim token is invalid.' };
+  const claimName = `owner.${owner.owner.token}.${claimToken}.recovery`;
+  const claimPath = join(context.lockPath, claimName);
+  try {
+    await transactionDependencies.fs.lstat(claimPath);
+    return { ...inspection, action: 'none', recovered: false, reason: 'Recovery claim path already exists.' };
+  } catch (error) {
+    if (!isNotFound(error)) return { ...inspection, action: 'none', recovered: false, reason: 'Unable to inspect recovery claim path.' };
+  }
+  try {
+    await transactionDependencies.fs.rename(join(context.lockPath, evidenceName), claimPath);
+  } catch {
+    return { ...inspection, action: 'none', recovered: false, reason: 'Session pointer lock evidence changed before recovery claim.' };
+  }
+
+  const claimed = await inspectSessionPointerLockAtContext(context);
+  let claimedEntries: string[];
+  try {
+    claimedEntries = await transactionDependencies.fs.readdir(context.lockPath);
+  } catch {
+    return { ...claimed, action: 'none', recovered: false, reason: 'Unable to revalidate recovery claim.' };
+  }
+  const claimOwner = await inspectLockOwnerFile(claimPath);
+  if (claimedEntries.length !== 1 || claimedEntries[0] !== claimName || claimOwner.status !== 'dead' || claimOwner.owner?.token !== owner.owner.token || claimed.status !== 'unexpected') {
+    return { ...claimed, action: 'none', recovered: false, reason: 'Recovery claim revalidation failed.' };
+  }
+
+  const quarantinePath = `${context.lockPath}.quarantine.${owner.owner.token}.${claimToken}`;
+  try {
+    await transactionDependencies.fs.lstat(quarantinePath);
+    return { ...claimed, action: 'none', recovered: false, reason: 'Recovery quarantine path already exists.' };
+  } catch (error) {
+    if (!isNotFound(error)) return { ...claimed, action: 'none', recovered: false, reason: 'Unable to inspect recovery quarantine path.' };
+  }
+  try {
+    await transactionDependencies.fs.rename(claimPath, quarantinePath);
+  } catch {
+    return { ...claimed, action: 'none', recovered: false, reason: 'Unable to quarantine the exact session pointer recovery claim.' };
+  }
+  try {
+    await transactionDependencies.fs.rmdir(context.lockPath);
+  } catch (error) {
+    if (!isNotFound(error)) {
+      return {
+        ...claimed,
+        action: 'none',
+        recovered: false,
+        reason: 'The exact recovery claim was quarantined, but the canonical lock directory was not empty.',
+        quarantinePath,
+      };
+    }
+  }
+  return { ...inspection, action: 'quarantined', recovered: true, reason: 'Dead session pointer lock was atomically claimed and quarantined.', quarantinePath };
 }
 
 interface HeldPointerLock {


### PR DESCRIPTION
## Summary

- route `omx session` help and diagnostics before launch/isolation gating
- inspect one exact canonical or pre-rename owner record; missing, malformed, ambiguous, symlinked, reused, or indeterminate evidence stays fail-closed
- explicitly recover only a proven-dead `owner.<token>.tmp` by atomically claiming that exact token-bound path before quarantining the claimed directory
- leave dead canonical `owner.json` fail-closed because its shared name cannot provide an exact acquisition claim
- keep recovery idempotent and prevent the stale-reclaimer/successor race that blocked closed PR #3213

## Verification

- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- focused session pointer and CLI help tests: 48 passed
- `npm test`: all changed-area tests passed; one unrelated MCP lifecycle file failed under full-suite process load, then passed 15/15 in isolated rerun

Closes #3203

—
*repo owner's gaebal-gajae (clawdbot) 🦞*