### PR TITLE
fix(runtime): use direct SYS_renameat2 syscall on musl targets

### DIFF
--- a/crates/omx-runtime/src/main.rs
+++ b/crates/omx-runtime/src/main.rs
@@ -177,13 +177,50 @@ fn validate_absolute_path(raw: &str, name: &str) -> Result<std::ffi::CString, St
         .map_err(|_| format!("{name} path contains an embedded NUL byte"))
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", not(target_env = "musl")))]
 fn fs_rename_no_replace(
     from: &std::ffi::CString,
     to: &std::ffi::CString,
 ) -> Result<FsRenameOutcome, String> {
     let result = unsafe {
         libc::renameat2(
+            libc::AT_FDCWD,
+            from.as_ptr(),
+            libc::AT_FDCWD,
+            to.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    };
+    if result == 0 {
+        return Ok(FsRenameOutcome::Moved);
+    }
+
+    let error = std::io::Error::last_os_error();
+    match error.raw_os_error() {
+        Some(libc::EEXIST) => Ok(FsRenameOutcome::NotMoved),
+        Some(libc::ENOSYS) => Ok(FsRenameOutcome::Unsupported("ENOSYS")),
+        Some(libc::EINVAL) => Ok(FsRenameOutcome::Unsupported("EINVAL")),
+        Some(libc::ENOTSUP) => Ok(FsRenameOutcome::Unsupported("ENOTSUP")),
+        Some(code) => Err(format!("renameat2 failed with errno {code}: {error}")),
+        None => Err(format!("renameat2 failed: {error}")),
+    }
+}
+
+#[cfg(all(target_os = "linux", target_env = "musl"))]
+fn fs_rename_no_replace(
+    from: &std::ffi::CString,
+    to: &std::ffi::CString,
+) -> Result<FsRenameOutcome, String> {
+    // libc 0.2.189 added a musl binding for renameat2, but the release
+    // runner's older musl exported symbol surface does not include it,
+    // causing an undefined-symbol link failure. Invoke the syscall
+    // directly via libc::syscall so the atomic no-replace rename works
+    // regardless of the musl version. The outcome and errno mapping are
+    // equivalent to the libc::renameat2 wrapper above (both classify the
+    // same errno values to the same FsRenameOutcome variants).
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_renameat2,
             libc::AT_FDCWD,
             from.as_ptr(),
             libc::AT_FDCWD,

--- a/crates/omx-runtime/tests/execution.rs
+++ b/crates/omx-runtime/tests/execution.rs
@@ -429,3 +429,163 @@ fn concurrent_exec_queue_accepts_exactly_one_request_id() {
     assert_eq!(dispatch["records"][0]["request_id"], "concurrent");
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+// ---------------------------------------------------------------------------
+// fs-rename-no-replace integration tests
+//
+// These tests exercise the omx-runtime `fs-rename-no-replace` subcommand
+// through the compiled binary. On Linux (both gnu and musl) this exercises
+// the SYS_renameat2 syscall path with RENAME_NOREPLACE.
+// ---------------------------------------------------------------------------
+
+/// Helper: run `fs-rename-no-replace <from> <to>` and return (exit_ok, stdout, stderr).
+fn run_rename_no_replace(from: &str, to: &str) -> (bool, String, String) {
+    let output = Command::new(env!("CARGO_BIN_EXE_omx-runtime"))
+        .args(["fs-rename-no-replace", from, to])
+        .output()
+        .expect("ran omx-runtime fs-rename-no-replace");
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[cfg(target_os = "linux")]
+mod fs_rename_no_replace_linux {
+    use super::*;
+
+    fn temp_dir() -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "omx-rename-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn moves_regular_file_and_source_removed() {
+        let dir = temp_dir();
+        let src = dir.join("source.txt");
+        let dst = dir.join("dest.txt");
+        std::fs::write(&src, "hello").unwrap();
+
+        let (ok, stdout, _stderr) =
+            run_rename_no_replace(src.to_str().unwrap(), dst.to_str().unwrap());
+        assert!(ok, "command should succeed: {stdout}");
+
+        if stdout.contains(r#""outcome":"unsupported""#) {
+            // Kernel/filesystem does not support RENAME_NOREPLACE; the
+            // binary correctly classified it as unsupported. Source must
+            // still exist (no move occurred).
+            assert!(src.exists(), "source must be preserved when unsupported");
+            let _ = std::fs::remove_dir_all(&dir);
+            return;
+        }
+
+        assert!(stdout.contains(r#""outcome":"moved""#), "stdout: {stdout}");
+
+        // Source must be gone; destination must contain the content.
+        assert!(!src.exists(), "source must be removed after move");
+        assert!(dst.exists(), "destination must exist after move");
+        assert_eq!(std::fs::read_to_string(&dst).unwrap(), "hello");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn moves_directory_and_source_removed() {
+        let dir = temp_dir();
+        let src = dir.join("source_dir");
+        let dst = dir.join("dest_dir");
+        std::fs::create_dir(&src).unwrap();
+        std::fs::write(src.join("inner.txt"), "inner").unwrap();
+
+        let (ok, stdout, _stderr) =
+            run_rename_no_replace(src.to_str().unwrap(), dst.to_str().unwrap());
+        assert!(ok, "directory move should succeed: {stdout}");
+
+        if stdout.contains(r#""outcome":"unsupported""#) {
+            assert!(
+                src.exists(),
+                "source dir must be preserved when unsupported"
+            );
+            let _ = std::fs::remove_dir_all(&dir);
+            return;
+        }
+
+        assert!(stdout.contains(r#""outcome":"moved""#), "stdout: {stdout}");
+
+        assert!(!src.exists(), "source directory must be removed");
+        assert!(dst.exists(), "destination directory must exist");
+        assert!(dst.join("inner.txt").exists(), "inner file must survive");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn destination_collision_returns_not_moved_and_source_preserved() {
+        let dir = temp_dir();
+        let src = dir.join("source.txt");
+        let dst = dir.join("dest.txt");
+        std::fs::write(&src, "source-content").unwrap();
+        std::fs::write(&dst, "dest-content").unwrap();
+
+        let (ok, stdout, _stderr) =
+            run_rename_no_replace(src.to_str().unwrap(), dst.to_str().unwrap());
+        assert!(ok, "command should succeed: {stdout}");
+
+        if stdout.contains(r#""outcome":"unsupported""#) {
+            // On unsupported filesystems both files must be untouched.
+            assert_eq!(std::fs::read_to_string(&src).unwrap(), "source-content");
+            assert_eq!(std::fs::read_to_string(&dst).unwrap(), "dest-content");
+            let _ = std::fs::remove_dir_all(&dir);
+            return;
+        }
+
+        assert!(
+            stdout.contains(r#""outcome":"not-moved""#),
+            "stdout: {stdout}"
+        );
+
+        // Both files must be untouched.
+        assert!(src.exists(), "source must still exist");
+        assert!(dst.exists(), "destination must still exist");
+        assert_eq!(std::fs::read_to_string(&src).unwrap(), "source-content");
+        assert_eq!(std::fs::read_to_string(&dst).unwrap(), "dest-content");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn nonexistent_source_returns_error() {
+        let dir = temp_dir();
+        let src = dir.join("nope.txt");
+        let dst = dir.join("dest.txt");
+
+        let (ok, _stdout, stderr) =
+            run_rename_no_replace(src.to_str().unwrap(), dst.to_str().unwrap());
+        assert!(!ok, "command should fail for nonexistent source");
+        assert!(
+            stderr.contains("omx-runtime:") || stderr.contains("error"),
+            "stderr should contain error: {stderr}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn relative_path_rejected_with_error() {
+        let (ok, _stdout, stderr) = run_rename_no_replace("relative.txt", "dest.txt");
+        assert!(!ok, "relative paths should be rejected");
+        assert!(
+            stderr.contains("absolute") || stderr.contains("error"),
+            "stderr should mention absolute: {stderr}"
+        );
+    }
+}


### PR DESCRIPTION
## Musl native build fix for v0.20.4

The v0.20.4 Release workflow (`30413544205`) failed on musl targets (`x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`) with `undefined reference to 'renameat2'`.

### Root cause

`libc 0.2.189` **added** a musl binding for `renameat2`, but the release runner's older musl exported symbol surface does not include it, causing an undefined-symbol link failure during cross-compilation. The direct syscall bypasses the missing libc symbol entirely.

### Fix (revision 3)

Split the Linux implementation into two cfg-gated functions:
- **`not(target_env = "musl")`** — `libc::renameat2` wrapper preserved for gnu, ohos, and all other non-musl Linux environments (no regression)
- **`target_env = "musl"`** — direct `libc::syscall(SYS_renameat2, ...)` (atomic, identical no-replace semantics, outcome-equivalent errno mapping)

Both paths produce the same atomic no-replace move. The errno classification maps the same errno values to the same `FsRenameOutcome` variants (note: the GNU wrapper may surface injected `ENOSYS` as `EINVAL` while the direct musl syscall reports `ENOSYS` directly; both classify as `Unsupported`).

### Tests

5 focused integration tests in `crates/omx-runtime/tests/execution.rs`:
- Regular file move + source removal
- Directory move + source removal
- Destination collision → not-moved + source preserved
- Nonexistent source → error
- Relative path → rejected

### Build/test evidence

| Target | Step | Result |
|--------|------|--------|
| `x86_64-unknown-linux-gnu` | `cargo test -p omx-runtime` | 20/20 pass |
| `x86_64-unknown-linux-musl` | `cargo build` + `cargo test` | 5/5 `fs_rename_no_replace` pass |
| `x86_64-unknown-linux-musl` | behavioral (file move) | `{"outcome":"moved"}`, source removed |
| `x86_64-unknown-linux-musl` | behavioral (directory move) | `{"outcome":"moved"}`, source dir removed |
| `x86_64-unknown-linux-musl` | behavioral (collision) | `{"outcome":"not-moved"}`, source preserved |
| `aarch64-unknown-linux-musl` | `cargo check` | compiles clean |
| `x86_64-unknown-linux-ohos` | `cargo check` (regression gate) | compiles clean — E0425 fixed |

### Scope
- Does NOT resolve umbrella issue #3309
- Does NOT move tag v0.20.4 (still at `57f8e682a` on main)
- Does NOT close #3303
- Awaiting owner decision on merge, tag move, and release retry