### PR TITLE
fix(native-assets): fail closed on unverified cache authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -557,7 +557,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - name: Download prebuilt dist artifact
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -541,6 +541,40 @@ jobs:
       - name: Run Ralph persistence verification matrix
         run: npm run test:ralph-persistence:compiled
 
+  native-cache-integrity:
+    name: Native Cache Integrity (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    needs: [changes, build-dist]
+    if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.native_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Download prebuilt dist artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ci-dist-node20
+          path: dist
+      - name: Verify native-cache integrity boundary
+        shell: bash
+        run: |
+          node --test \
+            dist/cli/__tests__/native-assets.test.js \
+            dist/cli/__tests__/sparkshell-cli.test.js \
+            dist/cli/__tests__/api.test.js \
+            dist/scripts/__tests__/verify-native-release-assets.test.js \
+            dist/verification/__tests__/native-release-manifest.test.js \
+            dist/verification/__tests__/explore-harness-release-workflow.test.js \
+            dist/verification/__tests__/ci-rust-gates.test.js
+
   build:
     name: Build (Full Source Build)
     runs-on: ubuntu-latest
@@ -576,7 +610,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [changes, docs-check, rustfmt, clippy, rust-tests, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, build]
+    needs: [changes, docs-check, rustfmt, clippy, rust-tests, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build]
     steps:
       - name: Check required job results
         shell: bash
@@ -600,6 +634,7 @@ jobs:
           COVERAGE_TEAM_CRITICAL_RESULT: ${{ needs.coverage-team-critical.result }}
           RALPH_PERSISTENCE_GATE_RESULT: ${{ needs.ralph-persistence-gate.result }}
           BUILD_RESULT: ${{ needs.build.result }}
+          NATIVE_CACHE_INTEGRITY_RESULT: ${{ needs.native-cache-integrity.result }}
           REASON: ${{ needs.changes.outputs.reason }}
         run: |
           set -euo pipefail
@@ -653,6 +688,7 @@ jobs:
           echo "  coverage-team-critical: $COVERAGE_TEAM_CRITICAL_RESULT"
           echo "  ralph-persistence-gate: $RALPH_PERSISTENCE_GATE_RESULT"
           echo "  build: $BUILD_RESULT"
+          echo "  native-cache-integrity: $NATIVE_CACHE_INTEGRITY_RESULT"
 
           check_job changes "$CHANGES_RESULT" true
 
@@ -661,11 +697,13 @@ jobs:
           ts_active=false
           dist_active=false
           build_active=false
+          native_cache_integrity_active=false
           if [[ "$FULL_SUITE" == "true" ]] || [[ "$DOCS_CHANGED" == "true" ]]; then docs_active=true; fi
           if [[ "$FULL_SUITE" == "true" ]] || bool_any "$RUST_CHANGED" "$NATIVE_CHANGED"; then rust_active=true; fi
           if [[ "$FULL_SUITE" == "true" ]] || bool_any "$TS_CHANGED" "$SHARED_CONFIG_CHANGED"; then ts_active=true; fi
           if [[ "$FULL_SUITE" == "true" ]] || bool_any "$TS_CHANGED" "$RUST_CHANGED" "$NATIVE_CHANGED" "$SHARED_CONFIG_CHANGED"; then dist_active=true; fi
           if [[ "$FULL_SUITE" == "true" ]] || bool_any "$RUST_CHANGED" "$NATIVE_CHANGED" "$SHARED_CONFIG_CHANGED"; then build_active=true; fi
+          if [[ "$FULL_SUITE" == "true" ]] || bool_any "$TS_CHANGED" "$NATIVE_CHANGED" "$SHARED_CONFIG_CHANGED"; then native_cache_integrity_active=true; fi
 
           check_job docs-check "$DOCS_CHECK_RESULT" "$docs_active"
           check_job rustfmt "$RUSTFMT_RESULT" "$rust_active"
@@ -678,6 +716,7 @@ jobs:
           check_job test "$TEST_RESULT" "$ts_active"
           check_job coverage-team-critical "$COVERAGE_TEAM_CRITICAL_RESULT" "$ts_active"
           check_job ralph-persistence-gate "$RALPH_PERSISTENCE_GATE_RESULT" "$ts_active"
+          check_job native-cache-integrity "$NATIVE_CACHE_INTEGRITY_RESULT" "$native_cache_integrity_active"
           check_job build "$BUILD_RESULT" "$build_active"
 
           if (( failures > 0 )); then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,13 +179,22 @@ jobs:
         run: |
           dist plan --output-format=json > dist-plan.json
           mkdir -p release-assets
-          find release-artifacts -type f \( -name '*.tar.xz' -o -name '*.tar.gz' -o -name '*.zip' -o -name '*.sha256' \) -exec cp {} release-assets/ \;
+          while IFS= read -r -d '' source; do
+            destination="release-assets/$(basename "$source")"
+            if [[ -e "$destination" || -L "$destination" ]]; then
+              echo "release asset basename collision: $source -> $destination" >&2
+              exit 1
+            fi
+            cp -- "$source" "$destination"
+          done < <(find release-artifacts -type f \( -name '*.tar.xz' -o -name '*.tar.gz' -o -name '*.zip' -o -name '*.sha256' \) -print0)
           node dist/scripts/generate-native-release-manifest.js \
             --plan dist-plan.json \
             --artifacts-dir release-assets \
             --out release-assets/native-release-manifest.json \
             --release-base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}" \
             --require-products "omx-api,omx-explore-harness,omx-sparkshell"
+      - name: Verify release archives and manifest
+        run: node dist/scripts/verify-native-release-assets.js --manifest release-assets/native-release-manifest.json --artifacts-dir release-assets
       - name: Upload release asset bundle for follow-up jobs
         uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Native cache integrity boundary** — managed cache binaries without their `.sha256` sidecar are rejected; checksum verification establishes integrity, not a signature. On a retained hydration lock, confirm that no OMX hydration process is active for that cache key, remove only that named lock manually, then retry. SparkShell warns and falls back to raw command execution without summary support when its native sidecar is unavailable or GLIBC-incompatible. Binary and checksum sidecars are published as two files and are not an atomic pair; the lock protocol provides process-crash-safe, fail-closed publication, with manual retained-lock remediation, rather than recovery from a process crash.
+
 ## [0.20.3] - 2026-07-19
 
 Patch release for the reliability and workflow-safety work in `v0.20.2..f967cfed64ec57614af136f75d7cb81509808f7e`, plus one additive, backward-compatible feature. No intentional breaking CLI or package-layout changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "@modelcontextprotocol/sdk": "^1.26.0",
+        "@napi-rs/lzma": "1.4.1",
+        "tar-stream": "2.2.0",
+        "yauzl": "3.4.0",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -20,8 +23,12 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.4",
         "@types/node": "^26.0.0",
+        "@types/tar-stream": "2.2.3",
+        "@types/yauzl": "2.10.3",
+        "@types/yazl": "2.4.5",
         "c8": "^11.0.0",
-        "typescript": "^7.0.2"
+        "typescript": "^7.0.2",
+        "yazl": "3.3.1"
       },
       "engines": {
         "node": ">=20"
@@ -106,6 +113,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -113,10 +123,7 @@
       ],
       "engines": {
         "node": ">=14.21.3"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
       "version": "2.5.4",
@@ -126,6 +133,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -133,10 +143,7 @@
       ],
       "engines": {
         "node": ">=14.21.3"
-      },
-      "libc": [
-        "musl"
-      ]
+      }
     },
     "node_modules/@biomejs/cli-linux-x64": {
       "version": "2.5.4",
@@ -146,6 +153,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -153,10 +163,7 @@
       ],
       "engines": {
         "node": ">=14.21.3"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
       "version": "2.5.4",
@@ -166,6 +173,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -173,10 +183,7 @@
       ],
       "engines": {
         "node": ">=14.21.3"
-      },
-      "libc": [
-        "musl"
-      ]
+      }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
       "version": "2.5.4",
@@ -210,6 +217,37 @@
       ],
       "engines": {
         "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -308,6 +346,353 @@
         }
       }
     },
+    "node_modules/@napi-rs/lzma": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma/-/lzma-1.4.1.tgz",
+      "integrity": "sha512-5f8K9NHjwHjZKGm3SS+7CFxXQhz8rbg2umBm/9g0xQRXBdYEI31N5z1ACuk9bmBQOusXAq9CArGfs/ZQso2rUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-android-arm-eabi": "1.4.1",
+        "@napi-rs/lzma-android-arm64": "1.4.1",
+        "@napi-rs/lzma-darwin-arm64": "1.4.1",
+        "@napi-rs/lzma-darwin-x64": "1.4.1",
+        "@napi-rs/lzma-freebsd-x64": "1.4.1",
+        "@napi-rs/lzma-linux-arm-gnueabihf": "1.4.1",
+        "@napi-rs/lzma-linux-arm64-gnu": "1.4.1",
+        "@napi-rs/lzma-linux-arm64-musl": "1.4.1",
+        "@napi-rs/lzma-linux-ppc64-gnu": "1.4.1",
+        "@napi-rs/lzma-linux-riscv64-gnu": "1.4.1",
+        "@napi-rs/lzma-linux-s390x-gnu": "1.4.1",
+        "@napi-rs/lzma-linux-x64-gnu": "1.4.1",
+        "@napi-rs/lzma-linux-x64-musl": "1.4.1",
+        "@napi-rs/lzma-wasm32-wasi": "1.4.1",
+        "@napi-rs/lzma-win32-arm64-msvc": "1.4.1",
+        "@napi-rs/lzma-win32-ia32-msvc": "1.4.1",
+        "@napi-rs/lzma-win32-x64-msvc": "1.4.1"
+      }
+    },
+    "node_modules/@napi-rs/lzma-android-arm-eabi": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-android-arm-eabi/-/lzma-android-arm-eabi-1.4.1.tgz",
+      "integrity": "sha512-yenreSpZ9IrqppJOiWDqWMmja7XtSgio9LhtxYwgdILmy/OJTe/mlTYv+FhJBf7hIV9Razu5eBuEa3zKri81IA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-android-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-android-arm64/-/lzma-android-arm64-1.4.1.tgz",
+      "integrity": "sha512-piutVBz5B1TNxXeEjub0n/IKI6dMaXPPRbVSXuc4gnZgzcihNDUh68vcLZgYd+IMiACZvBxvx2O3t5nthtph3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-darwin-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-darwin-arm64/-/lzma-darwin-arm64-1.4.1.tgz",
+      "integrity": "sha512-sDfOhQQFqV8lGbpgJN9DqNLBPR7QOfYjcWUv8FOGPaVP1LPJDnrc5uCpRWWEa2zIKmTiO8P9xzIl0TDzrYmghg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-darwin-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-darwin-x64/-/lzma-darwin-x64-1.4.1.tgz",
+      "integrity": "sha512-S5/RbC6EP4QkYy2xhxbfm48ZD9FkysfpWY4Slve0nj5RGGsHvcJBg2Pi69jrTPB/zLKz2SUa0i+RfUt9zvZNaw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-freebsd-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-freebsd-x64/-/lzma-freebsd-x64-1.4.1.tgz",
+      "integrity": "sha512-4AFnq6aZnclwameSBkDWu5Ftb8y4GwvVXeQXJKbN7hf7O5GG/8QpQB1R1NJw2QORUhpKwjAQUpbkTyhL2GFWWw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-arm-gnueabihf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm-gnueabihf/-/lzma-linux-arm-gnueabihf-1.4.1.tgz",
+      "integrity": "sha512-j5rL1YRIm6rWmmGAvN6DPX6QuRjvFGB93xJ7DTRB47GXW4zHekXae6ivowjJ95vT4Iz4hSWkZbuwAy95eFrWRA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-arm64-gnu": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm64-gnu/-/lzma-linux-arm64-gnu-1.4.1.tgz",
+      "integrity": "sha512-1XdFGKyTS9m+VrRQYs9uz+ToHf4Jwm0ejHU48k9lT9MPl8jSqzKdVtFzZBPzronHteSynBfKmUq0+HeWmjrsOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-arm64-musl": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-arm64-musl/-/lzma-linux-arm64-musl-1.4.1.tgz",
+      "integrity": "sha512-9d09tYS0/rBwIk1QTcO2hMZEB/ZpsG2+uFW5am1RHElSWMclObirB1An7b6AMDJcRvcomkOg2GZ9COzrvHKwEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-ppc64-gnu": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-ppc64-gnu/-/lzma-linux-ppc64-gnu-1.4.1.tgz",
+      "integrity": "sha512-UzEkmsgoJ3IOGIRb6kBzNiw+ThUpiighop7dVYfSqlF5juGzwf7YewC57RGn4FoJCvadOCrSm5VikAcgrwVgAw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-riscv64-gnu": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-riscv64-gnu/-/lzma-linux-riscv64-gnu-1.4.1.tgz",
+      "integrity": "sha512-9dUKlZ1PdwxTaFF+j3oc+xjlk9nqFwo1NWWOH30uwjl4Rm5Gkv+Fx0pHrzu4kR/iVA+oyQqa9/2uDYnGSTijBA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-s390x-gnu": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-s390x-gnu/-/lzma-linux-s390x-gnu-1.4.1.tgz",
+      "integrity": "sha512-MOVXUWJSLLCJDCCAlGa39sh7nv9XjvXzCf7QJus7rD8Ciz0mpXNXF9mg0ji7/MZ7pZlKPlXjXDnpVCfFdSEaFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.4.1.tgz",
+      "integrity": "sha512-Sxu7aJxU1sDbUTqjqLVDV3DCOAlbsFKvmuCN/S5uXBJd1IF2wJ9jK3NbFzfqTAo5Hudx8Y7kOb6+3K+fYPI1KQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-musl": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-musl/-/lzma-linux-x64-musl-1.4.1.tgz",
+      "integrity": "sha512-4I3BeKBQJSE5gF2/VTEv7wCLLjhapeutbCGpZPmDiLHZ74rm9edmNXAlKpdjADQ4YDLJ2GIBzttvwLXkJ9U+cw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-wasm32-wasi": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-wasm32-wasi/-/lzma-wasm32-wasi-1.4.1.tgz",
+      "integrity": "sha512-s32HdKqQWbohf6DGWpG9YMODaBdbKJ++JpNr6Ii7821sKf4h/o+p8IRFTOaWdmdJdllEWlRirnd5crA29VivJQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@napi-rs/lzma-win32-arm64-msvc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-arm64-msvc/-/lzma-win32-arm64-msvc-1.4.1.tgz",
+      "integrity": "sha512-ISz+v7ML5mKnjEZ7Kk4Z1BIn411r/fz3tDy9j5yDnwQI0MgTsUQFrIQElGUpULWYs2aYc6EZ9PhECbLBfSjh7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-win32-ia32-msvc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-ia32-msvc/-/lzma-win32-ia32-msvc-1.4.1.tgz",
+      "integrity": "sha512-3WKuCpZBrd7Jrw+h1jSu5XAsRWepMJu0sYuRoA4Y4Cwfu9gI7p5Z5Bc510nfjg7M7xvdpkI4UoW2WY7kBFRYrQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-win32-x64-msvc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-win32-x64-msvc/-/lzma-win32-x64-msvc-1.4.1.tgz",
+      "integrity": "sha512-0ixRo5z1zFXdh62hlrTV+QCTKHK0te5NHKaExOluhtcc6AdpMmpslvM9JhUxNHI+zM46w/DmmcvcOtqsaTmHgg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -323,6 +708,36 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/tar-stream": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@types/tar-stream/-/tar-stream-2.2.3.tgz",
+      "integrity": "sha512-if3mugZfjVkXOMZdFjIHySxY13r6GXPpyOlsDmLffvyI7tLz9wXE8BFjNivXsvUeyJ1KNlOpfLnag+ISmxgxPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yazl": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@types/yazl/-/yazl-2.4.5.tgz",
+      "integrity": "sha512-qpmPfx32HS7vlGJf7EsoM9qJnLZhXJBf1KH0hzfdc+D794rljQWh4H0I/UrZy+6Nhqn0l2jdBZXBGZtR1vnHqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
@@ -721,6 +1136,37 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -756,6 +1202,40 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/bytes": {
@@ -1077,6 +1557,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1309,6 +1798,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1480,6 +1975,26 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -1854,6 +2369,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -1915,6 +2436,20 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1949,6 +2484,26 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -2135,6 +2690,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2146,6 +2710,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/test-exclude": {
@@ -2171,6 +2751,13 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-is": {
       "version": "2.0.1",
@@ -2236,6 +2823,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -2364,6 +2957,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^1.0.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -95,13 +95,20 @@
   "dependencies": {
     "@iarna/toml": "^2.2.5",
     "@modelcontextprotocol/sdk": "^1.26.0",
+    "@napi-rs/lzma": "1.4.1",
+    "tar-stream": "2.2.0",
+    "yauzl": "3.4.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",
     "@types/node": "^26.0.0",
+    "@types/tar-stream": "2.2.3",
+    "@types/yauzl": "2.10.3",
+    "@types/yazl": "2.4.5",
     "c8": "^11.0.0",
-    "typescript": "^7.0.2"
+    "typescript": "^7.0.2",
+    "yazl": "3.3.1"
   },
   "overrides": {
     "ajv": ">=8.18.0",

--- a/src/cli/__tests__/api.test.ts
+++ b/src/cli/__tests__/api.test.ts
@@ -227,17 +227,10 @@ describe('omx api', () => {
   it('preserves child stdout, stderr, and exit code through the JS bridge', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-api-bridge-'));
     try {
-      const binDir = join(cwd, 'bin');
-      const stubPath = join(binDir, process.platform === 'win32' ? 'omx-api.cmd' : 'omx-api');
-      await mkdir(binDir, { recursive: true });
-      if (process.platform === 'win32') {
-        await writeFile(stubPath, '@echo off\r\necho api-stdout\r\n>&2 echo api-stderr\r\nexit /b 7\r\n');
-      } else {
-        await writeFile(stubPath, '#!/bin/sh\necho api-stdout\necho api-stderr 1>&2\nexit 7\n');
-        await chmod(stubPath, 0o755);
-      }
+      const stubPath = join(cwd, 'api-stub.cjs');
+      await writeFile(stubPath, 'process.stdout.write("api-stdout\\n"); process.stderr.write("api-stderr\\n"); process.exit(7);\n');
 
-      const result = runOmx(cwd, ['api', 'generate', 'text', 'hello'], { OMX_API_BIN: stubPath });
+      const result = runOmx(cwd, ['api', stubPath], { OMX_API_BIN: process.execPath });
       if (shouldSkipForSpawnPermissions(result.error)) return;
 
       assert.equal(result.status, 7, result.stderr || result.stdout);

--- a/src/cli/__tests__/api.test.ts
+++ b/src/cli/__tests__/api.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
@@ -115,7 +115,7 @@ describe('resolveApiBinaryPath', () => {
           linuxLibcPreference: ['musl', 'glibc'],
           env: { OMX_NATIVE_CACHE_DIR: cacheDir, OMX_NATIVE_AUTO_FETCH: '0' },
         }),
-        cachedBinary,
+        await realpath(cachedBinary),
       );
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/cli/__tests__/api.test.ts
+++ b/src/cli/__tests__/api.test.ts
@@ -4,6 +4,7 @@ import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import {
   nestedRepoLocalApiBinaryPath,
@@ -39,6 +40,9 @@ function shouldSkipForSpawnPermissions(err?: string): boolean {
   return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
 }
 
+const fixturePackageRoot = join(tmpdir(), 'omx-api-package-root');
+
+
 describe('resolveApiBinaryPath', () => {
   it('prefers OMX_API_BIN override', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-api-override-'));
@@ -58,36 +62,34 @@ describe('resolveApiBinaryPath', () => {
 
   it('checks Linux musl packaged paths before glibc and legacy paths', () => {
     assert.deepEqual(
-      packagedApiBinaryCandidatePaths('/repo', 'linux', 'x64', {}, ['musl', 'glibc']),
+      packagedApiBinaryCandidatePaths(fixturePackageRoot, 'linux', 'x64', {}, ['musl', 'glibc']),
       [
-        '/repo/bin/native/linux-x64-musl/omx-api',
-        '/repo/bin/native/linux-x64-glibc/omx-api',
-        '/repo/bin/native/linux-x64/omx-api',
+        join(fixturePackageRoot, 'bin', 'native', 'linux-x64-musl', 'omx-api'),
+        join(fixturePackageRoot, 'bin', 'native', 'linux-x64-glibc', 'omx-api'),
+        join(fixturePackageRoot, 'bin', 'native', 'linux-x64', 'omx-api'),
       ],
     );
   });
 
   it('falls back from packaged binary to repo-local build artifact', () => {
-    const packageRoot = '/repo';
-    const repoLocal = repoLocalApiBinaryPath(packageRoot);
+    const repoLocal = repoLocalApiBinaryPath(fixturePackageRoot);
     assert.equal(
-      resolveApiBinaryPath({ packageRoot, exists: (path) => path === repoLocal }),
+      resolveApiBinaryPath({ packageRoot: fixturePackageRoot, exists: (path) => path === repoLocal }),
       repoLocal,
     );
   });
 
   it('falls back to nested repo-local native build artifact when present', () => {
-    const packageRoot = '/repo';
-    const nestedRepoLocal = nestedRepoLocalApiBinaryPath(packageRoot);
+    const nestedRepoLocal = nestedRepoLocalApiBinaryPath(fixturePackageRoot);
     assert.equal(
-      resolveApiBinaryPath({ packageRoot, exists: (path) => path === nestedRepoLocal }),
+      resolveApiBinaryPath({ packageRoot: fixturePackageRoot, exists: (path) => path === nestedRepoLocal }),
       nestedRepoLocal,
     );
   });
 
   it('throws with checked paths when neither packaged nor repo-local binary exists', () => {
     assert.throws(
-      () => resolveApiBinaryPath({ packageRoot: '/repo', exists: () => false }),
+      () => resolveApiBinaryPath({ packageRoot: fixturePackageRoot, exists: () => false }),
       /native binary not found/,
     );
   });
@@ -103,6 +105,7 @@ describe('resolveApiBinaryPath', () => {
       await mkdir(cachedDir, { recursive: true });
       await writeFile(cachedBinary, '#!/bin/sh\n');
       await chmod(cachedBinary, 0o755);
+      await writeFile(`${cachedBinary}.sha256`, `${createHash('sha256').update('#!/bin/sh\n').digest('hex')}\n`, { mode: 0o600 });
 
       assert.equal(
         await resolveApiBinaryPathWithHydration({
@@ -114,6 +117,53 @@ describe('resolveApiBinaryPath', () => {
         }),
         cachedBinary,
       );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('reports the first rejected cache entry instead of an earlier missing candidate', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-api-rejected-cache-'));
+    try {
+      await writeFile(join(cwd, 'package.json'), JSON.stringify({ version: '0.8.15' }));
+      const cacheDir = join(cwd, 'cache');
+      const rejected = join(cacheDir, '0.8.15', 'linux-x64-glibc', 'omx-api', 'omx-api');
+      await mkdir(dirname(rejected), { recursive: true });
+      await writeFile(rejected, 'unverified');
+      await assert.rejects(
+        () => resolveApiBinaryPathWithHydration({
+          packageRoot: cwd,
+          platform: 'linux',
+          arch: 'x64',
+          linuxLibcPreference: ['musl', 'glibc'],
+          env: { OMX_NATIVE_CACHE_DIR: cacheDir, OMX_NATIVE_AUTO_FETCH: '0' },
+        }),
+        (error: Error) => error.message.includes(rejected) && error.message.includes('legacy-unverified'),
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a sidecarless managed cache binary and falls through to the packaged authority', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-api-sidecarless-'));
+    try {
+      await writeFile(join(cwd, 'package.json'), JSON.stringify({ version: '0.8.15' }));
+      const cacheDir = join(cwd, 'cache');
+      const cachedDir = join(cacheDir, '0.8.15', 'linux-x64-musl', 'omx-api');
+      const cachedBinary = join(cachedDir, 'omx-api');
+      const packaged = join(cwd, 'bin', 'native', 'linux-x64-musl', 'omx-api');
+      await mkdir(cachedDir, { recursive: true });
+      await mkdir(dirname(packaged), { recursive: true });
+      await writeFile(cachedBinary, '#!/bin/sh\necho untrusted\n');
+      await writeFile(packaged, '#!/bin/sh\necho packaged\n');
+      assert.equal(await resolveApiBinaryPathWithHydration({
+        packageRoot: cwd,
+        platform: 'linux',
+        arch: 'x64',
+        linuxLibcPreference: ['musl'],
+        env: { OMX_NATIVE_CACHE_DIR: cacheDir, OMX_NATIVE_AUTO_FETCH: '0' },
+      }), packaged);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/native-assets.test.ts
+++ b/src/cli/__tests__/native-assets.test.ts
@@ -1,14 +1,19 @@
 import { createServer } from 'node:http';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, link, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+
 import { createHash } from 'node:crypto';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { spawnSync } from 'node:child_process';
+import { gzipSync } from 'node:zlib';
+import { compress as xzCompress } from '@napi-rs/lzma/xz';
+import * as tar from 'tar-stream';
+import * as yazl from 'yazl';
 import {
   hydrateNativeBinary,
   inferNativeAssetLibc,
+  inspectManagedNativeBinary,
   isRepositoryCheckout,
   resolveCachedNativeBinaryCandidatePaths,
   resolveCachedNativeBinaryPath,
@@ -16,6 +21,12 @@ import {
   resolveNativeReleaseAssetCandidates,
   resolveNativeReleaseBaseUrl,
 } from '../native-assets.js';
+import {
+  assertSafeNativeArchiveEntries,
+  normalizeNativeArchivePath,
+  validateNativeReleaseManifest,
+} from '../../native-assets/policy.js';
+import { inspectNativeArchive, selectNativeArchiveBinary } from '../../native-assets/archive.js';
 
 async function startStaticServer(root: string): Promise<{ baseUrl: string; close: () => Promise<void> }> {
   const server = createServer(async (req, res) => {
@@ -42,6 +53,46 @@ async function startStaticServer(root: string): Promise<{ baseUrl: string; close
 function sha256(buffer: Buffer): string {
   return createHash('sha256').update(buffer).digest('hex');
 }
+async function collect(stream: NodeJS.ReadableStream): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks);
+}
+
+async function makeTar(entries: Array<{ name: string; data?: Buffer; type?: tar.Headers['type']; linkname?: string }>, format: 'tar.gz' | 'tar.xz' = 'tar.gz'): Promise<Buffer> {
+  const archive = tar.pack();
+  for (const item of entries) {
+    const type = item.type ?? 'file';
+    const header: tar.Headers = { name: item.name, type, size: type === 'file' ? item.data?.length ?? 0 : 0, linkname: item.linkname };
+    if (type === 'file') archive.entry(header, item.data ?? Buffer.alloc(0));
+    else archive.entry(header);
+  }
+  archive.finalize();
+  const raw = await collect(archive);
+  return format === 'tar.gz' ? gzipSync(raw) : await xzCompress(raw);
+}
+
+async function makeZip(entries: Array<{ name: string; data?: Buffer }>): Promise<Buffer> {
+  const archive = new yazl.ZipFile();
+  for (const item of entries) {
+    if (item.name.endsWith('/')) archive.addEmptyDirectory(item.name);
+    else archive.addBuffer(item.data ?? Buffer.alloc(0), item.name);
+  }
+  archive.end();
+  return collect(archive.outputStream);
+}
+
+
+async function writeManagedBinary(binaryPath: string, contents = 'native-binary'): Promise<void> {
+  await mkdir(dirname(binaryPath), { recursive: true });
+  await writeFile(binaryPath, contents);
+}
+
+async function writeManagedSidecar(binaryPath: string, contents: string): Promise<void> {
+  await mkdir(dirname(binaryPath), { recursive: true });
+  await writeFile(`${binaryPath}.sha256`, contents);
+}
+
 
 describe('repository checkout detection', () => {
   it('does not treat an installed npm package that ships src/scripts as a source checkout', async () => {
@@ -85,16 +136,17 @@ describe('native asset helpers', () => {
   });
 
   it('prefers musl cache paths before glibc and legacy Linux cache paths', () => {
+    const cacheRoot = join(tmpdir(), 'omx-native-cache');
     assert.deepEqual(
       resolveCachedNativeBinaryCandidatePaths('omx-sparkshell', '0.8.15', 'linux', 'x64', {
-        OMX_NATIVE_CACHE_DIR: '/tmp/omx-native-cache',
+        OMX_NATIVE_CACHE_DIR: cacheRoot,
       }, {
         linuxLibcPreference: ['musl', 'glibc'],
       }),
       [
-        '/tmp/omx-native-cache/0.8.15/linux-x64-musl/omx-sparkshell/omx-sparkshell',
-        '/tmp/omx-native-cache/0.8.15/linux-x64-glibc/omx-sparkshell/omx-sparkshell',
-        '/tmp/omx-native-cache/0.8.15/linux-x64/omx-sparkshell/omx-sparkshell',
+        join(cacheRoot, '0.8.15', 'linux-x64-musl', 'omx-sparkshell', 'omx-sparkshell'),
+        join(cacheRoot, '0.8.15', 'linux-x64-glibc', 'omx-sparkshell', 'omx-sparkshell'),
+        join(cacheRoot, '0.8.15', 'linux-x64', 'omx-sparkshell', 'omx-sparkshell'),
       ],
     );
   });
@@ -176,11 +228,11 @@ describe('native asset helpers', () => {
       await chmod(binaryPath, 0o755);
 
       const archivePath = join(assetRoot, 'omx-sparkshell-x86_64-unknown-linux-musl.tar.gz');
-      const archive = spawnSync('tar', ['-czf', archivePath, '-C', stagingDir, 'omx-sparkshell'], { encoding: 'utf-8' });
-      assert.equal(archive.status, 0, archive.stderr || archive.stdout);
+      await writeFile(archivePath, await makeTar([{ name: 'omx-sparkshell', data: Buffer.from('#!/bin/sh\necho hydrated\n') }]));
       const archiveBuffer = await readFile(archivePath);
 
       const manifest = {
+        manifest_version: 1,
         version: '0.8.15',
         tag: 'v0.8.15',
         assets: [
@@ -189,6 +241,8 @@ describe('native asset helpers', () => {
             version: '0.8.15',
             platform: 'linux',
             arch: 'x64',
+            target: 'x86_64-unknown-linux-musl',
+            libc: 'musl',
             archive: 'omx-sparkshell-x86_64-unknown-linux-musl.tar.gz',
             binary: 'omx-sparkshell',
             binary_path: 'omx-sparkshell',
@@ -244,11 +298,14 @@ describe('native asset helpers', () => {
       await chmod(binaryPath, 0o755);
 
       const archivePath = join(assetRoot, 'omx-sparkshell-x86_64-unknown-linux-musl.tar.gz');
-      const archive = spawnSync('tar', ['-czf', archivePath, '-C', join(wd, 'staging'), 'omx-sparkshell-x86_64-unknown-linux-musl'], { encoding: 'utf-8' });
-      assert.equal(archive.status, 0, archive.stderr || archive.stdout);
+      await writeFile(archivePath, await makeTar([
+        { name: 'omx-sparkshell-x86_64-unknown-linux-musl/', type: 'directory' },
+        { name: 'omx-sparkshell-x86_64-unknown-linux-musl/omx-sparkshell', data: Buffer.from('#!/bin/sh\necho hydrated-nested\n') },
+      ]));
       const archiveBuffer = await readFile(archivePath);
 
       const manifest = {
+        manifest_version: 1,
         version: '0.8.15',
         tag: 'v0.8.15',
         assets: [
@@ -257,6 +314,8 @@ describe('native asset helpers', () => {
             version: '0.8.15',
             platform: 'linux',
             arch: 'x64',
+            target: 'x86_64-unknown-linux-musl',
+            libc: 'musl',
             archive: 'omx-sparkshell-x86_64-unknown-linux-musl.tar.gz',
             binary: 'omx-sparkshell',
             binary_path: 'omx-sparkshell',
@@ -319,6 +378,222 @@ describe('native asset helpers', () => {
       } finally {
         await server.close();
       }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('managed native binary inspection', () => {
+  it('classifies B/S/L protocol states without accepting unverified cache files', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-native-inspect-'));
+    const cacheDir = join(wd, 'cache');
+    const env = { OMX_NATIVE_CACHE_DIR: cacheDir };
+    const binaryPath = resolveCachedNativeBinaryPath('omx-sparkshell', '0.8.15', 'linux', 'x64', env);
+    const lockPath = `${binaryPath}.hydrate.lock`;
+    const cases: Array<{
+      name: string;
+      expected: string;
+      setup: () => Promise<void>;
+      expectedLock?: string;
+    }> = [
+      {
+        name: 'missing B/S/L',
+        expected: 'missing',
+        setup: async () => undefined,
+      },
+      {
+        name: 'legacy B without S',
+        expected: 'legacy-unverified',
+        setup: () => writeManagedBinary(binaryPath),
+      },
+      {
+        name: 'verified B and exact S',
+        expected: 'verified',
+        setup: async () => {
+          await writeManagedBinary(binaryPath);
+          await writeManagedSidecar(binaryPath, `${sha256(Buffer.from('native-binary'))}\n`);
+        },
+      },
+      {
+        name: 'truncated S',
+        expected: 'checksum-malformed',
+        setup: async () => {
+          await writeManagedBinary(binaryPath);
+          await writeManagedSidecar(binaryPath, 'a'.repeat(64));
+        },
+      },
+      {
+        name: 'malformed S',
+        expected: 'checksum-malformed',
+        setup: async () => {
+          await writeManagedBinary(binaryPath);
+          await writeManagedSidecar(binaryPath, `${'z'.repeat(64)}\n`);
+        },
+      },
+      {
+        name: 'mismatched S',
+        expected: 'checksum-mismatch',
+        setup: async () => {
+          await writeManagedBinary(binaryPath);
+          await writeManagedSidecar(binaryPath, `${'0'.repeat(64)}\n`);
+        },
+      },
+      {
+        name: 'orphan S without B',
+        expected: 'orphan-checksum',
+        setup: () => writeManagedSidecar(binaryPath, `${'0'.repeat(64)}\n`),
+      },
+      {
+        name: 'empty B',
+        expected: 'binary-empty',
+        setup: () => writeManagedBinary(binaryPath, ''),
+      },
+      {
+        name: 'nonregular B',
+        expected: 'binary-unsafe',
+        setup: async () => { await mkdir(binaryPath, { recursive: true }); },
+      },
+      {
+        name: 'valid L without B',
+        expected: 'publication-in-progress',
+        expectedLock: 'valid-owner-record',
+        setup: async () => {
+          await mkdir(dirname(binaryPath), { recursive: true });
+          await writeFile(lockPath, `${JSON.stringify({
+            version: 1,
+            token: '00000000-0000-4000-8000-000000000000',
+            pid: 1,
+            hostname: 'test-host',
+            started_at: '2026-01-01T00:00:00.000Z',
+            binary_path: binaryPath,
+          })}\n`);
+        },
+      },
+    ];
+    cases.push({
+      name: 'hardlinked B',
+      expected: 'binary-unsafe',
+      setup: async () => {
+        const source = join(wd, 'linked-source');
+        await writeFile(source, 'native-binary');
+        await mkdir(dirname(binaryPath), { recursive: true });
+        await link(source, binaryPath);
+      },
+    });
+    if (process.platform !== 'win32') {
+      cases.push({
+        name: 'symlinked B',
+        expected: 'binary-unsafe',
+        setup: async () => {
+          const source = join(wd, 'symlink-source');
+          await writeFile(source, 'native-binary');
+          await mkdir(dirname(binaryPath), { recursive: true });
+          await symlink(source, binaryPath);
+        },
+      });
+    }
+    try {
+      for (const testCase of cases) {
+        await rm(cacheDir, { recursive: true, force: true });
+        await testCase.setup();
+        const inspected = await inspectManagedNativeBinary(binaryPath, env);
+        assert.equal(inspected.state, testCase.expected, testCase.name);
+        if (testCase.expected === 'verified') assert.equal(inspected.path, binaryPath);
+        if (testCase.expectedLock) {
+          assert.equal(inspected.lock?.classification, testCase.expectedLock, testCase.name);
+          assert.equal(inspected.lock?.owner?.binary_path, binaryPath, testCase.name);
+        }
+      }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+describe('managed native binary lock diagnostics', () => {
+  it('keeps a verified binary authoritative when the lock is unsafe', async () => {
+    if (process.platform === 'win32') return;
+    const wd = await mkdtemp(join(tmpdir(), 'omx-native-lock-diagnostic-'));
+    const env = { OMX_NATIVE_CACHE_DIR: join(wd, 'cache') };
+    const binaryPath = resolveCachedNativeBinaryPath('omx-sparkshell', '0.8.15', 'linux', 'x64', env);
+    try {
+      await writeManagedBinary(binaryPath);
+      await writeManagedSidecar(binaryPath, `${sha256(Buffer.from('native-binary'))}\n`);
+      await symlink(join(wd, 'missing-lock-target'), `${binaryPath}.hydrate.lock`);
+      const inspected = await inspectManagedNativeBinary(binaryPath, env);
+      assert.equal(inspected.state, 'verified');
+      assert.equal(inspected.lock?.classification, 'lock-unsafe');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('treats an unsafe checksum entry as orphaned when the binary is absent', async () => {
+    if (process.platform === 'win32') return;
+    const wd = await mkdtemp(join(tmpdir(), 'omx-native-orphan-sidecar-'));
+    const env = { OMX_NATIVE_CACHE_DIR: join(wd, 'cache') };
+    const binaryPath = resolveCachedNativeBinaryPath('omx-sparkshell', '0.8.15', 'linux', 'x64', env);
+    try {
+      await mkdir(dirname(binaryPath), { recursive: true });
+      await symlink(join(wd, 'missing-sidecar-target'), `${binaryPath}.sha256`);
+      assert.equal((await inspectManagedNativeBinary(binaryPath, env)).state, 'orphan-checksum');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});
+});
+
+describe('native archive policy', () => {
+  it('rejects unsafe paths, duplicate logical manifest keys, and path collisions', () => {
+    for (const path of ['../binary', '/binary', 'C:/binary', '//server/binary', 'dir\\binary', 'dir//binary']) {
+      assert.throws(() => normalizeNativeArchivePath(path, 'file'));
+    }
+    assert.throws(() => assertSafeNativeArchiveEntries([
+      { path: 'binary', type: 'file' },
+      { path: 'binary/config', type: 'file' },
+    ]));
+    assert.throws(() => validateNativeReleaseManifest({
+      version: '0.8.15',
+      assets: [
+        { product: 'omx-api', version: '0.8.15', platform: 'linux', arch: 'x64', target: 'x86_64-unknown-linux-musl', libc: 'musl', archive: 'one.tar.gz', binary: 'omx-api', binary_path: 'omx-api', sha256: 'a'.repeat(64), download_url: 'https://example.invalid/one' },
+        { product: 'omx-api', version: '0.8.15', platform: 'linux', arch: 'x64', target: 'x86_64-unknown-linux-musl', libc: 'musl', archive: 'two.tar.gz', binary: 'omx-api', binary_path: 'omx-api', sha256: 'b'.repeat(64), download_url: 'https://example.invalid/two' },
+      ],
+    }));
+  });
+
+  it('inspects tar.xz, tar.gz, and zip archives before selecting a unique non-empty binary', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-native-archive-policy-'));
+    try {
+      const archives = new Map<string, Buffer>([
+        ['tar.gz', await makeTar([{ name: 'wrapper/', type: 'directory' }, { name: 'wrapper/omx-api', data: Buffer.from('binary') }], 'tar.gz')],
+        ['tar.xz', await makeTar([{ name: 'wrapper/', type: 'directory' }, { name: 'wrapper/omx-api', data: Buffer.from('binary') }], 'tar.xz')],
+        ['zip', await makeZip([{ name: 'wrapper/' }, { name: 'wrapper/omx-api', data: Buffer.from('binary') }])],
+      ]);
+      for (const [suffix, bytes] of archives) {
+        const archivePath = join(wd, `asset.${suffix}`);
+        await writeFile(archivePath, bytes);
+        const entries = await inspectNativeArchive(archivePath);
+        assert.equal(selectNativeArchiveBinary(entries, 'omx-api').path, 'wrapper/omx-api');
+      }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed for links, ambiguous matches, and zero-byte selected members', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-native-archive-adversarial-'));
+    try {
+      const archive = join(wd, 'unsafe.tar.gz');
+      await writeFile(archive, await makeTar([
+        { name: 'link', type: 'symlink', linkname: '/etc/passwd' },
+      ]));
+      await assert.rejects(() => inspectNativeArchive(archive));
+      assert.throws(() => selectNativeArchiveBinary([
+        { rawName: 'one/omx-api', normalizedName: 'one/omx-api', path: 'one/omx-api', type: 'file', size: 1 },
+        { rawName: 'two/omx-api', normalizedName: 'two/omx-api', path: 'two/omx-api', type: 'file', size: 1 },
+      ], 'omx-api'));
+      assert.throws(() => selectNativeArchiveBinary([{ rawName: 'omx-api', normalizedName: 'omx-api', path: 'omx-api', type: 'file', size: 0 }], 'omx-api'));
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/native-assets.test.ts
+++ b/src/cli/__tests__/native-assets.test.ts
@@ -596,7 +596,7 @@ describe('native archive policy', () => {
       ], 'omx-api'));
       assert.throws(() => selectNativeArchiveBinary([{ rawName: 'omx-api', normalizedName: 'omx-api', path: 'omx-api', type: 'file', size: 0 }], 'omx-api'));
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await rm(wd, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
     }
   });
 });

--- a/src/cli/__tests__/native-assets.test.ts
+++ b/src/cli/__tests__/native-assets.test.ts
@@ -491,10 +491,11 @@ describe('native asset helpers', () => {
     if (process.platform === 'win32') return;
     const fixture = await createHydrationFixture();
     const attackerDirectory = join(fixture.wd, 'attacker');
+    const canonicalCacheDir = join(await realpath(dirname(fixture.cacheDir)), 'cache');
     let swapped = false;
     const resetHooks = setNativeAssetsTestHooksForTests({
       beforeCreateParent: async (path) => {
-        if (path !== join(fixture.cacheDir, '0.8.15') || swapped) return;
+        if (path !== join(canonicalCacheDir, '0.8.15') || swapped) return;
         swapped = true;
         await mkdir(attackerDirectory);
         await symlink(attackerDirectory, path);

--- a/src/cli/__tests__/native-assets.test.ts
+++ b/src/cli/__tests__/native-assets.test.ts
@@ -1,7 +1,7 @@
 import { createServer } from 'node:http';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { chmod, link, mkdtemp, mkdir, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, link, mkdtemp, mkdir, readFile, readdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
@@ -17,9 +17,11 @@ import {
   isRepositoryCheckout,
   resolveCachedNativeBinaryCandidatePaths,
   resolveCachedNativeBinaryPath,
+  loadNativeReleaseManifest,
   type NativeReleaseManifest,
   resolveNativeReleaseAssetCandidates,
   resolveNativeReleaseBaseUrl,
+  setNativeAssetsTestHooksForTests,
 } from '../native-assets.js';
 import {
   assertSafeNativeArchiveEntries,
@@ -91,6 +93,53 @@ async function writeManagedBinary(binaryPath: string, contents = 'native-binary'
 async function writeManagedSidecar(binaryPath: string, contents: string): Promise<void> {
   await mkdir(dirname(binaryPath), { recursive: true });
   await writeFile(`${binaryPath}.sha256`, contents);
+}
+
+async function createHydrationFixture(): Promise<{
+  wd: string;
+  cacheDir: string;
+  env: NodeJS.ProcessEnv;
+  expectedPath: string;
+  cleanup: () => Promise<void>;
+}> {
+  const wd = await mkdtemp(join(tmpdir(), 'omx-native-hydrate-race-'));
+  const cacheDir = join(wd, 'cache');
+  const assetRoot = join(wd, 'assets');
+  await mkdir(assetRoot, { recursive: true });
+  await writeFile(join(wd, 'package.json'), JSON.stringify({
+    version: '0.8.15',
+    repository: { url: 'git+https://github.com/Yeachan-Heo/oh-my-codex.git' },
+  }));
+  const archive = await makeTar([{ name: 'omx-sparkshell', data: Buffer.from('#!/bin/sh\necho hydrated\n') }]);
+  const archiveName = 'omx-sparkshell-x86_64-unknown-linux-musl.tar.gz';
+  await writeFile(join(assetRoot, archiveName), archive);
+  const server = await startStaticServer(assetRoot);
+  const manifest = {
+    manifest_version: 1,
+    version: '0.8.15',
+    tag: 'v0.8.15',
+    assets: [{
+      product: 'omx-sparkshell', version: '0.8.15', platform: 'linux', arch: 'x64',
+      target: 'x86_64-unknown-linux-musl', libc: 'musl', archive: archiveName,
+      binary: 'omx-sparkshell', binary_path: 'omx-sparkshell', sha256: sha256(archive), size: archive.length,
+      download_url: `${server.baseUrl}/${archiveName}`,
+    }],
+  };
+  await writeFile(join(assetRoot, 'native-release-manifest.json'), JSON.stringify(manifest));
+  const env = {
+    OMX_NATIVE_MANIFEST_URL: `${server.baseUrl}/native-release-manifest.json`,
+    OMX_NATIVE_CACHE_DIR: cacheDir,
+  };
+  return {
+    wd,
+    cacheDir,
+    env,
+    expectedPath: resolveCachedNativeBinaryPath('omx-sparkshell', '0.8.15', 'linux', 'x64', env, 'musl'),
+    cleanup: async () => {
+      await server.close();
+      await rm(wd, { recursive: true, force: true });
+    },
+  };
 }
 
 
@@ -194,6 +243,42 @@ describe('native asset helpers', () => {
         'omx-sparkshell-x86_64-unknown-linux-gnu.tar.gz',
       ],
     );
+  });
+
+  it('loads the published v0.20.3 manifest shape while selecting only hydratable sibling products', async () => {
+    const publishedV0203Manifest = {
+      manifest_version: 1,
+      version: '0.20.3',
+      tag: 'v0.20.3',
+      generated_at: '2026-07-19T14:27:37.972Z',
+      assets: [
+        {
+          product: 'omx-api', version: '0.20.3', platform: 'win32', arch: 'x64', target: 'x86_64-pc-windows-msvc',
+          archive: 'omx-api-x86_64-pc-windows-msvc.zip', binary: 'omx-api', binary_path: 'omx-api.exe',
+          sha256: 'b08ef0f6b09978755b554b1c7a7b37989723c360136f91d27cdcbf3c4abadae7', size: 478927,
+          download_url: 'https://github.com/Yeachan-Heo/oh-my-codex/releases/download/v0.20.3/omx-api-x86_64-pc-windows-msvc.zip',
+        },
+        {
+          product: 'omx-runtime', version: '0.20.3', platform: 'win32', arch: 'x64', target: 'x86_64-pc-windows-msvc',
+          archive: 'omx-runtime-x86_64-pc-windows-msvc.zip', binary: 'omx-runtime', binary_path: 'omx-runtime.exe',
+          sha256: '52cfc795467c2971ac19ceafb9686f83691375b6fa15ee02b5465839d98c6909', size: 466657,
+          download_url: 'https://github.com/Yeachan-Heo/oh-my-codex/releases/download/v0.20.3/omx-runtime-x86_64-pc-windows-msvc.zip',
+        },
+      ],
+    };
+    const loadedManifest = await loadNativeReleaseManifest(process.cwd(), '0.20.3', {
+      OMX_NATIVE_MANIFEST_URL: `data:application/json,${encodeURIComponent(JSON.stringify(publishedV0203Manifest))}`,
+    });
+    const candidates = resolveNativeReleaseAssetCandidates(
+      loadedManifest,
+      'omx-api',
+      '0.20.3',
+      'win32',
+      'x64',
+    );
+    assert.deepEqual(candidates.map((asset) => [asset.product, asset.binary, asset.binary_path]), [
+      ['omx-api', 'omx-api', 'omx-api.exe'],
+    ]);
   });
 
   it('derives GitHub release base url from package.json repository + version', async () => {
@@ -380,6 +465,56 @@ describe('native asset helpers', () => {
       }
     } finally {
       await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('converges concurrent hydrators from an absent cache tree without publication leftovers', async () => {
+    const fixture = await createHydrationFixture();
+    try {
+      const options = { packageRoot: fixture.wd, env: fixture.env, platform: 'linux' as const, arch: 'x64' };
+      const [first, second] = await Promise.all([
+        hydrateNativeBinary('omx-sparkshell', options),
+        hydrateNativeBinary('omx-sparkshell', options),
+      ]);
+      assert.equal(first, await realpath(fixture.expectedPath));
+      assert.equal(second, await realpath(fixture.expectedPath));
+      assert.deepEqual(
+        (await readdir(dirname(fixture.expectedPath))).sort(),
+        ['omx-sparkshell', 'omx-sparkshell.sha256'],
+      );
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it('fails closed when a parent mkdir races with a symlink swap', async () => {
+    if (process.platform === 'win32') return;
+    const fixture = await createHydrationFixture();
+    const attackerDirectory = join(fixture.wd, 'attacker');
+    let swapped = false;
+    const resetHooks = setNativeAssetsTestHooksForTests({
+      beforeCreateParent: async (path) => {
+        if (path !== join(fixture.cacheDir, '0.8.15') || swapped) return;
+        swapped = true;
+        await mkdir(attackerDirectory);
+        await symlink(attackerDirectory, path);
+      },
+    });
+    try {
+      await assert.rejects(
+        () => hydrateNativeBinary('omx-sparkshell', {
+          packageRoot: fixture.wd,
+          env: fixture.env,
+          platform: 'linux',
+          arch: 'x64',
+        }),
+        /cache descendant is unsafe/,
+      );
+      assert.equal(swapped, true);
+      assert.deepEqual(await readdir(attackerDirectory), []);
+    } finally {
+      resetHooks();
+      await fixture.cleanup();
     }
   });
 });

--- a/src/cli/__tests__/native-assets.test.ts
+++ b/src/cli/__tests__/native-assets.test.ts
@@ -268,9 +268,9 @@ describe('native asset helpers', () => {
           arch: 'x64',
         });
 
-        assert.equal(hydrated, resolveCachedNativeBinaryPath('omx-sparkshell', '0.8.15', 'linux', 'x64', {
+        assert.equal(hydrated, await realpath(resolveCachedNativeBinaryPath('omx-sparkshell', '0.8.15', 'linux', 'x64', {
           OMX_NATIVE_CACHE_DIR: cacheDir,
-        }, 'musl'));
+        }, 'musl')));
         assert.equal(await readFile(hydrated!, 'utf-8'), '#!/bin/sh\necho hydrated\n');
       } finally {
         await server.close();
@@ -341,9 +341,9 @@ describe('native asset helpers', () => {
           arch: 'x64',
         });
 
-        assert.equal(hydrated, resolveCachedNativeBinaryPath('omx-sparkshell', '0.8.15', 'linux', 'x64', {
+        assert.equal(hydrated, await realpath(resolveCachedNativeBinaryPath('omx-sparkshell', '0.8.15', 'linux', 'x64', {
           OMX_NATIVE_CACHE_DIR: cacheDir,
-        }, 'musl'));
+        }, 'musl')));
         assert.equal(await readFile(hydrated!, 'utf-8'), '#!/bin/sh\necho hydrated-nested\n');
       } finally {
         await server.close();
@@ -460,13 +460,14 @@ describe('managed native binary inspection', () => {
         expectedLock: 'valid-owner-record',
         setup: async () => {
           await mkdir(dirname(binaryPath), { recursive: true });
+          const canonicalBinaryPath = join(await realpath(dirname(binaryPath)), 'omx-sparkshell');
           await writeFile(lockPath, `${JSON.stringify({
             version: 1,
             token: '00000000-0000-4000-8000-000000000000',
             pid: 1,
             hostname: 'test-host',
             started_at: '2026-01-01T00:00:00.000Z',
-            binary_path: binaryPath,
+            binary_path: canonicalBinaryPath,
           })}\n`);
         },
       },
@@ -502,7 +503,7 @@ describe('managed native binary inspection', () => {
         if (testCase.expected === 'verified') assert.equal(inspected.path, await realpath(binaryPath));
         if (testCase.expectedLock) {
           assert.equal(inspected.lock?.classification, testCase.expectedLock, testCase.name);
-          assert.equal(inspected.lock?.owner?.binary_path, binaryPath, testCase.name);
+          assert.equal(inspected.lock?.owner?.binary_path, join(await realpath(dirname(binaryPath)), 'omx-sparkshell'), testCase.name);
         }
       }
     } finally {

--- a/src/cli/__tests__/native-assets.test.ts
+++ b/src/cli/__tests__/native-assets.test.ts
@@ -1,7 +1,7 @@
 import { createServer } from 'node:http';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { chmod, link, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, link, mkdtemp, mkdir, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 
 import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
@@ -499,7 +499,7 @@ describe('managed native binary inspection', () => {
         await testCase.setup();
         const inspected = await inspectManagedNativeBinary(binaryPath, env);
         assert.equal(inspected.state, testCase.expected, testCase.name);
-        if (testCase.expected === 'verified') assert.equal(inspected.path, binaryPath);
+        if (testCase.expected === 'verified') assert.equal(inspected.path, await realpath(binaryPath));
         if (testCase.expectedLock) {
           assert.equal(inspected.lock?.classification, testCase.expectedLock, testCase.name);
           assert.equal(inspected.lock?.owner?.binary_path, binaryPath, testCase.name);

--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -247,7 +247,7 @@ describe('resolveSparkShellBinaryPath', () => {
             target: process.platform === 'win32' ? 'x86_64-pc-windows-msvc' : 'x86_64-unknown-linux-musl',
             ...(process.platform === 'win32' ? {} : { libc: 'musl' }),
             archive: archiveName,
-            binary: process.platform === 'win32' ? 'omx-sparkshell.exe' : 'omx-sparkshell',
+            binary: 'omx-sparkshell',
             binary_path: process.platform === 'win32' ? 'omx-sparkshell.exe' : 'omx-sparkshell',
             sha256: checksum,
             size: archiveBuffer.length,

--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -542,24 +542,11 @@ describe('omx sparkshell', () => {
   it('preserves child stdout, stderr, and exit code through the JS bridge', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-sparkshell-bridge-'));
     try {
-      const binDir = join(cwd, 'bin');
-      const stubPath = join(binDir, process.platform === 'win32' ? 'omx-sparkshell.cmd' : 'omx-sparkshell');
-      await mkdir(binDir, { recursive: true });
-      if (process.platform === 'win32') {
-        await writeFile(
-          stubPath,
-          '@echo off\r\necho spark-stdout\r\n>&2 echo spark-stderr\r\nexit /b 7\r\n',
-        );
-      } else {
-        await writeFile(
-          stubPath,
-          '#!/bin/sh\necho spark-stdout\necho spark-stderr 1>&2\nexit 7\n',
-        );
-        await chmod(stubPath, 0o755);
-      }
+      const stubPath = join(cwd, 'sparkshell-stub.cjs');
+      await writeFile(stubPath, 'process.stdout.write("spark-stdout\\n"); process.stderr.write("spark-stderr\\n"); process.exit(7);\n');
 
-      const result = runOmx(cwd, ['sparkshell', 'git', 'status'], {
-        OMX_SPARKSHELL_BIN: stubPath,
+      const result = runOmx(cwd, ['sparkshell', stubPath], {
+        OMX_SPARKSHELL_BIN: process.execPath,
       });
       if (shouldSkipForSpawnPermissions(result.error)) return;
 

--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
 import { readFile } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { dirname, join } from 'node:path';
@@ -599,7 +599,8 @@ describe('omx sparkshell', () => {
       assert.equal(result.status, 0, result.stderr || result.stdout);
       assert.equal(result.stdout, 'raw-fallback\n');
       assert.match(result.stderr, /cause=.*GLIBC_2\.39/i);
-      assert.match(result.stderr, new RegExp(`path=${stubPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      const canonicalStubPath = await realpath(stubPath);
+      assert.match(result.stderr, new RegExp(`path=${canonicalStubPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
       assert.match(result.stderr, /state=glibc-incompatible/i);
       assert.match(result.stderr, /remediation=/i);
     } finally {

--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -452,9 +452,23 @@ describe('parseSparkShellFallbackInvocation', () => {
     );
   });
 
+  it('strips native-only summary flags before raw command fallback', () => {
+    assert.deepEqual(
+      parseSparkShellFallbackInvocation(['--json', '--budget', '4096', '--cache=off', 'node', '-e', 'console.log("ok")']),
+      { kind: 'command', argv: ['node', '-e', 'console.log("ok")'] },
+    );
+  });
+
+  it('strips native-only flags before explicit shell fallback', () => {
+    assert.deepEqual(
+      parseSparkShellFallbackInvocation(['--json', '--budget=4096', '--shell', 'printf ok'], { platform: 'linux' }),
+      { kind: 'command', argv: ['sh', '-lc', 'printf ok'] },
+    );
+  });
+
   it('translates explicit shell fallback through sh -lc', () => {
     assert.deepEqual(
-      parseSparkShellFallbackInvocation(['--shell', 'printf ok']),
+      parseSparkShellFallbackInvocation(['--shell', 'printf ok'], { platform: 'linux' }),
       { kind: 'command', argv: ['sh', '-lc', 'printf ok'] },
     );
   });
@@ -566,15 +580,14 @@ describe('omx sparkshell', () => {
       const packageJson = JSON.parse(await readFile(join(repoRoot, 'package.json'), 'utf-8')) as { version: string };
       const cacheDir = join(cwd, 'cache');
       const binDir = join(cacheDir, packageJson.version, `${process.platform}-${process.arch}`, 'omx-sparkshell');
+      if (process.platform === 'win32') return;
       await mkdir(binDir, { recursive: true });
-      const stubPath = join(binDir, process.platform === 'win32' ? 'omx-sparkshell.exe' : 'omx-sparkshell');
+      const stubPath = join(binDir, 'omx-sparkshell');
       await writeFile(
         stubPath,
-        process.platform === 'win32'
-          ? '@echo off\r\n>&2 echo omx-sparkshell: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39\' not found\r\nexit /b 1\r\n'
-          : "#!/bin/sh\necho \"omx-sparkshell: /lib/x86_64-linux-gnu/libc.so.6: version \\`GLIBC_2.39' not found\" 1>&2\nexit 1\n",
+        "#!/bin/sh\necho \"omx-sparkshell: /lib/x86_64-linux-gnu/libc.so.6: version \\`GLIBC_2.39' not found\" 1>&2\nexit 1\n",
       );
-      if (process.platform !== 'win32') await chmod(stubPath, 0o755);
+      await chmod(stubPath, 0o755);
       const stubDigest = createHash('sha256').update(await readFile(stubPath)).digest('hex');
       await writeFile(`${stubPath}.sha256`, `${stubDigest}\n`);
 

--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -46,6 +46,9 @@ function shouldSkipForSpawnPermissions(err?: string): boolean {
   return typeof err === 'string' && /(EPERM|EACCES)/i.test(err);
 }
 
+const fixturePackageRoot = join(tmpdir(), 'omx-sparkshell-package-root');
+
+
 describe('resolveSparkShellBinaryPath', () => {
   it('prefers OMX_SPARKSHELL_BIN override', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-sparkshell-override-'));
@@ -55,7 +58,8 @@ describe('resolveSparkShellBinaryPath', () => {
         resolveSparkShellBinaryPath({
           cwd,
           env: { OMX_SPARKSHELL_BIN: './bin/custom-sparkshell' },
-          packageRoot: '/unused',
+          packageRoot: fixturePackageRoot,
+
         }),
         binary,
       );
@@ -65,13 +69,12 @@ describe('resolveSparkShellBinaryPath', () => {
   });
 
   it('falls back from packaged binary to repo-local build artifact', () => {
-    const packageRoot = '/repo';
-    const packaged = join(packageRoot, 'bin', 'native', `${process.platform}-${process.arch}`, process.platform === 'win32' ? 'omx-sparkshell.exe' : 'omx-sparkshell');
-    const repoLocal = repoLocalSparkShellBinaryPath(packageRoot);
+    const packaged = join(fixturePackageRoot, 'bin', 'native', `${process.platform}-${process.arch}`, process.platform === 'win32' ? 'omx-sparkshell.exe' : 'omx-sparkshell');
+    const repoLocal = repoLocalSparkShellBinaryPath(fixturePackageRoot);
 
     assert.equal(
       resolveSparkShellBinaryPath({
-        packageRoot,
+        packageRoot: fixturePackageRoot,
         exists: (path) => path === repoLocal,
       }),
       repoLocal,
@@ -81,23 +84,22 @@ describe('resolveSparkShellBinaryPath', () => {
 
   it('checks Linux musl packaged paths before glibc and legacy paths', () => {
     assert.deepEqual(
-      packagedSparkShellBinaryCandidatePaths('/repo', 'linux', 'x64', {}, ['musl', 'glibc']),
+      packagedSparkShellBinaryCandidatePaths(fixturePackageRoot, 'linux', 'x64', {}, ['musl', 'glibc']),
       [
-        '/repo/bin/native/linux-x64-musl/omx-sparkshell',
-        '/repo/bin/native/linux-x64-glibc/omx-sparkshell',
-        '/repo/bin/native/linux-x64/omx-sparkshell',
+        join(fixturePackageRoot, 'bin', 'native', 'linux-x64-musl', 'omx-sparkshell'),
+        join(fixturePackageRoot, 'bin', 'native', 'linux-x64-glibc', 'omx-sparkshell'),
+        join(fixturePackageRoot, 'bin', 'native', 'linux-x64', 'omx-sparkshell'),
       ],
     );
   });
 
   it('tries Linux musl packaged binaries before glibc fallbacks', () => {
-    const packageRoot = '/repo';
     const seen: string[] = [];
-    const glibcPath = '/repo/bin/native/linux-x64-glibc/omx-sparkshell';
+    const glibcPath = join(fixturePackageRoot, 'bin', 'native', 'linux-x64-glibc', 'omx-sparkshell');
 
     assert.equal(
       resolveSparkShellBinaryPath({
-        packageRoot,
+        packageRoot: fixturePackageRoot,
         platform: 'linux',
         arch: 'x64',
         linuxLibcPreference: ['musl', 'glibc'],
@@ -111,19 +113,18 @@ describe('resolveSparkShellBinaryPath', () => {
     assert.deepEqual(
       seen.slice(0, 2),
       [
-        '/repo/bin/native/linux-x64-musl/omx-sparkshell',
-        '/repo/bin/native/linux-x64-glibc/omx-sparkshell',
+        join(fixturePackageRoot, 'bin', 'native', 'linux-x64-musl', 'omx-sparkshell'),
+        join(fixturePackageRoot, 'bin', 'native', 'linux-x64-glibc', 'omx-sparkshell'),
       ],
     );
   });
 
   it('falls back to nested repo-local native build artifact when present', () => {
-    const packageRoot = '/repo';
-    const nestedRepoLocal = nestedRepoLocalSparkShellBinaryPath(packageRoot);
+    const nestedRepoLocal = nestedRepoLocalSparkShellBinaryPath(fixturePackageRoot);
 
     assert.equal(
       resolveSparkShellBinaryPath({
-        packageRoot,
+        packageRoot: fixturePackageRoot,
         exists: (path) => path === nestedRepoLocal,
       }),
       nestedRepoLocal,
@@ -132,9 +133,56 @@ describe('resolveSparkShellBinaryPath', () => {
 
   it('throws with checked paths when neither packaged nor repo-local binary exists', () => {
     assert.throws(
-      () => resolveSparkShellBinaryPath({ packageRoot: '/repo', exists: () => false }),
+      () => resolveSparkShellBinaryPath({ packageRoot: fixturePackageRoot, exists: () => false }),
       /native binary not found/,
     );
+  });
+
+  it('reports the first rejected cache entry instead of an earlier missing candidate', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-sparkshell-rejected-cache-'));
+    try {
+      await writeFile(join(cwd, 'package.json'), JSON.stringify({ version: '0.8.15' }));
+      const cacheDir = join(cwd, 'cache');
+      const rejected = join(cacheDir, '0.8.15', 'linux-x64-glibc', 'omx-sparkshell', 'omx-sparkshell');
+      await mkdir(dirname(rejected), { recursive: true });
+      await writeFile(rejected, 'unverified');
+      await assert.rejects(
+        () => resolveSparkShellBinaryPathWithHydration({
+          packageRoot: cwd,
+          platform: 'linux',
+          arch: 'x64',
+          linuxLibcPreference: ['musl', 'glibc'],
+          env: { OMX_NATIVE_CACHE_DIR: cacheDir, OMX_NATIVE_AUTO_FETCH: '0' },
+        }),
+        (error: Error) => error.message.includes(rejected) && error.message.includes('legacy-unverified'),
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a sidecarless managed cache binary before selecting packaged sparkshell', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-sparkshell-sidecarless-'));
+    try {
+      await writeFile(join(cwd, 'package.json'), JSON.stringify({ version: '0.8.15' }));
+      const cacheDir = join(cwd, 'cache');
+      const cachedDir = join(cacheDir, '0.8.15', 'linux-x64-musl', 'omx-sparkshell');
+      const cachedBinary = join(cachedDir, 'omx-sparkshell');
+      const packaged = join(cwd, 'bin', 'native', 'linux-x64-musl', 'omx-sparkshell');
+      await mkdir(cachedDir, { recursive: true });
+      await mkdir(dirname(packaged), { recursive: true });
+      await writeFile(cachedBinary, '#!/bin/sh\necho untrusted\n');
+      await writeFile(packaged, '#!/bin/sh\necho packaged\n');
+      assert.equal(await resolveSparkShellBinaryPathWithHydration({
+        packageRoot: cwd,
+        platform: 'linux',
+        arch: 'x64',
+        linuxLibcPreference: ['musl'],
+        env: { OMX_NATIVE_CACHE_DIR: cacheDir, OMX_NATIVE_AUTO_FETCH: '0' },
+      }), packaged);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 
   it('hydrates a native binary when packaged and repo-local binaries are absent', async () => {
@@ -188,12 +236,16 @@ describe('resolveSparkShellBinaryPath', () => {
 
       try {
         await writeFile(join(assetRoot, 'native-release-manifest.json'), JSON.stringify({
+          manifest_version: 1,
+          tag: 'v0.8.15',
           version: '0.8.15',
           assets: [{
             product: 'omx-sparkshell',
             version: '0.8.15',
             platform: process.platform === 'win32' ? 'win32' : 'linux',
             arch: 'x64',
+            target: process.platform === 'win32' ? 'x86_64-pc-windows-msvc' : 'x86_64-unknown-linux-musl',
+            ...(process.platform === 'win32' ? {} : { libc: 'musl' }),
             archive: archiveName,
             binary: process.platform === 'win32' ? 'omx-sparkshell.exe' : 'omx-sparkshell',
             binary_path: process.platform === 'win32' ? 'omx-sparkshell.exe' : 'omx-sparkshell',
@@ -536,6 +588,8 @@ describe('omx sparkshell', () => {
           : "#!/bin/sh\necho \"omx-sparkshell: /lib/x86_64-linux-gnu/libc.so.6: version \\`GLIBC_2.39' not found\" 1>&2\nexit 1\n",
       );
       if (process.platform !== 'win32') await chmod(stubPath, 0o755);
+      const stubDigest = createHash('sha256').update(await readFile(stubPath)).digest('hex');
+      await writeFile(`${stubPath}.sha256`, `${stubDigest}\n`);
 
       const result = runOmx(cwd, ['sparkshell', 'node', '-e', 'process.stdout.write("raw-fallback\\n")'], {
         OMX_NATIVE_CACHE_DIR: cacheDir,
@@ -544,8 +598,10 @@ describe('omx sparkshell', () => {
 
       assert.equal(result.status, 0, result.stderr || result.stdout);
       assert.equal(result.stdout, 'raw-fallback\n');
-      assert.match(result.stderr, /GLIBC-incompatible/i);
-      assert.doesNotMatch(result.stderr, /version `GLIBC_2\.39' not found/);
+      assert.match(result.stderr, /cause=.*GLIBC_2\.39/i);
+      assert.match(result.stderr, new RegExp(`path=${stubPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+      assert.match(result.stderr, /state=glibc-incompatible/i);
+      assert.match(result.stderr, /remediation=/i);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/api.ts
+++ b/src/cli/api.ts
@@ -14,6 +14,7 @@ import {
   hydrateNativeBinary,
   resolveCachedNativeBinaryCandidatePaths,
   resolveLinuxNativeLibcPreference,
+  inspectManagedNativeBinary,
 } from './native-assets.js';
 
 const OMX_API_BIN_ENV = API_BIN_ENV_SHARED;
@@ -149,12 +150,15 @@ export async function resolveApiBinaryPathWithHydration(
   if (override) return isAbsolute(override) ? override : resolve(cwd, override);
 
   const version = await getPackageVersion(packageRoot);
+  let rejectedCache: { path: string; state: string } | undefined;
   for (const cached of resolveCachedNativeBinaryCandidatePaths('omx-api', version, platform, arch, env, {
     linuxLibcPreference: platform === 'linux'
       ? (linuxLibcPreference ?? resolveLinuxNativeLibcPreference({ env }))
       : undefined,
   })) {
-    if (exists(cached)) return cached;
+    const inspected = await inspectManagedNativeBinary(cached, env);
+    if (inspected.state === 'verified') return inspected.path!;
+    if (inspected.state !== 'missing') rejectedCache ??= { path: cached, state: inspected.state };
   }
 
   for (const packaged of packagedApiBinaryCandidatePaths(packageRoot, platform, arch, env, linuxLibcPreference)) {
@@ -172,6 +176,7 @@ export async function resolveApiBinaryPathWithHydration(
 
   throw new Error(
     `[api] native binary not found. Checked cached/native candidates under ${packageRoot}, ${repoLocal}, and ${nestedRepoLocal}. `
+      + `${rejectedCache ? `Rejected managed cache entry ${rejectedCache.path} (${rejectedCache.state}). ` : ''}`
       + `Reconnect to the network so OMX can fetch the release asset, or set ${OMX_API_BIN_ENV} to override the path.`,
   );
 }
@@ -207,12 +212,7 @@ export async function apiCommand(args: string[]): Promise<void> {
     return;
   }
 
-  let binaryPath: string;
-  try {
-    binaryPath = await resolveApiBinaryPathWithHydration();
-  } catch (error) {
-    throw error;
-  }
+  const binaryPath = await resolveApiBinaryPathWithHydration();
 
   const result = runApiBinary(binaryPath, args);
   if (result.error) {

--- a/src/cli/native-assets.ts
+++ b/src/cli/native-assets.ts
@@ -1,12 +1,14 @@
 import { createHash } from 'node:crypto';
-import { chmodSync, createWriteStream, existsSync, readdirSync } from 'node:fs';
-import { copyFile, mkdir, mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
-import { homedir, tmpdir } from 'node:os';
-import { dirname, extname, join, resolve } from 'node:path';
+import { constants, createWriteStream, existsSync, readdirSync } from 'node:fs';
+import { chmod, copyFile, lstat, mkdir, mkdtemp, open, readFile, realpath, rename, rm, stat, unlink } from 'node:fs/promises';
+import { homedir, hostname, tmpdir } from 'node:os';
+import { dirname, join, relative, resolve, sep } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { Readable } from 'node:stream';
 import { spawnPlatformCommandSync } from '../utils/platform-command.js';
 import { getPackageRoot } from '../utils/package.js';
+import { validateNativeReleaseManifest } from '../native-assets/policy.js';
+import { inspectNativeArchive, selectNativeArchiveBinary, writeSelectedNativeArchiveMember } from '../native-assets/archive.js';
 
 export type NativeProduct = 'omx-explore-harness' | 'omx-sparkshell' | 'omx-api';
 export type NativeLibc = 'musl' | 'glibc';
@@ -240,7 +242,10 @@ export async function loadNativeReleaseManifest(
   if (!response.ok) {
     throw new Error(`[native-assets] failed to fetch native release manifest (${response.status} ${response.statusText}) from ${url}`);
   }
-  return await response.json() as NativeReleaseManifest;
+  const manifest = await response.json() as NativeReleaseManifest;
+  validateNativeReleaseManifest(manifest as never);
+  if (version && manifest.version !== version) throw new Error(`[native-assets] manifest version mismatch: expected ${version}, received ${manifest.version}`);
+  return manifest;
 }
 
 function isUnavailableManifestError(error: unknown): boolean {
@@ -270,52 +275,388 @@ async function sha256ForFile(path: string): Promise<string> {
   return hash.digest('hex');
 }
 
-async function extractArchive(archivePath: string, destinationDir: string): Promise<void> {
-  await mkdir(destinationDir, { recursive: true });
-  const ext = extname(archivePath).toLowerCase();
-  if (ext === '.zip') {
-    const { result } = spawnPlatformCommandSync(
-      process.platform === 'win32' ? 'powershell' : 'unzip',
-      process.platform === 'win32'
-        ? ['-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', `Expand-Archive -LiteralPath '${archivePath.replace(/'/g, "''")}' -DestinationPath '${destinationDir.replace(/'/g, "''")}' -Force`]
-        : ['-oq', archivePath, '-d', destinationDir],
-      { encoding: 'utf-8' },
-    );
-    if (result.status !== 0 || result.error) {
-      throw new Error(`[native-assets] failed to extract zip archive ${archivePath}: ${(result.stderr || result.error?.message || '').trim()}`);
-    }
-    return;
-  }
 
-  const { result } = spawnPlatformCommandSync('tar', ['-xf', archivePath, '-C', destinationDir], { encoding: 'utf-8' });
-  if (result.status !== 0 || result.error) {
-    throw new Error(`[native-assets] failed to extract archive ${archivePath}: ${(result.stderr || result.error?.message || '').trim()}`);
+const SIDECAR_SUFFIX = '.sha256';
+const LOCK_SUFFIX = '.hydrate.lock';
+const LOCK_WAIT_MS = 10_000;
+const LOCK_RETRY_MS = 100;
+const NATIVE_LOCK_WAIT_MS_ENV = 'OMX_NATIVE_LOCK_WAIT_MS';
+
+const SHA256_LINE = /^[0-9a-f]{64}\n$/;
+
+export type ManagedNativeBinaryState =
+  | 'verified'
+  | 'missing'
+  | 'publication-in-progress'
+  | 'binary-unsafe'
+  | 'binary-empty'
+  | 'orphan-checksum'
+  | 'checksum-unsafe'
+  | 'checksum-malformed'
+  | 'checksum-mismatch'
+  | 'legacy-unverified'
+  | 'cache-descendant-unsafe'
+  | 'inspection-race'
+  | 'publication-lock-timeout'
+  | 'cleanup-failed';
+
+export interface NativeCacheLockDiagnostic {
+  path: string;
+  classification: 'valid-owner-record' | 'metadata-malformed' | 'lock-unsafe' | 'inspection-race' | 'metadata-unavailable';
+  owner?: { pid: number; hostname: string; started_at: string; binary_path: string };
+}
+
+export interface ManagedNativeBinaryInspection {
+  state: ManagedNativeBinaryState;
+  /** Present only when opened-handle verification authorizes this exact binary. */
+  path?: string;
+  lock?: NativeCacheLockDiagnostic;
+}
+
+interface FileIdentity { dev: number | bigint; ino: number | bigint; size: number; }
+interface OpenedFile extends FileIdentity { digest?: string; text?: string; }
+interface PublicationLock { path: string; token: string; record: string; identity: FileIdentity; }
+
+function sidecarPath(binaryPath: string): string { return `${binaryPath}${SIDECAR_SUFFIX}`; }
+function lockPath(binaryPath: string): string { return `${binaryPath}${LOCK_SUFFIX}`; }
+function sameFile(left: FileIdentity, right: FileIdentity): boolean { return left.dev === right.dev && left.ino === right.ino && left.size === right.size; }
+function errno(error: unknown): string | undefined { return (error as NodeJS.ErrnoException).code; }
+function uuid(): string { return crypto.randomUUID(); }
+function absent(error: unknown): boolean { return errno(error) === 'ENOENT'; }
+
+function lockWaitMs(env: NodeJS.ProcessEnv): number {
+  const configured = env[NATIVE_LOCK_WAIT_MS_ENV]?.trim();
+  if (!configured) return LOCK_WAIT_MS;
+  const value = Number(configured);
+  return Number.isFinite(value) && value >= 0 ? value : LOCK_WAIT_MS;
+}
+
+function lockRecord(token: string, binaryPath: string): string {
+  return `${JSON.stringify({
+    version: 1,
+    token,
+    pid: process.pid,
+    hostname: hostname(),
+    started_at: new Date().toISOString(),
+    binary_path: binaryPath,
+  })}\n`;
+}
+
+
+function canonicalDescendantPath(path: string, configuredRoot: string, canonicalRoot: string): string {
+  const rel = relative(resolve(configuredRoot), resolve(path));
+  if (!rel || rel === '..' || rel.startsWith(`..${sep}`)) throw new Error('[native-assets] cache path escapes configured root');
+  return join(canonicalRoot, rel);
+}
+
+async function canonicalCacheRoot(root: string, create: boolean): Promise<string | undefined> {
+  try {
+    if (create) await mkdir(root, { recursive: true, mode: 0o700 });
+    const entry = await lstat(root);
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) throw new Error('unsafe root');
+    return await realpath(root); // The configured root itself is intentionally allowed to be a symlink.
+  } catch (error) {
+    if (!create && absent(error)) return undefined;
+    throw error;
   }
 }
 
-async function findExtractedBinaryPath(rootDir: string, binaryPath: string): Promise<string | undefined> {
-  const normalizedNeedle = binaryPath.replaceAll('\\', '/');
-  const exactCandidate = join(rootDir, binaryPath);
-  if (existsSync(exactCandidate)) return exactCandidate;
-
-  const pending = [rootDir];
-  while (pending.length > 0) {
-    const current = pending.pop()!;
-    const entries = await readdir(current, { withFileTypes: true });
-    for (const entry of entries) {
-      const fullPath = join(current, entry.name);
-      if (entry.isDirectory()) {
-        pending.push(fullPath);
-        continue;
-      }
-      const relative = fullPath.slice(rootDir.length + 1).replaceAll('\\', '/');
-      if (relative === normalizedNeedle || relative.endsWith(`/${normalizedNeedle}`)) {
-        return fullPath;
-      }
+async function validateDescendant(path: string, canonicalRoot: string, createParents: boolean): Promise<void> {
+  const candidate = resolve(path);
+  const rel = relative(canonicalRoot, candidate);
+  if (!rel || rel === '..' || rel.startsWith(`..${sep}`) || resolve(canonicalRoot, rel) !== candidate) {
+    throw new Error('[native-assets] cache path escapes configured root');
+  }
+  const parts = rel.split(sep).filter(Boolean);
+  let current = canonicalRoot;
+  for (const [index, part] of parts.entries()) {
+    current = join(current, part);
+    const isLeaf = index === parts.length - 1;
+    try {
+      const entry = await lstat(current);
+      if (!isLeaf && (entry.isSymbolicLink() || !entry.isDirectory())) throw new Error(`[native-assets] cache descendant is unsafe: ${current}`);
+    } catch (error) {
+      if (!absent(error)) throw error;
+      if (!createParents || isLeaf) continue;
+      await mkdir(current, { mode: 0o700 });
+      const created = await lstat(current);
+      if (!created.isDirectory() || created.isSymbolicLink()) throw new Error(`[native-assets] cache descendant is unsafe: ${current}`);
     }
   }
+  try {
+    const parent = await realpath(dirname(path));
+    if (parent !== canonicalRoot && !parent.startsWith(`${canonicalRoot}${sep}`)) throw new Error('[native-assets] cache path escapes configured root');
+  } catch (error) {
+    if (!absent(error)) throw error;
+  }
+}
 
+async function reInspectPath(path: string, identity: FileIdentity, requireNonEmpty: boolean): Promise<void> {
+  try {
+    const current = await lstat(path);
+    if (current.isSymbolicLink() || !current.isFile() || current.nlink !== 1
+      || (requireNonEmpty && current.size <= 0)
+      || !sameFile(identity, { dev: current.dev, ino: current.ino, size: current.size })) {
+      throw new Error('inspection race');
+    }
+  } catch (error) {
+    if (absent(error)) throw new Error('inspection race');
+    throw error;
+  }
+}
+
+async function readOpenedFile(path: string, requireNonEmpty: boolean, hash: boolean, maxBytes?: number): Promise<OpenedFile> {
+  const before = await lstat(path);
+  if (before.isSymbolicLink() || !before.isFile() || before.nlink !== 1) throw new Error('unsafe file');
+  if (requireNonEmpty && before.size <= 0) throw new Error('empty file');
+  if (maxBytes !== undefined && before.size > maxBytes) throw new Error('file too large');
+  const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const opened = await handle.stat();
+    const identity = { dev: opened.dev, ino: opened.ino, size: opened.size };
+    if (!opened.isFile() || opened.nlink !== 1 || (requireNonEmpty && opened.size <= 0)
+      || (maxBytes !== undefined && opened.size > maxBytes)
+      || !sameFile({ dev: before.dev, ino: before.ino, size: before.size }, identity)) throw new Error('inspection race');
+    const chunks: Buffer[] = [];
+    const digest = hash ? createHash('sha256') : undefined;
+    const buffer = Buffer.alloc(Math.min(64 * 1024, maxBytes ?? 64 * 1024));
+    let position = 0;
+    while (position < opened.size) {
+      const { bytesRead } = await handle.read(buffer, 0, Math.min(buffer.length, opened.size - position), position);
+      if (bytesRead === 0) throw new Error('inspection race');
+      const bytes = buffer.subarray(0, bytesRead);
+      digest?.update(bytes);
+      if (!hash) chunks.push(Buffer.from(bytes));
+      position += bytesRead;
+    }
+    const after = await handle.stat();
+    if (!sameFile(identity, { dev: after.dev, ino: after.ino, size: after.size }) || after.nlink !== 1) throw new Error('inspection race');
+    await reInspectPath(path, identity, requireNonEmpty);
+    return { ...identity, digest: digest?.digest('hex'), text: hash ? undefined : Buffer.concat(chunks).toString('utf8') };
+  } finally { await handle.close(); }
+}
+
+const MAX_SIDECAR_BYTES = 65;
+const MAX_LOCK_RECORD_BYTES = 1024;
+
+function validLockRecord(record: Record<string, unknown>, text: string, binaryPath: string): record is {
+  version: 1; token: string; pid: number; hostname: string; started_at: string; binary_path: string;
+} {
+  if (record.version !== 1 || typeof record.token !== 'string'
+    || !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(record.token)
+    || typeof record.pid !== 'number' || !Number.isSafeInteger(record.pid) || record.pid <= 0
+    || typeof record.hostname !== 'string' || !record.hostname.trim()
+    || typeof record.started_at !== 'string' || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(record.started_at)
+    || !Number.isFinite(Date.parse(record.started_at))
+    || typeof record.binary_path !== 'string' || !record.binary_path.trim() || record.binary_path !== binaryPath) return false;
+  return text === `${JSON.stringify(record)}\n`;
+}
+
+function sanitizeLockDiagnosticField(value: string): string {
+  return value.replace(/[\r\n\t\0]/g, ' ').replace(/[^\x20-\x7e]/g, '?').slice(0, 512);
+}
+
+
+async function inspectLock(path: string, binaryPath: string): Promise<NativeCacheLockDiagnostic | undefined> {
+  try {
+    const file = await readOpenedFile(path, false, false, MAX_LOCK_RECORD_BYTES);
+    const text = file.text || '';
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+    const record = {
+      version: parsed.version,
+      token: parsed.token,
+      pid: parsed.pid,
+      hostname: parsed.hostname,
+      started_at: parsed.started_at,
+      binary_path: parsed.binary_path,
+    };
+    if (!validLockRecord(record, text, binaryPath)) return { path, classification: 'metadata-malformed' };
+    return {
+      path,
+      classification: 'valid-owner-record',
+      owner: {
+        pid: record.pid,
+        hostname: sanitizeLockDiagnosticField(record.hostname),
+        started_at: record.started_at,
+        binary_path: sanitizeLockDiagnosticField(record.binary_path),
+      },
+    };
+  } catch (error) {
+    if (absent(error)) return undefined;
+    const message = error instanceof Error ? error.message : '';
+    return { path, classification: message.includes('race') ? 'inspection-race' : message.includes('unsafe') ? 'lock-unsafe' : error instanceof SyntaxError || message.includes('too large') ? 'metadata-malformed' : 'metadata-unavailable' };
+  }
+}
+
+
+/** Inspects the exact B/S/L protocol. Only `verified` has a path. */
+export async function inspectManagedNativeBinary(binaryPath: string, env: NodeJS.ProcessEnv = process.env): Promise<ManagedNativeBinaryInspection> {
+  const configuredRoot = resolveNativeCacheRoot(env);
+  let root: string | undefined;
+  let effectiveBinaryPath: string;
+  try {
+    root = await canonicalCacheRoot(configuredRoot, false);
+    if (!root) return { state: 'missing' };
+    effectiveBinaryPath = canonicalDescendantPath(binaryPath, configuredRoot, root);
+    await validateDescendant(effectiveBinaryPath, root, false);
+    await validateDescendant(sidecarPath(effectiveBinaryPath), root, false);
+    await validateDescendant(lockPath(effectiveBinaryPath), root, false);
+  } catch (error) {
+    return { state: error instanceof Error && error.message.includes('race') ? 'inspection-race' : 'cache-descendant-unsafe' };
+  }
+  const lockDiagnostic = await inspectLock(lockPath(effectiveBinaryPath!), effectiveBinaryPath!);
+  try {
+    await validateDescendant(effectiveBinaryPath!, root!, false);
+    await validateDescendant(sidecarPath(effectiveBinaryPath!), root!, false);
+    await validateDescendant(lockPath(effectiveBinaryPath!), root!, false);
+  } catch {
+    return { state: 'inspection-race' };
+  }
+  let binary: OpenedFile | undefined;
+  try { binary = await readOpenedFile(effectiveBinaryPath!, true, true); } catch (error) {
+    if (!absent(error)) {
+      const message = error instanceof Error ? error.message : '';
+      return { state: message.includes('empty') ? 'binary-empty' : message.includes('race') ? 'inspection-race' : 'binary-unsafe', lock: lockDiagnostic };
+    }
+    try { await lstat(sidecarPath(effectiveBinaryPath!)); return { state: 'orphan-checksum', lock: lockDiagnostic }; } catch (sidecarError) {
+      if (!absent(sidecarError)) return { state: 'inspection-race', lock: lockDiagnostic };
+      return { state: lockDiagnostic ? 'publication-in-progress' : 'missing', lock: lockDiagnostic };
+
+    }
+  }
+  try { await validateDescendant(effectiveBinaryPath!, root!, false); } catch { return { state: 'inspection-race', lock: lockDiagnostic }; }
+  let sidecar: OpenedFile;
+  try { sidecar = await readOpenedFile(sidecarPath(effectiveBinaryPath!), true, false, MAX_SIDECAR_BYTES); } catch (error) {
+    if (absent(error)) return { state: lockDiagnostic ? 'publication-in-progress' : 'legacy-unverified', lock: lockDiagnostic };
+    return { state: error instanceof Error && error.message.includes('too large') ? 'checksum-malformed' : 'checksum-unsafe', lock: lockDiagnostic };
+  }
+  try { await validateDescendant(sidecarPath(effectiveBinaryPath!), root!, false); } catch { return { state: 'inspection-race', lock: lockDiagnostic }; }
+  if (sidecar.size !== MAX_SIDECAR_BYTES || !SHA256_LINE.test(sidecar.text || '')) return { state: 'checksum-malformed', lock: lockDiagnostic };
+  if (sidecar.text!.slice(0, 64) !== binary.digest) return { state: 'checksum-mismatch', lock: lockDiagnostic };
+  return { state: 'verified', path: effectiveBinaryPath!, lock: lockDiagnostic };
+}
+
+async function acquireCacheLock(binaryPath: string, env: NodeJS.ProcessEnv): Promise<PublicationLock> {
+
+  const path = lockPath(binaryPath);
+  const started = performance.now();
+  const deadline = started + lockWaitMs(env);
+
+  for (;;) {
+    const token = uuid();
+    const record = lockRecord(token, binaryPath);
+
+    const recordBytes = Buffer.from(record, 'utf8');
+    try {
+      const handle = await open(path, constants.O_RDWR | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, 0o600);
+      try {
+        const { bytesWritten } = await handle.write(recordBytes, 0, recordBytes.length, 0);
+        if (bytesWritten !== recordBytes.length) throw new Error('[native-assets] incomplete lock write');
+        const readback = Buffer.alloc(recordBytes.length);
+        const { bytesRead } = await handle.read(readback, 0, readback.length, 0);
+        if (bytesRead !== readback.length || !readback.equals(recordBytes)) throw new Error('[native-assets] lock readback mismatch');
+        const identity = await handle.stat();
+        const fileIdentity = { dev: identity.dev, ino: identity.ino, size: identity.size };
+        if (!identity.isFile() || identity.nlink !== 1) throw new Error('[native-assets] unsafe publication lock');
+        await reInspectPath(path, fileIdentity, true);
+        return { path, token, record, identity: fileIdentity };
+
+      } finally { await handle.close(); }
+    } catch (error) {
+      if (errno(error) !== 'EEXIST') throw error;
+      if (performance.now() >= deadline) {
+        const diagnostic = await inspectLock(path, binaryPath) ?? { path, classification: 'metadata-unavailable' as const };
+        const owner = diagnostic.owner ? ` owner=${JSON.stringify(diagnostic.owner)}` : '';
+        throw new Error(`[native-assets] publication-lock-timeout: ${path}; elapsed=${Math.round(performance.now() - started)}ms deadline=${lockWaitMs(env)}ms; ${diagnostic.classification}${owner}. Confirm no OMX hydration process is active for this cache key, remove only this named lock manually, then retry.`);
+      }
+
+      await new Promise<void>((done) => setTimeout(done, LOCK_RETRY_MS));
+    }
+  }
+}
+
+async function releaseCacheLock(lock: PublicationLock): Promise<ManagedNativeBinaryInspection | undefined> {
+  try {
+    const reopened = await readOpenedFile(lock.path, false, false);
+    if (!sameFile(lock.identity, reopened) || reopened.text !== lock.record) return { state: 'cleanup-failed' };
+    const current = await lstat(lock.path);
+    if (!sameFile(lock.identity, { dev: current.dev, ino: current.ino, size: current.size }) || !current.isFile() || current.nlink !== 1) return { state: 'cleanup-failed' };
+    await unlink(lock.path);
+  } catch (error) { return absent(error) ? undefined : { state: 'cleanup-failed' }; }
   return undefined;
+}
+
+async function quarantineInvalid(path: string): Promise<void> {
+  try {
+    await lstat(path);
+    await rename(path, `${path}.quarantine.${uuid()}`);
+  } catch (error) { if (!absent(error)) throw error; }
+}
+
+async function publishManagedNativeBinary(source: string, destination: string, platform: NodeJS.Platform, env: NodeJS.ProcessEnv): Promise<string | undefined> {
+  const configuredRoot = resolveNativeCacheRoot(env);
+  const root = await canonicalCacheRoot(configuredRoot, true);
+  if (!root) throw new Error('[native-assets] unable to create cache root');
+  destination = canonicalDescendantPath(destination, configuredRoot, root);
+  await validateDescendant(destination, root, true);
+  const lock = await acquireCacheLock(destination, env);
+  const attempt = uuid();
+  const tempBinary = join(dirname(destination), `.${attempt}.tmp.bin`);
+  const tempSidecar = join(dirname(destination), `.${attempt}.tmp.sha256`);
+  const revalidatePublicationPaths = async (): Promise<void> => {
+    await validateDescendant(destination, root, false);
+    await validateDescendant(sidecarPath(destination), root, false);
+    await validateDescendant(lock.path, root, false);
+    await validateDescendant(tempBinary, root, false);
+    await validateDescendant(tempSidecar, root, false);
+  };
+  let primaryError: unknown;
+  try {
+    await revalidatePublicationPaths();
+    const existing = await inspectManagedNativeBinary(destination, env);
+    if (existing.state === 'verified') return existing.path;
+    await copyFile(source, tempBinary, constants.COPYFILE_EXCL);
+    await revalidatePublicationPaths();
+    if (platform !== 'win32') await chmod(tempBinary, 0o755);
+    const binary = await readOpenedFile(tempBinary, true, true);
+    const sidecar = `${binary.digest}\n`;
+    const handle = await open(tempSidecar, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, 0o600);
+    try { await handle.writeFile(sidecar, 'utf8'); } finally { await handle.close(); }
+    if ((await readOpenedFile(tempSidecar, true, false, MAX_SIDECAR_BYTES)).text !== sidecar) throw new Error('[native-assets] temporary checksum verification failed');
+    await revalidatePublicationPaths();
+    await quarantineInvalid(destination);
+    await revalidatePublicationPaths();
+    await quarantineInvalid(sidecarPath(destination));
+    await revalidatePublicationPaths();
+    await rename(tempBinary, destination);
+    await revalidatePublicationPaths();
+    await rename(tempSidecar, sidecarPath(destination));
+    await revalidatePublicationPaths();
+    const final = await inspectManagedNativeBinary(destination, env);
+    await revalidatePublicationPaths();
+    if (final.state !== 'verified') throw new Error(`[native-assets] cache publication verification failed: ${final.state}`);
+    return final.path;
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    const cleanupFailures: string[] = [];
+    try { await revalidatePublicationPaths(); } catch (error) {
+      cleanupFailures.push(`revalidate publication paths: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    for (const temporary of [tempBinary, tempSidecar]) {
+      try { await rm(temporary, { force: true }); } catch (error) {
+        cleanupFailures.push(`remove ${temporary}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+    const lockCleanup = await releaseCacheLock(lock);
+    if (lockCleanup) cleanupFailures.push(`${lockCleanup.state}: publication lock was retained`);
+    if (cleanupFailures.length > 0) {
+      const evidence = `[native-assets] cleanup evidence: ${cleanupFailures.join('; ')}`;
+      if (primaryError instanceof Error) primaryError.message += `\n${evidence}`;
+      else throw new Error(evidence);
+    }
+  }
 }
 
 export async function hydrateNativeBinary(
@@ -335,7 +676,8 @@ export async function hydrateNativeBinary(
 
   const version = await getPackageVersion(packageRoot);
   for (const cachedBinaryPath of resolveCachedNativeBinaryCandidatePaths(product, version, platform, arch, env)) {
-    if (existsSync(cachedBinaryPath)) return cachedBinaryPath;
+    const inspected = await inspectManagedNativeBinary(cachedBinaryPath, env);
+    if (inspected.state === 'verified') return inspected.path!;
   }
 
   let manifest: NativeReleaseManifest;
@@ -351,7 +693,7 @@ export async function hydrateNativeBinary(
   if (assets.length === 0) return undefined;
 
   const tempRoot = await mkdtemp(join(tmpdir(), `${product}-${platform}-${arch}-`));
-  const extractDir = join(tempRoot, 'extract');
+  const extractedBinaryPath = join(tempRoot, 'native-binary');
 
   try {
     for (let index = 0; index < assets.length; index += 1) {
@@ -376,20 +718,17 @@ export async function hydrateNativeBinary(
           throw new Error(`[native-assets] checksum mismatch for ${asset.archive}`);
         }
 
-        await extractArchive(archivePath, extractDir);
-        const extractedBinaryPath = await findExtractedBinaryPath(extractDir, asset.binary_path);
-        if (!extractedBinaryPath) {
-          throw new Error(`[native-assets] extracted archive missing expected binary ${asset.binary_path}`);
-        }
+        const archiveEntries = await inspectNativeArchive(archivePath);
+        const archiveBinary = selectNativeArchiveBinary(archiveEntries, asset.binary_path);
+        await writeSelectedNativeArchiveMember(archivePath, archiveBinary.path, extractedBinaryPath);
 
-        await mkdir(dirname(cachedBinaryPath), { recursive: true });
-        await copyFile(extractedBinaryPath, cachedBinaryPath);
-        if (platform !== 'win32') chmodSync(cachedBinaryPath, 0o755);
-        return cachedBinaryPath;
+        const published = await publishManagedNativeBinary(extractedBinaryPath, cachedBinaryPath, platform, env);
+        if (published) return published;
+        throw new Error(`[native-assets] cache publication verification failed for ${cachedBinaryPath}`);
       } catch (error) {
         if (index < assets.length - 1 && isUnavailableArchiveError(error)) {
           await rm(archivePath, { force: true });
-          await rm(extractDir, { recursive: true, force: true });
+          await rm(extractedBinaryPath, { force: true });
           continue;
         }
         throw error;

--- a/src/cli/native-assets.ts
+++ b/src/cli/native-assets.ts
@@ -344,7 +344,10 @@ function lockRecord(token: string, binaryPath: string): string {
 
 
 function canonicalDescendantPath(path: string, configuredRoot: string, canonicalRoot: string): string {
-  const rel = relative(resolve(configuredRoot), resolve(path));
+  const resolvedPath = resolve(path);
+  const canonicalRelative = relative(canonicalRoot, resolvedPath);
+  if (canonicalRelative && canonicalRelative !== '..' && !canonicalRelative.startsWith(`..${sep}`)) return resolvedPath;
+  const rel = relative(resolve(configuredRoot), resolvedPath);
   if (!rel || rel === '..' || rel.startsWith(`..${sep}`)) throw new Error('[native-assets] cache path escapes configured root');
   return join(canonicalRoot, rel);
 }

--- a/src/cli/native-assets.ts
+++ b/src/cli/native-assets.ts
@@ -323,6 +323,19 @@ function sameFile(left: FileIdentity, right: FileIdentity): boolean { return lef
 function errno(error: unknown): string | undefined { return (error as NodeJS.ErrnoException).code; }
 function uuid(): string { return crypto.randomUUID(); }
 function absent(error: unknown): boolean { return errno(error) === 'ENOENT'; }
+interface NativeAssetsTestHooks {
+  beforeCreateParent?(path: string): Promise<void>;
+}
+
+let nativeAssetsTestHooks: NativeAssetsTestHooks | undefined;
+
+/** Test-only seam for deterministic cache-parent creation races. */
+export function setNativeAssetsTestHooksForTests(hooks: NativeAssetsTestHooks | undefined): () => void {
+  const previousHooks = nativeAssetsTestHooks;
+  nativeAssetsTestHooks = hooks;
+  return () => { nativeAssetsTestHooks = previousHooks; };
+}
+
 
 function lockWaitMs(env: NodeJS.ProcessEnv): number {
   const configured = env[NATIVE_LOCK_WAIT_MS_ENV]?.trim();
@@ -381,7 +394,12 @@ async function validateDescendant(path: string, canonicalRoot: string, createPar
     } catch (error) {
       if (!absent(error)) throw error;
       if (!createParents || isLeaf) continue;
-      await mkdir(current, { mode: 0o700 });
+      await nativeAssetsTestHooks?.beforeCreateParent?.(current);
+      try {
+        await mkdir(current, { mode: 0o700 });
+      } catch (error) {
+        if (errno(error) !== 'EEXIST') throw error;
+      }
       const created = await lstat(current);
       if (!created.isDirectory() || created.isSymbolicLink()) throw new Error(`[native-assets] cache descendant is unsafe: ${current}`);
     }

--- a/src/cli/sparkshell.ts
+++ b/src/cli/sparkshell.ts
@@ -271,10 +271,34 @@ export function resolveFallbackShellArgv(
   return [env.ComSpec?.trim() || 'cmd.exe', '/d', '/s', '/c', script];
 }
 
+function stripSparkShellWrapperOptions(args: readonly string[]): string[] {
+  let index = 0;
+  while (index < args.length) {
+    const token = args[index]!;
+    if (token === '--') return [...args.slice(index + 1)];
+    if (token === '--json' || token === '--since-last' || token.startsWith('--cache=')) {
+      index += 1;
+      continue;
+    }
+    if (token === '--budget' || token === '--cache-ttl-ms' || token === '--team' || token === '--worker') {
+      if (args[index + 1] === undefined) throw new Error(`${token} requires a value.\n${SPARKSHELL_USAGE}`);
+      index += 2;
+      continue;
+    }
+    if (token.startsWith('--budget=') || token.startsWith('--cache-ttl-ms=') || token.startsWith('--team=') || token.startsWith('--worker=')) {
+      index += 1;
+      continue;
+    }
+    return [...args.slice(index)];
+  }
+  return [];
+}
+
 export function parseSparkShellFallbackInvocation(
   args: readonly string[],
   options: ParseSparkShellFallbackOptions = {},
 ): SparkShellFallbackInvocation {
+  args = stripSparkShellWrapperOptions(args);
   if (args.length === 0) {
     throw new Error(`Missing command to run.\n${SPARKSHELL_USAGE}`);
   }

--- a/src/cli/sparkshell.ts
+++ b/src/cli/sparkshell.ts
@@ -16,6 +16,7 @@ import {
   hydrateNativeBinary,
   resolveLinuxNativeLibcPreference,
   resolveCachedNativeBinaryCandidatePaths,
+  inspectManagedNativeBinary,
 } from './native-assets.js';
 
 const OMX_SPARKSHELL_BIN_ENV = SPARKSHELL_BIN_ENV_SHARED;
@@ -155,12 +156,15 @@ export async function resolveSparkShellBinaryPathWithHydration(
   }
 
   const version = await getPackageVersion(packageRoot);
+  let rejectedCache: { path: string; state: string } | undefined;
   for (const cached of resolveCachedNativeBinaryCandidatePaths('omx-sparkshell', version, platform, arch, env, {
     linuxLibcPreference: platform === 'linux'
       ? (linuxLibcPreference ?? resolveLinuxNativeLibcPreference({ env }))
       : undefined,
   })) {
-    if (exists(cached)) return cached;
+    const inspected = await inspectManagedNativeBinary(cached, env);
+    if (inspected.state === 'verified') return inspected.path!;
+    if (inspected.state !== 'missing') rejectedCache ??= { path: cached, state: inspected.state };
   }
 
   for (const packaged of packagedSparkShellBinaryCandidatePaths(packageRoot, platform, arch, env, linuxLibcPreference)) {
@@ -178,7 +182,8 @@ export async function resolveSparkShellBinaryPathWithHydration(
 
   throw new Error(
     `[sparkshell] native binary not found. Checked cached/native candidates under ${packageRoot}, ${repoLocal}, and ${nestedRepoLocal}. `
-      + `Reconnect to the network so OMX can fetch the release asset, or set ${OMX_SPARKSHELL_BIN_ENV} to override the path.`
+      + `${rejectedCache ? `Rejected managed cache entry ${rejectedCache.path} (${rejectedCache.state}). ` : ''}`
+      + `Reconnect to the network so OMX can fetch the release asset, or set ${OMX_SPARKSHELL_BIN_ENV} to override the path.`,
   );
 }
 
@@ -231,7 +236,17 @@ interface SparkShellFallbackInvocation {
 }
 
 interface RunSparkShellFallbackOptions {
+  cause?: unknown;
+  nativePath?: string;
+  state?: string;
   announce?: boolean;
+}
+
+function sanitizeFallbackDiagnostic(value: unknown): string {
+  return String(value instanceof Error ? value.message : value ?? 'unknown')
+    .replace(/[\r\n\t\0]/g, ' ')
+    .replace(/[^\x20-\x7e]/g, '?')
+    .slice(0, 500);
 }
 
 interface ParseSparkShellFallbackOptions {
@@ -333,10 +348,10 @@ export function parseSparkShellFallbackInvocation(
 }
 
 function runSparkShellFallback(args: readonly string[], options: RunSparkShellFallbackOptions = {}): void {
-  const { announce = true } = options;
+  const { announce = true, cause = 'native sidecar unavailable', nativePath = 'native-resolution', state = 'unavailable' } = options;
   const invocation = parseSparkShellFallbackInvocation(args);
   if (announce) {
-    process.stderr.write('[sparkshell] native sidecar unavailable; falling back to raw command execution without summary support.\n');
+    process.stderr.write(`[sparkshell] native sidecar unavailable; cause=${sanitizeFallbackDiagnostic(cause)}; path=${sanitizeFallbackDiagnostic(nativePath)}; state=${sanitizeFallbackDiagnostic(state)}; remediation=install a compatible native sidecar, reconnect for hydration, or set ${OMX_SPARKSHELL_BIN_ENV}. Falling back to raw command execution without summary support.\n`);
   }
   const result = spawnSync(invocation.argv[0], invocation.argv.slice(1), {
     cwd: process.cwd(),
@@ -379,7 +394,7 @@ export async function sparkshellCommand(args: string[]): Promise<void> {
     binaryPath = await resolveSparkShellBinaryPathWithHydration();
   } catch (error) {
     if (!hasExplicitOverride) {
-      runSparkShellFallback(args);
+      runSparkShellFallback(args, { cause: error, state: 'resolution-failed' });
       return;
     }
     throw error;
@@ -390,7 +405,7 @@ export async function sparkshellCommand(args: string[]): Promise<void> {
     const errno = result.error as NodeJS.ErrnoException;
     const kind = classifySpawnError(errno);
     if (!hasExplicitOverride && (kind === 'missing' || kind === 'blocked')) {
-      runSparkShellFallback(args);
+      runSparkShellFallback(args, { cause: errno, nativePath: binaryPath, state: kind });
       return;
     }
     if (kind === 'missing') {
@@ -403,8 +418,11 @@ export async function sparkshellCommand(args: string[]): Promise<void> {
   }
 
   if (!hasExplicitOverride && isSparkShellNativeCompatibilityFailure(result)) {
-    process.stderr.write('[sparkshell] GLIBC-incompatible native sidecar detected; falling back to raw command execution without summary support.\n');
-    runSparkShellFallback(args, { announce: false });
+    runSparkShellFallback(args, {
+      cause: result.stderr || 'GLIBC-incompatible native sidecar',
+      nativePath: binaryPath,
+      state: 'glibc-incompatible',
+    });
     return;
   }
 

--- a/src/native-assets/archive.ts
+++ b/src/native-assets/archive.ts
@@ -1,5 +1,5 @@
-import { createReadStream, createWriteStream, readFileSync } from 'node:fs';
-import { mkdir, rm } from 'node:fs/promises';
+import { createReadStream, readFileSync } from 'node:fs';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { createGunzip } from 'node:zlib';
 import { PassThrough, Readable } from 'node:stream';
@@ -219,15 +219,20 @@ export async function writeSelectedNativeArchiveMember(archivePath: string, memb
   if (!selected) throw archiveError('archive_binary_missing', member);
   if (selected.size <= 0) throw archiveError('archive_binary_empty', member);
   const source = await streamSelectedNativeArchiveMember(archivePath, member);
+  const chunks: Buffer[] = [];
   let size = 0;
-  source.on('data', (chunk: Buffer) => { size += chunk.length; });
+  for await (const chunk of source) {
+    const bytes = Buffer.from(chunk);
+    chunks.push(bytes);
+    size += bytes.length;
+  }
   await mkdir(dirname(destinationPath), { recursive: true });
   try {
-    await pipeline(source, createWriteStream(destinationPath, { flags: 'wx' }));
     if (size !== selected.size) throw archiveError('archive_binary_size_mismatch', member);
+    await writeFile(destinationPath, Buffer.concat(chunks), { flag: 'wx' });
     return size;
   } catch (error) {
-    await rm(destinationPath, { force: true });
+    await rm(destinationPath, { force: true, maxRetries: 5, retryDelay: 50 });
     throw error;
   }
 }

--- a/src/native-assets/archive.ts
+++ b/src/native-assets/archive.ts
@@ -1,7 +1,7 @@
-import { createReadStream, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import { createGunzip } from 'node:zlib';
+import { gunzipSync } from 'node:zlib';
 import { PassThrough, Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { decompress } from '@napi-rs/lzma/xz';
@@ -42,9 +42,9 @@ function entry(rawName: string, type: NativeArchiveEntryType, size: number): Nat
 }
 
 async function tarInput(archivePath: string, format: 'tar.xz' | 'tar.gz'): Promise<Readable> {
-  if (format === 'tar.gz') return createReadStream(archivePath).pipe(createGunzip());
   try {
-    return Readable.from(await decompress(readFileSync(archivePath)));
+    const archive = readFileSync(archivePath);
+    return Readable.from(format === 'tar.gz' ? gunzipSync(archive) : await decompress(archive));
   } catch (error) {
     throw archiveError('archive_inspection_failed', error instanceof Error ? error.message : archivePath);
   }

--- a/src/native-assets/archive.ts
+++ b/src/native-assets/archive.ts
@@ -1,0 +1,233 @@
+import { createReadStream, createWriteStream, readFileSync } from 'node:fs';
+import { mkdir, rm } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { createGunzip } from 'node:zlib';
+import { PassThrough, Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { decompress } from '@napi-rs/lzma/xz';
+import * as tar from 'tar-stream';
+import * as yauzl from 'yauzl';
+import {
+  assertSafeNativeArchiveEntries,
+  normalizeNativeArchivePath,
+  type NativeArchiveEntryType,
+} from './policy.js';
+
+export interface NativeArchiveEntry {
+  /** Original archive member name, retained for diagnostics and exact extraction. */
+  rawName: string;
+  /** Safe, separator-normalized logical member name. */
+  normalizedName: string;
+  /** @deprecated Use normalizedName. */
+  path: string;
+  type: NativeArchiveEntryType;
+  size: number;
+}
+
+function archiveError(code: string, detail: string): Error {
+  return new Error(`[native-assets] ${code}: ${detail}`);
+}
+
+function archiveFormat(archivePath: string): 'tar.xz' | 'tar.gz' | 'zip' {
+  if (/\.tar\.xz$/i.test(archivePath)) return 'tar.xz';
+  if (/\.tar\.gz$/i.test(archivePath)) return 'tar.gz';
+  if (/\.zip$/i.test(archivePath)) return 'zip';
+  throw archiveError('archive_format_unsupported', archivePath);
+}
+
+function entry(rawName: string, type: NativeArchiveEntryType, size: number): NativeArchiveEntry {
+  if (!Number.isSafeInteger(size) || size < 0) throw archiveError('archive_inspection_failed', `invalid entry size: ${rawName}`);
+  const normalizedName = normalizeNativeArchivePath(rawName, type);
+  return { rawName, normalizedName, path: normalizedName, type, size };
+}
+
+async function tarInput(archivePath: string, format: 'tar.xz' | 'tar.gz'): Promise<Readable> {
+  if (format === 'tar.gz') return createReadStream(archivePath).pipe(createGunzip());
+  try {
+    return Readable.from(await decompress(readFileSync(archivePath)));
+  } catch (error) {
+    throw archiveError('archive_inspection_failed', error instanceof Error ? error.message : archivePath);
+  }
+}
+
+async function inspectTar(archivePath: string, format: 'tar.xz' | 'tar.gz'): Promise<NativeArchiveEntry[]> {
+  const entries: NativeArchiveEntry[] = [];
+  const extractor = tar.extract();
+  extractor.on('entry', (header, source, next) => {
+    try {
+      if (header.type !== 'file' && header.type !== 'directory') throw archiveError('archive_entry_unsupported', header.name);
+      entries.push(entry(header.name, header.type, header.size ?? 0));
+      source.resume();
+      source.once('end', next);
+    } catch (error) {
+      source.resume();
+      next(error);
+    }
+  });
+  try {
+    await pipeline(await tarInput(archivePath, format), extractor);
+  } catch (error) {
+    throw archiveError('archive_inspection_failed', error instanceof Error ? error.message : archivePath);
+  }
+  assertSafeNativeArchiveEntries(entries);
+  return entries;
+}
+
+function openZip(archivePath: string): Promise<yauzl.ZipFile> {
+  return new Promise((resolve, reject) => {
+    yauzl.open(archivePath, { autoClose: false, lazyEntries: true, strictFileNames: true }, (error, zip) => {
+      if (error || !zip) reject(archiveError('archive_inspection_failed', error?.message || archivePath));
+      else resolve(zip);
+    });
+  });
+}
+
+function zipEntryType(candidate: yauzl.Entry): NativeArchiveEntryType {
+  const modeType = (candidate.externalFileAttributes >>> 16) & 0o170000;
+  const trailingSlash = candidate.fileName.endsWith('/');
+  const dosDirectory = (candidate.externalFileAttributes & 0x10) !== 0;
+  const unixModeIsExplicit = (candidate.versionMadeBy >>> 8) === 3 && modeType !== 0;
+
+  if (unixModeIsExplicit) {
+    if (modeType === 0o100000) {
+      if (trailingSlash || dosDirectory) throw archiveError('archive_entry_unsupported', candidate.fileName);
+      return 'file';
+    }
+    if (modeType === 0o040000) {
+      if (!trailingSlash) throw archiveError('archive_entry_unsupported', candidate.fileName);
+      return 'directory';
+    }
+    throw archiveError('archive_entry_unsupported', candidate.fileName);
+  }
+
+  if (modeType !== 0 && modeType !== 0o100000 && modeType !== 0o040000) {
+    throw archiveError('archive_entry_unsupported', candidate.fileName);
+  }
+  if (trailingSlash !== dosDirectory) throw archiveError('archive_entry_unsupported', candidate.fileName);
+  return trailingSlash ? 'directory' : 'file';
+}
+
+async function inspectZip(archivePath: string): Promise<NativeArchiveEntry[]> {
+  const zip = await openZip(archivePath);
+  const entries: NativeArchiveEntry[] = [];
+  try {
+    await new Promise<void>((resolve, reject) => {
+      zip.once('error', reject);
+      zip.on('entry', (candidate: yauzl.Entry) => {
+        try {
+          entries.push(entry(candidate.fileName, zipEntryType(candidate), candidate.uncompressedSize));
+          zip.readEntry();
+        } catch (error) {
+          reject(error);
+        }
+      });
+      zip.once('end', resolve);
+      zip.readEntry();
+    });
+  } catch (error) {
+    throw archiveError('archive_inspection_failed', error instanceof Error ? error.message : archivePath);
+  } finally {
+    zip.close();
+  }
+  assertSafeNativeArchiveEntries(entries);
+  return entries;
+}
+
+export async function inspectNativeArchive(archivePath: string): Promise<NativeArchiveEntry[]> {
+  const format = archiveFormat(archivePath);
+  return format === 'zip' ? inspectZip(archivePath) : inspectTar(archivePath, format);
+}
+
+export function selectNativeArchiveBinary(entries: readonly NativeArchiveEntry[], binaryPath: string): NativeArchiveEntry {
+  const expected = normalizeNativeArchivePath(binaryPath, 'file');
+  const exact = entries.filter((candidate) => candidate.type === 'file' && candidate.normalizedName === expected);
+  const wrapped = entries.filter((candidate) => candidate.type === 'file'
+    && candidate.normalizedName.endsWith(`/${expected}`)
+    && candidate.normalizedName.split('/').length === expected.split('/').length + 1);
+  const candidates = [...exact, ...wrapped];
+  if (candidates.length !== 1) throw archiveError('archive_binary_ambiguous', expected);
+  if (candidates[0]!.size <= 0) throw archiveError('archive_binary_empty', candidates[0]!.normalizedName);
+  return candidates[0]!;
+}
+
+async function streamTarMember(archivePath: string, format: 'tar.xz' | 'tar.gz', rawName: string): Promise<Readable> {
+  const output = new PassThrough();
+  const extractor = tar.extract();
+  let found = false;
+  extractor.on('entry', (header, source, next) => {
+    if (header.name !== rawName) {
+      source.resume();
+      source.once('end', next);
+      return;
+    }
+    found = true;
+    source.once('error', next);
+    source.once('end', next);
+    source.pipe(output, { end: false });
+  });
+  void pipeline(await tarInput(archivePath, format), extractor).then(() => {
+    if (!found) output.destroy(archiveError('archive_binary_missing', rawName));
+    else output.end();
+  }, (error) => output.destroy(archiveError('archive_stream_failed', error instanceof Error ? error.message : rawName)));
+  return output;
+}
+
+async function streamZipMember(archivePath: string, rawName: string): Promise<Readable> {
+  const zip = await openZip(archivePath);
+  let selected: yauzl.Entry | undefined;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      zip.once('error', reject);
+      zip.on('entry', (candidate: yauzl.Entry) => {
+        if (candidate.fileName === rawName) selected = candidate;
+        zip.readEntry();
+      });
+      zip.once('end', resolve);
+      zip.readEntry();
+    });
+    if (!selected) throw archiveError('archive_binary_missing', rawName);
+    return await new Promise<Readable>((resolve, reject) => {
+      zip.openReadStream(selected!, (error, source) => {
+        if (error || !source) reject(archiveError('archive_stream_failed', error?.message || rawName));
+        else {
+          source.once('end', () => zip.close());
+          source.once('error', () => zip.close());
+          resolve(source);
+        }
+      });
+    });
+  } catch (error) {
+    zip.close();
+    throw error;
+  }
+}
+
+export async function streamSelectedNativeArchiveMember(archivePath: string, memberPath: string): Promise<Readable> {
+  const entries = await inspectNativeArchive(archivePath);
+  const member = normalizeNativeArchivePath(memberPath, 'file');
+  const selected = entries.find((candidate) => candidate.type === 'file' && candidate.normalizedName === member);
+  if (!selected) throw archiveError('archive_binary_missing', member);
+  if (selected.size <= 0) throw archiveError('archive_binary_empty', member);
+  const format = archiveFormat(archivePath);
+  return format === 'zip' ? streamZipMember(archivePath, selected.rawName) : streamTarMember(archivePath, format, selected.rawName);
+}
+
+export async function writeSelectedNativeArchiveMember(archivePath: string, memberPath: string, destinationPath: string): Promise<number> {
+  const entries = await inspectNativeArchive(archivePath);
+  const member = normalizeNativeArchivePath(memberPath, 'file');
+  const selected = entries.find((candidate) => candidate.type === 'file' && candidate.normalizedName === member);
+  if (!selected) throw archiveError('archive_binary_missing', member);
+  if (selected.size <= 0) throw archiveError('archive_binary_empty', member);
+  const source = await streamSelectedNativeArchiveMember(archivePath, member);
+  let size = 0;
+  source.on('data', (chunk: Buffer) => { size += chunk.length; });
+  await mkdir(dirname(destinationPath), { recursive: true });
+  try {
+    await pipeline(source, createWriteStream(destinationPath, { flags: 'wx' }));
+    if (size !== selected.size) throw archiveError('archive_binary_size_mismatch', member);
+    return size;
+  } catch (error) {
+    await rm(destinationPath, { force: true });
+    throw error;
+  }
+}

--- a/src/native-assets/policy.ts
+++ b/src/native-assets/policy.ts
@@ -1,0 +1,180 @@
+export type NativeArchiveEntryType = 'file' | 'directory';
+
+export interface NativeReleaseAssetPolicyInput {
+  product: string;
+  version: string;
+  platform: string;
+  arch: string;
+  target: string;
+  libc?: string;
+  archive: string;
+  binary: string;
+  binary_path: string;
+  sha256: string;
+  size?: number;
+  download_url: string;
+}
+
+export interface NativeReleaseManifestPolicyInput {
+  manifest_version?: number;
+  version: string;
+  tag?: string;
+  assets: NativeReleaseAssetPolicyInput[];
+}
+
+export interface NativeTargetMapping {
+  platform: string;
+  arch: string;
+  libc?: string;
+}
+
+export const NATIVE_PRODUCTS = ['omx-explore-harness', 'omx-sparkshell', 'omx-api'] as const;
+
+const NATIVE_PRODUCT_SET = new Set<string>(NATIVE_PRODUCTS);
+const NATIVE_ARCHIVE_SUFFIXES = ['.tar.xz', '.tar.gz', '.zip'] as const;
+
+function nativeArchiveSuffix(basename: string): string | undefined {
+  return NATIVE_ARCHIVE_SUFFIXES.find((suffix) => basename.toLowerCase().endsWith(suffix));
+}
+
+function archiveHintMismatch(asset: NativeReleaseAssetPolicyInput, basename: string): boolean {
+  const stem = basename.slice(0, -nativeArchiveSuffix(basename)!.length);
+  const hintedTarget = Object.keys(TARGET_MAPPINGS).find((target) => stem.includes(target));
+  if (hintedTarget && hintedTarget !== asset.target) return true;
+
+  const hasHint = (hint: string) => new RegExp(`(?:^|-)${hint}(?:-|$)`).test(stem);
+  if ((hasHint('linux') && asset.platform !== 'linux')
+    || (hasHint('darwin') && asset.platform !== 'darwin')
+    || ((hasHint('windows') || hasHint('win32') || hasHint('msvc')) && asset.platform !== 'win32')
+    || ((hasHint('x86_64') || hasHint('x64')) && asset.arch !== 'x64')
+    || ((hasHint('aarch64') || hasHint('arm64')) && asset.arch !== 'arm64')
+    || (hasHint('musl') && asset.libc !== 'musl')
+    || ((hasHint('gnu') || hasHint('glibc')) && asset.libc !== 'glibc')) return true;
+  return false;
+}
+
+export function nativeProductBinaryName(product: string, platform: string): string | undefined {
+  if (!NATIVE_PRODUCT_SET.has(product)) return undefined;
+  return `${product}${platform === 'win32' ? '.exe' : ''}`;
+}
+
+const TARGET_MAPPINGS: Readonly<Record<string, NativeTargetMapping>> = {
+  'x86_64-unknown-linux-gnu': { platform: 'linux', arch: 'x64', libc: 'glibc' },
+  'aarch64-unknown-linux-gnu': { platform: 'linux', arch: 'arm64', libc: 'glibc' },
+  'x86_64-unknown-linux-musl': { platform: 'linux', arch: 'x64', libc: 'musl' },
+  'aarch64-unknown-linux-musl': { platform: 'linux', arch: 'arm64', libc: 'musl' },
+  'x86_64-apple-darwin': { platform: 'darwin', arch: 'x64' },
+  'aarch64-apple-darwin': { platform: 'darwin', arch: 'arm64' },
+  'x86_64-pc-windows-msvc': { platform: 'win32', arch: 'x64' },
+  'aarch64-pc-windows-msvc': { platform: 'win32', arch: 'arm64' },
+};
+
+function policyError(code: string, detail: string): Error {
+  return new Error(`[native-assets] ${code}: ${detail}`);
+}
+
+function requiredString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value === value.trim();
+}
+
+export function normalizeNativeArchivePath(path: string, type: NativeArchiveEntryType): string {
+  if (typeof path !== 'string' || path.length === 0) throw policyError('archive_path_invalid', 'path is empty');
+  if (/[\u0000-\u001f\u007f\u0080-\u009f\\]/.test(path)) throw policyError('archive_path_invalid', path);
+  if (path.startsWith('/') || /^[A-Za-z]:/.test(path)) throw policyError('archive_path_absolute', path);
+
+  const terminalSlash = path.endsWith('/');
+  if (type === 'file' && terminalSlash) throw policyError('archive_path_type_mismatch', path);
+  const body = terminalSlash ? path.slice(0, -1) : path;
+  if (!body || body.endsWith('/') || body.includes('//')) throw policyError('archive_path_invalid', path);
+  const segments = body.split('/');
+  if (segments.some((segment) => segment === '.' || segment === '..')) throw policyError('archive_path_traversal', path);
+  return body;
+}
+
+export function assertSafeNativeArchiveEntries(entries: Iterable<{ path: string; type: NativeArchiveEntryType }>): void {
+  const paths = new Map<string, NativeArchiveEntryType>();
+  for (const entry of entries) {
+    const normalized = normalizeNativeArchivePath(entry.path, entry.type);
+    if (paths.has(normalized)) throw policyError('archive_path_duplicate', normalized);
+    for (const existing of paths) {
+      const [existingPath, existingType] = existing;
+      if ((existingType === 'file' && normalized.startsWith(`${existingPath}/`))
+        || (entry.type === 'file' && existingPath.startsWith(`${normalized}/`))) {
+        throw policyError('archive_path_prefix_collision', normalized);
+      }
+    }
+    paths.set(normalized, entry.type);
+  }
+}
+
+export function nativeTargetMapping(target: string): NativeTargetMapping | undefined {
+  return TARGET_MAPPINGS[target];
+}
+
+export function nativeReleaseAssetLogicalKey(asset: Pick<NativeReleaseAssetPolicyInput, 'product' | 'version' | 'platform' | 'arch' | 'libc'>): string {
+  return [asset.product, asset.version, asset.platform, asset.arch, asset.libc ?? ''].join('\u0000');
+}
+
+export function nativeReleaseAssetBasename(asset: Pick<NativeReleaseAssetPolicyInput, 'archive'>): string {
+  return normalizeNativeArchivePath(asset.archive, 'file').split('/').at(-1)!;
+}
+
+export function validateNativeReleaseManifest(manifest: NativeReleaseManifestPolicyInput): void {
+  if (!manifest || typeof manifest !== 'object' || manifest.manifest_version !== 1 || !requiredString(manifest.version)
+    || manifest.version.startsWith('v') || manifest.tag !== `v${manifest.version}` || !Array.isArray(manifest.assets) || manifest.assets.length === 0) {
+    throw policyError('manifest_invalid', 'manifest_version, non-v version, exact tag, and assets are required');
+  }
+
+  const logicalKeys = new Set<string>();
+  const basenames = new Set<string>();
+  for (const asset of manifest.assets) {
+    if (!asset || typeof asset !== 'object' || !requiredString(asset.version) || asset.version !== manifest.version) {
+      throw policyError('manifest_version_mismatch', asset?.archive || 'unknown');
+    }
+    const requiredStrings: Array<keyof NativeReleaseAssetPolicyInput> = [
+      'product', 'platform', 'arch', 'target', 'archive', 'binary', 'binary_path', 'sha256', 'download_url',
+    ];
+    if (requiredStrings.some((field) => !requiredString(asset[field]))) {
+      throw policyError('manifest_invalid_asset', asset.archive || 'unknown');
+    }
+    const assetSize = asset.size;
+    if (!/^[a-f0-9]{64}$/.test(asset.sha256) || assetSize === undefined || !Number.isSafeInteger(assetSize) || assetSize <= 0) {
+      throw policyError('manifest_invalid_integrity', asset.archive);
+    }
+    const mapping = nativeTargetMapping(asset.target);
+    if (!mapping || mapping.platform !== asset.platform || mapping.arch !== asset.arch
+      || (mapping.platform === 'linux' ? asset.libc !== mapping.libc : asset.libc !== undefined)) {
+      throw policyError('manifest_target_mismatch', asset.target || asset.archive);
+    }
+    const expectedBinary = nativeProductBinaryName(asset.product, asset.platform);
+    if (!expectedBinary || asset.binary !== expectedBinary) {
+      throw policyError('manifest_binary_product_mismatch', asset.binary);
+    }
+
+    const binaryPath = normalizeNativeArchivePath(asset.binary_path, 'file');
+    if (binaryPath !== asset.binary_path || binaryPath.split('/').at(-1) !== expectedBinary) {
+      throw policyError('manifest_binary_basename_mismatch', asset.binary_path);
+    }
+
+    const key = nativeReleaseAssetLogicalKey(asset);
+    if (logicalKeys.has(key)) throw policyError('manifest_duplicate_logical_key', asset.archive);
+    logicalKeys.add(key);
+    const basename = nativeReleaseAssetBasename(asset);
+    if (asset.archive !== basename || !nativeArchiveSuffix(basename)) {
+      throw policyError('manifest_archive_invalid', asset.archive);
+    }
+    if (archiveHintMismatch(asset, basename)) throw policyError('manifest_archive_hint_mismatch', basename);
+    if (basenames.has(basename)) throw policyError('manifest_duplicate_archive_basename', basename);
+    basenames.add(basename);
+    let downloadUrl: URL;
+    try {
+      downloadUrl = new URL(asset.download_url);
+    } catch {
+      throw policyError('manifest_invalid_url', asset.download_url);
+    }
+    if ((downloadUrl.protocol !== 'https:' && downloadUrl.protocol !== 'http:')
+      || downloadUrl.pathname.split('/').at(-1) !== basename) {
+      throw policyError('manifest_url_basename_mismatch', asset.download_url);
+    }
+  }
+}

--- a/src/native-assets/policy.ts
+++ b/src/native-assets/policy.ts
@@ -28,9 +28,13 @@ export interface NativeTargetMapping {
   libc?: string;
 }
 
-export const NATIVE_PRODUCTS = ['omx-explore-harness', 'omx-sparkshell', 'omx-api'] as const;
+/** Products that must be accepted by release-manifest generation and verification. */
+export const NATIVE_RELEASE_PRODUCTS = ['omx-explore-harness', 'omx-sparkshell', 'omx-api', 'omx-runtime'] as const;
 
-const NATIVE_PRODUCT_SET = new Set<string>(NATIVE_PRODUCTS);
+/** Products exposed through the runtime hydration APIs. */
+export const NATIVE_HYDRATABLE_PRODUCTS = ['omx-explore-harness', 'omx-sparkshell', 'omx-api'] as const;
+
+const NATIVE_RELEASE_PRODUCT_SET = new Set<string>(NATIVE_RELEASE_PRODUCTS);
 const NATIVE_ARCHIVE_SUFFIXES = ['.tar.xz', '.tar.gz', '.zip'] as const;
 
 function nativeArchiveSuffix(basename: string): string | undefined {
@@ -53,9 +57,14 @@ function archiveHintMismatch(asset: NativeReleaseAssetPolicyInput, basename: str
   return false;
 }
 
-export function nativeProductBinaryName(product: string, platform: string): string | undefined {
-  if (!NATIVE_PRODUCT_SET.has(product)) return undefined;
-  return `${product}${platform === 'win32' ? '.exe' : ''}`;
+export function nativeProductBinaryName(product: string): string | undefined {
+  if (!NATIVE_RELEASE_PRODUCT_SET.has(product)) return undefined;
+  return product;
+}
+
+export function nativeProductBinaryPath(product: string, platform: string): string | undefined {
+  const binary = nativeProductBinaryName(product);
+  return binary && `${binary}${platform === 'win32' ? '.exe' : ''}`;
 }
 
 const TARGET_MAPPINGS: Readonly<Record<string, NativeTargetMapping>> = {
@@ -146,13 +155,14 @@ export function validateNativeReleaseManifest(manifest: NativeReleaseManifestPol
       || (mapping.platform === 'linux' ? asset.libc !== mapping.libc : asset.libc !== undefined)) {
       throw policyError('manifest_target_mismatch', asset.target || asset.archive);
     }
-    const expectedBinary = nativeProductBinaryName(asset.product, asset.platform);
-    if (!expectedBinary || asset.binary !== expectedBinary) {
+    const expectedBinary = nativeProductBinaryName(asset.product);
+    const expectedBinaryPath = nativeProductBinaryPath(asset.product, asset.platform);
+    if (!expectedBinary || !expectedBinaryPath || asset.binary !== expectedBinary) {
       throw policyError('manifest_binary_product_mismatch', asset.binary);
     }
 
     const binaryPath = normalizeNativeArchivePath(asset.binary_path, 'file');
-    if (binaryPath !== asset.binary_path || binaryPath.split('/').at(-1) !== expectedBinary) {
+    if (binaryPath !== asset.binary_path || binaryPath.split('/').at(-1) !== expectedBinaryPath) {
       throw policyError('manifest_binary_basename_mismatch', asset.binary_path);
     }
 

--- a/src/scripts/__tests__/verify-native-release-assets.test.ts
+++ b/src/scripts/__tests__/verify-native-release-assets.test.ts
@@ -1,0 +1,201 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import { gzipSync } from 'node:zlib';
+import { describe, it } from 'node:test';
+import { compress as xzCompress } from '@napi-rs/lzma/xz';
+import * as tar from 'tar-stream';
+import * as yazl from 'yazl';
+import { fileURLToPath } from 'node:url';
+
+function sha256(value: Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function verify(manifest: string, artifacts: string) {
+  return spawnSync(process.execPath, [fileURLToPath(new URL('../verify-native-release-assets.js', import.meta.url)), '--manifest', manifest, '--artifacts-dir', artifacts], { encoding: 'utf-8' });
+}
+
+async function collect(stream: NodeJS.ReadableStream): Promise<Buffer> {
+  const output: Buffer[] = [];
+  for await (const chunk of stream) output.push(Buffer.from(chunk));
+  return Buffer.concat(output);
+}
+
+async function tarArchive(entries: Array<{ name: string; data?: Buffer; type?: tar.Headers['type']; linkname?: string }>, format: 'tar.gz' | 'tar.xz'): Promise<Buffer> {
+  const archive = tar.pack();
+  for (const item of entries) {
+    const header: tar.Headers = { name: item.name, type: item.type ?? 'file', size: item.data?.length ?? 0, linkname: item.linkname };
+    if ((item.type ?? 'file') === 'file') archive.entry(header, item.data ?? Buffer.alloc(0));
+    else archive.entry(header);
+  }
+  archive.finalize();
+  const raw = await collect(archive);
+  return format === 'tar.gz' ? gzipSync(raw) : xzCompress(raw);
+}
+
+async function zipArchive(entries: Array<{ name: string; data?: Buffer }>): Promise<Buffer> {
+  const archive = new yazl.ZipFile();
+  for (const item of entries) {
+    if (item.name.endsWith('/')) archive.addEmptyDirectory(item.name);
+    else archive.addBuffer(item.data ?? Buffer.alloc(0), item.name);
+  }
+  archive.end();
+  return collect(archive.outputStream);
+}
+
+function crc32(value: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of value) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) crc = (crc >>> 1) ^ (-(crc & 1) & 0xedb88320);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function rawZip(name: string, mode: number, dosAttributes = 0, data = Buffer.alloc(0)): Buffer {
+  const fileName = Buffer.from(name);
+  const crc = crc32(data);
+  const local = Buffer.alloc(30);
+  local.writeUInt32LE(0x04034b50, 0);
+  local.writeUInt16LE(20, 4);
+  local.writeUInt32LE(crc, 14);
+  local.writeUInt32LE(data.length, 18);
+  local.writeUInt32LE(data.length, 22);
+  local.writeUInt16LE(fileName.length, 26);
+
+  const central = Buffer.alloc(46);
+  central.writeUInt32LE(0x02014b50, 0);
+  central.writeUInt16LE((3 << 8) | 20, 4);
+  central.writeUInt16LE(20, 6);
+  central.writeUInt32LE(crc, 16);
+  central.writeUInt32LE(data.length, 20);
+  central.writeUInt32LE(data.length, 24);
+  central.writeUInt16LE(fileName.length, 28);
+  central.writeUInt32LE((((mode & 0xffff) << 16) | dosAttributes) >>> 0, 38);
+
+  const directoryOffset = local.length + fileName.length + data.length;
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(1, 8);
+  end.writeUInt16LE(1, 10);
+  end.writeUInt32LE(central.length + fileName.length, 12);
+  end.writeUInt32LE(directoryOffset, 16);
+  return Buffer.concat([local, fileName, data, central, fileName, end]);
+}
+
+function manifestFor(archive: string, content: Buffer, overrides: Record<string, unknown> = {}) {
+  return {
+    manifest_version: 1,
+    version: '0.8.15',
+    tag: 'v0.8.15',
+    assets: [{
+      product: 'omx-api', version: '0.8.15', platform: 'linux', arch: 'x64', target: 'x86_64-unknown-linux-musl', libc: 'musl',
+      archive, binary: 'omx-api', binary_path: 'omx-api', sha256: sha256(content), size: content.length,
+      download_url: `https://example.invalid/${archive}`,
+      ...overrides,
+    }],
+  };
+}
+
+async function verifyArchive(root: string, archive: string, content: Buffer, overrides: Record<string, unknown> = {}, manifestOverrides: Record<string, unknown> = {}) {
+  await writeFile(join(root, archive), content);
+  const manifest = join(root, `${archive}.manifest.json`);
+  await writeFile(manifest, JSON.stringify({ ...manifestFor(archive, content, overrides), ...manifestOverrides }));
+  return verify(manifest, root);
+}
+
+describe('verify-native-release-assets', () => {
+  it('accepts tar.gz, tar.xz, and zip archives with one wrapped regular binary', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-verify-native-release-'));
+    try {
+      for (const format of ['tar.gz', 'tar.xz', 'zip'] as const) {
+        const artifacts = join(wd, format.replace('.', '-'));
+        await mkdir(artifacts, { recursive: true });
+        const archive = `omx-api-x86_64-unknown-linux-musl.${format}`;
+        const content = format === 'zip'
+          ? await zipArchive([{ name: 'wrapper/', data: Buffer.alloc(0) }, { name: 'wrapper/omx-api', data: Buffer.from('x') }])
+          : await tarArchive([{ name: 'wrapper/', type: 'directory' }, { name: 'wrapper/omx-api', data: Buffer.from('x') }], format);
+        assert.equal((await verifyArchive(artifacts, archive, content)).status, 0, format);
+      }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects unsafe unrelated paths and links before selecting a binary', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-verify-native-release-unsafe-'));
+    try {
+      for (const [index, unsafe] of ['../escape', '/absolute', 'C:/drive', 'dir\\backslash'].entries()) {
+        const archive = `unsafe-${index}.tar.gz`;
+        const content = await tarArchive([{ name: 'omx-api', data: Buffer.from('x') }, { name: unsafe, data: Buffer.from('x') }], 'tar.gz');
+        assert.notEqual((await verifyArchive(wd, archive, content)).status, 0, unsafe);
+      }
+      const linked = await tarArchive([{ name: 'omx-api', data: Buffer.from('x') }, { name: 'link', type: 'symlink', linkname: 'omx-api' }], 'tar.gz');
+      assert.notEqual((await verifyArchive(wd, 'linked.tar.gz', linked)).status, 0);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects ZIP entries with contradictory Unix types and directory markers', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-verify-native-release-zip-types-'));
+    try {
+      const malformed = [
+        rawZip('regular/', 0o100644),
+        rawZip('regular', 0o100644, 0x10),
+        rawZip('directory', 0o040755),
+      ];
+      for (const [index, content] of malformed.entries()) {
+        assert.notEqual((await verifyArchive(wd, `zip-types-${index}.zip`, content)).status, 0);
+      }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects ambiguous, colliding, and zero-byte selected members', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-verify-native-release-selection-'));
+    try {
+      const cases = [
+        await tarArchive([{ name: 'one/omx-api', data: Buffer.from('x') }, { name: 'two/omx-api', data: Buffer.from('x') }], 'tar.gz'),
+        await tarArchive([{ name: 'omx-api', data: Buffer.from('x') }, { name: 'omx-api/config', data: Buffer.from('x') }], 'tar.gz'),
+        await tarArchive([{ name: 'omx-api', data: Buffer.alloc(0) }], 'tar.gz'),
+      ];
+      for (const [index, content] of cases.entries()) {
+        assert.notEqual((await verifyArchive(wd, `selection-${index}.tar.gz`, content)).status, 0);
+      }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('enforces manifest version, target, libc, and basename coherence', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-verify-native-release-manifest-'));
+    try {
+      const content = await tarArchive([{ name: 'omx-api', data: Buffer.from('x') }], 'tar.gz');
+      const invalid = [
+        [{}, { manifest_version: undefined }],
+        [{}, { version: 'v0.8.15', tag: 'vv0.8.15' }],
+        [{}, { tag: 'v0.8.16' }],
+        [{ platform: 'darwin', arch: 'x64', target: 'x86_64-apple-darwin', libc: 'musl' }, {}],
+        [{ product: 'omx-unknown' }, {}],
+        [{ binary: 'omx-api.exe' }, {}],
+        [{ binary_path: '../omx-api' }, {}],
+        [{ archive: 'nested/omx-api-x86_64-unknown-linux-musl.tar.gz' }, {}],
+        [{ archive: 'omx-api-x86_64-unknown-linux-musl.tar.bz2' }, {}],
+        [{ archive: 'omx-api-x86_64-unknown-linux-gnu.tar.gz' }, {}],
+        [{ archive: 'omx-api-aarch64-unknown-linux-musl.tar.gz' }, {}],
+      ] as const;
+      for (const [index, [assetOverrides, documentOverrides]] of invalid.entries()) {
+        assert.notEqual((await verifyArchive(wd, `manifest-${index}.tar.gz`, content, assetOverrides, documentOverrides)).status, 0);
+      }
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/scripts/__tests__/verify-native-release-assets.test.ts
+++ b/src/scripts/__tests__/verify-native-release-assets.test.ts
@@ -127,6 +127,45 @@ describe('verify-native-release-assets', () => {
     }
   });
 
+  it('accepts full-release siblings with logical Windows binary names and executable paths', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-verify-native-release-full-'));
+    try {
+      const apiArchive = 'omx-api-x86_64-pc-windows-msvc.zip';
+      const runtimeArchive = 'omx-runtime-x86_64-pc-windows-msvc.zip';
+      const apiBytes = await zipArchive([{ name: 'omx-api.exe', data: Buffer.from('api') }]);
+      const runtimeBytes = await zipArchive([{ name: 'omx-runtime.exe', data: Buffer.from('runtime') }]);
+      await writeFile(join(wd, apiArchive), apiBytes);
+      await writeFile(join(wd, runtimeArchive), runtimeBytes);
+      const asset = (product: string, archive: string, binaryPath: string, content: Buffer) => ({
+        product,
+        version: '0.20.3',
+        platform: 'win32',
+        arch: 'x64',
+        target: 'x86_64-pc-windows-msvc',
+        archive,
+        binary: product,
+        binary_path: binaryPath,
+        sha256: sha256(content),
+        size: content.length,
+        download_url: `https://example.invalid/${archive}`,
+      });
+      const manifestPath = join(wd, 'native-release-manifest.json');
+      await writeFile(manifestPath, JSON.stringify({
+        manifest_version: 1,
+        version: '0.20.3',
+        tag: 'v0.20.3',
+        assets: [
+          asset('omx-api', apiArchive, 'omx-api.exe', apiBytes),
+          asset('omx-runtime', runtimeArchive, 'omx-runtime.exe', runtimeBytes),
+        ],
+      }));
+      const result = verify(manifestPath, wd);
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('rejects unsafe unrelated paths and links before selecting a binary', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-verify-native-release-unsafe-'));
     try {

--- a/src/scripts/generate-native-release-manifest.ts
+++ b/src/scripts/generate-native-release-manifest.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { createHash } from 'node:crypto';
 import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
-import { basename, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { inspectNativeArchive, selectNativeArchiveBinary } from '../native-assets/archive.js';
 import {
   nativeTargetMapping,
@@ -72,7 +72,12 @@ const planPath = arg('--plan');
 const artifactsDir = arg('--artifacts-dir');
 const outPath = arg('--out');
 const releaseBaseUrl = arg('--release-base-url');
-const requireProducts = (arg('--require-products') || '').split(',').map((value) => value.trim()).filter(Boolean);
+const requestedProducts = (arg('--require-products') || '').split(',').map((value) => value.trim()).filter(Boolean);
+// A product preflight denotes a full cargo-dist release. omx-runtime is released with
+// that bundle but is intentionally not a runtime-hydratable product.
+const requireProducts = requestedProducts.length === 0
+  ? []
+  : [...new Set([...requestedProducts, 'omx-runtime'])];
 if (!planPath || !artifactsDir || !outPath || !releaseBaseUrl) usage();
 
 const plan = JSON.parse(readFileSync(resolve(planPath), 'utf-8')) as Plan;
@@ -114,7 +119,7 @@ for (const artifact of Object.values(plan.artifacts)) {
     target,
     ...(mapping.libc ? { libc: mapping.libc } : {}),
     archive: artifact.name,
-    binary: basename(binary.path),
+    binary: release.app_name,
     binary_path: binary.path,
     sha256: expectedSha256,
     size: statSync(archivePath).size,

--- a/src/scripts/generate-native-release-manifest.ts
+++ b/src/scripts/generate-native-release-manifest.ts
@@ -1,16 +1,22 @@
 #!/usr/bin/env node
-import { readFileSync, writeFileSync, statSync, readdirSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { createHash } from 'node:crypto';
+import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { basename, join, resolve } from 'node:path';
+import { inspectNativeArchive, selectNativeArchiveBinary } from '../native-assets/archive.js';
+import {
+  nativeTargetMapping,
+  validateNativeReleaseManifest,
+  type NativeReleaseAssetPolicyInput,
+} from '../native-assets/policy.js';
 
-function usage(): void {
+function usage(): never {
   console.error('Usage: node scripts/generate-native-release-manifest.mjs --plan <path> --artifacts-dir <dir> --out <path> --release-base-url <url> [--require-products a,b]');
   process.exit(1);
 }
 
 function arg(name: string): string | undefined {
   const index = process.argv.indexOf(name);
-  if (index === -1) return undefined;
-  return process.argv[index + 1];
+  return index === -1 ? undefined : process.argv[index + 1];
 }
 
 function walk(dir: string): string[] {
@@ -18,41 +24,30 @@ function walk(dir: string): string[] {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
     if (entry.isDirectory()) files.push(...walk(full));
-    else files.push(full);
+    else if (entry.isFile()) files.push(full);
   }
   return files;
 }
 
-function parseChecksum(raw: string): string {
-  return String(raw).trim().split(/\s+/)[0];
+function sha256(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
 }
 
-interface TripleMapping {
-  platform: string;
-  arch: string;
-  libc?: string;
+function checksum(raw: string, artifact: string): string {
+  const value = raw.trim().split(/\s+/)[0] || '';
+  if (!/^[a-f0-9]{64}$/i.test(value)) throw new Error(`invalid SHA-256 sidecar for ${artifact}`);
+  return value.toLowerCase();
 }
 
-function mapTriple(triple: string): TripleMapping | undefined {
-  switch (triple) {
-    case 'x86_64-unknown-linux-gnu': return { platform: 'linux', arch: 'x64', libc: 'glibc' };
-    case 'aarch64-unknown-linux-gnu': return { platform: 'linux', arch: 'arm64', libc: 'glibc' };
-    case 'x86_64-unknown-linux-musl': return { platform: 'linux', arch: 'x64', libc: 'musl' };
-    case 'aarch64-unknown-linux-musl': return { platform: 'linux', arch: 'arm64', libc: 'musl' };
-    case 'x86_64-apple-darwin': return { platform: 'darwin', arch: 'x64' };
-    case 'aarch64-apple-darwin': return { platform: 'darwin', arch: 'arm64' };
-    case 'x86_64-pc-windows-msvc': return { platform: 'win32', arch: 'x64' };
-    case 'aarch64-pc-windows-msvc': return { platform: 'win32', arch: 'arm64' };
-    default: return undefined;
+function basenameIndex(files: string[]): Map<string, string> {
+  const result = new Map<string, string>();
+  for (const file of files) {
+    const name = file.split(/[\\/]/).at(-1)!;
+    if (result.has(name)) throw new Error(`duplicate artifact basename: ${name}`);
+    result.set(name, file);
   }
+  return result;
 }
-
-const planPath = arg('--plan');
-const artifactsDir = arg('--artifacts-dir');
-const outPath = arg('--out');
-const releaseBaseUrl = arg('--release-base-url');
-const requireProducts = (arg('--require-products') || '').split(',').map((value) => value.trim()).filter(Boolean);
-if (!planPath || !artifactsDir || !outPath || !releaseBaseUrl) usage();
 
 interface PlanArtifact {
   kind: string;
@@ -73,75 +68,79 @@ interface Plan {
   announcement_tag: string;
 }
 
-interface ManifestAsset {
-  product: string;
-  version: string;
-  platform: string;
-  arch: string;
-  target: string;
-  libc?: string;
-  archive: string;
-  binary: string;
-  binary_path: string;
-  sha256: string;
-  size: number;
-  download_url: string;
+const planPath = arg('--plan');
+const artifactsDir = arg('--artifacts-dir');
+const outPath = arg('--out');
+const releaseBaseUrl = arg('--release-base-url');
+const requireProducts = (arg('--require-products') || '').split(',').map((value) => value.trim()).filter(Boolean);
+if (!planPath || !artifactsDir || !outPath || !releaseBaseUrl) usage();
+
+const plan = JSON.parse(readFileSync(resolve(planPath), 'utf-8')) as Plan;
+if (!/^v[^\s/]+$/.test(plan.announcement_tag)) throw new Error('announcement tag must be a v-prefixed release version');
+const version = plan.announcement_tag.slice(1);
+if (!Array.isArray(plan.releases) || plan.releases.length === 0 || plan.releases.some((release) => release.app_version !== version)) {
+  throw new Error(`release versions must exactly match announcement tag ${plan.announcement_tag}`);
 }
 
-const plan = JSON.parse(readFileSync(resolve(planPath!), 'utf-8')) as Plan;
-const files = walk(resolve(artifactsDir!));
-const byName = new Map(files.map((file) => [file.split('/').pop()!, file]));
-const assets: ManifestAsset[] = [];
-
+const byName = basenameIndex(walk(resolve(artifactsDir)));
+const assets: NativeReleaseAssetPolicyInput[] = [];
 for (const artifact of Object.values(plan.artifacts)) {
   if (artifact.kind !== 'executable-zip') continue;
-  const triple = artifact.target_triples?.[0];
-  const mapped = triple ? mapTriple(triple) : undefined;
-  if (!mapped) continue;
-  const executable = (artifact.assets || []).find((asset) => asset.kind === 'executable');
-  if (!executable) continue;
+  if (!Array.isArray(artifact.target_triples) || artifact.target_triples.length !== 1) {
+    throw new Error(`expected exactly one target triple for ${artifact.name}`);
+  }
+  const target = artifact.target_triples[0]!;
+  const mapping = nativeTargetMapping(target);
+  if (!mapping) throw new Error(`unsupported native target ${target}`);
+  if (!/\.(?:tar\.xz|tar\.gz|zip)$/i.test(artifact.name)) throw new Error(`unsupported native archive format: ${artifact.name}`);
+  const executable = artifact.assets?.filter((asset) => asset.kind === 'executable') ?? [];
+  if (executable.length !== 1) throw new Error(`expected exactly one executable for ${artifact.name}`);
+  const binary = executable[0]!;
   const archivePath = byName.get(artifact.name);
   const checksumPath = byName.get(artifact.checksum);
-  if (!archivePath || !checksumPath) {
-    throw new Error(`missing artifact files for ${artifact.name}`);
-  }
-
-  const release = plan.releases.find((item) => item.app_name === executable.name || item.app_name === executable.id?.split('-exe-')[0]);
-  const version = release?.app_version || plan.announcement_tag.replace(/^v/, '');
+  if (!archivePath || !checksumPath) throw new Error(`missing artifact files for ${artifact.name}`);
+  if (statSync(archivePath).size <= 0 || statSync(checksumPath).size <= 0) throw new Error(`empty artifact file for ${artifact.name}`);
+  const expectedSha256 = checksum(readFileSync(checksumPath, 'utf-8'), artifact.name);
+  if (sha256(archivePath) !== expectedSha256) throw new Error(`checksum mismatch for ${artifact.name}`);
+  const archiveEntries = await inspectNativeArchive(archivePath);
+  selectNativeArchiveBinary(archiveEntries, binary.path);
+  const release = plan.releases.find((item) => item.app_name === binary.name || item.app_name === binary.id?.split('-exe-')[0]);
+  if (!release || release.app_version !== version) throw new Error(`missing coherent release metadata for ${artifact.name}`);
   assets.push({
-    product: executable.name,
+    product: release.app_name,
     version,
-    platform: mapped.platform,
-    arch: mapped.arch,
-    target: triple!,
-    ...(mapped.libc ? { libc: mapped.libc } : {}),
+    platform: mapping.platform,
+    arch: mapping.arch,
+    target,
+    ...(mapping.libc ? { libc: mapping.libc } : {}),
     archive: artifact.name,
-    binary: executable.name,
-    binary_path: executable.path,
-    sha256: parseChecksum(readFileSync(checksumPath, 'utf-8')),
+    binary: basename(binary.path),
+    binary_path: binary.path,
+    sha256: expectedSha256,
     size: statSync(archivePath).size,
-    download_url: `${releaseBaseUrl!.replace(/\/$/, '')}/${artifact.name}`,
+    download_url: `${releaseBaseUrl.replace(/\/$/, '')}/${artifact.name}`,
   });
 }
 
 const manifest = {
   manifest_version: 1,
-  version: plan.announcement_tag.replace(/^v/, ''),
+  version,
   tag: plan.announcement_tag,
   generated_at: new Date().toISOString(),
   assets: assets.sort((a, b) => {
-    const keyCompare = `${a.product}-${a.platform}-${a.arch}`.localeCompare(`${b.product}-${b.platform}-${b.arch}`);
-    if (keyCompare !== 0) return keyCompare;
-    const libcOrder: Record<string, number> = { musl: 0, glibc: 1 };
-    const libcCompare = (libcOrder[a.libc ?? ''] ?? 2) - (libcOrder[b.libc ?? ''] ?? 2);
-    if (libcCompare !== 0) return libcCompare;
-    return a.archive.localeCompare(b.archive);
+    const libcRank = (asset: NativeReleaseAssetPolicyInput): number => asset.libc === 'musl' ? 0 : asset.libc === 'glibc' ? 1 : 2;
+    return a.product.localeCompare(b.product)
+      || a.platform.localeCompare(b.platform)
+      || a.arch.localeCompare(b.arch)
+      || libcRank(a) - libcRank(b)
+      || a.archive.localeCompare(b.archive);
   }),
 };
+if (manifest.assets.length === 0) throw new Error('release manifest must declare at least one native archive');
+validateNativeReleaseManifest(manifest);
+if (manifest.tag !== `v${manifest.version}`) throw new Error('manifest tag/version mismatch');
 for (const product of requireProducts) {
-  if (!manifest.assets.some((asset) => asset.product === product)) {
-    throw new Error(`missing required product in release manifest: ${product}`);
-  }
+  if (!manifest.assets.some((asset) => asset.product === product)) throw new Error(`missing required product in release manifest: ${product}`);
 }
-writeFileSync(resolve(outPath!), `${JSON.stringify(manifest, null, 2)}\n`);
-console.log(resolve(outPath!));
+writeFileSync(resolve(outPath), `${JSON.stringify(manifest, null, 2)}\n`);
+console.log(resolve(outPath));

--- a/src/scripts/verify-native-release-assets.ts
+++ b/src/scripts/verify-native-release-assets.ts
@@ -1,68 +1,76 @@
 #!/usr/bin/env node
-import { readFileSync, statSync, readdirSync } from 'node:fs';
-import { join, resolve } from 'node:path';
 import { createHash } from 'node:crypto';
-import { spawnSync } from 'node:child_process';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { inspectNativeArchive, selectNativeArchiveBinary } from '../native-assets/archive.js';
+import {
+  validateNativeReleaseManifest,
+  type NativeReleaseManifestPolicyInput,
+} from '../native-assets/policy.js';
 
-function usage(): void {
+function usage(): never {
   console.error('Usage: node scripts/verify-native-release-assets.mjs --manifest <path> --artifacts-dir <dir>');
   process.exit(1);
 }
+
 function arg(name: string): string | undefined {
   const index = process.argv.indexOf(name);
-  if (index === -1) return undefined;
-  return process.argv[index + 1];
+  return index === -1 ? undefined : process.argv[index + 1];
 }
+
 function walk(dir: string): string[] {
   const files: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
     if (entry.isDirectory()) files.push(...walk(full));
-    else files.push(full);
+    else if (entry.isFile()) files.push(full);
   }
   return files;
 }
+
 function sha256(path: string): string {
   return createHash('sha256').update(readFileSync(path)).digest('hex');
 }
 
-function archiveContainsBinary(members: string[], binaryPath: string): boolean {
-  return members.includes(binaryPath)
-    || members.some((member) => member.endsWith(`/${binaryPath}`))
-    || members.some((member) => member.replace(/\\/g, '/').endsWith(`/${binaryPath.replace(/\\/g, '/')}`));
+function basenameIndex(files: string[]): Map<string, string> {
+  const result = new Map<string, string>();
+  for (const file of files) {
+    const name = file.split(/[\\/]/).at(-1)!;
+    if (result.has(name)) throw new Error(`duplicate artifact basename: ${name}`);
+    result.set(name, file);
+  }
+  return result;
 }
 
 const manifestPath = arg('--manifest');
 const artifactsDir = arg('--artifacts-dir');
 if (!manifestPath || !artifactsDir) usage();
 
-interface ManifestAsset {
-  archive: string;
-  size?: number;
-  sha256: string;
-  binary_path: string;
-}
-
-const manifest = JSON.parse(readFileSync(resolve(manifestPath!), 'utf-8')) as { assets: ManifestAsset[] };
-const byName = new Map(walk(resolve(artifactsDir!)).map((file) => [file.split('/').pop()!, file]));
-
+const manifest = JSON.parse(readFileSync(resolve(manifestPath), 'utf-8')) as NativeReleaseManifestPolicyInput;
+if (manifest.tag !== `v${manifest.version}`) throw new Error('manifest tag/version mismatch');
+validateNativeReleaseManifest(manifest);
+if (manifest.assets.length === 0) throw new Error('release manifest must declare at least one native archive');
+const byName = basenameIndex(walk(resolve(artifactsDir)));
+const manifestArchives = new Set<string>();
 for (const asset of manifest.assets) {
+  if (!/\.(?:tar\.xz|tar\.gz|zip)$/i.test(asset.archive)) throw new Error(`unsupported native archive format: ${asset.archive}`);
+  if (manifestArchives.has(asset.archive)) throw new Error(`duplicate manifest archive: ${asset.archive}`);
+  manifestArchives.add(asset.archive);
   const archivePath = byName.get(asset.archive);
   if (!archivePath) throw new Error(`missing archive ${asset.archive}`);
-  if (typeof asset.size === 'number' && statSync(archivePath).size !== asset.size) {
+  const expectedSize = asset.size;
+  if (!Number.isSafeInteger(expectedSize) || expectedSize === undefined || expectedSize <= 0 || statSync(archivePath).size !== expectedSize) {
     throw new Error(`size mismatch for ${asset.archive}`);
   }
-  if (sha256(archivePath) !== asset.sha256) {
+  if (!/^[a-f0-9]{64}$/i.test(asset.sha256) || sha256(archivePath) !== asset.sha256.toLowerCase()) {
     throw new Error(`checksum mismatch for ${asset.archive}`);
   }
-  const list = asset.archive.endsWith('.zip')
-    ? spawnSync('python3', ['-c', 'import sys, zipfile; z=zipfile.ZipFile(sys.argv[1]); print("\\n".join(z.namelist()))', archivePath], { encoding: 'utf-8' })
-    : spawnSync('tar', ['-tf', archivePath], { encoding: 'utf-8' });
-  if (list.status !== 0) throw new Error(`unable to inspect archive ${asset.archive}: ${list.stderr || list.stdout}`);
-  const members = String(list.stdout || '').split(/\r?\n/).filter(Boolean);
-  if (!archiveContainsBinary(members, asset.binary_path)) {
-    throw new Error(`archive ${asset.archive} is missing ${asset.binary_path}`);
-  }
+  const entries = await inspectNativeArchive(archivePath);
+  selectNativeArchiveBinary(entries, asset.binary_path);
 }
 
+const archiveFiles = [...byName.keys()].filter((name) => /\.(?:tar\.xz|tar\.gz|zip)$/i.test(name));
+for (const archive of archiveFiles) {
+  if (!manifestArchives.has(archive)) throw new Error(`archive is not declared by manifest: ${archive}`);
+}
 console.log(`[native-release-assets] verified ${manifest.assets.length} assets`);

--- a/src/verification/__tests__/ci-rust-gates.test.ts
+++ b/src/verification/__tests__/ci-rust-gates.test.ts
@@ -8,7 +8,7 @@ import { execFileSync } from 'node:child_process';
 function readCiWorkflow(): string {
   const workflowPath = join(process.cwd(), '.github', 'workflows', 'ci.yml');
   assert.equal(existsSync(workflowPath), true, `missing workflow: ${workflowPath}`);
-  return readFileSync(workflowPath, 'utf-8');
+  return readFileSync(workflowPath, 'utf-8').replace(/\r\n/g, '\n');
 }
 
 function jobBlock(workflow: string, jobName: string): string {

--- a/src/verification/__tests__/ci-rust-gates.test.ts
+++ b/src/verification/__tests__/ci-rust-gates.test.ts
@@ -26,6 +26,13 @@ function assertJobIf(workflow: string, jobName: string, expected: RegExp): void 
   assert.match(jobBlock(workflow, jobName), expected, `${jobName} should have the expected lane predicate`);
 }
 
+type GitHubJobResult = 'success' | 'failure' | 'cancelled' | 'skipped';
+
+function satisfiesCiStatusContract(result: GitHubJobResult, active: boolean): boolean {
+  return active ? result === 'success' : result === 'success' || result === 'skipped';
+}
+
+
 function classifyChangedPaths(paths: string[]): Record<string, string> {
   const workflow = readCiWorkflow();
   const changesJob = jobBlock(workflow, 'changes');
@@ -263,10 +270,50 @@ describe('CI Rust gates', () => {
     assert.doesNotMatch(testJob, /^\s+npm run build$/m);
   });
 
+  it('defines the native-cache-integrity matrix and aggregate-status contract exactly', () => {
+    const workflow = readCiWorkflow();
+    const nativeCacheJob = jobBlock(workflow, 'native-cache-integrity');
+    const ciStatusJob = jobBlock(workflow, 'ci-status');
+
+    assert.match(nativeCacheJob, /^    runs-on:\s*\$\{\{ matrix\.os \}\}$/m);
+    assert.match(nativeCacheJob, /^    timeout-minutes:\s*30$/m);
+    assert.match(nativeCacheJob, /^    needs:\s*\[changes, build-dist\]$/m);
+    assert.match(nativeCacheJob, /^    if: \$\{\{ needs\.changes\.outputs\.full_suite == 'true' \|\| needs\.changes\.outputs\.ts_changed == 'true' \|\| needs\.changes\.outputs\.native_changed == 'true' \|\| needs\.changes\.outputs\.shared_config_changed == 'true' \}\}$/m);
+    assert.match(nativeCacheJob, /strategy:\s*\n\s+fail-fast:\s*false\s*\n\s+matrix:\s*\n\s+os:\s*\[ubuntu-latest, macos-latest, windows-latest\]/);
+    assert.match(nativeCacheJob, /uses:\s*actions\/checkout@v7/);
+    assert.match(nativeCacheJob, /uses:\s*actions\/setup-node@v7\s*\n\s+with:\s*\n\s+node-version:\s*20\s*\n\s+cache:\s*npm/);
+    assert.match(nativeCacheJob, /run:\s*npm ci/);
+    assert.match(nativeCacheJob, /name:\s*Download prebuilt dist artifact\s*\n\s+uses:\s*actions\/download-artifact@v8\s*\n\s+with:\s*\n\s+name:\s*ci-dist-node20\s*\n\s+path:\s*dist/);
+    assert.match(nativeCacheJob, /node --test\s*\\\n\s+dist\/cli\/__tests__\/native-assets\.test\.js\s*\\\n\s+dist\/cli\/__tests__\/sparkshell-cli\.test\.js\s*\\\n\s+dist\/cli\/__tests__\/api\.test\.js\s*\\\n\s+dist\/scripts\/__tests__\/verify-native-release-assets\.test\.js\s*\\\n\s+dist\/verification\/__tests__\/native-release-manifest\.test\.js\s*\\\n\s+dist\/verification\/__tests__\/explore-harness-release-workflow\.test\.js\s*\\\n\s+dist\/verification\/__tests__\/ci-rust-gates\.test\.js/);
+
+    assert.match(ciStatusJob, /^    if: always\(\)$/m);
+    assert.match(ciStatusJob, /^    needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build\]$/m);
+    assert.match(ciStatusJob, /NATIVE_CACHE_INTEGRITY_RESULT: \$\{\{ needs\.native-cache-integrity\.result \}\}/);
+    assert.match(ciStatusJob, /if \[\[ "\$FULL_SUITE" == "true" \]\] \|\| bool_any "\$TS_CHANGED" "\$NATIVE_CHANGED" "\$SHARED_CONFIG_CHANGED"; then native_cache_integrity_active=true; fi/);
+    assert.match(ciStatusJob, /check_job native-cache-integrity "\$NATIVE_CACHE_INTEGRITY_RESULT" "\$native_cache_integrity_active"/);
+  });
+
+  it('models CI-status active and inactive result semantics deterministically', () => {
+    const cases: Array<{ active: boolean; result: GitHubJobResult; accepted: boolean }> = [
+      { active: true, result: 'success', accepted: true },
+      { active: true, result: 'failure', accepted: false },
+      { active: true, result: 'cancelled', accepted: false },
+      { active: true, result: 'skipped', accepted: false },
+      { active: false, result: 'skipped', accepted: true },
+      { active: false, result: 'success', accepted: true },
+      { active: false, result: 'failure', accepted: false },
+      { active: false, result: 'cancelled', accepted: false },
+    ];
+
+    for (const { active, result, accepted } of cases) {
+      assert.equal(satisfiesCiStatusContract(result, active), accepted, `active=${active} result=${result}`);
+    }
+  });
+
   it('uses npm package caching without skipping clean dependency installs', () => {
     const workflow = readCiWorkflow();
 
-    for (const jobName of ['lint', 'typecheck', 'build-dist', 'test', 'coverage-team-critical', 'ralph-persistence-gate', 'build']) {
+    for (const jobName of ['lint', 'typecheck', 'build-dist', 'test', 'coverage-team-critical', 'ralph-persistence-gate', 'native-cache-integrity', 'build']) {
       const job = jobBlock(workflow, jobName);
 
       assert.match(job, /uses:\s*actions\/setup-node@v7/);
@@ -283,7 +330,7 @@ describe('CI Rust gates', () => {
 
     assert.match(
       workflow,
-      /needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, build\]/,
+      /needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build\]/,
     );
   });
 
@@ -311,12 +358,13 @@ describe('CI Rust gates', () => {
       'test',
       'coverage-team-critical',
       'ralph-persistence-gate',
+      'native-cache-integrity',
       'build',
     ];
 
     assert.match(
       ciStatusJob,
-      /needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, build\]/,
+      /needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build\]/,
     );
 
     for (const jobName of requiredJobs) {
@@ -333,6 +381,8 @@ describe('CI Rust gates', () => {
     assert.match(ciStatusJob, /ts_active=false/);
     assert.match(ciStatusJob, /dist_active=false/);
     assert.match(ciStatusJob, /build_active=false/);
+    assert.match(ciStatusJob, /native_cache_integrity_active=false/);
+    assert.match(ciStatusJob, /check_job native-cache-integrity "\$NATIVE_CACHE_INTEGRITY_RESULT" "\$native_cache_integrity_active"/);
     assert.match(ciStatusJob, /All required CI checks passed for active lanes/);
   });
 
@@ -368,6 +418,7 @@ describe('CI Rust gates', () => {
       'test',
       'coverage-team-critical',
       'ralph-persistence-gate',
+      'native-cache-integrity',
       'build',
       'ci-status',
     ]) {

--- a/src/verification/__tests__/explore-harness-release-workflow.test.ts
+++ b/src/verification/__tests__/explore-harness-release-workflow.test.ts
@@ -3,6 +3,35 @@ import assert from 'node:assert/strict';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+function releaseUploadRunsAfterVerifier(
+  workflow: string,
+  uploadName: string,
+  verifierResult: 'success' | 'failure',
+): boolean {
+  const verification = workflow.indexOf('Verify release archives and manifest');
+  const upload = workflow.indexOf(uploadName);
+  const nextStep = workflow.indexOf('\n      - name:', upload + uploadName.length);
+  const uploadBlock = workflow.slice(upload, nextStep === -1 ? workflow.length : nextStep);
+  return verification >= 0 && upload > verification && verifierResult === 'success' && !/^\s+if:/m.test(uploadBlock);
+}
+
+function flattenReleaseArtifacts(sourcePaths: string[]): string[] {
+  const destinations = new Set<string>();
+
+  for (const source of sourcePaths) {
+    const basename = source.slice(source.lastIndexOf('/') + 1);
+    if (destinations.has(basename)) {
+      throw new Error(`release asset basename collision: ${source} -> release-assets/${basename}`);
+    }
+    destinations.add(basename);
+  }
+
+  return [...destinations];
+}
+
+
+
+
 describe('native release workflow', () => {
   it('defines a unified tag workflow that publishes both Rust binaries before npm publish', () => {
     const workflowPath = join(process.cwd(), '.github', 'workflows', 'release.yml');
@@ -59,6 +88,56 @@ describe('native release workflow', () => {
     assert.match(workflow, /smoke-verify-native:[\s\S]*npm run build[\s\S]*node dist\/scripts\/verify-native-release-assets\.js/);
     assert.match(workflow, /smoke-packed-install:[\s\S]*npm run build[\s\S]*Smoke test packed install boot \+ core commands[\s\S]*npm run smoke:packed-install/);
     assert.match(workflow, /publish-npm:[\s\S]*Verify version sync against workspace crates[\s\S]*npm pack --dry-run/);
+
+    const manifestGeneration = workflow.indexOf('Generate release manifest from cargo-dist plan');
+    const verification = workflow.indexOf('Verify release archives and manifest');
+    const bundleUpload = workflow.indexOf('Upload release asset bundle for follow-up jobs');
+    const releaseUpload = workflow.indexOf('Attach native assets to GitHub Release');
+    assert.ok(manifestGeneration >= 0, 'release workflow must generate the manifest');
+    assert.ok(verification > manifestGeneration, 'release workflow must verify after manifest generation');
+    assert.ok(bundleUpload > verification, 'release bundle upload must occur after verification');
+    assert.ok(releaseUpload > bundleUpload, 'GitHub Release upload must occur after the verified bundle upload');
+    assert.match(workflow, /Verify release archives and manifest[\s\S]*node dist\/scripts\/verify-native-release-assets\.js/);
+
+    const bundleUploadBlock = workflow.slice(bundleUpload, workflow.indexOf('Generate release body', bundleUpload));
+    const releaseUploadBlock = workflow.slice(releaseUpload, workflow.indexOf('Write release summary', releaseUpload));
+    assert.doesNotMatch(bundleUploadBlock, /^\s+if:/m, 'bundle upload must retain the default success() condition');
+    assert.doesNotMatch(releaseUploadBlock, /^\s+if:/m, 'release attachment must retain the default success() condition');
+    for (const uploadName of ['Upload release asset bundle for follow-up jobs', 'Attach native assets to GitHub Release']) {
+      assert.equal(releaseUploadRunsAfterVerifier(workflow, uploadName, 'success'), true, `${uploadName} must run after successful verification`);
+      assert.equal(releaseUploadRunsAfterVerifier(workflow, uploadName, 'failure'), false, `${uploadName} must not run when verification fails`);
+    }
+  });
+
+  it('fails closed before manifest generation when downloaded artifacts share a basename', () => {
+    const duplicateArchiveBasenameFixture = [
+      'release-artifacts/native-x86/omx-api-v0.20.3-x86_64-unknown-linux-gnu.tar.xz',
+      'release-artifacts/native-arm/omx-api-v0.20.3-x86_64-unknown-linux-gnu.tar.xz',
+    ];
+    const duplicateChecksumBasenameFixture = [
+      'release-artifacts/native-x86/omx-api-v0.20.3-x86_64-unknown-linux-gnu.tar.xz.sha256',
+      'release-artifacts/native-arm/omx-api-v0.20.3-x86_64-unknown-linux-gnu.tar.xz.sha256',
+    ];
+    for (const fixture of [duplicateArchiveBasenameFixture, duplicateChecksumBasenameFixture]) {
+      assert.throws(
+        () => flattenReleaseArtifacts(fixture),
+        /release asset basename collision: release-artifacts\/native-arm\/.* -> release-assets\//,
+      );
+    }
+
+    const workflowPath = join(process.cwd(), '.github', 'workflows', 'release.yml');
+    const workflow = readFileSync(workflowPath, 'utf-8');
+    const manifestGeneration = workflow.indexOf('Generate release manifest from cargo-dist plan');
+    const verification = workflow.indexOf('Verify release archives and manifest', manifestGeneration);
+    const bundleUpload = workflow.indexOf('Upload release asset bundle for follow-up jobs', manifestGeneration);
+    const collisionCheck = workflow.indexOf('release asset basename collision:', manifestGeneration);
+    const copy = workflow.indexOf('cp -- "$source" "$destination"', manifestGeneration);
+
+    assert.ok(collisionCheck > manifestGeneration, 'collision detection must be in the artifact collection step');
+    assert.ok(copy > collisionCheck, 'collision detection must run before copying an artifact basename');
+    assert.ok(verification > copy, 'verification must not run when collision detection blocks manifest generation');
+    assert.ok(bundleUpload > verification, 'upload must not run when collision detection blocks manifest generation or verification');
+    assert.match(workflow, /destination="release-assets\/\$\(basename "\$source"\)"[\s\S]*if \[\[ -e "\$destination" \|\| -L "\$destination" \]\]; then[\s\S]*exit 1[\s\S]*cp -- "\$source" "\$destination"/);
   });
 
   it('keeps cargo-dist Linux targets aligned with musl-first plus glibc fallback assets', () => {

--- a/src/verification/__tests__/native-release-manifest.test.ts
+++ b/src/verification/__tests__/native-release-manifest.test.ts
@@ -155,11 +155,67 @@ describe('native release manifest generator', () => {
       const manifest = JSON.parse(await readFile(outputPath, 'utf-8')) as { assets: Array<Record<string, unknown>> };
       const asset = manifest.assets[0]!;
       assert.equal(asset.product, 'omx-api');
-      assert.equal(asset.binary, 'omx-api.exe');
+      assert.equal(asset.binary, 'omx-api');
       assert.equal(asset.binary_path, 'omx-api.exe');
       assert.equal(asset.target, 'x86_64-pc-windows-msvc');
       assert.equal(asset.platform, 'win32');
       assert.equal(asset.arch, 'x64');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('generates and verifies a complete cargo-dist release manifest, including non-hydratable omx-runtime', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-native-release-manifest-full-'));
+    try {
+      const artifactsDir = join(root, 'artifacts');
+      await mkdir(artifactsDir, { recursive: true });
+      const artifacts = [
+        { key: 'apiWindows', product: 'omx-api', target: 'x86_64-pc-windows-msvc', archive: 'omx-api-x86_64-pc-windows-msvc.zip', binaryPath: 'omx-api.exe', format: 'zip' as const },
+        { key: 'exploreLinux', product: 'omx-explore-harness', target: 'x86_64-unknown-linux-musl', archive: 'omx-explore-harness-x86_64-unknown-linux-musl.tar.gz', binaryPath: 'omx-explore-harness', format: 'tar.gz' as const },
+        { key: 'runtimeLinux', product: 'omx-runtime', target: 'x86_64-unknown-linux-musl', archive: 'omx-runtime-x86_64-unknown-linux-musl.tar.gz', binaryPath: 'omx-runtime', format: 'tar.gz' as const },
+        { key: 'sparkshellLinux', product: 'omx-sparkshell', target: 'x86_64-unknown-linux-musl', archive: 'omx-sparkshell-x86_64-unknown-linux-musl.tar.gz', binaryPath: 'omx-sparkshell', format: 'tar.gz' as const },
+      ];
+      for (const artifact of artifacts) {
+        const bytes = artifact.format === 'zip'
+          ? await makeZip(artifact.binaryPath, artifact.product)
+          : await makeTarGz(artifact.binaryPath, artifact.product);
+        await writeFile(join(artifactsDir, artifact.archive), bytes);
+        await writeFile(join(artifactsDir, `${artifact.archive}.sha256`), `${createHash('sha256').update(bytes).digest('hex')}  ${artifact.archive}\n`);
+      }
+      const planPath = join(root, 'dist-plan.json');
+      await writeFile(planPath, JSON.stringify({
+        announcement_tag: 'v0.20.3',
+        releases: artifacts.map(({ product }) => ({ app_name: product, app_version: '0.20.3' })),
+        artifacts: Object.fromEntries(artifacts.map((artifact) => [artifact.key, {
+          kind: 'executable-zip',
+          name: artifact.archive,
+          checksum: `${artifact.archive}.sha256`,
+          target_triples: [artifact.target],
+          assets: [{ kind: 'executable', name: artifact.product, path: artifact.binaryPath }],
+        }])),
+      }));
+      const outputPath = join(root, 'native-release-manifest.json');
+      const generated = spawnSync(process.execPath, [
+        join(process.cwd(), 'dist', 'scripts', 'generate-native-release-manifest.js'),
+        '--plan', planPath,
+        '--artifacts-dir', artifactsDir,
+        '--out', outputPath,
+        '--release-base-url', 'https://github.com/example/releases/download/v0.20.3',
+        '--require-products', 'omx-api,omx-explore-harness,omx-sparkshell',
+      ], { cwd: process.cwd(), encoding: 'utf-8' });
+      assert.equal(generated.status, 0, generated.stderr || generated.stdout);
+      const manifest = JSON.parse(await readFile(outputPath, 'utf-8')) as { assets: Array<{ product: string; binary: string; binary_path: string }> };
+      assert.deepEqual(new Set(manifest.assets.map((asset) => asset.product)), new Set(artifacts.map((artifact) => artifact.product)));
+      const windowsApi = manifest.assets.find((asset) => asset.product === 'omx-api');
+      assert.equal(windowsApi?.binary, 'omx-api');
+      assert.equal(windowsApi?.binary_path, 'omx-api.exe');
+      const verified = spawnSync(process.execPath, [
+        join(process.cwd(), 'dist', 'scripts', 'verify-native-release-assets.js'),
+        '--manifest', outputPath,
+        '--artifacts-dir', artifactsDir,
+      ], { cwd: process.cwd(), encoding: 'utf-8' });
+      assert.equal(verified.status, 0, verified.stderr || verified.stdout);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/src/verification/__tests__/native-release-manifest.test.ts
+++ b/src/verification/__tests__/native-release-manifest.test.ts
@@ -1,9 +1,35 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { gzipSync } from 'node:zlib';
+import * as tar from 'tar-stream';
+import * as yazl from 'yazl';
+import { validateNativeReleaseManifest } from '../../native-assets/policy.js';
+
+
+async function collect(stream: NodeJS.ReadableStream): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks);
+}
+
+async function makeTarGz(binaryName: string, contents: string): Promise<Buffer> {
+  const archive = tar.pack();
+  archive.entry({ name: binaryName, type: 'file', size: Buffer.byteLength(contents) }, Buffer.from(contents));
+  archive.finalize();
+  return gzipSync(await collect(archive));
+}
+async function makeZip(binaryName: string, contents: string): Promise<Buffer> {
+  const archive = new yazl.ZipFile();
+  archive.addBuffer(Buffer.from(contents), binaryName);
+  archive.end();
+  return collect(archive.outputStream);
+}
+
 
 describe('native release manifest generator', () => {
   it('annotates Linux libc variants and sorts musl assets before glibc fallbacks', async () => {
@@ -14,10 +40,12 @@ describe('native release manifest generator', () => {
 
       const muslArchive = 'omx-sparkshell-x86_64-unknown-linux-musl.tar.gz';
       const glibcArchive = 'omx-sparkshell-x86_64-unknown-linux-gnu.tar.gz';
-      await writeFile(join(artifactsDir, muslArchive), 'musl');
-      await writeFile(join(artifactsDir, `${muslArchive}.sha256`), 'musl-checksum\n');
-      await writeFile(join(artifactsDir, glibcArchive), 'glibc');
-      await writeFile(join(artifactsDir, `${glibcArchive}.sha256`), 'glibc-checksum\n');
+      const muslBytes = await makeTarGz('omx-sparkshell', 'musl');
+      const glibcBytes = await makeTarGz('omx-sparkshell', 'glibc');
+      await writeFile(join(artifactsDir, muslArchive), muslBytes);
+      await writeFile(join(artifactsDir, `${muslArchive}.sha256`), `${createHash('sha256').update(muslBytes).digest('hex')}  ${muslArchive}\n`);
+      await writeFile(join(artifactsDir, glibcArchive), glibcBytes);
+      await writeFile(join(artifactsDir, `${glibcArchive}.sha256`), `${createHash('sha256').update(glibcBytes).digest('hex')}  ${glibcArchive}\n`);
 
       const planPath = join(root, 'dist-plan.json');
       await writeFile(planPath, JSON.stringify({
@@ -90,5 +118,79 @@ describe('native release manifest generator', () => {
     } finally {
       await rm(root, { recursive: true, force: true });
     }
+  });
+
+  it('uses the executable path basename for Windows cargo-dist assets', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-native-release-manifest-windows-'));
+    try {
+      const artifactsDir = join(root, 'artifacts');
+      await mkdir(artifactsDir, { recursive: true });
+      const archiveName = 'omx-api-x86_64-pc-windows-msvc.zip';
+      const archiveBytes = await makeZip('omx-api.exe', 'windows');
+      await writeFile(join(artifactsDir, archiveName), archiveBytes);
+      await writeFile(join(artifactsDir, `${archiveName}.sha256`), `${createHash('sha256').update(archiveBytes).digest('hex')}  ${archiveName}\n`);
+      const planPath = join(root, 'dist-plan.json');
+      await writeFile(planPath, JSON.stringify({
+        announcement_tag: 'v0.10.2',
+        releases: [{ app_name: 'omx-api', app_version: '0.10.2' }],
+        artifacts: {
+          windows: {
+            kind: 'executable-zip',
+            name: archiveName,
+            checksum: `${archiveName}.sha256`,
+            target_triples: ['x86_64-pc-windows-msvc'],
+            assets: [{ kind: 'executable', id: 'omx-api-exe-x86_64-pc-windows-msvc', name: 'omx-api', path: 'omx-api.exe' }],
+          },
+        },
+      }));
+      const outputPath = join(root, 'native-release-manifest.json');
+      const result = spawnSync(process.execPath, [
+        join(process.cwd(), 'dist', 'scripts', 'generate-native-release-manifest.js'),
+        '--plan', planPath,
+        '--artifacts-dir', artifactsDir,
+        '--out', outputPath,
+        '--release-base-url', 'https://github.com/example/releases/download/v0.10.2',
+      ], { cwd: process.cwd(), encoding: 'utf-8' });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const manifest = JSON.parse(await readFile(outputPath, 'utf-8')) as { assets: Array<Record<string, unknown>> };
+      const asset = manifest.assets[0]!;
+      assert.equal(asset.product, 'omx-api');
+      assert.equal(asset.binary, 'omx-api.exe');
+      assert.equal(asset.binary_path, 'omx-api.exe');
+      assert.equal(asset.target, 'x86_64-pc-windows-msvc');
+      assert.equal(asset.platform, 'win32');
+      assert.equal(asset.arch, 'x64');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects the same closed-product, binary, path, suffix, and archive-hint violations as release verification', () => {
+    const asset = {
+      product: 'omx-api', version: '0.8.15', platform: 'linux', arch: 'x64', target: 'x86_64-unknown-linux-musl', libc: 'musl',
+      archive: 'omx-api-x86_64-unknown-linux-musl.tar.gz', binary: 'omx-api', binary_path: 'omx-api', sha256: 'a'.repeat(64), size: 1,
+      download_url: 'https://example.invalid/omx-api-x86_64-unknown-linux-musl.tar.gz',
+    };
+    const assertInvalid = (assetOverrides: Record<string, unknown> = {}, documentOverrides: Record<string, unknown> = {}) => {
+      assert.throws(() => validateNativeReleaseManifest({
+        manifest_version: 1,
+        version: '0.8.15',
+        tag: 'v0.8.15',
+        assets: [{ ...asset, ...assetOverrides }],
+        ...documentOverrides,
+      } as never));
+    };
+
+    assertInvalid({}, { manifest_version: undefined });
+    assertInvalid({}, { version: 'v0.8.15', tag: 'vv0.8.15' });
+    assertInvalid({}, { tag: 'v0.8.16' });
+    assertInvalid({ platform: 'darwin', arch: 'x64', target: 'x86_64-apple-darwin', libc: 'musl' });
+    assertInvalid({ product: 'omx-unknown' });
+    assertInvalid({ binary: 'omx-api.exe' });
+    assertInvalid({ binary_path: '../omx-api' });
+    assertInvalid({ archive: 'nested/omx-api-x86_64-unknown-linux-musl.tar.gz' });
+    assertInvalid({ archive: 'omx-api-x86_64-unknown-linux-musl.tar.bz2' });
+    assertInvalid({ archive: 'omx-api-x86_64-unknown-linux-gnu.tar.gz' });
+    assertInvalid({ archive: 'omx-api-aarch64-unknown-linux-musl.tar.gz' });
   });
 });


### PR DESCRIPTION
## Summary

- replace existence-based native cache authority with opened-handle binary + exact SHA-256 sidecar verification
- serialize hydration with a no-break publication lock, quarantine invalid occupants, and keep every two-file crash midpoint fail closed
- share strict manifest/archive path, type, collision, target, and selection policy across runtime, generator, and release verifier
- preserve packaged/repo-local resolution ordering; Sparkshell warns and raw-falls back while API errors actionably
- verify release assets before attachment and require the focused Ubuntu/macOS/Windows cache-integrity matrix in CI Status

## Security boundaries

- sidecarless, empty, truncated, mismatched, non-regular, hard-linked, or symlinked cache entries never authorize execution
- only the explicitly configured OMX_NATIVE_CACHE_DIR root may be a user-authorized symlink; descendants must remain contained and link/reparse-safe
- the binary/sidecar protocol is process-crash-safe and fail closed, not an atomic pair, transaction, signature system, power-loss guarantee, or descriptor-relative spawn guarantee
- retained locks are never automatically broken; diagnostics name the exact lock and manual remediation

## Validation on exact head

- npm run build
- focused compiled native/resolver/verifier/workflow suite: 85/85 pass
- npm run lint
- npm run check:no-unused
- npx tsc --noEmit
- git diff --check
- npm pack --dry-run --json --ignore-scripts
- npm run smoke:packed-install
- npm test

## Review

Closes #3278.

Closed external PR #3279 was used only as review evidence; this implementation was independently derived from dev base 12da62941ff65c32864bf90ad3b74b1cb4f2bc64. Please review the exact head independently. I will not self-review or merge.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*