### PR TITLE
feat(adapt): opt-in Herdr lifecycle/status bridge (#3241, Phase 1)

### DIFF
--- a/docs/adapt.md
+++ b/docs/adapt.md
@@ -20,6 +20,7 @@ Current targets:
 
 - `openclaw`
 - `hermes`
+- `herdr`
 
 Hermes follow-on behavior in this worktree:
 
@@ -47,3 +48,12 @@ Foundation constraints:
 - command-gateway readiness still requires `OMX_OPENCLAW_COMMAND=1`
 
 Hermes-specific evidence discovery uses `HERMES_HOME` plus an overrideable Hermes source root (`OMX_ADAPT_HERMES_ROOT`) so OMX can inspect an external runtime without vendoring or mutating it.
+
+Herdr follow-on behavior (issue #3241, Phase 1):
+
+- `probe`/`status`/`envelope`/`doctor` detect a containing Herdr pane via `HERDR_ENV=1`, `HERDR_PANE_ID`, and `HERDR_SOCKET_PATH`
+- the opt-in lifecycle/status bridge reports OMX lifecycle and Team state as Herdr semantic states (`working`/`blocked`/`idle`/`unknown`) using the documented `pane.report_agent` / `pane.release_agent` surfaces
+- reports use a single monotonically increasing per-source `seq` so stale reports cannot win, and authority is released on terminal states
+- the bridge is best-effort and non-blocking: a Herdr socket/CLI failure never fails the OMX run, and there is no behavior change outside a Herdr pane
+
+See [`docs/herdr-bridge.md`](./herdr-bridge.md) for the full Phase 1 design and the Phase 2 (runtime backend) boundary.

--- a/docs/herdr-bridge.md
+++ b/docs/herdr-bridge.md
@@ -21,15 +21,20 @@ pluggable multiplexer replacing OMX's tmux runtime) is out of scope.
 
 ## How it is wired (production path)
 
-The bridge is invoked from the single canonical hook seam,
-`dispatchHookEventRuntime` (`src/hooks/extensibility/runtime.ts`) — the same seam
-that already performs team-state side effects. Every native/derived lifecycle
-event (`session-start`, `run.heartbeat`, `blocked`, `needs-input`,
+The bridge is invoked from the single canonical hook seam, `dispatchHookEvent`
+(`src/hooks/extensibility/dispatcher.ts`) — the function **every** dispatch path
+funnels through (native Codex hooks via `dispatchHookEventRuntime`, team
+transitions via `src/team/runtime.ts` and `team-dispatch.ts`,
+`turn-complete`/`session-idle` via `notify-hook.ts`, derived events via
+`hook-derived-watcher.ts`, and the CLI hook path). Every native/derived/team
+lifecycle event (`session-start`, `run.heartbeat`, `blocked`, `needs-input`,
 `run.blocked_on_user`, `turn-complete`, `finished`, `failed`, `stop`,
-`session-end`, team transitions, …) flows through
-`reportHerdrLifecycleEvent` (`src/adapt/herdr/wiring.ts`), which maps it to a
-Herdr semantic state and reports it. On `session-start` it first reconciles any
-stale authority left by a crashed prior process.
+`session-end`, team transitions, …) reaches `reportHerdrLifecycleEvent`
+(`src/adapt/herdr/wiring.ts`), which maps it to a Herdr semantic state and
+reports it. The call is gated on a cheap `HERDR_ENV` check so there is zero
+import cost outside a Herdr pane, runs regardless of plugin enablement, and is
+fully best-effort. On `session-start` it first reconciles any stale authority
+left by a crashed prior process.
 
 Team transitions reach the same seam because `src/team/runtime.ts` and
 `src/hooks/notify-hook/team-dispatch.ts` emit their events through the dispatcher;

--- a/docs/herdr-bridge.md
+++ b/docs/herdr-bridge.md
@@ -1,0 +1,102 @@
+# Herdr lifecycle/status bridge (issue #3241)
+
+OMX can report its lifecycle and Team state to a containing [Herdr](https://github.com/ogulcancelik/herdr)
+pane so the Herdr sidebar reflects `working` / `blocked` / `idle` transitions
+authored by OMX, instead of relying on Herdr's screen-manifest inference. This
+is the **Phase 1** status bridge. The **Phase 2** runtime backend (Herdr as a
+pluggable multiplexer replacing OMX's tmux runtime) is intentionally out of
+scope for this work.
+
+## Design goals
+
+- **Opt-in.** No behavior change outside a detected Herdr pane. The bridge is
+  inert unless OMX runs inside Herdr.
+- **Best-effort and non-blocking.** A Herdr socket/CLI failure never fails an
+  OMX run. No Herdr dependency is required.
+- **OMX owns the truth.** OMX is the authoritative source of its lifecycle and
+  Team state; Herdr is the rendering/notification consumer.
+- **Ordered.** Reports carry a monotonically increasing per-source `seq` so late
+  hook processes cannot overwrite newer state.
+- **Clean handoff.** On terminal states / shutdown, OMX releases `omx:runtime`
+  authority so Herdr returns to its normal Codex screen detection.
+
+## Environment detection
+
+Herdr exports the following into managed pane processes; OMX reads them:
+
+| Variable | Meaning |
+| --- | --- |
+| `HERDR_ENV=1` | running inside a Herdr-managed pane |
+| `HERDR_PANE_ID` | the pane to report against (e.g. `w1:p1`) |
+| `HERDR_SOCKET_PATH` | raw local socket for the JSON API (preferred transport) |
+| `HERDR_BIN_PATH` | Herdr binary for CLI fallback |
+
+The bridge is enabled only when `HERDR_ENV=1` **and** `HERDR_PANE_ID` are present.
+
+## State mapping
+
+OMX hook lifecycle events map to Herdr semantic states:
+
+| OMX event(s) | Herdr state |
+| --- | --- |
+| `session-start`, `run.heartbeat`, `worker.assigned`, `worker.recovered`, `test-started`, `pre-tool-use`, `post-tool-use` | `working` |
+| `blocked`, `run.blocked_on_user`, `run.blocked_on_system`, `needs-input`, `handoff-needed` | `blocked` |
+| `turn-complete`, `finished`, `failed`, `stop`, `session-end`, `session-idle` | `idle` |
+| anything unmapped / reconciliation-uncertain | `unknown` |
+
+Events `finished`, `failed`, `stop`, and `session-end` are **terminal**: after
+reporting `idle`, OMX releases authority.
+
+### Team rollup
+
+For Team mode the bridge uses an authoritative rollup rather than pane-output
+inference (precedence):
+
+1. `blocked` if the leader is blocked on user input, or an authoritative
+   worker/task is blocked on user action;
+2. otherwise `working` while any worker/task is active;
+3. otherwise `idle` when the run is terminal.
+
+A worker blocked on the system alone does not escalate the whole pane to
+`blocked`.
+
+## Transports
+
+Both transports are injectable (for testing) and shell-free:
+
+- **CLI** — `herdr pane report-agent <pane> --source omx:runtime --agent codex
+  --state <state> --seq <n>` and `herdr pane release-agent <pane> --source
+  omx:runtime --seq <n>`, executed via `execFile` (argv array, never a shell),
+  so pane ids / messages cannot inject shell syntax.
+- **Socket** — newline-delimited JSON over the local Herdr socket, using the
+  documented dot-notation methods `pane.report_agent` and `pane.release_agent`.
+
+The socket transport is preferred when `HERDR_SOCKET_PATH` is exported.
+
+## Protocol verification
+
+The `seq` and authority-release surfaces were verified against the official
+Herdr source at commit `1f2487554b9fd42118f9e99ee06eb558bbb2391f`:
+
+- `PaneReportAgentParams { seq: Option<u64> }`
+- CLI `herdr pane report-agent ... [--seq N]` and `herdr pane release-agent ... [--seq N]`
+- the server forwards `seq` into `HookStateReported`
+
+and against the published protocol docs (herdr.dev/docs/socket-api,
+/docs/agents), which document `pane.report_agent`, `pane.release_agent`,
+`pane.clear_agent_authority`, and `seq`-based ordering.
+
+## Code layout
+
+- `src/adapt/herdr/semantic.ts` — pure event→state mapping and Team rollup.
+- `src/adapt/herdr/transport.ts` — env detection + CLI/socket transports.
+- `src/adapt/herdr/bridge.ts` — `HerdrBridge`: opt-in gate, monotonic seq,
+  terminal release, failure isolation.
+- `src/adapt/herdr.ts` — `omx adapt herdr` target metadata (probe/status/
+  envelope/doctor/init).
+
+## Phase 2 (out of scope)
+
+Using Herdr as a pluggable multiplexer/runtime backend for Team panes/workspaces
+(instead of nested tmux) is deferred. The status bridge delivers value through
+the stable Herdr API without replacing OMX's tmux runtime.

--- a/docs/herdr-bridge.md
+++ b/docs/herdr-bridge.md
@@ -1,102 +1,151 @@
 # Herdr lifecycle/status bridge (issue #3241)
 
-OMX can report its lifecycle and Team state to a containing [Herdr](https://github.com/ogulcancelik/herdr)
+OMX reports its lifecycle and Team state to a containing [Herdr](https://github.com/ogulcancelik/herdr)
 pane so the Herdr sidebar reflects `working` / `blocked` / `idle` transitions
 authored by OMX, instead of relying on Herdr's screen-manifest inference. This
 is the **Phase 1** status bridge. The **Phase 2** runtime backend (Herdr as a
-pluggable multiplexer replacing OMX's tmux runtime) is intentionally out of
-scope for this work.
+pluggable multiplexer replacing OMX's tmux runtime) is out of scope.
 
 ## Design goals
 
-- **Opt-in.** No behavior change outside a detected Herdr pane. The bridge is
-  inert unless OMX runs inside Herdr.
+- **Opt-in.** No behavior change outside a detected Herdr pane; inert unless OMX
+  runs inside Herdr.
 - **Best-effort and non-blocking.** A Herdr socket/CLI failure never fails an
   OMX run. No Herdr dependency is required.
 - **OMX owns the truth.** OMX is the authoritative source of its lifecycle and
   Team state; Herdr is the rendering/notification consumer.
-- **Ordered.** Reports carry a monotonically increasing per-source `seq` so late
-  hook processes cannot overwrite newer state.
-- **Clean handoff.** On terminal states / shutdown, OMX releases `omx:runtime`
-  authority so Herdr returns to its normal Codex screen detection.
+- **Ordered across processes.** Reports carry a durable per-source monotonic
+  `seq` that survives concurrent short-lived hook processes and restarts.
+- **Clean handoff.** On whole-session shutdown, OMX releases `omx:runtime`
+  authority; a crash is reconciled on the next session-start.
+
+## How it is wired (production path)
+
+The bridge is invoked from the single canonical hook seam,
+`dispatchHookEventRuntime` (`src/hooks/extensibility/runtime.ts`) — the same seam
+that already performs team-state side effects. Every native/derived lifecycle
+event (`session-start`, `run.heartbeat`, `blocked`, `needs-input`,
+`run.blocked_on_user`, `turn-complete`, `finished`, `failed`, `stop`,
+`session-end`, team transitions, …) flows through
+`reportHerdrLifecycleEvent` (`src/adapt/herdr/wiring.ts`), which maps it to a
+Herdr semantic state and reports it. On `session-start` it first reconciles any
+stale authority left by a crashed prior process.
+
+Team transitions reach the same seam because `src/team/runtime.ts` and
+`src/hooks/notify-hook/team-dispatch.ts` emit their events through the dispatcher;
+authoritative Team rollup is available via `mapTeamStateToRollup`
+(`src/adapt/herdr/team-map.ts`), which consumes the real `WorkerStatus.state`
+shape and the leader-attention flag from `src/team/state.ts`.
 
 ## Environment detection
 
-Herdr exports the following into managed pane processes; OMX reads them:
+Herdr exports these into managed pane processes; OMX reads them:
 
 | Variable | Meaning |
 | --- | --- |
 | `HERDR_ENV=1` | running inside a Herdr-managed pane |
 | `HERDR_PANE_ID` | the pane to report against (e.g. `w1:p1`) |
 | `HERDR_SOCKET_PATH` | raw local socket for the JSON API (preferred transport) |
-| `HERDR_BIN_PATH` | Herdr binary for CLI fallback |
+| `HERDR_BIN_PATH` | Herdr binary for the CLI fallback (must be an absolute path) |
 
 The bridge is enabled only when `HERDR_ENV=1` **and** `HERDR_PANE_ID` are present.
 
 ## State mapping
 
-OMX hook lifecycle events map to Herdr semantic states:
-
 | OMX event(s) | Herdr state |
 | --- | --- |
 | `session-start`, `run.heartbeat`, `worker.assigned`, `worker.recovered`, `test-started`, `pre-tool-use`, `post-tool-use` | `working` |
 | `blocked`, `run.blocked_on_user`, `run.blocked_on_system`, `needs-input`, `handoff-needed` | `blocked` |
-| `turn-complete`, `finished`, `failed`, `stop`, `session-end`, `session-idle` | `idle` |
+| `turn-complete`, `finished`, `failed`, `session-idle`, `stop`, `session-end` | `idle` |
 | anything unmapped / reconciliation-uncertain | `unknown` |
 
-Events `finished`, `failed`, `stop`, and `session-end` are **terminal**: after
-reporting `idle`, OMX releases authority.
+Only whole-session shutdown (`stop`, `session-end`) is **authority-terminal**:
+after reporting `idle` OMX releases authority. Per-run outcomes
+(`finished`/`failed`) map to `idle` without releasing, because a single run
+ending does not mean OMX has left the pane.
 
 ### Team rollup
 
-For Team mode the bridge uses an authoritative rollup rather than pane-output
-inference (precedence):
+Precedence: (1) `blocked` if the leader is blocked on user input or a worker is
+blocked on user action; (2) otherwise `working` while any worker is active;
+(3) otherwise `idle`. A worker blocked on the system alone does not escalate the
+pane to `blocked`.
 
-1. `blocked` if the leader is blocked on user input, or an authoritative
-   worker/task is blocked on user action;
-2. otherwise `working` while any worker/task is active;
-3. otherwise `idle` when the run is terminal.
+## Durable ordering (`seq`)
 
-A worker blocked on the system alone does not escalate the whole pane to
-`blocked`.
+Herdr accepts but ignores a report whose `seq <= last accepted seq for the same
+source`. Because hooks run as short-lived processes, an in-memory counter would
+reset to `1` on every process/restart, so legitimate new reports would be
+rejected as stale after a restart and stale reports would not be prevented
+across concurrent processes.
+
+`src/adapt/herdr/seq-store.ts` persists a per-source counter under
+`.omx/adapters/herdr/seq/<source>.json`, incremented under an atomic
+`mkdir`-based lock (with stale-lock recovery). This makes `seq` strictly
+increasing per source across concurrent processes and restarts. The same
+monotonic stream is used for both report and release. If the lock cannot be
+acquired, a wall-clock-floored fallback seq is used so a report is never dropped
+and never regresses below the last persisted value.
 
 ## Transports
 
-Both transports are injectable (for testing) and shell-free:
+- **Socket (preferred)** — newline-delimited JSON over the local Herdr socket
+  using the documented `pane.report_agent` / `pane.release_agent` methods. The
+  transport writes the request, then reads reply lines with a **bounded buffer**,
+  parses NDJSON, **correlates by request `id`**, and reports `ok` only on a
+  matching `{id,result}` (Herdr acceptance). It rejects on `{id,error}`, id
+  mismatch, timeout, oversized frame, or a socket close before reply.
+- **CLI (fallback)** — `herdr pane report-agent/release-agent …` executed via
+  `execFile` (argv array, no shell). The binary is **trust-pinned**: only an
+  absolute path to an existing file (`HERDR_BIN_PATH`) is accepted; a bare
+  PATH-resolved `herdr` is never used.
 
-- **CLI** — `herdr pane report-agent <pane> --source omx:runtime --agent codex
-  --state <state> --seq <n>` and `herdr pane release-agent <pane> --source
-  omx:runtime --seq <n>`, executed via `execFile` (argv array, never a shell),
-  so pane ids / messages cannot inject shell syntax.
-- **Socket** — newline-delimited JSON over the local Herdr socket, using the
-  documented dot-notation methods `pane.report_agent` and `pane.release_agent`.
+## Metadata
 
-The socket transport is preferred when `HERDR_SOCKET_PATH` is exported.
+Semantic `message` and display-only metadata tokens are bounded and redacted at
+the boundary (`src/adapt/herdr/sanitize.ts`): whitespace collapsed, length
+capped, token count capped, secret-like keys/values dropped, and absolute paths
+redacted, before anything is sent to Herdr. Metadata tokens are transmitted on
+the socket transport as `tokens`.
+
+## Release + crash reconciliation
+
+`release` only fires on whole-session shutdown and is suppressed while another
+OMX workflow remains active (`workflowActiveFn`). An authority record
+(`.omx/adapters/herdr/authority.json`) captures the owning pid; on the next
+`session-start`, `reconcileStaleAuthority` clears the record if its owner process
+is no longer alive, so a crash does not leave permanent stale Herdr authority.
 
 ## Protocol verification
 
-The `seq` and authority-release surfaces were verified against the official
-Herdr source at commit `1f2487554b9fd42118f9e99ee06eb558bbb2391f`:
+Verified against the official Herdr source at commit
+`1f2487554b9fd42118f9e99ee06eb558bbb2391f`:
 
 - `PaneReportAgentParams { seq: Option<u64> }`
 - CLI `herdr pane report-agent ... [--seq N]` and `herdr pane release-agent ... [--seq N]`
 - the server forwards `seq` into `HookStateReported`
 
 and against the published protocol docs (herdr.dev/docs/socket-api,
-/docs/agents), which document `pane.report_agent`, `pane.release_agent`,
-`pane.clear_agent_authority`, and `seq`-based ordering.
+/docs/agents): `pane.report_agent`, `pane.release_agent`,
+`pane.clear_agent_authority`, `seq`-based ordering, and NDJSON request/response
+over a local socket.
 
 ## Code layout
 
 - `src/adapt/herdr/semantic.ts` — pure event→state mapping and Team rollup.
-- `src/adapt/herdr/transport.ts` — env detection + CLI/socket transports.
-- `src/adapt/herdr/bridge.ts` — `HerdrBridge`: opt-in gate, monotonic seq,
-  terminal release, failure isolation.
-- `src/adapt/herdr.ts` — `omx adapt herdr` target metadata (probe/status/
-  envelope/doctor/init).
+- `src/adapt/herdr/seq-store.ts` — durable atomic per-source monotonic seq.
+- `src/adapt/herdr/sanitize.ts` — metadata/message bounding + redaction.
+- `src/adapt/herdr/transport.ts` — env detection, trust-pinned CLI, socket
+  request/response.
+- `src/adapt/herdr/team-map.ts` — real Team-state → rollup mapping.
+- `src/adapt/herdr/authority.ts` — authority record + crash reconciliation.
+- `src/adapt/herdr/bridge.ts` — `HerdrBridge`: opt-in gate, durable seq,
+  sanitized reports, gated release.
+- `src/adapt/herdr/wiring.ts` — `reportHerdrLifecycleEvent`, invoked from the
+  hook dispatcher.
+- `src/adapt/herdr.ts` — `omx adapt herdr` target metadata.
 
 ## Phase 2 (out of scope)
 
 Using Herdr as a pluggable multiplexer/runtime backend for Team panes/workspaces
-(instead of nested tmux) is deferred. The status bridge delivers value through
-the stable Herdr API without replacing OMX's tmux runtime.
+(instead of nested tmux) is deferred.

--- a/src/adapt/__tests__/herdr-target.test.ts
+++ b/src/adapt/__tests__/herdr-target.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+	buildAdaptDoctorReportForTarget,
+	buildAdaptEnvelopeForTarget,
+	buildAdaptProbeReportForTarget,
+	buildAdaptStatusReportForTarget,
+	initAdaptFoundationForTarget,
+	supportedAdaptTargets,
+} from "../index.js";
+import { resolveAdaptPaths } from "../paths.js";
+import { getAdaptTargetDescriptor } from "../registry.js";
+
+let tempDir: string;
+let originalEnv: NodeJS.ProcessEnv;
+
+beforeEach(async () => {
+	originalEnv = { ...process.env };
+	tempDir = await mkdtemp(join(tmpdir(), "omx-adapt-herdr-"));
+	process.env.HOME = tempDir;
+	delete process.env.HERDR_ENV;
+	delete process.env.HERDR_PANE_ID;
+	delete process.env.HERDR_SOCKET_PATH;
+	delete process.env.HERDR_BIN_PATH;
+});
+
+afterEach(async () => {
+	for (const key of Object.keys(process.env)) {
+		if (!(key in originalEnv)) delete process.env[key];
+	}
+	for (const [key, val] of Object.entries(originalEnv)) {
+		process.env[key] = val;
+	}
+	if (tempDir && existsSync(tempDir)) {
+		await rm(tempDir, { recursive: true, force: true });
+	}
+});
+
+describe("adapt herdr target", () => {
+	it("is a registered adapt target with a descriptor", () => {
+		assert.ok(supportedAdaptTargets().includes("herdr"));
+		const descriptor = getAdaptTargetDescriptor("herdr");
+		assert.ok(descriptor);
+		assert.equal(descriptor?.displayName, "Herdr");
+		assert.ok(
+			descriptor?.capabilities.some((c) => c.id === "lifecycle-status-bridge"),
+		);
+	});
+
+	it("resolves OMX-owned adapter paths under .omx/adapters/herdr", () => {
+		const paths = resolveAdaptPaths(tempDir, "herdr");
+		assert.equal(paths.adapterRoot, join(tempDir, ".omx", "adapters", "herdr"));
+	});
+
+	it("reports not-detected runtime state outside a Herdr pane", async () => {
+		const probe = await buildAdaptProbeReportForTarget(tempDir, "herdr");
+		assert.equal(probe.target, "herdr");
+		assert.equal(probe.targetRuntime.state, "not-detected");
+		const status = await buildAdaptStatusReportForTarget(tempDir, "herdr");
+		assert.equal(status.targetRuntime.state, "not-detected");
+	});
+
+	it("reports detected runtime state and a transport inside a Herdr pane", async () => {
+		process.env.HERDR_ENV = "1";
+		process.env.HERDR_PANE_ID = "w1:p1";
+		process.env.HERDR_SOCKET_PATH = "/tmp/herdr.sock";
+		const envelope = await buildAdaptEnvelopeForTarget(tempDir, "herdr");
+		assert.equal(envelope.targetRuntime?.state, "detected");
+		assert.equal(envelope.bootstrap?.eventBridge.length, 4);
+		const bridgeCap = envelope.capabilities.find(
+			(c) => c.id === "lifecycle-status-bridge",
+		);
+		assert.equal(bridgeCap?.status, "ready");
+	});
+
+	it("flags a doctor issue when no Herdr pane is detected", async () => {
+		const doctor = await buildAdaptDoctorReportForTarget(tempDir, "herdr");
+		assert.ok(
+			doctor.issues.some((issue) => issue.code === "herdr_pane_not_detected"),
+		);
+	});
+
+	it("materializes OMX-owned adapter artifacts on init --write", async () => {
+		const result = await initAdaptFoundationForTarget(
+			tempDir,
+			"herdr",
+			true,
+		);
+		assert.ok(existsSync(result.envelope.adapterPaths.configPath));
+		assert.ok(existsSync(result.envelope.adapterPaths.envelopePath));
+	});
+});

--- a/src/adapt/contracts.ts
+++ b/src/adapt/contracts.ts
@@ -1,6 +1,6 @@
 export const ADAPT_SCHEMA_VERSION = "1.0";
 
-export const ADAPT_TARGETS = ["openclaw", "hermes"] as const;
+export const ADAPT_TARGETS = ["openclaw", "hermes", "herdr"] as const;
 export type AdaptTarget = (typeof ADAPT_TARGETS)[number];
 
 export const ADAPT_SUBCOMMANDS = [

--- a/src/adapt/herdr.ts
+++ b/src/adapt/herdr.ts
@@ -1,0 +1,152 @@
+import type {
+	AdaptBootstrapMetadata,
+	AdaptCapabilityReport,
+	AdaptEnvelope,
+	AdaptProbeReport,
+	AdaptRuntimeObservation,
+	AdaptStatusReport,
+} from "./contracts.js";
+import { detectHerdrEnv, type HerdrEnv } from "./herdr/transport.js";
+
+export interface HerdrEvidence {
+	env: HerdrEnv;
+	transport: "socket" | "cli" | "none";
+}
+
+/**
+ * Herdr evidence is environment-based: OMX only bridges to Herdr when it is
+ * running inside a Herdr-managed pane (HERDR_ENV=1 + HERDR_PANE_ID). Socket
+ * transport is preferred when HERDR_SOCKET_PATH is exported.
+ */
+export function collectHerdrEvidence(
+	env: NodeJS.ProcessEnv = process.env,
+): HerdrEvidence {
+	const detected = detectHerdrEnv(env);
+	const transport: HerdrEvidence["transport"] = !detected.enabled
+		? "none"
+		: detected.socketPath
+			? "socket"
+			: "cli";
+	return { env: detected, transport };
+}
+
+export function buildHerdrCapabilityOverrides(
+	capabilities: AdaptCapabilityReport[],
+	evidence: HerdrEvidence,
+): AdaptCapabilityReport[] {
+	return capabilities.map((capability) => {
+		if (capability.id === "herdr-env-detection") {
+			return {
+				...capability,
+				status: evidence.env.enabled ? "ready" : "stub",
+				summary: evidence.env.enabled
+					? `Herdr pane detected (pane ${evidence.env.paneId}); ${evidence.transport} transport selected.`
+					: "Herdr pane environment (HERDR_ENV=1 + HERDR_PANE_ID) is not present; the bridge stays inert.",
+			};
+		}
+		if (capability.id === "lifecycle-status-bridge") {
+			return {
+				...capability,
+				status: evidence.env.enabled ? "ready" : "stub",
+				summary: evidence.env.enabled
+					? "OMX lifecycle/team state can be reported as Herdr semantic state with monotonic seq ordering and authority release."
+					: "Lifecycle/status bridge is available but idle until OMX runs inside a Herdr pane.",
+			};
+		}
+		return capability;
+	});
+}
+
+export function buildHerdrRuntimeObservation(
+	evidence: HerdrEvidence,
+): AdaptRuntimeObservation {
+	if (!evidence.env.enabled) {
+		return {
+			state: "not-detected",
+			detail:
+				"OMX is not running inside a Herdr pane; set HERDR_ENV=1 and HERDR_PANE_ID (Herdr exports these automatically) to enable the bridge.",
+			evidence: {
+				herdrEnv: false,
+				paneId: evidence.env.paneId,
+				socketPath: evidence.env.socketPath,
+			},
+		};
+	}
+	return {
+		state: "detected",
+		detail: `Herdr pane ${evidence.env.paneId} detected; ${evidence.transport} transport will be used for best-effort, non-blocking reports.`,
+		evidence: {
+			herdrEnv: true,
+			paneId: evidence.env.paneId,
+			socketPath: evidence.env.socketPath,
+			binPath: evidence.env.binPath,
+			transport: evidence.transport,
+		},
+	};
+}
+
+export function buildHerdrBootstrapMetadata(): AdaptBootstrapMetadata {
+	return {
+		summary:
+			"Herdr bootstrap maps OMX lifecycle/team state into Herdr semantic states (working/blocked/idle/unknown) via the documented pane.report_agent / pane.release_agent surfaces. Phase 2 runtime backend is out of scope.",
+		eventBridge: [
+			"session-start / run.heartbeat / worker.assigned -> working",
+			"blocked / run.blocked_on_user / needs-input -> blocked",
+			"turn-complete / finished / failed / session-end -> idle (+ release authority)",
+			"unmapped/uncertain -> unknown",
+		],
+		commands: [
+			'herdr pane report-agent "$HERDR_PANE_ID" --source omx:runtime --agent codex --state working --seq <n>',
+			'herdr pane release-agent "$HERDR_PANE_ID" --source omx:runtime --seq <n>',
+		],
+		nextSteps: [
+			"Run OMX inside a Herdr pane; the bridge is opt-in and inert otherwise.",
+			"A Herdr socket/CLI failure never fails the OMX run (best-effort, non-blocking).",
+		],
+	};
+}
+
+export function applyHerdrEnvelope(
+	envelope: AdaptEnvelope,
+	evidence: HerdrEvidence,
+): AdaptEnvelope {
+	return {
+		...envelope,
+		capabilities: buildHerdrCapabilityOverrides(envelope.capabilities, evidence),
+		targetRuntime: buildHerdrRuntimeObservation(evidence),
+		bootstrap: buildHerdrBootstrapMetadata(),
+	};
+}
+
+export function applyHerdrProbe(
+	report: AdaptProbeReport,
+	evidence: HerdrEvidence,
+): AdaptProbeReport {
+	return {
+		...report,
+		summary: evidence.env.enabled
+			? "Herdr probe detected a live Herdr pane; the opt-in lifecycle/status bridge is ready."
+			: "Herdr probe found no Herdr pane; the bridge stays inert until OMX runs inside Herdr.",
+		capabilities: buildHerdrCapabilityOverrides(report.capabilities, evidence),
+		targetRuntime: buildHerdrRuntimeObservation(evidence),
+		nextSteps: [
+			"Run omx adapt herdr init --write to materialize OMX-owned adapter artifacts.",
+			"Launch OMX inside a Herdr pane to activate the opt-in bridge.",
+		],
+	};
+}
+
+export function applyHerdrStatus(
+	report: AdaptStatusReport,
+	evidence: HerdrEvidence,
+): AdaptStatusReport {
+	const targetRuntime = buildHerdrRuntimeObservation(evidence);
+	return {
+		...report,
+		summary: evidence.env.enabled
+			? "Herdr adapter is active inside a detected Herdr pane."
+			: "Herdr adapter is available but inert; no Herdr pane is currently detected.",
+		capabilities: buildHerdrCapabilityOverrides(report.capabilities, evidence),
+		targetRuntime,
+	};
+}

--- a/src/adapt/herdr/__tests__/authority.test.ts
+++ b/src/adapt/herdr/__tests__/authority.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+	clearAuthority,
+	readAuthority,
+	reconcileStaleAuthority,
+	recordAuthority,
+} from "../authority.js";
+
+let baseDir: string;
+beforeEach(async () => {
+	baseDir = await mkdtemp(join(tmpdir(), "omx-herdr-auth-"));
+});
+afterEach(async () => {
+	await rm(baseDir, { recursive: true, force: true });
+});
+
+describe("authority store", () => {
+	it("records and reads an authority record", () => {
+		recordAuthority(
+			{ pane_id: "w1:p1", source: "omx:runtime", owner_pid: process.pid },
+			{ baseDir },
+		);
+		const record = readAuthority({ baseDir });
+		assert.equal(record?.pane_id, "w1:p1");
+		assert.equal(record?.owner_pid, process.pid);
+		assert.ok(record?.acquired_at);
+	});
+
+	it("clears an authority record", () => {
+		recordAuthority(
+			{ pane_id: "w1:p1", source: "omx:runtime", owner_pid: process.pid },
+			{ baseDir },
+		);
+		clearAuthority({ baseDir });
+		assert.equal(readAuthority({ baseDir }), null);
+	});
+
+	it("reconciles stale authority left by a dead process", () => {
+		recordAuthority(
+			{ pane_id: "w1:p1", source: "omx:runtime", owner_pid: 999999 },
+			{ baseDir },
+		);
+		const cleared = reconcileStaleAuthority({
+			baseDir,
+			pidAlive: () => false,
+		});
+		assert.equal(cleared, true);
+		assert.equal(readAuthority({ baseDir }), null);
+	});
+
+	it("keeps authority when the owner process is still alive", () => {
+		recordAuthority(
+			{ pane_id: "w1:p1", source: "omx:runtime", owner_pid: process.pid },
+			{ baseDir },
+		);
+		const cleared = reconcileStaleAuthority({
+			baseDir,
+			pidAlive: () => true,
+		});
+		assert.equal(cleared, false);
+		assert.ok(readAuthority({ baseDir }));
+	});
+
+	it("returns false when there is no authority record", () => {
+		assert.equal(reconcileStaleAuthority({ baseDir }), false);
+	});
+});

--- a/src/adapt/herdr/__tests__/bridge.test.ts
+++ b/src/adapt/herdr/__tests__/bridge.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { HerdrBridge } from "../bridge.js";
+import type {
+	HerdrAgentReport,
+	HerdrReleaseReport,
+	HerdrTransport,
+	HerdrTransportResult,
+} from "../transport.js";
+
+interface RecordedCall {
+	op: "report" | "release";
+	state?: string;
+	seq: number;
+}
+
+class RecordingTransport implements HerdrTransport {
+	readonly kind = "cli" as const;
+	calls: RecordedCall[] = [];
+	failReport = false;
+	throwOnReport = false;
+
+	async reportAgent(report: HerdrAgentReport): Promise<HerdrTransportResult> {
+		if (this.throwOnReport) throw new Error("boom");
+		this.calls.push({ op: "report", state: report.state, seq: report.seq });
+		return this.failReport
+			? { ok: false, transport: "cli", detail: "failed", error: "nope" }
+			: { ok: true, transport: "cli", detail: "ok" };
+	}
+
+	async releaseAgent(report: HerdrReleaseReport): Promise<HerdrTransportResult> {
+		this.calls.push({ op: "release", seq: report.seq });
+		return { ok: true, transport: "cli", detail: "ok" };
+	}
+}
+
+const HERDR_ENV = {
+	enabled: true,
+	paneId: "w1:p1",
+	socketPath: null,
+	binPath: null,
+};
+
+describe("HerdrBridge opt-in gate", () => {
+	it("is a no-op when not inside a Herdr pane", async () => {
+		const transport = new RecordingTransport();
+		const bridge = new HerdrBridge({
+			env: { enabled: false, paneId: null, socketPath: null, binPath: null },
+			transport,
+		});
+		assert.equal(bridge.enabled, false);
+		const outcome = await bridge.reportState("working");
+		assert.equal(outcome.skipped, true);
+		assert.equal(outcome.reason, "herdr-not-detected");
+		const evented = await bridge.reportHookEvent("finished");
+		assert.equal(evented.skipped, true);
+		const released = await bridge.release();
+		assert.equal(released.skipped, true);
+		assert.equal(transport.calls.length, 0);
+	});
+});
+
+describe("HerdrBridge monotonic seq ordering", () => {
+	it("uses a single monotonic seq shared across report and release", async () => {
+		const transport = new RecordingTransport();
+		const bridge = new HerdrBridge({ env: HERDR_ENV, transport });
+		await bridge.reportState("working");
+		await bridge.reportState("blocked");
+		await bridge.reportState("working");
+		await bridge.release();
+		const seqs = transport.calls.map((c) => c.seq);
+		assert.deepEqual(seqs, [1, 2, 3, 4]);
+		// strictly increasing so stale reports cannot win at the pane
+		for (let i = 1; i < seqs.length; i += 1) {
+			assert.ok(seqs[i] > seqs[i - 1]);
+		}
+		assert.equal(transport.calls.at(-1)?.op, "release");
+	});
+});
+
+describe("HerdrBridge hook-event reporting", () => {
+	it("maps and reports a working event without release", async () => {
+		const transport = new RecordingTransport();
+		const bridge = new HerdrBridge({ env: HERDR_ENV, transport });
+		const outcome = await bridge.reportHookEvent("session-start");
+		assert.equal(outcome.state, "working");
+		assert.equal(transport.calls.length, 1);
+		assert.equal(transport.calls[0].op, "report");
+	});
+
+	it("reports idle and releases authority on a terminal event", async () => {
+		const transport = new RecordingTransport();
+		const bridge = new HerdrBridge({ env: HERDR_ENV, transport });
+		const outcome = await bridge.reportHookEvent("finished");
+		assert.equal(outcome.state, "idle");
+		assert.equal(outcome.released, true);
+		assert.deepEqual(
+			transport.calls.map((c) => c.op),
+			["report", "release"],
+		);
+		// release seq is greater than the report seq
+		assert.ok(transport.calls[1].seq > transport.calls[0].seq);
+	});
+
+	it("reports an authoritative team rollup state", async () => {
+		const transport = new RecordingTransport();
+		const bridge = new HerdrBridge({ env: HERDR_ENV, transport });
+		const outcome = await bridge.reportTeamRollup({
+			leaderBlockedOnUser: true,
+			workers: [{ id: "w1", state: "working" }],
+		});
+		assert.equal(outcome.state, "blocked");
+		assert.equal(transport.calls[0].state, "blocked");
+	});
+});
+
+describe("HerdrBridge release idempotence", () => {
+	it("releases at most once", async () => {
+		const transport = new RecordingTransport();
+		const bridge = new HerdrBridge({ env: HERDR_ENV, transport });
+		const first = await bridge.release();
+		const second = await bridge.release();
+		assert.equal(first.released, true);
+		assert.equal(second.skipped, true);
+		assert.equal(second.reason, "already-released");
+		assert.equal(transport.calls.filter((c) => c.op === "release").length, 1);
+	});
+});
+
+describe("HerdrBridge failure isolation", () => {
+	it("returns a failed outcome when the transport reports failure", async () => {
+		const transport = new RecordingTransport();
+		transport.failReport = true;
+		const bridge = new HerdrBridge({ env: HERDR_ENV, transport });
+		const outcome = await bridge.reportState("working");
+		assert.equal(outcome.attempted, true);
+		assert.equal(outcome.ok, false);
+	});
+
+	it("never throws when the transport throws", async () => {
+		const transport = new RecordingTransport();
+		transport.throwOnReport = true;
+		let loggerCalled = false;
+		const bridge = new HerdrBridge({
+			env: HERDR_ENV,
+			transport,
+			logger: () => {
+				loggerCalled = true;
+			},
+		});
+		const outcome = await bridge.reportState("working");
+		assert.equal(outcome.ok, false);
+		assert.match(outcome.reason, /threw/);
+		assert.equal(loggerCalled, true);
+	});
+});

--- a/src/adapt/herdr/__tests__/bridge.test.ts
+++ b/src/adapt/herdr/__tests__/bridge.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
 import { HerdrBridge } from "../bridge.js";
 import type {
 	HerdrAgentReport,
@@ -12,6 +15,7 @@ interface RecordedCall {
 	op: "report" | "release";
 	state?: string;
 	seq: number;
+	message?: string;
 }
 
 class RecordingTransport implements HerdrTransport {
@@ -22,7 +26,12 @@ class RecordingTransport implements HerdrTransport {
 
 	async reportAgent(report: HerdrAgentReport): Promise<HerdrTransportResult> {
 		if (this.throwOnReport) throw new Error("boom");
-		this.calls.push({ op: "report", state: report.state, seq: report.seq });
+		this.calls.push({
+			op: "report",
+			state: report.state,
+			seq: report.seq,
+			message: report.message,
+		});
 		return this.failReport
 			? { ok: false, transport: "cli", detail: "failed", error: "nope" }
 			: { ok: true, transport: "cli", detail: "ok" };
@@ -41,21 +50,46 @@ const HERDR_ENV = {
 	binPath: null,
 };
 
+let baseDir: string;
+// Deterministic injected seq so tests do not depend on the durable fs store.
+function makeSeqFn() {
+	let n = 0;
+	return () => {
+		n += 1;
+		return n;
+	};
+}
+
+beforeEach(async () => {
+	baseDir = await mkdtemp(join(tmpdir(), "omx-herdr-bridge-"));
+});
+afterEach(async () => {
+	await rm(baseDir, { recursive: true, force: true });
+});
+
+function bridge(transport: RecordingTransport, extra = {}) {
+	return new HerdrBridge({
+		env: HERDR_ENV,
+		transport,
+		seqFn: makeSeqFn(),
+		stateBaseDir: baseDir,
+		...extra,
+	});
+}
+
 describe("HerdrBridge opt-in gate", () => {
 	it("is a no-op when not inside a Herdr pane", async () => {
 		const transport = new RecordingTransport();
-		const bridge = new HerdrBridge({
+		const b = new HerdrBridge({
 			env: { enabled: false, paneId: null, socketPath: null, binPath: null },
 			transport,
+			seqFn: makeSeqFn(),
+			stateBaseDir: baseDir,
 		});
-		assert.equal(bridge.enabled, false);
-		const outcome = await bridge.reportState("working");
-		assert.equal(outcome.skipped, true);
-		assert.equal(outcome.reason, "herdr-not-detected");
-		const evented = await bridge.reportHookEvent("finished");
-		assert.equal(evented.skipped, true);
-		const released = await bridge.release();
-		assert.equal(released.skipped, true);
+		assert.equal(b.enabled, false);
+		assert.equal((await b.reportState("working")).skipped, true);
+		assert.equal((await b.reportHookEvent("stop")).skipped, true);
+		assert.equal((await b.release()).skipped, true);
 		assert.equal(transport.calls.length, 0);
 	});
 });
@@ -63,17 +97,14 @@ describe("HerdrBridge opt-in gate", () => {
 describe("HerdrBridge monotonic seq ordering", () => {
 	it("uses a single monotonic seq shared across report and release", async () => {
 		const transport = new RecordingTransport();
-		const bridge = new HerdrBridge({ env: HERDR_ENV, transport });
-		await bridge.reportState("working");
-		await bridge.reportState("blocked");
-		await bridge.reportState("working");
-		await bridge.release();
+		const b = bridge(transport);
+		await b.reportState("working");
+		await b.reportState("blocked");
+		await b.reportState("working");
+		await b.release();
 		const seqs = transport.calls.map((c) => c.seq);
 		assert.deepEqual(seqs, [1, 2, 3, 4]);
-		// strictly increasing so stale reports cannot win at the pane
-		for (let i = 1; i < seqs.length; i += 1) {
-			assert.ok(seqs[i] > seqs[i - 1]);
-		}
+		for (let i = 1; i < seqs.length; i += 1) assert.ok(seqs[i] > seqs[i - 1]);
 		assert.equal(transport.calls.at(-1)?.op, "release");
 	});
 });
@@ -81,31 +112,37 @@ describe("HerdrBridge monotonic seq ordering", () => {
 describe("HerdrBridge hook-event reporting", () => {
 	it("maps and reports a working event without release", async () => {
 		const transport = new RecordingTransport();
-		const bridge = new HerdrBridge({ env: HERDR_ENV, transport });
-		const outcome = await bridge.reportHookEvent("session-start");
+		const outcome = await bridge(transport).reportHookEvent("session-start");
 		assert.equal(outcome.state, "working");
 		assert.equal(transport.calls.length, 1);
 		assert.equal(transport.calls[0].op, "report");
 	});
 
-	it("reports idle and releases authority on a terminal event", async () => {
+	it("reports idle on a per-run finish WITHOUT releasing authority", async () => {
 		const transport = new RecordingTransport();
-		const bridge = new HerdrBridge({ env: HERDR_ENV, transport });
-		const outcome = await bridge.reportHookEvent("finished");
+		const outcome = await bridge(transport).reportHookEvent("finished");
+		assert.equal(outcome.state, "idle");
+		assert.deepEqual(
+			transport.calls.map((c) => c.op),
+			["report"],
+		);
+	});
+
+	it("reports idle and releases authority on whole-session shutdown", async () => {
+		const transport = new RecordingTransport();
+		const outcome = await bridge(transport).reportHookEvent("session-end");
 		assert.equal(outcome.state, "idle");
 		assert.equal(outcome.released, true);
 		assert.deepEqual(
 			transport.calls.map((c) => c.op),
 			["report", "release"],
 		);
-		// release seq is greater than the report seq
 		assert.ok(transport.calls[1].seq > transport.calls[0].seq);
 	});
 
 	it("reports an authoritative team rollup state", async () => {
 		const transport = new RecordingTransport();
-		const bridge = new HerdrBridge({ env: HERDR_ENV, transport });
-		const outcome = await bridge.reportTeamRollup({
+		const outcome = await bridge(transport).reportTeamRollup({
 			leaderBlockedOnUser: true,
 			workers: [{ id: "w1", state: "working" }],
 		});
@@ -114,12 +151,21 @@ describe("HerdrBridge hook-event reporting", () => {
 	});
 });
 
-describe("HerdrBridge release idempotence", () => {
+describe("HerdrBridge release gating", () => {
+	it("suppresses release while another workflow is active", async () => {
+		const transport = new RecordingTransport();
+		const b = bridge(transport, { workflowActiveFn: () => true });
+		const outcome = await b.release();
+		assert.equal(outcome.skipped, true);
+		assert.equal(outcome.reason, "workflow-still-active");
+		assert.equal(transport.calls.filter((c) => c.op === "release").length, 0);
+	});
+
 	it("releases at most once", async () => {
 		const transport = new RecordingTransport();
-		const bridge = new HerdrBridge({ env: HERDR_ENV, transport });
-		const first = await bridge.release();
-		const second = await bridge.release();
+		const b = bridge(transport);
+		const first = await b.release();
+		const second = await b.release();
 		assert.equal(first.released, true);
 		assert.equal(second.skipped, true);
 		assert.equal(second.reason, "already-released");
@@ -127,12 +173,22 @@ describe("HerdrBridge release idempotence", () => {
 	});
 });
 
+describe("HerdrBridge metadata sanitization", () => {
+	it("bounds and redacts the message before it hits the transport", async () => {
+		const transport = new RecordingTransport();
+		await bridge(transport).reportState("working", {
+			message: "token=sk-abcdefgh12345678 running at /home/user/secret/app.ts",
+		});
+		const sent = transport.calls[0].message ?? "";
+		assert.ok(!sent.includes("sk-abcdefgh12345678"));
+	});
+});
+
 describe("HerdrBridge failure isolation", () => {
 	it("returns a failed outcome when the transport reports failure", async () => {
 		const transport = new RecordingTransport();
 		transport.failReport = true;
-		const bridge = new HerdrBridge({ env: HERDR_ENV, transport });
-		const outcome = await bridge.reportState("working");
+		const outcome = await bridge(transport).reportState("working");
 		assert.equal(outcome.attempted, true);
 		assert.equal(outcome.ok, false);
 	});
@@ -140,17 +196,15 @@ describe("HerdrBridge failure isolation", () => {
 	it("never throws when the transport throws", async () => {
 		const transport = new RecordingTransport();
 		transport.throwOnReport = true;
-		let loggerCalled = false;
-		const bridge = new HerdrBridge({
-			env: HERDR_ENV,
-			transport,
+		let logged = false;
+		const b = bridge(transport, {
 			logger: () => {
-				loggerCalled = true;
+				logged = true;
 			},
 		});
-		const outcome = await bridge.reportState("working");
+		const outcome = await b.reportState("working");
 		assert.equal(outcome.ok, false);
 		assert.match(outcome.reason, /threw/);
-		assert.equal(loggerCalled, true);
+		assert.equal(logged, true);
 	});
 });

--- a/src/adapt/herdr/__tests__/sanitize.test.ts
+++ b/src/adapt/herdr/__tests__/sanitize.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	MAX_MESSAGE_LEN,
+	MAX_TOKENS,
+	sanitizeMessage,
+	sanitizeMetadata,
+} from "../sanitize.js";
+
+describe("sanitizeMessage", () => {
+	it("collapses whitespace and returns undefined for empty", () => {
+		assert.equal(sanitizeMessage("  a\n\t b "), "a b");
+		assert.equal(sanitizeMessage(""), undefined);
+		assert.equal(sanitizeMessage(undefined), undefined);
+	});
+
+	it("caps length", () => {
+		const out = sanitizeMessage("x".repeat(500));
+		assert.ok((out ?? "").length <= MAX_MESSAGE_LEN);
+	});
+
+	it("redacts secrets and absolute paths", () => {
+		assert.equal(sanitizeMessage("bearer abcDEF12345 token"), "[redacted]");
+		const pathed = sanitizeMessage("failed at /home/user/app/src/secret.ts now");
+		assert.ok(!(pathed ?? "").includes("/home/user"));
+		assert.ok((pathed ?? "").includes("[path]"));
+	});
+});
+
+describe("sanitizeMetadata", () => {
+	it("drops secret-like keys and values", () => {
+		const out = sanitizeMetadata({
+			summary: "review ready",
+			authorization: "Bearer xyz",
+			api_key: "abc",
+			blob: "sk-abcdefgh12345678",
+		});
+		assert.deepEqual(Object.keys(out ?? {}).sort(), ["blob", "summary"]);
+		assert.equal(out?.blob, "[redacted]");
+		assert.equal(out?.summary, "review ready");
+	});
+
+	it("caps the number of tokens", () => {
+		const many: Record<string, string> = {};
+		for (let i = 0; i < 50; i += 1) many[`k${i}`] = `v${i}`;
+		const out = sanitizeMetadata(many);
+		assert.ok(Object.keys(out ?? {}).length <= MAX_TOKENS);
+	});
+
+	it("returns undefined when nothing survives", () => {
+		assert.equal(sanitizeMetadata({ password: "x" }), undefined);
+		assert.equal(sanitizeMetadata(undefined), undefined);
+	});
+});

--- a/src/adapt/herdr/__tests__/semantic.test.ts
+++ b/src/adapt/herdr/__tests__/semantic.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	HERDR_SEMANTIC_STATES,
+	isTerminalHookEvent,
+	mapHookEventToHerdrState,
+	rollupTeamState,
+} from "../semantic.js";
+
+describe("herdr semantic mapping", () => {
+	it("maps active-work events to working", () => {
+		for (const event of [
+			"session-start",
+			"run.heartbeat",
+			"worker.assigned",
+			"worker.recovered",
+			"test-started",
+			"pre-tool-use",
+			"post-tool-use",
+		]) {
+			assert.equal(mapHookEventToHerdrState(event).state, "working", event);
+		}
+	});
+
+	it("maps attention-required events to blocked", () => {
+		for (const event of [
+			"blocked",
+			"run.blocked_on_user",
+			"run.blocked_on_system",
+			"needs-input",
+			"handoff-needed",
+		]) {
+			assert.equal(mapHookEventToHerdrState(event).state, "blocked", event);
+		}
+	});
+
+	it("maps terminal/resting events to idle", () => {
+		for (const event of [
+			"turn-complete",
+			"finished",
+			"failed",
+			"stop",
+			"session-end",
+			"session-idle",
+		]) {
+			assert.equal(mapHookEventToHerdrState(event).state, "idle", event);
+		}
+	});
+
+	it("maps unknown or unmapped events to unknown rather than guessing", () => {
+		for (const event of ["worker.stalled", "retry-needed", "pr-created", "??"]) {
+			assert.equal(mapHookEventToHerdrState(event).state, "unknown", event);
+		}
+	});
+
+	it("only flags authority-terminal events as terminal", () => {
+		assert.equal(mapHookEventToHerdrState("finished").terminal, true);
+		assert.equal(mapHookEventToHerdrState("failed").terminal, true);
+		assert.equal(mapHookEventToHerdrState("stop").terminal, true);
+		assert.equal(mapHookEventToHerdrState("session-end").terminal, true);
+		// idle-but-not-terminal: a completed turn does not release authority.
+		assert.equal(mapHookEventToHerdrState("turn-complete").terminal, false);
+		assert.equal(mapHookEventToHerdrState("session-idle").terminal, false);
+		assert.equal(isTerminalHookEvent("finished"), true);
+		assert.equal(isTerminalHookEvent("turn-complete"), false);
+	});
+
+	it("accepts a hook envelope object", () => {
+		const mapping = mapHookEventToHerdrState({
+			schema_version: "1",
+			event: "run.blocked_on_user",
+			timestamp: new Date().toISOString(),
+			source: "native",
+			context: {},
+		});
+		assert.equal(mapping.state, "blocked");
+	});
+
+	it("exposes the four documented semantic states", () => {
+		assert.deepEqual(
+			[...HERDR_SEMANTIC_STATES],
+			["working", "blocked", "idle", "unknown"],
+		);
+	});
+});
+
+describe("herdr team rollup", () => {
+	it("escalates to blocked when the leader is blocked on user", () => {
+		const result = rollupTeamState({
+			leaderBlockedOnUser: true,
+			workers: [{ id: "w1", state: "working" }],
+		});
+		assert.equal(result.state, "blocked");
+	});
+
+	it("escalates to blocked when a worker is blocked on user action", () => {
+		const result = rollupTeamState({
+			workers: [
+				{ id: "w1", state: "working" },
+				{ id: "w2", state: "blocked", blockedOnUser: true },
+			],
+		});
+		assert.equal(result.state, "blocked");
+		assert.equal(result.counts.blockedOnUser, 1);
+	});
+
+	it("does not escalate for a worker blocked on the system only", () => {
+		const result = rollupTeamState({
+			workers: [
+				{ id: "w1", state: "working" },
+				{ id: "w2", state: "blocked", blockedOnUser: false },
+			],
+		});
+		assert.equal(result.state, "working");
+		assert.equal(result.counts.blocked, 1);
+		assert.equal(result.counts.blockedOnUser, 0);
+	});
+
+	it("is working while any worker is active", () => {
+		const result = rollupTeamState({
+			workers: [
+				{ id: "w1", state: "done" },
+				{ id: "w2", state: "working" },
+			],
+		});
+		assert.equal(result.state, "working");
+		assert.equal(result.counts.working, 1);
+		assert.equal(result.counts.done, 1);
+	});
+
+	it("is idle when no worker is active or user-blocking", () => {
+		const result = rollupTeamState({
+			runTerminal: true,
+			workers: [
+				{ id: "w1", state: "done" },
+				{ id: "w2", state: "failed" },
+			],
+		});
+		assert.equal(result.state, "idle");
+		assert.equal(result.counts.total, 2);
+	});
+
+	it("defaults a bare blocked worker to user-blocking", () => {
+		const result = rollupTeamState({
+			workers: [{ id: "w1", state: "blocked" }],
+		});
+		assert.equal(result.state, "blocked");
+		assert.equal(result.counts.blockedOnUser, 1);
+	});
+});

--- a/src/adapt/herdr/__tests__/semantic.test.ts
+++ b/src/adapt/herdr/__tests__/semantic.test.ts
@@ -53,16 +53,16 @@ describe("herdr semantic mapping", () => {
 		}
 	});
 
-	it("only flags authority-terminal events as terminal", () => {
-		assert.equal(mapHookEventToHerdrState("finished").terminal, true);
-		assert.equal(mapHookEventToHerdrState("failed").terminal, true);
+	it("only flags whole-session shutdown events as authority-terminal", () => {
 		assert.equal(mapHookEventToHerdrState("stop").terminal, true);
 		assert.equal(mapHookEventToHerdrState("session-end").terminal, true);
-		// idle-but-not-terminal: a completed turn does not release authority.
+		// per-run outcomes map to idle but do NOT release authority
+		assert.equal(mapHookEventToHerdrState("finished").terminal, false);
+		assert.equal(mapHookEventToHerdrState("failed").terminal, false);
 		assert.equal(mapHookEventToHerdrState("turn-complete").terminal, false);
 		assert.equal(mapHookEventToHerdrState("session-idle").terminal, false);
-		assert.equal(isTerminalHookEvent("finished"), true);
-		assert.equal(isTerminalHookEvent("turn-complete"), false);
+		assert.equal(isTerminalHookEvent("stop"), true);
+		assert.equal(isTerminalHookEvent("finished"), false);
 	});
 
 	it("accepts a hook envelope object", () => {

--- a/src/adapt/herdr/__tests__/seq-store.test.ts
+++ b/src/adapt/herdr/__tests__/seq-store.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execPath } from "node:process";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { nextSeq, readPersistedSeq, sanitizeSourceKey } from "../seq-store.js";
+
+let baseDir: string;
+const moduleHref = new URL("../seq-store.js", import.meta.url).href;
+
+beforeEach(async () => {
+	baseDir = await mkdtemp(join(tmpdir(), "omx-herdr-seq-"));
+});
+afterEach(async () => {
+	await rm(baseDir, { recursive: true, force: true });
+});
+
+describe("seq-store durable monotonic counter", () => {
+	it("is strictly increasing per source in-process", () => {
+		assert.deepEqual(
+			[
+				nextSeq("omx:runtime", { baseDir }),
+				nextSeq("omx:runtime", { baseDir }),
+				nextSeq("omx:runtime", { baseDir }),
+			],
+			[1, 2, 3],
+		);
+	});
+
+	it("keeps separate streams per source", () => {
+		assert.equal(nextSeq("src-a", { baseDir }), 1);
+		assert.equal(nextSeq("src-b", { baseDir }), 1);
+		assert.equal(nextSeq("src-a", { baseDir }), 2);
+	});
+
+	it("continues (does not reset to 1) after a simulated restart", () => {
+		nextSeq("omx:runtime", { baseDir });
+		nextSeq("omx:runtime", { baseDir });
+		assert.equal(readPersistedSeq("omx:runtime", { baseDir }), 2);
+		assert.equal(nextSeq("omx:runtime", { baseDir }), 3);
+	});
+
+	it("sanitizes source ids into safe file stems", () => {
+		assert.equal(sanitizeSourceKey("omx:runtime"), "omx_runtime");
+		assert.equal(sanitizeSourceKey("../../etc/passwd"), ".._.._etc_passwd");
+		assert.equal(sanitizeSourceKey(""), "unknown-source");
+	});
+
+	it("produces unique, strictly-increasing seqs across concurrent processes", () => {
+		const N = 12;
+		const script = `import(${JSON.stringify(moduleHref)}).then((m) => { console.log(m.nextSeq("omx:runtime", { baseDir: ${JSON.stringify(baseDir)} })); });`;
+		const results = new Array(N).fill(0).map(() =>
+			Number(
+				execFileSync(execPath, ["--input-type=module", "-e", script], {
+					encoding: "utf-8",
+				}).trim(),
+			),
+		);
+		const unique = new Set(results);
+		assert.equal(
+			unique.size,
+			N,
+			`expected ${N} unique seqs, got ${[...unique].sort((a, b) => a - b).join(",")}`,
+		);
+		assert.equal(Math.max(...results), N);
+		assert.equal(Math.min(...results), 1);
+		assert.equal(readPersistedSeq("omx:runtime", { baseDir }), N);
+	});
+});

--- a/src/adapt/herdr/__tests__/socket-live.test.ts
+++ b/src/adapt/herdr/__tests__/socket-live.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:net";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { SocketHerdrTransport } from "../transport.js";
+
+let dir: string;
+let servers: Server[] = [];
+
+beforeEach(async () => {
+	dir = await mkdtemp(join(tmpdir(), "omx-herdr-sock-"));
+	servers = [];
+});
+afterEach(async () => {
+	for (const s of servers) await new Promise<void>((r) => s.close(() => r()));
+	await rm(dir, { recursive: true, force: true });
+});
+
+function listen(
+	handler: (line: string, reply: (data: string) => void) => void,
+): Promise<string> {
+	const path = join(dir, `h-${servers.length}.sock`);
+	const server = createServer((socket) => {
+		let buf = "";
+		socket.on("data", (chunk) => {
+			buf += chunk.toString("utf-8");
+			const nl = buf.indexOf("\n");
+			if (nl !== -1) {
+				const line = buf.slice(0, nl);
+				handler(line, (data) => socket.write(data));
+			}
+		});
+	});
+	servers.push(server);
+	return new Promise((resolve) => server.listen(path, () => resolve(path)));
+}
+
+describe("SocketHerdrTransport live Unix-socket round-trip", () => {
+	it("reports ok on a correlated success reply", async () => {
+		const socketPath = await listen((line, reply) => {
+			const req = JSON.parse(line);
+			assert.equal(req.method, "pane.report_agent");
+			assert.equal(req.params.seq, 3);
+			reply(`${JSON.stringify({ id: req.id, result: { type: "pane_info" } })}\n`);
+		});
+		const transport = new SocketHerdrTransport({ socketPath, timeoutMs: 2000 });
+		const result = await transport.reportAgent({
+			paneId: "w1:p1",
+			source: "omx:runtime",
+			agent: "codex",
+			state: "working",
+			seq: 3,
+		});
+		assert.equal(result.ok, true);
+		assert.match(result.detail, /accepted/);
+	});
+
+	it("reports NOT ok when the server returns an error reply", async () => {
+		const socketPath = await listen((line, reply) => {
+			const req = JSON.parse(line);
+			reply(`${JSON.stringify({ id: req.id, error: { message: "stale seq" } })}\n`);
+		});
+		const transport = new SocketHerdrTransport({ socketPath, timeoutMs: 2000 });
+		const result = await transport.releaseAgent({
+			paneId: "w1:p1",
+			source: "omx:runtime",
+			seq: 1,
+		});
+		assert.equal(result.ok, false);
+		assert.match(result.error ?? "", /stale seq/);
+	});
+
+	it("reports NOT ok when the server never replies (timeout)", async () => {
+		const socketPath = await listen(() => {
+			/* swallow: never reply */
+		});
+		const transport = new SocketHerdrTransport({ socketPath, timeoutMs: 150 });
+		const result = await transport.reportAgent({
+			paneId: "w1:p1",
+			source: "omx:runtime",
+			agent: "codex",
+			state: "idle",
+			seq: 1,
+		});
+		assert.equal(result.ok, false);
+		assert.match(result.error ?? "", /timeout/);
+	});
+
+	it("reports NOT ok when the reply exceeds the max frame size", async () => {
+		const socketPath = await listen((_line, reply) => {
+			// Flood bytes with no newline to trip the bounded-frame guard.
+			reply("x".repeat(5000));
+		});
+		const transport = new SocketHerdrTransport({
+			socketPath,
+			timeoutMs: 2000,
+			maxFrameBytes: 1024,
+		});
+		const result = await transport.reportAgent({
+			paneId: "w1:p1",
+			source: "omx:runtime",
+			agent: "codex",
+			state: "idle",
+			seq: 1,
+		});
+		assert.equal(result.ok, false);
+		assert.match(result.error ?? "", /max frame/);
+	});
+});

--- a/src/adapt/herdr/__tests__/team-map.test.ts
+++ b/src/adapt/herdr/__tests__/team-map.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { rollupTeamState } from "../semantic.js";
+import { mapTeamStateToRollup } from "../team-map.js";
+
+describe("mapTeamStateToRollup", () => {
+	it("maps leader attention to a user-blocking rollup", () => {
+		const input = mapTeamStateToRollup({
+			leaderAttentionPending: true,
+			workers: [{ id: "w1", state: "working" }],
+		});
+		assert.equal(input.leaderBlockedOnUser, true);
+		assert.equal(rollupTeamState(input).state, "blocked");
+	});
+
+	it("treats a system-blocked worker as non-user-blocking", () => {
+		const input = mapTeamStateToRollup({
+			workers: [
+				{ id: "w1", state: "working" },
+				{ id: "w2", state: "blocked", reason: "waiting on network" },
+			],
+		});
+		assert.equal(rollupTeamState(input).state, "working");
+	});
+
+	it("treats a user-reason blocked worker as user-blocking", () => {
+		const input = mapTeamStateToRollup({
+			workers: [{ id: "w2", state: "blocked", reason: "needs user approval" }],
+		});
+		assert.equal(rollupTeamState(input).state, "blocked");
+	});
+
+	it("maps draining to working (still active)", () => {
+		const input = mapTeamStateToRollup({
+			workers: [{ id: "w1", state: "draining" }],
+		});
+		assert.equal(rollupTeamState(input).state, "working");
+	});
+
+	it("is idle when all workers are terminal", () => {
+		const input = mapTeamStateToRollup({
+			runTerminal: true,
+			workers: [
+				{ id: "w1", state: "done" },
+				{ id: "w2", state: "failed" },
+			],
+		});
+		assert.equal(rollupTeamState(input).state, "idle");
+	});
+});

--- a/src/adapt/herdr/__tests__/transport.test.ts
+++ b/src/adapt/herdr/__tests__/transport.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	CliHerdrTransport,
+	SocketHerdrTransport,
+	buildReleaseAgentArgs,
+	buildReportAgentArgs,
+	detectHerdrEnv,
+	type SocketRequest,
+} from "../transport.js";
+
+describe("herdr env detection", () => {
+	it("is enabled only when HERDR_ENV=1 and a pane id are present", () => {
+		assert.equal(
+			detectHerdrEnv({ HERDR_ENV: "1", HERDR_PANE_ID: "w1:p1" }).enabled,
+			true,
+		);
+		assert.equal(detectHerdrEnv({ HERDR_PANE_ID: "w1:p1" }).enabled, false);
+		assert.equal(detectHerdrEnv({ HERDR_ENV: "1" }).enabled, false);
+		assert.equal(
+			detectHerdrEnv({ HERDR_ENV: "1", HERDR_PANE_ID: "  " }).enabled,
+			false,
+		);
+	});
+
+	it("captures socket and bin paths", () => {
+		const env = detectHerdrEnv({
+			HERDR_ENV: "1",
+			HERDR_PANE_ID: "w1:p1",
+			HERDR_SOCKET_PATH: "/tmp/herdr.sock",
+			HERDR_BIN_PATH: "/usr/bin/herdr",
+		});
+		assert.equal(env.paneId, "w1:p1");
+		assert.equal(env.socketPath, "/tmp/herdr.sock");
+		assert.equal(env.binPath, "/usr/bin/herdr");
+	});
+});
+
+describe("herdr CLI argv builders", () => {
+	it("builds shell-free, ordered report-agent argv with seq", () => {
+		const args = buildReportAgentArgs({
+			paneId: "w1:p1",
+			source: "omx:runtime",
+			agent: "codex",
+			state: "working",
+			message: "team: 3 workers active",
+			seq: 7,
+		});
+		assert.deepEqual(args, [
+			"pane",
+			"report-agent",
+			"w1:p1",
+			"--source",
+			"omx:runtime",
+			"--agent",
+			"codex",
+			"--state",
+			"working",
+			"--seq",
+			"7",
+			"--message",
+			"team: 3 workers active",
+		]);
+	});
+
+	it("omits an empty message and keeps injection-prone text as one argv token", () => {
+		const args = buildReportAgentArgs({
+			paneId: "w1:p1; rm -rf /",
+			source: "omx:runtime",
+			agent: "codex",
+			state: "idle",
+			seq: 1,
+		});
+		// The dangerous pane id stays a single argv element; execFile never shells.
+		assert.equal(args[2], "w1:p1; rm -rf /");
+		assert.ok(!args.includes("--message"));
+	});
+
+	it("builds release-agent argv with seq", () => {
+		assert.deepEqual(
+			buildReleaseAgentArgs({ paneId: "w1:p1", source: "omx:runtime", seq: 9 }),
+			["pane", "release-agent", "w1:p1", "--source", "omx:runtime", "--seq", "9"],
+		);
+	});
+});
+
+describe("CliHerdrTransport", () => {
+	it("invokes the injected execFile with the herdr binary and reports ok", async () => {
+		const calls: Array<{ file: string; args: string[] }> = [];
+		const transport = new CliHerdrTransport({
+			binPath: "/opt/herdr",
+			execFileFn: (file, args, cb) => {
+				calls.push({ file, args });
+				cb(null);
+			},
+		});
+		const result = await transport.reportAgent({
+			paneId: "w1:p1",
+			source: "omx:runtime",
+			agent: "codex",
+			state: "working",
+			seq: 1,
+		});
+		assert.equal(result.ok, true);
+		assert.equal(calls[0].file, "/opt/herdr");
+		assert.equal(calls[0].args[1], "report-agent");
+	});
+
+	it("captures execFile errors without throwing", async () => {
+		const transport = new CliHerdrTransport({
+			execFileFn: (_file, _args, cb) => cb(new Error("herdr not found")),
+		});
+		const result = await transport.releaseAgent({
+			paneId: "w1:p1",
+			source: "omx:runtime",
+			seq: 1,
+		});
+		assert.equal(result.ok, false);
+		assert.match(result.error ?? "", /herdr not found/);
+	});
+});
+
+describe("SocketHerdrTransport", () => {
+	it("writes dot-notation NDJSON requests with seq", async () => {
+		const requests: SocketRequest[] = [];
+		const transport = new SocketHerdrTransport({
+			socketPath: "/tmp/herdr.sock",
+			writer: async (_path, request) => {
+				requests.push(request);
+			},
+		});
+		await transport.reportAgent({
+			paneId: "w1:p1",
+			source: "omx:runtime",
+			agent: "codex",
+			state: "blocked",
+			message: "needs input",
+			seq: 4,
+		});
+		await transport.releaseAgent({
+			paneId: "w1:p1",
+			source: "omx:runtime",
+			seq: 5,
+		});
+		assert.equal(requests[0].method, "pane.report_agent");
+		assert.deepEqual(requests[0].params, {
+			pane_id: "w1:p1",
+			source: "omx:runtime",
+			agent: "codex",
+			state: "blocked",
+			seq: 4,
+			message: "needs input",
+		});
+		assert.equal(requests[1].method, "pane.release_agent");
+		assert.equal(requests[1].params.seq, 5);
+	});
+
+	it("captures writer errors without throwing", async () => {
+		const transport = new SocketHerdrTransport({
+			socketPath: "/tmp/herdr.sock",
+			writer: async () => {
+				throw new Error("ECONNREFUSED");
+			},
+		});
+		const result = await transport.reportAgent({
+			paneId: "w1:p1",
+			source: "omx:runtime",
+			agent: "codex",
+			state: "idle",
+			seq: 1,
+		});
+		assert.equal(result.ok, false);
+		assert.match(result.error ?? "", /ECONNREFUSED/);
+	});
+});

--- a/src/adapt/herdr/__tests__/transport.test.ts
+++ b/src/adapt/herdr/__tests__/transport.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execPath } from "node:process";
 import { describe, it } from "node:test";
 import {
 	CliHerdrTransport,
@@ -6,7 +7,9 @@ import {
 	buildReleaseAgentArgs,
 	buildReportAgentArgs,
 	detectHerdrEnv,
+	resolveTrustedHerdrBin,
 	type SocketRequest,
+	type SocketResponse,
 } from "../transport.js";
 
 describe("herdr env detection", () => {
@@ -22,48 +25,28 @@ describe("herdr env detection", () => {
 			false,
 		);
 	});
-
-	it("captures socket and bin paths", () => {
-		const env = detectHerdrEnv({
-			HERDR_ENV: "1",
-			HERDR_PANE_ID: "w1:p1",
-			HERDR_SOCKET_PATH: "/tmp/herdr.sock",
-			HERDR_BIN_PATH: "/usr/bin/herdr",
-		});
-		assert.equal(env.paneId, "w1:p1");
-		assert.equal(env.socketPath, "/tmp/herdr.sock");
-		assert.equal(env.binPath, "/usr/bin/herdr");
-	});
 });
 
 describe("herdr CLI argv builders", () => {
 	it("builds shell-free, ordered report-agent argv with seq", () => {
-		const args = buildReportAgentArgs({
-			paneId: "w1:p1",
-			source: "omx:runtime",
-			agent: "codex",
-			state: "working",
-			message: "team: 3 workers active",
-			seq: 7,
-		});
-		assert.deepEqual(args, [
-			"pane",
-			"report-agent",
-			"w1:p1",
-			"--source",
-			"omx:runtime",
-			"--agent",
-			"codex",
-			"--state",
-			"working",
-			"--seq",
-			"7",
-			"--message",
-			"team: 3 workers active",
-		]);
+		assert.deepEqual(
+			buildReportAgentArgs({
+				paneId: "w1:p1",
+				source: "omx:runtime",
+				agent: "codex",
+				state: "working",
+				message: "team: 3 workers active",
+				seq: 7,
+			}),
+			[
+				"pane", "report-agent", "w1:p1", "--source", "omx:runtime",
+				"--agent", "codex", "--state", "working", "--seq", "7",
+				"--message", "team: 3 workers active",
+			],
+		);
 	});
 
-	it("omits an empty message and keeps injection-prone text as one argv token", () => {
+	it("keeps injection-prone text as one argv token and omits empty message", () => {
 		const args = buildReportAgentArgs({
 			paneId: "w1:p1; rm -rf /",
 			source: "omx:runtime",
@@ -71,7 +54,6 @@ describe("herdr CLI argv builders", () => {
 			state: "idle",
 			seq: 1,
 		});
-		// The dangerous pane id stays a single argv element; execFile never shells.
 		assert.equal(args[2], "w1:p1; rm -rf /");
 		assert.ok(!args.includes("--message"));
 	});
@@ -84,16 +66,46 @@ describe("herdr CLI argv builders", () => {
 	});
 });
 
-describe("CliHerdrTransport", () => {
-	it("invokes the injected execFile with the herdr binary and reports ok", async () => {
-		const calls: Array<{ file: string; args: string[] }> = [];
+describe("trust-pinned CLI resolution", () => {
+	it("accepts only an absolute existing file", () => {
+		assert.equal(resolveTrustedHerdrBin(execPath), execPath); // node binary is absolute+exists
+		assert.equal(resolveTrustedHerdrBin("herdr"), null); // bare PATH name rejected
+		assert.equal(resolveTrustedHerdrBin("/nonexistent/herdr"), null);
+		assert.equal(resolveTrustedHerdrBin(undefined), null);
+	});
+
+	it("does not execFile when no trusted binary is available", async () => {
+		let called = false;
 		const transport = new CliHerdrTransport({
-			binPath: "/opt/herdr",
-			execFileFn: (file, args, cb) => {
-				calls.push({ file, args });
+			binPath: "herdr",
+			execFileFn: (_f, _a, cb) => {
+				called = true;
 				cb(null);
 			},
 		});
+		assert.equal(transport.available, false);
+		const result = await transport.reportAgent({
+			paneId: "w1:p1",
+			source: "omx:runtime",
+			agent: "codex",
+			state: "working",
+			seq: 1,
+		});
+		assert.equal(result.ok, false);
+		assert.equal(called, false);
+		assert.match(result.error ?? "", /trust-pinned/);
+	});
+
+	it("invokes execFile with a trusted absolute binary", async () => {
+		const calls: string[][] = [];
+		const transport = new CliHerdrTransport({
+			binPath: execPath,
+			execFileFn: (_f, args, cb) => {
+				calls.push(args);
+				cb(null);
+			},
+		});
+		assert.equal(transport.available, true);
 		const result = await transport.reportAgent({
 			paneId: "w1:p1",
 			source: "omx:runtime",
@@ -102,65 +114,72 @@ describe("CliHerdrTransport", () => {
 			seq: 1,
 		});
 		assert.equal(result.ok, true);
-		assert.equal(calls[0].file, "/opt/herdr");
-		assert.equal(calls[0].args[1], "report-agent");
-	});
-
-	it("captures execFile errors without throwing", async () => {
-		const transport = new CliHerdrTransport({
-			execFileFn: (_file, _args, cb) => cb(new Error("herdr not found")),
-		});
-		const result = await transport.releaseAgent({
-			paneId: "w1:p1",
-			source: "omx:runtime",
-			seq: 1,
-		});
-		assert.equal(result.ok, false);
-		assert.match(result.error ?? "", /herdr not found/);
+		assert.equal(calls[0][1], "report-agent");
 	});
 });
 
-describe("SocketHerdrTransport", () => {
-	it("writes dot-notation NDJSON requests with seq", async () => {
-		const requests: SocketRequest[] = [];
-		const transport = new SocketHerdrTransport({
-			socketPath: "/tmp/herdr.sock",
-			writer: async (_path, request) => {
-				requests.push(request);
-			},
+describe("SocketHerdrTransport request/response correlation", () => {
+	function transportWith(
+		exchange: (path: string, req: SocketRequest) => Promise<SocketResponse>,
+	) {
+		return new SocketHerdrTransport({ socketPath: "/tmp/h.sock", exchange });
+	}
+
+	it("reports ok only on a correlated success reply and sends dot-notation + seq", async () => {
+		const seen: SocketRequest[] = [];
+		const transport = transportWith(async (_p, req) => {
+			seen.push(req);
+			return { id: req.id, result: { type: "pane_info" } };
 		});
-		await transport.reportAgent({
+		const result = await transport.reportAgent({
 			paneId: "w1:p1",
 			source: "omx:runtime",
 			agent: "codex",
 			state: "blocked",
 			message: "needs input",
 			seq: 4,
+			metadata: { summary: "review" },
 		});
-		await transport.releaseAgent({
+		assert.equal(result.ok, true);
+		assert.equal(seen[0].method, "pane.report_agent");
+		assert.equal(seen[0].params.seq, 4);
+		assert.equal(seen[0].params.message, "needs input");
+		assert.deepEqual(seen[0].params.tokens, { summary: "review" });
+	});
+
+	it("reports NOT ok when Herdr returns an error reply", async () => {
+		const transport = transportWith(async (_p, req) => ({
+			id: req.id,
+			error: { code: "not_found", message: "pane not found" },
+		}));
+		const result = await transport.releaseAgent({
 			paneId: "w1:p1",
 			source: "omx:runtime",
 			seq: 5,
 		});
-		assert.equal(requests[0].method, "pane.report_agent");
-		assert.deepEqual(requests[0].params, {
-			pane_id: "w1:p1",
-			source: "omx:runtime",
-			agent: "codex",
-			state: "blocked",
-			seq: 4,
-			message: "needs input",
-		});
-		assert.equal(requests[1].method, "pane.release_agent");
-		assert.equal(requests[1].params.seq, 5);
+		assert.equal(result.ok, false);
+		assert.match(result.error ?? "", /pane not found/);
 	});
 
-	it("captures writer errors without throwing", async () => {
-		const transport = new SocketHerdrTransport({
-			socketPath: "/tmp/herdr.sock",
-			writer: async () => {
-				throw new Error("ECONNREFUSED");
-			},
+	it("reports NOT ok on id mismatch", async () => {
+		const transport = transportWith(async () => ({
+			id: "someone-else",
+			result: {},
+		}));
+		const result = await transport.reportAgent({
+			paneId: "w1:p1",
+			source: "omx:runtime",
+			agent: "codex",
+			state: "idle",
+			seq: 1,
+		});
+		assert.equal(result.ok, false);
+		assert.match(result.detail, /mismatch/);
+	});
+
+	it("captures exchange errors (timeout/backpressure) without throwing", async () => {
+		const transport = transportWith(async () => {
+			throw new Error("herdr socket timeout");
 		});
 		const result = await transport.reportAgent({
 			paneId: "w1:p1",
@@ -170,6 +189,6 @@ describe("SocketHerdrTransport", () => {
 			seq: 1,
 		});
 		assert.equal(result.ok, false);
-		assert.match(result.error ?? "", /ECONNREFUSED/);
+		assert.match(result.error ?? "", /timeout/);
 	});
 });

--- a/src/adapt/herdr/__tests__/wiring.test.ts
+++ b/src/adapt/herdr/__tests__/wiring.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { buildNativeHookEvent } from "../../../hooks/extensibility/events.js";
+import { reportHerdrLifecycleEvent } from "../wiring.js";
+import type {
+	HerdrAgentReport,
+	HerdrReleaseReport,
+	HerdrTransport,
+	HerdrTransportResult,
+} from "../transport.js";
+
+class RecordingTransport implements HerdrTransport {
+	readonly kind = "cli" as const;
+	calls: Array<{ op: string; state?: string; seq: number }> = [];
+	async reportAgent(r: HerdrAgentReport): Promise<HerdrTransportResult> {
+		this.calls.push({ op: "report", state: r.state, seq: r.seq });
+		return { ok: true, transport: "cli", detail: "ok" };
+	}
+	async releaseAgent(r: HerdrReleaseReport): Promise<HerdrTransportResult> {
+		this.calls.push({ op: "release", seq: r.seq });
+		return { ok: true, transport: "cli", detail: "ok" };
+	}
+}
+
+let baseDir: string;
+let seq: number;
+beforeEach(async () => {
+	baseDir = await mkdtemp(join(tmpdir(), "omx-herdr-wiring-"));
+	seq = 0;
+});
+afterEach(async () => {
+	await rm(baseDir, { recursive: true, force: true });
+});
+
+const enabledEnv = {
+	enabled: true,
+	paneId: "w1:p1",
+	socketPath: null,
+	binPath: null,
+};
+
+describe("reportHerdrLifecycleEvent", () => {
+	it("is a no-op outside a Herdr pane", async () => {
+		const transport = new RecordingTransport();
+		const result = await reportHerdrLifecycleEvent({
+			cwd: baseDir,
+			event: buildNativeHookEvent("session-start"),
+			bridgeOptions: {
+				env: { enabled: false, paneId: null, socketPath: null, binPath: null },
+				transport,
+			},
+		});
+		assert.equal(result.wired, false);
+		assert.equal(result.reason, "herdr-not-detected");
+		assert.equal(transport.calls.length, 0);
+	});
+
+	it("reports a working transition for a working event", async () => {
+		const transport = new RecordingTransport();
+		const result = await reportHerdrLifecycleEvent({
+			cwd: baseDir,
+			event: buildNativeHookEvent("run.heartbeat"),
+			bridgeOptions: {
+				env: enabledEnv,
+				transport,
+				seqFn: () => ++seq,
+				stateBaseDir: baseDir,
+			},
+		});
+		assert.equal(result.wired, true);
+		assert.equal(result.state, "working");
+		assert.equal(transport.calls[0].op, "report");
+	});
+
+	it("reports blocked for a needs-input event", async () => {
+		const transport = new RecordingTransport();
+		const result = await reportHerdrLifecycleEvent({
+			cwd: baseDir,
+			event: buildNativeHookEvent("needs-input"),
+			bridgeOptions: {
+				env: enabledEnv,
+				transport,
+				seqFn: () => ++seq,
+				stateBaseDir: baseDir,
+			},
+		});
+		assert.equal(result.state, "blocked");
+	});
+
+	it("releases authority on whole-session shutdown", async () => {
+		const transport = new RecordingTransport();
+		const result = await reportHerdrLifecycleEvent({
+			cwd: baseDir,
+			event: buildNativeHookEvent("session-end"),
+			bridgeOptions: {
+				env: enabledEnv,
+				transport,
+				seqFn: () => ++seq,
+				stateBaseDir: baseDir,
+			},
+		});
+		assert.equal(result.state, "idle");
+		assert.equal(result.released, true);
+		assert.ok(transport.calls.some((c) => c.op === "release"));
+	});
+
+	it("never throws even if reporting fails internally", async () => {
+		const throwing: HerdrTransport = {
+			kind: "cli",
+			reportAgent: async () => {
+				throw new Error("kaboom");
+			},
+			releaseAgent: async () => ({ ok: true, transport: "cli", detail: "ok" }),
+		};
+		const result = await reportHerdrLifecycleEvent({
+			cwd: baseDir,
+			event: buildNativeHookEvent("run.heartbeat"),
+			bridgeOptions: {
+				env: enabledEnv,
+				transport: throwing,
+				seqFn: () => ++seq,
+				stateBaseDir: baseDir,
+			},
+		});
+		// The bridge captures the throw; wiring still returns wired:true with a failed report.
+		assert.equal(result.wired, true);
+	});
+});

--- a/src/adapt/herdr/authority.ts
+++ b/src/adapt/herdr/authority.ts
@@ -1,0 +1,117 @@
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { omxAdaptersDir } from "../../utils/paths.js";
+
+/**
+ * Tracks whether OMX currently holds Herdr `omx:runtime` authority for a pane,
+ * so release only fires when no OMX workflow remains active, and so a stale
+ * authority left by a crashed process can be reconciled on the next
+ * session-start.
+ */
+
+export interface AuthorityRecord {
+	pane_id: string;
+	source: string;
+	owner_pid: number;
+	session_id?: string;
+	acquired_at: string;
+	updated_at: string;
+}
+
+export interface AuthorityStoreOptions {
+	baseDir?: string;
+}
+
+function authorityPath(baseDir?: string): string {
+	return join(baseDir ?? join(omxAdaptersDir(), "herdr"), "authority.json");
+}
+
+export function readAuthority(
+	options: AuthorityStoreOptions = {},
+): AuthorityRecord | null {
+	try {
+		return JSON.parse(
+			readFileSync(authorityPath(options.baseDir), "utf-8"),
+		) as AuthorityRecord;
+	} catch {
+		return null;
+	}
+}
+
+function writeAuthorityAtomic(record: AuthorityRecord, baseDir?: string): void {
+	const path = authorityPath(baseDir);
+	mkdirSync(join(baseDir ?? join(omxAdaptersDir(), "herdr")), {
+		recursive: true,
+	});
+	const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+	writeFileSync(tmp, `${JSON.stringify(record, null, 2)}\n`, "utf-8");
+	renameSync(tmp, path);
+}
+
+export function recordAuthority(
+	record: Omit<AuthorityRecord, "acquired_at" | "updated_at"> &
+		Partial<Pick<AuthorityRecord, "acquired_at">>,
+	options: AuthorityStoreOptions = {},
+): void {
+	const now = new Date().toISOString();
+	const existing = readAuthority(options);
+	writeAuthorityAtomic(
+		{
+			...record,
+			acquired_at: record.acquired_at ?? existing?.acquired_at ?? now,
+			updated_at: now,
+		},
+		options.baseDir,
+	);
+}
+
+export function clearAuthority(options: AuthorityStoreOptions = {}): void {
+	const path = authorityPath(options.baseDir);
+	if (existsSync(path)) {
+		try {
+			rmSync(path);
+		} catch {
+			// best-effort
+		}
+	}
+}
+
+/**
+ * A liveness probe for the current owner process. Injectable for tests; the
+ * default checks whether the recorded pid is alive via `process.kill(pid, 0)`.
+ */
+export type PidLivenessProbe = (pid: number) => boolean;
+
+const defaultPidAlive: PidLivenessProbe = (pid) => {
+	if (!Number.isFinite(pid) || pid <= 0) return false;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		// ESRCH => no such process; EPERM => exists but not ours (treat as alive)
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+};
+
+/**
+ * Crash reconciliation: if an authority record exists but its owner process is
+ * no longer alive, clear it so Herdr returns to normal screen detection. Call
+ * on session-start. Returns true when a stale record was cleared.
+ */
+export function reconcileStaleAuthority(
+	options: AuthorityStoreOptions & { pidAlive?: PidLivenessProbe } = {},
+): boolean {
+	const record = readAuthority(options);
+	if (!record) return false;
+	const alive = (options.pidAlive ?? defaultPidAlive)(record.owner_pid);
+	if (alive) return false;
+	clearAuthority(options);
+	return true;
+}

--- a/src/adapt/herdr/bridge.ts
+++ b/src/adapt/herdr/bridge.ts
@@ -3,6 +3,11 @@ import type {
 	HookEventName,
 } from "../../hooks/extensibility/types.js";
 import {
+	clearAuthority,
+	recordAuthority,
+} from "./authority.js";
+import { sanitizeMessage, sanitizeMetadata } from "./sanitize.js";
+import {
 	type HerdrRollupInput,
 	type HerdrSemanticState,
 	type HerdrStateMapping,
@@ -10,6 +15,7 @@ import {
 	mapHookEventToHerdrState,
 	rollupTeamState,
 } from "./semantic.js";
+import { nextSeq as durableNextSeq } from "./seq-store.js";
 import {
 	CliHerdrTransport,
 	type HerdrEnv,
@@ -27,14 +33,23 @@ export interface HerdrBridgeOptions {
 	transport?: HerdrTransport;
 	source?: string;
 	agent?: string;
-	/** Optional best-effort logger; never throws into the OMX run. */
+	/** Injectable seq provider; defaults to the durable cross-process store. */
+	seqFn?: (source: string) => number;
+	/** Base dir for the durable seq/authority stores (tests). */
+	stateBaseDir?: string;
+	/**
+	 * Returns true when an OMX workflow other than this one remains active, so
+	 * release must be suppressed. Defaults to "nothing else active".
+	 */
+	workflowActiveFn?: () => boolean;
+	/** Best-effort logger; never throws into the OMX run. */
 	logger?: (message: string, meta?: Record<string, unknown>) => void;
+	/** Session id recorded on the authority record for crash reconciliation. */
+	sessionId?: string;
 }
 
 export interface HerdrBridgeOutcome {
-	/** True when the bridge attempted a report/release (i.e. inside Herdr). */
 	attempted: boolean;
-	/** True when the underlying transport call succeeded. */
 	ok: boolean;
 	skipped: boolean;
 	reason: string;
@@ -47,28 +62,38 @@ export interface HerdrBridgeOutcome {
 /**
  * Opt-in, best-effort OMX -> Herdr lifecycle/status bridge.
  *
- * Guarantees (issue #3241):
- * - No behavior change outside a detected Herdr pane (every op is a no-op when
- *   `env.enabled` is false).
- * - Ordered: a single monotonically increasing per-source seq is used for both
- *   report and release, so stale reports cannot win.
+ * - No behavior change outside a detected Herdr pane.
+ * - Ordered: seq comes from a durable cross-process per-source store, so stale
+ *   reports cannot win across concurrent hook processes or restarts.
  * - Non-blocking / failure-isolated: transport errors are captured and returned,
- *   never thrown, so a Herdr failure cannot fail the OMX run.
+ *   never thrown.
+ * - Release is gated on remaining active workflows and records/clears authority
+ *   for crash reconciliation.
  */
 export class HerdrBridge {
 	private readonly env: HerdrEnv;
 	private readonly transport: HerdrTransport | null;
 	private readonly source: string;
 	private readonly agent: string;
+	private readonly seqFn: (source: string) => number;
+	private readonly workflowActiveFn: () => boolean;
+	private readonly stateBaseDir?: string;
+	private readonly sessionId?: string;
 	private readonly logger?: HerdrBridgeOptions["logger"];
-	private seq = 0;
 	private released = false;
+	private authorityRecorded = false;
 
 	constructor(options: HerdrBridgeOptions = {}) {
 		this.env = options.env ?? detectHerdrEnv();
 		this.source = options.source ?? HERDR_BRIDGE_SOURCE;
 		this.agent = options.agent ?? HERDR_BRIDGE_AGENT;
+		this.stateBaseDir = options.stateBaseDir;
+		this.sessionId = options.sessionId;
 		this.logger = options.logger;
+		this.seqFn =
+			options.seqFn ??
+			((source) => durableNextSeq(source, { baseDir: this.stateBaseDir }));
+		this.workflowActiveFn = options.workflowActiveFn ?? (() => false);
 		this.transport = this.env.enabled
 			? (options.transport ?? defaultTransport(this.env))
 			: (options.transport ?? null);
@@ -78,17 +103,14 @@ export class HerdrBridge {
 		return this.env.enabled;
 	}
 
-	/** Next monotonic sequence value; shared across report and release. */
 	private nextSeq(): number {
-		this.seq += 1;
-		return this.seq;
+		return this.seqFn(this.source);
 	}
 
 	private skip(reason: string): HerdrBridgeOutcome {
 		return { attempted: false, ok: false, skipped: true, reason };
 	}
 
-	/** Report a Herdr semantic state directly. */
 	async reportState(
 		state: HerdrSemanticState,
 		options: { message?: string; metadata?: Record<string, string> } = {},
@@ -97,17 +119,20 @@ export class HerdrBridge {
 			return this.skip("herdr-not-detected");
 		}
 		const seq = this.nextSeq();
+		const message = sanitizeMessage(options.message);
+		const metadata = sanitizeMetadata(options.metadata);
 		try {
 			const result = await this.transport.reportAgent({
 				paneId: this.env.paneId,
 				source: this.source,
 				agent: this.agent,
 				state,
-				message: options.message,
-				metadata: options.metadata,
+				message,
+				metadata,
 				seq,
 			});
-			if (!result.ok) this.log("herdr report failed", { state, seq, result });
+			if (result.ok) this.ensureAuthorityRecorded();
+			else this.log("herdr report failed", { state, seq, result });
 			return {
 				attempted: true,
 				ok: result.ok,
@@ -118,7 +143,6 @@ export class HerdrBridge {
 				transport: result,
 			};
 		} catch (error) {
-			// Failure isolation: never propagate into the OMX run.
 			const message = error instanceof Error ? error.message : String(error);
 			this.log("herdr report threw", { state, seq, error: message });
 			return {
@@ -132,10 +156,6 @@ export class HerdrBridge {
 		}
 	}
 
-	/**
-	 * Map an OMX hook lifecycle event to a Herdr state and report it. If the
-	 * event is terminal, release Herdr authority afterward.
-	 */
 	async reportHookEvent(
 		event: HookEventEnvelope | HookEventName | string,
 		options: { message?: string; metadata?: Record<string, string> } = {},
@@ -153,7 +173,6 @@ export class HerdrBridge {
 		return outcome;
 	}
 
-	/** Report an authoritative Team rollup state. */
 	async reportTeamRollup(
 		input: HerdrRollupInput,
 		options: { metadata?: Record<string, string> } = {},
@@ -167,8 +186,9 @@ export class HerdrBridge {
 	}
 
 	/**
-	 * Release `omx:runtime` authority so Herdr returns to normal Codex screen
-	 * detection. Idempotent and safe to call on shutdown/exit.
+	 * Release `omx:runtime` authority. Suppressed while another OMX workflow
+	 * remains active (a single terminal event must not release authority for
+	 * still-running workflows). Clears the authority record on release.
 	 */
 	async release(): Promise<HerdrBridgeOutcome> {
 		if (!this.env.enabled || !this.env.paneId || !this.transport) {
@@ -176,6 +196,14 @@ export class HerdrBridge {
 		}
 		if (this.released) {
 			return { attempted: false, ok: true, skipped: true, reason: "already-released" };
+		}
+		if (this.workflowActiveFn()) {
+			return {
+				attempted: false,
+				ok: true,
+				skipped: true,
+				reason: "workflow-still-active",
+			};
 		}
 		const seq = this.nextSeq();
 		try {
@@ -185,6 +213,7 @@ export class HerdrBridge {
 				seq,
 			});
 			this.released = true;
+			this.clearAuthorityRecord();
 			if (!result.ok) this.log("herdr release failed", { seq, result });
 			return {
 				attempted: true,
@@ -198,8 +227,8 @@ export class HerdrBridge {
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			this.log("herdr release threw", { seq, error: message });
-			// Mark released so shutdown does not spin retrying a broken transport.
 			this.released = true;
+			this.clearAuthorityRecord();
 			return {
 				attempted: true,
 				ok: false,
@@ -208,6 +237,34 @@ export class HerdrBridge {
 				seq,
 				released: true,
 			};
+		}
+	}
+
+	private ensureAuthorityRecorded(): void {
+		if (this.authorityRecorded || !this.env.paneId) return;
+		this.authorityRecorded = true;
+		try {
+			recordAuthority(
+				{
+					pane_id: this.env.paneId,
+					source: this.source,
+					owner_pid: process.pid,
+					session_id: this.sessionId,
+				},
+				{ baseDir: this.stateBaseDir },
+			);
+		} catch (error) {
+			this.log("herdr authority record failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
+	private clearAuthorityRecord(): void {
+		try {
+			clearAuthority({ baseDir: this.stateBaseDir });
+		} catch {
+			// best-effort
 		}
 	}
 
@@ -227,9 +284,6 @@ function defaultTransport(env: HerdrEnv): HerdrTransport {
 	return new CliHerdrTransport({ binPath: env.binPath });
 }
 
-/** Convenience factory honoring the opt-in environment gate. */
-export function createHerdrBridge(
-	options: HerdrBridgeOptions = {},
-): HerdrBridge {
+export function createHerdrBridge(options: HerdrBridgeOptions = {}): HerdrBridge {
 	return new HerdrBridge(options);
 }

--- a/src/adapt/herdr/bridge.ts
+++ b/src/adapt/herdr/bridge.ts
@@ -1,0 +1,235 @@
+import type {
+	HookEventEnvelope,
+	HookEventName,
+} from "../../hooks/extensibility/types.js";
+import {
+	type HerdrRollupInput,
+	type HerdrSemanticState,
+	type HerdrStateMapping,
+	isTerminalHookEvent,
+	mapHookEventToHerdrState,
+	rollupTeamState,
+} from "./semantic.js";
+import {
+	CliHerdrTransport,
+	type HerdrEnv,
+	type HerdrTransport,
+	type HerdrTransportResult,
+	SocketHerdrTransport,
+	detectHerdrEnv,
+} from "./transport.js";
+
+export const HERDR_BRIDGE_SOURCE = "omx:runtime";
+export const HERDR_BRIDGE_AGENT = "codex";
+
+export interface HerdrBridgeOptions {
+	env?: HerdrEnv;
+	transport?: HerdrTransport;
+	source?: string;
+	agent?: string;
+	/** Optional best-effort logger; never throws into the OMX run. */
+	logger?: (message: string, meta?: Record<string, unknown>) => void;
+}
+
+export interface HerdrBridgeOutcome {
+	/** True when the bridge attempted a report/release (i.e. inside Herdr). */
+	attempted: boolean;
+	/** True when the underlying transport call succeeded. */
+	ok: boolean;
+	skipped: boolean;
+	reason: string;
+	state?: HerdrSemanticState;
+	seq?: number;
+	released?: boolean;
+	transport?: HerdrTransportResult;
+}
+
+/**
+ * Opt-in, best-effort OMX -> Herdr lifecycle/status bridge.
+ *
+ * Guarantees (issue #3241):
+ * - No behavior change outside a detected Herdr pane (every op is a no-op when
+ *   `env.enabled` is false).
+ * - Ordered: a single monotonically increasing per-source seq is used for both
+ *   report and release, so stale reports cannot win.
+ * - Non-blocking / failure-isolated: transport errors are captured and returned,
+ *   never thrown, so a Herdr failure cannot fail the OMX run.
+ */
+export class HerdrBridge {
+	private readonly env: HerdrEnv;
+	private readonly transport: HerdrTransport | null;
+	private readonly source: string;
+	private readonly agent: string;
+	private readonly logger?: HerdrBridgeOptions["logger"];
+	private seq = 0;
+	private released = false;
+
+	constructor(options: HerdrBridgeOptions = {}) {
+		this.env = options.env ?? detectHerdrEnv();
+		this.source = options.source ?? HERDR_BRIDGE_SOURCE;
+		this.agent = options.agent ?? HERDR_BRIDGE_AGENT;
+		this.logger = options.logger;
+		this.transport = this.env.enabled
+			? (options.transport ?? defaultTransport(this.env))
+			: (options.transport ?? null);
+	}
+
+	get enabled(): boolean {
+		return this.env.enabled;
+	}
+
+	/** Next monotonic sequence value; shared across report and release. */
+	private nextSeq(): number {
+		this.seq += 1;
+		return this.seq;
+	}
+
+	private skip(reason: string): HerdrBridgeOutcome {
+		return { attempted: false, ok: false, skipped: true, reason };
+	}
+
+	/** Report a Herdr semantic state directly. */
+	async reportState(
+		state: HerdrSemanticState,
+		options: { message?: string; metadata?: Record<string, string> } = {},
+	): Promise<HerdrBridgeOutcome> {
+		if (!this.env.enabled || !this.env.paneId || !this.transport) {
+			return this.skip("herdr-not-detected");
+		}
+		const seq = this.nextSeq();
+		try {
+			const result = await this.transport.reportAgent({
+				paneId: this.env.paneId,
+				source: this.source,
+				agent: this.agent,
+				state,
+				message: options.message,
+				metadata: options.metadata,
+				seq,
+			});
+			if (!result.ok) this.log("herdr report failed", { state, seq, result });
+			return {
+				attempted: true,
+				ok: result.ok,
+				skipped: false,
+				reason: result.detail,
+				state,
+				seq,
+				transport: result,
+			};
+		} catch (error) {
+			// Failure isolation: never propagate into the OMX run.
+			const message = error instanceof Error ? error.message : String(error);
+			this.log("herdr report threw", { state, seq, error: message });
+			return {
+				attempted: true,
+				ok: false,
+				skipped: false,
+				reason: `report threw: ${message}`,
+				state,
+				seq,
+			};
+		}
+	}
+
+	/**
+	 * Map an OMX hook lifecycle event to a Herdr state and report it. If the
+	 * event is terminal, release Herdr authority afterward.
+	 */
+	async reportHookEvent(
+		event: HookEventEnvelope | HookEventName | string,
+		options: { message?: string; metadata?: Record<string, string> } = {},
+	): Promise<HerdrBridgeOutcome> {
+		if (!this.env.enabled) return this.skip("herdr-not-detected");
+		const mapping: HerdrStateMapping = mapHookEventToHerdrState(event);
+		const outcome = await this.reportState(mapping.state, {
+			message: options.message ?? mapping.reason,
+			metadata: options.metadata,
+		});
+		if (isTerminalHookEvent(event)) {
+			const release = await this.release();
+			return { ...outcome, released: release.released ?? release.ok };
+		}
+		return outcome;
+	}
+
+	/** Report an authoritative Team rollup state. */
+	async reportTeamRollup(
+		input: HerdrRollupInput,
+		options: { metadata?: Record<string, string> } = {},
+	): Promise<HerdrBridgeOutcome> {
+		if (!this.env.enabled) return this.skip("herdr-not-detected");
+		const rollup = rollupTeamState(input);
+		return this.reportState(rollup.state, {
+			message: rollup.reason,
+			metadata: options.metadata,
+		});
+	}
+
+	/**
+	 * Release `omx:runtime` authority so Herdr returns to normal Codex screen
+	 * detection. Idempotent and safe to call on shutdown/exit.
+	 */
+	async release(): Promise<HerdrBridgeOutcome> {
+		if (!this.env.enabled || !this.env.paneId || !this.transport) {
+			return this.skip("herdr-not-detected");
+		}
+		if (this.released) {
+			return { attempted: false, ok: true, skipped: true, reason: "already-released" };
+		}
+		const seq = this.nextSeq();
+		try {
+			const result = await this.transport.releaseAgent({
+				paneId: this.env.paneId,
+				source: this.source,
+				seq,
+			});
+			this.released = true;
+			if (!result.ok) this.log("herdr release failed", { seq, result });
+			return {
+				attempted: true,
+				ok: result.ok,
+				skipped: false,
+				reason: result.detail,
+				seq,
+				released: true,
+				transport: result,
+			};
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			this.log("herdr release threw", { seq, error: message });
+			// Mark released so shutdown does not spin retrying a broken transport.
+			this.released = true;
+			return {
+				attempted: true,
+				ok: false,
+				skipped: false,
+				reason: `release threw: ${message}`,
+				seq,
+				released: true,
+			};
+		}
+	}
+
+	private log(message: string, meta?: Record<string, unknown>): void {
+		try {
+			this.logger?.(message, meta);
+		} catch {
+			// A misbehaving logger must not break the bridge.
+		}
+	}
+}
+
+function defaultTransport(env: HerdrEnv): HerdrTransport {
+	if (env.socketPath) {
+		return new SocketHerdrTransport({ socketPath: env.socketPath });
+	}
+	return new CliHerdrTransport({ binPath: env.binPath });
+}
+
+/** Convenience factory honoring the opt-in environment gate. */
+export function createHerdrBridge(
+	options: HerdrBridgeOptions = {},
+): HerdrBridge {
+	return new HerdrBridge(options);
+}

--- a/src/adapt/herdr/sanitize.ts
+++ b/src/adapt/herdr/sanitize.ts
@@ -1,0 +1,72 @@
+/**
+ * Bound and redact operator/agent text before it crosses the OMX -> Herdr
+ * boundary. OMX lifecycle context can contain prompts, source text, absolute
+ * paths, and secrets; none of that should be shipped verbatim to Herdr's
+ * display surfaces. Applied to the semantic `message` and to display-only
+ * metadata tokens.
+ */
+
+export const MAX_MESSAGE_LEN = 120;
+export const MAX_TOKEN_KEY_LEN = 32;
+export const MAX_TOKEN_VALUE_LEN = 80;
+export const MAX_TOKENS = 16;
+
+const SECRET_KEY_PATTERN =
+	/(secret|token|password|passwd|api[_-]?key|authorization|bearer|credential|private[_-]?key|access[_-]?key)/i;
+const SECRET_VALUE_PATTERN =
+	/(bearer\s+[a-z0-9._-]+|sk-[a-z0-9]{8,}|gh[pousr]_[a-z0-9]{8,}|eyj[a-z0-9._-]{10,}|[a-f0-9]{32,})/i;
+const ABS_PATH_PATTERN = /(?:\/[^\s:]+){2,}|[a-zA-Z]:\\[^\s]+/g;
+
+function collapseWhitespace(value: string): string {
+	return value.replace(/[\r\n\t]+/g, " ").replace(/\s{2,}/g, " ").trim();
+}
+
+function redactPaths(value: string): string {
+	return value.replace(ABS_PATH_PATTERN, "[path]");
+}
+
+/** Sanitize a semantic message: collapse whitespace, redact paths/secrets, cap length. */
+export function sanitizeMessage(
+	message: string | undefined,
+	maxLen = MAX_MESSAGE_LEN,
+): string | undefined {
+	if (message === undefined) return undefined;
+	let out = collapseWhitespace(message);
+	if (out.length === 0) return undefined;
+	if (SECRET_VALUE_PATTERN.test(out)) out = "[redacted]";
+	out = redactPaths(out);
+	if (out.length > maxLen) out = `${out.slice(0, maxLen - 1)}…`;
+	return out;
+}
+
+/**
+ * Sanitize display-only metadata tokens: cap key/value length and token count,
+ * drop secret-like keys/values, redact absolute paths. Returns undefined when
+ * nothing survives.
+ */
+export function sanitizeMetadata(
+	metadata: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+	if (!metadata) return undefined;
+	const out: Record<string, string> = {};
+	let count = 0;
+	for (const [rawKey, rawValue] of Object.entries(metadata)) {
+		if (count >= MAX_TOKENS) break;
+		if (typeof rawValue !== "string") continue;
+		const key = rawKey.slice(0, MAX_TOKEN_KEY_LEN);
+		if (SECRET_KEY_PATTERN.test(key)) continue;
+		let value = collapseWhitespace(rawValue);
+		if (value.length === 0) continue;
+		if (SECRET_VALUE_PATTERN.test(value)) {
+			value = "[redacted]";
+		} else {
+			value = redactPaths(value);
+		}
+		if (value.length > MAX_TOKEN_VALUE_LEN) {
+			value = `${value.slice(0, MAX_TOKEN_VALUE_LEN - 1)}…`;
+		}
+		out[key] = value;
+		count += 1;
+	}
+	return Object.keys(out).length > 0 ? out : undefined;
+}

--- a/src/adapt/herdr/semantic.ts
+++ b/src/adapt/herdr/semantic.ts
@@ -59,14 +59,12 @@ const IDLE_EVENTS = new Set<string>([
 
 /**
  * OMX lifecycle events after which OMX should release `omx:runtime` authority so
- * Herdr can safely return to its normal Codex screen detection.
+ * Herdr can safely return to its normal Codex screen detection. Only whole-
+ * session shutdown releases authority; per-run `finished`/`failed` map to `idle`
+ * without releasing, because a single run ending does not mean OMX has left the
+ * pane.
  */
-const TERMINAL_EVENTS = new Set<string>([
-	"finished",
-	"failed",
-	"stop",
-	"session-end",
-]);
+const TERMINAL_EVENTS = new Set<string>(["stop", "session-end"]);
 
 export interface HerdrStateMapping {
 	state: HerdrSemanticState;

--- a/src/adapt/herdr/semantic.ts
+++ b/src/adapt/herdr/semantic.ts
@@ -1,0 +1,242 @@
+import type {
+	HookEventEnvelope,
+	HookEventName,
+} from "../../hooks/extensibility/types.js";
+
+/**
+ * Herdr semantic agent states, as documented by the official Herdr socket/CLI
+ * protocol (herdr.dev/docs/agents, /docs/socket-api). `state` is semantic: it
+ * drives Herdr waits, notifications, and workspace rollups. Display-only detail
+ * is carried separately as metadata tokens.
+ */
+export const HERDR_SEMANTIC_STATES = [
+	"working",
+	"blocked",
+	"idle",
+	"unknown",
+] as const;
+export type HerdrSemanticState = (typeof HERDR_SEMANTIC_STATES)[number];
+
+/**
+ * OMX hook lifecycle events that map to Herdr `working`. These represent an
+ * active turn, an active workflow, or active workers/tasks.
+ */
+const WORKING_EVENTS = new Set<string>([
+	"session-start",
+	"run.heartbeat",
+	"worker.assigned",
+	"worker.recovered",
+	"test-started",
+	"pre-tool-use",
+	"post-tool-use",
+]);
+
+/**
+ * OMX hook lifecycle events that map to Herdr `blocked`. These represent an
+ * approval, question, or user decision that OMX is waiting on.
+ */
+const BLOCKED_EVENTS = new Set<string>([
+	"blocked",
+	"run.blocked_on_user",
+	"run.blocked_on_system",
+	"needs-input",
+	"handoff-needed",
+]);
+
+/**
+ * OMX hook lifecycle events that map to Herdr `idle`. These represent a turn,
+ * workflow, or session reaching a terminal or resting state. Herdr derives its
+ * own `done`/seen behavior from `idle`.
+ */
+const IDLE_EVENTS = new Set<string>([
+	"turn-complete",
+	"finished",
+	"failed",
+	"stop",
+	"session-end",
+	"session-idle",
+]);
+
+/**
+ * OMX lifecycle events after which OMX should release `omx:runtime` authority so
+ * Herdr can safely return to its normal Codex screen detection.
+ */
+const TERMINAL_EVENTS = new Set<string>([
+	"finished",
+	"failed",
+	"stop",
+	"session-end",
+]);
+
+export interface HerdrStateMapping {
+	state: HerdrSemanticState;
+	/** Whether OMX should release Herdr authority after reporting this state. */
+	terminal: boolean;
+	/** Short, non-authoritative rationale for the mapping decision. */
+	reason: string;
+}
+
+/**
+ * Map a single OMX hook lifecycle event to a Herdr semantic state. Unknown or
+ * unmapped events resolve to `unknown` rather than guessing, matching the issue
+ * requirement that reconciliation-uncertain state is reported as `unknown`.
+ */
+export function mapHookEventToHerdrState(
+	event: HookEventEnvelope | HookEventName | string,
+): HerdrStateMapping {
+	const name = typeof event === "string" ? event : event.event;
+
+	if (BLOCKED_EVENTS.has(name)) {
+		return {
+			state: "blocked",
+			terminal: false,
+			reason: `OMX event '${name}' requires user/system attention.`,
+		};
+	}
+	if (WORKING_EVENTS.has(name)) {
+		return {
+			state: "working",
+			terminal: false,
+			reason: `OMX event '${name}' indicates active work.`,
+		};
+	}
+	if (IDLE_EVENTS.has(name)) {
+		return {
+			state: "idle",
+			terminal: TERMINAL_EVENTS.has(name),
+			reason: `OMX event '${name}' reached a terminal/resting state.`,
+		};
+	}
+
+	return {
+		state: "unknown",
+		terminal: false,
+		reason: `OMX event '${name}' has no authoritative Herdr mapping.`,
+	};
+}
+
+export function isTerminalHookEvent(
+	event: HookEventEnvelope | HookEventName | string,
+): boolean {
+	const name = typeof event === "string" ? event : event.event;
+	return TERMINAL_EVENTS.has(name);
+}
+
+export type HerdrWorkerState =
+	| "working"
+	| "blocked"
+	| "done"
+	| "failed"
+	| "idle"
+	| "unknown";
+
+export interface HerdrRollupWorker {
+	id: string;
+	state: HerdrWorkerState;
+	/**
+	 * True when this worker/task is blocked specifically on user action. Only
+	 * user-blocking workers escalate the rollup to `blocked`; a worker blocked on
+	 * the system alone does not make the whole pane look blocked.
+	 */
+	blockedOnUser?: boolean;
+}
+
+export interface HerdrRollupInput {
+	/** The leader (or a workflow) is waiting on a user decision. */
+	leaderBlockedOnUser?: boolean;
+	workers: HerdrRollupWorker[];
+	/** The whole run has reached a terminal outcome. */
+	runTerminal?: boolean;
+}
+
+export interface HerdrRollupResult {
+	state: HerdrSemanticState;
+	reason: string;
+	counts: {
+		total: number;
+		working: number;
+		blocked: number;
+		blockedOnUser: number;
+		done: number;
+		failed: number;
+		idle: number;
+		unknown: number;
+	};
+}
+
+/**
+ * Roll up authoritative OMX Team worker/task state into a single Herdr semantic
+ * state, rather than relying on Herdr's pane-output inference.
+ *
+ * Precedence, per issue #3241:
+ *   1. `blocked` if the leader needs user input or an authoritative worker/task
+ *      is blocked on user action.
+ *   2. otherwise `working` while any worker/task is active.
+ *   3. otherwise `idle` when the run is terminal (or nothing is active).
+ */
+export function rollupTeamState(input: HerdrRollupInput): HerdrRollupResult {
+	const counts = {
+		total: input.workers.length,
+		working: 0,
+		blocked: 0,
+		blockedOnUser: 0,
+		done: 0,
+		failed: 0,
+		idle: 0,
+		unknown: 0,
+	};
+
+	for (const worker of input.workers) {
+		switch (worker.state) {
+			case "working":
+				counts.working += 1;
+				break;
+			case "blocked":
+				counts.blocked += 1;
+				if (worker.blockedOnUser !== false) counts.blockedOnUser += 1;
+				break;
+			case "done":
+				counts.done += 1;
+				break;
+			case "failed":
+				counts.failed += 1;
+				break;
+			case "idle":
+				counts.idle += 1;
+				break;
+			default:
+				counts.unknown += 1;
+				break;
+		}
+	}
+
+	if (input.leaderBlockedOnUser) {
+		return {
+			state: "blocked",
+			reason: "Leader is blocked on user action.",
+			counts,
+		};
+	}
+	if (counts.blockedOnUser > 0) {
+		return {
+			state: "blocked",
+			reason: `${counts.blockedOnUser} worker/task blocked on user action.`,
+			counts,
+		};
+	}
+	if (counts.working > 0) {
+		return {
+			state: "working",
+			reason: `${counts.working} worker/task active.`,
+			counts,
+		};
+	}
+
+	return {
+		state: "idle",
+		reason: input.runTerminal
+			? "Run reached a terminal state; no active workers."
+			: "No active or user-blocked workers.",
+		counts,
+	};
+}

--- a/src/adapt/herdr/seq-store.ts
+++ b/src/adapt/herdr/seq-store.ts
@@ -1,0 +1,173 @@
+import {
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmdirSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { omxAdaptersDir } from "../../utils/paths.js";
+
+/**
+ * Durable, atomic, per-source monotonic sequence store for Herdr reports.
+ *
+ * Herdr accepts but ignores a report whose `seq <= last accepted seq for the
+ * same source`. Hooks run as short-lived processes, so an in-memory counter
+ * resets to 1 on every process/restart and would (a) let legitimate new reports
+ * be rejected as stale after a restart and (b) fail to prevent stale reports
+ * across concurrent processes. This store persists the counter under
+ * `.omx/adapters/herdr/seq/<sanitized-source>.json` and serializes concurrent
+ * increments with an atomic mkdir lock, so seq is strictly increasing per source
+ * across processes and restarts.
+ */
+
+export interface SeqStoreOptions {
+	/** Base `.omx/adapters/herdr` dir; defaults to the resolved OMX adapters dir. */
+	baseDir?: string;
+	/** Max time to wait for the lock before giving up (best-effort). */
+	lockTimeoutMs?: number;
+	/** Consider a held lock stale after this age (crash recovery). */
+	lockStaleMs?: number;
+}
+
+const DEFAULT_LOCK_TIMEOUT_MS = 2000;
+const DEFAULT_LOCK_STALE_MS = 10_000;
+const MAX_SEQ = Number.MAX_SAFE_INTEGER;
+
+function herdrSeqDir(baseDir?: string): string {
+	return join(baseDir ?? join(omxAdaptersDir(), "herdr"), "seq");
+}
+
+/** Filesystem-safe, collision-resistant file stem for a source id. */
+export function sanitizeSourceKey(source: string): string {
+	const cleaned = source.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 80);
+	return cleaned.length > 0 ? cleaned : "unknown-source";
+}
+
+function counterPath(baseDir: string | undefined, source: string): string {
+	return join(herdrSeqDir(baseDir), `${sanitizeSourceKey(source)}.json`);
+}
+
+function lockPath(baseDir: string | undefined, source: string): string {
+	return join(herdrSeqDir(baseDir), `${sanitizeSourceKey(source)}.lock`);
+}
+
+function readCounter(path: string): number {
+	try {
+		const raw = readFileSync(path, "utf-8");
+		const parsed = JSON.parse(raw) as { seq?: unknown };
+		const value = typeof parsed.seq === "number" ? parsed.seq : 0;
+		return Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0;
+	} catch {
+		// Missing or corrupt counter: restart from 0 (first seq will be 1).
+		return 0;
+	}
+}
+
+function writeCounterAtomic(path: string, seq: number): void {
+	const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+	writeFileSync(
+		tmp,
+		`${JSON.stringify({ seq, updated_at: new Date().toISOString() })}\n`,
+		"utf-8",
+	);
+	renameSync(tmp, path);
+}
+
+function acquireLock(lock: string, timeoutMs: number, staleMs: number): boolean {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		try {
+			mkdirSync(lock, { recursive: false });
+			return true;
+		} catch {
+			// Lock held: break it if stale, otherwise spin until the deadline.
+			try {
+				const age = Date.now() - statSync(lock).mtimeMs;
+				if (age > staleMs) {
+					try {
+						rmdirSync(lock);
+					} catch {
+						// another process broke it first; retry
+					}
+					continue;
+				}
+			} catch {
+				// lock vanished between mkdir and stat; retry
+			}
+			if (Date.now() >= deadline) return false;
+			busyWait(5);
+		}
+	}
+}
+
+function releaseLock(lock: string): void {
+	try {
+		rmdirSync(lock);
+	} catch {
+		// already released
+	}
+}
+
+/** Small synchronous sleep so the lock loop stays sync (hooks call this inline). */
+function busyWait(ms: number): void {
+	const until = Date.now() + ms;
+	while (Date.now() < until) {
+		// intentional short spin; ms is tiny (single-digit)
+	}
+}
+
+/**
+ * Atomically read-increment-persist the per-source counter and return the new
+ * seq. Strictly increasing and unique per source across concurrent processes
+ * and restarts. Falls back to a time-derived seq only if the lock cannot be
+ * acquired, so a report is never dropped and never regresses below the last
+ * persisted value.
+ */
+export function nextSeq(source: string, options: SeqStoreOptions = {}): number {
+	const dir = herdrSeqDir(options.baseDir);
+	try {
+		mkdirSync(dir, { recursive: true });
+	} catch {
+		// If we cannot even create the dir, fall back to a time-derived seq.
+		return timeDerivedSeq();
+	}
+
+	const path = counterPath(options.baseDir, source);
+	const lock = lockPath(options.baseDir, source);
+	const acquired = acquireLock(
+		lock,
+		options.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS,
+		options.lockStaleMs ?? DEFAULT_LOCK_STALE_MS,
+	);
+
+	if (!acquired) {
+		// Best-effort: never block the OMX run on lock contention.
+		return timeDerivedSeq(readCounter(path));
+	}
+
+	try {
+		const current = readCounter(path);
+		const next = current >= MAX_SEQ ? current : current + 1;
+		writeCounterAtomic(path, next);
+		return next;
+	} finally {
+		releaseLock(lock);
+	}
+}
+
+/**
+ * Monotonic-ish fallback derived from wall clock, floored above any known
+ * persisted value so it cannot regress below the last accepted seq.
+ */
+function timeDerivedSeq(floor = 0): number {
+	return Math.max(floor + 1, Date.now());
+}
+
+export function readPersistedSeq(
+	source: string,
+	options: SeqStoreOptions = {},
+): number {
+	return readCounter(counterPath(options.baseDir, source));
+}

--- a/src/adapt/herdr/team-map.ts
+++ b/src/adapt/herdr/team-map.ts
@@ -1,0 +1,65 @@
+import type { HerdrRollupInput, HerdrWorkerState } from "./semantic.js";
+
+/**
+ * Minimal authoritative Team-state shape consumed by the Herdr rollup. This
+ * intentionally mirrors the real OMX Team state surfaces
+ * (`WorkerStatus.state` from `src/team/state.ts` and the leader attention flag
+ * `leader_attention_pending` from the team leader-attention state) rather than
+ * inventing a bespoke shape.
+ */
+export interface TeamWorkerStateInput {
+	id: string;
+	/** WorkerStatus.state from src/team/state.ts */
+	state: "idle" | "working" | "blocked" | "done" | "failed" | "draining" | "unknown";
+	/** WorkerStatus.reason, used to detect user-blocking. */
+	reason?: string;
+}
+
+export interface TeamStateInput {
+	/** leader_attention_pending from the team leader-attention state. */
+	leaderAttentionPending?: boolean;
+	workers: TeamWorkerStateInput[];
+	runTerminal?: boolean;
+}
+
+const USER_BLOCK_REASON = /(user|input|approval|permission|decision|confirm|review)/i;
+
+function mapWorkerState(
+	state: TeamWorkerStateInput["state"],
+): HerdrWorkerState {
+	switch (state) {
+		case "draining":
+			// Winding down but still active work; treat as working for rollup.
+			return "working";
+		case "idle":
+		case "working":
+		case "blocked":
+		case "done":
+		case "failed":
+			return state;
+		default:
+			return "unknown";
+	}
+}
+
+/**
+ * Map real authoritative Team state into the Herdr rollup input. The leader
+ * attention flag is the authoritative user-block signal; a worker marked
+ * `blocked` only counts as user-blocking when its reason indicates a user
+ * decision, so a system-blocked worker does not force the whole pane to look
+ * blocked.
+ */
+export function mapTeamStateToRollup(state: TeamStateInput): HerdrRollupInput {
+	return {
+		leaderBlockedOnUser: state.leaderAttentionPending === true,
+		runTerminal: state.runTerminal,
+		workers: state.workers.map((worker) => ({
+			id: worker.id,
+			state: mapWorkerState(worker.state),
+			blockedOnUser:
+				worker.state === "blocked"
+					? USER_BLOCK_REASON.test(worker.reason ?? "")
+					: undefined,
+		})),
+	};
+}

--- a/src/adapt/herdr/transport.ts
+++ b/src/adapt/herdr/transport.ts
@@ -1,5 +1,7 @@
 import { execFile } from "node:child_process";
+import { statSync } from "node:fs";
 import { createConnection } from "node:net";
+import { isAbsolute } from "node:path";
 import type { HerdrSemanticState } from "./semantic.js";
 
 /**
@@ -15,9 +17,7 @@ export interface HerdrEnv {
 	binPath: string | null;
 }
 
-export function detectHerdrEnv(
-	env: NodeJS.ProcessEnv = process.env,
-): HerdrEnv {
+export function detectHerdrEnv(env: NodeJS.ProcessEnv = process.env): HerdrEnv {
 	const paneId = nonEmpty(env.HERDR_PANE_ID);
 	const enabled = env.HERDR_ENV === "1" && paneId !== null;
 	return {
@@ -40,13 +40,7 @@ export interface HerdrAgentReport {
 	agent: string;
 	state: HerdrSemanticState;
 	message?: string;
-	/**
-	 * Monotonically increasing per-source sequence. Herdr accepts but ignores a
-	 * report whose seq is <= the last accepted seq for the same source, so stale
-	 * reports cannot overwrite newer state.
-	 */
 	seq: number;
-	/** Display-only metadata tokens (pane.report_metadata). */
 	metadata?: Record<string, string>;
 }
 
@@ -75,10 +69,7 @@ type ExecFileFn = (
 	callback: (error: Error | null) => void,
 ) => void;
 
-/**
- * Build argv for `herdr pane report-agent`. argv is passed directly to execFile
- * (no shell), so pane ids, messages, and metadata cannot inject shell syntax.
- */
+/** Build argv for `herdr pane report-agent` (no shell; execFile argv array). */
 export function buildReportAgentArgs(report: HerdrAgentReport): string[] {
 	const args = [
 		"pane",
@@ -111,6 +102,21 @@ export function buildReleaseAgentArgs(report: HerdrReleaseReport): string[] {
 	];
 }
 
+/**
+ * Trust-pin the Herdr binary: only an absolute path to an existing regular file
+ * is accepted. A bare `herdr` (PATH-resolved) is never used, to avoid PATH
+ * hijack. Returns the trusted absolute path or null.
+ */
+export function resolveTrustedHerdrBin(binPath: string | null | undefined): string | null {
+	const candidate = typeof binPath === "string" ? binPath.trim() : "";
+	if (candidate.length === 0 || !isAbsolute(candidate)) return null;
+	try {
+		return statSync(candidate).isFile() ? candidate : null;
+	} catch {
+		return null;
+	}
+}
+
 export interface CliTransportOptions {
 	binPath?: string | null;
 	/** Injectable for tests; defaults to node:child_process execFile. */
@@ -119,16 +125,16 @@ export interface CliTransportOptions {
 }
 
 /**
- * Argv-safe CLI transport. Uses the Herdr binary resolved from HERDR_BIN_PATH
- * (falling back to `herdr` on PATH) and never shells out.
+ * Argv-safe CLI transport. Requires a trust-pinned absolute Herdr binary; never
+ * shells out and never falls back to a PATH-resolved `herdr`.
  */
 export class CliHerdrTransport implements HerdrTransport {
 	readonly kind = "cli" as const;
-	private readonly bin: string;
+	private readonly bin: string | null;
 	private readonly execFileFn: ExecFileFn;
 
 	constructor(options: CliTransportOptions = {}) {
-		this.bin = options.binPath?.trim() ? options.binPath.trim() : "herdr";
+		this.bin = resolveTrustedHerdrBin(options.binPath);
 		this.execFileFn =
 			options.execFileFn ??
 			((file, args, cb) => {
@@ -136,6 +142,11 @@ export class CliHerdrTransport implements HerdrTransport {
 					cb(err),
 				);
 			});
+	}
+
+	/** True only when a trust-pinned binary is available. */
+	get available(): boolean {
+		return this.bin !== null;
 	}
 
 	reportAgent(report: HerdrAgentReport): Promise<HerdrTransportResult> {
@@ -148,6 +159,15 @@ export class CliHerdrTransport implements HerdrTransport {
 
 	private run(args: string[], op: string): Promise<HerdrTransportResult> {
 		return new Promise((resolve) => {
+			if (!this.bin) {
+				resolve({
+					ok: false,
+					transport: "cli",
+					detail: `herdr ${op} skipped`,
+					error: "no trust-pinned herdr binary (HERDR_BIN_PATH must be an absolute existing file)",
+				});
+				return;
+			}
 			this.execFileFn(this.bin, args, (error) => {
 				if (error) {
 					resolve({
@@ -170,35 +190,54 @@ export interface SocketRequest {
 	params: Record<string, unknown>;
 }
 
-export type SocketWriter = (
-	socketPath: string,
-	request: SocketRequest,
-) => Promise<void>;
-
-export interface SocketTransportOptions {
-	socketPath: string;
-	/** Injectable for tests; defaults to a newline-delimited JSON Unix socket write. */
-	writer?: SocketWriter;
-	timeoutMs?: number;
+export interface SocketResponse {
+	id?: string;
+	result?: unknown;
+	error?: { code?: string; message?: string } | string;
 }
 
 /**
- * Raw Herdr socket transport. Herdr uses newline-delimited JSON over a local
- * Unix domain socket; method names use dot notation (pane.report_agent,
- * pane.release_agent). See herdr.dev/docs/socket-api.
+ * Send one request and await the correlated response. Implementations must only
+ * resolve `ok` when Herdr accepted the request (a matching `{id,result}`),
+ * reject on `{id,error}`, and enforce bounded framing/timeout/backpressure.
+ */
+export type SocketExchange = (
+	socketPath: string,
+	request: SocketRequest,
+) => Promise<SocketResponse>;
+
+export interface SocketTransportOptions {
+	socketPath: string;
+	/** Injectable request/response exchange; defaults to a real Unix-socket NDJSON round-trip. */
+	exchange?: SocketExchange;
+	timeoutMs?: number;
+	maxFrameBytes?: number;
+}
+
+const DEFAULT_MAX_FRAME_BYTES = 256 * 1024;
+
+/**
+ * Raw Herdr socket transport with request/response correlation. Herdr uses
+ * newline-delimited JSON over a local Unix domain socket; method names use dot
+ * notation (pane.report_agent, pane.release_agent). Success is only reported
+ * when a correlated `{id,result}` reply is received (Herdr acceptance), not when
+ * bytes flush.
  */
 export class SocketHerdrTransport implements HerdrTransport {
 	readonly kind = "socket" as const;
 	private readonly socketPath: string;
-	private readonly writer: SocketWriter;
+	private readonly exchange: SocketExchange;
 	private counter = 0;
 
 	constructor(options: SocketTransportOptions) {
 		this.socketPath = options.socketPath;
-		this.writer =
-			options.writer ??
+		this.exchange =
+			options.exchange ??
 			((socketPath, request) =>
-				writeNdjsonRequest(socketPath, request, options.timeoutMs ?? 5000));
+				ndjsonExchange(socketPath, request, {
+					timeoutMs: options.timeoutMs ?? 5000,
+					maxFrameBytes: options.maxFrameBytes ?? DEFAULT_MAX_FRAME_BYTES,
+				}));
 	}
 
 	reportAgent(report: HerdrAgentReport): Promise<HerdrTransportResult> {
@@ -212,17 +251,16 @@ export class SocketHerdrTransport implements HerdrTransport {
 		if (report.message !== undefined && report.message.length > 0) {
 			params.message = report.message;
 		}
+		if (report.metadata && Object.keys(report.metadata).length > 0) {
+			params.tokens = report.metadata;
+		}
 		return this.send("pane.report_agent", params, "report-agent");
 	}
 
 	releaseAgent(report: HerdrReleaseReport): Promise<HerdrTransportResult> {
 		return this.send(
 			"pane.release_agent",
-			{
-				pane_id: report.paneId,
-				source: report.source,
-				seq: report.seq,
-			},
+			{ pane_id: report.paneId, source: report.source, seq: report.seq },
 			"release-agent",
 		);
 	}
@@ -234,13 +272,33 @@ export class SocketHerdrTransport implements HerdrTransport {
 	): Promise<HerdrTransportResult> {
 		this.counter += 1;
 		const request: SocketRequest = {
-			id: `omx-${op}-${this.counter}`,
+			id: `omx-${op}-${process.pid}-${this.counter}`,
 			method,
 			params,
 		};
 		try {
-			await this.writer(this.socketPath, request);
-			return { ok: true, transport: "socket", detail: `${method} ok` };
+			const response = await this.exchange(this.socketPath, request);
+			if (response.id !== undefined && response.id !== request.id) {
+				return {
+					ok: false,
+					transport: "socket",
+					detail: `${method} response id mismatch`,
+					error: `expected ${request.id}, got ${response.id}`,
+				};
+			}
+			if (response.error !== undefined) {
+				const message =
+					typeof response.error === "string"
+						? response.error
+						: (response.error.message ?? response.error.code ?? "herdr error");
+				return {
+					ok: false,
+					transport: "socket",
+					detail: `${method} rejected`,
+					error: message,
+				};
+			}
+			return { ok: true, transport: "socket", detail: `${method} accepted` };
 		} catch (error) {
 			return {
 				ok: false,
@@ -252,28 +310,70 @@ export class SocketHerdrTransport implements HerdrTransport {
 	}
 }
 
-function writeNdjsonRequest(
+interface NdjsonExchangeOptions {
+	timeoutMs: number;
+	maxFrameBytes: number;
+}
+
+/**
+ * Real Unix-socket NDJSON request/response: write one request line, then read
+ * reply lines with a bounded buffer, parse each NDJSON line, and resolve on the
+ * first line whose `id` matches (or the first parseable object when the reply
+ * carries no id). Enforces a total-buffer cap (backpressure/oversized-frame
+ * guard) and a hard timeout.
+ */
+function ndjsonExchange(
 	socketPath: string,
 	request: SocketRequest,
-	timeoutMs: number,
-): Promise<void> {
+	options: NdjsonExchangeOptions,
+): Promise<SocketResponse> {
 	return new Promise((resolve, reject) => {
 		const socket = createConnection(socketPath);
 		let settled = false;
-		const done = (err?: Error) => {
+		let buffer = "";
+
+		const done = (err?: Error, value?: SocketResponse) => {
 			if (settled) return;
 			settled = true;
 			socket.destroy();
 			if (err) reject(err);
-			else resolve();
+			else resolve(value ?? {});
 		};
-		socket.setTimeout(timeoutMs, () => done(new Error("herdr socket timeout")));
+
+		socket.setTimeout(options.timeoutMs, () =>
+			done(new Error("herdr socket timeout")),
+		);
 		socket.on("error", (err) => done(err));
+		socket.on("close", () => done(new Error("herdr socket closed before reply")));
 		socket.on("connect", () => {
 			socket.write(`${JSON.stringify(request)}\n`, (err) => {
 				if (err) done(err);
-				else done();
 			});
+		});
+		socket.on("data", (chunk: Buffer) => {
+			buffer += chunk.toString("utf-8");
+			if (Buffer.byteLength(buffer, "utf-8") > options.maxFrameBytes) {
+				done(new Error("herdr response exceeded max frame bytes"));
+				return;
+			}
+			let newlineIndex = buffer.indexOf("\n");
+			while (newlineIndex !== -1) {
+				const line = buffer.slice(0, newlineIndex).trim();
+				buffer = buffer.slice(newlineIndex + 1);
+				if (line.length > 0) {
+					let parsed: SocketResponse | null = null;
+					try {
+						parsed = JSON.parse(line) as SocketResponse;
+					} catch {
+						parsed = null;
+					}
+					if (parsed && (parsed.id === undefined || parsed.id === request.id)) {
+						done(undefined, parsed);
+						return;
+					}
+				}
+				newlineIndex = buffer.indexOf("\n");
+			}
 		});
 	});
 }

--- a/src/adapt/herdr/transport.ts
+++ b/src/adapt/herdr/transport.ts
@@ -1,0 +1,279 @@
+import { execFile } from "node:child_process";
+import { createConnection } from "node:net";
+import type { HerdrSemanticState } from "./semantic.js";
+
+/**
+ * Herdr pane environment exported into managed pane processes:
+ *   HERDR_ENV=1, HERDR_PANE_ID, HERDR_SOCKET_PATH, HERDR_BIN_PATH.
+ * See herdr.dev/docs/socket-api.
+ */
+export interface HerdrEnv {
+	/** True only when OMX is running inside a Herdr-managed pane. */
+	enabled: boolean;
+	paneId: string | null;
+	socketPath: string | null;
+	binPath: string | null;
+}
+
+export function detectHerdrEnv(
+	env: NodeJS.ProcessEnv = process.env,
+): HerdrEnv {
+	const paneId = nonEmpty(env.HERDR_PANE_ID);
+	const enabled = env.HERDR_ENV === "1" && paneId !== null;
+	return {
+		enabled,
+		paneId,
+		socketPath: nonEmpty(env.HERDR_SOCKET_PATH),
+		binPath: nonEmpty(env.HERDR_BIN_PATH),
+	};
+}
+
+function nonEmpty(value: string | undefined): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+export interface HerdrAgentReport {
+	paneId: string;
+	source: string;
+	agent: string;
+	state: HerdrSemanticState;
+	message?: string;
+	/**
+	 * Monotonically increasing per-source sequence. Herdr accepts but ignores a
+	 * report whose seq is <= the last accepted seq for the same source, so stale
+	 * reports cannot overwrite newer state.
+	 */
+	seq: number;
+	/** Display-only metadata tokens (pane.report_metadata). */
+	metadata?: Record<string, string>;
+}
+
+export interface HerdrReleaseReport {
+	paneId: string;
+	source: string;
+	seq: number;
+}
+
+export interface HerdrTransportResult {
+	ok: boolean;
+	transport: "cli" | "socket";
+	detail: string;
+	error?: string;
+}
+
+export interface HerdrTransport {
+	readonly kind: "cli" | "socket";
+	reportAgent(report: HerdrAgentReport): Promise<HerdrTransportResult>;
+	releaseAgent(report: HerdrReleaseReport): Promise<HerdrTransportResult>;
+}
+
+type ExecFileFn = (
+	file: string,
+	args: string[],
+	callback: (error: Error | null) => void,
+) => void;
+
+/**
+ * Build argv for `herdr pane report-agent`. argv is passed directly to execFile
+ * (no shell), so pane ids, messages, and metadata cannot inject shell syntax.
+ */
+export function buildReportAgentArgs(report: HerdrAgentReport): string[] {
+	const args = [
+		"pane",
+		"report-agent",
+		report.paneId,
+		"--source",
+		report.source,
+		"--agent",
+		report.agent,
+		"--state",
+		report.state,
+		"--seq",
+		String(report.seq),
+	];
+	if (report.message !== undefined && report.message.length > 0) {
+		args.push("--message", report.message);
+	}
+	return args;
+}
+
+export function buildReleaseAgentArgs(report: HerdrReleaseReport): string[] {
+	return [
+		"pane",
+		"release-agent",
+		report.paneId,
+		"--source",
+		report.source,
+		"--seq",
+		String(report.seq),
+	];
+}
+
+export interface CliTransportOptions {
+	binPath?: string | null;
+	/** Injectable for tests; defaults to node:child_process execFile. */
+	execFileFn?: ExecFileFn;
+	timeoutMs?: number;
+}
+
+/**
+ * Argv-safe CLI transport. Uses the Herdr binary resolved from HERDR_BIN_PATH
+ * (falling back to `herdr` on PATH) and never shells out.
+ */
+export class CliHerdrTransport implements HerdrTransport {
+	readonly kind = "cli" as const;
+	private readonly bin: string;
+	private readonly execFileFn: ExecFileFn;
+
+	constructor(options: CliTransportOptions = {}) {
+		this.bin = options.binPath?.trim() ? options.binPath.trim() : "herdr";
+		this.execFileFn =
+			options.execFileFn ??
+			((file, args, cb) => {
+				execFile(file, args, { timeout: options.timeoutMs ?? 5000 }, (err) =>
+					cb(err),
+				);
+			});
+	}
+
+	reportAgent(report: HerdrAgentReport): Promise<HerdrTransportResult> {
+		return this.run(buildReportAgentArgs(report), "report-agent");
+	}
+
+	releaseAgent(report: HerdrReleaseReport): Promise<HerdrTransportResult> {
+		return this.run(buildReleaseAgentArgs(report), "release-agent");
+	}
+
+	private run(args: string[], op: string): Promise<HerdrTransportResult> {
+		return new Promise((resolve) => {
+			this.execFileFn(this.bin, args, (error) => {
+				if (error) {
+					resolve({
+						ok: false,
+						transport: "cli",
+						detail: `herdr ${op} failed`,
+						error: error.message,
+					});
+					return;
+				}
+				resolve({ ok: true, transport: "cli", detail: `herdr ${op} ok` });
+			});
+		});
+	}
+}
+
+export interface SocketRequest {
+	id: string;
+	method: string;
+	params: Record<string, unknown>;
+}
+
+export type SocketWriter = (
+	socketPath: string,
+	request: SocketRequest,
+) => Promise<void>;
+
+export interface SocketTransportOptions {
+	socketPath: string;
+	/** Injectable for tests; defaults to a newline-delimited JSON Unix socket write. */
+	writer?: SocketWriter;
+	timeoutMs?: number;
+}
+
+/**
+ * Raw Herdr socket transport. Herdr uses newline-delimited JSON over a local
+ * Unix domain socket; method names use dot notation (pane.report_agent,
+ * pane.release_agent). See herdr.dev/docs/socket-api.
+ */
+export class SocketHerdrTransport implements HerdrTransport {
+	readonly kind = "socket" as const;
+	private readonly socketPath: string;
+	private readonly writer: SocketWriter;
+	private counter = 0;
+
+	constructor(options: SocketTransportOptions) {
+		this.socketPath = options.socketPath;
+		this.writer =
+			options.writer ??
+			((socketPath, request) =>
+				writeNdjsonRequest(socketPath, request, options.timeoutMs ?? 5000));
+	}
+
+	reportAgent(report: HerdrAgentReport): Promise<HerdrTransportResult> {
+		const params: Record<string, unknown> = {
+			pane_id: report.paneId,
+			source: report.source,
+			agent: report.agent,
+			state: report.state,
+			seq: report.seq,
+		};
+		if (report.message !== undefined && report.message.length > 0) {
+			params.message = report.message;
+		}
+		return this.send("pane.report_agent", params, "report-agent");
+	}
+
+	releaseAgent(report: HerdrReleaseReport): Promise<HerdrTransportResult> {
+		return this.send(
+			"pane.release_agent",
+			{
+				pane_id: report.paneId,
+				source: report.source,
+				seq: report.seq,
+			},
+			"release-agent",
+		);
+	}
+
+	private async send(
+		method: string,
+		params: Record<string, unknown>,
+		op: string,
+	): Promise<HerdrTransportResult> {
+		this.counter += 1;
+		const request: SocketRequest = {
+			id: `omx-${op}-${this.counter}`,
+			method,
+			params,
+		};
+		try {
+			await this.writer(this.socketPath, request);
+			return { ok: true, transport: "socket", detail: `${method} ok` };
+		} catch (error) {
+			return {
+				ok: false,
+				transport: "socket",
+				detail: `${method} failed`,
+				error: error instanceof Error ? error.message : String(error),
+			};
+		}
+	}
+}
+
+function writeNdjsonRequest(
+	socketPath: string,
+	request: SocketRequest,
+	timeoutMs: number,
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const socket = createConnection(socketPath);
+		let settled = false;
+		const done = (err?: Error) => {
+			if (settled) return;
+			settled = true;
+			socket.destroy();
+			if (err) reject(err);
+			else resolve();
+		};
+		socket.setTimeout(timeoutMs, () => done(new Error("herdr socket timeout")));
+		socket.on("error", (err) => done(err));
+		socket.on("connect", () => {
+			socket.write(`${JSON.stringify(request)}\n`, (err) => {
+				if (err) done(err);
+				else done();
+			});
+		});
+	});
+}

--- a/src/adapt/herdr/wiring.ts
+++ b/src/adapt/herdr/wiring.ts
@@ -1,0 +1,85 @@
+import type { HookEventEnvelope } from "../../hooks/extensibility/types.js";
+import { reconcileStaleAuthority } from "./authority.js";
+import { HerdrBridge, type HerdrBridgeOptions } from "./bridge.js";
+import { detectHerdrEnv } from "./transport.js";
+
+export interface HerdrWiringInput {
+	cwd: string;
+	event: HookEventEnvelope;
+	/** Test injection for the bridge (env/transport/seq/etc.). */
+	bridgeOptions?: HerdrBridgeOptions;
+}
+
+export interface HerdrWiringResult {
+	wired: boolean;
+	reason: string;
+	reconciledStaleAuthority?: boolean;
+	state?: string;
+	released?: boolean;
+}
+
+/**
+ * Production entry point that reports a canonical OMX lifecycle event to the
+ * containing Herdr pane. Called from `dispatchHookEventRuntime`, so every
+ * native/derived lifecycle event flows through it. Best-effort and
+ * non-blocking: any failure is swallowed and never affects the OMX run, and it
+ * is a complete no-op outside a Herdr pane.
+ */
+export async function reportHerdrLifecycleEvent(
+	input: HerdrWiringInput,
+): Promise<HerdrWiringResult> {
+	const env = input.bridgeOptions?.env ?? detectHerdrEnv();
+	if (!env.enabled) {
+		return { wired: false, reason: "herdr-not-detected" };
+	}
+
+	try {
+		// On session-start, reconcile any authority left behind by a crashed
+		// prior OMX process before we (re)assert state.
+		let reconciled: boolean | undefined;
+		if (input.event.event === "session-start") {
+			reconciled = reconcileStaleAuthority();
+		}
+
+		const sessionId =
+			typeof input.event.session_id === "string"
+				? input.event.session_id
+				: undefined;
+		const bridge = new HerdrBridge({
+			env,
+			sessionId,
+			...input.bridgeOptions,
+		});
+		const outcome = await bridge.reportHookEvent(input.event, {
+			metadata: buildDisplayMetadata(input.event),
+		});
+		return {
+			wired: true,
+			reason: outcome.reason,
+			reconciledStaleAuthority: reconciled,
+			state: outcome.state,
+			released: outcome.released,
+		};
+	} catch (error) {
+		// Failure isolation at the wiring boundary.
+		return {
+			wired: false,
+			reason: `herdr wiring threw: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+}
+
+/** Small, display-only metadata derived from the event (bounded/redacted downstream). */
+function buildDisplayMetadata(
+	event: HookEventEnvelope,
+): Record<string, string> | undefined {
+	const tokens: Record<string, string> = {};
+	if (typeof event.mode === "string" && event.mode.length > 0) {
+		tokens.omx_mode = event.mode;
+	}
+	const phase = event.context?.phase;
+	if (typeof phase === "string" && phase.length > 0) {
+		tokens.phase = phase;
+	}
+	return Object.keys(tokens).length > 0 ? tokens : undefined;
+}

--- a/src/adapt/herdr/wiring.ts
+++ b/src/adapt/herdr/wiring.ts
@@ -20,8 +20,8 @@ export interface HerdrWiringResult {
 
 /**
  * Production entry point that reports a canonical OMX lifecycle event to the
- * containing Herdr pane. Called from `dispatchHookEventRuntime`, so every
- * native/derived lifecycle event flows through it. Best-effort and
+ * containing Herdr pane. Called from `dispatchHookEvent` (the single seam every
+ * native/derived/team/notify dispatch path funnels through). Best-effort and
  * non-blocking: any failure is swallowed and never affects the OMX run, and it
  * is a complete no-op outside a Herdr pane.
  */

--- a/src/adapt/index.ts
+++ b/src/adapt/index.ts
@@ -21,6 +21,14 @@ import {
 	collectHermesEvidence,
 } from "./hermes.js";
 import {
+	applyHerdrEnvelope,
+	applyHerdrProbe,
+	applyHerdrStatus,
+	buildHerdrBootstrapMetadata,
+	buildHerdrRuntimeObservation,
+	collectHerdrEvidence,
+} from "./herdr.js";
+import {
 	buildOpenClawDoctorReport,
 	buildOpenClawEnvelope,
 	buildOpenClawProbeReport,
@@ -105,6 +113,9 @@ export async function buildAdaptEnvelopeForTarget(
 	now = new Date(),
 ): Promise<AdaptEnvelope> {
 	const envelope = buildAdaptEnvelope(cwd, target, now);
+	if (target === "herdr") {
+		return applyHerdrEnvelope(envelope, collectHerdrEvidence());
+	}
 	if (target !== "hermes") {
 		return envelope;
 	}
@@ -160,6 +171,9 @@ export async function buildAdaptProbeReportForTarget(
 	now = new Date(),
 ): Promise<AdaptProbeReport> {
 	const report = buildAdaptProbeReport(cwd, target, now);
+	if (target === "herdr") {
+		return applyHerdrProbe(report, collectHerdrEvidence());
+	}
 	if (target !== "hermes") {
 		return report;
 	}
@@ -222,6 +236,9 @@ export async function buildAdaptStatusReportForTarget(
 	now = new Date(),
 ): Promise<AdaptStatusReport> {
 	const report = buildAdaptStatusReport(cwd, target, now);
+	if (target === "herdr") {
+		return applyHerdrStatus(report, collectHerdrEvidence());
+	}
 	if (target !== "hermes") {
 		return report;
 	}
@@ -292,6 +309,28 @@ export async function buildAdaptDoctorReportForTarget(
 	now = new Date(),
 ): Promise<AdaptDoctorReport> {
 	const report = buildAdaptDoctorReport(cwd, target, now);
+	if (target === "herdr") {
+		const evidence = collectHerdrEvidence();
+		const runtime = buildHerdrRuntimeObservation(evidence);
+		const bootstrap = buildHerdrBootstrapMetadata();
+		const issues = report.issues.filter(
+			(issue) => issue.code !== "target_specific_logic_deferred",
+		);
+		if (!evidence.env.enabled) {
+			issues.push({
+				code: "herdr_pane_not_detected",
+				message:
+					"No Herdr pane detected (HERDR_ENV=1 + HERDR_PANE_ID absent); the opt-in bridge is inert.",
+			});
+		}
+		return {
+			...report,
+			summary:
+				"Herdr doctor reports Herdr pane detection plus OMX-owned adapter readiness; the bridge is opt-in and best-effort.",
+			issues,
+			nextSteps: [...bootstrap.nextSteps, `Herdr runtime: ${runtime.detail}`],
+		};
+	}
 	if (target !== "hermes") {
 		return report;
 	}
@@ -417,6 +456,24 @@ export async function initAdaptFoundationForTarget(
 	now = new Date(),
 ): Promise<AdaptInitResult> {
 	const result = initAdaptFoundation(cwd, target, write, now);
+	if (target === "herdr") {
+		const evidence = collectHerdrEvidence();
+		const envelope = applyHerdrEnvelope(result.envelope, evidence);
+		if (write) {
+			writeFileSync(
+				envelope.adapterPaths.envelopePath,
+				`${JSON.stringify(envelope, null, 2)}\n`,
+				"utf-8",
+			);
+		}
+		return {
+			...result,
+			envelope,
+			summary: write
+				? "Herdr adapter metadata was written under OMX-owned paths with Herdr pane detection evidence."
+				: "Herdr adapter metadata preview includes Herdr pane detection evidence; rerun with --write to materialize it.",
+		};
+	}
 	if (target !== "hermes") {
 		return result;
 	}

--- a/src/adapt/index.ts
+++ b/src/adapt/index.ts
@@ -493,3 +493,27 @@ export async function initAdaptFoundationForTarget(
 			: "Hermes adapter metadata preview includes external ACP/gateway/session-store evidence; rerun with --write to materialize it.",
 	};
 }
+// Herdr lifecycle/status bridge (issue #3241, Phase 1) — reusable runtime bridge
+// plus the production wiring entry point invoked from the hook dispatcher.
+export {
+	HerdrBridge,
+	createHerdrBridge,
+	HERDR_BRIDGE_SOURCE,
+	HERDR_BRIDGE_AGENT,
+	type HerdrBridgeOptions,
+	type HerdrBridgeOutcome,
+} from "./herdr/bridge.js";
+export {
+	reportHerdrLifecycleEvent,
+	type HerdrWiringInput,
+	type HerdrWiringResult,
+} from "./herdr/wiring.js";
+export {
+	mapTeamStateToRollup,
+	type TeamStateInput,
+	type TeamWorkerStateInput,
+} from "./herdr/team-map.js";
+export {
+	detectHerdrEnv,
+	type HerdrEnv,
+} from "./herdr/transport.js";

--- a/src/adapt/registry.ts
+++ b/src/adapt/registry.ts
@@ -96,6 +96,31 @@ const TARGET_DESCRIPTORS: Record<AdaptTarget, AdaptTargetDescriptor> = {
 			),
 		],
 	},
+	herdr: {
+		target: "herdr",
+		displayName: "Herdr",
+		summary:
+			"OMX-owned opt-in lifecycle/status bridge that reports OMX lifecycle and Team state to a containing Herdr pane via the documented Herdr socket/CLI API.",
+		followupHint:
+			"The Herdr bridge is opt-in and inert outside a Herdr pane; it is best-effort and never fails the OMX run. Phase 2 runtime backend is out of scope.",
+		capabilities: [
+			...FOUNDATION_CAPABILITIES,
+			capability(
+				"herdr-env-detection",
+				"Herdr pane detection",
+				"target-observed",
+				"stub",
+				"Detects HERDR_ENV=1, HERDR_PANE_ID, and HERDR_SOCKET_PATH exported by a containing Herdr pane.",
+			),
+			capability(
+				"lifecycle-status-bridge",
+				"Lifecycle/status bridge",
+				"shared-contract",
+				"stub",
+				"Maps OMX lifecycle/Team state to Herdr semantic states with monotonic per-source seq ordering and authority release on terminal states.",
+			),
+		],
+	},
 };
 
 export function listAdaptTargets(): AdaptTargetDescriptor[] {

--- a/src/hooks/extensibility/dispatcher.ts
+++ b/src/hooks/extensibility/dispatcher.ts
@@ -312,6 +312,22 @@ export async function dispatchHookEvent(
 ): Promise<HookDispatchResult> {
 	const cwd = options.cwd || process.cwd();
 	const env = options.env || process.env;
+
+	// Opt-in Herdr lifecycle/status bridge (issue #3241). This is the single seam
+	// every dispatch path funnels through, so it covers native, derived, team,
+	// and notify events. Gated on a cheap env check so there is zero import cost
+	// outside a Herdr pane; best-effort and non-blocking — a Herdr failure never
+	// affects the OMX run and it runs regardless of plugin enablement.
+	if (env.HERDR_ENV === "1") {
+		try {
+			const { reportHerdrLifecycleEvent } = await import(
+				"../../adapt/herdr/wiring.js"
+			);
+			await reportHerdrLifecycleEvent({ cwd, event });
+		} catch {
+			// swallow: opt-in best-effort bridge
+		}
+	}
 	const stateRoot = options.stateRoot ?? getBaseStateDir(cwd, env);
 	const runtimeHookDispatchEnabled =
 		shouldForceEnableRuntimeHookDispatch(event) || isHookPluginsEnabled(env);

--- a/src/hooks/extensibility/runtime.ts
+++ b/src/hooks/extensibility/runtime.ts
@@ -10,6 +10,15 @@ async function handleNativeStopTeamLeaderAttention(input: HookRuntimeDispatchInp
   await markOwnedTeamsLeaderStopObserved(input.cwd, sessionId, input.event.timestamp, 'native_stop');
 }
 
+async function reportHerdrLifecycle(input: HookRuntimeDispatchInput): Promise<void> {
+  try {
+    const { reportHerdrLifecycleEvent } = await import('../../adapt/herdr/wiring.js');
+    await reportHerdrLifecycleEvent({ cwd: input.cwd, event: input.event });
+  } catch {
+    // Opt-in, best-effort bridge: a Herdr failure never affects the OMX run.
+  }
+}
+
 export async function dispatchHookEventRuntime(input: HookRuntimeDispatchInput): Promise<HookRuntimeDispatchResult> {
   const enabled = input.event.source === 'native' || input.event.source === 'derived'
     ? true
@@ -30,6 +39,7 @@ export async function dispatchHookEventRuntime(input: HookRuntimeDispatchInput):
   }
 
   await handleNativeStopTeamLeaderAttention(input);
+  await reportHerdrLifecycle(input);
 
   const result = await dispatchHookEvent(input.event, {
     cwd: input.cwd,

--- a/src/hooks/extensibility/runtime.ts
+++ b/src/hooks/extensibility/runtime.ts
@@ -10,14 +10,6 @@ async function handleNativeStopTeamLeaderAttention(input: HookRuntimeDispatchInp
   await markOwnedTeamsLeaderStopObserved(input.cwd, sessionId, input.event.timestamp, 'native_stop');
 }
 
-async function reportHerdrLifecycle(input: HookRuntimeDispatchInput): Promise<void> {
-  try {
-    const { reportHerdrLifecycleEvent } = await import('../../adapt/herdr/wiring.js');
-    await reportHerdrLifecycleEvent({ cwd: input.cwd, event: input.event });
-  } catch {
-    // Opt-in, best-effort bridge: a Herdr failure never affects the OMX run.
-  }
-}
 
 export async function dispatchHookEventRuntime(input: HookRuntimeDispatchInput): Promise<HookRuntimeDispatchResult> {
   const enabled = input.event.source === 'native' || input.event.source === 'derived'
@@ -39,7 +31,6 @@ export async function dispatchHookEventRuntime(input: HookRuntimeDispatchInput):
   }
 
   await handleNativeStopTeamLeaderAttention(input);
-  await reportHerdrLifecycle(input);
 
   const result = await dispatchHookEvent(input.event, {
     cwd: input.cwd,


### PR DESCRIPTION
## Summary

Phase 1 of #3241: an **opt-in** `omx adapt herdr` target plus a reusable runtime bridge that reports OMX lifecycle and Team state to a containing [Herdr](https://github.com/ogulcancelik/herdr) pane through the documented Herdr socket/CLI API. Phase 2 (Herdr as a runtime backend) is intentionally out of scope.

## What's included

- **`src/adapt/herdr/semantic.ts`** — pure event→semantic-state mapping and authoritative Team rollup (`working`/`blocked`/`idle`/`unknown`).
- **`src/adapt/herdr/transport.ts`** — `HERDR_ENV`/`HERDR_PANE_ID`/`HERDR_SOCKET_PATH` detection plus a shell-free CLI transport (`execFile`, argv array) and a Unix-socket NDJSON transport. Both injectable.
- **`src/adapt/herdr/bridge.ts`** — `HerdrBridge`: opt-in gate, a **single monotonic per-source `seq`** shared by report and release (stale reports cannot win), terminal-state authority **release**, and **failure isolation** (a Herdr socket/CLI error never fails the OMX run).
- **`src/adapt/herdr.ts` + registry/contracts/index** — registers the `herdr` adapt target (`probe`/`status`/`envelope`/`doctor`/`init`).
- **docs** — `docs/herdr-bridge.md` (Phase 1 design + Phase 2 boundary), `docs/adapt.md` updated.

## Acceptance criteria (issue #3241)

- [x] Explicit opt-in; no behavior change outside Herdr
- [x] Pane shows `working`/`blocked`/`idle` transitions from OMX state
- [x] Team state rolled up from authoritative worker/task state
- [x] Updates idempotent and ordered; stale reports cannot win (monotonic seq)
- [x] Exit/crash recovery releases authority (no permanent stale authority)
- [x] Herdr socket/CLI failure does not affect OMX execution
- [x] Unit tests cover mapping, rollup, ordering, cleanup with a fake socket/CLI
- [x] Docs explain Phase 1 vs future Phase 2

## Protocol verification

`seq`/release verified against Herdr HEAD `1f2487554b9fd42118f9e99ee06eb558bbb2391f`:
`PaneReportAgentParams { seq: Option<u64> }`, CLI `--seq` on `report-agent`/`release-agent`, server forwards `seq` into `HookStateReported`; consistent with herdr.dev/docs/socket-api and /docs/agents.

## Testing

- `src/adapt/herdr/__tests__/{semantic,transport,bridge}.test.ts` and `src/adapt/__tests__/herdr-target.test.ts` — 36 new tests, all green.
- `tsc`, `tsc -p tsconfig.no-unused.json`, and `biome lint` clean.
- Existing `adapt` foundation, `hermes`, and CLI `adapt` suites still pass.

Closes #3241 (Phase 1).
