### PR TITLE
fix(hooks): make lock recovery checkpoints resumable

### DIFF
--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -1059,6 +1059,35 @@ describe('session pointer transaction', () => {
     }
   });
 
+  it('preserves foreign claim bytes swapped in after the initial recovery link', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-post-link-claim-swap-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      const ownerPath = join(context.lockPath, 'owner.json');
+      const claimPath = join(context.lockPath, `owner.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.recovery`);
+      const originalClaimPath = `${claimPath}.original`;
+      const foreignMarker = 'foreign post-link claim bytes';
+      await writeLockOwner(cwd, validLockOwner());
+      let swapped = false;
+      await withPointerDependencies({ token: () => SUCCESSOR_TOKEN, probePid: () => 'dead', fs: { link: async (from, to) => {
+        await link(from, to);
+        if (!swapped && to === claimPath) {
+          swapped = true;
+          await rename(claimPath, originalClaimPath);
+          await writeFile(claimPath, foreignMarker, 'utf-8');
+        }
+      } } }, async () => {
+        const recovered = await recoverSessionPointerLock(cwd);
+        assert.equal(recovered.recovered, false);
+        assert.match(recovered.reason, /foreign evidence.*left untouched/i);
+      });
+      assert.equal(swapped, true);
+      assert.equal(await readFile(claimPath, 'utf-8'), foreignMarker);
+      assert.equal(await readFile(originalClaimPath, 'utf-8'), JSON.stringify(validLockOwner()));
+      assert.equal(await readFile(ownerPath, 'utf-8'), JSON.stringify(validLockOwner()));
+    } finally { await rm(cwd, { recursive: true, force: true }); }
+  });
+
   it('live canonical successor survives a refused recovery claim and stays recognizable, releasable, and acquirable', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-live-successor-'));
     try {

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -939,7 +939,7 @@ describe('session pointer transaction', () => {
         assert.equal(inspected.evidenceSource, 'owner.json');
         assert.equal(inspected.safeToRecover, true);
         const recovered = await recoverSessionPointerLock(cwd);
-        assert.equal(recovered.recovered, true);
+        assert.equal(recovered.recovered, true, recovered.reason);
         assert.equal(recovered.action, 'quarantined');
         assert.equal(existsSync(context.lockPath), false);
         assert.equal(existsSync(recovered.quarantinePath!), true);
@@ -950,11 +950,10 @@ describe('session pointer transaction', () => {
       });
       assert.match(links[0]![0], /owner\.json$/);
       assert.match(links[0]![1], new RegExp(`owner\\.${TEST_TOKEN}\\.${SUCCESSOR_TOKEN}\\.recovery$`));
-      assert.match(links[1]![0], new RegExp(`owner\\.${TEST_TOKEN}\\.${SUCCESSOR_TOKEN}\\.recovery$`));
+      assert.equal(links[1]![0].startsWith(`${context.lockPath}.parked-`), true);
       assert.equal(links[1]![1].includes('.quarantine.'), true);
       assert.match(renames[0]![0], /owner\.json$/);
-      assert.match(renames[1]![0], new RegExp(`owner\\.${TEST_TOKEN}\\.${SUCCESSOR_TOKEN}\\.recovery$`));
-      assert.equal(renames[2]![0], context.lockPath);
+      assert.equal(renames.some(([from, to]) => from === context.lockPath && to === `${context.lockPath}.parked-lock-${SUCCESSOR_TOKEN}`), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -1220,7 +1219,8 @@ describe('session pointer transaction', () => {
       await link(ownerPath, claimPath);
       await rename(ownerPath, parkPath);
       const parked = await lstat(parkPath);
-      await writeFile(`${context.lockPath}.recovery.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.json`, JSON.stringify({ version: 1, sourcePath: ownerPath, parkPath, identity: { dev: parked.dev, ino: parked.ino }, phase: 'evidence-pending' }));
+      const lock = await lstat(context.lockPath);
+      await writeFile(`${context.lockPath}.recovery.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.json`, JSON.stringify({ version: 1, sourcePath: ownerPath, parkPath, lockParkPath: `${context.lockPath}.parked-lock-${SUCCESSOR_TOKEN}`, identity: { dev: parked.dev, ino: parked.ino }, lockIdentity: { dev: lock.dev, ino: lock.ino }, phase: 'evidence-pending' }));
       await withPointerDependencies({ token: () => { throw new Error('resume must reuse checkpoint token'); }, probePid: () => 'dead' }, async () => {
         const resumed = await recoverSessionPointerLock(cwd);
         assert.equal(resumed.recovered, true);
@@ -1243,9 +1243,76 @@ describe('session pointer transaction', () => {
       await link(ownerPath, claimPath);
       await rename(ownerPath, parkPath);
       const parked = await lstat(parkPath);
-      await writeFile(`${context.lockPath}.recovery.${TEST_TOKEN}.${claimToken}.json`, JSON.stringify({ version: 1, sourcePath: ownerPath, parkPath, identity: { dev: parked.dev, ino: parked.ino }, phase: 'evidence-pending' }));
+      const lock = await lstat(context.lockPath);
+      await writeFile(`${context.lockPath}.recovery.${TEST_TOKEN}.${claimToken}.json`, JSON.stringify({ version: 1, sourcePath: ownerPath, parkPath, lockParkPath: `${context.lockPath}.parked-lock-${claimToken}`, identity: { dev: parked.dev, ino: parked.ino }, lockIdentity: { dev: lock.dev, ino: lock.ino }, phase: 'evidence-pending' }));
       await withPointerDependencies({ token: () => { throw new Error('resume must not mint a replacement token'); }, probePid: () => 'dead' }, async () => assert.equal((await recoverSessionPointerLock(cwd)).recovered, true));
       assert.equal(await readFile(`${context.lockPath}.quarantine.${TEST_TOKEN}.${claimToken}`, 'utf-8'), JSON.stringify(validLockOwner()));
+    } finally { await rm(cwd, { recursive: true, force: true }); }
+  });
+
+  it('resumes a checkpoint written before evidence parking', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-source-checkpoint-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      const ownerPath = join(context.lockPath, 'owner.json');
+      const claimPath = join(context.lockPath, `owner.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.recovery`);
+      const parkPath = `${context.lockPath}.parked-${SUCCESSOR_TOKEN}`;
+      const checkpointPath = `${context.lockPath}.recovery.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.json`;
+      await writeLockOwner(cwd, validLockOwner());
+      await link(ownerPath, claimPath);
+      const owner = await lstat(ownerPath);
+      const lock = await lstat(context.lockPath);
+      await writeFile(checkpointPath, JSON.stringify({ version: 1, sourcePath: ownerPath, parkPath, lockParkPath: `${context.lockPath}.parked-lock-${SUCCESSOR_TOKEN}`, identity: { dev: owner.dev, ino: owner.ino }, lockIdentity: { dev: lock.dev, ino: lock.ino }, phase: 'evidence-pending' }));
+      await withPointerDependencies({ token: () => { throw new Error('resume must not mint token'); }, probePid: () => 'dead' }, async () => assert.equal((await recoverSessionPointerLock(cwd)).recovered, true));
+      assert.equal(existsSync(context.lockPath), false);
+      assert.equal(existsSync(checkpointPath), false);
+    } finally { await rm(cwd, { recursive: true, force: true }); }
+  });
+
+  it('resumes after quarantine hard-link creation but before claim and park cleanup', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-dual-evidence-checkpoint-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      const ownerPath = join(context.lockPath, 'owner.json');
+      const claimPath = join(context.lockPath, `owner.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.recovery`);
+      const parkPath = `${context.lockPath}.parked-${SUCCESSOR_TOKEN}`;
+      const quarantinePath = `${context.lockPath}.quarantine.${TEST_TOKEN}.${SUCCESSOR_TOKEN}`;
+      const checkpointPath = `${context.lockPath}.recovery.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.json`;
+      await writeLockOwner(cwd, validLockOwner());
+      await link(ownerPath, claimPath);
+      await rename(ownerPath, parkPath);
+      await link(parkPath, quarantinePath);
+      const parked = await lstat(parkPath);
+      const lock = await lstat(context.lockPath);
+      await writeFile(checkpointPath, JSON.stringify({ version: 1, sourcePath: ownerPath, parkPath, lockParkPath: `${context.lockPath}.parked-lock-${SUCCESSOR_TOKEN}`, identity: { dev: parked.dev, ino: parked.ino }, lockIdentity: { dev: lock.dev, ino: lock.ino }, phase: 'evidence-pending' }));
+      await withPointerDependencies({ token: () => { throw new Error('resume must not mint token'); }, probePid: () => 'dead' }, async () => assert.equal((await recoverSessionPointerLock(cwd)).recovered, true));
+      assert.equal(await readFile(quarantinePath, 'utf-8'), JSON.stringify(validLockOwner()));
+      assert.equal(existsSync(checkpointPath), false);
+    } finally { await rm(cwd, { recursive: true, force: true }); }
+  });
+
+  it('reports absent recovery on a fresh workspace without a state directory', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-fresh-'));
+    try {
+      const recovered = await recoverSessionPointerLock(cwd);
+      assert.equal(recovered.recovered, false);
+      assert.equal(recovered.status, 'absent');
+      assert.match(recovered.reason, /No session pointer lock exists/);
+    } finally { await rm(cwd, { recursive: true, force: true }); }
+  });
+
+  it('fails closed when recovery checkpoint discovery cannot be enumerated', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-checkpoint-readdir-error-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      await writeLockOwner(cwd, validLockOwner());
+      await withPointerDependencies({ probePid: () => 'dead', fs: { readdir: async () => { throw codedError('EACCES'); } } }, async () => {
+        const recovered = await recoverSessionPointerLock(cwd);
+        assert.equal(recovered.recovered, false);
+        assert.equal(recovered.status, 'io-error');
+        assert.match(recovered.reason, /enumerate.*checkpoints/i);
+      });
+      assert.deepEqual(await readdir(context.lockPath), ['owner.json']);
     } finally { await rm(cwd, { recursive: true, force: true }); }
   });
 
@@ -1300,7 +1367,8 @@ describe('session pointer transaction', () => {
       const context = resolveSessionPointerContext(cwd); await mkdir(context.lockPath, { recursive: true });
       const parkPath = `${context.lockPath}.parked-${SUCCESSOR_TOKEN}`; await writeFile(parkPath, 'stale', 'utf-8'); const stat = await lstat(parkPath);
       const checkpointPath = `${context.lockPath}.recovery.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.json`;
-      await writeFile(checkpointPath, JSON.stringify({ version: 1, sourcePath: join(context.lockPath, 'owner.json'), parkPath, identity: { dev: stat.dev, ino: stat.ino }, phase: 'evidence-pending' }));
+      const lock = await lstat(context.lockPath);
+      await writeFile(checkpointPath, JSON.stringify({ version: 1, sourcePath: join(context.lockPath, 'owner.json'), parkPath, lockParkPath: `${context.lockPath}.parked-lock-${SUCCESSOR_TOKEN}`, identity: { dev: stat.dev, ino: stat.ino }, lockIdentity: { dev: lock.dev, ino: lock.ino }, phase: 'evidence-pending' }));
       await withPointerDependencies({ token: () => { throw new Error('must not mint token'); }, probePid: () => 'dead' }, async () => assert.equal((await recoverSessionPointerLock(cwd)).recovered, false));
       assert.equal(await readFile(checkpointPath, 'utf-8').then(Boolean), true); assert.equal(await readFile(parkPath, 'utf-8'), 'stale');
     } finally { await rm(cwd, { recursive: true, force: true }); }
@@ -1310,9 +1378,9 @@ describe('session pointer transaction', () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-checkpoint-rename-busy-'));
     try {
       const context = resolveSessionPointerContext(cwd); const ownerPath = join(context.lockPath, 'owner.json'); const claimPath = join(context.lockPath, `owner.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.recovery`); const parkPath = `${context.lockPath}.parked-${SUCCESSOR_TOKEN}`;
-      await writeLockOwner(cwd, validLockOwner()); await link(ownerPath, claimPath); await rename(ownerPath, parkPath); const stat = await lstat(parkPath);
-      const checkpointPath = `${context.lockPath}.recovery.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.json`; await writeFile(checkpointPath, JSON.stringify({ version: 1, sourcePath: ownerPath, parkPath, identity: { dev: stat.dev, ino: stat.ino }, phase: 'evidence-pending' }));
-      await withPointerDependencies({ token: () => { throw new Error('must not mint token'); }, probePid: () => 'dead', fs: { rename: async (from, to) => { if (from === parkPath) throw codedError('EBUSY'); await rename(from, to); } } }, async () => assert.equal((await recoverSessionPointerLock(cwd)).recovered, false));
+      await writeLockOwner(cwd, validLockOwner()); await link(ownerPath, claimPath); await rename(ownerPath, parkPath); const stat = await lstat(parkPath); const lock = await lstat(context.lockPath);
+      const checkpointPath = `${context.lockPath}.recovery.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.json`; await writeFile(checkpointPath, JSON.stringify({ version: 1, sourcePath: ownerPath, parkPath, lockParkPath: `${context.lockPath}.parked-lock-${SUCCESSOR_TOKEN}`, identity: { dev: stat.dev, ino: stat.ino }, lockIdentity: { dev: lock.dev, ino: lock.ino }, phase: 'evidence-pending' }));
+      await withPointerDependencies({ token: () => { throw new Error('must not mint token'); }, probePid: () => 'dead', fs: { link: async (from, to) => { if (from === parkPath) throw codedError('EBUSY'); await link(from, to); } } }, async () => assert.equal((await recoverSessionPointerLock(cwd)).recovered, false));
       assert.equal(await readFile(checkpointPath, 'utf-8').then(Boolean), true); assert.equal(await readFile(parkPath, 'utf-8'), JSON.stringify(validLockOwner())); assert.equal(await readFile(claimPath, 'utf-8'), JSON.stringify(validLockOwner()));
     } finally { await rm(cwd, { recursive: true, force: true }); }
   });
@@ -1321,15 +1389,122 @@ describe('session pointer transaction', () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-checkpoint-unlink-busy-'));
     try {
       const context = resolveSessionPointerContext(cwd); const ownerPath = join(context.lockPath, 'owner.json'); const claimPath = join(context.lockPath, `owner.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.recovery`); const parkPath = `${context.lockPath}.parked-${SUCCESSOR_TOKEN}`; const checkpointPath = `${context.lockPath}.recovery.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.json`;
-      await writeLockOwner(cwd, validLockOwner()); await link(ownerPath, claimPath); await rename(ownerPath, parkPath); const stat = await lstat(parkPath);
-      await writeFile(checkpointPath, JSON.stringify({ version: 1, sourcePath: ownerPath, parkPath, identity: { dev: stat.dev, ino: stat.ino }, phase: 'evidence-pending' }));
-      let fail = true;
-      await withPointerDependencies({ token: () => { throw new Error('must not mint token'); }, probePid: () => 'dead', fs: { unlink: async (path) => { if (path === claimPath && fail) { fail = false; throw codedError('EBUSY'); } await rm(path); } } }, async () => {
+      await writeLockOwner(cwd, validLockOwner()); await link(ownerPath, claimPath); await rename(ownerPath, parkPath); const stat = await lstat(parkPath); const lock = await lstat(context.lockPath);
+      await writeFile(checkpointPath, JSON.stringify({ version: 1, sourcePath: ownerPath, parkPath, lockParkPath: `${context.lockPath}.parked-lock-${SUCCESSOR_TOKEN}`, identity: { dev: stat.dev, ino: stat.ino }, lockIdentity: { dev: lock.dev, ino: lock.ino }, phase: 'evidence-pending' }));
+      let failures = 2;
+      await withPointerDependencies({ token: () => { throw new Error('must not mint token'); }, probePid: () => 'dead', fs: { rename: async (from, to) => { if (from === claimPath && failures-- > 0) throw codedError('EBUSY'); await rename(from, to); } } }, async () => {
         assert.equal((await recoverSessionPointerLock(cwd)).recovered, false);
         assert.equal(await readFile(parkPath, 'utf-8'), JSON.stringify(validLockOwner()));
         assert.equal((await recoverSessionPointerLock(cwd)).recovered, true);
       });
       assert.equal(existsSync(checkpointPath), false);
+    } finally { await rm(cwd, { recursive: true, force: true }); }
+  });
+
+  for (const fault of ['EBUSY', 'ENOTEMPTY'] as const) it(`completes a checkpoint resume retry after one-shot final rmdir ${fault}`, async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-checkpoint-rmdir-retry-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      const ownerPath = join(context.lockPath, 'owner.json');
+      const claimPath = join(context.lockPath, `owner.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.recovery`);
+      const parkPath = `${context.lockPath}.parked-${SUCCESSOR_TOKEN}`;
+      const checkpointPath = `${context.lockPath}.recovery.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.json`;
+      const quarantinePath = `${context.lockPath}.quarantine.${TEST_TOKEN}.${SUCCESSOR_TOKEN}`;
+      await writeLockOwner(cwd, validLockOwner());
+      await link(ownerPath, claimPath);
+      await rename(ownerPath, parkPath);
+      const parked = await lstat(parkPath);
+      const lock = await lstat(context.lockPath);
+      await writeFile(checkpointPath, JSON.stringify({ version: 1, sourcePath: ownerPath, parkPath, lockParkPath: `${context.lockPath}.parked-lock-${SUCCESSOR_TOKEN}`, identity: { dev: parked.dev, ino: parked.ino }, lockIdentity: { dev: lock.dev, ino: lock.ino }, phase: 'evidence-pending' }));
+      let failures = fault === 'EBUSY' ? 2 : 1;
+      await withPointerDependencies({ token: () => { throw new Error('resume must not mint token'); }, probePid: () => 'dead', fs: { rmdir: async (path) => { if (path === `${context.lockPath}.parked-lock-${SUCCESSOR_TOKEN}` && failures-- > 0) throw codedError(fault); await rmdir(path); } } }, async () => {
+        const failed = await recoverSessionPointerLock(cwd);
+        assert.equal(failed.recovered, false);
+        assert.equal(existsSync(checkpointPath), true);
+        assert.equal(existsSync(parkPath), false);
+        assert.equal(existsSync(claimPath), false);
+        assert.equal(await readFile(quarantinePath, 'utf-8'), JSON.stringify(validLockOwner()));
+        const retried = await recoverSessionPointerLock(cwd);
+        assert.equal(retried.recovered, true);
+        assert.equal(retried.quarantinePath, quarantinePath);
+      });
+      assert.equal(existsSync(context.lockPath), false);
+      assert.equal(existsSync(checkpointPath), false);
+    } finally { await rm(cwd, { recursive: true, force: true }); }
+  });
+
+  it('refuses an advanced checkpoint when a live successor replaces the bound lock directory', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-checkpoint-successor-swap-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      const ownerPath = join(context.lockPath, 'owner.json');
+      const claimPath = join(context.lockPath, `owner.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.recovery`);
+      const parkPath = `${context.lockPath}.parked-${SUCCESSOR_TOKEN}`;
+      const checkpointPath = `${context.lockPath}.recovery.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.json`;
+      const quarantinePath = `${context.lockPath}.quarantine.${TEST_TOKEN}.${SUCCESSOR_TOKEN}`;
+      await writeLockOwner(cwd, validLockOwner());
+      await link(ownerPath, claimPath);
+      await rename(ownerPath, parkPath);
+      const parked = await lstat(parkPath);
+      const lock = await lstat(context.lockPath);
+      await writeFile(checkpointPath, JSON.stringify({ version: 1, sourcePath: ownerPath, parkPath, lockParkPath: `${context.lockPath}.parked-lock-${SUCCESSOR_TOKEN}`, identity: { dev: parked.dev, ino: parked.ino }, lockIdentity: { dev: lock.dev, ino: lock.ino }, phase: 'evidence-pending' }));
+      await rename(parkPath, quarantinePath);
+      await rm(claimPath);
+      await rename(context.lockPath, `${context.lockPath}.displaced`);
+      const successorPid = process.pid + 100_000;
+      const successor = JSON.stringify(validLockOwner({ token: FOREIGN_TOKEN, pid: successorPid }));
+      await mkdir(context.lockPath);
+      await writeFile(ownerPath, successor, 'utf-8');
+      await withPointerDependencies({ token: () => { throw new Error('resume must not mint token'); }, probePid: (pid) => pid === successorPid ? 'alive' : 'dead', readProcessIdentity: () => matchingProcessIdentity() }, async () => {
+        const refused = await recoverSessionPointerLock(cwd);
+        assert.equal(refused.recovered, false);
+        assert.match(refused.reason, /recovery state/i);
+        assert.deepEqual(await readdir(context.lockPath), ['owner.json']);
+        assert.equal(await readFile(ownerPath, 'utf-8'), successor);
+        assert.deepEqual(await __releasePointerLockForTests(cwd, FOREIGN_TOKEN), []);
+        assert.equal(existsSync(context.lockPath), false);
+      });
+      assert.equal(await readFile(quarantinePath, 'utf-8'), JSON.stringify(validLockOwner()));
+      assert.equal(existsSync(checkpointPath), true);
+    } finally { await rm(cwd, { recursive: true, force: true }); }
+  });
+
+  it('does not remove a live successor swapped in before final checkpoint lock removal', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-checkpoint-final-rmdir-swap-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      const ownerPath = join(context.lockPath, 'owner.json');
+      const claimPath = join(context.lockPath, `owner.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.recovery`);
+      const parkPath = `${context.lockPath}.parked-${SUCCESSOR_TOKEN}`;
+      const lockParkPath = `${context.lockPath}.parked-lock-${SUCCESSOR_TOKEN}`;
+      const checkpointPath = `${context.lockPath}.recovery.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.json`;
+      await writeLockOwner(cwd, validLockOwner());
+      await link(ownerPath, claimPath);
+      await rename(ownerPath, parkPath);
+      const parked = await lstat(parkPath);
+      const lock = await lstat(context.lockPath);
+      await writeFile(checkpointPath, JSON.stringify({ version: 1, sourcePath: ownerPath, parkPath, lockParkPath, identity: { dev: parked.dev, ino: parked.ino }, lockIdentity: { dev: lock.dev, ino: lock.ino }, phase: 'evidence-pending' }));
+      const successorPid = process.pid + 100_000;
+      const successor = JSON.stringify(validLockOwner({ token: FOREIGN_TOKEN, pid: successorPid }));
+      let swapped = false;
+      await withPointerDependencies({ token: () => { throw new Error('resume must not mint token'); }, probePid: (pid) => pid === successorPid ? 'alive' : 'dead', readProcessIdentity: () => matchingProcessIdentity(), fs: { rename: async (from, to) => {
+        await rename(from, to);
+        if (!swapped && from === context.lockPath && to === lockParkPath) {
+          swapped = true;
+          await mkdir(context.lockPath);
+          await writeFile(ownerPath, successor, 'utf-8');
+        }
+      } } }, async () => {
+        const refused = await recoverSessionPointerLock(cwd);
+        assert.equal(refused.recovered, false);
+        assert.equal(swapped, true);
+        assert.deepEqual(await readdir(context.lockPath), ['owner.json']);
+        assert.equal(await readFile(ownerPath, 'utf-8'), successor);
+        assert.deepEqual(await __releasePointerLockForTests(cwd, FOREIGN_TOKEN), []);
+      });
+      assert.equal(existsSync(context.lockPath), false);
+      assert.equal(existsSync(lockParkPath), false);
+      assert.equal(existsSync(checkpointPath), true);
     } finally { await rm(cwd, { recursive: true, force: true }); }
   });
 
@@ -1349,8 +1524,9 @@ describe('session pointer transaction', () => {
         assert.equal(recovered.recovered, false);
         assert.match(recovered.reason, /Recovery quarantine path already exists/);
       });
-      assert.equal(await readFile(ownerPath, 'utf-8'), owner);
-      assert.equal((await readdir(context.lockPath)).some((entry) => entry.includes('.recovery')), false);
+      assert.equal(existsSync(ownerPath), false);
+      assert.equal(await readFile(`${context.lockPath}.parked-${SUCCESSOR_TOKEN}`, 'utf-8'), owner);
+      assert.equal(await readFile(join(context.lockPath, `owner.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.recovery`), 'utf-8'), owner);
       assert.equal(await readFile(`${context.lockPath}.quarantine.${TEST_TOKEN}.${SUCCESSOR_TOKEN}`, 'utf-8'), marker);
     } finally { await rm(cwd, { recursive: true, force: true }); }
   });
@@ -1385,47 +1561,6 @@ describe('session pointer transaction', () => {
     }
   });
 
-  it('does not overwrite a rollback destination that appears before the no-clobber rollback link', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-rollback-exist-'));
-    try {
-      const context = resolveSessionPointerContext(cwd);
-      const staleOwner = JSON.stringify(validLockOwner());
-      await writeLockOwner(cwd, validLockOwner());
-      const ownerPath = join(context.lockPath, 'owner.json');
-      const claimPath = join(context.lockPath, `owner.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.recovery`);
-      const foreignMarker = 'foreign rollback destination';
-      let armed = false;
-      await withPointerDependencies({
-        token: () => SUCCESSOR_TOKEN,
-        probePid: () => 'dead',
-        fs: {
-          rename: async (from, to) => {
-            await rename(from, to);
-            if (from === ownerPath) armed = true;
-          },
-          readdir: async (path) => {
-            const entries = await readdir(path);
-            if (armed && path === context.lockPath) entries.push('foreign-extra');
-            return entries;
-          },
-          link: async (from, to) => {
-            if (to === ownerPath) await writeFile(to, foreignMarker, 'utf-8');
-            await link(from, to);
-          },
-        },
-      }, async () => {
-        const recovered = await recoverSessionPointerLock(cwd);
-        assert.equal(recovered.recovered, false);
-        assert.equal(recovered.action, 'none');
-        assert.match(recovered.reason, /revalidation failed/i);
-        assert.match(recovered.reason, /reappeared during rollback/i);
-      });
-      assert.equal(await readFile(ownerPath, 'utf-8'), foreignMarker);
-      assert.equal(await readFile(claimPath, 'utf-8'), staleOwner);
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
-  });
 
   it('preserves a swapped parked quarantine claim rather than unlinking it', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-lock-recovery-claim-swap-'));
@@ -1457,15 +1592,15 @@ describe('session pointer transaction', () => {
         const recovered = await recoverSessionPointerLock(cwd);
         assert.equal(recovered.recovered, false);
         assert.equal(recovered.action, 'none');
-        assert.match(recovered.reason, /parked pathname no longer holds the validated identity/i);
-        assert.equal(recovered.quarantinePath, quarantinePath);
+        assert.match(recovered.reason, /checkpoint claim removal failed/i);
+        assert.equal(existsSync(quarantinePath), false);
       });
       assert.ok(parkedPath);
       assert.ok(parkedIdentity);
       const parkedStat = await lstat(parkedPath);
       assert.deepEqual({ dev: parkedStat.dev, ino: parkedStat.ino }, parkedIdentity);
       assert.equal(await readFile(parkedPath, 'utf-8'), foreignMarker);
-      assert.equal(await readFile(quarantinePath, 'utf-8'), staleOwner);
+      assert.equal(await readFile(`${parkedPath}.original`, 'utf-8'), staleOwner);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -1529,11 +1664,10 @@ describe('session pointer transaction', () => {
         const recovered = await recoverSessionPointerLock(cwd);
         assert.equal(recovered.recovered, false);
         assert.equal(recovered.action, 'none');
-        assert.match(recovered.reason, /Unable to inspect recovery quarantine path/);
-        assert.match(recovered.reason, /rolled back/i);
+        assert.match(recovered.reason, /EACCES/);
       });
-      assert.deepEqual(await readdir(context.lockPath), ['owner.json']);
-      assert.equal(await readFile(ownerPath, 'utf-8'), staleOwner);
+      assert.equal(existsSync(ownerPath), false);
+      assert.equal(existsSync(`${context.lockPath}.recovery.${TEST_TOKEN}.${SUCCESSOR_TOKEN}.json`), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -1570,8 +1704,7 @@ describe('session pointer transaction', () => {
         const recovered = await recoverSessionPointerLock(cwd);
         assert.equal(recovered.recovered, false);
         assert.equal(recovered.action, 'none');
-        assert.match(recovered.reason, /canonical lock directory was replaced before removal/i);
-        assert.equal(recovered.quarantinePath, quarantinePath);
+        assert.match(recovered.reason, /checkpoint lock removal failed/i);
       });
       assert.ok(parkedPath);
       assert.ok(parkedIdentity);
@@ -1686,11 +1819,10 @@ describe('session pointer transaction', () => {
       assert.equal(successorBlocked, true);
       assert.match(links[0]![0], /owner\.transaction_token_123456\.tmp$/);
       assert.match(links[0]![1], new RegExp(`owner\\.${TEST_TOKEN}\\.${SUCCESSOR_TOKEN}\\.recovery$`));
-      assert.match(links[1]![0], new RegExp(`owner\\.${TEST_TOKEN}\\.${SUCCESSOR_TOKEN}\\.recovery$`));
+      assert.equal(links[1]![0].startsWith(`${context.lockPath}.parked-`), true);
       assert.equal(links[1]![1].includes('.quarantine.'), true);
       assert.match(renames[0]![0], /owner\.transaction_token_123456\.tmp$/);
-      assert.match(renames[1]![0], new RegExp(`owner\\.${TEST_TOKEN}\\.${SUCCESSOR_TOKEN}\\.recovery$`));
-      assert.equal(renames[2]![0], context.lockPath);
+      assert.equal(renames.some(([from, to]) => from === context.lockPath && to === `${context.lockPath}.parked-lock-${SUCCESSOR_TOKEN}`), true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -1760,8 +1892,7 @@ describe('session pointer transaction', () => {
         const recovered = await recoverSessionPointerLock(cwd);
         assert.equal(recovered.recovered, false);
         assert.equal(recovered.action, 'none');
-        assert.match(recovered.reason, /canonical lock directory was replaced before removal/i);
-        assert.ok(recovered.quarantinePath);
+        assert.match(recovered.reason, /checkpoint lock removal failed/i);
       });
       assert.equal(displaced, true);
       assert.deepEqual(await readdir(context.lockPath), [`owner.${SUCCESSOR_TOKEN}.tmp`]);

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -1086,36 +1086,36 @@ async function removeIfIdentityMatches(
   }
 }
 
-async function rollbackRecoveryClaim(lockPath: string, evidenceName: string, claimName: string, claimIdentity: { dev: number; ino: number }): Promise<{ ok: boolean; reason?: string; residuePath?: string }> {
-  const evidencePath = join(lockPath, evidenceName);
-  const claimPath = join(lockPath, claimName);
-  try { await transactionDependencies.fs.lstat(evidencePath); return { ok: false, reason: 'the original evidence name reappeared' }; } catch (error) { if (!isNotFound(error)) return { ok: false, reason: 'unable to inspect the original evidence name' }; }
-  try { await transactionDependencies.fs.link(claimPath, evidencePath); } catch (error) {
-    if (isAlreadyExists(error)) return { ok: false, reason: 'the original evidence name reappeared during rollback' };
-    return { ok: false, reason: `the exact claim cannot be restored on this filesystem (${errorCode(error) ?? 'unknown'}); it was left in place under its recovery name` };
-  }
-  let restoredStat: Awaited<ReturnType<SessionPointerFsDependencies['lstat']>>;
+async function parkIfIdentityMatches(
+  path: string,
+  parkPath: string,
+  identity: { dev: number; ino: number },
+): Promise<{ parked: boolean; reason?: string; code?: string; residuePath?: string }> {
   try {
-    restoredStat = await transactionDependencies.fs.lstat(evidencePath);
-  } catch {
-    return { ok: false, reason: 'unable to verify the restored evidence name' };
+    await transactionDependencies.fs.lstat(parkPath);
+    return { parked: false, reason: 'a park destination unexpectedly exists' };
+  } catch (error) {
+    if (!isNotFound(error)) return { parked: false, reason: 'unable to inspect a park destination', code: errorCode(error) };
   }
-  if (restoredStat.dev !== claimIdentity.dev || restoredStat.ino !== claimIdentity.ino) {
-    const foreign = await removeIfIdentityMatches(evidencePath, claimIdentity, 'file', lockPath);
-    return { ok: false, reason: 'claim identity changed before rollback; the exact claim was left in place under its recovery name', residuePath: foreign.residuePath };
+  try {
+    await transactionDependencies.fs.rename(path, parkPath);
+  } catch (error) {
+    if (errorCode(error) !== 'EBUSY') return { parked: false, reason: `unable to park the exact pathname (${errorCode(error) ?? 'unknown'})`, code: errorCode(error) };
+    try {
+      await transactionDependencies.fs.rename(path, parkPath);
+    } catch (retryError) {
+      return { parked: false, reason: `unable to park the exact pathname (${errorCode(retryError) ?? 'unknown'})`, code: errorCode(retryError) };
+    }
   }
-  const removal = await removeIfIdentityMatches(claimPath, claimIdentity, 'file', lockPath);
-  if (removal.removed) return { ok: true, residuePath: removal.residuePath };
-  if (removal.residuePath) return { ok: true, residuePath: removal.residuePath };
-  return { ok: false, reason: removal.reason };
+  try {
+    const parked = await transactionDependencies.fs.lstat(parkPath);
+    if (parked.isSymbolicLink() || !parked.isFile() || parked.dev !== identity.dev || parked.ino !== identity.ino) return { parked: false, reason: 'the parked pathname no longer holds the validated identity; it was preserved as residue', residuePath: parkPath };
+    return { parked: true };
+  } catch (error) {
+    return { parked: false, reason: 'unable to verify the parked pathname', code: errorCode(error), residuePath: parkPath };
+  }
 }
 
-function recoveryRollbackReason(prefix: string, rollback: { ok: boolean; reason?: string; residuePath?: string }): string {
-  const residue = rollback.residuePath ? ` Residue preserved at ${rollback.residuePath}; inspect and remove it manually.` : '';
-  return rollback.ok
-    ? `${prefix}; the exact claim was rolled back to its original evidence name without modifying any other bytes.${residue}`
-    : `${prefix}; rollback was not possible: ${rollback.reason}.${residue || ' The exact claim was left in place under its recovery name.'}`;
-}
 
 /** Explicitly quarantine only a dead, atomically claimed pointer lock; never force recovery. */
 export async function recoverSessionPointerLock(cwd: string): Promise<SessionPointerLockRecovery> {
@@ -1124,34 +1124,80 @@ export async function recoverSessionPointerLock(cwd: string): Promise<SessionPoi
   let checkpointNames: string[];
   try {
     checkpointNames = (await transactionDependencies.fs.readdir(dirname(context.lockPath))).filter((name) => name.startsWith(checkpointPrefix) && name.endsWith('.json'));
-  } catch {
-    checkpointNames = [];
+  } catch (error) {
+    if (isNotFound(error)) checkpointNames = [];
+    else return { status: 'io-error', lockPath: context.lockPath, evidenceSource: 'none', safeToRecover: false, action: 'none', recovered: false, reason: 'Unable to enumerate session pointer recovery checkpoints.' };
   }
   if (checkpointNames.length > 1) return { status: 'unexpected', lockPath: context.lockPath, evidenceSource: 'none', safeToRecover: false, action: 'none', recovered: false, reason: 'Multiple recovery checkpoints exist.' };
   if (checkpointNames.length === 1) {
     const checkpointPath = join(dirname(context.lockPath), checkpointNames[0]!);
     const match = new RegExp(`^${basename(context.lockPath).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\.recovery\\.([A-Za-z0-9_-]{16,128})\\.([A-Za-z0-9_-]{16,128})\\.json$`).exec(checkpointNames[0]!);
     try {
-      const checkpoint = JSON.parse(await transactionDependencies.fs.readFile(checkpointPath, 'utf8')) as { version: number; sourcePath: string; parkPath: string; identity: { dev: number; ino: number }; phase: string };
-      if (!match || checkpoint.version !== 1 || checkpoint.phase !== 'evidence-pending' || (checkpoint.sourcePath !== join(context.lockPath, 'owner.json') && checkpoint.sourcePath !== join(context.lockPath, `owner.${match[1]}.tmp`))) throw new Error('invalid checkpoint');
-      const parked = await transactionDependencies.fs.lstat(checkpoint.parkPath);
-      if (parked.isSymbolicLink() || !parked.isFile() || parked.dev !== checkpoint.identity.dev || parked.ino !== checkpoint.identity.ino) throw new Error('checkpoint identity mismatch');
+      const checkpoint = JSON.parse(await transactionDependencies.fs.readFile(checkpointPath, 'utf8')) as { version: number; sourcePath: string; parkPath: string; lockParkPath: string; identity: { dev: number; ino: number }; lockIdentity: { dev: number; ino: number }; phase: string };
+      const expectedParkPrefix = `${context.lockPath}.parked-`;
+      const expectedLockParkPath = `${context.lockPath}.parked-lock-${match?.[2] ?? ''}`;
+      if (!match || checkpoint.version !== 1 || checkpoint.phase !== 'evidence-pending' || (checkpoint.sourcePath !== join(context.lockPath, 'owner.json') && checkpoint.sourcePath !== join(context.lockPath, `owner.${match[1]}.tmp`)) || !checkpoint.parkPath.startsWith(expectedParkPrefix) || !isValidToken(checkpoint.parkPath.slice(expectedParkPrefix.length)) || checkpoint.lockParkPath !== expectedLockParkPath) throw new Error('invalid checkpoint');
       const claimPath = join(context.lockPath, `owner.${match[1]}.${match[2]}.recovery`);
-      const claim = await transactionDependencies.fs.lstat(claimPath);
-      if (claim.isSymbolicLink() || !claim.isFile() || claim.dev !== parked.dev || claim.ino !== parked.ino) throw new Error('checkpoint claim mismatch');
       const quarantinePath = `${context.lockPath}.quarantine.${match[1]}.${match[2]}`;
-      await transactionDependencies.fs.rename(checkpoint.parkPath, quarantinePath);
-      try {
-        await transactionDependencies.fs.unlink(join(context.lockPath, `owner.${match[1]}.${match[2]}.recovery`));
-      } catch (error) {
-        await transactionDependencies.fs.rename(quarantinePath, checkpoint.parkPath);
-        throw error;
+      const lstatIfPresent = async (path: string): Promise<Awaited<ReturnType<SessionPointerFsDependencies['lstat']>> | undefined> => {
+        try { return await transactionDependencies.fs.lstat(path); } catch (error) { if (isNotFound(error)) return undefined; throw error; }
+      };
+      const matchesFileIdentity = (stat: Awaited<ReturnType<SessionPointerFsDependencies['lstat']>> | undefined): boolean => Boolean(stat && !stat.isSymbolicLink() && stat.isFile() && stat.dev === checkpoint.identity.dev && stat.ino === checkpoint.identity.ino);
+      let lock = await lstatIfPresent(context.lockPath);
+      let parkedLock = await lstatIfPresent(checkpoint.lockParkPath);
+      if (lock && parkedLock || lock && (lock.isSymbolicLink() || !lock.isDirectory() || lock.dev !== checkpoint.lockIdentity?.dev || lock.ino !== checkpoint.lockIdentity?.ino) || parkedLock && (parkedLock.isSymbolicLink() || !parkedLock.isDirectory() || parkedLock.dev !== checkpoint.lockIdentity?.dev || parkedLock.ino !== checkpoint.lockIdentity?.ino)) throw new Error('checkpoint lock identity mismatch');
+      let source = await lstatIfPresent(checkpoint.sourcePath);
+      let claim = await lstatIfPresent(claimPath);
+      let parked = await lstatIfPresent(checkpoint.parkPath);
+      let quarantined = await lstatIfPresent(quarantinePath);
+      if (source && (parked || quarantined) || source && !matchesFileIdentity(source) || claim && !matchesFileIdentity(claim) || parked && !matchesFileIdentity(parked) || quarantined && !matchesFileIdentity(quarantined)) throw new Error('checkpoint evidence identity mismatch');
+      if (source) {
+        if (!lock) throw new Error('checkpoint lock missing before evidence transition');
+        if (!claim) {
+          await transactionDependencies.fs.link(checkpoint.sourcePath, claimPath);
+          claim = await transactionDependencies.fs.lstat(claimPath);
+          if (!matchesFileIdentity(claim)) throw new Error('checkpoint claim mismatch');
+        }
+        const parkResult = await parkIfIdentityMatches(checkpoint.sourcePath, checkpoint.parkPath, checkpoint.identity);
+        if (!parkResult.parked) throw new Error(`checkpoint evidence park failed: ${parkResult.reason}`);
+        source = undefined;
+        parked = await transactionDependencies.fs.lstat(checkpoint.parkPath);
       }
-      await transactionDependencies.fs.rmdir(context.lockPath);
+      if (!parked && !quarantined) throw new Error('checkpoint evidence missing');
+      if (parked && !quarantined) {
+        if (!lock || !claim) throw new Error('checkpoint claim missing before quarantine transition');
+        await transactionDependencies.fs.link(checkpoint.parkPath, quarantinePath);
+        quarantined = await transactionDependencies.fs.lstat(quarantinePath);
+      }
+      if (parked && quarantined) {
+        if (!matchesFileIdentity(parked) || !matchesFileIdentity(quarantined)) throw new Error('checkpoint quarantine mismatch');
+        if (claim) {
+          const claimRemoval = await removeIfIdentityMatches(claimPath, checkpoint.identity, 'file', context.lockPath, `${context.lockPath}.parked-claim-${match[2]}`);
+          if (!claimRemoval.removed) {
+            await removeIfIdentityMatches(quarantinePath, checkpoint.identity, 'file', context.lockPath, `${context.lockPath}.parked-quarantine-${match[2]}`);
+            throw new Error('checkpoint claim removal failed');
+          }
+          claim = undefined;
+        }
+        const parkRemoval = await removeIfIdentityMatches(checkpoint.parkPath, checkpoint.identity, 'file', context.lockPath, `${checkpoint.parkPath}.remove-${match[2]}`);
+        if (!parkRemoval.removed) throw new Error('checkpoint park removal failed');
+        parked = undefined;
+      }
+      if (parked || claim || !matchesFileIdentity(quarantined)) throw new Error('checkpoint final evidence state mismatch');
+      lock = await lstatIfPresent(context.lockPath);
+      parkedLock = await lstatIfPresent(checkpoint.lockParkPath);
+      if (lock && parkedLock || lock && (lock.isSymbolicLink() || !lock.isDirectory() || lock.dev !== checkpoint.lockIdentity.dev || lock.ino !== checkpoint.lockIdentity.ino) || parkedLock && (parkedLock.isSymbolicLink() || !parkedLock.isDirectory() || parkedLock.dev !== checkpoint.lockIdentity.dev || parkedLock.ino !== checkpoint.lockIdentity.ino)) throw new Error('checkpoint lock identity changed');
+      if (lock) {
+        const lockRemoval = await removeIfIdentityMatches(context.lockPath, checkpoint.lockIdentity, 'directory', context.lockPath, checkpoint.lockParkPath);
+        if (!lockRemoval.removed) throw new Error('checkpoint lock removal failed');
+      } else if (parkedLock) {
+        await transactionDependencies.fs.rmdir(checkpoint.lockParkPath);
+      }
       await transactionDependencies.fs.unlink(checkpointPath);
       return { status: 'dead', lockPath: context.lockPath, evidenceSource: 'owner.json', safeToRecover: true, action: 'quarantined', recovered: true, reason: 'Dead session pointer lock recovery checkpoint resumed.', quarantinePath };
-    } catch {
-      return { status: 'unexpected', lockPath: context.lockPath, evidenceSource: 'none', safeToRecover: false, action: 'none', recovered: false, reason: 'Recovery checkpoint is malformed or no longer identifies its recorded parked evidence.' };
+    } catch (error) {
+      const detail = isAlreadyExists(error) ? 'Recovery quarantine path already exists.' : error instanceof Error ? error.message : 'unknown';
+      return { status: 'unexpected', lockPath: context.lockPath, evidenceSource: 'none', safeToRecover: false, action: 'none', recovered: false, reason: `Recovery checkpoint is malformed or no longer identifies its recorded recovery state (${detail}).` };
     }
   }
   const inspection = await inspectSessionPointerLockAtContext(context);
@@ -1165,32 +1211,36 @@ export async function recoverSessionPointerLock(cwd: string): Promise<SessionPoi
   const owner = await inspectLockOwnerFile(join(context.lockPath, evidenceName));
   if (owner.status !== 'dead' || !owner.owner || (inspection.evidenceSource === 'owner-temp' && owner.owner.token !== /^owner\.([A-Za-z0-9_-]{16,128})\.tmp$/.exec(evidenceName)?.[1])) return { ...inspection, action: 'none', recovered: false, reason: 'Session pointer lock evidence changed before recovery claim.' };
   let claimToken: string;
-  try { claimToken = transactionDependencies.token(); } catch { return { ...inspection, action: 'none', recovered: false, reason: 'Unable to create recovery claim token.' }; }
-  if (!isValidToken(claimToken)) return { ...inspection, action: 'none', recovered: false, reason: 'Recovery claim token is invalid.' };
+  let evidenceParkToken: string;
+  try {
+    claimToken = transactionDependencies.token();
+    evidenceParkToken = transactionDependencies.token();
+  } catch { return { ...inspection, action: 'none', recovered: false, reason: 'Unable to create recovery claim token.' }; }
+  if (!isValidToken(claimToken) || !isValidToken(evidenceParkToken)) return { ...inspection, action: 'none', recovered: false, reason: 'Recovery claim token is invalid.' };
   const claimName = `owner.${owner.owner.token}.${claimToken}.recovery`;
   const evidencePath = join(context.lockPath, evidenceName);
   const claimPath = join(context.lockPath, claimName);
   try { await transactionDependencies.fs.lstat(claimPath); return { ...inspection, action: 'none', recovered: false, reason: 'Recovery claim path already exists.' }; } catch (error) { if (!isNotFound(error)) return { ...inspection, action: 'none', recovered: false, reason: 'Unable to inspect recovery claim path.' }; }
   const preClaim = await revalidateRecoveryEvidence(context.lockPath, evidenceName);
-  if (!preClaim.ok) return { ...inspection, action: 'none', recovered: false, reason: preClaim.reason };
+  if (!preClaim.ok || preClaim.lockStat.dev !== evidence.lockStat.dev || preClaim.lockStat.ino !== evidence.lockStat.ino || preClaim.evidenceStat.dev !== evidence.evidenceStat.dev || preClaim.evidenceStat.ino !== evidence.evidenceStat.ino) return { ...inspection, action: 'none', recovered: false, reason: 'Session pointer lock evidence changed before recovery claim.' };
+  const currentOwner = await inspectLockOwnerFile(evidencePath);
+  if (currentOwner.status !== 'dead' || currentOwner.owner?.token !== owner.owner.token) return { ...inspection, action: 'none', recovered: false, reason: 'Session pointer lock evidence changed before recovery claim.' };
   try { await transactionDependencies.fs.link(evidencePath, claimPath); } catch (error) { return { ...inspection, action: 'none', recovered: false, reason: isAlreadyExists(error) ? 'Session pointer lock evidence changed before recovery claim.' : `Unable to create exact recovery claim (${errorCode(error) ?? 'unknown'}).` }; }
-  let postLinkClaim: Awaited<ReturnType<SessionPointerFsDependencies['lstat']>>;
-  const cleanupClaim = async (): Promise<string> => {
-    const cleanup = await removeIfIdentityMatches(claimPath, preClaim.evidenceStat, 'file', context.lockPath);
+  const cleanupClaim = async (identity = preClaim.evidenceStat): Promise<string> => {
+    const cleanup = await removeIfIdentityMatches(claimPath, identity, 'file', context.lockPath, `${context.lockPath}.parked-cleanup-${claimToken}`);
     return cleanup.removed
       ? 'The recovery claim was removed.'
       : `The recovery claim could not be removed (${cleanup.reason})${cleanup.residuePath ? `; residue preserved at ${cleanup.residuePath}` : '; it was left in place under its recovery name'}.`;
   };
   try {
-    const [currentEvidence, currentClaim] = await Promise.all([transactionDependencies.fs.lstat(evidencePath), transactionDependencies.fs.lstat(claimPath)]);
-    postLinkClaim = currentClaim;
-    if (currentEvidence.dev !== preClaim.evidenceStat.dev || currentEvidence.ino !== preClaim.evidenceStat.ino || currentClaim.dev !== preClaim.evidenceStat.dev || currentClaim.ino !== preClaim.evidenceStat.ino) {
-      return { ...inspection, action: 'none', recovered: false, reason: `Session pointer lock evidence changed before recovery claim. ${await cleanupClaim()}` };
+    const [currentLock, currentEvidence, currentClaim] = await Promise.all([transactionDependencies.fs.lstat(context.lockPath), transactionDependencies.fs.lstat(evidencePath), transactionDependencies.fs.lstat(claimPath)]);
+    if (currentLock.isSymbolicLink() || !currentLock.isDirectory() || currentLock.dev !== preClaim.lockStat.dev || currentLock.ino !== preClaim.lockStat.ino || currentEvidence.isSymbolicLink() || !currentEvidence.isFile() || currentEvidence.dev !== preClaim.evidenceStat.dev || currentEvidence.ino !== preClaim.evidenceStat.ino || currentClaim.isSymbolicLink() || !currentClaim.isFile() || currentClaim.dev !== preClaim.evidenceStat.dev || currentClaim.ino !== preClaim.evidenceStat.ino) {
+      return { ...inspection, action: 'none', recovered: false, reason: `Session pointer lock evidence changed before recovery claim. ${await cleanupClaim(currentClaim)}` };
     }
   } catch {
     return { ...inspection, action: 'none', recovered: false, reason: `Session pointer lock evidence changed before recovery claim. ${await cleanupClaim()}` };
   }
-  const evidenceParkPath = `${context.lockPath}.parked-${transactionDependencies.token()}`;
+  const evidenceParkPath = `${context.lockPath}.parked-${evidenceParkToken}`;
   const evidenceCheckpointPath = `${context.lockPath}.recovery.${owner.owner.token}.${claimToken}.json`;
   try {
     await transactionDependencies.fs.writeFile(evidenceCheckpointPath, JSON.stringify({
@@ -1198,51 +1248,20 @@ export async function recoverSessionPointerLock(cwd: string): Promise<SessionPoi
       sourcePath: evidencePath,
       parkPath: evidenceParkPath,
       identity: { dev: preClaim.evidenceStat.dev, ino: preClaim.evidenceStat.ino },
+      lockIdentity: { dev: preClaim.lockStat.dev, ino: preClaim.lockStat.ino },
+      lockParkPath: `${context.lockPath}.parked-lock-${claimToken}`,
       phase: 'evidence-pending',
     }), { flag: 'wx' });
   } catch (error) {
     const cleanup = await cleanupClaim();
     return { ...inspection, action: 'none', recovered: false, reason: `Unable to create recovery checkpoint (${errorCode(error) ?? 'unknown'}). ${cleanup}` };
   }
-  const evidenceRemoval = await removeIfIdentityMatches(evidencePath, preClaim.evidenceStat, 'file', context.lockPath, evidenceParkPath);
-  if (!evidenceRemoval.removed) {
+  const evidenceRemoval = await parkIfIdentityMatches(evidencePath, evidenceParkPath, preClaim.evidenceStat);
+  if (!evidenceRemoval.parked) {
     const cleanup = await cleanupClaim();
-    try { await transactionDependencies.fs.unlink(evidenceCheckpointPath); } catch { /* Preserve the checkpoint if cleanup cannot remove it. */ }
-    return { ...inspection, action: 'none', recovered: false, reason: `The exact recovery claim was created, but its original evidence name could not be removed (${evidenceRemoval.reason}). ${cleanup}${evidenceRemoval.residuePath ? ` Residue preserved at ${evidenceRemoval.residuePath}; inspect and remove it manually.` : ''}` };
+    return { ...inspection, action: 'none', recovered: false, reason: `The exact recovery claim was created, but its original evidence name could not be parked (${evidenceRemoval.reason}). ${cleanup}${evidenceRemoval.residuePath ? ` Residue preserved at ${evidenceRemoval.residuePath}; inspect and remove it manually.` : ''}` };
   }
-  try { await transactionDependencies.fs.unlink(evidenceCheckpointPath); } catch (error) { if (!isNotFound(error)) return { ...inspection, action: 'none', recovered: false, reason: 'The exact recovery evidence checkpoint could not be removed.' }; }
-  const claimIdentity = { dev: postLinkClaim.dev, ino: postLinkClaim.ino };
-  const claimed = await inspectSessionPointerLockAtContext(context);
-  if (claimed.status !== 'unexpected') {
-    const rollback = await rollbackRecoveryClaim(context.lockPath, evidenceName, claimName, claimIdentity);
-    return { ...claimed, action: 'none', recovered: false, reason: recoveryRollbackReason('Recovery claim revalidation failed', rollback) };
-  }
-  let claimedEntries: string[] | undefined;
-  let claimedClaimLstat: Awaited<ReturnType<SessionPointerFsDependencies['lstat']>> | undefined;
-  try { claimedEntries = await transactionDependencies.fs.readdir(context.lockPath); } catch { /* Roll back below. */ }
-  try { claimedClaimLstat = await transactionDependencies.fs.lstat(claimPath); } catch { /* Roll back below. */ }
-  const claimOwner = claimedClaimLstat && !claimedClaimLstat.isSymbolicLink() && claimedClaimLstat.isFile() ? await inspectLockOwnerFile(claimPath) : { status: 'unexpected' as const };
-  if (!claimedEntries || claimedEntries.length !== 1 || claimedEntries[0] !== claimName || claimOwner.status !== 'dead' || claimOwner.owner?.token !== owner.owner.token || !claimedClaimLstat || claimedClaimLstat.isSymbolicLink() || !claimedClaimLstat.isFile() || claimedClaimLstat.dev !== claimIdentity.dev || claimedClaimLstat.ino !== claimIdentity.ino) {
-    const rollback = await rollbackRecoveryClaim(context.lockPath, evidenceName, claimName, claimIdentity);
-    return { ...claimed, action: 'none', recovered: false, reason: recoveryRollbackReason('Recovery claim revalidation failed', rollback) };
-  }
-  const quarantinePath = `${context.lockPath}.quarantine.${owner.owner.token}.${claimToken}`;
-  let quarantineFailure: string | undefined;
-  try {
-    const [lockStat, claimStat] = await Promise.all([transactionDependencies.fs.lstat(context.lockPath), transactionDependencies.fs.lstat(claimPath)]);
-    if (lockStat.isSymbolicLink() || !lockStat.isDirectory() || lockStat.dev !== preClaim.lockStat.dev || lockStat.ino !== preClaim.lockStat.ino || claimStat.isSymbolicLink() || !claimStat.isFile() || claimStat.dev !== claimIdentity.dev || claimStat.ino !== claimIdentity.ino) quarantineFailure = 'Unable to quarantine the exact session pointer recovery claim';
-  } catch { quarantineFailure = 'Unable to quarantine the exact session pointer recovery claim'; }
-  if (!quarantineFailure) try { await transactionDependencies.fs.lstat(quarantinePath); quarantineFailure = 'Recovery quarantine path already exists.'; } catch (error) { if (!isNotFound(error)) quarantineFailure = 'Unable to inspect recovery quarantine path.'; }
-  if (quarantineFailure) { const rollback = await rollbackRecoveryClaim(context.lockPath, evidenceName, claimName, claimIdentity); return { ...claimed, action: 'none', recovered: false, reason: recoveryRollbackReason(quarantineFailure, rollback) }; }
-  try { await transactionDependencies.fs.link(claimPath, quarantinePath); } catch (error) { const rollback = await rollbackRecoveryClaim(context.lockPath, evidenceName, claimName, claimIdentity); return { ...claimed, action: 'none', recovered: false, reason: recoveryRollbackReason(isAlreadyExists(error) ? 'Recovery quarantine path already exists.' : `Unable to quarantine the exact session pointer recovery claim (${errorCode(error) ?? 'unknown'})`, rollback) }; }
-  const claimRemoval = await removeIfIdentityMatches(claimPath, claimIdentity, 'file', context.lockPath);
-  if (!claimRemoval.removed) return { ...claimed, action: 'none', recovered: false, reason: `The exact recovery claim was quarantined, but its recovery name could not be removed (${claimRemoval.reason}).${claimRemoval.residuePath ? ` Residue preserved at ${claimRemoval.residuePath}; inspect and remove it manually.` : ''}`, quarantinePath };
-  const lockRemoval = await removeIfIdentityMatches(context.lockPath, preClaim.lockStat, 'directory', context.lockPath);
-  if (!lockRemoval.removed) {
-    const residue = lockRemoval.residuePath ? ` Residue preserved at ${lockRemoval.residuePath}; inspect and remove it manually.` : '';
-    return { ...claimed, action: 'none', recovered: false, reason: lockRemoval.code === 'ENOTEMPTY' ? `The exact recovery claim was quarantined, but the canonical lock directory was not empty.${residue}` : `The exact recovery claim was quarantined, but the canonical lock directory was replaced before removal.${residue}`, quarantinePath };
-  }
-  return { ...inspection, action: 'quarantined', recovered: true, reason: 'Dead session pointer lock was atomically claimed and quarantined.', quarantinePath };
+  return await recoverSessionPointerLock(cwd);
 }
 
 interface HeldPointerLock {

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -1234,8 +1234,15 @@ export async function recoverSessionPointerLock(cwd: string): Promise<SessionPoi
   };
   try {
     const [currentLock, currentEvidence, currentClaim] = await Promise.all([transactionDependencies.fs.lstat(context.lockPath), transactionDependencies.fs.lstat(evidencePath), transactionDependencies.fs.lstat(claimPath)]);
-    if (currentLock.isSymbolicLink() || !currentLock.isDirectory() || currentLock.dev !== preClaim.lockStat.dev || currentLock.ino !== preClaim.lockStat.ino || currentEvidence.isSymbolicLink() || !currentEvidence.isFile() || currentEvidence.dev !== preClaim.evidenceStat.dev || currentEvidence.ino !== preClaim.evidenceStat.ino || currentClaim.isSymbolicLink() || !currentClaim.isFile() || currentClaim.dev !== preClaim.evidenceStat.dev || currentClaim.ino !== preClaim.evidenceStat.ino) {
-      return { ...inspection, action: 'none', recovered: false, reason: `Session pointer lock evidence changed before recovery claim. ${await cleanupClaim(currentClaim)}` };
+    const claimMatchesOriginal = !currentClaim.isSymbolicLink() && currentClaim.isFile() && currentClaim.dev === preClaim.evidenceStat.dev && currentClaim.ino === preClaim.evidenceStat.ino;
+    const claimMatchesCurrentEvidence = !currentClaim.isSymbolicLink() && currentClaim.isFile() && !currentEvidence.isSymbolicLink() && currentEvidence.isFile() && currentClaim.dev === currentEvidence.dev && currentClaim.ino === currentEvidence.ino;
+    if (currentLock.isSymbolicLink() || !currentLock.isDirectory() || currentLock.dev !== preClaim.lockStat.dev || currentLock.ino !== preClaim.lockStat.ino || currentEvidence.isSymbolicLink() || !currentEvidence.isFile() || currentEvidence.dev !== preClaim.evidenceStat.dev || currentEvidence.ino !== preClaim.evidenceStat.ino || !claimMatchesOriginal) {
+      const cleanup = claimMatchesOriginal
+        ? await cleanupClaim()
+        : claimMatchesCurrentEvidence
+          ? await cleanupClaim(currentClaim)
+          : 'The recovery claim path contains foreign evidence and was left untouched.';
+      return { ...inspection, action: 'none', recovered: false, reason: `Session pointer lock evidence changed before recovery claim. ${cleanup}` };
     }
   } catch {
     return { ...inspection, action: 'none', recovered: false, reason: `Session pointer lock evidence changed before recovery claim. ${await cleanupClaim()}` };


### PR DESCRIPTION
## Summary

Post-merge hardening follow-up for #3261 after the reproduced review blocker on merged PR #3262.

- make recovery checkpoints idempotently resume from source+claim, parked+claim, parked+quarantine, quarantined+claim-absent, lock-parked, and lock-removed states
- bind every checkpoint to the exact evidence and lock-directory dev/ino identities and constrained recovery paths
- use no-clobber hard-link quarantine creation and deterministic post-claim cleanup paths
- preserve checkpoints across uncertain evidence parking and transient final lock removal failures
- fail closed on checkpoint enumeration I/O errors while preserving absent behavior for fresh workspaces
- refuse successor/foreign directory incarnations without polluting or removing them

## Regressions

- one-shot final-rmdir EBUSY and ENOTEMPTY followed by a fault-free retry
- live successor swap before final lock removal remains byte-identical, releasable, and unpolluted
- source+claim and parked+quarantine crash checkpoints resume
- checkpoint path/schema, inode, collision, symlink, and partial-state adversarial cases
- fresh workspace ENOENT versus checkpoint enumeration EACCES

## Verification

- `npm run build`
- focused session suite: 107/107
- grouped hooks + session CLI lane: 66 files, exit 0
- `npm run check:no-unused`
- `npm run lint`
- `git diff --check`
- independent terminal architecture review: CLEAR / APPROVE on the pre-commit worktree

No merge, tag, release, or main-branch mutation is included. This PR is ready for independent exact-head review.

Signed: GJC post-merge corrective lane