### PR TITLE
fix: 保留活动会话使用的插件缓存路径

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -8,6 +8,7 @@ import {
 	mkdir,
 	mkdtemp,
 	readFile,
+	readlink,
 	readdir,
 	rm,
 	symlink,
@@ -1287,7 +1288,7 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
-	it("invalidates old versioned plugin cache dirs while materializing the current cache", async () => {
+	it("replaces old versioned plugin caches with compatibility links to the current cache", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {
 			await withIsolatedUserHome(wd, async (codexHomeDir) => {
@@ -1299,7 +1300,16 @@ describe("omx setup install mode behavior", () => {
 					});
 
 					const currentCacheDir = await packagedPluginCacheDir(codexHomeDir);
-					assert.equal(existsSync(oldCacheDir), false);
+					assert.equal((await lstat(oldCacheDir)).isSymbolicLink(), true);
+					assert.equal(await readlink(oldCacheDir), basename(currentCacheDir));
+					assert.equal(
+						existsSync(join(oldCacheDir, "hooks", "codex-native-hook.mjs")),
+						true,
+					);
+					const oldVersionEntry = (
+						await readdir(dirname(oldCacheDir), { withFileTypes: true })
+					).find((entry) => entry.name === basename(oldCacheDir));
+					assert.equal(oldVersionEntry?.isDirectory(), false);
 					assert.equal(existsSync(join(currentCacheDir, ".codex-plugin", "plugin.json")), true);
 					assert.equal(existsSync(join(currentCacheDir, "hooks", "hooks.json")), true);
 					assert.equal(existsSync(join(currentCacheDir, "hooks", "codex-native-hook.mjs")), true);
@@ -1307,7 +1317,10 @@ describe("omx setup install mode behavior", () => {
 					assert.equal(existsSync(join(currentCacheDir, "skills", "ask", "SKILL.md")), true);
 					assert.match(output, /Invalidated 1 stale Codex plugin discovery cache entry/);
 					assert.match(output, /Installed local Codex plugin cache/);
-					assert.doesNotMatch(output, /Retained .* old versioned Codex plugin cache/);
+					assert.match(
+						output,
+						/Linked 1 retired versioned Codex plugin cache entry to the current cache/,
+					);
 				});
 			});
 		} finally {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -16,6 +16,7 @@ import {
 	rm,
 	open,
 	chmod,
+	symlink,
 } from "fs/promises";
 
 import { join, dirname, relative, basename, isAbsolute, sep, win32 } from "path";
@@ -2868,6 +2869,42 @@ interface PluginDiscoveryCacheRefreshResult {
 	staleDirs: string[];
 }
 
+async function createPluginCacheCompatibilityLinks(
+	staleDirs: string[],
+	currentCacheDir: string,
+): Promise<string[]> {
+	const currentCacheParent = dirname(currentCacheDir);
+	const currentVersion = basename(currentCacheDir);
+	const linkedDirs: string[] = [];
+
+	for (const staleDir of staleDirs) {
+		if (
+			dirname(staleDir) !== currentCacheParent ||
+			basename(staleDir) === currentVersion ||
+			existsSync(staleDir)
+		) {
+			continue;
+		}
+
+		const target = process.platform === "win32"
+			? currentCacheDir
+			: currentVersion;
+		try {
+			await symlink(
+				target,
+				staleDir,
+				process.platform === "win32" ? "junction" : "dir",
+			);
+			linkedDirs.push(staleDir);
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code;
+			if (code !== "EEXIST") throw error;
+		}
+	}
+
+	return linkedDirs;
+}
+
 async function refreshOmxPluginDiscoveryCache(
 	pkgRoot: string,
 	options: Pick<SetupOptions, "dryRun" | "verbose">,
@@ -4444,12 +4481,28 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			preflightMarketplace,
 			{ dryRun, teamMode: resolvedTeamMode },
 		);
+		const pluginCacheDir = pluginCacheMaterialize.cacheDir;
+		const pluginCacheCompatibilityLinks =
+			!dryRun &&
+			pluginCacheDir !== undefined &&
+			(pluginCacheMaterialize.status === "materialized" ||
+				pluginCacheMaterialize.status === "unchanged")
+				? await createPluginCacheCompatibilityLinks(
+						pluginCacheRefresh.staleDirs,
+						pluginCacheDir,
+					)
+				: [];
 		if (pluginCacheMaterialize.status === "materialized") {
 			console.log(
 				`  ${dryRun ? "Would install" : "Installed"} local Codex plugin cache for ${OMX_LOCAL_MARKETPLACE_NAME}/${OMX_PLUGIN_NAME} at ${pluginCacheMaterialize.cacheDir}.`,
 			);
 		} else if (pluginCacheMaterialize.status === "unchanged") {
 			console.log("  Local Codex plugin cache already exposes packaged OMX skills.");
+		}
+		if (pluginCacheCompatibilityLinks.length > 0) {
+			console.log(
+				`  Linked ${pluginCacheCompatibilityLinks.length} retired versioned Codex plugin cache entr${pluginCacheCompatibilityLinks.length === 1 ? "y" : "ies"} to the current cache so active sessions keep resolving PLUGIN_ROOT.`,
+			);
 		}
 		if (
 			pluginCacheMaterialize.status === "materialized" ||


### PR DESCRIPTION
## Summary

修复 OMX 升级后删除旧版本 Codex 插件缓存目录，导致仍在运行的会话继续使用旧 `PLUGIN_ROOT` 时所有 plugin hook 以 `MODULE_NOT_FOUND` / exit code 1 失败的问题。

根因是 setup 会清理旧版本缓存目录，而 Codex 会话会在启动时固定插件根路径，不会随缓存升级重新解析。

## Changes

- 在当前插件缓存物化完成后，为本次失效的旧版本目录创建指向当前版本的兼容链接。
- 仅处理同一 marketplace/plugin 缓存目录下的版本路径，并跳过当前版本或已经存在的路径。
- Windows 使用 junction，POSIX 使用相对目录符号链接。
- 增加回归测试，验证旧路径仍可解析 hook，同时目录枚举不会把兼容链接识别为可选插件版本。

## Impact

- 已启动的 Codex 会话在 OMX 升级后可以继续执行 plugin hook，无需立即重启。
- 新会话仍只发现当前真实缓存目录，不会把旧版本兼容链接选作活动插件版本。

## Validation

- [x] `npm run build`
- [x] `npx biome lint src/cli/setup.ts src/cli/__tests__/setup-install-mode.test.ts`
- [x] `node --test --test-name-pattern="replaces old versioned plugin caches" dist/cli/__tests__/setup-install-mode.test.js`
- [x] `git diff --check origin/dev...HEAD`
- [x] `omx doctor`：18 passed，2 warnings，0 failed（已安装版本）
- [ ] `npm test`：完整矩阵在本机 macOS / Node 26 环境中触发多项与本改动无关的既有环境失败，包括缺少 `tmux`、沙箱禁止监听 `127.0.0.1`、`/var` 与 `/private/var` 路径别名，以及 Node 原生断言；目标回归通过。

## Checklist

- [x] PR 聚焦于插件缓存兼容问题，无无关修改
- [x] 已考虑向后兼容影响
- [x] 不需要文档更新：行为由 setup 自动完成

## Related

由一次 `0.20.2` 到 `0.20.3` 升级后的活动会话 hook 故障复现并定位。
