### PR TITLE
fix: keep status and stale Stop recovery pure

### DIFF
--- a/src/cli/__tests__/tmux-hook.test.ts
+++ b/src/cli/__tests__/tmux-hook.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(testDir, "..", "..", "..");
+const omxBin = join(repoRoot, "dist", "cli", "omx.js");
+
+describe("tmux-hook CLI", () => {
+	it("keeps status read-only when no tmux-hook configuration exists", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-tmux-hook-status-pure-"));
+		try {
+			const result = spawnSync(
+				process.execPath,
+				[omxBin, "tmux-hook", "status"],
+				{
+					cwd,
+					encoding: "utf-8",
+					env: {
+						...process.env,
+						OMX_AUTO_UPDATE: "0",
+						OMX_NOTIFY_FALLBACK: "0",
+						OMX_HOOK_DERIVED_SIGNALS: "0",
+					},
+				},
+			);
+
+			assert.equal(result.status, 0, result.stderr || result.stdout);
+			assert.match(result.stdout, /Config: missing/);
+			assert.match(result.stdout, /Run: omx tmux-hook init/);
+			assert.equal(existsSync(join(cwd, ".omx")), false);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/cli/tmux-hook.ts
+++ b/src/cli/tmux-hook.ts
@@ -382,19 +382,24 @@ export async function ensureTmuxHookInitialized(cwd = process.cwd()): Promise<vo
 
 async function showTmuxHookStatus(): Promise<void> {
   const cwd = process.cwd();
+  const configPath = tmuxHookConfigPath(cwd);
   const statePath = tmuxHookStatePath(cwd);
   const logPath = tmuxHookLogPath(cwd);
 
   console.log('tmux-hook status');
   console.log('----------------');
-  const { config, initResult } = await loadConfigForCommand('status', cwd);
-  const configPath = tmuxHookConfigPath(cwd);
+  if (!existsSync(configPath)) {
+    console.log(`Config: missing (${configPath})`);
+    console.log('Run: omx tmux-hook init');
+    console.log(`State: ${existsSync(statePath) ? statePath : `missing (${statePath})`}`);
+    console.log(`Log (today): ${existsSync(logPath) ? logPath : 'none yet'}`);
+    return;
+  }
+
+  const { config } = await loadConfigForCommand('status', cwd);
   console.log(`Config: ${configPath}`);
   console.log(`Enabled: ${config.enabled ? 'yes' : 'no'}`);
   console.log(`Target: ${config.target.type}:${config.target.value}`);
-  if (initResult?.usedPlaceholderTarget) {
-    console.log('Target Status: placeholder (set `target.value` to enable injection)');
-  }
   console.log(`Allowed Modes: ${config.allowed_modes.join(', ')}`);
   console.log(`Cooldown: ${config.cooldown_ms}ms`);
   console.log(`Max Injections/Pane: ${config.max_injections_per_session}`);

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -1202,7 +1202,10 @@ describe('session pointer transaction', () => {
       }]);
 
       warnings.length = 0;
-      await writeSessionStart(cwd, 'sess-degraded-start', { platform: 'win32' });
+      await writeSessionStart(cwd, 'sess-degraded-start', {
+        platform: 'win32',
+        regularFileSync: async () => {},
+      });
       assert.deepEqual(warnings, []);
 
       await withPointerDependencies({

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
 import { existsSync, realpathSync } from "node:fs";
 import {
 	chmod,
@@ -26454,6 +26455,54 @@ PY`,
       assert.equal(result.omxEventName, "stop");
       assert.equal(result.outputJson?.decision, "block");
       assert.equal(result.outputJson?.stopReason, "session_pointer_unusable");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows Stop without lifecycle side effects when session.json points to a definitely dead owner", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-stale-dead-owner-"));
+    const deadOwner = spawn(process.execPath, ["-e", "process.exit(0)"], {
+      stdio: "ignore",
+    });
+    const deadPid = deadOwner.pid;
+    assert.ok(deadPid);
+    await once(deadOwner, "exit");
+
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-stale-dead-owner";
+      const pointerPath = join(stateDir, "session.json");
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(pointerPath, {
+        session_id: sessionId,
+        cwd,
+        pid: deadPid,
+        platform: process.platform,
+        started_at: "2026-01-01T00:00:00.000Z",
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "ralph-state.json"), {
+        active: true,
+        current_phase: "verifying",
+        session_id: sessionId,
+      });
+      const pointerBefore = await readFile(pointerPath, "utf8");
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "Stop",
+          cwd,
+          session_id: sessionId,
+          thread_id: "thread-stale-dead-owner",
+          stop_hook_active: true,
+        },
+        { cwd },
+      );
+
+      assert.equal(result.omxEventName, "stop");
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(pointerPath, "utf8"), pointerBefore);
+      assert.equal(existsSync(join(stateDir, "native-stop-state.json")), false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -20282,6 +20282,13 @@ export async function dispatchCodexNativeHook(
         skipRalphStopBlock: isSubagentStop,
         skipAutoNudge: isSubagentStop,
       }) ?? await buildCompletedGoalCleanupStopOutput(payload, cwd);
+    } else if (
+      stopAuthorizationFailure?.stopReason === "session_pointer_unusable"
+      && pointer.status === "stale-dead"
+    ) {
+      // A definitely dead owner cannot authorize or receive lifecycle writes.
+      // Allow Stop without side effects and preserve the stale pointer as evidence.
+      outputJson = null;
     } else {
       const failure = stopAuthorizationFailure ?? {
         stopReason: "session_pointer_unusable",


### PR DESCRIPTION
## Summary

- make `omx tmux-hook status` read-only when no configuration exists
- allow native Stop to return without lifecycle writes when the selected session pointer has a definitely dead owner
- preserve stale pointer evidence and continue to fail closed for indeterminate/malformed ownership
- correct the Windows session transaction test so its synced branch explicitly supplies a successful regular-file sync

## Verification

- `npm run build`: PASS
- `npm run check:no-unused`: PASS
- tmux-hook status purity regression: PASS
- stale-dead native Stop regression: PASS
- complete session lifecycle test file: 47 passed, 1 Linux-only skip

The broader native-hook test file is not currently a clean Windows aggregate: unrelated cases include Windows symlink `EPERM` and existing fixture/guard expectation drift. The focused changed behavior is covered above.
