### PR TITLE
fix(state): allow the documented Team + Ultragoal overlap

### DIFF
--- a/docs/contracts/multi-state-transition-contract.md
+++ b/docs/contracts/multi-state-transition-contract.md
@@ -1,7 +1,8 @@
 # Multi-state transition compatibility contract
 
-This document freezes the first-pass peer workflow state model for the approved
-multi-state compatibility rollout from `.omx/plans/prd-multi-state-compat.md`.
+This document defines the peer workflow state model introduced by the approved
+multi-state compatibility rollout from `.omx/plans/prd-multi-state-compat.md`
+and records later-approved overlap extensions.
 
 ## Canonical sources of truth
 
@@ -15,13 +16,20 @@ fields such as `skill` or `phase` may remain as compatibility metadata, but they
 must not override the authoritative active set when multiple workflow members
 are live.
 
-## Approved first-pass combinations
+## First-pass combinations and later extensions
 
-Allowed active-set shapes in this rollout are intentionally narrow:
+The first-pass rollout approved these intentionally narrow active-set shapes:
 
 - standalone single-workflow state for tracked workflows
 - `team + ralph`
 - `team + ultrawork`
+
+A later approval added this pairwise overlap:
+
+- `team + ultragoal`
+
+For `team + ultragoal`, Ultragoal retains leader-owned durable goal and ledger
+state while Team supplies parallel execution evidence.
 
 The resulting active set is peer state. Neither member is semantically primary
 just because it was activated first or happens to occupy the legacy top-level
@@ -109,8 +117,10 @@ Implementation should be considered complete only when tests prove:
 1. canonical active state can hold a multi-entry active set
 2. `team + ralph` is allowed in both activation orders
 3. `team + ultrawork` is allowed in both activation orders
-4. unsupported overlaps deny without mutation
-5. denial messages mention both `omx state` and `omx_state.*`
-6. HUD / overlay / stop-hook consumers honor the combined set consistently
-7. `autopilot` and `autoresearch` still reject unsupported overlap attempts; Autopilot review-driven planning loopbacks keep `autopilot` active and update its `current_phase` to `ralplan` instead of starting standalone `ralplan`
-8. `deep-interview -> ralplan` is evidence-gated: answered or handoff-cleared question obligations alone do not complete deep-interview, and Autopilot `ralplan -> ultragoal` remains blocked with `documented_host_consensus_receipt_unavailable` until an official non-user-mintable host receipt verifier exists; native lanes, trackers, `codex_exec`, and artifact approvals are non-authoritative.
+4. `team + ultragoal` is allowed in both activation orders and persists both peers in session-scoped canonical state
+5. `ultrawork` can join `team + ultragoal` without auto-completing either peer
+6. unsupported overlaps deny without mutation
+7. denial messages mention both `omx state` and `omx_state.*`
+8. HUD / overlay / stop-hook consumers honor the combined set consistently
+9. `autopilot` and `autoresearch` still reject unsupported overlap attempts; Autopilot review-driven planning loopbacks keep `autopilot` active and update its `current_phase` to `ralplan` instead of starting standalone `ralplan`
+10. `deep-interview -> ralplan` is evidence-gated: answered or handoff-cleared question obligations alone do not complete deep-interview, and Autopilot `ralplan -> ultragoal` remains blocked with `documented_host_consensus_receipt_unavailable` until an official non-user-mintable host receipt verifier exists; native lanes, trackers, `codex_exec`, and artifact approvals are non-authoritative.

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -1903,6 +1903,53 @@ describe('state operations directory initialization', () => {
   });
 
 
+  it('persists supported team and ultragoal overlaps in either activation order', async () => {
+    const scenarios = [
+      { sessionId: 'sess-team-ultragoal', order: ['team', 'ultragoal'] },
+      { sessionId: 'sess-ultragoal-team', order: ['ultragoal', 'team'] },
+    ] as const;
+
+    for (const scenario of scenarios) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-state-ops-${scenario.sessionId}-`));
+      try {
+        for (const mode of scenario.order) {
+          const written = await executeStateOperation('state_write', {
+            workingDirectory: wd,
+            session_id: scenario.sessionId,
+            mode,
+            active: true,
+            current_phase: 'running',
+          });
+          assert.equal(written.isError, undefined, `${scenario.order.join(' -> ')} should allow ${mode}`);
+        }
+
+        const sessionDir = join(wd, '.omx', 'state', 'sessions', scenario.sessionId);
+        const teamState = JSON.parse(
+          await readFile(join(sessionDir, 'team-state.json'), 'utf-8'),
+        ) as { active?: boolean };
+        const ultragoalState = JSON.parse(
+          await readFile(join(sessionDir, 'ultragoal-state.json'), 'utf-8'),
+        ) as { active?: boolean };
+        const canonical = JSON.parse(
+          await readFile(join(sessionDir, 'skill-active-state.json'), 'utf-8'),
+        ) as { active_skills?: Array<{ skill: string; active?: boolean }> };
+
+        assert.equal(teamState.active, true);
+        assert.equal(ultragoalState.active, true);
+        assert.deepEqual(
+          canonical.active_skills?.map((entry) => entry.skill),
+          [...scenario.order],
+        );
+        assert.deepEqual(
+          canonical.active_skills?.map((entry) => entry.active),
+          [true, true],
+        );
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+
   it('denies unsupported overlaps without writing the requested mode state', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-deny-overlap-'));
     try {

--- a/src/state/__tests__/workflow-transition.test.ts
+++ b/src/state/__tests__/workflow-transition.test.ts
@@ -42,17 +42,51 @@ describe('workflow transition rules', () => {
   it('allows the approved overlap matrix and denies unsupported combinations', () => {
     const cases: Array<{
       current: string[];
-      requested: 'team' | 'ralph' | 'ultrawork' | 'autopilot' | 'autoresearch';
+      requested: 'team' | 'ultragoal' | 'ralph' | 'ultrawork' | 'autopilot' | 'autoresearch';
       allowed: boolean;
       resulting: string[];
+      expectedKind?: 'overlap' | 'deny';
+      expectedAutoCompleteModes?: string[];
     }> = [
       { current: [], requested: 'team', allowed: true, resulting: ['team'] },
       { current: ['team'], requested: 'ralph', allowed: true, resulting: ['team', 'ralph'] },
       { current: ['ralph'], requested: 'team', allowed: true, resulting: ['ralph', 'team'] },
+      {
+        current: ['team'],
+        requested: 'ultragoal',
+        allowed: true,
+        resulting: ['team', 'ultragoal'],
+        expectedKind: 'overlap',
+        expectedAutoCompleteModes: [],
+      },
+      {
+        current: ['ultragoal'],
+        requested: 'team',
+        allowed: true,
+        resulting: ['ultragoal', 'team'],
+        expectedKind: 'overlap',
+        expectedAutoCompleteModes: [],
+      },
       { current: ['team'], requested: 'ultrawork', allowed: true, resulting: ['team', 'ultrawork'] },
       { current: ['ultrawork'], requested: 'team', allowed: true, resulting: ['ultrawork', 'team'] },
       { current: ['ralph'], requested: 'ultrawork', allowed: true, resulting: ['ralph', 'ultrawork'] },
       { current: ['ultrawork'], requested: 'ralph', allowed: true, resulting: ['ultrawork', 'ralph'] },
+      {
+        current: ['team', 'ultragoal'],
+        requested: 'ultrawork',
+        allowed: true,
+        resulting: ['team', 'ultragoal', 'ultrawork'],
+        expectedKind: 'overlap',
+        expectedAutoCompleteModes: [],
+      },
+      {
+        current: ['team', 'ultragoal'],
+        requested: 'ralph',
+        allowed: false,
+        resulting: ['team', 'ultragoal'],
+        expectedKind: 'deny',
+        expectedAutoCompleteModes: [],
+      },
       { current: ['autopilot'], requested: 'team', allowed: false, resulting: ['autopilot'] },
       { current: ['team'], requested: 'autopilot', allowed: false, resulting: ['team'] },
       { current: ['autoresearch'], requested: 'ralph', allowed: false, resulting: ['autoresearch'] },
@@ -64,6 +98,16 @@ describe('workflow transition rules', () => {
       const decision = evaluateWorkflowTransition(testCase.current, testCase.requested);
       assert.equal(decision.allowed, testCase.allowed, `${testCase.current.join(',')} -> ${testCase.requested}`);
       assert.deepEqual(decision.resultingModes, testCase.resulting, `${testCase.current.join(',')} -> ${testCase.requested}`);
+      if (testCase.expectedKind) {
+        assert.equal(decision.kind, testCase.expectedKind, `${testCase.current.join(',')} -> ${testCase.requested}`);
+      }
+      if (testCase.expectedAutoCompleteModes) {
+        assert.deepEqual(
+          decision.autoCompleteModes,
+          testCase.expectedAutoCompleteModes,
+          `${testCase.current.join(',')} -> ${testCase.requested}`,
+        );
+      }
     }
   });
 

--- a/src/state/workflow-transition.ts
+++ b/src/state/workflow-transition.ts
@@ -780,6 +780,7 @@ export type WorkflowTransitionKind = 'allow' | 'overlap' | 'auto-complete' | 'de
 
 const ALLOWED_OVERLAP_PAIRS = new Set([
   'ralph|team',
+  'team|ultragoal',
 ]);
 
 const AUTO_COMPLETE_TRANSITIONS = new Set([


### PR DESCRIPTION
## Summary

Team and Ultragoal are documented to run together: Ultragoal retains leader-owned durable goal and ledger state, while Team supplies parallel execution evidence. The central pairwise overlap allowlist omitted the normalized `team|ultragoal` pair, so starting either workflow while the other was active was rejected.

This PR adds only that compatibility pair. It does not change Team startup ordering or preflight behavior.

## Changes

- Add `team|ultragoal` to the central overlap allowlist.
- Cover both activation orders and verify overlap classification without peer auto-completion.
- Verify per-mode state files and the session-scoped canonical active set persist in either activation order.
- Verify `ultrawork` can join the pair, while `ralph` remains denied without changing the active mode set.
- Document the supported overlap and ownership model in the multi-state transition contract.

## Validation

- [x] `npm run build`
- [x] `node --test dist/state/__tests__/workflow-transition.test.js dist/state/__tests__/operations.test.js dist/modes/__tests__/base-multi-state-compat.test.js` — 110 passed
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `npx tsc --noEmit`
- [x] `git diff --check upstream/dev...HEAD`
- [ ] `npm test`
  - On Node 22.20.0 on macOS, 12 of 399 test files failed. Observed failures included path-sensitive `/var` versus `/private/var` assertions, BSD `script` lacking `-c`, and two Team scaling teardown assertions.
  - The targeted transition/state suites above passed, and none of the 12 failing file paths is part of this PR's four-file diff. No clean `upstream/dev` baseline run was performed, so these failures are not attributed to the branch or to the baseline.
- [ ] `omx doctor` — not run because setup and configuration behavior are unchanged.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated for the behavior change
- [x] Backward-compatibility impact considered; unsupported overlaps remain denied

## Related

N/A
