### PR TITLE
test(scripts): make PATH candidate-budget smoke test deterministic

### DIFF
--- a/src/scripts/__tests__/smoke-packed-install.test.ts
+++ b/src/scripts/__tests__/smoke-packed-install.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from 'node:assert/strict';
-import { access, chmod, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { EventEmitter } from 'node:events';
 import { tmpdir } from 'node:os';
 import { delimiter, join } from 'node:path';
@@ -714,24 +714,40 @@ test('packed lifecycle fails before probing the 33rd unique PATH candidate', asy
   if (process.platform === 'win32') return;
   const root = await mkdtemp(join(tmpdir(), 'omx-codex-candidate-budget-'));
   const candidateDirs = Array.from({ length: 33 }, (_value, index) => join(root, `candidate-${index}`));
-  const thirtyThirdProbe = join(root, '33rd-candidate-was-probed');
+  // Duplicate the first PATH entry twice to demonstrate that PATH de-duplication
+  // (by resolved candidate path) does not consume extra candidate-budget slots,
+  // while still preserving first-occurrence probing order.
+  const pathValue = [candidateDirs[0], candidateDirs[0], ...candidateDirs].join(delimiter);
+  const spawnedExecutables: string[] = [];
+  const spawnSyncImpl = ((command: string) => {
+    spawnedExecutables.push(command);
+    return { status: 1, stdout: '', stderr: '', error: undefined };
+  }) as never;
   try {
     await Promise.all(candidateDirs.map((dir) => mkdir(dir, { recursive: true })));
-    await Promise.all(candidateDirs.map(async (dir, index) => {
+    await Promise.all(candidateDirs.map(async (dir) => {
       const executable = join(dir, 'codex');
-      await writeFile(
-        executable,
-        index === candidateDirs.length - 1
-          ? `#!/bin/sh\n: > ${JSON.stringify(thirtyThirdProbe)}\nprintf '%s\\n' 'codex-cli 0.142.5'\n`
-          : '#!/bin/sh\nexit 1\n',
-      );
+      // These candidates are never actually executed: spawnSyncImpl is a
+      // deterministic seam that returns an immediate nonzero result without
+      // starting a real shell process. Only filesystem presence is real.
+      await writeFile(executable, '#!/bin/sh\nexit 1\n');
       await chmod(executable, 0o755);
     }));
     assert.throws(
-      () => probeCodexVersion(root, { PATH: candidateDirs.join(delimiter) }),
+      () => probeCodexVersion(root, { PATH: pathValue }, { spawnSyncImpl }),
       /32-candidate PATH budget/,
     );
-    await assert.rejects(access(thirtyThirdProbe));
+    assert.equal(spawnedExecutables.length, 32, 'must probe exactly 32 unique candidates before the budget error');
+    assert.deepEqual(
+      spawnedExecutables,
+      candidateDirs.slice(0, 32).map((dir) => join(dir, 'codex')),
+      'must probe unique candidates in PATH order, with the duplicated first entry counted only once',
+    );
+    const thirtyThirdExecutable = join(candidateDirs[32], 'codex');
+    assert.ok(
+      !spawnedExecutables.includes(thirtyThirdExecutable),
+      'the 33rd unique candidate must never be spawned',
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #3329

## Summary
- Replaced 32 real shell process startups in `packed lifecycle fails before probing the 33rd unique PATH candidate` (`src/scripts/__tests__/smoke-packed-install.test.ts`) with a deterministic `spawnSyncImpl` seam (existing `CodexCommandSpawnSeam` on `probeCodexVersion`) that returns an immediate nonzero result and records every invocation.
- Assertions now check: exactly 32 unique candidates probed, in PATH order; the 33rd unique candidate is never spawned; and the exact `/32-candidate PATH budget/` error is thrown.
- A duplicated leading PATH entry demonstrates PATH de-duplication still holds (dedup doesn't consume extra budget slots) and that first-occurrence probing order is preserved.
- The separate real-process `packed lifecycle bounds all slow Codex candidates with a global deadline` test (5000ms deadline, real `sleep 30` processes) is untouched, so timing/termination behavior stays exercised.
- No production resolver code changed (`src/scripts/smoke-packed-install.ts` untouched); scope is test-only.

## Verification
- Target test run 3x consecutively via `node --test` (repo's `dist/scripts/run-test-files.js` runner): pass, ~13-15ms each (down from real-process latency).
- Full `smoke-packed-install.test.ts` (48 tests) run via `node dist/scripts/run-test-files.js` and via `node --test --test-concurrency=8`: all pass, no cross-test contamination.
- Full smoke file re-run with `TMPDIR` pointed at a private temp root: pass.
- `npm run lint` (biome): clean.
- `npx tsc --noEmit -p tsconfig.no-unused.json`: clean (no unused symbols, including the now-unused `access` import removed from the test file).
- `npm run build`: clean.
- `git diff` scoped to exactly `src/scripts/__tests__/smoke-packed-install.test.ts`.
- Checked overlap with #3327 (`triage/issue-3327-macos-fixture-roots`): branch is still at `dev` HEAD with no changes to this file, so no conflict; this file remains owned only by this lane.

Base: `dev` @ `7f8b17d0`. Does not merge automatically.