### PR TITLE
fix(team): coalesce mailbox wakeups

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -1433,6 +1433,46 @@ describe('notify-fallback watcher', () => {
     }
   });
 
+  it('does not keep leader mailbox nudges alive after the team becomes terminal', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-terminal-mailbox-'));
+    const fakeBinDir = join(wd, 'fake-bin');
+    const tmuxLogPath = join(wd, 'tmux.log');
+    try {
+      await writeCanonicalWatcherTeamFixture(wd, { coarseState: 'inactive', terminal: true });
+      await mkdir(join(wd, '.omx', 'state', 'team', 'dispatch-team', 'mailbox'), { recursive: true });
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));
+      await chmod(join(fakeBinDir, 'tmux'), 0o755);
+      await writeFile(join(wd, '.omx', 'state', 'team', 'dispatch-team', 'mailbox', 'leader-fixed.json'), JSON.stringify({
+        worker: 'leader-fixed',
+        messages: [{
+          message_id: 'terminal-msg',
+          from_worker: 'worker-1',
+          to_worker: 'leader-fixed',
+          body: 'must not wake a terminal team',
+          created_at: new Date().toISOString(),
+        }],
+      }, null, 2));
+
+      const watcherScript = new URL('../../../dist/scripts/notify-fallback-watcher.js', import.meta.url).pathname;
+      const notifyHook = new URL('../../../dist/scripts/notify-hook.js', import.meta.url).pathname;
+      const result = spawnSync(process.execPath, [watcherScript, '--once', '--cwd', wd, '--notify-script', notifyHook], {
+        encoding: 'utf-8',
+        env: buildCleanNotifyEnv({
+          PATH: `${fakeBinDir}:${process.env.PATH || ''}`,
+          OMX_SESSION_ID: 'sess-current',
+        }),
+      });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.equal(await readFile(tmuxLogPath, 'utf8').catch(() => ''), '');
+      const logPath = join(wd, '.omx', 'logs', `notify-fallback-${new Date().toISOString().split('T')[0]}.jsonl`);
+      const logEntries = await readJsonLines(logPath);
+      assert.equal(logEntries.some((entry) => entry.type === 'leader_nudge_tick'), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('does not run stalled-worker leader nudges from the fallback watcher when the leader is not stale', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-fallback-worker-stall-nudge-'));
     const fakeBinDir = join(wd, 'fake-bin');

--- a/src/scripts/notify-fallback-watcher.ts
+++ b/src/scripts/notify-fallback-watcher.ts
@@ -1842,6 +1842,20 @@ async function runLeaderNudgeTick(): Promise<boolean> {
     return false;
   }
 
+  const activeTeam = await resolveActiveTeamState();
+  if (!activeTeam.active) {
+    leaderNudgeRuns += 1;
+    lastLeaderNudge = {
+      enabled: true,
+      leader_only: true,
+      stale_threshold_ms: staleThresholdMs,
+      precomputed_leader_stale: false,
+      last_tick_at: startedIso,
+      last_error: `inactive_team:${activeTeam.reason}`,
+    };
+    return false;
+  }
+
   try {
     const preComputedLeaderStale = await isLeaderStale(stateDir, staleThresholdMs, Date.now());
     await maybeNudgeTeamLeader({

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -653,6 +653,11 @@ describe('executeTeamApiOperation: mailbox-mark-delivered', () => {
       }, cwd);
       assert.equal(coalesced.deduped, true);
       assert.equal(coalesced.request.request_id, wake.request.request_id);
+      const alternateWake = await enqueueDispatchRequest('mark-dlv-coalesced', {
+        kind: 'mailbox', to_worker: 'worker-2', worker_index: 2,
+        message_id: secondId, trigger_message: 'follow up', intent: 'followup-relaunch',
+      }, cwd);
+      assert.equal(alternateWake.deduped, false);
 
       const firstAck = await executeTeamApiOperation('mailbox-mark-delivered', {
         team_name: 'mark-dlv-coalesced', worker: 'worker-2', message_id: firstId,
@@ -669,6 +674,7 @@ describe('executeTeamApiOperation: mailbox-mark-delivered', () => {
       if (!finalAck.ok) throw new Error('expected final acknowledgement to succeed');
       assert.equal(finalAck.data.dispatch_updated, true);
       assert.equal((await readDispatchRequest('mark-dlv-coalesced', wake.request.request_id, cwd))?.status, 'delivered');
+      assert.equal((await readDispatchRequest('mark-dlv-coalesced', alternateWake.request.request_id, cwd))?.status, 'delivered');
     } finally {
       await cleanup();
     }

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -635,6 +635,45 @@ describe('executeTeamApiOperation: mailbox-mark-delivered', () => {
     }
   });
 
+  it('keeps one mailbox wake pending until every queued message is acknowledged', async () => {
+    const { cwd, cleanup } = await setupTeam('mark-dlv-coalesced');
+    try {
+      const firstMessage = await sendDirectMessage('mark-dlv-coalesced', 'worker-1', 'worker-2', 'first', cwd);
+      const secondMessage = await sendDirectMessage('mark-dlv-coalesced', 'worker-1', 'worker-2', 'second', cwd);
+      const firstId = firstMessage.message_id;
+      const secondId = secondMessage.message_id;
+
+      const wake = await enqueueDispatchRequest('mark-dlv-coalesced', {
+        kind: 'mailbox', to_worker: 'worker-2', worker_index: 2,
+        message_id: firstId, trigger_message: 'check mailbox', intent: 'pending-mailbox-review',
+      }, cwd);
+      const coalesced = await enqueueDispatchRequest('mark-dlv-coalesced', {
+        kind: 'mailbox', to_worker: 'worker-2', worker_index: 2,
+        message_id: secondId, trigger_message: 'check mailbox', intent: 'pending-mailbox-review',
+      }, cwd);
+      assert.equal(coalesced.deduped, true);
+      assert.equal(coalesced.request.request_id, wake.request.request_id);
+
+      const firstAck = await executeTeamApiOperation('mailbox-mark-delivered', {
+        team_name: 'mark-dlv-coalesced', worker: 'worker-2', message_id: firstId,
+      }, cwd);
+      assert.equal(firstAck.ok, true);
+      if (!firstAck.ok) throw new Error('expected first acknowledgement to succeed');
+      assert.equal(firstAck.data.dispatch_updated, false);
+      assert.equal((await readDispatchRequest('mark-dlv-coalesced', wake.request.request_id, cwd))?.status, 'pending');
+
+      const finalAck = await executeTeamApiOperation('mailbox-mark-delivered', {
+        team_name: 'mark-dlv-coalesced', worker: 'worker-2', message_id: secondId,
+      }, cwd);
+      assert.equal(finalAck.ok, true);
+      if (!finalAck.ok) throw new Error('expected final acknowledgement to succeed');
+      assert.equal(finalAck.data.dispatch_updated, true);
+      assert.equal((await readDispatchRequest('mark-dlv-coalesced', wake.request.request_id, cwd))?.status, 'delivered');
+    } finally {
+      await cleanup();
+    }
+  });
+
   it('marks leader-fixed mailbox delivery from a worker worktree and resolves the matching dispatch receipt', async () => {
     const teamName = 'mark-dlv-leader-worktree';
     const repoCwd = await mkdtemp(join(tmpdir(), 'omx-interop-mark-dlv-root-'));

--- a/src/team/__tests__/delivery-e2e-smoke.test.ts
+++ b/src/team/__tests__/delivery-e2e-smoke.test.ts
@@ -417,10 +417,8 @@ describe('team message delivery end-to-end smoke tests', () => {
         assert.equal(workerMessages.filter((message) => message.notified_at).length, 3);
 
         const requests = await listDispatchRequests('worker-leader-concurrent', cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
-        const workerMessageIds = new Set(workerMessages.map((message) => message.message_id));
-        const workerRequests = requests.filter((request) => request.message_id && workerMessageIds.has(request.message_id));
-        assert.equal(workerRequests.length, 3);
-        assert.equal(workerRequests.filter((request) => request.status === 'notified').length, 3);
+        assert.equal(requests.length, 1);
+        assert.equal(requests[0]?.status, 'notified');
       });
     } finally {
       await cleanup();

--- a/src/team/__tests__/mcp-comm.test.ts
+++ b/src/team/__tests__/mcp-comm.test.ts
@@ -174,6 +174,53 @@ describe('mcp-comm', () => {
     }
   });
 
+  it('preserves direct and broadcast mailbox messages behind one notified wake', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-mcp-comm-'));
+    try {
+      await initTeamState('alpha-coalesced', 't', 'executor', 2, cwd);
+      let notifications = 0;
+      const direct = await queueDirectMailboxMessage({
+        teamName: 'alpha-coalesced',
+        fromWorker: 'worker-1',
+        toWorker: 'worker-2',
+        toWorkerIndex: 2,
+        body: 'direct message',
+        triggerMessage: 'check mailbox',
+        intent: 'pending-mailbox-review',
+        cwd,
+        notify: async () => {
+          notifications += 1;
+          return { ok: true, transport: 'tmux_send_keys', reason: 'sent' };
+        },
+      });
+      const broadcast = await queueBroadcastMailboxMessage({
+        teamName: 'alpha-coalesced',
+        fromWorker: 'worker-1',
+        recipients: [{ workerName: 'worker-2', workerIndex: 2 }],
+        body: 'broadcast message',
+        cwd,
+        triggerFor: () => 'check mailbox',
+        intentFor: () => 'pending-mailbox-review',
+        notify: async () => {
+          notifications += 1;
+          return { ok: true, transport: 'tmux_send_keys', reason: 'sent' };
+        },
+      });
+
+      assert.equal(direct.ok, true);
+      assert.equal(broadcast.length, 1);
+      assert.equal(broadcast[0]?.reason, 'duplicate_pending_dispatch_request');
+      assert.equal(notifications, 1);
+      const mailbox = await listMailboxMessages('alpha-coalesced', 'worker-2', cwd);
+      assert.equal(mailbox.length, 2);
+      const requests = await listDispatchRequests('alpha-coalesced', cwd, { kind: 'mailbox', to_worker: 'worker-2' });
+      assert.equal(requests.length, 1);
+      assert.equal(requests[0]?.status, 'notified');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('queueBroadcastMailboxMessage notifies and marks notified per recipient', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-mcp-comm-'));
     try {
@@ -209,41 +256,44 @@ describe('mcp-comm', () => {
     }
   });
 
-  it('prevents duplicate pending mailbox dispatch requests for same message id', async () => {
+  it('preserves direct and broadcast mailbox messages while coalescing their outstanding wake', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-mcp-comm-'));
     try {
       await initTeamState('alpha', 't', 'executor', 2, cwd);
+      let notifications = 0;
+      const notify = async () => {
+        notifications += 1;
+        return { ok: false, transport: 'hook' as const, reason: 'queued_pending' };
+      };
 
-      const first = await queueDirectMailboxMessage({
-        teamName: 'alpha',
-        fromWorker: 'worker-1',
-        toWorker: 'worker-2',
-        toWorkerIndex: 2,
-        body: 'hello',
-        triggerMessage: 'check mailbox',
-        cwd,
-        notify: async () => ({ ok: false, transport: 'hook', reason: 'queued_pending' }),
+      await queueDirectMailboxMessage({
+        teamName: 'alpha', fromWorker: 'worker-1', toWorker: 'worker-2', toWorkerIndex: 2,
+        body: 'direct-first', triggerMessage: 'check mailbox', cwd, notify,
       });
+      await queueDirectMailboxMessage({
+        teamName: 'alpha', fromWorker: 'worker-1', toWorker: 'worker-2', toWorkerIndex: 2,
+        body: 'direct-second', triggerMessage: 'check mailbox', cwd, notify,
+      });
+      for (const body of ['broadcast-first', 'broadcast-second']) {
+        await queueBroadcastMailboxMessage({
+          teamName: 'alpha',
+          fromWorker: 'worker-1',
+          recipients: [{ workerName: 'worker-2', workerIndex: 2 }],
+          body,
+          cwd,
+          triggerFor: () => 'check mailbox',
+          notify,
+        });
+      }
 
-      assert.equal(first.ok, false);
-      assert.ok(first.message_id);
-      const requests = await listDispatchRequests('alpha', cwd, { kind: 'mailbox' });
+      const mailbox = await listMailboxMessages('alpha', 'worker-2', cwd);
+      const requests = await listDispatchRequests('alpha', cwd, { kind: 'mailbox', to_worker: 'worker-2' });
+      assert.equal(mailbox.length, 4);
+      assert.deepEqual(mailbox.map((message) => message.body), [
+        'direct-first', 'direct-second', 'broadcast-first', 'broadcast-second',
+      ]);
+      assert.equal(notifications, 1);
       assert.equal(requests.length, 1);
-
-      const second = await queueDirectMailboxMessage({
-        teamName: 'alpha',
-        fromWorker: 'worker-1',
-        toWorker: 'worker-2',
-        toWorkerIndex: 2,
-        body: 'hello-2',
-        triggerMessage: 'check mailbox',
-        cwd,
-        notify: async () => ({ ok: false, transport: 'hook', reason: 'queued_pending' }),
-      });
-      assert.equal(second.ok, false);
-      const allRequests = await listDispatchRequests('alpha', cwd, { kind: 'mailbox' });
-      // second message has distinct message_id -> second request exists
-      assert.equal(allRequests.length, 2);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -313,6 +363,23 @@ describe('mcp-comm', () => {
       const request = await readDispatchRequest('alpha', outcome.request_id!, cwd);
       assert.equal(request?.status, 'failed');
       assert.match(request?.last_reason ?? '', /^notify_exception:/);
+
+      const retry = await queueDirectMailboxMessage({
+        teamName: 'alpha',
+        fromWorker: 'worker-1',
+        toWorker: 'worker-2',
+        toWorkerIndex: 2,
+        body: 'hello after crash',
+        triggerMessage: 'check mailbox',
+        cwd,
+        transportPreference: 'prompt_stdin',
+        fallbackAllowed: false,
+        notify: async () => ({ ok: true, transport: 'prompt_stdin', reason: 'retry_sent' }),
+      });
+      assert.equal(retry.ok, true);
+      assert.notEqual(retry.request_id, outcome.request_id);
+      const retriedRequest = await readDispatchRequest('alpha', retry.request_id!, cwd);
+      assert.equal(retriedRequest?.status, 'notified');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -61,6 +61,8 @@ import { normalizeDispatchRequest } from '../state/dispatch.js';
 import { claimTask as claimTaskWithDeps } from '../state/tasks.js';
 import { withScalingLock as withScalingLeaseLock, withTeamLock } from '../state/locks.js';
 import type { TeamTaskV2 } from '../state/types.js';
+import type { TeamReminderIntent } from '../reminder-intents.js';
+
 
 const ORIGINAL_OMX_TEAM_STATE_ROOT = process.env.OMX_TEAM_STATE_ROOT;
 
@@ -602,46 +604,47 @@ exit 1
     }
   });
 
-  it('dispatch request store enqueues, dedupes, and transitions idempotently', async () => {
+  it('coalesces mailbox wakes only for an exact target proof and releases on acknowledgement', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-dispatch-store-'));
     try {
-      await initTeamState('team-dispatch', 't', 'executor', 1, cwd);
-      const first = await enqueueDispatchRequest(
-        'team-dispatch',
-        {
-          kind: 'mailbox',
-          to_worker: 'worker-1',
-          message_id: 'msg-1',
-          trigger_message: 'check mailbox',
-          intent: 'pending-mailbox-review',
-        },
-        cwd,
-      );
-      assert.equal(first.deduped, false);
-
-      const dup = await enqueueDispatchRequest(
-        'team-dispatch',
-        {
-          kind: 'mailbox',
-          to_worker: 'worker-1',
-          message_id: 'msg-1',
-          trigger_message: 'check mailbox',
-        },
-        cwd,
-      );
-      assert.equal(dup.deduped, true);
-      assert.equal(dup.request.request_id, first.request.request_id);
+      await initTeamState('team-dispatch', 't', 'executor', 2, cwd);
+      await initTeamState('team-dispatch-other', 't', 'executor', 1, cwd);
+      const input = (to_worker: string, message_id: string, pane_id = 'pane-1', intent: TeamReminderIntent = 'pending-mailbox-review') => ({
+        kind: 'mailbox' as const,
+        to_worker,
+        pane_id,
+        message_id,
+        trigger_message: 'check mailbox',
+        intent,
+      });
+      const first = await enqueueDispatchRequest('team-dispatch', input('worker-1', 'msg-1'), cwd);
+      const pendingSibling = await enqueueDispatchRequest('team-dispatch', input('worker-1', 'msg-2'), cwd);
+      assert.equal(pendingSibling.deduped, true);
+      assert.equal(pendingSibling.request.request_id, first.request.request_id);
 
       const notified = await markDispatchRequestNotified('team-dispatch', first.request.request_id, {}, cwd);
       assert.equal(notified?.status, 'notified');
-      const notifiedAgain = await markDispatchRequestNotified('team-dispatch', first.request.request_id, {}, cwd);
-      assert.equal(notifiedAgain?.status, 'notified');
+      const notifiedSibling = await enqueueDispatchRequest('team-dispatch', input('worker-1', 'msg-3'), cwd);
+      assert.equal(notifiedSibling.deduped, true);
+      assert.equal(notifiedSibling.request.request_id, first.request.request_id);
+
+      const differentWorker = await enqueueDispatchRequest('team-dispatch', input('worker-2', 'msg-4'), cwd);
+      const differentPane = await enqueueDispatchRequest('team-dispatch', input('worker-1', 'msg-5', 'pane-2'), cwd);
+      const differentIntent = await enqueueDispatchRequest('team-dispatch', input('worker-1', 'msg-6', 'pane-1', 'followup-relaunch'), cwd);
+      const differentTeam = await enqueueDispatchRequest('team-dispatch-other', input('worker-1', 'msg-7'), cwd);
+      assert.equal(differentWorker.deduped, false);
+      assert.equal(differentPane.deduped, false);
+      assert.equal(differentIntent.deduped, false);
+      assert.equal(differentTeam.deduped, false);
+
       const delivered = await markDispatchRequestDelivered('team-dispatch', first.request.request_id, {}, cwd);
       assert.equal(delivered?.status, 'delivered');
-      const listed = await listDispatchRequests('team-dispatch', cwd);
-      assert.equal(listed.length, 1);
-      assert.equal(listed[0]?.message_id, 'msg-1');
-      assert.equal(listed[0]?.intent, 'pending-mailbox-review');
+      const successor = await enqueueDispatchRequest('team-dispatch', input('worker-1', 'msg-8'), cwd);
+      assert.equal(successor.deduped, false);
+      assert.notEqual(successor.request.request_id, first.request.request_id);
+
+      const listed = await listDispatchRequests('team-dispatch', cwd, { kind: 'mailbox' });
+      assert.equal(listed.length, 5);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -146,10 +146,10 @@ async function markLatestMailboxDispatchDelivered(
   messageId: string,
   cwd: string,
 ): Promise<{ matched_request_id: string | null; dispatch_updated: boolean }> {
-  const requests = await teamListDispatchRequests(teamName, cwd, { kind: 'mailbox', to_worker: worker });
-  const latest = requests
+  const active = (await teamListDispatchRequests(teamName, cwd, { kind: 'mailbox', to_worker: worker }))
     .filter((request) => request.status === 'pending' || request.status === 'notified')
-    .sort((left, right) => Date.parse(right.updated_at) - Date.parse(left.updated_at))[0];
+    .sort((left, right) => Date.parse(right.updated_at) - Date.parse(left.updated_at));
+  const latest = active[0];
   if (!latest) return { matched_request_id: null, dispatch_updated: false };
 
   const mailbox = await listMailboxMessages(teamName, worker, cwd);
@@ -157,13 +157,17 @@ async function markLatestMailboxDispatchDelivered(
     return { matched_request_id: latest.request_id, dispatch_updated: false };
   }
 
-  if (latest.status === 'pending') {
-    await teamMarkDispatchRequestNotified(teamName, latest.request_id, { message_id: messageId }, cwd);
+  let allDelivered = true;
+  for (const request of active) {
+    if (request.status === 'pending') {
+      await teamMarkDispatchRequestNotified(teamName, request.request_id, { message_id: messageId }, cwd);
+    }
+    const delivered = await teamMarkDispatchRequestDelivered(teamName, request.request_id, { message_id: messageId }, cwd);
+    allDelivered &&= delivered?.status === 'delivered';
   }
-  const delivered = await teamMarkDispatchRequestDelivered(teamName, latest.request_id, { message_id: messageId }, cwd);
   return {
     matched_request_id: latest.request_id,
-    dispatch_updated: delivered?.status === 'delivered',
+    dispatch_updated: allDelivered,
   };
 }
 

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -147,19 +147,19 @@ async function markLatestMailboxDispatchDelivered(
   cwd: string,
 ): Promise<{ matched_request_id: string | null; dispatch_updated: boolean }> {
   const requests = await teamListDispatchRequests(teamName, cwd, { kind: 'mailbox', to_worker: worker });
-  const matching = requests
-    .filter((request) => request.message_id === messageId)
-    .sort((left, right) => Date.parse(right.updated_at) - Date.parse(left.updated_at));
+  const latest = requests
+    .filter((request) => request.status === 'pending' || request.status === 'notified')
+    .sort((left, right) => Date.parse(right.updated_at) - Date.parse(left.updated_at))[0];
+  if (!latest) return { matched_request_id: null, dispatch_updated: false };
 
-  const latest = matching[0];
-  if (!latest) {
-    return { matched_request_id: null, dispatch_updated: false };
+  const mailbox = await listMailboxMessages(teamName, worker, cwd);
+  if (mailbox.some((message) => !message.delivered_at)) {
+    return { matched_request_id: latest.request_id, dispatch_updated: false };
   }
 
   if (latest.status === 'pending') {
     await teamMarkDispatchRequestNotified(teamName, latest.request_id, { message_id: messageId }, cwd);
   }
-
   const delivered = await teamMarkDispatchRequestDelivered(teamName, latest.request_id, { message_id: messageId }, cwd);
   return {
     matched_request_id: latest.request_id,

--- a/src/team/state/dispatch.ts
+++ b/src/team/state/dispatch.ts
@@ -21,6 +21,7 @@ export interface TeamDispatchRequest {
   trigger_message: string;
   intent?: TeamReminderIntent;
   message_id?: string;
+
   inbox_correlation_key?: string;
   transport_preference: TeamDispatchTransportPreference;
   fallback_allowed: boolean;
@@ -109,6 +110,7 @@ export function normalizeDispatchRequest(
     trigger_message: raw.trigger_message,
     intent: isTeamReminderIntent(raw.intent) ? raw.intent : undefined,
     message_id: typeof raw.message_id === 'string' && raw.message_id !== '' ? raw.message_id : undefined,
+
     inbox_correlation_key:
       typeof raw.inbox_correlation_key === 'string' && raw.inbox_correlation_key !== '' ? raw.inbox_correlation_key : undefined,
     transport_preference:
@@ -127,15 +129,23 @@ export function normalizeDispatchRequest(
   });
 }
 
+function sameMailboxWakeTarget(existing: TeamDispatchRequest, input: TeamDispatchRequestInput): boolean {
+  if (existing.status !== 'pending' && existing.status !== 'notified') return false;
+  if (existing.to_worker !== input.to_worker || existing.pane_id !== input.pane_id) return false;
+  if (existing.intent || input.intent) return existing.intent === input.intent;
+  // Legacy callers without structured intent may coalesce only identical
+  // directives; a changed directive can reflect a changed target boundary.
+  return existing.trigger_message === input.trigger_message;
+}
+
 function equivalentPendingDispatch(existing: TeamDispatchRequest, input: TeamDispatchRequestInput): boolean {
-  if (existing.status !== 'pending') return false;
   if (existing.kind !== input.kind) return false;
-  if (existing.to_worker !== input.to_worker) return false;
 
   if (input.kind === 'mailbox') {
-    return Boolean(input.message_id) && existing.message_id === input.message_id;
+    return sameMailboxWakeTarget(existing, input);
   }
 
+  if (existing.to_worker !== input.to_worker || existing.status !== 'pending') return false;
   if (input.kind === 'inbox' && input.inbox_correlation_key) {
     return existing.inbox_correlation_key === input.inbox_correlation_key;
   }
@@ -168,6 +178,15 @@ function executeBridgeCommand(cwd: string, command: RuntimeCommand): boolean {
   try {
     getDefaultBridge(resolveBridgeStateDir(cwd)).execCommand(command);
     return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasBridgeDispatchCompat(cwd: string): boolean {
+  if (!isBridgeEnabled()) return false;
+  try {
+    return getDefaultBridge(resolveBridgeStateDir(cwd)).readCompatFile('dispatch.json') !== null;
   } catch {
     return false;
   }
@@ -246,7 +265,9 @@ export async function enqueueDispatchRequest(
   const queued = await deps.withDispatchLock(deps.teamName, deps.cwd, async () => {
     const requests = await deps.readDispatchRequests(deps.teamName, deps.cwd);
     const existing = requests.find((req) => equivalentPendingDispatch(req, requestInput));
-    if (existing) return { request: existing, deduped: true };
+    if (existing && (!isBridgeEnabled() || hasBridgeDispatchCompat(deps.cwd))) {
+      return { request: existing, deduped: true };
+    }
 
     const nowIso = new Date().toISOString();
     const request = normalizeDispatchRequest(
@@ -389,8 +410,6 @@ export async function markDispatchRequestDelivered(
   const current = await readDispatchRequest(requestId, deps);
   if (!current) return null;
   if (current.status === 'delivered') return current;
-  // Mirror the terminal-state guard from markDispatchRequestNotified: failed
-  // dispatches cannot be promoted to delivered via the bridge side-channel.
   if (current.status === 'failed') return null;
   if (executeBridgeCommand(deps.cwd, { command: 'MarkDelivered', request_id: requestId })) {
     return await readDispatchRequest(requestId, deps) ?? current;


### PR DESCRIPTION
## Summary
- coalesce active mailbox-review dispatches by exact team target/pane proof instead of per message
- keep the shared wake pending until every currently undelivered mailbox message is acknowledged
- preserve bridge authority when compatibility state is unavailable or stale
- stop fallback leader-nudge ticks when no active non-terminal team remains
- add busy leader/worker, concurrent, crash/retry, acknowledgement, and terminal watcher regressions

## Verification
- `npm run build`
- focused compiled mailbox/watcher regressions: pass
- `npm run check:no-unused`: pass
- `npm run lint`: pass
- issue-related broad suites (`rust-runtime-compat`, `notify-fallback-watcher`, `notify-hook-team-dispatch`, `delivery-e2e-smoke`): pass serially
- `npm test`: issue-related suites pass; aggregate run still exposed unrelated existing process-lifecycle/plugin-cache launch flakes in `server-lifecycle.test` and `codex-plugin-layout.test`

Fixes #3195

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
