### PR TITLE
fix(hook): canonicalize conductor mutation roots (#3325)

### DIFF
--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -17536,11 +17536,15 @@ function conductorPathnameExpansionIsAmbiguous(path: string): boolean {
 
 function normalizeWgetMutationTargets(targets: string[], effectiveCwd: string, rootCwd: string): string[] | null {
   const normalized: string[] = [];
+  const canonicalEffectiveCwd = canonicalizeComparablePath(effectiveCwd);
+  const canonicalRootCwd = canonicalizeComparablePath(rootCwd);
   for (const target of targets) {
     if (isUnresolvedVariableTarget(target) || /[`$]/.test(target) || conductorPathnameExpansionIsAmbiguous(target)) return null;
     try {
-      const absoluteTarget = isAbsolute(target) ? resolve(target) : resolve(effectiveCwd, target);
-      normalized.push(relative(rootCwd, absoluteTarget).replace(/\\/g, "/") || ".");
+      const absoluteTarget = isAbsolute(target)
+        ? canonicalizeComparablePath(target)
+        : resolve(canonicalEffectiveCwd, target);
+      normalized.push(relative(canonicalRootCwd, absoluteTarget).replace(/\\/g, "/") || ".");
     } catch {
       return null;
     }


### PR DESCRIPTION
Closes #3325 (tracking reference only — this PR targets `dev`, not the repository's default branch `main`, so GitHub will not auto-close the issue; closure is manual after the post-merge SHA/tree check).

## Summary

Fixes `normalizeWgetMutationTargets()` (also used by `normalizeConductorMutationTargets()`) so both `effectiveCwd` and `rootCwd` — plus absolute mutation operands — are canonicalized with `canonicalizeComparablePath()` *before* resolving relative operands and computing `relative()` against the policy root. Previously, a canonical policy root (`/private/var/...`, from `#3321`'s `realpathSync()`) was compared against a lexical execution cwd (`/var/...`), producing a false escape path like `../../../../../../../var/folders/.../.omx/state` and incorrectly blocking legitimate in-root workflow-metadata writes.

**Explicit dependency**: this PR requires #3321 (already merged as `23605fb1`) — `62220b1ca` calls `canonicalizeComparablePath`, which only exists once `#3321` lands. Branch was cut from `dev` after that merge.

**Fail-closed authorization is unchanged** — this fixes mixed lexical/canonical target normalization; the allow/deny boundary logic itself is untouched.

## Scope gate

```
$ git diff origin/dev...HEAD --stat
 src/scripts/codex-native-hook.ts | 8 ++++++--
 1 file changed, 6 insertions(+), 2 deletions(-)

$ git log origin/dev..HEAD --oneline
0726a1f31 fix(hook): canonicalize conductor mutation roots
```
Exactly one commit, exactly the expected file.

## Verification

- `npm run build`: pass (also proves #3321's `canonicalizeComparablePath` import resolves at cut time)
- **Named-test acceptance** (`blocks common Bash file mutations in Main-root conductor states unless they target workflow metadata`, controlled system `PATH=<node-dir>:/usr/bin:/bin` isolating the unrelated executable-trust regression):
  - default TMPDIR: **2/2 pass**
  - hermetic lexical-vs-canonical alias fixture TMPDIR (no macOS runner available in this harness; a Linux symlink simulates the `/var`↔`/private/var` alias class): **2/2 pass** — this is the exact case that failed pre-fix on the `#3321`-only branch (confirming this PR closes that gap)
- Full-file regression `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js`: **624/624 pass**
- `npm run lint`: pass
- `npm run check:no-unused`: pass

Containment guard math (`relative(canonicalRootCwd, ...)`) is unchanged — only its inputs are now canonicalized.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
