### PR TITLE
fix(hooks): bound sloppy fallback Stop audit repeats and scope it to the session

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -303,9 +303,11 @@ The audit is bounded so a single finding cannot hold a session hostage:
 - Identical findings block at most `OMX_NATIVE_STOP_SLOPPY_FALLBACK_MAX_REPEATS`
   times (default 3), tracked per session in
   `.omx/state/native-stop-state.json` under `sloppy_fallback_diff_guard`. The
-  guard fingerprints the finding set only (not the assistant message), resets
-  when findings change, and clears when findings disappear. Past the cap the
-  gate fails open for that identical finding set.
+  guard fingerprints the finding set by path and line only (not the assistant
+  message, and not the staged/unstaged/untracked source, so identical findings
+  keep counting across `git add`/`git reset`), resets when findings change,
+  and clears when findings disappear. Past the cap the gate fails open for
+  that identical finding set.
 - `OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT=off` (also `0`/`false`/`disabled`)
   disables the audit entirely.
 - Untracked files whose mtime predates the session start (derived from the

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -292,6 +292,28 @@ returns a no-op response instead of a diagnostic continuation block.
 Native `Stop` ends one assistant turn rather than the Codex process, so a
 successful `Stop` does not delete owner evidence.
 
+## Stop: sloppy fallback/workaround diff audit
+
+Native `Stop` audits the worktree for ungrounded fallback wording in added
+source lines: staged and unstaged diffs, plus untracked source files. A finding
+blocks the stop and asks the agent to ground or rework the line.
+
+The audit is bounded so a single finding cannot hold a session hostage:
+
+- Identical findings block at most `OMX_NATIVE_STOP_SLOPPY_FALLBACK_MAX_REPEATS`
+  times (default 3), tracked per session in
+  `.omx/state/native-stop-state.json` under `sloppy_fallback_diff_guard`. The
+  guard fingerprints the finding set only (not the assistant message), resets
+  when findings change, and clears when findings disappear. Past the cap the
+  gate fails open for that identical finding set.
+- `OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT=off` (also `0`/`false`/`disabled`)
+  disables the audit entirely.
+- Untracked files whose mtime predates the session start (derived from the
+  transcript file's birth time) are skipped, so pre-existing repo content the
+  session never touched cannot block it. When no transcript path or birth time
+  is available, the untracked scan falls back to auditing all untracked source
+  files.
+
 ## UserPromptSubmit: triage advisory context
 
 `UserPromptSubmit` can now emit triage advisory context alongside keyword context. When no keyword matches, the triage layer classifies the prompt and may inject an advisory prompt-routing context string — this is advisory prompt-routing context that does not activate a skill or workflow by itself; it adds a developer-context hint the model may follow. Light advisory destinations include repo-local `explore`, narrow-edit `executor`, visual `designer`, and external documentation/reference `researcher`; researcher routing is for official-doc, version-compatibility, source-backed, or external lookup requests, does not override local anchors or implementation-shaped prompts, and still writes only prompt-routing state. Keywords remain the deterministic control surface: a matched keyword always takes precedence over triage output, and users can suppress triage injection per prompt with phrases such as `no workflow`, `just chat`, or `plain answer`.

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import {
 	chmod,
 	mkdir,
@@ -9,6 +9,7 @@ import {
 	readdir,
 	rm,
 	symlink,
+	utimes,
 	writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -22544,6 +22545,164 @@ PY`,
       assert.equal((first.outputJson as { decision?: string } | null)?.decision, "block");
       assert.equal((repeated.outputJson as { decision?: string } | null)?.decision, "block");
       assert.equal((repeated.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails open after repeated identical sloppy fallback findings exceed the repeat cap", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-cap-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+      const payload = { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-cap", turn_id: "turn-cap" };
+
+      const decisions: Array<string | null> = [];
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        const result = await dispatchCodexNativeHook(
+          attempt === 0 ? payload : { ...payload, stop_hook_active: true },
+          { cwd },
+        );
+        decisions.push((result.outputJson as { decision?: string } | null)?.decision ?? null);
+      }
+
+      assert.deepEqual(decisions, ["block", "block", "block", null, null]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("resets the sloppy fallback repeat cap when findings change", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-cap-reset-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      const sloppySource = (exportName: string) => [
+        `export function ${exportName}() {`,
+        "  // implement a quick hack fallback if it fails",
+        "  return process.env.RUNTIME || 'local';",
+        "}",
+      ].join("\n");
+      await writeFile(join(cwd, "src", "runtime.ts"), sloppySource("loadRuntime"));
+      const payload = { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-cap-reset", turn_id: "turn-cap-reset" };
+
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        await dispatchCodexNativeHook(
+          attempt === 0 ? payload : { ...payload, stop_hook_active: true },
+          { cwd },
+        );
+      }
+      const allowed = await dispatchCodexNativeHook({ ...payload, stop_hook_active: true }, { cwd });
+      assert.equal(allowed.outputJson, null);
+
+      await writeFile(join(cwd, "src", "other.ts"), sloppySource("loadOther"));
+      const blockedAgain = await dispatchCodexNativeHook({ ...payload, stop_hook_active: true }, { cwd });
+      assert.equal((blockedAgain.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((blockedAgain.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("skips the sloppy fallback diff audit when OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT is off", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-disabled-");
+    const previousValue = process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT;
+    process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT = "off";
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-disabled" },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      if (previousValue === undefined) delete process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT;
+      else process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT = previousValue;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores untracked sloppy fallback files last written before the session transcript", async (t) => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-preexisting-");
+    try {
+      const transcriptPath = join(cwd, "transcript.jsonl");
+      await writeFile(transcriptPath, "{}\n");
+      const { birthtimeMs } = statSync(transcriptPath);
+      if (!(birthtimeMs > 0)) {
+        t.skip("file birth time is not available on this platform");
+        return;
+      }
+      await mkdir(join(cwd, "src"), { recursive: true });
+      const sloppyPath = join(cwd, "src", "runtime.ts");
+      await writeFile(
+        sloppyPath,
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+      const preSessionTime = new Date(Date.now() - 10 * 60_000);
+      await utimes(sloppyPath, preSessionTime, preSessionTime);
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-preexisting", transcript_path: transcriptPath },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("still blocks untracked sloppy fallback files written after the session transcript", async (t) => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-inturn-");
+    try {
+      const transcriptPath = join(cwd, "transcript.jsonl");
+      await writeFile(transcriptPath, "{}\n");
+      const { birthtimeMs } = statSync(transcriptPath);
+      if (!(birthtimeMs > 0)) {
+        t.skip("file birth time is not available on this platform");
+        return;
+      }
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-inturn", transcript_path: transcriptPath },
+        { cwd },
+      );
+
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((result.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -22611,6 +22611,39 @@ PY`,
     }
   });
 
+  it("keeps the repeat count when identical findings move across staging states", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-staging-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+      const payload = { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-staging", turn_id: "turn-staging" };
+      const stop = (attempt: number) =>
+        dispatchCodexNativeHook(attempt === 0 ? payload : { ...payload, stop_hook_active: true }, { cwd });
+
+      const first = await stop(0);
+      execFileSync("git", ["add", "src/runtime.ts"], { cwd, stdio: "ignore" });
+      const staged = await stop(1);
+      execFileSync("git", ["reset", "-q", "--", "src/runtime.ts"], { cwd, stdio: "ignore" });
+      const unstagedAgain = await stop(2);
+      const afterCap = await stop(3);
+
+      assert.equal((first.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((staged.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((unstagedAgain.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal(afterCap.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("skips the sloppy fallback diff audit when OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT is off", async () => {
     const cwd = await initTempGitRepo("omx-native-hook-stop-slop-disabled-");
     const previousValue = process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -219,6 +219,7 @@ const NATIVE_STOP_STATE_FILE = "native-stop-state.json";
 const NATIVE_SUBAGENT_CAPACITY_BLOCKER_FILE = "native-subagent-capacity-blocker.json";
 const NATIVE_SUBAGENT_CAPACITY_BLOCKER_TTL_MS = 30 * 60_000;
 const ORDINARY_STOP_NO_PROGRESS_DEFAULT_MAX_REPEATS = 8;
+const SLOPPY_FALLBACK_DIFF_STOP_DEFAULT_MAX_REPEATS = 3;
 const RALPH_ORPHANED_STARTING_STALE_MS = 15 * 60_000;
 const ORDINARY_STOP_NO_PROGRESS_DEFAULT_IDLE_MS = 10 * 60_000;
 const ORDINARY_STOP_NO_PROGRESS_MAX_MESSAGE_LENGTH = 240;
@@ -1920,13 +1921,39 @@ function collectSloppyFallbackFindingsFromPatch(
   return findings;
 }
 
-function collectSloppyFallbackFindingsFromUntracked(cwd: string): SloppyFallbackDiffFinding[] {
+function isSloppyFallbackDiffAuditDisabled(): boolean {
+  return /^(?:0|off|false|disabled?)$/i.test(
+    safeString(process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT).trim(),
+  );
+}
+
+function resolveSloppyFallbackSessionStartMs(payload: CodexHookPayload, cwd: string): number | null {
+  const transcriptPath = safeString(payload.transcript_path ?? payload.transcriptPath).trim();
+  if (!transcriptPath) return null;
+  try {
+    const resolvedPath = isAbsolute(transcriptPath) ? transcriptPath : resolve(cwd, transcriptPath);
+    const { birthtimeMs } = statSync(resolvedPath);
+    return Number.isFinite(birthtimeMs) && birthtimeMs > 0 ? birthtimeMs : null;
+  } catch {
+    return null;
+  }
+}
+
+function collectSloppyFallbackFindingsFromUntracked(cwd: string, sessionStartMs?: number | null): SloppyFallbackDiffFinding[] {
   const output = gitOutput(cwd, ["ls-files", "--others", "--exclude-standard", "-z"]);
   if (!output) return [];
   const findings: SloppyFallbackDiffFinding[] = [];
   for (const rawPath of output.split("\0")) {
     const path = normalizeGitPath(rawPath.trim());
     if (!path || !isDiffAuditableSourcePath(path)) continue;
+    if (sessionStartMs != null) {
+      try {
+        const { mtimeMs } = statSync(join(cwd, path));
+        if (Number.isFinite(mtimeMs) && mtimeMs < sessionStartMs) continue;
+      } catch {
+        continue;
+      }
+    }
     let content = "";
     try {
       content = readFileSync(join(cwd, path), "utf-8");
@@ -1938,14 +1965,14 @@ function collectSloppyFallbackFindingsFromUntracked(cwd: string): SloppyFallback
   return findings;
 }
 
-function findSloppyFallbackDiffFindings(cwd: string): SloppyFallbackDiffFinding[] {
+function findSloppyFallbackDiffFindings(cwd: string, sessionStartMs?: number | null): SloppyFallbackDiffFinding[] {
   const layout = findGitLayout(cwd);
   if (!layout) return [];
   const auditRoot = layout.worktreeRoot;
   return [
     ...collectSloppyFallbackFindingsFromPatch(gitOutput(auditRoot, ["diff", "--cached", "--no-ext-diff", "--unified=3"]), "staged"),
     ...collectSloppyFallbackFindingsFromPatch(gitOutput(auditRoot, ["diff", "--no-ext-diff", "--unified=3"]), "unstaged"),
-    ...collectSloppyFallbackFindingsFromUntracked(auditRoot),
+    ...collectSloppyFallbackFindingsFromUntracked(auditRoot, sessionStartMs),
   ];
 }
 
@@ -1964,6 +1991,75 @@ function buildSloppyFallbackDiffStopOutput(findings: SloppyFallbackDiffFinding[]
     stopReason: "sloppy_fallback_diff_audit",
     systemMessage,
   };
+}
+
+function buildSloppyFallbackDiffGuardFingerprint(findings: SloppyFallbackDiffFinding[]): string {
+  return JSON.stringify(findings.map((finding) => [finding.source, finding.path, finding.line]));
+}
+
+async function maybeBuildSloppyFallbackDiffStopOutput(
+  payload: CodexHookPayload,
+  cwd: string,
+  stateDir: string,
+  canonicalSessionId?: string,
+): Promise<Record<string, unknown> | null> {
+  if (isSloppyFallbackDiffAuditDisabled()) return null;
+  const findings = findSloppyFallbackDiffFindings(cwd, resolveSloppyFallbackSessionStartMs(payload, cwd));
+  const statePath = join(stateDir, NATIVE_STOP_STATE_FILE);
+  const state = await readJsonIfExists(statePath) ?? {};
+  const sessions = safeObject(state.sessions);
+  const sessionKey = readNativeStopSessionKey(payload, canonicalSessionId);
+  const sessionState = safeObject(sessions[sessionKey]);
+
+  if (findings.length === 0) {
+    if (sessionState.sloppy_fallback_diff_guard !== undefined) {
+      const clearedSessionState = { ...sessionState };
+      delete clearedSessionState.sloppy_fallback_diff_guard;
+      sessions[sessionKey] = clearedSessionState;
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(statePath, JSON.stringify({ ...state, sessions }, null, 2));
+    }
+    return null;
+  }
+
+  const fingerprint = buildSloppyFallbackDiffGuardFingerprint(findings);
+  const nowIso = new Date().toISOString();
+  const previousGuard = safeObject(sessionState.sloppy_fallback_diff_guard);
+  const sameFingerprint = safeString(previousGuard.fingerprint).trim() === fingerprint;
+  const repeatCount = sameFingerprint
+    ? parseBoundedPositiveInteger(previousGuard.repeat_count, 1) + 1
+    : 1;
+  sessions[sessionKey] = {
+    ...sessionState,
+    sloppy_fallback_diff_guard: {
+      fingerprint,
+      first_seen_at: sameFingerprint
+        ? safeString(previousGuard.first_seen_at).trim() || nowIso
+        : nowIso,
+      last_seen_at: nowIso,
+      repeat_count: repeatCount,
+      last_turn_id: readPayloadTurnId(payload) || null,
+      last_thread_id: readPayloadThreadId(payload) || null,
+    },
+  };
+  await mkdir(stateDir, { recursive: true });
+  await writeFile(statePath, JSON.stringify({ ...state, sessions }, null, 2));
+
+  const maxRepeats = parseBoundedPositiveInteger(
+    process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_MAX_REPEATS,
+    SLOPPY_FALLBACK_DIFF_STOP_DEFAULT_MAX_REPEATS,
+  );
+  if (repeatCount > maxRepeats) return null;
+
+  return await returnPersistentStopBlock(
+    payload,
+    stateDir,
+    "sloppy-fallback-diff-stop",
+    JSON.stringify(findings),
+    buildSloppyFallbackDiffStopOutput(findings),
+    canonicalSessionId,
+    { allowRepeatDuringStopHook: true },
+  );
 }
 
 function localExcludeAlreadyIgnoresOmx(cwd: string): boolean {
@@ -20781,18 +20877,14 @@ async function buildStopHookOutput(
       );
     }
 
-    const sloppyFallbackDiffFindings = findSloppyFallbackDiffFindings(cwd);
-    const sloppyFallbackDiffOutput = buildSloppyFallbackDiffStopOutput(sloppyFallbackDiffFindings);
-    if (sloppyFallbackDiffOutput) {
-      return await returnPersistentStopBlock(
-        payload,
-        stateDir,
-        "sloppy-fallback-diff-stop",
-        JSON.stringify(sloppyFallbackDiffFindings),
-        sloppyFallbackDiffOutput,
-        canonicalSessionId,
-        { allowRepeatDuringStopHook: true },
-      );
+    const sloppyFallbackDiffStopOutput = await maybeBuildSloppyFallbackDiffStopOutput(
+      payload,
+      cwd,
+      stateDir,
+      canonicalSessionId,
+    );
+    if (sloppyFallbackDiffStopOutput) {
+      return sloppyFallbackDiffStopOutput;
     }
 
     if (isFinalHandoffDocumentRefreshCandidate(lastAssistantMessage)) {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1994,7 +1994,7 @@ function buildSloppyFallbackDiffStopOutput(findings: SloppyFallbackDiffFinding[]
 }
 
 function buildSloppyFallbackDiffGuardFingerprint(findings: SloppyFallbackDiffFinding[]): string {
-  return JSON.stringify(findings.map((finding) => [finding.source, finding.path, finding.line]));
+  return JSON.stringify(findings.map((finding) => [finding.path, finding.line]));
 }
 
 async function maybeBuildSloppyFallbackDiffStopOutput(


### PR DESCRIPTION
## Summary

Fixes a permanent Stop-hook deadlock reported in #3341. The sloppy fallback/workaround diff audit re-audits the whole worktree on every `Stop` and re-blocks with `allowRepeatDuringStopHook: true` and **no repeat bound**, so any single finding — including a false positive in a pre-existing untracked file the session never touched (e.g. pinned-SHA evidence snapshots in investigation repos) — deadlocks the session forever, with no opt-out and no path exemption.

Base branch `dev` per the template guidance.

## Changes

- **Bounded repeat** (`src/scripts/codex-native-hook.ts`): the audit now goes through `maybeBuildSloppyFallbackDiffStopOutput`, which tracks identical findings per session in `native-stop-state.json` (`sloppy_fallback_diff_guard`, fingerprinted on the finding set only — not the volatile assistant message/turn id) and fails open after `OMX_NATIVE_STOP_SLOPPY_FALLBACK_MAX_REPEATS` blocks (default 3). The guard resets when findings change and clears when they disappear. Mirrors the existing `ordinary_no_progress_guard` idiom.
- **Escape hatch**: `OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT=off` (also `0`/`false`/`disabled`) disables the audit.
- **Session scoping**: untracked files whose mtime predates the session start (transcript file birth time) are skipped, so pre-existing repo content cannot block a session that never touched it. Graceful fallback to current behavior when no transcript path or birth time is available.
- **Tests**: 5 new cases — cap fail-open, cap reset on finding change, env kill switch, pre-session untracked file skipped, in-session untracked file still blocks.
- **Docs**: new "Stop: sloppy fallback/workaround diff audit" section in `docs/codex-native-hooks.md` (per the native-hook document-refresh contract).

## Validation

- [x] `npm run build`
- [x] `npm test` — 389/405 files pass; the 16 failing files fail **identically on unmodified `dev`** in this environment (A/B verified: same 23 named failures in `codex-native-hook.test.js` on both branches — tmux/team/auth/close_agent environment-dependent suites; zero new failures introduced by this change)
- [ ] `omx doctor` (when setup/config behavior changes) — N/A, no setup/config surface change
- [x] `npm run lint`, `npm run check:no-unused`, `npx tsc --noEmit` also pass
- [x] Targeted: all 12 sloppy-fallback tests pass, including the pre-existing `keeps blocking repeated Stop while sloppy fallback diff remains` (default cap 3 preserves current expectations)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed — `docs/codex-native-hooks.md`
- [x] Backward-compatibility impact considered: in-session sloppy edits still block from the first Stop and keep blocking through the cap; only *identical* findings past the cap fail open; no config/schema changes; state file gains one optional per-session guard key

## Related

Closes #3341
