### PR TITLE
fail closed on unauthoritative plan bootstrap (#3309)

### DIFF
--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -68,6 +68,70 @@ async function capture(run: () => Promise<void>): Promise<{ stdout: string[]; st
 }
 
 describe('cli/ultragoal', () => {
+  it('does not create durable artifacts when OMX_SESSION_ID is unbound', async () => {
+    await withCwd(async (cwd) => {
+      const previousSessionId = process.env.OMX_SESSION_ID;
+      process.env.OMX_SESSION_ID = 'sess-unbound';
+      try {
+        const result = await capture(() => ultragoalCommand([
+          'create-goals',
+          '--brief',
+          '- First milestone',
+        ]));
+
+        assert.equal(result.exitCode, 1);
+        assert.match(result.stderr.join('\n'), /writable lifecycle authority/);
+        assert.match(result.stderr.join('\n'), /OMX_SESSION_ID is not bound to session\.json/);
+        assert.equal(existsSync(join(cwd, '.omx/ultragoal')), false);
+        assert.equal(existsSync(join(cwd, '.omx/ultragoal/brief.md')), false);
+        assert.equal(existsSync(join(cwd, '.omx/ultragoal/goals.json')), false);
+        assert.equal(existsSync(join(cwd, '.omx/ultragoal/ledger.jsonl')), false);
+      } finally {
+        if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
+        else delete process.env.OMX_SESSION_ID;
+      }
+    });
+  });
+
+  it('preserves an existing plan when unbound OMX_SESSION_ID rejects --force recreation', async () => {
+    await withCwd(async (cwd) => {
+      const previousSessionId = process.env.OMX_SESSION_ID;
+      delete process.env.OMX_SESSION_ID;
+      try {
+        const created = await capture(() => ultragoalCommand([
+          'create-goals',
+          '--brief',
+          '- Original milestone',
+        ]));
+        assert.equal(created.exitCode, undefined);
+
+        const artifactPaths = [
+          join(cwd, '.omx/ultragoal/brief.md'),
+          join(cwd, '.omx/ultragoal/goals.json'),
+          join(cwd, '.omx/ultragoal/ledger.jsonl'),
+        ];
+        const before = await Promise.all(artifactPaths.map((path) => readFile(path)));
+
+        process.env.OMX_SESSION_ID = 'sess-unbound-force';
+        const rejected = await capture(() => ultragoalCommand([
+          'create-goals',
+          '--brief',
+          '- Replacement milestone',
+          '--force',
+        ]));
+
+        assert.equal(rejected.exitCode, 1);
+        assert.match(rejected.stderr.join('\n'), /writable lifecycle authority/);
+        assert.match(rejected.stderr.join('\n'), /OMX_SESSION_ID is not bound to session\.json/);
+        const after = await Promise.all(artifactPaths.map((path) => readFile(path)));
+        assert.deepEqual(after, before);
+      } finally {
+        if (typeof previousSessionId === 'string') process.env.OMX_SESSION_ID = previousSessionId;
+        else delete process.env.OMX_SESSION_ID;
+      }
+    });
+  });
+
   it('refuses mutating ultragoal commands from Team worker environments', async () => {
     const mutators: string[][] = [
       ['create-goals', '--brief', 'worker must not create'],

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -2787,6 +2787,91 @@ describe('ultragoal artifacts', () => {
   });
 
 
+  it('preserves root-mode bootstrap when OMX_SESSION_ID is absent', async () => {
+    await withTempRepo(async (cwd) => {
+      const previousEnv = process.env.OMX_SESSION_ID;
+      delete process.env.OMX_SESSION_ID;
+      try {
+        const plan = await createUltragoalPlan(cwd, { brief: '- Root-mode goal' });
+
+        assert.equal(plan.goals.length, 1);
+        assert.equal(existsSync(join(cwd, '.omx/ultragoal/brief.md')), true);
+        assert.equal(existsSync(join(cwd, '.omx/ultragoal/goals.json')), true);
+        assert.equal(existsSync(join(cwd, '.omx/ultragoal/ledger.jsonl')), true);
+      } finally {
+        if (typeof previousEnv === 'string') process.env.OMX_SESSION_ID = previousEnv;
+        else delete process.env.OMX_SESSION_ID;
+      }
+    });
+  });
+
+  for (const [label, malformedSessionId] of [
+    ['path separator', 'bad/session'],
+    ['overlong value', 'x'.repeat(65)],
+  ] as const) {
+    it(`rejects root-mode bootstrap for a nonempty OMX_SESSION_ID with ${label}`, async () => {
+      await withTempRepo(async (cwd) => {
+        const previousEnv = process.env.OMX_SESSION_ID;
+        process.env.OMX_SESSION_ID = malformedSessionId;
+        try {
+          await assert.rejects(
+            () => createUltragoalPlan(cwd, { brief: '- Must not persist' }),
+            /OMX_SESSION_ID/,
+          );
+          assert.equal(existsSync(join(cwd, '.omx/ultragoal')), false);
+        } finally {
+          if (typeof previousEnv === 'string') process.env.OMX_SESSION_ID = previousEnv;
+          else delete process.env.OMX_SESSION_ID;
+        }
+      });
+    });
+  }
+
+  it('rejects a malformed OMX_SESSION_ID even when a live selected session exists', async () => {
+    await withTempRepo(async (cwd) => {
+      const previousEnv = process.env.OMX_SESSION_ID;
+      process.env.OMX_SESSION_ID = 'bad/session';
+      try {
+        const stateDir = join(cwd, '.omx', 'state');
+        await mkdir(stateDir, { recursive: true });
+        await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: 'sess-live', cwd }));
+
+        await assert.rejects(
+          () => createUltragoalPlan(cwd, { brief: '- Must not persist' }),
+          /OMX_SESSION_ID/,
+        );
+        assert.equal(existsSync(join(cwd, '.omx/ultragoal')), false);
+      } finally {
+        if (typeof previousEnv === 'string') process.env.OMX_SESSION_ID = previousEnv;
+        else delete process.env.OMX_SESSION_ID;
+      }
+    });
+  });
+
+  it('preserves unbound compatibility for mutations of an existing plan', async () => {
+    await withTempRepo(async (cwd) => {
+      const previousEnv = process.env.OMX_SESSION_ID;
+      delete process.env.OMX_SESSION_ID;
+      try {
+        await createUltragoalPlan(cwd, { brief: '- Initial goal' });
+
+        process.env.OMX_SESSION_ID = 'sess-compat';
+        const added = await addUltragoalGoal(cwd, {
+          title: 'Compatibility goal',
+          objective: 'Preserve the existing-plan compatibility path.',
+        });
+
+        assert.equal(added.plan.goals.length, 2);
+        assert.equal(added.goal.title, 'Compatibility goal');
+        const ledger = await readFile(join(cwd, '.omx/ultragoal/ledger.jsonl'), 'utf-8');
+        assert.match(ledger, /"event":"goal_added"/);
+      } finally {
+        if (typeof previousEnv === 'string') process.env.OMX_SESSION_ID = previousEnv;
+        else delete process.env.OMX_SESSION_ID;
+      }
+    });
+  });
+
   it('blocks durable ultragoal mutations while the selected pointer is stale-dead and no exact session is bound', async () => {
     await withTempRepo(async (cwd) => {
       const previousEnv = process.env.OMX_SESSION_ID;
@@ -2968,11 +3053,12 @@ describe('ultragoal artifacts', () => {
       const goalsPath = join(cwd, '.omx/ultragoal/goals.json');
       const ledgerPath = join(cwd, '.omx/ultragoal/ledger.jsonl');
       const lockPath = join(cwd, '.omx/ultragoal/.mutation.lock');
-      process.env.OMX_SESSION_ID = 'sess-compat';
+      delete process.env.OMX_SESSION_ID;
       try {
         await mkdir(stateDir, { recursive: true });
         await createUltragoalPlan(cwd, { brief: '- Initial goal' });
 
+        process.env.OMX_SESSION_ID = 'sess-compat';
         await writeFile(lockPath, 'held');
         setTimeout(() => { void rm(lockPath, { force: true }); }, 25);
         await addUltragoalGoal(cwd, { title: 'Stable compatibility authority', objective: 'Mutation proceeds.' });

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { appendFile, mkdir, open, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { isAbsolute, join, relative } from 'node:path';
-import { resolveWritableStateScope, WRITABLE_STATE_SCOPE_ERRORS } from '../mcp/state-paths.js';
+import { normalizeSessionId, resolveWritableStateScope, WRITABLE_STATE_SCOPE_ERRORS } from '../mcp/state-paths.js';
 import type { ResolvedStateScope } from '../mcp/state-paths.js';
 import {
   formatCodexGoalReconciliation,
@@ -868,9 +868,20 @@ function sleep(ms: number): Promise<void> {
  * the second check and before a filesystem write; unrelated resolver failures
  * propagate and block the mutation.
  */
-export async function assertUltragoalWritableLifecycleAuthority(cwd: string): Promise<UltragoalWritableAuthority> {
+export async function assertUltragoalWritableLifecycleAuthority(
+  cwd: string,
+  options: { allowUnboundEnvironment?: boolean } = {},
+): Promise<UltragoalWritableAuthority> {
   try {
+    const suppliedEnvironmentSessionId = process.env.OMX_SESSION_ID?.trim();
     const scope = await resolveWritableStateScope(cwd);
+    if (
+      options.allowUnboundEnvironment === false
+      && suppliedEnvironmentSessionId
+      && !normalizeSessionId(suppliedEnvironmentSessionId)
+    ) {
+      throw new Error(WRITABLE_STATE_SCOPE_ERRORS.unboundEnvironment);
+    }
     return {
       kind: 'resolved',
       source: scope.source,
@@ -878,18 +889,25 @@ export async function assertUltragoalWritableLifecycleAuthority(cwd: string): Pr
       stateDir: scope.stateDir,
     };
   } catch (error) {
-    if (error instanceof Error && error.message === WRITABLE_STATE_SCOPE_ERRORS.unusableSession) {
-      throw new UltragoalError(
-        `Refusing a durable ultragoal mutation before writable lifecycle authority is restored: ${error.message} Bind the exact current session (set OMX_SESSION_ID to the current session id); see docs/troubleshooting.md (stale session pointer recovery).`,
-      );
-    }
-    // Documented compatibility exception only: root-mode projects and unbound
-    // environments (no selected session pointer) keep their existing behavior.
-    // Every other resolver failure — allowlist violations, conflicting
-    // authoritative roots, live-owner binding mismatches, unexpected I/O
-    // errors — stays fail-closed and propagates.
-    if (error instanceof Error && error.message === WRITABLE_STATE_SCOPE_ERRORS.unboundEnvironment) {
+    // Existing-plan mutators keep the documented unbound compatibility path.
+    // Bootstrap callers opt out so failed state activation cannot create a new durable plan.
+    if (
+      error instanceof Error
+      && error.message === WRITABLE_STATE_SCOPE_ERRORS.unboundEnvironment
+      && options.allowUnboundEnvironment !== false
+    ) {
       return { kind: 'no-pointer-compat' };
+    }
+    if (
+      error instanceof Error
+      && (
+        error.message === WRITABLE_STATE_SCOPE_ERRORS.unusableSession
+        || error.message === WRITABLE_STATE_SCOPE_ERRORS.unboundEnvironment
+      )
+    ) {
+      throw new UltragoalError(
+        `Refusing a durable ultragoal mutation before writable lifecycle authority is restored: ${error.message} Restore the authoritative session binding so OMX_SESSION_ID matches the current session.json before retrying; see docs/troubleshooting.md (stale session pointer recovery).`,
+      );
     }
     throw error;
   }
@@ -913,8 +931,12 @@ function describeWritableAuthority(authority: UltragoalWritableAuthority): strin
     : `resolved(source=${authority.source}, sessionId=${authority.sessionId ?? 'undefined'}, stateDir=${authority.stateDir})`;
 }
 
-async function withUltragoalMutationLock<T>(cwd: string, operation: () => Promise<T>): Promise<T> {
-  const beforeLock = await assertUltragoalWritableLifecycleAuthority(cwd);
+async function withUltragoalMutationLock<T>(
+  cwd: string,
+  operation: () => Promise<T>,
+  options: { allowUnboundEnvironment?: boolean } = {},
+): Promise<T> {
+  const beforeLock = await assertUltragoalWritableLifecycleAuthority(cwd, options);
   await mkdir(ultragoalDir(cwd), { recursive: true });
   const lockPath = join(ultragoalDir(cwd), ULTRAGOAL_MUTATION_LOCK);
   let handle: Awaited<ReturnType<typeof open>> | undefined;
@@ -936,7 +958,7 @@ async function withUltragoalMutationLock<T>(cwd: string, operation: () => Promis
     // The post-lock comparison addresses pointer changes while waiting for this
     // lock only. A SessionStart publication can still land after it and before
     // the operation's filesystem writes.
-    const afterLock = await assertUltragoalWritableLifecycleAuthority(cwd);
+    const afterLock = await assertUltragoalWritableLifecycleAuthority(cwd, options);
     if (!writableAuthorityEquals(beforeLock, afterLock)) {
       throw new UltragoalError(
         `Refusing durable ultragoal mutation after writable lifecycle authority drift while waiting for the mutation lock: before lock ${describeWritableAuthority(beforeLock)}; after lock ${describeWritableAuthority(afterLock)}.`,
@@ -1080,7 +1102,7 @@ export async function createUltragoalPlan(cwd: string, options: CreateUltragoalO
   await writeFile(ultragoalLedgerPath(cwd), '');
   await appendLedger(cwd, { ts: now, event: 'plan_created', message: `${candidates.length} goal(s) created` });
   return plan;
-  });
+  }, { allowUnboundEnvironment: false });
 }
 
 export function summarizeUltragoalPlan(plan: UltragoalPlan): { total: number; pending: number; inProgress: number; complete: number; failed: number; reviewBlocked: number; historicalReviewBlocked: number; needsUserDecision: number; superseded: number; steeringBlocked: number; aggregateComplete: boolean; artifactComplete: boolean; activeGoalId?: string } {


### PR DESCRIPTION
## Summary

- reject new Ultragoal plan bootstrap when an explicit `OMX_SESSION_ID` is malformed or is not bound to authoritative `session.json`
- leave no `.omx/ultragoal` directory or durable plan artifacts after a fresh-bootstrap rejection
- preserve every existing plan artifact byte-for-byte when an unbound `--force` recreation is rejected
- preserve root-mode bootstrap and the existing-plan unbound compatibility path

## Scope

This is a fresh reconstruction of the same narrow bootstrap-authority slice from current `dev`, as requested when #3315 was closed:
https://github.com/Yeachan-Heo/oh-my-codex/pull/3315#issuecomment-5095600155

Base SHA: `7f8b17d0111cfe5794567cea3c806bdbfb21f955`

The patch is limited to `createUltragoalPlan()` authority enforcement and its focused regression tests. Existing-plan mutators retain their documented unbound compatibility behavior; this does not broaden lifecycle policy or attempt terminal-state convergence.

The stable patch ID matches the final focused patch from #3315: `faa9210cc36fd72838ec8f7db986c7dec1291e19`.

## Test intent

The tests lock these contracts:

1. explicit unbound or malformed session -> bootstrap rejects before publication
2. rejection is atomic -> no new `.omx/ultragoal` directory or durable artifacts
3. `--force` does not bypass authority -> existing artifacts remain byte-for-byte unchanged
4. valid authoritative session binding succeeds regardless of state-directory scope
5. root-mode bootstrap and existing-plan unbound mutation compatibility remain unchanged

## Verification

- 173/173 related tests pass
  - CLI Ultragoal
  - Ultragoal artifacts
  - state paths
- build passes
- lint passes across 788 files
- TypeScript `--noEmit` passes
- no-unused check passes
- `git diff --check` passes

## Local full-suite note

The complete 405-file local run finished with four unrelated failing files:

- `launch-fallback`: four macOS failures because BSD `script` rejects GNU-only `script -c`
- `uninstall`: two Windows-path durability fixtures fail under local POSIX path semantics
- `codex-native-hook`: one unchanged Conductor/PATH assertion is affected by the surrounding active OMX App workspace
- `smoke-packed-install`: one timing-sensitive assertion reaches the 5s global deadline before the PATH-candidate budget

No local full-suite green claim is made.

## Hosted exact-head CI

All applicable checks passed on exact head `1cc7008d8089c77017a10200da38a9efffa3a8b7`, including all Node test lanes, Team coverage, build, lint, typecheck, Ralplan security preflight, Ralph persistence, and native cache integrity on Ubuntu, macOS, and Windows.

This PR intentionally remains draft so the author can perform the Ready for Review transition.

Related to #3309. Supersedes #3315.
