### PR TITLE
fix(cli): tear down detached HUD on child exit

### DIFF
--- a/src/cli/__tests__/detached-leader-teardown.test.ts
+++ b/src/cli/__tests__/detached-leader-teardown.test.ts
@@ -1,0 +1,389 @@
+import assert from 'node:assert/strict';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { describe, it, type TestContext } from 'node:test';
+import {
+  applyDetachedTerminalExitStatus,
+  buildDetachedSessionBootstrapSteps,
+  publishDetachedReleaseMarker,
+  probeExactDetachedSessionExists,
+  resolveDetachedAttachExitStatus,
+} from '../index.js';
+import { isRealTmuxAvailable, tmuxSessionExists, withTempTmuxSession } from '../../team/__tests__/tmux-test-fixture.js';
+
+const TEST_TIMEOUT_MS = 45_000;
+const POLL_INTERVAL_MS = 50;
+const omxBin = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'dist', 'cli', 'omx.js');
+
+interface DetachedLeaderReport {
+  version: number;
+  kind: string;
+  nonce: string;
+  sessionId: string;
+  sessionName: string;
+  leaderPid: number;
+  finalized?: boolean;
+  exitStatus?: number;
+}
+
+interface DetachedHudAuthority {
+  paneId: string;
+  panePid: number;
+  sessionId: string;
+  windowId: string;
+  operationMarker: string;
+}
+
+function skipUnlessTmux(t: TestContext): boolean {
+  if (process.platform === 'win32') {
+    t.skip('detached tmux leader tests are not supported on win32');
+    return false;
+  }
+  if (isRealTmuxAvailable()) return true;
+  assert.equal(process.env.CI, undefined, 'CI must provide tmux for detached leader teardown regression tests');
+  t.skip('tmux is not installed');
+  return false;
+}
+
+async function poll<T>(description: string, predicate: () => Promise<T | undefined> | T | undefined, timeoutMs = TEST_TIMEOUT_MS): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await predicate();
+    if (result !== undefined) return result;
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+  throw new Error(`timed out waiting for ${description}`);
+}
+
+async function readReportWhen(path: string, predicate: (report: DetachedLeaderReport) => boolean): Promise<DetachedLeaderReport> {
+  return poll(`detached leader report at ${path}`, async () => {
+    try {
+      const report = JSON.parse(await readFile(path, 'utf-8')) as DetachedLeaderReport;
+      return predicate(report) ? report : undefined;
+    } catch {
+      return undefined;
+    }
+  });
+}
+
+function paneExists(fixture: { run: (args: string[]) => string }, paneId: string): boolean {
+  return fixture.run(['list-panes', '-a', '-F', '#{pane_id}']).split('\n').includes(paneId);
+}
+
+function assertProcessDead(pid: number): void {
+  assert.throws(
+    () => process.kill(pid, 0),
+    (error: unknown) => (error as NodeJS.ErrnoException).code === 'ESRCH',
+  );
+}
+
+async function startDetachedLeader(
+  fixture: {
+    run: (args: string[]) => string;
+  },
+  wd: string,
+  sessionName: string,
+  sessionId: string,
+  nonce: string,
+  fakeChild: string,
+): Promise<{ releaseMarkerPath: string; leaderPaneId: string; hud: DetachedHudAuthority }> {
+  const releaseMarkerPath = join(wd, `${sessionId}.${nonce}.release`);
+  const hudCmd = `${JSON.stringify(process.execPath)} ${JSON.stringify(omxBin)} hud --watch`;
+  const steps = buildDetachedSessionBootstrapSteps(
+    sessionName,
+    wd,
+    fakeChild,
+    hudCmd,
+    null,
+    undefined,
+    undefined,
+    false,
+    sessionId,
+    undefined,
+    undefined,
+    undefined,
+    process.env,
+    undefined,
+    undefined,
+    undefined,
+    releaseMarkerPath,
+    omxBin,
+  );
+  const newSession = steps.find((step) => step.name === 'new-session');
+  const tagSession = steps.find((step) => step.name === 'tag-session');
+  const splitHud = steps.find((step) => step.name === 'split-and-capture-hud-pane');
+  assert.ok(newSession);
+  assert.ok(tagSession);
+  assert.ok(splitHud);
+
+  newSession.args.splice(
+    -1,
+    0,
+    '-e', 'OMX_AUTO_UPDATE=0',
+    '-e', 'OMX_NOTIFY_FALLBACK=0',
+    '-e', 'OMX_HOOK_DERIVED_SIGNALS=0',
+  );
+  const leaderPaneId = fixture.run(newSession.args);
+  fixture.run(tagSession.args);
+
+  const operationMarker = randomUUID();
+  const splitArgs = [...splitHud.args];
+  splitArgs[splitArgs.length - 1] = `env OMX_DETACHED_HUD_OPERATION=${operationMarker} ${splitArgs.at(-1)}`;
+  const hudPaneId = fixture.run(splitArgs);
+  const [paneId, panePidRaw, hudSessionId, windowId] = fixture.run([
+    'display-message', '-p', '-t', hudPaneId, '#{pane_id}\t#{pane_pid}\t#{session_id}\t#{window_id}',
+  ]).split('\t');
+  const panePid = Number(panePidRaw);
+  assert.equal(paneId, hudPaneId);
+  assert.equal(Number.isSafeInteger(panePid) && panePid > 0, true);
+  assert.notEqual(windowId, '');
+
+  const ready = await readReportWhen(releaseMarkerPath, (report) => report.kind === 'ready');
+  assert.equal(ready.nonce, nonce);
+  assert.equal(ready.sessionId, sessionId);
+  assert.equal(ready.sessionName, sessionName);
+  assert.equal(Number.isSafeInteger(ready.leaderPid) && ready.leaderPid > 0, true);
+  const hud = { paneId, panePid, sessionId: hudSessionId, windowId, operationMarker };
+  publishDetachedReleaseMarker(releaseMarkerPath, nonce, sessionId, sessionName, ready.leaderPid, hud);
+
+  return { releaseMarkerPath, leaderPaneId, hud };
+}
+
+function writeChild(wd: string, body: string): string {
+  const path = join(wd, 'fake-codex.sh');
+  writeFileSync(path, `#!/bin/sh\n${body}\n`);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+describe('detached leader HUD teardown', () => {
+  it('tears down the proven HUD pane and session after a zero-status child exit', async (t) => {
+    if (!skipUnlessTmux(t)) return;
+    const wd = mkdtempSync(join(tmpdir(), 'omx-detached-leader-zero-'));
+    try {
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-detached-zero';
+        const sessionId = 'detached-zero-session';
+        const fakeChild = writeChild(wd, 'sleep 1\nexit 0');
+        const started = await startDetachedLeader(fixture, wd, sessionName, sessionId, 'zero-nonce', fakeChild);
+        const terminal = await readReportWhen(started.releaseMarkerPath, (report) => report.kind === 'terminal');
+        assert.equal(terminal.finalized, true);
+        assert.equal(terminal.exitStatus, 0);
+        await poll('leader pane removal', () => !paneExists(fixture, started.leaderPaneId) ? true : undefined);
+        await poll('HUD pane removal', () => !paneExists(fixture, started.hud.paneId) ? true : undefined);
+        await poll('leader session destruction', () => !tmuxSessionExists(sessionName, fixture.serverName) ? true : undefined);
+        assertProcessDead(started.hud.panePid);
+        assert.equal(fixture.sessionExists(), true);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('tears down the proven HUD pane and session after a nonzero child exit', async (t) => {
+    if (!skipUnlessTmux(t)) return;
+    const wd = mkdtempSync(join(tmpdir(), 'omx-detached-leader-nonzero-'));
+    try {
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-detached-nonzero';
+        const sessionId = 'detached-nonzero-session';
+        const fakeChild = writeChild(wd, 'sleep 1\nexit 7');
+        const started = await startDetachedLeader(fixture, wd, sessionName, sessionId, 'nonzero-nonce', fakeChild);
+        const terminal = await readReportWhen(started.releaseMarkerPath, (report) => report.kind === 'terminal');
+        assert.equal(terminal.finalized, true);
+        assert.equal(terminal.exitStatus, 7);
+        await poll('leader pane removal', () => !paneExists(fixture, started.leaderPaneId) ? true : undefined);
+        await poll('HUD pane removal', () => !paneExists(fixture, started.hud.paneId) ? true : undefined);
+        await poll('leader session destruction', () => !tmuxSessionExists(sessionName, fixture.serverName) ? true : undefined);
+        assertProcessDead(started.hud.panePid);
+        assert.equal(fixture.sessionExists(), true);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves the HUD pane and session after signal-derived child death', async (t) => {
+    if (!skipUnlessTmux(t)) return;
+    const wd = mkdtempSync(join(tmpdir(), 'omx-detached-leader-signal-'));
+    try {
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-detached-signal';
+        const sessionId = 'detached-signal-session';
+        // Signal the direct child process regardless of /bin/sh -c exec behavior:
+      // with exec-optimization $PPID is the leader (external-interrupt path);
+      // without it, $PPID is the wrapped /bin/sh child itself (outcome.signal path).
+      // Both are signal-derived exits where teardown must stay closed (exit 143).
+      const fakeChild = writeChild(wd, 'sleep 1\nkill -TERM $PPID\nsleep 30');
+        const started = await startDetachedLeader(fixture, wd, sessionName, sessionId, 'signal-nonce', fakeChild);
+        const terminal = await readReportWhen(started.releaseMarkerPath, (report) => report.kind === 'terminal');
+        assert.equal(terminal.finalized, true);
+        assert.equal(terminal.exitStatus, 143);
+        assert.equal(paneExists(fixture, started.hud.paneId), true);
+        assert.equal(tmuxSessionExists(sessionName, fixture.serverName), true);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('removes only the proven HUD pane while preserving a foreign pane in the leader session', async (t) => {
+    if (!skipUnlessTmux(t)) return;
+    const wd = mkdtempSync(join(tmpdir(), 'omx-detached-leader-foreign-'));
+    try {
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-detached-foreign';
+        const sessionId = 'detached-foreign-session';
+        const fakeChild = writeChild(wd, 'sleep 1\nexit 0');
+        const started = await startDetachedLeader(fixture, wd, sessionName, sessionId, 'foreign-nonce', fakeChild);
+        const foreignPaneId = fixture.run([
+          'split-window', '-d', '-P', '-F', '#{pane_id}', '-t', sessionName, '-c', wd, 'sleep 300',
+        ]);
+        const foreignPanePid = Number(fixture.run([
+          'display-message', '-p', '-t', foreignPaneId, '#{pane_pid}',
+        ]));
+        const terminal = await readReportWhen(started.releaseMarkerPath, (report) => report.kind === 'terminal');
+        assert.equal(terminal.exitStatus, 0);
+        await poll('leader pane removal', () => !paneExists(fixture, started.leaderPaneId) ? true : undefined);
+        await poll('HUD pane removal', () => !paneExists(fixture, started.hud.paneId) ? true : undefined);
+        assertProcessDead(started.hud.panePid);
+        assert.equal(paneExists(fixture, foreignPaneId), true);
+        assert.doesNotThrow(() => process.kill(foreignPanePid, 0));
+        assert.equal(tmuxSessionExists(sessionName, fixture.serverName), true);
+        assert.equal(fixture.sessionExists(), true);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('applies only a matching finalized terminal exit status', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omx-detached-exit-status-'));
+    const path = join(wd, 'marker.release');
+    const previousExitCode = process.exitCode;
+    try {
+      writeFileSync(path, JSON.stringify({
+        version: 1, kind: 'terminal', nonce: 'n', sessionId: 's', sessionName: 'sn', leaderPid: 123,
+        finalized: true, exitStatus: 7,
+      }));
+      process.exitCode = undefined;
+      assert.equal(applyDetachedTerminalExitStatus(path, { nonce: 'n', sessionId: 's', sessionName: 'sn', leaderPid: 123 }), true);
+      assert.equal(process.exitCode, 7);
+
+      process.exitCode = 19;
+      assert.equal(applyDetachedTerminalExitStatus(path, { nonce: 'wrong', sessionId: 's', sessionName: 'sn', leaderPid: 123 }), false);
+      assert.equal(process.exitCode, 19);
+
+      writeFileSync(path, JSON.stringify({ version: 1, kind: 'failed', nonce: 'n', sessionId: 's', sessionName: 'sn', leaderPid: 123, finalized: true, exitStatus: 7 }));
+      assert.equal(applyDetachedTerminalExitStatus(path, { nonce: 'n', sessionId: 's', sessionName: 'sn', leaderPid: 123 }), false);
+      assert.equal(process.exitCode, 19);
+
+      writeFileSync(path, JSON.stringify({ version: 1, kind: 'terminal', nonce: 'n', sessionId: 's', sessionName: 'sn', leaderPid: 123, finalized: true }));
+      assert.equal(applyDetachedTerminalExitStatus(path, { nonce: 'n', sessionId: 's', sessionName: 'sn', leaderPid: 123 }), false);
+      assert.equal(process.exitCode, 19);
+    } finally {
+      process.exitCode = previousExitCode;
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('publishes an optional HUD authority proof exactly', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omx-detached-release-marker-'));
+    const path = join(wd, 'marker.release');
+    const hud = { paneId: '%1', panePid: 123, sessionId: '$1', windowId: '@1', operationMarker: 'operation' };
+    try {
+      publishDetachedReleaseMarker(path, 'n', 's', 'sn', 456, hud);
+      assert.deepEqual(JSON.parse(readFileSync(`${path}.release`, 'utf-8')), {
+        version: 1, kind: 'release', nonce: 'n', sessionId: 's', sessionName: 'sn', leaderPid: 456, hud,
+      });
+
+      publishDetachedReleaseMarker(path, 'n', 's', 'sn', 456);
+      const withoutHud = JSON.parse(readFileSync(`${path}.release`, 'utf-8')) as Record<string, unknown>;
+      assert.equal(Object.hasOwn(withoutHud, 'hud'), false);
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('distinguishes destroyed-session protocol failure from manual detach', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omx-detached-attach-resolution-'));
+    const path = join(wd, 'marker.release');
+    const expected = { nonce: 'n', sessionId: 's', sessionName: 'sn', leaderPid: 123 };
+    const previousExitCode = process.exitCode;
+    try {
+      // Destroyed session + missing report: finalized status is mandatory -> failure.
+      assert.equal(
+        resolveDetachedAttachExitStatus(path, expected, { exactSessionExists: () => false }),
+        'protocol-failure',
+      );
+      // Destroyed session + malformed report -> failure.
+      writeFileSync(path, 'not json');
+      assert.equal(
+        resolveDetachedAttachExitStatus(path, expected, { exactSessionExists: () => false }),
+        'protocol-failure',
+      );
+      // Exact owned session provably alive with no terminal report -> manual detach stays success.
+      rmSync(path, { force: true });
+      assert.equal(
+        resolveDetachedAttachExitStatus(path, expected, { exactSessionExists: () => true }),
+        'manual-detach',
+      );
+      // Ambiguous session query (tmux unreachable) fails closed without any mutation.
+      assert.equal(
+        resolveDetachedAttachExitStatus(path, expected, { exactSessionExists: () => undefined }),
+        'protocol-failure',
+      );
+      // A valid finalized terminal report applies its status and never probes the session.
+      writeFileSync(path, JSON.stringify({
+        version: 1, kind: 'terminal', nonce: 'n', sessionId: 's', sessionName: 'sn', leaderPid: 123,
+        finalized: true, exitStatus: 7,
+      }));
+      process.exitCode = undefined;
+      assert.equal(
+        resolveDetachedAttachExitStatus(path, expected, {
+          exactSessionExists: () => { throw new Error('probe must not run when the status applies'); },
+        }),
+        'applied',
+      );
+      assert.equal(process.exitCode, 7);
+    } finally {
+      process.exitCode = previousExitCode;
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('probeExactDetachedSessionExists distinguishes live, retained-dead, and destroyed leader panes', async (t) => {
+    if (!skipUnlessTmux(t)) return;
+    await withTempTmuxSession(async (fixture) => {
+      const sessionName = 'omx-probe-liveness';
+      fixture.run(['new-session', '-d', '-s', sessionName, '-x', '80', '-y', '24', 'sleep 1', ';', 'set-option', 'remain-on-exit', 'on']);
+      const paneId = fixture.run(['list-panes', '-t', sessionName, '-F', '#{pane_id}']).split('\n')[0]!;
+      const fields = fixture.run([
+        'display-message', '-p', '-t', paneId,
+        '#{session_name}\t#{session_id}\t#{session_created}\t#{window_index}\t#{window_id}\t#{pane_id}\t#{pane_pid}',
+      ]).split('\t');
+      const authority = {
+        paneId,
+        panePid: Number(fields[6]),
+        sessionName,
+        sessionId: fields[1]!,
+        sessionCreated: fields[2]!,
+        windowIndex: fields[3]!,
+        windowId: fields[4]!,
+        ownerId: 'probe-owner',
+      };
+      assert.equal(probeExactDetachedSessionExists(authority), true, 'live leader pane reads as surviving session');
+      await poll('leader pane death', () => {
+        const dead = fixture.run(['display-message', '-p', '-t', paneId, '#{pane_dead}']);
+        return dead === '1' ? true : undefined;
+      });
+      assert.equal(probeExactDetachedSessionExists(authority), false, 'retained dead pane (remain-on-exit) fails closed as not-alive');
+      fixture.run(['kill-session', '-t', sessionName]);
+      assert.equal(probeExactDetachedSessionExists(authority), undefined, 'destroyed session is ambiguous and fails closed');
+    });
+  });
+});

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, type TestContext } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync } from 'node:fs';
+import { existsSync, writeFileSync } from 'node:fs';
 import { chmod, mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
@@ -2477,12 +2477,71 @@ exit 0
         leaderPid: ready.leaderPid,
         paneId: '%3202',
         finalized: true,
+        exitStatus: 0,
       });
       assert.equal(existsSync(join(wd, '.omx', 'state', 'session.json')), false);
       assert.equal(existsSync(join(wd, '.omx', 'state', 'detached-active-record.json')), false);
       assert.equal(existsSync(readyPath), true);
       await rm(readyPath, { force: true });
       assert.match(await readFile(join(wd, '.omx', 'logs', 'session-history.jsonl'), 'utf-8'), new RegExp(sessionId));
+    } finally {
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
+    }
+  });
+
+  it('returns the attached client to the shell with the child status after a normal detached child exit', async (t) => {
+    if (!skipUnlessPrivateRealTmux(t)) return;
+    if (process.platform === 'win32') { t.skip('PTY launch harness requires posix script(1)'); return; }
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-detached-e2e-'));
+    try {
+      await withTempTmuxSession(async (fixture) => {
+        const home = join(wd, 'home');
+        const bin = join(wd, 'bin');
+        await mkdir(home, { recursive: true });
+        await mkdir(bin, { recursive: true });
+        // The PTY is required for detached attach behavior, but it would also
+        // trigger OMX's unrelated one-time interactive star prompt. Mark it
+        // handled so this harness deterministically exercises only launch exit.
+        await mkdir(join(home, '.omx', 'state'), { recursive: true });
+        await writeFile(join(home, '.omx', 'state', 'star-prompt.json'), '{"prompted_at":"2026-01-01T00:00:00.000Z"}\n');
+        await fixture.createPathShim(bin);
+        const omxBin = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'dist', 'cli', 'omx.js');
+        const runPtyLaunch = (childExitStatus: number, remainOnExit: string): { status: number | null; output: string } => {
+          writeFileSync(join(bin, 'codex'), `#!/bin/sh\nsleep 1\nexit ${childExitStatus}\n`, { mode: 0o755 });
+          // Simulate a user tmux config that would retain the dead leader pane.
+          fixture.run(['set-option', '-g', 'remain-on-exit', remainOnExit]);
+          const envPrefix = [
+            `HOME=${JSON.stringify(home)}`,
+            `PATH=${JSON.stringify(bin)}:$PATH`,
+            'OMX_AUTO_UPDATE=0',
+            'OMX_NOTIFY_FALLBACK=0',
+            'OMX_HOOK_DERIVED_SIGNALS=0',
+            'TERM=xterm-256color',
+          ].map((kv) => `export ${kv}`).join('; ');
+          const result = spawnSync(
+            'script',
+            ['-q', '-e', '-c', `${envPrefix}; cd ${JSON.stringify(wd)} && exec ${JSON.stringify(process.execPath)} ${JSON.stringify(omxBin)} --tmux ${JSON.stringify('e2e prompt')}`, '/dev/null'],
+            {
+              encoding: 'utf-8',
+              timeout: 120_000,
+              killSignal: 'SIGKILL',
+              env: buildRunOmxEnv({ TMUX: '', TMUX_PANE: '' }),
+            },
+          );
+          return { status: result.status, output: `${result.stdout || ''}\n${result.stderr || ''}` };
+        };
+        const listOmxSessions = (): string[] => fixture.run(['list-sessions', '-F', '#{session_name}'])
+          .split('\n')
+          .filter((name) => name.startsWith('omx-') && name !== fixture.sessionName);
+
+        const zero = runPtyLaunch(0, 'on');
+        assert.equal(zero.status, 0, `zero-status attached launch must return to the shell successfully:\n${zero.output}`);
+        assert.deepEqual(listOmxSessions(), [], 'zero-status exit must destroy the owned detached session despite remain-on-exit=on');
+
+        const seven = runPtyLaunch(7, 'failed');
+        assert.equal(seven.status, 7, `nonzero child status must propagate to the invoking shell:\n${seven.output}`);
+        assert.deepEqual(listOmxSessions(), [], 'nonzero exit must destroy the owned detached session despite remain-on-exit=failed');
+      });
     } finally {
       await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
     }

--- a/src/cli/__tests__/windows-popup-loop-contract.test.ts
+++ b/src/cli/__tests__/windows-popup-loop-contract.test.ts
@@ -48,8 +48,10 @@ describe('detached tmux authority contract', () => {
     assert.match(cliIndex, /function detachedHudAuthorityCondition[\s\S]*?#\{==:#\{pane_pid\},\$\{authority\.panePid\}\}[\s\S]*?#\{==:#\{session_id\},\$\{authority\.sessionId\}\}[\s\S]*?#\{==:#\{window_id\},\$\{authority\.windowId\}\}[\s\S]*?OMX_DETACHED_HUD_OPERATION=\$\{authority\.operationMarker\}/);
     assert.match(cliIndex, /function runDetachedHudMutation[\s\S]*?if-shell -F -t \$\{quoteShellArg\(hudAuthority\.paneId\)\}[\s\S]*?detachedLeaderAuthorityCondition\(leaderAuthority\)/);
     assert.match(cliIndex, /function guardDetachedHudDeferredMutation[\s\S]*?buildDeferredDetachedHudGuard\(leaderAuthority, hudAuthority/);
-    assert.match(cliIndex, /const hudAuthority = runDetachedLeaderSplit\(authority, step\.args\)/);
-    assert.match(cliIndex, /if \(targetsHudPane\) runDetachedHudMutation\(authority, hudAuthority, guardDetachedHudDeferredMutation\(authority, hudAuthority, finalizeStep\.args\)\)/);
+    assert.match(cliIndex, /let detachedHudAuthority: DetachedHudAuthority \| null = null;/);
+    assert.match(cliIndex, /detachedHudAuthority = runDetachedLeaderSplit\(authority, step\.args\)/);
+    assert.match(cliIndex, /if \(targetsHudPane\) runDetachedHudMutation\(authority, detachedHudAuthority, guardDetachedHudDeferredMutation\(authority, detachedHudAuthority, finalizeStep\.args\)\)/);
+    assert.match(cliIndex, /publishDetachedReleaseMarker\(releaseMarkerPath, detachedLaunchNonce, sessionId, sessionName, detachedLeaderPid, detachedHudAuthority \?\? undefined\)/);
     assert.match(cliIndex, /runDetachedLeaderMutation\(detachedLeaderAuthority, step\.args\)/);
     assert.ok(cliIndex.includes('splitArgs[commandIndex] = `env OMX_DETACHED_HUD_OPERATION=${operationMarker} ${splitArgs[commandIndex]}`;'));
   });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4708,6 +4708,8 @@ interface DetachedLeaderReport {
   leaderPid?: number;
   error?: string;
   finalized?: boolean;
+  exitStatus?: number;
+  hud?: DetachedHudAuthority;
 }
 
 function writeDetachedLeaderReport(path: string, report: DetachedLeaderReport): void {
@@ -4747,12 +4749,72 @@ function readDetachedLeaderReport(path: string): DetachedLeaderReport | undefine
       typeof report.nonce !== "string" || typeof report.sessionId !== "string" || typeof report.sessionName !== "string") return undefined;
     if (report.paneId !== undefined && typeof report.paneId !== "string") return undefined;
     if (report.leaderPid !== undefined && (!Number.isSafeInteger(report.leaderPid) || Number(report.leaderPid) <= 0)) return undefined;
+    if (report.exitStatus !== undefined && (!Number.isSafeInteger(report.exitStatus) || Number(report.exitStatus) < 0 || Number(report.exitStatus) > 255)) return undefined;
     return report as unknown as DetachedLeaderReport;
   } catch { return undefined; }
 }
 
-function publishDetachedReleaseMarker(releaseMarkerPath: string, nonce: string, sessionId: string, sessionName: string, leaderPid: number): void {
-  writeDetachedLeaderReport(`${releaseMarkerPath}.release`, { version: 1, kind: "release", nonce, sessionId, sessionName, leaderPid });
+/** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
+export function publishDetachedReleaseMarker(
+  releaseMarkerPath: string,
+  nonce: string,
+  sessionId: string,
+  sessionName: string,
+  leaderPid: number,
+  hud?: DetachedHudAuthority,
+): void {
+  writeDetachedLeaderReport(`${releaseMarkerPath}.release`, {
+    version: 1, kind: "release", nonce, sessionId, sessionName, leaderPid, ...(hud ? { hud } : {}),
+  });
+}
+
+/** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
+export function applyDetachedTerminalExitStatus(
+  releaseMarkerPath: string,
+  expected: { nonce: string; sessionId: string; sessionName: string; leaderPid: number },
+): boolean {
+  const report = readDetachedLeaderReport(releaseMarkerPath);
+  if (!report || report.kind !== "terminal" || report.finalized !== true) return false;
+  if (report.nonce !== expected.nonce || report.sessionId !== expected.sessionId ||
+      report.sessionName !== expected.sessionName || report.leaderPid !== expected.leaderPid) return false;
+  if (typeof report.exitStatus !== "number") return false;
+  process.exitCode = report.exitStatus;
+  return true;
+}
+
+/** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
+export function probeExactDetachedSessionExists(authority: DetachedLeaderAuthority | null): boolean | undefined {
+  if (!authority) return undefined;
+  try {
+    // A retained dead pane (remain-on-exit) keeps its pid/topology, so prove
+    // liveness first: a dead leader with no valid terminal report is a failure,
+    // never a manual detach.
+    const paneDead = execTmuxFileSync(
+      ["display-message", "-p", "-t", authority.paneId, "#{pane_dead}"],
+      { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
+    ).trim();
+    if (paneDead === "1") return false;
+    if (paneDead !== "0") return undefined;
+    // Re-capture the exact leader-pane topology the bootstrap authority recorded.
+    // A matching recapture proves the owned session and its leader survive (manual
+    // detach); a destroyed session, recycled pane id, or tmux error fails closed.
+    const current = captureDetachedLeaderAuthority(authority.paneId, authority.sessionName, authority.ownerId);
+    return current.panePid === authority.panePid && current.sessionId === authority.sessionId
+      && current.sessionCreated === authority.sessionCreated && current.windowId === authority.windowId
+      && current.windowIndex === authority.windowIndex;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
+export function resolveDetachedAttachExitStatus(
+  releaseMarkerPath: string,
+  expected: { nonce: string; sessionId: string; sessionName: string; leaderPid: number },
+  probe: { exactSessionExists: () => boolean | undefined },
+): "applied" | "manual-detach" | "protocol-failure" {
+  if (applyDetachedTerminalExitStatus(releaseMarkerPath, expected)) return "applied";
+  return probe.exactSessionExists() === true ? "manual-detach" : "protocol-failure";
 }
 
 function publishDetachedAbortMarker(releaseMarkerPath: string, nonce: string, sessionId: string, sessionName: string, leaderPid: number): void {
@@ -6049,6 +6111,7 @@ async function runCodex(
     let detachedParentEnvFilePath: string | undefined;
     let detachedLeaderPaneId: string | null = null;
     let detachedLeaderAuthority: DetachedLeaderAuthority | null = null;
+    let detachedHudAuthority: DetachedHudAuthority | null = null;
     let detachedLeaderPid: number | null = null;
 
     let attachStep: DetachedSessionTmuxStep | null = null;
@@ -6086,14 +6149,18 @@ async function runCodex(
               runDetachedLeaderMutation(authority, step.args, false);
               runDetachedLeaderMutation(authority, ["set-option", "-q", "-t", authority.sessionName, "history-limit", String(DETACHED_TMUX_HISTORY_LIMIT)]);
               runDetachedLeaderMutation(authority, ["set-option", "-pq", "-t", authority.paneId, "history-limit", String(DETACHED_TMUX_HISTORY_LIMIT)]);
+              // #3266: the owned leader pane must close with its process so a normal
+              // child exit destroys the session naturally even when the user's tmux
+              // config inherits remain-on-exit=on/failed.
+              runDetachedLeaderMutation(authority, ["set-option", "-pq", "-t", authority.paneId, "remain-on-exit", "off"]);
               continue;
             }
             if (step.name !== "split-and-capture-hud-pane") {
               throw new Error(`unexpected detached bootstrap mutation: ${step.name}`);
             }
-            const hudAuthority = runDetachedLeaderSplit(authority, step.args);
+            detachedHudAuthority = runDetachedLeaderSplit(authority, step.args);
             for (const finalizeStep of buildDetachedSessionFinalizeSteps(
-              authority.sessionName, hudAuthority.paneId, authority.windowIndex, process.env.OMX_MOUSE !== "0",
+              authority.sessionName, detachedHudAuthority.paneId, authority.windowIndex, process.env.OMX_MOUSE !== "0",
               nativeWindows, detachedPreflight.shouldAttach, authority.paneId,
             )) {
               if (finalizeStep.name === "attach-session") { attachStep = finalizeStep; continue; }
@@ -6104,7 +6171,7 @@ async function runCodex(
                 "schedule-delayed-resize",
                 "reconcile-hud-resize",
               ]).has(finalizeStep.name);
-              if (targetsHudPane) runDetachedHudMutation(authority, hudAuthority, guardDetachedHudDeferredMutation(authority, hudAuthority, finalizeStep.args));
+              if (targetsHudPane) runDetachedHudMutation(authority, detachedHudAuthority, guardDetachedHudDeferredMutation(authority, detachedHudAuthority, finalizeStep.args));
               else runDetachedLeaderMutation(authority, finalizeStep.args);
             }
           } catch (error) {
@@ -6113,7 +6180,7 @@ async function runCodex(
         }
         return undefined;
       };
-      await executeDetachedLaunchStateMachine(
+      const launchTerminal = await executeDetachedLaunchStateMachine(
         { preflight: detachedPreflight },
         {
           establish: bootstrapLeader,
@@ -6171,7 +6238,7 @@ async function runCodex(
           finalizeSetupFailure: async () => {},
           releaseBarrier: async () => {
             if (!detachedLeaderPid) throw new Error("detached leader PID missing before release");
-            publishDetachedReleaseMarker(releaseMarkerPath, detachedLaunchNonce, sessionId, sessionName, detachedLeaderPid);
+            publishDetachedReleaseMarker(releaseMarkerPath, detachedLaunchNonce, sessionId, sessionName, detachedLeaderPid, detachedHudAuthority ?? undefined);
           },
           abortAndAwaitFinalization: async () => {
             // The leader has the retained binding. Publishing abort is the only
@@ -6227,6 +6294,21 @@ async function runCodex(
           },
         },
       );
+      if (launchTerminal.kind === "attached" && detachedLeaderPid) {
+        // #3266: propagate the finalized detached child's exit status to the invoking shell.
+        // A rejected status protocol is only benign when the exact owned session
+        // provably survives (manual detach); a destroyed or ambiguous session with
+        // no authenticated finalized status is a protocol failure, never silent success.
+        const attachResolution = resolveDetachedAttachExitStatus(
+          releaseMarkerPath,
+          { nonce: detachedLaunchNonce, sessionId, sessionName, leaderPid: detachedLeaderPid },
+          { exactSessionExists: () => probeExactDetachedSessionExists(detachedLeaderAuthority) },
+        );
+        if (attachResolution === "protocol-failure") {
+          process.stderr.write("[omx] detached session ended without an authenticated finalized terminal status; treating the launch as failed.\n");
+          if (!process.exitCode) process.exitCode = 1;
+        }
+      }
       return { postLaunchHandledExternally: true };
     };
 
@@ -6428,11 +6510,40 @@ function decodeDetachedLeaderPayload(encoded: string | undefined): DetachedLeade
   };
 }
 
+function parseDetachedHudAuthorityProof(value: unknown): DetachedHudAuthority | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const proof = value as Record<string, unknown>;
+  if (typeof proof.paneId !== "string" || !/^%[0-9]+$/.test(proof.paneId)) return undefined;
+  if (typeof proof.panePid !== "number" || !Number.isSafeInteger(proof.panePid) || proof.panePid <= 0) return undefined;
+  if (typeof proof.sessionId !== "string" || !/^\$[0-9]+$/.test(proof.sessionId)) return undefined;
+  if (typeof proof.windowId !== "string" || !/^@[0-9]+$/.test(proof.windowId)) return undefined;
+  if (typeof proof.operationMarker !== "string" || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(proof.operationMarker)) return undefined;
+  return { paneId: proof.paneId, panePid: proof.panePid, sessionId: proof.sessionId, windowId: proof.windowId, operationMarker: proof.operationMarker };
+}
+
+function teardownDetachedOwnedHudPane(leaderPaneId: string, payload: DetachedLeaderPayload, hudProof: DetachedHudAuthority | undefined): void {
+  // #3266: on a normal child exit, kill exactly the bootstrap-proven OMX HUD pane so
+  // the leader pane becomes the last live pane and the owned session closes naturally,
+  // returning the attached client to its shell. Fail-closed: any doubt means zero mutations.
+  // Contract: only the proven HUD is removed. A pane the user added to the detached
+  // session is deliberately preserved, which intentionally keeps that session (and any
+  // attached client) alive; natural closure and shell return happen only when no other
+  // panes remain.
+  if (!hudProof) return;
+  try {
+    const leaderAuthority = captureDetachedLeaderAuthority(leaderPaneId, payload.sessionName, payload.sessionId);
+    runDetachedHudMutation(leaderAuthority, hudProof, ["kill-pane", "-t", hudProof.paneId]);
+  } catch (error) {
+    logCliOperationFailure(error);
+  }
+}
+
 async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise<void> {
   for (const [key, value] of Object.entries(payload.parentEnv ?? {})) process.env[key] = value;
   const established = await establishPreLaunchBinding(payload.cwd, payload.sessionId);
   const binding = established.binding;
   let ownedRecord: DetachedActiveRecordOwnership | undefined;
+  let detachedHudProof: DetachedHudAuthority | undefined;
   const nonce = payload.readyPath?.split(".").at(-2) || payload.sessionId;
   const contextKey = process.env[OMX_MADMAX_DETACHED_CONTEXT_ENV]?.trim();
   const activeRecordPath = contextKey
@@ -6488,7 +6599,10 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
       while (true) {
         if (interrupted) throw new Error(`detached leader interrupted before release: ${interrupted}`);
         const release = readDetachedLeaderReport(releasePath);
-        if (release?.kind === "release" && release.nonce === nonce && release.sessionId === payload.sessionId && release.sessionName === payload.sessionName && release.leaderPid === process.pid) break;
+        if (release?.kind === "release" && release.nonce === nonce && release.sessionId === payload.sessionId && release.sessionName === payload.sessionName && release.leaderPid === process.pid) {
+          detachedHudProof = parseDetachedHudAuthorityProof(release.hud);
+          break;
+        }
         const abort = readDetachedLeaderReport(abortPath);
         if (abort?.kind === "abort" && abort.nonce === nonce && abort.sessionId === payload.sessionId && abort.sessionName === payload.sessionName && abort.leaderPid === process.pid) {
           throw new Error("detached launch aborted before release");
@@ -6553,12 +6667,16 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
     if (payload.readyPath) writeDetachedLeaderReport(payload.readyPath, {
       version: 1, kind: "terminal", nonce, sessionId: payload.sessionId, sessionName: payload.sessionName,
       paneId: pane, leaderPid: process.pid, finalized: true,
+      ...(typeof process.exitCode === "number" ? { exitStatus: process.exitCode } : {}),
     });
     await cleanupRuntimeCodexHome(payload.runtimeCodexHomeForCleanup, payload.projectLocalCodexHomeForCleanup);
     if (ownedRecord) {
       const bytes = readFileSync(activeRecordPath, "utf-8");
       const digest = createHash("sha256").update(bytes).digest("hex");
       if (bytes === ownedRecord.bytes && digest === ownedRecord.digest) rmSync(activeRecordPath, { force: true });
+    }
+    if (!externalInterrupt && outcome.signal === null) {
+      teardownDetachedOwnedHudPane(pane, payload, detachedHudProof);
     }
   } catch (error) {
     let failure: unknown = error;


### PR DESCRIPTION
## Summary
- tear down only the bootstrap-proven detached HUD after normal child completion
- propagate authenticated detached child exit status to the attached invoker
- make the PTY launch assertion deterministic by pre-marking the unrelated star prompt as handled

## Validation
- npm run build
- node dist/scripts/run-test-files.js dist/cli/__tests__/detached-leader-teardown.test.js dist/cli/__tests__/launch-fallback.test.js
- npm run check:no-unused
- npm run lint