### PR TITLE
fix(state): resolve verified native session aliases

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -14094,8 +14094,10 @@ exit 0
 				["foreign session", { mode: "deep-interview", active: true, session_id: "foreign", workingDirectory: cwd }],
 				["dynamic session", { mode: "deep-interview", active: true, session_id: "$CODEX_THREAD_ID", workingDirectory: cwd }],
 				["conflicting owner alias", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", owner_codex_session_id: "foreign", workingDirectory: cwd }],
+				["persisted verified owner alias", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", owner_codex_session_id: "owner-codex-di-artifact", workingDirectory: cwd }],
 				["foreign cwd", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", workingDirectory: join(cwd, "src") }],
 				["nested foreign session", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", workingDirectory: cwd, state: { session_id: "foreign" } }],
+				["nested persisted verified session alias", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", workingDirectory: cwd, state: { session_id: "native-di-artifact" } }],
 				["nested foreign owner alias", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", workingDirectory: cwd, state: { owner_omx_session_id: "foreign" } }],
 				["nested foreign cwd", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", workingDirectory: cwd, state: { workingDirectory: join(cwd, "src") } }],
 				["nested conflicting mode", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", workingDirectory: cwd, state: { mode: "ralplan" } }],
@@ -14139,37 +14141,29 @@ exit 0
 				assert.equal(aliasStateWrite.outputJson, null, name);
 			}
 
-			const nestedNativeAliasStateWrite = await preToolUse({
+			const canonicalOwnershipStateWrite = await preToolUse({
 				hook_event_name: "PreToolUse",
 				cwd,
 				session_id: "sess-di-artifact",
 				tool_name: "mcp__omx_state__state_write",
-				tool_use_id: "tool-di-nested-native-alias-state-scope",
+				tool_use_id: "tool-di-canonical-ownership-state-scope",
 				tool_input: {
 					mode: "deep-interview",
 					active: true,
 					session_id: "sess-di-artifact",
+					owner_omx_session_id: "sess-di-artifact",
+					owner_codex_session_id: "sess-di-artifact",
+					codex_session_id: "sess-di-artifact",
 					workingDirectory: cwd,
-					state: { session_id: "native-di-artifact" },
+					state: {
+						session_id: "sess-di-artifact",
+						owner_omx_session_id: "sess-di-artifact",
+						owner_codex_session_id: "sess-di-artifact",
+						codex_session_id: "sess-di-artifact",
+					},
 				},
 			});
-			assert.equal(nestedNativeAliasStateWrite.outputJson, null);
-
-			const mixedVerifiedAliasesStateWrite = await preToolUse({
-				hook_event_name: "PreToolUse",
-				cwd,
-				session_id: "sess-di-artifact",
-				tool_name: "mcp__omx_state__state_write",
-				tool_use_id: "tool-di-mixed-verified-alias-state-scope",
-				tool_input: {
-					mode: "deep-interview",
-					active: true,
-					session_id: "sess-di-artifact",
-					owner_codex_session_id: "owner-codex-di-artifact",
-					workingDirectory: cwd,
-				},
-			});
-			assert.equal(mixedVerifiedAliasesStateWrite.outputJson, null);
+			assert.equal(canonicalOwnershipStateWrite.outputJson, null);
 
 			const blockedReadWriteRedirect = await preToolUse({
 				hook_event_name: "PreToolUse",

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -13717,9 +13717,9 @@ exit 0
 		}
 	});
 	it("allows canonical leader deep-interview artifact and state writes while blocking implementation Bash writes", async () => {
-		const cwd = await mkdtemp(
+		const cwd = realpathSync(await mkdtemp(
 			join(tmpdir(), "omx-native-hook-pretool-deep-interview-artifact-"),
-		);
+		));
 		try {
 			const stateDir = join(cwd, ".omx", "state");
 			const sessionDir = join(stateDir, "sessions", "sess-di-artifact");
@@ -13729,6 +13729,9 @@ exit 0
 				cwd,
 				leader_thread_id: "thread-di-artifact",
 				native_session_id: "native-di-artifact",
+				owner_omx_session_id: "owner-omx-di-artifact",
+				owner_codex_session_id: "owner-codex-di-artifact",
+				codex_session_id: "codex-di-artifact",
 			});
 			const threadId = "thread-di-artifact";
 			await writeJson(join(stateDir, "subagent-tracking.json"), {
@@ -14089,12 +14092,14 @@ exit 0
 				["missing session", { mode: "deep-interview", active: true, workingDirectory: cwd }],
 				["missing cwd", { mode: "deep-interview", active: true, session_id: "sess-di-artifact" }],
 				["foreign session", { mode: "deep-interview", active: true, session_id: "foreign", workingDirectory: cwd }],
+				["dynamic session", { mode: "deep-interview", active: true, session_id: "$CODEX_THREAD_ID", workingDirectory: cwd }],
+				["conflicting owner alias", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", owner_codex_session_id: "foreign", workingDirectory: cwd }],
 				["foreign cwd", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", workingDirectory: join(cwd, "src") }],
-				["nested foreign session", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", workingDirectory: cwd, state: { session_id: "native-di-artifact" } }],
+				["nested foreign session", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", workingDirectory: cwd, state: { session_id: "foreign" } }],
 				["nested foreign owner alias", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", workingDirectory: cwd, state: { owner_omx_session_id: "foreign" } }],
 				["nested foreign cwd", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", workingDirectory: cwd, state: { workingDirectory: join(cwd, "src") } }],
 				["nested conflicting mode", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", workingDirectory: cwd, state: { mode: "ralplan" } }],
-				["depth-two foreign session", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", workingDirectory: cwd, state: { state: { session_id: "native-di-artifact" } } }],
+				["depth-two foreign session", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", workingDirectory: cwd, state: { state: { session_id: "foreign" } } }],
 				["depth-two foreign cwd", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", workingDirectory: cwd, state: { state: { workingDirectory: join(cwd, "src") } } }],
 				["depth-two conflicting mode", { mode: "deep-interview", active: true, session_id: "sess-di-artifact", workingDirectory: cwd, state: { state: { mode: "ralplan" } } }],
 			] as const) {
@@ -14110,23 +14115,61 @@ exit 0
 				assert.match(String(invalidPlanningStateWrite.outputJson?.reason ?? ""), /canonical session and workingDirectory scope/);
 			}
 
-			const nativeAliasStateWrite = await dispatchCodexNativeHook({
+			for (const [name, alias] of [
+				["native", "native-di-artifact"],
+				["owner OMX", "owner-omx-di-artifact"],
+				["owner Codex", "owner-codex-di-artifact"],
+				["Codex", "codex-di-artifact"],
+			] as const) {
+				const aliasStateWrite = await dispatchCodexNativeHook({
+					hook_event_name: "PreToolUse",
+					cwd,
+					session_id: alias,
+					thread_id: threadId,
+					agent_id: threadId,
+					tool_name: "mcp__omx_state__state_write",
+					tool_use_id: `tool-di-${name}-alias-state-scope`,
+					tool_input: {
+						mode: "deep-interview",
+						active: true,
+						session_id: alias,
+						workingDirectory: cwd,
+					},
+				}, { cwd });
+				assert.equal(aliasStateWrite.outputJson, null, name);
+			}
+
+			const nestedNativeAliasStateWrite = await preToolUse({
 				hook_event_name: "PreToolUse",
 				cwd,
-				session_id: "native-di-artifact",
-				thread_id: threadId,
-				agent_id: threadId,
+				session_id: "sess-di-artifact",
 				tool_name: "mcp__omx_state__state_write",
-				tool_use_id: "tool-di-native-alias-state-scope",
+				tool_use_id: "tool-di-nested-native-alias-state-scope",
 				tool_input: {
 					mode: "deep-interview",
 					active: true,
-					session_id: "native-di-artifact",
+					session_id: "sess-di-artifact",
+					workingDirectory: cwd,
+					state: { session_id: "native-di-artifact" },
+				},
+			});
+			assert.equal(nestedNativeAliasStateWrite.outputJson, null);
+
+			const mixedVerifiedAliasesStateWrite = await preToolUse({
+				hook_event_name: "PreToolUse",
+				cwd,
+				session_id: "sess-di-artifact",
+				tool_name: "mcp__omx_state__state_write",
+				tool_use_id: "tool-di-mixed-verified-alias-state-scope",
+				tool_input: {
+					mode: "deep-interview",
+					active: true,
+					session_id: "sess-di-artifact",
+					owner_codex_session_id: "owner-codex-di-artifact",
 					workingDirectory: cwd,
 				},
-			}, { cwd });
-			assert.equal(nativeAliasStateWrite.outputJson?.decision, "block");
-			assert.match(String(nativeAliasStateWrite.outputJson?.reason ?? ""), /canonical session and workingDirectory scope/);
+			});
+			assert.equal(mixedVerifiedAliasesStateWrite.outputJson, null);
 
 			const blockedReadWriteRedirect = await preToolUse({
 				hook_event_name: "PreToolUse",

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -9023,19 +9023,6 @@ function suppliedSessionAliasesMatch(payload: Record<string, unknown>, sessionId
     .every((value) => safeString(value).trim() === sessionId);
 }
 
-function suppliedSessionAliasesAreVerified(
-  payload: Record<string, unknown>,
-  verifiedAliases: ReadonlySet<string>,
-): boolean {
-  return [
-    payload.session_id,
-    payload.owner_omx_session_id,
-    payload.codex_session_id,
-    payload.owner_codex_session_id,
-  ].filter((value) => value !== undefined)
-    .every((value) => verifiedAliases.has(safeString(value).trim()));
-}
-
 function hasOnlyFinishedExplicitOutcomes(payload: Record<string, unknown>): boolean {
   const values = [
     payload.lifecycle_outcome,
@@ -18906,13 +18893,18 @@ async function directConductorStateWritePayloadHasExactSchema(
   if (safeString(currentSession?.session_id).trim() === canonicalSessionId) {
     for (const alias of sessionPointerAliases(currentSession)) verifiedAliases.add(alias);
   }
+  // The top-level session_id selects the writable scope and is stripped by
+  // executeStateOperation. Other ownership fields can be persisted.
   if (!verifiedAliases.has(safeString(input.session_id).trim())) return false;
-  if (!suppliedSessionAliasesAreVerified(input, verifiedAliases)) return false;
+  if (![
+    input.owner_omx_session_id,
+    input.codex_session_id,
+    input.owner_codex_session_id,
+  ].filter((value) => value !== undefined)
+    .every((value) => safeString(value).trim() === canonicalSessionId)) return false;
   let nestedState = input.state === undefined ? null : safeObject(input.state);
   while (nestedState) {
-    if (!suppliedSessionAliasesAreVerified(nestedState, verifiedAliases)) return false;
-    const nestedSessionId = safeString(nestedState.session_id).trim();
-    if (nestedSessionId && !verifiedAliases.has(nestedSessionId)) return false;
+    if (!suppliedSessionAliasesMatch(nestedState, canonicalSessionId)) return false;
     const nestedWorkingDirectory = safeString(nestedState.workingDirectory).trim();
     if (nestedWorkingDirectory && resolve(nestedWorkingDirectory) !== resolve(policyCwd)) return false;
     const nestedMode = safeString(nestedState.mode).trim();

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3609,6 +3609,16 @@ interface PreToolUseSessionBinding {
   missing: boolean;
 }
 
+function sessionPointerAliases(state: SessionState | null | undefined): Set<string> {
+  return new Set(uniqueNonEmpty([
+    safeString(state?.session_id).trim(),
+    safeString(state?.native_session_id).trim(),
+    safeString(state?.owner_omx_session_id).trim(),
+    safeString(state?.owner_codex_session_id).trim(),
+    safeString(state?.codex_session_id).trim(),
+  ]));
+}
+
 async function resolvePreToolUseSessionBinding(
   cwd: string,
   stateDir: string,
@@ -3620,10 +3630,7 @@ async function resolvePreToolUseSessionBinding(
     : await readUsableSessionStateFromStateDir(cwd, stateDir).catch(() => null);
   const canonicalSessionId = safeString(currentSession?.session_id).trim();
   const aliases = payloadAliasValues(payload, ["session_id", "sessionId"]);
-  const knownAliases = new Set([
-    canonicalSessionId,
-    safeString(currentSession?.native_session_id).trim(),
-  ].filter(Boolean));
+  const knownAliases = sessionPointerAliases(currentSession);
   return {
     canonicalSessionId,
     missing: aliases.length === 0,
@@ -4094,12 +4101,8 @@ async function resolveInternalSessionIdForPayload(
   const canonicalSessionId = safeString(currentSession?.session_id).trim();
   if (!canonicalSessionId) return allowUnboundPayloadFallback ? payloadSessionId : "";
 
-  const nativeSessionId = safeString(currentSession?.native_session_id).trim();
-  const ownerOmxSessionId = safeString(currentSession?.owner_omx_session_id).trim();
   if (!payloadSessionId) return canonicalSessionId;
-  if (payloadSessionId === canonicalSessionId) return canonicalSessionId;
-  if (nativeSessionId && payloadSessionId === nativeSessionId) return canonicalSessionId;
-  if (ownerOmxSessionId && payloadSessionId === ownerOmxSessionId) return canonicalSessionId;
+  if (sessionPointerAliases(currentSession).has(payloadSessionId)) return canonicalSessionId;
   return allowUnboundPayloadFallback ? payloadSessionId : "";
 }
 
@@ -4116,13 +4119,8 @@ async function readRootSessionStateFromStateDir(stateDir: string): Promise<Sessi
 }
 
 function payloadMatchesSessionPointer(payloadSessionId: string, state: SessionState): boolean {
-  const canonicalSessionId = safeString(state.session_id).trim();
-  const nativeSessionId = safeString(state.native_session_id).trim();
-  const ownerOmxSessionId = safeString(state.owner_omx_session_id).trim();
   if (!payloadSessionId) return true;
-  return payloadSessionId === canonicalSessionId
-    || (nativeSessionId !== "" && payloadSessionId === nativeSessionId)
-    || (ownerOmxSessionId !== "" && payloadSessionId === ownerOmxSessionId);
+  return sessionPointerAliases(state).has(payloadSessionId);
 }
 
 function isRootSessionPointerLive(state: SessionState): boolean {
@@ -9025,6 +9023,19 @@ function suppliedSessionAliasesMatch(payload: Record<string, unknown>, sessionId
     .every((value) => safeString(value).trim() === sessionId);
 }
 
+function suppliedSessionAliasesAreVerified(
+  payload: Record<string, unknown>,
+  verifiedAliases: ReadonlySet<string>,
+): boolean {
+  return [
+    payload.session_id,
+    payload.owner_omx_session_id,
+    payload.codex_session_id,
+    payload.owner_codex_session_id,
+  ].filter((value) => value !== undefined)
+    .every((value) => verifiedAliases.has(safeString(value).trim()));
+}
+
 function hasOnlyFinishedExplicitOutcomes(payload: Record<string, unknown>): boolean {
   const values = [
     payload.lifecycle_outcome,
@@ -9796,7 +9807,7 @@ async function buildRalplanPreToolUseBoundaryOutput(
   if (!activeState) return null;
 
   const toolName = safeString(payload.tool_name).trim();
-  if (toolName === "mcp__omx_state__state_write" && !directConductorStateWritePayloadHasExactSchema(payload, cwd, sessionId)) {
+  if (toolName === "mcp__omx_state__state_write" && !await directConductorStateWritePayloadHasExactSchema(payload, cwd, stateDir, sessionId)) {
     return buildPlanningStateScopeDeny(
       safeString(activeState.mode).trim().toLowerCase() === "autopilot" ? "Autopilot planning" : "Ralplan",
       formatPhase(activeState.current_phase ?? activeState.currentPhase, "planning"),
@@ -9920,7 +9931,7 @@ async function buildDeepInterviewPreToolUseBoundaryOutput(
   if (!activeState) return null;
 
   const toolName = safeString(payload.tool_name).trim();
-  if (toolName === "mcp__omx_state__state_write" && !directConductorStateWritePayloadHasExactSchema(payload, cwd, sessionId)) {
+  if (toolName === "mcp__omx_state__state_write" && !await directConductorStateWritePayloadHasExactSchema(payload, cwd, stateDir, sessionId)) {
     return buildPlanningStateScopeDeny(
       "Deep-interview",
       formatPhase(activeState.current_phase ?? activeState.currentPhase, "planning"),
@@ -18881,17 +18892,27 @@ function buildConductorBashBlockedDetail(cwd: string, command: string): string {
     ?? "Bash write intent target <unresolved>; Main-root Conductor may write only workflow state/ledger/mailbox/handoff metadata";
 }
 
-function directConductorStateWritePayloadHasExactSchema(payload: CodexHookPayload, policyCwd: string, canonicalSessionId: string): boolean {
+async function directConductorStateWritePayloadHasExactSchema(
+  payload: CodexHookPayload,
+  policyCwd: string,
+  stateDir: string,
+  canonicalSessionId: string,
+): Promise<boolean> {
   const input = safeObject(payload.tool_input);
   if (!input || !conductorStateWritePayloadHasExactSchema(input)) return false;
   if (!canonicalSessionId) return false;
-  if (safeString(input.session_id).trim() !== canonicalSessionId) return false;
-  if (!suppliedSessionAliasesMatch(input, canonicalSessionId)) return false;
+  const verifiedAliases = new Set([canonicalSessionId]);
+  const currentSession = await readUsableSessionStateFromStateDir(policyCwd, stateDir).catch(() => null);
+  if (safeString(currentSession?.session_id).trim() === canonicalSessionId) {
+    for (const alias of sessionPointerAliases(currentSession)) verifiedAliases.add(alias);
+  }
+  if (!verifiedAliases.has(safeString(input.session_id).trim())) return false;
+  if (!suppliedSessionAliasesAreVerified(input, verifiedAliases)) return false;
   let nestedState = input.state === undefined ? null : safeObject(input.state);
   while (nestedState) {
-    if (!suppliedSessionAliasesMatch(nestedState, canonicalSessionId)) return false;
+    if (!suppliedSessionAliasesAreVerified(nestedState, verifiedAliases)) return false;
     const nestedSessionId = safeString(nestedState.session_id).trim();
-    if (nestedSessionId && nestedSessionId !== canonicalSessionId) return false;
+    if (nestedSessionId && !verifiedAliases.has(nestedSessionId)) return false;
     const nestedWorkingDirectory = safeString(nestedState.workingDirectory).trim();
     if (nestedWorkingDirectory && resolve(nestedWorkingDirectory) !== resolve(policyCwd)) return false;
     const nestedMode = safeString(nestedState.mode).trim();
@@ -18997,7 +19018,7 @@ export async function buildConductorPreToolUseWriteGuardOutput(
     } else if (
       toolName === "mcp__omx_state__state_write"
       && (
-        !directConductorStateWritePayloadHasExactSchema(payload, policyCwd, sessionId)
+        !await directConductorStateWritePayloadHasExactSchema(payload, policyCwd, stateDir, sessionId)
         || !conductorStatePayloadPreservesActiveGuard(directStateInput, activeState)
       )
     ) {


### PR DESCRIPTION
Fixes #3307.

## Summary

Bind structured native-hook state writes to the canonical OMX session when the supplied selector identity is a verified alias recorded on the same usable, cwd-bound selected pointer.

This preserves the existing Conductor boundary: the change does not grant authority from same-session provenance or a typed role. It only permits a verified alias to select the canonical state scope; ownership identities that can be persisted must remain canonical.

## Root cause

The hook already canonicalized the event `session_id`, but `directConductorStateWritePayloadHasExactSchema` originally required literal canonical equality for `tool_input.session_id`. The first fix admitted every verified alias in both selector and ownership fields. However, `executeStateOperation` strips only the top-level selector and persists the remaining fields, so a verified non-canonical ownership alias could replace canonical metadata and later fail canonical guard comparisons.

## Before / after

Before:

- canonical `omx-...` selector: allowed
- verified native/Codex selector alias from the selected pointer: blocked
- after the initial alias fix, verified aliases could also be persisted as ownership metadata

After:

- canonical selector: allowed
- native, owner OMX, owner Codex, and Codex aliases recorded on the usable selected pointer: allowed only as the top-level scope selector
- persisted `session_id`, `owner_omx_session_id`, `owner_codex_session_id`, and `codex_session_id`: canonical or omitted
- missing, dynamic, foreign, conflicting, wrong-cwd, and nested non-canonical identities: blocked

## Security invariants

- same session is not write authority
- typed role is not write authority
- payload-only aliases are never trusted
- a verified pointer alias may select the canonical writable scope
- persisted ownership metadata must remain canonical
- cwd and mode checks remain unchanged

## Regression coverage

The native-hook regression covers:

- canonical structured state writes
- each verified selected-pointer alias as the top-level selector
- canonical ownership identities at top level and in nested state
- verified aliases rejected when supplied in persisted ownership fields
- missing session/cwd
- literal `$CODEX_THREAD_ID`
- foreign and conflicting aliases
- nested/depth-two foreign or non-canonical aliases
- foreign cwd and nested foreign cwd
- conflicting nested mode

The test temp cwd is canonicalized with `realpathSync` so macOS `/var` to `/private/var` filesystem aliases do not mask the session-identity assertion.

## Validation

- `npm run lint` — passed, 787 files
- `npm run check:no-unused` — passed
- `npm run build` — passed
- targeted native-hook P1 regression — passed, 1 test
- state-path tests — passed, 60/60
- `git diff --check` — passed
- full native-hook file on this macOS host — 594/616 passed, 22 existing baseline failures
- clean `upstream/dev` comparison — the same existing failure families remain and the B1 target regression additionally fails; this change removes that failure without adding a new failure family

## Scope

This is the B1 structured state-write fix only. It intentionally excludes shell/env command parsing and native-child scoped write delegation.

The defect was found during FinderLike work, but it is a general OMX runtime identity-normalization issue and does not depend on FinderLike application code.