### PR TITLE
fix(team): preserve leader session pointer ownership

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4629,6 +4629,56 @@ PY`,
     }
   });
 
+  it("fails closed for invalid Team worker lifecycle identity with absent or live pointers", async () => {
+    for (const pointerKind of ["absent", "live"] as const) {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-native-hook-team-worker-invalid-${pointerKind}-`));
+      try {
+        delete process.env.OMX_TEAM_INTERNAL_WORKER;
+        delete process.env.OMX_TEAM_WORKER;
+        delete process.env.OMX_TEAM_STATE_ROOT;
+        delete process.env.OMX_TEAM_LEADER_CWD;
+        delete process.env.OMX_SESSION_ID;
+        delete process.env.TMUX;
+        delete process.env.TMUX_PANE;
+        const pointerPath = join(cwd, ".omx", "state", "session.json");
+        await configureAuthoritativeTeamWorker(cwd, "invalid-identity-team");
+        if (pointerKind === "live") {
+          await writeSessionStart(cwd, "leader-session", {
+            nativeSessionId: "invalid-test-leader-native",
+            pid: process.pid,
+          });
+        }
+        const pointerBefore = existsSync(pointerPath) ? await readFile(pointerPath, "utf-8") : null;
+
+        for (const payload of [
+          { session_id: "../escape" },
+          { session_id: "worker-one", sessionId: "worker-two" },
+        ]) {
+          await dispatchCodexNativeHook({
+            hook_event_name: "SessionStart",
+            cwd,
+            ...payload,
+          }, { cwd, sessionOwnerPid: process.pid });
+          assert.equal(existsSync(pointerPath), pointerBefore !== null);
+          if (pointerBefore !== null) assert.equal(await readFile(pointerPath, "utf-8"), pointerBefore);
+
+          const stop = await dispatchCodexNativeHook({
+            hook_event_name: "Stop",
+            cwd,
+            ...payload,
+            thread_id: "invalid-worker-thread",
+            turn_id: `invalid-worker-${pointerKind}-stop`,
+          }, { cwd });
+          assert.equal(stop.outputJson?.stopReason, "session_scope_unmatched");
+          assert.equal(existsSync(pointerPath), pointerBefore !== null);
+          if (pointerBefore !== null) assert.equal(await readFile(pointerPath, "utf-8"), pointerBefore);
+        }
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  });
+
   it("keeps authoritative worker payload scope independent of malformed selected-pointer evidence", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-worker-malformed-pointer-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4629,6 +4629,45 @@ PY`,
     }
   });
 
+  it("keeps declared Team workers fail closed before startup authority is materialized", async () => {
+    for (const pointerKind of ["absent", "live"] as const) {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-native-hook-team-worker-race-${pointerKind}-`));
+      try {
+        const pointerPath = join(cwd, ".omx", "state", "session.json");
+        if (pointerKind === "live") {
+          await writeSessionStart(cwd, "race-leader-session", {
+            nativeSessionId: "race-leader-native",
+            pid: process.pid,
+          });
+        }
+        const pointerBefore = existsSync(pointerPath) ? await readFile(pointerPath, "utf-8") : null;
+        process.env.OMX_TEAM_WORKER = "race-team/worker-1";
+        process.env.OMX_TEAM_INTERNAL_WORKER = "race-team/worker-1";
+        process.env.TMUX = "1";
+        process.env.TMUX_PANE = "%10";
+
+        await dispatchCodexNativeHook({
+          hook_event_name: "SessionStart",
+          cwd,
+          session_id: "race-worker-native",
+        }, { cwd, sessionOwnerPid: process.pid });
+        assert.equal(existsSync(pointerPath), pointerBefore !== null);
+        if (pointerBefore !== null) assert.equal(await readFile(pointerPath, "utf-8"), pointerBefore);
+
+        const stop = await dispatchCodexNativeHook({
+          hook_event_name: "Stop",
+          cwd,
+          session_id: "race-worker-native",
+          thread_id: "race-worker-native",
+          turn_id: "race-worker-stop",
+        }, { cwd });
+        assert.equal(stop.outputJson?.stopReason, "session_scope_unmatched");
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  });
+
   it("fails closed for invalid Team worker lifecycle identity across pointer states", async () => {
     for (const pointerKind of ["absent", "live", "stale", "malformed"] as const) {
       const cwd = await mkdtemp(join(tmpdir(), `omx-native-hook-team-worker-invalid-${pointerKind}-`));
@@ -4668,12 +4707,16 @@ PY`,
         }
         const pointerBefore = existsSync(pointerPath) ? await readFile(pointerPath, "utf-8") : null;
 
-        for (const payload of [
+        const payloads: Array<Record<string, unknown>> = [
           {},
           { session_id: "" },
           { session_id: "../escape" },
           { session_id: "worker-one", sessionId: "worker-two" },
-        ]) {
+          ...(pointerKind === "live"
+            ? [{ session_id: "leader-session" }, { session_id: "invalid-test-leader-native" }]
+            : []),
+        ];
+        for (const payload of payloads) {
           await dispatchCodexNativeHook({
             hook_event_name: "SessionStart",
             cwd,

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4608,7 +4608,8 @@ PY`,
       await dispatchCodexNativeHook({
         hook_event_name: "SessionStart",
         cwd,
-        session_id: "worker-native",
+        session_id: "",
+        sessionId: "worker-native",
       }, { cwd, sessionOwnerPid: process.pid });
 
       assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), leaderPointerBefore);

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4651,6 +4651,21 @@ PY`,
           await mkdir(dirname(pointerPath), { recursive: true });
           await writeFile(pointerPath, "{ malformed missing-identity evidence", "utf-8");
         }
+        if (pointerKind === "live") {
+          await writeJson(join(cwd, ".omx", "state", "subagent-tracking.json"), {
+            schemaVersion: 1,
+            sessions: {
+              "leader-session": {
+                session_id: "leader-session",
+                leader_thread_id: "invalid-test-leader-native",
+                threads: {
+                  "invalid-test-leader-native": { thread_id: "invalid-test-leader-native", kind: "leader" },
+                  "invalid-worker-thread": { thread_id: "invalid-worker-thread", kind: "subagent" },
+                },
+              },
+            },
+          });
+        }
         const pointerBefore = existsSync(pointerPath) ? await readFile(pointerPath, "utf-8") : null;
 
         for (const payload of [

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4653,6 +4653,22 @@ PY`,
       assert.notEqual(stop.outputJson?.stopReason, "session_pointer_unusable");
       assert.notEqual(stop.outputJson?.stopReason, "session_scope_unmatched");
       assert.equal(await readFile(pointerPath, "utf-8"), "{ malformed leader evidence");
+
+      for (const payload of [
+        { session_id: "../escape" },
+        { session_id: "worker-one", sessionId: "worker-two" },
+      ]) {
+        const rejected = await dispatchCodexNativeHook({
+          hook_event_name: "SessionStart",
+          cwd,
+          ...payload,
+        }, { cwd, sessionOwnerPid: process.pid });
+        assert.equal(rejected.outputJson, null);
+        assert.equal(await readFile(pointerPath, "utf-8"), "{ malformed leader evidence");
+        assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", "escape")), false);
+        assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", "worker-one")), false);
+        assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", "worker-two")), false);
+      }
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -4707,6 +4723,17 @@ PY`,
         session_id: "worker-after-stale-leader",
       }, { cwd, sessionOwnerPid: process.pid });
 
+      assert.equal(await readFile(pointerPath, "utf-8"), pointerBefore);
+
+      const stop = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "worker-after-stale-leader",
+        thread_id: "worker-after-stale-leader",
+        turn_id: "worker-after-stale-stop",
+      }, { cwd });
+      assert.notEqual(stop.outputJson?.stopReason, "session_pointer_unusable");
+      assert.notEqual(stop.outputJson?.stopReason, "session_scope_unmatched");
       assert.equal(await readFile(pointerPath, "utf-8"), pointerBefore);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4629,8 +4629,8 @@ PY`,
     }
   });
 
-  it("fails closed for invalid Team worker lifecycle identity with absent or live pointers", async () => {
-    for (const pointerKind of ["absent", "live"] as const) {
+  it("fails closed for invalid Team worker lifecycle identity across pointer states", async () => {
+    for (const pointerKind of ["absent", "live", "stale", "malformed"] as const) {
       const cwd = await mkdtemp(join(tmpdir(), `omx-native-hook-team-worker-invalid-${pointerKind}-`));
       try {
         delete process.env.OMX_TEAM_INTERNAL_WORKER;
@@ -4642,15 +4642,20 @@ PY`,
         delete process.env.TMUX_PANE;
         const pointerPath = join(cwd, ".omx", "state", "session.json");
         await configureAuthoritativeTeamWorker(cwd, "invalid-identity-team");
-        if (pointerKind === "live") {
+        if (pointerKind === "live" || pointerKind === "stale") {
           await writeSessionStart(cwd, "leader-session", {
             nativeSessionId: "invalid-test-leader-native",
-            pid: process.pid,
+            pid: pointerKind === "live" ? process.pid : 2_147_483_647,
           });
+        } else if (pointerKind === "malformed") {
+          await mkdir(dirname(pointerPath), { recursive: true });
+          await writeFile(pointerPath, "{ malformed missing-identity evidence", "utf-8");
         }
         const pointerBefore = existsSync(pointerPath) ? await readFile(pointerPath, "utf-8") : null;
 
         for (const payload of [
+          {},
+          { session_id: "" },
           { session_id: "../escape" },
           { session_id: "worker-one", sessionId: "worker-two" },
         ]) {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -23267,12 +23267,17 @@ PY`,
         { ...payload, stop_hook_active: true },
         { cwd: workerCwd },
       );
+      const camelReplay = await dispatchCodexNativeHook(
+        { ...payload, stopHookActive: true },
+        { cwd: workerCwd },
+      );
 
       assert.equal(
         (result.outputJson as { stopReason?: string } | null)?.stopReason,
         "team_worker_worker-1_1_in_progress",
       );
       assert.equal(replay.outputJson, null);
+      assert.equal(camelReplay.outputJson, null);
     } finally {
       if (typeof prevTeamWorker === "string") process.env.OMX_TEAM_WORKER = prevTeamWorker;
       else delete process.env.OMX_TEAM_WORKER;
@@ -23352,6 +23357,10 @@ PY`,
         { ...basePayload, turn_id: "turn-stop-team-worker-repeat-2", stop_hook_active: true },
         { cwd: workerCwd },
       );
+      const exempt = await dispatchCodexNativeHook(
+        { ...basePayload, turn_id: "turn-stop-team-worker-exempt", stopReason: "context limit" },
+        { cwd: workerCwd },
+      );
 
       await writeJson(taskPath, {
         id: "1",
@@ -23369,6 +23378,7 @@ PY`,
       assert.deepEqual(first.outputJson, expectedInProgress);
       assert.deepEqual(replay.outputJson, expectedInProgress);
       assert.deepEqual(freshTurn.outputJson, expectedInProgress);
+      assert.equal(exempt.outputJson, null);
       assert.deepEqual(stateChanged.outputJson, {
         decision: "block",
         reason:

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4661,7 +4661,7 @@ PY`,
           thread_id: "race-worker-native",
           turn_id: "race-worker-stop",
         }, { cwd });
-        assert.equal(stop.outputJson?.stopReason, "session_scope_unmatched");
+        assert.match(String(stop.outputJson?.stopReason ?? ""), /^team_worker_/);
       } finally {
         await rm(cwd, { recursive: true, force: true });
       }
@@ -4732,7 +4732,7 @@ PY`,
             thread_id: "invalid-worker-thread",
             turn_id: `invalid-worker-${pointerKind}-stop`,
           }, { cwd });
-          assert.equal(stop.outputJson?.stopReason, "session_scope_unmatched");
+          assert.match(String(stop.outputJson?.stopReason ?? ""), /^team_worker_/);
           assert.equal(existsSync(pointerPath), pointerBefore !== null);
           if (pointerBefore !== null) assert.equal(await readFile(pointerPath, "utf-8"), pointerBefore);
         }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4602,6 +4602,8 @@ PY`,
         owner_codex_session_id: "leader-native",
       });
       const leaderRalphBeforeWorkerStop = await readFile(leaderRalphPath, "utf-8");
+      const rootNativeStopPath = join(stateDir, "native-stop-state.json");
+      assert.equal(existsSync(rootNativeStopPath), false);
 
       await dispatchCodexNativeHook({
         hook_event_name: "SessionStart",
@@ -4621,6 +4623,7 @@ PY`,
       assert.notEqual(workerStop.outputJson?.stopReason, "session_scope_unmatched");
       assert.notEqual(workerStop.outputJson?.stopReason, "session_pointer_unusable");
       assert.equal(await readFile(leaderRalphPath, "utf-8"), leaderRalphBeforeWorkerStop);
+      assert.equal(existsSync(rootNativeStopPath), false);
 
       delete process.env.OMX_TEAM_INTERNAL_WORKER;
       delete process.env.OMX_TEAM_WORKER;
@@ -4634,6 +4637,34 @@ PY`,
       }, { cwd });
       assert.notEqual(leaderStop.outputJson?.stopReason, "session_scope_unmatched");
       assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), leaderPointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects leader aliases from foreign-cwd pointer evidence in a worker worktree", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-worker-foreign-alias-"));
+    try {
+      await writeSessionStart(cwd, "foreign-alias-leader", {
+        nativeSessionId: "foreign-alias-leader-native",
+        pid: process.pid,
+      });
+      await configureAuthoritativeTeamWorker(cwd, "foreign-alias-team");
+      const pointerPath = join(cwd, ".omx", "state", "session.json");
+      const pointer = JSON.parse(await readFile(pointerPath, "utf-8")) as Record<string, unknown>;
+      pointer.cwd = join(cwd, "leader-worktree");
+      await writeJson(pointerPath, pointer);
+      const pointerBefore = await readFile(pointerPath, "utf-8");
+
+      for (const sessionId of ["foreign-alias-leader", "foreign-alias-leader-native"]) {
+        await dispatchCodexNativeHook({
+          hook_event_name: "SessionStart",
+          cwd,
+          session_id: sessionId,
+        }, { cwd, sessionOwnerPid: process.pid });
+        assert.equal(await readFile(pointerPath, "utf-8"), pointerBefore);
+        assert.equal(existsSync(join(cwd, ".omx", "state", "sessions", sessionId)), false);
+      }
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4593,6 +4593,15 @@ PY`,
       });
       await configureAuthoritativeTeamWorker(cwd, "pointer-team");
       const leaderPointerBefore = await readFile(join(stateDir, "session.json"), "utf-8");
+      const leaderRalphPath = join(stateDir, "sessions", "leader-session", "ralph-state.json");
+      await writeJson(leaderRalphPath, {
+        active: true,
+        mode: "ralph",
+        current_phase: "executing",
+        session_id: "leader-session",
+        owner_codex_session_id: "leader-native",
+      });
+      const leaderRalphBeforeWorkerStop = await readFile(leaderRalphPath, "utf-8");
 
       await dispatchCodexNativeHook({
         hook_event_name: "SessionStart",
@@ -4611,6 +4620,7 @@ PY`,
       }, { cwd });
       assert.notEqual(workerStop.outputJson?.stopReason, "session_scope_unmatched");
       assert.notEqual(workerStop.outputJson?.stopReason, "session_pointer_unusable");
+      assert.equal(await readFile(leaderRalphPath, "utf-8"), leaderRalphBeforeWorkerStop);
 
       delete process.env.OMX_TEAM_INTERNAL_WORKER;
       delete process.env.OMX_TEAM_WORKER;
@@ -4653,6 +4663,21 @@ PY`,
         }, { cwd, sessionOwnerPid: process.pid });
         assert.equal(existsSync(pointerPath), pointerBefore !== null);
         if (pointerBefore !== null) assert.equal(await readFile(pointerPath, "utf-8"), pointerBefore);
+
+        for (const declaration of [
+          { internal: "malformed", external: "" },
+          { internal: "race-team/worker-1", external: "other-team/worker-1" },
+        ]) {
+          process.env.OMX_TEAM_INTERNAL_WORKER = declaration.internal;
+          process.env.OMX_TEAM_WORKER = declaration.external;
+          await dispatchCodexNativeHook({
+            hook_event_name: "SessionStart",
+            cwd,
+            session_id: "race-worker-malformed-native",
+          }, { cwd, sessionOwnerPid: process.pid });
+          assert.equal(existsSync(pointerPath), pointerBefore !== null);
+          if (pointerBefore !== null) assert.equal(await readFile(pointerPath, "utf-8"), pointerBefore);
+        }
 
         const stop = await dispatchCodexNativeHook({
           hook_event_name: "Stop",

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -296,6 +296,54 @@ async function setTeamPaneIds(
 	}
 }
 
+async function configureAuthoritativeTeamWorker(
+  cwd: string,
+  teamName: string,
+  workerPaneId = "%10",
+): Promise<void> {
+  const stateRoot = join(cwd, ".omx", "state");
+  await initTeamState(teamName, "session pointer ownership regression", "executor", 1, cwd, undefined, {
+    OMX_SESSION_ID: "leader-session",
+  });
+  await setTeamPaneIds(cwd, teamName, {
+    leaderPaneId: "%42",
+    workerPaneIds: { "worker-1": workerPaneId },
+  });
+  for (const fileName of ["config.json", "manifest.v2.json"]) {
+    const filePath = join(stateRoot, "team", teamName, fileName);
+    const state = JSON.parse(await readFile(filePath, "utf-8")) as {
+      team_state_root?: string;
+      leader_cwd?: string;
+      workers?: Array<Record<string, unknown>>;
+    };
+    state.team_state_root = stateRoot;
+    state.leader_cwd = cwd;
+    state.workers = (state.workers ?? []).map((worker) => ({
+      ...worker,
+      working_dir: cwd,
+      worktree_path: cwd,
+      team_state_root: stateRoot,
+    }));
+    await writeJson(filePath, state);
+  }
+  await writeJson(join(stateRoot, "team", teamName, "workers", "worker-1", "identity.json"), {
+    name: "worker-1",
+    index: 1,
+    role: "executor",
+    pane_id: workerPaneId,
+    working_dir: cwd,
+    worktree_path: cwd,
+    team_state_root: stateRoot,
+  });
+  process.env.TMUX = "1";
+  process.env.TMUX_PANE = workerPaneId;
+  process.env.OMX_TEAM_INTERNAL_WORKER = `${teamName}/worker-1`;
+  process.env.OMX_TEAM_WORKER = `${teamName}/worker-1`;
+  process.env.OMX_TEAM_STATE_ROOT = stateRoot;
+  process.env.OMX_TEAM_LEADER_CWD = cwd;
+  process.env.OMX_SESSION_ID = "leader-session";
+}
+
 async function withIsolatedHome<T>(
 	prefix: string,
 	run: (homeDir: string) => Promise<T>,
@@ -4531,6 +4579,170 @@ PY`,
       } else {
         process.env.CODEX_HOME = originalCodexHome;
       }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps an authoritative Team worker lifecycle scoped without replacing the live leader pointer", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-worker-pointer-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await writeSessionStart(cwd, "leader-session", {
+        nativeSessionId: "leader-native",
+        pid: process.pid,
+      });
+      await configureAuthoritativeTeamWorker(cwd, "pointer-team");
+      const leaderPointerBefore = await readFile(join(stateDir, "session.json"), "utf-8");
+
+      await dispatchCodexNativeHook({
+        hook_event_name: "SessionStart",
+        cwd,
+        session_id: "worker-native",
+      }, { cwd, sessionOwnerPid: process.pid });
+
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), leaderPointerBefore);
+
+      const workerStop = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "worker-native",
+        thread_id: "worker-native",
+        turn_id: "worker-stop-turn",
+      }, { cwd });
+      assert.notEqual(workerStop.outputJson?.stopReason, "session_scope_unmatched");
+      assert.notEqual(workerStop.outputJson?.stopReason, "session_pointer_unusable");
+
+      delete process.env.OMX_TEAM_INTERNAL_WORKER;
+      delete process.env.OMX_TEAM_WORKER;
+      process.env.TMUX_PANE = "%42";
+      const leaderStop = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "leader-native",
+        thread_id: "leader-native",
+        turn_id: "leader-stop-turn",
+      }, { cwd });
+      assert.notEqual(leaderStop.outputJson?.stopReason, "session_scope_unmatched");
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), leaderPointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps authoritative worker payload scope independent of malformed selected-pointer evidence", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-worker-malformed-pointer-"));
+    try {
+      await configureAuthoritativeTeamWorker(cwd, "malformed-team");
+      const pointerPath = join(cwd, ".omx", "state", "session.json");
+      await writeFile(pointerPath, "{ malformed leader evidence", "utf-8");
+
+      await dispatchCodexNativeHook({
+        hook_event_name: "SessionStart",
+        cwd,
+        session_id: "worker-malformed-native",
+      }, { cwd, sessionOwnerPid: process.pid });
+      assert.equal(await readFile(pointerPath, "utf-8"), "{ malformed leader evidence");
+
+      const stop = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "worker-malformed-native",
+        thread_id: "worker-malformed-native",
+        turn_id: "worker-malformed-stop",
+      }, { cwd });
+      assert.notEqual(stop.outputJson?.stopReason, "session_pointer_unusable");
+      assert.notEqual(stop.outputJson?.stopReason, "session_scope_unmatched");
+      assert.equal(await readFile(pointerPath, "utf-8"), "{ malformed leader evidence");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  for (const [name, mutate] of [
+    ["foreign", async (cwd: string) => {
+      process.env.OMX_TEAM_STATE_ROOT = join(cwd, "foreign-state");
+    }],
+    ["nested", async (cwd: string) => {
+      process.env.OMX_TEAM_INTERNAL_WORKER = "other-team/worker-1";
+    }],
+    ["non-Team", async () => {
+      delete process.env.OMX_TEAM_INTERNAL_WORKER;
+      delete process.env.OMX_TEAM_WORKER;
+    }],
+  ] as const) {
+    it(`does not grant the Team worker pointer bypass to ${name} hook context`, async () => {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-native-hook-${name}-pointer-`));
+      try {
+        await configureAuthoritativeTeamWorker(cwd, "boundary-team");
+        await mutate(cwd);
+        const pointerPath = join(cwd, ".omx", "state", "session.json");
+        await writeFile(pointerPath, "{ malformed boundary evidence", "utf-8");
+
+        await dispatchCodexNativeHook({
+          hook_event_name: "SessionStart",
+          cwd,
+          session_id: "boundary-native",
+        }, { cwd, sessionOwnerPid: process.pid });
+        assert.equal(await readFile(pointerPath, "utf-8"), "{ malformed boundary evidence");
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it("does not let a Team worker adopt a stale leader-selected pointer", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-worker-stale-leader-"));
+    try {
+      await writeSessionStart(cwd, "stale-leader-session", {
+        nativeSessionId: "stale-leader-native",
+        pid: 2_147_483_647,
+      });
+      await configureAuthoritativeTeamWorker(cwd, "stale-leader-team");
+      const pointerPath = join(cwd, ".omx", "state", "session.json");
+      const pointerBefore = await readFile(pointerPath, "utf-8");
+
+      await dispatchCodexNativeHook({
+        hook_event_name: "SessionStart",
+        cwd,
+        session_id: "worker-after-stale-leader",
+      }, { cwd, sessionOwnerPid: process.pid });
+
+      assert.equal(await readFile(pointerPath, "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves leader pointer ownership through the packed native-hook entrypoint", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-worker-packed-"));
+    try {
+      await writeSessionStart(cwd, "leader-session", {
+        nativeSessionId: "packed-leader-native",
+        pid: process.pid,
+      });
+      await configureAuthoritativeTeamWorker(cwd, "packed-team");
+      const pointerPath = join(cwd, ".omx", "state", "session.json");
+      const pointerBefore = await readFile(pointerPath, "utf-8");
+      const env = { ...process.env };
+
+      parseSingleJsonStdout(runNativeHookCli({
+        hook_event_name: "SessionStart",
+        cwd,
+        session_id: "packed-worker-native",
+      }, { cwd, env }));
+      assert.equal(await readFile(pointerPath, "utf-8"), pointerBefore);
+
+      const stopOutput = parseSingleJsonStdout(runNativeHookCli({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "packed-worker-native",
+        thread_id: "packed-worker-native",
+        turn_id: "packed-worker-stop",
+      }, { cwd, env }));
+      assert.notEqual(stopOutput.stopReason, "session_scope_unmatched");
+      assert.notEqual(stopOutput.stopReason, "session_pointer_unusable");
+      assert.equal(await readFile(pointerPath, "utf-8"), pointerBefore);
+    } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3333,6 +3333,12 @@ function readPayloadSessionId(payload: CodexHookPayload): string {
   return payloadAliasValues(payload, ["session_id", "sessionId"])[0] ?? "";
 }
 
+function readUnambiguousNormalizedPayloadSessionId(payload: CodexHookPayload): string {
+  const aliases = payloadAliasValues(payload, ["session_id", "sessionId"]);
+  if (aliases.length !== 1) return "";
+  return normalizeSessionId(aliases[0]) ?? "";
+}
+
 function readPayloadThreadId(payload: CodexHookPayload): string {
   return payloadAliasValues(payload, ["thread_id", "threadId"])[0] ?? "";
 }
@@ -19709,10 +19715,9 @@ export async function dispatchCodexNativeHook(
   let skipCanonicalSessionStartContext = false;
   let isSubagentSessionStart = false;
   const authoritativeTeamWorker = await hasAuthoritativeTeamWorkerContext(cwd);
-  if (authoritativeTeamWorker) {
-    allowImplicitSessionSideEffects = true;
-    stopAuthorizationFailure = null;
-  }
+  const authoritativeWorkerPayloadSessionId = authoritativeTeamWorker
+    ? readUnambiguousNormalizedPayloadSessionId(payload)
+    : "";
 
   if (hookEventName === "SessionStart" && nativeSessionId) {
     const transcriptPath = safeString(payload.transcript_path ?? payload.transcriptPath).trim();
@@ -19768,12 +19773,14 @@ export async function dispatchCodexNativeHook(
           transcriptPath,
         );
       }
-    } else if (authoritativeTeamWorker) {
+    } else if (authoritativeWorkerPayloadSessionId && authoritativeWorkerPayloadSessionId === nativeSessionId) {
       // Team workers share the leader's selected state root, but they do not own
       // its compatibility pointer. Keep lifecycle state scoped to the explicit
       // hook payload without reconciling or replacing the live leader pointer.
-      canonicalSessionId = nativeSessionId;
-      resolvedNativeSessionId = nativeSessionId;
+      canonicalSessionId = authoritativeWorkerPayloadSessionId;
+      resolvedNativeSessionId = authoritativeWorkerPayloadSessionId;
+      allowImplicitSessionSideEffects = true;
+      stopAuthorizationFailure = null;
     } else {
       const ownerOmxSessionId = await resolveVerifiedOwnerOmxSessionId();
       try {
@@ -19814,12 +19821,13 @@ export async function dispatchCodexNativeHook(
 
   if (hookEventName === "Stop") {
     const stopPayloadSessionId = readPayloadSessionId(payload);
+    const authorizedWorkerStopSessionId = authoritativeWorkerPayloadSessionId;
     const stopCanonicalSessionId = await resolveInternalSessionIdForPayload(
       cwd,
-      stopPayloadSessionId,
+      authorizedWorkerStopSessionId || stopPayloadSessionId,
       undefined,
       currentSessionState,
-      pointer.status === "absent" || authoritativeTeamWorker,
+      pointer.status === "absent" || Boolean(authorizedWorkerStopSessionId),
     );
     if (stopPayloadSessionId && !stopCanonicalSessionId) {
       canonicalSessionId = "";
@@ -19832,6 +19840,10 @@ export async function dispatchCodexNativeHook(
       }
     } else if (stopCanonicalSessionId) {
       canonicalSessionId = stopCanonicalSessionId;
+    }
+    if (authorizedWorkerStopSessionId && stopCanonicalSessionId === authorizedWorkerStopSessionId) {
+      allowImplicitSessionSideEffects = true;
+      stopAuthorizationFailure = null;
     }
     if (canonicalSessionId && safeString(currentSessionState?.session_id).trim() === canonicalSessionId) {
       resolvedNativeSessionId =

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -19902,7 +19902,11 @@ export async function dispatchCodexNativeHook(
         )),
     )).some(Boolean)
     : false;
-  if (isSubagentStop && stopAuthorizationFailure?.stopReason === "session_scope_unmatched") {
+  if (
+    isSubagentStop
+    && stopAuthorizationFailure?.stopReason === "session_scope_unmatched"
+    && !(authoritativeTeamWorker && !authoritativeWorkerPayloadSessionId)
+  ) {
     canonicalSessionId = normalizeSessionId(readPayloadSessionId(payload)) ?? "";
     allowImplicitSessionSideEffects = true;
     stopAuthorizationFailure = null;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2555,6 +2555,11 @@ function readTeamWorkerEnvironment(): { teamName: string; workerName: string } |
   return internalWorker ?? externalWorker;
 }
 
+function hasRawTeamWorkerDeclaration(): boolean {
+  return safeString(process.env.OMX_TEAM_INTERNAL_WORKER).trim() !== ""
+    || safeString(process.env.OMX_TEAM_WORKER).trim() !== "";
+}
+
 async function hasAuthoritativeTeamWorkerContext(cwd: string): Promise<boolean> {
   const workerContext = readTeamWorkerEnvironment();
   if (!workerContext) return false;
@@ -2799,6 +2804,37 @@ function isStopExempt(payload: CodexHookPayload): boolean {
     || value.includes("compact")
     || value.includes("limit"),
   );
+}
+
+async function buildDeclaredTeamWorkerStopOutput(
+  payload: CodexHookPayload,
+  cwd: string,
+): Promise<Record<string, unknown> | null> {
+  const decision = await resolveTeamWorkerStopDecision(cwd);
+  if (decision.kind === "blocked") {
+    if (payload.stop_hook_active === true && !decision.allowRepeatDuringStopHook) return null;
+    return decision.output;
+  }
+  if (decision.kind === "allowed") {
+    try {
+      await maybeNudgeLeaderForAllowedWorkerStop({
+        stateDir: decision.stateDir,
+        logsDir: join(cwd, ".omx", "logs"),
+        workerContext: decision.workerContext,
+      });
+    } catch (err) {
+      void err;
+    }
+    return null;
+  }
+  const workerName = readTeamWorkerEnvironment()?.workerName ?? "unknown";
+  const reason = "OMX cannot resolve authoritative Team worker state for Stop.";
+  return {
+    decision: "block",
+    stopReason: `team_worker_${workerName}_missing_worker_state`,
+    reason,
+    systemMessage: reason,
+  };
 }
 
 async function readModeStateWithStopSource(
@@ -19687,6 +19723,14 @@ export async function dispatchCodexNativeHook(
       outputJson: null,
     };
   }
+  if (hookEventName === "Stop" && hasRawTeamWorkerDeclaration()) {
+    return {
+      hookEventName,
+      omxEventName: mapCodexHookEventToOmxEvent(hookEventName),
+      skillState: null,
+      outputJson: await buildDeclaredTeamWorkerStopOutput(payload, cwd),
+    };
+  }
   // Native hooks must use the exact pointer root selected for this dispatch.
   const pointerContext = resolveSessionPointerContext(cwd);
   const stateDir = pointerContext.baseStateDir;
@@ -19746,15 +19790,14 @@ export async function dispatchCodexNativeHook(
   let resolvedNativeSessionId = nativeSessionId;
   let skipCanonicalSessionStartContext = false;
   let isSubagentSessionStart = false;
-  const declaredTeamWorker = safeString(process.env.OMX_TEAM_INTERNAL_WORKER).trim() !== ""
-    || safeString(process.env.OMX_TEAM_WORKER).trim() !== "";
+  const declaredTeamWorker = hasRawTeamWorkerDeclaration();
   const authoritativeTeamWorker = declaredTeamWorker && await hasAuthoritativeTeamWorkerContext(cwd);
   const candidateWorkerPayloadSessionId = declaredTeamWorker
     ? readUnambiguousNormalizedPayloadSessionId(payload)
     : "";
   const authoritativeWorkerPayloadSessionId = authoritativeTeamWorker
     && candidateWorkerPayloadSessionId
-    && (!currentSessionState || !payloadMatchesSessionPointer(candidateWorkerPayloadSessionId, currentSessionState))
+    && (!pointer.state || !payloadMatchesSessionPointer(candidateWorkerPayloadSessionId, pointer.state))
       ? candidateWorkerPayloadSessionId
       : "";
   const declaredTeamWorkerStopOnly = hookEventName === "Stop" && declaredTeamWorker;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -19273,12 +19273,34 @@ async function buildStopHookOutput(
   payload: CodexHookPayload,
   cwd: string,
   stateDir: string,
-  options: { skipAutoNudge?: boolean; skipRalphStopBlock?: boolean; canonicalSessionId?: string } = {},
+  options: { skipAutoNudge?: boolean; skipRalphStopBlock?: boolean; canonicalSessionId?: string; teamWorkerOnly?: boolean } = {},
 ): Promise<Record<string, unknown> | null> {
   if (isStopExempt(payload)) {
     return null;
   }
 
+  if (options.teamWorkerOnly === true) {
+    const teamWorkerDecision = await resolveTeamWorkerStopDecision(cwd);
+    if (teamWorkerDecision.kind === "blocked") return teamWorkerDecision.output;
+    if (teamWorkerDecision.kind === "allowed") {
+      try {
+        await maybeNudgeLeaderForAllowedWorkerStop({
+          stateDir: teamWorkerDecision.stateDir,
+          logsDir: join(cwd, ".omx", "logs"),
+          workerContext: teamWorkerDecision.workerContext,
+        });
+      } catch (err) {
+        void err;
+      }
+      return null;
+    }
+    return {
+      decision: "block",
+      stopReason: `team_worker_${readTeamWorkerEnvironment()?.workerName ?? "unknown"}_missing_worker_state`,
+      reason: "OMX cannot resolve authoritative Team worker state for Stop.",
+      systemMessage: "OMX cannot resolve authoritative Team worker state for Stop.",
+    };
+  }
   const sessionId = readPayloadSessionId(payload);
   const canonicalSessionId = options.canonicalSessionId
     ?? await resolveInternalSessionIdForPayload(cwd, sessionId);
@@ -19724,6 +19746,9 @@ export async function dispatchCodexNativeHook(
     && (!currentSessionState || !payloadMatchesSessionPointer(candidateWorkerPayloadSessionId, currentSessionState))
       ? candidateWorkerPayloadSessionId
       : "";
+  const declaredTeamWorkerStopOnly = hookEventName === "Stop"
+    && declaredTeamWorker
+    && !authoritativeWorkerPayloadSessionId;
 
   if (hookEventName === "SessionStart" && declaredTeamWorker && !authoritativeWorkerPayloadSessionId) {
     canonicalSessionId = "";
@@ -20360,7 +20385,9 @@ export async function dispatchCodexNativeHook(
     }
     outputJson = buildNativePostToolUseOutput(payload);
   } else if (hookEventName === "Stop") {
-    if (allowImplicitSessionSideEffects) {
+    if (declaredTeamWorkerStopOnly) {
+      outputJson = await buildStopHookOutput(payload, cwd, stateDir, { teamWorkerOnly: true });
+    } else if (allowImplicitSessionSideEffects) {
       outputJson = await buildStopHookOutput(payload, cwd, stateDir, {
         canonicalSessionId: canonicalSessionId || undefined,
         skipRalphStopBlock: isSubagentStop,

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -19714,12 +19714,18 @@ export async function dispatchCodexNativeHook(
   let resolvedNativeSessionId = nativeSessionId;
   let skipCanonicalSessionStartContext = false;
   let isSubagentSessionStart = false;
-  const authoritativeTeamWorker = await hasAuthoritativeTeamWorkerContext(cwd);
-  const authoritativeWorkerPayloadSessionId = authoritativeTeamWorker
+  const declaredTeamWorker = readTeamWorkerEnvironment() !== null;
+  const authoritativeTeamWorker = declaredTeamWorker && await hasAuthoritativeTeamWorkerContext(cwd);
+  const candidateWorkerPayloadSessionId = declaredTeamWorker
     ? readUnambiguousNormalizedPayloadSessionId(payload)
     : "";
+  const authoritativeWorkerPayloadSessionId = authoritativeTeamWorker
+    && candidateWorkerPayloadSessionId
+    && (!currentSessionState || !payloadMatchesSessionPointer(candidateWorkerPayloadSessionId, currentSessionState))
+      ? candidateWorkerPayloadSessionId
+      : "";
 
-  if (hookEventName === "SessionStart" && authoritativeTeamWorker && !authoritativeWorkerPayloadSessionId) {
+  if (hookEventName === "SessionStart" && declaredTeamWorker && !authoritativeWorkerPayloadSessionId) {
     canonicalSessionId = "";
     resolvedNativeSessionId = nativeSessionId;
     skipCanonicalSessionStartContext = true;
@@ -19778,7 +19784,7 @@ export async function dispatchCodexNativeHook(
           transcriptPath,
         );
       }
-    } else if (authoritativeTeamWorker) {
+    } else if (declaredTeamWorker) {
       if (authoritativeWorkerPayloadSessionId && authoritativeWorkerPayloadSessionId === nativeSessionId) {
         // Team workers share the leader's selected state root, but they do not own
         // its compatibility pointer. Keep lifecycle state scoped to the explicit
@@ -19834,21 +19840,21 @@ export async function dispatchCodexNativeHook(
   if (hookEventName === "Stop") {
     const stopPayloadSessionId = readPayloadSessionId(payload);
     const authorizedWorkerStopSessionId = authoritativeWorkerPayloadSessionId;
-    const stopCanonicalSessionId = authoritativeTeamWorker && !authorizedWorkerStopSessionId
+    const stopCanonicalSessionId = declaredTeamWorker && !authorizedWorkerStopSessionId
       ? ""
       : await resolveInternalSessionIdForPayload(
         cwd,
         authorizedWorkerStopSessionId || stopPayloadSessionId,
         undefined,
         currentSessionState,
-        authoritativeTeamWorker
+        declaredTeamWorker
           ? Boolean(authorizedWorkerStopSessionId)
           : pointer.status === "absent",
       );
-    if ((authoritativeTeamWorker && !authorizedWorkerStopSessionId) || (stopPayloadSessionId && !stopCanonicalSessionId)) {
+    if ((declaredTeamWorker && !authorizedWorkerStopSessionId) || (stopPayloadSessionId && !stopCanonicalSessionId)) {
       canonicalSessionId = "";
       allowImplicitSessionSideEffects = false;
-      if (authoritativeTeamWorker && !authorizedWorkerStopSessionId) {
+      if (declaredTeamWorker && !authorizedWorkerStopSessionId) {
         stopAuthorizationFailure = {
           stopReason: "session_scope_unmatched",
           reason: "OMX cannot authorize Team worker Stop without exactly one valid explicit session id.",
@@ -19905,7 +19911,7 @@ export async function dispatchCodexNativeHook(
   if (
     isSubagentStop
     && stopAuthorizationFailure?.stopReason === "session_scope_unmatched"
-    && !(authoritativeTeamWorker && !authoritativeWorkerPayloadSessionId)
+    && !(declaredTeamWorker && !authoritativeWorkerPayloadSessionId)
   ) {
     canonicalSessionId = normalizeSessionId(readPayloadSessionId(payload)) ?? "";
     allowImplicitSessionSideEffects = true;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -19773,14 +19773,21 @@ export async function dispatchCodexNativeHook(
           transcriptPath,
         );
       }
-    } else if (authoritativeWorkerPayloadSessionId && authoritativeWorkerPayloadSessionId === nativeSessionId) {
-      // Team workers share the leader's selected state root, but they do not own
-      // its compatibility pointer. Keep lifecycle state scoped to the explicit
-      // hook payload without reconciling or replacing the live leader pointer.
-      canonicalSessionId = authoritativeWorkerPayloadSessionId;
-      resolvedNativeSessionId = authoritativeWorkerPayloadSessionId;
-      allowImplicitSessionSideEffects = true;
-      stopAuthorizationFailure = null;
+    } else if (authoritativeTeamWorker) {
+      if (authoritativeWorkerPayloadSessionId && authoritativeWorkerPayloadSessionId === nativeSessionId) {
+        // Team workers share the leader's selected state root, but they do not own
+        // its compatibility pointer. Keep lifecycle state scoped to the explicit
+        // hook payload without reconciling or replacing the live leader pointer.
+        canonicalSessionId = authoritativeWorkerPayloadSessionId;
+        resolvedNativeSessionId = authoritativeWorkerPayloadSessionId;
+        allowImplicitSessionSideEffects = true;
+        stopAuthorizationFailure = null;
+      } else {
+        canonicalSessionId = "";
+        resolvedNativeSessionId = nativeSessionId;
+        skipCanonicalSessionStartContext = true;
+        allowImplicitSessionSideEffects = false;
+      }
     } else {
       const ownerOmxSessionId = await resolveVerifiedOwnerOmxSessionId();
       try {
@@ -19827,7 +19834,9 @@ export async function dispatchCodexNativeHook(
       authorizedWorkerStopSessionId || stopPayloadSessionId,
       undefined,
       currentSessionState,
-      pointer.status === "absent" || Boolean(authorizedWorkerStopSessionId),
+      authoritativeTeamWorker
+        ? Boolean(authorizedWorkerStopSessionId)
+        : pointer.status === "absent",
     );
     if (stopPayloadSessionId && !stopCanonicalSessionId) {
       canonicalSessionId = "";

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2810,9 +2810,10 @@ async function buildDeclaredTeamWorkerStopOutput(
   payload: CodexHookPayload,
   cwd: string,
 ): Promise<Record<string, unknown> | null> {
+  if (isStopExempt(payload)) return null;
   const decision = await resolveTeamWorkerStopDecision(cwd);
   if (decision.kind === "blocked") {
-    if (payload.stop_hook_active === true && !decision.allowRepeatDuringStopHook) return null;
+    if ((payload.stop_hook_active === true || payload.stopHookActive === true) && !decision.allowRepeatDuringStopHook) return null;
     return decision.output;
   }
   if (decision.kind === "allowed") {
@@ -19715,20 +19716,20 @@ export async function dispatchCodexNativeHook(
       outputJson: null,
     };
   }
-  if (hookEventName === "Stop" && !hasNativeStopRuntimeSurface(cwd)) {
-    return {
-      hookEventName,
-      omxEventName: mapCodexHookEventToOmxEvent(hookEventName),
-      skillState: null,
-      outputJson: null,
-    };
-  }
   if (hookEventName === "Stop" && hasRawTeamWorkerDeclaration()) {
     return {
       hookEventName,
       omxEventName: mapCodexHookEventToOmxEvent(hookEventName),
       skillState: null,
       outputJson: await buildDeclaredTeamWorkerStopOutput(payload, cwd),
+    };
+  }
+  if (hookEventName === "Stop" && !hasNativeStopRuntimeSurface(cwd)) {
+    return {
+      hookEventName,
+      omxEventName: mapCodexHookEventToOmxEvent(hookEventName),
+      skillState: null,
+      outputJson: null,
     };
   }
   // Native hooks must use the exact pointer root selected for this dispatch.

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -19719,7 +19719,12 @@ export async function dispatchCodexNativeHook(
     ? readUnambiguousNormalizedPayloadSessionId(payload)
     : "";
 
-  if (hookEventName === "SessionStart" && nativeSessionId) {
+  if (hookEventName === "SessionStart" && authoritativeTeamWorker && !authoritativeWorkerPayloadSessionId) {
+    canonicalSessionId = "";
+    resolvedNativeSessionId = nativeSessionId;
+    skipCanonicalSessionStartContext = true;
+    allowImplicitSessionSideEffects = false;
+  } else if (hookEventName === "SessionStart" && nativeSessionId) {
     const transcriptPath = safeString(payload.transcript_path ?? payload.transcriptPath).trim();
     const subagentSessionStart = readNativeSubagentSessionStartMetadata(transcriptPath);
     if (subagentSessionStart) {
@@ -19829,19 +19834,26 @@ export async function dispatchCodexNativeHook(
   if (hookEventName === "Stop") {
     const stopPayloadSessionId = readPayloadSessionId(payload);
     const authorizedWorkerStopSessionId = authoritativeWorkerPayloadSessionId;
-    const stopCanonicalSessionId = await resolveInternalSessionIdForPayload(
-      cwd,
-      authorizedWorkerStopSessionId || stopPayloadSessionId,
-      undefined,
-      currentSessionState,
-      authoritativeTeamWorker
-        ? Boolean(authorizedWorkerStopSessionId)
-        : pointer.status === "absent",
-    );
-    if (stopPayloadSessionId && !stopCanonicalSessionId) {
+    const stopCanonicalSessionId = authoritativeTeamWorker && !authorizedWorkerStopSessionId
+      ? ""
+      : await resolveInternalSessionIdForPayload(
+        cwd,
+        authorizedWorkerStopSessionId || stopPayloadSessionId,
+        undefined,
+        currentSessionState,
+        authoritativeTeamWorker
+          ? Boolean(authorizedWorkerStopSessionId)
+          : pointer.status === "absent",
+      );
+    if ((authoritativeTeamWorker && !authorizedWorkerStopSessionId) || (stopPayloadSessionId && !stopCanonicalSessionId)) {
       canonicalSessionId = "";
       allowImplicitSessionSideEffects = false;
-      if (!stopAuthorizationFailure) {
+      if (authoritativeTeamWorker && !authorizedWorkerStopSessionId) {
+        stopAuthorizationFailure = {
+          stopReason: "session_scope_unmatched",
+          reason: "OMX cannot authorize Team worker Stop without exactly one valid explicit session id.",
+        };
+      } else if (!stopAuthorizationFailure) {
         stopAuthorizationFailure = {
           stopReason: "session_scope_unmatched",
           reason: `OMX cannot authorize Stop for unmatched session id ${stopPayloadSessionId}; the selected session pointer remains authoritative.`,

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -19281,7 +19281,17 @@ async function buildStopHookOutput(
 
   if (options.teamWorkerOnly === true) {
     const teamWorkerDecision = await resolveTeamWorkerStopDecision(cwd);
-    if (teamWorkerDecision.kind === "blocked") return teamWorkerDecision.output;
+    if (teamWorkerDecision.kind === "blocked") {
+      return await returnPersistentStopBlock(
+        payload,
+        stateDir,
+        "team-worker-stop",
+        safeString(teamWorkerDecision.output.stopReason),
+        teamWorkerDecision.output,
+        undefined,
+        { allowRepeatDuringStopHook: teamWorkerDecision.allowRepeatDuringStopHook },
+      );
+    }
     if (teamWorkerDecision.kind === "allowed") {
       try {
         await maybeNudgeLeaderForAllowedWorkerStop({
@@ -19736,7 +19746,8 @@ export async function dispatchCodexNativeHook(
   let resolvedNativeSessionId = nativeSessionId;
   let skipCanonicalSessionStartContext = false;
   let isSubagentSessionStart = false;
-  const declaredTeamWorker = readTeamWorkerEnvironment() !== null;
+  const declaredTeamWorker = safeString(process.env.OMX_TEAM_INTERNAL_WORKER).trim() !== ""
+    || safeString(process.env.OMX_TEAM_WORKER).trim() !== "";
   const authoritativeTeamWorker = declaredTeamWorker && await hasAuthoritativeTeamWorkerContext(cwd);
   const candidateWorkerPayloadSessionId = declaredTeamWorker
     ? readUnambiguousNormalizedPayloadSessionId(payload)
@@ -19746,9 +19757,7 @@ export async function dispatchCodexNativeHook(
     && (!currentSessionState || !payloadMatchesSessionPointer(candidateWorkerPayloadSessionId, currentSessionState))
       ? candidateWorkerPayloadSessionId
       : "";
-  const declaredTeamWorkerStopOnly = hookEventName === "Stop"
-    && declaredTeamWorker
-    && !authoritativeWorkerPayloadSessionId;
+  const declaredTeamWorkerStopOnly = hookEventName === "Stop" && declaredTeamWorker;
 
   if (hookEventName === "SessionStart" && declaredTeamWorker && !authoritativeWorkerPayloadSessionId) {
     canonicalSessionId = "";

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2684,7 +2684,7 @@ async function resolveTeamWorkerStopDecision(
   const blockWorkerStop = (
     reasonCode: string,
     detail: string,
-    stateDirForDecision = getBaseStateDir(cwd),
+    stateDirForDecision = join(cwd, ".omx", "state"),
   ): TeamWorkerStopDecision => ({
     kind: "blocked",
     stateDir: stateDirForDecision,
@@ -19747,7 +19747,13 @@ export async function dispatchCodexNativeHook(
   let teamNoticeTargetKey: string | null = null;
   let promptClassification: KeywordInputClassification | null = null;
 
-  const nativeSessionId = safeString(payload.session_id ?? payload.sessionId).trim();
+  const declaredTeamWorker = hasRawTeamWorkerDeclaration();
+  const candidateWorkerPayloadSessionId = declaredTeamWorker
+    ? readUnambiguousNormalizedPayloadSessionId(payload)
+    : "";
+  const nativeSessionId = declaredTeamWorker
+    ? candidateWorkerPayloadSessionId
+    : safeString(payload.session_id ?? payload.sessionId).trim();
   const threadId = safeString(payload.thread_id ?? payload.threadId).trim();
   const turnId = safeString(payload.turn_id ?? payload.turnId).trim();
   const pointer = await readSessionPointer(pointerContext);
@@ -19791,11 +19797,7 @@ export async function dispatchCodexNativeHook(
   let resolvedNativeSessionId = nativeSessionId;
   let skipCanonicalSessionStartContext = false;
   let isSubagentSessionStart = false;
-  const declaredTeamWorker = hasRawTeamWorkerDeclaration();
   const authoritativeTeamWorker = declaredTeamWorker && await hasAuthoritativeTeamWorkerContext(cwd);
-  const candidateWorkerPayloadSessionId = declaredTeamWorker
-    ? readUnambiguousNormalizedPayloadSessionId(payload)
-    : "";
   const authoritativeWorkerPayloadSessionId = authoritativeTeamWorker
     && candidateWorkerPayloadSessionId
     && (!pointer.state || !payloadMatchesSessionPointer(candidateWorkerPayloadSessionId, pointer.state))

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -19708,6 +19708,11 @@ export async function dispatchCodexNativeHook(
   let resolvedNativeSessionId = nativeSessionId;
   let skipCanonicalSessionStartContext = false;
   let isSubagentSessionStart = false;
+  const authoritativeTeamWorker = await hasAuthoritativeTeamWorkerContext(cwd);
+  if (authoritativeTeamWorker) {
+    allowImplicitSessionSideEffects = true;
+    stopAuthorizationFailure = null;
+  }
 
   if (hookEventName === "SessionStart" && nativeSessionId) {
     const transcriptPath = safeString(payload.transcript_path ?? payload.transcriptPath).trim();
@@ -19763,6 +19768,12 @@ export async function dispatchCodexNativeHook(
           transcriptPath,
         );
       }
+    } else if (authoritativeTeamWorker) {
+      // Team workers share the leader's selected state root, but they do not own
+      // its compatibility pointer. Keep lifecycle state scoped to the explicit
+      // hook payload without reconciling or replacing the live leader pointer.
+      canonicalSessionId = nativeSessionId;
+      resolvedNativeSessionId = nativeSessionId;
     } else {
       const ownerOmxSessionId = await resolveVerifiedOwnerOmxSessionId();
       try {
@@ -19808,7 +19819,7 @@ export async function dispatchCodexNativeHook(
       stopPayloadSessionId,
       undefined,
       currentSessionState,
-      pointer.status === "absent",
+      pointer.status === "absent" || authoritativeTeamWorker,
     );
     if (stopPayloadSessionId && !stopCanonicalSessionId) {
       canonicalSessionId = "";


### PR DESCRIPTION
## Summary
- prevent an authoritative Team worker SessionStart from reconciling or replacing the shared leader-selected session pointer
- resolve worker SessionStart and Stop state from explicit hook payload identity after full Team worker identity validation
- keep malformed, foreign, nested, non-Team, and stale-pointer behavior bounded without broad pointer recovery or last-writer-wins semantics

## Regression coverage
- exact leader SessionStart -> worker SessionStart -> leader Stop interleaving
- worker Stop explicit session scope
- foreign, nested, and non-Team contexts
- stale leader and malformed pointer evidence
- packed native-hook entrypoint

## Verification
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
- focused native hook suite: 569 passed
- focused session pointer suite: 48 passed
- `npm test`: 385 compiled test files passed; catalog check passed

This deliberately does not change stale-dead finalization behavior tracked in #3202.

Closes #3221