### PR TITLE
fix: preserve launch handling for short Codex flags

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -2392,6 +2392,13 @@ describe("resolveCliInvocation", () => {
     });
   });
 
+  it("keeps short Codex flags on the normal launch dispatch path", () => {
+    assert.deepEqual(resolveCliInvocation(["-p", "minimax", "--hotswap", "--direct"]), {
+      command: "launch",
+      launchArgs: ["-p", "minimax", "--hotswap", "--direct"],
+    });
+  });
+
   it("advertises the explicit update command in top-level help", () => {
     assert.match(HELP, /omx update\s+Install the stable channel now, then refresh setup/);
     assert.match(HELP, /omx update --stable\s+Install\/rollback to npm stable \(oh-my-codex@latest\), then refresh setup/);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -757,7 +757,7 @@ export function resolveCliInvocation(args: string[]): ResolvedCliInvocation {
   if (firstArg === "--version" || firstArg === "-v") {
     return { command: "version", launchArgs: [] };
   }
-  if (!firstArg || firstArg.startsWith("--")) {
+  if (!firstArg || firstArg.startsWith("-")) {
     return { command: "launch", launchArgs: firstArg ? args : [] };
   }
   if (firstArg === "launch") {


### PR DESCRIPTION
## Summary

Short Codex options at argv position 0 are currently classified differently from long options:

```ts
resolveCliInvocation(["-p", "minimax", "--hotswap", "--direct"])
// before: { command: "-p", launchArgs: [] }
// after:  { command: "launch", launchArgs: ["-p", "minimax", "--hotswap", "--direct"] }
```

This PR makes every leading option use the normal launch dispatch contract, while preserving the dedicated `-h` and `-v` handling that is checked first.

### Why this is necessary

The existing dispatcher fallback makes short-first invocations appear to work because an unknown leading option is eventually passed to `launchWithHud(args)`. That fallback is not equivalent to the normal `launch` branch, however:

- the normal branch inspects the complete launch argument vector with `launchArgsRequestAuthHotswap()`;
- when `--hotswap` is present, it selects `launchWithAuthHotswap()`;
- the unknown-command fallback always calls `launchWithHud()` directly.

As a result, a valid Codex short option such as `-p minimax` placed before OMX's `--hotswap` flag bypasses the requested auth-slot rotation/resume path. Long-first invocations do not have this problem because `startsWith("--")` already classifies them as `launch`.

The resolver should decide by option shape, not by whether the option uses one or two dashes. Routing all leading options through `launch` removes the semantic split and lets the existing launch branch remain the single place that selects HUD versus auth-hotswap behavior.

## Changes

- Treat any leading `-` option as launch passthrough after the explicit help/version checks.
- Add a focused regression test for a short Codex profile option followed by `--hotswap`.

The implementation is intentionally one conditional change plus one resolver test; no command parsing or launch behavior is otherwise modified.

## Validation

- [x] `npm run build`
- [x] Focused regression: `node --test --test-name-pattern='keeps short Codex flags on the normal launch dispatch path' dist/cli/__tests__/index.test.js`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `npx tsc --noEmit`
- [ ] `npm test`
- [ ] `omx doctor` (not applicable; setup/config behavior is unchanged)

`npm test` was attempted from this macOS boxed OMX session. It encounters pre-existing `upstream/dev` failures in unrelated auth/state/setup tests, including inherited `OMX_ROOT` session-pointer conflicts and macOS `/var/...` versus `/private/var/...` canonical-path assertions. Representative failures were reproduced from a clean detached `upstream/dev` worktree at `64dff19f`, without this patch. The changed resolver test and all static checks above pass; hosted CI remains the authoritative full-suite gate.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs considered: no refresh needed because this restores the existing documented launch-passthrough contract rather than adding a new flag or command
- [x] Backward-compatibility impact considered: `-h` and `-v` retain their explicit behavior; other short options now follow the same launch path as long options

## Related

No issue linked; found while reconciling short-first Codex profile launches.
