### PR TITLE
fix(update): preserve Bun install ownership

### DIFF
--- a/docs/reports/issue-3257-update-owner-verification-manifest.json
+++ b/docs/reports/issue-3257-update-owner-verification-manifest.json
@@ -1,0 +1,53 @@
+{
+  "issue": 3257,
+  "phase": "Phase-0 feasibility harness",
+  "revision": 8,
+  "revisionSha256": "6de6d7f89f4be3cbe0dcb7b7780ffad753065871cffacd569cd4a5be9a8d0b4d",
+  "commandContractSha256": "4cacc4a13de4f6d53c54c9237aa4c1df6b9582cf824aa19d4911e12a57d447df",
+  "runtimeContract": "Node is the only runtime contract. npm and Windows behavior remain supported.",
+  "reviewChain": [
+    { "revision": 6, "reviewer": "Revision", "artifact": "stage-06-revision.md", "sha256": "1e4d9a1c34bba7e81e25398996b714a54b4607546fed67d79b2f4c86b9ff868d" },
+    { "revision": 6, "reviewer": "Architect", "artifact": "stage-06-architect.md", "sha256": "8e9bf50fbe22c771c26db8cfd144361f7d8531570304b48626be8653900b783b" },
+    { "revision": 6, "reviewer": "Critic", "artifact": "stage-06-critic.md", "sha256": "f77a034f411fdbba6c83bd61f0e8863adfdeaf2b79b41bcbf9f6c0d7842a66d9" },
+    { "revision": 7, "reviewer": "Revision", "artifact": "stage-07-revision.md", "sha256": "3fa478b0c27057fcd6d5fd5971208bc502dbf915f82f4f0c1bb0e3cda748a3e7" },
+    { "revision": 7, "reviewer": "Architect", "artifact": "stage-07-architect.md", "sha256": "cb6ed4ebbb99703e198fc7b52d89fd675ac2a32330c9a2fb89722f89c915d940" },
+    { "revision": 7, "reviewer": "Critic", "artifact": "stage-07-critic.md", "sha256": "51038b96a030c6e7b48e6dff6d3255c9fcb94841be02c22dd08672fbd1249bc9" }
+  ],
+  "installProfiles": {
+    "stable": {
+      "name": "CONTROLLER_INSTALL_ENV_V1.windows",
+      "argv": ["install", "--global", "--ignore-scripts", "--no-audit", "--no-progress", "--prefix", "<FROZEN_PREFIX>", "oh-my-codex@latest"],
+      "scriptExecution": "SUPPRESSED",
+      "empiricalExecution": "NOT_EXECUTED",
+      "ownerReview": "REQUIRED"
+    },
+    "dev": {
+      "name": "CONTROLLER_INSTALL_ENV_V1.posix",
+      "argv": ["install", "--global", "--ignore-scripts", "--no-audit", "--no-progress", "--prefix", "<FROZEN_PREFIX>", "<VALIDATED_ABSOLUTE_CONTAINED_TARBALL>"],
+      "scriptExecution": "SUPPRESSED",
+      "empiricalExecution": "NOT_EXECUTED",
+      "ownerReview": "REQUIRED"
+    }
+  },
+  "externalLifecycleVectors": [
+    { "profile": "EXTERNAL_GLOBAL_ENV_V1.enabled", "lifecycleExecution": "NOT_EXECUTED", "ownerReview": "REQUIRED" },
+    { "profile": "EXTERNAL_GLOBAL_ENV_V1.suppressed", "lifecycleExecution": "NOT_EXECUTED", "ownerReview": "REQUIRED" }
+  ],
+  "advisoryClosureRule": "A receipt is advisory only. Closure requires owner review of all NOT_EXECUTED evidence and must not infer product execution, package-manager ownership, or lifecycle safety.",
+  "residualWindowsThreatModel": {
+    "covered": "Deterministic resolution of existing pre-launch .com, .exe, .bat, and .cmd shadows in PATH order.",
+    "excluded": "Post-launch replacement, TOCTOU races, PATH mutation after launch, and any command execution.",
+    "residualRisk": "Owner review required; Bun must own the transaction or fail closed, and Bun dev must fail unsupported."
+  },
+  "candidateEvidence": {
+    "harness": "docs/reports/issue-3257/windows-command-harness/harness.mjs",
+    "dispatcher": "docs/reports/issue-3257/windows-command-harness/dispatcher.cmd",
+    "corpus": "docs/reports/issue-3257/windows-command-harness/resolution-corpus.json",
+    "empiricalStatus": "NOT_EXECUTED",
+    "ownerReview": "REQUIRED"
+  },
+  "ownerGate": {
+    "status": "REQUIRED",
+    "requiredBeforeClosure": ["Owner review", "Empirical execution evidence", "Bun transaction-or-fail-closed evidence", "Bun dev unsupported-failure evidence"]
+  }
+}

--- a/docs/reports/issue-3257/windows-command-harness/README.md
+++ b/docs/reports/issue-3257/windows-command-harness/README.md
@@ -1,0 +1,27 @@
+# Issue 3257 Windows command feasibility harness
+
+This is a **Phase-0, receipt-only** Node harness for the frozen Revision 8 command contract. It does not execute npm, Bun, package installation, product code, lifecycle scripts, or external commands. It makes no package-manager, global, user, or repository mutation.
+
+## Contract
+
+- Command-contract SHA-256: `4cacc4a13de4f6d53c54c9237aa4c1df6b9582cf824aa19d4911e12a57d447df`
+- Windows model: only command shadows already present before launch, resolved by PATH order and `.com`, `.exe`, `.bat`, `.cmd` precedence.
+- Excluded: post-launch replacement, TOCTOU races, PATH mutation after launch, and product execution.
+- Nested dispatcher allowlist: `npm run build`, `npm run verify:native-agents`, `npm run sync:plugin`, `npm run verify:plugin-bundle`, and `npm run clean:native-package-assets`.
+
+`dispatcher.cmd` delegates only to the Node allowlist checker. `dispatcher.mjs` prints an approved edge; it does not invoke npm.
+
+## Receipt shapes
+
+The harness emits a JSON feasibility receipt for one of two sources:
+
+- `stable`: `install --global --ignore-scripts --no-audit --no-progress --prefix <FROZEN_PREFIX> oh-my-codex@latest`
+- `dev`: `install --global --ignore-scripts --no-audit --no-progress --prefix <FROZEN_PREFIX> <VALIDATED_ABSOLUTE_CONTAINED_TARBALL>`
+
+`noop` accepts no root. `disposable` requires a direct child of the system temporary directory named `issue-3257-disposable-*`; all other roots fail closed. Both shapes report every empirical or execution field as `NOT_EXECUTED` and require owner review.
+
+## Evidence and limitations
+
+The corpus is deterministic fixture data, not a record of a Windows run. It is limited to pre-launch command resolution and cannot establish package-manager ownership, lifecycle safety, Bun behavior, npm behavior, or protection against post-launch races. Receipt output is advisory and cannot close the owner gate.
+
+Created Phase-0 artifacts: `harness.mjs`, `dispatcher.cmd`, `dispatcher.mjs`, `resolution-corpus.json`, `policy-schema.json`, this README, and `../issue-3257-update-owner-verification-manifest.json`.

--- a/docs/reports/issue-3257/windows-command-harness/dispatcher.cmd
+++ b/docs/reports/issue-3257/windows-command-harness/dispatcher.cmd
@@ -1,0 +1,4 @@
+@echo off
+setlocal DisableDelayedExpansion
+node "%~dp0dispatcher.mjs" %*
+exit /b %ERRORLEVEL%

--- a/docs/reports/issue-3257/windows-command-harness/dispatcher.mjs
+++ b/docs/reports/issue-3257/windows-command-harness/dispatcher.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import process from "node:process";
+
+const APPROVED_EDGES = new Set([
+  "npm run build",
+  "npm run verify:native-agents",
+  "npm run sync:plugin",
+  "npm run verify:plugin-bundle",
+  "npm run clean:native-package-assets",
+]);
+
+const requestedEdge = process.argv.slice(2).join(" ");
+if (!APPROVED_EDGES.has(requestedEdge)) {
+  process.stderr.write(`issue-3257 dispatcher rejected nested edge: ${requestedEdge || "<empty>"}\n`);
+  process.exitCode = 64;
+} else {
+  process.stdout.write(`${requestedEdge}\n`);
+}

--- a/docs/reports/issue-3257/windows-command-harness/harness.mjs
+++ b/docs/reports/issue-3257/windows-command-harness/harness.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import { relative, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import process from "node:process";
+
+const HERE = new URL(".", import.meta.url);
+const CORPUS_URL = new URL("resolution-corpus.json", HERE);
+const DISPOSABLE_PREFIX = "issue-3257-disposable-";
+const STABLE_PROFILE = "install --global --ignore-scripts --no-audit --no-progress --prefix <FROZEN_PREFIX> oh-my-codex@latest";
+const DEV_PROFILE = "install --global --ignore-scripts --no-audit --no-progress --prefix <FROZEN_PREFIX> <VALIDATED_ABSOLUTE_CONTAINED_TARBALL>";
+
+function usage(message) {
+  if (message) process.stderr.write(`${message}\n`);
+  process.stderr.write("usage: node harness.mjs --mode noop|disposable --source stable|dev [--root <disposable-temp-root>]\n");
+  process.exit(64);
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const option = argv[index];
+    if (!["--mode", "--source", "--root"].includes(option) || options[option]) usage("invalid or duplicate option");
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) usage(`missing value for ${option}`);
+    options[option] = value;
+    index += 1;
+  }
+  if (!options["--mode"] || !options["--source"]) usage("--mode and --source are required");
+  return { mode: options["--mode"], source: options["--source"], root: options["--root"] };
+}
+
+function assertDisposableRoot(root) {
+  if (!root) usage("--root is required for disposable mode");
+  const resolvedRoot = resolve(root);
+  const tempRoot = resolve(tmpdir());
+  const pathFromTemp = relative(tempRoot, resolvedRoot);
+  const contained = pathFromTemp && !pathFromTemp.startsWith("..") && !pathFromTemp.includes("/") && !pathFromTemp.includes("\\");
+  if (!contained || !resolvedRoot.split(/[\\/]/).at(-1).startsWith(DISPOSABLE_PREFIX)) {
+    usage("refusing non-disposable root; use a direct child of the system temp directory named issue-3257-disposable-*");
+  }
+  return resolvedRoot;
+}
+
+function windowsResolve(scenario, extensions) {
+  const existing = new Set(scenario.existingCommands.map((entry) => entry.toLowerCase()));
+  for (const directory of scenario.pathDirectories) {
+    for (const extension of extensions) {
+      const candidate = `${directory}\\${scenario.command}${extension}`;
+      if (existing.has(candidate.toLowerCase())) return candidate;
+    }
+  }
+  return null;
+}
+
+function verifyCorpus(corpus) {
+  const approvedEdges = [
+    "npm run build",
+    "npm run verify:native-agents",
+    "npm run sync:plugin",
+    "npm run verify:plugin-bundle",
+    "npm run clean:native-package-assets",
+  ];
+  if (
+    corpus.contractRevision !== 8
+    || corpus.commandContractSha256 !== "4cacc4a13de4f6d53c54c9237aa4c1df6b9582cf824aa19d4911e12a57d447df"
+    || corpus.windowsPathExtensions.join(",") !== ".com,.exe,.bat,.cmd"
+    || corpus.approvedNestedNpmRunEdges.join("\n") !== approvedEdges.join("\n")
+  ) {
+    throw new Error("corpus violates the frozen Revision 8 Windows resolution policy");
+  }
+  return corpus.scenarios.map((scenario) => {
+    const actualResolution = windowsResolve(scenario, corpus.windowsPathExtensions);
+    if (actualResolution !== scenario.expectedResolution) throw new Error(`resolution mismatch for ${scenario.id}`);
+    const actualDisposition = actualResolution === null
+      ? "REJECT_UNRESOLVED"
+      : actualResolution.toLowerCase().includes("\\disposable\\shadow\\")
+        ? "REJECT_SHADOW"
+        : "ALLOW";
+    if (actualDisposition !== scenario.expectedDisposition) throw new Error(`disposition mismatch for ${scenario.id}`);
+    return { id: scenario.id, resolution: actualResolution, disposition: actualDisposition };
+  });
+}
+
+const { mode, source, root } = parseArgs(process.argv.slice(2));
+if (!["noop", "disposable"].includes(mode)) usage("--mode must be noop or disposable");
+if (!["stable", "dev"].includes(source)) usage("--source must be stable or dev");
+if (mode === "noop" && root) usage("--root is not allowed for noop mode");
+const disposableRoot = mode === "disposable" ? assertDisposableRoot(root) : null;
+const corpus = JSON.parse(await readFile(CORPUS_URL, "utf8"));
+const modeledWindowsResolution = verifyCorpus(corpus);
+
+process.stdout.write(`${JSON.stringify({
+  receiptType: "ISSUE_3257_PHASE_0_FEASIBILITY_RECEIPT",
+  contractRevision: 8,
+  commandContractSha256: corpus.commandContractSha256,
+  mode,
+  source,
+  disposableRoot,
+  installProfile: source === "stable" ? STABLE_PROFILE : DEV_PROFILE,
+  installScripts: "SUPPRESSED",
+  productExecution: "NOT_EXECUTED",
+  packageManagerMutation: "NOT_EXECUTED",
+  globalOrUserMutation: "NOT_EXECUTED",
+  externalLifecycleExecution: "NOT_EXECUTED",
+  empiricalResult: "NOT_EXECUTED",
+  ownerReview: "REQUIRED",
+  modeledWindowsResolution,
+  scope: corpus.scope,
+})}\n`);

--- a/docs/reports/issue-3257/windows-command-harness/policy-schema.json
+++ b/docs/reports/issue-3257/windows-command-harness/policy-schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Issue 3257 Phase-0 Windows command harness policy",
+  "type": "object",
+  "required": ["contractRevision", "commandContractSha256", "scope", "windowsPathExtensions", "approvedNestedNpmRunEdges", "scenarios"],
+  "properties": {
+    "contractRevision": { "const": 8 },
+    "commandContractSha256": { "const": "4cacc4a13de4f6d53c54c9237aa4c1df6b9582cf824aa19d4911e12a57d447df" },
+    "scope": { "type": "string", "minLength": 1 },
+    "windowsPathExtensions": {
+      "const": [".com", ".exe", ".bat", ".cmd"]
+    },
+    "approvedNestedNpmRunEdges": {
+      "const": [
+        "npm run build",
+        "npm run verify:native-agents",
+        "npm run sync:plugin",
+        "npm run verify:plugin-bundle",
+        "npm run clean:native-package-assets"
+      ]
+    },
+    "scenarios": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "command", "pathDirectories", "existingCommands", "expectedResolution", "expectedDisposition"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "command": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
+          "pathDirectories": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+          "existingCommands": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+          "expectedResolution": { "type": ["string", "null"] },
+          "expectedDisposition": { "enum": ["ALLOW", "REJECT_SHADOW", "REJECT_UNRESOLVED"] }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/reports/issue-3257/windows-command-harness/resolution-corpus.json
+++ b/docs/reports/issue-3257/windows-command-harness/resolution-corpus.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "./policy-schema.json",
+  "contractRevision": 8,
+  "commandContractSha256": "4cacc4a13de4f6d53c54c9237aa4c1df6b9582cf824aa19d4911e12a57d447df",
+  "scope": "Deterministic model of command shadows already present before launch; post-launch replacement and race conditions are out of scope.",
+  "windowsPathExtensions": [".com", ".exe", ".bat", ".cmd"],
+  "approvedNestedNpmRunEdges": [
+    "npm run build",
+    "npm run verify:native-agents",
+    "npm run sync:plugin",
+    "npm run verify:plugin-bundle",
+    "npm run clean:native-package-assets"
+  ],
+  "scenarios": [
+    {
+      "id": "clean-path",
+      "command": "npm",
+      "pathDirectories": ["C:\\Program Files\\nodejs"],
+      "existingCommands": ["C:\\Program Files\\nodejs\\npm.cmd"],
+      "expectedResolution": "C:\\Program Files\\nodejs\\npm.cmd",
+      "expectedDisposition": "ALLOW"
+    },
+    {
+      "id": "earlier-cmd-shadow",
+      "command": "npm",
+      "pathDirectories": ["C:\\disposable\\shadow", "C:\\Program Files\\nodejs"],
+      "existingCommands": ["C:\\disposable\\shadow\\npm.cmd", "C:\\Program Files\\nodejs\\npm.cmd"],
+      "expectedResolution": "C:\\disposable\\shadow\\npm.cmd",
+      "expectedDisposition": "REJECT_SHADOW"
+    },
+    {
+      "id": "extension-precedence-shadow",
+      "command": "npm",
+      "pathDirectories": ["C:\\disposable\\shadow", "C:\\Program Files\\nodejs"],
+      "existingCommands": ["C:\\disposable\\shadow\\npm.bat", "C:\\disposable\\shadow\\npm.cmd", "C:\\Program Files\\nodejs\\npm.cmd"],
+      "expectedResolution": "C:\\disposable\\shadow\\npm.bat",
+      "expectedDisposition": "REJECT_SHADOW"
+    },
+    {
+      "id": "missing-command",
+      "command": "npm",
+      "pathDirectories": ["C:\\disposable\\empty"],
+      "existingCommands": [],
+      "expectedResolution": null,
+      "expectedDisposition": "REJECT_UNRESOLVED"
+    }
+  ]
+}

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1810,4 +1810,45 @@ describe('package-manager ownership', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it('rejects malformed frozen npm and Bun ownership before spawning a manager or deferred worker', async () => {
+    const malformedOwners: PackageManagerOwnership[] = [
+      {
+        ...frozenNpmOwnership,
+        npmCommand: { kind: 'node-script', command: '/untrusted/npm-launcher', commandArgs: [] },
+      },
+      {
+        manager: 'bun',
+        bunCommand: '/untrusted/bun-launcher',
+        bunGlobalBin: '',
+        bunInstallRoot: '/configured/bun',
+        globalInstallRoot: '/configured/node_modules',
+        packageRoot: '/configured/node_modules/oh-my-codex',
+        npmPrefix: '/configured',
+        environment: { BUN_INSTALL: '/configured/bun' },
+      },
+    ];
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-malformed-frozen-ownership-'));
+    try {
+      for (const ownership of malformedOwners) {
+        const managerCalls: string[] = [];
+        const result = runGlobalUpdate('oh-my-codex@latest', ((command: string) => {
+          managerCalls.push(command);
+          return { status: 0, signal: null, error: undefined, stdout: '', stderr: '', output: [null, '', ''], pid: 0 };
+        }) as typeof import('node:child_process').spawnSync, 'linux', ownership);
+        assert.deepEqual(result, { ok: false, stderr: 'The package-manager ownership transaction is incomplete.' });
+        assert.deepEqual(managerCalls, []);
+
+        const workerCalls: string[] = [];
+        const deferred = runDeferredGlobalUpdate(cwd, ((command) => {
+          workerCalls.push(command);
+          return { once() { return this; }, unref() {} } as unknown as ReturnType<typeof import('node:child_process').spawn>;
+        }) as typeof import('node:child_process').spawn, 'linux', 12345, ownership);
+        assert.deepEqual(deferred.ok, false);
+        assert.deepEqual(workerCalls, []);
+      }
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1279,7 +1279,8 @@ describe('deferred update worker', () => {
     const root = await mkdtemp(join(tmpdir(), 'omx-update-worker-'));
     const globalRoot = join(root, 'global');
     const packageRoot = join(globalRoot, PACKAGE_NAME);
-    const stage = join(root, 'stage');
+    const stage = join(root, 'omx-update-stage');
+
     const payloadPath = join(stage, 'transaction.json');
     const capturePath = join(root, 'setup-capture.json');
     const codexHome = join(root, 'codex-home');
@@ -1366,7 +1367,8 @@ describe('deferred update worker', () => {
 
   it('rejects a worker whose frozen identity digest no longer matches', async () => {
     const root = await mkdtemp(join(tmpdir(), 'omx-update-worker-integrity-'));
-    const stage = join(root, 'stage');
+    const stage = join(root, 'omx-update-integrity');
+
     const payloadPath = join(stage, 'transaction.json');
     const workerPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'update-worker.js');
 
@@ -1390,7 +1392,8 @@ describe('deferred update worker', () => {
 
   it('rejects a signed deferred payload with an invalid parent transaction boundary', async () => {
     const root = await mkdtemp(join(tmpdir(), 'omx-update-worker-payload-'));
-    const stage = join(root, 'stage');
+    const stage = join(root, 'omx-update-payload');
+
     const payloadPath = join(stage, 'transaction.json');
     const workerPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'update-worker.js');
 
@@ -1406,7 +1409,55 @@ describe('deferred update worker', () => {
       });
 
       assert.equal(result.status, 1, result.stderr);
-      await assert.rejects(readFile(stage), { code: 'ENOENT' });
+      assert.equal(await readFile(payloadPath, 'utf-8'), serialized);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a noncanonical payload path without removing its owner-only directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-update-worker-noncanonical-'));
+    const stage = join(root, 'omx-update-noncanonical');
+    const payloadPath = join(stage, 'unrelated.json');
+    const workerPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'update-worker.js');
+
+    try {
+      await mkdir(stage, { recursive: true });
+      await chmod(stage, 0o700);
+      const serialized = '{}';
+      await writeFile(payloadPath, serialized, { mode: 0o600 });
+      const digest = (contents: string | Buffer) => createHash('sha256').update(contents).digest('hex');
+      const result = spawnSync(process.execPath, [workerPath, payloadPath, digest(serialized), digest(await readFile(workerPath))], {
+        encoding: 'utf-8',
+        timeout: 10000,
+      });
+
+      assert.equal(result.status, 1, result.stderr);
+      assert.equal(await readFile(payloadPath, 'utf-8'), serialized);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves an owner-only directory outside the scheduler staging namespace', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-update-worker-foreign-stage-'));
+    const stage = join(root, 'foreign-stage');
+    const payloadPath = join(stage, 'transaction.json');
+    const workerPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'update-worker.js');
+
+    try {
+      await mkdir(stage, { recursive: true });
+      await chmod(stage, 0o700);
+      const serialized = '{}';
+      await writeFile(payloadPath, serialized, { mode: 0o600 });
+      const digest = (contents: string | Buffer) => createHash('sha256').update(contents).digest('hex');
+      const result = spawnSync(process.execPath, [workerPath, payloadPath, digest(serialized), digest(await readFile(workerPath))], {
+        encoding: 'utf-8',
+        timeout: 10000,
+      });
+
+      assert.equal(result.status, 1, result.stderr);
+      assert.equal(await readFile(payloadPath, 'utf-8'), serialized);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -623,6 +623,17 @@ describe('frozen package-manager update ownership', () => {
     assert.deepEqual(calls, []);
   });
 
+  it('requires ownership when the native updater remains selected beside an explicit setup seam', async () => {
+    const result = await runImmediateUpdate('/tmp/omx-unowned-update', {
+      getCurrentVersion: async () => '0.14.0',
+      fetchLatestVersion: async () => '0.14.1',
+      resolvePackageManagerOwnership: async () => null,
+      runSetupRefresh: async () => ({ ok: true, stderr: '' }),
+    });
+
+    assert.equal(result.status, 'failed');
+  });
+
   it('uses only the selected frozen npm command for dev packaging and installation', () => {
     const calls: Array<{ command: string; args: string[] }> = [];
     const owner: PackageManagerOwnership = {

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1678,7 +1678,7 @@ describe('package-manager ownership', () => {
     assert.deepEqual(npmCommand, {
       kind: 'node-script',
       command: 'C:\\Program Files\\nodejs\\node.exe',
-      commandArgs: ['C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js'],
+      commandArgs: ['C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js'],
     });
     assert.equal(ownership?.manager, 'npm');
   });
@@ -1726,6 +1726,30 @@ describe('package-manager ownership', () => {
       environment: {},
       realpath: (path) => path,
     });
+    assert.deepEqual(ownership, {
+      manager: 'bun',
+      bunCommand: 'C:\\Users\\alice\\.bun\\bin\\bun.exe',
+      bunGlobalBin: 'C:\\Users\\alice\\.bun\\bin',
+      bunInstallRoot: 'C:\\Users\\alice\\.bun',
+      npmPrefix: 'C:\\Users\\alice\\.bun\\install\\global\\node_modules',
+      globalInstallRoot: 'C:\\Users\\alice\\.bun\\install\\global\\node_modules',
+      packageRoot: 'C:\\Users\\alice\\.bun\\install\\global\\node_modules\\oh-my-codex',
+      environment: { BUN_INSTALL: 'C:\\Users\\alice\\.bun' },
+    });
+  });
+
+  it('derives a fresh Bun installation root from its canonical executable without ambient PATH lookup', async () => {
+    const ownership = await resolvePackageManagerOwnership({
+      ...ownershipDependencies('bun', { bunBin: 'C:\\Users\\alice\\.bun\\bin' }),
+      platform: 'win32',
+      currentExecutable: 'C:\\Users\\alice\\.bun\\install\\global\\node_modules\\oh-my-codex\\dist\\cli\\omx.js',
+      currentPackageRoot: 'C:\\Users\\alice\\.bun\\install\\global\\node_modules\\oh-my-codex',
+      bunInstallRoot: undefined,
+      resolveBunCommand: () => 'C:\\Users\\alice\\.bun\\bin\\bun.exe',
+      environment: {},
+      realpath: (path) => path,
+    });
+
     assert.deepEqual(ownership, {
       manager: 'bun',
       bunCommand: 'C:\\Users\\alice\\.bun\\bin\\bun.exe',

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1604,7 +1604,7 @@ describe('package-manager ownership', () => {
       npmPrefix: '/fake/bun/install/global/node_modules',
       globalInstallRoot: '/fake/bun/install/global/node_modules',
       packageRoot: '/fake/bun/install/global/node_modules/oh-my-codex',
-      environment: { BUN_INSTALL: '/fake/bun' },
+      environment: {},
     });
     assert.equal(await resolvePackageManagerOwnership({
       ...ownershipDependencies('bun', { bunBin: '/fake/bun/bin' }),
@@ -1613,56 +1613,60 @@ describe('package-manager ownership', () => {
       resolveBunCommand: () => null,
       bunInstallRoot: undefined,
       environment: {},
-    }), null, 'missing configured Bun install root must fail closed');
+    }), null, 'missing Bun command provenance must fail closed');
   });
 
-  it('uses canonical BUN_INSTALL layout and an independent .cmd shim on Windows', async () => {
+  it('uses platform-correct canonical paths for a Windows Bun .cmd shim', async () => {
     const ownership = await resolvePackageManagerOwnership({
-      ...ownershipDependencies('bun', { bunBin: 'C:/Users/alice/.bun/bin' }),
+      ...ownershipDependencies('bun', { bunBin: 'C:\\Users\\alice\\.bun\\bin' }),
       platform: 'win32',
-      bunInstallRoot: 'C:/Users/alice/.bun',
-      currentExecutable: 'C:/Users/alice/.bun/install/global/node_modules/oh-my-codex/dist/cli/omx.js',
-      currentPackageRoot: 'C:/Users/alice/.bun/install/global/node_modules/oh-my-codex',
+      bunInstallRoot: 'C:\\Users\\alice\\.bun',
+      currentExecutable: 'C:\\Users\\alice\\.bun\\install\\global\\node_modules\\oh-my-codex\\dist\\cli\\omx.js',
+      currentPackageRoot: 'C:\\Users\\alice\\.bun\\install\\global\\node_modules\\oh-my-codex',
+      resolveBunCommand: () => null,
       environment: {},
       realpath: (path) => path,
     });
     assert.deepEqual(ownership, {
       manager: 'bun',
-      bunCommand: '/configured/runtime/bun',
-      bunGlobalBin: 'C:/Users/alice/.bun/bin',
-      bunInstallRoot: 'C:/Users/alice/.bun',
-      npmPrefix: 'C:/Users/alice/.bun/install/global/node_modules',
-      globalInstallRoot: 'C:/Users/alice/.bun/install/global/node_modules',
-      packageRoot: 'C:/Users/alice/.bun/install/global/node_modules/oh-my-codex',
-      environment: { BUN_INSTALL: 'C:/Users/alice/.bun' },
+      bunCommand: 'C:\\Users\\alice\\.bun\\bin\\bun.exe',
+      bunGlobalBin: 'C:\\Users\\alice\\.bun\\bin',
+      bunInstallRoot: 'C:\\Users\\alice\\.bun',
+      npmPrefix: 'C:\\Users\\alice\\.bun\\install\\global\\node_modules',
+      globalInstallRoot: 'C:\\Users\\alice\\.bun\\install\\global\\node_modules',
+      packageRoot: 'C:\\Users\\alice\\.bun\\install\\global\\node_modules\\oh-my-codex',
+      environment: {},
     });
   });
 
-  it('freezes Bun ownership from its configured bin and canonical omx shim without inferring a package root', async () => {
+  it('preserves custom Bun bin and shim ownership when BUN_INSTALL is unavailable', async () => {
     let npmCalls = 0;
     const ownership = await resolvePackageManagerOwnership({
       ...ownershipDependencies('bun', { bunBin: '/configured/bun/bin' }),
+      bunInstallRoot: '/missing/developer-bun',
       currentExecutable: '/links/omx.js',
       currentPackageRoot: '/links/package',
-      realpath: (path: string) => (({
-        '/configured/bun/bin': '/canonical/bun/bin',
-        '/configured/runtime/bun': '/canonical/runtime/bun',
-        '/canonical/bun/bin/omx': '/isolated/global/oh-my-codex/dist/cli/omx.js',
-        '/canonical/bun/bin/bun': '/canonical/bun/bin/bun',
-        '/links/omx.js': '/isolated/global/oh-my-codex/dist/cli/omx.js',
-        '/links/package': '/isolated/global/oh-my-codex',
-      } as Record<string, string>)[path] ?? path),
+      realpath: (path: string) => {
+        if (path === '/missing/developer-bun') throw new Error('missing BUN_INSTALL');
+        return ({
+          '/configured/bun/bin': '/canonical/bun/bin',
+          '/configured/runtime/bun': '/canonical/runtime/bun',
+          '/canonical/bun/bin/omx': '/isolated/global/oh-my-codex/dist/cli/omx.js',
+          '/canonical/bun/bin/bun': '/canonical/bun/bin/bun',
+          '/links/omx.js': '/isolated/global/oh-my-codex/dist/cli/omx.js',
+          '/links/package': '/isolated/global/oh-my-codex',
+        } as Record<string, string>)[path] ?? path;
+      },
       resolveNpmGlobalInstallRoot: () => { npmCalls += 1; return null; },
     });
     assert.deepEqual(ownership, {
       manager: 'bun',
       bunCommand: '/canonical/runtime/bun',
       bunGlobalBin: '/canonical/bun/bin',
-      bunInstallRoot: process.env.BUN_INSTALL,
       globalInstallRoot: '/isolated/global',
       packageRoot: '/isolated/global/oh-my-codex',
       npmPrefix: '/isolated/global',
-      environment: { BUN_INSTALL: process.env.BUN_INSTALL },
+      environment: {},
     });
     assert.equal(npmCalls, 0, 'Bun ownership must not invoke npm.');
   });

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1715,6 +1715,14 @@ describe('package-manager ownership', () => {
     });
   });
 
+  it('recovers an npm owner from a stale Bun stamp without deleting the stamp', async () => {
+    const ownership = await resolvePackageManagerOwnership(ownershipDependencies('bun', {
+      npm: '/configured/node_modules',
+    }));
+
+    assert.equal(ownership?.manager, 'npm');
+  });
+
   it('freezes CODEX_HOME for deferred setup and update finalization', async () => {
     const ownership = await resolvePackageManagerOwnership({
       ...ownershipDependencies('npm', { npm: '/configured/node_modules' }),
@@ -1866,24 +1874,42 @@ describe('package-manager ownership', () => {
     });
   });
 
-  it('fails closed when unstamped npm and Bun ownership both validate', async () => {
+  it('recovers a Bun owner from a stale npm stamp without deleting the stamp', async () => {
     const ownership = await resolvePackageManagerOwnership({
-      ...ownershipDependencies(undefined, {
-        npm: '/fake/bun/install/global/node_modules',
-        bunBin: '/fake/bun/bin',
-      }),
+      ...ownershipDependencies('npm', { bunBin: '/fake/bun/bin' }),
       currentExecutable: '/fake/bun/install/global/node_modules/oh-my-codex/dist/cli/omx.js',
       currentPackageRoot: '/fake/bun/install/global/node_modules/oh-my-codex',
       bunInstallRoot: '/fake/bun',
       resolveBunCommand: () => '/fake/bun/bin/bun',
-      resolveNpmPrefix: () => '/fake/bun/install/global',
       environment: {},
       realpath: (path) => (({
         '/fake/bun/bin/omx': '/fake/bun/install/global/node_modules/oh-my-codex/dist/cli/omx.js',
       } as Record<string, string>)[path] ?? path),
     });
 
-    assert.equal(ownership, null);
+    assert.equal(ownership?.manager, 'bun');
+  });
+
+  it('fails closed when npm and Bun ownership both validate, even with a manager stamp', async () => {
+    for (const stamp of [undefined, 'npm', 'bun'] as const) {
+      const ownership = await resolvePackageManagerOwnership({
+        ...ownershipDependencies(stamp, {
+          npm: '/fake/bun/install/global/node_modules',
+          bunBin: '/fake/bun/bin',
+        }),
+        currentExecutable: '/fake/bun/install/global/node_modules/oh-my-codex/dist/cli/omx.js',
+        currentPackageRoot: '/fake/bun/install/global/node_modules/oh-my-codex',
+        bunInstallRoot: '/fake/bun',
+        resolveBunCommand: () => '/fake/bun/bin/bun',
+        resolveNpmPrefix: () => '/fake/bun/install/global',
+        environment: {},
+        realpath: (path) => (({
+          '/fake/bun/bin/omx': '/fake/bun/install/global/node_modules/oh-my-codex/dist/cli/omx.js',
+        } as Record<string, string>)[path] ?? path),
+      });
+
+      assert.equal(ownership, null);
+    }
   });
 
   it('uses platform-correct canonical paths for a Windows Bun .cmd shim', async () => {
@@ -1949,14 +1975,14 @@ describe('package-manager ownership', () => {
       resolveNpmGlobalInstallRoot: () => { npmCalls += 1; return null; },
     });
     assert.equal(ownership, null);
-    assert.equal(npmCalls, 0, 'A stamped Bun candidate must not fall back to npm.');
+    assert.equal(npmCalls, 1, 'A stale stamp cannot suppress independent live ownership validation.');
   });
 
   it('fails closed for missing, ambiguous, stale, or non-shim Bun ownership evidence', async () => {
     assert.equal(await resolvePackageManagerOwnership(ownershipDependencies(undefined, {})), null);
-    assert.equal(await resolvePackageManagerOwnership(ownershipDependencies('bun', {
+    assert.equal((await resolvePackageManagerOwnership(ownershipDependencies('bun', {
       npm: '/configured/node_modules',
-    })), null);
+    })))?.manager, 'npm', 'a stale Bun stamp must yield to one uniquely validated npm owner');
     assert.equal(await resolvePackageManagerOwnership({
       ...ownershipDependencies('bun', { bunBin: '/configured/bun/bin' }),
       resolveBunGlobalBin: () => '/configured/bun/bin',

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -13,7 +13,6 @@ import {
   maybeCheckAndPromptUpdate,
   readUserInstallStamp,
   resolveAutoUpdateMode,
-  resolveGlobalInstallRoot,
   resolveInstalledCliEntry,
   formatDeferredSetupCommand,
   resolveSetupRefreshArgs,
@@ -607,218 +606,44 @@ describe('maybeCheckAndPromptUpdate', () => {
   });
 });
 
-describe('direct npm spawn fallback', () => {
-  function spawnErrorResult(code: string) {
-    const error = Object.assign(new Error(`spawnSync npm ${code}`), { code });
-    return { status: null, signal: null, error, stdout: '', stderr: '', output: [null, '', ''], pid: 0 };
-  }
-
-  function enoentResult() {
-    return spawnErrorResult('ENOENT');
-  }
-
-  function einvalResult() {
-    return spawnErrorResult('EINVAL');
-  }
-
+describe('frozen package-manager update ownership', () => {
   function okResult(stdout = '') {
     return { status: 0, signal: null, error: undefined, stdout, stderr: '', output: [null, stdout, ''], pid: 0 };
   }
 
-  it('falls back to npm.cmd for win32 global installs when direct npm spawn returns ENOENT', () => {
-    const calls: Array<{ command: string; args: string[] }> = [];
-
-    const result = runGlobalUpdate(
-      ((command: string, args: readonly string[]) => {
-        calls.push({ command, args: args as string[] });
-        return command === 'npm' ? enoentResult() : okResult();
-      }) as unknown as typeof import('node:child_process').spawnSync,
-      'win32',
-    );
-
-    assert.equal(result.ok, true);
-    assert.deepEqual(calls.map((call) => call.command), ['npm', 'npm.cmd']);
-    assert.deepEqual(calls[0].args, ['install', '-g', 'oh-my-codex@latest']);
-    assert.deepEqual(calls[1].args, ['install', '-g', 'oh-my-codex@latest']);
-  });
-
-  it('falls back through cmd.exe when win32 npm.cmd cannot be spawned', () => {
-    const calls: Array<{ command: string; args: string[] }> = [];
-
-    const result = runGlobalUpdate(
-      ((command: string, args: readonly string[]) => {
-        calls.push({ command, args: args as string[] });
-        if (command === 'npm') return enoentResult();
-        if (command === 'npm.cmd') return einvalResult();
-        return okResult();
-      }) as unknown as typeof import('node:child_process').spawnSync,
-      'win32',
-    );
-
-    assert.equal(result.ok, true);
-    assert.deepEqual(calls.map((call) => call.command), ['npm', 'npm.cmd', 'cmd.exe']);
-    assert.deepEqual(calls[0].args, ['install', '-g', 'oh-my-codex@latest']);
-    assert.deepEqual(calls[1].args, ['install', '-g', 'oh-my-codex@latest']);
-    assert.deepEqual(calls[2].args, ['/d', '/s', '/c', 'npm', 'install', '-g', 'oh-my-codex@latest']);
-  });
-
-  it('uses cmd.exe for win32 global installs when direct npm returns EINVAL', () => {
-    const calls: Array<{ command: string; args: string[] }> = [];
-
-    const result = runGlobalUpdate(
-      ((command: string, args: readonly string[]) => {
-        calls.push({ command, args: args as string[] });
-        return command === 'npm' ? einvalResult() : okResult();
-      }) as unknown as typeof import('node:child_process').spawnSync,
-      'win32',
-    );
-
-    assert.equal(result.ok, true);
-    assert.deepEqual(calls.map((call) => call.command), ['npm', 'cmd.exe']);
-    assert.deepEqual(calls[1].args, ['/d', '/s', '/c', 'npm', 'install', '-g', 'oh-my-codex@latest']);
-  });
-
-  it('does not shell-wrap non-target win32 npm operations when npm.cmd returns EINVAL', () => {
-    const calls: Array<{ command: string; args: string[] }> = [];
-
-    const root = resolveGlobalInstallRoot(
-      ((command: string, args: readonly string[]) => {
-        calls.push({ command, args: args as string[] });
-        if (command === 'npm') return enoentResult();
-        if (command === 'npm.cmd') return einvalResult();
-        return okResult('unexpected');
-      }) as unknown as typeof import('node:child_process').spawnSync,
-      'win32',
-    );
-
-    assert.equal(root, null);
-    assert.deepEqual(calls.map((call) => call.command), ['npm', 'npm.cmd']);
-    assert.deepEqual(calls[0].args, ['root', '-g']);
-    assert.deepEqual(calls[1].args, ['root', '-g']);
-  });
-
-  it('keeps the direct npm path when it succeeds', () => {
-    const calls: Array<{ command: string; args: string[] }> = [];
-
-    const result = runGlobalUpdate(
-      ((command: string, args: readonly string[]) => {
-        calls.push({ command, args: args as string[] });
-        return okResult();
-      }) as unknown as typeof import('node:child_process').spawnSync,
-      'win32',
-    );
-
-    assert.equal(result.ok, true);
-    assert.deepEqual(calls.map((call) => call.command), ['npm']);
-    assert.deepEqual(calls[0].args, ['install', '-g', 'oh-my-codex@latest']);
-  });
-
-  it('does not fall back to npm.cmd for non-Windows ENOENT failures', () => {
+  it('rejects legacy unowned update calls without selecting an ambient manager', () => {
     const calls: string[] = [];
-
-    const result = runGlobalUpdate(
-      ((command: string) => {
-        calls.push(command);
-        return enoentResult();
-      }) as unknown as typeof import('node:child_process').spawnSync,
-      'linux',
-    );
+    const result = runGlobalUpdate(((command: string) => {
+      calls.push(command);
+      return okResult();
+    }) as unknown as typeof import('node:child_process').spawnSync);
 
     assert.equal(result.ok, false);
-    assert.match(result.stderr, /ENOENT/);
-    assert.deepEqual(calls, ['npm']);
+    assert.match(result.stderr, /validated package-manager ownership/);
+    assert.deepEqual(calls, []);
   });
 
+  it('uses only the selected frozen npm command for dev packaging and installation', () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const owner: PackageManagerOwnership = {
+      ...frozenNpmOwnership,
+      npmCommand: { kind: 'node-script', command: '/configured/node', commandArgs: ['/configured/npm-cli.js'] },
+    };
+    const result = runGlobalUpdate('github:Yeachan-Heo/oh-my-codex#dev', ((command: string, args: readonly string[]) => {
+      calls.push({ command, args: [...args] });
+      return command === 'git' ? { ...okResult(), stdout: args[0] === 'rev-parse' ? '1234567890abcdef\n' : '' } : okResult();
+    }) as typeof import('node:child_process').spawnSync, 'win32', owner);
 
-  it('packs the dev branch from a local checkout instead of globally installing the git dependency spec', () => {
-    const originalNpmLocation = process.env.npm_config_location;
-    const calls: Array<{ command: string; args: string[]; cwd?: string; env?: NodeJS.ProcessEnv }> = [];
-
-    process.env.npm_config_location = 'global';
-
-    try {
-      const result = runGlobalUpdate(
-        'github:Yeachan-Heo/oh-my-codex#dev',
-        ((command: string, args: readonly string[], options?: { cwd?: string; env?: NodeJS.ProcessEnv }) => {
-          calls.push({ command, args: args as string[], cwd: options?.cwd, env: options?.env });
-          if (command === 'git' && args[0] === 'clone') {
-            mkdirSync(String(args[args.length - 1]), { recursive: true });
-          }
-          if (command === 'git' && args[0] === 'rev-parse') {
-            return okResult('1234567890abcdef\n');
-          }
-          if (command === 'npm' && args[0] === 'pack') {
-            writeFileSync(join(options?.cwd ?? process.cwd(), 'oh-my-codex-0.18.9.tgz'), 'packed');
-            return okResult(JSON.stringify([{ filename: 'oh-my-codex-0.18.9.tgz' }]));
-          }
-          return okResult();
-        }) as unknown as typeof import('node:child_process').spawnSync,
-        'linux',
-      );
-
-      assert.equal(result.ok, true);
-      assert.deepEqual(calls.map((call) => [call.command, ...call.args.slice(0, 3)]), [
-        ['git', 'clone', '--depth', '1'],
-        ['git', 'rev-parse', 'HEAD'],
-        ['npm', 'install', '--global=false', '--location=project'],
-        ['npm', 'run', 'prepack'],
-        ['npm', 'pack', '--ignore-scripts', '--json'],
-        ['npm', 'install', '-g', join(calls[2].cwd ?? '', 'oh-my-codex-0.18.9.tgz')],
-      ]);
-      const dependencyInstall = calls.find((call) => call.command === 'npm' && call.args[0] === 'install' && call.args.includes('--include=dev'));
-      assert.equal(dependencyInstall?.env?.npm_config_global, 'false');
-      assert.equal(dependencyInstall?.env?.npm_config_location, 'project');
-      assert.equal(calls.some((call) => call.args.includes('github:Yeachan-Heo/oh-my-codex#dev')), false);
-    } finally {
-      if (typeof originalNpmLocation === 'string') {
-        process.env.npm_config_location = originalNpmLocation;
-      } else {
-        delete process.env.npm_config_location;
-      }
+    assert.equal(result.ok, false);
+    assert.match(result.stderr, /npm pack did not produce/);
+    assert.deepEqual(calls.map((call) => call.command), [
+      'git', 'git', '/configured/node', '/configured/node', '/configured/node',
+    ]);
+    for (const call of calls.slice(2)) {
+      assert.deepEqual(call.args.slice(0, 1), ['/configured/npm-cli.js']);
     }
   });
 
-  it('does not use cmd.exe for win32 dev-channel npm packaging when npm.cmd returns EINVAL', () => {
-    const calls: Array<{ command: string; args: string[] }> = [];
-
-    const result = runGlobalUpdate(
-      'github:Yeachan-Heo/oh-my-codex#dev',
-      ((command: string, args: readonly string[]) => {
-        calls.push({ command, args: args as string[] });
-        if (command === 'git' && args[0] === 'clone') {
-          mkdirSync(String(args[args.length - 1]), { recursive: true });
-          return okResult();
-        }
-        if (command === 'git' && args[0] === 'rev-parse') return okResult('1234567890abcdef\n');
-        if (command === 'npm') return enoentResult();
-        if (command === 'npm.cmd') return einvalResult();
-        return okResult();
-      }) as unknown as typeof import('node:child_process').spawnSync,
-      'win32',
-    );
-
-    assert.equal(result.ok, false);
-    assert.match(result.stderr, /EINVAL/);
-    assert.deepEqual(calls.map((call) => call.command), ['git', 'git', 'npm', 'npm.cmd']);
-    assert.equal(calls.some((call) => call.command === 'cmd.exe'), false);
-  });
-
-  it('falls back to npm.cmd for win32 global-root lookup when direct npm spawn returns ENOENT', () => {
-    const calls: Array<{ command: string; args: string[] }> = [];
-
-    const root = resolveGlobalInstallRoot(
-      ((command: string, args: readonly string[]) => {
-        calls.push({ command, args: args as string[] });
-        return command === 'npm' ? enoentResult() : okResult('C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\r\n');
-      }) as unknown as typeof import('node:child_process').spawnSync,
-      'win32',
-    );
-
-    assert.equal(root, 'C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules');
-    assert.deepEqual(calls.map((call) => call.command), ['npm', 'npm.cmd']);
-    assert.deepEqual(calls[0].args, ['root', '-g']);
-    assert.deepEqual(calls[1].args, ['root', '-g']);
-  });
 });
 
 describe('runImmediateUpdate', () => {
@@ -1775,10 +1600,11 @@ describe('package-manager ownership', () => {
       manager: 'bun',
       bunCommand: '/fake/bun/bin/bun',
       bunGlobalBin: '/fake/bun/bin',
+      bunInstallRoot: '/fake/bun',
       npmPrefix: '/fake/bun/install/global/node_modules',
       globalInstallRoot: '/fake/bun/install/global/node_modules',
       packageRoot: '/fake/bun/install/global/node_modules/oh-my-codex',
-      environment: {},
+      environment: { BUN_INSTALL: '/fake/bun' },
     });
     assert.equal(await resolvePackageManagerOwnership({
       ...ownershipDependencies('bun', { bunBin: '/fake/bun/bin' }),
@@ -1788,6 +1614,28 @@ describe('package-manager ownership', () => {
       bunInstallRoot: undefined,
       environment: {},
     }), null, 'missing configured Bun install root must fail closed');
+  });
+
+  it('uses canonical BUN_INSTALL layout and an independent .cmd shim on Windows', async () => {
+    const ownership = await resolvePackageManagerOwnership({
+      ...ownershipDependencies('bun', { bunBin: 'C:/Users/alice/.bun/bin' }),
+      platform: 'win32',
+      bunInstallRoot: 'C:/Users/alice/.bun',
+      currentExecutable: 'C:/Users/alice/.bun/install/global/node_modules/oh-my-codex/dist/cli/omx.js',
+      currentPackageRoot: 'C:/Users/alice/.bun/install/global/node_modules/oh-my-codex',
+      environment: {},
+      realpath: (path) => path,
+    });
+    assert.deepEqual(ownership, {
+      manager: 'bun',
+      bunCommand: '/configured/runtime/bun',
+      bunGlobalBin: 'C:/Users/alice/.bun/bin',
+      bunInstallRoot: 'C:/Users/alice/.bun',
+      npmPrefix: 'C:/Users/alice/.bun/install/global/node_modules',
+      globalInstallRoot: 'C:/Users/alice/.bun/install/global/node_modules',
+      packageRoot: 'C:/Users/alice/.bun/install/global/node_modules/oh-my-codex',
+      environment: { BUN_INSTALL: 'C:/Users/alice/.bun' },
+    });
   });
 
   it('freezes Bun ownership from its configured bin and canonical omx shim without inferring a package root', async () => {
@@ -1810,10 +1658,11 @@ describe('package-manager ownership', () => {
       manager: 'bun',
       bunCommand: '/canonical/runtime/bun',
       bunGlobalBin: '/canonical/bun/bin',
+      bunInstallRoot: process.env.BUN_INSTALL,
       globalInstallRoot: '/isolated/global',
       packageRoot: '/isolated/global/oh-my-codex',
       npmPrefix: '/isolated/global',
-      environment: {},
+      environment: { BUN_INSTALL: process.env.BUN_INSTALL },
     });
     assert.equal(npmCalls, 0, 'Bun ownership must not invoke npm.');
   });

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -29,7 +29,7 @@ import {
 const PACKAGE_NAME = 'oh-my-codex';
 const frozenNpmOwnership: PackageManagerOwnership = {
   manager: 'npm',
-  npmCommand: { kind: 'direct', command: 'npm' },
+  npmCommand: { kind: 'node-script', command: process.execPath, commandArgs: ['/configured/npm-cli.js'] },
   npmPrefix: '/configured',
   globalInstallRoot: '/configured/node_modules',
   packageRoot: '/configured/node_modules/oh-my-codex',
@@ -1247,9 +1247,9 @@ describe('runImmediateUpdate failure diagnostics', () => {
 
       assert.equal(result.status, 'failed');
       assert.equal(refreshCalls, 0);
-      assert.match(logs.join('\n'), /Update failed while running npm install -g oh-my-codex@latest/);
+      assert.match(logs.join('\n'), /Update failed while running the selected npm transaction \(npm install -g oh-my-codex@latest\)/);
       assert.match(logs.join('\n'), /npm stderr: EPERM: file is locked/);
-      assert.match(logs.join('\n'), /npm install -g oh-my-codex@latest && omx setup/);
+      assert.match(logs.join('\n'), /ownership-safe recovery command: omx update/);
     } finally {
       console.log = originalLog;
       await rm(cwd, { recursive: true, force: true });
@@ -1613,7 +1613,7 @@ describe('package-manager ownership', () => {
       resolveNpmGlobalInstallRoot: () => roots.npm ?? null,
       resolveBunGlobalBin: () => roots.bunBin ?? null,
       resolveBunCommand: () => '/configured/runtime/bun',
-      resolveNpmCommand: () => ({ kind: 'direct' as const, command: 'npm' as const }),
+      resolveNpmCommand: () => ({ kind: 'node-script' as const, command: '/canonical/node', commandArgs: ['/canonical/npm-cli.js'] }),
       resolveNpmPrefix: () => '/configured',
       environment: { OMX_UPDATE_TEST: '1' },
     };
@@ -1624,11 +1624,11 @@ describe('package-manager ownership', () => {
       npm: '/configured/node_modules',
     })), {
       manager: 'npm',
-      npmCommand: { kind: 'direct', command: 'npm' },
+      npmCommand: { kind: 'node-script', command: '/canonical/node', commandArgs: ['/canonical/npm-cli.js'] },
       npmPrefix: '/configured',
       globalInstallRoot: '/configured/node_modules',
       packageRoot: '/configured/node_modules/oh-my-codex',
-      environment: { OMX_UPDATE_TEST: '1' },
+      environment: {},
     });
   });
 
@@ -1655,7 +1655,7 @@ describe('package-manager ownership', () => {
       globalInstallRoot: '/isolated/global',
       packageRoot: '/isolated/global/oh-my-codex',
       npmPrefix: '/isolated/global',
-      environment: { OMX_UPDATE_TEST: '1' },
+      environment: {},
     });
     assert.equal(npmCalls, 0, 'Bun ownership must not invoke npm.');
   });
@@ -1689,13 +1689,13 @@ describe('package-manager ownership', () => {
       npmPrefix: '/configured',
       environment: { OMX_UPDATE_TEST: '1' },
     };
-    const calls: string[] = [];
-    const spawnProcess = ((command: string) => {
-      calls.push(command);
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const spawnProcess = ((command: string, args: string[]) => {
+      calls.push({ command, args });
       return { status: 0, stdout: '', stderr: '' };
     }) as typeof import('node:child_process').spawnSync;
     assert.deepEqual(runGlobalUpdate('oh-my-codex@latest', spawnProcess, 'linux', owner), { ok: true, stderr: '' });
-    assert.deepEqual(calls, ['/configured/runtime/bun']);
+    assert.deepEqual(calls, [{ command: '/configured/runtime/bun', args: ['add', '--global', '--ignore-scripts', 'oh-my-codex@latest'] }]);
     calls.length = 0;
     assert.deepEqual(runGlobalUpdate('github:Yeachan-Heo/oh-my-codex#dev', spawnProcess, 'linux', owner), {
       ok: false, stderr: 'Bun dev updates are not yet supported',

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1152,6 +1152,35 @@ describe('runDeferredGlobalUpdate', () => {
     }
   });
 
+  it('removes the frozen staged payload when the detached launcher emits an error', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-deferred-update-launcher-error-'));
+    let payloadPath = '';
+
+    try {
+      const result = runDeferredGlobalUpdate(
+        cwd,
+        ((_command, args) => {
+          payloadPath = String((args as readonly string[])[1]);
+          return {
+            once(event: string, listener: (error: Error) => void) {
+              if (event === 'error') listener(new Error('launcher failed'));
+              return this;
+            },
+            unref() {},
+          } as unknown as ReturnType<typeof import('node:child_process').spawn>;
+        }) as typeof import('node:child_process').spawn,
+        'linux',
+        12345,
+        frozenNpmOwnership,
+      );
+
+      assert.equal(result.ok, true);
+      assert.equal(existsSync(payloadPath), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('preserves plugin setup delivery mode for deferred post-update refreshes', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-deferred-update-plugin-'));
     const calls: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = [];
@@ -1354,6 +1383,30 @@ describe('deferred update worker', () => {
 
       assert.equal(result.status, 1);
       assert.equal(existsSync(join(root, 'update.log')), false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a signed deferred payload with an invalid parent transaction boundary', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-update-worker-payload-'));
+    const stage = join(root, 'stage');
+    const payloadPath = join(stage, 'transaction.json');
+    const workerPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'update-worker.js');
+
+    try {
+      await mkdir(stage, { recursive: true });
+      await chmod(stage, 0o700);
+      const serialized = JSON.stringify({ cwd: root, logPath: join(root, 'update.log'), parentPid: 0, setupArgs: [], ownership: frozenNpmOwnership });
+      await writeFile(payloadPath, serialized, { mode: 0o600 });
+      const digest = (contents: string | Buffer) => createHash('sha256').update(contents).digest('hex');
+      const result = spawnSync(process.execPath, [workerPath, payloadPath, digest(serialized), digest(await readFile(workerPath))], {
+        encoding: 'utf-8',
+        timeout: 10000,
+      });
+
+      assert.equal(result.status, 1, result.stderr);
+      await assert.rejects(readFile(stage), { code: 'ENOENT' });
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1632,6 +1632,77 @@ describe('package-manager ownership', () => {
     });
   });
 
+  it('resolves a normal npm Node-shebang launch from its installed npm CLI without lifecycle provenance', async () => {
+    let npmCommand: Extract<PackageManagerOwnership, { manager: 'npm' }>['npmCommand'] | undefined;
+    const ownership = await resolvePackageManagerOwnership({
+      ...ownershipDependencies('npm', { npm: '/fake/npm/lib/node_modules' }),
+      currentExecutable: '/fake/npm/lib/node_modules/oh-my-codex/dist/cli/omx.js',
+      currentPackageRoot: '/fake/npm/lib/node_modules/oh-my-codex',
+      currentNodeExecutable: '/fake/npm/bin/node',
+      resolveNpmCommand: () => null,
+      resolveNpmGlobalInstallRoot: (command) => {
+        npmCommand = command;
+        return '/fake/npm/lib/node_modules';
+      },
+      resolveNpmPrefix: () => '/fake/npm',
+      environment: {},
+    });
+    assert.deepEqual(npmCommand, {
+      kind: 'node-script', command: '/fake/npm/bin/node', commandArgs: ['/fake/npm/lib/node_modules/npm/bin/npm-cli.js'],
+    });
+    assert.deepEqual(ownership, {
+      manager: 'npm',
+      npmCommand: npmCommand!,
+      npmPrefix: '/fake/npm',
+      globalInstallRoot: '/fake/npm/lib/node_modules',
+      packageRoot: '/fake/npm/lib/node_modules/oh-my-codex',
+      environment: {},
+    });
+    assert.equal(await resolvePackageManagerOwnership({
+      ...ownershipDependencies('npm', { npm: '/fake/npm/lib/node_modules' }),
+      currentExecutable: '/fake/npm/lib/node_modules/oh-my-codex/dist/cli/omx.js',
+      currentPackageRoot: '/fake/npm/lib/node_modules/oh-my-codex',
+      currentNodeExecutable: '/fake/npm/bin/node',
+      resolveNpmCommand: () => null,
+      realpath: (path) => {
+        if (path.endsWith('/npm/bin/npm-cli.js')) throw new Error('missing npm CLI');
+        return path;
+      },
+      environment: {},
+    }), null, 'missing installed npm CLI must fail closed');
+  });
+
+  it('resolves a normal Bun Node-shebang launch only from its configured install root and matching shim', async () => {
+    const ownership = await resolvePackageManagerOwnership({
+      ...ownershipDependencies('bun', { bunBin: '/fake/bun/bin' }),
+      currentExecutable: '/fake/bun/install/global/node_modules/oh-my-codex/dist/cli/omx.js',
+      currentPackageRoot: '/fake/bun/install/global/node_modules/oh-my-codex',
+      bunInstallRoot: '/fake/bun',
+      resolveBunCommand: () => null,
+      environment: {},
+      realpath: (path) => (({
+        '/fake/bun/bin/omx': '/fake/bun/install/global/node_modules/oh-my-codex/dist/cli/omx.js',
+      } as Record<string, string>)[path] ?? path),
+    });
+    assert.deepEqual(ownership, {
+      manager: 'bun',
+      bunCommand: '/fake/bun/bin/bun',
+      bunGlobalBin: '/fake/bun/bin',
+      npmPrefix: '/fake/bun/install/global/node_modules',
+      globalInstallRoot: '/fake/bun/install/global/node_modules',
+      packageRoot: '/fake/bun/install/global/node_modules/oh-my-codex',
+      environment: {},
+    });
+    assert.equal(await resolvePackageManagerOwnership({
+      ...ownershipDependencies('bun', { bunBin: '/fake/bun/bin' }),
+      currentExecutable: '/fake/bun/install/global/node_modules/oh-my-codex/dist/cli/omx.js',
+      currentPackageRoot: '/fake/bun/install/global/node_modules/oh-my-codex',
+      resolveBunCommand: () => null,
+      bunInstallRoot: undefined,
+      environment: {},
+    }), null, 'missing configured Bun install root must fail closed');
+  });
+
   it('freezes Bun ownership from its configured bin and canonical omx shim without inferring a package root', async () => {
     let npmCalls = 0;
     const ownership = await resolvePackageManagerOwnership({

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1261,7 +1261,7 @@ describe('deferred update worker', () => {
 
     try {
       await mkdir(dirname(cliPath), { recursive: true });
-      await writeFile(join(packageRoot, 'package.json'), JSON.stringify({ version: '0.14.1', bin: { omx: 'dist/cli.js' } }));
+      await writeFile(join(packageRoot, 'package.json'), JSON.stringify({ name: PACKAGE_NAME, version: '0.14.1', bin: { omx: 'dist/cli.js' } }));
       await writeFile(cliPath, [
         "import { existsSync, writeFileSync } from 'node:fs';",
         "writeFileSync(process.env.OMX_UPDATE_CAPTURE_PATH, JSON.stringify({ args: process.argv.slice(2), skip: process.env.OMX_SKIP_NATIVE_AGENT_REFRESH, stampPresent: existsSync(process.env.OMX_UPDATE_STAMP_PATH) }));",
@@ -1319,6 +1319,16 @@ describe('deferred update worker', () => {
       });
       assert.match(stamp.updated_at, /^\d{4}-\d{2}-\d{2}T/);
       await assert.rejects(readFile(payloadPath), { code: 'ENOENT' });
+      await assert.rejects(readFile(stage), { code: 'ENOENT' });
+      await writeFile(join(packageRoot, 'package.json'), JSON.stringify({ name: 'unexpected-package', version: '0.14.1', bin: { omx: 'dist/cli.js' } }));
+      await mkdir(stage, { recursive: true });
+      await chmod(stage, 0o700);
+      await writeFile(payloadPath, serialized, { mode: 0o600 });
+      const rejected = spawnSync(process.execPath, [workerPath, payloadPath, digest(serialized), digest(await readFile(workerPath))], {
+        encoding: 'utf-8',
+        timeout: 10000,
+      });
+      assert.equal(rejected.status, 1, rejected.stderr);
       await assert.rejects(readFile(stage), { code: 'ENOENT' });
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1768,6 +1768,51 @@ describe('package-manager ownership', () => {
     }), null, 'missing Bun command provenance must fail closed');
   });
 
+  it('resolves an unstamped Bun install after confirming its canonical shim and configured root', async () => {
+    const ownership = await resolvePackageManagerOwnership({
+      ...ownershipDependencies(undefined, { bunBin: '/fake/bun/bin' }),
+      currentExecutable: '/fake/bun/install/global/node_modules/oh-my-codex/dist/cli/omx.js',
+      currentPackageRoot: '/fake/bun/install/global/node_modules/oh-my-codex',
+      bunInstallRoot: '/fake/bun',
+      resolveBunCommand: () => '/fake/bun/bin/bun',
+      environment: {},
+      realpath: (path) => (({
+        '/fake/bun/bin/omx': '/fake/bun/install/global/node_modules/oh-my-codex/dist/cli/omx.js',
+      } as Record<string, string>)[path] ?? path),
+    });
+
+    assert.deepEqual(ownership, {
+      manager: 'bun',
+      bunCommand: '/fake/bun/bin/bun',
+      bunGlobalBin: '/fake/bun/bin',
+      bunInstallRoot: '/fake/bun',
+      npmPrefix: '/fake/bun/install/global/node_modules',
+      globalInstallRoot: '/fake/bun/install/global/node_modules',
+      packageRoot: '/fake/bun/install/global/node_modules/oh-my-codex',
+      environment: { BUN_INSTALL: '/fake/bun' },
+    });
+  });
+
+  it('fails closed when unstamped npm and Bun ownership both validate', async () => {
+    const ownership = await resolvePackageManagerOwnership({
+      ...ownershipDependencies(undefined, {
+        npm: '/fake/bun/install/global/node_modules',
+        bunBin: '/fake/bun/bin',
+      }),
+      currentExecutable: '/fake/bun/install/global/node_modules/oh-my-codex/dist/cli/omx.js',
+      currentPackageRoot: '/fake/bun/install/global/node_modules/oh-my-codex',
+      bunInstallRoot: '/fake/bun',
+      resolveBunCommand: () => '/fake/bun/bin/bun',
+      resolveNpmPrefix: () => '/fake/bun/install/global',
+      environment: {},
+      realpath: (path) => (({
+        '/fake/bun/bin/omx': '/fake/bun/install/global/node_modules/oh-my-codex/dist/cli/omx.js',
+      } as Record<string, string>)[path] ?? path),
+    });
+
+    assert.equal(ownership, null);
+  });
+
   it('uses platform-correct canonical paths for a Windows Bun .cmd shim', async () => {
     const ownership = await resolvePackageManagerOwnership({
       ...ownershipDependencies('bun', { bunBin: 'C:\\Users\\alice\\.bun\\bin' }),
@@ -1834,13 +1879,6 @@ describe('package-manager ownership', () => {
 
   it('fails closed for missing, ambiguous, stale, or non-shim Bun ownership evidence', async () => {
     assert.equal(await resolvePackageManagerOwnership(ownershipDependencies(undefined, {})), null);
-    assert.equal(await resolvePackageManagerOwnership({
-      ...ownershipDependencies(undefined, { npm: '/configured/node_modules', bunBin: '/configured/bun/bin' }),
-      realpath: (path) => (({
-        '/configured/bun/bin/omx': executable,
-        '/configured/bun/bin/bun': '/configured/bun/bin/bun',
-      } as Record<string, string>)[path] ?? path),
-    }), null);
     assert.equal(await resolvePackageManagerOwnership(ownershipDependencies('bun', {
       npm: '/configured/node_modules',
     })), null);

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -21,6 +21,10 @@ import {
   spawnInstalledSetupRefresh,
   writeUserInstallStamp,
 } from '../update.js';
+import {
+  resolvePackageManagerOwnership,
+  type PackageManagerOwnership,
+} from '../package-manager-ownership.js';
 
 const PACKAGE_NAME = 'oh-my-codex';
 
@@ -1567,6 +1571,112 @@ describe('persisted merge policy update replay', () => {
         assert.match(calls[0]?.args.at(-1) ?? '', /--no-merge-agents/);
         assert.doesNotMatch(calls[0]?.args.at(-1) ?? '', /--force/);
       }
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('package-manager ownership', () => {
+  const executable = '/configured/node_modules/oh-my-codex/dist/cli/omx.js';
+  const packageRoot = '/configured/node_modules/oh-my-codex';
+
+  function ownershipDependencies(stamp: 'npm' | 'bun' | undefined, roots: { npm?: string; bunBin?: string }) {
+    return {
+      currentExecutable: executable,
+      currentPackageRoot: packageRoot,
+      readInstallStamp: async () => stamp
+        ? { installed_version: '0.20.3', updated_at: '2026-07-22T00:00:00.000Z', package_manager: stamp }
+        : null,
+      realpath: (path: string) => path,
+      resolveNpmGlobalInstallRoot: () => roots.npm ?? null,
+      resolveBunGlobalBin: () => roots.bunBin ?? null,
+    };
+  }
+
+  it('selects a validated npm owner from isolated roots', async () => {
+    assert.deepEqual(await resolvePackageManagerOwnership(ownershipDependencies('npm', {
+      npm: '/configured/node_modules',
+    })), { manager: 'npm', globalInstallRoot: '/configured/node_modules' });
+  });
+
+  it('freezes Bun ownership from its configured bin and canonical omx shim without inferring a package root', async () => {
+    let npmCalls = 0;
+    const ownership = await resolvePackageManagerOwnership({
+      ...ownershipDependencies('bun', { bunBin: '/configured/bun/bin' }),
+      currentExecutable: '/links/omx.js',
+      currentPackageRoot: '/links/package',
+      realpath: (path: string) => (({
+        '/configured/bun/bin': '/canonical/bun/bin',
+        '/canonical/bun/bin/omx': '/isolated/global/oh-my-codex/dist/cli/omx.js',
+        '/canonical/bun/bin/bun': '/canonical/bun/bin/bun',
+        '/links/omx.js': '/isolated/global/oh-my-codex/dist/cli/omx.js',
+        '/links/package': '/isolated/global/oh-my-codex',
+      } as Record<string, string>)[path] ?? path),
+      resolveNpmGlobalInstallRoot: () => { npmCalls += 1; return null; },
+    });
+    assert.deepEqual(ownership, {
+      manager: 'bun',
+      bunCommand: '/canonical/bun/bin/bun',
+      bunGlobalBin: '/canonical/bun/bin',
+      globalInstallRoot: '/isolated/global',
+      packageRoot: '/isolated/global/oh-my-codex',
+    });
+    assert.equal(npmCalls, 0, 'Bun ownership must not invoke npm.');
+  });
+
+  it('fails closed for missing, ambiguous, stale, or non-shim Bun ownership evidence', async () => {
+    assert.equal(await resolvePackageManagerOwnership(ownershipDependencies(undefined, {})), null);
+    assert.equal(await resolvePackageManagerOwnership({
+      ...ownershipDependencies(undefined, { npm: '/configured/node_modules', bunBin: '/configured/bun/bin' }),
+      realpath: (path) => (({
+        '/configured/bun/bin/omx': executable,
+        '/configured/bun/bin/bun': '/configured/bun/bin/bun',
+      } as Record<string, string>)[path] ?? path),
+    }), null);
+    assert.equal(await resolvePackageManagerOwnership(ownershipDependencies('bun', {
+      npm: '/configured/node_modules',
+    })), null);
+    assert.equal(await resolvePackageManagerOwnership({
+      ...ownershipDependencies('bun', { bunBin: '/configured/bun/bin' }),
+      resolveBunGlobalBin: () => '/configured/bun/bin',
+      realpath: (path) => path,
+    }), null);
+  });
+
+  it('uses the frozen Bun command for stable and deferred updates and rejects Bun dev before spawning', async () => {
+    const owner: PackageManagerOwnership = {
+      manager: 'bun',
+      bunCommand: '/configured/bun/bin/bun',
+      bunGlobalBin: '/configured/bun/bin',
+      globalInstallRoot: '/configured/node_modules',
+      packageRoot: '/configured/node_modules/oh-my-codex',
+    };
+    const calls: string[] = [];
+    const spawnProcess = ((command: string) => {
+      calls.push(command);
+      return { status: 0, stdout: '', stderr: '' };
+    }) as typeof import('node:child_process').spawnSync;
+    assert.deepEqual(runGlobalUpdate('oh-my-codex@latest', spawnProcess, 'linux', owner), { ok: true, stderr: '' });
+    assert.deepEqual(calls, ['/configured/bun/bin/bun']);
+    calls.length = 0;
+    assert.deepEqual(runGlobalUpdate('github:Yeachan-Heo/oh-my-codex#dev', spawnProcess, 'linux', owner), {
+      ok: false, stderr: 'Bun dev updates are not yet supported',
+    });
+    assert.deepEqual(calls, []);
+
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-deferred-bun-'));
+    try {
+      const deferredCalls: Array<{ command: string; args: string[] }> = [];
+      const deferred = runDeferredGlobalUpdate(cwd, ((command, args) => {
+        deferredCalls.push({ command, args: args as string[] });
+        return { once() { return this; }, unref() {} } as unknown as ReturnType<typeof import('node:child_process').spawn>;
+      }) as typeof import('node:child_process').spawn, 'linux', 12345, owner);
+      assert.equal(deferred.ok, true);
+      assert.equal(deferredCalls[0]?.command, 'sh');
+      assert.match(deferredCalls[0]?.args.at(-1) ?? '', /'\/configured\/bun\/bin\/bun' 'add' '-g' 'oh-my-codex@latest'/);
+      assert.match(deferredCalls[0]?.args.at(-1) ?? '', /'\/configured\/bun\/bin\/bun' '\/configured\/node_modules\/oh-my-codex\/dist\/cli\/omx\.js' 'setup'/);
+      assert.doesNotMatch(deferredCalls[0]?.args.at(-1) ?? '', /npm install -g|\bbun add -g/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1423,6 +1423,29 @@ describe('post-update setup refresh handoff', () => {
     assert.equal(receivedTimeout, undefined);
   });
 
+  it('passes only the frozen ownership environment to the immediate setup child', () => {
+    const frozenEnvironment: NodeJS.ProcessEnv = {
+      CODEX_HOME: '/frozen/codex-home',
+      OMX_SKIP_NATIVE_AGENT_REFRESH: '1',
+    };
+    let receivedEnvironment: NodeJS.ProcessEnv | undefined;
+
+    const result = spawnInstalledSetupRefresh(
+      '/tmp/omx.js',
+      '/tmp/project',
+      ((_command, _args, options) => {
+        receivedEnvironment = options?.env;
+        return { status: 0, error: undefined };
+      }) as typeof import('node:child_process').spawnSync,
+      process.execPath,
+      frozenEnvironment,
+    );
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(receivedEnvironment, frozenEnvironment);
+    assert.equal(receivedEnvironment?.OMX_SKIP_NATIVE_AGENT_REFRESH, '1');
+  });
+
   it('passes persisted plugin setup choices to the updated CLI refresh', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-plugin-refresh-'));
     const received: Array<{ command: string; args: string[] }> = [];

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1253,16 +1253,18 @@ describe('deferred update worker', () => {
     const stage = join(root, 'stage');
     const payloadPath = join(stage, 'transaction.json');
     const capturePath = join(root, 'setup-capture.json');
+    const codexHome = join(root, 'codex-home');
+    const stampPath = join(codexHome, '.omx', 'install-state.json');
     const npmCliPath = join(root, 'npm-cli.js');
     const cliPath = join(packageRoot, 'dist', 'cli.js');
     const workerPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'update-worker.js');
 
     try {
       await mkdir(dirname(cliPath), { recursive: true });
-      await writeFile(join(packageRoot, 'package.json'), JSON.stringify({ bin: { omx: 'dist/cli.js' } }));
+      await writeFile(join(packageRoot, 'package.json'), JSON.stringify({ version: '0.14.1', bin: { omx: 'dist/cli.js' } }));
       await writeFile(cliPath, [
-        "import { writeFileSync } from 'node:fs';",
-        "writeFileSync(process.env.OMX_UPDATE_CAPTURE_PATH, JSON.stringify({ args: process.argv.slice(2), skip: process.env.OMX_SKIP_NATIVE_AGENT_REFRESH }));",
+        "import { existsSync, writeFileSync } from 'node:fs';",
+        "writeFileSync(process.env.OMX_UPDATE_CAPTURE_PATH, JSON.stringify({ args: process.argv.slice(2), skip: process.env.OMX_SKIP_NATIVE_AGENT_REFRESH, stampPresent: existsSync(process.env.OMX_UPDATE_STAMP_PATH) }));",
       ].join('\n'));
       await writeFile(npmCliPath, [
         "const args = process.argv.slice(2);",
@@ -1281,6 +1283,8 @@ describe('deferred update worker', () => {
           OMX_UPDATE_CAPTURE_PATH: capturePath,
           OMX_UPDATE_GLOBAL_ROOT: globalRoot,
           OMX_UPDATE_PREFIX: root,
+          CODEX_HOME: codexHome,
+          OMX_UPDATE_STAMP_PATH: stampPath,
         },
       };
       const serialized = JSON.stringify({ cwd: root, logPath: join(root, 'update.log'), parentPid: 999999, ownership, setupArgs: ['setup', '--scope', 'project'] });
@@ -1295,7 +1299,25 @@ describe('deferred update worker', () => {
       assert.deepEqual(JSON.parse(await readFile(capturePath, 'utf-8')), {
         args: ['setup', '--scope', 'project'],
         skip: '1',
+        stampPresent: false,
       });
+      const stamp = JSON.parse(await readFile(stampPath, 'utf-8')) as {
+        installed_version: string;
+        setup_completed_version: string;
+        install_channel: string;
+        install_source: string;
+        package_manager: string;
+        updated_at: string;
+      };
+      assert.deepEqual({ ...stamp, updated_at: undefined }, {
+        installed_version: '0.14.1',
+        setup_completed_version: '0.14.1',
+        install_channel: 'stable',
+        install_source: 'oh-my-codex@latest',
+        package_manager: 'npm',
+        updated_at: undefined,
+      });
+      assert.match(stamp.updated_at, /^\d{4}-\d{2}-\d{2}T/);
       await assert.rejects(readFile(payloadPath), { code: 'ENOENT' });
       await assert.rejects(readFile(stage), { code: 'ENOENT' });
     } finally {
@@ -1555,6 +1577,14 @@ describe('package-manager ownership', () => {
     });
   });
 
+  it('freezes CODEX_HOME for deferred setup and update finalization', async () => {
+    const ownership = await resolvePackageManagerOwnership({
+      ...ownershipDependencies('npm', { npm: '/configured/node_modules' }),
+      environment: { CODEX_HOME: '/configured/codex-home' },
+    });
+    assert.deepEqual(ownership?.environment, { CODEX_HOME: '/configured/codex-home' });
+  });
+
   it('resolves a normal npm Node-shebang launch from its installed npm CLI without lifecycle provenance', async () => {
     let npmCommand: Extract<PackageManagerOwnership, { manager: 'npm' }>['npmCommand'] | undefined;
     const ownership = await resolvePackageManagerOwnership({
@@ -1595,6 +1625,31 @@ describe('package-manager ownership', () => {
     }), null, 'missing installed npm CLI must fail closed');
   });
 
+  it('resolves the installed npm CLI with Windows path semantics for a standard global npm layout', async () => {
+    let npmCommand: Extract<PackageManagerOwnership, { manager: 'npm' }>['npmCommand'] | undefined;
+    const ownership = await resolvePackageManagerOwnership({
+      ...ownershipDependencies('npm', { npm: 'C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules' }),
+      platform: 'win32',
+      currentExecutable: 'C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\oh-my-codex\\dist\\cli\\omx.js',
+      currentPackageRoot: 'C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\oh-my-codex',
+      currentNodeExecutable: 'C:\\Program Files\\nodejs\\node.exe',
+      resolveNpmCommand: () => null,
+      resolveNpmGlobalInstallRoot: (command) => {
+        npmCommand = command;
+        return 'C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules';
+      },
+      resolveNpmPrefix: () => 'C:\\Users\\alice\\AppData\\Roaming\\npm',
+      environment: {},
+    });
+
+    assert.deepEqual(npmCommand, {
+      kind: 'node-script',
+      command: 'C:\\Program Files\\nodejs\\node.exe',
+      commandArgs: ['C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js'],
+    });
+    assert.equal(ownership?.manager, 'npm');
+  });
+
   it('resolves a normal Bun Node-shebang launch only from its configured install root and matching shim', async () => {
     const ownership = await resolvePackageManagerOwnership({
       ...ownershipDependencies('bun', { bunBin: '/fake/bun/bin' }),
@@ -1615,7 +1670,7 @@ describe('package-manager ownership', () => {
       npmPrefix: '/fake/bun/install/global/node_modules',
       globalInstallRoot: '/fake/bun/install/global/node_modules',
       packageRoot: '/fake/bun/install/global/node_modules/oh-my-codex',
-      environment: {},
+      environment: { BUN_INSTALL: '/fake/bun' },
     });
     assert.equal(await resolvePackageManagerOwnership({
       ...ownershipDependencies('bun', { bunBin: '/fake/bun/bin' }),
@@ -1646,11 +1701,11 @@ describe('package-manager ownership', () => {
       npmPrefix: 'C:\\Users\\alice\\.bun\\install\\global\\node_modules',
       globalInstallRoot: 'C:\\Users\\alice\\.bun\\install\\global\\node_modules',
       packageRoot: 'C:\\Users\\alice\\.bun\\install\\global\\node_modules\\oh-my-codex',
-      environment: {},
+      environment: { BUN_INSTALL: 'C:\\Users\\alice\\.bun' },
     });
   });
 
-  it('preserves custom Bun bin and shim ownership when BUN_INSTALL is unavailable', async () => {
+  it('rejects Bun shim evidence when BUN_INSTALL cannot bind the command and global target', async () => {
     let npmCalls = 0;
     const ownership = await resolvePackageManagerOwnership({
       ...ownershipDependencies('bun', { bunBin: '/configured/bun/bin' }),
@@ -1659,27 +1714,12 @@ describe('package-manager ownership', () => {
       currentPackageRoot: '/links/package',
       realpath: (path: string) => {
         if (path === '/missing/developer-bun') throw new Error('missing BUN_INSTALL');
-        return ({
-          '/configured/bun/bin': '/canonical/bun/bin',
-          '/configured/runtime/bun': '/canonical/runtime/bun',
-          '/canonical/bun/bin/omx': '/isolated/global/oh-my-codex/dist/cli/omx.js',
-          '/canonical/bun/bin/bun': '/canonical/bun/bin/bun',
-          '/links/omx.js': '/isolated/global/oh-my-codex/dist/cli/omx.js',
-          '/links/package': '/isolated/global/oh-my-codex',
-        } as Record<string, string>)[path] ?? path;
+        return path;
       },
       resolveNpmGlobalInstallRoot: () => { npmCalls += 1; return null; },
     });
-    assert.deepEqual(ownership, {
-      manager: 'bun',
-      bunCommand: '/canonical/runtime/bun',
-      bunGlobalBin: '/canonical/bun/bin',
-      globalInstallRoot: '/isolated/global',
-      packageRoot: '/isolated/global/oh-my-codex',
-      npmPrefix: '/isolated/global',
-      environment: {},
-    });
-    assert.equal(npmCalls, 0, 'Bun ownership must not invoke npm.');
+    assert.equal(ownership, null);
+    assert.equal(npmCalls, 0, 'A stamped Bun candidate must not fall back to npm.');
   });
 
   it('fails closed for missing, ambiguous, stale, or non-shim Bun ownership evidence', async () => {
@@ -1699,6 +1739,14 @@ describe('package-manager ownership', () => {
       resolveBunGlobalBin: () => '/configured/bun/bin',
       realpath: (path) => path,
     }), null);
+    assert.equal(await resolvePackageManagerOwnership({
+      ...ownershipDependencies('bun', { bunBin: '/fake/bun/bin' }),
+      currentExecutable: '/fake/bun/install/global/node_modules/oh-my-codex/dist/cli/omx.js',
+      currentPackageRoot: '/fake/bun/install/global/node_modules/oh-my-codex',
+      bunInstallRoot: '/fake/bun',
+      resolveBunCommand: () => '/other/bun',
+      environment: {},
+    }), null, 'Bun executable provenance must bind to the configured installation target.');
   });
 
   it('uses the frozen Bun command for stable and deferred updates and rejects Bun dev before spawning', async () => {
@@ -1706,10 +1754,11 @@ describe('package-manager ownership', () => {
       manager: 'bun',
       bunCommand: '/configured/runtime/bun',
       bunGlobalBin: '/configured/bun/bin',
+      bunInstallRoot: '/configured/bun',
       globalInstallRoot: '/configured/node_modules',
       packageRoot: '/configured/node_modules/oh-my-codex',
       npmPrefix: '/configured',
-      environment: { OMX_UPDATE_TEST: '1' },
+      environment: { OMX_UPDATE_TEST: '1', BUN_INSTALL: '/configured/bun' },
     };
     const calls: Array<{ command: string; args: string[] }> = [];
     const spawnProcess = ((command: string, args: string[]) => {
@@ -1719,6 +1768,16 @@ describe('package-manager ownership', () => {
     assert.deepEqual(runGlobalUpdate('oh-my-codex@latest', spawnProcess, 'linux', owner), { ok: true, stderr: '' });
     assert.deepEqual(calls, [{ command: '/configured/runtime/bun', args: ['add', '--global', '--ignore-scripts', 'oh-my-codex@latest'] }]);
     calls.length = 0;
+    const incompleteOwner: PackageManagerOwnership = {
+      ...owner,
+      bunInstallRoot: undefined,
+      environment: { OMX_UPDATE_TEST: '1' },
+    };
+    assert.deepEqual(runGlobalUpdate('oh-my-codex@latest', spawnProcess, 'linux', incompleteOwner), {
+      ok: false,
+      stderr: 'The package-manager ownership transaction is incomplete.',
+    });
+    assert.deepEqual(calls, []);
     assert.deepEqual(runGlobalUpdate('github:Yeachan-Heo/oh-my-codex#dev', spawnProcess, 'linux', owner), {
       ok: false, stderr: 'Bun dev updates are not yet supported',
     });

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -27,6 +27,14 @@ import {
 } from '../package-manager-ownership.js';
 
 const PACKAGE_NAME = 'oh-my-codex';
+const frozenNpmOwnership: PackageManagerOwnership = {
+  manager: 'npm',
+  npmCommand: { kind: 'direct', command: 'npm' },
+  npmPrefix: '/configured',
+  globalInstallRoot: '/configured/node_modules',
+  packageRoot: '/configured/node_modules/oh-my-codex',
+  environment: { OMX_UPDATE_TEST: '1' },
+};
 
 describe('isNewerVersion', () => {
   it('returns true when latest has higher major', () => {
@@ -1251,7 +1259,7 @@ describe('runImmediateUpdate failure diagnostics', () => {
 
 
 describe('runDeferredGlobalUpdate', () => {
-  it('launches a detached Windows PowerShell updater that waits for the parent and runs setup after npm', async () => {
+  it('launches a detached Node worker with a frozen ownership payload on Windows', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-deferred-update-'));
     const calls: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = [];
     const listeners: string[] = [];
@@ -1271,24 +1279,35 @@ describe('runDeferredGlobalUpdate', () => {
         }) as typeof import('node:child_process').spawn,
         'win32',
         12345,
+        frozenNpmOwnership,
       );
 
       assert.equal(result.ok, true);
       assert.match(result.logPath ?? '', /\.omx[\\/]logs[\\/]update-/);
       assert.equal(calls.length, 1);
-      assert.equal(calls[0].command, 'powershell.exe');
-      assert.deepEqual(calls[0].args.slice(0, 4), ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command']);
+      assert.equal(calls[0]?.command, process.execPath);
+      assert.match(calls[0]?.args[0] ?? '', /update-worker\.js$/);
+      const payloadPath = calls[0]?.args[1];
+      assert.equal(typeof payloadPath, 'string');
+      const payload = JSON.parse(await readFile(String(payloadPath), 'utf-8')) as {
+        cwd: string;
+        parentPid: number;
+        ownership: PackageManagerOwnership;
+        setupArgs: string[];
+      };
+      assert.deepEqual(payload, {
+        cwd,
+        logPath: result.logPath,
+        parentPid: 12345,
+        ownership: frozenNpmOwnership,
+        setupArgs: ['setup'],
+      });
       assert.deepEqual(listeners, ['error']);
-      assert.equal(calls[0].options.detached, true);
-      assert.equal(calls[0].options.stdio, 'ignore');
-      assert.equal(calls[0].options.windowsHide, true);
-      assert.equal(calls[0].options.cwd, cwd);
-      assert.equal((calls[0].options.env as NodeJS.ProcessEnv | undefined)?.OMX_DEFERRED_UPDATE_PARENT_PID, '12345');
-      assert.equal((calls[0].options.env as NodeJS.ProcessEnv | undefined)?.OMX_DEFERRED_UPDATE_LOG, result.logPath);
-      assert.equal((calls[0].options.env as NodeJS.ProcessEnv | undefined)?.OMX_SKIP_NATIVE_AGENT_REFRESH, '1');
-      assert.match(calls[0].args[4], /Get-Process -Id \$parentPid/);
-      assert.match(calls[0].args[4], /npm install -g oh-my-codex@latest/);
-      assert.match(calls[0].args[4], /& 'omx' 'setup'/);
+      assert.equal(calls[0]?.options.detached, true);
+      assert.equal(calls[0]?.options.stdio, 'ignore');
+      assert.equal(calls[0]?.options.windowsHide, true);
+      assert.equal(calls[0]?.options.cwd, cwd);
+      assert.deepEqual(calls[0]?.options.env, { OMX_UPDATE_TEST: '1', OMX_SKIP_NATIVE_AGENT_REFRESH: '1' });
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -1318,11 +1337,13 @@ describe('runDeferredGlobalUpdate', () => {
         }) as typeof import('node:child_process').spawn,
         'linux',
         12345,
+        frozenNpmOwnership,
       );
 
       assert.equal(result.ok, true);
       assert.equal(calls.length, 1);
-      assert.match(calls[0].args[1], /'omx' 'setup' '--scope' 'user' '--plugin' '--mcp' 'none' '--disable-team'/);
+      const payload = JSON.parse(await readFile(calls[0]?.args[1] ?? '', 'utf-8')) as { setupArgs: string[] };
+      assert.deepEqual(payload.setupArgs, ['setup', '--scope', 'user', '--plugin', '--mcp', 'none', '--disable-team']);
       assert.equal((calls[0].options as { env?: NodeJS.ProcessEnv } | undefined)?.env?.OMX_SKIP_NATIVE_AGENT_REFRESH, '1');
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -1354,6 +1375,7 @@ describe('runDeferredGlobalUpdate', () => {
         }) as typeof import('node:child_process').spawn,
         'linux',
         12345,
+        frozenNpmOwnership,
       );
 
       await writeFile(
@@ -1363,9 +1385,8 @@ describe('runDeferredGlobalUpdate', () => {
 
       assert.equal(result.ok, true);
       assert.equal(calls.length, 1);
-      assert.match(calls[0].args[1], /'omx' 'setup' '--scope' 'user' '--plugin' '--mcp' 'none' '--disable-team'/);
-      assert.doesNotMatch(calls[0].args[1], /compat/);
-      assert.doesNotMatch(calls[0].args[1], /legacy/);
+      const payload = JSON.parse(await readFile(calls[0]?.args[1] ?? '', 'utf-8')) as { setupArgs: string[] };
+      assert.deepEqual(payload.setupArgs, ['setup', '--scope', 'user', '--plugin', '--mcp', 'none', '--disable-team']);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -1555,7 +1576,7 @@ describe('persisted merge policy update replay', () => {
     }
   });
 
-  it('snapshots the same merge-policy argv for deferred POSIX and PowerShell commands', async () => {
+  it('snapshots merge-policy argv in the detached Node-worker payload on every platform', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-merge-policy-snapshot-'));
     const calls: Array<{ args: string[] }> = [];
     try {
@@ -1566,10 +1587,10 @@ describe('persisted merge policy update replay', () => {
         const result = runDeferredGlobalUpdate(cwd, ((_, args) => {
           calls.push({ args: args as string[] });
           return { once() { return this; }, unref() {} } as unknown as ReturnType<typeof import('node:child_process').spawn>;
-        }) as typeof import('node:child_process').spawn, platform, 12345);
+        }) as typeof import('node:child_process').spawn, platform, 12345, frozenNpmOwnership);
         assert.equal(result.ok, true);
-        assert.match(calls[0]?.args.at(-1) ?? '', /--no-merge-agents/);
-        assert.doesNotMatch(calls[0]?.args.at(-1) ?? '', /--force/);
+        const payload = JSON.parse(await readFile(calls[0]?.args[1] ?? '', 'utf-8')) as { setupArgs: string[] };
+        assert.deepEqual(payload.setupArgs, ['setup', '--scope', 'user', '--no-merge-agents']);
       }
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -1591,13 +1612,24 @@ describe('package-manager ownership', () => {
       realpath: (path: string) => path,
       resolveNpmGlobalInstallRoot: () => roots.npm ?? null,
       resolveBunGlobalBin: () => roots.bunBin ?? null,
+      resolveBunCommand: () => '/configured/runtime/bun',
+      resolveNpmCommand: () => ({ kind: 'direct' as const, command: 'npm' as const }),
+      resolveNpmPrefix: () => '/configured',
+      environment: { OMX_UPDATE_TEST: '1' },
     };
   }
 
   it('selects a validated npm owner from isolated roots', async () => {
     assert.deepEqual(await resolvePackageManagerOwnership(ownershipDependencies('npm', {
       npm: '/configured/node_modules',
-    })), { manager: 'npm', globalInstallRoot: '/configured/node_modules' });
+    })), {
+      manager: 'npm',
+      npmCommand: { kind: 'direct', command: 'npm' },
+      npmPrefix: '/configured',
+      globalInstallRoot: '/configured/node_modules',
+      packageRoot: '/configured/node_modules/oh-my-codex',
+      environment: { OMX_UPDATE_TEST: '1' },
+    });
   });
 
   it('freezes Bun ownership from its configured bin and canonical omx shim without inferring a package root', async () => {
@@ -1608,6 +1640,7 @@ describe('package-manager ownership', () => {
       currentPackageRoot: '/links/package',
       realpath: (path: string) => (({
         '/configured/bun/bin': '/canonical/bun/bin',
+        '/configured/runtime/bun': '/canonical/runtime/bun',
         '/canonical/bun/bin/omx': '/isolated/global/oh-my-codex/dist/cli/omx.js',
         '/canonical/bun/bin/bun': '/canonical/bun/bin/bun',
         '/links/omx.js': '/isolated/global/oh-my-codex/dist/cli/omx.js',
@@ -1617,10 +1650,12 @@ describe('package-manager ownership', () => {
     });
     assert.deepEqual(ownership, {
       manager: 'bun',
-      bunCommand: '/canonical/bun/bin/bun',
+      bunCommand: '/canonical/runtime/bun',
       bunGlobalBin: '/canonical/bun/bin',
       globalInstallRoot: '/isolated/global',
       packageRoot: '/isolated/global/oh-my-codex',
+      npmPrefix: '/isolated/global',
+      environment: { OMX_UPDATE_TEST: '1' },
     });
     assert.equal(npmCalls, 0, 'Bun ownership must not invoke npm.');
   });
@@ -1647,10 +1682,12 @@ describe('package-manager ownership', () => {
   it('uses the frozen Bun command for stable and deferred updates and rejects Bun dev before spawning', async () => {
     const owner: PackageManagerOwnership = {
       manager: 'bun',
-      bunCommand: '/configured/bun/bin/bun',
+      bunCommand: '/configured/runtime/bun',
       bunGlobalBin: '/configured/bun/bin',
       globalInstallRoot: '/configured/node_modules',
       packageRoot: '/configured/node_modules/oh-my-codex',
+      npmPrefix: '/configured',
+      environment: { OMX_UPDATE_TEST: '1' },
     };
     const calls: string[] = [];
     const spawnProcess = ((command: string) => {
@@ -1658,7 +1695,7 @@ describe('package-manager ownership', () => {
       return { status: 0, stdout: '', stderr: '' };
     }) as typeof import('node:child_process').spawnSync;
     assert.deepEqual(runGlobalUpdate('oh-my-codex@latest', spawnProcess, 'linux', owner), { ok: true, stderr: '' });
-    assert.deepEqual(calls, ['/configured/bun/bin/bun']);
+    assert.deepEqual(calls, ['/configured/runtime/bun']);
     calls.length = 0;
     assert.deepEqual(runGlobalUpdate('github:Yeachan-Heo/oh-my-codex#dev', spawnProcess, 'linux', owner), {
       ok: false, stderr: 'Bun dev updates are not yet supported',
@@ -1673,10 +1710,11 @@ describe('package-manager ownership', () => {
         return { once() { return this; }, unref() {} } as unknown as ReturnType<typeof import('node:child_process').spawn>;
       }) as typeof import('node:child_process').spawn, 'linux', 12345, owner);
       assert.equal(deferred.ok, true);
-      assert.equal(deferredCalls[0]?.command, 'sh');
-      assert.match(deferredCalls[0]?.args.at(-1) ?? '', /'\/configured\/bun\/bin\/bun' 'add' '-g' 'oh-my-codex@latest'/);
-      assert.match(deferredCalls[0]?.args.at(-1) ?? '', /'\/configured\/bun\/bin\/bun' '\/configured\/node_modules\/oh-my-codex\/dist\/cli\/omx\.js' 'setup'/);
-      assert.doesNotMatch(deferredCalls[0]?.args.at(-1) ?? '', /npm install -g|\bbun add -g/);
+      assert.equal(deferredCalls[0]?.command, process.execPath);
+      assert.match(deferredCalls[0]?.args[0] ?? '', /update-worker\.js$/);
+      const payload = JSON.parse(await readFile(deferredCalls[0]?.args[1] ?? '', 'utf-8')) as { ownership: PackageManagerOwnership; setupArgs: string[] };
+      assert.deepEqual(payload.ownership, owner);
+      assert.deepEqual(payload.setupArgs, ['setup']);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -24,6 +24,7 @@ import {
   writeUserInstallStamp,
 } from '../update.js';
 import {
+  resolveBunGlobalBin,
   resolvePackageManagerOwnership,
   type PackageManagerOwnership,
 } from '../package-manager-ownership.js';
@@ -1762,7 +1763,7 @@ describe('package-manager ownership', () => {
     }), null, 'missing installed npm CLI must fail closed');
   });
 
-  it('resolves the installed npm CLI with Windows path semantics for a standard global npm layout', async () => {
+  it('resolves npm from the selected global OMX root before a Node runtime sibling on Windows', async () => {
     let npmCommand: Extract<PackageManagerOwnership, { manager: 'npm' }>['npmCommand'] | undefined;
     const ownership = await resolvePackageManagerOwnership({
       ...ownershipDependencies('npm', { npm: 'C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules' }),
@@ -1782,7 +1783,7 @@ describe('package-manager ownership', () => {
     assert.deepEqual(npmCommand, {
       kind: 'node-script',
       command: 'C:\\Program Files\\nodejs\\node.exe',
-      commandArgs: ['C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js'],
+      commandArgs: ['C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js'],
     });
     assert.equal(ownership?.manager, 'npm');
   });
@@ -1803,6 +1804,7 @@ describe('package-manager ownership', () => {
       manager: 'bun',
       bunCommand: '/fake/bun/bin/bun',
       bunGlobalBin: '/fake/bun/bin',
+      bunShim: '/fake/bun/bin/omx',
       bunInstallRoot: '/fake/bun',
       npmPrefix: '/fake/bun/install/global/node_modules',
       globalInstallRoot: '/fake/bun/install/global/node_modules',
@@ -1817,6 +1819,25 @@ describe('package-manager ownership', () => {
       bunInstallRoot: undefined,
       environment: {},
     }), null, 'missing Bun command provenance must fail closed');
+  });
+
+  it('queries Bun global-bin under the frozen configured environment', () => {
+    const calls: Array<{ command: string; args: string[]; environment: NodeJS.ProcessEnv | undefined }> = [];
+    const bin = resolveBunGlobalBin(
+      '/fake/bun/bin/bun',
+      { BUN_INSTALL: '/fake/bun', PATH: '/frozen/path' },
+      ((command, args, options) => {
+        calls.push({ command, args: args as string[], environment: options?.env });
+        return { status: 0, stdout: '/fake/bun/bin\n', stderr: '', error: undefined } as ReturnType<typeof import('node:child_process').spawnSync>;
+      }) as typeof import('node:child_process').spawnSync,
+    );
+
+    assert.equal(bin, '/fake/bun/bin');
+    assert.deepEqual(calls, [{
+      command: '/fake/bun/bin/bun',
+      args: ['pm', 'bin', '-g'],
+      environment: { BUN_INSTALL: '/fake/bun', PATH: '/frozen/path' },
+    }]);
   });
 
   it('resolves an unstamped Bun install after confirming its canonical shim and configured root', async () => {
@@ -1836,6 +1857,7 @@ describe('package-manager ownership', () => {
       manager: 'bun',
       bunCommand: '/fake/bun/bin/bun',
       bunGlobalBin: '/fake/bun/bin',
+      bunShim: '/fake/bun/bin/omx',
       bunInstallRoot: '/fake/bun',
       npmPrefix: '/fake/bun/install/global/node_modules',
       globalInstallRoot: '/fake/bun/install/global/node_modules',
@@ -1879,6 +1901,7 @@ describe('package-manager ownership', () => {
       manager: 'bun',
       bunCommand: 'C:\\Users\\alice\\.bun\\bin\\bun.exe',
       bunGlobalBin: 'C:\\Users\\alice\\.bun\\bin',
+      bunShim: 'C:\\Users\\alice\\.bun\\bin\\omx.cmd',
       bunInstallRoot: 'C:\\Users\\alice\\.bun',
       npmPrefix: 'C:\\Users\\alice\\.bun\\install\\global\\node_modules',
       globalInstallRoot: 'C:\\Users\\alice\\.bun\\install\\global\\node_modules',
@@ -1903,6 +1926,7 @@ describe('package-manager ownership', () => {
       manager: 'bun',
       bunCommand: 'C:\\Users\\alice\\.bun\\bin\\bun.exe',
       bunGlobalBin: 'C:\\Users\\alice\\.bun\\bin',
+      bunShim: 'C:\\Users\\alice\\.bun\\bin\\omx.cmd',
       bunInstallRoot: 'C:\\Users\\alice\\.bun',
       npmPrefix: 'C:\\Users\\alice\\.bun\\install\\global\\node_modules',
       globalInstallRoot: 'C:\\Users\\alice\\.bun\\install\\global\\node_modules',
@@ -1953,6 +1977,7 @@ describe('package-manager ownership', () => {
       manager: 'bun',
       bunCommand: '/configured/runtime/bun',
       bunGlobalBin: '/configured/bun/bin',
+      bunShim: '/configured/bun/bin/omx',
       bunInstallRoot: '/configured/bun',
       globalInstallRoot: '/configured/node_modules',
       packageRoot: '/configured/node_modules/oh-my-codex',
@@ -2010,6 +2035,7 @@ describe('package-manager ownership', () => {
         manager: 'bun',
         bunCommand: '/untrusted/bun-launcher',
         bunGlobalBin: '',
+        bunShim: '',
         bunInstallRoot: '/configured/bun',
         globalInstallRoot: '/configured/node_modules',
         packageRoot: '/configured/node_modules/oh-my-codex',

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1,9 +1,12 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import {
   isInstallVersionBump,
   isNewerVersion,
@@ -1404,6 +1407,90 @@ describe('runDeferredGlobalUpdate', () => {
       "& 'omx tool' 'setup' '--scope' 'user project' '--mcp' 'none''; echo pwned #' '--flag' ''",
     );
   });
+
+
+describe('deferred update worker', () => {
+  it('retains refresh suppression and removes the verified staging directory after execution', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-update-worker-'));
+    const globalRoot = join(root, 'global');
+    const packageRoot = join(globalRoot, PACKAGE_NAME);
+    const stage = join(root, 'stage');
+    const payloadPath = join(stage, 'transaction.json');
+    const capturePath = join(root, 'setup-capture.json');
+    const npmCliPath = join(root, 'npm-cli.js');
+    const cliPath = join(packageRoot, 'dist', 'cli.js');
+    const workerPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'update-worker.js');
+
+    try {
+      await mkdir(dirname(cliPath), { recursive: true });
+      await writeFile(join(packageRoot, 'package.json'), JSON.stringify({ bin: { omx: 'dist/cli.js' } }));
+      await writeFile(cliPath, [
+        "import { writeFileSync } from 'node:fs';",
+        "writeFileSync(process.env.OMX_UPDATE_CAPTURE_PATH, JSON.stringify({ args: process.argv.slice(2), skip: process.env.OMX_SKIP_NATIVE_AGENT_REFRESH }));",
+      ].join('\n'));
+      await writeFile(npmCliPath, [
+        "const args = process.argv.slice(2);",
+        "if (args[0] === 'root') process.stdout.write(process.env.OMX_UPDATE_GLOBAL_ROOT + '\\n');",
+        "else if (args[0] === 'prefix') process.stdout.write(process.env.OMX_UPDATE_PREFIX + '\\n');",
+      ].join('\n'));
+      await mkdir(stage, { recursive: true });
+      await chmod(stage, 0o700);
+      const ownership: PackageManagerOwnership = {
+        manager: 'npm',
+        npmCommand: { kind: 'node-script', command: process.execPath, commandArgs: [npmCliPath] },
+        npmPrefix: root,
+        globalInstallRoot: globalRoot,
+        packageRoot,
+        environment: {
+          OMX_UPDATE_CAPTURE_PATH: capturePath,
+          OMX_UPDATE_GLOBAL_ROOT: globalRoot,
+          OMX_UPDATE_PREFIX: root,
+        },
+      };
+      const serialized = JSON.stringify({ cwd: root, logPath: join(root, 'update.log'), parentPid: 999999, ownership, setupArgs: ['setup', '--scope', 'project'] });
+      await writeFile(payloadPath, serialized, { mode: 0o600 });
+      const digest = (contents: string | Buffer) => createHash('sha256').update(contents).digest('hex');
+      const result = spawnSync(process.execPath, [workerPath, payloadPath, digest(serialized), digest(await readFile(workerPath))], {
+        encoding: 'utf-8',
+        timeout: 10000,
+      });
+
+      assert.equal(result.status, 0, result.stderr);
+      assert.deepEqual(JSON.parse(await readFile(capturePath, 'utf-8')), {
+        args: ['setup', '--scope', 'project'],
+        skip: '1',
+      });
+      await assert.rejects(readFile(payloadPath), { code: 'ENOENT' });
+      await assert.rejects(readFile(stage), { code: 'ENOENT' });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a worker whose frozen identity digest no longer matches', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-update-worker-integrity-'));
+    const stage = join(root, 'stage');
+    const payloadPath = join(stage, 'transaction.json');
+    const workerPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'update-worker.js');
+
+    try {
+      await mkdir(stage, { recursive: true });
+      await chmod(stage, 0o700);
+      const serialized = '{}';
+      await writeFile(payloadPath, serialized, { mode: 0o600 });
+      const digest = (contents: string) => createHash('sha256').update(contents).digest('hex');
+      const result = spawnSync(process.execPath, [workerPath, payloadPath, digest(serialized), digest('different worker')], {
+        encoding: 'utf-8',
+        timeout: 10000,
+      });
+
+      assert.equal(result.status, 1);
+      assert.equal(existsSync(join(root, 'update.log')), false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
 });
 
 describe('post-update setup refresh handoff', () => {

--- a/src/cli/__tests__/windows-popup-loop-contract.test.ts
+++ b/src/cli/__tests__/windows-popup-loop-contract.test.ts
@@ -27,7 +27,7 @@ describe('Windows popup loop contracts', () => {
     assert.match(cliIndex, /spawnSync\(\s*process\.execPath,\s*\[watcherScript,\s*"--once",\s*"--cwd",\s*cwd,\s*"--notify-script",\s*notifyScript\],\s*\{[\s\S]*?windowsHide:\s*true/);
     assert.match(cliIndex, /spawnSync\(process\.execPath,\s*\[watcherScript,\s*"--once",\s*"--cwd",\s*cwd\],\s*\{[\s\S]*?windowsHide:\s*true/);
     assert.match(starPrompt, /spawnSyncFn\('gh',\s*\['api',[\s\S]*?windowsHide:\s*true/);
-    assert.match(updateSource, /spawnNpmSync\(\s*\[\s*'install',\s*'-g',[\s\S]*?windowsHide:\s*true/);
+    assert.match(updateSource, /runNpmCommand\(\s*ownership\.npmCommand,[\s\S]*?windowsHide:\s*true/);
     assert.match(notifierSource, /execFileAsync\(cmd,\s*args,\s*\{\s*windowsHide:\s*true\s*\}\)/);
     assert.match(replyListenerSource, /spawn\('node',\s*\['-e',\s*daemonScript\],\s*\{[\s\S]*?windowsHide:\s*true/);
     assert.match(fallbackWatcherSource, /spawnPlatformCommandSync\(\s*'tmux',\s*\[\s*'if-shell',\s*'-F',\s*'-t',\s*binding\.paneId,\s*ralphInputAuthorityCondition\(binding\),\s*success,\s*denied\s*\]/);

--- a/src/cli/package-manager-ownership.ts
+++ b/src/cli/package-manager-ownership.ts
@@ -41,6 +41,8 @@ export interface PackageManagerOwnershipDependencies {
   resolveNpmPrefix: (command: NpmCommand) => string | null;
   platform: NodeJS.Platform;
   environment?: NodeJS.ProcessEnv;
+  currentNodeExecutable: string;
+  bunInstallRoot?: string;
 }
 
 const rootOptions: SpawnSyncOptions = {
@@ -96,18 +98,43 @@ export function resolveBunGlobalBin(command: string, spawnProcess: SpawnSyncLike
   return result.error || result.status !== 0 ? null : String(result.stdout || '').trim() || null;
 }
 
-/** Only accept Bun provenance from the current runtime or lifecycle launcher, never PATH. */
+/** Only accept Bun provenance from the current runtime, lifecycle launcher, or configured install root, never PATH. */
 export function resolveBunCommand(): string | null {
-  const candidates = [process.execPath, process.env.npm_execpath].filter((value): value is string => Boolean(value));
+  const candidates = [process.execPath, process.env.npm_execpath, process.env.BUN_INSTALL && join(process.env.BUN_INSTALL, 'bin', 'bun')]
+    .filter((value): value is string => Boolean(value));
   for (const candidate of candidates) {
     try {
       const resolved = realpathSync(candidate);
       if (/^bun(?:\.exe)?$/i.test(basename(resolved))) return resolved;
     } catch {
-      // A lifecycle hint must be a real Bun executable to be trusted.
+      // A provenance hint must be a real Bun executable to be trusted.
     }
   }
   return null;
+}
+
+function resolveInstalledNpmCommand(dependencies: Pick<PackageManagerOwnershipDependencies, 'currentNodeExecutable' | 'currentPackageRoot' | 'realpath'>): NpmCommand | null {
+  try {
+    const packageRoot = dependencies.realpath(dependencies.currentPackageRoot);
+    if (basename(packageRoot) !== 'oh-my-codex') return null;
+    const script = dependencies.realpath(join(dirname(packageRoot), 'npm', 'bin', 'npm-cli.js'));
+    return { kind: 'node-script', command: dependencies.realpath(dependencies.currentNodeExecutable), commandArgs: [script] };
+  } catch {
+    return null;
+  }
+}
+
+function resolveInstalledBunCommand(dependencies: Pick<PackageManagerOwnershipDependencies, 'bunInstallRoot' | 'currentPackageRoot' | 'realpath'>): string | null {
+  if (!dependencies.bunInstallRoot) return null;
+  try {
+    const installRoot = dependencies.realpath(dependencies.bunInstallRoot);
+    const packageRoot = dependencies.realpath(dependencies.currentPackageRoot);
+    if (packageRoot !== join(installRoot, 'install', 'global', 'node_modules', 'oh-my-codex')) return null;
+    const command = dependencies.realpath(join(installRoot, 'bin', 'bun'));
+    return /^bun(?:\.exe)?$/i.test(basename(command)) ? command : null;
+  } catch {
+    return null;
+  }
 }
 
 function transactionEnvironment(source: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv {
@@ -134,9 +161,9 @@ function matchesCurrentInstall(root: string, dependencies: Pick<PackageManagerOw
   }
 }
 
-function resolveBunOwnership(dependencies: Pick<PackageManagerOwnershipDependencies, 'currentExecutable' | 'currentPackageRoot' | 'environment' | 'platform' | 'realpath' | 'resolveBunGlobalBin' | 'resolveBunCommand'>): Extract<PackageManagerOwnership, { manager: 'bun' }> | null {
+function resolveBunOwnership(dependencies: Pick<PackageManagerOwnershipDependencies, 'bunInstallRoot' | 'currentExecutable' | 'currentPackageRoot' | 'environment' | 'platform' | 'realpath' | 'resolveBunGlobalBin' | 'resolveBunCommand'>): Extract<PackageManagerOwnership, { manager: 'bun' }> | null {
   try {
-    const command = dependencies.resolveBunCommand();
+    const command = dependencies.resolveBunCommand() ?? resolveInstalledBunCommand(dependencies);
     if (!command) return null;
     const bunCommand = dependencies.realpath(command);
     const configuredBin = dependencies.resolveBunGlobalBin(bunCommand);
@@ -155,11 +182,13 @@ function resolveBunOwnership(dependencies: Pick<PackageManagerOwnershipDependenc
 
 export async function resolvePackageManagerOwnership(dependencies: Partial<PackageManagerOwnershipDependencies> = {}): Promise<PackageManagerOwnership | null> {
   const resolved: PackageManagerOwnershipDependencies = {
-    currentExecutable: process.argv[1] ?? '', currentPackageRoot: process.cwd(), readInstallStamp: async () => null,
-    realpath: (path) => realpathSync(path), resolveBunGlobalBin, resolveBunCommand, resolveNpmCommand,
+    currentExecutable: process.argv[1] ?? '', currentPackageRoot: process.cwd(), currentNodeExecutable: process.execPath,
+    bunInstallRoot: process.env.BUN_INSTALL,
+    readInstallStamp: async () => null, realpath: (path) => realpathSync(path), resolveBunGlobalBin, resolveBunCommand,
     resolveNpmGlobalInstallRoot: (command) => resolveNpmGlobalInstallRoot(spawnSync, process.platform, command),
     resolveNpmPrefix: (command) => resolveNpmPrefix(spawnSync, process.platform, command),
     platform: process.platform, environment: process.env, ...dependencies,
+    resolveNpmCommand: dependencies.resolveNpmCommand ?? resolveNpmCommand,
   };
   if (!resolved.currentExecutable) return null;
   const stamp = await resolved.readInstallStamp();
@@ -171,7 +200,7 @@ export async function resolvePackageManagerOwnership(dependencies: Partial<Packa
       if (ownership) candidates.push(ownership);
       continue;
     }
-    const npmCommand = resolved.resolveNpmCommand();
+    const npmCommand = resolved.resolveNpmCommand() ?? resolveInstalledNpmCommand(resolved);
     if (!npmCommand) continue;
     try {
       const globalInstallRoot = resolved.realpath(resolved.resolveNpmGlobalInstallRoot(npmCommand) ?? '');

--- a/src/cli/package-manager-ownership.ts
+++ b/src/cli/package-manager-ownership.ts
@@ -31,6 +31,41 @@ export type PackageManagerOwnership =
     environment: NodeJS.ProcessEnv;
   };
 
+/** Reject incomplete or malformed serialized ownership before any package-manager spawn. */
+export function isCompletePackageManagerOwnership(ownership: unknown): ownership is PackageManagerOwnership {
+  if (!ownership || typeof ownership !== 'object' || Array.isArray(ownership)) return false;
+  const candidate = ownership as Record<string, unknown>;
+  if (
+    typeof candidate.npmPrefix !== 'string' || !candidate.npmPrefix
+    || typeof candidate.globalInstallRoot !== 'string' || !candidate.globalInstallRoot
+    || typeof candidate.packageRoot !== 'string' || !candidate.packageRoot
+    || !candidate.environment || typeof candidate.environment !== 'object' || Array.isArray(candidate.environment)
+  ) return false;
+  if (candidate.manager === 'npm') {
+    const command = candidate.npmCommand;
+    if (!command || typeof command !== 'object' || Array.isArray(command)) return false;
+    const npmCommand = command as Record<string, unknown>;
+    const commandArgs = npmCommand.commandArgs;
+    return npmCommand.kind === 'node-script'
+      && typeof npmCommand.command === 'string'
+      && Boolean(npmCommand.command)
+      && Array.isArray(commandArgs)
+      && commandArgs.length > 0
+      && commandArgs.every((arg: unknown) => typeof arg === 'string' && Boolean(arg));
+  }
+  if (candidate.manager === 'bun') {
+    const environment = candidate.environment as Record<string, unknown>;
+    return typeof candidate.bunCommand === 'string'
+      && Boolean(candidate.bunCommand)
+      && typeof candidate.bunGlobalBin === 'string'
+      && Boolean(candidate.bunGlobalBin)
+      && typeof candidate.bunInstallRoot === 'string'
+      && Boolean(candidate.bunInstallRoot)
+      && environment.BUN_INSTALL === candidate.bunInstallRoot;
+  }
+  return false;
+}
+
 export interface PackageManagerOwnershipDependencies {
   currentExecutable: string;
   currentPackageRoot: string;

--- a/src/cli/package-manager-ownership.ts
+++ b/src/cli/package-manager-ownership.ts
@@ -348,7 +348,8 @@ export async function resolvePackageManagerOwnership(dependencies: Partial<Packa
   }
   if (!resolved.currentExecutable) return null;
   const stamp = await resolved.readInstallStamp();
-  const managers: PackageManager[] = stamp?.package_manager ? [stamp.package_manager] : ['npm', 'bun'];
+  // The stamp only prioritizes a probe; each candidate requires live ownership proof.
+  const managers: PackageManager[] = stamp?.package_manager === 'bun' ? ['bun', 'npm'] : ['npm', 'bun'];
   const candidates: PackageManagerOwnership[] = [];
   for (const manager of managers) {
     if (manager === 'bun') {

--- a/src/cli/package-manager-ownership.ts
+++ b/src/cli/package-manager-ownership.ts
@@ -1,4 +1,5 @@
-import { realpathSync } from 'node:fs';
+import { lstatSync, realpathSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { basename, isAbsolute, join, posix, win32 } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import type { UserInstallStamp } from '../scripts/postinstall-advisory.js';
@@ -66,6 +67,51 @@ export function isCompletePackageManagerOwnership(ownership: unknown): ownership
   return false;
 }
 
+/** Revalidate the frozen manager, root, package, and bin before transaction advancement. */
+export async function validatePackageManagerOwnership(
+  ownership: PackageManagerOwnership,
+): Promise<string | null> {
+  if (!isCompletePackageManagerOwnership(ownership)) return null;
+  try {
+    const globalInstallRoot = realpathSync(ownership.globalInstallRoot);
+    const packageRoot = realpathSync(ownership.packageRoot);
+    if (
+      pathsEqual(globalInstallRoot, packageRoot)
+      || !pathsEqual(realpathSync(join(globalInstallRoot, 'oh-my-codex')), packageRoot)
+      || !isPathWithin(packageRoot, globalInstallRoot)
+    ) return null;
+    if (ownership.manager === 'npm') {
+      const root = commandResult(ownership.npmCommand, ['root', '-g'], spawnSync, { ...rootOptions, env: ownership.environment });
+      const prefix = commandResult(ownership.npmCommand, ['prefix', '-g'], spawnSync, { ...rootOptions, env: ownership.environment });
+      if (
+        !root || !prefix
+        || !pathsEqual(realpathSync(root), globalInstallRoot)
+        || !pathsEqual(realpathSync(prefix), ownership.npmPrefix)
+        || !isPathWithin(globalInstallRoot, realpathSync(prefix))
+      ) return null;
+    } else {
+      if (!ownership.bunInstallRoot || ownership.environment.BUN_INSTALL !== ownership.bunInstallRoot) return null;
+      const result = spawnSync(ownership.bunCommand, ['pm', 'bin', '-g'], { ...rootOptions, env: ownership.environment });
+      const bin = result.error || result.status !== 0 ? null : String(result.stdout || '').trim() || null;
+      if (
+        !bin
+        || !pathsEqual(realpathSync(bin), ownership.bunGlobalBin)
+        || !pathsEqual(realpathSync(ownership.bunInstallRoot), ownership.bunInstallRoot)
+      ) return null;
+    }
+    const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf-8')) as {
+      name?: string;
+      bin?: string | Record<string, string>;
+    };
+    const bin = typeof manifest.bin === 'string' ? manifest.bin : manifest.bin?.omx;
+    if (manifest.name !== 'oh-my-codex' || typeof bin !== 'string' || !bin.trim() || isAbsolute(bin)) return null;
+    const entry = realpathSync(join(packageRoot, bin));
+    return lstatSync(entry).isFile() && isPathWithin(entry, packageRoot) ? entry : null;
+  } catch {
+    return null;
+  }
+}
+
 export interface PackageManagerOwnershipDependencies {
   currentExecutable: string;
   currentPackageRoot: string;
@@ -96,8 +142,13 @@ export function runNpmCommand(
   return spawnProcess(npmCommand.command, [...npmCommand.commandArgs, ...args], options);
 }
 
-function commandResult(command: NpmCommand, args: string[], spawnProcess: SpawnSyncLike): string | null {
-  const result = runNpmCommand(command, args, rootOptions, spawnProcess);
+function commandResult(
+  command: NpmCommand,
+  args: string[],
+  spawnProcess: SpawnSyncLike,
+  options: SpawnSyncOptions = rootOptions,
+): string | null {
+  const result = runNpmCommand(command, args, options, spawnProcess);
   return result.error || result.status !== 0 ? null : String(result.stdout || '').trim() || null;
 }
 

--- a/src/cli/package-manager-ownership.ts
+++ b/src/cli/package-manager-ownership.ts
@@ -7,26 +7,26 @@ export type PackageManager = 'npm' | 'bun';
 type SpawnSyncLike = typeof spawnSync;
 type SpawnSyncOptions = NonNullable<Parameters<SpawnSyncLike>[2]>;
 
-/** A resolved invocation form, including the Windows shim fallback selected during validation. */
-export type NpmCommand = { kind: 'direct'; command: 'npm' | 'npm.cmd' };
+/** The validated executable and fixed launcher arguments for an npm transaction. */
+export type NpmCommand = { kind: 'node-script'; command: string; commandArgs: string[] };
 
 export type PackageManagerOwnership =
   | {
     manager: 'npm';
-    npmCommand?: NpmCommand;
-    npmPrefix?: string;
+    npmCommand: NpmCommand;
+    npmPrefix: string;
     globalInstallRoot: string;
-    packageRoot?: string;
-    environment?: NodeJS.ProcessEnv;
+    packageRoot: string;
+    environment: NodeJS.ProcessEnv;
   }
   | {
     manager: 'bun';
     bunCommand: string;
     bunGlobalBin: string;
-    npmPrefix?: string;
+    npmPrefix: string;
     globalInstallRoot: string;
-    packageRoot?: string;
-    environment?: NodeJS.ProcessEnv;
+    packageRoot: string;
+    environment: NodeJS.ProcessEnv;
   };
 
 export interface PackageManagerOwnershipDependencies {
@@ -34,11 +34,11 @@ export interface PackageManagerOwnershipDependencies {
   currentPackageRoot: string;
   readInstallStamp: () => Promise<UserInstallStamp | null>;
   realpath: (path: string) => string;
-  resolveBunGlobalBin: () => string | null;
+  resolveBunGlobalBin: (command: string) => string | null;
   resolveBunCommand: () => string | null;
   resolveNpmCommand: () => NpmCommand | null;
-  resolveNpmGlobalInstallRoot: (command?: NpmCommand) => string | null;
-  resolveNpmPrefix: (command?: NpmCommand) => string | null;
+  resolveNpmGlobalInstallRoot: (command: NpmCommand) => string | null;
+  resolveNpmPrefix: (command: NpmCommand) => string | null;
   platform: NodeJS.Platform;
   environment?: NodeJS.ProcessEnv;
 }
@@ -47,13 +47,14 @@ const rootOptions: SpawnSyncOptions = {
   encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 15000, windowsHide: true,
 };
 
+/** Never resolve a manager through PATH after ownership has been established. */
 export function runNpmCommand(
   npmCommand: NpmCommand,
   args: string[],
   options: SpawnSyncOptions,
   spawnProcess: SpawnSyncLike = spawnSync,
 ): ReturnType<SpawnSyncLike> {
-  return spawnProcess(npmCommand.command, args, options);
+  return spawnProcess(npmCommand.command, [...npmCommand.commandArgs, ...args], options);
 }
 
 function commandResult(command: NpmCommand, args: string[], spawnProcess: SpawnSyncLike): string | null {
@@ -61,42 +62,41 @@ function commandResult(command: NpmCommand, args: string[], spawnProcess: SpawnS
   return result.error || result.status !== 0 ? null : String(result.stdout || '').trim() || null;
 }
 
-export function resolveNpmCommand(
-  spawnProcess: SpawnSyncLike = spawnSync,
-  platform: NodeJS.Platform = process.platform,
-): NpmCommand | null {
-  const commands: NpmCommand[] = [{ kind: 'direct', command: 'npm' }];
-  if (platform === 'win32') commands.push({ kind: 'direct', command: 'npm.cmd' });
-  return commands.find((command) => commandResult(command, ['--version'], spawnProcess) !== null) ?? null;
+/** npm's lifecycle script is executed by this Node binary, not an ambient npm on PATH. */
+export function resolveNpmCommand(): NpmCommand | null {
+  const npmExecPath = process.env.npm_execpath;
+  if (!npmExecPath || !isAbsolute(npmExecPath)) return null;
+  try {
+    const script = realpathSync(npmExecPath);
+    return { kind: 'node-script', command: realpathSync(process.execPath), commandArgs: [script] };
+  } catch {
+    return null;
+  }
 }
 
 export function resolveNpmGlobalInstallRoot(
   spawnProcess: SpawnSyncLike = spawnSync,
-  platform: NodeJS.Platform = process.platform,
-  command = resolveNpmCommand(spawnProcess, platform),
+  _platform: NodeJS.Platform = process.platform,
+  command = resolveNpmCommand(),
 ): string | null {
   return command ? commandResult(command, ['root', '-g'], spawnProcess) : null;
 }
 
 export function resolveNpmPrefix(
   spawnProcess: SpawnSyncLike = spawnSync,
-  platform: NodeJS.Platform = process.platform,
-  command = resolveNpmCommand(spawnProcess, platform),
+  _platform: NodeJS.Platform = process.platform,
+  command = resolveNpmCommand(),
 ): string | null {
   return command ? commandResult(command, ['prefix', '-g'], spawnProcess) : null;
 }
 
-/** Bun reports its configured global bin directory; its executable is resolved separately. */
-export function resolveBunGlobalBin(
-  spawnProcess: SpawnSyncLike = spawnSync,
-  platform: NodeJS.Platform = process.platform,
-): string | null {
-  const command = platform === 'win32' ? 'bun.exe' : 'bun';
+/** Bun's configured global bin must be queried through its validated executable. */
+export function resolveBunGlobalBin(command: string, spawnProcess: SpawnSyncLike = spawnSync): string | null {
   const result = spawnProcess(command, ['pm', 'bin', '-g'], rootOptions);
   return result.error || result.status !== 0 ? null : String(result.stdout || '').trim() || null;
 }
 
-/** Only accept Bun provenance from the current runtime or lifecycle launcher, never the global bin path. */
+/** Only accept Bun provenance from the current runtime or lifecycle launcher, never PATH. */
 export function resolveBunCommand(): string | null {
   const candidates = [process.execPath, process.env.npm_execpath].filter((value): value is string => Boolean(value));
   for (const candidate of candidates) {
@@ -110,12 +110,20 @@ export function resolveBunCommand(): string | null {
   return null;
 }
 
+function transactionEnvironment(source: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {};
+  for (const key of ['HOME', 'PATH', 'TMPDIR', 'TEMP', 'TMP', 'SystemRoot', 'USERPROFILE']) {
+    if (source?.[key]) environment[key] = source[key];
+  }
+  return environment;
+}
+
 function isPathWithin(path: string, root: string): boolean {
   const relation = relative(root, path);
   return relation === '' || (!relation.startsWith('..') && !isAbsolute(relation));
 }
 
-function matchesCurrentNpmInstall(root: string, dependencies: Pick<PackageManagerOwnershipDependencies, 'currentExecutable' | 'currentPackageRoot' | 'realpath'>): string | null {
+function matchesCurrentInstall(root: string, dependencies: Pick<PackageManagerOwnershipDependencies, 'currentExecutable' | 'currentPackageRoot' | 'realpath'>): string | null {
   try {
     const packageRoot = dependencies.realpath(join(root, 'oh-my-codex'));
     const currentPackageRoot = dependencies.realpath(dependencies.currentPackageRoot);
@@ -128,16 +136,18 @@ function matchesCurrentNpmInstall(root: string, dependencies: Pick<PackageManage
 
 function resolveBunOwnership(dependencies: Pick<PackageManagerOwnershipDependencies, 'currentExecutable' | 'currentPackageRoot' | 'environment' | 'platform' | 'realpath' | 'resolveBunGlobalBin' | 'resolveBunCommand'>): Extract<PackageManagerOwnership, { manager: 'bun' }> | null {
   try {
-    const configuredBin = dependencies.resolveBunGlobalBin();
     const command = dependencies.resolveBunCommand();
-    if (!configuredBin || !command) return null;
+    if (!command) return null;
+    const bunCommand = dependencies.realpath(command);
+    const configuredBin = dependencies.resolveBunGlobalBin(bunCommand);
+    if (!configuredBin) return null;
     const bunGlobalBin = dependencies.realpath(configuredBin);
     const executable = dependencies.realpath(dependencies.currentExecutable);
     const packageRoot = dependencies.realpath(dependencies.currentPackageRoot);
     const shimName = dependencies.platform === 'win32' ? 'omx.cmd' : 'omx';
     if (dependencies.realpath(join(bunGlobalBin, shimName)) !== executable) return null;
     if (basename(packageRoot) !== 'oh-my-codex' || !isPathWithin(executable, packageRoot)) return null;
-    return { manager: 'bun', bunCommand: dependencies.realpath(command), bunGlobalBin, npmPrefix: dirname(packageRoot), globalInstallRoot: dirname(packageRoot), packageRoot, environment: { ...(dependencies.environment ?? process.env) } };
+    return { manager: 'bun', bunCommand, bunGlobalBin, npmPrefix: dirname(packageRoot), globalInstallRoot: dirname(packageRoot), packageRoot, environment: transactionEnvironment(dependencies.environment) };
   } catch {
     return null;
   }
@@ -145,18 +155,11 @@ function resolveBunOwnership(dependencies: Pick<PackageManagerOwnershipDependenc
 
 export async function resolvePackageManagerOwnership(dependencies: Partial<PackageManagerOwnershipDependencies> = {}): Promise<PackageManagerOwnership | null> {
   const resolved: PackageManagerOwnershipDependencies = {
-    currentExecutable: process.argv[1] ?? '',
-    currentPackageRoot: process.cwd(),
-    readInstallStamp: async () => null,
-    realpath: (path) => realpathSync(path),
-    resolveBunGlobalBin,
-    resolveBunCommand,
-    resolveNpmCommand,
+    currentExecutable: process.argv[1] ?? '', currentPackageRoot: process.cwd(), readInstallStamp: async () => null,
+    realpath: (path) => realpathSync(path), resolveBunGlobalBin, resolveBunCommand, resolveNpmCommand,
     resolveNpmGlobalInstallRoot: (command) => resolveNpmGlobalInstallRoot(spawnSync, process.platform, command),
     resolveNpmPrefix: (command) => resolveNpmPrefix(spawnSync, process.platform, command),
-    platform: process.platform,
-    environment: process.env,
-    ...dependencies,
+    platform: process.platform, environment: process.env, ...dependencies,
   };
   if (!resolved.currentExecutable) return null;
   const stamp = await resolved.readInstallStamp();
@@ -170,14 +173,20 @@ export async function resolvePackageManagerOwnership(dependencies: Partial<Packa
     }
     const npmCommand = resolved.resolveNpmCommand();
     if (!npmCommand) continue;
-    const globalInstallRoot = resolved.resolveNpmGlobalInstallRoot(npmCommand);
-    const npmPrefix = resolved.resolveNpmPrefix(npmCommand);
-    const packageRoot = globalInstallRoot && matchesCurrentNpmInstall(globalInstallRoot, resolved);
-    if (globalInstallRoot && npmPrefix && packageRoot) candidates.push({ manager: 'npm', npmCommand, npmPrefix, globalInstallRoot, packageRoot, environment: { ...(resolved.environment ?? process.env) } });
+    try {
+      const globalInstallRoot = resolved.realpath(resolved.resolveNpmGlobalInstallRoot(npmCommand) ?? '');
+      const npmPrefix = resolved.realpath(resolved.resolveNpmPrefix(npmCommand) ?? '');
+      const packageRoot = matchesCurrentInstall(globalInstallRoot, resolved);
+      if (packageRoot && isPathWithin(globalInstallRoot, npmPrefix)) candidates.push({ manager: 'npm', npmCommand, npmPrefix, globalInstallRoot, packageRoot, environment: transactionEnvironment(resolved.environment) });
+    } catch {
+      // Manager output must canonicalize before it can authorize a transaction.
+    }
   }
   return candidates.length === 1 ? candidates[0]! : null;
 }
 
 export function packageManagerOwnershipError(): string {
-  return '[omx] Unable to determine whether this global install is owned by npm or Bun. Reinstall OMX globally with one package manager, then retry.';
+  const launcher = basename(process.env.npm_execpath ?? '').toLowerCase();
+  if (launcher.includes('pnpm') || launcher.includes('yarn')) return '[omx] pnpm and Yarn global ownership layouts are not supported for self-update. Reinstall OMX with npm or Bun, then retry.';
+  return '[omx] Unable to determine whether this global install is owned by npm or Bun. Reinstall OMX globally with one supported package manager, then retry.';
 }

--- a/src/cli/package-manager-ownership.ts
+++ b/src/cli/package-manager-ownership.ts
@@ -155,8 +155,21 @@ function resolveInstalledNpmCommand(dependencies: Pick<PackageManagerOwnershipDe
     const path = platformPath(dependencies.platform);
     const packageRoot = dependencies.realpath(dependencies.currentPackageRoot);
     if (path.basename(packageRoot) !== 'oh-my-codex') return null;
-    const script = dependencies.realpath(path.join(path.dirname(packageRoot), 'npm', 'bin', 'npm-cli.js'));
-    return { kind: 'node-script', command: dependencies.realpath(dependencies.currentNodeExecutable), commandArgs: [script] };
+    const node = dependencies.realpath(dependencies.currentNodeExecutable);
+    const candidates = dependencies.platform === 'win32'
+      ? [
+        path.join(path.dirname(node), 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+        path.join(path.dirname(packageRoot), 'npm', 'bin', 'npm-cli.js'),
+      ]
+      : [path.join(path.dirname(packageRoot), 'npm', 'bin', 'npm-cli.js')];
+    for (const candidate of candidates) {
+      try {
+        return { kind: 'node-script', command: node, commandArgs: [dependencies.realpath(candidate)] };
+      } catch {
+        // Try the next supported installed-npm layout; never use PATH.
+      }
+    }
+    return null;
   } catch {
     return null;
   }
@@ -264,6 +277,20 @@ function resolveBunOwnership(dependencies: Pick<PackageManagerOwnershipDependenc
   }
 }
 
+function inferBunInstallRoot(command: string | null, platform: NodeJS.Platform): string | undefined {
+  if (!command) return undefined;
+  const path = platformPath(platform);
+  try {
+    const binDirectory = path.dirname(command);
+    return path.basename(binDirectory).toLowerCase() === 'bin'
+      && /^bun(?:\.exe)?$/i.test(path.basename(command))
+      ? path.dirname(binDirectory)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function resolvePackageManagerOwnership(dependencies: Partial<PackageManagerOwnershipDependencies> = {}): Promise<PackageManagerOwnership | null> {
   const resolved: PackageManagerOwnershipDependencies = {
     currentExecutable: process.argv[1] ?? '', currentPackageRoot: process.cwd(), currentNodeExecutable: process.execPath,
@@ -274,6 +301,9 @@ export async function resolvePackageManagerOwnership(dependencies: Partial<Packa
     platform: process.platform, environment: process.env, ...dependencies,
     resolveNpmCommand: dependencies.resolveNpmCommand ?? resolveNpmCommand,
   };
+  if (!resolved.bunInstallRoot) {
+    resolved.bunInstallRoot = inferBunInstallRoot(resolved.resolveBunCommand(), resolved.platform);
+  }
   if (!resolved.currentExecutable) return null;
   const stamp = await resolved.readInstallStamp();
   const managers: PackageManager[] = stamp?.package_manager ? [stamp.package_manager] : ['npm', 'bun'];

--- a/src/cli/package-manager-ownership.ts
+++ b/src/cli/package-manager-ownership.ts
@@ -275,24 +275,7 @@ function matchesCurrentInstall(root: string, dependencies: Pick<PackageManagerOw
   }
 }
 
-function hasAmbiguousBunShimEvidence(dependencies: Pick<PackageManagerOwnershipDependencies, 'currentExecutable' | 'platform' | 'realpath' | 'resolveBunGlobalBin' | 'resolveBunCommand'>): boolean {
-  try {
-    const commandHint = dependencies.resolveBunCommand();
-    if (!commandHint) return false;
-    const path = platformPath(dependencies.platform);
-    const command = dependencies.realpath(commandHint);
-    if (!/^bun(?:\.exe)?$/i.test(path.basename(command))) return false;
-    const globalBinHint = dependencies.resolveBunGlobalBin(command);
-    if (!globalBinHint) return false;
-    const globalBin = dependencies.realpath(globalBinHint);
-    const shimName = dependencies.platform === 'win32' ? 'omx.cmd' : 'omx';
-    const shim = dependencies.realpath(path.join(globalBin, shimName));
-    const executable = dependencies.realpath(dependencies.currentExecutable);
-    return pathsEqual(shim, executable, dependencies.platform);
-  } catch {
-    return false;
-  }
-}
+
 
 function resolveBunOwnership(dependencies: Pick<PackageManagerOwnershipDependencies, 'bunInstallRoot' | 'currentExecutable' | 'currentPackageRoot' | 'environment' | 'platform' | 'realpath' | 'resolveBunGlobalBin' | 'resolveBunCommand'>): Extract<PackageManagerOwnership, { manager: 'bun' }> | null {
   try {
@@ -358,7 +341,6 @@ export async function resolvePackageManagerOwnership(dependencies: Partial<Packa
   if (!resolved.currentExecutable) return null;
   const stamp = await resolved.readInstallStamp();
   const managers: PackageManager[] = stamp?.package_manager ? [stamp.package_manager] : ['npm', 'bun'];
-  if (!stamp?.package_manager && hasAmbiguousBunShimEvidence(resolved)) return null;
   const candidates: PackageManagerOwnership[] = [];
   for (const manager of managers) {
     if (manager === 'bun') {

--- a/src/cli/package-manager-ownership.ts
+++ b/src/cli/package-manager-ownership.ts
@@ -1,0 +1,149 @@
+import { realpathSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import type { UserInstallStamp } from '../scripts/postinstall-advisory.js';
+
+export type PackageManager = 'npm' | 'bun';
+
+type SpawnSyncLike = typeof spawnSync;
+type SpawnSyncOptions = NonNullable<Parameters<SpawnSyncLike>[2]>;
+
+export type PackageManagerOwnership =
+  | {
+    manager: 'npm';
+    globalInstallRoot: string;
+  }
+  | {
+    manager: 'bun';
+    bunCommand: string;
+    bunGlobalBin: string;
+    globalInstallRoot: string;
+    packageRoot: string;
+  };
+
+export interface PackageManagerOwnershipDependencies {
+  currentExecutable: string;
+  currentPackageRoot: string;
+  readInstallStamp: () => Promise<UserInstallStamp | null>;
+  realpath: (path: string) => string;
+  resolveBunGlobalBin: () => string | null;
+  resolveNpmGlobalInstallRoot: () => string | null;
+  platform: NodeJS.Platform;
+}
+
+function spawnRoot(
+  command: string,
+  args: string[],
+  spawnProcess: SpawnSyncLike = spawnSync,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  const options: SpawnSyncOptions = {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 15000,
+    windowsHide: true,
+  };
+  const result = spawnProcess(command, args, options);
+  if (platform === 'win32' && (result.error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT') {
+    const shim = spawnProcess(`${command}.cmd`, args, options);
+    if (!shim.error && shim.status === 0) return String(shim.stdout || '').trim() || null;
+  }
+  return result.error || result.status !== 0 ? null : String(result.stdout || '').trim() || null;
+}
+
+export function resolveNpmGlobalInstallRoot(
+  spawnProcess: SpawnSyncLike = spawnSync,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  return spawnRoot('npm', ['root', '-g'], spawnProcess, platform);
+}
+
+/** Bun reports its configured global bin directory. */
+export function resolveBunGlobalBin(
+  spawnProcess: SpawnSyncLike = spawnSync,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  return spawnRoot('bun', ['pm', 'bin', '-g'], spawnProcess, platform);
+}
+
+function isPathWithin(path: string, root: string): boolean {
+  const relation = relative(root, path);
+  return relation === '' || (!relation.startsWith('..') && !isAbsolute(relation));
+}
+
+function matchesCurrentNpmInstall(
+  root: string,
+  dependencies: Pick<PackageManagerOwnershipDependencies, 'currentExecutable' | 'currentPackageRoot' | 'realpath'>,
+): boolean {
+  try {
+    const packageRoot = dependencies.realpath(join(root, 'oh-my-codex'));
+    const currentPackageRoot = dependencies.realpath(dependencies.currentPackageRoot);
+    const executable = dependencies.realpath(dependencies.currentExecutable);
+    return packageRoot === currentPackageRoot && isPathWithin(executable, packageRoot);
+  } catch {
+    return false;
+  }
+}
+
+function resolveBunOwnership(
+  dependencies: Pick<PackageManagerOwnershipDependencies, 'currentExecutable' | 'currentPackageRoot' | 'platform' | 'realpath' | 'resolveBunGlobalBin'>,
+): Extract<PackageManagerOwnership, { manager: 'bun' }> | null {
+  try {
+    const configuredBin = dependencies.resolveBunGlobalBin();
+    if (!configuredBin) return null;
+    const bunGlobalBin = dependencies.realpath(configuredBin);
+    const executable = dependencies.realpath(dependencies.currentExecutable);
+    const packageRoot = dependencies.realpath(dependencies.currentPackageRoot);
+    const shimName = dependencies.platform === 'win32' ? 'omx.cmd' : 'omx';
+    const bunName = dependencies.platform === 'win32' ? 'bun.exe' : 'bun';
+    if (dependencies.realpath(join(bunGlobalBin, shimName)) !== executable) return null;
+    if (basename(packageRoot) !== 'oh-my-codex' || !isPathWithin(executable, packageRoot)) return null;
+    return {
+      manager: 'bun',
+      bunCommand: dependencies.realpath(join(bunGlobalBin, bunName)),
+      bunGlobalBin,
+      globalInstallRoot: dirname(packageRoot),
+      packageRoot,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function resolvePackageManagerOwnership(
+  dependencies: Partial<PackageManagerOwnershipDependencies> = {},
+): Promise<PackageManagerOwnership | null> {
+  const resolved: PackageManagerOwnershipDependencies = {
+    currentExecutable: process.argv[1] ?? '',
+    currentPackageRoot: process.cwd(),
+    readInstallStamp: async () => null,
+    realpath: (path) => realpathSync(path),
+    resolveBunGlobalBin,
+    resolveNpmGlobalInstallRoot,
+    platform: process.platform,
+    ...dependencies,
+  };
+  if (!resolved.currentExecutable) return null;
+
+  const stamp = await resolved.readInstallStamp();
+  const managers: PackageManager[] = stamp?.package_manager
+    ? [stamp.package_manager]
+    : ['npm', 'bun'];
+  const candidates: PackageManagerOwnership[] = [];
+  for (const manager of managers) {
+    if (manager === 'bun') {
+      const ownership = resolveBunOwnership(resolved);
+      if (ownership) candidates.push(ownership);
+      continue;
+    }
+    const globalInstallRoot = resolved.resolveNpmGlobalInstallRoot();
+    if (globalInstallRoot && matchesCurrentNpmInstall(globalInstallRoot, resolved)) {
+      candidates.push({ manager, globalInstallRoot });
+    }
+  }
+  return candidates.length === 1 ? candidates[0]! : null;
+}
+
+export function packageManagerOwnershipError(): string {
+  return '[omx] Unable to determine whether this global install is owned by npm or Bun. Reinstall OMX globally with one package manager, then retry.';
+}

--- a/src/cli/package-manager-ownership.ts
+++ b/src/cli/package-manager-ownership.ts
@@ -1,5 +1,5 @@
 import { realpathSync } from 'node:fs';
-import { basename, dirname, isAbsolute, join, posix, win32 } from 'node:path';
+import { basename, isAbsolute, join, posix, win32 } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import type { UserInstallStamp } from '../scripts/postinstall-advisory.js';
 
@@ -115,11 +115,12 @@ export function resolveBunCommand(): string | null {
   return null;
 }
 
-function resolveInstalledNpmCommand(dependencies: Pick<PackageManagerOwnershipDependencies, 'currentNodeExecutable' | 'currentPackageRoot' | 'realpath'>): NpmCommand | null {
+function resolveInstalledNpmCommand(dependencies: Pick<PackageManagerOwnershipDependencies, 'currentNodeExecutable' | 'currentPackageRoot' | 'platform' | 'realpath'>): NpmCommand | null {
   try {
+    const path = platformPath(dependencies.platform);
     const packageRoot = dependencies.realpath(dependencies.currentPackageRoot);
-    if (basename(packageRoot) !== 'oh-my-codex') return null;
-    const script = dependencies.realpath(join(dirname(packageRoot), 'npm', 'bin', 'npm-cli.js'));
+    if (path.basename(packageRoot) !== 'oh-my-codex') return null;
+    const script = dependencies.realpath(path.join(path.dirname(packageRoot), 'npm', 'bin', 'npm-cli.js'));
     return { kind: 'node-script', command: dependencies.realpath(dependencies.currentNodeExecutable), commandArgs: [script] };
   } catch {
     return null;
@@ -136,7 +137,7 @@ function resolveInstalledBunCommand(dependencies: Pick<PackageManagerOwnershipDe
     const path = platformPath(dependencies.platform);
     const installRoot = dependencies.realpath(dependencies.bunInstallRoot);
     const packageRoot = dependencies.realpath(dependencies.currentPackageRoot);
-    if (packageRoot !== path.join(installRoot, 'install', 'global', 'node_modules', 'oh-my-codex')) return null;
+    if (!pathsEqual(packageRoot, path.join(installRoot, 'install', 'global', 'node_modules', 'oh-my-codex'), dependencies.platform)) return null;
     const command = dependencies.realpath(path.join(installRoot, 'bin', dependencies.platform === 'win32' ? 'bun.exe' : 'bun'));
     return /^bun(?:\.exe)?$/i.test(path.basename(command)) ? command : null;
   } catch {
@@ -146,61 +147,82 @@ function resolveInstalledBunCommand(dependencies: Pick<PackageManagerOwnershipDe
 
 function transactionEnvironment(source: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv {
   const environment: NodeJS.ProcessEnv = {};
-  for (const key of ['HOME', 'PATH', 'TMPDIR', 'TEMP', 'TMP', 'SystemRoot', 'USERPROFILE', 'BUN_INSTALL']) {
+  for (const key of ['CODEX_HOME', 'HOME', 'PATH', 'TMPDIR', 'TEMP', 'TMP', 'SystemRoot', 'USERPROFILE', 'BUN_INSTALL']) {
     if (source?.[key]) environment[key] = source[key];
   }
   return environment;
 }
 
-function isPathWithin(path: string, root: string, platform: NodeJS.Platform = process.platform): boolean {
-  const relation = platformPath(platform).relative(root, path);
-  return relation === '' || (!relation.startsWith('..') && !platformPath(platform).isAbsolute(relation));
+function pathsEqual(left: string, right: string, platform: NodeJS.Platform = process.platform): boolean {
+  if (platform !== 'win32') return left === right;
+  return win32.normalize(left).toLowerCase() === win32.normalize(right).toLowerCase();
 }
 
-function matchesCurrentInstall(root: string, dependencies: Pick<PackageManagerOwnershipDependencies, 'currentExecutable' | 'currentPackageRoot' | 'realpath'>): string | null {
+function isPathWithin(path: string, root: string, platform: NodeJS.Platform = process.platform): boolean {
+  const platformPaths = platformPath(platform);
+  const relation = platformPaths.relative(platformPaths.normalize(root), platformPaths.normalize(path));
+  return relation === '' || (!relation.startsWith('..') && !platformPaths.isAbsolute(relation));
+}
+
+function matchesCurrentInstall(root: string, dependencies: Pick<PackageManagerOwnershipDependencies, 'currentExecutable' | 'currentPackageRoot' | 'platform' | 'realpath'>): string | null {
   try {
-    const packageRoot = dependencies.realpath(join(root, 'oh-my-codex'));
+    const path = platformPath(dependencies.platform);
+    const packageRoot = dependencies.realpath(path.join(root, 'oh-my-codex'));
     const currentPackageRoot = dependencies.realpath(dependencies.currentPackageRoot);
     const executable = dependencies.realpath(dependencies.currentExecutable);
-    return packageRoot === currentPackageRoot && isPathWithin(executable, packageRoot) ? packageRoot : null;
+    return pathsEqual(packageRoot, currentPackageRoot, dependencies.platform) && isPathWithin(executable, packageRoot, dependencies.platform) ? packageRoot : null;
   } catch {
     return null;
   }
 }
 
+function hasAmbiguousBunShimEvidence(dependencies: Pick<PackageManagerOwnershipDependencies, 'currentExecutable' | 'platform' | 'realpath' | 'resolveBunGlobalBin' | 'resolveBunCommand'>): boolean {
+  try {
+    const commandHint = dependencies.resolveBunCommand();
+    if (!commandHint) return false;
+    const path = platformPath(dependencies.platform);
+    const command = dependencies.realpath(commandHint);
+    if (!/^bun(?:\.exe)?$/i.test(path.basename(command))) return false;
+    const globalBinHint = dependencies.resolveBunGlobalBin(command);
+    if (!globalBinHint) return false;
+    const globalBin = dependencies.realpath(globalBinHint);
+    const shimName = dependencies.platform === 'win32' ? 'omx.cmd' : 'omx';
+    const shim = dependencies.realpath(path.join(globalBin, shimName));
+    const executable = dependencies.realpath(dependencies.currentExecutable);
+    return pathsEqual(shim, executable, dependencies.platform);
+  } catch {
+    return false;
+  }
+}
+
 function resolveBunOwnership(dependencies: Pick<PackageManagerOwnershipDependencies, 'bunInstallRoot' | 'currentExecutable' | 'currentPackageRoot' | 'environment' | 'platform' | 'realpath' | 'resolveBunGlobalBin' | 'resolveBunCommand'>): Extract<PackageManagerOwnership, { manager: 'bun' }> | null {
   try {
+    if (!dependencies.bunInstallRoot) return null;
     const path = platformPath(dependencies.platform);
-    const command = dependencies.resolveBunCommand() ?? resolveInstalledBunCommand(dependencies);
-    if (!command) return null;
-    const bunCommand = dependencies.realpath(command);
+    const bunInstallRoot = dependencies.realpath(dependencies.bunInstallRoot);
+    const packageRoot = dependencies.realpath(dependencies.currentPackageRoot);
+    if (!pathsEqual(packageRoot, path.join(bunInstallRoot, 'install', 'global', 'node_modules', 'oh-my-codex'), dependencies.platform)) return null;
+    const expectedCommand = dependencies.realpath(path.join(bunInstallRoot, 'bin', dependencies.platform === 'win32' ? 'bun.exe' : 'bun'));
+    if (!/^bun(?:\.exe)?$/i.test(path.basename(expectedCommand))) return null;
+    const resolvedCommand = dependencies.resolveBunCommand();
+    const bunCommand = resolvedCommand ? dependencies.realpath(resolvedCommand) : resolveInstalledBunCommand(dependencies);
+    if (!bunCommand || !pathsEqual(bunCommand, expectedCommand, dependencies.platform)) return null;
     const configuredBin = dependencies.resolveBunGlobalBin(bunCommand);
     if (!configuredBin) return null;
     const bunGlobalBin = dependencies.realpath(configuredBin);
     const executable = dependencies.realpath(dependencies.currentExecutable);
-    const packageRoot = dependencies.realpath(dependencies.currentPackageRoot);
-    let bunInstallRoot: string | undefined;
-    if (dependencies.bunInstallRoot) {
-      try {
-        const configuredInstallRoot = dependencies.realpath(dependencies.bunInstallRoot);
-        if (packageRoot === path.join(configuredInstallRoot, 'install', 'global', 'node_modules', 'oh-my-codex')) bunInstallRoot = configuredInstallRoot;
-      } catch {
-        // A configured bin and canonical shim can independently prove ownership.
-      }
-    }
     const shimName = dependencies.platform === 'win32' ? 'omx.cmd' : 'omx';
     const shim = dependencies.realpath(path.join(bunGlobalBin, shimName));
-    if (path.basename(packageRoot) !== 'oh-my-codex' || !isPathWithin(executable, packageRoot, dependencies.platform)) return null;
+    if (!isPathWithin(executable, packageRoot, dependencies.platform)) return null;
     if (dependencies.platform === 'win32') {
-      // A Windows .cmd shim is a separate file, so its canonical location is the ownership evidence.
       if (!isPathWithin(shim, bunGlobalBin, dependencies.platform)) return null;
-    } else if (shim !== executable) {
+    } else if (!pathsEqual(shim, executable, dependencies.platform)) {
       return null;
     }
     return {
-      manager: 'bun', bunCommand, bunGlobalBin, ...(bunInstallRoot ? { bunInstallRoot } : {}),
+      manager: 'bun', bunCommand, bunGlobalBin, bunInstallRoot,
       npmPrefix: path.dirname(packageRoot), globalInstallRoot: path.dirname(packageRoot), packageRoot,
-      environment: transactionEnvironment(dependencies.environment),
+      environment: { ...transactionEnvironment(dependencies.environment), BUN_INSTALL: bunInstallRoot },
     };
   } catch {
     return null;
@@ -220,6 +242,7 @@ export async function resolvePackageManagerOwnership(dependencies: Partial<Packa
   if (!resolved.currentExecutable) return null;
   const stamp = await resolved.readInstallStamp();
   const managers: PackageManager[] = stamp?.package_manager ? [stamp.package_manager] : ['npm', 'bun'];
+  if (!stamp?.package_manager && hasAmbiguousBunShimEvidence(resolved)) return null;
   const candidates: PackageManagerOwnership[] = [];
   for (const manager of managers) {
     if (manager === 'bun') {
@@ -233,7 +256,7 @@ export async function resolvePackageManagerOwnership(dependencies: Partial<Packa
       const globalInstallRoot = resolved.realpath(resolved.resolveNpmGlobalInstallRoot(npmCommand) ?? '');
       const npmPrefix = resolved.realpath(resolved.resolveNpmPrefix(npmCommand) ?? '');
       const packageRoot = matchesCurrentInstall(globalInstallRoot, resolved);
-      if (packageRoot && isPathWithin(globalInstallRoot, npmPrefix)) candidates.push({ manager: 'npm', npmCommand, npmPrefix, globalInstallRoot, packageRoot, environment: transactionEnvironment(resolved.environment) });
+      if (packageRoot && isPathWithin(globalInstallRoot, npmPrefix, resolved.platform)) candidates.push({ manager: 'npm', npmCommand, npmPrefix, globalInstallRoot, packageRoot, environment: transactionEnvironment(resolved.environment) });
     } catch {
       // Manager output must canonicalize before it can authorize a transaction.
     }

--- a/src/cli/package-manager-ownership.ts
+++ b/src/cli/package-manager-ownership.ts
@@ -1,6 +1,6 @@
 import { lstatSync, realpathSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { basename, isAbsolute, join, posix, win32 } from 'node:path';
+import { basename, dirname, isAbsolute, join, posix, win32 } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import type { UserInstallStamp } from '../scripts/postinstall-advisory.js';
 
@@ -24,6 +24,7 @@ export type PackageManagerOwnership =
     manager: 'bun';
     bunCommand: string;
     bunGlobalBin: string;
+    bunShim: string;
     /** Canonical configured BUN_INSTALL root when it defines this install. */
     bunInstallRoot?: string;
     npmPrefix: string;
@@ -60,6 +61,8 @@ export function isCompletePackageManagerOwnership(ownership: unknown): ownership
       && Boolean(candidate.bunCommand)
       && typeof candidate.bunGlobalBin === 'string'
       && Boolean(candidate.bunGlobalBin)
+      && typeof candidate.bunShim === 'string'
+      && Boolean(candidate.bunShim)
       && typeof candidate.bunInstallRoot === 'string'
       && Boolean(candidate.bunInstallRoot)
       && environment.BUN_INSTALL === candidate.bunInstallRoot;
@@ -106,6 +109,12 @@ export async function validatePackageManagerOwnership(
     const bin = typeof manifest.bin === 'string' ? manifest.bin : manifest.bin?.omx;
     if (manifest.name !== 'oh-my-codex' || typeof bin !== 'string' || !bin.trim() || isAbsolute(bin)) return null;
     const entry = realpathSync(join(packageRoot, bin));
+    if (ownership.manager === 'bun' && (
+      !pathsEqual(realpathSync(dirname(ownership.bunShim)), ownership.bunGlobalBin)
+      || (basename(ownership.bunShim).toLowerCase().endsWith('.cmd')
+        ? (!lstatSync(ownership.bunShim).isFile() || !isPathWithin(realpathSync(ownership.bunShim), ownership.bunGlobalBin))
+        : !pathsEqual(realpathSync(ownership.bunShim), entry))
+    )) return null;
     return lstatSync(entry).isFile() && isPathWithin(entry, packageRoot) ? entry : null;
   } catch {
     return null;
@@ -117,7 +126,7 @@ export interface PackageManagerOwnershipDependencies {
   currentPackageRoot: string;
   readInstallStamp: () => Promise<UserInstallStamp | null>;
   realpath: (path: string) => string;
-  resolveBunGlobalBin: (command: string) => string | null;
+  resolveBunGlobalBin: (command: string, environment: NodeJS.ProcessEnv) => string | null;
   resolveBunCommand: () => string | null;
   resolveNpmCommand: () => NpmCommand | null;
   resolveNpmGlobalInstallRoot: (command: NpmCommand) => string | null;
@@ -180,9 +189,9 @@ export function resolveNpmPrefix(
   return command ? commandResult(command, ['prefix', '-g'], spawnProcess) : null;
 }
 
-/** Bun's configured global bin must be queried through its validated executable. */
-export function resolveBunGlobalBin(command: string, spawnProcess: SpawnSyncLike = spawnSync): string | null {
-  const result = spawnProcess(command, ['pm', 'bin', '-g'], rootOptions);
+/** Bun's configured global bin must be queried through its validated executable and frozen environment. */
+export function resolveBunGlobalBin(command: string, environment: NodeJS.ProcessEnv = process.env, spawnProcess: SpawnSyncLike = spawnSync): string | null {
+  const result = spawnProcess(command, ['pm', 'bin', '-g'], { ...rootOptions, env: environment });
   return result.error || result.status !== 0 ? null : String(result.stdout || '').trim() || null;
 }
 
@@ -201,23 +210,21 @@ export function resolveBunCommand(): string | null {
   return null;
 }
 
-function resolveInstalledNpmCommand(dependencies: Pick<PackageManagerOwnershipDependencies, 'currentNodeExecutable' | 'currentPackageRoot' | 'platform' | 'realpath'>): NpmCommand | null {
+function resolveInstalledNpmCommand(dependencies: Pick<PackageManagerOwnershipDependencies, 'currentNodeExecutable' | 'platform' | 'realpath'>, globalInstallRoot: string): NpmCommand | null {
   try {
     const path = platformPath(dependencies.platform);
-    const packageRoot = dependencies.realpath(dependencies.currentPackageRoot);
-    if (path.basename(packageRoot) !== 'oh-my-codex') return null;
     const node = dependencies.realpath(dependencies.currentNodeExecutable);
-    const candidates = dependencies.platform === 'win32'
-      ? [
-        path.join(path.dirname(node), 'node_modules', 'npm', 'bin', 'npm-cli.js'),
-        path.join(path.dirname(packageRoot), 'npm', 'bin', 'npm-cli.js'),
-      ]
-      : [path.join(path.dirname(packageRoot), 'npm', 'bin', 'npm-cli.js')];
+    const candidates = [
+      path.join(globalInstallRoot, 'npm', 'bin', 'npm-cli.js'),
+      ...(dependencies.platform === 'win32'
+        ? [path.join(path.dirname(node), 'node_modules', 'npm', 'bin', 'npm-cli.js')]
+        : []),
+    ];
     for (const candidate of candidates) {
       try {
         return { kind: 'node-script', command: node, commandArgs: [dependencies.realpath(candidate)] };
       } catch {
-        // Try the next supported installed-npm layout; never use PATH.
+        // Try the runtime's supported npm layout only after the selected global root.
       }
     }
     return null;
@@ -282,19 +289,21 @@ function resolveBunOwnership(dependencies: Pick<PackageManagerOwnershipDependenc
     if (!dependencies.bunInstallRoot) return null;
     const path = platformPath(dependencies.platform);
     const bunInstallRoot = dependencies.realpath(dependencies.bunInstallRoot);
-    const packageRoot = dependencies.realpath(dependencies.currentPackageRoot);
-    if (!pathsEqual(packageRoot, path.join(bunInstallRoot, 'install', 'global', 'node_modules', 'oh-my-codex'), dependencies.platform)) return null;
+    const globalInstallRoot = dependencies.realpath(path.join(bunInstallRoot, 'install', 'global', 'node_modules'));
+    const packageRoot = matchesCurrentInstall(globalInstallRoot, dependencies);
+    if (!packageRoot) return null;
     const expectedCommand = dependencies.realpath(path.join(bunInstallRoot, 'bin', dependencies.platform === 'win32' ? 'bun.exe' : 'bun'));
     if (!/^bun(?:\.exe)?$/i.test(path.basename(expectedCommand))) return null;
     const resolvedCommand = dependencies.resolveBunCommand();
     const bunCommand = resolvedCommand ? dependencies.realpath(resolvedCommand) : resolveInstalledBunCommand(dependencies);
     if (!bunCommand || !pathsEqual(bunCommand, expectedCommand, dependencies.platform)) return null;
-    const configuredBin = dependencies.resolveBunGlobalBin(bunCommand);
+    const environment = { ...transactionEnvironment(dependencies.environment), BUN_INSTALL: bunInstallRoot };
+    const configuredBin = dependencies.resolveBunGlobalBin(bunCommand, environment);
     if (!configuredBin) return null;
     const bunGlobalBin = dependencies.realpath(configuredBin);
+    const bunShim = path.join(bunGlobalBin, dependencies.platform === 'win32' ? 'omx.cmd' : 'omx');
+    const shim = dependencies.realpath(bunShim);
     const executable = dependencies.realpath(dependencies.currentExecutable);
-    const shimName = dependencies.platform === 'win32' ? 'omx.cmd' : 'omx';
-    const shim = dependencies.realpath(path.join(bunGlobalBin, shimName));
     if (!isPathWithin(executable, packageRoot, dependencies.platform)) return null;
     if (dependencies.platform === 'win32') {
       if (!isPathWithin(shim, bunGlobalBin, dependencies.platform)) return null;
@@ -302,9 +311,8 @@ function resolveBunOwnership(dependencies: Pick<PackageManagerOwnershipDependenc
       return null;
     }
     return {
-      manager: 'bun', bunCommand, bunGlobalBin, bunInstallRoot,
-      npmPrefix: path.dirname(packageRoot), globalInstallRoot: path.dirname(packageRoot), packageRoot,
-      environment: { ...transactionEnvironment(dependencies.environment), BUN_INSTALL: bunInstallRoot },
+      manager: 'bun', bunCommand, bunGlobalBin, bunShim, bunInstallRoot,
+      npmPrefix: globalInstallRoot, globalInstallRoot, packageRoot, environment,
     };
   } catch {
     return null;
@@ -348,7 +356,12 @@ export async function resolvePackageManagerOwnership(dependencies: Partial<Packa
       if (ownership) candidates.push(ownership);
       continue;
     }
-    const npmCommand = resolved.resolveNpmCommand() ?? resolveInstalledNpmCommand(resolved);
+    const lifecycleNpmCommand = resolved.resolveNpmCommand();
+    const selectedGlobalInstallRoot = resolved.realpath(platformPath(resolved.platform).dirname(resolved.currentPackageRoot));
+    const selectedPackageRoot = matchesCurrentInstall(selectedGlobalInstallRoot, resolved);
+    const npmCommand = lifecycleNpmCommand ?? (selectedPackageRoot
+      ? resolveInstalledNpmCommand(resolved, selectedGlobalInstallRoot)
+      : null);
     if (!npmCommand) continue;
     try {
       const globalInstallRoot = resolved.realpath(resolved.resolveNpmGlobalInstallRoot(npmCommand) ?? '');

--- a/src/cli/package-manager-ownership.ts
+++ b/src/cli/package-manager-ownership.ts
@@ -4,21 +4,29 @@ import { spawnSync } from 'node:child_process';
 import type { UserInstallStamp } from '../scripts/postinstall-advisory.js';
 
 export type PackageManager = 'npm' | 'bun';
-
 type SpawnSyncLike = typeof spawnSync;
 type SpawnSyncOptions = NonNullable<Parameters<SpawnSyncLike>[2]>;
+
+/** A resolved invocation form, including the Windows shim fallback selected during validation. */
+export type NpmCommand = { kind: 'direct'; command: 'npm' | 'npm.cmd' };
 
 export type PackageManagerOwnership =
   | {
     manager: 'npm';
+    npmCommand?: NpmCommand;
+    npmPrefix?: string;
     globalInstallRoot: string;
+    packageRoot?: string;
+    environment?: NodeJS.ProcessEnv;
   }
   | {
     manager: 'bun';
     bunCommand: string;
     bunGlobalBin: string;
+    npmPrefix?: string;
     globalInstallRoot: string;
-    packageRoot: string;
+    packageRoot?: string;
+    environment?: NodeJS.ProcessEnv;
   };
 
 export interface PackageManagerOwnershipDependencies {
@@ -27,43 +35,79 @@ export interface PackageManagerOwnershipDependencies {
   readInstallStamp: () => Promise<UserInstallStamp | null>;
   realpath: (path: string) => string;
   resolveBunGlobalBin: () => string | null;
-  resolveNpmGlobalInstallRoot: () => string | null;
+  resolveBunCommand: () => string | null;
+  resolveNpmCommand: () => NpmCommand | null;
+  resolveNpmGlobalInstallRoot: (command?: NpmCommand) => string | null;
+  resolveNpmPrefix: (command?: NpmCommand) => string | null;
   platform: NodeJS.Platform;
+  environment?: NodeJS.ProcessEnv;
 }
 
-function spawnRoot(
-  command: string,
+const rootOptions: SpawnSyncOptions = {
+  encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 15000, windowsHide: true,
+};
+
+export function runNpmCommand(
+  npmCommand: NpmCommand,
   args: string[],
+  options: SpawnSyncOptions,
+  spawnProcess: SpawnSyncLike = spawnSync,
+): ReturnType<SpawnSyncLike> {
+  return spawnProcess(npmCommand.command, args, options);
+}
+
+function commandResult(command: NpmCommand, args: string[], spawnProcess: SpawnSyncLike): string | null {
+  const result = runNpmCommand(command, args, rootOptions, spawnProcess);
+  return result.error || result.status !== 0 ? null : String(result.stdout || '').trim() || null;
+}
+
+export function resolveNpmCommand(
   spawnProcess: SpawnSyncLike = spawnSync,
   platform: NodeJS.Platform = process.platform,
-): string | null {
-  const options: SpawnSyncOptions = {
-    encoding: 'utf-8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-    timeout: 15000,
-    windowsHide: true,
-  };
-  const result = spawnProcess(command, args, options);
-  if (platform === 'win32' && (result.error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT') {
-    const shim = spawnProcess(`${command}.cmd`, args, options);
-    if (!shim.error && shim.status === 0) return String(shim.stdout || '').trim() || null;
-  }
-  return result.error || result.status !== 0 ? null : String(result.stdout || '').trim() || null;
+): NpmCommand | null {
+  const commands: NpmCommand[] = [{ kind: 'direct', command: 'npm' }];
+  if (platform === 'win32') commands.push({ kind: 'direct', command: 'npm.cmd' });
+  return commands.find((command) => commandResult(command, ['--version'], spawnProcess) !== null) ?? null;
 }
 
 export function resolveNpmGlobalInstallRoot(
   spawnProcess: SpawnSyncLike = spawnSync,
   platform: NodeJS.Platform = process.platform,
+  command = resolveNpmCommand(spawnProcess, platform),
 ): string | null {
-  return spawnRoot('npm', ['root', '-g'], spawnProcess, platform);
+  return command ? commandResult(command, ['root', '-g'], spawnProcess) : null;
 }
 
-/** Bun reports its configured global bin directory. */
+export function resolveNpmPrefix(
+  spawnProcess: SpawnSyncLike = spawnSync,
+  platform: NodeJS.Platform = process.platform,
+  command = resolveNpmCommand(spawnProcess, platform),
+): string | null {
+  return command ? commandResult(command, ['prefix', '-g'], spawnProcess) : null;
+}
+
+/** Bun reports its configured global bin directory; its executable is resolved separately. */
 export function resolveBunGlobalBin(
   spawnProcess: SpawnSyncLike = spawnSync,
   platform: NodeJS.Platform = process.platform,
 ): string | null {
-  return spawnRoot('bun', ['pm', 'bin', '-g'], spawnProcess, platform);
+  const command = platform === 'win32' ? 'bun.exe' : 'bun';
+  const result = spawnProcess(command, ['pm', 'bin', '-g'], rootOptions);
+  return result.error || result.status !== 0 ? null : String(result.stdout || '').trim() || null;
+}
+
+/** Only accept Bun provenance from the current runtime or lifecycle launcher, never the global bin path. */
+export function resolveBunCommand(): string | null {
+  const candidates = [process.execPath, process.env.npm_execpath].filter((value): value is string => Boolean(value));
+  for (const candidate of candidates) {
+    try {
+      const resolved = realpathSync(candidate);
+      if (/^bun(?:\.exe)?$/i.test(basename(resolved))) return resolved;
+    } catch {
+      // A lifecycle hint must be a real Bun executable to be trusted.
+    }
+  }
+  return null;
 }
 
 function isPathWithin(path: string, root: string): boolean {
@@ -71,64 +115,52 @@ function isPathWithin(path: string, root: string): boolean {
   return relation === '' || (!relation.startsWith('..') && !isAbsolute(relation));
 }
 
-function matchesCurrentNpmInstall(
-  root: string,
-  dependencies: Pick<PackageManagerOwnershipDependencies, 'currentExecutable' | 'currentPackageRoot' | 'realpath'>,
-): boolean {
+function matchesCurrentNpmInstall(root: string, dependencies: Pick<PackageManagerOwnershipDependencies, 'currentExecutable' | 'currentPackageRoot' | 'realpath'>): string | null {
   try {
     const packageRoot = dependencies.realpath(join(root, 'oh-my-codex'));
     const currentPackageRoot = dependencies.realpath(dependencies.currentPackageRoot);
     const executable = dependencies.realpath(dependencies.currentExecutable);
-    return packageRoot === currentPackageRoot && isPathWithin(executable, packageRoot);
-  } catch {
-    return false;
-  }
-}
-
-function resolveBunOwnership(
-  dependencies: Pick<PackageManagerOwnershipDependencies, 'currentExecutable' | 'currentPackageRoot' | 'platform' | 'realpath' | 'resolveBunGlobalBin'>,
-): Extract<PackageManagerOwnership, { manager: 'bun' }> | null {
-  try {
-    const configuredBin = dependencies.resolveBunGlobalBin();
-    if (!configuredBin) return null;
-    const bunGlobalBin = dependencies.realpath(configuredBin);
-    const executable = dependencies.realpath(dependencies.currentExecutable);
-    const packageRoot = dependencies.realpath(dependencies.currentPackageRoot);
-    const shimName = dependencies.platform === 'win32' ? 'omx.cmd' : 'omx';
-    const bunName = dependencies.platform === 'win32' ? 'bun.exe' : 'bun';
-    if (dependencies.realpath(join(bunGlobalBin, shimName)) !== executable) return null;
-    if (basename(packageRoot) !== 'oh-my-codex' || !isPathWithin(executable, packageRoot)) return null;
-    return {
-      manager: 'bun',
-      bunCommand: dependencies.realpath(join(bunGlobalBin, bunName)),
-      bunGlobalBin,
-      globalInstallRoot: dirname(packageRoot),
-      packageRoot,
-    };
+    return packageRoot === currentPackageRoot && isPathWithin(executable, packageRoot) ? packageRoot : null;
   } catch {
     return null;
   }
 }
 
-export async function resolvePackageManagerOwnership(
-  dependencies: Partial<PackageManagerOwnershipDependencies> = {},
-): Promise<PackageManagerOwnership | null> {
+function resolveBunOwnership(dependencies: Pick<PackageManagerOwnershipDependencies, 'currentExecutable' | 'currentPackageRoot' | 'environment' | 'platform' | 'realpath' | 'resolveBunGlobalBin' | 'resolveBunCommand'>): Extract<PackageManagerOwnership, { manager: 'bun' }> | null {
+  try {
+    const configuredBin = dependencies.resolveBunGlobalBin();
+    const command = dependencies.resolveBunCommand();
+    if (!configuredBin || !command) return null;
+    const bunGlobalBin = dependencies.realpath(configuredBin);
+    const executable = dependencies.realpath(dependencies.currentExecutable);
+    const packageRoot = dependencies.realpath(dependencies.currentPackageRoot);
+    const shimName = dependencies.platform === 'win32' ? 'omx.cmd' : 'omx';
+    if (dependencies.realpath(join(bunGlobalBin, shimName)) !== executable) return null;
+    if (basename(packageRoot) !== 'oh-my-codex' || !isPathWithin(executable, packageRoot)) return null;
+    return { manager: 'bun', bunCommand: dependencies.realpath(command), bunGlobalBin, npmPrefix: dirname(packageRoot), globalInstallRoot: dirname(packageRoot), packageRoot, environment: { ...(dependencies.environment ?? process.env) } };
+  } catch {
+    return null;
+  }
+}
+
+export async function resolvePackageManagerOwnership(dependencies: Partial<PackageManagerOwnershipDependencies> = {}): Promise<PackageManagerOwnership | null> {
   const resolved: PackageManagerOwnershipDependencies = {
     currentExecutable: process.argv[1] ?? '',
     currentPackageRoot: process.cwd(),
     readInstallStamp: async () => null,
     realpath: (path) => realpathSync(path),
     resolveBunGlobalBin,
-    resolveNpmGlobalInstallRoot,
+    resolveBunCommand,
+    resolveNpmCommand,
+    resolveNpmGlobalInstallRoot: (command) => resolveNpmGlobalInstallRoot(spawnSync, process.platform, command),
+    resolveNpmPrefix: (command) => resolveNpmPrefix(spawnSync, process.platform, command),
     platform: process.platform,
+    environment: process.env,
     ...dependencies,
   };
   if (!resolved.currentExecutable) return null;
-
   const stamp = await resolved.readInstallStamp();
-  const managers: PackageManager[] = stamp?.package_manager
-    ? [stamp.package_manager]
-    : ['npm', 'bun'];
+  const managers: PackageManager[] = stamp?.package_manager ? [stamp.package_manager] : ['npm', 'bun'];
   const candidates: PackageManagerOwnership[] = [];
   for (const manager of managers) {
     if (manager === 'bun') {
@@ -136,10 +168,12 @@ export async function resolvePackageManagerOwnership(
       if (ownership) candidates.push(ownership);
       continue;
     }
-    const globalInstallRoot = resolved.resolveNpmGlobalInstallRoot();
-    if (globalInstallRoot && matchesCurrentNpmInstall(globalInstallRoot, resolved)) {
-      candidates.push({ manager, globalInstallRoot });
-    }
+    const npmCommand = resolved.resolveNpmCommand();
+    if (!npmCommand) continue;
+    const globalInstallRoot = resolved.resolveNpmGlobalInstallRoot(npmCommand);
+    const npmPrefix = resolved.resolveNpmPrefix(npmCommand);
+    const packageRoot = globalInstallRoot && matchesCurrentNpmInstall(globalInstallRoot, resolved);
+    if (globalInstallRoot && npmPrefix && packageRoot) candidates.push({ manager: 'npm', npmCommand, npmPrefix, globalInstallRoot, packageRoot, environment: { ...(resolved.environment ?? process.env) } });
   }
   return candidates.length === 1 ? candidates[0]! : null;
 }

--- a/src/cli/package-manager-ownership.ts
+++ b/src/cli/package-manager-ownership.ts
@@ -1,5 +1,5 @@
 import { realpathSync } from 'node:fs';
-import { basename, dirname, isAbsolute, join, relative } from 'node:path';
+import { basename, dirname, isAbsolute, join, posix, win32 } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import type { UserInstallStamp } from '../scripts/postinstall-advisory.js';
 
@@ -23,6 +23,8 @@ export type PackageManagerOwnership =
     manager: 'bun';
     bunCommand: string;
     bunGlobalBin: string;
+    /** Canonical configured BUN_INSTALL root when it defines this install. */
+    bunInstallRoot?: string;
     npmPrefix: string;
     globalInstallRoot: string;
     packageRoot: string;
@@ -100,7 +102,7 @@ export function resolveBunGlobalBin(command: string, spawnProcess: SpawnSyncLike
 
 /** Only accept Bun provenance from the current runtime, lifecycle launcher, or configured install root, never PATH. */
 export function resolveBunCommand(): string | null {
-  const candidates = [process.execPath, process.env.npm_execpath, process.env.BUN_INSTALL && join(process.env.BUN_INSTALL, 'bin', 'bun')]
+  const candidates = [process.execPath, process.env.npm_execpath, process.env.BUN_INSTALL && join(process.env.BUN_INSTALL, 'bin', process.platform === 'win32' ? 'bun.exe' : 'bun')]
     .filter((value): value is string => Boolean(value));
   for (const candidate of candidates) {
     try {
@@ -124,14 +126,19 @@ function resolveInstalledNpmCommand(dependencies: Pick<PackageManagerOwnershipDe
   }
 }
 
-function resolveInstalledBunCommand(dependencies: Pick<PackageManagerOwnershipDependencies, 'bunInstallRoot' | 'currentPackageRoot' | 'realpath'>): string | null {
+function platformPath(platform: NodeJS.Platform): typeof posix {
+  return platform === 'win32' ? win32 : posix;
+}
+
+function resolveInstalledBunCommand(dependencies: Pick<PackageManagerOwnershipDependencies, 'bunInstallRoot' | 'currentPackageRoot' | 'platform' | 'realpath'>): string | null {
   if (!dependencies.bunInstallRoot) return null;
   try {
+    const path = platformPath(dependencies.platform);
     const installRoot = dependencies.realpath(dependencies.bunInstallRoot);
     const packageRoot = dependencies.realpath(dependencies.currentPackageRoot);
-    if (packageRoot !== join(installRoot, 'install', 'global', 'node_modules', 'oh-my-codex')) return null;
-    const command = dependencies.realpath(join(installRoot, 'bin', 'bun'));
-    return /^bun(?:\.exe)?$/i.test(basename(command)) ? command : null;
+    if (packageRoot !== path.join(installRoot, 'install', 'global', 'node_modules', 'oh-my-codex')) return null;
+    const command = dependencies.realpath(path.join(installRoot, 'bin', dependencies.platform === 'win32' ? 'bun.exe' : 'bun'));
+    return /^bun(?:\.exe)?$/i.test(path.basename(command)) ? command : null;
   } catch {
     return null;
   }
@@ -139,15 +146,15 @@ function resolveInstalledBunCommand(dependencies: Pick<PackageManagerOwnershipDe
 
 function transactionEnvironment(source: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv {
   const environment: NodeJS.ProcessEnv = {};
-  for (const key of ['HOME', 'PATH', 'TMPDIR', 'TEMP', 'TMP', 'SystemRoot', 'USERPROFILE']) {
+  for (const key of ['HOME', 'PATH', 'TMPDIR', 'TEMP', 'TMP', 'SystemRoot', 'USERPROFILE', 'BUN_INSTALL']) {
     if (source?.[key]) environment[key] = source[key];
   }
   return environment;
 }
 
-function isPathWithin(path: string, root: string): boolean {
-  const relation = relative(root, path);
-  return relation === '' || (!relation.startsWith('..') && !isAbsolute(relation));
+function isPathWithin(path: string, root: string, platform: NodeJS.Platform = process.platform): boolean {
+  const relation = platformPath(platform).relative(root, path);
+  return relation === '' || (!relation.startsWith('..') && !platformPath(platform).isAbsolute(relation));
 }
 
 function matchesCurrentInstall(root: string, dependencies: Pick<PackageManagerOwnershipDependencies, 'currentExecutable' | 'currentPackageRoot' | 'realpath'>): string | null {
@@ -163,6 +170,7 @@ function matchesCurrentInstall(root: string, dependencies: Pick<PackageManagerOw
 
 function resolveBunOwnership(dependencies: Pick<PackageManagerOwnershipDependencies, 'bunInstallRoot' | 'currentExecutable' | 'currentPackageRoot' | 'environment' | 'platform' | 'realpath' | 'resolveBunGlobalBin' | 'resolveBunCommand'>): Extract<PackageManagerOwnership, { manager: 'bun' }> | null {
   try {
+    const path = platformPath(dependencies.platform);
     const command = dependencies.resolveBunCommand() ?? resolveInstalledBunCommand(dependencies);
     if (!command) return null;
     const bunCommand = dependencies.realpath(command);
@@ -171,10 +179,29 @@ function resolveBunOwnership(dependencies: Pick<PackageManagerOwnershipDependenc
     const bunGlobalBin = dependencies.realpath(configuredBin);
     const executable = dependencies.realpath(dependencies.currentExecutable);
     const packageRoot = dependencies.realpath(dependencies.currentPackageRoot);
+    let bunInstallRoot: string | undefined;
+    if (dependencies.bunInstallRoot) {
+      try {
+        const configuredInstallRoot = dependencies.realpath(dependencies.bunInstallRoot);
+        if (packageRoot === path.join(configuredInstallRoot, 'install', 'global', 'node_modules', 'oh-my-codex')) bunInstallRoot = configuredInstallRoot;
+      } catch {
+        // A configured bin and canonical shim can independently prove ownership.
+      }
+    }
     const shimName = dependencies.platform === 'win32' ? 'omx.cmd' : 'omx';
-    if (dependencies.realpath(join(bunGlobalBin, shimName)) !== executable) return null;
-    if (basename(packageRoot) !== 'oh-my-codex' || !isPathWithin(executable, packageRoot)) return null;
-    return { manager: 'bun', bunCommand, bunGlobalBin, npmPrefix: dirname(packageRoot), globalInstallRoot: dirname(packageRoot), packageRoot, environment: transactionEnvironment(dependencies.environment) };
+    const shim = dependencies.realpath(path.join(bunGlobalBin, shimName));
+    if (path.basename(packageRoot) !== 'oh-my-codex' || !isPathWithin(executable, packageRoot, dependencies.platform)) return null;
+    if (dependencies.platform === 'win32') {
+      // A Windows .cmd shim is a separate file, so its canonical location is the ownership evidence.
+      if (!isPathWithin(shim, bunGlobalBin, dependencies.platform)) return null;
+    } else if (shim !== executable) {
+      return null;
+    }
+    return {
+      manager: 'bun', bunCommand, bunGlobalBin, ...(bunInstallRoot ? { bunInstallRoot } : {}),
+      npmPrefix: path.dirname(packageRoot), globalInstallRoot: path.dirname(packageRoot), packageRoot,
+      environment: transactionEnvironment(dependencies.environment),
+    };
   } catch {
     return null;
   }

--- a/src/cli/update-worker.ts
+++ b/src/cli/update-worker.ts
@@ -7,6 +7,7 @@ import { runNpmCommand, type PackageManagerOwnership } from './package-manager-o
 type DeferredUpdatePayload = { cwd: string; logPath: string; parentPid: number; ownership: PackageManagerOwnership; setupArgs: string[] };
 const PACKAGE_NAME = 'oh-my-codex';
 const installSource = `${PACKAGE_NAME}@latest`;
+const SKIP_NATIVE_AGENT_REFRESH_ENV = 'OMX_SKIP_NATIVE_AGENT_REFRESH';
 const installOptions: SpawnSyncOptions = { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 120000, windowsHide: true };
 
 function within(root: string, path: string): boolean {
@@ -36,7 +37,11 @@ async function canonicalRegularFile(path: string, stage: string): Promise<string
 async function ownerOnlyStage(stage: string): Promise<boolean> {
   try {
     const stat = await lstat(stage);
-    return stat.isDirectory() && !stat.isSymbolicLink() && (stat.mode & 0o077) === 0 && (typeof process.getuid !== 'function' || stat.uid === process.getuid());
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    // Windows does not expose POSIX mode/uid ownership through Node's stat data.
+    // The per-user temp directory and signed payload protect the Windows stage.
+    return process.platform === 'win32'
+      || ((stat.mode & 0o077) === 0 && (typeof process.getuid !== 'function' || stat.uid === process.getuid()));
   } catch { return false; }
 }
 async function validatePackage(ownership: PackageManagerOwnership): Promise<string | null> {
@@ -69,15 +74,17 @@ async function main(): Promise<void> {
   const expectedDigest = process.argv[3];
   let payload: DeferredUpdatePayload | null = null;
   let stagedPayload: string | null = null;
+  let stagedDirectory: string | null = null;
   try {
     const expectedWorkerDigest = process.argv[4];
     if (!payloadPath || !expectedDigest || !expectedWorkerDigest) throw new Error('Frozen transaction payload is missing.');
     const workerPath = await canonicalRegularFile(process.argv[1] ?? '', await realpath(join(process.argv[1] ?? '', '..')));
     if (!workerPath || digest(await readFile(workerPath, 'utf-8')) !== expectedWorkerDigest) throw new Error('Frozen update worker identity changed before execution.');
     const stage = await realpath(join(payloadPath, '..'));
-    if (!await ownerOnlyStage(stage)) throw new Error('Frozen transaction staging directory is not owner-only.');
+    if (!await ownerOnlyStage(stage)) throw new Error('Frozen transaction staging directory is not an owner-only stage.');
+    stagedDirectory = stage;
     stagedPayload = await canonicalRegularFile(payloadPath, stage);
-    if (!stagedPayload) throw new Error('Frozen transaction payload is not an owner-only regular staged file.');
+    if (!stagedPayload) throw new Error('Frozen transaction payload is not a regular canonical staged file.');
     const serialized = await readFile(stagedPayload, 'utf-8');
     if (digest(serialized) !== expectedDigest) throw new Error('Frozen transaction payload fingerprint changed before execution.');
     payload = JSON.parse(serialized) as DeferredUpdatePayload;
@@ -90,13 +97,14 @@ async function main(): Promise<void> {
     if (result.error || result.status !== 0) throw new Error(String(result.stderr || result.error?.message || 'controller install failed'));
     const cliEntry = await validateOwnership(payload.ownership);
     if (!cliEntry) throw new Error('Frozen manager, package root, or bin ownership validation failed after update.');
-    const setup = spawnSync(process.execPath, [cliEntry, ...payload.setupArgs], { cwd: payload.cwd, env: payload.ownership.environment, stdio: 'inherit', windowsHide: true });
+    const setup = spawnSync(process.execPath, [cliEntry, ...payload.setupArgs], { cwd: payload.cwd, env: { ...payload.ownership.environment, [SKIP_NATIVE_AGENT_REFRESH_ENV]: '1' }, stdio: 'inherit', windowsHide: true });
     if (setup.error || setup.status !== 0) throw new Error(setup.error?.message || `setup exited ${setup.status}`);
   } catch (error) {
     if (payload) await appendFile(payload.logPath, `[omx] Deferred update failed: ${error instanceof Error ? error.message : String(error)}\n`);
     process.exitCode = 1;
   } finally {
-    if (stagedPayload) await rm(stagedPayload, { force: true }).catch(() => undefined);
+    if (stagedDirectory) await rm(stagedDirectory, { recursive: true, force: true }).catch(() => undefined);
+    else if (stagedPayload) await rm(stagedPayload, { force: true }).catch(() => undefined);
   }
 }
 void main();

--- a/src/cli/update-worker.ts
+++ b/src/cli/update-worker.ts
@@ -1,7 +1,7 @@
 import { appendFile, lstat, readFile, realpath, rm } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { spawnSync, type SpawnSyncOptions } from 'node:child_process';
-import { isAbsolute, join, relative } from 'node:path';
+import { isAbsolute, join, relative, win32 } from 'node:path';
 import { runNpmCommand, type PackageManagerOwnership } from './package-manager-ownership.js';
 import { writeUserInstallStamp } from '../scripts/postinstall-advisory.js';
 import { omxUserInstallStampPath } from '../utils/paths.js';
@@ -11,6 +11,12 @@ const PACKAGE_NAME = 'oh-my-codex';
 const installSource = `${PACKAGE_NAME}@latest`;
 const SKIP_NATIVE_AGENT_REFRESH_ENV = 'OMX_SKIP_NATIVE_AGENT_REFRESH';
 const installOptions: SpawnSyncOptions = { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 120000, windowsHide: true };
+
+function pathsEqual(left: string, right: string): boolean {
+  return process.platform === 'win32'
+    ? win32.normalize(left).toLowerCase() === win32.normalize(right).toLowerCase()
+    : left === right;
+}
 
 function within(root: string, path: string): boolean {
   const relation = relative(root, path);
@@ -49,10 +55,13 @@ async function ownerOnlyStage(stage: string): Promise<boolean> {
 async function validatePackage(ownership: PackageManagerOwnership): Promise<string | null> {
   try {
     const packageRoot = await realpath(join(ownership.globalInstallRoot, PACKAGE_NAME));
-    if (packageRoot !== ownership.packageRoot) return null;
-    const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf-8')) as { bin?: string | Record<string, string> };
+    if (!pathsEqual(packageRoot, ownership.packageRoot)) return null;
+    const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf-8')) as {
+      name?: string;
+      bin?: string | Record<string, string>;
+    };
     const bin = typeof manifest.bin === 'string' ? manifest.bin : manifest.bin?.omx;
-    if (typeof bin !== 'string' || !bin.trim() || isAbsolute(bin)) return null;
+    if (manifest.name !== PACKAGE_NAME || typeof bin !== 'string' || !bin.trim() || isAbsolute(bin)) return null;
     const entry = await realpath(join(packageRoot, bin));
     return within(packageRoot, entry) ? entry : null;
   } catch { return null; }
@@ -61,14 +70,14 @@ async function validateManager(ownership: PackageManagerOwnership): Promise<bool
   if (ownership.manager === 'npm') {
     const root = output(runNpmCommand(ownership.npmCommand, ['root', '-g'], { ...installOptions, env: ownership.environment }));
     const prefix = output(runNpmCommand(ownership.npmCommand, ['prefix', '-g'], { ...installOptions, env: ownership.environment }));
-    try { return root !== null && prefix !== null && await realpath(root) === ownership.globalInstallRoot && await realpath(prefix) === ownership.npmPrefix; } catch { return false; }
+    try { return root !== null && prefix !== null && pathsEqual(await realpath(root), ownership.globalInstallRoot) && pathsEqual(await realpath(prefix), ownership.npmPrefix); } catch { return false; }
   }
   if (!ownership.bunInstallRoot || ownership.environment.BUN_INSTALL !== ownership.bunInstallRoot) return false;
   const bin = output(spawnSync(ownership.bunCommand, ['pm', 'bin', '-g'], { ...installOptions, env: ownership.environment }));
   try {
     return bin !== null
-      && await realpath(bin) === ownership.bunGlobalBin
-      && await realpath(ownership.environment.BUN_INSTALL) === ownership.bunInstallRoot;
+      && pathsEqual(await realpath(bin), ownership.bunGlobalBin)
+      && pathsEqual(await realpath(ownership.environment.BUN_INSTALL), ownership.bunInstallRoot);
   } catch { return false; }
 }
 async function validateOwnership(ownership: PackageManagerOwnership): Promise<string | null> {

--- a/src/cli/update-worker.ts
+++ b/src/cli/update-worker.ts
@@ -62,7 +62,10 @@ async function validateManager(ownership: PackageManagerOwnership): Promise<bool
     try { return root !== null && prefix !== null && await realpath(root) === ownership.globalInstallRoot && await realpath(prefix) === ownership.npmPrefix; } catch { return false; }
   }
   const bin = output(spawnSync(ownership.bunCommand, ['pm', 'bin', '-g'], { ...installOptions, env: ownership.environment }));
-  try { return bin !== null && await realpath(bin) === ownership.bunGlobalBin; } catch { return false; }
+  try {
+    if (bin === null || await realpath(bin) !== ownership.bunGlobalBin) return false;
+    return !ownership.bunInstallRoot || (typeof ownership.environment.BUN_INSTALL === 'string' && await realpath(ownership.environment.BUN_INSTALL) === ownership.bunInstallRoot);
+  } catch { return false; }
 }
 async function validateOwnership(ownership: PackageManagerOwnership): Promise<string | null> {
   if (!await validateManager(ownership)) return null;

--- a/src/cli/update-worker.ts
+++ b/src/cli/update-worker.ts
@@ -1,8 +1,8 @@
 import { appendFile, lstat, readFile, realpath, rm } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { spawnSync, type SpawnSyncOptions } from 'node:child_process';
-import { isAbsolute, join, relative, win32 } from 'node:path';
-import { isCompletePackageManagerOwnership, runNpmCommand, type PackageManagerOwnership } from './package-manager-ownership.js';
+import { isAbsolute, join, relative } from 'node:path';
+import { isCompletePackageManagerOwnership, runNpmCommand, validatePackageManagerOwnership, type PackageManagerOwnership } from './package-manager-ownership.js';
 import { writeUserInstallStamp } from '../scripts/postinstall-advisory.js';
 import { omxUserInstallStampPath } from '../utils/paths.js';
 
@@ -12,22 +12,30 @@ const installSource = `${PACKAGE_NAME}@latest`;
 const SKIP_NATIVE_AGENT_REFRESH_ENV = 'OMX_SKIP_NATIVE_AGENT_REFRESH';
 const installOptions: SpawnSyncOptions = { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 120000, windowsHide: true };
 
-function pathsEqual(left: string, right: string): boolean {
-  return process.platform === 'win32'
-    ? win32.normalize(left).toLowerCase() === win32.normalize(right).toLowerCase()
-    : left === right;
-}
 
 function within(root: string, path: string): boolean {
   const relation = relative(root, path);
   return relation !== '' && !relation.startsWith('..') && !isAbsolute(relation);
 }
 function digest(contents: string): string { return createHash('sha256').update(contents).digest('hex'); }
-function output(result: ReturnType<typeof spawnSync>): string | null { return result.error || result.status !== 0 ? null : String(result.stdout || '').trim() || null; }
 function installArgs(ownership: PackageManagerOwnership): string[] {
   return ownership.manager === 'bun'
     ? ['add', '--global', '--ignore-scripts', installSource]
     : ['install', '--global', '--ignore-scripts', '--no-audit', '--no-progress', '--prefix', ownership.npmPrefix, installSource];
+}
+
+function isDeferredUpdatePayload(value: unknown): value is DeferredUpdatePayload {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const payload = value as Record<string, unknown>;
+  return typeof payload.cwd === 'string'
+    && Boolean(payload.cwd)
+    && typeof payload.logPath === 'string'
+    && Boolean(payload.logPath)
+    && Number.isSafeInteger(payload.parentPid)
+    && (payload.parentPid as number) > 0
+    && Array.isArray(payload.setupArgs)
+    && payload.setupArgs.every((arg) => typeof arg === 'string')
+    && isCompletePackageManagerOwnership(payload.ownership);
 }
 async function waitForParent(parentPid: number): Promise<void> {
   await new Promise<void>((resolve) => {
@@ -51,38 +59,6 @@ async function ownerOnlyStage(stage: string): Promise<boolean> {
     return process.platform === 'win32'
       || ((stat.mode & 0o077) === 0 && (typeof process.getuid !== 'function' || stat.uid === process.getuid()));
   } catch { return false; }
-}
-async function validatePackage(ownership: PackageManagerOwnership): Promise<string | null> {
-  try {
-    const packageRoot = await realpath(join(ownership.globalInstallRoot, PACKAGE_NAME));
-    if (!pathsEqual(packageRoot, ownership.packageRoot)) return null;
-    const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf-8')) as {
-      name?: string;
-      bin?: string | Record<string, string>;
-    };
-    const bin = typeof manifest.bin === 'string' ? manifest.bin : manifest.bin?.omx;
-    if (manifest.name !== PACKAGE_NAME || typeof bin !== 'string' || !bin.trim() || isAbsolute(bin)) return null;
-    const entry = await realpath(join(packageRoot, bin));
-    return within(packageRoot, entry) ? entry : null;
-  } catch { return null; }
-}
-async function validateManager(ownership: PackageManagerOwnership): Promise<boolean> {
-  if (ownership.manager === 'npm') {
-    const root = output(runNpmCommand(ownership.npmCommand, ['root', '-g'], { ...installOptions, env: ownership.environment }));
-    const prefix = output(runNpmCommand(ownership.npmCommand, ['prefix', '-g'], { ...installOptions, env: ownership.environment }));
-    try { return root !== null && prefix !== null && pathsEqual(await realpath(root), ownership.globalInstallRoot) && pathsEqual(await realpath(prefix), ownership.npmPrefix); } catch { return false; }
-  }
-  if (!ownership.bunInstallRoot || ownership.environment.BUN_INSTALL !== ownership.bunInstallRoot) return false;
-  const bin = output(spawnSync(ownership.bunCommand, ['pm', 'bin', '-g'], { ...installOptions, env: ownership.environment }));
-  try {
-    return bin !== null
-      && pathsEqual(await realpath(bin), ownership.bunGlobalBin)
-      && pathsEqual(await realpath(ownership.environment.BUN_INSTALL), ownership.bunInstallRoot);
-  } catch { return false; }
-}
-async function validateOwnership(ownership: PackageManagerOwnership): Promise<string | null> {
-  if (!await validateManager(ownership)) return null;
-  return validatePackage(ownership);
 }
 
 async function finalizeSuccessfulUpdate(ownership: PackageManagerOwnership): Promise<void> {
@@ -118,15 +94,16 @@ async function main(): Promise<void> {
     if (!stagedPayload) throw new Error('Frozen transaction payload is not a regular canonical staged file.');
     const serialized = await readFile(stagedPayload, 'utf-8');
     if (digest(serialized) !== expectedDigest) throw new Error('Frozen transaction payload fingerprint changed before execution.');
-    payload = JSON.parse(serialized) as DeferredUpdatePayload;
-    if (!isCompletePackageManagerOwnership(payload.ownership)) throw new Error('Frozen transaction payload is incomplete.');
+    const parsedPayload: unknown = JSON.parse(serialized);
+    if (!isDeferredUpdatePayload(parsedPayload)) throw new Error('Frozen transaction payload is incomplete.');
+    payload = parsedPayload;
     await waitForParent(payload.parentPid);
-    if (!await validateOwnership(payload.ownership)) throw new Error('Frozen manager, package root, or bin ownership validation failed before update.');
+    if (!await validatePackageManagerOwnership(payload.ownership)) throw new Error('Frozen manager, package root, or bin ownership validation failed before update.');
     const result = payload.ownership.manager === 'npm'
       ? runNpmCommand(payload.ownership.npmCommand, installArgs(payload.ownership), { ...installOptions, env: payload.ownership.environment })
       : spawnSync(payload.ownership.bunCommand, installArgs(payload.ownership), { ...installOptions, env: payload.ownership.environment });
     if (result.error || result.status !== 0) throw new Error(String(result.stderr || result.error?.message || 'controller install failed'));
-    const cliEntry = await validateOwnership(payload.ownership);
+    const cliEntry = await validatePackageManagerOwnership(payload.ownership);
     if (!cliEntry) throw new Error('Frozen manager, package root, or bin ownership validation failed after update.');
     const setup = spawnSync(process.execPath, [cliEntry, ...payload.setupArgs], { cwd: payload.cwd, env: { ...payload.ownership.environment, [SKIP_NATIVE_AGENT_REFRESH_ENV]: '1' }, stdio: 'inherit', windowsHide: true });
     if (setup.error || setup.status !== 0) throw new Error(setup.error?.message || `setup exited ${setup.status}`);

--- a/src/cli/update-worker.ts
+++ b/src/cli/update-worker.ts
@@ -1,111 +1,102 @@
-import { appendFile, readFile, realpath, rm } from 'node:fs/promises';
+import { appendFile, lstat, readFile, realpath, rm } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import { spawnSync, type SpawnSyncOptions } from 'node:child_process';
 import { isAbsolute, join, relative } from 'node:path';
 import { runNpmCommand, type PackageManagerOwnership } from './package-manager-ownership.js';
 
-type DeferredUpdatePayload = {
-  cwd: string;
-  logPath: string;
-  parentPid: number;
-  ownership: PackageManagerOwnership;
-  setupArgs: string[];
-};
-
+type DeferredUpdatePayload = { cwd: string; logPath: string; parentPid: number; ownership: PackageManagerOwnership; setupArgs: string[] };
 const PACKAGE_NAME = 'oh-my-codex';
 const installSource = `${PACKAGE_NAME}@latest`;
-const installOptions: SpawnSyncOptions = {
-  encoding: 'utf-8',
-  stdio: ['ignore', 'pipe', 'pipe'],
-  timeout: 120000,
-  windowsHide: true,
-};
+const installOptions: SpawnSyncOptions = { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 120000, windowsHide: true };
 
 function within(root: string, path: string): boolean {
   const relation = relative(root, path);
   return relation !== '' && !relation.startsWith('..') && !isAbsolute(relation);
 }
-
-function stableInstallArgs(ownership: PackageManagerOwnership): string[] {
-  return ['install', '--global', '--ignore-scripts', '--no-audit', '--no-progress', '--prefix', ownership.npmPrefix!, installSource];
+function digest(contents: string): string { return createHash('sha256').update(contents).digest('hex'); }
+function output(result: ReturnType<typeof spawnSync>): string | null { return result.error || result.status !== 0 ? null : String(result.stdout || '').trim() || null; }
+function installArgs(ownership: PackageManagerOwnership): string[] {
+  return ownership.manager === 'bun'
+    ? ['add', '--global', '--ignore-scripts', installSource]
+    : ['install', '--global', '--ignore-scripts', '--no-audit', '--no-progress', '--prefix', ownership.npmPrefix, installSource];
 }
-
-function output(result: ReturnType<typeof spawnSync>): string | null {
-  return result.error || result.status !== 0 ? null : String(result.stdout || '').trim() || null;
-}
-
-function waitForParent(parentPid: number): Promise<void> {
-  return new Promise((resolve) => {
-    const timer = setInterval(() => {
-      try {
-        process.kill(parentPid, 0);
-      } catch {
-        clearInterval(timer);
-        resolve();
-      }
-    }, 1000);
+async function waitForParent(parentPid: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const timer = setInterval(() => { try { process.kill(parentPid, 0); } catch { clearInterval(timer); resolve(); } }, 1000);
   });
 }
-
-async function validatePackage(ownership: PackageManagerOwnership): Promise<string | null> {
-  if (!ownership.packageRoot) return null;
-  const packageRoot = await realpath(join(ownership.globalInstallRoot, PACKAGE_NAME));
-  if (packageRoot !== ownership.packageRoot) return null;
-  let bin: string | undefined;
+async function canonicalRegularFile(path: string, stage: string): Promise<string | null> {
   try {
-    const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf-8')) as {
-      bin?: string | Record<string, string>;
-    };
-    bin = typeof manifest.bin === 'string' ? manifest.bin : manifest.bin?.omx;
-  } catch {
-    bin = join('dist', 'cli', 'omx.js');
-  }
-  if (typeof bin !== 'string' || bin.trim() === '' || isAbsolute(bin)) return null;
-  const entry = await realpath(join(packageRoot, bin));
-  return within(packageRoot, entry) ? entry : null;
+    const stat = await lstat(path);
+    if (!stat.isFile() || stat.isSymbolicLink()) return null;
+    const canonical = await realpath(path);
+    return within(stage, canonical) ? canonical : null;
+  } catch { return null; }
 }
-
+async function ownerOnlyStage(stage: string): Promise<boolean> {
+  try {
+    const stat = await lstat(stage);
+    return stat.isDirectory() && !stat.isSymbolicLink() && (stat.mode & 0o077) === 0 && (typeof process.getuid !== 'function' || stat.uid === process.getuid());
+  } catch { return false; }
+}
+async function validatePackage(ownership: PackageManagerOwnership): Promise<string | null> {
+  try {
+    const packageRoot = await realpath(join(ownership.globalInstallRoot, PACKAGE_NAME));
+    if (packageRoot !== ownership.packageRoot) return null;
+    const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf-8')) as { bin?: string | Record<string, string> };
+    const bin = typeof manifest.bin === 'string' ? manifest.bin : manifest.bin?.omx;
+    if (typeof bin !== 'string' || !bin.trim() || isAbsolute(bin)) return null;
+    const entry = await realpath(join(packageRoot, bin));
+    return within(packageRoot, entry) ? entry : null;
+  } catch { return null; }
+}
 async function validateManager(ownership: PackageManagerOwnership): Promise<boolean> {
   if (ownership.manager === 'npm') {
-    const root = output(runNpmCommand(ownership.npmCommand!, ['root', '-g'], { ...installOptions, env: ownership.environment }));
-    const prefix = output(runNpmCommand(ownership.npmCommand!, ['prefix', '-g'], { ...installOptions, env: ownership.environment }));
-    return root === ownership.globalInstallRoot && prefix === ownership.npmPrefix;
+    const root = output(runNpmCommand(ownership.npmCommand, ['root', '-g'], { ...installOptions, env: ownership.environment }));
+    const prefix = output(runNpmCommand(ownership.npmCommand, ['prefix', '-g'], { ...installOptions, env: ownership.environment }));
+    try { return root !== null && prefix !== null && await realpath(root) === ownership.globalInstallRoot && await realpath(prefix) === ownership.npmPrefix; } catch { return false; }
   }
   const bin = output(spawnSync(ownership.bunCommand, ['pm', 'bin', '-g'], { ...installOptions, env: ownership.environment }));
-  if (!bin) return false;
-  try {
-    return await realpath(bin) === ownership.bunGlobalBin;
-  } catch {
-    return false;
-  }
+  try { return bin !== null && await realpath(bin) === ownership.bunGlobalBin; } catch { return false; }
+}
+async function validateOwnership(ownership: PackageManagerOwnership): Promise<string | null> {
+  if (!await validateManager(ownership)) return null;
+  return validatePackage(ownership);
 }
 
 async function main(): Promise<void> {
   const payloadPath = process.argv[2];
-  if (!payloadPath) process.exitCode = 1;
-  if (!payloadPath) return;
+  const expectedDigest = process.argv[3];
   let payload: DeferredUpdatePayload | null = null;
+  let stagedPayload: string | null = null;
   try {
-    payload = JSON.parse(await readFile(payloadPath, 'utf-8')) as DeferredUpdatePayload;
+    const expectedWorkerDigest = process.argv[4];
+    if (!payloadPath || !expectedDigest || !expectedWorkerDigest) throw new Error('Frozen transaction payload is missing.');
+    const workerPath = await canonicalRegularFile(process.argv[1] ?? '', await realpath(join(process.argv[1] ?? '', '..')));
+    if (!workerPath || digest(await readFile(workerPath, 'utf-8')) !== expectedWorkerDigest) throw new Error('Frozen update worker identity changed before execution.');
+    const stage = await realpath(join(payloadPath, '..'));
+    if (!await ownerOnlyStage(stage)) throw new Error('Frozen transaction staging directory is not owner-only.');
+    stagedPayload = await canonicalRegularFile(payloadPath, stage);
+    if (!stagedPayload) throw new Error('Frozen transaction payload is not an owner-only regular staged file.');
+    const serialized = await readFile(stagedPayload, 'utf-8');
+    if (digest(serialized) !== expectedDigest) throw new Error('Frozen transaction payload fingerprint changed before execution.');
+    payload = JSON.parse(serialized) as DeferredUpdatePayload;
+    if (!payload.ownership || !payload.ownership.packageRoot || !payload.ownership.environment) throw new Error('Frozen transaction payload is incomplete.');
     await waitForParent(payload.parentPid);
-    if (!payload.ownership.npmPrefix || !payload.ownership.packageRoot || !payload.ownership.environment || (payload.ownership.manager === 'npm' && !payload.ownership.npmCommand)) throw new Error('Frozen transaction payload is incomplete.');
-    if (!await validateManager(payload.ownership)) throw new Error('Frozen package-manager command, root, or prefix no longer validates.');
-    if (!await validatePackage(payload.ownership)) throw new Error('Frozen installed package/bin validation failed before update.');
+    if (!await validateOwnership(payload.ownership)) throw new Error('Frozen manager, package root, or bin ownership validation failed before update.');
     const result = payload.ownership.manager === 'npm'
-      ? runNpmCommand(payload.ownership.npmCommand!, stableInstallArgs(payload.ownership), { ...installOptions, env: payload.ownership.environment! })
-      : spawnSync(payload.ownership.bunCommand, stableInstallArgs(payload.ownership), { ...installOptions, env: payload.ownership.environment! });
+      ? runNpmCommand(payload.ownership.npmCommand, installArgs(payload.ownership), { ...installOptions, env: payload.ownership.environment })
+      : spawnSync(payload.ownership.bunCommand, installArgs(payload.ownership), { ...installOptions, env: payload.ownership.environment });
     if (result.error || result.status !== 0) throw new Error(String(result.stderr || result.error?.message || 'controller install failed'));
-    const cliEntry = await validatePackage(payload.ownership);
-    if (!cliEntry) throw new Error('Installed package/bin validation failed after update.');
-    const setup = spawnSync(process.execPath, [cliEntry, ...payload.setupArgs], {
-      cwd: payload.cwd, env: payload.ownership.environment!, stdio: 'inherit', windowsHide: true,
-    });
+    const cliEntry = await validateOwnership(payload.ownership);
+    if (!cliEntry) throw new Error('Frozen manager, package root, or bin ownership validation failed after update.');
+    const setup = spawnSync(process.execPath, [cliEntry, ...payload.setupArgs], { cwd: payload.cwd, env: payload.ownership.environment, stdio: 'inherit', windowsHide: true });
     if (setup.error || setup.status !== 0) throw new Error(setup.error?.message || `setup exited ${setup.status}`);
   } catch (error) {
     if (payload) await appendFile(payload.logPath, `[omx] Deferred update failed: ${error instanceof Error ? error.message : String(error)}\n`);
     process.exitCode = 1;
   } finally {
-    await rm(payloadPath, { force: true }).catch(() => undefined);
+    if (stagedPayload) await rm(stagedPayload, { force: true }).catch(() => undefined);
   }
 }
-
 void main();

--- a/src/cli/update-worker.ts
+++ b/src/cli/update-worker.ts
@@ -3,6 +3,8 @@ import { createHash } from 'node:crypto';
 import { spawnSync, type SpawnSyncOptions } from 'node:child_process';
 import { isAbsolute, join, relative } from 'node:path';
 import { runNpmCommand, type PackageManagerOwnership } from './package-manager-ownership.js';
+import { writeUserInstallStamp } from '../scripts/postinstall-advisory.js';
+import { omxUserInstallStampPath } from '../utils/paths.js';
 
 type DeferredUpdatePayload = { cwd: string; logPath: string; parentPid: number; ownership: PackageManagerOwnership; setupArgs: string[] };
 const PACKAGE_NAME = 'oh-my-codex';
@@ -61,15 +63,32 @@ async function validateManager(ownership: PackageManagerOwnership): Promise<bool
     const prefix = output(runNpmCommand(ownership.npmCommand, ['prefix', '-g'], { ...installOptions, env: ownership.environment }));
     try { return root !== null && prefix !== null && await realpath(root) === ownership.globalInstallRoot && await realpath(prefix) === ownership.npmPrefix; } catch { return false; }
   }
+  if (!ownership.bunInstallRoot || ownership.environment.BUN_INSTALL !== ownership.bunInstallRoot) return false;
   const bin = output(spawnSync(ownership.bunCommand, ['pm', 'bin', '-g'], { ...installOptions, env: ownership.environment }));
   try {
-    if (bin === null || await realpath(bin) !== ownership.bunGlobalBin) return false;
-    return !ownership.bunInstallRoot || (typeof ownership.environment.BUN_INSTALL === 'string' && await realpath(ownership.environment.BUN_INSTALL) === ownership.bunInstallRoot);
+    return bin !== null
+      && await realpath(bin) === ownership.bunGlobalBin
+      && await realpath(ownership.environment.BUN_INSTALL) === ownership.bunInstallRoot;
   } catch { return false; }
 }
 async function validateOwnership(ownership: PackageManagerOwnership): Promise<string | null> {
   if (!await validateManager(ownership)) return null;
   return validatePackage(ownership);
+}
+
+async function finalizeSuccessfulUpdate(ownership: PackageManagerOwnership): Promise<void> {
+  const manifest = JSON.parse(await readFile(join(ownership.packageRoot, 'package.json'), 'utf-8')) as { version?: string };
+  if (typeof manifest.version !== 'string' || manifest.version.trim() === '') {
+    throw new Error('Updated package version is unavailable for deferred update finalization.');
+  }
+  await writeUserInstallStamp({
+    installed_version: manifest.version.trim().replace(/^v/i, ''),
+    setup_completed_version: manifest.version.trim().replace(/^v/i, ''),
+    install_channel: 'stable',
+    install_source: installSource,
+    package_manager: ownership.manager,
+    updated_at: new Date().toISOString(),
+  }, omxUserInstallStampPath(ownership.environment.CODEX_HOME));
 }
 
 async function main(): Promise<void> {
@@ -102,6 +121,7 @@ async function main(): Promise<void> {
     if (!cliEntry) throw new Error('Frozen manager, package root, or bin ownership validation failed after update.');
     const setup = spawnSync(process.execPath, [cliEntry, ...payload.setupArgs], { cwd: payload.cwd, env: { ...payload.ownership.environment, [SKIP_NATIVE_AGENT_REFRESH_ENV]: '1' }, stdio: 'inherit', windowsHide: true });
     if (setup.error || setup.status !== 0) throw new Error(setup.error?.message || `setup exited ${setup.status}`);
+    await finalizeSuccessfulUpdate(payload.ownership);
   } catch (error) {
     if (payload) await appendFile(payload.logPath, `[omx] Deferred update failed: ${error instanceof Error ? error.message : String(error)}\n`);
     process.exitCode = 1;

--- a/src/cli/update-worker.ts
+++ b/src/cli/update-worker.ts
@@ -1,0 +1,111 @@
+import { appendFile, readFile, realpath, rm } from 'node:fs/promises';
+import { spawnSync, type SpawnSyncOptions } from 'node:child_process';
+import { isAbsolute, join, relative } from 'node:path';
+import { runNpmCommand, type PackageManagerOwnership } from './package-manager-ownership.js';
+
+type DeferredUpdatePayload = {
+  cwd: string;
+  logPath: string;
+  parentPid: number;
+  ownership: PackageManagerOwnership;
+  setupArgs: string[];
+};
+
+const PACKAGE_NAME = 'oh-my-codex';
+const installSource = `${PACKAGE_NAME}@latest`;
+const installOptions: SpawnSyncOptions = {
+  encoding: 'utf-8',
+  stdio: ['ignore', 'pipe', 'pipe'],
+  timeout: 120000,
+  windowsHide: true,
+};
+
+function within(root: string, path: string): boolean {
+  const relation = relative(root, path);
+  return relation !== '' && !relation.startsWith('..') && !isAbsolute(relation);
+}
+
+function stableInstallArgs(ownership: PackageManagerOwnership): string[] {
+  return ['install', '--global', '--ignore-scripts', '--no-audit', '--no-progress', '--prefix', ownership.npmPrefix!, installSource];
+}
+
+function output(result: ReturnType<typeof spawnSync>): string | null {
+  return result.error || result.status !== 0 ? null : String(result.stdout || '').trim() || null;
+}
+
+function waitForParent(parentPid: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setInterval(() => {
+      try {
+        process.kill(parentPid, 0);
+      } catch {
+        clearInterval(timer);
+        resolve();
+      }
+    }, 1000);
+  });
+}
+
+async function validatePackage(ownership: PackageManagerOwnership): Promise<string | null> {
+  if (!ownership.packageRoot) return null;
+  const packageRoot = await realpath(join(ownership.globalInstallRoot, PACKAGE_NAME));
+  if (packageRoot !== ownership.packageRoot) return null;
+  let bin: string | undefined;
+  try {
+    const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf-8')) as {
+      bin?: string | Record<string, string>;
+    };
+    bin = typeof manifest.bin === 'string' ? manifest.bin : manifest.bin?.omx;
+  } catch {
+    bin = join('dist', 'cli', 'omx.js');
+  }
+  if (typeof bin !== 'string' || bin.trim() === '' || isAbsolute(bin)) return null;
+  const entry = await realpath(join(packageRoot, bin));
+  return within(packageRoot, entry) ? entry : null;
+}
+
+async function validateManager(ownership: PackageManagerOwnership): Promise<boolean> {
+  if (ownership.manager === 'npm') {
+    const root = output(runNpmCommand(ownership.npmCommand!, ['root', '-g'], { ...installOptions, env: ownership.environment }));
+    const prefix = output(runNpmCommand(ownership.npmCommand!, ['prefix', '-g'], { ...installOptions, env: ownership.environment }));
+    return root === ownership.globalInstallRoot && prefix === ownership.npmPrefix;
+  }
+  const bin = output(spawnSync(ownership.bunCommand, ['pm', 'bin', '-g'], { ...installOptions, env: ownership.environment }));
+  if (!bin) return false;
+  try {
+    return await realpath(bin) === ownership.bunGlobalBin;
+  } catch {
+    return false;
+  }
+}
+
+async function main(): Promise<void> {
+  const payloadPath = process.argv[2];
+  if (!payloadPath) process.exitCode = 1;
+  if (!payloadPath) return;
+  let payload: DeferredUpdatePayload | null = null;
+  try {
+    payload = JSON.parse(await readFile(payloadPath, 'utf-8')) as DeferredUpdatePayload;
+    await waitForParent(payload.parentPid);
+    if (!payload.ownership.npmPrefix || !payload.ownership.packageRoot || !payload.ownership.environment || (payload.ownership.manager === 'npm' && !payload.ownership.npmCommand)) throw new Error('Frozen transaction payload is incomplete.');
+    if (!await validateManager(payload.ownership)) throw new Error('Frozen package-manager command, root, or prefix no longer validates.');
+    if (!await validatePackage(payload.ownership)) throw new Error('Frozen installed package/bin validation failed before update.');
+    const result = payload.ownership.manager === 'npm'
+      ? runNpmCommand(payload.ownership.npmCommand!, stableInstallArgs(payload.ownership), { ...installOptions, env: payload.ownership.environment! })
+      : spawnSync(payload.ownership.bunCommand, stableInstallArgs(payload.ownership), { ...installOptions, env: payload.ownership.environment! });
+    if (result.error || result.status !== 0) throw new Error(String(result.stderr || result.error?.message || 'controller install failed'));
+    const cliEntry = await validatePackage(payload.ownership);
+    if (!cliEntry) throw new Error('Installed package/bin validation failed after update.');
+    const setup = spawnSync(process.execPath, [cliEntry, ...payload.setupArgs], {
+      cwd: payload.cwd, env: payload.ownership.environment!, stdio: 'inherit', windowsHide: true,
+    });
+    if (setup.error || setup.status !== 0) throw new Error(setup.error?.message || `setup exited ${setup.status}`);
+  } catch (error) {
+    if (payload) await appendFile(payload.logPath, `[omx] Deferred update failed: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  } finally {
+    await rm(payloadPath, { force: true }).catch(() => undefined);
+  }
+}
+
+void main();

--- a/src/cli/update-worker.ts
+++ b/src/cli/update-worker.ts
@@ -2,7 +2,7 @@ import { appendFile, lstat, readFile, realpath, rm } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { spawnSync, type SpawnSyncOptions } from 'node:child_process';
 import { isAbsolute, join, relative, win32 } from 'node:path';
-import { runNpmCommand, type PackageManagerOwnership } from './package-manager-ownership.js';
+import { isCompletePackageManagerOwnership, runNpmCommand, type PackageManagerOwnership } from './package-manager-ownership.js';
 import { writeUserInstallStamp } from '../scripts/postinstall-advisory.js';
 import { omxUserInstallStampPath } from '../utils/paths.js';
 
@@ -119,7 +119,7 @@ async function main(): Promise<void> {
     const serialized = await readFile(stagedPayload, 'utf-8');
     if (digest(serialized) !== expectedDigest) throw new Error('Frozen transaction payload fingerprint changed before execution.');
     payload = JSON.parse(serialized) as DeferredUpdatePayload;
-    if (!payload.ownership || !payload.ownership.packageRoot || !payload.ownership.environment) throw new Error('Frozen transaction payload is incomplete.');
+    if (!isCompletePackageManagerOwnership(payload.ownership)) throw new Error('Frozen transaction payload is incomplete.');
     await waitForParent(payload.parentPid);
     if (!await validateOwnership(payload.ownership)) throw new Error('Frozen manager, package root, or bin ownership validation failed before update.');
     const result = payload.ownership.manager === 'npm'

--- a/src/cli/update-worker.ts
+++ b/src/cli/update-worker.ts
@@ -1,7 +1,8 @@
 import { appendFile, lstat, readFile, realpath, rm } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { spawnSync, type SpawnSyncOptions } from 'node:child_process';
-import { isAbsolute, join, relative } from 'node:path';
+import { basename, isAbsolute, join, relative } from 'node:path';
+
 import { isCompletePackageManagerOwnership, runNpmCommand, validatePackageManagerOwnership, type PackageManagerOwnership } from './package-manager-ownership.js';
 import { writeUserInstallStamp } from '../scripts/postinstall-advisory.js';
 import { omxUserInstallStampPath } from '../utils/paths.js';
@@ -55,7 +56,7 @@ async function ownerOnlyStage(stage: string): Promise<boolean> {
     const stat = await lstat(stage);
     if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
     // Windows does not expose POSIX mode/uid ownership through Node's stat data.
-    // The per-user temp directory and signed payload protect the Windows stage.
+    // Its per-user temp location is combined with canonical stage and frozen-payload validation.
     return process.platform === 'win32'
       || ((stat.mode & 0o077) === 0 && (typeof process.getuid !== 'function' || stat.uid === process.getuid()));
   } catch { return false; }
@@ -80,7 +81,7 @@ async function main(): Promise<void> {
   const payloadPath = process.argv[2];
   const expectedDigest = process.argv[3];
   let payload: DeferredUpdatePayload | null = null;
-  let stagedPayload: string | null = null;
+
   let stagedDirectory: string | null = null;
   try {
     const expectedWorkerDigest = process.argv[4];
@@ -88,15 +89,20 @@ async function main(): Promise<void> {
     const workerPath = await canonicalRegularFile(process.argv[1] ?? '', await realpath(join(process.argv[1] ?? '', '..')));
     if (!workerPath || digest(await readFile(workerPath, 'utf-8')) !== expectedWorkerDigest) throw new Error('Frozen update worker identity changed before execution.');
     const stage = await realpath(join(payloadPath, '..'));
-    if (!await ownerOnlyStage(stage)) throw new Error('Frozen transaction staging directory is not an owner-only stage.');
-    stagedDirectory = stage;
-    stagedPayload = await canonicalRegularFile(payloadPath, stage);
-    if (!stagedPayload) throw new Error('Frozen transaction payload is not a regular canonical staged file.');
+    if (!await ownerOnlyStage(stage) || !basename(stage).startsWith('omx-update-')) {
+      throw new Error('Frozen transaction staging directory is not an owner-only update stage.');
+    }
+    const stagedPayload = await canonicalRegularFile(payloadPath, stage);
+
+    if (!stagedPayload || stagedPayload !== join(stage, 'transaction.json')) {
+      throw new Error('Frozen transaction payload is not the canonical staged transaction file.');
+    }
     const serialized = await readFile(stagedPayload, 'utf-8');
     if (digest(serialized) !== expectedDigest) throw new Error('Frozen transaction payload fingerprint changed before execution.');
     const parsedPayload: unknown = JSON.parse(serialized);
     if (!isDeferredUpdatePayload(parsedPayload)) throw new Error('Frozen transaction payload is incomplete.');
     payload = parsedPayload;
+    stagedDirectory = stage;
     await waitForParent(payload.parentPid);
     if (!await validatePackageManagerOwnership(payload.ownership)) throw new Error('Frozen manager, package root, or bin ownership validation failed before update.');
     const result = payload.ownership.manager === 'npm'
@@ -113,7 +119,6 @@ async function main(): Promise<void> {
     process.exitCode = 1;
   } finally {
     if (stagedDirectory) await rm(stagedDirectory, { recursive: true, force: true }).catch(() => undefined);
-    else if (stagedPayload) await rm(stagedPayload, { force: true }).catch(() => undefined);
   }
 }
 void main();

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -171,47 +171,6 @@ async function getCurrentVersion(): Promise<string | null> {
   }
 }
 
-function isSpawnErrorCode(error: unknown, codes: string[]): boolean {
-  return Boolean(
-    error &&
-    typeof error === 'object' &&
-    'code' in error &&
-    codes.includes(String((error as NodeJS.ErrnoException).code)),
-  );
-}
-
-function spawnNpmSync(
-  args: string[],
-  options: SpawnSyncOptions,
-  spawnProcess: SpawnSyncLike = spawnSync,
-  platform: NodeJS.Platform = process.platform,
-): ReturnType<SpawnSyncLike> {
-  const result = spawnProcess('npm', args, options);
-  if (platform === 'win32' && isSpawnErrorCode(result.error, ['ENOENT'])) {
-    return spawnProcess('npm.cmd', args, options);
-  }
-  return result;
-}
-
-function runLegacyNpmGlobalUpdate(
-  spawnProcess: SpawnSyncLike,
-  platform: NodeJS.Platform,
-): RunGlobalUpdateResult {
-  const args = ['install', '-g', STABLE_INSTALL_SOURCE];
-  const options: SpawnSyncOptions = {
-    encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 120000, windowsHide: true,
-  };
-  let result = spawnProcess('npm', args, options);
-  if (platform === 'win32' && isSpawnErrorCode(result.error, ['ENOENT'])) {
-    result = spawnProcess('npm.cmd', args, options);
-  }
-  if (platform === 'win32' && isSpawnErrorCode(result.error, ['EINVAL'])) {
-    result = spawnProcess('cmd.exe', ['/d', '/s', '/c', 'npm', ...args], options);
-  }
-  if (result.error) return { ok: false, stderr: result.error.message };
-  if (result.status !== 0) return commandFailure(result.stderr, result.status, 'npm install -g');
-  return { ok: true, stderr: '' };
-}
 
 function stableInstallArgs(ownership: PackageManagerOwnership, installSource: string): string[] {
   return ownership.manager === 'bun'
@@ -237,8 +196,8 @@ function commandFailure(stderr: unknown, status: number | null, label: string): 
 }
 
 function runDevGlobalUpdate(
+  ownership: Extract<PackageManagerOwnership, { manager: 'npm' }>,
   spawnProcess: SpawnSyncLike = spawnSync,
-  platform: NodeJS.Platform = process.platform,
 ): RunGlobalUpdateResult {
   const tempRoot = mkdtempSync(join(tmpdir(), 'omx-dev-update-'));
   const checkoutDir = join(tempRoot, 'checkout');
@@ -277,7 +236,8 @@ function runDevGlobalUpdate(
       ? String(clonedRevision).slice(0, 12)
       : null;
 
-    const installResult = spawnNpmSync(
+    const installResult = runNpmCommand(
+      ownership.npmCommand,
       [
         'install',
         '--global=false',
@@ -293,17 +253,17 @@ function runDevGlobalUpdate(
         stdio: ['ignore', 'pipe', 'pipe'],
         timeout: DEV_UPDATE_TIMEOUT_MS,
         windowsHide: true,
-        env: { ...process.env, npm_config_global: 'false', npm_config_location: 'project' },
+        env: { ...ownership.environment, npm_config_global: 'false', npm_config_location: 'project' },
       },
       spawnProcess,
-      platform,
     );
     if (installResult.error) return { ok: false, stderr: installResult.error.message };
     if (installResult.status !== 0) {
       return commandFailure(installResult.stderr, installResult.status, 'npm install --include=dev');
     }
 
-    const prepackResult = spawnNpmSync(
+    const prepackResult = runNpmCommand(
+      ownership.npmCommand,
       ['run', 'prepack'],
       {
         cwd: checkoutDir,
@@ -311,16 +271,17 @@ function runDevGlobalUpdate(
         stdio: ['ignore', 'pipe', 'pipe'],
         timeout: DEV_UPDATE_TIMEOUT_MS,
         windowsHide: true,
+        env: ownership.environment,
       },
       spawnProcess,
-      platform,
     );
     if (prepackResult.error) return { ok: false, stderr: prepackResult.error.message };
     if (prepackResult.status !== 0) {
       return commandFailure(prepackResult.stderr, prepackResult.status, 'npm run prepack');
     }
 
-    const packResult = spawnNpmSync(
+    const packResult = runNpmCommand(
+      ownership.npmCommand,
       ['pack', '--ignore-scripts', '--json'],
       {
         cwd: checkoutDir,
@@ -328,9 +289,9 @@ function runDevGlobalUpdate(
         stdio: ['ignore', 'pipe', 'pipe'],
         timeout: DEV_UPDATE_TIMEOUT_MS,
         windowsHide: true,
+        env: ownership.environment,
       },
       spawnProcess,
-      platform,
     );
     if (packResult.error) return { ok: false, stderr: packResult.error.message };
     if (packResult.status !== 0) {
@@ -351,16 +312,17 @@ function runDevGlobalUpdate(
       return { ok: false, stderr: 'npm pack did not produce an installable tarball.' };
     }
 
-    const globalInstallResult = spawnNpmSync(
-      ['install', '-g', tarballPath],
+    const globalInstallResult = runNpmCommand(
+      ownership.npmCommand,
+      ['install', '--global', '--ignore-scripts', '--no-audit', '--no-progress', '--prefix', ownership.npmPrefix, tarballPath],
       {
         encoding: 'utf-8',
         stdio: ['ignore', 'pipe', 'pipe'],
         timeout: DEV_UPDATE_TIMEOUT_MS,
         windowsHide: true,
+        env: ownership.environment,
       },
       spawnProcess,
-      platform,
     );
     if (globalInstallResult.error) {
       return { ok: false, stderr: globalInstallResult.error.message };
@@ -383,20 +345,19 @@ function runDevGlobalUpdate(
 export function runGlobalUpdate(
   installSourceOrSpawnProcess: string | SpawnSyncLike = STABLE_INSTALL_SOURCE,
   spawnProcessOrPlatform: SpawnSyncLike | NodeJS.Platform = spawnSync,
-  platform: NodeJS.Platform = process.platform,
+  _platform: NodeJS.Platform = process.platform,
   ownership?: PackageManagerOwnership,
 ): RunGlobalUpdateResult {
-  const legacySpawnFirst = typeof installSourceOrSpawnProcess === 'function';
-  const installSource = legacySpawnFirst ? STABLE_INSTALL_SOURCE : installSourceOrSpawnProcess;
-  const spawnProcess = legacySpawnFirst
-    ? installSourceOrSpawnProcess
-    : typeof spawnProcessOrPlatform === 'function' ? spawnProcessOrPlatform : spawnSync;
-  const resolvedPlatform = typeof spawnProcessOrPlatform === 'string' ? spawnProcessOrPlatform : platform;
-  if (legacySpawnFirst) return runLegacyNpmGlobalUpdate(spawnProcess, resolvedPlatform);
+  if (typeof installSourceOrSpawnProcess === 'function') {
+    return { ok: false, stderr: 'A validated package-manager ownership transaction is required before installing.' };
+  }
+  const installSource = installSourceOrSpawnProcess;
+  const spawnProcess = typeof spawnProcessOrPlatform === 'function' ? spawnProcessOrPlatform : spawnSync;
   if (installSource === DEV_INSTALL_SOURCE) {
-    return ownership?.manager === 'bun'
+    if (!ownership) return { ok: false, stderr: 'A validated package-manager ownership transaction is required before installing.' };
+    return ownership.manager === 'bun'
       ? { ok: false, stderr: 'Bun dev updates are not yet supported' }
-      : runDevGlobalUpdate(spawnProcess, resolvedPlatform);
+      : runDevGlobalUpdate(ownership, spawnProcess);
   }
   if (!ownership) {
     return { ok: false, stderr: 'A validated package-manager ownership transaction is required before installing.' };
@@ -666,32 +627,9 @@ function resolveUpdateCheckBaseline(
   return currentVersion;
 }
 
-export function resolveGlobalInstallRoot(
-  spawnProcess: SpawnSyncLike = spawnSync,
-  platform: NodeJS.Platform = process.platform,
-): string | null {
-  const result = spawnNpmSync(
-    ['root', '-g'],
-    {
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 15000,
-      windowsHide: true,
-    },
-    spawnProcess,
-    platform,
-  );
-
-  if (result.error || result.status !== 0) {
-    return null;
-  }
-
-  const root = String(result.stdout || '').trim();
-  return root === '' ? null : root;
-}
 
 async function getInstalledVersionAfterUpdate(ownership?: PackageManagerOwnership): Promise<string | null> {
-  const globalInstallRoot = ownership?.globalInstallRoot ?? resolveGlobalInstallRoot();
+  const globalInstallRoot = ownership?.globalInstallRoot;
   if (!globalInstallRoot) return null;
   try {
     const content = await readFile(join(globalInstallRoot, PACKAGE_NAME, 'package.json'), 'utf-8');
@@ -703,7 +641,7 @@ async function getInstalledVersionAfterUpdate(ownership?: PackageManagerOwnershi
 }
 
 async function getInstalledRevisionAfterUpdate(ownership?: PackageManagerOwnership): Promise<string | null> {
-  const globalInstallRoot = ownership?.globalInstallRoot ?? resolveGlobalInstallRoot();
+  const globalInstallRoot = ownership?.globalInstallRoot;
   if (!globalInstallRoot) return null;
   try {
     const content = await readFile(join(globalInstallRoot, PACKAGE_NAME, 'package.json'), 'utf-8');
@@ -805,9 +743,10 @@ async function executeUpdate(
     nowMs = Date.now(),
   } = options;
   const channelConfig = resolveUpdateChannelConfig(channel);
-  const usesNativeTransaction = dependencies.runGlobalUpdate === defaultUpdateDependencies.runGlobalUpdate
-    && dependencies.runDeferredGlobalUpdate === defaultUpdateDependencies.runDeferredGlobalUpdate
-    && dependencies.runSetupRefresh === defaultUpdateDependencies.runSetupRefresh;
+  const usesNativeTransaction = immediate
+    ? dependencies.runGlobalUpdate === defaultUpdateDependencies.runGlobalUpdate
+      || dependencies.runSetupRefresh === defaultUpdateDependencies.runSetupRefresh
+    : dependencies.runDeferredGlobalUpdate === defaultUpdateDependencies.runDeferredGlobalUpdate;
   const ownership = usesNativeTransaction
     ? await dependencies.resolvePackageManagerOwnership()
     : null;

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -362,7 +362,7 @@ export function runGlobalUpdate(
   if (!ownership) {
     return { ok: false, stderr: 'A validated package-manager ownership transaction is required before installing.' };
   }
-  if (!ownership.npmPrefix || !ownership.packageRoot || !ownership.environment || (ownership.manager === 'npm' && !ownership.npmCommand)) {
+  if (!ownership.npmPrefix || !ownership.packageRoot || !ownership.environment || (ownership.manager === 'npm' && !ownership.npmCommand) || (ownership.manager === 'bun' && (!ownership.bunInstallRoot || ownership.environment.BUN_INSTALL !== ownership.bunInstallRoot))) {
     return { ok: false, stderr: 'The package-manager ownership transaction is incomplete.' };
   }
   const result = ownership.manager === 'bun'
@@ -448,7 +448,7 @@ export function runDeferredGlobalUpdate(
   ownership?: PackageManagerOwnership,
 ): RunDeferredUpdateResult {
   const logPath = join(cwd, '.omx', 'logs', formatUpdateLogPath());
-  if (!ownership || !ownership.npmPrefix || !ownership.packageRoot || !ownership.environment || (ownership.manager === 'npm' && !ownership.npmCommand)) {
+  if (!ownership || !ownership.npmPrefix || !ownership.packageRoot || !ownership.environment || (ownership.manager === 'npm' && !ownership.npmCommand) || (ownership.manager === 'bun' && (!ownership.bunInstallRoot || ownership.environment.BUN_INSTALL !== ownership.bunInstallRoot))) {
     return { ok: false, stderr: 'The package-manager ownership transaction is incomplete.', logPath };
   }
   try {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -24,6 +24,7 @@ import {
   packageManagerOwnershipError,
   resolvePackageManagerOwnership,
   runNpmCommand,
+  validatePackageManagerOwnership,
   type PackageManagerOwnership,
 } from './package-manager-ownership.js';
 import {
@@ -448,9 +449,10 @@ export function runDeferredGlobalUpdate(
   if (!isCompletePackageManagerOwnership(ownership)) {
     return { ok: false, stderr: 'The package-manager ownership transaction is incomplete.', logPath };
   }
+  let stage: string | undefined;
   try {
     mkdirSync(dirname(logPath), { recursive: true });
-    const stage = mkdtempSync(join(tmpdir(), 'omx-update-'));
+    stage = mkdtempSync(join(tmpdir(), 'omx-update-'));
     if (platform !== 'win32') chmodSync(stage, 0o700);
     const payloadPath = join(stage, 'transaction.json');
     const payload: DeferredUpdatePayload = { cwd, logPath, parentPid, ownership, setupArgs: resolveSetupRefreshArgs(cwd) };
@@ -458,14 +460,24 @@ export function runDeferredGlobalUpdate(
     writeFileSync(payloadPath, serialized, { encoding: 'utf-8', mode: 0o600, flag: 'wx' });
     const canonicalStage = realpathSync(stage);
     const canonicalPayload = realpathSync(payloadPath);
+    const stageStat = lstatSync(stage);
     const payloadStat = lstatSync(payloadPath);
-    if (canonicalPayload !== join(canonicalStage, 'transaction.json') || payloadStat.isSymbolicLink() || !payloadStat.isFile() || (platform !== 'win32' && (payloadStat.mode & 0o077) !== 0)) throw new Error('Deferred update payload is not a canonical owner-only staged file.');
+    if (
+      !stageStat.isDirectory()
+      || stageStat.isSymbolicLink()
+      || (platform !== 'win32' && ((stageStat.mode & 0o077) !== 0 || (typeof process.getuid === 'function' && stageStat.uid !== process.getuid())))
+      || canonicalPayload !== join(canonicalStage, 'transaction.json')
+      || payloadStat.isSymbolicLink()
+      || !payloadStat.isFile()
+      || (platform !== 'win32' && (payloadStat.mode & 0o077) !== 0)
+    ) throw new Error('Deferred update payload is not a canonical owner-only staged file.');
     const bundledWorker = join(dirname(fileURLToPath(import.meta.url)), 'update-worker.js');
     const workerCandidate = existsSync(bundledWorker) ? bundledWorker : join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'dist', 'cli', 'update-worker.js');
     const workerPath = realpathSync(workerCandidate);
     if (lstatSync(workerCandidate).isSymbolicLink() || !lstatSync(workerPath).isFile()) throw new Error('Deferred update worker is not a regular canonical file.');
     const payloadFingerprint = createHash('sha256').update(readFileSync(canonicalPayload)).digest('hex');
     const workerFingerprint = createHash('sha256').update(readFileSync(workerPath)).digest('hex');
+    const stagedDirectory = stage;
     const child = spawnProcess(process.execPath, [workerPath, payloadPath, payloadFingerprint, workerFingerprint], {
       cwd, detached: true, env: { ...ownership.environment, [SKIP_NATIVE_AGENT_REFRESH_ENV]: '1' }, stdio: 'ignore', windowsHide: true,
     });
@@ -475,10 +487,23 @@ export function runDeferredGlobalUpdate(
       } catch {
         // The scheduler must not become fatal when diagnostics cannot be persisted.
       }
+      try {
+        rmSync(stagedDirectory, { recursive: true, force: true });
+      } catch {
+        // The asynchronous launcher failure must not throw into the caller.
+      }
     });
     child.unref();
+    stage = undefined;
     return { ok: true, stderr: '', logPath };
   } catch (error) {
+    if (stage) {
+      try {
+        rmSync(stage, { recursive: true, force: true });
+      } catch {
+        // Preserve the original scheduling failure when cleanup cannot complete.
+      }
+    }
     return { ok: false, stderr: error instanceof Error ? error.message : String(error), logPath };
   }
 }
@@ -713,9 +738,9 @@ export function spawnInstalledSetupRefresh(
 
 async function runSetupRefresh(cwd: string, ownership?: PackageManagerOwnership): Promise<RunSetupRefreshResult> {
   if (!ownership || !ownership.packageRoot) return { ok: false, stderr: 'A frozen package-manager ownership transaction is required for setup refresh.' };
-  const cliEntry = await resolveInstalledCliEntry(ownership.globalInstallRoot);
+  const cliEntry = await validatePackageManagerOwnership(ownership);
   if (!cliEntry) {
-    return { ok: false, stderr: `Unable to validate the updated OMX CLI entry under ${join(ownership.globalInstallRoot, PACKAGE_NAME)}.` };
+    return { ok: false, stderr: `Frozen manager, package root, or bin ownership validation failed before setup refresh under ${join(ownership.globalInstallRoot, PACKAGE_NAME)}.` };
   }
   return spawnInstalledSetupRefresh(
     cliEntry,

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -440,7 +440,7 @@ interface DeferredUpdatePayload {
 export function runDeferredGlobalUpdate(
   cwd: string,
   spawnProcess: SpawnLike = spawn,
-  _platform: NodeJS.Platform = process.platform,
+  platform: NodeJS.Platform = process.platform,
   parentPid = process.pid,
   ownership?: PackageManagerOwnership,
 ): RunDeferredUpdateResult {
@@ -451,7 +451,7 @@ export function runDeferredGlobalUpdate(
   try {
     mkdirSync(dirname(logPath), { recursive: true });
     const stage = mkdtempSync(join(tmpdir(), 'omx-update-'));
-    chmodSync(stage, 0o700);
+    if (platform !== 'win32') chmodSync(stage, 0o700);
     const payloadPath = join(stage, 'transaction.json');
     const payload: DeferredUpdatePayload = { cwd, logPath, parentPid, ownership, setupArgs: resolveSetupRefreshArgs(cwd) };
     const serialized = JSON.stringify(payload);
@@ -459,7 +459,7 @@ export function runDeferredGlobalUpdate(
     const canonicalStage = realpathSync(stage);
     const canonicalPayload = realpathSync(payloadPath);
     const payloadStat = lstatSync(payloadPath);
-    if (canonicalPayload !== join(canonicalStage, 'transaction.json') || payloadStat.isSymbolicLink() || !payloadStat.isFile() || (payloadStat.mode & 0o077) !== 0) throw new Error('Deferred update payload is not a canonical owner-only staged file.');
+    if (canonicalPayload !== join(canonicalStage, 'transaction.json') || payloadStat.isSymbolicLink() || !payloadStat.isFile() || (platform !== 'win32' && (payloadStat.mode & 0o077) !== 0)) throw new Error('Deferred update payload is not a canonical owner-only staged file.');
     const bundledWorker = join(dirname(fileURLToPath(import.meta.url)), 'update-worker.js');
     const workerCandidate = existsSync(bundledWorker) ? bundledWorker : join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'dist', 'cli', 'update-worker.js');
     const workerPath = realpathSync(workerCandidate);

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -6,11 +6,12 @@
  * launch-time cadence so a user request always checks npm immediately.
  */
 
-import { readFile, writeFile, mkdir } from 'fs/promises';
-import { appendFileSync, existsSync, mkdirSync, mkdtempSync, rmSync } from 'fs';
-import { dirname, join } from 'path';
+import { readFile, writeFile, mkdir, realpath } from 'fs/promises';
+import { appendFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { dirname, join, relative, isAbsolute } from 'path';
 import { tmpdir } from 'os';
 import { spawn, spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
 import { createInterface } from 'readline/promises';
 import { getPackageRoot } from '../utils/package.js';
 import {
@@ -20,6 +21,7 @@ import {
 import {
   packageManagerOwnershipError,
   resolvePackageManagerOwnership,
+  runNpmCommand,
   type PackageManagerOwnership,
 } from './package-manager-ownership.js';
 import {
@@ -190,28 +192,37 @@ function spawnNpmSync(
   return result;
 }
 
-function spawnGlobalNpmInstallSync(
+function runLegacyNpmGlobalUpdate(
+  spawnProcess: SpawnSyncLike,
+  platform: NodeJS.Platform,
+): RunGlobalUpdateResult {
+  const args = ['install', '-g', STABLE_INSTALL_SOURCE];
+  const options: SpawnSyncOptions = {
+    encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 120000, windowsHide: true,
+  };
+  let result = spawnProcess('npm', args, options);
+  if (platform === 'win32' && isSpawnErrorCode(result.error, ['ENOENT'])) {
+    result = spawnProcess('npm.cmd', args, options);
+  }
+  if (platform === 'win32' && isSpawnErrorCode(result.error, ['EINVAL'])) {
+    result = spawnProcess('cmd.exe', ['/d', '/s', '/c', 'npm', ...args], options);
+  }
+  if (result.error) return { ok: false, stderr: result.error.message };
+  if (result.status !== 0) return commandFailure(result.stderr, result.status, 'npm install -g');
+  return { ok: true, stderr: '' };
+}
+
+function stableInstallArgs(ownership: PackageManagerOwnership, installSource: string): string[] {
+  return ['install', '--global', '--ignore-scripts', '--no-audit', '--no-progress', '--prefix', ownership.npmPrefix!, installSource];
+}
+
+function runFrozenNpmInstall(
+  ownership: Extract<PackageManagerOwnership, { manager: 'npm' }>,
   installSource: string,
   options: SpawnSyncOptions,
-  spawnProcess: SpawnSyncLike = spawnSync,
-  platform: NodeJS.Platform = process.platform,
+  spawnProcess: SpawnSyncLike,
 ): ReturnType<SpawnSyncLike> {
-  const args = ['install', '-g', installSource];
-  const result = spawnProcess('npm', args, options);
-  if (platform !== 'win32' || !isSpawnErrorCode(result.error, ['ENOENT', 'EINVAL'])) {
-    return result;
-  }
-
-  if (isSpawnErrorCode(result.error, ['ENOENT'])) {
-    const cmdShimResult = spawnProcess('npm.cmd', args, options);
-    if (!isSpawnErrorCode(cmdShimResult.error, ['ENOENT', 'EINVAL'])) {
-      return cmdShimResult;
-    }
-  }
-
-  // Some Windows/npm shim layouts reject direct npm/npm.cmd spawn with EINVAL;
-  // cmd.exe can still resolve and run npm from the user's configured PATH.
-  return spawnProcess('cmd.exe', ['/d', '/s', '/c', 'npm', ...args], options);
+  return runNpmCommand(ownership.npmCommand!, stableInstallArgs(ownership, installSource), options, spawnProcess);
 }
 
 function commandFailure(stderr: unknown, status: number | null, label: string): RunGlobalUpdateResult {
@@ -377,24 +388,29 @@ export function runGlobalUpdate(
   const spawnProcess = legacySpawnFirst
     ? installSourceOrSpawnProcess
     : typeof spawnProcessOrPlatform === 'function' ? spawnProcessOrPlatform : spawnSync;
-  const resolvedPlatform = legacySpawnFirst
-    ? typeof spawnProcessOrPlatform === 'string' ? spawnProcessOrPlatform : platform
-    : typeof spawnProcessOrPlatform === 'string' ? spawnProcessOrPlatform : platform;
+  const resolvedPlatform = typeof spawnProcessOrPlatform === 'string' ? spawnProcessOrPlatform : platform;
+  if (legacySpawnFirst) return runLegacyNpmGlobalUpdate(spawnProcess, resolvedPlatform);
   if (installSource === DEV_INSTALL_SOURCE) {
     return ownership?.manager === 'bun'
       ? { ok: false, stderr: 'Bun dev updates are not yet supported' }
       : runDevGlobalUpdate(spawnProcess, resolvedPlatform);
   }
-  const result = ownership?.manager === 'bun'
-    ? spawnProcess(ownership.bunCommand, ['add', '-g', installSource], {
-      encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 120000, windowsHide: true,
+  if (!ownership) {
+    return { ok: false, stderr: 'A validated package-manager ownership transaction is required before installing.' };
+  }
+  if (!ownership.npmPrefix || !ownership.packageRoot || !ownership.environment || (ownership.manager === 'npm' && !ownership.npmCommand)) {
+    return { ok: false, stderr: 'The package-manager ownership transaction is incomplete.' };
+  }
+  const result = ownership.manager === 'bun'
+    ? spawnProcess(ownership.bunCommand, stableInstallArgs(ownership, installSource), {
+      encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 120000, windowsHide: true, env: ownership.environment!,
     })
-    : spawnGlobalNpmInstallSync(installSource, {
-      encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 120000, windowsHide: true,
-    }, spawnProcess, resolvedPlatform);
+    : runFrozenNpmInstall(ownership, installSource, {
+      encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 120000, windowsHide: true, env: ownership.environment!,
+    }, spawnProcess);
   if (result.error) return { ok: false, stderr: result.error.message };
   if (result.status !== 0) {
-    return { ok: false, stderr: String(result.stderr || '').trim() || `${ownership?.manager === 'bun' ? 'bun' : 'npm'} exited ${result.status}` };
+    return { ok: false, stderr: String(result.stderr || '').trim() || `${ownership.manager} exited ${result.status}` };
   }
   return { ok: true, stderr: '' };
 }
@@ -429,112 +445,68 @@ export function resolveSetupRefreshArgs(cwd: string): string[] {
 }
 
 function quotePosixShellArg(value: string): string {
-  if (value === '') return "''";
-  return `'${value.replace(/'/g, "'\\''")}'`;
+  return value === '' ? "''" : `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 function quotePowerShellArg(value: string): string {
-  return `'${value.replace(/'/g, `''`)}'`;
+  return `'${value.replace(/'/g, "''")}'`;
 }
 
+/** Compatibility formatter retained for existing callers; deferred updates use update-worker instead. */
 export function formatDeferredSetupCommand(
   platform: NodeJS.Platform,
   command: string,
   args: string[],
 ): string {
   const argv = [command, ...args];
-  if (platform === 'win32') {
-    return `& ${argv.map(quotePowerShellArg).join(' ')}`;
-  }
-  return argv.map(quotePosixShellArg).join(' ');
+  return platform === 'win32'
+    ? `& ${argv.map(quotePowerShellArg).join(' ')}`
+    : argv.map(quotePosixShellArg).join(' ');
 }
 
 function formatUpdateLogPath(date = new Date()): string {
   return `update-${date.toISOString().replace(/[:.]/g, '-')}.log`;
 }
 
+interface DeferredUpdatePayload {
+  cwd: string;
+  logPath: string;
+  parentPid: number;
+  ownership: PackageManagerOwnership;
+  setupArgs: string[];
+}
+
 export function runDeferredGlobalUpdate(
   cwd: string,
   spawnProcess: SpawnLike = spawn,
-  platform: NodeJS.Platform = process.platform,
+  _platform: NodeJS.Platform = process.platform,
   parentPid = process.pid,
   ownership?: PackageManagerOwnership,
 ): RunDeferredUpdateResult {
   const logPath = join(cwd, '.omx', 'logs', formatUpdateLogPath());
-  // Snapshot the current setup delivery mode when the update is scheduled.
-  // The detached process runs after this CLI exits, so the refresh should replay
-  // the setup mode that was active when the user accepted/scheduled the update.
-  const setupArgs = resolveSetupRefreshArgs(cwd);
-  const setupCommand = ownership?.manager === 'bun'
-    ? formatDeferredSetupCommand(platform, ownership.bunCommand, [join(ownership.packageRoot, 'dist', 'cli', 'omx.js'), ...setupArgs])
-    : ownership
-      ? formatDeferredSetupCommand(platform, process.execPath, [join(ownership.globalInstallRoot, PACKAGE_NAME, 'dist', 'cli', 'omx.js'), ...setupArgs])
-      : formatDeferredSetupCommand(platform, 'omx', setupArgs);
-
+  if (!ownership || !ownership.npmPrefix || !ownership.packageRoot || !ownership.environment || (ownership.manager === 'npm' && !ownership.npmCommand)) {
+    return { ok: false, stderr: 'The package-manager ownership transaction is incomplete.', logPath };
+  }
   try {
     mkdirSync(dirname(logPath), { recursive: true });
-
-    const installCommand = ownership?.manager === 'bun'
-      ? formatDeferredSetupCommand(platform, ownership.bunCommand, ['add', '-g', `${PACKAGE_NAME}@latest`])
-      : `npm install -g ${PACKAGE_NAME}@latest`;
-    const env = {
-      ...process.env,
-      OMX_DEFERRED_UPDATE_LOG: logPath,
-      OMX_DEFERRED_UPDATE_PARENT_PID: String(parentPid),
-      [SKIP_NATIVE_AGENT_REFRESH_ENV]: '1',
-    };
-
-    const command = platform === 'win32' ? 'powershell.exe' : 'sh';
-    const args = platform === 'win32'
-      ? [
-          '-NoProfile',
-          '-ExecutionPolicy',
-          'Bypass',
-          '-Command',
-          [
-            '$ErrorActionPreference = "Continue"',
-            '$log = $env:OMX_DEFERRED_UPDATE_LOG',
-            '$parentPid = [int]$env:OMX_DEFERRED_UPDATE_PARENT_PID',
-            'while (Get-Process -Id $parentPid -ErrorAction SilentlyContinue) { Start-Sleep -Seconds 1 }',
-            `${installCommand} *>> $log`,
-            `if ($LASTEXITCODE -eq 0) { ${setupCommand} *>> $log }`,
-          ].join('; '),
-        ]
-      : [
-          '-c',
-          [
-            'while kill -0 "$OMX_DEFERRED_UPDATE_PARENT_PID" 2>/dev/null; do sleep 1; done',
-            `${installCommand} >> "$OMX_DEFERRED_UPDATE_LOG" 2>&1`,
-            `if [ "$?" -eq 0 ]; then ${setupCommand} >> "$OMX_DEFERRED_UPDATE_LOG" 2>&1; fi`,
-          ].join('; '),
-        ];
-
-    const child = spawnProcess(command, args, {
-      cwd,
-      detached: true,
-      env,
-      stdio: 'ignore',
-      windowsHide: true,
+    const payloadPath = join(dirname(logPath), `${formatUpdateLogPath()}.payload.json`);
+    const payload: DeferredUpdatePayload = { cwd, logPath, parentPid, ownership, setupArgs: resolveSetupRefreshArgs(cwd) };
+    writeFileSync(payloadPath, JSON.stringify(payload), { encoding: 'utf-8', mode: 0o600 });
+    const workerPath = join(dirname(fileURLToPath(import.meta.url)), 'update-worker.js');
+    const child = spawnProcess(process.execPath, [workerPath, payloadPath], {
+      cwd, detached: true, env: { ...ownership.environment!, [SKIP_NATIVE_AGENT_REFRESH_ENV]: '1' }, stdio: 'ignore', windowsHide: true,
     });
     child.once('error', (error) => {
       try {
-        appendFileSync(
-          logPath,
-          `[omx] Deferred update launcher failed: ${error.message}\n`,
-          'utf-8',
-        );
+        appendFileSync(logPath, `[omx] Deferred update launcher failed: ${error.message}\n`, 'utf-8');
       } catch {
-        // The startup path must remain non-fatal even when diagnostics cannot be persisted.
+        // The scheduler must not become fatal when diagnostics cannot be persisted.
       }
     });
     child.unref();
     return { ok: true, stderr: '', logPath };
   } catch (error) {
-    return {
-      ok: false,
-      stderr: error instanceof Error ? error.message : String(error),
-      logPath,
-    };
+    return { ok: false, stderr: error instanceof Error ? error.message : String(error), logPath };
   }
 }
 
@@ -728,30 +700,37 @@ async function getInstalledRevisionAfterUpdate(ownership?: PackageManagerOwnersh
   }
 }
 
+async function resolveCliEntryWithinPackage(packageRoot: string, relativePath: string): Promise<string | null> {
+  if (relativePath.trim() === '' || isAbsolute(relativePath)) return null;
+  try {
+    const cliEntry = await realpath(join(packageRoot, relativePath));
+    const relation = relative(packageRoot, cliEntry);
+    return relation !== '' && !relation.startsWith('..') && !isAbsolute(relation) ? cliEntry : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function resolveInstalledCliEntry(globalInstallRoot: string): Promise<string | null> {
   const packageRoot = join(globalInstallRoot, PACKAGE_NAME);
-  const packageJsonPath = join(packageRoot, 'package.json');
-  let cliRelativePath = join('dist', 'cli', 'omx.js');
-
+  let packageRootRealpath: string;
   try {
-    const content = await readFile(packageJsonPath, 'utf-8');
-    const pkg = JSON.parse(content) as PackageManifest;
-    if (typeof pkg.bin === 'string' && pkg.bin.trim() !== '') {
-      cliRelativePath = pkg.bin;
-    } else if (
-      pkg.bin &&
-      typeof pkg.bin === 'object' &&
-      typeof pkg.bin.omx === 'string' &&
-      pkg.bin.omx.trim() !== ''
-    ) {
-      cliRelativePath = pkg.bin.omx;
-    }
+    packageRootRealpath = await realpath(packageRoot);
   } catch {
-    // Fall back to the published contract used in package.json today.
+    return null;
   }
-
-  const cliEntry = join(packageRoot, cliRelativePath);
-  return existsSync(cliEntry) ? cliEntry : null;
+  try {
+    const content = await readFile(join(packageRootRealpath, 'package.json'), 'utf-8');
+    const pkg = JSON.parse(content) as PackageManifest;
+    const cliRelativePath = typeof pkg.bin === 'string'
+      ? pkg.bin
+      : pkg.bin && typeof pkg.bin === 'object' ? pkg.bin.omx : undefined;
+    return typeof cliRelativePath === 'string'
+      ? resolveCliEntryWithinPackage(packageRootRealpath, cliRelativePath)
+      : null;
+  } catch {
+    return resolveCliEntryWithinPackage(packageRootRealpath, join('dist', 'cli', 'omx.js'));
+  }
 }
 
 export function spawnInstalledSetupRefresh(
@@ -782,23 +761,12 @@ export function spawnInstalledSetupRefresh(
 }
 
 async function runSetupRefresh(cwd: string, ownership?: PackageManagerOwnership): Promise<RunSetupRefreshResult> {
-  const globalInstallRoot = ownership?.globalInstallRoot ?? resolveGlobalInstallRoot();
-  if (!globalInstallRoot) {
-    return {
-      ok: false,
-      stderr: `Unable to resolve the ${ownership?.manager ?? 'npm'} global install root after updating.`,
-    };
-  }
-
-  const cliEntry = await resolveInstalledCliEntry(globalInstallRoot);
+  if (!ownership || !ownership.packageRoot) return { ok: false, stderr: 'A frozen package-manager ownership transaction is required for setup refresh.' };
+  const cliEntry = await resolveInstalledCliEntry(ownership.globalInstallRoot);
   if (!cliEntry) {
-    return {
-      ok: false,
-      stderr: `Unable to find the updated OMX CLI entry under ${join(globalInstallRoot, PACKAGE_NAME)}.`,
-    };
+    return { ok: false, stderr: `Unable to validate the updated OMX CLI entry under ${join(ownership.globalInstallRoot, PACKAGE_NAME)}.` };
   }
-
-  return spawnInstalledSetupRefresh(cliEntry, cwd, spawnSync, ownership?.manager === 'bun' ? ownership.bunCommand : process.execPath);
+  return spawnInstalledSetupRefresh(cliEntry, cwd, spawnSync, process.execPath);
 }
 
 async function executeUpdate(

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -13,26 +13,32 @@ import { tmpdir } from 'os';
 import { spawn, spawnSync } from 'child_process';
 import { createInterface } from 'readline/promises';
 import { getPackageRoot } from '../utils/package.js';
-import { omxUserInstallStampPath } from '../utils/paths.js';
 import {
   readPersistedSetupPreferencesSync,
   resolvePersistedSetupMergeAgents,
 } from './setup-preferences.js';
+import {
+  packageManagerOwnershipError,
+  resolvePackageManagerOwnership,
+  type PackageManagerOwnership,
+} from './package-manager-ownership.js';
+import {
+  readUserInstallStamp,
+  writeUserInstallStamp,
+  type UserInstallStamp,
+} from '../scripts/postinstall-advisory.js';
+export {
+  isInstallVersionBump,
+  readUserInstallStamp,
+  writeUserInstallStamp,
+} from '../scripts/postinstall-advisory.js';
+export type { UserInstallStamp } from '../scripts/postinstall-advisory.js';
 
 export interface UpdateState {
   last_checked_at: string;
   last_seen_latest?: string;
 }
 
-export interface UserInstallStamp {
-  installed_version: string;
-  setup_completed_version?: string;
-  install_channel?: UpdateChannel;
-  install_source?: string;
-  install_revision?: string;
-  dev_base_version?: string;
-  updated_at: string;
-}
 
 interface LatestPackageInfo {
   version?: string;
@@ -364,43 +370,31 @@ export function runGlobalUpdate(
   installSourceOrSpawnProcess: string | SpawnSyncLike = STABLE_INSTALL_SOURCE,
   spawnProcessOrPlatform: SpawnSyncLike | NodeJS.Platform = spawnSync,
   platform: NodeJS.Platform = process.platform,
+  ownership?: PackageManagerOwnership,
 ): RunGlobalUpdateResult {
   const legacySpawnFirst = typeof installSourceOrSpawnProcess === 'function';
   const installSource = legacySpawnFirst ? STABLE_INSTALL_SOURCE : installSourceOrSpawnProcess;
   const spawnProcess = legacySpawnFirst
     ? installSourceOrSpawnProcess
-    : typeof spawnProcessOrPlatform === 'function'
-      ? spawnProcessOrPlatform
-      : spawnSync;
+    : typeof spawnProcessOrPlatform === 'function' ? spawnProcessOrPlatform : spawnSync;
   const resolvedPlatform = legacySpawnFirst
-    ? typeof spawnProcessOrPlatform === 'string'
-      ? spawnProcessOrPlatform
-      : platform
-    : typeof spawnProcessOrPlatform === 'string'
-      ? spawnProcessOrPlatform
-      : platform;
-
+    ? typeof spawnProcessOrPlatform === 'string' ? spawnProcessOrPlatform : platform
+    : typeof spawnProcessOrPlatform === 'string' ? spawnProcessOrPlatform : platform;
   if (installSource === DEV_INSTALL_SOURCE) {
-    return runDevGlobalUpdate(spawnProcess, resolvedPlatform);
+    return ownership?.manager === 'bun'
+      ? { ok: false, stderr: 'Bun dev updates are not yet supported' }
+      : runDevGlobalUpdate(spawnProcess, resolvedPlatform);
   }
-
-  const result = spawnGlobalNpmInstallSync(
-    installSource,
-    {
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 120000,
-      windowsHide: true,
-    },
-    spawnProcess,
-    resolvedPlatform,
-  );
-
-  if (result.error) {
-    return { ok: false, stderr: result.error.message };
-  }
+  const result = ownership?.manager === 'bun'
+    ? spawnProcess(ownership.bunCommand, ['add', '-g', installSource], {
+      encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 120000, windowsHide: true,
+    })
+    : spawnGlobalNpmInstallSync(installSource, {
+      encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 120000, windowsHide: true,
+    }, spawnProcess, resolvedPlatform);
+  if (result.error) return { ok: false, stderr: result.error.message };
   if (result.status !== 0) {
-    return { ok: false, stderr: String(result.stderr || '').trim() || `npm exited ${result.status}` };
+    return { ok: false, stderr: String(result.stderr || '').trim() || `${ownership?.manager === 'bun' ? 'bun' : 'npm'} exited ${result.status}` };
   }
   return { ok: true, stderr: '' };
 }
@@ -464,17 +458,25 @@ export function runDeferredGlobalUpdate(
   spawnProcess: SpawnLike = spawn,
   platform: NodeJS.Platform = process.platform,
   parentPid = process.pid,
+  ownership?: PackageManagerOwnership,
 ): RunDeferredUpdateResult {
   const logPath = join(cwd, '.omx', 'logs', formatUpdateLogPath());
   // Snapshot the current setup delivery mode when the update is scheduled.
   // The detached process runs after this CLI exits, so the refresh should replay
   // the setup mode that was active when the user accepted/scheduled the update.
   const setupArgs = resolveSetupRefreshArgs(cwd);
-  const setupCommand = formatDeferredSetupCommand(platform, 'omx', setupArgs);
+  const setupCommand = ownership?.manager === 'bun'
+    ? formatDeferredSetupCommand(platform, ownership.bunCommand, [join(ownership.packageRoot, 'dist', 'cli', 'omx.js'), ...setupArgs])
+    : ownership
+      ? formatDeferredSetupCommand(platform, process.execPath, [join(ownership.globalInstallRoot, PACKAGE_NAME, 'dist', 'cli', 'omx.js'), ...setupArgs])
+      : formatDeferredSetupCommand(platform, 'omx', setupArgs);
 
   try {
     mkdirSync(dirname(logPath), { recursive: true });
 
+    const installCommand = ownership?.manager === 'bun'
+      ? formatDeferredSetupCommand(platform, ownership.bunCommand, ['add', '-g', `${PACKAGE_NAME}@latest`])
+      : `npm install -g ${PACKAGE_NAME}@latest`;
     const env = {
       ...process.env,
       OMX_DEFERRED_UPDATE_LOG: logPath,
@@ -494,7 +496,7 @@ export function runDeferredGlobalUpdate(
             '$log = $env:OMX_DEFERRED_UPDATE_LOG',
             '$parentPid = [int]$env:OMX_DEFERRED_UPDATE_PARENT_PID',
             'while (Get-Process -Id $parentPid -ErrorAction SilentlyContinue) { Start-Sleep -Seconds 1 }',
-            'npm install -g oh-my-codex@latest *>> $log',
+            `${installCommand} *>> $log`,
             `if ($LASTEXITCODE -eq 0) { ${setupCommand} *>> $log }`,
           ].join('; '),
         ]
@@ -502,7 +504,7 @@ export function runDeferredGlobalUpdate(
           '-c',
           [
             'while kill -0 "$OMX_DEFERRED_UPDATE_PARENT_PID" 2>/dev/null; do sleep 1; done',
-            'npm install -g oh-my-codex@latest >> "$OMX_DEFERRED_UPDATE_LOG" 2>&1',
+            `${installCommand} >> "$OMX_DEFERRED_UPDATE_LOG" 2>&1`,
             `if [ "$?" -eq 0 ]; then ${setupCommand} >> "$OMX_DEFERRED_UPDATE_LOG" 2>&1; fi`,
           ].join('; '),
         ];
@@ -536,12 +538,16 @@ export function runDeferredGlobalUpdate(
   }
 }
 
-function formatDeferredUpdateFailure(stderr: string, logPath?: string): string {
+function formatDeferredUpdateFailure(
+  stderr: string,
+  logPath?: string,
+  manager: PackageManagerOwnership['manager'] = 'npm',
+): string {
   return [
     '[omx] Failed to schedule the deferred update.',
     stderr.trim() ? `[omx] scheduler error: ${stderr.trim()}` : undefined,
     logPath ? `[omx] Intended log: ${logPath}` : undefined,
-    '[omx] You can retry manually with: npm install -g oh-my-codex@latest && omx setup',
+    `[omx] You can retry manually with: ${manager === 'bun' ? 'bun add -g' : 'npm install -g'} oh-my-codex@latest && omx setup`,
   ].filter((line): line is string => typeof line === 'string').join('\n');
 }
 
@@ -549,6 +555,7 @@ function summarizeUpdateFailure(
   stderr: string,
   installSource = STABLE_INSTALL_SOURCE,
   logPath?: string,
+  manager: PackageManagerOwnership['manager'] = 'npm',
 ): string {
   const details = stderr.trim().split(/\r?\n/).filter(Boolean).slice(0, 3).join(' | ');
   if (installSource === DEV_INSTALL_SOURCE) {
@@ -559,11 +566,12 @@ function summarizeUpdateFailure(
       '[omx] You can retry manually with: omx update --dev',
     ].filter((line): line is string => typeof line === 'string').join('\n');
   }
+  const installCommand = `${manager === 'bun' ? 'bun add -g' : 'npm install -g'} ${installSource}`;
   return [
-    `[omx] Update failed while running npm install -g ${installSource}.`,
-    details ? `[omx] npm stderr: ${details}` : undefined,
+    `[omx] Update failed while running ${installCommand}.`,
+    details ? `[omx] ${manager} stderr: ${details}` : undefined,
     logPath ? `[omx] Full log: ${logPath}` : undefined,
-    `[omx] You can retry manually with: npm install -g ${installSource} && omx setup`,
+    `[omx] You can retry manually with: ${installCommand} && omx setup`,
   ].filter((line): line is string => typeof line === 'string').join('\n');
 }
 
@@ -585,10 +593,18 @@ interface UpdateDependencies {
   getInstalledVersionAfterUpdate: typeof getInstalledVersionAfterUpdate;
   getInstalledRevisionAfterUpdate: typeof getInstalledRevisionAfterUpdate;
   readUserInstallStamp: typeof readUserInstallStamp;
-  runGlobalUpdate: (installSource: string) => RunGlobalUpdateResult;
-  runDeferredGlobalUpdate: typeof runDeferredGlobalUpdate;
-  runSetupRefresh: (cwd: string) => Promise<RunSetupRefreshResult>;
+  resolvePackageManagerOwnership: () => Promise<PackageManagerOwnership | null>;
+  runGlobalUpdate: (installSource: string, ownership?: PackageManagerOwnership) => RunGlobalUpdateResult;
+  runDeferredGlobalUpdate: (cwd: string, ownership?: PackageManagerOwnership) => RunDeferredUpdateResult;
+  runSetupRefresh: (cwd: string, ownership?: PackageManagerOwnership) => Promise<RunSetupRefreshResult>;
   writeUpdateState: typeof writeUpdateState;
+}
+
+async function resolveCurrentPackageManagerOwnership(): Promise<PackageManagerOwnership | null> {
+  return resolvePackageManagerOwnership({
+    currentPackageRoot: getPackageRoot(),
+    readInstallStamp: readUserInstallStamp,
+  });
 }
 
 const defaultUpdateDependencies: UpdateDependencies = {
@@ -598,11 +614,12 @@ const defaultUpdateDependencies: UpdateDependencies = {
   getInstalledVersionAfterUpdate,
   getInstalledRevisionAfterUpdate,
   readUserInstallStamp,
-  runGlobalUpdate,
-  runDeferredGlobalUpdate,
+  resolvePackageManagerOwnership: resolveCurrentPackageManagerOwnership,
+  runGlobalUpdate: (installSource, ownership) => runGlobalUpdate(installSource, spawnSync, process.platform, ownership),
+  runDeferredGlobalUpdate: (cwd, ownership) => runDeferredGlobalUpdate(cwd, spawn, process.platform, process.pid, ownership),
   runSetupRefresh,
   writeUpdateState,
-};
+}
 
 function stripLeadingV(version: string): string {
   return version.trim().replace(/^v/i, '');
@@ -615,6 +632,7 @@ async function writeSuccessfulInstallStamp(
     source?: string;
     revision?: string | null;
     devBaseVersion?: string | null;
+    packageManager?: PackageManagerOwnership['manager'];
   } = {},
 ): Promise<void> {
   await writeUserInstallStamp({
@@ -624,60 +642,11 @@ async function writeSuccessfulInstallStamp(
     ...(metadata.source ? { install_source: metadata.source } : {}),
     ...(metadata.revision ? { install_revision: metadata.revision } : {}),
     ...(metadata.devBaseVersion ? { dev_base_version: stripLeadingV(metadata.devBaseVersion) } : {}),
+    ...(metadata.packageManager ? { package_manager: metadata.packageManager } : {}),
     updated_at: new Date().toISOString(),
   });
 }
 
-export async function readUserInstallStamp(
-  path = omxUserInstallStampPath(),
-): Promise<UserInstallStamp | null> {
-  if (!existsSync(path)) return null;
-  try {
-    const content = await readFile(path, 'utf-8');
-    const parsed = JSON.parse(content) as Partial<UserInstallStamp>;
-    if (typeof parsed.installed_version !== 'string' || typeof parsed.updated_at !== 'string') {
-      return null;
-    }
-    return {
-      installed_version: parsed.installed_version,
-      ...(typeof parsed.setup_completed_version === 'string'
-        ? { setup_completed_version: parsed.setup_completed_version }
-        : {}),
-      ...(parsed.install_channel === 'stable' || parsed.install_channel === 'dev'
-        ? { install_channel: parsed.install_channel }
-        : {}),
-      ...(typeof parsed.install_source === 'string'
-        ? { install_source: parsed.install_source }
-        : {}),
-      ...(typeof parsed.install_revision === 'string'
-        ? { install_revision: parsed.install_revision }
-        : {}),
-      ...(typeof parsed.dev_base_version === 'string'
-        ? { dev_base_version: parsed.dev_base_version }
-        : {}),
-      updated_at: parsed.updated_at,
-    };
-  } catch {
-    return null;
-  }
-}
-
-export async function writeUserInstallStamp(
-  stamp: UserInstallStamp,
-  path = omxUserInstallStampPath(),
-): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(stamp, null, 2));
-}
-
-export function isInstallVersionBump(
-  currentVersion: string | null | undefined,
-  stamp: UserInstallStamp | null,
-): boolean {
-  if (!currentVersion) return false;
-  if (!stamp?.installed_version) return true;
-  return stripLeadingV(currentVersion) !== stripLeadingV(stamp.installed_version);
-}
 
 function doesSetupStampMatchVersion(
   currentVersion: string,
@@ -734,29 +703,23 @@ export function resolveGlobalInstallRoot(
   return root === '' ? null : root;
 }
 
-async function getInstalledVersionAfterUpdate(): Promise<string | null> {
-  const globalInstallRoot = resolveGlobalInstallRoot();
+async function getInstalledVersionAfterUpdate(ownership?: PackageManagerOwnership): Promise<string | null> {
+  const globalInstallRoot = ownership?.globalInstallRoot ?? resolveGlobalInstallRoot();
   if (!globalInstallRoot) return null;
-
   try {
-    const packageJsonPath = join(globalInstallRoot, PACKAGE_NAME, 'package.json');
-    const content = await readFile(packageJsonPath, 'utf-8');
+    const content = await readFile(join(globalInstallRoot, PACKAGE_NAME, 'package.json'), 'utf-8');
     const pkg = JSON.parse(content) as PackageManifest;
-    return typeof pkg.version === 'string' && pkg.version.trim() !== ''
-      ? pkg.version
-      : null;
+    return typeof pkg.version === 'string' && pkg.version.trim() !== '' ? pkg.version : null;
   } catch {
     return null;
   }
 }
 
-async function getInstalledRevisionAfterUpdate(): Promise<string | null> {
-  const globalInstallRoot = resolveGlobalInstallRoot();
+async function getInstalledRevisionAfterUpdate(ownership?: PackageManagerOwnership): Promise<string | null> {
+  const globalInstallRoot = ownership?.globalInstallRoot ?? resolveGlobalInstallRoot();
   if (!globalInstallRoot) return null;
-
   try {
-    const packageJsonPath = join(globalInstallRoot, PACKAGE_NAME, 'package.json');
-    const content = await readFile(packageJsonPath, 'utf-8');
+    const content = await readFile(join(globalInstallRoot, PACKAGE_NAME, 'package.json'), 'utf-8');
     const pkg = JSON.parse(content) as { gitHead?: string };
     const revision = typeof pkg.gitHead === 'string' ? pkg.gitHead.trim() : '';
     return /^[0-9a-f]{7,40}$/i.test(revision) ? revision.slice(0, 12) : null;
@@ -795,8 +758,9 @@ export function spawnInstalledSetupRefresh(
   cliEntry: string,
   cwd: string,
   spawnProcess: SpawnSyncLike = spawnSync,
+  command = process.execPath,
 ): RunSetupRefreshResult {
-  const result = spawnProcess(process.execPath, [cliEntry, ...resolveSetupRefreshArgs(cwd)], {
+  const result = spawnProcess(command, [cliEntry, ...resolveSetupRefreshArgs(cwd)], {
     cwd,
     env: process.env,
     stdio: 'inherit',
@@ -817,12 +781,12 @@ export function spawnInstalledSetupRefresh(
   return { ok: true, stderr: '' };
 }
 
-async function runSetupRefresh(cwd: string): Promise<RunSetupRefreshResult> {
-  const globalInstallRoot = resolveGlobalInstallRoot();
+async function runSetupRefresh(cwd: string, ownership?: PackageManagerOwnership): Promise<RunSetupRefreshResult> {
+  const globalInstallRoot = ownership?.globalInstallRoot ?? resolveGlobalInstallRoot();
   if (!globalInstallRoot) {
     return {
       ok: false,
-      stderr: 'Unable to resolve the npm global install root after updating.',
+      stderr: `Unable to resolve the ${ownership?.manager ?? 'npm'} global install root after updating.`,
     };
   }
 
@@ -834,7 +798,7 @@ async function runSetupRefresh(cwd: string): Promise<RunSetupRefreshResult> {
     };
   }
 
-  return spawnInstalledSetupRefresh(cliEntry, cwd);
+  return spawnInstalledSetupRefresh(cliEntry, cwd, spawnSync, ownership?.manager === 'bun' ? ownership.bunCommand : process.execPath);
 }
 
 async function executeUpdate(
@@ -858,6 +822,20 @@ async function executeUpdate(
     nowMs = Date.now(),
   } = options;
   const channelConfig = resolveUpdateChannelConfig(channel);
+  const usesNativeTransaction = dependencies.runGlobalUpdate === defaultUpdateDependencies.runGlobalUpdate
+    && dependencies.runDeferredGlobalUpdate === defaultUpdateDependencies.runDeferredGlobalUpdate
+    && dependencies.runSetupRefresh === defaultUpdateDependencies.runSetupRefresh;
+  const ownership = usesNativeTransaction
+    ? await dependencies.resolvePackageManagerOwnership()
+    : null;
+  if (usesNativeTransaction && !ownership) {
+    console.log(packageManagerOwnershipError());
+    return { status: 'failed', currentVersion: null, latestVersion: null };
+  }
+  if (ownership?.manager === 'bun' && channel === 'dev') {
+    console.log('[omx] Bun dev updates are not yet supported');
+    return { status: 'failed', currentVersion: null, latestVersion: null };
+  }
   const [current, latest] = await Promise.all([
     dependencies.getCurrentVersion(),
     channel === 'stable' || !forceInstall || channel === 'dev' ? dependencies.fetchLatestVersion() : Promise.resolve(null),
@@ -890,14 +868,14 @@ async function executeUpdate(
         console.log(
           `[omx] oh-my-codex is already up to date (v${updateCheckBaseline}). Running setup refresh...`,
         );
-        const setupRefreshResult = await dependencies.runSetupRefresh(cwd);
+        const setupRefreshResult = await dependencies.runSetupRefresh(cwd, ownership ?? undefined);
         if (!setupRefreshResult.ok) {
           console.log(
             `[omx] Update installed, but the setup refresh failed. Run \`omx setup\` with the new install. (${setupRefreshResult.stderr})`,
           );
           return { status: 'failed', currentVersion: current, latestVersion: latest };
         }
-        await writeSuccessfulInstallStamp(current);
+        await writeSuccessfulInstallStamp(current, { packageManager: ownership?.manager });
         console.log(`[omx] Setup refresh completed for v${updateCheckBaseline}. Restart to use current code.`);
         return { status: 'up-to-date', currentVersion: current, latestVersion: latest };
       }
@@ -921,9 +899,9 @@ async function executeUpdate(
   }
 
   if (!immediate) {
-    const deferredResult = dependencies.runDeferredGlobalUpdate(cwd);
+    const deferredResult = dependencies.runDeferredGlobalUpdate(cwd, ownership ?? undefined);
     if (!deferredResult.ok) {
-      console.log(formatDeferredUpdateFailure(deferredResult.stderr, deferredResult.logPath));
+      console.log(formatDeferredUpdateFailure(deferredResult.stderr, deferredResult.logPath, ownership?.manager));
       return { status: 'failed', currentVersion: current, latestVersion: latest };
     }
     console.log('[omx] Update scheduled after this session exits.');
@@ -938,16 +916,16 @@ async function executeUpdate(
   if (channelConfig.channel === 'dev') {
     console.log('[omx] Running: clone dev branch, run prepack, then npm install -g the packed tarball');
   } else {
-    console.log(`[omx] Running: npm install -g ${channelConfig.installSource}`);
+    console.log(`[omx] Running: ${ownership?.manager === 'bun' ? 'bun add -g' : 'npm install -g'} ${channelConfig.installSource}`);
   }
-  const result = dependencies.runGlobalUpdate(channelConfig.installSource);
+  const result = dependencies.runGlobalUpdate(channelConfig.installSource, ownership ?? undefined);
 
   if (!result.ok) {
-    console.log(summarizeUpdateFailure(result.stderr, channelConfig.installSource));
+    console.log(summarizeUpdateFailure(result.stderr, channelConfig.installSource, undefined, ownership?.manager));
     return { status: 'failed', currentVersion: current, latestVersion: latest };
   }
 
-  const setupRefreshResult = await dependencies.runSetupRefresh(cwd);
+  const setupRefreshResult = await dependencies.runSetupRefresh(cwd, ownership ?? undefined);
   if (!setupRefreshResult.ok) {
     console.log(
       `[omx] Update installed, but the setup refresh failed. Run \`omx setup\` with the new install. (${setupRefreshResult.stderr})`,
@@ -955,9 +933,9 @@ async function executeUpdate(
     return { status: 'failed', currentVersion: current, latestVersion: latest };
   }
 
-  const installedVersion = await dependencies.getInstalledVersionAfterUpdate();
+  const installedVersion = await dependencies.getInstalledVersionAfterUpdate(ownership ?? undefined);
   const installedRevision = channelConfig.channel === 'dev'
-    ? ((await dependencies.getInstalledRevisionAfterUpdate()) ?? result.revision ?? null)
+    ? ((await dependencies.getInstalledRevisionAfterUpdate(ownership ?? undefined)) ?? result.revision ?? null)
     : null;
   const devBaseVersion = channelConfig.channel === 'dev'
     ? (latest && installedVersion
@@ -973,6 +951,7 @@ async function executeUpdate(
       source: channelConfig.installSource,
       revision: channelConfig.channel === 'dev' ? installedRevision : null,
       devBaseVersion,
+      packageManager: ownership?.manager,
     });
   } else if (channelConfig.channel === 'dev') {
     console.log(

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -7,9 +7,10 @@
  */
 
 import { readFile, writeFile, mkdir, realpath } from 'fs/promises';
-import { appendFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { appendFileSync, chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'fs';
 import { dirname, join, relative, isAbsolute } from 'path';
 import { tmpdir } from 'os';
+import { createHash } from 'node:crypto';
 import { spawn, spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { createInterface } from 'readline/promises';
@@ -213,7 +214,9 @@ function runLegacyNpmGlobalUpdate(
 }
 
 function stableInstallArgs(ownership: PackageManagerOwnership, installSource: string): string[] {
-  return ['install', '--global', '--ignore-scripts', '--no-audit', '--no-progress', '--prefix', ownership.npmPrefix!, installSource];
+  return ownership.manager === 'bun'
+    ? ['add', '--global', '--ignore-scripts', installSource]
+    : ['install', '--global', '--ignore-scripts', '--no-audit', '--no-progress', '--prefix', ownership.npmPrefix, installSource];
 }
 
 function runFrozenNpmInstall(
@@ -222,7 +225,7 @@ function runFrozenNpmInstall(
   options: SpawnSyncOptions,
   spawnProcess: SpawnSyncLike,
 ): ReturnType<SpawnSyncLike> {
-  return runNpmCommand(ownership.npmCommand!, stableInstallArgs(ownership, installSource), options, spawnProcess);
+  return runNpmCommand(ownership.npmCommand, stableInstallArgs(ownership, installSource), options, spawnProcess);
 }
 
 function commandFailure(stderr: unknown, status: number | null, label: string): RunGlobalUpdateResult {
@@ -489,12 +492,24 @@ export function runDeferredGlobalUpdate(
   }
   try {
     mkdirSync(dirname(logPath), { recursive: true });
-    const payloadPath = join(dirname(logPath), `${formatUpdateLogPath()}.payload.json`);
+    const stage = mkdtempSync(join(tmpdir(), 'omx-update-'));
+    chmodSync(stage, 0o700);
+    const payloadPath = join(stage, 'transaction.json');
     const payload: DeferredUpdatePayload = { cwd, logPath, parentPid, ownership, setupArgs: resolveSetupRefreshArgs(cwd) };
-    writeFileSync(payloadPath, JSON.stringify(payload), { encoding: 'utf-8', mode: 0o600 });
-    const workerPath = join(dirname(fileURLToPath(import.meta.url)), 'update-worker.js');
-    const child = spawnProcess(process.execPath, [workerPath, payloadPath], {
-      cwd, detached: true, env: { ...ownership.environment!, [SKIP_NATIVE_AGENT_REFRESH_ENV]: '1' }, stdio: 'ignore', windowsHide: true,
+    const serialized = JSON.stringify(payload);
+    writeFileSync(payloadPath, serialized, { encoding: 'utf-8', mode: 0o600, flag: 'wx' });
+    const canonicalStage = realpathSync(stage);
+    const canonicalPayload = realpathSync(payloadPath);
+    const payloadStat = lstatSync(payloadPath);
+    if (canonicalPayload !== join(canonicalStage, 'transaction.json') || payloadStat.isSymbolicLink() || !payloadStat.isFile() || (payloadStat.mode & 0o077) !== 0) throw new Error('Deferred update payload is not a canonical owner-only staged file.');
+    const bundledWorker = join(dirname(fileURLToPath(import.meta.url)), 'update-worker.js');
+    const workerCandidate = existsSync(bundledWorker) ? bundledWorker : join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'dist', 'cli', 'update-worker.js');
+    const workerPath = realpathSync(workerCandidate);
+    if (lstatSync(workerCandidate).isSymbolicLink() || !lstatSync(workerPath).isFile()) throw new Error('Deferred update worker is not a regular canonical file.');
+    const payloadFingerprint = createHash('sha256').update(readFileSync(canonicalPayload)).digest('hex');
+    const workerFingerprint = createHash('sha256').update(readFileSync(workerPath)).digest('hex');
+    const child = spawnProcess(process.execPath, [workerPath, payloadPath, payloadFingerprint, workerFingerprint], {
+      cwd, detached: true, env: { ...ownership.environment, [SKIP_NATIVE_AGENT_REFRESH_ENV]: '1' }, stdio: 'ignore', windowsHide: true,
     });
     child.once('error', (error) => {
       try {
@@ -519,7 +534,7 @@ function formatDeferredUpdateFailure(
     '[omx] Failed to schedule the deferred update.',
     stderr.trim() ? `[omx] scheduler error: ${stderr.trim()}` : undefined,
     logPath ? `[omx] Intended log: ${logPath}` : undefined,
-    `[omx] You can retry manually with: ${manager === 'bun' ? 'bun add -g' : 'npm install -g'} oh-my-codex@latest && omx setup`,
+    `[omx] Retry with the selected ${manager} owner through: omx update`,
   ].filter((line): line is string => typeof line === 'string').join('\n');
 }
 
@@ -540,10 +555,10 @@ function summarizeUpdateFailure(
   }
   const installCommand = `${manager === 'bun' ? 'bun add -g' : 'npm install -g'} ${installSource}`;
   return [
-    `[omx] Update failed while running ${installCommand}.`,
+    `[omx] Update failed while running the selected ${manager} transaction (${installCommand}).`,
     details ? `[omx] ${manager} stderr: ${details}` : undefined,
     logPath ? `[omx] Full log: ${logPath}` : undefined,
-    `[omx] You can retry manually with: ${installCommand} && omx setup`,
+    '[omx] Retry through the ownership-safe recovery command: omx update',
   ].filter((line): line is string => typeof line === 'string').join('\n');
 }
 

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -688,10 +688,11 @@ export function spawnInstalledSetupRefresh(
   cwd: string,
   spawnProcess: SpawnSyncLike = spawnSync,
   command = process.execPath,
+  environment: NodeJS.ProcessEnv = process.env,
 ): RunSetupRefreshResult {
   const result = spawnProcess(command, [cliEntry, ...resolveSetupRefreshArgs(cwd)], {
     cwd,
-    env: process.env,
+    env: environment,
     stdio: 'inherit',
     windowsHide: true,
   });
@@ -716,7 +717,13 @@ async function runSetupRefresh(cwd: string, ownership?: PackageManagerOwnership)
   if (!cliEntry) {
     return { ok: false, stderr: `Unable to validate the updated OMX CLI entry under ${join(ownership.globalInstallRoot, PACKAGE_NAME)}.` };
   }
-  return spawnInstalledSetupRefresh(cliEntry, cwd, spawnSync, process.execPath);
+  return spawnInstalledSetupRefresh(
+    cliEntry,
+    cwd,
+    spawnSync,
+    process.execPath,
+    { ...ownership.environment, [SKIP_NATIVE_AGENT_REFRESH_ENV]: '1' },
+  );
 }
 
 async function executeUpdate(

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -20,6 +20,7 @@ import {
   resolvePersistedSetupMergeAgents,
 } from './setup-preferences.js';
 import {
+  isCompletePackageManagerOwnership,
   packageManagerOwnershipError,
   resolvePackageManagerOwnership,
   runNpmCommand,
@@ -353,17 +354,13 @@ export function runGlobalUpdate(
   }
   const installSource = installSourceOrSpawnProcess;
   const spawnProcess = typeof spawnProcessOrPlatform === 'function' ? spawnProcessOrPlatform : spawnSync;
+  if (!ownership || !isCompletePackageManagerOwnership(ownership)) {
+    return { ok: false, stderr: ownership ? 'The package-manager ownership transaction is incomplete.' : 'A validated package-manager ownership transaction is required before installing.' };
+  }
   if (installSource === DEV_INSTALL_SOURCE) {
-    if (!ownership) return { ok: false, stderr: 'A validated package-manager ownership transaction is required before installing.' };
     return ownership.manager === 'bun'
       ? { ok: false, stderr: 'Bun dev updates are not yet supported' }
       : runDevGlobalUpdate(ownership, spawnProcess);
-  }
-  if (!ownership) {
-    return { ok: false, stderr: 'A validated package-manager ownership transaction is required before installing.' };
-  }
-  if (!ownership.npmPrefix || !ownership.packageRoot || !ownership.environment || (ownership.manager === 'npm' && !ownership.npmCommand) || (ownership.manager === 'bun' && (!ownership.bunInstallRoot || ownership.environment.BUN_INSTALL !== ownership.bunInstallRoot))) {
-    return { ok: false, stderr: 'The package-manager ownership transaction is incomplete.' };
   }
   const result = ownership.manager === 'bun'
     ? spawnProcess(ownership.bunCommand, stableInstallArgs(ownership, installSource), {
@@ -448,7 +445,7 @@ export function runDeferredGlobalUpdate(
   ownership?: PackageManagerOwnership,
 ): RunDeferredUpdateResult {
   const logPath = join(cwd, '.omx', 'logs', formatUpdateLogPath());
-  if (!ownership || !ownership.npmPrefix || !ownership.packageRoot || !ownership.environment || (ownership.manager === 'npm' && !ownership.npmCommand) || (ownership.manager === 'bun' && (!ownership.bunInstallRoot || ownership.environment.BUN_INSTALL !== ownership.bunInstallRoot))) {
+  if (!isCompletePackageManagerOwnership(ownership)) {
     return { ok: false, stderr: 'The package-manager ownership transaction is incomplete.', logPath };
   }
   try {

--- a/src/scripts/__tests__/postinstall.test.ts
+++ b/src/scripts/__tests__/postinstall.test.ts
@@ -24,7 +24,7 @@ describe("isGlobalInstallLifecycle", () => {
 });
 
 describe("runPostinstall", () => {
-  it("records the installed version and prints an explicit opt-in setup hint for bumped global installs", async () => {
+  it("preserves Bun provenance across bumped global installs while printing an explicit opt-in setup hint", async () => {
     const root = await mkdtemp(join(tmpdir(), "omx-postinstall-"));
     const stampPath = join(root, ".codex", ".omx", "install-state.json");
     const logs: string[] = [];
@@ -37,6 +37,7 @@ describe("runPostinstall", () => {
         readStamp: async () => ({
           installed_version: "0.14.0",
           setup_completed_version: "0.14.0",
+          package_manager: "bun",
           updated_at: "2026-04-20T00:00:00.000Z",
         }),
         writeStamp: async (stamp) => writeUserInstallStamp(stamp, stampPath),
@@ -48,9 +49,11 @@ describe("runPostinstall", () => {
       const stamp = JSON.parse(await readFile(stampPath, "utf-8")) as {
         installed_version: string;
         setup_completed_version: string;
+        package_manager?: string;
       };
       assert.equal(stamp.installed_version, "0.14.1");
       assert.equal(stamp.setup_completed_version, "0.14.0");
+      assert.equal(stamp.package_manager, "bun");
     } finally {
       await rm(root, { recursive: true, force: true });
     }
@@ -86,6 +89,25 @@ describe("runPostinstall", () => {
     } finally {
       await rm(root, { recursive: true, force: true });
     }
+  });
+
+  it("does not infer package-manager provenance from a Bun user agent", async () => {
+    let writtenStamp: { package_manager?: "npm" | "bun" } | undefined;
+
+    const result = await runPostinstall({
+      env: {
+        npm_config_global: "true",
+        npm_config_user_agent: "bun/1.2.0 npm/? node/v22.0.0 linux x64",
+      },
+      getCurrentVersion: async () => "0.14.1",
+      readStamp: async () => null,
+      writeStamp: async (stamp) => {
+        writtenStamp = stamp;
+      },
+    });
+
+    assert.equal(result.status, "hinted");
+    assert.equal(writtenStamp?.package_manager, undefined);
   });
 
   it("skips local installs", async () => {

--- a/src/scripts/__tests__/postinstall.test.ts
+++ b/src/scripts/__tests__/postinstall.test.ts
@@ -24,7 +24,7 @@ describe("isGlobalInstallLifecycle", () => {
 });
 
 describe("runPostinstall", () => {
-  it("preserves Bun provenance across bumped global installs while printing an explicit opt-in setup hint", async () => {
+  it("clears stale Bun provenance for a global replacement while printing an explicit opt-in setup hint", async () => {
     const root = await mkdtemp(join(tmpdir(), "omx-postinstall-"));
     const stampPath = join(root, ".codex", ".omx", "install-state.json");
     const logs: string[] = [];
@@ -53,7 +53,7 @@ describe("runPostinstall", () => {
       };
       assert.equal(stamp.installed_version, "0.14.1");
       assert.equal(stamp.setup_completed_version, "0.14.0");
-      assert.equal(stamp.package_manager, "bun");
+      assert.equal(stamp.package_manager, undefined);
     } finally {
       await rm(root, { recursive: true, force: true });
     }
@@ -91,7 +91,7 @@ describe("runPostinstall", () => {
     }
   });
 
-  it("does not infer package-manager provenance from a Bun user agent", async () => {
+  it("does not infer Bun provenance from a Bun user agent", async () => {
     let writtenStamp: { package_manager?: "npm" | "bun" } | undefined;
 
     const result = await runPostinstall({

--- a/src/scripts/postinstall-advisory.ts
+++ b/src/scripts/postinstall-advisory.ts
@@ -1,0 +1,67 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { omxUserInstallStampPath } from '../utils/paths.js';
+
+export interface UserInstallStamp {
+  installed_version: string;
+  setup_completed_version?: string;
+  install_channel?: 'stable' | 'dev';
+  install_source?: string;
+  install_revision?: string;
+  dev_base_version?: string;
+  package_manager?: 'npm' | 'bun';
+  updated_at: string;
+}
+
+function stripLeadingV(version: string): string {
+  return version.trim().replace(/^v/i, '');
+}
+
+export async function readUserInstallStamp(
+  path = omxUserInstallStampPath(),
+): Promise<UserInstallStamp | null> {
+  if (!existsSync(path)) return null;
+  try {
+    const content = await readFile(path, 'utf-8');
+    const parsed = JSON.parse(content) as Partial<UserInstallStamp>;
+    if (typeof parsed.installed_version !== 'string' || typeof parsed.updated_at !== 'string') {
+      return null;
+    }
+    return {
+      installed_version: parsed.installed_version,
+      ...(typeof parsed.setup_completed_version === 'string'
+        ? { setup_completed_version: parsed.setup_completed_version }
+        : {}),
+      ...(parsed.install_channel === 'stable' || parsed.install_channel === 'dev'
+        ? { install_channel: parsed.install_channel }
+        : {}),
+      ...(typeof parsed.install_source === 'string' ? { install_source: parsed.install_source } : {}),
+      ...(typeof parsed.install_revision === 'string' ? { install_revision: parsed.install_revision } : {}),
+      ...(typeof parsed.dev_base_version === 'string' ? { dev_base_version: parsed.dev_base_version } : {}),
+      ...(parsed.package_manager === 'npm' || parsed.package_manager === 'bun'
+        ? { package_manager: parsed.package_manager }
+        : {}),
+      updated_at: parsed.updated_at,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function writeUserInstallStamp(
+  stamp: UserInstallStamp,
+  path = omxUserInstallStampPath(),
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(stamp, null, 2));
+}
+
+export function isInstallVersionBump(
+  currentVersion: string | null | undefined,
+  stamp: UserInstallStamp | null,
+): boolean {
+  if (!currentVersion) return false;
+  if (!stamp?.installed_version) return true;
+  return stripLeadingV(currentVersion) !== stripLeadingV(stamp.installed_version);
+}

--- a/src/scripts/postinstall.ts
+++ b/src/scripts/postinstall.ts
@@ -85,9 +85,6 @@ export async function runPostinstall(
     ...(typeof existingStamp?.setup_completed_version === "string"
       ? { setup_completed_version: existingStamp.setup_completed_version }
       : {}),
-    ...(existingStamp?.package_manager === "npm" || existingStamp?.package_manager === "bun"
-      ? { package_manager: existingStamp.package_manager }
-      : {}),
     updated_at: new Date().toISOString(),
   });
 

--- a/src/scripts/postinstall.ts
+++ b/src/scripts/postinstall.ts
@@ -6,7 +6,7 @@ import {
   readUserInstallStamp,
   type UserInstallStamp,
   writeUserInstallStamp,
-} from "../cli/update.js";
+} from './postinstall-advisory.js';
 import { getPackageRoot } from "../utils/package.js";
 
 type PostinstallStatus =
@@ -84,6 +84,9 @@ export async function runPostinstall(
     installed_version: currentStampVersion,
     ...(typeof existingStamp?.setup_completed_version === "string"
       ? { setup_completed_version: existingStamp.setup_completed_version }
+      : {}),
+    ...(existingStamp?.package_manager === "npm" || existingStamp?.package_manager === "bun"
+      ? { package_manager: existingStamp.package_manager }
       : {}),
     updated_at: new Date().toISOString(),
   });


### PR DESCRIPTION
## Summary

Implements the narrow #3257 package-manager ownership path while keeping OMX on Node:

- validates npm or Bun ownership from canonical current executable/package-root evidence;
- freezes Bun ownership through stable, deferred, setup, stamp, and diagnostic paths, without npm fallback;
- fails Bun `--dev` before effects with the owner-approved unsupported message;
- preserves npm and Windows npm fallback behavior;
- separates advisory postinstall provenance and preserves an existing Bun owner stamp;
- adds deterministic ownership tests and the Phase-0 command harness/verification manifest.

## Verification

- `npm run build`
- focused update and postinstall tests
- `npm run check:no-unused`
- `npm run lint`
- `npm test`
- `npm run smoke:packed-install`
- no-op stable/dev command-harness receipts

Refs #3257

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*