### PR TITLE
fix(team): guard terminal follow-up boundary

### DIFF
--- a/src/team/__tests__/phase-controller.test.ts
+++ b/src/team/__tests__/phase-controller.test.ts
@@ -61,6 +61,28 @@ describe('phase-controller', () => {
     assert.ok(next.transitions.some((t) => t.from === 'complete' && t.to === 'team-exec'));
   });
 
+  it('does not reopen a phase after terminal epoch begins', () => {
+    const terminal = {
+      current_phase: 'complete' as const,
+      max_fix_attempts: 3,
+      current_fix_attempt: 0,
+      transitions: [],
+      updated_at: '2026-07-19T00:00:00.000Z',
+      terminal_epoch: '2026-07-19T00:00:00.000Z',
+      terminal_reason: 'shutdown_gate_passed',
+      final_task_counts: {
+        total: 1,
+        pending: 0,
+        blocked: 0,
+        in_progress: 0,
+        completed: 1,
+        failed: 0,
+      },
+    };
+
+    assert.deepEqual(reconcilePhaseStateForMonitor(terminal, 'team-exec'), terminal);
+  });
+
   it('moves team-exec to team-verify when verification is pending', () => {
     const next = reconcilePhaseStateForMonitor(
       {

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -16,6 +16,7 @@ import {
   readTeamConfig,
   saveTeamConfig,
   listMailboxMessages,
+  sendDirectMessage,
   listDispatchRequests,
   transitionDispatchRequest,
   updateWorkerHeartbeat,
@@ -26,6 +27,8 @@ import {
   transitionTaskStatus,
   readWorkerStatus,
   writeWorkerStatus,
+  readTeamPhase,
+  writeTeamPhase,
 } from '../state.js';
 import {
   monitorTeam,
@@ -45,6 +48,7 @@ import {
   TEAM_LOW_COMPLEXITY_DEFAULT_MODEL,
   type TeamRuntime,
   setDetachedSessionDestroyAfterJournalHookForTest,
+  setTerminalEpochStartedHookForTest,
 } from '../runtime.js';
 import {
   resolveAgentReasoningEffort,
@@ -657,6 +661,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  setTerminalEpochStartedHookForTest(null);
   if (typeof ORIGINAL_OMX_TEAM_STATE_ROOT === 'string') process.env.OMX_TEAM_STATE_ROOT = ORIGINAL_OMX_TEAM_STATE_ROOT;
   else delete process.env.OMX_TEAM_STATE_ROOT;
 });
@@ -7021,6 +7026,158 @@ exec "${realGit}" "$@"
     }
   });
 
+  it('follow-up created before terminal epoch blocks shutdown without starting the epoch', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-terminal-before-'));
+    try {
+      await initTeamState('team-terminal-before', 'terminal boundary before test', 'executor', 1, cwd);
+      await createTask(
+        'team-terminal-before',
+        { subject: 'valid follow-up', description: 'must block shutdown', status: 'pending' },
+        cwd,
+      );
+
+      await assert.rejects(
+        () => shutdownTeam('team-terminal-before', cwd),
+        /shutdown_gate_blocked:pending=1,blocked=0,in_progress=0,failed=0/,
+      );
+
+      const phase = await readTeamPhase('team-terminal-before', cwd);
+      assert.equal(phase?.terminal_epoch, undefined);
+      assert.equal(phase?.terminal_reason, undefined);
+      assert.equal((await readTask('team-terminal-before', '1', cwd))?.status, 'pending');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('terminal epoch rejects duplicate late assignment and task creation without stale delivery', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-terminal-after-'));
+    let releaseEpoch!: () => void;
+    let observeEpoch!: () => void;
+    const epochObserved = new Promise<void>((resolve) => { observeEpoch = resolve; });
+    const epochRelease = new Promise<void>((resolve) => { releaseEpoch = resolve; });
+    try {
+      await initTeamState('team-terminal-after', 'terminal boundary after test', 'executor', 1, cwd);
+      const task = await createTask(
+        'team-terminal-after',
+        { subject: 'forced follow-up', description: 'must not leak after epoch', status: 'pending' },
+        cwd,
+      );
+      await markDetachedSessionAbsent('team-terminal-after', cwd);
+
+      let capturedReason: string | undefined;
+      let capturedCounts: Record<string, number> | undefined;
+      setTerminalEpochStartedHookForTest(async (_teamName, _cwd, phase) => {
+        capturedReason = phase.terminal_reason;
+        capturedCounts = phase.final_task_counts;
+        observeEpoch();
+        await epochRelease;
+      });
+
+      const shutdown = shutdownWithoutTmuxSession('team-terminal-after', cwd, { force: true });
+      await epochObserved;
+
+      const attempts = await Promise.allSettled([
+        assignTask('team-terminal-after', 'worker-1', task.id, cwd),
+        assignTask('team-terminal-after', 'worker-1', task.id, cwd),
+        createTask(
+          'team-terminal-after',
+          { subject: 'too late', description: 'must require continuation', status: 'pending' },
+          cwd,
+        ),
+      ]);
+      const diagnostics = attempts.map((attempt) => {
+        assert.equal(attempt.status, 'rejected');
+        return String((attempt as PromiseRejectedResult).reason?.message ?? (attempt as PromiseRejectedResult).reason);
+      });
+      assert.equal(new Set(diagnostics).size, 1);
+      assert.match(
+        diagnostics[0] ?? '',
+        /^team_continuation_required:terminal_epoch=.*:reason=forced_shutdown:action=reopen_or_start_continuation$/,
+      );
+      assert.equal(capturedReason, 'forced_shutdown');
+      assert.deepEqual(capturedCounts, {
+        total: 1,
+        pending: 1,
+        blocked: 0,
+        in_progress: 0,
+        completed: 0,
+        failed: 0,
+      });
+      assert.equal((await readTask('team-terminal-after', task.id, cwd))?.status, 'pending');
+      assert.equal((await listMailboxMessages('team-terminal-after', 'worker-1', cwd)).length, 0);
+      assert.equal((await listDispatchRequests('team-terminal-after', cwd, { kind: 'inbox' })).length, 0);
+
+      releaseEpoch();
+      await shutdown;
+    } finally {
+      releaseEpoch?.();
+      setTerminalEpochStartedHookForTest(null);
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('terminal watcher phase rejects assignment with one continuation diagnostic', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-terminal-watcher-'));
+    try {
+      await initTeamState('team-terminal-watcher', 'terminal watcher test', 'executor', 1, cwd);
+      const task = await createTask(
+        'team-terminal-watcher',
+        { subject: 'late watcher work', description: 'worker has exited', status: 'pending' },
+        cwd,
+      );
+      const staleMessage = await sendDirectMessage(
+        'team-terminal-watcher',
+        'leader-fixed',
+        'worker-1',
+        'stale follow-up assignment',
+        cwd,
+      );
+      await updateWorkerHeartbeat('team-terminal-watcher', 'worker-1', {
+        pid: process.pid,
+        alive: true,
+        last_turn_at: new Date().toISOString(),
+        turn_count: 1,
+      }, cwd);
+      const phase = await readTeamPhase('team-terminal-watcher', cwd);
+      assert.ok(phase);
+      await writeTeamPhase('team-terminal-watcher', {
+        ...phase!,
+        current_phase: 'complete',
+        updated_at: '2026-07-19T00:00:00.000Z',
+        terminal_epoch: '2026-07-19T00:00:00.000Z',
+        terminal_reason: 'shutdown_gate_passed',
+        final_task_counts: {
+          total: 1,
+          pending: 1,
+          blocked: 0,
+          in_progress: 0,
+          completed: 0,
+          failed: 0,
+        },
+      }, cwd);
+
+      await assert.rejects(
+        () => assignTask('team-terminal-watcher', 'worker-1', task.id, cwd),
+        (error: unknown) => {
+          assert.equal(
+            (error as Error).message,
+            'team_continuation_required:terminal_epoch=2026-07-19T00:00:00.000Z:reason=shutdown_gate_passed:action=reopen_or_start_continuation',
+          );
+          return true;
+        },
+      );
+      await monitorTeam('team-terminal-watcher', cwd);
+      assert.equal((await readTask('team-terminal-watcher', task.id, cwd))?.status, 'pending');
+      const mailbox = await listMailboxMessages('team-terminal-watcher', 'worker-1', cwd);
+      assert.equal(mailbox.length, 1);
+      assert.equal(mailbox[0]?.message_id, staleMessage.message_id);
+      assert.equal(mailbox[0]?.notified_at, undefined);
+      assert.equal((await listDispatchRequests('team-terminal-watcher', cwd, { kind: 'inbox' })).length, 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
   it('shutdownTeam honors governance cleanup override when active tasks remain', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-gate-override-'));
     try {

--- a/src/team/phase-controller.ts
+++ b/src/team/phase-controller.ts
@@ -105,6 +105,7 @@ export function reconcilePhaseStateForMonitor(
 ): TeamPhaseState {
   const now = new Date().toISOString();
   const base = persisted ?? defaultPersistedPhaseState();
+  if (base.terminal_epoch) return base;
   if (base.current_phase === target) {
     return {
       ...base,

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -97,7 +97,11 @@ import {
   type TeamPolicy,
   type TeamDispatchRequest,
 } from './team-ops.js';
-import { commitTeamMembershipTaskTransaction, writeTeamManifestV2 as writeTeamManifestV2State } from './state.js';
+import {
+  commitTeamMembershipTaskTransaction,
+  teamContinuationRequiredDiagnostic,
+  writeTeamManifestV2 as writeTeamManifestV2State,
+} from './state.js';
 import {
   queueInboxInstruction,
   queueDirectMailboxMessage,
@@ -406,6 +410,14 @@ interface ShutdownOptions {
 export interface TeamShutdownSummary {
   commitHygieneArtifacts: TeamCommitHygieneArtifactPaths | null;
 }
+let terminalEpochStartedHookForTest: ((teamName: string, cwd: string, phase: TeamPhaseState) => Promise<void>) | null = null;
+
+export function setTerminalEpochStartedHookForTest(
+  hook: ((teamName: string, cwd: string, phase: TeamPhaseState) => Promise<void>) | null,
+): void {
+  terminalEpochStartedHookForTest = hook;
+}
+
 
 export function applyCreatedInteractiveSessionToConfig(
   config: TeamConfig,
@@ -4424,14 +4436,16 @@ export async function monitorTeam(teamName: string, cwd: string): Promise<TeamSn
     cwd,
   });
   const mailboxDeliveryStartMs = performance.now();
-  const mailboxNotifiedByMessageId = await deliverPendingMailboxMessages(
-    sanitized,
-    config,
-    workers,
-    previousSnapshot?.mailboxNotifiedByMessageId ?? {},
-    dispatchPolicy,
-    cwd
-  );
+  const mailboxNotifiedByMessageId = phaseState.terminal_epoch
+    ? {}
+    : await deliverPendingMailboxMessages(
+        sanitized,
+        config,
+        workers,
+        previousSnapshot?.mailboxNotifiedByMessageId ?? {},
+        dispatchPolicy,
+        cwd,
+      );
   const mailboxDeliveryMs = performance.now() - mailboxDeliveryStartMs;
 
   // Prune ephemeral status messages from leader mailbox (TTL: 60s)
@@ -4506,8 +4520,13 @@ export async function assignTask(
   cwd: string,
 ): Promise<void> {
   const sanitized = sanitizeTeamName(teamName);
-  const task = await readTask(sanitized, taskId, cwd);
-  if (!task) throw new Error(`Task ${taskId} not found`);
+  return await withTeamTaskMembershipBarrier(sanitized, cwd, async () => {
+    const phaseState = await readTeamPhaseState(sanitized, cwd);
+    if (phaseState?.terminal_epoch || (phaseState && isTerminalPhase(phaseState.current_phase))) {
+      throw new Error(teamContinuationRequiredDiagnostic(phaseState));
+    }
+    const task = await readTask(sanitized, taskId, cwd);
+    if (!task) throw new Error(`Task ${taskId} not found`);
   const manifest = await readTeamManifestV2(sanitized, cwd);
   const governance = resolveGovernancePolicy(manifest?.governance);
 
@@ -4634,6 +4653,7 @@ export async function assignTask(
     if (reason === 'worker_notify_failed') throw new Error('worker_notify_failed');
     throw new Error(`worker_assignment_failed:${reason}`);
   }
+  });
 }
 
 /**
@@ -4741,27 +4761,17 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     manifest?.policy as Partial<TeamGovernance> | undefined,
   );
 
-  if (!force) {
-    const classification = await classifyShutdown({
+  const classification = await withTeamTaskMembershipBarrier(sanitized, cwd, async () => {
+    const current = await classifyShutdown({
       teamName: sanitized,
       cwd,
-      config,
+      config: config!,
       governance,
       confirmIssues,
     });
-    const { gate, dirtyWorkers, requiresIssueConfirmation, useCleanFastPath } = classification;
+    const { gate, requiresIssueConfirmation } = current;
 
-    await appendTeamEvent(
-      sanitized,
-      {
-        type: 'shutdown_gate',
-        worker: 'leader-fixed',
-        reason: `allowed=${gate.allowed} total=${gate.total} pending=${gate.pending} blocked=${gate.blocked} in_progress=${gate.in_progress} completed=${gate.completed} failed=${gate.failed} cleanup_requires_all_workers_inactive=${governance.cleanup_requires_all_workers_inactive} dirty_workers=${dirtyWorkers.join('|') || 'none'} confirm_issues=${confirmIssues} clean_fast_path=${useCleanFastPath}`,
-      },
-      cwd,
-    ).catch(() => {});
-
-    if (!gate.allowed) {
+    if (!force && !gate.allowed) {
       if (requiresIssueConfirmation) {
         throw new Error(
           `shutdown_confirm_issues_required:failed=${gate.failed}:rerun=omx team shutdown ${sanitized} --confirm-issues`,
@@ -4772,19 +4782,52 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       );
     }
 
-    skipWorkerAcks = useCleanFastPath;
+    const now = new Date().toISOString();
+    const existingPhase = await readTeamPhaseState(sanitized, cwd);
+    const terminalReason = force ? 'forced_shutdown' : 'shutdown_gate_passed';
+    await writeTeamPhaseState(sanitized, {
+      current_phase: existingPhase?.current_phase ?? 'team-exec',
+      max_fix_attempts: existingPhase?.max_fix_attempts ?? 3,
+      current_fix_attempt: existingPhase?.current_fix_attempt ?? 0,
+      transitions: existingPhase?.transitions ?? [],
+      updated_at: now,
+      terminal_epoch: existingPhase?.terminal_epoch ?? now,
+      terminal_reason: existingPhase?.terminal_reason ?? terminalReason,
+      final_task_counts: {
+        total: gate.total,
+        pending: gate.pending,
+        blocked: gate.blocked,
+        in_progress: gate.in_progress,
+        completed: gate.completed,
+        failed: gate.failed,
+      },
+    }, cwd);
+    return current;
+  });
+  const terminalPhase = await readTeamPhaseState(sanitized, cwd);
+  if (terminalPhase && terminalEpochStartedHookForTest) {
+    await terminalEpochStartedHookForTest(sanitized, cwd, terminalPhase);
   }
+  const { gate, dirtyWorkers, useCleanFastPath } = classification;
+
+  await appendTeamEvent(
+    sanitized,
+    {
+      type: force ? 'shutdown_gate_forced' : 'shutdown_gate',
+      worker: 'leader-fixed',
+      reason: force
+        ? `force_bypass total=${gate.total} pending=${gate.pending} blocked=${gate.blocked} in_progress=${gate.in_progress} completed=${gate.completed} failed=${gate.failed}`
+        : `allowed=${gate.allowed} total=${gate.total} pending=${gate.pending} blocked=${gate.blocked} in_progress=${gate.in_progress} completed=${gate.completed} failed=${gate.failed} cleanup_requires_all_workers_inactive=${governance.cleanup_requires_all_workers_inactive} dirty_workers=${dirtyWorkers.join('|') || 'none'} confirm_issues=${confirmIssues} clean_fast_path=${useCleanFastPath}`,
+    },
+    cwd,
+  ).catch(() => {});
 
   if (force) {
-    await appendTeamEvent(sanitized, {
-      type: 'shutdown_gate_forced',
-      worker: 'leader-fixed',
-      reason: 'force_bypass',
-    }, cwd).catch(() => {});
-
     // Explicit force means teardown now. Do not spend the graceful ack window
     // waiting for interactive panes or prompt workers that will be killed below.
     skipWorkerAcks = true;
+  } else {
+    skipWorkerAcks = useCleanFastPath;
   }
 
   const sessionName = config.tmux_session;

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -1714,6 +1714,12 @@ async function withMailboxLock<T>(
   return await withMailboxLockImpl(teamName, workerName, cwd, LOCK_STALE_MS, { teamDir, taskClaimLockDir, mailboxLockDir }, fn);
 }
 
+export function teamContinuationRequiredDiagnostic(phase: TeamPhaseState): string {
+  const epoch = phase.terminal_epoch ?? phase.updated_at;
+  const reason = phase.terminal_reason ?? `terminal_phase_${phase.current_phase}`;
+  return `team_continuation_required:terminal_epoch=${epoch}:reason=${reason}:action=reopen_or_start_continuation`;
+}
+
 // Create a task (auto-increment ID)
 export async function createTask(
   teamName: string,
@@ -1724,6 +1730,10 @@ export async function createTask(
     await recoverTeamMembershipTaskTransaction(teamName, cwd);
     const cfg = await readTeamConfig(teamName, cwd);
     if (!cfg) throw new Error(`Team ${teamName} not found`);
+    const phase = await readTeamPhase(teamName, cwd);
+    if (phase?.terminal_epoch || (phase && isTerminalPhase(phase.current_phase))) {
+      throw new Error(teamContinuationRequiredDiagnostic(phase));
+    }
 
     let nextNumeric = normalizeNextTaskId(cfg.next_task_id);
     const nextNumericFromDisk = await computeNextTaskIdFromDisk(teamName, cwd);
@@ -2485,6 +2495,16 @@ export interface TeamPhaseState {
   current_fix_attempt: number;
   transitions: Array<{ from: string; to: string; at: string; reason?: string }>;
   updated_at: string;
+  terminal_epoch?: string;
+  terminal_reason?: string;
+  final_task_counts?: {
+    total: number;
+    pending: number;
+    blocked: number;
+    in_progress: number;
+    completed: number;
+    failed: number;
+  };
 }
 
 export type TeamLeaderDecisionState = 'still_actionable' | 'done_waiting_on_leader' | 'stuck_waiting_on_leader';

--- a/src/team/state/monitor.ts
+++ b/src/team/state/monitor.ts
@@ -67,6 +67,16 @@ export interface TeamPhaseState {
   current_fix_attempt: number;
   transitions: Array<{ from: string; to: string; at: string; reason?: string }>;
   updated_at: string;
+  terminal_epoch?: string;
+  terminal_reason?: string;
+  final_task_counts?: {
+    total: number;
+    pending: number;
+    blocked: number;
+    in_progress: number;
+    completed: number;
+    failed: number;
+  };
 }
 
 interface MonitorDeps {
@@ -291,12 +301,25 @@ export async function readTeamPhase(teamName: string, cwd: string, teamPhasePath
     const parsed = JSON.parse(raw) as Partial<TeamPhaseState>;
     if (!parsed || typeof parsed !== 'object') return null;
     const currentPhase = typeof parsed.current_phase === 'string' ? parsed.current_phase : 'team-exec';
+    const finalTaskCounts = parsed.final_task_counts;
     return {
       current_phase: currentPhase,
       max_fix_attempts: typeof parsed.max_fix_attempts === 'number' ? parsed.max_fix_attempts : 3,
       current_fix_attempt: typeof parsed.current_fix_attempt === 'number' ? parsed.current_fix_attempt : 0,
       transitions: Array.isArray(parsed.transitions) ? parsed.transitions : [],
       updated_at: typeof parsed.updated_at === 'string' ? parsed.updated_at : new Date().toISOString(),
+      terminal_epoch: typeof parsed.terminal_epoch === 'string' ? parsed.terminal_epoch : undefined,
+      terminal_reason: typeof parsed.terminal_reason === 'string' ? parsed.terminal_reason : undefined,
+      final_task_counts: finalTaskCounts && typeof finalTaskCounts === 'object'
+        ? {
+            total: typeof finalTaskCounts.total === 'number' ? finalTaskCounts.total : 0,
+            pending: typeof finalTaskCounts.pending === 'number' ? finalTaskCounts.pending : 0,
+            blocked: typeof finalTaskCounts.blocked === 'number' ? finalTaskCounts.blocked : 0,
+            in_progress: typeof finalTaskCounts.in_progress === 'number' ? finalTaskCounts.in_progress : 0,
+            completed: typeof finalTaskCounts.completed === 'number' ? finalTaskCounts.completed : 0,
+            failed: typeof finalTaskCounts.failed === 'number' ? finalTaskCounts.failed : 0,
+          }
+        : undefined,
     };
   } catch {
     return null;

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -362,6 +362,16 @@ export interface TeamPhaseState {
   current_fix_attempt: number;
   transitions: Array<{ from: string; to: string; at: string; reason?: string }>;
   updated_at: string;
+  terminal_epoch?: string;
+  terminal_reason?: string;
+  final_task_counts?: {
+    total: number;
+    pending: number;
+    blocked: number;
+    in_progress: number;
+    completed: number;
+    failed: number;
+  };
 }
 
 export const DEFAULT_MAX_WORKERS = 20;


### PR DESCRIPTION
## Summary
- serialize follow-up creation/assignment against the Team task-membership barrier and persist a minimal terminal epoch, shutdown reason, and final task counts
- reject post-epoch creation/assignment with one deterministic continuation/reopen diagnostic
- stop explicit terminal epochs from reopening phases or delivering stale worker mailbox notifications
- cover pre/post boundary, duplicate requests, exited/watch workers, forced shutdown, and stale-mailbox safety

## Verification
- terminal-boundary and mailbox compatibility focused runtime tests (5/5)
- phase-controller (7/7) and team-ops API contract (2/2)
- focused shutdown/assignment runtime suite (70/70)
- Team critical coverage gate passed locally (statements 87.47%, branches 80.81%, functions 95.85%, lines 87.47%)
- `npm run check:no-unused`
- `npm run lint`
- broad `npm test`; unrelated MCP lifecycle timing failure passed immediately on isolated serial rerun (15/15)

Exact signed head: `641374304da4767b37fad87cf76c0797546d24f0`

Fixes #3224