### PR TITLE
fix(hooks): stop misclassifying omx/gjc read-only discovery as writes (#3313, #3314)

### DIFF
--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -473,6 +473,17 @@ describe('parseSparkShellFallbackInvocation', () => {
     );
   });
 
+  it('rejects extra argv after explicit --shell fallback', () => {
+    assert.throws(
+      () => parseSparkShellFallbackInvocation(['--shell', 'printf ok', '--help'], { platform: 'linux' }),
+      /--shell does not accept additional arguments/,
+    );
+    assert.throws(
+      () => parseSparkShellFallbackInvocation(['--shell=printf ok', 'extra'], { platform: 'linux' }),
+      /--shell does not accept additional arguments/,
+    );
+  });
+
   it('translates explicit shell fallback through pwsh on Windows when available', () => {
     assert.deepEqual(
       parseSparkShellFallbackInvocation(['--shell', 'Write-Output ok'], {

--- a/src/cli/sparkshell.ts
+++ b/src/cli/sparkshell.ts
@@ -306,11 +306,13 @@ export function parseSparkShellFallbackInvocation(
   if (args[0] === '--shell') {
     const script = args[1];
     if (!script) throw new Error(`--shell requires a command string.\n${SPARKSHELL_USAGE}`);
+    if (args.length !== 2) throw new Error(`--shell does not accept additional arguments.\n${SPARKSHELL_USAGE}`);
     return { kind: 'command', argv: resolveFallbackShellArgv(script, options) };
   }
   if (args[0]?.startsWith('--shell=')) {
     const script = args[0].slice('--shell='.length);
     if (!script.trim()) throw new Error(`--shell requires a command string.\n${SPARKSHELL_USAGE}`);
+    if (args.length !== 1) throw new Error(`--shell does not accept additional arguments.\n${SPARKSHELL_USAGE}`);
     return { kind: 'command', argv: resolveFallbackShellArgv(script, options) };
   }
 

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -13738,6 +13738,19 @@ exit 0
 			await symlink(workspacePackageCli, join(trustedBinDir, "omx"));
 			const inheritedPath = process.env.PATH;
 			process.env.PATH = `${trustedBinDir}:${dirname(process.execPath)}:/usr/bin:/bin`;
+			const sparkshellImplementationEnvironmentNames = [
+				"OMX_SPARKSHELL_BIN",
+				"OMX_NATIVE_CACHE_DIR",
+				"OMX_NATIVE_MANIFEST_URL",
+				"OMX_NATIVE_RELEASE_BASE_URL",
+				"OMX_NATIVE_AUTO_FETCH",
+				"XDG_CACHE_HOME",
+				"LOCALAPPDATA",
+			] as const;
+			const inheritedSparkshellImplementationEnvironment = Object.fromEntries(
+				sparkshellImplementationEnvironmentNames.map((name) => [name, process.env[name]]),
+			);
+			for (const name of sparkshellImplementationEnvironmentNames) delete process.env[name];
 
 			const preToolUse = (command: string) => dispatchCodexNativeHook({
 				hook_event_name: "PreToolUse",
@@ -13794,10 +13807,14 @@ exit 0
 				await assertAllowed("omx ralplan --help", "omx ralplan --help");
 				await assertAllowed("omx state read (bare)", "omx state read --json");
 				await assertAllowed("omx state read --mode deep-interview --json", "omx state read --mode deep-interview --json");
-				await assertAllowed("omx state status --mode=deep-interview --json", "omx state status --mode=deep-interview --json");
+				await assertAllowed("omx state get-status --mode=deep-interview --json", "omx state get-status --mode=deep-interview --json");
+				await assertAllowed("omx state read nested help", "omx state read --help");
+				await assertAllowed("omx auth nested help", "omx auth --help");
+				await assertBlocked("invalid state status spelling stays blocked", "omx state status --mode=deep-interview --json");
 
 				// #3314: sparkshell-wrapped read-only discovery must not be misclassified as a write.
 				await assertAllowed("sparkshell wrapped git status", "omx sparkshell -- git status --short --branch");
+				await assertAllowed("sparkshell nested help", "omx sparkshell --help");
 				await assertAllowed("sparkshell wrapped find", "omx sparkshell -- find . -maxdepth 1 -type f");
 				await assertAllowed("sparkshell json-flagged wrapped git status", "omx sparkshell --json -- git status --short --branch");
 
@@ -13935,16 +13952,20 @@ exit 0
 
 				// Guards that must NOT relax: unsafe sparkshell modes, mutation-shaped
 				// wrapped argv, raw redirects into own session state, active-state
-				// overrides, and PATH-prefix smuggling on `omx cancel`. `--help`/`-h`
-				// is safe anywhere (every subcommand consulted short-circuits before
-				// real work), but `--version`/`-v` is NOT universally safe (e.g.
-				// `omx cleanup --version` still performs real cleanup because that
-				// subcommand only special-cases `--help`/`-h`), so it must only be
-				// trusted as a bare top-level probe. A `--help` meant for a
+				// overrides, and PATH-prefix smuggling on `omx cancel`. Nested help is
+				// allowed only in parser positions that short-circuit before side effects;
+				// trailing help on mutators must remain blocked. A `--help` meant for a
 				// sparkshell-wrapped script must not short-circuit scrutiny of that
-				// wrapped script, and an inherited OMX_SPARKSHELL_BIN override must
-				// deny the sparkshell allowance entirely.
+				// wrapped script, and every inherited or leading sidecar/cache identity
+				// override must deny the sparkshell allowance entirely.
 				await assertBlocked("sparkshell --shell mode stays scrutinized", "omx sparkshell --shell 'git status --short --branch'");
+				await assertBlocked("sparkshell tmux-pane mode stays scrutinized", "omx sparkshell --tmux-pane %42");
+				await assertBlocked("sparkshell trailing help does not short-circuit shell mode", "omx sparkshell --shell 'git status --short --branch' --help");
+				await assertBlocked("auth trailing help does not short-circuit slot mutation", "omx auth use slot --help");
+				await assertBlocked(
+					"workflow mutator trailing help does not short-circuit execution",
+					"omx performance-goal create --objective x --evaluator-command true --evaluator-contract x --help",
+				);
 				await assertBlocked("sparkshell wrapped write stays blocked", `omx sparkshell -- bash -c 'echo x > src/generated.ts'`);
 				await assertBlocked("omx cleanup --version stays blocked (not a bare top-level probe)", "omx cleanup --version");
 				await assertBlocked("omx cleanup -v stays blocked (not a bare top-level probe)", "omx cleanup -v");
@@ -13952,18 +13973,25 @@ exit 0
 					"sparkshell-wrapped --help meant for the wrapped script stays scrutinized",
 					"omx sparkshell -- ./mutate.sh --help",
 				);
-				{
-					const previousSparkshellBin = process.env.OMX_SPARKSHELL_BIN;
-					process.env.OMX_SPARKSHELL_BIN = "/tmp/attacker-sidecar";
+				for (const [name, value] of [
+					["OMX_SPARKSHELL_BIN", "/tmp/attacker-sidecar"],
+					["OMX_NATIVE_CACHE_DIR", "/tmp/attacker-native-cache"],
+					["OMX_NATIVE_MANIFEST_URL", "https://attacker.invalid/manifest.json"],
+					["OMX_NATIVE_RELEASE_BASE_URL", "https://attacker.invalid/releases"],
+					["OMX_NATIVE_AUTO_FETCH", "0"],
+					["XDG_CACHE_HOME", "/tmp/attacker-xdg-cache"],
+					["LOCALAPPDATA", "/tmp/attacker-localappdata"],
+				] as const) {
+					const previous = process.env[name];
+					process.env[name] = value;
 					try {
-						await assertBlocked(
-							"inherited OMX_SPARKSHELL_BIN override denies the sparkshell allowance",
-							"omx sparkshell -- git status --short --branch",
-						);
+						await assertBlocked(`inherited ${name} override denies the sparkshell allowance`, "omx sparkshell -- git status --short --branch");
 					} finally {
-						if (previousSparkshellBin === undefined) delete process.env.OMX_SPARKSHELL_BIN;
-						else process.env.OMX_SPARKSHELL_BIN = previousSparkshellBin;
+						if (previous === undefined) delete process.env[name];
+						else process.env[name] = previous;
 					}
+					await assertBlocked(`leading ${name} override denies the sparkshell allowance`, `${name}=${JSON.stringify(value)} omx sparkshell -- git status --short --branch`);
+					await assertBlocked(`env-wrapper ${name} override denies the sparkshell allowance`, `env ${name}=${JSON.stringify(value)} omx sparkshell -- git status --short --branch`);
 				}
 				await assertBlocked(
 					"raw redirect into own session state",
@@ -13977,6 +14005,11 @@ exit 0
 				await assertBlocked("PATH-prefix smuggled omx cancel stays blocked", `PATH="${trustedBinDir}" omx cancel`, /PATH|write intent/);
 			} finally {
 				if (inheritedPath === undefined) delete process.env.PATH; else process.env.PATH = inheritedPath;
+				for (const name of sparkshellImplementationEnvironmentNames) {
+					const previous = (inheritedSparkshellImplementationEnvironment as Record<string, string | undefined>)[name];
+					if (previous === undefined) delete process.env[name];
+					else process.env[name] = previous;
+				}
 				await rm(trustedBinDir, { recursive: true, force: true });
 			}
 		} finally {
@@ -14024,6 +14057,19 @@ exit 0
 			await symlink(workspacePackageCli, join(trustedBinDir, "omx"));
 			const inheritedPath = process.env.PATH;
 			process.env.PATH = `${trustedBinDir}:${dirname(process.execPath)}:/usr/bin:/bin`;
+			const sparkshellImplementationEnvironmentNames = [
+				"OMX_SPARKSHELL_BIN",
+				"OMX_NATIVE_CACHE_DIR",
+				"OMX_NATIVE_MANIFEST_URL",
+				"OMX_NATIVE_RELEASE_BASE_URL",
+				"OMX_NATIVE_AUTO_FETCH",
+				"XDG_CACHE_HOME",
+				"LOCALAPPDATA",
+			] as const;
+			const inheritedSparkshellImplementationEnvironment = Object.fromEntries(
+				sparkshellImplementationEnvironmentNames.map((name) => [name, process.env[name]]),
+			);
+			for (const name of sparkshellImplementationEnvironmentNames) delete process.env[name];
 
 			const preToolUse = (command: string) => dispatchCodexNativeHook({
 				hook_event_name: "PreToolUse",
@@ -14050,6 +14096,8 @@ exit 0
 				await assertAllowed("omx --help", "omx --help");
 				await assertAllowed("omx ralplan --help", "omx ralplan --help");
 				await assertAllowed("omx state read --mode ralplan --json", "omx state read --mode ralplan --json");
+				await assertAllowed("omx state get-status --mode ralplan --json", "omx state get-status --mode ralplan --json");
+				await assertBlocked("invalid state status spelling stays blocked", "omx state status --mode ralplan --json");
 				await assertAllowed("sparkshell wrapped git status", "omx sparkshell -- git status --short --branch");
 
 				{
@@ -14081,24 +14129,37 @@ exit 0
 				}
 
 				await assertBlocked("sparkshell --shell mode stays scrutinized", "omx sparkshell --shell 'git status --short --branch'");
+				await assertBlocked("sparkshell tmux-pane mode stays scrutinized", "omx sparkshell --tmux-pane %42");
+				await assertBlocked("sparkshell trailing help does not short-circuit shell mode", "omx sparkshell --shell 'git status --short --branch' --help");
+				await assertBlocked("auth trailing help does not short-circuit slot mutation", "omx auth use slot --help");
+				await assertBlocked(
+					"workflow mutator trailing help does not short-circuit execution",
+					"omx performance-goal create --objective x --evaluator-command true --evaluator-contract x --help",
+				);
 				await assertBlocked("sparkshell wrapped write stays blocked", `omx sparkshell -- bash -c 'echo x > src/generated.ts'`);
 				await assertBlocked("omx cleanup --version stays blocked (not a bare top-level probe)", "omx cleanup --version");
 				await assertBlocked(
 					"sparkshell-wrapped --help meant for the wrapped script stays scrutinized",
 					"omx sparkshell -- ./mutate.sh --help",
 				);
-				{
-					const previousSparkshellBin = process.env.OMX_SPARKSHELL_BIN;
-					process.env.OMX_SPARKSHELL_BIN = "/tmp/attacker-sidecar";
+				for (const [name, value] of [
+					["OMX_SPARKSHELL_BIN", "/tmp/attacker-sidecar"],
+					["OMX_NATIVE_CACHE_DIR", "/tmp/attacker-native-cache"],
+					["OMX_NATIVE_MANIFEST_URL", "https://attacker.invalid/manifest.json"],
+					["OMX_NATIVE_RELEASE_BASE_URL", "https://attacker.invalid/releases"],
+					["OMX_NATIVE_AUTO_FETCH", "0"],
+					["XDG_CACHE_HOME", "/tmp/attacker-xdg-cache"],
+					["LOCALAPPDATA", "/tmp/attacker-localappdata"],
+				] as const) {
+					const previous = process.env[name];
+					process.env[name] = value;
 					try {
-						await assertBlocked(
-							"inherited OMX_SPARKSHELL_BIN override denies the sparkshell allowance",
-							"omx sparkshell -- git status --short --branch",
-						);
+						await assertBlocked(`inherited ${name} override denies the sparkshell allowance`, "omx sparkshell -- git status --short --branch");
 					} finally {
-						if (previousSparkshellBin === undefined) delete process.env.OMX_SPARKSHELL_BIN;
-						else process.env.OMX_SPARKSHELL_BIN = previousSparkshellBin;
+						if (previous === undefined) delete process.env[name];
+						else process.env[name] = previous;
 					}
+					await assertBlocked(`leading ${name} override denies the sparkshell allowance`, `${name}=${JSON.stringify(value)} omx sparkshell -- git status --short --branch`);
 				}
 				await assertBlocked(
 					"raw redirect into own session state",
@@ -14106,6 +14167,11 @@ exit 0
 				);
 			} finally {
 				if (inheritedPath === undefined) delete process.env.PATH; else process.env.PATH = inheritedPath;
+				for (const name of sparkshellImplementationEnvironmentNames) {
+					const previous = (inheritedSparkshellImplementationEnvironment as Record<string, string | undefined>)[name];
+					if (previous === undefined) delete process.env[name];
+					else process.env[name] = previous;
+				}
 				await rm(trustedBinDir, { recursive: true, force: true });
 			}
 		} finally {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -13666,6 +13666,209 @@ exit 0
 			await rm(cwd, { recursive: true, force: true });
 		}
 	});
+	it("issue #3313/#3314 permits standalone deep-interview lifecycle reachability and read-only discovery without relaxing write guards", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-issue-3313-3314-di-"));
+		try {
+			const stateDir = join(cwd, ".omx", "state");
+			const sessionId = "sess-issue-3313-3314-di";
+			const threadId = "thread-issue-3313-3314-di";
+			const sessionDir = join(stateDir, "sessions", sessionId);
+			await mkdir(sessionDir, { recursive: true });
+			await writeJson(join(stateDir, "session.json"), { session_id: sessionId, cwd, leader_thread_id: threadId });
+			await writeJson(join(stateDir, "subagent-tracking.json"), {
+				schemaVersion: 1,
+				sessions: {
+					[sessionId]: {
+						session_id: sessionId,
+						leader_thread_id: threadId,
+						threads: { [threadId]: { thread_id: threadId, kind: "leader" } },
+					},
+				},
+			});
+			await writeJson(join(sessionDir, "skill-active-state.json"), {
+				active: true,
+				skill: "deep-interview",
+				phase: "planning",
+				session_id: sessionId,
+				thread_id: threadId,
+				active_skills: [{
+					skill: "deep-interview",
+					phase: "planning",
+					active: true,
+					session_id: sessionId,
+					thread_id: threadId,
+				}],
+			});
+			const activeWrite = await executeStateOperation("state_write", {
+				mode: "deep-interview",
+				active: true,
+				current_phase: "intent-first",
+				session_id: sessionId,
+				thread_id: threadId,
+				workingDirectory: cwd,
+			});
+			assert.notEqual(activeWrite.isError, true);
+			await writeFile(join(cwd, "README.md"), "foo bar\n");
+
+			// Payload-realistic regression for #3314's reported live-runtime
+			// discrepancy: exercise the actual PreToolUse dispatch path against a
+			// process-wide trusted PATH (not an inline `PATH=... omx` assignment,
+			// and not a manually short-circuited fixture) so the omx CLI resolves
+			// exactly the way a live Codex session resolves it.
+			const workspacePackageCli = realpathSync(resolve(process.cwd(), "dist", "cli", "omx.js"));
+			const trustedBinDir = await mkdtemp(join(tmpdir(), "omx-issue-3313-3314-trusted-bin-"));
+			await symlink(workspacePackageCli, join(trustedBinDir, "omx"));
+			const inheritedPath = process.env.PATH;
+			process.env.PATH = `${trustedBinDir}:${dirname(process.execPath)}:/usr/bin:/bin`;
+
+			const preToolUse = (command: string) => dispatchCodexNativeHook({
+				hook_event_name: "PreToolUse",
+				cwd,
+				session_id: sessionId,
+				thread_id: threadId,
+				agent_id: threadId,
+				tool_name: "Bash",
+				tool_use_id: `tool-issue-3313-3314-di-${Math.random()}`,
+				tool_input: { command },
+			}, { cwd });
+			const assertAllowed = async (label: string, command: string) => {
+				const result = await preToolUse(command);
+				assert.equal(result.outputJson, null, `${label}: ${JSON.stringify(result.outputJson)}`);
+			};
+			const assertBlocked = async (label: string, command: string, pattern?: RegExp) => {
+				const result = await preToolUse(command);
+				assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block", label);
+				if (pattern) assert.match(JSON.stringify(result.outputJson), pattern, label);
+			};
+
+			try {
+				// #3314: plain, non-omx-wrapped read-only discovery must already stay allowed.
+				await assertAllowed("plain rg", `rg -n -i "foo" README.md`);
+				await assertAllowed("plain git status", "git status --short --branch");
+				await assertAllowed("plain find", "find . -maxdepth 3 -type d");
+
+				// #3313/#3314: omx/gjc help/version/status/read must not be misclassified as writes.
+				await assertAllowed("omx --help", "omx --help");
+				await assertAllowed("omx ralplan --help", "omx ralplan --help");
+				await assertAllowed("omx state read (bare)", "omx state read --json");
+				await assertAllowed("omx state read --mode deep-interview --json", "omx state read --mode deep-interview --json");
+				await assertAllowed("omx state status --mode=deep-interview --json", "omx state status --mode=deep-interview --json");
+
+				// #3314: sparkshell-wrapped read-only discovery must not be misclassified as a write.
+				await assertAllowed("sparkshell wrapped rg", `omx sparkshell -- rg -n -i "foo" README.md`);
+				await assertAllowed("sparkshell wrapped git status", "omx sparkshell -- git status --short --branch");
+				await assertAllowed("sparkshell json-flagged wrapped rg", `omx sparkshell --json -- rg -n -i "foo" README.md`);
+
+				// #3313: deep-interview's own structured lifecycle stays reachable.
+				await assertAllowed("omx cancel", "omx cancel");
+
+				// Guards that must NOT relax: unsafe sparkshell modes, mutation-shaped
+				// wrapped argv, raw redirects into own session state, active-state
+				// overrides, and PATH-prefix smuggling on `omx cancel`.
+				await assertBlocked("sparkshell --shell mode stays scrutinized", `omx sparkshell --shell 'rg -n -i "foo" README.md'`);
+				await assertBlocked("sparkshell wrapped write stays blocked", `omx sparkshell -- bash -c 'echo x > src/generated.ts'`);
+				await assertBlocked(
+					"raw redirect into own session state",
+					`echo '{}' > ${join(sessionDir, "deep-interview-state.json")}`,
+					/is not under allowed deep-interview artifact/,
+				);
+				await assertBlocked(
+					"active-state override via omx state write stays blocked",
+					`omx state write --input '${JSON.stringify({ mode: "deep-interview", active: true, current_phase: "planning", session_id: sessionId, workingDirectory: cwd })}' --json`,
+				);
+				await assertBlocked("PATH-prefix smuggled omx cancel stays blocked", `PATH="${trustedBinDir}" omx cancel`, /PATH|write intent/);
+			} finally {
+				if (inheritedPath === undefined) delete process.env.PATH; else process.env.PATH = inheritedPath;
+				await rm(trustedBinDir, { recursive: true, force: true });
+			}
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("issue #3314 permits ralplan planning read-only discovery without relaxing write guards", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-issue-3314-ralplan-"));
+		try {
+			const stateDir = join(cwd, ".omx", "state");
+			const sessionId = "sess-issue-3314-ralplan";
+			const threadId = "thread-issue-3314-ralplan";
+			const sessionDir = join(stateDir, "sessions", sessionId);
+			await mkdir(sessionDir, { recursive: true });
+			await writeJson(join(stateDir, "session.json"), { session_id: sessionId, cwd, leader_thread_id: threadId });
+			await writeJson(join(stateDir, "subagent-tracking.json"), {
+				schemaVersion: 1,
+				sessions: {
+					[sessionId]: {
+						session_id: sessionId,
+						leader_thread_id: threadId,
+						threads: { [threadId]: { thread_id: threadId, kind: "leader" } },
+					},
+				},
+			});
+			await writeJson(join(sessionDir, "skill-active-state.json"), {
+				version: 1,
+				active: true,
+				skill: "ralplan",
+				phase: "planning",
+				session_id: sessionId,
+				active_skills: [{ skill: "ralplan", phase: "planning", active: true, session_id: sessionId }],
+			});
+			await writeJson(join(sessionDir, "ralplan-state.json"), {
+				active: true,
+				mode: "ralplan",
+				current_phase: "planning",
+				session_id: sessionId,
+			});
+			await writeFile(join(cwd, "README.md"), "foo bar\n");
+
+			const workspacePackageCli = realpathSync(resolve(process.cwd(), "dist", "cli", "omx.js"));
+			const trustedBinDir = await mkdtemp(join(tmpdir(), "omx-issue-3314-ralplan-trusted-bin-"));
+			await symlink(workspacePackageCli, join(trustedBinDir, "omx"));
+			const inheritedPath = process.env.PATH;
+			process.env.PATH = `${trustedBinDir}:${dirname(process.execPath)}:/usr/bin:/bin`;
+
+			const preToolUse = (command: string) => dispatchCodexNativeHook({
+				hook_event_name: "PreToolUse",
+				cwd,
+				session_id: sessionId,
+				thread_id: threadId,
+				agent_id: threadId,
+				tool_name: "Bash",
+				tool_use_id: `tool-issue-3314-ralplan-${Math.random()}`,
+				tool_input: { command },
+			}, { cwd });
+			const assertAllowed = async (label: string, command: string) => {
+				const result = await preToolUse(command);
+				assert.equal(result.outputJson, null, `${label}: ${JSON.stringify(result.outputJson)}`);
+			};
+			const assertBlocked = async (label: string, command: string) => {
+				const result = await preToolUse(command);
+				assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block", label);
+			};
+
+			try {
+				await assertAllowed("plain rg", `rg -n -i "foo" README.md`);
+				await assertAllowed("plain git status", "git status --short --branch");
+				await assertAllowed("plain find", "find . -maxdepth 3 -type d");
+				await assertAllowed("omx --help", "omx --help");
+				await assertAllowed("omx ralplan --help", "omx ralplan --help");
+				await assertAllowed("omx state read --mode ralplan --json", "omx state read --mode ralplan --json");
+				await assertAllowed("sparkshell wrapped rg", `omx sparkshell -- rg -n -i "foo" README.md`);
+
+				await assertBlocked("sparkshell --shell mode stays scrutinized", `omx sparkshell --shell 'rg -n -i "foo" README.md'`);
+				await assertBlocked("sparkshell wrapped write stays blocked", `omx sparkshell -- bash -c 'echo x > src/generated.ts'`);
+				await assertBlocked(
+					"raw redirect into own session state",
+					`echo '{}' > ${join(sessionDir, "ralplan-state.json")}`,
+				);
+			} finally {
+				if (inheritedPath === undefined) delete process.env.PATH; else process.env.PATH = inheritedPath;
+				await rm(trustedBinDir, { recursive: true, force: true });
+			}
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
 
 	it("does not protect matching state basenames outside the canonical state root", async () => {
 		const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-product-session-json-"));

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -13743,7 +13743,10 @@ exit 0
 
 			try {
 				// #3314: plain, non-omx-wrapped read-only discovery must already stay allowed.
-				await assertAllowed("plain rg", `rg -n -i "foo" README.md`);
+				// Use coreutils/git only (guaranteed present and root-owned on every CI
+				// runner); ripgrep is not part of the standard test image, so asserting
+				// on it here would make this hermetic classifier test depend on ambient
+				// package installation rather than on the fix under test.
 				await assertAllowed("plain git status", "git status --short --branch");
 				await assertAllowed("plain find", "find . -maxdepth 3 -type d");
 
@@ -13755,9 +13758,9 @@ exit 0
 				await assertAllowed("omx state status --mode=deep-interview --json", "omx state status --mode=deep-interview --json");
 
 				// #3314: sparkshell-wrapped read-only discovery must not be misclassified as a write.
-				await assertAllowed("sparkshell wrapped rg", `omx sparkshell -- rg -n -i "foo" README.md`);
 				await assertAllowed("sparkshell wrapped git status", "omx sparkshell -- git status --short --branch");
-				await assertAllowed("sparkshell json-flagged wrapped rg", `omx sparkshell --json -- rg -n -i "foo" README.md`);
+				await assertAllowed("sparkshell wrapped find", "omx sparkshell -- find . -maxdepth 1 -type f");
+				await assertAllowed("sparkshell json-flagged wrapped git status", "omx sparkshell --json -- git status --short --branch");
 
 				// #3313: deep-interview's own structured lifecycle stays reachable.
 				await assertAllowed("omx cancel", "omx cancel");
@@ -13765,7 +13768,7 @@ exit 0
 				// Guards that must NOT relax: unsafe sparkshell modes, mutation-shaped
 				// wrapped argv, raw redirects into own session state, active-state
 				// overrides, and PATH-prefix smuggling on `omx cancel`.
-				await assertBlocked("sparkshell --shell mode stays scrutinized", `omx sparkshell --shell 'rg -n -i "foo" README.md'`);
+				await assertBlocked("sparkshell --shell mode stays scrutinized", "omx sparkshell --shell 'git status --short --branch'");
 				await assertBlocked("sparkshell wrapped write stays blocked", `omx sparkshell -- bash -c 'echo x > src/generated.ts'`);
 				await assertBlocked(
 					"raw redirect into own session state",
@@ -13847,15 +13850,14 @@ exit 0
 			};
 
 			try {
-				await assertAllowed("plain rg", `rg -n -i "foo" README.md`);
 				await assertAllowed("plain git status", "git status --short --branch");
 				await assertAllowed("plain find", "find . -maxdepth 3 -type d");
 				await assertAllowed("omx --help", "omx --help");
 				await assertAllowed("omx ralplan --help", "omx ralplan --help");
 				await assertAllowed("omx state read --mode ralplan --json", "omx state read --mode ralplan --json");
-				await assertAllowed("sparkshell wrapped rg", `omx sparkshell -- rg -n -i "foo" README.md`);
+				await assertAllowed("sparkshell wrapped git status", "omx sparkshell -- git status --short --branch");
 
-				await assertBlocked("sparkshell --shell mode stays scrutinized", `omx sparkshell --shell 'rg -n -i "foo" README.md'`);
+				await assertBlocked("sparkshell --shell mode stays scrutinized", "omx sparkshell --shell 'git status --short --branch'");
 				await assertBlocked("sparkshell wrapped write stays blocked", `omx sparkshell -- bash -c 'echo x > src/generated.ts'`);
 				await assertBlocked(
 					"raw redirect into own session state",

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -13768,6 +13768,27 @@ exit 0
 				await assertAllowed("plain git status", "git status --short --branch");
 				await assertAllowed("plain find", "find . -maxdepth 3 -type d");
 
+				// Direct plain `rg` must also stay read-only when it is genuinely
+				// available on this host's real PATH (a user-managed external
+				// executable, not one this repo controls). ripgrep is not part of
+				// the base OS image or this lane's installed toolset, so this check
+				// is best-effort/skip-when-absent rather than hermetic -- it proves
+				// the classifier's generic non-omx/gjc read-only path for a real,
+				// externally-resolved `rg` wherever one happens to exist, without
+				// making the suite depend on ripgrep being installed everywhere.
+				{
+					const { execFileSync } = await import("node:child_process");
+					let realRgPath: string | null = null;
+					try {
+						realRgPath = execFileSync("/bin/sh", ["-c", "command -v rg"], { encoding: "utf-8" }).trim() || null;
+					} catch {
+						realRgPath = null;
+					}
+					if (realRgPath) {
+						await assertAllowed("plain rg (real, externally-resolved binary)", `rg -n -i "foo" README.md`);
+					}
+				}
+
 				// #3313/#3314: omx/gjc help/version/status/read must not be misclassified as writes.
 				await assertAllowed("omx --help", "omx --help");
 				await assertAllowed("omx ralplan --help", "omx ralplan --help");
@@ -13914,9 +13935,36 @@ exit 0
 
 				// Guards that must NOT relax: unsafe sparkshell modes, mutation-shaped
 				// wrapped argv, raw redirects into own session state, active-state
-				// overrides, and PATH-prefix smuggling on `omx cancel`.
+				// overrides, and PATH-prefix smuggling on `omx cancel`. `--help`/`-h`
+				// is safe anywhere (every subcommand consulted short-circuits before
+				// real work), but `--version`/`-v` is NOT universally safe (e.g.
+				// `omx cleanup --version` still performs real cleanup because that
+				// subcommand only special-cases `--help`/`-h`), so it must only be
+				// trusted as a bare top-level probe. A `--help` meant for a
+				// sparkshell-wrapped script must not short-circuit scrutiny of that
+				// wrapped script, and an inherited OMX_SPARKSHELL_BIN override must
+				// deny the sparkshell allowance entirely.
 				await assertBlocked("sparkshell --shell mode stays scrutinized", "omx sparkshell --shell 'git status --short --branch'");
 				await assertBlocked("sparkshell wrapped write stays blocked", `omx sparkshell -- bash -c 'echo x > src/generated.ts'`);
+				await assertBlocked("omx cleanup --version stays blocked (not a bare top-level probe)", "omx cleanup --version");
+				await assertBlocked("omx cleanup -v stays blocked (not a bare top-level probe)", "omx cleanup -v");
+				await assertBlocked(
+					"sparkshell-wrapped --help meant for the wrapped script stays scrutinized",
+					"omx sparkshell -- ./mutate.sh --help",
+				);
+				{
+					const previousSparkshellBin = process.env.OMX_SPARKSHELL_BIN;
+					process.env.OMX_SPARKSHELL_BIN = "/tmp/attacker-sidecar";
+					try {
+						await assertBlocked(
+							"inherited OMX_SPARKSHELL_BIN override denies the sparkshell allowance",
+							"omx sparkshell -- git status --short --branch",
+						);
+					} finally {
+						if (previousSparkshellBin === undefined) delete process.env.OMX_SPARKSHELL_BIN;
+						else process.env.OMX_SPARKSHELL_BIN = previousSparkshellBin;
+					}
+				}
 				await assertBlocked(
 					"raw redirect into own session state",
 					`echo '{}' > ${join(sessionDir, "deep-interview-state.json")}`,
@@ -14034,6 +14082,24 @@ exit 0
 
 				await assertBlocked("sparkshell --shell mode stays scrutinized", "omx sparkshell --shell 'git status --short --branch'");
 				await assertBlocked("sparkshell wrapped write stays blocked", `omx sparkshell -- bash -c 'echo x > src/generated.ts'`);
+				await assertBlocked("omx cleanup --version stays blocked (not a bare top-level probe)", "omx cleanup --version");
+				await assertBlocked(
+					"sparkshell-wrapped --help meant for the wrapped script stays scrutinized",
+					"omx sparkshell -- ./mutate.sh --help",
+				);
+				{
+					const previousSparkshellBin = process.env.OMX_SPARKSHELL_BIN;
+					process.env.OMX_SPARKSHELL_BIN = "/tmp/attacker-sidecar";
+					try {
+						await assertBlocked(
+							"inherited OMX_SPARKSHELL_BIN override denies the sparkshell allowance",
+							"omx sparkshell -- git status --short --branch",
+						);
+					} finally {
+						if (previousSparkshellBin === undefined) delete process.env.OMX_SPARKSHELL_BIN;
+						else process.env.OMX_SPARKSHELL_BIN = previousSparkshellBin;
+					}
+				}
 				await assertBlocked(
 					"raw redirect into own session state",
 					`echo '{}' > ${join(sessionDir, "ralplan-state.json")}`,

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -13803,14 +13803,45 @@ exit 0
 							"PATH-prefix impostor omx sparkshell stays blocked",
 							`PATH="${impostorBinDir}" omx sparkshell -- git status --short --branch`,
 						);
-						await assertBlocked(
-							"path-qualified impostor omx sparkshell stays blocked",
-							`${join(impostorBinDir, "omx")} sparkshell -- git status --short --branch`,
-						);
+					await assertBlocked(
+						"path-qualified impostor omx sparkshell stays blocked",
+						`${join(impostorBinDir, "omx")} sparkshell -- git status --short --branch`,
+					);
 					} finally {
 						await rm(impostorBinDir, { recursive: true, force: true });
 					}
 				}
+
+				// A relative-path impostor `./omx` resolves via the current directory,
+				// never via PATH, so it must stay blocked even when a legitimate
+				// trusted `omx` also exists on PATH -- basename-only trust would be
+				// fooled by the unrelated trusted PATH entry.
+				{
+					await writeFile(join(cwd, "omx"), "#!/bin/sh\necho pwned\n");
+					await chmod(join(cwd, "omx"), 0o755);
+					try {
+						await assertBlocked(
+							"relative-path impostor ./omx sparkshell stays blocked with a legitimate trusted omx also on PATH",
+							"./omx sparkshell -- git status --short --branch",
+						);
+					} finally {
+						await rm(join(cwd, "omx"), { force: true });
+					}
+				}
+
+				// An inherited BASH_FUNC_omx%% shell-function shadow must stay blocked
+				// even against a trusted PATH resolution for the real binary.
+				{
+					const previousBashFuncOmx = process.env["BASH_FUNC_omx%%"];
+					process.env["BASH_FUNC_omx%%"] = "() { echo shadowed; }";
+					try {
+						await assertBlocked("inherited BASH_FUNC_omx%% shadow stays blocked", "omx --help");
+					} finally {
+						if (previousBashFuncOmx === undefined) delete process.env["BASH_FUNC_omx%%"];
+						else process.env["BASH_FUNC_omx%%"] = previousBashFuncOmx;
+					}
+				}
+
 
 				// gjc is a first-class alias of the same canonical package CLI; a trusted
 				// gjc shim must get the same read-only discovery allowance omx does.

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -157,6 +157,31 @@ async function writeJson(path: string, value: unknown): Promise<void> {
 	await writeFile(path, JSON.stringify(value, null, 2));
 }
 
+const AMBIENT_UNSAFE_NODE_RUNTIME_ENV_NAMES = [
+	"NODE_OPTIONS",
+	"OPENSSL_CONF",
+	"NODE_V8_COVERAGE",
+	"NODE_COMPILE_CACHE",
+	"NODE_REDIRECT_WARNINGS",
+	"NODE_REPORT_DIRECTORY",
+	"NODE_REPORT_FILENAME",
+] as const;
+
+async function withCleanAmbientNodeRuntimeEnvironment<T>(run: () => Promise<T>): Promise<T> {
+	const previousRuntimeEnv = Object.fromEntries(
+		AMBIENT_UNSAFE_NODE_RUNTIME_ENV_NAMES.map((name) => [name, process.env[name]]),
+	);
+	for (const name of AMBIENT_UNSAFE_NODE_RUNTIME_ENV_NAMES) delete process.env[name];
+	try {
+		return await run();
+	} finally {
+		for (const name of AMBIENT_UNSAFE_NODE_RUNTIME_ENV_NAMES) {
+			if (previousRuntimeEnv[name] === undefined) delete process.env[name];
+			else process.env[name] = previousRuntimeEnv[name];
+		}
+	}
+}
+
 async function writeCanonicalLeaderFixture(
 	stateDir: string,
 	sessionId: string,
@@ -13436,7 +13461,20 @@ exit 0
 				const workspacePackageCliForReadOnly = realpathSync(resolve(process.cwd(), "dist", "cli", "omx.js"));
 				await symlink(workspacePackageCliForReadOnly, join(readOnlyTrustedBinDir, "omx"));
 				const inheritedReadOnlyPath = process.env.PATH;
+				const unsafeRuntimeEnvNames = [
+					"NODE_OPTIONS",
+					"OPENSSL_CONF",
+					"NODE_V8_COVERAGE",
+					"NODE_COMPILE_CACHE",
+					"NODE_REDIRECT_WARNINGS",
+					"NODE_REPORT_DIRECTORY",
+					"NODE_REPORT_FILENAME",
+				] as const;
+				const inheritedReadOnlyRuntimeEnvironment = Object.fromEntries(
+					unsafeRuntimeEnvNames.map((name) => [name, process.env[name]]),
+				);
 				process.env.PATH = `${readOnlyTrustedBinDir}:${inheritedReadOnlyPath ?? ""}`;
+				for (const name of unsafeRuntimeEnvNames) delete process.env[name];
 				try {
 					for (const [label, command] of [
 						["omx-help", "omx --help"],
@@ -13451,6 +13489,10 @@ exit 0
 				} finally {
 					if (inheritedReadOnlyPath === undefined) delete process.env.PATH;
 					else process.env.PATH = inheritedReadOnlyPath;
+					for (const name of unsafeRuntimeEnvNames) {
+						if (inheritedReadOnlyRuntimeEnvironment[name] === undefined) delete process.env[name];
+						else process.env[name] = inheritedReadOnlyRuntimeEnvironment[name];
+					}
 					await rm(readOnlyTrustedBinDir, { recursive: true, force: true });
 				}
 			}
@@ -13500,7 +13542,7 @@ exit 0
 		}
 	});
 
-	it("allows only the canonical leader's authenticated standalone deep-interview complete terminal state write", async () => {
+	it("allows only the canonical leader's authenticated standalone deep-interview complete terminal state write", async () => withCleanAmbientNodeRuntimeEnvironment(async () => {
 		const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-deep-interview-terminal-write-"));
 		try {
 			const stateDir = join(cwd, ".omx", "state");
@@ -13683,7 +13725,7 @@ exit 0
 		} finally {
 			await rm(cwd, { recursive: true, force: true });
 		}
-	});
+	}));
 	it("issue #3313/#3314 permits standalone deep-interview lifecycle reachability and read-only discovery without relaxing write guards", async () => {
 		const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-issue-3313-3314-di-"));
 		try {
@@ -13738,6 +13780,19 @@ exit 0
 			await symlink(workspacePackageCli, join(trustedBinDir, "omx"));
 			const inheritedPath = process.env.PATH;
 			process.env.PATH = `${trustedBinDir}:${dirname(process.execPath)}:/usr/bin:/bin`;
+			const unsafeRuntimeEnvironmentNames = [
+				"NODE_OPTIONS",
+				"OPENSSL_CONF",
+				"NODE_V8_COVERAGE",
+				"NODE_COMPILE_CACHE",
+				"NODE_REDIRECT_WARNINGS",
+				"NODE_REPORT_DIRECTORY",
+				"NODE_REPORT_FILENAME",
+			] as const;
+			const inheritedUnsafeRuntimeEnvironment = Object.fromEntries(
+				unsafeRuntimeEnvironmentNames.map((name) => [name, process.env[name]]),
+			);
+			for (const name of unsafeRuntimeEnvironmentNames) delete process.env[name];
 			const sparkshellImplementationEnvironmentNames = [
 				"OMX_SPARKSHELL_BIN",
 				"OMX_NATIVE_CACHE_DIR",
@@ -14005,6 +14060,10 @@ exit 0
 				await assertBlocked("PATH-prefix smuggled omx cancel stays blocked", `PATH="${trustedBinDir}" omx cancel`, /PATH|write intent/);
 			} finally {
 				if (inheritedPath === undefined) delete process.env.PATH; else process.env.PATH = inheritedPath;
+				for (const name of unsafeRuntimeEnvironmentNames) {
+					if (inheritedUnsafeRuntimeEnvironment[name] === undefined) delete process.env[name];
+					else process.env[name] = inheritedUnsafeRuntimeEnvironment[name];
+				}
 				for (const name of sparkshellImplementationEnvironmentNames) {
 					const previous = (inheritedSparkshellImplementationEnvironment as Record<string, string | undefined>)[name];
 					if (previous === undefined) delete process.env[name];
@@ -14057,6 +14116,19 @@ exit 0
 			await symlink(workspacePackageCli, join(trustedBinDir, "omx"));
 			const inheritedPath = process.env.PATH;
 			process.env.PATH = `${trustedBinDir}:${dirname(process.execPath)}:/usr/bin:/bin`;
+			const unsafeRuntimeEnvironmentNames = [
+				"NODE_OPTIONS",
+				"OPENSSL_CONF",
+				"NODE_V8_COVERAGE",
+				"NODE_COMPILE_CACHE",
+				"NODE_REDIRECT_WARNINGS",
+				"NODE_REPORT_DIRECTORY",
+				"NODE_REPORT_FILENAME",
+			] as const;
+			const inheritedUnsafeRuntimeEnvironment = Object.fromEntries(
+				unsafeRuntimeEnvironmentNames.map((name) => [name, process.env[name]]),
+			);
+			for (const name of unsafeRuntimeEnvironmentNames) delete process.env[name];
 			const sparkshellImplementationEnvironmentNames = [
 				"OMX_SPARKSHELL_BIN",
 				"OMX_NATIVE_CACHE_DIR",
@@ -14167,6 +14239,10 @@ exit 0
 				);
 			} finally {
 				if (inheritedPath === undefined) delete process.env.PATH; else process.env.PATH = inheritedPath;
+				for (const name of unsafeRuntimeEnvironmentNames) {
+					if (inheritedUnsafeRuntimeEnvironment[name] === undefined) delete process.env[name];
+					else process.env[name] = inheritedUnsafeRuntimeEnvironment[name];
+				}
 				for (const name of sparkshellImplementationEnvironmentNames) {
 					const previous = (inheritedSparkshellImplementationEnvironment as Record<string, string | undefined>)[name];
 					if (previous === undefined) delete process.env[name];
@@ -14228,7 +14304,7 @@ exit 0
 			await rm(cwd, { recursive: true, force: true });
 		}
 	});
-	it("allows canonical leader deep-interview artifact and state writes while blocking implementation Bash writes", async () => {
+	it("allows canonical leader deep-interview artifact and state writes while blocking implementation Bash writes", async () => withCleanAmbientNodeRuntimeEnvironment(async () => {
 		const cwd = realpathSync(await mkdtemp(
 			join(tmpdir(), "omx-native-hook-pretool-deep-interview-artifact-"),
 		));
@@ -18620,9 +18696,9 @@ exit 0
 		} finally {
 			await rm(cwd, { recursive: true, force: true });
 		}
-	});
+	}));
 
-	it("allows canonical leader ralplan complete terminal state writes while blocking partial deactivation writes", async () => {
+	it("allows canonical leader ralplan complete terminal state writes while blocking partial deactivation writes", async () => withCleanAmbientNodeRuntimeEnvironment(async () => {
 		const cwd = await mkdtemp(
 			join(tmpdir(), "omx-native-hook-pretool-ralplan-state-input-file-"),
 		);
@@ -19187,7 +19263,7 @@ exit 0
 		} finally {
 			await rm(cwd, { recursive: true, force: true });
 		}
-	});
+	}));
 
 	it("emits hook-specific deny ralplan PreToolUse JSON for wrapped implementation writes on the live CLI path", async () => {
 		const cwd = await mkdtemp(
@@ -33602,7 +33678,7 @@ PY`,
     }
   });
 
-  it("uses hook-native agent_id as child provenance without borrowing Team or legacy identity", async () => {
+  it("uses hook-native agent_id as child provenance without borrowing Team or legacy identity", async () => withCleanAmbientNodeRuntimeEnvironment(async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-conductor-agent-id-"));
     const originalTeamWorker = process.env.OMX_TEAM_WORKER;
     const originalInternalTeamWorker = process.env.OMX_TEAM_INTERNAL_WORKER;
@@ -34318,7 +34394,7 @@ PY`,
       else process.env.GJC_SESSION_ID = originalGjcSessionId;
       await rm(cwd, { recursive: true, force: true });
     }
-  });
+  }));
 
   it("keeps active Ralph starting phase behind the PreToolUse write guard", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralph-starting-pretool-"));
@@ -35648,8 +35724,19 @@ PY`,
   it("blocks non-shell direct writes in Main-root conductor states", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-conductor-bash-mutations-"));
     const previousPath = process.env.PATH;
+    const unsafeRuntimeEnvNames = [
+      "NODE_OPTIONS",
+      "OPENSSL_CONF",
+      "NODE_V8_COVERAGE",
+      "NODE_COMPILE_CACHE",
+      "NODE_REDIRECT_WARNINGS",
+      "NODE_REPORT_DIRECTORY",
+      "NODE_REPORT_FILENAME",
+    ] as const;
+    const previousRuntimeEnv = Object.fromEntries(unsafeRuntimeEnvNames.map((name) => [name, process.env[name]]));
     try {
       process.env.PATH = `${dirname(process.execPath)}:/usr/bin:/bin`;
+      for (const name of unsafeRuntimeEnvNames) delete process.env[name];
       const stateDir = join(cwd, ".omx", "state");
       const sessionId = "sess-conductor-bash-mutations";
       await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
@@ -35742,6 +35829,10 @@ PY`,
     } finally {
       if (typeof previousPath === "string") process.env.PATH = previousPath;
       else delete process.env.PATH;
+      for (const name of unsafeRuntimeEnvNames) {
+        if (previousRuntimeEnv[name] === undefined) delete process.env[name];
+        else process.env[name] = previousRuntimeEnv[name];
+      }
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -13859,6 +13859,44 @@ exit 0
 					}
 				}
 
+				// Lexical-boundary mismatches between our tokenizer/analysis and the
+				// actual shell that will execute the command must not let a
+				// differently-named executable borrow this trust: a wrapper
+				// (env/command/time) around an impostor, a non-ASCII whitespace
+				// character embedded mid-command, and a leading BOM stripped by
+				// ECMAScript trim() must all still resolve to denial.
+				{
+					const lexicalAttackerDir = await mkdtemp(join(tmpdir(), "omx-lexical-attacker-"));
+					await writeFile(join(lexicalAttackerDir, "omx"), "#!/bin/sh\necho pwned\n");
+					await chmod(join(lexicalAttackerDir, "omx"), 0o755);
+					// A file literally named "omx<NBSP>--help" (single word to the real
+					// shell, since Bash does not treat U+00A0 as a blank).
+					await writeFile(join(lexicalAttackerDir, "omx\u00A0--help"), "#!/bin/sh\necho pwned\n");
+					await chmod(join(lexicalAttackerDir, "omx\u00A0--help"), 0o755);
+					// A file literally named "\uFEFFomx" (leading BOM preserved by Bash).
+					await writeFile(join(lexicalAttackerDir, "\uFEFFomx"), "#!/bin/sh\necho pwned\n");
+					await chmod(join(lexicalAttackerDir, "\uFEFFomx"), 0o755);
+					const previousLexicalPath = process.env.PATH;
+					// Attacker directory first, then the legitimate trusted CLI later on PATH.
+					process.env.PATH = `${lexicalAttackerDir}:${trustedBinDir}:${dirname(process.execPath)}:/usr/bin:/bin`;
+					try {
+						await assertBlocked("env-wrapped omx --help stays blocked", "env omx --help");
+						await assertBlocked("command-wrapped omx --help stays blocked", "command omx --help");
+						await assertBlocked("time-wrapped omx --help stays blocked", "time omx --help");
+						await assertBlocked(
+							"embedded NBSP between omx and --help stays blocked",
+							"omx\u00A0--help",
+						);
+						await assertBlocked(
+							"leading BOM before omx --help stays blocked",
+							"\uFEFFomx --help",
+						);
+					} finally {
+						if (previousLexicalPath === undefined) delete process.env.PATH; else process.env.PATH = previousLexicalPath;
+						await rm(lexicalAttackerDir, { recursive: true, force: true });
+					}
+				}
+
 				// Guards that must NOT relax: unsafe sparkshell modes, mutation-shaped
 				// wrapped argv, raw redirects into own session state, active-state
 				// overrides, and PATH-prefix smuggling on `omx cancel`.

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -13876,6 +13876,13 @@ exit 0
 					// A file literally named "\uFEFFomx" (leading BOM preserved by Bash).
 					await writeFile(join(lexicalAttackerDir, "\uFEFFomx"), "#!/bin/sh\necho pwned\n");
 					await chmod(join(lexicalAttackerDir, "\uFEFFomx"), 0o755);
+					// Files literally named "omx<VT>--help" / "omx<FF>--help" (single
+					// words to the real shell -- Bash does not treat U+000B/U+000C as
+					// blanks either, only ASCII space/tab/newline).
+					await writeFile(join(lexicalAttackerDir, "omx\v--help"), "#!/bin/sh\necho pwned\n");
+					await chmod(join(lexicalAttackerDir, "omx\v--help"), 0o755);
+					await writeFile(join(lexicalAttackerDir, "omx\f--help"), "#!/bin/sh\necho pwned\n");
+					await chmod(join(lexicalAttackerDir, "omx\f--help"), 0o755);
 					const previousLexicalPath = process.env.PATH;
 					// Attacker directory first, then the legitimate trusted CLI later on PATH.
 					process.env.PATH = `${lexicalAttackerDir}:${trustedBinDir}:${dirname(process.execPath)}:/usr/bin:/bin`;
@@ -13890,6 +13897,14 @@ exit 0
 						await assertBlocked(
 							"leading BOM before omx --help stays blocked",
 							"\uFEFFomx --help",
+						);
+						await assertBlocked(
+							"embedded vertical tab between omx and --help stays blocked",
+							"omx\v--help",
+						);
+						await assertBlocked(
+							"embedded form feed between omx and --help stays blocked",
+							"omx\f--help",
 						);
 					} finally {
 						if (previousLexicalPath === undefined) delete process.env.PATH; else process.env.PATH = previousLexicalPath;

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -13426,15 +13426,33 @@ exit 0
 			})(), /Deep-interview is active|write intent|handoff|direct/);
 			await writeIssue3239ActiveAutopilotDeepInterviewState(cwd, sessionId, threadId);
 
-			for (const [label, command] of [
-				["omx-help", "omx --help"],
-				["omx-state-read", "omx state read --json"],
-				["omx-cleanup-dry-run", "omx cleanup --dry-run"],
-				["gh-issue-list", "gh issue list --repo Yeachan-Heo/oh-my-codex"],
-				["rtk-version", "rtk --version"],
-				["omx-help-benign-locale-env", "LANG=C omx --help"],
-			] as const) {
-				await assertAllowed(label, await bash(command, label));
+			{
+				// The read-only allowlist requires the same trusted-package-CLI
+				// execution-context proof the direct-cancel path uses (#3313/#3314
+				// hardening), so these assertions need `omx` to resolve to this
+				// worktree's own canonical CLI rather than relying on whatever
+				// ambient PATH the test runner happens to inherit.
+				const readOnlyTrustedBinDir = await mkdtemp(join(tmpdir(), "omx-issue-3239-readonly-trusted-bin-"));
+				const workspacePackageCliForReadOnly = realpathSync(resolve(process.cwd(), "dist", "cli", "omx.js"));
+				await symlink(workspacePackageCliForReadOnly, join(readOnlyTrustedBinDir, "omx"));
+				const inheritedReadOnlyPath = process.env.PATH;
+				process.env.PATH = `${readOnlyTrustedBinDir}:${inheritedReadOnlyPath ?? ""}`;
+				try {
+					for (const [label, command] of [
+						["omx-help", "omx --help"],
+						["omx-state-read", "omx state read --json"],
+						["omx-cleanup-dry-run", "omx cleanup --dry-run"],
+						["gh-issue-list", "gh issue list --repo Yeachan-Heo/oh-my-codex"],
+						["rtk-version", "rtk --version"],
+						["omx-help-benign-locale-env", "LANG=C omx --help"],
+					] as const) {
+						await assertAllowed(label, await bash(command, label));
+					}
+				} finally {
+					if (inheritedReadOnlyPath === undefined) delete process.env.PATH;
+					else process.env.PATH = inheritedReadOnlyPath;
+					await rm(readOnlyTrustedBinDir, { recursive: true, force: true });
+				}
 			}
 
 			for (const [label, command, pattern] of [
@@ -13765,6 +13783,51 @@ exit 0
 				// #3313: deep-interview's own structured lifecycle stays reachable.
 				await assertAllowed("omx cancel", "omx cancel");
 
+				// The read-only allowlist authorizes the *outer* omx/gjc invocation, not
+				// just the wrapped argv shape, so it must require the same trusted-package-CLI
+				// execution-context proof the direct-cancel path already uses. An impostor
+				// binary (PATH-prefix override or path-qualified) must never reach the
+				// allow-return for --help, state read, or sparkshell, regardless of what its
+				// wrapped argv looks like.
+				{
+					const impostorBinDir = await mkdtemp(join(tmpdir(), "omx-impostor-bin-"));
+					await writeFile(join(impostorBinDir, "omx"), "#!/bin/sh\necho pwned\n");
+					await chmod(join(impostorBinDir, "omx"), 0o755);
+					try {
+						await assertBlocked("PATH-prefix impostor omx --help stays blocked", `PATH="${impostorBinDir}" omx --help`);
+						await assertBlocked(
+							"PATH-prefix impostor omx state read stays blocked",
+							`PATH="${impostorBinDir}" omx state read --mode deep-interview --json`,
+						);
+						await assertBlocked(
+							"PATH-prefix impostor omx sparkshell stays blocked",
+							`PATH="${impostorBinDir}" omx sparkshell -- git status --short --branch`,
+						);
+						await assertBlocked(
+							"path-qualified impostor omx sparkshell stays blocked",
+							`${join(impostorBinDir, "omx")} sparkshell -- git status --short --branch`,
+						);
+					} finally {
+						await rm(impostorBinDir, { recursive: true, force: true });
+					}
+				}
+
+				// gjc is a first-class alias of the same canonical package CLI; a trusted
+				// gjc shim must get the same read-only discovery allowance omx does.
+				{
+					const gjcTrustedBinDir = await mkdtemp(join(tmpdir(), "omx-gjc-trusted-bin-"));
+					await symlink(workspacePackageCli, join(gjcTrustedBinDir, "gjc"));
+					const previousGjcPath = process.env.PATH;
+					process.env.PATH = `${gjcTrustedBinDir}:${dirname(process.execPath)}:/usr/bin:/bin`;
+					try {
+						await assertAllowed("trusted gjc --help", "gjc --help");
+						await assertAllowed("trusted gjc sparkshell wrapped git status", "gjc sparkshell -- git status --short --branch");
+					} finally {
+						if (previousGjcPath === undefined) delete process.env.PATH; else process.env.PATH = previousGjcPath;
+						await rm(gjcTrustedBinDir, { recursive: true, force: true });
+					}
+				}
+
 				// Guards that must NOT relax: unsafe sparkshell modes, mutation-shaped
 				// wrapped argv, raw redirects into own session state, active-state
 				// overrides, and PATH-prefix smuggling on `omx cancel`.
@@ -13856,6 +13919,34 @@ exit 0
 				await assertAllowed("omx ralplan --help", "omx ralplan --help");
 				await assertAllowed("omx state read --mode ralplan --json", "omx state read --mode ralplan --json");
 				await assertAllowed("sparkshell wrapped git status", "omx sparkshell -- git status --short --branch");
+
+				{
+					const impostorBinDir = await mkdtemp(join(tmpdir(), "omx-impostor-bin-ralplan-"));
+					await writeFile(join(impostorBinDir, "omx"), "#!/bin/sh\necho pwned\n");
+					await chmod(join(impostorBinDir, "omx"), 0o755);
+					try {
+						await assertBlocked("PATH-prefix impostor omx --help stays blocked", `PATH="${impostorBinDir}" omx --help`);
+						await assertBlocked(
+							"PATH-prefix impostor omx sparkshell stays blocked",
+							`PATH="${impostorBinDir}" omx sparkshell -- git status --short --branch`,
+						);
+					} finally {
+						await rm(impostorBinDir, { recursive: true, force: true });
+					}
+				}
+
+				{
+					const gjcTrustedBinDir = await mkdtemp(join(tmpdir(), "omx-gjc-trusted-bin-ralplan-"));
+					await symlink(workspacePackageCli, join(gjcTrustedBinDir, "gjc"));
+					const previousGjcPath = process.env.PATH;
+					process.env.PATH = `${gjcTrustedBinDir}:${dirname(process.execPath)}:/usr/bin:/bin`;
+					try {
+						await assertAllowed("trusted gjc --help", "gjc --help");
+					} finally {
+						if (previousGjcPath === undefined) delete process.env.PATH; else process.env.PATH = previousGjcPath;
+						await rm(gjcTrustedBinDir, { recursive: true, force: true });
+					}
+				}
 
 				await assertBlocked("sparkshell --shell mode stays scrutinized", "omx sparkshell --shell 'git status --short --branch'");
 				await assertBlocked("sparkshell wrapped write stays blocked", `omx sparkshell -- bash -c 'echo x > src/generated.ts'`);

--- a/src/scripts/__tests__/issue-3293-callsite-parity.test.ts
+++ b/src/scripts/__tests__/issue-3293-callsite-parity.test.ts
@@ -57,13 +57,28 @@ function assertBlocked(result: Awaited<ReturnType<typeof dispatchCodexNativeHook
 async function withTrustedOmx<T>(cwd: string, action: () => Promise<T>): Promise<T> {
 	const binDir = join(cwd, "trusted-bin");
 	const priorPath = process.env.PATH;
+	const unsafeRuntimeEnvNames = [
+		"NODE_OPTIONS",
+		"OPENSSL_CONF",
+		"NODE_V8_COVERAGE",
+		"NODE_COMPILE_CACHE",
+		"NODE_REDIRECT_WARNINGS",
+		"NODE_REPORT_DIRECTORY",
+		"NODE_REPORT_FILENAME",
+	] as const;
+	const priorRuntimeEnv = Object.fromEntries(unsafeRuntimeEnvNames.map((name) => [name, process.env[name]]));
 	await mkdir(binDir, { recursive: true });
 	await symlink(resolve(process.cwd(), "dist", "cli", "omx.js"), join(binDir, "omx"));
 	process.env.PATH = `${binDir}:${dirname(process.execPath)}`;
+	for (const name of unsafeRuntimeEnvNames) delete process.env[name];
 	try { return await action(); }
 	finally {
 		if (priorPath === undefined) delete process.env.PATH;
 		else process.env.PATH = priorPath;
+		for (const name of unsafeRuntimeEnvNames) {
+			if (priorRuntimeEnv[name] === undefined) delete process.env[name];
+			else process.env[name] = priorRuntimeEnv[name];
+		}
 	}
 }
 

--- a/src/scripts/__tests__/issue-3293-callsite-parity.test.ts
+++ b/src/scripts/__tests__/issue-3293-callsite-parity.test.ts
@@ -85,7 +85,7 @@ describe("issue #3293 callsite parity baseline", () => {
 
 	it("deep-interview ~9498: non-cancel read-only OMX command is allowed", async () => {
 		const f = await fixture("deep-interview", "readonly");
-		try { assert.equal((await preToolUse(f, "omx state read --json")).outputJson, null); }
+		try { await withTrustedOmx(f.cwd, async () => assert.equal((await preToolUse(f, "omx state read --json")).outputJson, null)); }
 		finally { await rm(f.cwd, { recursive: true, force: true }); }
 	});
 

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -9450,21 +9450,74 @@ function isAllowedOmxSparkshellWrappedReadOnlyCommand(wrappedCommand: string): b
 
 // The read-only allowlist (help/version/status/read, sparkshell-wrapped
 // discovery) must not authorize based on the bare `omx`/`gjc` basename alone:
-// an attacker-controlled PATH prefix or a path-qualified impostor executable
-// could otherwise be granted this allowance regardless of what it actually
-// does, since the caller returns immediately on a positive match. Require the
-// same trusted-package-CLI execution-context proof already used for the
-// direct-cancel path before any read-only shape is even considered.
-function isTrustedOmxOrGjcReadOnlyInvocation(command: string, cwd: string): boolean {
-  if (!isSingleLiteralShellInvocation(command)) return false;
-  if (commandHasUnsafeLeadingRuntimeEnvironment(command)) return false;
+// an attacker-controlled PATH prefix, a path-qualified impostor executable
+// (absolute OR relative -- `./omx` resolves via the current directory, never
+// via PATH, so a basename-only trust check can be fooled by a legitimate
+// trusted `omx` existing elsewhere on PATH while a *different* `./omx` is
+// what the shell actually executes), or an inherited BASH_FUNC_omx%%/gjc%%
+// shell-function shadow could otherwise be granted this allowance regardless
+// of what it actually does, since the caller returns immediately on a
+// positive match. Share the exact trusted-package-CLI execution-context
+// proof already used for the direct-cancel path (including its literal bare
+// command-word grammar, function-shadow rejection, and inherited
+// NODE_OPTIONS/OPENSSL_CONF/Node-output-environment checks) so both paths
+// can never drift apart.
+const OMX_GJC_TRUSTED_CONTEXT_UNSAFE_INHERITED_ENV_NAMES = [
+  "NODE_OPTIONS",
+  "OPENSSL_CONF",
+];
+
+function omxOrGjcExecutionContextIsTrusted(
+  command: string,
+  cwd: string,
+  allowedCommandWords: readonly string[],
+): boolean {
   if (commandHasUnsafeConductorShellState(command, cwd)) return false;
+  if (allowedCommandWords.some((name) => safeString(process.env[`BASH_FUNC_${name}%%`]).trim() !== "")) return false;
+  const unsafeInheritedNames = [...OMX_GJC_TRUSTED_CONTEXT_UNSAFE_INHERITED_ENV_NAMES, ...CONDUCTOR_NODE_OUTPUT_ENVIRONMENT_NAMES];
+  if (unsafeInheritedNames.some((name) => safeString(process.env[name]).trim() !== "")) return false;
   if (commandHasUnsafeDynamicLoaderEnvironment(command)) return false;
+  if (commandHasUnsafeLeadingRuntimeEnvironment(command)) return false;
   const words = tokenizeConductorShellWords(command);
   const index = skipShellCommandPositionPrefixWords(words, 0);
+  // Require the literal bare command word (no path separator at all, not
+  // just an unqualified basename) so a relative or absolute impostor never
+  // borrows a trusted PATH resolution that belongs to a different, unrelated
+  // `omx`/`gjc` entry.
+  const commandWord = shellWordLiteral(words[index] ?? "");
+  if (!allowedCommandWords.includes(commandWord)) return false;
+  return conductorCommandResolvesTrustedPackageCli(words, 0, index, createConductorRuntimeShellState(cwd), cwd);
+}
+
+function isTrustedOmxOrGjcReadOnlyInvocation(command: string, cwd: string): boolean {
+  if (!isSingleLiteralShellInvocation(command)) return false;
+  return omxOrGjcExecutionContextIsTrusted(command, cwd, ["omx", "gjc"]);
+}
+// Shape-only recognizer (no trust check): true when `command` syntactically
+// looks like one of the omx/gjc read-only shapes this allowlist grants
+// (--help/-h/--version/-v, help/status/version, state read|status,
+// sparkshell direct-argv, cleanup --dry-run). Used so callers can hard-deny
+// a recognized-but-untrusted shape instead of silently falling through to
+// the generic write-intent scanner, which has no notion of this allowlist's
+// trust requirement and could independently (and wrongly) conclude "no
+// write intent" for an unrelated reason -- e.g. an inherited BASH_FUNC_omx%%
+// shell-function shadow can make the generic PATH-mutation scanner treat the
+// invocation as a shell function rather than a binary and skip its own
+// mutation classification entirely. A hard hard-deny here closes that
+// fallthrough regardless of what the generic scanner would otherwise infer.
+function omxOrGjcReadOnlyShapeMatches(command: string): boolean {
+  if (!isSingleLiteralShellInvocation(command)) return false;
+  const words = literalInvocationWords(command);
+  const index = skipLiteralLeadingAssignments(words);
   const commandName = commandNameFromShellWord(words[index] ?? "");
   if (commandName !== "omx" && commandName !== "gjc") return false;
-  return conductorCommandResolvesTrustedPackageCli(words, 0, index, createConductorRuntimeShellState(cwd), cwd);
+  const args = words.slice(index + 1).filter(Boolean);
+  if (args.length === 0) return false;
+  if (args.some((arg) => arg === "--help" || arg === "-h" || arg === "--version" || arg === "-v")) return true;
+  if (args[0] === "help" || args[0] === "status" || args[0] === "version") return true;
+  if (args[0] === "state" && ["read", "status"].includes(args[1] ?? "")) return true;
+  if (extractOmxSparkshellDirectArgvCommand(args) !== null) return true;
+  return args[0] === "cleanup" && args.includes("--dry-run");
 }
 
 function isAllowedOmxReadOnlyCommand(command: string, cwd: string): boolean {
@@ -9527,20 +9580,10 @@ function isAllowedDeepInterviewCommandSpecificBash(
 // The pre-#3293 direct-cancel trust check is retained for Ralplan and
 // Conductor. IR2 scopes hook-owned terminalization to Autopilot deep-interview
 // only; those other workflows still execute their existing trusted command.
-const DIRECT_OMX_CANCEL_UNSAFE_INHERITED_ENV_NAMES = [
-  "NODE_OPTIONS",
-  "OPENSSL_CONF",
-];
-
+// Shares omxOrGjcExecutionContextIsTrusted with the read-only allowlist so the
+// two proofs cannot drift apart (see the comment above that helper).
 function directOmxCancelCommandHasTrustedExecutionContext(command: string, cwd: string): boolean {
-  if (commandHasUnsafeConductorShellState(command, cwd)) return false;
-  if (safeString(process.env["BASH_FUNC_omx%%"]).trim() !== "") return false;
-  const unsafeInheritedNames = [...DIRECT_OMX_CANCEL_UNSAFE_INHERITED_ENV_NAMES, ...CONDUCTOR_NODE_OUTPUT_ENVIRONMENT_NAMES];
-  if (unsafeInheritedNames.some((name) => safeString(process.env[name]).trim() !== "")) return false;
-  if (commandHasUnsafeDynamicLoaderEnvironment(command)) return false;
-  if (commandHasUnsafeLeadingRuntimeEnvironment(command)) return false;
-  const words = tokenizeConductorShellWords(command);
-  return conductorCommandResolvesTrustedPackageCli(words, 0, 0, createConductorRuntimeShellState(cwd), cwd);
+  return omxOrGjcExecutionContextIsTrusted(command, cwd, ["omx"]);
 }
 
 function isCommandResolutionSensitiveEnvironmentName(name: string): boolean {
@@ -9584,6 +9627,18 @@ function isAllowedDeepInterviewBashWrite(
     return questionClassification.kind === "allowed" && isSingleLiteralShellInvocation(command);
   }
   if (payload && isAllowedDeepInterviewCommandSpecificBash(payload, command, cwd)) return true;
+  // A command that syntactically matches a direct-cancel or read-only omx/gjc
+  // shape but failed that specific check (untrusted execution context,
+  // invalid grammar, unsafe sparkshell mode, etc.) must hard-deny here rather
+  // than fall through to the generic write-intent scanner below: that
+  // scanner has no notion of this allowlist's trust requirement and can
+  // independently conclude "no write intent" for unrelated reasons (e.g. an
+  // inherited BASH_FUNC_omx%%/gjc%% shell-function shadow), silently
+  // re-authorizing exactly what the specific check just refused.
+  if (
+    (payload && readPreToolUseRawCommand(payload) === command && isDirectOmxCancelCommand(command))
+    || omxOrGjcReadOnlyShapeMatches(command)
+  ) return false;
   if (sourcesFileWrittenEarlierInSameCommand(cwd, command)) return false;
   const stateWriteOperations = collectOmxStateCommandOperations(command, "write");
   const hasUnsafeRuntimeStateWrite = (words: string[]): boolean => {
@@ -9765,6 +9820,11 @@ function isAllowedRalplanBashWrite(
   if (isAllowedOmxReadOnlyCommand(command, cwd) || isAllowedGhReadOnlyCommand(command) || isAllowedVersionProbeCommand(command)) {
     return true;
   }
+  // Hard-deny a recognized-but-untrusted omx/gjc read-only shape instead of
+  // falling through to the generic write-intent scanner below, which has no
+  // notion of this allowlist's trust requirement (see the identical deny in
+  // isAllowedDeepInterviewBashWrite for the full rationale).
+  if (omxOrGjcReadOnlyShapeMatches(command)) return false;
 
   const beadsCommand = classifyRalplanBeadsMetadataCommand(cwd, command);
   const targets = extractDeepInterviewCommandWriteTargets(command);

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -9456,6 +9456,12 @@ function extractOmxSparkshellDirectArgvCommand(args: readonly string[]): string 
 }
 
 function isAllowedOmxSparkshellWrappedReadOnlyCommand(wrappedCommand: string): boolean {
+  // sparkshell dispatches the wrapped argv through a native sidecar binary
+  // resolved via OMX_SPARKSHELL_BIN (overridable) rather than executing the
+  // wrapped argv directly; an inherited override could substitute an
+  // attacker-controlled sidecar for the one that scrutiny assumes runs the
+  // literal wrapped argv, so this allowance requires no override is present.
+  if (safeString(process.env.OMX_SPARKSHELL_BIN).trim() !== "") return false;
   return !commandHasDeepInterviewWriteIntent(wrappedCommand)
     && !commandHasNestedCliMutationIntent(wrappedCommand)
     && collectOmxStateCommandOperations(wrappedCommand, "write").length === 0;
@@ -9541,13 +9547,29 @@ function isAllowedOmxReadOnlyCommand(command: string, cwd: string): boolean {
   if (commandName !== "omx" && commandName !== "gjc") return false;
   const args = words.slice(index + 1).filter(Boolean);
   if (args.length === 0) return false;
-  if (args.some((arg) => arg === "--help" || arg === "-h" || arg === "--version" || arg === "-v")) return true;
+  // Sparkshell must be recognized before any generic "--help/--version
+  // anywhere in args" heuristic below: its wrapped argv belongs to a
+  // DIFFERENT program (e.g. `omx sparkshell -- ./mutate.sh --help`), and a
+  // `--help` meant for that wrapped script is not evidence the omx/gjc
+  // invocation itself is read-only.
+  const sparkshellWrapped = extractOmxSparkshellDirectArgvCommand(args);
+  if (sparkshellWrapped !== null) return isAllowedOmxSparkshellWrappedReadOnlyCommand(sparkshellWrapped);
+  // A bare top-level probe (`omx --help`, `omx -h`, `omx --version`,
+  // `omx -v`, and nothing else) never dispatches to a subcommand handler,
+  // so both help and version forms are safe here.
+  if (args.length === 1 && (args[0] === "--help" || args[0] === "-h" || args[0] === "--version" || args[0] === "-v")) return true;
+  // `--help`/`-h` appearing anywhere is safe to recognize generically: every
+  // omx subcommand consulted (including `cleanup`) short-circuits real work
+  // before it runs when `--help`/`-h` is present, matching conventional CLI
+  // behavior. `--version`/`-v` is NOT universally safe the same way --
+  // `cleanup`, for example, never inspects them and falls through to real
+  // process/tmp cleanup -- so they are only trusted in the bare top-level
+  // form above, never as a trailing flag on an arbitrary subcommand.
+  if (args.some((arg) => arg === "--help" || arg === "-h")) return true;
   if (args[0] === "help" || args[0] === "status" || args[0] === "version") return true;
   if (args[0] === "state" && ["read", "status"].includes(args[1] ?? "")) {
     return stateReadTrailingArgsAreSafe(args.slice(2));
   }
-  const sparkshellWrapped = extractOmxSparkshellDirectArgvCommand(args);
-  if (sparkshellWrapped !== null) return isAllowedOmxSparkshellWrappedReadOnlyCommand(sparkshellWrapped);
   return isAllowedOmxCleanupDryRunCommand(command);
 }
 

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -6531,7 +6531,17 @@ function tokenizeShellWords(segment: string): string[] {
       }
       continue;
     }
-    if (!quote && /\s/.test(char)) {
+    // Bash's own lexer only treats ASCII space/tab (and newline as a
+    // statement terminator already normalized upstream) as word-separating
+    // blanks; it does NOT split on other Unicode whitespace (NBSP U+00A0,
+    // BOM U+FEFF, Zs-class spaces, U+2028/2029, etc). JS regex `\s` matches
+    // all of those, which previously let an embedded Unicode whitespace
+    // character make this tokenizer see two words ("omx", "--help") while
+    // Bash resolves and executes a single differently-named executable
+    // ("omx<NBSP>--help") -- silently borrowing a trusted lookup for a
+    // different, attacker-controlled binary. Restrict this split to the
+    // literal ASCII blank set Bash actually recognizes.
+    if (!quote && (char === " " || char === "\t" || char === "\n" || char === "\r" || char === "\v" || char === "\f")) {
       pushCurrent();
       continue;
     }
@@ -9572,6 +9582,14 @@ function isAllowedDeepInterviewCommandSpecificBash(
   if (readPreToolUseRawCommand(payload) === command && isDirectOmxCancelCommand(command)) {
     return directOmxCancelCommandHasTrustedExecutionContext(command, cwd);
   }
+  // Authorization decisions whose security contract depends on exact bytes
+  // must compare against the unmodified command string, matching the
+  // direct-cancel exemption above: ECMAScript trim() removes a leading
+  // BOM/NBSP/CR from the analyzed `command`, which could otherwise let a
+  // differently-named executable (e.g. `\uFEFFomx`) borrow the trusted
+  // `omx`/`gjc` read-only allowance while the shell actually executes the
+  // untrimmed, differently-named binary.
+  if (readPreToolUseRawCommand(payload) !== command) return false;
   return isAllowedOmxReadOnlyCommand(command, cwd)
     || isAllowedGhReadOnlyCommand(command)
     || isAllowedVersionProbeCommand(command);
@@ -9817,7 +9835,14 @@ function isAllowedRalplanBashWrite(
   // Read-only discovery (help/version/status/read, sparkshell-wrapped
   // read-only argv, and gh read-only commands) is not implementation intent
   // and must not be misclassified as a write during ralplan planning (#3314).
-  if (isAllowedOmxReadOnlyCommand(command, cwd) || isAllowedGhReadOnlyCommand(command) || isAllowedVersionProbeCommand(command)) {
+  // Requires raw/analyzed byte equality first, matching the direct-cancel
+  // exemption above: trimming can otherwise let a differently-named
+  // executable (e.g. leading BOM/NBSP) borrow this trusted allowance while
+  // the shell executes a different, untrimmed binary name.
+  if (
+    rawCommand === command
+    && (isAllowedOmxReadOnlyCommand(command, cwd) || isAllowedGhReadOnlyCommand(command) || isAllowedVersionProbeCommand(command))
+  ) {
     return true;
   }
   // Hard-deny a recognized-but-untrusted omx/gjc read-only shape instead of

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "child_process";
 import { accessSync, closeSync, constants as fsConstants, existsSync, lstatSync, openSync, readFileSync, readSync, readdirSync, realpathSync, statSync } from "fs";
 import { appendFile, lstat, mkdir, open, readFile, readdir, stat, unlink, writeFile } from "fs/promises";
-import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "path";
+import { basename, delimiter, dirname, extname, isAbsolute, join, relative, resolve } from "path";
 import { createHash } from "crypto";
 
 import { fileURLToPath, pathToFileURL } from "url";
@@ -9395,6 +9395,7 @@ function isAllowedOmxCleanupDryRunCommand(command: string): boolean {
 }
 
 function stateReadTrailingArgsAreSafe(trailing: string[]): boolean {
+  if (trailing.length === 1 && (trailing[0] === "--help" || trailing[0] === "-h" || trailing[0] === "help")) return true;
   let sawMode = false;
   let sawJson = false;
   for (let index = 0; index < trailing.length; index += 1) {
@@ -9456,12 +9457,7 @@ function extractOmxSparkshellDirectArgvCommand(args: readonly string[]): string 
 }
 
 function isAllowedOmxSparkshellWrappedReadOnlyCommand(wrappedCommand: string): boolean {
-  // sparkshell dispatches the wrapped argv through a native sidecar binary
-  // resolved via OMX_SPARKSHELL_BIN (overridable) rather than executing the
-  // wrapped argv directly; an inherited override could substitute an
-  // attacker-controlled sidecar for the one that scrutiny assumes runs the
-  // literal wrapped argv, so this allowance requires no override is present.
-  if (safeString(process.env.OMX_SPARKSHELL_BIN).trim() !== "") return false;
+  if ([...OMX_SPARKSHELL_IMPLEMENTATION_ENV_NAMES].some(environmentNameIsPresent)) return false;
   return !commandHasDeepInterviewWriteIntent(wrappedCommand)
     && !commandHasNestedCliMutationIntent(wrappedCommand)
     && collectOmxStateCommandOperations(wrappedCommand, "write").length === 0;
@@ -9481,6 +9477,38 @@ function isAllowedOmxSparkshellWrappedReadOnlyCommand(wrappedCommand: string): b
 // command-word grammar, function-shadow rejection, and inherited
 // NODE_OPTIONS/OPENSSL_CONF/Node-output-environment checks) so both paths
 // can never drift apart.
+
+const OMX_SPARKSHELL_IMPLEMENTATION_ENV_NAMES = new Set([
+  "OMX_SPARKSHELL_BIN",
+  "OMX_NATIVE_CACHE_DIR",
+  "OMX_NATIVE_MANIFEST_URL",
+  "OMX_NATIVE_RELEASE_BASE_URL",
+  "OMX_NATIVE_AUTO_FETCH",
+  "XDG_CACHE_HOME",
+  "LOCALAPPDATA",
+]);
+
+function environmentNameIsPresent(name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(process.env, name);
+}
+
+function commandHasLeadingEnvironmentName(command: string, names: ReadonlySet<string>): boolean {
+  const segments = splitShellCommandSegments(
+    stripHeredocBodiesForCommandScan(normalizeShellLineContinuations(command)),
+  );
+  for (const segment of segments) {
+    const words = tokenizeShellWords(segment);
+    const commandIndex = findWrappedCommandPositionIndex(words, 0);
+    const prefix = commandIndex === null ? words : words.slice(0, commandIndex);
+    if (prefix.some((word) => isEnvironmentAssignmentWord(word) && names.has(shellAssignmentName(word)))) return true;
+  }
+  return false;
+}
+
+function sparkshellImplementationOverrideIsPresent(command?: string): boolean {
+  if ([...OMX_SPARKSHELL_IMPLEMENTATION_ENV_NAMES].some(environmentNameIsPresent)) return true;
+  return command ? commandHasLeadingEnvironmentName(command, OMX_SPARKSHELL_IMPLEMENTATION_ENV_NAMES) : false;
+}
 const OMX_GJC_TRUSTED_CONTEXT_UNSAFE_INHERITED_ENV_NAMES = [
   "NODE_OPTIONS",
   "OPENSSL_CONF",
@@ -9512,18 +9540,63 @@ function isTrustedOmxOrGjcReadOnlyInvocation(command: string, cwd: string): bool
   if (!isSingleLiteralShellInvocation(command)) return false;
   return omxOrGjcExecutionContextIsTrusted(command, cwd, ["omx", "gjc"]);
 }
+const OMX_NESTED_HELP_COMMANDS = new Set([
+  "adapt",
+  "agents",
+  "agents-init",
+  "api",
+  "ask",
+  "autoresearch",
+  "autoresearch-goal",
+  "auth",
+  "capabilities",
+  "cleanup",
+  "deepinit",
+  "explore",
+  "hooks",
+  "hud",
+  "list",
+  "mcp-serve",
+  "mission",
+  "performance-goal",
+  "question",
+  "ralplan",
+  "ralph",
+  "resume",
+  "session",
+  "sidecar",
+  "sparkshell",
+  "state",
+  "team",
+  "tmux-hook",
+  "trace",
+  "ultragoal",
+  "url",
+  "wiki",
+]);
+const OMX_STATE_READ_ONLY_OPERATIONS = new Set(["read", "get-status"]);
+const OMX_HELP_TOKENS = new Set(["--help", "-h"]);
+
+function isAllowedOmxNestedHelpForm(args: readonly string[]): boolean {
+  if (args.length === 2 && OMX_NESTED_HELP_COMMANDS.has(args[0] ?? "")) {
+    return OMX_HELP_TOKENS.has(args[1] ?? "");
+  }
+  if (
+    args.length === 3
+    && args[0] === "state"
+    && OMX_STATE_READ_ONLY_OPERATIONS.has(args[1] ?? "")
+  ) {
+    return OMX_HELP_TOKENS.has(args[2] ?? "") || args[2] === "help";
+  }
+  return args.length === 2 && args[0] === "auth" && args[1] === "help";
+}
+
 // Shape-only recognizer (no trust check): true when `command` syntactically
-// looks like one of the omx/gjc read-only shapes this allowlist grants
-// (--help/-h/--version/-v, help/status/version, state read|status,
-// sparkshell direct-argv, cleanup --dry-run). Used so callers can hard-deny
-// a recognized-but-untrusted shape instead of silently falling through to
-// the generic write-intent scanner, which has no notion of this allowlist's
-// trust requirement and could independently (and wrongly) conclude "no
-// write intent" for an unrelated reason -- e.g. an inherited BASH_FUNC_omx%%
-// shell-function shadow can make the generic PATH-mutation scanner treat the
-// invocation as a shell function rather than a binary and skip its own
-// mutation classification entirely. A hard hard-deny here closes that
-// fallthrough regardless of what the generic scanner would otherwise infer.
+// resembles an OMX/GJC read-only surface or a recognized-but-sensitive
+// invocation that must be hard-denied when its strict parser form is not met.
+// It prevents the generic write-intent scanner from silently re-authorizing an
+// untrusted binary, shell-function shadow, invalid state spelling, or unsafe
+// sparkshell mode.
 function omxOrGjcReadOnlyShapeMatches(command: string): boolean {
   if (!isSingleLiteralShellInvocation(command)) return false;
   const words = literalInvocationWords(command);
@@ -9534,8 +9607,8 @@ function omxOrGjcReadOnlyShapeMatches(command: string): boolean {
   if (args.length === 0) return false;
   if (args.some((arg) => arg === "--help" || arg === "-h" || arg === "--version" || arg === "-v")) return true;
   if (args[0] === "help" || args[0] === "status" || args[0] === "version") return true;
-  if (args[0] === "state" && ["read", "status"].includes(args[1] ?? "")) return true;
-  if (extractOmxSparkshellDirectArgvCommand(args) !== null) return true;
+  if (args[0] === "state" && ["read", "get-status", "status"].includes(args[1] ?? "")) return true;
+  if (args[0] === "sparkshell") return true;
   return args[0] === "cleanup" && args.includes("--dry-run");
 }
 
@@ -9547,27 +9620,18 @@ function isAllowedOmxReadOnlyCommand(command: string, cwd: string): boolean {
   if (commandName !== "omx" && commandName !== "gjc") return false;
   const args = words.slice(index + 1).filter(Boolean);
   if (args.length === 0) return false;
-  // Sparkshell must be recognized before any generic "--help/--version
-  // anywhere in args" heuristic below: its wrapped argv belongs to a
-  // DIFFERENT program (e.g. `omx sparkshell -- ./mutate.sh --help`), and a
-  // `--help` meant for that wrapped script is not evidence the omx/gjc
-  // invocation itself is read-only.
-  const sparkshellWrapped = extractOmxSparkshellDirectArgvCommand(args);
-  if (sparkshellWrapped !== null) return isAllowedOmxSparkshellWrappedReadOnlyCommand(sparkshellWrapped);
-  // A bare top-level probe (`omx --help`, `omx -h`, `omx --version`,
-  // `omx -v`, and nothing else) never dispatches to a subcommand handler,
-  // so both help and version forms are safe here.
+
+  if (args[0] === "sparkshell") {
+    if (sparkshellImplementationOverrideIsPresent(command)) return false;
+    if (args.length === 2 && OMX_HELP_TOKENS.has(args[1] ?? "")) return true;
+    const sparkshellWrapped = extractOmxSparkshellDirectArgvCommand(args);
+    return sparkshellWrapped !== null && isAllowedOmxSparkshellWrappedReadOnlyCommand(sparkshellWrapped);
+  }
+
   if (args.length === 1 && (args[0] === "--help" || args[0] === "-h" || args[0] === "--version" || args[0] === "-v")) return true;
-  // `--help`/`-h` appearing anywhere is safe to recognize generically: every
-  // omx subcommand consulted (including `cleanup`) short-circuits real work
-  // before it runs when `--help`/`-h` is present, matching conventional CLI
-  // behavior. `--version`/`-v` is NOT universally safe the same way --
-  // `cleanup`, for example, never inspects them and falls through to real
-  // process/tmp cleanup -- so they are only trusted in the bare top-level
-  // form above, never as a trailing flag on an arbitrary subcommand.
-  if (args.some((arg) => arg === "--help" || arg === "-h")) return true;
-  if (args[0] === "help" || args[0] === "status" || args[0] === "version") return true;
-  if (args[0] === "state" && ["read", "status"].includes(args[1] ?? "")) {
+  if (args.length === 1 && (args[0] === "help" || args[0] === "status" || args[0] === "version")) return true;
+  if (isAllowedOmxNestedHelpForm(args)) return true;
+  if (args[0] === "state" && OMX_STATE_READ_ONLY_OPERATIONS.has(args[1] ?? "")) {
     return stateReadTrailingArgsAreSafe(args.slice(2));
   }
   return isAllowedOmxCleanupDryRunCommand(command);
@@ -11884,7 +11948,7 @@ function omxCliInvocationHasMutationIntent(words: string[], commandIndex: number
   const commandName = operands[0] ?? "";
   const subcommand = operands[1] ?? "";
   if (!commandName || ["help", "read", "status", "version"].includes(commandName)) return false;
-  if (commandName === "state" && ["read", "status"].includes(subcommand)) return false;
+  if (commandName === "state" && ["read", "get-status"].includes(subcommand)) return false;
   if (["deep-interview", "ralplan", "ralph", "team", "ultragoal"].includes(commandName) && ["read", "status"].includes(subcommand)) return false;
   return true;
 }
@@ -16756,18 +16820,42 @@ function conductorNativeExecutableHeaderIsRecognized(header: Buffer): boolean {
     || header.includes(0);
 }
 
+const CONDUCTOR_WINDOWS_DEFAULT_PATHEXT = [".COM", ".EXE", ".BAT", ".CMD"] as const;
+function conductorPathListDelimiter(): string {
+  return process.platform === "win32" ? ";" : delimiter;
+}
+// Windows resolves a bare command through PATHEXT; enumerate the actual suffix
+// order instead of treating `:` as a universal PATH separator or trusting a
+// basename without proving which executable the shell selected.
+
+function conductorExecutablePathCandidates(directory: string, commandName: string): string[] | null {
+  if (process.platform !== "win32") return [join(directory, commandName)];
+  const rawPathext = process.env.PATHEXT;
+  const suffixes = rawPathext === undefined || rawPathext === ""
+    ? [...CONDUCTOR_WINDOWS_DEFAULT_PATHEXT]
+    : rawPathext.split(conductorPathListDelimiter()).map((suffix) => suffix.trim().toUpperCase()).filter(Boolean);
+  if (suffixes.length === 0 || suffixes.some((suffix) => !/^\.[A-Z0-9]+$/.test(suffix))) return null;
+  return [
+    join(directory, commandName),
+    ...suffixes.map((suffix) => join(directory, `${commandName}${suffix.toLowerCase()}`)),
+  ];
+}
+
 function conductorResolvePathInterpreter(commandName: string, state: ShellPosixState): string | null {
   const path = getConductorShellBinding(state, "PATH").value;
   if (!path || path === CONDUCTOR_UNKNOWN_SHELL_BINDING) return null;
-  for (const entry of path.split(":")) {
+  for (const entry of path.split(conductorPathListDelimiter())) {
     if (!entry || !isAbsolute(entry) || isConductorStaticDirectoryInvalidated(state, resolve(entry))) return null;
-    const candidate = join(entry, commandName);
-    try {
-      accessSync(candidate, fsConstants.X_OK);
-      return candidate;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
-      return null;
+    const candidates = conductorExecutablePathCandidates(entry, commandName);
+    if (!candidates) return null;
+    for (const candidate of candidates) {
+      try {
+        accessSync(candidate, fsConstants.X_OK);
+        return candidate;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+        return null;
+      }
     }
   }
   return null;
@@ -16831,7 +16919,7 @@ function conductorPathMayResolveRepositoryExecutable(
   } catch {
     return true;
   }
-  for (const entry of path.split(":")) {
+  for (const entry of path.split(conductorPathListDelimiter())) {
     if (!entry || !isAbsolute(entry)) return true;
     let canonical: string;
     try {
@@ -16847,16 +16935,23 @@ function conductorPathMayResolveRepositoryExecutable(
       }
     }
 
-    const candidate = join(entry, commandName);
-    if (!existsSync(candidate)) {
+    const candidates = conductorExecutablePathCandidates(entry, commandName);
+    if (!candidates) return true;
+    let candidate: string | undefined;
+    for (const candidatePath of candidates) {
+      if (existsSync(candidatePath)) {
+        candidate = candidatePath;
+        break;
+      }
       try {
-        lstatSync(candidate);
+        lstatSync(candidatePath);
         return true;
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
-        return true;
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") return true;
       }
     }
+    if (!candidate) continue;
+
     // An invalidated PATH entry cannot affect resolution when it lacks this command.
     if (
       isConductorStaticDirectoryInvalidated(state, resolve(entry))
@@ -16941,7 +17036,7 @@ function conductorPackageCliHasTrustedNodeInterpreter(candidate: string, state: 
   }
   const path = getConductorShellBinding(state, "PATH").value;
   if (!path || path === CONDUCTOR_UNKNOWN_SHELL_BINDING) return false;
-  for (const entry of path.split(":")) {
+  for (const entry of path.split(conductorPathListDelimiter())) {
     if (!isAbsolute(entry) || isConductorStaticDirectoryInvalidated(state, resolve(entry))) return false;
     try {
       if (!statSync(realpathSync(entry)).isDirectory()) return false;
@@ -16949,16 +17044,22 @@ function conductorPackageCliHasTrustedNodeInterpreter(candidate: string, state: 
       if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
       return false;
     }
-    const nodeCandidate = join(entry, "node");
-    if (!existsSync(nodeCandidate)) {
+    const nodeCandidates = conductorExecutablePathCandidates(entry, "node");
+    if (!nodeCandidates) return false;
+    let nodeCandidate: string | undefined;
+    for (const candidatePath of nodeCandidates) {
+      if (existsSync(candidatePath)) {
+        nodeCandidate = candidatePath;
+        break;
+      }
       try {
-        lstatSync(nodeCandidate);
+        lstatSync(candidatePath);
         return false;
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
-        return false;
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") return false;
       }
     }
+    if (!nodeCandidate) continue;
     return conductorPackageCliNodeInterpreterIsTrusted(nodeCandidate, rootCwd);
   }
   return false;
@@ -16974,7 +17075,7 @@ function conductorResolvedPackageCliCandidateIsTrusted(
   const expectedCandidate = conductorKnownPackageCliPath(commandName);
   const path = getConductorShellBinding(state, "PATH").value;
   if (!path || path === CONDUCTOR_UNKNOWN_SHELL_BINDING) return false;
-  for (const entry of path.split(":")) {
+  for (const entry of path.split(conductorPathListDelimiter())) {
     if (!isAbsolute(entry)) return false;
     let binDirectory: string;
     try {
@@ -16988,16 +17089,22 @@ function conductorResolvedPackageCliCandidateIsTrusted(
         return false;
       }
     }
-    const candidate = join(binDirectory, commandName);
-    if (!existsSync(candidate)) {
+    const candidates = conductorExecutablePathCandidates(binDirectory, commandName);
+    if (!candidates) return false;
+    let candidate: string | undefined;
+    for (const candidatePath of candidates) {
+      if (existsSync(candidatePath)) {
+        candidate = candidatePath;
+        break;
+      }
       try {
-        lstatSync(candidate);
+        lstatSync(candidatePath);
         return false;
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
-        return false;
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") return false;
       }
     }
+    if (!candidate) continue;
     try {
       accessSync(candidate, fsConstants.X_OK);
       const trustedCli = expectedCandidate !== null && realpathSync(candidate) === expectedCandidate;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -9381,6 +9381,73 @@ function isAllowedOmxCleanupDryRunCommand(command: string): boolean {
     && args.every((arg, argIndex) => argIndex === 0 || arg === "--dry-run" || arg === "--json");
 }
 
+function stateReadTrailingArgsAreSafe(trailing: string[]): boolean {
+  let sawMode = false;
+  let sawJson = false;
+  for (let index = 0; index < trailing.length; index += 1) {
+    const arg = trailing[index] ?? "";
+    if (arg === "--json") {
+      if (sawJson) return false;
+      sawJson = true;
+      continue;
+    }
+    if (arg === "--mode") {
+      if (sawMode) return false;
+      const value = trailing[index + 1] ?? "";
+      if (!value || value.startsWith("-")) return false;
+      sawMode = true;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--mode=")) {
+      if (sawMode || !arg.slice("--mode=".length)) return false;
+      sawMode = true;
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+// Sparkshell's direct-argv dispatch (`omx sparkshell [--json] [--budget N] --
+// <argv...>`) executes the wrapped argv without shell reinterpretation, so
+// each wrapped word is already a literal token. Re-quoting those literal
+// tokens into a synthetic single-invocation command string lets the wrapped
+// invocation be re-scrutinized through the exact same write-intent checks
+// used for a directly-typed command, instead of trusting a bespoke allowlist.
+// `--shell`/`--tmux-pane`/any unrecognized sparkshell flag is refused (return
+// null) because those modes are not literal, bounded argv dispatch.
+function extractOmxSparkshellDirectArgvCommand(args: readonly string[]): string | null {
+  if (args[0] !== "sparkshell") return null;
+  let index = 1;
+  while (index < args.length) {
+    const arg = args[index] ?? "";
+    if (arg === "--") {
+      const wrapped = args.slice(index + 1);
+      if (wrapped.length === 0) return null;
+      return wrapped.map((word) => `'${word.replace(/'/g, `'\\''`)}'`).join(" ");
+    }
+    if (arg === "--json") {
+      index += 1;
+      continue;
+    }
+    if (arg === "--budget") {
+      const value = args[index + 1] ?? "";
+      if (!/^[1-9][0-9]*$/.test(value)) return null;
+      index += 2;
+      continue;
+    }
+    return null;
+  }
+  return null;
+}
+
+function isAllowedOmxSparkshellWrappedReadOnlyCommand(wrappedCommand: string): boolean {
+  return !commandHasDeepInterviewWriteIntent(wrappedCommand)
+    && !commandHasNestedCliMutationIntent(wrappedCommand)
+    && collectOmxStateCommandOperations(wrappedCommand, "write").length === 0;
+}
+
 function isAllowedOmxReadOnlyCommand(command: string): boolean {
   if (!isSingleLiteralShellInvocation(command)) return false;
   const words = literalInvocationWords(command);
@@ -9391,8 +9458,10 @@ function isAllowedOmxReadOnlyCommand(command: string): boolean {
   if (args.some((arg) => arg === "--help" || arg === "-h" || arg === "--version" || arg === "-v")) return true;
   if (args[0] === "help" || args[0] === "status" || args[0] === "version") return true;
   if (args[0] === "state" && ["read", "status"].includes(args[1] ?? "")) {
-    return args.slice(2).every((arg) => arg === "--json");
+    return stateReadTrailingArgsAreSafe(args.slice(2));
   }
+  const sparkshellWrapped = extractOmxSparkshellDirectArgvCommand(args);
+  if (sparkshellWrapped !== null) return isAllowedOmxSparkshellWrappedReadOnlyCommand(sparkshellWrapped);
   return isAllowedOmxCleanupDryRunCommand(command);
 }
 
@@ -9418,14 +9487,17 @@ function isAllowedGhReadOnlyCommand(command: string): boolean {
 function isAllowedDeepInterviewCommandSpecificBash(
   payload: CodexHookPayload,
   command: string,
+  cwd: string,
 ): boolean {
   const questionClassification = classifyOmxQuestionPreToolUse(command, payload);
   if (questionClassification.kind === "allowed") return true;
-  // A command shaped like direct cancellation must never fall through to a
-  // generic allowance: when the trusted execution context cannot be proven,
-  // the exemption denies rather than degrading to the ordinary benign path.
+  // Parity with the ralplan/Conductor trusted direct-cancel path (#3313): a
+  // standalone (non-Autopilot-supervised) deep-interview session has no
+  // hook-owned cancellation handler, so `omx cancel` must still reach the
+  // same trusted-execution-context check ralplan already applies rather than
+  // being denied unconditionally. An unproven execution context still denies.
   if (readPreToolUseRawCommand(payload) === command && isDirectOmxCancelCommand(command)) {
-    return false;
+    return directOmxCancelCommandHasTrustedExecutionContext(command, cwd);
   }
   return isAllowedOmxReadOnlyCommand(command)
     || isAllowedGhReadOnlyCommand(command)
@@ -9491,7 +9563,7 @@ function isAllowedDeepInterviewBashWrite(
     // compound/redirect/substitution form is denied so it cannot smuggle a mutation.
     return questionClassification.kind === "allowed" && isSingleLiteralShellInvocation(command);
   }
-  if (payload && isAllowedDeepInterviewCommandSpecificBash(payload, command)) return true;
+  if (payload && isAllowedDeepInterviewCommandSpecificBash(payload, command, cwd)) return true;
   if (sourcesFileWrittenEarlierInSameCommand(cwd, command)) return false;
   const stateWriteOperations = collectOmxStateCommandOperations(command, "write");
   const hasUnsafeRuntimeStateWrite = (words: string[]): boolean => {
@@ -9666,6 +9738,12 @@ function isAllowedRalplanBashWrite(
   // executable, preload code, or redirect a state tree.
   if (rawCommand === command && isDirectOmxCancelCommand(command, { allowForce: true })) {
     return directOmxCancelCommandHasTrustedExecutionContext(command, cwd);
+  }
+  // Read-only discovery (help/version/status/read, sparkshell-wrapped
+  // read-only argv, and gh read-only commands) is not implementation intent
+  // and must not be misclassified as a write during ralplan planning (#3314).
+  if (isAllowedOmxReadOnlyCommand(command) || isAllowedGhReadOnlyCommand(command) || isAllowedVersionProbeCommand(command)) {
+    return true;
   }
 
   const beadsCommand = classifyRalplanBeadsMetadataCommand(cwd, command);

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -9374,7 +9374,7 @@ function isAllowedOmxCleanupDryRunCommand(command: string): boolean {
   if (!isSingleLiteralShellInvocation(command)) return false;
   const words = literalInvocationWords(command);
   const index = skipLiteralLeadingAssignments(words);
-  if (commandNameFromShellWord(words[index] ?? "") !== "omx") return false;
+  if (!["omx", "gjc"].includes(commandNameFromShellWord(words[index] ?? ""))) return false;
   const args = words.slice(index + 1).filter(Boolean);
   return args[0] === "cleanup"
     && args.includes("--dry-run")
@@ -9448,11 +9448,31 @@ function isAllowedOmxSparkshellWrappedReadOnlyCommand(wrappedCommand: string): b
     && collectOmxStateCommandOperations(wrappedCommand, "write").length === 0;
 }
 
-function isAllowedOmxReadOnlyCommand(command: string): boolean {
+// The read-only allowlist (help/version/status/read, sparkshell-wrapped
+// discovery) must not authorize based on the bare `omx`/`gjc` basename alone:
+// an attacker-controlled PATH prefix or a path-qualified impostor executable
+// could otherwise be granted this allowance regardless of what it actually
+// does, since the caller returns immediately on a positive match. Require the
+// same trusted-package-CLI execution-context proof already used for the
+// direct-cancel path before any read-only shape is even considered.
+function isTrustedOmxOrGjcReadOnlyInvocation(command: string, cwd: string): boolean {
   if (!isSingleLiteralShellInvocation(command)) return false;
+  if (commandHasUnsafeLeadingRuntimeEnvironment(command)) return false;
+  if (commandHasUnsafeConductorShellState(command, cwd)) return false;
+  if (commandHasUnsafeDynamicLoaderEnvironment(command)) return false;
+  const words = tokenizeConductorShellWords(command);
+  const index = skipShellCommandPositionPrefixWords(words, 0);
+  const commandName = commandNameFromShellWord(words[index] ?? "");
+  if (commandName !== "omx" && commandName !== "gjc") return false;
+  return conductorCommandResolvesTrustedPackageCli(words, 0, index, createConductorRuntimeShellState(cwd), cwd);
+}
+
+function isAllowedOmxReadOnlyCommand(command: string, cwd: string): boolean {
+  if (!isTrustedOmxOrGjcReadOnlyInvocation(command, cwd)) return false;
   const words = literalInvocationWords(command);
   const index = skipLiteralLeadingAssignments(words);
-  if (commandNameFromShellWord(words[index] ?? "") !== "omx") return false;
+  const commandName = commandNameFromShellWord(words[index] ?? "");
+  if (commandName !== "omx" && commandName !== "gjc") return false;
   const args = words.slice(index + 1).filter(Boolean);
   if (args.length === 0) return false;
   if (args.some((arg) => arg === "--help" || arg === "-h" || arg === "--version" || arg === "-v")) return true;
@@ -9499,7 +9519,7 @@ function isAllowedDeepInterviewCommandSpecificBash(
   if (readPreToolUseRawCommand(payload) === command && isDirectOmxCancelCommand(command)) {
     return directOmxCancelCommandHasTrustedExecutionContext(command, cwd);
   }
-  return isAllowedOmxReadOnlyCommand(command)
+  return isAllowedOmxReadOnlyCommand(command, cwd)
     || isAllowedGhReadOnlyCommand(command)
     || isAllowedVersionProbeCommand(command);
 }
@@ -9742,7 +9762,7 @@ function isAllowedRalplanBashWrite(
   // Read-only discovery (help/version/status/read, sparkshell-wrapped
   // read-only argv, and gh read-only commands) is not implementation intent
   // and must not be misclassified as a write during ralplan planning (#3314).
-  if (isAllowedOmxReadOnlyCommand(command) || isAllowedGhReadOnlyCommand(command) || isAllowedVersionProbeCommand(command)) {
+  if (isAllowedOmxReadOnlyCommand(command, cwd) || isAllowedGhReadOnlyCommand(command) || isAllowedVersionProbeCommand(command)) {
     return true;
   }
 

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -6531,17 +6531,20 @@ function tokenizeShellWords(segment: string): string[] {
       }
       continue;
     }
-    // Bash's own lexer only treats ASCII space/tab (and newline as a
-    // statement terminator already normalized upstream) as word-separating
-    // blanks; it does NOT split on other Unicode whitespace (NBSP U+00A0,
-    // BOM U+FEFF, Zs-class spaces, U+2028/2029, etc). JS regex `\s` matches
-    // all of those, which previously let an embedded Unicode whitespace
-    // character make this tokenizer see two words ("omx", "--help") while
-    // Bash resolves and executes a single differently-named executable
-    // ("omx<NBSP>--help") -- silently borrowing a trusted lookup for a
-    // different, attacker-controlled binary. Restrict this split to the
-    // literal ASCII blank set Bash actually recognizes.
-    if (!quote && (char === " " || char === "\t" || char === "\n" || char === "\r" || char === "\v" || char === "\f")) {
+    // Bash's own lexer treats ONLY ASCII space, tab, and newline as
+    // word-separating blanks. It does NOT split on any other whitespace --
+    // not Unicode whitespace (NBSP U+00A0, BOM U+FEFF, Zs-class spaces,
+    // U+2028/2029), and not other ASCII control characters either (CR, VT,
+    // FF are literal bytes within a word to Bash, confirmed empirically via
+    // `bash -c`). JS regex `\s` (and an earlier, still-too-broad fix that
+    // additionally special-cased CR/VT/FF) previously let an embedded
+    // whitespace/control character make this tokenizer see two words
+    // ("omx", "--help") while Bash resolves and executes a single,
+    // differently-named executable ("omx<NBSP>--help", "omx<VT>--help",
+    // etc.) -- silently borrowing a trusted lookup for a different,
+    // attacker-controlled binary. Restrict this split to exactly the three
+    // characters Bash's own lexer recognizes as blanks.
+    if (!quote && (char === " " || char === "\t" || char === "\n")) {
       pushCurrent();
       continue;
     }


### PR DESCRIPTION
## Summary

Both issues share one root cause in `src/scripts/codex-native-hook.ts`: `commandHasDeepInterviewWriteIntent()` treats every recognized `omx`/`gjc` shell invocation shape as write intent via the generic `extractConductorBashMutations()` scan, without consulting the existing `--help`/`-h`/`--version`/`read`/`status` allowlist that `omxCliInvocationHasMutationIntent()` already implements correctly. `isAllowedDeepInterviewBashWrite`/`isAllowedRalplanBashWrite` never routed enough command shapes through that allowlist, so several genuinely read-only or documented-lifecycle commands were denied.

Fixes (all in `src/scripts/codex-native-hook.ts`):

- **`omx state read --mode <mode> --json` was denied.** `isAllowedOmxReadOnlyCommand()`'s `state read|status` branch only tolerated a bare `--json`. Added `stateReadTrailingArgsAreSafe()` to accept `--mode <value>` / `--mode=<value>` alongside `--json`.
- **`omx cancel` was unconditionally denied in standalone (non-Autopilot) deep-interview.** `isAllowedDeepInterviewCommandSpecificBash()` now routes it through the same `directOmxCancelCommandHasTrustedExecutionContext()` trust check ralplan already uses, instead of `return false` unconditionally. An unproven execution context (PATH smuggling, untrusted shim, etc.) still denies.
- **`omx sparkshell -- <read-only argv>` had no recognition path.** Sparkshell's direct-argv dispatch mode (`omx sparkshell [--json] [--budget N] -- <argv>`) executes the wrapped argv without shell reinterpretation, so each wrapped token is already literal. Added `extractOmxSparkshellDirectArgvCommand()` to re-quote the wrapped literal argv into a synthetic command string and re-run it through the *same* write-intent classifiers used for a directly-typed command (`isAllowedOmxSparkshellWrappedReadOnlyCommand()`), instead of trusting a bespoke allowlist. `--shell` / `--tmux-pane` / any unrecognized sparkshell flag is refused (not unwrapped), so only bounded literal-argv dispatch is reclassified — a wrapped mutation command (e.g. `omx sparkshell -- bash -c 'echo x > f'`) still denies.
- **Ralplan had no read-only allowlist at all.** Even `omx --help` / `omx ralplan --help` were denied during active ralplan planning. `isAllowedRalplanBashWrite()` now has the same early-return read-only check (`isAllowedOmxReadOnlyCommand` / `isAllowedGhReadOnlyCommand` / `isAllowedVersionProbeCommand`) deep-interview already had.

## What stays denied (unchanged, verified in tests)

- Raw redirects into `.omx/state/sessions/**` (protected planning state).
- Active-state override writes via `omx state write` while a workflow is active.
- Native-child / foreign / path / PATH-prefix-smuggling denials, including a `PATH="..." omx cancel` inline-assignment attempt.
- Sparkshell `--shell` mode and sparkshell-wrapped mutation commands.

## Regression coverage

Added two payload-realistic tests to `src/scripts/__tests__/codex-native-hook.test.ts`:

- `issue #3313/#3314 permits standalone deep-interview lifecycle reachability and read-only discovery without relaxing write guards`
- `issue #3314 permits ralplan planning read-only discovery without relaxing write guards`

Both exercise the actual `dispatchCodexNativeHook` PreToolUse path against a **process-wide trusted PATH** pointing at a symlinked `dist/cli/omx.js` (matching the `withTrustedWorkspaceOmxCli` pattern used elsewhere in the suite), not an inline `PATH=... omx` assignment and not a manually short-circuited fixture — addressing #3314's reported live-runtime discrepancy where a synthetic-fixture-only verification missed real blocks.

## Verification

- `npm run build` — clean
- `npm run lint` — clean (biome)
- `npm run check:no-unused` — clean (tsc no-unused)
- Focused: `node --test --test-name-pattern="issue #3313|issue #3314" dist/scripts/__tests__/codex-native-hook.test.js` — 2/2 pass
- Broad: `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js` — 618/618 pass (616 pre-existing + 2 new)
- `node dist/scripts/run-test-files.js dist/hooks/__tests__/keyword-detector.test.js dist/cli/__tests__/launch-fallback.test.js dist/team/__tests__/runtime.test.js dist/team/__tests__/hardening-e2e.test.js` — all pass

## Scope

Diff is limited to `src/scripts/codex-native-hook.ts` (fix) and `src/scripts/__tests__/codex-native-hook.test.ts` (tests). Does not touch #3316 (native collaboration transport classifier) or #3309 (ultragoal artifacts scope).

Closes #3313
Closes #3314