### PR TITLE
fix(native-assets): validate cached binaries before reuse

### DIFF
--- a/src/cli/__tests__/api.test.ts
+++ b/src/cli/__tests__/api.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -13,6 +14,7 @@ import {
   resolveApiBinaryPathWithHydration,
   runApiBinary,
 } from '../api.js';
+import { resolveCachedNativeBinaryChecksumPath } from '../native-assets.js';
 
 function runOmx(
   cwd: string,
@@ -101,8 +103,13 @@ describe('resolveApiBinaryPath', () => {
       const cachedDir = join(cacheDir, '0.8.15', 'linux-x64-musl', 'omx-api');
       const cachedBinary = join(cachedDir, 'omx-api');
       await mkdir(cachedDir, { recursive: true });
-      await writeFile(cachedBinary, '#!/bin/sh\n');
+      const cachedContent = '#!/bin/sh\n';
+      await writeFile(cachedBinary, cachedContent);
       await chmod(cachedBinary, 0o755);
+      await writeFile(
+        resolveCachedNativeBinaryChecksumPath(cachedBinary),
+        `${createHash('sha256').update(cachedContent).digest('hex')}\n`,
+      );
 
       assert.equal(
         await resolveApiBinaryPathWithHydration({
@@ -118,6 +125,8 @@ describe('resolveApiBinaryPath', () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+
 });
 
 describe('runApiBinary', () => {

--- a/src/cli/__tests__/native-assets.test.ts
+++ b/src/cli/__tests__/native-assets.test.ts
@@ -1,7 +1,7 @@
 import { createServer } from 'node:http';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -11,6 +11,7 @@ import {
   inferNativeAssetLibc,
   isRepositoryCheckout,
   resolveCachedNativeBinaryCandidatePaths,
+  resolveCachedNativeBinaryChecksumPath,
   resolveCachedNativeBinaryPath,
   type NativeReleaseManifest,
   resolveNativeReleaseAssetCandidates,
@@ -218,6 +219,69 @@ describe('native asset helpers', () => {
           OMX_NATIVE_CACHE_DIR: cacheDir,
         }, 'musl'));
         assert.equal(await readFile(hydrated!, 'utf-8'), '#!/bin/sh\necho hydrated\n');
+
+        const cached = await hydrateNativeBinary('omx-sparkshell', {
+          packageRoot: wd,
+          env: {
+            OMX_NATIVE_MANIFEST_URL: 'http://127.0.0.1:1/unreachable-manifest.json',
+            OMX_NATIVE_CACHE_DIR: cacheDir,
+          },
+          platform: 'linux',
+          arch: 'x64',
+        });
+        assert.equal(cached, hydrated, 'expected a verified cache hit without another manifest request');
+
+        await writeFile(hydrated!, '');
+        assert.equal(
+          await hydrateNativeBinary('omx-sparkshell', {
+            packageRoot: wd,
+            env: {
+              OMX_NATIVE_MANIFEST_URL: `${server.baseUrl}/native-release-manifest.json`,
+              OMX_NATIVE_CACHE_DIR: cacheDir,
+            },
+            platform: 'linux',
+            arch: 'x64',
+          }),
+          hydrated,
+        );
+        assert.equal(await readFile(hydrated!, 'utf-8'), '#!/bin/sh\necho hydrated\n');
+
+        await rm(resolveCachedNativeBinaryChecksumPath(hydrated!), { force: true });
+        await writeFile(hydrated!, '#!/bin/sh\nech');
+        assert.equal(
+          await hydrateNativeBinary('omx-sparkshell', {
+            packageRoot: wd,
+            env: {
+              OMX_NATIVE_MANIFEST_URL: `${server.baseUrl}/native-release-manifest.json`,
+              OMX_NATIVE_CACHE_DIR: cacheDir,
+            },
+            platform: 'linux',
+            arch: 'x64',
+          }),
+          hydrated,
+        );
+        assert.equal(await readFile(hydrated!, 'utf-8'), '#!/bin/sh\necho hydrated\n');
+
+        await rm(hydrated!, { force: true });
+        await mkdir(hydrated!);
+        assert.equal(
+          await hydrateNativeBinary('omx-sparkshell', {
+            packageRoot: wd,
+            env: {
+              OMX_NATIVE_MANIFEST_URL: `${server.baseUrl}/native-release-manifest.json`,
+              OMX_NATIVE_CACHE_DIR: cacheDir,
+            },
+            platform: 'linux',
+            arch: 'x64',
+          }),
+          hydrated,
+        );
+        assert.equal(await readFile(hydrated!, 'utf-8'), '#!/bin/sh\necho hydrated\n');
+        assert.deepEqual(
+          await readdir(join(hydrated!, '..')),
+          ['omx-sparkshell', 'omx-sparkshell.sha256'],
+          'expected atomic cache publication to leave no temporary files behind',
+        );
       } finally {
         await server.close();
       }
@@ -316,6 +380,85 @@ describe('native asset helpers', () => {
           arch: 'x64',
         });
         assert.equal(hydrated, undefined);
+      } finally {
+        await server.close();
+      }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves a non-empty legacy cache entry when the manifest is unavailable', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-native-hydrate-legacy-offline-'));
+    try {
+      await writeFile(join(wd, 'package.json'), JSON.stringify({
+        version: '0.8.15',
+        repository: { url: 'git+https://github.com/Yeachan-Heo/oh-my-codex.git' },
+      }));
+      const cacheDir = join(wd, 'cache');
+      const cachedBinary = resolveCachedNativeBinaryPath('omx-sparkshell', '0.8.15', 'linux', 'x64', {
+        OMX_NATIVE_CACHE_DIR: cacheDir,
+      }, 'musl');
+      await mkdir(join(cachedBinary, '..'), { recursive: true });
+      await writeFile(cachedBinary, '#!/bin/sh\necho legacy\n');
+
+      assert.equal(
+        await hydrateNativeBinary('omx-sparkshell', {
+          packageRoot: wd,
+          env: {
+            OMX_NATIVE_AUTO_FETCH: '0',
+            OMX_NATIVE_CACHE_DIR: cacheDir,
+          },
+          platform: 'linux',
+          arch: 'x64',
+        }),
+        cachedBinary,
+      );
+
+      const missingRoot = join(wd, 'missing-assets');
+      await mkdir(missingRoot, { recursive: true });
+      const server = await startStaticServer(missingRoot);
+      try {
+        assert.equal(
+          await hydrateNativeBinary('omx-sparkshell', {
+            packageRoot: wd,
+            env: {
+              OMX_NATIVE_MANIFEST_URL: `${server.baseUrl}/native-release-manifest.json`,
+              OMX_NATIVE_CACHE_DIR: cacheDir,
+            },
+            platform: 'linux',
+            arch: 'x64',
+          }),
+          cachedBinary,
+        );
+
+        await writeFile(join(missingRoot, 'native-release-manifest.json'), JSON.stringify({
+          version: '0.8.15',
+          assets: [{
+            product: 'omx-sparkshell',
+            version: '0.8.15',
+            platform: 'linux',
+            arch: 'x64',
+            libc: 'musl',
+            archive: 'missing.tar.gz',
+            binary: 'omx-sparkshell',
+            binary_path: 'omx-sparkshell',
+            sha256: '0'.repeat(64),
+            download_url: `${server.baseUrl}/missing.tar.gz`,
+          }],
+        }));
+        assert.equal(
+          await hydrateNativeBinary('omx-sparkshell', {
+            packageRoot: wd,
+            env: {
+              OMX_NATIVE_MANIFEST_URL: `${server.baseUrl}/native-release-manifest.json`,
+              OMX_NATIVE_CACHE_DIR: cacheDir,
+            },
+            platform: 'linux',
+            arch: 'x64',
+          }),
+          cachedBinary,
+        );
       } finally {
         await server.close();
       }

--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 import {
   isSparkShellNativeCompatibilityFailure,
   nestedRepoLocalSparkShellBinaryPath,
+  packagedSparkShellBinaryPath,
   packagedSparkShellBinaryCandidatePaths,
   parseSparkShellFallbackInvocation,
   repoLocalSparkShellBinaryPath,
@@ -19,6 +20,7 @@ import {
   resolveSparkShellBinaryPathWithHydration,
   runSparkShellBinary,
 } from '../sparkshell.js';
+import { resolveCachedNativeBinaryChecksumPath } from '../native-assets.js';
 import { buildCapturePaneArgv as buildNotificationCapturePaneArgv } from '../../notifications/tmux-detector.js';
 
 function runOmx(
@@ -217,6 +219,33 @@ describe('resolveSparkShellBinaryPath', () => {
       } finally {
         await server.close();
       }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('skips an empty cached binary in favor of a usable packaged binary', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-sparkshell-invalid-cache-'));
+    try {
+      const cacheDir = join(wd, 'cache');
+      const cachedBinary = join(cacheDir, '0.8.15', 'linux-x64-musl', 'omx-sparkshell', 'omx-sparkshell');
+      const packagedBinary = packagedSparkShellBinaryPath(wd, 'linux', 'x64', 'musl');
+      await writeFile(join(wd, 'package.json'), JSON.stringify({ version: '0.8.15' }));
+      await mkdir(dirname(cachedBinary), { recursive: true });
+      await writeFile(cachedBinary, '');
+      await mkdir(dirname(packagedBinary), { recursive: true });
+      await writeFile(packagedBinary, '#!/bin/sh\n');
+
+      assert.equal(
+        await resolveSparkShellBinaryPathWithHydration({
+          packageRoot: wd,
+          platform: 'linux',
+          arch: 'x64',
+          linuxLibcPreference: ['musl', 'glibc'],
+          env: { OMX_NATIVE_CACHE_DIR: cacheDir, OMX_NATIVE_AUTO_FETCH: '0' },
+        }),
+        packagedBinary,
+      );
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -536,6 +565,10 @@ describe('omx sparkshell', () => {
           : "#!/bin/sh\necho \"omx-sparkshell: /lib/x86_64-linux-gnu/libc.so.6: version \\`GLIBC_2.39' not found\" 1>&2\nexit 1\n",
       );
       if (process.platform !== 'win32') await chmod(stubPath, 0o755);
+      await writeFile(
+        resolveCachedNativeBinaryChecksumPath(stubPath),
+        `${createHash('sha256').update(await readFile(stubPath)).digest('hex')}\n`,
+      );
 
       const result = runOmx(cwd, ['sparkshell', 'node', '-e', 'process.stdout.write("raw-fallback\\n")'], {
         OMX_NATIVE_CACHE_DIR: cacheDir,

--- a/src/cli/api.ts
+++ b/src/cli/api.ts
@@ -12,6 +12,7 @@ import {
   API_BIN_ENV as API_BIN_ENV_SHARED,
   getPackageVersion,
   hydrateNativeBinary,
+  isVerifiedCachedNativeBinary,
   resolveCachedNativeBinaryCandidatePaths,
   resolveLinuxNativeLibcPreference,
 } from './native-assets.js';
@@ -154,7 +155,7 @@ export async function resolveApiBinaryPathWithHydration(
       ? (linuxLibcPreference ?? resolveLinuxNativeLibcPreference({ env }))
       : undefined,
   })) {
-    if (exists(cached)) return cached;
+    if (exists(cached) && await isVerifiedCachedNativeBinary(cached)) return cached;
   }
 
   for (const packaged of packagedApiBinaryCandidatePaths(packageRoot, platform, arch, env, linuxLibcPreference)) {

--- a/src/cli/native-assets.ts
+++ b/src/cli/native-assets.ts
@@ -1,8 +1,8 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { chmodSync, createWriteStream, existsSync, readdirSync } from 'node:fs';
-import { copyFile, mkdir, mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
+import { copyFile, mkdir, mkdtemp, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
-import { dirname, extname, join, resolve } from 'node:path';
+import { basename, dirname, extname, join, resolve } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { Readable } from 'node:stream';
 import { spawnPlatformCommandSync } from '../utils/platform-command.js';
@@ -200,6 +200,35 @@ export function resolveCachedNativeBinaryCandidatePaths(
   return [...new Set(candidates)];
 }
 
+export function resolveCachedNativeBinaryChecksumPath(binaryPath: string): string {
+  return `${binaryPath}.sha256`;
+}
+
+type CachedNativeBinaryState = 'missing' | 'invalid' | 'legacy' | 'verified';
+
+async function inspectCachedNativeBinary(binaryPath: string): Promise<CachedNativeBinaryState> {
+  try {
+    const binaryStat = await stat(binaryPath);
+    if (!binaryStat.isFile() || binaryStat.size === 0) return 'invalid';
+  } catch {
+    return 'missing';
+  }
+
+  const checksumPath = resolveCachedNativeBinaryChecksumPath(binaryPath);
+  if (!existsSync(checksumPath)) return 'legacy';
+  try {
+    const expectedDigest = (await readFile(checksumPath, 'utf-8')).trim().toLowerCase();
+    if (!/^[a-f0-9]{64}$/.test(expectedDigest)) return 'invalid';
+    return await sha256ForFile(binaryPath) === expectedDigest ? 'verified' : 'invalid';
+  } catch {
+    return 'invalid';
+  }
+}
+
+export async function isVerifiedCachedNativeBinary(binaryPath: string): Promise<boolean> {
+  return await inspectCachedNativeBinary(binaryPath) === 'verified';
+}
+
 export function resolveNativeReleaseAssetCandidates(
   manifest: NativeReleaseManifest,
   product: NativeProduct,
@@ -318,6 +347,42 @@ async function findExtractedBinaryPath(rootDir: string, binaryPath: string): Pro
   return undefined;
 }
 
+async function publishCachedNativeBinary(
+  sourcePath: string,
+  destinationPath: string,
+  platform: NodeJS.Platform,
+): Promise<void> {
+  const destinationDir = dirname(destinationPath);
+  await mkdir(destinationDir, { recursive: true });
+  const tempPath = join(
+    destinationDir,
+    `.${basename(destinationPath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  const checksumPath = resolveCachedNativeBinaryChecksumPath(destinationPath);
+  const checksumTempPath = `${tempPath}.sha256`;
+  try {
+    await copyFile(sourcePath, tempPath);
+    if (platform !== 'win32') chmodSync(tempPath, 0o755);
+    await writeFile(checksumTempPath, `${await sha256ForFile(tempPath)}\n`, { mode: 0o600 });
+
+    for (const publishedPath of [destinationPath, checksumPath]) {
+      try {
+        if ((await stat(publishedPath)).isDirectory()) {
+          await rm(publishedPath, { recursive: true, force: true });
+        }
+      } catch {
+        // Missing paths and unreadable stale entries are handled by rename below.
+      }
+    }
+
+    await rename(tempPath, destinationPath);
+    await rename(checksumTempPath, checksumPath);
+  } finally {
+    await rm(tempPath, { force: true });
+    await rm(checksumTempPath, { force: true });
+  }
+}
+
 export async function hydrateNativeBinary(
   product: NativeProduct,
   options: HydrateNativeBinaryOptions = {},
@@ -329,26 +394,29 @@ export async function hydrateNativeBinary(
     arch = process.arch,
   } = options;
 
-  if (env[NATIVE_AUTO_FETCH_ENV]?.trim() === '0') return undefined;
   if (!['linux', 'darwin', 'win32'].includes(platform)) return undefined;
   if (!['x64', 'arm64'].includes(arch)) return undefined;
 
   const version = await getPackageVersion(packageRoot);
+  let legacyCachedBinaryPath: string | undefined;
   for (const cachedBinaryPath of resolveCachedNativeBinaryCandidatePaths(product, version, platform, arch, env)) {
-    if (existsSync(cachedBinaryPath)) return cachedBinaryPath;
+    const cacheState = await inspectCachedNativeBinary(cachedBinaryPath);
+    if (cacheState === 'verified') return cachedBinaryPath;
+    if (cacheState === 'legacy') legacyCachedBinaryPath ??= cachedBinaryPath;
   }
+  if (env[NATIVE_AUTO_FETCH_ENV]?.trim() === '0') return legacyCachedBinaryPath;
 
   let manifest: NativeReleaseManifest;
   try {
     manifest = await loadNativeReleaseManifest(packageRoot, version, env);
   } catch (error) {
-    if (isUnavailableManifestError(error)) return undefined;
+    if (isUnavailableManifestError(error)) return legacyCachedBinaryPath;
     throw error;
   }
   const assets = resolveNativeReleaseAssetCandidates(manifest, product, version, platform, arch, {
     linuxLibcPreference: platform === 'linux' ? resolveLinuxNativeLibcPreference({ env }) : undefined,
   });
-  if (assets.length === 0) return undefined;
+  if (assets.length === 0) return legacyCachedBinaryPath;
 
   const tempRoot = await mkdtemp(join(tmpdir(), `${product}-${platform}-${arch}-`));
   const extractDir = join(tempRoot, 'extract');
@@ -382,15 +450,14 @@ export async function hydrateNativeBinary(
           throw new Error(`[native-assets] extracted archive missing expected binary ${asset.binary_path}`);
         }
 
-        await mkdir(dirname(cachedBinaryPath), { recursive: true });
-        await copyFile(extractedBinaryPath, cachedBinaryPath);
-        if (platform !== 'win32') chmodSync(cachedBinaryPath, 0o755);
+        await publishCachedNativeBinary(extractedBinaryPath, cachedBinaryPath, platform);
         return cachedBinaryPath;
       } catch (error) {
-        if (index < assets.length - 1 && isUnavailableArchiveError(error)) {
+        if (isUnavailableArchiveError(error)) {
           await rm(archivePath, { force: true });
           await rm(extractDir, { recursive: true, force: true });
-          continue;
+          if (index < assets.length - 1) continue;
+          if (legacyCachedBinaryPath) return legacyCachedBinaryPath;
         }
         throw error;
       }

--- a/src/cli/sparkshell.ts
+++ b/src/cli/sparkshell.ts
@@ -14,6 +14,7 @@ import {
   SPARKSHELL_BIN_ENV as SPARKSHELL_BIN_ENV_SHARED,
   getPackageVersion,
   hydrateNativeBinary,
+  isVerifiedCachedNativeBinary,
   resolveLinuxNativeLibcPreference,
   resolveCachedNativeBinaryCandidatePaths,
 } from './native-assets.js';
@@ -160,7 +161,7 @@ export async function resolveSparkShellBinaryPathWithHydration(
       ? (linuxLibcPreference ?? resolveLinuxNativeLibcPreference({ env }))
       : undefined,
   })) {
-    if (exists(cached)) return cached;
+    if (exists(cached) && await isVerifiedCachedNativeBinary(cached)) return cached;
   }
 
   for (const packaged of packagedSparkShellBinaryCandidatePaths(packageRoot, platform, arch, env, linuxLibcPreference)) {


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Native cache fast paths accepted any existing path, so empty/truncated files or directories could bypass hydration permanently. Hydration also copied extracted binaries directly to the final cache path, allowing interrupted writes to expose partial cache entries.

This change gives hydrated binaries a verifiable cache record and publishes them through same-directory temporary files.

## Changes

- Persist a SHA-256 sidecar for each successfully hydrated native binary.
- Require regular-file, non-empty, checksum-matching cache entries in the sparkshell and api resolver fast paths.
- Refresh unverified legacy or checksum-mismatched entries when a release asset is available.
- Preserve structurally valid legacy entries when auto-fetch is disabled or the manifest/archive is unavailable, retaining offline compatibility.
- Copy, chmod, and checksum unique same-directory temporary files before renaming them into the cache.
- Add regressions for verified cache hits, empty/truncated/directory recovery, legacy offline fallback, and resolver cache bypasses.

## Validation

- [x] `npm run build`
- [x] Focused compiled suites:
  - `node --test dist/cli/__tests__/native-assets.test.js dist/cli/__tests__/sparkshell-cli.test.js dist/cli/__tests__/api.test.js` — 47/47 pass
- [x] Original isolated reproduction, repeated 3 times — control passed and 0/3 bug scenarios remained on every run
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `npx tsc --noEmit`
- [x] `git diff --check`
- [ ] `npm test` — attempted locally. The changed native suites passed when reached, but the broader macOS run reported unrelated existing environment-sensitive failures, including BSD `script -c` incompatibility and `/var` vs `/private/var` path assertions, plus active-session auth fixture interference. The run was stopped after those unrelated failures were established; Linux PR CI remains authoritative.
- [ ] `omx doctor` — not applicable; setup/config behavior is unchanged

## Compatibility

Sidecarless cache entries are refreshed once when release assets are reachable. If auto-fetch is disabled or the manifest/archive cannot be reached, a structurally valid legacy entry remains available as the fallback. Successful verified cache hits remain network-free.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed — not needed; this preserves the existing CLI contract and changes only internal cache validation/publication
- [x] Backward-compatibility impact considered

## Related

Closes #3278
