### PR TITLE
fix(tmux): preserve separator argv boundaries

### DIFF
--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test';
+import { describe, it, type TestContext } from 'node:test';
 import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
 import { chmod, mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
@@ -6,7 +6,7 @@ import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { HUD_TMUX_HEIGHT_LINES } from '../../hud/constants.js';
+import { HUD_RESIZE_RECONCILE_DELAY_SECONDS, HUD_TMUX_HEIGHT_LINES } from '../../hud/constants.js';
 import { DETACHED_TMUX_HISTORY_LIMIT } from '../index.js';
 import {
   closeLaunchSessionBindingOnce,
@@ -15,9 +15,9 @@ import {
   writeSessionStart,
   type LaunchSessionBinding,
 } from '../../hooks/session.js';
+import { isRealTmuxAvailable, withTempTmuxSession } from '../../team/__tests__/tmux-test-fixture.js';
 
 const CLI_SPAWN_TIMEOUT_MS = 60_000;
-
 function buildRunOmxEnv(envOverrides: Record<string, string>): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env };
   for (const key of Object.keys(env)) {
@@ -75,7 +75,6 @@ function shouldSkipForSpawnPermissions(_err: string): false {
   // not a pass. Node's test runner has no portable dynamic skip here.
   return false;
 }
-
 
 async function createGitRepo(wd: string): Promise<string> {
   const repo = join(wd, 'repo');
@@ -273,6 +272,19 @@ async function waitForPath(path: string, expectedLines: number = 1): Promise<voi
   throw new Error(`timed out waiting for ${path}`);
 }
 
+function parseShimTmuxArgv(contents: string): string[][] {
+  return contents
+    .split('tmux argv:\n')
+    .slice(1)
+    .map((record) => record.split('\nend tmux argv')[0]!.split('\n').filter(Boolean));
+}
+
+async function assertShimLogQuiescent(path: string, quietPeriodMs: number, message: string): Promise<void> {
+  const before = await readFile(path, 'utf-8').catch(() => '');
+  await new Promise((resolve) => setTimeout(resolve, quietPeriodMs));
+  assert.equal(await readFile(path, 'utf-8').catch(() => ''), before, message);
+}
+
 async function stopHeldOmx(child: ReturnType<typeof spawn>, releasePath: string): Promise<void> {
   await rm(releasePath, { force: true });
   await new Promise<void>((resolve, reject) => {
@@ -316,6 +328,13 @@ while [ -f "${releasePath}" ]; do sleep 1; done
       TMUX_PANE: '',
     },
   };
+}
+
+function skipUnlessPrivateRealTmux(t: TestContext): boolean {
+  if (isRealTmuxAvailable()) return true;
+  assert.equal(process.env.CI, undefined, 'CI must provide tmux for the private-server detached launch regression');
+  t.skip('tmux is not installed');
+  return false;
 }
 
 describe('omx launch fallback when tmux is unavailable', () => {
@@ -913,6 +932,117 @@ exit 0
 });
 
 describe('omx launcher when tmux is available', () => {
+  it('captures the compiled detached parser transport and stored hook on a private tmux server', async (t) => {
+    if (!skipUnlessPrivateRealTmux(t)) return;
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-private-real-tmux-'));
+    try {
+      await withTempTmuxSession(async (fixture) => {
+        const home = join(wd, 'home');
+        const bin = join(wd, 'bin');
+        const foreignSession = 'foreign-control';
+        await mkdir(home, { recursive: true });
+        await mkdir(bin, { recursive: true });
+        await writeExecutable(join(bin, 'codex'), '#!/bin/sh\nsleep 300\n');
+        const shimLogPath = join(wd, 'private-tmux-shim.log');
+        await fixture.createPathShim(bin, shimLogPath);
+        fixture.run(['new-session', '-d', '-s', foreignSession, 'sleep 300']);
+        const foreignBefore = fixture.run(['list-panes', '-t', foreignSession, '-F', '#{pane_id}\t#{pane_pid}\t#{pane_height}']);
+
+        const result = runOmx(wd, ['--madmax', '--tmux'], {
+          HOME: home,
+          PATH: `${bin}:${process.env.PATH ?? ''}`,
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+          OMX_HERMES_MCP_BRIDGE: '1',
+          OMX_LAUNCH_POLICY: 'direct',
+          TMUX: '',
+          TMUX_PANE: '',
+        });
+        assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+
+        const launchedSession = fixture.run(['list-sessions', '-F', '#{session_name}'])
+          .split('\n')
+          .find((name) => name.startsWith('omx-') && name !== fixture.sessionName);
+        assert.ok(launchedSession, 'compiled launcher must create its detached session on the private server');
+        const panes = fixture.run(['list-panes', '-t', launchedSession, '-F', '#{pane_id}\t#{pane_height}\t#{pane_start_command}'])
+          .split('\n')
+          .map((line) => line.split('\t'));
+        const hud = panes.find(([, , command]) => command.includes('OMX_DETACHED_HUD_OPERATION='));
+        assert.ok(hud, 'HUD split must carry its operation marker');
+        assert.equal(Number(hud[1]), HUD_TMUX_HEIGHT_LINES, 'authorized direct reconciliation must resize the HUD');
+        assert.equal(
+          fixture.run(['show-options', '-v', '-t', launchedSession, 'history-limit']),
+          String(DETACHED_TMUX_HISTORY_LIMIT),
+          'direct leader mutation must receive its receipt and set session history',
+        );
+
+        const hooks = fixture.run(['show-hooks', '-t', launchedSession]);
+        assert.match(hooks, /client-resized\[[0-9]+\].*run-shell -b/);
+        assert.match(hooks, /tmux if-shell -F -t/);
+        assert.match(hooks, /OMX_DETACHED_HUD_OPERATION=/);
+        const storedPaneFormat = hooks.match(/##\{pane_id\}\\t##\{pane_dead\}\\t##\{pane_pid\}/)?.[0] ?? '';
+        assert.equal(storedPaneFormat, '##{pane_id}\\t##{pane_dead}\\t##{pane_pid}', 'stored hook display must retain one outer format escape and encode TAB bytes');
+        const executablePaneFormat = storedPaneFormat.replaceAll('##{', '#{').replaceAll('\\t', '\t');
+        assert.equal(executablePaneFormat, '#{pane_id}\t#{pane_dead}\t#{pane_pid}', 'one outer tmux format pass must decode the stored format into the executable nested argv');
+
+        const clientAttachedHookSlots = [...hooks.matchAll(/client-attached\[[0-9]+\]/g)].map(([slot]) => slot);
+        for (const hookSlot of clientAttachedHookSlots) {
+          fixture.run(['set-hook', '-u', '-t', launchedSession, hookSlot]);
+        }
+        const installedHooks = fixture.run(['show-hooks', '-t', launchedSession]);
+        const storedResizeHookSlots = [...installedHooks.matchAll(/client-resized\[[0-9]+\]/g)].map(([slot]) => slot);
+        assert.equal(storedResizeHookSlots.length, 1, 'exactly one installed client-resized hook must remain for the natural resize trigger');
+        assert.match(installedHooks, /client-resized\[[0-9]+\].*run-shell -b/);
+        assert.doesNotMatch(installedHooks, /client-attached\[[0-9]+\]/, 'the resize trigger must not be conflated with client-attached hook execution');
+
+        await new Promise((resolve) => setTimeout(resolve, (HUD_RESIZE_RECONCILE_DELAY_SECONDS * 1_000) + 250));
+        const launchPaneSnapshots = parseShimTmuxArgv(await readFile(shimLogPath, 'utf-8'))
+          .filter((argv) => argv[0] === 'list-panes' && argv[1] === '-a');
+        assert.ok(
+          launchPaneSnapshots.length >= 2,
+          'the direct and delayed launch reconciliations must both complete before the stored-hook baseline is cleared',
+        );
+        await assertShimLogQuiescent(
+          shimLogPath,
+          250,
+          'launch and delayed reconciliation must settle before clearing the stored-hook baseline',
+        );
+        await writeFile(shimLogPath, '');
+        assert.equal(await readFile(shimLogPath, 'utf-8'), '', 'the shim baseline must start after launch and reconciliation activity settles');
+
+        fixture.triggerClientResize(launchedSession);
+        await new Promise((resolve) => setTimeout(resolve, (HUD_RESIZE_RECONCILE_DELAY_SECONDS * 1_000) + 250));
+        await assertShimLogQuiescent(
+          shimLogPath,
+          250,
+          'the stored client-resized hook must finish both its immediate and delayed passes before assertions',
+        );
+
+        const nestedArgv = parseShimTmuxArgv(await readFile(shimLogPath, 'utf-8'));
+        const paneSnapshots = nestedArgv.filter((argv) => argv[0] === 'list-panes' && argv[1] === '-a');
+        assert.equal(
+          paneSnapshots.length,
+          2,
+          'only the explicitly triggered stored client-resized hook may produce the post-baseline immediate and delayed pane snapshots',
+        );
+        for (const argv of paneSnapshots) {
+          assert.deepEqual(
+            argv,
+            ['list-panes', '-a', '-F', executablePaneFormat],
+            'post-baseline stored client-resized hook execution must preserve the exact executable TAB-delimited nested argv',
+          );
+        }
+
+        fixture.run(['set-option', '-t', launchedSession, '@omx_instance_id', 'foreign-owner']);
+        assert.equal(Number(fixture.run(['display-message', '-p', '-t', hud[0]!, '#{pane_height}'])), HUD_TMUX_HEIGHT_LINES, 'foreign owner must not receive a deferred mutation without an authority receipt');
+        assert.equal(fixture.run(['list-panes', '-t', foreignSession, '-F', '#{pane_id}\t#{pane_pid}\t#{pane_height}']), foreignBefore);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
+    }
+  });
+
   it('does not let the outer launcher fabricate leader-owned active records', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-madmax-reuse-'));
     try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1542,7 +1542,7 @@ function detachedAuthorityReceipt(): string {
 
 function runDetachedLeaderMutation(authority: DetachedLeaderAuthority, args: string[], requireOwner = true): void {
   const receipt = detachedAuthorityReceipt();
-  const success = `${args.map(quoteShellArg).join(" ")} \\; display-message -p ${quoteShellArg(receipt)}`;
+  const success = `${args.map(quoteShellArg).join(" ")} ; display-message -p ${quoteShellArg(receipt)}`;
   const output = execTmuxFileSync([
     "if-shell", "-F", "-t", authority.paneId, detachedLeaderAuthorityCondition(authority, requireOwner),
     success, "display-message -p ''",
@@ -1556,7 +1556,7 @@ function runDetachedHudMutation(
   args: string[],
 ): void {
   const receipt = detachedAuthorityReceipt();
-  const success = `${args.map(quoteShellArg).join(" ")} \\; display-message -p ${quoteShellArg(receipt)}`;
+  const success = `${args.map(quoteShellArg).join(" ")} ; display-message -p ${quoteShellArg(receipt)}`;
   const hudGuard = `if-shell -F -t ${quoteShellArg(hudAuthority.paneId)} ${quoteShellArg(detachedHudAuthorityCondition(hudAuthority))} ${quoteShellArg(success)} ${quoteShellArg("display-message -p ''")}`;
   const output = execTmuxFileSync([
     "if-shell", "-F", "-t", leaderAuthority.paneId, detachedLeaderAuthorityCondition(leaderAuthority),
@@ -1572,11 +1572,15 @@ function buildDeferredDetachedHudGuard(
 ): string {
   const deferredReceipt = detachedAuthorityReceipt();
   const guardedResize = (match: string): string => {
-    const success = `${match} \\; display-message -p ${quoteShellArg(deferredReceipt)}`;
+    const success = `${match} ; display-message -p ${quoteShellArg(deferredReceipt)}`;
     const hudGuard = `if-shell -F -t ${quoteShellArg(hudAuthority.paneId)} ${quoteShellArg(detachedHudAuthorityCondition(hudAuthority))} ${quoteShellArg(success)} ${quoteShellArg("")}`;
     return `tmux if-shell -F -t ${quoteShellArg(leaderAuthority.paneId)} ${quoteShellArg(detachedLeaderAuthorityCondition(leaderAuthority))} ${quoteShellArg(hudGuard)} ${quoteShellArg("")}`;
   };
-  const guardedCommand = command.replace(
+  const outerFormatEscapedCommand = command
+    .replaceAll('#{pane_id}', '##{pane_id}')
+    .replaceAll('#{pane_dead}', '##{pane_dead}')
+    .replaceAll('#{pane_pid}', '##{pane_pid}');
+  const guardedCommand = outerFormatEscapedCommand.replace(
     /tmux resize-pane -t %[0-9]+ -y [1-9][0-9]*/g,
     guardedResize,
   );

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -5915,7 +5915,7 @@ exit 0
           assert.equal(tmuxLog.match(/set-hook -t leader:0 client-resized\[\d+\]/g)?.length ?? 0, 2);
           assert.equal(tmuxLog.match(/set-hook -t leader:0 client-attached\[\d+\]/g)?.length ?? 0, 2);
           assert.match(tmuxLog, /snapshot=\$\(tmux list-panes -a -F/);
-          assert.ok((tmuxLog.match(/list-panes -a -F '#\{pane_id\}\\t#\{pane_dead\}\\t#\{pane_pid\}'/g)?.length ?? 0) >= 6);
+          assert.ok((tmuxLog.match(/list-panes -a -F '#\{pane_id\}\t#\{pane_dead\}\t#\{pane_pid\}'/g)?.length ?? 0) >= 6);
           assert.ok((tmuxLog.match(/select-layout -t @1 main-vertical/g)?.length ?? 0) >= 2);
           assert.equal(tmuxLog.match(/kill-pane -t %3/g)?.length ?? 0, 2);
         },

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -470,6 +470,21 @@ describe('HUD resize hook command builders', () => {
     assert.match(args[4] ?? '', /set-hook -u -t my-session:0 client-attached\[\d+\]/);
   });
 
+  it('preserves literal formats and TAB-delimited authoritative snapshots across all HUD callers', () => {
+    const finalSnapshot = "#{pane_id}\t#{pane_dead}\t#{pane_pid}";
+    const commands = [
+      buildRegisterResizeHookArgs('my-session:0', 'omx_resize_team_session_0_1', '%1'),
+      buildRegisterClientAttachedReconcileArgs('my-session:0', 'omx_attached_team_session_0_1', '%1'),
+      buildScheduleDelayedHudResizeArgs('%1'),
+      buildReconcileHudResizeArgs('%1'),
+    ].map((args) => args.at(-1) ?? '');
+    for (const command of commands) {
+      assert.ok(command.includes(finalSnapshot));
+      assert.equal([...finalSnapshot].filter((character) => character === '\t').length, 2);
+      assert.doesNotMatch(finalSnapshot, /\\t/);
+    }
+  });
+
   it('pins Team hook and delayed HUD reconciliation to the created pane PID and owner', () => {
     const expectedPid = 2000000123;
     const expectedOwner = 'team:exact-owner';

--- a/src/team/__tests__/tmux-test-fixture.ts
+++ b/src/team/__tests__/tmux-test-fixture.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from 'node:child_process';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 
 const TMUX_COMMAND_TIMEOUT_MS = 5_000;
 const NULL_TMUX_CONFIG = process.platform === 'win32' ? 'NUL' : '/dev/null';
@@ -23,6 +24,10 @@ export interface TempTmuxSessionFixture {
     TMUX_PANE: string;
   };
   sessionExists: (targetSessionName?: string) => boolean;
+  run: (args: string[]) => string;
+  runResult: (args: string[]) => { status: number | null; stdout: string; stderr: string; error: string };
+  createPathShim: (directory: string, commandLogPath?: string) => Promise<string>;
+  triggerClientResize: (targetSession: string) => void;
 }
 
 export interface TempTmuxSessionOptions {
@@ -44,10 +49,10 @@ function applyTmuxEnv(snapshot: TmuxEnvSnapshot): void {
   else delete process.env.TMUX_PANE;
 }
 
-function runTmux(
+function runTmuxResult(
   args: string[],
   options: { ignoreTmuxEnv?: boolean; env?: NodeJS.ProcessEnv; serverName?: string; configFile?: string } = {},
-): string {
+): { status: number | null; stdout: string; stderr: string; error: string } {
   const env = options.env
     ?? (options.ignoreTmuxEnv ? { ...process.env, TMUX: undefined, TMUX_PANE: undefined } : process.env);
   const argv = [
@@ -62,22 +67,44 @@ function runTmux(
     timeout: TMUX_COMMAND_TIMEOUT_MS,
     killSignal: 'SIGKILL',
   });
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    error: result.error?.message || '',
+  };
+}
+
+function runTmux(
+  args: string[],
+  options: { ignoreTmuxEnv?: boolean; env?: NodeJS.ProcessEnv; serverName?: string; configFile?: string } = {},
+): string {
+  const result = runTmuxResult(args, options);
   if (result.error) {
+    throw new Error(result.error);
+  }
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `tmux exited ${result.status}`);
+  }
+  return result.stdout.trim();
+}
+
+export function isRealTmuxAvailable(): boolean {
+  const result = spawnSync('tmux', ['-V'], {
+    encoding: 'utf-8',
+    env: { ...process.env, TMUX: undefined, TMUX_PANE: undefined },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: TMUX_COMMAND_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
+  });
+  if (result.error) {
+    if ((result.error as NodeJS.ErrnoException).code === 'ENOENT') return false;
     throw result.error;
   }
   if (result.status !== 0) {
     throw new Error((result.stderr || '').trim() || `tmux exited ${result.status}`);
   }
-  return (result.stdout || '').trim();
-}
-
-export function isRealTmuxAvailable(): boolean {
-  try {
-    runTmux(['-V'], { ignoreTmuxEnv: true });
-    return true;
-  } catch {
-    return false;
-  }
+  return true;
 }
 
 export function tmuxSessionExists(sessionName: string, serverName?: string): boolean {
@@ -90,6 +117,14 @@ export function tmuxSessionExists(sessionName: string, serverName?: string): boo
   } catch {
     return false;
   }
+}
+
+function resolveTmuxExecutable(): string {
+  for (const directory of (process.env.PATH ?? '').split(delimiter)) {
+    const candidate = join(directory || '.', 'tmux');
+    if (existsSync(candidate)) return candidate;
+  }
+  throw new Error('tmux executable disappeared after availability probe');
 }
 
 function uniqueTmuxIdentifier(prefix: string): string {
@@ -120,6 +155,34 @@ export async function withTempTmuxSession<T>(
     serverName: serverName || undefined,
     configFile: serverKind === 'synthetic' ? NULL_TMUX_CONFIG : undefined,
   } as const;
+  const tmuxExecutable = resolveTmuxExecutable();
+  const createPathShim = async (directory: string, commandLogPath?: string): Promise<string> => {
+    if (serverKind !== 'synthetic') throw new Error('private tmux PATH shim requires a synthetic server');
+    const shimPath = join(directory, 'tmux');
+    const logCommand = commandLogPath ? `printf '%s\\n' 'tmux argv:' >> ${JSON.stringify(commandLogPath)}\nfor argument do printf '%s\\n' "$argument"; done >> ${JSON.stringify(commandLogPath)}\nprintf '%s\\n' 'end tmux argv' >> ${JSON.stringify(commandLogPath)}\n` : '';
+    await writeFile(
+      shimPath,
+      `#!/bin/sh\n${logCommand}exec ${JSON.stringify(tmuxExecutable)} -f ${JSON.stringify(NULL_TMUX_CONFIG)} -L ${JSON.stringify(serverName)} "$@"\n`,
+    );
+    await chmod(shimPath, 0o755);
+    runTmux(['set-environment', '-g', 'PATH', `${directory}${delimiter}${process.env.PATH ?? ''}`], tmuxOptions);
+    return shimPath;
+  };
+  const triggerClientResize = (targetSession: string): void => {
+    const script = `(sleep 0.1; stty rows 41 cols 121) & exec env TERM=xterm timeout 1 tmux -f ${JSON.stringify(NULL_TMUX_CONFIG)} -L ${JSON.stringify(serverName)} attach-session -t ${JSON.stringify(targetSession)}`;
+    const result = spawnSync('script', ['-q', '-e', '-c', script, '/dev/null'], {
+      encoding: 'utf-8',
+      env: { ...process.env, TMUX: undefined, TMUX_PANE: undefined },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: TMUX_COMMAND_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+    });
+    if (result.error) throw result.error;
+    if (result.status !== 124) {
+      throw new Error(`client resize trigger result: ${JSON.stringify({ status: result.status, stdout: result.stdout || '', stderr: result.stderr || '', error: '' })}`);
+    }
+  };
+
 
   const created = runTmux([
     'new-session',
@@ -162,18 +225,49 @@ export async function withTempTmuxSession<T>(
       TMUX_PANE: leaderPaneId,
     },
     sessionExists: (targetSessionName = sessionName) => tmuxSessionExists(targetSessionName, serverName || undefined),
+    run: (args) => runTmux(args, tmuxOptions),
+    runResult: (args) => runTmuxResult(args, tmuxOptions),
+    createPathShim,
+    triggerClientResize,
   };
 
   try {
     return await fn(fixture);
   } finally {
-    try {
-      if (serverKind === 'synthetic') {
+    if (serverKind === 'synthetic') {
+      try {
         runTmux(['kill-server'], tmuxOptions);
-      } else {
-        runTmux(['kill-session', '-t', sessionName], tmuxOptions);
+      } catch {}
+      const expectedNoServerMessages = [
+        `no server running on ${socketPath}`,
+        `error connecting to ${socketPath} (No such file or directory)`,
+      ];
+      let probe = runTmuxResult(['list-sessions'], tmuxOptions);
+      for (let attempt = 0; attempt < 10 && !(
+        probe.status === 1
+        && probe.stdout === ''
+        && expectedNoServerMessages.includes(probe.stderr.trim())
+      ); attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        probe = runTmuxResult(['list-sessions'], tmuxOptions);
       }
-    } catch {}
+      if (
+        probe.error
+        || probe.status !== 1
+        || probe.stdout !== ''
+        || !expectedNoServerMessages.includes(probe.stderr.trim())
+      ) {
+        applyTmuxEnv(previousEnv);
+        await rm(fixtureCwd, { recursive: true, force: true });
+        throw new Error(
+          `private tmux fixture cleanup did not prove private server termination: ${serverName}; ${JSON.stringify(probe)}`,
+        );
+      }
+    } else {
+      try {
+        runTmux(['kill-session', '-t', sessionName], tmuxOptions);
+      } catch {}
+    }
     applyTmuxEnv(previousEnv);
     await rm(fixtureCwd, { recursive: true, force: true });
   }

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1324,7 +1324,7 @@ function buildAuthoritativeHudResizeShellCommand(
   effectCommand: string = buildNestedTmuxShellCommand(buildHudResizeCommand(buildHudPaneTarget(hudPaneId), heightLines)),
 ): string {
   const target = buildHudPaneTarget(hudPaneId);
-  const snapshot = buildNestedTmuxShellCommand("list-panes -a -F '#{pane_id}\\t#{pane_dead}\\t#{pane_pid}'");
+  const snapshot = buildNestedTmuxShellCommand("list-panes -a -F '#{pane_id}\t#{pane_dead}\t#{pane_pid}'");
   const expectedPid = typeof expectedPanePid === 'number' && Number.isSafeInteger(expectedPanePid) && expectedPanePid > 0
     ? ` && $3 == "${expectedPanePid}"`
     : '';


### PR DESCRIPTION
Fixes #3256.

## Summary
- Correct detached tmux receipt command-list separators.
- Preserve literal pane formats and real TAB delimiters through the deferred outer-parser boundary.
- Add isolated private-server stored-hook provenance and lifecycle cleanup coverage.

## Verification
- `npm test`
- Focused private tmux stored-hook regression
- Full `launch-fallback` suite: 32/32
- Runtime relaunch regression

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*