### PR TITLE
fix(exec): retain detached finalization authority

### DIFF
--- a/src/auth/__tests__/hotswap.test.ts
+++ b/src/auth/__tests__/hotswap.test.ts
@@ -4,6 +4,7 @@ import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runAuthHotswap, type HotswapLifecycle } from "../hotswap.js";
+import type { LaunchSessionBinding } from "../../hooks/session.js";
 
 function sessionPointerAbort(cwd: string): Error {
   return Object.assign(new Error("selected pointer root is unavailable"), {
@@ -20,7 +21,7 @@ function sessionPointerAbort(cwd: string): Error {
 function lifecycle(overrides: Partial<HotswapLifecycle> = {}): HotswapLifecycle {
   return {
     prepareCodexHomeForLaunch: async () => ({}),
-    preLaunch: async () => {},
+    preLaunch: async () => ({ binding: {} as LaunchSessionBinding, completion: { kind: "success" } }),
     postLaunch: async () => {},
     cleanupRuntimeCodexHome: async () => {},
     normalizeCodexLaunchArgs: (args) => args,
@@ -98,6 +99,35 @@ describe("auth hotswap pointer abort lifecycle", () => {
     }
   });
 
+  it("does not mutate a slot or call postLaunch when preLaunch setup fails", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-hotswap-setup-failure-"));
+    const home = join(cwd, "home");
+    const runtimeHome = join(cwd, "runtime-codex-home");
+    const liveAuthPath = join(runtimeHome, "auth.json");
+    let postLaunchCalls = 0;
+    try {
+      await writeAuthSlot(home);
+      await mkdir(runtimeHome, { recursive: true });
+      await writeFile(liveAuthPath, '{"access_token":"live-sentinel"}\n');
+      const status = await runAuthHotswap({
+        cwd,
+        home,
+        env: { CODEX_HOME: runtimeHome },
+        argv: [],
+        lifecycle: lifecycle({
+          prepareCodexHomeForLaunch: async () => ({ codexHomeOverride: runtimeHome }),
+          preLaunch: async () => { throw new Error("mandatory overlay failed"); },
+          postLaunch: async () => { postLaunchCalls += 1; },
+        }),
+      });
+      assert.equal(status, 1);
+      assert.equal(postLaunchCalls, 0);
+      assert.equal(await readFile(liveAuthPath, "utf-8"), '{"access_token":"live-sentinel"}\n');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("runs postLaunch and runtime cleanup after a successful preLaunch then initial useSlot failure", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-hotswap-use-slot-failure-"));
     const home = join(cwd, "home");
@@ -119,6 +149,7 @@ describe("auth hotswap pointer abort lifecycle", () => {
           }),
           preLaunch: async () => {
             await rm(slotPath);
+            return { binding: {} as LaunchSessionBinding, completion: { kind: "success" } };
           },
           postLaunch: async () => {
             postLaunchCalls += 1;
@@ -182,6 +213,7 @@ describe("auth hotswap pointer abort lifecycle", () => {
           }),
           preLaunch: async () => {
             await rm(secondSlotPath);
+            return { binding: {} as LaunchSessionBinding, completion: { kind: "success" } };
           },
           postLaunch: async () => {
             postLaunchCalls += 1;
@@ -196,6 +228,34 @@ describe("auth hotswap pointer abort lifecycle", () => {
       assert.equal(await readFile(codexLog, "utf-8"), "spawned\n");
       assert.equal(postLaunchCalls, 1);
       assert.equal(cleanupCalls, 1);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("auth hotswap terminal lifecycle failures", () => {
+  it("returns nonzero when postLaunch finalization fails", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-hotswap-terminal-failure-"));
+    const home = join(cwd, "home");
+    const runtimeHome = join(cwd, "runtime-codex-home");
+    const binDir = join(cwd, "bin");
+    try {
+      await writeAuthSlot(home);
+      await mkdir(binDir, { recursive: true });
+      await writeFile(join(binDir, "codex"), "#!/bin/sh\nexit 0\n");
+      await chmod(join(binDir, "codex"), 0o755);
+      const status = await runAuthHotswap({
+        cwd,
+        home,
+        env: { CODEX_HOME: runtimeHome, PATH: `${binDir}:/usr/bin:/bin` },
+        argv: [],
+        lifecycle: lifecycle({
+          prepareCodexHomeForLaunch: async () => ({ codexHomeOverride: runtimeHome }),
+          postLaunch: async () => { throw new Error("retained close failed"); },
+        }),
+      });
+      assert.equal(status, 1);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/auth/hotswap.ts
+++ b/src/auth/hotswap.ts
@@ -9,6 +9,7 @@ import { buildRotationPlan, nextSlotAfter } from "./rotation.js";
 import { findLatestRolloutSession } from "./sessions.js";
 import { listSlots, markSlotQuota, readAuthMetadata, useSlot } from "./storage.js";
 import { isSessionPointerLaunchAbort } from "../hooks/session.js";
+import type { LaunchSessionBinding } from "../hooks/session.js";
 
 export interface PreparedHotswapCodexHome {
   codexHomeOverride?: string;
@@ -16,6 +17,11 @@ export interface PreparedHotswapCodexHome {
   projectLocalCodexHomeForCleanup?: string;
   runtimeCodexHomeForCleanup?: string;
 }
+
+export type HotswapCompletionResult =
+  | { kind: "success" }
+  | { kind: "degraded-success"; operations: readonly string[] }
+  | { kind: "failure"; operation: string; error: unknown };
 
 export interface HotswapLifecycle {
   prepareCodexHomeForLaunch: (cwd: string, sessionId: string, env: NodeJS.ProcessEnv) => Promise<PreparedHotswapCodexHome>;
@@ -26,10 +32,11 @@ export interface HotswapLifecycle {
     codexHomeOverride: string | undefined,
     enableNotifyFallbackAuthority: boolean,
     worktreeDirty: boolean,
-  ) => Promise<void>;
+  ) => Promise<{ binding: LaunchSessionBinding; completion: HotswapCompletionResult }>;
   postLaunch: (
     cwd: string,
     sessionId: string,
+    binding: LaunchSessionBinding,
     codexHomeOverride: string | undefined,
     enableNotifyFallbackAuthority: boolean,
     projectLocalCodexHomeForCleanup?: string,
@@ -243,9 +250,13 @@ export async function runAuthHotswap(options: HotswapOptions): Promise<number> {
   const exhausted = new Set<string>();
   let resumeArgs: string[] | null = null;
   let skipPostLaunch = false;
+  let launchEstablished = false;
+  let launch: { binding: LaunchSessionBinding; completion: HotswapCompletionResult } | undefined;
   try {
     try {
-      await lifecycle.preLaunch(cwd, sessionId, notifyTempResult.contract, prepared.codexHomeOverride, true, false);
+      launch = await lifecycle.preLaunch(cwd, sessionId, notifyTempResult.contract, prepared.codexHomeOverride, true, false);
+      if (launch.completion.kind === "failure") throw launch.completion.error;
+    launchEstablished = true;
     } catch (err) {
       if (isSessionPointerLaunchAbort(err)) {
         skipPostLaunch = true;
@@ -318,13 +329,20 @@ export async function runAuthHotswap(options: HotswapOptions): Promise<number> {
     process.stderr.write(`[omx auth] ${redactAuthSecrets(err)}\n`);
     return 1;
   } finally {
-    if (!skipPostLaunch) {
-      await lifecycle.postLaunch(cwd, sessionId, prepared.codexHomeOverride, true, prepared.projectLocalCodexHomeForCleanup).catch((err) => {
-        process.stderr.write(`[omx auth] postLaunch warning: ${redactAuthSecrets(err)}\n`);
-      });
+    let terminalCleanupFailed = false;
+    if (launchEstablished && !skipPostLaunch && launch) {
+      try {
+        await lifecycle.postLaunch(cwd, sessionId, launch.binding, prepared.codexHomeOverride, true, prepared.projectLocalCodexHomeForCleanup);
+      } catch (err) {
+        terminalCleanupFailed = true;
+        process.stderr.write(`[omx auth] postLaunch failed: ${redactAuthSecrets(err)}\n`);
+      }
     }
-    await lifecycle.cleanupRuntimeCodexHome(prepared.runtimeCodexHomeForCleanup, prepared.projectLocalCodexHomeForCleanup).catch((err) => {
+    try {
+      await lifecycle.cleanupRuntimeCodexHome(prepared.runtimeCodexHomeForCleanup, prepared.projectLocalCodexHomeForCleanup);
+    } catch (err) {
       process.stderr.write(`[omx auth] cleanup warning: ${redactAuthSecrets(err)}\n`);
-    });
+    }
+    if (terminalCleanupFailed) return 1;
   }
 }

--- a/src/cli/__tests__/exec.test.ts
+++ b/src/cli/__tests__/exec.test.ts
@@ -306,6 +306,51 @@ describe('omx exec', () => {
     }
   });
 
+  it('archives a native live-to-dead exec binding and leaves cancel immediately usable', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-exec-bound-stale-dead-'));
+    try {
+      const home = join(wd, 'home');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+      const testDir = dirname(fileURLToPath(import.meta.url));
+      const nativeHookPath = join(testDir, '..', '..', '..', 'dist', 'scripts', 'codex-native-hook.js');
+      await mkdir(join(home, '.codex'), { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(
+        fakeCodexPath,
+        [
+          '#!/bin/sh',
+          `printf '%s\\n' '{"hook_event_name":"SessionStart","session_id":"native-exec-stale-dead"}' | ${process.execPath} ${nativeHookPath}`,
+          'printf \'fake-codex:%s\\n\' "$*"',
+        ].join('\n'),
+      );
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+
+      const result = runOmx(wd, ['exec', 'say hi'], {
+        HOME: home,
+        NODE_OPTIONS: '',
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      });
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'session.json')), false);
+      assert.match(await readFile(join(wd, '.omx', 'logs', 'session-history.jsonl'), 'utf-8'), /native-exec-stale-dead/);
+
+      const cancel = runOmx(wd, ['cancel'], {
+        HOME: home,
+        NODE_OPTIONS: '',
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+      });
+      assert.equal(cancel.status, 0, cancel.error || cancel.stderr || cancel.stdout);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
   it('passes exec --help through to codex exec', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-exec-help-'));
     try {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -5543,13 +5543,34 @@ describe("Windows detached leader environment", () => {
   it("serializes inherited parent values into the detached Windows leader command", () => {
     const steps = buildDetachedSessionBootstrapSteps(
       "omx-test", "C:/project", "codex", "hud", null, undefined, null, true, "session-1",
-      undefined, undefined, undefined, { PATH: "C:/parent/bin", CUSTOM_VALUE: "retained", TMUX: "foreign" },
+      undefined, undefined, undefined, {
+        PATH: "C:/runtime-shim;C:/parent/bin",
+        CUSTOM_VALUE: "retained",
+        CODEX_HOME: "C:/project/.codex-runtime",
+        CODEX_SQLITE_HOME: "C:/project/.codex-sqlite",
+        OMX_ROOT: "C:/project/.omx-run",
+        OMX_CODEX_LAUNCH_ID: "launch-id",
+        OMX_NOTIFY_TEMP_CONTRACT: "{\"active\":true}",
+        OMX_TEAM_WORKER_LAUNCH_ARGS: "[\"--model\",\"gpt-5\"]",
+        TMUX: "foreign",
+        TMUX_PANE: "%9",
+        TERM: "xterm-256color",
+      },
     );
     const command = steps[0]?.args.at(-1) ?? "";
     const encodedPayload = command.match(/__detached-session-leader ''([^']+)''/)?.[1];
     assert.ok(encodedPayload);
     const payload = JSON.parse(Buffer.from(encodedPayload!, "base64url").toString("utf8"));
-    assert.deepEqual(payload.parentEnv, { CUSTOM_VALUE: "retained", PATH: "C:/parent/bin" });
+    assert.deepEqual(payload.parentEnv, {
+      CODEX_HOME: "C:/project/.codex-runtime",
+      CODEX_SQLITE_HOME: "C:/project/.codex-sqlite",
+      CUSTOM_VALUE: "retained",
+      OMX_CODEX_LAUNCH_ID: "launch-id",
+      OMX_NOTIFY_TEMP_CONTRACT: "{\"active\":true}",
+      OMX_ROOT: "C:/project/.omx-run",
+      OMX_TEAM_WORKER_LAUNCH_ARGS: "[\"--model\",\"gpt-5\"]",
+      PATH: "C:/runtime-shim;C:/parent/bin",
+    });
   });
 });
 

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -459,6 +459,14 @@ describe("detached launch state machine", () => {
       },
       finalizeSetupFailure: async () => { await step("finalize-setup-failure"); },
       releaseBarrier: async () => { await step("D9"); },
+      abortAndAwaitFinalization: async () => ({
+        acknowledged: true,
+        nonce: "nonce",
+        sessionId: "session",
+        sessionName: "session-name",
+        leaderPid: 123,
+        kind: "failed",
+      }),
       attachOrReturn: async () => { await step("D10"); },
       rollback: async () => { events.push("rollback"); },
     };
@@ -548,12 +556,45 @@ describe("detached launch state machine", () => {
   it("permits rollback only after an authenticated D9 abort acknowledgement", async () => {
     const events: string[] = [];
     const deps = createDependencies(events, "D9");
-    deps.abortAndAwaitFinalization = async () => ({ acknowledged: true });
+    deps.abortAndAwaitFinalization = async () => ({
+      acknowledged: true,
+      nonce: "nonce",
+      sessionId: "session",
+      sessionName: "session-name",
+      leaderPid: 123,
+      kind: "failed",
+    });
     await assert.rejects(() => executeDetachedLaunchStateMachine(
       { preflight: { kind: "available", shouldAttach: true, report: { transitions: ["D0"], rollback: { attempted: [], failures: [] } } } },
       deps,
     ));
     assert.equal(events.includes("rollback"), true);
+  });
+
+  it("fails closed when a purported D9 acknowledgement omits its finalized authority binding", async () => {
+    const events: string[] = [];
+    const deps = createDependencies(events, "D9");
+    deps.abortAndAwaitFinalization = async () => ({ acknowledged: true });
+    await assert.rejects(() => executeDetachedLaunchStateMachine(
+      { preflight: { kind: "available", shouldAttach: true, report: { transitions: ["D0"], rollback: { attempted: [], failures: [] } } } },
+      deps,
+    ));
+    assert.equal(events.includes("rollback"), false);
+  });
+
+  it("preserves the authority-owning leader on a pre-D9 failure without finalized acknowledgement", async () => {
+    const events: string[] = [];
+    const deps = createDependencies(events, "D4");
+    deps.abortAndAwaitFinalization = async () => {
+      events.push("abort-request");
+      return { acknowledged: false };
+    };
+    await assert.rejects(() => executeDetachedLaunchStateMachine(
+      { preflight: { kind: "available", shouldAttach: true, report: { transitions: ["D0"], rollback: { attempted: [], failures: [] } } } },
+      deps,
+    ));
+    assert.deepEqual(events.slice(-2), ["D4", "abort-request"]);
+    assert.equal(events.includes("rollback"), false);
   });
 });
 
@@ -5495,6 +5536,20 @@ describe("buildWindowsDetachedChildCommand", () => {
       Buffer.from(result.slice(prefix.length), "base64").toString("utf16le"),
       "$ErrorActionPreference = 'Stop'; & 'codex' '--model' 'gpt-5'; exit $LASTEXITCODE",
     );
+  });
+});
+
+describe("Windows detached leader environment", () => {
+  it("serializes inherited parent values into the detached Windows leader command", () => {
+    const steps = buildDetachedSessionBootstrapSteps(
+      "omx-test", "C:/project", "codex", "hud", null, undefined, null, true, "session-1",
+      undefined, undefined, undefined, { PATH: "C:/parent/bin", CUSTOM_VALUE: "retained", TMUX: "foreign" },
+    );
+    const command = steps[0]?.args.at(-1) ?? "";
+    const encodedPayload = command.match(/__detached-session-leader ''([^']+)''/)?.[1];
+    assert.ok(encodedPayload);
+    const payload = JSON.parse(Buffer.from(encodedPayload!, "base64url").toString("utf8"));
+    assert.deepEqual(payload.parentEnv, { CUSTOM_VALUE: "retained", PATH: "C:/parent/bin" });
   });
 });
 

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -486,7 +486,7 @@ describe("detached launch state machine", () => {
     });
   }
 
-  for (const failure of ["D1", "D2", "D3", "D4", "D5", "D6", "D7", "D9"] as const) {
+  for (const failure of ["D1", "D2", "D3", "D4", "D5", "D6", "D7"] as const) {
     it(`rolls back verified pre-release ownership when ${failure} fails`, async () => {
       const events: string[] = [];
       await assert.rejects(executeDetachedLaunchStateMachine(
@@ -528,6 +528,32 @@ describe("detached launch state machine", () => {
     });
     assert.equal(events.includes("rollback"), false);
     assert.deepEqual(events.slice(-2), ["D9", "D10"]);
+  });
+
+  it("preserves leader authority when D9 publication fails without an authenticated finalization acknowledgement", async () => {
+    const events: string[] = [];
+    const deps = createDependencies(events, "D9");
+    deps.abortAndAwaitFinalization = async () => {
+      events.push("abort-request");
+      return { acknowledged: false };
+    };
+    await assert.rejects(() => executeDetachedLaunchStateMachine(
+      { preflight: { kind: "available", shouldAttach: true, report: { transitions: ["D0"], rollback: { attempted: [], failures: [] } } } },
+      deps,
+    ));
+    assert.deepEqual(events.slice(-2), ["D9", "abort-request"]);
+    assert.equal(events.includes("rollback"), false);
+  });
+
+  it("permits rollback only after an authenticated D9 abort acknowledgement", async () => {
+    const events: string[] = [];
+    const deps = createDependencies(events, "D9");
+    deps.abortAndAwaitFinalization = async () => ({ acknowledged: true });
+    await assert.rejects(() => executeDetachedLaunchStateMachine(
+      { preflight: { kind: "available", shouldAttach: true, report: { transitions: ["D0"], rollback: { attempted: [], failures: [] } } } },
+      deps,
+    ));
+    assert.equal(events.includes("rollback"), true);
   });
 });
 

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, readFileSync, utimesSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { chmod, lstat, mkdir, mkdtemp, readFile, readdir as fsReaddir, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { delimiter, dirname, join } from "node:path";
 import { tmpdir } from "node:os";
@@ -14,6 +15,7 @@ import {
   buildTmuxPaneCommand,
   shouldSourceTmuxPaneShellRc,
   buildWindowsPromptCommand,
+  buildWindowsDetachedChildCommand,
   buildTmuxSessionName,
   resolveCliInvocation,
   parseResumeCodexHomeSelection,
@@ -52,6 +54,8 @@ import {
   createMadmaxIsolatedRoot,
   buildMadmaxDetachedLaunchContextKey,
   withMadmaxDetachedContextLock,
+  executeDetachedLaunchStateMachine,
+  type DetachedLaunchDependencies,
   resolveOmxRootForLaunch,
   resolveDisposableWorktreeOmxRootForLaunch,
   prepareCodexHomeForLaunch,
@@ -79,7 +83,6 @@ import {
   resolveNotifyFallbackWatcherScript,
   resolveHookDerivedWatcherScript,
   resolveNotifyHookScript,
-  buildDetachedWindowsBootstrapScript,
   acquireTmuxExtendedKeysLease,
   resolveNativeSessionName,
   releaseTmuxExtendedKeysLease,
@@ -382,7 +385,7 @@ describe("madmax state isolation", () => {
       await writeFile(join(lockPath, "pid"), "2147483647");
 
       let ran = false;
-      const result = withMadmaxDetachedContextLock(
+      const result = await withMadmaxDetachedContextLock(
         runs,
         contextKey,
         () => {
@@ -417,7 +420,7 @@ describe("madmax state isolation", () => {
       );
       await writeFile(join(lockPath, "pid"), String(process.pid));
 
-      assert.throws(
+      await assert.rejects(
         () => withMadmaxDetachedContextLock(runs, contextKey, () => "should-not-run", { maxAttempts: 1, retryMs: 0 }),
         (err: unknown) => {
           assert.ok(err instanceof Error);
@@ -434,6 +437,97 @@ describe("madmax state isolation", () => {
     } finally {
       await rm(runs, { recursive: true, force: true });
     }
+  });
+});
+
+describe("detached launch state machine", () => {
+  function createDependencies(events: string[], failAt?: string): DetachedLaunchDependencies<string, string, string> {
+    const step = async (name: string): Promise<void> => {
+      events.push(name);
+      if (failAt === name) throw new Error(name);
+    };
+    return {
+      establish: async () => { await step("D1"); return "binding"; },
+      complete: async () => { await step("D2"); return { kind: "success" }; },
+      createInertSession: async () => { await step("D3"); return "inert"; },
+      capturePane: async () => { await step("D4"); return "%1"; },
+      updateNameMetadata: async () => { await step("D5"); return "committed-released"; },
+      updatePaneMetadata: async () => { await step("D6"); return "committed-released"; },
+      publishActiveRecord: async () => {
+        await step("D7");
+        return { bytes: "record", digest: "digest", nonce: "nonce" };
+      },
+      finalizeSetupFailure: async () => { await step("finalize-setup-failure"); },
+      releaseBarrier: async () => { await step("D9"); },
+      attachOrReturn: async () => { await step("D10"); },
+      rollback: async () => { events.push("rollback"); },
+    };
+  }
+
+  it("uses the frozen D0 outcome without rediscovering transport or reuse", async () => {
+    const events: string[] = [];
+    const result = await executeDetachedLaunchStateMachine(
+      { preflight: { kind: "available", shouldAttach: true, report: { transitions: ["D0"], rollback: { attempted: [], failures: [] } } } },
+      createDependencies(events),
+    );
+    assert.equal(result.kind, "attached");
+    assert.deepEqual(events, ["D1", "D2", "D3", "D4", "D5", "D6", "D7", "D9", "D10"]);
+  });
+
+  for (const platform of ["posix", "native-windows"] as const) {
+    it(`${platform}: releases only after atomic record and starts exactly once`, async () => {
+      const events: string[] = [];
+      const result = await executeDetachedLaunchStateMachine(
+        { preflight: { kind: "available", shouldAttach: platform === "posix", report: { transitions: ["D0"], rollback: { attempted: [], failures: [] } } } },
+        createDependencies(events),
+      );
+      assert.equal(result.kind, platform === "posix" ? "attached" : "returned");
+      assert.deepEqual(events, ["D1", "D2", "D3", "D4", "D5", "D6", "D7", "D9", "D10"]);
+    });
+  }
+
+  for (const failure of ["D1", "D2", "D3", "D4", "D5", "D6", "D7", "D9"] as const) {
+    it(`rolls back verified pre-release ownership when ${failure} fails`, async () => {
+      const events: string[] = [];
+      await assert.rejects(executeDetachedLaunchStateMachine(
+        { preflight: { kind: "available", shouldAttach: true, report: { transitions: ["D0"], rollback: { attempted: [], failures: [] } } } },
+        createDependencies(events, failure),
+      ), (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.equal((err as { report?: { transitions: string[] } }).report?.transitions.at(-1), failure);
+        return true;
+      });
+      assert.ok(events.includes("rollback"));
+      assert.equal(events.includes("D10"), false);
+    });
+  }
+
+  it("finalizes and closes exactly once before D2 rollback without transport effects", async () => {
+    const events: string[] = [];
+    const deps = createDependencies(events);
+    deps.complete = async () => {
+      events.push("D2");
+      return { kind: "failure", operation: "session-instructions", error: new Error("instructions") };
+    };
+    await assert.rejects(() => executeDetachedLaunchStateMachine(
+      { preflight: { kind: "available", shouldAttach: true, report: { transitions: ["D0"], rollback: { attempted: [], failures: [] } } } },
+      deps,
+    ));
+    assert.deepEqual(events, ["D1", "D2", "finalize-setup-failure", "rollback"]);
+  });
+
+  it("never rolls back, deletes records, or falls back after D10 attach failure", async () => {
+    const events: string[] = [];
+    await assert.rejects(executeDetachedLaunchStateMachine(
+      { preflight: { kind: "available", shouldAttach: true, report: { transitions: ["D0"], rollback: { attempted: [], failures: [] } } } },
+      createDependencies(events, "D10"),
+    ), (err: unknown) => {
+      assert.ok(err instanceof Error);
+      assert.equal((err as { report?: { transitions: string[] } }).report?.transitions.at(-1), "D10");
+      return true;
+    });
+    assert.equal(events.includes("rollback"), false);
+    assert.deepEqual(events.slice(-2), ["D9", "D10"]);
   });
 });
 
@@ -3359,7 +3453,7 @@ describe("pointer launch aborts", () => {
       });
 
       assert.equal(result.status, 1, result.stderr || result.stdout);
-      assert.match(result.stderr, /session_pointer_context_failure/);
+      assert.match(result.stderr, /Unable to establish launch directory capability/);
       assert.equal(existsSync(codexLog), false);
       assert.equal(existsSync(tmuxLog), false);
       assert.equal(existsSync(join(wd, ".omx", "state", "sessions")), false);
@@ -4513,562 +4607,47 @@ exit 0
     }), false);
   });
 
-  it("buildDetachedSessionBootstrapSteps starts native Windows detached sessions with powershell", () => {
-    const hudCmd = buildWindowsPromptCommand("node", [
-      "omx.js",
-      "hud",
-      "--watch",
-    ]);
+  it("buildDetachedSessionBootstrapSteps starts native Windows with the persistent internal leader", () => {
     const steps = buildDetachedSessionBootstrapSteps(
-      "omx-demo",
-      "C:/project",
-      "'codex' '--dangerously-bypass-approvals-and-sandbox'",
-      hudCmd,
-      "--model gpt-5",
-      "C:/codex-home",
-      null,
-      true,
+      "omx-demo", "C:/project", buildWindowsDetachedChildCommand("codex", ["--model", "gpt-5"]),
+      "'node' 'omx.js' 'hud' '--watch'", null, undefined, null, true, "omx-session-123",
+      "C:/project/.codex", "C:/project/.omx/runtime/codex-home/omx-session-123", undefined,
+      process.env, undefined, undefined, undefined,
+      "C:/project/.omx/runtime/detached-release/omx-session-123.release",
+      "C:/project/dist/cli/omx.js",
     );
-    assert.equal(steps[0]?.name, "new-session");
-    assert.equal(steps[0]?.args.at(-1), "powershell.exe");
-    assert.equal(steps[1]?.name, "split-and-capture-hud-pane");
-    assert.equal(steps[1]?.args.at(-1), hudCmd);
+    const leaderCmd = steps[0]?.args.at(-1);
+    assert.equal(typeof leaderCmd, "string");
+    assert.match(leaderCmd!, /powershell\.exe -NoLogo -NoProfile -NonInteractive -Command/);
+    assert.match(leaderCmd!, /__detached-session-leader/);
+    assert.doesNotMatch(leaderCmd!, /__detached-post-launch|Test-Path -LiteralPath/);
   });
 
-  it("buildDetachedWindowsBootstrapScript targets the resolved tmux-compatible command", () => {
-    const script = buildDetachedWindowsBootstrapScript(
-      "omx-demo",
-      "powershell.exe -NoLogo -NoExit -EncodedCommand abc",
-      2500,
-      "C:\\Program Files\\psmux\\psmux.exe",
-    );
-    assert.match(script, /const tmuxCommand = "C:\\\\Program Files\\\\psmux\\\\psmux\.exe";/);
-    assert.match(script, /execFileSync\(tmuxCommand, \['send-keys'/);
-    assert.doesNotMatch(script, /execFileSync\('tmux'/);
-  });
-
-  it("buildDetachedSessionBootstrapSteps kills detached tmux session on normal shell exit", () => {
+  it("buildDetachedSessionBootstrapSteps gives the POSIX leader persistent lifecycle ownership", () => {
+    const releaseMarkerPath = "/tmp/project/.omx/runtime/detached-release/omx-session-123.release";
     const steps = buildDetachedSessionBootstrapSteps(
-      "omx-demo",
-      "/tmp/project",
-      "'codex' '--model' 'gpt-5'",
-      "'node' '/tmp/omx.js' 'hud' '--watch'",
-      null,
+      "omx-demo", "/tmp/project", "'codex' '--model' 'gpt-5'", "'node' '/tmp/omx.js' 'hud' '--watch'",
+      null, "/tmp/codex-home", null, false, "omx-session-123", "/tmp/project/.codex-project",
+      "/tmp/project/.omx/runtime/codex-home/omx-session-123", undefined, process.env, undefined,
+      undefined, undefined, releaseMarkerPath,
     );
     const leaderCmd = steps[0]?.args.at(-1);
     assert.equal(typeof leaderCmd, "string");
     assert.match(leaderCmd!, /^\/bin\/sh -c '/);
-    assert.doesNotMatch(leaderCmd!, /^\/bin\/sh -lc '/);
-    assert.match(leaderCmd!, /acquireTmuxExtendedKeysLease/);
-    assert.match(leaderCmd!, /omx_detached_session_cleanup\(\)/);
-    assert.match(leaderCmd!, /trap omx_detached_session_cleanup 0 INT TERM HUP;/);
-    assert.match(leaderCmd!, /exec 3<&0;/);
-    assert.match(leaderCmd!, /omx_codex_pid=\$!;/);
-    assert.match(leaderCmd!, /<\&3 &/);
-    assert.match(leaderCmd!, /wait "\$omx_codex_pid";/);
-    assert.match(leaderCmd!, /kill -TERM "\$omx_codex_pid"/);
-    assert.match(leaderCmd!, /releaseTmuxExtendedKeysLease/);
-    assert.match(leaderCmd!, /if \[ "\$status" -eq 0 \]; then/);
-    assert.match(leaderCmd!, /tmux kill-session -t/);
-    assert.match(leaderCmd!, /"omx-demo"/);
-    assert.match(leaderCmd!, /codex exited immediately with code 0/);
-    assert.match(leaderCmd!, /codex exited with code/);
-    assert.match(leaderCmd!, /detached tmux session is being kept open/);
-    assert.match(leaderCmd!, /exit \$status/);
+    assert.match(leaderCmd!, /__detached-session-leader/);
+    assert.doesNotMatch(leaderCmd!, /__detached-post-launch|omx_codex_pid|while \[ ! -f/);
   });
 
-  it("buildDetachedSessionBootstrapSteps finalizes postLaunch inside the detached leader when a session id is available", () => {
+  it("keeps capability data out of the detached leader command payload", () => {
     const steps = buildDetachedSessionBootstrapSteps(
-      "omx-demo",
-      "/tmp/project",
-      "'codex' '--model' 'gpt-5'",
-      "'node' '/tmp/omx.js' 'hud' '--watch'",
-      null,
-      "/tmp/codex-home",
-      null,
-      false,
-      "omx-session-123",
-      "/tmp/project/.codex-project",
-      "/tmp/project/.omx/runtime/codex-home/omx-session-123",
+      "omx-demo", "/tmp/project", "codex", "hud", null, undefined, null, false,
+      "omx-session-123", undefined, undefined, undefined, process.env,
     );
-    const leaderCmd = steps[0]?.args.at(-1);
-    assert.equal(typeof leaderCmd, "string");
-    assert.match(leaderCmd!, /runDetachedSessionPostLaunch/);
-    assert.match(leaderCmd!, /omx-session-123/);
-    assert.match(leaderCmd!, /\/tmp\/codex-home/);
-    assert.match(leaderCmd!, /\/tmp\/project\/\.codex-project/);
-    assert.match(leaderCmd!, /\/tmp\/project\/\.omx\/runtime\/codex-home\/omx-session-123/);
-    const helperIndex = leaderCmd!.indexOf("runDetachedSessionPostLaunch");
-    const signalGateIndex = leaderCmd!.indexOf('if [ "$status" -eq 0 ]');
-    assert.ok(helperIndex >= 0);
-    assert.ok(signalGateIndex >= 0);
-    assert.ok(
-      helperIndex < signalGateIndex,
-      "detached postLaunch helper must run before the signal-derived tmux kill-session gate",
-    );
+    const leaderCmd = steps[0]?.args.at(-1) ?? "";
+    assert.match(leaderCmd, /__detached-session-leader/);
+    assert.doesNotMatch(leaderCmd, /launch_lineage_token|directoryIdentity|FileHandle/);
   });
 
-  it("detached leader command keeps stdin open for the Codex child", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-detached-leader-stdin-"));
-    const fakeBin = join(cwd, "bin");
-    const stdinLogPath = join(cwd, "stdin.log");
-
-    try {
-      await mkdir(fakeBin, { recursive: true });
-      await writeFile(
-        join(fakeBin, "codex"),
-        `#!/bin/sh
-if IFS= read -r line; then
-  printf 'stdin:%s\n' "$line" > "${stdinLogPath}"
-else
-  printf 'stdin:EOF\n' > "${stdinLogPath}"
-fi
-`,
-      );
-      await chmod(join(fakeBin, "codex"), 0o755);
-      await writeFile(
-        join(fakeBin, "tmux"),
-        `#!/bin/sh
-case "$1" in
-  display-message)
-    if [ "$3" = '#{socket_path}' ] || [ "$4" = '#{socket_path}' ]; then
-      printf '/tmp/tmux-test.sock\n'
-    else
-      printf '0\n'
-    fi
-    ;;
-  show-options)
-    printf 'off\n'
-    ;;
-  set-option|kill-session)
-    ;;
-esac
-exit 0
-`,
-      );
-      await chmod(join(fakeBin, "tmux"), 0o755);
-
-      const steps = buildDetachedSessionBootstrapSteps(
-        "omx-demo",
-        cwd,
-        buildTmuxPaneCommand("codex", [], "/bin/sh"),
-        "'node' '/tmp/omx.js' 'hud' '--watch'",
-        null,
-      );
-      const leaderCmd = steps[0]?.args.at(-1);
-      assert.equal(typeof leaderCmd, "string");
-
-      const result = (await import("node:child_process")).spawnSync("/bin/sh", ["-c", leaderCmd!], {
-        cwd,
-        env: {
-          ...process.env,
-          PATH: `${fakeBin}:/usr/bin:/bin`,
-          HOME: cwd,
-        },
-        input: "hello from leader\n",
-        encoding: "utf-8",
-      });
-
-      assert.equal(result.status, 0, result.stderr || result.stdout);
-      const stdinLog = await readFile(stdinLogPath, "utf-8");
-      assert.match(stdinLog, /stdin:hello from leader/);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it("detached leader command preserves cwd and cleanup without shell-quote breakage", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-detached-leader-"));
-    const fakeBin = join(cwd, "bin");
-    const logPath = join(cwd, "leader.log");
-
-    try {
-      await mkdir(fakeBin, { recursive: true });
-      await writeFile(
-        join(fakeBin, "codex"),
-        `#!/bin/sh
-printf 'codex:%s\\n' "$*" >> "${logPath}"
-printf 'codex-pwd:%s\\n' "$(pwd)" >> "${logPath}"
-printf 'codex-bridge-env:%s\\n' "\${OMX_HERMES_MCP_BRIDGE-unset}" >> "${logPath}"
-exit 0
-`,
-      );
-      await chmod(join(fakeBin, "codex"), 0o755);
-      await writeFile(join(cwd, ".profile"), "cd ..\n");
-      await writeFile(
-        join(fakeBin, "tmux"),
-        `#!/bin/sh
-printf 'tmux:%s\\n' "$*" >> "${logPath}"
-case "$1" in
-  display-message)
-    if [ "$3" = '#{socket_path}' ] || [ "$4" = '#{socket_path}' ]; then
-      printf '/tmp/tmux-test.sock\\n'
-    else
-      printf '0\\n'
-    fi
-    ;;
-  show-options)
-    printf 'off\\n'
-    ;;
-  set-option|kill-session)
-    ;;
-esac
-exit 0
-`,
-      );
-      await chmod(join(fakeBin, "tmux"), 0o755);
-
-      const steps = buildDetachedSessionBootstrapSteps(
-        "omx-demo",
-        cwd,
-        buildTmuxPaneCommand(
-          "codex",
-          ["--dangerously-bypass-approvals-and-sandbox"],
-          "/bin/sh",
-        ),
-        "'node' '/tmp/omx.js' 'hud' '--watch'",
-        null,
-      );
-      const leaderCmd = steps[0]?.args.at(-1);
-      assert.equal(typeof leaderCmd, "string");
-
-      (await import("node:child_process")).execFileSync("/bin/sh", ["-c", leaderCmd!], {
-        cwd,
-        env: {
-          ...process.env,
-          PATH: `${fakeBin}:/usr/bin:/bin`,
-          HOME: cwd,
-          OMX_HERMES_MCP_BRIDGE: "1",
-        },
-        stdio: "ignore",
-      });
-
-      const log = await readFile(logPath, "utf-8");
-      assert.match(log, /codex:--dangerously-bypass-approvals-and-sandbox/);
-      assert.match(
-        normalizeDarwinTmpPath(log),
-        new RegExp(`codex-pwd:${escapeRegExp(normalizeDarwinTmpPath(cwd))}`),
-      );
-      assert.match(log, /codex-bridge-env:unset/);
-      assert.match(log, /tmux:display-message -p #\{socket_path\}/);
-      assert.match(log, /tmux:show-options -sv extended-keys/);
-      assert.match(log, /tmux:set-option -sq extended-keys always/);
-      assert.match(log, /tmux:set-option -sq extended-keys off/);
-      assert.match(log, /tmux:kill-session -t omx-demo/);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it("detached leader command preserves the detached tmux session on signal-derived exits", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-detached-leader-signal-"));
-    const fakeBin = join(cwd, "bin");
-    const logPath = join(cwd, "leader.log");
-
-    try {
-      await mkdir(fakeBin, { recursive: true });
-      await writeFile(
-        join(fakeBin, "codex"),
-        `#!/bin/sh
-printf 'codex:%s\\n' "$*" >> "${logPath}"
-exit 143
-`,
-      );
-      await chmod(join(fakeBin, "codex"), 0o755);
-      await writeFile(
-        join(fakeBin, "tmux"),
-        `#!/bin/sh
-printf 'tmux:%s\\n' "$*" >> "${logPath}"
-case "$1" in
-  display-message)
-    if [ "$3" = '#{socket_path}' ] || [ "$4" = '#{socket_path}' ]; then
-      printf '/tmp/tmux-test.sock\\n'
-    else
-      printf '0\\n'
-    fi
-    ;;
-  show-options)
-    printf 'off\\n'
-    ;;
-  set-option|kill-session)
-    ;;
-esac
-exit 0
-`,
-      );
-      await chmod(join(fakeBin, "tmux"), 0o755);
-
-      const steps = buildDetachedSessionBootstrapSteps(
-        "omx-demo",
-        cwd,
-        buildTmuxPaneCommand(
-          "codex",
-          ["--dangerously-bypass-approvals-and-sandbox"],
-          "/bin/sh",
-        ),
-        "'node' '/tmp/omx.js' 'hud' '--watch'",
-        null,
-      );
-      const leaderCmd = steps[0]?.args.at(-1);
-      assert.equal(typeof leaderCmd, "string");
-
-      const result = (await import("node:child_process")).spawnSync("/bin/sh", ["-c", leaderCmd!], {
-        cwd,
-        env: {
-          ...process.env,
-          PATH: `${fakeBin}:/usr/bin:/bin`,
-          HOME: cwd,
-        },
-        encoding: "utf-8",
-      });
-
-      assert.equal(result.status, 143);
-      const log = await readFile(logPath, "utf-8");
-      assert.match(log, /codex:--dangerously-bypass-approvals-and-sandbox/);
-      assert.match(log, /tmux:display-message -p #\{socket_path\}/);
-      assert.match(log, /tmux:show-options -sv extended-keys/);
-      assert.match(log, /tmux:set-option -sq extended-keys always/);
-      assert.match(log, /tmux:set-option -sq extended-keys off/);
-      assert.doesNotMatch(log, /tmux:kill-session -t omx-demo/);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it("detached leader command keeps child startup errors visible instead of killing the session", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-detached-leader-error-"));
-    const fakeBin = join(cwd, "bin");
-    const logPath = join(cwd, "leader.log");
-
-    try {
-      await mkdir(fakeBin, { recursive: true });
-      await writeFile(
-        join(fakeBin, "codex"),
-        `#!/bin/sh
-printf 'codex-stderr: unsupported startup flag\\n' >&2
-exit 42
-`,
-      );
-      await chmod(join(fakeBin, "codex"), 0o755);
-      await writeFile(
-        join(fakeBin, "tmux"),
-        `#!/bin/sh
-printf 'tmux:%s\\n' "$*" >> "${logPath}"
-case "$1" in
-  display-message)
-    if [ "$3" = '#{socket_path}' ] || [ "$4" = '#{socket_path}' ]; then
-      printf '/tmp/tmux-test.sock\\n'
-    else
-      printf '0\\n'
-    fi
-    ;;
-  show-options)
-    printf 'off\\n'
-    ;;
-  set-option|kill-session)
-    ;;
-esac
-exit 0
-`,
-      );
-      await chmod(join(fakeBin, "tmux"), 0o755);
-
-      const steps = buildDetachedSessionBootstrapSteps(
-        "omx-demo",
-        cwd,
-        buildTmuxPaneCommand("codex", ["--bad-startup-flag"], "/bin/sh"),
-        "'node' '/tmp/omx.js' 'hud' '--watch'",
-        null,
-      );
-      const leaderCmd = steps[0]?.args.at(-1);
-      assert.equal(typeof leaderCmd, "string");
-
-      const result = (await import("node:child_process")).spawnSync("/bin/sh", ["-c", leaderCmd!], {
-        cwd,
-        env: {
-          ...process.env,
-          PATH: `${fakeBin}:/usr/bin:/bin`,
-          HOME: cwd,
-        },
-        input: "\n",
-        encoding: "utf-8",
-      });
-
-      assert.equal(result.status, 42);
-      assert.match(result.stderr, /codex-stderr: unsupported startup flag/);
-      assert.match(result.stderr, /codex exited with code 42 during startup/);
-      assert.match(result.stderr, /detached tmux session is being kept open/);
-      const log = await readFile(logPath, "utf-8");
-      assert.doesNotMatch(log, /tmux:kill-session -t omx-demo/);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it("detached leader command keeps immediate zero-code exits visible instead of silently closing", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-detached-leader-zero-"));
-    const fakeBin = join(cwd, "bin");
-    const logPath = join(cwd, "leader.log");
-
-    try {
-      await mkdir(fakeBin, { recursive: true });
-      await writeFile(
-        join(fakeBin, "codex"),
-        `#!/bin/sh
-printf 'codex-started-then-quit\\n' >&2
-exit 0
-`,
-      );
-      await chmod(join(fakeBin, "codex"), 0o755);
-      await writeFile(
-        join(fakeBin, "tmux"),
-        `#!/bin/sh
-printf 'tmux:%s\\n' "$*" >> "${logPath}"
-case "$1" in
-  display-message)
-    if [ "$3" = '#{socket_path}' ] || [ "$4" = '#{socket_path}' ]; then
-      printf '/tmp/tmux-test.sock\\n'
-    else
-      printf '0\\n'
-    fi
-    ;;
-  show-options)
-    printf 'off\\n'
-    ;;
-  set-option|kill-session)
-    ;;
-esac
-exit 0
-`,
-      );
-      await chmod(join(fakeBin, "tmux"), 0o755);
-
-      const steps = buildDetachedSessionBootstrapSteps(
-        "omx-demo",
-        cwd,
-        buildTmuxPaneCommand("codex", [], "/bin/sh"),
-        "'node' '/tmp/omx.js' 'hud' '--watch'",
-        null,
-      );
-      const leaderCmd = steps[0]?.args.at(-1);
-      assert.equal(typeof leaderCmd, "string");
-
-      const result = (await import("node:child_process")).spawnSync("/bin/sh", ["-c", leaderCmd!], {
-        cwd,
-        env: {
-          ...process.env,
-          PATH: `${fakeBin}:/usr/bin:/bin`,
-          HOME: cwd,
-        },
-        input: "\n",
-        encoding: "utf-8",
-      });
-
-      assert.equal(result.status, 0, result.stderr || result.stdout);
-      assert.match(result.stderr, /codex-started-then-quit/);
-      assert.match(result.stderr, /codex exited immediately with code 0 during startup/);
-      assert.match(result.stderr, /detached tmux session is being kept open/);
-      const log = await readFile(logPath, "utf-8");
-      assert.match(log, /tmux:kill-session -t omx-demo/);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
-
-  it("detached leader command terminates codex child on external SIGHUP", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "omx-detached-leader-hup-"));
-    const fakeBin = join(cwd, "bin");
-    const pidFile = join(cwd, "codex.pid");
-    try {
-      await mkdir(fakeBin, { recursive: true });
-      await writeFile(
-        join(fakeBin, "codex"),
-        `#!/bin/sh
-echo $$ > "${pidFile}"
-trap '' HUP
-while true; do sleep 1; done
-`,
-      );
-      await chmod(join(fakeBin, "codex"), 0o755);
-      await writeFile(
-        join(fakeBin, "tmux"),
-        `#!/bin/sh
-case "$1" in
-  display-message)
-    if [ "$3" = '#{socket_path}' ] || [ "$4" = '#{socket_path}' ]; then
-      printf '/tmp/tmux-test.sock\\n'
-    else
-      printf '0\\n'
-    fi
-    ;;
-  show-options) printf 'off\\n' ;;
-  set-option|kill-session) ;;
-esac
-exit 0
-`,
-      );
-      await chmod(join(fakeBin, "tmux"), 0o755);
-
-      const steps = buildDetachedSessionBootstrapSteps(
-        "omx-demo",
-        cwd,
-        buildTmuxPaneCommand("codex", [], "/bin/sh"),
-        "'node' '/tmp/omx.js' 'hud' '--watch'",
-        null,
-      );
-      const leaderCmd = steps[0]?.args.at(-1);
-      assert.equal(typeof leaderCmd, "string");
-
-      const { spawn } = await import("node:child_process");
-      const child = spawn("/bin/sh", ["-c", `exec ${leaderCmd!}`], {
-        cwd,
-        env: {
-          ...process.env,
-          PATH: `${fakeBin}:/usr/bin:/bin`,
-          HOME: cwd,
-        },
-        stdio: "ignore",
-        detached: true,
-      });
-
-      try {
-        for (let i = 0; i < 50; i += 1) {
-          if (existsSync(pidFile)) break;
-          await new Promise((resolve) => setTimeout(resolve, 100));
-        }
-        assert.ok(existsSync(pidFile), "codex pid file not written");
-        const codexPid = Number.parseInt((await readFile(pidFile, "utf-8")).trim(), 10);
-        assert.ok(codexPid > 0, "codex pid must be positive");
-        assert.doesNotThrow(() => process.kill(codexPid, 0), "codex must be alive before signal");
-
-        const leaderExit = once(child, "exit");
-        process.kill(child.pid!, "SIGHUP");
-        await Promise.race([
-          leaderExit,
-          new Promise((_, reject) =>
-            setTimeout(() => reject(new Error("leader did not exit after SIGHUP")), 3000),
-          ),
-        ]);
-        assert.throws(
-          () => process.kill(codexPid, 0),
-          (err: unknown) =>
-            typeof err === "object" &&
-            err !== null &&
-            "code" in err &&
-            (err as NodeJS.ErrnoException).code === "ESRCH",
-          "codex child must be terminated after leader SIGHUP",
-        );
-      } finally {
-        try {
-          process.kill(child.pid!, "SIGKILL");
-        } catch {
-          /* already dead */
-        }
-      }
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
 
   it("withTmuxExtendedKeys enables tmux extended keys during codex launch and restores them afterwards", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-tmux-lease-wrapper-"));
@@ -5876,6 +5455,19 @@ describe("buildWindowsPromptCommand", () => {
     assert.equal(
       decoded,
       "$ErrorActionPreference = 'Stop'; & { & 'codex' '--dangerously-bypass-approvals-and-sandbox' '-c' 'model_reasoning_effort=\"high\"' 'it''s' }",
+    );
+  });
+});
+
+describe("buildWindowsDetachedChildCommand", () => {
+  it("exits with the Codex child status instead of retaining an interactive shell", () => {
+    const result = buildWindowsDetachedChildCommand("codex", ["--model", "gpt-5"]);
+    const prefix = "powershell.exe -NoLogo -NoProfile -NonInteractive -EncodedCommand ";
+    assert.ok(result.startsWith(prefix));
+    assert.doesNotMatch(result, /-NoExit/);
+    assert.equal(
+      Buffer.from(result.slice(prefix.length), "base64").toString("utf16le"),
+      "$ErrorActionPreference = 'Stop'; & 'codex' '--model' 'gpt-5'; exit $LASTEXITCODE",
     );
   });
 });

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -1961,6 +1961,7 @@ exit 0
       );
 
       if (shouldSkipForSpawnPermissions(result.error)) return;
+      await waitForPath(`${fakeTmuxPath}.leader-done`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /\/bin\/sh/);

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -102,6 +102,8 @@ if [ "$status" -eq 0 ] && [ "$1" = "new-session" ]; then
   for last_arg do :; done
   pane=$(printf '%s' "$output" | sed -n '1p')
   TMUX=/tmp/omx-test-tmux,1,0 TMUX_PANE="$pane" nohup /bin/sh -c "$last_arg" </dev/null >/tmp/omx-test-detached-leader.log 2>&1 &
+  leader_pid=$!
+  (while kill -0 "$leader_pid" 2>/dev/null; do sleep 0.02; done; printf done > ${JSON.stringify(`${fakeTmuxPath}.leader-done`)}) </dev/null >/dev/null 2>&1 &
 fi
 exit "$status"
 `);
@@ -1265,6 +1267,7 @@ exit 0
       );
       assert.match(tmuxLog, new RegExp(`tmux:split-window -v -l ${HUD_TMUX_HEIGHT_LINES} .* -t `));
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      await waitForPath(`${fakeTmuxPath}.leader-done`);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -1793,7 +1796,7 @@ exit 0
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal(result.status, 1, result.error || result.stderr || result.stdout);
-      assert.match(result.stderr, /Command failed: .*tmux attach-session/);
+      assert.match(result.stderr, /detached launch safety failure during post-release-attach/);
       assert.match(tmuxLog, /tmux:attach-session -t /);
       assert.doesNotMatch(tmuxLog, /tmux:kill-session -t /);
     } finally {
@@ -2047,6 +2050,7 @@ exit 0
       assert.doesNotMatch(tmuxLog, /not-a-real-shell/);
       assert.match(tmuxLog, /__detached-session-leader/);
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      await waitForPath(`${fakeTmuxPath}.leader-done`);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -2071,6 +2075,7 @@ exit 0
         sessionId,
         codexCmd: fakeChild,
         readyPath,
+        preLaunchOptions: { enableNotifyFallbackAuthority: false, worktreeDirty: false },
       })).toString('base64url');
       const leader = spawn(process.execPath, [omxBin, '__detached-session-leader', payload], {
         cwd: wd,
@@ -2084,6 +2089,9 @@ exit 0
         }),
         stdio: ['ignore', 'inherit', 'inherit'],
       });
+      await waitForPath(readyPath);
+      const ready = JSON.parse(await readFile(readyPath, 'utf-8')) as { nonce: string; sessionId: string; sessionName: string };
+      await writeFile(`${readyPath}.release`, `${JSON.stringify({ version: 1, kind: 'release', nonce: ready.nonce, sessionId: ready.sessionId, sessionName: ready.sessionName })}\n`);
       await waitForPath(childReady);
       assert.equal(existsSync(readyPath), true);
       assert.equal(existsSync(join(wd, '.omx', 'state', 'session.json')), true);

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
-import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
@@ -90,6 +90,21 @@ async function createGitRepo(wd: string): Promise<string> {
 async function writeExecutable(path: string, content: string): Promise<void> {
   await writeFile(path, content);
   await chmod(path, 0o755);
+}
+async function wrapFakeTmuxWithDetachedLeader(fakeTmuxPath: string): Promise<void> {
+  const implementationPath = `${fakeTmuxPath}.impl`;
+  await rename(fakeTmuxPath, implementationPath);
+  await writeExecutable(fakeTmuxPath, `#!/bin/sh
+output=$(${JSON.stringify(implementationPath)} "$@")
+status=$?
+printf '%s' "$output"
+if [ "$status" -eq 0 ] && [ "$1" = "new-session" ]; then
+  for last_arg do :; done
+  pane=$(printf '%s' "$output" | sed -n '1p')
+  TMUX=/tmp/omx-test-tmux,1,0 TMUX_PANE="$pane" nohup /bin/sh -c "$last_arg" </dev/null >/tmp/omx-test-detached-leader.log 2>&1 &
+fi
+exit "$status"
+`);
 }
 
 async function createLaunchFixture(
@@ -884,17 +899,20 @@ exit 0
       const second = runOmx(wd, ['--madmax', '--tmux'], baseEnv);
       if (shouldSkipForSpawnPermissions(second.error)) return;
       assert.equal(second.status, 0, second.error || second.stderr || second.stdout);
-      assert.doesNotMatch(second.stderr, /madmax detached launch already active/);
+      assert.match(second.stderr, /madmax detached launch already active for this context/);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.equal((tmuxLog.match(/tmux:new-session/g) || []).length, 2);
-      assert.equal(existsSync(join(runs, 'active-detached', 'boxed-context-under-test.json')), false);
+      assert.equal((tmuxLog.match(/tmux:new-session/g) || []).length, 1);
+      const activeRecord = await readFile(join(runs, 'active-detached', 'boxed-context-under-test.json'), 'utf-8');
+      assert.match(activeRecord, /"leader_pid"/);
+      assert.match(activeRecord, /"base_state_root"/);
+      assert.match(activeRecord, /"lifecycle_phase": "ready"/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
   });
 
-  it('keeps boxed runtime identity in leader launch environment without outer active records', async () => {
+  it('records boxed runtime identity in the leader-owned active record', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-madmax-worktree-detached-'));
     try {
       const repo = await createGitRepo(wd);
@@ -963,7 +981,13 @@ exit 0
       if (shouldSkipForSpawnPermissions(result.error)) return;
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
 
-      assert.deepEqual(await readdir(join(runs, 'active-detached')), []);
+      const activeFiles = await readdir(join(runs, 'active-detached'));
+      assert.equal(activeFiles.length, 1);
+      const activeRecord = JSON.parse(await readFile(join(runs, 'active-detached', activeFiles[0]!), 'utf-8')) as { source_cwd: string; worktree_cwd?: string; leader_pid?: number; lifecycle_phase?: string };
+      const worktreePath = join(dirname(repo), `${basename(repo)}.omx-worktrees`, 'launch-detached');
+      assert.equal(normalizeDarwinTmpPath(activeRecord.source_cwd), normalizeDarwinTmpPath(worktreePath));
+      assert.equal(typeof activeRecord.leader_pid, 'number');
+      assert.equal(activeRecord.lifecycle_phase, 'ready');
       const tmuxLog = normalizeDarwinTmpPath(await readFile(tmuxLogPath, 'utf-8'));
       assert.match(tmuxLog, /__detached-session-leader/);
       assert.match(tmuxLog, /-e OMXBOX_ACTIVE=1/);
@@ -1106,7 +1130,7 @@ exit 0
         registryEntries[1]!.detached_launch_context,
         'independent launches must get distinct active-detached lock identities',
       );
-      assert.deepEqual(await readdir(join(runs, 'active-detached')), []);
+      assert.equal((await readdir(join(runs, 'active-detached'))).length, 2);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal((tmuxLog.match(/tmux:new-session/g) || []).length, 2);
@@ -1210,6 +1234,7 @@ exit 0
 `,
       );
       await chmod(fakeTmuxPath, 0o755);
+      await wrapFakeTmuxWithDetachedLeader(fakeTmuxPath);
 
       const result = runOmx(
         wd,
@@ -1300,6 +1325,7 @@ case "$1" in
       TERMINFO=/tmp/server-terminfo \
       TERMINFO_DIRS=/tmp/server-terminfo-dirs \
       TERMCAP=server-termcap \
+      nohup /bin/sh -c "$last" </dev/null >/tmp/omx-test-provider-leader.log 2>&1 &
     printf '%%12\n'
     exit 0
     ;;
@@ -1581,6 +1607,7 @@ exit 0
 `,
       );
       await chmod(fakeTmuxPath, 0o755);
+      await wrapFakeTmuxWithDetachedLeader(fakeTmuxPath);
 
       const result = runOmx(
         wd,
@@ -1653,6 +1680,7 @@ exit 1
 `,
       );
       await chmod(fakeTmuxPath, 0o755);
+      await wrapFakeTmuxWithDetachedLeader(fakeTmuxPath);
 
       const result = runOmx(
         wd,
@@ -1745,6 +1773,7 @@ exit 0
 `,
       );
       await chmod(fakeTmuxPath, 0o755);
+      await wrapFakeTmuxWithDetachedLeader(fakeTmuxPath);
 
       const result = runOmx(
         wd,
@@ -1902,6 +1931,7 @@ exit 0
 `,
       );
       await chmod(fakeTmuxPath, 0o755);
+      await wrapFakeTmuxWithDetachedLeader(fakeTmuxPath);
 
       const result = runOmx(
         wd,
@@ -1993,6 +2023,7 @@ exit 0
 `,
       );
       await chmod(fakeTmuxPath, 0o755);
+      await wrapFakeTmuxWithDetachedLeader(fakeTmuxPath);
 
       const result = runOmx(
         wd,
@@ -2065,7 +2096,8 @@ exit 0
       assert.equal(exitCode, 0);
       assert.equal(existsSync(join(wd, '.omx', 'state', 'session.json')), false);
       assert.equal(existsSync(join(wd, '.omx', 'state', 'detached-active-record.json')), false);
-      assert.equal(existsSync(readyPath), false);
+      assert.equal(existsSync(readyPath), true);
+      await rm(readyPath, { force: true });
       assert.match(await readFile(join(wd, '.omx', 'logs', 'session-history.jsonl'), 'utf-8'), new RegExp(sessionId));
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -104,10 +104,22 @@ async function createLaunchFixture(
   await mkdir(fakeBin, { recursive: true });
   await writeExecutable(
     join(fakeBin, 'codex'),
-    '#!/bin/sh\nprintf \'fake-codex:%s\\n\' "$*"\n',
+    '#!/bin/sh\nprintf \'fake-codex:%s\\n\' "$*"\nsleep 1\n',
   );
   await writeExecutable(join(fakeBin, 'ps'), '#!/bin/sh\nexit 0\n');
-  await writeExecutable(join(fakeBin, 'tmux'), tmuxScript(tmuxLogPath));
+  const tmuxImpl = join(fakeBin, 'tmux-impl');
+  await writeExecutable(tmuxImpl, tmuxScript(tmuxLogPath));
+  await writeExecutable(join(fakeBin, 'tmux'), `#!/bin/sh
+output=$(${JSON.stringify(tmuxImpl)} "$@")
+status=$?
+printf '%s' "$output"
+if [ "$status" -eq 0 ] && [ "$1" = "new-session" ]; then
+  for last_arg do :; done
+  pane=$(printf '%s' "$output" | sed -n '1p')
+  TMUX=/tmp/omx-test-tmux,1,0 TMUX_PANE="$pane" nohup /bin/sh -c "$last_arg" </dev/null >/tmp/omx-test-detached-leader.log 2>&1 &
+fi
+exit "$status"
+`);
 
   return {
     tmuxLogPath,
@@ -2010,4 +2022,53 @@ exit 0
   });
 
 
+  it('keeps finalization authority in the real detached leader process through child exit', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-detached-leader-process-'));
+    const home = join(wd, 'home');
+    const fakeChild = join(wd, 'fake-codex.sh');
+    const childReady = join(wd, 'child-ready');
+    const childRelease = join(wd, 'child-release');
+    const readyPath = join(wd, '.omx', 'runtime', 'detached-release', 'ready');
+    const omxBin = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'dist', 'cli', 'omx.js');
+    const sessionId = 'omx-detached-leader-process';
+    try {
+      await mkdir(home, { recursive: true });
+      await writeExecutable(fakeChild, `#!/bin/sh\nprintf ready > ${JSON.stringify(childReady)}\nwhile [ ! -f ${JSON.stringify(childRelease)} ]; do sleep 0.02; done\nexit 0\n`);
+      const payload = Buffer.from(JSON.stringify({
+        cwd: wd,
+        sessionName: 'omx-detached-leader-process',
+        sessionId,
+        codexCmd: fakeChild,
+        readyPath,
+      })).toString('base64url');
+      const leader = spawn(process.execPath, [omxBin, '__detached-session-leader', payload], {
+        cwd: wd,
+        env: buildRunOmxEnv({
+          HOME: home,
+          TMUX: '/tmp/fake-tmux,1,0',
+          TMUX_PANE: '%3202',
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+        }),
+        stdio: ['ignore', 'inherit', 'inherit'],
+      });
+      await waitForPath(childReady);
+      assert.equal(existsSync(readyPath), true);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'session.json')), true);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'detached-active-record.json')), true);
+      await writeFile(childRelease, 'release\n');
+      const exitCode = await new Promise<number | null>((resolveExit, rejectExit) => {
+        leader.once('error', rejectExit);
+        leader.once('exit', resolveExit);
+      });
+      assert.equal(exitCode, 0);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'session.json')), false);
+      assert.equal(existsSync(join(wd, '.omx', 'state', 'detached-active-record.json')), false);
+      assert.equal(existsSync(readyPath), false);
+      assert.match(await readFile(join(wd, '.omx', 'logs', 'session-history.jsonl'), 'utf-8'), new RegExp(sessionId));
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -70,8 +70,10 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function shouldSkipForSpawnPermissions(err: string): boolean {
-  return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
+function shouldSkipForSpawnPermissions(_err: string): false {
+  // These integration fixtures are contractual: EPERM/EACCES is a failure,
+  // not a pass. Node's test runner has no portable dynamic skip here.
+  return false;
 }
 
 
@@ -1793,6 +1795,7 @@ exit 0
       );
 
       if (shouldSkipForSpawnPermissions(result.error)) return;
+      await waitForPath(`${fakeTmuxPath}.leader-done`);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal(result.status, 1, result.error || result.stderr || result.stdout);

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -264,7 +264,7 @@ exit 42
       assert.match(result.stderr, /codex-startup-boom/);
       assert.match(result.stderr, /\[omx\] codex exited with code 42/);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -294,7 +294,7 @@ exit 42
       assert.match(result.stderr, /failed to launch codex: executable not found in PATH/);
       assert.notEqual(result.stderr.trim(), '');
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -335,7 +335,7 @@ exit 42
       assert.match(result.stdout, /fake-codex:.*model_reasoning_effort="xhigh"/);
       assert.doesNotMatch(result.stderr, /spawnSync tmux ENOENT/);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -420,7 +420,7 @@ exit 42
         'after second marker',
       ]);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -488,7 +488,7 @@ exec "$NODE_BINARY" -e 'const fs = require("node:fs"); const path = require("nod
         assert.equal(captured.hasResumeSqlite, testCase.resumes, JSON.stringify(testCase.args));
       }
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 });
@@ -526,7 +526,7 @@ describe('ordinary launch root collision guidance', () => {
       await finalizeBoundOnce(binding, 'test');
     } finally {
       if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -563,7 +563,7 @@ describe('ordinary launch root collision guidance', () => {
     } finally {
       if (first) first.kill('SIGKILL');
       if (second) second.kill('SIGKILL');
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -602,7 +602,7 @@ describe('ordinary launch root collision guidance', () => {
     } finally {
       if (firstBinding) await closeLaunchSessionBindingOnce(firstBinding).catch(() => {});
       if (secondBinding) await closeLaunchSessionBindingOnce(secondBinding).catch(() => {});
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 });
@@ -648,7 +648,7 @@ printf 'fake-codex:%s\n' "$*"
       assert.equal(existsSync(join(repo, '.omx', 'state')), true);
       assert.equal(existsSync(join(worktreePath, '.omx')), false);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -689,7 +689,7 @@ printf 'fake-codex:%s\n' "$*"
       assert.equal(existsSync(join(explicitRoot, '.omx', 'state')), true);
       assert.equal(existsSync(join(repo, '.omx')), false);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -750,7 +750,7 @@ printf 'fake-codex:%s\n' "$*"
       );
       assert.match(normalizedStdout, /fake-codex-context:[0-9a-f]{32}/);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 });
@@ -819,7 +819,7 @@ exit 0
       assert.doesNotMatch(tmuxLog, /tmux:attach-session/);
       assert.doesNotMatch(result.stderr, /failed to attach detached tmux session/);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 });
@@ -916,7 +916,7 @@ exit 0
       assert.match(activeRecord, /"base_state_root"/);
       assert.match(activeRecord, /"lifecycle_phase": "ready"/);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -1002,7 +1002,7 @@ exit 0
       assert.match(tmuxLog, new RegExp(`-e OMX_SOURCE_CWD=${escapeRegExp(normalizeDarwinTmpPath(repo))}`));
       await waitForPath(leaderDonePath);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -1090,7 +1090,7 @@ exit 0
       assert.doesNotMatch(tmuxLog, /tmux:clear-history .*user-owned-session|tmux:clear-history .*%99/);
       assert.match(tmuxLog, /tmux:new-session /);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -1145,7 +1145,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal((tmuxLog.match(/tmux:new-session/g) || []).length, 2);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -1184,7 +1184,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal((tmuxLog.match(/tmux:new-session/g) || []).length, 2);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -1277,7 +1277,7 @@ exit 0
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       await waitForPath(`${fakeTmuxPath}.leader-done`);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -1396,7 +1396,7 @@ exit 0
       assert.match(tmuxLog, /__detached-session-leader/);
       assert.doesNotMatch(tmuxLog, /fake-provider-key|CUSTOM_LLM_API_KEY=/);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -1433,7 +1433,7 @@ exit 0
       assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
       assert.doesNotMatch(tmuxLog, /new-session|split-window|attach-session/);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -1466,7 +1466,7 @@ exit 0
       assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
       assert.doesNotMatch(tmuxLog, /new-session|split-window|attach-session/);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -1498,7 +1498,7 @@ exit 0
       assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
       assert.doesNotMatch(tmuxLog, /split-window|show-options|extended-keys|mouse on/);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -1556,7 +1556,7 @@ exit 0
       assert.match(tmuxLog, /tmux:set-option -t managed-session mouse on/);
       assert.match(tmuxLog, /tmux:set-option -sq extended-keys always/);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -1643,7 +1643,7 @@ exit 0
       assert.match(tmuxLog, /tmux:new-session .* -s /);
       assert.doesNotMatch(result.stderr, /server\/socket is unusable/);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -1721,7 +1721,7 @@ exit 1
       assert.match(tmuxLog, /tmux:new-session/);
       assert.doesNotMatch(tmuxLog, /tmux:list-sessions|attach-session/);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -1809,7 +1809,7 @@ exit 0
       assert.match(tmuxLog, /tmux:attach-session -t /);
       assert.doesNotMatch(tmuxLog, /tmux:kill-session -t /);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -1873,7 +1873,7 @@ exit 0
       assert.match(tmuxLog, /tmux:attach-session -t /);
       assert.doesNotMatch(tmuxLog, /tmux:display-message -p -t .* #\{session_attached\}|tmux:kill-session -t/);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -1968,7 +1968,7 @@ exit 0
       assert.match(tmuxLog, /__detached-session-leader/);
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -2062,7 +2062,7 @@ exit 0
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       await waitForPath(`${fakeTmuxPath}.leader-done`);
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 
@@ -2073,19 +2073,31 @@ exit 0
     const fakeChild = join(wd, 'fake-codex.sh');
     const childReady = join(wd, 'child-ready');
     const childRelease = join(wd, 'child-release');
+    const childEnv = join(wd, 'child-env');
+    const descendantPidPath = join(wd, 'descendant-pid');
     const readyPath = join(wd, '.omx', 'runtime', 'detached-release', 'ready');
     const omxBin = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'dist', 'cli', 'omx.js');
     const sessionId = 'omx-detached-leader-process';
     try {
       await mkdir(home, { recursive: true });
-      await writeExecutable(fakeChild, `#!/bin/sh\nprintf ready > ${JSON.stringify(childReady)}\nwhile [ ! -f ${JSON.stringify(childRelease)} ]; do sleep 0.02; done\nexit 0\n`);
+      await writeExecutable(fakeChild, `#!/bin/sh\nprintf '%s' "$OMX_NOTIFY_TEMP_CONTRACT" > ${JSON.stringify(childEnv)}\n(sh -c 'trap "" TERM; while :; do sleep 1; done') &\nprintf '%s' "$!" > ${JSON.stringify(descendantPidPath)}\nprintf ready > ${JSON.stringify(childReady)}\nwhile [ ! -f ${JSON.stringify(childRelease)} ]; do sleep 0.02; done\nexit 0\n`);
       const payload = Buffer.from(JSON.stringify({
         cwd: wd,
         sessionName: 'omx-detached-leader-process',
         sessionId,
         codexCmd: fakeChild,
         readyPath,
-        preLaunchOptions: { enableNotifyFallbackAuthority: false, worktreeDirty: false },
+        preLaunchOptions: {
+          notifyTempContract: {
+            active: true,
+            selectors: ['custom:test-provider'],
+            canonicalSelectors: ['custom:test-provider'],
+            warnings: [],
+            source: 'cli',
+          },
+          enableNotifyFallbackAuthority: false,
+          worktreeDirty: false,
+        },
       })).toString('base64url');
       const leader = spawn(process.execPath, [omxBin, '__detached-session-leader', payload], {
         cwd: wd,
@@ -2100,9 +2112,16 @@ exit 0
         stdio: ['ignore', 'inherit', 'inherit'],
       });
       await waitForPath(readyPath);
-      const ready = JSON.parse(await readFile(readyPath, 'utf-8')) as { nonce: string; sessionId: string; sessionName: string };
-      await writeFile(`${readyPath}.release`, `${JSON.stringify({ version: 1, kind: 'release', nonce: ready.nonce, sessionId: ready.sessionId, sessionName: ready.sessionName })}\n`);
+      const ready = JSON.parse(await readFile(readyPath, 'utf-8')) as { nonce: string; sessionId: string; sessionName: string; leaderPid: number };
+      await writeFile(`${readyPath}.release`, `${JSON.stringify({ version: 1, kind: 'release', nonce: `${ready.nonce}-foreign`, sessionId: ready.sessionId, sessionName: ready.sessionName, leaderPid: ready.leaderPid })}\n`);
+      await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+      assert.equal(existsSync(childReady), false);
+      await writeFile(`${readyPath}.release`, `${JSON.stringify({ version: 1, kind: 'release', nonce: ready.nonce, sessionId: ready.sessionId, sessionName: ready.sessionName, leaderPid: ready.leaderPid })}\n`);
       await waitForPath(childReady);
+      assert.match(await readFile(childEnv, 'utf-8'), /custom:test-provider/);
+      await waitForPath(descendantPidPath);
+      const descendantPid = Number.parseInt((await readFile(descendantPidPath, 'utf-8')).trim(), 10);
+      assert.equal(Number.isSafeInteger(descendantPid) && descendantPid > 0, true);
       assert.equal(existsSync(readyPath), true);
       assert.equal(existsSync(join(wd, '.omx', 'state', 'session.json')), true);
       assert.equal(existsSync(join(wd, '.omx', 'state', 'detached-active-record.json')), true);
@@ -2112,13 +2131,34 @@ exit 0
         leader.once('exit', resolveExit);
       });
       assert.equal(exitCode, 0);
+      assert.throws(() => process.kill(descendantPid, 0), (error: unknown) => (error as NodeJS.ErrnoException).code === 'ESRCH');
+      const terminalReport = JSON.parse(await readFile(readyPath, 'utf-8')) as {
+        version: number;
+        kind: string;
+        nonce: string;
+        sessionId: string;
+        sessionName: string;
+        paneId: string;
+        leaderPid: number;
+        finalized: boolean;
+      };
+      assert.deepEqual(terminalReport, {
+        version: 1,
+        kind: 'terminal',
+        nonce: ready.nonce,
+        sessionId: ready.sessionId,
+        sessionName: ready.sessionName,
+        leaderPid: ready.leaderPid,
+        paneId: '%3202',
+        finalized: true,
+      });
       assert.equal(existsSync(join(wd, '.omx', 'state', 'session.json')), false);
       assert.equal(existsSync(join(wd, '.omx', 'state', 'detached-active-record.json')), false);
       assert.equal(existsSync(readyPath), true);
       await rm(readyPath, { force: true });
       assert.match(await readFile(join(wd, '.omx', 'logs', 'session-history.jsonl'), 'utf-8'), new RegExp(sessionId));
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }
   });
 });

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -114,10 +114,11 @@ exit "$status"
 async function createLaunchFixture(
   wd: string,
   tmuxScript: (tmuxLogPath: string) => string,
-): Promise<{ env: Record<string, string>; tmuxLogPath: string }> {
+): Promise<{ env: Record<string, string>; tmuxLogPath: string; leaderDonePath: string }> {
   const home = join(wd, 'home');
   const fakeBin = join(wd, 'bin');
   const tmuxLogPath = join(wd, 'tmux.log');
+  const leaderDonePath = join(wd, 'leader-done');
 
   await mkdir(home, { recursive: true });
   await mkdir(fakeBin, { recursive: true });
@@ -136,12 +137,15 @@ if [ "$status" -eq 0 ] && [ "$1" = "new-session" ]; then
   for last_arg do :; done
   pane=$(printf '%s' "$output" | sed -n '1p')
   TMUX=/tmp/omx-test-tmux,1,0 TMUX_PANE="$pane" nohup /bin/sh -c "$last_arg" </dev/null >/tmp/omx-test-detached-leader.log 2>&1 &
+  leader_pid=$!
+  (while kill -0 "$leader_pid" 2>/dev/null; do sleep 0.02; done; printf done > ${JSON.stringify(join(wd, 'leader-done'))}) </dev/null >/dev/null 2>&1 &
 fi
 exit "$status"
 `);
 
   return {
     tmuxLogPath,
+    leaderDonePath,
     env: {
       HOME: home,
       PATH: `${fakeBin}:/usr/bin:/bin`,
@@ -922,7 +926,7 @@ exit 0
       const repo = await createGitRepo(wd);
       const runs = join(wd, 'runs');
       const instanceMarker = join(wd, 'active-instance');
-      const { env, tmuxLogPath } = await createLaunchFixture(
+      const { env, tmuxLogPath, leaderDonePath } = await createLaunchFixture(
         wd,
         (logPath) => `#!/bin/sh
 printf 'tmux:%s\n' "$*" >> "${logPath}"
@@ -996,6 +1000,7 @@ exit 0
       assert.match(tmuxLog, /__detached-session-leader/);
       assert.match(tmuxLog, /-e OMXBOX_ACTIVE=1/);
       assert.match(tmuxLog, new RegExp(`-e OMX_SOURCE_CWD=${escapeRegExp(normalizeDarwinTmpPath(repo))}`));
+      await waitForPath(leaderDonePath);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -1021,7 +1026,7 @@ exit 0
           tmux_pane_id: '%99',
         })}\n`,
       );
-      const { env, tmuxLogPath } = await createLaunchFixture(
+      const { env, tmuxLogPath, leaderDonePath } = await createLaunchFixture(
         wd,
         (logPath) => `#!/bin/sh
 printf 'tmux:%s\n' "$*" >> "${logPath}"
@@ -1079,6 +1084,7 @@ exit 0
 
       if (shouldSkipForSpawnPermissions(result.error)) return;
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      await waitForPath(leaderDonePath);
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.doesNotMatch(tmuxLog, /tmux:set-option .* -t user-owned-session .*history-limit/);
       assert.doesNotMatch(tmuxLog, /tmux:clear-history .*user-owned-session|tmux:clear-history .*%99/);

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -8,7 +8,13 @@ import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { HUD_TMUX_HEIGHT_LINES } from '../../hud/constants.js';
 import { DETACHED_TMUX_HISTORY_LIMIT } from '../index.js';
-import { writeSessionEnd, writeSessionStart } from '../../hooks/session.js';
+import {
+  closeLaunchSessionBindingOnce,
+  establishLaunchSessionBinding,
+  finalizeBoundOnce,
+  writeSessionStart,
+  type LaunchSessionBinding,
+} from '../../hooks/session.js';
 
 const CLI_SPAWN_TIMEOUT_MS = 60_000;
 
@@ -28,6 +34,7 @@ function buildRunOmxEnv(envOverrides: Record<string, string>): NodeJS.ProcessEnv
   }
   return {
     ...env,
+    OMX_TEST_DETACHED_READY_BYPASS: '1',
     ...envOverrides,
   };
 }
@@ -455,10 +462,14 @@ exec "$NODE_BINARY" -e 'const fs = require("node:fs"); const path = require("nod
 describe('ordinary launch root collision guidance', () => {
   it('keeps the cwd default for the first launch and fails the second and third launches closed with explicit-root guidance', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-root-conflict-'));
+    let binding: LaunchSessionBinding | undefined;
     try {
       execFileSync('git', ['init'], { cwd: wd, stdio: 'ignore' });
       const fixture = await createHeldCodexFixture(wd);
-      await writeSessionStart(wd, 'first-standard-launch', { pid: process.pid });
+      const established = await establishLaunchSessionBinding(wd, 'first-standard-launch', { pid: process.pid });
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
 
       const second = runOmx(wd, ['--direct', '--version'], fixture.env);
       const third = runOmx(wd, ['--direct', '--version'], fixture.env);
@@ -478,8 +489,9 @@ describe('ordinary launch root collision guidance', () => {
         assert.match(resume.stderr, /session_pointer_owner_conflict/);
         assert.doesNotMatch(resume.stderr, /concurrent conversations in this checkout require distinct user-specified OMX_ROOT values/);
       }
-      await writeSessionEnd(wd, 'first-standard-launch');
+      await finalizeBoundOnce(binding, 'test');
     } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
       await rm(wd, { recursive: true, force: true });
     }
   });
@@ -521,8 +533,10 @@ describe('ordinary launch root collision guidance', () => {
     }
   });
 
-  it('keeps different checkout defaults independent and relaunches through stale default-pointer evidence', async () => {
+  it('keeps different checkout defaults independent and fails closed on stale default-pointer evidence', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-root-stale-'));
+    let firstBinding: LaunchSessionBinding | undefined;
+    let secondBinding: LaunchSessionBinding | undefined;
     try {
       const firstCheckout = join(wd, 'first-checkout');
       const secondCheckout = join(wd, 'second-checkout');
@@ -531,21 +545,29 @@ describe('ordinary launch root collision guidance', () => {
       execFileSync('git', ['init'], { cwd: firstCheckout, stdio: 'ignore' });
       execFileSync('git', ['init'], { cwd: secondCheckout, stdio: 'ignore' });
 
-      await writeSessionStart(firstCheckout, 'first-checkout-owner', { pid: process.pid });
-      await writeSessionStart(secondCheckout, 'second-checkout-owner', { pid: process.pid });
+      const firstEstablished = await establishLaunchSessionBinding(firstCheckout, 'first-checkout-owner', { pid: process.pid });
+      const secondEstablished = await establishLaunchSessionBinding(secondCheckout, 'second-checkout-owner', { pid: process.pid });
+      assert.equal(firstEstablished.kind, 'committed-released');
+      assert.equal(secondEstablished.kind, 'committed-released');
+      if (firstEstablished.kind !== 'committed-released' || secondEstablished.kind !== 'committed-released') return;
+      firstBinding = firstEstablished.binding;
+      secondBinding = secondEstablished.binding;
       assert.match(await readFile(join(firstCheckout, '.omx', 'state', 'session.json'), 'utf-8'), /first-checkout-owner/);
       assert.match(await readFile(join(secondCheckout, '.omx', 'state', 'session.json'), 'utf-8'), /second-checkout-owner/);
-      await writeSessionEnd(firstCheckout, 'first-checkout-owner');
-      await writeSessionEnd(secondCheckout, 'second-checkout-owner');
+      await finalizeBoundOnce(firstBinding, 'test');
+      await finalizeBoundOnce(secondBinding, 'test');
 
       await writeSessionStart(firstCheckout, 'stale-owner', { pid: 2_147_483_647 });
       const fixture = await createHeldCodexFixture(wd);
       await rm(fixture.releasePath, { force: true });
       const relaunch = runOmx(firstCheckout, ['--direct', '--version'], fixture.env);
       if (shouldSkipForSpawnPermissions(relaunch.error)) return;
-      assert.equal(relaunch.status, 0, relaunch.error || relaunch.stderr || relaunch.stdout);
-      assert.doesNotMatch(relaunch.stderr, /concurrent conversations in this checkout require distinct user-specified OMX_ROOT values/);
+      assert.notEqual(relaunch.status, 0, relaunch.error || relaunch.stderr || relaunch.stdout);
+      assert.match(relaunch.stderr, /session_pointer_unusable|stale-dead/);
+      assert.match(await readFile(join(firstCheckout, '.omx', 'state', 'session.json'), 'utf-8'), /stale-owner/);
     } finally {
+      if (firstBinding) await closeLaunchSessionBindingOnce(firstBinding).catch(() => {});
+      if (secondBinding) await closeLaunchSessionBindingOnce(secondBinding).catch(() => {});
       await rm(wd, { recursive: true, force: true });
     }
   });
@@ -769,7 +791,7 @@ exit 0
 });
 
 describe('omx launcher when tmux is available', () => {
-  it('reuses the same boxed madmax detached launch context instead of spawning duplicate tmux sessions', async () => {
+  it('does not let the outer launcher fabricate leader-owned active records', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-madmax-reuse-'));
     try {
       const runs = join(wd, 'runs');
@@ -851,28 +873,17 @@ exit 0
       const second = runOmx(wd, ['--madmax', '--tmux'], baseEnv);
       if (shouldSkipForSpawnPermissions(second.error)) return;
       assert.equal(second.status, 0, second.error || second.stderr || second.stdout);
-      assert.match(
-        second.stderr,
-        /madmax detached launch already active for this context; attaching .* instead of starting a duplicate/,
-      );
+      assert.doesNotMatch(second.stderr, /madmax detached launch already active/);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.equal((tmuxLog.match(/tmux:new-session/g) || []).length, 1);
-      assert.equal((tmuxLog.match(/tmux:has-session/g) || []).length, 1);
-      assert.equal((tmuxLog.match(/tmux:attach-session/g) || []).length, 2);
-      const activeRecords = await readFile(
-        join(runs, 'active-detached', 'boxed-context-under-test.json'),
-        'utf-8',
-      );
-      assert.match(activeRecords, /"tmux_session_name"/);
-      assert.match(activeRecords, /"session_id"/);
-      assert.match(activeRecords, /"tmux_pane_id": "%12"/);
+      assert.equal((tmuxLog.match(/tmux:new-session/g) || []).length, 2);
+      assert.equal(existsSync(join(runs, 'active-detached', 'boxed-context-under-test.json')), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
   });
 
-  it('records boxed runtime identity for detached madmax worktree launches', async () => {
+  it('keeps boxed runtime identity in leader launch environment without outer active records', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-madmax-worktree-detached-'));
     try {
       const repo = await createGitRepo(wd);
@@ -941,21 +952,11 @@ exit 0
       if (shouldSkipForSpawnPermissions(result.error)) return;
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
 
-      const activeFiles = await readdir(join(runs, 'active-detached'));
-      assert.equal(activeFiles.length, 1);
-      const activeRecord = JSON.parse(await readFile(join(runs, 'active-detached', activeFiles[0]), 'utf-8'));
-      const worktreePath = join(dirname(repo), `${basename(repo)}.omx-worktrees`, 'launch-detached');
-      assert.match(activeRecord.run_dir, new RegExp(`^${escapeRegExp(normalizeDarwinTmpPath(runs))}/run-`));
-      assert.equal(normalizeDarwinTmpPath(activeRecord.source_cwd), normalizeDarwinTmpPath(repo));
-      assert.equal(normalizeDarwinTmpPath(activeRecord.worktree_cwd), normalizeDarwinTmpPath(worktreePath));
-      assert.equal(activeRecord.session_id.startsWith('omx-'), true);
-      assert.equal(activeRecord.tmux_pane_id, '%77');
-
+      assert.deepEqual(await readdir(join(runs, 'active-detached')), []);
       const tmuxLog = normalizeDarwinTmpPath(await readFile(tmuxLogPath, 'utf-8'));
-      assert.match(tmuxLog, new RegExp(`-e OMX_ROOT=${escapeRegExp(normalizeDarwinTmpPath(activeRecord.run_dir))}`));
+      assert.match(tmuxLog, /__detached-session-leader/);
       assert.match(tmuxLog, /-e OMXBOX_ACTIVE=1/);
       assert.match(tmuxLog, new RegExp(`-e OMX_SOURCE_CWD=${escapeRegExp(normalizeDarwinTmpPath(repo))}`));
-      assert.match(tmuxLog, new RegExp(`-e OMX_MADMAX_DETACHED_CONTEXT=${escapeRegExp(activeRecord.context_key)}`));
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -1094,14 +1095,7 @@ exit 0
         registryEntries[1]!.detached_launch_context,
         'independent launches must get distinct active-detached lock identities',
       );
-      assert.equal(
-        existsSync(join(runs, 'active-detached', `${registryEntries[0]!.detached_launch_context}.json`)),
-        true,
-      );
-      assert.equal(
-        existsSync(join(runs, 'active-detached', `${registryEntries[1]!.detached_launch_context}.json`)),
-        true,
-      );
+      assert.deepEqual(await readdir(join(runs, 'active-detached')), []);
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal((tmuxLog.match(/tmux:new-session/g) || []).length, 2);
@@ -1295,8 +1289,7 @@ case "$1" in
       TERMINFO=/tmp/server-terminfo \
       TERMINFO_DIRS=/tmp/server-terminfo-dirs \
       TERMCAP=server-termcap \
-      sh -c "$last" >/dev/null 2>&1 || true
-    printf 'leader-pane\\n'
+    printf '%%12\n'
     exit 0
     ;;
   split-window)
@@ -1351,28 +1344,9 @@ exit 0
       if (shouldSkipForSpawnPermissions(result.error)) return;
 
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
-      assert.equal(
-        await readFile(envLogPath, 'utf-8'),
-        [
-          'custom=fake-provider-key',
-          'marker=1',
-          'term=tmux-256color',
-          'term_program=tmux',
-          'term_program_version=3.4',
-          'colorterm=truecolor',
-          'tmux=/tmp/tmux-test.sock,123,0',
-          'tmux_pane=%12',
-          'columns=211',
-          'lines=77',
-          'terminfo=/tmp/outer-terminfo',
-          'terminfo_dirs=/tmp/outer-terminfo-dirs',
-          'termcap=outer-termcap',
-          '',
-        ].join('\n'),
-      );
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.doesNotMatch(tmuxLog, /fake-provider-key/);
-      assert.doesNotMatch(tmuxLog, /CUSTOM_LLM_API_KEY=/);
+      assert.match(tmuxLog, /__detached-session-leader/);
+      assert.doesNotMatch(tmuxLog, /fake-provider-key|CUSTOM_LLM_API_KEY=/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -1538,7 +1512,8 @@ exit 0
     }
   });
 
-  it('treats a missing tmux server socket as safe for detached tmux startup', async () => {
+  it('does not probe an existing tmux server before detached tmux startup', async () => {
+
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-missing-socket-'));
     try {
       const home = join(wd, 'home');
@@ -1566,12 +1541,9 @@ case "$1" in
     printf 'tmux 3.6a\n'
     exit 0
     ;;
-  list-sessions)
-    printf 'error connecting to /private/tmp/tmux-501/default (No such file or directory)\n' >&2
-    exit 1
-    ;;
+
   new-session)
-    printf 'leader-pane\n'
+    printf '%%12\n'
     exit 0
     ;;
   split-window)
@@ -1617,7 +1589,8 @@ exit 0
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
-      assert.match(tmuxLog, /tmux:list-sessions/);
+      assert.doesNotMatch(tmuxLog, /tmux:list-sessions/);
+
       assert.match(tmuxLog, /tmux:new-session .* -s /);
       assert.doesNotMatch(result.stderr, /server\/socket is unusable/);
     } finally {
@@ -1625,7 +1598,8 @@ exit 0
     }
   });
 
-  it('falls back directly when tmux is installed but the server socket is unusable', async () => {
+  it('does not fall back directly when a later detached tmux operation fails', async () => {
+
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-stale-socket-'));
     try {
       const home = join(wd, 'home');
@@ -1634,6 +1608,8 @@ exit 0
       const fakePsPath = join(fakeBin, 'ps');
       const fakeTmuxPath = join(fakeBin, 'tmux');
       const tmuxLogPath = join(wd, 'tmux.log');
+      const runsPath = join(wd, 'runs');
+
 
       await mkdir(home, { recursive: true });
       await mkdir(fakeBin, { recursive: true });
@@ -1650,13 +1626,16 @@ exit 0
 printf 'tmux:%s\n' "$*" >> "${tmuxLogPath}"
 case "$1" in
   -V)
+    printf 'tmux:d0-runs:%s\n' "$(test -e "${runsPath}" && printf present || printf missing)" >> "${tmuxLogPath}"
+
     printf 'tmux 3.6a\n'
     exit 0
     ;;
-  list-sessions)
-    printf 'error connecting to /tmp/tmux-1000/default (Operation not permitted)\n' >&2
+  new-session)
+    printf 'unsafe-tmux-handle-secret\n' >&2
     exit 1
     ;;
+
 esac
 printf 'unexpected tmux command: %s\n' "$*" >&2
 exit 1
@@ -1673,6 +1652,8 @@ exit 1
           OMX_AUTO_UPDATE: '0',
           OMX_NOTIFY_FALLBACK: '0',
           OMX_HOOK_DERIVED_SIGNALS: '0',
+          OMX_RUNS_DIR: runsPath,
+
           TMUX: '',
           TMUX_PANE: '',
         },
@@ -1681,16 +1662,20 @@ exit 1
       if (shouldSkipForSpawnPermissions(result.error)) return;
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
-      assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
-      assert.match(result.stderr, /server\/socket is unusable/);
-      assert.doesNotMatch(tmuxLog, /new-session|attach-session/);
+      assert.equal(result.status, 1, result.error || result.stderr || result.stdout);
+      assert.match(result.stderr, /detached launch safety failure during inert-session/);
+      assert.doesNotMatch(result.stderr, /unsafe-tmux-handle-secret/);
+      assert.doesNotMatch(result.stdout, /fake-codex/);
+      assert.match(tmuxLog, /tmux:-V/);
+      assert.match(tmuxLog, /tmux:d0-runs:missing/);
+      assert.match(tmuxLog, /tmux:new-session/);
+      assert.doesNotMatch(tmuxLog, /tmux:list-sessions|attach-session/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
   });
 
-  it('rolls back and falls back directly when attaching the detached tmux session fails', async () => {
+  it('preserves detached ownership when attaching the released tmux session fails', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-attach-fail-'));
     try {
       const home = join(wd, 'home');
@@ -1718,7 +1703,7 @@ case "$1" in
     exit 0
     ;;
   new-session)
-    printf 'leader-pane\n'
+    printf '%%12\n'
     exit 0
     ;;
   split-window)
@@ -1767,16 +1752,16 @@ exit 0
       if (shouldSkipForSpawnPermissions(result.error)) return;
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
-      assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
+      assert.equal(result.status, 1, result.error || result.stderr || result.stdout);
+      assert.match(result.stderr, /Command failed: .*tmux attach-session/);
       assert.match(tmuxLog, /tmux:attach-session -t /);
-      assert.match(tmuxLog, /tmux:kill-session -t /);
+      assert.doesNotMatch(tmuxLog, /tmux:kill-session -t /);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
   });
 
-  it('rolls back with guidance when WSL Windows Terminal attach exits without attaching', async () => {
+  it('does not probe or fall back after a released WSL attach returns immediately', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-tmux-attach-noop-'));
     try {
       const { env, tmuxLogPath } = await createLaunchFixture(
@@ -1788,7 +1773,7 @@ case "$1" in
     exit 0
     ;;
   new-session)
-    printf 'leader-pane\n'
+    printf '%%12\n'
     exit 0
     ;;
   split-window)
@@ -1832,12 +1817,9 @@ exit 0
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
-      assert.match(result.stdout, /fake-codex:.*--dangerously-bypass-approvals-and-sandbox/);
-      assert.match(result.stderr, /attach-session returned immediately without attaching a client/i);
-      assert.match(result.stderr, /Falling back to direct Codex launch/i);
+      assert.doesNotMatch(result.stderr, /Falling back to direct Codex launch|attach-session returned immediately/);
       assert.match(tmuxLog, /tmux:attach-session -t /);
-      assert.match(tmuxLog, /tmux:display-message -p -t .* #\{session_attached\}/);
-      assert.match(tmuxLog, /tmux:kill-session -t /);
+      assert.doesNotMatch(tmuxLog, /tmux:display-message -p -t .* #\{session_attached\}|tmux:kill-session -t/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -1882,11 +1864,7 @@ case "$cmd" in
     exit 0
     ;;
   new-session)
-    for last; do :; done
-    if [ -n "\${last:-}" ]; then
-      /bin/sh -c "$last"
-    fi
-    printf 'leader-pane\\n'
+    printf '%%12\n'
     exit 0
     ;;
   split-window)
@@ -1931,9 +1909,9 @@ exit 0
 
       if (shouldSkipForSpawnPermissions(result.error)) return;
 
-      const codexLog = normalizeDarwinTmpPath(await readFile(codexLogPath, 'utf-8'));
-      assert.match(codexLog, /codex:.*--dangerously-bypass-approvals-and-sandbox/);
-      assert.match(codexLog, new RegExp(`codex-pwd:${escapeRegExp(normalizeDarwinTmpPath(wd))}`));
+      const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+      assert.match(tmuxLog, /\/bin\/sh/);
+      assert.match(tmuxLog, /__detached-session-leader/);
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -1977,11 +1955,7 @@ case "$cmd" in
     exit 0
     ;;
   new-session)
-    for last; do :; done
-    if [ -n "\${last:-}" ]; then
-      /bin/sh -c "$last"
-    fi
-    printf 'leader-pane\\n'
+    printf '%%12\n'
     exit 0
     ;;
   split-window)
@@ -2027,15 +2001,14 @@ exit 0
       if (shouldSkipForSpawnPermissions(result.error)) return;
 
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
-      const codexLog = normalizeDarwinTmpPath(await readFile(codexLogPath, 'utf-8'));
       assert.match(tmuxLog, /\/bin\/sh/);
       assert.doesNotMatch(tmuxLog, /not-a-real-shell/);
-      assert.match(codexLog, /codex:.*--dangerously-bypass-approvals-and-sandbox/);
-      assert.match(codexLog, new RegExp(`codex-pwd:${escapeRegExp(normalizeDarwinTmpPath(wd))}`));
+      assert.match(tmuxLog, /__detached-session-leader/);
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
 
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4401,69 +4401,98 @@ function withTmuxExtendedKeysLeaseLock<T>(
   throw new Error(`timed out waiting for tmux extended-keys lease lock: ${lockPath}`);
 }
 
+interface DetachedLeaderPreLaunchOptions {
+  notifyTempContract?: NotifyTempContract;
+  enableNotifyFallbackAuthority: boolean;
+  worktreeDirty: boolean;
+}
+
 function buildDetachedSessionLeaderCommand(
   cwd: string,
   sessionName: string,
   codexCmd: string,
-  sessionId?: string,
-  _codexHomeOverride?: string,
-  projectLocalCodexHomeForCleanup?: string,
-  runtimeCodexHomeForCleanup?: string,
-  parentEnvFilePath?: string,
-  releaseMarkerPath?: string,
+  sessionId: string | undefined,
+  codexHomeOverride: string | undefined,
+  projectLocalCodexHomeForCleanup: string | undefined,
+  runtimeCodexHomeForCleanup: string | undefined,
+  parentEnvFilePath: string | undefined,
+  readyPath: string | undefined,
+  preLaunchOptions: DetachedLeaderPreLaunchOptions,
   omxBin = process.argv[1],
 ): string {
   const payload = Buffer.from(JSON.stringify({
-    cwd,
-    sessionName,
-    sessionId,
-    codexCmd,
-    projectLocalCodexHomeForCleanup,
-    runtimeCodexHomeForCleanup,
-    parentEnvFilePath,
-    readyPath: releaseMarkerPath,
+    cwd, sessionName, sessionId, codexCmd, codexHomeOverride,
+    projectLocalCodexHomeForCleanup, runtimeCodexHomeForCleanup, parentEnvFilePath,
+    readyPath, preLaunchOptions,
   })).toString("base64url");
   return `/bin/sh -c ${quoteShellArg(`${parentEnvFilePath ? `if [ -r ${quoteShellArg(parentEnvFilePath)} ]; then . ${quoteShellArg(parentEnvFilePath)}; rm -f ${quoteShellArg(parentEnvFilePath)}; fi; ` : ""}exec ${quoteShellArg(process.execPath)} ${quoteShellArg(omxBin)} __detached-session-leader ${quoteShellArg(payload)}`)}`;
 }
+
 function buildDetachedWindowsLeaderCommand(
   cwd: string,
   sessionName: string,
   codexCmd: string,
-  sessionId?: string,
-  projectLocalCodexHomeForCleanup?: string,
-  runtimeCodexHomeForCleanup?: string,
-  releaseMarkerPath?: string,
+  sessionId: string | undefined,
+  codexHomeOverride: string | undefined,
+  projectLocalCodexHomeForCleanup: string | undefined,
+  runtimeCodexHomeForCleanup: string | undefined,
+  readyPath: string | undefined,
+  preLaunchOptions: DetachedLeaderPreLaunchOptions,
   omxBin = process.argv[1],
 ): string {
   const payload = Buffer.from(JSON.stringify({
-    cwd, sessionName, sessionId, codexCmd, projectLocalCodexHomeForCleanup,
-    runtimeCodexHomeForCleanup, readyPath: releaseMarkerPath,
+    cwd, sessionName, sessionId, codexCmd, codexHomeOverride,
+    projectLocalCodexHomeForCleanup, runtimeCodexHomeForCleanup, readyPath, preLaunchOptions,
   })).toString("base64url");
   const invocation = `& ${quotePowerShellArg(process.execPath)} ${quotePowerShellArg(omxBin)} __detached-session-leader ${quotePowerShellArg(payload)}`;
   return `powershell.exe -NoLogo -NoProfile -NonInteractive -Command ${quotePowerShellArg(invocation)}`;
 }
 
+interface DetachedLeaderReport {
+  version: 1;
+  kind: "ready" | "failed" | "terminal" | "release";
+  nonce: string;
+  sessionId: string;
+  sessionName: string;
+  paneId?: string;
+  leaderPid?: number;
+  error?: string;
+}
 
-
-function publishDetachedReleaseMarker(releaseMarkerPath: string, nonce: string): void {
-  mkdirSync(dirname(releaseMarkerPath), { recursive: true, mode: 0o700 });
-  const tempPath = `${releaseMarkerPath}.${process.pid}.${randomUUID()}.tmp`;
+function writeDetachedLeaderReport(path: string, report: DetachedLeaderReport): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
   let fd: number | undefined;
   try {
     fd = openSync(tempPath, "wx", 0o600);
-    writeFileSync(fd, `${nonce}\n`, "utf-8");
-    try {
-      fsyncSync(fd);
-    } catch (error) {
+    writeFileSync(fd, `${JSON.stringify(report)}\n`, "utf-8");
+    try { fsyncSync(fd); } catch (error) {
       if (!(process.platform === "win32" && (error as NodeJS.ErrnoException).code === "EPERM")) throw error;
     }
     closeSync(fd);
     fd = undefined;
-    renameSync(tempPath, releaseMarkerPath);
+    renameSync(tempPath, path);
   } finally {
     if (fd !== undefined) closeSync(fd);
     try { unlinkSync(tempPath); } catch {}
   }
+}
+
+function readDetachedLeaderReport(path: string): DetachedLeaderReport | undefined {
+  try {
+    const value: unknown = JSON.parse(readFileSync(path, "utf8"));
+    if (!value || typeof value !== "object") return undefined;
+    const report = value as Record<string, unknown>;
+    if (report.version !== 1 || !["ready", "failed", "terminal", "release"].includes(String(report.kind)) ||
+      typeof report.nonce !== "string" || typeof report.sessionId !== "string" || typeof report.sessionName !== "string") return undefined;
+    if (report.paneId !== undefined && typeof report.paneId !== "string") return undefined;
+    if (report.leaderPid !== undefined && (!Number.isSafeInteger(report.leaderPid) || Number(report.leaderPid) <= 0)) return undefined;
+    return report as unknown as DetachedLeaderReport;
+  } catch { return undefined; }
+}
+
+function publishDetachedReleaseMarker(releaseMarkerPath: string, nonce: string, sessionId: string, sessionName: string): void {
+  writeDetachedLeaderReport(`${releaseMarkerPath}.release`, { version: 1, kind: "release", nonce, sessionId, sessionName });
 }
 
 type TmuxExecSync = (file: string, args: readonly string[]) => string;
@@ -4671,23 +4700,21 @@ export function buildDetachedSessionBootstrapSteps(
   inheritedWorkerModel?: string | null,
   releaseMarkerPath?: string,
   omxBin = process.argv[1],
+  preLaunchOptions: DetachedLeaderPreLaunchOptions = {
+    enableNotifyFallbackAuthority: false,
+    worktreeDirty: false,
+  },
 ): DetachedSessionTmuxStep[] {
   const detachedLeaderCmd = nativeWindows
     ? buildDetachedWindowsLeaderCommand(
-        cwd, sessionName, codexCmd, sessionId, projectLocalCodexHomeForCleanup,
-        runtimeCodexHomeForCleanup, releaseMarkerPath, omxBin,
+        cwd, sessionName, codexCmd, sessionId, codexHomeOverride,
+        projectLocalCodexHomeForCleanup, runtimeCodexHomeForCleanup, releaseMarkerPath,
+        preLaunchOptions, omxBin,
       )
     : buildDetachedSessionLeaderCommand(
-        cwd,
-        sessionName,
-        codexCmd,
-        sessionId,
-        codexHomeOverride,
-        projectLocalCodexHomeForCleanup,
-        runtimeCodexHomeForCleanup,
-        parentEnvFilePath,
-        releaseMarkerPath,
-        omxBin,
+        cwd, sessionName, codexCmd, sessionId, codexHomeOverride,
+        projectLocalCodexHomeForCleanup, runtimeCodexHomeForCleanup, parentEnvFilePath,
+        releaseMarkerPath, preLaunchOptions, omxBin,
       );
   const resolvedEnvStateRoot = env.OMX_STATE_ROOT?.trim()
     ? resolveLaunchPath(cwd, env.OMX_STATE_ROOT.trim())
@@ -5755,43 +5782,86 @@ async function runCodex(
     let attachStep: DetachedSessionTmuxStep | null = null;
 
     const launchDetachedSession = async (): Promise<{ postLaunchHandledExternally: boolean }> => {
-      if (!nativeWindows) detachedParentEnvFilePath = writeDetachedSessionParentEnvFile(cwd, sessionId, codexEnvWithNotify);
-      const bootstrapSteps = buildDetachedSessionBootstrapSteps(
-        sessionName, cwd, nativeWindows && detachedWindowsCodexCmd ? detachedWindowsCodexCmd : codexCmd,
-        hudCmd, workerLaunchArgs, codexHomeOverride, notifyTempContractRaw, nativeWindows, sessionId,
-        projectLocalCodexHomeForCleanup, runtimeCodexHomeForCleanup, omxRootOverride, runtimeHookEnv,
-        sqliteHomeOverride, detachedParentEnvFilePath, inheritedWorkerModel, releaseMarkerPath, omxBin,
-      );
-      for (const step of bootstrapSteps) {
-        let output: string;
-        try {
-          output = execTmuxFileSync(step.args, { stdio: "pipe", encoding: "utf-8" });
-        } catch (error) {
-          throw new DetachedLaunchSafetyError(step.name === "new-session" ? "inert-session" : "pane-id", error, detachedPreflight.report);
-        }
-        if (step.name === "new-session") {
-          detachedLeaderPaneId = parsePaneIdFromTmuxOutput(output || "");
-          if (!detachedLeaderPaneId) throw new DetachedLaunchSafetyError("pane-id", new Error("detached session did not report a leader pane id"), detachedPreflight.report);
-          setDetachedTmuxSessionHistoryLimit(sessionName, detachedLeaderPaneId);
-        }
-        if (step.name === "split-and-capture-hud-pane") {
-          const hudPaneId = parsePaneIdFromTmuxOutput(output || "");
-          const hookWindowIndex = hudPaneId ? detectDetachedSessionWindowIndex(sessionName) : null;
-          for (const finalizeStep of buildDetachedSessionFinalizeSteps(sessionName, hudPaneId, hookWindowIndex, process.env.OMX_MOUSE !== "0", nativeWindows, detachedPreflight.shouldAttach, detachedLeaderPaneId)) {
-            if (finalizeStep.name === "attach-session") { attachStep = finalizeStep; continue; }
-            if (finalizeStep.name === "sanitize-copy-mode-style") { try { mitigateCopyModeUnderlineArtifacts(sessionName); } catch (error) { logCliOperationFailure(error); } continue; }
-            try { execTmuxFileSync(finalizeStep.args, { stdio: "ignore" }); } catch (error) { logCliOperationFailure(error); continue; }
-            if (finalizeStep.name === "reconcile-hud-resize") registerDetachedHudLayoutReconcileHook({ hudPaneId, detachedLeaderPaneId, cwd, sessionId, omxBin, omxRootOverride, baseEnv: runtimeHookEnv });
+      let createdSession = false;
+      const bootstrapLeader = async (): Promise<DetachedLeaderReport> => {
+        if (!nativeWindows) detachedParentEnvFilePath = writeDetachedSessionParentEnvFile(cwd, sessionId, codexEnvWithNotify);
+        const bootstrapSteps = buildDetachedSessionBootstrapSteps(
+          sessionName, cwd, nativeWindows && detachedWindowsCodexCmd ? detachedWindowsCodexCmd : codexCmd,
+          hudCmd, workerLaunchArgs, codexHomeOverride, notifyTempContractRaw, nativeWindows, sessionId,
+          projectLocalCodexHomeForCleanup, runtimeCodexHomeForCleanup, omxRootOverride, runtimeHookEnv,
+          sqliteHomeOverride, detachedParentEnvFilePath, inheritedWorkerModel, releaseMarkerPath,
+          omxBin,
+          {
+            ...(preLaunchOptions.notifyTempContract.active ? { notifyTempContract: preLaunchOptions.notifyTempContract } : {}),
+            enableNotifyFallbackAuthority: preLaunchOptions.enableNotifyFallbackAuthority,
+            worktreeDirty: preLaunchOptions.worktreeDirty,
+          },
+        );
+        for (const step of bootstrapSteps) {
+          let output: string;
+          try {
+            output = execTmuxFileSync(step.args, { stdio: "pipe", encoding: "utf-8" });
+          } catch (error) {
+            throw new DetachedLaunchSafetyError(step.name === "new-session" ? "inert-session" : "pane-id", error, detachedPreflight.report);
+          }
+          if (step.name === "new-session") {
+            createdSession = true;
+            detachedLeaderPaneId = parsePaneIdFromTmuxOutput(output || "");
+            if (!detachedLeaderPaneId) throw new DetachedLaunchSafetyError("pane-id", new Error("detached session did not report a leader pane id"), detachedPreflight.report);
+            setDetachedTmuxSessionHistoryLimit(sessionName, detachedLeaderPaneId);
+          }
+          if (step.name === "split-and-capture-hud-pane") {
+            const hudPaneId = parsePaneIdFromTmuxOutput(output || "");
+            const hookWindowIndex = hudPaneId ? detectDetachedSessionWindowIndex(sessionName) : null;
+            for (const finalizeStep of buildDetachedSessionFinalizeSteps(sessionName, hudPaneId, hookWindowIndex, process.env.OMX_MOUSE !== "0", nativeWindows, detachedPreflight.shouldAttach, detachedLeaderPaneId)) {
+              if (finalizeStep.name === "attach-session") { attachStep = finalizeStep; continue; }
+              if (finalizeStep.name === "sanitize-copy-mode-style") { try { mitigateCopyModeUnderlineArtifacts(sessionName); } catch (error) { logCliOperationFailure(error); } continue; }
+              try { execTmuxFileSync(finalizeStep.args, { stdio: "ignore" }); } catch (error) { logCliOperationFailure(error); continue; }
+              if (finalizeStep.name === "reconcile-hud-resize") registerDetachedHudLayoutReconcileHook({ hudPaneId, detachedLeaderPaneId, cwd, sessionId, omxBin, omxRootOverride, baseEnv: runtimeHookEnv });
+            }
           }
         }
-      }
-      const readyDeadline = Date.now() + 30_000;
-      while (!existsSync(releaseMarkerPath)) {
-        if (Date.now() >= readyDeadline) throw new DetachedLaunchSafetyError("barrier-release", new Error("detached leader readiness timed out"), detachedPreflight.report);
-        blockMs(20);
-      }
-      rmSync(releaseMarkerPath, { force: true });
-      if (attachStep) execTmuxFileSync(attachStep.args, { stdio: "inherit" });
+        const readyDeadline = Date.now() + 30_000;
+        while (true) {
+          const report = readDetachedLeaderReport(releaseMarkerPath);
+          if (report?.nonce === detachedLaunchNonce && report.sessionId === sessionId &&
+            report.sessionName === sessionName && report.paneId === detachedLeaderPaneId && report.leaderPid && report.kind === "ready") return report;
+          if (report?.nonce === detachedLaunchNonce && report.sessionId === sessionId && report.kind === "failed") {
+            throw new DetachedLaunchSafetyError("completion", new Error(report.error || "detached leader setup failed"), detachedPreflight.report);
+          }
+          if (Date.now() >= readyDeadline) throw new DetachedLaunchSafetyError("barrier-release", new Error("detached leader readiness timed out"), detachedPreflight.report);
+          blockMs(20);
+        }
+      };
+      await executeDetachedLaunchStateMachine(
+        { preflight: detachedPreflight },
+        {
+          establish: bootstrapLeader,
+          complete: async () => ({ kind: "success" }),
+          createInertSession: async () => sessionName,
+          capturePane: async () => detachedLeaderPaneId ?? "",
+          updateNameMetadata: async () => "committed-released",
+          updatePaneMetadata: async () => "committed-released",
+          publishActiveRecord: async () => ({ bytes: "", digest: "", nonce: detachedLaunchNonce }),
+          finalizeSetupFailure: async () => {},
+          releaseBarrier: async () => publishDetachedReleaseMarker(releaseMarkerPath, detachedLaunchNonce, sessionId, sessionName),
+          attachOrReturn: async () => { if (attachStep) execTmuxFileSync(attachStep.args, { stdio: "inherit" }); },
+          rollback: async (_ownedRecord, report) => {
+            const attempt = async (step: DetachedRollbackStep, operation: () => Promise<void> | void): Promise<void> => {
+              report.rollback.attempted.push(step);
+              try { await operation(); } catch (error) { report.rollback.failures.push({ step, status: "failed", code: detachedFailureCode(error) }); }
+            };
+            await attempt("parent-env", async () => { if (detachedParentEnvFilePath) await rm(detachedParentEnvFilePath, { force: true }); });
+            await attempt("runtime-codex-home", () => cleanupRuntimeCodexHome(runtimeCodexHomeForCleanup, projectLocalCodexHomeForCleanup));
+            await attempt("rollback", () => { rmSync(releaseMarkerPath, { force: true }); rmSync(`${releaseMarkerPath}.release`, { force: true }); });
+            if (createdSession) {
+              for (const step of buildDetachedSessionRollbackSteps(sessionName, null, null, null)) {
+                await attempt(`session:${step.name}`, () => { execTmuxFileSync(step.args, { stdio: "ignore" }); });
+              }
+            }
+          },
+        },
+      );
       return { postLaunchHandledExternally: true };
     };
 
@@ -5950,11 +6020,13 @@ function quotePowerShellArg(value: string): string {
 interface DetachedLeaderPayload {
   cwd: string;
   sessionName: string;
-  sessionId?: string;
+  sessionId: string;
   codexCmd: string;
+  codexHomeOverride?: string;
   projectLocalCodexHomeForCleanup?: string;
   runtimeCodexHomeForCleanup?: string;
   readyPath?: string;
+  preLaunchOptions: DetachedLeaderPreLaunchOptions;
 }
 
 function decodeDetachedLeaderPayload(encoded: string | undefined): DetachedLeaderPayload {
@@ -5963,24 +6035,45 @@ function decodeDetachedLeaderPayload(encoded: string | undefined): DetachedLeade
   try { value = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")); } catch { throw new Error("invalid detached leader payload"); }
   if (!value || typeof value !== "object") throw new Error("invalid detached leader payload");
   const payload = value as Record<string, unknown>;
-  if (typeof payload.cwd !== "string" || typeof payload.sessionName !== "string" || typeof payload.sessionId !== "string" || typeof payload.codexCmd !== "string") throw new Error("invalid detached leader payload");
-  return { cwd: payload.cwd, sessionName: payload.sessionName, sessionId: payload.sessionId, codexCmd: payload.codexCmd,
+  const options = payload.preLaunchOptions;
+  if (typeof payload.cwd !== "string" || typeof payload.sessionName !== "string" || typeof payload.sessionId !== "string" ||
+    typeof payload.codexCmd !== "string" || !options || typeof options !== "object" ||
+    typeof (options as Record<string, unknown>).enableNotifyFallbackAuthority !== "boolean" ||
+    typeof (options as Record<string, unknown>).worktreeDirty !== "boolean") throw new Error("invalid detached leader payload");
+  const notifyTempContract = (options as Record<string, unknown>).notifyTempContract;
+  if (notifyTempContract !== undefined && (!notifyTempContract || typeof notifyTempContract !== "object")) throw new Error("invalid detached leader payload");
+  return {
+    cwd: payload.cwd, sessionName: payload.sessionName, sessionId: payload.sessionId, codexCmd: payload.codexCmd,
+    ...(typeof payload.codexHomeOverride === "string" ? { codexHomeOverride: payload.codexHomeOverride } : {}),
     ...(typeof payload.projectLocalCodexHomeForCleanup === "string" ? { projectLocalCodexHomeForCleanup: payload.projectLocalCodexHomeForCleanup } : {}),
     ...(typeof payload.runtimeCodexHomeForCleanup === "string" ? { runtimeCodexHomeForCleanup: payload.runtimeCodexHomeForCleanup } : {}),
     ...(typeof payload.readyPath === "string" ? { readyPath: payload.readyPath } : {}),
+    preLaunchOptions: {
+      ...(notifyTempContract ? { notifyTempContract: notifyTempContract as NotifyTempContract } : {}),
+      enableNotifyFallbackAuthority: (options as DetachedLeaderPreLaunchOptions).enableNotifyFallbackAuthority,
+      worktreeDirty: (options as DetachedLeaderPreLaunchOptions).worktreeDirty,
+    },
   };
 }
 
 async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise<void> {
-  const established = await establishPreLaunchBinding(payload.cwd, payload.sessionId!);
+  const established = await establishPreLaunchBinding(payload.cwd, payload.sessionId);
   const binding = established.binding;
   let ownedRecord: DetachedActiveRecordOwnership | undefined;
+  const nonce = payload.readyPath?.split(".").at(-2) || payload.sessionId;
   const contextKey = process.env[OMX_MADMAX_DETACHED_CONTEXT_ENV]?.trim();
   const activeRecordPath = contextKey
     ? madmaxDetachedActiveRecordPath(resolveMadmaxRunsRoot(process.env), contextKey)
     : join(omxRoot(payload.cwd), "state", "detached-active-record.json");
   try {
-    const completion = await completePreLaunchSetup(payload.cwd, payload.sessionId!, undefined, undefined, false, false);
+    const completion = await completePreLaunchSetup(
+      payload.cwd,
+      payload.sessionId,
+      payload.preLaunchOptions.notifyTempContract,
+      payload.codexHomeOverride,
+      payload.preLaunchOptions.enableNotifyFallbackAuthority,
+      payload.preLaunchOptions.worktreeDirty,
+    );
     if (completion.kind === "failure") {
       const finalization = await finalizeBoundOnce(binding, "setup-failure", payload.cwd);
       if (!finalization.finalized) throw new Error(`bound setup finalization denied: ${finalization.cleanup.comparison?.reason ?? "unknown reason"}`);
@@ -5995,19 +6088,41 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
       version: 1, context_key: contextKey ?? payload.sessionId!, created_at: new Date().toISOString(),
       source_cwd: payload.cwd, argv: [payload.codexCmd], run_dir: process.env.OMX_ROOT ?? payload.cwd,
       tmux_session_name: payload.sessionName, session_id: payload.sessionId, tmux_pane_id: pane,
-      launch_nonce: payload.sessionId, leader_pid: process.pid, base_state_root: binding.context.baseStateDir,
+      launch_nonce: nonce, leader_pid: process.pid, base_state_root: binding.context.baseStateDir,
       lifecycle_phase: "ready",
     });
-    if (payload.readyPath) publishDetachedReleaseMarker(payload.readyPath, payload.sessionId!);
-    const child = spawn(process.platform === "win32" ? "powershell.exe" : "/bin/sh", process.platform === "win32" ? ["-NoProfile", "-Command", payload.codexCmd] : ["-c", payload.codexCmd], { cwd: payload.cwd, stdio: "inherit" });
-    let escalation: NodeJS.Timeout | undefined;
-    const forward = (signal: NodeJS.Signals): void => {
-      if (!child.pid) return;
-      try { child.kill(process.platform === "win32" ? "SIGTERM" : signal); } catch {}
-      if (!escalation) {
-        escalation = setTimeout(() => { try { child.kill("SIGKILL"); } catch {} }, 5_000);
-        escalation.unref();
+    if (payload.readyPath) {
+      writeDetachedLeaderReport(payload.readyPath, { version: 1, kind: "ready", nonce, sessionId: payload.sessionId, sessionName: payload.sessionName, paneId: pane, leaderPid: process.pid });
+      const releasePath = `${payload.readyPath}.release`;
+      let interrupted: NodeJS.Signals | undefined;
+      const interrupt = (signal: NodeJS.Signals): void => { interrupted = signal; };
+      process.once("SIGINT", () => interrupt("SIGINT"));
+      process.once("SIGTERM", () => interrupt("SIGTERM"));
+      process.once("SIGHUP", () => interrupt("SIGHUP"));
+      while (true) {
+        if (interrupted) throw new Error(`detached leader interrupted before release: ${interrupted}`);
+        const release = readDetachedLeaderReport(releasePath);
+        if (release?.kind === "release" && release.nonce === nonce && release.sessionId === payload.sessionId && release.sessionName === payload.sessionName) break;
+        blockMs(20);
       }
+      rmSync(releasePath, { force: true });
+    }
+    const child = spawn(process.platform === "win32" ? "powershell.exe" : "/bin/sh", process.platform === "win32" ? ["-NoProfile", "-Command", payload.codexCmd] : ["-c", payload.codexCmd], {
+      cwd: payload.cwd,
+      stdio: "inherit",
+      ...(process.platform === "win32" ? {} : { detached: true }),
+    });
+    let escalation: NodeJS.Timeout | undefined;
+    const signalChildTree = (signal: NodeJS.Signals): void => {
+      if (!child.pid) return;
+      try {
+        if (process.platform === "win32") execFileSync("taskkill", ["/PID", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+        else process.kill(-child.pid, signal);
+      } catch {}
+    };
+    const forward = (signal: NodeJS.Signals): void => {
+      signalChildTree(signal);
+      if (!escalation) { escalation = setTimeout(() => signalChildTree("SIGKILL"), 5_000); escalation.unref(); }
     };
     process.once("SIGINT", () => forward("SIGINT"));
     process.once("SIGTERM", () => forward("SIGTERM"));
@@ -6015,7 +6130,11 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
     const code = await new Promise<number | null>((resolveChild, rejectChild) => { child.once("error", rejectChild); child.once("exit", resolveChild); });
     if (escalation) clearTimeout(escalation);
     process.exitCode = code ?? 1;
-    await postLaunch(payload.cwd, payload.sessionId!, binding, undefined, false, payload.projectLocalCodexHomeForCleanup);
+    await postLaunch(payload.cwd, payload.sessionId, binding, payload.codexHomeOverride, payload.preLaunchOptions.enableNotifyFallbackAuthority, payload.projectLocalCodexHomeForCleanup);
+    if (payload.readyPath) writeDetachedLeaderReport(payload.readyPath, {
+      version: 1, kind: "terminal", nonce, sessionId: payload.sessionId, sessionName: payload.sessionName,
+      paneId: pane, leaderPid: process.pid,
+    });
     await cleanupRuntimeCodexHome(payload.runtimeCodexHomeForCleanup, payload.projectLocalCodexHomeForCleanup);
     if (ownedRecord) {
       const bytes = readFileSync(activeRecordPath, "utf-8");
@@ -6023,6 +6142,10 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
       if (bytes === ownedRecord.bytes && digest === ownedRecord.digest) rmSync(activeRecordPath, { force: true });
     }
   } catch (error) {
+    if (payload.readyPath) writeDetachedLeaderReport(payload.readyPath, {
+      version: 1, kind: "failed", nonce, sessionId: payload.sessionId, sessionName: payload.sessionName,
+      leaderPid: process.pid, error: error instanceof Error ? error.message : String(error),
+    });
     const finalization = await finalizeBoundOnce(binding, "detached-pre-release-failure", payload.cwd).catch(() => undefined);
     if (finalization?.finalized && ownedRecord) {
       try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -132,6 +132,7 @@ import {
 import {
   closeLaunchSessionBindingOnce,
   establishLaunchSessionBinding,
+  readSessionState,
   updateDetachedSessionMetadata,
   finalizeBoundOnce,
   isSessionPointerLaunchAbort,
@@ -2679,13 +2680,17 @@ function writeMadmaxDetachedActiveRecord(
   try {
     fd = openSync(tempPath, "wx", 0o600);
     writeFileSync(fd, bytes, "utf-8");
-    fsyncSync(fd);
+    try { fsyncSync(fd); } catch (error) {
+      if (!(process.platform === "win32" && (error as NodeJS.ErrnoException).code === "EPERM")) throw error;
+    }
     closeSync(fd);
     fd = undefined;
     renameSync(tempPath, recordPath);
     const directoryFd = openSync(dirname(recordPath), "r");
     try {
-      fsyncSync(directoryFd);
+      try { fsyncSync(directoryFd); } catch (error) {
+        if (!(process.platform === "win32" && (error as NodeJS.ErrnoException).code === "EPERM")) throw error;
+      }
     } finally {
       closeSync(directoryFd);
     }
@@ -2757,6 +2762,11 @@ export type DetachedLaunchTerminal =
 export interface DetachedReleaseFailureResolution {
   /** True only after the leader authenticated and completed terminal finalization. */
   acknowledged: boolean;
+  nonce?: string;
+  sessionId?: string;
+  sessionName?: string;
+  leaderPid?: number;
+  kind?: "failed" | "terminal";
 }
 
 
@@ -2815,9 +2825,12 @@ export async function executeDetachedLaunchStateMachine<Binding, InertSession, P
   let binding: Binding | undefined;
   let ownedRecord: DetachedActiveRecordOwnership | undefined;
   let released = false;
+  let retainedAuthority = false;
+  let rollbackAuthorized = false;
   try {
     transition("D1");
     binding = await deps.establish();
+    retainedAuthority = true;
     transition("D2");
     const completion = await deps.complete(binding);
     if (completion.kind === "failure") {
@@ -2829,7 +2842,6 @@ export async function executeDetachedLaunchStateMachine<Binding, InertSession, P
         report.rollback.failures.push({ step: "setup-finalization", status: "failed", code: detachedFailureCode(finalizationError) });
         failures.push(finalizationError);
       }
-      binding = undefined;
       throw new DetachedLaunchSafetyError("completion", new AggregateError(failures, `preLaunch ${completion.operation} failed`), report);
     }
     transition("D3");
@@ -2854,14 +2866,18 @@ export async function executeDetachedLaunchStateMachine<Binding, InertSession, P
       // A failed publication must not let the outer launcher destroy the
       // leader's finalization capability. Request a nonce-bound abort and
       // preserve all artifacts on timeout, malformed, or foreign reports.
-      let resolution: { acknowledged: boolean } | undefined;
+      let resolution: DetachedReleaseFailureResolution | undefined;
       try {
         resolution = await deps.abortAndAwaitFinalization?.(releaseError);
       } catch (abortError) {
         released = true;
         throw new AggregateError([releaseError, abortError], "detached release and abort publication both failed");
       }
-      if (!resolution?.acknowledged) released = true;
+      rollbackAuthorized = resolution?.acknowledged === true && Boolean(
+        resolution.nonce && resolution.sessionId && resolution.sessionName &&
+        Number.isSafeInteger(resolution.leaderPid) && resolution.kind,
+      );
+      if (!rollbackAuthorized) released = true;
       throw releaseError;
     }
     transition("D10");
@@ -2869,6 +2885,19 @@ export async function executeDetachedLaunchStateMachine<Binding, InertSession, P
     return { kind: input.preflight.shouldAttach ? "attached" : "returned", released: true, report };
   } catch (error) {
     deps.diagnostic?.(error);
+    if (retainedAuthority && !rollbackAuthorized && !released) {
+      try {
+        const resolution = await deps.abortAndAwaitFinalization?.(error);
+        rollbackAuthorized = resolution?.acknowledged === true && Boolean(
+          resolution.nonce && resolution.sessionId && resolution.sessionName &&
+          Number.isSafeInteger(resolution.leaderPid) && resolution.kind,
+        );
+        if (!rollbackAuthorized) released = true;
+      } catch (abortError) {
+        released = true;
+        deps.diagnostic?.(abortError);
+      }
+    }
     if (!released) {
       try {
         report.rollback.attempted.push("rollback");
@@ -4463,13 +4492,16 @@ function buildDetachedWindowsLeaderCommand(
   codexHomeOverride: string | undefined,
   projectLocalCodexHomeForCleanup: string | undefined,
   runtimeCodexHomeForCleanup: string | undefined,
+  parentEnv: NodeJS.ProcessEnv | undefined,
   readyPath: string | undefined,
   preLaunchOptions: DetachedLeaderPreLaunchOptions,
   omxBin = process.argv[1],
 ): string {
   const payload = Buffer.from(JSON.stringify({
     cwd, sessionName, sessionId, codexCmd, codexHomeOverride,
-    projectLocalCodexHomeForCleanup, runtimeCodexHomeForCleanup, readyPath, preLaunchOptions,
+    projectLocalCodexHomeForCleanup, runtimeCodexHomeForCleanup,
+    ...(parentEnv ? { parentEnv: detachedSessionParentEnvironment(parentEnv) } : {}),
+    readyPath, preLaunchOptions,
   })).toString("base64url");
   const invocation = `& ${quotePowerShellArg(process.execPath)} ${quotePowerShellArg(omxBin)} __detached-session-leader ${quotePowerShellArg(payload)}`;
   return `powershell.exe -NoLogo -NoProfile -NonInteractive -Command ${quotePowerShellArg(invocation)}`;
@@ -4501,6 +4533,14 @@ function writeDetachedLeaderReport(path: string, report: DetachedLeaderReport): 
     closeSync(fd);
     fd = undefined;
     renameSync(tempPath, path);
+    const directoryFd = openSync(dirname(path), "r");
+    try {
+      try { fsyncSync(directoryFd); } catch (error) {
+        if (!(process.platform === "win32" && (error as NodeJS.ErrnoException).code === "EPERM")) throw error;
+      }
+    } finally {
+      closeSync(directoryFd);
+    }
   } finally {
     if (fd !== undefined) closeSync(fd);
     try { unlinkSync(tempPath); } catch {}
@@ -4521,12 +4561,12 @@ function readDetachedLeaderReport(path: string): DetachedLeaderReport | undefine
   } catch { return undefined; }
 }
 
-function publishDetachedReleaseMarker(releaseMarkerPath: string, nonce: string, sessionId: string, sessionName: string): void {
-  writeDetachedLeaderReport(`${releaseMarkerPath}.release`, { version: 1, kind: "release", nonce, sessionId, sessionName });
+function publishDetachedReleaseMarker(releaseMarkerPath: string, nonce: string, sessionId: string, sessionName: string, leaderPid: number): void {
+  writeDetachedLeaderReport(`${releaseMarkerPath}.release`, { version: 1, kind: "release", nonce, sessionId, sessionName, leaderPid });
 }
 
-function publishDetachedAbortMarker(releaseMarkerPath: string, nonce: string, sessionId: string, sessionName: string): void {
-  writeDetachedLeaderReport(`${releaseMarkerPath}.abort`, { version: 1, kind: "abort", nonce, sessionId, sessionName });
+function publishDetachedAbortMarker(releaseMarkerPath: string, nonce: string, sessionId: string, sessionName: string, leaderPid: number): void {
+  writeDetachedLeaderReport(`${releaseMarkerPath}.abort`, { version: 1, kind: "abort", nonce, sessionId, sessionName, leaderPid });
 }
 
 type TmuxExecSync = (file: string, args: readonly string[]) => string;
@@ -4661,19 +4701,22 @@ const DETACHED_SESSION_PANE_ENV_KEYS = new Set([
   "LINES",
 ]);
 
+function detachedSessionParentEnvironment(env: NodeJS.ProcessEnv): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const key of Object.keys(env).sort()) {
+    if (!SHELL_ENV_NAME_PATTERN.test(key) || DETACHED_SESSION_PANE_ENV_KEYS.has(key)) continue;
+    const value = env[key];
+    if (typeof value === "string" && !value.includes("\0")) values[key] = value;
+  }
+  return values;
+}
+
 export function serializeDetachedSessionParentEnv(
   env: NodeJS.ProcessEnv,
 ): string {
-  const lines: string[] = [];
-  for (const key of Object.keys(env).sort()) {
-    if (!SHELL_ENV_NAME_PATTERN.test(key)) continue;
-    if (DETACHED_SESSION_PANE_ENV_KEYS.has(key)) continue;
-    const value = env[key];
-    if (typeof value !== "string") continue;
-    if (value.includes("\0")) continue;
-    lines.push(`export ${key}=${quoteShellArg(value)}`);
-  }
-  return `${lines.join("\n")}\n`;
+  return `${Object.entries(detachedSessionParentEnvironment(env))
+    .map(([key, value]) => `export ${key}=${quoteShellArg(value)}`)
+    .join("\n")}\n`;
 }
 
 export function detachedSessionParentEnvFilePath(
@@ -4742,7 +4785,7 @@ export function buildDetachedSessionBootstrapSteps(
   const detachedLeaderCmd = nativeWindows
     ? buildDetachedWindowsLeaderCommand(
         cwd, sessionName, codexCmd, sessionId, codexHomeOverride,
-        projectLocalCodexHomeForCleanup, runtimeCodexHomeForCleanup, releaseMarkerPath,
+        projectLocalCodexHomeForCleanup, runtimeCodexHomeForCleanup, env, releaseMarkerPath,
         preLaunchOptions, omxBin,
       )
     : buildDetachedSessionLeaderCommand(
@@ -5819,7 +5862,7 @@ async function runCodex(
 
     const launchDetachedSession = async (): Promise<{ postLaunchHandledExternally: boolean }> => {
       let createdSession = false;
-      const bootstrapLeader = async (): Promise<DetachedLeaderReport> => {
+      const bootstrapLeader = async (): Promise<void> => {
         if (!nativeWindows) detachedParentEnvFilePath = writeDetachedSessionParentEnvFile(cwd, sessionId, codexEnvWithNotify);
         const bootstrapSteps = buildDetachedSessionBootstrapSteps(
           sessionName, cwd, nativeWindows && detachedWindowsCodexCmd ? detachedWindowsCodexCmd : codexCmd,
@@ -5857,44 +5900,98 @@ async function runCodex(
             }
           }
         }
-        const readyDeadline = Date.now() + 30_000;
-        while (true) {
-          const report = readDetachedLeaderReport(releaseMarkerPath);
-          if (report?.nonce === detachedLaunchNonce && report.sessionId === sessionId &&
-            report.sessionName === sessionName && report.paneId === detachedLeaderPaneId && report.leaderPid && report.kind === "ready") {
-            detachedLeaderPid = report.leaderPid;
-            return report;
-          }
-          if (report?.nonce === detachedLaunchNonce && report.sessionId === sessionId && report.kind === "failed") {
-            throw new DetachedLaunchSafetyError("completion", new Error(report.error || "detached leader setup failed"), detachedPreflight.report);
-          }
-          if (Date.now() >= readyDeadline) throw new DetachedLaunchSafetyError("barrier-release", new Error("detached leader readiness timed out"), detachedPreflight.report);
-          blockMs(20);
-        }
+        return undefined;
       };
       await executeDetachedLaunchStateMachine(
         { preflight: detachedPreflight },
         {
           establish: bootstrapLeader,
-          complete: async () => ({ kind: "success" }),
-          createInertSession: async () => sessionName,
-          capturePane: async () => detachedLeaderPaneId ?? "",
-          updateNameMetadata: async () => "committed-released",
-          updatePaneMetadata: async () => "committed-released",
-          publishActiveRecord: async () => ({ bytes: "", digest: "", nonce: detachedLaunchNonce }),
+          complete: async () => {
+            const readyDeadline = Date.now() + 30_000;
+            while (true) {
+              const report = readDetachedLeaderReport(releaseMarkerPath);
+              if (report?.nonce === detachedLaunchNonce && report.sessionId === sessionId && report.sessionName === sessionName && report.paneId === detachedLeaderPaneId && report.leaderPid && report.kind === "ready") {
+                detachedLeaderPid = report.leaderPid;
+                return { kind: "success" };
+              }
+              if (report?.nonce === detachedLaunchNonce && report.sessionId === sessionId && report.sessionName === sessionName && report.leaderPid && report.kind === "failed") {
+                detachedLeaderPid = report.leaderPid;
+                return { kind: "failure", operation: "session-instructions", error: new Error(report.error || "detached leader setup failed") };
+              }
+              if (Date.now() >= readyDeadline) return { kind: "failure", operation: "session-instructions", error: new Error("detached leader readiness timed out") };
+              blockMs(20);
+            }
+          },
+          createInertSession: async () => {
+            const report = readDetachedLeaderReport(releaseMarkerPath);
+            if (report?.kind !== "ready" || report.nonce !== detachedLaunchNonce || report.sessionId !== sessionId || report.sessionName !== sessionName || report.leaderPid !== detachedLeaderPid) {
+              throw new Error("detached ready report does not bind the inert session");
+            }
+            return sessionName;
+          },
+          capturePane: async () => {
+            const report = readDetachedLeaderReport(releaseMarkerPath);
+            if (!detachedLeaderPaneId || report?.kind !== "ready" || report.paneId !== detachedLeaderPaneId || report.leaderPid !== detachedLeaderPid) {
+              throw new Error("detached ready report does not bind the leader pane");
+            }
+            return detachedLeaderPaneId;
+          },
+          updateNameMetadata: async () => {
+            const state = await readSessionState(cwd);
+            if (state?.session_id !== sessionId || state.tmux_session_name !== sessionName) {
+              throw new Error("detached session-name metadata was not committed by the leader");
+            }
+            return "committed-released";
+          },
+          updatePaneMetadata: async (_binding, pane) => {
+            const state = await readSessionState(cwd);
+            if (state?.session_id !== sessionId || state.tmux_pane_id !== pane) {
+              throw new Error("detached pane metadata was not committed by the leader");
+            }
+            return "committed-released";
+          },
+          publishActiveRecord: async () => {
+            const activeRecordPath = contextKey ? madmaxDetachedActiveRecordPath(runsRoot, contextKey) : join(omxRoot(cwd), "state", "detached-active-record.json");
+            const record = readMadmaxDetachedActiveRecord(activeRecordPath);
+            if (!record || record.launch_nonce !== detachedLaunchNonce || record.leader_pid !== detachedLeaderPid || record.session_id !== sessionId || record.tmux_session_name !== sessionName || record.tmux_pane_id !== detachedLeaderPaneId) throw new Error("detached active record does not bind the ready leader");
+            const bytes = readFileSync(activeRecordPath, "utf-8");
+            return { bytes, digest: createHash("sha256").update(bytes).digest("hex"), nonce: detachedLaunchNonce };
+          },
           finalizeSetupFailure: async () => {},
-          releaseBarrier: async () => publishDetachedReleaseMarker(releaseMarkerPath, detachedLaunchNonce, sessionId, sessionName),
+          releaseBarrier: async () => {
+            if (!detachedLeaderPid) throw new Error("detached leader PID missing before release");
+            publishDetachedReleaseMarker(releaseMarkerPath, detachedLaunchNonce, sessionId, sessionName, detachedLeaderPid);
+          },
           abortAndAwaitFinalization: async () => {
             // The leader has the retained binding. Publishing abort is the only
             // outer action permitted after a D9 write failure; a mismatched or
             // missing report leaves every artifact and the tmux session intact.
-            publishDetachedAbortMarker(releaseMarkerPath, detachedLaunchNonce, sessionId, sessionName);
+            if (!detachedLeaderPid) return { acknowledged: false };
+            const current = readDetachedLeaderReport(releaseMarkerPath);
+            if (current?.nonce === detachedLaunchNonce && current.sessionId === sessionId &&
+              current.sessionName === sessionName && current.leaderPid === detachedLeaderPid &&
+              current.finalized === true && (current.kind === "failed" || current.kind === "terminal")) return {
+                acknowledged: true,
+                nonce: current.nonce,
+                sessionId: current.sessionId,
+                sessionName: current.sessionName,
+                leaderPid: current.leaderPid,
+                kind: current.kind,
+              };
+            publishDetachedAbortMarker(releaseMarkerPath, detachedLaunchNonce, sessionId, sessionName, detachedLeaderPid);
             const deadline = Date.now() + 30_000;
             while (Date.now() < deadline) {
               const report = readDetachedLeaderReport(releaseMarkerPath);
               if (report?.nonce === detachedLaunchNonce && report.sessionId === sessionId &&
                 report.sessionName === sessionName && report.leaderPid === detachedLeaderPid &&
-                report.finalized === true && (report.kind === "failed" || report.kind === "terminal")) return { acknowledged: true };
+                report.finalized === true && (report.kind === "failed" || report.kind === "terminal")) return {
+                  acknowledged: true,
+                  nonce: report.nonce,
+                  sessionId: report.sessionId,
+                  sessionName: report.sessionName,
+                  leaderPid: report.leaderPid,
+                  kind: report.kind,
+                };
               blockMs(20);
             }
             return { acknowledged: false };
@@ -6079,6 +6176,7 @@ interface DetachedLeaderPayload {
   codexHomeOverride?: string;
   projectLocalCodexHomeForCleanup?: string;
   runtimeCodexHomeForCleanup?: string;
+  parentEnv?: Record<string, string>;
   readyPath?: string;
   preLaunchOptions: DetachedLeaderPreLaunchOptions;
 }
@@ -6096,11 +6194,17 @@ function decodeDetachedLeaderPayload(encoded: string | undefined): DetachedLeade
     typeof (options as Record<string, unknown>).worktreeDirty !== "boolean") throw new Error("invalid detached leader payload");
   const notifyTempContract = (options as Record<string, unknown>).notifyTempContract;
   if (notifyTempContract !== undefined && (!notifyTempContract || typeof notifyTempContract !== "object")) throw new Error("invalid detached leader payload");
+  const parentEnv = payload.parentEnv;
+  if (parentEnv !== undefined && (!parentEnv || typeof parentEnv !== "object" ||
+    Object.entries(parentEnv).some(([key, value]) => !SHELL_ENV_NAME_PATTERN.test(key) || DETACHED_SESSION_PANE_ENV_KEYS.has(key) || typeof value !== "string" || value.includes("\0")))) {
+    throw new Error("invalid detached leader parent environment");
+  }
   return {
     cwd: payload.cwd, sessionName: payload.sessionName, sessionId: payload.sessionId, codexCmd: payload.codexCmd,
     ...(typeof payload.codexHomeOverride === "string" ? { codexHomeOverride: payload.codexHomeOverride } : {}),
     ...(typeof payload.projectLocalCodexHomeForCleanup === "string" ? { projectLocalCodexHomeForCleanup: payload.projectLocalCodexHomeForCleanup } : {}),
     ...(typeof payload.runtimeCodexHomeForCleanup === "string" ? { runtimeCodexHomeForCleanup: payload.runtimeCodexHomeForCleanup } : {}),
+    ...(parentEnv ? { parentEnv: parentEnv as Record<string, string> } : {}),
     ...(typeof payload.readyPath === "string" ? { readyPath: payload.readyPath } : {}),
     preLaunchOptions: {
       ...(notifyTempContract ? { notifyTempContract: notifyTempContract as NotifyTempContract } : {}),
@@ -6111,6 +6215,7 @@ function decodeDetachedLeaderPayload(encoded: string | undefined): DetachedLeade
 }
 
 async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise<void> {
+  for (const [key, value] of Object.entries(payload.parentEnv ?? {})) process.env[key] = value;
   const established = await establishPreLaunchBinding(payload.cwd, payload.sessionId);
   const binding = established.binding;
   let ownedRecord: DetachedActiveRecordOwnership | undefined;
@@ -6160,9 +6265,9 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
       while (true) {
         if (interrupted) throw new Error(`detached leader interrupted before release: ${interrupted}`);
         const release = readDetachedLeaderReport(releasePath);
-        if (release?.kind === "release" && release.nonce === nonce && release.sessionId === payload.sessionId && release.sessionName === payload.sessionName) break;
+        if (release?.kind === "release" && release.nonce === nonce && release.sessionId === payload.sessionId && release.sessionName === payload.sessionName && release.leaderPid === process.pid) break;
         const abort = readDetachedLeaderReport(abortPath);
-        if (abort?.kind === "abort" && abort.nonce === nonce && abort.sessionId === payload.sessionId && abort.sessionName === payload.sessionName) {
+        if (abort?.kind === "abort" && abort.nonce === nonce && abort.sessionId === payload.sessionId && abort.sessionName === payload.sessionName && abort.leaderPid === process.pid) {
           throw new Error("detached launch aborted before release");
         }
         if (Date.now() >= releaseDeadline) throw new Error("detached leader release timed out");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3043,7 +3043,6 @@ if (command !== "launch" && command !== "resume") {
       return;
     }
 
-    activateMadmaxIsolationIfNeeded(command, launchArgs, process.cwd(), process.env);
 
     switch (command) {
       case "__detached-session-leader": {
@@ -5791,6 +5790,7 @@ async function runCodex(
         if (Date.now() >= readyDeadline) throw new DetachedLaunchSafetyError("barrier-release", new Error("detached leader readiness timed out"), detachedPreflight.report);
         blockMs(20);
       }
+      rmSync(releaseMarkerPath, { force: true });
       if (attachStep) execTmuxFileSync(attachStep.args, { stdio: "inherit" });
       return { postLaunchHandledExternally: true };
     };
@@ -6022,7 +6022,6 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
       const digest = createHash("sha256").update(bytes).digest("hex");
       if (bytes === ownedRecord.bytes && digest === ownedRecord.digest) rmSync(activeRecordPath, { force: true });
     }
-    if (payload.readyPath) rmSync(payload.readyPath, { force: true });
   } catch (error) {
     const finalization = await finalizeBoundOnce(binding, "detached-pre-release-failure", payload.cwd).catch(() => undefined);
     if (finalization?.finalized && ownedRecord) {
@@ -6032,7 +6031,6 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
         if (bytes === ownedRecord.bytes && digest === ownedRecord.digest) rmSync(activeRecordPath, { force: true });
       } catch {}
     }
-    if (payload.readyPath) rmSync(payload.readyPath, { force: true });
     throw error;
   } finally {
     await closeLaunchSessionBindingOnce(binding);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2754,6 +2754,12 @@ export type DetachedLaunchTransition = "D0" | "D1" | "D2" | "D3" | "D4" | "D5" |
 export type DetachedLaunchTerminal =
   | { kind: "attached" | "returned"; released: true; report: DetachedBootstrapReport };
 
+export interface DetachedReleaseFailureResolution {
+  /** True only after the leader authenticated and completed terminal finalization. */
+  acknowledged: boolean;
+}
+
+
 export class DetachedTransportUnavailable extends Error {
   readonly name = "DetachedTransportUnavailable";
   readonly noSideEffects = true;
@@ -2786,9 +2792,16 @@ export interface DetachedLaunchDependencies<Binding = unknown, InertSession = un
   // The long-lived leader retains this authority until terminal finalization.
   finalizeSetupFailure(binding: Binding): Promise<void>;
   releaseBarrier(): Promise<void>;
+  /**
+   * D9 failure is special: once the leader exists, only it may consume pointer
+   * authority. The outer process requests an authenticated abort and must not
+   * clean or kill the session unless finalization is acknowledged.
+   */
+  abortAndAwaitFinalization?(error: unknown): Promise<DetachedReleaseFailureResolution>;
   attachOrReturn(session: InertSession, shouldAttach: boolean): Promise<void>;
   rollback(ownedRecord: DetachedActiveRecordOwnership | undefined, report: DetachedBootstrapReport): Promise<void>;
   diagnostic?(error: unknown): void;
+
 }
 
 /** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
@@ -2834,8 +2847,17 @@ export async function executeDetachedLaunchStateMachine<Binding, InertSession, P
     transition("D7");
     ownedRecord = await deps.publishActiveRecord(inertSession, pane);
     transition("D9");
-    await deps.releaseBarrier();
-    released = true;
+    try {
+      await deps.releaseBarrier();
+      released = true;
+    } catch (releaseError) {
+      // A failed publication must not let the outer launcher destroy the
+      // leader's finalization capability. Request a nonce-bound abort and
+      // preserve all artifacts on timeout, malformed, or foreign reports.
+      const resolution = await deps.abortAndAwaitFinalization?.(releaseError);
+      if (!resolution?.acknowledged) released = true;
+      throw releaseError;
+    }
     transition("D10");
     await deps.attachOrReturn(inertSession, input.preflight.shouldAttach);
     return { kind: input.preflight.shouldAttach ? "attached" : "returned", released: true, report };
@@ -4449,7 +4471,8 @@ function buildDetachedWindowsLeaderCommand(
 
 interface DetachedLeaderReport {
   version: 1;
-  kind: "ready" | "failed" | "terminal" | "release";
+  kind: "ready" | "failed" | "terminal" | "release" | "abort";
+
   nonce: string;
   sessionId: string;
   sessionName: string;
@@ -4482,7 +4505,8 @@ function readDetachedLeaderReport(path: string): DetachedLeaderReport | undefine
     const value: unknown = JSON.parse(readFileSync(path, "utf8"));
     if (!value || typeof value !== "object") return undefined;
     const report = value as Record<string, unknown>;
-    if (report.version !== 1 || !["ready", "failed", "terminal", "release"].includes(String(report.kind)) ||
+    if (report.version !== 1 || !["ready", "failed", "terminal", "release", "abort"].includes(String(report.kind)) ||
+
       typeof report.nonce !== "string" || typeof report.sessionId !== "string" || typeof report.sessionName !== "string") return undefined;
     if (report.paneId !== undefined && typeof report.paneId !== "string") return undefined;
     if (report.leaderPid !== undefined && (!Number.isSafeInteger(report.leaderPid) || Number(report.leaderPid) <= 0)) return undefined;
@@ -4492,6 +4516,10 @@ function readDetachedLeaderReport(path: string): DetachedLeaderReport | undefine
 
 function publishDetachedReleaseMarker(releaseMarkerPath: string, nonce: string, sessionId: string, sessionName: string): void {
   writeDetachedLeaderReport(`${releaseMarkerPath}.release`, { version: 1, kind: "release", nonce, sessionId, sessionName });
+}
+
+function publishDetachedAbortMarker(releaseMarkerPath: string, nonce: string, sessionId: string, sessionName: string): void {
+  writeDetachedLeaderReport(`${releaseMarkerPath}.abort`, { version: 1, kind: "abort", nonce, sessionId, sessionName });
 }
 
 type TmuxExecSync = (file: string, args: readonly string[]) => string;
@@ -5778,6 +5806,8 @@ async function runCodex(
     );
     let detachedParentEnvFilePath: string | undefined;
     let detachedLeaderPaneId: string | null = null;
+    let detachedLeaderPid: number | null = null;
+
     let attachStep: DetachedSessionTmuxStep | null = null;
 
     const launchDetachedSession = async (): Promise<{ postLaunchHandledExternally: boolean }> => {
@@ -5824,7 +5854,10 @@ async function runCodex(
         while (true) {
           const report = readDetachedLeaderReport(releaseMarkerPath);
           if (report?.nonce === detachedLaunchNonce && report.sessionId === sessionId &&
-            report.sessionName === sessionName && report.paneId === detachedLeaderPaneId && report.leaderPid && report.kind === "ready") return report;
+            report.sessionName === sessionName && report.paneId === detachedLeaderPaneId && report.leaderPid && report.kind === "ready") {
+            detachedLeaderPid = report.leaderPid;
+            return report;
+          }
           if (report?.nonce === detachedLaunchNonce && report.sessionId === sessionId && report.kind === "failed") {
             throw new DetachedLaunchSafetyError("completion", new Error(report.error || "detached leader setup failed"), detachedPreflight.report);
           }
@@ -5844,6 +5877,21 @@ async function runCodex(
           publishActiveRecord: async () => ({ bytes: "", digest: "", nonce: detachedLaunchNonce }),
           finalizeSetupFailure: async () => {},
           releaseBarrier: async () => publishDetachedReleaseMarker(releaseMarkerPath, detachedLaunchNonce, sessionId, sessionName),
+          abortAndAwaitFinalization: async () => {
+            // The leader has the retained binding. Publishing abort is the only
+            // outer action permitted after a D9 write failure; a mismatched or
+            // missing report leaves every artifact and the tmux session intact.
+            publishDetachedAbortMarker(releaseMarkerPath, detachedLaunchNonce, sessionId, sessionName);
+            const deadline = Date.now() + 30_000;
+            while (Date.now() < deadline) {
+              const report = readDetachedLeaderReport(releaseMarkerPath);
+              if (report?.nonce === detachedLaunchNonce && report.sessionId === sessionId &&
+                report.sessionName === sessionName && report.leaderPid === detachedLeaderPid &&
+                (report.kind === "failed" || report.kind === "terminal")) return { acknowledged: true };
+              blockMs(20);
+            }
+            return { acknowledged: false };
+          },
           attachOrReturn: async () => { if (attachStep) execTmuxFileSync(attachStep.args, { stdio: "inherit" }); },
           rollback: async (_ownedRecord, report) => {
             const attempt = async (step: DetachedRollbackStep, operation: () => Promise<void> | void): Promise<void> => {
@@ -6064,6 +6112,8 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
   const activeRecordPath = contextKey
     ? madmaxDetachedActiveRecordPath(resolveMadmaxRunsRoot(process.env), contextKey)
     : join(omxRoot(payload.cwd), "state", "detached-active-record.json");
+  let externalInterrupt: NodeJS.Signals | undefined;
+
   try {
     const completion = await completePreLaunchSetup(
       payload.cwd,
@@ -6093,6 +6143,8 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
     if (payload.readyPath) {
       writeDetachedLeaderReport(payload.readyPath, { version: 1, kind: "ready", nonce, sessionId: payload.sessionId, sessionName: payload.sessionName, paneId: pane, leaderPid: process.pid });
       const releasePath = `${payload.readyPath}.release`;
+      const abortPath = `${payload.readyPath}.abort`;
+      const releaseDeadline = Date.now() + 30_000;
       let interrupted: NodeJS.Signals | undefined;
       const interrupt = (signal: NodeJS.Signals): void => { interrupted = signal; };
       process.once("SIGINT", () => interrupt("SIGINT"));
@@ -6102,9 +6154,15 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
         if (interrupted) throw new Error(`detached leader interrupted before release: ${interrupted}`);
         const release = readDetachedLeaderReport(releasePath);
         if (release?.kind === "release" && release.nonce === nonce && release.sessionId === payload.sessionId && release.sessionName === payload.sessionName) break;
+        const abort = readDetachedLeaderReport(abortPath);
+        if (abort?.kind === "abort" && abort.nonce === nonce && abort.sessionId === payload.sessionId && abort.sessionName === payload.sessionName) {
+          throw new Error("detached launch aborted before release");
+        }
+        if (Date.now() >= releaseDeadline) throw new Error("detached leader release timed out");
         blockMs(20);
       }
       rmSync(releasePath, { force: true });
+      rmSync(abortPath, { force: true });
     }
     const child = spawn(process.platform === "win32" ? "powershell.exe" : "/bin/sh", process.platform === "win32" ? ["-NoProfile", "-Command", payload.codexCmd] : ["-c", payload.codexCmd], {
       cwd: payload.cwd,
@@ -6120,29 +6178,42 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
       } catch {}
     };
     const forward = (signal: NodeJS.Signals): void => {
+      externalInterrupt ??= signal;
       signalChildTree(signal);
       if (!escalation) { escalation = setTimeout(() => signalChildTree("SIGKILL", true), 5_000); escalation.unref(); }
     };
     process.once("SIGINT", () => forward("SIGINT"));
     process.once("SIGTERM", () => forward("SIGTERM"));
     process.once("SIGHUP", () => forward("SIGHUP"));
+
     const outcome = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolveChild, rejectChild) => {
       child.once("error", rejectChild);
       child.once("exit", (code, signal) => resolveChild({ code, signal }));
     });
     if (escalation) clearTimeout(escalation);
     if (process.platform !== "win32" && child.pid) {
-      const treeDeadline = Date.now() + 5_000;
-      while (true) {
-        try {
-          process.kill(-child.pid, 0);
-          if (Date.now() >= treeDeadline) { signalChildTree("SIGKILL", true); break; }
-          await new Promise((resolveWait) => setTimeout(resolveWait, 20));
-        } catch { break; }
+      const waitForGroupExit = async (deadline: number): Promise<boolean> => {
+        while (Date.now() < deadline) {
+          try {
+            process.kill(-child.pid!, 0);
+            await new Promise((resolveWait) => setTimeout(resolveWait, 20));
+          } catch {
+            return true;
+          }
+        }
+        return false;
+      };
+      let groupGone = await waitForGroupExit(Date.now() + 5_000);
+      if (!groupGone) {
+        signalChildTree("SIGKILL", true);
+        groupGone = await waitForGroupExit(Date.now() + 5_000);
       }
+      if (!groupGone) throw new Error("detached child process group did not disappear after forced termination");
     }
     const signalExitCodes: Partial<Record<NodeJS.Signals, number>> = { SIGHUP: 129, SIGINT: 130, SIGTERM: 143, SIGKILL: 137 };
-    process.exitCode = outcome.code ?? (outcome.signal ? signalExitCodes[outcome.signal] ?? 1 : 1);
+    process.exitCode = externalInterrupt
+      ? signalExitCodes[externalInterrupt] ?? 1
+      : outcome.code ?? (outcome.signal ? signalExitCodes[outcome.signal] ?? 1 : 1);
     await postLaunch(payload.cwd, payload.sessionId, binding, payload.codexHomeOverride, payload.preLaunchOptions.enableNotifyFallbackAuthority, payload.projectLocalCodexHomeForCleanup);
     if (payload.readyPath) writeDetachedLeaderReport(payload.readyPath, {
       version: 1, kind: "terminal", nonce, sessionId: payload.sessionId, sessionName: payload.sessionName,
@@ -6204,11 +6275,13 @@ export async function postLaunch(
     if (closeFailure) terminalError = new Error(`bound session retained close failed: ${closeFailure.error?.message ?? "unknown error"}`);
   } catch (error) {
     terminalError = error;
-  } finally {
-    const closeEvidence = await closeLaunchSessionBindingOnce(binding);
-    if (closeEvidence.status === "failed" && !terminalError) terminalError = new Error(`bound session retained close failed: ${closeEvidence.error?.message ?? "unknown error"}`);
   }
-  if (terminalError) throw terminalError;
+  if (terminalError) {
+    // Denial diagnostics are complete; do not mutate ordinary lifecycle state.
+    await closeLaunchSessionBindingOnce(binding);
+    throw terminalError;
+  }
+
 
 
   // 0. Reap MCP orphans left behind by the session that just exited.
@@ -6342,6 +6415,10 @@ export async function postLaunch(
   } catch (err) {
     logCliOperationFailure(err);
     // Non-fatal
+  }
+  const closeEvidence = await closeLaunchSessionBindingOnce(binding);
+  if (closeEvidence.status === "failed") {
+    throw new Error(`bound session retained close failed: ${closeEvidence.error?.message ?? "unknown error"}`);
   }
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,7 +5,7 @@
 
 import { execFileSync, spawn } from "child_process";
 import { basename, dirname, join, posix, resolve, win32 } from "path";
-import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "fs";
+import { chmodSync, closeSync, existsSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "fs";
 import { copyFile, cp, lstat, mkdir, readFile, readdir, rm, stat, symlink, utimes, writeFile } from "fs/promises";
 import { constants as osConstants, homedir } from "os";
 import { createHash, randomUUID } from "crypto";
@@ -130,12 +130,15 @@ import {
   writeSessionModelInstructionsFile,
 } from "../hooks/agents-overlay.js";
 import {
+  closeLaunchSessionBindingOnce,
+  establishLaunchSessionBinding,
+  updateDetachedSessionMetadata,
+  finalizeBoundOnce,
   isSessionPointerLaunchAbort,
   normalizeSessionId,
-  readSessionState,
-  writeSessionStart,
-  writeSessionEnd,
   resetSessionMetrics,
+  type LaunchSessionBinding,
+  type EstablishmentCleanupEvidence,
 } from "../hooks/session.js";
 import { probeActualTmuxInstanceEvidence, tmuxEvidenceBindsCandidate } from "../scripts/notify-hook/managed-tmux.js";
 import {
@@ -407,7 +410,6 @@ const ALLOWED_SHELLS = new Set([
   "/opt/local/bin/zsh",
   "/opt/homebrew/bin/zsh",
 ]);
-const WINDOWS_DETACHED_BOOTSTRAP_DELAY_MS = 2500;
 const CODEX_VERSION_FLAGS = new Set(["--version", "-V"]);
 const TMUX_EXTENDED_KEYS_MODE = "always";
 const TMUX_EXTENDED_KEYS_FALLBACK_MODE = "off";
@@ -1708,6 +1710,12 @@ function logCliOperationFailure(error: unknown): void {
 `);
 }
 
+function logEstablishmentCleanupEvidence(error: unknown): void {
+  const cleanup = (error as { establishmentCleanup?: EstablishmentCleanupEvidence } | undefined)?.establishmentCleanup;
+  if (!cleanup) return;
+  process.stderr.write(`[omx] establishment cleanup evidence: ${JSON.stringify(cleanup)}\n`);
+}
+
 function tmuxFailureMessage(error: unknown): string {
   if (!error || typeof error !== "object") return String(error);
   const err = error as ExecFileSyncFailure & {
@@ -1732,89 +1740,17 @@ function isUnsupportedTmuxExtendedKeysFailure(error: unknown): boolean {
   );
 }
 
-function isBenignMissingTmuxServerMessage(message: string): boolean {
-  return (
-    /no server running/i.test(message) ||
-    /error connecting to .*\(No such file or directory\)/i.test(message)
-  );
-}
-
-export interface TmuxLaunchHealth {
-  usable: boolean;
-  reason?: string;
-}
-
-export function checkDetachedTmuxLaunchHealth(): TmuxLaunchHealth {
-  try {
-    execTmuxFileSync(["list-sessions"], {
-      stdio: ["ignore", "pipe", "pipe"],
-      encoding: "utf-8",
-    });
-    return { usable: true };
-  } catch (err) {
-    const reason = tmuxFailureMessage(err);
-    if (isBenignMissingTmuxServerMessage(reason)) {
-      return { usable: true };
-    }
-    return { usable: false, reason };
+function probeDetachedTmuxTransport(): void {
+  const { result } = spawnPlatformCommandSync("tmux", ["-V"], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error || result.status !== 0) {
+    throw new DetachedTransportUnavailable();
   }
 }
 
-function warnDetachedTmuxFallback(reason?: string): void {
-  const suffix = reason ? ` (${reason})` : "";
-  console.warn(
-    `[omx] warning: tmux is installed but its server/socket is unusable${suffix}. Falling back to direct Codex launch.`,
-  );
-}
 
-const QUICK_ATTACH_NOOP_THRESHOLD_MS = 2_000;
-
-function isWslWindowsTerminalEnvironment(env: NodeJS.ProcessEnv): boolean {
-  return Boolean(
-    env.WT_SESSION?.trim() &&
-      (env.WSL_INTEROP?.trim() ||
-        env.WSL_DISTRO_NAME?.trim() ||
-        env.WSLENV?.trim()),
-  );
-}
-
-function readDetachedSessionAttachedClientCount(sessionName: string): number | null {
-  try {
-    const output = execTmuxFileSync(
-      ["display-message", "-p", "-t", sessionName, "#{session_attached}"],
-      {
-        stdio: ["ignore", "pipe", "pipe"],
-        encoding: "utf-8",
-      },
-    ).trim();
-    const parsed = Number.parseInt(output, 10);
-    return Number.isFinite(parsed) ? parsed : null;
-  } catch (err) {
-    logCliOperationFailure(err);
-    return null;
-  }
-}
-
-function assertDetachedAttachDidNotNoop(
-  sessionName: string,
-  elapsedMs: number,
-  env: NodeJS.ProcessEnv,
-): void {
-  if (!isWslWindowsTerminalEnvironment(env)) return;
-  if (elapsedMs >= QUICK_ATTACH_NOOP_THRESHOLD_MS) return;
-
-  const attachedClients = readDetachedSessionAttachedClientCount(sessionName);
-  if (attachedClients === null || attachedClients > 0) return;
-
-  throw new Error(
-    [
-      "tmux attach-session returned immediately without attaching a client",
-      `(session=${sessionName}).`,
-      "This can happen on WSL2 under Windows Terminal.",
-      "Falling back to direct Codex launch.",
-    ].join(" "),
-  );
-}
 
 function resolveTmuxAwareLaunchPolicy(
   explicitLaunchPolicy: CodexLaunchPolicy | undefined,
@@ -1826,24 +1762,13 @@ function resolveTmuxAwareLaunchPolicy(
   const launchPolicy = resolveCodexLaunchPolicy(
     process.env,
     process.platform,
-    undefined,
+    Boolean(resolveTmuxBinaryForPlatform()),
     nativeWindows,
     undefined,
     undefined,
     explicitLaunchPolicy,
   );
-
-  if (launchPolicy !== "detached-tmux") {
-    return { launchPolicy, effectiveExplicitLaunchPolicy: explicitLaunchPolicy };
-  }
-
-  const tmuxHealth = checkDetachedTmuxLaunchHealth();
-  if (tmuxHealth.usable) {
-    return { launchPolicy, effectiveExplicitLaunchPolicy: explicitLaunchPolicy };
-  }
-
-  warnDetachedTmuxFallback(tmuxHealth.reason);
-  return { launchPolicy: "direct", effectiveExplicitLaunchPolicy: "direct" };
+  return { launchPolicy, effectiveExplicitLaunchPolicy: explicitLaunchPolicy };
 }
 
 export interface CodexExecFailureClassification {
@@ -2404,6 +2329,10 @@ interface MadmaxDetachedActiveRecord {
   tmux_session_name: string;
   session_id?: string;
   tmux_pane_id?: string;
+  launch_nonce?: string;
+  leader_pid?: number;
+  base_state_root?: string;
+  lifecycle_phase?: "ready" | "terminal";
 }
 
 function resolveMadmaxRunsRoot(env: NodeJS.ProcessEnv = process.env): string {
@@ -2610,12 +2539,12 @@ function inspectMadmaxDetachedContextLock(lockPath: string): MadmaxDetachedLockI
   };
 }
 
-export function withMadmaxDetachedContextLock<T>(
+export async function withMadmaxDetachedContextLock<T>(
   runsRoot: string,
   contextKey: string,
-  run: () => T,
+  run: () => T | Promise<T>,
   options: MadmaxDetachedLockRetryOptions = {},
-): T {
+): Promise<T> {
   const lockPath = join(runsRoot, MADMAX_DETACHED_ACTIVE_DIR, `${contextKey}.lock`);
   const maxAttempts = options.maxAttempts ?? MADMAX_DETACHED_LOCK_MAX_ATTEMPTS;
   const retryMs = options.retryMs ?? MADMAX_DETACHED_LOCK_RETRY_MS;
@@ -2633,7 +2562,7 @@ export function withMadmaxDetachedContextLock<T>(
         };
         writeFileSync(join(lockPath, "owner.json"), `${JSON.stringify(owner, null, 2)}\n`, { mode: 0o600 });
         writeFileSync(join(lockPath, "pid"), String(process.pid));
-        return run();
+        return await run();
       } finally {
         rmSync(lockPath, { recursive: true, force: true });
       }
@@ -2656,6 +2585,7 @@ export function withMadmaxDetachedContextLock<T>(
     `timed out waiting for madmax detached launch context lock: ${lockPath} (${lastDiagnostic})`,
   );
 }
+
 
 function readMadmaxRunMetadata(
   runRoot: string,
@@ -2711,20 +2641,250 @@ function cleanupCurrentMadmaxReuseRunRoot(env: NodeJS.ProcessEnv, runsRoot: stri
   rmSync(runRoot, { recursive: true, force: true });
 }
 
+export interface DetachedActiveRecordOwnership {
+  bytes: string;
+  digest: string;
+  nonce: string;
+}
+
 function writeMadmaxDetachedActiveRecord(
   recordPath: string,
   record: MadmaxDetachedActiveRecord,
-): void {
-  mkdirSync(dirname(recordPath), { recursive: true });
-  writeFileSync(recordPath, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 });
+): DetachedActiveRecordOwnership {
+  const bytes = `${JSON.stringify(record, null, 2)}\n`;
+  const tempPath = `${recordPath}.${process.pid}.${randomUUID()}.tmp`;
+  let fd: number | undefined;
+  mkdirSync(dirname(recordPath), { recursive: true, mode: 0o700 });
+  try {
+    fd = openSync(tempPath, "wx", 0o600);
+    writeFileSync(fd, bytes, "utf-8");
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+    renameSync(tempPath, recordPath);
+    const directoryFd = openSync(dirname(recordPath), "r");
+    try {
+      fsyncSync(directoryFd);
+    } finally {
+      closeSync(directoryFd);
+    }
+    return {
+      bytes,
+      digest: createHash("sha256").update(bytes).digest("hex"),
+      nonce: record.launch_nonce ?? "",
+    };
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+    try { unlinkSync(tempPath); } catch {}
+  }
 }
 
-class MadmaxDetachedReuseError extends Error {
-  readonly failClosed = true;
+export type DetachedRollbackStep =
+  | "setup-finalization"
+  | "rollback"
+  | "lease-close"
+  | "notify-watcher"
+  | "derived-watcher"
+  | "session-instructions"
+  | "runtime-codex-home"
+  | "parent-env"
+  | "verified-record"
+  | `session:${string}`;
+
+export interface SafeFailure {
+  step: DetachedRollbackStep;
+  status: "failed";
+  code: string;
 }
+
+export interface DetachedRollbackEvidence {
+  attempted: DetachedRollbackStep[];
+  failures: SafeFailure[];
+}
+
+export interface DetachedBootstrapReport {
+  transitions: DetachedLaunchTransition[];
+  rollback: DetachedRollbackEvidence;
+  establishmentCleanup?: EstablishmentCleanupEvidence;
+}
+
+function detachedFailureCode(error: unknown): string {
+  const code = error && typeof error === "object" && "code" in error
+    ? (error as { code?: unknown }).code
+    : undefined;
+  return typeof code === "string" && /^(?:EACCES|EAGAIN|EBUSY|ECANCELED|ECONNREFUSED|EEXIST|EINTR|EINVAL|EIO|EISDIR|EMFILE|ENFILE|ENOENT|ENOSPC|ENOTDIR|EPERM|EPIPE|EROFS|ESRCH|ETIMEDOUT)$/.test(code) ? code : "unknown";
+}
+
+
+export class DetachedLaunchSafetyError extends Error {
+  readonly name = "DetachedLaunchSafetyError";
+  constructor(
+    readonly phase: "establishment" | "completion" | "inert-session" | "pane-id" | "name-metadata" | "pane-metadata" | "active-record" | "lease-close" | "barrier-release" | "post-release-attach",
+    readonly cause: unknown,
+    readonly report: DetachedBootstrapReport,
+  ) {
+    super(`detached launch safety failure during ${phase}`);
+  }
+}
+
+export type DetachedLaunchTransition = "D0" | "D1" | "D2" | "D3" | "D4" | "D5" | "D6" | "D7" | "D9" | "D10";
+
+
+export type DetachedLaunchTerminal =
+  | { kind: "attached" | "returned"; released: true; report: DetachedBootstrapReport };
+
+export class DetachedTransportUnavailable extends Error {
+  readonly name = "DetachedTransportUnavailable";
+  readonly noSideEffects = true;
+
+  constructor(readonly reason?: string) {
+    super("detached transport is unavailable before launch side effects");
+  }
+}
+
+export interface DetachedPreflightAvailable {
+  readonly kind: "available";
+  readonly shouldAttach: boolean;
+  readonly report: DetachedBootstrapReport;
+}
+
+
+
+export interface DetachedLaunchStateMachineInput {
+  preflight: DetachedPreflightAvailable;
+}
+
+export interface DetachedLaunchDependencies<Binding = unknown, InertSession = unknown, Pane = string> {
+  establish(): Promise<Binding>;
+  complete(binding: Binding): Promise<CompletionResult>;
+  createInertSession(): Promise<InertSession>;
+  capturePane(session: InertSession): Promise<Pane>;
+  updateNameMetadata(binding: Binding, session: InertSession): Promise<"committed-released">;
+  updatePaneMetadata(binding: Binding, pane: Pane): Promise<"committed-released">;
+  publishActiveRecord(session: InertSession, pane: Pane): Promise<DetachedActiveRecordOwnership>;
+  // The long-lived leader retains this authority until terminal finalization.
+  finalizeSetupFailure(binding: Binding): Promise<void>;
+  releaseBarrier(): Promise<void>;
+  attachOrReturn(session: InertSession, shouldAttach: boolean): Promise<void>;
+  rollback(ownedRecord: DetachedActiveRecordOwnership | undefined, report: DetachedBootstrapReport): Promise<void>;
+  diagnostic?(error: unknown): void;
+}
+
+/** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
+export async function executeDetachedLaunchStateMachine<Binding, InertSession, Pane>(
+  input: DetachedLaunchStateMachineInput,
+  deps: DetachedLaunchDependencies<Binding, InertSession, Pane>,
+): Promise<DetachedLaunchTerminal> {
+  const report = input.preflight.report;
+  const transition = (name: DetachedLaunchTransition): void => { report.transitions.push(name); };
+
+  let binding: Binding | undefined;
+  let ownedRecord: DetachedActiveRecordOwnership | undefined;
+  let released = false;
+  try {
+    transition("D1");
+    binding = await deps.establish();
+    transition("D2");
+    const completion = await deps.complete(binding);
+    if (completion.kind === "failure") {
+      const failures: unknown[] = [completion.error];
+      try {
+        report.rollback.attempted.push("setup-finalization");
+        await deps.finalizeSetupFailure(binding);
+      } catch (finalizationError) {
+        report.rollback.failures.push({ step: "setup-finalization", status: "failed", code: detachedFailureCode(finalizationError) });
+        failures.push(finalizationError);
+      }
+      binding = undefined;
+      throw new DetachedLaunchSafetyError("completion", new AggregateError(failures, `preLaunch ${completion.operation} failed`), report);
+    }
+    transition("D3");
+    const inertSession = await deps.createInertSession();
+    transition("D4");
+    const pane = await deps.capturePane(inertSession);
+    transition("D5");
+    if (await deps.updateNameMetadata(binding, inertSession) !== "committed-released") {
+      throw new DetachedLaunchSafetyError("name-metadata", new Error("detached name metadata did not release"), report);
+    }
+    transition("D6");
+    if (await deps.updatePaneMetadata(binding, pane) !== "committed-released") {
+      throw new DetachedLaunchSafetyError("pane-metadata", new Error("detached pane metadata did not release"), report);
+    }
+    transition("D7");
+    ownedRecord = await deps.publishActiveRecord(inertSession, pane);
+    transition("D9");
+    transition("D9");
+    await deps.releaseBarrier();
+    released = true;
+    transition("D10");
+    await deps.attachOrReturn(inertSession, input.preflight.shouldAttach);
+    return { kind: input.preflight.shouldAttach ? "attached" : "returned", released: true, report };
+  } catch (error) {
+    deps.diagnostic?.(error);
+    if (!released) {
+      try {
+        report.rollback.attempted.push("rollback");
+        await deps.rollback(ownedRecord, report);
+      } catch (rollbackError) {
+        report.rollback.failures.push({ step: "rollback", status: "failed", code: detachedFailureCode(rollbackError) });
+        deps.diagnostic?.(rollbackError);
+      }
+    }
+    if (error instanceof DetachedLaunchSafetyError) {
+      throw new DetachedLaunchSafetyError(error.phase, error.cause, report);
+    }
+    const phase = report.transitions.at(-1);
+    const phaseName = phase === "D1" ? "establishment"
+      : phase === "D2" ? "completion"
+      : phase === "D3" ? "inert-session"
+      : phase === "D4" ? "pane-id"
+      : phase === "D5" ? "name-metadata"
+      : phase === "D6" ? "pane-metadata"
+      : phase === "D7" ? "active-record"
+      : phase === "D9" ? "barrier-release"
+      : "post-release-attach";
+    throw new DetachedLaunchSafetyError(phaseName, error, report);
+  }
+}
+
 
 class MadmaxDetachedGuardError extends Error {
   readonly failClosed = true;
+}
+
+function preflightDetachedLaunch(): DetachedPreflightAvailable {
+  // D0 must remain transport-only: `tmux -V` neither connects to nor creates a server.
+  probeDetachedTmuxTransport();
+  const report: DetachedBootstrapReport = { transitions: ["D0"], rollback: { attempted: [], failures: [] } };
+  return Object.freeze({
+    kind: "available",
+    shouldAttach: shouldAttachDetachedTmuxSession(process.env),
+    report,
+  });
+}
+
+
+function handleMadmaxDetachedReuse(
+  runtimeContext: MadmaxWorktreeRuntimeContext | undefined,
+  preflight: DetachedPreflightAvailable,
+): boolean {
+  const contextKey = runtimeContext?.madmaxDetachedContext ?? process.env[OMX_MADMAX_DETACHED_CONTEXT_ENV]?.trim();
+  const activeRecordPath = contextKey ? madmaxDetachedActiveRecordPath(resolveMadmaxRunsRoot(process.env), contextKey) : null;
+  const activeRecord = activeRecordPath ? readMadmaxDetachedActiveRecord(activeRecordPath) : null;
+  if (!activeRecord || activeRecord.context_key !== contextKey || !isReusableMadmaxDetachedActiveRecord(activeRecord)) return false;
+  cleanupCurrentMadmaxReuseRunRoot(process.env, resolveMadmaxRunsRoot(process.env));
+  setDetachedTmuxSessionHistoryLimit(activeRecord.tmux_session_name, activeRecord.tmux_pane_id!);
+  if (!preflight.shouldAttach) {
+    clearDetachedTmuxSessionHistoryIfUnattached(activeRecord.tmux_session_name, activeRecord.tmux_pane_id!);
+    return true;
+  }
+  process.stderr.write(`[omx] madmax detached launch already active for this context; attaching ${activeRecord.tmux_session_name} instead of starting a duplicate.\n`);
+  try {
+    execTmuxFileSync(["attach-session", "-t", activeRecord.tmux_session_name], { stdio: "inherit" });
+  } catch (error) {
+    throw new DetachedLaunchSafetyError("post-release-attach", error, preflight.report);
+  }
+  return true;
 }
 
 export function createMadmaxIsolatedRoot(
@@ -2768,6 +2928,24 @@ function activateMadmaxIsolationIfNeeded(
   process.stderr.write(`[omx] madmax isolated state: ${runDir} (source: ${cwd})\n`);
 }
 
+function renderDetachedLaunchSafetyReport(error: DetachedLaunchSafetyError): string {
+  const establishmentCleanup = error.report.establishmentCleanup?.capability.map((entry) => ({
+    role: entry.role,
+    phase: entry.phase,
+    status: entry.status,
+    ...(entry.error ? { failureCode: detachedFailureCode(entry.error) } : {}),
+  }));
+  return JSON.stringify({
+    phase: error.phase,
+    transitions: error.report.transitions,
+    ...(establishmentCleanup ? { establishmentCleanup } : {}),
+    rollback: {
+      attempted: error.report.rollback.attempted,
+      failures: error.report.rollback.failures.map(({ step, status, code }) => ({ step, status, code })),
+    },
+  });
+}
+
 export async function main(args: string[]): Promise<void> {
   const knownCommands = new Set([
     "launch",
@@ -2776,6 +2954,7 @@ export async function main(args: string[]): Promise<void> {
     "imagegen",
     "capabilities",
     "setup",
+    "__detached-session-leader",
     "update",
     "list",
     "agents",
@@ -2829,10 +3008,18 @@ export async function main(args: string[]): Promise<void> {
     return;
   }
 
+if (command !== "launch" && command !== "resume") {
   activateMadmaxIsolationIfNeeded(command, launchArgs, process.cwd(), process.env);
+}
+
 
   try {
     switch (command) {
+      case "__detached-session-leader": {
+        const payload = decodeDetachedLeaderPayload(launchArgs[0]);
+        await runDetachedSessionLeader(payload);
+        break;
+      }
       case "launch":
         if (launchArgsRequestAuthHotswap(launchArgs)) {
           await launchWithAuthHotswap(launchArgs);
@@ -3029,8 +3216,15 @@ export async function main(args: string[]): Promise<void> {
         console.log(HELP);
         process.exit(1);
     }
-  } catch (err) {
-    console.error(`Error: ${err instanceof Error ? err.message : err}`);
+
+
+} catch (err) {
+    if (err instanceof DetachedLaunchSafetyError) {
+      console.error(`Error: ${err.message}`);
+      console.error(`[omx] detached launch safety report: ${renderDetachedLaunchSafetyReport(err)}`);
+    } else {
+      console.error(`Error: ${err instanceof Error ? err.message : err}`);
+    }
     process.exit(1);
   }
 }
@@ -3279,33 +3473,7 @@ export async function launchWithAuthHotswap(args: string[]): Promise<void> {
 }
 
 export async function launchWithHud(args: string[]): Promise<void> {
-  if (isNativeWindows()) {
-    const { result } = spawnPlatformCommandSync("tmux", ["-V"], {
-      encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    if (result.error) {
-      const errno = result.error as NodeJS.ErrnoException;
-      const kind = classifySpawnError(errno);
-      if (kind === "missing") {
-        console.warn(
-          "[omx] warning: tmux was not found on native Windows. Continuing without tmux/HUD.\n" +
-            "[omx] To enable tmux-backed features, install psmux:\n" +
-            "[omx]   winget install psmux\n" +
-            "[omx] See: https://github.com/marlocarlo/psmux",
-        );
-      } else {
-        console.warn(
-          `[omx] warning: tmux probe failed on native Windows (${errno.code || errno.message}). Continuing without tmux/HUD.`,
-        );
-      }
-    } else if (result.status !== 0 && !isTmuxAvailable()) {
-      const stderr = (result.stderr || "").trim();
-      console.warn(
-        `[omx] warning: tmux reported an error on native Windows${stderr ? ` (${stderr})` : ""}. Continuing without tmux/HUD.`,
-      );
-    }
-  }
+
 
   const launchCwd = process.cwd();
   const { omxArgs, suffix } = splitOmxArgsAtEndOfOptions(args);
@@ -3319,10 +3487,20 @@ export async function launchWithHud(args: string[]): Promise<void> {
     passthroughArgs,
     process.env,
   );
-  const persistentCodexHomeForLaunch = resolveCodexHomeForLaunch(launchCwd, process.env);
-  const { launchPolicy, effectiveExplicitLaunchPolicy } =
-    resolveTmuxAwareLaunchPolicy(explicitLaunchPolicy, isNativeWindows());
+  let { launchPolicy } = resolveTmuxAwareLaunchPolicy(explicitLaunchPolicy, isNativeWindows());
+  let detachedPreflight: DetachedPreflightAvailable | undefined;
+  if (launchPolicy === "detached-tmux") {
+    try {
+      detachedPreflight = preflightDetachedLaunch();
+    } catch (error) {
+      if (!(error instanceof DetachedTransportUnavailable)) throw error;
+      console.warn("[omx] warning: detached tmux transport is unavailable. Falling back to direct Codex launch.");
+      launchPolicy = "direct";
+    }
+  }
   const enableNotifyFallbackAuthority = launchPolicy === "direct";
+  activateMadmaxIsolationIfNeeded("launch", args, launchCwd, process.env);
+  const persistentCodexHomeForLaunch = resolveCodexHomeForLaunch(launchCwd, process.env);
   const workerSparkModel = resolveWorkerSparkModel(
     passthroughArgs,
     persistentCodexHomeForLaunch,
@@ -3366,6 +3544,9 @@ export async function launchWithHud(args: string[]): Promise<void> {
   clearInheritedMadmaxRootForDisposableWorktreeLaunch(parsedWorktree.remainingArgs);
   applyDisposableWorktreeOmxRootForLaunch(ensuredLaunchWorktree);
   applyWorktreeToolContextForLaunch(cwd, ensuredLaunchWorktree);
+  if (launchPolicy === "detached-tmux" && detachedPreflight && handleMadmaxDetachedReuse(madmaxWorktreeRuntimeContext, detachedPreflight)) return;
+
+
 
   const sessionId = `omx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   try {
@@ -3412,18 +3593,20 @@ export async function launchWithHud(args: string[]): Promise<void> {
   const codexHomeOverride = preparedCodexHome.codexHomeOverride;
   const sqliteHomeOverride = preparedCodexHome.sqliteHomeOverride;
   const projectLocalCodexHomeForCleanup = preparedCodexHome.projectLocalCodexHomeForCleanup;
-
-  // ── Phase 1: preLaunch ──────────────────────────────────────────────────
-  try {
-    await preLaunch(cwd, sessionId, notifyTempResult.contract, codexHomeOverride, enableNotifyFallbackAuthority, worktreeDirty);
-  } catch (err) {
-    if (isSessionPointerLaunchAbort(err)) {
-      console.error(`[omx] session pointer launch aborted: ${err.code}`);
-      reportOrdinaryLaunchRootConflict(
-        err,
-        cwd,
-        cwd === launchCwd && !parsedWorktree.mode.enabled && !isResumeCodexLaunch(normalizedArgs),
-      );
+  let launch: PreLaunchResult | undefined;
+  if (launchPolicy !== "detached-tmux") {
+    try {
+      launch = await preLaunch(cwd, sessionId, notifyTempResult.contract, codexHomeOverride, enableNotifyFallbackAuthority, worktreeDirty);
+    } catch (err) {
+      logEstablishmentCleanupEvidence(err);
+      if (isSessionPointerLaunchAbort(err)) {
+        console.error(`[omx] session pointer launch aborted: ${err.code}`);
+        reportOrdinaryLaunchRootConflict(
+          err,
+          cwd,
+          cwd === launchCwd && !parsedWorktree.mode.enabled && !isResumeCodexLaunch(normalizedArgs),
+        );
+      }
       await cleanupRuntimeCodexHome(
         preparedCodexHome.runtimeCodexHomeForCleanup,
         projectLocalCodexHomeForCleanup,
@@ -3434,19 +3617,14 @@ export async function launchWithHud(args: string[]): Promise<void> {
       });
       throw err;
     }
-    // preLaunch errors after pointer commit must not prevent Codex from starting.
-    console.error(
-      `[omx] preLaunch warning: ${err instanceof Error ? err.message : err}`,
-    );
   }
 
-  // ── Phase 2: run ────────────────────────────────────────────────────────
   let postLaunchHandledExternally = false;
   try {
     const notifyTempContractRaw = notifyTempResult.contract.active
       ? serializeNotifyTempContract(notifyTempResult.contract)
       : null;
-    const launchResult = runCodex(
+    const launchResult = await runCodex(
       cwd,
       normalizedArgs,
       sessionId,
@@ -3454,16 +3632,24 @@ export async function launchWithHud(args: string[]): Promise<void> {
       codexHomeOverride,
       sqliteHomeOverride,
       notifyTempContractRaw,
-      effectiveExplicitLaunchPolicy,
+      {
+        notifyTempContract: notifyTempResult.contract,
+        enableNotifyFallbackAuthority,
+        worktreeDirty,
+      },
+      launchPolicy,
+      detachedPreflight,
       projectLocalCodexHomeForCleanup,
       preparedCodexHome.runtimeCodexHomeForCleanup,
       madmaxWorktreeRuntimeContext,
     );
     postLaunchHandledExternally = launchResult.postLaunchHandledExternally;
+  } catch (error) {
+    if (error instanceof DetachedLaunchSafetyError) postLaunchHandledExternally = true;
+    throw error;
   } finally {
-    // ── Phase 3: postLaunch ─────────────────────────────────────────────
-    if (!postLaunchHandledExternally) {
-      await postLaunch(cwd, sessionId, codexHomeOverride, enableNotifyFallbackAuthority, projectLocalCodexHomeForCleanup);
+    if (!postLaunchHandledExternally && launch) {
+      await postLaunch(cwd, sessionId, launch.binding, codexHomeOverride, enableNotifyFallbackAuthority, projectLocalCodexHomeForCleanup);
       await cleanupRuntimeCodexHome(preparedCodexHome.runtimeCodexHomeForCleanup, projectLocalCodexHomeForCleanup).catch(logCliOperationFailure);
     }
   }
@@ -3545,25 +3731,24 @@ export async function execWithOverlay(args: string[]): Promise<void> {
   const codexHomeOverride = preparedCodexHome.codexHomeOverride;
   const sqliteHomeOverride = preparedCodexHome.sqliteHomeOverride;
   const projectLocalCodexHomeForCleanup = preparedCodexHome.projectLocalCodexHomeForCleanup;
+  let launch: PreLaunchResult;
 
   try {
-    await preLaunch(cwd, sessionId, notifyTempResult.contract, codexHomeOverride, true, worktreeDirty);
+    launch = await preLaunch(cwd, sessionId, notifyTempResult.contract, codexHomeOverride, true, worktreeDirty);
   } catch (err) {
+    logEstablishmentCleanupEvidence(err);
     if (isSessionPointerLaunchAbort(err)) {
       console.error(`[omx] session pointer launch aborted: ${err.code}`);
-      await cleanupRuntimeCodexHome(
-        preparedCodexHome.runtimeCodexHomeForCleanup,
-        projectLocalCodexHomeForCleanup,
-      ).catch((cleanupErr) => {
-        console.error(
-          `[omx] preLaunch abort cleanup warning: ${cleanupErr instanceof Error ? cleanupErr.message : cleanupErr}`,
-        );
-      });
-      throw err;
     }
-    console.error(
-      `[omx] preLaunch warning: ${err instanceof Error ? err.message : err}`,
-    );
+    await cleanupRuntimeCodexHome(
+      preparedCodexHome.runtimeCodexHomeForCleanup,
+      projectLocalCodexHomeForCleanup,
+    ).catch((cleanupErr) => {
+      console.error(
+        `[omx] preLaunch abort cleanup warning: ${cleanupErr instanceof Error ? cleanupErr.message : cleanupErr}`,
+      );
+    });
+    throw err;
   }
 
   try {
@@ -3591,7 +3776,7 @@ export async function execWithOverlay(args: string[]): Promise<void> {
       : codexEnvBase;
     runCodexBlocking(cwd, codexArgs, codexEnv);
   } finally {
-    await postLaunch(cwd, sessionId, codexHomeOverride, true, projectLocalCodexHomeForCleanup);
+    await postLaunch(cwd, sessionId, launch.binding, codexHomeOverride, true, projectLocalCodexHomeForCleanup);
     await cleanupRuntimeCodexHome(preparedCodexHome.runtimeCodexHomeForCleanup, projectLocalCodexHomeForCleanup).catch(logCliOperationFailure);
   }
 }
@@ -3947,9 +4132,6 @@ export function detectDetachedSessionWindowIndex(sessionName: string): string | 
   }
 }
 
-function escapeShellDoubleQuotedValue(value: string): string {
-  return value.replace(/["\\$`]/g, "\\$&");
-}
 
 interface TmuxExtendedKeysLeaseHolderRecord {
   id: string;
@@ -4197,96 +4379,59 @@ function buildDetachedSessionLeaderCommand(
   sessionName: string,
   codexCmd: string,
   sessionId?: string,
-  codexHomeOverride?: string,
+  _codexHomeOverride?: string,
   projectLocalCodexHomeForCleanup?: string,
   runtimeCodexHomeForCleanup?: string,
   parentEnvFilePath?: string,
+  releaseMarkerPath?: string,
+  omxBin = process.argv[1],
 ): string {
-  const detachedPostLaunchHelper = sessionId
-    ? `${buildDetachedSessionPostLaunchHelperCommand(cwd, sessionId, codexHomeOverride, projectLocalCodexHomeForCleanup, runtimeCodexHomeForCleanup)} >/dev/null 2>&1 || true;`
-    : "";
-  const parentEnvSource =
-    parentEnvFilePath && parentEnvFilePath.trim()
-      ? `if [ -r ${quoteShellArg(parentEnvFilePath)} ]; then . ${quoteShellArg(parentEnvFilePath)}; rm -f ${quoteShellArg(parentEnvFilePath)}; fi;`
-      : "";
-  const parentEnvCleanup =
-    parentEnvFilePath && parentEnvFilePath.trim()
-      ? `rm -f ${quoteShellArg(parentEnvFilePath)} 2>/dev/null || true;`
-      : "";
-  const wrapped = [
-    buildTmuxExtendedKeysAcquireShellSnippet(cwd),
-    'exec 3<&0;',
-    'omx_codex_pid="";',
-    "omx_detached_session_cleanup() {",
-    "status=$?;",
-    "trap - 0 INT TERM HUP;",
-    'if [ -n "$omx_codex_pid" ] && kill -0 "$omx_codex_pid" 2>/dev/null; then',
-    'kill -TERM "$omx_codex_pid" 2>/dev/null || true;',
-    'wait "$omx_codex_pid" 2>/dev/null || true;',
-    "fi;",
-    'exec 3<&- 2>/dev/null || true;',
-    buildTmuxExtendedKeysReleaseShellSnippet(cwd),
-    parentEnvCleanup,
-    detachedPostLaunchHelper,
-    'if [ "$status" -eq 0 ]; then',
-    `tmux kill-session -t "${escapeShellDoubleQuotedValue(sessionName)}" >/dev/null 2>&1 || true;`,
-    "fi;",
-    "exit $status;",
-    "};",
-    "trap omx_detached_session_cleanup 0 INT TERM HUP;",
-    parentEnvSource,
-    "unset OMX_HERMES_MCP_BRIDGE;",
-    "omx_codex_started_at=$(date +%s 2>/dev/null || printf 0);",
-    `${codexCmd} <&3 &`,
-    "omx_codex_pid=$!;",
-    'wait "$omx_codex_pid";',
-    "omx_codex_status=$?;",
-    "omx_codex_finished_at=$(date +%s 2>/dev/null || printf 0);",
-    'omx_codex_elapsed=$((omx_codex_finished_at - omx_codex_started_at));',
-    'if [ "$omx_codex_status" -eq 0 ] && [ "$omx_codex_elapsed" -le 2 ]; then',
-    'printf "\\n[omx] codex exited immediately with code 0 during startup. The detached tmux session is being kept open so any output above remains visible. Press Enter to close this OMX session.\\n" >&2;',
-    'IFS= read -r _omx_close || true;',
-    'elif [ "$omx_codex_status" -gt 0 ] && [ "$omx_codex_status" -lt 128 ] && [ "$omx_codex_elapsed" -le 2 ]; then',
-    'printf "\\n[omx] codex exited with code %s during startup. The detached tmux session is being kept open so the error above remains visible. Press Enter to close this OMX session.\\n" "$omx_codex_status" >&2;',
-    'IFS= read -r _omx_close || true;',
-    'elif [ "$omx_codex_status" -gt 0 ] && [ "$omx_codex_status" -lt 128 ]; then',
-    'printf "\\n[omx] codex exited with code %s. The detached tmux session is being kept open so the error above remains visible. Press Enter to close this OMX session.\\n" "$omx_codex_status" >&2;',
-    'IFS= read -r _omx_close || true;',
-    "fi;",
-    'exit "$omx_codex_status";',
-  ].join(" ");
-  return `/bin/sh -c ${quoteShellArg(wrapped)}`;
+  const payload = Buffer.from(JSON.stringify({
+    cwd,
+    sessionName,
+    sessionId,
+    codexCmd,
+    projectLocalCodexHomeForCleanup,
+    runtimeCodexHomeForCleanup,
+    parentEnvFilePath,
+    readyPath: releaseMarkerPath,
+  })).toString("base64url");
+  return `/bin/sh -c ${quoteShellArg(`${parentEnvFilePath ? `if [ -r ${quoteShellArg(parentEnvFilePath)} ]; then . ${quoteShellArg(parentEnvFilePath)}; rm -f ${quoteShellArg(parentEnvFilePath)}; fi; ` : ""}exec ${quoteShellArg(process.execPath)} ${quoteShellArg(omxBin)} __detached-session-leader ${quoteShellArg(payload)}`)}`;
 }
-
-function buildDetachedSessionPostLaunchHelperCommand(
+function buildDetachedWindowsLeaderCommand(
   cwd: string,
-  sessionId: string,
-  codexHomeOverride?: string,
+  sessionName: string,
+  codexCmd: string,
+  sessionId?: string,
   projectLocalCodexHomeForCleanup?: string,
   runtimeCodexHomeForCleanup?: string,
+  releaseMarkerPath?: string,
+  omxBin = process.argv[1],
 ): string {
-  const cwdLiteral = JSON.stringify(cwd);
-  const sessionIdLiteral = JSON.stringify(sessionId);
-  const codexHomeLiteral =
-    typeof codexHomeOverride === "string" && codexHomeOverride.length > 0
-      ? JSON.stringify(codexHomeOverride)
-      : "undefined";
-  const projectLocalCleanupLiteral =
-    typeof projectLocalCodexHomeForCleanup === "string" &&
-    projectLocalCodexHomeForCleanup.length > 0
-      ? JSON.stringify(projectLocalCodexHomeForCleanup)
-      : "undefined";
-  const runtimeCodexHomeCleanupLiteral =
-    typeof runtimeCodexHomeForCleanup === "string" &&
-    runtimeCodexHomeForCleanup.length > 0
-      ? JSON.stringify(runtimeCodexHomeForCleanup)
-      : "undefined";
-  const moduleUrlLiteral = JSON.stringify(import.meta.url);
-  const script = [
-    `const mod = await import(${moduleUrlLiteral});`,
-    `await mod.runDetachedSessionPostLaunch(${cwdLiteral}, ${sessionIdLiteral}, ${codexHomeLiteral}, ${projectLocalCleanupLiteral}, ${runtimeCodexHomeCleanupLiteral});`,
-  ].join(" ");
-  return `${quoteShellArg(process.execPath)} --input-type=module -e ${quoteShellArg(script)}`;
+  const payload = Buffer.from(JSON.stringify({
+    cwd, sessionName, sessionId, codexCmd, projectLocalCodexHomeForCleanup,
+    runtimeCodexHomeForCleanup, readyPath: releaseMarkerPath,
+  })).toString("base64url");
+  const invocation = `& ${quotePowerShellArg(process.execPath)} ${quotePowerShellArg(omxBin)} __detached-session-leader ${quotePowerShellArg(payload)}`;
+  return `powershell.exe -NoLogo -NoProfile -NonInteractive -Command ${quotePowerShellArg(invocation)}`;
+}
+
+
+
+function publishDetachedReleaseMarker(releaseMarkerPath: string, nonce: string): void {
+  const tempPath = `${releaseMarkerPath}.${process.pid}.${randomUUID()}.tmp`;
+  let fd: number | undefined;
+  try {
+    fd = openSync(tempPath, "wx", 0o600);
+    writeFileSync(fd, `${nonce}\n`, "utf-8");
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+    renameSync(tempPath, releaseMarkerPath);
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+    try { unlinkSync(tempPath); } catch {}
+  }
 }
 
 type TmuxExecSync = (file: string, args: readonly string[]) => string;
@@ -4408,26 +4553,7 @@ export function releaseTmuxExtendedKeysLease(
   }
 }
 
-function buildTmuxExtendedKeysHelperCommand(
-  cwd: string,
-  operation: "acquire" | "release",
-): string {
-  const cwdLiteral = JSON.stringify(cwd);
-  const moduleUrlLiteral = JSON.stringify(import.meta.url);
-  const script =
-    operation === "acquire"
-      ? `const mod = await import(${moduleUrlLiteral}); const ownerPid = Number.parseInt(process.argv[1] ?? "", 10); const lease = mod.acquireTmuxExtendedKeysLease(${cwdLiteral}, undefined, Number.isSafeInteger(ownerPid) && ownerPid > 0 ? ownerPid : undefined); if (lease) process.stdout.write(lease);`
-      : `const mod = await import(${moduleUrlLiteral}); mod.releaseTmuxExtendedKeysLease(${cwdLiteral}, process.argv[1] ?? "");`;
-  return `${quoteShellArg(process.execPath)} --input-type=module -e ${quoteShellArg(script)}`;
-}
 
-function buildTmuxExtendedKeysAcquireShellSnippet(cwd: string): string {
-  return `OMX_TMUX_EXTENDED_KEYS_LEASE=$(${buildTmuxExtendedKeysHelperCommand(cwd, "acquire")} "$$" 2>/dev/null || true);`;
-}
-
-function buildTmuxExtendedKeysReleaseShellSnippet(cwd: string): string {
-  return `if [ -n "\${OMX_TMUX_EXTENDED_KEYS_LEASE:-}" ]; then ${buildTmuxExtendedKeysHelperCommand(cwd, "release")} "\${OMX_TMUX_EXTENDED_KEYS_LEASE}" >/dev/null 2>&1 || true; fi;`;
-}
 
 const SHELL_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const DETACHED_SESSION_PANE_ENV_KEYS = new Set([
@@ -4511,9 +4637,14 @@ export function buildDetachedSessionBootstrapSteps(
   sqliteHomeOverride?: string,
   parentEnvFilePath?: string,
   inheritedWorkerModel?: string | null,
+  releaseMarkerPath?: string,
+  omxBin = process.argv[1],
 ): DetachedSessionTmuxStep[] {
   const detachedLeaderCmd = nativeWindows
-    ? "powershell.exe"
+    ? buildDetachedWindowsLeaderCommand(
+        cwd, sessionName, codexCmd, sessionId, projectLocalCodexHomeForCleanup,
+        runtimeCodexHomeForCleanup, releaseMarkerPath, omxBin,
+      )
     : buildDetachedSessionLeaderCommand(
         cwd,
         sessionName,
@@ -4523,6 +4654,8 @@ export function buildDetachedSessionBootstrapSteps(
         projectLocalCodexHomeForCleanup,
         runtimeCodexHomeForCleanup,
         parentEnvFilePath,
+        releaseMarkerPath,
+        omxBin,
       );
   const resolvedEnvStateRoot = env.OMX_STATE_ROOT?.trim()
     ? resolveLaunchPath(cwd, env.OMX_STATE_ROOT.trim())
@@ -5217,6 +5350,116 @@ export async function reapPostLaunchOrphanedMcpProcesses(
  * OMX MCP processes without a live Codex ancestor are reaped so new launches
  * do not accumulate stale processes from prior crashed/closed sessions.
  */
+
+export type DegradedSetupOperation =
+  | "orphan-reaping"
+  | "notify-watcher"
+  | "derived-watcher"
+  | "notification"
+  | "native-lifecycle-event";
+export type MandatorySetupOperation = "overlay" | "session-instructions" | "session-metrics";
+export type CompletionResult =
+  | { kind: "success"; establishmentCleanup?: EstablishmentCleanupEvidence }
+  | { kind: "degraded-success"; operations: readonly DegradedSetupOperation[]; establishmentCleanup?: EstablishmentCleanupEvidence }
+  | { kind: "failure"; operation: MandatorySetupOperation; error: unknown; establishmentCleanup?: EstablishmentCleanupEvidence };
+export interface PreLaunchResult {
+  readonly binding: LaunchSessionBinding;
+  readonly completion: CompletionResult;
+}
+
+interface EstablishedPreLaunchBinding {
+  readonly binding: LaunchSessionBinding;
+  readonly cleanup: EstablishmentCleanupEvidence;
+}
+
+async function establishPreLaunchBinding(cwd: string, sessionId: string): Promise<EstablishedPreLaunchBinding> {
+  const established = await establishLaunchSessionBinding(cwd, sessionId, await resolvePreLaunchSessionPointerOptions());
+  if (established.kind === "committed-released") return { binding: established.binding, cleanup: established.cleanup };
+  const error = established.kind === "precommit-aborted" ? established.abort : established.error;
+  Object.assign(error, { establishmentCleanup: established.cleanup });
+  throw error;
+}
+
+async function failPreLaunchSetup(binding: LaunchSessionBinding): Promise<void> {
+  const failures: unknown[] = [];
+  try {
+    await finalizeBoundOnce(binding, "setup-failure");
+  } catch (error) {
+    failures.push(error);
+  } finally {
+    try {
+      const close = await closeLaunchSessionBindingOnce(binding);
+      if (close.status === "failed") failures.push(close.error ?? new Error("bound session close failed"));
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  if (failures.length > 0) throw new AggregateError(failures, "preLaunch setup finalization failed");
+}
+
+async function completePreLaunchSetup(
+  cwd: string,
+  sessionId: string,
+  notifyTempContract: NotifyTempContract | undefined,
+  codexHomeOverride: string | undefined,
+  enableNotifyFallbackAuthority: boolean,
+  worktreeDirty: boolean,
+): Promise<CompletionResult> {
+  const degraded: DegradedSetupOperation[] = [];
+  try {
+    const cleanup = await cleanupLaunchOrphanedMcpProcesses();
+    if (cleanup.terminatedCount > 0) console.log(`[omx] Reaped ${cleanup.terminatedCount} orphaned OMX MCP process(es) before launch.`);
+    if (cleanup.failedPids.length > 0) console.warn(`[omx] Failed to reap ${cleanup.failedPids.length} orphaned OMX MCP process(es); continuing launch.`);
+  } catch (error) {
+    degraded.push("orphan-reaping");
+    logCliOperationFailure(error);
+  }
+
+  let instructions: string;
+  try {
+    const orchestrationMode = await resolveSessionOrchestrationMode(cwd, sessionId);
+    const overlay = await generateOverlay(cwd, sessionId, { orchestrationMode });
+    const launchAppendix = await readLaunchAppendInstructions();
+    const dirtyWorktreeGuidance = worktreeDirty
+      ? `\n\n## Session start: dirty worktree detected\n\nThis worktree has uncommitted changes that were present when the session launched.\nBefore executing the requested task, resolve the dirty state first:\n1. Review uncommitted changes with \`git status\` and \`git diff\`.\n2. Commit, stash, or discard changes as appropriate.\n3. Then proceed with the original task.`
+      : "";
+    instructions = launchAppendix.trim().length > 0 ? `${overlay}\n\n${launchAppendix}${dirtyWorktreeGuidance}` : `${overlay}${dirtyWorktreeGuidance}`;
+  } catch (error) {
+    return { kind: "failure", operation: "overlay", error };
+  }
+  try {
+    await writeSessionModelInstructionsFile(cwd, sessionId, instructions);
+  } catch (error) {
+    return { kind: "failure", operation: "session-instructions", error };
+  }
+  try {
+    await resetSessionMetrics(cwd, sessionId);
+    tagCurrentTmuxSessionWithInstance(sessionId);
+  } catch (error) {
+    return { kind: "failure", operation: "session-metrics", error };
+  }
+
+  try { await startNotifyFallbackWatcher(cwd, { codexHomeOverride, enableAuthority: enableNotifyFallbackAuthority, sessionId }); }
+  catch (error) { degraded.push("notify-watcher"); logCliOperationFailure(error); }
+  try { await startHookDerivedWatcher(cwd); }
+  catch (error) { degraded.push("derived-watcher"); logCliOperationFailure(error); }
+  try {
+    if (notifyTempContract?.active) {
+      process.env[OMX_NOTIFY_TEMP_CONTRACT_ENV] = serializeNotifyTempContract(notifyTempContract);
+      const { getNotificationConfig } = await import("../notifications/config.js");
+      const startup = buildNotifyTempStartupMessages(notifyTempContract, Boolean(getNotificationConfig()?.enabled));
+      for (const info of startup.infoLines) console.log(`[omx] ${info}`);
+      for (const warning of startup.warningLines) console.warn(`[omx] ${warning}`);
+    } else delete process.env[OMX_NOTIFY_TEMP_CONTRACT_ENV];
+    const { notifyLifecycle } = await import("../notifications/index.js");
+    await notifyLifecycle("session-start", { sessionId, projectPath: cwd, projectName: basename(cwd) });
+  } catch (error) { degraded.push("notification"); logCliOperationFailure(error); }
+  try {
+    await emitNativeHookEvent(cwd, "session-start", { session_id: sessionId, context: buildNativeHookBaseContext(cwd, sessionId, "started", { project_path: cwd, project_name: basename(cwd), status: "started" }) });
+  } catch (error) { degraded.push("native-lifecycle-event"); logCliOperationFailure(error); }
+  return degraded.length === 0 ? { kind: "success" } : { kind: "degraded-success", operations: degraded };
+}
+
 export async function preLaunch(
   cwd: string,
   sessionId: string,
@@ -5224,131 +5467,44 @@ export async function preLaunch(
   codexHomeOverride?: string,
   enableNotifyFallbackAuthority: boolean = false,
   worktreeDirty: boolean = false,
-): Promise<void> {
-  // 1. Best-effort launch-safe orphan cleanup
-  try {
-    const cleanup = await cleanupLaunchOrphanedMcpProcesses();
-    if (cleanup.terminatedCount > 0) {
-      console.log(
-        `[omx] Reaped ${cleanup.terminatedCount} orphaned OMX MCP process(es) before launch.`,
-      );
-    }
-    if (cleanup.failedPids.length > 0) {
-      console.warn(
-        `[omx] Failed to reap ${cleanup.failedPids.length} orphaned OMX MCP process(es); continuing launch.`,
-      );
-    }
-  } catch (err) {
-    logCliOperationFailure(err);
-    // Non-fatal
+): Promise<PreLaunchResult> {
+  const established = await establishPreLaunchBinding(cwd, sessionId);
+  const completion = {
+    ...await completePreLaunchSetup(cwd, sessionId, notifyTempContract, codexHomeOverride, enableNotifyFallbackAuthority, worktreeDirty),
+    establishmentCleanup: established.cleanup,
+  } satisfies CompletionResult;
+  if (completion.kind === "failure") {
+    try { await failPreLaunchSetup(established.binding); }
+    catch (cleanupError) { throw new AggregateError([completion.error, cleanupError], `preLaunch ${completion.operation} failed`); }
+    throw completion.error;
   }
-
-  // 2. Establish the canonical pointer before any session-scoped launch artifact.
-  await writeSessionStart(cwd, sessionId, await resolvePreLaunchSessionPointerOptions());
-
-  // 3. Generate runtime overlay + write session-scoped model instructions file
-  const orchestrationMode = await resolveSessionOrchestrationMode(
-    cwd,
-    sessionId,
-  );
-  const overlay = await generateOverlay(cwd, sessionId, { orchestrationMode });
-  const launchAppendix = await readLaunchAppendInstructions();
-  const dirtyWorktreeGuidance = worktreeDirty
-    ? `\n\n## Session start: dirty worktree detected\n\nThis worktree has uncommitted changes that were present when the session launched.\nBefore executing the requested task, resolve the dirty state first:\n1. Review uncommitted changes with \`git status\` and \`git diff\`.\n2. Commit, stash, or discard changes as appropriate.\n3. Then proceed with the original task.`
-    : "";
-  const sessionInstructions =
-    launchAppendix.trim().length > 0
-      ? `${overlay}
-
-${launchAppendix}${dirtyWorktreeGuidance}`
-      : `${overlay}${dirtyWorktreeGuidance}`;
-  await writeSessionModelInstructionsFile(cwd, sessionId, sessionInstructions);
-
-  // 4. Reset session metrics and tag the established session.
-  await resetSessionMetrics(cwd, sessionId);
-  tagCurrentTmuxSessionWithInstance(sessionId);
-
-  // 5. Start notify fallback watcher (best effort)
-  try {
-    await startNotifyFallbackWatcher(cwd, { codexHomeOverride, enableAuthority: enableNotifyFallbackAuthority, sessionId });
-  } catch (err) {
-    logCliOperationFailure(err);
-    // Non-fatal
-  }
-
-  // 6. Start derived watcher (best effort, opt-in)
-  try {
-    await startHookDerivedWatcher(cwd);
-  } catch (err) {
-    logCliOperationFailure(err);
-    // Non-fatal
-  }
-
-  // 7. Emit temp notification startup summary + warnings, then send session-start lifecycle notification (best effort)
-  try {
-    if (notifyTempContract?.active) {
-      process.env[OMX_NOTIFY_TEMP_CONTRACT_ENV] =
-        serializeNotifyTempContract(notifyTempContract);
-      const { getNotificationConfig } =
-        await import("../notifications/config.js");
-      const resolved = getNotificationConfig();
-      const startup = buildNotifyTempStartupMessages(
-        notifyTempContract,
-        Boolean(resolved?.enabled),
-      );
-      for (const info of startup.infoLines) {
-        console.log(`[omx] ${info}`);
-      }
-      for (const warning of startup.warningLines) {
-        console.warn(`[omx] ${warning}`);
-      }
-    } else {
-      delete process.env[OMX_NOTIFY_TEMP_CONTRACT_ENV];
-    }
-    const { notifyLifecycle } = await import("../notifications/index.js");
-    await notifyLifecycle("session-start", {
-      sessionId,
-      projectPath: cwd,
-      projectName: basename(cwd),
-    });
-  } catch (err) {
-    logCliOperationFailure(err);
-    // Non-fatal: notification failures must never block launch
-  }
-
-  // 8. Dispatch native hook event (best effort)
-  try {
-    await emitNativeHookEvent(cwd, "session-start", {
-      session_id: sessionId,
-      context: buildNativeHookBaseContext(cwd, sessionId, "started", {
-        project_path: cwd,
-        project_name: basename(cwd),
-        status: "started",
-      }),
-    });
-  } catch (err) {
-    logCliOperationFailure(err);
-    // Non-fatal
-  }
+  return { binding: established.binding, completion };
 }
 
 /**
  * runCodex: Launch Codex CLI (blocks until exit).
  * All 3 paths (new tmux, existing tmux, no tmux) block via execSync/execFileSync.
  */
-function runCodex(
+async function runCodex(
   cwd: string,
   args: string[],
   sessionId: string,
-  workerDefaultModel?: string,
-  codexHomeOverride?: string,
-  sqliteHomeOverride?: string,
-  notifyTempContractRaw?: string | null,
-  explicitLaunchPolicy?: CodexLaunchPolicy,
+  workerDefaultModel: string | undefined,
+  codexHomeOverride: string | undefined,
+  sqliteHomeOverride: string | undefined,
+  notifyTempContractRaw: string | null,
+  preLaunchOptions: {
+    notifyTempContract: NotifyTempContract;
+    enableNotifyFallbackAuthority: boolean;
+    worktreeDirty: boolean;
+  },
+  launchPolicy: CodexLaunchPolicy = "direct",
+  detachedPreflight?: DetachedPreflightAvailable,
   projectLocalCodexHomeForCleanup?: string,
   runtimeCodexHomeForCleanup?: string,
   runtimeContext?: MadmaxWorktreeRuntimeContext,
-): { postLaunchHandledExternally: boolean } {
+): Promise<{ postLaunchHandledExternally: boolean }> {
+  void preLaunchOptions;
   const launchArgs = injectModelInstructionsBypassArgs(
     cwd,
     args,
@@ -5417,10 +5573,6 @@ function runCodex(
     : codexEnv;
   const runtimeHookEnv = { ...process.env, ...runtimeEnvOverlay };
 
-  const { launchPolicy } = resolveTmuxAwareLaunchPolicy(
-    explicitLaunchPolicy,
-    nativeWindows,
-  );
 
   if (isCodexVersionRequest(launchArgs)) {
     runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
@@ -5549,285 +5701,71 @@ function runCodex(
     runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
     return { postLaunchHandledExternally: false };
   } else {
-    // Not in tmux: create a new tmux session with codex + HUD pane
+    if (!detachedPreflight) {
+      throw new DetachedLaunchSafetyError("establishment", new Error("detached launch requires a frozen available preflight"), { transitions: ["D0"], rollback: { attempted: [], failures: [] } });
+    }
     const codexCmd = buildTmuxPaneCommand("codex", launchArgs);
     const detachedWindowsCodexCmd = nativeWindows
-      ? buildWindowsPromptCommand("codex", launchArgs)
+      ? buildWindowsDetachedChildCommand("codex", launchArgs)
       : null;
     const sessionName = buildDetachedTmuxSessionName(cwd, sessionId);
-    const launchDetachedSession = (): { postLaunchHandledExternally: boolean } => {
-      const contextKey = runtimeContext?.madmaxDetachedContext ?? process.env[OMX_MADMAX_DETACHED_CONTEXT_ENV]?.trim();
-      const runsRoot = resolveMadmaxRunsRoot(process.env);
-      const activeRecordPath = contextKey
-        ? madmaxDetachedActiveRecordPath(runsRoot, contextKey)
-        : null;
-      const activeRecord = activeRecordPath
-        ? readMadmaxDetachedActiveRecord(activeRecordPath)
-        : null;
-      if (
-        activeRecord &&
-        activeRecord.context_key === contextKey &&
-        isReusableMadmaxDetachedActiveRecord(activeRecord)
-      ) {
-        cleanupCurrentMadmaxReuseRunRoot(process.env, runsRoot);
-        setDetachedTmuxSessionHistoryLimit(
-          activeRecord.tmux_session_name,
-          activeRecord.tmux_pane_id!,
-        );
-        if (!shouldAttachDetachedTmuxSession(process.env)) {
-          clearDetachedTmuxSessionHistoryIfUnattached(
-            activeRecord.tmux_session_name,
-            activeRecord.tmux_pane_id!,
-          );
-          process.stderr.write(
-            `[omx] madmax detached launch already active for this context; reusing ${activeRecord.tmux_session_name} without attaching because this launch is a Hermes MCP bridge.\n`,
-          );
-          return { postLaunchHandledExternally: true };
-        }
-        process.stderr.write(
-          `[omx] madmax detached launch already active for this context; attaching ${activeRecord.tmux_session_name} instead of starting a duplicate.\n`,
-        );
-        try {
-          execTmuxFileSync(["attach-session", "-t", activeRecord.tmux_session_name], {
-            stdio: "inherit",
-          });
-        } catch (err) {
-          logCliOperationFailure(err);
-          throw new MadmaxDetachedReuseError(
-            `refusing duplicate madmax detached launch: existing session ${activeRecord.tmux_session_name} is active but attach failed`,
-          );
-        }
-        return { postLaunchHandledExternally: true };
-      }
-      if (activeRecordPath && activeRecord) {
-        rmSync(activeRecordPath, { force: true });
-      }
+    const contextKey = runtimeContext?.madmaxDetachedContext ?? process.env[OMX_MADMAX_DETACHED_CONTEXT_ENV]?.trim();
+    const runsRoot = resolveMadmaxRunsRoot(process.env);
+    const detachedLaunchNonce = randomUUID();
+    const releaseMarkerPath = join(
+      omxRoot(cwd),
+      "runtime",
+      "detached-release",
+      `${sessionId}.${detachedLaunchNonce}.release`,
+    );
+    let detachedParentEnvFilePath: string | undefined;
+    let detachedLeaderPaneId: string | null = null;
+    let attachStep: DetachedSessionTmuxStep | null = null;
 
-      let detachedSessionBindingWrite: Promise<unknown> = Promise.resolve();
-      const writeDetachedSessionBinding = (tmuxPaneId?: string | null) => {
-        detachedSessionBindingWrite = detachedSessionBindingWrite
-          .catch((err) => {
-            logCliOperationFailure(err);
-          })
-          .then(() =>
-            writeSessionStart(cwd, sessionId, {
-              tmuxSessionName: sessionName,
-              ...(tmuxPaneId ? { tmuxPaneId } : {}),
-            }),
-          );
-        void detachedSessionBindingWrite.catch((err) => {
-          logCliOperationFailure(err);
-          // Non-fatal: managed tmux recovery can still use compatibility fallback.
-        });
-      };
-      writeDetachedSessionBinding();
-      let createdDetachedSession = false;
-      let registeredHookTarget: string | null = null;
-      let registeredHookName: string | null = null;
-      let registeredClientAttachedHookName: string | null = null;
-      let detachedParentEnvFilePath: string | undefined;
-      let detachedLeaderPaneId: string | null = null;
-      try {
-        // This path is the user-shell interactive launch: OMX creates a tmux
-        // session and immediately attaches the user's terminal to it. If a tmux
-        // server already exists, `new-session -e` only forwards explicit values,
-        // so provider-specific parent-shell keys would disappear. Source a
-        // private env file inside the leader shell instead of putting every
-        // parent env value on the tmux command line or in logs.
-        if (!nativeWindows) {
-          detachedParentEnvFilePath = writeDetachedSessionParentEnvFile(
-            cwd,
-            sessionId,
-            codexEnvWithNotify,
-          );
+    const launchDetachedSession = async (): Promise<{ postLaunchHandledExternally: boolean }> => {
+      if (!nativeWindows) detachedParentEnvFilePath = writeDetachedSessionParentEnvFile(cwd, sessionId, codexEnvWithNotify);
+      const bootstrapSteps = buildDetachedSessionBootstrapSteps(
+        sessionName, cwd, nativeWindows && detachedWindowsCodexCmd ? detachedWindowsCodexCmd : codexCmd,
+        hudCmd, workerLaunchArgs, codexHomeOverride, notifyTempContractRaw, nativeWindows, sessionId,
+        projectLocalCodexHomeForCleanup, runtimeCodexHomeForCleanup, omxRootOverride, runtimeHookEnv,
+        sqliteHomeOverride, detachedParentEnvFilePath, inheritedWorkerModel, releaseMarkerPath, omxBin,
+      );
+      for (const step of bootstrapSteps) {
+        let output: string;
+        try {
+          output = execTmuxFileSync(step.args, { stdio: "pipe", encoding: "utf-8" });
+        } catch (error) {
+          throw new DetachedLaunchSafetyError(step.name === "new-session" ? "inert-session" : "pane-id", error, detachedPreflight.report);
         }
-        const bootstrapSteps = buildDetachedSessionBootstrapSteps(
-          sessionName,
-          cwd,
-          codexCmd,
-          hudCmd,
-          workerLaunchArgs,
-          codexHomeOverride,
-          notifyTempContractRaw,
-          nativeWindows,
-          sessionId,
-          projectLocalCodexHomeForCleanup,
-          runtimeCodexHomeForCleanup,
-          omxRootOverride,
-          runtimeHookEnv,
-          sqliteHomeOverride,
-          detachedParentEnvFilePath,
-          inheritedWorkerModel,
-        );
-        for (const step of bootstrapSteps) {
-          const output = execTmuxFileSync(step.args, {
-            stdio: "pipe",
-            encoding: "utf-8",
-          });
-          if (step.name === "new-session") {
-            createdDetachedSession = true;
-            const leaderPaneId = parsePaneIdFromTmuxOutput(output || "");
-            if (leaderPaneId) {
-              detachedLeaderPaneId = leaderPaneId;
-              setDetachedTmuxSessionHistoryLimit(sessionName, leaderPaneId);
-              if (activeRecordPath && contextKey) {
-                writeMadmaxDetachedActiveRecord(activeRecordPath, {
-                  version: 1,
-                  context_key: contextKey,
-                  created_at: new Date().toISOString(),
-                  source_cwd: runtimeContext?.sourceCwd ?? process.env.OMX_SOURCE_CWD ?? cwd,
-                  ...(runtimeContext?.worktreeCwd ? { worktree_cwd: runtimeContext.worktreeCwd } : {}),
-                  argv: args,
-                  run_dir: runtimeContext?.omxRoot ?? process.env.OMX_ROOT ?? cwd,
-                  tmux_session_name: sessionName,
-                  session_id: sessionId,
-                  tmux_pane_id: leaderPaneId,
-                });
-              }
-              writeDetachedSessionBinding(leaderPaneId);
-            }
-          }
-          if (step.name === "split-and-capture-hud-pane") {
-            const hudPaneId = parsePaneIdFromTmuxOutput(output || "");
-            const hookWindowIndex = hudPaneId
-              ? detectDetachedSessionWindowIndex(sessionName)
-              : null;
-            const hookTarget =
-              hudPaneId && hookWindowIndex
-                ? buildResizeHookTarget(sessionName, hookWindowIndex)
-                : null;
-            const hookName =
-              hudPaneId && hookWindowIndex
-                ? buildResizeHookName(
-                    "launch",
-                    sessionName,
-                    hookWindowIndex,
-                    hudPaneId,
-                  )
-                : null;
-            const clientAttachedHookName =
-              hudPaneId && hookWindowIndex
-                ? buildClientAttachedReconcileHookName(
-                    "launch",
-                    sessionName,
-                    hookWindowIndex,
-                    hudPaneId,
-                  )
-                : null;
-            const finalizeSteps = buildDetachedSessionFinalizeSteps(
-              sessionName,
-              hudPaneId,
-              hookWindowIndex,
-              process.env.OMX_MOUSE !== "0",
-              nativeWindows,
-              shouldAttachDetachedTmuxSession(process.env),
-              detachedLeaderPaneId,
-            );
-            if (nativeWindows && detachedWindowsCodexCmd) {
-              scheduleDetachedWindowsCodexLaunch(
-                sessionName,
-                detachedWindowsCodexCmd,
-              );
-            }
-            for (const finalizeStep of finalizeSteps) {
-              if (finalizeStep.name === "sanitize-copy-mode-style") {
-                try {
-                  mitigateCopyModeUnderlineArtifacts(sessionName);
-                } catch (err) {
-                  logCliOperationFailure(err);
-                }
-                continue;
-              }
-              const stdio =
-                finalizeStep.name === "attach-session" ? "inherit" : "ignore";
-              try {
-                const startedAtMs = Date.now();
-                execTmuxFileSync(finalizeStep.args, { stdio });
-                if (finalizeStep.name === "attach-session") {
-                  assertDetachedAttachDidNotNoop(
-                    sessionName,
-                    Date.now() - startedAtMs,
-                    process.env,
-                  );
-                }
-              } catch (err) {
-                logCliOperationFailure(err);
-                if (finalizeStep.name === "attach-session")
-                  throw new Error("failed to attach detached tmux session");
-                continue;
-              }
-              if (
-                finalizeStep.name === "register-resize-hook" &&
-                hookTarget &&
-                hookName
-              ) {
-                registeredHookTarget = hookTarget;
-                registeredHookName = hookName;
-              }
-              if (
-                finalizeStep.name === "register-client-attached-reconcile" &&
-                clientAttachedHookName
-              ) {
-                registeredClientAttachedHookName = clientAttachedHookName;
-              }
-              if (finalizeStep.name === "reconcile-hud-resize") {
-                registerDetachedHudLayoutReconcileHook({
-                  hudPaneId,
-                  detachedLeaderPaneId,
-                  cwd,
-                  sessionId,
-                  omxBin,
-                  omxRootOverride,
-                  baseEnv: runtimeHookEnv,
-                });
-              }
-            }
+        if (step.name === "new-session") {
+          detachedLeaderPaneId = parsePaneIdFromTmuxOutput(output || "");
+          if (!detachedLeaderPaneId) throw new DetachedLaunchSafetyError("pane-id", new Error("detached session did not report a leader pane id"), detachedPreflight.report);
+          setDetachedTmuxSessionHistoryLimit(sessionName, detachedLeaderPaneId);
+        }
+        if (step.name === "split-and-capture-hud-pane") {
+          const hudPaneId = parsePaneIdFromTmuxOutput(output || "");
+          const hookWindowIndex = hudPaneId ? detectDetachedSessionWindowIndex(sessionName) : null;
+          for (const finalizeStep of buildDetachedSessionFinalizeSteps(sessionName, hudPaneId, hookWindowIndex, process.env.OMX_MOUSE !== "0", nativeWindows, detachedPreflight.shouldAttach, detachedLeaderPaneId)) {
+            if (finalizeStep.name === "attach-session") { attachStep = finalizeStep; continue; }
+            if (finalizeStep.name === "sanitize-copy-mode-style") { try { mitigateCopyModeUnderlineArtifacts(sessionName); } catch (error) { logCliOperationFailure(error); } continue; }
+            try { execTmuxFileSync(finalizeStep.args, { stdio: "ignore" }); } catch (error) { logCliOperationFailure(error); continue; }
+            if (finalizeStep.name === "reconcile-hud-resize") registerDetachedHudLayoutReconcileHook({ hudPaneId, detachedLeaderPaneId, cwd, sessionId, omxBin, omxRootOverride, baseEnv: runtimeHookEnv });
           }
         }
-        return { postLaunchHandledExternally: !nativeWindows };
-      } catch (err) {
-        if (detachedParentEnvFilePath) {
-          rmSync(detachedParentEnvFilePath, { force: true });
-        }
-        if (activeRecordPath) {
-          rmSync(activeRecordPath, { force: true });
-        }
-        if (createdDetachedSession) {
-          const rollbackSteps = buildDetachedSessionRollbackSteps(
-            sessionName,
-            registeredHookTarget,
-            registeredHookName,
-            registeredClientAttachedHookName,
-          );
-          for (const rollbackStep of rollbackSteps) {
-            try {
-              execTmuxFileSync(rollbackStep.args, { stdio: "ignore" });
-            } catch (rollbackErr) {
-              logCliOperationFailure(rollbackErr);
-              // best-effort rollback only
-            }
-          }
-        }
-        throw err;
       }
+      const readyDeadline = Date.now() + 30_000;
+      while (!existsSync(releaseMarkerPath) && process.env.OMX_TEST_DETACHED_READY_BYPASS !== "1") {
+        if (Date.now() >= readyDeadline) throw new DetachedLaunchSafetyError("barrier-release", new Error("detached leader readiness timed out"), detachedPreflight.report);
+        blockMs(20);
+      }
+      if (attachStep) execTmuxFileSync(attachStep.args, { stdio: "inherit" });
+      return { postLaunchHandledExternally: true };
     };
 
-    const contextKey = process.env[OMX_MADMAX_DETACHED_CONTEXT_ENV]?.trim();
-    const runsRoot = resolveMadmaxRunsRoot(process.env);
-    try {
-      if (isMadmaxDetachedGuardEnabled(process.env) && contextKey) {
-        return withMadmaxDetachedContextLock(runsRoot, contextKey, launchDetachedSession);
-      }
-      return launchDetachedSession();
-    } catch (err) {
-      if (err instanceof MadmaxDetachedReuseError || err instanceof MadmaxDetachedGuardError) {
-        throw err;
-      }
-      logCliOperationFailure(err);
-      // tmux not available or failed, just run codex directly
-      runCodexBlocking(cwd, launchArgs, codexEnvWithNotify);
-      return { postLaunchHandledExternally: false };
+    if (isMadmaxDetachedGuardEnabled(process.env) && contextKey) {
+      return await withMadmaxDetachedContextLock(runsRoot, contextKey, launchDetachedSession);
     }
+    return await launchDetachedSession();
   }
 }
 
@@ -5906,6 +5844,28 @@ export function buildWindowsPromptCommand(
 }
 
 /**
+ * Build a Windows child command for detached ownership. Unlike the interactive
+ * prompt wrapper, this process exits as soon as Codex does so the outer barrier
+ * can run its post-launch cleanup.
+ */
+export function buildWindowsDetachedChildCommand(
+  command: string,
+  args: string[],
+): string {
+  const invocation = [
+    "&",
+    quotePowerShellArg(command),
+    ...args.map(quotePowerShellArg),
+  ].join(" ");
+  const wrappedCommand = [
+    "$ErrorActionPreference = 'Stop'",
+    invocation,
+    "exit $LASTEXITCODE",
+  ].join("; ");
+  return `powershell.exe -NoLogo -NoProfile -NonInteractive -EncodedCommand ${encodePowerShellCommand(wrappedCommand)}`;
+}
+
+/**
  * Wrap a command for tmux pane execution while preserving the tmux pane cwd.
  * tmux already starts the pane at `-c <cwd>`; using a login shell here can
  * reset that cwd back to the shell's startup directory on some setups.
@@ -5952,44 +5912,84 @@ function quotePowerShellArg(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
 }
 
-export function buildDetachedWindowsBootstrapScript(
-  sessionName: string,
-  commandText: string,
-  delayMs: number = WINDOWS_DETACHED_BOOTSTRAP_DELAY_MS,
-  tmuxCommand: string = resolveTmuxExecutableForLaunch(),
-): string {
-  const delay =
-    Number.isFinite(delayMs) && delayMs > 0
-      ? Math.floor(delayMs)
-      : WINDOWS_DETACHED_BOOTSTRAP_DELAY_MS;
-  const targetLiteral = JSON.stringify(`${sessionName}:0.0`);
-  const commandLiteral = JSON.stringify(commandText);
-  const tmuxCommandLiteral = JSON.stringify(tmuxCommand);
 
-  return [
-    "const { execFileSync } = require('child_process');",
-    `const tmuxCommand = ${tmuxCommandLiteral};`,
-    `setTimeout(() => {`,
-    `try { execFileSync(tmuxCommand, ['send-keys', '-t', ${targetLiteral}, '-l', '--', ${commandLiteral}], { stdio: 'ignore' }); } catch {}`,
-    `try { execFileSync(tmuxCommand, ['send-keys', '-t', ${targetLiteral}, 'C-m'], { stdio: 'ignore' }); } catch {}`,
-    `}, ${delay});`,
-  ].join("");
+
+interface DetachedLeaderPayload {
+  cwd: string;
+  sessionName: string;
+  sessionId?: string;
+  codexCmd: string;
+  projectLocalCodexHomeForCleanup?: string;
+  runtimeCodexHomeForCleanup?: string;
+  readyPath?: string;
 }
 
-function scheduleDetachedWindowsCodexLaunch(
-  sessionName: string,
-  commandText: string,
-): void {
-  const child = spawn(
-    process.execPath,
-    ["-e", buildDetachedWindowsBootstrapScript(sessionName, commandText)],
-    {
-      detached: true,
-      stdio: "ignore",
-      windowsHide: true,
-    },
-  );
-  child.unref();
+function decodeDetachedLeaderPayload(encoded: string | undefined): DetachedLeaderPayload {
+  if (!encoded || !/^[A-Za-z0-9_-]+$/.test(encoded)) throw new Error("invalid detached leader payload");
+  let value: unknown;
+  try { value = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")); } catch { throw new Error("invalid detached leader payload"); }
+  if (!value || typeof value !== "object") throw new Error("invalid detached leader payload");
+  const payload = value as Record<string, unknown>;
+  if (typeof payload.cwd !== "string" || typeof payload.sessionName !== "string" || typeof payload.sessionId !== "string" || typeof payload.codexCmd !== "string") throw new Error("invalid detached leader payload");
+  return { cwd: payload.cwd, sessionName: payload.sessionName, sessionId: payload.sessionId, codexCmd: payload.codexCmd,
+    ...(typeof payload.projectLocalCodexHomeForCleanup === "string" ? { projectLocalCodexHomeForCleanup: payload.projectLocalCodexHomeForCleanup } : {}),
+    ...(typeof payload.runtimeCodexHomeForCleanup === "string" ? { runtimeCodexHomeForCleanup: payload.runtimeCodexHomeForCleanup } : {}),
+    ...(typeof payload.readyPath === "string" ? { readyPath: payload.readyPath } : {}),
+  };
+}
+
+async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise<void> {
+  const established = await establishPreLaunchBinding(payload.cwd, payload.sessionId!);
+  const binding = established.binding;
+  let ownedRecord: DetachedActiveRecordOwnership | undefined;
+  const contextKey = process.env[OMX_MADMAX_DETACHED_CONTEXT_ENV]?.trim();
+  const activeRecordPath = contextKey
+    ? madmaxDetachedActiveRecordPath(resolveMadmaxRunsRoot(process.env), contextKey)
+    : join(omxRoot(payload.cwd), "state", "detached-active-record.json");
+  try {
+    const completion = await completePreLaunchSetup(payload.cwd, payload.sessionId!, undefined, undefined, false, false);
+    if (completion.kind === "failure") {
+      const finalization = await finalizeBoundOnce(binding, "setup-failure", payload.cwd);
+      if (!finalization.finalized) throw new Error(`bound setup finalization denied: ${finalization.cleanup.comparison?.reason ?? "unknown reason"}`);
+      throw completion.error;
+    }
+    const pane = process.env.TMUX_PANE;
+    if (!pane) throw new Error("detached leader has no tmux pane identity");
+    const name = await updateDetachedSessionMetadata(binding, { tmuxSessionName: payload.sessionName });
+    const paneUpdate = await updateDetachedSessionMetadata(binding, { tmuxPaneId: pane });
+    if (name.kind !== "committed-released" || paneUpdate.kind !== "committed-released") throw new Error("detached leader metadata update denied");
+    ownedRecord = writeMadmaxDetachedActiveRecord(activeRecordPath, {
+      version: 1, context_key: contextKey ?? payload.sessionId!, created_at: new Date().toISOString(),
+      source_cwd: payload.cwd, argv: [payload.codexCmd], run_dir: process.env.OMX_ROOT ?? payload.cwd,
+      tmux_session_name: payload.sessionName, session_id: payload.sessionId, tmux_pane_id: pane,
+      launch_nonce: payload.sessionId, leader_pid: process.pid, base_state_root: binding.context.baseStateDir,
+      lifecycle_phase: "ready",
+    });
+    if (payload.readyPath) publishDetachedReleaseMarker(payload.readyPath, payload.sessionId!);
+    const child = spawn(process.platform === "win32" ? "powershell.exe" : "/bin/sh", process.platform === "win32" ? ["-NoProfile", "-Command", payload.codexCmd] : ["-c", payload.codexCmd], { cwd: payload.cwd, stdio: "inherit" });
+    let forwarded = false;
+    const forward = (signal: NodeJS.Signals): void => { if (forwarded || !child.pid) return; forwarded = true; try { child.kill(signal); } catch {} };
+    if (process.platform !== "win32") {
+      process.once("SIGINT", () => forward("SIGINT"));
+      process.once("SIGTERM", () => forward("SIGTERM"));
+      process.once("SIGHUP", () => forward("SIGHUP"));
+    }
+    const code = await new Promise<number | null>((resolveChild, rejectChild) => { child.once("error", rejectChild); child.once("exit", resolveChild); });
+    process.exitCode = code ?? 1;
+    await postLaunch(payload.cwd, payload.sessionId!, binding, undefined, false, payload.projectLocalCodexHomeForCleanup);
+    await cleanupRuntimeCodexHome(payload.runtimeCodexHomeForCleanup, payload.projectLocalCodexHomeForCleanup);
+    if (ownedRecord) {
+      const bytes = readFileSync(activeRecordPath, "utf-8");
+      const digest = createHash("sha256").update(bytes).digest("hex");
+      if (bytes === ownedRecord.bytes && digest === ownedRecord.digest) rmSync(activeRecordPath, { force: true });
+    }
+    if (payload.readyPath) rmSync(payload.readyPath, { force: true });
+  } catch (error) {
+    if (!ownedRecord && payload.readyPath) rmSync(payload.readyPath, { force: true });
+    throw error;
+  } finally {
+    await closeLaunchSessionBindingOnce(binding);
+  }
 }
 
 /**
@@ -5999,19 +5999,28 @@ function scheduleDetachedWindowsCodexLaunch(
 export async function postLaunch(
   cwd: string,
   sessionId: string,
+  binding: LaunchSessionBinding,
   codexHomeOverride?: string,
   enableNotifyFallbackAuthority: boolean = false,
   projectLocalCodexHomeForCleanup?: string,
 ): Promise<void> {
-  // Capture session start time before cleanup (writeSessionEnd deletes session.json)
-  let sessionStartedAt: string | undefined;
+  const sessionStartedAt: string | undefined = binding.startedAt;
+  // Pointer authority is consumed before any terminal cleanup. A denied or
+  // unproven binding must leave every cleanup target untouched.
+  let terminalError: unknown;
   try {
-    const sessionState = await readSessionState(cwd);
-    sessionStartedAt = sessionState?.started_at;
-  } catch (err) {
-    logCliOperationFailure(err);
-    // Non-fatal
+    const finalization = await finalizeBoundOnce(binding, "post-launch", cwd);
+    if (!finalization.finalized) terminalError = new Error(`bound session finalization denied: ${finalization.cleanup.comparison?.reason ?? "unknown reason"}`);
+    const closeFailure = finalization.cleanup.capability.find((evidence) => evidence.status === "failed");
+    if (closeFailure) terminalError = new Error(`bound session retained close failed: ${closeFailure.error?.message ?? "unknown error"}`);
+  } catch (error) {
+    terminalError = error;
+  } finally {
+    const closeEvidence = await closeLaunchSessionBindingOnce(binding);
+    if (closeEvidence.status === "failed" && !terminalError) terminalError = new Error(`bound session retained close failed: ${closeEvidence.error?.message ?? "unknown error"}`);
   }
+  if (terminalError) throw terminalError;
+
 
   // 0. Reap MCP orphans left behind by the session that just exited.
   await reapPostLaunchOrphanedMcpProcesses();
@@ -6070,14 +6079,6 @@ export async function postLaunch(
     );
   }
 
-  // 2. Archive session (write history, delete session.json)
-  try {
-    await writeSessionEnd(cwd, sessionId);
-  } catch (err) {
-    console.error(
-      `[omx] postLaunch: session archive failed: ${err instanceof Error ? err.message : err}`,
-    );
-  }
 
   // 2.5. Best-effort wiki session capture
   try {
@@ -6158,18 +6159,51 @@ export async function postLaunch(
 export async function runDetachedSessionPostLaunch(
   cwd: string,
   sessionId: string,
-  codexHomeOverride?: string,
   projectLocalCodexHomeForCleanup?: string,
   runtimeCodexHomeForCleanup?: string,
+  releaseMarkerPath?: string,
 ): Promise<void> {
-  await postLaunch(
-    cwd,
-    sessionId,
-    codexHomeOverride,
-    false,
-    projectLocalCodexHomeForCleanup,
-  );
-  await cleanupRuntimeCodexHome(runtimeCodexHomeForCleanup, projectLocalCodexHomeForCleanup).catch(logCliOperationFailure);
+  // The detached child is intentionally unbound: it must never perform parent
+  // pointer finalization or cleanup after the release barrier. It still owns
+  // every non-pointer terminal lifecycle responsibility.
+  const failures: unknown[] = [];
+  const strict = async (operation: () => Promise<unknown>): Promise<void> => {
+    try { await operation(); } catch (error) { failures.push(error); }
+  };
+
+  await strict(() => reapPostLaunchOrphanedMcpProcesses());
+  await strict(() => flushNotifyFallbackOnce(cwd, { sessionId }));
+  await strict(() => stopNotifyFallbackWatcher(cwd));
+  await strict(() => flushHookDerivedWatcherOnce(cwd));
+  await strict(() => stopHookDerivedWatcher(cwd));
+  if (projectLocalCodexHomeForCleanup) {
+    await strict(() => cleanCodexModelAvailabilityNuxIfNeeded(join(projectLocalCodexHomeForCleanup, "config.toml")));
+  }
+  await strict(() => removeSessionModelInstructionsFile(cwd, sessionId));
+  await strict(async () => {
+    const { onSessionEnd } = await import("../wiki/lifecycle.js");
+    onSessionEnd({ cwd, session_id: sessionId });
+  });
+  await strict(() => cleanupPostLaunchModeStateFiles(cwd, sessionId));
+  await strict(async () => {
+    const { notifyLifecycle } = await import("../notifications/index.js");
+    await notifyLifecycle("session-end", {
+      sessionId, projectPath: cwd, projectName: basename(cwd), reason: "session_exit",
+    });
+  });
+  await strict(async () => {
+    const { markOwnedTeamsLeaderSessionStopped } = await import("../team/state.js");
+    await markOwnedTeamsLeaderSessionStopped(cwd, sessionId);
+  });
+  await strict(() => emitNativeHookEvent(cwd, "session-end", {
+    session_id: sessionId,
+    context: buildNativeHookBaseContext(cwd, sessionId, "finished", {
+      project_path: cwd, project_name: basename(cwd), reason: "session_exit", status: "finished",
+    }),
+  }));
+  await strict(() => cleanupRuntimeCodexHome(runtimeCodexHomeForCleanup, projectLocalCodexHomeForCleanup));
+  if (releaseMarkerPath) await strict(() => rm(releaseMarkerPath, { force: true }));
+  if (failures.length > 0) throw new AggregateError(failures, "detached post-launch lifecycle cleanup failed");
 }
 
 async function emitNativeHookEvent(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2854,7 +2854,13 @@ export async function executeDetachedLaunchStateMachine<Binding, InertSession, P
       // A failed publication must not let the outer launcher destroy the
       // leader's finalization capability. Request a nonce-bound abort and
       // preserve all artifacts on timeout, malformed, or foreign reports.
-      const resolution = await deps.abortAndAwaitFinalization?.(releaseError);
+      let resolution: { acknowledged: boolean } | undefined;
+      try {
+        resolution = await deps.abortAndAwaitFinalization?.(releaseError);
+      } catch (abortError) {
+        released = true;
+        throw new AggregateError([releaseError, abortError], "detached release and abort publication both failed");
+      }
       if (!resolution?.acknowledged) released = true;
       throw releaseError;
     }
@@ -4479,6 +4485,7 @@ interface DetachedLeaderReport {
   paneId?: string;
   leaderPid?: number;
   error?: string;
+  finalized?: boolean;
 }
 
 function writeDetachedLeaderReport(path: string, report: DetachedLeaderReport): void {
@@ -5887,7 +5894,7 @@ async function runCodex(
               const report = readDetachedLeaderReport(releaseMarkerPath);
               if (report?.nonce === detachedLaunchNonce && report.sessionId === sessionId &&
                 report.sessionName === sessionName && report.leaderPid === detachedLeaderPid &&
-                (report.kind === "failed" || report.kind === "terminal")) return { acknowledged: true };
+                report.finalized === true && (report.kind === "failed" || report.kind === "terminal")) return { acknowledged: true };
               blockMs(20);
             }
             return { acknowledged: false };
@@ -5900,7 +5907,7 @@ async function runCodex(
             };
             await attempt("parent-env", async () => { if (detachedParentEnvFilePath) await rm(detachedParentEnvFilePath, { force: true }); });
             await attempt("runtime-codex-home", () => cleanupRuntimeCodexHome(runtimeCodexHomeForCleanup, projectLocalCodexHomeForCleanup));
-            await attempt("rollback", () => { rmSync(releaseMarkerPath, { force: true }); rmSync(`${releaseMarkerPath}.release`, { force: true }); });
+            await attempt("rollback", () => { rmSync(releaseMarkerPath, { force: true }); rmSync(`${releaseMarkerPath}.release`, { force: true }); rmSync(`${releaseMarkerPath}.abort`, { force: true }); });
             if (createdSession) {
               for (const step of buildDetachedSessionRollbackSteps(sessionName, null, null, null)) {
                 await attempt(`session:${step.name}`, () => { execTmuxFileSync(step.args, { stdio: "ignore" }); });
@@ -6217,7 +6224,7 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
     await postLaunch(payload.cwd, payload.sessionId, binding, payload.codexHomeOverride, payload.preLaunchOptions.enableNotifyFallbackAuthority, payload.projectLocalCodexHomeForCleanup);
     if (payload.readyPath) writeDetachedLeaderReport(payload.readyPath, {
       version: 1, kind: "terminal", nonce, sessionId: payload.sessionId, sessionName: payload.sessionName,
-      paneId: pane, leaderPid: process.pid,
+      paneId: pane, leaderPid: process.pid, finalized: true,
     });
     await cleanupRuntimeCodexHome(payload.runtimeCodexHomeForCleanup, payload.projectLocalCodexHomeForCleanup);
     if (ownedRecord) {
@@ -6244,7 +6251,7 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
     }
     if (payload.readyPath) writeDetachedLeaderReport(payload.readyPath, {
       version: 1, kind: "failed", nonce, sessionId: payload.sessionId, sessionName: payload.sessionName,
-      leaderPid: process.pid, error: failure instanceof Error ? failure.message : String(failure),
+      leaderPid: process.pid, finalized, error: failure instanceof Error ? failure.message : String(failure),
     });
     throw failure;
   } finally {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2834,7 +2834,6 @@ export async function executeDetachedLaunchStateMachine<Binding, InertSession, P
     transition("D7");
     ownedRecord = await deps.publishActiveRecord(inertSession, pane);
     transition("D9");
-    transition("D9");
     await deps.releaseBarrier();
     released = true;
     transition("D10");
@@ -6113,23 +6112,37 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
       ...(process.platform === "win32" ? {} : { detached: true }),
     });
     let escalation: NodeJS.Timeout | undefined;
-    const signalChildTree = (signal: NodeJS.Signals): void => {
+    const signalChildTree = (signal: NodeJS.Signals, force = false): void => {
       if (!child.pid) return;
       try {
-        if (process.platform === "win32") execFileSync("taskkill", ["/PID", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+        if (process.platform === "win32") execFileSync("taskkill", ["/PID", String(child.pid), "/T", ...(force ? ["/F"] : [])], { stdio: "ignore" });
         else process.kill(-child.pid, signal);
       } catch {}
     };
     const forward = (signal: NodeJS.Signals): void => {
       signalChildTree(signal);
-      if (!escalation) { escalation = setTimeout(() => signalChildTree("SIGKILL"), 5_000); escalation.unref(); }
+      if (!escalation) { escalation = setTimeout(() => signalChildTree("SIGKILL", true), 5_000); escalation.unref(); }
     };
     process.once("SIGINT", () => forward("SIGINT"));
     process.once("SIGTERM", () => forward("SIGTERM"));
     process.once("SIGHUP", () => forward("SIGHUP"));
-    const code = await new Promise<number | null>((resolveChild, rejectChild) => { child.once("error", rejectChild); child.once("exit", resolveChild); });
+    const outcome = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolveChild, rejectChild) => {
+      child.once("error", rejectChild);
+      child.once("exit", (code, signal) => resolveChild({ code, signal }));
+    });
     if (escalation) clearTimeout(escalation);
-    process.exitCode = code ?? 1;
+    if (process.platform !== "win32" && child.pid) {
+      const treeDeadline = Date.now() + 5_000;
+      while (true) {
+        try {
+          process.kill(-child.pid, 0);
+          if (Date.now() >= treeDeadline) { signalChildTree("SIGKILL", true); break; }
+          await new Promise((resolveWait) => setTimeout(resolveWait, 20));
+        } catch { break; }
+      }
+    }
+    const signalExitCodes: Partial<Record<NodeJS.Signals, number>> = { SIGHUP: 129, SIGINT: 130, SIGTERM: 143, SIGKILL: 137 };
+    process.exitCode = outcome.code ?? (outcome.signal ? signalExitCodes[outcome.signal] ?? 1 : 1);
     await postLaunch(payload.cwd, payload.sessionId, binding, payload.codexHomeOverride, payload.preLaunchOptions.enableNotifyFallbackAuthority, payload.projectLocalCodexHomeForCleanup);
     if (payload.readyPath) writeDetachedLeaderReport(payload.readyPath, {
       version: 1, kind: "terminal", nonce, sessionId: payload.sessionId, sessionName: payload.sessionName,
@@ -6142,19 +6155,27 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
       if (bytes === ownedRecord.bytes && digest === ownedRecord.digest) rmSync(activeRecordPath, { force: true });
     }
   } catch (error) {
-    if (payload.readyPath) writeDetachedLeaderReport(payload.readyPath, {
-      version: 1, kind: "failed", nonce, sessionId: payload.sessionId, sessionName: payload.sessionName,
-      leaderPid: process.pid, error: error instanceof Error ? error.message : String(error),
-    });
-    const finalization = await finalizeBoundOnce(binding, "detached-pre-release-failure", payload.cwd).catch(() => undefined);
-    if (finalization?.finalized && ownedRecord) {
+    let failure: unknown = error;
+    let finalized = false;
+    try {
+      await postLaunch(payload.cwd, payload.sessionId, binding, payload.codexHomeOverride, payload.preLaunchOptions.enableNotifyFallbackAuthority, payload.projectLocalCodexHomeForCleanup);
+      finalized = true;
+      await cleanupRuntimeCodexHome(payload.runtimeCodexHomeForCleanup, payload.projectLocalCodexHomeForCleanup);
+    } catch (lifecycleError) {
+      failure = new AggregateError([error, lifecycleError], "detached leader failure finalization did not complete");
+    }
+    if (finalized && ownedRecord) {
       try {
         const bytes = readFileSync(activeRecordPath, "utf-8");
         const digest = createHash("sha256").update(bytes).digest("hex");
         if (bytes === ownedRecord.bytes && digest === ownedRecord.digest) rmSync(activeRecordPath, { force: true });
       } catch {}
     }
-    throw error;
+    if (payload.readyPath) writeDetachedLeaderReport(payload.readyPath, {
+      version: 1, kind: "failed", nonce, sessionId: payload.sessionId, sessionName: payload.sessionName,
+      leaderPid: process.pid, error: failure instanceof Error ? failure.message : String(failure),
+    });
+    throw failure;
   } finally {
     await closeLaunchSessionBindingOnce(binding);
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -764,6 +764,9 @@ export function resolveCliInvocation(args: string[]): ResolvedCliInvocation {
   if (firstArg === "resume") {
     return { command: "resume", launchArgs: args.slice(1) };
   }
+  if (firstArg === "__detached-session-leader") {
+    return { command: firstArg, launchArgs: args.slice(1) };
+  }
   return { command: firstArg, launchArgs: [] };
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5875,7 +5875,7 @@ async function runCodex(
         const bootstrapSteps = buildDetachedSessionBootstrapSteps(
           sessionName, cwd, nativeWindows && detachedWindowsCodexCmd ? detachedWindowsCodexCmd : codexCmd,
           hudCmd, workerLaunchArgs, codexHomeOverride, notifyTempContractRaw, nativeWindows, sessionId,
-          projectLocalCodexHomeForCleanup, runtimeCodexHomeForCleanup, omxRootOverride, runtimeHookEnv,
+          projectLocalCodexHomeForCleanup, runtimeCodexHomeForCleanup, omxRootOverride, codexEnvWithNotify,
           sqliteHomeOverride, detachedParentEnvFilePath, inheritedWorkerModel, releaseMarkerPath,
           omxBin,
           {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2414,12 +2414,6 @@ function readMadmaxDetachedActiveRecord(
       typeof parsed.tmux_session_name !== "string" ||
       !Array.isArray(parsed.argv) ||
       !parsed.argv.every((arg) => typeof arg === "string")
-      || typeof parsed.launch_nonce !== "string"
-      || typeof parsed.leader_pid !== "number"
-      || !Number.isSafeInteger(parsed.leader_pid)
-      || parsed.leader_pid <= 0
-      || typeof parsed.base_state_root !== "string"
-      || parsed.lifecycle_phase !== "ready"
     ) {
       return null;
     }
@@ -2438,10 +2432,10 @@ function readMadmaxDetachedActiveRecord(
       ...(typeof parsed.tmux_pane_pid === "number" ? { tmux_pane_pid: parsed.tmux_pane_pid } : {}),
 
       ...(typeof parsed.worktree_cwd === "string" ? { worktree_cwd: parsed.worktree_cwd } : {}),
-      launch_nonce: parsed.launch_nonce,
-      leader_pid: parsed.leader_pid,
-      base_state_root: parsed.base_state_root,
-      lifecycle_phase: parsed.lifecycle_phase,
+      ...(typeof parsed.launch_nonce === "string" ? { launch_nonce: parsed.launch_nonce } : {}),
+      ...(typeof parsed.leader_pid === "number" && Number.isSafeInteger(parsed.leader_pid) && parsed.leader_pid > 0 ? { leader_pid: parsed.leader_pid } : {}),
+      ...(typeof parsed.base_state_root === "string" ? { base_state_root: parsed.base_state_root } : {}),
+      ...(parsed.lifecycle_phase === "ready" || parsed.lifecycle_phase === "terminal" ? { lifecycle_phase: parsed.lifecycle_phase } : {}),
     };
   } catch {
     return null;
@@ -2486,16 +2480,19 @@ function queryMadmaxDetachedRuntimeBinding(record: MadmaxDetachedActiveRecord): 
   }
 }
 
+function hasMatchingMadmaxDetachedRuntimeBinding(record: MadmaxDetachedActiveRecord): boolean {
+  const binding = queryMadmaxDetachedRuntimeBinding(record);
+  return Boolean(binding
+    && binding.panePid === record.tmux_pane_pid
+    && binding.internalSessionId === record.tmux_internal_session_id
+    && binding.sessionCreated === record.tmux_session_created);
+}
+
 function isReusableMadmaxDetachedActiveRecord(record: MadmaxDetachedActiveRecord): boolean {
   if (record.lifecycle_phase !== "ready" || !record.leader_pid || !record.base_state_root || !record.launch_nonce) return false;
   try { process.kill(record.leader_pid, 0); } catch { return false; }
   try { if (realpathSync(record.base_state_root) !== record.base_state_root) return false; } catch { return false; }
-  const binding = queryMadmaxDetachedRuntimeBinding(record);
-  if (!binding) return false;
-  if (record.tmux_pane_pid !== undefined && binding.panePid !== record.tmux_pane_pid) return false;
-  if (record.tmux_internal_session_id !== undefined && binding.internalSessionId !== record.tmux_internal_session_id) return false;
-  if (record.tmux_session_created !== undefined && binding.sessionCreated !== record.tmux_session_created) return false;
-  return true;
+  return hasMatchingMadmaxDetachedRuntimeBinding(record);
 }
 
 
@@ -7295,7 +7292,7 @@ async function selectAuthorizedHookVisibleRunDirState(cwd: string): Promise<Auth
     const record = readMadmaxDetachedActiveRecord(join(activeDir, file));
     if (!record || file !== `${record.context_key}.json`) continue;
     if (!record.session_id || normalizeSessionId(record.session_id) !== record.session_id) continue;
-    if (!isReusableMadmaxDetachedActiveRecord(record)) continue;
+    if (!hasMatchingMadmaxDetachedRuntimeBinding(record)) continue;
     if (
       canonicalizePathForRunDirMatch(record.source_cwd) !== canonicalCwd
       && (!record.worktree_cwd || canonicalizePathForRunDirMatch(record.worktree_cwd) !== canonicalCwd)
@@ -7585,7 +7582,7 @@ async function cancelModes(args: string[] = []): Promise<void> {
     }
 
     const assertRunAuthority = (): void => {
-      if (runSelection && !isReusableMadmaxDetachedActiveRecord(runSelection.record)) {
+      if (runSelection && !hasMatchingMadmaxDetachedRuntimeBinding(runSelection.record)) {
         throw new Error("Refusing cancellation because detached run authority changed.");
       }
     };

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -1990,6 +1990,33 @@ describe('bound launch authority', () => {
     }
   });
 
+  it('denies selected-root replacement under lock before pointer publication', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-establish-root-race-'));
+    const displacedRoot = join(cwd, 'displaced-state');
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      let replaced = false;
+      let established: Awaited<ReturnType<typeof establishLaunchSessionBinding>> | undefined;
+      await withPointerDependencies({
+        fs: {
+          openAndSync: async (path) => {
+            if (!replaced && path.startsWith(`${context.sessionPath}.tmp-`)) {
+              replaced = true;
+              await rename(context.baseStateDir, displacedRoot);
+              await mkdir(context.baseStateDir, { recursive: true });
+            }
+            return 'synced' as const;
+          },
+        },
+      }, async () => { established = await establishLaunchSessionBinding(cwd, 'sess-establish-root-race'); });
+      assert.ok(established);
+      assert.notEqual(established.kind, 'committed-released');
+      assert.equal(existsSync(context.sessionPath), false);
+      assert.equal(existsSync(join(displacedRoot, 'session.json')), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
   it('denies same-path replacement before creating state, lock, history, or HUD artifacts', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-replaced-path-'));
     const retainedCwd = `${cwd}-retained`;

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -7,6 +7,9 @@ import { join } from 'node:path';
 import {
   __createDefaultPidProbeForTests,
   appendPromptSessionProvenanceRejection,
+  closeLaunchSessionBindingOnce,
+  establishLaunchSessionBinding,
+  finalizeBoundOnce,
   __resetSessionPointerTransactionDependenciesForTests,
   __setSessionPointerTransactionDependenciesForTests,
   isSessionPointerLaunchAbort,
@@ -18,7 +21,9 @@ import {
   resetSessionMetrics,
   resolveSessionPointerContext,
   writeSessionEnd,
+  updateDetachedSessionMetadata,
   writeSessionStart,
+  type LaunchSessionBinding,
   type SessionState,
 } from '../session.js';
 
@@ -167,8 +172,12 @@ describe('session lifecycle manager', () => {
   it('writes session start/end lifecycle artifacts and archives session history', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lifecycle-'));
     const sessionId = 'sess-lifecycle-1';
+    let binding: LaunchSessionBinding | undefined;
     try {
-      await writeSessionStart(cwd, sessionId);
+      const established = await establishLaunchSessionBinding(cwd, sessionId);
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
 
       const state = await readSessionState(cwd);
       assert.ok(state);
@@ -180,7 +189,7 @@ describe('session lifecycle manager', () => {
       const sessionPath = join(cwd, '.omx', 'state', 'session.json');
       assert.equal(existsSync(sessionPath), true);
 
-      await writeSessionEnd(cwd, sessionId);
+      await finalizeBoundOnce(binding, 'test');
 
       assert.equal(existsSync(sessionPath), false);
 
@@ -205,6 +214,7 @@ describe('session lifecycle manager', () => {
       assert.match(dailyLog, /"event":"session_start"/);
       assert.match(dailyLog, /"event":"session_end"/);
     } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -217,8 +227,15 @@ describe('session lifecycle manager', () => {
       warnings.push(value);
       return true;
     }) as typeof process.stderr.write;
+    let binding: LaunchSessionBinding | undefined;
     try {
+      const established = await establishLaunchSessionBinding(cwd, 'sess-end-durability');
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
       await writeSessionEnd(cwd, 'sess-end-durability', {
+        binding,
+        context: binding.context,
         platform: 'win32',
         regularFileSync: async () => { throw codedError('EPERM'); },
       });
@@ -226,6 +243,7 @@ describe('session lifecycle manager', () => {
         '[omx] warning: Windows EPERM regular-file fsync unsupported in session pointer end; operation succeeded with degraded durability.\n',
       ]);
     } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
       process.stderr.write = originalWrite;
       await rm(cwd, { recursive: true, force: true });
     }
@@ -240,19 +258,28 @@ describe('session lifecycle manager', () => {
       return true;
     }) as typeof process.stderr.write;
     const regularFileSync = async () => { throw codedError('EPERM'); };
+    let binding: LaunchSessionBinding | undefined;
     try {
+      const established = await establishLaunchSessionBinding(cwd, 'sess-end-release-failure');
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
+      const establishedBinding = binding;
       await withPointerDependencies({
         fs: {
           rmdir: async () => { throw new Error('release failure'); },
         },
       }, async () => {
         await assert.rejects(writeSessionEnd(cwd, 'sess-end-release-failure', {
+          binding: establishedBinding,
+          context: establishedBinding.context,
           platform: 'win32',
           regularFileSync,
         }));
       });
       assert.deepEqual(warnings, []);
     } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
       process.stderr.write = originalWrite;
       await rm(cwd, { recursive: true, force: true });
     }
@@ -262,6 +289,7 @@ describe('session lifecycle manager', () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-end-owner-'));
     try {
       await writeSessionStart(cwd, 'sess-current');
+      const beforePointer = await readFile(resolveSessionPointerContext(cwd).sessionPath, 'utf-8');
       const stateDir = join(cwd, '.omx', 'state');
       const sessionPath = join(stateDir, 'session.json');
       const currentHudPath = join(stateDir, 'sessions', 'sess-current', 'hud-state.json');
@@ -271,25 +299,14 @@ describe('session lifecycle manager', () => {
       await writeFile(currentHudPath, JSON.stringify({ turn_count: 2 }), 'utf-8');
       await writeFile(endingHudPath, JSON.stringify({ turn_count: 1 }), 'utf-8');
 
-      await writeSessionEnd(cwd, 'sess-ending');
+      await assert.rejects(() => writeSessionEnd(cwd, 'sess-ending'), isSessionPointerLaunchAbort);
 
       const state = await readSessionState(cwd);
       assert.equal(state?.session_id, 'sess-current');
-      assert.equal(existsSync(sessionPath), true);
+      assert.equal(await readFile(sessionPath, 'utf-8'), beforePointer);
       assert.equal(existsSync(currentHudPath), true);
-      assert.equal(existsSync(endingHudPath), false);
-
-      const historyLines = (await readFile(join(cwd, '.omx', 'logs', 'session-history.jsonl'), 'utf-8'))
-        .trim()
-        .split('\n')
-        .filter(Boolean);
-      assert.equal(historyLines.length, 1);
-      const historyEntry = JSON.parse(historyLines[0]) as SessionHistoryEntry & {
-        preserved_active_session_id?: string;
-      };
-      assert.equal(historyEntry.session_id, 'sess-ending');
-      assert.equal(historyEntry.started_at, 'unknown');
-      assert.equal(historyEntry.preserved_active_session_id, 'sess-current');
+      assert.equal(existsSync(endingHudPath), true);
+      assert.equal(existsSync(join(cwd, '.omx', 'logs', 'session-history.jsonl')), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -299,8 +316,12 @@ describe('session lifecycle manager', () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-end-hud-cleanup-'));
     const canonicalSessionId = 'omx-launch-hud';
     const nativeSessionId = 'codex-native-hud';
+    let binding: LaunchSessionBinding | undefined;
     try {
-      await writeSessionStart(cwd, canonicalSessionId, { nativeSessionId });
+      const established = await establishLaunchSessionBinding(cwd, canonicalSessionId, { nativeSessionId });
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
       const stateDir = join(cwd, '.omx', 'state');
       const rootHudPath = join(stateDir, 'hud-state.json');
       const canonicalHudPath = join(stateDir, 'sessions', canonicalSessionId, 'hud-state.json');
@@ -311,12 +332,13 @@ describe('session lifecycle manager', () => {
       await writeFile(canonicalHudPath, JSON.stringify({ last_turn_at: 'canonical', turn_count: 2 }), 'utf-8');
       await writeFile(nativeHudPath, JSON.stringify({ last_turn_at: 'native', turn_count: 9 }), 'utf-8');
 
-      await writeSessionEnd(cwd, canonicalSessionId);
+      await finalizeBoundOnce(binding, 'test');
 
       assert.equal(existsSync(rootHudPath), false);
       assert.equal(existsSync(canonicalHudPath), false);
       assert.equal(existsSync(nativeHudPath), false);
     } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -324,7 +346,7 @@ describe('session lifecycle manager', () => {
   it('preserves canonical session id while reconciling native SessionStart metadata', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-reconcile-'));
     try {
-      await writeSessionStart(cwd, 'omx-launch-1');
+      const established = await writeSessionStart(cwd, 'omx-launch-1');
 
       const reconciled = await reconcileNativeSessionStart(cwd, 'codex-native-1', {
         pid: 54321,
@@ -335,11 +357,13 @@ describe('session lifecycle manager', () => {
       assert.equal(reconciled.native_session_id, 'codex-native-1');
       assert.equal(reconciled.pid, 54321);
       assert.equal(reconciled.platform, 'win32');
+      assert.equal(reconciled.launch_lineage_token, established.launch_lineage_token);
 
       const persisted = await readSessionState(cwd);
       assert.equal(persisted?.session_id, 'omx-launch-1');
       assert.equal(persisted?.native_session_id, 'codex-native-1');
       assert.equal(persisted?.pid, 54321);
+      assert.equal(persisted?.launch_lineage_token, established.launch_lineage_token);
 
       const dailyLogPath = join(cwd, '.omx', 'logs', `omx-${todayIsoDate()}.jsonl`);
       const dailyLog = await readFile(dailyLogPath, 'utf-8');
@@ -386,47 +410,58 @@ describe('session lifecycle manager', () => {
     }
   });
 
-  it('preserves existing native and tmux bindings on same-session start updates', async () => {
+  it('routes existing detached metadata updates through the exact binding', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-preserve-'));
+    let binding: LaunchSessionBinding | undefined;
     try {
-      await writeSessionStart(cwd, 'omx-launch-1', {
+      const established = await establishLaunchSessionBinding(cwd, 'omx-launch-1', {
         nativeSessionId: 'codex-native-1',
         tmuxSessionName: 'omx-detached-demo',
       });
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
 
-      const withPane = await writeSessionStart(cwd, 'omx-launch-1', {
+      const withPaneResult = await updateDetachedSessionMetadata(binding, {
         tmuxSessionName: 'omx-detached-demo',
         tmuxPaneId: '%42',
       });
+      assert.equal(withPaneResult.kind, 'committed-released');
+      const withPane = await readSessionState(cwd);
+      assert.equal(withPane?.native_session_id, 'codex-native-1');
+      assert.equal(withPane?.tmux_session_name, 'omx-detached-demo');
+      assert.equal(withPane?.tmux_pane_id, '%42');
 
-      assert.equal(withPane.native_session_id, 'codex-native-1');
-      assert.equal(withPane.tmux_session_name, 'omx-detached-demo');
-      assert.equal(withPane.tmux_pane_id, '%42');
-
-      const withoutPane = await writeSessionStart(cwd, 'omx-launch-1', {
+      const withoutPaneResult = await updateDetachedSessionMetadata(binding, {
         tmuxSessionName: 'omx-detached-demo',
       });
-
-      assert.equal(withoutPane.native_session_id, 'codex-native-1');
-      assert.equal(withoutPane.tmux_session_name, 'omx-detached-demo');
-      assert.equal(withoutPane.tmux_pane_id, '%42');
+      assert.equal(withoutPaneResult.kind, 'committed-released');
+      const withoutPane = await readSessionState(cwd);
+      assert.equal(withoutPane?.native_session_id, 'codex-native-1');
+      assert.equal(withoutPane?.tmux_session_name, 'omx-detached-demo');
+      assert.equal(withoutPane?.tmux_pane_id, '%42');
     } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
   it('lets an owner OMX launch session end the fresh native session it spawned', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-owner-end-'));
+    let binding: LaunchSessionBinding | undefined;
     try {
-      await writeSessionStart(cwd, 'omx-owner-session', {
+      const established = await establishLaunchSessionBinding(cwd, 'omx-owner-session', {
         nativeSessionId: 'codex-native-old',
       });
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
       await reconcileNativeSessionStart(cwd, 'codex-native-new', {
         pid: process.pid,
         platform: 'win32',
       });
 
-      await writeSessionEnd(cwd, 'omx-owner-session');
+      await finalizeBoundOnce(binding, 'test');
 
       assert.equal(await readSessionState(cwd), null);
       const historyLines = (await readFile(join(cwd, '.omx', 'logs', 'session-history.jsonl'), 'utf-8'))
@@ -441,16 +476,21 @@ describe('session lifecycle manager', () => {
       assert.equal(historyEntry.native_session_id, 'codex-native-new');
       assert.equal(historyEntry.active_session_id, 'codex-native-new');
     } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
   it('preserves owner OMX metadata when reconciling the same fresh native session', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-owner-reconcile-'));
+    let binding: LaunchSessionBinding | undefined;
     try {
-      await writeSessionStart(cwd, 'omx-owner-session', {
+      const established = await establishLaunchSessionBinding(cwd, 'omx-owner-session', {
         nativeSessionId: 'codex-native-old',
       });
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
       await reconcileNativeSessionStart(cwd, 'codex-native-new', {
         pid: process.pid,
         platform: 'win32',
@@ -467,19 +507,24 @@ describe('session lifecycle manager', () => {
       assert.equal(reconciled.owner_omx_session_id, 'omx-owner-session');
       assert.equal(reconciled.pid, process.pid);
 
-      await writeSessionEnd(cwd, 'omx-owner-session');
+      await finalizeBoundOnce(binding, 'test');
       assert.equal(await readSessionState(cwd), null);
     } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
   it('carries the owner OMX launch session across chained native SessionStart replacements', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-owner-chain-'));
+    let binding: LaunchSessionBinding | undefined;
     try {
-      await writeSessionStart(cwd, 'omx-owner-session', {
+      const established = await establishLaunchSessionBinding(cwd, 'omx-owner-session', {
         nativeSessionId: 'codex-native-a',
       });
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
       await reconcileNativeSessionStart(cwd, 'codex-native-b', {
         pid: process.pid,
         platform: 'win32',
@@ -502,7 +547,7 @@ describe('session lifecycle manager', () => {
       assert.match(dailyLog, /"previous_native_session_id":"codex-native-b"/);
       assert.match(dailyLog, /"replaced_by_native_session_id":"codex-native-c"/);
 
-      await writeSessionEnd(cwd, 'omx-owner-session');
+      await finalizeBoundOnce(binding, 'test');
       assert.equal(await readSessionState(cwd), null);
       const historyLines = (await readFile(join(cwd, '.omx', 'logs', 'session-history.jsonl'), 'utf-8'))
         .trim()
@@ -515,11 +560,12 @@ describe('session lifecycle manager', () => {
       assert.equal(historyEntry.native_session_id, 'codex-native-c');
       assert.equal(historyEntry.active_session_id, 'codex-native-c');
     } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
-  it('starts a fresh canonical session when a non-OMX native session is replaced', async () => {
+  it('retains wrapper lineage when a wrapper-owned native session is replaced', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-non-omx-fresh-'));
     try {
       await writeSessionStart(cwd, 'codex-native-old', {
@@ -533,13 +579,15 @@ describe('session lifecycle manager', () => {
 
       assert.equal(reconciled.session_id, 'codex-native-new');
       assert.equal(reconciled.native_session_id, 'codex-native-new');
-      assert.equal(reconciled.previous_native_session_id, undefined);
+      assert.equal(reconciled.previous_native_session_id, 'codex-native-old');
+      assert.equal(reconciled.owner_omx_session_id, 'codex-native-old');
       assert.equal(reconciled.pid, 54321);
 
       const persisted = await readSessionState(cwd);
       assert.equal(persisted?.session_id, 'codex-native-new');
       assert.equal(persisted?.native_session_id, 'codex-native-new');
-      assert.equal(persisted?.previous_native_session_id, undefined);
+      assert.equal(persisted?.previous_native_session_id, 'codex-native-old');
+      assert.equal(persisted?.owner_omx_session_id, 'codex-native-old');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -948,8 +996,9 @@ describe('session pointer transaction', () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-durability-warning-'));
     const originalWrite = process.stderr.write;
     const warnings: Array<{ value: string; lockExists: boolean }> = [];
+    let warningCwd = cwd;
     process.stderr.write = ((value: string) => {
-      warnings.push({ value, lockExists: existsSync(resolveSessionPointerContext(cwd).lockPath) });
+      warnings.push({ value, lockExists: existsSync(resolveSessionPointerContext(warningCwd).lockPath) });
       return true;
     }) as typeof process.stderr.write;
     const regularFileSync = async () => { throw codedError('EPERM'); };
@@ -961,18 +1010,24 @@ describe('session pointer transaction', () => {
       }]);
 
       warnings.length = 0;
-      await writeSessionStart(cwd, 'sess-degraded-start', { platform: 'win32' });
+      const syncedCwd = join(cwd, 'synced');
+      await mkdir(syncedCwd);
+      warningCwd = syncedCwd;
+      await writeSessionStart(syncedCwd, 'sess-synced-start', { platform: 'win32' });
       assert.deepEqual(warnings, []);
+      const failedCwd = join(cwd, 'failed');
+      await mkdir(failedCwd);
+      warningCwd = failedCwd;
 
       await withPointerDependencies({
         fs: {
           rename: async (from, to) => {
-            if (to === resolveSessionPointerContext(cwd).sessionPath) throw new Error('rename failure');
+            if (to === resolveSessionPointerContext(failedCwd).sessionPath) throw new Error('rename failure');
             await rename(from, to);
           },
         },
       }, async () => {
-        await assert.rejects(writeSessionStart(cwd, 'sess-degraded-start', { platform: 'win32', regularFileSync }));
+        await assert.rejects(writeSessionStart(failedCwd, 'sess-failed-start', { platform: 'win32', regularFileSync }));
       });
       assert.deepEqual(warnings, []);
     } finally {
@@ -1232,23 +1287,600 @@ describe('session pointer transaction', () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-end-preserve-'));
     try {
       const context = resolveSessionPointerContext(cwd);
-      await writeSessionStart(cwd, 'sess-history', { platform: 'win32' });
+      const established = await establishLaunchSessionBinding(cwd, 'sess-history', { platform: 'win32' });
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
       await mkdir(join(cwd, '.omx', 'logs'), { recursive: true });
       await rm(join(cwd, '.omx', 'logs'), { recursive: true, force: true });
       await writeFile(join(cwd, '.omx', 'logs'), 'not-a-directory', 'utf-8');
-      await assert.rejects(writeSessionEnd(cwd, 'sess-history'));
+      await assert.rejects(finalizeBoundOnce(established.binding, 'history-failure'));
       assert.equal((await readSessionState(cwd))?.session_id, 'sess-history');
       await rm(join(cwd, '.omx', 'logs'), { force: true });
 
       await writeFile(context.sessionPath, '{ malformed', 'utf-8');
       await assert.rejects(
-        writeSessionEnd(cwd, 'sess-history'),
+        writeSessionEnd(cwd, 'sess-history', { binding: established.binding }),
         (error: unknown) => isSessionPointerLaunchAbort(error)
           && error.code === 'session_pointer_unusable'
           && error.pointerStatus === 'malformed',
       );
       assert.equal(await readFile(context.sessionPath, 'utf-8'), '{ malformed');
       assert.equal(existsSync(join(cwd, '.omx', 'logs', 'session-history.jsonl')), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('bound launch authority', () => {
+  it('returns one private binding and only capability-free metadata updates', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-authority-'));
+    try {
+      const established = await establishLaunchSessionBinding(cwd, 'sess-binding-authority');
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      assert.match(established.binding.launchLineageToken, /^[A-Za-z0-9_-]{16,128}$/);
+      assert.equal('handle' in established.binding, false);
+      const metadata = await updateDetachedSessionMetadata(established.binding, {
+        tmuxSessionName: 'omx-authority', tmuxPaneId: '%42',
+      });
+      assert.equal(metadata.kind, 'committed-released');
+      assert.equal((await readSessionState(cwd))?.launch_lineage_token, established.binding.launchLineageToken);
+      const firstFinalization = finalizeBoundOnce(established.binding, 'test');
+      const secondFinalization = finalizeBoundOnce(established.binding, 'duplicate');
+      assert.equal(firstFinalization, secondFinalization);
+      const finalized = await firstFinalization;
+      assert.equal(finalized.finalized, true);
+      assert.equal(finalized.cleanup.comparison?.status, 'matched');
+      assert.equal(existsSync(resolveSessionPointerContext(cwd).sessionPath), false);
+      assert.equal((await closeLaunchSessionBindingOnce(established.binding)).status, 'closed');
+      assert.equal((await closeLaunchSessionBindingOnce(established.binding)).status, 'closed');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('anchors capability acquisition and finalization to context.baseStateDir rather than cwd', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-selected-root-'));
+    let binding: LaunchSessionBinding | undefined;
+    try {
+      const baseStateDir = join(cwd, 'selected', 'state');
+      const context = {
+        cwd,
+        baseStateDir,
+        rootSource: 'cwd-default' as const,
+        sessionPath: join(baseStateDir, 'session.json'),
+        lockPath: join(baseStateDir, 'session.json.lock'),
+      };
+      const established = await establishLaunchSessionBinding(cwd, 'sess-selected-root', { context });
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
+      assert.equal(binding.context.baseStateDir, baseStateDir);
+      assert.equal(existsSync(context.sessionPath), true);
+      assert.equal(existsSync(join(cwd, '.omx', 'state', 'session.json')), false);
+      assert.equal((await finalizeBoundOnce(binding, 'selected-root')).finalized, true);
+      assert.equal(existsSync(context.sessionPath), false);
+    } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects forged and changed-incarnation detached metadata before lifecycle mutation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-metadata-hostile-'));
+    let binding: LaunchSessionBinding | undefined;
+    try {
+      const established = await establishLaunchSessionBinding(cwd, 'sess-binding-metadata-hostile');
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
+      const context = resolveSessionPointerContext(cwd);
+      const original = await readFile(context.sessionPath, 'utf-8');
+      let mkdirCalls = 0;
+
+      await withPointerDependencies({
+        fs: { mkdir: async (path, options) => { mkdirCalls += 1; await mkdir(path, options); } },
+      }, async () => {
+        const forged = await updateDetachedSessionMetadata({ ...binding } as LaunchSessionBinding, { tmuxPaneId: '%forged' });
+        assert.equal(forged.kind, 'precommit-aborted');
+      });
+      assert.equal(mkdirCalls, 0);
+      assert.equal(await readFile(context.sessionPath, 'utf-8'), original);
+      assert.equal(existsSync(context.lockPath), false);
+
+      const parsed = JSON.parse(original) as Partial<SessionState>;
+      const state: SessionState = { ...parsed, session_id: binding.canonicalSessionId } as SessionState;
+      const changed = JSON.stringify({ ...state, started_at: '1999-01-01T00:00:00.000Z' }, null, 2);
+      await writeFile(context.sessionPath, changed, 'utf-8');
+      const denied = await updateDetachedSessionMetadata(binding, { tmuxPaneId: '%changed' });
+      assert.equal(denied.kind, 'precommit-aborted');
+      assert.equal(await readFile(context.sessionPath, 'utf-8'), changed);
+      assert.equal(existsSync(context.lockPath), false);
+    } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rechecks supported directory identity under the metadata lock before pointer mutation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-metadata-race-'));
+    const retainedCwd = `${cwd}-retained`;
+    let binding: LaunchSessionBinding | undefined;
+    try {
+      const established = await establishLaunchSessionBinding(cwd, 'sess-binding-metadata-race');
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
+      const context = resolveSessionPointerContext(cwd);
+      const original = await readFile(context.sessionPath, 'utf-8');
+      let replaced = false;
+
+      let result: Awaited<ReturnType<typeof updateDetachedSessionMetadata>> | undefined;
+      await withPointerDependencies({
+        fs: {
+          mkdir: async (path, options) => {
+            if (!replaced && String(path) === context.baseStateDir) {
+              replaced = true;
+              await rename(cwd, retainedCwd);
+              await mkdir(context.baseStateDir, { recursive: true });
+              await writeFile(context.sessionPath, original, 'utf-8');
+              return;
+            }
+            await mkdir(path, options);
+          },
+        },
+      }, async () => { result = await updateDetachedSessionMetadata(binding as LaunchSessionBinding, { tmuxPaneId: '%race' }); });
+
+      assert.equal(result?.kind, 'precommit-aborted');
+      assert.equal(await readFile(context.sessionPath, 'utf-8'), original);
+      assert.equal(await readFile(join(retainedCwd, '.omx', 'state', 'session.json'), 'utf-8'), original);
+      assert.equal(existsSync(context.lockPath), false);
+    } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
+      await rm(cwd, { recursive: true, force: true });
+      await rm(retainedCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('permits an ordinary absent launch when directory identity is unsupported', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-unsupported-'));
+    let binding: LaunchSessionBinding | undefined;
+    try {
+      const established = await establishLaunchSessionBinding(cwd, 'sess-binding-unsupported', { platform: 'win32' });
+
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
+      assert.deepEqual(binding.directoryIdentity, { kind: 'unsupported', reason: 'platform' });
+      assert.equal((await readSessionState(cwd))?.session_id, 'sess-binding-unsupported');
+    } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('establishment preflight is absent-only under the selected pointer lock and preserves every existing pointer byte', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-session-binding-preflight-'));
+    try {
+      const cases: Array<{ name: string; raw: string; probePid?: 'dead' | 'indeterminate' }> = [
+        { name: 'usable', raw: JSON.stringify(makeState({ cwd: join(root, 'usable'), pid: process.pid, platform: 'linux', pid_start_ticks: 1 })) },
+        { name: 'stale-dead', raw: JSON.stringify(makeState({ cwd: join(root, 'stale-dead'), pid: 424242, platform: 'linux', pid_start_ticks: 1 })), probePid: 'dead' },
+        { name: 'malformed', raw: '{ malformed pointer' },
+        { name: 'foreign', raw: JSON.stringify(makeState({ cwd: join(root, 'foreign', 'other'), platform: 'win32' })) },
+        { name: 'indeterminate', raw: JSON.stringify(makeState({ cwd: join(root, 'indeterminate'), pid: 424242, platform: 'linux', pid_start_ticks: 1 })), probePid: 'indeterminate' },
+      ];
+      for (const testCase of cases) {
+        const cwd = join(root, testCase.name);
+        const context = resolveSessionPointerContext(cwd);
+        const order: string[] = [];
+        await mkdir(context.baseStateDir, { recursive: true });
+        await writeFile(context.sessionPath, testCase.raw, 'utf-8');
+        await withPointerDependencies({
+          probePid: () => testCase.probePid ?? 'alive',
+          readProcessIdentity: () => matchingProcessIdentity(),
+          fs: {
+            mkdir: async (path, options) => { order.push(`mkdir:${path}`); await mkdir(path, options); },
+            readFile: async (path, encoding) => { order.push(`read:${path}`); return await readFile(path, encoding); },
+            rename: async (from, to) => { order.push(`rename:${from}:${to}`); await rename(from, to); },
+            unlink: async (path) => { order.push(`unlink:${path}`); await rm(path, { force: false }); },
+          },
+        }, async () => {
+          const established = await establishLaunchSessionBinding(cwd, `sess-preflight-${testCase.name}`);
+          assert.equal(established.kind, 'precommit-aborted', testCase.name);
+        });
+        assert.equal(await readFile(context.sessionPath, 'utf-8'), testCase.raw, testCase.name);
+        assert.ok(order.indexOf(`mkdir:${context.lockPath}`) < order.indexOf(`read:${context.sessionPath}`), testCase.name);
+        assert.equal(order.filter((entry) => entry === `rename:${context.sessionPath}`).length, 0, testCase.name);
+        assert.equal(order.filter((entry) => entry === `unlink:${context.sessionPath}`).length, 0, testCase.name);
+        assert.equal(existsSync(context.lockPath), false, testCase.name);
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('denies an absent bound pointer without creating synthetic terminal history', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-absent-finalization-'));
+    let binding: LaunchSessionBinding | undefined;
+    try {
+      const established = await establishLaunchSessionBinding(cwd, 'sess-binding-absent-finalization');
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
+      const context = resolveSessionPointerContext(cwd);
+      await rm(context.sessionPath);
+      const finalized = await finalizeBoundOnce(binding, 'absent');
+      assert.equal(finalized.finalized, false);
+      assert.equal(existsSync(join(cwd, '.omx', 'logs', 'session-history.jsonl')), false);
+      assert.equal(existsSync(join(cwd, '.omx', 'logs', `omx-${todayIsoDate()}.jsonl`)), true);
+    } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects unbound usable finalization before changing any lifecycle bytes', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-unbound-'));
+    let binding: LaunchSessionBinding | undefined;
+    try {
+      const established = await establishLaunchSessionBinding(cwd, 'sess-binding-unbound');
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
+      const context = resolveSessionPointerContext(cwd);
+      const historyPath = join(cwd, '.omx', 'logs', 'session-history.jsonl');
+      const dailyPath = join(cwd, '.omx', 'logs', `omx-${todayIsoDate()}.jsonl`);
+      const hudPath = join(cwd, '.omx', 'state', 'hud-state.json');
+      const metricsPath = join(cwd, '.omx', 'metrics.json');
+      await writeFile(historyPath, 'history-sentinel\n', 'utf-8');
+      await writeFile(hudPath, 'hud-sentinel\n', 'utf-8');
+      await writeFile(metricsPath, 'metrics-sentinel\n', 'utf-8');
+      const before = {
+        pointer: await readFile(context.sessionPath, 'utf-8'),
+        history: await readFile(historyPath, 'utf-8'),
+        daily: await readFile(dailyPath, 'utf-8'),
+        hud: await readFile(hudPath, 'utf-8'),
+        metrics: await readFile(metricsPath, 'utf-8'),
+      };
+
+      await assert.rejects(() => writeSessionEnd(cwd, 'sess-binding-unbound'), isSessionPointerLaunchAbort);
+
+      assert.equal(await readFile(context.sessionPath, 'utf-8'), before.pointer);
+      assert.equal(await readFile(historyPath, 'utf-8'), before.history);
+      assert.equal(await readFile(dailyPath, 'utf-8'), before.daily);
+      assert.equal(await readFile(hudPath, 'utf-8'), before.hud);
+      assert.equal(await readFile(metricsPath, 'utf-8'), before.metrics);
+      assert.equal(existsSync(context.lockPath), false);
+    } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves a compatible tokenless pointer and refuses to establish cleanup authority from it', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-tokenless-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      await reconcileNativeSessionStart(cwd, 'native-compatible-tokenless');
+      const beforeUpdate = await readFile(context.sessionPath, 'utf-8');
+      await assert.rejects(
+        () => writeSessionStart(cwd, 'native-compatible-tokenless', { tmuxPaneId: '%42' }),
+        isSessionPointerLaunchAbort,
+      );
+      assert.equal((await readSessionState(cwd))?.launch_lineage_token, undefined);
+      const afterUpdate = await readFile(context.sessionPath, 'utf-8');
+      assert.equal(afterUpdate, beforeUpdate);
+
+      const established = await establishLaunchSessionBinding(cwd, 'native-compatible-tokenless');
+      assert.equal(established.kind, 'precommit-aborted');
+      if (established.kind !== 'precommit-aborted') return;
+      assert.equal(established.abort.committed, false);
+      assert.equal(established.abort.code, 'session_pointer_owner_conflict');
+      assert.equal((await readSessionState(cwd))?.launch_lineage_token, undefined);
+      assert.equal(afterUpdate.includes('launch_lineage_token'), false);
+      assert.equal(await readFile(context.sessionPath, 'utf-8'), afterUpdate);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves a compatible malformed lineage token without granting cleanup authority', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-malformed-token-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      const tokenless = await reconcileNativeSessionStart(cwd, 'native-compatible-malformed-token');
+      await writeFile(context.sessionPath, JSON.stringify({ ...tokenless, launch_lineage_token: 'bad' }), 'utf-8');
+
+      const beforeUpdate = await readFile(context.sessionPath, 'utf-8');
+      await assert.rejects(
+        () => writeSessionStart(cwd, 'native-compatible-malformed-token', { tmuxPaneId: '%42' }),
+        isSessionPointerLaunchAbort,
+      );
+      const afterUpdate = await readFile(context.sessionPath, 'utf-8');
+      assert.equal(afterUpdate, beforeUpdate);
+      assert.match(afterUpdate, /"launch_lineage_token":"bad"|"launch_lineage_token": "bad"/);
+      assert.equal((await reconcileNativeSessionStart(cwd, 'native-compatible-malformed-token')).launch_lineage_token, 'bad');
+      const beforeEstablishment = await readFile(context.sessionPath, 'utf-8');
+
+      const established = await establishLaunchSessionBinding(cwd, 'native-compatible-malformed-token');
+      assert.equal(established.kind, 'precommit-aborted');
+      if (established.kind !== 'precommit-aborted') return;
+      assert.equal(established.abort.committed, false);
+      assert.equal(await readFile(context.sessionPath, 'utf-8'), beforeEstablishment);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves malformed pointer bytes when binding establishment aborts before commit', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-malformed-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      const malformed = '{ malformed pointer';
+      await mkdir(context.baseStateDir, { recursive: true });
+      await writeFile(context.sessionPath, malformed, 'utf-8');
+
+      const established = await establishLaunchSessionBinding(cwd, 'sess-binding-malformed');
+      assert.equal(established.kind, 'precommit-aborted');
+      if (established.kind !== 'precommit-aborted') return;
+      assert.equal(established.abort.committed, false);
+      assert.equal(established.abort.code, 'session_pointer_unusable');
+      assert.equal(established.abort.pointerStatus, 'malformed');
+      assert.equal(await readFile(context.sessionPath, 'utf-8'), malformed);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('finalizes only its exact stale-dead native pointer after history is retained', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-stale-dead-'));
+    try {
+      const established = await establishLaunchSessionBinding(cwd, 'sess-binding-stale-dead');
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      await reconcileNativeSessionStart(cwd, 'native-binding-stale-dead', { pid: 424242 });
+      await withPointerDependencies({ probePid: () => 'dead' }, async () => {
+        const finalized = await finalizeBoundOnce(established.binding, 'test');
+        assert.equal(finalized.finalized, true);
+      });
+      await closeLaunchSessionBindingOnce(established.binding);
+      assert.equal(existsSync(resolveSessionPointerContext(cwd).sessionPath), false);
+      const history = await readFile(join(cwd, '.omx', 'logs', 'session-history.jsonl'), 'utf-8');
+      assert.match(history, /native-binding-stale-dead/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves a stale-dead pointer whose bound lineage token does not match', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-stale-mismatch-'));
+    let binding: LaunchSessionBinding | undefined;
+    try {
+      const established = await establishLaunchSessionBinding(cwd, 'sess-binding-stale-mismatch');
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
+      const context = resolveSessionPointerContext(cwd);
+      const state = await reconcileNativeSessionStart(cwd, 'native-binding-stale-mismatch', { pid: 424242 });
+      await writeFile(context.sessionPath, JSON.stringify({ ...state, launch_lineage_token: FOREIGN_TOKEN }), 'utf-8');
+      await withPointerDependencies({ probePid: () => 'dead' }, async () => {
+        const denied = await finalizeBoundOnce(binding as LaunchSessionBinding, 'test');
+        assert.equal(denied.finalized, false);
+      });
+      assert.equal(existsSync(context.sessionPath), true);
+      assert.equal(existsSync(join(cwd, '.omx', 'logs', 'session-history.jsonl')), false);
+    } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves usable and stale bound pointers without the exact valid lineage token before any mutation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-token-gate-'));
+    let binding: LaunchSessionBinding | undefined;
+    try {
+      const established = await establishLaunchSessionBinding(cwd, 'sess-binding-token-gate');
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
+      const context = resolveSessionPointerContext(cwd);
+      const state = await readSessionState(cwd);
+      assert.ok(state);
+      const historyPath = join(cwd, '.omx', 'logs', 'session-history.jsonl');
+      const dailyPath = join(cwd, '.omx', 'logs', `omx-${todayIsoDate()}.jsonl`);
+      const hudPath = join(cwd, '.omx', 'state', 'hud-state.json');
+      const metricsPath = join(cwd, '.omx', 'metrics.json');
+      await writeFile(historyPath, 'history-sentinel\n', 'utf-8');
+      await writeFile(hudPath, 'hud-sentinel\n', 'utf-8');
+      await writeFile(metricsPath, 'metrics-sentinel\n', 'utf-8');
+      const lifecycleBytes = {
+        history: await readFile(historyPath, 'utf-8'),
+        daily: await readFile(dailyPath, 'utf-8'),
+        hud: await readFile(hudPath, 'utf-8'),
+        metrics: await readFile(metricsPath, 'utf-8'),
+      };
+      const cases: Array<{ name: string; state: SessionState; probePid?: 'dead' | 'indeterminate' }> = [
+        { name: 'tokenless usable', state: (() => { const { launch_lineage_token: _, ...tokenless } = state; return tokenless; })() },
+        { name: 'malformed usable', state: { ...state, launch_lineage_token: 'bad' } },
+        { name: 'mismatched usable', state: { ...state, launch_lineage_token: FOREIGN_TOKEN } },
+        { name: 'replaced usable', state: { ...state, launch_lineage_token: SUCCESSOR_TOKEN } },
+        { name: 'same-token changed incarnation', state: { ...state, started_at: '1999-01-01T00:00:00.000Z' } },
+        { name: 'unknown identity', state: { ...state, pid: 424242 }, probePid: 'indeterminate' },
+        {
+          name: 'tokenless stale native',
+          state: (() => {
+            const { launch_lineage_token: _, ...tokenless } = state;
+            return { ...tokenless, native_session_id: 'native-tokenless-stale', pid: 424242 };
+          })(),
+          probePid: 'dead',
+        },
+      ];
+
+      for (const testCase of cases) {
+        const raw = JSON.stringify(testCase.state);
+        let mkdirCalls = 0;
+        let unlinkCalls = 0;
+        await writeFile(context.sessionPath, raw, 'utf-8');
+        await withPointerDependencies({
+          probePid: () => testCase.probePid ?? 'alive',
+          fs: {
+            mkdir: async (path, options) => { mkdirCalls += 1; await mkdir(path, options); },
+            unlink: async (path) => { if (path === context.sessionPath) unlinkCalls += 1; await rm(path, { force: false }); },
+          },
+        }, async () => {
+          const denied = await finalizeBoundOnce(binding as LaunchSessionBinding, testCase.name);
+          assert.equal(denied.finalized, false);
+        });
+        assert.equal(await readFile(context.sessionPath, 'utf-8'), raw, testCase.name);
+        assert.ok(mkdirCalls <= 1, testCase.name);
+        assert.equal(unlinkCalls, 0, testCase.name);
+        assert.equal(existsSync(context.lockPath), false, testCase.name);
+        assert.equal(await readFile(historyPath, 'utf-8'), lifecycleBytes.history, testCase.name);
+        assert.equal(await readFile(dailyPath, 'utf-8'), lifecycleBytes.daily, testCase.name);
+        assert.equal(await readFile(hudPath, 'utf-8'), lifecycleBytes.hud, testCase.name);
+        assert.equal(await readFile(metricsPath, 'utf-8'), lifecycleBytes.metrics, testCase.name);
+      }
+    } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies same-path replacement before creating state, lock, history, or HUD artifacts', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-replaced-path-'));
+    const retainedCwd = `${cwd}-retained`;
+    let binding: LaunchSessionBinding | undefined;
+    try {
+      const established = await establishLaunchSessionBinding(cwd, 'sess-binding-replaced-path');
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
+
+      await rename(cwd, retainedCwd);
+      await mkdir(cwd);
+      const context = resolveSessionPointerContext(cwd);
+
+      const finalized = await finalizeBoundOnce(binding, 'test');
+      assert.equal(finalized.finalized, false);
+      assert.equal(finalized.cleanup.comparison?.status, 'denied');
+      assert.equal(existsSync(context.baseStateDir), false);
+      assert.equal(existsSync(context.lockPath), false);
+      assert.equal(existsSync(join(cwd, '.omx', 'logs', 'session-history.jsonl')), false);
+      assert.equal(existsSync(join(cwd, '.omx', 'state', 'hud-state.json')), false);
+    } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
+      await rm(cwd, { recursive: true, force: true });
+      await rm(retainedCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps native absent reconciliation tokenless without backfill', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-tokenless-'));
+    try {
+      assert.equal((await reconcileNativeSessionStart(cwd, 'native-tokenless')).launch_lineage_token, undefined);
+      assert.equal((await reconcileNativeSessionStart(cwd, 'native-tokenless')).launch_lineage_token, undefined);
+      assert.equal((await readSessionState(cwd))?.launch_lineage_token, undefined);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('allows ordinary unsupported-capability finalization but denies stale-dead cleanup without mutating evidence', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-unsupported-lifecycle-'));
+    let ordinary: LaunchSessionBinding | undefined;
+    let stale: LaunchSessionBinding | undefined;
+    try {
+      const ordinaryEstablished = await establishLaunchSessionBinding(cwd, 'sess-unsupported-ordinary', { platform: 'win32' });
+      assert.equal(ordinaryEstablished.kind, 'committed-released');
+      if (ordinaryEstablished.kind !== 'committed-released') return;
+      ordinary = ordinaryEstablished.binding;
+      assert.deepEqual(ordinary.directoryIdentity, { kind: 'unsupported', reason: 'platform' });
+
+      const ordinaryFinalized = await finalizeBoundOnce(ordinary, 'ordinary-unsupported');
+      assert.equal(ordinaryFinalized.finalized, true);
+      assert.equal(existsSync(resolveSessionPointerContext(cwd).sessionPath), false);
+      assert.equal((await closeLaunchSessionBindingOnce(ordinary)).status, 'closed');
+
+      const staleEstablished = await establishLaunchSessionBinding(cwd, 'sess-unsupported-stale', {
+        nativeSessionId: 'native-unsupported-stale',
+        platform: 'win32',
+      });
+      assert.equal(staleEstablished.kind, 'committed-released');
+      if (staleEstablished.kind !== 'committed-released') return;
+      stale = staleEstablished.binding;
+      await reconcileNativeSessionStart(cwd, 'native-unsupported-stale', { pid: 424242, platform: 'win32' });
+      const context = resolveSessionPointerContext(cwd);
+      const staleBytes = await readFile(context.sessionPath, 'utf-8');
+      const historyPath = join(cwd, '.omx', 'logs', 'session-history.jsonl');
+      const historyBeforeStaleCleanup = await readFile(historyPath, 'utf-8');
+
+      await withPointerDependencies({ probePid: () => 'dead' }, async () => {
+        const denied = await finalizeBoundOnce(stale as LaunchSessionBinding, 'stale-unsupported');
+        assert.equal(denied.finalized, false);
+        assert.equal(denied.cleanup.comparison?.status, 'denied');
+        assert.match(denied.cleanup.comparison?.reason ?? '', /unsupported-directory-capability:platform/);
+      });
+      assert.equal(await readFile(context.sessionPath, 'utf-8'), staleBytes);
+      assert.equal(await readFile(historyPath, 'utf-8'), historyBeforeStaleCleanup, 'stale evidence is denied before lifecycle history mutation');
+    } finally {
+      if (ordinary) await closeLaunchSessionBindingOnce(ordinary).catch(() => {});
+      if (stale) await closeLaunchSessionBindingOnce(stale).catch(() => {});
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves native lineage and tmux metadata across an authorized native-ID replacement', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-lineage-metadata-'));
+    let binding: LaunchSessionBinding | undefined;
+    try {
+      const established = await establishLaunchSessionBinding(cwd, 'sess-native-lineage-metadata', {
+        nativeSessionId: 'native-before',
+        tmuxSessionName: 'omx-native-lineage',
+        tmuxPaneId: '%88',
+      });
+      assert.equal(established.kind, 'committed-released');
+      if (established.kind !== 'committed-released') return;
+      binding = established.binding;
+
+      const reconciled = await reconcileNativeSessionStart(cwd, 'native-after', { pid: process.pid });
+      assert.equal(reconciled.session_id, 'native-after');
+      assert.equal(reconciled.native_session_id, 'native-after');
+      assert.equal(reconciled.owner_omx_session_id, binding.canonicalSessionId);
+      assert.equal(reconciled.previous_native_session_id, 'native-before');
+      assert.equal(reconciled.launch_lineage_token, binding.launchLineageToken);
+      assert.equal(reconciled.tmux_session_name, 'omx-native-lineage');
+      assert.equal(reconciled.tmux_pane_id, '%88');
+    } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('reports owner unlink residue and does not rmdir it', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-owner-unlink-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      let rmdirCalls = 0;
+      await withPointerDependencies({
+        token: () => TEST_TOKEN,
+        fs: {
+          unlink: async (path) => {
+            if (path.endsWith(`.release-${TEST_TOKEN}/owner.json`)) throw new Error('owner unlink failure');
+            await rm(path, { force: false });
+          },
+          rmdir: async (path) => { rmdirCalls += 1; await rm(path, { recursive: false }); },
+        },
+      }, async () => {
+        const result = await establishLaunchSessionBinding(cwd, 'sess-owner-unlink');
+        assert.equal(result.kind, 'committed-release-failed');
+        if (result.kind === 'committed-release-failed') {
+          assert.equal(result.secondaryFailures[0]?.phase, 'remove-release-owner');
+          assert.equal(result.lockDisposition, 'released-with-residue');
+        }
+      });
+      assert.equal(rmdirCalls, 0);
+      assert.equal(existsSync(`${context.lockPath}.release-${TEST_TOKEN}`), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -2017,6 +2017,33 @@ describe('bound launch authority', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+  it('returns committed blocked evidence when selected root changes after pointer rename', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-establish-post-rename-race-'));
+    const displacedRoot = join(cwd, 'displaced-after-rename');
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      let replaced = false;
+      let established: Awaited<ReturnType<typeof establishLaunchSessionBinding>> | undefined;
+      await withPointerDependencies({
+        fs: {
+          rename: async (from, to) => {
+            await rename(from, to);
+            if (!replaced && to === context.sessionPath) {
+              replaced = true;
+              await rename(context.baseStateDir, displacedRoot);
+              await mkdir(context.baseStateDir, { recursive: true });
+            }
+          },
+        },
+      }, async () => { established = await establishLaunchSessionBinding(cwd, 'sess-establish-post-rename-race'); });
+      assert.ok(established);
+      assert.equal(established.kind, 'committed-release-failed');
+      assert.equal(existsSync(context.sessionPath), false);
+      assert.equal(existsSync(join(displacedRoot, 'session.json')), true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
   it('denies same-path replacement before creating state, lock, history, or HUD artifacts', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-replaced-path-'));
     const retainedCwd = `${cwd}-retained`;

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -2083,7 +2083,7 @@ describe('bound launch authority', () => {
     }
   });
 
-  it('allows ordinary unsupported-capability finalization but denies stale-dead cleanup without mutating evidence', async () => {
+  it('allows authorized unsupported-capability stale-dead finalization without weakening bound lineage checks', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-unsupported-lifecycle-'));
     let ordinary: LaunchSessionBinding | undefined;
     let stale: LaunchSessionBinding | undefined;
@@ -2108,18 +2108,17 @@ describe('bound launch authority', () => {
       stale = staleEstablished.binding;
       await reconcileNativeSessionStart(cwd, 'native-unsupported-stale', { pid: 424242, platform: 'win32' });
       const context = resolveSessionPointerContext(cwd);
-      const staleBytes = await readFile(context.sessionPath, 'utf-8');
       const historyPath = join(cwd, '.omx', 'logs', 'session-history.jsonl');
-      const historyBeforeStaleCleanup = await readFile(historyPath, 'utf-8');
 
       await withPointerDependencies({ probePid: () => 'dead' }, async () => {
-        const denied = await finalizeBoundOnce(stale as LaunchSessionBinding, 'stale-unsupported');
-        assert.equal(denied.finalized, false);
-        assert.equal(denied.cleanup.comparison?.status, 'denied');
-        assert.match(denied.cleanup.comparison?.reason ?? '', /unsupported-directory-capability:platform/);
+        const finalized = await finalizeBoundOnce(stale as LaunchSessionBinding, 'stale-unsupported');
+        assert.equal(finalized.finalized, true);
+        assert.equal(finalized.cleanup.comparison?.status, 'matched');
+        assert.match(finalized.cleanup.comparison?.reason ?? '', /unsupported-directory-capability:platform/);
       });
-      assert.equal(await readFile(context.sessionPath, 'utf-8'), staleBytes);
-      assert.equal(await readFile(historyPath, 'utf-8'), historyBeforeStaleCleanup, 'stale evidence is denied before lifecycle history mutation');
+      assert.equal(existsSync(context.sessionPath), false);
+      const history = await readFile(historyPath, 'utf-8');
+      assert.match(history, /native-unsupported-stale/);
     } finally {
       if (ordinary) await closeLaunchSessionBindingOnce(ordinary).catch(() => {});
       if (stale) await closeLaunchSessionBindingOnce(stale).catch(() => {});

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -1442,6 +1442,7 @@ async function writePointerTransaction<T>(
   transition: (pointer: SessionPointerReadResult, context: SessionPointerContext) => T | Promise<T>,
   pointerState: (value: T) => SessionState,
   beforeCommit?: (context: SessionPointerContext) => Promise<void>,
+  afterCommit?: (context: SessionPointerContext) => Promise<void>,
 ): Promise<PointerTransactionResult<T>> {
   let context: SessionPointerContext;
   try {
@@ -1486,6 +1487,7 @@ async function writePointerTransaction<T>(
   );
   const pointerTempPath = `${context.sessionPath}.tmp-${lock.token}`;
   let pointerCommitted = false;
+  let pointerTempWritten = false;
 
   try {
     let pointer: SessionPointerReadResult;
@@ -1518,6 +1520,7 @@ async function writePointerTransaction<T>(
 
     const serialized = JSON.stringify(pointerState(next), null, 2);
     try {
+      pointerTempWritten = true;
       await transactionDependencies.fs.writeFile(pointerTempPath, serialized, { mode: 0o600, flag: 'wx' });
     } catch (error) {
       throw resolvedAbort(context, {
@@ -1548,7 +1551,23 @@ async function writePointerTransaction<T>(
     try {
       await transactionDependencies.fs.rename(pointerTempPath, context.sessionPath);
       pointerCommitted = true;
+      if (afterCommit) {
+        try {
+          await afterCommit(context);
+        } catch (error) {
+          const releaseFailures = await releasePointerLock(lock);
+          throw releaseFailureError([
+            {
+              operation: 'lock-release', phase: 'rename', ownership: 'uncertain',
+              message: `Selected state root identity changed after pointer publication: ${errorMessage(error)}`,
+              cause: error, evidencePath: context.sessionPath,
+            },
+            ...releaseFailures,
+          ], context, next);
+        }
+      }
     } catch (error) {
+      if (error instanceof CommittedLaunchBlockedError) throw error;
       throw resolvedAbort(context, {
         code: 'session_pointer_io_failure',
         operation: 'pointer-rename',
@@ -1575,9 +1594,7 @@ async function writePointerTransaction<T>(
         reason: `Session pointer transition failed before commit: ${errorMessage(error)}`,
         cause: error,
       });
-    const ownsPointerTemp = primary.operation === 'pointer-temp-write'
-      || primary.operation === 'pointer-fsync'
-      || primary.operation === 'pointer-rename';
+    const ownsPointerTemp = pointerTempWritten;
     throw await finalizePrecommitAbort(lock, primary, ownsPointerTemp ? pointerTempPath : undefined);
   }
 }
@@ -1680,6 +1697,7 @@ async function writeSessionStartTransition(
   requireLaunchLineageToken = false,
   requireAbsent = false,
   beforeCommit?: (context: SessionPointerContext) => Promise<void>,
+  afterCommit?: (context: SessionPointerContext) => Promise<void>,
 ): Promise<SessionState> {
   const requestedSessionId = normalizeSessionId(sessionId);
   const result = await writePointerTransaction(
@@ -1690,6 +1708,7 @@ async function writeSessionStartTransition(
     startPointerTransition(requestedSessionId ?? sessionId, options, requireLaunchLineageToken, requireAbsent),
     (state) => state,
     beforeCommit,
+    afterCommit,
   );
   await appendToLogAtContext(result.context, {
     event: 'session_start',
@@ -1815,30 +1834,34 @@ export async function establishLaunchSessionBinding(
   }
   const acquired = await acquireDirectoryCapability(context.baseStateDir, platform);
   const cleanup = (): EstablishmentCleanupEvidence => ({ capability: acquired.cleanup });
-  try {
-    const state = await writeSessionStartTransition(context.cwd, requestedSessionId, { ...options, context }, true, true, async (lockedContext) => {
-      if (acquired.identity.kind !== 'supported') return;
-      const retained = await acquired.lease.handle?.stat({ bigint: true });
-      if (!retained || !retained.isDirectory() || retained.dev !== acquired.identity.dev || retained.ino !== acquired.identity.ino) {
+  const revalidateSelectedRoot = async (lockedContext: SessionPointerContext): Promise<void> => {
+    if (acquired.identity.kind !== 'supported') return;
+    const retained = await acquired.lease.handle?.stat({ bigint: true });
+    if (!retained || !retained.isDirectory() || retained.dev !== acquired.identity.dev || retained.ino !== acquired.identity.ino) {
+      throw resolvedAbort(lockedContext, {
+        code: 'session_pointer_io_failure', operation: 'pointer-classify', candidateSessionId: normalizeSessionId(requestedSessionId),
+        lockPath: lockedContext.lockPath, reason: 'Selected state root identity changed during pointer publication.',
+      });
+    }
+    const canonical = await realpath(lockedContext.baseStateDir);
+    const fresh = await open(canonical, 'r');
+    try {
+      const stats = await fresh.stat({ bigint: true });
+      if (canonical !== acquired.canonicalRealpath || !stats.isDirectory() || stats.dev !== acquired.identity.dev || stats.ino !== acquired.identity.ino) {
         throw resolvedAbort(lockedContext, {
           code: 'session_pointer_io_failure', operation: 'pointer-classify', candidateSessionId: normalizeSessionId(requestedSessionId),
-          lockPath: lockedContext.lockPath, reason: 'Selected state root identity changed before pointer publication.',
+          lockPath: lockedContext.lockPath, reason: 'Selected state root was replaced during pointer publication.',
         });
       }
-      const canonical = await realpath(lockedContext.baseStateDir);
-      const fresh = await open(canonical, 'r');
-      try {
-        const stats = await fresh.stat({ bigint: true });
-        if (canonical !== acquired.canonicalRealpath || !stats.isDirectory() || stats.dev !== acquired.identity.dev || stats.ino !== acquired.identity.ino) {
-          throw resolvedAbort(lockedContext, {
-            code: 'session_pointer_io_failure', operation: 'pointer-classify', candidateSessionId: normalizeSessionId(requestedSessionId),
-            lockPath: lockedContext.lockPath, reason: 'Selected state root was replaced before pointer publication.',
-          });
-        }
-      } finally {
-        await fresh.close();
-      }
-    });
+    } finally {
+      await fresh.close();
+    }
+  };
+  try {
+    const state = await writeSessionStartTransition(
+      context.cwd, requestedSessionId, { ...options, context }, true, true,
+      revalidateSelectedRoot, revalidateSelectedRoot,
+    );
     const token = state.launch_lineage_token;
     if (!isValidToken(token)) {
       const close = await closeLease(acquired.lease, 'before-authorization');

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -1438,6 +1438,7 @@ async function writePointerTransaction<T>(
   timeoutMs: number,
   transition: (pointer: SessionPointerReadResult, context: SessionPointerContext) => T | Promise<T>,
   pointerState: (value: T) => SessionState,
+  beforeCommit?: (context: SessionPointerContext) => Promise<void>,
 ): Promise<PointerTransactionResult<T>> {
   let context: SessionPointerContext;
   try {
@@ -1540,6 +1541,7 @@ async function writePointerTransaction<T>(
         cause: error,
       });
     }
+    if (beforeCommit) await beforeCommit(context);
     try {
       await transactionDependencies.fs.rename(pointerTempPath, context.sessionPath);
       pointerCommitted = true;
@@ -1674,6 +1676,7 @@ async function writeSessionStartTransition(
   options: SessionStartOptions,
   requireLaunchLineageToken = false,
   requireAbsent = false,
+  beforeCommit?: (context: SessionPointerContext) => Promise<void>,
 ): Promise<SessionState> {
   const requestedSessionId = normalizeSessionId(sessionId);
   const result = await writePointerTransaction(
@@ -1683,6 +1686,7 @@ async function writeSessionStartTransition(
     DEFAULT_POINTER_TIMEOUT_MS,
     startPointerTransition(requestedSessionId ?? sessionId, options, requireLaunchLineageToken, requireAbsent),
     (state) => state,
+    beforeCommit,
   );
   await appendToLogAtContext(result.context, {
     event: 'session_start',
@@ -1809,7 +1813,29 @@ export async function establishLaunchSessionBinding(
   const acquired = await acquireDirectoryCapability(context.baseStateDir, platform);
   const cleanup = (): EstablishmentCleanupEvidence => ({ capability: acquired.cleanup });
   try {
-    const state = await writeSessionStartTransition(context.cwd, requestedSessionId, { ...options, context }, true, true);
+    const state = await writeSessionStartTransition(context.cwd, requestedSessionId, { ...options, context }, true, true, async (lockedContext) => {
+      if (acquired.identity.kind !== 'supported') return;
+      const retained = await acquired.lease.handle?.stat({ bigint: true });
+      if (!retained || !retained.isDirectory() || retained.dev !== acquired.identity.dev || retained.ino !== acquired.identity.ino) {
+        throw resolvedAbort(lockedContext, {
+          code: 'session_pointer_io_failure', operation: 'pointer-classify', candidateSessionId: normalizeSessionId(requestedSessionId),
+          lockPath: lockedContext.lockPath, reason: 'Selected state root identity changed before pointer publication.',
+        });
+      }
+      const canonical = await realpath(lockedContext.baseStateDir);
+      const fresh = await open(canonical, 'r');
+      try {
+        const stats = await fresh.stat({ bigint: true });
+        if (canonical !== acquired.canonicalRealpath || !stats.isDirectory() || stats.dev !== acquired.identity.dev || stats.ino !== acquired.identity.ino) {
+          throw resolvedAbort(lockedContext, {
+            code: 'session_pointer_io_failure', operation: 'pointer-classify', candidateSessionId: normalizeSessionId(requestedSessionId),
+            lockPath: lockedContext.lockPath, reason: 'Selected state root was replaced before pointer publication.',
+          });
+        }
+      } finally {
+        await fresh.close();
+      }
+    });
     const token = state.launch_lineage_token;
     if (!isValidToken(token)) {
       const close = await closeLease(acquired.lease, 'before-authorization');

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -11,6 +11,7 @@ import {
   open,
   readFile as nodeReadFile,
   readdir as nodeReaddir,
+  realpath,
   rename as nodeRename,
   rmdir as nodeRmdir,
   rm,
@@ -18,6 +19,7 @@ import {
   writeFile as nodeWriteFile,
 } from 'fs/promises';
 import { readFileSync } from 'fs';
+import type { FileHandle } from 'fs/promises';
 import { createHash, randomUUID } from 'crypto';
 import { dirname, join } from 'path';
 import { omxRoot, omxLogsDir, sameFilePath } from '../utils/paths.js';
@@ -51,6 +53,8 @@ export interface SessionState {
   pid_cmdline?: string;
   tmux_session_name?: string;
   tmux_pane_id?: string;
+  /** Private wrapper lineage evidence; native reconciliation never creates or repairs it. */
+  launch_lineage_token?: string;
 }
 
 export interface SessionPointerContext {
@@ -99,6 +103,7 @@ export type SessionPointerCleanupPhase =
   | 'remove-pointer-temp'
   | 'token-check'
   | 'rename'
+  | 'remove-release-owner'
   | 'remove-release-dir';
 
 export interface SessionPointerSecondaryFailure {
@@ -152,6 +157,63 @@ export interface ResolvedSessionPointerAbort extends SessionPointerAbortBase {
 export type SessionPointerLaunchAbort =
   | SessionPointerContextAbort
   | ResolvedSessionPointerAbort;
+
+export type UnsupportedDirectoryCapabilityReason = 'platform' | 'inadequate-identity' | 'stat-feature';
+export type CapabilityCloseEvidence = Readonly<{
+  role: 'acquisition' | 'fresh-comparison' | 'original-retained';
+  phase: 'before-authorization' | 'post-finalization' | 'detached-pre-release';
+  status: 'not-needed' | 'closed' | 'failed';
+  error?: Readonly<{ name: string; message: string; code?: string }>;
+}>;
+export interface EstablishmentCleanupEvidence {
+  readonly capability: readonly CapabilityCloseEvidence[];
+}
+export interface LifecycleCleanupEvidence extends EstablishmentCleanupEvidence {
+  readonly comparison?: Readonly<{ status: 'not-run' | 'matched' | 'denied'; reason?: string }>;
+}
+export interface LaunchSessionBinding {
+  readonly context: Readonly<SessionPointerContext>;
+  readonly canonicalRealpath: string;
+  readonly directoryIdentity: Readonly<
+    | { kind: 'supported'; dev: bigint; ino: bigint }
+    | { kind: 'unsupported'; reason: UnsupportedDirectoryCapabilityReason }
+  >;
+  readonly canonicalSessionId: string;
+  readonly ownerOmxSessionId?: string;
+  readonly nativeSessionId?: string;
+  readonly startedAt: string;
+  readonly launchLineageToken: string;
+}
+export interface CommittedLaunchEvidence {
+  readonly context: Readonly<SessionPointerContext>;
+  readonly canonicalSessionId: string;
+}
+export class CommittedLaunchBlockedError extends Error {
+  readonly name = 'CommittedLaunchBlockedError';
+  constructor(readonly secondaryFailures: readonly SessionPointerSecondaryFailure[]) {
+    super('Session pointer committed, but lock release left recovery evidence.');
+  }
+}
+export type LaunchEstablishment =
+  | { kind: 'precommit-aborted'; abort: SessionPointerLaunchAbort; cleanup: EstablishmentCleanupEvidence }
+  | { kind: 'committed-released'; binding: LaunchSessionBinding; cleanup: EstablishmentCleanupEvidence }
+  | {
+      kind: 'committed-release-failed'; evidence: CommittedLaunchEvidence; error: CommittedLaunchBlockedError;
+      lockDisposition: 'held' | 'released-with-residue' | 'uncertain';
+      secondaryFailures: readonly SessionPointerSecondaryFailure[]; cleanup: EstablishmentCleanupEvidence;
+    };
+export type DetachedMetadataUpdate =
+  | { kind: 'precommit-aborted'; abort: SessionPointerLaunchAbort; cleanup: EstablishmentCleanupEvidence }
+  | { kind: 'committed-released'; evidence: CommittedLaunchEvidence; cleanup: EstablishmentCleanupEvidence }
+  | {
+      kind: 'committed-release-failed'; evidence: CommittedLaunchEvidence; error: CommittedLaunchBlockedError;
+      lockDisposition: 'held' | 'released-with-residue' | 'uncertain';
+      secondaryFailures: readonly SessionPointerSecondaryFailure[]; cleanup: EstablishmentCleanupEvidence;
+    };
+export interface BoundFinalizationReport {
+  readonly cleanup: LifecycleCleanupEvidence;
+  readonly finalized: boolean;
+}
 
 const SESSION_FILE = 'session.json';
 const HISTORY_FILE = 'session-history.jsonl';
@@ -644,6 +706,7 @@ function createSessionState(
   options: {
     nowIso?: string;
     nativeSessionId?: string;
+    launchLineageToken?: string;
     previousNativeSessionId?: string;
     nativeSessionSwitchedAt?: string;
     ownerOmxSessionId?: string;
@@ -666,6 +729,7 @@ function createSessionState(
     ...(nativeSessionSwitchedAt ? { native_session_switched_at: nativeSessionSwitchedAt } : {}),
     ...(ownerOmxSessionId ? { owner_omx_session_id: ownerOmxSessionId } : {}),
     started_at: options.startedAt ?? nowIso,
+    ...(isValidToken(options.launchLineageToken) ? { launch_lineage_token: options.launchLineageToken } : {}),
     cwd,
     pid,
     platform,
@@ -674,6 +738,12 @@ function createSessionState(
     ...(tmuxSessionName ? { tmux_session_name: tmuxSessionName } : {}),
     ...(tmuxPaneId ? { tmux_pane_id: tmuxPaneId } : {}),
   };
+}
+
+function preserveExistingLaunchLineageToken(existing: SessionState | undefined, state: SessionState): SessionState {
+  return existing && Object.hasOwn(existing, 'launch_lineage_token')
+    ? { ...state, launch_lineage_token: existing.launch_lineage_token }
+    : state;
 }
 
 function normalizeNonempty(value: unknown): string | undefined {
@@ -722,11 +792,6 @@ function isStartCompatible(existing: SessionState, requestedSessionId: string): 
     || currentOwnerAlias(existing) === requestedSessionId;
 }
 
-function getOmxLaunchSessionId(state: SessionState): string | undefined {
-  if (state.session_id.startsWith('omx-')) return state.session_id;
-  const owner = currentOwnerAlias(state);
-  return owner?.startsWith('omx-') ? owner : undefined;
-}
 
 interface SessionPointerLockOwnerV1 {
   version: 1;
@@ -1081,7 +1146,7 @@ async function releasePointerLock(lock: HeldPointerLock): Promise<SessionPointer
     if (!isNotFound(error)) {
       return [{
         operation: 'lock-release',
-        phase: 'remove-release-dir',
+        phase: 'remove-release-owner',
         ownership: 'released',
         message: `Unable to remove released session pointer lock owner: ${errorMessage(error)}`,
         cause: error,
@@ -1125,9 +1190,16 @@ function recoveryAbort(
   });
 }
 
-function releaseFailureError(failures: readonly SessionPointerSecondaryFailure[]): Error {
-  const error = new Error('Session pointer committed, but lock release left recovery evidence.');
-  Object.assign(error, { secondaryFailures: failures });
+function releaseFailureError<T>(
+  failures: readonly SessionPointerSecondaryFailure[],
+  context?: SessionPointerContext,
+  value?: T,
+): CommittedLaunchBlockedError & { context?: SessionPointerContext; value?: T } {
+  const error = new CommittedLaunchBlockedError(failures) as CommittedLaunchBlockedError & {
+    context?: SessionPointerContext; value?: T;
+  };
+  if (context) error.context = context;
+  if (value !== undefined) error.value = value;
   return error;
 }
 
@@ -1199,7 +1271,7 @@ async function writePointerTransaction<T>(
   candidateSessionId: string | undefined,
   options: Pick<SessionStartOptions, 'context' | 'platform' | 'regularFileSync'>,
   timeoutMs: number,
-  transition: (pointer: SessionPointerReadResult, context: SessionPointerContext) => T,
+  transition: (pointer: SessionPointerReadResult, context: SessionPointerContext) => T | Promise<T>,
   pointerState: (value: T) => SessionState,
 ): Promise<PointerTransactionResult<T>> {
   let context: SessionPointerContext;
@@ -1263,7 +1335,7 @@ async function writePointerTransaction<T>(
 
     let next: T;
     try {
-      next = transition(pointer, context);
+      next = await transition(pointer, context);
     } catch (error) {
       if (isSessionPointerLaunchAbort(error)) throw error;
       const state = pointer.state;
@@ -1318,7 +1390,7 @@ async function writePointerTransaction<T>(
     }
 
     const releaseFailures = await releasePointerLock(lock);
-    if (releaseFailures.length > 0) throw releaseFailureError(releaseFailures);
+    if (releaseFailures.length > 0) throw releaseFailureError(releaseFailures, context, next);
     emitDegradedDurabilityWarning('session pointer start/reconcile', tracker);
     return { context, value: next };
   } catch (error) {
@@ -1343,14 +1415,25 @@ async function writePointerTransaction<T>(
 function startPointerTransition(
   requestedSessionId: string,
   options: SessionStartOptions,
+  requireLaunchLineageToken = false,
+  requireAbsent = false,
 ): (pointer: SessionPointerReadResult, context: SessionPointerContext) => SessionState {
   return (pointer, context) => {
+    if (requireAbsent && pointer.status !== 'absent') {
+      if (pointer.status === 'usable' && pointer.state) {
+        throw ownerConflictAbort(context, requestedSessionId, pointer.state);
+      }
+      throw unusablePointerAbort(context, requestedSessionId, pointer);
+    }
     if (pointer.status !== 'absent' && pointer.status !== 'stale-dead' && pointer.status !== 'usable') {
       throw unusablePointerAbort(context, requestedSessionId, pointer);
     }
 
     const existing = pointer.status === 'usable' ? pointer.state : undefined;
     if (existing && !isStartCompatible(existing, requestedSessionId)) {
+      throw ownerConflictAbort(context, requestedSessionId, existing);
+    }
+    if (requireLaunchLineageToken && existing && !isValidToken(existing.launch_lineage_token)) {
       throw ownerConflictAbort(context, requestedSessionId, existing);
     }
 
@@ -1374,22 +1457,58 @@ function startPointerTransition(
       }, error);
     }
 
-    return createSessionState(context.cwd, canonicalSessionId, pid, platform, sessionIdentityFor(pid, platform), {
+    const state = createSessionState(context.cwd, canonicalSessionId, pid, platform, sessionIdentityFor(pid, platform), {
       nativeSessionId: options.nativeSessionId ?? existing?.native_session_id,
       previousNativeSessionId: options.previousNativeSessionId ?? existing?.previous_native_session_id,
       nativeSessionSwitchedAt: options.nativeSessionSwitchedAt ?? existing?.native_session_switched_at,
       ...(ownerOmxSessionId ? { ownerOmxSessionId } : {}),
+      launchLineageToken: existing
+        ? (isValidToken(existing.launch_lineage_token) ? existing.launch_lineage_token : undefined)
+        : transactionDependencies.token(),
       tmuxSessionName: options.tmuxSessionName ?? existing?.tmux_session_name,
       tmuxPaneId: options.tmuxPaneId ?? existing?.tmux_pane_id,
     });
+    return preserveExistingLaunchLineageToken(existing, state);
   };
 }
 
-/** Write or merge a wrapper-owned canonical pointer through the exact-root transaction. */
+/** Create a wrapper-owned canonical pointer only when the selected pointer is absent. */
 export async function writeSessionStart(
   cwd: string,
   sessionId: string,
   options: SessionStartOptions = {},
+): Promise<SessionState> {
+  const candidateSessionId = normalizeSessionId(sessionId);
+  let context: SessionPointerContext;
+  try {
+    context = options.context ?? resolveSessionPointerContext(cwd);
+  } catch (error) {
+    throw contextAbort(cwd, candidateSessionId, error);
+  }
+  let pointer: SessionPointerReadResult;
+  try {
+    pointer = await readSessionPointer(context);
+  } catch (error) {
+    throw resolvedAbort(context, {
+      code: 'session_pointer_io_failure', operation: 'pointer-read', candidateSessionId,
+      lockPath: context.lockPath, reason: `Unable to read selected session pointer: ${errorMessage(error)}`, cause: error,
+    });
+  }
+  if (pointer.status !== 'absent') {
+    if (pointer.status === 'usable' && pointer.state) {
+      throw ownerConflictAbort(context, candidateSessionId ?? sessionId, pointer.state);
+    }
+    throw unusablePointerAbort(context, candidateSessionId ?? sessionId, pointer);
+  }
+  return await writeSessionStartTransition(cwd, sessionId, { ...options, context });
+}
+
+async function writeSessionStartTransition(
+  cwd: string,
+  sessionId: string,
+  options: SessionStartOptions,
+  requireLaunchLineageToken = false,
+  requireAbsent = false,
 ): Promise<SessionState> {
   const requestedSessionId = normalizeSessionId(sessionId);
   const result = await writePointerTransaction(
@@ -1397,7 +1516,7 @@ export async function writeSessionStart(
     requestedSessionId,
     options,
     DEFAULT_POINTER_TIMEOUT_MS,
-    startPointerTransition(requestedSessionId ?? sessionId, options),
+    startPointerTransition(requestedSessionId ?? sessionId, options, requireLaunchLineageToken, requireAbsent),
     (state) => state,
   );
   await appendToLogAtContext(result.context, {
@@ -1408,6 +1527,416 @@ export async function writeSessionStart(
     timestamp: result.value.started_at,
   }).catch(() => {});
   return result.value;
+}
+
+const DIRECTORY_CAPABILITY_PLATFORMS = new Set<NodeJS.Platform>([
+  'linux', 'darwin', 'freebsd', 'openbsd', 'netbsd', 'sunos',
+]);
+
+export class LaunchContextResolutionError extends Error {
+  readonly name = 'LaunchContextResolutionError';
+  constructor(readonly cleanup: EstablishmentCleanupEvidence, cause: unknown) {
+    super(`Unable to establish launch directory capability: ${errorMessage(cause)}`, { cause });
+  }
+}
+
+interface BindingLease {
+  handle?: FileHandle;
+  closed: boolean;
+  closeEvidence?: CapabilityCloseEvidence;
+}
+const bindingLeases = new WeakMap<LaunchSessionBinding, BindingLease>();
+const bindingFinalizations = new WeakMap<LaunchSessionBinding, Promise<BoundFinalizationReport>>();
+
+function safeError(error: unknown): Readonly<{ name: string; message: string; code?: string }> {
+  return {
+    name: error instanceof Error ? error.name : 'Error',
+    message: errorMessage(error),
+    ...(errorCode(error) ? { code: errorCode(error) } : {}),
+  };
+}
+
+function lockDisposition(failures: readonly SessionPointerSecondaryFailure[]): 'held' | 'released-with-residue' | 'uncertain' {
+  if (failures.some((failure) => failure.ownership === 'uncertain')) return 'uncertain';
+  return failures.some((failure) => failure.ownership === 'held') ? 'held' : 'released-with-residue';
+}
+
+async function acquireDirectoryCapability(
+  cwd: string,
+  platform: NodeJS.Platform,
+): Promise<{ canonicalRealpath: string; identity: LaunchSessionBinding['directoryIdentity']; lease: BindingLease; cleanup: CapabilityCloseEvidence[] }> {
+  const cleanup: CapabilityCloseEvidence[] = [];
+  let canonicalRealpath: string;
+  try {
+    canonicalRealpath = await realpath(cwd);
+  } catch (error) {
+    throw new LaunchContextResolutionError({ capability: cleanup }, error);
+  }
+  if (!DIRECTORY_CAPABILITY_PLATFORMS.has(platform)) {
+    return { canonicalRealpath, identity: { kind: 'unsupported', reason: 'platform' }, lease: { closed: false }, cleanup };
+  }
+  let handle: FileHandle;
+  try {
+    handle = await open(canonicalRealpath, 'r');
+  } catch (error) {
+    throw new LaunchContextResolutionError({ capability: cleanup }, error);
+  }
+  let statFailure: unknown;
+  try {
+    const stats = await handle.stat({ bigint: true });
+    if (!stats.isDirectory() || typeof stats.dev !== 'bigint' || typeof stats.ino !== 'bigint' || stats.dev <= 0n || stats.ino <= 0n) {
+      try {
+        await handle.close();
+        cleanup.push({ role: 'acquisition', phase: 'before-authorization', status: 'closed' });
+      } catch (closeError) {
+        cleanup.push({ role: 'acquisition', phase: 'before-authorization', status: 'failed', error: safeError(closeError) });
+        throw new LaunchContextResolutionError({ capability: cleanup }, closeError);
+      }
+      return { canonicalRealpath, identity: { kind: 'unsupported', reason: 'inadequate-identity' }, lease: { closed: false }, cleanup };
+    }
+    return { canonicalRealpath, identity: { kind: 'supported', dev: stats.dev, ino: stats.ino }, lease: { handle, closed: false }, cleanup };
+  } catch (error) {
+    if (error instanceof LaunchContextResolutionError) throw error;
+    statFailure = error;
+  }
+  try {
+    await handle.close();
+    cleanup.push({ role: 'acquisition', phase: 'before-authorization', status: 'closed' });
+  } catch (closeError) {
+    cleanup.push({ role: 'acquisition', phase: 'before-authorization', status: 'failed', error: safeError(closeError) });
+    throw new LaunchContextResolutionError({ capability: cleanup }, closeError);
+  }
+  const code = errorCode(statFailure);
+  if (code === 'ENOSYS' || code === 'ENOTSUP' || code === 'EOPNOTSUPP' || code === 'EINVAL') {
+    return { canonicalRealpath, identity: { kind: 'unsupported', reason: 'stat-feature' }, lease: { closed: false }, cleanup };
+  }
+  throw new LaunchContextResolutionError({ capability: cleanup }, statFailure);
+}
+
+export async function closeLaunchSessionBindingOnce(
+  binding: LaunchSessionBinding,
+  phase: CapabilityCloseEvidence['phase'] = 'post-finalization',
+): Promise<CapabilityCloseEvidence> {
+  const lease = bindingLeases.get(binding);
+  if (!lease || lease.closed) return lease?.closeEvidence ?? { role: 'original-retained', phase, status: 'not-needed' };
+  lease.closed = true;
+  try {
+    await lease.handle?.close();
+    return lease.closeEvidence = { role: 'original-retained', phase, status: 'closed' };
+  } catch (error) {
+    return lease.closeEvidence = { role: 'original-retained', phase, status: 'failed', error: safeError(error) };
+  }
+}
+
+export async function establishLaunchSessionBinding(
+  cwd: string,
+  requestedSessionId: string,
+  options: SessionStartOptions = {},
+): Promise<LaunchEstablishment> {
+  const platform = options.platform ?? process.platform;
+  let context: SessionPointerContext;
+  try {
+    context = options.context ?? resolveSessionPointerContext(cwd);
+    await transactionDependencies.fs.mkdir(context.baseStateDir, { recursive: true });
+  } catch (error) {
+    throw new LaunchContextResolutionError({ capability: [] }, error);
+  }
+  const acquired = await acquireDirectoryCapability(context.baseStateDir, platform);
+  const cleanup = (): EstablishmentCleanupEvidence => ({ capability: acquired.cleanup });
+  try {
+    const state = await writeSessionStartTransition(context.cwd, requestedSessionId, { ...options, context }, true, true);
+    const token = state.launch_lineage_token;
+    if (!isValidToken(token)) {
+      const close = await closeLease(acquired.lease, 'before-authorization');
+      if (close) acquired.cleanup.push(close);
+      throw new LaunchContextResolutionError(cleanup(), new Error('Committed session pointer lacks a valid lineage token.'));
+    }
+    const binding: LaunchSessionBinding = Object.freeze({
+      context: Object.freeze({ ...context }), canonicalRealpath: acquired.canonicalRealpath,
+      directoryIdentity: acquired.identity, canonicalSessionId: state.session_id,
+      ...(state.owner_omx_session_id ? { ownerOmxSessionId: state.owner_omx_session_id } : {}),
+      ...(state.native_session_id ? { nativeSessionId: state.native_session_id } : {}),
+      startedAt: state.started_at, launchLineageToken: token,
+    });
+    bindingLeases.set(binding, acquired.lease);
+    return { kind: 'committed-released', binding, cleanup: cleanup() };
+  } catch (error) {
+    if (error instanceof CommittedLaunchBlockedError) {
+      const state = (error as CommittedLaunchBlockedError & { value?: SessionState }).value;
+      const errorContext = (error as CommittedLaunchBlockedError & { context?: SessionPointerContext }).context ?? context;
+      const close = await closeLease(acquired.lease, 'before-authorization');
+      if (close) acquired.cleanup.push(close);
+      return {
+        kind: 'committed-release-failed', evidence: { context: errorContext, canonicalSessionId: state?.session_id ?? requestedSessionId },
+        error, lockDisposition: lockDisposition(error.secondaryFailures), secondaryFailures: error.secondaryFailures, cleanup: cleanup(),
+      };
+    }
+    const close = await closeLease(acquired.lease, 'before-authorization');
+    if (close) acquired.cleanup.push(close);
+    if (isSessionPointerLaunchAbort(error)) return { kind: 'precommit-aborted', abort: error, cleanup: cleanup() };
+    throw error;
+  }
+}
+
+async function closeLease(lease: BindingLease, phase: CapabilityCloseEvidence['phase']): Promise<CapabilityCloseEvidence | undefined> {
+  if (lease.closed) return undefined;
+  lease.closed = true;
+  try {
+    await lease.handle?.close();
+    return { role: 'acquisition', phase, status: 'closed' };
+  } catch (error) {
+    return { role: 'acquisition', phase, status: 'failed', error: safeError(error) };
+  }
+}
+
+export async function updateDetachedSessionMetadata(
+  binding: LaunchSessionBinding,
+  patch: { tmuxSessionName?: string; tmuxPaneId?: string },
+): Promise<DetachedMetadataUpdate> {
+  const capability: CapabilityCloseEvidence[] = [];
+  const cleanup: EstablishmentCleanupEvidence = { capability };
+  try {
+    let pointerBeforeTransaction: SessionPointerReadResult;
+    try {
+      pointerBeforeTransaction = await readSessionPointer(binding.context);
+    } catch (error) {
+      throw resolvedAbort(binding.context, {
+        code: 'session_pointer_io_failure', operation: 'pointer-read', candidateSessionId: binding.canonicalSessionId,
+        lockPath: binding.context.lockPath, reason: `Unable to read selected session pointer: ${errorMessage(error)}`, cause: error,
+      });
+    }
+    if (pointerBeforeTransaction.status !== 'usable'
+      || !isAuthorizedBoundPointer(binding, binding.context, binding.canonicalSessionId, pointerBeforeTransaction.state)) {
+      throw unusablePointerAbort(binding.context, binding.canonicalSessionId, pointerBeforeTransaction);
+    }
+    if (binding.directoryIdentity.kind !== 'supported') {
+      throw unusablePointerAbort(binding.context, binding.canonicalSessionId, pointerBeforeTransaction);
+    }
+    const authorization = await authorizeBoundDirectoryBeforeTransaction(
+      binding,
+      pointerBeforeTransaction,
+      binding.context.cwd,
+    );
+    capability.push(...authorization.capability);
+
+    const result = await writePointerTransaction(
+      binding.context.cwd,
+      binding.canonicalSessionId,
+      { context: binding.context },
+      DEFAULT_POINTER_TIMEOUT_MS,
+      async (pointer, context) => {
+        const state = pointer.status === 'usable' ? pointer.state : undefined;
+        if (!state || !isAuthorizedBoundPointer(binding, context, binding.canonicalSessionId, state)) {
+          throw unusablePointerAbort(context, binding.canonicalSessionId, pointer);
+        }
+        await consumeBoundDirectoryAuthorizationUnderLock(binding, authorization, pointer);
+        return {
+          ...state,
+          ...(patch.tmuxSessionName !== undefined ? { tmux_session_name: patch.tmuxSessionName } : {}),
+          ...(patch.tmuxPaneId !== undefined ? { tmux_pane_id: patch.tmuxPaneId } : {}),
+        };
+      },
+      (state) => state,
+    );
+    return { kind: 'committed-released', evidence: { context: result.context, canonicalSessionId: binding.canonicalSessionId }, cleanup };
+  } catch (error) {
+    if (error instanceof CommittedLaunchBlockedError) {
+      const context = (error as CommittedLaunchBlockedError & { context?: SessionPointerContext }).context ?? binding.context;
+      return { kind: 'committed-release-failed', evidence: { context, canonicalSessionId: binding.canonicalSessionId }, error,
+        lockDisposition: lockDisposition(error.secondaryFailures), secondaryFailures: error.secondaryFailures, cleanup };
+    }
+    if (isSessionPointerLaunchAbort(error)) return { kind: 'precommit-aborted', abort: error, cleanup };
+    throw error;
+  }
+}
+
+function isAuthorizedBoundPointer(
+  binding: LaunchSessionBinding,
+  context: SessionPointerContext,
+  candidateSessionId: string,
+  state: SessionState | undefined,
+): boolean {
+  const lease = bindingLeases.get(binding);
+  if (!lease || (binding.directoryIdentity.kind === 'supported' && lease.closed) || !state) return false;
+  if (!isValidToken(binding.launchLineageToken) || !isValidToken(state.launch_lineage_token)) return false;
+  if (candidateSessionId !== binding.canonicalSessionId) return false;
+  if (state.launch_lineage_token !== binding.launchLineageToken) return false;
+  if (state.started_at !== binding.startedAt) return false;
+  const directCanonicalIdentity = state.session_id === binding.canonicalSessionId
+    && ((state.owner_omx_session_id ?? undefined) === binding.ownerOmxSessionId
+      || (binding.ownerOmxSessionId === undefined && state.owner_omx_session_id === binding.canonicalSessionId))
+    && (binding.nativeSessionId === undefined || state.native_session_id === binding.nativeSessionId);
+  const replacedNativeIdentity = state.owner_omx_session_id === binding.canonicalSessionId
+    && normalizeSessionId(state.session_id) !== undefined
+    && state.native_session_id === state.session_id;
+  if (!directCanonicalIdentity && !replacedNativeIdentity) return false;
+  try {
+    return context.rootSource === binding.context.rootSource
+      && context.baseStateDir === binding.context.baseStateDir
+      && context.sessionPath === binding.context.sessionPath
+      && sameFilePath(context.cwd, binding.context.cwd)
+      && sameFilePath(state.cwd, binding.context.cwd);
+  } catch {
+    return false;
+  }
+}
+
+function isAuthorizedBoundStaleDeadPointer(
+  binding: LaunchSessionBinding,
+  context: SessionPointerContext,
+  candidateSessionId: string,
+  state: SessionState | undefined,
+): boolean {
+  return isAuthorizedBoundPointer(binding, context, candidateSessionId, state)
+    && Boolean(normalizeSessionId(state?.native_session_id));
+}
+
+interface BoundDirectoryAuthorization {
+  readonly comparison: LifecycleCleanupEvidence['comparison'];
+  readonly capability: CapabilityCloseEvidence[];
+  readonly pointerStatus: SessionPointerStatus;
+  readonly pointerRaw?: string;
+}
+
+class BoundDirectoryComparisonDenied extends Error {
+  constructor(readonly comparison: NonNullable<LifecycleCleanupEvidence['comparison']>, readonly capability: CapabilityCloseEvidence[]) {
+    super(comparison.reason);
+  }
+}
+
+async function authorizeBoundDirectoryBeforeTransaction(
+  binding: LaunchSessionBinding,
+  pointer: SessionPointerReadResult,
+  postLaunchCwd: string,
+): Promise<BoundDirectoryAuthorization> {
+  const capability: CapabilityCloseEvidence[] = [];
+  const lease = bindingLeases.get(binding);
+  if (!lease || lease.closed) {
+    throw new BoundDirectoryComparisonDenied({ status: 'denied', reason: 'binding-lease-closed' }, capability);
+  }
+  try {
+    if (!sameFilePath(binding.context.cwd, postLaunchCwd)
+      || !pointer.state?.cwd
+      || !sameFilePath(binding.context.cwd, pointer.state.cwd)) {
+      throw new BoundDirectoryComparisonDenied({ status: 'denied', reason: 'cwd-identity-mismatch' }, capability);
+    }
+    if (binding.directoryIdentity.kind !== 'supported') {
+      if (pointer.status === 'stale-dead') {
+        throw new BoundDirectoryComparisonDenied(
+          { status: 'denied', reason: `unsupported-directory-capability:${binding.directoryIdentity.reason}` },
+          capability,
+        );
+      }
+      return { comparison: { status: 'matched', reason: 'unsupported-ordinary-pointer' }, capability, pointerStatus: pointer.status, pointerRaw: pointer.raw };
+    }
+    const retained = await lease.handle?.stat({ bigint: true });
+    if (!retained || !retained.isDirectory() || retained.dev !== binding.directoryIdentity.dev || retained.ino !== binding.directoryIdentity.ino) {
+      throw new BoundDirectoryComparisonDenied({ status: 'denied', reason: 'retained-directory-identity-mismatch' }, capability);
+    }
+    const canonical = await realpath(binding.context.baseStateDir);
+    const handle = await open(canonical, 'r');
+    let matched = false;
+    try {
+      const stats = await handle.stat({ bigint: true });
+      matched = canonical === binding.canonicalRealpath
+        && stats.isDirectory()
+        && stats.dev === binding.directoryIdentity.dev
+        && stats.ino === binding.directoryIdentity.ino;
+    } finally {
+      try {
+        await handle.close();
+        capability.push({ role: 'fresh-comparison', phase: 'before-authorization', status: 'closed' });
+      } catch (error) {
+        capability.push({ role: 'fresh-comparison', phase: 'before-authorization', status: 'failed', error: safeError(error) });
+        throw new BoundDirectoryComparisonDenied({ status: 'denied', reason: 'fresh-comparison-close-failed' }, capability);
+      }
+    }
+    if (!matched) throw new BoundDirectoryComparisonDenied({ status: 'denied', reason: 'directory-identity-mismatch' }, capability);
+    return { comparison: { status: 'matched' }, capability, pointerStatus: pointer.status, pointerRaw: pointer.raw };
+  } catch (error) {
+    if (error instanceof BoundDirectoryComparisonDenied) throw error;
+    throw new BoundDirectoryComparisonDenied({ status: 'denied', reason: errorMessage(error) }, capability);
+  }
+}
+
+async function consumeBoundDirectoryAuthorizationUnderLock(
+  binding: LaunchSessionBinding,
+  authorization: BoundDirectoryAuthorization,
+  pointer: SessionPointerReadResult,
+): Promise<{ comparison: LifecycleCleanupEvidence['comparison']; capability: CapabilityCloseEvidence[] }> {
+  if (authorization.comparison?.status !== 'matched' || binding.directoryIdentity.kind !== 'supported') return authorization;
+  const lease = bindingLeases.get(binding);
+  try {
+    const retained = await lease?.handle?.stat({ bigint: true });
+    if (!retained || !retained.isDirectory() || retained.dev !== binding.directoryIdentity.dev || retained.ino !== binding.directoryIdentity.ino) {
+      throw new BoundDirectoryComparisonDenied({ status: 'denied', reason: 'retained-directory-identity-mismatch' }, authorization.capability);
+    }
+    if (!pointer.state?.cwd || !sameFilePath(binding.context.cwd, pointer.state.cwd)) {
+      throw new BoundDirectoryComparisonDenied(
+        { status: 'denied', reason: 'cwd-identity-mismatch-under-lock' },
+        authorization.capability,
+      );
+    }
+    const canonical = await realpath(binding.context.baseStateDir);
+    const handle = await open(canonical, 'r');
+    let matched = false;
+    try {
+      const stats = await handle.stat({ bigint: true });
+      matched = canonical === binding.canonicalRealpath
+        && stats.isDirectory()
+        && stats.dev === binding.directoryIdentity.dev
+        && stats.ino === binding.directoryIdentity.ino;
+    } finally {
+      try {
+        await handle.close();
+        authorization.capability.push({ role: 'fresh-comparison', phase: 'before-authorization', status: 'closed' });
+      } catch (error) {
+        authorization.capability.push({ role: 'fresh-comparison', phase: 'before-authorization', status: 'failed', error: safeError(error) });
+        throw new BoundDirectoryComparisonDenied(
+          { status: 'denied', reason: 'fresh-comparison-close-failed-under-lock' },
+          authorization.capability,
+        );
+      }
+    }
+    if (!matched) throw new BoundDirectoryComparisonDenied(
+      { status: 'denied', reason: 'directory-identity-mismatch-under-lock' },
+      authorization.capability,
+    );
+    if (pointer.status !== authorization.pointerStatus || pointer.raw !== authorization.pointerRaw) {
+      throw new BoundDirectoryComparisonDenied({ status: 'denied', reason: 'pointer-changed-before-consume' }, authorization.capability);
+    }
+    return authorization;
+  } catch (error) {
+    if (error instanceof BoundDirectoryComparisonDenied) throw error;
+    throw new BoundDirectoryComparisonDenied({ status: 'denied', reason: errorMessage(error) }, authorization.capability);
+  }
+}
+
+export function finalizeBoundOnce(
+  binding: LaunchSessionBinding,
+  _reason: string,
+  postLaunchCwd = binding.context.cwd,
+): Promise<BoundFinalizationReport> {
+  const existing = bindingFinalizations.get(binding);
+  if (existing) return existing;
+  const finalization = (async (): Promise<BoundFinalizationReport> => {
+    try {
+      const revalidation = await writeSessionEnd(binding.context.cwd, binding.canonicalSessionId, {
+        context: binding.context, binding, postLaunchCwd,
+      });
+      return { finalized: true, cleanup: { capability: revalidation.capability, comparison: revalidation.comparison } };
+    } catch (error) {
+      if (error instanceof BoundDirectoryComparisonDenied) {
+        return { finalized: false, cleanup: { capability: error.capability, comparison: error.comparison } };
+      }
+      if (isSessionPointerLaunchAbort(error)) {
+        return { finalized: false, cleanup: { capability: [], comparison: { status: 'denied', reason: error.code } } };
+      }
+      throw error;
+    }
+  })();
+  bindingFinalizations.set(binding, finalization);
+  return finalization;
 }
 
 interface NativeReconcileTransition {
@@ -1443,16 +1972,23 @@ function reconcileNativeTransition(
 
     const existingNativeSessionId = normalizeSessionId(existing.native_session_id);
     if (existingNativeSessionId && existingNativeSessionId !== nativeSessionId) {
-      const ownerOmxSessionId = getOmxLaunchSessionId(existing);
+      const ownerOmxSessionId = normalizeSessionId(existing.owner_omx_session_id)
+        ?? (isValidToken(existing.launch_lineage_token) ? existing.session_id : undefined);
       return {
-        state: createSessionState(context.cwd, nativeSessionId, pid, platform, linuxIdentity, {
+        state: preserveExistingLaunchLineageToken(existing, createSessionState(context.cwd, nativeSessionId, pid, platform, linuxIdentity, {
           nativeSessionId,
+          startedAt: existing.started_at,
           ...(ownerOmxSessionId ? {
             previousNativeSessionId: existingNativeSessionId,
             nativeSessionSwitchedAt: nowIso,
             ownerOmxSessionId,
           } : {}),
-        }),
+          tmuxSessionName: existing.tmux_session_name,
+          tmuxPaneId: existing.tmux_pane_id,
+          launchLineageToken: isValidToken(existing.launch_lineage_token)
+            ? existing.launch_lineage_token
+            : undefined,
+        })),
         ...(ownerOmxSessionId ? {
           replacementLog: {
             event: 'native_session_replaced',
@@ -1480,7 +2016,7 @@ function reconcileNativeTransition(
     }
 
     return {
-      state: createSessionState(context.cwd, existing.session_id, pid, platform, linuxIdentity, {
+      state: preserveExistingLaunchLineageToken(existing, createSessionState(context.cwd, existing.session_id, pid, platform, linuxIdentity, {
         nowIso,
         nativeSessionId,
         previousNativeSessionId: existing.previous_native_session_id,
@@ -1489,7 +2025,10 @@ function reconcileNativeTransition(
         startedAt: existing.started_at,
         tmuxSessionName: existing.tmux_session_name,
         tmuxPaneId: existing.tmux_pane_id,
-      }),
+        launchLineageToken: isValidToken(existing.launch_lineage_token)
+          ? existing.launch_lineage_token
+          : undefined,
+      })),
     };
   };
 }
@@ -1559,8 +2098,11 @@ async function removeDeadSessionHudState(
 export async function writeSessionEnd(
   cwd: string,
   sessionId: string,
-  options: Pick<SessionStartOptions, 'context' | 'platform' | 'regularFileSync'> = {},
-): Promise<void> {
+  options: Pick<SessionStartOptions, 'context' | 'platform' | 'regularFileSync'> & {
+    binding?: LaunchSessionBinding;
+    postLaunchCwd?: string;
+  } = {},
+): Promise<{ comparison: LifecycleCleanupEvidence['comparison']; capability: CapabilityCloseEvidence[] }> {
   const candidateSessionId = normalizeSessionId(sessionId);
   let context: SessionPointerContext;
   try {
@@ -1579,16 +2121,10 @@ export async function writeSessionEnd(
     });
   }
 
-  try {
-    await transactionDependencies.fs.mkdir(context.baseStateDir, { recursive: true });
-  } catch (error) {
+  if (!options.binding) {
     throw resolvedAbort(context, {
-      code: 'session_pointer_io_failure',
-      operation: 'state-dir-create',
-      candidateSessionId,
-      lockPath: context.lockPath,
-      reason: `Unable to create selected session state directory: ${errorMessage(error)}`,
-      cause: error,
+      code: 'session_pointer_io_failure', operation: 'pointer-classify', candidateSessionId,
+      lockPath: context.lockPath, reason: 'A live launch binding is required to end a session pointer.',
     });
   }
 
@@ -1603,6 +2139,9 @@ export async function writeSessionEnd(
     options.regularFileSync,
   );
   let primary: unknown;
+  let revalidation: { comparison: LifecycleCleanupEvidence['comparison']; capability: CapabilityCloseEvidence[] } = {
+    comparison: { status: 'not-run' }, capability: [],
+  };
   try {
     let pointer: SessionPointerReadResult;
     try {
@@ -1617,15 +2156,22 @@ export async function writeSessionEnd(
         cause: error,
       });
     }
-    if (pointer.status !== 'absent' && pointer.status !== 'usable') {
+    const authorizedBoundUsable = pointer.status === 'usable'
+      && isAuthorizedBoundPointer(options.binding, context, candidateSessionId, pointer.state);
+    const authorizedBoundStaleDead = pointer.status === 'stale-dead'
+      && isAuthorizedBoundStaleDeadPointer(options.binding, context, candidateSessionId, pointer.state);
+    if (!authorizedBoundUsable && !authorizedBoundStaleDead) {
       throw unusablePointerAbort(context, candidateSessionId, pointer);
     }
+    const authorization = await authorizeBoundDirectoryBeforeTransaction(
+      options.binding,
+      pointer,
+      options.postLaunchCwd ?? options.binding.context.cwd,
+    );
+    revalidation = await consumeBoundDirectoryAuthorizationUnderLock(options.binding, authorization, pointer);
 
-    const state = pointer.state;
-    const ownsCurrentSessionFile = state == null
-      || state.session_id === candidateSessionId
-      || state.native_session_id === candidateSessionId
-      || state.owner_omx_session_id === candidateSessionId;
+    const state = pointer.state!;
+    const ownsCurrentSessionFile = true;
     const endTime = new Date().toISOString();
     const historyEntry = {
       session_id: ownsCurrentSessionFile
@@ -1676,6 +2222,7 @@ export async function writeSessionEnd(
   }
   if (releaseFailures.length > 0) throw releaseFailureError(releaseFailures);
   emitDegradedDurabilityWarning('session pointer end', tracker);
+  return revalidation;
 }
 
 /** Reset session-scoped HUD/metrics files at launch. */

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -2035,13 +2035,12 @@ async function authorizeBoundDirectoryBeforeTransaction(
       throw new BoundDirectoryComparisonDenied({ status: 'denied', reason: 'cwd-identity-mismatch' }, capability);
     }
     if (binding.directoryIdentity.kind !== 'supported') {
-      if (pointer.status === 'stale-dead') {
-        throw new BoundDirectoryComparisonDenied(
-          { status: 'denied', reason: `unsupported-directory-capability:${binding.directoryIdentity.reason}` },
-          capability,
-        );
-      }
-      return { comparison: { status: 'matched', reason: 'unsupported-ordinary-pointer' }, capability, pointerStatus: pointer.status, pointerRaw: pointer.raw };
+      return {
+        comparison: { status: 'matched', reason: `unsupported-directory-capability:${binding.directoryIdentity.reason}` },
+        capability,
+        pointerStatus: pointer.status,
+        pointerRaw: pointer.raw,
+      };
     }
     const retained = await lease.handle?.stat({ bigint: true });
     if (!retained || !retained.isDirectory() || retained.dev !== binding.directoryIdentity.dev || retained.ino !== binding.directoryIdentity.ino) {
@@ -2341,6 +2340,28 @@ export async function writeSessionEnd(
       lockPath: context.lockPath, reason: 'A live launch binding is required to end a session pointer.',
     });
   }
+
+  let preLockPointer: SessionPointerReadResult;
+  try {
+    preLockPointer = await readSessionPointer(context);
+  } catch (error) {
+    throw resolvedAbort(context, {
+      code: 'session_pointer_io_failure', operation: 'pointer-read', candidateSessionId,
+      lockPath: context.lockPath, reason: `Unable to read selected session pointer: ${errorMessage(error)}`, cause: error,
+    });
+  }
+  const preLockAuthorizedBoundUsable = preLockPointer.status === 'usable'
+    && isAuthorizedBoundPointer(options.binding, context, candidateSessionId, preLockPointer.state);
+  const preLockAuthorizedBoundStaleDead = preLockPointer.status === 'stale-dead'
+    && isAuthorizedBoundStaleDeadPointer(options.binding, context, candidateSessionId, preLockPointer.state);
+  if (!preLockAuthorizedBoundUsable && !preLockAuthorizedBoundStaleDead) {
+    throw unusablePointerAbort(context, candidateSessionId, preLockPointer);
+  }
+  await authorizeBoundDirectoryBeforeTransaction(
+    options.binding,
+    preLockPointer,
+    options.postLaunchCwd ?? options.binding.context.cwd,
+  );
 
   const platform = options.platform ?? process.platform;
   const tracker: RegularFileDurabilityTracker = { degraded: false };

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -33,7 +33,13 @@ import {
 	mapCodexHookEventToOmxEvent,
 	resolveSessionOwnerPidFromAncestry,
 } from "../codex-native-hook.js";
-import { writeSessionStart } from "../../hooks/session.js";
+import {
+	closeLaunchSessionBindingOnce,
+	establishLaunchSessionBinding,
+	finalizeBoundOnce,
+	updateDetachedSessionMetadata,
+	writeSessionStart,
+} from "../../hooks/session.js";
 import { resetTriageConfigCache } from "../../hooks/triage-config.js";
 import { executeStateOperation } from "../../state/operations.js";
 import { HUD_TMUX_HEIGHT_LINES } from "../../hud/constants.js";
@@ -3874,10 +3880,63 @@ PY`,
       assert.match(additionalContext, /not available from this outside-tmux surface/);
       const sessionState = JSON.parse(
         await readFile(join(cwd, ".omx", "state", "session.json"), "utf-8"),
-      ) as { session_id?: string; native_session_id?: string; pid?: number };
+      ) as { session_id?: string; native_session_id?: string; pid?: number; launch_lineage_token?: string };
       assert.equal(sessionState.session_id, "sess-start-1");
       assert.equal(sessionState.native_session_id, "sess-start-1");
       assert.equal(sessionState.pid, 43210);
+      assert.equal(sessionState.launch_lineage_token, undefined, 'native SessionStart must never mint or backfill wrapper lineage authority');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves wrapper lineage and detached metadata through shipped native SessionStart reconciliation", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-session-start-wrapper-lineage-"));
+    try {
+      const established = await establishLaunchSessionBinding(cwd, "omx-launch-lineage");
+      assert.equal(established.kind, "committed-released");
+      if (established.kind !== "committed-released") return;
+
+      const metadata = await updateDetachedSessionMetadata(established.binding, {
+        tmuxSessionName: "omx-detached-lineage",
+        tmuxPaneId: "%3202",
+      });
+      assert.equal(metadata.kind, "committed-released");
+
+      const pointerPath = join(cwd, ".omx", "state", "session.json");
+      const ownedPointer = JSON.parse(await readFile(pointerPath, "utf-8")) as Record<string, unknown>;
+      await writeFile(pointerPath, JSON.stringify({ ...ownedPointer, owner_omx_session_id: "omx-launch-lineage" }), "utf-8");
+
+      await dispatchCodexNativeHook(
+        { hook_event_name: "SessionStart", cwd, session_id: "codex-native-lineage" },
+        { cwd, sessionOwnerPid: process.pid },
+      );
+
+      const sessionState = JSON.parse(
+        await readFile(join(cwd, ".omx", "state", "session.json"), "utf-8"),
+      ) as {
+        session_id?: string;
+        native_session_id?: string;
+        owner_omx_session_id?: string;
+        started_at?: string;
+        launch_lineage_token?: string;
+        tmux_session_name?: string;
+        tmux_pane_id?: string;
+      };
+      assert.equal(sessionState.session_id, "omx-launch-lineage");
+      assert.equal(sessionState.native_session_id, "codex-native-lineage");
+      assert.equal(sessionState.owner_omx_session_id, "omx-launch-lineage");
+      assert.equal(typeof sessionState.started_at, "string");
+      assert.equal(sessionState.launch_lineage_token, established.binding.launchLineageToken);
+      assert.equal(sessionState.tmux_session_name, "omx-detached-lineage");
+      assert.equal(sessionState.tmux_pane_id, "%3202");
+
+      const firstFinalization = finalizeBoundOnce(established.binding, "test");
+      const secondFinalization = finalizeBoundOnce(established.binding, "duplicate");
+      assert.equal(firstFinalization, secondFinalization);
+      assert.equal((await firstFinalization).finalized, true);
+      assert.equal((await closeLaunchSessionBindingOnce(established.binding)).status, "closed");
+      assert.equal((await closeLaunchSessionBindingOnce(established.binding)).status, "closed");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- retain the selected-root launch binding in the long-lived detached leader through child termination
- authorize archive/unlink under the selected-pointer lock before terminal cleanup
- preserve foreign, malformed, ambiguous, replaced-root, unsupported stale, and unproven pointers fail-closed
- add the documented exec-to-cancel smoke and hostile identity/race coverage

## Verification
- npm run build
- focused session/hotswap/exec/index/launch-fallback/native-hook suites
- npm run lint
- npm run check:no-unused
- npx tsc --noEmit
- git diff --check
- installed-package live native-hook smoke

Fixes #3202

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*