### PR TITLE
fix(hooks): bound sloppy fallback Stop audit and scope it to the session

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -311,11 +311,14 @@ The audit is bounded so a single finding cannot hold a session hostage:
   open for that identical finding set.
 - `OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT=off` (also `0`/`false`/`disabled`)
   disables the audit entirely.
-- Untracked files whose mtime predates the session start (derived from the
-  transcript file's birth time) are skipped, so pre-existing repo content the
-  session never touched cannot block it. When no transcript path or birth time
-  is available, the untracked scan falls back to auditing all untracked source
-  files.
+- Untracked files that provably predate the session are skipped, so
+  pre-existing repo content the session never touched cannot block it. A file
+  counts as pre-session only when every available indicator (mtime, ctime,
+  and birth time when reported) predates the session transcript's birth time;
+  lstat semantics keep in-session symlinks to older targets auditable. This
+  prevents `cp -p`/`tar`-style preserved mtimes from smuggling new sloppy
+  lines past the audit. When no transcript path or birth time is available,
+  the untracked scan falls back to auditing all untracked source files.
 
 ## UserPromptSubmit: triage advisory context
 

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -303,9 +303,11 @@ The audit is bounded so a single finding cannot hold a session hostage:
 - Identical findings block at most `OMX_NATIVE_STOP_SLOPPY_FALLBACK_MAX_REPEATS`
   times (default 3), tracked per session in
   `.omx/state/native-stop-state.json` under `sloppy_fallback_diff_guard`. The
-  guard fingerprints the finding set only (not the assistant message), resets
-  when findings change, and clears when findings disappear. Past the cap the
-  gate fails open for that identical finding set.
+  guard fingerprints the finding set by path and line only (not the assistant
+  message, and not the staged/unstaged/untracked source, so identical findings
+  keep counting across `git add`/`git reset`), resets when findings change,
+  and clears when findings disappear. Past the cap the gate fails open for
+  that identical finding set.
 - `OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT=off` (also `0`/`false`/`disabled`)
   disables the audit entirely.
 - Untracked files whose mtime predates the session start (derived from the

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -303,11 +303,12 @@ The audit is bounded so a single finding cannot hold a session hostage:
 - Identical findings block at most `OMX_NATIVE_STOP_SLOPPY_FALLBACK_MAX_REPEATS`
   times (default 3), tracked per session in
   `.omx/state/native-stop-state.json` under `sloppy_fallback_diff_guard`. The
-  guard fingerprints the finding set by path and line only (not the assistant
-  message, and not the staged/unstaged/untracked source, so identical findings
-  keep counting across `git add`/`git reset`), resets when findings change,
-  and clears when findings disappear. Past the cap the gate fails open for
-  that identical finding set.
+  guard fingerprints the finding set by path and line only, sorted so the
+  fingerprint is order-insensitive (not the assistant message, and not the
+  staged/unstaged/untracked source, so identical findings keep counting
+  across `git add`/`git reset` and subset staging), resets when findings
+  change, and clears when findings disappear. Past the cap the gate fails
+  open for that identical finding set.
 - `OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT=off` (also `0`/`false`/`disabled`)
   disables the audit entirely.
 - Untracked files whose mtime predates the session start (derived from the

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -292,6 +292,28 @@ returns a no-op response instead of a diagnostic continuation block.
 Native `Stop` ends one assistant turn rather than the Codex process, so a
 successful `Stop` does not delete owner evidence.
 
+## Stop: sloppy fallback/workaround diff audit
+
+Native `Stop` audits the worktree for ungrounded fallback wording in added
+source lines: staged and unstaged diffs, plus untracked source files. A finding
+blocks the stop and asks the agent to ground or rework the line.
+
+The audit is bounded so a single finding cannot hold a session hostage:
+
+- Identical findings block at most `OMX_NATIVE_STOP_SLOPPY_FALLBACK_MAX_REPEATS`
+  times (default 3), tracked per session in
+  `.omx/state/native-stop-state.json` under `sloppy_fallback_diff_guard`. The
+  guard fingerprints the finding set only (not the assistant message), resets
+  when findings change, and clears when findings disappear. Past the cap the
+  gate fails open for that identical finding set.
+- `OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT=off` (also `0`/`false`/`disabled`)
+  disables the audit entirely.
+- Untracked files whose mtime predates the session start (derived from the
+  transcript file's birth time) are skipped, so pre-existing repo content the
+  session never touched cannot block it. When no transcript path or birth time
+  is available, the untracked scan falls back to auditing all untracked source
+  files.
+
 ## UserPromptSubmit: triage advisory context
 
 `UserPromptSubmit` can now emit triage advisory context alongside keyword context. When no keyword matches, the triage layer classifies the prompt and may inject an advisory prompt-routing context string — this is advisory prompt-routing context that does not activate a skill or workflow by itself; it adds a developer-context hint the model may follow. Light advisory destinations include repo-local `explore`, narrow-edit `executor`, visual `designer`, and external documentation/reference `researcher`; researcher routing is for official-doc, version-compatibility, source-backed, or external lookup requests, does not override local anchors or implementation-shaped prompts, and still writes only prompt-routing state. Keywords remain the deterministic control surface: a matched keyword always takes precedence over triage output, and users can suppress triage injection per prompt with phrases such as `no workflow`, `just chat`, or `plain answer`.

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import {
 	chmod,
 	mkdir,
@@ -9,6 +9,7 @@ import {
 	readdir,
 	rm,
 	symlink,
+	utimes,
 	writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -22544,6 +22545,164 @@ PY`,
       assert.equal((first.outputJson as { decision?: string } | null)?.decision, "block");
       assert.equal((repeated.outputJson as { decision?: string } | null)?.decision, "block");
       assert.equal((repeated.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails open after repeated identical sloppy fallback findings exceed the repeat cap", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-cap-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+      const payload = { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-cap", turn_id: "turn-cap" };
+
+      const decisions: Array<string | null> = [];
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        const result = await dispatchCodexNativeHook(
+          attempt === 0 ? payload : { ...payload, stop_hook_active: true },
+          { cwd },
+        );
+        decisions.push((result.outputJson as { decision?: string } | null)?.decision ?? null);
+      }
+
+      assert.deepEqual(decisions, ["block", "block", "block", null, null]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("resets the sloppy fallback repeat cap when findings change", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-cap-reset-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      const sloppySource = (exportName: string) => [
+        `export function ${exportName}() {`,
+        "  // implement a quick hack fallback if it fails",
+        "  return process.env.RUNTIME || 'local';",
+        "}",
+      ].join("\n");
+      await writeFile(join(cwd, "src", "runtime.ts"), sloppySource("loadRuntime"));
+      const payload = { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-cap-reset", turn_id: "turn-cap-reset" };
+
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        await dispatchCodexNativeHook(
+          attempt === 0 ? payload : { ...payload, stop_hook_active: true },
+          { cwd },
+        );
+      }
+      const allowed = await dispatchCodexNativeHook({ ...payload, stop_hook_active: true }, { cwd });
+      assert.equal(allowed.outputJson, null);
+
+      await writeFile(join(cwd, "src", "other.ts"), sloppySource("loadOther"));
+      const blockedAgain = await dispatchCodexNativeHook({ ...payload, stop_hook_active: true }, { cwd });
+      assert.equal((blockedAgain.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((blockedAgain.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("skips the sloppy fallback diff audit when OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT is off", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-disabled-");
+    const previousValue = process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT;
+    process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT = "off";
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-disabled" },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      if (previousValue === undefined) delete process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT;
+      else process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT = previousValue;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores untracked sloppy fallback files last written before the session transcript", async (t) => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-preexisting-");
+    try {
+      const transcriptPath = join(cwd, "transcript.jsonl");
+      await writeFile(transcriptPath, "{}\n");
+      const { birthtimeMs } = statSync(transcriptPath);
+      if (!(birthtimeMs > 0)) {
+        t.skip("file birth time is not available on this platform");
+        return;
+      }
+      await mkdir(join(cwd, "src"), { recursive: true });
+      const sloppyPath = join(cwd, "src", "runtime.ts");
+      await writeFile(
+        sloppyPath,
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+      const preSessionTime = new Date(Date.now() - 10 * 60_000);
+      await utimes(sloppyPath, preSessionTime, preSessionTime);
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-preexisting", transcript_path: transcriptPath },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("still blocks untracked sloppy fallback files written after the session transcript", async (t) => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-inturn-");
+    try {
+      const transcriptPath = join(cwd, "transcript.jsonl");
+      await writeFile(transcriptPath, "{}\n");
+      const { birthtimeMs } = statSync(transcriptPath);
+      if (!(birthtimeMs > 0)) {
+        t.skip("file birth time is not available on this platform");
+        return;
+      }
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-inturn", transcript_path: transcriptPath },
+        { cwd },
+      );
+
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((result.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -22611,6 +22611,39 @@ PY`,
     }
   });
 
+  it("keeps the repeat count when identical findings move across staging states", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-staging-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+      const payload = { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-staging", turn_id: "turn-staging" };
+      const stop = (attempt: number) =>
+        dispatchCodexNativeHook(attempt === 0 ? payload : { ...payload, stop_hook_active: true }, { cwd });
+
+      const first = await stop(0);
+      execFileSync("git", ["add", "src/runtime.ts"], { cwd, stdio: "ignore" });
+      const staged = await stop(1);
+      execFileSync("git", ["reset", "-q", "--", "src/runtime.ts"], { cwd, stdio: "ignore" });
+      const unstagedAgain = await stop(2);
+      const afterCap = await stop(3);
+
+      assert.equal((first.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((staged.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((unstagedAgain.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal(afterCap.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("skips the sloppy fallback diff audit when OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT is off", async () => {
     const cwd = await initTempGitRepo("omx-native-hook-stop-slop-disabled-");
     const previousValue = process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT;

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -22644,6 +22644,40 @@ PY`,
     }
   });
 
+  it("keeps the repeat count when staging a subset reorders identical findings", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-subset-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      const sloppySource = (exportName: string) => [
+        `export function ${exportName}() {`,
+        "  // implement a quick hack fallback if it fails",
+        "  return process.env.RUNTIME || 'local';",
+        "}",
+      ].join("\n");
+      await writeFile(join(cwd, "src", "alpha.ts"), sloppySource("loadAlpha"));
+      await writeFile(join(cwd, "src", "beta.ts"), sloppySource("loadBeta"));
+      const payload = { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-subset", turn_id: "turn-subset" };
+      const stop = (attempt: number) =>
+        dispatchCodexNativeHook(attempt === 0 ? payload : { ...payload, stop_hook_active: true }, { cwd });
+
+      const first = await stop(0);
+      // Staging only beta reorders the raw finding list (staged findings come
+      // first), but the fingerprint must stay identical for the same set.
+      execFileSync("git", ["add", "src/beta.ts"], { cwd, stdio: "ignore" });
+      const subsetStaged = await stop(1);
+      execFileSync("git", ["add", "src/alpha.ts"], { cwd, stdio: "ignore" });
+      const allStaged = await stop(2);
+      const afterCap = await stop(3);
+
+      assert.equal((first.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((subsetStaged.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((allStaged.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal(afterCap.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("skips the sloppy fallback diff audit when OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT is off", async () => {
     const cwd = await initTempGitRepo("omx-native-hook-stop-slop-disabled-");
     const previousValue = process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT;

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -22710,6 +22710,54 @@ PY`,
   it("ignores untracked sloppy fallback files last written before the session transcript", async (t) => {
     const cwd = await initTempGitRepo("omx-native-hook-stop-slop-preexisting-");
     try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+      // The file must genuinely predate the session: ctime/birth time cannot
+      // be backdated with utimes, so create the transcript afterwards.
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      const transcriptPath = join(cwd, "transcript.jsonl");
+      await writeFile(transcriptPath, "{}\n");
+      const { birthtimeMs } = statSync(transcriptPath);
+      if (!(birthtimeMs > 0)) {
+        t.skip("file birth time is not available on this platform");
+        return;
+      }
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-preexisting", transcript_path: transcriptPath },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("still blocks untracked sloppy fallback files materialized in-session with preserved mtime", async (t) => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-cpreserve-");
+    try {
+      const seedPath = join(cwd, "seed.ts");
+      await writeFile(
+        seedPath,
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+      const oldTime = new Date(Date.now() - 10 * 60_000);
+      await utimes(seedPath, oldTime, oldTime);
+      await new Promise((resolve) => setTimeout(resolve, 25));
       const transcriptPath = join(cwd, "transcript.jsonl");
       await writeFile(transcriptPath, "{}\n");
       const { birthtimeMs } = statSync(transcriptPath);
@@ -22718,9 +22766,26 @@ PY`,
         return;
       }
       await mkdir(join(cwd, "src"), { recursive: true });
-      const sloppyPath = join(cwd, "src", "runtime.ts");
+      execFileSync("cp", ["-p", seedPath, join(cwd, "src", "runtime.ts")], { stdio: "ignore" });
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-cpreserve", transcript_path: transcriptPath },
+        { cwd },
+      );
+
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((result.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("still blocks untracked sloppy fallback files reachable through an in-session symlink to an older target", async (t) => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-symlink-");
+    try {
+      const seedPath = join(cwd, "seed.ts");
       await writeFile(
-        sloppyPath,
+        seedPath,
         [
           "export function loadRuntime() {",
           "  // implement a quick hack fallback if it fails",
@@ -22728,15 +22793,26 @@ PY`,
           "}",
         ].join("\n"),
       );
-      const preSessionTime = new Date(Date.now() - 10 * 60_000);
-      await utimes(sloppyPath, preSessionTime, preSessionTime);
+      const oldTime = new Date(Date.now() - 10 * 60_000);
+      await utimes(seedPath, oldTime, oldTime);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      const transcriptPath = join(cwd, "transcript.jsonl");
+      await writeFile(transcriptPath, "{}\n");
+      const { birthtimeMs } = statSync(transcriptPath);
+      if (!(birthtimeMs > 0)) {
+        t.skip("file birth time is not available on this platform");
+        return;
+      }
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await symlink(seedPath, join(cwd, "src", "runtime.ts"));
 
       const result = await dispatchCodexNativeHook(
-        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-preexisting", transcript_path: transcriptPath },
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-symlink", transcript_path: transcriptPath },
         { cwd },
       );
 
-      assert.equal(result.outputJson, null);
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((result.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1948,8 +1948,14 @@ function collectSloppyFallbackFindingsFromUntracked(cwd: string, sessionStartMs?
     if (!path || !isDiffAuditableSourcePath(path)) continue;
     if (sessionStartMs != null) {
       try {
-        const { mtimeMs } = statSync(join(cwd, path));
-        if (Number.isFinite(mtimeMs) && mtimeMs < sessionStartMs) continue;
+        // Skip only files that provably predate the session: mtime alone is
+        // preservable (cp -p, tar) and statSync follows symlinks to older
+        // targets, so require every available indicator (mtime, ctime, and
+        // birth time when the filesystem reports one) to predate the session.
+        const stats = lstatSync(join(cwd, path));
+        const indicators = [stats.mtimeMs, stats.ctimeMs];
+        if (Number.isFinite(stats.birthtimeMs) && stats.birthtimeMs > 0) indicators.push(stats.birthtimeMs);
+        if (indicators.every((indicatorMs) => Number.isFinite(indicatorMs) && indicatorMs < sessionStartMs)) continue;
       } catch {
         continue;
       }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1994,7 +1994,11 @@ function buildSloppyFallbackDiffStopOutput(findings: SloppyFallbackDiffFinding[]
 }
 
 function buildSloppyFallbackDiffGuardFingerprint(findings: SloppyFallbackDiffFinding[]): string {
-  return JSON.stringify(findings.map((finding) => [finding.path, finding.line]));
+  return JSON.stringify(
+    findings
+      .map((finding) => [finding.path, finding.line] as const)
+      .sort(([pathA, lineA], [pathB, lineB]) => pathA.localeCompare(pathB) || lineA.localeCompare(lineB)),
+  );
 }
 
 async function maybeBuildSloppyFallbackDiffStopOutput(

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -219,6 +219,7 @@ const NATIVE_STOP_STATE_FILE = "native-stop-state.json";
 const NATIVE_SUBAGENT_CAPACITY_BLOCKER_FILE = "native-subagent-capacity-blocker.json";
 const NATIVE_SUBAGENT_CAPACITY_BLOCKER_TTL_MS = 30 * 60_000;
 const ORDINARY_STOP_NO_PROGRESS_DEFAULT_MAX_REPEATS = 8;
+const SLOPPY_FALLBACK_DIFF_STOP_DEFAULT_MAX_REPEATS = 3;
 const RALPH_ORPHANED_STARTING_STALE_MS = 15 * 60_000;
 const ORDINARY_STOP_NO_PROGRESS_DEFAULT_IDLE_MS = 10 * 60_000;
 const ORDINARY_STOP_NO_PROGRESS_MAX_MESSAGE_LENGTH = 240;
@@ -1920,13 +1921,39 @@ function collectSloppyFallbackFindingsFromPatch(
   return findings;
 }
 
-function collectSloppyFallbackFindingsFromUntracked(cwd: string): SloppyFallbackDiffFinding[] {
+function isSloppyFallbackDiffAuditDisabled(): boolean {
+  return /^(?:0|off|false|disabled?)$/i.test(
+    safeString(process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT).trim(),
+  );
+}
+
+function resolveSloppyFallbackSessionStartMs(payload: CodexHookPayload, cwd: string): number | null {
+  const transcriptPath = safeString(payload.transcript_path ?? payload.transcriptPath).trim();
+  if (!transcriptPath) return null;
+  try {
+    const resolvedPath = isAbsolute(transcriptPath) ? transcriptPath : resolve(cwd, transcriptPath);
+    const { birthtimeMs } = statSync(resolvedPath);
+    return Number.isFinite(birthtimeMs) && birthtimeMs > 0 ? birthtimeMs : null;
+  } catch {
+    return null;
+  }
+}
+
+function collectSloppyFallbackFindingsFromUntracked(cwd: string, sessionStartMs?: number | null): SloppyFallbackDiffFinding[] {
   const output = gitOutput(cwd, ["ls-files", "--others", "--exclude-standard", "-z"]);
   if (!output) return [];
   const findings: SloppyFallbackDiffFinding[] = [];
   for (const rawPath of output.split("\0")) {
     const path = normalizeGitPath(rawPath.trim());
     if (!path || !isDiffAuditableSourcePath(path)) continue;
+    if (sessionStartMs != null) {
+      try {
+        const { mtimeMs } = statSync(join(cwd, path));
+        if (Number.isFinite(mtimeMs) && mtimeMs < sessionStartMs) continue;
+      } catch {
+        continue;
+      }
+    }
     let content = "";
     try {
       content = readFileSync(join(cwd, path), "utf-8");
@@ -1938,14 +1965,14 @@ function collectSloppyFallbackFindingsFromUntracked(cwd: string): SloppyFallback
   return findings;
 }
 
-function findSloppyFallbackDiffFindings(cwd: string): SloppyFallbackDiffFinding[] {
+function findSloppyFallbackDiffFindings(cwd: string, sessionStartMs?: number | null): SloppyFallbackDiffFinding[] {
   const layout = findGitLayout(cwd);
   if (!layout) return [];
   const auditRoot = layout.worktreeRoot;
   return [
     ...collectSloppyFallbackFindingsFromPatch(gitOutput(auditRoot, ["diff", "--cached", "--no-ext-diff", "--unified=3"]), "staged"),
     ...collectSloppyFallbackFindingsFromPatch(gitOutput(auditRoot, ["diff", "--no-ext-diff", "--unified=3"]), "unstaged"),
-    ...collectSloppyFallbackFindingsFromUntracked(auditRoot),
+    ...collectSloppyFallbackFindingsFromUntracked(auditRoot, sessionStartMs),
   ];
 }
 
@@ -1964,6 +1991,75 @@ function buildSloppyFallbackDiffStopOutput(findings: SloppyFallbackDiffFinding[]
     stopReason: "sloppy_fallback_diff_audit",
     systemMessage,
   };
+}
+
+function buildSloppyFallbackDiffGuardFingerprint(findings: SloppyFallbackDiffFinding[]): string {
+  return JSON.stringify(findings.map((finding) => [finding.source, finding.path, finding.line]));
+}
+
+async function maybeBuildSloppyFallbackDiffStopOutput(
+  payload: CodexHookPayload,
+  cwd: string,
+  stateDir: string,
+  canonicalSessionId?: string,
+): Promise<Record<string, unknown> | null> {
+  if (isSloppyFallbackDiffAuditDisabled()) return null;
+  const findings = findSloppyFallbackDiffFindings(cwd, resolveSloppyFallbackSessionStartMs(payload, cwd));
+  const statePath = join(stateDir, NATIVE_STOP_STATE_FILE);
+  const state = await readJsonIfExists(statePath) ?? {};
+  const sessions = safeObject(state.sessions);
+  const sessionKey = readNativeStopSessionKey(payload, canonicalSessionId);
+  const sessionState = safeObject(sessions[sessionKey]);
+
+  if (findings.length === 0) {
+    if (sessionState.sloppy_fallback_diff_guard !== undefined) {
+      const clearedSessionState = { ...sessionState };
+      delete clearedSessionState.sloppy_fallback_diff_guard;
+      sessions[sessionKey] = clearedSessionState;
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(statePath, JSON.stringify({ ...state, sessions }, null, 2));
+    }
+    return null;
+  }
+
+  const fingerprint = buildSloppyFallbackDiffGuardFingerprint(findings);
+  const nowIso = new Date().toISOString();
+  const previousGuard = safeObject(sessionState.sloppy_fallback_diff_guard);
+  const sameFingerprint = safeString(previousGuard.fingerprint).trim() === fingerprint;
+  const repeatCount = sameFingerprint
+    ? parseBoundedPositiveInteger(previousGuard.repeat_count, 1) + 1
+    : 1;
+  sessions[sessionKey] = {
+    ...sessionState,
+    sloppy_fallback_diff_guard: {
+      fingerprint,
+      first_seen_at: sameFingerprint
+        ? safeString(previousGuard.first_seen_at).trim() || nowIso
+        : nowIso,
+      last_seen_at: nowIso,
+      repeat_count: repeatCount,
+      last_turn_id: readPayloadTurnId(payload) || null,
+      last_thread_id: readPayloadThreadId(payload) || null,
+    },
+  };
+  await mkdir(stateDir, { recursive: true });
+  await writeFile(statePath, JSON.stringify({ ...state, sessions }, null, 2));
+
+  const maxRepeats = parseBoundedPositiveInteger(
+    process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_MAX_REPEATS,
+    SLOPPY_FALLBACK_DIFF_STOP_DEFAULT_MAX_REPEATS,
+  );
+  if (repeatCount > maxRepeats) return null;
+
+  return await returnPersistentStopBlock(
+    payload,
+    stateDir,
+    "sloppy-fallback-diff-stop",
+    JSON.stringify(findings),
+    buildSloppyFallbackDiffStopOutput(findings),
+    canonicalSessionId,
+    { allowRepeatDuringStopHook: true },
+  );
 }
 
 function localExcludeAlreadyIgnoresOmx(cwd: string): boolean {
@@ -20781,18 +20877,14 @@ async function buildStopHookOutput(
       );
     }
 
-    const sloppyFallbackDiffFindings = findSloppyFallbackDiffFindings(cwd);
-    const sloppyFallbackDiffOutput = buildSloppyFallbackDiffStopOutput(sloppyFallbackDiffFindings);
-    if (sloppyFallbackDiffOutput) {
-      return await returnPersistentStopBlock(
-        payload,
-        stateDir,
-        "sloppy-fallback-diff-stop",
-        JSON.stringify(sloppyFallbackDiffFindings),
-        sloppyFallbackDiffOutput,
-        canonicalSessionId,
-        { allowRepeatDuringStopHook: true },
-      );
+    const sloppyFallbackDiffStopOutput = await maybeBuildSloppyFallbackDiffStopOutput(
+      payload,
+      cwd,
+      stateDir,
+      canonicalSessionId,
+    );
+    if (sloppyFallbackDiffStopOutput) {
+      return sloppyFallbackDiffStopOutput;
     }
 
     if (isFinalHandoffDocumentRefreshCandidate(lastAssistantMessage)) {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1994,7 +1994,7 @@ function buildSloppyFallbackDiffStopOutput(findings: SloppyFallbackDiffFinding[]
 }
 
 function buildSloppyFallbackDiffGuardFingerprint(findings: SloppyFallbackDiffFinding[]): string {
-  return JSON.stringify(findings.map((finding) => [finding.source, finding.path, finding.line]));
+  return JSON.stringify(findings.map((finding) => [finding.path, finding.line]));
 }
 
 async function maybeBuildSloppyFallbackDiffStopOutput(


### PR DESCRIPTION
## Summary

Fixes the permanent Stop-hook deadlock from #3341 (full analysis there). **Supersedes #3342**, which was closed with terminal REQUEST_CHANGES on head `a470d16d`:

> *"the order-sensitive finding fingerprint still permits repeat-cap reset via staging-state reordering."*

That critique was correct, and this version fixes it. The repeat-guard fingerprint is now **order-insensitive and staging-state-insensitive**: findings are fingerprinted as the *sorted* set of `(path, line)` pairs. Rationale: the raw scan concatenates staged findings before unstaged/untracked ones, so staging a *subset* of flagged files reordered the finding list and produced a different fingerprint for the identical finding set — resetting the counter, exactly as the review said. Sorting makes the fingerprint invariant to scan order, so an identical finding set keeps one counter no matter how `git add` / `git reset` shuffles files between buckets.

The new regression test `keeps the repeat count when staging a subset reorders identical findings` **fails without the sort (verified adversarially) and passes with it**.

## Changes

Delta vs closed #3342 (everything else unchanged):

- Fingerprint: sorted `(path, line)` set (was: scan-order `(path, line)` list) — `buildSloppyFallbackDiffGuardFingerprint`
- Test: subset-staging reorder regression
- Docs: order-insensitivity note in `docs/codex-native-hooks.md`

Carried over from #3342:

- **Bounded repeat**: per-session `sloppy_fallback_diff_guard` in `native-stop-state.json`; identical findings block at most `OMX_NATIVE_STOP_SLOPPY_FALLBACK_MAX_REPEATS` times (default 3), then fail open; resets on finding-set change, clears when findings disappear (mirrors the `ordinary_no_progress_guard` idiom)
- **Escape hatch**: `OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT=off`
- **Session scoping**: untracked files whose mtime predates the session transcript's birth time are skipped (graceful fallback when unavailable)
- **Tests**: cap fail-open, cap reset on change, kill switch, pre-session untracked skip, in-session untracked still blocks, staging-state moves, subset-staging reorder
- **Docs**: "Stop: sloppy fallback/workaround diff audit" section

## Validation

- [x] `npm run build`
- [x] `npm test` — A/B verified against unmodified `dev`: the 23 failing tests in `codex-native-hook.test.js` are **identical by name** on both branches (pre-existing tmux/team/auth/close_agent environment-dependent failures); zero new failures introduced
- [ ] `omx doctor` (when setup/config behavior changes) — N/A, no setup/config surface change
- [x] `npm run lint`, `npm run check:no-unused`, `npx tsc --noEmit`
- [x] Targeted: 14 sloppy-fallback/repeat-cap tests pass; reorder regression verified to fail without the fix

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed — `docs/codex-native-hooks.md`
- [x] Backward-compatibility impact considered: in-session sloppy edits still block from the first Stop through the cap; only identical findings past the cap fail open; no config/schema changes; state file gains one optional per-session guard key

## Related

Closes #3341
Supersedes #3342
