### PR TITLE
fix(ultragoal): persist aggregate completion on ordinary final checkpoint

### DIFF
--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -325,7 +325,7 @@ describe('cli/ultragoal', () => {
         reconciliation?: { ok: boolean; warnings: string[]; snapshot: { unavailableReason?: string } };
       };
       assert.equal(parsed.summary.complete, 1);
-      assert.equal(parsed.summary.aggregateComplete, false);
+      assert.equal(parsed.summary.aggregateComplete, true);
       assert.equal(parsed.summary.artifactComplete, true);
       assert.equal(parsed.codexGoalFallback?.status, 'codex_goal_reconciliation_unavailable');
       assert.equal(parsed.codexGoalFallback?.reason, 'db_schema_context_error');
@@ -339,7 +339,7 @@ describe('cli/ultragoal', () => {
         JSON.stringify({ error: 'SQL error: no such table: thread_goals' }),
       ]));
       const output = human.stdout.join('\n');
-      assert.match(output, /ultragoal artifact goals: complete/);
+      assert.match(output, /ultragoal aggregate product: complete/);
       assert.match(output, /codex goal fallback: Codex goal DB\/schema\/context is unavailable/);
       assert.match(output, /codex goal warning: .*no such table: thread_goals/);
     });

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -1073,17 +1073,102 @@ describe('ultragoal artifacts', () => {
       ]);
 
       const tampered = await readUltragoalPlan(cwd);
-      assert.equal(isFinalRunCompletionCandidate(tampered, tampered.goals.find((goal) => goal.id === 'G004-final')!), true);
+      assert.equal(isFinalRunCompletionCandidate(tampered, tampered.goals.find((goal) => goal.id === 'G004-final')!), false);
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: 'G004-final',
+          status: 'complete',
+          evidence: 'G004-final completed planned work for .omx/ultragoal/goals.json; validation complete; reviews clean.',
+          codexGoal: { goal: { objective, status: 'complete' } },
+          qualityGate: cleanQualityGate(),
+        }),
+        /not complete|objective mismatch|Completed task-scoped aggregate reconciliation/,
+      );
+
+      const plan = await readUltragoalPlan(cwd);
+      assert.equal(plan.goals.find((goal) => goal.id === 'G001-parent')?.status, 'review_blocked');
+      assert.equal(plan.aggregateCompletion, undefined);
+      assert.equal(summarizeUltragoalPlan(plan).aggregateComplete, false);
+      assert.equal(isUltragoalDone(plan), false);
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 0);
+    });
+  });
+
+  it('does not terminalize when a falsely-resolved parent coexists with a legitimate designated resolver', async () => {
+    await withTempRepo(async (cwd) => {
+      const objective = ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE;
+      await writeAggregateFixturePlan(cwd, 'G004-resolver-b', [
+        aggregateFixtureGoal('G001-parent-a', 'review_blocked', {
+          reviewBlockerResolution: {
+            resolverGoalId: 'G002-resolver-a',
+            status: 'complete',
+            resolvedAt: '2026-01-01T00:00:00.000Z',
+            evidence: 'forged resolution metadata for parent A',
+          },
+        }),
+        aggregateFixtureGoal('G002-resolver-a', 'complete', {
+          completedAt: '2026-01-01T00:00:00.000Z',
+          evidence: 'resolver A done',
+          resolvesReviewBlockedGoalId: 'G009-elsewhere',
+        }),
+        aggregateFixtureGoal('G003-parent-b', 'review_blocked', {
+          reviewBlockerResolution: {
+            resolverGoalId: 'G004-resolver-b',
+            status: 'pending',
+            evidence: 'legitimate blocker for parent B',
+          },
+        }),
+        aggregateFixtureGoal('G004-resolver-b', 'in_progress', {
+          startedAt: '2026-01-01T00:00:00.000Z',
+          resolvesReviewBlockedGoalId: 'G003-parent-b',
+        }),
+      ]);
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: 'G004-resolver-b',
+          status: 'complete',
+          evidence: 'G004-resolver-b completed planned work for .omx/ultragoal/goals.json; validation complete; reviews clean.',
+          codexGoal: { goal: { objective, status: 'complete' } },
+          qualityGate: cleanQualityGate(),
+        }),
+        /not complete|objective mismatch|Completed task-scoped aggregate reconciliation/,
+      );
+
+      const plan = await readUltragoalPlan(cwd);
+      assert.equal(plan.goals.find((goal) => goal.id === 'G001-parent-a')?.status, 'review_blocked');
+      assert.equal(plan.aggregateCompletion, undefined);
+      assert.equal(summarizeUltragoalPlan(plan).aggregateComplete, false);
+      assert.equal(isUltragoalDone(plan), false);
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 0);
+    });
+  });
+
+  it('does not treat a self-referential review-blocker resolver as a designated resolver', async () => {
+    await withTempRepo(async (cwd) => {
+      const objective = ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE;
+      await writeAggregateFixturePlan(cwd, 'G001-self', [
+        aggregateFixtureGoal('G001-self', 'review_blocked', {
+          reviewBlockerResolution: {
+            resolverGoalId: 'G001-self',
+            status: 'pending',
+            evidence: 'self-referential resolver metadata',
+          },
+          resolvesReviewBlockedGoalId: 'G001-self',
+        }),
+      ]);
 
       const completed = await checkpointUltragoal(cwd, {
-        goalId: 'G004-final',
+        goalId: 'G001-self',
         status: 'complete',
-        evidence: 'G004-final completed planned work for .omx/ultragoal/goals.json; validation complete; reviews clean.',
+        evidence: 'G001-self completed planned work for .omx/ultragoal/goals.json; validation complete; reviews clean.',
         codexGoal: { goal: { objective, status: 'complete' } },
         qualityGate: cleanQualityGate(),
       });
 
-      assert.equal(completed.goals.find((goal) => goal.id === 'G001-parent')?.status, 'review_blocked');
       assert.equal(completed.aggregateCompletion, undefined);
       assert.equal(summarizeUltragoalPlan(completed).aggregateComplete, false);
       const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -606,6 +606,12 @@ describe('ultragoal artifacts', () => {
         codexGoal: { goal: { objective: aggregateObjective, status: 'active' } },
       });
 
+      const midRunPlan = await readUltragoalPlan(cwd);
+      assert.equal(midRunPlan.goals.find((goal) => goal.id === 'G001-first')?.status, 'complete');
+      assert.equal(midRunPlan.goals.find((goal) => goal.id === 'G002-second')?.status, 'pending');
+      assert.equal(midRunPlan.aggregateCompletion, undefined);
+      assert.equal(summarizeUltragoalPlan(midRunPlan).aggregateComplete, false);
+
       const second = await startNextUltragoal(cwd);
       await checkpointUltragoal(cwd, {
         goalId: second.goal!.id,
@@ -616,8 +622,16 @@ describe('ultragoal artifacts', () => {
       });
 
       const plan = await readUltragoalPlan(cwd);
+      assert.equal(plan.goals.find((goal) => goal.id === second.goal!.id)?.status, 'complete');
       assert.equal(plan.goals.every((goal) => goal.status === 'complete'), true);
       assert.equal(plan.activeGoalId, undefined);
+      assert.equal(plan.aggregateCompletion?.status, 'complete');
+      const summary = summarizeUltragoalPlan(plan);
+      assert.equal(summary.aggregateComplete, true);
+      assert.equal(summary.artifactComplete, true);
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.equal((ledger.match(/"event":"goal_completed"/g) ?? []).length, 2);
+      assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 1);
     });
   });
 
@@ -885,6 +899,124 @@ describe('ultragoal artifacts', () => {
       assert.match(ledger, /code-reviewer REQUEST CHANGES before resolver/);
       assert.match(ledger, /Review-blocked final story resolved by/);
       assert.match(ledger, /"event":"aggregate_completed"/);
+    });
+  });
+
+  it('does not terminalize through a one-way designated resolver pointer', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [{ title: 'Final', objective: 'Complete final milestone.' }],
+      });
+      const started = await startNextUltragoal(cwd);
+      const objective = started.plan.codexObjective!;
+      const blocked = await recordFinalReviewBlockers(cwd, {
+        goalId: started.goal!.id,
+        title: 'Resolve final code-review blockers',
+        objective: 'Fix final code-review blockers and rerun final gates.',
+        evidence: 'code-reviewer REQUEST CHANGES before resolver',
+        codexGoal: { goal: { objective, status: 'active' } },
+      });
+      const resolver = await startNextUltragoal(cwd);
+      assert.equal(resolver.goal?.id, blocked.addedGoal.id);
+
+      const planPath = join(cwd, '.omx/ultragoal/goals.json');
+      const tampered = JSON.parse(await readFile(planPath, 'utf-8')) as UltragoalPlan;
+      const resolverGoal = tampered.goals.find((goal) => goal.id === resolver.goal!.id)!;
+      delete resolverGoal.resolvesReviewBlockedGoalId;
+      await writeFile(planPath, `${JSON.stringify(tampered, null, 2)}\n`);
+
+      const parentBeforeCheckpoint = tampered.goals.find((goal) => goal.id === blocked.blockedGoal.id);
+      assert.equal(isFinalRunCompletionCandidate(tampered, resolverGoal), true);
+      assert.equal(parentBeforeCheckpoint?.reviewBlockerResolution?.resolverGoalId, resolverGoal.id);
+
+      const completed = await checkpointUltragoal(cwd, {
+        goalId: resolverGoal.id,
+        status: 'complete',
+        evidence: `${resolverGoal.id} fixed blockers; final gate passed for .omx/ultragoal/goals.json`,
+        codexGoal: { goal: { objective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      });
+      const parent = completed.goals.find((goal) => goal.id === blocked.blockedGoal.id);
+      const completedResolver = completed.goals.find((goal) => goal.id === resolverGoal.id);
+      const summary = summarizeUltragoalPlan(completed);
+
+      assert.equal(completedResolver?.status, 'complete');
+      assert.equal(parent?.status, 'review_blocked');
+      assert.equal(parent?.reviewBlockerResolution?.resolverGoalId, resolverGoal.id);
+      assert.equal(completed.aggregateCompletion, undefined);
+      assert.equal(summary.reviewBlocked, 1);
+      assert.equal(summary.aggregateComplete, false);
+      assert.equal(summary.artifactComplete, false);
+      assert.equal(isUltragoalDone(completed), false);
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 0);
+    });
+  });
+
+  it('does not terminalize when two unresolved review-blocked parents point at one resolver', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [{ title: 'Final', objective: 'Complete final milestone.' }],
+      });
+      const started = await startNextUltragoal(cwd);
+      const objective = started.plan.codexObjective!;
+      const blocked = await recordFinalReviewBlockers(cwd, {
+        goalId: started.goal!.id,
+        title: 'Resolve final code-review blockers',
+        objective: 'Fix final code-review blockers and rerun final gates.',
+        evidence: 'code-reviewer REQUEST CHANGES before resolver',
+        codexGoal: { goal: { objective, status: 'active' } },
+      });
+      const resolver = await startNextUltragoal(cwd);
+      assert.equal(resolver.goal?.id, blocked.addedGoal.id);
+
+      const planPath = join(cwd, '.omx/ultragoal/goals.json');
+      const tampered = JSON.parse(await readFile(planPath, 'utf-8')) as UltragoalPlan;
+      const resolverGoal = tampered.goals.find((goal) => goal.id === resolver.goal!.id)!;
+      const originalParent = tampered.goals.find((goal) => goal.id === blocked.blockedGoal.id)!;
+      tampered.goals.push({
+        ...originalParent,
+        id: 'G999-forged-second-parent',
+        title: 'Forged second review-blocked parent',
+        objective: 'Forge a second unresolved review-blocked parent.',
+        status: 'review_blocked',
+        reviewBlockerResolution: {
+          resolverGoalId: resolverGoal.id,
+          status: 'pending',
+          evidence: 'forged second parent',
+        },
+      });
+      await writeFile(planPath, `${JSON.stringify(tampered, null, 2)}\n`);
+
+      assert.equal(tampered.goals.filter((goal) => goal.status === 'review_blocked').length, 2);
+      assert.equal(isFinalRunCompletionCandidate(tampered, resolverGoal), true);
+
+      const completed = await checkpointUltragoal(cwd, {
+        goalId: resolverGoal.id,
+        status: 'complete',
+        evidence: `${resolverGoal.id} fixed blockers; final gate passed for .omx/ultragoal/goals.json`,
+        codexGoal: { goal: { objective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      });
+      const originalParentAfter = completed.goals.find((goal) => goal.id === originalParent.id);
+      const secondParentAfter = completed.goals.find((goal) => goal.id === 'G999-forged-second-parent');
+      const completedResolver = completed.goals.find((goal) => goal.id === resolverGoal.id);
+      const summary = summarizeUltragoalPlan(completed);
+
+      assert.equal(completedResolver?.status, 'complete');
+      assert.equal(originalParentAfter?.status, 'complete');
+      assert.equal(originalParentAfter?.reviewBlockerResolution?.status, 'complete');
+      assert.equal(secondParentAfter?.status, 'review_blocked');
+      assert.equal(secondParentAfter?.reviewBlockerResolution?.status, 'pending');
+      assert.equal(completed.aggregateCompletion, undefined);
+      assert.equal(summary.reviewBlocked, 1);
+      assert.equal(summary.aggregateComplete, false);
+      assert.equal(summary.artifactComplete, false);
+      assert.equal(isUltragoalDone(completed), false);
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 0);
     });
   });
 

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -1233,6 +1233,126 @@ describe('ultragoal artifacts', () => {
     });
   });
 
+  it('does not terminalize a final aggregate candidate that is not the active in-progress goal', async () => {
+    const objective = ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE;
+    for (const unowned of ['pending', 'failed', 'needs_user_decision'] as const) {
+      await withTempRepo(async (cwd) => {
+        await writeAggregateFixturePlan(cwd, 'G002-target', [
+          aggregateFixtureGoal('G001-first', 'complete', { completedAt: '2026-01-01T00:00:00.000Z', evidence: 'first done' }),
+          aggregateFixtureGoal('G002-target', unowned),
+        ]);
+
+        const tampered = await readUltragoalPlan(cwd);
+        assert.equal(isFinalRunCompletionCandidate(tampered, tampered.goals.find((goal) => goal.id === 'G002-target')!), true);
+
+        const completed = await checkpointUltragoal(cwd, {
+          goalId: 'G002-target',
+          status: 'complete',
+          evidence: 'G002-target completed planned work for .omx/ultragoal/goals.json; validation complete; reviews clean.',
+          codexGoal: { goal: { objective, status: 'complete' } },
+          qualityGate: cleanQualityGate(),
+        });
+
+        assert.equal(completed.aggregateCompletion, undefined, unowned);
+        assert.equal(summarizeUltragoalPlan(completed).aggregateComplete, false, unowned);
+        const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+        assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 0, unowned);
+      });
+    }
+  });
+
+  it('keeps terminal aggregate completion idempotent under repeated and concurrent final checkpoints', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [
+          { title: 'First', objective: 'Complete first milestone.' },
+          { title: 'Second', objective: 'Complete second milestone.' },
+        ],
+      });
+      const first = await startNextUltragoal(cwd);
+      const aggregateObjective = first.plan.codexObjective!;
+      await checkpointUltragoal(cwd, {
+        goalId: first.goal!.id,
+        status: 'complete',
+        evidence: 'first audit passed',
+        codexGoal: { goal: { objective: aggregateObjective, status: 'active' } },
+      });
+
+      const second = await startNextUltragoal(cwd);
+      const terminal = await checkpointUltragoal(cwd, {
+        goalId: second.goal!.id,
+        status: 'complete',
+        evidence: 'final audit passed',
+        codexGoal: { goal: { objective: aggregateObjective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      });
+      const firstCompletedAt = terminal.aggregateCompletion?.completedAt;
+      assert.equal(terminal.aggregateCompletion?.status, 'complete');
+      assert.ok(firstCompletedAt);
+
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        await checkpointUltragoal(cwd, {
+          goalId: second.goal!.id,
+          status: 'complete',
+          evidence: `repeated terminal checkpoint ${attempt}`,
+          codexGoal: { goal: { objective: aggregateObjective, status: 'complete' } },
+          qualityGate: cleanQualityGate(),
+        }).catch(() => undefined);
+      }
+
+      await Promise.allSettled(Array.from({ length: 5 }, (_, index) => checkpointUltragoal(cwd, {
+        goalId: second.goal!.id,
+        status: 'complete',
+        evidence: `concurrent terminal checkpoint ${index}`,
+        codexGoal: { goal: { objective: aggregateObjective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      })));
+
+      const plan = await readUltragoalPlan(cwd);
+      assert.equal(plan.aggregateCompletion?.status, 'complete');
+      assert.equal(plan.aggregateCompletion?.completedAt, firstCompletedAt);
+      assert.equal(summarizeUltragoalPlan(plan).aggregateComplete, true);
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 1);
+    });
+  });
+
+  it('pins allowActiveFinalCodexGoal as a required negative condition for terminal aggregate completion', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [
+          { title: 'First', objective: 'Complete first milestone.' },
+          { title: 'Second', objective: 'Complete second milestone.' },
+        ],
+      });
+      const first = await startNextUltragoal(cwd);
+      const aggregateObjective = first.plan.codexObjective!;
+      await checkpointUltragoal(cwd, {
+        goalId: first.goal!.id,
+        status: 'complete',
+        evidence: 'first audit passed',
+        codexGoal: { goal: { objective: aggregateObjective, status: 'active' } },
+      });
+
+      const second = await startNextUltragoal(cwd);
+      const completed = await checkpointUltragoal(cwd, {
+        goalId: second.goal!.id,
+        status: 'complete',
+        evidence: 'final story completed while the aggregate Codex goal stays active',
+        codexGoal: { goal: { objective: aggregateObjective, status: 'active' } },
+        allowActiveFinalCodexGoal: true,
+      });
+
+      assert.equal(completed.goals.find((goal) => goal.id === second.goal!.id)?.status, 'complete');
+      assert.equal(completed.aggregateCompletion, undefined);
+      assert.equal(summarizeUltragoalPlan(completed).aggregateComplete, false);
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 0);
+    });
+  });
+
   it('does not reconcile a review-blocked parent from a non-designated resolver goal', async () => {
     await withTempRepo(async (cwd) => {
       await createUltragoalPlan(cwd, {

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -79,7 +79,7 @@ function aggregateFixtureGoal(id: string, status: string, extra: Record<string, 
   };
 }
 
-async function writeAggregateFixturePlan(cwd: string, activeGoalId: string, goals: Array<Record<string, unknown>>): Promise<void> {
+async function writeAggregateFixturePlan(cwd: string, activeGoalId: string | undefined, goals: Array<Record<string, unknown>>): Promise<void> {
   await mkdir(join(cwd, '.omx/ultragoal'), { recursive: true });
   await writeFile(join(cwd, '.omx/ultragoal/brief.md'), 'aggregate terminalization fixture\n');
   await writeFile(join(cwd, '.omx/ultragoal/goals.json'), `${JSON.stringify({
@@ -1350,6 +1350,77 @@ describe('ultragoal artifacts', () => {
       assert.equal(summarizeUltragoalPlan(completed).aggregateComplete, false);
       const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
       assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 0);
+    });
+  });
+
+  it('does not terminalize an in-progress final candidate whose activeGoalId pointer does not match', async () => {
+    const objective = ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE;
+    for (const activePointer of ['G001-first', undefined] as const) {
+      await withTempRepo(async (cwd) => {
+        await writeAggregateFixturePlan(cwd, activePointer, [
+          aggregateFixtureGoal('G001-first', 'complete', { completedAt: '2026-01-01T00:00:00.000Z', evidence: 'first done' }),
+          aggregateFixtureGoal('G002-target', 'in_progress', { startedAt: '2026-01-01T00:00:00.000Z' }),
+        ]);
+
+        const tampered = await readUltragoalPlan(cwd);
+        const target = tampered.goals.find((goal) => goal.id === 'G002-target')!;
+        assert.equal(target.status, 'in_progress');
+        assert.equal(isFinalRunCompletionCandidate(tampered, target), true);
+
+        const completed = await checkpointUltragoal(cwd, {
+          goalId: 'G002-target',
+          status: 'complete',
+          evidence: 'G002-target completed planned work for .omx/ultragoal/goals.json; validation complete; reviews clean.',
+          codexGoal: { goal: { objective, status: 'complete' } },
+          qualityGate: cleanQualityGate(),
+        });
+
+        assert.equal(completed.aggregateCompletion, undefined, String(activePointer));
+        assert.equal(summarizeUltragoalPlan(completed).aggregateComplete, false, String(activePointer));
+        const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+        assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 0, String(activePointer));
+      });
+    }
+  });
+
+  it('freezes a completed aggregate plan against post-terminal failure checkpoints and goal additions', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [{ title: 'Only', objective: 'Complete the only milestone.' }],
+      });
+      const started = await startNextUltragoal(cwd);
+      const terminal = await checkpointUltragoal(cwd, {
+        goalId: started.goal!.id,
+        status: 'complete',
+        evidence: 'terminal aggregate checkpoint',
+        codexGoal: { goal: { objective: started.plan.codexObjective!, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      });
+      assert.equal(terminal.aggregateCompletion?.status, 'complete');
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: started.goal!.id,
+          status: 'failed',
+          evidence: 'post-terminal failure attempt',
+        }),
+        /after the aggregate ultragoal plan is complete/,
+      );
+
+      await assert.rejects(
+        () => addUltragoalGoal(cwd, { title: 'Post terminal', objective: 'Added after completion.' }),
+        /already completed aggregate ultragoal plan/,
+      );
+
+      const plan = await readUltragoalPlan(cwd);
+      assert.equal(plan.goals.length, 1);
+      assert.equal(plan.goals[0]?.status, 'complete');
+      assert.equal(plan.aggregateCompletion?.status, 'complete');
+      assert.equal(summarizeUltragoalPlan(plan).aggregateComplete, true);
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 1);
+      assert.equal((ledger.match(/"event":"goal_failed"/g) ?? []).length, 0);
     });
   });
 

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -66,6 +66,37 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function aggregateFixtureGoal(id: string, status: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id,
+    title: id,
+    objective: `${id} work.`,
+    status,
+    attempt: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...extra,
+  };
+}
+
+async function writeAggregateFixturePlan(cwd: string, activeGoalId: string, goals: Array<Record<string, unknown>>): Promise<void> {
+  await mkdir(join(cwd, '.omx/ultragoal'), { recursive: true });
+  await writeFile(join(cwd, '.omx/ultragoal/brief.md'), 'aggregate terminalization fixture\n');
+  await writeFile(join(cwd, '.omx/ultragoal/goals.json'), `${JSON.stringify({
+    version: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    briefPath: '.omx/ultragoal/brief.md',
+    goalsPath: '.omx/ultragoal/goals.json',
+    ledgerPath: '.omx/ultragoal/ledger.jsonl',
+    codexGoalMode: 'aggregate',
+    codexObjective: ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE,
+    activeGoalId,
+    goals,
+  }, null, 2)}\n`);
+  await writeFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), '');
+}
+
 async function writeFixturePlan(cwd: string, plan: UltragoalPlan): Promise<void> {
   await mkdir(join(cwd, '.omx/ultragoal'), { recursive: true });
   await writeFile(join(cwd, '.omx/ultragoal/brief.md'), 'G001-core-steering-model fixture for .omx/ultragoal steering behavior.\n');
@@ -1014,6 +1045,103 @@ describe('ultragoal artifacts', () => {
       assert.equal(summary.reviewBlocked, 1);
       assert.equal(summary.aggregateComplete, false);
       assert.equal(summary.artifactComplete, false);
+      assert.equal(isUltragoalDone(completed), false);
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 0);
+    });
+  });
+
+  it('does not terminalize when a review-blocked parent names a resolver whose back-pointer targets another parent', async () => {
+    await withTempRepo(async (cwd) => {
+      const objective = ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE;
+      await writeAggregateFixturePlan(cwd, 'G004-final', [
+        aggregateFixtureGoal('G001-parent', 'review_blocked', {
+          reviewBlockerResolution: {
+            resolverGoalId: 'G002-resolver',
+            status: 'complete',
+            resolvedAt: '2026-01-01T00:00:00.000Z',
+            evidence: 'forged resolution metadata',
+          },
+        }),
+        aggregateFixtureGoal('G002-resolver', 'complete', {
+          completedAt: '2026-01-01T00:00:00.000Z',
+          evidence: 'resolver done',
+          resolvesReviewBlockedGoalId: 'G003-other',
+        }),
+        aggregateFixtureGoal('G003-other', 'complete', { completedAt: '2026-01-01T00:00:00.000Z', evidence: 'other done' }),
+        aggregateFixtureGoal('G004-final', 'in_progress', { startedAt: '2026-01-01T00:00:00.000Z' }),
+      ]);
+
+      const tampered = await readUltragoalPlan(cwd);
+      assert.equal(isFinalRunCompletionCandidate(tampered, tampered.goals.find((goal) => goal.id === 'G004-final')!), true);
+
+      const completed = await checkpointUltragoal(cwd, {
+        goalId: 'G004-final',
+        status: 'complete',
+        evidence: 'G004-final completed planned work for .omx/ultragoal/goals.json; validation complete; reviews clean.',
+        codexGoal: { goal: { objective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      });
+
+      assert.equal(completed.goals.find((goal) => goal.id === 'G001-parent')?.status, 'review_blocked');
+      assert.equal(completed.aggregateCompletion, undefined);
+      assert.equal(summarizeUltragoalPlan(completed).aggregateComplete, false);
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 0);
+    });
+  });
+
+  it('does not terminalize when the final aggregate candidate is steering-blocked', async () => {
+    await withTempRepo(async (cwd) => {
+      const objective = ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE;
+      await writeAggregateFixturePlan(cwd, 'G002-target', [
+        aggregateFixtureGoal('G001-first', 'complete', { completedAt: '2026-01-01T00:00:00.000Z', evidence: 'first done' }),
+        aggregateFixtureGoal('G002-target', 'in_progress', { startedAt: '2026-01-01T00:00:00.000Z', steeringStatus: 'blocked' }),
+      ]);
+
+      const tampered = await readUltragoalPlan(cwd);
+      assert.equal(isFinalRunCompletionCandidate(tampered, tampered.goals.find((goal) => goal.id === 'G002-target')!), true);
+
+      const completed = await checkpointUltragoal(cwd, {
+        goalId: 'G002-target',
+        status: 'complete',
+        evidence: 'G002-target completed planned work for .omx/ultragoal/goals.json; validation complete; reviews clean.',
+        codexGoal: { goal: { objective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      });
+
+      assert.equal(completed.goals.find((goal) => goal.id === 'G002-target')?.steeringStatus, 'blocked');
+      assert.equal(completed.aggregateCompletion, undefined);
+      assert.equal(summarizeUltragoalPlan(completed).aggregateComplete, false);
+      assert.equal(isUltragoalDone(completed), false);
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 0);
+    });
+  });
+
+  it('does not terminalize when duplicate goal ids hide an unresolved row', async () => {
+    await withTempRepo(async (cwd) => {
+      const objective = ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE;
+      await writeAggregateFixturePlan(cwd, 'G002-dup', [
+        aggregateFixtureGoal('G001-first', 'complete', { completedAt: '2026-01-01T00:00:00.000Z', evidence: 'first done' }),
+        aggregateFixtureGoal('G002-dup', 'in_progress', { startedAt: '2026-01-01T00:00:00.000Z' }),
+        aggregateFixtureGoal('G002-dup', 'pending'),
+      ]);
+
+      const tampered = await readUltragoalPlan(cwd);
+      assert.equal(isFinalRunCompletionCandidate(tampered, tampered.goals.find((goal) => goal.id === 'G002-dup')!), true);
+
+      const completed = await checkpointUltragoal(cwd, {
+        goalId: 'G002-dup',
+        status: 'complete',
+        evidence: 'G002-dup completed planned work for .omx/ultragoal/goals.json; validation complete; reviews clean.',
+        codexGoal: { goal: { objective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      });
+
+      assert.equal(completed.goals.filter((goal) => goal.id === 'G002-dup' && goal.status === 'pending').length, 1);
+      assert.equal(completed.aggregateCompletion, undefined);
+      assert.equal(summarizeUltragoalPlan(completed).aggregateComplete, false);
       assert.equal(isUltragoalDone(completed), false);
       const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
       assert.equal((ledger.match(/"event":"aggregate_completed"/g) ?? []).length, 0);

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -627,6 +627,35 @@ function canUseCleanFinalResolverPathForReviewBlockedParent(
     && isDesignatedReviewBlockerResolver(goal, unresolvedReviewBlocked[0]);
 }
 
+function hasReciprocalReviewBlockerResolver(goal: UltragoalItem, plan: UltragoalPlan): boolean {
+  const resolverId = goal.reviewBlockerResolution?.resolverGoalId;
+  if (!resolverId) return false;
+  const resolvers = plan.goals.filter((candidate) => candidate.id === resolverId);
+  if (resolvers.length !== 1) return false;
+  return resolvers[0]!.resolvesReviewBlockedGoalId === goal.id;
+}
+
+function hasUniqueGoalIds(plan: UltragoalPlan): boolean {
+  return new Set(plan.goals.map((candidate) => candidate.id)).size === plan.goals.length;
+}
+
+function canPersistNormalFinalAggregateCompletion(
+  plan: UltragoalPlan,
+  goal: UltragoalItem,
+  finalRunCheckpoint: boolean,
+  allowActiveFinalCodexGoal: boolean | undefined,
+): boolean {
+  if (!finalRunCheckpoint || allowActiveFinalCodexGoal) return false;
+  if (!hasUniqueGoalIds(plan)) return false;
+  if (!isScheduleEligible(goal)) return false;
+  const unresolvedReviewBlocked = unresolvedReviewBlockedGoals(plan);
+  if (unresolvedReviewBlocked.length === 0) {
+    return plan.goals.every((candidate) => candidate.status !== 'review_blocked'
+      || hasReciprocalReviewBlockerResolver(candidate, plan));
+  }
+  return canUseCleanFinalResolverPathForReviewBlockedParent(plan, goal, finalRunCheckpoint, allowActiveFinalCodexGoal);
+}
+
 async function canReconcileCompletedTaskScopedAggregateSnapshot(
   cwd: string,
   plan: UltragoalPlan,
@@ -1831,16 +1860,11 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
     }
     if (
       aggregateMode
-      && finalRunCheckpoint
-      && !options.allowActiveFinalCodexGoal
-      && (
-        unresolvedReviewBlockedGoals(plan).length === 0
-        || canUseCleanFinalResolverPathForReviewBlockedParent(
-          plan,
-          goal,
-          finalRunCheckpoint,
-          options.allowActiveFinalCodexGoal,
-        )
+      && canPersistNormalFinalAggregateCompletion(
+        plan,
+        goal,
+        finalRunCheckpoint,
+        options.allowActiveFinalCodexGoal,
       )
     ) {
       normalFinalAggregateCompletion = {

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -649,6 +649,7 @@ function canPersistNormalFinalAggregateCompletion(
   if (!finalRunCheckpoint || allowActiveFinalCodexGoal) return false;
   if (!hasUniqueGoalIds(plan)) return false;
   if (!isScheduleEligible(goal)) return false;
+  if (goal.status !== 'in_progress' || plan.activeGoalId !== goal.id) return false;
   if (unresolvedReviewBlockedGoals(plan).length === 0) return true;
   return canUseCleanFinalResolverPathForReviewBlockedParent(plan, goal, finalRunCheckpoint, allowActiveFinalCodexGoal);
 }

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -1150,6 +1150,9 @@ function appendGoalToPlan(plan: UltragoalPlan, options: AddUltragoalGoalOptions 
 export async function addUltragoalGoal(cwd: string, options: AddUltragoalGoalOptions): Promise<{ plan: UltragoalPlan; goal: UltragoalItem }> {
   return withUltragoalMutationLock(cwd, async () => {
   const plan = await readUltragoalPlanUnderLock(cwd);
+  if (plan.aggregateCompletion?.status === 'complete') {
+    throw new UltragoalError('Cannot add a goal to an already completed aggregate ultragoal plan; start a new plan for post-terminal work.');
+  }
   const now = iso(options.now);
   const goal = appendGoalToPlan(plan, options);
   await writePlan(cwd, plan);
@@ -1742,6 +1745,9 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
   const plan = await readUltragoalPlanUnderLock(cwd);
   const goal = plan.goals.find((candidate) => candidate.id === options.goalId);
   if (!goal) throw new UltragoalError(`Unknown ultragoal id: ${options.goalId}`);
+  if (plan.aggregateCompletion?.status === 'complete' && options.status !== 'complete') {
+    throw new UltragoalError(`Cannot record a ${options.status} checkpoint for ${goal.id} after the aggregate ultragoal plan is complete; the terminal aggregate receipt is immutable.`);
+  }
   const now = iso(options.now);
   if (options.status === 'blocked') {
     if (goal.status !== 'in_progress') {

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -1829,13 +1829,20 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
         throw new UltragoalError(`${formatCodexGoalReconciliation(reconciliation)}${taskScopedRequirement}${remediation}`);
       }
     }
-    const designatedReviewBlockerResolver = goal.resolvesReviewBlockedGoalId
-      ? isDesignatedReviewBlockerResolver(
-        goal,
-        plan.goals.find((candidate) => candidate.id === goal.resolvesReviewBlockedGoalId),
+    if (
+      aggregateMode
+      && finalRunCheckpoint
+      && !options.allowActiveFinalCodexGoal
+      && (
+        unresolvedReviewBlockedGoals(plan).length === 0
+        || canUseCleanFinalResolverPathForReviewBlockedParent(
+          plan,
+          goal,
+          finalRunCheckpoint,
+          options.allowActiveFinalCodexGoal,
+        )
       )
-      : false;
-    if (aggregateMode && finalRunCheckpoint && !options.allowActiveFinalCodexGoal && designatedReviewBlockerResolver) {
+    ) {
       normalFinalAggregateCompletion = {
         status: 'complete',
         completedAt: now,

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -610,6 +610,7 @@ function unresolvedReviewBlockedGoals(plan: UltragoalPlan): UltragoalItem[] {
 
 function isDesignatedReviewBlockerResolver(goal: UltragoalItem, parent: UltragoalItem | undefined): boolean {
   return parent?.status === 'review_blocked'
+    && parent.id !== goal.id
     && goal.resolvesReviewBlockedGoalId === parent.id
     && parent.reviewBlockerResolution?.resolverGoalId === goal.id;
 }
@@ -648,11 +649,7 @@ function canPersistNormalFinalAggregateCompletion(
   if (!finalRunCheckpoint || allowActiveFinalCodexGoal) return false;
   if (!hasUniqueGoalIds(plan)) return false;
   if (!isScheduleEligible(goal)) return false;
-  const unresolvedReviewBlocked = unresolvedReviewBlockedGoals(plan);
-  if (unresolvedReviewBlocked.length === 0) {
-    return plan.goals.every((candidate) => candidate.status !== 'review_blocked'
-      || hasReciprocalReviewBlockerResolver(candidate, plan));
-  }
+  if (unresolvedReviewBlockedGoals(plan).length === 0) return true;
   return canUseCleanFinalResolverPathForReviewBlockedParent(plan, goal, finalRunCheckpoint, allowActiveFinalCodexGoal);
 }
 
@@ -769,6 +766,7 @@ function isReviewBlockedResolved(goal: UltragoalItem, plan: UltragoalPlan): bool
   if (goal.status !== 'review_blocked') return false;
   const resolverId = goal.reviewBlockerResolution?.resolverGoalId;
   if (!resolverId || goal.reviewBlockerResolution?.status !== 'complete') return false;
+  if (!hasReciprocalReviewBlockerResolver(goal, plan)) return false;
   const resolver = plan.goals.find((candidate) => candidate.id === resolverId);
   return resolver?.status === 'complete';
 }


### PR DESCRIPTION
Fixes #3274

## Root cause

In `checkpointUltragoal` (`src/ultragoal/artifacts.ts`), the `normalFinalAggregateCompletion` guard was scoped to a designated review-blocker resolver:

```ts
if (aggregateMode && finalRunCheckpoint && !options.allowActiveFinalCodexGoal && designatedReviewBlockerResolver) {
```

For an ordinary final aggregate checkpoint whose Codex objective exactly matches `plan.codexObjective`, reconciliation succeeds (so the task-scoped fallback branch never runs) and the goal is not a designated resolver, so `normalFinalAggregateCompletion` stayed `undefined`. The goal row became `complete`, but both downstream uses were no-ops: `plan.aggregateCompletion` was never written and no `aggregate_completed` ledger event was appended.

`summarizeUltragoalPlan` therefore reported the contradictory terminal state `aggregateComplete: false` alongside `artifactComplete: true`, and `omx ultragoal status` printed a misleading artifact-backed reconciliation remediation even though a matching completed snapshot had already been supplied and recorded in the final `goal_completed` event.

## The fix

```diff
-    const designatedReviewBlockerResolver = goal.resolvesReviewBlockedGoalId
-      ? isDesignatedReviewBlockerResolver(
-        goal,
-        plan.goals.find((candidate) => candidate.id === goal.resolvesReviewBlockedGoalId),
-      )
-      : false;
-    if (aggregateMode && finalRunCheckpoint && !options.allowActiveFinalCodexGoal && designatedReviewBlockerResolver) {
+    if (
+      aggregateMode
+      && finalRunCheckpoint
+      && !options.allowActiveFinalCodexGoal
+      && (
+        unresolvedReviewBlockedGoals(plan).length === 0
+        || canUseCleanFinalResolverPathForReviewBlockedParent(
+          plan,
+          goal,
+          finalRunCheckpoint,
+          options.allowActiveFinalCodexGoal,
+        )
+      )
+    ) {
       normalFinalAggregateCompletion = {
```

### Why not just drop the conjunct

The issue's literal suggestion (remove `designatedReviewBlockerResolver`) is unsafe. `isCompletionBlockingForFinalCandidate` exempts a `review_blocked` candidate based only on the **parent's** one-way `resolverGoalId` pointer, while reconciliation additionally needs the child's reverse pointer. Forged or inconsistent blocker metadata could therefore make `finalRunCheckpoint` true, terminalize the aggregate, and leave an unresolved review-blocked goal hidden behind `isUltragoalDone`'s aggregate-marker short-circuit.

Reusing the existing `canUseCleanFinalResolverPathForReviewBlockedParent` helper is load-bearing: it already requires **exactly one** unresolved review-blocked parent with **bidirectional** resolver pointers, keeping that path fail-closed. The helper itself is unmodified and remains used by its pre-existing caller.

## Preserved unchanged

- Designated review-blocker resolver path
- Task-scoped-objective reconciliation path (separate branch, early return)
- Strict snapshot, final quality gate, and architecture-invariant boundaries
- No CLI, HUD, native-hook, or state source changes; no schema or migration

## Regression coverage

- **Expanded** `requires aggregate Codex goal completion only for the final story` — asserts mid-run state (no marker), then the final row `complete`, `activeGoalId` cleared, `aggregateCompletion.status === 'complete'`, both `aggregateComplete` and `artifactComplete` true, and exact ledger counts of 2 `goal_completed` + 1 `aggregate_completed`. Covers all seven acceptance criteria from the issue.
- **New** `does not terminalize through a one-way designated resolver pointer`
- **New** `does not terminalize when two unresolved review-blocked parents point at one resolver`

Both new tests assert `isFinalRunCompletionCandidate === true` **before** checkpointing, so they provably reach the guarded branch rather than passing vacuously.

**Fail-before-fix proof:** with the guard hunk reverted but the new tests present, the expanded ordinary-flow test and the multi-parent test both fail; both pass with the fix.

Two expectations in `src/cli/__tests__/ultragoal.test.ts` encoded the defect and were updated: `aggregateComplete` `false` → `true`, and the human headline `ultragoal artifact goals: complete` → `ultragoal aggregate product: complete`. All fallback, reconciliation, and warning assertions are retained.

## Verification

| Gate | Result |
|---|---|
| `npm run build` | exit 0 |
| `npm run lint` | exit 0 (783 files) |
| `npm run check:no-unused` | exit 0 |
| `node dist/scripts/run-test-files.js dist/ultragoal/__tests__ dist/cli/__tests__/ultragoal.test.js` | exit 0 — 93/93 pass |
| `npm run test:node` | exit 0 — full suite, 400 test files |

Diff is exactly 3 files, +147/-8.
