### PR TITLE
fix(state): bounded exact-match recovery for identity-indeterminate pointers

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -88,7 +88,8 @@ Do not force-shutdown a team that may still have useful live panes or worker sta
 
 ## Stale session pointer blocks state writes (`session.json is present but unusable`)
 
-State writes fail closed with `Cannot resolve writable state scope: session.json is present but unusable.` when a stale-dead selected pointer lacks a valid `OMX_SESSION_ID` binding, or when the pointer is malformed, belongs to a different working directory, or has indeterminate identity. Malformed, foreign-working-directory, and identity-indeterminate pointers always fail closed. Durable Ultragoal mutations (`goals.json` story/goal transitions) perform point-in-time writable-authority checks at mutation entry and after lock acquisition; a later SessionStart publication can still interleave before filesystem writes.
+State writes fail closed with `Cannot resolve writable state scope: session.json is present but unusable.` when a stale-dead selected pointer lacks a valid `OMX_SESSION_ID` binding, or when the pointer is malformed, belongs to a different working directory, or has indeterminate identity without the bounded exact-session reconciliation described below. Malformed and foreign-working-directory pointers always fail closed; identity-indeterminate pointers have only the narrow exact-session recovery path described below. Durable Ultragoal mutations (`goals.json` story/goal transitions) perform point-in-time writable-authority checks at mutation entry and after lock acquisition; a later SessionStart publication can still interleave before filesystem writes.
+
 
 ### Exact-session reconciliation (stale-dead pointer)
 
@@ -101,13 +102,17 @@ omx state write --input '{"mode":"ultragoal","active":true,"current_phase":"revi
 
 A stale-dead pointer holds no owner authority, so the validated `OMX_SESSION_ID` binding becomes the writable session scope (state lands under `.omx/state/sessions/<current-session-id>/`). The binding is operator-asserted: the code proves the pointer is definitively dead and authoritative, not that the env value names your live session — set it to the exact current session id. Recovery additionally requires the dead pointer itself to be authoritative for this project: its recorded `cwd` must contain the working directory, and its recorded `state_root` — when present — must canonical-match the selected state root (legacy pointers without `state_root` are accepted only when the cwd-derived `.omx/state` root matches exactly). A pointer with missing or foreign authority metadata stays fail-closed even with an env binding. Scope resolution never rewrites `session.json` itself; only a SessionStart hook reconciles the pointer through the normal pointer-lock protocol. Note that a plain OMX relaunch with a stale-dead pointer aborts with `session_pointer_unusable`/`stale-dead` and preserves the pointer, so setting `OMX_SESSION_ID` explicitly is the reliable recovery path.
 
+### Exact-session reconciliation (identity-indeterminate pointer)
+
+When the pointer's identity is indeterminate, recovery requires the same cwd/state_root authority as stale-dead recovery: the recorded `cwd` must contain the working directory, and the recorded `state_root` — when present — must canonical-match the selected state root (legacy pointers without `state_root` are accepted only when the cwd-derived `.omx/state` root matches exactly). In addition, `OMX_SESSION_ID` must exactly equal the pointer's own recorded `session_id`; no alias resolution is accepted. This is narrower than stale-dead recovery, which accepts any validated binding because a dead owner holds no authority. An identity-indeterminate owner might still be alive, so recovery requires the binding to already match the pointer's own claimed identity, not merely be validated. Scope resolution still never rewrites `session.json`; only a SessionStart hook reconciles the pointer through the normal pointer-lock protocol.
+
 ### Known limitation
 
 Pre-commit scope revalidation is a point-in-time check: it reduces but does not eliminate the window between validation and the filesystem commit. A completion that touches several files is not atomic, so a concurrent SessionStart publication can still interleave. Fully addressing this is separate follow-up work: `state: serialize writable commits with SessionStart pointer publication`.
 
 ### Still fail-closed
 
-- A malformed, foreign-working-directory, or identity-indeterminate pointer always requires operator inspection; `OMX_SESSION_ID` does not override it.
+- Malformed and foreign-working-directory pointers always fail closed. An identity-indeterminate pointer also fails closed unless `OMX_SESSION_ID` exactly matches the pointer's own `session_id` and cwd/state_root authority already holds; see **Exact-session reconciliation (identity-indeterminate pointer)**.
 - Without an env binding, a stale-dead pointer still blocks writes — set `OMX_SESSION_ID` (a plain relaunch aborts instead of reconciling; only a SessionStart hook reconciles the pointer).
 - A live pointer with an unmatched `OMX_SESSION_ID` fails closed as `OMX_SESSION_ID does not match the live session recorded in session.json`.
 - Durable Ultragoal mutations (including the legacy aggregate-objective migration that used to run on plain reads) require successful writable-scope resolution: with no selected pointer they keep prior root/unbound behavior, but allowlist violations, conflicting roots, and live-owner mismatches now propagate instead of being ignored.

--- a/src/mcp/__tests__/state-paths.test.ts
+++ b/src/mcp/__tests__/state-paths.test.ts
@@ -1038,6 +1038,31 @@ describe('state paths', () => {
         await rm(wd, { recursive: true, force: true });
       }
     });
+    it('recovers writable scope for an identity-indeterminate pointer with an exact-match OMX_SESSION_ID', async () => {
+      const wd = await mkRealTemp('omx-writable-indeterminate-exact-');
+      __setSessionPointerTransactionDependenciesForTests({ probePid: () => 'indeterminate' });
+      try {
+        const stateDir = getBaseStateDir(wd);
+        const sessionPath = join(stateDir, 'session.json');
+        await mkdir(stateDir, { recursive: true });
+        const pointerBody = JSON.stringify({ session_id: 'sess-exact', cwd: wd, pid: 8388607 });
+        await writeFile(sessionPath, pointerBody);
+        const beforePointer = await readFile(sessionPath, 'utf-8');
+        const beforeEntries = (await readdir(stateDir)).sort();
+        process.env.OMX_SESSION_ID = 'sess-exact';
+
+        assert.deepEqual(await resolveWritableStateScope(wd), {
+          source: 'session',
+          sessionId: 'sess-exact',
+          stateDir: join(stateDir, 'sessions', 'sess-exact'),
+        });
+        assert.equal(await readFile(sessionPath, 'utf-8'), beforePointer);
+        assert.deepEqual((await readdir(stateDir)).sort(), beforeEntries);
+      } finally {
+        __resetSessionPointerTransactionDependenciesForTests();
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
     it('fails closed for an identity-indeterminate pointer even with an env binding', async () => {
       const wd = await mkRealTemp('omx-writable-indeterminate-env-');
       __setSessionPointerTransactionDependenciesForTests({ probePid: () => 'indeterminate' });
@@ -1162,6 +1187,35 @@ describe('writable state scope recovery and revalidation', () => {
     }
   });
 
+  it('fails closed when the pointer bytes change during identity-indeterminate exact-match recovery', async () => {
+    const wd = await mkRealTemp('omx-writable-indeterminate-unstable-');
+    __setSessionPointerTransactionDependenciesForTests({ probePid: () => 'indeterminate' });
+    try {
+      const stateDir = getBaseStateDir(wd);
+      const sessionPath = join(stateDir, 'session.json');
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(sessionPath, JSON.stringify({ session_id: 'sess-indeterminate', cwd: wd, pid: 8388607 }));
+      process.env.OMX_SESSION_ID = 'sess-indeterminate';
+      __setWritableStateScopeTestHooksForTests({
+        beforeRecoveryReread: async () => {
+          await writeFile(sessionPath, JSON.stringify({ session_id: 'sess-indeterminate', cwd: wd, pid: 9999999 }));
+        },
+      });
+      await assert.rejects(
+        () => resolveWritableStateScope(wd),
+        (error: unknown) => {
+          assert.equal((error as Error).message, WRITABLE_STATE_SCOPE_ERRORS.unusableSession);
+          return true;
+        },
+      );
+      assert.equal(existsSync(join(stateDir, 'sessions', 'sess-indeterminate')), false);
+    } finally {
+      __setWritableStateScopeTestHooksForTests({});
+      __resetSessionPointerTransactionDependenciesForTests();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('T12 leaves the stale-dead pointer and base state root entries unchanged during recovery', async () => {
     const wd = await mkRealTemp('omx-writable-pointer-immutable-');
     __setSessionPointerTransactionDependenciesForTests({ probePid: () => 'dead' });
@@ -1205,6 +1259,36 @@ describe('writable state scope recovery and revalidation', () => {
           },
         );
         assert.equal(existsSync(join(stateDir, 'sessions', 'sess-current')), false, testCase.name);
+      }
+    } finally {
+      __setWritableStateScopeTestHooksForTests({});
+      __resetSessionPointerTransactionDependenciesForTests();
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed for identity-indeterminate pointer without selected-root authority even with an exact-match env binding', async () => {
+    const wd = await mkRealTemp('omx-writable-indeterminate-noauthority-');
+    __setSessionPointerTransactionDependenciesForTests({ probePid: () => 'indeterminate' });
+    try {
+      const stateDir = getBaseStateDir(wd);
+      await mkdir(stateDir, { recursive: true });
+      process.env.OMX_SESSION_ID = 'sess-indeterminate';
+      const cases = [
+        { name: 'missing recorded cwd', pointer: { session_id: 'sess-indeterminate', pid: 8388607 } },
+        { name: 'different state root', pointer: { session_id: 'sess-indeterminate', cwd: wd, state_root: join(wd, 'other-root'), pid: 8388607 } },
+        { name: 'recorded cwd does not contain the observed cwd', pointer: { session_id: 'sess-indeterminate', cwd: join(wd, 'other-worktree'), pid: 8388607 } },
+      ];
+      for (const testCase of cases) {
+        await writeFile(join(stateDir, 'session.json'), JSON.stringify(testCase.pointer));
+        await assert.rejects(
+          () => resolveWritableStateScope(wd),
+          (error: unknown) => {
+            assert.equal((error as Error).message, WRITABLE_STATE_SCOPE_ERRORS.unusableSession, testCase.name);
+            return true;
+          },
+        );
+        assert.equal(existsSync(join(stateDir, 'sessions', 'sess-indeterminate')), false, testCase.name);
       }
     } finally {
       __setWritableStateScopeTestHooksForTests({});

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -617,6 +617,9 @@ export function __setWritableStateScopeTestHooksForTests(hooks: WritableStateSco
  * - a stale-dead session.json yields to an explicit exact-current
  *   OMX_SESSION_ID binding (the dead owner holds no authority; SessionStart
  *   remains the only pointer writer);
+ * - an identity-indeterminate session.json may recover only when OMX_SESSION_ID
+ *   exactly matches the pointer's own session_id (the owner may still be alive,
+ *   so unlike stale-dead recovery, no looser validated binding is accepted);
  * - root writes are allowed only when session.json is absent.
  */
 export async function resolveWritableStateScope(
@@ -653,29 +656,34 @@ export async function resolveWritableStateScope(
           raw: snapshot.raw,
         });
       }
-      if (
-        envSessionId
-        && snapshot
-        && normalizeSessionId(snapshot.state.session_id)
-        && liveness === 'stale-dead'
-      ) {
-        if (selectedPointerRecoveryHookForTests) await selectedPointerRecoveryHookForTests();
-        const reread = await readFile(sessionPath, 'utf-8').catch((error: NodeJS.ErrnoException) => {
-          if (error.code === 'ENOENT') return undefined;
-          throw error;
-        });
-        if (recoveryStabilityRereadHookForTests) {
-          recoveryStabilityRereadHookForTests({
-            ordinal: ++recoveryStabilityRereadOrdinalForTests,
-            raw: reread,
+      if (snapshot && envSessionId) {
+        const canonicalPointerSessionId = normalizeSessionId(snapshot.state.session_id);
+        const recoveryEligible = Boolean(
+          canonicalPointerSessionId
+          && (
+            liveness === 'stale-dead'
+            || (liveness === 'identity-indeterminate' && envSessionId === canonicalPointerSessionId)
+          ),
+        );
+        if (recoveryEligible) {
+          if (selectedPointerRecoveryHookForTests) await selectedPointerRecoveryHookForTests();
+          const reread = await readFile(sessionPath, 'utf-8').catch((error: NodeJS.ErrnoException) => {
+            if (error.code === 'ENOENT') return undefined;
+            throw error;
           });
-        }
-        if (reread === snapshot.raw) {
-          return {
-            source: 'session',
-            sessionId: envSessionId,
-            stateDir: join(baseStateDir, 'sessions', envSessionId),
-          };
+          if (recoveryStabilityRereadHookForTests) {
+            recoveryStabilityRereadHookForTests({
+              ordinal: ++recoveryStabilityRereadOrdinalForTests,
+              raw: reread,
+            });
+          }
+          if (reread === snapshot.raw) {
+            return {
+              source: 'session',
+              sessionId: envSessionId,
+              stateDir: join(baseStateDir, 'sessions', envSessionId),
+            };
+          }
         }
       }
       throw new Error(WRITABLE_STATE_SCOPE_ERRORS.unusableSession);

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../hooks/session.js';
 import {
   addUltragoalGoal,
+  assertUltragoalWritableLifecycleAuthority,
   buildCodexGoalInstruction,
   checkpointUltragoal,
   createUltragoalPlan,
@@ -3204,6 +3205,55 @@ describe('ultragoal artifacts', () => {
         assert.equal(reread.codexObjectiveAliases, undefined);
         assert.equal(rootLedgerAfter, rootLedgerBefore);
       });
+    });
+  });
+
+  it('allows durable Ultragoal mutations for an exact-match identity-indeterminate pointer and rejects mismatches', async () => {
+    await withTempRepo(async (cwd) => {
+      const previousEnv = process.env.OMX_SESSION_ID;
+      const sessionId = 'sess-indeterminate';
+      const stateDir = join(cwd, '.omx', 'state');
+      try {
+        await mkdir(stateDir, { recursive: true });
+        await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+          session_id: sessionId,
+          cwd,
+          state_root: stateDir,
+          pid: 8388607,
+        }));
+        __setSessionPointerTransactionDependenciesForTests({ probePid: () => 'indeterminate' });
+        process.env.OMX_SESSION_ID = sessionId;
+
+        const plan = await createUltragoalPlan(cwd, { brief: '- Ship the indeterminate recovery' });
+        assert.equal(plan.goals.length, 1);
+        assert.equal(existsSync(join(cwd, '.omx', 'ultragoal', 'goals.json')), true);
+        const authority = await assertUltragoalWritableLifecycleAuthority(cwd);
+        assert.deepEqual(authority, {
+          kind: 'resolved',
+          source: 'session',
+          sessionId,
+          stateDir: join(stateDir, 'sessions', sessionId),
+        });
+
+        const goalsPath = join(cwd, '.omx', 'ultragoal', 'goals.json');
+        const beforeMismatch = await readFile(goalsPath, 'utf-8');
+        process.env.OMX_SESSION_ID = 'sess-foreign';
+        // withUltragoalMutationLock calls assertUltragoalWritableLifecycleAuthority before and after lock
+        // acquisition, and that helper calls resolveWritableStateScope, so its point-in-time revalidation
+        // inherits this exact-match branch for free with no separate production-code change needed.
+        await assert.rejects(
+          () => addUltragoalGoal(cwd, { title: 'Must not persist', objective: 'Foreign session mutation.' }),
+          (error: unknown) => {
+            assert.match(String(error), /writable lifecycle authority/);
+            return true;
+          },
+        );
+        assert.equal(await readFile(goalsPath, 'utf-8'), beforeMismatch);
+      } finally {
+        if (typeof previousEnv === 'string') process.env.OMX_SESSION_ID = previousEnv;
+        else delete process.env.OMX_SESSION_ID;
+        __resetSessionPointerTransactionDependenciesForTests();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

`resolveWritableStateScope` now allows writable-scope recovery for an `identity-indeterminate` selected session pointer, but only when:

- the pointer already proved cwd/state_root ownership authority via the existing `readAuthoritativeSessionSnapshotFromBaseStateDir` gate,
- normalized `OMX_SESSION_ID` exactly equals the pointer's own canonical `session_id` (no alias resolution — unlike the looser stale-dead rule),
- the raw pointer bytes are unchanged across the existing pre-return reread, and
- the resolver still never writes `session.json`.

Stale-dead recovery keeps its existing looser (non-exact-match) rule unchanged, since a dead owner holds no authority. An identity-indeterminate owner might still be alive, so recovery requires the env binding to already match the pointer's own claimed identity, not merely be validated.

Mismatched / malformed / missing-metadata / foreign-cwd-or-state-root / replacement-race / same-ID-byte-replacement / cross-cwd-reuse pointers all remain denied exactly as before. Live-mismatch semantics and the explicit `session_id` path are unchanged.

Implemented independently against canonical `dev` code; no code was cherry-picked from the external candidate patch referenced in the issue thread (`d1aeec6c`).

Closes #3324

## Changes

- `src/mcp/state-paths.ts`: extend `resolveWritableStateScope`'s existing recovery branch with a strictly narrower exact-match condition for `identity-indeterminate` liveness; update the doc comment.
- `src/mcp/__tests__/state-paths.test.ts`: new regression tests — exact-match allow case (with pointer-bytes/directory-entries-unchanged assertions), foreign-cwd/foreign-state_root/missing-cwd denial matrix, and same-session_id byte-replacement-race denial. Existing mismatch-denial test kept unmodified.
- `src/ultragoal/__tests__/artifacts.test.ts`: appended one durable-mutation regression test (exact-match success + mismatch fail-closed) near the existing `resolveWritableStateScope`-adjacent call site; no edits to `artifacts.ts`. Appended only, to minimize merge risk against #3326 (open, touches the same test file elsewhere).
- `docs/troubleshooting.md`: new "Exact-session reconciliation (identity-indeterminate pointer)" subsection parallel to the existing stale-dead one; updated "Still fail-closed" list and summary paragraph; existing "Known limitation" and Durable-Ultragoal-mutation sentences preserved verbatim.

No changes to `src/hooks/session.ts` (out of scope, avoids #3318 overlap) or any #3319-related file/wording.

## Planning

Ran through `deep-interview` → `ralplan` (Planner/Architect/Critic consensus, Architect `CLEAR`/`APPROVE`, Critic `OKAY` in one pass) → `ultragoal` execution per the user's explicit bounded contract. Full consensus plan: `.gjc/_session-omx-3324-indeterminate-pointer/plans/ralplan/omx-3324-indeterminate-pointer/pending-approval.md` (session-local, not part of this diff).

## Verification

- `npx tsc --noEmit` — clean
- `npm run build` — clean
- `npm run lint` (`biome lint src`) — clean, 788 files
- `npm run check:no-unused` — clean
- `node dist/scripts/generate-catalog-docs.js --check` — clean
- Focused tests: `node --test dist/mcp/__tests__/state-paths.test.js` — 63/63 passed
- Focused tests: `node --test dist/ultragoal/__tests__/artifacts.test.js` — 80/80 passed
- `git diff --stat` scope confirmed to touch only the 4 files above
- CLI/MCP parity: confirmed via `grep -rn resolveWritableStateScope src/` that CLI (`src/cli/index.ts`), MCP-facing (`src/state/operations.ts`), hooks, ultragoal, ralplan, and mode callers all delegate to the single shared implementation — no divergent implementation exists, so no additional parity test was needed
- Independent architect review (architecture/product/code lanes): `architectureStatus: CLEAR`, `productStatus: CLEAR`, initial `codeStatus: WATCH` (one low-priority misleading test comment) → fixed, full suite rerun clean
- Executor QA/red-team lane (package surface): case/whitespace exact-match boundary checks, idempotency + byte/mtime stability, alias-field bypass attempts (native_session_id/owner_omx_session_id), stale-dead-regression check — all passed, 0 blockers

## Do not merge

This PR is opened for review per the requesting workflow's terminal contract; do not merge.