### PR TITLE
fix(hook): canonicalize issue 3323 path expectation (#3323)

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -5075,7 +5075,7 @@ PY`,
       assert.notEqual(terminalWrite.isError, true);
       assert.equal(
         (terminalWrite.payload as { path?: string }).path,
-        join(stateDir, "sessions", canonicalSessionId, "deep-interview-state.json"),
+        join(realpathSync(stateDir), "sessions", canonicalSessionId, "deep-interview-state.json"),
       );
       assert.equal(existsSync(join(stateDir, "sessions", ownerSessionId, "deep-interview-state.json")), false);
 


### PR DESCRIPTION
Closes #3323 (tracking reference only — this PR targets `dev`, not the repository's default branch `main`, so GitHub will not auto-close the issue; closure is manual after the post-merge SHA/tree check, per this batch's merge/close criteria).

## Summary

Test-expectation-only fix, no production code change. Canonicalizes the `issue #3138` regression test's expected state-directory path with `realpathSync()` so the assertion is portable across macOS (`/var` → `/private/var` alias) and Linux, matching what `executeStateOperation()` already returns in production.

## Scope gate

```
$ git diff origin/dev...HEAD --stat
 src/scripts/__tests__/codex-native-hook.test.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

$ git log origin/dev..HEAD --oneline
f816cc26a test(hook): canonicalize issue 3323 path expectation
```
Exactly one commit, exactly the expected file. No dependency on #3321/#3325/#3327 — sequenced first only as this batch's elective review-risk-control ordering.

## Verification

- `npm run build`: pass
- Focused acceptance `node --test --test-name-pattern='issue #3138' dist/scripts/__tests__/codex-native-hook.test.js`:
  - default TMPDIR (this harness's Linux default, `/tmp`): 1/1 pass
  - hermetic lexical-vs-canonical alias fixture (`TMPDIR` pointed at a symlink whose target differs from its `realpathSync()` form, simulating the macOS `/var`↔`/private/var` class of divergence — this harness has no macOS runner available, so the alias behavior is exercised via an equivalent-class Linux symlink fixture rather than fabricating macOS execution): 1/1 pass
- Full-file regression `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js`: 620/620 pass
- `npm run lint`: pass
- `npm run check:no-unused`: pass

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
