### PR TITLE
fix(auth): validate metadata before credential switch

### DIFF
--- a/src/auth/__tests__/storage.test.ts
+++ b/src/auth/__tests__/storage.test.ts
@@ -5,7 +5,13 @@ import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { atomicWriteFile, addSlotFromAuthFile, listSlots, readAuthMetadata, useSlot } from "../storage.js";
-import { resolveLiveAuthPath, resolveOmxAuthDir, resolveSlotPath, validateSlotName } from "../paths.js";
+import {
+  resolveAuthMetadataPath,
+  resolveLiveAuthPath,
+  resolveOmxAuthDir,
+  resolveSlotPath,
+  validateSlotName,
+} from "../paths.js";
 
 async function tempHome(): Promise<string> {
   return await mkdtemp(join(tmpdir(), "omx-auth-storage-"));
@@ -90,6 +96,45 @@ describe("auth slot storage", () => {
       );
       assert.equal(await readFile(target, "utf-8"), "original\n");
       assert.equal(existsSync(`${target}.tmp`), false);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps live auth unchanged when slot metadata is malformed", async () => {
+    const home = await tempHome();
+    try {
+      const live = join(home, ".codex", "auth.json");
+      await mkdir(join(home, ".codex"), { recursive: true });
+      await mkdir(resolveOmxAuthDir(home), { recursive: true });
+      await writeFile(live, '{"access_token":"original"}\n');
+      await writeFile(resolveSlotPath("work", home), '{"access_token":"replacement"}\n');
+      await writeFile(resolveAuthMetadataPath(home), "{not-json\n");
+
+      await assert.rejects(useSlot("work", live, home));
+
+      assert.equal(await readFile(live, "utf-8"), '{"access_token":"original"}\n');
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps live auth unchanged when slot metadata contains an invalid slot", async () => {
+    const home = await tempHome();
+    try {
+      const live = join(home, ".codex", "auth.json");
+      await mkdir(join(home, ".codex"), { recursive: true });
+      await mkdir(resolveOmxAuthDir(home), { recursive: true });
+      await writeFile(live, '{"access_token":"original"}\n');
+      await writeFile(resolveSlotPath("work", home), '{"access_token":"replacement"}\n');
+      await writeFile(
+        resolveAuthMetadataPath(home),
+        `${JSON.stringify({ version: 1, slots: [{ slot: "../invalid" }] })}\n`,
+      );
+
+      await assert.rejects(useSlot("work", live, home), /invalid auth slot name/);
+
+      assert.equal(await readFile(live, "utf-8"), '{"access_token":"original"}\n');
     } finally {
       await rm(home, { recursive: true, force: true });
     }

--- a/src/auth/storage.ts
+++ b/src/auth/storage.ts
@@ -126,11 +126,11 @@ export async function useSlot(
   const safeSlot = validateSlotName(slot);
   const slotPath = resolveSlotPath(safeSlot, home);
   await assertReadableFile(slotPath, `auth slot ${safeSlot}`);
+  const metadata = await readAuthMetadata(home);
   await ensurePrivateDir(dirname(liveAuthPath));
   await assertNoSymlink(liveAuthPath, "live Codex auth.json");
   const data = await readFile(slotPath);
   await atomicWriteFile(liveAuthPath, data, { mode: AUTH_FILE_MODE });
-  const metadata = await readAuthMetadata(home);
   const record = upsertSlotRecord(metadata, safeSlot, now.toISOString());
   record.lastUsedAt = now.toISOString();
   delete record.exhaustedAt;


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

`omx auth use <slot>` could report failure after it had already replaced the live Codex credentials. `useSlot()` parsed and validated `slots.json` only after committing the live `auth.json` replacement, so malformed or legacy-invalid metadata produced a partial commit.

This change performs that deterministic metadata preflight before mutating live credentials.

## Changes

- Read and validate auth slot metadata before replacing live `auth.json`.
- Reuse the validated metadata for the existing `currentSlot`/`lastUsedAt` update.
- Add regression coverage for malformed JSON and invalid slot-name metadata, asserting that failed switches preserve the original live credentials.

## Validation

- [x] `npm run build`
- [x] `node --test dist/auth/__tests__/storage.test.js` — 8/8 pass
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [ ] `npm test` — attempted in both sandboxed and elevated local runs; the elevated run reached unrelated macOS-only failures in `launch-fallback.test.js` because BSD `script` rejects the test fixture's `-c` flag. The focused auth suite and all static gates above are green; full Linux coverage is left to PR CI.
- [ ] `omx doctor` — not applicable; setup/config behavior is unchanged

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed — not needed; this preserves the documented CLI behavior
- [x] Backward-compatibility impact considered — successful slot switching is unchanged

## Related

Closes #3275
