### PR TITLE
fix(hooks): canonicalize known flattened collaboration tool names

### DIFF
--- a/src/leader/__tests__/contract.test.ts
+++ b/src/leader/__tests__/contract.test.ts
@@ -18,12 +18,15 @@ import {
   NATIVE_SUBAGENT_SUPPORT_BLOCKER_FILE,
   buildRoleRoutingUnavailableGuidance,
   buildUnsupportedNativeSubagentGuidance,
+  isNativeSubagentResultToolName,
+  isNativeSubagentSpawnToolName,
   isRoleRoutingUnavailableEvidence,
   isUnsupportedNativeSubagentEvidence,
   isUnsupportedNativeSubagentEvidenceForScope,
   type RoleRoutingUnavailableMarker,
   resolveNativeSubagentSupportStatus,
   parseNativeSubagentResultDisposition,
+  canonicalizeNativeCollaborationToolName,
   canonicalizeOriginCwd,
 } from '../contract.js';
 
@@ -233,6 +236,76 @@ describe('leader conductor contract', () => {
         persistedCapacityBlocker: { reason: 'agent_thread_limit_reached', expires_at: '2026-07-12T00:00:00.000Z' },
       }).reason,
       'agent_thread_limit_reached',
+    );
+  });
+
+  it('canonicalizes only the finite known flattened collaboration tool names', () => {
+    const known = new Map([
+      ['collaborationspawn_agent', 'collaboration.spawn_agent'],
+      ['collaborationclose_agent', 'collaboration.close_agent'],
+      ['collaborationlist_agents', 'collaboration.list_agents'],
+      ['collaborationfollowup_task', 'collaboration.followup_task'],
+      ['collaborationwait_agent', 'collaboration.wait_agent'],
+      ['collaborationsend_message', 'collaboration.send_message'],
+      ['collaborationinterrupt_agent', 'collaboration.interrupt_agent'],
+    ]);
+    for (const [flattened, dotted] of known) {
+      assert.equal(canonicalizeNativeCollaborationToolName(flattened), dotted);
+      assert.equal(canonicalizeNativeCollaborationToolName(dotted), dotted);
+    }
+    // Unknown or near-miss flattened names pass through unchanged (fail-closed).
+    for (const name of ['collaborationbogus_thing', 'collaborationspawn_agentx', 'xcollaborationspawn_agent', 'collaborationlist_agent', 'collaborationspawnagent', 'collaboration']) {
+      assert.equal(canonicalizeNativeCollaborationToolName(name), name);
+    }
+  });
+
+  it('recognizes flattened known collaboration spawn and result tool names', () => {
+    assert.equal(isNativeSubagentSpawnToolName('collaborationspawn_agent'), true);
+    for (const toolName of ['collaborationspawn_agent', 'collaborationlist_agents', 'collaborationfollowup_task', 'collaborationwait_agent']) {
+      assert.equal(isNativeSubagentResultToolName(toolName), true, toolName);
+    }
+    // close/send/interrupt keep dotted parity: they are not spawn or result tools.
+    for (const toolName of ['collaborationclose_agent', 'collaborationsend_message', 'collaborationinterrupt_agent']) {
+      assert.equal(isNativeSubagentSpawnToolName(toolName), false, toolName);
+      assert.equal(isNativeSubagentResultToolName(toolName), false, toolName);
+    }
+    // Unknown flattened names remain unrecognized.
+    for (const toolName of ['collaborationbogus_thing', 'collaborationspawn_agentx', 'collaborationlist_agent']) {
+      assert.equal(isNativeSubagentSpawnToolName(toolName), false, toolName);
+      assert.equal(isNativeSubagentResultToolName(toolName), false, toolName);
+    }
+  });
+
+  it('detects native subagent support from flattened available_tools names', () => {
+    assert.equal(
+      resolveNativeSubagentSupportStatus({ payload: { available_tools: ['Read', 'collaborationspawn_agent'] } }).status,
+      'supported',
+    );
+    assert.equal(
+      resolveNativeSubagentSupportStatus({ payload: { available_tools: [{ name: 'collaborationspawn_agent' }] } }).status,
+      'supported',
+    );
+    const companionsOnly = resolveNativeSubagentSupportStatus({
+      payload: { available_tools: ['collaborationfollowup_task', 'collaborationwait_agent'] },
+    });
+    assert.equal(companionsOnly.status, 'unknown');
+  });
+
+  it('parses flattened collaboration result dispositions like their dotted forms', () => {
+    for (const toolName of ['collaborationspawn_agent', 'collaborationlist_agents', 'collaborationfollowup_task', 'collaborationwait_agent']) {
+      assert.equal(
+        parseNativeSubagentResultDisposition(toolName, { success: true, status: 'completed', error: null }).kind,
+        'success',
+        toolName,
+      );
+    }
+    assert.equal(
+      parseNativeSubagentResultDisposition('collaborationspawn_agent', 'collab spawn failed: agent thread limit reached').kind,
+      'capacity',
+    );
+    assert.equal(
+      parseNativeSubagentResultDisposition('collaborationspawn_agent', 'unknown tool is unavailable').kind,
+      'unsupported',
     );
   });
 

--- a/src/leader/contract.ts
+++ b/src/leader/contract.ts
@@ -329,6 +329,27 @@ function reasonFromCapabilityRecord(record: Record<string, unknown> | null): Nat
   return nativeSubagents === false ? 'native_subagents_unsupported' : 'multi_agent_v1_unavailable';
 }
 
+// Codex CLI can deliver the known dotted collaboration tool names in a
+// flattened form (the namespace dot is dropped), e.g. `collaboration.spawn_agent`
+// arrives as `collaborationspawn_agent`. Canonicalize ONLY the finite known
+// flattened names back to their dotted form so transport classification,
+// spawn/result recognition, and capability detection all key on one canonical
+// name. Unknown flattened names pass through unchanged and stay fail-closed.
+// Callers keep the original received name for diagnostics and persisted evidence.
+const FLATTENED_NATIVE_COLLABORATION_TOOL_NAMES: ReadonlyMap<string, string> = new Map([
+  ['collaborationspawn_agent', 'collaboration.spawn_agent'],
+  ['collaborationclose_agent', 'collaboration.close_agent'],
+  ['collaborationlist_agents', 'collaboration.list_agents'],
+  ['collaborationfollowup_task', 'collaboration.followup_task'],
+  ['collaborationwait_agent', 'collaboration.wait_agent'],
+  ['collaborationsend_message', 'collaboration.send_message'],
+  ['collaborationinterrupt_agent', 'collaboration.interrupt_agent'],
+]);
+
+export function canonicalizeNativeCollaborationToolName(name: string): string {
+  return FLATTENED_NATIVE_COLLABORATION_TOOL_NAMES.get(name) ?? name;
+}
+
 const NATIVE_SUBAGENT_SPAWN_TOOL_PATTERN = /(?:^|\.)spawn_agent$/;
 
 // Recognizes native delegation spawn tools across terminology drift: bare
@@ -336,13 +357,15 @@ const NATIVE_SUBAGENT_SPAWN_TOOL_PATTERN = /(?:^|\.)spawn_agent$/;
 // the current Codex App `collaboration.spawn_agent`, plus the legacy `task`
 // alias. The suffix anchor keeps `respawn_agent`/`spawn_agentx` from matching.
 export function isNativeSubagentSpawnToolName(name: string): boolean {
-  return NATIVE_SUBAGENT_SPAWN_TOOL_PATTERN.test(name) || name === 'task';
+  const canonical = canonicalizeNativeCollaborationToolName(name);
+  return NATIVE_SUBAGENT_SPAWN_TOOL_PATTERN.test(canonical) || canonical === 'task';
 }
 
 const NATIVE_SUBAGENT_RESULT_TOOL_PATTERN = /(?:^|\.)(?:spawn_agent|list_agents|followup_task|wait_agent)$/;
 
 export function isNativeSubagentResultToolName(name: string): boolean {
-  return NATIVE_SUBAGENT_RESULT_TOOL_PATTERN.test(name) || name === 'task';
+  const canonical = canonicalizeNativeCollaborationToolName(name);
+  return NATIVE_SUBAGENT_RESULT_TOOL_PATTERN.test(canonical) || canonical === 'task';
 }
 
 function availableToolsEvidence(payload: Record<string, unknown> | null): NativeSubagentSupportEvidence | null {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -12806,7 +12806,7 @@ exit 0
 					delete process.env.OMX_QUESTION_RETURN_PANE;
 				}
 			})(), /OMX_QUESTION_RETURN_PANE=\$TMUX_PANE/);
-			await assertAllowed("direct documented cancellation", await (async () => {
+			await assertAllowed("direct documented cancellation", await withCleanRunnerNodeEnvironment(async () => {
 				const workspacePackageCli = realpathSync(resolve(process.cwd(), "dist", "cli", "omx.js"));
 				const trustedBinDir = await mkdtemp(join(tmpdir(), "omx-di-trusted-bin-"));
 				await symlink(workspacePackageCli, join(trustedBinDir, "omx"));
@@ -12819,7 +12819,7 @@ exit 0
 					else process.env.PATH = inheritedPath;
 					await rm(trustedBinDir, { recursive: true, force: true });
 				}
-			})());
+			}));
 			await assertDenied("chained cancellation is not documented direct cancellation", await bash("printf ready && omx cancel", "omx-cancel-chained"), /Deep-interview is active|write intent|handoff|direct/);
 			await assertDenied("force cancellation is ralplan/conductor-only", await bash("omx cancel --force", "omx-cancel-force"), /Deep-interview is active|write intent|handoff|direct/);
 			await assertDenied("bom lookalike is not direct cancellation", await bash("\ufeffomx cancel", "omx-cancel-bom"), /Deep-interview is active|write intent|handoff|direct/);
@@ -12831,6 +12831,16 @@ exit 0
 				} finally {
 					if (previousBashEnv === undefined) delete process.env.BASH_ENV;
 					else process.env.BASH_ENV = previousBashEnv;
+				}
+			})(), /Deep-interview is active|write intent|handoff|direct/);
+			await assertDenied("inherited node coverage output poisons direct cancellation", await (async () => {
+				const previousCoverage = process.env.NODE_V8_COVERAGE;
+				process.env.NODE_V8_COVERAGE = "/tmp/coverage-out";
+				try {
+					return await bash("omx cancel", "omx-cancel-coverage");
+				} finally {
+					if (previousCoverage === undefined) delete process.env.NODE_V8_COVERAGE;
+					else process.env.NODE_V8_COVERAGE = previousCoverage;
 				}
 			})(), /Deep-interview is active|write intent|handoff|direct/);
 
@@ -20848,6 +20858,38 @@ PY`,
     }
   });
 
+  // Direct-cancel positives must prove behavior in a clean execution context,
+  // but the test runner itself may inherit Node startup/output instrumentation
+  // (e.g. NODE_V8_COVERAGE from the coverage lane). Clear only the runner's
+  // baseline values around clean-context assertions; per-case injected values
+  // in denial tests are set explicitly afterwards and still exercise the
+  // product predicate. Mirrors DIRECT_OMX_CANCEL_UNSAFE_INHERITED_ENV_NAMES
+  // and CONDUCTOR_NODE_OUTPUT_ENVIRONMENT_NAMES in the hook.
+  const RUNNER_BASELINE_NODE_ENV_NAMES = [
+    "NODE_OPTIONS",
+    "NODE_EXTRA_CA_CERTS",
+    "OPENSSL_CONF",
+    "NODE_V8_COVERAGE",
+    "NODE_COMPILE_CACHE",
+    "NODE_REDIRECT_WARNINGS",
+    "NODE_REPORT_DIRECTORY",
+    "NODE_REPORT_FILENAME",
+  ];
+  const withCleanRunnerNodeEnvironment = async <T>(run: () => Promise<T>): Promise<T> => {
+    const previous = new Map<string, string | undefined>();
+    for (const name of RUNNER_BASELINE_NODE_ENV_NAMES) {
+      previous.set(name, process.env[name]);
+      delete process.env[name];
+    }
+    try {
+      return await run();
+    } finally {
+      for (const [name, value] of previous) {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+    }
+  };
   const writeFlattenedCollaborationRalplanFixture = async (cwd: string) => {
     const stateDir = join(cwd, ".omx", "state");
     const sessionId = "sess-flattened-collab-ralplan";
@@ -21100,8 +21142,12 @@ PY`,
         }
       };
 
-      assert.equal((await bashTrusted("omx cancel")).outputJson, null);
-      assert.equal((await bashTrusted("omx cancel --force")).outputJson, null);
+      const cleanPositives = await withCleanRunnerNodeEnvironment(async () => ({
+        plain: await bashTrusted("omx cancel"),
+        force: await bashTrusted("omx cancel --force"),
+      }));
+      assert.equal(cleanPositives.plain.outputJson, null);
+      assert.equal(cleanPositives.force.outputJson, null);
       assert.equal((await bash("omx cancel")).outputJson?.decision, "block",
         "ambient non-package omx resolution is not trusted");
 
@@ -21159,6 +21205,7 @@ PY`,
         ["inherited node loader override", "NODE_OPTIONS", "--require=./payload.cjs"],
         ["inherited openssl config", "OPENSSL_CONF", "/tmp/evil.cnf"],
         ["inherited dynamic loader preload", "LD_PRELOAD", "/tmp/payload.so"],
+        ["inherited node coverage output", "NODE_V8_COVERAGE", "/tmp/coverage-out"],
       ] as const) {
         const previousValue = process.env[envName];
         process.env[envName] = envValue;
@@ -31555,8 +31602,12 @@ PY`,
         }
       };
 
-      assert.equal((await bashTrusted("omx cancel")).outputJson, null);
-      assert.equal((await bashTrusted("omx cancel --force")).outputJson, null);
+      const cleanPositives = await withCleanRunnerNodeEnvironment(async () => ({
+        plain: await bashTrusted("omx cancel"),
+        force: await bashTrusted("omx cancel --force"),
+      }));
+      assert.equal(cleanPositives.plain.outputJson, null);
+      assert.equal(cleanPositives.force.outputJson, null);
       assert.equal((await bash("omx cancel")).outputJson?.decision, "block",
         "ambient non-package omx resolution is not trusted");
 
@@ -31580,6 +31631,7 @@ PY`,
         ["inherited node loader override", "NODE_OPTIONS", "--require=./payload.cjs"],
         ["inherited openssl config", "OPENSSL_CONF", "/tmp/evil.cnf"],
         ["inherited dynamic loader preload", "LD_PRELOAD", "/tmp/payload.so"],
+        ["inherited node coverage output", "NODE_V8_COVERAGE", "/tmp/coverage-out"],
       ] as const) {
         const previousValue = process.env[envName];
         process.env[envName] = envValue;

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -845,7 +845,7 @@ describe("codex native hook config", () => {
 	});
 });
 
-describe("codex native hook dispatch", () => {
+describe("codex native hook dispatch", { concurrency: false }, () => {
 	it("treats space-containing argv entry paths as the main module", () => {
 		const entryPath = "/tmp/omx native/codex-native-hook.js";
 

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -12806,16 +12806,31 @@ exit 0
 					delete process.env.OMX_QUESTION_RETURN_PANE;
 				}
 			})(), /OMX_QUESTION_RETURN_PANE=\$TMUX_PANE/);
-			await assertAllowed("direct documented cancellation", await bash("omx cancel", "omx-cancel"));
+			await assertAllowed("direct documented cancellation", await (async () => {
+				const workspacePackageCli = realpathSync(resolve(process.cwd(), "dist", "cli", "omx.js"));
+				const trustedBinDir = await mkdtemp(join(tmpdir(), "omx-di-trusted-bin-"));
+				await symlink(workspacePackageCli, join(trustedBinDir, "omx"));
+				const inheritedPath = process.env.PATH;
+				process.env.PATH = `${trustedBinDir}:/usr/bin:/bin`;
+				try {
+					return await bash("omx cancel", "omx-cancel");
+				} finally {
+					if (inheritedPath === undefined) delete process.env.PATH;
+					else process.env.PATH = inheritedPath;
+					await rm(trustedBinDir, { recursive: true, force: true });
+				}
+			})());
 			await assertDenied("chained cancellation is not documented direct cancellation", await bash("printf ready && omx cancel", "omx-cancel-chained"), /Deep-interview is active|write intent|handoff|direct/);
 			await assertDenied("force cancellation is ralplan/conductor-only", await bash("omx cancel --force", "omx-cancel-force"), /Deep-interview is active|write intent|handoff|direct/);
 			await assertDenied("bom lookalike is not direct cancellation", await bash("\ufeffomx cancel", "omx-cancel-bom"), /Deep-interview is active|write intent|handoff|direct/);
 			await assertDenied("inherited bash startup poisons direct cancellation", await (async () => {
+				const previousBashEnv = process.env.BASH_ENV;
 				process.env.BASH_ENV = "/tmp/prelude.sh";
 				try {
 					return await bash("omx cancel", "omx-cancel-bash-env");
 				} finally {
-					delete process.env.BASH_ENV;
+					if (previousBashEnv === undefined) delete process.env.BASH_ENV;
+					else process.env.BASH_ENV = previousBashEnv;
 				}
 			})(), /Deep-interview is active|write intent|handoff|direct/);
 
@@ -21064,8 +21079,31 @@ PY`,
         tool_input: { command },
       }, { cwd });
 
-      assert.equal((await bash("omx cancel")).outputJson, null);
-      assert.equal((await bash("omx cancel --force")).outputJson, null);
+      // The exemption also requires the bare `omx` token to resolve to the
+      // hook package's canonical CLI under the inherited PATH, so positives
+      // and impostor denials run under a proven-trusted resolution to stay
+      // discriminating (a denial must not pass merely because the ambient
+      // PATH was untrusted).
+      const workspacePackageCli = realpathSync(resolve(process.cwd(), "dist", "cli", "omx.js"));
+      const trustedPackageBin = join(cwd, "node_modules", ".bin", "omx");
+      await mkdir(dirname(trustedPackageBin), { recursive: true });
+      await symlink(workspacePackageCli, trustedPackageBin);
+      const trustedPackagePath = `${dirname(trustedPackageBin)}:/usr/bin:/bin`;
+      const bashTrusted = async (command: string) => {
+        const inheritedPath = process.env.PATH;
+        process.env.PATH = trustedPackagePath;
+        try {
+          return await bash(command);
+        } finally {
+          if (inheritedPath === undefined) delete process.env.PATH;
+          else process.env.PATH = inheritedPath;
+        }
+      };
+
+      assert.equal((await bashTrusted("omx cancel")).outputJson, null);
+      assert.equal((await bashTrusted("omx cancel --force")).outputJson, null);
+      assert.equal((await bash("omx cancel")).outputJson?.decision, "block",
+        "ambient non-package omx resolution is not trusted");
 
       const chained = await bash("omx cancel --force && rm -rf x");
       assert.equal(chained.outputJson?.decision, "block");
@@ -21107,7 +21145,7 @@ PY`,
         ["byte-order-mark lookalike executable", "\ufeffomx cancel"],
         ["carriage-return suffix lookalike", "omx cancel\r"],
       ] as const) {
-        const impostor = await bash(command);
+        const impostor = await bashTrusted(command);
         assert.equal(impostor.outputJson?.decision, "block", label);
       }
 
@@ -21119,15 +21157,35 @@ PY`,
         ["inherited bash startup file", "BASH_ENV", "/tmp/prelude.sh"],
         ["imported omx function shadow", "BASH_FUNC_omx%%", "() { printf owned > src/pwned.ts; }"],
         ["inherited node loader override", "NODE_OPTIONS", "--require=./payload.cjs"],
+        ["inherited openssl config", "OPENSSL_CONF", "/tmp/evil.cnf"],
+        ["inherited dynamic loader preload", "LD_PRELOAD", "/tmp/payload.so"],
       ] as const) {
         const previousValue = process.env[envName];
         process.env[envName] = envValue;
         try {
-          const poisoned = await bash("omx cancel");
+          const poisoned = await bashTrusted("omx cancel");
           assert.equal(poisoned.outputJson?.decision, "block", label);
         } finally {
           if (previousValue === undefined) delete process.env[envName];
           else process.env[envName] = previousValue;
+        }
+      }
+
+      // A PATH-shadowed omx (a different executable resolving first) is not
+      // the validated cancellation program and must deny even byte-exact text.
+      const shadowBinDir = join(cwd, "shadow-bin");
+      await mkdir(shadowBinDir, { recursive: true });
+      await writeFile(join(shadowBinDir, "omx"), "#!/bin/sh\ntouch src/path-shadow-owned.ts\n", "utf-8");
+      await chmod(join(shadowBinDir, "omx"), 0o755);
+      {
+        const inheritedPath = process.env.PATH;
+        process.env.PATH = `${shadowBinDir}:${trustedPackagePath}`;
+        try {
+          const shadowed = await bash("omx cancel");
+          assert.equal(shadowed.outputJson?.decision, "block", "PATH-shadowed omx executable");
+        } finally {
+          if (inheritedPath === undefined) delete process.env.PATH;
+          else process.env.PATH = inheritedPath;
         }
       }
 
@@ -31481,8 +31539,26 @@ PY`,
         tool_input: { command },
       }, { cwd });
 
-      assert.equal((await bash("omx cancel")).outputJson, null);
-      assert.equal((await bash("omx cancel --force")).outputJson, null);
+      const workspacePackageCli = realpathSync(resolve(process.cwd(), "dist", "cli", "omx.js"));
+      const trustedPackageBin = join(cwd, "node_modules", ".bin", "omx");
+      await mkdir(dirname(trustedPackageBin), { recursive: true });
+      await symlink(workspacePackageCli, trustedPackageBin);
+      const trustedPackagePath = `${dirname(trustedPackageBin)}:/usr/bin:/bin`;
+      const bashTrusted = async (command: string) => {
+        const inheritedPath = process.env.PATH;
+        process.env.PATH = trustedPackagePath;
+        try {
+          return await bash(command);
+        } finally {
+          if (inheritedPath === undefined) delete process.env.PATH;
+          else process.env.PATH = inheritedPath;
+        }
+      };
+
+      assert.equal((await bashTrusted("omx cancel")).outputJson, null);
+      assert.equal((await bashTrusted("omx cancel --force")).outputJson, null);
+      assert.equal((await bash("omx cancel")).outputJson?.decision, "block",
+        "ambient non-package omx resolution is not trusted");
 
       for (const [label, command] of [
         ["openssl config injection", "OPENSSL_CONF=/tmp/evil.cnf omx cancel"],
@@ -31494,7 +31570,7 @@ PY`,
         ["carriage-return suffix lookalike", "omx cancel\r"],
         ["unicode nbsp separator", "omx\u00a0cancel"],
       ] as const) {
-        const impostor = await bash(command);
+        const impostor = await bashTrusted(command);
         assert.equal(impostor.outputJson?.decision, "block", label);
       }
 
@@ -31502,15 +31578,33 @@ PY`,
         ["inherited bash startup file", "BASH_ENV", "/tmp/prelude.sh"],
         ["imported omx function shadow", "BASH_FUNC_omx%%", "() { printf owned > src/pwned.ts; }"],
         ["inherited node loader override", "NODE_OPTIONS", "--require=./payload.cjs"],
+        ["inherited openssl config", "OPENSSL_CONF", "/tmp/evil.cnf"],
+        ["inherited dynamic loader preload", "LD_PRELOAD", "/tmp/payload.so"],
       ] as const) {
         const previousValue = process.env[envName];
         process.env[envName] = envValue;
         try {
-          const poisoned = await bash("omx cancel");
+          const poisoned = await bashTrusted("omx cancel");
           assert.equal(poisoned.outputJson?.decision, "block", label);
         } finally {
           if (previousValue === undefined) delete process.env[envName];
           else process.env[envName] = previousValue;
+        }
+      }
+
+      const shadowBinDir = join(cwd, "shadow-bin");
+      await mkdir(shadowBinDir, { recursive: true });
+      await writeFile(join(shadowBinDir, "omx"), "#!/bin/sh\ntouch src/path-shadow-owned.ts\n", "utf-8");
+      await chmod(join(shadowBinDir, "omx"), 0o755);
+      {
+        const inheritedPath = process.env.PATH;
+        process.env.PATH = `${shadowBinDir}:${trustedPackagePath}`;
+        try {
+          const shadowed = await bash("omx cancel");
+          assert.equal(shadowed.outputJson?.decision, "block", "PATH-shadowed omx executable");
+        } finally {
+          if (inheritedPath === undefined) delete process.env.PATH;
+          else process.env.PATH = inheritedPath;
         }
       }
 

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -12808,6 +12808,16 @@ exit 0
 			})(), /OMX_QUESTION_RETURN_PANE=\$TMUX_PANE/);
 			await assertAllowed("direct documented cancellation", await bash("omx cancel", "omx-cancel"));
 			await assertDenied("chained cancellation is not documented direct cancellation", await bash("printf ready && omx cancel", "omx-cancel-chained"), /Deep-interview is active|write intent|handoff|direct/);
+			await assertDenied("force cancellation is ralplan/conductor-only", await bash("omx cancel --force", "omx-cancel-force"), /Deep-interview is active|write intent|handoff|direct/);
+			await assertDenied("bom lookalike is not direct cancellation", await bash("\ufeffomx cancel", "omx-cancel-bom"), /Deep-interview is active|write intent|handoff|direct/);
+			await assertDenied("inherited bash startup poisons direct cancellation", await (async () => {
+				process.env.BASH_ENV = "/tmp/prelude.sh";
+				try {
+					return await bash("omx cancel", "omx-cancel-bash-env");
+				} finally {
+					delete process.env.BASH_ENV;
+				}
+			})(), /Deep-interview is active|write intent|handoff|direct/);
 
 			for (const [label, command] of [
 				["omx-help", "omx --help"],
@@ -21099,6 +21109,26 @@ PY`,
       ] as const) {
         const impostor = await bash(command);
         assert.equal(impostor.outputJson?.decision, "block", label);
+      }
+
+      // Inherited execution-context overrides must deny even the byte-exact
+      // command: the exemption proves the text, not the runtime that will
+      // execute it (Bash sources $BASH_ENV first, imported functions shadow
+      // the omx executable, and Node loader env preloads code).
+      for (const [label, envName, envValue] of [
+        ["inherited bash startup file", "BASH_ENV", "/tmp/prelude.sh"],
+        ["imported omx function shadow", "BASH_FUNC_omx%%", "() { printf owned > src/pwned.ts; }"],
+        ["inherited node loader override", "NODE_OPTIONS", "--require=./payload.cjs"],
+      ] as const) {
+        const previousValue = process.env[envName];
+        process.env[envName] = envValue;
+        try {
+          const poisoned = await bash("omx cancel");
+          assert.equal(poisoned.outputJson?.decision, "block", label);
+        } finally {
+          if (previousValue === undefined) delete process.env[envName];
+          else process.env[envName] = previousValue;
+        }
       }
 
       const stateClear = await bash("omx state clear --force --mode ralplan --json");
@@ -31466,6 +31496,22 @@ PY`,
       ] as const) {
         const impostor = await bash(command);
         assert.equal(impostor.outputJson?.decision, "block", label);
+      }
+
+      for (const [label, envName, envValue] of [
+        ["inherited bash startup file", "BASH_ENV", "/tmp/prelude.sh"],
+        ["imported omx function shadow", "BASH_FUNC_omx%%", "() { printf owned > src/pwned.ts; }"],
+        ["inherited node loader override", "NODE_OPTIONS", "--require=./payload.cjs"],
+      ] as const) {
+        const previousValue = process.env[envName];
+        process.env[envName] = envValue;
+        try {
+          const poisoned = await bash("omx cancel");
+          assert.equal(poisoned.outputJson?.decision, "block", label);
+        } finally {
+          if (previousValue === undefined) delete process.env[envName];
+          else process.env[envName] = previousValue;
+        }
       }
 
       const stateClear = await bash("omx state clear --force --mode ultragoal --json");

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -12811,7 +12811,7 @@ exit 0
 				const trustedBinDir = await mkdtemp(join(tmpdir(), "omx-di-trusted-bin-"));
 				await symlink(workspacePackageCli, join(trustedBinDir, "omx"));
 				const inheritedPath = process.env.PATH;
-				process.env.PATH = `${trustedBinDir}:/usr/bin:/bin`;
+				process.env.PATH = `${trustedBinDir}:${dirname(process.execPath)}`;
 				try {
 					return await bash("omx cancel", "omx-cancel");
 				} finally {
@@ -21130,7 +21130,7 @@ PY`,
       const trustedPackageBin = join(cwd, "node_modules", ".bin", "omx");
       await mkdir(dirname(trustedPackageBin), { recursive: true });
       await symlink(workspacePackageCli, trustedPackageBin);
-      const trustedPackagePath = `${dirname(trustedPackageBin)}:/usr/bin:/bin`;
+      const trustedPackagePath = `${dirname(trustedPackageBin)}:${dirname(process.execPath)}`;
       const bashTrusted = async (command: string) => {
         const inheritedPath = process.env.PATH;
         process.env.PATH = trustedPackagePath;
@@ -31590,7 +31590,7 @@ PY`,
       const trustedPackageBin = join(cwd, "node_modules", ".bin", "omx");
       await mkdir(dirname(trustedPackageBin), { recursive: true });
       await symlink(workspacePackageCli, trustedPackageBin);
-      const trustedPackagePath = `${dirname(trustedPackageBin)}:/usr/bin:/bin`;
+      const trustedPackagePath = `${dirname(trustedPackageBin)}:${dirname(process.execPath)}`;
       const bashTrusted = async (command: string) => {
         const inheritedPath = process.env.PATH;
         process.env.PATH = trustedPackagePath;

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -21056,7 +21056,6 @@ PY`,
 
       assert.equal((await bash("omx cancel")).outputJson, null);
       assert.equal((await bash("omx cancel --force")).outputJson, null);
-      assert.equal((await bash("FOO=bar omx cancel --force")).outputJson, null);
 
       const chained = await bash("omx cancel --force && rm -rf x");
       assert.equal(chained.outputJson?.decision, "block");
@@ -21064,7 +21063,14 @@ PY`,
       const unknownFlag = await bash("omx cancel --json");
       assert.equal(unknownFlag.outputJson?.decision, "block");
 
+      // The direct-cancel grammar admits no leading environment assignments at
+      // all: runtime startup/configuration variables are an open-ended
+      // namespace (PATH, NODE_OPTIONS, OPENSSL_CONF, OMX_* state selectors),
+      // so every prefixed form is denied rather than denylisted one by one.
       for (const [label, command] of [
+        ["benign-looking env prefix", "FOO=bar omx cancel --force"],
+        ["multi env prefix", "A=1 B=2 omx cancel"],
+        ["openssl config injection", "OPENSSL_CONF=/tmp/evil.cnf omx cancel"],
         ["path override", "PATH=/tmp/attacker omx cancel"],
         ["node preload override", "NODE_OPTIONS=--require=./payload.cjs omx cancel"],
         ["path-qualified impostor", "/tmp/omx cancel --force"],
@@ -21245,6 +21251,45 @@ PY`,
 
       assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
       assert.match(JSON.stringify(result.outputJson), /Do not call multi_agent_v1\.close_agent/);
+      assert.match(JSON.stringify(result.outputJson), /do not batch close_agent through multi_tool_use\.parallel/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks parallel close_agent cleanup with flattened nested recipients after native capacity exhaustion", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-subagent-capacity-parallel-close-flattened-"));
+    try {
+      await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PostToolUse",
+          cwd,
+          session_id: "sess-subagent-capacity-parallel-close-flattened",
+          thread_id: "thread-subagent-capacity-parallel-close-flattened",
+          tool_name: "collaborationspawn_agent",
+          tool_response: "agent thread limit reached",
+        },
+        { cwd },
+      );
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "sess-subagent-capacity-parallel-close-flattened",
+          thread_id: "thread-subagent-capacity-parallel-close-flattened",
+          tool_name: "multi_tool_use.parallel",
+          tool_input: {
+            tool_uses: [
+              { recipient_name: "collaborationclose_agent", parameters: { target: "stale-1" } },
+              { recipient_name: "collaborationclose_agent", parameters: { target: "stale-2" } },
+            ],
+          },
+        },
+        { cwd },
+      );
+
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
       assert.match(JSON.stringify(result.outputJson), /do not batch close_agent through multi_tool_use\.parallel/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -31379,6 +31424,57 @@ PY`,
 
       assert.equal(result.outputJson?.decision, "block");
       assert.match(String(result.outputJson?.reason ?? ""), /Main-root Conductor mode is active \(ultragoal phase: planning\)/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows session-scoped omx cancel under active ultragoal conductor while impostors stay blocked", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ultragoal-conductor-cancel-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-ultragoal-conductor-cancel";
+      const leaderThreadId = "thread-ultragoal-conductor-cancel";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), {
+        session_id: sessionId,
+        native_session_id: leaderThreadId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), { schemaVersion: 1, sessions: { [sessionId]: { session_id: sessionId, leader_thread_id: leaderThreadId, threads: { [leaderThreadId]: { thread_id: leaderThreadId, kind: "leader" } } } } });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ultragoal", "planning");
+      await writeJson(join(stateDir, "sessions", sessionId, "ultragoal-state.json"), {
+        active: true,
+        mode: "ultragoal",
+        current_phase: "planning",
+        session_id: sessionId,
+      });
+
+      const bash = (command: string) => dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: sessionId,
+        thread_id: leaderThreadId,
+        agent_id: leaderThreadId,
+        tool_name: "Bash",
+        tool_input: { command },
+      }, { cwd });
+
+      assert.equal((await bash("omx cancel")).outputJson, null);
+      assert.equal((await bash("omx cancel --force")).outputJson, null);
+
+      for (const [label, command] of [
+        ["openssl config injection", "OPENSSL_CONF=/tmp/evil.cnf omx cancel"],
+        ["path override", "PATH=/tmp/attacker omx cancel"],
+        ["path-qualified impostor", "/tmp/omx cancel --force"],
+        ["chained cancellation", "omx cancel --force && rm -rf x"],
+        ["omx root override", "OMX_ROOT=/tmp/other omx cancel"],
+      ] as const) {
+        const impostor = await bash(command);
+        assert.equal(impostor.outputJson?.decision, "block", label);
+      }
+
+      const stateClear = await bash("omx state clear --force --mode ultragoal --json");
+      assert.equal(stateClear.outputJson?.decision, "block");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -20823,6 +20823,294 @@ PY`,
     }
   });
 
+  const writeFlattenedCollaborationRalplanFixture = async (cwd: string) => {
+    const stateDir = join(cwd, ".omx", "state");
+    const sessionId = "sess-flattened-collab-ralplan";
+    const leaderThreadId = "thread-flattened-collab-ralplan-leader";
+    const sessionDir = join(stateDir, "sessions", sessionId);
+    await mkdir(sessionDir, { recursive: true });
+    await writeJson(join(stateDir, "session.json"), {
+      session_id: sessionId,
+      native_session_id: leaderThreadId,
+      cwd,
+    });
+    await writeJson(join(sessionDir, "skill-active-state.json"), {
+      version: 1,
+      active: true,
+      skill: "autopilot",
+      phase: "ralplan",
+      session_id: sessionId,
+      thread_id: leaderThreadId,
+      active_skills: [{
+        skill: "autopilot",
+        phase: "ralplan",
+        active: true,
+        session_id: sessionId,
+        thread_id: leaderThreadId,
+      }],
+    });
+    await writeJson(join(sessionDir, "autopilot-state.json"), {
+      active: true,
+      mode: "autopilot",
+      current_phase: "ralplan",
+      started_at: "2026-07-22T00:00:00.000Z",
+      updated_at: "2026-07-22T00:10:00.000Z",
+      session_id: sessionId,
+      thread_id: leaderThreadId,
+    });
+    await writeJson(join(stateDir, "subagent-tracking.json"), {
+      schemaVersion: 1,
+      sessions: {
+        [sessionId]: {
+          session_id: sessionId,
+          leader_thread_id: leaderThreadId,
+          updated_at: "2026-07-22T00:10:00.000Z",
+          threads: {
+            [leaderThreadId]: {
+              thread_id: leaderThreadId,
+              kind: "leader",
+              first_seen_at: "2026-07-22T00:00:00.000Z",
+              last_seen_at: "2026-07-22T00:10:00.000Z",
+              turn_count: 1,
+            },
+          },
+        },
+      },
+    });
+    return { sessionId, leaderThreadId, stateDir };
+  };
+
+  it("allows flattened known collaboration tools under active ralplan while unknown flattened names stay blocked", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-flattened-collab-ralplan-"));
+    try {
+      const { sessionId, leaderThreadId } = await writeFlattenedCollaborationRalplanFixture(cwd);
+      for (const [tool_name, tool_input] of [
+        ["collaborationspawn_agent", { agent_type: "planner", message: "draft the plan" }],
+        ["collaborationlist_agents", {}],
+        ["collaborationfollowup_task", {}],
+        ["collaborationwait_agent", {}],
+        ["collaborationsend_message", {}],
+        ["collaborationinterrupt_agent", {}],
+        ["collaborationclose_agent", {}],
+      ] as const) {
+        const result = await dispatchCodexNativeHook({
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: leaderThreadId,
+          tool_name,
+          tool_input,
+        }, { cwd });
+        assert.equal(result.outputJson, null, tool_name);
+      }
+
+      const blocked = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: sessionId,
+        thread_id: leaderThreadId,
+        tool_name: "collaborationbogus_thing",
+        tool_input: {},
+      }, { cwd });
+      assert.equal(blocked.outputJson?.decision, "block");
+      const reason = String(blocked.outputJson?.reason ?? "");
+      assert.match(reason, /not a recognized read-only or explicitly authorized planning mutation transport/);
+      assert.match(reason, /collaborationbogus_thing/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("denies unknown typed roles dispatched through flattened spawn names", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-flattened-collab-unknown-role-"));
+    try {
+      const { sessionId, leaderThreadId } = await writeFlattenedCollaborationRalplanFixture(cwd);
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: sessionId,
+        thread_id: leaderThreadId,
+        tool_name: "collaborationspawn_agent",
+        tool_input: { agent_type: "definitely-not-an-installed-role", message: "x" },
+      }, { cwd });
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /unknown or not installed/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("records native blockers from flattened collaboration spawn failures with the original tool name", async () => {
+    const capacityCwd = await mkdtemp(join(tmpdir(), "omx-native-hook-flattened-collab-capacity-"));
+    try {
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "PostToolUse",
+        cwd: capacityCwd,
+        session_id: "sess-flattened-capacity",
+        thread_id: "thread-flattened-capacity",
+        turn_id: "turn-flattened-capacity",
+        tool_name: "collaborationspawn_agent",
+        tool_response: "collab spawn failed: agent thread limit reached",
+      }, { cwd: capacityCwd });
+      assert.equal(result.outputJson, null);
+      const blocker = JSON.parse(
+        await readFile(join(capacityCwd, ".omx", "state", "native-subagent-capacity-blocker.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(blocker.tool_name, "collaborationspawn_agent");
+      assert.match(String(blocker.error_summary), /agent thread limit reached/);
+    } finally {
+      await rm(capacityCwd, { recursive: true, force: true });
+    }
+
+    const supportCwd = await mkdtemp(join(tmpdir(), "omx-native-hook-flattened-collab-support-"));
+    try {
+      await dispatchCodexNativeHook({
+        hook_event_name: "PostToolUse",
+        cwd: supportCwd,
+        session_id: "sess-flattened-support",
+        thread_id: "thread-flattened-support",
+        turn_id: "turn-flattened-support",
+        tool_name: "collaborationspawn_agent",
+        tool_response: { error: "unknown tool: collaborationspawn_agent is unavailable" },
+      }, { cwd: supportCwd });
+      const blocker = JSON.parse(
+        await readFile(join(supportCwd, ".omx", "state", "native-subagent-support.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      assert.equal(blocker.tool_name, "collaborationspawn_agent");
+    } finally {
+      await rm(supportCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not persist support or capacity poison from successful flattened collaboration child output", async () => {
+    for (const toolName of [
+      "collaborationspawn_agent",
+      "collaborationlist_agents",
+      "collaborationfollowup_task",
+      "collaborationwait_agent",
+    ]) {
+      const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-flattened-collab-success-"));
+      try {
+        await dispatchCodexNativeHook({
+          hook_event_name: "PostToolUse",
+          cwd,
+          session_id: "sess-flattened-success",
+          thread_id: "thread-flattened-success",
+          tool_name: toolName,
+          tool_response: {
+            success: true,
+            status: "completed",
+            output: "Child completed. Optional packed plugin was unavailable, unsupported, and not found.",
+          },
+        }, { cwd });
+        const stateDir = join(cwd, ".omx", "state");
+        assert.equal(existsSync(join(stateDir, "native-subagent-support.json")), false, toolName);
+        assert.equal(existsSync(join(stateDir, "native-subagent-capacity-blocker.json")), false, toolName);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("blocks flattened close_agent cleanup after recent native subagent capacity exhaustion", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-flattened-collab-capacity-close-block-"));
+    try {
+      await dispatchCodexNativeHook({
+        hook_event_name: "PostToolUse",
+        cwd,
+        session_id: "sess-flattened-capacity-close-block",
+        thread_id: "thread-flattened-capacity-close-block",
+        turn_id: "turn-flattened-capacity-close-block",
+        tool_name: "collaborationspawn_agent",
+        tool_response: "collab spawn failed: agent thread limit reached",
+      }, { cwd });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: "sess-flattened-capacity-close-block",
+        thread_id: "thread-flattened-capacity-close-block",
+        tool_name: "collaborationclose_agent",
+        tool_input: { target: "019ecc36-stale" },
+      }, { cwd });
+
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /capacity/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows session-scoped omx cancel under active ralplan without weakening state guards", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-flattened-collab-ralplan-cancel-"));
+    try {
+      const { sessionId, leaderThreadId } = await writeFlattenedCollaborationRalplanFixture(cwd);
+      const bash = (command: string) => dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: sessionId,
+        thread_id: leaderThreadId,
+        tool_name: "Bash",
+        tool_input: { command },
+      }, { cwd });
+
+      assert.equal((await bash("omx cancel")).outputJson, null);
+      assert.equal((await bash("omx cancel --force")).outputJson, null);
+      assert.equal((await bash("FOO=bar omx cancel --force")).outputJson, null);
+
+      const chained = await bash("omx cancel --force && rm -rf x");
+      assert.equal(chained.outputJson?.decision, "block");
+
+      const unknownFlag = await bash("omx cancel --json");
+      assert.equal(unknownFlag.outputJson?.decision, "block");
+
+      for (const [label, command] of [
+        ["path override", "PATH=/tmp/attacker omx cancel"],
+        ["node preload override", "NODE_OPTIONS=--require=./payload.cjs omx cancel"],
+        ["path-qualified impostor", "/tmp/omx cancel --force"],
+        ["relative-path impostor", "./omx cancel"],
+        ["quoted pseudo-assignment", "'X=./payload' omx cancel"],
+        ["escaped pseudo-assignment", "X\\=./payload omx cancel"],
+        ["omx root override", "OMX_ROOT=/tmp/other omx cancel"],
+        ["omx state root override", "OMX_STATE_ROOT=/tmp/other omx cancel"],
+        ["omx team state root override", "OMX_TEAM_STATE_ROOT=/tmp/other omx cancel"],
+        ["omx session override", "OMX_SESSION_ID=other-session omx cancel"],
+        ["quoted executable", "\"omx\" cancel"],
+        ["semicolon operator in assignment", "FOO=bar;./payload omx cancel"],
+        ["command substitution in assignment", "FOO=$(./payload) omx cancel"],
+        ["backtick substitution in assignment", "FOO=`./payload` omx cancel"],
+        ["redirection in assignment", "FOO=bar>src/pwned omx cancel"],
+        ["and-operator in assignment", "FOO=bar&&./payload omx cancel"],
+        ["uppercase executable", "OMX cancel"],
+        ["unicode nbsp separator", "omx\u00a0cancel"],
+        ["newline between words", "omx\ncancel"],
+      ] as const) {
+        const impostor = await bash(command);
+        assert.equal(impostor.outputJson?.decision, "block", label);
+      }
+
+      // The direct-cancel scanner also rejects BOM and CR byte forms, so these
+      // never receive the cancellation exemption. They remain observable as
+      // ordinary unrecognized Bash invocations: the generic write-intent path
+      // sees no mutation in a nonexistent `\ufeffomx` executable or a
+      // `cancel\r` argument, which is the standard posture for unknown
+      // commands and not a cancellation authorization.
+      for (const [label, command] of [
+        ["byte-order-mark prefix", "\ufeffomx cancel"],
+        ["carriage-return suffix", "omx cancel\r"],
+      ] as const) {
+        const unrecognized = await bash(command);
+        assert.equal(unrecognized.outputJson, null, label);
+      }
+
+      const stateClear = await bash("omx state clear --force --mode ralplan --json");
+      assert.equal(stateClear.outputJson?.decision, "block");
+      assert.match(String(stateClear.outputJson?.reason ?? ""), /Autopilot planning is active \(phase: ralplan\)/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not persist native blockers from structured failures on unrelated tools", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-unrelated-structured-failure-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -21090,23 +21090,15 @@ PY`,
         ["uppercase executable", "OMX cancel"],
         ["unicode nbsp separator", "omx\u00a0cancel"],
         ["newline between words", "omx\ncancel"],
+        // Byte-form lookalikes: the raw payload command is not byte-identical
+        // to the trim-normalized command, so the direct-cancel exemption can
+        // never fire and the omx-mutation analysis denies the command. This
+        // asserts observable denial, not merely failure of one helper.
+        ["byte-order-mark lookalike executable", "\ufeffomx cancel"],
+        ["carriage-return suffix lookalike", "omx cancel\r"],
       ] as const) {
         const impostor = await bash(command);
         assert.equal(impostor.outputJson?.decision, "block", label);
-      }
-
-      // The direct-cancel scanner also rejects BOM and CR byte forms, so these
-      // never receive the cancellation exemption. They remain observable as
-      // ordinary unrecognized Bash invocations: the generic write-intent path
-      // sees no mutation in a nonexistent `\ufeffomx` executable or a
-      // `cancel\r` argument, which is the standard posture for unknown
-      // commands and not a cancellation authorization.
-      for (const [label, command] of [
-        ["byte-order-mark prefix", "\ufeffomx cancel"],
-        ["carriage-return suffix", "omx cancel\r"],
-      ] as const) {
-        const unrecognized = await bash(command);
-        assert.equal(unrecognized.outputJson, null, label);
       }
 
       const stateClear = await bash("omx state clear --force --mode ralplan --json");
@@ -31468,6 +31460,9 @@ PY`,
         ["path-qualified impostor", "/tmp/omx cancel --force"],
         ["chained cancellation", "omx cancel --force && rm -rf x"],
         ["omx root override", "OMX_ROOT=/tmp/other omx cancel"],
+        ["byte-order-mark lookalike executable", "\ufeffomx cancel"],
+        ["carriage-return suffix lookalike", "omx cancel\r"],
+        ["unicode nbsp separator", "omx\u00a0cancel"],
       ] as const) {
         const impostor = await bash(command);
         assert.equal(impostor.outputJson?.decision, "block", label);

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -8765,13 +8765,40 @@ function isAllowedGhReadOnlyCommand(command: string): boolean {
 function isAllowedDeepInterviewCommandSpecificBash(
   payload: CodexHookPayload,
   command: string,
+  cwd = process.cwd(),
 ): boolean {
   const questionClassification = classifyOmxQuestionPreToolUse(command, payload);
   if (questionClassification.kind === "allowed") return true;
-  return (readPreToolUseRawCommand(payload) === command && isDirectOmxCancelCommand(command))
-    || isAllowedOmxReadOnlyCommand(command)
+  // A command shaped like direct cancellation must never fall through to a
+  // generic allowance: when the trusted execution context cannot be proven,
+  // the exemption denies rather than degrading to the ordinary benign path.
+  if (readPreToolUseRawCommand(payload) === command && isDirectOmxCancelCommand(command)) {
+    return directOmxCancelCommandHasTrustedExecutionContext(command, cwd);
+  }
+  return isAllowedOmxReadOnlyCommand(command)
     || isAllowedGhReadOnlyCommand(command)
     || isAllowedVersionProbeCommand(command);
+}
+
+// The direct-cancel exemption authorizes a state-changing recovery command
+// ahead of the normal mutation analysis, so it must independently prove the
+// execution context cannot substitute different code for the validated text:
+// no unsafe inherited Bash startup (`BASH_ENV`) or conductor shell state
+// (imported handlers, unsafe options, untrusted absolute commands), no
+// imported `omx` shell function shadow, no inherited Node loader/output
+// overrides, and no command-resolution/runtime environment assignments. This
+// mirrors the established conductor/state-transport safety model instead of
+// inventing a parallel one.
+const DIRECT_OMX_CANCEL_UNSAFE_INHERITED_ENV_NAMES = [
+  "NODE_OPTIONS",
+  "NODE_EXTRA_CA_CERTS",
+];
+
+function directOmxCancelCommandHasTrustedExecutionContext(command: string, cwd: string): boolean {
+  if (commandHasUnsafeConductorShellState(command, cwd)) return false;
+  if (safeString(process.env["BASH_FUNC_omx%%"]).trim() !== "") return false;
+  if (DIRECT_OMX_CANCEL_UNSAFE_INHERITED_ENV_NAMES.some((name) => safeString(process.env[name]).trim() !== "")) return false;
+  return !commandHasUnsafeLeadingRuntimeEnvironment(command);
 }
 
 function isCommandResolutionSensitiveEnvironmentName(name: string): boolean {
@@ -8814,7 +8841,7 @@ function isAllowedDeepInterviewBashWrite(
     // compound/redirect/substitution form is denied so it cannot smuggle a mutation.
     return questionClassification.kind === "allowed" && isSingleLiteralShellInvocation(command);
   }
-  if (payload && isAllowedDeepInterviewCommandSpecificBash(payload, command)) return true;
+  if (payload && isAllowedDeepInterviewCommandSpecificBash(payload, command, cwd)) return true;
   if (sourcesFileWrittenEarlierInSameCommand(cwd, command)) return false;
   const stateWriteOperations = collectOmxStateCommandOperations(command, "write");
   const hasUnsafeRuntimeStateWrite = (words: string[]): boolean => {
@@ -8975,7 +9002,9 @@ function isAllowedRalplanBashWrite(
   command: string,
   activeState: Record<string, unknown>,
   sessionId: string,
-  rawCommand = command,
+  // Authorizing evaluators must receive the untrimmed payload command
+  // explicitly; only diagnostic callers may reuse the analyzed command here.
+  rawCommand: string,
 ): boolean {
   // Session-scoped cancellation is the owning session's documented recovery
   // surface: it terminalizes workflow state without touching planning
@@ -8985,7 +9014,9 @@ function isAllowedRalplanBashWrite(
   // is byte-identical to the analyzed command, so neither a presented
   // cancellation nor a lossy normalization seam can smuggle a different
   // executable, preload code, or redirect a state tree.
-  if (rawCommand === command && isDirectOmxCancelCommand(command, { allowForce: true })) return true;
+  if (rawCommand === command && isDirectOmxCancelCommand(command, { allowForce: true })) {
+    return directOmxCancelCommandHasTrustedExecutionContext(command, cwd);
+  }
   const beadsCommand = classifyRalplanBeadsMetadataCommand(cwd, command);
   const targets = extractDeepInterviewCommandWriteTargets(command);
   const hasAllowedTargets = targets.length > 0
@@ -18085,7 +18116,9 @@ function evaluateConductorBashWrite(
   depth = 0,
   authoritativeSessionId = "",
   policyCwd = cwd,
-  rawCommand = command,
+  // Authorizing evaluators must receive the untrimmed payload command
+  // explicitly; only diagnostic callers may reuse the analyzed command here.
+  rawCommand: string,
 ): { allowed: boolean; blockedDetail?: string } {
   // Session-scoped cancellation is the owning session's documented recovery
   // surface across planning workflows (parity with the ralplan/deep-interview
@@ -18094,7 +18127,11 @@ function evaluateConductorBashWrite(
   // the analyzed command, so neither a presented cancellation nor a lossy
   // normalization seam can smuggle a different executable, preload code, or
   // redirect a state tree.
-  if (rawCommand === command && isDirectOmxCancelCommand(command, { allowForce: true })) return { allowed: true };
+  if (rawCommand === command && isDirectOmxCancelCommand(command, { allowForce: true })) {
+    return directOmxCancelCommandHasTrustedExecutionContext(command, cwd)
+      ? { allowed: true }
+      : { allowed: false, blockedDetail: "direct cancellation execution context is not trusted: inherited Bash startup, imported omx function, or Node loader environment overrides present" };
+  }
   const commandWithHeredocBodies = normalizeShellLineContinuations(command);
   const normalizedCommand = stripHeredocBodiesForCommandScan(commandWithHeredocBodies);
   if (authoritativeSessionId && !conductorStateWriteTransportIsBoundToActiveSession(commandWithHeredocBodies, authoritativeSessionId, policyCwd)) {
@@ -18282,7 +18319,7 @@ function isExactConductorMetadataRoot(cwd: string, target: string): boolean {
 
 
 function buildConductorBashBlockedDetail(cwd: string, command: string): string {
-  return evaluateConductorBashWrite(cwd, command).blockedDetail
+  return evaluateConductorBashWrite(cwd, command, 0, "", cwd, command).blockedDetail
     ?? "Bash write intent target <unresolved>; Main-root Conductor may write only workflow state/ledger/mailbox/handoff metadata";
 }
 

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3706,11 +3706,18 @@ function isFreshNativeSubagentCapacityBlocker(
   return !blockerSessionId || !payloadSessionId || blockerSessionId === payloadSessionId;
 }
 
+// Batched payloads embed recipient names inside serialized input, so the
+// substring scan must also recognize the flattened close_agent delivery form
+// (`collaborationclose_agent`); dotted forms already carry a word boundary
+// before close_agent. This is a recognition heuristic for the capacity close
+// guard only: matching here can only make the guard block, never authorize.
+const NATIVE_CLOSE_AGENT_REQUEST_PATTERN = /\b(?:close_agent|collaborationclose_agent)\b/i;
+
 function inputContainsCloseAgentRequest(value: unknown): boolean {
-  if (typeof value === "string") return /\bclose_agent\b/i.test(value);
+  if (typeof value === "string") return NATIVE_CLOSE_AGENT_REQUEST_PATTERN.test(value);
   if (!value || typeof value !== "object") return false;
   try {
-    return /\bclose_agent\b/i.test(JSON.stringify(value));
+    return NATIVE_CLOSE_AGENT_REQUEST_PATTERN.test(JSON.stringify(value));
   } catch {
     return false;
   }
@@ -8680,40 +8687,21 @@ function skipLiteralLeadingAssignments(words: string[]): number {
 }
 
 // Direct cancellation is recognized from the RAW command string with a
-// deliberately tiny ASCII grammar, not from normalized shell tokens:
-// quote/escape provenance decides whether a leading word is an assignment or
-// the executable, so a quoted or escaped pseudo-assignment such as
-// 'X=./payload' must never be skipped as a benign prefix, and shell control
-// grammar (`;`, `&`, `|`, redirection, `$()`, backticks) inside an assignment
-// value must never be skipped either. Separators are ASCII space/tab only and
-// the executable must be exactly lowercase `omx`, so the scanner's word
-// boundaries and executable identity are the shell's (no ECMAScript \s
-// Unicode whitespace, BOM, CR/LF, or case folding). OMX root/session
-// selectors are rejected so a presented cancellation cannot be redirected at
-// a different state tree.
-const DIRECT_OMX_CANCEL_LEADING_ASSIGNMENT_PATTERN = /^([A-Za-z_][A-Za-z0-9_]*)=[A-Za-z0-9_\-.,:\/+@%=]+$/;
-const DIRECT_OMX_CANCEL_REJECTED_ASSIGNMENT_NAMES = new Set([
-  "omx_root",
-  "omx_state_root",
-  "omx_team_state_root",
-  "omx_session_id",
-]);
-
+// deliberately tiny ASCII grammar: exactly `omx cancel` (plus the ralplan-only
+// `--force`) with optional ASCII space/tab padding. No leading environment
+// assignments are accepted at all — runtime startup/configuration variables
+// are an open-ended namespace (PATH, NODE_OPTIONS, OPENSSL_CONF, ...) and a
+// denylist cannot prove the invoked program is the unmodified OMX
+// cancellation path. No quotes, backslashes, shell operators, path-qualified
+// or case-folded executables, and no CR/LF/NUL/BOM/NBSP/Unicode whitespace:
+// the scanner's word boundaries and executable identity are exactly the
+// shell's, so a presented cancellation cannot smuggle a different executable,
+// preload code, or redirect a state tree.
 function isDirectOmxCancelCommand(command: string, options: { allowForce?: boolean } = {}): boolean {
-  // ASCII horizontal whitespace and printable characters only: no CR/LF/NUL,
-  // no BOM/NBSP/Unicode whitespace, no case-folded executable spelling.
   if (!/^[\x09\x20-\x7E]*$/.test(command)) return false;
   const words = command.replace(/^[ \t]+|[ \t]+$/g, "").split(/[ \t]+/).filter(Boolean);
-  let index = 0;
-  while (index < words.length) {
-    const assignment = DIRECT_OMX_CANCEL_LEADING_ASSIGNMENT_PATTERN.exec(words[index] ?? "");
-    if (!assignment) break;
-    if (DIRECT_OMX_CANCEL_REJECTED_ASSIGNMENT_NAMES.has((assignment[1] ?? "").toLowerCase())) return false;
-    index += 1;
-  }
-  const rest = words.slice(index);
-  if (rest[0] !== "omx" || rest[1] !== "cancel") return false;
-  const args = rest.slice(2);
+  if (words[0] !== "omx" || words[1] !== "cancel") return false;
+  const args = words.slice(2);
   return args.length === 0 || (options.allowForce === true && args.length === 1 && args[0] === "--force");
 }
 
@@ -8979,11 +8967,10 @@ function isAllowedRalplanBashWrite(
   // Session-scoped cancellation is the owning session's documented recovery
   // surface: it terminalizes workflow state without touching planning
   // artifacts, so it stays available while ralplan is active (parity with the
-  // deep-interview boundary). The allow is limited to the bare `omx` token and
-  // rejects command-resolution/runtime environment overrides so a presented
-  // cancellation cannot smuggle a different executable or preload code.
-  if (isDirectOmxCancelCommand(command, { allowForce: true })
-    && !commandHasUnsafeLeadingRuntimeEnvironment(command)) return true;
+  // deep-interview boundary). The allow admits only the exact bare
+  // `omx cancel [--force]` invocation, so a presented cancellation cannot
+  // smuggle a different executable, preload code, or redirect a state tree.
+  if (isDirectOmxCancelCommand(command, { allowForce: true })) return true;
   const beadsCommand = classifyRalplanBeadsMetadataCommand(cwd, command);
   const targets = extractDeepInterviewCommandWriteTargets(command);
   const hasAllowedTargets = targets.length > 0
@@ -18084,6 +18071,12 @@ function evaluateConductorBashWrite(
   authoritativeSessionId = "",
   policyCwd = cwd,
 ): { allowed: boolean; blockedDetail?: string } {
+  // Session-scoped cancellation is the owning session's documented recovery
+  // surface across planning workflows (parity with the ralplan/deep-interview
+  // boundaries). The allow admits only the exact bare `omx cancel [--force]`
+  // invocation, so a presented cancellation cannot smuggle a different
+  // executable, preload code, or redirect a state tree.
+  if (isDirectOmxCancelCommand(command, { allowForce: true })) return { allowed: true };
   const commandWithHeredocBodies = normalizeShellLineContinuations(command);
   const normalizedCommand = stripHeredocBodiesForCommandScan(commandWithHeredocBodies);
   if (authoritativeSessionId && !conductorStateWriteTransportIsBoundToActiveSession(commandWithHeredocBodies, authoritativeSessionId, policyCwd)) {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -133,6 +133,7 @@ import {
   authorizeConductorAction,
   buildRoleRoutingUnavailableGuidance,
   buildUnsupportedNativeSubagentGuidance,
+  canonicalizeNativeCollaborationToolName,
   classifyConductorArtifactKind,
   isNativeSubagentSpawnToolName,
   isRoleRoutingUnavailableEvidence,
@@ -3716,7 +3717,7 @@ function inputContainsCloseAgentRequest(value: unknown): boolean {
 }
 
 function isCloseAgentToolUse(payload: CodexHookPayload): boolean {
-  const toolName = safeString(payload.tool_name).trim();
+  const toolName = canonicalizeNativeCollaborationToolName(safeString(payload.tool_name).trim());
   if (/\bclose_agent\b/i.test(toolName)) return true;
   if (/multi_tool_use\.parallel/i.test(toolName) && inputContainsCloseAgentRequest(payload.tool_input)) return true;
   return inputContainsCloseAgentRequest(payload.tool_input) && /multi_agent|agent|tool_use/i.test(toolName);
@@ -4886,10 +4887,12 @@ function classifyPreToolUseMutationTransport(
   if (READ_ONLY_PRETOOLUSE_TOOL_NAMES.has(toolName) || READ_ONLY_PRETOOLUSE_MCP_TOOL_NAMES.has(toolName)) {
     return "read-only";
   }
+  const canonicalToolName = canonicalizeNativeCollaborationToolName(toolName);
+
   if (
-    CONDUCTOR_ORCHESTRATION_TOOL_NAMES.has(toolName)
-    || toolName.startsWith("collaboration.")
-    || toolName.startsWith("multi_agent_v1.")
+    CONDUCTOR_ORCHESTRATION_TOOL_NAMES.has(canonicalToolName)
+    || canonicalToolName.startsWith("collaboration.")
+    || canonicalToolName.startsWith("multi_agent_v1.")
     || toolName.startsWith("mcp__omx_team__")
     || toolName.startsWith("mcp__omx_ultragoal__")
   ) {
@@ -8676,13 +8679,42 @@ function skipLiteralLeadingAssignments(words: string[]): number {
   return index;
 }
 
-function isDirectOmxCancelCommand(command: string): boolean {
-  if (!isSingleLiteralShellInvocation(command)) return false;
-  const words = literalInvocationWords(command);
-  const index = skipLiteralLeadingAssignments(words);
-  return commandNameFromShellWord(words[index] ?? "") === "omx"
-    && words[index + 1] === "cancel"
-    && words.slice(index + 2).every((word) => word === "");
+// Direct cancellation is recognized from the RAW command string with a
+// deliberately tiny ASCII grammar, not from normalized shell tokens:
+// quote/escape provenance decides whether a leading word is an assignment or
+// the executable, so a quoted or escaped pseudo-assignment such as
+// 'X=./payload' must never be skipped as a benign prefix, and shell control
+// grammar (`;`, `&`, `|`, redirection, `$()`, backticks) inside an assignment
+// value must never be skipped either. Separators are ASCII space/tab only and
+// the executable must be exactly lowercase `omx`, so the scanner's word
+// boundaries and executable identity are the shell's (no ECMAScript \s
+// Unicode whitespace, BOM, CR/LF, or case folding). OMX root/session
+// selectors are rejected so a presented cancellation cannot be redirected at
+// a different state tree.
+const DIRECT_OMX_CANCEL_LEADING_ASSIGNMENT_PATTERN = /^([A-Za-z_][A-Za-z0-9_]*)=[A-Za-z0-9_\-.,:\/+@%=]+$/;
+const DIRECT_OMX_CANCEL_REJECTED_ASSIGNMENT_NAMES = new Set([
+  "omx_root",
+  "omx_state_root",
+  "omx_team_state_root",
+  "omx_session_id",
+]);
+
+function isDirectOmxCancelCommand(command: string, options: { allowForce?: boolean } = {}): boolean {
+  // ASCII horizontal whitespace and printable characters only: no CR/LF/NUL,
+  // no BOM/NBSP/Unicode whitespace, no case-folded executable spelling.
+  if (!/^[\x09\x20-\x7E]*$/.test(command)) return false;
+  const words = command.replace(/^[ \t]+|[ \t]+$/g, "").split(/[ \t]+/).filter(Boolean);
+  let index = 0;
+  while (index < words.length) {
+    const assignment = DIRECT_OMX_CANCEL_LEADING_ASSIGNMENT_PATTERN.exec(words[index] ?? "");
+    if (!assignment) break;
+    if (DIRECT_OMX_CANCEL_REJECTED_ASSIGNMENT_NAMES.has((assignment[1] ?? "").toLowerCase())) return false;
+    index += 1;
+  }
+  const rest = words.slice(index);
+  if (rest[0] !== "omx" || rest[1] !== "cancel") return false;
+  const args = rest.slice(2);
+  return args.length === 0 || (options.allowForce === true && args.length === 1 && args[0] === "--force");
 }
 
 function isAllowedOmxCleanupDryRunCommand(command: string): boolean {
@@ -8944,6 +8976,14 @@ function isAllowedRalplanBashWrite(
   activeState: Record<string, unknown>,
   sessionId: string,
 ): boolean {
+  // Session-scoped cancellation is the owning session's documented recovery
+  // surface: it terminalizes workflow state without touching planning
+  // artifacts, so it stays available while ralplan is active (parity with the
+  // deep-interview boundary). The allow is limited to the bare `omx` token and
+  // rejects command-resolution/runtime environment overrides so a presented
+  // cancellation cannot smuggle a different executable or preload code.
+  if (isDirectOmxCancelCommand(command, { allowForce: true })
+    && !commandHasUnsafeLeadingRuntimeEnvironment(command)) return true;
   const beadsCommand = classifyRalplanBeadsMetadataCommand(cwd, command);
   const targets = extractDeepInterviewCommandWriteTargets(command);
   const hasAllowedTargets = targets.length > 0

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -8785,20 +8785,27 @@ function isAllowedDeepInterviewCommandSpecificBash(
 // execution context cannot substitute different code for the validated text:
 // no unsafe inherited Bash startup (`BASH_ENV`) or conductor shell state
 // (imported handlers, unsafe options, untrusted absolute commands), no
-// imported `omx` shell function shadow, no inherited Node loader/output
-// overrides, and no command-resolution/runtime environment assignments. This
-// mirrors the established conductor/state-transport safety model instead of
-// inventing a parallel one.
+// imported `omx` shell function shadow, no inherited Node loader/OpenSSL
+// startup overrides, no inherited dynamic-loader controls, no
+// command-resolution/runtime environment assignments — and the bare `omx`
+// token must resolve to the hook package's own canonical CLI under the
+// inherited PATH, never to a PATH-shadowed or repository lookalike
+// executable. This reuses the established conductor executable-resolution
+// and runtime-startup safety model instead of inventing a parallel one.
 const DIRECT_OMX_CANCEL_UNSAFE_INHERITED_ENV_NAMES = [
   "NODE_OPTIONS",
   "NODE_EXTRA_CA_CERTS",
+  "OPENSSL_CONF",
 ];
 
 function directOmxCancelCommandHasTrustedExecutionContext(command: string, cwd: string): boolean {
   if (commandHasUnsafeConductorShellState(command, cwd)) return false;
   if (safeString(process.env["BASH_FUNC_omx%%"]).trim() !== "") return false;
   if (DIRECT_OMX_CANCEL_UNSAFE_INHERITED_ENV_NAMES.some((name) => safeString(process.env[name]).trim() !== "")) return false;
-  return !commandHasUnsafeLeadingRuntimeEnvironment(command);
+  if (commandHasUnsafeDynamicLoaderEnvironment(command)) return false;
+  if (commandHasUnsafeLeadingRuntimeEnvironment(command)) return false;
+  const words = tokenizeConductorShellWords(command);
+  return conductorCommandResolvesTrustedPackageCli(words, 0, 0, createConductorRuntimeShellState(cwd), cwd);
 }
 
 function isCommandResolutionSensitiveEnvironmentName(name: string): boolean {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -4193,6 +4193,15 @@ function readPreToolUseCommand(payload: CodexHookPayload): string {
   return safeString(toolInput.command).trim();
 }
 
+// Authorization decisions whose security contract depends on exact bytes
+// (currently only the direct `omx cancel` exemption) must compare against the
+// unmodified command string: ECMAScript trim() removes BOM/NBSP/CR and other
+// non-shell whitespace, so a trimmed command can normalize a different
+// executable name (e.g. `\uFEFFomx`) into the exact `omx` token.
+function readPreToolUseRawCommand(payload: CodexHookPayload): string {
+  return safeString(safeObject(payload.tool_input).command);
+}
+
 function readPreToolUsePathCandidates(payload: CodexHookPayload): string[] {
   const input = safeObject(payload.tool_input);
   const candidates = [
@@ -8687,16 +8696,19 @@ function skipLiteralLeadingAssignments(words: string[]): number {
 }
 
 // Direct cancellation is recognized from the RAW command string with a
-// deliberately tiny ASCII grammar: exactly `omx cancel` (plus the ralplan-only
-// `--force`) with optional ASCII space/tab padding. No leading environment
-// assignments are accepted at all — runtime startup/configuration variables
-// are an open-ended namespace (PATH, NODE_OPTIONS, OPENSSL_CONF, ...) and a
-// denylist cannot prove the invoked program is the unmodified OMX
-// cancellation path. No quotes, backslashes, shell operators, path-qualified
-// or case-folded executables, and no CR/LF/NUL/BOM/NBSP/Unicode whitespace:
-// the scanner's word boundaries and executable identity are exactly the
-// shell's, so a presented cancellation cannot smuggle a different executable,
-// preload code, or redirect a state tree.
+// deliberately tiny ASCII grammar: exactly `omx cancel` (plus `--force` only
+// at the ralplan/Conductor callsites; deep-interview stays plain-cancel) with
+// optional ASCII space/tab padding. No leading environment assignments are
+// accepted at all — runtime startup/configuration variables are an open-ended
+// namespace (PATH, NODE_OPTIONS, OPENSSL_CONF, ...) and a denylist cannot
+// prove the invoked program is the unmodified OMX cancellation path. No
+// quotes, backslashes, shell operators, path-qualified or case-folded
+// executables, and no CR/LF/NUL/BOM/NBSP/Unicode whitespace: the scanner's
+// word boundaries and executable identity are exactly the shell's, so a
+// presented cancellation cannot smuggle a different executable, preload code,
+// or redirect a state tree. Callers must also prove the raw payload command
+// equals the analyzed command, because a lossy trim seam would otherwise
+// normalize a lookalike executable (e.g. `\uFEFFomx`) into the exact token.
 function isDirectOmxCancelCommand(command: string, options: { allowForce?: boolean } = {}): boolean {
   if (!/^[\x09\x20-\x7E]*$/.test(command)) return false;
   const words = command.replace(/^[ \t]+|[ \t]+$/g, "").split(/[ \t]+/).filter(Boolean);
@@ -8756,7 +8768,7 @@ function isAllowedDeepInterviewCommandSpecificBash(
 ): boolean {
   const questionClassification = classifyOmxQuestionPreToolUse(command, payload);
   if (questionClassification.kind === "allowed") return true;
-  return isDirectOmxCancelCommand(command)
+  return (readPreToolUseRawCommand(payload) === command && isDirectOmxCancelCommand(command))
     || isAllowedOmxReadOnlyCommand(command)
     || isAllowedGhReadOnlyCommand(command)
     || isAllowedVersionProbeCommand(command);
@@ -8963,14 +8975,17 @@ function isAllowedRalplanBashWrite(
   command: string,
   activeState: Record<string, unknown>,
   sessionId: string,
+  rawCommand = command,
 ): boolean {
   // Session-scoped cancellation is the owning session's documented recovery
   // surface: it terminalizes workflow state without touching planning
   // artifacts, so it stays available while ralplan is active (parity with the
   // deep-interview boundary). The allow admits only the exact bare
-  // `omx cancel [--force]` invocation, so a presented cancellation cannot
-  // smuggle a different executable, preload code, or redirect a state tree.
-  if (isDirectOmxCancelCommand(command, { allowForce: true })) return true;
+  // `omx cancel [--force]` invocation, and only when the raw payload command
+  // is byte-identical to the analyzed command, so neither a presented
+  // cancellation nor a lossy normalization seam can smuggle a different
+  // executable, preload code, or redirect a state tree.
+  if (rawCommand === command && isDirectOmxCancelCommand(command, { allowForce: true })) return true;
   const beadsCommand = classifyRalplanBeadsMetadataCommand(cwd, command);
   const targets = extractDeepInterviewCommandWriteTargets(command);
   const hasAllowedTargets = targets.length > 0
@@ -9229,7 +9244,7 @@ async function buildRalplanPreToolUseBoundaryOutput(
   let blockedDetail = "implementation/write tools are blocked until an explicit execution handoff workflow is activated";
 
   if (toolName === "Bash") {
-    blocked = !isAllowedRalplanBashWrite(cwd, command, activeState, sessionId);
+    blocked = !isAllowedRalplanBashWrite(cwd, command, activeState, sessionId, readPreToolUseRawCommand(payload));
     if (blocked) {
       blockedDetail = buildRalplanBashBlockedDetail(cwd, command, sessionId);
     }
@@ -9499,7 +9514,7 @@ async function buildPlanningRootPointerConflictPreToolUseOutput(
   if (toolName === "Bash") {
     const command = readPreToolUseCommand(payload);
     blocked = commandEndsPlanningPhase(cwd, command)
-      || !isAllowedRalplanBashWrite(cwd, command, ralplanState, rootSessionId);
+      || !isAllowedRalplanBashWrite(cwd, command, ralplanState, rootSessionId, readPreToolUseRawCommand(payload));
   } else if (
     mutationTransport === "state"
     && (
@@ -18070,13 +18085,16 @@ function evaluateConductorBashWrite(
   depth = 0,
   authoritativeSessionId = "",
   policyCwd = cwd,
+  rawCommand = command,
 ): { allowed: boolean; blockedDetail?: string } {
   // Session-scoped cancellation is the owning session's documented recovery
   // surface across planning workflows (parity with the ralplan/deep-interview
   // boundaries). The allow admits only the exact bare `omx cancel [--force]`
-  // invocation, so a presented cancellation cannot smuggle a different
-  // executable, preload code, or redirect a state tree.
-  if (isDirectOmxCancelCommand(command, { allowForce: true })) return { allowed: true };
+  // invocation, and only when the raw payload command is byte-identical to
+  // the analyzed command, so neither a presented cancellation nor a lossy
+  // normalization seam can smuggle a different executable, preload code, or
+  // redirect a state tree.
+  if (rawCommand === command && isDirectOmxCancelCommand(command, { allowForce: true })) return { allowed: true };
   const commandWithHeredocBodies = normalizeShellLineContinuations(command);
   const normalizedCommand = stripHeredocBodiesForCommandScan(commandWithHeredocBodies);
   if (authoritativeSessionId && !conductorStateWriteTransportIsBoundToActiveSession(commandWithHeredocBodies, authoritativeSessionId, policyCwd)) {
@@ -18355,7 +18373,7 @@ export async function buildConductorPreToolUseWriteGuardOutput(
 
   if (toolName === "Bash") {
     const shellMutations = extractConductorBashMutations(command, cwd, policyCwd);
-    const bashEvaluation = evaluateConductorBashWrite(cwd, command, 0, sessionId, policyCwd);
+    const bashEvaluation = evaluateConductorBashWrite(cwd, command, 0, sessionId, policyCwd, readPreToolUseRawCommand(payload));
     blocked = !bashEvaluation.allowed;
     const canonicalStateCommand = canonicalizeOmxStateTransportCommand(command);
     const bashStateOperations = collectOmxStateCommandOperations(canonicalStateCommand, "write");

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -8786,10 +8786,11 @@ function isAllowedDeepInterviewCommandSpecificBash(
 // no unsafe inherited Bash startup (`BASH_ENV`) or conductor shell state
 // (imported handlers, unsafe options, untrusted absolute commands), no
 // imported `omx` shell function shadow, no inherited Node loader/OpenSSL
-// startup overrides, no inherited dynamic-loader controls, no
-// command-resolution/runtime environment assignments — and the bare `omx`
-// token must resolve to the hook package's own canonical CLI under the
-// inherited PATH, never to a PATH-shadowed or repository lookalike
+// startup overrides, no inherited Node filesystem-output controls (coverage,
+// compile cache, report/redirect destinations), no inherited dynamic-loader
+// controls, no command-resolution/runtime environment assignments — and the
+// bare `omx` token must resolve to the hook package's own canonical CLI
+// under the inherited PATH, never to a PATH-shadowed or repository lookalike
 // executable. This reuses the established conductor executable-resolution
 // and runtime-startup safety model instead of inventing a parallel one.
 const DIRECT_OMX_CANCEL_UNSAFE_INHERITED_ENV_NAMES = [
@@ -8801,7 +8802,8 @@ const DIRECT_OMX_CANCEL_UNSAFE_INHERITED_ENV_NAMES = [
 function directOmxCancelCommandHasTrustedExecutionContext(command: string, cwd: string): boolean {
   if (commandHasUnsafeConductorShellState(command, cwd)) return false;
   if (safeString(process.env["BASH_FUNC_omx%%"]).trim() !== "") return false;
-  if (DIRECT_OMX_CANCEL_UNSAFE_INHERITED_ENV_NAMES.some((name) => safeString(process.env[name]).trim() !== "")) return false;
+  const unsafeInheritedNames = [...DIRECT_OMX_CANCEL_UNSAFE_INHERITED_ENV_NAMES, ...CONDUCTOR_NODE_OUTPUT_ENVIRONMENT_NAMES];
+  if (unsafeInheritedNames.some((name) => safeString(process.env[name]).trim() !== "")) return false;
   if (commandHasUnsafeDynamicLoaderEnvironment(command)) return false;
   if (commandHasUnsafeLeadingRuntimeEnvironment(command)) return false;
   const words = tokenizeConductorShellWords(command);


### PR DESCRIPTION
Fixes #3263.

## Problem

Codex CLI 0.145.0 can deliver known dotted collaboration tools with the namespace dot dropped (`collaboration.spawn_agent` -> `collaborationspawn_agent`). OMX 0.20.3 then classified those flattened names as unknown mutation transports and rejected them during active Ralplan, preventing typed Planner/Architect/Critic delegation and its consensus evidence. The owning session also could not recover: `omx cancel` / `omx cancel --force` were rejected at PreToolUse while Ralplan was active.

Reproduced against `origin/dev` (`299f31ad`) before the fix; acknowledgment with the full consumer map is on the issue.

## Fix

One conservative canonicalization seam, exactly as scoped in the report:

- `src/leader/contract.ts`: `canonicalizeNativeCollaborationToolName` — an exact seven-name flattened-to-dotted map (`spawn_agent`, `close_agent`, `list_agents`, `followup_task`, `wait_agent`, `send_message`, `interrupt_agent`). The shared spawn/result predicates canonicalize before matching, which covers capability detection (`availableToolsEvidence`), typed role extraction, result disposition, and capacity/support blocker recording through the existing call chain. Unknown flattened names pass through unchanged and stay fail-closed; the original received name is preserved for diagnostics and persisted blocker `tool_name`.
- `src/scripts/codex-native-hook.ts`: transport classification (`classifyPreToolUseMutationTransport`) and the capacity close guard (`isCloseAgentToolUse`) canonicalize through the same seam. No allowlist patching, no prefix matching, no broad renaming.
- Session-scoped Ralplan recovery: `omx cancel` / `omx cancel --force` are recognized as direct cancellation under active Ralplan through a strict raw ASCII grammar — bare `omx` token only, ASCII space/tab separators, operator/substitution-free assignment values, case-insensitive rejection of `OMX_ROOT`/`OMX_STATE_ROOT`/`OMX_TEAM_STATE_ROOT`/`OMX_SESSION_ID` selectors, plus the existing unsafe runtime environment check — so a presented cancellation cannot smuggle a different executable or redirect a state tree. Planning-state deactivation guards (`state_clear`, deactivation payloads) are unchanged.

## Blocker mapping (review rounds -> resolution)

Independent adversarial review ran four rounds against the frozen change set:

1. **Round 1 (major, fixed):** the new Ralplan cancel allow accepted `PATH=`/`NODE_OPTIONS=` leading assignments and path-qualified `omx` impostors -> bare-token requirement + unsafe-environment gate added.
2. **Round 2 (high+medium, fixed):** quoted/escaped pseudo-assignments (`'X=./payload' omx cancel`) bypassed assignment skipping, and OMX root/session selectors could redirect cancellation -> direct-cancel recognizer rewritten as a raw-string scanner with the four selectors rejected.
3. **Round 3 (high+medium, fixed):** shell operators/substitutions inside assignment values (`FOO=bar;./payload omx cancel`) and ECMAScript-vs-shell whitespace/executable identity (`OMX`, NBSP, BOM, CR/LF) -> strict ASCII grammar: exact lowercase `omx`, space/tab separators only, allowlisted assignment-value alphabet.
4. **Round 4:** `CLEAR` / `APPROVE`, zero findings, zero blockers.

## Verification (all on the final head)

- `npm run build` — green.
- `npm run check:no-unused` (tsc -p tsconfig.no-unused.json) — green.
- `npm run lint` (biome lint src, 775 files) — green.
- Focused: `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js dist/leader/__tests__/contract.test.js` — 588/588 + 19/19, including 4 new contract tests and 6 new hook tests (flattened transport parity, typed role extraction, blocker provenance with original `tool_name`, poison guards, close-agent capacity block, cancel recovery, fail-closed unknowns).
- Full suite: `npm test` (build + verify:native-agents + verify:plugin-bundle + full `test:node` + catalog check) — green, zero failures.
- Independent QA red-team (`/tmp/qa-3263/redteam-report.json`): 60/60 executed cases against current dist — canonicalizer exactness (near-miss, `__proto__`/case/whitespace variants), transport parity under active Ralplan and deep-interview, result dispositions, dotted/bare/`multi_agent_v1` regressions, and the full cancel impostor/operator/identity matrix.

## Out of scope (follow-up)

The pre-existing `skipLiteralLeadingAssignments` pattern in the other read-only command recognizers (`isAllowedOmxReadOnlyCommand`, etc.) shares the lossy-normalization class reviewed here; the direct-cancel path no longer depends on it. Flagged by review as a separate follow-up, not coupled to this PR.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*