### PR TITLE
fix(hooks): repair planning state transport guards

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -32376,6 +32376,162 @@ PY`,
     }
   });
 
+  it("allows trusted omx state read with structured input under ultragoal conductor planning (#3343)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3343-state-read-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-3343-state-read";
+      const leaderThreadId = "thread-3343-state-read";
+      await mkdir(join(cwd, ".git"), { recursive: true });
+      await writeNativeMappedSessionState(cwd, stateDir, sessionId, leaderThreadId, leaderThreadId);
+      await writeSessionSkillActiveState(stateDir, sessionId, "ultragoal", "planning");
+      await writeJson(join(stateDir, "sessions", sessionId, "ultragoal-state.json"), {
+        active: true,
+        mode: "ultragoal",
+        current_phase: "planning",
+        session_id: sessionId,
+        workingDirectory: cwd,
+      });
+
+      await withCleanAmbientNodeRuntimeEnvironment(async () => {
+        await withTrustedWorkspaceOmxCli(cwd, async (_omxCommand, trustedPath) => {
+          const inheritedPath = process.env.PATH;
+          process.env.PATH = trustedPath;
+          try {
+            const payload = JSON.stringify({ mode: "ultragoal", session_id: sessionId, workingDirectory: cwd });
+            const result = await dispatchCodexNativeHook(
+              {
+                hook_event_name: "PreToolUse",
+                cwd,
+                session_id: sessionId,
+                thread_id: leaderThreadId,
+                agent_id: leaderThreadId,
+                tool_name: "Bash",
+                tool_use_id: "tool-3343-omx-state-read-input",
+                tool_input: {
+                  command: `omx state read --input '${payload}' --json`,
+                },
+              },
+              { cwd },
+            );
+
+            assert.equal(result.outputJson, null);
+          } finally {
+            if (inheritedPath === undefined) delete process.env.PATH;
+            else process.env.PATH = inheritedPath;
+          }
+        });
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("diagnoses Autopilot lifecycle and skill-mirror phase mismatches (#3344)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3344-phase-mismatch-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-3344-phase-mismatch";
+      const leaderThreadId = "thread-3344-phase-mismatch";
+      await writeNativeMappedSessionState(cwd, stateDir, sessionId, leaderThreadId, leaderThreadId);
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "autopilot",
+        phase: "planning",
+        session_id: sessionId,
+        active_skills: [{ skill: "autopilot", phase: "planning", active: true, session_id: sessionId }],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "deep-interview",
+        session_id: sessionId,
+        workingDirectory: cwd,
+      });
+
+      const result = await dispatchCodexNativeHook(
+        {
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: leaderThreadId,
+          agent_id: leaderThreadId,
+          tool_name: "Write",
+          tool_use_id: "tool-3344-phase-mismatch-write",
+          tool_input: { file_path: "src/runtime.ts", content: "export {};\n" },
+        },
+        { cwd },
+      );
+
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(String(result.outputJson?.reason ?? ""), /STATE_PHASE_MISMATCH/);
+      assert.match(String(result.outputJson?.reason ?? ""), /lifecycle phase: deep-interview/);
+      assert.match(String(result.outputJson?.reason ?? ""), /skill mirror phase: planning/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("lets omx cancel terminalize Autopilot deep-interview even when the skill mirror advanced (#3344)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3344-cancel-mismatch-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-3344-cancel-mismatch";
+      const leaderThreadId = "thread-3344-cancel-mismatch";
+      await writeNativeMappedSessionState(cwd, stateDir, sessionId, leaderThreadId, leaderThreadId);
+      await writeJson(join(stateDir, "sessions", sessionId, "skill-active-state.json"), {
+        active: true,
+        skill: "autopilot",
+        phase: "planning",
+        session_id: sessionId,
+        active_skills: [{ skill: "autopilot", phase: "planning", active: true, session_id: sessionId }],
+      });
+      await writeJson(join(stateDir, "sessions", sessionId, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "deep-interview",
+        session_id: sessionId,
+        workingDirectory: cwd,
+      });
+
+      await withCleanAmbientNodeRuntimeEnvironment(async () => {
+        await withTrustedWorkspaceOmxCli(cwd, async (_omxCommand, trustedPath) => {
+          const inheritedPath = process.env.PATH;
+          process.env.PATH = trustedPath;
+          try {
+            const result = await dispatchCodexNativeHook(
+              {
+                hook_event_name: "PreToolUse",
+                cwd,
+                session_id: sessionId,
+                thread_id: leaderThreadId,
+                agent_id: leaderThreadId,
+                tool_name: "Bash",
+                tool_use_id: "tool-3344-cancel-mismatch",
+                tool_input: { command: "omx cancel" },
+              },
+              { cwd },
+            );
+            assert.equal(result.outputJson?.decision, "block");
+            assert.match(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+          } finally {
+            if (inheritedPath === undefined) delete process.env.PATH;
+            else process.env.PATH = inheritedPath;
+          }
+        });
+      });
+
+      const nextAutopilot = JSON.parse(await readFile(join(stateDir, "sessions", sessionId, "autopilot-state.json"), "utf-8"));
+      const nextSkill = JSON.parse(await readFile(join(stateDir, "sessions", sessionId, "skill-active-state.json"), "utf-8"));
+      assert.equal(nextAutopilot.active, false);
+      assert.equal(nextAutopilot.current_phase, "cancelled");
+      assert.equal(nextSkill.active, false);
+      assert.equal(nextSkill.phase, "cancelled");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("blocks mapped implementation writes when explicit ultragoal conductor handoff is active", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ralplan-native-map-handoff-"));
     try {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -218,7 +218,7 @@ async function withTrustedWorkspaceOmxCli<T>(
   await mkdir(binDir, { recursive: true });
   await rm(shimPath, { force: true });
   await symlink(cliPath, shimPath);
-  const path = `${binDir}:/usr/bin:/bin`;
+  const path = `${binDir}:${dirname(process.execPath)}:/usr/bin:/bin`;
   return await action(commandForm === "env" ? `env PATH="${path}" omx` : `PATH="${path}" omx`, path);
 }
 
@@ -32419,6 +32419,63 @@ PY`,
           } finally {
             if (inheritedPath === undefined) delete process.env.PATH;
             else process.env.PATH = inheritedPath;
+          }
+        });
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+  it("blocks an untrusted omx shim ahead of the trusted workspace CLI on PATH under ultragoal conductor planning (#3343)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3343-untrusted-shim-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-3343-untrusted-shim";
+      const leaderThreadId = "thread-3343-untrusted-shim";
+      await mkdir(join(cwd, ".git"), { recursive: true });
+      await writeNativeMappedSessionState(cwd, stateDir, sessionId, leaderThreadId, leaderThreadId);
+      await writeSessionSkillActiveState(stateDir, sessionId, "ultragoal", "planning");
+      await writeJson(join(stateDir, "sessions", sessionId, "ultragoal-state.json"), {
+        active: true,
+        mode: "ultragoal",
+        current_phase: "planning",
+        session_id: sessionId,
+        workingDirectory: cwd,
+      });
+
+      await withCleanAmbientNodeRuntimeEnvironment(async () => {
+        await withTrustedWorkspaceOmxCli(cwd, async (_omxCommand, trustedPath) => {
+          const attackerDir = await mkdtemp(join(tmpdir(), "omx-3343-untrusted-shim-attacker-"));
+          await writeFile(join(attackerDir, "omx"), "#!/bin/sh\necho pwned\n");
+          await chmod(join(attackerDir, "omx"), 0o755);
+          const inheritedPath = process.env.PATH;
+          // Attacker directory sits ahead of the trusted workspace bin dir on PATH.
+          process.env.PATH = `${attackerDir}:${trustedPath}`;
+          try {
+            const payload = JSON.stringify({ mode: "ultragoal", session_id: sessionId, workingDirectory: cwd });
+            const result = await dispatchCodexNativeHook(
+              {
+                hook_event_name: "PreToolUse",
+                cwd,
+                session_id: sessionId,
+                thread_id: leaderThreadId,
+                agent_id: leaderThreadId,
+                tool_name: "Bash",
+                tool_use_id: "tool-3343-untrusted-shim-state-read-input",
+                tool_input: {
+                  command: `omx state read --input '${payload}' --json`,
+                },
+              },
+              { cwd },
+            );
+
+            assert.notEqual(result.outputJson, null);
+            assert.equal(result.outputJson?.decision, "block");
+            assert.match(JSON.stringify(result.outputJson), /PATH/);
+          } finally {
+            if (inheritedPath === undefined) delete process.env.PATH;
+            else process.env.PATH = inheritedPath;
+            await rm(attackerDir, { recursive: true, force: true });
           }
         });
       });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3763,7 +3763,10 @@ function hookCancelSkillMatches(value: Record<string, unknown>, sessionId: strin
   return entries.some((candidate) => {
     if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return false;
     const entry = candidate as Record<string, unknown>;
-    return hookCancelString(entry.skill).toLowerCase() === "autopilot" && entry.active !== false && normalizeAutopilotPhase(hookCancelString(entry.phase)) === "deep-interview" && (!hookCancelString(entry.session_id) || hookCancelString(entry.session_id) === sessionId) && hookCancelCwdMatches(entry, cwd);
+    return hookCancelString(entry.skill).toLowerCase() === "autopilot"
+      && entry.active !== false
+      && (!hookCancelString(entry.session_id) || hookCancelString(entry.session_id) === sessionId)
+      && hookCancelCwdMatches(entry, cwd);
   });
 }
 async function hookCancelFsyncDirectory(path: string): Promise<void> {
@@ -3792,7 +3795,9 @@ function hookCancelPreparedSkill(value: Record<string, unknown>, sessionId: stri
   const entries = sourceEntries.map((candidate) => {
     if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return candidate;
     const entry = candidate as Record<string, unknown>;
-    const matches = hookCancelString(entry.skill).toLowerCase() === "autopilot" && entry.active !== false && normalizeAutopilotPhase(hookCancelString(entry.phase)) === "deep-interview" && (!hookCancelString(entry.session_id) || hookCancelString(entry.session_id) === sessionId);
+    const matches = hookCancelString(entry.skill).toLowerCase() === "autopilot"
+      && entry.active !== false
+      && (!hookCancelString(entry.session_id) || hookCancelString(entry.session_id) === sessionId);
     if (!matches) return entry; cancelled = true; return { ...entry, active: false, phase: "cancelled", updated_at: nowIso };
   });
   if (!cancelled) return value;
@@ -5314,6 +5319,10 @@ function classifyPreToolUseMutationTransport(
 ): PreToolUseMutationTransport {
   if (toolName === "Bash") {
     const command = readPreToolUseCommand(payload);
+    if (
+      readPreToolUseRawCommand(payload) === command
+      && (isAllowedOmxReadOnlyCommand(command, cwd) || isAllowedGhReadOnlyCommand(command) || isAllowedVersionProbeCommand(command))
+    ) return "read-only";
     return commandHasDeepInterviewWriteIntent(command, 0, cwd) || collectOmxStateCommandOperations(command, "write").length > 0 || commandHasNestedCliMutationIntent(command) || classifyConductorExecutableRuntime(command, 0, cwd) !== null
       ? "bash"
       : "read-only";
@@ -9398,6 +9407,9 @@ function stateReadTrailingArgsAreSafe(trailing: string[]): boolean {
   if (trailing.length === 1 && (trailing[0] === "--help" || trailing[0] === "-h" || trailing[0] === "help")) return true;
   let sawMode = false;
   let sawJson = false;
+  let sawInput = false;
+  let sawInputFile = false;
+  const staticFlagValue = (value: string): boolean => Boolean(value) && !/[`$\0]/.test(value);
   for (let index = 0; index < trailing.length; index += 1) {
     const arg = trailing[index] ?? "";
     if (arg === "--json") {
@@ -9408,14 +9420,43 @@ function stateReadTrailingArgsAreSafe(trailing: string[]): boolean {
     if (arg === "--mode") {
       if (sawMode) return false;
       const value = trailing[index + 1] ?? "";
-      if (!value || value.startsWith("-")) return false;
+      if (!staticFlagValue(value) || value.startsWith("-")) return false;
       sawMode = true;
       index += 1;
       continue;
     }
     if (arg.startsWith("--mode=")) {
-      if (sawMode || !arg.slice("--mode=".length)) return false;
+      const value = arg.slice("--mode=".length);
+      if (sawMode || !staticFlagValue(value)) return false;
       sawMode = true;
+      continue;
+    }
+    if (arg === "--input") {
+      if (sawInput || sawInputFile) return false;
+      const value = trailing[index + 1] ?? "";
+      if (!staticFlagValue(value)) return false;
+      sawInput = true;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--input=")) {
+      const value = arg.slice("--input=".length);
+      if (sawInput || sawInputFile || !staticFlagValue(value)) return false;
+      sawInput = true;
+      continue;
+    }
+    if (arg === "--input-file") {
+      if (sawInput || sawInputFile) return false;
+      const value = trailing[index + 1] ?? "";
+      if (!staticFlagValue(value) || value.startsWith("-")) return false;
+      sawInputFile = true;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--input-file=")) {
+      const value = arg.slice("--input-file=".length);
+      if (sawInput || sawInputFile || !staticFlagValue(value)) return false;
+      sawInputFile = true;
       continue;
     }
     return false;
@@ -9840,16 +9881,28 @@ async function readActiveDeepInterviewStateForPreToolUse(
   if (!modeStateMatchesSkillStopContext(autopilotState, cwd, sessionId)) return null;
   const autopilotStatePhase = safeString(autopilotState.current_phase ?? autopilotState.currentPhase).trim().toLowerCase();
   const autopilotIsDeepInterview = normalizeAutopilotPhase(autopilotStatePhase) === "deep-interview";
-  const hasDeepInterviewScopedAutopilotSkill = listActiveSkills(canonicalState).some((entry) => (
-    entry.skill === "autopilot"
-    && normalizeAutopilotPhase(safeString(entry.phase).trim().toLowerCase()) === "deep-interview"
-    && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
-  ));
-  const hasActiveAutopilotSkill = listActiveSkills(canonicalState).some((entry) => (
+  const activeAutopilotEntries = listActiveSkills(canonicalState).filter((entry) => (
     entry.skill === "autopilot"
     && matchesSkillStopContext(entry, canonicalState, sessionId, threadId)
   ));
-  if (!hasActiveAutopilotSkill) return null;
+  const hasDeepInterviewScopedAutopilotSkill = activeAutopilotEntries.some((entry) => (
+    normalizeAutopilotPhase(safeString(entry.phase).trim().toLowerCase()) === "deep-interview"
+  ));
+  if (activeAutopilotEntries.length === 0) return null;
+  if (autopilotIsDeepInterview && !hasDeepInterviewScopedAutopilotSkill) {
+    const disagreeingPhase = activeAutopilotEntries
+      .map((entry) => safeString(entry.phase).trim())
+      .find((phase) => phase && normalizeAutopilotPhase(phase.toLowerCase()) !== "deep-interview");
+    if (disagreeingPhase) {
+      return {
+        ...autopilotState,
+        __omx_state_phase_mismatch: {
+          lifecycle_phase: autopilotStatePhase || "deep-interview",
+          skill_mirror_phase: disagreeingPhase,
+        },
+      };
+    }
+  }
   if (!autopilotIsDeepInterview && !hasDeepInterviewScopedAutopilotSkill) return null;
   return autopilotState;
 }
@@ -10412,6 +10465,22 @@ async function buildDeepInterviewPreToolUseBoundaryOutput(
   if (!blocked) return null;
 
   const phase = formatPhase(activeState.current_phase ?? activeState.currentPhase, "planning");
+  const phaseMismatch = activeState.__omx_state_phase_mismatch && typeof activeState.__omx_state_phase_mismatch === "object"
+    ? activeState.__omx_state_phase_mismatch as Record<string, unknown>
+    : null;
+  if (phaseMismatch) {
+    const lifecyclePhase = safeString(phaseMismatch.lifecycle_phase).trim() || phase;
+    const skillMirrorPhase = safeString(phaseMismatch.skill_mirror_phase).trim() || "<missing>";
+    return {
+      decision: "block",
+      reason: `STATE_PHASE_MISMATCH: Autopilot lifecycle phase: ${lifecyclePhase}; skill mirror phase: ${skillMirrorPhase}. The lifecycle state remains authoritative for write protection; use same-session \`omx cancel\` or a validated Autopilot deep-interview -> ralplan state transition to recover; ${blockedDetail}.`,
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        additionalContext:
+          "STATE_PHASE_MISMATCH: Autopilot lifecycle and skill-active mirror disagree. Do not infer implementation authorization from the mirror phase; recover with same-session `omx cancel` or a validated lifecycle transition that updates canonical state.",
+      },
+    };
+  }
   return {
     decision: "block",
     reason: `Deep-interview is active (phase: ${phase}); implementation/write tools are blocked until an explicit handoff workflow is activated; ${blockedDetail}.`,
@@ -12218,25 +12287,27 @@ function commandMayPopulateSensitiveRuntimeEnvironment(command: string): boolean
   };
   for (const segment of splitShellCommandSegments(stripHeredocBodiesForCommandScan(command))) {
     const words = tokenizeConductorShellWords(segment);
-    for (let index = 0; index < words.length; index += 1) {
-      const commandName = commandNameFromShellWord(words[index] ?? "");
+    for (const commandStart of collectShellCommandStartIndexes(words)) {
+      const directCommandIndex = skipShellCommandPositionPrefixWords(words, commandStart);
+      const commandIndex = findWrappedCommandPositionIndex(words, commandStart) ?? directCommandIndex;
+      const commandName = commandNameFromShellWord(words[commandIndex] ?? "");
       if (commandName === "printf") {
-        const operands = collectConductorInvocationWords(words, index);
+        const operands = collectConductorInvocationWords(words, commandIndex);
         const valueIndex = operands.findIndex((operand) => shellWordLiteral(operand) === "-v");
         if (valueIndex >= 0 && isSensitiveTarget(operands[valueIndex + 1])) return true;
         if (operands.some((operand) => /^-v[^-]/.test(shellWordLiteral(operand)))) return true;
       } else if (commandName === "read") {
-        const operands = collectConductorInvocationWords(words, index);
+        const operands = collectConductorInvocationWords(words, commandIndex);
         const names = operands.filter((operand) => {
           const literal = shellWordLiteral(operand);
           return literal !== "--" && !literal.startsWith("-");
         });
         if (names.some((name) => isSensitiveTarget(name))) return true;
       } else if (commandName === "getopts") {
-        const operands = collectConductorInvocationWords(words, index);
+        const operands = collectConductorInvocationWords(words, commandIndex);
         if (isSensitiveTarget(operands[1])) return true;
       } else if (commandName === "for" || commandName === "select") {
-        if (isSensitiveTarget(words[index + 1])) return true;
+        if (isSensitiveTarget(words[commandIndex + 1])) return true;
       }
     }
   }
@@ -19547,27 +19618,29 @@ export async function buildConductorPreToolUseWriteGuardOutput(
   let nativeChildMutationAttempt = false;
 
   if (toolName === "Bash") {
-    const shellMutations = extractConductorBashMutations(command, cwd, policyCwd);
-    const bashEvaluation = evaluateConductorBashWrite(cwd, command, 0, sessionId, policyCwd, readPreToolUseRawCommand(payload));
-    blocked = !bashEvaluation.allowed;
-    const canonicalStateCommand = canonicalizeOmxStateTransportCommand(command);
-    const bashStateOperations = collectOmxStateCommandOperations(canonicalStateCommand, "write");
-    if (bashStateOperations.length > 0) {
-      const bashStatePayload = readStateWriteInputPayload(policyCwd, canonicalStateCommand, command);
-      if (
-        !isStandaloneParsedOmxStateWriteTransport(policyCwd, command, sessionId)
-        || !conductorStatePayloadPreservesActiveGuard(bashStatePayload, activeState)
-      ) {
-        blocked = true;
-        blockedDetail = "Bash state writes must preserve the canonical active Conductor guard";
+    if (mutationTransport !== "read-only") {
+      const shellMutations = extractConductorBashMutations(command, cwd, policyCwd);
+      const bashEvaluation = evaluateConductorBashWrite(cwd, command, 0, sessionId, policyCwd, readPreToolUseRawCommand(payload));
+      blocked = !bashEvaluation.allowed;
+      const canonicalStateCommand = canonicalizeOmxStateTransportCommand(command);
+      const bashStateOperations = collectOmxStateCommandOperations(canonicalStateCommand, "write");
+      if (bashStateOperations.length > 0) {
+        const bashStatePayload = readStateWriteInputPayload(policyCwd, canonicalStateCommand, command);
+        if (
+          !isStandaloneParsedOmxStateWriteTransport(policyCwd, command, sessionId)
+          || !conductorStatePayloadPreservesActiveGuard(bashStatePayload, activeState)
+        ) {
+          blocked = true;
+          blockedDetail = "Bash state writes must preserve the canonical active Conductor guard";
+        }
       }
+      const safeExportedFunctionRead = !blocked
+        && shellMutations.length === 0
+        && /\b(?:export\s+(?:-[A-Za-z]*f[A-Za-z]*|--functions?)|(?:declare|typeset)\s+-[A-Za-z]*f[A-Za-z]*)\b/.test(command);
+      nativeChildMutationAttempt = (mutationTransport === "bash" || shellMutations.length > 0)
+        && !safeExportedFunctionRead;
+      if (blocked) blockedDetail = bashEvaluation.blockedDetail ?? buildConductorBashBlockedDetail(cwd, command);
     }
-    const safeExportedFunctionRead = !blocked
-      && shellMutations.length === 0
-      && /\b(?:export\s+(?:-[A-Za-z]*f[A-Za-z]*|--functions?)|(?:declare|typeset)\s+-[A-Za-z]*f[A-Za-z]*)\b/.test(command);
-    nativeChildMutationAttempt = (mutationTransport === "bash" || shellMutations.length > 0)
-      && !safeExportedFunctionRead;
-    if (blocked) blockedDetail = bashEvaluation.blockedDetail ?? buildConductorBashBlockedDetail(cwd, command);
   } else if (mutationTransport === "state") {
     nativeChildMutationAttempt = true;
     const directStateInput = safeObject(payload.tool_input);


### PR DESCRIPTION
## Summary
- Allow trusted literal `omx state read --input ... --json` transport during Ultragoal conductor planning instead of treating the `read` subcommand as a Bash/runtime mutation.
- Detect Autopilot lifecycle vs skill-active phase split-brain (`deep-interview` vs `planning`) and emit an explicit `STATE_PHASE_MISMATCH` guard diagnostic.
- Let same-session trusted `omx cancel` terminalize Autopilot deep-interview even when the skill-active mirror has advanced, without broadening other workflow cancellation paths.

Fixes #3343.
Fixes #3344.

## Baseline reproduction evidence
Starting from current dev with PR #3318 merged (`bb58e727`), focused regression tests were added first and failed before implementation:
- #3343: `omx state read --input '{"mode":"ultragoal","session_id":"...","workingDirectory":"..."}' --json` under Ultragoal planning was blocked as a write/mutation guard path.
- #3344: lifecycle `autopilot-state.json` at `deep-interview` plus `skill-active-state.json` at `planning` did not surface `STATE_PHASE_MISMATCH`.
- #3344: same-session trusted `omx cancel` in that split-brain state failed instead of terminalizing Autopilot.

After #3346 moved dev, this branch was rebased onto current `origin/dev` (`4dcddf8`).

## Validation
- `npm run build && node --test --test-name-pattern '3343|3344' dist/scripts/__tests__/codex-native-hook.test.js` ✅ (post-rebase)
- `npm run test:recent-bug-regressions` ✅ (pre-rebase; 822 tests passing across recent hook/team regressions)
- `npm run lint` ✅ (post-rebase)
- `npm run check:no-unused` ✅ (post-rebase)
- `npm run verify:native-agents` ✅
- `npm run verify:plugin-bundle` ✅

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
