### PR TITLE
fix(hooks): drain oversized native hook stdin

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -29,6 +29,10 @@ Project-scoped resume and search discovery include generated runtime homes under
 
 `omx doctor` can confirm that these files exist and are shaped correctly. It does not prove that the same shell/profile can complete an authenticated Codex request; use `codex login status` plus a real `omx exec --skip-git-repo-check -C . "Reply with exactly OMX-EXEC-OK"` smoke test for that boundary.
 
+The native hook CLI retains at most 1 MiB of stdin for parsing. It still drains
+the complete stream when that limit is exceeded so Codex can finish writing the
+event payload without receiving `EPIPE`.
+
 ## Ownership split
 
 - **Plugin-scoped Codex hooks**: `plugins/oh-my-codex/hooks/hooks.json` for plugin installs on Codex versions with `[features].plugin_hooks`

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { existsSync, realpathSync } from "node:fs";
 import {
 	chmod,
@@ -2176,6 +2176,26 @@ PY`,
 		} finally {
 			await rm(cwd, { recursive: true, force: true });
 		}
+	});
+
+	it("drains oversized stdin without breaking the parent writer pipe", async () => {
+		const child = spawn(process.execPath, [nativeHookScriptPath()], {
+			stdio: ["pipe", "ignore", "ignore"],
+		});
+		const payload = JSON.stringify({
+			hook_event_name: "UserPromptSubmit",
+			prompt: "x".repeat(MAX_NATIVE_STDIN_JSON_BYTES * 2),
+		});
+		const exitCode = new Promise<number | null>((resolve) => {
+			child.once("close", resolve);
+		});
+		const writeError = await new Promise<Error | null>((resolve) => {
+			child.stdin.once("error", resolve);
+			child.stdin.end(payload, () => resolve(null));
+		});
+
+		assert.equal(writeError, null);
+		assert.equal(await exitCode, 0);
 	});
 
 	it("blocks oversized Stop stdin when current session autopilot is active", async () => {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -21013,8 +21013,7 @@ async function readStdinJson(): Promise<NativeHookCliReadResult> {
       const remaining = Math.max(0, MAX_NATIVE_STDIN_JSON_BYTES - (totalBytes - buffer.byteLength));
       if (remaining > 0) chunks.push(Buffer.from(buffer.subarray(0, remaining)));
       oversized = true;
-      process.stdin.destroy();
-      break;
+      continue;
     }
     chunks.push(buffer);
   }


### PR DESCRIPTION
## Summary

Codex writes each native hook event as a complete stdin stream. The current 1 MiB guard destroys stdin as soon as the retained parsing limit is reached, which can make the parent writer fail with `Broken pipe (os error 32)`.

## Changes

- keep the existing 1 MiB parsing cap
- discard bytes beyond the cap while draining the stream to EOF
- add a child-process regression test that fails with `write EPIPE` before the fix
- document the bounded-retention/full-drain contract

## Validation

- [x] `npm run build`
- [x] `npx biome lint src/scripts/codex-native-hook.ts src/scripts/__tests__/codex-native-hook.test.ts`
- [x] `npm run check:no-unused`
- [x] new oversized parent-writer regression test
- [x] oversized native-hook tests: 6 passed on the original base before rebasing to `dev`
- [ ] full native-hook file: unrelated existing `allows Ralplan Markdown draft-only...` failure on macOS because an absolute `/var/folders/.../.omx/drafts` path is rejected

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Native hook documentation updated
- [x] Backward compatibility preserved: oversized payload handling remains fail-closed

## Related

No existing issue found for the exact `failed to write hook stdin: Broken pipe` error.