### PR TITLE
fix(runtime): isolate detached OMX session ownership

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -4568,7 +4568,7 @@ exit 0
     assert.match(leaderCmd!, /wait "\$omx_codex_pid";/);
     assert.match(leaderCmd!, /kill -TERM "\$omx_codex_pid"/);
     assert.match(leaderCmd!, /releaseTmuxExtendedKeysLease/);
-    assert.match(leaderCmd!, /if \[ "\$status" -eq 0 \]; then/);
+    assert.match(leaderCmd!, /if \[ "\$status" -eq 0 \] \|\| \[ "\$status" -ge 128 \]; then/);
     assert.match(leaderCmd!, /tmux kill-session -t/);
     assert.match(leaderCmd!, /"omx-demo"/);
     assert.match(leaderCmd!, /codex exited immediately with code 0/);
@@ -4760,7 +4760,7 @@ exit 0
     }
   });
 
-  it("detached leader command preserves the detached tmux session on signal-derived exits", async () => {
+  it("detached leader command removes the detached tmux session on signal-derived exits", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-detached-leader-signal-"));
     const fakeBin = join(cwd, "bin");
     const logPath = join(cwd, "leader.log");
@@ -4829,7 +4829,7 @@ exit 0
       assert.match(log, /tmux:show-options -sv extended-keys/);
       assert.match(log, /tmux:set-option -sq extended-keys always/);
       assert.match(log, /tmux:set-option -sq extended-keys off/);
-      assert.doesNotMatch(log, /tmux:kill-session -t omx-demo/);
+      assert.match(log, /tmux:kill-session -t omx-demo/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4240,7 +4240,7 @@ function buildDetachedSessionLeaderCommand(
     buildTmuxExtendedKeysReleaseShellSnippet(cwd),
     parentEnvCleanup,
     detachedPostLaunchHelper,
-    'if [ "$status" -eq 0 ]; then',
+    'if [ "$status" -eq 0 ] || [ "$status" -ge 128 ]; then',
     `tmux kill-session -t "${escapeShellDoubleQuotedValue(sessionName)}" >/dev/null 2>&1 || true;`,
     "fi;",
     "exit $status;",

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -115,6 +115,33 @@ async function linuxProcessStartTicks(pid: number): Promise<number> {
 }
 
 describe('session lifecycle manager', () => {
+  it('isolates a team worker session pointer from the shared team state root', async () => {
+    const workerCwd = await mkdtemp(join(tmpdir(), 'omx-session-worker-root-'));
+    const sharedStateRoot = await mkdtemp(join(tmpdir(), 'omx-session-team-root-'));
+    const previousTeamWorker = process.env.OMX_TEAM_WORKER;
+    const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
+    const previousOmxRoot = process.env.OMX_ROOT;
+    try {
+      process.env.OMX_TEAM_WORKER = 'alpha/worker-1';
+      process.env.OMX_TEAM_STATE_ROOT = sharedStateRoot;
+      process.env.OMX_ROOT = workerCwd;
+
+      const context = resolveSessionPointerContext(workerCwd);
+      assert.equal(context.baseStateDir, join(workerCwd, '.omx', 'state'));
+      assert.equal(context.rootSource, 'omx-root-env');
+      assert.notEqual(context.baseStateDir, sharedStateRoot);
+    } finally {
+      if (previousTeamWorker === undefined) delete process.env.OMX_TEAM_WORKER;
+      else process.env.OMX_TEAM_WORKER = previousTeamWorker;
+      if (previousTeamStateRoot === undefined) delete process.env.OMX_TEAM_STATE_ROOT;
+      else process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+      if (previousOmxRoot === undefined) delete process.env.OMX_ROOT;
+      else process.env.OMX_ROOT = previousOmxRoot;
+      await rm(workerCwd, { recursive: true, force: true });
+      await rm(sharedStateRoot, { recursive: true, force: true });
+    }
+  });
+
   it('resets session metrics files with zeroed counters', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-metrics-'));
     try {

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -176,7 +176,15 @@ export function normalizeSessionId(value: unknown): string | undefined {
 /** Resolve the one exact pointer path used by an operation. */
 export function resolveSessionPointerContext(cwd: string): SessionPointerContext {
   const normalizedCwd = resolveWorkingDirectoryForState(cwd);
-  const { baseStateDir, rootSource } = getBaseStateDirWithSource(normalizedCwd);
+  const workerOmxRoot = process.env.OMX_TEAM_WORKER?.trim()
+    ? process.env.OMX_ROOT?.trim()
+    : undefined;
+  const { baseStateDir, rootSource } = workerOmxRoot
+    ? {
+        baseStateDir: join(resolveWorkingDirectoryForState(workerOmxRoot), '.omx', 'state'),
+        rootSource: 'omx-root-env' as const,
+      }
+    : getBaseStateDirWithSource(normalizedCwd);
   const pointerPath = join(baseStateDir, SESSION_FILE);
   return {
     cwd: normalizedCwd,
@@ -189,6 +197,7 @@ export function resolveSessionPointerContext(cwd: string): SessionPointerContext
 
 function attemptedStateRootSource(): AttemptedStateRootSource {
   try {
+    if (process.env.OMX_TEAM_WORKER?.trim() && process.env.OMX_ROOT?.trim()) return 'omx-root-env';
     if (process.env.OMX_TEAM_STATE_ROOT?.trim()) return 'team-env';
     if (process.env.OMX_ROOT?.trim()) return 'omx-root-env';
     if (process.env.OMX_STATE_ROOT?.trim()) return 'omx-state-root-env';
@@ -298,6 +307,16 @@ export interface SessionStartOptions {
   tmuxSessionName?: string;
   tmuxPaneId?: string;
   context?: SessionPointerContext;
+}
+
+export interface OwnedForeignSessionPointerRepairOptions {
+  context?: SessionPointerContext;
+  pid: number;
+  nativeSessionId: string;
+  verifiedOwnerOmxSessionId: string;
+  platform?: NodeJS.Platform;
+  /** @internal Scoped deterministic regular-file fsync seam. */
+  regularFileSync?: (platform: NodeJS.Platform) => Promise<void>;
 }
 
 /** @internal Test-only deterministic transaction seam; do not use outside session tests. */
@@ -1689,6 +1708,88 @@ export async function reconcileNativeSessionStart(
     timestamp: result.value.state.native_session_switched_at ?? new Date().toISOString(),
   }).catch(() => {});
   return result.value.state;
+}
+
+/**
+ * Repair a foreign-cwd pointer only when the current tmux owner alias and the
+ * exact live process identity both prove that the pointer still belongs to the
+ * caller. This is intentionally narrower than SessionStart reconciliation:
+ * unrelated or identity-indeterminate foreign pointers remain fail-closed.
+ */
+export async function repairOwnedForeignSessionPointer(
+  cwd: string,
+  options: OwnedForeignSessionPointerRepairOptions,
+): Promise<SessionState> {
+  const verifiedOwnerOmxSessionId = normalizeSessionId(options.verifiedOwnerOmxSessionId);
+  const nativeSessionId = normalizeSessionId(options.nativeSessionId);
+  const pid = Number.isInteger(options.pid) && options.pid > 0 ? options.pid : undefined;
+  const result = await writePointerTransaction(
+    cwd,
+    verifiedOwnerOmxSessionId,
+    {
+      context: options.context,
+      platform: options.platform,
+      regularFileSync: options.regularFileSync,
+    },
+    NATIVE_POINTER_TIMEOUT_MS,
+    (pointer, context) => {
+      const state = pointer.state;
+      const platform = options.platform ?? process.platform;
+      const ownerMatches = state
+        && verifiedOwnerOmxSessionId
+        && (
+          normalizeSessionId(state.session_id) === verifiedOwnerOmxSessionId
+          || normalizeSessionId(state.owner_omx_session_id) === verifiedOwnerOmxSessionId
+        );
+      const processMatches = state
+        && platform === 'linux'
+        && (state.platform ?? platform) === platform
+        && pid !== undefined
+        && state.pid === pid
+        && classifySessionProcess(state, transactionDependencies) === 'usable';
+      if (
+        pointer.status !== 'foreign-cwd'
+        || !state
+        || !ownerMatches
+        || !processMatches
+        || !nativeSessionId
+      ) {
+        throw unusablePointerAbort(context, verifiedOwnerOmxSessionId, pointer);
+      }
+
+      const existingNativeSessionId = normalizeSessionId(state.native_session_id);
+      const nativeSessionChanged = existingNativeSessionId !== nativeSessionId;
+      return createSessionState(
+        context.cwd,
+        state.session_id,
+        pid,
+        platform,
+        sessionIdentityFor(pid, platform),
+        {
+          nativeSessionId,
+          previousNativeSessionId: nativeSessionChanged
+            ? existingNativeSessionId
+            : state.previous_native_session_id,
+          nativeSessionSwitchedAt: nativeSessionChanged
+            ? new Date().toISOString()
+            : state.native_session_switched_at,
+          ownerOmxSessionId: state.owner_omx_session_id,
+          startedAt: state.started_at,
+          tmuxSessionName: state.tmux_session_name,
+          tmuxPaneId: state.tmux_pane_id,
+        },
+      );
+    },
+    (state) => state,
+  );
+  await appendToLogAtContext(result.context, {
+    event: 'session_pointer_foreign_cwd_repaired',
+    session_id: result.value.session_id,
+    native_session_id: result.value.native_session_id,
+    pid: result.value.pid,
+    timestamp: result.value.native_session_switched_at ?? new Date().toISOString(),
+  }).catch(() => {});
+  return result.value;
 }
 
 function historyDirectory(context: SessionPointerContext): string {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4342,6 +4342,64 @@ PY`,
       assert.equal(stalePointer.session_id, "native-stale-3138");
       assert.equal(stalePointer.owner_omx_session_id, "omx-stale-3138");
 
+      const repairCwd = join(root, "repair-owned-foreign");
+      const repairStatePath = join(repairCwd, ".omx", "state", "session.json");
+      const repairOwner = "omx-repair-3138";
+      const contaminatedNativeSessionId = "native-worker-3138";
+      const leaderNativeSessionId = "native-leader-3138";
+      await mkdir(repairCwd, { recursive: true });
+      await writeSessionStart(repairCwd, repairOwner, {
+        nativeSessionId: contaminatedNativeSessionId,
+        pid: process.pid,
+      });
+      const contaminatedPointer = JSON.parse(await readFile(repairStatePath, "utf-8")) as Record<string, unknown>;
+      contaminatedPointer.cwd = join(root, "deleted-worker-worktree");
+      await writeJson(repairStatePath, contaminatedPointer);
+      process.env.OMX_SESSION_ID = repairOwner;
+      await setOwnerEvidence(repairOwner);
+
+      const repairedStop = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd: repairCwd,
+        session_id: leaderNativeSessionId,
+      }, { cwd: repairCwd, sessionOwnerPid: process.pid });
+      assert.equal(repairedStop.outputJson, null);
+      const repairedPointer = JSON.parse(await readFile(repairStatePath, "utf-8")) as {
+        session_id?: string;
+        native_session_id?: string;
+        previous_native_session_id?: string;
+        cwd?: string;
+      };
+      assert.equal(repairedPointer.session_id, repairOwner);
+      assert.equal(repairedPointer.native_session_id, leaderNativeSessionId);
+      assert.equal(repairedPointer.previous_native_session_id, contaminatedNativeSessionId);
+      assert.equal(repairedPointer.cwd, repairCwd);
+
+      const indeterminateCwd = join(root, "indeterminate-owned-foreign");
+      const indeterminateStatePath = join(indeterminateCwd, ".omx", "state", "session.json");
+      const indeterminateOwner = "omx-indeterminate-3138";
+      await writeJson(indeterminateStatePath, {
+        session_id: indeterminateOwner,
+        native_session_id: "native-worker-indeterminate-3138",
+        cwd: join(root, "other-indeterminate-worktree"),
+        started_at: "2026-01-01T00:00:00.000Z",
+        pid: process.pid,
+        platform: "linux",
+      });
+      process.env.OMX_SESSION_ID = indeterminateOwner;
+      await setOwnerEvidence(indeterminateOwner);
+      const indeterminateStop = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd: indeterminateCwd,
+        session_id: "native-leader-indeterminate-3138",
+      }, { cwd: indeterminateCwd, sessionOwnerPid: process.pid });
+      assert.equal(indeterminateStop.outputJson?.decision, "block");
+      assert.equal(indeterminateStop.outputJson?.stopReason, "session_pointer_unusable");
+      assert.equal(
+        (JSON.parse(await readFile(indeterminateStatePath, "utf-8")) as { cwd?: string }).cwd,
+        join(root, "other-indeterminate-worktree"),
+      );
+
       const foreignCwd = join(root, "foreign");
       const foreignStatePath = join(foreignCwd, ".omx", "state", "session.json");
       await writeJson(foreignStatePath, {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -43,6 +43,7 @@ import {
   readSessionState,
   readUsableSessionState,
   reconcileNativeSessionStart,
+  repairOwnedForeignSessionPointer,
   resolveSessionPointerContext,
   type SessionStartOptions,
   type SessionState,
@@ -19664,7 +19665,25 @@ export async function dispatchCodexNativeHook(
   const nativeSessionId = safeString(payload.session_id ?? payload.sessionId).trim();
   const threadId = safeString(payload.thread_id ?? payload.threadId).trim();
   const turnId = safeString(payload.turn_id ?? payload.turnId).trim();
-  const pointer = await readSessionPointer(pointerContext);
+  let pointer = await readSessionPointer(pointerContext);
+  if (hookEventName === "Stop" && pointer.status === "foreign-cwd" && nativeSessionId) {
+    const verifiedOwnerOmxSessionId = await resolveVerifiedOwnerOmxSessionId();
+    if (verifiedOwnerOmxSessionId) {
+      try {
+        const repairedState = await repairOwnedForeignSessionPointer(cwd, {
+          context: pointerContext,
+          pid: options.sessionOwnerPid ?? resolveSessionOwnerPid(payload),
+          nativeSessionId,
+          verifiedOwnerOmxSessionId,
+          platform: options.sessionStartOptions?.platform,
+          regularFileSync: options.sessionStartOptions?.regularFileSync,
+        });
+        pointer = { status: "usable", state: repairedState };
+      } catch (error) {
+        if (!isSessionPointerLaunchAbort(error)) throw error;
+      }
+    }
+  }
   const currentSessionState = pointer.status === "usable" ? pointer.state ?? null : null;
   let promptTurnContext: ResolvedPromptTurnContext | null = hookEventName === "UserPromptSubmit"
     ? evaluateResolvedPromptTurn({

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -5568,6 +5568,10 @@ fs.writeFileSync(path.join(logDir, 'env.json'), JSON.stringify({
   cwd: process.cwd(),
   teamStateRoot: process.env.OMX_TEAM_STATE_ROOT || '',
   worker: process.env.OMX_TEAM_WORKER || '',
+  omxRoot: process.env.OMX_ROOT || '',
+  omxSessionId: process.env.OMX_SESSION_ID || '',
+  codexSessionId: process.env.CODEX_SESSION_ID || '',
+  genericSessionId: process.env.SESSION_ID || '',
 }));
 process.stdin.on('data', (chunk) => {
   fs.appendFileSync(path.join(logDir, 'stdin.log'), chunk.toString());
@@ -5584,12 +5588,20 @@ process.on('SIGTERM', () => process.exit(0));
     const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
     const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
     const prevLogDir = process.env.OMX_TEST_LOG_DIR;
+    const prevOmxRoot = process.env.OMX_ROOT;
+    const prevOmxSessionId = process.env.OMX_SESSION_ID;
+    const prevCodexSessionId = process.env.CODEX_SESSION_ID;
+    const prevGenericSessionId = process.env.SESSION_ID;
 
     process.env.PATH = `${binDir}:${prevPath ?? ''}`;
     delete process.env.TMUX;
     process.env.OMX_TEAM_WORKER_LAUNCH_MODE = 'prompt';
     process.env.OMX_TEAM_WORKER_CLI = 'codex';
     process.env.OMX_TEST_LOG_DIR = logDir;
+    process.env.OMX_ROOT = repo;
+    process.env.OMX_SESSION_ID = 'omx-inherited-leader';
+    process.env.CODEX_SESSION_ID = 'codex-inherited-leader';
+    process.env.SESSION_ID = 'generic-inherited-leader';
 
     let runtime: TeamRuntime | null = null;
     try {
@@ -5629,10 +5641,18 @@ process.on('SIGTERM', () => process.exit(0));
         cwd: string;
         teamStateRoot: string;
         worker: string;
+        omxRoot: string;
+        omxSessionId: string;
+        codexSessionId: string;
+        genericSessionId: string;
       };
       assert.equal(envLog.cwd, workerPath);
       assert.equal(envLog.teamStateRoot, join(repo, '.omx', 'state'));
       assert.equal(envLog.worker, 'team-detached-worktree-paths/worker-1');
+      assert.equal(envLog.omxRoot, workerPath);
+      assert.equal(envLog.omxSessionId, '');
+      assert.equal(envLog.codexSessionId, '');
+      assert.equal(envLog.genericSessionId, '');
       const rootAgents = await readFile(join(workerPath, 'AGENTS.md'), 'utf-8');
       assert.match(rootAgents, /Team Worker Runtime Instructions/);
       assert.match(rootAgents, new RegExp(`Inbox path: .*${runtime.teamName}/workers/worker-1/inbox\\.md`));
@@ -5663,6 +5683,14 @@ process.on('SIGTERM', () => process.exit(0));
       else delete process.env.OMX_TEAM_WORKER_CLI;
       if (typeof prevLogDir === 'string') process.env.OMX_TEST_LOG_DIR = prevLogDir;
       else delete process.env.OMX_TEST_LOG_DIR;
+      if (typeof prevOmxRoot === 'string') process.env.OMX_ROOT = prevOmxRoot;
+      else delete process.env.OMX_ROOT;
+      if (typeof prevOmxSessionId === 'string') process.env.OMX_SESSION_ID = prevOmxSessionId;
+      else delete process.env.OMX_SESSION_ID;
+      if (typeof prevCodexSessionId === 'string') process.env.CODEX_SESSION_ID = prevCodexSessionId;
+      else delete process.env.CODEX_SESSION_ID;
+      if (typeof prevGenericSessionId === 'string') process.env.SESSION_ID = prevGenericSessionId;
+      else delete process.env.SESSION_ID;
       await rm(toolingDir, { recursive: true, force: true });
       await rm(repo, { recursive: true, force: true });
     }
@@ -5670,6 +5698,7 @@ process.on('SIGTERM', () => process.exit(0));
 
   it('shutdownTeam removes team-created detached worktrees on normal shutdown', async () => {
     const repo = await initRepo();
+    const foreignCallerCwd = await mkdtemp(join(tmpdir(), 'omx-runtime-worktree-shutdown-caller-'));
     const toolingDir = await mkdtemp(join(tmpdir(), 'omx-runtime-worktree-tools-'));
     const binDir = join(toolingDir, 'bin');
     const fakeCodexPath = join(binDir, 'codex');
@@ -5692,6 +5721,7 @@ process.on('SIGTERM', () => process.exit(0));
     const prevTmux = process.env.TMUX;
     const prevLaunchMode = process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
     const prevWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+    const prevTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
 
     process.env.PATH = `${binDir}:${prevPath ?? ''}`;
     delete process.env.TMUX;
@@ -5717,10 +5747,13 @@ process.on('SIGTERM', () => process.exit(0));
       assert.equal(runtime.config.workers[0]?.worktree_created, true);
       assert.equal(existsSync(worktreePath as string), true);
       assert.equal(existsSync(join(worktreePath as string, 'AGENTS.md')), true);
+      await writeFile(join(worktreePath as string, 'worker-shutdown-change.txt'), 'preserved\n', 'utf-8');
 
-      await shutdownTeam(runtime.teamName, repo);
+      process.env.OMX_TEAM_STATE_ROOT = join(repo, '.omx', 'state');
+      await shutdownTeam(runtime.teamName, foreignCallerCwd, { force: true });
       runtime = null;
 
+      assert.equal(await readFile(join(repo, 'worker-shutdown-change.txt'), 'utf-8'), 'preserved\n');
       assert.equal(existsSync(worktreePath as string), false);
       assert.equal(existsSync(join(repo, '.omx', 'state', 'team', 'team-detached-worktree-shutdown')), false);
     } finally {
@@ -5735,7 +5768,10 @@ process.on('SIGTERM', () => process.exit(0));
       else delete process.env.OMX_TEAM_WORKER_LAUNCH_MODE;
       if (typeof prevWorkerCli === 'string') process.env.OMX_TEAM_WORKER_CLI = prevWorkerCli;
       else delete process.env.OMX_TEAM_WORKER_CLI;
+      if (typeof prevTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = prevTeamStateRoot;
+      else delete process.env.OMX_TEAM_STATE_ROOT;
       await rm(toolingDir, { recursive: true, force: true });
+      await rm(foreignCallerCwd, { recursive: true, force: true });
       await rm(repo, { recursive: true, force: true });
     }
   });

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -1138,7 +1138,13 @@ describe('buildWorkerStartupCommand', () => {
       );
       assert.match(cmd, /OMX_TEAM_WORKER=alpha-team\/worker-1/);
       assert.match(cmd, /OMX_TEAM_STATE_ROOT=\/tmp\/workspace\/\.omx\/state/);
+      assert.match(cmd, /OMX_ROOT=\/tmp\/workspace/);
       assert.match(cmd, /'-u' 'OMX_TMUX_HUD_OWNER' '-u' 'OMX_TMUX_HUD_LEADER_PANE'/);
+      assert.match(cmd, /'-u' 'OMX_SESSION_ID'/);
+      assert.match(cmd, /'-u' 'CODEX_SESSION_ID'/);
+      assert.match(cmd, /'-u' 'SESSION_ID'/);
+      assert.match(cmd, /'-u' 'OMX_STATE_ROOT'/);
+      assert.match(cmd, /'-u' 'OMX_ROOT'/);
       assert.doesNotMatch(cmd, /OMX_TMUX_HUD_OWNER=1/);
       assert.doesNotMatch(cmd, /OMX_TMUX_HUD_LEADER_PANE=%leader/);
     } finally {
@@ -1626,7 +1632,10 @@ describe('buildWorkerStartupCommand', () => {
       const script = await readFile(join(stateRoot, 'team', 'alpha', 'runtime', 'worker-1-startup.sh'), 'utf-8');
       assert.match(script, /^#!\/bin\/sh/m);
       assert.match(script, new RegExp(`cd '${wd.replace(/'/g, `'\\\\''`)}'`));
-      assert.match(script, /^unset OMX_TMUX_HUD_OWNER OMX_TMUX_HUD_LEADER_PANE$/m);
+      assert.match(
+        script,
+        /^unset OMX_TMUX_HUD_OWNER OMX_TMUX_HUD_LEADER_PANE OMX_SESSION_ID CODEX_SESSION_ID SESSION_ID OMX_STATE_ROOT OMX_ROOT$/m,
+      );
       assert.match(script, /export OMX_TEAM_STATE_ROOT=/);
       assert.doesNotMatch(script, /^export OMX_TMUX_HUD_OWNER=/m);
       assert.doesNotMatch(script, /^export OMX_TMUX_HUD_LEADER_PANE=/m);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -16,6 +16,7 @@ import {
   CreateTeamSessionPartialError,
   buildWorkerProcessLaunchSpec,
   scrubTeamWorkerHudOwnershipEnv,
+  scrubTeamWorkerSessionOwnershipEnv,
   resolveTeamWorkerCli,
   resolveTeamWorkerCliForResolvedLaunchArgs,
   assertTeamWorkerCliPolicyCompatibility,
@@ -3051,7 +3052,10 @@ function spawnPromptWorker(
     initialPrompt,
     workerRole,
   );
-  const childEnv = scrubTeamWorkerHudOwnershipEnv({ ...process.env, ...processSpec.env });
+  const childEnv = scrubTeamWorkerHudOwnershipEnv({
+    ...scrubTeamWorkerSessionOwnershipEnv(process.env),
+    ...processSpec.env,
+  });
   // Prompt workers are external CLI processes, not in-process runtime code.
   // Keeping c8's NODE_V8_COVERAGE in their environment makes coverage runs
   // track long-lived fake worker descendants and can keep node --test alive
@@ -5303,7 +5307,10 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     }
   }
 
-  const shutdownReports = await prepareWorkerWorktreeShutdownReports(config, cwd);
+  const shutdownReports = await prepareWorkerWorktreeShutdownReports(
+    config,
+    config.leader_cwd?.trim() || cwd,
+  );
 
   const commitHygieneEntries: TeamOperationalCommitEntry[] = [];
   for (const report of shutdownReports) {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -154,6 +154,13 @@ const GEMINI_APPROVAL_MODE_FLAG = '--approval-mode';
 const GEMINI_APPROVAL_MODE_YOLO = 'yolo';
 const OMX_LEADER_NODE_PATH_ENV = 'OMX_LEADER_NODE_PATH';
 const OMX_LEADER_CLI_PATH_ENV = 'OMX_LEADER_CLI_PATH';
+const TEAM_WORKER_SESSION_OWNERSHIP_ENV_KEYS = [
+  'OMX_SESSION_ID',
+  'CODEX_SESSION_ID',
+  'SESSION_ID',
+  'OMX_STATE_ROOT',
+  'OMX_ROOT',
+] as const;
 const TMUX_WORKER_AMBIENT_ENV_ALLOWLIST = [
   'HTTPS_PROXY',
   'HTTP_PROXY',
@@ -1679,6 +1686,14 @@ export function scrubTeamWorkerHudOwnershipEnv<T extends Record<string, string |
   return scrubbed;
 }
 
+export function scrubTeamWorkerSessionOwnershipEnv<T extends Record<string, string | undefined>>(env: T): T {
+  const scrubbed = { ...env };
+  for (const key of TEAM_WORKER_SESSION_OWNERSHIP_ENV_KEYS) {
+    delete scrubbed[key];
+  }
+  return scrubbed;
+}
+
 function hasConfigOverride(args: readonly string[], key: string): boolean {
   return someConfigOverrideBeforeEndOfOptions(args, (value) => {
     const trimmed = value.trim();
@@ -1796,7 +1811,11 @@ export function buildWorkerStartupCommand(
     const pathBootstrap = leaderNodeDir
       ? `$env:PATH = ${quotePowerShellArg(`${leaderNodeDir};`)} + $env:PATH`
       : '';
-    const hudEnvUnset = [OMX_TMUX_HUD_OWNER_ENV, OMX_TMUX_HUD_LEADER_PANE_ENV]
+    const hudEnvUnset = [
+      OMX_TMUX_HUD_OWNER_ENV,
+      OMX_TMUX_HUD_LEADER_PANE_ENV,
+      ...TEAM_WORKER_SESSION_OWNERSHIP_ENV_KEYS,
+    ]
       .map((key) => `Remove-Item Env:${key} -ErrorAction SilentlyContinue`)
       .join('; ');
     const envAssignments = Object.entries(startupEnv)
@@ -1831,7 +1850,11 @@ export function buildWorkerStartupCommand(
     : '';
   const inner = `${rcPrefix}${pathPrefix}${cliInvocation}`;
   const envParts = Object.entries(startupEnv).map(([key, value]) => `${key}=${value}`);
-  const unsetParts = ['-u', OMX_TMUX_HUD_OWNER_ENV, '-u', OMX_TMUX_HUD_LEADER_PANE_ENV];
+  const unsetParts = [
+    OMX_TMUX_HUD_OWNER_ENV,
+    OMX_TMUX_HUD_LEADER_PANE_ENV,
+    ...TEAM_WORKER_SESSION_OWNERSHIP_ENV_KEYS,
+  ].flatMap((key) => ['-u', key]);
 
   return `env ${[...unsetParts, ...envParts].map(shellQuoteSingle).join(' ')} ${shellQuoteSingle(launchSpec.shell)} -c ${shellQuoteSingle(inner)}`;
 }
@@ -1871,7 +1894,11 @@ function buildWorkerStartupScriptContent(
   return [
     '#!/bin/sh',
     'set -eu',
-    `unset ${OMX_TMUX_HUD_OWNER_ENV} ${OMX_TMUX_HUD_LEADER_PANE_ENV}`,
+    `unset ${[
+      OMX_TMUX_HUD_OWNER_ENV,
+      OMX_TMUX_HUD_LEADER_PANE_ENV,
+      ...TEAM_WORKER_SESSION_OWNERSHIP_ENV_KEYS,
+    ].join(' ')}`,
     `cd ${shellQuoteSingle(translatePathForMsys(cwd))}`,
     envExports,
     `exec ${shellQuoteSingle(launchSpec.shell)} -c ${shellQuoteSingle(`${rcPrefix}${pathPrefix}${cliInvocation}`)}`,
@@ -2044,6 +2071,9 @@ function buildWorkerProcessLaunchSpecForMode(
     if (typeof value !== 'string' || value.trim() === '') continue;
     workerEnv[key] = value;
   }
+  // Team coordination remains rooted at OMX_TEAM_STATE_ROOT, but lifecycle
+  // hooks must never reuse the leader's session pointer or inherited aliases.
+  workerEnv.OMX_ROOT = cwd;
 
   return {
     workerCli,


### PR DESCRIPTION
## What changed

- isolate Team workers behind worker-local OMX_ROOT session pointers
- generate shutdown worktree reports from persisted leader_cwd
- require verified tmux ownership and exact Linux process identity before foreign-cwd session repair
- clean detached leader tmux sessions after signal-derived exits
- add regression coverage across session hooks, native hooks, CLI, runtime, and tmux lifecycle paths

## Why

Inherited leader session pointers and weak detached-session ownership checks could let worker or foreign-cwd processes mutate the wrong OMX session, produce reports from the wrong repository, or leave detached tmux sessions behind.

## Impact

Ambiguous ownership now remains fail-closed, while verified recovery and normal detached shutdown continue automatically.

## Validation

- build passed
- lint passed
- no-unused check passed
- session suite: 49/49
- tmux-session suite: 280/280
- targeted runtime, native-hook, and CLI regressions passed