### PR TITLE
fix(hooks): trust exact absolute package CLI status (#3333)

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -33255,6 +33255,101 @@ PY`,
     }
   });
 
+  it("allows the exact installed omx CLI by absolute path for Main-root read-only commands (#3333)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-absolute-cli-readonly-"));
+    const installRoot = await mkdtemp(join(tmpdir(), "omx-native-hook-user-install-"));
+    const originalOmxEnvironment = Object.fromEntries(
+      Object.entries(process.env).filter(([name]) => /^(?:OMX|GJC)_/.test(name)),
+    );
+    const originalPath = process.env.PATH;
+    const originalBashEnv = process.env.BASH_ENV;
+    try {
+      for (const name of Object.keys(process.env)) {
+        if (/^(?:OMX|GJC)_/.test(name)) delete process.env[name];
+      }
+      process.env.OMX_ROOT = cwd;
+      process.env.PATH = `${dirname(process.execPath)}:/usr/bin:/bin`;
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-conductor-absolute-cli-readonly";
+      const leaderThreadId = "thread-conductor-absolute-cli-readonly-leader";
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      await writeCanonicalLeaderFixture(stateDir, sessionId, leaderThreadId, cwd);
+      await writeSessionSkillActiveState(stateDir, sessionId, "ultragoal", "executing");
+      await writeJson(join(stateDir, "sessions", sessionId, "ultragoal-state.json"), {
+        active: true,
+        mode: "ultragoal",
+        current_phase: "executing",
+        session_id: sessionId,
+      });
+      const absoluteOmx = join(installRoot, "bin", "omx");
+      await mkdir(dirname(absoluteOmx), { recursive: true });
+      await symlink(realpathSync(resolve(process.cwd(), "dist", "cli", "omx.js")), absoluteOmx);
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: sessionId,
+        thread_id: leaderThreadId,
+        agent_id: leaderThreadId,
+        tool_name: "Bash",
+        tool_input: { command: `${absoluteOmx} ultragoal status --json` },
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+
+      process.env.BASH_ENV = join(installRoot, "inherited-bash-env");
+      const checkpoint = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: sessionId,
+        thread_id: leaderThreadId,
+        agent_id: leaderThreadId,
+        tool_name: "Bash",
+        tool_input: {
+          command: `${absoluteOmx} ultragoal checkpoint --goal-id G001-ship --status complete --evidence 'G001 complete verified by tests reviews deployment .omx/ultragoal/goals.json .omx/ultragoal/ledger.jsonl' --codex-goal-json .omx/ultragoal/g001-codex-goal-complete.json --quality-gate-json .omx/ultragoal/g001-quality-gate.json --json`,
+        },
+      }, { cwd });
+      assert.equal(checkpoint.outputJson, null);
+
+      const lookalikeOmx = join(installRoot, "lookalike", "bin", "omx");
+      await mkdir(dirname(lookalikeOmx), { recursive: true });
+      await writeFile(lookalikeOmx, "#!/usr/bin/env node\n", "utf-8");
+      await chmod(lookalikeOmx, 0o755);
+      const lookalike = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: sessionId,
+        thread_id: leaderThreadId,
+        agent_id: leaderThreadId,
+        tool_name: "Bash",
+        tool_input: { command: `${lookalikeOmx} ultragoal status --json` },
+      }, { cwd });
+      assert.equal(lookalike.outputJson?.decision, "block");
+
+      const nested = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: sessionId,
+        thread_id: leaderThreadId,
+        agent_id: leaderThreadId,
+        tool_name: "Bash",
+        tool_input: { command: `bash -c '${absoluteOmx} ultragoal checkpoint --goal-id G001-ship --status complete --evidence done --codex-goal-json goal.json --quality-gate-json gate.json --json'` },
+      }, { cwd });
+      assert.equal(nested.outputJson?.decision, "block");
+    } finally {
+      for (const name of Object.keys(process.env)) {
+        if (/^(?:OMX|GJC)_/.test(name)) delete process.env[name];
+      }
+      Object.assign(process.env, originalOmxEnvironment);
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      if (originalBashEnv === undefined) delete process.env.BASH_ENV;
+      else process.env.BASH_ENV = originalBashEnv;
+      await rm(cwd, { recursive: true, force: true });
+      await rm(installRoot, { recursive: true, force: true });
+    }
+  });
+
   it("allows finite Codex goal tools under Main-root Ultragoal checkpointing while near-misses stay unknown-denied (#3300)", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3300-goal-tool-transport-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -9680,6 +9680,29 @@ function isAllowedOmxReadOnlyCommand(command: string, cwd: string): boolean {
   return isAllowedOmxCleanupDryRunCommand(command);
 }
 
+function isAllowedTrustedAbsoluteOmxReadOnlyCommand(command: string, cwd: string): boolean {
+  if (!isSingleLiteralShellInvocation(command)) return false;
+  if (commandHasUnsafeDynamicLoaderEnvironment(command) || commandHasUnsafeLeadingRuntimeEnvironment(command)) return false;
+  const unsafeInheritedNames = [...OMX_GJC_TRUSTED_CONTEXT_UNSAFE_INHERITED_ENV_NAMES, ...CONDUCTOR_NODE_OUTPUT_ENVIRONMENT_NAMES];
+  if (unsafeInheritedNames.some((name) => safeString(process.env[name]).trim() !== "")) return false;
+  const words = tokenizeConductorShellWords(command);
+  const index = skipShellCommandPositionPrefixWords(words, 0);
+  const commandWord = shellWordLiteral(words[index] ?? "");
+  if (!isAbsolute(commandWord) || !commandWord.includes("/") || /[$`]/.test(commandWord)) return false;
+  const commandName = commandNameFromShellWord(commandWord);
+  if (commandName !== "omx" && commandName !== "gjc") return false;
+  const state = resolveConductorCommandPathState(words, 0, index, createConductorRuntimeShellState(cwd));
+  if (!conductorSlashCommandIsTrusted(commandWord, state, cwd)) return false;
+  const args = collectConductorInvocationWords(words, index).map(shellWordLiteral).filter(Boolean);
+  if (args.length === 1 && (args[0] === "--help" || args[0] === "-h" || args[0] === "--version" || args[0] === "-v")) return true;
+  if (args.length === 1 && (args[0] === "help" || args[0] === "status" || args[0] === "version")) return true;
+  if (isAllowedOmxNestedHelpForm(args)) return true;
+  return args.length === 3
+    && args[0] === "ultragoal"
+    && args[1] === "status"
+    && args[2] === "--json";
+}
+
 function isAllowedVersionProbeCommand(command: string): boolean {
   if (!isSingleLiteralShellInvocation(command)) return false;
   const words = literalInvocationWords(command);
@@ -11462,6 +11485,7 @@ function commandHasUnsafeConductorShellState(command: string, cwd = process.cwd(
   let unresolvedNameref = false;
 
   if (!inheritedConductorShellOptions().known) return true;
+  if (isAllowedTrustedAbsoluteOmxReadOnlyCommand(command, cwd)) return false;
   for (const commandStart of collectShellCommandStartIndexes(words)) {
     const directCommandIndex = skipShellCommandPositionPrefixWords(words, commandStart);
     const directCommandWord = shellWordLiteral(words[directCommandIndex] ?? "");
@@ -15958,6 +15982,26 @@ function isStaticallyRecognizedConductorOrchestrationMutation(
   return hasExactConductorOrchestrationOptionSchema(commandName, words, commandIndex);
 }
 
+function isDirectTrustedAbsoluteUltragoalCheckpoint(command: string, rootCwd: string): boolean {
+  const words = tokenizeConductorShellWords(command);
+  const commandStarts = collectShellCommandStartIndexes(words);
+  if (commandStarts.length !== 1 || commandStarts[0] !== 0) return false;
+  const commandIndex = skipShellCommandPositionPrefixWords(words, 0);
+  if (words.slice(0, commandIndex).some((word) => parseShellAssignmentWord(word) === null)) return false;
+  const commandWord = shellWordLiteral(words[commandIndex] ?? "");
+  if (!isAbsolute(commandWord) || !commandWord.includes("/") || /[$`]/.test(commandWord)) return false;
+  const commandName = commandNameFromShellWord(commandWord);
+  if (commandName !== "omx" && commandName !== "gjc") return false;
+  const invocation = collectConductorInvocationWords(words, commandIndex).map(shellWordLiteral);
+  if (invocation[0] !== "ultragoal" || invocation[1] !== "checkpoint") return false;
+  const state = resolveConductorCommandPathState(words, 0, commandIndex, createConductorRuntimeShellState(rootCwd));
+  return conductorSlashCommandIsTrusted(commandWord, state, rootCwd)
+    && hasCanonicalInheritedConductorOrchestrationRoots(words, 0, commandIndex, rootCwd)
+    && !commandHasUnsafeConductorOrchestrationPrefixEnvironment(command, rootCwd)
+    && hasSafeConductorOrchestrationRuntimeEnvironment(words, 0, commandIndex, rootCwd, state)
+    && isStaticallyRecognizedConductorOrchestrationMutation(commandName, words, commandIndex, false);
+}
+
 
 function findConductorIsolatedInvocationBoundary(words: string[], commandStartIndex: number): number {
   const groupingOpens: number[] = [];
@@ -16863,6 +16907,28 @@ function conductorExecutableHasTrustedCurrentNodeRuntimeIdentity(commandName: st
   }
 }
 
+function conductorExecutableHasTrustedPackageCliIdentity(
+  commandName: string,
+  commandPath: string,
+  rootCwd: string,
+  state: ShellPosixState,
+): boolean {
+  if (commandName !== "omx" && commandName !== "gjc") return false;
+  try {
+    const lexical = resolve(commandPath);
+    const root = realpathSync(resolve(rootCwd));
+    if (lexical === root || lexical.startsWith(`${root}/`)) return false;
+    const knownCli = conductorKnownPackageCliPath(commandName);
+    const canonicalCommand = realpathSync(commandPath);
+    const interpreterTrusted = conductorPackageCliHasTrustedNodeInterpreter(commandPath, state, rootCwd);
+    return knownCli !== null
+      && canonicalCommand === knownCli
+      && interpreterTrusted;
+  } catch {
+    return false;
+  }
+}
+
 function conductorExecutableHasTrustedIdentity(
   commandName: string,
   commandPath: string,
@@ -16872,6 +16938,7 @@ function conductorExecutableHasTrustedIdentity(
   seen = new Set<string>(),
 ): boolean {
   if (conductorExecutableHasTrustedCurrentNodeRuntimeIdentity(commandName, commandPath)) return true;
+  if (conductorExecutableHasTrustedPackageCliIdentity(commandName, commandPath, rootCwd, state)) return true;
   if (!conductorExecutableHasTrustedSystemIdentity(commandPath, rootCwd)) return false;
   if (depth >= CONDUCTOR_BASH_MAX_NESTING_DEPTH) return false;
   let canonical: string;
@@ -18170,10 +18237,11 @@ function scanConductorShellSegment(
       && (!CONDUCTOR_PATH_INDEPENDENT_BUILTINS.has(commandName) || invocation.childDispatch)
       && conductorCommandPathMayResolveRepositoryExecutable(words, commandStartIndex, commandIndex, activeState, rootCwd);
     const trustedOmxGjcPackageCliPath = isOmxGjcCommand
-      && commandIsBare
-      && conductorCommandResolvesTrustedPackageCli(words, commandStartIndex, commandIndex, activeState, rootCwd);
+      && (commandIsBare
+        ? conductorCommandResolvesTrustedPackageCli(words, commandStartIndex, commandIndex, activeState, rootCwd)
+        : conductorSlashCommandIsTrusted(commandWord, activeState, rootCwd));
     const bareCommandPathIsSafe = commandIsBare && !commandPathMayResolveRepositoryExecutable;
-    if (isOmxGjcCommand && (!commandIsBare || !trustedOmxGjcPackageCliPath)) {
+    if (isOmxGjcCommand && !trustedOmxGjcPackageCliPath) {
       mutations.push({ command: "PATH", targets: [] });
       continue;
     }
@@ -19385,6 +19453,10 @@ function evaluateConductorBashWrite(
       blockedDetail: "Bash arithmetic expansion is not statically numeric and cannot be validated for Main-root Conductor writes",
     };
   }
+  if (
+    rawCommand === command
+    && isDirectTrustedAbsoluteUltragoalCheckpoint(normalizedCommand, cwd)
+  ) return { allowed: true };
   if (commandHasUnsafeConductorShellState(normalizedCommand, cwd)) {
     return {
       allowed: false,
@@ -19403,6 +19475,10 @@ function evaluateConductorBashWrite(
       blockedDetail: "Bash unquoted heredoc expansion is not workflow state/ledger/mailbox/handoff metadata",
     };
   }
+  if (
+    rawCommand === command
+    && isAllowedTrustedAbsoluteOmxReadOnlyCommand(normalizedCommand, cwd)
+  ) return { allowed: true };
   const redirectTargets = extractDeepInterviewCommandRedirectTargets(commandWithHeredocBodies);
   if (!conductorMetadataRedirectsHaveBoundedProducers(commandWithHeredocBodies)) {
     return {


### PR DESCRIPTION
## Summary
- Trust absolute `omx`/`gjc` package CLI invocations only when the path canonicalizes to the package-declared installed CLI and its `/usr/bin/env node` interpreter resolves to a trusted Node identity.
- Keep the Main-root Conductor relaxation narrow: read-only help/status/version forms plus direct `ultragoal checkpoint` metadata writes using the existing exact option schema.
- Preserve fail-closed behavior for lookalike absolute CLIs, repo-local paths, nested shells, dynamic loader/runtime env, and unsafe inherited env.

Fixes #3333.

## Validation
- `npm run build` ✅
- `node --test --test-name-pattern='allows the exact installed omx CLI by absolute path|issue #3239 permits|allows Ralplan read-only inspection|fail-closed: escaped-quote|uses hook-native agent_id|blocks common Bash file mutations|allows conductor sed/perl metadata' dist/scripts/__tests__/codex-native-hook.test.js` ✅ 8/8
- `npm run check:no-unused` ✅
- `npm run lint` ✅
- `git diff --check` ✅
- `node --test dist/scripts/__tests__/codex-native-hook.test.js` ✅ 621/621
- Earlier pre-rebase full `npm test` on the same fix over `bb58e727` ✅ exit 0; rebased afterward onto `origin/dev` `4dcddf8aa` and re-ran build/focused/static/full-hook gates above.

## Notes
- #3320 and #3322 reproduced as already resolved on current dev before this branch; they will be closed with signed evidence comments.
- Formal independent `$code-review` lanes were not spawned because this task explicitly required no subagents; I performed a local hostile review and kept the patch to a single hook-trust subsystem change with regression coverage.
