### PR TITLE
fix(hooks): remove nonexistent native assignment guidance

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -35052,7 +35052,7 @@ PY`,
         },
       });
 
-      // A tracked descendant has same-session provenance but no assigned write authority.
+      // A tracked descendant has same-session provenance but no product-write authority.
       const trackedDescendant = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",
@@ -35068,7 +35068,7 @@ PY`,
       assert.match(String(trackedDescendant.outputJson?.reason ?? ""), /OWNER_CONFIRMATION_REQUIRED/);
       assert.doesNotMatch(String(trackedDescendant.outputJson?.reason ?? ""), /Main-root/);
 
-      // A runtime-proven descendant has same-session provenance but no assigned write authority.
+      // A runtime-proven descendant has same-session provenance but no product-write authority.
       const chainedDescendant = await dispatchCodexNativeHook(
         {
           hook_event_name: "PreToolUse",

--- a/src/scripts/__tests__/issue-3311-ultragoal-native-outside-tmux.test.ts
+++ b/src/scripts/__tests__/issue-3311-ultragoal-native-outside-tmux.test.ts
@@ -84,6 +84,12 @@ describe("issue-3311: standalone Ultragoal native-App outside-tmux activation gu
 
       assert.equal(result.outputJson?.decision, "block");
       assert.match(String(result.outputJson?.reason ?? ""), /OMX-ULTRAGOAL-NO-OWNER/);
+      const context = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } } | null)
+          ?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(context, /native child\/descendant provenance does not grant write authority/);
+      assert.doesNotMatch(context, /write-assignment|assignment-backed|scoped native .*grant/i);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -114,6 +120,12 @@ describe("issue-3311: standalone Ultragoal native-App outside-tmux activation gu
 
       assert.equal(result.outputJson?.decision, "block");
       assert.match(String(result.outputJson?.reason ?? ""), /OMX-ULTRAGOAL-NO-OWNER/);
+      const context = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } } | null)
+          ?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(context, /native child\/descendant provenance does not grant write authority/);
+      assert.doesNotMatch(context, /write-assignment|assignment-backed|scoped native .*grant/i);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -147,6 +159,12 @@ describe("issue-3311: standalone Ultragoal native-App outside-tmux activation gu
 
       assert.equal(result.outputJson?.decision, "block");
       assert.match(String(result.outputJson?.reason ?? ""), /OMX-ULTRAGOAL-NO-OWNER/);
+      const context = String(
+        (result.outputJson as { hookSpecificOutput?: { additionalContext?: string } } | null)
+          ?.hookSpecificOutput?.additionalContext || "",
+      );
+      assert.match(context, /native child\/descendant provenance does not grant write authority/);
+      assert.doesNotMatch(context, /write-assignment|assignment-backed|scoped native .*grant/i);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -10030,12 +10030,12 @@ function buildPlanningActorWriteDeny(
     decision: "block",
     reason: provenanceConflict
       ? `PROVENANCE_DENIED: ${modeLabel} is active (phase: ${phase}); payload identity aliases conflict and cannot authorize a write.`
-      : `OWNER_CONFIRMATION_REQUIRED: ${modeLabel} is active (phase: ${phase}); implementation/write tools are blocked because native child/descendant provenance establishes same-session origin, not assigned write authority.`,
+      : `OWNER_CONFIRMATION_REQUIRED: ${modeLabel} is active (phase: ${phase}); implementation/write tools are blocked because native child/descendant provenance establishes same-session origin, not product-write authority.`,
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       additionalContext: provenanceConflict
         ? "PROVENANCE_DENIED: Conflicting or ambiguous native identity cannot authorize planning or workflow-state mutations."
-        : `OWNER_CONFIRMATION_REQUIRED: Native child/descendant provenance permits only positively classified read-only operations unless exact authoritative write assignment exists. ${modeLabel === "Deep-interview" ? "Deep-interview remains requirements/spec mode." : "Planning artifact paths do not grant write authority."}`,
+        : `OWNER_CONFIRMATION_REQUIRED: Native child/descendant provenance permits only positively classified read-only operations in this implementation. ${modeLabel === "Deep-interview" ? "Deep-interview remains requirements/spec mode." : "Planning artifact paths do not grant write authority."}`,
     },
   };
 }
@@ -10764,9 +10764,9 @@ async function buildUltragoalNoOwnerActivationGuardOutput(
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       additionalContext:
-        "Standalone Ultragoal Conductor mode requires either an attached tmux session (Team execution) or a scoped "
-        + "native write-assignment grant, neither of which exists on native Codex App outside tmux. Do not set "
-        + "ultragoal active/current_phase here. Proceed with direct bounded implementation for this task without "
+        "Standalone Ultragoal Conductor mode requires an attached tmux session (Team execution) on native Codex App "
+        + "outside tmux; native child/descendant provenance does not grant write authority. Do not set ultragoal "
+        + "active/current_phase here. Proceed with direct bounded implementation for this task without "
         + "entering Ultragoal's Conductor-gated planning mode, or re-run from an attached tmux OMX CLI shell so "
         + "`omx team` is available. `omx cancel` remains available if a stuck Conductor state already exists.",
     },
@@ -19629,11 +19629,11 @@ export async function buildConductorPreToolUseWriteGuardOutput(
       decision: "block",
       reason:
         `OWNER_CONFIRMATION_REQUIRED: Conductor mode is active (${activeState.mode} phase: ${formatPhase(activeState.phase, "active")}); `
-        + `native child/descendant provenance establishes same-session origin, not assigned write authority; ${blockedDetail}.`,
+        + `native child/descendant provenance establishes same-session origin, not product-write authority; ${blockedDetail}.`,
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
         additionalContext:
-          "OWNER_CONFIRMATION_REQUIRED: Native child/descendant provenance establishes only session membership, not assigned write authority. "
+          "OWNER_CONFIRMATION_REQUIRED: Native child/descendant provenance establishes only session membership, not product-write authority. "
           + "Do not perform source, package, git, or other substantive writes; return control to the owning Conductor for explicit confirmation.",
       },
     };


### PR DESCRIPTION
## Summary

- remove the unimplemented native write-assignment alternative from standalone Ultragoal native-outside-tmux denial guidance
- keep native child/descendant provenance fail-closed as read-only/product-write denied, matching the existing Option C contract
- add regression assertions that the Ultragoal activation denial no longer advertises `write-assignment`, `assignment-backed`, or a scoped native grant while preserving `OMX-ULTRAGOAL-NO-OWNER`

## Scope

Smallest #3319 resolution path: do **not** implement a new assignment subsystem. Current docs already state no assignment-backed grant exists in this implementation, so the runtime denial text must stop advertising one.

Related to #3309; fixes #3319.

## Verification

- `npm ci`
- `npm run build`
- `node --test dist/scripts/__tests__/issue-3311-ultragoal-native-outside-tmux.test.js` — 14/14 pass
- `node --test dist/scripts/__tests__/codex-native-hook.test.js` — 620/620 pass
- `npm run lint` — 788 files clean
- `npx tsc --noEmit` — clean
- `npm run check:no-unused` — clean
- `git diff --check` — clean

## #3309 reconciliation after #3326

Concrete resolved slices now on `dev` before this PR:

- #3326 resolved the narrow transactional bootstrap-authority slice: explicit malformed/unbound `OMX_SESSION_ID` now rejects new Ultragoal bootstrap atomically before durable plan artifacts are published.
- #3332 resolved the exact `OMX_SESSION_ID` / identity-indeterminate pointer recovery slice tracked separately as #3324.
- #3318 resolved the planning-mode read-only discovery/self-lock slice tracked by #3313/#3314.

Concrete slice this PR resolves:

- #3319: runtime guidance advertised a native write-assignment path that no implementation could create, persist, or consume.

Remaining concrete #3309 slices are only those with independent open issue/backlog ownership, not this PR:

- terminal-state convergence across native goal tools, OMX workflow state, and Ultragoal ledger state when fresh reproducible evidence is filed/accepted;
- bounded recovery/tracker cardinality and reclaimable native collaboration capacity when fresh reproducible evidence is filed/accepted;
- currently open non-#3309 hook/platform regressions remain separately tracked (#3320, #3321/#3322/#3323/#3325/#3327, #3333, #3341/#3343/#3344) and are intentionally outside this PR.

Signed-off-by: Yeachan-Heo <54757707+Yeachan-Heo@users.noreply.github.com>
