### PR TITLE
Prevent live session pointers from native-start replacement

### DIFF
--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -62,6 +62,11 @@ function codedError(code: string): Error & { code: string } {
   return Object.assign(new Error(code), { code });
 }
 
+function isOwnerConflict(error: unknown): boolean {
+  return isSessionPointerLaunchAbort(error)
+    && (error as { code?: string }).code === 'session_pointer_owner_conflict';
+}
+
 async function withPointerDependencies(
   overrides: Parameters<typeof __setSessionPointerTransactionDependenciesForTests>[0],
   run: () => Promise<void>,
@@ -388,37 +393,24 @@ describe('session lifecycle manager', () => {
     }
   });
 
-  it('starts a fresh native session while retaining the owner OMX launch session when native SessionStart changes', async () => {
+  it('rejects replacing a live native session pointer with another native SessionStart', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-fresh-'));
     try {
       await writeSessionStart(cwd, 'omx-old-session', {
         nativeSessionId: 'codex-native-old',
       });
 
-      const reconciled = await reconcileNativeSessionStart(cwd, 'codex-native-new', {
-        pid: 54321,
-        platform: 'win32',
-      });
-
-      assert.equal(reconciled.session_id, 'codex-native-new');
-      assert.equal(reconciled.native_session_id, 'codex-native-new');
-      assert.equal(reconciled.previous_native_session_id, 'codex-native-old');
-      assert.equal(reconciled.owner_omx_session_id, 'omx-old-session');
-      assert.match(reconciled.native_session_switched_at ?? '', /^\d{4}-\d{2}-\d{2}T/);
-      assert.equal(reconciled.pid, 54321);
+      await assert.rejects(
+        reconcileNativeSessionStart(cwd, 'codex-native-new', {
+          pid: 54321,
+          platform: 'win32',
+        }),
+        isOwnerConflict,
+      );
 
       const persisted = await readSessionState(cwd);
-      assert.equal(persisted?.session_id, 'codex-native-new');
-      assert.equal(persisted?.native_session_id, 'codex-native-new');
-      assert.equal(persisted?.previous_native_session_id, 'codex-native-old');
-      assert.equal(persisted?.owner_omx_session_id, 'omx-old-session');
-
-      const dailyLogPath = join(cwd, '.omx', 'logs', `omx-${todayIsoDate()}.jsonl`);
-      const dailyLog = await readFile(dailyLogPath, 'utf-8');
-      assert.match(dailyLog, /"event":"native_session_replaced"/);
-      assert.match(dailyLog, /"event":"session_start"/);
-      assert.match(dailyLog, /"previous_native_session_id":"codex-native-old"/);
-      assert.match(dailyLog, /"native_session_id":"codex-native-new"/);
+      assert.equal(persisted?.session_id, 'omx-old-session');
+      assert.equal(persisted?.native_session_id, 'codex-native-old');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -460,7 +452,7 @@ describe('session lifecycle manager', () => {
     }
   });
 
-  it('lets an owner OMX launch session end the fresh native session it spawned', async () => {
+  it('lets an owner OMX launch session end after rejecting an unrelated native replacement', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-owner-end-'));
     let binding: LaunchSessionBinding | undefined;
     try {
@@ -470,10 +462,13 @@ describe('session lifecycle manager', () => {
       assert.equal(established.kind, 'committed-released');
       if (established.kind !== 'committed-released') return;
       binding = established.binding;
-      await reconcileNativeSessionStart(cwd, 'codex-native-new', {
-        pid: process.pid,
-        platform: 'win32',
-      });
+      await assert.rejects(
+        reconcileNativeSessionStart(cwd, 'codex-native-new', {
+          pid: process.pid,
+          platform: 'win32',
+        }),
+        isOwnerConflict,
+      );
 
       await finalizeBoundOnce(binding, 'test');
 
@@ -487,15 +482,15 @@ describe('session lifecycle manager', () => {
         active_session_id?: string;
       };
       assert.equal(historyEntry.session_id, 'omx-owner-session');
-      assert.equal(historyEntry.native_session_id, 'codex-native-new');
-      assert.equal(historyEntry.active_session_id, 'codex-native-new');
+      assert.equal(historyEntry.native_session_id, 'codex-native-old');
+      assert.equal(historyEntry.active_session_id, undefined);
     } finally {
       if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
-  it('preserves owner OMX metadata when reconciling the same fresh native session', async () => {
+  it('preserves canonical session metadata when reconciling the same native session', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-owner-reconcile-'));
     let binding: LaunchSessionBinding | undefined;
     try {
@@ -505,20 +500,16 @@ describe('session lifecycle manager', () => {
       assert.equal(established.kind, 'committed-released');
       if (established.kind !== 'committed-released') return;
       binding = established.binding;
-      await reconcileNativeSessionStart(cwd, 'codex-native-new', {
+
+      const reconciled = await reconcileNativeSessionStart(cwd, 'codex-native-old', {
         pid: process.pid,
         platform: 'win32',
       });
 
-      const reconciled = await reconcileNativeSessionStart(cwd, 'codex-native-new', {
-        pid: process.pid,
-        platform: 'win32',
-      });
-
-      assert.equal(reconciled.session_id, 'codex-native-new');
-      assert.equal(reconciled.native_session_id, 'codex-native-new');
-      assert.equal(reconciled.previous_native_session_id, 'codex-native-old');
-      assert.equal(reconciled.owner_omx_session_id, 'omx-owner-session');
+      assert.equal(reconciled.session_id, 'omx-owner-session');
+      assert.equal(reconciled.native_session_id, 'codex-native-old');
+      assert.equal(reconciled.previous_native_session_id, undefined);
+      assert.equal(reconciled.owner_omx_session_id, undefined);
       assert.equal(reconciled.pid, process.pid);
 
       await finalizeBoundOnce(binding, 'test');
@@ -529,7 +520,7 @@ describe('session lifecycle manager', () => {
     }
   });
 
-  it('carries the owner OMX launch session across chained native SessionStart replacements', async () => {
+  it('rejects chained native SessionStart replacements and preserves the original pointer', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-owner-chain-'));
     let binding: LaunchSessionBinding | undefined;
     try {
@@ -539,27 +530,18 @@ describe('session lifecycle manager', () => {
       assert.equal(established.kind, 'committed-released');
       if (established.kind !== 'committed-released') return;
       binding = established.binding;
-      await reconcileNativeSessionStart(cwd, 'codex-native-b', {
+      await assert.rejects(reconcileNativeSessionStart(cwd, 'codex-native-b', {
         pid: process.pid,
         platform: 'win32',
-      });
-
-      const reconciled = await reconcileNativeSessionStart(cwd, 'codex-native-c', {
+      }), isOwnerConflict);
+      await assert.rejects(reconcileNativeSessionStart(cwd, 'codex-native-c', {
         pid: process.pid,
         platform: 'win32',
-      });
+      }), isOwnerConflict);
 
-      assert.equal(reconciled.session_id, 'codex-native-c');
-      assert.equal(reconciled.native_session_id, 'codex-native-c');
-      assert.equal(reconciled.previous_native_session_id, 'codex-native-b');
-      assert.equal(reconciled.owner_omx_session_id, 'omx-owner-session');
-
-      const dailyLogPath = join(cwd, '.omx', 'logs', `omx-${todayIsoDate()}.jsonl`);
-      const dailyLog = await readFile(dailyLogPath, 'utf-8');
-      assert.match(dailyLog, /"session_id":"omx-owner-session"/);
-      assert.match(dailyLog, /"active_session_id":"codex-native-b"/);
-      assert.match(dailyLog, /"previous_native_session_id":"codex-native-b"/);
-      assert.match(dailyLog, /"replaced_by_native_session_id":"codex-native-c"/);
+      const persisted = await readSessionState(cwd);
+      assert.equal(persisted?.session_id, 'omx-owner-session');
+      assert.equal(persisted?.native_session_id, 'codex-native-a');
 
       await finalizeBoundOnce(binding, 'test');
       assert.equal(await readSessionState(cwd), null);
@@ -571,37 +553,33 @@ describe('session lifecycle manager', () => {
         active_session_id?: string;
       };
       assert.equal(historyEntry.session_id, 'omx-owner-session');
-      assert.equal(historyEntry.native_session_id, 'codex-native-c');
-      assert.equal(historyEntry.active_session_id, 'codex-native-c');
+      assert.equal(historyEntry.native_session_id, 'codex-native-a');
+      assert.equal(historyEntry.active_session_id, undefined);
     } finally {
       if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
-  it('retains wrapper lineage when a wrapper-owned native session is replaced', async () => {
+  it('rejects replacing a live wrapper-owned native session', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-non-omx-fresh-'));
     try {
       await writeSessionStart(cwd, 'codex-native-old', {
         nativeSessionId: 'codex-native-old',
       });
 
-      const reconciled = await reconcileNativeSessionStart(cwd, 'codex-native-new', {
-        pid: 54321,
-        platform: 'win32',
-      });
-
-      assert.equal(reconciled.session_id, 'codex-native-new');
-      assert.equal(reconciled.native_session_id, 'codex-native-new');
-      assert.equal(reconciled.previous_native_session_id, 'codex-native-old');
-      assert.equal(reconciled.owner_omx_session_id, 'codex-native-old');
-      assert.equal(reconciled.pid, 54321);
+      await assert.rejects(
+        reconcileNativeSessionStart(cwd, 'codex-native-new', {
+          pid: 54321,
+          platform: 'win32',
+        }),
+        isOwnerConflict,
+      );
 
       const persisted = await readSessionState(cwd);
-      assert.equal(persisted?.session_id, 'codex-native-new');
-      assert.equal(persisted?.native_session_id, 'codex-native-new');
-      assert.equal(persisted?.previous_native_session_id, 'codex-native-old');
-      assert.equal(persisted?.owner_omx_session_id, 'codex-native-old');
+      assert.equal(persisted?.session_id, 'codex-native-old');
+      assert.equal(persisted?.native_session_id, 'codex-native-old');
+      assert.equal(persisted?.previous_native_session_id, undefined);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -1515,12 +1493,17 @@ describe('session pointer transaction', () => {
         assert.equal(bound.session_id, 'native-first');
         assert.equal(bound.owner_omx_session_id, 'omx-owner');
 
-        const replacement = await reconcileNativeSessionStart(cwd, 'native-second', {
-          platform: 'win32',
-          ownerAliasVerified: true,
-        });
-        assert.equal(replacement.session_id, 'native-second');
-        assert.equal(replacement.owner_omx_session_id, 'omx-owner');
+        await assert.rejects(
+          reconcileNativeSessionStart(cwd, 'native-second', {
+            platform: 'win32',
+            ownerAliasVerified: true,
+          }),
+          isOwnerConflict,
+        );
+
+        const persisted = await readSessionState(cwd);
+        assert.equal(persisted?.session_id, 'native-first');
+        assert.equal(persisted?.owner_omx_session_id, 'omx-owner');
       });
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -2129,7 +2112,7 @@ describe('bound launch authority', () => {
     }
   });
 
-  it('preserves native lineage and tmux metadata across an authorized native-ID replacement', async () => {
+  it('preserves native lineage and tmux metadata when rejecting a live native-ID replacement', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-lineage-metadata-'));
     let binding: LaunchSessionBinding | undefined;
     try {
@@ -2142,14 +2125,14 @@ describe('bound launch authority', () => {
       if (established.kind !== 'committed-released') return;
       binding = established.binding;
 
-      const reconciled = await reconcileNativeSessionStart(cwd, 'native-after', { pid: process.pid });
-      assert.equal(reconciled.session_id, 'native-after');
-      assert.equal(reconciled.native_session_id, 'native-after');
-      assert.equal(reconciled.owner_omx_session_id, binding.canonicalSessionId);
-      assert.equal(reconciled.previous_native_session_id, 'native-before');
-      assert.equal(reconciled.launch_lineage_token, binding.launchLineageToken);
-      assert.equal(reconciled.tmux_session_name, 'omx-native-lineage');
-      assert.equal(reconciled.tmux_pane_id, '%88');
+      await assert.rejects(reconcileNativeSessionStart(cwd, 'native-after', { pid: process.pid }), isOwnerConflict);
+      const persisted = await readSessionState(cwd);
+      assert.equal(persisted?.session_id, binding.canonicalSessionId);
+      assert.equal(persisted?.native_session_id, 'native-before');
+      assert.equal(persisted?.previous_native_session_id, undefined);
+      assert.equal(persisted?.launch_lineage_token, binding.launchLineageToken);
+      assert.equal(persisted?.tmux_session_name, 'omx-native-lineage');
+      assert.equal(persisted?.tmux_pane_id, '%88');
     } finally {
       if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
       await rm(cwd, { recursive: true, force: true });

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -2152,15 +2152,11 @@ export function finalizeBoundOnce(
   return finalization;
 }
 
-interface NativeReconcileTransition {
-  state: SessionState;
-  replacementLog?: Record<string, unknown>;
-}
 
 function reconcileNativeTransition(
   nativeSessionId: string,
   options: SessionStartOptions,
-): (pointer: SessionPointerReadResult, context: SessionPointerContext) => NativeReconcileTransition {
+): (pointer: SessionPointerReadResult, context: SessionPointerContext) => SessionState {
   return (pointer, context) => {
     if (pointer.status !== 'absent' && pointer.status !== 'stale-dead' && pointer.status !== 'usable') {
       throw unusablePointerAbort(context, nativeSessionId, pointer);
@@ -2170,51 +2166,22 @@ function reconcileNativeTransition(
     const platform = options.platform ?? process.platform;
     const linuxIdentity = sessionIdentityFor(pid, platform);
     const existing = pointer.status === 'usable' ? pointer.state : undefined;
-    const nowIso = new Date().toISOString();
 
     if (!existing) {
       const ownerCandidate = verifiedOwnerCandidate(context, options);
       const ownerOmxSessionId = ownerCandidate;
-      return {
-        state: createSessionState(context.cwd, context.baseStateDir, nativeSessionId, pid, platform, linuxIdentity, {
-          nativeSessionId,
-          ...(ownerOmxSessionId ? { ownerOmxSessionId } : {}),
-        }),
-      };
+      return createSessionState(context.cwd, context.baseStateDir, nativeSessionId, pid, platform, linuxIdentity, {
+        nativeSessionId,
+        ...(ownerOmxSessionId ? { ownerOmxSessionId } : {}),
+      });
     }
 
     const existingNativeSessionId = normalizeSessionId(existing.native_session_id);
     if (existingNativeSessionId && existingNativeSessionId !== nativeSessionId) {
-      const ownerOmxSessionId = normalizeSessionId(existing.owner_omx_session_id)
-        ?? (isValidToken(existing.launch_lineage_token) ? existing.session_id : undefined);
-      return {
-        state: preserveExistingLaunchLineageToken(existing, createSessionState(context.cwd, context.baseStateDir, nativeSessionId, pid, platform, linuxIdentity, {
-          nativeSessionId,
-          startedAt: existing.started_at,
-          ...(ownerOmxSessionId ? {
-            previousNativeSessionId: existingNativeSessionId,
-            nativeSessionSwitchedAt: nowIso,
-            ownerOmxSessionId,
-          } : {}),
-          tmuxSessionName: existing.tmux_session_name,
-          tmuxPaneId: existing.tmux_pane_id,
-          launchLineageToken: isValidToken(existing.launch_lineage_token)
-            ? existing.launch_lineage_token
-            : undefined,
-        })),
-        ...(ownerOmxSessionId ? {
-          replacementLog: {
-            event: 'native_session_replaced',
-            session_id: ownerOmxSessionId,
-            ...(existing.session_id !== ownerOmxSessionId ? { active_session_id: existing.session_id } : {}),
-            previous_native_session_id: existingNativeSessionId,
-            replaced_by_native_session_id: nativeSessionId,
-            pid,
-            timestamp: nowIso,
-          },
-        } : {}),
-      };
+      throw ownerConflictAbort(context, nativeSessionId, existing);
     }
+
+    const nowIso = new Date().toISOString();
 
     const ownerCandidate = verifiedOwnerCandidate(context, options);
     let ownerOmxSessionId: string | undefined;
@@ -2228,28 +2195,26 @@ function reconcileNativeTransition(
       throw ownerConflictAbort(context, nativeSessionId, existing, error);
     }
 
-    return {
-      state: preserveExistingLaunchLineageToken(existing, createSessionState(context.cwd, context.baseStateDir, existing.session_id, pid, platform, linuxIdentity, {
-        nowIso,
-        nativeSessionId,
-        previousNativeSessionId: existing.previous_native_session_id,
-        nativeSessionSwitchedAt: existing.native_session_switched_at,
-        ...(ownerOmxSessionId ? { ownerOmxSessionId } : {}),
-        startedAt: existing.started_at,
-        tmuxSessionName: existing.tmux_session_name,
-        tmuxPaneId: existing.tmux_pane_id,
-        launchLineageToken: isValidToken(existing.launch_lineage_token)
-          ? existing.launch_lineage_token
-          : undefined,
-      })),
-    };
+    return preserveExistingLaunchLineageToken(existing, createSessionState(context.cwd, context.baseStateDir, existing.session_id, pid, platform, linuxIdentity, {
+      nowIso,
+      nativeSessionId,
+      previousNativeSessionId: existing.previous_native_session_id,
+      nativeSessionSwitchedAt: existing.native_session_switched_at,
+      ...(ownerOmxSessionId ? { ownerOmxSessionId } : {}),
+      startedAt: existing.started_at,
+      tmuxSessionName: existing.tmux_session_name,
+      tmuxPaneId: existing.tmux_pane_id,
+      launchLineageToken: isValidToken(existing.launch_lineage_token)
+        ? existing.launch_lineage_token
+        : undefined,
+    }));
   };
 }
 
 /**
- * Reconcile a native SessionStart without borrowing another root's pointer.
- * A different native ID retains the existing OMX owner chain, but never binds a
- * new owner alias during that replacement transition.
+ * Reconcile native SessionStart only when the selected pointer is absent, stale,
+ * or already belongs to that native session. A different live native ID is
+ * authoritative owner evidence and must never be replaced.
  */
 export async function reconcileNativeSessionStart(
   cwd: string,
@@ -2263,19 +2228,16 @@ export async function reconcileNativeSessionStart(
     options,
     NATIVE_POINTER_TIMEOUT_MS,
     reconcileNativeTransition(normalizedNativeSessionId ?? nativeSessionId, options),
-    (transition) => transition.state,
+    (state) => state,
   );
-  if (result.value.replacementLog) {
-    await appendToLogAtContext(result.context, result.value.replacementLog).catch(() => {});
-  }
   await appendToLogAtContext(result.context, {
-    event: result.value.replacementLog ? 'session_start' : 'session_start_reconciled',
-    session_id: result.value.state.session_id,
+    event: 'session_start_reconciled',
+    session_id: result.value.session_id,
     native_session_id: normalizedNativeSessionId ?? nativeSessionId,
-    pid: result.value.state.pid,
-    timestamp: result.value.state.native_session_switched_at ?? new Date().toISOString(),
+    pid: result.value.pid,
+    timestamp: new Date().toISOString(),
   }).catch(() => {});
-  return result.value.state;
+  return result.value;
 }
 
 function historyDirectory(context: SessionPointerContext): string {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4385,16 +4385,19 @@ PY`,
       });
       process.env.OMX_SESSION_ID = replacementCandidate;
       await setOwnerEvidence(replacementCandidate);
-      await dispatchCodexNativeHook(
+      const replacementStart = await dispatchCodexNativeHook(
         { hook_event_name: "SessionStart", cwd: replacementCwd, session_id: "native-after-new-3138" },
         { cwd: replacementCwd, sessionOwnerPid: process.pid },
       );
+      assert.equal(replacementStart.outputJson, null);
       const replacementPointer = JSON.parse(await readFile(join(replacementStateDir, "session.json"), "utf-8")) as {
         session_id?: string;
+        native_session_id?: string;
         owner_omx_session_id?: string;
       };
-      assert.equal(replacementPointer.session_id, "native-after-new-3138");
-      assert.equal(replacementPointer.owner_omx_session_id, replacementOwner);
+      assert.equal(replacementPointer.session_id, replacementOwner);
+      assert.equal(replacementPointer.native_session_id, "native-before-new-3138");
+      assert.equal(replacementPointer.owner_omx_session_id, undefined);
       assert.notEqual(replacementPointer.owner_omx_session_id, replacementCandidate);
 
       const nativeOnlyCwd = join(root, "native-only");
@@ -5584,7 +5587,7 @@ PY`,
     }
   });
 
-  it("prefers the OMX owner session id when a native new session revives HUD", async () => {
+  it("preserves the OMX owner HUD session when an unrelated native SessionStart is rejected", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-hud-owner-session-revive-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -5614,17 +5617,17 @@ PY`,
         previous_native_session_id?: string;
         owner_omx_session_id?: string;
       };
-      assert.equal(sessionState.session_id, nativeSessionId);
-      assert.equal(sessionState.native_session_id, nativeSessionId);
-      assert.equal(sessionState.previous_native_session_id, oldNativeSessionId);
-      assert.equal(sessionState.owner_omx_session_id, ownerSessionId);
+      assert.equal(sessionState.session_id, ownerSessionId);
+      assert.equal(sessionState.native_session_id, oldNativeSessionId);
+      assert.equal(sessionState.previous_native_session_id, undefined);
+      assert.equal(sessionState.owner_omx_session_id, undefined);
 
       let reconcileCall: { cwd: string; sessionId?: string; sessionIds?: string[] } | null = null;
       const promptResult = await dispatchCodexNativeHook(
         {
           hook_event_name: "UserPromptSubmit",
           cwd,
-          session_id: nativeSessionId,
+          session_id: ownerSessionId,
           thread_id: "thread-hud-owner",
           turn_id: "turn-hud-owner",
           prompt: "$ralplan fix native new hud owner handoff",
@@ -5642,7 +5645,7 @@ PY`,
       assert.deepEqual(reconcileCall, {
         cwd,
         sessionId: ownerSessionId,
-        sessionIds: [ownerSessionId, nativeSessionId],
+        sessionIds: [ownerSessionId, oldNativeSessionId],
       });
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -5968,6 +5971,7 @@ PY`,
       await mkdir(join(stateDir, "sessions", priorSessionId), { recursive: true });
       await writeSessionStart(cwd, priorSessionId, {
         nativeSessionId: "codex-native-old",
+        pid: 999_999_999,
       });
       await writeJson(join(stateDir, "sessions", priorSessionId, "ralph-state.json"), {
         active: true,
@@ -32985,7 +32989,9 @@ PY`,
 
   it("blocks non-shell direct writes in Main-root conductor states", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-conductor-bash-mutations-"));
+    const previousPath = process.env.PATH;
     try {
+      process.env.PATH = `${dirname(process.execPath)}:/usr/bin:/bin`;
       const stateDir = join(cwd, ".omx", "state");
       const sessionId = "sess-conductor-bash-mutations";
       await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
@@ -33076,6 +33082,8 @@ PY`,
         assert.equal(result.outputJson, null, command);
       }
     } finally {
+      if (typeof previousPath === "string") process.env.PATH = previousPath;
+      else delete process.env.PATH;
       await rm(cwd, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary
- Reject native `SessionStart` reconciliation when a live pointer already belongs to a different native session.
- Preserve same-native metadata refresh and stale/dead pointer recovery behavior.
- Update session and native-hook regressions, including PATH isolation for conductor direct-write tests.

## Why
A nested or ephemeral native Codex session could publish over a live parent pointer. Stop authorization then sees stale or unrelated pointer evidence and fails closed.

## Test Plan
- [x] `npm run build`
- [x] `npm run check:no-unused`
- [x] `node dist/scripts/run-test-files.js dist/hooks/__tests__/session.test.js`
- [x] `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js`
- [x] `git diff --check`

## Not Tested
- Installed OMX live smoke after packaging.