### PR TITLE
fix(tmux): guard deferred HUD resize sinks in command-list context (#3292)

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -4698,6 +4698,26 @@ exit 0
       assert.equal(countMatches(hookCommand, /tmux if-shell -F/g), 2);
       assert.equal(countMatches(hookCommand, /run-shell -b/g), 1);
     });
+
+    it("escapes injected authority conditions so they survive the outer run-shell format pass", () => {
+      const args = buildRegisterResizeHookArgs("omx-detached:0", "omx_resize_detached", "%77", 2, 7700, "instance-1");
+      const hookCommand = guardDetachedHudDeferredMutation(leader, hud, args).at(-1)!;
+
+      // run-shell applies exactly one outer tmux format pass to the stored payload.
+      // Unescaped, tmux pre-expands these conditions against the hook's own pane and
+      // collapses them to constants, denying the resize before the sink is parsed.
+      for (const condition of [
+        "##{==:##{pane_id},%11}",
+        "##{==:##{pane_pid},1100}",
+        "##{==:##{@omx_instance_id},instance-1}",
+        "##{==:##{pane_id},%77}",
+        "##{m:*OMX_DETACHED_HUD_OPERATION=operation-1*,##{pane_start_command}}",
+      ]) {
+        assert.ok(hookCommand.includes(condition), `stored payload must escape ${condition}`);
+      }
+      assert.doesNotMatch(hookCommand, /(^|[^#])#\{==:#\{pane_id\},%77\}/);
+      assert.doesNotMatch(hookCommand, /(^|[^#])#\{&&:/);
+    });
   });
 
   it("registerDetachedHudLayoutReconcileHook reads TMUX from the detached leader pane before registering", () => {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -98,6 +98,7 @@ import {
   CODEX_SQLITE_HOME_ENV,
   DETACHED_TMUX_HISTORY_LIMIT,
   isExistingTmuxWindowTooCrampedForLaunchHud,
+  guardDetachedHudDeferredMutation,
 } from "../index.js";
 import { buildResumeArgsWithPreservedFlags, stripHotswapArg } from "../../auth/hotswap.js";
 import { mergeConfig, repairConfigIfNeeded } from "../../config/generator.js";
@@ -112,6 +113,7 @@ import {
 } from "../../config/models.js";
 import type { ProcessEntry } from "../cleanup.js";
 import { splitWorkerLaunchArgs } from "../../team/model-contract.js";
+import { buildRegisterResizeHookArgs } from "../../team/tmux-session.js";
 
 
 const testDir = dirname(fileURLToPath(import.meta.url));
@@ -4654,6 +4656,48 @@ exit 0
     assert.equal(env.OMX_TMUX_HUD_OWNER, "1");
     assert.equal(env.OMX_ROOT, "/repo");
     assert.equal(env.OMX_ENTRY_PATH, "/repo/dist/cli/omx.js");
+  });
+
+  describe("detached HUD deferred mutation guard", () => {
+    const leader = {
+      paneId: "%11",
+      panePid: 1100,
+      sessionName: "omx-detached",
+      sessionId: "$1",
+      sessionCreated: "1700000000",
+      windowId: "@1",
+      windowIndex: "0",
+      ownerId: "instance-1",
+    };
+    const hud = {
+      paneId: "%77",
+      panePid: 7700,
+      sessionId: "$1",
+      windowId: "@1",
+      operationMarker: "operation-1",
+    };
+
+    it("throws fail-closed when a deferred HUD payload has format escapes but no resize sink", () => {
+      const sinkFree = ["run-shell", "-b",
+        "tmux list-panes -a -F '#{pane_id}\t#{pane_dead}\t#{pane_pid}' >/dev/null 2>&1 || true"];
+      assert.throws(
+        () => guardDetachedHudDeferredMutation(leader, hud, sinkFree),
+        /detached deferred HUD mutation lacks a recognized resize sink/,
+      );
+    });
+
+    it("guards immediate and delayed resize sinks as bare tmux command-list commands", () => {
+      const args = buildRegisterResizeHookArgs("omx-detached:0", "omx_resize_detached", "%77", 2, 7700, "instance-1");
+      const guarded = guardDetachedHudDeferredMutation(leader, hud, args);
+      const hookCommand = guarded.at(-1)!;
+
+      assert.match(hookCommand, /resize-pane -t %77 -y 2 ; display-message/);
+      assert.doesNotMatch(hookCommand, /tmux resize-pane -t %77 -y 2 ; display-message/);
+      assert.match(hookCommand, /tmux if-shell -F/);
+      assert.match(hookCommand, /##\{pane_id\}/);
+      assert.equal(countMatches(hookCommand, /tmux if-shell -F/g), 2);
+      assert.equal(countMatches(hookCommand, /run-shell -b/g), 1);
+    });
   });
 
   it("registerDetachedHudLayoutReconcileHook reads TMUX from the detached leader pane before registering", () => {

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -285,6 +285,26 @@ async function assertShimLogQuiescent(path: string, quietPeriodMs: number, messa
   assert.equal(await readFile(path, 'utf-8').catch(() => ''), before, message);
 }
 
+async function waitForServerLogSubstring(
+  readServerLog: () => Promise<string>,
+  offset: number,
+  needle: string,
+  timeoutMs = 3_000,
+  intervalMs = 25,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let lastWindow = '';
+  while (Date.now() <= deadline) {
+    const log = await readServerLog();
+    lastWindow = log.slice(offset);
+    if (lastWindow.includes(needle)) return lastWindow;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(
+    `timed out after ${timeoutMs}ms waiting for ${JSON.stringify(needle)} in private tmux server log; tail=${JSON.stringify(lastWindow.slice(-2_000))}`,
+  );
+}
+
 async function stopHeldOmx(child: ReturnType<typeof spawn>, releasePath: string): Promise<void> {
   await rm(releasePath, { force: true });
   await new Promise<void>((resolve, reject) => {
@@ -932,21 +952,112 @@ exit 0
 });
 
 describe('omx launcher when tmux is available', () => {
-  it('captures the compiled detached parser transport and stored hook on a private tmux server', async (t) => {
+  it('restores an enlarged detached HUD on the first larger client attach', async (t) => {
     if (!skipUnlessPrivateRealTmux(t)) return;
     const wd = await mkdtemp(join(tmpdir(), 'omx-launch-private-real-tmux-'));
     try {
       await withTempTmuxSession(async (fixture) => {
         const home = join(wd, 'home');
         const bin = join(wd, 'bin');
-        const foreignSession = 'foreign-control';
+        const shimLogPath = join(wd, 'private-tmux-shim.log');
         await mkdir(home, { recursive: true });
         await mkdir(bin, { recursive: true });
         await writeExecutable(join(bin, 'codex'), '#!/bin/sh\nsleep 300\n');
-        const shimLogPath = join(wd, 'private-tmux-shim.log');
         await fixture.createPathShim(bin, shimLogPath);
-        fixture.run(['new-session', '-d', '-s', foreignSession, 'sleep 300']);
-        const foreignBefore = fixture.run(['list-panes', '-t', foreignSession, '-F', '#{pane_id}\t#{pane_pid}\t#{pane_height}']);
+
+        const result = runOmx(wd, ['--madmax', '--tmux'], {
+          HOME: home,
+          PATH: `${bin}:${process.env.PATH ?? ''}`,
+          OMX_AUTO_UPDATE: '0',
+          OMX_NOTIFY_FALLBACK: '0',
+          OMX_HOOK_DERIVED_SIGNALS: '0',
+          OMX_HERMES_MCP_BRIDGE: '1',
+          OMX_LAUNCH_POLICY: 'direct',
+          TMUX: '',
+          TMUX_PANE: '',
+        });
+        assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+
+        const launchedSession = fixture.run(['list-sessions', '-F', '#{session_name}'])
+          .split('\n')
+          .find((name) => name.startsWith('omx-') && name !== fixture.sessionName);
+        assert.ok(launchedSession, 'compiled launcher must create its detached session on the private server');
+        // tmux 3.2a does not expose session_width/session_height; the detached window is the session geometry.
+        assert.equal(
+          fixture.run(['display-message', '-p', '-t', launchedSession, '#{window_width}x#{window_height}']),
+          '80x24',
+          'the detached session must remain at its initial geometry before any client attaches',
+        );
+        const panes = fixture.run(['list-panes', '-t', launchedSession, '-F', '#{pane_id}\t#{pane_height}\t#{pane_start_command}'])
+          .split('\n')
+          .map((line) => line.split('\t'));
+        const hud = panes.find(([, , command]) => command.includes('OMX_DETACHED_HUD_OPERATION='));
+        assert.ok(hud, 'HUD split must carry its operation marker');
+        assert.equal(Number(hud[1]), HUD_TMUX_HEIGHT_LINES, 'authorized direct reconciliation must resize the HUD');
+        assert.equal(
+          fixture.run(['show-options', '-v', '-t', launchedSession, 'history-limit']),
+          String(DETACHED_TMUX_HISTORY_LIMIT),
+          'direct leader mutation must receive its receipt and set session history',
+        );
+
+        const hooks = fixture.run(['show-hooks', '-t', launchedSession]);
+        assert.match(hooks, /client-resized\[[0-9]+\].*run-shell -b/);
+        assert.match(hooks, /tmux if-shell -F -t/);
+        assert.match(hooks, /OMX_DETACHED_HUD_OPERATION=/);
+        const storedPaneFormat = hooks.match(/##\{pane_id\}\\t##\{pane_dead\}\\t##\{pane_pid\}/)?.[0] ?? '';
+        assert.equal(storedPaneFormat, '##{pane_id}\\t##{pane_dead}\\t##{pane_pid}', 'stored hook display must retain one outer format escape and encode TAB bytes');
+        const executablePaneFormat = storedPaneFormat.replaceAll('##{', '#{').replaceAll('\\t', '\t');
+        assert.equal(executablePaneFormat, '#{pane_id}\t#{pane_dead}\t#{pane_pid}', 'one outer tmux format pass must decode the stored format into the executable nested argv');
+        const clientAttachedHookSlots = [...hooks.matchAll(/client-attached\[[0-9]+\]/g)].map(([slot]) => slot);
+        for (const hookSlot of clientAttachedHookSlots) {
+          fixture.run(['set-hook', '-u', '-t', launchedSession, hookSlot]);
+        }
+        const installedHooks = fixture.run(['show-hooks', '-t', launchedSession]);
+        const storedResizeHookSlots = [...installedHooks.matchAll(/client-resized\[[0-9]+\]/g)].map(([slot]) => slot);
+        assert.equal(storedResizeHookSlots.length, 1, 'exactly one installed client-resized hook must remain for the natural resize trigger');
+        assert.match(installedHooks, /client-resized\[[0-9]+\].*run-shell -b/);
+        assert.doesNotMatch(installedHooks, /client-attached\[[0-9]+\]/, 'the resize trigger must not be conflated with client-attached hook execution');
+
+        await new Promise((resolve) => setTimeout(resolve, (HUD_RESIZE_RECONCILE_DELAY_SECONDS * 1_000) + 250));
+        const launchPaneSnapshots = parseShimTmuxArgv(await readFile(shimLogPath, 'utf-8'))
+          .filter((argv) => argv[0] === 'list-panes' && argv[1] === '-a');
+        assert.ok(launchPaneSnapshots.length >= 2, 'the direct and delayed launch reconciliations must both complete before the stored-hook baseline is cleared');
+        await assertShimLogQuiescent(shimLogPath, 250, 'launch and delayed reconciliation must settle before clearing the stored-hook baseline');
+        await writeFile(shimLogPath, '');
+        assert.equal(await readFile(shimLogPath, 'utf-8'), '', 'the shim baseline must start after launch and reconciliation activity settles');
+
+        fixture.run(['resize-pane', '-t', hud[0]!, '-y', '7']);
+        assert.equal(Number(fixture.run(['display-message', '-p', '-t', hud[0]!, '#{pane_height}'])), 7, 'the detached HUD must be enlarged before the restore trigger');
+        assert.equal(fixture.run(['display-message', '-p', '-t', launchedSession, '#{window_width}x#{window_height}']), '80x24', 'enlarging the detached HUD must not attach a client');
+        fixture.triggerClientResize(launchedSession, { cols: 121, rows: 41 });
+        await new Promise((resolve) => setTimeout(resolve, (HUD_RESIZE_RECONCILE_DELAY_SECONDS * 1_000) + 250));
+        await assertShimLogQuiescent(shimLogPath, 250, 'the stored client-resized hook must finish both its immediate and delayed passes before assertions');
+        assert.equal(Number(fixture.run(['display-message', '-p', '-t', hud[0]!, '#{pane_height}'])), HUD_TMUX_HEIGHT_LINES, 'the first larger client attach must restore the enlarged detached HUD');
+
+        const paneSnapshots = parseShimTmuxArgv(await readFile(shimLogPath, 'utf-8'))
+          .filter((argv) => argv[0] === 'list-panes' && argv[1] === '-a');
+        assert.equal(paneSnapshots.length, 2, 'only the explicitly triggered stored client-resized hook may produce the post-baseline immediate and delayed pane snapshots');
+        for (const argv of paneSnapshots) {
+          assert.deepEqual(argv, ['list-panes', '-a', '-F', executablePaneFormat], 'post-baseline stored client-resized hook execution must preserve the exact executable TAB-delimited nested argv');
+        }
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
+    }
+  });
+
+  it('records the guarded resize command without an unknown-command parser error', async (t) => {
+    if (!skipUnlessPrivateRealTmux(t)) return;
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-private-real-tmux-'));
+    try {
+      await withTempTmuxSession({ serverLog: true }, async (fixture) => {
+        const home = join(wd, 'home');
+        const bin = join(wd, 'bin');
+        const shimLogPath = join(wd, 'private-tmux-shim.log');
+        await mkdir(home, { recursive: true });
+        await mkdir(bin, { recursive: true });
+        await writeExecutable(join(bin, 'codex'), '#!/bin/sh\nsleep 300\n');
+        await fixture.createPathShim(bin, shimLogPath);
 
         const result = runOmx(wd, ['--madmax', '--tmux'], {
           HOME: home,
@@ -970,22 +1081,10 @@ describe('omx launcher when tmux is available', () => {
           .map((line) => line.split('\t'));
         const hud = panes.find(([, , command]) => command.includes('OMX_DETACHED_HUD_OPERATION='));
         assert.ok(hud, 'HUD split must carry its operation marker');
-        assert.equal(Number(hud[1]), HUD_TMUX_HEIGHT_LINES, 'authorized direct reconciliation must resize the HUD');
-        assert.equal(
-          fixture.run(['show-options', '-v', '-t', launchedSession, 'history-limit']),
-          String(DETACHED_TMUX_HISTORY_LIMIT),
-          'direct leader mutation must receive its receipt and set session history',
-        );
-
         const hooks = fixture.run(['show-hooks', '-t', launchedSession]);
-        assert.match(hooks, /client-resized\[[0-9]+\].*run-shell -b/);
-        assert.match(hooks, /tmux if-shell -F -t/);
-        assert.match(hooks, /OMX_DETACHED_HUD_OPERATION=/);
         const storedPaneFormat = hooks.match(/##\{pane_id\}\\t##\{pane_dead\}\\t##\{pane_pid\}/)?.[0] ?? '';
-        assert.equal(storedPaneFormat, '##{pane_id}\\t##{pane_dead}\\t##{pane_pid}', 'stored hook display must retain one outer format escape and encode TAB bytes');
         const executablePaneFormat = storedPaneFormat.replaceAll('##{', '#{').replaceAll('\\t', '\t');
         assert.equal(executablePaneFormat, '#{pane_id}\t#{pane_dead}\t#{pane_pid}', 'one outer tmux format pass must decode the stored format into the executable nested argv');
-
         const clientAttachedHookSlots = [...hooks.matchAll(/client-attached\[[0-9]+\]/g)].map(([slot]) => slot);
         for (const hookSlot of clientAttachedHookSlots) {
           fixture.run(['set-hook', '-u', '-t', launchedSession, hookSlot]);
@@ -993,50 +1092,145 @@ describe('omx launcher when tmux is available', () => {
         const installedHooks = fixture.run(['show-hooks', '-t', launchedSession]);
         const storedResizeHookSlots = [...installedHooks.matchAll(/client-resized\[[0-9]+\]/g)].map(([slot]) => slot);
         assert.equal(storedResizeHookSlots.length, 1, 'exactly one installed client-resized hook must remain for the natural resize trigger');
-        assert.match(installedHooks, /client-resized\[[0-9]+\].*run-shell -b/);
-        assert.doesNotMatch(installedHooks, /client-attached\[[0-9]+\]/, 'the resize trigger must not be conflated with client-attached hook execution');
 
         await new Promise((resolve) => setTimeout(resolve, (HUD_RESIZE_RECONCILE_DELAY_SECONDS * 1_000) + 250));
         const launchPaneSnapshots = parseShimTmuxArgv(await readFile(shimLogPath, 'utf-8'))
           .filter((argv) => argv[0] === 'list-panes' && argv[1] === '-a');
-        assert.ok(
-          launchPaneSnapshots.length >= 2,
-          'the direct and delayed launch reconciliations must both complete before the stored-hook baseline is cleared',
-        );
-        await assertShimLogQuiescent(
-          shimLogPath,
-          250,
-          'launch and delayed reconciliation must settle before clearing the stored-hook baseline',
-        );
+        assert.ok(launchPaneSnapshots.length >= 2, 'the direct and delayed launch reconciliations must both complete before the stored-hook baseline is cleared');
+        await assertShimLogQuiescent(shimLogPath, 250, 'launch and delayed reconciliation must settle before clearing the stored-hook baseline');
         await writeFile(shimLogPath, '');
-        assert.equal(await readFile(shimLogPath, 'utf-8'), '', 'the shim baseline must start after launch and reconciliation activity settles');
 
-        fixture.triggerClientResize(launchedSession);
-        await new Promise((resolve) => setTimeout(resolve, (HUD_RESIZE_RECONCILE_DELAY_SECONDS * 1_000) + 250));
-        await assertShimLogQuiescent(
-          shimLogPath,
-          250,
-          'the stored client-resized hook must finish both its immediate and delayed passes before assertions',
+        const probeOffset = (await fixture.readServerLog()).length;
+        const probe = fixture.runResult([
+          'if-shell', '-F', '-t', fixture.leaderPaneId, '1',
+          'tmux display-message -p omx-oracle-probe', '',
+        ]);
+        assert.equal(probe.error, '', 'the positive-control tmux client must start successfully');
+        assert.notEqual(probe.status, 0, 'tmux must reject the deliberately malformed selected command list');
+        assert.ok(
+          probe.stderr === '' || /unknown command: tmux/.test(probe.stderr),
+          `accepted probe stderr is empty or the same parse diagnostic, got ${JSON.stringify(probe.stderr)}`,
         );
-
-        const nestedArgv = parseShimTmuxArgv(await readFile(shimLogPath, 'utf-8'));
-        const paneSnapshots = nestedArgv.filter((argv) => argv[0] === 'list-panes' && argv[1] === '-a');
+        assert.equal(fixture.sessionExists(), true, 'the private tmux server must remain alive after the malformed client command');
         assert.equal(
-          paneSnapshots.length,
-          2,
-          'only the explicitly triggered stored client-resized hook may produce the post-baseline immediate and delayed pane snapshots',
+          fixture.run(['display-message', '-p', '-t', fixture.leaderPaneId, '#{pane_id}']),
+          fixture.leaderPaneId,
+          'a successful post-probe command must prove the server remains responsive',
         );
+        await waitForServerLogSubstring(fixture.readServerLog, probeOffset, 'unknown command: tmux', 3_000, 25);
+
+        const triggerOffset = (await fixture.readServerLog()).length;
+        fixture.run(['resize-pane', '-t', hud[0]!, '-y', '7']);
+        assert.equal(Number(fixture.run(['display-message', '-p', '-t', hud[0]!, '#{pane_height}'])), 7, 'the detached HUD must be enlarged before the parser oracle trigger');
+        fixture.triggerClientResize(launchedSession, { cols: 121, rows: 41 });
+        await new Promise((resolve) => setTimeout(resolve, (HUD_RESIZE_RECONCILE_DELAY_SECONDS * 1_000) + 250));
+        await assertShimLogQuiescent(shimLogPath, 250, 'the stored client-resized hook must finish both its immediate and delayed passes before assertions');
+        const paneSnapshots = parseShimTmuxArgv(await readFile(shimLogPath, 'utf-8'))
+          .filter((argv) => argv[0] === 'list-panes' && argv[1] === '-a');
+        assert.equal(paneSnapshots.length, 2, 'only the explicitly triggered stored client-resized hook may produce the post-baseline immediate and delayed pane snapshots');
         for (const argv of paneSnapshots) {
-          assert.deepEqual(
-            argv,
-            ['list-panes', '-a', '-F', executablePaneFormat],
-            'post-baseline stored client-resized hook execution must preserve the exact executable TAB-delimited nested argv',
-          );
+          assert.deepEqual(argv, ['list-panes', '-a', '-F', executablePaneFormat], 'post-baseline stored client-resized hook execution must preserve the exact executable TAB-delimited nested argv');
         }
 
-        fixture.run(['set-option', '-t', launchedSession, '@omx_instance_id', 'foreign-owner']);
-        assert.equal(Number(fixture.run(['display-message', '-p', '-t', hud[0]!, '#{pane_height}'])), HUD_TMUX_HEIGHT_LINES, 'foreign owner must not receive a deferred mutation without an authority receipt');
-        assert.equal(fixture.run(['list-panes', '-t', foreignSession, '-F', '#{pane_id}\t#{pane_pid}\t#{pane_height}']), foreignBefore);
+        const triggerWindow = (await fixture.readServerLog()).slice(triggerOffset);
+        assert.ok(
+          triggerWindow.includes(`resize-pane -t ${hud[0]} -y ${HUD_TMUX_HEIGHT_LINES}`),
+          'the server-log window must cover the stored hook resize command',
+        );
+        assert.doesNotMatch(
+          triggerWindow,
+          /unknown command: tmux/,
+          'the triggered guarded sink must parse as a bare tmux command-list entry (#3292)',
+        );
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
+    }
+  });
+
+  it('denies detached HUD mutation after the pane owner changes', async (t) => {
+    if (!skipUnlessPrivateRealTmux(t)) return;
+    const wd = await mkdtemp(join(tmpdir(), 'omx-launch-private-real-tmux-'));
+    try {
+      await withTempTmuxSession(async (fixture) => {
+        const home = join(wd, 'home');
+        const bin = join(wd, 'bin');
+        const shimLogPath = join(wd, 'private-tmux-shim.log');
+        const foreignSession = 'foreign-control';
+        let launchedSession: string | undefined;
+        let originalOwner: string | undefined;
+        await mkdir(home, { recursive: true });
+        await mkdir(bin, { recursive: true });
+        await writeExecutable(join(bin, 'codex'), '#!/bin/sh\nsleep 300\n');
+        await fixture.createPathShim(bin, shimLogPath);
+        fixture.run(['new-session', '-d', '-s', foreignSession, 'sleep 300']);
+        const foreignBefore = fixture.run(['list-panes', '-t', foreignSession, '-F', '#{pane_id}\t#{pane_pid}\t#{pane_height}']);
+
+        try {
+          const result = runOmx(wd, ['--madmax', '--tmux'], {
+            HOME: home,
+            PATH: `${bin}:${process.env.PATH ?? ''}`,
+            OMX_AUTO_UPDATE: '0',
+            OMX_NOTIFY_FALLBACK: '0',
+            OMX_HOOK_DERIVED_SIGNALS: '0',
+            OMX_HERMES_MCP_BRIDGE: '1',
+            OMX_LAUNCH_POLICY: 'direct',
+            TMUX: '',
+            TMUX_PANE: '',
+          });
+          assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+
+          launchedSession = fixture.run(['list-sessions', '-F', '#{session_name}'])
+            .split('\n')
+            .find((name) => name.startsWith('omx-') && name !== fixture.sessionName);
+          assert.ok(launchedSession, 'compiled launcher must create its detached session on the private server');
+          const panes = fixture.run(['list-panes', '-t', launchedSession, '-F', '#{pane_id}\t#{pane_height}\t#{pane_start_command}'])
+            .split('\n')
+            .map((line) => line.split('\t'));
+          const hud = panes.find(([, , command]) => command.includes('OMX_DETACHED_HUD_OPERATION='));
+          assert.ok(hud, 'HUD split must carry its operation marker');
+          const hooks = fixture.run(['show-hooks', '-t', launchedSession]);
+          const storedPaneFormat = hooks.match(/##\{pane_id\}\\t##\{pane_dead\}\\t##\{pane_pid\}/)?.[0] ?? '';
+          const executablePaneFormat = storedPaneFormat.replaceAll('##{', '#{').replaceAll('\\t', '\t');
+          assert.equal(executablePaneFormat, '#{pane_id}\t#{pane_dead}\t#{pane_pid}', 'one outer tmux format pass must decode the stored format into the executable nested argv');
+          const clientAttachedHookSlots = [...hooks.matchAll(/client-attached\[[0-9]+\]/g)].map(([slot]) => slot);
+          for (const hookSlot of clientAttachedHookSlots) {
+            fixture.run(['set-hook', '-u', '-t', launchedSession, hookSlot]);
+          }
+          const installedHooks = fixture.run(['show-hooks', '-t', launchedSession]);
+          const storedResizeHookSlots = [...installedHooks.matchAll(/client-resized\[[0-9]+\]/g)].map(([slot]) => slot);
+          assert.equal(storedResizeHookSlots.length, 1, 'exactly one installed client-resized hook must remain for the natural resize trigger');
+
+          await new Promise((resolve) => setTimeout(resolve, (HUD_RESIZE_RECONCILE_DELAY_SECONDS * 1_000) + 250));
+          const launchPaneSnapshots = parseShimTmuxArgv(await readFile(shimLogPath, 'utf-8'))
+            .filter((argv) => argv[0] === 'list-panes' && argv[1] === '-a');
+          assert.ok(launchPaneSnapshots.length >= 2, 'the direct and delayed launch reconciliations must both complete before the stored-hook baseline is cleared');
+          await assertShimLogQuiescent(shimLogPath, 250, 'launch and delayed reconciliation must settle before clearing the stored-hook baseline');
+          await writeFile(shimLogPath, '');
+
+          originalOwner = fixture.run(['show-options', '-v', '-t', launchedSession, '@omx_instance_id']);
+          assert.ok(originalOwner, 'the detached session must retain its original pane owner before the denial trigger');
+          fixture.run(['resize-pane', '-t', hud[0]!, '-y', '7']);
+          assert.equal(Number(fixture.run(['display-message', '-p', '-t', hud[0]!, '#{pane_height}'])), 7, 'the detached HUD must be enlarged before the authority denial trigger');
+          fixture.run(['set-option', '-t', launchedSession, '@omx_instance_id', 'foreign-owner']);
+          await writeFile(shimLogPath, '');
+          fixture.triggerClientResize(launchedSession, { cols: 122, rows: 42 });
+          await new Promise((resolve) => setTimeout(resolve, (HUD_RESIZE_RECONCILE_DELAY_SECONDS * 1_000) + 250));
+          await assertShimLogQuiescent(shimLogPath, 250, 'the stored client-resized hook must finish both its immediate and delayed passes before assertions');
+          const paneSnapshots = parseShimTmuxArgv(await readFile(shimLogPath, 'utf-8'))
+            .filter((argv) => argv[0] === 'list-panes' && argv[1] === '-a');
+          assert.equal(paneSnapshots.length, 2, 'only the explicitly triggered stored client-resized hook may produce the post-baseline immediate and delayed pane snapshots');
+          for (const argv of paneSnapshots) {
+            assert.deepEqual(argv, ['list-panes', '-a', '-F', executablePaneFormat], 'post-baseline stored client-resized hook execution must preserve the exact executable TAB-delimited nested argv');
+          }
+          assert.equal(Number(fixture.run(['display-message', '-p', '-t', hud[0]!, '#{pane_height}'])), 7, 'the foreign pane owner must deny the deferred HUD mutation');
+          assert.equal(fixture.run(['list-panes', '-t', foreignSession, '-F', '#{pane_id}\t#{pane_pid}\t#{pane_height}']), foreignBefore, 'the denial trigger must not affect a foreign session');
+        } finally {
+          if (launchedSession && originalOwner && fixture.sessionExists(launchedSession)) {
+            fixture.run(['set-option', '-t', launchedSession, '@omx_instance_id', originalOwner]);
+            assert.equal(fixture.run(['show-options', '-v', '-t', launchedSession, '@omx_instance_id']), originalOwner, 'the original detached pane owner must be restored before fixture teardown');
+          }
+        }
       });
     } finally {
       await rm(wd, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1571,20 +1571,28 @@ function buildDeferredDetachedHudGuard(
   command: string,
 ): string {
   const deferredReceipt = detachedAuthorityReceipt();
-  const guardedResize = (match: string): string => {
-    const success = `${match} ; display-message -p ${quoteShellArg(deferredReceipt)}`;
-    const hudGuard = `if-shell -F -t ${quoteShellArg(hudAuthority.paneId)} ${quoteShellArg(detachedHudAuthorityCondition(hudAuthority))} ${quoteShellArg(success)} ${quoteShellArg("")}`;
-    return `tmux if-shell -F -t ${quoteShellArg(leaderAuthority.paneId)} ${quoteShellArg(detachedLeaderAuthorityCondition(leaderAuthority))} ${quoteShellArg(hudGuard)} ${quoteShellArg("")}`;
+  let guardedSinkCount = 0;
+  const guardedResize = (_match: string, sink: string): string => {
+    guardedSinkCount += 1;
+    // The stored hook payload is consumed by one outer tmux format pass when
+    // run-shell executes it. The injected authority conditions must survive that
+    // pass so they are evaluated at execution time against the guarded panes;
+    // unescaped, tmux pre-expands them against the hook's own pane and collapses
+    // them to constants, denying the resize before the sink is parsed (#3292).
+    const outerFormatEscaped = (condition: string): string => condition.replaceAll("#{", "##{");
+    const success = `${sink} ; display-message -p ${quoteShellArg(deferredReceipt)}`;
+    const hudGuard = `if-shell -F -t ${quoteShellArg(hudAuthority.paneId)} ${quoteShellArg(outerFormatEscaped(detachedHudAuthorityCondition(hudAuthority)))} ${quoteShellArg(success)} ${quoteShellArg("")}`;
+    return `tmux if-shell -F -t ${quoteShellArg(leaderAuthority.paneId)} ${quoteShellArg(outerFormatEscaped(detachedLeaderAuthorityCondition(leaderAuthority)))} ${quoteShellArg(hudGuard)} ${quoteShellArg("")}`;
   };
   const outerFormatEscapedCommand = command
     .replaceAll('#{pane_id}', '##{pane_id}')
     .replaceAll('#{pane_dead}', '##{pane_dead}')
     .replaceAll('#{pane_pid}', '##{pane_pid}');
   const guardedCommand = outerFormatEscapedCommand.replace(
-    /tmux resize-pane -t %[0-9]+ -y [1-9][0-9]*/g,
+    /tmux (resize-pane -t %[0-9]+ -y [1-9][0-9]*)/g,
     guardedResize,
   );
-  if (guardedCommand === command) {
+  if (guardedSinkCount === 0) {
     throw new Error("detached deferred HUD mutation lacks a recognized resize sink");
   }
   return guardedCommand;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1590,7 +1590,7 @@ function buildDeferredDetachedHudGuard(
   return guardedCommand;
 }
 
-function guardDetachedHudDeferredMutation(
+export function guardDetachedHudDeferredMutation(
   leaderAuthority: DetachedLeaderAuthority,
   hudAuthority: DetachedHudAuthority,
   args: string[],

--- a/src/team/__tests__/tmux-test-fixture.test.ts
+++ b/src/team/__tests__/tmux-test-fixture.test.ts
@@ -138,4 +138,36 @@ describe('withTempTmuxSession', () => {
 
     assert.equal(ambientSessionExists(sessionName), false);
   });
+
+  it('rejects private server logging on the ambient server', async (t) => {
+    skipUnlessTmux(t);
+    await assert.rejects(
+      withTempTmuxSession({ useAmbientServer: true, serverLog: true }, async () => undefined),
+      /server logging requires a private synthetic tmux server/,
+    );
+  });
+
+  it('exposes a private server log only when logging is enabled', async (t) => {
+    skipUnlessTmux(t);
+    await withTempTmuxSession(async (fixture) => {
+      assert.equal(fixture.serverLogPath, null);
+      await assert.rejects(fixture.readServerLog(), /server logging was not enabled/);
+    });
+
+    await withTempTmuxSession({ serverLog: true }, async (fixture) => {
+      assert.match(fixture.serverLogPath ?? '', /tmux-server-[0-9]+\.log$/);
+      assert.equal(typeof (await fixture.readServerLog()), 'string');
+    });
+  });
+
+  it('rejects out-of-range client resize geometry before attaching', async (t) => {
+    skipUnlessTmux(t);
+    await withTempTmuxSession(async (fixture) => {
+      assert.throws(() => fixture.triggerClientResize(fixture.sessionName, { rows: 3 }), /invalid trigger rows: 3/);
+      assert.throws(() => fixture.triggerClientResize(fixture.sessionName, { rows: 501 }), /invalid trigger rows: 501/);
+      assert.throws(() => fixture.triggerClientResize(fixture.sessionName, { rows: 40.5 }), /invalid trigger rows: 40.5/);
+      assert.throws(() => fixture.triggerClientResize(fixture.sessionName, { cols: 19 }), /invalid trigger cols: 19/);
+      assert.throws(() => fixture.triggerClientResize(fixture.sessionName, { cols: 501 }), /invalid trigger cols: 501/);
+    });
+  });
 });

--- a/src/team/__tests__/tmux-test-fixture.ts
+++ b/src/team/__tests__/tmux-test-fixture.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, join } from 'node:path';
@@ -27,11 +27,17 @@ export interface TempTmuxSessionFixture {
   run: (args: string[]) => string;
   runResult: (args: string[]) => { status: number | null; stdout: string; stderr: string; error: string };
   createPathShim: (directory: string, commandLogPath?: string) => Promise<string>;
-  triggerClientResize: (targetSession: string) => void;
+  triggerClientResize: (
+    targetSession: string,
+    geometry?: { rows?: number; cols?: number },
+  ) => void;
+  serverLogPath: string | null;
+  readServerLog: () => Promise<string>;
 }
 
 export interface TempTmuxSessionOptions {
   useAmbientServer?: boolean;
+  serverLog?: boolean;
 }
 
 function snapshotTmuxEnv(source: NodeJS.ProcessEnv = process.env): TmuxEnvSnapshot {
@@ -51,13 +57,21 @@ function applyTmuxEnv(snapshot: TmuxEnvSnapshot): void {
 
 function runTmuxResult(
   args: string[],
-  options: { ignoreTmuxEnv?: boolean; env?: NodeJS.ProcessEnv; serverName?: string; configFile?: string } = {},
+  options: {
+    ignoreTmuxEnv?: boolean;
+    env?: NodeJS.ProcessEnv;
+    serverName?: string;
+    configFile?: string;
+    verbose?: boolean;
+    cwd?: string;
+  } = {},
 ): { status: number | null; stdout: string; stderr: string; error: string } {
   const env = options.env
     ?? (options.ignoreTmuxEnv ? { ...process.env, TMUX: undefined, TMUX_PANE: undefined } : process.env);
   const argv = [
     ...(options.configFile ? ['-f', options.configFile] : []),
     ...(options.serverName ? ['-L', options.serverName] : []),
+    ...(options.verbose ? ['-vv'] : []),
     ...args,
   ];
   const result = spawnSync('tmux', argv, {
@@ -66,6 +80,7 @@ function runTmuxResult(
     stdio: ['ignore', 'pipe', 'pipe'],
     timeout: TMUX_COMMAND_TIMEOUT_MS,
     killSignal: 'SIGKILL',
+    cwd: options.cwd,
   });
   return {
     status: result.status,
@@ -77,7 +92,14 @@ function runTmuxResult(
 
 function runTmux(
   args: string[],
-  options: { ignoreTmuxEnv?: boolean; env?: NodeJS.ProcessEnv; serverName?: string; configFile?: string } = {},
+  options: {
+    ignoreTmuxEnv?: boolean;
+    env?: NodeJS.ProcessEnv;
+    serverName?: string;
+    configFile?: string;
+    verbose?: boolean;
+    cwd?: string;
+  } = {},
 ): string {
   const result = runTmuxResult(args, options);
   if (result.error) {
@@ -145,6 +167,10 @@ export async function withTempTmuxSession<T>(
     throw new Error('withTempTmuxSession requires a callback');
   }
 
+  if (options.serverLog && options.useAmbientServer) {
+    throw new Error('server logging requires a private synthetic tmux server');
+  }
+
   const previousEnv = snapshotTmuxEnv(process.env);
   const fixtureCwd = await mkdtemp(join(tmpdir(), 'omx-tmux-fixture-'));
   const sessionName = uniqueTmuxIdentifier('omx-test');
@@ -168,8 +194,19 @@ export async function withTempTmuxSession<T>(
     runTmux(['set-environment', '-g', 'PATH', `${directory}${delimiter}${process.env.PATH ?? ''}`], tmuxOptions);
     return shimPath;
   };
-  const triggerClientResize = (targetSession: string): void => {
-    const script = `(sleep 0.1; stty rows 41 cols 121) & exec env TERM=xterm timeout 1 tmux -f ${JSON.stringify(NULL_TMUX_CONFIG)} -L ${JSON.stringify(serverName)} attach-session -t ${JSON.stringify(targetSession)}`;
+  const triggerClientResize = (
+    targetSession: string,
+    geometry: { rows?: number; cols?: number } = {},
+  ): void => {
+    const rows = geometry.rows === undefined ? 41 : geometry.rows;
+    const cols = geometry.cols === undefined ? 121 : geometry.cols;
+    if (!Number.isSafeInteger(rows) || rows < 4 || rows > 500) {
+      throw new Error(`invalid trigger rows: ${rows}`);
+    }
+    if (!Number.isSafeInteger(cols) || cols < 20 || cols > 500) {
+      throw new Error(`invalid trigger cols: ${cols}`);
+    }
+    const script = `(sleep 0.1; stty rows ${rows} cols ${cols}) & exec env TERM=xterm timeout 1 tmux -f ${JSON.stringify(NULL_TMUX_CONFIG)} -L ${JSON.stringify(serverName)} attach-session -t ${JSON.stringify(targetSession)}`;
     const result = spawnSync('script', ['-q', '-e', '-c', script, '/dev/null'], {
       encoding: 'utf-8',
       env: { ...process.env, TMUX: undefined, TMUX_PANE: undefined },
@@ -195,7 +232,7 @@ export async function withTempTmuxSession<T>(
     '-c',
     fixtureCwd,
     'sleep 300',
-  ], tmuxOptions);
+  ], options.serverLog ? { ...tmuxOptions, verbose: true, cwd: fixtureCwd } : tmuxOptions);
   const [windowTarget = '', leaderPaneId = ''] = created.split(/\s+/, 2);
   if (windowTarget === '' || leaderPaneId === '') {
     try {
@@ -208,6 +245,10 @@ export async function withTempTmuxSession<T>(
     await rm(fixtureCwd, { recursive: true, force: true });
     throw new Error(`failed to create temporary tmux fixture: ${created}`);
   }
+
+  const serverLogPath = options.serverLog
+    ? join(fixtureCwd, `tmux-server-${runTmux(['display-message', '-p', '#{pid}'], tmuxOptions)}.log`)
+    : null;
 
   const socketPath = runTmux(['display-message', '-p', '-t', leaderPaneId, '#{socket_path}'], tmuxOptions);
   process.env.TMUX = `${socketPath},${process.pid},0`;
@@ -229,6 +270,16 @@ export async function withTempTmuxSession<T>(
     runResult: (args) => runTmuxResult(args, tmuxOptions),
     createPathShim,
     triggerClientResize,
+    serverLogPath,
+    readServerLog: async () => {
+      if (serverLogPath === null) {
+        throw new Error('server logging was not enabled');
+      }
+      return readFile(serverLogPath, 'utf-8').catch((error: NodeJS.ErrnoException) => {
+        if (error.code === 'ENOENT') return '';
+        throw error;
+      });
+    },
   };
 
   try {


### PR DESCRIPTION
Fixes #3292

## Summary

The detached tmux HUD stayed enlarged (7–23 rows) after a client attached, instead of returning to `HUD_TMUX_HEIGHT_LINES` (2). The stored `client-resized` reconciliation hook could never resize it.

The issue identified one root cause. Implementation found **two** defects in `buildDeferredDetachedHudGuard` (`src/cli/index.ts:1568`), and the second one *masked* the first — which is why the reported `unknown command: tmux` was only intermittently visible.

### Defect 1 — command-context error (the reported root cause)

The resize sink was spliced into a nested tmux `if-shell` success branch **including its `tmux ` executable prefix**. That branch is a tmux **command list**, not a shell, so tmux parsed `tmux` as a command name:

```
unknown command: tmux
```

The regex now captures the bare command and embeds only the capture:

```diff
-    /tmux resize-pane -t %[0-9]+ -y [1-9][0-9]*/g,
+    /tmux (resize-pane -t %[0-9]+ -y [1-9][0-9]*)/g,
```

This matches the sibling invariant already used by `runDetachedLeaderMutation` and `runDetachedHudMutation` (`src/cli/index.ts:1543-1566`), which embed bare tmux commands.

### Defect 2 — format-escaping error (found during implementation)

`run-shell` applies **exactly one outer tmux format pass** to the stored hook payload. Only the *original* command's `#{pane_*}` formats were escaped; the leader and HUD authority conditions **injected by `guardedResize`** were not. tmux therefore pre-expanded them against the hook's own pane and collapsed them to constants. The shim capture shows what actually reached tmux:

```
["if-shell","-F","-t","%0","1","if-shell -F -t '%1' '0' 'resize-pane -t %1 -y 2 ; ...'"]
```

Leader condition → literal `1`, HUD condition → literal `0`. The resize was denied **before the sink was ever parsed**. The injected conditions are now escaped so they survive the outer pass and are evaluated at execution time against the guarded panes.

### Why both are required

Real tmux 3.2a, detached 80x24, HUD enlarged to 7, natural first larger-client attach:

| sink | injected conditions | HUD after | `unknown command: tmux` |
|---|---|---|---|
| prefixed | unescaped *(= `dev` today)* | 7 ❌ | false *(masked)* |
| prefixed | escaped | 7 ❌ | **true** |
| bare | unescaped | 7 ❌ | false |
| **bare** | **escaped** *(this PR)* | **2** ✅ | false |

Defect 2 masks defect 1: with the conditions collapsed to `0`, the inner command list is never selected, so tmux never reaches the invalid token. Fixing only the prefix leaves the HUD enlarged; fixing only the escaping surfaces the reported error.

### Bonus: the fail-closed sentinel was bypassable

`if (guardedCommand === command)` compared the post-regex output against the **pre-escaping** original. A payload carrying `#{pane_id}`/`#{pane_dead}`/`#{pane_pid}` but **no** resize sink mutated through escaping alone and silently skipped the throw. Replaced with an explicit replacement counter, so the guard genuinely fails closed.

## Scope

One product function. Preserved exactly: the `/g` flag (both the immediate and the `sleep N`-delayed sink), the original command's `##{pane_*}` escaping, the receipt `; display-message -p` suffix, the outer `tmux if-shell` prefix (that layer *is* a shell context inside `run-shell -b`), and both authority-condition builders.

Only the four synchronous callers' conditions stay **unescaped** — correctly, since `execTmuxFileSync` passes them as direct argv with no format pass. Escaping there would have broken them.

**Not done** (explicit non-goals): `new-session -x/-y` seeding, `run-shell` re-wrap, authority/hook-registration refactor, reasoning-flag semantics changes, and issues #3284/#3289/#3290. One new `export` (`guardDetachedHudDeferredMutation`) as the direct test seam; both authority types stay module-private.

## Commits

| commit | purpose |
|---|---|
| `465502cd` | tests + the one visibility export — **product behavior unchanged**, so the discriminators are observably red |
| `6831e91f` | the product fix |
| `36a7f809` | fixture contract coverage added after the cleanup review |

`465502cd` is retained deliberately as the immutable pre-fix evidence commit.

## Verification

Verified on **tmux 3.2a** (reporter used 3.7b; the nested command-list semantics are version-independent).

**Pre-fix discriminators**, captured at `465502cd`:

- fail-closed unit test → `AssertionError: Missing expected exception`
- bare-sink companion → fails
- injected-condition escaping → fails
- real-tmux restore → **`7 !== 2`**

**Post-fix**: `index` 327/327 · `launch-fallback` 35/35 (3 consecutive runs) · `tmux-test-fixture` 7/7 · focused 6-file run all green · `lint` · `check:no-unused` · `verify:plugin-bundle` · `verify:native-agents` · `npm pack --dry-run` (zero forbidden paths).

**Adversarial suite, 22/22**: repeated resizes at three distinct geometries all restore to 2; idempotent re-fire; owner drift, `pane_pid` drift, and pane recycling all correctly **deny**; unrelated session byte-identical; 12 fail-closed bypass attempts all throw or guard correctly.

### Notes for the reviewer

- **AC3 is a post-fix guarantee, not a pre-fix discriminator.** Because defect 2 masks defect 1, the `unknown command: tmux` oracle passes *vacuously* on the unfixed tree — the error is unreachable, not absent-by-correctness. Stated plainly rather than presented as a matching matrix.
- `npm run smoke:packed-install` fails **identically on the pristine base** `99d87f36` (this workstation has codex-cli 0.145.0 vs the script's 0.142.5 boundary) — a pre-existing environment limitation, not a regression.
- The base `99d87f36` fails its own full `npm test` with 19 unrelated failures (MCP/Stop-hook/UserPromptSubmit suites), so full-suite red is a pre-existing baseline condition.

Not merging — stopping here for independent exact-head review.

---

🤖 generated by **gaebal-gajae (clawdbot)**
