### PR TITLE
fix(team): invalidate stale queued notices

### DIFF
--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -1626,7 +1626,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, /display-message -p -t %93 #\{pane_in_mode\}/);
       assert.match(tmuxLog, /capture-pane -t %93 -p -S -80/);
-      assert.match(tmuxLog, /send-keys -t %93 -l .*Team busy-live-pane:/);
+      assert.match(tmuxLog, /send-keys -t %93 -l \[omx:team-notice-ledger:[a-f0-9]{24}\] Review current Team notices\./);
       assert.match(tmuxLog, /send-keys -t %93 Tab/);
       assert.match(tmuxLog, /send-keys -t %93 C-m/);
       assert.ok(
@@ -1634,6 +1634,12 @@ exit 0
         'busy leader queue path should press Tab before C-m',
       );
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should keep the injection marker on busy-pane sends');
+      assert.doesNotMatch(tmuxLog, /send-keys -t %93 -l .*busy-live-pane/, 'busy queued wake must not retain a Team reference in model-visible input');
+      const ledger = JSON.parse(await readFile(join(stateDir, 'team', 'notice-ledger.json'), 'utf-8')) as {
+        notices?: Record<string, { teamName?: string; noticeClass?: string; presentedAt?: string }>;
+      };
+      assert.ok(Object.values(ledger.notices ?? {}).some((notice) =>
+        notice.teamName === teamName && notice.noticeClass === 'mailbox' && notice.presentedAt === undefined));
 
       const eventsPath = join(teamDir, 'events', 'events.ndjson');
       assert.ok(existsSync(eventsPath), 'events.ndjson should exist');

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -26,6 +26,7 @@ import {
 	writeTeamLeaderAttention,
   writeWorkerIdentity,
 } from "../../team/state.js";
+import { registerTeamNotice } from "../../team/notice-ledger.js";
 import {
 	dispatchCodexNativeHook,
 	isCodexNativeHookMainModule,
@@ -23147,8 +23148,8 @@ PY`,
 
       assert.equal(result.outputJson, null);
       const tmuxLog = await readFile(tmuxLogPath, "utf-8");
-      assert.match(tmuxLog, /send-keys -t %42 -l \[OMX\] worker-1 native Stop allowed/);
-      assert.doesNotMatch(tmuxLog, /send-keys -t %42 Tab/);
+      assert.match(tmuxLog, /send-keys -t %42 -l \[omx:team-notice-ledger:[a-f0-9]{24}\] Review current Team notices\./);
+      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l .*worker-stop-team-busy-leader|send-keys -t %42 Tab/);
       const submits = tmuxLog.match(/send-keys -t %42 C-m/g) || [];
       assert.equal(submits.length, 2, "busy worker-stop nudge should submit directly as steering, not queue via Tab");
       const nudgeState = JSON.parse(await readFile(join(workerDir, "worker-stop-nudge.json"), "utf-8"));
@@ -23344,8 +23345,8 @@ PY`,
 
       assert.equal(result.result, "steered");
       const tmuxLog = await readFile(tmuxLogPath, "utf-8");
-      assert.match(tmuxLog, /send-keys -t %42 -l \[OMX\] worker-2 native Stop allowed/);
-      assert.doesNotMatch(tmuxLog, /send-keys -t %42 Tab/);
+      assert.match(tmuxLog, /send-keys -t %42 -l \[omx:team-notice-ledger:[a-f0-9]{24}\] Review current Team notices\./);
+      assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l .*worker-2 native Stop allowed|send-keys -t %42 Tab/);
       const teamNudgeState = JSON.parse(await readFile(join(teamDir, "worker-stop-nudge.json"), "utf-8"));
       assert.equal(teamNudgeState.worker, "worker-2");
       assert.equal(teamNudgeState.delivery, "steered");
@@ -35315,6 +35316,54 @@ describe('native UserPromptSubmit payload provenance', () => {
       assert.equal(foreignChild.skillState, null);
       assert.equal(existsSync(join(stateDir, 'sessions', 'foreign-child', 'skill-active-state.json')), false);
       assert.equal(await readFile(join(stateDir, 'sessions', 'selected-root', 'sentinel.json'), 'utf-8'), sentinelBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("native Team notice ledger reconciliation", () => {
+  it("invalidates removed Teams before queued wake context reaches the model", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-team-notice-ledger-"));
+    const stateRoot = join(cwd, ".omx", "state");
+    try {
+      const session = await writeSessionStart(cwd, "sess-team-notice-ledger");
+      let wakePrompt = "";
+      for (const teamName of ["notice-live", "notice-removed"]) {
+        const teamDir = join(stateRoot, "team", teamName);
+        await mkdir(teamDir, { recursive: true });
+        await writeFile(join(teamDir, "config.json"), JSON.stringify({ team_name: teamName }));
+        const registration = await registerTeamNotice({
+          stateRoot,
+          targetId: "leader-shared",
+          teamName,
+          noticeClass: "mailbox",
+          generation: "1",
+          source: { kind: "test" },
+        });
+        wakePrompt ||= registration.prompt ?? "";
+      }
+      await rm(join(stateRoot, "team", "notice-removed"), { recursive: true, force: true });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "UserPromptSubmit",
+        cwd,
+        session_id: session.session_id,
+        prompt: `${wakePrompt} [OMX_TMUX_INJECT]`,
+      }, { cwd });
+      const context = String((result.outputJson?.hookSpecificOutput as { additionalContext?: unknown } | undefined)?.additionalContext ?? "");
+      assert.match(context, /notice-live \(mailbox\)/);
+      assert.doesNotMatch(context, /notice-removed/);
+
+      const replay = await dispatchCodexNativeHook({
+        hook_event_name: "UserPromptSubmit",
+        cwd,
+        session_id: session.session_id,
+        prompt: `${wakePrompt} [OMX_TMUX_INJECT]`,
+      }, { cwd });
+      const replayContext = String((replay.outputJson?.hookSpecificOutput as { additionalContext?: unknown } | undefined)?.additionalContext ?? "");
+      assert.match(replayContext, /notice-live \(mailbox\)/);
+      assert.doesNotMatch(replayContext, /notice-removed/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -63,6 +63,7 @@ import {
   writeTeamLeaderAttention,
   writeTeamPhase,
 } from "../team/state.js";
+import { parseTeamNoticeLedgerPrompt, reconcileTeamNoticeLedger } from "../team/notice-ledger.js";
 import { omxNotepadPath, resolveProjectMemoryPath } from "../utils/paths.js";
 import { findGitLayout } from "../utils/git-layout.js";
 import {
@@ -19659,6 +19660,8 @@ export async function dispatchCodexNativeHook(
   let triageAdditionalContext: string | null = null;
   let goalWorkflowAdditionalContext: string | null = null;
   let ultragoalSteeringAdditionalContext: string | null = null;
+  let teamNoticeAdditionalContext: string | null = null;
+  let teamNoticeTargetKey: string | null = null;
   let promptClassification: KeywordInputClassification | null = null;
 
   const nativeSessionId = safeString(payload.session_id ?? payload.sessionId).trim();
@@ -19869,6 +19872,9 @@ export async function dispatchCodexNativeHook(
   if (hookEventName === "UserPromptSubmit") {
     const prompt = readPromptText(payload);
     if (!isSubagentPromptSubmit) {
+      teamNoticeTargetKey = parseTeamNoticeLedgerPrompt(prompt);
+    }
+    if (!isSubagentPromptSubmit) {
       promptClassification = classifyKeywordInput(prompt);
     }
     goalWorkflowAdditionalContext = allowPromptGlobalSideEffects
@@ -20047,6 +20053,31 @@ export async function dispatchCodexNativeHook(
       allowTeamWorkerSideEffects: false,
     });
   }
+  if (hookEventName === "UserPromptSubmit" && !isSubagentPromptSubmit && teamNoticeTargetKey) {
+    const reconciled = await reconcileTeamNoticeLedger({ stateRoot: stateDir, targetKey: teamNoticeTargetKey }).catch(() => null);
+    if (!reconciled || reconciled.context.length === 0) {
+      teamNoticeAdditionalContext = "OMX invalidated this queued Team wake immediately before model input because no active source-proven Team notices remain. Do not infer or reference a removed Team from the generic wake.";
+    } else {
+      const byTeam = new Map<string, Set<string>>();
+      for (const notice of reconciled.context) {
+        const classes = byTeam.get(notice.teamName) ?? new Set<string>();
+        classes.add(notice.noticeClass);
+        byTeam.set(notice.teamName, classes);
+      }
+      const entries = [...byTeam.entries()];
+      const visible = entries.slice(0, 12).map(([teamName, classes]) =>
+        `${teamName} (${[...classes].join(", ")}): run \`omx team status ${teamName}\`, read current messages/results, then assign, reconcile, or shut down.`
+      );
+      const overflow = entries.length > visible.length
+        ? `Also inspect the remaining ${entries.length - visible.length} active Team director${entries.length - visible.length === 1 ? "y" : "ies"} under .omx/state/team before concluding.`
+        : null;
+      teamNoticeAdditionalContext = [
+        `OMX reconciled ${reconciled.presented} queued Team notice generation(s) against current canonical state immediately before model input.`,
+        ...visible,
+        overflow,
+      ].filter(Boolean).join("\n");
+    }
+  }
 
   if (hookEventName === "PreCompact") {
     // Codex native PreCompact currently accepts only the common continuation fields.
@@ -20063,14 +20094,13 @@ export async function dispatchCodexNativeHook(
       })
       : isSubagentPromptSubmit
         ? null
-        : promptClassification
-          ? [
-            buildAdditionalContextMessage(promptClassification, skillState, cwd, payload),
-            ultragoalSteeringAdditionalContext,
-            goalWorkflowAdditionalContext,
-            triageAdditionalContext,
-          ].filter((entry): entry is string => Boolean(entry)).join("\n\n") || null
-          : null;
+        : [
+          teamNoticeAdditionalContext,
+          promptClassification ? buildAdditionalContextMessage(promptClassification, skillState, cwd, payload) : null,
+          ultragoalSteeringAdditionalContext,
+          goalWorkflowAdditionalContext,
+          triageAdditionalContext,
+        ].filter((entry): entry is string => Boolean(entry)).join("\n\n") || null;
     if (additionalContext) {
       outputJson = {
         hookSpecificOutput: {

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -24,6 +24,7 @@ import { readLatestTeamProgressEvidenceMs } from '../../team/progress-evidence.j
 import { validateSessionId } from '../../mcp/state-paths.js';
 import { TEAM_NAME_SAFE_PATTERN } from '../../team/contracts.js';
 import { isDeepInterviewStateActive } from './auto-nudge.js';
+import { registerTeamNotice, releaseTeamNoticeWake } from '../../team/notice-ledger.js';
 const LEADER_PANE_MISSING_NO_INJECTION_REASON = 'leader_pane_missing_no_injection';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
 const TEAM_SHUTDOWN_NO_INJECTION_REASON = 'team_state_gone_or_shutdown';
@@ -1043,8 +1044,16 @@ export async function maybeNudgeTeamLeader({
       await recordShutdownSuppression(orchestrationIntent);
       continue;
     }
-    const capped = text.length > 180 ? `${text.slice(0, 177)}...` : text;
-    const markedText = `${capped} ${DEFAULT_MARKER}`;
+    const noticeClass = nudgeReason === 'all_workers_idle'
+      || nudgeReason === 'done_waiting_on_leader'
+      || nudgeReason === 'stuck_waiting_on_leader'
+      ? 'all_idle'
+      : nudgeReason.includes('stale')
+        ? 'leader_stale'
+        : 'mailbox';
+    const noticeGeneration = noticeClass === 'mailbox' && newestId
+      ? newestId
+      : `${nudgeReason}:${progressSnapshot.signature}:${prevIdleAtIso || prevAtIso || 'initial'}`;
 
     if (!tmuxTarget) {
       if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
@@ -1148,7 +1157,7 @@ export async function maybeNudgeTeamLeader({
       continue;
     }
 
-    if (paneAlreadyShowsVisibleLeaderState(paneGuard.paneCapture, capped)) {
+    if (paneAlreadyShowsVisibleLeaderState(paneGuard.paneCapture, text)) {
       if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
         await recordShutdownSuppression(orchestrationIntent);
         continue;
@@ -1194,11 +1203,26 @@ export async function maybeNudgeTeamLeader({
       await recordShutdownSuppression(orchestrationIntent);
       continue;
     }
-
+    let queuedNoticeRegistration = null;
     try {
       const leaderHasActiveTask = paneHasActiveTask(paneGuard.paneCapture);
       let deliveryMode = 'sent';
+      let markedText = `${text.length > 180 ? `${text.slice(0, 177)}...` : text} ${DEFAULT_MARKER}`;
       if (leaderHasActiveTask) {
+        const noticeRegistration = await registerTeamNotice({
+          stateRoot: stateDir,
+          targetId: tmuxPaneOwnerId,
+          teamName,
+          noticeClass,
+          generation: noticeGeneration,
+          source: { kind: 'leader_nudge', detail: nudgeReason },
+        }).catch(() => null);
+        if (!noticeRegistration?.queued || !noticeRegistration.prompt) {
+          await persistLeaderNudgeBookkeeping({ orchestrationIntent, recordLastNudged: true });
+          continue;
+        }
+        markedText = `${noticeRegistration.prompt} ${DEFAULT_MARKER}`;
+        queuedNoticeRegistration = noticeRegistration;
         const sendResult = await sendPaneInput({
           paneTarget: tmuxTarget,
           prompt: markedText,
@@ -1214,6 +1238,7 @@ export async function maybeNudgeTeamLeader({
           throw new Error(sendResult.error || sendResult.reason);
         }
         deliveryMode = 'queued';
+        queuedNoticeRegistration = null;
       } else {
         const sendResult = await sendPaneInput({
           paneTarget: tmuxTarget,
@@ -1266,6 +1291,9 @@ export async function maybeNudgeTeamLeader({
         orchestration_intent: orchestrationIntent,
       }).catch(() => {});
     } catch (err) {
+      if (queuedNoticeRegistration?.targetKey && queuedNoticeRegistration?.wakeId) {
+        await releaseTeamNoticeWake(stateDir, queuedNoticeRegistration.targetKey, queuedNoticeRegistration.wakeId).catch(() => {});
+      }
       if (!(await teamStateAllowsLeaderNudge(stateDir, teamName))) {
         await recordShutdownSuppression(orchestrationIntent);
         continue;

--- a/src/scripts/notify-hook/team-worker-stop.ts
+++ b/src/scripts/notify-hook/team-worker-stop.ts
@@ -16,6 +16,7 @@ import { readJsonIfExists } from './state-io.js';
 import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, normalizeExactPaneId, sendPaneInput } from './team-tmux-guard.js';
 import { readTeamWorkersForIdleCheck } from './team-worker.js';
+import { registerTeamNotice, releaseTeamNoticeWake } from '../../team/notice-ledger.js';
 
 const STOP_NUDGE_COOLDOWN_MS = 30_000;
 const SOURCE_TYPE = 'worker_stop';
@@ -249,6 +250,7 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
   let tmuxSession = '';
   let leaderPaneId = '';
   let recordedShutdownSuppression = false;
+  let queuedNoticeRegistration = null;
   const recordShutdownSuppressionOnce = async () => {
     if (recordedShutdownSuppression) return;
     recordedShutdownSuppression = true;
@@ -356,10 +358,23 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
     return { ok: true, result: TEAM_SHUTDOWN_NO_INJECTION_REASON };
   }
 
-  const prompt =
-    `[OMX] ${workerName} native Stop allowed. `
-    + `Run \`omx team status ${teamName}\`, read worker messages/results, then assign next task, reconcile completion, or shut down. `
-    + DEFAULT_MARKER;
+  const leaderBusy = paneHasActiveTask(paneGuard.paneCapture);
+  let prompt = `[OMX] ${workerName} native Stop allowed. Run \`omx team status ${teamName}\`, read worker messages/results, then assign next task, reconcile completion, or shut down. ${DEFAULT_MARKER}`;
+  if (leaderBusy) {
+    const noticeRegistration = await registerTeamNotice({
+      stateRoot: stateDir,
+      targetId: leaderPaneOwnerId,
+      teamName,
+      noticeClass: 'worker_stop',
+      generation: `${nowIso}:${workerName}`,
+      source: { kind: SOURCE_TYPE, detail: workerName },
+    }).catch(() => null);
+    if (!noticeRegistration?.queued || !noticeRegistration.prompt) {
+      return { ok: true, result: 'coalesced' };
+    }
+    prompt = `${noticeRegistration.prompt} ${DEFAULT_MARKER}`;
+    queuedNoticeRegistration = noticeRegistration;
+  }
 
     const leaderHasActiveTask = paneHasActiveTask(paneGuard.paneCapture);
     const sendResult = await sendPaneInput({
@@ -373,6 +388,7 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
       expectedHudPaneId: teamInfo.hudPaneId,
     });
     if (!sendResult.ok) throw new Error(sendResult.error || sendResult.reason || 'send_failed');
+    queuedNoticeRegistration = null;
     const deliveryMode = leaderHasActiveTask ? 'steered' : 'sent';
 
     const deliveryState = {
@@ -418,6 +434,9 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
     }).catch(() => {});
     return { ok: true, result: deliveryMode };
   } catch (err) {
+    if (queuedNoticeRegistration?.targetKey && queuedNoticeRegistration?.wakeId) {
+      await releaseTeamNoticeWake(stateDir, queuedNoticeRegistration.targetKey, queuedNoticeRegistration.wakeId).catch(() => {});
+    }
     if (!(await teamStateAllowsWorkerStopNudge(stateDir, teamName))) {
       await recordShutdownSuppressionOnce();
       return { ok: true, result: TEAM_SHUTDOWN_NO_INJECTION_REASON };

--- a/src/scripts/notify-hook/team-worker.ts
+++ b/src/scripts/notify-hook/team-worker.ts
@@ -16,7 +16,8 @@ import {
   resolveAllWorkersIdleIntent,
   resolveWorkerIdleIntent,
 } from './orchestration-intent.js';
-import { DEFAULT_MARKER } from '../tmux-hook-engine.js';
+import { DEFAULT_MARKER, paneHasActiveTask } from '../tmux-hook-engine.js';
+import { registerTeamNotice, releaseTeamNoticeWake } from '../../team/notice-ledger.js';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
 
 function positivePanePid(value) {
@@ -425,8 +426,6 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
   }
 
   const N = workers.length;
-  const nextAction = `Run \`omx team status ${teamName}\` now, read unread worker messages, then assign the next concrete task, reconcile results, or shut the team down.`;
-  const message = `[OMX] All ${N} worker${N === 1 ? '' : 's'} idle. ${nextAction} ${DEFAULT_MARKER}`;
   const tmuxTarget = canonicalLeaderPaneId;
   const paneGuard = await checkLeaderPaneReadyForWorkerStateReminder(tmuxTarget, canonicalLeaderPaneId, leaderPanePid, tmuxPaneOwnerId);
   if (!paneGuard.ok) {
@@ -454,6 +453,22 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
     });
     return;
   }
+  const leaderBusy = paneHasActiveTask(paneGuard.paneCapture);
+  let queuedNoticeRegistration = null;
+  let message = `[OMX] All ${N} worker${N === 1 ? '' : 's'} idle. Run \`omx team status ${teamName}\` now, read unread worker messages, then assign the next concrete task, reconcile results, or shut the team down. ${DEFAULT_MARKER}`;
+  if (leaderBusy) {
+    const noticeRegistration = await registerTeamNotice({
+      stateRoot: stateDir,
+      targetId: tmuxPaneOwnerId,
+      teamName,
+      noticeClass: 'all_idle',
+      generation: `${nowIso}:${N}:${orchestrationIntent}`,
+      source: { kind: 'all_workers_idle', detail: orchestrationIntent },
+    }).catch(() => null);
+    if (!noticeRegistration?.queued || !noticeRegistration.prompt) return;
+    message = `${noticeRegistration.prompt} ${DEFAULT_MARKER}`;
+    queuedNoticeRegistration = noticeRegistration;
+  }
 
   try {
     const sendResult = await sendPaneInput({
@@ -467,6 +482,7 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
       expectedHudPaneId: hudPaneId,
     });
     if (!sendResult.ok) throw new Error(sendResult.error || sendResult.reason || 'send_failed');
+    queuedNoticeRegistration = null;
 
     const nextIdleState = {
       ...idleState,
@@ -503,6 +519,9 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
       orchestration_intent: orchestrationIntent,
     });
   } catch (err) {
+    if (queuedNoticeRegistration?.targetKey && queuedNoticeRegistration?.wakeId) {
+      await releaseTeamNoticeWake(stateDir, queuedNoticeRegistration.targetKey, queuedNoticeRegistration.wakeId).catch(() => {});
+    }
     await logTmuxHookEvent(logsDir, {
       timestamp: nowIso,
       type: 'all_workers_idle_notification',
@@ -646,13 +665,28 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
     return;
   }
 
-  // Build notification message with context
+  // Build notification message with context. Busy panes use the durable ledger wake.
   const parts = [`[OMX] ${workerName} ${currentState}`];
   if (prevState && prevState !== 'unknown') parts.push(`(was: ${prevState})`);
   if (currentTaskId) parts.push(`task: ${currentTaskId}`);
   if (currentReason) parts.push(`reason: ${currentReason}`);
   parts.push(`Next: read ${workerName}'s latest message/output, then assign the next concrete step or mark the task complete.`);
-  const message = `${parts.join('. ')}. ${DEFAULT_MARKER}`;
+  const leaderBusy = paneHasActiveTask(paneGuard.paneCapture);
+  let queuedNoticeRegistration = null;
+  let message = `${parts.join('. ')}. ${DEFAULT_MARKER}`;
+  if (leaderBusy) {
+    const noticeRegistration = await registerTeamNotice({
+      stateRoot: stateDir,
+      targetId: tmuxPaneOwnerId,
+      teamName,
+      noticeClass: 'worker_idle',
+      generation: `${workerName}:${currentState}:${currentTaskId}:${safeString(heartbeat.last_turn_at)}`,
+      source: { kind: 'worker_idle', detail: orchestrationIntent },
+    }).catch(() => null);
+    if (!noticeRegistration?.queued || !noticeRegistration.prompt) return;
+    queuedNoticeRegistration = noticeRegistration;
+    message = `${noticeRegistration.prompt} ${DEFAULT_MARKER}`;
+  }
 
   try {
     const sendResult = await sendPaneInput({
@@ -666,6 +700,7 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
       expectedHudPaneId: hudPaneId,
     });
     if (!sendResult.ok) throw new Error(sendResult.error || sendResult.reason || 'send_failed');
+    queuedNoticeRegistration = null;
 
     // Update cooldown state
     try {
@@ -709,6 +744,9 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
       orchestration_intent: orchestrationIntent,
     });
   } catch (err) {
+    if (queuedNoticeRegistration?.targetKey && queuedNoticeRegistration?.wakeId) {
+      await releaseTeamNoticeWake(stateDir, queuedNoticeRegistration.targetKey, queuedNoticeRegistration.wakeId).catch(() => {});
+    }
     await logTmuxHookEvent(logsDir, {
       timestamp: nowIso,
       type: 'worker_idle_notification',

--- a/src/team/__tests__/notice-ledger.test.ts
+++ b/src/team/__tests__/notice-ledger.test.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { mkdtemp, mkdir, readFile, rm, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildTeamNoticeLedgerPrompt,
+  parseTeamNoticeLedgerPrompt,
+  reconcileTeamNoticeLedger,
+  registerTeamNotice,
+  releaseTeamNoticeWake,
+  teamNoticeLedgerLockPath,
+  teamNoticeLedgerPath,
+  teamNoticeTargetKey,
+  type TeamNoticeClass,
+} from '../notice-ledger.js';
+
+async function fixture(): Promise<{ root: string; stateRoot: string }> {
+  const root = await mkdtemp(join(tmpdir(), 'omx-notice-ledger-'));
+  return { root, stateRoot: join(root, '.omx', 'state') };
+}
+
+async function liveTeam(stateRoot: string, name: string): Promise<void> {
+  const dir = join(stateRoot, 'team', name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'config.json'), JSON.stringify({ team_name: name }), 'utf8');
+}
+
+function registration(stateRoot: string, teamName: string, targetId: string, generation: string, noticeClass: TeamNoticeClass = 'mailbox') {
+  return { stateRoot, teamName, targetId, generation, noticeClass, source: { kind: 'test', detail: `${teamName}:${generation}` } };
+}
+
+describe('team notice ledger', () => {
+  it('coalesces two Teams for one busy target into a target-scoped generic wake', async () => {
+    const { root, stateRoot } = await fixture();
+    try {
+      await Promise.all([liveTeam(stateRoot, 'alpha'), liveTeam(stateRoot, 'bravo')]);
+      const first = await registerTeamNotice(registration(stateRoot, 'alpha', 'shared-target', '1', 'leader_stale'));
+      const second = await registerTeamNotice(registration(stateRoot, 'bravo', 'shared-target', '1', 'worker_stop'));
+      assert.equal(first.queued, true);
+      assert.equal(second.queued, false);
+      assert.equal(first.targetKey, teamNoticeTargetKey('shared-target'));
+      assert.equal(parseTeamNoticeLedgerPrompt(`${first.prompt} [OMX_TMUX_INJECT]`), first.targetKey);
+      assert.ok((first.prompt?.length ?? 999) <= 180);
+      assert.doesNotMatch(first.prompt ?? '', /alpha|bravo|shared-target/);
+      const result = await reconcileTeamNoticeLedger({ stateRoot, targetKey: first.targetKey });
+      assert.deepEqual(result.context.map((notice) => notice.teamName).sort(), ['alpha', 'bravo']);
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+
+  it('keeps independent targets isolated during reconciliation', async () => {
+    const { root, stateRoot } = await fixture();
+    try {
+      await Promise.all([liveTeam(stateRoot, 'alpha'), liveTeam(stateRoot, 'bravo')]);
+      const alpha = await registerTeamNotice(registration(stateRoot, 'alpha', 'target-a', '1'));
+      const bravo = await registerTeamNotice(registration(stateRoot, 'bravo', 'target-b', '1'));
+      const result = await reconcileTeamNoticeLedger({ stateRoot, targetKey: alpha.targetKey });
+      assert.deepEqual(result.context.map((notice) => notice.teamName), ['alpha']);
+      const other = await reconcileTeamNoticeLedger({ stateRoot, targetKey: bravo.targetKey });
+      assert.deepEqual(other.context.map((notice) => notice.teamName), ['bravo']);
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+
+  it('invalidates terminal and removed Teams before presentation', async () => {
+    const { root, stateRoot } = await fixture();
+    try {
+      await Promise.all([liveTeam(stateRoot, 'live'), liveTeam(stateRoot, 'terminal'), liveTeam(stateRoot, 'removed')]);
+      await writeFile(join(stateRoot, 'team', 'terminal', 'phase.json'), JSON.stringify({ current_phase: 'complete' }));
+      const targetId = 'leader';
+      for (const name of ['live', 'terminal', 'removed']) await registerTeamNotice(registration(stateRoot, name, targetId, '1'));
+      await rm(join(stateRoot, 'team', 'removed'), { recursive: true, force: true });
+      const result = await reconcileTeamNoticeLedger({ stateRoot, targetKey: teamNoticeTargetKey(targetId) });
+      assert.deepEqual(result.context.map((notice) => notice.teamName), ['live']);
+      assert.equal(result.discarded, 2);
+      assert.doesNotMatch(await readFile(teamNoticeLedgerPath(stateRoot), 'utf8'), /terminal|removed/);
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+
+  it('replays a presented batch after a hook crash and retires it only on a later source event', async () => {
+    const { root, stateRoot } = await fixture();
+    try {
+      await liveTeam(stateRoot, 'retry');
+      const first = await registerTeamNotice(registration(stateRoot, 'retry', 'leader', '1'));
+      const presented = await reconcileTeamNoticeLedger({ stateRoot, targetKey: first.targetKey });
+      const replay = await reconcileTeamNoticeLedger({ stateRoot, targetKey: first.targetKey });
+      assert.deepEqual(replay.context, presented.context);
+      const later = await registerTeamNotice(registration(stateRoot, 'retry', 'leader', '2', 'all_idle'));
+      assert.equal(later.queued, true);
+      const next = await reconcileTeamNoticeLedger({ stateRoot, targetKey: later.targetKey });
+      assert.deepEqual(next.context.map((notice) => notice.generation), ['2']);
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+
+  it('releases only the failed wake lease while retaining concurrent notices for retry election', async () => {
+    const { root, stateRoot } = await fixture();
+    try {
+      await Promise.all([liveTeam(stateRoot, 'alpha'), liveTeam(stateRoot, 'bravo')]);
+      const first = await registerTeamNotice(registration(stateRoot, 'alpha', 'leader', '1'));
+      await registerTeamNotice(registration(stateRoot, 'bravo', 'leader', '1', 'worker_stop'));
+      assert.equal(await releaseTeamNoticeWake(stateRoot, first.targetKey, first.wakeId!), true);
+      const retry = await registerTeamNotice(registration(stateRoot, 'alpha', 'leader', '1'));
+      assert.equal(retry.queued, true);
+      const result = await reconcileTeamNoticeLedger({ stateRoot, targetKey: retry.targetKey });
+      assert.deepEqual(result.context.map((notice) => notice.teamName).sort(), ['alpha', 'bravo']);
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+
+  it('recovers stale locks and rejects malformed ledgers without overwriting them', async () => {
+    const { root, stateRoot } = await fixture();
+    try {
+      await liveTeam(stateRoot, 'recover');
+      const lock = teamNoticeLedgerLockPath(stateRoot);
+      await mkdir(lock, { recursive: true });
+      await writeFile(join(lock, 'owner'), 'crashed');
+      await writeFile(join(lock, 'lease'), 'crashed');
+      const old = new Date(Date.now() - 31_000);
+      await utimes(join(lock, 'lease'), old, old);
+      assert.equal((await registerTeamNotice(registration(stateRoot, 'recover', 'leader', '1'))).queued, true);
+      await writeFile(teamNoticeLedgerPath(stateRoot), '{broken');
+      await assert.rejects(registerTeamNotice(registration(stateRoot, 'recover', 'leader', '2')), /JSON|Unexpected/);
+      assert.equal(await readFile(teamNoticeLedgerPath(stateRoot), 'utf8'), '{broken');
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+
+  it('accepts every source-proven class and builds exact target markers', () => {
+    const key = teamNoticeTargetKey('leader');
+    assert.equal(parseTeamNoticeLedgerPrompt(buildTeamNoticeLedgerPrompt(key)), key);
+    const classes: TeamNoticeClass[] = ['mailbox', 'all_idle', 'worker_idle', 'leader_stale', 'worker_stop', 'terminal'];
+    assert.equal(classes.length, 6);
+  });
+});

--- a/src/team/notice-ledger.ts
+++ b/src/team/notice-ledger.ts
@@ -1,0 +1,294 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { omxStateDir } from '../utils/paths.js';
+import { writeAtomic } from './state.js';
+
+export const TEAM_NOTICE_LEDGER_MARKER_PREFIX = '[omx:team-notice-ledger:';
+export const TEAM_NOTICE_CLASSES = ['mailbox', 'all_idle', 'worker_idle', 'leader_stale', 'worker_stop', 'terminal'] as const;
+
+export type TeamNoticeClass = typeof TEAM_NOTICE_CLASSES[number];
+export type TeamNoticeGeneration = string | number;
+
+export interface TeamNoticeRegistration {
+  stateRoot?: string;
+  cwd?: string;
+  targetId: string;
+  teamName: string;
+  noticeClass: TeamNoticeClass;
+  generation: TeamNoticeGeneration;
+  source: { kind: string; detail?: string };
+}
+
+export interface TeamNoticeRegistrationResult {
+  generation: string;
+  queued: boolean;
+  prompt: string | null;
+  targetKey: string;
+  wakeId: string | null;
+}
+
+export interface TeamNoticeContext {
+  targetKey: string;
+  teamName: string;
+  noticeClass: TeamNoticeClass;
+  generation: string;
+  source: { kind: string; detail?: string };
+}
+
+export interface ReconcileTeamNoticeOptions {
+  stateRoot?: string;
+  cwd?: string;
+  targetKey: string;
+  beforePresent?: (context: readonly TeamNoticeContext[]) => Promise<void> | void;
+}
+
+export interface ReconcileTeamNoticeResult {
+  context: TeamNoticeContext[];
+  presented: number;
+  discarded: number;
+}
+
+interface LedgerNotice extends TeamNoticeContext {
+  createdAt: string;
+  presentedAt?: string;
+}
+
+interface WakeLease {
+  wakeId: string;
+  createdAtMs: number;
+}
+
+interface NoticeLedger {
+  schemaVersion: 2;
+  notices: Record<string, LedgerNotice>;
+  wakes: Record<string, WakeLease>;
+}
+
+const LOCK_STALE_MS = 30_000;
+const WAKE_STALE_MS = 30_000;
+const LOCK_WAIT_MS = 25;
+const LOCK_TIMEOUT_MS = 5_000;
+const TERMINAL_PHASES = new Set(['complete', 'completed', 'failed', 'cancelled', 'terminated', 'shutdown']);
+const TARGET_KEY_PATTERN = /^[a-f0-9]{24}$/;
+
+function resolvedStateRoot(stateRoot: string | undefined, cwd: string | undefined): string {
+  return stateRoot ?? omxStateDir(cwd);
+}
+
+export function teamNoticeLedgerPath(stateRoot: string): string {
+  return join(stateRoot, 'team', 'notice-ledger.json');
+}
+
+export function teamNoticeLedgerLockPath(stateRoot: string): string {
+  return join(stateRoot, 'team', '.notice-ledger.lock');
+}
+
+export function teamNoticeTargetKey(targetId: string): string {
+  return createHash('sha256').update(`omx-team-notice-target-v2\0${targetId}`).digest('hex').slice(0, 24);
+}
+
+export function buildTeamNoticeLedgerPrompt(targetKey: string): string {
+  if (!TARGET_KEY_PATTERN.test(targetKey)) throw new Error('Invalid Team notice target key');
+  return `${TEAM_NOTICE_LEDGER_MARKER_PREFIX}${targetKey}] Review current Team notices.`;
+}
+
+export function parseTeamNoticeLedgerPrompt(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const match = value.trim().match(/^\[omx:team-notice-ledger:([a-f0-9]{24})\]\s+Review current Team notices\.(?:\s+\[OMX_TMUX_INJECT\])?$/i);
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+export function isTeamNoticeLedgerPrompt(value: unknown): boolean {
+  return parseTeamNoticeLedgerPrompt(value) !== null;
+}
+
+function noticeKey(targetKey: string, teamName: string, noticeClass: TeamNoticeClass, generation: TeamNoticeGeneration): string {
+  return createHash('sha256')
+    .update(`omx-team-notice-v2\0${targetKey}\0${teamName}\0${noticeClass}\0${String(generation)}`)
+    .digest('hex');
+}
+
+function isNoticeClass(value: unknown): value is TeamNoticeClass {
+  return typeof value === 'string' && (TEAM_NOTICE_CLASSES as readonly string[]).includes(value);
+}
+
+function emptyLedger(): NoticeLedger {
+  return { schemaVersion: 2, notices: {}, wakes: {} };
+}
+
+function normalizeLedger(raw: unknown): NoticeLedger {
+  if (!raw || typeof raw !== 'object') throw new Error('invalid_team_notice_ledger');
+  const parsed = raw as Partial<NoticeLedger>;
+  if (parsed.schemaVersion !== 2 || !parsed.notices || typeof parsed.notices !== 'object' || !parsed.wakes || typeof parsed.wakes !== 'object') {
+    throw new Error('invalid_team_notice_ledger_schema');
+  }
+  const ledger = emptyLedger();
+  for (const [key, rawNotice] of Object.entries(parsed.notices)) {
+    if (!rawNotice || typeof rawNotice !== 'object') throw new Error('invalid_team_notice_record');
+    const notice = rawNotice as Partial<LedgerNotice>;
+    if (!TARGET_KEY_PATTERN.test(String(notice.targetKey ?? '')) || typeof notice.teamName !== 'string'
+      || !isNoticeClass(notice.noticeClass) || typeof notice.generation !== 'string'
+      || !notice.source || typeof notice.source.kind !== 'string' || typeof notice.createdAt !== 'string'
+      || (notice.presentedAt !== undefined && typeof notice.presentedAt !== 'string')) {
+      throw new Error('invalid_team_notice_record');
+    }
+    ledger.notices[key] = {
+      targetKey: notice.targetKey!, teamName: notice.teamName, noticeClass: notice.noticeClass,
+      generation: notice.generation, source: typeof notice.source.detail === 'string'
+        ? { kind: notice.source.kind, detail: notice.source.detail }
+        : { kind: notice.source.kind }, createdAt: notice.createdAt,
+      ...(notice.presentedAt ? { presentedAt: notice.presentedAt } : {}),
+    };
+  }
+  for (const [targetKey, rawWake] of Object.entries(parsed.wakes)) {
+    if (!TARGET_KEY_PATTERN.test(targetKey) || !rawWake || typeof rawWake !== 'object') throw new Error('invalid_team_notice_wake');
+    const wake = rawWake as Partial<WakeLease>;
+    if (typeof wake.wakeId !== 'string' || typeof wake.createdAtMs !== 'number' || !Number.isSafeInteger(wake.createdAtMs)) {
+      throw new Error('invalid_team_notice_wake');
+    }
+    ledger.wakes[targetKey] = { wakeId: wake.wakeId, createdAtMs: wake.createdAtMs };
+  }
+  return ledger;
+}
+
+async function readLedger(stateRoot: string): Promise<NoticeLedger> {
+  try {
+    return normalizeLedger(JSON.parse(await readFile(teamNoticeLedgerPath(stateRoot), 'utf8')));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return emptyLedger();
+    throw error;
+  }
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function staleLock(lockPath: string): Promise<boolean> {
+  try {
+    return Date.now() - (await stat(join(lockPath, 'lease'))).mtimeMs > LOCK_STALE_MS;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return false;
+  }
+  try { return Date.now() - (await stat(lockPath)).mtimeMs > LOCK_STALE_MS; } catch { return false; }
+}
+
+async function withLedgerLock<T>(stateRoot: string, fn: () => Promise<T>): Promise<T> {
+  const lockPath = teamNoticeLedgerLockPath(stateRoot);
+  const owner = randomUUID();
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  await mkdir(join(stateRoot, 'team'), { recursive: true });
+  while (true) {
+    try {
+      await mkdir(lockPath);
+      await writeFile(join(lockPath, 'owner'), owner, 'utf8');
+      await writeFile(join(lockPath, 'lease'), owner, 'utf8');
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      if (await staleLock(lockPath)) { await rm(lockPath, { recursive: true, force: true }); continue; }
+      if (Date.now() >= deadline) throw new Error('Timed out acquiring team notice ledger lock');
+      await sleep(LOCK_WAIT_MS);
+    }
+  }
+  try { return await fn(); } finally {
+    try {
+      if ((await readFile(join(lockPath, 'owner'), 'utf8')) === owner) await rm(lockPath, { recursive: true, force: true });
+    } catch { /* recovered locks are owned by their replacement */ }
+  }
+}
+
+function boundedDetail(detail: string | undefined): string | undefined {
+  return detail ? detail.slice(0, 240) : undefined;
+}
+
+export async function registerTeamNotice(registration: TeamNoticeRegistration): Promise<TeamNoticeRegistrationResult> {
+  const stateRoot = resolvedStateRoot(registration.stateRoot, registration.cwd);
+  const generation = String(registration.generation);
+  if (!registration.targetId || !registration.teamName || !generation || !isNoticeClass(registration.noticeClass) || !registration.source.kind) {
+    throw new Error('Invalid team notice registration');
+  }
+  return await withLedgerLock(stateRoot, async () => {
+    const ledger = await readLedger(stateRoot);
+    const targetKey = teamNoticeTargetKey(registration.targetId);
+    // A later source-proven event confirms the previous presented batch reached a model turn.
+    for (const [key, notice] of Object.entries(ledger.notices)) {
+      if (notice.targetKey === targetKey && notice.presentedAt) delete ledger.notices[key];
+    }
+    const key = noticeKey(targetKey, registration.teamName, registration.noticeClass, generation);
+    if (!ledger.notices[key]) {
+      ledger.notices[key] = {
+        targetKey, teamName: registration.teamName, noticeClass: registration.noticeClass, generation,
+        source: { kind: registration.source.kind, detail: boundedDetail(registration.source.detail) },
+        createdAt: new Date().toISOString(),
+      };
+    }
+    const now = Date.now();
+    const existingWake = ledger.wakes[targetKey];
+    if (existingWake && now - existingWake.createdAtMs <= WAKE_STALE_MS) {
+      await writeAtomic(teamNoticeLedgerPath(stateRoot), JSON.stringify(ledger, null, 2));
+      return { generation, queued: false, prompt: null, targetKey, wakeId: existingWake.wakeId };
+    }
+    const wakeId = randomUUID();
+    ledger.wakes[targetKey] = { wakeId, createdAtMs: now };
+    await writeAtomic(teamNoticeLedgerPath(stateRoot), JSON.stringify(ledger, null, 2));
+    return { generation, queued: true, prompt: buildTeamNoticeLedgerPrompt(targetKey), targetKey, wakeId };
+  });
+}
+
+export async function releaseTeamNoticeWake(stateRoot: string, targetKey: string, wakeId: string): Promise<boolean> {
+  if (!TARGET_KEY_PATTERN.test(targetKey) || !wakeId) return false;
+  return await withLedgerLock(stateRoot, async () => {
+    const ledger = await readLedger(stateRoot);
+    if (ledger.wakes[targetKey]?.wakeId !== wakeId) return false;
+    delete ledger.wakes[targetKey];
+    await writeAtomic(teamNoticeLedgerPath(stateRoot), JSON.stringify(ledger, null, 2));
+    return true;
+  });
+}
+
+async function teamIsLive(stateRoot: string, teamName: string): Promise<boolean> {
+  const teamDir = join(stateRoot, 'team', teamName);
+  try {
+    if (!(await stat(teamDir)).isDirectory()) return false;
+    const config = JSON.parse(await readFile(join(teamDir, 'config.json'), 'utf8')) as { name?: unknown; team_name?: unknown };
+    if ((typeof config.team_name === 'string' ? config.team_name : config.name) !== teamName) return false;
+  } catch { return false; }
+  for (const shutdownName of ['shutdown.json', 'shutdown']) {
+    try { await stat(join(teamDir, shutdownName)); return false; } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return false;
+    }
+  }
+  try {
+    const phase = JSON.parse(await readFile(join(teamDir, 'phase.json'), 'utf8')) as { current_phase?: unknown };
+    return !(typeof phase.current_phase === 'string' && TERMINAL_PHASES.has(phase.current_phase));
+  } catch (error) { return (error as NodeJS.ErrnoException).code === 'ENOENT'; }
+}
+
+export async function reconcileTeamNoticeLedger(options: ReconcileTeamNoticeOptions): Promise<ReconcileTeamNoticeResult> {
+  if (!TARGET_KEY_PATTERN.test(options.targetKey)) throw new Error('Invalid Team notice target key');
+  const stateRoot = resolvedStateRoot(options.stateRoot, options.cwd);
+  return await withLedgerLock(stateRoot, async () => {
+    const ledger = await readLedger(stateRoot);
+    let discarded = 0;
+    for (const [key, notice] of Object.entries(ledger.notices)) {
+      if (notice.targetKey === options.targetKey && !await teamIsLive(stateRoot, notice.teamName)) {
+        delete ledger.notices[key];
+        discarded += 1;
+      }
+    }
+    const selected = Object.values(ledger.notices)
+      .filter((notice) => notice.targetKey === options.targetKey)
+      .sort((left, right) => left.createdAt.localeCompare(right.createdAt));
+    const context = selected.map(({ targetKey, teamName, noticeClass, generation, source }) => ({
+      targetKey, teamName, noticeClass, generation, source,
+    }));
+    await options.beforePresent?.(context);
+    const presentedAt = new Date().toISOString();
+    for (const notice of selected) notice.presentedAt ??= presentedAt;
+    delete ledger.wakes[options.targetKey];
+    if (discarded > 0 || selected.length > 0) await writeAtomic(teamNoticeLedgerPath(stateRoot), JSON.stringify(ledger, null, 2));
+    return { context, presented: selected.length, discarded };
+  });
+}


### PR DESCRIPTION
Closes #3223

## Summary
- add a durable per-target/per-generation Team notice acknowledgement ledger for mailbox, all-idle, leader-stale, native Stop, and terminal invalidation
- queue one generic busy-leader wake with no Team references, then reconcile canonical live Team state in native UserPromptSubmit before model input
- discard terminal, shutdown, and removed Teams atomically; preserve retry/idempotency after crashes
- add deterministic two-Team busy-leader, removal, bounded prompt, stale-lock, retry, replay, and native-hook coverage

## Verification
- `npm run build`
- focused notice and native-hook suites
- `npm run check:no-unused`
- `npm run lint`
- `npm test`

Signed-off-by: Yeachan-Heo <hurrc04@gmail.com>