### PR TITLE
Keep generic Team lanes distributed and source authorization functional

### DIFF
--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -14,6 +14,7 @@ import {
   finalizeBoundOnce,
   writeSessionStart,
   type LaunchSessionBinding,
+  type SessionPointerContext,
 } from '../../hooks/session.js';
 import { buildPtyScriptCommand, isRealScriptAvailable, isRealTmuxAvailable, withTempTmuxSession } from '../../team/__tests__/tmux-test-fixture.js';
 
@@ -70,6 +71,18 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function cwdDefaultSessionPointerContext(cwd: string): SessionPointerContext {
+  const baseStateDir = join(cwd, '.omx', 'state');
+  const sessionPath = join(baseStateDir, 'session.json');
+  return {
+    cwd,
+    baseStateDir,
+    rootSource: 'cwd-default',
+    sessionPath,
+    lockPath: `${sessionPath}.lock`,
+  };
+}
+
 function shouldSkipForSpawnPermissions(_err: string): false {
   // These integration fixtures are contractual: EPERM/EACCES is a failure,
   // not a pass. Node's test runner has no portable dynamic skip here.
@@ -94,20 +107,23 @@ async function writeExecutable(path: string, content: string): Promise<void> {
 }
 async function wrapFakeTmuxWithDetachedLeader(fakeTmuxPath: string): Promise<void> {
   const implementationPath = `${fakeTmuxPath}.impl`;
+  const detachedSessionNamePath = `${fakeTmuxPath}.detached-session-name`;
+  const detachedOwnerIdPath = `${fakeTmuxPath}.detached-owner-id`;
+  const detachedLeaderLogPath = `${fakeTmuxPath}.detached-leader.log`;
   await rename(fakeTmuxPath, implementationPath);
   await writeExecutable(fakeTmuxPath, `#!/bin/sh
 if [ "$1" = "display-message" ] && [ "$2" = "-p" ] && [ "$3" = "-t" ] && case "$5" in *'#{session_created}'*'#{window_id}'*'#{pane_pid}'*) true;; *) false;; esac; then
-  session=$(cat /tmp/omx-test-detached-session-name 2>/dev/null || printf omx-test)
+  session=$(cat ${JSON.stringify(detachedSessionNamePath)} 2>/dev/null || printf omx-test)
   printf '%s\t$1\t1\t0\t@1\t%s\t123\n' "$session" "$4"
   exit 0
 fi
 if [ "$1" = "set-option" ] && [ "$2" = "-t" ] && [ "$4" = "@omx_instance_id" ]; then
-  printf '%s' "$5" > /tmp/omx-test-detached-owner-id
+  printf '%s' "$5" > ${JSON.stringify(detachedOwnerIdPath)}
 fi
 if [ "$1" = "list-panes" ] && case "$*" in *'#{session_created}'*'#{@omx_instance_id}'*) true;; *) false;; esac; then
   ${JSON.stringify(implementationPath)} "$@" >/dev/null 2>&1 || true
-  session=$(cat /tmp/omx-test-detached-session-name 2>/dev/null || printf omx-test)
-  owner=$(cat /tmp/omx-test-detached-owner-id 2>/dev/null || printf '')
+  session=$(cat ${JSON.stringify(detachedSessionNamePath)} 2>/dev/null || printf omx-test)
+  owner=$(cat ${JSON.stringify(detachedOwnerIdPath)} 2>/dev/null || printf '')
   printf '%%12\t0\t123\t%s\t$1\t1\t%s\n' "$session" "$owner"
   exit 0
 fi
@@ -141,12 +157,12 @@ printf '%s' "$output"
 if [ "$status" -eq 0 ] && [ "$1" = "new-session" ]; then
   previous=''
   for arg in "$@"; do
-    if [ "$previous" = '-s' ]; then printf '%s' "$arg" > /tmp/omx-test-detached-session-name; break; fi
+    if [ "$previous" = '-s' ]; then printf '%s' "$arg" > ${JSON.stringify(detachedSessionNamePath)}; break; fi
     previous="$arg"
   done
   for last_arg do :; done
   pane=$(printf '%s' "$output" | sed -n '1p')
-  TMUX=/tmp/omx-test-tmux,1,0 TMUX_PANE="$pane" nohup /bin/sh -c "$last_arg" </dev/null >/tmp/omx-test-detached-leader.log 2>&1 &
+  TMUX=/tmp/omx-test-tmux,1,0 TMUX_PANE="$pane" nohup /bin/sh -c "$last_arg" </dev/null >${JSON.stringify(detachedLeaderLogPath)} 2>&1 &
   leader_pid=$!
   (while kill -0 "$leader_pid" 2>/dev/null; do sleep 0.02; done; printf done > ${JSON.stringify(`${fakeTmuxPath}.leader-done`)}) </dev/null >/dev/null 2>&1 &
 fi
@@ -162,6 +178,10 @@ async function createLaunchFixture(
   const fakeBin = join(wd, 'bin');
   const tmuxLogPath = join(wd, 'tmux.log');
   const leaderDonePath = join(wd, 'leader-done');
+  const fakeTmuxPath = join(fakeBin, 'tmux');
+  const detachedSessionNamePath = `${fakeTmuxPath}.detached-session-name`;
+  const detachedOwnerIdPath = `${fakeTmuxPath}.detached-owner-id`;
+  const detachedLeaderLogPath = `${fakeTmuxPath}.detached-leader.log`;
 
   await mkdir(home, { recursive: true });
   await mkdir(fakeBin, { recursive: true });
@@ -172,19 +192,19 @@ async function createLaunchFixture(
   await writeExecutable(join(fakeBin, 'ps'), '#!/bin/sh\nexit 0\n');
   const tmuxImpl = join(fakeBin, 'tmux-impl');
   await writeExecutable(tmuxImpl, tmuxScript(tmuxLogPath));
-  await writeExecutable(join(fakeBin, 'tmux'), `#!/bin/sh
+  await writeExecutable(fakeTmuxPath, `#!/bin/sh
 if [ "$1" = "display-message" ] && [ "$2" = "-p" ] && [ "$3" = "-t" ] && case "$5" in *'#{session_created}'*'#{window_id}'*'#{pane_pid}'*) true;; *) false;; esac; then
-  session=$(cat /tmp/omx-test-detached-session-name 2>/dev/null || printf omx-test)
+  session=$(cat ${JSON.stringify(detachedSessionNamePath)} 2>/dev/null || printf omx-test)
   printf '%s\t$1\t1\t0\t@1\t%s\t123\n' "$session" "$4"
   exit 0
 fi
 if [ "$1" = "set-option" ] && [ "$2" = "-t" ] && [ "$4" = "@omx_instance_id" ]; then
-  printf '%s' "$5" > /tmp/omx-test-detached-owner-id
+  printf '%s' "$5" > ${JSON.stringify(detachedOwnerIdPath)}
 fi
 if [ "$1" = "list-panes" ] && case "$*" in *'#{session_created}'*'#{@omx_instance_id}'*) true;; *) false;; esac; then
   ${JSON.stringify(tmuxImpl)} "$@" >/dev/null 2>&1 || true
-  session=$(cat /tmp/omx-test-detached-session-name 2>/dev/null || printf omx-test)
-  owner=$(cat /tmp/omx-test-detached-owner-id 2>/dev/null || printf '')
+  session=$(cat ${JSON.stringify(detachedSessionNamePath)} 2>/dev/null || printf omx-test)
+  owner=$(cat ${JSON.stringify(detachedOwnerIdPath)} 2>/dev/null || printf '')
   printf '%%12\t0\t123\t%s\t$1\t1\t%s\n' "$session" "$owner"
   exit 0
 fi
@@ -218,12 +238,12 @@ printf '%s' "$output"
 if [ "$status" -eq 0 ] && [ "$1" = "new-session" ]; then
   previous=''
   for arg in "$@"; do
-    if [ "$previous" = '-s' ]; then printf '%s' "$arg" > /tmp/omx-test-detached-session-name; break; fi
+    if [ "$previous" = '-s' ]; then printf '%s' "$arg" > ${JSON.stringify(detachedSessionNamePath)}; break; fi
     previous="$arg"
   done
   for last_arg do :; done
   pane=$(printf '%s' "$output" | sed -n '1p')
-  TMUX=/tmp/omx-test-tmux,1,0 TMUX_PANE="$pane" nohup /bin/sh -c "$last_arg" </dev/null >/tmp/omx-test-detached-leader.log 2>&1 &
+  TMUX=/tmp/omx-test-tmux,1,0 TMUX_PANE="$pane" nohup /bin/sh -c "$last_arg" </dev/null >${JSON.stringify(detachedLeaderLogPath)} 2>&1 &
   leader_pid=$!
   (while kill -0 "$leader_pid" 2>/dev/null; do sleep 0.02; done; printf done > ${JSON.stringify(join(wd, 'leader-done'))}) </dev/null >/dev/null 2>&1 &
 fi
@@ -634,7 +654,10 @@ describe('ordinary launch root collision guidance', () => {
     try {
       execFileSync('git', ['init'], { cwd: wd, stdio: 'ignore' });
       const fixture = await createHeldCodexFixture(wd);
-      const established = await establishLaunchSessionBinding(wd, 'first-standard-launch', { pid: process.pid });
+      const established = await establishLaunchSessionBinding(wd, 'first-standard-launch', {
+        pid: process.pid,
+        context: cwdDefaultSessionPointerContext(wd),
+      });
       assert.equal(established.kind, 'committed-released');
       if (established.kind !== 'committed-released') return;
       binding = established.binding;
@@ -713,8 +736,14 @@ describe('ordinary launch root collision guidance', () => {
       execFileSync('git', ['init'], { cwd: firstCheckout, stdio: 'ignore' });
       execFileSync('git', ['init'], { cwd: secondCheckout, stdio: 'ignore' });
 
-      const firstEstablished = await establishLaunchSessionBinding(firstCheckout, 'first-checkout-owner', { pid: process.pid });
-      const secondEstablished = await establishLaunchSessionBinding(secondCheckout, 'second-checkout-owner', { pid: process.pid });
+      const firstEstablished = await establishLaunchSessionBinding(firstCheckout, 'first-checkout-owner', {
+        pid: process.pid,
+        context: cwdDefaultSessionPointerContext(firstCheckout),
+      });
+      const secondEstablished = await establishLaunchSessionBinding(secondCheckout, 'second-checkout-owner', {
+        pid: process.pid,
+        context: cwdDefaultSessionPointerContext(secondCheckout),
+      });
       assert.equal(firstEstablished.kind, 'committed-released');
       assert.equal(secondEstablished.kind, 'committed-released');
       if (firstEstablished.kind !== 'committed-released' || secondEstablished.kind !== 'committed-released') return;
@@ -725,7 +754,10 @@ describe('ordinary launch root collision guidance', () => {
       await finalizeBoundOnce(firstBinding, 'test');
       await finalizeBoundOnce(secondBinding, 'test');
 
-      await writeSessionStart(firstCheckout, 'stale-owner', { pid: 2_147_483_647 });
+      await writeSessionStart(firstCheckout, 'stale-owner', {
+        pid: 2_147_483_647,
+        context: cwdDefaultSessionPointerContext(firstCheckout),
+      });
       const fixture = await createHeldCodexFixture(wd);
       await rm(fixture.releasePath, { force: true });
       const relaunch = runOmx(firstCheckout, ['--direct', '--version'], fixture.env);

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -1813,6 +1813,7 @@ exit 0
       const fakeBin = join(wd, 'bin');
       const envLogPath = join(wd, 'codex-env.log');
       const tmuxLogPath = join(wd, 'tmux.log');
+      const leaderLogPath = join(wd, 'provider-leader.log');
 
       await mkdir(home, { recursive: true });
       await mkdir(fakeBin, { recursive: true });
@@ -1861,7 +1862,7 @@ case "$1" in
       TERMINFO=/tmp/server-terminfo \
       TERMINFO_DIRS=/tmp/server-terminfo-dirs \
       TERMCAP=server-termcap \
-      nohup /bin/sh -c "$last" </dev/null >/tmp/omx-test-provider-leader.log 2>&1 &
+      nohup /bin/sh -c "$last" </dev/null >"${leaderLogPath}" 2>&1 &
     printf '%%12\n'
     exit 0
     ;;

--- a/src/cli/__tests__/team-decompose.test.ts
+++ b/src/cli/__tests__/team-decompose.test.ts
@@ -74,12 +74,12 @@ describe('decomposeTaskString', () => {
     assert.deepEqual(tasks.map((task) => task.owner), ['worker-1', 'worker-2', 'worker-3']);
   });
 
-  it('clusters same-role work to preserve specialization when routing is mixed', () => {
+  it('distributes same-role generic-worker lanes when routing is mixed', () => {
     const tasks = decomposeTaskString('write docs, build UI component, update docs, and fix tests', 3, 'executor', false);
     assert.equal(tasks.length, 4);
     const docOwners = tasks.filter((task) => task.role === 'writer').map((task) => task.owner);
     assert.ok(docOwners.length >= 2);
-    assert.equal(new Set(docOwners).size, 1);
+    assert.equal(new Set(docOwners).size, 2);
   });
 
   it('handles single worker with single task', () => {

--- a/src/team/__tests__/allocation-policy.test.ts
+++ b/src/team/__tests__/allocation-policy.test.ts
@@ -104,11 +104,12 @@ describe('allocation-policy', () => {
     assert.deepEqual(assignments.map((task) => task.owner), ['worker-1', 'worker-2', 'worker-3', 'worker-4']);
   });
 
-  it('preserves short explicit domain affinity in generic worker pools without file paths', () => {
+  it('preserves short explicit domain affinity as generic-worker load grows', () => {
     const assignments = allocateTasksToWorkers(
       [
-        { subject: 'alpha', description: 'first lane', role: 'executor', domains: ['ui'] },
-        { subject: 'beta', description: 'second lane', role: 'executor', domains: ['ui'] },
+        { subject: 'alpha', description: 'first lane', domains: ['ui'] },
+        { subject: 'beta', description: 'second lane', domains: ['ui'] },
+        { subject: 'gamma', description: 'third lane', domains: ['ui'] },
       ],
       [
         { name: 'worker-1' },
@@ -116,8 +117,24 @@ describe('allocation-policy', () => {
       ],
     );
 
-    assert.deepEqual(assignments.map((task) => task.owner), ['worker-1', 'worker-1']);
-    assert.match(assignments[1].allocation_reason, /file\/domain ownership/);
+    assert.deepEqual(assignments.map((task) => task.owner), ['worker-1', 'worker-1', 'worker-1']);
+    assert.match(assignments[2].allocation_reason, /file\/domain ownership/);
+  });
+
+  it('preserves explicit file affinity after repeated generic-worker assignments', () => {
+    const assignments = allocateTasksToWorkers(
+      Array.from({ length: 6 }, (_, index) => ({
+        subject: `runtime lane ${index + 1}`,
+        description: `unique work item ${index + 1}`,
+        filePaths: ['src/team/runtime.ts'],
+      })),
+      [
+        { name: 'worker-1' },
+        { name: 'worker-2' },
+      ],
+    );
+
+    assert.deepEqual(assignments.map((task) => task.owner), Array(6).fill('worker-1'));
   });
 
   it('keeps related file-path work on the same worker to reduce overlap', () => {

--- a/src/team/__tests__/allocation-policy.test.ts
+++ b/src/team/__tests__/allocation-policy.test.ts
@@ -137,6 +137,21 @@ describe('allocation-policy', () => {
     assert.deepEqual(assignments.map((task) => task.owner), Array(6).fill('worker-1'));
   });
 
+  it('distributes different exact paths that share only a basename hint', () => {
+    const assignments = allocateTasksToWorkers(
+      [
+        { subject: 'client entry', description: 'client lane', filePaths: ['src/client/index.ts'] },
+        { subject: 'server entry', description: 'server lane', filePaths: ['src/server/index.ts'] },
+      ],
+      [
+        { name: 'worker-1' },
+        { name: 'worker-2' },
+      ],
+    );
+
+    assert.deepEqual(assignments.map((task) => task.owner), ['worker-1', 'worker-2']);
+  });
+
   it('keeps related file-path work on the same worker to reduce overlap', () => {
     const assignments = allocateTasksToWorkers(
       [

--- a/src/team/__tests__/allocation-policy.test.ts
+++ b/src/team/__tests__/allocation-policy.test.ts
@@ -104,11 +104,11 @@ describe('allocation-policy', () => {
     assert.deepEqual(assignments.map((task) => task.owner), ['worker-1', 'worker-2', 'worker-3', 'worker-4']);
   });
 
-  it('preserves explicit domain affinity in generic worker pools without file paths', () => {
+  it('preserves short explicit domain affinity in generic worker pools without file paths', () => {
     const assignments = allocateTasksToWorkers(
       [
-        { subject: 'alpha', description: 'first lane', role: 'executor', domains: ['notifications'] },
-        { subject: 'beta', description: 'second lane', role: 'executor', domains: ['notifications'] },
+        { subject: 'alpha', description: 'first lane', role: 'executor', domains: ['ui'] },
+        { subject: 'beta', description: 'second lane', role: 'executor', domains: ['ui'] },
       ],
       [
         { name: 'worker-1' },

--- a/src/team/__tests__/allocation-policy.test.ts
+++ b/src/team/__tests__/allocation-policy.test.ts
@@ -137,6 +137,23 @@ describe('allocation-policy', () => {
     assert.deepEqual(assignments.map((task) => task.owner), Array(6).fill('worker-1'));
   });
 
+  it('canonicalizes equivalent exact path spellings before assigning affinity', () => {
+    const assignments = allocateTasksToWorkers(
+      [
+        { subject: 'parser first', description: 'first lane', filePaths: ['./src/parser.ts'] },
+        { subject: 'parser second', description: 'second lane', filePaths: ['src/./parser.ts'] },
+        { subject: 'parser third', description: 'Continue src/parser.ts.' },
+      ],
+      [
+        { name: 'worker-1' },
+        { name: 'worker-2' },
+        { name: 'worker-3' },
+      ],
+    );
+
+    assert.deepEqual(assignments.map((task) => task.owner), ['worker-1', 'worker-1', 'worker-1']);
+  });
+
   it('distributes different exact paths that share only a basename hint', () => {
     const assignments = allocateTasksToWorkers(
       [

--- a/src/team/__tests__/allocation-policy.test.ts
+++ b/src/team/__tests__/allocation-policy.test.ts
@@ -85,6 +85,25 @@ describe('allocation-policy', () => {
     assert.deepEqual(assignments.map((task) => task.owner), ['worker-1', 'worker-2', 'worker-1']);
   });
 
+  it('does not let shared prose collapse independent generic-worker lanes', () => {
+    const assignments = allocateTasksToWorkers(
+      [
+        { subject: 'Foundation', description: 'Implement shared light theme tokens and navigation', role: 'designer' },
+        { subject: 'Console', description: 'Implement light theme surfaces for console navigation', role: 'designer' },
+        { subject: 'Public proof', description: 'Apply the shared light theme to proof surfaces', role: 'researcher' },
+        { subject: 'Metrics', description: 'Apply the shared light theme to metrics surfaces', role: 'quality-reviewer' },
+      ],
+      [
+        { name: 'worker-1' },
+        { name: 'worker-2' },
+        { name: 'worker-3' },
+        { name: 'worker-4' },
+      ],
+    );
+
+    assert.deepEqual(assignments.map((task) => task.owner), ['worker-1', 'worker-2', 'worker-3', 'worker-4']);
+  });
+
   it('keeps related file-path work on the same worker to reduce overlap', () => {
     const assignments = allocateTasksToWorkers(
       [

--- a/src/team/__tests__/allocation-policy.test.ts
+++ b/src/team/__tests__/allocation-policy.test.ts
@@ -137,21 +137,25 @@ describe('allocation-policy', () => {
     assert.deepEqual(assignments.map((task) => task.owner), Array(6).fill('worker-1'));
   });
 
-  it('canonicalizes equivalent exact path spellings before assigning affinity', () => {
+  it('canonicalizes equivalent structured and prose path spellings before assigning affinity', () => {
     const assignments = allocateTasksToWorkers(
       [
         { subject: 'parser first', description: 'first lane', filePaths: ['./src/parser.ts'] },
         { subject: 'parser second', description: 'second lane', filePaths: ['src/./parser.ts'] },
         { subject: 'parser third', description: 'Continue src/parser.ts.' },
+        { subject: 'parser fourth', description: 'Continue ./src/parser.ts' },
+        { subject: 'parser fifth', description: 'Continue src\\parser.ts.' },
       ],
       [
         { name: 'worker-1' },
         { name: 'worker-2' },
         { name: 'worker-3' },
+        { name: 'worker-4' },
+        { name: 'worker-5' },
       ],
     );
 
-    assert.deepEqual(assignments.map((task) => task.owner), ['worker-1', 'worker-1', 'worker-1']);
+    assert.deepEqual(assignments.map((task) => task.owner), Array(5).fill('worker-1'));
   });
 
   it('distributes different exact paths that share only a basename hint', () => {

--- a/src/team/__tests__/allocation-policy.test.ts
+++ b/src/team/__tests__/allocation-policy.test.ts
@@ -104,6 +104,22 @@ describe('allocation-policy', () => {
     assert.deepEqual(assignments.map((task) => task.owner), ['worker-1', 'worker-2', 'worker-3', 'worker-4']);
   });
 
+  it('preserves explicit domain affinity in generic worker pools without file paths', () => {
+    const assignments = allocateTasksToWorkers(
+      [
+        { subject: 'alpha', description: 'first lane', role: 'executor', domains: ['notifications'] },
+        { subject: 'beta', description: 'second lane', role: 'executor', domains: ['notifications'] },
+      ],
+      [
+        { name: 'worker-1' },
+        { name: 'worker-2' },
+      ],
+    );
+
+    assert.deepEqual(assignments.map((task) => task.owner), ['worker-1', 'worker-1']);
+    assert.match(assignments[1].allocation_reason, /file\/domain ownership/);
+  });
+
   it('keeps related file-path work on the same worker to reduce overlap', () => {
     const assignments = allocateTasksToWorkers(
       [

--- a/src/team/__tests__/allocation-policy.test.ts
+++ b/src/team/__tests__/allocation-policy.test.ts
@@ -173,6 +173,21 @@ describe('allocation-policy', () => {
     assert.deepEqual(assignments.map((task) => task.owner), ['worker-1', 'worker-2']);
   });
 
+  it('keeps structured trailing-dot filenames distinct from punctuation-free paths', () => {
+    const assignments = allocateTasksToWorkers(
+      [
+        { subject: 'dotted release', description: 'first lane', filePaths: ['docs/release.'] },
+        { subject: 'plain release', description: 'second lane', filePaths: ['docs/release'] },
+      ],
+      [
+        { name: 'worker-1' },
+        { name: 'worker-2' },
+      ],
+    );
+
+    assert.deepEqual(assignments.map((task) => task.owner), ['worker-1', 'worker-2']);
+  });
+
   it('keeps related file-path work on the same worker to reduce overlap', () => {
     const assignments = allocateTasksToWorkers(
       [

--- a/src/team/__tests__/allocation-policy.test.ts
+++ b/src/team/__tests__/allocation-policy.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { allocateTasksToWorkers, chooseTaskOwner } from '../allocation-policy.js';
+import { allocateTasksToWorkers, allocationPathCasePolicyForPlatform, chooseTaskOwner } from '../allocation-policy.js';
 
 describe('allocation-policy', () => {
   it('prefers matching worker role when no prior assignments exist', () => {
@@ -107,9 +107,9 @@ describe('allocation-policy', () => {
   it('preserves short explicit domain affinity as generic-worker load grows', () => {
     const assignments = allocateTasksToWorkers(
       [
-        { subject: 'alpha', description: 'first lane', domains: ['ui'] },
-        { subject: 'beta', description: 'second lane', domains: ['ui'] },
-        { subject: 'gamma', description: 'third lane', domains: ['ui'] },
+        { subject: 'alpha', description: 'first lane', explicitDomains: ['ui'] },
+        { subject: 'beta', description: 'second lane', explicitDomains: ['ui'] },
+        { subject: 'gamma', description: 'third lane', explicitDomains: ['ui'] },
       ],
       [
         { name: 'worker-1' },
@@ -186,6 +186,64 @@ describe('allocation-policy', () => {
     );
 
     assert.deepEqual(assignments.map((task) => task.owner), ['worker-1', 'worker-2']);
+  });
+
+  it('uses acceptance text as caller-authored prose affinity', () => {
+    const assignments = allocateTasksToWorkers(
+      [
+        { subject: 'first acceptance lane', description: 'first lane', acceptance: ['Update src/shared.ts'] },
+        { subject: 'second acceptance lane', description: 'second lane', acceptance: ['Verify src/shared.ts'] },
+      ],
+      [
+        { name: 'worker-1' },
+        { name: 'worker-2' },
+      ],
+    );
+
+    assert.deepEqual(assignments.map((task) => task.owner), ['worker-1', 'worker-1']);
+  });
+
+  it('applies deterministic platform-bounded path case policies', () => {
+    assert.equal(allocationPathCasePolicyForPlatform('win32'), 'case-insensitive');
+    assert.equal(allocationPathCasePolicyForPlatform('darwin'), 'case-insensitive');
+    assert.equal(allocationPathCasePolicyForPlatform('linux'), 'case-sensitive');
+    assert.equal(allocationPathCasePolicyForPlatform('freebsd'), 'case-sensitive');
+
+    const tasks = [
+      { subject: 'upper parser', description: 'first lane', filePaths: ['src/Parser.ts'] },
+      { subject: 'lower parser', description: 'second lane', filePaths: ['src/parser.ts'] },
+    ];
+    const workers = [{ name: 'worker-1' }, { name: 'worker-2' }];
+
+    assert.deepEqual(
+      allocateTasksToWorkers(tasks, workers, { pathCasePolicy: 'case-sensitive' }).map((task) => task.owner),
+      ['worker-1', 'worker-2'],
+    );
+    assert.deepEqual(
+      allocateTasksToWorkers(tasks, workers, { pathCasePolicy: 'case-insensitive' }).map((task) => task.owner),
+      ['worker-1', 'worker-1'],
+    );
+  });
+
+  it('keeps inferred domains soft while explicit domains bind', () => {
+    const workers = [{ name: 'worker-1' }, { name: 'worker-2' }];
+    const inferred = allocateTasksToWorkers(
+      [
+        { subject: 'client', description: 'first lane', filePaths: ['src/client/index.ts'], inferredDomains: ['src', 'index'] },
+        { subject: 'server', description: 'second lane', filePaths: ['src/server/index.ts'], inferredDomains: ['src', 'index'] },
+      ],
+      workers,
+    );
+    const explicit = allocateTasksToWorkers(
+      [
+        { subject: 'client UI', description: 'first lane', filePaths: ['src/client.ts'], explicitDomains: ['ui'] },
+        { subject: 'server UI', description: 'second lane', filePaths: ['src/server.ts'], explicitDomains: ['ui'] },
+      ],
+      workers,
+    );
+
+    assert.deepEqual(inferred.map((task) => task.owner), ['worker-1', 'worker-2']);
+    assert.deepEqual(explicit.map((task) => task.owner), ['worker-1', 'worker-1']);
   });
 
   it('keeps related file-path work on the same worker to reduce overlap', () => {

--- a/src/team/__tests__/rebalance-policy.test.ts
+++ b/src/team/__tests__/rebalance-policy.test.ts
@@ -190,7 +190,7 @@ describe('rebalance-policy', () => {
     assert.match(decisions[1]?.reason ?? '', /file\/domain ownership/);
   });
 
-  it('canonicalizes equivalent exact path spellings during rebalance', () => {
+  it('canonicalizes equivalent structured and prose path spellings during rebalance', () => {
     const decisions = buildRebalanceDecisions({
       reclaimedTaskIds: [],
       tasks: [
@@ -217,27 +217,29 @@ describe('rebalance-policy', () => {
           status: 'pending',
           created_at: '2026-03-11T00:00:02.000Z',
         },
-      ],
-      workers: [
         {
-          name: 'worker-1',
-          alive: true,
-          status: { state: 'idle', updated_at: '2026-03-11T00:00:03.000Z' },
+          id: '4',
+          subject: 'Parser fourth',
+          description: 'Continue ./src/parser.ts',
+          status: 'pending',
+          created_at: '2026-03-11T00:00:03.000Z',
         },
         {
-          name: 'worker-2',
-          alive: true,
-          status: { state: 'idle', updated_at: '2026-03-11T00:00:03.000Z' },
-        },
-        {
-          name: 'worker-3',
-          alive: true,
-          status: { state: 'idle', updated_at: '2026-03-11T00:00:03.000Z' },
+          id: '5',
+          subject: 'Parser fifth',
+          description: 'Continue src\\parser.ts.',
+          status: 'pending',
+          created_at: '2026-03-11T00:00:04.000Z',
         },
       ],
+      workers: Array.from({ length: 5 }, (_, index) => ({
+        name: `worker-${index + 1}`,
+        alive: true,
+        status: { state: 'idle' as const, updated_at: '2026-03-11T00:00:05.000Z' },
+      })),
     });
 
-    assert.deepEqual(decisions.map((decision) => decision.workerName), ['worker-1', 'worker-1', 'worker-1']);
+    assert.deepEqual(decisions.map((decision) => decision.workerName), Array(5).fill('worker-1'));
   });
 
   it('distributes rebalance work whose exact paths share only a basename', () => {

--- a/src/team/__tests__/rebalance-policy.test.ts
+++ b/src/team/__tests__/rebalance-policy.test.ts
@@ -190,6 +190,56 @@ describe('rebalance-policy', () => {
     assert.match(decisions[1]?.reason ?? '', /file\/domain ownership/);
   });
 
+  it('canonicalizes equivalent exact path spellings during rebalance', () => {
+    const decisions = buildRebalanceDecisions({
+      reclaimedTaskIds: [],
+      tasks: [
+        {
+          id: '1',
+          subject: 'Parser first',
+          description: 'first lane',
+          status: 'pending',
+          filePaths: ['./src/parser.ts'],
+          created_at: '2026-03-11T00:00:00.000Z',
+        },
+        {
+          id: '2',
+          subject: 'Parser second',
+          description: 'second lane',
+          status: 'pending',
+          filePaths: ['src/./parser.ts'],
+          created_at: '2026-03-11T00:00:01.000Z',
+        },
+        {
+          id: '3',
+          subject: 'Parser third',
+          description: 'Continue src/parser.ts.',
+          status: 'pending',
+          created_at: '2026-03-11T00:00:02.000Z',
+        },
+      ],
+      workers: [
+        {
+          name: 'worker-1',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:03.000Z' },
+        },
+        {
+          name: 'worker-2',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:03.000Z' },
+        },
+        {
+          name: 'worker-3',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:03.000Z' },
+        },
+      ],
+    });
+
+    assert.deepEqual(decisions.map((decision) => decision.workerName), ['worker-1', 'worker-1', 'worker-1']);
+  });
+
   it('distributes rebalance work whose exact paths share only a basename', () => {
     const decisions = buildRebalanceDecisions({
       reclaimedTaskIds: [],

--- a/src/team/__tests__/rebalance-policy.test.ts
+++ b/src/team/__tests__/rebalance-policy.test.ts
@@ -318,6 +318,84 @@ describe('rebalance-policy', () => {
     assert.deepEqual(decisions.map((decision) => decision.workerName), ['worker-1', 'worker-2']);
   });
 
+  it('uses persisted caller acceptance prose during rebalance', () => {
+    const decisions = buildRebalanceDecisions({
+      reclaimedTaskIds: [],
+      tasks: [
+        {
+          id: '1',
+          subject: 'Shared first',
+          description: 'Rendered first lane metadata',
+          affinityDescription: 'Acceptance: update src/shared.ts',
+          status: 'pending',
+          created_at: '2026-03-11T00:00:00.000Z',
+        },
+        {
+          id: '2',
+          subject: 'Shared second',
+          description: 'Rendered second lane metadata',
+          affinityDescription: 'Acceptance: verify src/shared.ts',
+          status: 'pending',
+          created_at: '2026-03-11T00:00:01.000Z',
+        },
+      ],
+      workers: [
+        {
+          name: 'worker-1',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:02.000Z' },
+        },
+        {
+          name: 'worker-2',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:02.000Z' },
+        },
+      ],
+    });
+
+    assert.deepEqual(decisions.map((decision) => decision.workerName), ['worker-1', 'worker-1']);
+  });
+
+  it('applies the requested path case policy during rebalance', () => {
+    const decide = (pathCasePolicy: 'case-sensitive' | 'case-insensitive') => buildRebalanceDecisions({
+      reclaimedTaskIds: [],
+      pathCasePolicy,
+      tasks: [
+        {
+          id: '1',
+          subject: 'Upper parser',
+          description: 'first lane',
+          status: 'pending',
+          filePaths: ['src/Parser.ts'],
+          created_at: '2026-03-11T00:00:00.000Z',
+        },
+        {
+          id: '2',
+          subject: 'Lower parser',
+          description: 'second lane',
+          status: 'pending',
+          filePaths: ['src/parser.ts'],
+          created_at: '2026-03-11T00:00:01.000Z',
+        },
+      ],
+      workers: [
+        {
+          name: 'worker-1',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:02.000Z' },
+        },
+        {
+          name: 'worker-2',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:02.000Z' },
+        },
+      ],
+    });
+
+    assert.deepEqual(decide('case-sensitive').map((decision) => decision.workerName), ['worker-1', 'worker-2']);
+    assert.deepEqual(decide('case-insensitive').map((decision) => decision.workerName), ['worker-1', 'worker-1']);
+  });
+
   it('preserves exact file affinity under repeated rebalance load', () => {
     const decisions = buildRebalanceDecisions({
       reclaimedTaskIds: [],

--- a/src/team/__tests__/rebalance-policy.test.ts
+++ b/src/team/__tests__/rebalance-policy.test.ts
@@ -163,22 +163,80 @@ describe('rebalance-policy', () => {
           domains: ['ui'],
           created_at: '2026-03-11T00:00:01.000Z',
         },
+        {
+          id: '3',
+          subject: 'Third UI lane',
+          description: 'Implement the third surface',
+          status: 'pending',
+          domains: ['ui'],
+          created_at: '2026-03-11T00:00:02.000Z',
+        },
       ],
       workers: [
         {
           name: 'worker-1',
           alive: true,
-          status: { state: 'idle', updated_at: '2026-03-11T00:00:02.000Z' },
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:03.000Z' },
         },
         {
           name: 'worker-2',
           alive: true,
-          status: { state: 'idle', updated_at: '2026-03-11T00:00:02.000Z' },
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:03.000Z' },
+        },
+      ],
+    });
+
+    assert.deepEqual(decisions.map((decision) => decision.workerName), ['worker-1', 'worker-1', 'worker-1']);
+    assert.match(decisions[1]?.reason ?? '', /file\/domain ownership/);
+  });
+
+  it('preserves seeded in-flight file and short-domain affinity during rebalance', () => {
+    const decisions = buildRebalanceDecisions({
+      reclaimedTaskIds: [],
+      tasks: [
+        {
+          id: '9',
+          subject: 'Existing UI runtime lane',
+          description: 'Current in-flight ownership',
+          status: 'in_progress',
+          owner: 'worker-1',
+          filePaths: ['src/team/runtime.ts'],
+          domains: ['ui'],
+          created_at: '2026-03-11T00:00:00.000Z',
+        },
+        {
+          id: '1',
+          subject: 'UI follow-up',
+          description: 'Continue the UI domain',
+          status: 'pending',
+          domains: ['ui'],
+          created_at: '2026-03-11T00:00:01.000Z',
+        },
+        {
+          id: '2',
+          subject: 'Runtime follow-up',
+          description: 'Continue the runtime file',
+          status: 'pending',
+          filePaths: ['src/team/runtime.ts'],
+          created_at: '2026-03-11T00:00:02.000Z',
+        },
+      ],
+      workers: [
+        {
+          name: 'worker-1',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:03.000Z' },
+        },
+        {
+          name: 'worker-2',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:03.000Z' },
         },
       ],
     });
 
     assert.deepEqual(decisions.map((decision) => decision.workerName), ['worker-1', 'worker-1']);
+    assert.match(decisions[0]?.reason ?? '', /file\/domain ownership/);
     assert.match(decisions[1]?.reason ?? '', /file\/domain ownership/);
   });
 

--- a/src/team/__tests__/rebalance-policy.test.ts
+++ b/src/team/__tests__/rebalance-policy.test.ts
@@ -143,6 +143,45 @@ describe('rebalance-policy', () => {
     assert.match(decisions[0]?.reason ?? '', /reclaimed work is ready; (keeps writer work grouped|matches worker role writer)/);
   });
 
+  it('preserves short explicit domain affinity across rebalance decisions', () => {
+    const decisions = buildRebalanceDecisions({
+      reclaimedTaskIds: [],
+      tasks: [
+        {
+          id: '1',
+          subject: 'First UI lane',
+          description: 'Implement the first surface',
+          status: 'pending',
+          domains: ['ui'],
+          created_at: '2026-03-11T00:00:00.000Z',
+        },
+        {
+          id: '2',
+          subject: 'Second UI lane',
+          description: 'Implement the second surface',
+          status: 'pending',
+          domains: ['ui'],
+          created_at: '2026-03-11T00:00:01.000Z',
+        },
+      ],
+      workers: [
+        {
+          name: 'worker-1',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:02.000Z' },
+        },
+        {
+          name: 'worker-2',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:02.000Z' },
+        },
+      ],
+    });
+
+    assert.deepEqual(decisions.map((decision) => decision.workerName), ['worker-1', 'worker-1']);
+    assert.match(decisions[1]?.reason ?? '', /file\/domain ownership/);
+  });
+
   it('does not assign work when no live idle worker is available', () => {
     const decisions = buildRebalanceDecisions({
       reclaimedTaskIds: ['4'],

--- a/src/team/__tests__/rebalance-policy.test.ts
+++ b/src/team/__tests__/rebalance-policy.test.ts
@@ -280,6 +280,44 @@ describe('rebalance-policy', () => {
     assert.deepEqual(decisions.map((decision) => decision.workerName), ['worker-1', 'worker-2']);
   });
 
+  it('keeps structured trailing-dot filenames distinct during rebalance', () => {
+    const decisions = buildRebalanceDecisions({
+      reclaimedTaskIds: [],
+      tasks: [
+        {
+          id: '1',
+          subject: 'Dotted release',
+          description: 'first lane',
+          status: 'pending',
+          filePaths: ['docs/release.'],
+          created_at: '2026-03-11T00:00:00.000Z',
+        },
+        {
+          id: '2',
+          subject: 'Plain release',
+          description: 'second lane',
+          status: 'pending',
+          filePaths: ['docs/release'],
+          created_at: '2026-03-11T00:00:01.000Z',
+        },
+      ],
+      workers: [
+        {
+          name: 'worker-1',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:02.000Z' },
+        },
+        {
+          name: 'worker-2',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:02.000Z' },
+        },
+      ],
+    });
+
+    assert.deepEqual(decisions.map((decision) => decision.workerName), ['worker-1', 'worker-2']);
+  });
+
   it('preserves exact file affinity under repeated rebalance load', () => {
     const decisions = buildRebalanceDecisions({
       reclaimedTaskIds: [],

--- a/src/team/__tests__/rebalance-policy.test.ts
+++ b/src/team/__tests__/rebalance-policy.test.ts
@@ -190,6 +190,72 @@ describe('rebalance-policy', () => {
     assert.match(decisions[1]?.reason ?? '', /file\/domain ownership/);
   });
 
+  it('distributes rebalance work whose exact paths share only a basename', () => {
+    const decisions = buildRebalanceDecisions({
+      reclaimedTaskIds: [],
+      tasks: [
+        {
+          id: '1',
+          subject: 'Client entry',
+          description: 'client lane',
+          status: 'pending',
+          filePaths: ['src/client/index.ts'],
+          created_at: '2026-03-11T00:00:00.000Z',
+        },
+        {
+          id: '2',
+          subject: 'Server entry',
+          description: 'server lane',
+          status: 'pending',
+          filePaths: ['src/server/index.ts'],
+          created_at: '2026-03-11T00:00:01.000Z',
+        },
+      ],
+      workers: [
+        {
+          name: 'worker-1',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:02.000Z' },
+        },
+        {
+          name: 'worker-2',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:02.000Z' },
+        },
+      ],
+    });
+
+    assert.deepEqual(decisions.map((decision) => decision.workerName), ['worker-1', 'worker-2']);
+  });
+
+  it('preserves exact file affinity under repeated rebalance load', () => {
+    const decisions = buildRebalanceDecisions({
+      reclaimedTaskIds: [],
+      tasks: Array.from({ length: 6 }, (_, index) => ({
+        id: String(index + 1),
+        subject: `Runtime lane ${index + 1}`,
+        description: `unique work item ${index + 1}`,
+        status: 'pending' as const,
+        filePaths: ['src/team/runtime.ts'],
+        created_at: `2026-03-11T00:00:0${index}.000Z`,
+      })),
+      workers: [
+        {
+          name: 'worker-1',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:06.000Z' },
+        },
+        {
+          name: 'worker-2',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:06.000Z' },
+        },
+      ],
+    });
+
+    assert.deepEqual(decisions.map((decision) => decision.workerName), Array(6).fill('worker-1'));
+  });
+
   it('preserves seeded in-flight file and short-domain affinity during rebalance', () => {
     const decisions = buildRebalanceDecisions({
       reclaimedTaskIds: [],

--- a/src/team/__tests__/repo-aware-decomposition.test.ts
+++ b/src/team/__tests__/repo-aware-decomposition.test.ts
@@ -21,7 +21,11 @@ const legacy = () => ({
   tasks: [{ subject: 'legacy', description: 'legacy', owner: 'worker-1', role: 'team-executor' }],
 });
 
-function buildDagPlan(cwd: string, nodes: Array<Record<string, unknown>>) {
+function buildDagPlan(
+  cwd: string,
+  nodes: Array<Record<string, unknown>>,
+  pathCasePolicy?: 'case-sensitive' | 'case-insensitive',
+) {
   writeFileSync(join(cwd, '.omx', 'plans', 'team-dag-demo.json'), JSON.stringify({
     schema_version: 1,
     nodes,
@@ -35,6 +39,7 @@ function buildDagPlan(cwd: string, nodes: Array<Record<string, unknown>>) {
     cwd,
     buildLegacyPlan: legacy,
     allowDagHandoff: true,
+    pathCasePolicy,
   });
 }
 
@@ -102,6 +107,33 @@ describe('buildRepoAwareTeamExecutionPlan', () => {
 
     assert.deepEqual(plan.tasks.map((task) => task.owner), ['worker-1', 'worker-1']);
     assert.deepEqual(plan.tasks.map((task) => task.domains), [['ui'], ['ui']]);
+    assert.deepEqual(plan.tasks.map((task) => task.explicitDomains), [['ui'], ['ui']]);
+  });
+
+  it('binds acceptance-only shared paths through caller prose affinity', () => {
+    const cwd = repo();
+    const plan = buildDagPlan(cwd, [
+      { id: 'first', subject: 'Shared first', description: 'first lane', acceptance: ['Update src/shared.ts'] },
+      { id: 'second', subject: 'Shared second', description: 'second lane', acceptance: ['Verify src/shared.ts'] },
+    ]);
+
+    assert.deepEqual(plan.tasks.map((task) => task.owner), ['worker-1', 'worker-1']);
+    assert.deepEqual(
+      plan.tasks.map((task) => task.affinityDescription),
+      ['first lane\nUpdate src/shared.ts', 'second lane\nVerify src/shared.ts'],
+    );
+  });
+
+  it('applies explicit path case policy in repo-aware allocation', () => {
+    const nodes = [
+      { id: 'upper', subject: 'Upper parser', description: 'first lane', filePaths: ['src/Parser.ts'] },
+      { id: 'lower', subject: 'Lower parser', description: 'second lane', filePaths: ['src/parser.ts'] },
+    ];
+    const sensitive = buildDagPlan(repo(), nodes, 'case-sensitive');
+    const insensitive = buildDagPlan(repo(), nodes, 'case-insensitive');
+
+    assert.deepEqual(sensitive.tasks.map((task) => task.owner), ['worker-1', 'worker-2']);
+    assert.deepEqual(insensitive.tasks.map((task) => task.owner), ['worker-1', 'worker-1']);
   });
 
   it('binds semantically equivalent structured paths in repo-aware allocation', () => {

--- a/src/team/__tests__/repo-aware-decomposition.test.ts
+++ b/src/team/__tests__/repo-aware-decomposition.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { buildRepoAwareTeamExecutionPlan } from '../repo-aware-decomposition.js';
+import { buildRebalanceDecisions } from '../rebalance-policy.js';
 
 function repo(): string {
   const cwd = mkdtempSync(join(tmpdir(), 'omx-dag-'));
@@ -121,6 +122,31 @@ describe('buildRepoAwareTeamExecutionPlan', () => {
     ]);
 
     assert.deepEqual(plan.tasks.map((task) => task.owner), ['worker-1', 'worker-2']);
+    assert.deepEqual(plan.tasks.map((task) => task.affinityDescription), ['first lane', 'second lane']);
+
+    const decisions = buildRebalanceDecisions({
+      reclaimedTaskIds: [],
+      tasks: plan.tasks.map((task, index) => ({
+        ...task,
+        id: String(index + 1),
+        status: 'pending' as const,
+        owner: undefined,
+        created_at: `2026-03-11T00:00:0${index}.000Z`,
+      })),
+      workers: [
+        {
+          name: 'worker-1',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:02.000Z' },
+        },
+        {
+          name: 'worker-2',
+          alive: true,
+          status: { state: 'idle', updated_at: '2026-03-11T00:00:02.000Z' },
+        },
+      ],
+    });
+    assert.deepEqual(decisions.map((decision) => decision.workerName), ['worker-1', 'worker-2']);
   });
 
 

--- a/src/team/__tests__/repo-aware-decomposition.test.ts
+++ b/src/team/__tests__/repo-aware-decomposition.test.ts
@@ -20,6 +20,23 @@ const legacy = () => ({
   tasks: [{ subject: 'legacy', description: 'legacy', owner: 'worker-1', role: 'team-executor' }],
 });
 
+function buildDagPlan(cwd: string, nodes: Array<Record<string, unknown>>) {
+  writeFileSync(join(cwd, '.omx', 'plans', 'team-dag-demo.json'), JSON.stringify({
+    schema_version: 1,
+    nodes,
+  }));
+  return buildRepoAwareTeamExecutionPlan({
+    task: 'team',
+    workerCount: 2,
+    agentType: 'executor',
+    explicitAgentType: false,
+    explicitWorkerCount: true,
+    cwd,
+    buildLegacyPlan: legacy,
+    allowDagHandoff: true,
+  });
+}
+
 describe('buildRepoAwareTeamExecutionPlan', () => {
   it('falls back to legacy text decomposition when no DAG exists', () => {
     const cwd = repo();
@@ -52,6 +69,58 @@ describe('buildRepoAwareTeamExecutionPlan', () => {
     assert.equal(plan.metadata?.node_id_to_task_id, undefined);
     assert.deepEqual(plan.metadata?.node_dependencies?.tests, ['impl']);
     assert.match(plan.tasks[0].description, /File scope: src\/team\/runtime.ts/);
+  });
+
+  it('distributes distinct files under src despite shared inferred top-level domains', () => {
+    const cwd = repo();
+    const plan = buildDagPlan(cwd, [
+      { id: 'client', subject: 'Client', description: 'client lane', filePaths: ['src/client.ts'] },
+      { id: 'server', subject: 'Server', description: 'server lane', filePaths: ['src/server.ts'] },
+    ]);
+
+    assert.deepEqual(plan.tasks.map((task) => task.owner), ['worker-1', 'worker-2']);
+    assert.deepEqual(plan.tasks.map((task) => task.domains), [undefined, undefined]);
+  });
+
+  it('distributes distinct same-basename paths when inferred domains are soft only', () => {
+    const cwd = repo();
+    const plan = buildDagPlan(cwd, [
+      { id: 'client', subject: 'Client index', description: 'client lane', filePaths: ['src/client/index.ts'] },
+      { id: 'server', subject: 'Server index', description: 'server lane', filePaths: ['src/server/index.ts'] },
+    ]);
+
+    assert.deepEqual(plan.tasks.map((task) => task.owner), ['worker-1', 'worker-2']);
+  });
+
+  it('keeps explicit caller-declared domains hard across distinct paths', () => {
+    const cwd = repo();
+    const plan = buildDagPlan(cwd, [
+      { id: 'client', subject: 'Client UI', description: 'client lane', filePaths: ['src/client.ts'], domains: ['ui'] },
+      { id: 'server', subject: 'Server UI', description: 'server lane', filePaths: ['src/server.ts'], domains: ['ui'] },
+    ]);
+
+    assert.deepEqual(plan.tasks.map((task) => task.owner), ['worker-1', 'worker-1']);
+    assert.deepEqual(plan.tasks.map((task) => task.domains), [['ui'], ['ui']]);
+  });
+
+  it('binds semantically equivalent structured paths in repo-aware allocation', () => {
+    const cwd = repo();
+    const plan = buildDagPlan(cwd, [
+      { id: 'first', subject: 'Parser first', description: 'first lane', filePaths: ['./src/parser.ts'] },
+      { id: 'second', subject: 'Parser second', description: 'second lane', filePaths: ['src/./parser.ts'] },
+    ]);
+
+    assert.deepEqual(plan.tasks.map((task) => task.owner), ['worker-1', 'worker-1']);
+  });
+
+  it('preserves structured trailing-dot filename boundaries in repo-aware allocation', () => {
+    const cwd = repo();
+    const plan = buildDagPlan(cwd, [
+      { id: 'dotted', subject: 'Dotted release', description: 'first lane', filePaths: ['docs/release.'] },
+      { id: 'plain', subject: 'Plain release', description: 'second lane', filePaths: ['docs/release'] },
+    ]);
+
+    assert.deepEqual(plan.tasks.map((task) => task.owner), ['worker-1', 'worker-2']);
   });
 
 

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -176,8 +176,17 @@ async function withMockTmuxFixture<T>(
   const logPath = join(fakeBinDir, 'tmux.log');
   const tmuxStubPath = join(fakeBinDir, 'tmux');
   const previousPath = process.env.PATH;
+  const previousOmxRoot = process.env.OMX_ROOT;
+  const previousOmxStateRoot = process.env.OMX_STATE_ROOT;
+  const previousTeamStateRoot = process.env.OMX_TEAM_STATE_ROOT;
 
   try {
+    // Team state is cwd-scoped in these fixtures. Do not let the leader's
+    // boxed runtime root redirect durable fixture assertions outside the
+    // temporary test worktree.
+    delete process.env.OMX_ROOT;
+    delete process.env.OMX_STATE_ROOT;
+    delete process.env.OMX_TEAM_STATE_ROOT;
     const fixtureScript = tmuxScript(logPath);
     const standaloneGlobalProofFallback = dirPrefix.includes('standalone')
       ? `  [ -n "$pid" ] || case "$target" in %11) pid=2000000011 ;; %44) pid=2000000044 ;; esac\n`
@@ -266,9 +275,20 @@ ${standaloneGlobalPaneProofFallback}
 fi
 ` : ''}
 if [ "${'$'}1" = "if-shell" ] && [ "${'$'}{2:-}" = "-F" ] && [ "${'$'}{3:-}" = "-t" ]; then
+  success="${'$'}6"
+  # Only source-authority transactions need fixture-side command-list
+  # emulation. Other if-shell calls (for example detached teardown) retain
+  # their fixture-defined behavior, including deliberate server-side denial.
+  case "$success" in
+    *omx_source_*) ;;
+    *) exec "$fixture" "${'$'}@" ;;
+  esac
+  # Preserve the guarded command list in the fixture log before emulating its
+  # success branch. Real tmux receives this one atomic command, not the
+  # individual effect re-issued below for fixture execution.
+  printf '%s\n' "${'$'}*" >> "${logPath}"
   source="${'$'}4"
   predicate="${'$'}5"
-  success="${'$'}6"
   frame="$(source_frame "$source")" || { exec "$fixture" "${'$'}@"; }
   old_ifs="$IFS"; IFS="$(printf '\tX')"; IFS="${'$'}{IFS%X}"; set -- $frame; IFS="$old_ifs"
   session="${'$'}1"; session_id="${'$'}2"; created="${'$'}3"; index="${'$'}4"; window_id="${'$'}5"; pane="${'$'}6"; pid="${'$'}7"
@@ -285,7 +305,7 @@ if [ "${'$'}1" = "if-shell" ] && [ "${'$'}{2:-}" = "-F" ] && [ "${'$'}{3:-}" = "
     esac
   fi
   receipt="$(printf '%s' "$success" | sed -n "s/.*\\(omx_source_[A-Za-z0-9_]*\\).*/\\1/p")"
-  effect="${'$'}{success%% \\; display-message*}"
+  effect="${'$'}{success%% ; display-message*}"
   eval "set -- $effect"
   output="$($0 "${'$'}@")" || exit 1
   case "${'$'}1" in
@@ -315,6 +335,12 @@ exec "$fixture" "${'$'}@"
   } finally {
     if (typeof previousPath === 'string') process.env.PATH = previousPath;
     else delete process.env.PATH;
+    if (typeof previousOmxRoot === 'string') process.env.OMX_ROOT = previousOmxRoot;
+    else delete process.env.OMX_ROOT;
+    if (typeof previousOmxStateRoot === 'string') process.env.OMX_STATE_ROOT = previousOmxStateRoot;
+    else delete process.env.OMX_STATE_ROOT;
+    if (typeof previousTeamStateRoot === 'string') process.env.OMX_TEAM_STATE_ROOT = previousTeamStateRoot;
+    else delete process.env.OMX_TEAM_STATE_ROOT;
     await rm(fakeBinDir, { recursive: true, force: true });
   }
 }
@@ -340,7 +366,7 @@ esac
         const captured = spawnSync('tmux', ['display-message', '-p', '-t', '%1', '#{session_name}\t#{session_id}\t#{session_created}\t#{window_index}\t#{window_id}\t#{pane_id}\t#{pane_pid}'], { encoding: 'utf8' });
         assert.equal(captured.status, 0);
         assert.equal(captured.stdout, 'recycled\t$1\t1\t0\t@0\t%1\t101\n');
-        const guarded = spawnSync('tmux', ['if-shell', '-F', '-t', '%1', '#{==:#{pane_pid},101}', "split-window -h -t %1 -P -F '#{pane_id}\tomx_source_recycled' \\; display-message -p 'omx_source_recycled'", "display-message -p ''"], { encoding: 'utf8' });
+        const guarded = spawnSync('tmux', ['if-shell', '-F', '-t', '%1', '#{==:#{pane_pid},101}', "split-window -h -t %1 -P -F '#{pane_id}\tomx_source_recycled' ; display-message -p 'omx_source_recycled'", "display-message -p ''"], { encoding: 'utf8' });
         assert.equal(guarded.status, 0);
         assert.equal(guarded.stdout, '');
         assert.equal(fs.existsSync(`${logPath}.split`), false);
@@ -374,7 +400,7 @@ esac
         const guarded = spawnSync('tmux', [
           'if-shell', '-F', '-t', '%1',
           '#{&&:#{==:#{pane_dead},0},#{&&:#{==:#{pane_id},%1},#{&&:#{==:#{pane_pid},101},#{&&:#{==:#{session_id},$1},#{&&:#{==:#{session_created},1},#{&&:#{==:#{window_id},@0},#{==:#{@omx_team_pane_owner_id},team:original}}}}}}',
-          `split-window -h -t %1 -P -F '#{pane_id}\\t${receipt}' \\; display-message -p '${receipt}'`,
+          `split-window -h -t %1 -P -F '#{pane_id}\t${receipt}' ; display-message -p '${receipt}'`,
           "display-message -p ''",
         ], { encoding: 'utf8' });
         assert.equal(guarded.status, 0);
@@ -5164,13 +5190,13 @@ esac
           const redrawTransactions = commands
             .map((command, index) => ({ command, index }))
             .filter(({ command }) => command.includes('send-keys -t %1 C-l')
-              && command.includes('display-message -p omx_source_'));
+              && /display-message -p ['"]?omx_source_/.test(command));
           assert.equal(redrawTransactions.length, 1);
           const redrawIndex = redrawTransactions[0]!.index;
           assert.ok(redrawIndex > 0);
           assert.match(
             redrawTransactions[0]!.command,
-            /send-keys -t %1 C-l.*display-message -p omx_source_/,
+            /send-keys -t %1 C-l.*display-message -p ['"]?omx_source_/,
             'leader Codex pane redraw must carry the exact guarded transaction receipt',
           );
 
@@ -5368,24 +5394,27 @@ esac
           const globalExactPanePidProof = /^list-panes -a -F #\{pane_id\}\t#\{pane_dead\}\t#\{pane_pid\}$/;
           const targetScopedExactPaneSetProof = /^list-panes -t shared:0 -F #\{pane_id\}\t#\{pane_current_command\}\t#\{pane_start_command\}$/;
           const exactPaneEffects = /^(set-option -p -t %|split-window .* -t %|resize-pane -t %|select-pane -t %|send-keys -t %|if-shell -F -t %)/;
+          const isGuardedAuthorityTransaction = (command: string): boolean => command.startsWith('if-shell -F -t %')
+            && command.includes('#{==:#{pane_dead},0}')
+            && /#\{==:#\{pane_id\},%[0-9]+\}/.test(command)
+            && /#\{==:#\{pane_pid\},[1-9][0-9]*\}/.test(command)
+            && /#\{==:#\{session_id\},\$[0-9]+\}/.test(command)
+            && /#\{==:#\{session_created\},[0-9]+\}/.test(command)
+            && /#\{==:#\{window_id\},@[0-9]+\}/.test(command)
+            && (/set-option(?: [^;]*)? @omx_(?:team_pane_owner_id|instance_id|pane_instance_id)\b/.test(command)
+              || new RegExp(`#\\{==:#\\{@omx_team_pane_owner_id\\},${escapeRegExp(session.teamPaneOwnerId)}\\}`).test(command));
           for (const [index, command] of commands.entries()) {
             if (!exactPaneEffects.test(command)) continue;
             const immediatelyPrevious = commands[index - 1] ?? '';
             const previousProof = commands[index - 2] ?? '';
-            const guardedAuthorityTransaction = command.startsWith('if-shell -F -t %')
-              && command.includes('#{==:#{pane_dead},0}')
-              && /#\{==:#\{pane_id\},%[0-9]+\}/.test(command)
-              && /#\{==:#\{pane_pid\},[1-9][0-9]*\}/.test(command)
-              && /#\{==:#\{session_id\},\$[0-9]+\}/.test(command)
-              && /#\{==:#\{session_created\},[0-9]+\}/.test(command)
-              && /#\{==:#\{window_id\},@[0-9]+\}/.test(command)
-              && (/set-option(?: [^;]*)? @omx_(?:team_pane_owner_id|instance_id|pane_instance_id)\b/.test(command)
-                || new RegExp(`#\\{==:#\\{@omx_team_pane_owner_id\\},${escapeRegExp(session.teamPaneOwnerId)}\\}`).test(command));
             const hasAdjacentAuthority = globalExactPanePidProof.test(immediatelyPrevious)
               || (targetScopedExactPaneSetProof.test(immediatelyPrevious)
                 && globalExactPanePidProof.test(previousProof))
-              || guardedAuthorityTransaction
-              || command.includes('display-message -p omx_source_');
+              || isGuardedAuthorityTransaction(command)
+              // The fixture logs the actual guarded `if-shell` command, then
+              // replays its source-owned effect to maintain pane state.
+              || isGuardedAuthorityTransaction(immediatelyPrevious)
+              || /display-message -p ['"]?omx_source_/.test(command);
             assert.equal(
               hasAdjacentAuthority,
               true,

--- a/src/team/allocation-policy.ts
+++ b/src/team/allocation-policy.ts
@@ -4,6 +4,7 @@ export interface AllocationTaskInput {
   subject: string;
   description: string;
   role?: string;
+  affinityDescription?: string;
   blocked_by?: string[];
   filePaths?: string[];
   domains?: string[];
@@ -92,7 +93,7 @@ function extractHardAffinityHints(task: AllocationTaskInput): Set<string> {
   for (const pathValue of task.filePaths ?? []) collectExactPathHint(pathValue, hints, 'structured');
   for (const domain of task.domains ?? []) collectExactDeclaredDomainHint(domain, hints);
 
-  const text = `${task.subject}\n${task.description}`;
+  const text = `${task.subject}\n${task.affinityDescription ?? task.description}`;
   for (const match of text.matchAll(FILE_PATH_PATTERN)) {
     if (match[1]) collectExactPathHint(match[1], hints, 'prose');
   }
@@ -105,7 +106,7 @@ function extractTaskHints(task: AllocationTaskInput): Set<string> {
   for (const domain of task.domains ?? []) collectDeclaredDomainHints(domain, hints);
   for (const domain of task.inferredDomains ?? []) collectDeclaredDomainHints(domain, hints);
 
-  const text = `${task.subject}\n${task.description}`;
+  const text = `${task.subject}\n${task.affinityDescription ?? task.description}`;
   for (const match of text.matchAll(FILE_PATH_PATTERN)) {
     if (match[1]) collectPathHints(match[1], hints, 'prose');
   }
@@ -153,7 +154,7 @@ function scoreWorker(
 export function chooseTaskOwner(
   task: AllocationTaskInput,
   workers: AllocationWorkerInput[],
-  currentAssignments: Array<{ owner: string; role?: string; subject?: string; description?: string; filePaths?: string[]; domains?: string[]; inferredDomains?: string[] }>,
+  currentAssignments: Array<{ owner: string; role?: string; subject?: string; description?: string; affinityDescription?: string; filePaths?: string[]; domains?: string[]; inferredDomains?: string[] }>,
 ): AllocationDecision {
   if (workers.length === 0) {
     throw new Error('at least one worker is required for allocation');
@@ -170,6 +171,7 @@ export function chooseTaskOwner(
       const assignedTask = {
         subject: item.subject ?? '',
         description: item.description ?? '',
+        affinityDescription: item.affinityDescription,
         role: item.role,
         filePaths: item.filePaths,
         domains: item.domains,

--- a/src/team/allocation-policy.ts
+++ b/src/team/allocation-policy.ts
@@ -7,6 +7,7 @@ export interface AllocationTaskInput {
   blocked_by?: string[];
   filePaths?: string[];
   domains?: string[];
+  inferredDomains?: string[];
 }
 
 export interface AllocationWorkerInput {
@@ -40,8 +41,15 @@ function normalizeHint(value: string): string | null {
   return normalized.length >= 3 ? normalized : null;
 }
 
-function collectPathHints(pathValue: string, target: Set<string>): void {
-  const normalizedPath = normalizeTeamFileScope(pathValue);
+function normalizedPathHint(pathValue: string, source: 'structured' | 'prose'): string {
+  const boundaryValue = source === 'prose'
+    ? pathValue.replace(/([A-Za-z0-9])\.+$/, '$1')
+    : pathValue;
+  return normalizeTeamFileScope(boundaryValue);
+}
+
+function collectPathHints(pathValue: string, target: Set<string>, source: 'structured' | 'prose'): void {
+  const normalizedPath = normalizedPathHint(pathValue, source);
   if (!normalizedPath) return;
   target.add(`path:${normalizedPath}`);
 
@@ -51,8 +59,8 @@ function collectPathHints(pathValue: string, target: Set<string>): void {
   if (normalizedStem) target.add(`domain:${normalizedStem}`);
 }
 
-function collectExactPathHint(pathValue: string, target: Set<string>): void {
-  const normalizedPath = normalizeTeamFileScope(pathValue);
+function collectExactPathHint(pathValue: string, target: Set<string>, source: 'structured' | 'prose'): void {
+  const normalizedPath = normalizedPathHint(pathValue, source);
   if (normalizedPath) target.add(`path:${normalizedPath}`);
 }
 
@@ -81,24 +89,25 @@ function collectExactDeclaredDomainHint(value: string, target: Set<string>): voi
 
 function extractHardAffinityHints(task: AllocationTaskInput): Set<string> {
   const hints = new Set<string>();
-  for (const pathValue of task.filePaths ?? []) collectExactPathHint(pathValue, hints);
+  for (const pathValue of task.filePaths ?? []) collectExactPathHint(pathValue, hints, 'structured');
   for (const domain of task.domains ?? []) collectExactDeclaredDomainHint(domain, hints);
 
   const text = `${task.subject}\n${task.description}`;
   for (const match of text.matchAll(FILE_PATH_PATTERN)) {
-    if (match[1]) collectExactPathHint(match[1], hints);
+    if (match[1]) collectExactPathHint(match[1], hints, 'prose');
   }
   return hints;
 }
 
 function extractTaskHints(task: AllocationTaskInput): Set<string> {
   const hints = new Set<string>();
-  for (const pathValue of task.filePaths ?? []) collectPathHints(pathValue, hints);
+  for (const pathValue of task.filePaths ?? []) collectPathHints(pathValue, hints, 'structured');
   for (const domain of task.domains ?? []) collectDeclaredDomainHints(domain, hints);
+  for (const domain of task.inferredDomains ?? []) collectDeclaredDomainHints(domain, hints);
 
   const text = `${task.subject}\n${task.description}`;
   for (const match of text.matchAll(FILE_PATH_PATTERN)) {
-    if (match[1]) collectPathHints(match[1], hints);
+    if (match[1]) collectPathHints(match[1], hints, 'prose');
   }
   collectDomainHints(text, hints);
   return hints;
@@ -144,7 +153,7 @@ function scoreWorker(
 export function chooseTaskOwner(
   task: AllocationTaskInput,
   workers: AllocationWorkerInput[],
-  currentAssignments: Array<{ owner: string; role?: string; subject?: string; description?: string; filePaths?: string[]; domains?: string[] }>,
+  currentAssignments: Array<{ owner: string; role?: string; subject?: string; description?: string; filePaths?: string[]; domains?: string[]; inferredDomains?: string[] }>,
 ): AllocationDecision {
   if (workers.length === 0) {
     throw new Error('at least one worker is required for allocation');
@@ -164,6 +173,7 @@ export function chooseTaskOwner(
         role: item.role,
         filePaths: item.filePaths,
         domains: item.domains,
+        inferredDomains: item.inferredDomains,
       };
       for (const hint of extractTaskHints(assignedTask)) scopeHints.add(hint);
       for (const hint of extractHardAffinityHints(assignedTask)) workerHardAffinityHints.add(hint);

--- a/src/team/allocation-policy.ts
+++ b/src/team/allocation-policy.ts
@@ -21,7 +21,7 @@ interface WorkerAllocationState extends AllocationWorkerInput {
   assignedCount: number;
   primaryRole?: string;
   scopeHints: Set<string>;
-  explicitAffinityHints: Set<string>;
+  hardAffinityHints: Set<string>;
 }
 
 const FILE_PATH_PATTERN = /(?:^|[\s("'])((?:src|scripts|docs|prompts|skills|templates|native|crates)\/[A-Za-z0-9._/-]+)/g;
@@ -49,6 +49,11 @@ function collectPathHints(pathValue: string, target: Set<string>): void {
   if (normalizedStem) target.add(`domain:${normalizedStem}`);
 }
 
+function collectExactPathHint(pathValue: string, target: Set<string>): void {
+  const normalizedPath = normalizeHint(pathValue.replace(/^[./]+/, ''));
+  if (normalizedPath) target.add(`path:${normalizedPath}`);
+}
+
 function collectDomainHints(value: string, target: Set<string>): void {
   const words = value.toLowerCase().match(/[a-z][a-z0-9_-]{2,}/g) ?? [];
   for (const word of words) {
@@ -67,7 +72,24 @@ function collectDeclaredDomainHints(value: string, target: Set<string>): void {
   collectDomainHints(value, target);
 }
 
-function extractExplicitAffinityHints(task: AllocationTaskInput): Set<string> {
+function collectExactDeclaredDomainHint(value: string, target: Set<string>): void {
+  const normalized = normalizeDeclaredDomainHint(value);
+  if (normalized) target.add(`declared-domain:${normalized}`);
+}
+
+function extractHardAffinityHints(task: AllocationTaskInput): Set<string> {
+  const hints = new Set<string>();
+  for (const pathValue of task.filePaths ?? []) collectExactPathHint(pathValue, hints);
+  for (const domain of task.domains ?? []) collectExactDeclaredDomainHint(domain, hints);
+
+  const text = `${task.subject}\n${task.description}`;
+  for (const match of text.matchAll(FILE_PATH_PATTERN)) {
+    if (match[1]) collectExactPathHint(match[1], hints);
+  }
+  return hints;
+}
+
+function extractTaskHints(task: AllocationTaskInput): Set<string> {
   const hints = new Set<string>();
   for (const pathValue of task.filePaths ?? []) collectPathHints(pathValue, hints);
   for (const domain of task.domains ?? []) collectDeclaredDomainHints(domain, hints);
@@ -76,12 +98,7 @@ function extractExplicitAffinityHints(task: AllocationTaskInput): Set<string> {
   for (const match of text.matchAll(FILE_PATH_PATTERN)) {
     if (match[1]) collectPathHints(match[1], hints);
   }
-  return hints;
-}
-
-function extractTaskHints(task: AllocationTaskInput): Set<string> {
-  const hints = extractExplicitAffinityHints(task);
-  collectDomainHints(`${task.subject}\n${task.description}`, hints);
+  collectDomainHints(text, hints);
   return hints;
 }
 
@@ -131,13 +148,13 @@ export function chooseTaskOwner(
     throw new Error('at least one worker is required for allocation');
   }
 
-  const explicitAffinityHints = extractExplicitAffinityHints(task);
+  const hardAffinityHints = extractHardAffinityHints(task);
   const taskHints = extractTaskHints(task);
   const workerState = workers.map<WorkerAllocationState>((worker) => {
     const assigned = currentAssignments.filter((item) => item.owner === worker.name);
     const primaryRole = assigned.find((item) => item.role)?.role;
     const scopeHints = new Set<string>();
-    const workerExplicitAffinityHints = new Set<string>();
+    const workerHardAffinityHints = new Set<string>();
     for (const item of assigned) {
       const assignedTask = {
         subject: item.subject ?? '',
@@ -147,14 +164,14 @@ export function chooseTaskOwner(
         domains: item.domains,
       };
       for (const hint of extractTaskHints(assignedTask)) scopeHints.add(hint);
-      for (const hint of extractExplicitAffinityHints(assignedTask)) workerExplicitAffinityHints.add(hint);
+      for (const hint of extractHardAffinityHints(assignedTask)) workerHardAffinityHints.add(hint);
     }
     return {
       ...worker,
       assignedCount: assigned.length,
       primaryRole,
       scopeHints,
-      explicitAffinityHints: workerExplicitAffinityHints,
+      hardAffinityHints: workerHardAffinityHints,
     };
   });
 
@@ -163,13 +180,15 @@ export function chooseTaskOwner(
   const minimumAssignedCount = Math.min(...workerState.map((worker) => worker.assignedCount));
   let candidates = workerState;
   if (genericWorkerPool) {
-    if (explicitAffinityHints.size === 0) {
-      candidates = workerState.filter((worker) => worker.assignedCount === minimumAssignedCount);
-    } else {
+    if (hardAffinityHints.size > 0) {
       const affinityCandidates = workerState.filter((worker) => (
-        countHintOverlap(explicitAffinityHints, worker.explicitAffinityHints) > 0
+        countHintOverlap(hardAffinityHints, worker.hardAffinityHints) > 0
       ));
-      if (affinityCandidates.length > 0) candidates = affinityCandidates;
+      candidates = affinityCandidates.length > 0
+        ? affinityCandidates
+        : workerState.filter((worker) => worker.assignedCount === minimumAssignedCount);
+    } else {
+      candidates = workerState.filter((worker) => worker.assignedCount === minimumAssignedCount);
     }
   }
   const uniformRolePool = Boolean(task.role?.trim())

--- a/src/team/allocation-policy.ts
+++ b/src/team/allocation-policy.ts
@@ -73,11 +73,13 @@ function extractTaskHints(task: AllocationTaskInput): Set<string> {
 /**
  * A generic Team worker pool has no durable specialization to preserve. In
  * that case, free-form prose such as "shared theme" is too weak a signal to
- * put every otherwise-independent lane on the first worker. Explicit file
- * ownership remains strong enough to keep related work together.
+ * put every otherwise-independent lane on the first worker. Explicit file or
+ * declared domain ownership remains strong enough to keep related work
+ * together.
  */
-function hasExplicitFilePathHint(task: AllocationTaskInput): boolean {
+function hasExplicitAffinityHint(task: AllocationTaskInput): boolean {
   if ((task.filePaths?.length ?? 0) > 0) return true;
+  if ((task.domains ?? []).some((domain) => normalizeHint(domain) !== null)) return true;
   const text = `${task.subject}\n${task.description}`;
   return [...text.matchAll(FILE_PATH_PATTERN)].length > 0;
 }
@@ -154,7 +156,7 @@ export function chooseTaskOwner(
   const genericWorkerPool = workerState.length > 0
     && workerState.every((worker) => !worker.role?.trim());
   const minimumAssignedCount = Math.min(...workerState.map((worker) => worker.assignedCount));
-  const candidates = genericWorkerPool && !hasExplicitFilePathHint(task)
+  const candidates = genericWorkerPool && !hasExplicitAffinityHint(task)
     ? workerState.filter((worker) => worker.assignedCount === minimumAssignedCount)
     : workerState;
   const uniformRolePool = Boolean(task.role?.trim())

--- a/src/team/allocation-policy.ts
+++ b/src/team/allocation-policy.ts
@@ -55,11 +55,22 @@ function collectDomainHints(value: string, target: Set<string>): void {
   }
 }
 
+function normalizeDeclaredDomainHint(value: string): string | null {
+  const normalized = value.trim().toLowerCase().replace(/\s+/g, ' ');
+  return normalized || null;
+}
+
+function collectDeclaredDomainHints(value: string, target: Set<string>): void {
+  const normalized = normalizeDeclaredDomainHint(value);
+  if (normalized) target.add(`domain:${normalized}`);
+  collectDomainHints(value, target);
+}
+
 function extractTaskHints(task: AllocationTaskInput): Set<string> {
   const hints = new Set<string>();
 
   for (const pathValue of task.filePaths ?? []) collectPathHints(pathValue, hints);
-  for (const domain of task.domains ?? []) collectDomainHints(domain, hints);
+  for (const domain of task.domains ?? []) collectDeclaredDomainHints(domain, hints);
 
   const text = `${task.subject}\n${task.description}`;
   for (const match of text.matchAll(FILE_PATH_PATTERN)) {
@@ -79,7 +90,7 @@ function extractTaskHints(task: AllocationTaskInput): Set<string> {
  */
 function hasExplicitAffinityHint(task: AllocationTaskInput): boolean {
   if ((task.filePaths?.length ?? 0) > 0) return true;
-  if ((task.domains ?? []).some((domain) => normalizeHint(domain) !== null)) return true;
+  if ((task.domains ?? []).some((domain) => normalizeDeclaredDomainHint(domain) !== null)) return true;
   const text = `${task.subject}\n${task.description}`;
   return [...text.matchAll(FILE_PATH_PATTERN)].length > 0;
 }

--- a/src/team/allocation-policy.ts
+++ b/src/team/allocation-policy.ts
@@ -5,9 +5,11 @@ export interface AllocationTaskInput {
   description: string;
   role?: string;
   affinityDescription?: string;
+  acceptance?: string[];
   blocked_by?: string[];
   filePaths?: string[];
   domains?: string[];
+  explicitDomains?: string[];
   inferredDomains?: string[];
 }
 
@@ -19,6 +21,21 @@ export interface AllocationWorkerInput {
 export interface AllocationDecision {
   owner: string;
   reason: string;
+}
+
+export type AllocationPathCasePolicy = 'case-sensitive' | 'case-insensitive';
+
+export interface AllocationContext {
+  pathCasePolicy?: AllocationPathCasePolicy;
+}
+
+/**
+ * Bounded deterministic default: known Windows/macOS allocation contexts fold
+ * case; Linux and unknown platforms preserve case unless a caller proves and
+ * supplies a different policy.
+ */
+export function allocationPathCasePolicyForPlatform(platform = process.platform): AllocationPathCasePolicy {
+  return platform === 'win32' || platform === 'darwin' ? 'case-insensitive' : 'case-sensitive';
 }
 
 interface WorkerAllocationState extends AllocationWorkerInput {
@@ -42,15 +59,20 @@ function normalizeHint(value: string): string | null {
   return normalized.length >= 3 ? normalized : null;
 }
 
-function normalizedPathHint(pathValue: string, source: 'structured' | 'prose'): string {
+function normalizedPathHint(
+  pathValue: string,
+  source: 'structured' | 'prose',
+  casePolicy: AllocationPathCasePolicy,
+): string {
   const boundaryValue = source === 'prose'
     ? pathValue.replace(/([A-Za-z0-9])\.+$/, '$1')
     : pathValue;
-  return normalizeTeamFileScope(boundaryValue);
+  const normalized = normalizeTeamFileScope(boundaryValue);
+  return casePolicy === 'case-insensitive' ? normalized.toLowerCase() : normalized;
 }
 
-function collectPathHints(pathValue: string, target: Set<string>, source: 'structured' | 'prose'): void {
-  const normalizedPath = normalizedPathHint(pathValue, source);
+function collectPathHints(pathValue: string, target: Set<string>, source: 'structured' | 'prose', casePolicy: AllocationPathCasePolicy): void {
+  const normalizedPath = normalizedPathHint(pathValue, source, casePolicy);
   if (!normalizedPath) return;
   target.add(`path:${normalizedPath}`);
 
@@ -60,8 +82,8 @@ function collectPathHints(pathValue: string, target: Set<string>, source: 'struc
   if (normalizedStem) target.add(`domain:${normalizedStem}`);
 }
 
-function collectExactPathHint(pathValue: string, target: Set<string>, source: 'structured' | 'prose'): void {
-  const normalizedPath = normalizedPathHint(pathValue, source);
+function collectExactPathHint(pathValue: string, target: Set<string>, source: 'structured' | 'prose', casePolicy: AllocationPathCasePolicy): void {
+  const normalizedPath = normalizedPathHint(pathValue, source, casePolicy);
   if (normalizedPath) target.add(`path:${normalizedPath}`);
 }
 
@@ -88,27 +110,35 @@ function collectExactDeclaredDomainHint(value: string, target: Set<string>): voi
   if (normalized) target.add(`declared-domain:${normalized}`);
 }
 
-function extractHardAffinityHints(task: AllocationTaskInput): Set<string> {
-  const hints = new Set<string>();
-  for (const pathValue of task.filePaths ?? []) collectExactPathHint(pathValue, hints, 'structured');
-  for (const domain of task.domains ?? []) collectExactDeclaredDomainHint(domain, hints);
+function allocationProseText(task: AllocationTaskInput): string {
+  return [
+    task.subject,
+    task.affinityDescription ?? task.description,
+    ...(task.acceptance ?? []),
+  ].join('\n');
+}
 
-  const text = `${task.subject}\n${task.affinityDescription ?? task.description}`;
+function extractHardAffinityHints(task: AllocationTaskInput, casePolicy: AllocationPathCasePolicy): Set<string> {
+  const hints = new Set<string>();
+  for (const pathValue of task.filePaths ?? []) collectExactPathHint(pathValue, hints, 'structured', casePolicy);
+  for (const domain of task.explicitDomains ?? task.domains ?? []) collectExactDeclaredDomainHint(domain, hints);
+
+  const text = allocationProseText(task);
   for (const match of text.matchAll(FILE_PATH_PATTERN)) {
-    if (match[1]) collectExactPathHint(match[1], hints, 'prose');
+    if (match[1]) collectExactPathHint(match[1], hints, 'prose', casePolicy);
   }
   return hints;
 }
 
-function extractTaskHints(task: AllocationTaskInput): Set<string> {
+function extractTaskHints(task: AllocationTaskInput, casePolicy: AllocationPathCasePolicy): Set<string> {
   const hints = new Set<string>();
-  for (const pathValue of task.filePaths ?? []) collectPathHints(pathValue, hints, 'structured');
-  for (const domain of task.domains ?? []) collectDeclaredDomainHints(domain, hints);
+  for (const pathValue of task.filePaths ?? []) collectPathHints(pathValue, hints, 'structured', casePolicy);
+  for (const domain of task.explicitDomains ?? task.domains ?? []) collectDeclaredDomainHints(domain, hints);
   for (const domain of task.inferredDomains ?? []) collectDeclaredDomainHints(domain, hints);
 
-  const text = `${task.subject}\n${task.affinityDescription ?? task.description}`;
+  const text = allocationProseText(task);
   for (const match of text.matchAll(FILE_PATH_PATTERN)) {
-    if (match[1]) collectPathHints(match[1], hints, 'prose');
+    if (match[1]) collectPathHints(match[1], hints, 'prose', casePolicy);
   }
   collectDomainHints(text, hints);
   return hints;
@@ -154,14 +184,16 @@ function scoreWorker(
 export function chooseTaskOwner(
   task: AllocationTaskInput,
   workers: AllocationWorkerInput[],
-  currentAssignments: Array<{ owner: string; role?: string; subject?: string; description?: string; affinityDescription?: string; filePaths?: string[]; domains?: string[]; inferredDomains?: string[] }>,
+  currentAssignments: Array<{ owner: string; role?: string; subject?: string; description?: string; affinityDescription?: string; acceptance?: string[]; filePaths?: string[]; domains?: string[]; explicitDomains?: string[]; inferredDomains?: string[] }>,
+  context: AllocationContext = {},
 ): AllocationDecision {
   if (workers.length === 0) {
     throw new Error('at least one worker is required for allocation');
   }
+  const pathCasePolicy = context.pathCasePolicy ?? allocationPathCasePolicyForPlatform();
 
-  const hardAffinityHints = extractHardAffinityHints(task);
-  const taskHints = extractTaskHints(task);
+  const hardAffinityHints = extractHardAffinityHints(task, pathCasePolicy);
+  const taskHints = extractTaskHints(task, pathCasePolicy);
   const workerState = workers.map<WorkerAllocationState>((worker) => {
     const assigned = currentAssignments.filter((item) => item.owner === worker.name);
     const primaryRole = assigned.find((item) => item.role)?.role;
@@ -172,13 +204,15 @@ export function chooseTaskOwner(
         subject: item.subject ?? '',
         description: item.description ?? '',
         affinityDescription: item.affinityDescription,
+        acceptance: item.acceptance,
         role: item.role,
         filePaths: item.filePaths,
         domains: item.domains,
+        explicitDomains: item.explicitDomains,
         inferredDomains: item.inferredDomains,
       };
-      for (const hint of extractTaskHints(assignedTask)) scopeHints.add(hint);
-      for (const hint of extractHardAffinityHints(assignedTask)) workerHardAffinityHints.add(hint);
+      for (const hint of extractTaskHints(assignedTask, pathCasePolicy)) scopeHints.add(hint);
+      for (const hint of extractHardAffinityHints(assignedTask, pathCasePolicy)) workerHardAffinityHints.add(hint);
     }
     return {
       ...worker,
@@ -244,10 +278,11 @@ export function chooseTaskOwner(
 export function allocateTasksToWorkers<T extends AllocationTaskInput>(
   tasks: T[],
   workers: AllocationWorkerInput[],
+  context: AllocationContext = {},
 ): Array<T & { owner: string; allocation_reason: string }> {
   const assignments: Array<T & { owner: string; allocation_reason: string }> = [];
   for (const task of tasks) {
-    const decision = chooseTaskOwner(task, workers, assignments);
+    const decision = chooseTaskOwner(task, workers, assignments, context);
     assignments.push({
       ...task,
       owner: decision.owner,

--- a/src/team/allocation-policy.ts
+++ b/src/team/allocation-policy.ts
@@ -70,6 +70,18 @@ function extractTaskHints(task: AllocationTaskInput): Set<string> {
   return hints;
 }
 
+/**
+ * A generic Team worker pool has no durable specialization to preserve. In
+ * that case, free-form prose such as "shared theme" is too weak a signal to
+ * put every otherwise-independent lane on the first worker. Explicit file
+ * ownership remains strong enough to keep related work together.
+ */
+function hasExplicitFilePathHint(task: AllocationTaskInput): boolean {
+  if ((task.filePaths?.length ?? 0) > 0) return true;
+  const text = `${task.subject}\n${task.description}`;
+  return [...text.matchAll(FILE_PATH_PATTERN)].length > 0;
+}
+
 function countHintOverlap(taskHints: Set<string>, workerHints: Set<string>): number {
   let overlap = 0;
   for (const hint of taskHints) {
@@ -139,11 +151,17 @@ export function chooseTaskOwner(
     };
   });
 
+  const genericWorkerPool = workerState.length > 0
+    && workerState.every((worker) => !worker.role?.trim());
+  const minimumAssignedCount = Math.min(...workerState.map((worker) => worker.assignedCount));
+  const candidates = genericWorkerPool && !hasExplicitFilePathHint(task)
+    ? workerState.filter((worker) => worker.assignedCount === minimumAssignedCount)
+    : workerState;
   const uniformRolePool = Boolean(task.role?.trim())
-    && workerState.length > 0
-    && workerState.every((worker) => worker.role?.trim() === task.role?.trim());
+    && candidates.length > 0
+    && candidates.every((worker) => worker.role?.trim() === task.role?.trim());
 
-  const ranked = workerState
+  const ranked = candidates
     .map((worker, index) => ({
       worker,
       index,

--- a/src/team/allocation-policy.ts
+++ b/src/team/allocation-policy.ts
@@ -26,7 +26,7 @@ interface WorkerAllocationState extends AllocationWorkerInput {
   hardAffinityHints: Set<string>;
 }
 
-const FILE_PATH_PATTERN = /(?:^|[\s("'])((?:src|scripts|docs|prompts|skills|templates|native|crates)\/[A-Za-z0-9._/-]+)/g;
+const FILE_PATH_PATTERN = /(?:^|[\s("'])((?:\.[\\/])?(?:src|scripts|docs|prompts|skills|templates|native|crates)[\\/][A-Za-z0-9._\\/-]+)/g;
 const DOMAIN_STOP_WORDS = new Set([
   'a', 'an', 'and', 'the', 'for', 'with', 'into', 'from', 'then', 'than', 'that', 'this', 'those', 'these',
   'work', 'task', 'tasks', 'implement', 'implementation', 'continue', 'additional', 'update', 'fix', 'lane',

--- a/src/team/allocation-policy.ts
+++ b/src/team/allocation-policy.ts
@@ -1,3 +1,5 @@
+import { normalizeTeamFileScope } from './coordination-protocol.js';
+
 export interface AllocationTaskInput {
   subject: string;
   description: string;
@@ -39,7 +41,7 @@ function normalizeHint(value: string): string | null {
 }
 
 function collectPathHints(pathValue: string, target: Set<string>): void {
-  const normalizedPath = normalizeHint(pathValue.replace(/^[./]+/, ''));
+  const normalizedPath = normalizeTeamFileScope(pathValue);
   if (!normalizedPath) return;
   target.add(`path:${normalizedPath}`);
 
@@ -50,7 +52,7 @@ function collectPathHints(pathValue: string, target: Set<string>): void {
 }
 
 function collectExactPathHint(pathValue: string, target: Set<string>): void {
-  const normalizedPath = normalizeHint(pathValue.replace(/^[./]+/, ''));
+  const normalizedPath = normalizeTeamFileScope(pathValue);
   if (normalizedPath) target.add(`path:${normalizedPath}`);
 }
 

--- a/src/team/allocation-policy.ts
+++ b/src/team/allocation-policy.ts
@@ -21,6 +21,7 @@ interface WorkerAllocationState extends AllocationWorkerInput {
   assignedCount: number;
   primaryRole?: string;
   scopeHints: Set<string>;
+  explicitAffinityHints: Set<string>;
 }
 
 const FILE_PATH_PATTERN = /(?:^|[\s("'])((?:src|scripts|docs|prompts|skills|templates|native|crates)\/[A-Za-z0-9._/-]+)/g;
@@ -66,9 +67,8 @@ function collectDeclaredDomainHints(value: string, target: Set<string>): void {
   collectDomainHints(value, target);
 }
 
-function extractTaskHints(task: AllocationTaskInput): Set<string> {
+function extractExplicitAffinityHints(task: AllocationTaskInput): Set<string> {
   const hints = new Set<string>();
-
   for (const pathValue of task.filePaths ?? []) collectPathHints(pathValue, hints);
   for (const domain of task.domains ?? []) collectDeclaredDomainHints(domain, hints);
 
@@ -76,23 +76,13 @@ function extractTaskHints(task: AllocationTaskInput): Set<string> {
   for (const match of text.matchAll(FILE_PATH_PATTERN)) {
     if (match[1]) collectPathHints(match[1], hints);
   }
-  collectDomainHints(text, hints);
-
   return hints;
 }
 
-/**
- * A generic Team worker pool has no durable specialization to preserve. In
- * that case, free-form prose such as "shared theme" is too weak a signal to
- * put every otherwise-independent lane on the first worker. Explicit file or
- * declared domain ownership remains strong enough to keep related work
- * together.
- */
-function hasExplicitAffinityHint(task: AllocationTaskInput): boolean {
-  if ((task.filePaths?.length ?? 0) > 0) return true;
-  if ((task.domains ?? []).some((domain) => normalizeDeclaredDomainHint(domain) !== null)) return true;
-  const text = `${task.subject}\n${task.description}`;
-  return [...text.matchAll(FILE_PATH_PATTERN)].length > 0;
+function extractTaskHints(task: AllocationTaskInput): Set<string> {
+  const hints = extractExplicitAffinityHints(task);
+  collectDomainHints(`${task.subject}\n${task.description}`, hints);
+  return hints;
 }
 
 function countHintOverlap(taskHints: Set<string>, workerHints: Set<string>): number {
@@ -141,35 +131,47 @@ export function chooseTaskOwner(
     throw new Error('at least one worker is required for allocation');
   }
 
+  const explicitAffinityHints = extractExplicitAffinityHints(task);
   const taskHints = extractTaskHints(task);
   const workerState = workers.map<WorkerAllocationState>((worker) => {
     const assigned = currentAssignments.filter((item) => item.owner === worker.name);
     const primaryRole = assigned.find((item) => item.role)?.role;
     const scopeHints = new Set<string>();
+    const workerExplicitAffinityHints = new Set<string>();
     for (const item of assigned) {
-      const itemHints = extractTaskHints({
+      const assignedTask = {
         subject: item.subject ?? '',
         description: item.description ?? '',
         role: item.role,
         filePaths: item.filePaths,
         domains: item.domains,
-      });
-      for (const hint of itemHints) scopeHints.add(hint);
+      };
+      for (const hint of extractTaskHints(assignedTask)) scopeHints.add(hint);
+      for (const hint of extractExplicitAffinityHints(assignedTask)) workerExplicitAffinityHints.add(hint);
     }
     return {
       ...worker,
       assignedCount: assigned.length,
       primaryRole,
       scopeHints,
+      explicitAffinityHints: workerExplicitAffinityHints,
     };
   });
 
   const genericWorkerPool = workerState.length > 0
     && workerState.every((worker) => !worker.role?.trim());
   const minimumAssignedCount = Math.min(...workerState.map((worker) => worker.assignedCount));
-  const candidates = genericWorkerPool && !hasExplicitAffinityHint(task)
-    ? workerState.filter((worker) => worker.assignedCount === minimumAssignedCount)
-    : workerState;
+  let candidates = workerState;
+  if (genericWorkerPool) {
+    if (explicitAffinityHints.size === 0) {
+      candidates = workerState.filter((worker) => worker.assignedCount === minimumAssignedCount);
+    } else {
+      const affinityCandidates = workerState.filter((worker) => (
+        countHintOverlap(explicitAffinityHints, worker.explicitAffinityHints) > 0
+      ));
+      if (affinityCandidates.length > 0) candidates = affinityCandidates;
+    }
+  }
   const uniformRolePool = Boolean(task.role?.trim())
     && candidates.length > 0
     && candidates.every((worker) => worker.role?.trim() === task.role?.trim());

--- a/src/team/coordination-protocol.ts
+++ b/src/team/coordination-protocol.ts
@@ -77,7 +77,7 @@ function hasInterdependenceSignal(text: string): boolean {
 }
 
 export function normalizeTeamFileScope(value: string): string {
-	const portable = value.trim().replace(/\\/g, "/").replace(/([A-Za-z0-9])\.+$/, "$1");
+	const portable = value.trim().replace(/\\/g, "/");
 	const normalized = pathPosix.normalize(portable);
 	return normalized === "." ? "" : normalized.replace(/^(\.\/)+/, "");
 }

--- a/src/team/coordination-protocol.ts
+++ b/src/team/coordination-protocol.ts
@@ -76,8 +76,9 @@ function hasInterdependenceSignal(text: string): boolean {
 	return INTERDEPENDENCE_PATTERNS.some((pattern) => pattern.test(text));
 }
 
-function normalizedFileScope(value: string): string {
-	const normalized = pathPosix.normalize(value.trim().replace(/\\/g, "/"));
+export function normalizeTeamFileScope(value: string): string {
+	const portable = value.trim().replace(/\\/g, "/").replace(/([A-Za-z0-9])\.+$/, "$1");
+	const normalized = pathPosix.normalize(portable);
 	return normalized === "." ? "" : normalized.replace(/^(\.\/)+/, "");
 }
 
@@ -86,7 +87,7 @@ function normalizedScopeValue(
 	field: "filePaths" | "domains",
 ): string {
 	return field === "filePaths"
-		? normalizedFileScope(value)
+		? normalizeTeamFileScope(value)
 		: value.trim().toLowerCase();
 }
 

--- a/src/team/rebalance-policy.ts
+++ b/src/team/rebalance-policy.ts
@@ -46,7 +46,14 @@ export function buildRebalanceDecisions(input: RebalancePolicyInput): RebalanceD
 
   const inFlightAssignments = input.tasks
     .filter((task) => task.owner && task.status === 'in_progress')
-    .map((task) => ({ owner: task.owner as string, role: task.role }));
+    .map((task) => ({
+      owner: task.owner as string,
+      role: task.role,
+      subject: task.subject,
+      description: task.description,
+      filePaths: task.filePaths,
+      domains: task.domains,
+    }));
 
   const decisions: RebalanceDecision[] = [];
   const claimedTaskIds = new Set<string>();
@@ -62,7 +69,14 @@ export function buildRebalanceDecisions(input: RebalancePolicyInput): RebalanceD
         ? `reclaimed work is ready; ${decision.reason}`
         : `idle worker pickup; ${decision.reason}`,
     });
-    inFlightAssignments.push({ owner: decision.owner, role: task.role });
+    inFlightAssignments.push({
+      owner: decision.owner,
+      role: task.role,
+      subject: task.subject,
+      description: task.description,
+      filePaths: task.filePaths,
+      domains: task.domains,
+    });
     claimedTaskIds.add(task.id);
   }
 

--- a/src/team/rebalance-policy.ts
+++ b/src/team/rebalance-policy.ts
@@ -51,6 +51,7 @@ export function buildRebalanceDecisions(input: RebalancePolicyInput): RebalanceD
       role: task.role,
       subject: task.subject,
       description: task.description,
+      affinityDescription: task.affinityDescription,
       filePaths: task.filePaths,
       domains: task.domains,
     }));
@@ -74,6 +75,7 @@ export function buildRebalanceDecisions(input: RebalancePolicyInput): RebalanceD
       role: task.role,
       subject: task.subject,
       description: task.description,
+      affinityDescription: task.affinityDescription,
       filePaths: task.filePaths,
       domains: task.domains,
     });

--- a/src/team/rebalance-policy.ts
+++ b/src/team/rebalance-policy.ts
@@ -1,5 +1,5 @@
 import type { TeamTask, WorkerStatus } from './state/types.js';
-import { chooseTaskOwner, type AllocationWorkerInput } from './allocation-policy.js';
+import { chooseTaskOwner, type AllocationPathCasePolicy, type AllocationWorkerInput } from './allocation-policy.js';
 
 export interface RebalanceWorkerInput extends AllocationWorkerInput {
   alive: boolean;
@@ -17,6 +17,7 @@ export interface RebalancePolicyInput {
   tasks: TeamTask[];
   workers: RebalanceWorkerInput[];
   reclaimedTaskIds: string[];
+  pathCasePolicy?: AllocationPathCasePolicy;
 }
 
 function hasCompletedDependencies(task: TeamTask, taskById: Map<string, TeamTask>): boolean {
@@ -54,6 +55,7 @@ export function buildRebalanceDecisions(input: RebalancePolicyInput): RebalanceD
       affinityDescription: task.affinityDescription,
       filePaths: task.filePaths,
       domains: task.domains,
+      explicitDomains: task.explicitDomains,
     }));
 
   const decisions: RebalanceDecision[] = [];
@@ -61,7 +63,9 @@ export function buildRebalanceDecisions(input: RebalancePolicyInput): RebalanceD
 
   for (const task of unownedPendingTasks) {
     if (claimedTaskIds.has(task.id)) continue;
-    const decision = chooseTaskOwner(task, liveWorkers, inFlightAssignments);
+    const decision = chooseTaskOwner(task, liveWorkers, inFlightAssignments, {
+      pathCasePolicy: input.pathCasePolicy,
+    });
     decisions.push({
       type: 'assign',
       taskId: task.id,
@@ -78,6 +82,7 @@ export function buildRebalanceDecisions(input: RebalancePolicyInput): RebalanceD
       affinityDescription: task.affinityDescription,
       filePaths: task.filePaths,
       domains: task.domains,
+      explicitDomains: task.explicitDomains,
     });
     claimedTaskIds.add(task.id);
   }

--- a/src/team/repo-aware-decomposition.ts
+++ b/src/team/repo-aware-decomposition.ts
@@ -21,6 +21,7 @@ export interface LegacyTeamExecutionPlanInput {
 export interface RepoAwareTask {
   subject: string;
   description: string;
+  affinityDescription?: string;
   owner: string;
   role?: string;
   blocked_by?: string[];
@@ -214,6 +215,7 @@ function buildFromDag(input: LegacyTeamExecutionPlanInput, resolution: TeamDagRe
   const allocationInput = sorted.map((node) => ({
     subject: node.subject,
     description: node.description,
+    affinityDescription: node.description,
     role: input.explicitAgentType ? input.agentType : node.role,
     blocked_by: node.depends_on ?? [],
     symbolic_depends_on: node.depends_on ?? [],

--- a/src/team/repo-aware-decomposition.ts
+++ b/src/team/repo-aware-decomposition.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { relative } from 'node:path';
-import { allocateTasksToWorkers } from './allocation-policy.js';
+import { allocateTasksToWorkers, allocationPathCasePolicyForPlatform, type AllocationPathCasePolicy } from './allocation-policy.js';
 import type { ApprovedRepositoryContextSummary } from '../planning/artifacts.js';
 import { readTeamDagHandoffForLatestPlan, type TeamDagHandoff, type TeamDagNode, type TeamDagResolution, type TeamDagWorkerCountSource } from './dag-schema.js';
 import { normalizeTeamFileScope } from './coordination-protocol.js';
@@ -16,6 +16,7 @@ export interface LegacyTeamExecutionPlanInput {
   allowDagHandoff?: boolean;
   dagFallbackReason?: string;
   approvedRepositoryContextSummary?: ApprovedRepositoryContextSummary;
+  pathCasePolicy?: AllocationPathCasePolicy;
 }
 
 export interface RepoAwareTask {
@@ -30,6 +31,7 @@ export interface RepoAwareTask {
   requires_code_change?: boolean;
   filePaths?: string[];
   domains?: string[];
+  explicitDomains?: string[];
   lane?: string;
   allocation_reason?: string;
   symbolic_id?: string;
@@ -216,24 +218,33 @@ function buildFromDag(input: LegacyTeamExecutionPlanInput, resolution: TeamDagRe
     subject: node.subject,
     description: node.description,
     affinityDescription: node.description,
+    acceptance: node.acceptance,
     role: input.explicitAgentType ? input.agentType : node.role,
     blocked_by: node.depends_on ?? [],
     symbolic_depends_on: node.depends_on ?? [],
     requires_code_change: node.requires_code_change,
     filePaths: node.filePaths,
-    domains: node.domains,
+    explicitDomains: node.domains,
     inferredDomains: inferSoftDomains(node),
     lane: node.lane,
     symbolic_id: node.id,
   }));
-  const allocated = allocateTasksToWorkers(allocationInput, workers);
+  const allocated = allocateTasksToWorkers(allocationInput, workers, {
+    pathCasePolicy: input.pathCasePolicy ?? allocationPathCasePolicyForPlatform(),
+  });
   const allocationReasons: Record<string, string> = {};
   const tasks = allocated.map((task): RepoAwareTask => {
     allocationReasons[task.symbolic_id] = task.allocation_reason;
-    const { blocked_by: _symbolicBlockedBy, inferredDomains: _inferredDomains, ...runtimeTask } = task;
+    const { blocked_by: _symbolicBlockedBy, acceptance: _acceptance, inferredDomains: _inferredDomains, ...runtimeTask } = task;
     const sourceNode = nodeById.get(task.symbolic_id);
     return sourceNode
-      ? { ...runtimeTask, description: enrichNodeDescription(sourceNode, input.cwd) }
+      ? {
+          ...runtimeTask,
+          description: enrichNodeDescription(sourceNode, input.cwd),
+          affinityDescription: [sourceNode.description, ...(sourceNode.acceptance ?? [])].join('\n'),
+          domains: sourceNode.domains,
+          explicitDomains: sourceNode.domains,
+        }
       : runtimeTask;
   });
   const nodeDependencies = Object.fromEntries(sorted.map((node) => [node.id, node.depends_on ?? []]));

--- a/src/team/repo-aware-decomposition.ts
+++ b/src/team/repo-aware-decomposition.ts
@@ -3,6 +3,7 @@ import { relative } from 'node:path';
 import { allocateTasksToWorkers } from './allocation-policy.js';
 import type { ApprovedRepositoryContextSummary } from '../planning/artifacts.js';
 import { readTeamDagHandoffForLatestPlan, type TeamDagHandoff, type TeamDagNode, type TeamDagResolution, type TeamDagWorkerCountSource } from './dag-schema.js';
+import { normalizeTeamFileScope } from './coordination-protocol.js';
 
 export interface LegacyTeamExecutionPlanInput {
   task: string;
@@ -75,15 +76,15 @@ const IMPLEMENTATION_LANE_PATTERN = /\b(?:impl|implementation|code|build|feature
 const VERIFICATION_LANE_PATTERN = /\b(?:verify|verification|test|qa|review)\b/i;
 
 function normalizePath(path: string): string {
-  return path.replace(/^\.\//, '');
+  return normalizeTeamFileScope(path);
 }
 
 function pathExists(cwd: string, path: string): boolean {
   return existsSync(`${cwd}/${normalizePath(path)}`);
 }
 
-function inferDomains(node: TeamDagNode): string[] {
-  const domains = new Set(node.domains ?? []);
+function inferSoftDomains(node: TeamDagNode): string[] {
+  const domains = new Set<string>();
   for (const path of node.filePaths ?? []) {
     const normalized = normalizePath(path);
     const first = normalized.split('/')[0];
@@ -104,7 +105,7 @@ function enrichNodeDescription(node: TeamDagNode, cwd: string): string {
     if (existing.length > 0) parts.push(`Existing paths: ${existing.map((file) => relative(cwd, `${cwd}/${file}`)).join(', ')}`);
     if (missing.length > 0) parts.push(`Planned/new paths: ${missing.join(', ')}`);
   }
-  const domains = inferDomains(node);
+  const domains = [...new Set([...(node.domains ?? []), ...inferSoftDomains(node)])];
   if (domains.length > 0) parts.push(`Domains: ${domains.join(', ')}`);
   if (node.lane) parts.push(`Lane: ${node.lane}`);
   if (node.acceptance?.length) parts.push(`Acceptance: ${node.acceptance.join('; ')}`);
@@ -208,16 +209,18 @@ function buildFromDag(input: LegacyTeamExecutionPlanInput, resolution: TeamDagRe
     name: `worker-${index + 1}`,
     role: input.explicitAgentType ? input.agentType : undefined,
   }));
+  const nodeById = new Map(sorted.map((node) => [node.id, node]));
 
   const allocationInput = sorted.map((node) => ({
     subject: node.subject,
-    description: enrichNodeDescription(node, input.cwd),
+    description: node.description,
     role: input.explicitAgentType ? input.agentType : node.role,
     blocked_by: node.depends_on ?? [],
     symbolic_depends_on: node.depends_on ?? [],
     requires_code_change: node.requires_code_change,
     filePaths: node.filePaths,
-    domains: inferDomains(node),
+    domains: node.domains,
+    inferredDomains: inferSoftDomains(node),
     lane: node.lane,
     symbolic_id: node.id,
   }));
@@ -225,8 +228,11 @@ function buildFromDag(input: LegacyTeamExecutionPlanInput, resolution: TeamDagRe
   const allocationReasons: Record<string, string> = {};
   const tasks = allocated.map((task): RepoAwareTask => {
     allocationReasons[task.symbolic_id] = task.allocation_reason;
-    const { blocked_by: _symbolicBlockedBy, ...runtimeTask } = task;
-    return runtimeTask;
+    const { blocked_by: _symbolicBlockedBy, inferredDomains: _inferredDomains, ...runtimeTask } = task;
+    const sourceNode = nodeById.get(task.symbolic_id);
+    return sourceNode
+      ? { ...runtimeTask, description: enrichNodeDescription(sourceNode, input.cwd) }
+      : runtimeTask;
   });
   const nodeDependencies = Object.fromEntries(sorted.map((node) => [node.id, node.depends_on ?? []]));
 

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -3345,7 +3345,7 @@ export async function startTeam(
   task: string,
   agentType: string,
   workerCount: number,
-  tasks: Array<{ subject: string; description: string; affinityDescription?: string; owner?: string; blocked_by?: string[]; depends_on?: string[]; symbolic_depends_on?: string[]; role?: string; delegation?: TeamTask['delegation']; coordination?: TeamTask['coordination']; requires_code_change?: boolean; filePaths?: string[]; domains?: string[]; lane?: string; allocation_reason?: string; symbolic_id?: string }>,
+  tasks: Array<{ subject: string; description: string; affinityDescription?: string; owner?: string; blocked_by?: string[]; depends_on?: string[]; symbolic_depends_on?: string[]; role?: string; delegation?: TeamTask['delegation']; coordination?: TeamTask['coordination']; requires_code_change?: boolean; filePaths?: string[]; domains?: string[]; explicitDomains?: string[]; lane?: string; allocation_reason?: string; symbolic_id?: string }>,
   cwd: string,
   options: TeamStartOptions = {},
 ): Promise<TeamRuntime> {
@@ -3603,6 +3603,7 @@ export async function startTeam(
         requires_code_change: t.requires_code_change,
         filePaths: t.filePaths,
         domains: t.domains,
+        explicitDomains: t.explicitDomains,
         lane: t.lane,
         allocation_reason: t.allocation_reason,
       }, leaderCwd);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -3345,7 +3345,7 @@ export async function startTeam(
   task: string,
   agentType: string,
   workerCount: number,
-  tasks: Array<{ subject: string; description: string; owner?: string; blocked_by?: string[]; depends_on?: string[]; symbolic_depends_on?: string[]; role?: string; delegation?: TeamTask['delegation']; coordination?: TeamTask['coordination']; requires_code_change?: boolean; filePaths?: string[]; domains?: string[]; lane?: string; allocation_reason?: string; symbolic_id?: string }>,
+  tasks: Array<{ subject: string; description: string; affinityDescription?: string; owner?: string; blocked_by?: string[]; depends_on?: string[]; symbolic_depends_on?: string[]; role?: string; delegation?: TeamTask['delegation']; coordination?: TeamTask['coordination']; requires_code_change?: boolean; filePaths?: string[]; domains?: string[]; lane?: string; allocation_reason?: string; symbolic_id?: string }>,
   cwd: string,
   options: TeamStartOptions = {},
 ): Promise<TeamRuntime> {
@@ -3590,6 +3590,7 @@ export async function startTeam(
       const created = await createStateTask(sanitized, {
         subject: t.subject,
         description: t.description,
+        affinityDescription: t.affinityDescription,
         status: 'pending',
         owner: t.owner,
         blocked_by: hasSymbolicDagIdentity ? undefined : t.blocked_by ?? t.depends_on,

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -202,6 +202,7 @@ export interface TeamTask {
   id: string;
   subject: string;
   description: string;
+  affinityDescription?: string;
   status: 'pending' | 'blocked' | 'in_progress' | 'completed' | 'failed';
   requires_code_change?: boolean;
   role?: string; // agent role for this task (e.g., 'executor', 'test-engineer', 'designer')

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -213,6 +213,7 @@ export interface TeamTask {
   depends_on?: string[]; // task IDs
   filePaths?: string[];
   domains?: string[];
+  explicitDomains?: string[];
   lane?: string;
   allocation_reason?: string;
   version?: number;

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -125,6 +125,7 @@ export interface TeamTask {
   depends_on?: string[];
   filePaths?: string[];
   domains?: string[];
+  explicitDomains?: string[];
   lane?: string;
   allocation_reason?: string;
   version?: number;

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -114,6 +114,7 @@ export interface TeamTask {
   id: string;
   subject: string;
   description: string;
+  affinityDescription?: string;
   status: TeamTaskStatus;
   requires_code_change?: boolean;
   role?: string;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -349,7 +349,7 @@ function bindSplitReceiptToPaneCommand(command: string, receipt: string): string
 function runSourceAuthorizedTmux(source: SourcePaneAuthority, effect: string, receipt: string = sourceTransactionReceipt()): string {
   const result = runTmux([
     'if-shell', '-F', '-t', source.paneId, sourceAuthorityPredicate(source),
-    `${effect} \\; display-message -p ${shellQuoteSingle(receipt)}`,
+    `${effect} ; display-message -p ${shellQuoteSingle(receipt)}`,
     "display-message -p ''",
   ]);
   if (!result.ok) throw new Error(`tmux source authority transaction failed: ${result.stderr}`);
@@ -374,7 +374,7 @@ function runSourceAuthorizedSplit(
   const effect = buildEffect(receipt);
   const result = runTmux([
     'if-shell', '-F', '-t', source.paneId, sourceAuthorityPredicate(source),
-    effect.replace("-F '#{pane_id}'", `-F '#{pane_id}\\t${receipt}'`),
+    effect.replace("-F '#{pane_id}'", `-F '#{pane_id}\t${receipt}'`),
     "display-message -p ''",
   ], true);
   if (!result.ok) throw new Error(`tmux source authority transaction failed: ${result.stderr}`);


### PR DESCRIPTION
## Summary
- send literal tmux command-list separators and real tab-delimited split receipts under the existing source-pane authorization transaction
- distribute independent generic Team lanes instead of collapsing them onto `worker-1`, while preserving explicit file-path affinity
- cover real tmux fixture parsing and generic-worker allocation regression

## Validation
- `npm run build`
- `node --test dist/team/__tests__/allocation-policy.test.js dist/team/__tests__/tmux-session.test.js` — 298 passed

The tmux behavior was also reproduced and verified against tmux 3.6 on macOS before adding the fixture coverage.
