### PR TITLE
test: make Windows durability sync deterministic

### DIFF
--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -1254,7 +1254,10 @@ describe('session pointer transaction', () => {
       const syncedCwd = join(cwd, 'synced');
       await mkdir(syncedCwd);
       warningCwd = syncedCwd;
-      await writeSessionStart(syncedCwd, 'sess-synced-start', { platform: 'win32' });
+      await writeSessionStart(syncedCwd, 'sess-synced-start', {
+        platform: 'win32',
+        regularFileSync: async () => {},
+      });
       assert.deepEqual(warnings, []);
       const failedCwd = join(cwd, 'failed');
       await mkdir(failedCwd);


### PR DESCRIPTION
## Summary

On native Windows, the "synced" branch of the session durability warning test still calls the host `FileHandle.sync()`. Node reports `EPERM` for that regular-file sync on this environment, so the test observes a degraded-durability warning even though this branch intends to model a successful sync.

## Changes

- Inject the existing successful `regularFileSync` test seam for the synced session.
- Keep production behavior unchanged.

## Validation

- [x] `npm run build`
- [x] Targeted session durability warning test passes on Windows
- [x] `dist/utils/__tests__/file-durability.test.js` passes (8/8)
- [x] `npx biome lint src/hooks/__tests__/session.test.ts`
- [ ] `npm test` (not run; the full session test file currently has other unrelated native-Windows failures)
- [ ] `omx doctor` (not applicable; no setup/config behavior change)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed: not needed for a test-only determinism fix
- [x] Backward-compatibility impact considered: no runtime change

## Related

Follow-up to #3191.