### PR TITLE
test: canonicalize macOS temporary fixture roots (#3327)

### DIFF
--- a/src/cli/__tests__/auth.test.ts
+++ b/src/cli/__tests__/auth.test.ts
@@ -2,9 +2,12 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
-import { tmpdir } from "node:os";
+import { realpathSync } from "node:fs";
+import { tmpdir as osTmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+
+const tmpdir = (): string => realpathSync(osTmpdir());
 
 function omxBin(): string {
   const testDir = dirname(fileURLToPath(import.meta.url));

--- a/src/cli/__tests__/mcp-parity.test.ts
+++ b/src/cli/__tests__/mcp-parity.test.ts
@@ -1,12 +1,14 @@
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { tmpdir as osTmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { mcpParityCommand } from "../mcp-parity.js";
 import { writeSessionStart } from "../../hooks/session.js";
 import { getWikiDir } from "../../wiki/storage.js";
+
+const tmpdir = (): string => realpathSync(osTmpdir());
 
 const originalLog = console.log;
 

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -2,15 +2,17 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { chmod, mkdir, mkdtemp, rm, symlink, writeFile, readFile } from 'fs/promises';
 
-import { existsSync } from 'fs';
+import { existsSync, realpathSync } from 'fs';
 import { dirname, join } from 'path';
-import { tmpdir } from 'os';
+import { tmpdir as osTmpdir } from 'os';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { readModeState } from '../../modes/base.js';
 import { readSkillActiveState } from '../../state/skill-active.js';
 import { recordSkillActivation } from '../../hooks/keyword-detector.js';
 import { cancelModesForTest } from '../index.js';
+
+const tmpdir = (): string => realpathSync(osTmpdir());
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(testDir, '..', '..', '..');

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -1,9 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
-import { existsSync, lstatSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, lstatSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { tmpdir as osTmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import {
@@ -14,6 +14,9 @@ import {
 } from '../../config/codex-hooks.js';
 import { uninstall } from '../uninstall.js';
 import TOML from '@iarna/toml';
+
+const tmpdir = (): string => realpathSync(osTmpdir());
+const shortTmpdir = (): string => process.platform === 'win32' ? tmpdir() : realpathSync('/tmp');
 
 function runOmx(
   cwd: string,
@@ -1824,7 +1827,7 @@ describe('omx uninstall', () => {
       { name: 'finalization', stage: 'after-staged-cleanup', drift: 'config', committed: true },
     ] as const;
     for (const fixture of fixtures) {
-      const wd = await mkdtemp(join(tmpdir(), `omx-uninstall-applied-${fixture.name}-`));
+      const wd = await mkdtemp(join(shortTmpdir(), `omx-uninstall-applied-${fixture.name}-`));
       try {
         await withCwd(wd, async () => {
           const codexDir = join(wd, '.codex');
@@ -3119,7 +3122,7 @@ describe('omx uninstall', () => {
     }
   });
   it('warns once after a successful Windows EPERM-degraded uninstall transaction', async () => {
-    const wd = await mkdtemp(join(tmpdir(), 'omx-uninstall-durability-'));
+    const wd = await mkdtemp(join(shortTmpdir(), 'omx-uninstall-durability-'));
     const originalStderrWrite = process.stderr.write;
     const stderr: string[] = [];
     try {

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -1,11 +1,11 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { tmpdir } from 'node:os';
+import { tmpdir as osTmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import {
   isInstallVersionBump,
@@ -28,6 +28,8 @@ import {
   resolvePackageManagerOwnership,
   type PackageManagerOwnership,
 } from '../package-manager-ownership.js';
+
+const tmpdir = (): string => realpathSync(osTmpdir());
 
 const PACKAGE_NAME = 'oh-my-codex';
 const frozenNpmOwnership: PackageManagerOwnership = {

--- a/src/hooks/extensibility/__tests__/dispatcher.test.ts
+++ b/src/hooks/extensibility/__tests__/dispatcher.test.ts
@@ -1,11 +1,13 @@
 import assert from 'node:assert/strict';
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { tmpdir as osTmpdir } from 'node:os';
 import { delimiter, join } from 'node:path';
 import { describe, it } from 'node:test';
 import { isHookPluginFeatureEnabled, dispatchHookEvent } from '../dispatcher.js';
 import { buildHookEvent } from '../events.js';
+
+const tmpdir = (): string => realpathSync(osTmpdir());
 
 function processExists(pid: number): boolean {
   try {

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -4,8 +4,8 @@ import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import { mkdtemp, rm, readFile, writeFile, mkdir, chmod, readdir, symlink } from 'fs/promises';
 import { join, posix, relative, win32 } from 'path';
-import { tmpdir } from 'os';
-import { existsSync, readFileSync } from 'fs';
+import { tmpdir as osTmpdir } from 'os';
+import { existsSync, readFileSync, realpathSync } from 'fs';
 import {
   initTeamState,
   createTask,
@@ -32,6 +32,7 @@ import {
 import { TEAM_WORKER_INHERITED_MODEL_ENV } from '../model-contract.js';
 import { buildWorkerProcessLaunchSpec } from '../tmux-session.js';
 
+const tmpdir = (): string => realpathSync(osTmpdir());
 
 delete process.env.OMX_TEAM_STATE_ROOT;
 process.env.OMX_RUNTIME_BRIDGE = '0';

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -1,9 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { tmpdir as osTmpdir } from 'node:os';
 import {
   __resetSessionPointerTransactionDependenciesForTests,
   __setSessionPointerTransactionDependenciesForTests,
@@ -30,6 +30,8 @@ import {
 } from '../artifacts.js';
 import { LEADER_CONDUCTOR_BLOCK, buildUnsupportedNativeSubagentGuidance } from '../../leader/contract.js';
 import { steeringFixtures, type SteeringFixtureProposal } from './steering-fixtures.js';
+
+const tmpdir = (): string => realpathSync(osTmpdir());
 
 async function withTempRepo<T>(run: (cwd: string) => Promise<T>): Promise<T> {
   const cwd = await mkdtemp(join(tmpdir(), 'omx-ultragoal-'));


### PR DESCRIPTION
Closes #3327 (tracking reference only — this PR targets `dev`, not the repository's default branch `main`, so GitHub will not auto-close the issue; closure is manual after the post-merge SHA/tree check).

## Summary

Fixture-only change, **no production code touched**. Each of the 8 listed test files replaces the imported `tmpdir()` from `node:os` with a local shim `const tmpdir = (): string => realpathSync(osTmpdir());`, so security-sensitive fixture roots, exact path expectations, `OMX_MCP_WORKDIR_ROOTS` allowlists, and worktree/debt metadata comparisons use the canonicalized temp root instead of the lexical `os.tmpdir()` result. This eliminates macOS `/var` ↔ `/private/var` fixture/production drift without changing any production symlink/containment guard.

Files (all under `__tests__`):
- `src/cli/__tests__/auth.test.ts`
- `src/cli/__tests__/mcp-parity.test.ts`
- `src/cli/__tests__/session-scoped-runtime.test.ts`
- `src/cli/__tests__/uninstall.test.ts`
- `src/cli/__tests__/update.test.ts`
- `src/hooks/extensibility/__tests__/dispatcher.test.ts`
- `src/team/__tests__/scaling.test.ts`
- `src/ultragoal/__tests__/artifacts.test.ts`

No code dependency on #3321/#3325/#3323 (all merged) — sequenced last per the batch plan's elective ordering (avoids a window where these fixtures assert canonicalized behavior before the production canonicalization landed), not a compile/runtime dependency.

## Scope gate

```
$ git diff origin/dev...HEAD --stat
 src/cli/__tests__/auth.test.ts                       |  5 ++++-
 src/cli/__tests__/mcp-parity.test.ts                 |  6 ++++--
 src/cli/__tests__/session-scoped-runtime.test.ts     |  6 ++++--
 src/cli/__tests__/uninstall.test.ts                  | 11 +++++++----
 src/cli/__tests__/update.test.ts                     |  6 ++++--
 src/hooks/extensibility/__tests__/dispatcher.test.ts |  6 ++++--
 src/team/__tests__/scaling.test.ts                   |  5 +++--
 src/ultragoal/__tests__/artifacts.test.ts            |  6 ++++--
 8 files changed, 34 insertions(+), 17 deletions(-)

$ git log origin/dev..HEAD --oneline
6b80180ae test: canonicalize macOS temporary fixture roots
```
Exactly one commit, exactly the 8-file allowlist.

## Verification

- `npm run build`: pass
- **Default-TMPDIR cross-platform run** (`node dist/scripts/run-test-files.js <8 files>`, unset/inherited TMPDIR — this is the portable regression gate and does not force `TMPDIR=/private/tmp`, since `/private/tmp` doesn't exist off macOS): **all 8 files exit 0** — `10/10, 8/8, 41/41, 79/79, 79/79, 16/16, 119/119, 85/85` (counts recorded from this branch's actual run, not copied from the issue body, per the plan's evidence requirement).
- **Hermetic lexical-vs-canonical alias fixture run** (no macOS runner available in this harness, so the alias class of divergence is exercised via a Linux symlink fixture instead of fabricating macOS execution): `TMPDIR` pointed at a symlink whose target differs from its `realpath()` form. Recorded before/around the run:
  ```
  default: os.tmpdir() = /tmp                                          | realpathSync(os.tmpdir()) = /tmp
  alias:   os.tmpdir() = /tmp/hermetic-alias-fixture/lexical-alias      | realpathSync(os.tmpdir()) = /tmp/hermetic-alias-fixture/canonical-root
  ```
  Under the alias TMPDIR, **all 8 files still exit 0** with identical pass counts — confirming each file's `realpathSync(osTmpdir())` shim correctly canonicalizes regardless of whether the environment hands it a lexical alias or the canonical root directly.
- `npm run lint`: pass
- `npm run check:no-unused`: pass

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
