### PR TITLE
fix(team): fail closed on managed Codex bypass rejection

### DIFF
--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -551,6 +551,86 @@ if (process.argv.includes('--version') || process.argv.includes('-V')) {
 ${body}`;
 }
 
+function codexMdmTmuxScript(marker: string): (tmuxLogPath: string) => string {
+  return (tmuxLogPath) => `#!/bin/sh
+set -eu
+${tmuxOwnerProofShim}
+printf '%s\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V) echo 'tmux 3.4' ;;
+  display-message)
+    case "$*" in *'#{window_width}'*) echo 120 ;; *) echo 'leader:0 %1' ;; esac
+    ;;
+  list-panes)
+    case "$*" in
+      *'-a -F #{pane_id}'*)
+        printf '%%1\t0\t2000001111\n'
+        if [ -f "${tmuxLogPath}.worker-created" ]; then
+          worker_pid=$(cat "${tmuxLogPath}.worker-pid")
+          printf '%%2\t0\t%s\n' "$worker_pid"
+        fi
+        if [ -f "${tmuxLogPath}.hud-created" ]; then printf '%%3\t0\t2000003333\n'; fi
+        ;;
+      *'pane_current_command'*)
+        printf "%%1\tnode\t'codex'\n"
+        if [ -f "${tmuxLogPath}.worker-created" ]; then printf '%%2\tcodex\tcodex\n'; fi
+        if [ -f "${tmuxLogPath}.hud-created" ]; then printf '%%3\tnode\thud --watch\n'; fi
+        ;;
+      *'#{pane_dead} #{pane_pid}'*)
+        case "$*" in
+          *'%1'*) echo '0 2000001111' ;;
+          *'%2'*) if [ -f "${tmuxLogPath}.worker-pid" ]; then echo "0 $(cat "${tmuxLogPath}.worker-pid")"; fi ;;
+          *'%3'*) echo '0 2000003333' ;;
+        esac
+        ;;
+      *'#{pane_dead}'*) echo 0 ;;
+      *'#{pane_pid}'*)
+        case "$*" in
+          *'%1'*) echo 2000001111 ;;
+          *'%2'*) if [ -f "${tmuxLogPath}.worker-pid" ]; then cat "${tmuxLogPath}.worker-pid"; fi ;;
+          *'%3'*) echo 2000003333 ;;
+        esac
+        ;;
+    esac
+    ;;
+  capture-pane)
+    count=0
+    [ -f "${tmuxLogPath}.capture-count" ] && count=$(cat "${tmuxLogPath}.capture-count")
+    count=$((count + 1))
+    printf '%s' "$count" > "${tmuxLogPath}.capture-count"
+    if [ "${'$'}{OMX_MDM_CAPTURE_MODE:-direct}" = detailed ] && [ "$count" -lt 5 ]; then
+      printf 'OpenAI Codex\\nmodel: test\\ndirectory: /tmp/demo\\n'
+    else
+      printf '%s\\n' '${marker}'
+    fi
+    ;;
+  split-window)
+    case "$*" in
+      *' -h '*)
+        : > "${tmuxLogPath}.worker-created"
+        last=''
+        for arg in "$@"; do last="$arg"; done
+        sh -c "$last" >/dev/null 2>&1 &
+        printf '%s' "$!" > "${tmuxLogPath}.worker-pid"
+        echo '%2'
+        ;;
+      *) : > "${tmuxLogPath}.hud-created"; echo '%3' ;;
+    esac
+    ;;
+  kill-pane)
+    case "$*" in
+      *'%2'*)
+        if [ -f "${tmuxLogPath}.worker-pid" ]; then kill "$(cat "${tmuxLogPath}.worker-pid")" 2>/dev/null || true; fi
+        rm -f "${tmuxLogPath}.worker-created" "${tmuxLogPath}.worker-pid"
+        ;;
+      *'%3'*) rm -f "${tmuxLogPath}.hud-created" ;;
+    esac
+    ;;
+  set-hook|run-shell|select-layout|set-window-option|select-pane|send-keys|kill-session|resize-pane) ;;
+esac
+`;
+}
+
 
 function teamStateTestPath(cwd: string, ...parts: string[]): string {
   const stateRoot = process.env.OMX_TEAM_STATE_ROOT ?? join(cwd, '.omx', 'state');
@@ -3370,6 +3450,152 @@ esac
       else delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRIES;
       if (typeof previousStartupDispatchRetryDelay === 'string') process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS = previousStartupDispatchRetryDelay;
       else delete process.env.OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('terminates attached Codex startup on the first exact MDM bypass marker without dispatch or retry', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-codex-mdm-direct-'));
+    const teamName = `codex-mdm-${process.pid}-${Date.now().toString(36)}`;
+    const argvCapturePath = join(cwd, 'codex-argv.json');
+    const marker = 'MDM_POLICY_REJECTED: approval_policy=never forbids --dangerously-bypass-approvals-and-sandbox';
+    const previousTmux = process.env.TMUX;
+    const previousPane = process.env.TMUX_PANE;
+
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-codex-mdm-direct-bin-',
+          tmuxScript: codexMdmTmuxScript(marker),
+          binaries: [{
+            name: 'codex',
+            content: fakeCodexNodeScript(`require('fs').writeFileSync(process.env.OMX_CODEX_ARGV_CAPTURE, JSON.stringify(process.argv.slice(2)));
+process.stdin.resume();`),
+          }],
+          env: {
+            OMX_TEAM_WORKER_LAUNCH_MODE: 'interactive',
+            OMX_TEAM_WORKER_CLI: 'codex',
+            OMX_TEAM_WORKER_LAUNCH_ARGS: '--dangerously-bypass-approvals-and-sandbox --model gpt-5.6-test',
+            OMX_CODEX_ARGV_CAPTURE: argvCapturePath,
+            OMX_TEAM_READY_TIMEOUT_MS: '50',
+            OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS: '50',
+            OMX_TEAM_STARTUP_DISPATCH_RETRIES: '2',
+            OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS: '1',
+          },
+        },
+        async ({ tmuxLogPath }) => {
+          delete process.env.TMUX;
+          process.env.TMUX_PANE = '%1';
+
+          await assert.rejects(
+            () => withoutTeamWorkerEnv(() => startTeam(
+              teamName,
+              'reject an attached Codex bypass rejected by MDM',
+              'executor',
+              1,
+              [{ subject: 'w1', description: 'worker one', owner: 'worker-1' }],
+              cwd,
+            )),
+            /(worker_startup_incompatible:worker-1:codex_bypass_mdm_incompatible|startup_rollback_pane_proof_unavailable:%2:pane_proof_lost_during_process_teardown)/,
+          );
+
+          const finalArgv = JSON.parse(await waitForFileText(argvCapturePath, (content) => content.length > 0)) as string[];
+          assert.deepEqual(finalArgv.slice(0, 5), [
+            '-c', 'model_reasoning_effort="medium"',
+            '--model', 'gpt-5.6-test',
+            '--dangerously-bypass-approvals-and-sandbox',
+          ]);
+          assert.ok(finalArgv.some((arg) => arg.startsWith('model_instructions_file=')));
+          assert.equal(finalArgv.filter((arg) => arg === '--dangerously-bypass-approvals-and-sandbox').length, 1);
+
+          const tmuxEvents = (await readFile(tmuxLogPath, 'utf-8')).trim().split('\n').filter(Boolean);
+          const captureEvents = tmuxEvents.filter((event) => event.startsWith('capture-pane '));
+          assert.equal(captureEvents.length, 1, 'marker must not enter a second readiness cycle');
+          assert.equal(tmuxEvents.some((event) => event.startsWith('send-keys ') && event.includes(' -l -- ')), false, `marker must stop before any literal dispatch: ${tmuxEvents.join(',')}`);
+          const retainedTeams = await readdir(teamStateTestPath(cwd, 'team'));
+          assert.equal(retainedTeams.length, 1, 'proof-loss rollback must retain one inspectable team root');
+          const retainedTeamName = retainedTeams[0]!;
+          const retainedTask = await readTask(retainedTeamName, '1', cwd);
+          assert.equal(retainedTask?.status, 'pending');
+          assert.equal(retainedTask?.owner, 'worker-1');
+          assert.equal(retainedTask?.claim, undefined);
+          const retainedWorker = await readWorkerStatus(retainedTeamName, 'worker-1', cwd);
+          assert.equal(retainedWorker.reason, 'codex_bypass_mdm_incompatible');
+          assert.equal(retainedWorker.current_task_id, undefined);
+        },
+      );
+    } finally {
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousPane === 'string') process.env.TMUX_PANE = previousPane;
+      else delete process.env.TMUX_PANE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('terminates on an MDM marker first observed during detailed readiness before fallback dispatch', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-codex-mdm-detailed-'));
+    const teamName = `codex-mdm-detailed-${process.pid}-${Date.now().toString(36)}`;
+    const marker = 'MDM_POLICY_REJECTED: approval_policy=never forbids --dangerously-bypass-approvals-and-sandbox';
+    const previousTmux = process.env.TMUX;
+    const previousPane = process.env.TMUX_PANE;
+
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-codex-mdm-detailed-bin-',
+          tmuxScript: codexMdmTmuxScript(marker),
+          binaries: [{ name: 'codex', content: fakeCodexNodeScript('process.stdin.resume();') }],
+          env: {
+            OMX_TEAM_WORKER_LAUNCH_MODE: 'interactive',
+            OMX_TEAM_WORKER_CLI: 'codex',
+            OMX_TEAM_WORKER_LAUNCH_ARGS: '--dangerously-bypass-approvals-and-sandbox --model gpt-5.6-test',
+            OMX_MDM_CAPTURE_MODE: 'detailed',
+            OMX_TEAM_READY_TIMEOUT_MS: '50',
+            OMX_TEAM_STARTUP_EVIDENCE_TIMEOUT_MS: '50',
+            OMX_TEAM_STARTUP_DISPATCH_RETRIES: '2',
+            OMX_TEAM_STARTUP_DISPATCH_RETRY_DELAY_MS: '1',
+          },
+        },
+        async ({ tmuxLogPath }) => {
+          delete process.env.TMUX;
+          process.env.TMUX_PANE = '%1';
+          await assert.rejects(
+            () => withoutTeamWorkerEnv(() => startTeam(
+              teamName,
+              'reject a detailed-readiness Codex MDM bypass marker',
+              'executor',
+              1,
+              [{ subject: 'w1', description: 'worker one', owner: 'worker-1' }],
+              cwd,
+            )),
+            /(worker_startup_incompatible:worker-1:codex_bypass_mdm_incompatible|startup_rollback_pane_proof_unavailable:%2:pane_proof_lost_during_process_teardown)/,
+          );
+
+          const tmuxEvents = (await readFile(tmuxLogPath, 'utf-8')).trim().split('\n').filter(Boolean);
+          const captureIndexes = tmuxEvents
+            .map((event, index) => event.startsWith('capture-pane ') ? index : -1)
+            .filter((index) => index >= 0);
+          assert.ok(captureIndexes.length >= 5, `expected startup-direct delivery captures followed by detailed readiness marker: ${tmuxEvents.join(',')}`);
+          const markerCaptureIndex = captureIndexes[4]!;
+          assert.equal(tmuxEvents.slice(markerCaptureIndex + 1).some((event) => event.startsWith('send-keys ') && event.includes(' -l -- ')), false, `marker must stop before fallback dispatch/retry: ${tmuxEvents.join(',')}`);
+          const retainedTeams = await readdir(teamStateTestPath(cwd, 'team'));
+          assert.equal(retainedTeams.length, 1, 'proof-loss rollback must retain one inspectable team root');
+          const retainedTeamName = retainedTeams[0]!;
+          const retainedTask = await readTask(retainedTeamName, '1', cwd);
+          assert.equal(retainedTask?.status, 'pending');
+          assert.equal(retainedTask?.owner, 'worker-1');
+          assert.equal(retainedTask?.claim, undefined);
+          const retainedWorker = await readWorkerStatus(retainedTeamName, 'worker-1', cwd);
+          assert.equal(retainedWorker.reason, 'codex_bypass_mdm_incompatible');
+          assert.equal(retainedWorker.current_task_id, undefined);
+        },
+      );
+    } finally {
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousPane === 'string') process.env.TMUX_PANE = previousPane;
+      else delete process.env.TMUX_PANE;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -66,6 +66,7 @@ import {
   checkWorkerStartupInjectSafety,
   dismissTrustPromptIfPresent,
   evaluateStartupDirectTriggerSafetyCapture,
+  classifyCodexBypassMdmIncompatibility,
   mitigateCopyModeUnderlineArtifacts,
   listPaneIds,
 } from '../tmux-session.js';
@@ -546,6 +547,18 @@ esac
 
 
 describe('evaluateStartupDirectTriggerSafetyCapture', () => {
+  it('classifies only the exact Codex bypass MDM rejection marker', () => {
+    const bypassArgs = ['--dangerously-bypass-approvals-and-sandbox'];
+    const directPolicyArgs = ['--sandbox', 'workspace-write', '--model', 'gpt-5'];
+    const marker = 'MDM_POLICY_REJECTED: approval_policy=never forbids --dangerously-bypass-approvals-and-sandbox';
+    assert.equal(classifyCodexBypassMdmIncompatibility(marker, 'codex', bypassArgs), 'codex_bypass_mdm_incompatible');
+    assert.equal(classifyCodexBypassMdmIncompatibility(`${marker} extra`, 'codex', bypassArgs), null);
+    assert.equal(classifyCodexBypassMdmIncompatibility(` ${marker}`, 'codex', bypassArgs), null);
+    assert.equal(classifyCodexBypassMdmIncompatibility(`${marker} `, 'codex', bypassArgs), null);
+    assert.equal(classifyCodexBypassMdmIncompatibility(marker, 'claude', bypassArgs), null);
+    assert.equal(classifyCodexBypassMdmIncompatibility(marker, 'codex', directPolicyArgs), null, 'direct policy without bypass must keep normal startup handling');
+    assert.equal(classifyCodexBypassMdmIncompatibility('OpenAI Codex\nLoading workspace...', 'codex', bypassArgs), null, 'bypass without the exact marker must keep normal readiness/timeout handling');
+  });
   it('allows startup direct triggers on a ready prompt or Codex viewport', () => {
     assert.deepEqual(evaluateStartupDirectTriggerSafetyCapture(READY_HELPER_CAPTURE, 'codex'), {
       safe: true,

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -24,6 +24,7 @@ import {
   type TeamSession,
   waitForWorkerReady,
   waitForWorkerReadyAsync,
+  waitForWorkerReadyDetailedAsync,
   dismissTrustPromptIfPresent,
   evaluateStartupDirectTriggerSafety,
   sendToWorker,
@@ -2224,6 +2225,10 @@ function isStartupEvidenceMissingReason(reason: string): boolean {
     || normalized.includes('fallback_attempted_but_unconfirmed');
 }
 
+function isStartupIncompatibleReason(reason: string): boolean {
+  return reason.trim() === 'codex_bypass_mdm_incompatible';
+}
+
 async function recordRecoverableStartupIssue(params: {
   teamName: string;
   workerName: string;
@@ -2233,7 +2238,7 @@ async function recordRecoverableStartupIssue(params: {
 }): Promise<void> {
   const { teamName, workerName, taskIds, reason, cwd } = params;
   const updatedAt = new Date().toISOString();
-  const currentTaskId = isStartupEvidenceMissingReason(reason) ? undefined : taskIds[0];
+  const currentTaskId = isStartupEvidenceMissingReason(reason) || isStartupIncompatibleReason(reason) ? undefined : taskIds[0];
   await writeWorkerStatus(
     teamName,
     workerName,
@@ -3766,6 +3771,7 @@ export async function startTeam(
       writeWarning: options.writeCleanupWarning,
     });
     const startupTiming = createStartupTimingRecorder(sanitized, leaderCwd);
+    let workerStartupArgs: ReadonlyArray<ReadonlyArray<string>> | undefined;
 
     if (workerLaunchMode === 'interactive') {
       const createdSession = createTeamSession(
@@ -3781,6 +3787,7 @@ export async function startTeam(
       createdWorkerPaneIds.push(...createdSession.workerPaneIds);
       createdLeaderPaneId = createdSession.leaderPaneId;
       applyCreatedInteractiveSessionToConfig(config, createdSession, workerPaneIds);
+      workerStartupArgs = createdSession.workerStartupArgs;
       const createdOwnerId = typeof createdSession.teamPaneOwnerId === 'string'
         ? createdSession.teamPaneOwnerId.trim()
         : '';
@@ -3882,6 +3889,7 @@ export async function startTeam(
           workerIndex,
           paneId,
           workerCli: bootstrapPlan.workerCli,
+          finalArgs: workerStartupArgs?.[workerIndex - 1],
           inbox,
           triggerMessage: trigger,
           intent: triggerIntent,
@@ -3890,12 +3898,47 @@ export async function startTeam(
           timing: startupTiming,
         })
         : null;
+      if (startupDirectOutcome?.reason === 'codex_bypass_mdm_incompatible') {
+        await recordRecoverableStartupIssue({
+          teamName: sanitized,
+          workerName,
+          taskIds: workerTasks.map((task) => task.id),
+          reason: startupDirectOutcome.reason,
+          cwd: leaderCwd,
+        });
+        return {
+          ok: false,
+          workerIndex,
+          workerName,
+          error: new Error(`worker_startup_incompatible:${workerName}:${startupDirectOutcome.reason}`),
+        };
+      }
 
       let startupReadyPromptObserved = false;
       if (workerLaunchMode === 'interactive' && !skipWorkerReadyWait && !initialPrompt && !startupDirectOutcome?.ok) {
         startupTiming.mark('ready_wait_start', { worker: workerName, pane_id: paneId });
-        const ready = await waitForWorkerReadyAsync(sessionName, workerIndex, workerReadyTimeoutMs, paneId, config!.workers[workerIndex - 1]?.pid, config!.tmux_pane_owner_id ?? undefined, config!.hud_pane_id ?? undefined);
+        let readinessIncompatibility: string | null = null;
+        const ready = await waitForWorkerReadyDetailedAsync(sessionName, workerIndex, workerReadyTimeoutMs, paneId, config!.workers[workerIndex - 1]?.pid, config!.tmux_pane_owner_id ?? undefined, config!.hud_pane_id ?? undefined, {
+          workerCli: bootstrapPlan.workerCli,
+          finalArgs: workerStartupArgs?.[workerIndex - 1],
+          onIncompatible: (reason) => { readinessIncompatibility = reason; },
+        });
         startupTiming.mark('ready_wait_end', { worker: workerName, pane_id: paneId, ok: ready });
+        if (readinessIncompatibility) {
+          await recordRecoverableStartupIssue({
+            teamName: sanitized,
+            workerName,
+            taskIds: workerTasks.map((task) => task.id),
+            reason: readinessIncompatibility,
+            cwd: leaderCwd,
+          });
+          return {
+            ok: false,
+            workerIndex,
+            workerName,
+            error: new Error(`worker_startup_incompatible:${workerName}:${readinessIncompatibility}`),
+          };
+        }
         if (!ready) {
           const workerAlive = isWorkerPaneOpen(
             sessionName,
@@ -5819,6 +5862,7 @@ async function attemptStartupDirectTrigger(params: {
   workerIndex: number;
   paneId?: string;
   workerCli?: TeamWorkerCli;
+  finalArgs?: readonly string[];
   inbox: string;
   triggerMessage: string;
   intent?: TeamReminderIntent;
@@ -5833,6 +5877,7 @@ async function attemptStartupDirectTrigger(params: {
     workerIndex,
     paneId,
     workerCli,
+    finalArgs,
     inbox,
     triggerMessage,
     intent,
@@ -5841,7 +5886,7 @@ async function attemptStartupDirectTrigger(params: {
     timing,
   } = params;
 
-  const safety = await evaluateStartupDirectTriggerSafety(config.tmux_session, workerIndex, paneId, workerCli);
+  const safety = await evaluateStartupDirectTriggerSafety(config.tmux_session, workerIndex, paneId, workerCli, finalArgs);
   if (!safety.safe) {
     timing.mark('startup_direct_bypass', {
       worker: workerName,
@@ -5849,6 +5894,9 @@ async function attemptStartupDirectTrigger(params: {
       ok: false,
       reason: `startup_direct_unsafe:${safety.reason}`,
     });
+    if (safety.reason === 'codex_bypass_mdm_incompatible') {
+      return { ok: false, transport: 'none', reason: safety.reason };
+    }
     return null;
   }
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -89,6 +89,8 @@ export interface TeamSession {
   resizeHookTarget: string | null;
   /** Team-scoped tmux pane ownership token used by shutdown safety checks. */
   teamPaneOwnerId: string;
+  /** Immutable effective argv used by attached tmux startup scripts, aligned by worker index. */
+  workerStartupArgs?: ReadonlyArray<ReadonlyArray<string>>;
 }
 
 /** Carries live tmux resources when creation cannot safely roll them back. */
@@ -1779,6 +1781,42 @@ function appendTeamWorkerMcpDisableOverrides(args: string[], env: NodeJS.Process
   }
 }
 
+const CODEX_BYPASS_MDM_INCOMPATIBLE_REASON = 'codex_bypass_mdm_incompatible';
+const CODEX_BYPASS_MDM_REJECTED_MARKER = 'MDM_POLICY_REJECTED: approval_policy=never forbids --dangerously-bypass-approvals-and-sandbox';
+
+export function classifyCodexBypassMdmIncompatibility(
+  captured: string,
+  workerCli: TeamWorkerCli | undefined,
+  finalArgs: readonly string[] | undefined,
+): typeof CODEX_BYPASS_MDM_INCOMPATIBLE_REASON | null {
+  if (workerCli !== 'codex' || !finalArgs || !parseTeamWorkerLaunchArgs([...finalArgs], 'final tmux worker arguments', { directPolicyMode: 'ignore' }).wantsBypass) return null;
+  const normalizedLines = captured.replace(/\r\n?/g, '\n').split('\n');
+  return normalizedLines.includes(CODEX_BYPASS_MDM_REJECTED_MARKER)
+    ? CODEX_BYPASS_MDM_INCOMPATIBLE_REASON
+    : null;
+}
+
+type AttachedTmuxWorkerStartupPlan = Readonly<{
+  processSpec: WorkerProcessLaunchSpec;
+  startupArgs: ReadonlyArray<string>;
+}>;
+
+function buildAttachedTmuxWorkerStartupPlan(
+  teamName: string,
+  workerIndex: number,
+  launchArgs: string[],
+  cwd: string,
+  extraEnv: Record<string, string>,
+  workerCliOverride?: TeamWorkerCli,
+  initialPrompt?: string,
+  workerRole?: string,
+): AttachedTmuxWorkerStartupPlan {
+  const processSpec = buildWorkerStartupProcessLaunchSpec(teamName, workerIndex, launchArgs, cwd, extraEnv, workerCliOverride, initialPrompt, workerRole);
+  const startupArgs = [...processSpec.args];
+  if (processSpec.workerCli === 'codex') appendTeamWorkerMcpDisableOverrides(startupArgs, { ...process.env, ...extraEnv });
+  return Object.freeze({ processSpec, startupArgs: Object.freeze(startupArgs) });
+}
+
 function insertArgsBeforeEndOfOptions(args: string[], insertedArgs: readonly string[]): string[] {
   const endOfOptionsIndex = args.indexOf('--');
   if (endOfOptionsIndex < 0) return [...args, ...insertedArgs];
@@ -1946,33 +1984,17 @@ export function writeWorkerStartupScriptCommand(
   workerCliOverride?: TeamWorkerCli,
   initialPrompt?: string,
   workerRole?: string,
+  attachedPlan?: AttachedTmuxWorkerStartupPlan,
 ): string | null {
   if (process.platform === 'win32' && !isMsysOrGitBash()) return null;
   const stateRoot = extraEnv[OMX_TEAM_STATE_ROOT_ENV]?.trim();
   if (!stateRoot) return null;
 
-  const processSpec = buildWorkerStartupProcessLaunchSpec(
-    teamName,
-    workerIndex,
-    launchArgs,
-    cwd,
-    extraEnv,
-    workerCliOverride,
-    initialPrompt,
-    workerRole,
-  );
-  const startupEnv = {
-    ...readTmuxWorkerAmbientEnv(process.env),
-    ...processSpec.env,
-  };
-  const startupArgs = [...processSpec.args];
-  if (processSpec.workerCli === 'codex') {
-    appendTeamWorkerMcpDisableOverrides(startupArgs, { ...process.env, ...extraEnv });
-  }
-
+  const startupPlan = attachedPlan ?? buildAttachedTmuxWorkerStartupPlan(teamName, workerIndex, launchArgs, cwd, extraEnv, workerCliOverride, initialPrompt, workerRole);
+  const startupEnv = { ...readTmuxWorkerAmbientEnv(process.env), ...startupPlan.processSpec.env };
   const scriptPath = join(stateRoot, 'team', teamName, 'runtime', `worker-${workerIndex}-startup.sh`);
   mkdirSync(dirname(scriptPath), { recursive: true });
-  writeFileSync(scriptPath, buildWorkerStartupScriptContent(processSpec, startupEnv, startupArgs, cwd, extraEnv), 'utf-8');
+  writeFileSync(scriptPath, buildWorkerStartupScriptContent(startupPlan.processSpec, startupEnv, [...startupPlan.startupArgs], cwd, extraEnv), 'utf-8');
   chmodSync(scriptPath, 0o700);
   return `exec /bin/sh ${shellQuoteSingle(translatePathForMsys(scriptPath))}`;
 }
@@ -2296,6 +2318,7 @@ export function createTeamSession(
     }
 
     const workerPaneIds: string[] = [];
+    const workerStartupArgs: Array<ReadonlyArray<string>> = Array.from({ length: workerCount }, () => Object.freeze([]));
     const workerPanePidsByIndex: Array<number | null> = Array.from({ length: workerCount }, () => null);
     let rightStackRootPaneId: string | null = null;
     let rightStackRootPanePid: number | null = null;
@@ -2308,17 +2331,10 @@ export function createTeamSession(
       const tmuxWorkerCwd = translatePathForMsys(workerCwd);
       const workerEnv = startup.env || {};
       const launchArgsForWorker = [...(workerLaunchPolicyPlan[i - 1] ?? workerLaunchArgs)];
+      const attachedStartupPlan = buildAttachedTmuxWorkerStartupPlan(safeTeamName, i, launchArgsForWorker, workerCwd, workerEnv, workerCliPlan[i - 1], startup.initialPrompt, startup.workerRole);
+      workerStartupArgs[i - 1] = attachedStartupPlan.startupArgs;
       trustWorkerMiseConfigIfAvailable(workerCwd);
-      const cmd = writeWorkerStartupScriptCommand(
-        safeTeamName,
-        i,
-        launchArgsForWorker,
-        workerCwd,
-        workerEnv,
-        workerCliPlan[i - 1],
-        startup.initialPrompt,
-        startup.workerRole,
-      ) ?? buildWorkerStartupCommand(
+      const cmd = writeWorkerStartupScriptCommand(safeTeamName, i, launchArgsForWorker, workerCwd, workerEnv, workerCliPlan[i - 1], startup.initialPrompt, startup.workerRole, attachedStartupPlan) ?? buildWorkerStartupCommand(
         safeTeamName,
         i,
         launchArgsForWorker,
@@ -2573,6 +2589,7 @@ export function createTeamSession(
       workerPaneIdsByIndex: [...workerPaneIds],
       workerPanePidsByIndex,
       leaderPanePid,
+      workerStartupArgs: Object.freeze(workerStartupArgs),
       hudPanePid: partialHudPanePid,
 
       leaderPaneId,
@@ -2897,9 +2914,11 @@ function paneHasClaudeBypassPermissionsPrompt(captured: string): boolean {
 
 export type StartupDirectTriggerSafety =
   | { safe: true; reason: 'ready_prompt' | 'codex_viewport' }
-  | { safe: false; reason: 'tmux_unavailable' | 'capture_failed' | 'trust_prompt' | 'claude_bypass_prompt' | 'bootstrapping' | 'not_agent_viewport' };
+  | { safe: false; reason: 'tmux_unavailable' | 'capture_failed' | 'trust_prompt' | 'claude_bypass_prompt' | 'bootstrapping' | 'not_agent_viewport' | typeof CODEX_BYPASS_MDM_INCOMPATIBLE_REASON };
 
-export function evaluateStartupDirectTriggerSafetyCapture(captured: string, workerCli?: TeamWorkerCli): StartupDirectTriggerSafety {
+export function evaluateStartupDirectTriggerSafetyCapture(captured: string, workerCli?: TeamWorkerCli, finalArgs?: readonly string[]): StartupDirectTriggerSafety {
+  const incompatibleReason = classifyCodexBypassMdmIncompatibility(captured, workerCli, finalArgs);
+  if (incompatibleReason) return { safe: false, reason: incompatibleReason };
   if (paneHasTrustPrompt(captured)) return { safe: false, reason: 'trust_prompt' };
   if (paneHasClaudeBypassPermissionsPrompt(captured)) return { safe: false, reason: 'claude_bypass_prompt' };
   if (paneLooksReady(captured)) return { safe: true, reason: 'ready_prompt' };
@@ -2913,14 +2932,14 @@ export async function evaluateStartupDirectTriggerSafety(
   workerIndex: number,
   workerPaneId?: string,
   workerCli?: TeamWorkerCli,
+  finalArgs?: readonly string[],
 ): Promise<StartupDirectTriggerSafety> {
   if (!isTmuxAvailable()) return { safe: false, reason: 'tmux_unavailable' };
   const target = await resolveWorkerPaneTargetAsync(sessionName, workerIndex, workerPaneId);
-
   if (!target) return { safe: false, reason: 'capture_failed' };
   const result = await runTmuxAsync(sharedBuildVisibleCapturePaneArgv(target));
   if (!result.ok) return { safe: false, reason: 'capture_failed' };
-  return evaluateStartupDirectTriggerSafetyCapture(result.stdout, workerCli);
+  return evaluateStartupDirectTriggerSafetyCapture(result.stdout, workerCli, finalArgs);
 }
 
 function acceptClaudeBypassPermissionsPrompt(resolveTarget: () => string | null): boolean {
@@ -3228,7 +3247,7 @@ export function waitForWorkerReady(
 // Async twin of waitForWorkerReady for team startup fan-out. Keep the readiness
 // semantics mirrored with the synchronous helper above, but yield between polls
 // so one slow worker pane cannot block later workers' startup attempts.
-export async function waitForWorkerReadyAsync(
+export async function waitForWorkerReadyDetailedAsync(
   sessionName: string,
   workerIndex: number,
   timeoutMs: number = 30_000,
@@ -3236,12 +3255,14 @@ export async function waitForWorkerReadyAsync(
   expectedPanePid?: number,
   expectedTeamOwnerId?: string,
   hudPaneId?: string,
+  incompatibility?: { workerCli?: TeamWorkerCli; finalArgs?: readonly string[]; onIncompatible: (reason: typeof CODEX_BYPASS_MDM_INCOMPATIBLE_REASON) => void },
 ): Promise<boolean> {
   const initialBackoffMs = 150;
   const maxBackoffMs = 8000;
   const startedAt = Date.now();
   let blockedByTrustPrompt = false;
   let promptDismissed = false;
+  let startupIncompatible = false;
   const resolveTarget = createPinnedWorkerPaneTargetResolver(sessionName, workerIndex, workerPaneId, expectedPanePid, expectedTeamOwnerId, hudPaneId);
 
 
@@ -3262,6 +3283,12 @@ export async function waitForWorkerReadyAsync(
     if (!target) return false;
     const result = await runTmuxAsync(sharedBuildVisibleCapturePaneArgv(target));
     if (!result.ok) return false;
+    const incompatibleReason = classifyCodexBypassMdmIncompatibility(result.stdout, incompatibility?.workerCli, incompatibility?.finalArgs);
+    if (incompatibleReason) {
+      startupIncompatible = true;
+      incompatibility?.onIncompatible(incompatibleReason);
+      return false;
+    }
     if (await dismissClaudeBypassPermissionsPromptIfPresentAsync(resolveTarget, result.stdout)) {
       promptDismissed = true;
       return false;
@@ -3296,6 +3323,7 @@ export async function waitForWorkerReadyAsync(
   let delayMs = initialBackoffMs;
   while (Date.now() - startedAt < timeoutMs) {
     if (await check()) return true;
+    if (startupIncompatible) return false;
     if (blockedByTrustPrompt) return false;
     // After dismissing a trust prompt, reset backoff so we re-check quickly
     // instead of sleeping 2s/4s/8s while the worker is starting up.
@@ -3310,6 +3338,18 @@ export async function waitForWorkerReadyAsync(
   }
 
   return false;
+}
+
+export async function waitForWorkerReadyAsync(
+  sessionName: string,
+  workerIndex: number,
+  timeoutMs: number = 30_000,
+  workerPaneId?: string,
+  expectedPanePid?: number,
+  expectedTeamOwnerId?: string,
+  hudPaneId?: string,
+): Promise<boolean> {
+  return waitForWorkerReadyDetailedAsync(sessionName, workerIndex, timeoutMs, workerPaneId, expectedPanePid, expectedTeamOwnerId, hudPaneId);
 }
 
 /**


### PR DESCRIPTION
## Summary
- preserve the final attached-tmux Codex argv after MCP overrides
- detect the exact MDM `Never`/bypass rejection marker at direct-safety and readiness capture boundaries
- fail startup once with `codex_bypass_mdm_incompatible`, without retry or policy substitution
- preserve supported explicit policy, execution-role behavior, and rollback task-state semantics

## Independent reproduction
Gate 0 on pristine current `dev` (`d73f0753b7e5d019cb7d84628e2f4de0f7b17dd2`) confirmed all predicates with a non-tracked fake-tmux/fake-Codex harness:
1. actual generated worker argv contained exactly one canonical bypass flag;
2. fake Codex originated `MDM_POLICY_REJECTED: approval_policy=never forbids --dangerously-bypass-approvals-and-sandbox`;
3. two complete runtime-action-mediated prompt/capture cycles occurred.

Evidence hashes:
- harness: `38e224066d5d04bb4d0a5b0e51d33798100285c24e604358c089545fe18c194e`
- ordered log: `648f4e9eb566771dbac34aeec6b74f7c789cff2bbcc825f7af94e53a622e8853`
- argv: `6243fbb88c5427f846dff75484a3f5bda04f2c587803a6e0b2a81150fcbf23fe`

## Verification
- `npm run build`
- `npm run check:no-unused`
- `npm run lint`
- focused tmux-session/runtime suites: 282/282 passing
- `npm run coverage:team-critical:compiled`: 87.58% statements, 80.75% branches
- `npm run test:ci:compiled` (one unrelated package-bin timeout passed in isolated rerun)
- `npm test` (one unrelated MCP lifecycle race passed in isolated rerun)
- hostile adversarial QA: passed, report SHA-256 `2ad668f18c45372f6eb83c9070d9630f328405423fe5f7d5902de61c465a7aaa`
- final architecture review: CLEAR / APPROVE
- commit signature verified: `a009f3fa60255dda87da646bde110b8813b8b24c`

Closes #3220

Signed-off-by: Yeachan-Heo <hurrc04@gmail.com>