### PR TITLE
fix(ultragoal): preserve native Codex goal status blocked (#3301)

### DIFF
--- a/docs/ultragoal.md
+++ b/docs/ultragoal.md
@@ -80,7 +80,7 @@ Completed legacy thread-goal blocker handling:
 omx ultragoal checkpoint --goal-id G001-example --status blocked --evidence "completed legacy Codex goal blocks create_goal in this thread" --codex-goal-json ./get-goal.json
 ```
 
-`--status blocked` is a non-terminal ledger checkpoint for legacy per-story or pre-aggregate sessions: a previous, different Codex thread goal is already `complete`, and the current `get_goal`/`create_goal` tool surface has no reset/new-goal operation that can clear that completed goal from the same thread. This writes a `goal_blocked` event, preserves the ultragoal as `in_progress`, and records that the agent must continue the same repo/worktree only from a Codex goal context where `create_goal` can start the active ultragoal objective.
+`--status blocked` is a non-terminal ledger checkpoint. Use it in two cases: (1) legacy per-story or pre-aggregate sessions where a previous, different Codex thread goal is already `complete` and the current `get_goal`/`create_goal` tool surface has no reset/new-goal operation that can clear that completed goal from the same thread; (2) when the matching Codex goal for the active ultragoal objective is truthfully `blocked` and you need to persist a non-terminal `goal_blocked` receipt with evidence. Both cases write a `goal_blocked` event, preserve the ultragoal as `in_progress`, and keep recovery finite without treating the microgoal as complete or failed.
 
 Status:
 
@@ -214,5 +214,5 @@ When Scholastic advisory evidence exists for ontology-heavy goals, add it alongs
 - Ultragoal owns durable plan and ledger state; Codex goal mode owns active-thread focus and accounting.
 - OMX never edits upstream Codex source such as `../../codex`, never shells out to a hidden `/goal` mutator, and never claims that `omx ultragoal checkpoint` changes Codex's active thread goal. The only Codex goal-mode handoff is explicit: `get_goal`, then `create_goal` when no active goal exists, then `update_goal({status: "complete"})` after the real completion audit passes.
 - Completion checkpoints require a fresh `get_goal` snapshot. Save or pass the JSON from `get_goal` with `--codex-goal-json <json-or-path>`; OMX compares the objective and enforces the mode-specific status (`active` for intermediate aggregate stories, `complete` for final aggregate or per-story completion).
-- Active or incomplete wrong Codex goals remain strict mismatch errors. The `--status blocked` workaround only applies when the blocking Codex snapshot is `complete` and has a different objective from the active ultragoal; it must not be used to bypass active-goal mismatch protection.
+- Active or incomplete wrong Codex goals remain strict mismatch errors. The `--status blocked` path accepts either a different completed legacy Codex objective or a matching native Codex `blocked` snapshot with required evidence; it must not be used to bypass active-goal mismatch protection for active or wrong-objective goals.
 - A goal is not complete merely because tests pass or a ledger entry exists. The agent must audit the objective against files, commands, tests, PR state, or other concrete evidence.

--- a/plugins/oh-my-codex/skills/ultragoal/SKILL.md
+++ b/plugins/oh-my-codex/skills/ultragoal/SKILL.md
@@ -64,8 +64,9 @@ Loop until `omx ultragoal status` reports all goals complete:
    `omx ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>" --codex-goal-json <get_goal-json-or-path> [--quality-gate-json <quality-gate-json-or-path>]`
 9. If blocked or failed, checkpoint failure:
    `omx ultragoal checkpoint --goal-id <id> --status failed --evidence "<blocker/evidence>"`
-10. For legacy per-story completed-goal blockers, preserve the non-terminal blocker with:
-   `omx ultragoal checkpoint --goal-id <id> --status blocked --evidence "<completed legacy Codex goal blocks create_goal in this thread>" --codex-goal-json <get_goal-json-or-path>`
+10. For non-terminal blockers, use blocked checkpoints:
+   - legacy different completed goal: `omx ultragoal checkpoint --goal-id <id> --status blocked --evidence "<completed legacy Codex goal blocks create_goal in this thread>" --codex-goal-json <get_goal-json-or-path>`
+   - matching native Codex `blocked` status: `omx ultragoal checkpoint --goal-id <id> --status blocked --evidence "<blocker evidence>" --codex-goal-json <matching-blocked-get_goal-json-or-path>`
 11. Resume failed goals with `omx ultragoal complete-goals --retry-failed`.
 
 ## Dynamic steering

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -64,8 +64,9 @@ Loop until `omx ultragoal status` reports all goals complete:
    `omx ultragoal checkpoint --goal-id <id> --status complete --evidence "<evidence>" --codex-goal-json <get_goal-json-or-path> [--quality-gate-json <quality-gate-json-or-path>]`
 9. If blocked or failed, checkpoint failure:
    `omx ultragoal checkpoint --goal-id <id> --status failed --evidence "<blocker/evidence>"`
-10. For legacy per-story completed-goal blockers, preserve the non-terminal blocker with:
-   `omx ultragoal checkpoint --goal-id <id> --status blocked --evidence "<completed legacy Codex goal blocks create_goal in this thread>" --codex-goal-json <get_goal-json-or-path>`
+10. For non-terminal blockers, use blocked checkpoints:
+   - legacy different completed goal: `omx ultragoal checkpoint --goal-id <id> --status blocked --evidence "<completed legacy Codex goal blocks create_goal in this thread>" --codex-goal-json <get_goal-json-or-path>`
+   - matching native Codex `blocked` status: `omx ultragoal checkpoint --goal-id <id> --status blocked --evidence "<blocker evidence>" --codex-goal-json <matching-blocked-get_goal-json-or-path>`
 11. Resume failed goals with `omx ultragoal complete-goals --retry-failed`.
 
 ## Dynamic steering

--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -725,6 +725,60 @@ describe('cli/ultragoal', () => {
       assert.match(ledger, /"event":"goal_blocked"/);
     });
   });
+  it('records matching native blocked Codex goal checkpoints as non-terminal and exposes status diagnostics', async () => {
+    await withCwd(async (cwd) => {
+      await capture(() => ultragoalCommand(['create-goals', '--brief', '- First milestone']));
+      await capture(() => ultragoalCommand(['complete-goals']));
+      const statusOut = await capture(() => ultragoalCommand(['status', '--json']));
+      const status = JSON.parse(statusOut.stdout.join('\n')) as { plan?: { codexObjective?: string }; goals?: Array<{ objective?: string }> };
+      // fall back to known aggregate objective text if needed
+      const objective = status.plan?.codexObjective
+        ?? 'Complete the durable ultragoal plan in .omx/ultragoal/goals.json, including later accepted/appended stories, under the original brief constraints; use .omx/ultragoal/ledger.jsonl as the audit trail.';
+
+      const blockedJson = JSON.stringify({ goal: { objective, status: 'blocked' } });
+      const blocked = await capture(() => ultragoalCommand([
+        'checkpoint',
+        '--goal-id', 'G001-first-milestone',
+        '--status', 'blocked',
+        '--evidence', 'native matching blocked needs attention',
+        '--codex-goal-json', blockedJson,
+        '--json',
+      ]));
+      assert.equal(blocked.exitCode, undefined, blocked.stderr.join('\n'));
+      const parsed = JSON.parse(blocked.stdout.join('\n')) as { summary: { inProgress: number }; plan: { activeGoalId?: string } };
+      assert.equal(parsed.summary.inProgress, 1);
+      assert.equal(parsed.plan.activeGoalId, 'G001-first-milestone');
+
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.match(ledger, /"event":"goal_blocked"/);
+      assert.match(ledger, /"status":"blocked"/);
+
+      const recon = await capture(() => ultragoalCommand([
+        'status',
+        '--codex-goal-json', blockedJson,
+        '--json',
+      ]));
+      assert.equal(recon.exitCode, undefined, recon.stderr.join('\n'));
+      const reconParsed = JSON.parse(recon.stdout.join('\n')) as {
+        reconciliation?: { ok?: boolean; snapshot?: { status?: string; raw?: { goal?: { status?: string } } }; errors?: string[] };
+      };
+      assert.equal(reconParsed.reconciliation?.snapshot?.status, 'blocked');
+      assert.equal(reconParsed.reconciliation?.snapshot?.raw?.goal?.status, 'blocked');
+      assert.equal(reconParsed.reconciliation?.ok, false);
+      assert.match((reconParsed.reconciliation?.errors ?? []).join('\n'), /got blocked/);
+      assert.doesNotMatch((reconParsed.reconciliation?.errors ?? []).join('\n'), /got unknown/);
+
+      const mismatch = await capture(() => ultragoalCommand([
+        'checkpoint',
+        '--goal-id', 'G001-first-milestone',
+        '--status', 'blocked',
+        '--evidence', 'foreign blocked goal',
+        '--codex-goal-json', '{"goal":{"objective":"Different blocked work","status":"blocked"}}',
+      ]));
+      assert.equal(mismatch.exitCode, 1);
+      assert.match(mismatch.stderr.join('\n'), /objective mismatch/);
+    });
+  });
 
   it('circuit-breaks repeated GHCR authorization blockers and skips them on retry-failed', async () => {
     await withCwd(async (cwd) => {

--- a/src/goal-workflows/__tests__/codex-goal-snapshot.test.ts
+++ b/src/goal-workflows/__tests__/codex-goal-snapshot.test.ts
@@ -95,6 +95,41 @@ describe('codex goal snapshot reconciliation', () => {
     assert.equal(result.ok, true);
     assert.deepEqual(result.errors, []);
   });
+  it('preserves native blocked status instead of coercing it to unknown', () => {
+    const snapshot = parseCodexGoalSnapshot({
+      goal: { objective: 'Ship blocked path', status: 'blocked' },
+    });
+
+    assert.equal(snapshot.available, true);
+    assert.equal(snapshot.status, 'blocked');
+    assert.equal((snapshot.raw as { goal?: { status?: string } }).goal?.status, 'blocked');
+  });
+
+  it('reconciles blocked when allowed and fails closed without calling it unknown', () => {
+    const allowed = reconcileCodexGoalSnapshot(
+      parseCodexGoalSnapshot({ goal: { objective: 'Expected objective', status: 'blocked' } }),
+      { expectedObjective: 'Expected objective', requireSnapshot: true, allowedStatuses: ['blocked'] },
+    );
+    assert.equal(allowed.ok, true);
+    assert.equal(allowed.snapshot.status, 'blocked');
+
+    const excluded = reconcileCodexGoalSnapshot(
+      parseCodexGoalSnapshot({ goal: { objective: 'Expected objective', status: 'blocked' } }),
+      { expectedObjective: 'Expected objective', requireSnapshot: true, allowedStatuses: ['active', 'complete'] },
+    );
+    assert.equal(excluded.ok, false);
+    assert.match(excluded.errors.join('\n'), /got blocked/);
+    assert.doesNotMatch(excluded.errors.join('\n'), /got unknown/);
+    assert.equal((excluded.snapshot.raw as { goal?: { status?: string } }).goal?.status, 'blocked');
+  });
+
+  it('preserves normalized blocked status when a parsed snapshot is re-parsed', () => {
+    const first = parseCodexGoalSnapshot({ goal: { objective: 'Ship blocked path', status: 'blocked' } });
+    const second = parseCodexGoalSnapshot(first);
+    assert.equal(second.status, 'blocked');
+    assert.equal((second.raw as { status?: string }).status, 'blocked');
+    assert.equal((second.raw as { raw?: { goal?: { status?: string } } }).raw?.goal?.status, 'blocked');
+  });
 
   it('reads inline JSON and path input but rejects malformed sources', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-codex-goal-snapshot-'));

--- a/src/goal-workflows/codex-goal-snapshot.ts
+++ b/src/goal-workflows/codex-goal-snapshot.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
-export type CodexGoalSnapshotStatus = 'active' | 'complete' | 'cancelled' | 'failed' | 'unknown';
+export type CodexGoalSnapshotStatus = 'active' | 'complete' | 'cancelled' | 'failed' | 'blocked' | 'unknown';
 
 export interface CodexGoalSnapshot {
   available: boolean;
@@ -45,12 +45,13 @@ function safeNumber(value: unknown): number | undefined {
 }
 
 function normalizeStatus(value: unknown): CodexGoalSnapshotStatus {
-  const status = safeString(value).toLowerCase();
-  if (status === 'complete' || status === 'completed' || status === 'done') return 'complete';
-  if (status === 'cancelled' || status === 'canceled') return 'cancelled';
-  if (status === 'failed' || status === 'failure') return 'failed';
-  if (status === 'active' || status === 'in_progress' || status === 'pending' || status === 'running') return 'active';
-  return 'unknown';
+	const status = safeString(value).toLowerCase();
+	if (status === 'complete' || status === 'completed' || status === 'done') return 'complete';
+	if (status === 'cancelled' || status === 'canceled') return 'cancelled';
+	if (status === 'failed' || status === 'failure') return 'failed';
+	if (status === 'blocked') return 'blocked';
+	if (status === 'active' || status === 'in_progress' || status === 'pending' || status === 'running') return 'active';
+	return 'unknown';
 }
 
 function normalizeObjective(value: string): string {

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -2587,6 +2587,51 @@ describe('ultragoal artifacts', () => {
       );
     });
   });
+  it('records matching native blocked Codex goal checkpoints as non-terminal', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [
+          { title: 'First', objective: 'Complete first milestone.' },
+        ],
+      });
+
+      const first = await startNextUltragoal(cwd);
+      const objective = first.plan.codexObjective ?? first.goal!.objective;
+      const plan = await checkpointUltragoal(cwd, {
+        goalId: first.goal!.id,
+        status: 'blocked',
+        evidence: 'native matching blocked needs attention',
+        codexGoal: { goal: { objective, status: 'blocked' } },
+      });
+      const goal = plan.goals.find((item) => item.id === first.goal!.id);
+      assert.equal(goal?.status, 'in_progress');
+      assert.equal(plan.activeGoalId, first.goal!.id);
+
+      const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+      assert.match(ledger, /"event":"goal_blocked"/);
+      assert.match(ledger, /Native Codex goal status is blocked/);
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: first.goal!.id,
+          status: 'blocked',
+          codexGoal: { goal: { objective, status: 'blocked' } },
+        }),
+        /--evidence/,
+      );
+
+      await assert.rejects(
+        () => checkpointUltragoal(cwd, {
+          goalId: first.goal!.id,
+          status: 'blocked',
+          evidence: 'foreign blocked goal',
+          codexGoal: { goal: { objective: 'Different blocked work', status: 'blocked' } },
+        }),
+        /objective mismatch/,
+      );
+    });
+  });
 
   it('steers a split pending goal through superseded lifecycle without weakening completion gates', async () => {
     await withTempRepo(async (cwd) => {

--- a/src/ultragoal/__tests__/docs-contract.test.ts
+++ b/src/ultragoal/__tests__/docs-contract.test.ts
@@ -51,6 +51,7 @@ describe('ultragoal docs contract', () => {
     assert.match(doc, /same branch\/worktree/i);
     assert.match(doc, /Active or incomplete wrong Codex goals remain strict mismatch errors/i);
     assert.match(doc, /must not be used to bypass active-goal mismatch protection/i);
+    assert.match(doc, /matching native Codex `blocked`|matching native Codex blocked|truthfully `blocked`/i);
   });
 
   it('documents the mandatory final cleanup and review gate', () => {

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -1772,17 +1772,39 @@ export async function checkpointUltragoal(cwd: string, options: CheckpointOption
       return plan;
     }
     if (!snapshot?.available) {
-      throw new UltragoalError('Blocked ultragoal checkpoints require either a get_goal snapshot for the completed legacy Codex goal that blocked create_goal, or an unavailable get_goal error JSON for a Codex DB/schema/context failure; pass --codex-goal-json.');
-    }
-    if (snapshot.status !== 'complete') {
-      throw new UltragoalError(`Cannot record a blocked ultragoal checkpoint while the existing Codex goal is ${snapshot.status ?? 'unknown'}; strict objective mismatch protection remains required for active or incomplete goals.`);
+      throw new UltragoalError('Blocked ultragoal checkpoints require either a get_goal snapshot for the completed legacy Codex goal that blocked create_goal, an unavailable get_goal error JSON for a Codex DB/schema/context failure, or a matching native blocked snapshot; pass --codex-goal-json.');
     }
     if (!snapshot.objective) {
       throw new UltragoalError('Blocked ultragoal checkpoint Codex snapshot is missing objective text.');
     }
-    const safeCompletedAggregateBlocker = isSafeCompletedAggregateBlockerSnapshot(plan, goal, snapshot, options.evidence);
     const blockedSnapshotMatchesExpected = [expectedCodexObjective(plan, goal), ...compatibleCodexObjectives(plan)]
       .some((objective) => normalizeObjective(objective) === normalizeObjective(snapshot.objective ?? ''));
+    if (snapshot.status === 'blocked') {
+      if (!blockedSnapshotMatchesExpected) {
+        throw new UltragoalError(
+          `Blocked ultragoal checkpoint objective mismatch: expected one of [${[expectedCodexObjective(plan, goal), ...compatibleCodexObjectives(plan)].join(' | ')}], got ${snapshot.objective}. Matching native blocked checkpoints require the expected/compatible Codex objective; finish or clear the foreign goal, or pass a matching blocked get_goal snapshot with --evidence.`,
+        );
+      }
+      const evidence = assertNonEmpty(options.evidence, '--evidence');
+      goal.updatedAt = now;
+      plan.activeGoalId = goal.id;
+      plan.updatedAt = now;
+      await writePlan(cwd, plan);
+      await appendLedger(cwd, {
+        ts: now,
+        event: 'goal_blocked',
+        goalId: goal.id,
+        status: goal.status,
+        evidence,
+        codexGoal: options.codexGoal,
+        message: 'Native Codex goal status is blocked for the matching objective; recorded a non-terminal goal_blocked checkpoint. Continue work without treating this as complete or failed; re-check get_goal when the blocker clears.',
+      });
+      return plan;
+    }
+    if (snapshot.status !== 'complete') {
+      throw new UltragoalError(`Cannot record a blocked ultragoal checkpoint while the existing Codex goal is ${snapshot.status ?? 'unknown'}; strict objective mismatch protection remains required for active or incomplete goals.`);
+    }
+    const safeCompletedAggregateBlocker = isSafeCompletedAggregateBlockerSnapshot(plan, goal, snapshot, options.evidence);
     if (!safeCompletedAggregateBlocker && blockedSnapshotMatchesExpected) {
       throw new UltragoalError('Blocked ultragoal checkpoint is only for a different completed legacy Codex goal unless an aggregate Codex goal is already complete and unreconcilable while the active repo-native microgoal remains in progress.');
     }
@@ -2156,7 +2178,7 @@ function buildPerStoryCodexGoalInstruction(goal: UltragoalItem, plan: UltragoalP
     finalStory
       ? '- After the final checkpoint command succeeds, treat `/goal clear` as the explicit terminal cleanup step before another same-thread goal.'
       : null,
-    '- If blocked or failed, checkpoint with --status failed and the failure evidence; rerun complete-goals --retry-failed to resume.',
+    '- If blocked on a matching native Codex goal status, record a non-terminal blocker with: omx ultragoal checkpoint --goal-id ' + goal.id + ' --status blocked --evidence "<blocker evidence>" --codex-goal-json "<matching blocked get_goal JSON or path>". If failed, checkpoint with --status failed and the failure evidence; rerun complete-goals --retry-failed to resume.',
     '',
     'create_goal payload:',
     JSON.stringify(createPayload, null, 2),
@@ -2209,7 +2231,7 @@ function buildAggregateCodexGoalInstruction(goal: UltragoalItem, plan: Ultragoal
     finalStory
       ? `  omx ultragoal checkpoint --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>" --codex-goal-json "<fresh complete get_goal JSON or path>" --quality-gate-json "<quality gate JSON or path>"`
       : `  omx ultragoal checkpoint --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>" --codex-goal-json "<fresh get_goal JSON or path>"`,
-    '- If blocked or failed, checkpoint with --status failed and the failure evidence; rerun complete-goals --retry-failed to resume.',
+    '- If blocked on a matching native Codex goal status, record a non-terminal blocker with: omx ultragoal checkpoint --goal-id ' + goal.id + ' --status blocked --evidence "<blocker evidence>" --codex-goal-json "<matching blocked get_goal JSON or path>". If failed, checkpoint with --status failed and the failure evidence; rerun complete-goals --retry-failed to resume.',
     '',
     'create_goal payload:',
     JSON.stringify(createPayload, null, 2),


### PR DESCRIPTION
## Summary
- Treat native Codex goal status `blocked` as first-class in `parseCodexGoalSnapshot` / `normalizeStatus` (never coerce to `unknown`; keep raw).
- Accept matching-objective native `blocked` snapshots on `omx ultragoal checkpoint --status blocked` as non-terminal `goal_blocked` with required evidence; preserve legacy different-complete and DB-unavailable paths.
- Fail-closed reconcile diagnostics report `got blocked` (not `got unknown`) when blocked is not allowed.
- Update docs + root/plugin Ultragoal skill mirrors and instruction handoffs.
- Full regression matrix: parser/reconcile/checkpoint/CLI status JSON + negatives; focused suite green; #3295 aggregate terminal tests still green; no #3300 bundling.

## Test plan
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `npm run build`
- [x] `node --test dist/goal-workflows/__tests__/codex-goal-snapshot.test.js dist/ultragoal/__tests__/artifacts.test.js dist/cli/__tests__/ultragoal.test.js dist/ultragoal/__tests__/docs-contract.test.js` (124 pass)
- [x] `npm run sync:plugin:check`

Closes #3301