### PR TITLE
fix(hooks): bound sloppy fallback Stop audit and scope it to the session

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -303,12 +303,13 @@ The audit is bounded so a single finding cannot hold a session hostage:
 - Identical findings block at most `OMX_NATIVE_STOP_SLOPPY_FALLBACK_MAX_REPEATS`
   times (default 3), tracked per session in
   `.omx/state/native-stop-state.json` under `sloppy_fallback_diff_guard`. The
-  guard fingerprints the finding set by path and line only, sorted so the
-  fingerprint is order-insensitive (not the assistant message, and not the
-  staged/unstaged/untracked source, so identical findings keep counting
-  across `git add`/`git reset` and subset staging), resets when findings
-  change, and clears when findings disappear. Past the cap the gate fails
-  open for that identical finding set.
+  guard fingerprints the finding set by path, line text, and new-file line
+  number, sorted so the fingerprint is order-insensitive (not the assistant
+  message, and not the staged/unstaged/untracked source, so identical
+  findings keep counting across `git add`/`git reset` and subset staging,
+  while relocating the same text to another line starts a fresh count),
+  resets when findings change, and clears when findings disappear. Past the
+  cap the gate fails open for that identical finding set.
 - `OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT=off` (also `0`/`false`/`disabled`)
   disables the audit entirely.
 - Untracked files that provably predate the session are skipped, so

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -316,9 +316,11 @@ The audit is bounded so a single finding cannot hold a session hostage:
   pre-existing repo content the session never touched cannot block it. A file
   counts as pre-session only when every available indicator (mtime, ctime,
   and birth time when reported) predates the session transcript's birth time;
-  lstat semantics keep in-session symlinks to older targets auditable. This
-  prevents `cp -p`/`tar`-style preserved mtimes from smuggling new sloppy
-  lines past the audit. The transcript birth time is trusted only when it is
+  lstat semantics keep in-session symlinks to older targets auditable, and
+  symlink targets are stat'ed as well, so a pre-session link whose target is
+  rewritten during the session is audited too. This prevents
+  `cp -p`/`tar`-style preserved mtimes from smuggling new sloppy lines past
+  the audit. The transcript birth time is trusted only when it is
   immutable — when the filesystem reports no birth time or one
   indistinguishable from ctime (a mutable fallback that transcript appends
   would move), the scoping is disabled and all untracked source files are

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -317,8 +317,11 @@ The audit is bounded so a single finding cannot hold a session hostage:
   and birth time when reported) predates the session transcript's birth time;
   lstat semantics keep in-session symlinks to older targets auditable. This
   prevents `cp -p`/`tar`-style preserved mtimes from smuggling new sloppy
-  lines past the audit. When no transcript path or birth time is available,
-  the untracked scan falls back to auditing all untracked source files.
+  lines past the audit. The transcript birth time is trusted only when it is
+  immutable — when the filesystem reports no birth time or one
+  indistinguishable from ctime (a mutable fallback that transcript appends
+  would move), the scoping is disabled and all untracked source files are
+  audited.
 
 ## UserPromptSubmit: triage advisory context
 

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -311,11 +311,14 @@ The audit is bounded so a single finding cannot hold a session hostage:
   open for that identical finding set.
 - `OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT=off` (also `0`/`false`/`disabled`)
   disables the audit entirely.
-- Untracked files whose mtime predates the session start (derived from the
-  transcript file's birth time) are skipped, so pre-existing repo content the
-  session never touched cannot block it. When no transcript path or birth time
-  is available, the untracked scan falls back to auditing all untracked source
-  files.
+- Untracked files that provably predate the session are skipped, so
+  pre-existing repo content the session never touched cannot block it. A file
+  counts as pre-session only when every available indicator (mtime, ctime,
+  and birth time when reported) predates the session transcript's birth time;
+  lstat semantics keep in-session symlinks to older targets auditable. This
+  prevents `cp -p`/`tar`-style preserved mtimes from smuggling new sloppy
+  lines past the audit. When no transcript path or birth time is available,
+  the untracked scan falls back to auditing all untracked source files.
 
 ## UserPromptSubmit: triage advisory context
 

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -303,9 +303,11 @@ The audit is bounded so a single finding cannot hold a session hostage:
 - Identical findings block at most `OMX_NATIVE_STOP_SLOPPY_FALLBACK_MAX_REPEATS`
   times (default 3), tracked per session in
   `.omx/state/native-stop-state.json` under `sloppy_fallback_diff_guard`. The
-  guard fingerprints the finding set only (not the assistant message), resets
-  when findings change, and clears when findings disappear. Past the cap the
-  gate fails open for that identical finding set.
+  guard fingerprints the finding set by path and line only (not the assistant
+  message, and not the staged/unstaged/untracked source, so identical findings
+  keep counting across `git add`/`git reset`), resets when findings change,
+  and clears when findings disappear. Past the cap the gate fails open for
+  that identical finding set.
 - `OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT=off` (also `0`/`false`/`disabled`)
   disables the audit entirely.
 - Untracked files whose mtime predates the session start (derived from the

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -303,11 +303,12 @@ The audit is bounded so a single finding cannot hold a session hostage:
 - Identical findings block at most `OMX_NATIVE_STOP_SLOPPY_FALLBACK_MAX_REPEATS`
   times (default 3), tracked per session in
   `.omx/state/native-stop-state.json` under `sloppy_fallback_diff_guard`. The
-  guard fingerprints the finding set by path and line only (not the assistant
-  message, and not the staged/unstaged/untracked source, so identical findings
-  keep counting across `git add`/`git reset`), resets when findings change,
-  and clears when findings disappear. Past the cap the gate fails open for
-  that identical finding set.
+  guard fingerprints the finding set by path and line only, sorted so the
+  fingerprint is order-insensitive (not the assistant message, and not the
+  staged/unstaged/untracked source, so identical findings keep counting
+  across `git add`/`git reset` and subset staging), resets when findings
+  change, and clears when findings disappear. Past the cap the gate fails
+  open for that identical finding set.
 - `OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT=off` (also `0`/`false`/`disabled`)
   disables the audit entirely.
 - Untracked files whose mtime predates the session start (derived from the

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -292,6 +292,28 @@ returns a no-op response instead of a diagnostic continuation block.
 Native `Stop` ends one assistant turn rather than the Codex process, so a
 successful `Stop` does not delete owner evidence.
 
+## Stop: sloppy fallback/workaround diff audit
+
+Native `Stop` audits the worktree for ungrounded fallback wording in added
+source lines: staged and unstaged diffs, plus untracked source files. A finding
+blocks the stop and asks the agent to ground or rework the line.
+
+The audit is bounded so a single finding cannot hold a session hostage:
+
+- Identical findings block at most `OMX_NATIVE_STOP_SLOPPY_FALLBACK_MAX_REPEATS`
+  times (default 3), tracked per session in
+  `.omx/state/native-stop-state.json` under `sloppy_fallback_diff_guard`. The
+  guard fingerprints the finding set only (not the assistant message), resets
+  when findings change, and clears when findings disappear. Past the cap the
+  gate fails open for that identical finding set.
+- `OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT=off` (also `0`/`false`/`disabled`)
+  disables the audit entirely.
+- Untracked files whose mtime predates the session start (derived from the
+  transcript file's birth time) are skipped, so pre-existing repo content the
+  session never touched cannot block it. When no transcript path or birth time
+  is available, the untracked scan falls back to auditing all untracked source
+  files.
+
 ## UserPromptSubmit: triage advisory context
 
 `UserPromptSubmit` can now emit triage advisory context alongside keyword context. When no keyword matches, the triage layer classifies the prompt and may inject an advisory prompt-routing context string — this is advisory prompt-routing context that does not activate a skill or workflow by itself; it adds a developer-context hint the model may follow. Light advisory destinations include repo-local `explore`, narrow-edit `executor`, visual `designer`, and external documentation/reference `researcher`; researcher routing is for official-doc, version-compatibility, source-backed, or external lookup requests, does not override local anchors or implementation-shaped prompts, and still writes only prompt-routing state. Keywords remain the deterministic control surface: a matched keyword always takes precedence over triage output, and users can suppress triage injection per prompt with phrases such as `no workflow`, `just chat`, or `plain answer`.

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -23298,6 +23298,54 @@ PY`,
   it("ignores untracked sloppy fallback files last written before the session transcript", async (t) => {
     const cwd = await initTempGitRepo("omx-native-hook-stop-slop-preexisting-");
     try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+      // The file must genuinely predate the session: ctime/birth time cannot
+      // be backdated with utimes, so create the transcript afterwards.
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      const transcriptPath = join(cwd, "transcript.jsonl");
+      await writeFile(transcriptPath, "{}\n");
+      const { birthtimeMs } = statSync(transcriptPath);
+      if (!(birthtimeMs > 0)) {
+        t.skip("file birth time is not available on this platform");
+        return;
+      }
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-preexisting", transcript_path: transcriptPath },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("still blocks untracked sloppy fallback files materialized in-session with preserved mtime", async (t) => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-cpreserve-");
+    try {
+      const seedPath = join(cwd, "seed.ts");
+      await writeFile(
+        seedPath,
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+      const oldTime = new Date(Date.now() - 10 * 60_000);
+      await utimes(seedPath, oldTime, oldTime);
+      await new Promise((resolve) => setTimeout(resolve, 25));
       const transcriptPath = join(cwd, "transcript.jsonl");
       await writeFile(transcriptPath, "{}\n");
       const { birthtimeMs } = statSync(transcriptPath);
@@ -23306,9 +23354,26 @@ PY`,
         return;
       }
       await mkdir(join(cwd, "src"), { recursive: true });
-      const sloppyPath = join(cwd, "src", "runtime.ts");
+      execFileSync("cp", ["-p", seedPath, join(cwd, "src", "runtime.ts")], { stdio: "ignore" });
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-cpreserve", transcript_path: transcriptPath },
+        { cwd },
+      );
+
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((result.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("still blocks untracked sloppy fallback files reachable through an in-session symlink to an older target", async (t) => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-symlink-");
+    try {
+      const seedPath = join(cwd, "seed.ts");
       await writeFile(
-        sloppyPath,
+        seedPath,
         [
           "export function loadRuntime() {",
           "  // implement a quick hack fallback if it fails",
@@ -23316,15 +23381,26 @@ PY`,
           "}",
         ].join("\n"),
       );
-      const preSessionTime = new Date(Date.now() - 10 * 60_000);
-      await utimes(sloppyPath, preSessionTime, preSessionTime);
+      const oldTime = new Date(Date.now() - 10 * 60_000);
+      await utimes(seedPath, oldTime, oldTime);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      const transcriptPath = join(cwd, "transcript.jsonl");
+      await writeFile(transcriptPath, "{}\n");
+      const { birthtimeMs } = statSync(transcriptPath);
+      if (!(birthtimeMs > 0)) {
+        t.skip("file birth time is not available on this platform");
+        return;
+      }
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await symlink(seedPath, join(cwd, "src", "runtime.ts"));
 
       const result = await dispatchCodexNativeHook(
-        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-preexisting", transcript_path: transcriptPath },
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-symlink", transcript_path: transcriptPath },
         { cwd },
       );
 
-      assert.equal(result.outputJson, null);
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((result.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -23199,6 +23199,39 @@ PY`,
     }
   });
 
+  it("keeps the repeat count when identical findings move across staging states", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-staging-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+      const payload = { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-staging", turn_id: "turn-staging" };
+      const stop = (attempt: number) =>
+        dispatchCodexNativeHook(attempt === 0 ? payload : { ...payload, stop_hook_active: true }, { cwd });
+
+      const first = await stop(0);
+      execFileSync("git", ["add", "src/runtime.ts"], { cwd, stdio: "ignore" });
+      const staged = await stop(1);
+      execFileSync("git", ["reset", "-q", "--", "src/runtime.ts"], { cwd, stdio: "ignore" });
+      const unstagedAgain = await stop(2);
+      const afterCap = await stop(3);
+
+      assert.equal((first.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((staged.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((unstagedAgain.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal(afterCap.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("skips the sloppy fallback diff audit when OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT is off", async () => {
     const cwd = await initTempGitRepo("omx-native-hook-stop-slop-disabled-");
     const previousValue = process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT;

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -23268,6 +23268,39 @@ PY`,
     }
   });
 
+  it("resets the repeat cap when a finding moves to a new line in the same file", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-moveline-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      const sloppySource = (headerLines: string[]) => [
+        ...headerLines,
+        "export function loadRuntime() {",
+        "  // implement a quick hack fallback if it fails",
+        "  return process.env.RUNTIME || 'local';",
+        "}",
+      ].join("\n");
+      await writeFile(join(cwd, "src", "runtime.ts"), sloppySource([]));
+      const payload = { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-moveline", turn_id: "turn-moveline" };
+      const stop = (attempt: number) =>
+        dispatchCodexNativeHook(attempt === 0 ? payload : { ...payload, stop_hook_active: true }, { cwd });
+
+      for (let attempt = 0; attempt < 4; attempt += 1) {
+        await stop(attempt);
+      }
+      const allowed = await dispatchCodexNativeHook({ ...payload, stop_hook_active: true }, { cwd });
+      assert.equal(allowed.outputJson, null);
+
+      // The identical text relocated to another line is a new finding set and
+      // must block again rather than inherit the exhausted repeat cap.
+      await writeFile(join(cwd, "src", "runtime.ts"), sloppySource(["// header comment"]));
+      const blockedAgain = await dispatchCodexNativeHook({ ...payload, stop_hook_active: true }, { cwd });
+      assert.equal((blockedAgain.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((blockedAgain.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("skips the sloppy fallback diff audit when OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT is off", async () => {
     const cwd = await initTempGitRepo("omx-native-hook-stop-slop-disabled-");
     const previousValue = process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT;

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import {
 	chmod,
 	mkdir,
@@ -9,6 +9,7 @@ import {
 	readdir,
 	rm,
 	symlink,
+	utimes,
 	writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -23132,6 +23133,164 @@ PY`,
       assert.equal((first.outputJson as { decision?: string } | null)?.decision, "block");
       assert.equal((repeated.outputJson as { decision?: string } | null)?.decision, "block");
       assert.equal((repeated.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails open after repeated identical sloppy fallback findings exceed the repeat cap", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-cap-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+      const payload = { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-cap", turn_id: "turn-cap" };
+
+      const decisions: Array<string | null> = [];
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        const result = await dispatchCodexNativeHook(
+          attempt === 0 ? payload : { ...payload, stop_hook_active: true },
+          { cwd },
+        );
+        decisions.push((result.outputJson as { decision?: string } | null)?.decision ?? null);
+      }
+
+      assert.deepEqual(decisions, ["block", "block", "block", null, null]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("resets the sloppy fallback repeat cap when findings change", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-cap-reset-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      const sloppySource = (exportName: string) => [
+        `export function ${exportName}() {`,
+        "  // implement a quick hack fallback if it fails",
+        "  return process.env.RUNTIME || 'local';",
+        "}",
+      ].join("\n");
+      await writeFile(join(cwd, "src", "runtime.ts"), sloppySource("loadRuntime"));
+      const payload = { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-cap-reset", turn_id: "turn-cap-reset" };
+
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        await dispatchCodexNativeHook(
+          attempt === 0 ? payload : { ...payload, stop_hook_active: true },
+          { cwd },
+        );
+      }
+      const allowed = await dispatchCodexNativeHook({ ...payload, stop_hook_active: true }, { cwd });
+      assert.equal(allowed.outputJson, null);
+
+      await writeFile(join(cwd, "src", "other.ts"), sloppySource("loadOther"));
+      const blockedAgain = await dispatchCodexNativeHook({ ...payload, stop_hook_active: true }, { cwd });
+      assert.equal((blockedAgain.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((blockedAgain.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("skips the sloppy fallback diff audit when OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT is off", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-disabled-");
+    const previousValue = process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT;
+    process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT = "off";
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-disabled" },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      if (previousValue === undefined) delete process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT;
+      else process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT = previousValue;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores untracked sloppy fallback files last written before the session transcript", async (t) => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-preexisting-");
+    try {
+      const transcriptPath = join(cwd, "transcript.jsonl");
+      await writeFile(transcriptPath, "{}\n");
+      const { birthtimeMs } = statSync(transcriptPath);
+      if (!(birthtimeMs > 0)) {
+        t.skip("file birth time is not available on this platform");
+        return;
+      }
+      await mkdir(join(cwd, "src"), { recursive: true });
+      const sloppyPath = join(cwd, "src", "runtime.ts");
+      await writeFile(
+        sloppyPath,
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+      const preSessionTime = new Date(Date.now() - 10 * 60_000);
+      await utimes(sloppyPath, preSessionTime, preSessionTime);
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-preexisting", transcript_path: transcriptPath },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("still blocks untracked sloppy fallback files written after the session transcript", async (t) => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-inturn-");
+    try {
+      const transcriptPath = join(cwd, "transcript.jsonl");
+      await writeFile(transcriptPath, "{}\n");
+      const { birthtimeMs } = statSync(transcriptPath);
+      if (!(birthtimeMs > 0)) {
+        t.skip("file birth time is not available on this platform");
+        return;
+      }
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-inturn", transcript_path: transcriptPath },
+        { cwd },
+      );
+
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((result.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -3,6 +3,7 @@ import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { existsSync, realpathSync, statSync } from "node:fs";
 import {
 	chmod,
+	appendFile,
 	mkdir,
 	mkdtemp,
 	readFile,
@@ -30,6 +31,7 @@ import {
 import { registerTeamNotice } from "../../team/notice-ledger.js";
 import {
 	dispatchCodexNativeHook,
+	isSloppyFallbackTranscriptStartUsable,
   readUnambiguousSessionStartNativeId,
   resolvePersistedReopenRootContext,
 	isCodexNativeHookMainModule,
@@ -23313,9 +23315,14 @@ PY`,
       await new Promise((resolve) => setTimeout(resolve, 25));
       const transcriptPath = join(cwd, "transcript.jsonl");
       await writeFile(transcriptPath, "{}\n");
-      const { birthtimeMs } = statSync(transcriptPath);
-      if (!(birthtimeMs > 0)) {
-        t.skip("file birth time is not available on this platform");
+      // A real session appends to its transcript; the append makes the
+      // transcript's ctime newer than its immutable birth time, which is what
+      // lets the audit trust that birth time as the session start.
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      await appendFile(transcriptPath, "{}\n");
+      const { birthtimeMs, ctimeMs } = statSync(transcriptPath);
+      if (!(birthtimeMs > 0) || birthtimeMs >= ctimeMs) {
+        t.skip("immutable file birth time is not available on this platform");
         return;
       }
 
@@ -23325,6 +23332,51 @@ PY`,
       );
 
       assert.equal(result.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("trusts only immutable transcript birth times as the sloppy fallback session start", () => {
+    assert.equal(isSloppyFallbackTranscriptStartUsable(50, 100), true);
+    assert.equal(isSloppyFallbackTranscriptStartUsable(100, 100), false);
+    assert.equal(isSloppyFallbackTranscriptStartUsable(0, 100), false);
+    assert.equal(isSloppyFallbackTranscriptStartUsable(100, 50), false);
+    assert.equal(isSloppyFallbackTranscriptStartUsable(Number.NaN, 100), false);
+    assert.equal(isSloppyFallbackTranscriptStartUsable(50, Number.NaN), false);
+  });
+
+  it("audits untracked files when the transcript birth time is indistinguishable from ctime", async (t) => {    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-ctimebacked-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await writeFile(
+        join(cwd, "src", "runtime.ts"),
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      const transcriptPath = join(cwd, "transcript.jsonl");
+      await writeFile(transcriptPath, "{}\n");
+      // A freshly created transcript has birth time == ctime, mimicking
+      // filesystems where Node reports a mutable ctime fallback as birthtime;
+      // the audit must treat that as unavailable rather than trust it.
+      const { birthtimeMs, ctimeMs } = statSync(transcriptPath);
+      if (!(birthtimeMs > 0) || birthtimeMs < ctimeMs) {
+        t.skip("this platform reports an immutable birth time distinct from ctime");
+        return;
+      }
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-ctimebacked", transcript_path: transcriptPath },
+        { cwd },
+      );
+
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((result.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -23491,6 +23491,48 @@ PY`,
     }
   });
 
+  it("still blocks when a pre-session symlink's target is rewritten during the session", async (t) => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-targetrewrite-");
+    try {
+      // A non-auditable target extension keeps the symlink path as the only
+      // route to the flagged content.
+      const targetPath = join(cwd, "seed-data.txt");
+      await writeFile(targetPath, "export const clean = true;\n");
+      await mkdir(join(cwd, "src"), { recursive: true });
+      await symlink(targetPath, join(cwd, "src", "runtime.ts"));
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      const transcriptPath = join(cwd, "transcript.jsonl");
+      await writeFile(transcriptPath, "{}\n");
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      await appendFile(transcriptPath, "{}\n");
+      const { birthtimeMs, ctimeMs } = statSync(transcriptPath);
+      if (!(birthtimeMs > 0) || birthtimeMs >= ctimeMs) {
+        t.skip("immutable file birth time is not available on this platform");
+        return;
+      }
+
+      await writeFile(
+        targetPath,
+        [
+          "export function loadRuntime() {",
+          "  // implement a quick hack fallback if it fails",
+          "  return process.env.RUNTIME || 'local';",
+          "}",
+        ].join("\n"),
+      );
+
+      const result = await dispatchCodexNativeHook(
+        { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-targetrewrite", transcript_path: transcriptPath },
+        { cwd },
+      );
+
+      assert.equal((result.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((result.outputJson as { stopReason?: string } | null)?.stopReason, "sloppy_fallback_diff_audit");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("still blocks untracked sloppy fallback files written after the session transcript", async (t) => {
     const cwd = await initTempGitRepo("omx-native-hook-stop-slop-inturn-");
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -23232,6 +23232,40 @@ PY`,
     }
   });
 
+  it("keeps the repeat count when staging a subset reorders identical findings", async () => {
+    const cwd = await initTempGitRepo("omx-native-hook-stop-slop-subset-");
+    try {
+      await mkdir(join(cwd, "src"), { recursive: true });
+      const sloppySource = (exportName: string) => [
+        `export function ${exportName}() {`,
+        "  // implement a quick hack fallback if it fails",
+        "  return process.env.RUNTIME || 'local';",
+        "}",
+      ].join("\n");
+      await writeFile(join(cwd, "src", "alpha.ts"), sloppySource("loadAlpha"));
+      await writeFile(join(cwd, "src", "beta.ts"), sloppySource("loadBeta"));
+      const payload = { hook_event_name: "Stop", cwd, session_id: "sess-stop-slop-subset", turn_id: "turn-subset" };
+      const stop = (attempt: number) =>
+        dispatchCodexNativeHook(attempt === 0 ? payload : { ...payload, stop_hook_active: true }, { cwd });
+
+      const first = await stop(0);
+      // Staging only beta reorders the raw finding list (staged findings come
+      // first), but the fingerprint must stay identical for the same set.
+      execFileSync("git", ["add", "src/beta.ts"], { cwd, stdio: "ignore" });
+      const subsetStaged = await stop(1);
+      execFileSync("git", ["add", "src/alpha.ts"], { cwd, stdio: "ignore" });
+      const allStaged = await stop(2);
+      const afterCap = await stop(3);
+
+      assert.equal((first.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((subsetStaged.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal((allStaged.outputJson as { decision?: string } | null)?.decision, "block");
+      assert.equal(afterCap.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("skips the sloppy fallback diff audit when OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT is off", async () => {
     const cwd = await initTempGitRepo("omx-native-hook-stop-slop-disabled-");
     const previousValue = process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1765,6 +1765,7 @@ interface SloppyFallbackDiffFinding {
   path: string;
   line: string;
   source: "staged" | "unstaged" | "untracked";
+  lineNumber?: number;
 }
 
 const SOURCE_DIFF_EXTENSIONS = new Set([
@@ -1863,6 +1864,7 @@ function isSuspiciousSloppyFallbackAddedLine(line: string, nearbyContext: string
 interface SloppyFallbackCandidateLine {
   text: string;
   added: boolean;
+  lineNumber?: number;
 }
 
 function collectFindingsFromCandidateLines(
@@ -1880,7 +1882,7 @@ function collectFindingsFromCandidateLines(
       .map((line) => line.text)
       .join("\n");
     if (isSuspiciousSloppyFallbackAddedLine(candidate.text, nearbyContext)) {
-      findings.push({ path, line: candidate.text.trim(), source });
+      findings.push({ path, line: candidate.text.trim(), source, lineNumber: candidate.lineNumber });
     }
   }
   return findings;
@@ -1893,6 +1895,7 @@ function collectSloppyFallbackFindingsFromPatch(
   const findings: SloppyFallbackDiffFinding[] = [];
   let currentPath = "";
   let hunkLines: SloppyFallbackCandidateLine[] = [];
+  let newFileLineNumber = 0;
 
   const flushHunk = () => {
     findings.push(...collectFindingsFromCandidateLines(currentPath, hunkLines, source));
@@ -1904,6 +1907,7 @@ function collectSloppyFallbackFindingsFromPatch(
     if (fileMatch) {
       flushHunk();
       currentPath = normalizeGitPath(fileMatch[2] || fileMatch[1] || "");
+      newFileLineNumber = 0;
       continue;
     }
     const renameMatch = rawLine.match(/^\+\+\+ b\/(.*)$/);
@@ -1913,13 +1917,17 @@ function collectSloppyFallbackFindingsFromPatch(
     }
     if (rawLine.startsWith("@@")) {
       flushHunk();
+      const hunkMatch = rawLine.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      newFileLineNumber = hunkMatch ? Number.parseInt(hunkMatch[1], 10) : 0;
       continue;
     }
     if (!currentPath || !isDiffAuditableSourcePath(currentPath) || isDiffHeaderLine(rawLine)) continue;
     if (rawLine.startsWith("+")) {
-      hunkLines.push({ text: rawLine.slice(1), added: true });
+      hunkLines.push({ text: rawLine.slice(1), added: true, lineNumber: newFileLineNumber || undefined });
+      if (newFileLineNumber > 0) newFileLineNumber += 1;
     } else if (rawLine.startsWith(" ")) {
-      hunkLines.push({ text: rawLine.slice(1), added: false });
+      hunkLines.push({ text: rawLine.slice(1), added: false, lineNumber: newFileLineNumber || undefined });
+      if (newFileLineNumber > 0) newFileLineNumber += 1;
     }
   }
   flushHunk();
@@ -1985,7 +1993,7 @@ function collectSloppyFallbackFindingsFromUntracked(cwd: string, sessionStartMs?
     } catch {
       continue;
     }
-    findings.push(...collectFindingsFromCandidateLines(path, content.split(/\r?\n/).map((text) => ({ text, added: true })), "untracked"));
+    findings.push(...collectFindingsFromCandidateLines(path, content.split(/\r?\n/).map((text, index) => ({ text, added: true, lineNumber: index + 1 })), "untracked"));
   }
   return findings;
 }
@@ -2021,8 +2029,9 @@ function buildSloppyFallbackDiffStopOutput(findings: SloppyFallbackDiffFinding[]
 function buildSloppyFallbackDiffGuardFingerprint(findings: SloppyFallbackDiffFinding[]): string {
   return JSON.stringify(
     findings
-      .map((finding) => [finding.path, finding.line] as const)
-      .sort(([pathA, lineA], [pathB, lineB]) => pathA.localeCompare(pathB) || lineA.localeCompare(lineB)),
+      .map((finding) => [finding.path, finding.line, finding.lineNumber ?? 0] as const)
+      .sort(([pathA, lineA, numberA], [pathB, lineB, numberB]) =>
+        pathA.localeCompare(pathB) || lineA.localeCompare(lineB) || numberA - numberB),
   );
 }
 

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1999,7 +1999,7 @@ function buildSloppyFallbackDiffStopOutput(findings: SloppyFallbackDiffFinding[]
 }
 
 function buildSloppyFallbackDiffGuardFingerprint(findings: SloppyFallbackDiffFinding[]): string {
-  return JSON.stringify(findings.map((finding) => [finding.source, finding.path, finding.line]));
+  return JSON.stringify(findings.map((finding) => [finding.path, finding.line]));
 }
 
 async function maybeBuildSloppyFallbackDiffStopOutput(

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1976,13 +1976,28 @@ function collectSloppyFallbackFindingsFromUntracked(cwd: string, sessionStartMs?
     if (sessionStartMs != null) {
       try {
         // Skip only files that provably predate the session: mtime alone is
-        // preservable (cp -p, tar) and statSync follows symlinks to older
-        // targets, so require every available indicator (mtime, ctime, and
-        // birth time when the filesystem reports one) to predate the session.
-        const stats = lstatSync(join(cwd, path));
-        const indicators = [stats.mtimeMs, stats.ctimeMs];
-        if (Number.isFinite(stats.birthtimeMs) && stats.birthtimeMs > 0) indicators.push(stats.birthtimeMs);
-        if (indicators.every((indicatorMs) => Number.isFinite(indicatorMs) && indicatorMs < sessionStartMs)) continue;
+        // preservable (cp -p, tar), so require every available indicator
+        // (mtime, ctime, and birth time when the filesystem reports one) to
+        // predate the session. A pre-session symlink can still surface
+        // in-session edits through its target, so the target's indicators
+        // must predate the session too; the link's own indicators keep
+        // in-session links to older targets auditable.
+        const fullPath = join(cwd, path);
+        const linkStats = lstatSync(fullPath);
+        const statsToCheck = [linkStats];
+        if (linkStats.isSymbolicLink()) {
+          try {
+            statsToCheck.push(statSync(fullPath));
+          } catch {
+            // Dangling link: nothing readable to audit either way.
+          }
+        }
+        const predatesSession = statsToCheck.every((stats) => {
+          const indicators = [stats.mtimeMs, stats.ctimeMs];
+          if (Number.isFinite(stats.birthtimeMs) && stats.birthtimeMs > 0) indicators.push(stats.birthtimeMs);
+          return indicators.every((indicatorMs) => Number.isFinite(indicatorMs) && indicatorMs < sessionStartMs);
+        });
+        if (predatesSession) continue;
       } catch {
         continue;
       }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1999,7 +1999,11 @@ function buildSloppyFallbackDiffStopOutput(findings: SloppyFallbackDiffFinding[]
 }
 
 function buildSloppyFallbackDiffGuardFingerprint(findings: SloppyFallbackDiffFinding[]): string {
-  return JSON.stringify(findings.map((finding) => [finding.path, finding.line]));
+  return JSON.stringify(
+    findings
+      .map((finding) => [finding.path, finding.line] as const)
+      .sort(([pathA, lineA], [pathB, lineB]) => pathA.localeCompare(pathB) || lineA.localeCompare(lineB)),
+  );
 }
 
 async function maybeBuildSloppyFallbackDiffStopOutput(

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -224,6 +224,7 @@ const NATIVE_STOP_STATE_FILE = "native-stop-state.json";
 const NATIVE_SUBAGENT_CAPACITY_BLOCKER_FILE = "native-subagent-capacity-blocker.json";
 const NATIVE_SUBAGENT_CAPACITY_BLOCKER_TTL_MS = 30 * 60_000;
 const ORDINARY_STOP_NO_PROGRESS_DEFAULT_MAX_REPEATS = 8;
+const SLOPPY_FALLBACK_DIFF_STOP_DEFAULT_MAX_REPEATS = 3;
 const RALPH_ORPHANED_STARTING_STALE_MS = 15 * 60_000;
 const ORDINARY_STOP_NO_PROGRESS_DEFAULT_IDLE_MS = 10 * 60_000;
 const ORDINARY_STOP_NO_PROGRESS_MAX_MESSAGE_LENGTH = 240;
@@ -1925,13 +1926,39 @@ function collectSloppyFallbackFindingsFromPatch(
   return findings;
 }
 
-function collectSloppyFallbackFindingsFromUntracked(cwd: string): SloppyFallbackDiffFinding[] {
+function isSloppyFallbackDiffAuditDisabled(): boolean {
+  return /^(?:0|off|false|disabled?)$/i.test(
+    safeString(process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT).trim(),
+  );
+}
+
+function resolveSloppyFallbackSessionStartMs(payload: CodexHookPayload, cwd: string): number | null {
+  const transcriptPath = safeString(payload.transcript_path ?? payload.transcriptPath).trim();
+  if (!transcriptPath) return null;
+  try {
+    const resolvedPath = isAbsolute(transcriptPath) ? transcriptPath : resolve(cwd, transcriptPath);
+    const { birthtimeMs } = statSync(resolvedPath);
+    return Number.isFinite(birthtimeMs) && birthtimeMs > 0 ? birthtimeMs : null;
+  } catch {
+    return null;
+  }
+}
+
+function collectSloppyFallbackFindingsFromUntracked(cwd: string, sessionStartMs?: number | null): SloppyFallbackDiffFinding[] {
   const output = gitOutput(cwd, ["ls-files", "--others", "--exclude-standard", "-z"]);
   if (!output) return [];
   const findings: SloppyFallbackDiffFinding[] = [];
   for (const rawPath of output.split("\0")) {
     const path = normalizeGitPath(rawPath.trim());
     if (!path || !isDiffAuditableSourcePath(path)) continue;
+    if (sessionStartMs != null) {
+      try {
+        const { mtimeMs } = statSync(join(cwd, path));
+        if (Number.isFinite(mtimeMs) && mtimeMs < sessionStartMs) continue;
+      } catch {
+        continue;
+      }
+    }
     let content = "";
     try {
       content = readFileSync(join(cwd, path), "utf-8");
@@ -1943,14 +1970,14 @@ function collectSloppyFallbackFindingsFromUntracked(cwd: string): SloppyFallback
   return findings;
 }
 
-function findSloppyFallbackDiffFindings(cwd: string): SloppyFallbackDiffFinding[] {
+function findSloppyFallbackDiffFindings(cwd: string, sessionStartMs?: number | null): SloppyFallbackDiffFinding[] {
   const layout = findGitLayout(cwd);
   if (!layout) return [];
   const auditRoot = layout.worktreeRoot;
   return [
     ...collectSloppyFallbackFindingsFromPatch(gitOutput(auditRoot, ["diff", "--cached", "--no-ext-diff", "--unified=3"]), "staged"),
     ...collectSloppyFallbackFindingsFromPatch(gitOutput(auditRoot, ["diff", "--no-ext-diff", "--unified=3"]), "unstaged"),
-    ...collectSloppyFallbackFindingsFromUntracked(auditRoot),
+    ...collectSloppyFallbackFindingsFromUntracked(auditRoot, sessionStartMs),
   ];
 }
 
@@ -1969,6 +1996,75 @@ function buildSloppyFallbackDiffStopOutput(findings: SloppyFallbackDiffFinding[]
     stopReason: "sloppy_fallback_diff_audit",
     systemMessage,
   };
+}
+
+function buildSloppyFallbackDiffGuardFingerprint(findings: SloppyFallbackDiffFinding[]): string {
+  return JSON.stringify(findings.map((finding) => [finding.source, finding.path, finding.line]));
+}
+
+async function maybeBuildSloppyFallbackDiffStopOutput(
+  payload: CodexHookPayload,
+  cwd: string,
+  stateDir: string,
+  canonicalSessionId?: string,
+): Promise<Record<string, unknown> | null> {
+  if (isSloppyFallbackDiffAuditDisabled()) return null;
+  const findings = findSloppyFallbackDiffFindings(cwd, resolveSloppyFallbackSessionStartMs(payload, cwd));
+  const statePath = join(stateDir, NATIVE_STOP_STATE_FILE);
+  const state = await readJsonIfExists(statePath) ?? {};
+  const sessions = safeObject(state.sessions);
+  const sessionKey = readNativeStopSessionKey(payload, canonicalSessionId);
+  const sessionState = safeObject(sessions[sessionKey]);
+
+  if (findings.length === 0) {
+    if (sessionState.sloppy_fallback_diff_guard !== undefined) {
+      const clearedSessionState = { ...sessionState };
+      delete clearedSessionState.sloppy_fallback_diff_guard;
+      sessions[sessionKey] = clearedSessionState;
+      await mkdir(stateDir, { recursive: true });
+      await writeFile(statePath, JSON.stringify({ ...state, sessions }, null, 2));
+    }
+    return null;
+  }
+
+  const fingerprint = buildSloppyFallbackDiffGuardFingerprint(findings);
+  const nowIso = new Date().toISOString();
+  const previousGuard = safeObject(sessionState.sloppy_fallback_diff_guard);
+  const sameFingerprint = safeString(previousGuard.fingerprint).trim() === fingerprint;
+  const repeatCount = sameFingerprint
+    ? parseBoundedPositiveInteger(previousGuard.repeat_count, 1) + 1
+    : 1;
+  sessions[sessionKey] = {
+    ...sessionState,
+    sloppy_fallback_diff_guard: {
+      fingerprint,
+      first_seen_at: sameFingerprint
+        ? safeString(previousGuard.first_seen_at).trim() || nowIso
+        : nowIso,
+      last_seen_at: nowIso,
+      repeat_count: repeatCount,
+      last_turn_id: readPayloadTurnId(payload) || null,
+      last_thread_id: readPayloadThreadId(payload) || null,
+    },
+  };
+  await mkdir(stateDir, { recursive: true });
+  await writeFile(statePath, JSON.stringify({ ...state, sessions }, null, 2));
+
+  const maxRepeats = parseBoundedPositiveInteger(
+    process.env.OMX_NATIVE_STOP_SLOPPY_FALLBACK_MAX_REPEATS,
+    SLOPPY_FALLBACK_DIFF_STOP_DEFAULT_MAX_REPEATS,
+  );
+  if (repeatCount > maxRepeats) return null;
+
+  return await returnPersistentStopBlock(
+    payload,
+    stateDir,
+    "sloppy-fallback-diff-stop",
+    JSON.stringify(findings),
+    buildSloppyFallbackDiffStopOutput(findings),
+    canonicalSessionId,
+    { allowRepeatDuringStopHook: true },
+  );
 }
 
 function localExcludeAlreadyIgnoresOmx(cwd: string): boolean {
@@ -21284,18 +21380,14 @@ async function buildStopHookOutput(
       );
     }
 
-    const sloppyFallbackDiffFindings = findSloppyFallbackDiffFindings(cwd);
-    const sloppyFallbackDiffOutput = buildSloppyFallbackDiffStopOutput(sloppyFallbackDiffFindings);
-    if (sloppyFallbackDiffOutput) {
-      return await returnPersistentStopBlock(
-        payload,
-        stateDir,
-        "sloppy-fallback-diff-stop",
-        JSON.stringify(sloppyFallbackDiffFindings),
-        sloppyFallbackDiffOutput,
-        canonicalSessionId,
-        { allowRepeatDuringStopHook: true },
-      );
+    const sloppyFallbackDiffStopOutput = await maybeBuildSloppyFallbackDiffStopOutput(
+      payload,
+      cwd,
+      stateDir,
+      canonicalSessionId,
+    );
+    if (sloppyFallbackDiffStopOutput) {
+      return sloppyFallbackDiffStopOutput;
     }
 
     if (isFinalHandoffDocumentRefreshCandidate(lastAssistantMessage)) {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1953,8 +1953,14 @@ function collectSloppyFallbackFindingsFromUntracked(cwd: string, sessionStartMs?
     if (!path || !isDiffAuditableSourcePath(path)) continue;
     if (sessionStartMs != null) {
       try {
-        const { mtimeMs } = statSync(join(cwd, path));
-        if (Number.isFinite(mtimeMs) && mtimeMs < sessionStartMs) continue;
+        // Skip only files that provably predate the session: mtime alone is
+        // preservable (cp -p, tar) and statSync follows symlinks to older
+        // targets, so require every available indicator (mtime, ctime, and
+        // birth time when the filesystem reports one) to predate the session.
+        const stats = lstatSync(join(cwd, path));
+        const indicators = [stats.mtimeMs, stats.ctimeMs];
+        if (Number.isFinite(stats.birthtimeMs) && stats.birthtimeMs > 0) indicators.push(stats.birthtimeMs);
+        if (indicators.every((indicatorMs) => Number.isFinite(indicatorMs) && indicatorMs < sessionStartMs)) continue;
       } catch {
         continue;
       }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -1932,13 +1932,27 @@ function isSloppyFallbackDiffAuditDisabled(): boolean {
   );
 }
 
+export function isSloppyFallbackTranscriptStartUsable(birthtimeMs: number, ctimeMs: number): boolean {
+  return (
+    Number.isFinite(birthtimeMs)
+    && birthtimeMs > 0
+    && Number.isFinite(ctimeMs)
+    && birthtimeMs < ctimeMs
+  );
+}
+
 function resolveSloppyFallbackSessionStartMs(payload: CodexHookPayload, cwd: string): number | null {
   const transcriptPath = safeString(payload.transcript_path ?? payload.transcriptPath).trim();
   if (!transcriptPath) return null;
   try {
     const resolvedPath = isAbsolute(transcriptPath) ? transcriptPath : resolve(cwd, transcriptPath);
-    const { birthtimeMs } = statSync(resolvedPath);
-    return Number.isFinite(birthtimeMs) && birthtimeMs > 0 ? birthtimeMs : null;
+    const { birthtimeMs, ctimeMs } = statSync(resolvedPath);
+    // Only trust an immutable birth time. On filesystems where Node reports
+    // birthtime as ctime (or another mutable fallback), every transcript
+    // append moves the derived session start forward and can make in-session
+    // edits look pre-session; treat that ambiguity as unavailable and audit
+    // all untracked files instead of risking a silent skip.
+    return isSloppyFallbackTranscriptStartUsable(birthtimeMs, ctimeMs) ? birthtimeMs : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

Fixes the permanent Stop-hook deadlock from #3341 (full analysis there). **Supersedes #3345**, which was closed under terminal request-changes on head `c6fa8e2`:

> *"the transcript start-time authority is still unsafe on filesystems where Node reports `birthtimeMs` as ctime or another mutable fallback … Use an immutable recorded SessionStart timestamp, or treat ambiguous/ctime-backed transcript birth time as unavailable and audit all untracked files. Add a regression that simulates transcript birth time changing after the in-session source materialization."*

This successor takes the second option exactly as offered and adds the requested regression. Rebased onto current `dev@bb58e727` for fresh CI.

## How the start-time authority is now safe

Session scoping engages **only** when the transcript's reported birth time is strictly older than its ctime — an immutable birth time on an appended transcript. A ctime-backed, mutable, or missing birth time disables scoping entirely and audits all untracked files (the pre-feature fail-closed behavior), so transcript appends/touches can never push the derived session start past an in-session edit on those filesystems.

The trust decision is an exported pure predicate, `isSloppyFallbackTranscriptStartUsable(birthtimeMs, ctimeMs)`.

## The requested regression

The scenario "transcript birth time changes after the in-session source materialization" is covered two ways, because a ctime-backed birth time **cannot be simulated through user-space fs operations on true-btime filesystems** (measured on macOS/APFS: fresh files report `birthtimeMs` ~0.06–0.12 ms *before* `ctimeMs`; nothing in userspace can make them equal or move birthtime forward):

1. **Deterministic unit test of the trust predicate** (runs everywhere): mutable/equal (`btime >= ctime`), missing (`0`), and inverted inputs are all rejected; only `btime < ctime` is trusted.
2. **Filesystem-level regression** (`audits untracked files when the transcript birth time is indistinguishable from ctime`): a genuinely pre-session sloppy file is still audited when the transcript reports a ctime-backed (fresh, `btime == ctime`) birth time. It runs on platforms where the fallback exists and skip-guards elsewhere.

## Changes (complete, for fresh review)

- **Bounded repeat**: per-session `sloppy_fallback_diff_guard` in `native-stop-state.json`; identical findings block at most `OMX_NATIVE_STOP_SLOPPY_FALLBACK_MAX_REPEATS` times (default 3), then fail open; resets on finding-set change, clears when findings disappear (mirrors the `ordinary_no_progress_guard` idiom). Fingerprint = **sorted set of (path, line)** — insensitive to scan order and staging state (both reset vectors from #3342/#3345 review rounds are covered by regression tests).
- **Escape hatch**: `OMX_NATIVE_STOP_SLOPPY_FALLBACK_AUDIT=off`.
- **Session scoping**: pre-session untracked files skipped only when *every* available indicator (mtime, ctime, birth time when reported) predates the trusted session start; lstat semantics keep in-session symlinks auditable; `cp -p`/`tar` preserved-mtime smuggle closed; ctime-backed/missing transcript birth time disables scoping (fail-closed).
- **Tests**: 9 sloppy-diff cases incl. cap fail-open, reset-on-change, kill switch, pre-session skip, in-session block, staging-state moves, subset-staging reorder, preserved-mtime `cp -p`, symlink-to-older-target, plus the trust-predicate unit test.
- **Docs**: "Stop: sloppy fallback/workaround diff audit" section in `docs/codex-native-hooks.md`.

## Validation

- [x] `npm run build`
- [x] `npm test` — A/B against unmodified `dev@bb58e727`: the 23 failing tests in `codex-native-hook.test.js` are **identical by name** on both branches (pre-existing tmux/team/auth/close_agent environment-dependent failures); zero new failures
- [ ] `omx doctor` (when setup/config behavior changes) — N/A, no setup/config surface change
- [x] `npm run lint`, `npm run check:no-unused`, `npx tsc --noEmit`
- [x] Targeted: 17 pass / 0 fail / 1 platform-skipped (the fs-level ctime-fallback regression, by design — covered everywhere by the predicate unit test)
- [x] Earlier fixes adversarially verified: each bypass regression **fails without its fix** (staging-source, ordering, preserved-mtime, symlink) and passes with it

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated — `docs/codex-native-hooks.md`
- [x] Backward-compatibility impact considered: in-session sloppy edits still block from the first Stop through the cap; only identical findings past the cap fail open; no config/schema changes; state file gains one optional per-session guard key

## Related

Closes #3341
Supersedes #3342, #3345
