### PR TITLE
fix(ultragoal): bind aggregate goal to canonical state paths (#3294)

### DIFF
--- a/src/cli/__tests__/detached-leader-teardown.test.ts
+++ b/src/cli/__tests__/detached-leader-teardown.test.ts
@@ -81,6 +81,34 @@ function assertProcessDead(pid: number): void {
   );
 }
 
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+/**
+ * Remove a detached-leader working directory once nothing is still writing to it.
+ *
+ * Subtests that intentionally preserve the HUD pane leave `omx hud --watch` running
+ * against `<wd>/.omx/state` on a 1s tick. Recursive removal races that writer:
+ * `force` only suppresses ENOENT, so a file recreated mid-walk surfaces as
+ * `ENOTEMPTY: directory not empty, rmdir '<wd>/.omx/state'`. Wait for the writer to
+ * exit, then retry to absorb any in-flight tick.
+ */
+async function cleanupDetachedWorkdir(wd: string, hudPanePid?: number): Promise<void> {
+  if (hudPanePid !== undefined) {
+    const deadline = Date.now() + TEST_TIMEOUT_MS;
+    while (processAlive(hudPanePid) && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+  }
+  await rm(wd, { recursive: true, force: true, maxRetries: 10, retryDelay: POLL_INTERVAL_MS });
+}
+
 async function startDetachedLeader(
   fixture: {
     run: (args: string[]) => string;
@@ -180,7 +208,7 @@ describe('detached leader HUD teardown', () => {
         assert.equal(fixture.sessionExists(), true);
       });
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await cleanupDetachedWorkdir(wd);
     }
   });
 
@@ -203,13 +231,16 @@ describe('detached leader HUD teardown', () => {
         assert.equal(fixture.sessionExists(), true);
       });
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await cleanupDetachedWorkdir(wd);
     }
   });
 
   it('preserves the HUD pane and session after signal-derived child death', async (t) => {
     if (!skipUnlessTmux(t)) return;
     const wd = mkdtempSync(join(tmpdir(), 'omx-detached-leader-signal-'));
+    // This subtest deliberately preserves the HUD pane, so its `omx hud --watch`
+    // is still writing `<wd>/.omx/state` when the test body returns.
+    let hudPanePid: number | undefined;
     try {
       await withTempTmuxSession(async (fixture) => {
         const sessionName = 'omx-detached-signal';
@@ -220,6 +251,7 @@ describe('detached leader HUD teardown', () => {
       // Both are signal-derived exits where teardown must stay closed (exit 143).
       const fakeChild = writeChild(wd, 'sleep 1\nkill -TERM $PPID\nsleep 30');
         const started = await startDetachedLeader(fixture, wd, sessionName, sessionId, 'signal-nonce', fakeChild);
+        hudPanePid = started.hud.panePid;
         const terminal = await readReportWhen(started.releaseMarkerPath, (report) => report.kind === 'terminal');
         assert.equal(terminal.finalized, true);
         assert.equal(terminal.exitStatus, 143);
@@ -227,7 +259,7 @@ describe('detached leader HUD teardown', () => {
         assert.equal(tmuxSessionExists(sessionName, fixture.serverName), true);
       });
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await cleanupDetachedWorkdir(wd, hudPanePid);
     }
   });
 
@@ -257,7 +289,7 @@ describe('detached leader HUD teardown', () => {
         assert.equal(fixture.sessionExists(), true);
       });
     } finally {
-      await rm(wd, { recursive: true, force: true });
+      await cleanupDetachedWorkdir(wd);
     }
   });
 

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -2425,4 +2425,119 @@ describe('ultragoal artifacts', () => {
       }
     });
   });
+  describe('canonical state paths in nested projects', () => {
+    async function withNestedRepo<T>(run: (paths: { repo: string; subproject: string }) => Promise<T>): Promise<T> {
+      const repo = await mkdtemp(join(tmpdir(), 'omx-ultragoal-nested-'));
+      try {
+        // A real git worktree root plus pre-existing root-level state that must never be selected.
+        await mkdir(join(repo, '.git'), { recursive: true });
+        await mkdir(join(repo, '.omx/ultragoal'), { recursive: true });
+        await writeFile(join(repo, '.omx/ultragoal/goals.json'), '{"version":1,"goals":[]}\n');
+        await writeFile(join(repo, '.omx/ultragoal/ledger.jsonl'), '');
+        const subproject = join(repo, 'subproject');
+        await mkdir(subproject, { recursive: true });
+        return await run({ repo, subproject });
+      } finally {
+        await rm(repo, { recursive: true, force: true });
+      }
+    }
+
+    it('binds the aggregate objective to the subtree state root', async () => {
+      await withNestedRepo(async ({ subproject }) => {
+        const plan = await createUltragoalPlan(subproject, { brief: 'Ship the nested feature' });
+
+        assert.equal(plan.statePathPrefix, 'subproject');
+        assert.match(plan.codexObjective ?? '', /subproject\/\.omx\/ultragoal\/goals\.json/);
+        assert.match(plan.codexObjective ?? '', /subproject\/\.omx\/ultragoal\/ledger\.jsonl/);
+        assert.notEqual(plan.codexObjective, ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE);
+      });
+    });
+
+    it('keeps repository-root launches byte-identical to the root objective', async () => {
+      await withNestedRepo(async ({ repo }) => {
+        const plan = await createUltragoalPlan(repo, { brief: 'Ship the root feature', force: true });
+
+        assert.equal(plan.statePathPrefix, undefined);
+        assert.equal(plan.codexObjective, ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE);
+      });
+    });
+
+    it('renders the aggregate handoff header with canonical state paths', async () => {
+      await withNestedRepo(async ({ subproject }) => {
+        await createUltragoalPlan(subproject, { brief: 'Ship the nested feature' });
+        const started = await startNextUltragoal(subproject);
+        const instruction = buildCodexGoalInstruction(started.goal!, started.plan);
+
+        assert.match(instruction, /Plan: subproject\/\.omx\/ultragoal\/goals\.json/);
+        assert.match(instruction, /Ledger: subproject\/\.omx\/ultragoal\/ledger\.jsonl/);
+      });
+    });
+
+    it('reconciles the prefixed objective and rejects the ambiguous bare objective', async () => {
+      await withNestedRepo(async ({ subproject }) => {
+        const created = await createUltragoalPlan(subproject, { brief: 'Ship the nested feature' });
+        const started = await startNextUltragoal(subproject);
+
+        const checkpointed = await checkpointUltragoal(subproject, {
+          goalId: started.goal!.id,
+          status: 'complete',
+          evidence: 'tests passed',
+          codexGoal: { goal: { objective: created.codexObjective, status: 'complete' } },
+          qualityGate: cleanQualityGate(),
+        });
+        assert.equal(checkpointed.goals[0]?.status, 'complete');
+
+        // A reader that resolved the bare `.omx/...` reference from the repo root must not match.
+        await assert.rejects(
+          checkpointUltragoal(subproject, {
+            goalId: started.goal!.id,
+            status: 'complete',
+            evidence: 'tests passed',
+            codexGoal: { goal: { objective: ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE, status: 'complete' } },
+            qualityGate: cleanQualityGate(),
+          }),
+        );
+      });
+    });
+
+    it('migrates a pre-existing nested plan and leaves root plans untouched', async () => {
+      await withNestedRepo(async ({ repo, subproject }) => {
+        await createUltragoalPlan(subproject, { brief: 'Ship the nested feature' });
+        const planPath = join(subproject, '.omx/ultragoal/goals.json');
+        const stale = JSON.parse(await readFile(planPath, 'utf-8')) as UltragoalPlan;
+        stale.codexObjective = ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE;
+        delete stale.statePathPrefix;
+        await writeFile(planPath, `${JSON.stringify(stale, null, 2)}\n`);
+
+        const migrated = await readUltragoalPlan(subproject);
+        assert.equal(migrated.statePathPrefix, 'subproject');
+        assert.match(migrated.codexObjective ?? '', /subproject\/\.omx\/ultragoal\/goals\.json/);
+        assert.deepEqual(migrated.codexObjectiveAliases, [ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE]);
+        const ledger = await readFile(join(subproject, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+        assert.match(ledger, /"event":"aggregate_objective_migrated"/);
+        assert.match(ledger, /canonical repo-root-relative state paths/);
+
+        // The already-active hidden Codex goal keeps reconciling through the retained alias.
+        const started = await startNextUltragoal(subproject);
+        const checkpointed = await checkpointUltragoal(subproject, {
+          goalId: started.goal!.id,
+          status: 'complete',
+          evidence: 'tests passed',
+          codexGoal: { goal: { objective: ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE, status: 'complete' } },
+          qualityGate: cleanQualityGate(),
+        });
+        assert.equal(checkpointed.goals[0]?.status, 'complete');
+
+        const rootPlan = await createUltragoalPlan(repo, { brief: 'Ship the root feature', force: true });
+        const rootLedgerBefore = await readFile(join(repo, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+        const reread = await readUltragoalPlan(repo);
+        const rootLedgerAfter = await readFile(join(repo, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+
+        assert.equal(reread.codexObjective, rootPlan.codexObjective);
+        assert.equal(reread.codexObjectiveAliases, undefined);
+        assert.equal(rootLedgerAfter, rootLedgerBefore);
+      });
+    });
+  });
+
 });

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { appendFile, mkdir, open, readFile, rename, rm, writeFile } from 'node:fs/promises';
-import { join, relative } from 'node:path';
+import { isAbsolute, join, relative } from 'node:path';
 import { resolveWritableStateScope, WRITABLE_STATE_SCOPE_ERRORS } from '../mcp/state-paths.js';
 import type { ResolvedStateScope } from '../mcp/state-paths.js';
 import {
@@ -15,6 +15,7 @@ import {
   buildUnsupportedNativeSubagentGuidance,
   type NativeSubagentSupportEvidence,
 } from '../leader/contract.js';
+import { findGitLayout } from '../utils/git-layout.js';
 
 export const ULTRAGOAL_DIR = '.omx/ultragoal';
 export const ULTRAGOAL_BRIEF = 'brief.md';
@@ -183,6 +184,7 @@ export interface UltragoalPlan {
   codexGoalMode?: UltragoalCodexGoalMode;
   codexObjective?: string;
   codexObjectiveAliases?: string[];
+  statePathPrefix?: string;
   aggregateCompletion?: UltragoalAggregateCompletion;
   activeGoalId?: string;
   goals: UltragoalItem[];
@@ -319,6 +321,25 @@ export function ultragoalLedgerPath(cwd: string): string {
 
 function repoRelative(cwd: string, path: string): string {
   return relative(cwd, path).split('\\').join('/');
+}
+
+/**
+ * Repo-root-relative prefix for the Ultragoal state directory selected by `cwd`.
+ *
+ * Returns `''` for repository-root launches and for any cwd we cannot bind to a
+ * git worktree root, so root-level behavior stays byte-identical to a plain
+ * `.omx/ultragoal` reference.
+ */
+export function ultragoalStatePathPrefix(cwd: string): string {
+  const worktreeRoot = findGitLayout(cwd)?.worktreeRoot;
+  if (!worktreeRoot) return '';
+  const prefix = repoRelative(worktreeRoot, cwd);
+  if (!prefix || prefix.startsWith('../') || prefix === '..' || isAbsolute(prefix)) return '';
+  return prefix;
+}
+
+function prefixedStatePath(prefix: string, artifact: string): string {
+  return `${prefix ? `${prefix}/` : ''}${ULTRAGOAL_DIR}/${artifact}`;
 }
 
 function cleanLine(line: string): string {
@@ -673,11 +694,15 @@ function isScheduleEligibleGoal(goal: UltragoalItem): boolean {
   return goal.steeringStatus !== 'superseded' && goal.steeringStatus !== 'blocked';
 }
 
-export const ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE =
-  `Complete the durable ultragoal plan in ${ULTRAGOAL_DIR}/${ULTRAGOAL_GOALS}, including later accepted/appended stories, under the original brief constraints; use ${ULTRAGOAL_DIR}/${ULTRAGOAL_LEDGER} as the audit trail.`;
+export const ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE = buildAggregateCodexObjective('');
 
-function aggregateCodexObjective(_goals: readonly UltragoalItem[]): string {
-  if (ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE.length <= 4000) return ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE;
+function buildAggregateCodexObjective(statePathPrefix: string): string {
+  return `Complete the durable ultragoal plan in ${prefixedStatePath(statePathPrefix, ULTRAGOAL_GOALS)}, including later accepted/appended stories, under the original brief constraints; use ${prefixedStatePath(statePathPrefix, ULTRAGOAL_LEDGER)} as the audit trail.`;
+}
+
+function aggregateCodexObjective(statePathPrefix: string): string {
+  const objective = buildAggregateCodexObjective(statePathPrefix);
+  if (objective.length <= 4000) return objective;
   throw new UltragoalError('Generated aggregate Codex objective exceeds the 4,000 character goal limit.');
 }
 
@@ -691,12 +716,13 @@ function isLegacyEnumeratedAggregateObjective(objective: string | undefined): bo
 
 function compatibleCodexObjectives(plan: UltragoalPlan): string[] {
   return (plan.codexObjectiveAliases ?? [])
-    .filter((objective) => isLegacyEnumeratedAggregateObjective(objective));
+    .filter((objective) => isLegacyEnumeratedAggregateObjective(objective)
+      || objective === ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE);
 }
 
 function expectedCodexObjective(plan: UltragoalPlan, goal: UltragoalItem): string {
   return codexGoalMode(plan) === 'aggregate'
-    ? (plan.codexObjective ?? aggregateCodexObjective(plan.goals))
+    ? (plan.codexObjective ?? aggregateCodexObjective(plan.statePathPrefix ?? ''))
     : goal.objective;
 }
 
@@ -927,23 +953,34 @@ export async function readUltragoalPlanSnapshot(cwd: string): Promise<UltragoalP
   return readUltragoalPlanFile(cwd);
 }
 
-function requiresAggregateObjectiveMigration(plan: UltragoalPlan): boolean {
-  return codexGoalMode(plan) === 'aggregate' && isLegacyEnumeratedAggregateObjective(plan.codexObjective);
+function requiresCanonicalStatePathMigration(plan: UltragoalPlan, statePathPrefix: string): boolean {
+  return statePathPrefix !== '' && plan.codexObjective === ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE;
+}
+
+function requiresAggregateObjectiveMigration(plan: UltragoalPlan, statePathPrefix: string): boolean {
+  if (codexGoalMode(plan) !== 'aggregate') return false;
+  return isLegacyEnumeratedAggregateObjective(plan.codexObjective)
+    || requiresCanonicalStatePathMigration(plan, statePathPrefix);
 }
 
 /** Durable legacy-objective migration; caller MUST hold the mutation lock. */
 async function migrateAggregateObjectiveUnderLock(cwd: string, parsed: UltragoalPlan): Promise<UltragoalPlan> {
-  if (!requiresAggregateObjectiveMigration(parsed)) return parsed;
+  const statePathPrefix = ultragoalStatePathPrefix(cwd);
+  if (!requiresAggregateObjectiveMigration(parsed, statePathPrefix)) return parsed;
+  const canonicalStatePathMigration = requiresCanonicalStatePathMigration(parsed, statePathPrefix);
   const previousObjective = parsed.codexObjective;
   const now = iso();
-  parsed.codexObjective = aggregateCodexObjective(parsed.goals);
+  parsed.codexObjective = aggregateCodexObjective(statePathPrefix);
+  parsed.statePathPrefix = statePathPrefix === '' ? undefined : statePathPrefix;
   parsed.codexObjectiveAliases = Array.from(new Set([...(parsed.codexObjectiveAliases ?? []), previousObjective].filter((value): value is string => typeof value === 'string' && value.length > 0)));
   parsed.updatedAt = now;
   await writePlan(cwd, parsed);
   await appendLedger(cwd, {
     ts: now,
     event: 'aggregate_objective_migrated',
-    message: 'Migrated legacy enumerated aggregate Codex objective to the stable pointer objective.',
+    message: canonicalStatePathMigration
+      ? 'Migrated the cwd-relative aggregate Codex objective to canonical repo-root-relative state paths.'
+      : 'Migrated legacy enumerated aggregate Codex objective to the stable pointer objective.',
     before: { codexObjective: previousObjective },
     after: { codexObjective: parsed.codexObjective },
   });
@@ -957,7 +994,7 @@ async function readUltragoalPlanUnderLock(cwd: string): Promise<UltragoalPlan> {
 
 export async function readUltragoalPlan(cwd: string): Promise<UltragoalPlan> {
   const parsed = await readUltragoalPlanFile(cwd);
-  if (!requiresAggregateObjectiveMigration(parsed)) return parsed;
+  if (!requiresAggregateObjectiveMigration(parsed, ultragoalStatePathPrefix(cwd))) return parsed;
   // The legacy objective migration is a durable story transition: it requires
   // writable lifecycle authority and the mutation lock, and re-reads the plan
   // under the lock so a concurrent mutator cannot be clobbered or duplicated.
@@ -1003,7 +1040,11 @@ export async function createUltragoalPlan(cwd: string, options: CreateUltragoalO
     codexGoalMode: options.codexGoalMode ?? 'aggregate',
     goals: candidates,
   };
-  if (plan.codexGoalMode === 'aggregate') plan.codexObjective = aggregateCodexObjective(candidates);
+  if (plan.codexGoalMode === 'aggregate') {
+    const statePathPrefix = ultragoalStatePathPrefix(cwd);
+    if (statePathPrefix !== '') plan.statePathPrefix = statePathPrefix;
+    plan.codexObjective = aggregateCodexObjective(statePathPrefix);
+  }
 
   await mkdir(ultragoalDir(cwd), { recursive: true });
   await writeFile(ultragoalBriefPath(cwd), options.brief.endsWith('\n') ? options.brief : `${options.brief}\n`);
@@ -1124,6 +1165,7 @@ function hasProtectedSteeringPayload(value: unknown): boolean {
     'codexObjective',
     'constraints',
     'completedAt',
+    'statePathPrefix',
     'qualityGate',
     'status',
   ]);
@@ -2089,7 +2131,8 @@ function buildPerStoryCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalP
 }
 
 function buildAggregateCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalPlan, options: CodexGoalInstructionOptions): string {
-  const objective = plan.codexObjective ?? aggregateCodexObjective(plan.goals);
+  const statePathPrefix = plan.statePathPrefix ?? '';
+  const objective = plan.codexObjective ?? aggregateCodexObjective(statePathPrefix);
   const finalStory = isFinalRunCompletionCandidate(plan, goal);
   const createPayload = { objective };
   const checkpointStatus = finalStory ? 'complete' : 'active';
@@ -2097,8 +2140,8 @@ function buildAggregateCodexGoalInstruction(goal: UltragoalItem, plan: Ultragoal
     codexGoalConductorGuidance(options),
     '',
     'Ultragoal aggregate-goal handoff',
-    `Plan: ${plan.goalsPath}`,
-    `Ledger: ${plan.ledgerPath}`,
+    `Plan: ${prefixedStatePath(statePathPrefix, ULTRAGOAL_GOALS)}`,
+    `Ledger: ${prefixedStatePath(statePathPrefix, ULTRAGOAL_LEDGER)}`,
     `Goal: ${goal.id} — ${goal.title}`,
     '',
     'Codex goal integration constraints:',


### PR DESCRIPTION
Fixes #3294.

## Problem

When `omx ultragoal` starts from a project subtree, the native aggregate Codex objective still referenced bare paths:

```
.omx/ultragoal/goals.json
.omx/ultragoal/ledger.jsonl
```

Those resolve against whatever cwd a later reader happens to have. After a session/root handoff, a reader rooted at `/repo` selects `/repo/.omx/ultragoal` instead of the active `/repo/subproject/.omx/ultragoal` — so the durable plan and the native goal silently point at different workflows, with no visible change to the objective text.

## Fix

Derive a repo-root-relative `statePathPrefix` from the git worktree root and bake it into the aggregate objective and the aggregate handoff header, so the goal identifies its artifacts unambiguously from any cwd:

```
Complete the durable ultragoal plan in subproject/.omx/ultragoal/goals.json, … use subproject/.omx/ultragoal/ledger.jsonl as the audit trail.
```

The prefix is **persisted on the plan**, so reconciliation and recovery use that canonical identity rather than reinterpreting relative paths against the reader's cwd.

### Design notes

- **No subprocess.** `ultragoalStatePathPrefix()` uses the pure-fs `findGitLayout()` walker (which already handles `.git` files and `commondir`) instead of `git rev-parse`. It fails closed to `''` for non-repo dirs and for absolute or `..`-escaping relatives.
- **Root launches are byte-identical.** A repository-root launch yields prefix `''`, so `ULTRAGOAL_AGGREGATE_CODEX_OBJECTIVE` is unchanged and existing root-level plans see zero churn.
- **`plan.goalsPath` / `plan.ledgerPath` deliberately unchanged.** `src/team/ultragoal-context.ts` validates both by strict equality against `.omx/ultragoal/…`; changing them would be out-of-scope breakage.
- **Migration reuses the existing alias mechanism.** A pre-existing nested plan holding the bare pointer objective migrates on read, retains the old string in `codexObjectiveAliases` (so an already-active hidden Codex goal still reconciles), and emits the existing `aggregate_objective_migrated` ledger event. Root plans read from the root are a strict no-op.

## Acceptance criteria

- [x] Nested launches reference `goals.json` / `ledger.jsonl` unambiguously from the repository root
- [x] Starting from `/repo/subproject` cannot cause a reader rooted at `/repo` to select `/repo/.omx/ultragoal`
- [x] Existing repository-root launches continue to resolve root-level `.omx/ultragoal` correctly
- [x] Regression test with **both** `/repo/.omx/ultragoal` and `/repo/subproject/.omx/ultragoal` proving the generated goal identifies the subtree state
- [x] Reconciliation/recovery uses the canonical artifact identity rather than reinterpreting bare relative paths

## Testing

Five new regression tests in `src/ultragoal/__tests__/artifacts.test.ts` under `canonical state paths in nested projects`, covering the subtree binding, the byte-identical root launch, the handoff header, prefixed-vs-bare reconciliation, and migration plus the root no-op.

- `npx tsc --noEmit` — clean for `src/ultragoal` (only pre-existing `native-assets` optional-dep errors remain)
- `node --test dist/ultragoal/__tests__/*.test.js dist/goal-workflows/__tests__/*.test.js dist/team/__tests__/ultragoal-context.test.js` — **83/83 pass**
- `node --test dist/cli/__tests__/ultragoal.test.js dist/team/__tests__/approved-execution.test.js dist/team/__tests__/worker-bootstrap.test.js` — **113/113 pass**
- Live nested-repo run against the compiled runtime confirmed the prefixed objective, the prefixed `Plan:`/`Ledger:` header, an untouched root-level state dir and ledger, the byte-identical root launch, and the audited migration

Scope is limited to this issue; #3272 / #3274 / #3284 / #3293 are untouched.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*