### PR TITLE
fix: prevent root session self-reopen (#3284)

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4363,6 +4363,45 @@ PY`,
     }
   });
 
+  for (const source of ["startup", "resume"] as const) {
+    it(`issue #3284 skips persisted-root repair and reopen output for a self-parented child SessionStart on ${source}`, async () => {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-3284-self-parented-${source}-`));
+      try {
+        const stateDir = join(cwd, ".omx", "state");
+        const canonicalSessionId = `omx-3284-self-parented-${source}`;
+        const nativeRoleThreadId = `codex-role-thread-${source}`;
+        await mkdir(join(stateDir, "sessions", canonicalSessionId), { recursive: true });
+        await writeSessionStart(cwd, canonicalSessionId, { nativeSessionId: nativeRoleThreadId, pid: process.pid });
+        const transcriptPath = join(cwd, `rollout-self-parented-${source}.jsonl`);
+        await writeFile(transcriptPath, `${JSON.stringify({
+          type: "session_meta",
+          payload: { id: nativeRoleThreadId, source: { subagent: { thread_spawn: {
+            parent_thread_id: nativeRoleThreadId, depth: 1, agent_nickname: "Architect", agent_role: "architect" } } } },
+        })}\n`);
+        await writeJson(join(stateDir, "subagent-tracking.json"), {
+          schemaVersion: 1,
+          sessions: {
+            [canonicalSessionId]: { session_id: canonicalSessionId, leader_thread_id: "turn-like-foreign",
+              updated_at: "2026-07-24T00:00:00.000Z", threads: {
+                [nativeRoleThreadId]: { thread_id: nativeRoleThreadId, kind: "subagent", status: "available",
+                  first_seen_at: "2026-07-24T00:00:00.000Z", last_seen_at: "2026-07-24T00:00:00.000Z", turn_count: 1 },
+              } },
+          },
+        });
+        const result = await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd,
+          session_id: nativeRoleThreadId, source, transcript_path: transcriptPath }, { cwd, sessionOwnerPid: process.pid });
+        const context = String((result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "");
+        assert.doesNotMatch(context, /\[Persisted subagent reopen\]/);
+        assert.doesNotMatch(context, /resume_agent\(/);
+        const tracking = JSON.parse(await readFile(join(stateDir, "subagent-tracking.json"), "utf-8"));
+        assert.equal(tracking.sessions[canonicalSessionId].threads[nativeRoleThreadId].kind, "subagent");
+        assert.equal(tracking.sessions[canonicalSessionId].leader_thread_id, "turn-like-foreign");
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+  }
+
   it("issue #3284 fails closed when SessionStart native id aliases conflict", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-3284-alias-conflict-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4364,7 +4364,7 @@ PY`,
   });
 
   for (const source of ["startup", "resume"] as const) {
-    it(`issue #3284 skips persisted-root repair and reopen output for a self-parented child SessionStart on ${source}`, async () => {
+    it(`issue #3284 quarantines root reopen authority without asserting leader identity for a self-parented child SessionStart on ${source}`, async () => {
       const cwd = await mkdtemp(join(tmpdir(), `omx-3284-self-parented-${source}-`));
       try {
         const stateDir = join(cwd, ".omx", "state");
@@ -4384,6 +4384,8 @@ PY`,
             [canonicalSessionId]: { session_id: canonicalSessionId, leader_thread_id: "turn-like-foreign",
               updated_at: "2026-07-24T00:00:00.000Z", threads: {
                 [nativeRoleThreadId]: { thread_id: nativeRoleThreadId, kind: "subagent", status: "available",
+                  provenance_kind: "native_subagent", direct_child_root_id: nativeRoleThreadId,
+                  direct_child_parent_id: nativeRoleThreadId, resume_requested_at: "2026-07-24T00:02:00.000Z",
                   first_seen_at: "2026-07-24T00:00:00.000Z", last_seen_at: "2026-07-24T00:00:00.000Z", turn_count: 1 },
               } },
           },
@@ -4393,14 +4395,58 @@ PY`,
         const context = String((result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "");
         assert.doesNotMatch(context, /\[Persisted subagent reopen\]/);
         assert.doesNotMatch(context, /resume_agent\(/);
+        // The transcript marker names this very root as its own child, so it is
+        // not distinct-child evidence and cannot override the authenticated
+        // pointer identity. The root's reopen authority is quarantined without
+        // asserting leader identity, so descriptive subagent evidence survives.
         const tracking = JSON.parse(await readFile(join(stateDir, "subagent-tracking.json"), "utf-8"));
-        assert.equal(tracking.sessions[canonicalSessionId].threads[nativeRoleThreadId].kind, "subagent");
-        assert.equal(tracking.sessions[canonicalSessionId].leader_thread_id, "turn-like-foreign");
+        const rootRecord = tracking.sessions[canonicalSessionId].threads[nativeRoleThreadId];
+        assert.equal(rootRecord.kind, "subagent");
+        assert.equal(rootRecord.reopen_authority_revoked, true);
+        assert.equal(rootRecord.reopen_authority_conflict_reason, "contradictory_root_child_evidence");
+        assert.equal(rootRecord.resume_requested_at, undefined);
       } finally {
         await rm(cwd, { recursive: true, force: true });
       }
     });
   }
+
+  it("issue #3284 still suppresses root repair for a genuinely distinct child SessionStart", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3284-distinct-child-suppression-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const canonicalSessionId = "omx-3284-distinct-child";
+      const rootNativeSessionId = "root-3284-distinct-child";
+      const childId = "child-3284-distinct";
+      await mkdir(join(stateDir, "sessions", canonicalSessionId), { recursive: true });
+      await writeSessionStart(cwd, canonicalSessionId, { nativeSessionId: rootNativeSessionId, pid: process.pid });
+      const transcriptPath = join(cwd, "rollout-distinct-child.jsonl");
+      await writeFile(transcriptPath, `${JSON.stringify({
+        type: "session_meta",
+        payload: { id: childId, source: { subagent: { thread_spawn: { parent_thread_id: rootNativeSessionId, depth: 1 } } } },
+      })}\n`);
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [canonicalSessionId]: { session_id: canonicalSessionId, leader_thread_id: "turn-like-foreign",
+            updated_at: "2026-07-24T00:00:00.000Z", threads: {
+              [rootNativeSessionId]: { thread_id: rootNativeSessionId, kind: "subagent", status: "available",
+                first_seen_at: "2026-07-24T00:00:00.000Z", last_seen_at: "2026-07-24T00:00:00.000Z", turn_count: 1 },
+            } },
+        },
+      });
+      const result = await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd,
+        session_id: rootNativeSessionId, source: "resume", transcript_path: transcriptPath }, { cwd, sessionOwnerPid: process.pid });
+      const context = String((result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "");
+      assert.doesNotMatch(context, /resume_agent\(/);
+      // A distinct child id is real child evidence, so this event stays a child
+      // observation and does not act as a root observation.
+      const tracking = JSON.parse(await readFile(join(stateDir, "subagent-tracking.json"), "utf-8"));
+      assert.equal(tracking.sessions[canonicalSessionId].threads[rootNativeSessionId].kind, "subagent");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 
   it("issue #3284 fails closed when SessionStart native id aliases conflict", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-3284-alias-conflict-"));

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4411,7 +4411,7 @@ PY`,
     });
   }
 
-  it("issue #3284 still suppresses root repair for a genuinely distinct child SessionStart", async () => {
+  it("issue #3284 suppresses root handling only for an authenticated direct-child SessionStart", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-3284-distinct-child-suppression-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -4435,18 +4435,74 @@ PY`,
             } },
         },
       });
+      // The event's own unambiguous native id IS the marker's child, and the
+      // marker's parent is exactly the authenticated native root, so this is a
+      // real direct-child session start and must not act as a root observation.
       const result = await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd,
-        session_id: rootNativeSessionId, source: "resume", transcript_path: transcriptPath }, { cwd, sessionOwnerPid: process.pid });
+        session_id: childId, sessionId: childId, source: "resume", transcript_path: transcriptPath }, { cwd, sessionOwnerPid: process.pid });
       const context = String((result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "");
       assert.doesNotMatch(context, /resume_agent\(/);
-      // A distinct child id is real child evidence, so this event stays a child
-      // observation and does not act as a root observation.
       const tracking = JSON.parse(await readFile(join(stateDir, "subagent-tracking.json"), "utf-8"));
       assert.equal(tracking.sessions[canonicalSessionId].threads[rootNativeSessionId].kind, "subagent");
+      assert.equal(tracking.sessions[canonicalSessionId].threads[rootNativeSessionId].reopen_authority_revoked, undefined);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  for (const marker of [
+    { name: "arbitrary-nonexistent-child", childId: "made-up-child", parentId: "made-up-parent" },
+    { name: "nested-grandchild", childId: "grandchild-3284", parentId: "intermediate-3284" },
+    { name: "foreign-root-child", childId: "foreign-child-3284", parentId: "foreign-root-3284" },
+  ] as const) {
+    it(`issue #3284 does not let an unauthenticated ${marker.name} marker suppress root quarantine`, async () => {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-3284-unauth-marker-${marker.name}-`));
+      try {
+        const stateDir = join(cwd, ".omx", "state");
+        const canonicalSessionId = `omx-3284-unauth-${marker.name}`;
+        const rootNativeSessionId = `root-3284-unauth-${marker.name}`;
+        await mkdir(join(stateDir, "sessions", canonicalSessionId), { recursive: true });
+        await writeSessionStart(cwd, canonicalSessionId, { nativeSessionId: rootNativeSessionId, pid: process.pid });
+        const transcriptPath = join(cwd, `unauth-${marker.name}.jsonl`);
+        await writeFile(transcriptPath, `${JSON.stringify({
+          type: "session_meta",
+          payload: { id: marker.childId, source: { subagent: { thread_spawn: { parent_thread_id: marker.parentId, depth: 1 } } } },
+        })}\n`);
+        await writeJson(join(stateDir, "subagent-tracking.json"), {
+          schemaVersion: 1,
+          sessions: {
+            [canonicalSessionId]: { session_id: canonicalSessionId, leader_thread_id: "turn-like-foreign",
+              updated_at: "2026-07-24T00:00:00.000Z", threads: {
+                [rootNativeSessionId]: { thread_id: rootNativeSessionId, kind: "subagent", status: "available",
+                  provenance_kind: "native_subagent", direct_child_root_id: rootNativeSessionId,
+                  direct_child_parent_id: rootNativeSessionId, resume_requested_at: "2026-07-24T00:02:00.000Z",
+                  first_seen_at: "2026-07-24T00:00:00.000Z", last_seen_at: "2026-07-24T00:00:00.000Z", turn_count: 1 },
+              } },
+          },
+        });
+        const result = await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd,
+          session_id: rootNativeSessionId, source: "resume", transcript_path: transcriptPath }, { cwd, sessionOwnerPid: process.pid });
+        const context = String((result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "");
+        assert.doesNotMatch(context, /resume_agent\(/);
+        // The marker is not bound to the authenticated event identity, so the
+        // pointer-authoritative root never gains reopen authority: it is denied
+        // either by the dispatcher's foreign-parent revocation or by the
+        // contradictory-evidence quarantine. Both are fail-closed.
+        const rootRecord = JSON.parse(await readFile(join(stateDir, "subagent-tracking.json"), "utf-8"))
+          .sessions[canonicalSessionId].threads[rootNativeSessionId];
+        assert.equal(rootRecord.reopen_authority_revoked, true);
+        assert.ok(
+          ["contradictory_root_child_evidence", "foreign_parent", "identity_untrusted"].includes(rootRecord.reopen_authority_conflict_reason),
+          `unexpected conflict reason: ${rootRecord.reopen_authority_conflict_reason}`,
+        );
+        // Reopen eligibility is what matters: the revoked root can never be
+        // emitted regardless of leftover descriptive bookkeeping.
+        assert.equal(rootRecord.direct_child_root_id !== undefined && rootRecord.reopen_authority_revoked !== true, false);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+  }
 
   it("issue #3284 fails closed when SessionStart native id aliases conflict", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-3284-alias-conflict-"));

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4290,6 +4290,79 @@ PY`,
     });
   }
 
+  it("issue #3284 excludes a delegated top-level root labelled thread_source subagent with no parent evidence", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3284-delegated-root-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const canonicalSessionId = "omx-3284-delegated";
+      const rootNativeSessionId = "codex-delegated-root";
+      const childId = "codex-delegated-child";
+      await writeSessionStart(cwd, canonicalSessionId, { nativeSessionId: rootNativeSessionId, pid: process.pid });
+      // Evidence comment 5069022871: rollout provenance marks the task
+      // thread_source "subagent", yet it has no parent_thread_id/forked_from_id
+      // and is the root of its current collaboration tree.
+      const transcriptPath = join(cwd, "rollout-delegated-root.jsonl");
+      await writeFile(transcriptPath, `${JSON.stringify({
+        type: "session_meta",
+        payload: { id: rootNativeSessionId, source: { thread_source: "subagent" } },
+      })}\n`);
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [canonicalSessionId]: { session_id: canonicalSessionId, leader_thread_id: "turn-like-foreign",
+            updated_at: "2026-07-24T00:00:00.000Z", threads: {
+              [rootNativeSessionId]: { thread_id: rootNativeSessionId, kind: "subagent", status: "closed",
+                first_seen_at: "2026-07-24T00:00:00.000Z", last_seen_at: "2026-07-24T00:00:00.000Z", turn_count: 1 },
+              [childId]: { thread_id: childId, kind: "subagent", status: "available", provenance_kind: "native_subagent",
+                direct_child_root_id: rootNativeSessionId, direct_child_parent_id: rootNativeSessionId,
+                first_seen_at: "2026-07-24T00:01:00.000Z", last_seen_at: "2026-07-24T00:01:00.000Z", turn_count: 1 },
+            } },
+        },
+      });
+      const result = await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd,
+        session_id: rootNativeSessionId, source: "resume", transcript_path: transcriptPath }, { cwd, sessionOwnerPid: process.pid });
+      const context = String((result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "");
+      assert.equal(context.includes(`resume_agent(${JSON.stringify(rootNativeSessionId)})`), false);
+      assert.equal(context.includes(`resume_agent(${JSON.stringify(childId)})`), true);
+      const tracking = JSON.parse(await readFile(join(stateDir, "subagent-tracking.json"), "utf-8"));
+      assert.equal(tracking.sessions[canonicalSessionId].threads[rootNativeSessionId].kind, "leader");
+      assert.equal(tracking.sessions[canonicalSessionId].leader_thread_id, rootNativeSessionId);
+      assert.equal(tracking.sessions[canonicalSessionId].threads[rootNativeSessionId].resume_requested_at, undefined);
+      assert.match(tracking.sessions[canonicalSessionId].threads[childId].resume_requested_at, /^\d{4}-\d{2}-\d{2}T/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("issue #3284 repairs a root inversion on a non-reopen SessionStart source without emitting reopen output", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3284-repair-other-source-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const canonicalSessionId = "omx-3284-other-source";
+      const rootNativeSessionId = "codex-root-other-source";
+      await writeSessionStart(cwd, canonicalSessionId, { nativeSessionId: rootNativeSessionId, pid: process.pid });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [canonicalSessionId]: { session_id: canonicalSessionId, leader_thread_id: "turn-like-foreign",
+            updated_at: "2026-07-24T00:00:00.000Z", threads: {
+              [rootNativeSessionId]: { thread_id: rootNativeSessionId, kind: "subagent", status: "closed",
+                first_seen_at: "2026-07-24T00:00:00.000Z", last_seen_at: "2026-07-24T00:00:00.000Z", turn_count: 1 },
+            } },
+        },
+      });
+      const result = await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd,
+        session_id: rootNativeSessionId, source: "clear" }, { cwd, sessionOwnerPid: process.pid });
+      const context = String((result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "");
+      assert.doesNotMatch(context, /\[Persisted subagent reopen\]/);
+      const tracking = JSON.parse(await readFile(join(stateDir, "subagent-tracking.json"), "utf-8"));
+      assert.equal(tracking.sessions[canonicalSessionId].threads[rootNativeSessionId].kind, "leader");
+      assert.equal(tracking.sessions[canonicalSessionId].leader_thread_id, rootNativeSessionId);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("issue #3284 fails closed when SessionStart native id aliases conflict", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-3284-alias-conflict-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -29,6 +29,8 @@ import {
 import { registerTeamNotice } from "../../team/notice-ledger.js";
 import {
 	dispatchCodexNativeHook,
+  readUnambiguousSessionStartNativeId,
+  resolvePersistedReopenRootContext,
 	isCodexNativeHookMainModule,
 	looksLikeGoalCompletionPrompt,
 	mapCodexHookEventToOmxEvent,
@@ -4199,6 +4201,9 @@ PY`,
                 lane_id: "plan-review",
                 scope: "SessionStart reopen",
                 status: "available",
+                provenance_kind: "native_subagent",
+                direct_child_root_id: "codex-leader-reopen",
+                direct_child_parent_id: "codex-leader-reopen",
                 last_handoff_summary: "reviewed the restart plan",
               },
             },
@@ -4236,6 +4241,295 @@ PY`,
     }
   });
 
+  for (const status of ["closed", "available"] as const) {
+    it(`issue #3284 excludes the current root when persisted as a ${status} subagent`, async () => {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-3284-root-self-${status}-`));
+      try {
+        const stateDir = join(cwd, ".omx", "state");
+        const canonicalSessionId = `omx-3284-${status}`;
+        const rootNativeSessionId = `codex-root-${status}`;
+        const childId = `codex-child-${status}`;
+        await writeSessionStart(cwd, canonicalSessionId, { nativeSessionId: rootNativeSessionId, pid: process.pid });
+        await writeJson(join(stateDir, "subagent-tracking.json"), {
+          schemaVersion: 1,
+          sessions: {
+            [canonicalSessionId]: { session_id: canonicalSessionId, leader_thread_id: `turn-like-${status}`,
+              updated_at: "2026-07-23T00:00:00.000Z", threads: {
+                [rootNativeSessionId]: { thread_id: rootNativeSessionId, kind: "subagent", status,
+                  first_seen_at: "2026-07-23T00:00:00.000Z", last_seen_at: "2026-07-23T00:00:00.000Z", turn_count: 1 },
+                [childId]: { thread_id: childId, kind: "subagent", status: "available", provenance_kind: "native_subagent",
+                  direct_child_root_id: rootNativeSessionId, direct_child_parent_id: rootNativeSessionId,
+                  first_seen_at: "2026-07-23T00:01:00.000Z", last_seen_at: "2026-07-23T00:01:00.000Z", turn_count: 1 },
+              } },
+            [rootNativeSessionId]: { session_id: rootNativeSessionId, leader_thread_id: `turn-like-correlation-${status}`,
+              updated_at: "2026-07-23T00:00:00.000Z", threads: {
+                [rootNativeSessionId]: { thread_id: rootNativeSessionId, kind: "subagent", status, provenance_kind: "native_subagent",
+                  direct_child_root_id: rootNativeSessionId, direct_child_parent_id: rootNativeSessionId,
+                  resume_requested_at: "2026-07-23T00:02:00.000Z",
+                  first_seen_at: "2026-07-23T00:00:00.000Z", last_seen_at: "2026-07-23T00:00:00.000Z", turn_count: 1 },
+              } },
+          },
+        });
+        const result = await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd,
+          session_id: rootNativeSessionId, source: "resume" }, { cwd, sessionOwnerPid: process.pid });
+        const context = String((result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "");
+        assert.equal(context.includes(`resume_agent(${JSON.stringify(rootNativeSessionId)})`), false);
+        assert.equal(context.includes(`resume_agent(${JSON.stringify(childId)})`), true);
+        const tracking = JSON.parse(await readFile(join(stateDir, "subagent-tracking.json"), "utf-8"));
+        assert.equal(tracking.sessions[canonicalSessionId].threads[rootNativeSessionId].resume_requested_at, undefined);
+        assert.equal(tracking.sessions[canonicalSessionId].threads[rootNativeSessionId].kind, "leader");
+        assert.equal(tracking.sessions[canonicalSessionId].leader_thread_id, rootNativeSessionId);
+        assert.equal(tracking.sessions[rootNativeSessionId].threads[rootNativeSessionId].kind, "leader");
+        assert.equal(tracking.sessions[rootNativeSessionId].threads[rootNativeSessionId].resume_requested_at, undefined);
+        assert.equal(tracking.sessions[rootNativeSessionId].threads[rootNativeSessionId].direct_child_root_id, undefined);
+        assert.equal(tracking.sessions[rootNativeSessionId].leader_thread_id, rootNativeSessionId);
+        assert.match(tracking.sessions[canonicalSessionId].threads[childId].resume_requested_at, /^\d{4}-\d{2}-\d{2}T/);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it("issue #3284 fails closed when SessionStart native id aliases conflict", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3284-alias-conflict-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const canonicalSessionId = "omx-3284-alias";
+      const rootNativeSessionId = "codex-root-alias";
+      await writeSessionStart(cwd, canonicalSessionId, { nativeSessionId: rootNativeSessionId, pid: process.pid });
+      await writeJson(join(stateDir, "subagent-tracking.json"), { schemaVersion: 1, sessions: {
+        [canonicalSessionId]: { session_id: canonicalSessionId, updated_at: "2026-07-23T00:00:00.000Z", threads: {
+          child: { thread_id: "child", kind: "subagent", status: "available", provenance_kind: "native_subagent",
+            direct_child_root_id: rootNativeSessionId, direct_child_parent_id: rootNativeSessionId,
+            first_seen_at: "2026-07-23T00:00:00.000Z", last_seen_at: "2026-07-23T00:00:00.000Z", turn_count: 1 },
+        } },
+      } });
+      const result = await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd,
+        session_id: rootNativeSessionId, sessionId: "foreign-root", source: "resume" }, { cwd, sessionOwnerPid: process.pid });
+      const context = String((result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "");
+      assert.doesNotMatch(context, /\[Persisted subagent reopen\]/);
+      const tracking = JSON.parse(await readFile(join(stateDir, "subagent-tracking.json"), "utf-8"));
+      assert.equal(tracking.sessions[canonicalSessionId].threads.child.resume_requested_at, undefined);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("issue #3284 enforces the native alias truth table and root-context failure precedence", () => {
+    assert.deepEqual(readUnambiguousSessionStartNativeId(undefined), { ok: false, reason: "missing" });
+    assert.deepEqual(readUnambiguousSessionStartNativeId({ session_id: "root", sessionId: "root" }), { ok: true, value: "root" });
+    assert.deepEqual(readUnambiguousSessionStartNativeId({ session_id: "root", sessionId: "foreign" }), { ok: false, reason: "conflict" });
+    assert.deepEqual(readUnambiguousSessionStartNativeId({ session_id: "root", sessionId: undefined }), { ok: false, reason: "malformed" });
+    assert.deepEqual(readUnambiguousSessionStartNativeId({ session_id: 42, sessionId: "root" } as never), { ok: false, reason: "malformed" });
+    assert.deepEqual(readUnambiguousSessionStartNativeId({ session_id: "root" }), { ok: true, value: "root" });
+    assert.deepEqual(readUnambiguousSessionStartNativeId({ sessionId: "root" }), { ok: true, value: "root" });
+    assert.deepEqual(readUnambiguousSessionStartNativeId({ session_id: "foreign", sessionId: "root" }), { ok: false, reason: "conflict" });
+    assert.deepEqual(readUnambiguousSessionStartNativeId({ session_id: undefined, sessionId: "root" }), { ok: false, reason: "malformed" });
+    assert.deepEqual(readUnambiguousSessionStartNativeId({ session_id: "root", sessionId: 42 } as never), { ok: false, reason: "malformed" });
+    assert.deepEqual(readUnambiguousSessionStartNativeId({ session_id: "", sessionId: 42 } as never), { ok: false, reason: "malformed" });
+    assert.deepEqual(readUnambiguousSessionStartNativeId({ sessionId: "" }), { ok: false, reason: "malformed" });
+    assert.deepEqual(readUnambiguousSessionStartNativeId({ session_id: 42 } as never), { ok: false, reason: "malformed" });
+    assert.deepEqual(readUnambiguousSessionStartNativeId({ session_id: "", sessionId: "" }), { ok: false, reason: "malformed" });
+    assert.deepEqual(readUnambiguousSessionStartNativeId({ session_id: " root ", sessionId: "root" }), { ok: true, value: "root" });
+    const cwd = resolve("/tmp/omx-3284-root-context");
+    const baseState = { session_id: "canonical", native_session_id: "root", cwd, pid: process.pid, started_at: "2026-07-23T00:00:00.000Z" } as any;
+    assert.deepEqual(resolvePersistedReopenRootContext(cwd, "canonical", { session_id: "root" }, null), { ok: false, reason: "pointer_not_usable" });
+    assert.deepEqual(resolvePersistedReopenRootContext(cwd, "canonical", { session_id: "root" }, { ...baseState, cwd: "" }), { ok: false, reason: "pointer_cwd_missing" });
+    assert.deepEqual(resolvePersistedReopenRootContext(cwd, "canonical", { session_id: "root" }, { ...baseState, session_id: "" }), { ok: false, reason: "pointer_session_missing" });
+    assert.deepEqual(resolvePersistedReopenRootContext(cwd, "canonical", { session_id: "root" }, { ...baseState, native_session_id: "" }), { ok: false, reason: "pointer_native_root_missing" });
+    assert.deepEqual(resolvePersistedReopenRootContext(cwd, "canonical", { session_id: "root" }, { ...baseState, cwd: resolve("/tmp/foreign") }), { ok: false, reason: "pointer_cwd_mismatch" });
+    assert.deepEqual(resolvePersistedReopenRootContext(cwd, "", { session_id: "root" }, baseState), { ok: false, reason: "selected_canonical_missing" });
+    assert.deepEqual(resolvePersistedReopenRootContext(cwd, "foreign", { session_id: "root" }, baseState), { ok: false, reason: "canonical_mismatch" });
+    assert.deepEqual(resolvePersistedReopenRootContext(cwd, "canonical", {}, baseState), { ok: false, reason: "event_native_missing" });
+    assert.deepEqual(resolvePersistedReopenRootContext(cwd, "canonical", { session_id: "" }, baseState), { ok: false, reason: "event_native_malformed" });
+    assert.deepEqual(resolvePersistedReopenRootContext(cwd, "canonical", { session_id: "other" }, baseState), { ok: false, reason: "native_root_mismatch" });
+    assert.deepEqual(resolvePersistedReopenRootContext(cwd, "canonical", { session_id: "root" }, baseState), { ok: true, sessionId: "canonical", rootNativeSessionId: "root" });
+    assert.deepEqual(resolvePersistedReopenRootContext(cwd, "canonical", { session_id: "root", sessionId: "foreign" }, baseState), { ok: false, reason: "event_native_conflict" });
+    assert.deepEqual(resolvePersistedReopenRootContext(cwd, "canonical", { session_id: "root", sessionId: "foreign" }, null), { ok: false, reason: "pointer_not_usable" });
+    assert.deepEqual(resolvePersistedReopenRootContext(cwd, "foreign", {}, baseState), { ok: false, reason: "canonical_mismatch" });
+    assert.deepEqual(resolvePersistedReopenRootContext(cwd, "canonical", { session_id: "root" }, { ...baseState, owner_omx_session_id: "foreign", owner_codex_session_id: "foreign", codex_session_id: "foreign", previous_native_session_id: "foreign" }), { ok: true, sessionId: "canonical", rootNativeSessionId: "root" });
+  });
+
+  it("issue #3284 withholds authority when transcript and hook child identities disagree", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3284-child-mismatch-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const canonicalSessionId = "omx-3284-child-mismatch";
+      const rootNativeSessionId = "root-3284-child-mismatch";
+      const hookChildId = "hook-child-3284";
+      await writeSessionStart(cwd, canonicalSessionId, { nativeSessionId: rootNativeSessionId, pid: process.pid });
+      const cachedThread = { thread_id: hookChildId, kind: "subagent", provenance_kind: "native_subagent", direct_child_root_id: rootNativeSessionId, direct_child_parent_id: rootNativeSessionId, status: "available", first_seen_at: "2026-07-23T00:00:00.000Z", last_seen_at: "2026-07-23T00:00:00.000Z", turn_count: 1 };
+      await writeJson(join(stateDir, "subagent-tracking.json"), { schemaVersion: 1, sessions: {
+        [canonicalSessionId]: { session_id: canonicalSessionId, updated_at: "2026-07-23T00:00:00.000Z", threads: { [hookChildId]: cachedThread } },
+        [rootNativeSessionId]: { session_id: rootNativeSessionId, updated_at: "2026-07-23T00:00:00.000Z", threads: { [hookChildId]: cachedThread } },
+      } });
+      const transcriptPath = join(cwd, "child-mismatch.jsonl");
+      await writeFile(transcriptPath, `${JSON.stringify({ type: "session_meta", payload: { id: "transcript-child-3284", source: { subagent: { thread_spawn: { parent_thread_id: rootNativeSessionId } } } } })}\n`);
+      await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd, session_id: hookChildId, sessionId: hookChildId, transcript_path: transcriptPath }, { cwd, sessionOwnerPid: process.pid });
+      const tracking = JSON.parse(await readFile(join(stateDir, "subagent-tracking.json"), "utf-8"));
+      const child = tracking.sessions[canonicalSessionId].threads[hookChildId];
+      assert.equal(child.kind, "subagent");
+      assert.equal(child.reopen_authority_revoked, true);
+      const rootResume = await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd, session_id: rootNativeSessionId, source: "resume" }, { cwd, sessionOwnerPid: process.pid });
+      const context = String((rootResume.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "");
+      assert.equal(context.includes(`resume_agent(${JSON.stringify(hookChildId)})`), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("issue #3284 revokes cached authority across conflicting child aliases", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3284-child-alias-revoke-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const canonicalSessionId = "omx-3284-child-alias-revoke";
+      const rootNativeSessionId = "root-3284-child-alias-revoke";
+      const realChildId = "real-child-3284";
+      const fakeChildId = "fake-child-3284";
+      await writeSessionStart(cwd, canonicalSessionId, { nativeSessionId: rootNativeSessionId, pid: process.pid });
+      const cachedThread = { thread_id: realChildId, kind: "subagent", provenance_kind: "native_subagent", direct_child_root_id: rootNativeSessionId, direct_child_parent_id: rootNativeSessionId, status: "available", first_seen_at: "2026-07-23T00:00:00.000Z", last_seen_at: "2026-07-23T00:00:00.000Z", turn_count: 1 };
+      await writeJson(join(stateDir, "subagent-tracking.json"), { schemaVersion: 1, sessions: {
+        [canonicalSessionId]: { session_id: canonicalSessionId, updated_at: "2026-07-23T00:00:00.000Z", threads: { [realChildId]: cachedThread } },
+        [rootNativeSessionId]: { session_id: rootNativeSessionId, updated_at: "2026-07-23T00:00:00.000Z", threads: { [realChildId]: cachedThread } },
+      } });
+      const transcriptPath = join(cwd, "child-alias-revoke.jsonl");
+      await writeFile(transcriptPath, `${JSON.stringify({ type: "session_meta", payload: { id: realChildId, source: { subagent: { thread_spawn: { parent_thread_id: rootNativeSessionId } } } } })}\n`);
+      await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd, session_id: fakeChildId, sessionId: realChildId, transcript_path: transcriptPath }, { cwd, sessionOwnerPid: process.pid });
+      const tracking = JSON.parse(await readFile(join(stateDir, "subagent-tracking.json"), "utf-8"));
+      assert.equal(tracking.sessions[canonicalSessionId].threads[realChildId].reopen_authority_revoked, true);
+      const rootResume = await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd, session_id: rootNativeSessionId, source: "resume" }, { cwd, sessionOwnerPid: process.pid });
+      const context = String((rootResume.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "");
+      assert.equal(context.includes(`resume_agent(${JSON.stringify(realChildId)})`), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("issue #3284 revokes cached authority when the child reappears under a foreign parent", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3284-foreign-parent-revoke-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const canonicalSessionId = "omx-3284-foreign-parent-revoke";
+      const rootNativeSessionId = "root-3284-foreign-parent-revoke";
+      const childId = "child-3284-foreign-parent";
+      await writeSessionStart(cwd, canonicalSessionId, { nativeSessionId: rootNativeSessionId, pid: process.pid });
+      const cachedThread = { thread_id: childId, kind: "subagent", provenance_kind: "native_subagent", direct_child_root_id: rootNativeSessionId, direct_child_parent_id: rootNativeSessionId, status: "available", first_seen_at: "2026-07-23T00:00:00.000Z", last_seen_at: "2026-07-23T00:00:00.000Z", turn_count: 1 };
+      await writeJson(join(stateDir, "subagent-tracking.json"), { schemaVersion: 1, sessions: {
+        [canonicalSessionId]: { session_id: canonicalSessionId, updated_at: "2026-07-23T00:00:00.000Z", threads: { [childId]: cachedThread } },
+        [rootNativeSessionId]: { session_id: rootNativeSessionId, updated_at: "2026-07-23T00:00:00.000Z", threads: { [childId]: cachedThread } },
+      } });
+      const transcriptPath = join(cwd, "foreign-parent-revoke.jsonl");
+      await writeFile(transcriptPath, `${JSON.stringify({ type: "session_meta", payload: { id: childId, source: { subagent: { thread_spawn: { parent_thread_id: "foreign-parent" } } } } })}\n`);
+      await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd, session_id: childId, sessionId: childId, transcript_path: transcriptPath }, { cwd, sessionOwnerPid: process.pid });
+      const tracking = JSON.parse(await readFile(join(stateDir, "subagent-tracking.json"), "utf-8"));
+      assert.equal(tracking.sessions[canonicalSessionId].threads[childId].reopen_authority_revoked, true);
+      const rootResume = await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd, session_id: rootNativeSessionId, source: "resume" }, { cwd, sessionOwnerPid: process.pid });
+      const context = String((rootResume.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "");
+      assert.equal(context.includes(`resume_agent(${JSON.stringify(childId)})`), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  for (const malformedFirstAlias of ["", 42] as const) {
+    it(`issue #3284 revokes cached authority when the first child alias is ${JSON.stringify(malformedFirstAlias)}`, async () => {
+      const cwd = await mkdtemp(join(tmpdir(), "omx-3284-child-malformed-first-"));
+      try {
+        const stateDir = join(cwd, ".omx", "state");
+        const canonicalSessionId = "omx-3284-child-malformed-first";
+        const rootNativeSessionId = "root-3284-child-malformed-first";
+        const childId = "child-3284-malformed-first";
+        await writeSessionStart(cwd, canonicalSessionId, { nativeSessionId: rootNativeSessionId, pid: process.pid });
+        const cachedThread = { thread_id: childId, kind: "subagent", provenance_kind: "native_subagent", direct_child_root_id: rootNativeSessionId, direct_child_parent_id: rootNativeSessionId, status: "available", first_seen_at: "2026-07-23T00:00:00.000Z", last_seen_at: "2026-07-23T00:00:00.000Z", turn_count: 1 };
+        await writeJson(join(stateDir, "subagent-tracking.json"), { schemaVersion: 1, sessions: {
+          [canonicalSessionId]: { session_id: canonicalSessionId, updated_at: "2026-07-23T00:00:00.000Z", threads: { [childId]: cachedThread } },
+          [rootNativeSessionId]: { session_id: rootNativeSessionId, updated_at: "2026-07-23T00:00:00.000Z", threads: { [childId]: cachedThread } },
+        } });
+        const transcriptPath = join(cwd, "child-malformed-first.jsonl");
+        await writeFile(transcriptPath, `${JSON.stringify({ type: "session_meta", payload: { id: childId, source: { subagent: { thread_spawn: { parent_thread_id: rootNativeSessionId } } } } })}\n`);
+        await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd, session_id: malformedFirstAlias, sessionId: childId, transcript_path: transcriptPath } as never, { cwd, sessionOwnerPid: process.pid });
+        const tracking = JSON.parse(await readFile(join(stateDir, "subagent-tracking.json"), "utf-8"));
+        assert.equal(tracking.sessions[canonicalSessionId].threads[childId].reopen_authority_revoked, true);
+        const rootResume = await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd, session_id: rootNativeSessionId, source: "resume" }, { cwd, sessionOwnerPid: process.pid });
+        const context = String((rootResume.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "");
+        assert.equal(context.includes(`resume_agent(${JSON.stringify(childId)})`), false);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+  }
+
+
+  for (const scenario of [
+    { name: "valid-first-blank-second", aliases: { session_id: "child-3284-no-candidate", sessionId: "" } },
+    { name: "both-blank", aliases: { session_id: "", sessionId: "" } },
+    { name: "both-non-string", aliases: { session_id: 42, sessionId: false } },
+    { name: "both-absent", aliases: {} },
+  ] as const) {
+    it(`issue #3284 revokes transcript-identified cached authority for ${scenario.name}`, async () => {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-3284-no-candidate-${scenario.name}-`));
+      try {
+        const stateDir = join(cwd, ".omx", "state");
+        const canonicalSessionId = `omx-3284-no-candidate-${scenario.name}`;
+        const rootNativeSessionId = `root-3284-no-candidate-${scenario.name}`;
+        const childId = "child-3284-no-candidate";
+        await writeSessionStart(cwd, canonicalSessionId, { nativeSessionId: rootNativeSessionId, pid: process.pid });
+        const cachedThread = { thread_id: childId, kind: "subagent", provenance_kind: "native_subagent", direct_child_root_id: rootNativeSessionId, direct_child_parent_id: rootNativeSessionId, status: "available", first_seen_at: "2026-07-23T00:00:00.000Z", last_seen_at: "2026-07-23T00:00:00.000Z", turn_count: 1 };
+        await writeJson(join(stateDir, "subagent-tracking.json"), { schemaVersion: 1, sessions: {
+          [canonicalSessionId]: { session_id: canonicalSessionId, updated_at: "2026-07-23T00:00:00.000Z", threads: { [childId]: cachedThread } },
+          [rootNativeSessionId]: { session_id: rootNativeSessionId, updated_at: "2026-07-23T00:00:00.000Z", threads: { [childId]: cachedThread } },
+        } });
+        const transcriptPath = join(cwd, `no-candidate-${scenario.name}.jsonl`);
+        await writeFile(transcriptPath, `${JSON.stringify({ type: "session_meta", payload: { id: childId, source: { subagent: { thread_spawn: { parent_thread_id: rootNativeSessionId } } } } })}\n`);
+        await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd, ...scenario.aliases, transcript_path: transcriptPath } as never, { cwd, sessionOwnerPid: process.pid });
+        const tracking = JSON.parse(await readFile(join(stateDir, "subagent-tracking.json"), "utf-8"));
+        assert.equal(tracking.sessions[canonicalSessionId].threads[childId].reopen_authority_revoked, true);
+        const rootResume = await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd, session_id: rootNativeSessionId, source: "resume" }, { cwd, sessionOwnerPid: process.pid });
+        const context = String((rootResume.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "");
+        assert.equal(context.includes(`resume_agent(${JSON.stringify(childId)})`), false);
+        const afterRootResume = JSON.parse(await readFile(join(stateDir, "subagent-tracking.json"), "utf-8"));
+        assert.equal(afterRootResume.sessions[canonicalSessionId].threads[childId].resume_requested_at, undefined);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it("issue #3284 preserves ordinary transcript-bearing SessionStart when native aliases are unusable", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3284-ordinary-transcript-"));
+    try {
+      const canonicalSessionId = "omx-3284-ordinary-transcript";
+      const rootNativeSessionId = "root-3284-ordinary-transcript";
+      await writeSessionStart(cwd, canonicalSessionId, { nativeSessionId: rootNativeSessionId, pid: process.pid });
+      const sessionPath = join(cwd, ".omx", "state", "session.json");
+      const before = await readFile(sessionPath, "utf-8");
+      const transcriptPath = join(cwd, "ordinary-root.jsonl");
+      await writeFile(transcriptPath, `${JSON.stringify({ type: "session_meta", payload: { id: rootNativeSessionId, source: "user" } })}\n`);
+      await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd, session_id: "", sessionId: 42, transcript_path: transcriptPath } as never, { cwd, sessionOwnerPid: process.pid });
+      assert.equal(await readFile(sessionPath, "utf-8"), before);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+  it("issue #3284 fresh-reads the pointer created by root SessionStart reconciliation", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3284-fresh-pointer-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const rootNativeSessionId = "root-3284-fresh-pointer";
+      const childId = "child-3284-fresh-pointer";
+      await writeJson(join(stateDir, "subagent-tracking.json"), { schemaVersion: 1, sessions: {
+        [rootNativeSessionId]: { session_id: rootNativeSessionId, updated_at: "2026-07-23T00:00:00.000Z", threads: {
+          [childId]: { thread_id: childId, kind: "subagent", provenance_kind: "native_subagent", direct_child_root_id: rootNativeSessionId, direct_child_parent_id: rootNativeSessionId, status: "available", first_seen_at: "2026-07-23T00:00:00.000Z", last_seen_at: "2026-07-23T00:00:00.000Z", turn_count: 1 },
+        } },
+      } });
+      const result = await dispatchCodexNativeHook({ hook_event_name: "SessionStart", cwd, session_id: rootNativeSessionId, source: "resume" }, { cwd, sessionOwnerPid: process.pid });
+      const context = String((result.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "");
+      assert.equal(context.includes(`resume_agent(${JSON.stringify(childId)})`), true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("does not suggest duplicate same-role subagent spawns when reopen ids exist", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-subagent-no-duplicates-"));
     try {
@@ -4266,6 +4560,9 @@ PY`,
                 role: "critic",
                 lane_id: "risk-review",
                 status: "closed",
+                provenance_kind: "native_subagent",
+                direct_child_root_id: "codex-leader-reuse",
+                direct_child_parent_id: "codex-leader-reuse",
               },
             },
           },
@@ -4326,6 +4623,9 @@ PY`,
                 status: "unavailable",
                 resume_failed_at: "2026-07-09T00:02:00.000Z",
                 resume_failure_reason: "Codex reported missing thread id",
+                provenance_kind: "native_subagent",
+                direct_child_root_id: "codex-leader-warning",
+                direct_child_parent_id: "codex-leader-warning",
               },
             },
           },
@@ -5012,15 +5312,24 @@ PY`,
       ) as {
         sessions?: Record<string, {
           leader_thread_id?: string;
-          threads?: Record<string, { kind?: string; mode?: string }>;
+          threads?: Record<string, { kind?: string; mode?: string; direct_child_root_id?: string; direct_child_parent_id?: string }>;
         }>;
       };
       assert.equal(tracking.sessions?.[canonicalSessionId]?.leader_thread_id, leaderNativeSessionId);
       assert.equal(tracking.sessions?.[canonicalSessionId]?.threads?.[childNativeSessionId]?.kind, "subagent");
       assert.equal(tracking.sessions?.[canonicalSessionId]?.threads?.[childNativeSessionId]?.mode, "critic");
+      assert.equal(tracking.sessions?.[canonicalSessionId]?.threads?.[childNativeSessionId]?.direct_child_root_id, leaderNativeSessionId);
+      assert.equal(tracking.sessions?.[canonicalSessionId]?.threads?.[childNativeSessionId]?.direct_child_parent_id, leaderNativeSessionId);
       assert.equal(tracking.sessions?.[leaderNativeSessionId]?.leader_thread_id, leaderNativeSessionId);
       assert.equal(tracking.sessions?.[leaderNativeSessionId]?.threads?.[childNativeSessionId]?.kind, "subagent");
       assert.equal(tracking.sessions?.[leaderNativeSessionId]?.threads?.[childNativeSessionId]?.mode, "critic");
+      const rootResume = await dispatchCodexNativeHook(
+        { hook_event_name: "SessionStart", cwd, session_id: leaderNativeSessionId, source: "resume" },
+        { cwd, sessionOwnerPid: process.pid },
+      );
+      const rootResumeContext = String((rootResume.outputJson as { hookSpecificOutput?: { additionalContext?: string } })?.hookSpecificOutput?.additionalContext ?? "");
+      assert.equal(rootResumeContext.includes(`resume_agent(${JSON.stringify(childNativeSessionId)})`), true);
+      await rm(join(cwd, "hook-events.jsonl"), { force: true });
 
       await dispatchCodexNativeHook(
         {

--- a/src/scripts/__tests__/role-intent-durable-recovery-3181.test.ts
+++ b/src/scripts/__tests__/role-intent-durable-recovery-3181.test.ts
@@ -17,7 +17,7 @@ async function withCwd(fn: (cwd: string) => Promise<void>): Promise<void> {
 }
 
 describe('#3181 durable tracker upgrade recovery', () => {
-  it('filters legacy adapted provenance during tolerant tracker recovery', async () => {
+  it('preserves legacy adapted provenance as descriptive-only during tolerant tracker recovery', async () => {
     await withCwd(async (cwd) => {
       const path = subagentTrackingPath(cwd);
       await mkdir(dirname(path), { recursive: true });
@@ -69,6 +69,7 @@ describe('#3181 durable tracker upgrade recovery', () => {
                 turn_count: 2,
                 mode: 'architect',
                 role: 'architect',
+                provenance_kind: 'adapted',
               },
             },
           },
@@ -76,7 +77,7 @@ describe('#3181 durable tracker upgrade recovery', () => {
       });
       assert.equal((JSON.parse(await readFile(path, 'utf8')) as { sessions: Record<string, { threads: Record<string, { provenance_kind?: string }> }> }).sessions['synthetic-session'].threads['synthetic-child'].provenance_kind, 'adapted');
       await writeSubagentTrackingState(cwd, state);
-      assert.equal(JSON.parse(await readFile(path, 'utf8')).sessions['synthetic-session'].threads['synthetic-child'].provenance_kind, undefined);
+      assert.equal(JSON.parse(await readFile(path, 'utf8')).sessions['synthetic-session'].threads['synthetic-child'].provenance_kind, 'adapted');
     });
   });
 

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -17,12 +17,14 @@ import {
   type SkillActiveEntry,
 } from "../state/skill-active.js";
 import {
+  fenceNativeSubagentAuthorities,
   consumeDirectChildReopenContext,
   isTrustedSubagentThread,
   readSubagentSessionSummary,
   readSubagentTrackingState,
   recordNativeSubagentAuthorityObservation,
   repairPersistedRootIdentity,
+  quarantinePersistedRootAuthority,
   revokeNativeSubagentAuthorities,
   resolveInstalledRoleName,
 } from "../subagents/tracker.js";
@@ -498,6 +500,16 @@ async function recordNativeSubagentSessionStart(
     });
   } catch {
     authorityTrackingFailed = true;
+    // A failed observation must not leave stale authority usable. Only a
+    // negative (untrusted) observation carries a revocation intent, so fence
+    // exactly those implicated ids until the revocation is durably applied.
+    if (authorityEvidence === "untrusted") {
+      fenceNativeSubagentAuthorities(
+        cwd,
+        [...new Set([childThreadId, ...implicatedChildThreadIds].filter(Boolean))],
+        "identity_untrusted_revocation_failed",
+      );
+    }
   }
   refreshNativeSubagentRoleRoutingMarker(
     cwd,
@@ -2087,12 +2099,36 @@ async function buildPersistedSubagentReopenContext(
     pointer.status === "usable" ? pointer.state ?? null : null,
   );
   if (!rootContext.ok) return null;
-  // A SessionStart that itself carries native subagent thread_spawn evidence is
-  // a child session start, not a root observation. It must not trigger root
-  // identity repair or reopen consumption on any source, including
-  // startup/resume.
+  // A SessionStart that carries native subagent thread_spawn evidence for a
+  // genuinely DISTINCT child is a child session start, not a root observation,
+  // so it must not trigger root identity repair or reopen consumption on any
+  // source. The suppression is bound to the pointer-authoritative root: a
+  // transcript marker that is self-parented, names this very root as its child,
+  // or otherwise fails to identify a distinct child cannot override the
+  // authenticated pointer/event root identity, because that would let a stale
+  // or spurious marker keep a root-as-subagent inversion persisted forever.
   const sessionStartTranscriptPath = safeString(options.payload?.transcript_path ?? options.payload?.transcriptPath).trim();
-  if (readNativeSubagentSessionStartMetadata(sessionStartTranscriptPath)) return null;
+  const sessionStartChildMetadata = readNativeSubagentSessionStartMetadata(sessionStartTranscriptPath);
+  if (sessionStartChildMetadata) {
+    const markerParentId = sessionStartChildMetadata.parentThreadId.trim();
+    const markerChildId = safeString(sessionStartChildMetadata.childSessionId).trim();
+    const identifiesDistinctChild = markerChildId !== ""
+      && markerChildId !== rootContext.rootNativeSessionId
+      && markerChildId !== rootContext.sessionId
+      && markerParentId !== markerChildId;
+    if (identifiesDistinctChild) return null;
+    // Contradictory or self-parented child evidence: this event cannot prove a
+    // distinct child, so it must not suppress the pointer-authoritative root's
+    // protection. Quarantine the root's reopen authority without asserting
+    // leader identity, which preserves legitimate descriptive subagent evidence
+    // while ensuring the root can never carry reopen authority.
+    try {
+      quarantinePersistedRootAuthority(cwd, { sessionId: rootContext.sessionId, rootNativeSessionId: rootContext.rootNativeSessionId });
+    } catch {
+      // Quarantine is best-effort; reopen output stays denied for this event.
+    }
+    return null;
+  }
   if (!shouldBuildSubagentReopenContext(options)) {
     // Reopen output is gated to startup/resume, but root identity repair is not:
     // a known root-as-subagent inversion must not survive merely because this
@@ -20343,7 +20379,10 @@ export async function dispatchCodexNativeHook(
           try {
             revokeNativeSubagentAuthorities(cwd, implicatedChildThreadIds, "foreign_parent");
           } catch {
-            // Authority revocation remains fail-closed and must not promote this child.
+            // The negative identity observation could not be published. Fence
+            // the implicated ids durably so reopen consumption keeps denying
+            // them instead of leaving the old authority usable.
+            fenceNativeSubagentAuthorities(cwd, implicatedChildThreadIds, "foreign_parent_revocation_failed");
           }
           await recordIgnoredNativeSubagentSessionStart(
             cwd,

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -18,6 +18,7 @@ import {
 } from "../state/skill-active.js";
 import {
   fenceNativeSubagentAuthorities,
+  forceGlobalAuthorityDenial,
   consumeDirectChildReopenContext,
   isTrustedSubagentThread,
   readSubagentSessionSummary,
@@ -506,11 +507,13 @@ async function recordNativeSubagentSessionStart(
     // exactly those implicated ids until the revocation is durably applied.
     // A conflicting VALID observation also revokes, so it must fence too.
     if (authorityEvidence !== "absent") {
-      authorityFenceFailed = !fenceNativeSubagentAuthorities(
-        cwd,
-        [...new Set([childThreadId, ...implicatedChildThreadIds].filter(Boolean))],
-        `${authorityEvidence}_revocation_failed`,
-      );
+      const fencedIds = [...new Set([childThreadId, ...implicatedChildThreadIds].filter(Boolean))];
+      authorityFenceFailed = !fenceNativeSubagentAuthorities(cwd, fencedIds, `${authorityEvidence}_revocation_failed`);
+      if (authorityFenceFailed) {
+        // Both the tracker denial and the locked fence failed. Escalate to a
+        // lock-free global denial so old authority cannot stay usable.
+        authorityFenceFailed = !forceGlobalAuthorityDenial(cwd, `${authorityEvidence}_denial_escalated`);
+      }
     }
   }
   refreshNativeSubagentRoleRoutingMarker(
@@ -20398,12 +20401,17 @@ export async function dispatchCodexNativeHook(
             // also fails to persist is recorded so the failure is observable
             // rather than silently dropped.
             if (!fenceNativeSubagentAuthorities(cwd, implicatedChildThreadIds, "foreign_parent_revocation_failed")) {
+              // Both the tracker denial and the locked fence failed. Escalate
+              // to a lock-free global denial so the old authority cannot stay
+              // usable, and record whether even that succeeded.
+              const escalated = forceGlobalAuthorityDenial(cwd, "foreign_parent_denial_escalated");
               await appendToLog(cwd, {
                 event: "subagent_authority_fence_failed",
                 session_id: canonicalSessionId,
                 native_session_id: nativeSessionId,
                 reason: "foreign_parent_revocation_failed",
                 implicated_thread_ids: implicatedChildThreadIds,
+                global_denial_escalated: escalated,
                 timestamp: new Date().toISOString(),
               }).catch(() => {});
             }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -22,6 +22,7 @@ import {
   readSubagentSessionSummary,
   readSubagentTrackingState,
   recordNativeSubagentAuthorityObservation,
+  repairPersistedRootIdentity,
   revokeNativeSubagentAuthorities,
   resolveInstalledRoleName,
 } from "../subagents/tracker.js";
@@ -2076,7 +2077,7 @@ async function buildPersistedSubagentReopenContext(
     payload?: CodexHookPayload;
   },
 ): Promise<string | null> {
-  if (!shouldBuildSubagentReopenContext(options)) return null;
+  if (options.hookEventName !== "SessionStart") return null;
   const pointerContext = resolveSessionPointerContext(cwd);
   const pointer = await readSessionPointer(pointerContext);
   const rootContext = resolvePersistedReopenRootContext(
@@ -2086,6 +2087,23 @@ async function buildPersistedSubagentReopenContext(
     pointer.status === "usable" ? pointer.state ?? null : null,
   );
   if (!rootContext.ok) return null;
+  if (!shouldBuildSubagentReopenContext(options)) {
+    // Reopen output is gated to startup/resume, but root identity repair is not:
+    // a known root-as-subagent inversion must not survive merely because this
+    // SessionStart used another source. Alias/identity conflicts above stay
+    // fail-closed and repair nothing. A SessionStart that itself carries native
+    // subagent thread_spawn evidence is a child session start, not a root
+    // observation, so it must not trigger root repair either.
+    const transcriptPath = safeString(options.payload?.transcript_path ?? options.payload?.transcriptPath).trim();
+    if (!readNativeSubagentSessionStartMetadata(transcriptPath)) {
+      try {
+        repairPersistedRootIdentity(cwd, { sessionId: rootContext.sessionId, rootNativeSessionId: rootContext.rootNativeSessionId });
+      } catch {
+        // Repair is best-effort; reopen output remains separately gated.
+      }
+    }
+    return null;
+  }
   try {
     return consumeDirectChildReopenContext(cwd, {
       sessionId: rootContext.sessionId,

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -2087,20 +2087,21 @@ async function buildPersistedSubagentReopenContext(
     pointer.status === "usable" ? pointer.state ?? null : null,
   );
   if (!rootContext.ok) return null;
+  // A SessionStart that itself carries native subagent thread_spawn evidence is
+  // a child session start, not a root observation. It must not trigger root
+  // identity repair or reopen consumption on any source, including
+  // startup/resume.
+  const sessionStartTranscriptPath = safeString(options.payload?.transcript_path ?? options.payload?.transcriptPath).trim();
+  if (readNativeSubagentSessionStartMetadata(sessionStartTranscriptPath)) return null;
   if (!shouldBuildSubagentReopenContext(options)) {
     // Reopen output is gated to startup/resume, but root identity repair is not:
     // a known root-as-subagent inversion must not survive merely because this
     // SessionStart used another source. Alias/identity conflicts above stay
-    // fail-closed and repair nothing. A SessionStart that itself carries native
-    // subagent thread_spawn evidence is a child session start, not a root
-    // observation, so it must not trigger root repair either.
-    const transcriptPath = safeString(options.payload?.transcript_path ?? options.payload?.transcriptPath).trim();
-    if (!readNativeSubagentSessionStartMetadata(transcriptPath)) {
-      try {
-        repairPersistedRootIdentity(cwd, { sessionId: rootContext.sessionId, rootNativeSessionId: rootContext.rootNativeSessionId });
-      } catch {
-        // Repair is best-effort; reopen output remains separately gated.
-      }
+    // fail-closed and repair nothing.
+    try {
+      repairPersistedRootIdentity(cwd, { sessionId: rootContext.sessionId, rootNativeSessionId: rootContext.rootNativeSessionId });
+    } catch {
+      // Repair is best-effort; reopen output remains separately gated.
     }
     return null;
   }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -488,6 +488,7 @@ async function recordNativeSubagentSessionStart(
     parentThreadId,
   ].filter(Boolean))];
   let authorityTrackingFailed = false;
+  let authorityFenceFailed = false;
   try {
     recordNativeSubagentAuthorityObservation(cwd, {
       sessionIds: trackingSessionIds,
@@ -503,11 +504,12 @@ async function recordNativeSubagentSessionStart(
     // A failed observation must not leave stale authority usable. Only a
     // negative (untrusted) observation carries a revocation intent, so fence
     // exactly those implicated ids until the revocation is durably applied.
-    if (authorityEvidence === "untrusted") {
-      fenceNativeSubagentAuthorities(
+    // A conflicting VALID observation also revokes, so it must fence too.
+    if (authorityEvidence !== "absent") {
+      authorityFenceFailed = !fenceNativeSubagentAuthorities(
         cwd,
         [...new Set([childThreadId, ...implicatedChildThreadIds].filter(Boolean))],
-        "identity_untrusted_revocation_failed",
+        `${authorityEvidence}_revocation_failed`,
       );
     }
   }
@@ -527,6 +529,7 @@ async function recordNativeSubagentSessionStart(
     ...(metadata.agentRole ? { agent_role: metadata.agentRole } : {}),
     ...(transcriptPath ? { transcript_path: transcriptPath } : {}),
     authority_tracking_status: authorityTrackingFailed ? "failed" : authorityEvidence,
+    ...(authorityFenceFailed ? { authority_fence_status: "failed" } : {}),
     timestamp: new Date().toISOString(),
   }).catch(() => {});
 }
@@ -2112,11 +2115,21 @@ async function buildPersistedSubagentReopenContext(
   if (sessionStartChildMetadata) {
     const markerParentId = sessionStartChildMetadata.parentThreadId.trim();
     const markerChildId = safeString(sessionStartChildMetadata.childSessionId).trim();
-    const identifiesDistinctChild = markerChildId !== ""
+    // String-distinctness is NOT attestation. Suppression of the
+    // pointer-authoritative root's protection requires the marker to be bound
+    // to the authenticated event identity: the marker's child must be this very
+    // SessionStart's unambiguous native id, and its parent must be exactly the
+    // authenticated native root (a direct child, not a nested descendant or a
+    // child of some foreign parent). Anything else is unauthenticated evidence
+    // and must not keep a root-as-subagent inversion alive.
+    const eventChildIdentity = readUnambiguousSessionStartNativeId(options.payload ?? {});
+    const identifiesAuthenticatedDirectChild = markerChildId !== ""
       && markerChildId !== rootContext.rootNativeSessionId
       && markerChildId !== rootContext.sessionId
-      && markerParentId !== markerChildId;
-    if (identifiesDistinctChild) return null;
+      && markerParentId === rootContext.rootNativeSessionId
+      && eventChildIdentity.ok
+      && eventChildIdentity.value === markerChildId;
+    if (identifiesAuthenticatedDirectChild) return null;
     // Contradictory or self-parented child evidence: this event cannot prove a
     // distinct child, so it must not suppress the pointer-authoritative root's
     // protection. Quarantine the root's reopen authority without asserting
@@ -20381,8 +20394,19 @@ export async function dispatchCodexNativeHook(
           } catch {
             // The negative identity observation could not be published. Fence
             // the implicated ids durably so reopen consumption keeps denying
-            // them instead of leaving the old authority usable.
-            fenceNativeSubagentAuthorities(cwd, implicatedChildThreadIds, "foreign_parent_revocation_failed");
+            // them instead of leaving the old authority usable. A fence that
+            // also fails to persist is recorded so the failure is observable
+            // rather than silently dropped.
+            if (!fenceNativeSubagentAuthorities(cwd, implicatedChildThreadIds, "foreign_parent_revocation_failed")) {
+              await appendToLog(cwd, {
+                event: "subagent_authority_fence_failed",
+                session_id: canonicalSessionId,
+                native_session_id: nativeSessionId,
+                reason: "foreign_parent_revocation_failed",
+                implicated_thread_ids: implicatedChildThreadIds,
+                timestamp: new Date().toISOString(),
+              }).catch(() => {});
+            }
           }
           await recordIgnoredNativeSubagentSessionStart(
             cwd,

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -17,11 +17,12 @@ import {
   type SkillActiveEntry,
 } from "../state/skill-active.js";
 import {
+  consumeDirectChildReopenContext,
   isTrustedSubagentThread,
   readSubagentSessionSummary,
-  readSubagentSessionLedger,
   readSubagentTrackingState,
-  recordSubagentTurnForSession,
+  recordNativeSubagentAuthorityObservation,
+  revokeNativeSubagentAuthorities,
   resolveInstalledRoleName,
 } from "../subagents/tracker.js";
 
@@ -39,6 +40,7 @@ import {
   isSessionPointerLaunchAbort,
   isSessionStale,
   isSessionStateUsable,
+  isSessionStateAuthoritativeForCwd,
   normalizeSessionId,
   readNativeSessionOwner,
   readSessionPointer,
@@ -379,6 +381,7 @@ function shouldSuppressParentWorkflowStopForSideConversation(payload: CodexHookP
 
 interface NativeSubagentSessionStartMetadata {
   parentThreadId: string;
+  childSessionId?: string;
   agentNickname?: string;
   agentRole?: string;
 }
@@ -452,6 +455,7 @@ function readNativeSubagentSessionStartMetadata(transcriptPath: string): NativeS
     ).trim();
     return {
       parentThreadId,
+      ...(safeString(payload.id).trim() ? { childSessionId: safeString(payload.id).trim() } : {}),
       ...(agentNickname ? { agentNickname } : {}),
       ...(agentRole ? { agentRole } : {}),
     };
@@ -469,6 +473,9 @@ async function recordNativeSubagentSessionStart(
   childSessionId: string,
   metadata: NativeSubagentSessionStartMetadata,
   transcriptPath: string,
+  rootNativeSessionId = "",
+  authorityEvidence: "valid" | "untrusted" | "absent" = "absent",
+  implicatedChildThreadIds: string[] = [],
 ): Promise<void> {
   const parentThreadId = metadata.parentThreadId.trim();
   const childThreadId = childSessionId.trim();
@@ -477,22 +484,19 @@ async function recordNativeSubagentSessionStart(
     canonicalSessionId.trim(),
     parentThreadId,
   ].filter(Boolean))];
-  for (const sessionId of trackingSessionIds) {
-    if (parentThreadId && parentThreadId !== childThreadId) {
-      await recordSubagentTurnForSession(cwd, {
-        sessionId,
-        threadId: parentThreadId,
-        kind: "leader",
-      }).catch(() => {});
-    }
-    await recordSubagentTurnForSession(cwd, {
-      sessionId,
-      threadId: childThreadId,
-      kind: "subagent",
-      ...(parentThreadId && parentThreadId !== childThreadId ? { leaderThreadId: parentThreadId } : {}),
-      // agent_type is lifecycle/routing metadata, never authority.
+  let authorityTrackingFailed = false;
+  try {
+    recordNativeSubagentAuthorityObservation(cwd, {
+      sessionIds: trackingSessionIds,
+      childThreadId,
+      parentThreadId,
+      rootNativeSessionId,
+      authorityEvidence,
+      implicatedChildThreadIds,
       mode: metadata.agentRole,
-    }).catch(() => {});
+    });
+  } catch {
+    authorityTrackingFailed = true;
   }
   refreshNativeSubagentRoleRoutingMarker(
     cwd,
@@ -509,6 +513,7 @@ async function recordNativeSubagentSessionStart(
     ...(metadata.agentNickname ? { agent_nickname: metadata.agentNickname } : {}),
     ...(metadata.agentRole ? { agent_role: metadata.agentRole } : {}),
     ...(transcriptPath ? { transcript_path: transcriptPath } : {}),
+    authority_tracking_status: authorityTrackingFailed ? "failed" : authorityEvidence,
     timestamp: new Date().toISOString(),
   }).catch(() => {});
 }
@@ -2005,24 +2010,63 @@ function shouldBuildSubagentReopenContext(options: {
   return source === "startup" || source === "resume";
 }
 
-function formatSubagentLedgerMetadata(entry: {
-  role?: string;
-  laneId?: string;
-  scope?: string;
-  status?: string;
-  lastHandoffSummary?: string;
-  resumeFailureReason?: string;
-}): string {
-  const metadata = [
-    entry.role ? `role: ${entry.role}` : null,
-    entry.laneId ? `lane: ${entry.laneId}` : null,
-    entry.scope ? `scope: ${entry.scope}` : null,
-    entry.status ? `status: ${entry.status}` : null,
-    entry.lastHandoffSummary ? `handoff: ${entry.lastHandoffSummary.slice(0, 120)}` : null,
-    entry.resumeFailureReason ? `last failure: ${entry.resumeFailureReason.slice(0, 120)}` : null,
-  ].filter((item): item is string => Boolean(item));
-  return metadata.length > 0 ? ` (${metadata.join("; ")})` : "";
+type RawSessionStartNativeId =
+  | { ok: true; value: string }
+  | { ok: false; reason: "missing" | "malformed" | "conflict" };
+
+export function readUnambiguousSessionStartNativeId(payload: CodexHookPayload | undefined): RawSessionStartNativeId {
+  if (!payload) return { ok: false, reason: "missing" };
+  const object = payload as Record<string, unknown>;
+  const hasSnake = Object.prototype.hasOwnProperty.call(object, "session_id");
+  const hasCamel = Object.prototype.hasOwnProperty.call(object, "sessionId");
+  if (!hasSnake && !hasCamel) return { ok: false, reason: "missing" };
+  const values = [
+    ...(hasSnake ? [object.session_id] : []),
+    ...(hasCamel ? [object.sessionId] : []),
+  ];
+  if (values.some((value) => typeof value !== "string" || value.trim().length === 0)) {
+    return { ok: false, reason: "malformed" };
+  }
+  const normalized = values.map((value) => (value as string).trim());
+  if (new Set(normalized).size !== 1) return { ok: false, reason: "conflict" };
+  return { ok: true, value: normalized[0]! };
 }
+
+function readSessionStartNativeCandidates(payload: CodexHookPayload | undefined): string[] {
+  if (!payload) return [];
+  const object = payload as Record<string, unknown>;
+  return [...new Set([
+    Object.prototype.hasOwnProperty.call(object, "session_id") ? object.session_id : undefined,
+    Object.prototype.hasOwnProperty.call(object, "sessionId") ? object.sessionId : undefined,
+  ].filter((value): value is string => typeof value === "string" && value.trim().length > 0).map((value) => value.trim()))];
+}
+
+export type PersistedReopenRootContextResult =
+  | { ok: true; sessionId: string; rootNativeSessionId: string }
+  | { ok: false; reason: "pointer_not_usable" | "pointer_cwd_missing" | "pointer_session_missing" | "pointer_native_root_missing" | "pointer_cwd_mismatch" | "selected_canonical_missing" | "canonical_mismatch" | "event_native_missing" | "event_native_malformed" | "event_native_conflict" | "native_root_mismatch" };
+
+export function resolvePersistedReopenRootContext(
+  cwd: string,
+  selectedCanonicalSessionId: string,
+  payload: CodexHookPayload | undefined,
+  state: SessionState | null,
+): PersistedReopenRootContextResult {
+  if (!state) return { ok: false, reason: "pointer_not_usable" };
+  if (!safeString(state.cwd).trim()) return { ok: false, reason: "pointer_cwd_missing" };
+  const pointerSessionId = safeString(state.session_id).trim();
+  if (!pointerSessionId) return { ok: false, reason: "pointer_session_missing" };
+  const pointerNativeId = safeString(state.native_session_id).trim();
+  if (!pointerNativeId) return { ok: false, reason: "pointer_native_root_missing" };
+  if (!isSessionStateAuthoritativeForCwd(state, cwd)) return { ok: false, reason: "pointer_cwd_mismatch" };
+  const canonicalSessionId = selectedCanonicalSessionId.trim();
+  if (!canonicalSessionId) return { ok: false, reason: "selected_canonical_missing" };
+  if (canonicalSessionId !== pointerSessionId) return { ok: false, reason: "canonical_mismatch" };
+  const rawNativeId = readUnambiguousSessionStartNativeId(payload);
+  if (!rawNativeId.ok) return { ok: false, reason: `event_native_${rawNativeId.reason}` };
+  if (rawNativeId.value !== pointerNativeId) return { ok: false, reason: "native_root_mismatch" };
+  return { ok: true, sessionId: pointerSessionId, rootNativeSessionId: pointerNativeId };
+}
+
 
 async function buildPersistedSubagentReopenContext(
   cwd: string,
@@ -2033,58 +2077,28 @@ async function buildPersistedSubagentReopenContext(
   },
 ): Promise<string | null> {
   if (!shouldBuildSubagentReopenContext(options)) return null;
-
-  const ledger = await readSubagentSessionLedger(cwd, sessionId).catch(() => null);
-  if (!ledger || ledger.savedSubagents.length === 0) return null;
-
-  const source = readSessionStartSource(options.payload);
-  const reopenTargets = ledger.resumeTargets.filter((entry) => entry.status !== "unavailable");
-  const unavailableTargets = ledger.unavailableSubagents;
-  const failedTargets = ledger.savedSubagents.filter((entry) => entry.resumeFailedAt || entry.resumeFailureReason);
-  const nowIso = new Date().toISOString();
-
-  await Promise.all(reopenTargets.map((entry) => recordSubagentTurnForSession(cwd, {
+  const pointerContext = resolveSessionPointerContext(cwd);
+  const pointer = await readSessionPointer(pointerContext);
+  const rootContext = resolvePersistedReopenRootContext(
+    cwd,
     sessionId,
-    threadId: entry.threadId,
-    kind: "subagent",
-    role: entry.role,
-    laneId: entry.laneId,
-    scope: entry.scope,
-    agentNickname: entry.agentNickname,
-    status: entry.status,
-    resumeRequestedAt: nowIso,
-    preserveCompletionEvidence: true,
-  }).catch(() => null)));
-
-  const lines = [
-    "[Persisted subagent reopen]",
-    `- SessionStart source: ${source}; saved subagent ids found: ${ledger.savedSubagents.length}.`,
-  ];
-
-  if (reopenTargets.length > 0) {
-    lines.push("- Reopen these persisted subagents by id before continuing work or spawning any same-role/same-lane replacement:");
-    for (const entry of reopenTargets.slice(0, 12)) {
-      lines.push(`  - resume_agent(${JSON.stringify(entry.agentId)})${formatSubagentLedgerMetadata(entry)}`);
-    }
-    if (reopenTargets.length > 12) {
-      lines.push(`  - ... ${reopenTargets.length - 12} more saved subagent id(s) omitted from this compact SessionStart context; consult .omx/state/subagent-tracking.json before spawning replacements.`);
-    }
-  } else {
-    lines.push("- No compatible saved subagent id is currently marked reopenable; do not spawn a replacement merely because reopen was unavailable.");
+    options.payload,
+    pointer.status === "usable" ? pointer.state ?? null : null,
+  );
+  if (!rootContext.ok) return null;
+  try {
+    return consumeDirectChildReopenContext(cwd, {
+      sessionId: rootContext.sessionId,
+      rootNativeSessionId: rootContext.rootNativeSessionId,
+      source: readSessionStartSource(options.payload),
+    });
+  } catch {
+    return [
+      "[Persisted subagent reopen]",
+      "- Warning: persisted subagent authority could not be evaluated; no resume authority or bookkeeping was granted.",
+      "- Silver rule: do not spawn a same-role/same-lane replacement solely because persisted reopen was unavailable; continue in the root or another compatible existing lane.",
+    ].join("\n");
   }
-
-  lines.push("- Silver rule: when follow-up work targets an existing role/lane, reuse the matching reopened id; avoid duplicate same-type subagent spawns.");
-  lines.push("- If resume_agent fails, surface a clear warning with the id and reason, then continue in the root or another compatible existing lane; do not spawn a new agent solely because reopen failed.");
-
-  const warningEntries = [...new Map([...unavailableTargets, ...failedTargets].map((entry) => [entry.agentId, entry])).values()];
-  if (warningEntries.length > 0) {
-    lines.push("- Reopen warnings:");
-    for (const entry of warningEntries.slice(0, 8)) {
-      lines.push(`  - ${entry.agentId}${formatSubagentLedgerMetadata(entry)}`);
-    }
-  }
-
-  return lines.join("\n");
 }
 
 async function buildSessionStartContext(
@@ -20193,9 +20207,15 @@ export async function dispatchCodexNativeHook(
   const candidateWorkerPayloadSessionId = declaredTeamWorker
     ? readUnambiguousNormalizedPayloadSessionId(payload)
     : "";
+  const sessionStartNativeCandidates = hookEventName === "SessionStart"
+    ? readSessionStartNativeCandidates(payload)
+    : [];
   const nativeSessionId = declaredTeamWorker
     ? candidateWorkerPayloadSessionId
-    : safeString(payload.session_id ?? payload.sessionId).trim();
+    : sessionStartNativeCandidates[0] ?? safeString(payload.session_id ?? payload.sessionId).trim();
+  const sessionStartTranscriptPath = hookEventName === "SessionStart"
+    ? safeString(payload.transcript_path ?? payload.transcriptPath).trim()
+    : "";
   const threadId = safeString(payload.thread_id ?? payload.threadId).trim();
   const turnId = safeString(payload.turn_id ?? payload.turnId).trim();
   const pointer = await readSessionPointer(pointerContext);
@@ -20252,9 +20272,15 @@ export async function dispatchCodexNativeHook(
     resolvedNativeSessionId = nativeSessionId;
     skipCanonicalSessionStartContext = true;
     allowImplicitSessionSideEffects = false;
-  } else if (hookEventName === "SessionStart" && nativeSessionId) {
-    const transcriptPath = safeString(payload.transcript_path ?? payload.transcriptPath).trim();
+  } else if (hookEventName === "SessionStart" && (nativeSessionId || readNativeSubagentSessionStartMetadata(sessionStartTranscriptPath))) {
+    const transcriptPath = sessionStartTranscriptPath;
     const subagentSessionStart = readNativeSubagentSessionStartMetadata(transcriptPath);
+    const eventChildIdentity = readUnambiguousSessionStartNativeId(payload);
+    const implicatedChildThreadIds = [...new Set([
+      nativeSessionId,
+      subagentSessionStart?.childSessionId ?? "",
+      ...readSessionStartNativeCandidates(payload),
+    ].filter(Boolean))];
     if (subagentSessionStart) {
       // A native child/subagent SessionStart carries a parent_thread_id in its
       // transcript session_meta. Treat it as a child-agent lifecycle event for
@@ -20278,11 +20304,28 @@ export async function dispatchCodexNativeHook(
             nativeSessionId,
             subagentSessionStart,
             transcriptPath,
+            eventChildIdentity.ok
+              && eventChildIdentity.value === nativeSessionId
+              && subagentSessionStart.childSessionId === nativeSessionId
+              ? safeString(currentSessionState?.native_session_id).trim()
+              : "",
+            eventChildIdentity.ok
+              && eventChildIdentity.value === nativeSessionId
+              && subagentSessionStart.childSessionId === nativeSessionId
+              && safeString(currentSessionState?.native_session_id).trim()
+              ? "valid"
+              : "untrusted",
+            implicatedChildThreadIds,
           );
         } else {
           skipCanonicalSessionStartContext = true;
           resolvedNativeSessionId =
             safeString(currentSessionState?.native_session_id).trim() || nativeSessionId;
+          try {
+            revokeNativeSubagentAuthorities(cwd, implicatedChildThreadIds, "foreign_parent");
+          } catch {
+            // Authority revocation remains fail-closed and must not promote this child.
+          }
           await recordIgnoredNativeSubagentSessionStart(
             cwd,
             canonicalSessionId,
@@ -20304,6 +20347,9 @@ export async function dispatchCodexNativeHook(
           nativeSessionId,
           subagentSessionStart,
           transcriptPath,
+          "",
+          "absent",
+          implicatedChildThreadIds,
         );
       }
     } else if (declaredTeamWorker) {

--- a/src/subagents/__tests__/tracker.test.ts
+++ b/src/subagents/__tests__/tracker.test.ts
@@ -430,6 +430,97 @@ describe('subagents/tracker', () => {
     }
   });
 
+  it('keeps a legacy plain canonical-key collision as ambiguous without revocation or reclassification', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-legacy-collision-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: { canonical: { session_id: 'canonical', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+        canonical: { thread_id: 'canonical', kind: 'subagent', resume_requested_at: '2026-07-23T00:02:00.000Z', status: 'closed', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+      } } } }));
+      const context = consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '';
+      assert.doesNotMatch(context, /resume_agent\("canonical"\)/);
+      const persisted = JSON.parse(readFileSync(path, 'utf8'));
+      assert.equal(persisted.sessions.canonical.threads.canonical.kind, 'subagent');
+      assert.equal(persisted.sessions.canonical.threads.canonical.reopen_authority_revoked, undefined);
+      assert.equal(persisted.sessions.canonical.threads.canonical.resume_requested_at, undefined);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies an adapted peer view recorded with leader kind', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-adapted-leader-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      const attested = { thread_id: 'child', kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'root', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 };
+      writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: {
+        canonical: { session_id: 'canonical', updated_at: '2026-07-23T00:00:00.000Z', threads: { child: attested } },
+        correlation: { session_id: 'correlation', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+          child: { thread_id: 'child', kind: 'leader', provenance_kind: DESCRIPTIVE_ADAPTED_PROVENANCE, status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+        } },
+      } }));
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies an adapted peer view colliding with the session leader boundary', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-adapted-leader-boundary-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      const attested = { thread_id: 'child', kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'root', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 };
+      writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: {
+        canonical: { session_id: 'canonical', updated_at: '2026-07-23T00:00:00.000Z', threads: { child: attested } },
+        correlation: { session_id: 'correlation', leader_thread_id: 'child', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+          child: { thread_id: 'child', kind: 'subagent', provenance_kind: DESCRIPTIVE_ADAPTED_PROVENANCE, status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+        } },
+      } }));
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the legacy notice silent when an authority-bearing denial is present in another partition', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-mixed-notice-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: {
+        canonical: { session_id: 'canonical', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+          legacy: { thread_id: 'legacy', kind: 'subagent', provenance_kind: DESCRIPTIVE_ADAPTED_PROVENANCE, status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+        } },
+        correlation: { session_id: 'correlation', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+          legacy: { thread_id: 'legacy', kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'root', reopen_authority_revoked: true, status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+        } },
+      } }));
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects malformed proposed state in the generic writer even without an existing tracker', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-malformed-proposed-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      const malformedProposed = { schemaVersion: 1, sessions: { root: { session_id: 'root', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+        child: { thread_id: 'child', kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'root', reopen_authority_revoked: 'false', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+      } } } };
+      await assert.rejects(writeSubagentTrackingState(cwd, malformedProposed as never));
+      assert.equal(existsSync(path), false);
+      const validState = recordSubagentTurn(createSubagentTrackingState(), { sessionId: 'root', threadId: 'child', kind: 'subagent' });
+      await writeSubagentTrackingState(cwd, validState);
+      assert.equal(existsSync(path), true);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('repairs a root inversion even when the canonical tracker partition is missing', () => {
     const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-native-only-repair-'));
     try {

--- a/src/subagents/__tests__/tracker.test.ts
+++ b/src/subagents/__tests__/tracker.test.ts
@@ -5,7 +5,7 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { hostname, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
-import { __setCrossProcessPublishBarrierForTest, __setCrossProcessQuarantineBarrierForTest, consumeDirectChildReopenContext, CrossProcessLockLostError, buildSubagentResumeLedger, CROSS_PROCESS_LOCK_ARTIFACT_SWEEP_CAP, CROSS_PROCESS_LOCK_LEASE_MS, createSubagentTrackingState, crossProcessLockPath, DESCRIPTIVE_ADAPTED_PROVENANCE, fenceNativeSubagentAuthorities, recordNativeSubagentAuthorityObservation, recordSubagentTurn, recordSubagentTurnForSession, NATIVE_SUBAGENT_PROVENANCE, readProcessStartIdentity, readSubagentTrackingState, readSubagentTrackingStateStrict, repairPersistedRootIdentity, revokeNativeSubagentAuthorities, selectReusableSubagentEntry, subagentTrackingPath, summarizeSubagentSession, withCrossProcessFileLockSync, writeSubagentTrackingState } from '../tracker.js';
+import { __setCrossProcessPublishBarrierForTest, __setCrossProcessQuarantineBarrierForTest, consumeDirectChildReopenContext, CrossProcessLockLostError, buildSubagentResumeLedger, CROSS_PROCESS_LOCK_ARTIFACT_SWEEP_CAP, CROSS_PROCESS_LOCK_LEASE_MS, createSubagentTrackingState, crossProcessLockPath, DESCRIPTIVE_ADAPTED_PROVENANCE, fenceNativeSubagentAuthorities, forceGlobalAuthorityDenial, recordNativeSubagentAuthorityObservation, recordSubagentTurn, recordSubagentTurnForSession, NATIVE_SUBAGENT_PROVENANCE, readProcessStartIdentity, readSubagentTrackingState, readSubagentTrackingStateStrict, repairPersistedRootIdentity, revokeNativeSubagentAuthorities, selectReusableSubagentEntry, subagentTrackingPath, summarizeSubagentSession, withCrossProcessFileLockSync, writeSubagentTrackingState } from '../tracker.js';
 import { NATIVE_SUBAGENT_ROLE_ROUTING_MARKER_FILE, readRoleRoutingMarker, writeRoleRoutingMarker } from '../role-routing-marker.js';
 
 const CROSS_PROCESS_LOCK_HOLDER_SOURCE = `
@@ -669,6 +669,48 @@ describe('subagents/tracker', () => {
       minted.sessions.canonical!.threads.child!.direct_child_parent_id = 'root';
       await assert.rejects(writeSubagentTrackingState(cwd, minted), /Stale subagent tracker authority state/);
       assert.equal(existsSync(subagentTrackingPath(cwd)), false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('lets a fresh generic write set a descriptive leader_thread_id but never mint authority', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-mint-leader-'));
+    try {
+      // leader_thread_id alone is descriptive lifecycle data that legitimate
+      // first writers set; it never makes a thread an eligible reopen target.
+      const descriptive = recordSubagentTurn(createSubagentTrackingState(), { sessionId: 'canonical', threadId: 'child', kind: 'subagent', leaderThreadId: 'thread-leader' });
+      await writeSubagentTrackingState(cwd, descriptive);
+      assert.doesNotMatch(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '', /resume_agent\(/);
+      // Attaching attestation to that same fresh create is refused.
+      rmSync(subagentTrackingPath(cwd), { force: true });
+      const minted = recordSubagentTurn(createSubagentTrackingState(), { sessionId: 'canonical', threadId: 'child', kind: 'subagent', leaderThreadId: 'thread-leader' });
+      minted.sessions.canonical!.threads.child!.provenance_kind = NATIVE_SUBAGENT_PROVENANCE;
+      minted.sessions.canonical!.threads.child!.direct_child_root_id = 'root';
+      minted.sessions.canonical!.threads.child!.direct_child_parent_id = 'root';
+      await assert.rejects(writeSubagentTrackingState(cwd, minted), /Stale subagent tracker authority state/);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies every reopen target after a forced global authority denial', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-global-denial-'));
+    try {
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence: 'valid' });
+      assert.match(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '', /resume_agent\("child"\)/);
+      // Simulates both the tracker revocation AND the locked fence failing.
+      assert.equal(forceGlobalAuthorityDenial(cwd, 'identity_untrusted_denial_escalated'), true);
+      assert.match(
+        consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '',
+        /unreadable_authority_fence/,
+      );
+      // The escalated denial survives an unrelated successful revocation.
+      revokeNativeSubagentAuthorities(cwd, ['other'], 'identity_untrusted');
+      assert.match(
+        consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '',
+        /unreadable_authority_fence/,
+      );
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }

--- a/src/subagents/__tests__/tracker.test.ts
+++ b/src/subagents/__tests__/tracker.test.ts
@@ -5,7 +5,7 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { hostname, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
-import { __setCrossProcessPublishBarrierForTest, __setCrossProcessQuarantineBarrierForTest, consumeDirectChildReopenContext, CrossProcessLockLostError, buildSubagentResumeLedger, CROSS_PROCESS_LOCK_ARTIFACT_SWEEP_CAP, CROSS_PROCESS_LOCK_LEASE_MS, createSubagentTrackingState, crossProcessLockPath, recordNativeSubagentAuthorityObservation, recordSubagentTurn, recordSubagentTurnForSession, NATIVE_SUBAGENT_PROVENANCE, readProcessStartIdentity, selectReusableSubagentEntry, subagentTrackingPath, summarizeSubagentSession, withCrossProcessFileLockSync } from '../tracker.js';
+import { __setCrossProcessPublishBarrierForTest, __setCrossProcessQuarantineBarrierForTest, consumeDirectChildReopenContext, CrossProcessLockLostError, buildSubagentResumeLedger, CROSS_PROCESS_LOCK_ARTIFACT_SWEEP_CAP, CROSS_PROCESS_LOCK_LEASE_MS, createSubagentTrackingState, crossProcessLockPath, DESCRIPTIVE_ADAPTED_PROVENANCE, recordNativeSubagentAuthorityObservation, recordSubagentTurn, recordSubagentTurnForSession, NATIVE_SUBAGENT_PROVENANCE, readProcessStartIdentity, readSubagentTrackingStateStrict, repairPersistedRootIdentity, selectReusableSubagentEntry, subagentTrackingPath, summarizeSubagentSession, withCrossProcessFileLockSync, writeSubagentTrackingState } from '../tracker.js';
 import { NATIVE_SUBAGENT_ROLE_ROUTING_MARKER_FILE, readRoleRoutingMarker, writeRoleRoutingMarker } from '../role-routing-marker.js';
 
 const CROSS_PROCESS_LOCK_HOLDER_SOURCE = `
@@ -369,6 +369,120 @@ describe('subagents/tracker', () => {
     }
   });
 
+  it('ignores a same-child adapted legacy peer when validating a newly attested child', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-adapted-peer-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: {
+        correlation: { session_id: 'correlation', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+          child: { thread_id: 'child', kind: 'subagent', provenance_kind: DESCRIPTIVE_ADAPTED_PROVENANCE, status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+        } },
+      } }));
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence: 'valid' });
+      const context = consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '';
+      assert.match(context, /resume_agent\("child"\)/);
+      const persisted = JSON.parse(readFileSync(path, 'utf8'));
+      assert.equal(persisted.sessions.correlation.threads.child.provenance_kind, DESCRIPTIVE_ADAPTED_PROVENANCE);
+      assert.equal(persisted.sessions.correlation.threads.child.direct_child_root_id, undefined);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the generic shared writer fail closed on malformed authority bytes', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-generic-writer-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      const raw = JSON.stringify({ schemaVersion: 1, sessions: { root: { session_id: 'root', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+        child: { thread_id: 'child', kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'root', reopen_authority_revoked: 'false', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+      } } } });
+      writeFileSync(path, raw);
+      const strict = await readSubagentTrackingStateStrict(cwd);
+      assert.equal(strict.ok, false);
+      const tolerantState = createSubagentTrackingState();
+      await assert.rejects(writeSubagentTrackingState(cwd, tolerantState));
+      assert.equal(readFileSync(path, 'utf8'), raw);
+      assert.match(consumeDirectChildReopenContext(cwd, { sessionId: 'root', rootNativeSessionId: 'root', source: 'resume' }) ?? '', /malformed_tracker_state/);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies a canonical-key-colliding attested child without destructive reclassification', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-canonical-collision-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: { canonical: { session_id: 'canonical', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+        canonical: { thread_id: 'canonical', kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'root', resume_requested_at: '2026-07-23T00:02:00.000Z', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+      } } } }));
+      const context = consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '';
+      assert.doesNotMatch(context, /resume_agent\("canonical"\)/);
+      const persisted = JSON.parse(readFileSync(path, 'utf8'));
+      assert.equal(persisted.sessions.canonical.threads.canonical.kind, 'subagent');
+      assert.equal(persisted.sessions.canonical.threads.canonical.reopen_authority_revoked, true);
+      assert.equal(persisted.sessions.canonical.threads.canonical.reopen_authority_conflict_reason, 'canonical_root_collision');
+      assert.equal(persisted.sessions.canonical.threads.canonical.resume_requested_at, undefined);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('repairs a root inversion even when the canonical tracker partition is missing', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-native-only-repair-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: { root: { session_id: 'root', leader_thread_id: 'turn-like-foreign', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+        root: { thread_id: 'root', kind: 'subagent', status: 'closed', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+      } } } }));
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+      const persisted = JSON.parse(readFileSync(path, 'utf8'));
+      assert.equal(persisted.sessions.root.threads.root.kind, 'leader');
+      assert.equal(persisted.sessions.root.leader_thread_id, 'root');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('repairs a root inversion through the decoupled repair entrypoint', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-decoupled-repair-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: { root: { session_id: 'root', leader_thread_id: 'turn-like-foreign', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+        root: { thread_id: 'root', kind: 'subagent', status: 'closed', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+      } } } }));
+      assert.equal(repairPersistedRootIdentity(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root' }), true);
+      const persisted = JSON.parse(readFileSync(path, 'utf8'));
+      assert.equal(persisted.sessions.root.threads.root.kind, 'leader');
+      assert.equal(persisted.sessions.root.leader_thread_id, 'root');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('surfaces an explicit notice when only legacy non-authoritative records are excluded', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-legacy-notice-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: { canonical: { session_id: 'canonical', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+        legacy: { thread_id: 'legacy', kind: 'subagent', provenance_kind: DESCRIPTIVE_ADAPTED_PROVENANCE, status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+      } } } }));
+      const context = consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '';
+      assert.match(context, /\[Persisted subagent reopen\]/);
+      assert.match(context, /excluded as non-authoritative or legacy/);
+      assert.doesNotMatch(context, /resume_agent\(/);
+      const persisted = JSON.parse(readFileSync(path, 'utf8'));
+      assert.equal(persisted.sessions.canonical.threads.legacy.resume_requested_at, undefined);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('prevents descriptive writers from normalizing malformed authority into reopen access', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-shared-writer-'));
     try {
@@ -518,7 +632,11 @@ describe('subagents/tracker', () => {
         recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence });
         const state = JSON.parse(readFileSync(subagentTrackingPath(cwd), 'utf8'));
         assert.equal(state.sessions.canonical.threads.child.direct_child_root_id, undefined);
-        assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+        const context = consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '';
+        // Fail-closed denial: no authority, no bookkeeping, no resume output. An
+        // explicit exclusion notice is allowed in place of a bare null.
+        assert.doesNotMatch(context, /resume_agent\(/);
+        assert.equal(JSON.parse(readFileSync(subagentTrackingPath(cwd), 'utf8')).sessions.canonical.threads.child.resume_requested_at, undefined);
       } finally {
         rmSync(cwd, { recursive: true, force: true });
       }

--- a/src/subagents/__tests__/tracker.test.ts
+++ b/src/subagents/__tests__/tracker.test.ts
@@ -5,7 +5,7 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { hostname, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
-import { __setCrossProcessPublishBarrierForTest, __setCrossProcessQuarantineBarrierForTest, consumeDirectChildReopenContext, CrossProcessLockLostError, buildSubagentResumeLedger, CROSS_PROCESS_LOCK_ARTIFACT_SWEEP_CAP, CROSS_PROCESS_LOCK_LEASE_MS, createSubagentTrackingState, crossProcessLockPath, DESCRIPTIVE_ADAPTED_PROVENANCE, recordNativeSubagentAuthorityObservation, recordSubagentTurn, recordSubagentTurnForSession, NATIVE_SUBAGENT_PROVENANCE, readProcessStartIdentity, readSubagentTrackingStateStrict, repairPersistedRootIdentity, selectReusableSubagentEntry, subagentTrackingPath, summarizeSubagentSession, withCrossProcessFileLockSync, writeSubagentTrackingState } from '../tracker.js';
+import { __setCrossProcessPublishBarrierForTest, __setCrossProcessQuarantineBarrierForTest, consumeDirectChildReopenContext, CrossProcessLockLostError, buildSubagentResumeLedger, CROSS_PROCESS_LOCK_ARTIFACT_SWEEP_CAP, CROSS_PROCESS_LOCK_LEASE_MS, createSubagentTrackingState, crossProcessLockPath, DESCRIPTIVE_ADAPTED_PROVENANCE, fenceNativeSubagentAuthorities, recordNativeSubagentAuthorityObservation, recordSubagentTurn, recordSubagentTurnForSession, NATIVE_SUBAGENT_PROVENANCE, readProcessStartIdentity, readSubagentTrackingState, readSubagentTrackingStateStrict, repairPersistedRootIdentity, revokeNativeSubagentAuthorities, selectReusableSubagentEntry, subagentTrackingPath, summarizeSubagentSession, withCrossProcessFileLockSync, writeSubagentTrackingState } from '../tracker.js';
 import { NATIVE_SUBAGENT_ROLE_ROUTING_MARKER_FILE, readRoleRoutingMarker, writeRoleRoutingMarker } from '../role-routing-marker.js';
 
 const CROSS_PROCESS_LOCK_HOLDER_SOURCE = `
@@ -516,6 +516,118 @@ describe('subagents/tracker', () => {
       const validState = recordSubagentTurn(createSubagentTrackingState(), { sessionId: 'root', threadId: 'child', kind: 'subagent' });
       await writeSubagentTrackingState(cwd, validState);
       assert.equal(existsSync(path), true);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses a stale generic write that would roll back a newer authority revocation', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-stale-generic-write-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence: 'valid' });
+      // A descriptive caller snapshots the tracker outside the lock.
+      const stale = await readSubagentTrackingState(cwd);
+      // A competing negative observation revokes that authority.
+      revokeNativeSubagentAuthorities(cwd, ['child'], 'foreign_parent');
+      assert.equal(JSON.parse(readFileSync(path, 'utf8')).sessions.canonical.threads.child.reopen_authority_revoked, true);
+      // Publishing the stale snapshot must not resurrect the revoked authority.
+      await assert.rejects(writeSubagentTrackingState(cwd, stale), /Stale subagent tracker authority state/);
+      const persisted = JSON.parse(readFileSync(path, 'utf8'));
+      assert.equal(persisted.sessions.canonical.threads.child.reopen_authority_revoked, true);
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('still allows a descriptive generic write when authority has not moved', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-descriptive-write-ok-'));
+    try {
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence: 'valid' });
+      const snapshot = await readSubagentTrackingState(cwd);
+      const descriptive = recordSubagentTurn(snapshot, { sessionId: 'canonical', threadId: 'child', kind: 'subagent' });
+      await writeSubagentTrackingState(cwd, descriptive);
+      assert.match(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '', /resume_agent\("child"\)/);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves an uncorrelated partition untouched when a thread id collides with the canonical key', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-uncorrelated-collision-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: {
+        canonical: { session_id: 'canonical', updated_at: '2026-07-23T00:00:00.000Z', threads: {} },
+        unrelated: { session_id: 'unrelated', leader_thread_id: 'foreign-root', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+          canonical: { thread_id: 'canonical', kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'foreign-root', direct_child_parent_id: 'foreign-root', resume_requested_at: '2026-07-23T00:02:00.000Z', resume_completed_at: '2026-07-23T00:03:00.000Z', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+        } },
+      } }));
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+      const persisted = JSON.parse(readFileSync(path, 'utf8'));
+      const foreignChild = persisted.sessions.unrelated.threads.canonical;
+      assert.equal(foreignChild.reopen_authority_revoked, undefined);
+      assert.equal(foreignChild.reopen_authority_conflict_reason, undefined);
+      assert.equal(foreignChild.direct_child_root_id, 'foreign-root');
+      assert.equal(foreignChild.resume_requested_at, '2026-07-23T00:02:00.000Z');
+      assert.equal(foreignChild.resume_completed_at, '2026-07-23T00:03:00.000Z');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('still quarantines a canonical-key collision inside a correlated partition', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-correlated-collision-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: {
+        correlated: { session_id: 'correlated', leader_thread_id: 'root', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+          root: { thread_id: 'root', kind: 'leader', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+          canonical: { thread_id: 'canonical', kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'root', resume_requested_at: '2026-07-23T00:02:00.000Z', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+        } },
+      } }));
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+      const collided = JSON.parse(readFileSync(path, 'utf8')).sessions.correlated.threads.canonical;
+      assert.equal(collided.kind, 'subagent');
+      assert.equal(collided.reopen_authority_revoked, true);
+      assert.equal(collided.reopen_authority_conflict_reason, 'canonical_root_collision');
+      assert.equal(collided.resume_requested_at, undefined);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps authority denied when a revocation could not be published', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-authority-fence-'));
+    try {
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence: 'valid' });
+      assert.match(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '', /resume_agent\("child"\)/);
+      // Simulate a revocation whose transaction failed: the tracker still shows
+      // valid authority, but the fence records the unpublished denial.
+      fenceNativeSubagentAuthorities(cwd, ['child'], 'identity_untrusted_revocation_failed');
+      assert.equal(JSON.parse(readFileSync(subagentTrackingPath(cwd), 'utf8')).sessions.canonical.threads.child.reopen_authority_revoked, undefined);
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+      // Once the revocation is durably applied, the fence is released.
+      revokeNativeSubagentAuthorities(cwd, ['child'], 'identity_untrusted');
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+      assert.equal(JSON.parse(readFileSync(subagentTrackingPath(cwd), 'utf8')).sessions.canonical.threads.child.reopen_authority_revoked, true);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed for every id when the authority fence is unreadable', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-fence-unreadable-'));
+    try {
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence: 'valid' });
+      writeFileSync(`${subagentTrackingPath(cwd)}.authority-fence.json`, '{ not json');
+      assert.match(
+        consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '',
+        /unreadable_authority_fence/,
+      );
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }

--- a/src/subagents/__tests__/tracker.test.ts
+++ b/src/subagents/__tests__/tracker.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { hostname, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
-import { __setCrossProcessPublishBarrierForTest, __setCrossProcessQuarantineBarrierForTest, CrossProcessLockLostError, buildSubagentResumeLedger, CROSS_PROCESS_LOCK_ARTIFACT_SWEEP_CAP, CROSS_PROCESS_LOCK_LEASE_MS, createSubagentTrackingState, crossProcessLockPath, recordSubagentTurn, NATIVE_SUBAGENT_PROVENANCE, readProcessStartIdentity, selectReusableSubagentEntry, summarizeSubagentSession, withCrossProcessFileLockSync } from '../tracker.js';
+import { __setCrossProcessPublishBarrierForTest, __setCrossProcessQuarantineBarrierForTest, consumeDirectChildReopenContext, CrossProcessLockLostError, buildSubagentResumeLedger, CROSS_PROCESS_LOCK_ARTIFACT_SWEEP_CAP, CROSS_PROCESS_LOCK_LEASE_MS, createSubagentTrackingState, crossProcessLockPath, recordNativeSubagentAuthorityObservation, recordSubagentTurn, recordSubagentTurnForSession, NATIVE_SUBAGENT_PROVENANCE, readProcessStartIdentity, selectReusableSubagentEntry, subagentTrackingPath, summarizeSubagentSession, withCrossProcessFileLockSync } from '../tracker.js';
 import { NATIVE_SUBAGENT_ROLE_ROUTING_MARKER_FILE, readRoleRoutingMarker, writeRoleRoutingMarker } from '../role-routing-marker.js';
 
 const CROSS_PROCESS_LOCK_HOLDER_SOURCE = `
@@ -27,6 +27,46 @@ const CROSS_PROCESS_LOCK_HOLDER_SOURCE = `
     }
   });
 `;
+
+const AUTHORITY_COMPETITOR_SOURCE = `
+  const tracker = await import(process.env.OMX_TRACKER_MODULE_URL ?? '');
+  const { writeFileSync } = await import('node:fs');
+  const cwd = process.env.OMX_AUTHORITY_CWD ?? '';
+  const readyPath = process.env.OMX_AUTHORITY_READY_PATH ?? '';
+  const resultPath = process.env.OMX_AUTHORITY_RESULT_PATH ?? '';
+  const operation = process.env.OMX_AUTHORITY_OPERATION ?? '';
+  const waitArray = new Int32Array(new SharedArrayBuffer(4));
+  let observedContention = false;
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    try {
+      const result = operation === 'reopen'
+        ? tracker.consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' })
+        : tracker.recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'other-root'], childThreadId: 'child', parentThreadId: 'other-root', rootNativeSessionId: 'other-root', authorityEvidence: 'valid' });
+      writeFileSync(resultPath, JSON.stringify({ observedContention, result: operation === 'reopen' ? result : 'revoked' }));
+      process.exit(0);
+    } catch {
+      if (!observedContention) {
+        observedContention = true;
+        writeFileSync(readyPath, 'contended\\n');
+      }
+      Atomics.wait(waitArray, 0, 0, 25);
+    }
+  }
+  throw new Error('Authority competitor never acquired the released lock');
+`;
+
+function spawnAuthorityCompetitor(cwd: string, operation: 'reopen' | 'revoke', readyPath: string, resultPath: string) {
+  return spawn(process.execPath, ['--input-type=module', '--eval', AUTHORITY_COMPETITOR_SOURCE], {
+    env: {
+      ...process.env,
+      OMX_TRACKER_MODULE_URL: new URL('../tracker.js', import.meta.url).href,
+      OMX_AUTHORITY_CWD: cwd,
+      OMX_AUTHORITY_OPERATION: operation,
+      OMX_AUTHORITY_READY_PATH: readyPath,
+      OMX_AUTHORITY_RESULT_PATH: resultPath,
+    },
+  });
+}
 
 function crossProcessLockClaim(
   token: string,
@@ -146,6 +186,343 @@ describe('subagents/tracker', () => {
       activeWindowMs: 60_000,
     });
     assert.deepEqual(drained?.activeSubagentThreadIds, []);
+  });
+
+  it('authorizes only attested direct children for persisted reopen', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-authority-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: { root: { session_id: 'root', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+        root: { thread_id: 'root', kind: 'subagent', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+        direct: { thread_id: 'direct', kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'root', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+        nested: { thread_id: 'nested', kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'direct', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+        revoked: { thread_id: 'revoked', kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'root', reopen_authority_revoked: true, status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+      } } } }));
+      const context = consumeDirectChildReopenContext(cwd, { sessionId: 'root', rootNativeSessionId: 'root', source: 'resume' }) ?? '';
+      assert.match(context, /resume_agent\("direct"\)/);
+      assert.doesNotMatch(context, /resume_agent\("root"\)|resume_agent\("nested"\)|resume_agent\("revoked"\)/);
+      const persisted = JSON.parse(readFileSync(path, 'utf8'));
+      assert.match(persisted.sessions.root.threads.direct.resume_requested_at, /^\d{4}-\d{2}-\d{2}T/);
+      assert.equal(persisted.sessions.root.threads.root.resume_requested_at, undefined);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('atomically revokes conflicting direct-child authority across correlation records', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-conflict-'));
+    try {
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root-a'], childThreadId: 'child', parentThreadId: 'root-a', rootNativeSessionId: 'root-a' });
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root-b'], childThreadId: 'child', parentThreadId: 'root-b', rootNativeSessionId: 'root-b' });
+      const state = JSON.parse(readFileSync(subagentTrackingPath(cwd), 'utf8'));
+      assert.equal(state.sessions.canonical.threads.child.reopen_authority_revoked, true);
+      assert.equal(state.sessions['root-a'].threads.child.reopen_authority_revoked, true);
+      assert.equal(state.sessions['root-b'].threads.child.reopen_authority_revoked, true);
+      assert.equal(state.sessions.canonical.threads.child.reopen_authority_conflict_reason, 'root_or_parent_mismatch');
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root-a'], childThreadId: 'child', parentThreadId: 'root-a', rootNativeSessionId: 'root-a' });
+      const repaired = JSON.parse(readFileSync(subagentTrackingPath(cwd), 'utf8'));
+      assert.equal(repaired.sessions.canonical.threads.child.reopen_authority_revoked, undefined);
+      assert.equal(repaired.sessions['root-a'].threads.child.reopen_authority_revoked, undefined);
+      assert.match(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root-a', source: 'resume' }) ?? '', /resume_agent\("child"\)/);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps malformed tracker bytes unchanged across authority reads and writes', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-malformed-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      const malformed = '{not-json\n';
+      writeFileSync(path, malformed);
+      assert.throws(() => recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root' }));
+      assert.match(consumeDirectChildReopenContext(cwd, { sessionId: 'root', rootNativeSessionId: 'root', source: 'resume' }) ?? '', /malformed_tracker_state/);
+      assert.equal(readFileSync(path, 'utf8'), malformed);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies a leader-colliding attested child without bookkeeping', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-leader-collision-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: { root: { session_id: 'root', leader_thread_id: 'child', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+        child: { thread_id: 'child', kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'root', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+      } } } }));
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'root', rootNativeSessionId: 'root', source: 'resume' }), null);
+      const state = JSON.parse(readFileSync(path, 'utf8'));
+      assert.equal(state.sessions.root.threads.child.resume_requested_at, undefined);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies malformed valid-JSON authority evidence without rewriting bytes', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-malformed-authority-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      const raw = JSON.stringify({ schemaVersion: 1, sessions: { root: { session_id: 'root', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+        child: { thread_id: 'child', kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'root', reopen_authority_revoked: 'false', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+      } } } });
+      writeFileSync(path, raw);
+      assert.match(consumeDirectChildReopenContext(cwd, { sessionId: 'root', rootNativeSessionId: 'root', source: 'resume' }) ?? '', /malformed_tracker_state/);
+      assert.equal(readFileSync(path, 'utf8'), raw);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies malformed status authority evidence without rewriting bytes', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-malformed-status-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      const raw = JSON.stringify({ schemaVersion: 1, sessions: { root: { session_id: 'root', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+        child: { thread_id: 'child', kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'root', status: 'bogus', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+      } } } });
+      writeFileSync(path, raw);
+      assert.match(consumeDirectChildReopenContext(cwd, { sessionId: 'root', rootNativeSessionId: 'root', source: 'resume' }) ?? '', /malformed_tracker_state/);
+      assert.equal(readFileSync(path, 'utf8'), raw);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies an unattested descriptive correlation view', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-partial-correlation-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      const common = { thread_id: 'child', kind: 'subagent', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 };
+      writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: {
+        canonical: { session_id: 'canonical', updated_at: '2026-07-23T00:00:00.000Z', threads: { child: { ...common, provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'root' } } },
+        correlation: { session_id: 'correlation', updated_at: '2026-07-23T00:00:00.000Z', threads: { child: common } },
+      } }));
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies cross-partition authority disagreement', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-partition-disagreement-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      const thread = { thread_id: 'child', kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'root', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 };
+      writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: {
+        canonical: { session_id: 'canonical', updated_at: '2026-07-23T00:00:00.000Z', threads: { child: thread } },
+        correlation: { session_id: 'correlation', updated_at: '2026-07-23T00:00:00.000Z', threads: { child: { ...thread, direct_child_root_id: 'foreign', direct_child_parent_id: 'foreign' } } },
+      } }));
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves attested authority on pointerless descriptive reobservation', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-pointerless-'));
+    try {
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root' });
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root' });
+      const state = JSON.parse(readFileSync(subagentTrackingPath(cwd), 'utf8'));
+      assert.equal(state.sessions.canonical.threads.child.reopen_authority_revoked, undefined);
+      assert.match(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '', /resume_agent\("child"\)/);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('revokes cached authority after an identity-untrusted reobservation', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-untrusted-reobserve-'));
+    try {
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence: 'valid' });
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', authorityEvidence: 'untrusted' });
+      const state = JSON.parse(readFileSync(subagentTrackingPath(cwd), 'utf8'));
+      assert.equal(state.sessions.canonical.threads.child.reopen_authority_revoked, true);
+      assert.equal(state.sessions.root.threads.child.reopen_authority_revoked, true);
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('allows legacy adapted descriptive records to coexist with a newly attested child', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-legacy-coexist-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: { canonical: { session_id: 'canonical', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+        legacy: { thread_id: 'legacy', kind: 'subagent', provenance_kind: 'adapted', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+      } } } }));
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence: 'valid' });
+      const context = consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '';
+      assert.match(context, /resume_agent\("child"\)/);
+      assert.doesNotMatch(context, /resume_agent\("legacy"\)/);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('prevents descriptive writers from normalizing malformed authority into reopen access', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-shared-writer-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      const raw = JSON.stringify({ schemaVersion: 1, sessions: { root: { session_id: 'root', updated_at: '2026-07-23T00:00:00.000Z', threads: {
+        child: { thread_id: 'child', kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'root', reopen_authority_revoked: 'false', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 },
+      } } } });
+      writeFileSync(path, raw);
+      await assert.rejects(recordSubagentTurnForSession(cwd, { sessionId: 'root', threadId: 'other', kind: 'subagent' }));
+      assert.equal(readFileSync(path, 'utf8'), raw);
+      assert.match(consumeDirectChildReopenContext(cwd, { sessionId: 'root', rootNativeSessionId: 'root', source: 'resume' }) ?? '', /malformed_tracker_state/);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('counts omission caps from authorized targets and warnings only', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-caps-'));
+    try {
+      const path = subagentTrackingPath(cwd);
+      mkdirSync(join(cwd, '.omx', 'state'), { recursive: true });
+      const threads: Record<string, unknown> = {};
+      for (let index = 0; index < 14; index += 1) threads[`child-${index}`] = { thread_id: `child-${index}`, kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'root', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: `2026-07-23T00:${String(index).padStart(2, '0')}:00.000Z`, turn_count: 1 };
+      for (let index = 0; index < 10; index += 1) threads[`warning-${index}`] = { thread_id: `warning-${index}`, kind: 'subagent', provenance_kind: NATIVE_SUBAGENT_PROVENANCE, direct_child_root_id: 'root', direct_child_parent_id: 'root', status: 'unavailable', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 };
+      threads.legacy = { thread_id: 'legacy', kind: 'subagent', status: 'available', first_seen_at: '2026-07-23T00:00:00.000Z', last_seen_at: '2026-07-23T00:00:00.000Z', turn_count: 1 };
+      writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: { root: { session_id: 'root', updated_at: '2026-07-23T00:00:00.000Z', threads } } }));
+      const context = consumeDirectChildReopenContext(cwd, { sessionId: 'root', rootNativeSessionId: 'root', source: 'resume' }) ?? '';
+      assert.match(context, /2 more saved subagent id\(s\) omitted/);
+      assert.match(context, /2 more warning\(s\) omitted/);
+      assert.doesNotMatch(context, /resume_agent\("legacy"\)/);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('revokes direct-child authority when an authoritative observation moves it under a nested parent', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-direct-to-nested-'));
+    try {
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root' });
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'nested-parent'], childThreadId: 'child', parentThreadId: 'nested-parent', rootNativeSessionId: 'root' });
+      const state = JSON.parse(readFileSync(subagentTrackingPath(cwd), 'utf8'));
+      assert.equal(state.sessions.canonical.threads.child.reopen_authority_revoked, true);
+      assert.equal(state.sessions.root.threads.child.reopen_authority_revoked, true);
+      assert.equal(state.sessions['nested-parent'].threads.child.reopen_authority_revoked, true);
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('linearizes revocation before reopen as a denied operation', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-revoke-first-'));
+    try {
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root' });
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'other-root'], childThreadId: 'child', parentThreadId: 'other-root', rootNativeSessionId: 'other-root' });
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+      const state = JSON.parse(readFileSync(subagentTrackingPath(cwd), 'utf8'));
+      assert.equal(state.sessions.canonical.threads.child.resume_requested_at, undefined);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('linearizes reopen before a later revocation and denies subsequent reopen', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-reopen-first-'));
+    try {
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root' });
+      const first = consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '';
+      assert.match(first, /resume_agent\("child"\)/);
+      const requestedAt = JSON.parse(readFileSync(subagentTrackingPath(cwd), 'utf8')).sessions.canonical.threads.child.resume_requested_at;
+      assert.match(requestedAt, /^\d{4}-\d{2}-\d{2}T/);
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'other-root'], childThreadId: 'child', parentThreadId: 'other-root', rootNativeSessionId: 'other-root' });
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+      const revoked = JSON.parse(readFileSync(subagentTrackingPath(cwd), 'utf8'));
+      assert.equal(revoked.sessions.canonical.threads.child.resume_requested_at, requestedAt);
+      assert.equal(revoked.sessions.canonical.threads.child.reopen_authority_revoked, true);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('serializes a queued reopen behind revocation publication', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-contended-revoke-first-'));
+    const readyPath = join(cwd, 'reopen-contended');
+    const resultPath = join(cwd, 'reopen-result.json');
+    let competitor: ReturnType<typeof spawn> | undefined;
+    try {
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence: 'valid' });
+      __setCrossProcessPublishBarrierForTest(() => {
+        competitor = spawnAuthorityCompetitor(cwd, 'reopen', readyPath, resultPath);
+        waitForFileSync(readyPath, 10_000);
+      });
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'other-root'], childThreadId: 'child', parentThreadId: 'other-root', rootNativeSessionId: 'other-root', authorityEvidence: 'valid' });
+      __setCrossProcessPublishBarrierForTest(null);
+      assert.ok(competitor);
+      await waitForChildExit(competitor);
+      const result = JSON.parse(readFileSync(resultPath, 'utf8'));
+      assert.equal(result.observedContention, true);
+      assert.equal(result.result, null);
+      const state = JSON.parse(readFileSync(subagentTrackingPath(cwd), 'utf8'));
+      assert.equal(state.sessions.canonical.threads.child.resume_requested_at, undefined);
+      assert.equal(state.sessions.canonical.threads.child.reopen_authority_revoked, true);
+    } finally {
+      __setCrossProcessPublishBarrierForTest(null);
+      await stopChild(competitor);
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('serializes queued revocation behind completed reopen publication', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-contended-reopen-first-'));
+    const readyPath = join(cwd, 'revoke-contended');
+    const resultPath = join(cwd, 'revoke-result.json');
+    let competitor: ReturnType<typeof spawn> | undefined;
+    try {
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence: 'valid' });
+      __setCrossProcessPublishBarrierForTest(() => {
+        competitor = spawnAuthorityCompetitor(cwd, 'revoke', readyPath, resultPath);
+        waitForFileSync(readyPath, 10_000);
+      });
+      const first = consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '';
+      __setCrossProcessPublishBarrierForTest(null);
+      assert.match(first, /resume_agent\("child"\)/);
+      const requestedAt = JSON.parse(readFileSync(subagentTrackingPath(cwd), 'utf8')).sessions.canonical.threads.child.resume_requested_at;
+      assert.match(requestedAt, /^\d{4}-\d{2}-\d{2}T/);
+      assert.ok(competitor);
+      await waitForChildExit(competitor);
+      const result = JSON.parse(readFileSync(resultPath, 'utf8'));
+      assert.equal(result.observedContention, true);
+      assert.equal(result.result, 'revoked');
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+      const revoked = JSON.parse(readFileSync(subagentTrackingPath(cwd), 'utf8'));
+      assert.equal(revoked.sessions.canonical.threads.child.resume_requested_at, requestedAt);
+      assert.equal(revoked.sessions.canonical.threads.child.reopen_authority_revoked, true);
+    } finally {
+      __setCrossProcessPublishBarrierForTest(null);
+      await stopChild(competitor);
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('never grants fresh authority from absent or untrusted evidence', () => {
+    for (const authorityEvidence of ['absent', 'untrusted'] as const) {
+      const cwd = mkdtempSync(join(tmpdir(), `omx-3284-tracker-${authorityEvidence}-fresh-`));
+      try {
+        recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence });
+        const state = JSON.parse(readFileSync(subagentTrackingPath(cwd), 'utf8'));
+        assert.equal(state.sessions.canonical.threads.child.direct_child_root_id, undefined);
+        assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+      } finally {
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    }
   });
 
   it('can record an explicitly spawned subagent as subagent even when it is the first seen thread', () => {

--- a/src/subagents/__tests__/tracker.test.ts
+++ b/src/subagents/__tests__/tracker.test.ts
@@ -633,6 +633,115 @@ describe('subagents/tracker', () => {
     }
   });
 
+  it('refuses a fresh generic write that would grant or remove reopen authority', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-fresh-generic-authority-'));
+    try {
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence: 'valid' });
+      revokeNativeSubagentAuthorities(cwd, ['child'], 'foreign_parent');
+      // A FRESH read still must not let the descriptive writer lift a revocation.
+      const fresh = await readSubagentTrackingState(cwd);
+      delete fresh.sessions.canonical!.threads.child!.reopen_authority_revoked;
+      delete fresh.sessions.canonical!.threads.child!.reopen_authority_conflict_reason;
+      delete fresh.sessions.canonical!.threads.child!.reopen_authority_conflict_at;
+      await assert.rejects(writeSubagentTrackingState(cwd, fresh), /Stale subagent tracker authority state/);
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+      // A fresh read must equally not let it GRANT authority. Attaching a fresh
+      // attestation to a previously unattested thread is refused as a stale
+      // authority change rather than published.
+      const granting = await readSubagentTrackingState(cwd);
+      const plain = recordSubagentTurn(granting, { sessionId: 'canonical', threadId: 'newcomer', kind: 'subagent' });
+      plain.sessions.canonical!.threads.newcomer!.provenance_kind = NATIVE_SUBAGENT_PROVENANCE;
+      plain.sessions.canonical!.threads.newcomer!.direct_child_root_id = 'root';
+      plain.sessions.canonical!.threads.newcomer!.direct_child_parent_id = 'root';
+      await assert.rejects(writeSubagentTrackingState(cwd, plain), /Stale subagent tracker authority state/);
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses a generic write that would mint authority into a fresh tracker', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-mint-authority-'));
+    try {
+      const minted = recordSubagentTurn(createSubagentTrackingState(), { sessionId: 'canonical', threadId: 'child', kind: 'subagent' });
+      minted.sessions.canonical!.threads.child!.provenance_kind = NATIVE_SUBAGENT_PROVENANCE;
+      minted.sessions.canonical!.threads.child!.direct_child_root_id = 'root';
+      minted.sessions.canonical!.threads.child!.direct_child_parent_id = 'root';
+      await assert.rejects(writeSubagentTrackingState(cwd, minted), /Stale subagent tracker authority state/);
+      assert.equal(existsSync(subagentTrackingPath(cwd)), false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses a generic write that would roll an authorized child back to available', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-status-rollback-'));
+    try {
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence: 'valid' });
+      const snapshot = await readSubagentTrackingState(cwd);
+      snapshot.sessions.canonical!.threads.child!.status = 'unavailable';
+      await assert.rejects(writeSubagentTrackingState(cwd, snapshot), /Stale subagent tracker authority state/);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('never destroys an unreadable global fence during an unrelated revocation clear', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-fence-preserved-'));
+    try {
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'a', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence: 'valid' });
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'b', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence: 'valid' });
+      const fencePath = `${subagentTrackingPath(cwd)}.authority-fence.json`;
+      writeFileSync(fencePath, '{ not json');
+      // An unrelated revocation must not delete the global denial.
+      revokeNativeSubagentAuthorities(cwd, ['a'], 'identity_untrusted');
+      assert.equal(existsSync(fencePath), true);
+      assert.match(
+        consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '',
+        /unreadable_authority_fence/,
+      );
+      // A no-op revocation for an unknown id must not clear it either.
+      revokeNativeSubagentAuthorities(cwd, ['nonexistent'], 'identity_untrusted');
+      assert.equal(existsSync(fencePath), true);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not weaken an unreadable global fence when a later fence records more ids', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-fence-no-weaken-'));
+    try {
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'child', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence: 'valid' });
+      const fencePath = `${subagentTrackingPath(cwd)}.authority-fence.json`;
+      writeFileSync(fencePath, '{ not json');
+      assert.equal(fenceNativeSubagentAuthorities(cwd, ['other'], 'identity_untrusted_revocation_failed'), true);
+      assert.match(
+        consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }) ?? '',
+        /unreadable_authority_fence/,
+      );
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('clears only fully reconciled fence ids and keeps the rest denied', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-fence-partial-clear-'));
+    try {
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'a', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence: 'valid' });
+      recordNativeSubagentAuthorityObservation(cwd, { sessionIds: ['canonical', 'root'], childThreadId: 'b', parentThreadId: 'root', rootNativeSessionId: 'root', authorityEvidence: 'valid' });
+      assert.equal(fenceNativeSubagentAuthorities(cwd, ['a', 'b'], 'identity_untrusted_revocation_failed'), true);
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+      revokeNativeSubagentAuthorities(cwd, ['a'], 'identity_untrusted');
+      // `b` is still fenced, so it must not be emitted even though its tracker
+      // record still looks valid.
+      assert.equal(consumeDirectChildReopenContext(cwd, { sessionId: 'canonical', rootNativeSessionId: 'root', source: 'resume' }), null);
+      const fence = JSON.parse(readFileSync(`${subagentTrackingPath(cwd)}.authority-fence.json`, 'utf8'));
+      assert.deepEqual(fence.ids, ['b']);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('repairs a root inversion even when the canonical tracker partition is missing', () => {
     const cwd = mkdtempSync(join(tmpdir(), 'omx-3284-tracker-native-only-repair-'));
     try {

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -38,6 +38,12 @@ export interface TrackedSubagentThread {
   resume_completed_at?: string;
   resume_failed_at?: string;
   resume_failure_reason?: string;
+  // Reopen authority is explicit direct-child attestation, never inferred from lifecycle metadata.
+  direct_child_root_id?: string;
+  direct_child_parent_id?: string;
+  reopen_authority_revoked?: boolean;
+  reopen_authority_conflict_reason?: string;
+  reopen_authority_conflict_at?: string;
 }
 
 export interface TrackedSubagentSession {
@@ -76,6 +82,17 @@ export interface RecordSubagentTurnInput {
   resumeFailedAt?: string;
   resumeFailureReason?: string;
   preserveCompletionEvidence?: boolean;
+}
+
+export interface NativeSubagentAuthorityObservation {
+  sessionIds: string[];
+  childThreadId: string;
+  parentThreadId: string;
+  rootNativeSessionId?: string;
+  authorityEvidence?: 'valid' | 'untrusted' | 'absent';
+  implicatedChildThreadIds?: string[];
+  mode?: string;
+  timestamp?: string;
 }
 
 
@@ -294,6 +311,19 @@ export function normalizeSubagentTrackingState(input: unknown): SubagentTracking
         ...(typeof candidate.resume_failure_reason === 'string' && candidate.resume_failure_reason.trim().length > 0
           ? { resume_failure_reason: candidate.resume_failure_reason.trim() }
           : {}),
+        ...(typeof candidate.direct_child_root_id === 'string' && candidate.direct_child_root_id.trim().length > 0
+          ? { direct_child_root_id: candidate.direct_child_root_id.trim() }
+          : {}),
+        ...(typeof candidate.direct_child_parent_id === 'string' && candidate.direct_child_parent_id.trim().length > 0
+          ? { direct_child_parent_id: candidate.direct_child_parent_id.trim() }
+          : {}),
+        ...(candidate.reopen_authority_revoked === true ? { reopen_authority_revoked: true } : {}),
+        ...(typeof candidate.reopen_authority_conflict_reason === 'string' && candidate.reopen_authority_conflict_reason.trim()
+          ? { reopen_authority_conflict_reason: candidate.reopen_authority_conflict_reason.trim() }
+          : {}),
+        ...(typeof candidate.reopen_authority_conflict_at === 'string' && candidate.reopen_authority_conflict_at.trim()
+          ? { reopen_authority_conflict_at: candidate.reopen_authority_conflict_at.trim() }
+          : {}),
       };
     }
 
@@ -316,6 +346,65 @@ export function normalizeSubagentTrackingState(input: unknown): SubagentTracking
     schemaVersion: SUBAGENT_TRACKING_SCHEMA_VERSION,
     sessions,
   };
+}
+
+function parseStrictSubagentTrackingState(raw: string): SubagentTrackingState | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const candidate = parsed as { schemaVersion?: unknown; sessions?: unknown };
+  if (candidate.schemaVersion !== SUBAGENT_TRACKING_SCHEMA_VERSION || !candidate.sessions || typeof candidate.sessions !== 'object' || Array.isArray(candidate.sessions)) return null;
+  const normalizedSessionIds = new Set<string>();
+  for (const [sessionId, sessionValue] of Object.entries(candidate.sessions as Record<string, unknown>)) {
+    if (!sessionId || sessionId.trim() !== sessionId || normalizedSessionIds.has(sessionId.trim())) return null;
+    normalizedSessionIds.add(sessionId.trim());
+    if (!sessionValue || typeof sessionValue !== 'object' || Array.isArray(sessionValue)) return null;
+    const session = sessionValue as Record<string, unknown>;
+    if (session.session_id !== sessionId || typeof session.updated_at !== 'string' || !session.updated_at.trim()) return null;
+    if (!session.threads || typeof session.threads !== 'object' || Array.isArray(session.threads)) return null;
+    if (session.leader_thread_id !== undefined && (typeof session.leader_thread_id !== 'string' || !session.leader_thread_id.trim() || session.leader_thread_id.trim() !== session.leader_thread_id)) return null;
+    const normalizedThreadIds = new Set<string>();
+    for (const [threadId, threadValue] of Object.entries(session.threads as Record<string, unknown>)) {
+      if (!threadId || threadId.trim() !== threadId || normalizedThreadIds.has(threadId.trim())) return null;
+      normalizedThreadIds.add(threadId.trim());
+      if (!threadValue || typeof threadValue !== 'object' || Array.isArray(threadValue)) return null;
+      const thread = threadValue as Record<string, unknown>;
+      if (thread.thread_id !== threadId || (thread.kind !== 'leader' && thread.kind !== 'subagent')) return null;
+      if (typeof thread.first_seen_at !== 'string' || !thread.first_seen_at.trim()) return null;
+      if (typeof thread.last_seen_at !== 'string' || !thread.last_seen_at.trim()) return null;
+      if (typeof thread.turn_count !== 'number' || !Number.isFinite(thread.turn_count) || thread.turn_count < 1) return null;
+      const hasAuthorityEvidence = thread.provenance_kind === NATIVE_SUBAGENT_PROVENANCE
+        || thread.direct_child_root_id !== undefined
+        || thread.direct_child_parent_id !== undefined
+        || thread.reopen_authority_revoked !== undefined
+        || thread.reopen_authority_conflict_reason !== undefined
+        || thread.reopen_authority_conflict_at !== undefined;
+      if (hasAuthorityEvidence && thread.status !== undefined && normalizeSubagentStatus(thread.status) === undefined) return null;
+      if (hasAuthorityEvidence && thread.provenance_kind !== undefined && thread.provenance_kind !== NATIVE_SUBAGENT_PROVENANCE) return null;
+      for (const field of ['direct_child_root_id', 'direct_child_parent_id', 'reopen_authority_conflict_reason', 'reopen_authority_conflict_at'] as const) {
+        if (thread[field] !== undefined && (typeof thread[field] !== 'string' || !(thread[field] as string).trim() || (thread[field] as string).trim() !== thread[field])) return null;
+      }
+      if (thread.reopen_authority_revoked !== undefined && typeof thread.reopen_authority_revoked !== 'boolean') return null;
+      if ((thread.direct_child_root_id === undefined) !== (thread.direct_child_parent_id === undefined)) return null;
+      if ((thread.reopen_authority_conflict_reason !== undefined || thread.reopen_authority_conflict_at !== undefined) && thread.reopen_authority_revoked !== true) return null;
+    }
+  }
+  return normalizeSubagentTrackingState(parsed);
+}
+
+function readSubagentTrackingStateStrictSync(cwd: string): { ok: true; state: SubagentTrackingState } | { ok: false } {
+  const path = subagentTrackingPath(cwd);
+  if (!existsSync(path)) return { ok: true, state: createSubagentTrackingState() };
+  try {
+    const state = parseStrictSubagentTrackingState(readFileSync(path, 'utf-8'));
+    return state ? { ok: true, state } : { ok: false };
+  } catch {
+    return { ok: false };
+  }
 }
 
 function atomicTrackingTempPath(path: string): string {
@@ -693,16 +782,6 @@ export function withCrossProcessFileLockSync<T>(
   }
 }
 
-function readSubagentTrackingStateSync(cwd: string): SubagentTrackingState {
-  const path = subagentTrackingPath(cwd);
-  if (!existsSync(path)) return createSubagentTrackingState();
-  try {
-    return normalizeSubagentTrackingState(JSON.parse(readFileSync(path, 'utf-8')));
-  } catch {
-    return createSubagentTrackingState();
-  }
-}
-
 
 function threadIsTrackedAsSubagent(state: SubagentTrackingState, threadId: string): boolean {
   const id = threadId.trim();
@@ -877,6 +956,11 @@ export function recordSubagentTurn(state: SubagentTrackingState, input: RecordSu
       : existingThread?.resume_failure_reason
         ? { resume_failure_reason: existingThread.resume_failure_reason }
         : {}),
+    ...(existingThread?.direct_child_root_id ? { direct_child_root_id: existingThread.direct_child_root_id } : {}),
+    ...(existingThread?.direct_child_parent_id ? { direct_child_parent_id: existingThread.direct_child_parent_id } : {}),
+    ...(existingThread?.reopen_authority_revoked ? { reopen_authority_revoked: true } : {}),
+    ...(existingThread?.reopen_authority_conflict_reason ? { reopen_authority_conflict_reason: existingThread.reopen_authority_conflict_reason } : {}),
+    ...(existingThread?.reopen_authority_conflict_at ? { reopen_authority_conflict_at: existingThread.reopen_authority_conflict_at } : {}),
   };
 
   const threads = {
@@ -901,11 +985,259 @@ export function recordSubagentTurn(state: SubagentTrackingState, input: RecordSu
 
 export async function recordSubagentTurnForSession(cwd: string, input: RecordSubagentTurnInput): Promise<SubagentTrackingState> {
   return withCrossProcessFileLockSync(subagentTrackingPath(cwd), (context) => {
-    const current = readSubagentTrackingStateSync(cwd);
-    const next = recordSubagentTurn(current, input);
+    const strict = readSubagentTrackingStateStrictSync(cwd);
+    if (!strict.ok) throw new Error('Malformed subagent tracker authority state');
+    const next = recordSubagentTurn(strict.state, input);
     context.assertOwnership();
     writeSubagentTrackingStateSync(cwd, next, context.publish);
     return next;
+  });
+}
+export function recordNativeSubagentAuthorityObservation(
+  cwd: string,
+  observation: NativeSubagentAuthorityObservation,
+): SubagentTrackingState {
+  const requestedSessionIds = [...new Set(observation.sessionIds.map((value) => value.trim()).filter(Boolean))];
+  const childThreadId = observation.childThreadId.trim();
+  const parentThreadId = observation.parentThreadId.trim();
+  const rootNativeSessionId = observation.rootNativeSessionId?.trim() ?? '';
+  const implicatedChildThreadIds = [...new Set([
+    childThreadId,
+    ...(observation.implicatedChildThreadIds ?? []).map((value) => value.trim()),
+  ].filter(Boolean))];
+  return withCrossProcessFileLockSync(subagentTrackingPath(cwd), (context) => {
+    const strict = readSubagentTrackingStateStrictSync(cwd);
+    if (!strict.ok) throw new Error('Malformed subagent tracker authority state');
+    let next = strict.state;
+    const existingSessionIds = Object.entries(next.sessions)
+      .filter(([, session]) => implicatedChildThreadIds.some((id) => Boolean(session.threads[id]?.direct_child_root_id || session.threads[id]?.reopen_authority_revoked)))
+      .map(([sessionId]) => sessionId);
+    const sessionIds = [...new Set([...requestedSessionIds, ...existingSessionIds])];
+    const existingBindings = Object.values(next.sessions)
+      .map((session) => session.threads[childThreadId])
+      .filter((thread): thread is TrackedSubagentThread => Boolean(thread?.direct_child_root_id));
+    const authorityEvidence = observation.authorityEvidence ?? (rootNativeSessionId ? 'valid' : 'absent');
+    const globalConflict = authorityEvidence === 'untrusted' && existingBindings.length > 0
+      || authorityEvidence === 'valid' && existingBindings.some((thread) =>
+        thread.direct_child_root_id !== rootNativeSessionId || thread.direct_child_parent_id !== parentThreadId,
+      );
+    const timestamp = observation.timestamp ?? new Date().toISOString();
+    if (authorityEvidence === 'untrusted') {
+      for (const session of Object.values(next.sessions)) {
+        for (const implicatedId of implicatedChildThreadIds) {
+          const implicatedThread = session.threads[implicatedId];
+          if (!implicatedThread?.direct_child_root_id && !implicatedThread?.reopen_authority_revoked) continue;
+          implicatedThread.reopen_authority_revoked = true;
+          implicatedThread.reopen_authority_conflict_reason = 'identity_untrusted';
+          implicatedThread.reopen_authority_conflict_at = timestamp;
+        }
+      }
+    }
+    for (const sessionId of sessionIds) {
+      if (parentThreadId && parentThreadId !== childThreadId) {
+        next = recordSubagentTurn(next, { sessionId, threadId: parentThreadId, kind: 'leader', timestamp });
+      }
+      next = recordSubagentTurn(next, {
+        sessionId,
+        threadId: childThreadId,
+        kind: 'subagent',
+        ...(parentThreadId && parentThreadId !== childThreadId ? { leaderThreadId: parentThreadId } : {}),
+        mode: observation.mode,
+        timestamp,
+      });
+      const thread = next.sessions[sessionId]?.threads[childThreadId];
+      if (!thread) continue;
+      const mayAttest = authorityEvidence === 'valid'
+        && Boolean(rootNativeSessionId)
+        && childThreadId !== rootNativeSessionId
+        && parentThreadId === rootNativeSessionId;
+      if (globalConflict) {
+        thread.reopen_authority_revoked = true;
+        thread.reopen_authority_conflict_reason = 'root_or_parent_mismatch';
+        thread.reopen_authority_conflict_at = timestamp;
+      } else if (mayAttest) {
+        thread.direct_child_root_id = rootNativeSessionId;
+        thread.direct_child_parent_id = parentThreadId;
+        thread.provenance_kind = NATIVE_SUBAGENT_PROVENANCE;
+        delete thread.reopen_authority_revoked;
+        delete thread.reopen_authority_conflict_reason;
+        delete thread.reopen_authority_conflict_at;
+      }
+    }
+    context.assertOwnership();
+    writeSubagentTrackingStateSync(cwd, next, context.publish);
+    return next;
+  });
+}
+
+export function revokeNativeSubagentAuthorities(
+  cwd: string,
+  childThreadIds: string[],
+  reason = 'identity_untrusted',
+): SubagentTrackingState {
+  const ids = [...new Set(childThreadIds.map((value) => value.trim()).filter(Boolean))];
+  return withCrossProcessFileLockSync(subagentTrackingPath(cwd), (context) => {
+    const strict = readSubagentTrackingStateStrictSync(cwd);
+    if (!strict.ok) throw new Error('Malformed subagent tracker authority state');
+    const next = strict.state;
+    const timestamp = new Date().toISOString();
+    let changed = false;
+    for (const session of Object.values(next.sessions)) {
+      for (const id of ids) {
+        const thread = session.threads[id];
+        if (!thread?.direct_child_root_id && !thread?.reopen_authority_revoked) continue;
+        thread.reopen_authority_revoked = true;
+        thread.reopen_authority_conflict_reason = reason;
+        thread.reopen_authority_conflict_at = timestamp;
+        changed = true;
+      }
+    }
+    if (changed) {
+      context.assertOwnership();
+      writeSubagentTrackingStateSync(cwd, next, context.publish);
+    }
+    return next;
+  });
+}
+
+export interface DirectChildReopenContext {
+  sessionId: string;
+  rootNativeSessionId: string;
+  source: string;
+}
+
+function formatReopenMetadata(entry: SubagentLedgerEntry): string {
+  const values = [
+    entry.role ? `role: ${entry.role}` : null,
+    entry.laneId ? `lane: ${entry.laneId}` : null,
+    entry.scope ? `scope: ${entry.scope}` : null,
+    `status: ${entry.status}`,
+    entry.lastHandoffSummary ? `handoff: ${entry.lastHandoffSummary.slice(0, 120)}` : null,
+    entry.resumeFailureReason ? `last failure: ${entry.resumeFailureReason.slice(0, 120)}` : null,
+  ].filter((value): value is string => Boolean(value));
+  return values.length ? ` (${values.join('; ')})` : '';
+}
+
+function persistedReopenAuthorityWarning(reason: string): string {
+  return [
+    '[Persisted subagent reopen]',
+    `- Warning: persisted subagent authority was excluded (${reason}); no resume authority or bookkeeping was granted.`,
+    '- Silver rule: do not spawn a same-role/same-lane replacement solely because persisted reopen authority was unavailable; continue in the root or another compatible existing lane.',
+  ].join('\n');
+}
+
+/** Strict, lock-serialized authority consumption for SessionStart persisted reopen output. */
+export function consumeDirectChildReopenContext(
+  cwd: string,
+  context: DirectChildReopenContext,
+): string | null {
+  const sessionId = context.sessionId.trim();
+  const rootNativeSessionId = context.rootNativeSessionId.trim();
+  if (!sessionId || !rootNativeSessionId) return null;
+  const path = subagentTrackingPath(cwd);
+  return withCrossProcessFileLockSync(path, (lock) => {
+    let raw: string;
+    try {
+      raw = readFileSync(path, 'utf-8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      return persistedReopenAuthorityWarning('tracker_read_failed');
+    }
+    const state = parseStrictSubagentTrackingState(raw);
+    if (!state) return persistedReopenAuthorityWarning('malformed_tracker_state');
+    const session = state.sessions[sessionId];
+    if (!session) return null;
+    let changed = false;
+    const repairTimestamp = new Date().toISOString();
+    for (const correlatedSession of Object.values(state.sessions)) {
+      let sessionChanged = false;
+      for (const rootId of new Set([sessionId, rootNativeSessionId])) {
+        const rootThread = correlatedSession.threads[rootId];
+        if (!rootThread || rootThread.kind !== 'subagent') continue;
+        rootThread.kind = 'leader';
+        delete rootThread.direct_child_root_id;
+        delete rootThread.direct_child_parent_id;
+        delete rootThread.reopen_authority_revoked;
+        delete rootThread.reopen_authority_conflict_reason;
+        delete rootThread.reopen_authority_conflict_at;
+        delete rootThread.resume_requested_at;
+        delete rootThread.resume_completed_at;
+        delete rootThread.resume_failed_at;
+        delete rootThread.resume_failure_reason;
+        sessionChanged = true;
+      }
+      if (correlatedSession.threads[rootNativeSessionId] && correlatedSession.leader_thread_id !== rootNativeSessionId) {
+        correlatedSession.leader_thread_id = rootNativeSessionId;
+        sessionChanged = true;
+      }
+      if (sessionChanged) {
+        correlatedSession.updated_at = repairTimestamp;
+        changed = true;
+      }
+    }
+    const savedSubagents = Object.values(session.threads)
+      .filter((thread) => {
+        if (thread.kind !== 'subagent'
+          || thread.thread_id === sessionId
+          || thread.thread_id === rootNativeSessionId
+          || session.leader_thread_id === thread.thread_id
+          || thread.provenance_kind !== NATIVE_SUBAGENT_PROVENANCE
+          || thread.direct_child_root_id !== rootNativeSessionId
+          || thread.direct_child_parent_id !== rootNativeSessionId
+          || thread.reopen_authority_revoked === true) return false;
+        return Object.values(state.sessions).every((correlationSession) => {
+          const view = correlationSession.threads[thread.thread_id];
+          if (!view) return true;
+          return correlationSession.leader_thread_id !== thread.thread_id
+            && view.kind === 'subagent'
+            && view.provenance_kind === NATIVE_SUBAGENT_PROVENANCE
+            && view.direct_child_root_id === rootNativeSessionId
+            && view.direct_child_parent_id === rootNativeSessionId
+            && view.reopen_authority_revoked !== true;
+        });
+      })
+      .map((thread) => normalizeLedgerEntry(thread, thread.status ?? 'closed'))
+      .sort(compareResumeEntries);
+    if (!savedSubagents.length) {
+      if (changed) {
+        session.updated_at = new Date().toISOString();
+        lock.assertOwnership();
+        writeSubagentTrackingStateSync(cwd, state, lock.publish);
+      }
+      return null;
+    }
+    const reopenTargets = savedSubagents.filter((entry) => entry.status !== 'unavailable');
+    const unavailableTargets = savedSubagents.filter((entry) => entry.status === 'unavailable');
+    const failedTargets = savedSubagents.filter((entry) => entry.resumeFailedAt || entry.resumeFailureReason);
+    const now = new Date().toISOString();
+    for (const target of reopenTargets) {
+      session.threads[target.threadId] = { ...session.threads[target.threadId]!, resume_requested_at: now };
+    }
+    if (reopenTargets.length || changed) {
+      session.updated_at = now;
+      lock.assertOwnership();
+      writeSubagentTrackingStateSync(cwd, state, lock.publish);
+    }
+    const lines = [
+      '[Persisted subagent reopen]',
+      `- SessionStart source: ${context.source}; saved subagent ids found: ${savedSubagents.length}.`,
+    ];
+    if (reopenTargets.length) {
+      lines.push('- Reopen these persisted subagents by id before continuing work or spawning any same-role/same-lane replacement:');
+      lines.push(...reopenTargets.slice(0, 12).map((entry) => `  - resume_agent(${JSON.stringify(entry.agentId)})${formatReopenMetadata(entry)}`));
+      if (reopenTargets.length > 12) lines.push(`  - ... ${reopenTargets.length - 12} more saved subagent id(s) omitted from this compact SessionStart context; consult .omx/state/subagent-tracking.json before spawning replacements.`);
+    } else {
+      lines.push('- No compatible saved subagent id is currently marked reopenable; do not spawn a replacement merely because reopen was unavailable.');
+    }
+    lines.push('- Silver rule: when follow-up work targets an existing role/lane, reuse the matching reopened id; avoid duplicate same-type subagent spawns.');
+    lines.push('- If resume_agent fails, surface a clear warning with the id and reason, then continue in the root or another compatible existing lane; do not spawn a new agent solely because reopen failed.');
+    const warnings = [...new Map([...unavailableTargets, ...failedTargets].map((entry) => [entry.agentId, entry])).values()];
+    if (warnings.length) {
+      lines.push('- Reopen warnings:');
+      lines.push(...warnings.slice(0, 8).map((entry) => `  - ${entry.agentId}${formatReopenMetadata(entry)}`));
+      if (warnings.length > 8) lines.push(`  - ... ${warnings.length - 8} more warning(s) omitted from this compact SessionStart context.`);
+    }
+    return lines.join('\n');
   });
 }
 

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { closeSync, existsSync, ftruncateSync, linkSync, mkdirSync, openSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync, writeSync } from 'node:fs';
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { hostname } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 import { AGENT_DEFINITIONS } from '../agents/definitions.js';
@@ -846,24 +846,30 @@ export async function readSubagentTrackingState(cwd: string): Promise<SubagentTr
 
 export async function writeSubagentTrackingState(cwd: string, state: SubagentTrackingState): Promise<string> {
   const path = subagentTrackingPath(cwd);
-  // Fail closed: never overwrite existing authority-bearing bytes that do not
-  // survive strict parsing. A tolerant read must not launder malformed authority
-  // into a valid-looking attestation through this shared writer.
-  if (existsSync(path)) {
-    let raw: string;
-    try {
-      raw = await readFile(path, 'utf-8');
-    } catch {
-      throw new Error('Malformed subagent tracker authority state');
-    }
-    if (!parseStrictSubagentTrackingState(raw)) throw new Error('Malformed subagent tracker authority state');
-  }
+  // Fail closed on both sides of the write: the proposed state must survive
+  // strict authority validation (tolerant inputs must not launder malformed
+  // authority into a valid-looking attestation), and existing on-disk bytes
+  // must not be overwritten when they fail strict parsing. The whole
+  // read/validate/publish transaction is serialized under the tracker lock.
+  const proposedRaw = JSON.stringify(state);
+  if (!parseStrictSubagentTrackingState(proposedRaw)) throw new Error('Malformed subagent tracker authority state');
   const normalized = normalizeSubagentTrackingState(state);
-  await mkdir(dirname(path), { recursive: true });
-  const temporaryPath = atomicTrackingTempPath(path);
-  await writeFile(temporaryPath, `${JSON.stringify(normalized, null, 2)}\n`);
-  await rename(temporaryPath, path);
-  return path;
+  const contents = `${JSON.stringify(normalized, null, 2)}\n`;
+  return withCrossProcessFileLockSync(path, (lock) => {
+    if (existsSync(path)) {
+      let raw: string;
+      try {
+        raw = readFileSync(path, 'utf-8');
+      } catch {
+        throw new Error('Malformed subagent tracker authority state');
+      }
+      if (!parseStrictSubagentTrackingState(raw)) throw new Error('Malformed subagent tracker authority state');
+    }
+    mkdirSync(dirname(path), { recursive: true });
+    lock.assertOwnership();
+    lock.publish(contents);
+    return path;
+  });
 }
 
 
@@ -1155,11 +1161,12 @@ function persistedReopenLegacyNotice(excludedCount: number, source: string): str
 
 /**
  * Repair persisted root-as-subagent identity inversion inside an already-parsed
- * state. A thread whose id equals the native root id is conclusively the root and
- * is reclassified as leader. A thread whose id equals only the canonical session
- * key while carrying a valid direct-child attestation is ambiguous: it is denied
- * (authority revoked) without destructive reclassification. Returns true when any
- * record changed.
+ * state. Only a thread whose id equals the exact native root id is conclusively
+ * the root and is reclassified as leader. A thread whose id equals only the
+ * canonical session key is always ambiguous — the storage key is not identity
+ * proof — so it is never destructively reclassified: authority-bearing records
+ * are revoked (fail closed) and every ambiguous record loses resume bookkeeping.
+ * Returns true when any record changed.
  */
 function repairPersistedRootIdentityInState(
   state: SubagentTrackingState,
@@ -1173,27 +1180,35 @@ function repairPersistedRootIdentityInState(
     for (const rootId of new Set([sessionId, rootNativeSessionId])) {
       const rootThread = correlatedSession.threads[rootId];
       if (!rootThread || rootThread.kind !== 'subagent') continue;
-      const ambiguousCanonicalCollision =
-        rootId === sessionId
-        && sessionId !== rootNativeSessionId
-        && rootThread.provenance_kind === NATIVE_SUBAGENT_PROVENANCE
-        && typeof rootThread.direct_child_root_id === 'string'
-        && typeof rootThread.direct_child_parent_id === 'string';
+      const ambiguousCanonicalCollision = rootId === sessionId && sessionId !== rootNativeSessionId;
       if (ambiguousCanonicalCollision) {
-        // Fail closed without rewriting identity: the id collides with the
-        // canonical root key but carries child attestation, so it stays a
-        // subagent whose reopen authority is revoked until root identity is
-        // independently established.
-        rootThread.reopen_authority_revoked = true;
-        rootThread.reopen_authority_conflict_reason = 'canonical_root_collision';
-        rootThread.reopen_authority_conflict_at = repairTimestamp;
-        delete rootThread.resume_requested_at;
-        delete rootThread.resume_completed_at;
-        delete rootThread.resume_failed_at;
-        delete rootThread.resume_failure_reason;
-        sessionChanged = true;
+        const carriesAuthority =
+          rootThread.provenance_kind === NATIVE_SUBAGENT_PROVENANCE
+          || rootThread.direct_child_root_id !== undefined
+          || rootThread.direct_child_parent_id !== undefined;
+        if (carriesAuthority && rootThread.reopen_authority_revoked !== true) {
+          // Fail closed without rewriting identity: the id collides with the
+          // canonical root key but carries child-shaped authority evidence, so
+          // it stays a subagent whose reopen authority is revoked until root
+          // identity is independently established.
+          rootThread.reopen_authority_revoked = true;
+          rootThread.reopen_authority_conflict_reason = 'canonical_root_collision';
+          rootThread.reopen_authority_conflict_at = repairTimestamp;
+          sessionChanged = true;
+        }
+        if (rootThread.resume_requested_at !== undefined
+          || rootThread.resume_completed_at !== undefined
+          || rootThread.resume_failed_at !== undefined
+          || rootThread.resume_failure_reason !== undefined) {
+          delete rootThread.resume_requested_at;
+          delete rootThread.resume_completed_at;
+          delete rootThread.resume_failed_at;
+          delete rootThread.resume_failure_reason;
+          sessionChanged = true;
+        }
         continue;
       }
+      if (rootId !== rootNativeSessionId) continue;
       rootThread.kind = 'leader';
       delete rootThread.direct_child_root_id;
       delete rootThread.direct_child_parent_id;
@@ -1293,8 +1308,13 @@ export function consumeDirectChildReopenContext(
           const view = correlationSession.threads[thread.thread_id];
           if (!view) return true;
           // Recognized legacy adapted records are descriptive-only: they never
-          // grant authority and never block a newly attested valid child.
-          if (view.provenance_kind === DESCRIPTIVE_ADAPTED_PROVENANCE) return true;
+          // grant authority and never block a newly attested valid child. The
+          // tolerance is shape-constrained: an adapted view may only waive
+          // missing attestation for a non-leader subagent view and never waives
+          // leader-kind or leader_thread_id contradictions.
+          if (view.provenance_kind === DESCRIPTIVE_ADAPTED_PROVENANCE
+            && view.kind === 'subagent'
+            && correlationSession.leader_thread_id !== thread.thread_id) return true;
           return correlationSession.leader_thread_id !== thread.thread_id
             && view.kind === 'subagent'
             && view.provenance_kind === NATIVE_SUBAGENT_PROVENANCE
@@ -1312,16 +1332,30 @@ export function consumeDirectChildReopenContext(
         writeSubagentTrackingStateSync(cwd, state, lock.publish);
       }
       // Surface intentional exclusion of legacy/non-authoritative records instead
-      // of silently returning no context. Authority-bearing denials (revoked,
-      // leader-colliding, cross-partition conflicts) stay fail-closed null.
-      const subagentThreads = Object.values(session.threads).filter((thread) => thread.kind === 'subagent');
-      const hadAuthorityBearing = subagentThreads.some((thread) =>
-        thread.provenance_kind === NATIVE_SUBAGENT_PROVENANCE
-        || thread.direct_child_root_id !== undefined
-        || thread.direct_child_parent_id !== undefined
-        || thread.reopen_authority_revoked === true);
-      if (!hadAuthorityBearing && subagentThreads.length > 0) {
-        return persistedReopenLegacyNotice(subagentThreads.length, context.source);
+      // of silently returning no context. The notice fires only when every
+      // relevant view across every correlation partition is genuinely
+      // descriptive/legacy: any authority-bearing, leader-kind, or
+      // leader_thread_id-colliding view keeps the denial fail-closed null.
+      const excludedIds = new Set(
+        Object.values(session.threads)
+          .filter((thread) => thread.kind === 'subagent')
+          .map((thread) => thread.thread_id),
+      );
+      const everyRelevantViewIsLegacy = excludedIds.size > 0
+        && Object.values(state.sessions).every((correlationSession) => {
+          if (correlationSession.leader_thread_id && excludedIds.has(correlationSession.leader_thread_id)) return false;
+          return [...excludedIds].every((threadId) => {
+            const view = correlationSession.threads[threadId];
+            if (!view) return true;
+            return view.kind === 'subagent'
+              && view.provenance_kind !== NATIVE_SUBAGENT_PROVENANCE
+              && view.direct_child_root_id === undefined
+              && view.direct_child_parent_id === undefined
+              && view.reopen_authority_revoked !== true;
+          });
+        });
+      if (everyRelevantViewIsLegacy) {
+        return persistedReopenLegacyNotice(excludedIds.size, context.source);
       }
       return null;
     }

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -911,13 +911,18 @@ export async function writeSubagentTrackingState(cwd: string, state: SubagentTra
         throw new Error('Stale subagent tracker authority state');
       }
     } else if (proposedAuthorityRevision !== authorityRevisionOf(createSubagentTrackingState())) {
-      // Creating the tracker from nothing must not mint authority either.
+      // Creating the tracker from nothing must not mint reopen authority.
+      // `leader_thread_id` is deliberately NOT included: it is ordinary
+      // descriptive lifecycle data that legitimate first writers set, and it
+      // never by itself makes a thread an eligible reopen target.
       const mintsAuthority = Object.values(normalized.sessions).some((session) =>
         Object.values(session.threads).some((thread) =>
           thread.provenance_kind === NATIVE_SUBAGENT_PROVENANCE
           || thread.direct_child_root_id !== undefined
           || thread.direct_child_parent_id !== undefined
-          || thread.reopen_authority_revoked !== undefined));
+          || thread.reopen_authority_revoked !== undefined
+          || thread.reopen_authority_conflict_reason !== undefined
+          || thread.reopen_authority_conflict_at !== undefined));
       if (mintsAuthority) throw new Error('Stale subagent tracker authority state');
     }
     mkdirSync(dirname(path), { recursive: true });
@@ -1216,6 +1221,34 @@ export function fenceNativeSubagentAuthorities(cwd: string, childThreadIds: stri
     // The denial could not be made durable. The caller must surface this
     // rather than continue as if the revocation had been applied.
     return false;
+  }
+}
+
+/**
+ * Last-resort global denial used when BOTH the tracker revocation transaction
+ * and the locked fence publication fail. It deliberately avoids the fence lock
+ * (which may be exactly what is unavailable) and writes an intentionally
+ * unreadable sentinel directly, because `readAuthorityFence` treats any
+ * unreadable fence as a denial of every id. Returns true when the denial is
+ * durable on disk.
+ */
+export function forceGlobalAuthorityDenial(cwd: string, reason: string): boolean {
+  const path = authorityFencePath(cwd);
+  const contents = `${JSON.stringify({ ids: 'all', reason, fenced_at: new Date().toISOString() }, null, 2)}\n`;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    const temporaryPath = atomicTrackingTempPath(path);
+    writeFileSync(temporaryPath, contents);
+    renameSync(temporaryPath, path);
+    return true;
+  } catch {
+    try {
+      // Even a partial/truncated write is safe here: unreadable means denied.
+      writeFileSync(path, contents);
+      return true;
+    } catch {
+      return false;
+    }
   }
 }
 

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -144,6 +144,35 @@ export function subagentTrackingPath(cwd: string): string {
   return join(getBaseStateDir(cwd), 'subagent-tracking.json');
 }
 
+/**
+ * Authority-relevant projection of a tracker state. The generic descriptive
+ * writer is allowed to publish descriptive churn, but it must never roll back
+ * an authority decision that another process committed after the caller read
+ * its snapshot. Comparing this projection is the durable equivalent of a CAS
+ * on the authority surface without forcing every descriptive caller to hold
+ * the tracker lock across its own read/modify/write.
+ */
+function authorityRevisionOf(state: SubagentTrackingState): string {
+  const sessions = Object.keys(state.sessions).sort().map((sessionId) => {
+    const session = state.sessions[sessionId]!;
+    const threads = Object.keys(session.threads).sort().map((threadId) => {
+      const thread = session.threads[threadId]!;
+      return [
+        threadId,
+        thread.kind,
+        thread.provenance_kind ?? '',
+        thread.direct_child_root_id ?? '',
+        thread.direct_child_parent_id ?? '',
+        thread.reopen_authority_revoked === true ? '1' : '',
+        thread.reopen_authority_conflict_reason ?? '',
+        thread.reopen_authority_conflict_at ?? '',
+      ].join('\u0001');
+    });
+    return [sessionId, session.leader_thread_id ?? '', ...threads].join('\u0002');
+  });
+  return sessions.join('\u0003');
+}
+
 
 export function resolveInstalledRoleName(role: string, codexHomeOverride?: string, projectRootOverride?: string): string | null {
   const normalizedRole = role.trim().toLowerCase();
@@ -834,11 +863,20 @@ function writeSubagentTrackingStateSync(
   return path;
 }
 
+/**
+ * Authority revision observed when a descriptive caller last read the tracker.
+ * `writeSubagentTrackingState` uses it to refuse a stale publication that would
+ * roll back a newer authority decision.
+ */
+const observedAuthorityRevisions = new WeakMap<SubagentTrackingState, string>();
+
 export async function readSubagentTrackingState(cwd: string): Promise<SubagentTrackingState> {
   const path = subagentTrackingPath(cwd);
   if (!existsSync(path)) return createSubagentTrackingState();
   try {
-    return normalizeSubagentTrackingState(JSON.parse(await readFile(path, 'utf-8')));
+    const state = normalizeSubagentTrackingState(JSON.parse(await readFile(path, 'utf-8')));
+    observedAuthorityRevisions.set(state, authorityRevisionOf(state));
+    return state;
   } catch {
     return createSubagentTrackingState();
   }
@@ -846,15 +884,19 @@ export async function readSubagentTrackingState(cwd: string): Promise<SubagentTr
 
 export async function writeSubagentTrackingState(cwd: string, state: SubagentTrackingState): Promise<string> {
   const path = subagentTrackingPath(cwd);
-  // Fail closed on both sides of the write: the proposed state must survive
+  // Fail closed on every side of the write. The proposed state must survive
   // strict authority validation (tolerant inputs must not launder malformed
-  // authority into a valid-looking attestation), and existing on-disk bytes
-  // must not be overwritten when they fail strict parsing. The whole
-  // read/validate/publish transaction is serialized under the tracker lock.
+  // authority into a valid-looking attestation); existing on-disk bytes must
+  // not be overwritten when they fail strict parsing; and the publication must
+  // not roll back an authority decision committed after the caller read its
+  // snapshot. The whole read/validate/compare/publish transaction is
+  // serialized under the tracker lock.
   const proposedRaw = JSON.stringify(state);
   if (!parseStrictSubagentTrackingState(proposedRaw)) throw new Error('Malformed subagent tracker authority state');
   const normalized = normalizeSubagentTrackingState(state);
   const contents = `${JSON.stringify(normalized, null, 2)}\n`;
+  const proposedAuthorityRevision = authorityRevisionOf(normalized);
+  const observedAuthorityRevision = observedAuthorityRevisions.get(state);
   return withCrossProcessFileLockSync(path, (lock) => {
     if (existsSync(path)) {
       let raw: string;
@@ -863,7 +905,16 @@ export async function writeSubagentTrackingState(cwd: string, state: SubagentTra
       } catch {
         throw new Error('Malformed subagent tracker authority state');
       }
-      if (!parseStrictSubagentTrackingState(raw)) throw new Error('Malformed subagent tracker authority state');
+      const current = parseStrictSubagentTrackingState(raw);
+      if (!current) throw new Error('Malformed subagent tracker authority state');
+      // Descriptive churn is allowed; authority rollback is not. The write is
+      // refused when on-disk authority has moved since the caller's snapshot
+      // and the proposal does not already carry that newer authority.
+      const currentAuthorityRevision = authorityRevisionOf(current);
+      if (currentAuthorityRevision !== proposedAuthorityRevision
+        && observedAuthorityRevision !== currentAuthorityRevision) {
+        throw new Error('Stale subagent tracker authority state');
+      }
     }
     mkdirSync(dirname(path), { recursive: true });
     lock.assertOwnership();
@@ -1094,6 +1145,77 @@ export function recordNativeSubagentAuthorityObservation(
   });
 }
 
+/**
+ * Durable fence for authority revocations that could not be published.
+ *
+ * A negative identity observation is only meaningful if reopen consumption can
+ * see it. When the revocation transaction fails (lock exhaustion, malformed
+ * bytes, I/O error) the affected ids are recorded here instead of being
+ * silently dropped, and `consumeDirectChildReopenContext` treats any fenced id
+ * as denied until the revocation is durably applied.
+ */
+function authorityFencePath(cwd: string): string {
+  return `${subagentTrackingPath(cwd)}.authority-fence.json`;
+}
+
+/** Read the fenced ids. An unreadable/malformed fence fails closed for all ids. */
+function readAuthorityFence(cwd: string): { ok: boolean; ids: Set<string> } {
+  const path = authorityFencePath(cwd);
+  if (!existsSync(path)) return { ok: true, ids: new Set() };
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as { ids?: unknown };
+    if (!Array.isArray(parsed.ids)) return { ok: false, ids: new Set() };
+    const ids = parsed.ids.filter((id): id is string => typeof id === 'string' && Boolean(id.trim()));
+    if (ids.length !== parsed.ids.length) return { ok: false, ids: new Set() };
+    return { ok: true, ids: new Set(ids.map((id) => id.trim())) };
+  } catch {
+    return { ok: false, ids: new Set() };
+  }
+}
+
+/** Record ids whose revocation could not be persisted, so reopen stays denied. */
+export function fenceNativeSubagentAuthorities(cwd: string, childThreadIds: string[], reason: string): void {
+  const ids = childThreadIds.map((value) => value.trim()).filter(Boolean);
+  if (!ids.length) return;
+  const path = authorityFencePath(cwd);
+  const existing = readAuthorityFence(cwd);
+  const merged = [...new Set([...existing.ids, ...ids])].sort();
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    const temporaryPath = atomicTrackingTempPath(path);
+    writeFileSync(temporaryPath, `${JSON.stringify({ ids: merged, reason, fenced_at: new Date().toISOString() }, null, 2)}\n`);
+    renameSync(temporaryPath, path);
+  } catch {
+    // Best-effort persistence. A fence that cannot be written leaves the
+    // pre-existing fence (if any) intact; consumption still fails closed for
+    // an unreadable fence.
+  }
+}
+
+/** Drop ids from the fence once their revocation is durably published. */
+function clearAuthorityFence(cwd: string, childThreadIds: string[]): void {
+  const path = authorityFencePath(cwd);
+  if (!existsSync(path)) return;
+  const cleared = new Set(childThreadIds.map((value) => value.trim()).filter(Boolean));
+  const existing = readAuthorityFence(cwd);
+  try {
+    if (!existing.ok) {
+      unlinkSync(path);
+      return;
+    }
+    const remaining = [...existing.ids].filter((id) => !cleared.has(id)).sort();
+    if (!remaining.length) {
+      unlinkSync(path);
+      return;
+    }
+    const temporaryPath = atomicTrackingTempPath(path);
+    writeFileSync(temporaryPath, `${JSON.stringify({ ids: remaining, reason: 'partial_clear', fenced_at: new Date().toISOString() }, null, 2)}\n`);
+    renameSync(temporaryPath, path);
+  } catch {
+    // Leaving a stale fence entry is fail-closed and therefore acceptable.
+  }
+}
+
 export function revokeNativeSubagentAuthorities(
   cwd: string,
   childThreadIds: string[],
@@ -1120,6 +1242,9 @@ export function revokeNativeSubagentAuthorities(
       context.assertOwnership();
       writeSubagentTrackingStateSync(cwd, next, context.publish);
     }
+    // The revocation is now durable for these ids (either just published, or
+    // already present on disk), so any prior fence for them can be released.
+    clearAuthorityFence(cwd, ids);
     return next;
   });
 }
@@ -1160,12 +1285,34 @@ function persistedReopenLegacyNotice(excludedCount: number, source: string): str
 }
 
 /**
+ * True when a stored partition is provably about the current root, and not an
+ * unrelated/historical workspace session that merely happens to contain a
+ * thread id equal to the current canonical session key. Canonical-key collision
+ * quarantine is scoped to correlated partitions so it cannot destroy authority
+ * or resume bookkeeping belonging to a different root.
+ */
+function partitionCorrelatesToRoot(
+  session: TrackedSubagentSession,
+  sessionId: string,
+  rootNativeSessionId: string,
+): boolean {
+  if (session.session_id === sessionId || session.session_id === rootNativeSessionId) return true;
+  if (session.leader_thread_id === rootNativeSessionId) return true;
+  if (session.threads[rootNativeSessionId] !== undefined) return true;
+  return Object.values(session.threads).some((thread) =>
+    thread.direct_child_root_id === rootNativeSessionId
+    || thread.direct_child_parent_id === rootNativeSessionId);
+}
+
+/**
  * Repair persisted root-as-subagent identity inversion inside an already-parsed
  * state. Only a thread whose id equals the exact native root id is conclusively
  * the root and is reclassified as leader. A thread whose id equals only the
  * canonical session key is always ambiguous — the storage key is not identity
  * proof — so it is never destructively reclassified: authority-bearing records
  * are revoked (fail closed) and every ambiguous record loses resume bookkeeping.
+ * That ambiguity quarantine only applies inside partitions that correlate to
+ * this root; unrelated partitions are left untouched.
  * Returns true when any record changed.
  */
 function repairPersistedRootIdentityInState(
@@ -1177,11 +1324,15 @@ function repairPersistedRootIdentityInState(
   let changed = false;
   for (const correlatedSession of Object.values(state.sessions)) {
     let sessionChanged = false;
+    const correlated = partitionCorrelatesToRoot(correlatedSession, sessionId, rootNativeSessionId);
     for (const rootId of new Set([sessionId, rootNativeSessionId])) {
       const rootThread = correlatedSession.threads[rootId];
       if (!rootThread || rootThread.kind !== 'subagent') continue;
       const ambiguousCanonicalCollision = rootId === sessionId && sessionId !== rootNativeSessionId;
       if (ambiguousCanonicalCollision) {
+        // An uncorrelated partition's identically-named thread belongs to a
+        // different root: leave its authority and bookkeeping alone.
+        if (!correlated) continue;
         const carriesAuthority =
           rootThread.provenance_kind === NATIVE_SUBAGENT_PROVENANCE
           || rootThread.direct_child_root_id !== undefined
@@ -1263,6 +1414,70 @@ export function repairPersistedRootIdentity(
   });
 }
 
+/**
+ * Quarantine reopen authority for a root that is persisted as a subagent when
+ * the identity evidence is contradictory (for example a self-parented
+ * transcript marker). Unlike full repair this never asserts leader identity, so
+ * legitimate descriptive subagent evidence is preserved; it only strips the
+ * authority and resume bookkeeping that a root must never carry. Returns true
+ * when any record changed.
+ */
+export function quarantinePersistedRootAuthority(
+  cwd: string,
+  context: { sessionId: string; rootNativeSessionId: string },
+): boolean {
+  const sessionId = context.sessionId.trim();
+  const rootNativeSessionId = context.rootNativeSessionId.trim();
+  if (!sessionId || !rootNativeSessionId) return false;
+  const path = subagentTrackingPath(cwd);
+  return withCrossProcessFileLockSync(path, (lock) => {
+    let raw: string;
+    try {
+      raw = readFileSync(path, 'utf-8');
+    } catch {
+      return false;
+    }
+    const state = parseStrictSubagentTrackingState(raw);
+    if (!state) return false;
+    const timestamp = new Date().toISOString();
+    let changed = false;
+    for (const session of Object.values(state.sessions)) {
+      if (!partitionCorrelatesToRoot(session, sessionId, rootNativeSessionId)) continue;
+      const rootThread = session.threads[rootNativeSessionId];
+      if (!rootThread || rootThread.kind !== 'subagent') continue;
+      const carriesAuthority = rootThread.provenance_kind === NATIVE_SUBAGENT_PROVENANCE
+        || rootThread.direct_child_root_id !== undefined
+        || rootThread.direct_child_parent_id !== undefined;
+      let sessionChanged = false;
+      if (carriesAuthority && rootThread.reopen_authority_revoked !== true) {
+        rootThread.reopen_authority_revoked = true;
+        rootThread.reopen_authority_conflict_reason = 'contradictory_root_child_evidence';
+        rootThread.reopen_authority_conflict_at = timestamp;
+        sessionChanged = true;
+      }
+      if (rootThread.resume_requested_at !== undefined
+        || rootThread.resume_completed_at !== undefined
+        || rootThread.resume_failed_at !== undefined
+        || rootThread.resume_failure_reason !== undefined) {
+        delete rootThread.resume_requested_at;
+        delete rootThread.resume_completed_at;
+        delete rootThread.resume_failed_at;
+        delete rootThread.resume_failure_reason;
+        sessionChanged = true;
+      }
+      if (sessionChanged) {
+        session.updated_at = timestamp;
+        changed = true;
+      }
+    }
+    if (changed) {
+      lock.assertOwnership();
+      writeSubagentTrackingStateSync(cwd, state, lock.publish);
+    }
+    return changed;
+  });
+}
+
 /** Strict, lock-serialized authority consumption for SessionStart persisted reopen output. */
 export function consumeDirectChildReopenContext(
   cwd: string,
@@ -1282,6 +1497,11 @@ export function consumeDirectChildReopenContext(
     }
     const state = parseStrictSubagentTrackingState(raw);
     if (!state) return persistedReopenAuthorityWarning('malformed_tracker_state');
+    // A revocation that could not be published leaves a durable fence. Fenced
+    // ids stay denied here even though the on-disk record still looks valid,
+    // so a failed negative observation can never leave old authority usable.
+    const fence = readAuthorityFence(cwd);
+    if (!fence.ok) return persistedReopenAuthorityWarning('unreadable_authority_fence');
     const repairTimestamp = new Date().toISOString();
     // Root identity repair runs before candidate eligibility so a missing
     // canonical partition cannot leave a known root inversion unrepaired.
@@ -1300,6 +1520,7 @@ export function consumeDirectChildReopenContext(
           || thread.thread_id === sessionId
           || thread.thread_id === rootNativeSessionId
           || session.leader_thread_id === thread.thread_id
+          || fence.ids.has(thread.thread_id)
           || thread.provenance_kind !== NATIVE_SUBAGENT_PROVENANCE
           || thread.direct_child_root_id !== rootNativeSessionId
           || thread.direct_child_parent_id !== rootNativeSessionId

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -166,6 +166,9 @@ function authorityRevisionOf(state: SubagentTrackingState): string {
         thread.reopen_authority_revoked === true ? '1' : '',
         thread.reopen_authority_conflict_reason ?? '',
         thread.reopen_authority_conflict_at ?? '',
+        // Availability gates whether an eligible child is actually emitted as
+        // a reopen target, so it is part of the authority surface.
+        thread.status ?? '',
       ].join('\u0001');
     });
     return [sessionId, session.leader_thread_id ?? '', ...threads].join('\u0002');
@@ -863,20 +866,11 @@ function writeSubagentTrackingStateSync(
   return path;
 }
 
-/**
- * Authority revision observed when a descriptive caller last read the tracker.
- * `writeSubagentTrackingState` uses it to refuse a stale publication that would
- * roll back a newer authority decision.
- */
-const observedAuthorityRevisions = new WeakMap<SubagentTrackingState, string>();
-
 export async function readSubagentTrackingState(cwd: string): Promise<SubagentTrackingState> {
   const path = subagentTrackingPath(cwd);
   if (!existsSync(path)) return createSubagentTrackingState();
   try {
-    const state = normalizeSubagentTrackingState(JSON.parse(await readFile(path, 'utf-8')));
-    observedAuthorityRevisions.set(state, authorityRevisionOf(state));
-    return state;
+    return normalizeSubagentTrackingState(JSON.parse(await readFile(path, 'utf-8')));
   } catch {
     return createSubagentTrackingState();
   }
@@ -896,7 +890,6 @@ export async function writeSubagentTrackingState(cwd: string, state: SubagentTra
   const normalized = normalizeSubagentTrackingState(state);
   const contents = `${JSON.stringify(normalized, null, 2)}\n`;
   const proposedAuthorityRevision = authorityRevisionOf(normalized);
-  const observedAuthorityRevision = observedAuthorityRevisions.get(state);
   return withCrossProcessFileLockSync(path, (lock) => {
     if (existsSync(path)) {
       let raw: string;
@@ -907,14 +900,25 @@ export async function writeSubagentTrackingState(cwd: string, state: SubagentTra
       }
       const current = parseStrictSubagentTrackingState(raw);
       if (!current) throw new Error('Malformed subagent tracker authority state');
-      // Descriptive churn is allowed; authority rollback is not. The write is
-      // refused when on-disk authority has moved since the caller's snapshot
-      // and the proposal does not already carry that newer authority.
-      const currentAuthorityRevision = authorityRevisionOf(current);
-      if (currentAuthorityRevision !== proposedAuthorityRevision
-        && observedAuthorityRevision !== currentAuthorityRevision) {
+      // The generic writer is descriptive-only: it may publish descriptive
+      // churn, but it must never CHANGE the authority surface in any
+      // direction. Granting, revoking, or rolling back authority is reserved
+      // for the lock-owning authority transactions. Requiring the proposed
+      // authority projection to equal the current on-disk projection makes a
+      // stale snapshot, a fresh-read escalation, and a concurrent interleaving
+      // all fail closed with one rule.
+      if (authorityRevisionOf(current) !== proposedAuthorityRevision) {
         throw new Error('Stale subagent tracker authority state');
       }
+    } else if (proposedAuthorityRevision !== authorityRevisionOf(createSubagentTrackingState())) {
+      // Creating the tracker from nothing must not mint authority either.
+      const mintsAuthority = Object.values(normalized.sessions).some((session) =>
+        Object.values(session.threads).some((thread) =>
+          thread.provenance_kind === NATIVE_SUBAGENT_PROVENANCE
+          || thread.direct_child_root_id !== undefined
+          || thread.direct_child_parent_id !== undefined
+          || thread.reopen_authority_revoked !== undefined));
+      if (mintsAuthority) throw new Error('Stale subagent tracker authority state');
     }
     mkdirSync(dirname(path), { recursive: true });
     lock.assertOwnership();
@@ -1173,44 +1177,75 @@ function readAuthorityFence(cwd: string): { ok: boolean; ids: Set<string> } {
   }
 }
 
-/** Record ids whose revocation could not be persisted, so reopen stays denied. */
-export function fenceNativeSubagentAuthorities(cwd: string, childThreadIds: string[], reason: string): void {
+/** Upper bound on fenced ids, so repeated failures cannot grow the fence without limit. */
+export const AUTHORITY_FENCE_MAX_IDS = 512;
+
+/**
+ * Record ids whose revocation could not be persisted, so reopen stays denied.
+ *
+ * Every fence mutation runs under a dedicated cross-process lock on the fence
+ * path so read/merge/publish is atomic with respect to concurrent fencing and
+ * clearing. Returns true when the denial is durable; the caller must treat
+ * false as an unresolved fail-closed condition.
+ */
+export function fenceNativeSubagentAuthorities(cwd: string, childThreadIds: string[], reason: string): boolean {
   const ids = childThreadIds.map((value) => value.trim()).filter(Boolean);
-  if (!ids.length) return;
+  if (!ids.length) return true;
   const path = authorityFencePath(cwd);
-  const existing = readAuthorityFence(cwd);
-  const merged = [...new Set([...existing.ids, ...ids])].sort();
   try {
-    mkdirSync(dirname(path), { recursive: true });
-    const temporaryPath = atomicTrackingTempPath(path);
-    writeFileSync(temporaryPath, `${JSON.stringify({ ids: merged, reason, fenced_at: new Date().toISOString() }, null, 2)}\n`);
-    renameSync(temporaryPath, path);
+    return withCrossProcessFileLockSync(path, (lock) => {
+      const existing = readAuthorityFence(cwd);
+      // An unreadable fence already denies every id; do not weaken it by
+      // rewriting it into a narrower explicit id list.
+      if (!existing.ok) return true;
+      const merged = [...new Set([...existing.ids, ...ids])].sort();
+      if (merged.length > AUTHORITY_FENCE_MAX_IDS) {
+        // Refuse to grow past the cap by writing a deliberately unreadable
+        // sentinel: a global denial is strictly stronger than a partial list.
+        mkdirSync(dirname(path), { recursive: true });
+        lock.assertOwnership();
+        lock.publish(`${JSON.stringify({ ids: 'all', reason: 'fence_capacity_exceeded', fenced_at: new Date().toISOString() }, null, 2)}\n`);
+        return true;
+      }
+      mkdirSync(dirname(path), { recursive: true });
+      lock.assertOwnership();
+      lock.publish(`${JSON.stringify({ ids: merged, reason, fenced_at: new Date().toISOString() }, null, 2)}\n`);
+      return true;
+    });
   } catch {
-    // Best-effort persistence. A fence that cannot be written leaves the
-    // pre-existing fence (if any) intact; consumption still fails closed for
-    // an unreadable fence.
+    // The denial could not be made durable. The caller must surface this
+    // rather than continue as if the revocation had been applied.
+    return false;
   }
 }
 
-/** Drop ids from the fence once their revocation is durably published. */
+/**
+ * Drop ids from the fence once their revocation is durably published.
+ *
+ * Runs under the fence lock and re-reads inside it, so it can never clear
+ * based on a stale snapshot. An unreadable fence is a global denial and is
+ * NEVER destroyed here: only an explicit, fully reconciled id list is removed.
+ */
 function clearAuthorityFence(cwd: string, childThreadIds: string[]): void {
   const path = authorityFencePath(cwd);
   if (!existsSync(path)) return;
   const cleared = new Set(childThreadIds.map((value) => value.trim()).filter(Boolean));
-  const existing = readAuthorityFence(cwd);
+  if (!cleared.size) return;
   try {
-    if (!existing.ok) {
-      unlinkSync(path);
-      return;
-    }
-    const remaining = [...existing.ids].filter((id) => !cleared.has(id)).sort();
-    if (!remaining.length) {
-      unlinkSync(path);
-      return;
-    }
-    const temporaryPath = atomicTrackingTempPath(path);
-    writeFileSync(temporaryPath, `${JSON.stringify({ ids: remaining, reason: 'partial_clear', fenced_at: new Date().toISOString() }, null, 2)}\n`);
-    renameSync(temporaryPath, path);
+    withCrossProcessFileLockSync(path, (lock) => {
+      const existing = readAuthorityFence(cwd);
+      // Preserve an unreadable/global denial. Reconciling it requires explicit
+      // operator action, not an incidental unrelated revocation.
+      if (!existing.ok) return;
+      const remaining = [...existing.ids].filter((id) => !cleared.has(id)).sort();
+      if (remaining.length === existing.ids.size) return;
+      lock.assertOwnership();
+      if (!remaining.length) {
+        unlinkSync(path);
+        return;
+      }
+      lock.publish(`${JSON.stringify({ ids: remaining, reason: 'partial_clear', fenced_at: new Date().toISOString() }, null, 2)}\n`);
+    });
   } catch {
     // Leaving a stale fence entry is fail-closed and therefore acceptable.
   }

--- a/src/subagents/tracker.ts
+++ b/src/subagents/tracker.ts
@@ -13,6 +13,11 @@ export const SUBAGENT_TRACKING_SCHEMA_VERSION = 1;
 export const DEFAULT_SUBAGENT_ACTIVE_WINDOW_MS = 120_000;
 
 export const NATIVE_SUBAGENT_PROVENANCE = 'native_subagent';
+// Legacy descriptive provenance written by pre-authority releases. Tolerated as
+// descriptive-only evidence: it never grants reopen authority and never blocks a
+// newly attested valid direct child, but it is preserved so authority-consistency
+// checks can distinguish recognized legacy data from unknown descriptive views.
+export const DESCRIPTIVE_ADAPTED_PROVENANCE = 'adapted';
 
 export type SubagentAvailabilityStatus = 'available' | 'closed' | 'unavailable';
 
@@ -286,7 +291,9 @@ export function normalizeSubagentTrackingState(input: unknown): SubagentTracking
         ...(typeof candidate.role === 'string' && candidate.role.trim().length > 0 ? { role: candidate.role.trim() } : {}),
         ...(candidate.provenance_kind === NATIVE_SUBAGENT_PROVENANCE
           ? { provenance_kind: NATIVE_SUBAGENT_PROVENANCE }
-          : {}),
+          : candidate.provenance_kind === DESCRIPTIVE_ADAPTED_PROVENANCE
+            ? { provenance_kind: DESCRIPTIVE_ADAPTED_PROVENANCE }
+            : {}),
         ...(typeof candidate.lane_id === 'string' && candidate.lane_id.trim().length > 0 ? { lane_id: candidate.lane_id.trim() } : {}),
         ...(typeof candidate.scope === 'string' && candidate.scope.trim().length > 0 ? { scope: candidate.scope.trim() } : {}),
         ...(typeof candidate.agent_nickname === 'string' && candidate.agent_nickname.trim().length > 0
@@ -803,11 +810,8 @@ export async function readSubagentTrackingStateStrict(cwd: string): Promise<{ ok
     if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return { ok: true, state: createSubagentTrackingState() };
     return { ok: false };
   }
-  try {
-    return { ok: true, state: normalizeSubagentTrackingState(JSON.parse(raw)) };
-  } catch {
-    return { ok: false };
-  }
+  const state = parseStrictSubagentTrackingState(raw);
+  return state ? { ok: true, state } : { ok: false };
 }
 
 
@@ -841,8 +845,20 @@ export async function readSubagentTrackingState(cwd: string): Promise<SubagentTr
 }
 
 export async function writeSubagentTrackingState(cwd: string, state: SubagentTrackingState): Promise<string> {
-  const normalized = normalizeSubagentTrackingState(state);
   const path = subagentTrackingPath(cwd);
+  // Fail closed: never overwrite existing authority-bearing bytes that do not
+  // survive strict parsing. A tolerant read must not launder malformed authority
+  // into a valid-looking attestation through this shared writer.
+  if (existsSync(path)) {
+    let raw: string;
+    try {
+      raw = await readFile(path, 'utf-8');
+    } catch {
+      throw new Error('Malformed subagent tracker authority state');
+    }
+    if (!parseStrictSubagentTrackingState(raw)) throw new Error('Malformed subagent tracker authority state');
+  }
+  const normalized = normalizeSubagentTrackingState(state);
   await mkdir(dirname(path), { recursive: true });
   const temporaryPath = atomicTrackingTempPath(path);
   await writeFile(temporaryPath, `${JSON.stringify(normalized, null, 2)}\n`);
@@ -922,7 +938,9 @@ export function recordSubagentTurn(state: SubagentTrackingState, input: RecordSu
       ? { provenance_kind: NATIVE_SUBAGENT_PROVENANCE }
       : existingThread?.provenance_kind === NATIVE_SUBAGENT_PROVENANCE
         ? { provenance_kind: NATIVE_SUBAGENT_PROVENANCE }
-        : {}),
+        : existingThread?.provenance_kind === DESCRIPTIVE_ADAPTED_PROVENANCE
+          ? { provenance_kind: DESCRIPTIVE_ADAPTED_PROVENANCE }
+          : {}),
     ...(input.laneId?.trim() ? { lane_id: input.laneId.trim() } : existingThread?.lane_id ? { lane_id: existingThread.lane_id } : {}),
     ...(input.scope?.trim() ? { scope: input.scope.trim() } : existingThread?.scope ? { scope: existingThread.scope } : {}),
     ...(input.agentNickname?.trim()
@@ -1126,6 +1144,110 @@ function persistedReopenAuthorityWarning(reason: string): string {
   ].join('\n');
 }
 
+function persistedReopenLegacyNotice(excludedCount: number, source: string): string {
+  return [
+    '[Persisted subagent reopen]',
+    `- SessionStart source: ${source}; saved subagent ids found: 0.`,
+    `- Notice: ${excludedCount} persisted subagent record(s) were excluded as non-authoritative or legacy; no resume authority or bookkeeping was granted.`,
+    '- Silver rule: do not spawn a same-role/same-lane replacement solely because persisted reopen authority was unavailable; continue in the root or another compatible existing lane.',
+  ].join('\n');
+}
+
+/**
+ * Repair persisted root-as-subagent identity inversion inside an already-parsed
+ * state. A thread whose id equals the native root id is conclusively the root and
+ * is reclassified as leader. A thread whose id equals only the canonical session
+ * key while carrying a valid direct-child attestation is ambiguous: it is denied
+ * (authority revoked) without destructive reclassification. Returns true when any
+ * record changed.
+ */
+function repairPersistedRootIdentityInState(
+  state: SubagentTrackingState,
+  sessionId: string,
+  rootNativeSessionId: string,
+  repairTimestamp: string,
+): boolean {
+  let changed = false;
+  for (const correlatedSession of Object.values(state.sessions)) {
+    let sessionChanged = false;
+    for (const rootId of new Set([sessionId, rootNativeSessionId])) {
+      const rootThread = correlatedSession.threads[rootId];
+      if (!rootThread || rootThread.kind !== 'subagent') continue;
+      const ambiguousCanonicalCollision =
+        rootId === sessionId
+        && sessionId !== rootNativeSessionId
+        && rootThread.provenance_kind === NATIVE_SUBAGENT_PROVENANCE
+        && typeof rootThread.direct_child_root_id === 'string'
+        && typeof rootThread.direct_child_parent_id === 'string';
+      if (ambiguousCanonicalCollision) {
+        // Fail closed without rewriting identity: the id collides with the
+        // canonical root key but carries child attestation, so it stays a
+        // subagent whose reopen authority is revoked until root identity is
+        // independently established.
+        rootThread.reopen_authority_revoked = true;
+        rootThread.reopen_authority_conflict_reason = 'canonical_root_collision';
+        rootThread.reopen_authority_conflict_at = repairTimestamp;
+        delete rootThread.resume_requested_at;
+        delete rootThread.resume_completed_at;
+        delete rootThread.resume_failed_at;
+        delete rootThread.resume_failure_reason;
+        sessionChanged = true;
+        continue;
+      }
+      rootThread.kind = 'leader';
+      delete rootThread.direct_child_root_id;
+      delete rootThread.direct_child_parent_id;
+      delete rootThread.reopen_authority_revoked;
+      delete rootThread.reopen_authority_conflict_reason;
+      delete rootThread.reopen_authority_conflict_at;
+      delete rootThread.resume_requested_at;
+      delete rootThread.resume_completed_at;
+      delete rootThread.resume_failed_at;
+      delete rootThread.resume_failure_reason;
+      sessionChanged = true;
+    }
+    if (correlatedSession.threads[rootNativeSessionId] && correlatedSession.leader_thread_id !== rootNativeSessionId) {
+      correlatedSession.leader_thread_id = rootNativeSessionId;
+      sessionChanged = true;
+    }
+    if (sessionChanged) {
+      correlatedSession.updated_at = repairTimestamp;
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+/**
+ * Pointer-authoritative root identity repair, decoupled from reopen candidate
+ * output. Runs under the tracker lock and fails closed on malformed bytes.
+ */
+export function repairPersistedRootIdentity(
+  cwd: string,
+  context: { sessionId: string; rootNativeSessionId: string },
+): boolean {
+  const sessionId = context.sessionId.trim();
+  const rootNativeSessionId = context.rootNativeSessionId.trim();
+  if (!sessionId || !rootNativeSessionId) return false;
+  const path = subagentTrackingPath(cwd);
+  return withCrossProcessFileLockSync(path, (lock) => {
+    let raw: string;
+    try {
+      raw = readFileSync(path, 'utf-8');
+    } catch {
+      return false;
+    }
+    const state = parseStrictSubagentTrackingState(raw);
+    if (!state) return false;
+    const changed = repairPersistedRootIdentityInState(state, sessionId, rootNativeSessionId, new Date().toISOString());
+    if (changed) {
+      lock.assertOwnership();
+      writeSubagentTrackingStateSync(cwd, state, lock.publish);
+    }
+    return changed;
+  });
+}
+
 /** Strict, lock-serialized authority consumption for SessionStart persisted reopen output. */
 export function consumeDirectChildReopenContext(
   cwd: string,
@@ -1145,35 +1267,17 @@ export function consumeDirectChildReopenContext(
     }
     const state = parseStrictSubagentTrackingState(raw);
     if (!state) return persistedReopenAuthorityWarning('malformed_tracker_state');
-    const session = state.sessions[sessionId];
-    if (!session) return null;
-    let changed = false;
     const repairTimestamp = new Date().toISOString();
-    for (const correlatedSession of Object.values(state.sessions)) {
-      let sessionChanged = false;
-      for (const rootId of new Set([sessionId, rootNativeSessionId])) {
-        const rootThread = correlatedSession.threads[rootId];
-        if (!rootThread || rootThread.kind !== 'subagent') continue;
-        rootThread.kind = 'leader';
-        delete rootThread.direct_child_root_id;
-        delete rootThread.direct_child_parent_id;
-        delete rootThread.reopen_authority_revoked;
-        delete rootThread.reopen_authority_conflict_reason;
-        delete rootThread.reopen_authority_conflict_at;
-        delete rootThread.resume_requested_at;
-        delete rootThread.resume_completed_at;
-        delete rootThread.resume_failed_at;
-        delete rootThread.resume_failure_reason;
-        sessionChanged = true;
+    // Root identity repair runs before candidate eligibility so a missing
+    // canonical partition cannot leave a known root inversion unrepaired.
+    const changed = repairPersistedRootIdentityInState(state, sessionId, rootNativeSessionId, repairTimestamp);
+    const session = state.sessions[sessionId];
+    if (!session) {
+      if (changed) {
+        lock.assertOwnership();
+        writeSubagentTrackingStateSync(cwd, state, lock.publish);
       }
-      if (correlatedSession.threads[rootNativeSessionId] && correlatedSession.leader_thread_id !== rootNativeSessionId) {
-        correlatedSession.leader_thread_id = rootNativeSessionId;
-        sessionChanged = true;
-      }
-      if (sessionChanged) {
-        correlatedSession.updated_at = repairTimestamp;
-        changed = true;
-      }
+      return null;
     }
     const savedSubagents = Object.values(session.threads)
       .filter((thread) => {
@@ -1188,6 +1292,9 @@ export function consumeDirectChildReopenContext(
         return Object.values(state.sessions).every((correlationSession) => {
           const view = correlationSession.threads[thread.thread_id];
           if (!view) return true;
+          // Recognized legacy adapted records are descriptive-only: they never
+          // grant authority and never block a newly attested valid child.
+          if (view.provenance_kind === DESCRIPTIVE_ADAPTED_PROVENANCE) return true;
           return correlationSession.leader_thread_id !== thread.thread_id
             && view.kind === 'subagent'
             && view.provenance_kind === NATIVE_SUBAGENT_PROVENANCE
@@ -1203,6 +1310,18 @@ export function consumeDirectChildReopenContext(
         session.updated_at = new Date().toISOString();
         lock.assertOwnership();
         writeSubagentTrackingStateSync(cwd, state, lock.publish);
+      }
+      // Surface intentional exclusion of legacy/non-authoritative records instead
+      // of silently returning no context. Authority-bearing denials (revoked,
+      // leader-colliding, cross-partition conflicts) stay fail-closed null.
+      const subagentThreads = Object.values(session.threads).filter((thread) => thread.kind === 'subagent');
+      const hadAuthorityBearing = subagentThreads.some((thread) =>
+        thread.provenance_kind === NATIVE_SUBAGENT_PROVENANCE
+        || thread.direct_child_root_id !== undefined
+        || thread.direct_child_parent_id !== undefined
+        || thread.reopen_authority_revoked === true);
+      if (!hadAuthorityBearing && subagentThreads.length > 0) {
+        return persistedReopenLegacyNotice(subagentThreads.length, context.source);
       }
       return null;
     }


### PR DESCRIPTION
## Summary

- separate descriptive native-subagent lifecycle tracking from persisted reopen authority
- require strict direct-child root/parent attestation before emitting `resume_agent(...)`
- fail closed for root self-ID, conflicting aliases, transcript/hook identity mismatch, malformed ledgers, cross-partition disagreement, nested descendants, and revoked authority
- serialize authority observation, conflict revocation/repair, reopen bookkeeping, and bounded context rendering under the tracker lock
- preserve current `dev` native cache/release behavior from #3285 and unrelated Stop/HUD/notification/Ralph/consensus/Team/Ultragoal/recovery contracts

Closes #3284

## Verification

- independent pre-edit reproduction confirmed the current root could be emitted as its own `resume_agent` target and receive `resume_requested_at`
- `npm run build`
- focused compiled suites: 597/597 codex-native-hook, 45/45 tracker, 4/4 leader-bootstrap
- `npm run check:no-unused`
- `npm run lint`
- `git diff --check origin/dev...HEAD`
- `npm run test:recent-bug-regressions:compiled`
- `npm run test:explicit-terminal-contract:compiled`
- `npm run test:ralph-persistence:compiled`
- `npm run test:node` (one unrelated MCP lifecycle flake; isolated exact-head rerun passed 15/15)
- `npm run sync:plugin:check`
- `npm run verify:plugin-bundle`
- `npm run verify:native-agents`
- frozen exact-head Architect review: CLEAR/CLEAR/CLEAR, APPROVE

## Exact head

- base: `99d87f36e1ab14fcfc76c54ca0ff809bb965f6cf`
- head: `d5d96cb1d42f0786ef19eb30ce145032509c1846`
- reviewed diff SHA-256: `1f8d1750818979eadbc0c3834fb038bacd60f50ce90af3968ecc8132c13ef880`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*