### PR TITLE
release: 0.20.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,41 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [0.20.4] - 2026-07-28
+
+Patch release for the reliability, workflow-safety, and native-hook trust work in `v0.20.3..73cb50c125c11aca0654b8841e690f011eb5f43f`, plus one additive, backward-compatible feature. No intentional breaking CLI or package-layout changes.
+
+### Added
+
+- **Herdr lifecycle/status bridge** — opt-in Herdr lifecycle and status bridge (Phase 1) provides an external adaptation surface (#3241, #3242).
+
 ### Fixed
 
 - **Autopilot host-receipt preflight** — fresh default Autopilot now fails before deep-interview and Architect/Critic review work when the official host consensus receipt verifier is deterministically unavailable, while preserving the exact fail-closed blocker, direct/manual Ralplan diagnostics, active-session resumability, and ADR 3194/3212 authority boundaries (#3270).
-- **Native cache integrity boundary** — managed cache binaries without their `.sha256` sidecar are rejected; checksum verification establishes integrity, not a signature. On a retained hydration lock, confirm that no OMX hydration process is active for that cache key, remove only that named lock manually, then retry. SparkShell warns and falls back to raw command execution without summary support when its native sidecar is unavailable or GLIBC-incompatible. Binary and checksum sidecars are published as two files and are not an atomic pair; the lock protocol provides process-crash-safe, fail-closed publication, with manual retained-lock remediation, rather than recovery from a process crash.
+- **Native cache integrity boundary** — managed cache binaries without their `.sha256` sidecar are rejected; checksum verification establishes integrity, not a signature. On a retained hydration lock, confirm that no OMX hydration process is active for that cache key, remove only that named lock manually, then retry. SparkShell warns and falls back to raw command execution without summary support when its native sidecar is unavailable or GLIBC-incompatible. Binary and checksum sidecars are published as two files and are not an atomic pair; the lock protocol provides process-crash-safe, fail-closed publication, with manual retained-lock remediation, rather than recovery from a process crash (#3285).
+- **Dead session-pointer lock recovery** — canonical session-pointer locks are recovered when positively dead, with identity-revalidated, no-clobber reversible claims; recovery checkpoints are resumable, swapped claims preserved, failed claims rolled back, and recovery directories atomically quarantined (#3261, #3262; issue #3256).
+- **Team startup rollback and pane authority** — startup cleanup is bound to exact owned panes and split-proof reconciliation, pinned against ambiguous worker/HUD cleanup and PID reuse (#3265; #3231, #3228, #3229, #3230; issue #3224).
+- **Team fail-closed on managed Codex bypass** — managed bypass rejection is enforced fail-closed when Codex bypass is rejected under managed mode (#3232).
+- **Resumed session cancel ownership** — cancel ownership is reconciled for resumed sessions, preserving proven-session scoping (#3280, #3290, #3214).
+- **Root session self-reopen prevention** — root sessions are prevented from self-reopening (#3284, #3289).
+- **Native hook trust and path canonicalization** — exact absolute package CLI status is trusted (#3333; issues #3320, #3322, #3323, #3325, #3321, #3327), conductor mutation roots are canonicalized, macOS policy paths and temporary fixture roots are canonicalized, and planning state transport guards are repaired (#3343, #3344, #3348, #3349, #3350, #3351, #3352, #3353).
+- **Identity-indeterminate pointer recovery** — bounded exact-match recovery resolves identity-indeterminate session pointers (#3324, #3332).
+- **Ultragoal goal-status and state binding** — native Codex goal blocked status is preserved (#3301, #3305), aggregate goals are bound to canonical state paths (#3294, #3297), aggregate completion is persisted on ordinary final checkpoint (#3295), and finite Codex goal tools are authorized under Main-root Conductor (#3300, #3304).
+- **State authoritative root and alias resolution** — verified native session aliases are resolved (#3308, #3160), and durable state commits are revalidated against exact stale session bindings (#3272, #3298).
+- **Deep-interview cancel and self-lock** — the deep-interview omx cancel hook is made hook-owned (#3293, #3299), and the PreToolUse self-lock is fixed (#3240).
+- **HUD teardown and resize guards** — detached HUD is torn down on child exit (#3267), and deferred HUD resize sinks are guarded in command-list context (#3292, #3296).
+- **Native Stop hook bounds** — sloppy fallback Stop audit is bounded and session-scoped (#3347), native Stop hook pointer loops are bounded (#3238), paused Stop guidance is bounded (#3237), and unmatched native Stop is silenced (#3254).
+- **Native sidecar and collaboration authority** — native sidecar session authority is scoped during pointer conflicts (#3244), live session pointers are prevented from native-start replacement (#3235), collaboration tool names are canonicalized (#3264), and collaboration.send_message is scoped out of native-child orchestration deny (#3317).
+- **Standalone Conductor activation guard** — standalone Ultragoal Conductor activation with no reachable owner is refused (#3311, #3312).
+- **Unauthoritative plan bootstrap rejection** — unauthoritative Ultragoal bootstrap publication is rejected (#3326).
+- **Read-only discovery misclassification** — omx/gjc read-only discovery is no longer misclassified as writes (#3313, #3314, #3318).
+- **Auth metadata validation and credential switch** — metadata is validated before credential switch (#3276).
+- **Oversized native hook stdin** — oversized native hook stdin is drained (#3273).
+- **Nonexistent native assignment guidance** — nonexistent native assignment guidance is removed (#3346).
+- **Windows session owner PID** — Windows native hook session owner PID is resolved (#3260).
+- **Bun install ownership** — Bun install ownership is preserved during update (#3259).
+- **tmux separator argv boundaries** — tmux separator argv boundaries are preserved (#3258).
+- **Ralplan preflight guidance** — Ralplan preflight guidance is scoped (#3255).
 
 ## [0.20.3] - 2026-07-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "omx-api"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -40,14 +40,14 @@ dependencies = [
 
 [[package]]
 name = "omx-explore-harness"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "omx-mux"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "fs2",
  "libc",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime-core"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "fs2",
  "serde",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "omx-sparkshell"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "omx-mux",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.20.3"
+version = "0.20.4"
 
 edition = "2021"
 rust-version = "1.73"

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,40 +1,39 @@
-# oh-my-codex 0.20.3
+# oh-my-codex 0.20.4
 
-`0.20.3` is a patch release for the reliability and workflow-safety work in the exact range `v0.20.2..f967cfed64ec57614af136f75d7cb81509808f7e`, plus one additive, backward-compatible feature.
+`0.20.4` is a patch release for the reliability, workflow-safety, and native-hook trust work in the exact range `v0.20.3..73cb50c125c11aca0654b8841e690f011eb5f43f`, plus one additive, backward-compatible feature.
 
 ## Highlights
 
-- Reasoning effort can be capped per agent through the team model contract (#3143).
-- Team validates exact live tmux panes before explicit lifecycle effects and preserves pane ownership through startup, scaling, rollback, recovery, and teardown, with durable failure-atomic membership/scaling transactions and pane-pid-bound notify dispatch (#3153; issue #3121).
-- Ralplan requires strict direct review order, fails closed without documented leader proof, attests the reconciled leader in `PreToolUse`, and resolves the App leader-proof regression by parsing collaboration results structurally (#3186, #3196, #3187, #3218; issues #3194, #3181, #3204).
+- Dead session-pointer lock recovery with identity-revalidated, no-clobber reversible claims, resumable checkpoints, and atomic quarantine (#3261, #3262; issue #3256).
+- Team startup rollback bound to exact owned panes with split-proof reconciliation, worker liveness pinning, leader session pointer ownership, stale notice invalidation, terminal follow-up boundary guards, and fail-closed managed Codex bypass rejection (#3265; #3231, #3228, #3229, #3230, #3232; issue #3224).
+- Native hook trust and path canonicalization: exact absolute package CLI status trusted (#3333; issues #3320, #3322, #3323, #3325, #3321, #3327), conductor mutation roots and macOS policy/fixture paths canonicalized, planning state transport guards repaired (#3343, #3344, #3348, #3349, #3350, #3351, #3352, #3353).
+- Ultragoal goal-status preservation, canonical state path binding, aggregate completion persistence, and finite Codex goal tool authorization under Main-root Conductor (#3301, #3305, #3294, #3297, #3295, #3300, #3304).
+- State authoritative runtime root with session-scoped authority, authenticated fixtures, and plugin authority isolation (#3160).
+- Opt-in Herdr lifecycle/status bridge Phase 1 (#3241, #3242).
+- Ralplan review authority remains fail-closed without an official host consensus receipt, and autopilot preflight fails before deep-interview and Architect/Critic review work when the receipt verifier is unavailable (#3270).
 
 > **Current status / supersession (ADR 3212):** Local leader attestation and adapted role intent no longer authorize. Typed routing/tracker evidence are lifecycle/diagnostic only. On `role_routing_unavailable` adapted Ralplan authority attempts, installed role-intent/preflight fails closed with `unsupported_documented_leader_proof`. Consensus is unavailable with `documented_host_consensus_receipt_unavailable` absent an official host receipt.
-- Team mailbox wakeups are coalesced with every wake acknowledged (#3217; issue #3195), and exact session pointer lock recovery is added (#3215; issue #3203).
-- Native child write identity is hardened across the native hook, code-intel, and wiki MCP surfaces (#3135; issue #3127), and the configuration generator reconciles duplicate project trust tables idempotently (#3201; issue #3199).
-- The plugin native hook returns structured responses for oversized tool-hook payloads (#3211), and Windows regular-file `fsync` `EPERM` is tolerated across hooks, uninstall, and the native hook (#3191).
 
 ## Additional fixes
 
-- Isolated standard launches are documented in the CLI and README (#3192).
-
-## Release collateral
-
-- `1c007fff`, `122b0cba`, `fb13a6db`, and `0a7baa81` are v0.20.2 post-publish evidence corrections carried forward; they are release-collateral inventory only. `4b557d13` is the 0.20.3 version-development preparation commit.
-
-## Merged PRs since v0.20.2
-
-#3135, #3143, #3153, #3186, #3187, #3191, #3192, #3196, #3201, #3211, #3215, #3217, #3218. Issues #3121, #3127, #3181, #3194, #3195, #3199, #3203, and #3204 are associated issues, not additional PRs.
-
-## Compatibility
-
-Patch release with no intentional breaking CLI or package-layout changes; the one feature (#3143) is additive and backward-compatible.
-
-## Validation
-
-Local build, lint, typecheck, plugin-bundle, native-agents, and Node test gates for the touched surface are recorded in `docs/qa/release-readiness-0.20.3.md`. External CI, tag, GitHub release, and npm provenance publication evidence is recorded in that same readiness record as the publish sequence completes.
+- Resumed session cancel ownership reconciliation (#3280, #3290, #3214).
+- Root session self-reopen prevention (#3284, #3289).
+- Identity-indeterminate pointer recovery (#3324, #3332).
+- State alias resolution and stale binding revalidation (#3308, #3272, #3298).
+- Deep-interview cancel hook ownership and PreToolUse self-lock fix (#3293, #3299, #3240).
+- HUD teardown on child exit and deferred resize guards (#3267, #3292, #3296).
+- Native Stop hook bounds: session-scoped sloppy fallback audit, pointer loop bounds, paused guidance bounds, unmatched Stop silence (#3347, #3238, #3237, #3254).
+- Native sidecar and collaboration authority scoping (#3244, #3235, #3264, #3317).
+- Standalone Conductor activation guard and unauthoritative plan bootstrap rejection (#3311, #3312, #3326).
+- Read-only discovery misclassification fix (#3313, #3314, #3318).
+- Auth metadata validation, oversized hook stdin drain, nonexistent assignment guidance removal (#3276, #3273, #3346).
+- Windows session owner PID, Bun install ownership, tmux separator argv boundaries (#3260, #3259, #3258).
+- Ralplan preflight guidance scoping and PowerShell psmux pane safety (#3255, #3145).
+- Autopilot host-receipt preflight and native cache integrity fail-closed (#3270, #3285).
+- Dependency updates: libc, serde, serde_json, @modelcontextprotocol/sdk, @biomejs/biome, c8, @types/yauzl, @types/yazl.
 
 ## Contributors
 
-Thanks to Bellman (@Yeachan-Heo) for commits in this range.
+Thanks to Bellman (@Yeachan-Heo) for the majority of commits in this range, with additional contributions from @achieve0410, @bohe76, @chief-impact7, @don9x2E, @huajuan404, @ictechgy, @lux-02, @masterFoad, and @WangErgouaaaa, plus @app/dependabot for dependency updates.
 
-**Full Changelog**: [`v0.20.2...v0.20.3`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.20.2...v0.20.3)
+**Full Changelog**: [`v0.20.3...v0.20.4`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.20.3...v0.20.4)

--- a/docs/qa/release-readiness-0.20.4.md
+++ b/docs/qa/release-readiness-0.20.4.md
@@ -1,0 +1,62 @@
+# Release readiness — 0.20.4
+
+## Release readiness record
+
+This record is the readiness declaration for the frozen `0.20.4` candidate. It captures the compare-range inventory, local gate evidence collected on 2026-07-28, and external CI/tag/npm evidence recorded as the publish sequence completes.
+
+## Release identity
+
+- Release: `0.20.4` (patch; includes one additive, backward-compatible feature, #3241/#3242).
+- Date: 2026-07-28.
+- Previous tag: `v0.20.3`.
+- Frozen dev base: `73cb50c125c11aca0654b8841e690f011eb5f43f`.
+- Exact compare range: `v0.20.3..73cb50c125c11aca0654b8841e690f011eb5f43f`.
+- Ancestry: `git merge-base --is-ancestor v0.20.3 dev` passes; `merge-base(v0.20.3, dev-HEAD)` equals the v0.20.3 commit `2e666461d4147fa4718691f7b4d9a1a282380f16`.
+- Range size: 130 commits — 62 merged product PRs (one additive feature plus reliability, workflow-safety, native-hook trust, and path-canonicalization fixes), plus squash-merged constituents and dependency bumps.
+- Compatibility: no intentional breaking CLI or package-layout changes.
+
+## Frozen commit inventory
+
+The full commit/PR inventory is in `docs/release-notes-0.20.4.md` and `artifacts/release-0.20.4/inventory.md`. The merged product PR set is #3145, #3160, #3214, #3216, #3219, #3228, #3229, #3230, #3231, #3232, #3233, #3235, #3237, #3238, #3240, #3241, #3242, #3244, #3248, #3249, #3250, #3251, #3252, #3254, #3255, #3258, #3259, #3260, #3262, #3264, #3265, #3267, #3271, #3272, #3273, #3276, #3277, #3280, #3284, #3285, #3289, #3290, #3292, #3293, #3294, #3295, #3296, #3297, #3298, #3299, #3300, #3304, #3305, #3308, #3311, #3312, #3313, #3314, #3317, #3318, #3324, #3326, #3328, #3330, #3331, #3332, #3333, #3335, #3337, #3339, #3340, #3343, #3346, #3347, #3348, #3349, #3350, #3351, #3352, and #3353. Reproduce with:
+
+```sh
+git log --reverse --format='%H%x09%s' v0.20.3..73cb50c125c11aca0654b8841e690f011eb5f43f
+```
+
+Any mismatch blocks release preparation.
+
+## Required gates
+
+| Gate | Evidence | Status |
+|---|---|---|
+| Collateral/range review | Confirmed the frozen 130-commit range, 62 merged PRs, classifications, highlights, contributors, and compare link across `CHANGELOG.md`, `docs/release-notes-0.20.4.md`, `RELEASE_BODY.md`, and this record against `git log v0.20.3..dev`. | Passed locally |
+| Release-scope review | Candidate ships the current `dev` tip `73cb50c12`. Release-prep pass adds only release-collateral files and version-carrier bumps; no product-runtime source, dependency, lockfile, or workflow change is introduced by the release-prep pass. Version metadata is `0.20.4` in `package.json`, `package-lock.json`, `Cargo.toml`, `Cargo.lock`, and `plugins/oh-my-codex/.codex-plugin/plugin.json`. | Passed locally |
+| Local static gates | `npm ci`, `npm run build`, `npm run lint`, `npm run verify:plugin-bundle`, `npm run verify:native-agents`. | Pending (local gate run) |
+| Local Node tests | `npm run test:node` for the touched surface. | Pending (local gate run) |
+| Release-body generation | `node dist/scripts/generate-release-body.js --template RELEASE_BODY.md --current-tag v0.20.4 --previous-tag v0.20.3 --repo Yeachan-Heo/oh-my-codex` | Pending (local gate run) |
+| CI | `dev` and `main` CI green for the exact shipped commit. | Pending (publish sequence) |
+| Tag and release | Annotated `v0.20.4` peels to the shipped commit; release workflow completes all native builds, asset publication/verification, packed-install smoke, and npm publication. | Pending (publish sequence) |
+| npm publication | `npm view oh-my-codex@0.20.4` returns `0.20.4`. | Pending (publish sequence) |
+| Public registry install | Isolated public-registry install boots and reports `oh-my-codex v0.20.4`. | Pending (publish sequence) |
+
+## Known gaps
+
+- **Environment/platform-gated local test suites.** The Linux CI boundary is authoritative for platform-gated suites. Any local failures matching the v0.20.3 baseline on this workstation are documented during the local gate run (Phase B) and are not v0.20.4 regressions if they reproduce identically at the v0.20.3 baseline.
+- **Contributors.** The range includes external contributors: @achieve0410 (#3260, #3308), @bohe76 (#3260), @chief-impact7 (#3273), @don9x2E (#3233), @huajuan404 (#3347), @ictechgy (#3265), @lux-02 (#3276), @masterFoad (#3238), @WangErgouaaaa (#3235, #3244), plus @app/dependabot for dependency updates. The maintainer (Yeachan Heo, @Yeachan-Heo) authored the majority of commits.
+
+## Compatibility
+
+This patch release has no intentional breaking CLI or package-layout changes; the one feature (#3241/#3242) is additive and backward-compatible.
+
+## Publish sequence (RELEASE_PROTOCOL.md §5)
+
+1. Push the candidate collateral commit to `dev`; wait for `dev` CI green for the shipped commit.
+2. Promote the candidate to `main` through the normal CI path; wait for `main` CI green.
+3. Create and push the annotated `v0.20.4` tag; wait for the tag-triggered release workflow (native builds, asset publication/verification, packed-install smoke, npm publication).
+4. Verify the non-draft GitHub release with native assets/manifest attached and `npm view oh-my-codex version` == `0.20.4`.
+5. Fast-forward `dev` to the shipped `main` commit; wait for final `dev` CI green.
+6. Bump `dev` metadata to the next development base version (`0.20.5`).
+
+## Release notes and contributors
+
+The product-facing summary is in `docs/release-notes-0.20.4.md`, the GitHub body is `RELEASE_BODY.md`, and the changelog entry is `CHANGELOG.md`. The compare link is [`v0.20.3...v0.20.4`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.20.3...v0.20.4).

--- a/docs/release-notes-0.20.4.md
+++ b/docs/release-notes-0.20.4.md
@@ -1,0 +1,64 @@
+# oh-my-codex 0.20.4 release notes
+
+Release date: 2026-07-28
+
+`0.20.4` is a patch release covering the exact frozen range `v0.20.3..73cb50c125c11aca0654b8841e690f011eb5f43f`. It contains 62 merged product PRs (one additive, backward-compatible feature plus reliability, workflow-safety, native-hook trust, and path-canonicalization fixes).
+
+## Highlights
+
+- **Dead session-pointer lock recovery** — canonical session-pointer locks are now recovered when positively dead, with identity-revalidated, no-clobber reversible claims. Recovery checkpoints are resumable, swapped claims are preserved, failed claims are rolled back, and recovery directories are atomically quarantined (#3261, #3262; issue #3256).
+- **Team startup rollback and pane authority** — startup cleanup is bound to exact owned panes with split-proof reconciliation, pinned against ambiguous worker/HUD cleanup and PID reuse. Team also validates worker liveness against exact panes, preserves leader session pointer ownership, invalidates stale queued notices, guards the terminal follow-up boundary, and fails closed on managed Codex bypass rejection (#3265; #3231, #3228, #3229, #3230, #3232; issue #3224).
+- **Native hook trust and path canonicalization** — exact absolute package CLI status is trusted (#3333; issues #3320, #3322, #3323, #3325, #3321, #3327). Conductor mutation roots, macOS policy paths, and temporary fixture roots are canonicalized. Planning state transport guards are repaired (#3343, #3344, #3348, #3349, #3350, #3351, #3352, #3353).
+- **Ultragoal goal-status and state binding** — native Codex goal blocked status is preserved (#3301, #3305), aggregate goals are bound to canonical state paths (#3294, #3297), aggregate completion is persisted on ordinary final checkpoint (#3295), and finite Codex goal tools are authorized under Main-root Conductor (#3300, #3304).
+- **State authoritative root** — the authoritative runtime root establishes session-scoped authority with authenticated fixtures, ownership enforcement, alias binding, HUD read binding, stale-ancestor rejection, plugin authority isolation, and contained root targets (#3160).
+- **Herdr lifecycle/status bridge** — opt-in Herdr lifecycle and status bridge (Phase 1) provides an external adaptation surface (#3241, #3242).
+
+## Other fixes
+
+- **Resumed session cancel ownership** — cancel ownership is reconciled for resumed sessions, preserving proven-session scoping (#3280, #3290, #3214).
+- **Root session self-reopen prevention** — root sessions are prevented from self-reopening (#3284, #3289).
+- **Identity-indeterminate pointer recovery** — bounded exact-match recovery resolves identity-indeterminate session pointers (#3324, #3332).
+- **State alias resolution and revalidation** — verified native session aliases are resolved (#3308), and durable state commits are revalidated against exact stale session bindings (#3272, #3298).
+- **Deep-interview cancel and self-lock** — the deep-interview omx cancel hook is made hook-owned (#3293, #3299), and the PreToolUse self-lock is fixed (#3240).
+- **HUD teardown and resize guards** — detached HUD is torn down on child exit (#3267), and deferred HUD resize sinks are guarded in command-list context (#3292, #3296).
+- **Native Stop hook bounds** — sloppy fallback Stop audit is bounded and session-scoped (#3347), native Stop hook pointer loops are bounded (#3238), paused Stop guidance is bounded (#3237), and unmatched native Stop is silenced (#3254).
+- **Native sidecar and collaboration authority** — native sidecar session authority is scoped during pointer conflicts (#3244), live session pointers are prevented from native-start replacement (#3235), collaboration tool names are canonicalized (#3264), and collaboration.send_message is scoped out of native-child orchestration deny (#3317).
+- **Standalone Conductor activation guard** — standalone Ultragoal Conductor activation with no reachable owner is refused (#3311, #3312).
+- **Unauthoritative plan bootstrap rejection** — unauthoritative Ultragoal bootstrap publication is rejected (#3326).
+- **Read-only discovery misclassification** — omx/gjc read-only discovery is no longer misclassified as writes (#3313, #3314, #3318).
+- **Auth metadata validation** — metadata is validated before credential switch (#3276).
+- **Oversized native hook stdin** — oversized native hook stdin is drained (#3273).
+- **Nonexistent native assignment guidance** — nonexistent native assignment guidance is removed (#3346).
+- **Windows session owner PID** — Windows native hook session owner PID is resolved (#3260).
+- **Bun install ownership** — Bun install ownership is preserved during update (#3259).
+- **tmux separator argv boundaries** — tmux separator argv boundaries are preserved (#3258).
+- **Ralplan preflight guidance** — Ralplan preflight guidance is scoped (#3255).
+- **PowerShell psmux pane creation** — Team's PowerShell psmux pane creation is made safe (#3145).
+- **Autopilot host-receipt preflight** — fresh default Autopilot now fails before deep-interview and Architect/Critic review work when the official host consensus receipt verifier is deterministically unavailable (#3270).
+- **Native cache integrity boundary** — managed cache binaries without their `.sha256` sidecar are rejected; native-assets fail closed on unverified cache authority (#3285).
+- **Deterministic test fixes** — PATH candidate-budget smoke test is made deterministic (#3330), portable PTY script(1) argv helper for Darwin/Linux is added (#3328, #3331), and Windows durability sync is made deterministic (#3233).
+- **Dependency bumps** — libc 0.2.186→0.2.189 (#3251, #3335), serde 1.0.228→1.0.229 (#3249), serde_json 1.0.150→1.0.151 (#3248), @modelcontextprotocol/sdk 1.29.0→1.30.0 (#3337), @biomejs/biome 2.5.3→2.5.4 (#3252), c8 11.0.0→12.0.0 (#3250), @types/yauzl 2.10.3→3.4.0 (#3339), @types/yazl 2.4.5→3.3.1 (#3340).
+
+## Merged PR inventory
+
+The merged product PR set is #3145, #3160, #3214, #3216, #3219, #3228, #3229, #3230, #3231, #3232, #3233, #3235, #3237, #3238, #3240, #3241, #3242, #3244, #3248, #3249, #3250, #3251, #3252, #3254, #3255, #3258, #3259, #3260, #3262, #3264, #3265, #3267, #3271, #3272, #3273, #3276, #3277, #3280, #3284, #3285, #3289, #3290, #3292, #3293, #3294, #3295, #3296, #3297, #3298, #3299, #3300, #3304, #3305, #3308, #3311, #3312, #3313, #3314, #3317, #3318, #3324, #3326, #3328, #3330, #3331, #3332, #3333, #3335, #3337, #3339, #3340, #3343, #3346, #3347, #3348, #3349, #3350, #3351, #3352, #3353. Associated issues #3301, #3309, #3220, #3320, #3321, #3322, #3323, #3325, #3327, #3293, #3284, #3292, #3294, #3272, #3311, #3313, #3314, #3241, #3256, #3224, #3270, and #3300 are not additional PRs. Reproduce the inventory with:
+
+```sh
+git log --reverse --format='%H%x09%s' v0.20.3..73cb50c125c11aca0654b8841e690f011eb5f43f
+```
+
+A full commit-level classification is in `artifacts/release-0.20.4/inventory.md`.
+
+## Compatibility
+
+Patch release with no intentional breaking CLI or package-layout changes. The one feature (#3241/#3242 Herdr bridge) is additive and backward-compatible.
+
+## Validation
+
+Local build, lint, typecheck, plugin-bundle, native-agents, and Node test gates for the touched surface are recorded in `docs/qa/release-readiness-0.20.4.md`. External CI, tag, GitHub release, and npm publication evidence is recorded in that same readiness record as the publish sequence completes.
+
+## Contributors
+
+Thanks to Bellman (@Yeachan-Heo) for the majority of commits in this range, with additional contributions from @achieve0410, @bohe76, @chief-impact7, @don9x2E, @huajuan404, @ictechgy, @lux-02, @masterFoad, and @WangErgouaaaa, plus @app/dependabot for dependency updates.
+
+**Full Changelog**: [`v0.20.3...v0.20.4`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.20.3...v0.20.4)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-codex",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-codex",
-      "version": "0.20.3",
+      "version": "0.20.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/oh-my-codex/.codex-plugin/plugin.json
+++ b/plugins/oh-my-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "author": {
     "name": "Yeachan Heo",


### PR DESCRIPTION
## Release: 0.20.4

**Frozen compare range:** `v0.20.3..73cb50c125c11aca0654b8841e690f011eb5f43f` (130 commits, 62 merged product PRs)

### Release-prep scope
This PR adds only release collateral and version-carrier synchronization. No product-runtime source, dependency, lockfile, or workflow change.

**Version carriers bumped:** `package.json`, `package-lock.json`, `Cargo.toml`, `Cargo.lock`, `plugins/oh-my-codex/.codex-plugin/plugin.json`

**Collateral files:**
- `CHANGELOG.md` — `[Unreleased]` promoted to `[0.20.4] - 2026-07-28`
- `docs/release-notes-0.20.4.md` — full release notes with Highlights, Fixes, PR inventory
- `docs/qa/release-readiness-0.20.4.md` — readiness record with compare range, gates, publish sequence
- `RELEASE_BODY.md` — GitHub release body template

### Local gate evidence
- ✅ `npm ci`, `npm run build`, `npm run lint` (788 files), `npm run check:no-unused`, `npm run verify:plugin-bundle` (29 dirs), `npm run verify:native-agents` (22 agents)
- ✅ Release-body generation validated for v0.20.4 vs v0.20.3
- ✅ `npm pack --dry-run` → `oh-my-codex-0.20.4.tgz`
- ✅ `npm run test:node` — zero failures across executed files (Linux CI is authoritative for platform-gated suites)

### Key changes in range
- Dead session-pointer lock recovery (#3261, #3262)
- Team startup rollback and pane authority (#3265, #3231, #3228, #3229, #3230, #3232)
- Native hook trust and path canonicalization (#3333, #3349, #3350, #3351, #3352, #3353)
- Ultragoal goal-status and state binding (#3301, #3305, #3294, #3297, #3295, #3300, #3304)
- State authoritative runtime root (#3160)
- Herdr lifecycle/status bridge Phase 1 (#3241, #3242)

Full inventory: `docs/release-notes-0.20.4.md`
Readiness: `docs/qa/release-readiness-0.20.4.md`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*