### PR TITLE
Keep native sidecar session authority scoped during pointer conflicts

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -261,6 +261,25 @@ Native and notify leader turns classify provenance once and pass an immutable au
 
 Rejected turns perform no activation, continuation, steering, plugin, HUD, pane, timestamp, or neighboring-session mutation. They may append one redacted `prompt_session_provenance_rejected` diagnostic under the already-selected state root; the record contains the reason and producer but no raw session/thread identifiers, prompt text, environment value, or foreign path. `PreToolUse`, `Stop`, SessionStart reconciliation, and authoritative-root selection retain their existing contracts.
 
+## Stop: session owner provenance
+
+Native root `SessionStart` records process-bound owner evidence under
+`.omx/state/sessions/<native-session-id>/session-owner.json`. The singleton
+`.omx/state/session.json` remains the backward-compatible selected pointer,
+but a different live process cannot replace it.
+
+When a `Stop` payload does not match a usable selected pointer, or the selected
+pointer is stale-dead, OMX reads only the payload session's exact owner sidecar.
+Usable PID, Linux start-tick, command-line, cwd, and session-id evidence
+authorizes only that session's scoped workflow checks. Root/global hook side
+effects remain suppressed, the selected pointer is not rewritten, and missing,
+dead, reused, malformed, foreign, forged, or indeterminate evidence stays
+fail-closed. A foreign, malformed, or identity-indeterminate selected pointer
+also remains fail-closed.
+
+Native `Stop` ends one assistant turn rather than the Codex process, so a
+successful `Stop` does not delete owner evidence.
+
 ## UserPromptSubmit: triage advisory context
 
 `UserPromptSubmit` can now emit triage advisory context alongside keyword context. When no keyword matches, the triage layer classifies the prompt and may inject an advisory prompt-routing context string — this is advisory prompt-routing context that does not activate a skill or workflow by itself; it adds a developer-context hint the model may follow. Light advisory destinations include repo-local `explore`, narrow-edit `executor`, visual `designer`, and external documentation/reference `researcher`; researcher routing is for official-doc, version-compatibility, source-backed, or external lookup requests, does not override local anchors or implementation-shaped prompts, and still writes only prompt-routing state. Keywords remain the deterministic control surface: a matched keyword always takes precedence over triage output, and users can suppress triage injection per prompt with phrases such as `no workflow`, `just chat`, or `plain answer`.

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -20,11 +20,13 @@ import {
   readSessionPointer,
   readSessionState,
   readUsableSessionState,
+  readNativeSessionOwner,
   reconcileNativeSessionStart,
   recoverSessionPointerLock,
   resetSessionMetrics,
   resolveSessionPointerContext,
   writeSessionEnd,
+  writeNativeSessionOwner,
   updateDetachedSessionMetadata,
   writeSessionStart,
   type LaunchSessionBinding,
@@ -1504,6 +1506,238 @@ describe('session pointer transaction', () => {
         const persisted = await readSessionState(cwd);
         assert.equal(persisted?.session_id, 'native-first');
         assert.equal(persisted?.owner_omx_session_id, 'omx-owner');
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps native session owner sidecars isolated and rejects live cross-process reuse', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-owner-sidecar-'));
+    try {
+      await withPointerDependencies({ probePid: () => 'alive' }, async () => {
+        const first = await writeNativeSessionOwner(
+          cwd,
+          'native-owner-a',
+          { pid: 11, platform: 'win32' },
+        );
+        const second = await writeNativeSessionOwner(
+          cwd,
+          'native-owner-b',
+          { pid: 22, platform: 'win32' },
+        );
+        assert.equal(first.pid, 11);
+        assert.equal(second.pid, 22);
+        const firstPath = join(
+          cwd,
+          '.omx',
+          'state',
+          'sessions',
+          'native-owner-a',
+          'session-owner.json',
+        );
+        const secondPath = join(
+          cwd,
+          '.omx',
+          'state',
+          'sessions',
+          'native-owner-b',
+          'session-owner.json',
+        );
+        assert.equal(
+          (JSON.parse(await readFile(firstPath, 'utf-8')) as SessionState).pid,
+          11,
+        );
+        assert.equal(
+          (JSON.parse(await readFile(secondPath, 'utf-8')) as SessionState).pid,
+          22,
+        );
+        await writeNativeSessionOwner(cwd, 'native-owner-current', {
+          pid: process.pid,
+        });
+        assert.equal(
+          (await readNativeSessionOwner(cwd, 'native-owner-current'))?.pid,
+          process.pid,
+        );
+        await assert.rejects(
+          writeNativeSessionOwner(
+            cwd,
+            'native-owner-a',
+            { pid: 22, platform: 'win32' },
+          ),
+          (error: unknown) => isSessionPointerLaunchAbort(error)
+            && error.code === 'session_pointer_owner_conflict',
+        );
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects owner sidecars recorded for another platform', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-owner-platform-'));
+    try {
+      const ownerDir = join(
+        cwd,
+        '.omx',
+        'state',
+        'sessions',
+        'native-owner-platform',
+      );
+      await mkdir(ownerDir, { recursive: true });
+      const ownerPath = join(ownerDir, 'session-owner.json');
+      const forgedPlatform: NodeJS.Platform = process.platform === 'win32'
+        ? 'darwin'
+        : 'win32';
+      await writeFile(ownerPath, JSON.stringify({
+        session_id: 'native-owner-platform',
+        native_session_id: 'native-owner-platform',
+        started_at: new Date().toISOString(),
+        cwd,
+        pid: process.pid,
+        platform: forgedPlatform,
+      }), 'utf-8');
+      const before = await readFile(ownerPath, 'utf-8');
+
+      assert.equal(await readNativeSessionOwner(cwd, 'native-owner-platform'), null);
+      await assert.rejects(
+        writeNativeSessionOwner(cwd, 'native-owner-platform', {
+          pid: process.pid,
+        }),
+        (error: unknown) => isSessionPointerLaunchAbort(error)
+          && error.code === 'session_pointer_owner_conflict',
+      );
+      assert.equal(await readFile(ownerPath, 'utf-8'), before);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('replaces only stale-dead owner evidence and preserves malformed evidence', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-owner-recovery-'));
+    try {
+      await withPointerDependencies({
+        probePid: (pid) => pid === 11 ? 'dead' : 'alive',
+      }, async () => {
+        await writeNativeSessionOwner(
+          cwd,
+          'native-owner-recovery',
+          { pid: 11, platform: 'win32' },
+        );
+        const recovered = await writeNativeSessionOwner(
+          cwd,
+          'native-owner-recovery',
+          { pid: 22, platform: 'win32' },
+        );
+        assert.equal(recovered.pid, 22);
+
+        const malformedDir = join(
+          cwd,
+          '.omx',
+          'state',
+          'sessions',
+          'native-owner-malformed',
+        );
+        await mkdir(malformedDir, { recursive: true });
+        const malformedPath = join(malformedDir, 'session-owner.json');
+        await writeFile(malformedPath, '{ malformed', 'utf-8');
+        assert.equal(await readNativeSessionOwner(cwd, 'native-owner-malformed'), null);
+        await assert.rejects(
+          writeNativeSessionOwner(
+            cwd,
+            'native-owner-malformed',
+            { pid: 22, platform: 'win32' },
+          ),
+          (error: unknown) => isSessionPointerLaunchAbort(error)
+            && error.code === 'session_pointer_unusable'
+            && error.pointerStatus === 'malformed',
+        );
+
+        const forgedDir = join(
+          cwd,
+          '.omx',
+          'state',
+          'sessions',
+          'native-owner-forged',
+        );
+        await mkdir(forgedDir, { recursive: true });
+        const forgedPath = join(forgedDir, 'session-owner.json');
+        await writeFile(forgedPath, JSON.stringify({
+          session_id: 'native-owner-other',
+          native_session_id: 'native-owner-other',
+          started_at: new Date().toISOString(),
+          cwd,
+          pid: 22,
+          platform: 'win32',
+        }), 'utf-8');
+        const forgedBefore = await readFile(forgedPath, 'utf-8');
+        assert.equal(await readNativeSessionOwner(cwd, 'native-owner-forged'), null);
+        await assert.rejects(
+          writeNativeSessionOwner(
+            cwd,
+            'native-owner-forged',
+            { pid: 22, platform: 'win32' },
+          ),
+          (error: unknown) => isSessionPointerLaunchAbort(error)
+            && error.code === 'session_pointer_owner_conflict',
+        );
+        assert.equal(await readFile(forgedPath, 'utf-8'), forgedBefore);
+
+        const missingCwdDir = join(
+          cwd,
+          '.omx',
+          'state',
+          'sessions',
+          'native-owner-missing-cwd',
+        );
+        await mkdir(missingCwdDir, { recursive: true });
+        const missingCwdPath = join(missingCwdDir, 'session-owner.json');
+        await writeFile(missingCwdPath, JSON.stringify({
+          session_id: 'native-owner-missing-cwd',
+          native_session_id: 'native-owner-missing-cwd',
+          started_at: new Date().toISOString(),
+          pid: 22,
+          platform: 'win32',
+        }), 'utf-8');
+        const missingCwdBefore = await readFile(missingCwdPath, 'utf-8');
+        assert.equal(await readNativeSessionOwner(cwd, 'native-owner-missing-cwd'), null);
+        await assert.rejects(
+          writeNativeSessionOwner(
+            cwd,
+            'native-owner-missing-cwd',
+            { pid: 22, platform: 'win32' },
+          ),
+          (error: unknown) => isSessionPointerLaunchAbort(error)
+            && error.code === 'session_pointer_owner_conflict',
+        );
+        assert.equal(await readFile(missingCwdPath, 'utf-8'), missingCwdBefore);
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects cross-process native reconciliation while preserving the live selected pointer', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-cross-process-selected-'));
+    try {
+      await withPointerDependencies({ probePid: () => 'alive' }, async () => {
+        await writeSessionStart(cwd, 'native-selected-a', {
+          nativeSessionId: 'native-selected-a',
+          pid: 11,
+          platform: 'win32',
+        });
+        const context = resolveSessionPointerContext(cwd);
+        const before = await readFile(context.sessionPath, 'utf-8');
+        await assert.rejects(
+          reconcileNativeSessionStart(
+            cwd,
+            'native-selected-b',
+            { pid: 22, platform: 'win32' },
+          ),
+          (error: unknown) => isSessionPointerLaunchAbort(error)
+            && error.code === 'session_pointer_owner_conflict',
+        );
+        assert.equal(await readFile(context.sessionPath, 'utf-8'), before);
       });
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -2195,7 +2195,7 @@ function nativeSessionOwnerTransition(
       || normalizeSessionId(existing.native_session_id) !== nativeSessionId
       || existing.platform !== platform
       || !isSessionStateAuthoritativeForCwd(existing, context.cwd)
-      || !sameProcessIdentity(existing, pid, platform, linuxIdentity)
+      || existing.pid !== pid
     )) {
       throw ownerConflictAbort(context, nativeSessionId, existing);
     }

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -218,6 +218,7 @@ export interface BoundFinalizationReport {
 }
 
 const SESSION_FILE = 'session.json';
+const SESSION_OWNER_FILE = 'session-owner.json';
 const HISTORY_FILE = 'session-history.jsonl';
 const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 const SESSION_POINTER_TOKEN_PATTERN = /^[A-Za-z0-9_-]{16,128}$/;
@@ -247,6 +248,30 @@ export function resolveSessionPointerContext(cwd: string): SessionPointerContext
     rootSource,
     sessionPath: pointerPath,
     lockPath: `${pointerPath}.lock`,
+  };
+}
+
+function resolveNativeSessionOwnerContext(
+  cwd: string,
+  nativeSessionId: string,
+): SessionPointerContext {
+  const root = resolveSessionPointerContext(cwd);
+  const normalized = normalizeSessionId(nativeSessionId);
+  if (!normalized) {
+    throw resolvedAbort(root, {
+      code: 'session_pointer_io_failure',
+      operation: 'pointer-classify',
+      lockPath: root.lockPath,
+      reason: 'A valid native session ID is required for owner evidence.',
+    });
+  }
+  const baseStateDir = join(root.baseStateDir, 'sessions', normalized);
+  const sessionPath = join(baseStateDir, SESSION_OWNER_FILE);
+  return {
+    ...root,
+    baseStateDir,
+    sessionPath,
+    lockPath: `${sessionPath}.lock`,
   };
 }
 
@@ -2152,6 +2177,77 @@ export function finalizeBoundOnce(
   return finalization;
 }
 
+
+function nativeSessionOwnerTransition(
+  nativeSessionId: string,
+  options: SessionStartOptions,
+): (pointer: SessionPointerReadResult, context: SessionPointerContext) => SessionState {
+  return (pointer, context) => {
+    if (pointer.status !== 'absent' && pointer.status !== 'stale-dead' && pointer.status !== 'usable') {
+      throw unusablePointerAbort(context, nativeSessionId, pointer);
+    }
+    const pid = resolvePid(options);
+    const platform = options.platform ?? process.platform;
+    const linuxIdentity = sessionIdentityFor(pid, platform);
+    const existing = pointer.status === 'usable' ? pointer.state : undefined;
+    if (existing && (
+      normalizeSessionId(existing.session_id) !== nativeSessionId
+      || normalizeSessionId(existing.native_session_id) !== nativeSessionId
+      || existing.platform !== platform
+      || !isSessionStateAuthoritativeForCwd(existing, context.cwd)
+      || !sameProcessIdentity(existing, pid, platform, linuxIdentity)
+    )) {
+      throw ownerConflictAbort(context, nativeSessionId, existing);
+    }
+    return createSessionState(context.cwd, context.baseStateDir, nativeSessionId, pid, platform, linuxIdentity, {
+      nativeSessionId,
+      startedAt: existing?.started_at,
+      tmuxSessionName: options.tmuxSessionName ?? existing?.tmux_session_name,
+      tmuxPaneId: options.tmuxPaneId ?? existing?.tmux_pane_id,
+    });
+  };
+}
+
+export async function writeNativeSessionOwner(
+  cwd: string,
+  nativeSessionId: string,
+  options: SessionStartOptions = {},
+): Promise<SessionState> {
+  const normalized = normalizeSessionId(nativeSessionId);
+  const context = resolveNativeSessionOwnerContext(cwd, nativeSessionId);
+  const result = await writePointerTransaction(
+    cwd,
+    normalized,
+    { context },
+    NATIVE_POINTER_TIMEOUT_MS,
+    nativeSessionOwnerTransition(normalized ?? nativeSessionId, options),
+    (state) => state,
+  );
+  return result.value;
+}
+
+export async function readNativeSessionOwner(
+  cwd: string,
+  nativeSessionId: string,
+): Promise<SessionState | null> {
+  const normalized = normalizeSessionId(nativeSessionId);
+  if (!normalized) return null;
+  try {
+    const context = resolveNativeSessionOwnerContext(cwd, normalized);
+    const pointer = await readSessionPointer(
+      context,
+    );
+    const state = pointer.status === 'usable' ? pointer.state : undefined;
+    return state?.session_id === normalized
+      && state.native_session_id === normalized
+      && state.platform === process.platform
+      && isSessionStateAuthoritativeForCwd(state, context.cwd)
+      ? state
+      : null;
+  } catch {
+    return null;
+  }
+}
 
 function reconcileNativeTransition(
   nativeSessionId: string,

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -276,6 +276,36 @@ async function writeLiveNativeSessionOwnerSidecar(
 	);
 }
 
+async function withIndependentNativeSession(
+	suffix: string,
+	run: (fixture: {
+		cwd: string;
+		stateDir: string;
+		sessionId: string;
+		pointerBefore: string;
+	}) => Promise<void>,
+): Promise<void> {
+	const cwd = await mkdtemp(join(tmpdir(), `omx-native-hook-sidecar-${suffix}-`));
+	try {
+		const stateDir = join(cwd, ".omx", "state");
+		const selectedSessionId = `native-selected-${suffix}`;
+		const sessionId = `native-independent-${suffix}`;
+		await writeSessionStart(cwd, selectedSessionId, {
+			nativeSessionId: selectedSessionId,
+			pid: process.pid,
+		});
+		await writeLiveNativeSessionOwnerSidecar(cwd, stateDir, sessionId);
+		await run({
+			cwd,
+			stateDir,
+			sessionId,
+			pointerBefore: await readFile(join(stateDir, "session.json"), "utf-8"),
+		});
+	} finally {
+		await rm(cwd, { recursive: true, force: true });
+	}
+}
+
 async function writeSessionSkillActiveState(
 	stateDir: string,
 	sessionId: string,
@@ -4706,6 +4736,126 @@ PY`,
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
+  });
+
+  for (const mode of ["autopilot", "ultrawork", "ultraqa"] as const) {
+    it(`uses the unmatched sidecar ${mode} state as the Stop blocker`, async () => {
+      await withIndependentNativeSession(mode, async ({
+        cwd,
+        stateDir,
+        sessionId,
+        pointerBefore,
+      }) => {
+        await writeJson(
+          join(stateDir, "sessions", sessionId, `${mode}-state.json`),
+          {
+            active: true,
+            mode,
+            current_phase: "executing",
+            session_id: sessionId,
+            workingDirectory: cwd,
+          },
+        );
+
+        const result = await dispatchCodexNativeHook(
+          {
+            hook_event_name: "Stop",
+            cwd,
+            session_id: sessionId,
+            thread_id: sessionId,
+          },
+          { cwd },
+        );
+
+        assert.equal(result.outputJson?.decision, "block");
+        assert.match(String(result.outputJson?.stopReason ?? ""), new RegExp(`^${mode}_`));
+        assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+        assert.equal(existsSync(join(stateDir, "native-stop-state.json")), false);
+      });
+    });
+  }
+
+  it("uses the unmatched sidecar team state as the Stop blocker", async () => {
+    await withIndependentNativeSession("team", async ({
+      cwd,
+      stateDir,
+      sessionId,
+      pointerBefore,
+    }) => {
+      await writeJson(
+        join(stateDir, "sessions", sessionId, "team-state.json"),
+        {
+          active: true,
+          mode: "team",
+          team_name: "sidecar-team",
+          current_phase: "team-exec",
+          session_id: sessionId,
+          owner_codex_thread_id: sessionId,
+        },
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: sessionId,
+          thread_id: sessionId,
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson?.decision, "block");
+      assert.equal(result.outputJson?.stopReason, "team_team-exec");
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+      assert.equal(existsSync(join(stateDir, "native-stop-state.json")), false);
+    });
+  });
+
+  it("uses the unmatched sidecar deep-interview question state as the Stop blocker", async () => {
+    await withIndependentNativeSession("deep-interview", async ({
+      cwd,
+      stateDir,
+      sessionId,
+      pointerBefore,
+    }) => {
+      await writeSessionSkillActiveState(
+        stateDir,
+        sessionId,
+        "deep-interview",
+        "intent-first",
+      );
+      await writeJson(
+        join(stateDir, "sessions", sessionId, "deep-interview-state.json"),
+        {
+          active: true,
+          mode: "deep-interview",
+          current_phase: "intent-first",
+          session_id: sessionId,
+          thread_id: sessionId,
+          question_enforcement: {
+            obligation_id: "sidecar-question",
+            source: "omx-question",
+            status: "pending",
+            requested_at: "2026-07-18T00:00:00.000Z",
+          },
+        },
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: sessionId,
+          thread_id: sessionId,
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson?.decision, "block");
+      assert.equal(result.outputJson?.stopReason, "deep_interview_question_required");
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+      assert.equal(existsSync(join(stateDir, "native-stop-state.json")), false);
+    });
   });
 
   it("uses a live parent sidecar when a nested selected pointer is stale-dead", async () => {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3984,6 +3984,15 @@ PY`,
       assert.equal(sessionState.native_session_id, "sess-start-1");
       assert.equal(sessionState.pid, 43210);
       assert.equal(sessionState.launch_lineage_token, undefined, 'native SessionStart must never mint or backfill wrapper lineage authority');
+      const ownerState = JSON.parse(
+        await readFile(
+          join(cwd, ".omx", "state", "sessions", "sess-start-1", "session-owner.json"),
+          "utf-8",
+        ),
+      ) as { session_id?: string; native_session_id?: string; pid?: number };
+      assert.equal(ownerState.session_id, "sess-start-1");
+      assert.equal(ownerState.native_session_id, "sess-start-1");
+      assert.equal(ownerState.pid, 43210);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -256,6 +256,26 @@ async function writeLiveNativeMappedSessionState(
   }
 }
 
+async function writeLiveNativeSessionOwnerSidecar(
+	cwd: string,
+	stateDir: string,
+	sessionId: string,
+): Promise<void> {
+	const selected = JSON.parse(
+		await readFile(join(stateDir, "session.json"), "utf-8"),
+	) as Record<string, unknown>;
+	await writeJson(
+		join(stateDir, "sessions", sessionId, "session-owner.json"),
+		{
+			...selected,
+			session_id: sessionId,
+			native_session_id: sessionId,
+			started_at: new Date().toISOString(),
+			cwd,
+		},
+	);
+}
+
 async function writeSessionSkillActiveState(
 	stateDir: string,
 	sessionId: string,
@@ -4600,6 +4620,128 @@ PY`,
       if (typeof previousPath === "string") process.env.PATH = previousPath;
       else delete process.env.PATH;
       await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("authorizes a live unmatched Stop from its exact session owner sidecar without changing the selected pointer", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-sidecar-stop-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const selectedSessionId = "native-selected-owner";
+      const independentSessionId = "native-independent-owner";
+      await writeSessionStart(cwd, selectedSessionId, {
+        nativeSessionId: selectedSessionId,
+        pid: process.pid,
+      });
+      await writeLiveNativeSessionOwnerSidecar(cwd, stateDir, independentSessionId);
+      const pointerBefore = await readFile(join(stateDir, "session.json"), "utf-8");
+      const rootGoalPath = join(cwd, ".omx", "ultragoal", "goals.json");
+      await writeJson(rootGoalPath, {
+        version: 1,
+        aggregateCompletion: {
+          status: "complete",
+          completedAt: "2026-05-20T00:00:00.000Z",
+        },
+        goals: [{ id: "G001-done", status: "complete", objective: "Done" }],
+      });
+      const rootGoalBefore = await readFile(rootGoalPath, "utf-8");
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: independentSessionId,
+          thread_id: independentSessionId,
+          last_user_message:
+            "get_goal reports a completed Codex goal still attached to this thread; do not call create_goal until cleanup is explicit.",
+          last_assistant_message:
+            "I am starting another run now; create_goal payload follows.",
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+      assert.equal(await readFile(rootGoalPath, "utf-8"), rootGoalBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the unmatched sidecar session workflow as the Stop blocker", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-sidecar-skill-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const selectedSessionId = "native-selected-skill";
+      const independentSessionId = "native-independent-skill";
+      await writeSessionStart(cwd, selectedSessionId, {
+        nativeSessionId: selectedSessionId,
+        pid: process.pid,
+      });
+      await writeLiveNativeSessionOwnerSidecar(cwd, stateDir, independentSessionId);
+      await writeSessionSkillActiveState(stateDir, independentSessionId, "ralplan", "planning");
+      await writeJson(
+        join(stateDir, "sessions", independentSessionId, "ralplan-state.json"),
+        {
+          active: true,
+          current_phase: "planning",
+          session_id: independentSessionId,
+          workingDirectory: cwd,
+        },
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: independentSessionId,
+          thread_id: independentSessionId,
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.stopReason ?? ""), /^skill_ralplan_planning_/);
+      assert.notEqual(result.outputJson?.stopReason, "session_scope_unmatched");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("uses a live parent sidecar when a nested selected pointer is stale-dead", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-sidecar-stale-root-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const parentSessionId = "native-live-parent";
+      await writeSessionStart(cwd, parentSessionId, {
+        nativeSessionId: parentSessionId,
+        pid: process.pid,
+      });
+      await writeLiveNativeSessionOwnerSidecar(cwd, stateDir, parentSessionId);
+      await writeJson(join(stateDir, "session.json"), {
+        session_id: "native-dead-nested",
+        native_session_id: "native-dead-nested",
+        started_at: "2026-01-01T00:00:00.000Z",
+        cwd,
+        pid: 999_999,
+        platform: process.platform,
+      });
+      const pointerBefore = await readFile(join(stateDir, "session.json"), "utf-8");
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: parentSessionId,
+          thread_id: parentSessionId,
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
     }
   });
 

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -40,12 +40,14 @@ import {
   isSessionStale,
   isSessionStateUsable,
   normalizeSessionId,
+  readNativeSessionOwner,
   readSessionPointer,
   readSessionState,
   readUsableSessionState,
   reconcileNativeSessionStart,
   resolveSessionPointerContext,
   type SessionStartOptions,
+  writeNativeSessionOwner,
   type SessionState,
 } from "../hooks/session.js";
 import {
@@ -19964,7 +19966,7 @@ export async function dispatchCodexNativeHook(
   if (promptTurnContext?.status === "authorized") {
     canonicalSessionId = promptTurnContext.authorization.targetSessionId;
   }
-  const allowPromptGlobalSideEffects = promptTurnContext?.status !== "authorized"
+  let allowGlobalSideEffects = promptTurnContext?.status !== "authorized"
     || promptTurnContext.authorization.globalSideEffects === "allow";
   let resolvedNativeSessionId = nativeSessionId;
   let skipCanonicalSessionStartContext = false;
@@ -20052,11 +20054,16 @@ export async function dispatchCodexNativeHook(
         allowImplicitSessionSideEffects = false;
       }
     } else {
-      const ownerOmxSessionId = await resolveVerifiedOwnerOmxSessionId();
+      let ownerState: SessionState | null = null;
       try {
+        const sessionOwnerPid = options.sessionOwnerPid ?? resolveSessionOwnerPid(payload);
+        ownerState = await writeNativeSessionOwner(cwd, nativeSessionId, {
+          pid: sessionOwnerPid,
+        });
+        const ownerOmxSessionId = await resolveVerifiedOwnerOmxSessionId();
         const sessionState = await reconcileNativeSessionStart(cwd, nativeSessionId, {
           context: pointerContext,
-          pid: options.sessionOwnerPid ?? resolveSessionOwnerPid(payload),
+          pid: sessionOwnerPid,
           ...options.sessionStartOptions,
           ...(ownerOmxSessionId
             ? { ownerOmxSessionId, ownerAliasVerified: true }
@@ -20074,15 +20081,27 @@ export async function dispatchCodexNativeHook(
         // leader PreToolUse path below, which fires before the first in-turn role-intent
         // write. Fail closed here rather than risk a false-leader adoption.
       } catch (error) {
-        if (!isSessionPointerLaunchAbort(error)) throw error;
-        canonicalSessionId = "";
-        resolvedNativeSessionId = nativeSessionId;
-        skipCanonicalSessionStartContext = true;
-        allowImplicitSessionSideEffects = false;
-        stopAuthorizationFailure = {
-          stopReason: "session_pointer_unusable",
-          reason: `OMX cannot authorize Stop while the selected session pointer is ${pointer.status}; repair the pointer evidence before continuing.`,
-        };
+        if (
+          ownerState
+          && isSessionPointerLaunchAbort(error)
+          && error.code === "session_pointer_owner_conflict"
+        ) {
+          canonicalSessionId = ownerState.session_id;
+          resolvedNativeSessionId = ownerState.native_session_id ?? nativeSessionId;
+          allowImplicitSessionSideEffects = true;
+          allowGlobalSideEffects = false;
+          stopAuthorizationFailure = null;
+        } else {
+          if (!isSessionPointerLaunchAbort(error)) throw error;
+          canonicalSessionId = "";
+          resolvedNativeSessionId = nativeSessionId;
+          skipCanonicalSessionStartContext = true;
+          allowImplicitSessionSideEffects = false;
+          stopAuthorizationFailure = {
+            stopReason: "session_pointer_unusable",
+            reason: `OMX cannot authorize Stop while the selected session pointer is ${pointer.status}; repair the pointer evidence before continuing.`,
+          };
+        }
       }
     }
   } else if (!canonicalSessionId) {
@@ -20105,18 +20124,32 @@ export async function dispatchCodexNativeHook(
           : pointer.status === "absent",
       );
     if ((declaredTeamWorker && !authorizedWorkerStopSessionId) || (stopPayloadSessionId && !stopCanonicalSessionId)) {
-      canonicalSessionId = "";
-      allowImplicitSessionSideEffects = false;
-      if (declaredTeamWorker && !authorizedWorkerStopSessionId) {
-        stopAuthorizationFailure = {
-          stopReason: "session_scope_unmatched",
-          reason: "OMX cannot authorize Team worker Stop without exactly one valid explicit session id.",
-        };
-      } else if (!stopAuthorizationFailure) {
-        stopAuthorizationFailure = {
-          stopReason: "session_scope_unmatched",
-          reason: `OMX cannot authorize Stop for unmatched session id ${stopPayloadSessionId}; the selected session pointer remains authoritative.`,
-        };
+      const ownerState = !declaredTeamWorker && stopPayloadSessionId
+        ? await readNativeSessionOwner(cwd, stopPayloadSessionId)
+        : null;
+      if (
+        ownerState
+        && (pointer.status === "usable" || pointer.status === "stale-dead")
+      ) {
+        canonicalSessionId = ownerState.session_id;
+        resolvedNativeSessionId = ownerState.native_session_id ?? stopPayloadSessionId;
+        allowImplicitSessionSideEffects = true;
+        allowGlobalSideEffects = false;
+        stopAuthorizationFailure = null;
+      } else {
+        canonicalSessionId = "";
+        allowImplicitSessionSideEffects = false;
+        if (declaredTeamWorker && !authorizedWorkerStopSessionId) {
+          stopAuthorizationFailure = {
+            stopReason: "session_scope_unmatched",
+            reason: "OMX cannot authorize Team worker Stop without exactly one valid explicit session id.",
+          };
+        } else if (!stopAuthorizationFailure) {
+          stopAuthorizationFailure = {
+            stopReason: "session_scope_unmatched",
+            reason: `OMX cannot authorize Stop for unmatched session id ${stopPayloadSessionId}; the selected session pointer remains authoritative.`,
+          };
+        }
       }
     } else if (stopCanonicalSessionId) {
       canonicalSessionId = stopCanonicalSessionId;
@@ -20184,11 +20217,11 @@ export async function dispatchCodexNativeHook(
     if (!isSubagentPromptSubmit) {
       promptClassification = classifyKeywordInput(prompt);
     }
-    goalWorkflowAdditionalContext = allowPromptGlobalSideEffects
+    goalWorkflowAdditionalContext = allowGlobalSideEffects
       ? await buildCompletedGoalCleanupPromptWarning(cwd, prompt).catch(() => null)
         ?? await buildGoalWorkflowReconciliationPromptWarning(cwd, prompt).catch(() => null)
       : null;
-    ultragoalSteeringAdditionalContext = prompt && !isSubagentPromptSubmit && allowImplicitSessionSideEffects && allowPromptGlobalSideEffects
+    ultragoalSteeringAdditionalContext = prompt && !isSubagentPromptSubmit && allowImplicitSessionSideEffects && allowGlobalSideEffects
       ? await applyUserPromptUltragoalSteering(cwd, prompt).catch((error) => `OMX native UserPromptSubmit rejected bounded .omx/ultragoal steering for G002-cli-and-prompt-submit-bridge: ${error instanceof Error ? error.message : String(error)}`)
       : null;
     let suppressActivationSeeding = !allowImplicitSessionSideEffects;
@@ -20238,7 +20271,7 @@ export async function dispatchCodexNativeHook(
       prompt
       && skillState === null
       && !isSubagentPromptSubmit
-      && allowPromptGlobalSideEffects
+      && allowGlobalSideEffects
       && promptClassification?.reservedInput === null
       && promptClassification.hasExplicitLikeInvocation === false
       && promptClassification.matches.length === 0
@@ -20318,7 +20351,7 @@ export async function dispatchCodexNativeHook(
     const skipHudReconcileForDoctorSmoke = process.env.OMX_NATIVE_HOOK_DOCTOR_SMOKE === "1";
     const skipHudReconcileForTeamWorkerPane = !isSubagentPromptSubmit
       && await isConfirmedTeamWorkerPromptSubmitPane(cwd).catch(() => false);
-    if (allowImplicitSessionSideEffects && allowPromptGlobalSideEffects && !skipHudReconcileForDoctorSmoke && !skipHudReconcileForTeamWorkerPane) {
+    if (allowImplicitSessionSideEffects && allowGlobalSideEffects && !skipHudReconcileForDoctorSmoke && !skipHudReconcileForTeamWorkerPane) {
       const reconcileHudForPromptSubmitFn = options.reconcileHudForPromptSubmitFn ?? reconcileHudForPromptSubmit;
       const hudSessionId = resolveHudReconcileSessionId(
         currentSessionState,
@@ -20335,7 +20368,7 @@ export async function dispatchCodexNativeHook(
     }
   }
 
-  if (omxEventName && allowImplicitSessionSideEffects && allowPromptGlobalSideEffects && !skipCanonicalSessionStartContext && !suppressNoisySubagentLifecycleDispatch) {
+  if (omxEventName && allowImplicitSessionSideEffects && allowGlobalSideEffects && !skipCanonicalSessionStartContext && !suppressNoisySubagentLifecycleDispatch) {
     const baseContext = buildBaseContext(cwd, payload, hookEventName!, canonicalSessionId);
     if (resolvedNativeSessionId) {
       baseContext.native_session_id = resolvedNativeSessionId;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2832,7 +2832,15 @@ async function readModeStateWithStopSource(
   mode: "autopilot" | "ultrawork" | "ultraqa",
   cwd: string,
   sessionId?: string,
+  options: { sessionScopedOnly?: boolean } = {},
 ): Promise<{ state: Record<string, unknown>; path: string } | null> {
+  if (options.sessionScopedOnly) {
+    const normalizedSessionId = safeString(sessionId).trim();
+    if (!normalizedSessionId) return null;
+    const path = getStateFilePath(`${mode}-state.json`, cwd, normalizedSessionId);
+    const state = await readJsonIfExists(path);
+    return state ? { state, path } : null;
+  }
   const paths = await getAuthoritativeActiveStatePaths(mode, cwd, sessionId?.trim() || undefined).catch(() => [] as string[]);
   const path = paths[0];
   if (!path) return null;
@@ -2902,6 +2910,7 @@ async function buildModeBasedStopOutput(
   mode: "autopilot" | "ultrawork" | "ultraqa",
   cwd: string,
   sessionId?: string,
+  options: { sessionScopedOnly?: boolean } = {},
 ): Promise<Record<string, unknown> | null> {
   if (await readCanonicalTerminalRunStateForStop(cwd, sessionId, mode)) {
     return null;
@@ -2909,10 +2918,12 @@ async function buildModeBasedStopOutput(
   if (mode === "autopilot" && await readAutopilotDeepInterviewQuestionWaitState(cwd, sessionId)) {
     return null;
   }
-  const sourcedState = await readModeStateWithStopSource(mode, cwd, sessionId);
+  const sourcedState = await readModeStateWithStopSource(mode, cwd, sessionId, options);
   const state = sourcedState?.state ?? null;
   if (!state || !shouldContinueRun(state)) return null;
-  const rootCanonicalState = await readRawSkillActiveState(getSkillActiveStatePathsForStateDir(getBaseStateDir(cwd)).rootPath);
+  const rootCanonicalState = options.sessionScopedOnly
+    ? null
+    : await readRawSkillActiveState(getSkillActiveStatePathsForStateDir(getBaseStateDir(cwd)).rootPath);
   const canonicalDisagreement = rootCanonicalState
     ? canonicalStopDisagreement(state, rootCanonicalState, mode, sessionId)
     : "canonical_state_missing";
@@ -3249,6 +3260,7 @@ async function readTeamModeStateForStop(
   stateDir: string,
   sessionId?: string,
   threadId?: string,
+  options: { sessionScopedOnly?: boolean } = {},
 ): Promise<TeamModeStateForStop | null> {
   const normalizedSessionId = safeString(sessionId).trim();
   if (!normalizedSessionId) return null;
@@ -3259,6 +3271,7 @@ async function readTeamModeStateForStop(
       ? { state: scopedState, scope: "session" }
       : null;
   }
+  if (options.sessionScopedOnly) return null;
 
   const rootState = await readJsonIfExists(join(stateDir, "team-state.json"));
   if (rootState?.active !== true) return null;
@@ -3273,21 +3286,37 @@ async function readTeamModeStateForStop(
   return { state: rootState, scope: "root" };
 }
 
-async function buildTeamStopOutput(cwd: string, sessionId?: string, threadId?: string): Promise<Record<string, unknown> | null> {
+async function buildTeamStopOutput(
+  cwd: string,
+  sessionId?: string,
+  threadId?: string,
+  options: { sessionScopedOnly?: boolean } = {},
+): Promise<Record<string, unknown> | null> {
   if (await readCanonicalTerminalRunStateForStop(cwd, sessionId, "team")) {
     return null;
   }
-  const teamStateForStop = await readTeamModeStateForStop(cwd, getBaseStateDir(cwd), sessionId, threadId);
+  const teamStateForStop = await readTeamModeStateForStop(
+    cwd,
+    getBaseStateDir(cwd),
+    sessionId,
+    threadId,
+    options,
+  );
   if (!teamStateForStop || teamStateForStop.state.active !== true) return null;
   const teamState = teamStateForStop.state;
   const teamName = safeString(teamState.team_name).trim();
+  const coarsePhase = teamState.current_phase;
+  if (options.sessionScopedOnly) {
+    return isNonTerminalPhase(coarsePhase)
+      ? buildTeamStopOutputForPhase(teamName, formatPhase(coarsePhase))
+      : null;
+  }
   if (teamName) {
     const canonicalTeamDir = join(resolveCanonicalTeamStateRoot(cwd), "team", teamName);
     if (!existsSync(canonicalTeamDir)) {
       return null;
     }
   }
-  const coarsePhase = teamState.current_phase;
   const canonicalPhaseState = teamName ? await readTeamPhase(teamName, cwd) : null;
   if (teamStateForStop.scope === "root" && !canonicalPhaseState) return null;
   const canonicalPhase = canonicalPhaseState?.current_phase ?? coarsePhase;
@@ -18961,8 +18990,11 @@ async function buildDeepInterviewQuestionStopOutput(
   stateDir: string,
   sessionId: string,
   threadId: string,
+  options: { sessionScopedOnly?: boolean } = {},
 ): Promise<{ output: Record<string, unknown>; obligationId: string } | null> {
-  await reconcileDeepInterviewQuestionEnforcementFromAnsweredRecords(cwd, sessionId);
+  if (!options.sessionScopedOnly) {
+    await reconcileDeepInterviewQuestionEnforcementFromAnsweredRecords(cwd, sessionId);
+  }
   if (await readAutopilotDeepInterviewQuestionWaitState(cwd, sessionId)) {
     return null;
   }
@@ -19553,6 +19585,30 @@ async function buildStopHookOutput(
   const suppressParentWorkflowStop = shouldSuppressParentWorkflowStopForSideConversation(payload);
   if (options.sessionScopedOnly) {
     if (!canonicalSessionId || suppressParentWorkflowStop) return null;
+    for (const mode of ["autopilot", "ultrawork", "ultraqa"] as const) {
+      const modeOutput = await buildModeBasedStopOutput(
+        mode,
+        cwd,
+        canonicalSessionId,
+        { sessionScopedOnly: true },
+      );
+      if (modeOutput) return modeOutput;
+    }
+    const teamOutput = await buildTeamStopOutput(
+      cwd,
+      canonicalSessionId,
+      threadId,
+      { sessionScopedOnly: true },
+    );
+    if (teamOutput) return teamOutput;
+    const deepInterviewQuestionOutput = await buildDeepInterviewQuestionStopOutput(
+      cwd,
+      stateDir,
+      canonicalSessionId,
+      threadId,
+      { sessionScopedOnly: true },
+    );
+    if (deepInterviewQuestionOutput) return deepInterviewQuestionOutput.output;
     return await buildSkillStopOutput(
       cwd,
       stateDir,

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -20173,6 +20173,7 @@ export async function dispatchCodexNativeHook(
           resolvedNativeSessionId = ownerState.native_session_id ?? nativeSessionId;
           allowImplicitSessionSideEffects = true;
           allowGlobalSideEffects = false;
+          skipCanonicalSessionStartContext = true;
           stopAuthorizationFailure = null;
         } else {
           if (!isSessionPointerLaunchAbort(error)) throw error;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -18601,6 +18601,7 @@ async function readBlockingSkillForStop(
   sessionId: string,
   threadId: string,
   requiredSkill?: string,
+  options: { sessionScopedOnly?: boolean } = {},
 ): Promise<{ skill: string; phase: string; latestPlanPath?: string; planningComplete?: boolean; runOutcome?: string } | null> {
   const canonicalState = await readVisibleSkillActiveStateForStateDir(stateDir, sessionId);
   const visibleEntries = canonicalState ? listActiveSkills(canonicalState) : [];
@@ -18619,7 +18620,7 @@ async function readBlockingSkillForStop(
     const modeSnapshot = getRunContinuationSnapshot(modeState);
     if (modeSnapshot?.terminal === true) continue;
 
-    if (await shouldIgnoreSessionSkillBlockerForCanonicalInactiveRoot(
+    if (!options.sessionScopedOnly && await shouldIgnoreSessionSkillBlockerForCanonicalInactiveRoot(
       cwd,
       stateDir,
       skill,
@@ -19353,11 +19354,21 @@ async function buildSkillStopOutput(
   stateDir: string,
   sessionId: string,
   threadId: string,
+  options: { sessionScopedOnly?: boolean } = {},
 ): Promise<Record<string, unknown> | null> {
-  const blocker = await readBlockingSkillForStop(cwd, stateDir, sessionId, threadId);
+  const blocker = await readBlockingSkillForStop(
+    cwd,
+    stateDir,
+    sessionId,
+    threadId,
+    undefined,
+    options,
+  );
   if (!blocker) return null;
 
-  const subagentSummary = await readSubagentSessionSummary(cwd, sessionId).catch(() => null);
+  const subagentSummary = options.sessionScopedOnly
+    ? null
+    : await readSubagentSessionSummary(cwd, sessionId).catch(() => null);
   const activeSubagentCount = subagentSummary?.activeSubagentThreadIds.length ?? 0;
 
   if (blocker.skill === "ralplan") {
@@ -19491,7 +19502,13 @@ async function buildStopHookOutput(
   payload: CodexHookPayload,
   cwd: string,
   stateDir: string,
-  options: { skipAutoNudge?: boolean; skipRalphStopBlock?: boolean; canonicalSessionId?: string; teamWorkerOnly?: boolean } = {},
+  options: {
+    skipAutoNudge?: boolean;
+    skipRalphStopBlock?: boolean;
+    canonicalSessionId?: string;
+    teamWorkerOnly?: boolean;
+    sessionScopedOnly?: boolean;
+  } = {},
 ): Promise<Record<string, unknown> | null> {
   if (isStopExempt(payload)) {
     return null;
@@ -19534,6 +19551,16 @@ async function buildStopHookOutput(
     ?? await resolveInternalSessionIdForPayload(cwd, sessionId);
   const threadId = readPayloadThreadId(payload);
   const suppressParentWorkflowStop = shouldSuppressParentWorkflowStopForSideConversation(payload);
+  if (options.sessionScopedOnly) {
+    if (!canonicalSessionId || suppressParentWorkflowStop) return null;
+    return await buildSkillStopOutput(
+      cwd,
+      stateDir,
+      canonicalSessionId,
+      threadId,
+      { sessionScopedOnly: true },
+    );
+  }
   if (canonicalSessionId) {
     await reconcileStaleRootSkillActiveStateForStop(cwd, stateDir, canonicalSessionId);
     if (await hasAuthoritativeInactiveSkillStopState(cwd, stateDir, "ralplan", canonicalSessionId, threadId)) {
@@ -20655,11 +20682,17 @@ export async function dispatchCodexNativeHook(
     if (declaredTeamWorkerStopOnly) {
       outputJson = await buildStopHookOutput(payload, cwd, stateDir, { teamWorkerOnly: true });
     } else if (allowImplicitSessionSideEffects) {
-      outputJson = await buildStopHookOutput(payload, cwd, stateDir, {
+      const stopOutput = await buildStopHookOutput(payload, cwd, stateDir, {
         canonicalSessionId: canonicalSessionId || undefined,
         skipRalphStopBlock: isSubagentStop,
         skipAutoNudge: isSubagentStop,
-      }) ?? await buildCompletedGoalCleanupStopOutput(payload, cwd);
+        sessionScopedOnly: !allowGlobalSideEffects,
+      });
+      outputJson = stopOutput ?? (
+        allowGlobalSideEffects
+          ? await buildCompletedGoalCleanupStopOutput(payload, cwd)
+          : null
+      );
     } else {
       const failure = stopAuthorizationFailure ?? {
         stopReason: "session_pointer_unusable",


### PR DESCRIPTION
## Summary

Keep native owner-sidecar authority scoped to the exact owning session when selected-pointer evidence belongs to another live or stale native session.

This prevents an unrelated native `SessionStart` conflict from leaking misleading selected-pointer context into the current window, while preserving the selected pointer and keeping sidecar-authorized `Stop` handling session-local.

## Changes

- Register and preserve exact root native owner sidecar evidence without stealing the selected workspace pointer.
- Authorize unmatched native `Stop` only through exact, cwd-authoritative, live owner sidecar evidence.
- Keep sidecar-scoped `Stop` out of root/global lifecycle side effects.
- Suppress `SessionStart` context injection when the selected pointer rejects an unrelated native launch.
- Keep foreign, malformed, stale, identity-indeterminate, and cwd-mismatched evidence fail-closed.

## Verification

```text
npm test                                                    PASS, exit 0
node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js  PASS, 582/582
node dist/scripts/run-test-files.js dist/hooks/__tests__/session.test.js              PASS, 73/73
git diff --check                                           PASS
git diff --check HEAD                                      PASS
git merge-base --is-ancestor origin/dev HEAD               PASS
```

Manual check: a fresh new Codex window no longer reproduced the original prompt-level stale-dead selected-pointer failure.

## Delivery boundary

This PR is source-only.

Not performed:

- install/sync
- production/live rollout
- installed-package runtime acceptance

Related: #3243
Also adjacent to closed #3138, #3202, #3203, #3221, and #3234.
