### PR TITLE
fix(hooks): parse collaboration results structurally

### DIFF
--- a/src/leader/__tests__/contract.test.ts
+++ b/src/leader/__tests__/contract.test.ts
@@ -24,6 +24,7 @@ import {
   isUnsupportedNativeSubagentEvidenceForScope,
   type RoleRoutingUnavailableMarker,
   resolveNativeSubagentSupportStatus,
+  parseNativeSubagentResultDisposition,
   NATIVE_SPAWN_TASK_NAME_PATTERN,
   ROLE_INTENT_SPAWN_TASK_NAME_PREFIX,
   ROLE_INTENT_CORRELATION_TOKEN_PATTERN,
@@ -239,6 +240,67 @@ describe('leader conductor contract', () => {
       }).reason,
       'agent_thread_limit_reached',
     );
+  });
+
+  it('parses structured collaboration dispositions without child-output prose poisoning', () => {
+    for (const toolName of [
+      'collaboration.spawn_agent',
+      'collaboration.list_agents',
+      'collaboration.followup_task',
+      'collaboration.wait_agent',
+    ]) {
+      const disposition = parseNativeSubagentResultDisposition(toolName, {
+        success: true,
+        status: 'completed',
+        output: 'Child report: the optional plugin is unavailable, unsupported, and not found.',
+      });
+      assert.equal(disposition.kind, 'success', toolName);
+    }
+    assert.equal(parseNativeSubagentResultDisposition('collaboration.wait_agent', {
+      success: true,
+      status: 'completed',
+      error: null,
+      output: 'Child says optional support is unavailable.',
+    }).kind, 'success');
+  });
+
+  it('handles contradictory structured result fields deterministically', () => {
+    assert.equal(parseNativeSubagentResultDisposition('collaboration.wait_agent', {
+      success: true,
+      status: 'failed',
+      error: 'agent thread limit reached',
+    }).kind, 'capacity');
+    assert.equal(parseNativeSubagentResultDisposition('collaboration.followup_task', {
+      success: true,
+      status: 'failed',
+      error: 'unknown tool is unavailable',
+    }).kind, 'unsupported');
+  });
+
+  it('limits legacy prose classification to spawn results', () => {
+    assert.equal(
+      parseNativeSubagentResultDisposition('multi_agent_v1.spawn_agent', 'unknown tool is unavailable').kind,
+      'unsupported',
+    );
+    for (const toolName of [
+      'collaboration.list_agents',
+      'collaboration.followup_task',
+      'collaboration.wait_agent',
+    ]) {
+      assert.equal(
+        parseNativeSubagentResultDisposition(toolName, 'successful child output says a dependency is unavailable').kind,
+        'unknown',
+        toolName,
+      );
+    }
+  });
+
+  it('ignores structured failure prose from provably unrelated tools', () => {
+    assert.equal(parseNativeSubagentResultDisposition('Bash', {
+      success: false,
+      status: 'failed',
+      error: 'optional plugin is unsupported and unavailable',
+    }).kind, 'unknown');
   });
 
   it('recognizes scoped unsupported native blocker evidence and renders blocker guidance', () => {

--- a/src/leader/contract.ts
+++ b/src/leader/contract.ts
@@ -106,6 +106,11 @@ export interface NativeSubagentSupportEvidence {
   observedAt?: string;
   expiresAt?: string;
 }
+export type NativeSubagentResultDisposition =
+  | { kind: 'success'; evidenceSummary: string }
+  | { kind: 'capacity'; evidenceSummary: string }
+  | { kind: 'unsupported'; reason: Exclude<NativeSubagentUnsupportedReason, 'agent_thread_limit_reached'>; evidenceSummary: string }
+  | { kind: 'unknown'; evidenceSummary: string };
 
 export interface RoleRoutingUnavailableMarker {
   schema_version: 1;
@@ -166,6 +171,78 @@ function supportBoolean(value: unknown): boolean | null {
 
 function supportArray(value: unknown): unknown[] | null {
   return Array.isArray(value) ? value : null;
+}
+function stringifySupportValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value === undefined || value === null) return '';
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function parseSupportRecord(value: unknown): Record<string, unknown> | null {
+  const direct = supportRecord(value);
+  if (direct) return direct;
+  if (typeof value !== 'string') return null;
+  try {
+    return supportRecord(JSON.parse(value));
+  } catch {
+    return null;
+  }
+}
+
+function nativeSubagentFailureDisposition(evidence: string): NativeSubagentResultDisposition | null {
+  if (/\bagent thread limit reached\b/i.test(evidence)) {
+    return { kind: 'capacity', evidenceSummary: evidence };
+  }
+  if (/\bnative subagents? (?:unsupported|disabled|not enabled|unavailable|not found)\b/i.test(evidence)) {
+    return { kind: 'unsupported', reason: 'native_subagents_unsupported', evidenceSummary: evidence };
+  }
+  if (/\bmulti_agent_v1\b/i.test(evidence) && /\b(?:unavailable|unknown tool|disabled|not enabled|not found|unsupported)\b/i.test(evidence)) {
+    return { kind: 'unsupported', reason: 'multi_agent_v1_unavailable', evidenceSummary: evidence };
+  }
+  if (/\b(?:unknown tool|tool not found|not enabled|disabled|unavailable|unsupported)\b/i.test(evidence)) {
+    return { kind: 'unsupported', reason: 'multi_agent_v1_unavailable', evidenceSummary: evidence };
+  }
+  return null;
+}
+
+export function parseNativeSubagentResultDisposition(
+  toolName: string,
+  value: unknown,
+): NativeSubagentResultDisposition {
+  const evidenceSummary = stringifySupportValue(value).replace(/\s+/g, ' ').trim();
+  if (toolName && !isNativeSubagentResultToolName(toolName)) {
+    return { kind: 'unknown', evidenceSummary };
+  }
+  const record = parseSupportRecord(value);
+  if (record) {
+    const status = supportString(record.status).toLowerCase();
+    const explicitFailure = record.success === false
+      || record.ok === false
+      || record.is_error === true
+      || record.isError === true
+      || (record.error !== undefined && record.error !== null && record.error !== '')
+      || ['error', 'failed', 'failure', 'unsupported', 'unavailable'].includes(status);
+    const explicitSuccess = record.success === true
+      || record.ok === true
+      || record.is_error === false
+      || record.isError === false
+      || ['ok', 'success', 'succeeded', 'completed', 'finished'].includes(status);
+    if (explicitFailure) {
+      return nativeSubagentFailureDisposition(evidenceSummary)
+        ?? { kind: 'unknown', evidenceSummary };
+    }
+    if (explicitSuccess) return { kind: 'success', evidenceSummary };
+    return { kind: 'unknown', evidenceSummary };
+  }
+
+  if (toolName && !isNativeSubagentSpawnToolName(toolName)) return { kind: 'unknown', evidenceSummary };
+
+  return nativeSubagentFailureDisposition(evidenceSummary)
+    ?? { kind: 'unknown', evidenceSummary };
 }
 
 function isNativeSubagentUnsupportedReason(value: unknown): value is NativeSubagentUnsupportedReason {
@@ -283,6 +360,12 @@ const NATIVE_SUBAGENT_SPAWN_TOOL_PATTERN = /(?:^|\.)spawn_agent$/;
 // alias. The suffix anchor keeps `respawn_agent`/`spawn_agentx` from matching.
 export function isNativeSubagentSpawnToolName(name: string): boolean {
   return NATIVE_SUBAGENT_SPAWN_TOOL_PATTERN.test(name) || name === 'task';
+}
+
+const NATIVE_SUBAGENT_RESULT_TOOL_PATTERN = /(?:^|\.)(?:spawn_agent|list_agents|followup_task|wait_agent)$/;
+
+export function isNativeSubagentResultToolName(name: string): boolean {
+  return NATIVE_SUBAGENT_RESULT_TOOL_PATTERN.test(name) || name === 'task';
 }
 
 function availableToolsEvidence(payload: Record<string, unknown> | null): NativeSubagentSupportEvidence | null {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -19629,6 +19629,90 @@ PY`,
     }
   });
 
+  it("does not persist support or capacity poison from successful collaboration child output", async () => {
+    for (const toolName of [
+      "collaboration.spawn_agent",
+      "collaboration.list_agents",
+      "collaboration.followup_task",
+      "collaboration.wait_agent",
+    ]) {
+      const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-collaboration-success-"));
+      try {
+        await dispatchCodexNativeHook(
+          {
+            hook_event_name: "PostToolUse",
+            cwd,
+            session_id: "sess-collaboration-success",
+            thread_id: "thread-collaboration-success",
+            tool_name: toolName,
+            tool_response: {
+              success: true,
+              status: "completed",
+              output: "Child completed. Optional packed plugin was unavailable, unsupported, and not found.",
+            },
+          },
+          { cwd },
+        );
+
+        const stateDir = join(cwd, ".omx", "state");
+        assert.equal(existsSync(join(stateDir, "native-subagent-support.json")), false, toolName);
+        assert.equal(existsSync(join(stateDir, "native-subagent-capacity-blocker.json")), false, toolName);
+
+        await dispatchCodexNativeHook({
+          hook_event_name: "SessionStart",
+          cwd,
+          session_id: "sess-collaboration-success",
+          thread_id: "thread-collaboration-success",
+        }, { cwd });
+        assert.equal(existsSync(join(stateDir, "native-subagent-support.json")), false, `${toolName} restart`);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("does not persist legacy prose poison from non-spawn collaboration results", async () => {
+    for (const toolName of [
+      "collaboration.list_agents",
+      "collaboration.followup_task",
+      "collaboration.wait_agent",
+    ]) {
+      const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-collaboration-legacy-success-"));
+      try {
+        await dispatchCodexNativeHook({
+          hook_event_name: "PostToolUse",
+          cwd,
+          tool_name: toolName,
+          tool_response: "Successful result: optional dependency unavailable, unsupported, or not found.",
+        }, { cwd });
+        assert.equal(existsSync(join(cwd, ".omx", "state", "native-subagent-support.json")), false, toolName);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("does not persist native blockers from structured failures on unrelated tools", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-unrelated-structured-failure-"));
+    try {
+      await dispatchCodexNativeHook({
+        hook_event_name: "PostToolUse",
+        cwd,
+        tool_name: "Bash",
+        tool_response: {
+          success: false,
+          status: "failed",
+          error: "optional plugin is unsupported and unavailable",
+        },
+      }, { cwd });
+      const stateDir = join(cwd, ".omx", "state");
+      assert.equal(existsSync(join(stateDir, "native-subagent-support.json")), false);
+      assert.equal(existsSync(join(stateDir, "native-subagent-capacity-blocker.json")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("blocks close_agent cleanup after recent native subagent capacity exhaustion", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-subagent-capacity-close-block-"));
     try {

--- a/src/scripts/__tests__/smoke-packed-install.test.ts
+++ b/src/scripts/__tests__/smoke-packed-install.test.ts
@@ -48,6 +48,7 @@ import {
   assertGeneratedTrustMatchesCodex,
   managedCodexHooksByEvent,
 } from '../smoke-packed-install.js';
+import { parseNativeSubagentResultDisposition } from '../../leader/contract.js';
 
 function createFakeCodexAppServer(
   onRequest: (request: Record<string, unknown>, child: EventEmitter & Record<string, unknown>) => void,
@@ -95,6 +96,22 @@ test('packed 0.144.5 fixture is sanitized, pointer-free, and kept separate from 
   assert.equal(Object.hasOwn(PACKED_CODEX_01445_NO_POINTER_NO_TRACKER_FIXTURE, 'cwd'), false);
   assert.equal(Object.hasOwn(PACKED_CODEX_01445_NO_POINTER_NO_TRACKER_FIXTURE, 'thread_id'), false);
   assert.equal(PACKED_CODEX_01445_NO_POINTER_NO_TRACKER_FIXTURE.session_id.includes('-'), true);
+});
+
+test('packed plugin collaboration success stays authoritative over unrelated child prose', () => {
+  const packedResponse = JSON.stringify({
+    success: true,
+    status: 'completed',
+    output: 'Packed/plugin child succeeded; an optional adapter was unavailable, unsupported, and not found.',
+  });
+  for (const toolName of [
+    'collaboration.spawn_agent',
+    'collaboration.list_agents',
+    'collaboration.followup_task',
+    'collaboration.wait_agent',
+  ]) {
+    assert.equal(parseNativeSubagentResultDisposition(toolName, packedResponse).kind, 'success', toolName);
+  }
 });
 
 test('packed lifecycle keeps the pinned newline-delimited Codex app-server envelopes literal', () => {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -133,6 +133,7 @@ import {
   isRoleRoutingUnavailableEvidence,
   isUnsupportedNativeSubagentEvidence,
   parseRoleIntentCorrelationToken,
+  parseNativeSubagentResultDisposition,
   resolveNativeSubagentSupportStatus,
   type NativeSubagentUnsupportedReason,
 } from "../leader/contract.js";
@@ -3496,42 +3497,20 @@ function readJsonSyncIfExists(path: string): Record<string, unknown> | null {
   }
 }
 
-function stringifyUnknown(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (value === undefined || value === null) return "";
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
-}
 
-function payloadEvidenceText(payload: CodexHookPayload): string {
-  return [
-    safeString(payload.tool_name),
-    stringifyUnknown(payload.tool_response),
-    stringifyUnknown(payload.response),
-    stringifyUnknown(payload.error),
-    stringifyUnknown(payload.message),
-  ].filter(Boolean).join("\n");
+function nativeSubagentResultDisposition(payload: CodexHookPayload) {
+  const toolName = safeString(payload.tool_name).trim();
+  const result = payload.tool_response ?? payload.response ?? payload.error ?? payload.message;
+  return parseNativeSubagentResultDisposition(toolName, result);
 }
 
 function isNativeSubagentCapacityFailure(payload: CodexHookPayload): boolean {
-  const evidence = payloadEvidenceText(payload);
-  if (!/\bagent thread limit reached\b/i.test(evidence)) return false;
-  const toolName = safeString(payload.tool_name).trim();
-  return !toolName || /(?:spawn_agent|multi_agent|subagent|collab|agent)/i.test(toolName);
+  return nativeSubagentResultDisposition(payload).kind === "capacity";
 }
 
 function nativeSubagentFailureReason(payload: CodexHookPayload): NativeSubagentUnsupportedReason | null {
-  const evidence = payloadEvidenceText(payload);
-  const toolName = safeString(payload.tool_name).trim();
-  if (toolName && !/(?:spawn_agent|multi_agent|subagent|collab|agent)/i.test(toolName)) return null;
-  if (/\bagent thread limit reached\b/i.test(evidence)) return null;
-  if (/\bnative subagents? (?:unsupported|disabled|not enabled|unavailable|not found)\b/i.test(evidence)) return "native_subagents_unsupported";
-  if (/\bmulti_agent_v1\b/i.test(evidence) && /\b(?:unavailable|unknown tool|disabled|not enabled|not found|unsupported)\b/i.test(evidence)) return "multi_agent_v1_unavailable";
-  if (/\b(?:unknown tool|tool not found|not enabled|disabled|unavailable|unsupported)\b/i.test(evidence)) return "multi_agent_v1_unavailable";
-  return null;
+  const disposition = nativeSubagentResultDisposition(payload);
+  return disposition.kind === "unsupported" ? disposition.reason : null;
 }
 
 function summarizeNativeSubagentSupportFailure(text: string): string {
@@ -3556,7 +3535,7 @@ async function recordNativeSubagentSupportBlocker(
     ...(readPayloadThreadId(payload) ? { thread_id: readPayloadThreadId(payload) } : {}),
     ...(readPayloadTurnId(payload) ? { turn_id: readPayloadTurnId(payload) } : {}),
     ...(safeString(payload.tool_name).trim() ? { tool_name: safeString(payload.tool_name).trim() } : {}),
-    evidence: summarizeNativeSubagentSupportFailure(payloadEvidenceText(payload)),
+    evidence: summarizeNativeSubagentSupportFailure(nativeSubagentResultDisposition(payload).evidenceSummary),
     observed_at: nowIso,
     cwd,
   }, null, 2));
@@ -3604,7 +3583,7 @@ async function recordNativeSubagentCapacityBlocker(
     ...(readPayloadThreadId(payload) ? { thread_id: readPayloadThreadId(payload) } : {}),
     ...(readPayloadTurnId(payload) ? { turn_id: readPayloadTurnId(payload) } : {}),
     ...(safeString(payload.tool_name).trim() ? { tool_name: safeString(payload.tool_name).trim() } : {}),
-    error_summary: summarizeCapacityFailure(payloadEvidenceText(payload)),
+    error_summary: summarizeCapacityFailure(nativeSubagentResultDisposition(payload).evidenceSummary),
     observed_at: new Date(nowMs).toISOString(),
     expires_at: new Date(nowMs + NATIVE_SUBAGENT_CAPACITY_BLOCKER_TTL_MS).toISOString(),
   };


### PR DESCRIPTION
## Summary
- parse native collaboration support/capacity dispositions through one shared structured-result parser
- make explicit structured success authoritative over unrelated child prose mentioning unavailable, unsupported, or not found
- preserve fail-closed explicit failures, deterministic contradictory-field handling, legacy spawn/unknown-tool poison detection, and unsupported_documented_leader_proof behavior
- add restart, packed/plugin, collaboration spawn/list/followup/wait, nullable-error, and non-spawn legacy regressions

## Verification
- npm test
- npm run build
- npm run check:no-unused
- npm run lint
- focused leader contract, native hook, and packed-install test files: 623 tests passed

Fixes #3204

Signed-off-by: Yeachan-Heo <54757707+Yeachan-Heo@users.noreply.github.com>