### PR TITLE
fix(hooks): make Ultragoal cancellation hook-owned

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -33861,25 +33861,30 @@ PY`,
     }
   });
 
-  it("allows session-scoped omx cancel under active ultragoal conductor while impostors stay blocked", async () => {
+  it("hook-owns session-scoped omx cancel under active ultragoal conductor while impostors stay blocked", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-ultragoal-conductor-cancel-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
       const sessionId = "sess-ultragoal-conductor-cancel";
       const leaderThreadId = "thread-ultragoal-conductor-cancel";
-      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      const sessionDir = join(stateDir, "sessions", sessionId);
+      const ultragoalPath = join(sessionDir, "ultragoal-state.json");
+      await mkdir(sessionDir, { recursive: true });
       await writeJson(join(stateDir, "session.json"), {
         session_id: sessionId,
         native_session_id: leaderThreadId,
       });
       await writeJson(join(stateDir, "subagent-tracking.json"), { schemaVersion: 1, sessions: { [sessionId]: { session_id: sessionId, leader_thread_id: leaderThreadId, threads: { [leaderThreadId]: { thread_id: leaderThreadId, kind: "leader" } } } } });
-      await writeSessionSkillActiveState(stateDir, sessionId, "ultragoal", "planning");
-      await writeJson(join(stateDir, "sessions", sessionId, "ultragoal-state.json"), {
-        active: true,
-        mode: "ultragoal",
-        current_phase: "planning",
-        session_id: sessionId,
-      });
+      const resetUltragoal = async () => {
+        await writeSessionSkillActiveState(stateDir, sessionId, "ultragoal", "planning");
+        await writeJson(ultragoalPath, {
+          active: true,
+          mode: "ultragoal",
+          current_phase: "planning",
+          session_id: sessionId,
+        });
+      };
+      await resetUltragoal();
 
       const bash = (command: string) => dispatchCodexNativeHook({
         hook_event_name: "PreToolUse",
@@ -33890,40 +33895,35 @@ PY`,
         tool_name: "Bash",
         tool_input: { command },
       }, { cwd });
-
-      const workspacePackageCli = realpathSync(resolve(process.cwd(), "dist", "cli", "omx.js"));
-      const trustedPackageBin = join(cwd, "node_modules", ".bin", "omx");
-      await mkdir(dirname(trustedPackageBin), { recursive: true });
-      await symlink(workspacePackageCli, trustedPackageBin);
-      const trustedPackagePath = `${dirname(trustedPackageBin)}:${dirname(process.execPath)}`;
-      const bashTrusted = async (command: string) => {
-        const inheritedPath = process.env.PATH;
-        process.env.PATH = trustedPackagePath;
-        try {
-          return await bash(command);
-        } finally {
-          if (inheritedPath === undefined) delete process.env.PATH;
-          else process.env.PATH = inheritedPath;
-        }
+      const assertHandled = async (command: string, label: string) => {
+        await resetUltragoal();
+        const result = await bash(command);
+        assert.equal(result.outputJson?.decision, "block", label);
+        assert.match(JSON.stringify(result.outputJson), /cancelled_exact_session/, label);
+        assert.equal(JSON.parse(await readFile(ultragoalPath, "utf8")).active, false, label);
       };
 
-      const cleanPositives = await withCleanRunnerNodeEnvironment(async () => ({
-        plain: await bashTrusted("omx cancel"),
-        force: await bashTrusted("omx cancel --force"),
-      }));
-      assert.equal(cleanPositives.plain.outputJson, null);
-      assert.equal(cleanPositives.force.outputJson, null);
-      const inheritedCaPositives = await withCleanRunnerNodeEnvironment(async () => {
-        process.env.NODE_EXTRA_CA_CERTS = "/nonexistent/enterprise-ca.pem";
-        return {
-          plain: await bashTrusted("omx cancel"),
-          force: await bashTrusted("omx cancel --force"),
-        };
+      await withCleanRunnerNodeEnvironment(async () => {
+        await assertHandled("omx cancel", "plain cancellation");
+        await assertHandled("omx cancel --force", "force cancellation");
       });
-      assert.equal(inheritedCaPositives.plain.outputJson, null);
-      assert.equal(inheritedCaPositives.force.outputJson, null);
-      assert.equal((await bash("omx cancel")).outputJson?.decision, "block",
-        "ambient non-package omx resolution is not trusted");
+      for (const [label, envName, envValue] of [
+        ["inherited bash startup file", "BASH_ENV", "/tmp/prelude.sh"],
+        ["imported omx function shadow", "BASH_FUNC_omx%%", "() { printf owned > src/pwned.ts; }"],
+        ["inherited node loader override", "NODE_OPTIONS", "--require=./payload.cjs"],
+        ["inherited openssl config", "OPENSSL_CONF", "/tmp/evil.cnf"],
+        ["inherited dynamic loader preload", "LD_PRELOAD", "/tmp/payload.so"],
+        ["inherited node coverage output", "NODE_V8_COVERAGE", "/tmp/coverage-out"],
+      ] as const) {
+        const previousValue = process.env[envName];
+        process.env[envName] = envValue;
+        try {
+          await assertHandled("omx cancel --force", label);
+        } finally {
+          if (previousValue === undefined) delete process.env[envName];
+          else process.env[envName] = previousValue;
+        }
+      }
 
       for (const [label, command] of [
         ["openssl config injection", "OPENSSL_CONF=/tmp/evil.cnf omx cancel"],
@@ -33935,49 +33935,14 @@ PY`,
         ["carriage-return suffix lookalike", "omx cancel\r"],
         ["unicode nbsp separator", "omx\u00a0cancel"],
       ] as const) {
-        const impostor = await bashTrusted(command);
+        await resetUltragoal();
+        const impostor = await bash(command);
         assert.equal(impostor.outputJson?.decision, "block", label);
+        assert.doesNotMatch(JSON.stringify(impostor.outputJson), /cancelled_exact_session/, label);
+        assert.equal(JSON.parse(await readFile(ultragoalPath, "utf8")).active, true, label);
       }
 
-      for (const [label, envName, envValue] of [
-        ["inherited bash startup file", "BASH_ENV", "/tmp/prelude.sh"],
-        ["imported omx function shadow", "BASH_FUNC_omx%%", "() { printf owned > src/pwned.ts; }"],
-        ["inherited node loader override", "NODE_OPTIONS", "--require=./payload.cjs"],
-        ["inherited openssl config", "OPENSSL_CONF", "/tmp/evil.cnf"],
-        ["inherited dynamic loader preload", "LD_PRELOAD", "/tmp/payload.so"],
-        ["inherited node coverage output", "NODE_V8_COVERAGE", "/tmp/coverage-out"],
-      ] as const) {
-        const previousValue = process.env[envName];
-        process.env[envName] = envValue;
-        const previousCa = process.env.NODE_EXTRA_CA_CERTS;
-        process.env.NODE_EXTRA_CA_CERTS = "/nonexistent/enterprise-ca.pem";
-        try {
-          const poisoned = await bashTrusted("omx cancel");
-          assert.equal(poisoned.outputJson?.decision, "block", `${label} with inherited CA`);
-        } finally {
-          if (previousValue === undefined) delete process.env[envName];
-          else process.env[envName] = previousValue;
-          if (previousCa === undefined) delete process.env.NODE_EXTRA_CA_CERTS;
-          else process.env.NODE_EXTRA_CA_CERTS = previousCa;
-        }
-      }
-
-      const shadowBinDir = join(cwd, "shadow-bin");
-      await mkdir(shadowBinDir, { recursive: true });
-      await writeFile(join(shadowBinDir, "omx"), "#!/bin/sh\ntouch src/path-shadow-owned.ts\n", "utf-8");
-      await chmod(join(shadowBinDir, "omx"), 0o755);
-      {
-        const inheritedPath = process.env.PATH;
-        process.env.PATH = `${shadowBinDir}:${trustedPackagePath}`;
-        try {
-          const shadowed = await bash("omx cancel");
-          assert.equal(shadowed.outputJson?.decision, "block", "PATH-shadowed omx executable");
-        } finally {
-          if (inheritedPath === undefined) delete process.env.PATH;
-          else process.env.PATH = inheritedPath;
-        }
-      }
-
+      await resetUltragoal();
       const stateClear = await bash("omx state clear --force --mode ultragoal --json");
       assert.equal(stateClear.outputJson?.decision, "block");
     } finally {

--- a/src/scripts/__tests__/issue-3293-callsite-parity.test.ts
+++ b/src/scripts/__tests__/issue-3293-callsite-parity.test.ts
@@ -1,5 +1,5 @@
-// Characterization baseline for issue #3293 wave B callsite parity. Only the valid
-// exact-session deep-interview direct-cancel case is expected to change in wave B.
+// Characterization baseline for issue #3293 direct-cancel callsite parity.
+// Issue #3358 extends hook-owned exact-session cancellation to Ultragoal only.
 import assert from "node:assert/strict";
 import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -136,14 +136,17 @@ describe("issue #3293 callsite parity baseline", () => {
 		});
 	}
 
-	for (const [mode, site] of [["ralplan", "~9114"], ["conductor", "~18227"]] as const) {
-		for (const command of ["omx cancel", "omx cancel --force"]) {
-			it(`${mode} ${site}: ${command} falls through to the pre-#3293 executable-trust path`, async () => {
-				const f = await fixture(mode, `${mode}-${command.endsWith("force") ? "force" : "bare"}`);
-				try { await withTrustedOmx(f.cwd, async () => assert.equal((await preToolUse(f, command)).outputJson, null)); }
-				finally { await rm(f.cwd, { recursive: true, force: true }); }
-			});
-		}
+	for (const command of ["omx cancel", "omx cancel --force"]) {
+		it(`ralplan ~9114: ${command} falls through to the pre-#3293 executable-trust path`, async () => {
+			const f = await fixture("ralplan", `ralplan-${command.endsWith("force") ? "force" : "bare"}`);
+			try { await withTrustedOmx(f.cwd, async () => assert.equal((await preToolUse(f, command)).outputJson, null)); }
+			finally { await rm(f.cwd, { recursive: true, force: true }); }
+		});
+		it(`conductor ~18227: ${command} is hook-owned for the exact Ultragoal session`, async () => {
+			const f = await fixture("conductor", `conductor-${command.endsWith("force") ? "force" : "bare"}`);
+			try { assertBlocked(await preToolUse(f, command), /cancelled_exact_session/); }
+			finally { await rm(f.cwd, { recursive: true, force: true }); }
+		});
 	}
 
 
@@ -176,9 +179,9 @@ describe("issue #3293 callsite parity baseline", () => {
 		});
 	}
 
-	it("Conductor ~18419: cancel-shaped command retains its pre-#3293 trust denial when trust is absent", async () => {
+	it("Conductor ~18419: exact cancellation remains reachable when executable trust is absent", async () => {
 		const f = await fixture("conductor", "conductor-detail");
-		try { assertBlocked(await preToolUse(f, "omx cancel"), /direct cancellation execution context is not trusted/); }
+		try { assertBlocked(await preToolUse(f, "omx cancel"), /cancelled_exact_session/); }
 		finally { await rm(f.cwd, { recursive: true, force: true }); }
 	});
 });

--- a/src/scripts/__tests__/issue-3293-cancel-transaction.test.ts
+++ b/src/scripts/__tests__/issue-3293-cancel-transaction.test.ts
@@ -98,6 +98,17 @@ test("denies a pre-existing prepared journal with a value-free recovery reason",
   });
 });
 
+for (const sessionId of [".", "..", "../escape"]) {
+  test(`denies unsafe session id ${JSON.stringify(sessionId)} without mutation`, async () => {
+    await withFixture(async (f) => {
+      const before = [await readFile(f.autopilotPath), await readFile(f.skillPath)];
+      assert.deepEqual(await terminalizeExactAutopilotSessionForHookCancel({ stateDir: f.stateDir, canonicalSessionId: sessionId, cwd: f.cwd, nowIso: NOW }), { ok: false, reason: "invalid_target" });
+      assert.equal(await readHookCancelTransactionRecoveryState({ stateDir: f.stateDir, canonicalSessionId: sessionId }), "invalid_target");
+      assert.deepEqual([await readFile(f.autopilotPath), await readFile(f.skillPath)], before);
+    });
+  });
+}
+
 test("denies a symlinked session directory component", async () => {
   await withFixture(async (f) => {
     const linked = join(f.stateDir, "sessions", "linked-session"); await symlink(f.sessionDir, linked);
@@ -146,7 +157,24 @@ test("denies a missing paired skill-active state without mutation", async () => 
   await withFixture(async (f) => { const before = await readFile(f.autopilotPath); await rm(f.skillPath); assert.deepEqual(await terminalize(f), { ok: false, reason: "preflight_failed" }); assert.deepEqual(await readFile(f.autopilotPath), before); });
 });
 
-for (const boundary of ["journal-fsync", "first-data-write", "second-data-write", "verification", "journal-commit", "unlink", "lock-release"]) {
+test("cleans a lock whose initialization fails before the transaction starts", async () => {
+  await withFixture(async (f) => {
+    const original = [await readFile(f.autopilotPath), await readFile(f.skillPath)];
+    const prior = process.env.OMX_NATIVE_HOOK_TEST_CANCEL_TRANSACTION_FAIL_AFTER;
+    process.env.NODE_ENV = "test";
+    process.env.OMX_NATIVE_HOOK_TEST_CANCEL_TRANSACTION_FAIL_AFTER = "lock-acquire";
+    try {
+      assert.deepEqual(await terminalize(f), { ok: false, reason: "lock_held" });
+    } finally {
+      if (prior === undefined) delete process.env.OMX_NATIVE_HOOK_TEST_CANCEL_TRANSACTION_FAIL_AFTER;
+      else process.env.OMX_NATIVE_HOOK_TEST_CANCEL_TRANSACTION_FAIL_AFTER = prior;
+    }
+    assert.equal(existsSync(join(f.sessionDir, ".hook-cancel.lock")), false);
+    assert.deepEqual([await readFile(f.autopilotPath), await readFile(f.skillPath)], original);
+  });
+});
+
+for (const boundary of ["journal-fsync", "partial-first-data-write", "first-data-write", "partial-second-data-write", "second-data-write", "verification", "journal-commit", "unlink", "lock-release"]) {
   test(`fault injection after ${boundary} never leaves a torn two-file state`, async () => {
     await withFixture(async (f) => {
       const original = [await readFile(f.autopilotPath), await readFile(f.skillPath)];

--- a/src/scripts/__tests__/issue-3358-ultragoal-cancel-lifecycle.test.ts
+++ b/src/scripts/__tests__/issue-3358-ultragoal-cancel-lifecycle.test.ts
@@ -1,0 +1,701 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { dispatchCodexNativeHook, terminalizeExactUltragoalSessionForHookCancel } from "../codex-native-hook.js";
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(value, null, 2));
+}
+
+async function fixture(suffix: string) {
+  const cwd = await mkdtemp(join(tmpdir(), `omx-3358-ultragoal-cancel-${suffix}-`));
+  const stateDir = join(cwd, ".omx", "state");
+  const sessionId = `session-${suffix}`;
+  const threadId = `thread-${suffix}`;
+  const sessionDir = join(stateDir, "sessions", sessionId);
+  await writeJson(join(stateDir, "session.json"), {
+    session_id: sessionId,
+    cwd,
+    leader_thread_id: threadId,
+  });
+  await writeJson(join(stateDir, "subagent-tracking.json"), {
+    schemaVersion: 1,
+    sessions: {
+      [sessionId]: {
+        session_id: sessionId,
+        leader_thread_id: threadId,
+        threads: { [threadId]: { thread_id: threadId, kind: "leader" } },
+      },
+    },
+  });
+  await writeJson(join(sessionDir, "ultragoal-state.json"), {
+    active: true,
+    mode: "ultragoal",
+    current_phase: "planning",
+    session_id: sessionId,
+    workingDirectory: cwd,
+    durable_artifacts: { goals: "preserve", ledger: "preserve" },
+  });
+  await writeJson(join(sessionDir, "skill-active-state.json"), {
+    active: true,
+    skill: "ultragoal",
+    phase: "planning",
+    session_id: sessionId,
+    cwd,
+    active_skills: [
+      { active: true, skill: "ultragoal", phase: "planning", session_id: sessionId, thread_id: threadId, cwd, marker: "cancel" },
+      { active: true, skill: "ralph", phase: "execution", session_id: sessionId, thread_id: threadId, cwd, marker: "keep" },
+      { active: true, skill: "ultragoal", phase: "planning", session_id: sessionId, thread_id: threadId, cwd: join(cwd, "foreign"), marker: "foreign-cwd" },
+    ],
+  });
+  return { cwd, stateDir, sessionId, threadId, sessionDir };
+}
+
+type Fixture = Awaited<ReturnType<typeof fixture>>;
+
+function preTool(f: Fixture, command: string, overrides: Record<string, unknown> = {}) {
+  return dispatchCodexNativeHook({
+    hook_event_name: "PreToolUse",
+    cwd: f.cwd,
+    session_id: f.sessionId,
+    thread_id: f.threadId,
+    agent_id: f.threadId,
+    tool_name: "Bash",
+    tool_use_id: `tool-${Math.random()}`,
+    tool_input: { command },
+    ...overrides,
+  }, { cwd: f.cwd });
+}
+
+function stop(f: Fixture) {
+  return dispatchCodexNativeHook({
+    hook_event_name: "Stop",
+    cwd: f.cwd,
+    session_id: f.sessionId,
+    thread_id: f.threadId,
+  }, { cwd: f.cwd });
+}
+
+async function withEnv<T>(values: Record<string, string | undefined>, run: () => Promise<T>): Promise<T> {
+  const before = new Map(Object.keys(values).map((name) => [name, process.env[name]]));
+  try {
+    for (const [name, value] of Object.entries(values)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+    return await run();
+  } finally {
+    for (const [name, value] of before) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+}
+async function writeSupervisedUltragoal(f: Fixture) {
+  const autopilotPath = join(f.sessionDir, "autopilot-state.json");
+  const ultragoalPath = join(f.sessionDir, "ultragoal-state.json");
+  const skillPath = join(f.sessionDir, "skill-active-state.json");
+  await writeJson(autopilotPath, {
+    active: true,
+    mode: "autopilot",
+    current_phase: "ultragoal",
+    session_id: f.sessionId,
+    marker: "parent",
+  });
+  await writeJson(ultragoalPath, {
+    active: true,
+    mode: "ultragoal",
+    current_phase: "executing",
+    session_id: f.sessionId,
+    marker: "child",
+  });
+  await writeJson(skillPath, {
+    version: 1,
+    active: true,
+    skill: "autopilot",
+    phase: "ultragoal",
+    session_id: f.sessionId,
+    active_skills: [{ skill: "autopilot", phase: "ultragoal", active: true, session_id: f.sessionId }],
+  });
+  return { autopilotPath, ultragoalPath, skillPath };
+}
+
+describe("issue #3358 Ultragoal cancellation lifecycle", () => {
+  for (const command of ["omx cancel", "omx cancel --force"]) {
+    it(`hook-owns exact same-session ${command} even when inherited shell startup is untrusted`, async () => {
+      const f = await fixture(command.endsWith("--force") ? "force" : "plain");
+      try {
+        const otherSessionDir = join(f.stateDir, "sessions", "other-session");
+        await writeJson(join(otherSessionDir, "ultragoal-state.json"), {
+          active: true,
+          mode: "ultragoal",
+          current_phase: "planning",
+          session_id: "other-session",
+          workingDirectory: f.cwd,
+          marker: "other",
+        });
+        await writeJson(join(otherSessionDir, "skill-active-state.json"), {
+          active: true,
+          skill: "ultragoal",
+          phase: "planning",
+          session_id: "other-session",
+          cwd: f.cwd,
+        });
+        const otherBefore = await Promise.all([
+          readFile(join(otherSessionDir, "ultragoal-state.json")),
+          readFile(join(otherSessionDir, "skill-active-state.json")),
+        ]);
+
+        const result = await withEnv({ BASH_ENV: join(f.cwd, "hostile-bash-startup") }, () => preTool(f, command));
+        assert.equal(result.outputJson?.decision, "block");
+        assert.match(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+
+        const ultragoalPath = join(f.sessionDir, "ultragoal-state.json");
+        const skillPath = join(f.sessionDir, "skill-active-state.json");
+        const ultragoal = JSON.parse(await readFile(ultragoalPath, "utf8"));
+        const skill = JSON.parse(await readFile(skillPath, "utf8"));
+        assert.equal(ultragoal.active, false);
+        assert.equal(ultragoal.current_phase, "cancelled");
+        assert.deepEqual(ultragoal.durable_artifacts, { goals: "preserve", ledger: "preserve" });
+        assert.equal(skill.active, true);
+        assert.equal(skill.skill, "ralph");
+        assert.equal(skill.phase, "execution");
+        assert.equal(skill.active_skills[0].active, false);
+        assert.equal(skill.active_skills[0].phase, "cancelled");
+        assert.equal(skill.active_skills[0].marker, "cancel");
+        assert.deepEqual(skill.active_skills[1], {
+          active: true,
+          skill: "ralph",
+          phase: "execution",
+          session_id: f.sessionId,
+          thread_id: f.threadId,
+          cwd: f.cwd,
+          marker: "keep",
+        });
+        assert.deepEqual(skill.active_skills[2], {
+          active: true,
+          skill: "ultragoal",
+          phase: "planning",
+          session_id: f.sessionId,
+          thread_id: f.threadId,
+          cwd: join(f.cwd, "foreign"),
+          marker: "foreign-cwd",
+        });
+        assert.equal(existsSync(join(f.sessionDir, ".hook-cancel-transaction.json")), false);
+        assert.equal(existsSync(join(f.sessionDir, ".hook-cancel.lock")), false);
+        assert.deepEqual(await Promise.all([
+          readFile(join(otherSessionDir, "ultragoal-state.json")),
+          readFile(join(otherSessionDir, "skill-active-state.json")),
+        ]), otherBefore);
+
+        const terminalBytes = await Promise.all([readFile(ultragoalPath), readFile(skillPath)]);
+        assert.equal((await stop(f)).outputJson, null);
+        assert.equal((await stop(f)).outputJson, null);
+        assert.deepEqual(await Promise.all([readFile(ultragoalPath), readFile(skillPath)]), terminalBytes);
+      } finally {
+        await rm(f.cwd, { recursive: true, force: true });
+      }
+    });
+  }
+
+  for (const command of [
+    " BASH_ENV=/tmp/prelude omx cancel --force",
+    "omx cancel --force; true",
+    " omx cancel --force ",
+  ]) {
+    it(`rejects non-exact cancellation grammar without terminalizing: ${JSON.stringify(command)}`, async () => {
+      const f = await fixture(`grammar-${command.length}`);
+      try {
+        const before = await Promise.all([
+          readFile(join(f.sessionDir, "ultragoal-state.json")),
+          readFile(join(f.sessionDir, "skill-active-state.json")),
+        ]);
+        const result = await preTool(f, command);
+        assert.equal(result.outputJson?.decision, "block");
+        assert.doesNotMatch(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+        assert.deepEqual(await Promise.all([
+          readFile(join(f.sessionDir, "ultragoal-state.json")),
+          readFile(join(f.sessionDir, "skill-active-state.json")),
+        ]), before);
+      } finally {
+        await rm(f.cwd, { recursive: true, force: true });
+      }
+    });
+  }
+
+  for (const command of ["omx cancel", "omx cancel --force"]) {
+    it(`accepts affirmative alternate lifecycle identity aliases for ${command}`, async () => {
+      const f = await fixture(`aliases-${command.endsWith("--force") ? "force" : "plain"}`);
+      try {
+        const ultragoalPath = join(f.sessionDir, "ultragoal-state.json");
+        const skillPath = join(f.sessionDir, "skill-active-state.json");
+        const state = JSON.parse(await readFile(ultragoalPath, "utf8"));
+        state.sessionId = state.session_id;
+        delete state.session_id;
+        state.cwd = state.workingDirectory;
+        delete state.workingDirectory;
+        const skill = JSON.parse(await readFile(skillPath, "utf8"));
+        skill.sessionId = skill.session_id;
+        delete skill.session_id;
+        skill.workingDirectory = skill.cwd;
+        delete skill.cwd;
+        skill.active_skills[0].sessionId = skill.active_skills[0].session_id;
+        delete skill.active_skills[0].session_id;
+        skill.active_skills[0].workingDirectory = skill.active_skills[0].cwd;
+        delete skill.active_skills[0].cwd;
+        await writeJson(ultragoalPath, state);
+        await writeJson(skillPath, skill);
+        const result = await preTool(f, command);
+        assert.match(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+        assert.equal(JSON.parse(await readFile(ultragoalPath, "utf8")).active, false);
+      } finally {
+        await rm(f.cwd, { recursive: true, force: true });
+      }
+    });
+
+    it(`accepts canonical generated lifecycle state without cwd aliases for ${command}`, async () => {
+      const f = await fixture(`canonical-no-cwd-${command.endsWith("--force") ? "force" : "plain"}`);
+      try {
+        const ultragoalPath = join(f.sessionDir, "ultragoal-state.json");
+        const skillPath = join(f.sessionDir, "skill-active-state.json");
+        const state = JSON.parse(await readFile(ultragoalPath, "utf8"));
+        delete state.workingDirectory;
+        const skill = JSON.parse(await readFile(skillPath, "utf8"));
+        delete skill.cwd;
+        delete skill.active_skills[0].cwd;
+        await writeJson(ultragoalPath, state);
+        await writeJson(skillPath, skill);
+        const result = await preTool(f, command);
+        assert.match(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+        assert.equal(JSON.parse(await readFile(ultragoalPath, "utf8")).active, false);
+      } finally {
+        await rm(f.cwd, { recursive: true, force: true });
+      }
+    });
+
+    for (const missingIdentity of [
+      "workflow-session",
+      "skill-state",
+      "skill-target-session",
+    ] as const) {
+      it(`rejects ${missingIdentity} identity without mutation for ${command}`, async () => {
+        const f = await fixture(`missing-${missingIdentity}-${command.endsWith("--force") ? "force" : "plain"}`);
+        try {
+          const ultragoalPath = join(f.sessionDir, "ultragoal-state.json");
+          const skillPath = join(f.sessionDir, "skill-active-state.json");
+          const state = JSON.parse(await readFile(ultragoalPath, "utf8"));
+          const skill = JSON.parse(await readFile(skillPath, "utf8"));
+          if (missingIdentity === "workflow-session") delete state.session_id;
+          if (missingIdentity === "skill-state") {
+            delete skill.session_id;
+            delete skill.cwd;
+          }
+          if (missingIdentity === "skill-target-session") delete skill.active_skills[0].session_id;
+          await writeJson(ultragoalPath, state);
+          await writeJson(skillPath, skill);
+          const before = await Promise.all([readFile(ultragoalPath), readFile(skillPath)]);
+          const result = await preTool(f, command);
+          assert.doesNotMatch(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+          assert.deepEqual(await Promise.all([readFile(ultragoalPath), readFile(skillPath)]), before);
+        } finally {
+          await rm(f.cwd, { recursive: true, force: true });
+        }
+      });
+    }
+  }
+
+  for (const command of ["omx cancel", "omx cancel --force"]) {
+    it(`supports canonical Windows Ultragoal cancellation for ${command}`, async () => {
+      const f = await fixture(`windows-${command.endsWith("--force") ? "force" : "plain"}`);
+      try {
+        const ultragoalPath = join(f.sessionDir, "ultragoal-state.json");
+        const skillPath = join(f.sessionDir, "skill-active-state.json");
+        const state = JSON.parse(await readFile(ultragoalPath, "utf8"));
+        delete state.workingDirectory;
+        const skill = JSON.parse(await readFile(skillPath, "utf8"));
+        delete skill.cwd;
+        delete skill.active_skills[0].cwd;
+        await writeJson(ultragoalPath, state);
+        await writeJson(skillPath, skill);
+        const result = await withEnv({ NODE_ENV: "test", OMX_NATIVE_HOOK_TEST_PLATFORM: "win32" }, () => preTool(f, command));
+        assert.match(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+        assert.equal(JSON.parse(await readFile(ultragoalPath, "utf8")).active, false);
+      } finally {
+        await rm(f.cwd, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it("denies foreign Windows lifecycle identity without mutation", async () => {
+    const f = await fixture("windows-foreign");
+    try {
+      const ultragoalPath = join(f.sessionDir, "ultragoal-state.json");
+      const skillPath = join(f.sessionDir, "skill-active-state.json");
+      const state = JSON.parse(await readFile(ultragoalPath, "utf8"));
+      state.session_id = "foreign-session";
+      await writeJson(ultragoalPath, state);
+      const before = await Promise.all([readFile(ultragoalPath), readFile(skillPath)]);
+      const result = await withEnv({ NODE_ENV: "test", OMX_NATIVE_HOOK_TEST_PLATFORM: "win32" }, () => preTool(f, "omx cancel --force"));
+      assert.equal(result.outputJson?.decision, "block");
+      assert.doesNotMatch(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+      assert.deepEqual(await Promise.all([readFile(ultragoalPath), readFile(skillPath)]), before);
+    } finally {
+      await rm(f.cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("denies a Windows reparse-style target without touching its destination", async () => {
+    const f = await fixture("windows-reparse");
+    try {
+      const ultragoalPath = join(f.sessionDir, "ultragoal-state.json");
+      const outsidePath = join(f.cwd, "outside-ultragoal-state.json");
+      await writeJson(outsidePath, {
+        active: true,
+        mode: "ultragoal",
+        current_phase: "planning",
+        session_id: f.sessionId,
+        workingDirectory: f.cwd,
+        marker: "outside",
+      });
+      const outsideBefore = await readFile(outsidePath);
+      await rm(ultragoalPath);
+      await symlink(outsidePath, ultragoalPath, "file");
+      const result = await withEnv({ NODE_ENV: "test", OMX_NATIVE_HOOK_TEST_PLATFORM: "win32" }, () => preTool(f, "omx cancel --force"));
+      assert.equal(result.outputJson?.decision, "block");
+      assert.doesNotMatch(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+      assert.deepEqual(await readFile(outsidePath), outsideBefore);
+    } finally {
+      await rm(f.cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("denies Windows target substitution detected during pinned preflight", async () => {
+    const f = await fixture("windows-substitution");
+    try {
+      const paths = [
+        join(f.sessionDir, "ultragoal-state.json"),
+        join(f.sessionDir, "skill-active-state.json"),
+      ];
+      const before = await Promise.all(paths.map((path) => readFile(path)));
+      const result = await withEnv({
+        NODE_ENV: "test",
+        OMX_NATIVE_HOOK_TEST_PLATFORM: "win32",
+        OMX_NATIVE_HOOK_TEST_CANCEL_TRANSACTION_FAIL_AFTER: "preflight-instability",
+      }, () => preTool(f, "omx cancel --force"));
+      assert.equal(result.outputJson?.decision, "block");
+      assert.doesNotMatch(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+      assert.deepEqual(await Promise.all(paths.map((path) => readFile(path))), before);
+    } finally {
+      await rm(f.cwd, { recursive: true, force: true });
+    }
+  });
+
+  for (const strictMissingCwd of ["workflow", "skill"] as const) {
+    it(`keeps the exported transaction helper strict when ${strictMissingCwd} cwd identity is missing`, async () => {
+      const f = await fixture(`strict-${strictMissingCwd}-cwd`);
+      try {
+        const ultragoalPath = join(f.sessionDir, "ultragoal-state.json");
+        const skillPath = join(f.sessionDir, "skill-active-state.json");
+        if (strictMissingCwd === "workflow") {
+          const state = JSON.parse(await readFile(ultragoalPath, "utf8"));
+          delete state.workingDirectory;
+          await writeJson(ultragoalPath, state);
+        } else {
+          const skill = JSON.parse(await readFile(skillPath, "utf8"));
+          delete skill.cwd;
+          delete skill.active_skills[0].cwd;
+          await writeJson(skillPath, skill);
+        }
+        const before = await Promise.all([readFile(ultragoalPath), readFile(skillPath)]);
+        assert.deepEqual(await terminalizeExactUltragoalSessionForHookCancel({
+          stateDir: f.stateDir,
+          canonicalSessionId: f.sessionId,
+          cwd: f.cwd,
+          nowIso: "2026-07-29T00:00:00.000Z",
+        }), { ok: false, reason: "state_mismatch" });
+        assert.deepEqual(await Promise.all([readFile(ultragoalPath), readFile(skillPath)]), before);
+      } finally {
+        await rm(f.cwd, { recursive: true, force: true });
+      }
+    });
+  }
+
+  for (const command of ["omx cancel", "omx cancel --force"]) {
+    it(`cancels canonical Autopilot-supervised Ultragoal parent, child, and mirror for ${command}`, async () => {
+      const f = await fixture(`supervised-${command.endsWith("--force") ? "force" : "plain"}`);
+      try {
+        const paths = await writeSupervisedUltragoal(f);
+        const result = await preTool(f, command);
+        assert.match(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+        const autopilot = JSON.parse(await readFile(paths.autopilotPath, "utf8"));
+        const ultragoal = JSON.parse(await readFile(paths.ultragoalPath, "utf8"));
+        const skill = JSON.parse(await readFile(paths.skillPath, "utf8"));
+        assert.equal(autopilot.active, false);
+        assert.equal(autopilot.current_phase, "cancelled");
+        assert.equal(autopilot.marker, "parent");
+        assert.equal(ultragoal.active, false);
+        assert.equal(ultragoal.current_phase, "cancelled");
+        assert.equal(ultragoal.marker, "child");
+        assert.equal(skill.active, false);
+        assert.equal(skill.skill, "autopilot");
+        assert.equal(skill.phase, "cancelled");
+        assert.equal(skill.active_skills[0].active, false);
+        assert.equal(skill.active_skills[0].phase, "cancelled");
+      } finally {
+        await rm(f.cwd, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it("rejects a conflicting supervised parent cwd alias without mutation", async () => {
+    const f = await fixture("supervised-parent-cwd-conflict");
+    try {
+      const paths = await writeSupervisedUltragoal(f);
+      const parent = JSON.parse(await readFile(paths.autopilotPath, "utf8"));
+      parent.cwd = f.cwd;
+      parent.workingDirectory = join(f.cwd, "foreign");
+      await writeJson(paths.autopilotPath, parent);
+      const statePaths = [paths.autopilotPath, paths.ultragoalPath, paths.skillPath];
+      const before = await Promise.all(statePaths.map((path) => readFile(path)));
+      const result = await preTool(f, "omx cancel --force");
+      assert.doesNotMatch(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+      assert.deepEqual(await Promise.all(statePaths.map((path) => readFile(path))), before);
+    } finally {
+      await rm(f.cwd, { recursive: true, force: true });
+    }
+  });
+
+  for (const boundary of [
+    "journal-fsync",
+    "partial-parent-data-write",
+    "parent-data-write",
+    "partial-first-data-write",
+    "first-data-write",
+    "partial-second-data-write",
+    "second-data-write",
+    "verification",
+    "journal-commit",
+    "unlink",
+    "lock-release",
+  ]) {
+    it(`keeps supervised parent, child, and mirror transactionally aligned after ${boundary}`, async () => {
+      const f = await fixture(`supervised-fault-${boundary}`);
+      try {
+        const paths = await writeSupervisedUltragoal(f);
+        const statePaths = [paths.autopilotPath, paths.ultragoalPath, paths.skillPath];
+        const before = await Promise.all(statePaths.map((path) => readFile(path)));
+        await withEnv({ NODE_ENV: "test", OMX_NATIVE_HOOK_TEST_CANCEL_TRANSACTION_FAIL_AFTER: boundary }, () => preTool(f, "omx cancel --force"));
+        const after = await Promise.all(statePaths.map((path) => readFile(path)));
+        const changed = after.map((bytes, index) => !bytes.equals(before[index]));
+        assert.ok(changed.every((value) => value === changed[0]), boundary);
+        if (changed[0]) {
+          for (const bytes of after) {
+            const state = JSON.parse(bytes.toString("utf8"));
+            assert.equal(state.active, false, boundary);
+            assert.equal(state.current_phase ?? state.phase, "cancelled", boundary);
+          }
+        }
+        const journalPath = join(f.sessionDir, ".hook-cancel-transaction.json");
+        if (boundary === "journal-fsync") {
+          const journal = JSON.parse(await readFile(journalPath, "utf8"));
+          assert.ok(journal.targets.parent_autopilot);
+          assert.ok(journal.targets.workflow_state);
+          assert.ok(journal.targets.skill_active);
+        }
+        assert.equal(existsSync(join(f.sessionDir, ".hook-cancel.lock")), false);
+      } finally {
+        await rm(f.cwd, { recursive: true, force: true });
+      }
+    });
+  }
+
+  for (const scenario of [
+    "terminal-phase",
+    "completing-phase",
+    "foreign-cwd",
+    "conflicting-cwd-aliases",
+    "conflicting-skill-cwd-aliases",
+    "conflicting-session-aliases",
+    "malformed-cwd-alias",
+    "malformed-session-alias",
+    "malformed-skill-active",
+  ] as const) {
+    it(`does not hook-own ${scenario} Ultragoal lifecycle state`, async () => {
+      const f = await fixture(scenario);
+      try {
+        const ultragoalPath = join(f.sessionDir, "ultragoal-state.json");
+        const skillPath = join(f.sessionDir, "skill-active-state.json");
+        const state = JSON.parse(await readFile(ultragoalPath, "utf8"));
+        const skill = JSON.parse(await readFile(skillPath, "utf8"));
+        if (scenario === "terminal-phase") state.current_phase = "complete";
+        if (scenario === "completing-phase") state.current_phase = "completing";
+        if (scenario === "foreign-cwd") state.workingDirectory = join(f.cwd, "foreign");
+        if (scenario === "conflicting-cwd-aliases") {
+          state.cwd = f.cwd;
+          state.workingDirectory = join(f.cwd, "foreign");
+        }
+        if (scenario === "conflicting-session-aliases") state.sessionId = "other-session";
+        if (scenario === "malformed-cwd-alias") state.cwd = 42;
+        if (scenario === "malformed-session-alias") state.sessionId = 42;
+        if (scenario === "conflicting-skill-cwd-aliases") {
+          skill.cwd = f.cwd;
+          skill.workingDirectory = join(f.cwd, "foreign");
+        }
+        if (scenario === "malformed-skill-active") skill.active_skills[0].active = "false";
+        await writeJson(ultragoalPath, state);
+        await writeJson(skillPath, skill);
+        const before = await Promise.all([readFile(ultragoalPath), readFile(skillPath)]);
+        const result = await preTool(f, "omx cancel --force");
+        assert.doesNotMatch(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+        assert.deepEqual(await Promise.all([readFile(ultragoalPath), readFile(skillPath)]), before);
+      } finally {
+        await rm(f.cwd, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it("prefers active Ultragoal over simultaneous stale Autopilot state", async () => {
+    const f = await fixture("ultragoal-priority");
+    try {
+      const autopilotPath = join(f.sessionDir, "autopilot-state.json");
+      await writeJson(autopilotPath, {
+        active: true,
+        mode: "autopilot",
+        current_phase: "deep-interview",
+        session_id: f.sessionId,
+        workingDirectory: f.cwd,
+        marker: "preserve",
+      });
+      const autopilotBefore = await readFile(autopilotPath);
+      const result = await preTool(f, "omx cancel");
+      assert.match(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+      assert.equal(JSON.parse(await readFile(join(f.sessionDir, "ultragoal-state.json"), "utf8")).active, false);
+      assert.deepEqual(await readFile(autopilotPath), autopilotBefore);
+    } finally {
+      await rm(f.cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers active canonical Autopilot deep-interview over stale terminal Ultragoal state", async () => {
+    const f = await fixture("stale-terminal-ultragoal");
+    try {
+      const ultragoalPath = join(f.sessionDir, "ultragoal-state.json");
+      const autopilotPath = join(f.sessionDir, "autopilot-state.json");
+      const skillPath = join(f.sessionDir, "skill-active-state.json");
+      await writeJson(ultragoalPath, {
+        active: false,
+        mode: "ultragoal",
+        current_phase: "completed",
+        session_id: f.sessionId,
+        marker: "stale-child",
+      });
+      await writeJson(autopilotPath, {
+        active: true,
+        mode: "autopilot",
+        current_phase: "deep-interview",
+        session_id: f.sessionId,
+        marker: "active-parent",
+      });
+      await writeJson(skillPath, {
+        active: true,
+        skill: "autopilot",
+        phase: "deep-interview",
+        session_id: f.sessionId,
+        active_skills: [{ active: true, skill: "autopilot", phase: "deep-interview", session_id: f.sessionId }],
+      });
+      const staleUltragoal = await readFile(ultragoalPath);
+      const result = await preTool(f, "omx cancel");
+      assert.match(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+      assert.deepEqual(await readFile(ultragoalPath), staleUltragoal);
+      const autopilot = JSON.parse(await readFile(autopilotPath, "utf8"));
+      const skill = JSON.parse(await readFile(skillPath, "utf8"));
+      assert.equal(autopilot.active, false);
+      assert.equal(autopilot.current_phase, "cancelled");
+      assert.equal(skill.active, false);
+      assert.equal(skill.phase, "cancelled");
+    } finally {
+      await rm(f.cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("denies Autopilot fallback when an active Ultragoal lifecycle has a mismatched mirror", async () => {
+    const f = await fixture("active-ultragoal-mirror-mismatch");
+    try {
+      const autopilotPath = join(f.sessionDir, "autopilot-state.json");
+      const ultragoalPath = join(f.sessionDir, "ultragoal-state.json");
+      const skillPath = join(f.sessionDir, "skill-active-state.json");
+      await writeJson(autopilotPath, {
+        active: true,
+        mode: "autopilot",
+        current_phase: "deep-interview",
+        session_id: f.sessionId,
+      });
+      await writeJson(skillPath, {
+        active: true,
+        skill: "autopilot",
+        phase: "deep-interview",
+        session_id: f.sessionId,
+        active_skills: [{ active: true, skill: "autopilot", phase: "deep-interview", session_id: f.sessionId }],
+      });
+      const paths = [autopilotPath, ultragoalPath, skillPath];
+      const before = await Promise.all(paths.map((path) => readFile(path)));
+      const result = await preTool(f, "omx cancel");
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /active_state/);
+      assert.deepEqual(await Promise.all(paths.map((path) => readFile(path))), before);
+    } finally {
+      await rm(f.cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a malformed payload session alias without terminalizing", async () => {
+    const f = await fixture("malformed-payload-session");
+    try {
+      const paths = [
+        join(f.sessionDir, "ultragoal-state.json"),
+        join(f.sessionDir, "skill-active-state.json"),
+      ];
+      const before = await Promise.all(paths.map((path) => readFile(path)));
+      const result = await preTool(f, "omx cancel --force", { sessionId: 42 });
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /session_binding/);
+      assert.deepEqual(await Promise.all(paths.map((path) => readFile(path))), before);
+    } finally {
+      await rm(f.cwd, { recursive: true, force: true });
+    }
+  });
+  it("rejects native-child cancellation authority without terminalizing the owner session", async () => {
+    const f = await fixture("native-child");
+    try {
+      const paths = [
+        join(f.sessionDir, "ultragoal-state.json"),
+        join(f.sessionDir, "skill-active-state.json"),
+      ];
+      const before = await Promise.all(paths.map((path) => readFile(path)));
+      for (const overrides of [
+        {
+          thread_id: "child-thread",
+          agent_id: "child-thread",
+          is_subagent: true,
+          parent_session_id: f.sessionId,
+        },
+        {
+          thread_id: f.threadId,
+          agent_id: f.threadId,
+          source: { subagent: { thread_spawn: { parent_thread_id: f.threadId } } },
+        },
+      ]) {
+        const result = await preTool(f, "omx cancel --force", overrides);
+        assert.equal(result.outputJson?.decision, "block");
+        assert.match(JSON.stringify(result.outputJson), /actor_authority/);
+        assert.deepEqual(await Promise.all(paths.map((path) => readFile(path))), before);
+      }
+    } finally {
+      await rm(f.cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -39,6 +39,7 @@ import {
   resolveWorkerTeamStateRootPath,
 } from "../team/state-root.js";
 import { inferTerminalLifecycleOutcome } from "../runtime/run-outcome.js";
+import { syncRegularFile } from "../utils/file-durability.js";
 import {
   appendPromptSessionProvenanceRejection,
   appendToLog,
@@ -3895,36 +3896,129 @@ function hookCancelObject(bytes: Buffer): Record<string, unknown> | null {
   try { const value = JSON.parse(bytes.toString("utf8")); return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null; } catch { return null; }
 }
 function hookCancelString(value: unknown): string { return typeof value === "string" ? value.trim() : ""; }
-function hookCancelCwdMatches(value: Record<string, unknown>, canonicalCwd: string): boolean {
-  const recorded = hookCancelString(value.cwd) || hookCancelString(value.workingDirectory);
-  try { return !recorded || sameFilePath(recorded, canonicalCwd); } catch { return false; }
+type HookCancelIdentityPolicy = {
+  allowMissingCwd: boolean;
+  allowSupervisedAutopilotMirror: boolean;
+};
+const STRICT_HOOK_CANCEL_IDENTITY: HookCancelIdentityPolicy = {
+  allowMissingCwd: false,
+  allowSupervisedAutopilotMirror: false,
+};
+const AUTHENTICATED_HOOK_CANCEL_IDENTITY: HookCancelIdentityPolicy = {
+  allowMissingCwd: true,
+  allowSupervisedAutopilotMirror: true,
+};
+function hookCancelRequiredStringAliasesMatch(
+  value: Record<string, unknown>,
+  aliases: readonly string[],
+  matches: (candidate: string) => boolean,
+  allowMissing = false,
+): boolean {
+  let found = false;
+  for (const alias of aliases) {
+    if (!Object.prototype.hasOwnProperty.call(value, alias)) continue;
+    const raw = value[alias];
+    if (typeof raw !== "string" || raw.trim() === "") return false;
+    found = true;
+    if (!matches(raw.trim())) return false;
+  }
+  return found || allowMissing;
 }
-function hookCancelSessionMatches(value: Record<string, unknown>, sessionId: string, cwd: string): boolean {
-  const recorded = hookCancelString(value.session_id);
-  return (!recorded || recorded === sessionId) && hookCancelCwdMatches(value, cwd);
+function hookCancelCwdMatches(value: Record<string, unknown>, canonicalCwd: string, policy = STRICT_HOOK_CANCEL_IDENTITY): boolean {
+  try {
+    return hookCancelRequiredStringAliasesMatch(
+      value,
+      ["cwd", "workingDirectory"],
+      (candidate) => sameFilePath(candidate, canonicalCwd),
+      policy.allowMissingCwd,
+    );
+  } catch { return false; }
 }
-function hookCancelAutopilotMatches(value: Record<string, unknown>, sessionId: string, cwd: string): boolean {
-  return value.active === true && hookCancelString(value.mode).toLowerCase() === "autopilot" && normalizeAutopilotPhase(hookCancelString(value.current_phase)) === "deep-interview" && hookCancelSessionMatches(value, sessionId, cwd);
+function hookCancelSessionMatches(value: Record<string, unknown>, sessionId: string, cwd: string, policy = STRICT_HOOK_CANCEL_IDENTITY): boolean {
+  return hookCancelRequiredStringAliasesMatch(value, ["session_id", "sessionId"], (candidate) => candidate === sessionId)
+    && hookCancelCwdMatches(value, cwd, policy);
 }
-function hookCancelSkillMatches(value: Record<string, unknown>, sessionId: string, cwd: string): boolean {
-  if (!hookCancelSessionMatches(value, sessionId, cwd)) return false;
+function hookCancelAutopilotIsActive(value: Record<string, unknown>): boolean {
+  return value.active === true
+    && hookCancelString(value.mode).toLowerCase() === "autopilot"
+    && normalizeAutopilotPhase(hookCancelString(value.current_phase)) === "deep-interview";
+}
+function hookCancelAutopilotMatches(value: Record<string, unknown>, sessionId: string, cwd: string, policy = STRICT_HOOK_CANCEL_IDENTITY): boolean {
+  return hookCancelAutopilotIsActive(value) && hookCancelSessionMatches(value, sessionId, cwd, policy);
+}
+function hookCancelSupervisingAutopilotMatches(value: Record<string, unknown>, sessionId: string, cwd: string, policy: HookCancelIdentityPolicy): boolean {
+  return value.active === true
+    && hookCancelString(value.mode).toLowerCase() === "autopilot"
+    && normalizeAutopilotPhase(hookCancelString(value.current_phase)) === "ultragoal"
+    && hookCancelSessionMatches(value, sessionId, cwd, policy);
+}
+function hookCancelUltragoalIsActive(value: Record<string, unknown>): boolean {
+  const phase = hookCancelString(value.current_phase).toLowerCase();
+  return value.active === true
+    && hookCancelString(value.mode).toLowerCase() === "ultragoal"
+    && phase !== "completing"
+    && isNonTerminalPhase(phase);
+}
+function hookCancelUltragoalMatches(value: Record<string, unknown>, sessionId: string, cwd: string, policy = STRICT_HOOK_CANCEL_IDENTITY): boolean {
+  return hookCancelUltragoalIsActive(value) && hookCancelSessionMatches(value, sessionId, cwd, policy);
+}
+function hookCancelSkillEntryIsActive(value: unknown): boolean {
+  return value === undefined || value === true;
+}
+function hookCancelSkillEntryMatches(entry: Record<string, unknown>, workflow: HookCancelWorkflow, policy: HookCancelIdentityPolicy): boolean {
+  const skill = hookCancelString(entry.skill).toLowerCase();
+  return skill === workflow
+    || (policy.allowSupervisedAutopilotMirror
+      && workflow === "ultragoal"
+      && skill === "autopilot"
+      && hookCancelString(entry.phase).toLowerCase() === "ultragoal");
+}
+function hookCancelUsesSupervisedAutopilotMirror(value: Record<string, unknown>, sessionId: string, cwd: string, policy: HookCancelIdentityPolicy): boolean {
+  if (!policy.allowSupervisedAutopilotMirror
+    || !hookCancelSkillEntryIsActive(value.active)
+    || hookCancelString(value.skill).toLowerCase() !== "autopilot"
+    || hookCancelString(value.phase).toLowerCase() !== "ultragoal"
+    || !hookCancelSessionMatches(value, sessionId, cwd, policy)) return false;
   const entries = Array.isArray(value.active_skills) ? value.active_skills : [value];
   return entries.some((candidate) => {
     if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return false;
     const entry = candidate as Record<string, unknown>;
     return hookCancelString(entry.skill).toLowerCase() === "autopilot"
-      && entry.active !== false
-      && (!hookCancelString(entry.session_id) || hookCancelString(entry.session_id) === sessionId)
-      && hookCancelCwdMatches(entry, cwd);
+      && hookCancelString(entry.phase).toLowerCase() === "ultragoal"
+      && hookCancelSkillEntryIsActive(entry.active)
+      && hookCancelSessionMatches(entry, sessionId, cwd, policy);
   });
 }
+function hookCancelSkillMatches(value: Record<string, unknown>, workflow: HookCancelWorkflow, sessionId: string, cwd: string, policy = STRICT_HOOK_CANCEL_IDENTITY): boolean {
+  if (!hookCancelSkillEntryIsActive(value.active) || !hookCancelSessionMatches(value, sessionId, cwd, policy)) return false;
+  const entries = Array.isArray(value.active_skills) ? value.active_skills : [value];
+  return entries.some((candidate) => {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return false;
+    const entry = candidate as Record<string, unknown>;
+    return hookCancelSkillEntryMatches(entry, workflow, policy)
+      && hookCancelSkillEntryIsActive(entry.active)
+      && hookCancelSessionMatches(entry, sessionId, cwd, policy);
+  });
+}
+function hookCancelPlatform(): NodeJS.Platform {
+  const testPlatform = process.env.NODE_ENV === "test" ? process.env.OMX_NATIVE_HOOK_TEST_PLATFORM : undefined;
+  return testPlatform === "win32" ? "win32" : process.platform;
+}
+function hookCancelOwnerMatches(stat: Awaited<ReturnType<typeof lstat>>): boolean {
+  // Windows exposes no uid. The authenticated canonical session path, ACL-gated
+  // open, single-link regular-file shape, and lstat/open identity checks below
+  // form the platform ownership proof instead of silently disabling the path.
+  if (hookCancelPlatform() === "win32") return true;
+  return typeof process.getuid === "function" && stat.uid === process.getuid();
+}
 async function hookCancelFsyncDirectory(path: string): Promise<void> {
+  if (hookCancelPlatform() === "win32") return;
   const handle = await open(path, "r"); try { await handle.sync(); } finally { await handle.close(); }
 }
 async function hookCancelPinnedRead(path: string): Promise<HookCancelPinnedFile | null> {
   let before: Awaited<ReturnType<typeof lstat>>;
   try { before = await lstat(path); } catch { return null; }
-  if (!before.isFile() || before.isSymbolicLink() || before.nlink !== 1 || before.uid !== process.getuid?.()) return null;
+  if (!before.isFile() || before.isSymbolicLink() || before.nlink !== 1 || !hookCancelOwnerMatches(before)) return null;
   let handle: Awaited<ReturnType<typeof open>>;
   try { handle = await open(path, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW); } catch { return null; }
   try {
@@ -3936,44 +4030,80 @@ async function hookCancelPinnedRead(path: string): Promise<HookCancelPinnedFile 
     const value = hookCancelObject(bytes); return value ? { path, bytes, identity: hookCancelIdentity(after), value } : null;
   } catch { return null; } finally { await handle.close(); }
 }
-function hookCancelPreparedAutopilot(value: Record<string, unknown>, nowIso: string): Record<string, unknown> {
+function hookCancelPreparedWorkflow(value: Record<string, unknown>, nowIso: string): Record<string, unknown> {
   return { ...value, active: false, current_phase: "cancelled", completed_at: nowIso, last_turn_at: nowIso };
 }
-function hookCancelPreparedSkill(value: Record<string, unknown>, sessionId: string, nowIso: string): Record<string, unknown> {
+function hookCancelPreparedSkill(value: Record<string, unknown>, workflow: HookCancelWorkflow, sessionId: string, cwd: string, nowIso: string, policy = STRICT_HOOK_CANCEL_IDENTITY): Record<string, unknown> {
   const sourceEntries = Array.isArray(value.active_skills) ? value.active_skills : [value]; let cancelled = false;
   const entries = sourceEntries.map((candidate) => {
     if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return candidate;
     const entry = candidate as Record<string, unknown>;
-    const matches = hookCancelString(entry.skill).toLowerCase() === "autopilot"
-      && entry.active !== false
-      && (!hookCancelString(entry.session_id) || hookCancelString(entry.session_id) === sessionId);
+    const matches = hookCancelSkillEntryMatches(entry, workflow, policy)
+      && hookCancelSkillEntryIsActive(entry.active)
+      && hookCancelSessionMatches(entry, sessionId, cwd, policy);
     if (!matches) return entry; cancelled = true; return { ...entry, active: false, phase: "cancelled", updated_at: nowIso };
   });
   if (!cancelled) return value;
-  const activeEntries = entries.filter((entry) => entry && typeof entry === "object" && !Array.isArray(entry) && (entry as Record<string, unknown>).active !== false) as Record<string, unknown>[];
+  const activeEntries = entries.filter((entry) => entry && typeof entry === "object" && !Array.isArray(entry) && hookCancelSkillEntryIsActive((entry as Record<string, unknown>).active)) as Record<string, unknown>[];
   const primary = activeEntries[0];
-  return { ...value, active: activeEntries.length > 0, skill: primary ? hookCancelString(primary.skill) : "autopilot", phase: primary ? hookCancelString(primary.phase) : "cancelled", updated_at: nowIso, active_skills: entries };
+  const terminalSkill = hookCancelString(value.skill).toLowerCase() || workflow;
+  return { ...value, active: activeEntries.length > 0, skill: primary ? hookCancelString(primary.skill) : terminalSkill, phase: primary ? hookCancelString(primary.phase) : "cancelled", updated_at: nowIso, active_skills: entries };
 }
 function hookCancelInjectFailure(boundary: string): void {
   if (process.env.NODE_ENV === "test" && process.env.OMX_NATIVE_HOOK_TEST_CANCEL_TRANSACTION_FAIL_AFTER === boundary) throw new Error("test-induced hook cancellation transaction failure");
 }
-async function hookCancelWriteExact(handle: Awaited<ReturnType<typeof open>>, bytes: Buffer): Promise<void> { await handle.write(bytes, 0, bytes.length, 0); await handle.truncate(bytes.length); await handle.sync(); }
-async function hookCancelWriteTarget(path: string, identity: HookCancelTargetIdentity, expected: Buffer, next: Buffer): Promise<void> {
+async function hookCancelWriteExact(handle: Awaited<ReturnType<typeof open>>, bytes: Buffer): Promise<void> {
+  let offset = 0;
+  while (offset < bytes.length) {
+    const { bytesWritten } = await handle.write(bytes, offset, bytes.length - offset, offset);
+    if (bytesWritten <= 0) throw new Error("target write made no progress");
+    offset += bytesWritten;
+  }
+  await handle.truncate(bytes.length);
+  await syncRegularFile(handle, hookCancelPlatform());
+}
+class HookCancelTargetRollbackError extends Error {}
+async function hookCancelWriteTarget(path: string, identity: HookCancelTargetIdentity, expected: Buffer, next: Buffer, boundary: string): Promise<void> {
   const handle = await open(path, fsConstants.O_RDWR | fsConstants.O_NOFOLLOW);
-  try { const current = await handle.stat(); if (!current.isFile() || !hookCancelTargetMatches(identity, hookCancelIdentity(current))) throw new Error("target identity changed"); const bytes = await handle.readFile(); if (!bytes.equals(expected)) throw new Error("target content changed"); await hookCancelWriteExact(handle, next); } finally { await handle.close(); }
+  let writeStarted = false;
+  try {
+    const current = await handle.stat();
+    if (!current.isFile() || !hookCancelTargetMatches(identity, hookCancelIdentity(current))) throw new Error("target identity changed");
+    const bytes = await handle.readFile();
+    if (!bytes.equals(expected)) throw new Error("target content changed");
+    writeStarted = true;
+    if (process.env.NODE_ENV === "test" && process.env.OMX_NATIVE_HOOK_TEST_CANCEL_TRANSACTION_FAIL_AFTER === `partial-${boundary}`) {
+      const partialLength = Math.max(1, Math.floor(next.length / 2));
+      await handle.write(next, 0, partialLength, 0);
+      await syncRegularFile(handle, hookCancelPlatform());
+      throw new Error("test-induced partial target write");
+    }
+    await hookCancelWriteExact(handle, next);
+  } catch (error) {
+    if (writeStarted) {
+      try { await hookCancelWriteExact(handle, expected); } catch { throw new HookCancelTargetRollbackError(); }
+    }
+    throw error;
+  } finally { try { await handle.close(); } catch {} }
 }
 async function hookCancelRestoreTarget(path: string, identity: HookCancelTargetIdentity, original: Buffer): Promise<void> {
   const handle = await open(path, fsConstants.O_RDWR | fsConstants.O_NOFOLLOW);
   try { const current = await handle.stat(); if (!current.isFile() || !hookCancelTargetMatches(identity, hookCancelIdentity(current))) throw new Error("rollback identity changed"); await hookCancelWriteExact(handle, original); } finally { await handle.close(); }
 }
+function hookCancelSessionIdIsSafe(value: string): boolean {
+  return value !== "" && value !== "." && value !== ".." && basename(value) === value;
+}
 export async function readHookCancelTransactionRecoveryState(input: { stateDir: string; canonicalSessionId: string }): Promise<HookCancelTransactionFailureReason | null> {
-  if (!input.canonicalSessionId || basename(input.canonicalSessionId) !== input.canonicalSessionId) return "invalid_target";
+  if (!hookCancelSessionIdIsSafe(input.canonicalSessionId)) return "invalid_target";
   try { const journal = hookCancelObject(await readFile(join(input.stateDir, "sessions", input.canonicalSessionId, HOOK_CANCEL_JOURNAL_FILE))); return journal?.phase === "prepared" ? "recovery_required" : "cleanup_failed"; } catch (error) { return (error as NodeJS.ErrnoException).code === "ENOENT" ? null : "cleanup_failed"; }
 }
-export async function terminalizeExactAutopilotSessionForHookCancel(input: { stateDir: string; canonicalSessionId: string; cwd: string; nowIso: string }): Promise<HookCancelTransactionResult> {
+type HookCancelWorkflow = "autopilot" | "ultragoal";
+type HookCancelWorkflowInput = { stateDir: string; canonicalSessionId: string; cwd: string; nowIso: string };
+
+async function terminalizeExactWorkflowSessionForHookCancel(input: HookCancelWorkflowInput, workflow: HookCancelWorkflow, policy = STRICT_HOOK_CANCEL_IDENTITY): Promise<HookCancelTransactionResult> {
   let canonicalStateDir: string; let canonicalCwd: string;
   try { canonicalStateDir = realpathSync(input.stateDir); canonicalCwd = realpathSync(input.cwd); } catch { return { ok: false, reason: "invalid_target" }; }
-  if (!input.canonicalSessionId || basename(input.canonicalSessionId) !== input.canonicalSessionId) return { ok: false, reason: "invalid_target" };
+  if (!hookCancelSessionIdIsSafe(input.canonicalSessionId)) return { ok: false, reason: "invalid_target" };
   const sessionsDir = join(canonicalStateDir, "sessions"); const sessionDir = join(sessionsDir, input.canonicalSessionId);
   try {
     const [sessionsStats, sessionStats, resolvedSessionDir] = await Promise.all([lstat(sessionsDir), lstat(sessionDir), import("fs/promises").then(({ realpath }) => realpath(sessionDir))]);
@@ -3981,33 +4111,93 @@ export async function terminalizeExactAutopilotSessionForHookCancel(input: { sta
   } catch { return { ok: false, reason: "invalid_target" }; }
   const recovery = await readHookCancelTransactionRecoveryState({ stateDir: canonicalStateDir, canonicalSessionId: input.canonicalSessionId }); if (recovery) return { ok: false, reason: recovery };
   const lockPath = join(sessionDir, HOOK_CANCEL_LOCK_FILE); const journalPath = join(sessionDir, HOOK_CANCEL_JOURNAL_FILE); let lock: Awaited<ReturnType<typeof open>>;
-  try { lock = await open(lockPath, "wx", 0o600); await lock.sync(); await hookCancelFsyncDirectory(sessionDir); } catch { return { ok: false, reason: "lock_held" }; }
+  try { lock = await open(lockPath, "wx", 0o600); } catch { return { ok: false, reason: "lock_held" }; }
+  try { hookCancelInjectFailure("lock-acquire"); await syncRegularFile(lock, hookCancelPlatform()); await hookCancelFsyncDirectory(sessionDir); }
+  catch {
+    try { await lock.close(); await unlink(lockPath); await hookCancelFsyncDirectory(sessionDir); } catch {}
+    return { ok: false, reason: "lock_held" };
+  }
   try {
-    const [autopilot, skill] = await Promise.all([hookCancelPinnedRead(join(sessionDir, "autopilot-state.json")), hookCancelPinnedRead(join(sessionDir, "skill-active-state.json"))]);
-    if (!autopilot || !skill) return { ok: false, reason: "preflight_failed" };
-    if (!hookCancelAutopilotMatches(autopilot.value, input.canonicalSessionId, canonicalCwd) || !hookCancelSkillMatches(skill.value, input.canonicalSessionId, canonicalCwd)) return { ok: false, reason: "state_mismatch" };
-    const nextAutopilot = Buffer.from(JSON.stringify(hookCancelPreparedAutopilot(autopilot.value, input.nowIso), null, 2)); const nextSkill = Buffer.from(JSON.stringify(hookCancelPreparedSkill(skill.value, input.canonicalSessionId, input.nowIso), null, 2));
-    const journal = Buffer.from(JSON.stringify({ version: 1, session_id: input.canonicalSessionId, phase: "prepared", targets: { autopilot: { identity: autopilot.identity, old_sha256: hookCancelDigest(autopilot.bytes), new_sha256: hookCancelDigest(nextAutopilot) }, skill_active: { identity: skill.identity, old_sha256: hookCancelDigest(skill.bytes), new_sha256: hookCancelDigest(nextSkill) } } }));
+    const workflowStateFile = workflow === "autopilot" ? "autopilot-state.json" : "ultragoal-state.json";
+    const [workflowState, skill, parentAutopilot] = await Promise.all([
+      hookCancelPinnedRead(join(sessionDir, workflowStateFile)),
+      hookCancelPinnedRead(join(sessionDir, "skill-active-state.json")),
+      workflow === "ultragoal" ? hookCancelPinnedRead(join(sessionDir, "autopilot-state.json")) : Promise.resolve(null),
+    ]);
+    if (!workflowState || !skill) return { ok: false, reason: "preflight_failed" };
+    const workflowMatches = workflow === "autopilot"
+      ? hookCancelAutopilotMatches(workflowState.value, input.canonicalSessionId, canonicalCwd, policy)
+      : hookCancelUltragoalMatches(workflowState.value, input.canonicalSessionId, canonicalCwd, policy);
+    const supervisedAutopilot = workflow === "ultragoal"
+      && hookCancelUsesSupervisedAutopilotMirror(skill.value, input.canonicalSessionId, canonicalCwd, policy);
+    if (!workflowMatches || !hookCancelSkillMatches(skill.value, workflow, input.canonicalSessionId, canonicalCwd, policy)) return { ok: false, reason: "state_mismatch" };
+    if (supervisedAutopilot && (!parentAutopilot || !hookCancelSupervisingAutopilotMatches(parentAutopilot.value, input.canonicalSessionId, canonicalCwd, policy))) {
+      return { ok: false, reason: "state_mismatch" };
+    }
+    const nextWorkflowState = Buffer.from(JSON.stringify(hookCancelPreparedWorkflow(workflowState.value, input.nowIso), null, 2));
+    const nextSkill = Buffer.from(JSON.stringify(hookCancelPreparedSkill(skill.value, workflow, input.canonicalSessionId, canonicalCwd, input.nowIso, policy), null, 2));
+    const targets: Array<{ journalKey: string; file: HookCancelPinnedFile; next: Buffer; boundary: string }> = [];
+    if (supervisedAutopilot && parentAutopilot) {
+      targets.push({
+        journalKey: "parent_autopilot",
+        file: parentAutopilot,
+        next: Buffer.from(JSON.stringify(hookCancelPreparedWorkflow(parentAutopilot.value, input.nowIso), null, 2)),
+        boundary: "parent-data-write",
+      });
+    }
+    targets.push(
+      { journalKey: "workflow_state", file: workflowState, next: nextWorkflowState, boundary: "first-data-write" },
+      { journalKey: "skill_active", file: skill, next: nextSkill, boundary: "second-data-write" },
+    );
+    const journalTargets = Object.fromEntries(targets.map((target) => [target.journalKey, {
+      identity: target.file.identity,
+      old_sha256: hookCancelDigest(target.file.bytes),
+      new_sha256: hookCancelDigest(target.next),
+    }]));
+    const journal = Buffer.from(JSON.stringify({ version: 1, session_id: input.canonicalSessionId, workflow, phase: "prepared", targets: journalTargets }));
     if (journal.length > HOOK_CANCEL_MAX_STATE_BYTES) return { ok: false, reason: "journal_failed" };
-    const journalHandle = await open(journalPath, "wx", 0o600); try { await journalHandle.writeFile(journal); await journalHandle.sync(); } finally { await journalHandle.close(); }
+    const journalHandle = await open(journalPath, "wx", 0o600); try { await journalHandle.writeFile(journal); await syncRegularFile(journalHandle, hookCancelPlatform()); } finally { await journalHandle.close(); }
     await hookCancelFsyncDirectory(sessionDir); hookCancelInjectFailure("journal-fsync");
-    let autopilotWritten = false; let skillWritten = false;
-    try { await hookCancelWriteTarget(autopilot.path, autopilot.identity, autopilot.bytes, nextAutopilot); autopilotWritten = true; hookCancelInjectFailure("first-data-write"); await hookCancelWriteTarget(skill.path, skill.identity, skill.bytes, nextSkill); skillWritten = true; hookCancelInjectFailure("second-data-write"); }
-    catch {
-      try { if (skillWritten) await hookCancelRestoreTarget(skill.path, skill.identity, skill.bytes); if (autopilotWritten) await hookCancelRestoreTarget(autopilot.path, autopilot.identity, autopilot.bytes); await hookCancelFsyncDirectory(sessionDir); } catch { return { ok: false, reason: "rollback_failed" }; }
+    const written: typeof targets = [];
+    try {
+      for (const target of targets) {
+        await hookCancelWriteTarget(target.file.path, target.file.identity, target.file.bytes, target.next, target.boundary);
+        written.push(target);
+        hookCancelInjectFailure(target.boundary);
+      }
+    } catch (error) {
+      try {
+        for (const target of [...written].reverse()) await hookCancelRestoreTarget(target.file.path, target.file.identity, target.file.bytes);
+        await hookCancelFsyncDirectory(sessionDir);
+      } catch { return { ok: false, reason: "rollback_failed" }; }
+      if (error instanceof HookCancelTargetRollbackError) return { ok: false, reason: "rollback_failed" };
       await unlink(journalPath); await hookCancelFsyncDirectory(sessionDir); return { ok: false, reason: "write_failed" };
     }
-    const [verifiedAutopilot, verifiedSkill] = await Promise.all([readFile(autopilot.path), readFile(skill.path)]);
-    if (!verifiedAutopilot.equals(nextAutopilot) || !verifiedSkill.equals(nextSkill)) return { ok: false, reason: "verification_failed" };
+    const verified = await Promise.all(targets.map((target) => readFile(target.file.path))).catch(() => null);
+    if (!verified || verified.some((bytes, index) => !bytes.equals(targets[index]?.next))) {
+      try {
+        for (const target of [...targets].reverse()) await hookCancelRestoreTarget(target.file.path, target.file.identity, target.file.bytes);
+        await hookCancelFsyncDirectory(sessionDir); await unlink(journalPath); await hookCancelFsyncDirectory(sessionDir);
+      } catch { return { ok: false, reason: "rollback_failed" }; }
+      return { ok: false, reason: "verification_failed" };
+    }
     hookCancelInjectFailure("verification");
     const committed = Buffer.from(JSON.stringify({ ...JSON.parse(journal.toString("utf8")), phase: "committed" })); const committedHandle = await open(journalPath, fsConstants.O_WRONLY | fsConstants.O_NOFOLLOW);
-    try { await committedHandle.write(committed, 0, committed.length, 0); await committedHandle.truncate(committed.length); await committedHandle.sync(); } finally { await committedHandle.close(); }
+    try { await committedHandle.write(committed, 0, committed.length, 0); await committedHandle.truncate(committed.length); await syncRegularFile(committedHandle, hookCancelPlatform()); } finally { await committedHandle.close(); }
     hookCancelInjectFailure("journal-commit"); await unlink(journalPath); await hookCancelFsyncDirectory(sessionDir); hookCancelInjectFailure("unlink");
     return { ok: true };
   } catch { return { ok: false, reason: "journal_failed" }; }
   finally {
     try { await lock.close(); await unlink(lockPath); await hookCancelFsyncDirectory(sessionDir); hookCancelInjectFailure("lock-release"); } catch {}
   }
+}
+
+export async function terminalizeExactAutopilotSessionForHookCancel(input: HookCancelWorkflowInput): Promise<HookCancelTransactionResult> {
+  return terminalizeExactWorkflowSessionForHookCancel(input, "autopilot");
+}
+
+export async function terminalizeExactUltragoalSessionForHookCancel(input: HookCancelWorkflowInput): Promise<HookCancelTransactionResult> {
+  return terminalizeExactWorkflowSessionForHookCancel(input, "ultragoal");
 }
 
 
@@ -9502,35 +9692,60 @@ function directCancelOutput(reason: string, handled = false): Record<string, unk
 
 async function handleDirectOmxCancel(input: {
   command: string; rawCommand: string; cwd: string; stateDir: string;
-  canonicalSessionId: string; payload: CodexHookPayload; allowForce: boolean;
-  activeState: Record<string, unknown>;
+  canonicalSessionId: string; payload: CodexHookPayload;
+  activeStates: Record<HookCancelWorkflow, Record<string, unknown>>;
+  skillState: Record<string, unknown>;
 }): Promise<DirectCancelResult> {
   const cancelLike = /^[ \t]*omx[ \t]+cancel\b/.test(input.command);
   if (!cancelLike) return { kind: "not-direct-cancel" };
-  // IR2: hook-owned cancellation is exclusive to active Autopilot
-  // deep-interview. Every other workflow falls through to its pre-#3293
-  // executable-trust path unchanged.
-  if (!hookCancelAutopilotMatches(input.activeState, input.canonicalSessionId, resolve(input.cwd))) {
-    return { kind: "not-direct-cancel" };
+  const canonicalCwd = resolve(input.cwd);
+  const autopilotActive = hookCancelAutopilotIsActive(input.activeStates.autopilot);
+  const ultragoalActive = hookCancelUltragoalIsActive(input.activeStates.ultragoal);
+  const autopilotLifecycleMatches = hookCancelAutopilotMatches(input.activeStates.autopilot, input.canonicalSessionId, canonicalCwd, AUTHENTICATED_HOOK_CANCEL_IDENTITY);
+  const ultragoalLifecycleMatches = hookCancelUltragoalMatches(input.activeStates.ultragoal, input.canonicalSessionId, canonicalCwd, AUTHENTICATED_HOOK_CANCEL_IDENTITY);
+  const autopilotSkillMatches = hookCancelSkillMatches(input.skillState, "autopilot", input.canonicalSessionId, canonicalCwd, AUTHENTICATED_HOOK_CANCEL_IDENTITY);
+  const ultragoalSkillMatches = hookCancelSkillMatches(input.skillState, "ultragoal", input.canonicalSessionId, canonicalCwd, AUTHENTICATED_HOOK_CANCEL_IDENTITY);
+  if (ultragoalActive && (!ultragoalLifecycleMatches || !ultragoalSkillMatches)) {
+    return { kind: "denied", reason: "active_state", output: directCancelOutput("active_state") };
   }
-  if (input.rawCommand !== input.command || !isDirectOmxCancelCommand(input.command, { allowForce: input.allowForce })) {
+  const autopilotCandidate = autopilotLifecycleMatches && autopilotSkillMatches;
+  const workflow: HookCancelWorkflow | null = ultragoalLifecycleMatches
+    ? "ultragoal"
+    : autopilotCandidate
+      ? "autopilot"
+      : null;
+  if (!workflow && autopilotActive) {
+    return { kind: "denied", reason: "active_state", output: directCancelOutput("active_state") };
+  }
+  // Hook-owned cancellation requires both an active matching lifecycle and its
+  // canonical skill mirror. Stale files alone retain the normal executable path.
+  if (!workflow) return { kind: "not-direct-cancel" };
+  if (input.rawCommand !== input.command || !isDirectOmxCancelCommand(input.command, { allowForce: workflow === "ultragoal" })) {
     return { kind: "denied", reason: "invalid_command", output: directCancelOutput("invalid_command") };
   }
-  const aliases = payloadAliasValues(input.payload, ["session_id", "sessionId"]);
-  if (!input.canonicalSessionId || aliases.length !== 1 || aliases[0] !== input.canonicalSessionId || payloadHasConflictingIdentityAliases(input.payload)) {
+  if (
+    !hookCancelSessionIdIsSafe(input.canonicalSessionId)
+    || !hookCancelRequiredStringAliasesMatch(
+      input.payload as Record<string, unknown>,
+      ["session_id", "sessionId"],
+      (candidate) => candidate === input.canonicalSessionId,
+    )
+    || payloadHasConflictingIdentityAliases(input.payload)
+  ) {
     return { kind: "denied", reason: "session_binding", output: directCancelOutput("session_binding") };
   }
+  if (hasSubagentThreadSpawnProvenance(input.payload)) return { kind: "denied", reason: "actor_authority", output: directCancelOutput("actor_authority") };
   const actor = await resolvePreToolUseWriteActor(input.payload, input.cwd, input.stateDir, input.canonicalSessionId);
   if (actor !== "main-root") return { kind: "denied", reason: "actor_authority", output: directCancelOutput("actor_authority") };
 
   const recovery = await readHookCancelTransactionRecoveryState({ stateDir: input.stateDir, canonicalSessionId: input.canonicalSessionId });
   if (recovery) return { kind: "denied", reason: recovery, output: directCancelOutput(recovery) };
-  const transaction = await terminalizeExactAutopilotSessionForHookCancel({
+  const transaction = await terminalizeExactWorkflowSessionForHookCancel({
     stateDir: input.stateDir,
     canonicalSessionId: input.canonicalSessionId,
     cwd: input.cwd,
     nowIso: new Date().toISOString(),
-  });
+  }, workflow, AUTHENTICATED_HOOK_CANCEL_IDENTITY);
   if (!transaction.ok) {
     const reason = transaction.reason ?? "preflight_failed";
     return { kind: "denied", reason, output: directCancelOutput(reason) };
@@ -22192,6 +22407,13 @@ export async function dispatchCodexNativeHook(
       ? readPreToolUseCommand(payload)
       : "";
     if (/^[ \t]*omx[ \t]+cancel\b/.test(directCancelCommand)) {
+      const [autopilotState, ultragoalState, skillState] = sessionBinding.valid
+        ? await Promise.all([
+          readStopSessionPinnedState("autopilot-state.json", policyCwd, sessionBinding.canonicalSessionId, stateDir),
+          readStopSessionPinnedState("ultragoal-state.json", policyCwd, sessionBinding.canonicalSessionId, stateDir),
+          readStopSessionPinnedState("skill-active-state.json", policyCwd, sessionBinding.canonicalSessionId, stateDir),
+        ])
+        : [null, null, null];
       const directCancel = await handleDirectOmxCancel({
         command: directCancelCommand,
         rawCommand: readPreToolUseRawCommand(payload),
@@ -22199,10 +22421,11 @@ export async function dispatchCodexNativeHook(
         stateDir,
         canonicalSessionId: sessionBinding.valid ? sessionBinding.canonicalSessionId : "",
         payload,
-        allowForce: false,
-        activeState: sessionBinding.valid
-          ? (await readStopSessionPinnedState("autopilot-state.json", policyCwd, sessionBinding.canonicalSessionId, stateDir) ?? {})
-          : {},
+        activeStates: {
+          autopilot: autopilotState ?? {},
+          ultragoal: ultragoalState ?? {},
+        },
+        skillState: skillState ?? {},
       });
       if (directCancel.kind !== "not-direct-cancel") outputJson = directCancel.output;
     }


### PR DESCRIPTION
## Summary

Adds the narrow cancellation escape repair from #3358. Exact same-session Main-root `omx cancel` and `omx cancel --force` are hook-owned for active Ultragoal lifecycle state, so cancellation remains reachable even when inherited shell/loader state makes external executable trust unavailable.

## Cancellation-only scope

Resolved here:
- affirmative exact session and cwd/worktree identity on Ultragoal state, paired skill state, and the matching skill entry;
- fail-closed rejection for missing, malformed, conflicting, foreign, or traversal-shaped identity;
- Ultragoal-authoritative lifecycle arbitration with no stale-Autopilot fallback;
- two-file state/skill terminalization using the existing #3293 fail-stop journal contract;
- wrapper/impostor/native-child rejection and unrelated session/skill preservation.

Not resolved here:
- trusted Team launch reachability;
- `update_plan` transport classification;
- read-only discovery command classification;
- native-child implementation routing/write authority.

#3358 remains open for those independently reproduced paths. This PR does not claim to close the full issue.

## Verification

- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- focused compiled #3293/#3358 lifecycle suites: 27 callsite parity, 23 transaction, 39 hook-owned cancellation, and 31 Ultragoal lifecycle tests passed
- full compiled native-hook suite: 638/638 passed
- independent architect verdict: CLEAR / APPROVE
- independent adversarial red-team verdict: PASS, no blockers