### PR TITLE
fix(hooks): authorize finite Codex goal tools under Main-root Conductor (#3300)

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -32140,6 +32140,88 @@ PY`,
     }
   });
 
+  it("allows finite Codex goal tools under Main-root Ultragoal checkpointing while near-misses stay unknown-denied (#3300)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3300-goal-tool-transport-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-3300-goal-tool-transport";
+      const leaderThreadId = "thread-3300-goal-tool-transport";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeJson(join(stateDir, "session.json"), {
+        session_id: sessionId,
+        native_session_id: leaderThreadId,
+        cwd,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: leaderThreadId,
+            threads: { [leaderThreadId]: { thread_id: leaderThreadId, kind: "leader" } },
+          },
+        },
+      });
+      await writeSessionSkillActiveState(stateDir, sessionId, "ultragoal", "checkpointing");
+      await writeJson(join(stateDir, "sessions", sessionId, "ultragoal-state.json"), {
+        active: true,
+        mode: "ultragoal",
+        current_phase: "checkpointing",
+        session_id: sessionId,
+      });
+
+      const dispatch = (tool_name: string, tool_input: Record<string, unknown> = {}) =>
+        dispatchCodexNativeHook({
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: leaderThreadId,
+          agent_id: leaderThreadId,
+          tool_name,
+          tool_input,
+        }, { cwd });
+
+      for (const [tool_name, tool_input] of [
+        ["Read", { file_path: "README.md" }],
+        ["get_goal", {}],
+        ["functions.get_goal", {}],
+        ["functionsget_goal", {}],
+        ["create_goal", { objective: "complete the ultragoal plan" }],
+        ["update_goal", { status: "complete" }],
+        ["functions.create_goal", { objective: "complete the ultragoal plan" }],
+        ["functions.update_goal", { status: "complete" }],
+        ["functionscreate_goal", { objective: "complete the ultragoal plan" }],
+        ["functionsupdate_goal", { status: "complete" }],
+      ] as const) {
+        const result = await dispatch(tool_name, tool_input);
+        assert.equal(result.outputJson, null, tool_name);
+      }
+
+      for (const tool_name of ["getgoal", "get_goals", "updateGoal", "createGoal", "functions.get_goals"]) {
+        const blocked = await dispatch(tool_name, {});
+        assert.equal(blocked.outputJson?.decision, "block", tool_name);
+        const reason = String(blocked.outputJson?.reason ?? "");
+        assert.match(reason, /Main-root Conductor mode is active \(ultragoal phase: checkpointing\)/);
+        assert.match(reason, /not a recognized read-only or explicitly authorized Conductor mutation transport/);
+        assert.match(reason, new RegExp(tool_name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+      }
+
+      // Stop reconciliation must be able to require a fresh get_goal without PreToolUse self-block.
+      const stop = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        thread_id: leaderThreadId,
+        agent_id: leaderThreadId,
+      }, { cwd });
+      const stopMessage = JSON.stringify(stop.outputJson ?? {});
+      // Stop may still emit guidance, but must not claim get_goal is an unrecognized Conductor transport.
+      assert.doesNotMatch(stopMessage, /get_goal is not a recognized read-only or explicitly authorized Conductor mutation transport/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("allows session-scoped omx cancel under active ultragoal conductor while impostors stay blocked", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ultragoal-conductor-cancel-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -5138,7 +5138,7 @@ function commandHasDeepInterviewWriteIntent(command: string, depth = 0, cwd = pr
     ));
 }
 
-type PreToolUseMutationTransport = "read-only" | "bash" | "path" | "state" | "orchestration" | "unknown";
+type PreToolUseMutationTransport = "read-only" | "bash" | "path" | "state" | "orchestration" | "goal-lifecycle" | "unknown";
 
 const READ_ONLY_PRETOOLUSE_TOOL_NAMES = new Set([
   "Read",
@@ -5215,6 +5215,37 @@ const CONDUCTOR_ORCHESTRATION_TOOL_NAMES = new Set([
   "multi_agent_v1.close_agent",
 ]);
 
+// Finite native Codex goal-tool identities for Ultragoal reconciliation.
+// Canonicalize ONLY exact known host-emitted forms (bare, functions.*, and known
+// flattened forms). Unknown/near-miss names stay fail-closed as "unknown".
+// Callers keep the original received name for diagnostics.
+const NATIVE_CODEX_GOAL_READ_TOOL_NAMES = new Set([
+  "get_goal",
+  "functions.get_goal",
+  "functionsget_goal",
+]);
+const NATIVE_CODEX_GOAL_LIFECYCLE_TOOL_NAMES = new Set([
+  "create_goal",
+  "update_goal",
+  "functions.create_goal",
+  "functions.update_goal",
+  "functionscreate_goal",
+  "functionsupdate_goal",
+]);
+
+function canonicalizeNativeCodexGoalToolName(name: string): string {
+  switch (name) {
+    case "functionsget_goal":
+      return "functions.get_goal";
+    case "functionscreate_goal":
+      return "functions.create_goal";
+    case "functionsupdate_goal":
+      return "functions.update_goal";
+    default:
+      return name;
+  }
+}
+
 function classifyPreToolUseMutationTransport(
   payload: CodexHookPayload,
   toolName: string,
@@ -5230,6 +5261,14 @@ function classifyPreToolUseMutationTransport(
   if (PLANNING_MODE_IMPLEMENTATION_TOOL_NAMES.has(toolName)) return "path";
   if (READ_ONLY_PRETOOLUSE_TOOL_NAMES.has(toolName) || READ_ONLY_PRETOOLUSE_MCP_TOOL_NAMES.has(toolName)) {
     return "read-only";
+  }
+  // Finite Codex goal tools: exact names only (bare, functions.*, known flattened).
+  // Preserve the original toolName for deny diagnostics; classify on the canonical form.
+  if (NATIVE_CODEX_GOAL_READ_TOOL_NAMES.has(toolName) || NATIVE_CODEX_GOAL_READ_TOOL_NAMES.has(canonicalizeNativeCodexGoalToolName(toolName))) {
+    return "read-only";
+  }
+  if (NATIVE_CODEX_GOAL_LIFECYCLE_TOOL_NAMES.has(toolName) || NATIVE_CODEX_GOAL_LIFECYCLE_TOOL_NAMES.has(canonicalizeNativeCodexGoalToolName(toolName))) {
+    return "goal-lifecycle";
   }
   const canonicalToolName = canonicalizeNativeCollaborationToolName(toolName);
 
@@ -9674,7 +9713,7 @@ function teamWorkerMutationTargetsProtectedWorkflowState(
   };
   const mutationTransport = classifyPreToolUseMutationTransport(payload, toolName, cwd);
   if (toolName === "mcp__omx_state__state_clear" || toolName === "mcp__omx_state__state_write") return true;
-  if (mutationTransport === "unknown" || mutationTransport === "state") return true;
+  if (mutationTransport === "unknown" || mutationTransport === "state" || mutationTransport === "goal-lifecycle") return true;
   if (toolName === "Bash") {
     if (collectOmxStateCommandOperations(command, "write").length > 0
       || findUnquotedOmxStateCommandIndexes(command, "clear").length > 0) return true;
@@ -9820,7 +9859,7 @@ async function buildRalplanPreToolUseBoundaryOutput(
         blockedDetail = describeImplementationToolBlock(toolName, blockedPath, toolPathCandidates.length);
       }
     }
-  } else if (mutationTransport === "unknown") {
+  } else if (mutationTransport === "unknown" || mutationTransport === "goal-lifecycle") {
     blocked = true;
     blockedDetail = `${toolName || "unknown tool"} is not a recognized read-only or explicitly authorized planning mutation transport`;
   }
@@ -9939,7 +9978,7 @@ async function buildDeepInterviewPreToolUseBoundaryOutput(
       const blockedPath = candidates.find((candidate) => !isAllowedDeepInterviewArtifactPath(cwd, candidate, sessionId));
       blockedDetail = describeImplementationToolBlock(toolName, blockedPath, candidates.length);
     }
-  } else if (mutationTransport === "unknown") {
+  } else if (mutationTransport === "unknown" || mutationTransport === "goal-lifecycle") {
     blocked = true;
     blockedDetail = `${toolName || "unknown tool"} is not a recognized read-only or explicitly authorized deep-interview mutation transport`;
   }
@@ -9964,7 +10003,7 @@ function blocksDeepInterviewImplementationWrite(payload: CodexHookPayload, cwd: 
     return !isAllowedDeepInterviewBashWrite(cwd, readPreToolUseCommand(payload), undefined, authoritativeSessionId);
   }
   const mutationTransport = classifyPreToolUseMutationTransport(payload, toolName);
-  if (mutationTransport === "unknown") return true;
+  if (mutationTransport === "unknown" || mutationTransport === "goal-lifecycle") return true;
   if (mutationTransport !== "path") return false;
   const candidates = collectImplementationToolPathCandidates(
     payload,
@@ -10082,7 +10121,7 @@ async function buildPlanningRootPointerConflictPreToolUseOutput(
     );
     blocked = toolPathCandidates.length === 0
       || toolPathCandidates.some((candidate) => !isAllowedRalplanArtifactPath(cwd, candidate, rootSessionId));
-  } else if (mutationTransport === "unknown") {
+  } else if (mutationTransport === "unknown" || mutationTransport === "goal-lifecycle") {
     blocked = true;
   }
 
@@ -18966,7 +19005,7 @@ export async function buildConductorPreToolUseWriteGuardOutput(
       blocked = true;
       blockedDetail = "Structured state writes must preserve the canonical active Conductor guard";
     }
-  } else if (mutationTransport === "orchestration") {
+  } else if (mutationTransport === "orchestration" || mutationTransport === "goal-lifecycle") {
     nativeChildMutationAttempt = true;
   } else if (mutationTransport === "path") {
     nativeChildMutationAttempt = true;


### PR DESCRIPTION
## Summary
- Reproduce and fix #3300: active Main-root Ultragoal Conductor PreToolUse rejected finite Codex goal tools (`get_goal`/`create_goal`/`update_goal` and known `functions.*`/flattened forms) as unknown transports, blocking Stop reconciliation before the goal handler.
- Classify exact goal-tool identities with a fail-closed map: `get_goal` as read-only; `create_goal`/`update_goal` as a new `goal-lifecycle` transport authorized for Main-root under active Ultragoal/Conductor; near-misses remain unknown-denied.
- Keep planning/deep-interview fail-closed for goal-lifecycle; preserve #3264 collab canonicalization and existing stale-binding protections.

## Test plan
- [x] Isolated reproduction harness under Main-root Ultragoal `checkpointing`
- [x] `bun test` focused: `allows finite Codex goal tools under Main-root Ultragoal checkpointing`
- [x] Related: flattened collab ralplan allow/deny + standalone ultragoal conductor write block
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run check:no-unused`

Closes #3300