### PR TITLE
fix(team): pin worker liveness to exact panes

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -3295,12 +3295,14 @@ exit 1
   it('supports custom tail lines for generated raw inspect commands', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-tail-lines-'));
     const previousCwd = process.cwd();
+    const previousPath = process.env.PATH;
     const logs: string[] = [];
     const originalLog = console.log;
     try {
       process.chdir(wd);
       const config = await withoutTeamTestWorkerEnv(() => initTeamState('pane-tail-team', 'inspect worker panes', 'executor', 1, wd));
       config.workers[0]!.pane_id = '%51';
+      config.workers[0]!.pid = process.pid;
       const manifestPath = join(wd, '.omx', 'state', 'team', 'pane-tail-team', 'manifest.v2.json');
       const manifest = JSON.parse(await readFile(manifestPath, 'utf-8')) as {
         workers?: Array<{ pane_id?: string }>;
@@ -3317,6 +3319,16 @@ exit 1
         manifestPath,
         `${JSON.stringify(manifest, null, 2)}\n`,
       );
+      const tmuxPath = join(wd, 'tmux');
+      await writeFile(tmuxPath, `#!/bin/sh
+if [ "$1" = "display-message" ] && [ "$4" = "%51" ]; then
+  printf '%%51\\t0\\t${process.pid}\\t${config.tmux_pane_owner_id}\\n'
+  exit 0
+fi
+exit 1
+`);
+      await chmod(tmuxPath, 0o755);
+      process.env.PATH = `${wd}:${previousPath ?? ''}`;
 
       console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
       await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'pane-tail-team', '--tail-lines', '600']));
@@ -3335,6 +3347,8 @@ exit 1
       assert.equal(payload.tail_lines, 550);
       assert.equal(payload.panes?.sparkshell_commands?.['worker-1'], 'omx sparkshell --tmux-pane %51 --tail-lines 550');
     } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
       console.log = originalLog;
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -2402,6 +2402,7 @@ describe('teamCommand status', () => {
   it('prints pane ids and raw inspect hints when tmux panes are recorded', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-panes-'));
     const previousCwd = process.cwd();
+    const previousPath = process.env.PATH;
     const logs: string[] = [];
     const originalLog = console.log;
     try {
@@ -2525,6 +2526,20 @@ describe('teamCommand status', () => {
         manifestPath,
         `${JSON.stringify(manifest, null, 2)}\n`,
       );
+      const tmuxPath = join(wd, 'tmux');
+      await writeFile(tmuxPath, `#!/bin/sh
+if [ "$1" = "display-message" ]; then
+  case "$4" in
+    %21) printf '%%21\\t1\\t101\\t${config.tmux_pane_owner_id}\\n' ;;
+    %22) printf '%%22\\t1\\t102\\t${config.tmux_pane_owner_id}\\n' ;;
+    *) exit 1 ;;
+  esac
+  exit 0
+fi
+exit 1
+`);
+      await chmod(tmuxPath, 0o755);
+      process.env.PATH = `${wd}:${previousPath ?? ''}`;
 
       console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
       await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'pane-team']));
@@ -2548,6 +2563,8 @@ describe('teamCommand status', () => {
       const modelInspectOutput = logs.join('\n');
       assert.match(modelInspectOutput, /inspect_summary: [\s\S]*command=omx sparkshell --tmux-pane %21 --tail-lines 400/);
     } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
       console.log = originalLog;
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
@@ -2640,6 +2657,15 @@ describe('teamCommand status', () => {
         manifestPath,
         `${JSON.stringify(manifest, null, 2)}\n`,
       );
+      const tmuxPath = join(wd, 'tmux');
+      await writeFile(tmuxPath, `#!/bin/sh
+if [ "$1" = "display-message" ] && [ "$4" = "%41" ]; then
+  printf '%%41\\t1\\t201\\t${config.tmux_pane_owner_id}\\n'
+  exit 0
+fi
+exit 1
+`);
+      await chmod(tmuxPath, 0o755);
 
       console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
       await withoutTeamTestWorkerEnv(() => teamCommand(['status', 'pane-json-team', '--json']));

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -7351,8 +7351,6 @@ describe('dismissTrustPromptIfPresent', () => {
 
 describe('isWorkerAlive', () => {
   it('does not require pane_current_command to match "codex"', () => {
-    // This was a real failure mode: tmux reports pane_current_command=node for the Codex TUI,
-    // which caused workers to be treated as dead and the leader to clean up state too early.
     withEmptyPath(() => {
       assert.equal(isWorkerAlive('omx-team-x', 1), false);
     });
@@ -7372,56 +7370,78 @@ exit 1
     );
   });
 
-  it('treats EPERM liveness probes as unknown and emits no async kill controls', async () => {
+  it('queries each exact pane even when a broad snapshot would return the leader first', async () => {
     await withMockTmuxFixture(
-      'omx-worker-liveness-eperm-',
+      'omx-worker-liveness-exact-target-',
       (logPath) => `#!/bin/sh
 set -eu
 printf '%s\n' "$*" >> "${logPath}"
 case "$1" in
-  list-panes)
-    if [ "$2" = "-a" ]; then printf '%%77\t0\t%s\n' "$PPID"; exit 0; fi
-    if [ "$2" = "-t" ]; then printf '0 %s\n' "$PPID"; exit 0; fi
-    exit 1
+  display-message)
+    case "$4" in
+      %21) printf '%%21\t0\t%s\tteam:liveness\n' "$PPID" ;;
+      %22) printf '%%22\t0\t%s\tteam:liveness\n' "$PPID" ;;
+      *) exit 1 ;;
+    esac
     ;;
-  show-option) printf 'team:liveness\n'; exit 0 ;;
+  list-panes) printf '%%11\t0\t111\n%%21\t0\t%s\n%%22\t0\t%s\n' "$PPID" "$PPID" ;;
   *) exit 1 ;;
 esac
 `,
       async ({ logPath }) => {
-        const originalProcessKill = process.kill;
-        process.kill = ((pid: number, signal?: number | NodeJS.Signals) => {
-          if (pid === process.pid && signal === 0) {
-            const error = new Error('permission denied') as NodeJS.ErrnoException;
-            error.code = 'EPERM';
-            throw error;
-          }
-          return originalProcessKill(pid, signal as NodeJS.Signals);
-        }) as typeof process.kill;
-        try {
-          assert.equal(isWorkerAlive('compat-session', 1), true);
-          assert.equal(isWorkerAlive('ignored-session', 1, '%77', process.pid, 'team:liveness'), true);
-          await killWorker('ignored-session', 1, '%77', undefined, process.pid, 'team:liveness');
-        } finally {
-          process.kill = originalProcessKill;
-        }
+        assert.equal(isWorkerAlive('ignored-session', 1, '%21', process.pid, 'team:liveness'), true);
+        assert.equal(isWorkerAlive('ignored-session', 2, '%22', process.pid, 'team:liveness'), true);
         const log = await readFile(logPath, 'utf-8');
-        assert.doesNotMatch(log, /send-keys -t %77|kill-pane -t %77/);
+        assert.match(log, /display-message -p -t %21/);
+        assert.match(log, /display-message -p -t %22/);
+        assert.doesNotMatch(log, /list-panes -a/);
       },
     );
   });
 
-  it('treats only ESRCH as a gone process', async () => {
+  it('treats pane recycle and PID reuse identity mismatches as diagnostics, not death', async () => {
     await withMockTmuxFixture(
-      'omx-worker-liveness-esrch-',
+      'omx-worker-liveness-reuse-',
       () => `#!/bin/sh
+set -eu
 case "$1" in
-  list-panes)
-    if [ "$2" = "-a" ]; then printf '%%77\t0\t%s\n' "$PPID"; exit 0; fi
-    if [ "$2" = "-t" ]; then printf '0 %s\n' "$PPID"; exit 0; fi
-    exit 1
+  display-message)
+    case "$4" in
+      %31) printf '%%31\t0\t999999\tteam:liveness\n' ;;
+      %32) printf '%%32\t0\t%s\tteam:replacement\n' "$PPID" ;;
+      *) exit 1 ;;
+    esac
     ;;
-  show-option) printf 'team:liveness\n'; exit 0 ;;
+  *) exit 1 ;;
+esac
+`,
+      async () => {
+        assert.throws(
+          () => isWorkerAlive('ignored-session', 1, '%31', process.pid, 'team:liveness'),
+          /worker pane PID changed/,
+        );
+        assert.throws(
+          () => isWorkerAlive('ignored-session', 2, '%32', process.pid, 'team:liveness'),
+          /worker pane incarnation changed/,
+        );
+      },
+    );
+  });
+
+  it('classifies only missing, dead, or ESRCH exact panes as dead', async () => {
+    await withMockTmuxFixture(
+      'omx-worker-liveness-gone-',
+      () => `#!/bin/sh
+set -eu
+case "$1" in
+  display-message)
+    case "$4" in
+      %41) echo "can't find pane: %41" >&2; exit 1 ;;
+      %42) printf '%%42\t1\t42\tteam:liveness\n' ;;
+      %43) printf '%%43\t0\t%s\tteam:liveness\n' "$PPID" ;;
+      *) exit 1 ;;
+    esac
+    ;;
   *) exit 1 ;;
 esac
 `,
@@ -7436,8 +7456,9 @@ esac
           return originalProcessKill(pid, signal as NodeJS.Signals);
         }) as typeof process.kill;
         try {
-          assert.equal(isWorkerAlive('compat-session', 1), false);
-          assert.equal(isWorkerAlive('ignored-session', 1, '%77', process.pid, 'team:liveness'), false);
+          assert.equal(isWorkerAlive('ignored-session', 1, '%41', 41, 'team:liveness'), false);
+          assert.equal(isWorkerAlive('ignored-session', 2, '%42', 42, 'team:liveness'), false);
+          assert.equal(isWorkerAlive('ignored-session', 3, '%43', process.pid, 'team:liveness'), false);
         } finally {
           process.kill = originalProcessKill;
         }
@@ -7445,33 +7466,41 @@ esac
     );
   });
 
-  it('uses the exact global row for explicit pane liveness and fails closed for dead rows', async () => {
+  it('keeps EPERM and malformed exact identity as diagnostic/live-unknown outcomes', async () => {
     await withMockTmuxFixture(
-      'omx-pane-id-liveness-',
-      (logPath) => `#!/bin/sh
+      'omx-worker-liveness-fail-closed-',
+      () => `#!/bin/sh
 set -eu
-printf '%s\n' "$*" >> "${logPath}"
-case "\${1:-}" in
-  list-panes)
-    if [ "$2" = "-a" ]; then
-      printf '%%77\t0\t%s\n%%88\t1\t1\n' "$PPID"
-      exit 0
-    fi
-    exit 1
+case "$1" in
+  display-message)
+    case "$4" in
+      %51) printf '%%51\t0\t%s\tteam:liveness\n' "$PPID" ;;
+      %52) printf '%%leader\t0\t52\tteam:liveness\n' ;;
+      *) exit 2 ;;
+    esac
     ;;
-  show-option)
-    printf 'team:liveness\n'
-    ;;
-  *)
-    exit 1
-    ;;
+  *) exit 1 ;;
 esac
 `,
       async () => {
-        assert.equal(isWorkerAlive('ignored-session', 1, '%77', process.pid, 'team:liveness'), true);
-        assert.equal(isWorkerPaneOpen('ignored-session', 1, '%77', process.pid, 'team:liveness'), true);
-        assert.equal(isWorkerAlive('ignored-session', 2, '%88', 1, 'team:liveness'), false);
-        assert.equal(isWorkerPaneOpen('ignored-session', 2, '%88', 1, 'team:liveness'), false);
+        const originalProcessKill = process.kill;
+        process.kill = ((pid: number, signal?: number | NodeJS.Signals) => {
+          if (pid === process.pid && signal === 0) {
+            const error = new Error('permission denied') as NodeJS.ErrnoException;
+            error.code = 'EPERM';
+            throw error;
+          }
+          return originalProcessKill(pid, signal as NodeJS.Signals);
+        }) as typeof process.kill;
+        try {
+          assert.equal(isWorkerAlive('ignored-session', 1, '%51', process.pid, 'team:liveness'), true);
+          assert.throws(
+            () => isWorkerAlive('ignored-session', 2, '%52', 52, 'team:liveness'),
+            /worker pane identity changed.*pane_id_changed/,
+          );
+        } finally {
+          process.kill = originalProcessKill;
+        }
       },
     );
   });
@@ -7491,6 +7520,13 @@ case "$1" in
     ;;
   show-option)
     printf 'team:rows\n'
+    ;;
+  display-message)
+    case "$4" in
+      %13) printf '%%13\t0\t%s\tteam:rows\n' "${pane13Pid}" ;;
+      %130) printf '%%130\t0\t%s\tteam:rows\n' "${pane130Pid}" ;;
+      *) exit 1 ;;
+    esac
     ;;
   *)
     exit 1
@@ -7597,6 +7633,10 @@ printf '%s\n' "$*" >> "${logPath}"
 case "$1" in
   list-panes)
     printf '%%13\t0\t%s\n' "$PPID"
+    ;;
+  display-message)
+    echo "can't find pane: $4" >&2
+    exit 1
     ;;
   *)
     exit 0

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -7476,6 +7476,9 @@ case "$1" in
     case "$4" in
       %51) printf '%%51\t0\t%s\tteam:liveness\n' "$PPID" ;;
       %52) printf '%%leader\t0\t52\tteam:liveness\n' ;;
+      %53) printf '%%53\t0\t53\t\n' ;;
+      %54) printf '%%54\t1\t54\t\n' ;;
+      %55) printf '%%55\t0\t55\tteam:liveness\n' ;;
       *) exit 2 ;;
     esac
     ;;
@@ -7497,6 +7500,19 @@ esac
           assert.throws(
             () => isWorkerAlive('ignored-session', 2, '%52', 52, 'team:liveness'),
             /worker pane identity changed.*pane_id_changed/,
+          );
+          assert.throws(
+            () => isWorkerAlive('ignored-session', 3, '%53', 53, 'team:liveness'),
+            /worker pane incarnation changed.*missing/,
+          );
+          assert.equal(isWorkerAlive('ignored-session', 4, '%54', 54, 'team:liveness'), false);
+          assert.throws(
+            () => isWorkerAlive('ignored-session', 5, '%55', 55, 'team:liveness', '%55'),
+            /worker pane is HUD target/,
+          );
+          assert.throws(
+            () => getWorkerPanePid('ignored-session', 5, '%55', 55, 'team:liveness', '%55'),
+            /worker pane is HUD target/,
           );
         } finally {
           process.kill = originalProcessKill;
@@ -7645,7 +7661,7 @@ esac
 `,
       async ({ logPath }) => {
         assert.equal(getWorkerPanePid('ignored-session', 1, '%1'), null);
-        assert.equal(isWorkerAlive('ignored-session', 1, '%1'), false);
+        assert.equal(isWorkerAlive('ignored-session', 1, '%1'), true);
         assert.equal(isWorkerPaneOpen('ignored-session', 1, '%1'), false);
         await assert.rejects(() => sendToWorker('ignored-session', 1, 'check inbox', '%1'), /not proven live/);
         await killWorker('ignored-session', 1, '%1');

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -7479,6 +7479,7 @@ case "$1" in
       %53) printf '%%53\t0\t53\t\n' ;;
       %54) printf '%%54\t1\t54\t\n' ;;
       %55) printf '%%55\t0\t55\tteam:liveness\n' ;;
+      %56) printf '%%56\t1\t56\tteam:liveness\n' ;;
       *) exit 2 ;;
     esac
     ;;
@@ -7506,6 +7507,7 @@ esac
             /worker pane incarnation changed.*missing/,
           );
           assert.equal(isWorkerAlive('ignored-session', 4, '%54', 54, 'team:liveness'), false);
+          assert.equal(isWorkerAlive('ignored-session', 6, '%56', undefined, 'team:liveness'), false);
           assert.throws(
             () => isWorkerAlive('ignored-session', 5, '%55', 55, 'team:liveness', '%55'),
             /worker pane is HUD target/,
@@ -7669,7 +7671,7 @@ esac
 `,
       async ({ logPath }) => {
         assert.equal(getWorkerPanePid('ignored-session', 1, '%1'), null);
-        assert.equal(isWorkerAlive('ignored-session', 1, '%1'), true);
+        assert.equal(isWorkerAlive('ignored-session', 1, '%1'), false);
         assert.equal(isWorkerPaneOpen('ignored-session', 1, '%1'), false);
         await assert.rejects(() => sendToWorker('ignored-session', 1, 'check inbox', '%1'), /not proven live/);
         await killWorker('ignored-session', 1, '%1');

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -7511,6 +7511,14 @@ esac
             /worker pane is HUD target/,
           );
           assert.throws(
+            () => isWorkerAlive('ignored-session', 5, '%55', undefined, 'team:liveness', '%55'),
+            /worker pane is HUD target/,
+          );
+          assert.throws(
+            () => isWorkerAlive('ignored-session', 5, '%55', 55, undefined, '%55'),
+            /worker pane is HUD target/,
+          );
+          assert.throws(
             () => getWorkerPanePid('ignored-session', 5, '%55', 55, 'team:liveness', '%55'),
             /worker pane is HUD target/,
           );

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -836,6 +836,60 @@ function hasExplicitWorkerPaneId(workerPaneId: string | undefined): workerPaneId
   return typeof workerPaneId === 'string' && workerPaneId.trim().length > 0;
 }
 
+type ExactWorkerPaneLivenessProof =
+  | { status: 'live'; paneId: string; pid: number; ownerId: string }
+  | { status: 'gone'; paneId: string; reason: 'absent' | 'dead' }
+  | { status: 'unavailable'; paneId: string; reason: string };
+
+function readExactWorkerPaneLivenessProofSync(paneId: string): ExactWorkerPaneLivenessProof {
+  if (!/^%[0-9]+$/.test(paneId)) return { status: 'unavailable', paneId, reason: 'invalid_pane_id' };
+  const result = runTmux([
+    'display-message', '-p', '-t', paneId,
+    `#{pane_id}\t#{pane_dead}\t#{pane_pid}\t#{${OMX_TEAM_PANE_OWNER_OPTION}}`,
+  ]);
+  if (!result.ok) {
+    if (/can't find pane|no such pane|unknown pane/i.test(result.stderr)) {
+      return { status: 'gone', paneId, reason: 'absent' };
+    }
+    return { status: 'unavailable', paneId, reason: `query_failed:${result.stderr || 'unknown'}` };
+  }
+
+  const lines = result.stdout.replace(/\r\n/g, '\n').split('\n').filter((line) => line.length > 0);
+  if (lines.length !== 1) return { status: 'unavailable', paneId, reason: 'malformed_exact_pane_result' };
+  const fields = lines[0]!.split('\t');
+  if (fields.length !== 4) return { status: 'unavailable', paneId, reason: 'malformed_exact_pane_result' };
+  const [actualPaneId, paneDead, rawPid, ownerId] = fields;
+  if (actualPaneId !== paneId) {
+    return { status: 'unavailable', paneId, reason: `pane_id_changed:expected=${paneId}:actual=${actualPaneId}` };
+  }
+  if (paneDead !== '0' && paneDead !== '1') return { status: 'unavailable', paneId, reason: 'malformed_exact_pane_result' };
+  if (!/^[0-9]+$/.test(rawPid)) return { status: 'unavailable', paneId, reason: 'malformed_exact_pane_result' };
+  const pid = Number(rawPid);
+  if (!Number.isSafeInteger(pid) || pid <= 0) return { status: 'unavailable', paneId, reason: 'malformed_exact_pane_result' };
+  if (paneDead === '1') return { status: 'gone', paneId, reason: 'dead' };
+  return { status: 'live', paneId, pid, ownerId };
+}
+
+function requireExactWorkerPaneLivenessIdentity(
+  paneId: string,
+  expectedPanePid?: number,
+  expectedTeamOwnerId?: string,
+): ExactWorkerPaneLivenessProof {
+  const proof = readExactWorkerPaneLivenessProofSync(paneId);
+  if (proof.status === 'unavailable' && proof.reason.startsWith('pane_id_changed:')) {
+    throw new Error(`tmux worker pane identity changed: ${paneId}: ${proof.reason}`);
+  }
+  if (proof.status !== 'live') return proof;
+  if (typeof expectedPanePid === 'number' && proof.pid !== expectedPanePid) {
+    throw new Error(`tmux worker pane PID changed: ${paneId}: expected ${expectedPanePid}, got ${proof.pid}`);
+  }
+  const expectedOwner = typeof expectedTeamOwnerId === 'string' ? expectedTeamOwnerId.trim() : '';
+  if (expectedOwner && proof.ownerId !== expectedOwner) {
+    throw new Error(`tmux worker pane incarnation changed: ${paneId}: expected ${expectedOwner}, got ${proof.ownerId || 'missing'}`);
+  }
+  return proof;
+}
+
 function resolveWorkerPaneTargetSync(
   sessionName: string,
   workerIndex: number,
@@ -3458,18 +3512,11 @@ export function getWorkerPanePid(
   workerPaneId?: string,
   expectedPanePid?: number,
   expectedTeamOwnerId?: string,
-  hudPaneId?: string,
+  _hudPaneId?: string,
 ): number | null {
   if (hasExplicitWorkerPaneId(workerPaneId)) {
-    const target = createPinnedWorkerPaneTargetResolverSync(
-      sessionName,
-      workerIndex,
-      workerPaneId,
-      expectedPanePid,
-      expectedTeamOwnerId,
-      hudPaneId,
-    )();
-    return target ? expectedPanePid ?? null : null;
+    const proof = requireExactWorkerPaneLivenessIdentity(workerPaneId, expectedPanePid, expectedTeamOwnerId);
+    return proof.status === 'live' ? proof.pid : null;
   }
 
   const result = runTmux(['list-panes', '-t', paneTarget(sessionName, workerIndex), '-F', '#{pane_pid}']);
@@ -3491,19 +3538,13 @@ export function isWorkerAlive(
   workerPaneId?: string,
   expectedPanePid?: number,
   expectedTeamOwnerId?: string,
-  hudPaneId?: string,
+  _hudPaneId?: string,
 ): boolean {
   if (hasExplicitWorkerPaneId(workerPaneId)) {
-    const target = createPinnedWorkerPaneTargetResolverSync(
-      sessionName,
-      workerIndex,
-      workerPaneId,
-      expectedPanePid,
-      expectedTeamOwnerId,
-      hudPaneId,
-    )();
-    if (!target || typeof expectedPanePid !== 'number') return false;
-    return probeProcessLiveness(expectedPanePid) !== 'gone';
+    const proof = requireExactWorkerPaneLivenessIdentity(workerPaneId, expectedPanePid, expectedTeamOwnerId);
+    if (proof.status === 'unavailable') return true;
+    if (proof.status === 'gone') return false;
+    return probeProcessLiveness(proof.pid) !== 'gone';
   }
 
   const result = runTmux([

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -3545,6 +3545,9 @@ export function isWorkerAlive(
   hudPaneId?: string,
 ): boolean {
   if (hasExplicitWorkerPaneId(workerPaneId)) {
+    if (hudPaneId?.trim() && workerPaneId === hudPaneId.trim()) {
+      throw new Error(`tmux worker pane is HUD target: ${workerPaneId}`);
+    }
     if (typeof expectedPanePid !== 'number' || !Number.isSafeInteger(expectedPanePid) || expectedPanePid <= 0) return true;
     if (typeof expectedTeamOwnerId !== 'string' || expectedTeamOwnerId.trim() === '') return true;
     const proof = requireExactWorkerPaneLivenessIdentity(workerPaneId, expectedPanePid, expectedTeamOwnerId, hudPaneId);

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -3548,11 +3548,11 @@ export function isWorkerAlive(
     if (hudPaneId?.trim() && workerPaneId === hudPaneId.trim()) {
       throw new Error(`tmux worker pane is HUD target: ${workerPaneId}`);
     }
-    if (typeof expectedPanePid !== 'number' || !Number.isSafeInteger(expectedPanePid) || expectedPanePid <= 0) return true;
-    if (typeof expectedTeamOwnerId !== 'string' || expectedTeamOwnerId.trim() === '') return true;
     const proof = requireExactWorkerPaneLivenessIdentity(workerPaneId, expectedPanePid, expectedTeamOwnerId, hudPaneId);
     if (proof.status === 'unavailable') return true;
     if (proof.status === 'gone') return false;
+    if (typeof expectedPanePid !== 'number' || !Number.isSafeInteger(expectedPanePid) || expectedPanePid <= 0) return true;
+    if (typeof expectedTeamOwnerId !== 'string' || expectedTeamOwnerId.trim() === '') return true;
     return probeProcessLiveness(proof.pid) !== 'gone';
   }
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -843,7 +843,7 @@ type ExactWorkerPaneLivenessProof =
 
 function readExactWorkerPaneLivenessProofSync(paneId: string): ExactWorkerPaneLivenessProof {
   if (!/^%[0-9]+$/.test(paneId)) return { status: 'unavailable', paneId, reason: 'invalid_pane_id' };
-  const result = runTmux([
+  const result = runTmuxStructured([
     'display-message', '-p', '-t', paneId,
     `#{pane_id}\t#{pane_dead}\t#{pane_pid}\t#{${OMX_TEAM_PANE_OWNER_OPTION}}`,
   ]);
@@ -874,7 +874,11 @@ function requireExactWorkerPaneLivenessIdentity(
   paneId: string,
   expectedPanePid?: number,
   expectedTeamOwnerId?: string,
+  hudPaneId?: string,
 ): ExactWorkerPaneLivenessProof {
+  if (hudPaneId?.trim() && paneId === hudPaneId.trim()) {
+    throw new Error(`tmux worker pane is HUD target: ${paneId}`);
+  }
   const proof = readExactWorkerPaneLivenessProofSync(paneId);
   if (proof.status === 'unavailable' && proof.reason.startsWith('pane_id_changed:')) {
     throw new Error(`tmux worker pane identity changed: ${paneId}: ${proof.reason}`);
@@ -3512,10 +3516,10 @@ export function getWorkerPanePid(
   workerPaneId?: string,
   expectedPanePid?: number,
   expectedTeamOwnerId?: string,
-  _hudPaneId?: string,
+  hudPaneId?: string,
 ): number | null {
   if (hasExplicitWorkerPaneId(workerPaneId)) {
-    const proof = requireExactWorkerPaneLivenessIdentity(workerPaneId, expectedPanePid, expectedTeamOwnerId);
+    const proof = requireExactWorkerPaneLivenessIdentity(workerPaneId, expectedPanePid, expectedTeamOwnerId, hudPaneId);
     return proof.status === 'live' ? proof.pid : null;
   }
 
@@ -3538,10 +3542,12 @@ export function isWorkerAlive(
   workerPaneId?: string,
   expectedPanePid?: number,
   expectedTeamOwnerId?: string,
-  _hudPaneId?: string,
+  hudPaneId?: string,
 ): boolean {
   if (hasExplicitWorkerPaneId(workerPaneId)) {
-    const proof = requireExactWorkerPaneLivenessIdentity(workerPaneId, expectedPanePid, expectedTeamOwnerId);
+    if (typeof expectedPanePid !== 'number' || !Number.isSafeInteger(expectedPanePid) || expectedPanePid <= 0) return true;
+    if (typeof expectedTeamOwnerId !== 'string' || expectedTeamOwnerId.trim() === '') return true;
+    const proof = requireExactWorkerPaneLivenessIdentity(workerPaneId, expectedPanePid, expectedTeamOwnerId, hudPaneId);
     if (proof.status === 'unavailable') return true;
     if (proof.status === 'gone') return false;
     return probeProcessLiveness(proof.pid) !== 'gone';


### PR DESCRIPTION
Closes #3222

## Summary
- replace explicit worker liveness/PID broad pane snapshots with exact `display-message -t <pane>` identity reads
- verify returned pane ID, frozen PID, and Team pane-owner incarnation before classifying liveness
- treat identity mismatch as a diagnostic error and unavailable evidence as live-unknown, never worker death
- cover leader-first broad snapshots, pane recycle, PID reuse, missing/dead exact panes, ESRCH/EPERM, and multiple workers

## Verification
- `npx biome lint src/team/tmux-session.ts src/team/__tests__/tmux-session.test.ts src/cli/__tests__/team.test.ts`
- `npm run check:no-unused`
- `npm run build`
- `node dist/scripts/run-test-files.js dist/team/__tests__/tmux-session.test.js dist/cli/__tests__/team.test.js`
- `npm test`

Signed-off-by: GJC Maintainer Lane <maintainers@oh-my-codex.dev>