### PR TITLE
fix: stop agents &&-chaining independent shell probes

### DIFF
--- a/docs/prompt-guidance-fragments/core-operating-principles.md
+++ b/docs/prompt-guidance-fragments/core-operating-principles.md
@@ -14,3 +14,5 @@
 - When the user provides newer same-thread evidence (for example logs, stack traces, or test output), treat it as the current source of truth, re-evaluate earlier hypotheses against it, and do not anchor on older evidence unless the user reaffirms it.
 - Persist with retrieval, inspection, diagnostics, tests, or tool use only while they materially improve correctness, required citations, validation, or safe execution; stop once the core request is answerable with sufficient evidence.
 - More effort does not mean reflexive web/tool escalation; re-evaluate low/medium effort and the smallest useful tool loop before escalating reasoning or retrieval.
+- Run independent shell probes as separate commands; do not `&&`-chain them. `&&` short-circuits, so a single failing probe silently skips every later probe and you proceed on incomplete context while believing it was gathered.
+- Treat a missing optional input (for example `AGENTS.md`, `.omx/context`, or an absent config file) as information rather than failure: record the absence and continue, guarding individual probes with `|| true` or `2>/dev/null` instead of chaining them.

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -43,6 +43,8 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 - When the user provides newer same-thread evidence (for example logs, stack traces, or test output), treat it as the current source of truth, re-evaluate earlier hypotheses against it, and do not anchor on older evidence unless the user reaffirms it.
 - Persist with retrieval, inspection, diagnostics, tests, or tool use only while they materially improve correctness, required citations, validation, or safe execution; stop once the core request is answerable with sufficient evidence.
 - More effort does not mean reflexive web/tool escalation; re-evaluate low/medium effort and the smallest useful tool loop before escalating reasoning or retrieval.
+- Run independent shell probes as separate commands; do not `&&`-chain them. `&&` short-circuits, so a single failing probe silently skips every later probe and you proceed on incomplete context while believing it was gathered.
+- Treat a missing optional input (for example `AGENTS.md`, `.omx/context`, or an absent config file) as information rather than failure: record the absence and continue, guarding individual probes with `|| true` or `2>/dev/null` instead of chaining them.
 <!-- OMX:GUIDANCE:OPERATING:END -->
 </operating_principles>
 


### PR DESCRIPTION
## Summary

An agent composed this preflight probe in a repository with no `AGENTS.md`:

```
pwd && sed -n '1,260p' AGENTS.md && find .omx/context ... && command -v omx && omx state --help
```

`sed` exited non-zero, `&&` short-circuited, and the three probes that actually mattered — including `omx state` — never ran. The agent then proceeded as though it had gathered that context.

To be clear about scope: **OMX does not emit that command.** I checked before filing anything — `skills/autopilot/SKILL.md` never mentions `AGENTS.md`, and the string appears nowhere in the package. The model composed it at runtime. But the operating guidance is exactly where that behaviour is shaped, and it currently says nothing about probe composition, so the model has no reason not to chain.

A missing `AGENTS.md` is normal in a fresh repo — arguably the most likely place someone reaches for Autopilot.

## Changes

- Add two bullets to the shared `OMX:GUIDANCE:OPERATING` block: run independent probes as separate commands, and treat a missing optional input as information rather than failure.
- Applied to the canonical fragment (`docs/prompt-guidance-fragments/core-operating-principles.md`) and `templates/AGENTS.md`, keeping the surfaces byte-identical as `prompt-guidance-fragments.test.ts` requires.

Documentation/guidance only — no code paths change.

## Validation

- [x] `npm run build` — passes
- [x] `npm run lint` — passes, 789 files clean
- [ ] `npm test` — see below

`npm test` does **not** fully pass, and I want to be precise rather than tick the box.

On this branch, 6 test files fail. All 6 also fail on **clean `dev`** with none of my changes. I verified by checking out `dev`, rebuilding, and running the same files:

| test file | clean `dev` | this branch |
| --- | --- | --- |
| `cli/launch-fallback` | fail 1 | fail 1 |
| `cli/setup-prompts-overwrite` | fail 3 | fail 3 |
| `cli/setup-refresh` | fail 13 | fail 13 |
| `cli/setup-skills-overwrite` | fail 10 | fail 10 |
| `team/scaling` | fail 2 | fail 1 (timing-flaky) |
| `scripts/codex-native-hook` | fail | fail |
| `hooks/prompt-guidance-fragments` | pass | **pass** |

They look unrelated to this change (`setup-refresh`, for instance, asserts `model = "gpt-5.6-sol"` against an actual of `gpt-5.5`).

`prompt-guidance-fragments` did fail on my first attempt — I had edited `templates/AGENTS.md` without the canonical fragment. The test caught it correctly; both surfaces are now in sync and it passes.

- [ ] `omx doctor` — not run; no setup or config behavior changes here.

## Checklist

- [x] PR is focused and avoids unrelated changes (2 files, +4 lines)
- [x] Docs updated (AGENTS template + canonical guidance fragment)
- [x] Backward-compatibility impact considered — additive guidance; no code paths or config schema touched

## Related

Refs #3361

Deliberately **not** `Closes` — this addresses the trigger, not the underlying defect. In the reported session the failed call also ended with no tool result submitted, so the next turn was rejected with `No tool output found for custom tool call` and the session became unrecoverable from the inside. I could not determine whether that originates in OMX's hook layer or in Codex CLI, so I have left it open. This change makes the fragile probe less likely; it does not make a non-zero exit survivable.
